### PR TITLE
[codex] Fold affine accumulator loops

### DIFF
--- a/crates/perry-codegen/src/stmt/loops.rs
+++ b/crates/perry-codegen/src/stmt/loops.rs
@@ -81,6 +81,12 @@ struct AccumulatorClosedForm {
     final_acc: i64,
 }
 
+#[derive(Clone, Copy, Debug)]
+struct AffineAccumulatorAddend {
+    coeff: i128,
+    constant: i128,
+}
+
 /// For-loop lowering: classic init / cond / body / update / exit CFG.
 ///
 /// ```text
@@ -498,6 +504,15 @@ pub(crate) fn lower_for(
             body,
             acc,
         )
+        .or_else(|| {
+            classify_affine_accumulator_closed_form(
+                ctx,
+                local_bound_classification,
+                update,
+                body,
+                acc,
+            )
+        })
         .or_else(|| {
             classify_modulo_accumulator_closed_form(
                 ctx,
@@ -1298,6 +1313,126 @@ fn classify_constant_accumulator_closed_form(
         final_counter,
         final_acc: final_acc as i64,
     })
+}
+
+fn classify_affine_accumulator_closed_form(
+    ctx: &FnCtx<'_>,
+    local_bound_classification: Option<(u32, u32, perry_hir::CompareOp)>,
+    update: Option<&perry_hir::Expr>,
+    body: &[Stmt],
+    acc: &I64LoopAccumulator,
+) -> Option<AccumulatorClosedForm> {
+    let (counter_id, bound_id, op) = local_bound_classification?;
+    if !matches!(op, perry_hir::CompareOp::Lt)
+        || !loop_counter_bounds_are_safe(ctx, counter_id, update, body)
+    {
+        return None;
+    }
+
+    let [Stmt::Expr(perry_hir::Expr::LocalSet(acc_id, value))] = body else {
+        return None;
+    };
+    if *acc_id != acc.local_id {
+        return None;
+    }
+    let addend = affine_accumulator_addend(
+        counter_id,
+        self_add_accumulator_addend(acc.local_id, value.as_ref())?,
+    )?;
+    let start = *ctx.exact_safe_integer_locals.get(&counter_id)?;
+    let bound = *ctx.exact_safe_integer_locals.get(&bound_id)?;
+    let initial_acc = *ctx.exact_safe_integer_locals.get(&acc.local_id)?;
+    if start < 0 || bound < 0 || initial_acc < 0 {
+        return None;
+    }
+    let final_counter = if start < bound { bound } else { start };
+    i32::try_from(final_counter).ok()?;
+
+    let iterations = if start < bound {
+        (bound as i128).checked_sub(start as i128)?
+    } else {
+        0
+    };
+    let counter_sum = arithmetic_series_sum(start as i128, final_counter as i128)?;
+    let delta = addend
+        .coeff
+        .checked_mul(counter_sum)?
+        .checked_add(addend.constant.checked_mul(iterations)?)?;
+    let final_acc = (initial_acc as i128).checked_add(delta)?;
+    if final_acc < 0 || final_acc > MAX_SAFE_INTEGER_I64 as i128 {
+        return None;
+    }
+
+    Some(AccumulatorClosedForm {
+        acc_local_id: acc.local_id,
+        counter_local_id: counter_id,
+        final_counter,
+        final_acc: final_acc as i64,
+    })
+}
+
+fn affine_accumulator_addend(
+    counter_id: u32,
+    expr: &perry_hir::Expr,
+) -> Option<AffineAccumulatorAddend> {
+    if let Some(value) = exact_nonnegative_integer_const(expr) {
+        return Some(AffineAccumulatorAddend {
+            coeff: 0,
+            constant: value as i128,
+        });
+    }
+
+    match expr {
+        perry_hir::Expr::LocalGet(id) if *id == counter_id => Some(AffineAccumulatorAddend {
+            coeff: 1,
+            constant: 0,
+        }),
+        perry_hir::Expr::Binary {
+            op: perry_hir::BinaryOp::Add,
+            left,
+            right,
+        } => {
+            let left = affine_accumulator_addend(counter_id, left)?;
+            let right = affine_accumulator_addend(counter_id, right)?;
+            Some(AffineAccumulatorAddend {
+                coeff: left.coeff.checked_add(right.coeff)?,
+                constant: left.constant.checked_add(right.constant)?,
+            })
+        }
+        perry_hir::Expr::Binary {
+            op: perry_hir::BinaryOp::Mul,
+            left,
+            right,
+        } => {
+            let left = affine_accumulator_addend(counter_id, left)?;
+            let right = affine_accumulator_addend(counter_id, right)?;
+            match (left.coeff == 0, right.coeff == 0) {
+                (true, true) => left.scale(right.constant),
+                (true, false) => right.scale(left.constant),
+                (false, true) => left.scale(right.constant),
+                (false, false) => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+impl AffineAccumulatorAddend {
+    fn scale(self, factor: i128) -> Option<Self> {
+        Some(Self {
+            coeff: self.coeff.checked_mul(factor)?,
+            constant: self.constant.checked_mul(factor)?,
+        })
+    }
+}
+
+fn arithmetic_series_sum(start: i128, end_exclusive: i128) -> Option<i128> {
+    if start >= end_exclusive {
+        return Some(0);
+    }
+    let terms = end_exclusive.checked_sub(start)?;
+    let last = end_exclusive.checked_sub(1)?;
+    start.checked_add(last)?.checked_mul(terms)?.checked_div(2)
 }
 
 fn modulo_accumulator_addend(acc_id: u32, counter_id: u32, value: &perry_hir::Expr) -> Option<i64> {

--- a/crates/perry-codegen/tests/typed_feedback.rs
+++ b/crates/perry-codegen/tests/typed_feedback.rs
@@ -1335,14 +1335,17 @@ fn i32_for_update_skips_per_iteration_double_counter_store() {
                     op: UpdateOp::Increment,
                     prefix: false,
                 }),
-                body: vec![Stmt::Expr(Expr::LocalSet(
-                    2,
-                    Box::new(Expr::Binary {
-                        op: BinaryOp::Add,
-                        left: Box::new(Expr::LocalGet(2)),
-                        right: Box::new(Expr::LocalGet(3)),
-                    }),
-                ))],
+                body: vec![
+                    Stmt::Expr(Expr::LocalSet(
+                        2,
+                        Box::new(Expr::Binary {
+                            op: BinaryOp::Add,
+                            left: Box::new(Expr::LocalGet(2)),
+                            right: Box::new(Expr::LocalGet(3)),
+                        }),
+                    )),
+                    Stmt::Expr(Expr::LocalGet(2)),
+                ],
             },
             Stmt::Return(Some(Expr::LocalGet(3))),
         ],
@@ -1577,7 +1580,7 @@ fn i64_loop_accumulator_uses_uint8array_byte_addend() {
 }
 
 #[test]
-fn i64_loop_accumulator_uses_affine_counter_addend() {
+fn typed_feedback_folds_affine_i64_accumulator_loop() {
     let affine = Expr::Binary {
         op: BinaryOp::Add,
         left: Box::new(Expr::Binary {
@@ -1597,8 +1600,69 @@ fn i64_loop_accumulator_uses_affine_counter_addend() {
                 name: "limit".to_string(),
                 ty: Type::Number,
                 mutable: false,
-                init: Some(Expr::Integer(100)),
+                init: Some(Expr::Integer(10)),
             },
+            Stmt::Let {
+                id: 2,
+                name: "sum".to_string(),
+                ty: Type::Number,
+                mutable: true,
+                init: Some(Expr::Integer(5)),
+            },
+            Stmt::For {
+                init: Some(Box::new(Stmt::Let {
+                    id: 3,
+                    name: "i".to_string(),
+                    ty: Type::Number,
+                    mutable: true,
+                    init: Some(Expr::Integer(2)),
+                })),
+                condition: Some(Expr::Compare {
+                    op: CompareOp::Lt,
+                    left: Box::new(Expr::LocalGet(3)),
+                    right: Box::new(Expr::LocalGet(1)),
+                }),
+                update: Some(Expr::Update {
+                    id: 3,
+                    op: UpdateOp::Increment,
+                    prefix: false,
+                }),
+                body: vec![Stmt::Expr(Expr::LocalSet(
+                    2,
+                    Box::new(Expr::Binary {
+                        op: BinaryOp::Add,
+                        left: Box::new(Expr::LocalGet(2)),
+                        right: Box::new(affine),
+                    }),
+                ))],
+            },
+            Stmt::Return(Some(Expr::LocalGet(2))),
+        ],
+    ));
+
+    assert!(ir.contains("store i64 101"), "{ir}");
+    assert!(ir.contains("store i32 10"), "{ir}");
+    assert!(!ir.contains("mul i64"), "{ir}");
+    assert!(!ir.contains("for.body"), "{ir}");
+    assert!(!ir.contains("asm sideeffect"), "{ir}");
+}
+
+#[test]
+fn typed_feedback_keeps_dynamic_bound_affine_accumulator_loop() {
+    let affine = Expr::Binary {
+        op: BinaryOp::Add,
+        left: Box::new(Expr::Binary {
+            op: BinaryOp::Mul,
+            left: Box::new(Expr::LocalGet(3)),
+            right: Box::new(Expr::Integer(2)),
+        }),
+        right: Box::new(Expr::Integer(1)),
+    };
+    let ir = ir_for(module(
+        "typed_feedback_dynamic_affine_accumulator.ts",
+        vec![param(1, "limit", Type::Number)],
+        Type::Number,
+        vec![
             Stmt::Let {
                 id: 2,
                 name: "sum".to_string(),
@@ -1641,18 +1705,10 @@ fn i64_loop_accumulator_uses_affine_counter_addend() {
         .find("\nfor.update.")
         .map(|offset| body_start + offset)
         .expect("for update block");
-    let exit_start = ir.find("\nfor.exit.").expect("for exit block");
     let body_ir = &ir[body_start..body_end];
-    let exit_ir = &ir[exit_start..];
 
-    assert!(body_ir.contains("mul i64"), "{body_ir}");
-    assert!(body_ir.contains("add i64"), "{body_ir}");
-    assert!(body_ir.contains("store i64"), "{body_ir}");
-    assert!(!body_ir.contains("fmul double"), "{body_ir}");
-    assert!(!body_ir.contains("fadd double"), "{body_ir}");
-    assert!(!body_ir.contains("store double"), "{body_ir}");
-    assert!(exit_ir.contains("sitofp i64"), "{exit_ir}");
-    assert!(exit_ir.contains("store double"), "{exit_ir}");
+    assert!(body_ir.contains("fadd double"), "{body_ir}");
+    assert!(body_ir.contains("store double"), "{body_ir}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds a conservative affine closed-form path for exact i64 accumulator loops shaped like `sum = sum + (a * i + b)`.
- Reuses the existing i64 accumulator preparation and closed-form emitter, with strict `<` loop bounds, safe counter proof, exact nonnegative start/bound/initial values, i32 final counter checks, and checked i128 arithmetic.
- Updates typed-feedback coverage for exact affine folding and dynamic-bound safety.

## Performance evidence
- Target: `benchmarks/suite/14_closure.ts`, where `compute(i)` is inlined to `i * 2 + 1`.
- Before: traced IR contained `for.body`, `mul i64`, `add i64`, and `asm sideeffect`; runtime output `function_calls:34`, `sum:2500000000000000`.
- After: traced IR stores `2500000000000000` directly into the accumulator and `50000000` into the counter, with no `for.body` or asm barrier in main; runtime output `function_calls:0`, same sum.
- 40 paired runs: before mean `28.98ms` (min 14, max 38), after mean `0.00ms` (min 0, max 0), improved `40/40`, bad_sum `0`.
- Full suite smoke: `benchmarks/compare.sh --full --runs 3 --warn-only --json-out /tmp/perry-cycle37-suite-after-full.json`; `14_closure` reports `perry_ms: 0`. Node was unavailable, so benchmark correctness columns were unchecked.

## Validation
- `cargo fmt -- --check`
- `cargo test -p perry-codegen --test typed_feedback -- --nocapture`
- `cargo check -p perry-codegen`
- `cargo build --release -p perry`
- `git diff --check`
