### PR TITLE
[codex] Fast-path default JSON stringify full calls

### DIFF
--- a/crates/perry-runtime/src/json/mod.rs
+++ b/crates/perry-runtime/src/json/mod.rs
@@ -604,6 +604,28 @@ mod tests {
     }
 
     #[test]
+    fn stringify_full_without_replacer_matches_simple_path() {
+        let input = br#"{"a":1,"b":"x"}"#;
+        let text = js_string_from_bytes(input.as_ptr(), input.len() as u32);
+        let value = unsafe { js_json_parse(text) };
+        let boxed = f64::from_bits(value.bits());
+        let null = f64::from_bits(TAG_NULL);
+
+        let simple = unsafe { js_json_stringify(boxed, TYPE_UNKNOWN) };
+        let full_bits = unsafe { js_json_stringify_full(boxed, null, null) as u64 };
+        let full_ptr = (full_bits & POINTER_MASK) as *const StringHeader;
+        let simple_str = unsafe { str_from_header(simple).unwrap() };
+        let full_str = unsafe { str_from_header(full_ptr).unwrap() };
+
+        assert_eq!(full_str, simple_str);
+        assert_eq!(full_str, r#"{"a":1,"b":"x"}"#);
+        assert_eq!(
+            unsafe { js_json_stringify_full(f64::from_bits(TAG_UNDEFINED), null, null) as u64 },
+            TAG_UNDEFINED
+        );
+    }
+
+    #[test]
     fn typed_parse_layout_only_object_field_writes_preserve_layout() {
         let input = br#"[{"id":1,"name":"item_1","nested":{"x":1,"y":2}},{"id":2,"name":"item_2","nested":{"x":2,"y":4}}]"#;
         let packed_keys = b"id\0name\0nested\0";

--- a/crates/perry-runtime/src/json/replacer.rs
+++ b/crates/perry-runtime/src/json/replacer.rs
@@ -868,6 +868,8 @@ pub unsafe extern "C" fn js_json_stringify_full(
         if let Some(ptr) = try_stringify_lazy_array(value) {
             return JSValue::string_ptr(ptr).bits() as i64;
         }
+        let ptr = js_json_stringify(value, TYPE_UNKNOWN);
+        return JSValue::string_ptr(ptr).bits() as i64;
     }
     // Lazy-but-materialized: the fast path's `materialized.is_null()`
     // check above returns None; fall back to the tree walk, but


### PR DESCRIPTION
## Summary

- selected `bench_json_roundtrip` after the full suite showed it as the highest remaining non-skipped hotspot behind recursive Fibonacci
- keeps the HIR/codegen call shape unchanged, but makes the no-replacer/no-spacer `js_json_stringify_full` runtime path delegate to the simple stringifier after preserving top-level `undefined` and function-root behavior
- leaves replacer and pretty-print paths on the existing full implementation
- adds a runtime regression test proving the full default call matches the simple path while preserving `undefined`

## Performance evidence

Pre-change full suite (`benchmarks/compare.sh --full --runs 3 --warn-only`):

- `bench_json_roundtrip`: 136 ms, 386196 KB RSS

Post-change full suite:

- `bench_json_roundtrip`: 64 ms, 390152 KB RSS

Paired benchmark runs for `bench_json_roundtrip`:

- before: avg 78.9 ms, median 66 ms
- after: avg 65.1 ms, median 61 ms
- checksum `53735550` matched across all 40 executions

The full-suite harness reported Node unavailable, so suite-level JS correctness comparison was unchecked; the Perry runtime output checksums matched in the direct paired runs.

## Validation

- `git diff --check`
- `cargo fmt --check`
- `cargo test -p perry-runtime stringify_full_without_replacer_matches_simple_path -- --nocapture`
- `cargo build --release -p perry`
- `target/release/perry compile benchmarks/suite/bench_json_roundtrip.ts --trace llvm --verify-native-regions -o /tmp/perry-cycle27-json-final`
- pre/post full-suite benchmark runs and 20 paired direct benchmark runs

Additional note: a broader `cargo test -p perry-runtime json -- --nocapture` run had 42 filtered JSON-related tests pass and one existing GC helper-store test fail; rerunning that helper-store test alone failed the same way, so it was not introduced by this JSON stringify change.
