### PR TITLE
fix(codegen): unknown builtin-namespace member reads as undefined, not 0 (#5347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## v0.5.1188 — fix(codegen): unknown builtin-namespace member reads as `undefined`, not `0` (#5347)
+
+Reading a property that does not exist on a builtin global namespace object —
+`Reflect.enumerate`, `Math.bogus`, `JSON.bogus`, `Object.bogus`, `Number.bogus`,
+… — produced the JS number `0` instead of `undefined`, so `typeof Math.bogus`
+was `"number"` and feature-detection like `Reflect.enumerate === undefined`
+(the method was removed from the spec) was `false`.
+
+The HIR collapses every builtin global receiver to the `GlobalGet(0)` sentinel,
+so codegen routes these value reads by property name alone
+(`crates/perry-codegen/src/expr/property_get.rs`). The fall-through for an
+unrecognized member returned `double_literal(0.0)`; it now returns the
+`TAG_UNDEFINED` NaN-box — a spec-correct property miss for every namespace.
+Recognized statics (`Math.PI`, `Reflect.get`, `JSON.stringify`, `Promise.*`,
+`Error.*`, `process.env`, the `globalThis` builtin names) are special-cased
+above the fall-through and are unchanged. Fixes test262
+`built-ins/Reflect/enumerate/undefined.js`; regression-pinned by
+`crates/perry/tests/builtin_namespace_unknown_member.rs`.
+
 ## v0.5.1187 — fix(ci): per-PR cargo-test — per-package runs + don't fan into FFI shims (feature-unification link errors)
 
 Follow-up to #5411/#5413. Two more issues made the fast per-PR path fail on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5283,7 +5283,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "anyhow",
  "base64",
@@ -5340,14 +5340,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "cc",
  "libc",
@@ -5355,7 +5355,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "anyhow",
  "log",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5379,7 +5379,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "anyhow",
  "base64",
@@ -5419,7 +5419,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5456,14 +5456,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "serde",
  "serde_json",
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1187"
+version = "0.5.1188"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "anyhow",
  "clap",
@@ -5497,14 +5497,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5512,7 +5512,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5545,7 +5545,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5571,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5603,14 +5603,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5652,7 +5652,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "bytes",
  "h2",
@@ -5675,7 +5675,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5685,7 +5685,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5696,7 +5696,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5704,7 +5704,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5712,7 +5712,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "bson",
  "futures-util",
@@ -5724,7 +5724,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5734,7 +5734,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5765,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5782,7 +5782,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "base64",
  "image",
@@ -5799,14 +5799,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5815,7 +5815,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5833,7 +5833,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5845,7 +5845,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "brotli",
  "flate2",
@@ -5854,7 +5854,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5863,7 +5863,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5881,7 +5881,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5893,7 +5893,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "anyhow",
  "base64",
@@ -5926,7 +5926,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6018,7 +6018,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6028,7 +6028,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6036,14 +6036,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "base64",
  "itoa",
@@ -6060,7 +6060,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6070,7 +6070,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6093,7 +6093,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "base64",
  "block2",
@@ -6109,7 +6109,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "base64",
  "block2",
@@ -6124,7 +6124,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1187"
+version = "0.5.1188"
 
 [[package]]
 name = "perry-ui-test"
@@ -6132,11 +6132,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1187"
+version = "0.5.1188"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "base64",
  "block2",
@@ -6152,7 +6152,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "base64",
  "block2",
@@ -6168,7 +6168,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "block2",
  "libc",
@@ -6181,7 +6181,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "base64",
  "libc",
@@ -6198,14 +6198,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6219,7 +6219,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1187"
+version = "0.5.1188"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ strip = false
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1187"
+version = "0.5.1188"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -854,8 +854,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // for the only realistic alternative caller. The full fix
             // would side-channel the original global name through
             // lowering; deferred until a second-callable-builtin
-            // arrives. Other property shapes still fall through to
-            // `0.0`.
+            // arrives. Other unrecognized property shapes fall through
+            // to the `undefined` sentinel (a spec-correct property miss).
             if matches!(object.as_ref(), Expr::GlobalGet(_)) {
                 // `process.env` read as a VALUE (not `process.env.X`) must
                 // materialize the live env object, not the `undefined` sentinel.
@@ -1236,7 +1236,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         &[(PTR, &key_bytes_global), (I64, &key_len)],
                     ));
                 }
-                return Ok(double_literal(0.0));
+                // Unknown member on a builtin global namespace object
+                // (`Reflect.enumerate`, `Math.bogus`, `JSON.bogus`, …): JS
+                // semantics is a plain `undefined` property miss, not `0`. The
+                // HIR collapsed the receiver to the `GlobalGet(0)` sentinel so we
+                // can't tell which namespace it was, but an unrecognized member
+                // read is `undefined` for every one of them. (The legacy `0.0`
+                // here made `typeof Math.bogus === "number"` and broke
+                // feature-detection like `Reflect.enumerate === undefined`.)
+                return Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));
             }
             // Namespace-import member access: `import * as O from './oids';
             // O.OID_INT2`. The HIR lowers `O` itself to `ExternFuncRef { name:

--- a/crates/perry/tests/builtin_namespace_unknown_member.rs
+++ b/crates/perry/tests/builtin_namespace_unknown_member.rs
@@ -1,0 +1,103 @@
+//! Regression: an unknown property on a builtin global namespace object
+//! (`Reflect.enumerate`, `Math.bogus`, `JSON.bogus`, …) must read as
+//! `undefined`, not the number `0`.
+//!
+//! The codegen value-read fall-through for a `GlobalGet` receiver
+//! (`property_get.rs`) previously lowered any unrecognized member to `0.0`, so
+//! `typeof Math.bogus === "number"` and `Reflect.enumerate === undefined` was
+//! `false` — breaking feature-detection. test262:
+//! `built-ins/Reflect/enumerate/undefined.js`. Issue #5347.
+//!
+//! Uses a `.js` fixture (not `.ts`) so a bare unknown-member access like
+//! `Math.bogus` is valid source — it exercises the statically-typed
+//! builtin-namespace member path that the bug lived in (an `as any` cast would
+//! bypass it through dynamic property lookup).
+
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+/// Write `entry` into `dir`, compile it with `--no-cache`
+/// `PERRY_NO_AUTO_OPTIMIZE=1` (links the prebuilt runtime archive), run it, and
+/// return stdout. Asserts compile + run succeed. Mirrors the helper in
+/// `functional_batch2_regressions.rs`.
+fn compile_and_run_js(dir: &Path, entry: &str, source: &str) -> String {
+    let entry_path = dir.join(entry);
+    std::fs::write(&entry_path, source).expect("write fixture");
+    let output = dir.join("main_bin");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry_path)
+        .arg("--no-cache")
+        .arg("-o")
+        .arg(&output)
+        .env("PERRY_NO_AUTO_OPTIMIZE", "1")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+#[test]
+fn unknown_builtin_namespace_member_is_undefined_not_zero() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run_js(
+        dir.path(),
+        "main.js",
+        r#"
+// Unknown members on builtin namespace globals → undefined, not 0.
+console.log("math-bogus-undef:", Math.bogus === undefined);
+console.log("math-bogus-typeof:", typeof Math.bogus);
+console.log("math-bogus-not-zero:", Math.bogus !== 0);
+console.log("json-bogus-undef:", JSON.bogus === undefined);
+console.log("object-bogus-undef:", Object.bogus === undefined);
+console.log("number-bogus-undef:", Number.bogus === undefined);
+// The motivating test262 case: Reflect.enumerate was removed from the spec.
+console.log("reflect-enumerate-undef:", Reflect.enumerate === undefined);
+console.log("reflect-no-own-enumerate:", Reflect.hasOwnProperty("enumerate"));
+// Known members must still resolve (no regression on special-cased reads).
+console.log("math-pi:", Math.PI > 3.14159 && Math.PI < 3.1416);
+console.log("reflect-get:", typeof Reflect.get);
+console.log("json-stringify:", typeof JSON.stringify);
+console.log("promise-resolve:", typeof Promise.resolve);
+console.log("number-max:", Number.MAX_SAFE_INTEGER === 9007199254740991);
+"#,
+    );
+    let expected = "math-bogus-undef: true\n\
+        math-bogus-typeof: undefined\n\
+        math-bogus-not-zero: true\n\
+        json-bogus-undef: true\n\
+        object-bogus-undef: true\n\
+        number-bogus-undef: true\n\
+        reflect-enumerate-undef: true\n\
+        reflect-no-own-enumerate: false\n\
+        math-pi: true\n\
+        reflect-get: function\n\
+        json-stringify: function\n\
+        promise-resolve: function\n\
+        number-max: true\n";
+    assert_eq!(stdout, expected);
+}


### PR DESCRIPTION
## Problem

Reading a property that does **not** exist on a builtin global namespace object — `Reflect.enumerate`, `Math.bogus`, `JSON.bogus`, `Object.bogus`, `Number.bogus`, … — produced the JS number `0` instead of `undefined`:

```js
typeof Math.bogus            // was "number" (0); should be "undefined"
Reflect.enumerate === undefined  // was false; should be true
```

This broke feature-detection (`Reflect.enumerate` was **removed** from the spec, so code checks `=== undefined`). Found while measuring the `built-ins/Reflect` test262 bucket (the one remaining runtime-fail: `built-ins/Reflect/enumerate/undefined.js`). It is **general** across all builtin namespace globals, not Reflect-specific.

## Root cause

The HIR collapses every builtin global receiver to the `GlobalGet(0)` sentinel, so codegen (`crates/perry-codegen/src/expr/property_get.rs`) routes these value reads by property name alone. The arm special-cases the recognized statics (`Math.PI`, `Reflect.get`, `JSON.stringify`, `Promise.*`, `Error.*`, `process.env`, the `globalThis` builtin names) and then **fell through to `double_literal(0.0)`** for anything else — a placeholder the surrounding comments already flagged as "silently broken."

## Fix

The fall-through now returns the `TAG_UNDEFINED` NaN-box (the same sentinel used elsewhere in this file), which is the spec-correct property miss for every namespace. Recognized statics are special-cased *above* the fall-through and are unchanged. One-line behavioral change + comment updates.

## Verification

- New regression test `crates/perry/tests/builtin_namespace_unknown_member.rs` (passes) — covers the unknown-member cases **and** that known members still resolve.
- Existing `tests/test_math_existing_api_parity.sh` still passes (known Math reads unaffected).
- `cargo test -p perry-codegen` unit tests: 16 passed, 0 failed.
- Manual: `Math.PI`, `Reflect.get`, `JSON.stringify`, `Promise.resolve`, `Number.MAX_SAFE_INTEGER`, `Object.keys` all still resolve correctly.

Advances #5347 (resolves the `built-ins/Reflect/enumerate` fail and the broader unknown-namespace-member class).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected behavior when accessing unknown properties on global builtin objects (Math, JSON, Object, Number, Reflect). Previously returned `0`; now correctly returns `undefined`, aligning with standard JavaScript semantics for feature detection and `typeof` checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->