### PR TITLE
fix(runtime): reject Symbol argArray in Function.prototype.apply (#5347)

### DIFF
--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -4714,15 +4714,24 @@ pub unsafe extern "C" fn js_native_call_method(
                 // synthetic `arguments` array local) — top 16 bits zero.
                 let args_arr_bits = args_arr_val.to_bits();
                 let arr_raw: usize = if args_arr_jsval.is_pointer() {
-                    (args_arr_bits & 0x0000_FFFF_FFFF_FFFF) as usize
+                    // A Symbol is POINTER_TAG'd but is a primitive, not an
+                    // Object — Type(argArray) is not Object, so reject it
+                    // below rather than treating its payload as an array
+                    // pointer (test262 apply/argarray-not-object `Symbol()`).
+                    if crate::symbol::js_is_symbol(args_arr_val) != 0 {
+                        0
+                    } else {
+                        (args_arr_bits & 0x0000_FFFF_FFFF_FFFF) as usize
+                    }
                 } else if (args_arr_bits >> 48) == 0 && args_arr_bits >= 0x1000 {
                     args_arr_bits as usize
                 } else {
                     0
                 };
                 // Spec CreateListFromArrayLike: a non-nullish, non-object
-                // argArray (`fn.apply(null, true)` / `NaN` / `'1,2,3'`) is a
-                // TypeError. null/undefined mean "no arguments".
+                // argArray (`fn.apply(null, true)` / `NaN` / `'1,2,3'` /
+                // `Symbol()`) is a TypeError. null/undefined mean "no
+                // arguments".
                 if arr_raw == 0 && !args_arr_jsval.is_undefined() && !args_arr_jsval.is_null() {
                     throw_type_error_message(b"CreateListFromArrayLike called on non-object");
                 }

--- a/test-parity/node-suite/globals/function-apply-argarray-not-object.ts
+++ b/test-parity/node-suite/globals/function-apply-argarray-not-object.ts
@@ -1,0 +1,33 @@
+// Function.prototype.apply(thisArg, argArray): per CreateListFromArrayLike,
+// a non-nullish argArray whose Type is not Object is a TypeError. null and
+// undefined mean "no arguments" and call through cleanly. Primitives —
+// including a Symbol, which is heap-backed but still a primitive — must throw.
+// test262: built-ins/Function/prototype/apply/argarray-not-object.js
+function fn(...args: unknown[]): number {
+  return args.length;
+}
+
+function probe(label: string, run: () => unknown): void {
+  try {
+    const result = run();
+    console.log(label, "ok", typeof result, String(result));
+  } catch (e: unknown) {
+    const ctor = e && (e as { constructor?: { name?: string } }).constructor;
+    console.log(label, "threw", ctor ? ctor.name : typeof e);
+  }
+}
+
+// Nullish argArray → no arguments, runs clean.
+probe("null", () => fn.apply(null, null));
+probe("undefined", () => fn.apply(null, undefined));
+
+// Non-object primitives → TypeError.
+probe("boolean", () => fn.apply(null, true as never));
+probe("number", () => fn.apply(null, NaN as never));
+probe("string", () => fn.apply(null, "1,2,3" as never));
+probe("symbol", () => fn.apply(null, Symbol() as never));
+probe("bigint", () => fn.apply(null, 10n as never));
+
+// Real array-likes still spread correctly.
+probe("array", () => fn.apply(null, [1, 2, 3]));
+probe("arraylike", () => fn.apply(null, { length: 2, 0: "a", 1: "b" } as never));


### PR DESCRIPTION
## Summary

Part of the test262 built-ins umbrella (#5347), `built-ins/Function` cluster.

`Function.prototype.apply(thisArg, argArray)` runs `CreateListFromArrayLike` on `argArray`, which throws a `TypeError` when `Type(argArray)` is not Object. The direct-closure `apply` arm in `native_call_method.rs` rejected boolean/number/string/BigInt argArrays — they fail the `is_pointer()` probe — but let a **Symbol** through: a Symbol is `POINTER_TAG`'d, so `is_pointer()` returned `true` and its payload was read as an array pointer, silently producing an empty arg list instead of throwing.

Symbols are primitives, not Objects, so the fix adds a `js_is_symbol` check inside the pointer branch and falls through to the existing non-object `TypeError`. The proxy/`Reflect` path already handled this correctly via `reflect_value_is_object`; this brings the direct-closure path in line.

## Result

- Fixes test262 `built-ins/Function/prototype/apply/argarray-not-object.js`.
- `built-ins/Function` subset: **402 → 403 pass**, runtime-fail 55 → 54, **zero regressions** (only that one case flips; failure-set diff confirms nothing new fails).
- `fn.apply(null, Symbol())` now throws `TypeError`, matching Node; `true`/`NaN`/`'1,2,3'`/`10n` already threw; `null`/`undefined`/arrays/array-likes unchanged.

## Test

Adds parity fixture `test-parity/node-suite/globals/function-apply-argarray-not-object.ts`, verified byte-for-byte identical to `node --experimental-strip-types`.

Per maintainer convention, no version bump / CHANGELOG entry — left for merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `Function.prototype.apply` to properly reject symbols as the arguments array parameter, now correctly throwing a TypeError instead of misinterpreting the value.

* **Tests**
  * Added comprehensive test coverage for `Function.prototype.apply` with various argument types, including null, undefined, primitives, and array-like objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->