### PR TITLE
fix(hir): throw TypeError for Reflect.apply with omitted argumentsList (#5347)

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -1209,7 +1209,16 @@ pub(super) fn try_native_module_methods(
                             let mut it = args.into_iter();
                             let func = it.next().unwrap_or(Expr::Undefined);
                             let this_arg = it.next().unwrap_or(Expr::Undefined);
-                            let args_arr = it.next().unwrap_or(Expr::Array(vec![]));
+                            // Spec sec-reflect.apply runs CreateListFromArrayLike
+                            // on argumentsList, which throws a TypeError when
+                            // Type(argumentsList) is not Object. An OMITTED
+                            // argumentsList is `undefined` (not Object), so it
+                            // must reach the runtime as `undefined` and throw —
+                            // NOT default to an empty array, which would silently
+                            // succeed with no args (test262
+                            // Reflect/apply/arguments-list-is-not-array-like
+                            // `Reflect.apply(fn, null /* empty */)`).
+                            let args_arr = it.next().unwrap_or(Expr::Undefined);
                             return Ok(Ok(Expr::ReflectApply {
                                 func: Box::new(func),
                                 this_arg: Box::new(this_arg),

--- a/test-parity/node-suite/globals/reflect-apply-argumentslist-not-object.ts
+++ b/test-parity/node-suite/globals/reflect-apply-argumentslist-not-object.ts
@@ -1,0 +1,39 @@
+// Reflect.apply(target, thisArgument, argumentsList): per spec
+// sec-reflect.apply the argumentsList is run through CreateListFromArrayLike,
+// which throws a TypeError when Type(argumentsList) is not Object. Unlike
+// Function.prototype.apply (where a nullish argArray means "no arguments"),
+// Reflect.apply rejects EVERY non-object argumentsList — null, undefined, and
+// primitives all throw — and an OMITTED argumentsList is `undefined`, so it
+// must throw too rather than silently calling with zero arguments.
+// test262: built-ins/Reflect/apply/arguments-list-is-not-array-like.js
+function fn(...args: unknown[]): number {
+  return args.length;
+}
+
+function probe(label: string, run: () => unknown): void {
+  try {
+    const result = run();
+    console.log(label, "ok", typeof result, String(result));
+  } catch (e: unknown) {
+    const ctor = e && (e as { constructor?: { name?: string } }).constructor;
+    console.log(label, "threw", ctor ? ctor.name : typeof e);
+  }
+}
+
+const R = Reflect as unknown as {
+  apply: (t: unknown, thisArg: unknown, argsList?: unknown) => unknown;
+};
+
+// Non-object argumentsList → TypeError (no special nullish handling).
+probe("null", () => R.apply(fn, null, null));
+probe("undefined", () => R.apply(fn, null, undefined));
+probe("omitted", () => R.apply(fn, null));
+probe("boolean", () => R.apply(fn, null, true));
+probe("number", () => R.apply(fn, null, 1));
+probe("nan", () => R.apply(fn, null, NaN));
+probe("infinity", () => R.apply(fn, null, Infinity));
+probe("symbol", () => R.apply(fn, null, Symbol()));
+
+// Real array / array-like argumentsList still spreads correctly.
+probe("array", () => R.apply(fn, null, [1, 2, 3]));
+probe("arraylike", () => R.apply(fn, null, { length: 2, 0: "a", 1: "b" }));


### PR DESCRIPTION
## What

`Reflect.apply(target, thisArgument, argumentsList)` runs **CreateListFromArrayLike** on `argumentsList`, which throws a `TypeError` when `Type(argumentsList)` is not Object. Perry rejected every *explicit* non-object argumentsList correctly (`null` / `undefined` / number / boolean / `Symbol` all threw), but an **omitted** argumentsList was lowered to an empty array literal `[]` — a valid empty arg list — so `Reflect.apply(fn, null)` silently called `fn` with zero arguments instead of throwing.

## Fix

In the `Reflect.apply` HIR lowering (`crates/perry-hir/src/lower/expr_call/native_module.rs`), default an omitted `argumentsList` to `Expr::Undefined` instead of `Expr::Array(vec![])`. An omitted argument is `undefined` (not an Object), so it now reaches `js_reflect_apply` and throws via the existing non-object path — matching Node and the value-access thunk path (`const a = Reflect.apply; a(fn, null)`), which already threw because the arity-3 thunk fills the missing slot with `undefined`.

This is the direct sibling of #5347's already-merged `Function.prototype.apply` argArray fix.

## Validation

- **test262**: `built-ins/Reflect/apply/arguments-list-is-not-array-like.js` now passes. Reflect built-ins suite **98 → 99 pass, zero regressions** (`scripts/test262_subset.py --dir built-ins/Reflect`).
- **Parity**: new fixture `test-parity/node-suite/globals/reflect-apply-argumentslist-not-object.ts` is byte-for-byte against `node --experimental-strip-types`. Existing `reflective-builtins.ts` and the `globals` node-suite module unchanged.
- Valid array / array-like argumentsList still spreads correctly; the value-access thunk path unaffected.

Chips at the #5347 built-ins test262 umbrella tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)