### PR TITLE
perf(codegen): outline array-literal construction for oversized modules (#5391)

### DIFF
--- a/crates/perry-codegen/src/expr/array_literal.rs
+++ b/crates/perry-codegen/src/expr/array_literal.rs
@@ -9,7 +9,7 @@ use super::{
     nanbox_pointer_inline, FnCtx,
 };
 use crate::type_analysis::is_numeric_expr;
-use crate::types::{I32, I64, I8, PTR};
+use crate::types::{DOUBLE, I32, I64, I8, PTR};
 
 /// Lower an array literal `[a, b, c, …]`.
 ///
@@ -56,6 +56,26 @@ pub(crate) fn lower_array_literal(ctx: &mut FnCtx<'_>, elements: &[Expr]) -> Res
             ctx, value_expr,
         ));
         vals.push(lower_expr(ctx, value_expr)?);
+    }
+
+    // #5391: oversized modules outline array-literal construction. The inline
+    // bump-alloc + N×(store + layout-note + barrier) sequence makes minified
+    // data-table builders huge (single 18MB functions clang -O0 can't compile
+    // in practical time). Instead spill the already-evaluated element values to
+    // a per-literal stack buffer and build the array in ONE runtime call. The
+    // buffer is hoisted to the entry block (fixed size per site; bounded total
+    // stack) and consumed immediately by the call, so no GC-visible window.
+    if crate::codegen::full_outline_ic_enabled() {
+        let buf = ctx.func.alloca_entry_array(DOUBLE, n);
+        for (i, v) in vals.iter().enumerate() {
+            let slot = ctx.block().gep(DOUBLE, &buf, &[(I64, &i.to_string())]);
+            ctx.block().store(DOUBLE, v, &slot);
+        }
+        let n_str = n.to_string();
+        let arr = ctx
+            .block()
+            .call(I64, "js_array_from_values", &[(PTR, &buf), (I32, &n_str)]);
+        return Ok(nanbox_pointer_inline(ctx.block(), &arr));
     }
 
     // Inline bump-allocator path for small literals. Size threshold matches

--- a/crates/perry-codegen/src/runtime_decls/arrays.rs
+++ b/crates/perry-codegen/src/runtime_decls/arrays.rs
@@ -34,6 +34,9 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     // Exact-sized literal allocator — one call + N direct stores replaces
     // alloc + N×push_f64. See `js_array_alloc_literal` in perry-runtime/src/array.rs.
     module.declare_function("js_array_alloc_literal", I64, &[I32]);
+    // #5391: build an array literal from a stack buffer of N values in one call
+    // (outlines the inline alloc + per-element store/note/barrier). (values_ptr, n).
+    module.declare_function("js_array_from_values", I64, &[PTR, I32]);
     module.declare_function("js_array_push_f64", I64, &[I64, DOUBLE]);
     module.declare_function("js_array_push_hole", I64, &[I64]);
     module.declare_function("js_array_numeric_push_f64_unboxed", I64, &[I64, DOUBLE]);

--- a/crates/perry-codegen/tests/typed_feedback.rs
+++ b/crates/perry-codegen/tests/typed_feedback.rs
@@ -371,15 +371,17 @@ fn full_outline_array_literal_uses_builder_call() {
     // #5391: full-outline replaces the inline array-literal construction
     // (bump-alloc diamond + per-element store/note/barrier) with one
     // `js_array_from_values` call over a stack buffer.
+    // A param-based array (not all-const) so it reaches `lower_array_literal`
+    // rather than const-folding to a flat rodata global.
     let build = || {
         module(
             "outline_arr.ts",
-            Vec::new(),
+            vec![param(1, "x", Type::Number)],
             Type::Any,
             vec![Stmt::Return(Some(Expr::Array(vec![
-                Expr::Number(1.0),
+                Expr::LocalGet(1),
                 Expr::Number(2.0),
-                Expr::Number(3.0),
+                Expr::LocalGet(1),
             ])))],
         )
     };
@@ -391,7 +393,8 @@ fn full_outline_array_literal_uses_builder_call() {
         let ir = ir_for(build());
         assert!(ir.contains("call i64 @js_array_from_values"));
         assert!(!ir.contains("arrlit.fast"));
-        assert!(!ir.contains("js_inline_arena_slow_alloc"));
+        // the inline bump-alloc CALL (not its always-present declare) is gone
+        assert!(!ir.contains("call ptr @js_inline_arena_slow_alloc"));
     }
     {
         // OFF: the inline construction path (whatever it is for this literal) —

--- a/crates/perry-codegen/tests/typed_feedback.rs
+++ b/crates/perry-codegen/tests/typed_feedback.rs
@@ -367,6 +367,42 @@ fn full_outline_ic_collapses_class_field_set_to_single_call() {
 }
 
 #[test]
+fn full_outline_array_literal_uses_builder_call() {
+    // #5391: full-outline replaces the inline array-literal construction
+    // (bump-alloc diamond + per-element store/note/barrier) with one
+    // `js_array_from_values` call over a stack buffer.
+    let build = || {
+        module(
+            "outline_arr.ts",
+            Vec::new(),
+            Type::Any,
+            vec![Stmt::Return(Some(Expr::Array(vec![
+                Expr::Number(1.0),
+                Expr::Number(2.0),
+                Expr::Number(3.0),
+            ])))],
+        )
+    };
+
+    let _lock = ENV_LOCK.lock().unwrap();
+
+    {
+        let _g = EnvVarGuard::set("PERRY_FULL_OUTLINE_IC", Some("1"));
+        let ir = ir_for(build());
+        assert!(ir.contains("call i64 @js_array_from_values"));
+        assert!(!ir.contains("arrlit.fast"));
+        assert!(!ir.contains("js_inline_arena_slow_alloc"));
+    }
+    {
+        // OFF: the inline construction path (whatever it is for this literal) —
+        // crucially NOT the outlined builder.
+        let _g = EnvVarGuard::set("PERRY_FULL_OUTLINE_IC", Some("0"));
+        let ir = ir_for(build());
+        assert!(!ir.contains("call i64 @js_array_from_values"));
+    }
+}
+
+#[test]
 fn full_outline_ic_auto_gate_counts_class_methods() {
     // #5334 lever B: the auto size-gate counts class CALLABLES (methods,
     // accessors, ctor), not just top-level `hir.functions`. A class-heavy module

--- a/crates/perry-codegen/tests/typed_feedback.rs
+++ b/crates/perry-codegen/tests/typed_feedback.rs
@@ -669,6 +669,11 @@ fn typed_feedback_guards_numeric_array_push_specialization() {
 
 #[test]
 fn typed_feedback_marks_numeric_array_literals() {
+    // Serialize against the array-literal full-outline test and pin it off, so
+    // this test always observes the inline numeric-array construction
+    // (js_array_mark_numeric_f64_layout) rather than the outlined builder.
+    let _lock = ENV_LOCK.lock().unwrap();
+    let _g = EnvVarGuard::set("PERRY_FULL_OUTLINE_IC", Some("0"));
     let numeric_ir = ir_for(module(
         "typed_feedback_numeric_array_literal.ts",
         Vec::new(),

--- a/crates/perry-runtime/src/array/alloc.rs
+++ b/crates/perry-runtime/src/array/alloc.rs
@@ -326,6 +326,41 @@ pub extern "C" fn js_array_alloc_literal(capacity: u32) -> *mut ArrayHeader {
     ptr
 }
 
+/// #5391: build an array literal from a stack buffer of `n` pre-evaluated
+/// element values in ONE call, replacing the inline alloc + per-element
+/// store/layout-note/barrier sequence codegen otherwise emits at every literal
+/// site. For oversized modules that inline expansion makes individual functions
+/// enormous (a minified data-table builder reached 18MB of IR), which `clang
+/// -O0` compiles in superlinear time; outlining the construction keeps the call
+/// site to a buffer fill + one call.
+///
+/// Mirrors the inline `lower_array_literal` semantics: allocate via
+/// `js_array_alloc_literal` (length pre-set to `n`), copy each value, then note
+/// the slot layout and emit the write barrier per element. Both GC helpers
+/// no-op for non-pointer values, so the per-element calls are unconditional and
+/// correct for any mix of numbers and heap references.
+#[no_mangle]
+pub extern "C" fn js_array_from_values(values: *const f64, n: u32) -> *mut ArrayHeader {
+    let arr = js_array_alloc_literal(n);
+    if values.is_null() || n == 0 {
+        return arr;
+    }
+    let parent = arr as u64;
+    let elems = unsafe { (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64 };
+    for i in 0..n as usize {
+        let v = unsafe { *values.add(i) };
+        let slot = unsafe { elems.add(i) };
+        // GC_STORE_AUDIT(BARRIERED): element store immediately followed by the
+        // slot layout note + write barrier below, identical to the inline
+        // array-literal element store via emit_jsvalue_slot_store_on_block.
+        unsafe { core::ptr::write(slot, v) };
+        let vbits = v.to_bits();
+        crate::gc::js_gc_note_slot_layout(parent, i as u32, vbits);
+        crate::gc::js_write_barrier_slot(parent, slot as u64, vbits);
+    }
+    arr
+}
+
 /// Issue #179 Phase 2: if `arr` points at a `LazyArrayHeader`
 /// (`GcHeader::obj_type == GC_TYPE_LAZY_ARRAY`), force the lazy
 /// value to materialize and return the real `ArrayHeader` pointer.


### PR DESCRIPTION
## What

Outlines **array-literal construction** for oversized modules (#5391). When full-outline is enabled (size-gated by `PERRY_FULL_OUTLINE_IC`), an array literal spills its already-evaluated element values to a per-site stack buffer and builds the array in ONE `js_array_from_values(ptr, n)` call — instead of the inline bump-alloc diamond + N×(store + layout-note + barrier) that codegen otherwise emits.

## Why

After codegen-unit splitting (#5407) removed the module memory wall and the string-init split removed the 68MB generated function, the bundle's biggest *user* functions are minified **data-table builders**. The 18MB `perry_closure…31856` was ~17K `js_gc_note_slot_layout` + 11K `js_inline_arena_slow_alloc` + 9K `js_write_barrier_slot` — thousands of inline-allocated array literals. `clang -O0` time is superlinear in function size, so these were the residual wall.

## Result (measured on the bundle)

| function | before | after |
|---|---|---|
| `closure_31856` (array data-table) | **18.2MB** | **5.4MB** (−70%) |
| `closure_24850` | 7.6MB | 5.3MB |

25,070 array-literal sites collapsed to `js_array_from_values` calls. Per-site IR drops from ~15 + 4N instructions to ~N + 3.

## Correctness

The runtime helper `js_array_from_values` mirrors the inline path exactly: allocate via `js_array_alloc_literal` (length pre-set), copy each value, then `js_gc_note_slot_layout` + `js_write_barrier_slot` per element (both no-op for non-pointers, so the calls are unconditional and correct for any mix). The per-site stack buffer is entry-hoisted (bounded total stack) and consumed immediately by the call — no GC-visible half-built window.

- E2E: numeric + string-pointer + nested-array-pointer elements all read back correctly with full-outline ON and OFF (`51 == 51`).
- New unit test (both gate states); GC store-site inventory + full `perry-codegen` suite green. Default off = unchanged behavior.

## Next (separate)

The new biggest user function is `main` (11.5MB), dominated by a *different* construct — **closure construction** (40K `js_closure_set_capture_f64` + 5K `js_closure_alloc_singleton`). Outlining that is the next step under #5391.

Refs #5391.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Optimizations**
  * Improved array literal construction for outline-enabled configurations by switching to a builder-style path that reduces inline allocation overhead and streamlines element handling.

* **New Features**
  * Added a runtime helper to construct array literals from a contiguous buffer of values, including required GC slot layout tracking and write barriers.

* **Tests**
  * Added coverage to verify the builder call is emitted only when `PERRY_FULL_OUTLINE_IC=1`, and updated related assertions to preserve the expected inline construction behavior when set to `0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->