### PR TITLE
[codex] Guard downgraded array numeric updates

### DIFF
--- a/crates/perry-codegen/src/expr/binary.rs
+++ b/crates/perry-codegen/src/expr/binary.rs
@@ -46,6 +46,94 @@ use super::{
     I18nLowerCtx,
 };
 
+fn try_lower_preguarded_plain_array_f64_add(
+    ctx: &mut FnCtx<'_>,
+    array_expr: &Expr,
+    other_expr: &Expr,
+    array_is_left: bool,
+) -> Result<Option<String>> {
+    if !matches!(other_expr, Expr::Integer(_) | Expr::Number(_)) {
+        return Ok(None);
+    }
+
+    let Expr::IndexGet { object, index } = array_expr else {
+        return Ok(None);
+    };
+    let (Expr::LocalGet(arr_id), Expr::LocalGet(idx_id)) = (object.as_ref(), index.as_ref()) else {
+        return Ok(None);
+    };
+    let Some(guard_ok_slot) = ctx
+        .preguarded_plain_array_index_sets
+        .get(&(*arr_id, *idx_id))
+        .and_then(|preguard| preguard.f64_numeric_range_slot.clone())
+    else {
+        return Ok(None);
+    };
+
+    let arr_box = lower_expr(ctx, object)?;
+    let idx_i32 = if let Some(i32_slot) = ctx.i32_counter_slots.get(idx_id).cloned() {
+        ctx.block().load(I32, &i32_slot)
+    } else {
+        let idx_double = lower_expr(ctx, index)?;
+        ctx.block().fptosi(DOUBLE, &idx_double, I32)
+    };
+    let other_fast = lower_expr(ctx, other_expr)?;
+
+    let fast_idx = ctx.new_block("plain_f64_add.fast");
+    let fallback_idx = ctx.new_block("plain_f64_add.fallback");
+    let merge_idx = ctx.new_block("plain_f64_add.merge");
+    let fast_label = ctx.block_label(fast_idx);
+    let fallback_label = ctx.block_label(fallback_idx);
+    let merge_label = ctx.block_label(merge_idx);
+
+    let guard_ok_i32 = ctx.block().load(I32, &guard_ok_slot);
+    let guard_ok = ctx.block().icmp_ne(I32, &guard_ok_i32, "0");
+    ctx.block().cond_br(&guard_ok, &fast_label, &fallback_label);
+
+    ctx.current_block = fallback_idx;
+    let fallback_array = lower_expr(ctx, array_expr)?;
+    let fallback_other = lower_expr(ctx, other_expr)?;
+    let (fallback_left, fallback_right) = if array_is_left {
+        (&fallback_array, &fallback_other)
+    } else {
+        (&fallback_other, &fallback_array)
+    };
+    let fallback_val = ctx.block().call(
+        DOUBLE,
+        "js_dynamic_string_or_number_add",
+        &[(DOUBLE, fallback_left), (DOUBLE, fallback_right)],
+    );
+    let fallback_end_label = ctx.block().label.clone();
+    ctx.block().br(&merge_label);
+
+    ctx.current_block = fast_idx;
+    let fast_blk = ctx.block();
+    let arr_bits = fast_blk.bitcast_double_to_i64(&arr_box);
+    let arr_handle = fast_blk.and(I64, &arr_bits, POINTER_MASK_I64);
+    let idx_i64 = fast_blk.zext(I32, &idx_i32, I64);
+    let byte_offset = fast_blk.shl(I64, &idx_i64, "3");
+    let with_header = fast_blk.add(I64, &byte_offset, "8");
+    let element_addr = fast_blk.add(I64, &arr_handle, &with_header);
+    let element_ptr = fast_blk.inttoptr(I64, &element_addr);
+    let array_fast = fast_blk.load(DOUBLE, &element_ptr);
+    let fast_val = if array_is_left {
+        fast_blk.fadd(&array_fast, &other_fast)
+    } else {
+        fast_blk.fadd(&other_fast, &array_fast)
+    };
+    let fast_end_label = fast_blk.label.clone();
+    fast_blk.br(&merge_label);
+
+    ctx.current_block = merge_idx;
+    Ok(Some(ctx.block().phi(
+        DOUBLE,
+        &[
+            (&fast_val, &fast_end_label),
+            (&fallback_val, &fallback_end_label),
+        ],
+    )))
+}
+
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {
         Expr::Binary { op, left, right } => {
@@ -125,6 +213,16 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 let r_known_non_str =
                     crate::type_analysis::is_numeric_expr(ctx, right) || is_bigint_expr(ctx, right);
                 if !(l_known_non_str && r_known_non_str) {
+                    if let Some(value) =
+                        try_lower_preguarded_plain_array_f64_add(ctx, left, right, true)?
+                    {
+                        return Ok(value);
+                    }
+                    if let Some(value) =
+                        try_lower_preguarded_plain_array_f64_add(ctx, right, left, false)?
+                    {
+                        return Ok(value);
+                    }
                     let l = lower_expr(ctx, left)?;
                     let r = lower_expr(ctx, right)?;
                     return Ok(ctx.block().call(

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1043,6 +1043,7 @@ pub(crate) struct PreguardedNumericArrayIndexSet {
 pub(crate) struct PreguardedPlainArrayIndexSet {
     pub guard_ok_slot: String,
     pub pointer_free_range_slot: Option<String>,
+    pub f64_numeric_range_slot: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -213,6 +213,11 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
         &[DOUBLE, I32, I32],
     );
     module.declare_function(
+        "js_plain_array_f64_number_range_guard",
+        I32,
+        &[DOUBLE, I32, I32],
+    );
+    module.declare_function(
         "js_typed_feedback_plain_array_index_set_guard",
         I32,
         &[I64, DOUBLE, I32, DOUBLE, I32],

--- a/crates/perry-codegen/src/stmt/loops.rs
+++ b/crates/perry-codegen/src/stmt/loops.rs
@@ -46,6 +46,7 @@ struct RangePlainArrayIndexSetPreguard {
     array_local_id: u32,
     index_local_id: u32,
     max_index: PlainArraySetMaxIndex,
+    f64_numeric_update: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -1084,9 +1085,23 @@ fn emit_range_plain_array_index_set_preguard(
     ctx.block()
         .store(I32, &pointer_free_result, &pointer_free_range_slot);
 
+    let f64_numeric_range_slot = if preguard.f64_numeric_update {
+        let numeric_result = ctx.block().call(
+            I32,
+            "js_plain_array_f64_number_range_guard",
+            &[(DOUBLE, &arr_box), (I32, &counter_i32), (I32, &max_i32)],
+        );
+        let slot = ctx.func.alloca_entry(I32);
+        ctx.block().store(I32, &numeric_result, &slot);
+        Some(slot)
+    } else {
+        None
+    };
+
     Ok(PreguardedPlainArrayIndexSet {
         guard_ok_slot,
         pointer_free_range_slot: Some(pointer_free_range_slot),
+        f64_numeric_range_slot,
     })
 }
 
@@ -1545,11 +1560,43 @@ fn classify_range_plain_array_index_set_preguard_for_bounds(
     if !expr_preserves_invariant_array_read(value, arr_id, counter_id) {
         return None;
     }
+    let f64_numeric_update = plain_array_set_value_is_self_f64_add(value, arr_id, counter_id);
     Some(RangePlainArrayIndexSetPreguard {
         array_local_id: arr_id,
         index_local_id: counter_id,
         max_index,
+        f64_numeric_update,
     })
+}
+
+fn plain_array_set_value_is_self_f64_add(
+    value: &perry_hir::Expr,
+    arr_id: u32,
+    counter_id: u32,
+) -> bool {
+    use perry_hir::{BinaryOp, Expr};
+
+    fn is_self_index_get(expr: &Expr, arr_id: u32, counter_id: u32) -> bool {
+        matches!(
+            expr,
+            Expr::IndexGet { object, index }
+                if matches!(object.as_ref(), Expr::LocalGet(candidate_arr) if *candidate_arr == arr_id)
+                    && matches!(index.as_ref(), Expr::LocalGet(candidate_idx) if *candidate_idx == counter_id)
+        )
+    }
+
+    fn is_numeric_literal(expr: &Expr) -> bool {
+        matches!(expr, Expr::Integer(_) | Expr::Number(_))
+    }
+
+    let Expr::Binary { op, left, right } = value else {
+        return false;
+    };
+    if !matches!(op, BinaryOp::Add) {
+        return false;
+    }
+    (is_self_index_get(left, arr_id, counter_id) && is_numeric_literal(right))
+        || (is_self_index_get(right, arr_id, counter_id) && is_numeric_literal(left))
 }
 
 fn classify_range_plain_array_index_set_preguard_for_condition(

--- a/crates/perry-codegen/tests/typed_feedback.rs
+++ b/crates/perry-codegen/tests/typed_feedback.rs
@@ -490,6 +490,12 @@ fn typed_feedback_preguards_plain_array_writes_with_length_bound() {
         ir.contains("call i32 @js_plain_array_inbounds_pointer_free_range_guard"),
         "{ir}"
     );
+    assert!(
+        ir.contains("call i32 @js_plain_array_f64_number_range_guard"),
+        "{ir}"
+    );
+    assert!(ir.contains("plain_f64_add.fast"), "{ir}");
+    assert!(ir.contains("plain_f64_add.fallback"), "{ir}");
     assert!(ir.contains("idxset.preguarded_plain_fast"), "{ir}");
     assert!(ir.contains("idxset.preguarded_plain_fallback"), "{ir}");
     assert!(ir.contains("idxset.preguarded_plain_layout_note"), "{ir}");
@@ -557,6 +563,12 @@ fn typed_feedback_preguards_plain_array_writes_with_local_bound() {
         ir.contains("call i32 @js_plain_array_inbounds_pointer_free_range_guard"),
         "{ir}"
     );
+    assert!(
+        ir.contains("call i32 @js_plain_array_f64_number_range_guard"),
+        "{ir}"
+    );
+    assert!(ir.contains("plain_f64_add.fast"), "{ir}");
+    assert!(ir.contains("plain_f64_add.fallback"), "{ir}");
     assert!(ir.contains("idxset.preguarded_plain_fast"), "{ir}");
     assert!(ir.contains("idxset.preguarded_plain_fallback"), "{ir}");
     assert!(ir.contains("idxset.preguarded_plain_layout_note"), "{ir}");

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -1222,6 +1222,38 @@ pub extern "C" fn js_plain_array_inbounds_pointer_free_range_guard(
     }
 }
 
+#[inline]
+fn is_plain_f64_number_slot(value_bits: u64) -> bool {
+    let tag = value_bits & TAG_MASK;
+    !(SHORT_STRING_TAG..=STRING_TAG).contains(&tag)
+}
+
+#[no_mangle]
+pub extern "C" fn js_plain_array_f64_number_range_guard(
+    receiver: f64,
+    first_index: i32,
+    last_index: i32,
+) -> i32 {
+    if first_index < 0 || last_index < first_index {
+        return 0;
+    }
+    let raw_addr = normalize_raw_object_addr(receiver.to_bits());
+    if !plain_array_index_guard(raw_addr as *const ArrayHeader, last_index as u32, true) {
+        return 0;
+    }
+
+    unsafe {
+        let arr = raw_addr as *const ArrayHeader;
+        let elements = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const u64;
+        for index in first_index as usize..=last_index as usize {
+            if !is_plain_f64_number_slot(*elements.add(index)) {
+                return 0;
+            }
+        }
+    }
+    1
+}
+
 fn numeric_array_index_guard(arr: *const ArrayHeader, index: u32, require_in_bounds: bool) -> bool {
     plain_array_index_guard(arr, index, require_in_bounds)
         && crate::array::js_array_is_numeric_f64_layout(arr) != 0

--- a/crates/perry-runtime/src/typed_feedback/tests.rs
+++ b/crates/perry-runtime/src/typed_feedback/tests.rs
@@ -148,6 +148,27 @@ fn unique_temp_dir(name: &str) -> std::path::PathBuf {
 }
 
 #[test]
+fn plain_array_f64_number_range_guard_rejects_mixed_slots() {
+    let mut arr = crate::array::js_array_alloc(0);
+    arr = crate::array::js_array_push_f64(arr, 1.0);
+    arr = crate::array::js_array_push_f64(arr, f64::NAN);
+    arr = crate::array::js_array_push_f64(arr, 3.0);
+    let receiver = crate::value::js_nanbox_pointer(arr as i64);
+
+    assert_eq!(js_plain_array_f64_number_range_guard(receiver, 0, 2), 1);
+    assert_eq!(js_plain_array_f64_number_range_guard(receiver, -1, 2), 0);
+    assert_eq!(js_plain_array_f64_number_range_guard(receiver, 2, 1), 0);
+    assert_eq!(js_plain_array_f64_number_range_guard(receiver, 0, 3), 0);
+
+    let str_ptr = crate::string::js_string_from_bytes(b"mixed".as_ptr(), 5);
+    let str_value = f64::from_bits(crate::value::JSValue::string_ptr(str_ptr).bits());
+    crate::array::js_array_set_f64(arr, 1, str_value);
+
+    assert_eq!(js_plain_array_f64_number_range_guard(receiver, 0, 2), 0);
+    assert_eq!(js_plain_array_f64_number_range_guard(receiver, 0, 0), 1);
+}
+
+#[test]
 fn typed_feedback_registers_source_attribution() {
     let _guard = TYPED_FEEDBACK_TEST_LOCK.lock().unwrap();
     reset_typed_feedback_for_tests();


### PR DESCRIPTION
## Summary

Optimizes downgraded plain-array numeric self-updates such as `arr[i] = arr[i] + 1` when the existing plain-array write preguard can prove the loop range. The prebody now optionally verifies that every slot in the covered range is a raw f64 number; when that holds, codegen lowers the array read side of the addition to a direct slot load plus `fadd`, while retaining the existing dynamic `+` fallback for mixed ranges.

## Performance

Target: `benchmarks/suite/bench_numeric_array_downgrade.ts`

Interleaved 12-run comparison against the cycle 24 pre-change binary:

- Before: avg 312.7 ms, median 319.0 ms, checksum 6500875
- After: avg 116.2 ms, median 122.0 ms, checksum 6500875

Adjacent regression check: `bench_numeric_array_numeric.ts`

- Alternating 12-run check: before avg 99.5 ms / median 99.0 ms, after avg 99.6 ms / median 99.0 ms, checksum 6500625

## IR evidence

Trace compile for `bench_numeric_array_downgrade.ts` with `PERRY_VERIFY_NATIVE_REGIONS=1 --trace llvm --verify-native-regions` shows:

- two `js_plain_array_f64_number_range_guard` calls in the prebody
- `plain_f64_add.fast` / `plain_f64_add.fallback` blocks around the hot updates
- dynamic `js_dynamic_string_or_number_add` retained only on fallback/checksum paths for this benchmark

## Validation

- `git diff --check`
- `cargo fmt --check`
- `cargo test -p perry-codegen typed_feedback_preguards_plain_array_writes -- --nocapture`
- `cargo test -p perry-runtime plain_array_f64_number_range_guard_rejects_mixed_slots -- --nocapture`
- `cargo build --release -p perry`
- `target/release/perry compile benchmarks/suite/bench_numeric_array_downgrade.ts --trace llvm --verify-native-regions -o /tmp/perry-cycle24-numeric-downgrade-final`
- `target/release/perry compile benchmarks/suite/bench_numeric_array_numeric.ts -o /tmp/perry-cycle24-numeric-array-numeric-final`
