### PR TITLE
fix(compile,runtime): read-of-undefined cluster — native-compile bluebird + execa (winston prototype-getter)

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -777,6 +777,30 @@ unsafe fn resolve_proto_chain_field_inner(
     let mut cid = class_id;
     let mut depth = 0usize;
     while depth < 32 {
+        // The reflective `ClassName.prototype` object
+        // (`CLASS_DECL_PROTOTYPE_OBJECTS`) is where a user
+        // `Object.defineProperty(ClassName.prototype, name, { get })` installs
+        // its accessor — distinct from the #711/#809 synthetic-proto cache
+        // (`CLASS_PROTOTYPE_OBJECTS`) that the rest of this walk reads. The
+        // instance-read walk historically only consulted the latter, so such a
+        // getter was invisible to `instance.name` (winston:
+        // `Object.defineProperty(Logger.prototype, 'transports', { get })`,
+        // read as `this.transports`, came back `undefined` → `.length` threw).
+        // Check the decl-proto object for an ACCESSOR only: it is allocated
+        // WITH this `class_id` (`js_object_alloc(class_id, 0)`), so routing its
+        // DATA reads back through `js_object_get_field_by_name` would re-enter
+        // this same walk for the same id and recurse infinitely (a Transform
+        // subclass's `_read` lookup stack-overflowed → SIGSEGV). Class methods /
+        // data are already covered by the vtable + `class_prototype_object`
+        // path below, so the accessor-only probe here is sufficient.
+        if let Some(receiver) = receiver {
+            let decl_proto = class_decl_prototype_object(cid);
+            if !decl_proto.is_null() {
+                if let Some(value) = inherited_proto_accessor_value(decl_proto, key, receiver) {
+                    return Some(value);
+                }
+            }
+        }
         let proto_obj = class_prototype_object(cid);
         if !proto_obj.is_null() {
             if let Some(receiver) = receiver {

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -3552,6 +3552,22 @@ pub extern "C" fn js_object_get_field_by_name(
                                 return JSValue::from_bits(v.to_bits());
                             }
                         }
+                        // `promise.constructor` is the global `Promise`
+                        // (inherited from `Promise.prototype.constructor`). Any
+                        // own expando (`p.constructor = X`) already returned via
+                        // `exotic_get_own_property` above. execa
+                        // (`(async () => {})().constructor.prototype`) reads it
+                        // to capture the native promise prototype — without this
+                        // arm it fell through to `undefined` and
+                        // `.prototype` threw `Cannot read properties of
+                        // undefined`.
+                        if name_bytes == b"constructor" {
+                            let v = crate::object::js_get_global_this_builtin_value(
+                                b"Promise".as_ptr(),
+                                7,
+                            );
+                            return JSValue::from_bits(v.to_bits());
+                        }
                         // A Promise is a `GC_TYPE_PROMISE` cell, not an
                         // `ObjectHeader`; never fall through to the field/vtable
                         // path below (it would reinterpret the promise's bytes).

--- a/crates/perry/src/commands/compile/cjs_wrap/extract_requires.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/extract_requires.rs
@@ -180,6 +180,72 @@ pub fn identifier_is_reassigned(source: &str, name: &str) -> bool {
     false
 }
 
+/// Does the CJS source declare a binding named `name` via `var`/`let`/`const`/
+/// `function`/`class` anywhere in the body? Used by the named-export emission to
+/// decide whether `name` is a real module binding (so `export const name =
+/// _cjs.name;` is safe) or merely an object-literal export KEY whose value is a
+/// global/expression — in which case emitting a module-scope `const name` would
+/// SHADOW a global builtin that the body references freely.
+///
+/// Concretely: bluebird's `errors.js` ends with `module.exports = { Error:
+/// Error, TypeError: _TypeError, ... }`. The keys `Error`/`TypeError`/
+/// `RangeError` are JS global builtins; the body has no `function Error` /
+/// `var Error` etc. Emitting `export const Error = _cjs.Error;` introduced a
+/// module-scope `Error` that shadowed the global for the body's
+/// `inherits(SubError, Error)` (an IIFE-local free reference) — `Error` read
+/// `undefined` and `Parent.prototype` threw `Cannot read properties of
+/// undefined (reading 'prototype')`. This helper lets the caller skip the
+/// shadowing `const` for such names.
+///
+/// Heuristic, regex-crate-friendly (no lookaround): whole-word scan for `name`
+/// preceded (modulo whitespace) by a `var`/`let`/`const`/`function`/`class`
+/// keyword. Member-access positions (`x.name`) and `name`-as-a-substring are
+/// excluded. A false positive (treating a non-declared name as declared) only
+/// reverts to the prior `export const` behavior; a false negative (treating a
+/// declared name as undeclared) only forfeits a named export's module-scope
+/// binding while still surfacing the value via `_cjs.name`.
+pub fn identifier_is_declared_binding(source: &str, name: &str) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    let bytes = source.as_bytes();
+    let nlen = name.len();
+    let is_ident = |c: u8| c.is_ascii_alphanumeric() || c == b'_' || c == b'$';
+    let mut from = 0usize;
+    while let Some(rel) = source[from..].find(name) {
+        let start = from + rel;
+        let end = start + nlen;
+        from = start + 1;
+        // Whole-word boundaries.
+        if start > 0 && is_ident(bytes[start - 1]) {
+            continue;
+        }
+        if end < bytes.len() && is_ident(bytes[end]) {
+            continue;
+        }
+        // Preceding non-space char: skip member access (`.name`).
+        let mut p = start;
+        while p > 0 && (bytes[p - 1] as char).is_whitespace() {
+            p -= 1;
+        }
+        if p > 0 && bytes[p - 1] == b'.' {
+            continue;
+        }
+        // Preceding identifier token must be a binding keyword.
+        let mut w = p;
+        while w > 0 && is_ident(bytes[w - 1]) {
+            w -= 1;
+        }
+        if matches!(
+            &source[w..p],
+            "var" | "let" | "const" | "function" | "class"
+        ) {
+            return true;
+        }
+    }
+    false
+}
+
 /// Next.js lazy-require classification (single forward pass). Returns the set
 /// of specifiers whose EVERY `require('<spec>')` call site is lexically inside
 /// a FUNCTION body — never at module top level, and never inside a top-level

--- a/crates/perry/src/commands/compile/cjs_wrap/mod.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/mod.rs
@@ -51,7 +51,7 @@ pub(self) use extract_exports::{
 };
 pub(self) use extract_requires::{
     extract_export_star_specs, extract_require_aliases_with_ranges, extract_require_specifiers,
-    function_local_specs, identifier_is_reassigned,
+    function_local_specs, identifier_is_declared_binding, identifier_is_reassigned,
 };
 pub(self) use hoist_classes::{
     extract_top_level_class_decls, rewrite_module_exports_class_expression,
@@ -551,6 +551,67 @@ module.exports = inner;
     }
 
     #[test]
+    fn wrap_does_not_shadow_global_builtin_named_export() {
+        // Regression (bluebird errors.js): `module.exports = { Error: Error,
+        // TypeError: _TypeError, ... }`. The export KEY `Error` is a global
+        // builtin; the body has no `function/var/let/const/class Error`. Emitting
+        // `export const Error = _cjs.Error;` at module scope put an `Error`
+        // binding ahead of the global, so the IIFE body's free `Error`
+        // (`inherits(SubError, Error)`) resolved to the `export const` — value
+        // `_cjs.Error`, `undefined` until the IIFE returns — and reading
+        // `Error.prototype` threw `Cannot read properties of undefined (reading
+        // 'prototype')`. Fix: surface such builtin-named exports through a
+        // MANGLED module binding (`const __cjsexp_Error = _cjs.Error; export {
+        // __cjsexp_Error as Error };`) so no `Error` binding shadows the global.
+        let src = "var inherits = require('./util').inherits;\n\
+                   function subError() { function SubError() {} inherits(SubError, Error); return SubError; }\n\
+                   var Warning = subError();\n\
+                   module.exports = { Error: Error, Warning: Warning };";
+        let wrapped = wrap_commonjs(src, &PathBuf::from("/tmp/pkg/index.js"));
+        // `Error` (global builtin, undeclared in body) must NOT get a plain
+        // `export const Error` that shadows the global.
+        assert!(
+            !wrapped.contains("export const Error = _cjs.Error;"),
+            "must NOT emit a shadowing `export const Error`, got:\n{}",
+            wrapped
+        );
+        // It is surfaced via a mangled re-export instead.
+        assert!(
+            wrapped.contains("const __cjsexp_Error = _cjs.Error;")
+                && wrapped.contains("export { __cjsexp_Error as Error };"),
+            "expected mangled re-export of the builtin-named export, got:\n{}",
+            wrapped
+        );
+        // A NON-builtin named export (`Warning`, also undeclared as a body
+        // binding — it's a `var`) keeps the ordinary `export const` form.
+        assert!(
+            wrapped.contains("export const Warning = _cjs.Warning;"),
+            "expected ordinary `export const Warning`, got:\n{}",
+            wrapped
+        );
+    }
+
+    #[test]
+    fn wrap_keeps_export_const_for_builtin_name_declared_in_body() {
+        // A name that collides with a builtin but IS a real module binding
+        // (`function Error() {}`) is a genuine local export — keep the ordinary
+        // `export const Error = _cjs.Error;` (no global to shadow).
+        let src = "function Error() { this.x = 1; }\n\
+                   module.exports = { Error: Error };";
+        let wrapped = wrap_commonjs(src, &PathBuf::from("/tmp/pkg/index.js"));
+        assert!(
+            wrapped.contains("export const Error = _cjs.Error;"),
+            "a body-declared `Error` must keep the plain export const, got:\n{}",
+            wrapped
+        );
+        assert!(
+            !wrapped.contains("__cjsexp_Error"),
+            "must NOT mangle a body-declared export name, got:\n{}",
+            wrapped
+        );
+    }
+
+    #[test]
     fn identifier_is_reassigned_distinguishes_declaration_from_write() {
         use super::extract_requires::identifier_is_reassigned;
         // Pure read-only alias: declaration + member reads only.
@@ -572,6 +633,31 @@ module.exports = inner;
         assert!(!identifier_is_reassigned(
             "var s = require('./d'); if (s === other) {} obj.s = 1; cb(() => s);",
             "s"
+        ));
+    }
+
+    #[test]
+    fn identifier_is_declared_binding_detects_module_bindings() {
+        use super::extract_requires::identifier_is_declared_binding;
+        // Each declaration keyword form.
+        assert!(identifier_is_declared_binding(
+            "function Error() {}",
+            "Error"
+        ));
+        assert!(identifier_is_declared_binding("class Error {}", "Error"));
+        assert!(identifier_is_declared_binding("var Error = 1;", "Error"));
+        assert!(identifier_is_declared_binding("let Error = 1;", "Error"));
+        assert!(identifier_is_declared_binding("const Error = 1;", "Error"));
+        // A bare free reference / member access is NOT a declaration.
+        assert!(!identifier_is_declared_binding(
+            "inherits(SubError, Error); var x = Error.prototype;",
+            "Error"
+        ));
+        assert!(!identifier_is_declared_binding("obj.Error = 1;", "Error"));
+        // Substring of a longer identifier must not match.
+        assert!(!identifier_is_declared_binding(
+            "var ErrorType = 1;",
+            "Error"
         ));
     }
 

--- a/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
@@ -5,6 +5,63 @@ use super::*;
 use std::borrow::Cow;
 use std::path::Path;
 
+/// Is `name` a JS global-builtin VALUE (a constructor/namespace reachable as a
+/// bare identifier at runtime)? Used only to decide whether a CJS named export
+/// whose KEY equals such a name (`module.exports = { Error: Error }`) needs the
+/// mangled-rebinding emission so a module-scope `export const <name>` doesn't
+/// shadow the global for free references in the IIFE body. Deliberately limited
+/// to runtime VALUES (not TS-only utility types): an over-broad set would only
+/// route an unrelated export through the (correct) mangled re-export.
+fn is_global_value_builtin_name(name: &str) -> bool {
+    matches!(
+        name,
+        "Error"
+            | "TypeError"
+            | "RangeError"
+            | "SyntaxError"
+            | "ReferenceError"
+            | "EvalError"
+            | "URIError"
+            | "AggregateError"
+            | "SuppressedError"
+            | "Object"
+            | "Function"
+            | "Array"
+            | "Boolean"
+            | "Number"
+            | "String"
+            | "Symbol"
+            | "BigInt"
+            | "Math"
+            | "JSON"
+            | "Date"
+            | "RegExp"
+            | "Promise"
+            | "Proxy"
+            | "Reflect"
+            | "Map"
+            | "Set"
+            | "WeakMap"
+            | "WeakSet"
+            | "WeakRef"
+            | "ArrayBuffer"
+            | "SharedArrayBuffer"
+            | "DataView"
+            | "Buffer"
+            | "Uint8Array"
+            | "Uint8ClampedArray"
+            | "Int8Array"
+            | "Int16Array"
+            | "Uint16Array"
+            | "Int32Array"
+            | "Uint32Array"
+            | "Float32Array"
+            | "Float64Array"
+            | "BigInt64Array"
+            | "BigUint64Array"
+    )
+}
+
 /// Wrap CJS source as ESM. `source_path` is the absolute path of the file
 /// being wrapped — used to resolve `require('./relative')` targets when
 /// peeking at re-export wrappers' transitive named exports.
@@ -497,6 +554,22 @@ pub(in crate::commands::compile) fn wrap_commonjs_with_body_offset(
         .map(|(n, _)| n.clone())
         .collect();
 
+    // A named export whose name is a JS global-builtin VALUE (`Error`,
+    // `TypeError`, `Object`, `Promise`, …) and is NOT declared as a module
+    // binding in the body is the `module.exports = { Error: Error }` shape: the
+    // KEY collides with a global the IIFE body references freely. Emitting
+    // `export const Error = _cjs.Error;` puts a module-scope `Error` binding
+    // ahead of the global, so the body's `Error` (e.g. bluebird errors.js
+    // `inherits(SubError, Error)`) resolves to the `export const`, whose value
+    // `_cjs.Error` is `undefined` until the IIFE returns — `Parent.prototype`
+    // then threw `Cannot read properties of undefined (reading 'prototype')`.
+    // For these, surface the export through a MANGLED module-scope binding and
+    // re-export it under the original name (`const __cjsexp_Error = _cjs.Error;
+    // export { __cjsexp_Error as Error };`). The value still surfaces for named
+    // imports, but no `Error` binding shadows the global in the body.
+    let builtin_value_global_collision = |n: &str| -> bool {
+        is_global_value_builtin_name(n) && !identifier_is_declared_binding(source, n)
+    };
     let named_export_decls = if named_exports.is_empty() {
         String::new()
     } else {
@@ -504,7 +577,16 @@ pub(in crate::commands::compile) fn wrap_commonjs_with_body_offset(
             .iter()
             .filter(|n| !hoisted_class_names.contains(n))
             .filter(|n| !named_reexport_names.contains(n))
-            .map(|n| format!("export const {} = _cjs.{};", n, n))
+            .map(|n| {
+                if builtin_value_global_collision(n) {
+                    format!(
+                        "const __cjsexp_{n} = _cjs.{n};\nexport {{ __cjsexp_{n} as {n} }};",
+                        n = n
+                    )
+                } else {
+                    format!("export const {} = _cjs.{};", n, n)
+                }
+            })
             .collect::<Vec<_>>()
             .join("\n")
     };

--- a/test-files/test_read_undefined_proto_getter_promise_ctor.ts
+++ b/test-files/test_read_undefined_proto_getter_promise_ctor.ts
@@ -1,0 +1,61 @@
+// Regressions for the "read of undefined" cluster surfaced by native-compiling
+// bluebird / execa / winston (branch fix/read-undefined-bluebird-winston).
+//
+// 1. Promise `.constructor` is the global `Promise` — execa's
+//    `(async () => {})().constructor.prototype` captured the native promise
+//    prototype; pre-fix `.constructor` read `undefined` and `.prototype` threw
+//    `Cannot read properties of undefined (reading 'prototype')`.
+//
+// 2. An accessor installed via `Object.defineProperty(Class.prototype, name,
+//    { get })` must fire when the property is read on an INSTANCE (not only via
+//    `Class.prototype.name`). winston's `transports` getter
+//    (`Object.defineProperty(Logger.prototype, 'transports', { get })`, read as
+//    `this.transports`) returned `undefined` and `.length` threw. Covered for a
+//    plain class AND a class that `extends` a native node:stream base (the
+//    latter previously stack-overflowed once the getter was found, because the
+//    decl-prototype object carries the instance class_id and its data-field
+//    walk re-entered the same proto-chain resolution).
+
+import { Transform } from "node:stream";
+
+// --- 1. Promise.constructor ---
+const p0 = Promise.resolve(1);
+console.log("Promise.resolve().constructor === Promise:", p0.constructor === Promise);
+const p1 = (async () => {})();
+console.log("async-arrow promise .constructor typeof:", typeof p1.constructor);
+console.log("async-arrow promise .constructor.prototype typeof:", typeof p1.constructor.prototype);
+console.log("native promise then is fn:", typeof p1.constructor.prototype.then === "function");
+
+// --- 2a. defineProperty getter on a plain class prototype, read on instance ---
+class Plain {}
+Object.defineProperty(Plain.prototype, "tag", {
+  configurable: true,
+  enumerable: true,
+  get() {
+    return "plain-getter";
+  },
+});
+const plain = new Plain();
+console.log("plain instance getter:", (plain as any).tag);
+console.log("plain computed read:", (plain as any)["tag"]);
+
+// --- 2b. defineProperty getter on a native-stream subclass, read on instance ---
+class Logger extends Transform {
+  constructor() {
+    super({ objectMode: true });
+  }
+  readTransports() {
+    return (this as any).transports.length;
+  }
+}
+Object.defineProperty(Logger.prototype, "transports", {
+  configurable: false,
+  enumerable: true,
+  get() {
+    const pipes = (this as any)._readableState ? (this as any)._readableState.pipes : undefined;
+    return !Array.isArray(pipes) ? [pipes].filter(Boolean) : pipes;
+  },
+});
+const logger = new Logger();
+console.log("stream subclass getter is array:", Array.isArray((logger as any).transports));
+console.log("stream subclass getter .length via method:", logger.readTransports());


### PR DESCRIPTION
## Read-of-undefined cluster: native-compile bluebird + execa (and the winston prototype-getter)

Fixes the `Cannot read properties of undefined` failures blocking native compile of bluebird, execa, and winston. Three **distinct** roots (none was function-declaration hoisting — that already works; the bluebird diagnosis in the task brief was a red herring once traced with a non-perturbing runtime backtrace).

### Roots & fixes

**1. cjs-wrap builtin-named-export shadowing — DISTINCT (bluebird)**
bluebird's `errors.js` ends with `module.exports = { Error: Error, TypeError: _TypeError, ... }`. The wrap emitted `export const Error = _cjs.Error;` at module scope. That binding **shadowed the global builtin** for the IIFE body's free references (`inherits(SubError, Error)` in the same module), so `Error` read `undefined` (`_cjs.Error` is undefined until the IIFE returns) and `Parent.prototype` threw. Same family as #5337 (pino alias/export collision).
- *Fix* (`cjs_wrap/wrap.rs`, `extract_requires.rs`): for a named export whose key is a JS global-builtin VALUE **and** is not declared as a module binding in the body, surface it via a mangled re-export (`const __cjsexp_Error = _cjs.Error; export { __cjsexp_Error as Error };`) so no module-scope binding shadows the global. New helpers `identifier_is_declared_binding` + `is_global_value_builtin_name`.

**2. Promise `.constructor` returned undefined — DISTINCT (execa)**
execa's `(async () => {})().constructor.prototype` captures the native promise prototype. The `GC_TYPE_PROMISE` field-get arm handled `then`/`catch`/`finally` but fell through to `undefined` for `constructor`.
- *Fix* (`field_get_set.rs`): return the global `Promise` for `promise.constructor` (own expandos still win first).

**3. defineProperty prototype accessor invisible to instance reads — DISTINCT (winston)**
`Object.defineProperty(Class.prototype, name, { get })` installs the accessor on the `CLASS_DECL_PROTOTYPE_OBJECTS` object (what a reflective `Class.prototype` read returns), but the instance proto-chain walk only consulted `CLASS_PROTOTYPE_OBJECTS`, so `instance.name` got `undefined` and never fired the getter (true for plain classes too, not just native-base subclasses).
- *Fix* (`class_registry.rs`): also probe the decl-proto object for an **accessor** at each class id in `resolve_proto_chain_field_inner`. Accessor-only on purpose — that object carries the instance `class_id`, so routing its *data* reads back through `js_object_get_field_by_name` re-enters the same walk and recurses infinitely (a `Transform` subclass's `_read` lookup stack-overflowed → SIGSEGV during bring-up).

### Before / after (corpus, coherent binary, `--no-cache`)
| pkg | before | after |
|-----|--------|-------|
| bluebird | `reading 'prototype'` (promise.js:55 → really util.js `inherits`) | **runs, `bluebird object`** |
| execa | `reading 'prototype'` (uint-array.js:3 → really promise.js:10 `.constructor.prototype`) | **runs, `execa object`** |
| winston | `reading 'length'` (logger.js:82 — `this.transports` getter dropped) | getter now fires; **advances** to next wall |

**Corpus: 55→57/59, no regressions.**

### Remaining walls (honest partials)
- **winston** — the prototype-getter root is fixed (the `transports` getter now resolves and runs). It now fails *deeper*: `this._readableState` is `undefined` on a compiled `class extends Transform` instance (logger.js:695 `const { pipes } = this._readableState`). That's a separate node-stream-subclass state-init gap, not the getter-resolution task — not addressed here.
- **semver** — `Invalid comparator: >=0.0.0-0`, explicitly out of scope (someone else's task).

### Tests
- `cjs_wrap` unit tests: builtin-named-export mangling, body-declared-builtin keeps `export const`, `identifier_is_declared_binding`.
- `test-files/test_read_undefined_proto_getter_promise_ctor.ts` — end-to-end; perry output byte-matches `node --experimental-strip-types`.

### Validation
- Coherent `cargo build --release --workspace` (UI crates excluded) green.
- `cargo fmt --all --check` clean; `check_file_size.sh`, `gc_store_site_inventory.py`, `addr_class_inventory.py` all pass.
- perry-runtime object/promise tests pass single-threaded; the 2 parallel failures (`builtin_prototype_methods_reject_dynamic_new`, `dyn_prop_values_are_visited_in_mark_phase`) are pre-existing parallel-execution flakes (pass isolated), unrelated to this change.

### Version / CHANGELOG
Not touched (per contributor convention) — maintainer to fold the version bump + CHANGELOG entry at merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed prototype accessors installed via `Object.defineProperty` not being visible on instance property reads
  * Fixed `Promise.constructor` returning `undefined`
  * Fixed CommonJS wrapping preventing accidental shadowing of global built-in identifiers

* **Tests**
  * Added regression tests for prototype accessor behavior and CommonJS wrapping with global built-in naming collisions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->