### PR TITLE
fix(hir): suppress Annex B.3.3 legacy var across for-head/destructuring-catch lexicals (#5346)

### DIFF
--- a/crates/perry-hir/src/lower_decl/block.rs
+++ b/crates/perry-hir/src/lower_decl/block.rs
@@ -562,6 +562,22 @@ pub(crate) fn collect_lexical_decl_names(
     }
 }
 
+/// Add the lexically-bound names of a `let`/`const` for-head to the Annex B
+/// forbidden set. A `var` for-head is not lexical and does not gate B.3.3.
+fn annexb_forhead_lexical_names(
+    var_decl: &ast::VarDecl,
+    out: &mut std::collections::HashSet<String>,
+) {
+    if var_decl.kind == ast::VarDeclKind::Var {
+        return;
+    }
+    for decl in &var_decl.decls {
+        let mut names = Vec::new();
+        collect_var_binding_names_from_pat(&decl.name, &mut names);
+        out.extend(names);
+    }
+}
+
 /// Annex B B.3.3 (#5297): collect the names of function declarations that
 /// appear *inside a nested block* of a function/program body. In sloppy mode
 /// such a legacy block-level function declaration ALSO creates a `var`-style
@@ -632,9 +648,30 @@ fn annexb_nested_stmt(
         ast::Stmt::DoWhile(do_while) => {
             annexb_nested_stmt(&do_while.body, forbidden, all_out, var_out)
         }
-        ast::Stmt::For(for_stmt) => annexb_nested_stmt(&for_stmt.body, forbidden, all_out, var_out),
-        ast::Stmt::ForIn(for_in) => annexb_nested_stmt(&for_in.body, forbidden, all_out, var_out),
-        ast::Stmt::ForOf(for_of) => annexb_nested_stmt(&for_of.body, forbidden, all_out, var_out),
+        ast::Stmt::For(for_stmt) => {
+            // A `let`/`const` for-head (`for (let f; ;)`) lexically scopes the
+            // body, so the equivalent enclosing `var f` would be an early error
+            // — B.3.3 skips it. Seed those names into the body's forbidden set.
+            let mut inner = forbidden.clone();
+            if let Some(ast::VarDeclOrExpr::VarDecl(vd)) = &for_stmt.init {
+                annexb_forhead_lexical_names(vd, &mut inner);
+            }
+            annexb_nested_stmt(&for_stmt.body, &inner, all_out, var_out)
+        }
+        ast::Stmt::ForIn(for_in) => {
+            let mut inner = forbidden.clone();
+            if let ast::ForHead::VarDecl(vd) = &for_in.left {
+                annexb_forhead_lexical_names(vd, &mut inner);
+            }
+            annexb_nested_stmt(&for_in.body, &inner, all_out, var_out)
+        }
+        ast::Stmt::ForOf(for_of) => {
+            let mut inner = forbidden.clone();
+            if let ast::ForHead::VarDecl(vd) = &for_of.left {
+                annexb_forhead_lexical_names(vd, &mut inner);
+            }
+            annexb_nested_stmt(&for_of.body, &inner, all_out, var_out)
+        }
         ast::Stmt::Labeled(labeled) => {
             annexb_nested_stmt(&labeled.body, forbidden, all_out, var_out)
         }
@@ -654,7 +691,18 @@ fn annexb_nested_stmt(
         ast::Stmt::Try(try_stmt) => {
             annexb_nested_block(&try_stmt.block.stmts, forbidden, all_out, var_out);
             if let Some(handler) = &try_stmt.handler {
-                annexb_nested_block(&handler.body.stmts, forbidden, all_out, var_out);
+                // A *destructuring* catch parameter (`catch ({ f })`) lexically
+                // binds its names, so a same-named enclosing `var` would be an
+                // early error and B.3.3 is skipped. A *simple* catch binding
+                // (`catch (f)`) is exempt — Annex B.3.4 lets a `var f` alias it,
+                // so it does not gate B.3.3.
+                let mut inner = forbidden.clone();
+                if let Some(param @ (ast::Pat::Array(_) | ast::Pat::Object(_))) = &handler.param {
+                    let mut names = Vec::new();
+                    collect_var_binding_names_from_pat(param, &mut names);
+                    inner.extend(names);
+                }
+                annexb_nested_block(&handler.body.stmts, &inner, all_out, var_out);
             }
             if let Some(finalizer) = &try_stmt.finalizer {
                 annexb_nested_block(&finalizer.stmts, forbidden, all_out, var_out);


### PR DESCRIPTION
## Summary

Closes the dominant cluster from #5346 (follow-up to #5297/#5319): **94× `An initialized binding is not created`** in test262 `annexB/language`.

These are the B.3.3 **skip** cases. A sloppy block-nested `function f(){}` gets an enclosing-scope legacy `var f` *only* when replacing it with `var f` would not be an early error. #5319's collector seeded the `forbidden` set with the body's own top-level lexicals and each descended block's `let`/`const`/`class`, but **missed lexicals introduced by intermediate scopes** between the body and the nested declaration:

- a `let`/`const` **for-head** — `for (let f; ;) { { function f(){} } }`, `for (let f in/of …) { … }` — lexically scopes the loop body, so an enclosing `var f` collides → early error → var suppressed;
- a **destructuring catch parameter** — `catch ({ f }) { { function f(){} } }` — lexically binds its names. A *simple* `catch (f)` is exempt: Annex B.3.4 lets `var f` alias it, so it does **not** gate B.3.3.

Perry created the legacy `var` regardless, so `f` was observable (and a function after the block ran) where the spec keeps it unbound — reading `f` must throw `ReferenceError` and `typeof f` stay `"undefined"`.

## Fix

Seed the for-head (`let`/`const` only) and destructuring-catch lexical names into the `forbidden` set as the B.3.3 traversal descends into each of those bodies (`annexb_nested_stmt` in `lower_decl/block.rs`). Pure addition to the forbidden-set computation — no other lowering path is touched. The `switch` skip variant already worked (case lexicals were collected).

## Validation

- New behavior matches `node v26` exactly for the for / for-in / for-of / switch / try shapes (`f` throws `ReferenceError`, `typeof f === "undefined"` before and after the block).
- test262 `annexB/language` (`--all-features`, node v26 differential): **all 112** `function-code`/`global-code` `*skip-early-err-{for,for-in,for-of,switch,try}` cases now pass; overall annexB parity **645/970 → 776/1026 (75.6%)**.
- The `eval-code` variants of the same shape still fail — they need eval enablement (separate item in #5346).
- No regressions in the positive B.3.3 cases. `cargo test -p perry-hir` green.

Remaining #5346 clusters (out of scope here): 72× dynamic `eval` (AOT limit), 73× Annex B missed-negatives, and the `existing-fn-no-init` hoisting-precedence SameValue cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scoping correctness in for loops and try-catch blocks to ensure consistent behavior with JavaScript standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->