### PR TITLE
codegen: derived-ctor this-TDZ on standalone constructor-symbol path (toward #5345)

### DIFF
--- a/crates/perry-codegen/src/codegen/method.rs
+++ b/crates/perry-codegen/src/codegen/method.rs
@@ -490,7 +490,33 @@ pub(super) fn compile_method(
         }
     }
 
-    if method.is_async {
+    // ECMAScript TDZ-on-`this`: a DERIVED constructor whose body never calls
+    // `super()` leaves `this` uninitialized, so the implicit `return this`
+    // throws ReferenceError. The inline `new` path enforces this in
+    // `lower_new`; mirror it here for the standalone constructor-symbol path
+    // — the DEFAULT when `force_ctor_call` routes `new C(...)` through the
+    // shared `<class>_constructor` symbol instead of inlining. Without this,
+    // `class A extends Array { constructor() {} }; new A()` constructs
+    // silently instead of throwing. The predicate combination matches the
+    // inline path verbatim (closure-`super()` without a direct `this` use
+    // suppresses; a value-bearing `return` takes the return-override path).
+    // Refs class/subclass/builtin-objects/*/super-must-be-called.
+    let ctor_no_super_throw = is_constructor_method
+        && (class.extends.is_some()
+            || class.extends_name.is_some()
+            || class.native_extends.is_some()
+            || class.extends_expr.is_some())
+        && class.constructor.as_ref().is_some_and(|ctor| {
+            !crate::lower_call::ctor_body_calls_super(&ctor.body)
+                && !(crate::lower_call::ctor_body_closure_calls_super(&ctor.body)
+                    && !crate::lower_call::ctor_body_uses_this(&ctor.body))
+                && !crate::lower_call::ctor_body_has_value_return(&ctor.body)
+        });
+    if ctor_no_super_throw {
+        ctx.block()
+            .call(DOUBLE, "js_throw_reference_error_this_before_super", &[]);
+        ctx.block().unreachable();
+    } else if method.is_async {
         stmt::lower_async_rejecting_stmts(&mut ctx, &method.body).with_context(|| {
             format!(
                 "lowering async body of method '{}::{}'",

--- a/crates/perry-codegen/src/lower_call/mod.rs
+++ b/crates/perry-codegen/src/lower_call/mod.rs
@@ -103,6 +103,15 @@ pub(crate) use native::lower_native_method_call;
 // etc. keep resolving after the split.
 pub(crate) use field_init::{apply_field_initializers_recursive, FieldInitMode};
 pub(crate) use new::{bind_inline_constructor_params, lower_new, restore_inline_constructor_scope};
+// The derived-ctor no-super static-throw predicates (shared with the
+// standalone-ctor-symbol path in `codegen/method.rs`, which is the default
+// `new` lowering when `force_ctor_call` redirects construction to the shared
+// symbol instead of inlining). Refs class/subclass/builtin-objects/*/
+// super-must-be-called.
+pub(crate) use new_helpers::{
+    ctor_body_calls_super, ctor_body_closure_calls_super, ctor_body_has_value_return,
+    ctor_body_uses_this,
+};
 // `extract_options_fields` is consumed by `expr.rs` as
 // `crate::lower_call::extract_options_fields` — keep that path stable.
 pub(crate) use options::extract_options_fields;

--- a/crates/perry-codegen/src/lower_call/new_helpers.rs
+++ b/crates/perry-codegen/src/lower_call/new_helpers.rs
@@ -100,7 +100,7 @@ const NO_STMT_PRED: &dyn Fn(&perry_hir::Stmt) -> bool = &|_| false;
 /// uninitialized — ECMAScript then throws ReferenceError at the implicit
 /// `return this`. We detect the static no-super case at compile time so
 /// `new Sub()` throws instead of returning a half-built object.
-pub(super) fn ctor_body_calls_super(body: &[perry_hir::Stmt]) -> bool {
+pub(crate) fn ctor_body_calls_super(body: &[perry_hir::Stmt]) -> bool {
     ctor_body_any(body, &expr_calls_super, NO_STMT_PRED)
 }
 
@@ -123,7 +123,7 @@ fn expr_calls_super(expr: &Expr) -> bool {
 /// for-of is still iterating), so the static no-super throw must not fire —
 /// unless the body also dereferences `this` directly (see the call site).
 /// Refs class/subclass/derived-class-return-override-{for-of,finally-super}-arrow.
-pub(super) fn ctor_body_closure_calls_super(body: &[perry_hir::Stmt]) -> bool {
+pub(crate) fn ctor_body_closure_calls_super(body: &[perry_hir::Stmt]) -> bool {
     ctor_body_any(body, &expr_calls_super_incl_closures, NO_STMT_PRED)
 }
 
@@ -148,7 +148,7 @@ fn expr_calls_super_incl_closures(expr: &Expr) -> bool {
 /// a no-direct-super derived ctor throws ReferenceError per spec before any
 /// closure could run `super()`, so the static entry throw stays correct
 /// (test262 class/elements/privatefieldset-evaluation-order-1).
-pub(super) fn ctor_body_uses_this(body: &[perry_hir::Stmt]) -> bool {
+pub(crate) fn ctor_body_uses_this(body: &[perry_hir::Stmt]) -> bool {
     ctor_body_any(body, &expr_uses_this_direct, NO_STMT_PRED)
 }
 
@@ -177,7 +177,7 @@ fn expr_uses_this_direct(expr: &Expr) -> bool {
 /// returned value at runtime. Refs
 /// class/subclass/class-definition-null-proto-contains-return-override and
 /// class/subclass/builtin-objects/Object/constructor-return-undefined-throws.
-pub(super) fn ctor_body_has_value_return(body: &[perry_hir::Stmt]) -> bool {
+pub(crate) fn ctor_body_has_value_return(body: &[perry_hir::Stmt]) -> bool {
     ctor_body_any(
         body,
         &|_| false,


### PR DESCRIPTION
## What

A derived class constructor that never calls `super()` leaves `this` uninitialized, so the implicit `return this` (spec `GetThisBinding`) must throw a **ReferenceError**. Perry's inline `new` path (`lower_new`) already enforces this, but the **default** construction path routes `new C(...)` through the shared `<class>_constructor` symbol (`force_ctor_call`), which lacked the check. As a result:

```ts
class A extends Array { constructor() {} }
new A();   // should throw ReferenceError — Perry constructed silently
```

This mirrors the inline path's guard in `compile_method`'s standalone constructor-symbol emission, reusing the **exact same predicate combination** already battle-tested on the inline path:

- `ctor_body_calls_super` — a direct `super()` suppresses the throw
- `ctor_body_closure_calls_super` + `ctor_body_uses_this` — a closure-captured `super()` suppresses, *unless* the body also dereferences `this` directly
- `ctor_body_has_value_return` — a value-bearing `return` takes the return-override path instead

The four predicates were `pub(super)` in `lower_call::new_helpers`; they're promoted to `pub(crate)` and re-exported so `codegen/method.rs` can share them (no logic duplication).

## Results

Full `test262 language/{statements,expressions}/class` sweep (8426 cases, differential vs `node --experimental-strip-types`):

| | pass | runtime-fail | parity |
|---|---|---|---|
| before | 5046 | 252 | 94.0% |
| after | **5070** | **228** | **94.4%** |

**+24 cases fixed, 0 regressions.** Confirmed by diffing the failing-test sets before/after (not just counts), and by `perry-codegen` unit tests (16 passed).

Fixes:
- `subclass/builtin-objects/*/super-must-be-called` (Array, ArrayBuffer, Boolean, DataView, Date, Error, Function, Map, NativeError/{Eval,Range,Reference,Syntax,Type,URI}Error, Number, Promise, RegExp, Set, String, WeakMap, WeakSet)
- `subclass/builtin-objects/Object/constructor-return-undefined-throws`
- `subclass/class-definition-null-proto-this`

A spot-check of valid super-calling shapes (conditional super, super in `try`, super after statements, no-own-ctor forwarding, multi-level subclass, return-override) constructs correctly and matches Node — no false-positive throws.

This is a contained slice of the larger #5345 class tail; it does not close the tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced ECMAScript compliance for derived constructors. The compiler now enforces the "this-before-super" rule by detecting derived constructors that never call `super()` and emitting appropriate reference errors to prevent undefined behavior during runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->