### PR TITLE
feat(hir): ambient require in compiled compilePackages modules (#5389 Tier 1, fixes #5373)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+## v0.5.1183 — feat(hir): ambient `require` in compiled compilePackages modules — Tier 1 of #5389 (fixes #5373)
+
+A bare or **computed** `require(expr)` inside a `compilePackages`-compiled module
+threw `ReferenceError: require is not defined`. Only a **literal** `require('pkg')`
+is rewritten to an import at compile time; a non-literal callee fell through the
+HIR ident-read path to `js_global_get_or_throw_unresolved("require")`, and no
+ambient `require` binding was emitted (`require` is absent from
+`is_known_global_identifier_name`). `createRequire(import.meta.url)` from a
+`module` import worked, so the reporter (#5373) had a workaround — but a dynamic
+`require()` should keep working out of the box.
+
+**Tier 1 fix** (Tier 2 — static package/relative resolution for const-foldable
+specifiers — is tracked separately in #5389):
+
+- `crates/perry-hir/src/lower/lower_expr.rs` — in the ident-read fall-through, bind
+  a bare unshadowed `require` to a createRequire-backed closure (new
+  `js_module_ambient_require()` runtime entry) instead of the throwing global read.
+  Reaching this arm means `require` is unshadowed (a local/func/imported/native
+  binding matches an earlier arm). Also fold `typeof require` to `"function"` so the
+  common `typeof require === 'function'` capability guard works.
+- **Gated to `ctx.is_external_module`.** In first-party source the bare-`require`
+  compile error (#668, "use a static import") is deliberate and is left unchanged —
+  verified an ESM entry still reports `typeof require === 'undefined'`.
+- `crates/perry-runtime/src/module_require.rs` — `js_module_ambient_require()`
+  returns the same `make_require(undefined())` closure as `createRequire`, with a
+  `#[used]` keepalive anchor (generated-code-only callee; auto-optimize dead-strip
+  guard). `crates/perry-codegen/src/runtime_decls/strings.rs` declares the extern.
+
+**Behavior now** (external/compilePackages modules only): computed `require(builtin)`
+(e.g. `node:os`) resolves by string; computed `require(package)` throws the
+descriptive `ERR_PERRY_UNSUPPORTED_CREATE_REQUIRE` instead of a confusing
+`ReferenceError`; `typeof require === 'function'`; a shadowing local `require`
+still wins. New regression test
+`ambient_require_in_compiled_package_resolves_builtins_without_reference_error` in
+`crates/perry/tests/create_require_package.rs`; existing
+`create_require_package_specifier_reports_unsupported_interop` and the
+`create_require_literal_*` test remain green.
+
 ## v0.5.1182 — fix(hir): native-builtin require destructuring stranded on a pre-registered module-var slot (#5364 × #5216 merge skew)
 
 `const { createInterface } = require("readline")` (and every destructured

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1182
+**Current Version:** 0.5.1183
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5283,7 +5283,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "anyhow",
  "base64",
@@ -5340,14 +5340,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "cc",
  "libc",
@@ -5355,7 +5355,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "anyhow",
  "log",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5379,7 +5379,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "anyhow",
  "base64",
@@ -5419,7 +5419,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5456,14 +5456,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "serde",
  "serde_json",
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1182"
+version = "0.5.1183"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "anyhow",
  "clap",
@@ -5497,14 +5497,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5512,7 +5512,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5545,7 +5545,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5571,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5603,14 +5603,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5652,7 +5652,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "bytes",
  "h2",
@@ -5675,7 +5675,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5685,7 +5685,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5696,7 +5696,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5704,7 +5704,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5712,7 +5712,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "bson",
  "futures-util",
@@ -5724,7 +5724,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5734,7 +5734,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5765,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5782,7 +5782,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "base64",
  "image",
@@ -5799,14 +5799,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5815,7 +5815,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5833,7 +5833,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5845,7 +5845,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "brotli",
  "flate2",
@@ -5854,7 +5854,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5881,7 +5881,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5893,7 +5893,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "anyhow",
  "base64",
@@ -5926,7 +5926,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6018,7 +6018,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6028,7 +6028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6036,14 +6036,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "base64",
  "itoa",
@@ -6060,7 +6060,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6070,7 +6070,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6093,7 +6093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "base64",
  "block2",
@@ -6109,7 +6109,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "base64",
  "block2",
@@ -6124,7 +6124,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1182"
+version = "0.5.1183"
 
 [[package]]
 name = "perry-ui-test"
@@ -6132,11 +6132,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1182"
+version = "0.5.1183"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "base64",
  "block2",
@@ -6152,7 +6152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "base64",
  "block2",
@@ -6168,7 +6168,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "block2",
  "libc",
@@ -6181,7 +6181,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "base64",
  "libc",
@@ -6198,14 +6198,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6219,7 +6219,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1182"
+version = "0.5.1183"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ strip = false
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1182"
+version = "0.5.1183"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1247,6 +1247,10 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // Iterator-protocol result validation (for-of lazy loop).
     module.declare_function("js_iterator_result_validate", DOUBLE, &[DOUBLE]);
     module.declare_function("js_global_get_or_throw_unresolved", DOUBLE, &[DOUBLE]);
+    // Ambient `require` for compiled external / compilePackages modules (#5373):
+    // bind a bare `require` to a createRequire-backed closure instead of throwing
+    // ReferenceError. Takes no base; returns the require closure value.
+    module.declare_function("js_module_ambient_require", DOUBLE, &[]);
     // Non-throwing global read for `typeof <unresolved>` + global read-modify-
     // write for `i++`/`i--` on a sloppy implicit global (#3575).
     module.declare_function("js_global_get_optional", DOUBLE, &[DOUBLE]);

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -663,6 +663,30 @@ fn lower_expr_impl(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<Expr> 
                     object: Box::new(Expr::GlobalGet(0)),
                     property: name,
                 })
+            } else if name == "require" && ctx.is_external_module {
+                // Tier 1 of #5389 (fixes #5373): compiled external /
+                // compilePackages modules carry no ambient CJS `require`
+                // binding, so a bare or computed `require(expr)` would fall
+                // through to the `js_global_get_or_throw_unresolved` arm below
+                // and throw `ReferenceError: require is not defined`. Bind a
+                // bare unshadowed `require` to a real createRequire-backed
+                // closure instead — builtins (`node:os`, …) resolve by string;
+                // package/file specifiers throw the descriptive
+                // ERR_PERRY_UNSUPPORTED_CREATE_REQUIRE. Reaching this arm means
+                // `require` is unshadowed (a local/func/imported/native binding
+                // would have matched an earlier arm). Gated to external modules:
+                // in first-party source the bare-require compile error (#668)
+                // is deliberate and must not regress into a runtime path.
+                Ok(Expr::Call {
+                    callee: Box::new(Expr::ExternFuncRef {
+                        name: "js_module_ambient_require".to_string(),
+                        param_types: Vec::new(),
+                        return_type: Type::Any,
+                    }),
+                    args: Vec::new(),
+                    type_args: Vec::new(),
+                    byte_offset: 0,
+                })
             } else {
                 // GlobalGet(0) is a sentinel: codegen routes by name from the
                 // parent PropertyGet/Call/Member context. Bare uses lower to
@@ -1115,6 +1139,17 @@ fn lower_expr_impl(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<Expr> 
                                 return Ok(Expr::String("function".to_string()));
                             }
                         }
+                    }
+                    // #5373: in compiled external / compilePackages modules a
+                    // bare `require` is bound to a createRequire-backed closure
+                    // (see the ident-read arm), so `typeof require` is
+                    // "function" — matching Node CJS and enabling the common
+                    // `typeof require === 'function'` capability guard. Without
+                    // this, the generic non-throwing fold below reports
+                    // "undefined". Gated to external modules to mirror the
+                    // ident binding exactly.
+                    if n == "require" && ctx.is_external_module && ctx.lookup_local(n).is_none() {
+                        return Ok(Expr::String("function".to_string()));
                     }
                     if ctx.lookup_local(n).is_none()
                         && ctx.lookup_func(n).is_none()

--- a/crates/perry-runtime/src/module_require.rs
+++ b/crates/perry-runtime/src/module_require.rs
@@ -217,3 +217,23 @@ pub extern "C" fn js_module_create_require(filename_or_url: f64) -> f64 {
     validate_create_require_base(filename_or_url);
     make_require(undefined())
 }
+
+/// Ambient `require` for compiled external / `compilePackages` modules (Tier 1 of
+/// #5389, fixes #5373). These modules carry no CJS ambient `require` binding, so a
+/// bare or computed `require(expr)` would otherwise lower to
+/// `js_global_get_or_throw_unresolved` and throw `ReferenceError: require is not
+/// defined`. This returns the same `createRequire`-backed closure as
+/// `js_module_create_require`, but takes no base argument (it is produced where a
+/// bare `require` identifier appears, not from an explicit `createRequire(base)`).
+/// Builtins resolve by string today; package/file specifiers throw the descriptive
+/// `ERR_PERRY_UNSUPPORTED_CREATE_REQUIRE` until Tier 2 lands static package
+/// resolution.
+#[no_mangle]
+pub extern "C" fn js_module_ambient_require() -> f64 {
+    make_require(undefined())
+}
+
+/// Keepalive anchor for the auto-optimize whole-program build (generated-code-only
+/// callee; see project_auto_optimize_keepalive_3320).
+#[used]
+static KEEP_JS_MODULE_AMBIENT_REQUIRE: extern "C" fn() -> f64 = js_module_ambient_require;

--- a/crates/perry/tests/create_require_package.rs
+++ b/crates/perry/tests/create_require_package.rs
@@ -111,3 +111,111 @@ console.log("file:", Local.localValue, Local.localCall("C"));
         "builtin: function\npackage: mini-1 make:B login:A\nfile: local-ok local:C\n"
     );
 }
+
+/// Tier 1 of #5389 (fixes #5373): a bare/computed `require(expr)` inside a
+/// compiled `compilePackages` module must bind to a createRequire-backed closure
+/// instead of throwing `ReferenceError: require is not defined`. Builtins resolve
+/// by string, `typeof require` is "function", a non-builtin package specifier
+/// throws the descriptive ERR_PERRY_UNSUPPORTED_CREATE_REQUIRE (not a
+/// ReferenceError), and a shadowing local `require` still wins.
+#[test]
+fn ambient_require_in_compiled_package_resolves_builtins_without_reference_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+
+    std::fs::write(
+        root.join("package.json"),
+        r#"{
+  "name": "ambient-require-consumer",
+  "type": "module",
+  "perry": {
+    "compilePackages": ["amblib"],
+    "allow": { "compilePackages": ["amblib"] }
+  }
+}"#,
+    )
+    .expect("write consumer package.json");
+
+    let pkg = root.join("node_modules").join("amblib");
+    std::fs::create_dir_all(&pkg).expect("mkdir amblib");
+    std::fs::write(
+        pkg.join("package.json"),
+        r#"{ "name": "amblib", "version": "1.0.0", "main": "index.ts", "types": "index.ts" }"#,
+    )
+    .expect("write amblib package.json");
+    // The computed specifiers are built at runtime so the literal-require
+    // rewrites can't fire — they exercise the ambient closure directly.
+    std::fs::write(
+        pkg.join("index.ts"),
+        r#"
+export function probe(): string {
+  const builtin = ["n", "o", "d", "e", ":", "o", "s"].join("");
+  let viaRequire: string;
+  try {
+    require(builtin);
+    viaRequire = "builtin-ok";
+  } catch (e) {
+    viaRequire = "builtin-threw-" + (e as Error).name;
+  }
+
+  const pkgSpec = ["l", "o", "d", "a", "s", "h"].join("");
+  let viaPackage: string;
+  try {
+    require(pkgSpec);
+    viaPackage = "pkg-ok";
+  } catch (e) {
+    viaPackage = (e as Error).name + ":" + ((e as any).code ?? "(none)");
+  }
+
+  return `typeof=${typeof require} | ${viaRequire} | ${viaPackage}`;
+}
+
+export function shadowed(): string {
+  const require = (id: string) => "shadow:" + id;
+  return require("zzz");
+}
+"#,
+    )
+    .expect("write amblib index");
+
+    let entry = root.join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+import { probe, shadowed } from "amblib";
+console.log(probe());
+console.log(shadowed());
+"#,
+    )
+    .expect("write entry");
+
+    let output = root.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(root)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert_eq!(
+        stdout,
+        "typeof=function | builtin-ok | Error:ERR_PERRY_UNSUPPORTED_CREATE_REQUIRE\nshadow:zzz\n"
+    );
+}


### PR DESCRIPTION
## Summary

Tier 1 of #5389 — fixes #5373. A bare or **computed** `require(expr)` inside a `compilePackages`-compiled module threw `ReferenceError: require is not defined`: only a **literal** `require('pkg')` is rewritten to an import at compile time, and no ambient `require` binding was emitted (`require` is absent from `is_known_global_identifier_name`, so a non-literal callee fell through to `js_global_get_or_throw_unresolved`).

This binds a bare unshadowed `require` in **external/compilePackages** modules to a `createRequire`-backed closure instead.

## Changes

- **`crates/perry-hir/src/lower/lower_expr.rs`** — ident-read fall-through: bind bare unshadowed `require` to a new `js_module_ambient_require()` closure (reaching that arm means `require` is unshadowed — a local/func/imported/native binding matches earlier). Also fold `typeof require` → `"function"` so the common `typeof require === 'function'` guard works. **Gated to `ctx.is_external_module`** — first-party source keeps the deliberate bare-`require` compile error (#668).
- **`crates/perry-runtime/src/module_require.rs`** — `js_module_ambient_require()` returns the same `make_require(undefined())` closure as `createRequire`, with a `#[used]` keepalive anchor (generated-code-only callee; auto-optimize dead-strip guard).
- **`crates/perry-codegen/src/runtime_decls/strings.rs`** — declares the extern.

## Behavior (external/compilePackages modules only)

- Computed `require(builtin)` (e.g. `node:os`) resolves by string — no more `ReferenceError`.
- Computed `require(package)` throws the descriptive `ERR_PERRY_UNSUPPORTED_CREATE_REQUIRE` instead of `ReferenceError`.
- `typeof require === 'function'`; a shadowing local `require` still wins.
- First-party ESM entry unchanged — verified `typeof require === 'undefined'`.

## Not in this PR (Tier 2, tracked in #5389)

Static package/relative resolution for const-foldable computed specifiers (reuse the dynamic-`import()` resolver). Genuinely runtime-computed package strings remain unsupported by design (same boundary as dynamic `import()`).

## Tests

New `ambient_require_in_compiled_package_resolves_builtins_without_reference_error` in `crates/perry/tests/create_require_package.rs`. Existing `create_require_package_specifier_reports_unsupported_interop`, the `create_require_literal_*` test, and `module_import_forms` suite stay green.
