### PR TITLE
fix(perry-ui-windows): migrate to windows/windows-core 0.62 (unblock Windows release publish)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,55 @@
+## v0.5.1181 — fix(perry-ui-windows): migrate to windows / windows-core 0.62 (unblock Windows release publish)
+
+The v0.5.1180 release packaged macOS, Linux and Android, but **published
+nothing**: every publish job in `release-packages.yml` (`npm-publish`,
+`homebrew`, `apt`, `apt-repo`, `winget`, `update-workers`) is `needs: build`,
+and the `build` matrix's Windows leg failed to compile, collapsing the whole
+`build` job to `failure` and skipping all publishers. Only the GitHub Release
+page (notes + source tarball) shipped.
+
+Root cause: Dependabot PR #5300-era bump `c0f46f07e` raised `webview2-com` to
+`=0.39`, which resolves `windows` / `windows-core` to **0.62.2** — but
+`crates/perry-ui-windows/Cargo.toml` still pinned `windows` / `windows-core` at
+`0.58`. The webview2 COM interfaces (`ICoreWebView2`, etc.) were then a
+different crate version than perry's own `HWND` / `RECT` / `PCWSTR` / `PWSTR` /
+`Interface` types, so the WebView2 boundary in `widgets/webview.rs` failed to
+type-check (the in-file comment had warned this exact skew would break the
+build).
+
+Fix: align `perry-ui-windows` to `windows` / `windows-core` `0.62` and migrate
+the crate's source to the 0.62 API surface. This is a mechanical,
+behavior-preserving migration across ~47 files:
+
+- **`Option<HANDLE>` parameters**: many Win32 calls now take `Option<…>`
+  (`SendMessageW`/`PostMessageW` WPARAM/LPARAM, `InvalidateRect` / `SetParent`
+  / `ReleaseDC` / `SetFocus` / `SetWindowPos` / `CreateWindowExW` /
+  `SetTimer` / … HWND/HMENU/HINSTANCE) — present handles wrapped in `Some(…)`.
+- **GDI objects**: `DeleteObject` / `SelectObject` / `GetObjectW` now take
+  `HGDIOBJ`; `HBRUSH`/`HPEN`/`HFONT`/`HBITMAP` converted via `.into()`.
+- **`CreateFontW`**: charset / precision / quality integer args wrapped in
+  their 0.62 newtypes (`FONT_CHARSET` / `FONT_OUTPUT_PRECISION` /
+  `FONT_CLIP_PRECISION` / `FONT_QUALITY`).
+- **`BOOL`** moved from `windows::Win32::Foundation` to `windows::core`.
+- **`#[implement]` COM authoring** (`drag_drop.rs`) and a winrt
+  `TypedEventHandler` (`media_playback.rs`): 0.62 passes interface args as
+  `windows::core::Ref<'_, T>` instead of `Option<&T>`; signatures + bodies
+  (`pdataobj.as_ref()`) updated accordingly.
+- **`widgets/webview.rs`**: `#[implement]` macros now come from
+  `windows-core`'s re-export (the `windows` `implement` feature was removed in
+  0.62); `Error::from_win32()` replaced with
+  `Error::from(HRESULT::from_win32(GetLastError().0))`; event-registration
+  tokens are now `i64` (`add_NavigationStarting` / `add_NavigationCompleted`
+  take `*mut i64`).
+
+Verified by cross-compiling the crate to `x86_64-pc-windows-msvc` from macOS
+via `cargo-xwin` (`cargo xwin check -p perry-ui-windows --target
+x86_64-pc-windows-msvc` → clean) — the Windows build is not exercised by the
+PR `Tests` matrix (only by `release-packages.yml` on a tag), so local
+cross-check is the pre-merge gate. `perry-ui-windows` was the sole failing
+crate in the v0.5.1180 Windows build, so this restores both the
+`build (windows)` and `build-cross (perry-ui-windows)` legs and lets the
+publish jobs run.
+
 ## v0.5.1180 — ci: warm the main-scoped CI cache so PRs stop building cold
 
 Follow-up to v0.5.1179. Moving sccache to a persisted disk cache was necessary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1180
+**Current Version:** 0.5.1181
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3439,7 +3439,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -3736,7 +3736,7 @@ dependencies = [
  "socket2",
  "widestring",
  "windows-registry",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-sys 0.61.2",
 ]
 
@@ -5283,7 +5283,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "anyhow",
  "base64",
@@ -5340,14 +5340,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "cc",
  "libc",
@@ -5355,7 +5355,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "anyhow",
  "log",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5379,7 +5379,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "anyhow",
  "base64",
@@ -5419,7 +5419,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5456,14 +5456,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "serde",
  "serde_json",
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1180"
+version = "0.5.1181"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "anyhow",
  "clap",
@@ -5497,14 +5497,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5512,7 +5512,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5545,7 +5545,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5571,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5603,14 +5603,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5652,7 +5652,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "bytes",
  "h2",
@@ -5675,7 +5675,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5685,7 +5685,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5696,7 +5696,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5704,7 +5704,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5712,7 +5712,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "bson",
  "futures-util",
@@ -5724,7 +5724,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5734,7 +5734,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5765,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5782,7 +5782,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "base64",
  "image",
@@ -5799,14 +5799,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5815,7 +5815,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5833,7 +5833,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5845,7 +5845,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "brotli",
  "flate2",
@@ -5854,7 +5854,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5881,7 +5881,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5893,7 +5893,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "anyhow",
  "base64",
@@ -5926,7 +5926,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6018,7 +6018,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6028,7 +6028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6036,14 +6036,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "base64",
  "itoa",
@@ -6060,7 +6060,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6070,7 +6070,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6093,7 +6093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "base64",
  "block2",
@@ -6109,7 +6109,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "base64",
  "block2",
@@ -6124,7 +6124,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1180"
+version = "0.5.1181"
 
 [[package]]
 name = "perry-ui-test"
@@ -6132,11 +6132,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1180"
+version = "0.5.1181"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "base64",
  "block2",
@@ -6152,7 +6152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "base64",
  "block2",
@@ -6168,7 +6168,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "block2",
  "libc",
@@ -6181,7 +6181,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "base64",
  "libc",
@@ -6192,20 +6192,20 @@ dependencies = [
  "png 0.17.16",
  "qrcodegen",
  "webview2-com",
- "windows 0.58.0",
- "windows-core 0.58.0",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6219,7 +6219,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1180"
+version = "0.5.1181"
 dependencies = [
  "wasmi",
 ]
@@ -9596,8 +9596,8 @@ checksum = "3f89fca7a704cee10dcb3654c1dbb8941d1783132f1917358af75bec37a7d7e6"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -9618,8 +9618,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a07132775117d6065853d9d1178157b8c90e228de47129d6bce2c7edebedfb"
 dependencies = [
  "thiserror 2.0.18",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -9686,22 +9686,12 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.62.2",
+ "windows-core",
  "windows-future",
  "windows-numerics",
 ]
@@ -9712,20 +9702,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -9734,11 +9711,11 @@ version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-implement 0.60.2",
- "windows-interface 0.59.3",
+ "windows-implement",
+ "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -9747,20 +9724,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
  "windows-threading",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -9768,17 +9734,6 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9808,7 +9763,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
+ "windows-core",
  "windows-link",
 ]
 
@@ -9819,17 +9774,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -9839,16 +9785,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ strip = false
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1180"
+version = "0.5.1181"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-ui-windows/Cargo.toml
+++ b/crates/perry-ui-windows/Cargo.toml
@@ -25,24 +25,29 @@ qrcodegen = "1.8"
 # parented to a host HWND with sync-pumped init via WebView2's async
 # completion-handler callbacks. WebView2 Runtime ships with Windows 11
 # by default and as a redistributable on Windows 10 1803+.
-# webview2-com 0.34.x is the last release that uses windows 0.58 (matches
-# the rest of perry-ui-windows). 0.35+ moved to windows 0.59+ which would
-# clash with our HWND/PCWSTR types.
+# webview2-com 0.39.x resolves to windows / windows-core 0.62.2. The rest of
+# perry-ui-windows is aligned to the same 0.62 line below, so HWND / RECT /
+# PCWSTR / PWSTR / Interface types are identical across the webview2 boundary
+# (a version skew here is what broke the Windows build at v0.5.1180).
 webview2-com = "=0.39"
 
 [features]
 geisterhand = []
 
 [target.'cfg(target_os = "windows")'.dependencies]
-# The `#[implement]` macro from `windows` 0.58 expands to absolute
+# The `#[implement]` macro from `windows` expands to absolute
 # `::windows_core::` paths, so the consuming crate must depend on
 # `windows-core` directly or the COM authoring in drag_drop.rs fails to
-# resolve `windows_core` (E0433). Pinned to 0.58 to match `windows`.
-windows-core = "0.58"
-windows = { version = "0.58", features = [
-    # `#[implement]` — needed to author the IDropTarget / IDropSource /
-    # IDataObject COM objects for native drag-and-drop (#4773).
-    "implement",
+# resolve `windows_core` (E0433). Pinned to 0.62 to match `windows` and the
+# webview2-com 0.39 dependency tree.
+windows-core = "0.62"
+windows = { version = "0.62", features = [
+    # NOTE: `#[implement]` / `#[interface]` (used to author the IDropTarget /
+    # IDropSource / IDataObject COM objects for native drag-and-drop, #4773)
+    # are no longer a `windows` feature in 0.62 — they are re-exported from
+    # `windows::core` (via the unconditional `windows-implement` dep of
+    # `windows-core`), so `use windows::core::implement;` resolves without a
+    # feature flag.
     "Win32_Foundation",
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Controls",

--- a/crates/perry-ui-windows/src/app.rs
+++ b/crates/perry-ui-windows/src/app.rs
@@ -219,7 +219,7 @@ pub fn app_create(title_ptr: *const u8, width: f64, height: f64) -> i64 {
                 h,
                 None,
                 None,
-                HINSTANCE::from(hinstance),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();
@@ -277,7 +277,7 @@ pub fn app_set_body(app_handle: i64, root_handle: i64) {
                 // Set the root widget's HWND as a child of the main window
                 if let Some(child_hwnd) = crate::widgets::get_hwnd(root_handle) {
                     unsafe {
-                        let _ = SetParent(child_hwnd, hwnd);
+                        let _ = SetParent(child_hwnd, Some(hwnd));
                         let style = GetWindowLongW(child_hwnd, GWL_STYLE) as u32;
                         SetWindowLongW(child_hwnd, GWL_STYLE, (style | WS_CHILD.0) as i32);
                         // Trigger initial layout
@@ -336,7 +336,7 @@ pub fn app_run(app_handle: i64) {
                                 let r = mi.rcMonitor;
                                 let _ = SetWindowPos(
                                     hwnd,
-                                    HWND_TOP,
+                                    Some(HWND_TOP),
                                     r.left,
                                     r.top,
                                     r.right - r.left,
@@ -364,7 +364,7 @@ pub fn app_run(app_handle: i64) {
             let idx = (app_handle - 1) as usize;
             if idx < apps.len() {
                 unsafe {
-                    let _ = SetTimer(apps[idx].hwnd, TICK_TIMER_ID, 50, None);
+                    let _ = SetTimer(Some(apps[idx].hwnd), TICK_TIMER_ID, 50, None);
                 }
             }
         });
@@ -378,7 +378,7 @@ pub fn app_run(app_handle: i64) {
                 if idx < apps.len() {
                     unsafe {
                         let _ = SetTimer(
-                            apps[idx].hwnd,
+                            Some(apps[idx].hwnd),
                             TEST_EXIT_TIMER_ID,
                             perry_ui_testkit::exit_delay_ms(),
                             None,
@@ -754,7 +754,7 @@ pub fn app_set_level(app_handle: i64, value_ptr: *const u8) {
                         "modal" => HWND_TOPMOST,
                         _ => HWND_NOTOPMOST,
                     };
-                    let _ = SetWindowPos(hwnd, insert_after, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+                    let _ = SetWindowPos(hwnd, Some(insert_after), 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
                 }
             }
         });
@@ -894,7 +894,7 @@ pub fn set_timer(interval_ms: f64, callback: f64) {
                 let apps = apps.borrow();
                 if let Some(app) = apps.first() {
                     unsafe {
-                        let _ = SetTimer(app.hwnd, timer_id, ms, None);
+                        let _ = SetTimer(Some(app.hwnd), timer_id, ms, None);
                     }
                 }
             });
@@ -936,7 +936,7 @@ pub fn handle_timer(hwnd: HWND, timer_id: usize) {
     // PERRY_UI_TEST_MODE exit: capture screenshot (if configured), then exit.
     if timer_id == TEST_EXIT_TIMER_ID {
         unsafe {
-            let _ = KillTimer(hwnd, TEST_EXIT_TIMER_ID);
+            let _ = KillTimer(Some(hwnd), TEST_EXIT_TIMER_ID);
         }
         if let Some(path) = perry_ui_testkit::screenshot_path() {
             let mut len: usize = 0;
@@ -1027,7 +1027,7 @@ pub fn request_layout() {
             if let Some(app) = apps.first() {
                 if app.root_widget.is_some() {
                     unsafe {
-                        let _ = PostMessageW(app.hwnd, WM_PERRY_LAYOUT, WPARAM(0), LPARAM(0));
+                        let _ = PostMessageW(Some(app.hwnd), WM_PERRY_LAYOUT, WPARAM(0), LPARAM(0));
                     }
                 }
             }
@@ -1051,7 +1051,7 @@ fn do_layout() {
                                 let _ = MoveWindow(child_hwnd, 0, 0, rect.right, rect.bottom, true);
                                 crate::layout::layout_widget(root, rect.right, rect.bottom);
                             }
-                            let _ = InvalidateRect(app.hwnd, None, true);
+                            let _ = InvalidateRect(Some(app.hwnd), None, true);
                         }
                     }
                 }
@@ -1081,7 +1081,7 @@ unsafe extern "system" fn wnd_proc(
                     let _ = MoveWindow(child_hwnd, 0, 0, width, height, true);
                     crate::layout::layout_widget(root, width, height);
                     // Set a one-shot timer to force repaint
-                    let _ = SetTimer(hwnd, 9999, 500, None);
+                    let _ = SetTimer(Some(hwnd), 9999, 500, None);
                 }
             }
             LRESULT(0)
@@ -1144,7 +1144,7 @@ unsafe extern "system" fn wnd_proc(
             };
             let target = WindowFromPoint(cursor_pos);
             if !target.is_invalid() && target != hwnd {
-                return SendMessageW(target, msg, wparam, lparam);
+                return SendMessageW(target, msg, Some(wparam), Some(lparam));
             }
             DefWindowProcW(hwnd, msg, wparam, lparam)
         }
@@ -1228,7 +1228,7 @@ unsafe extern "system" fn wnd_proc(
         WM_TIMER => {
             let timer_id = wparam.0;
             if timer_id == 9999 {
-                let _ = KillTimer(hwnd, 9999);
+                let _ = KillTimer(Some(hwnd), 9999);
                 if let Some(root) = get_root_widget(1) {
                     crate::layout::force_paint_backgrounds(root);
                 }

--- a/crates/perry-ui-windows/src/app.rs
+++ b/crates/perry-ui-windows/src/app.rs
@@ -754,7 +754,15 @@ pub fn app_set_level(app_handle: i64, value_ptr: *const u8) {
                         "modal" => HWND_TOPMOST,
                         _ => HWND_NOTOPMOST,
                     };
-                    let _ = SetWindowPos(hwnd, Some(insert_after), 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
+                    let _ = SetWindowPos(
+                        hwnd,
+                        Some(insert_after),
+                        0,
+                        0,
+                        0,
+                        0,
+                        SWP_NOMOVE | SWP_NOSIZE,
+                    );
                 }
             }
         });

--- a/crates/perry-ui-windows/src/clipboard.rs
+++ b/crates/perry-ui-windows/src/clipboard.rs
@@ -101,7 +101,7 @@ pub fn write(text_ptr: *const u8) {
                 let _ = GlobalUnlock(hmem);
             }
 
-            let _ = SetClipboardData(CF_UNICODETEXT.0 as u32, HANDLE(hmem.0));
+            let _ = SetClipboardData(CF_UNICODETEXT.0 as u32, Some(HANDLE(hmem.0)));
             let _ = CloseClipboard();
         }
     }

--- a/crates/perry-ui-windows/src/drag_drop.rs
+++ b/crates/perry-ui-windows/src/drag_drop.rs
@@ -153,9 +153,9 @@ fn has_any_drag_source(key: usize) -> bool {
 #[cfg(target_os = "windows")]
 mod imp {
     use super::*;
-    use windows::core::{implement, PCWSTR};
+    use windows::core::{implement, BOOL, PCWSTR};
     use windows::Win32::Foundation::{
-        BOOL, DRAGDROP_S_CANCEL, DRAGDROP_S_DROP, DRAGDROP_S_USEDEFAULTCURSORS, DV_E_FORMATETC,
+        DRAGDROP_S_CANCEL, DRAGDROP_S_DROP, DRAGDROP_S_USEDEFAULTCURSORS, DV_E_FORMATETC,
         DV_E_TYMED, E_NOTIMPL, HGLOBAL, HWND, LPARAM, LRESULT, OLE_E_ADVISENOTSUPPORTED, POINT,
         POINTL, S_OK, WPARAM,
     };
@@ -307,7 +307,7 @@ mod imp {
             &self,
             _pformatetc: *const FORMATETC,
             _advf: u32,
-            _padvsink: Option<&IAdviseSink>,
+            _padvsink: windows::core::Ref<'_, IAdviseSink>,
         ) -> windows::core::Result<u32> {
             Err(OLE_E_ADVISENOTSUPPORTED.into())
         }
@@ -365,7 +365,7 @@ mod imp {
     impl IDropTarget_Impl for PerryDropTarget_Impl {
         fn DragEnter(
             &self,
-            _pdataobj: Option<&IDataObject>,
+            _pdataobj: windows::core::Ref<'_, IDataObject>,
             _grfkeystate: MODIFIERKEYS_FLAGS,
             _pt: &POINTL,
             pdweffect: *mut DROPEFFECT,
@@ -398,7 +398,7 @@ mod imp {
 
         fn Drop(
             &self,
-            pdataobj: Option<&IDataObject>,
+            pdataobj: windows::core::Ref<'_, IDataObject>,
             _grfkeystate: MODIFIERKEYS_FLAGS,
             _pt: &POINTL,
             pdweffect: *mut DROPEFFECT,
@@ -412,7 +412,7 @@ mod imp {
             let Some(cb) = cb else {
                 return Ok(());
             };
-            let Some(data) = pdataobj else {
+            let Some(data) = pdataobj.as_ref() else {
                 return Ok(());
             };
             unsafe {

--- a/crates/perry-ui-windows/src/layout.rs
+++ b/crates/perry-ui-windows/src/layout.rs
@@ -574,14 +574,14 @@ fn measure_stack_intrinsic(handle: i64, kind: &WidgetKind, vertical: bool, cross
 #[cfg(target_os = "windows")]
 fn measure_text_height(hwnd: HWND, width: i32, vertical: bool) -> i32 {
     unsafe {
-        let hdc = GetDC(hwnd);
+        let hdc = GetDC(Some(hwnd));
         if hdc.is_invalid() {
             return if vertical { 20 } else { 100 };
         }
 
         let text_len = GetWindowTextLengthW(hwnd);
         if text_len == 0 {
-            let _ = ReleaseDC(hwnd, hdc);
+            let _ = ReleaseDC(Some(hwnd), hdc);
             return if vertical { 20 } else { 100 };
         }
 
@@ -589,9 +589,9 @@ fn measure_text_height(hwnd: HWND, width: i32, vertical: bool) -> i32 {
         GetWindowTextW(hwnd, &mut buf);
 
         // Send WM_GETFONT to get the current font
-        let hfont = HFONT(SendMessageW(hwnd, WM_GETFONT, WPARAM(0), LPARAM(0)).0 as *mut _);
+        let hfont = HFONT(SendMessageW(hwnd, WM_GETFONT, Some(WPARAM(0)), Some(LPARAM(0))).0 as *mut _);
         let old_font = if !hfont.is_invalid() {
-            SelectObject(hdc, hfont)
+            SelectObject(hdc, hfont.into())
         } else {
             HGDIOBJ::default()
         };
@@ -613,7 +613,7 @@ fn measure_text_height(hwnd: HWND, width: i32, vertical: bool) -> i32 {
             if !old_font.is_invalid() {
                 SelectObject(hdc, old_font);
             }
-            let _ = ReleaseDC(hwnd, hdc);
+            let _ = ReleaseDC(Some(hwnd), hdc);
 
             (rect.bottom - rect.top).max(16)
         } else {
@@ -623,7 +623,7 @@ fn measure_text_height(hwnd: HWND, width: i32, vertical: bool) -> i32 {
             if !old_font.is_invalid() {
                 SelectObject(hdc, old_font);
             }
-            let _ = ReleaseDC(hwnd, hdc);
+            let _ = ReleaseDC(Some(hwnd), hdc);
 
             size.cx.max(20)
         }
@@ -637,7 +637,7 @@ pub fn force_paint_backgrounds(handle: i64) {
         if let Some(hwnd) = widgets::get_hwnd_safe(handle) {
             if widgets::get_bg_brush(handle).is_some() {
                 unsafe {
-                    let _ = InvalidateRect(hwnd, None, true);
+                    let _ = InvalidateRect(Some(hwnd), None, true);
                     let _ = UpdateWindow(hwnd);
                 }
             }

--- a/crates/perry-ui-windows/src/layout.rs
+++ b/crates/perry-ui-windows/src/layout.rs
@@ -589,7 +589,8 @@ fn measure_text_height(hwnd: HWND, width: i32, vertical: bool) -> i32 {
         GetWindowTextW(hwnd, &mut buf);
 
         // Send WM_GETFONT to get the current font
-        let hfont = HFONT(SendMessageW(hwnd, WM_GETFONT, Some(WPARAM(0)), Some(LPARAM(0))).0 as *mut _);
+        let hfont =
+            HFONT(SendMessageW(hwnd, WM_GETFONT, Some(WPARAM(0)), Some(LPARAM(0))).0 as *mut _);
         let old_font = if !hfont.is_invalid() {
             SelectObject(hdc, hfont.into())
         } else {

--- a/crates/perry-ui-windows/src/media_playback.rs
+++ b/crates/perry-ui-windows/src/media_playback.rs
@@ -323,16 +323,19 @@ pub fn set_now_playing(
         if !entry.smtc_installed {
             use windows::Foundation::TypedEventHandler;
             let player_handle = handle;
-            let _ = smtc.ButtonPressed(&TypedEventHandler::new(move |_, args| {
-                if let Some(args) = args {
-                    let args: &windows::Media::SystemMediaTransportControlsButtonPressedEventArgs =
-                        args;
-                    if let Ok(button) = args.Button() {
-                        enqueue_button(player_handle, button);
+            let _ = smtc.ButtonPressed(&TypedEventHandler::new(
+                move |_: windows::core::Ref<windows::Media::SystemMediaTransportControls>,
+                      args: windows::core::Ref<
+                    windows::Media::SystemMediaTransportControlsButtonPressedEventArgs,
+                >| {
+                    if let Some(args) = args.as_ref() {
+                        if let Ok(button) = args.Button() {
+                            enqueue_button(player_handle, button);
+                        }
                     }
-                }
-                Ok(())
-            }));
+                    Ok(())
+                },
+            ));
             entry.smtc_installed = true;
         }
 

--- a/crates/perry-ui-windows/src/menu.rs
+++ b/crates/perry-ui-windows/src/menu.rs
@@ -332,7 +332,7 @@ fn attach_menubar_to_hwnd(bar_handle: i64, hwnd: HWND) {
         let bar_idx = (bar_handle - 1) as usize;
         if bar_idx < bars.len() {
             unsafe {
-                let _ = SetMenu(hwnd, bars[bar_idx].hmenu);
+                let _ = SetMenu(hwnd, Some(bars[bar_idx].hmenu));
                 let _ = DrawMenuBar(hwnd);
             }
         }
@@ -392,7 +392,7 @@ pub fn handle_context_menu(parent_hwnd: HWND, child_hwnd: HWND, x: i32, y: i32) 
                     TPM_RETURNCMD | TPM_LEFTALIGN | TPM_TOPALIGN,
                     x,
                     y,
-                    0,
+                    Some(0),
                     parent_hwnd,
                     None,
                 );
@@ -420,7 +420,7 @@ pub fn clear(menu_handle: i64) {
             {
                 let hmenu = menus[idx].hmenu;
                 unsafe {
-                    while GetMenuItemCount(hmenu) > 0 {
+                    while GetMenuItemCount(Some(hmenu)) > 0 {
                         let _ = RemoveMenu(hmenu, 0, MF_BYPOSITION);
                     }
                 }

--- a/crates/perry-ui-windows/src/screenshot.rs
+++ b/crates/perry-ui-windows/src/screenshot.rs
@@ -45,22 +45,22 @@ pub extern "C" fn perry_ui_screenshot_capture(out_len: *mut usize) -> *mut u8 {
             }
 
             // Create a memory DC and compatible bitmap
-            let hdc_window = GetDC(hwnd);
+            let hdc_window = GetDC(Some(hwnd));
             if hdc_window.is_invalid() {
                 return std::ptr::null_mut();
             }
-            let hdc_mem = CreateCompatibleDC(hdc_window);
+            let hdc_mem = CreateCompatibleDC(Some(hdc_window));
             if hdc_mem.is_invalid() {
-                ReleaseDC(hwnd, hdc_window);
+                ReleaseDC(Some(hwnd), hdc_window);
                 return std::ptr::null_mut();
             }
             let hbm = CreateCompatibleBitmap(hdc_window, width, height);
             if hbm.is_invalid() {
                 DeleteDC(hdc_mem);
-                ReleaseDC(hwnd, hdc_window);
+                ReleaseDC(Some(hwnd), hdc_window);
                 return std::ptr::null_mut();
             }
-            let old_bm = SelectObject(hdc_mem, hbm);
+            let old_bm = SelectObject(hdc_mem, hbm.into());
 
             // Capture the window using PrintWindow (PW_RENDERFULLCONTENT = 2)
             let _ = PrintWindow(hwnd, hdc_mem, PRINT_WINDOW_FLAGS(2));
@@ -95,9 +95,9 @@ pub extern "C" fn perry_ui_screenshot_capture(out_len: *mut usize) -> *mut u8 {
 
             // Cleanup GDI
             SelectObject(hdc_mem, old_bm);
-            let _ = DeleteObject(hbm);
+            let _ = DeleteObject(hbm.into());
             DeleteDC(hdc_mem);
-            ReleaseDC(hwnd, hdc_window);
+            ReleaseDC(Some(hwnd), hdc_window);
 
             if lines == 0 {
                 return std::ptr::null_mut();

--- a/crates/perry-ui-windows/src/sheet.rs
+++ b/crates/perry-ui-windows/src/sheet.rs
@@ -77,7 +77,7 @@ pub fn create(_body_handle: i64, width: f64, height: f64) -> i64 {
                 height as i32,
                 None,
                 None,
-                HINSTANCE::from(hinstance),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();

--- a/crates/perry-ui-windows/src/system.rs
+++ b/crates/perry-ui-windows/src/system.rs
@@ -156,7 +156,7 @@ pub fn is_dark_mode() -> i64 {
             if RegOpenKeyExW(
                 HKEY_CURRENT_USER,
                 PCWSTR(key_wide.as_ptr()),
-                0,
+                Some(0),
                 KEY_READ,
                 &mut hkey,
             )

--- a/crates/perry-ui-windows/src/toolbar.rs
+++ b/crates/perry-ui-windows/src/toolbar.rs
@@ -94,9 +94,9 @@ pub fn create() -> i64 {
                 0,
                 800,
                 32,
-                parking,
+                Some(parking),
                 None,
-                HINSTANCE::from(hinstance),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();
@@ -158,9 +158,9 @@ pub fn add_item(toolbar_handle: i64, label_ptr: *const u8, icon_ptr: *const u8, 
                         2,
                         76,
                         28,
-                        *parent,
+                        Some(*parent),
                         None,
-                        HINSTANCE::from(hinstance),
+                        Some(HINSTANCE::from(hinstance)),
                         None,
                     );
                 }
@@ -185,7 +185,7 @@ pub fn attach(toolbar_handle: i64) {
                     let apps = apps.borrow();
                     if let Some(app) = apps.first() {
                         unsafe {
-                            let _ = SetParent(*toolbar_hwnd, app.hwnd);
+                            let _ = SetParent(*toolbar_hwnd, Some(app.hwnd));
                         }
                     }
                 });

--- a/crates/perry-ui-windows/src/tray.rs
+++ b/crates/perry-ui-windows/src/tray.rs
@@ -401,7 +401,7 @@ pub fn handle_callback_message(wparam: usize, lparam: isize) {
                             TPM_RETURNCMD | TPM_RIGHTBUTTON | TPM_LEFTALIGN | TPM_BOTTOMALIGN,
                             pt.x,
                             pt.y,
-                            0,
+                            Some(0),
                             hwnd,
                             None,
                         );

--- a/crates/perry-ui-windows/src/widgets/attributed_text.rs
+++ b/crates/perry-ui-windows/src/widgets/attributed_text.rs
@@ -197,7 +197,8 @@ pub fn append(
 
         unsafe {
             // Move caret to end-of-text and insert the new substring.
-            let end_total: isize = SendMessageW(hwnd, EM_GETTEXTLENGTH, Some(WPARAM(0)), Some(LPARAM(0))).0;
+            let end_total: isize =
+                SendMessageW(hwnd, EM_GETTEXTLENGTH, Some(WPARAM(0)), Some(LPARAM(0))).0;
             SendMessageW(
                 hwnd,
                 EM_SETSEL,

--- a/crates/perry-ui-windows/src/widgets/attributed_text.rs
+++ b/crates/perry-ui-windows/src/widgets/attributed_text.rs
@@ -139,9 +139,9 @@ pub fn create() -> i64 {
                 0,
                 200,
                 40,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             );
             let Ok(hwnd) = hwnd else {
@@ -197,18 +197,18 @@ pub fn append(
 
         unsafe {
             // Move caret to end-of-text and insert the new substring.
-            let end_total: isize = SendMessageW(hwnd, EM_GETTEXTLENGTH, WPARAM(0), LPARAM(0)).0;
+            let end_total: isize = SendMessageW(hwnd, EM_GETTEXTLENGTH, Some(WPARAM(0)), Some(LPARAM(0))).0;
             SendMessageW(
                 hwnd,
                 EM_SETSEL,
-                WPARAM(end_total as usize),
-                LPARAM(end_total),
+                Some(WPARAM(end_total as usize)),
+                Some(LPARAM(end_total)),
             );
             SendMessageW(
                 hwnd,
                 EM_REPLACESEL,
-                WPARAM(0),
-                LPARAM(wide.as_ptr() as isize),
+                Some(WPARAM(0)),
+                Some(LPARAM(wide.as_ptr() as isize)),
             );
 
             // Re-select the just-appended range and apply the attributes.
@@ -219,8 +219,8 @@ pub fn append(
             SendMessageW(
                 hwnd,
                 EM_EXSETSEL,
-                WPARAM(0),
-                LPARAM(&range as *const _ as isize),
+                Some(WPARAM(0)),
+                Some(LPARAM(&range as *const _ as isize)),
             );
 
             let mut cf = CharFormat2W::default();
@@ -252,8 +252,8 @@ pub fn append(
                 SendMessageW(
                     hwnd,
                     EM_SETCHARFORMAT,
-                    WPARAM(SCF_SELECTION as usize),
-                    LPARAM(&cf as *const _ as isize),
+                    Some(WPARAM(SCF_SELECTION as usize)),
+                    Some(LPARAM(&cf as *const _ as isize)),
                 );
             }
 
@@ -262,8 +262,8 @@ pub fn append(
             SendMessageW(
                 hwnd,
                 EM_SETSEL,
-                WPARAM(new_end as usize),
-                LPARAM(new_end as isize),
+                Some(WPARAM(new_end as usize)),
+                Some(LPARAM(new_end as isize)),
             );
         }
 
@@ -287,13 +287,13 @@ pub fn clear(handle: i64) {
         };
         unsafe {
             // Select-all + replace-with-empty.
-            SendMessageW(hwnd, EM_SETSEL, WPARAM(0), LPARAM(-1));
+            SendMessageW(hwnd, EM_SETSEL, Some(WPARAM(0)), Some(LPARAM(-1)));
             let empty: [u16; 1] = [0];
             SendMessageW(
                 hwnd,
                 EM_REPLACESEL,
-                WPARAM(0),
-                LPARAM(empty.as_ptr() as isize),
+                Some(WPARAM(0)),
+                Some(LPARAM(empty.as_ptr() as isize)),
             );
         }
         LENGTHS.with(|l| {

--- a/crates/perry-ui-windows/src/widgets/bottom_nav.rs
+++ b/crates/perry-ui-windows/src/widgets/bottom_nav.rs
@@ -100,9 +100,9 @@ pub fn create(on_select: f64) -> i64 {
                 0,
                 400,
                 56,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();
@@ -175,9 +175,9 @@ pub fn add_item(handle: i64, icon_ptr: *const u8, label_ptr: *const u8) {
                 0,
                 80,
                 48,
-                parent_hwnd,
-                HMENU(item_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(parent_hwnd),
+                Some(HMENU(item_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             );
             let Ok(btn) = btn else { return };
@@ -316,7 +316,7 @@ pub fn set_tint_color(handle: i64, r: f64, g: f64, b: f64, _a: f64) {
             for item in &entry.items {
                 unsafe {
                     let _ =
-                        windows::Win32::Graphics::Gdi::InvalidateRect(item.btn_hwnd, None, true);
+                        windows::Win32::Graphics::Gdi::InvalidateRect(Some(item.btn_hwnd), None, true);
                 }
             }
         }
@@ -333,7 +333,7 @@ pub fn set_unselected_tint_color(handle: i64, r: f64, g: f64, b: f64, _a: f64) {
             for item in &entry.items {
                 unsafe {
                     let _ =
-                        windows::Win32::Graphics::Gdi::InvalidateRect(item.btn_hwnd, None, true);
+                        windows::Win32::Graphics::Gdi::InvalidateRect(Some(item.btn_hwnd), None, true);
                 }
             }
         }

--- a/crates/perry-ui-windows/src/widgets/bottom_nav.rs
+++ b/crates/perry-ui-windows/src/widgets/bottom_nav.rs
@@ -315,8 +315,11 @@ pub fn set_tint_color(handle: i64, r: f64, g: f64, b: f64, _a: f64) {
             #[cfg(target_os = "windows")]
             for item in &entry.items {
                 unsafe {
-                    let _ =
-                        windows::Win32::Graphics::Gdi::InvalidateRect(Some(item.btn_hwnd), None, true);
+                    let _ = windows::Win32::Graphics::Gdi::InvalidateRect(
+                        Some(item.btn_hwnd),
+                        None,
+                        true,
+                    );
                 }
             }
         }
@@ -332,8 +335,11 @@ pub fn set_unselected_tint_color(handle: i64, r: f64, g: f64, b: f64, _a: f64) {
             #[cfg(target_os = "windows")]
             for item in &entry.items {
                 unsafe {
-                    let _ =
-                        windows::Win32::Graphics::Gdi::InvalidateRect(Some(item.btn_hwnd), None, true);
+                    let _ = windows::Win32::Graphics::Gdi::InvalidateRect(
+                        Some(item.btn_hwnd),
+                        None,
+                        true,
+                    );
                 }
             }
         }

--- a/crates/perry-ui-windows/src/widgets/button.rs
+++ b/crates/perry-ui-windows/src/widgets/button.rs
@@ -239,7 +239,12 @@ pub fn set_image(handle: i64, name_ptr: *const u8) {
             let font =
                 crate::widgets::text::create_font_with_family_pub(20, 400, "Segoe UI Symbol");
             unsafe {
-                SendMessageW(hwnd, WM_SETFONT, Some(WPARAM(font.0 as usize)), Some(LPARAM(1)));
+                SendMessageW(
+                    hwnd,
+                    WM_SETFONT,
+                    Some(WPARAM(font.0 as usize)),
+                    Some(LPARAM(1)),
+                );
             }
         }
     }

--- a/crates/perry-ui-windows/src/widgets/button.rs
+++ b/crates/perry-ui-windows/src/widgets/button.rs
@@ -71,9 +71,9 @@ pub fn create(label_ptr: *const u8, on_press: f64) -> i64 {
                 0,
                 100,
                 34,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();
@@ -148,7 +148,7 @@ pub fn set_bordered(handle: i64, bordered: bool) {
                 if !bordered {
                     BTN_HWND_TO_HANDLE.with(|m| m.borrow_mut().insert(hwnd.0 as isize, handle));
                 }
-                let _ = InvalidateRect(hwnd, None, true);
+                let _ = InvalidateRect(Some(hwnd), None, true);
             }
         }
     }
@@ -239,7 +239,7 @@ pub fn set_image(handle: i64, name_ptr: *const u8) {
             let font =
                 crate::widgets::text::create_font_with_family_pub(20, 400, "Segoe UI Symbol");
             unsafe {
-                SendMessageW(hwnd, WM_SETFONT, WPARAM(font.0 as usize), LPARAM(1));
+                SendMessageW(hwnd, WM_SETFONT, Some(WPARAM(font.0 as usize)), Some(LPARAM(1)));
             }
         }
     }
@@ -268,7 +268,7 @@ pub fn set_text_color(handle: i64, r: f64, g: f64, b: f64, _a: f64) {
                 let style = GetWindowLongW(hwnd, GWL_STYLE) as u32;
                 let new_style = (style & !0x0F) | BS_OWNERDRAW as u32;
                 SetWindowLongW(hwnd, GWL_STYLE, new_style as i32);
-                let _ = InvalidateRect(hwnd, None, true);
+                let _ = InvalidateRect(Some(hwnd), None, true);
             }
         }
     }
@@ -312,11 +312,11 @@ pub fn handle_draw_item(lparam: LPARAM) -> bool {
                     8,
                 );
                 windows::Win32::Graphics::Gdi::FillRgn(hdc, rgn, brush);
-                let _ = windows::Win32::Graphics::Gdi::DeleteObject(rgn);
+                let _ = windows::Win32::Graphics::Gdi::DeleteObject(rgn.into());
             } else {
                 FillRect(hdc, &rect, brush);
             }
-            let _ = windows::Win32::Graphics::Gdi::DeleteObject(brush);
+            let _ = windows::Win32::Graphics::Gdi::DeleteObject(brush.into());
         }
 
         // Draw centered text
@@ -324,10 +324,10 @@ pub fn handle_draw_item(lparam: LPARAM) -> bool {
         SetBkMode(hdc, TRANSPARENT);
 
         let hfont = windows::Win32::Graphics::Gdi::HFONT(
-            SendMessageW(dis.hwndItem, WM_GETFONT, WPARAM(0), LPARAM(0)).0 as *mut _,
+            SendMessageW(dis.hwndItem, WM_GETFONT, Some(WPARAM(0)), Some(LPARAM(0))).0 as *mut _,
         );
         let old_font = if !hfont.is_invalid() {
-            SelectObject(hdc, hfont)
+            SelectObject(hdc, hfont.into())
         } else {
             HGDIOBJ::default()
         };

--- a/crates/perry-ui-windows/src/widgets/calendar.rs
+++ b/crates/perry-ui-windows/src/widgets/calendar.rs
@@ -72,9 +72,9 @@ pub fn create(year: i64, month: i64, on_change: f64) -> i64 {
                 0,
                 240,
                 180,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             );
             let Ok(hwnd) = hwnd else {
@@ -105,8 +105,8 @@ pub fn create(year: i64, month: i64, on_change: f64) -> i64 {
             let _ = SendMessageW(
                 hwnd,
                 MCM_SETCURSEL,
-                WPARAM(0),
-                LPARAM(&st as *const _ as isize),
+                Some(WPARAM(0)),
+                Some(LPARAM(&st as *const _ as isize)),
             );
             handle
         }
@@ -133,8 +133,8 @@ pub fn set_date(handle: i64, year: i64, month: i64, day: i64) {
             SendMessageW(
                 hwnd,
                 MCM_SETCURSEL,
-                WPARAM(0),
-                LPARAM(&st as *const _ as isize),
+                Some(WPARAM(0)),
+                Some(LPARAM(&st as *const _ as isize)),
             );
         }
     }
@@ -156,8 +156,8 @@ pub fn get_selected_date(handle: i64) -> f64 {
             SendMessageW(
                 hwnd,
                 MCM_GETCURSEL,
-                WPARAM(0),
-                LPARAM(&mut st as *mut _ as isize),
+                Some(WPARAM(0)),
+                Some(LPARAM(&mut st as *mut _ as isize)),
             );
         }
         let iso = format!("{:04}-{:02}-{:02}", st.year, st.month, st.day);
@@ -191,8 +191,8 @@ pub fn handle_selection_change(handle: i64) {
         SendMessageW(
             hwnd,
             MCM_GETCURSEL,
-            WPARAM(0),
-            LPARAM(&mut st as *mut _ as isize),
+            Some(WPARAM(0)),
+            Some(LPARAM(&mut st as *mut _ as isize)),
         );
     }
     let iso = format!("{:04}-{:02}-{:02}", st.year, st.month, st.day);

--- a/crates/perry-ui-windows/src/widgets/canvas.rs
+++ b/crates/perry-ui-windows/src/widgets/canvas.rs
@@ -207,7 +207,7 @@ fn paint_canvas(handle: i64, hwnd: HWND) {
                     DrawCmd::Stroke(r, g, b, _a, width) => {
                         let color = COLORREF((r as u32) | ((g as u32) << 8) | ((b as u32) << 16));
                         let pen = CreatePen(PS_SOLID, width as i32, color);
-                        let old_pen = SelectObject(hdc, pen);
+                        let old_pen = SelectObject(hdc, pen.into());
 
                         let mut first = true;
                         for &(px, py) in &path_points {
@@ -221,7 +221,7 @@ fn paint_canvas(handle: i64, hwnd: HWND) {
 
                         SelectObject(hdc, old_pen);
                         if !current_pen.is_invalid() {
-                            let _ = DeleteObject(current_pen);
+                            let _ = DeleteObject(current_pen.into());
                         }
                         current_pen = pen;
                     }
@@ -259,7 +259,7 @@ fn paint_canvas(handle: i64, hwnd: HWND) {
                                 }
                             };
                             let _ = FillRect(hdc, &band, brush);
-                            let _ = DeleteObject(brush);
+                            let _ = DeleteObject(brush.into());
                         }
                     }
                     DrawCmd::DrawImage(image, sx, sy, sw, sh, dx, dy, dw, dh) => {
@@ -326,7 +326,7 @@ fn paint_canvas(handle: i64, hwnd: HWND) {
             }
 
             if !current_pen.is_invalid() {
-                let _ = DeleteObject(current_pen);
+                let _ = DeleteObject(current_pen.into());
             }
         }
 
@@ -352,9 +352,9 @@ pub fn create(width: f64, height: f64) -> i64 {
                 0,
                 width as i32,
                 height as i32,
-                super::get_parking_hwnd(),
+                Some(super::get_parking_hwnd()),
                 None,
-                HINSTANCE::from(hinstance),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();
@@ -399,7 +399,7 @@ fn invalidate(handle: i64) {
     {
         if let Some(hwnd) = super::get_hwnd(handle) {
             unsafe {
-                let _ = InvalidateRect(hwnd, None, false);
+                let _ = InvalidateRect(Some(hwnd), None, false);
             }
         }
     }

--- a/crates/perry-ui-windows/src/widgets/chart.rs
+++ b/crates/perry-ui-windows/src/widgets/chart.rs
@@ -197,16 +197,16 @@ unsafe fn draw_line(hdc: HDC, plot: &RECT, data: &[(String, f64)]) {
 
     // Baseline along the bottom of the plot rect.
     let axis_pen = CreatePen(PS_SOLID, 1, rgb(178, 178, 178));
-    let old = SelectObject(hdc, axis_pen);
+    let old = SelectObject(hdc, axis_pen.into());
     MoveToEx(hdc, plot.left, plot.bottom, None);
     let _ = LineTo(hdc, plot.right, plot.bottom);
     SelectObject(hdc, old);
-    let _ = DeleteObject(axis_pen);
+    let _ = DeleteObject(axis_pen.into());
 
     // Series.
     let (r, g, b) = PALETTE_RGB[0];
     let pen = CreatePen(PS_SOLID, 2, rgb(r, g, b));
-    let old = SelectObject(hdc, pen);
+    let old = SelectObject(hdc, pen.into());
     for (i, (_, v)) in data.iter().enumerate() {
         let px = plot.left + (i as f64 * dx) as i32;
         // Win32 GDI origin is top-left like Cairo; flip y so big values
@@ -219,7 +219,7 @@ unsafe fn draw_line(hdc: HDC, plot: &RECT, data: &[(String, f64)]) {
         }
     }
     SelectObject(hdc, old);
-    let _ = DeleteObject(pen);
+    let _ = DeleteObject(pen.into());
 }
 
 #[cfg(target_os = "windows")]
@@ -247,7 +247,7 @@ unsafe fn draw_bars(hdc: HDC, plot: &RECT, data: &[(String, f64)]) {
             bottom: plot.bottom,
         };
         let _ = FillRect(hdc, &bar_rect, brush);
-        let _ = DeleteObject(brush);
+        let _ = DeleteObject(brush.into());
     }
 }
 
@@ -284,8 +284,8 @@ unsafe fn draw_pie(hdc: HDC, plot: &RECT, data: &[(String, f64)]) {
         let (cr, cg, cb) = PALETTE_RGB[i % PALETTE_RGB.len()];
         let brush = CreateSolidBrush(rgb(cr, cg, cb));
         let pen = CreatePen(PS_SOLID, 1, rgb(255, 255, 255));
-        let old_brush = SelectObject(hdc, brush);
-        let old_pen = SelectObject(hdc, pen);
+        let old_brush = SelectObject(hdc, brush.into());
+        let old_pen = SelectObject(hdc, pen.into());
         // GDI Pie() with same start and end isn't valid; skip empty
         // wedges produced by a 0-frac entry.
         if (end_angle - start_angle).abs() > 1e-6 {
@@ -293,8 +293,8 @@ unsafe fn draw_pie(hdc: HDC, plot: &RECT, data: &[(String, f64)]) {
         }
         SelectObject(hdc, old_brush);
         SelectObject(hdc, old_pen);
-        let _ = DeleteObject(brush);
-        let _ = DeleteObject(pen);
+        let _ = DeleteObject(brush.into());
+        let _ = DeleteObject(pen.into());
         start_angle = end_angle;
     }
 }
@@ -323,9 +323,9 @@ pub fn create(kind: i64, width: f64, height: f64) -> i64 {
                 0,
                 width.max(40.0) as i32,
                 height.max(40.0) as i32,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             );
             let Ok(hwnd) = hwnd else {
@@ -404,7 +404,7 @@ fn request_redraw(handle: i64) {
             return;
         };
         unsafe {
-            let _ = InvalidateRect(hwnd, None, true);
+            let _ = InvalidateRect(Some(hwnd), None, true);
         }
     }
     #[cfg(not(target_os = "windows"))]

--- a/crates/perry-ui-windows/src/widgets/combobox.rs
+++ b/crates/perry-ui-windows/src/widgets/combobox.rs
@@ -86,9 +86,9 @@ pub fn create(initial_ptr: *const u8, on_change: f64) -> i64 {
                 0,
                 220,
                 200,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             );
             let Ok(hwnd) = hwnd else {
@@ -126,8 +126,8 @@ pub fn add_item(handle: i64, value_ptr: *const u8) {
             SendMessageW(
                 hwnd,
                 CB_ADDSTRING,
-                WPARAM(0),
-                LPARAM(wide.as_ptr() as isize),
+                Some(WPARAM(0)),
+                Some(LPARAM(wide.as_ptr() as isize)),
             );
         }
     }
@@ -213,7 +213,7 @@ pub fn handle_dropdown_pick(handle: i64) {
         return;
     };
     unsafe {
-        let idx = SendMessageW(hwnd, CB_GETCURSEL, WPARAM(0), LPARAM(0)).0 as i32;
+        let idx = SendMessageW(hwnd, CB_GETCURSEL, Some(WPARAM(0)), Some(LPARAM(0))).0 as i32;
         if idx < 0 {
             return;
         }
@@ -221,8 +221,8 @@ pub fn handle_dropdown_pick(handle: i64) {
         SendMessageW(
             hwnd,
             CB_GETLBTEXT,
-            WPARAM(idx as usize),
-            LPARAM(buf.as_mut_ptr() as isize),
+            Some(WPARAM(idx as usize)),
+            Some(LPARAM(buf.as_mut_ptr() as isize)),
         );
         // Find null terminator + write back into edit field.
         let nul = buf.iter().position(|&c| c == 0).unwrap_or(buf.len());

--- a/crates/perry-ui-windows/src/widgets/command_palette.rs
+++ b/crates/perry-ui-windows/src/widgets/command_palette.rs
@@ -131,7 +131,7 @@ fn refresh_filter() {
         POPUP.with(|p| {
             if let Some((_, _, list_hwnd)) = *p.borrow() {
                 unsafe {
-                    SendMessageW(list_hwnd, LB_RESETCONTENT, WPARAM(0), LPARAM(0));
+                    SendMessageW(list_hwnd, LB_RESETCONTENT, Some(WPARAM(0)), Some(LPARAM(0)));
                     COMMANDS.with(|c| {
                         let cmds = c.borrow();
                         for &i in &filtered {
@@ -145,14 +145,14 @@ fn refresh_filter() {
                                 SendMessageW(
                                     list_hwnd,
                                     LB_ADDSTRING,
-                                    WPARAM(0),
-                                    LPARAM(wide.as_ptr() as isize),
+                                    Some(WPARAM(0)),
+                                    Some(LPARAM(wide.as_ptr() as isize)),
                                 );
                             }
                         }
                     });
                     if !filtered.is_empty() {
-                        SendMessageW(list_hwnd, LB_SETCURSEL, WPARAM(0), LPARAM(0));
+                        SendMessageW(list_hwnd, LB_SETCURSEL, Some(WPARAM(0)), Some(LPARAM(0)));
                     }
                 }
             }
@@ -172,7 +172,7 @@ pub fn show() {
                 if let Some((popup, edit, _)) = *p.borrow() {
                     unsafe {
                         let _ = ShowWindow(popup, SW_SHOW);
-                        let _ = SetFocus(edit);
+                        let _ = SetFocus(Some(edit));
                     }
                 }
             });
@@ -214,7 +214,7 @@ pub fn show() {
                 h,
                 None,
                 None,
-                HINSTANCE::from(hinstance),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();
@@ -230,9 +230,9 @@ pub fn show() {
                 10,
                 w - 20,
                 28,
-                popup,
-                HMENU(1 as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(popup),
+                Some(HMENU(1 as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();
@@ -248,9 +248,9 @@ pub fn show() {
                 48,
                 w - 20,
                 h - 60,
-                popup,
-                HMENU(2 as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(popup),
+                Some(HMENU(2 as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();
@@ -260,7 +260,7 @@ pub fn show() {
             refresh_filter();
 
             let _ = ShowWindow(popup, SW_SHOW);
-            let _ = SetFocus(edit);
+            let _ = SetFocus(Some(edit));
         }
     }
 }
@@ -282,7 +282,7 @@ pub fn hide() {
 fn run_selected() {
     let idx_in_listbox = POPUP.with(|p| {
         p.borrow().map(|(_, _, list)| unsafe {
-            SendMessageW(list, LB_GETCURSEL, WPARAM(0), LPARAM(0)).0 as i64
+            SendMessageW(list, LB_GETCURSEL, Some(WPARAM(0)), Some(LPARAM(0))).0 as i64
         })
     });
     let Some(idx) = idx_in_listbox else { return };

--- a/crates/perry-ui-windows/src/widgets/date_picker.rs
+++ b/crates/perry-ui-windows/src/widgets/date_picker.rs
@@ -94,9 +94,9 @@ pub fn create(year: i64, month: i64, on_change: f64) -> i64 {
                 0,
                 160,
                 28,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             );
             let Ok(hwnd) = hwnd else {
@@ -127,8 +127,8 @@ pub fn create(year: i64, month: i64, on_change: f64) -> i64 {
             let _ = SendMessageW(
                 hwnd,
                 DTM_SETSYSTEMTIME,
-                WPARAM(GDT_VALID),
-                LPARAM(&st as *const _ as isize),
+                Some(WPARAM(GDT_VALID)),
+                Some(LPARAM(&st as *const _ as isize)),
             );
             handle
         }
@@ -155,8 +155,8 @@ pub fn set_date(handle: i64, year: i64, month: i64, day: i64) {
             SendMessageW(
                 hwnd,
                 DTM_SETSYSTEMTIME,
-                WPARAM(GDT_VALID),
-                LPARAM(&st as *const _ as isize),
+                Some(WPARAM(GDT_VALID)),
+                Some(LPARAM(&st as *const _ as isize)),
             );
         }
     }
@@ -178,8 +178,8 @@ pub fn get_selected_date(handle: i64) -> f64 {
             SendMessageW(
                 hwnd,
                 DTM_GETSYSTEMTIME,
-                WPARAM(0),
-                LPARAM(&mut st as *mut _ as isize),
+                Some(WPARAM(0)),
+                Some(LPARAM(&mut st as *mut _ as isize)),
             );
         }
         let iso = format!("{:04}-{:02}-{:02}", st.year, st.month, st.day);
@@ -213,8 +213,8 @@ pub fn handle_selection_change(handle: i64) {
         SendMessageW(
             hwnd,
             DTM_GETSYSTEMTIME,
-            WPARAM(0),
-            LPARAM(&mut st as *mut _ as isize),
+            Some(WPARAM(0)),
+            Some(LPARAM(&mut st as *mut _ as isize)),
         );
     }
     let iso = format!("{:04}-{:02}-{:02}", st.year, st.month, st.day);

--- a/crates/perry-ui-windows/src/widgets/divider.rs
+++ b/crates/perry-ui-windows/src/widgets/divider.rs
@@ -35,9 +35,9 @@ pub fn create() -> i64 {
                 0,
                 100,
                 2,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();

--- a/crates/perry-ui-windows/src/widgets/form.rs
+++ b/crates/perry-ui-windows/src/widgets/form.rs
@@ -78,9 +78,9 @@ pub fn create() -> i64 {
                 0,
                 100,
                 100,
-                super::get_parking_hwnd(),
+                Some(super::get_parking_hwnd()),
                 None,
-                HINSTANCE::from(hinstance),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();
@@ -118,9 +118,9 @@ pub fn section_create(title_ptr: *const u8) -> i64 {
                 0,
                 200,
                 100,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();

--- a/crates/perry-ui-windows/src/widgets/hstack.rs
+++ b/crates/perry-ui-windows/src/widgets/hstack.rs
@@ -52,7 +52,7 @@ unsafe extern "system" fn container_wnd_proc(
     match msg {
         WM_CTLCOLORSTATIC | WM_CTLCOLORBTN => {
             if let Ok(parent) = GetParent(hwnd) {
-                let result = SendMessageW(parent, msg, wparam, lparam);
+                let result = SendMessageW(parent, msg, Some(wparam), Some(lparam));
                 if result.0 != 0 {
                     return result;
                 }
@@ -71,13 +71,13 @@ unsafe extern "system" fn container_wnd_proc(
         }
         WM_COMMAND | WM_CONTEXTMENU | WM_DRAWITEM => {
             if let Ok(parent) = GetParent(hwnd) {
-                return SendMessageW(parent, msg, wparam, lparam);
+                return SendMessageW(parent, msg, Some(wparam), Some(lparam));
             }
             DefWindowProcW(hwnd, msg, wparam, lparam)
         }
         x if x == 0x0133 /* WM_CTLCOLOREDIT */ => {
             if let Ok(parent) = GetParent(hwnd) {
-                return SendMessageW(parent, msg, wparam, lparam);
+                return SendMessageW(parent, msg, Some(wparam), Some(lparam));
             }
             DefWindowProcW(hwnd, msg, wparam, lparam)
         }
@@ -115,7 +115,7 @@ unsafe extern "system" fn container_wnd_proc(
                     let mut rect = RECT::default();
                     let _ = GetClientRect(hwnd, &mut rect);
                     let _ = FillRect(hdc, &rect, brush);
-                    let _ = windows::Win32::Graphics::Gdi::DeleteObject(brush);
+                    let _ = windows::Win32::Graphics::Gdi::DeleteObject(brush.into());
                     return LRESULT(1);
                 } else {
                     let mut ps = windows::Win32::Graphics::Gdi::PAINTSTRUCT::default();
@@ -123,7 +123,7 @@ unsafe extern "system" fn container_wnd_proc(
                     let mut rect = RECT::default();
                     let _ = GetClientRect(hwnd, &mut rect);
                     let _ = FillRect(hdc, &rect, brush);
-                    let _ = windows::Win32::Graphics::Gdi::DeleteObject(brush);
+                    let _ = windows::Win32::Graphics::Gdi::DeleteObject(brush.into());
                     windows::Win32::Graphics::Gdi::EndPaint(hwnd, &ps);
                     return LRESULT(0);
                 }
@@ -179,9 +179,9 @@ pub fn create_with_insets(spacing: f64, top: f64, left: f64, bottom: f64, right:
                 0,
                 100,
                 100,
-                super::get_parking_hwnd(),
+                Some(super::get_parking_hwnd()),
                 None,
-                HINSTANCE::from(hinstance),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();

--- a/crates/perry-ui-windows/src/widgets/image.rs
+++ b/crates/perry-ui-windows/src/widgets/image.rs
@@ -214,7 +214,7 @@ unsafe extern "system" fn image_wnd_proc(
             // Background WinHTTP fetch finished — bytes are in
             // HWND_URL_BYTES; trigger a repaint so the next WM_PAINT
             // cycle picks them up.
-            let _ = InvalidateRect(hwnd, None, true);
+            let _ = InvalidateRect(Some(hwnd), None, true);
             LRESULT(0)
         }
         _ => DefWindowProcW(hwnd, msg, wparam, lparam),
@@ -282,9 +282,9 @@ pub fn create_file(path_ptr: *const u8) -> i64 {
                 0,
                 100,
                 100,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();
@@ -327,9 +327,9 @@ pub fn create_symbol(name_ptr: *const u8) -> i64 {
                 0,
                 32,
                 32,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();
@@ -350,8 +350,8 @@ pub fn create_symbol(name_ptr: *const u8) -> i64 {
                 SendMessageW(
                     hwnd,
                     STM_SETIMAGE,
-                    WPARAM(IMAGE_ICON.0 as usize),
-                    LPARAM(hicon.0 as isize),
+                    Some(WPARAM(IMAGE_ICON.0 as usize)),
+                    Some(LPARAM(hicon.0 as isize)),
                 );
             }
 
@@ -390,9 +390,9 @@ pub fn create_url(url_ptr: *const u8, alt_ptr: *const u8) -> i64 {
                 0,
                 100,
                 100,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();
@@ -428,7 +428,7 @@ pub fn set_url(handle: i64, url_ptr: *const u8) {
             }
         }
         unsafe {
-            let _ = InvalidateRect(hwnd, None, true);
+            let _ = InvalidateRect(Some(hwnd), None, true);
         }
         if !url.is_empty() {
             fetch_url_async(hwnd, url);
@@ -468,7 +468,7 @@ fn fetch_url_async(hwnd: HWND, url: String) {
         };
         url_bytes_set(target.0 .0 as isize, bytes);
         unsafe {
-            let _ = PostMessageW(target.0, WM_USER_IMAGE_LOADED, WPARAM(0), LPARAM(0));
+            let _ = PostMessageW(Some(target.0), WM_USER_IMAGE_LOADED, WPARAM(0), LPARAM(0));
         }
     });
 
@@ -650,7 +650,7 @@ pub fn reload_bitmap_scaled(handle: i64, _w: i32, _h: i32) {
     // The paint handler reads the current client rect and draws at that size.
     if let Some(hwnd) = super::get_hwnd(handle) {
         unsafe {
-            let _ = InvalidateRect(hwnd, None, false);
+            let _ = InvalidateRect(Some(hwnd), None, false);
         }
     }
 }
@@ -678,7 +678,7 @@ pub fn set_size(handle: i64, width: f64, height: f64) {
                     scaled_h,
                     SWP_NOMOVE | SWP_NOZORDER,
                 );
-                let _ = InvalidateRect(hwnd, None, false);
+                let _ = InvalidateRect(Some(hwnd), None, false);
             }
         }
     }
@@ -709,7 +709,7 @@ pub fn set_tint(handle: i64, r: f64, g: f64, b: f64, a: f64) {
         // Force repaint (custom-draw could use the tint if implemented)
         if let Some(hwnd) = super::get_hwnd(handle) {
             unsafe {
-                let _ = InvalidateRect(hwnd, None, true);
+                let _ = InvalidateRect(Some(hwnd), None, true);
             }
         }
     }

--- a/crates/perry-ui-windows/src/widgets/map_view.rs
+++ b/crates/perry-ui-windows/src/widgets/map_view.rs
@@ -90,9 +90,9 @@ pub fn create(width: f64, height: f64) -> i64 {
                 0,
                 w,
                 h,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();

--- a/crates/perry-ui-windows/src/widgets/mod.rs
+++ b/crates/perry-ui-windows/src/widgets/mod.rs
@@ -602,7 +602,8 @@ pub fn clear_children(handle: i64) {
         // preventing a black flash while new children are being added.
         if let Some(parent_hwnd) = get_hwnd(handle) {
             unsafe {
-                let _ = windows::Win32::Graphics::Gdi::InvalidateRect(Some(parent_hwnd), None, true);
+                let _ =
+                    windows::Win32::Graphics::Gdi::InvalidateRect(Some(parent_hwnd), None, true);
             }
         }
     }
@@ -944,7 +945,12 @@ pub fn set_control_size(handle: i64, size: i64) {
                         "Segoe UI\0".encode_utf16().collect::<Vec<u16>>().as_ptr(),
                     ),
                 );
-                SendMessageW(hwnd, WM_SETFONT, Some(WPARAM(font.0 as usize)), Some(LPARAM(1)));
+                SendMessageW(
+                    hwnd,
+                    WM_SETFONT,
+                    Some(WPARAM(font.0 as usize)),
+                    Some(LPARAM(1)),
+                );
             }
         }
     }

--- a/crates/perry-ui-windows/src/widgets/mod.rs
+++ b/crates/perry-ui-windows/src/widgets/mod.rs
@@ -235,9 +235,9 @@ pub fn get_parking_hwnd() -> HWND {
                 0,
                 0,
                 0,
-                HWND_MESSAGE,
-                HMENU::default(),
-                hinstance_h,
+                Some(HWND_MESSAGE),
+                Some(HMENU::default()),
+                Some(hinstance_h),
                 None,
             )
             .unwrap();
@@ -488,7 +488,7 @@ pub fn add_child(parent_handle: i64, child_handle: i64) {
             (get_hwnd(parent_handle), get_hwnd(child_handle))
         {
             unsafe {
-                let _ = SetParent(child_hwnd, parent_hwnd);
+                let _ = SetParent(child_hwnd, Some(parent_hwnd));
                 let style = GetWindowLongW(child_hwnd, GWL_STYLE) as u32;
                 SetWindowLongW(
                     child_hwnd,
@@ -516,7 +516,7 @@ pub fn add_child_at(parent_handle: i64, child_handle: i64, index: i64) {
             (get_hwnd(parent_handle), get_hwnd(child_handle))
         {
             unsafe {
-                let _ = SetParent(child_hwnd, parent_hwnd);
+                let _ = SetParent(child_hwnd, Some(parent_hwnd));
                 let style = GetWindowLongW(child_hwnd, GWL_STYLE) as u32;
                 SetWindowLongW(
                     child_hwnd,
@@ -566,7 +566,7 @@ pub fn remove_child(parent_handle: i64, child_handle: i64) {
             if let Some(child_hwnd) = get_hwnd(child_handle) {
                 unsafe {
                     let _ = ShowWindow(child_hwnd, SW_HIDE);
-                    let _ = SetParent(child_hwnd, parking);
+                    let _ = SetParent(child_hwnd, Some(parking));
                 }
             }
         }
@@ -594,7 +594,7 @@ pub fn clear_children(handle: i64) {
             if let Some(child_hwnd) = get_hwnd(*child) {
                 unsafe {
                     let _ = ShowWindow(child_hwnd, SW_HIDE);
-                    let _ = SetParent(child_hwnd, parking);
+                    let _ = SetParent(child_hwnd, Some(parking));
                 }
             }
         }
@@ -602,7 +602,7 @@ pub fn clear_children(handle: i64) {
         // preventing a black flash while new children are being added.
         if let Some(parent_hwnd) = get_hwnd(handle) {
             unsafe {
-                let _ = windows::Win32::Graphics::Gdi::InvalidateRect(parent_hwnd, None, true);
+                let _ = windows::Win32::Graphics::Gdi::InvalidateRect(Some(parent_hwnd), None, true);
             }
         }
     }
@@ -935,16 +935,16 @@ pub fn set_control_size(handle: i64, size: i64) {
                     0,
                     0,
                     0,
-                    0,
-                    0,
-                    0,
-                    0,
+                    windows::Win32::Graphics::Gdi::FONT_CHARSET(0),
+                    windows::Win32::Graphics::Gdi::FONT_OUTPUT_PRECISION(0),
+                    windows::Win32::Graphics::Gdi::FONT_CLIP_PRECISION(0),
+                    windows::Win32::Graphics::Gdi::FONT_QUALITY(0),
                     0,
                     windows::core::PCWSTR(
                         "Segoe UI\0".encode_utf16().collect::<Vec<u16>>().as_ptr(),
                     ),
                 );
-                SendMessageW(hwnd, WM_SETFONT, WPARAM(font.0 as usize), LPARAM(1));
+                SendMessageW(hwnd, WM_SETFONT, Some(WPARAM(font.0 as usize)), Some(LPARAM(1)));
             }
         }
     }
@@ -1104,7 +1104,7 @@ pub fn apply_shadow(handle: i64) {
     register_shadow_for_parent(parent_key, handle);
     ensure_shadow_subclass(parent_hwnd);
     unsafe {
-        let _ = InvalidateRect(parent_hwnd, None, true);
+        let _ = InvalidateRect(Some(parent_hwnd), None, true);
     }
 }
 
@@ -1163,7 +1163,7 @@ unsafe extern "system" fn shadow_subclass_proc(
 #[cfg(target_os = "windows")]
 unsafe fn paint_shadows(parent_hwnd: HWND, children: &[i64]) {
     use windows::Win32::Graphics::Gdi::{GetDC, ReleaseDC};
-    let hdc = GetDC(parent_hwnd);
+    let hdc = GetDC(Some(parent_hwnd));
     if hdc.is_invalid() {
         return;
     }
@@ -1172,7 +1172,7 @@ unsafe fn paint_shadows(parent_hwnd: HWND, children: &[i64]) {
             paint_shadow_for_child(parent_hwnd, hdc, child, shadow);
         }
     }
-    ReleaseDC(parent_hwnd, hdc);
+    ReleaseDC(Some(parent_hwnd), hdc);
 }
 
 /// Render one widget's drop shadow into a 32bpp DIB then `AlphaBlend`
@@ -1258,7 +1258,7 @@ unsafe fn paint_shadow_for_child(
     let dest_x = tl.x - widget_l_in_bmp;
     let dest_y = tl.y - widget_t_in_bmp;
 
-    let mem_dc = CreateCompatibleDC(parent_dc);
+    let mem_dc = CreateCompatibleDC(Some(parent_dc));
     if mem_dc.is_invalid() {
         return;
     }
@@ -1283,11 +1283,11 @@ unsafe fn paint_shadow_for_child(
     let mut bits_ptr: *mut std::ffi::c_void = std::ptr::null_mut();
     let null_section = windows::Win32::Foundation::HANDLE(std::ptr::null_mut());
     let dib = match CreateDIBSection(
-        parent_dc,
+        Some(parent_dc),
         &bmi,
         DIB_RGB_COLORS,
         &mut bits_ptr,
-        null_section,
+        Some(null_section),
         0,
     ) {
         Ok(d) if !bits_ptr.is_null() => d,
@@ -1297,7 +1297,7 @@ unsafe fn paint_shadow_for_child(
         }
     };
 
-    let old_obj = SelectObject(mem_dc, dib);
+    let old_obj = SelectObject(mem_dc, dib.into());
 
     // Render shadow: per-pixel falloff from the (un-blurred) shadow rect.
     // 32bpp ARGB layout (little-endian u32): 0xAARRGGBB where bytes go
@@ -1373,7 +1373,7 @@ unsafe fn paint_shadow_for_child(
     );
 
     SelectObject(mem_dc, old_obj);
-    let _ = DeleteObject(dib);
+    let _ = DeleteObject(dib.into());
     let _ = DeleteDC(mem_dc);
 }
 
@@ -1430,7 +1430,7 @@ fn apply_opacity(handle: i64, opacity: f64) {
             SetWindowLongW(hwnd, GWL_EXSTYLE, (cur_ex | WS_EX_LAYERED.0) as i32);
         }
         let _ = SetLayeredWindowAttributes(hwnd, COLORREF(0), alpha, LWA_ALPHA);
-        let _ = InvalidateRect(hwnd, None, true);
+        let _ = InvalidateRect(Some(hwnd), None, true);
     }
 }
 
@@ -1523,7 +1523,7 @@ pub fn apply_corner_radius(handle: i64) {
                         radius as i32,
                         radius as i32,
                     );
-                    SetWindowRgn(hwnd, rgn, true);
+                    SetWindowRgn(hwnd, Some(rgn), true);
                 }
             }
         }
@@ -1570,7 +1570,7 @@ fn ensure_border_subclass(handle: i64) {
     }
     if let Some(hwnd) = get_hwnd_safe(handle) {
         unsafe {
-            let _ = InvalidateRect(hwnd, None, true);
+            let _ = InvalidateRect(Some(hwnd), None, true);
         }
     }
 }
@@ -1616,17 +1616,17 @@ unsafe extern "system" fn border_subclass_proc(
                 let mut rect = RECT::default();
                 let _ = GetClientRect(hwnd, &mut rect);
                 if rect.right > 0 && rect.bottom > 0 {
-                    let hdc = GetDC(hwnd);
+                    let hdc = GetDC(Some(hwnd));
                     if !hdc.is_invalid() {
                         let pen = CreatePen(PS_SOLID, w, COLORREF(cr));
                         let null_brush = HBRUSH(GetStockObject(NULL_BRUSH).0);
-                        let old_pen = SelectObject(hdc, pen);
-                        let old_brush = SelectObject(hdc, null_brush);
+                        let old_pen = SelectObject(hdc, pen.into());
+                        let old_brush = SelectObject(hdc, null_brush.into());
                         let _ = Rectangle(hdc, 0, 0, rect.right, rect.bottom);
                         SelectObject(hdc, old_pen);
                         SelectObject(hdc, old_brush);
-                        let _ = DeleteObject(pen);
-                        ReleaseDC(hwnd, hdc);
+                        let _ = DeleteObject(pen.into());
+                        ReleaseDC(Some(hwnd), hdc);
                     }
                 }
             }
@@ -1729,7 +1729,7 @@ pub fn set_background_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
         if let Some(hwnd) = hwnd_opt {
             set_hwnd_bg_color(hwnd, color);
             unsafe {
-                let _ = InvalidateRect(hwnd, None, true);
+                let _ = InvalidateRect(Some(hwnd), None, true);
             }
         }
     }
@@ -1752,7 +1752,7 @@ pub fn set_hwnd_bg_color(hwnd: HWND, color: u32) {
         SetPropW(
             hwnd,
             windows::core::PCWSTR(prop_name.as_ptr()),
-            HANDLE((color as usize + 1) as *mut _),
+            Some(HANDLE((color as usize + 1) as *mut _)),
         );
     }
 }
@@ -1905,12 +1905,12 @@ pub fn set_background_gradient(
                 SetPropW(
                     hwnd,
                     windows::core::PCWSTR(prop_c1.as_ptr()),
-                    HANDLE((c1 as usize + 1) as *mut _),
+                    Some(HANDLE((c1 as usize + 1) as *mut _)),
                 );
                 SetPropW(
                     hwnd,
                     windows::core::PCWSTR(prop_c2.as_ptr()),
-                    HANDLE((c2 as usize + 1) as *mut _),
+                    Some(HANDLE((c2 as usize + 1) as *mut _)),
                 );
             }
         }

--- a/crates/perry-ui-windows/src/widgets/navstack.rs
+++ b/crates/perry-ui-windows/src/widgets/navstack.rs
@@ -96,9 +96,9 @@ pub fn create(title_ptr: *const u8, body_handle: i64) -> i64 {
                 0,
                 100,
                 100,
-                super::get_parking_hwnd(),
+                Some(super::get_parking_hwnd()),
                 None,
-                HINSTANCE::from(hinstance),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();

--- a/crates/perry-ui-windows/src/widgets/pdf_view.rs
+++ b/crates/perry-ui-windows/src/widgets/pdf_view.rs
@@ -77,9 +77,9 @@ pub fn create(width: f64, height: f64) -> i64 {
                 0,
                 w,
                 h,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();

--- a/crates/perry-ui-windows/src/widgets/picker.rs
+++ b/crates/perry-ui-windows/src/widgets/picker.rs
@@ -82,9 +82,9 @@ pub fn create(label_ptr: *const u8, on_change: f64, _style: i64) -> i64 {
                 // (same approach as button/textfield/toggle/slider/etc).
                 // layout::relayout() moves the widget to its real parent
                 // once the App() container hierarchy is resolved.
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();
@@ -151,8 +151,8 @@ pub fn add_item(handle: i64, title_ptr: *const u8) {
                 SendMessageW(
                     hwnd,
                     CB_ADDSTRING,
-                    WPARAM(0),
-                    LPARAM(wide.as_ptr() as isize),
+                    Some(WPARAM(0)),
+                    Some(LPARAM(wide.as_ptr() as isize)),
                 );
             }
         }
@@ -170,7 +170,7 @@ pub fn set_selected(handle: i64, index: i64) {
     {
         if let Some(hwnd) = super::get_hwnd(handle) {
             unsafe {
-                SendMessageW(hwnd, CB_SETCURSEL, WPARAM(index as usize), LPARAM(0));
+                SendMessageW(hwnd, CB_SETCURSEL, Some(WPARAM(index as usize)), Some(LPARAM(0)));
             }
         }
     }
@@ -186,7 +186,7 @@ pub fn get_selected(handle: i64) -> i64 {
     #[cfg(target_os = "windows")]
     {
         if let Some(hwnd) = super::get_hwnd(handle) {
-            let result = unsafe { SendMessageW(hwnd, CB_GETCURSEL, WPARAM(0), LPARAM(0)) };
+            let result = unsafe { SendMessageW(hwnd, CB_GETCURSEL, Some(WPARAM(0)), Some(LPARAM(0))) };
             return result.0 as i64;
         }
         -1

--- a/crates/perry-ui-windows/src/widgets/picker.rs
+++ b/crates/perry-ui-windows/src/widgets/picker.rs
@@ -170,7 +170,12 @@ pub fn set_selected(handle: i64, index: i64) {
     {
         if let Some(hwnd) = super::get_hwnd(handle) {
             unsafe {
-                SendMessageW(hwnd, CB_SETCURSEL, Some(WPARAM(index as usize)), Some(LPARAM(0)));
+                SendMessageW(
+                    hwnd,
+                    CB_SETCURSEL,
+                    Some(WPARAM(index as usize)),
+                    Some(LPARAM(0)),
+                );
             }
         }
     }
@@ -186,7 +191,8 @@ pub fn get_selected(handle: i64) -> i64 {
     #[cfg(target_os = "windows")]
     {
         if let Some(hwnd) = super::get_hwnd(handle) {
-            let result = unsafe { SendMessageW(hwnd, CB_GETCURSEL, Some(WPARAM(0)), Some(LPARAM(0))) };
+            let result =
+                unsafe { SendMessageW(hwnd, CB_GETCURSEL, Some(WPARAM(0)), Some(LPARAM(0))) };
             return result.0 as i64;
         }
         -1

--- a/crates/perry-ui-windows/src/widgets/progressview.rs
+++ b/crates/perry-ui-windows/src/widgets/progressview.rs
@@ -81,7 +81,12 @@ pub fn set_value(handle: i64, value: f64) {
                     SetWindowLongW(hwnd, GWL_STYLE, (style & !PBS_MARQUEE) as i32);
                     SendMessageW(hwnd, PBM_SETMARQUEE, Some(WPARAM(0)), Some(LPARAM(0)));
                     let pos = (value * 100.0) as isize;
-                    SendMessageW(hwnd, PBM_SETPOS, Some(WPARAM(pos as usize)), Some(LPARAM(0)));
+                    SendMessageW(
+                        hwnd,
+                        PBM_SETPOS,
+                        Some(WPARAM(pos as usize)),
+                        Some(LPARAM(0)),
+                    );
                 }
             }
         }

--- a/crates/perry-ui-windows/src/widgets/progressview.rs
+++ b/crates/perry-ui-windows/src/widgets/progressview.rs
@@ -42,15 +42,15 @@ pub fn create() -> i64 {
                 0,
                 200,
                 20,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();
 
             // Start marquee animation (30ms interval)
-            SendMessageW(hwnd, PBM_SETMARQUEE, WPARAM(1), LPARAM(30));
+            SendMessageW(hwnd, PBM_SETMARQUEE, Some(WPARAM(1)), Some(LPARAM(30)));
 
             register_widget(hwnd, WidgetKind::ProgressView, control_id)
         }
@@ -74,14 +74,14 @@ pub fn set_value(handle: i64, value: f64) {
                     // Switch to marquee (indeterminate) mode
                     let style = GetWindowLongW(hwnd, GWL_STYLE) as u32;
                     SetWindowLongW(hwnd, GWL_STYLE, (style | PBS_MARQUEE) as i32);
-                    SendMessageW(hwnd, PBM_SETMARQUEE, WPARAM(1), LPARAM(30));
+                    SendMessageW(hwnd, PBM_SETMARQUEE, Some(WPARAM(1)), Some(LPARAM(30)));
                 } else {
                     // Switch to determinate mode
                     let style = GetWindowLongW(hwnd, GWL_STYLE) as u32;
                     SetWindowLongW(hwnd, GWL_STYLE, (style & !PBS_MARQUEE) as i32);
-                    SendMessageW(hwnd, PBM_SETMARQUEE, WPARAM(0), LPARAM(0));
+                    SendMessageW(hwnd, PBM_SETMARQUEE, Some(WPARAM(0)), Some(LPARAM(0)));
                     let pos = (value * 100.0) as isize;
-                    SendMessageW(hwnd, PBM_SETPOS, WPARAM(pos as usize), LPARAM(0));
+                    SendMessageW(hwnd, PBM_SETPOS, Some(WPARAM(pos as usize)), Some(LPARAM(0)));
                 }
             }
         }

--- a/crates/perry-ui-windows/src/widgets/qrcode.rs
+++ b/crates/perry-ui-windows/src/widgets/qrcode.rs
@@ -102,9 +102,9 @@ pub fn create(data_ptr: *const u8, size: f64) -> i64 {
                 0,
                 display,
                 display,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();
@@ -118,7 +118,7 @@ pub fn create(data_ptr: *const u8, size: f64) -> i64 {
                 }
             }
             ensure_subclass(hwnd);
-            let _ = InvalidateRect(hwnd, None, true);
+            let _ = InvalidateRect(Some(hwnd), None, true);
             handle
         }
     }
@@ -150,7 +150,7 @@ pub fn set_data(handle: i64, data_ptr: *const u8) {
         });
         if let Some(hwnd) = super::get_hwnd(handle) {
             unsafe {
-                let _ = InvalidateRect(hwnd, None, true);
+                let _ = InvalidateRect(Some(hwnd), None, true);
             }
         }
     }
@@ -199,7 +199,7 @@ unsafe extern "system" fn qrcode_subclass_proc(
             let _ = GetClientRect(hwnd, &mut rect);
             let white = CreateSolidBrush(COLORREF(0x00_FF_FF_FF));
             FillRect(hdc, &rect, white);
-            let _ = DeleteObject(white);
+            let _ = DeleteObject(white.into());
 
             let handle = super::find_handle_by_hwnd(hwnd);
             if handle > 0 {
@@ -244,5 +244,5 @@ unsafe fn paint_matrix(hdc: windows::Win32::Graphics::Gdi::HDC, rect: &RECT, mat
             }
         }
     }
-    let _ = DeleteObject(black);
+    let _ = DeleteObject(black.into());
 }

--- a/crates/perry-ui-windows/src/widgets/rich_text.rs
+++ b/crates/perry-ui-windows/src/widgets/rich_text.rs
@@ -139,9 +139,9 @@ pub fn create(width: f64, height: f64, on_change: f64) -> i64 {
                 0,
                 width.max(40.0) as i32,
                 height.max(40.0) as i32,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             );
             let Ok(hwnd) = hwnd else {
@@ -297,8 +297,8 @@ fn toggle_effect(handle: i64, mask: u32, effect: u32) {
         SendMessageW(
             hwnd,
             0x043A,
-            WPARAM(SCF_SELECTION as usize),
-            LPARAM(&mut probe as *mut _ as isize),
+            Some(WPARAM(SCF_SELECTION as usize)),
+            Some(LPARAM(&mut probe as *mut _ as isize)),
         );
         let already_on = probe.dw_effects & effect != 0;
         let mut cf = CharFormat2W::default();
@@ -308,8 +308,8 @@ fn toggle_effect(handle: i64, mask: u32, effect: u32) {
         SendMessageW(
             hwnd,
             EM_SETCHARFORMAT,
-            WPARAM(SCF_SELECTION as usize),
-            LPARAM(&cf as *const _ as isize),
+            Some(WPARAM(SCF_SELECTION as usize)),
+            Some(LPARAM(&cf as *const _ as isize)),
         );
     }
 }

--- a/crates/perry-ui-windows/src/widgets/rich_tooltip.rs
+++ b/crates/perry-ui-windows/src/widgets/rich_tooltip.rs
@@ -206,7 +206,7 @@ fn show_popup(trigger_handle: i64) {
             popup_h + 16,
             None,
             None,
-            HINSTANCE::from(hinstance),
+            Some(HINSTANCE::from(hinstance)),
             None,
         );
         let popup = match popup {
@@ -215,7 +215,7 @@ fn show_popup(trigger_handle: i64) {
         };
 
         // Re-parent the content widget into the popup.
-        let _ = SetParent(content_hwnd, popup);
+        let _ = SetParent(content_hwnd, Some(popup));
         let _ = SetWindowPos(content_hwnd, None, 8, 8, popup_w, popup_h, SWP_NOACTIVATE);
 
         let _ = ShowWindow(popup, SW_SHOWNOACTIVATE);
@@ -238,7 +238,7 @@ fn hide_popup(trigger_handle: i64) {
                     // subsequent shows can re-parent cleanly.
                     let content_hwnd = super::get_hwnd(tip.content_handle);
                     if let Some(content) = content_hwnd {
-                        let _ = SetParent(content, super::get_parking_hwnd());
+                        let _ = SetParent(content, Some(super::get_parking_hwnd()));
                     }
                     let _ = DestroyWindow(popup);
                 }

--- a/crates/perry-ui-windows/src/widgets/scrollview.rs
+++ b/crates/perry-ui-windows/src/widgets/scrollview.rs
@@ -145,7 +145,7 @@ unsafe extern "system" fn scroll_wnd_proc(
         }
         WM_COMMAND | WM_CTLCOLORSTATIC | WM_CTLCOLORBTN | WM_CONTEXTMENU | WM_DRAWITEM => {
             if let Ok(parent) = GetParent(hwnd) {
-                return SendMessageW(parent, msg, wparam, lparam);
+                return SendMessageW(parent, msg, Some(wparam), Some(lparam));
             }
             DefWindowProcW(hwnd, msg, wparam, lparam)
         }
@@ -161,7 +161,7 @@ unsafe extern "system" fn scroll_wnd_proc(
                     let mut rect = RECT::default();
                     let _ = GetClientRect(hwnd, &mut rect);
                     let _ = FillRect(hdc, &rect, brush);
-                    let _ = windows::Win32::Graphics::Gdi::DeleteObject(brush);
+                    let _ = windows::Win32::Graphics::Gdi::DeleteObject(brush.into());
                     return LRESULT(1);
                 } else {
                     let mut ps = windows::Win32::Graphics::Gdi::PAINTSTRUCT::default();
@@ -169,7 +169,7 @@ unsafe extern "system" fn scroll_wnd_proc(
                     let mut rect = RECT::default();
                     let _ = GetClientRect(hwnd, &mut rect);
                     let _ = FillRect(hdc, &rect, brush);
-                    let _ = windows::Win32::Graphics::Gdi::DeleteObject(brush);
+                    let _ = windows::Win32::Graphics::Gdi::DeleteObject(brush.into());
                     windows::Win32::Graphics::Gdi::EndPaint(hwnd, &ps);
                     return LRESULT(0);
                 }
@@ -220,9 +220,9 @@ pub fn create() -> i64 {
                 0,
                 100,
                 100,
-                super::get_parking_hwnd(),
+                Some(super::get_parking_hwnd()),
                 None,
-                HINSTANCE::from(hinstance),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();

--- a/crates/perry-ui-windows/src/widgets/securefield.rs
+++ b/crates/perry-ui-windows/src/widgets/securefield.rs
@@ -75,9 +75,9 @@ pub fn create(placeholder_ptr: *const u8, on_change: f64) -> i64 {
                 // WS_CHILD requires a parent HWND; same pattern as picker/
                 // button/textfield — use the parking window until
                 // layout::relayout() moves the control to its real parent.
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();
@@ -88,8 +88,8 @@ pub fn create(placeholder_ptr: *const u8, on_change: f64) -> i64 {
                 SendMessageW(
                     hwnd,
                     EM_SETCUEBANNER,
-                    WPARAM(0),
-                    LPARAM(wide.as_ptr() as isize),
+                    Some(WPARAM(0)),
+                    Some(LPARAM(wide.as_ptr() as isize)),
                 );
             }
 

--- a/crates/perry-ui-windows/src/widgets/slider.rs
+++ b/crates/perry-ui-windows/src/widgets/slider.rs
@@ -78,25 +78,25 @@ pub fn create(min: f64, max: f64, initial: f64, on_change: f64) -> i64 {
                 0,
                 200,
                 24,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();
 
             // Set range [0, 1000]
-            SendMessageW(hwnd, TBM_SETRANGEMIN, WPARAM(0), LPARAM(0));
+            SendMessageW(hwnd, TBM_SETRANGEMIN, Some(WPARAM(0)), Some(LPARAM(0)));
             SendMessageW(
                 hwnd,
                 TBM_SETRANGEMAX,
-                WPARAM(1),
-                LPARAM(TRACKBAR_RANGE as isize),
+                Some(WPARAM(1)),
+                Some(LPARAM(TRACKBAR_RANGE as isize)),
             );
 
             // Set initial position
             let pos = value_to_pos(initial, min, max);
-            SendMessageW(hwnd, TBM_SETPOS, WPARAM(1), LPARAM(pos as isize));
+            SendMessageW(hwnd, TBM_SETPOS, Some(WPARAM(1)), Some(LPARAM(pos as isize)));
 
             let handle = register_widget(hwnd, WidgetKind::Slider, control_id);
             SLIDER_INFO.with(|info| {
@@ -167,7 +167,7 @@ pub fn handle_scroll(handle: i64) {
     #[cfg(target_os = "windows")]
     {
         if let Some(hwnd) = super::get_hwnd(handle) {
-            let pos = unsafe { SendMessageW(hwnd, TBM_GETPOS, WPARAM(0), LPARAM(0)).0 as i32 };
+            let pos = unsafe { SendMessageW(hwnd, TBM_GETPOS, Some(WPARAM(0)), Some(LPARAM(0))).0 as i32 };
 
             SLIDER_INFO.with(|info| {
                 let info = info.borrow();
@@ -195,7 +195,7 @@ pub fn set_value(handle: i64, value: f64) {
                 if let Some(si) = info.get(&handle) {
                     let pos = value_to_pos(value, si.min, si.max);
                     unsafe {
-                        SendMessageW(hwnd, TBM_SETPOS, WPARAM(1), LPARAM(pos as isize));
+                        SendMessageW(hwnd, TBM_SETPOS, Some(WPARAM(1)), Some(LPARAM(pos as isize)));
                     }
                 }
             });

--- a/crates/perry-ui-windows/src/widgets/slider.rs
+++ b/crates/perry-ui-windows/src/widgets/slider.rs
@@ -96,7 +96,12 @@ pub fn create(min: f64, max: f64, initial: f64, on_change: f64) -> i64 {
 
             // Set initial position
             let pos = value_to_pos(initial, min, max);
-            SendMessageW(hwnd, TBM_SETPOS, Some(WPARAM(1)), Some(LPARAM(pos as isize)));
+            SendMessageW(
+                hwnd,
+                TBM_SETPOS,
+                Some(WPARAM(1)),
+                Some(LPARAM(pos as isize)),
+            );
 
             let handle = register_widget(hwnd, WidgetKind::Slider, control_id);
             SLIDER_INFO.with(|info| {
@@ -167,7 +172,9 @@ pub fn handle_scroll(handle: i64) {
     #[cfg(target_os = "windows")]
     {
         if let Some(hwnd) = super::get_hwnd(handle) {
-            let pos = unsafe { SendMessageW(hwnd, TBM_GETPOS, Some(WPARAM(0)), Some(LPARAM(0))).0 as i32 };
+            let pos = unsafe {
+                SendMessageW(hwnd, TBM_GETPOS, Some(WPARAM(0)), Some(LPARAM(0))).0 as i32
+            };
 
             SLIDER_INFO.with(|info| {
                 let info = info.borrow();
@@ -195,7 +202,12 @@ pub fn set_value(handle: i64, value: f64) {
                 if let Some(si) = info.get(&handle) {
                     let pos = value_to_pos(value, si.min, si.max);
                     unsafe {
-                        SendMessageW(hwnd, TBM_SETPOS, Some(WPARAM(1)), Some(LPARAM(pos as isize)));
+                        SendMessageW(
+                            hwnd,
+                            TBM_SETPOS,
+                            Some(WPARAM(1)),
+                            Some(LPARAM(pos as isize)),
+                        );
                     }
                 }
             });

--- a/crates/perry-ui-windows/src/widgets/table.rs
+++ b/crates/perry-ui-windows/src/widgets/table.rs
@@ -200,7 +200,9 @@ pub fn create(row_count: f64, col_count: f64, render_closure: f64) -> i64 {
                 hwnd,
                 LVM_SETEXTENDEDLISTVIEWSTYLE,
                 Some(WPARAM(0)),
-                Some(LPARAM((LVS_EX_FULLROWSELECT | LVS_EX_GRIDLINES | LVS_EX_HEADERDRAGDROP) as isize)),
+                Some(LPARAM(
+                    (LVS_EX_FULLROWSELECT | LVS_EX_GRIDLINES | LVS_EX_HEADERDRAGDROP) as isize,
+                )),
             );
 
             // Insert the columns. Default header is "Col N".
@@ -351,7 +353,12 @@ pub fn update_row_count(handle: i64, count: i64) {
     {
         if let Some(hwnd) = super::get_hwnd(handle) {
             unsafe {
-                SendMessageW(hwnd, LVM_SETITEMCOUNT, Some(WPARAM(count as usize)), Some(LPARAM(0)));
+                SendMessageW(
+                    hwnd,
+                    LVM_SETITEMCOUNT,
+                    Some(WPARAM(count as usize)),
+                    Some(LPARAM(0)),
+                );
                 let _ = InvalidateRect(Some(hwnd), None, true);
             }
         }
@@ -431,7 +438,8 @@ pub fn get_selected_rows_count(handle: i64) -> i64 {
     {
         if let Some(hwnd) = super::get_hwnd(handle) {
             unsafe {
-                let res = SendMessageW(hwnd, LVM_GETSELECTEDCOUNT, Some(WPARAM(0)), Some(LPARAM(0)));
+                let res =
+                    SendMessageW(hwnd, LVM_GETSELECTEDCOUNT, Some(WPARAM(0)), Some(LPARAM(0)));
                 return res.0 as i64;
             }
         }

--- a/crates/perry-ui-windows/src/widgets/table.rs
+++ b/crates/perry-ui-windows/src/widgets/table.rs
@@ -188,9 +188,9 @@ pub fn create(row_count: f64, col_count: f64, render_closure: f64) -> i64 {
                 0,
                 400,
                 300,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();
@@ -199,8 +199,8 @@ pub fn create(row_count: f64, col_count: f64, render_closure: f64) -> i64 {
             SendMessageW(
                 hwnd,
                 LVM_SETEXTENDEDLISTVIEWSTYLE,
-                WPARAM(0),
-                LPARAM((LVS_EX_FULLROWSELECT | LVS_EX_GRIDLINES | LVS_EX_HEADERDRAGDROP) as isize),
+                Some(WPARAM(0)),
+                Some(LPARAM((LVS_EX_FULLROWSELECT | LVS_EX_GRIDLINES | LVS_EX_HEADERDRAGDROP) as isize)),
             );
 
             // Insert the columns. Default header is "Col N".
@@ -222,8 +222,8 @@ pub fn create(row_count: f64, col_count: f64, render_closure: f64) -> i64 {
                 SendMessageW(
                     hwnd,
                     LVM_INSERTCOLUMNW,
-                    WPARAM(i as usize),
-                    LPARAM(&mut lvc as *mut _ as isize),
+                    Some(WPARAM(i as usize)),
+                    Some(LPARAM(&mut lvc as *mut _ as isize)),
                 );
             }
 
@@ -231,8 +231,8 @@ pub fn create(row_count: f64, col_count: f64, render_closure: f64) -> i64 {
             SendMessageW(
                 hwnd,
                 LVM_SETITEMCOUNT,
-                WPARAM(row_count as usize),
-                LPARAM(0),
+                Some(WPARAM(row_count as usize)),
+                Some(LPARAM(0)),
             );
 
             let table_handle = register_widget(hwnd, WidgetKind::TreeView, control_id);
@@ -306,8 +306,8 @@ pub fn set_column_header(handle: i64, col: i64, title_ptr: *const u8) {
                 SendMessageW(
                     hwnd,
                     LVM_SETCOLUMNW,
-                    WPARAM(col as usize),
-                    LPARAM(&mut lvc as *mut _ as isize),
+                    Some(WPARAM(col as usize)),
+                    Some(LPARAM(&mut lvc as *mut _ as isize)),
                 );
             }
         }
@@ -327,8 +327,8 @@ pub fn set_column_width(handle: i64, col: i64, width: f64) {
                 SendMessageW(
                     hwnd,
                     LVM_SETCOLUMNWIDTH,
-                    WPARAM(col as usize),
-                    LPARAM(width as isize),
+                    Some(WPARAM(col as usize)),
+                    Some(LPARAM(width as isize)),
                 );
             }
         }
@@ -351,8 +351,8 @@ pub fn update_row_count(handle: i64, count: i64) {
     {
         if let Some(hwnd) = super::get_hwnd(handle) {
             unsafe {
-                SendMessageW(hwnd, LVM_SETITEMCOUNT, WPARAM(count as usize), LPARAM(0));
-                let _ = InvalidateRect(hwnd, None, true);
+                SendMessageW(hwnd, LVM_SETITEMCOUNT, Some(WPARAM(count as usize)), Some(LPARAM(0)));
+                let _ = InvalidateRect(Some(hwnd), None, true);
             }
         }
     }
@@ -380,8 +380,8 @@ pub fn get_selected_row(handle: i64) -> i64 {
                 let res = SendMessageW(
                     hwnd,
                     LVM_GETNEXTITEM,
-                    WPARAM(usize::MAX),
-                    LPARAM(LVNI_SELECTED as isize),
+                    Some(WPARAM(usize::MAX)),
+                    Some(LPARAM(LVNI_SELECTED as isize)),
                 );
                 return res.0 as i64;
             }
@@ -431,7 +431,7 @@ pub fn get_selected_rows_count(handle: i64) -> i64 {
     {
         if let Some(hwnd) = super::get_hwnd(handle) {
             unsafe {
-                let res = SendMessageW(hwnd, LVM_GETSELECTEDCOUNT, WPARAM(0), LPARAM(0));
+                let res = SendMessageW(hwnd, LVM_GETSELECTEDCOUNT, Some(WPARAM(0)), Some(LPARAM(0)));
                 return res.0 as i64;
             }
         }
@@ -454,8 +454,8 @@ pub fn get_selected_row_at(handle: i64, n: i64) -> i64 {
                     let res = SendMessageW(
                         hwnd,
                         LVM_GETNEXTITEM,
-                        WPARAM(cur as usize),
-                        LPARAM(LVNI_SELECTED as isize),
+                        Some(WPARAM(cur as usize)),
+                        Some(LPARAM(LVNI_SELECTED as isize)),
                     );
                     cur = res.0 as i64;
                     if cur < 0 {
@@ -666,7 +666,7 @@ pub fn handle_columnclick(handle: i64, lparam: LPARAM) {
     });
     if let Some(hwnd) = super::get_hwnd(handle) {
         unsafe {
-            let _ = InvalidateRect(hwnd, None, true);
+            let _ = InvalidateRect(Some(hwnd), None, true);
         }
     }
 }

--- a/crates/perry-ui-windows/src/widgets/text.rs
+++ b/crates/perry-ui-windows/src/widgets/text.rs
@@ -73,9 +73,9 @@ pub fn create(text_ptr: *const u8) -> i64 {
                 0,
                 100,
                 20,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();
@@ -136,7 +136,7 @@ pub fn set_number_of_lines(handle: i64, lines: i64) {
                 // changes to take effect on STATIC controls.
                 let _ = SetWindowPos(
                     hwnd,
-                    HWND(std::ptr::null_mut()),
+                    Some(HWND(std::ptr::null_mut())),
                     0,
                     0,
                     0,
@@ -183,7 +183,7 @@ pub fn set_truncation_mode(handle: i64, mode: i64) {
                 let _ = SetWindowLongPtrW(hwnd, GWL_STYLE, new_style as isize);
                 let _ = SetWindowPos(
                     hwnd,
-                    HWND(std::ptr::null_mut()),
+                    Some(HWND(std::ptr::null_mut())),
                     0,
                     0,
                     0,
@@ -223,7 +223,7 @@ pub fn set_text_alignment(handle: i64, alignment: i64) {
                 // SWP_FRAMECHANGED forces STATIC style changes to take effect.
                 let _ = SetWindowPos(
                     hwnd,
-                    HWND(std::ptr::null_mut()),
+                    Some(HWND(std::ptr::null_mut())),
                     0,
                     0,
                     0,
@@ -281,7 +281,7 @@ pub fn set_color(handle: i64, r: f64, g: f64, b: f64, _a: f64) {
         // Force repaint
         if let Some(hwnd) = super::get_hwnd(handle) {
             unsafe {
-                let _ = InvalidateRect(hwnd, None, true);
+                let _ = InvalidateRect(Some(hwnd), None, true);
             }
         }
     }
@@ -364,7 +364,7 @@ pub fn set_font_family(handle: i64, family_ptr: *const u8) {
                     let mut lf = LOGFONTW::default();
                     unsafe {
                         GetObjectW(
-                            style.font,
+                            style.font.into(),
                             std::mem::size_of::<LOGFONTW>() as i32,
                             Some(&mut lf as *mut _ as *mut _),
                         );
@@ -446,7 +446,7 @@ pub fn handle_ctlcolor(hdc: HDC, child_hwnd: HWND) -> Option<LRESULT> {
             }
             if !style.font.is_invalid() {
                 unsafe {
-                    SelectObject(hdc, style.font);
+                    SelectObject(hdc, style.font.into());
                 }
             }
             Some(bg_brush)
@@ -488,10 +488,10 @@ fn create_font_with_family(size: i32, weight: i32, family: &str) -> HFONT {
             0,            // fdwItalic
             0,            // fdwUnderline
             0,            // fdwStrikeOut
-            0,            // fdwCharSet (DEFAULT_CHARSET)
-            0,            // fdwOutputPrecision
-            0,            // fdwClipPrecision
-            0,            // fdwQuality
+            windows::Win32::Graphics::Gdi::FONT_CHARSET(0),            // fdwCharSet (DEFAULT_CHARSET)
+            windows::Win32::Graphics::Gdi::FONT_OUTPUT_PRECISION(0),            // fdwOutputPrecision
+            windows::Win32::Graphics::Gdi::FONT_CLIP_PRECISION(0),            // fdwClipPrecision
+            windows::Win32::Graphics::Gdi::FONT_QUALITY(0),            // fdwQuality
             0,            // fdwPitchAndFamily
             windows::core::PCWSTR(family_wide.as_ptr()),
         )
@@ -510,7 +510,7 @@ fn apply_font(handle: i64, font: HFONT) {
         // Clean up old font
         if !entry.font.is_invalid() {
             unsafe {
-                let _ = DeleteObject(entry.font);
+                let _ = DeleteObject(entry.font.into());
             }
         }
         entry.font = font;
@@ -518,7 +518,7 @@ fn apply_font(handle: i64, font: HFONT) {
 
     if let Some(hwnd) = super::get_hwnd(handle) {
         unsafe {
-            SendMessageW(hwnd, WM_SETFONT, WPARAM(font.0 as usize), LPARAM(1));
+            SendMessageW(hwnd, WM_SETFONT, Some(WPARAM(font.0 as usize)), Some(LPARAM(1)));
         }
     }
 }
@@ -574,7 +574,7 @@ fn apply_decoration(handle: i64, decoration: i64) {
     if let Some(font) = existing {
         unsafe {
             GetObjectW(
-                font,
+                font.into(),
                 std::mem::size_of::<LOGFONTW>() as i32,
                 Some(&mut lf as *mut _ as *mut _),
             );

--- a/crates/perry-ui-windows/src/widgets/text.rs
+++ b/crates/perry-ui-windows/src/widgets/text.rs
@@ -488,10 +488,10 @@ fn create_font_with_family(size: i32, weight: i32, family: &str) -> HFONT {
             0,            // fdwItalic
             0,            // fdwUnderline
             0,            // fdwStrikeOut
-            windows::Win32::Graphics::Gdi::FONT_CHARSET(0),            // fdwCharSet (DEFAULT_CHARSET)
-            windows::Win32::Graphics::Gdi::FONT_OUTPUT_PRECISION(0),            // fdwOutputPrecision
-            windows::Win32::Graphics::Gdi::FONT_CLIP_PRECISION(0),            // fdwClipPrecision
-            windows::Win32::Graphics::Gdi::FONT_QUALITY(0),            // fdwQuality
+            windows::Win32::Graphics::Gdi::FONT_CHARSET(0), // fdwCharSet (DEFAULT_CHARSET)
+            windows::Win32::Graphics::Gdi::FONT_OUTPUT_PRECISION(0), // fdwOutputPrecision
+            windows::Win32::Graphics::Gdi::FONT_CLIP_PRECISION(0), // fdwClipPrecision
+            windows::Win32::Graphics::Gdi::FONT_QUALITY(0), // fdwQuality
             0,            // fdwPitchAndFamily
             windows::core::PCWSTR(family_wide.as_ptr()),
         )
@@ -518,7 +518,12 @@ fn apply_font(handle: i64, font: HFONT) {
 
     if let Some(hwnd) = super::get_hwnd(handle) {
         unsafe {
-            SendMessageW(hwnd, WM_SETFONT, Some(WPARAM(font.0 as usize)), Some(LPARAM(1)));
+            SendMessageW(
+                hwnd,
+                WM_SETFONT,
+                Some(WPARAM(font.0 as usize)),
+                Some(LPARAM(1)),
+            );
         }
     }
 }

--- a/crates/perry-ui-windows/src/widgets/textarea.rs
+++ b/crates/perry-ui-windows/src/widgets/textarea.rs
@@ -79,9 +79,9 @@ pub fn create(on_change: f64) -> i64 {
                 0,
                 400,
                 200,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();

--- a/crates/perry-ui-windows/src/widgets/textfield.rs
+++ b/crates/perry-ui-windows/src/widgets/textfield.rs
@@ -267,7 +267,12 @@ pub fn set_font_size(handle: i64, size: f64) {
         if let Some(hwnd) = super::get_hwnd(handle) {
             let font = super::text::create_font_with_family_pub(size as i32, 400, "Segoe UI");
             unsafe {
-                SendMessageW(hwnd, WM_SETFONT, Some(WPARAM(font.0 as usize)), Some(LPARAM(1)));
+                SendMessageW(
+                    hwnd,
+                    WM_SETFONT,
+                    Some(WPARAM(font.0 as usize)),
+                    Some(LPARAM(1)),
+                );
             }
         }
     }

--- a/crates/perry-ui-windows/src/widgets/textfield.rs
+++ b/crates/perry-ui-windows/src/widgets/textfield.rs
@@ -78,9 +78,9 @@ pub fn create(placeholder_ptr: *const u8, on_change: f64) -> i64 {
                 0,
                 200,
                 30,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();
@@ -91,8 +91,8 @@ pub fn create(placeholder_ptr: *const u8, on_change: f64) -> i64 {
                 SendMessageW(
                     hwnd,
                     EM_SETCUEBANNER,
-                    WPARAM(0),
-                    LPARAM(wide.as_ptr() as isize),
+                    Some(WPARAM(0)),
+                    Some(LPARAM(wide.as_ptr() as isize)),
                 );
             }
 
@@ -177,7 +177,7 @@ pub fn focus(handle: i64) {
     {
         if let Some(hwnd) = super::get_hwnd(handle) {
             unsafe {
-                let _ = SetFocus(hwnd);
+                let _ = SetFocus(Some(hwnd));
             }
         }
     }
@@ -227,7 +227,7 @@ pub fn set_background_color(handle: i64, r: f64, g: f64, b: f64, a: f64) {
         });
         if let Some(hwnd) = super::get_hwnd(handle) {
             unsafe {
-                let _ = InvalidateRect(hwnd, None, true);
+                let _ = InvalidateRect(Some(hwnd), None, true);
             }
         }
     }
@@ -267,7 +267,7 @@ pub fn set_font_size(handle: i64, size: f64) {
         if let Some(hwnd) = super::get_hwnd(handle) {
             let font = super::text::create_font_with_family_pub(size as i32, 400, "Segoe UI");
             unsafe {
-                SendMessageW(hwnd, WM_SETFONT, WPARAM(font.0 as usize), LPARAM(1));
+                SendMessageW(hwnd, WM_SETFONT, Some(WPARAM(font.0 as usize)), Some(LPARAM(1)));
             }
         }
     }

--- a/crates/perry-ui-windows/src/widgets/toast.rs
+++ b/crates/perry-ui-windows/src/widgets/toast.rs
@@ -178,7 +178,7 @@ fn present_toast_win32(msg: String) {
             TOAST_HEIGHT,
             None,
             None,
-            HINSTANCE::from(hinstance),
+            Some(HINSTANCE::from(hinstance)),
             None,
         ) {
             Ok(h) => h,
@@ -199,7 +199,7 @@ fn present_toast_win32(msg: String) {
             CORNER_RADIUS,
         );
         if !rgn.is_invalid() {
-            SetWindowRgn(hwnd, rgn, false);
+            SetWindowRgn(hwnd, Some(rgn), false);
             // SetWindowRgn takes ownership of the region — don't DeleteObject(rgn).
         }
 
@@ -219,7 +219,7 @@ fn present_toast_win32(msg: String) {
         let _ = UpdateWindow(hwnd);
 
         // 50ms tick timer drives the fade-in / hold / fade-out animation.
-        let _ = SetTimer(hwnd, TIMER_ID, 50, None);
+        let _ = SetTimer(Some(hwnd), TIMER_ID, 50, None);
     }
 }
 
@@ -268,7 +268,7 @@ fn tick_animation(hwnd: HWND) {
     if done {
         ACTIVE_TOAST.with(|s| *s.borrow_mut() = None);
         unsafe {
-            let _ = KillTimer(hwnd, TIMER_ID);
+            let _ = KillTimer(Some(hwnd), TIMER_ID);
             let _ = DestroyWindow(hwnd);
         }
         PRESENTING.with(|p| p.set(false));
@@ -294,7 +294,7 @@ unsafe fn paint_toast(hwnd: HWND) {
     let mut client_rect = RECT::default();
     GetClientRect(hwnd, &mut client_rect).ok();
     FillRect(hdc, &client_rect, bg_brush);
-    let _ = DeleteObject(bg_brush);
+    let _ = DeleteObject(bg_brush.into());
 
     // Draw white text, centered.
     let mut wide: Vec<u16> = msg.encode_utf16().collect();
@@ -313,15 +313,15 @@ unsafe fn paint_toast(hwnd: HWND) {
             0,
             0,
             0,
-            0,
-            0,
-            0,
-            0,
+            windows::Win32::Graphics::Gdi::FONT_CHARSET(0),
+            windows::Win32::Graphics::Gdi::FONT_OUTPUT_PRECISION(0),
+            windows::Win32::Graphics::Gdi::FONT_CLIP_PRECISION(0),
+            windows::Win32::Graphics::Gdi::FONT_QUALITY(0),
             0,
             windows::core::PCWSTR(font_family.as_ptr()),
         );
         let old_font: HGDIOBJ = if !hfont.is_invalid() {
-            SelectObject(hdc, hfont)
+            SelectObject(hdc, hfont.into())
         } else {
             HGDIOBJ::default()
         };
@@ -344,7 +344,7 @@ unsafe fn paint_toast(hwnd: HWND) {
             SelectObject(hdc, old_font);
         }
         if !hfont.is_invalid() {
-            let _ = DeleteObject(hfont);
+            let _ = DeleteObject(hfont.into());
         }
     }
 
@@ -377,7 +377,7 @@ unsafe extern "system" fn toast_wnd_proc(
         x if x == WM_DESTROY => {
             // Kill the timer defensively in case DestroyWindow is called
             // externally (e.g. app shutdown before the fade completes).
-            let _ = KillTimer(hwnd, TIMER_ID);
+            let _ = KillTimer(Some(hwnd), TIMER_ID);
             LRESULT(0)
         }
         _ => DefWindowProcW(hwnd, msg, wparam, lparam),

--- a/crates/perry-ui-windows/src/widgets/toggle.rs
+++ b/crates/perry-ui-windows/src/widgets/toggle.rs
@@ -111,7 +111,8 @@ pub fn handle_click(handle: i64) {
     {
         if let Some(hwnd) = super::get_hwnd(handle) {
             let checked = unsafe {
-                SendMessageW(hwnd, BM_GETCHECK, Some(WPARAM(0)), Some(LPARAM(0))).0 == BST_CHECKED.0 as isize
+                SendMessageW(hwnd, BM_GETCHECK, Some(WPARAM(0)), Some(LPARAM(0))).0
+                    == BST_CHECKED.0 as isize
             };
             let value = if checked { 1.0 } else { 0.0 };
 
@@ -138,7 +139,12 @@ pub fn set_state(handle: i64, on: i32) {
         if let Some(hwnd) = super::get_hwnd(handle) {
             let check = if on != 0 { BST_CHECKED } else { BST_UNCHECKED };
             unsafe {
-                SendMessageW(hwnd, BM_SETCHECK, Some(WPARAM(check.0 as usize)), Some(LPARAM(0)));
+                SendMessageW(
+                    hwnd,
+                    BM_SETCHECK,
+                    Some(WPARAM(check.0 as usize)),
+                    Some(LPARAM(0)),
+                );
             }
         }
     }

--- a/crates/perry-ui-windows/src/widgets/toggle.rs
+++ b/crates/perry-ui-windows/src/widgets/toggle.rs
@@ -61,9 +61,9 @@ pub fn create(label_ptr: *const u8, on_change: f64) -> i64 {
                 0,
                 100,
                 24,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();
@@ -111,7 +111,7 @@ pub fn handle_click(handle: i64) {
     {
         if let Some(hwnd) = super::get_hwnd(handle) {
             let checked = unsafe {
-                SendMessageW(hwnd, BM_GETCHECK, WPARAM(0), LPARAM(0)).0 == BST_CHECKED.0 as isize
+                SendMessageW(hwnd, BM_GETCHECK, Some(WPARAM(0)), Some(LPARAM(0))).0 == BST_CHECKED.0 as isize
             };
             let value = if checked { 1.0 } else { 0.0 };
 
@@ -138,7 +138,7 @@ pub fn set_state(handle: i64, on: i32) {
         if let Some(hwnd) = super::get_hwnd(handle) {
             let check = if on != 0 { BST_CHECKED } else { BST_UNCHECKED };
             unsafe {
-                SendMessageW(hwnd, BM_SETCHECK, WPARAM(check.0 as usize), LPARAM(0));
+                SendMessageW(hwnd, BM_SETCHECK, Some(WPARAM(check.0 as usize)), Some(LPARAM(0)));
             }
         }
     }

--- a/crates/perry-ui-windows/src/widgets/tree_view.rs
+++ b/crates/perry-ui-windows/src/widgets/tree_view.rs
@@ -242,7 +242,12 @@ unsafe fn walk_and_apply_expand(hwnd: HWND, h_item: isize, code: u32) {
     if h_item == 0 {
         return;
     }
-    SendMessageW(hwnd, TVM_EXPAND, Some(WPARAM(code as usize)), Some(LPARAM(h_item)));
+    SendMessageW(
+        hwnd,
+        TVM_EXPAND,
+        Some(WPARAM(code as usize)),
+        Some(LPARAM(h_item)),
+    );
     // Walk children — TVGN_CHILD = 4.
     let child = SendMessageW(hwnd, TVM_GETNEXTITEM, Some(WPARAM(4)), Some(LPARAM(h_item))).0;
     walk_and_apply_expand(hwnd, child, code);

--- a/crates/perry-ui-windows/src/widgets/tree_view.rs
+++ b/crates/perry-ui-windows/src/widgets/tree_view.rs
@@ -169,8 +169,8 @@ unsafe fn insert_node(hwnd: HWND, h_parent: isize, node_id: i64) -> isize {
     let h: isize = SendMessageW(
         hwnd,
         TVM_INSERTITEMW,
-        WPARAM(0),
-        LPARAM(&ins as *const _ as isize),
+        Some(WPARAM(0)),
+        Some(LPARAM(&ins as *const _ as isize)),
     )
     .0;
     for child in children {
@@ -205,9 +205,9 @@ pub fn create(root_node: i64, on_select: f64) -> i64 {
                 0,
                 240,
                 320,
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             );
             let Ok(hwnd) = hwnd else {
@@ -242,12 +242,12 @@ unsafe fn walk_and_apply_expand(hwnd: HWND, h_item: isize, code: u32) {
     if h_item == 0 {
         return;
     }
-    SendMessageW(hwnd, TVM_EXPAND, WPARAM(code as usize), LPARAM(h_item));
+    SendMessageW(hwnd, TVM_EXPAND, Some(WPARAM(code as usize)), Some(LPARAM(h_item)));
     // Walk children — TVGN_CHILD = 4.
-    let child = SendMessageW(hwnd, TVM_GETNEXTITEM, WPARAM(4), LPARAM(h_item)).0;
+    let child = SendMessageW(hwnd, TVM_GETNEXTITEM, Some(WPARAM(4)), Some(LPARAM(h_item))).0;
     walk_and_apply_expand(hwnd, child, code);
     // Walk siblings — TVGN_NEXT = 1.
-    let sibling = SendMessageW(hwnd, TVM_GETNEXTITEM, WPARAM(1), LPARAM(h_item)).0;
+    let sibling = SendMessageW(hwnd, TVM_GETNEXTITEM, Some(WPARAM(1)), Some(LPARAM(h_item))).0;
     walk_and_apply_expand(hwnd, sibling, code);
 }
 
@@ -259,7 +259,7 @@ pub fn expand_all(handle: i64) {
         };
         unsafe {
             // TVGN_ROOT = 0
-            let root = SendMessageW(hwnd, TVM_GETNEXTITEM, WPARAM(0), LPARAM(0)).0;
+            let root = SendMessageW(hwnd, TVM_GETNEXTITEM, Some(WPARAM(0)), Some(LPARAM(0))).0;
             walk_and_apply_expand(hwnd, root, TVE_EXPAND);
         }
     }
@@ -276,7 +276,7 @@ pub fn collapse_all(handle: i64) {
             return;
         };
         unsafe {
-            let root = SendMessageW(hwnd, TVM_GETNEXTITEM, WPARAM(0), LPARAM(0)).0;
+            let root = SendMessageW(hwnd, TVM_GETNEXTITEM, Some(WPARAM(0)), Some(LPARAM(0))).0;
             walk_and_apply_expand(hwnd, root, TVE_COLLAPSE);
         }
     }
@@ -297,8 +297,8 @@ pub fn get_selected_id(handle: i64) -> f64 {
             let h_item = SendMessageW(
                 hwnd,
                 TVM_GETNEXTITEM,
-                WPARAM(TVGN_CARET as usize),
-                LPARAM(0),
+                Some(WPARAM(TVGN_CARET as usize)),
+                Some(LPARAM(0)),
             )
             .0;
             if h_item == 0 {
@@ -335,8 +335,8 @@ unsafe fn read_node_id_from_h_item(hwnd: HWND, h_item: isize) -> Option<String> 
     let ok = SendMessageW(
         hwnd,
         TVM_GETITEMW,
-        WPARAM(0),
-        LPARAM(&mut item as *mut _ as isize),
+        Some(WPARAM(0)),
+        Some(LPARAM(&mut item as *mut _ as isize)),
     )
     .0;
     if ok == 0 {
@@ -364,8 +364,8 @@ pub fn handle_selection_change(handle: i64) {
         let h_item = SendMessageW(
             hwnd,
             TVM_GETNEXTITEM,
-            WPARAM(TVGN_CARET as usize),
-            LPARAM(0),
+            Some(WPARAM(TVGN_CARET as usize)),
+            Some(LPARAM(0)),
         )
         .0;
         if h_item == 0 {

--- a/crates/perry-ui-windows/src/widgets/vstack.rs
+++ b/crates/perry-ui-windows/src/widgets/vstack.rs
@@ -62,7 +62,7 @@ unsafe extern "system" fn container_wnd_proc(
             // is the default (no custom brush), provide our own ancestor brush
             // so child controls get the correct background with WS_CLIPCHILDREN.
             if let Ok(parent) = GetParent(hwnd) {
-                let result = SendMessageW(parent, msg, wparam, lparam);
+                let result = SendMessageW(parent, msg, Some(wparam), Some(lparam));
                 if result.0 != 0 {
                     return result;
                 }
@@ -82,13 +82,13 @@ unsafe extern "system" fn container_wnd_proc(
         }
         WM_COMMAND | WM_CONTEXTMENU | WM_DRAWITEM => {
             if let Ok(parent) = GetParent(hwnd) {
-                return SendMessageW(parent, msg, wparam, lparam);
+                return SendMessageW(parent, msg, Some(wparam), Some(lparam));
             }
             DefWindowProcW(hwnd, msg, wparam, lparam)
         }
         x if x == 0x0133 /* WM_CTLCOLOREDIT */ => {
             if let Ok(parent) = GetParent(hwnd) {
-                return SendMessageW(parent, msg, wparam, lparam);
+                return SendMessageW(parent, msg, Some(wparam), Some(lparam));
             }
             DefWindowProcW(hwnd, msg, wparam, lparam)
         }
@@ -126,7 +126,7 @@ unsafe extern "system" fn container_wnd_proc(
                     let mut rect = RECT::default();
                     let _ = GetClientRect(hwnd, &mut rect);
                     let _ = FillRect(hdc, &rect, brush);
-                    let _ = windows::Win32::Graphics::Gdi::DeleteObject(brush);
+                    let _ = windows::Win32::Graphics::Gdi::DeleteObject(brush.into());
                     return LRESULT(1);
                 } else {
                     let mut ps = windows::Win32::Graphics::Gdi::PAINTSTRUCT::default();
@@ -134,7 +134,7 @@ unsafe extern "system" fn container_wnd_proc(
                     let mut rect = RECT::default();
                     let _ = GetClientRect(hwnd, &mut rect);
                     let _ = FillRect(hdc, &rect, brush);
-                    let _ = windows::Win32::Graphics::Gdi::DeleteObject(brush);
+                    let _ = windows::Win32::Graphics::Gdi::DeleteObject(brush.into());
                     windows::Win32::Graphics::Gdi::EndPaint(hwnd, &ps);
                     return LRESULT(0);
                 }
@@ -191,9 +191,9 @@ pub fn create_with_insets(spacing: f64, top: f64, left: f64, bottom: f64, right:
                 0,
                 100,
                 100,
-                super::get_parking_hwnd(),
+                Some(super::get_parking_hwnd()),
                 None,
-                HINSTANCE::from(hinstance),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();

--- a/crates/perry-ui-windows/src/widgets/webview.rs
+++ b/crates/perry-ui-windows/src/widgets/webview.rs
@@ -339,9 +339,11 @@ fn init_webview2_sync(handle: i64, user_data_dir: &PathBuf) -> windows::core::Re
             } else if let Some(env) = environment {
                 env_done_clone.set(Some(Ok(env)));
             } else {
-                env_done_clone.set(Some(Err(windows::core::Error::from(windows::core::HRESULT::from_win32(unsafe {
-                    windows::Win32::Foundation::GetLastError().0
-                })))));
+                env_done_clone.set(Some(Err(windows::core::Error::from(
+                    windows::core::HRESULT::from_win32(unsafe {
+                        windows::Win32::Foundation::GetLastError().0
+                    }),
+                ))));
             }
             env_ready_clone.set(true);
             Ok(())
@@ -381,9 +383,11 @@ fn init_webview2_sync(handle: i64, user_data_dir: &PathBuf) -> windows::core::Re
             } else if let Some(c) = controller {
                 ctrl_done_clone.set(Some(Ok(c)));
             } else {
-                ctrl_done_clone.set(Some(Err(windows::core::Error::from(windows::core::HRESULT::from_win32(unsafe {
-                    windows::Win32::Foundation::GetLastError().0
-                })))));
+                ctrl_done_clone.set(Some(Err(windows::core::Error::from(
+                    windows::core::HRESULT::from_win32(unsafe {
+                        windows::Win32::Foundation::GetLastError().0
+                    }),
+                ))));
             }
             ctrl_ready_clone.set(true);
             Ok(())

--- a/crates/perry-ui-windows/src/widgets/webview.rs
+++ b/crates/perry-ui-windows/src/widgets/webview.rs
@@ -36,15 +36,13 @@ use webview2_com::Microsoft::Web::WebView2::Win32::*;
 #[cfg(target_os = "windows")]
 use webview2_com::*;
 #[cfg(target_os = "windows")]
-use windows::core::{Interface, PCWSTR, PWSTR};
+use windows::core::{Interface, BOOL, PCWSTR, PWSTR};
 #[cfg(target_os = "windows")]
 use windows::Win32::Foundation::*;
 #[cfg(target_os = "windows")]
 use windows::Win32::System::Com::CoTaskMemFree;
 #[cfg(target_os = "windows")]
 use windows::Win32::System::LibraryLoader::GetModuleHandleW;
-#[cfg(target_os = "windows")]
-use windows::Win32::System::WinRT::EventRegistrationToken;
 #[cfg(target_os = "windows")]
 use windows::Win32::UI::WindowsAndMessaging::*;
 
@@ -218,9 +216,9 @@ pub fn create(url_ptr: *const u8, width: f64, height: f64, ephemeral_hint: f64) 
                 0,
                 if width > 0.0 { width as i32 } else { 600 },
                 if height > 0.0 { height as i32 } else { 400 },
-                super::get_parking_hwnd(),
-                HMENU(control_id as *mut _),
-                HINSTANCE::from(hinstance),
+                Some(super::get_parking_hwnd()),
+                Some(HMENU(control_id as *mut _)),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
         }
@@ -341,7 +339,9 @@ fn init_webview2_sync(handle: i64, user_data_dir: &PathBuf) -> windows::core::Re
             } else if let Some(env) = environment {
                 env_done_clone.set(Some(Ok(env)));
             } else {
-                env_done_clone.set(Some(Err(windows::core::Error::from_win32())));
+                env_done_clone.set(Some(Err(windows::core::Error::from(windows::core::HRESULT::from_win32(unsafe {
+                    windows::Win32::Foundation::GetLastError().0
+                })))));
             }
             env_ready_clone.set(true);
             Ok(())
@@ -381,7 +381,9 @@ fn init_webview2_sync(handle: i64, user_data_dir: &PathBuf) -> windows::core::Re
             } else if let Some(c) = controller {
                 ctrl_done_clone.set(Some(Ok(c)));
             } else {
-                ctrl_done_clone.set(Some(Err(windows::core::Error::from_win32())));
+                ctrl_done_clone.set(Some(Err(windows::core::Error::from(windows::core::HRESULT::from_win32(unsafe {
+                    windows::Win32::Foundation::GetLastError().0
+                })))));
             }
             ctrl_ready_clone.set(true);
             Ok(())
@@ -557,7 +559,7 @@ fn install_navigation_handlers(handle: i64, webview: &ICoreWebView2) {
         Ok(())
     }));
 
-    let mut token = EventRegistrationToken::default();
+    let mut token: i64 = 0;
     unsafe {
         let _ = webview.add_NavigationStarting(&nav_starting, &mut token);
         let _ = webview.add_NavigationCompleted(&nav_completed, &mut token);

--- a/crates/perry-ui-windows/src/widgets/zstack.rs
+++ b/crates/perry-ui-windows/src/widgets/zstack.rs
@@ -69,9 +69,9 @@ pub fn create() -> i64 {
                 0,
                 100,
                 100,
-                super::get_parking_hwnd(),
+                Some(super::get_parking_hwnd()),
                 None,
-                HINSTANCE::from(hinstance),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();

--- a/crates/perry-ui-windows/src/window.rs
+++ b/crates/perry-ui-windows/src/window.rs
@@ -143,7 +143,7 @@ pub fn create(title_ptr: *const u8, width: f64, height: f64) -> i64 {
                 height as i32,
                 None,
                 None,
-                HINSTANCE::from(hinstance),
+                Some(HINSTANCE::from(hinstance)),
                 None,
             )
             .unwrap();
@@ -183,7 +183,7 @@ pub fn set_body(window_handle: i64, widget_handle: i64) {
             if let Some(parent_hwnd) = w.borrow().get(&window_handle) {
                 if let Some(child_hwnd) = crate::widgets::get_hwnd(widget_handle) {
                     unsafe {
-                        let _ = SetParent(child_hwnd, *parent_hwnd);
+                        let _ = SetParent(child_hwnd, Some(*parent_hwnd));
                         let style = GetWindowLongW(child_hwnd, GWL_STYLE) as u32;
                         SetWindowLongW(child_hwnd, GWL_STYLE, (style | WS_CHILD.0) as i32);
                         // Trigger initial layout (mirrors app_set_body)


### PR DESCRIPTION
## Why

v0.5.1180 packaged macOS / Linux / Android but **published nothing**. Every publish job in `release-packages.yml` (`npm-publish`, `homebrew`, `apt`, `apt-repo`, `winget`, `update-workers`) is `needs: build`, and the `build` matrix's **Windows leg failed to compile** → the whole `build` job went `failure` → all publishers were skipped. Only the GitHub Release page shipped.

## Root cause

Dependabot bump `c0f46f07e` raised `webview2-com` to `=0.39`, which resolves `windows` / `windows-core` to **0.62.2** — but `crates/perry-ui-windows/Cargo.toml` still pinned them at **0.58**. The WebView2 COM interfaces were then a different crate version than perry's own `HWND`/`RECT`/`PCWSTR`/`PWSTR`/`Interface` types, so `widgets/webview.rs` failed to type-check (the in-file comment had literally warned this skew would break the build).

## Fix

Align `perry-ui-windows` to `windows`/`windows-core` **0.62** and migrate the source to the 0.62 API. Mechanical, behavior-preserving, ~47 files:

- `Option<HANDLE>` params on many Win32 calls → wrap present handles in `Some(…)`.
- GDI handles → `HGDIOBJ` via `.into()` (`DeleteObject`/`SelectObject`/`GetObjectW`).
- `CreateFontW` charset/precision/quality ints → 0.62 newtypes.
- `BOOL` moved `windows::Win32::Foundation` → `windows::core`.
- `#[implement]` COM authoring + a winrt `TypedEventHandler`: `Option<&T>` → `windows::core::Ref<'_, T>`.
- `Error::from_win32()` → `Error::from(HRESULT::from_win32(GetLastError().0))`; event tokens now `i64`; `implement` macro via `windows-core` re-export (the `windows` `implement` feature was removed in 0.62).

## Verification

The Windows build is **not** in the PR `Tests` matrix (only `release-packages.yml` on a tag builds it), so it was cross-checked locally against the exact CI target:

```
cargo xwin check -p perry-ui-windows --target x86_64-pc-windows-msvc   # clean, 0 errors
```

`perry-ui-windows` was the sole failing crate in the v0.5.1180 Windows build, so this restores both `build (windows)` and `build-cross (perry-ui-windows)` and unblocks the publish jobs.

> Follow-up worth tracking separately: decouple `release-packages.yml` so a single platform's build failure can't skip *all* publishers (macOS/Linux should ship even if Windows breaks).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Windows release build and publish jobs that were previously skipped.

* **Chores**
  * Updated Windows dependencies and added cross-compilation support for x86_64-pc-windows-msvc.
  * Version bumped to 0.5.1181.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->