### PR TITLE
fix(hir): hoist module-level destructuring require into module scope (semver native-compile)

### DIFF
--- a/crates/perry-hir/src/destructuring/pattern_binding.rs
+++ b/crates/perry-hir/src/destructuring/pattern_binding.rs
@@ -355,6 +355,23 @@ pub(crate) fn lower_pattern_binding_into(
                     }
                     pre_id
                 }
+                None if ctx.scope_depth == 0
+                    && ctx.inside_block_scope == 0
+                    && ctx.pre_registered_module_vars.remove(&name) =>
+                {
+                    // #5358: reuse the slot pre-registered by the module-level
+                    // forward-declaration pass for a destructured leaf
+                    // (`const { src, t } = require(...)` at the bottom of a
+                    // file). An earlier class/function body already resolved
+                    // `src`/`t` to this id; allocating a fresh one here would
+                    // strand that reference on an undefined slot.
+                    ctx.pre_registered_module_var_decls.remove(&name);
+                    let id = ctx.lookup_local(&name).unwrap();
+                    if let Some(existing_ty) = ctx.locals.lookup_type_mut(&name) {
+                        *existing_ty = ty.clone();
+                    }
+                    id
+                }
                 None => ctx.define_local(name.clone(), ty.clone()),
             };
             if !mutable {
@@ -547,6 +564,27 @@ pub(crate) fn lower_pattern_binding_into(
                                     *ety = ty.clone();
                                 }
                                 pre_id
+                            }
+                            None if ctx.scope_depth == 0
+                                && ctx.inside_block_scope == 0
+                                && ctx.pre_registered_module_vars.remove(&name) =>
+                            {
+                                // #5358: reuse the module-level slot pre-
+                                // registered for a `{ key }` shorthand leaf of a
+                                // bottom-of-file destructuring require (`const {
+                                // src, t } = require('./re.js')` — the canonical
+                                // cyclic-dep CJS shape used by semver's
+                                // classes/comparator.js). An earlier class/
+                                // function body already resolved `src`/`t` to
+                                // this id; allocating a fresh one here would
+                                // strand that read on an undefined slot and the
+                                // destructure's write would land elsewhere.
+                                ctx.pre_registered_module_var_decls.remove(&name);
+                                let id = ctx.lookup_local(&name).unwrap();
+                                if let Some(existing_ty) = ctx.locals.lookup_type_mut(&name) {
+                                    *existing_ty = ty.clone();
+                                }
+                                id
                             }
                             None => ctx.define_local(name.clone(), ty.clone()),
                         };

--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -557,6 +557,28 @@ pub fn lower_module_full(
                                 .insert(ident.id.sym.to_string());
                         }
                     }
+                } else if matches!(&decl.name, ast::Pat::Object(_) | ast::Pat::Array(_)) {
+                    // #5358: a module-level DESTRUCTURING binding
+                    // (`const { src, t } = require('./re.js')`) declared after
+                    // code that references those names — the canonical CJS
+                    // "require at the bottom for cyclic deps" pattern — must
+                    // pre-register each destructured leaf so a class/function
+                    // body lowered earlier resolves `src`/`t` to the module
+                    // slot, not an undefined implicit global. Without this the
+                    // destructuring leaf later allocates a *fresh* id and the
+                    // earlier reference points at the wrong (undefined) slot.
+                    // (The simple-ident arm above already handles `const x =`.)
+                    let mut leaf_names = Vec::new();
+                    crate::lower_patterns::collect_binding_names(&decl.name, &mut leaf_names);
+                    for name in leaf_names {
+                        if ctx.lookup_local(&name).is_none() {
+                            ctx.define_local(name.clone(), Type::Any);
+                            ctx.pre_registered_module_vars.insert(name.clone());
+                            if var_decl.kind == ast::VarDeclKind::Var {
+                                ctx.pre_registered_module_var_decls.insert(name);
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/tests/test_cjs_module_destructure_after_class.sh
+++ b/tests/test_cjs_module_destructure_after_class.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Regression (fix/semver-module-token-build, #5358): a compiled CJS package
+# whose module-level DESTRUCTURING require sits at the BOTTOM of the file — the
+# canonical "require at the end for cyclic deps" pattern used by semver's
+# classes/comparator.js (`const { safeRe: re, t } = require('../internal/re')`)
+# — must still bind the destructured leaves into module scope so a class/method
+# body lowered EARLIER in the file resolves them to the real module slot.
+#
+# Pre-fix: the module-level pre-registration pass only hoisted simple-ident
+# bindings (`const x = ...`). A bottom `const { src, t } = require('./re')` was
+# skipped, so the class constructor above it read `src`/`t` as undefined
+# implicit globals (`src is not defined` / undefined). semver's subset.js builds
+# `new Comparator('>=0.0.0-0')` at module-init time, which threw
+# `TypeError: Invalid comparator: >=0.0.0-0`, blocking native-compile of semver.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PERRY="$SCRIPT_DIR/../target/release/perry"
+[ ! -f "$PERRY" ] && PERRY="$SCRIPT_DIR/../target/debug/perry"
+if [ ! -f "$PERRY" ]; then
+  echo "SKIP: perry binary not found (build with cargo build --release)"
+  exit 0
+fi
+if ! command -v cc >/dev/null 2>&1; then
+  echo "SKIP: cc not available"
+  exit 0
+fi
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+PKG="$TMPDIR/node_modules/pk"
+mkdir -p "$PKG"
+
+# re.js — a module that builds up a table via a module-level closure (mirrors
+# semver/internal/re.js `createToken`).
+cat > "$PKG/re.js" << 'EOF'
+'use strict'
+exports = module.exports = {}
+const src = exports.src = []
+const t = exports.t = {}
+let R = 0
+const createToken = (name, value) => { const i = R++; t[name] = i; src[i] = value }
+createToken('A', 'aaa')
+createToken('B', 'bbb')
+createToken('C', `${src[t.A]}-${src[t.B]}`)
+EOF
+
+# cons.js — the kept pattern: a class whose ctor reads `src`/`t`, with the
+# DESTRUCTURING require at the BOTTOM of the file (cyclic-dep style).
+cat > "$PKG/cons.js" << 'EOF'
+'use strict'
+class Thing {
+  constructor(x) {
+    if (!src || !t) throw new Error('bindings undefined for ' + x)
+    this.v = src[t.C] + ':' + x
+    if (!src[t.C]) throw new Error('Invalid: src[C] undefined for ' + x)
+  }
+}
+module.exports = Thing
+const { src, t } = require('./re.js')
+EOF
+
+# subset.js — constructs the class at MODULE-INIT time (mirrors semver
+# ranges/subset.js `const minimumVersion = [new Comparator('>=0.0.0')]`).
+cat > "$PKG/subset.js" << 'EOF'
+'use strict'
+const Thing = require('./cons.js')
+const minimum = [new Thing('top-level')]
+module.exports = function () { return minimum[0].v }
+EOF
+
+cat > "$PKG/index.js" << 'EOF'
+'use strict'
+const subset = require('./subset.js')
+module.exports = function () { return subset() }
+EOF
+
+cat > "$PKG/package.json" << 'EOF'
+{ "name":"pk","version":"1.0.0","main":"index.js" }
+EOF
+
+cat > "$TMPDIR/package.json" << 'EOF'
+{ "type":"module","private":true,"perry":{"compilePackages":["*"],"allow":{"compilePackages":["*"]}} }
+EOF
+
+cat > "$TMPDIR/main.ts" << 'EOF'
+import pk from "pk";
+console.log(pk());
+EOF
+
+cd "$TMPDIR"
+COMPILE_OUTPUT=$(PERRY_NO_AUTO_OPTIMIZE=1 "$PERRY" main.ts -o test_bin --no-cache 2>&1) || {
+  echo "FAIL: compile error"
+  echo "$COMPILE_OUTPUT" | tail -20
+  exit 1
+}
+
+RUN_OUTPUT=$(./test_bin 2>&1)
+EXPECTED="aaa-bbb:top-level"
+
+if [ "$RUN_OUTPUT" = "$EXPECTED" ]; then
+  echo "PASS"
+  exit 0
+fi
+
+echo "FAIL: bottom-of-file destructuring require not hoisted into module scope"
+echo "Expected: $EXPECTED"
+echo "Got:      $RUN_OUTPUT"
+exit 1


### PR DESCRIPTION
## Root cause

Native-compiling **semver** threw `TypeError: Invalid comparator: >=0.0.0-0` at
import time, blocking it as one of the last corpus failures.

`semver/ranges/subset.js` constructs `new Comparator('>=0.0.0-0')` at **module-init
time**. `semver/classes/comparator.js` reads its regex table via

```js
const { safeRe: re, t } = require('../internal/re')   // at the BOTTOM of the file
```

— the canonical CJS *"require at the bottom for cyclic deps"* pattern.

Perry's module-level **forward-declaration pass** (`lower/lower_module_fn.rs`) only
pre-registered **simple-ident** bindings (`const x = ...`). A module-level
**destructuring** binding (`const { src, t } = ...`) declared *after* a class/function
that references its leaves was skipped entirely. The destructuring leaf then allocated
a **fresh** `LocalId`, so the earlier Comparator-constructor read of `re`/`t` resolved
to one (undefined) slot while the destructure's write landed on a different id.

At init time `re[t.COMPARATOR]` was therefore `undefined` → `comp.match(undefined)` →
`null` → the `Invalid comparator` throw.

Non-perturbing probes confirmed the token table itself (`src[t.FULLPLAIN]`,
`re[t.COMPARATOR].source`) is byte-identical to Node — the regex was correct; only the
*timing/binding* of the bottom-of-file destructured `re`/`t` was wrong.

## Fix (two additive sites, both gated on module scope)

- **`lower/lower_module_fn.rs`** — pre-register each destructured leaf name of a
  module-level `Object`/`Array` binding pattern (via `collect_binding_names`), mirroring
  the existing simple-ident arm, so a class/function body lowered earlier resolves the
  leaves to the module slot rather than an undefined implicit global.
- **`destructuring/pattern_binding.rs`** — in both the `{ key }` shorthand (`Assign`) arm
  and the `{ a: b }` rename (`Ident`) leaf arm, reuse the pre-registered module-var id
  when at module scope (`scope_depth == 0 && inside_block_scope == 0`), matching the proven
  simple-ident reuse path.

## Regression test

`tests/test_cjs_module_destructure_after_class.sh` — a compiled CJS package whose
bottom-of-file destructuring `require` feeds a class constructed at another module's
init time (the reduced semver shape: `re.js` builds a table via a module-level closure,
`cons.js` reads it via a bottom `const { src, t } = require('./re.js')`, `subset.js`
constructs at init).

## Results

semver, before → after:
- before: `TypeError: Invalid comparator: >=0.0.0-0` at import (compile-OK, run-FAIL)
- after: `require('semver')` loads; `new Comparator('>=0.0.0-0')`, `new Range('*')` work.
- **next wall (separate, unrelated logic bug):** `semver.satisfies('1.2.3', '*')`
  returns `false` (Node: `true`) — a comparison-path issue, not the module-binding bug.

Corpus (coherent binary, `--no-cache`): **57/59 → 58/59**. The only remaining failure is
`winston_` (pre-existing, unrelated: `Cannot set properties of null/undefined (setting
'needReadable')`). Zero regressions.

Lint gates: `cargo fmt --check`, `check_file_size.sh`, `gc_store_site_inventory.py`,
`addr_class_inventory.py` all pass. `perry-hir`/`perry-codegen`/`perry-transform` tests pass.

_Version bump + CHANGELOG left to the maintainer to fold at merge._