### PR TITLE
[codex] Skip layout notes for pointer-free array ranges

### DIFF
--- a/crates/perry-codegen/src/expr/index_set.rs
+++ b/crates/perry-codegen/src/expr/index_set.rs
@@ -10,6 +10,7 @@ use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
 #[allow(unused_imports)]
 use perry_types::Type as HirType;
 
+use crate::block::LlBlock;
 #[allow(unused_imports)]
 use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
 #[allow(unused_imports)]
@@ -20,7 +21,10 @@ use crate::lower_string_method::{
     lower_string_concat_chain, lower_string_self_append,
 };
 #[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
+use crate::nanbox::{
+    double_literal, i64_literal, BIGINT_TAG_I64, POINTER_MASK, POINTER_MASK_I64, POINTER_TAG_I64,
+    STRING_TAG_I64, TAG_MASK,
+};
 use crate::native_value::{
     BoundsState, BufferAccessMode, LoweredValue, MaterializationReason, NativeRep, SemanticKind,
 };
@@ -204,6 +208,7 @@ fn lower_preguarded_plain_array_index_set(
     val_double: &str,
     arr_id: u32,
     guard_ok_slot: &str,
+    pointer_free_range_slot: Option<&str>,
     layout_note_needed: bool,
     write_barrier_needed: bool,
     value_is_numeric: bool,
@@ -217,9 +222,25 @@ fn lower_preguarded_plain_array_index_set(
     let fast_idx = ctx.new_block("idxset.preguarded_plain_fast");
     let fallback_idx = ctx.new_block("idxset.preguarded_plain_fallback");
     let merge_idx = ctx.new_block("idxset.preguarded_plain_merge");
+    let layout_branch = pointer_free_range_slot
+        .filter(|_| layout_note_needed)
+        .map(|_| {
+            (
+                ctx.new_block("idxset.preguarded_plain_layout_note"),
+                ctx.new_block("idxset.preguarded_plain_layout_skip"),
+            )
+        });
     let fast_label = ctx.block_label(fast_idx);
     let fallback_label = ctx.block_label(fallback_idx);
     let merge_label = ctx.block_label(merge_idx);
+    let layout_branch_labels = layout_branch.map(|(note_idx, skip_idx)| {
+        (
+            note_idx,
+            skip_idx,
+            ctx.block_label(note_idx),
+            ctx.block_label(skip_idx),
+        )
+    });
 
     let guard_ok_i32 = ctx.block().load(I32, guard_ok_slot);
     let guard_ok = ctx.block().icmp_ne(I32, &guard_ok_i32, "0");
@@ -251,26 +272,80 @@ fn lower_preguarded_plain_array_index_set(
         let with_header = blk.add(I64, &byte_offset, "8");
         let element_addr = blk.add(I64, &arr_handle, &with_header);
         let element_ptr = blk.inttoptr(I64, &element_addr);
-        let value_bits = emit_jsvalue_slot_store_on_block(
-            blk,
-            &element_ptr,
-            val_double,
-            &arr_handle,
-            idx_i32,
-            layout_note_needed,
-            &arr_handle,
-            &element_addr,
-            write_barrier_needed,
-        )
-        .unwrap_or_else(|| blk.bitcast_double_to_i64(val_double));
-        if !value_is_numeric {
-            emit_array_numeric_write_note_on_block(blk, &arr_handle, &value_bits);
+        blk.store(DOUBLE, val_double, &element_ptr);
+        let value_bits = blk.bitcast_double_to_i64(val_double);
+        if let (Some(pointer_free_range_slot), Some((note_idx, skip_idx, note_label, skip_label))) =
+            (pointer_free_range_slot, layout_branch_labels.as_ref())
+        {
+            let range_free_i32 = blk.load(I32, pointer_free_range_slot);
+            let range_free = blk.icmp_ne(I32, &range_free_i32, "0");
+            let value_has_pointer = emit_layout_pointer_bearing_bits_check(blk, &value_bits);
+            let value_non_pointer = blk.xor(I1, &value_has_pointer, "true");
+            let skip_layout_note = blk.and(I1, &range_free, &value_non_pointer);
+            blk.cond_br(&skip_layout_note, skip_label, note_label);
+
+            ctx.current_block = *note_idx;
+            {
+                let blk = ctx.block();
+                emit_layout_note_slot_on_block(blk, &arr_handle, idx_i32, &value_bits);
+                blk.br(skip_label);
+            }
+
+            ctx.current_block = *skip_idx;
+            {
+                let blk = ctx.block();
+                if write_barrier_needed {
+                    emit_write_barrier_slot_on_block(blk, &arr_handle, &element_addr, &value_bits);
+                }
+                if !value_is_numeric {
+                    emit_array_numeric_write_note_on_block(blk, &arr_handle, &value_bits);
+                }
+                blk.br(&merge_label);
+            }
+        } else {
+            if layout_note_needed {
+                emit_layout_note_slot_on_block(blk, &arr_handle, idx_i32, &value_bits);
+            }
+            if write_barrier_needed {
+                emit_write_barrier_slot_on_block(blk, &arr_handle, &element_addr, &value_bits);
+            }
+            if !value_is_numeric {
+                emit_array_numeric_write_note_on_block(blk, &arr_handle, &value_bits);
+            }
+            blk.br(&merge_label);
         }
-        blk.br(&merge_label);
     }
 
     ctx.current_block = merge_idx;
     Ok(())
+}
+
+fn emit_layout_pointer_bearing_bits_check(blk: &mut LlBlock, value_bits: &str) -> String {
+    let tag_mask = i64_literal(TAG_MASK);
+    let nanbox_min = i64_literal(0x7FF8_0000_0000_0000);
+    let pointer_mask = i64_literal(POINTER_MASK);
+
+    let tag = blk.and(I64, value_bits, &tag_mask);
+    let payload = blk.and(I64, value_bits, POINTER_MASK_I64);
+    let payload_nonzero = blk.icmp_ne(I64, &payload, "0");
+    let is_pointer_tag = blk.icmp_eq(I64, &tag, POINTER_TAG_I64);
+    let is_string_tag = blk.icmp_eq(I64, &tag, STRING_TAG_I64);
+    let is_bigint_tag = blk.icmp_eq(I64, &tag, BIGINT_TAG_I64);
+    let is_ref_tag = blk.or(I1, &is_pointer_tag, &is_string_tag);
+    let is_ref_tag = blk.or(I1, &is_ref_tag, &is_bigint_tag);
+    let tagged_pointer = blk.and(I1, &is_ref_tag, &payload_nonzero);
+
+    let nanbox_high = blk.icmp_sge(I64, &tag, &nanbox_min);
+    let not_nanbox_high = blk.xor(I1, &nanbox_high, "true");
+    let raw_ge_min = blk.icmp_sge(I64, value_bits, "4096");
+    let raw_le_mask = blk.icmp_sle(I64, value_bits, &pointer_mask);
+    let raw_in_range = blk.and(I1, &raw_ge_min, &raw_le_mask);
+    let aligned_bits = blk.and(I64, value_bits, "7");
+    let raw_aligned = blk.icmp_eq(I64, &aligned_bits, "0");
+    let raw_pointer = blk.and(I1, &not_nanbox_high, &raw_in_range);
+    let raw_pointer = blk.and(I1, &raw_pointer, &raw_aligned);
+
+    blk.or(I1, &tagged_pointer, &raw_pointer)
 }
 
 fn affine_index_expr_matches(expr: &Expr, pattern: &PreguardedAffineIndexExpr) -> bool {
@@ -782,6 +857,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                         &val_double,
                                         id,
                                         &preguard.guard_ok_slot,
+                                        preguard.pointer_free_range_slot.as_deref(),
                                         layout_note_needed,
                                         write_barrier_needed,
                                         value_is_numeric,

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1042,6 +1042,7 @@ pub(crate) struct PreguardedNumericArrayIndexSet {
 #[derive(Debug, Clone)]
 pub(crate) struct PreguardedPlainArrayIndexSet {
     pub guard_ok_slot: String,
+    pub pointer_free_range_slot: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -208,6 +208,11 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
         &[DOUBLE, I32, I32],
     );
     module.declare_function(
+        "js_plain_array_inbounds_pointer_free_range_guard",
+        I32,
+        &[DOUBLE, I32, I32],
+    );
+    module.declare_function(
         "js_typed_feedback_plain_array_index_set_guard",
         I32,
         &[I64, DOUBLE, I32, DOUBLE, I32],

--- a/crates/perry-codegen/src/stmt/loops.rs
+++ b/crates/perry-codegen/src/stmt/loops.rs
@@ -1075,7 +1075,19 @@ fn emit_range_plain_array_index_set_preguard(
     let guard_ok_slot = ctx.func.alloca_entry(I32);
     ctx.block().store(I32, &guard_result, &guard_ok_slot);
 
-    Ok(PreguardedPlainArrayIndexSet { guard_ok_slot })
+    let pointer_free_result = ctx.block().call(
+        I32,
+        "js_plain_array_inbounds_pointer_free_range_guard",
+        &[(DOUBLE, &arr_box), (I32, &counter_i32), (I32, &max_i32)],
+    );
+    let pointer_free_range_slot = ctx.func.alloca_entry(I32);
+    ctx.block()
+        .store(I32, &pointer_free_result, &pointer_free_range_slot);
+
+    Ok(PreguardedPlainArrayIndexSet {
+        guard_ok_slot,
+        pointer_free_range_slot: Some(pointer_free_range_slot),
+    })
 }
 
 fn emit_affine_numeric_array_index_get_preguard(

--- a/crates/perry-codegen/tests/typed_feedback.rs
+++ b/crates/perry-codegen/tests/typed_feedback.rs
@@ -486,8 +486,14 @@ fn typed_feedback_preguards_plain_array_writes_with_length_bound() {
         ir.contains("call i32 @js_plain_array_inbounds_range_guard"),
         "{ir}"
     );
+    assert!(
+        ir.contains("call i32 @js_plain_array_inbounds_pointer_free_range_guard"),
+        "{ir}"
+    );
     assert!(ir.contains("idxset.preguarded_plain_fast"), "{ir}");
     assert!(ir.contains("idxset.preguarded_plain_fallback"), "{ir}");
+    assert!(ir.contains("idxset.preguarded_plain_layout_note"), "{ir}");
+    assert!(ir.contains("idxset.preguarded_plain_layout_skip"), "{ir}");
     assert!(ir.contains("call void @js_gc_note_slot_layout"), "{ir}");
     assert_eq!(
         ir.matches("call i32 @js_typed_feedback_plain_array_index_set_guard")
@@ -547,8 +553,14 @@ fn typed_feedback_preguards_plain_array_writes_with_local_bound() {
         ir.contains("call i32 @js_plain_array_inbounds_range_guard"),
         "{ir}"
     );
+    assert!(
+        ir.contains("call i32 @js_plain_array_inbounds_pointer_free_range_guard"),
+        "{ir}"
+    );
     assert!(ir.contains("idxset.preguarded_plain_fast"), "{ir}");
     assert!(ir.contains("idxset.preguarded_plain_fallback"), "{ir}");
+    assert!(ir.contains("idxset.preguarded_plain_layout_note"), "{ir}");
+    assert!(ir.contains("idxset.preguarded_plain_layout_skip"), "{ir}");
     assert_eq!(
         ir.matches("call i32 @js_typed_feedback_plain_array_index_set_guard")
             .count(),

--- a/crates/perry-runtime/src/gc/layout.rs
+++ b/crates/perry-runtime/src/gc/layout.rs
@@ -866,6 +866,35 @@ pub(crate) fn layout_pointer_slot_summary_for_user(
     }
 }
 
+pub(crate) fn layout_range_has_pointer_slots_for_user(
+    user_ptr: usize,
+    first_slot: usize,
+    last_slot: usize,
+    slot_count: usize,
+) -> Option<bool> {
+    if first_slot > last_slot || last_slot >= slot_count {
+        return None;
+    }
+    unsafe {
+        let header = layout_header_for_user(user_ptr)?;
+        match (*header)._reserved & GC_LAYOUT_STATE_MASK {
+            GC_LAYOUT_POINTER_FREE => Some(false),
+            GC_LAYOUT_SIDE_MASK => {
+                let mask = LAYOUT_SLOT_MASKS.with(|m| m.borrow().get(&user_ptr).cloned());
+                let Some(mask) = mask else {
+                    set_layout_state(header, GC_LAYOUT_UNKNOWN);
+                    return None;
+                };
+                Some(
+                    mask.next_slot_at_or_after(first_slot, slot_count)
+                        .is_some_and(|slot| slot <= last_slot),
+                )
+            }
+            _ => None,
+        }
+    }
+}
+
 pub(crate) fn layout_typed_raw_f64_slot_for_user(user_ptr: usize, slot_index: usize) -> bool {
     TYPED_LAYOUTS.with(|m| {
         m.borrow()

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -1200,6 +1200,28 @@ pub extern "C" fn js_plain_array_inbounds_range_guard(
     }
 }
 
+#[no_mangle]
+pub extern "C" fn js_plain_array_inbounds_pointer_free_range_guard(
+    receiver: f64,
+    first_index: i32,
+    last_index: i32,
+) -> i32 {
+    if first_index < 0 || last_index < first_index {
+        return 0;
+    }
+    let raw_addr = normalize_raw_object_addr(receiver.to_bits());
+    if !plain_array_index_guard(raw_addr as *const ArrayHeader, last_index as u32, true) {
+        return 0;
+    }
+    let first = first_index as usize;
+    let last = last_index as usize;
+    let slot_count = last.saturating_add(1);
+    match crate::gc::layout_range_has_pointer_slots_for_user(raw_addr, first, last, slot_count) {
+        Some(false) => 1,
+        _ => 0,
+    }
+}
+
 fn numeric_array_index_guard(arr: *const ArrayHeader, index: u32, require_in_bounds: bool) -> bool {
     plain_array_index_guard(arr, index, require_in_bounds)
         && crate::array::js_array_is_numeric_f64_layout(arr) != 0

--- a/crates/perry-runtime/src/typed_feedback/tests.rs
+++ b/crates/perry-runtime/src/typed_feedback/tests.rs
@@ -674,6 +674,58 @@ fn typed_feedback_plain_array_inbounds_range_guard_checks_current_and_last_index
 }
 
 #[test]
+fn typed_feedback_plain_array_pointer_free_range_guard_tracks_current_layout() {
+    let values = [1.0, 2.0, 3.0];
+    let arr = crate::array::js_array_from_f64(values.as_ptr(), values.len() as u32);
+    let arr_box = crate::value::js_nanbox_pointer(arr as i64);
+
+    assert_eq!(
+        js_plain_array_inbounds_pointer_free_range_guard(arr_box, 0, 2),
+        1
+    );
+    assert_eq!(
+        js_plain_array_inbounds_pointer_free_range_guard(arr_box, 1, 1),
+        1
+    );
+
+    let payload = crate::string::js_string_from_bytes(b"downgraded".as_ptr(), 10);
+    let payload_value = crate::value::js_nanbox_string(payload as i64);
+    crate::array::js_array_set_f64(arr, 1, payload_value);
+
+    assert_eq!(
+        js_plain_array_inbounds_pointer_free_range_guard(arr_box, 0, 0),
+        1
+    );
+    assert_eq!(
+        js_plain_array_inbounds_pointer_free_range_guard(arr_box, 0, 2),
+        0
+    );
+    assert_eq!(
+        js_plain_array_inbounds_pointer_free_range_guard(arr_box, 2, 2),
+        1
+    );
+    assert_eq!(
+        js_plain_array_inbounds_pointer_free_range_guard(arr_box, -1, 2),
+        0
+    );
+    assert_eq!(
+        js_plain_array_inbounds_pointer_free_range_guard(arr_box, 2, 1),
+        0
+    );
+    assert_eq!(
+        js_plain_array_inbounds_pointer_free_range_guard(arr_box, 0, 3),
+        0
+    );
+
+    let obj = crate::object::js_object_alloc(0, 0);
+    let obj_box = crate::value::js_nanbox_pointer(obj as i64);
+    assert_eq!(
+        js_plain_array_inbounds_pointer_free_range_guard(obj_box, 0, 0),
+        0
+    );
+}
+
+#[test]
 fn typed_feedback_numeric_array_guard_fast_path_respects_megamorphic_state() {
     let _guard = TYPED_FEEDBACK_TEST_LOCK.lock().unwrap();
     reset_typed_feedback_for_tests();


### PR DESCRIPTION
## Summary

This cycle removes the remaining per-store layout side-mask update from the hot preguarded plain-array range store path when it is safe to do so.

- adds a fail-closed runtime guard for plain-array ranges whose current GC layout has no pointer slots
- threads that guard through the existing loop preguard for plain array writes
- branches around `js_gc_note_slot_layout` in the fast store path only when the preguarded range is pointer-free and the new value is proven non-pointer by the same tag/mask predicate used by the runtime layout tracker
- keeps write barriers and numeric-write notes intact, and keeps the layout-note fallback for pointer-bearing values or failed guards

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p perry-runtime typed_feedback_plain_array_pointer_free_range_guard -- --nocapture`
- `cargo test -p perry-codegen typed_feedback_preguards_plain_array -- --nocapture`
- `cargo test -p perry-codegen --test typed_feedback -- --nocapture`
- `cargo test -p perry-runtime typed_feedback -- --nocapture`
- `cargo build --release -p perry`
- compiled `benchmarks/suite/bench_numeric_array_downgrade.ts` with `--trace llvm`

## IR / Runtime Evidence

The traced `runDowngradedArray` IR contains both loop preguards:

- `js_plain_array_inbounds_range_guard`
- `js_plain_array_inbounds_pointer_free_range_guard`

The hot store sites branch between `idxset.preguarded_plain_layout_skip` and `idxset.preguarded_plain_layout_note`; `js_gc_note_slot_layout` is retained only on the note branch, while `js_write_barrier_slot` remains on the continuation path.

Typed-feedback trace for the two hot `array[index]=` sites in `runDowngradedArray` showed `observed_count: 0`, `guard_failures: 0`, and `fallback_calls: 0`.

## Benchmark

Benchmark: `bench_numeric_array_downgrade`, checksum `6500875` in every run.

Paired internal reported milliseconds:

- baseline: 4333, 4336, 4360
- final: 352, 354, 359

Average: 4343.0 ms -> 355.0 ms, about 12.2x faster / 91.8% lower reported runtime.
