### PR TITLE
feat: synchronous computed require(expr) resolves compiled package modules (#5389 Tier 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,49 @@
+## v0.5.1189 — feat: synchronous computed `require(expr)` resolves compiled package modules — Tier 2 of #5389
+
+Builds on the Tier 1 ambient `require` (v0.5.1183). A **computed** `require(expr)`
+in a compiled external/compilePackages module — where the specifier is not a
+string literal but *does* const-fold to a finite set (ternary of literals, a
+module-`const`, or a directory-anchored template glob) — now resolves
+**synchronously** to the target compiled-module namespace, reusing the exact
+dynamic-`import()` path resolver. Previously every non-literal `require` fell back
+to the ambient closure, which only handles builtins (packages threw
+`ERR_PERRY_UNSUPPORTED_CREATE_REQUIRE`).
+
+**Mechanism** — `require(expr)` is the synchronous CJS analog of `import(expr)`,
+so it reuses the whole pipeline with one new bit:
+
+- `crates/perry-hir/src/ir/expr.rs` — new `synchronous: bool` field on
+  `Expr::DynamicImport` (`false` for ESM `import()`, `true` for CJS `require()`).
+- `crates/perry-hir/src/lower/expr_call/intrinsics.rs` — new `try_dynamic_require`:
+  a bare unshadowed `require` with a non-literal arg in an external module lowers
+  to `DynamicImport { synchronous: true }`. Literals stay on the existing
+  `try_require_literal` path; gated to `is_external_module`. Wired into the call
+  dispatch right after `try_require_literal`.
+- `crates/perry/src/commands/compile/collect_modules.rs` — the existing dynamic-
+  import const-folder/globber populates `paths` and registers each target as a
+  dynamic import edge **unchanged**. New: an *unresolved* synchronous node records
+  an empty path set (ambient fallback) instead of the `import()` deferred-reject /
+  strict error.
+- `crates/perry-codegen/src/expr/dyn_extern_i18n.rs` — new `lower_dynamic_require`:
+  emits the same single-/multi-target `js_string_equals` dispatch as `import()`,
+  but returns the namespace value **directly** (no `Promise` wrap) and uses the
+  ambient require (`js_module_ambient_require_apply`, new in
+  `crates/perry-runtime/src/module_require.rs`) as the unresolved / no-match
+  fallthrough (builtin-or-throw) rather than a rejected promise. Namespace
+  construction for the three target kinds (native submodule / native builtin /
+  compiled module) is factored into `namespace_value_for_prefix`.
+
+**Behavior** (external/compilePackages modules): `require(flag ? "./a" : "./b")`,
+`require(SPEC)` (module-const), and `` require(`./plugins/${name}`) `` (glob;
+runtime string must equal the file specifier incl. extension, same contract as
+`import()`) all resolve to the compiled namespaces synchronously. A specifier that
+does not const-fold (`["n","o",…].join("")`) still routes through the Tier 1
+ambient require — builtins resolve, unknown packages throw the descriptive error.
+**Out of scope (by design):** genuinely runtime-computed *package* strings, same
+boundary as dynamic `import()` in an AOT binary. New regression test
+`computed_require_const_folds_to_compiled_package_modules`; dynamic-`import()`
+suite (`module_import_forms`) and the Tier 1 tests stay green.
+
 ## v0.5.1188 — fix(codegen): unknown builtin-namespace member reads as `undefined`, not `0` (#5347)
 
 Reading a property that does not exist on a builtin global namespace object —
@@ -94,6 +140,68 @@ don't trigger Tests today). `test.yml` branches the cargo-test step on
 Trade-off (chosen deliberately, prioritizing a usable per-PR gate): a regression
 only an integration test would catch lands on a PR and is caught by the nightly /
 release-tag full run rather than at PR time.
+
+Three pre-existing CI fragilities on `main` were turning required checks red for
+PRs. Fixed together since all are "make main's CI green again."
+
+### 0. cargo-test never builds the runtime staticlib (latent; surfaced by fix #1)
+
+The `cargo-test` job runs `cargo test -p perry-runtime`, which only builds
+lib/bin/test targets — **not** the `staticlib` crate-type — so
+`libperry_runtime.a` / `libperry_stdlib.a` are never produced by the job and only
+exist when restored from the rust-cache. Integration tests that compile with
+`PERRY_NO_AUTO_OPTIMIZE=1` (e.g. `functional_batch2_regressions`) link the
+prebuilt archive directly, so the moment a PR touches perry-runtime/perry-stdlib
+the cached staticlib is invalidated, cargo never rebuilds it, and those tests fail
+with `Could not find libperry_runtime.a`. Fix #1 below touches perry-runtime and
+hit exactly this. Fix: add an explicit `cargo build -p perry-runtime -p
+perry-stdlib` to the cargo-test job before the integration-test loop so the
+staticlibs exist regardless of cache state.
+
+### 1. dead-stripped runtime symbol breaks cold runtime-only compiles (cargo-test)
+
+`js_array_numeric_value_to_raw_f64` (added by #5291 for representation-aware
+numeric array lowering, `crates/perry-runtime/src/array/header.rs`) is
+`#[no_mangle]` but is only ever called from generated machine code — nothing in
+the runtime crate references it. Without a `#[used]` anchor the linker dead-strips
+it from `libperry_runtime.a`, so any cold `PERRY_NO_AUTO_OPTIMIZE=1` compile of a
+program that triggers that lowering fails at link with `Undefined symbols:
+_js_array_numeric_value_to_raw_f64`. This surfaced as 5 failing
+`functional_batch2_regressions` tests. Fix: add the `#[used]` keepalive anchor
+(same pattern as the auto-optimize keepalives in `error.rs`; see
+project_autoopt_ffi_symbol_link_break). This regression class is normally
+CI-invisible because warm staticlib caches mask it.
+
+### 2. link/mod.rs over the file-size gate (lint)
+
+`crates/perry/src/commands/compile/link/mod.rs` crossed the 2000-line file-size
+gate (2132 lines) after #5400 grew the Windows response-file path, turning the
+`lint` job red for every PR branched off main. Split the single ~1770-line
+`build_and_run_link` orchestrator (the only oversized item) into a sibling
+`link/build_and_run.rs`, leaving mod.rs at 357 lines and the new file at 1785.
+Pure mechanical move (`use super::*`; `build_and_run_link` is now `pub(crate)`,
+re-exported from mod.rs; five compile-module paths became `super::super::…`).
+
+Pure mechanical move, no behavior change:
+
+- The function moved verbatim; `use super::*` pulls in every helper that stays in
+  the parent `link` module (the `NativeBackendLinkMetadata` selection, the
+  `resolve_optional_framework_dir` / `find_project_root_for` /
+  `rewrite_link_with_response_file` / `quote_response_arg` / `response_file_contents`
+  helpers, and the sibling-module re-exports).
+- `build_and_run_link` is now `pub(crate)` (was `pub(super)`) so mod.rs can
+  re-export it to the parent `compile` module via
+  `pub(super) use build_and_run::build_and_run_link;`.
+- The five fully-qualified paths that reached into the `compile` module
+  (`library_search::`, `sandbox_buildrs::`, `optimized_libs::`,
+  `run_lock_verify_for_compile`, `find_perry_workspace_root`) became
+  `super::super::…` from the new two-level-deep module.
+
+All 599 perry bin unit tests pass (including the link `response_file_tests` /
+`native_package_selection_tests` / `optional_framework_dir_tests`); a hello-world
+compile+link round-trips through the moved driver.
+
+## v0.5.1184 — fix: unblock main CI — dead-stripped symbol + cargo-test staticlib + oversized link/mod.rs
 
 Three pre-existing CI fragilities on `main` were turning required checks red for
 PRs. Fixed together since all are "make main's CI green again."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1187
+**Current Version:** 0.5.1189
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5283,7 +5283,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "anyhow",
  "base64",
@@ -5340,14 +5340,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "cc",
  "libc",
@@ -5355,7 +5355,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "anyhow",
  "log",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5379,7 +5379,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "anyhow",
  "base64",
@@ -5419,7 +5419,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5456,14 +5456,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "serde",
  "serde_json",
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1188"
+version = "0.5.1189"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "anyhow",
  "clap",
@@ -5497,14 +5497,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5512,7 +5512,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5545,7 +5545,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5571,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5603,14 +5603,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5652,7 +5652,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "bytes",
  "h2",
@@ -5675,7 +5675,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5685,7 +5685,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5696,7 +5696,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5704,7 +5704,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5712,7 +5712,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "bson",
  "futures-util",
@@ -5724,7 +5724,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5734,7 +5734,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5765,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5782,7 +5782,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "base64",
  "image",
@@ -5799,14 +5799,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5815,7 +5815,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5833,7 +5833,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5845,7 +5845,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "brotli",
  "flate2",
@@ -5854,7 +5854,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5881,7 +5881,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5893,7 +5893,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "anyhow",
  "base64",
@@ -5926,7 +5926,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6018,7 +6018,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6028,7 +6028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6036,14 +6036,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "base64",
  "itoa",
@@ -6060,7 +6060,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6070,7 +6070,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6093,7 +6093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "base64",
  "block2",
@@ -6109,7 +6109,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "base64",
  "block2",
@@ -6124,7 +6124,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1188"
+version = "0.5.1189"
 
 [[package]]
 name = "perry-ui-test"
@@ -6132,11 +6132,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1188"
+version = "0.5.1189"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "base64",
  "block2",
@@ -6152,7 +6152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "base64",
  "block2",
@@ -6168,7 +6168,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "block2",
  "libc",
@@ -6181,7 +6181,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "base64",
  "libc",
@@ -6198,14 +6198,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6219,7 +6219,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1188"
+version = "0.5.1189"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ strip = false
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1188"
+version = "0.5.1189"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
+++ b/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
@@ -46,6 +46,155 @@ use super::{
     I18nLowerCtx,
 };
 
+/// Build the namespace value for a resolved dynamic-import/require target prefix
+/// on the current block: a native submodule (`__node_submod__<key>`), a native
+/// builtin (`__native_mod__<name>`), or a compiled module (`<prefix>__init` +
+/// `@__perry_ns_<prefix>`). Returns a NaN-boxed `DOUBLE` value id.
+fn namespace_value_for_prefix(ctx: &mut FnCtx<'_>, prefix: &str) -> String {
+    if let Some(key) = prefix.strip_prefix("__node_submod__") {
+        let key = key.to_string();
+        let submod_label = emit_string_literal_global(ctx, &key);
+        let submod_len = key.len();
+        let install_sym = crate::nm_install::nm_submod_install_symbol(&key);
+        let blk = ctx.block();
+        if let Some(s) = install_sym {
+            blk.call_void(s, &[]);
+        }
+        blk.call(
+            DOUBLE,
+            "js_node_submodule_namespace",
+            &[(PTR, &submod_label), (I32, &submod_len.to_string())],
+        )
+    } else if let Some(name) = prefix.strip_prefix("__native_mod__") {
+        let name = name.to_string();
+        let mod_label = emit_string_literal_global(ctx, &name);
+        let mod_len = name.len();
+        let blk = ctx.block();
+        if let Some(s) = crate::nm_install::nm_install_symbol(&name) {
+            blk.call_void(s, &[]);
+        }
+        blk.call(
+            DOUBLE,
+            "js_create_native_module_namespace",
+            &[(PTR, &mod_label), (I64, &mod_len.to_string())],
+        )
+    } else {
+        // Issue #753: trigger the target's init (idempotent for Eager targets;
+        // the populating call for Deferred targets) before loading its namespace.
+        let blk = ctx.block();
+        blk.call_void(&format!("{}__init", prefix), &[]);
+        blk.load(DOUBLE, &format!("@__perry_ns_{}", prefix))
+    }
+}
+
+/// #5389 Tier 2: lower a synchronous CommonJS `require(expr)` in a compiled
+/// external module. Mirrors the dynamic-`import()` dispatch in `lower`, but
+/// returns the target **namespace value directly** (no Promise wrap) and uses the
+/// ambient createRequire-backed require (`js_module_ambient_require_apply`) as the
+/// unresolved / no-match fallthrough instead of a rejected promise — so builtins
+/// keep resolving by string and unknown packages throw the descriptive
+/// `ERR_PERRY_UNSUPPORTED_CREATE_REQUIRE`. `paths` is populated by the same
+/// `collect_modules` resolver as `import()`.
+fn lower_dynamic_require(ctx: &mut FnCtx<'_>, paths: &[String], arg: &Expr) -> Result<String> {
+    // Empty `paths` → genuinely runtime-computed specifier (didn't const-fold).
+    // Resolve it entirely through the ambient require.
+    if paths.is_empty() {
+        let spec_val = lower_expr(ctx, arg)?;
+        return Ok(ctx.block().call(
+            DOUBLE,
+            "js_module_ambient_require_apply",
+            &[(DOUBLE, &spec_val)],
+        ));
+    }
+
+    // Single resolved target: the resolver proved this is the only possible
+    // specifier. Evaluate the arg for side effects, then return the namespace
+    // directly (or fall back to the ambient require if the driver didn't map the
+    // path to a target prefix).
+    if paths.len() == 1 {
+        let spec_val = lower_expr(ctx, arg)?;
+        let target_prefix = ctx.dynamic_import_path_to_prefix.get(&paths[0]).cloned();
+        return Ok(match target_prefix {
+            Some(prefix) => namespace_value_for_prefix(ctx, &prefix),
+            None => ctx.block().call(
+                DOUBLE,
+                "js_module_ambient_require_apply",
+                &[(DOUBLE, &spec_val)],
+            ),
+        });
+    }
+
+    // Multi-target: compare the runtime specifier against each resolved path via
+    // `js_string_equals`; each match stores its namespace into the result slot.
+    // The no-match fallthrough resolves via the ambient require (builtin-or-throw)
+    // rather than rejecting.
+    let spec_val = lower_expr(ctx, arg)?;
+    let result_slot = ctx.block().alloca(DOUBLE);
+    let join_block_idx = ctx.new_block("dynamic_require_join");
+    let path_handle =
+        ctx.block()
+            .call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &spec_val)]);
+
+    let resolved: Vec<(String, String)> = paths
+        .iter()
+        .filter_map(|p| {
+            ctx.dynamic_import_path_to_prefix
+                .get(p)
+                .cloned()
+                .map(|tgt| (p.clone(), tgt))
+        })
+        .collect();
+
+    for (i, (path_str, target_prefix)) in resolved.iter().enumerate() {
+        let key_idx = ctx.strings.intern(path_str);
+        let key_entry = ctx.strings.entry(key_idx);
+        let key_handle_global = format!("@{}", key_entry.handle_global);
+
+        let blk = ctx.block();
+        let key_box = blk.load(DOUBLE, &key_handle_global);
+        let key_handle = blk.call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &key_box)]);
+        let eq_i32 = blk.call(
+            I32,
+            "js_string_equals",
+            &[(I64, &path_handle), (I64, &key_handle)],
+        );
+        let cond = blk.icmp_ne(I32, &eq_i32, "0");
+
+        let match_block_idx = ctx.new_block(&format!("dyn_require_match_{}", i));
+        let next_label = if i + 1 < resolved.len() {
+            ctx.new_block(&format!("dyn_require_next_{}", i))
+        } else {
+            ctx.new_block(&format!("dyn_require_fallback_{}", i))
+        };
+        let match_label = ctx.block_label(match_block_idx);
+        let next_label_str = ctx.block_label(next_label);
+        ctx.block().cond_br(&cond, &match_label, &next_label_str);
+
+        ctx.current_block = match_block_idx;
+        let join_label = ctx.block_label(join_block_idx);
+        let ns_val = namespace_value_for_prefix(ctx, target_prefix);
+        let blk = ctx.block();
+        blk.store(DOUBLE, &ns_val, &result_slot);
+        blk.br(&join_label);
+
+        ctx.current_block = next_label;
+    }
+
+    // No-match fallthrough: resolve via the ambient require.
+    let join_label = ctx.block_label(join_block_idx);
+    let fallback = ctx.block().call(
+        DOUBLE,
+        "js_module_ambient_require_apply",
+        &[(DOUBLE, &spec_val)],
+    );
+    let blk = ctx.block();
+    blk.store(DOUBLE, &fallback, &result_slot);
+    blk.br(&join_label);
+
+    ctx.current_block = join_block_idx;
+    Ok(ctx.block().load(DOUBLE, &result_slot))
+}
+
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {
         Expr::WorkerNew {
@@ -117,8 +266,16 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             paths,
             arg,
             deferred_error,
+            synchronous,
             ..
         } => {
+            // #5389 Tier 2: a synchronous CommonJS `require(expr)` returns the
+            // target namespace value directly (no Promise) and falls back to the
+            // ambient createRequire-backed `require` for unresolved / no-match
+            // specifiers. Resolution (`paths`) is identical to `import()`.
+            if *synchronous {
+                return lower_dynamic_require(ctx, paths, arg);
+            }
             // #5230: a non-resolvable (runtime-computed) specifier was
             // *deferred* (the default, non-strict policy — analog of #5206's
             // eval deferral). Evaluate the arg for its side effects, then

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1251,6 +1251,9 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // bind a bare `require` to a createRequire-backed closure instead of throwing
     // ReferenceError. Takes no base; returns the require closure value.
     module.declare_function("js_module_ambient_require", DOUBLE, &[]);
+    // #5389 Tier 2: synchronous ambient require(spec) resolution — the codegen
+    // fallthrough when a computed require() didn't const-fold to a compiled target.
+    module.declare_function("js_module_ambient_require_apply", DOUBLE, &[DOUBLE]);
     // Non-throwing global read for `typeof <unresolved>` + global read-modify-
     // write for `i++`/`i--` on a sloppy implicit global (#3575).
     module.declare_function("js_global_get_optional", DOUBLE, &[DOUBLE]);

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -2555,6 +2555,15 @@ pub enum Expr {
         /// (`paths` resolved to a finite set). In strict mode such a site is a
         /// compile error instead and never produces a node with this set.
         deferred_error: Option<String>,
+        /// #5389 Tier 2: `true` when this node came from a **synchronous**
+        /// CommonJS `require(expr)` in a compiled external/compilePackages
+        /// module rather than an ESM `import(expr)`. Codegen returns the target
+        /// namespace value directly (no `Promise` wrap) and uses the ambient
+        /// createRequire-backed `require` as the no-match / unresolved
+        /// fallthrough (builtin-or-throw) instead of a rejected promise. The
+        /// compile-time path resolution (`collect_modules`) is identical for
+        /// both — only the dispatch shape differs. `false` for ESM `import()`.
+        synchronous: bool,
     },
     /// Compile-time-resolved `new Worker(filename, options?)` from
     /// `node:worker_threads`. The filename expression follows the same

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -110,6 +110,62 @@ pub(super) fn try_require_literal(
     Ok(None)
 }
 
+/// #5389 Tier 2: a bare, **computed** `require(expr)` (non-literal specifier)
+/// inside a compiled external / `compilePackages` module.
+///
+/// Literal specifiers are handled by `try_require_literal` (which runs first):
+/// native builtins fold to `NativeModuleRef`, and the `createRequire`-alias /
+/// destructuring transforms rewrite literal package requires to imports. A
+/// non-literal specifier can't be rewritten statically, so route it through the
+/// same synchronous dynamic-require path as dynamic `import()`: emit a
+/// `DynamicImport { synchronous: true }` node whose `arg` `collect_modules`
+/// const-folds (or globs) to a finite target set, registering each as a dynamic
+/// import edge. Codegen then dispatches to the matching compiled-module
+/// namespace **synchronously** (no Promise), with the Tier-1 ambient
+/// createRequire-backed `require` as the no-match / unresolved fallthrough
+/// (builtins resolve by string; unknown packages throw the descriptive
+/// `ERR_PERRY_UNSUPPORTED_CREATE_REQUIRE`).
+///
+/// Gated to external modules: in first-party source a bare `require` keeps the
+/// deliberate compile-time behavior (#668). Returns `Some(expr)` when matched.
+pub(super) fn try_dynamic_require(
+    ctx: &mut LoweringContext,
+    call: &ast::CallExpr,
+) -> Result<Option<Expr>> {
+    if !ctx.is_external_module {
+        return Ok(None);
+    }
+    let ast::Callee::Expr(callee_expr) = &call.callee else {
+        return Ok(None);
+    };
+    let ast::Expr::Ident(ident) = callee_expr.as_ref() else {
+        return Ok(None);
+    };
+    // Only the bare unshadowed global `require` — a local/func/imported binding
+    // named `require` shadows it (and matched an earlier lowering arm).
+    if ident.sym.as_ref() != "require"
+        || ctx.lookup_local("require").is_some()
+        || ctx.lookup_func("require").is_some()
+        || ctx.lookup_imported_func("require").is_some()
+        || call.args.len() != 1
+        || call.args[0].spread.is_some()
+    {
+        return Ok(None);
+    }
+    // Literal specifiers were already handled by `try_require_literal`.
+    if matches!(call.args[0].expr.as_ref(), ast::Expr::Lit(ast::Lit::Str(_))) {
+        return Ok(None);
+    }
+    let arg = lower_expr(ctx, call.args[0].expr.as_ref())?;
+    Ok(Some(Expr::DynamicImport {
+        paths: Vec::new(),
+        arg: Box::new(arg),
+        byte_offset: call.span.lo.0,
+        deferred_error: None,
+        synchronous: true,
+    }))
+}
+
 /// #1678 (Phase 0 of #1677) — classify a bare `Function(...)` /
 /// `eval(...)` call. The `Function('return this')()` globalThis fold runs
 /// before this (in `lower_call_inner`) and short-circuits, so its inner

--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -58,8 +58,8 @@ use imported_array_methods::try_imported_array_methods;
 use inline_array_methods::try_inline_array_methods;
 use intrinsics::{
     check_eval_function_call, try_bare_regexp_call, try_builtin_prototype_method_apply_call,
-    try_embed_wasm, try_function_return_this, try_iife_call_rewrite, try_iterator_from,
-    try_namespace_static_method_apply_call_bind, try_native_arena_intrinsics,
+    try_dynamic_require, try_embed_wasm, try_function_return_this, try_iife_call_rewrite,
+    try_iterator_from, try_namespace_static_method_apply_call_bind, try_native_arena_intrinsics,
     try_native_arena_public_api, try_native_memory_public_api, try_native_module_method_apply_call,
     try_pod_layout_constants, try_precompile, try_require_literal,
     try_strict_eval_arguments_assignment,
@@ -172,6 +172,12 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
     // Compile-time intrinsics + legacy CJS/UMD bare-callee shapes
     // (require/embedWasm/IIFE.call/Function('return this')/RegExp).
     if let Some(expr) = try_require_literal(ctx, call)? {
+        return Ok(expr);
+    }
+    // #5389 Tier 2: a computed `require(expr)` in a compiled external module
+    // lowers to a synchronous dynamic-require node (resolved + dispatched like
+    // dynamic `import()`, but returning the namespace value directly).
+    if let Some(expr) = try_dynamic_require(ctx, call)? {
         return Ok(expr);
     }
     if let Some(expr) = try_embed_wasm(ctx, call)? {
@@ -664,6 +670,7 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
                 arg: Box::new(arg),
                 byte_offset: call.span.lo.0,
                 deferred_error: None,
+                synchronous: false,
             })
         }
     }

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -654,7 +654,7 @@ impl SH for Expr {
             Expr::WebAssemblyModuleCustomSections { module, name } => { tag(h, 12054); module.as_ref().hash(h); name.as_ref().hash(h); }
             Expr::WebAssemblyInstantiate(bytes) => { tag(h, 12028); bytes.as_ref().hash(h); }
             Expr::WebAssemblyCallExport { instance, name, args, } => { tag(h, 12029); instance.as_ref().hash(h); name.as_ref().hash(h); args.hash(h); }
-            Expr::DynamicImport { paths, arg, byte_offset, deferred_error } => { tag(h, 12030); for p in paths { p.hash(h); } arg.as_ref().hash(h); byte_offset.hash(h); deferred_error.hash(h); }
+            Expr::DynamicImport { paths, arg, byte_offset, deferred_error, synchronous } => { tag(h, 12030); for p in paths { p.hash(h); } arg.as_ref().hash(h); byte_offset.hash(h); deferred_error.hash(h); synchronous.hash(h); }
             Expr::WorkerNew { paths, filename, options } => {
                 tag(h, 12055);
                 for p in paths { p.hash(h); }

--- a/crates/perry-runtime/src/module_require.rs
+++ b/crates/perry-runtime/src/module_require.rs
@@ -237,3 +237,22 @@ pub extern "C" fn js_module_ambient_require() -> f64 {
 /// callee; see project_auto_optimize_keepalive_3320).
 #[used]
 static KEEP_JS_MODULE_AMBIENT_REQUIRE: extern "C" fn() -> f64 = js_module_ambient_require;
+
+/// Synchronous ambient `require(spec)` resolution for the #5389 Tier 2 codegen
+/// fallthrough. When a computed `require(expr)` in a compiled external module did
+/// not const-fold to a compiled-module target, the dynamic-require dispatch calls
+/// this with the runtime specifier value: it resolves exactly like a
+/// createRequire-backed `require(spec)` — builtins (`node:os`, …) by string,
+/// unknown package/file specifiers throw the descriptive
+/// `ERR_PERRY_UNSUPPORTED_CREATE_REQUIRE`. Returns the required value directly
+/// (no Promise).
+#[no_mangle]
+pub extern "C" fn js_module_ambient_require_apply(spec: f64) -> f64 {
+    require_thunk(std::ptr::null(), spec)
+}
+
+/// Keepalive anchor for the auto-optimize whole-program build (generated-code-only
+/// callee; see project_auto_optimize_keepalive_3320).
+#[used]
+static KEEP_JS_MODULE_AMBIENT_REQUIRE_APPLY: extern "C" fn(f64) -> f64 =
+    js_module_ambient_require_apply;

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -732,9 +732,11 @@ fn collect_module_one(
             paths,
             arg,
             byte_offset,
+            synchronous,
             ..
         } = expr
         {
+            let synchronous = *synchronous;
             if !paths.is_empty() {
                 // Already resolved (e.g. a second pass on the same module).
                 return;
@@ -803,6 +805,18 @@ fn collect_module_one(
                             dynamic_path_sets.push(DynImportOutcome::Resolved(matches));
                             return;
                         }
+                    }
+                    // #5389 Tier 2: a synchronous `require(expr)` whose specifier
+                    // doesn't const-fold (and didn't glob-match above) falls back
+                    // to the Tier-1 ambient createRequire-backed `require` at
+                    // codegen — builtins resolve by string, unknown packages throw
+                    // the descriptive ERR_PERRY_UNSUPPORTED_CREATE_REQUIRE. Leave
+                    // `paths` empty (no `deferred_error`); the empty-paths +
+                    // synchronous codegen arm emits the ambient require. This
+                    // never participates in the strict-dynamic-import hard error.
+                    if synchronous {
+                        dynamic_path_sets.push(DynImportOutcome::Resolved(Vec::new()));
+                        return;
                     }
                     // #5230: a genuinely runtime-computed specifier. This is the
                     // analog of #5206's runtime-unknown eval bucket. Strict mode

--- a/crates/perry/tests/create_require_package.rs
+++ b/crates/perry/tests/create_require_package.rs
@@ -219,3 +219,111 @@ console.log(shadowed());
         "typeof=function | builtin-ok | Error:ERR_PERRY_UNSUPPORTED_CREATE_REQUIRE\nshadow:zzz\n"
     );
 }
+
+/// Tier 2 of #5389: a **computed** `require(expr)` whose specifier const-folds
+/// (ternary of literals, module-const, or a directory-anchored template glob) to
+/// a finite set of compiled-package modules resolves **synchronously** to the
+/// target namespace — reusing the dynamic-`import()` resolver but returning the
+/// value directly (no Promise). A specifier that does not const-fold falls back
+/// to the Tier-1 ambient require (builtins resolve by string; unknown packages
+/// throw `ERR_PERRY_UNSUPPORTED_CREATE_REQUIRE`).
+#[test]
+fn computed_require_const_folds_to_compiled_package_modules() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+
+    std::fs::write(
+        root.join("package.json"),
+        r#"{
+  "name": "computed-require-consumer",
+  "type": "module",
+  "perry": {
+    "compilePackages": ["dynlib"],
+    "allow": { "compilePackages": ["dynlib"] }
+  }
+}"#,
+    )
+    .expect("write consumer package.json");
+
+    let pkg = root.join("node_modules").join("dynlib");
+    let plugins = pkg.join("plugins");
+    std::fs::create_dir_all(&plugins).expect("mkdir dynlib/plugins");
+    std::fs::write(
+        pkg.join("package.json"),
+        r#"{ "name": "dynlib", "version": "1.0.0", "main": "index.ts", "types": "index.ts" }"#,
+    )
+    .expect("write dynlib package.json");
+    std::fs::write(pkg.join("alpha.ts"), "export const tag = \"ALPHA\";\n").expect("write alpha");
+    std::fs::write(pkg.join("beta.ts"), "export const tag = \"BETA\";\n").expect("write beta");
+    std::fs::write(
+        plugins.join("foo.ts"),
+        "export const id = \"plugin-foo\";\n",
+    )
+    .expect("write plugin foo");
+    std::fs::write(
+        pkg.join("index.ts"),
+        r#"
+// ternary of relative literals -> const-folds to a 2-element set.
+export function pick(flag: boolean): string {
+  const m = require(flag ? "./alpha" : "./beta");
+  return m.tag;
+}
+// module-const literal -> const-folds to a single target.
+export function viaConst(): string {
+  const SPEC = "./alpha";
+  return "const:" + require(SPEC).tag;
+}
+// directory-anchored template -> globs the plugins dir (runtime string must
+// equal the file specifier, including extension — same contract as import()).
+export function plugin(name: string): string {
+  return require(`./plugins/${name}`).id;
+}
+// not const-foldable -> ambient fallback (builtin resolves by string).
+export function builtinComputed(): string {
+  const spec = ["n", "o", "d", "e", ":", "o", "s"].join("");
+  return "os:" + typeof require(spec).platform;
+}
+"#,
+    )
+    .expect("write dynlib index");
+
+    let entry = root.join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+import { pick, viaConst, plugin, builtinComputed } from "dynlib";
+console.log(pick(true), pick(false));
+console.log(viaConst());
+console.log(plugin("foo.ts"));
+console.log(builtinComputed());
+"#,
+    )
+    .expect("write entry");
+
+    let output = root.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(root)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert_eq!(stdout, "ALPHA BETA\nconst:ALPHA\nplugin-foo\nos:function\n");
+}


### PR DESCRIPTION
## Summary

Tier 2 of #5389 (Tier 1 landed in #5397). A **computed** `require(expr)` in a compiled external/compilePackages module whose specifier const-folds to a finite set now resolves **synchronously** to the target compiled-module namespace, reusing the dynamic-`import()` path resolver. Previously every non-literal `require` fell back to the ambient closure (builtins only; packages threw `ERR_PERRY_UNSUPPORTED_CREATE_REQUIRE`).

`require(expr)` is the synchronous CJS analog of `import(expr)`, so this reuses the whole pipeline with one new bit.

## Changes

- **`crates/perry-hir/src/ir/expr.rs`** — new `synchronous: bool` on `Expr::DynamicImport` (`false` = ESM `import()`, `true` = CJS `require()`).
- **`crates/perry-hir/src/lower/expr_call/intrinsics.rs`** — new `try_dynamic_require`: a bare unshadowed `require` with a non-literal arg in an external module lowers to `DynamicImport { synchronous: true }`. Literals stay on `try_require_literal`. Gated to `is_external_module`.
- **`crates/perry/src/commands/compile/collect_modules.rs`** — the existing const-folder/globber populates `paths` + registers dynamic edges **unchanged**; an *unresolved* synchronous node records an empty path set (ambient fallback) instead of `import()`'s deferred-reject / strict error.
- **`crates/perry-codegen/src/expr/dyn_extern_i18n.rs`** — new `lower_dynamic_require`: same single-/multi-target `js_string_equals` dispatch as `import()`, but returns the namespace value **directly** (no Promise) with the ambient require (`js_module_ambient_require_apply`) as the no-match fallthrough. Namespace construction factored into `namespace_value_for_prefix`.

## Behavior (external/compilePackages modules)

- `require(flag ? "./a" : "./b")`, `require(SPEC)` (module-const), and `` require(`./plugins/${name}`) `` (glob; runtime string must equal the file specifier incl. extension, same contract as `import()`) resolve to compiled namespaces synchronously.
- A specifier that does not const-fold (`["n","o",…].join("")`) routes through the Tier 1 ambient require — builtins resolve, unknown packages throw the descriptive error.

## Out of scope (by design)

Genuinely runtime-computed *package* strings — same AOT boundary as dynamic `import()`.

## Tests

New `computed_require_const_folds_to_compiled_package_modules` (ternary + module-const + glob + ambient fallback). Dynamic-`import()` suite (`module_import_forms`) and the Tier 1 tests stay green; full `perry-hir` + `perry-codegen` suites pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tier 2 computed `require(expr)` in compiled external modules can now resolve synchronously to the correct compiled-module namespace when the specifier const-folds.

* **Bug Fixes / Chores**
  * Improved build/CI reliability by tightening static artifact handling, preventing dead-stripping of a required runtime entry point, and reducing a file-size limit by reorganizing build orchestration.

* **Documentation**
  * Updated changelog and version metadata for the new synchronous computed-`require` behavior.

* **Tests**
  * Added a regression test covering const-foldable vs non-const-foldable computed `require` fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->