### PR TITLE
[codex] Optimize byte-load loop accumulators

### DIFF
--- a/crates/perry-codegen/src/expr/literals_vars.rs
+++ b/crates/perry-codegen/src/expr/literals_vars.rs
@@ -224,6 +224,15 @@ fn lower_nonnegative_i64_addend(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<Opti
             let rem = blk.srem(I32, &i32_value, &divisor_i32.to_string());
             Ok(Some(blk.sext(I32, &rem, I64)))
         }
+        Expr::Uint8ArrayGet { array, index } => {
+            let byte_i32 = super::arrays_finds::lower_uint8array_get_i32(ctx, array, index)?.value;
+            Ok(Some(ctx.block().zext(I32, &byte_i32, I64)))
+        }
+        Expr::BufferIndexGet { buffer, index } => {
+            let byte_i32 =
+                super::arrays_finds::lower_buffer_index_get_i32(ctx, buffer, index)?.value;
+            Ok(Some(ctx.block().zext(I32, &byte_i32, I64)))
+        }
         _ => Ok(None),
     }
 }

--- a/crates/perry-codegen/src/stmt/loops.rs
+++ b/crates/perry-codegen/src/stmt/loops.rs
@@ -1060,6 +1060,29 @@ fn exact_nonnegative_integer_const(expr: &perry_hir::Expr) -> Option<i64> {
     (0..=MAX_SAFE_INTEGER_I64).contains(&value).then_some(value)
 }
 
+fn bounded_byte_get_addend_max(
+    ctx: &FnCtx<'_>,
+    counter_id: u32,
+    buffer: &perry_hir::Expr,
+    index: &perry_hir::Expr,
+) -> Option<i64> {
+    let perry_hir::Expr::LocalGet(index_id) = index else {
+        return None;
+    };
+    if *index_id != counter_id {
+        return None;
+    }
+    let perry_hir::Expr::LocalGet(buffer_id) = buffer else {
+        return None;
+    };
+    if !ctx.buffer_view_slots.contains_key(buffer_id) {
+        return None;
+    }
+    crate::expr::bounds_for_buffer_access_width(ctx, *buffer_id, index, 1)
+        .allows_inbounds()
+        .then_some(255)
+}
+
 fn nonnegative_i64_addend_max(
     ctx: &FnCtx<'_>,
     counter_id: u32,
@@ -1088,6 +1111,12 @@ fn nonnegative_i64_addend_max(
             }
             let divisor = exact_nonnegative_integer_const(right.as_ref())?;
             (divisor > 0).then_some(divisor - 1)
+        }
+        perry_hir::Expr::Uint8ArrayGet { array, index } => {
+            bounded_byte_get_addend_max(ctx, counter_id, array, index)
+        }
+        perry_hir::Expr::BufferIndexGet { buffer, index } => {
+            bounded_byte_get_addend_max(ctx, counter_id, buffer, index)
         }
         _ => None,
     }

--- a/crates/perry-codegen/tests/typed_feedback.rs
+++ b/crates/perry-codegen/tests/typed_feedback.rs
@@ -1267,6 +1267,92 @@ fn i64_loop_accumulator_syncs_once_for_self_add_body() {
 }
 
 #[test]
+fn i64_loop_accumulator_uses_uint8array_byte_addend() {
+    let byte_get = Expr::Uint8ArrayGet {
+        array: Box::new(Expr::LocalGet(2)),
+        index: Box::new(Expr::LocalGet(4)),
+    };
+    let ir = ir_for(module(
+        "i64_loop_accumulator_uint8array_get.ts",
+        Vec::new(),
+        Type::Number,
+        vec![
+            Stmt::Let {
+                id: 1,
+                name: "size".to_string(),
+                ty: Type::Number,
+                mutable: false,
+                init: Some(Expr::Integer(16)),
+            },
+            Stmt::Let {
+                id: 2,
+                name: "bytes".to_string(),
+                ty: Type::Named("Uint8Array".to_string()),
+                mutable: false,
+                init: Some(Expr::Uint8ArrayNew(Some(Box::new(Expr::LocalGet(1))))),
+            },
+            Stmt::Let {
+                id: 3,
+                name: "sum".to_string(),
+                ty: Type::Number,
+                mutable: true,
+                init: Some(Expr::Integer(0)),
+            },
+            Stmt::For {
+                init: Some(Box::new(Stmt::Let {
+                    id: 4,
+                    name: "i".to_string(),
+                    ty: Type::Number,
+                    mutable: true,
+                    init: Some(Expr::Integer(0)),
+                })),
+                condition: Some(Expr::Compare {
+                    op: CompareOp::Lt,
+                    left: Box::new(Expr::LocalGet(4)),
+                    right: Box::new(Expr::LocalGet(1)),
+                }),
+                update: Some(Expr::Update {
+                    id: 4,
+                    op: UpdateOp::Increment,
+                    prefix: false,
+                }),
+                body: vec![Stmt::Expr(Expr::LocalSet(
+                    3,
+                    Box::new(Expr::Binary {
+                        op: BinaryOp::Add,
+                        left: Box::new(Expr::LocalGet(3)),
+                        right: Box::new(byte_get),
+                    }),
+                ))],
+            },
+            Stmt::Return(Some(Expr::LocalGet(3))),
+        ],
+    ));
+    let body_start = ir.find("\nfor.body.").expect("for body block");
+    let body_end = ir[body_start..]
+        .find("\nfor.update.")
+        .map(|offset| body_start + offset)
+        .expect("for update block");
+    let exit_start = ir.find("\nfor.exit.").expect("for exit block");
+    let body_ir = &ir[body_start..body_end];
+    let exit_ir = &ir[exit_start..];
+
+    assert!(body_ir.contains("load i8"), "{body_ir}");
+    assert!(body_ir.contains("zext i8"), "{body_ir}");
+    assert!(body_ir.contains("zext i32"), "{body_ir}");
+    assert!(body_ir.contains("add i64"), "{body_ir}");
+    assert!(body_ir.contains("store i64"), "{body_ir}");
+    assert!(!body_ir.contains("fadd double"), "{body_ir}");
+    assert!(!body_ir.contains("store double"), "{body_ir}");
+    assert!(
+        !body_ir.contains("call i32 @js_uint8array_get"),
+        "{body_ir}"
+    );
+    assert!(exit_ir.contains("sitofp i64"), "{exit_ir}");
+    assert!(exit_ir.contains("store double"), "{exit_ir}");
+}
+
+#[test]
 fn i64_loop_accumulator_rejects_negative_zero_initial_value() {
     let ir = ir_for(module(
         "i64_loop_accumulator_negative_zero.ts",


### PR DESCRIPTION
## Summary

Keeps proven byte-load loop accumulators in i64 form for `Uint8ArrayGet` and `BufferIndexGet` addends. The loop classifier only enables this when the byte access is a local buffer/view indexed directly by the loop counter and `bounds_for_buffer_access_width(...).allows_inbounds()` proves the load is inbounds. The lowering then zero-extends the byte value to i64 and syncs the accumulator back to double once at loop exit.

## Performance

Target benchmark: `bench_buffer_readwrite`.

- Before binary: `/tmp/perry-cycle32-buffer-probe`
- After binary: `/tmp/perry-cycle32-buffer-after`
- 60 alternating runs each, checksum verified every run: `checksum:12749385600`
- Median: 76ms -> 29ms, 47ms faster, 61.8% speedup
- Mean: 82.60ms -> 34.90ms
- Full-suite smoke run after the change: `bench_buffer_readwrite` 46ms, 18,920KB RSS (`/tmp/perry-cycle32-suite-after/full.json`)

## IR Evidence

Retained IR: `/tmp/perry_llvm_791343_1781743446083083114_0.ll`

Hot inner block now contains `load i8`, `zext i8`, `zext i32`, `add i64`, and `store i64`, with `sitofp i64` only on loop exit. The previous retained IR `/tmp/perry_llvm_781167_1781742903579684902_0.ll` used `fadd double` in the same hot loop body.

## Validation

- `cargo fmt`
- `cargo test -p perry-codegen --test typed_feedback i64_loop_accumulator -- --nocapture`
- `cargo test -p perry-codegen --test typed_feedback`
- `cargo check -p perry-codegen`
- `cargo build --release -p perry`
- `PERRY_LLVM_KEEP_IR=1 PERRY_NATIVE_REPS_DIR=/tmp/perry-cycle32-native-reps-after target/release/perry compile --no-cache benchmarks/suite/bench_buffer_readwrite.ts -o /tmp/perry-cycle32-buffer-after --trace llvm --quiet`
- `/tmp/perry-cycle32-buffer-probe` and `/tmp/perry-cycle32-buffer-after` runtime output comparison
- `benchmarks/compare.sh --full --runs 3 --warn-only --json-out /tmp/perry-cycle32-suite-after/full.json`

Note: Node.js is unavailable in this environment, so `.ts` benchmark correctness remains marked `unchecked` by the suite. The targeted before/after binaries both produced the same Perry checksum.
