### PR TITLE
fix(hir): native-builtin require destructuring stranded on pre-registered module-var slot (#5364 × #5216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+## v0.5.1182 — fix(hir): native-builtin require destructuring stranded on a pre-registered module-var slot (#5364 × #5216 merge skew)
+
+`const { createInterface } = require("readline")` (and every destructured
+native/Node-builtin `require`) regressed to `undefined` for the bound leaf on
+`main` after v0.5.1180 — a merge-skew interaction between two independently-green
+PRs:
+
+- **#5216** lowers `const { x } = require("<native>")` by registering each
+  destructured leaf as a *native-module alias* (`register_native_module`) and
+  skipping the runtime local, so `x` / `typeof x` resolves through the static
+  native table — exact `import { x } from "<native>"` parity.
+- **#5364** taught the module-level forward-declaration pass to *pre-register*
+  destructuring leaves as module-var locals (fixing semver's bottom-of-file
+  cyclic `const { safeRe, t } = require('../internal/re')`).
+
+Together, the native-alias leaf now also had a pre-registered module-var local
+that was never written (its runtime destructuring is skipped). A bare `x` read
+resolved to that stale `undefined` local and shadowed the native alias →
+`typeof createInterface === "undefined"`. The `require_native_builtin_lowers_like_namespace_import`
+gap test (correct as written) caught it; each PR was green on its own base, so
+it slipped in only at the merged HEAD and failed the `cargo-test` gate, blocking
+the v0.5.1181 publish.
+
+Fix (`destructuring/var_decl_sources.rs`): in the native-alias branches
+(generic resolvable-native modules + `net`'s skipped factory leaves), drop the
+pre-registered module-var local via `ctx.remove_local_binding(&binding)` — the
+same thing the simple-ident `register_require_namespace_binding` path already
+does — so the leaf resolves to the native table, not a stranded local. The
+relative/file-require path that #5364 targets (`require('../internal/re')`) is
+not a resolvable native specifier, so it never enters these branches and keeps
+#5364's behavior unchanged. Verified: all 6 `module_import_forms` tests pass and
+#5364's `test_cjs_module_destructure_after_class.sh` still passes.
+
 ## v0.5.1181 — fix(perry-ui-windows): migrate to windows / windows-core 0.62 (unblock Windows release publish)
 
 The v0.5.1180 release packaged macOS, Linux and Android, but **published

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1181
+**Current Version:** 0.5.1182
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5283,7 +5283,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "anyhow",
  "base64",
@@ -5340,14 +5340,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "cc",
  "libc",
@@ -5355,7 +5355,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "anyhow",
  "log",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5379,7 +5379,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "anyhow",
  "base64",
@@ -5419,7 +5419,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5456,14 +5456,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "serde",
  "serde_json",
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1181"
+version = "0.5.1182"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "anyhow",
  "clap",
@@ -5497,14 +5497,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5512,7 +5512,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5545,7 +5545,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5571,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5603,14 +5603,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5652,7 +5652,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "bytes",
  "h2",
@@ -5675,7 +5675,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5685,7 +5685,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5696,7 +5696,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5704,7 +5704,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5712,7 +5712,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "bson",
  "futures-util",
@@ -5724,7 +5724,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5734,7 +5734,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5765,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5782,7 +5782,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "base64",
  "image",
@@ -5799,14 +5799,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5815,7 +5815,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5833,7 +5833,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5845,7 +5845,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "brotli",
  "flate2",
@@ -5854,7 +5854,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5881,7 +5881,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5893,7 +5893,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "anyhow",
  "base64",
@@ -5926,7 +5926,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6018,7 +6018,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6028,7 +6028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6036,14 +6036,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "base64",
  "itoa",
@@ -6060,7 +6060,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6070,7 +6070,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6093,7 +6093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "base64",
  "block2",
@@ -6109,7 +6109,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "base64",
  "block2",
@@ -6124,7 +6124,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1181"
+version = "0.5.1182"
 
 [[package]]
 name = "perry-ui-test"
@@ -6132,11 +6132,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1181"
+version = "0.5.1182"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "base64",
  "block2",
@@ -6152,7 +6152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "base64",
  "block2",
@@ -6168,7 +6168,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "block2",
  "libc",
@@ -6181,7 +6181,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "base64",
  "libc",
@@ -6198,14 +6198,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6219,7 +6219,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1181"
+version = "0.5.1182"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ strip = false
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1181"
+version = "0.5.1182"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-hir/src/destructuring/var_decl_sources.rs
+++ b/crates/perry-hir/src/destructuring/var_decl_sources.rs
@@ -184,6 +184,15 @@ pub(super) fn register_destructured_stream_ctors(
                     _ => continue,
                 };
                 ctx.register_native_module(binding.clone(), module.clone(), Some(key));
+                // #5364 interaction: the module-level forward-declaration pass
+                // now pre-registers destructuring leaves as module-var locals.
+                // For a native-alias leaf that local is never written (the
+                // runtime destructuring is skipped below), so a bare
+                // `binding` / `typeof binding` read would resolve to that stale
+                // `undefined` local and shadow the native alias. Drop it so the
+                // name resolves to the native table, exactly as the simple-ident
+                // `register_require_namespace_binding` path does.
+                ctx.remove_local_binding(&binding);
                 skip_local_bindings.push(binding);
             }
             return skip_local_bindings;
@@ -224,6 +233,12 @@ pub(super) fn register_destructured_stream_ctors(
         if allowed.contains(&key.as_str()) {
             ctx.register_native_module(binding.clone(), module.clone(), Some(key));
             if module == "net" {
+                // Same #5364 interaction as the generic native branch above:
+                // drop the pre-registered module-var local for skipped leaves
+                // so the name resolves to the native alias, not a stale
+                // `undefined` local. (Stream ctors keep their runtime local and
+                // are not skipped, so they are intentionally left untouched.)
+                ctx.remove_local_binding(&binding);
                 skip_local_bindings.push(binding);
             }
         }


### PR DESCRIPTION
## Why

`const { createInterface } = require("readline")` (and every destructured native/Node-builtin `require`) regressed to `undefined` for the bound leaf on `main` after v0.5.1180. This failed the `require_native_builtin_lowers_like_namespace_import` gap test (`cargo-test` hard gate) and **blocked the v0.5.1181 release publish**.

## Root cause — a merge-skew between two independently-green PRs

- **#5216** lowers `const { x } = require("<native>")` by aliasing each leaf to the native table (`register_native_module`) and skipping the runtime local, so `x`/`typeof x` resolves through the static table (exact `import { x } from "<native>"` parity).
- **#5364** taught the module-level forward-declaration pass to *pre-register* destructuring leaves as module-var locals (to fix semver's bottom-of-file cyclic `const { safeRe, t } = require('../internal/re')`).

Together, a native-alias leaf now *also* had a pre-registered module-var local that is never written (its runtime destructuring is skipped). A bare `x` read resolved to that stale `undefined` local and shadowed the native alias. Each PR was green on its own base; the bug appears only at the merged HEAD.

## Fix

In `destructuring/var_decl_sources.rs`, the native-alias branches now drop the pre-registered local via `ctx.remove_local_binding(&binding)` — the same thing the simple-ident `register_require_namespace_binding` path already does at the namespace-binding site. The relative/file-require path #5364 targets is not a resolvable-native specifier, so it never enters these branches and #5364's behavior is unchanged.

## Verification (local)

- `cargo test -p perry --test module_import_forms` → **6/6 pass** (incl. the previously-failing test).
- #5364's `tests/test_cjs_module_destructure_after_class.sh` → **PASS** (semver cyclic-require case preserved).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a regression in native-builtin `require` destructuring that was incorrectly resolving to `undefined` after recent changes. Destructured module members now correctly resolve through the native-module alias table instead of stale local variable bindings. All relevant module import and destructuring tests pass.

* **Chores**
  * Version bumped to 0.5.1182.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->