### PR TITLE
fix(runtime): walk prototype chain for Reflect.get accessor receiver rebind (#5347)

### DIFF
--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -797,10 +797,6 @@ pub(crate) fn reflect_getter_closure_bits(value: f64, key: f64) -> Option<u64> {
     if !ACCESSORS_IN_USE.with(|c| c.get()) {
         return None;
     }
-    let obj = unsafe { extract_obj_ptr(value) };
-    if obj.is_null() {
-        return None;
-    }
     let key_str = crate::builtins::js_string_coerce(key);
     if key_str.is_null() {
         return None;
@@ -813,14 +809,42 @@ pub(crate) fn reflect_getter_closure_bits(value: f64, key: f64) -> Option<u64> {
             Err(_) => return None,
         }
     };
-    let acc = get_accessor_descriptor(obj as usize, &name)?;
-    if acc.get != 0 {
-        Some(acc.get)
-    } else {
-        // Accessor exists but has no getter → reading yields undefined; signal
-        // that via 0 so the caller returns undefined rather than a field read.
-        Some(0)
+    // Spec [[Get]] walks the prototype chain: `Reflect.get(target, key,
+    // receiver)` must locate an accessor *getter* installed anywhere on
+    // `target`'s chain (an inherited `get x() {…}`), so the caller can rebind
+    // its `this` to the receiver before invoking it. An own *data* property at
+    // some level shadows inherited accessors, so stop the walk there and let
+    // the caller fall back to an ordinary (receiver-aware) field read. (test262
+    // Reflect/get/return-value-from-receiver: inherited-getter-via-receiver.)
+    let mut current = value;
+    // Bounded to guard against a cyclic prototype side-table; real chains are
+    // a handful of links deep.
+    for _ in 0..10_000 {
+        let obj = unsafe { extract_obj_ptr(current) };
+        if obj.is_null() {
+            return None;
+        }
+        if let Some(acc) = get_accessor_descriptor(obj as usize, &name) {
+            return if acc.get != 0 {
+                Some(acc.get)
+            } else {
+                // Accessor exists but has no getter → reading yields undefined;
+                // signal that via 0 so the caller returns undefined rather than
+                // a field read.
+                Some(0)
+            };
+        }
+        // An own (data) property at this level shadows any inherited accessor.
+        if obj_value_has_own_key(current, key) {
+            return None;
+        }
+        let proto = crate::object::js_object_get_prototype_of(current);
+        if unsafe { extract_obj_ptr(proto) }.is_null() {
+            return None;
+        }
+        current = proto;
     }
+    None
 }
 
 /// `JSON.stringify` helper: if the own key `key_f64` on `obj` is an accessor

--- a/test-parity/node-suite/globals/reflect-get-receiver-prototype.ts
+++ b/test-parity/node-suite/globals/reflect-get-receiver-prototype.ts
@@ -1,0 +1,50 @@
+// Reflect.get(target, key, receiver): [[Get]] walks target's prototype chain,
+// and when the resolved property is an accessor, its getter runs with `this`
+// bound to the RECEIVER — not to whichever object in the chain owns the
+// getter. Perry handled an own getter via a receiver, but an INHERITED getter
+// fell back to a plain read that ignored the receiver, returning undefined.
+// An own data property shadows an inherited accessor (no receiver effect).
+// test262: built-ins/Reflect/get/return-value-from-receiver.js
+function log(label: string, value: unknown): void {
+  console.log(label, String(value));
+}
+
+const base: Record<string, unknown> = {};
+Object.defineProperty(base, "x", {
+  get(this: { y?: unknown }) {
+    return this.y;
+  },
+  configurable: true,
+});
+const receiver = { y: 42 };
+
+// Own accessor, distinct receiver → getter `this` is the receiver.
+log("own", Reflect.get(base, "x", receiver));
+
+// Inherited accessor (one and two links up) → still bound to the receiver.
+const mid = Object.create(base) as Record<string, unknown>;
+log("proto", Reflect.get(mid, "x", receiver));
+log("deep", Reflect.get(Object.create(mid) as object, "x", receiver));
+
+// Own data property shadows the inherited accessor → plain read, no receiver.
+const shadow = Object.create(base) as Record<string, unknown>;
+Object.defineProperty(shadow, "x", { value: "own", writable: true });
+log("shadow", Reflect.get(shadow, "x", receiver));
+
+// Inherited accessor with no getter → undefined.
+const noGet: Record<string, unknown> = {};
+Object.defineProperty(noGet, "z", { set() {}, configurable: true });
+log("nogetter", Reflect.get(Object.create(noGet) as object, "z", receiver));
+
+// Omitted receiver defaults to target.
+const selfish: Record<string, unknown> = {};
+Object.defineProperty(selfish, "w", {
+  get(this: unknown) {
+    return this === selfish ? "self" : "other";
+  },
+});
+log("default-receiver", Reflect.get(selfish, "w"));
+
+// Plain data reads (own + inherited) are unchanged.
+log("own-data", Reflect.get({ a: 1 }, "a", receiver));
+log("inherited-data", Reflect.get(Object.create({ k: 7 }) as object, "k", receiver));


### PR DESCRIPTION
## What

`Reflect.get(target, key, receiver)` must — per `[[Get]]` — find an accessor **getter** anywhere on `target`'s prototype chain and invoke it with `this` bound to `receiver`. `reflect_getter_closure_bits` only consulted the target's **own** accessor descriptors, so an **inherited** getter (`Reflect.get(Object.create(o1), 'x', receiver)`) wasn't recognized as an accessor and fell through to the ordinary field-read path. An object-literal getter ignores that path (it reads `this` from a reserved closure slot, not `IMPLICIT_THIS`), so the result was `undefined` instead of the receiver-derived value.

```js
var o1 = {}; Object.defineProperty(o1, 'x', { get() { return this.y; } });
var o2 = Object.create(o1);
Reflect.get(o2, 'x', { y: 42 });  // spec: 42  — Perry returned undefined
```

## Fix

Walk the prototype chain (via `js_object_get_prototype_of`) in `reflect_getter_closure_bits` (`crates/perry-runtime/src/object/mod.rs`): return the first accessor getter found, but stop at an own **data** property that shadows an inherited accessor (so the caller falls back to the ordinary receiver-aware read). The walk is bounded against a cyclic prototype side-table. `reflect_getter_closure_bits` is only called from `js_reflect_get`, so the blast radius is `Reflect.get` with a distinct receiver.

## Validation

- **test262**: `built-ins/Reflect/get/return-value-from-receiver.js` now passes. Reflect suite **+1 pass, zero regressions** (remaining fails are pre-existing: `enumerate/undefined` — removed-from-spec API — and `preventExtensions/prevent-extensions`, which is fixed by #5396).
- **Parity**: new fixture `test-parity/node-suite/globals/reflect-get-receiver-prototype.ts` is byte-for-byte against `node --experimental-strip-types`, covering own / one-link / two-link inherited getters, own-data shadowing, no-getter (→ undefined), omitted-receiver default, and plain own/inherited data reads.

Chips at the #5347 built-ins test262 umbrella tracker. Independent of #5392 (merged) and #5396 (open).

Side note (out of scope): `Reflect.get`/`Reflect.setPrototypeOf` accessed through a **variable alias** (rather than the `Reflect` global directly) fall to generic dispatch and return the target object instead of the proper result — worth a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)