### PR TITLE
[codex] Use layout-only JSON object field stores

### DIFF
--- a/crates/perry-codegen/src/collectors/hir_facts.rs
+++ b/crates/perry-codegen/src/collectors/hir_facts.rs
@@ -258,11 +258,25 @@ pub(crate) fn collect_hir_facts(
 
 fn collect_known_noalias_buffer_locals(stmts: &[Stmt]) -> HashSet<u32> {
     let mut out = HashSet::new();
-    collect_owned_buffer_lets(stmts, &mut out);
+    let mut known_length_locals = HashSet::new();
+    collect_owned_buffer_lets(stmts, &mut out, &mut known_length_locals);
     out
 }
 
-fn collect_owned_buffer_lets(stmts: &[Stmt], out: &mut HashSet<u32>) {
+fn collect_owned_buffer_lets_child_scope(
+    stmts: &[Stmt],
+    out: &mut HashSet<u32>,
+    known_length_locals: &HashSet<u32>,
+) {
+    let mut child_length_locals = known_length_locals.clone();
+    collect_owned_buffer_lets(stmts, out, &mut child_length_locals);
+}
+
+fn collect_owned_buffer_lets(
+    stmts: &[Stmt],
+    out: &mut HashSet<u32>,
+    known_length_locals: &mut HashSet<u32>,
+) {
     for stmt in stmts {
         match stmt {
             Stmt::Let {
@@ -271,8 +285,13 @@ fn collect_owned_buffer_lets(stmts: &[Stmt], out: &mut HashSet<u32>) {
                 init: Some(init),
                 ..
             } => {
-                if !*mutable && is_owned_u8_buffer_alloc(init) {
+                if !*mutable && is_owned_u8_buffer_alloc(init, known_length_locals) {
                     out.insert(*id);
+                }
+                if !*mutable && is_fresh_uint8array_length_expr(init, known_length_locals) {
+                    known_length_locals.insert(*id);
+                } else {
+                    known_length_locals.remove(id);
                 }
             }
             Stmt::If {
@@ -280,39 +299,48 @@ fn collect_owned_buffer_lets(stmts: &[Stmt], out: &mut HashSet<u32>) {
                 else_branch,
                 ..
             } => {
-                collect_owned_buffer_lets(then_branch, out);
+                collect_owned_buffer_lets_child_scope(then_branch, out, known_length_locals);
                 if let Some(else_branch) = else_branch {
-                    collect_owned_buffer_lets(else_branch, out);
+                    collect_owned_buffer_lets_child_scope(else_branch, out, known_length_locals);
                 }
             }
             Stmt::While { body, .. } | Stmt::DoWhile { body, .. } => {
-                collect_owned_buffer_lets(body, out);
+                collect_owned_buffer_lets_child_scope(body, out, known_length_locals);
             }
             Stmt::For { init, body, .. } => {
+                let mut loop_length_locals = known_length_locals.clone();
                 if let Some(init) = init {
-                    collect_owned_buffer_lets(std::slice::from_ref(init.as_ref()), out);
+                    collect_owned_buffer_lets(
+                        std::slice::from_ref(init.as_ref()),
+                        out,
+                        &mut loop_length_locals,
+                    );
                 }
-                collect_owned_buffer_lets(body, out);
+                collect_owned_buffer_lets(body, out, &mut loop_length_locals);
             }
             Stmt::Labeled { body, .. } => {
-                collect_owned_buffer_lets(std::slice::from_ref(body.as_ref()), out);
+                collect_owned_buffer_lets_child_scope(
+                    std::slice::from_ref(body.as_ref()),
+                    out,
+                    known_length_locals,
+                );
             }
             Stmt::Try {
                 body,
                 catch,
                 finally,
             } => {
-                collect_owned_buffer_lets(body, out);
+                collect_owned_buffer_lets_child_scope(body, out, known_length_locals);
                 if let Some(catch) = catch {
-                    collect_owned_buffer_lets(&catch.body, out);
+                    collect_owned_buffer_lets_child_scope(&catch.body, out, known_length_locals);
                 }
                 if let Some(finally) = finally {
-                    collect_owned_buffer_lets(finally, out);
+                    collect_owned_buffer_lets_child_scope(finally, out, known_length_locals);
                 }
             }
             Stmt::Switch { cases, .. } => {
                 for case in cases {
-                    collect_owned_buffer_lets(&case.body, out);
+                    collect_owned_buffer_lets_child_scope(&case.body, out, known_length_locals);
                 }
             }
             Stmt::Let { init: None, .. }
@@ -328,15 +356,17 @@ fn collect_owned_buffer_lets(stmts: &[Stmt], out: &mut HashSet<u32>) {
     }
 }
 
-fn is_owned_u8_buffer_alloc(expr: &Expr) -> bool {
+fn is_owned_u8_buffer_alloc(expr: &Expr, known_length_locals: &HashSet<u32>) -> bool {
     match expr {
         Expr::BufferAlloc { .. } | Expr::BufferAllocUnsafe(_) => true,
         Expr::Uint8ArrayNew(None) => true,
-        Expr::Uint8ArrayNew(Some(size)) => is_fresh_uint8array_length_literal(size),
+        Expr::Uint8ArrayNew(Some(size)) => {
+            is_fresh_uint8array_length_expr(size, known_length_locals)
+        }
         Expr::TypedArrayNew { arg: None, .. } => true,
         Expr::TypedArrayNew {
             arg: Some(size), ..
-        } => is_fresh_uint8array_length_literal(size),
+        } => is_fresh_uint8array_length_expr(size, known_length_locals),
         Expr::NativeMethodCall {
             module,
             method,
@@ -345,6 +375,13 @@ fn is_owned_u8_buffer_alloc(expr: &Expr) -> bool {
         } if module == "buffer" && method == "copyBytesFrom" => true,
         Expr::NativeArenaView { .. } => true,
         _ => false,
+    }
+}
+
+fn is_fresh_uint8array_length_expr(expr: &Expr, known_length_locals: &HashSet<u32>) -> bool {
+    match expr {
+        Expr::LocalGet(id) => known_length_locals.contains(id),
+        _ => is_fresh_uint8array_length_literal(expr),
     }
 }
 
@@ -367,6 +404,16 @@ mod tests {
             id,
             name: format!("v{}", id),
             ty: Type::Named("Uint8Array".into()),
+            mutable: false,
+            init: Some(init),
+        }
+    }
+
+    fn const_number_let(id: u32, init: Expr) -> Stmt {
+        Stmt::Let {
+            id,
+            name: format!("v{}", id),
+            ty: Type::Number,
             mutable: false,
             init: Some(init),
         }
@@ -493,6 +540,20 @@ mod tests {
     }
 
     #[test]
+    fn uint8array_const_local_lengths_are_known_noalias_sources() {
+        let ids = known_ids(vec![
+            const_number_let(10, Expr::Integer(8)),
+            const_let(1, Expr::Uint8ArrayNew(Some(Box::new(Expr::LocalGet(10))))),
+            const_number_let(11, Expr::Number(16.0)),
+            const_number_let(12, Expr::LocalGet(11)),
+            const_let(2, Expr::Uint8ArrayNew(Some(Box::new(Expr::LocalGet(12))))),
+        ]);
+
+        assert!(ids.contains(&1));
+        assert!(ids.contains(&2));
+    }
+
+    #[test]
     fn uint8array_non_literal_or_alias_possible_sources_are_not_noalias() {
         let ids = known_ids(vec![
             const_let(1, Expr::Uint8ArrayNew(Some(Box::new(Expr::LocalGet(99))))),
@@ -503,6 +564,8 @@ mod tests {
                 5,
                 Expr::Uint8ArrayNew(Some(Box::new(Expr::Number(i32::MAX as f64)))),
             ),
+            mutable_number_let(6, Expr::Integer(8)),
+            const_let(7, Expr::Uint8ArrayNew(Some(Box::new(Expr::LocalGet(6))))),
         ]);
 
         assert!(ids.is_empty(), "unexpected noalias ids: {ids:?}");

--- a/crates/perry-codegen/src/expr/index_set.rs
+++ b/crates/perry-codegen/src/expr/index_set.rs
@@ -10,6 +10,7 @@ use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
 #[allow(unused_imports)]
 use perry_types::Type as HirType;
 
+use crate::block::LlBlock;
 #[allow(unused_imports)]
 use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
 #[allow(unused_imports)]
@@ -20,7 +21,10 @@ use crate::lower_string_method::{
     lower_string_concat_chain, lower_string_self_append,
 };
 #[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
+use crate::nanbox::{
+    double_literal, i64_literal, BIGINT_TAG_I64, POINTER_MASK, POINTER_MASK_I64, POINTER_TAG_I64,
+    STRING_TAG_I64, TAG_MASK,
+};
 use crate::native_value::{
     BoundsState, BufferAccessMode, LoweredValue, MaterializationReason, NativeRep, SemanticKind,
 };
@@ -204,6 +208,7 @@ fn lower_preguarded_plain_array_index_set(
     val_double: &str,
     arr_id: u32,
     guard_ok_slot: &str,
+    pointer_free_range_slot: Option<&str>,
     layout_note_needed: bool,
     write_barrier_needed: bool,
     value_is_numeric: bool,
@@ -217,9 +222,25 @@ fn lower_preguarded_plain_array_index_set(
     let fast_idx = ctx.new_block("idxset.preguarded_plain_fast");
     let fallback_idx = ctx.new_block("idxset.preguarded_plain_fallback");
     let merge_idx = ctx.new_block("idxset.preguarded_plain_merge");
+    let layout_branch = pointer_free_range_slot
+        .filter(|_| layout_note_needed)
+        .map(|_| {
+            (
+                ctx.new_block("idxset.preguarded_plain_layout_note"),
+                ctx.new_block("idxset.preguarded_plain_layout_skip"),
+            )
+        });
     let fast_label = ctx.block_label(fast_idx);
     let fallback_label = ctx.block_label(fallback_idx);
     let merge_label = ctx.block_label(merge_idx);
+    let layout_branch_labels = layout_branch.map(|(note_idx, skip_idx)| {
+        (
+            note_idx,
+            skip_idx,
+            ctx.block_label(note_idx),
+            ctx.block_label(skip_idx),
+        )
+    });
 
     let guard_ok_i32 = ctx.block().load(I32, guard_ok_slot);
     let guard_ok = ctx.block().icmp_ne(I32, &guard_ok_i32, "0");
@@ -251,26 +272,80 @@ fn lower_preguarded_plain_array_index_set(
         let with_header = blk.add(I64, &byte_offset, "8");
         let element_addr = blk.add(I64, &arr_handle, &with_header);
         let element_ptr = blk.inttoptr(I64, &element_addr);
-        let value_bits = emit_jsvalue_slot_store_on_block(
-            blk,
-            &element_ptr,
-            val_double,
-            &arr_handle,
-            idx_i32,
-            layout_note_needed,
-            &arr_handle,
-            &element_addr,
-            write_barrier_needed,
-        )
-        .unwrap_or_else(|| blk.bitcast_double_to_i64(val_double));
-        if !value_is_numeric {
-            emit_array_numeric_write_note_on_block(blk, &arr_handle, &value_bits);
+        blk.store(DOUBLE, val_double, &element_ptr);
+        let value_bits = blk.bitcast_double_to_i64(val_double);
+        if let (Some(pointer_free_range_slot), Some((note_idx, skip_idx, note_label, skip_label))) =
+            (pointer_free_range_slot, layout_branch_labels.as_ref())
+        {
+            let range_free_i32 = blk.load(I32, pointer_free_range_slot);
+            let range_free = blk.icmp_ne(I32, &range_free_i32, "0");
+            let value_has_pointer = emit_layout_pointer_bearing_bits_check(blk, &value_bits);
+            let value_non_pointer = blk.xor(I1, &value_has_pointer, "true");
+            let skip_layout_note = blk.and(I1, &range_free, &value_non_pointer);
+            blk.cond_br(&skip_layout_note, skip_label, note_label);
+
+            ctx.current_block = *note_idx;
+            {
+                let blk = ctx.block();
+                emit_layout_note_slot_on_block(blk, &arr_handle, idx_i32, &value_bits);
+                blk.br(skip_label);
+            }
+
+            ctx.current_block = *skip_idx;
+            {
+                let blk = ctx.block();
+                if write_barrier_needed {
+                    emit_write_barrier_slot_on_block(blk, &arr_handle, &element_addr, &value_bits);
+                }
+                if !value_is_numeric {
+                    emit_array_numeric_write_note_on_block(blk, &arr_handle, &value_bits);
+                }
+                blk.br(&merge_label);
+            }
+        } else {
+            if layout_note_needed {
+                emit_layout_note_slot_on_block(blk, &arr_handle, idx_i32, &value_bits);
+            }
+            if write_barrier_needed {
+                emit_write_barrier_slot_on_block(blk, &arr_handle, &element_addr, &value_bits);
+            }
+            if !value_is_numeric {
+                emit_array_numeric_write_note_on_block(blk, &arr_handle, &value_bits);
+            }
+            blk.br(&merge_label);
         }
-        blk.br(&merge_label);
     }
 
     ctx.current_block = merge_idx;
     Ok(())
+}
+
+fn emit_layout_pointer_bearing_bits_check(blk: &mut LlBlock, value_bits: &str) -> String {
+    let tag_mask = i64_literal(TAG_MASK);
+    let nanbox_min = i64_literal(0x7FF8_0000_0000_0000);
+    let pointer_mask = i64_literal(POINTER_MASK);
+
+    let tag = blk.and(I64, value_bits, &tag_mask);
+    let payload = blk.and(I64, value_bits, POINTER_MASK_I64);
+    let payload_nonzero = blk.icmp_ne(I64, &payload, "0");
+    let is_pointer_tag = blk.icmp_eq(I64, &tag, POINTER_TAG_I64);
+    let is_string_tag = blk.icmp_eq(I64, &tag, STRING_TAG_I64);
+    let is_bigint_tag = blk.icmp_eq(I64, &tag, BIGINT_TAG_I64);
+    let is_ref_tag = blk.or(I1, &is_pointer_tag, &is_string_tag);
+    let is_ref_tag = blk.or(I1, &is_ref_tag, &is_bigint_tag);
+    let tagged_pointer = blk.and(I1, &is_ref_tag, &payload_nonzero);
+
+    let nanbox_high = blk.icmp_sge(I64, &tag, &nanbox_min);
+    let not_nanbox_high = blk.xor(I1, &nanbox_high, "true");
+    let raw_ge_min = blk.icmp_sge(I64, value_bits, "4096");
+    let raw_le_mask = blk.icmp_sle(I64, value_bits, &pointer_mask);
+    let raw_in_range = blk.and(I1, &raw_ge_min, &raw_le_mask);
+    let aligned_bits = blk.and(I64, value_bits, "7");
+    let raw_aligned = blk.icmp_eq(I64, &aligned_bits, "0");
+    let raw_pointer = blk.and(I1, &not_nanbox_high, &raw_in_range);
+    let raw_pointer = blk.and(I1, &raw_pointer, &raw_aligned);
+
+    blk.or(I1, &tagged_pointer, &raw_pointer)
 }
 
 fn affine_index_expr_matches(expr: &Expr, pattern: &PreguardedAffineIndexExpr) -> bool {
@@ -782,6 +857,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                                         &val_double,
                                         id,
                                         &preguard.guard_ok_slot,
+                                        preguard.pointer_free_range_slot.as_deref(),
                                         layout_note_needed,
                                         write_barrier_needed,
                                         value_is_numeric,

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1042,6 +1042,7 @@ pub(crate) struct PreguardedNumericArrayIndexSet {
 #[derive(Debug, Clone)]
 pub(crate) struct PreguardedPlainArrayIndexSet {
     pub guard_ok_slot: String,
+    pub pointer_free_range_slot: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -208,6 +208,11 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
         &[DOUBLE, I32, I32],
     );
     module.declare_function(
+        "js_plain_array_inbounds_pointer_free_range_guard",
+        I32,
+        &[DOUBLE, I32, I32],
+    );
+    module.declare_function(
         "js_typed_feedback_plain_array_index_set_guard",
         I32,
         &[I64, DOUBLE, I32, DOUBLE, I32],

--- a/crates/perry-codegen/src/stmt/loops.rs
+++ b/crates/perry-codegen/src/stmt/loops.rs
@@ -1075,7 +1075,19 @@ fn emit_range_plain_array_index_set_preguard(
     let guard_ok_slot = ctx.func.alloca_entry(I32);
     ctx.block().store(I32, &guard_result, &guard_ok_slot);
 
-    Ok(PreguardedPlainArrayIndexSet { guard_ok_slot })
+    let pointer_free_result = ctx.block().call(
+        I32,
+        "js_plain_array_inbounds_pointer_free_range_guard",
+        &[(DOUBLE, &arr_box), (I32, &counter_i32), (I32, &max_i32)],
+    );
+    let pointer_free_range_slot = ctx.func.alloca_entry(I32);
+    ctx.block()
+        .store(I32, &pointer_free_result, &pointer_free_range_slot);
+
+    Ok(PreguardedPlainArrayIndexSet {
+        guard_ok_slot,
+        pointer_free_range_slot: Some(pointer_free_range_slot),
+    })
 }
 
 fn emit_affine_numeric_array_index_get_preguard(

--- a/crates/perry-codegen/tests/native_proof_buffer_views.rs
+++ b/crates/perry-codegen/tests/native_proof_buffer_views.rs
@@ -1345,6 +1345,52 @@ fn native_owned_uint8array_set_fallback_uses_uint8array_helper() {
 }
 
 #[test]
+fn uint8array_const_local_length_uses_inline_byte_get_set() {
+    let ir = compile_ir(
+        "uint8array_const_local_length_inline_byte_access.ts",
+        vec![
+            number_let(1, "size", false, int(16)),
+            Stmt::Let {
+                id: 2,
+                name: "buf".to_string(),
+                ty: Type::Named("Uint8Array".to_string()),
+                mutable: false,
+                init: Some(Expr::Uint8ArrayNew(Some(Box::new(local(1))))),
+            },
+            for_loop(
+                3,
+                local(1),
+                vec![Stmt::Expr(Expr::Uint8ArraySet {
+                    array: Box::new(local(2)),
+                    index: Box::new(local(3)),
+                    value: Box::new(local(3)),
+                })],
+            ),
+            Stmt::Return(Some(Expr::Uint8ArrayGet {
+                array: Box::new(local(2)),
+                index: Box::new(int(0)),
+            })),
+        ],
+    );
+    assert!(
+        ir.contains("store i8"),
+        "bounded Uint8Array set should lower to an inline byte store:\n{ir}"
+    );
+    assert!(
+        ir.contains("load i8"),
+        "bounded Uint8Array get should lower to an inline byte load:\n{ir}"
+    );
+    assert!(
+        !ir.contains("call void @js_uint8array_set"),
+        "inline Uint8Array set should not call the runtime helper:\n{ir}"
+    );
+    assert!(
+        !ir.contains("call i32 @js_uint8array_get"),
+        "inline Uint8Array get should not call the runtime helper:\n{ir}"
+    );
+}
+
+#[test]
 fn native_owned_typed_array_fallback_reasons_are_explicit() {
     let disposed = compile_artifact_json(
         "artifact_native_owned_disposed.ts",

--- a/crates/perry-codegen/tests/typed_feedback.rs
+++ b/crates/perry-codegen/tests/typed_feedback.rs
@@ -486,8 +486,14 @@ fn typed_feedback_preguards_plain_array_writes_with_length_bound() {
         ir.contains("call i32 @js_plain_array_inbounds_range_guard"),
         "{ir}"
     );
+    assert!(
+        ir.contains("call i32 @js_plain_array_inbounds_pointer_free_range_guard"),
+        "{ir}"
+    );
     assert!(ir.contains("idxset.preguarded_plain_fast"), "{ir}");
     assert!(ir.contains("idxset.preguarded_plain_fallback"), "{ir}");
+    assert!(ir.contains("idxset.preguarded_plain_layout_note"), "{ir}");
+    assert!(ir.contains("idxset.preguarded_plain_layout_skip"), "{ir}");
     assert!(ir.contains("call void @js_gc_note_slot_layout"), "{ir}");
     assert_eq!(
         ir.matches("call i32 @js_typed_feedback_plain_array_index_set_guard")
@@ -547,8 +553,14 @@ fn typed_feedback_preguards_plain_array_writes_with_local_bound() {
         ir.contains("call i32 @js_plain_array_inbounds_range_guard"),
         "{ir}"
     );
+    assert!(
+        ir.contains("call i32 @js_plain_array_inbounds_pointer_free_range_guard"),
+        "{ir}"
+    );
     assert!(ir.contains("idxset.preguarded_plain_fast"), "{ir}");
     assert!(ir.contains("idxset.preguarded_plain_fallback"), "{ir}");
+    assert!(ir.contains("idxset.preguarded_plain_layout_note"), "{ir}");
+    assert!(ir.contains("idxset.preguarded_plain_layout_skip"), "{ir}");
     assert_eq!(
         ir.matches("call i32 @js_typed_feedback_plain_array_index_set_guard")
             .count(),

--- a/crates/perry-runtime/src/gc/layout.rs
+++ b/crates/perry-runtime/src/gc/layout.rs
@@ -866,6 +866,35 @@ pub(crate) fn layout_pointer_slot_summary_for_user(
     }
 }
 
+pub(crate) fn layout_range_has_pointer_slots_for_user(
+    user_ptr: usize,
+    first_slot: usize,
+    last_slot: usize,
+    slot_count: usize,
+) -> Option<bool> {
+    if first_slot > last_slot || last_slot >= slot_count {
+        return None;
+    }
+    unsafe {
+        let header = layout_header_for_user(user_ptr)?;
+        match (*header)._reserved & GC_LAYOUT_STATE_MASK {
+            GC_LAYOUT_POINTER_FREE => Some(false),
+            GC_LAYOUT_SIDE_MASK => {
+                let mask = LAYOUT_SLOT_MASKS.with(|m| m.borrow().get(&user_ptr).cloned());
+                let Some(mask) = mask else {
+                    set_layout_state(header, GC_LAYOUT_UNKNOWN);
+                    return None;
+                };
+                Some(
+                    mask.next_slot_at_or_after(first_slot, slot_count)
+                        .is_some_and(|slot| slot <= last_slot),
+                )
+            }
+            _ => None,
+        }
+    }
+}
+
 pub(crate) fn layout_typed_raw_f64_slot_for_user(user_ptr: usize, slot_index: usize) -> bool {
     TYPED_LAYOUTS.with(|m| {
         m.borrow()

--- a/crates/perry-runtime/src/json/mod.rs
+++ b/crates/perry-runtime/src/json/mod.rs
@@ -624,6 +624,27 @@ mod tests {
     }
 
     #[test]
+    fn typed_parse_layout_only_object_field_writes_preserve_layout() {
+        let input = br#"[{"id":1,"name":"item_1","nested":{"x":1,"y":2}},{"id":2,"name":"item_2","nested":{"x":2,"y":4}}]"#;
+        let packed_keys = b"id\0name\0nested\0";
+        let text = js_string_from_bytes(input.as_ptr(), input.len() as u32);
+        let value = unsafe {
+            js_json_parse_typed_array(text, packed_keys.as_ptr(), packed_keys.len() as u32, 3)
+        };
+        let arr = (value.bits() & POINTER_MASK) as *const crate::ArrayHeader;
+        let first_bits = crate::array::js_array_get_f64(arr, 0).to_bits();
+        let first = (first_bits & POINTER_MASK) as usize;
+
+        assert_eq!(crate::gc::test_layout_pointer_slot_count(first, 3), Some(2));
+
+        let output = unsafe { js_json_stringify(f64::from_bits(value.bits()), TYPE_UNKNOWN) };
+        assert_eq!(
+            unsafe { str_from_header(output).unwrap() },
+            std::str::from_utf8(input).unwrap()
+        );
+    }
+
+    #[test]
     fn direct_parse_array_numeric_layout_preserves_and_downgrades() {
         let numeric_input = br#"[1,2,3]"#;
         let numeric_text = js_string_from_bytes(numeric_input.as_ptr(), numeric_input.len() as u32);

--- a/crates/perry-runtime/src/json/parser.rs
+++ b/crates/perry-runtime/src/json/parser.rs
@@ -418,8 +418,12 @@ impl<'a> DirectParser<'a> {
                             if fast_idx < alloc_limit {
                                 let slot_idx = fast_idx;
                                 let value_bits = value.bits();
-                                // GC_STORE_AUDIT(BARRIERED): shaped JSON field write uses the shared object slot-store helper.
-                                crate::object::store_object_field_slot(
+                                // JSON.parse suppresses GC and writes only into
+                                // objects allocated by the same parse, so a
+                                // generational write barrier is redundant.
+                                // Keep the layout note so tracing still sees
+                                // the field slot.
+                                crate::object::store_object_field_slot_layout_only(
                                     js_obj, slot_idx, value_bits,
                                 );
                                 fast_idx += 1;
@@ -656,8 +660,7 @@ impl<'a> DirectParser<'a> {
         let write_field = |i: usize, value: JSValue| {
             let value_bits = value.bits();
             unsafe {
-                // GC_STORE_AUDIT(BARRIERED): JSON object field write uses the shared object slot-store helper.
-                crate::object::store_object_field_slot(js_obj, i, value_bits);
+                crate::object::store_object_field_slot_layout_only(js_obj, i, value_bits);
             }
         };
         if let Some((_, values)) = heap_fields.as_ref() {

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1936,6 +1936,18 @@ pub(crate) unsafe fn store_object_field_slot(
 }
 
 #[inline]
+pub(crate) unsafe fn store_object_field_slot_layout_only(
+    obj: *mut ObjectHeader,
+    field_index: usize,
+    value_bits: u64,
+) {
+    let fields_ptr = (obj as *mut u8).add(std::mem::size_of::<ObjectHeader>()) as *mut u64;
+    // GC_STORE_AUDIT(INIT): layout-only helper is restricted to fresh/suppressed caller sites.
+    std::ptr::write(fields_ptr.add(field_index), value_bits);
+    crate::gc::layout_note_slot(obj as usize, field_index, value_bits);
+}
+
+#[inline]
 pub(super) unsafe fn mark_object_dynamic_shape_unknown(obj: *mut ObjectHeader) {
     if obj.is_null() || (obj as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
         return;

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -1200,6 +1200,28 @@ pub extern "C" fn js_plain_array_inbounds_range_guard(
     }
 }
 
+#[no_mangle]
+pub extern "C" fn js_plain_array_inbounds_pointer_free_range_guard(
+    receiver: f64,
+    first_index: i32,
+    last_index: i32,
+) -> i32 {
+    if first_index < 0 || last_index < first_index {
+        return 0;
+    }
+    let raw_addr = normalize_raw_object_addr(receiver.to_bits());
+    if !plain_array_index_guard(raw_addr as *const ArrayHeader, last_index as u32, true) {
+        return 0;
+    }
+    let first = first_index as usize;
+    let last = last_index as usize;
+    let slot_count = last.saturating_add(1);
+    match crate::gc::layout_range_has_pointer_slots_for_user(raw_addr, first, last, slot_count) {
+        Some(false) => 1,
+        _ => 0,
+    }
+}
+
 fn numeric_array_index_guard(arr: *const ArrayHeader, index: u32, require_in_bounds: bool) -> bool {
     plain_array_index_guard(arr, index, require_in_bounds)
         && crate::array::js_array_is_numeric_f64_layout(arr) != 0

--- a/crates/perry-runtime/src/typed_feedback/tests.rs
+++ b/crates/perry-runtime/src/typed_feedback/tests.rs
@@ -674,6 +674,58 @@ fn typed_feedback_plain_array_inbounds_range_guard_checks_current_and_last_index
 }
 
 #[test]
+fn typed_feedback_plain_array_pointer_free_range_guard_tracks_current_layout() {
+    let values = [1.0, 2.0, 3.0];
+    let arr = crate::array::js_array_from_f64(values.as_ptr(), values.len() as u32);
+    let arr_box = crate::value::js_nanbox_pointer(arr as i64);
+
+    assert_eq!(
+        js_plain_array_inbounds_pointer_free_range_guard(arr_box, 0, 2),
+        1
+    );
+    assert_eq!(
+        js_plain_array_inbounds_pointer_free_range_guard(arr_box, 1, 1),
+        1
+    );
+
+    let payload = crate::string::js_string_from_bytes(b"downgraded".as_ptr(), 10);
+    let payload_value = crate::value::js_nanbox_string(payload as i64);
+    crate::array::js_array_set_f64(arr, 1, payload_value);
+
+    assert_eq!(
+        js_plain_array_inbounds_pointer_free_range_guard(arr_box, 0, 0),
+        1
+    );
+    assert_eq!(
+        js_plain_array_inbounds_pointer_free_range_guard(arr_box, 0, 2),
+        0
+    );
+    assert_eq!(
+        js_plain_array_inbounds_pointer_free_range_guard(arr_box, 2, 2),
+        1
+    );
+    assert_eq!(
+        js_plain_array_inbounds_pointer_free_range_guard(arr_box, -1, 2),
+        0
+    );
+    assert_eq!(
+        js_plain_array_inbounds_pointer_free_range_guard(arr_box, 2, 1),
+        0
+    );
+    assert_eq!(
+        js_plain_array_inbounds_pointer_free_range_guard(arr_box, 0, 3),
+        0
+    );
+
+    let obj = crate::object::js_object_alloc(0, 0);
+    let obj_box = crate::value::js_nanbox_pointer(obj as i64);
+    assert_eq!(
+        js_plain_array_inbounds_pointer_free_range_guard(obj_box, 0, 0),
+        0
+    );
+}
+
+#[test]
 fn typed_feedback_numeric_array_guard_fast_path_respects_megamorphic_state() {
     let _guard = TYPED_FEEDBACK_TEST_LOCK.lock().unwrap();
     reset_typed_feedback_for_tests();


### PR DESCRIPTION
## Summary

- add `store_object_field_slot_layout_only` for fresh/suppressed object field initialization
- use it when direct JSON.parse initializes shaped and generic object fields, preserving layout notes while skipping the full write-barrier store path
- add a typed parse regression test that verifies pointer-slot layout metadata and stringify roundtrip behavior

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p perry-runtime json::tests -- --nocapture` (14 passed)
- `cargo build --release -p perry`
- source inspection: `crates/perry-runtime/src/json/parser.rs` uses `store_object_field_slot_layout_only` only at the two JSON object initialization sites

## Benchmarks

Typed JSON roundtrip, interleaved old/new binaries, checksum stayed `53736400`:

- baseline samples: 548, 588, 540, 513, 514, 520, 587, 525, 509, 529 ms; avg 537.3 ms
- final samples: 502, 515, 484, 466, 474, 491, 480, 464, 483, 480 ms; avg 483.9 ms
- impact: 53.4 ms faster on average, about 9.9% lower runtime

Generic direct JSON roundtrip with `PERRY_JSON_TAPE=0`, checksum stayed `53736400`:

- baseline samples: 562, 577, 524, 566, 557 ms; avg 557.2 ms
- final samples: 523, 521, 521, 534, 539 ms; avg 527.6 ms

Default lazy-mode smoke for generic roundtrip stayed on the existing tape path: `json_roundtrip:65`, checksum `53735550`.
