### PR TITLE
[codex] Refresh JSON parse array roots only on grow

### DIFF
--- a/crates/perry-runtime/src/json/mod.rs
+++ b/crates/perry-runtime/src/json/mod.rs
@@ -224,21 +224,6 @@ pub(crate) fn parse_root_set(idx: usize, v: JSValue) {
 }
 
 #[inline]
-pub(crate) fn parse_root_get(idx: usize) -> JSValue {
-    PARSE_ROOTS.with(|r| {
-        r.borrow()
-            .get(idx)
-            .map(|slot| JSValue::from_bits(slot.to_bits()))
-            .unwrap_or_else(JSValue::undefined)
-    })
-}
-
-#[inline]
-pub(crate) fn parse_root_array_ptr(idx: usize) -> *mut crate::ArrayHeader {
-    (parse_root_get(idx).bits() & POINTER_MASK) as *mut crate::ArrayHeader
-}
-
-#[inline]
 pub(crate) fn parse_root_save_len() -> usize {
     PARSE_ROOTS.with(|r| r.borrow().len())
 }
@@ -660,6 +645,27 @@ mod tests {
             unsafe { str_from_header(output).unwrap() },
             std::str::from_utf8(input).unwrap()
         );
+    }
+
+    #[test]
+    fn direct_parse_array_growth_keeps_root_current() {
+        let mut input = String::from("[");
+        for i in 0..40 {
+            if i > 0 {
+                input.push(',');
+            }
+            input.push_str(&format!(r#"{{"i":{},"v":[{},{}]}}"#, i, i, i + 1));
+        }
+        input.push(']');
+
+        let text = js_string_from_bytes(input.as_ptr(), input.len() as u32);
+        let value = unsafe { js_json_parse(text) };
+        let arr = (value.bits() & POINTER_MASK) as *const crate::ArrayHeader;
+
+        assert_eq!(crate::array::js_array_length(arr), 40);
+
+        let output = unsafe { js_json_stringify(f64::from_bits(value.bits()), TYPE_UNKNOWN) };
+        assert_eq!(unsafe { str_from_header(output).unwrap() }, input);
     }
 
     #[test]

--- a/crates/perry-runtime/src/json/parser.rs
+++ b/crates/perry-runtime/src/json/parser.rs
@@ -516,11 +516,15 @@ impl<'a> DirectParser<'a> {
             } else {
                 self.parse_value_generic()
             };
-            js_arr = parse_root_array_ptr(arr_slot);
             // GC is suppressed for the whole typed parse, so array growth
-            // cannot collect before `value` is stored.
-            js_arr = self.array_push_parse_fast(js_arr, value);
-            parse_root_set(arr_slot, JSValue::object_ptr(js_arr as *mut u8));
+            // cannot collect before `value` is stored. The array pointer
+            // remains stable across nested value parsing; refresh the parse
+            // root only if the push actually grows to a new header.
+            let pushed = self.array_push_parse_fast(js_arr, value);
+            if pushed != js_arr {
+                parse_root_set(arr_slot, JSValue::object_ptr(pushed as *mut u8));
+            }
+            js_arr = pushed;
 
             self.skip_whitespace();
             if self.peek() == Some(b',') {
@@ -530,7 +534,6 @@ impl<'a> DirectParser<'a> {
             }
         }
         self.expect(b']');
-        js_arr = parse_root_array_ptr(arr_slot);
         parse_root_restore(saved_roots);
         JSValue::object_ptr(js_arr as *mut u8)
     }
@@ -700,13 +703,15 @@ impl<'a> DirectParser<'a> {
 
         loop {
             let value = self.parse_value();
-            js_arr = parse_root_array_ptr(arr_slot);
             // GC is suppressed for the whole direct parse, so array growth
-            // cannot collect before `value` is stored.
-            js_arr = self.array_push_parse_fast(js_arr, value);
-            // js_array_push may have returned a new ArrayHeader* after grow;
-            // update the root slot so GC sees the new pointer, not the stale one.
-            parse_root_set(arr_slot, JSValue::object_ptr(js_arr as *mut u8));
+            // cannot collect before `value` is stored. The array pointer
+            // remains stable across nested value parsing; refresh the parse
+            // root only if the push actually grows to a new header.
+            let pushed = self.array_push_parse_fast(js_arr, value);
+            if pushed != js_arr {
+                parse_root_set(arr_slot, JSValue::object_ptr(pushed as *mut u8));
+            }
+            js_arr = pushed;
 
             self.skip_whitespace();
             if self.peek() == Some(b',') {
@@ -716,7 +721,6 @@ impl<'a> DirectParser<'a> {
             }
         }
         self.expect(b']');
-        js_arr = parse_root_array_ptr(arr_slot);
         parse_root_restore(saved_roots);
         JSValue::object_ptr(js_arr as *mut u8)
     }


### PR DESCRIPTION
## Summary
- Keep the JSON direct parser's array header pointer in a local across nested element parsing while GC is suppressed.
- Refresh the parse root only when `array_push_parse_fast` grows to a new array header.
- Apply the change to both typed and generic direct array parsers, remove unused root reload helpers, and add a growth regression test.

## Benchmarks
Interleaved 10-pair runs, checksums stable.

- `bench_json_typed_roundtrip`: base avg 470.60 ms / median 472.50 ms; final avg 462.40 ms / median 459.00 ms; checksum `53736400`.
- `PERRY_JSON_TAPE=0 bench_json_roundtrip`: base avg 505.00 ms / median 504.00 ms; final avg 486.60 ms / median 486.50 ms; checksum `53736400`.
- `json_typed_parse_only`: base avg 263.30 ms / median 259.00 ms; final avg 256.80 ms / median 256.50 ms; checksum `500000`.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p perry-runtime json::tests -- --nocapture` (16 passed)
- `cargo build --release -p perry`
- Source inspection confirms only grow-conditioned array `parse_root_set` calls remain and the old array/root reload helpers are gone.
