### PR TITLE
fix(runtime): throw TypeError for Object.setPrototypeOf on non-extensible target (#5347)

### DIFF
--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -3027,6 +3027,23 @@ pub extern "C" fn js_object_set_prototype_of(obj_value: f64, proto: f64) -> f64 
         );
     }
 
+    // OrdinarySetPrototypeOf: a non-extensible target rejects a *changing*
+    // prototype. `Object.setPrototypeOf` surfaces that rejection as a
+    // TypeError; `Reflect.setPrototypeOf` returns `false` without throwing
+    // (handled in js_reflect_set_prototype_of, which never reaches here for the
+    // reject case). A no-op set to the SAME prototype still succeeds. Primitive
+    // targets are extensible-irrelevant — `obj_value_no_extend` is false for
+    // non-objects, so they fall through to the no-op return below. (test262
+    // Reflect/preventExtensions/prevent-extensions:
+    // `Object.setPrototypeOf(o, Array.prototype)` after preventExtensions.)
+    if crate::object::obj_value_no_extend(obj_value) {
+        let current = js_object_get_prototype_of(obj_value);
+        if current.to_bits() != proto_bits {
+            throw_object_type_error(b"#<Object> is not extensible");
+        }
+        return obj_value;
+    }
+
     // #2820: setting the prototype of a primitive target is a spec no-op that
     // returns the (boxed) primitive value. `value_is_object_like` is false for
     // numbers/strings/booleans, and class refs are handled by the recording

--- a/test-parity/node-suite/globals/object-setprototypeof-nonextensible.ts
+++ b/test-parity/node-suite/globals/object-setprototypeof-nonextensible.ts
@@ -1,0 +1,43 @@
+// OrdinarySetPrototypeOf: a non-extensible object rejects a *changing*
+// [[Prototype]]. Object.setPrototypeOf surfaces that as a TypeError; a no-op
+// set to the SAME prototype still succeeds, and extensible / primitive targets
+// are unaffected. Reflect.setPrototypeOf returns `false` (never throws) on the
+// same reject. test262: built-ins/Reflect/preventExtensions/prevent-extensions.js
+function probe(label: string, run: () => unknown): void {
+  try {
+    run();
+    console.log(label, "ok");
+  } catch (e: unknown) {
+    const ctor = e && (e as { constructor?: { name?: string } }).constructor;
+    console.log(label, "threw", ctor ? ctor.name : typeof e);
+  }
+}
+
+// Non-extensible target + changing prototype → TypeError.
+const a: Record<string, unknown> = {};
+Object.preventExtensions(a);
+probe("preventExt change", () => Object.setPrototypeOf(a, Array.prototype));
+
+// Non-extensible target + SAME prototype → no-op success (no throw).
+const b: Record<string, unknown> = {};
+const bProto = Object.getPrototypeOf(b);
+Object.preventExtensions(b);
+probe("preventExt same", () => Object.setPrototypeOf(b, bProto));
+
+// Frozen target (also non-extensible) + changing prototype → TypeError.
+const c = Object.freeze({ x: 1 });
+probe("frozen change", () => Object.setPrototypeOf(c, Array.prototype));
+
+// Extensible target → succeeds.
+const d: Record<string, unknown> = {};
+probe("extensible change", () => Object.setPrototypeOf(d, Array.prototype));
+console.log("extensible applied", Object.getPrototypeOf(d) === Array.prototype);
+
+// Primitive target → spec no-op, never throws.
+probe("primitive", () => Object.setPrototypeOf(5 as unknown as object, Array.prototype));
+
+// Reflect.setPrototypeOf returns false (no throw) on the same reject.
+const e: Record<string, unknown> = {};
+Object.preventExtensions(e);
+console.log("reflect change", (Reflect as { setPrototypeOf(o: object, p: object | null): boolean }).setPrototypeOf(e, Array.prototype));
+console.log("reflect same", (Reflect as { setPrototypeOf(o: object, p: object | null): boolean }).setPrototypeOf(e, Object.getPrototypeOf(e)));


### PR DESCRIPTION
## What

`OrdinarySetPrototypeOf` rejects a **changing** `[[Prototype]]` when the target is non-extensible. `Reflect.setPrototypeOf` already honored this (`js_reflect_set_prototype_of` returns `false` for the reject case), but `Object.setPrototypeOf` — which surfaces the same rejection as a **TypeError** — recorded the new prototype unconditionally. So `Object.setPrototypeOf(o, p)` after `Object.preventExtensions(o)` (or on a frozen / sealed object) silently succeeded instead of throwing.

## Fix

Add the `OrdinarySetPrototypeOf` extensibility gate to `js_object_set_prototype_of` (`crates/perry-runtime/src/object/object_ops.rs`): if the target is a non-extensible object and the new proto differs from the current one, throw a `TypeError`; a no-op set to the **same** prototype still succeeds. `obj_value_no_extend` is `false` for non-object targets, so primitive targets keep their spec no-op behavior, and freshly-created (extensible) class/prototype objects used by internal callers (e.g. `util_inherits`) are unaffected.

## Validation

- **test262**: `built-ins/Reflect/preventExtensions/prevent-extensions.js` now passes (Reflect suite +1). `built-ins/Object` subset: **3096 pass, zero regressions** (remaining fails are pre-existing categories — function-seal, isExtensible/preventExtensions `name` metadata, immutable-prototype cycle, proxy defineProperty — none touched by this change).
- **Parity**: new fixture `test-parity/node-suite/globals/object-setprototypeof-nonextensible.ts` is byte-for-byte against `node --experimental-strip-types`, covering: non-extensible change → throw, non-extensible same-proto → no-op, frozen change → throw, extensible change → applies, primitive target → no-op, and `Reflect.setPrototypeOf` returning `false` on the same reject.

Chips at the #5347 built-ins test262 umbrella tracker. Independent of #5392 (Reflect.apply argumentsList).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `Object.setPrototypeOf` now correctly enforces prototype immutability on non-extensible objects (created with `preventExtensions` or `freeze`), throwing errors for changes while allowing same-prototype operations to succeed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->