### PR TITLE
fix(hir,codegen): route class-extends userland stream-shim ctor through its real constructor (winston)

### DIFF
--- a/crates/perry-codegen/src/expr/this_super_call.rs
+++ b/crates/perry-codegen/src/expr/this_super_call.rs
@@ -245,29 +245,47 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     // semantics (Error sets this.message + this.name; streams allocate
                     // a registry handle). Anything else with an extends_expr is a
                     // real runtime-value parent and routes through this dispatch.
-                    let is_builtin_parent_name =
-                        matches!(
-                            parent_name.as_str(),
-                            "Error"
-                                | "TypeError"
-                                | "RangeError"
-                                | "ReferenceError"
-                                | "SyntaxError"
-                                | "URIError"
-                                | "EvalError"
-                                | "AggregateError"
-                                | "Readable"
-                                | "Writable"
-                                | "Duplex"
-                                | "Transform"
-                                | "ReadableStream"
-                                | "WritableStream"
-                                | "TransformStream"
-                                | "Request"
-                                | "Response"
-                                | "Event"
-                                | "CustomEvent"
-                        ) || is_other_builtin_constructor_name(parent_name.as_str());
+                    // The classic node:stream / Web-Streams names are only the
+                    // genuine built-in parents when HIR did NOT capture an
+                    // `extends_expr`. When it did, the parent is a userland
+                    // stream-shim value (e.g. readable-stream's `Transform`,
+                    // winston's `class Logger extends Transform`) whose real
+                    // constructor — which sets `this._readableState`,
+                    // `this._writableState`, `this._transformState` — must run.
+                    // HIR's `is_genuine_node_stream_parent` gate only leaves
+                    // `extends_expr` set for the non-builtin case (the genuine
+                    // node:stream import keeps `native_extends` + no
+                    // `extends_expr`), so deferring to the dynamic dispatch here
+                    // whenever an `extends_expr` exists is safe.
+                    let has_extends_expr = current_class.extends_expr.is_some();
+                    let is_stream_family_name = matches!(
+                        parent_name.as_str(),
+                        "Readable"
+                            | "Writable"
+                            | "Duplex"
+                            | "Transform"
+                            | "ReadableStream"
+                            | "WritableStream"
+                            | "TransformStream"
+                    );
+                    let is_builtin_parent_name = (matches!(
+                        parent_name.as_str(),
+                        "Error"
+                            | "TypeError"
+                            | "RangeError"
+                            | "ReferenceError"
+                            | "SyntaxError"
+                            | "URIError"
+                            | "EvalError"
+                            | "AggregateError"
+                            | "Request"
+                            | "Response"
+                            | "Event"
+                            | "CustomEvent"
+                    ) || (is_stream_family_name
+                        && !has_extends_expr)
+                        || is_other_builtin_constructor_name(parent_name.as_str()))
+                        && !(is_stream_family_name && has_extends_expr);
                     if !is_builtin_parent_name {
                         if let Some(extends_expr) = current_class.extends_expr.as_deref() {
                             // Lower the super-call args first so they get fresh slots

--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -11,6 +11,39 @@ use crate::lower::{
 use crate::lower_patterns::*;
 use crate::lower_types::*;
 
+/// The four classic node:stream base-class names (`Readable`/`Writable`/
+/// `Duplex`/`Transform`). When a class extends a parent with one of these
+/// textual names, perry routes `super()` to the native `js_node_stream_*`
+/// shim (which installs the native stream surface but never sets the
+/// `_readableState`/`_writableState`/`_transformState` objects). That is only
+/// correct when the name actually resolves to the `node:stream` builtin —
+/// i.e. it was imported from `stream`/`node:stream`, in which case the import
+/// machinery registered it as the `stream` native module
+/// (`register_native_module(binding, "stream", Some(name))`, see
+/// `var_decl_sources::register_destructured_stream_ctors` and the import
+/// arms in `lower/module_decl.rs`).
+///
+/// The same textual name can instead be a userland binding from a
+/// stream-shim npm package — `const { Transform } =
+/// require('readable-stream')` in winston's `logger.js`, where
+/// `class Logger extends Transform` then reads `this._readableState.pipes`
+/// directly. Such a binding never registers as the `stream` native module
+/// (readable-stream is not a node builtin), so the package's real constructor
+/// must run instead. Returning `false` here lets the unknown-Ident arm
+/// capture the parent as `extends_expr` and route `super()` through the
+/// dynamic-parent path (`js_register_class_parent_dynamic` + the
+/// `js_fetch_or_value_super` dispatch), which runs the real `Transform`
+/// function body on the subclass instance.
+fn is_genuine_node_stream_parent(ctx: &LoweringContext, name: &str) -> bool {
+    if !matches!(name, "Readable" | "Writable" | "Duplex" | "Transform") {
+        return false;
+    }
+    // Only the genuine `node:stream` builtin import registers these names as
+    // the `stream` native module. Anything else (a userland require/import of
+    // a stream-shim package, or an unbound reference) is not the builtin.
+    matches!(ctx.lookup_native_module(name), Some(("stream", _)))
+}
+
 use super::*;
 
 fn generic_computed_member_key<'a>(
@@ -361,10 +394,16 @@ pub fn lower_class_decl(
                 // native stream methods directly onto `this`, were already
                 // built; this is the missing HIR wiring. Keep in lockstep
                 // with the parallel arm in `lower_class_from_ast` below.
-                "Readable" => Some(("node_stream".to_string(), "Readable".to_string())),
-                "Writable" => Some(("node_stream".to_string(), "Writable".to_string())),
-                "Duplex" => Some(("node_stream".to_string(), "Duplex".to_string())),
-                "Transform" => Some(("node_stream".to_string(), "Transform".to_string())),
+                //
+                // Gate the classic node:stream names on `is_genuine_node_stream_parent`
+                // so a userland stream-shim binding (readable-stream's
+                // `Transform`, winston) falls through to the dynamic
+                // `extends_expr` parent path and runs its real constructor.
+                "Readable" | "Writable" | "Duplex" | "Transform"
+                    if is_genuine_node_stream_parent(ctx, &parent_name) =>
+                {
+                    Some(("node_stream".to_string(), parent_name.clone()))
+                }
                 _ => None,
             };
             if native_parent.is_some() {
@@ -1329,11 +1368,15 @@ pub fn lower_class_from_ast(
                     "TransformStream".to_string(),
                 )),
                 // #1545: classic node:stream base classes — keep in lockstep
-                // with the parallel arm in `lower_class_decl` above.
-                "Readable" => Some(("node_stream".to_string(), "Readable".to_string())),
-                "Writable" => Some(("node_stream".to_string(), "Writable".to_string())),
-                "Duplex" => Some(("node_stream".to_string(), "Duplex".to_string())),
-                "Transform" => Some(("node_stream".to_string(), "Transform".to_string())),
+                // with the parallel arm in `lower_class_decl` above. Gated on
+                // `is_genuine_node_stream_parent` so a userland stream-shim
+                // binding (readable-stream's `Transform`) falls through to the
+                // dynamic `extends_expr` parent path.
+                "Readable" | "Writable" | "Duplex" | "Transform"
+                    if is_genuine_node_stream_parent(ctx, &parent_name) =>
+                {
+                    Some(("node_stream".to_string(), parent_name.clone()))
+                }
                 _ => None,
             };
             if native_parent.is_some() {

--- a/test-files/test_gap_class_extends_userland_stream_shim.ts
+++ b/test-files/test_gap_class_extends_userland_stream_shim.ts
@@ -1,0 +1,79 @@
+// winston native-compile wall (branch fix/winston-stream-subclass-state):
+// `class Logger extends Transform` where `Transform` is NOT node:stream's
+// builtin but a userland stream-shim's ES5 function constructor
+// (`const { Transform } = require('readable-stream')`). readable-stream's
+// hierarchy is `Transform -> Duplex -> Readable` wired via ES5
+// `inherits()` (Object.create on the prototype), and the Readable ctor sets
+// `this._readableState = new ReadableState(...)`. winston's logger.js then
+// reads `const { pipes } = this._readableState`.
+//
+// Before the fix, perry routed `super()` for ANY parent textually named
+// `Transform`/`Readable`/`Writable`/`Duplex` to the native node:stream shim
+// (which never sets `_readableState`), so `this._readableState` was
+// `undefined` and the destructure threw
+// "Cannot convert undefined or null to object". The fix gates the native
+// routing on `is_genuine_node_stream_parent` (the name must resolve to the
+// `stream` native module) so a userland binding falls through to the
+// dynamic `extends_expr` parent path, which runs the real constructor chain.
+
+function inherits(ctor: any, superCtor: any) {
+  ctor.super_ = superCtor;
+  ctor.prototype = Object.create(superCtor.prototype, {
+    constructor: {
+      value: ctor,
+      enumerable: false,
+      writable: true,
+      configurable: true,
+    },
+  });
+}
+
+// Base of the chain: sets the state objects the userland code reads.
+function Readable(this: any, options: any) {
+  this._readableState = { pipes: [], objectMode: !!(options && options.objectMode) };
+  this.readable = true;
+}
+
+function Writable(this: any, options: any) {
+  this._writableState = { finished: false };
+  this.writable = true;
+}
+
+function Duplex(this: any, options: any) {
+  Readable.call(this, options);
+  Writable.call(this, options);
+  this.allowHalfOpen = true;
+}
+inherits(Duplex, Readable);
+
+function Transform(this: any, options: any) {
+  Duplex.call(this, options);
+  this._transformState = { transforming: false };
+  // Mirror readable-stream: read the state set by the Readable ctor.
+  this._readableState.needReadable = true;
+}
+inherits(Transform, Duplex);
+
+// User ES6 class extending the userland ES5 `Transform`.
+class Logger extends Transform {
+  configured: boolean;
+  constructor(options: any) {
+    super({ objectMode: true });
+    this.configured = true;
+  }
+  // Mirror winston logger.js line 695: read this._readableState directly.
+  pipeCount(): number {
+    const { pipes } = (this as any)._readableState;
+    return pipes.length;
+  }
+}
+
+const l: any = new Logger({});
+console.log("readableState defined:", l._readableState !== undefined);
+console.log("readableState.objectMode:", l._readableState.objectMode);
+console.log("readableState.needReadable:", l._readableState.needReadable);
+console.log("writableState defined:", l._writableState !== undefined);
+console.log("transformState defined:", l._transformState !== undefined);
+console.log("allowHalfOpen:", l.allowHalfOpen);
+console.log("configured:", l.configured);
+console.log("pipeCount:", l.pipeCount());


### PR DESCRIPTION
## Problem

Native-compiling **winston** (corpus `compilePackages:[\"*\"]`) threw
`TypeError: Cannot convert undefined or null to object` at
`winston/lib/winston/logger.js:695` — `const { pipes } = this._readableState`
where `this._readableState` was `undefined`.

winston's `Logger` is `class Logger extends Transform`, and `Transform` comes
from the **`readable-stream`** npm package
(`const { Stream, Transform } = require('readable-stream')`), NOT `node:stream`.
readable-stream's hierarchy is `Transform → Duplex → Readable` wired with ES5
`require('inherits')(...)`; the `Readable` constructor sets
`this._readableState = new ReadableState(...)`.

## Root cause

The native-parent match in `lower_class_decl` / `lower_class_from_ast`
(`perry-hir/src/lower_decl/class_decl.rs`) treated **any** parent literally
named `Readable`/`Writable`/`Duplex`/`Transform` as the `node:stream` builtin,
purely on the textual name. So winston's `class Logger extends Transform` was
routed to the native `js_node_stream_transform_subclass_init` shim, which
installs the native stream method surface but **never sets** `_readableState`
/`_writableState`/`_transformState`. readable-stream's own code then reads
`this._readableState.pipes` and crashes.

A genuine `node:stream` import registers the name as the `stream` native
module (`register_native_module(binding, \"stream\", Some(name))`); a
readable-stream binding never does (it isn't a node builtin), so the two are
distinguishable.

## Fix

- **HIR**: new `is_genuine_node_stream_parent()` gate — the four classic
  stream names map to the native `node_stream` parent **only** when
  `lookup_native_module(name)` resolves to the `stream` module. Otherwise the
  class falls through to the dynamic `extends_expr` parent path
  (`js_register_class_parent_dynamic` + `js_fetch_or_value_super`), which runs
  the package's real constructor chain on the subclass instance.
- **Codegen** (`this_super_call.rs`): the stream-family names are only treated
  as built-in parents for `super()` routing when HIR captured **no**
  `extends_expr`; when one was captured (the userland case) defer to the
  dynamic dispatch so the real `Transform` body runs.

## Validation

- `cargo fmt --check` clean; `check_file_size.sh`, `gc_store_site_inventory.py`,
  `addr_class_inventory.py` all pass; `perry-hir` tests green.
- Genuine `node:stream` subclass path unchanged
  (`test_read_undefined_proto_getter_promise_ctor.ts` matches node).
- New regression fixture `test_gap_class_extends_userland_stream_shim.ts`
  (ES5 `inherits`-built `Transform → Duplex → Readable`, ES6 `class extends
  Transform`) matches node byte-for-byte.
- **Full corpus 57/59 — no regressions** (`ws` and other stream-using packages
  still green; the other failure, `semver`, is pre-existing and unrelated).

## winston before / after & next wall

- **Before**: `TypeError: Cannot convert undefined or null to object` at
  `logger.js:695` (`this._readableState` undefined).
- **After**: that throw is **gone**. winston now reaches a deeper,
  **distinct** cross-module wall:
  `TypeError: Cannot set properties of null or undefined (setting 'needReadable')`
  at `readable-stream/lib/_stream_transform.js:97`.

  Investigation of the new wall (probed at runtime): two interacting
  cross-module issues remain, both outside the scope of this stream-routing fix:
  1. **Destructured re-export binds the wrong value** — readable-stream's
     `index` does `module.exports = require('./_stream_readable.js'); exports.Transform = require('./_stream_transform.js')`.
     winston's `const { Transform } = require('readable-stream')` resolves
     Logger's dynamic parent to the **Readable** function value, not Transform
     (confirmed: Logger's `register_parent_dynamic` parent bits == Readable's).
  2. **`util.inherits` reached indirectly** (`require('inherits')(...)` /
     `var inherits = require('util').inherits; inherits(...)`) does not always
     lower to the native `js_util_inherits`, so the synthetic-class parent chain
     `Transform → Duplex → Readable` isn't fully registered and the
     `if (!(this instanceof Readable))` guard re-news a throwaway object.

  Minimal multi-module repros of both were built and confirm the behavior. A
  speculative runtime mint of the synthetic parent id was prototyped and
  **reverted** (it did not clear winston and added unvalidated behavioral
  surface).

## Notes

Per CONTRIBUTING / CLAUDE.md, this PR does not bump `Cargo.toml` version, the
`Current Version` line, `CHANGELOG.md`, or `Cargo.lock` — the maintainer folds
those in at merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed class inheritance handling for userland stream-like implementations. Classes extending custom stream classes (instead of native Node.js streams) now compile correctly.
  * Added distinction between native Node.js stream constructors and userland stream-shim bindings to resolve edge cases in prototype inheritance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->