### PR TITLE
[codex] Prioritize old reclaim at parse boundaries

### DIFF
--- a/crates/perry-runtime/src/gc/policy.rs
+++ b/crates/perry-runtime/src/gc/policy.rs
@@ -676,6 +676,20 @@ pub fn gc_collect_pending_suppressed_parse() {
     }
 
     let in_use = crate::arena::arena_in_use_bytes();
+    if gen_gc_enabled() {
+        let old_pending = GC_OLD_RECLAIM_PENDING.with(|pending| pending.get());
+        let old_in_use = crate::arena::old_gen_in_use_bytes();
+        let old_baseline = GC_LAST_OLD_RECLAIM_IN_USE_BYTES.with(|bytes| bytes.get());
+        if old_pending || old_reclaim_pressure_due(old_in_use, old_baseline) {
+            GC_OLD_RECLAIM_PENDING.with(|pending| pending.set(false));
+            gc_collect_full_mark_sweep_with_trigger(GcTriggerSnapshot::capture(
+                GcTriggerKind::OldGenBytes,
+            ))
+            .emit_after_current();
+            return;
+        }
+    }
+
     if gen_gc_enabled() && in_use >= GC_SUPPRESSED_TINY_PARSE_IN_USE_TRIGGER_BYTES {
         let outcome =
             gc_collect_inner_with_trigger(GcTriggerSnapshot::capture(GcTriggerKind::ArenaBytes));

--- a/crates/perry-runtime/src/gc/tests/triggers.rs
+++ b/crates/perry-runtime/src/gc/tests/triggers.rs
@@ -230,6 +230,53 @@ fn test_pending_tiny_parse_boundary_collection_completes_and_rebaselines() {
 }
 
 #[test]
+fn test_pending_parse_boundary_prioritizes_old_reclaim_pressure() {
+    let _trace_guard = TestGcTraceCaptureGuard::force_enabled();
+    let _copying_guard = CopyingNurseryTestGuard::new(1);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    let _bump_guard = GcBumpTriggerTestGuard::new(usize::MAX, GC_THRESHOLD_INITIAL_BYTES);
+
+    let live_old = crate::arena::arena_alloc_gc_old(40, 8, GC_TYPE_STRING) as usize;
+    js_shadow_slot_set(0, ptr_bits(live_old));
+    GC_LAST_OLD_RECLAIM_IN_USE_BYTES.with(|bytes| bytes.set(0));
+    GC_OLD_RECLAIM_PENDING.with(|pending| pending.set(true));
+
+    let mut dead_bytes = 0usize;
+    let dead_chunks = (GC_OLD_GEN_RECLAIM_THRESHOLD_BYTES / (1024 * 1024)) + 2;
+    for _ in 0..dead_chunks {
+        let dead = crate::arena::arena_alloc_gc_old(1024 * 1024, 8, GC_TYPE_STRING) as usize;
+        let (_header, total) = old_test_header_and_size(dead);
+        dead_bytes = dead_bytes.saturating_add(total);
+    }
+    let old_before = crate::arena::old_gen_in_use_bytes();
+    let before = gc_collection_count();
+
+    GC_SUPPRESSED_TINY_PARSE_COLLECTION_PENDING.with(|pending| pending.set(true));
+    gc_collect_pending_suppressed_parse();
+
+    assert_eq!(gc_collection_count(), before + 1);
+    assert!(
+        crate::arena::old_gen_in_use_bytes() < old_before / 4,
+        "parse-boundary old reclaim should reclaim dead old JSON pressure"
+    );
+    assert!(
+        GC_LAST_OLD_RECLAIM_IN_USE_BYTES.with(|bytes| bytes.get())
+            <= crate::arena::old_gen_in_use_bytes(),
+        "completed old reclaim should rebaseline old-generation pressure"
+    );
+    assert!(dead_bytes >= GC_OLD_GEN_RECLAIM_THRESHOLD_BYTES);
+
+    let event =
+        take_test_last_gc_trace_json().expect("parse-boundary old reclaim should emit trace JSON");
+    assert_eq!(event["collection_kind"].as_str(), Some("full"));
+    assert_eq!(event["trigger"]["kind"].as_str(), Some("old_gen_bytes"));
+
+    let live_after = (js_shadow_slot_get(0) & POINTER_MASK) as usize;
+    assert_eq!(live_after, live_old);
+    assert!(crate::arena::pointer_in_old_gen(live_after));
+}
+
+#[test]
 fn test_old_reclaim_pressure_uses_threshold_and_growth() {
     assert!(!old_reclaim_pressure_due(
         GC_OLD_GEN_RECLAIM_THRESHOLD_BYTES - 1,


### PR DESCRIPTION
## Summary

- Teach the pending tiny-parse GC boundary to honor old-generation reclaim pressure before scheduling another copied-minor collection.
- Add a regression test that arms parse-boundary collection under old-gen pressure, verifies a full `old_gen_bytes` reclaim runs, and confirms a rooted old object survives.

## Root Cause

`bench_json_roundtrip` was repeatedly entering parse-boundary copied-minor collections even after lazy JSON/tape churn had moved pressure into old/large-excluded storage. Those minor collections could not reclaim the dead old-gen pressure, so Perry spent time copying/promoting young objects while RSS kept growing.

## Evidence

Targeted trace, same worktree before/after this commit, `PERRY_GC_TRACE=1`:

| Metric | Before | After |
| --- | ---: | ---: |
| stdout timing | `json_roundtrip:327` | `json_roundtrip:80` |
| checksum | `53735550` | `53735550` |
| RSS | `245588 KB` | `134528 KB` |
| elapsed | `0:00.39` | `0:00.14` |
| GC events | `36 minor` | `2 full` |
| triggers | `36 arena_bytes` | `2 old_gen_bytes` |
| total GC pause | `173554 us` | `31229 us` |
| max GC pause | `28927 us` | `16222 us` |
| swept bytes | `816368` | `94820920` |
| copied bytes | `10514712` | `0` |
| promoted bytes | `3502376` | `0` |

Full suite one-run after this change, with absolute JSON output path:

- `PERRY_BIN="$PWD/target/release/perry" benchmarks/compare.sh --full --runs 1 --json-out "$PWD/tmp/cycle41-profile/full-after.json" --warn-only`
- Target row improved from the pre-change cycle 41 suite run `bench_json_roundtrip: 392ms / 236480KB` to `91ms / 134660KB`.
- The compare script still reports broad regressions against historical baseline commit `c89b3ad5`; those are existing branch-vs-baseline differences from before this focused PR, not new rows introduced by this patch.

## Validation

- `cargo fmt -- --check`
- `cargo test -p perry-runtime gc::tests::triggers`
- `cargo test -p perry-runtime gc::tests::host_safepoints`
- `cargo test -p perry-runtime gc::tests::budgeted_step_api`
- `cargo test -p perry-runtime json::`
- `cargo build --release -p perry`
- Recompiled `bench_json_roundtrip.ts` with `./target/release/perry compile --no-cache ...` and ran the traced benchmark above.
