### PR TITLE
feat(cache): configurable cache dir, default to node_modules/.cache/perry

### DIFF
--- a/crates/perry/src/commands/audit.rs
+++ b/crates/perry/src/commands/audit.rs
@@ -364,8 +364,9 @@ fn print_local_sbom(path_arg: &str, format: OutputFormat) -> Result<()> {
     // `audit.json` — same shape `perry compile` walks up to find
     // `package.json`, so `perry audit --sbom` works from anywhere in the
     // project tree. The cache dir defaults to `node_modules/.cache/perry`
-    // but honors `--cache-dir` / `PERRY_CACHE_DIR` / `perry.cacheDir`, so
-    // resolve it per candidate directory rather than hard-coding a name.
+    // but honors `--cache-dir` / `PERRY_CACHE_DIR` / perry.toml
+    // `[perry] cacheDir` / package.json `perry.cacheDir`, so resolve it per
+    // candidate directory rather than hard-coding a name.
     let manifest_path = {
         let mut dir = root.clone();
         loop {

--- a/crates/perry/src/commands/audit.rs
+++ b/crates/perry/src/commands/audit.rs
@@ -10,6 +10,7 @@ use std::fs;
 use std::path::Path;
 use walkdir::WalkDir;
 
+use super::compile::{cache_dir_override, resolve_cache_dir};
 use crate::OutputFormat;
 
 #[derive(Args, Debug)]
@@ -43,8 +44,9 @@ pub struct AuditArgs {
     pub verify_url: String,
 
     /// #495: print the local behavioral SBOM produced at the last
-    /// compile (`.perry-cache/audit.json` under the current project
-    /// root). Per-module list of stdlib symbols actually called,
+    /// compile (`audit.json` in the resolved cache dir, default
+    /// `node_modules/.cache/perry`, under the current project root).
+    /// Per-module list of stdlib symbols actually called,
     /// keyed by source file with the owning npm package name when
     /// the source lives under `node_modules/<pkg>/...`. When this
     /// flag is set, the remote security scan is *not* invoked.
@@ -350,20 +352,25 @@ fn display_audit_results(audit: &AuditResponse, fail_on: &str) {
 
 /// Entry point for `perry audit` command
 /// #495: print the local behavioral SBOM emitted by the last
-/// `perry compile`/`perry run` into `<project>/.perry-cache/audit.json`.
+/// `perry compile`/`perry run` into `audit.json` in the resolved cache
+/// dir (default `<project>/node_modules/.cache/perry/audit.json`).
 /// In Text mode, formats a per-module breakdown grouped by owning npm
 /// package; in JSON mode, dumps the raw manifest. Returns a clear
 /// error if the manifest doesn't exist yet (build first).
 fn print_local_sbom(path_arg: &str, format: OutputFormat) -> Result<()> {
     let root = std::path::PathBuf::from(path_arg);
     let root = root.canonicalize().unwrap_or(root);
-    // Walk up to find a directory containing `.perry-cache/audit.json`
-    // — same shape `perry compile` walks up to find `package.json`,
-    // so `perry audit --sbom` works from anywhere in the project tree.
+    // Walk up to find a directory whose resolved cache dir holds
+    // `audit.json` — same shape `perry compile` walks up to find
+    // `package.json`, so `perry audit --sbom` works from anywhere in the
+    // project tree. The cache dir defaults to `node_modules/.cache/perry`
+    // but honors `--cache-dir` / `PERRY_CACHE_DIR` / `perry.cacheDir`, so
+    // resolve it per candidate directory rather than hard-coding a name.
     let manifest_path = {
         let mut dir = root.clone();
         loop {
-            let candidate = dir.join(".perry-cache").join("audit.json");
+            let cache_dir = resolve_cache_dir(&dir, cache_dir_override(&dir).as_deref());
+            let candidate = cache_dir.join("audit.json");
             if candidate.exists() {
                 break Some(candidate);
             }
@@ -374,7 +381,7 @@ fn print_local_sbom(path_arg: &str, format: OutputFormat) -> Result<()> {
     };
     let Some(manifest_path) = manifest_path else {
         bail!(
-            "no .perry-cache/audit.json found under `{}` — run `perry compile` or `perry run` first; the manifest is written on every successful build.",
+            "no audit.json found under `{}` (looked in the resolved cache dir, default `node_modules/.cache/perry`) — run `perry compile` or `perry run` first; the manifest is written on every successful build.",
             root.display()
         );
     };

--- a/crates/perry/src/commands/cache.rs
+++ b/crates/perry/src/commands/cache.rs
@@ -1,16 +1,21 @@
 //! Cache management subcommands: `perry cache clean`, `perry cache info`.
 //!
-//! The on-disk object cache lives at `<project-root>/.perry-cache/objects/<target>/<key>.o`
-//! (see `commands/compile.rs :: ObjectCache`). These subcommands let users
-//! inspect and wipe it without resorting to `rm -rf`, which matters mostly for
-//! discoverability: if a user suspects a stale cache they can reach for
-//! `perry cache clean` rather than digging into a hidden directory.
+//! The on-disk object cache lives at
+//! `<cache-dir>/objects/<target>/<key>.o`, where `cache-dir` defaults to
+//! `<project-root>/node_modules/.cache/perry` and can be overridden via
+//! `--cache-dir`, `PERRY_CACHE_DIR`, or package.json `perry.cacheDir`
+//! (see `commands/compile/object_cache.rs :: resolve_cache_dir`). These
+//! subcommands let users inspect and wipe it without resorting to `rm -rf`,
+//! which matters mostly for discoverability: if a user suspects a stale
+//! cache they can reach for `perry cache clean` rather than digging into a
+//! hidden directory.
 
 use anyhow::{anyhow, Result};
 use clap::{Args, Subcommand};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use super::compile::{cache_dir_override, resolve_cache_dir};
 use crate::OutputFormat;
 
 #[derive(Args, Debug)]
@@ -21,7 +26,8 @@ pub struct CacheArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum CacheCommand {
-    /// Delete the entire `.perry-cache/` directory for the current project.
+    /// Delete the entire Perry cache directory for the current project
+    /// (default `node_modules/.cache/perry`).
     Clean(CleanArgs),
     /// Show cache location, size, and per-target file counts.
     Info(InfoArgs),
@@ -58,7 +64,7 @@ fn resolve_root(explicit: Option<PathBuf>) -> Result<PathBuf> {
 
 fn clean(args: CleanArgs, format: OutputFormat) -> Result<()> {
     let root = resolve_root(args.project_root)?;
-    let cache_dir = root.join(".perry-cache");
+    let cache_dir = resolve_cache_dir(&root, cache_dir_override(&root).as_deref());
     if !cache_dir.exists() {
         match format {
             OutputFormat::Text => {
@@ -100,7 +106,7 @@ fn clean(args: CleanArgs, format: OutputFormat) -> Result<()> {
 
 fn info(args: InfoArgs, format: OutputFormat) -> Result<()> {
     let root = resolve_root(args.project_root)?;
-    let cache_dir = root.join(".perry-cache");
+    let cache_dir = resolve_cache_dir(&root, cache_dir_override(&root).as_deref());
     if !cache_dir.exists() {
         match format {
             OutputFormat::Text => {

--- a/crates/perry/src/commands/cache.rs
+++ b/crates/perry/src/commands/cache.rs
@@ -3,7 +3,8 @@
 //! The on-disk object cache lives at
 //! `<cache-dir>/objects/<target>/<key>.o`, where `cache-dir` defaults to
 //! `<project-root>/node_modules/.cache/perry` and can be overridden via
-//! `--cache-dir`, `PERRY_CACHE_DIR`, or package.json `perry.cacheDir`
+//! `--cache-dir`, `PERRY_CACHE_DIR`, perry.toml `[perry] cacheDir`, or
+//! package.json `perry.cacheDir`
 //! (see `commands/compile/object_cache.rs :: resolve_cache_dir`). These
 //! subcommands let users inspect and wipe it without resorting to `rm -rf`,
 //! which matters mostly for discoverability: if a user suspects a stale

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -451,15 +451,16 @@ pub fn run_with_parse_cache(
     ctx.cache_root = object_cache_project_root(&args.input, &project_root);
     // Resolve the on-disk cache directory ONCE, here, before any cache
     // consumer runs. Precedence: `--cache-dir` → `PERRY_CACHE_DIR` →
-    // package.json `perry.cacheDir` → default
-    // `<cache_root>/node_modules/.cache/perry` (the find-cache-dir
-    // convention). `cache_dir_override` reads the env var + package.json
-    // half; the CLI flag wins over both. Relative overrides resolve against
-    // `cache_root`. Computed here because the build-cache probe below runs
-    // before `host_config::apply_pkg_and_toml_config`, so the build cache
-    // must already know the dir. host_config re-resolves `ctx.cache_dir` to
-    // the same value when it parses `perry.cacheDir` alongside its sibling
-    // `perry.*` fields — that pass owns the canonical package.json read.
+    // perry.toml `[perry] cacheDir` → package.json `perry.cacheDir` →
+    // default `<cache_root>/node_modules/.cache/perry` (the find-cache-dir
+    // convention). `cache_dir_override` reads the env + perry.toml +
+    // package.json half; the CLI flag wins over all three. Relative
+    // overrides resolve against `cache_root`. Computed here because the
+    // build-cache probe below runs before
+    // `host_config::apply_pkg_and_toml_config`, so the build cache must
+    // already know the dir. host_config re-resolves `ctx.cache_dir` to the
+    // same value when it parses the config alongside its sibling `perry.*`
+    // fields — that pass owns the canonical read.
     let cache_dir_override = args
         .cache_dir
         .clone()

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -78,6 +78,7 @@ use link::{build_and_run_link, write_link_cache_manifest};
 pub use lock_scan::collect_native_archives_for_lock;
 pub(crate) use lock_scan::run_lock_verify_for_compile;
 pub use object_cache::ObjectCache;
+pub use object_cache::{cache_dir_override, resolve_cache_dir};
 use object_cache::{compute_object_cache_key, djb2_hash};
 use optimized_libs::{build_optimized_libs, OptimizedLibs};
 use parse_cache::parse_cached;
@@ -448,11 +449,28 @@ pub fn run_with_parse_cache(
 
     let mut ctx = CompilationContext::new(project_root.clone());
     ctx.cache_root = object_cache_project_root(&args.input, &project_root);
+    // Resolve the on-disk cache directory ONCE, here, before any cache
+    // consumer runs. Precedence: `--cache-dir` → `PERRY_CACHE_DIR` →
+    // package.json `perry.cacheDir` → default
+    // `<cache_root>/node_modules/.cache/perry` (the find-cache-dir
+    // convention). `cache_dir_override` reads the env var + package.json
+    // half; the CLI flag wins over both. Relative overrides resolve against
+    // `cache_root`. Computed here because the build-cache probe below runs
+    // before `host_config::apply_pkg_and_toml_config`, so the build cache
+    // must already know the dir. host_config re-resolves `ctx.cache_dir` to
+    // the same value when it parses `perry.cacheDir` alongside its sibling
+    // `perry.*` fields — that pass owns the canonical package.json read.
+    let cache_dir_override = args
+        .cache_dir
+        .clone()
+        .or_else(|| object_cache::cache_dir_override(&ctx.cache_root));
+    ctx.cache_dir = object_cache::resolve_cache_dir(&ctx.cache_root, cache_dir_override.as_deref());
     // #5247: propagate `--debug-symbols` so `collect_modules` records the
     // CJS-wrap source mapping needed to render original-source line numbers.
     ctx.debug_symbols = args.debug_symbols;
 
-    let build_cache_probe = BuildCacheProbe::new(&args, &project_root, &ctx.cache_root);
+    let build_cache_probe =
+        BuildCacheProbe::new(&args, &project_root, &ctx.cache_root, &ctx.cache_dir);
     let mut build_cache_stats = build_cache_probe.probe();
     if build_cache_stats.hit {
         if let OutputFormat::Json = format {
@@ -1810,7 +1828,7 @@ pub fn run_with_parse_cache(
     // mode here so the per-module codegen can emit .ll instead of .o.
     let bitcode_link = std::env::var("PERRY_LLVM_BITCODE_LINK").ok().as_deref() == Some("1");
 
-    // V2.2: Per-module object cache at `.perry-cache/objects/<target>/<key>.o`.
+    // V2.2: Per-module object cache at `<cache_dir>/objects/<target>/<key>.o`.
     // Disabled when the user passed `--no-cache`, when `PERRY_NO_CACHE=1`, or
     // when we're in bitcode-link mode (the artifacts aren't object files), or
     // when native-region verification is enabled and lowering must run.
@@ -1828,7 +1846,7 @@ pub fn run_with_parse_cache(
     // Target dir name for the cache layout. Using the resolved LLVM triple
     // keeps cross-compile caches from colliding with native-host caches.
     let cache_target_dir = target.as_deref().unwrap_or("host");
-    let object_cache = ObjectCache::new(&ctx.cache_root, cache_target_dir, cache_enabled);
+    let object_cache = ObjectCache::new(&ctx.cache_dir, cache_target_dir, cache_enabled);
     let perry_version = env!("CARGO_PKG_VERSION");
 
     // Issue #100: precompute the dynamic-import plumbing so the rayon
@@ -4164,11 +4182,11 @@ pub fn run_with_parse_cache(
                     );
                 }
                 // PERRY_CACHE_DEBUG_HIR=1: also dump the post-transform HIR of
-                // misses to .perry-cache/debug/<key>.txt so a user can diff two
+                // misses to <cache_dir>/debug/<key>.txt so a user can diff two
                 // miss-dumps and see exactly what differed. Best-effort — IO
                 // errors never fail the build.
                 if std::env::var("PERRY_CACHE_DEBUG_HIR").as_deref() == Ok("1") {
-                    let dump_dir = ctx.cache_root.join(".perry-cache").join("debug");
+                    let dump_dir = ctx.cache_dir.join("debug");
                     if std::fs::create_dir_all(&dump_dir).is_ok() {
                         let dump_path = dump_dir.join(format!("{:016x}.txt", k));
                         let _ = std::fs::write(

--- a/crates/perry/src/commands/compile/audit_manifest.rs
+++ b/crates/perry/src/commands/compile/audit_manifest.rs
@@ -5,7 +5,7 @@
 //! - `package_name_for_path` — used by the perry-jsruntime refusal diagnostic
 //!   (#499) to attribute a JS-runtime importer back to its owning npm package.
 //! - `write_audit_manifest` / `write_audit_manifest_logging_failures` — emit
-//!   `.perry-cache/audit.json` (#495 behavioral SBOM).
+//!   `<cache_dir>/audit.json` (#495 behavioral SBOM).
 //! - `allowlist_matches` — the host-allowlist pattern matcher for
 //!   `perry.nativeLibrary` / `perry.compilePackages` (#497).
 
@@ -43,7 +43,8 @@ pub(super) fn package_name_for_path(source_path: &str) -> Option<String> {
 }
 
 /// #495: serialize the per-module behavioral SBOM to
-/// `.perry-cache/audit.json` under the current project root. Walks
+/// `<cache_dir>/audit.json` (default
+/// `<project>/node_modules/.cache/perry/audit.json`). Walks
 /// every collected native HIR module (skips JS-runtime modules — they
 /// don't have HIR), groups records by stable canonical-path order
 /// so the JSON is byte-deterministic across builds.
@@ -56,8 +57,8 @@ fn write_audit_manifest(ctx: &CompilationContext) -> std::io::Result<()> {
         let record = perry_hir::audit_module(hir_module, &source);
         manifest.modules.push(record);
     }
-    let dir = ctx.cache_root.join(".perry-cache");
-    fs::create_dir_all(&dir)?;
+    let dir = &ctx.cache_dir;
+    fs::create_dir_all(dir)?;
     let path = dir.join("audit.json");
     let json = serde_json::to_string_pretty(&manifest)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
@@ -98,7 +99,7 @@ pub(crate) fn allowlist_matches(name: &str, patterns: &[String]) -> bool {
     false
 }
 
-/// #495 wrapper: emit the behavioral SBOM at `.perry-cache/audit.json`,
+/// #495 wrapper: emit the behavioral SBOM at `<cache_dir>/audit.json`,
 /// best-effort. The SBOM is observational metadata, not a correctness
 /// gate, so an I/O failure becomes a warning and the build continues.
 pub(super) fn write_audit_manifest_logging_failures(
@@ -108,7 +109,7 @@ pub(super) fn write_audit_manifest_logging_failures(
     if let Err(e) = write_audit_manifest(ctx) {
         match format {
             OutputFormat::Text => {
-                eprintln!("warning: failed to write .perry-cache/audit.json: {}", e);
+                eprintln!("warning: failed to write audit.json: {}", e);
             }
             OutputFormat::Json => {}
         }

--- a/crates/perry/src/commands/compile/bootstrap.rs
+++ b/crates/perry/src/commands/compile/bootstrap.rs
@@ -932,7 +932,8 @@ pub(super) fn run_post_collect_preflight(
     enforce_egress_policy(ctx)?;
     enforce_lockdown_policy(ctx)?;
 
-    // #495: emit a behavioral SBOM at `.perry-cache/audit.json`. The
+    // #495: emit a behavioral SBOM at `<cache_dir>/audit.json` (default
+    // `node_modules/.cache/perry/audit.json`). The
     // manifest captures, per source module, the stdlib symbols
     // actually called from the lowered HIR. Foundation for the
     // host-controlled per-package capability enforcement issue (#501)

--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -89,12 +89,19 @@ struct EnvFingerprint {
 }
 
 impl BuildCacheProbe {
-    pub(super) fn new(args: &CompileArgs, project_root: &Path, cache_root: &Path) -> Self {
+    /// `cache_root` is the config root (where package.json lives) used to
+    /// pick up config-file inputs; `cache_dir` is the already-resolved
+    /// Perry cache directory the build manifest is written under.
+    pub(super) fn new(
+        args: &CompileArgs,
+        project_root: &Path,
+        cache_root: &Path,
+        cache_dir: &Path,
+    ) -> Self {
         let output_path = default_output_path(args);
         let output_identity = absolute_identity(&output_path);
         let manifest_name = format!("{}.json", short_hash(output_identity.as_bytes()));
-        let manifest_path = cache_root
-            .join(".perry-cache")
+        let manifest_path = cache_dir
             .join("build")
             .join(args.target.as_deref().unwrap_or("native"))
             .join(manifest_name);

--- a/crates/perry/src/commands/compile/host_config.rs
+++ b/crates/perry/src/commands/compile/host_config.rs
@@ -14,7 +14,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use perry_codegen::FpContractMode;
@@ -178,6 +178,30 @@ pub(super) fn apply_pkg_and_toml_config(
                     .and_then(|v| v.as_bool())
                 {
                     ctx.fast_math = fm;
+                }
+                // perry.cacheDir: directory for Perry's on-disk caches.
+                // Default `<root>/node_modules/.cache/perry` (the
+                // find-cache-dir convention). Precedence below: `--cache-dir`
+                // → `PERRY_CACHE_DIR` → this package.json field. `compile.rs`
+                // already resolved `ctx.cache_dir` once before the build-cache
+                // probe ran; re-resolve here so the canonical config pass owns
+                // the package.json read alongside its `perry.*` siblings and
+                // every later consumer (audit.json, object/link cache, sandbox
+                // profiles) sees the same value. See `docs/src/cli/cache-dir.md`.
+                if let Some(s) = pkg
+                    .get("perry")
+                    .and_then(|p| p.get("cacheDir"))
+                    .and_then(|v| v.as_str())
+                {
+                    if !s.is_empty() {
+                        let cli_or_env = args
+                            .cache_dir
+                            .clone()
+                            .or_else(|| std::env::var_os("PERRY_CACHE_DIR").map(PathBuf::from));
+                        let override_dir = cli_or_env.unwrap_or_else(|| PathBuf::from(s));
+                        ctx.cache_dir =
+                            super::object_cache::resolve_cache_dir(&ctx.cache_root, Some(&override_dir));
+                    }
                 }
                 // #2309: perry.experiments.treeShake — host opt-in to
                 // tree-shaking / dead-code elimination (OR'd with the

--- a/crates/perry/src/commands/compile/host_config.rs
+++ b/crates/perry/src/commands/compile/host_config.rs
@@ -14,7 +14,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::Result;
 use perry_codegen::FpContractMode;
@@ -181,28 +181,25 @@ pub(super) fn apply_pkg_and_toml_config(
                 }
                 // perry.cacheDir: directory for Perry's on-disk caches.
                 // Default `<root>/node_modules/.cache/perry` (the
-                // find-cache-dir convention). Precedence below: `--cache-dir`
-                // → `PERRY_CACHE_DIR` → this package.json field. `compile.rs`
-                // already resolved `ctx.cache_dir` once before the build-cache
-                // probe ran; re-resolve here so the canonical config pass owns
-                // the package.json read alongside its `perry.*` siblings and
-                // every later consumer (audit.json, object/link cache, sandbox
-                // profiles) sees the same value. See `docs/src/cli/cache-dir.md`.
-                if let Some(s) = pkg
-                    .get("perry")
-                    .and_then(|p| p.get("cacheDir"))
-                    .and_then(|v| v.as_str())
-                {
-                    if !s.is_empty() {
-                        let cli_or_env = args
-                            .cache_dir
-                            .clone()
-                            .or_else(|| std::env::var_os("PERRY_CACHE_DIR").map(PathBuf::from));
-                        let override_dir = cli_or_env.unwrap_or_else(|| PathBuf::from(s));
-                        ctx.cache_dir =
-                            super::object_cache::resolve_cache_dir(&ctx.cache_root, Some(&override_dir));
-                    }
-                }
+                // find-cache-dir convention). Precedence: `--cache-dir` →
+                // `PERRY_CACHE_DIR` → perry.toml `[perry] cacheDir` →
+                // package.json `perry.cacheDir`. `compile.rs` already resolved
+                // `ctx.cache_dir` once before the build-cache probe ran;
+                // re-resolve here so the canonical config pass owns the read
+                // alongside its `perry.*` siblings and every later consumer
+                // (audit.json, object/link cache, sandbox profiles) sees the
+                // same value. `cache_dir_override` reads the env + perry.toml +
+                // package.json layers; `args.cache_dir` (the CLI flag) wins
+                // over all three — same merge `compile.rs` performs.
+                // See `docs/src/cli/cache-dir.md`.
+                let cache_dir_override = args
+                    .cache_dir
+                    .clone()
+                    .or_else(|| super::object_cache::cache_dir_override(&ctx.cache_root));
+                ctx.cache_dir = super::object_cache::resolve_cache_dir(
+                    &ctx.cache_root,
+                    cache_dir_override.as_deref(),
+                );
                 // #2309: perry.experiments.treeShake — host opt-in to
                 // tree-shaking / dead-code elimination (OR'd with the
                 // PERRY_TREE_SHAKE env var checked above).

--- a/crates/perry/src/commands/compile/link/build_and_run.rs
+++ b/crates/perry/src/commands/compile/link/build_and_run.rs
@@ -1736,7 +1736,7 @@ pub(crate) fn build_and_run_link(
     }
 
     let link_cache_status = prepare_link_cache_status(
-        &ctx.cache_root,
+        &ctx.cache_dir,
         target,
         &cmd,
         obj_paths,

--- a/crates/perry/src/commands/compile/link/link_cache.rs
+++ b/crates/perry/src/commands/compile/link/link_cache.rs
@@ -139,7 +139,7 @@ pub(in crate::commands::compile) fn write_link_cache_manifest(
 }
 
 pub(super) fn prepare_link_cache_status(
-    cache_root: &Path,
+    cache_dir: &Path,
     target: Option<&str>,
     cmd: &Command,
     obj_paths: &[PathBuf],
@@ -150,7 +150,7 @@ pub(super) fn prepare_link_cache_status(
         return LinkCacheStatus::linked(None);
     }
     let Some(state) = compute_link_cache_state(
-        cache_root,
+        cache_dir,
         target,
         cmd,
         obj_paths,
@@ -181,7 +181,7 @@ pub(super) fn prepare_link_cache_status(
 }
 
 fn compute_link_cache_state(
-    cache_root: &Path,
+    cache_dir: &Path,
     target: Option<&str>,
     cmd: &Command,
     obj_paths: &[PathBuf],
@@ -235,8 +235,7 @@ fn compute_link_cache_state(
         "{:016x}.json",
         super::super::object_cache::djb2_hash(output_identity.as_bytes())
     );
-    let manifest_path = cache_root
-        .join(".perry-cache")
+    let manifest_path = cache_dir
         .join("link")
         .join(target.unwrap_or("native"))
         .join(manifest_name);

--- a/crates/perry/src/commands/compile/link/platform_cmd.rs
+++ b/crates/perry/src/commands/compile/link/platform_cmd.rs
@@ -87,7 +87,7 @@ pub fn select_linker_command(
             .unwrap_or_else(|| "main_ts".to_string());
         // The entry object is the one that defines the `_main` text symbol.
         // Object files are content-hash-named in the per-module cache
-        // (`.perry-cache/objects/<hash>.o`), so the old filename-stem heuristic
+        // (`<cache_dir>/objects/<hash>.o`), so the old filename-stem heuristic
         // silently missed them — the objcopy rename then no-op'd and the link
         // failed with undefined `__perry_user_main`. Query each object's symbol
         // table instead; fall back to the stem match only if `nm` is unavailable.
@@ -289,7 +289,7 @@ pub fn select_linker_command(
                 .unwrap_or_else(|| "main_ts".to_string());
             // The entry object is the one that defines the `_main` text symbol.
             // Object files are content-hash-named in the per-module cache
-            // (`.perry-cache/objects/<hash>.o`), so the old filename-stem heuristic
+            // (`<cache_dir>/objects/<hash>.o`), so the old filename-stem heuristic
             // silently missed them — the objcopy rename then no-op'd and the link
             // failed with undefined `__perry_user_main`. Query each object's symbol
             // table instead; fall back to the stem match only if `nm` is unavailable.

--- a/crates/perry/src/commands/compile/object_cache.rs
+++ b/crates/perry/src/commands/compile/object_cache.rs
@@ -2,8 +2,9 @@
 //!
 //! Tier 2.1 follow-up (v0.5.340) — extracts the V2.2 codegen cache
 //! family from `compile.rs`. Three concerns clustered here because
-//! they all relate to the `.perry-cache/objects/<target>/<key>.o`
-//! cache layout:
+//! they all relate to the `<cache_dir>/objects/<target>/<key>.o`
+//! cache layout (where `cache_dir` defaults to
+//! `<project_root>/node_modules/.cache/perry`):
 //!
 //! 1. **`djb2_hash`** + **`Djb2Hasher`** — a fast non-crypto hash
 //!    used both for the cache-key field hasher and by other parts
@@ -58,6 +59,64 @@ fn perry_build_id() -> u64 {
             .map(|bytes| djb2_hash(&bytes))
             .unwrap_or(0)
     })
+}
+
+/// Directory holding Perry's on-disk caches for a project. Precedence:
+/// `--cache-dir` → `PERRY_CACHE_DIR` → package.json `perry.cacheDir`
+/// → default `<project_root>/node_modules/.cache/perry` (the find-cache-dir
+/// convention used by babel-loader / eslint / etc.). Relative overrides
+/// resolve against `project_root`.
+///
+/// This is a pure function: the caller reads the env var + package.json and
+/// passes the merged override in, so the resolver is race-free and unit-
+/// testable. Pass `None` for `override_dir` to get the default location.
+pub fn resolve_cache_dir(project_root: &Path, override_dir: Option<&Path>) -> PathBuf {
+    match override_dir {
+        Some(dir) if dir.is_absolute() => dir.to_path_buf(),
+        Some(dir) => project_root.join(dir),
+        None => project_root
+            .join("node_modules")
+            .join(".cache")
+            .join("perry"),
+    }
+}
+
+/// Read the project's cache-dir override from the environment and
+/// package.json, applying the non-CLI half of [`resolve_cache_dir`]'s
+/// precedence: `PERRY_CACHE_DIR` env var → package.json `perry.cacheDir`.
+/// Walks up from `project_root` to find the nearest `package.json` so it
+/// behaves like the rest of the compile pipeline's config discovery.
+/// Returns `None` when neither source sets a path, leaving the default.
+pub fn cache_dir_override(project_root: &Path) -> Option<PathBuf> {
+    if let Some(env) = std::env::var_os("PERRY_CACHE_DIR") {
+        if !env.is_empty() {
+            return Some(PathBuf::from(env));
+        }
+    }
+    let mut dir = project_root.to_path_buf();
+    loop {
+        let candidate = dir.join("package.json");
+        if candidate.exists() {
+            if let Ok(content) = fs::read_to_string(&candidate) {
+                if let Ok(pkg) = serde_json::from_str::<serde_json::Value>(&content) {
+                    if let Some(s) = pkg
+                        .get("perry")
+                        .and_then(|p| p.get("cacheDir"))
+                        .and_then(|v| v.as_str())
+                    {
+                        if !s.is_empty() {
+                            return Some(PathBuf::from(s));
+                        }
+                    }
+                }
+            }
+            break;
+        }
+        if !dir.pop() {
+            break;
+        }
+    }
+    None
 }
 
 /// Streaming djb2 accumulator so multi-part keys don't have to build a
@@ -129,8 +188,9 @@ fn stable_type_key(ty: &perry_types::Type) -> String {
 /// NOT captured in the key: the host CPU. `compile_ll_to_object` passes
 /// `-mcpu=native`/`-march=native` to clang, so the emitted `.o` bakes in
 /// whatever instruction set the build machine supports. The cache is
-/// consequently **machine-local** — `.perry-cache/` is in `.gitignore`
-/// for this reason. Sharing across machines with different CPUs (rsync,
+/// consequently **machine-local** — the default `node_modules/.cache/perry`
+/// is inside the already-gitignored `node_modules/` for this reason.
+/// Sharing across machines with different CPUs (rsync,
 /// NFS, Docker bind-mount) can produce SIGILL at runtime.
 ///
 /// Cross-platform non-determinism (Mach-O LC_UUID, PE TimeDateStamp,
@@ -728,7 +788,8 @@ fn serialize_namespace_entry_kind(kind: &perry_codegen::NamespaceEntryKind, out:
         }
     }
 }
-/// On-disk per-module object cache at `.perry-cache/objects/<target>/<hash:016x>.o`.
+/// On-disk per-module object cache at `<cache_dir>/objects/<target>/<hash:016x>.o`,
+/// where `cache_dir` defaults to `<project_root>/node_modules/.cache/perry`.
 ///
 /// Each rayon codegen worker calls `lookup_path(key)`; on hit, it skips the
 /// LLVM pipeline and links the cached object file directly. Older callers may
@@ -756,16 +817,15 @@ pub struct ObjectCache {
 }
 
 impl ObjectCache {
-    /// Create a new cache rooted at `<project_root>/.perry-cache/objects/<target>/`.
+    /// Create a new cache rooted at `<cache_dir>/objects/<target>/`, where
+    /// `cache_dir` is the already-resolved Perry cache directory (see
+    /// [`resolve_cache_dir`] — default `<project_root>/node_modules/.cache/perry`).
     /// `target_triple` is the LLVM target triple (or `"host"` for the host
     /// default). Passing `enabled = false` returns a no-op instance —
     /// every `lookup` misses and every `store` is a silent drop.
-    pub fn new(project_root: &Path, target_triple: &str, enabled: bool) -> Self {
+    pub fn new(cache_dir: &Path, target_triple: &str, enabled: bool) -> Self {
         let cache_dir = if enabled {
-            let dir = project_root
-                .join(".perry-cache")
-                .join("objects")
-                .join(target_triple);
+            let dir = cache_dir.join("objects").join(target_triple);
             match fs::create_dir_all(&dir) {
                 Ok(()) => Some(dir),
                 Err(_) => None, // silent degrade: cache stays disabled
@@ -1556,14 +1616,66 @@ mod object_cache_tests {
 
     #[test]
     fn cache_files_land_under_target_subdirectory() {
-        // The on-disk layout must be .perry-cache/objects/<target>/<hex>.o
-        // so cross-compile caches can coexist without colliding.
+        // The on-disk layout must be <cache_dir>/objects/<target>/<hex>.o
+        // so cross-compile caches can coexist without colliding. The dir
+        // passed to ObjectCache::new is the already-resolved cache dir.
         let dir = tempdir().unwrap();
         let cache = ObjectCache::new(dir.path(), "aarch64-apple-darwin", true);
         cache.store(0xabc, b"xx");
         let expected = dir
             .path()
-            .join(".perry-cache")
+            .join("objects")
+            .join("aarch64-apple-darwin")
+            .join(format!("{:016x}.o", 0xabc_u64));
+        assert!(expected.exists(), "missing: {}", expected.display());
+    }
+
+    #[test]
+    fn resolve_cache_dir_defaults_to_node_modules_cache_perry() {
+        // No override → the find-cache-dir convention under the project root.
+        let root = Path::new("/projects/app");
+        let got = resolve_cache_dir(root, None);
+        assert_eq!(
+            got,
+            Path::new("/projects/app")
+                .join("node_modules")
+                .join(".cache")
+                .join("perry")
+        );
+    }
+
+    #[test]
+    fn resolve_cache_dir_absolute_override_used_as_is() {
+        // An absolute override ignores the project root entirely.
+        let root = Path::new("/projects/app");
+        let override_dir = Path::new("/var/cache/perry");
+        let got = resolve_cache_dir(root, Some(override_dir));
+        assert_eq!(got, Path::new("/var/cache/perry"));
+    }
+
+    #[test]
+    fn resolve_cache_dir_relative_override_resolves_against_project_root() {
+        // A relative override joins onto the project root, so two projects
+        // with the same `perry.cacheDir: ".cache"` don't collide.
+        let root = Path::new("/projects/app");
+        let override_dir = Path::new("build/cache");
+        let got = resolve_cache_dir(root, Some(override_dir));
+        assert_eq!(got, Path::new("/projects/app").join("build").join("cache"));
+    }
+
+    #[test]
+    fn object_cache_writes_under_resolved_cache_dir() {
+        // End-to-end: resolve the default dir, build the cache against it,
+        // and confirm bytes land under <resolved>/objects/<target>/.
+        let dir = tempdir().unwrap();
+        let resolved = resolve_cache_dir(dir.path(), None);
+        let cache = ObjectCache::new(&resolved, "aarch64-apple-darwin", true);
+        cache.store(0xabc, b"xx");
+        let expected = dir
+            .path()
+            .join("node_modules")
+            .join(".cache")
+            .join("perry")
             .join("objects")
             .join("aarch64-apple-darwin")
             .join(format!("{:016x}.o", 0xabc_u64));

--- a/crates/perry/src/commands/compile/object_cache.rs
+++ b/crates/perry/src/commands/compile/object_cache.rs
@@ -62,8 +62,9 @@ fn perry_build_id() -> u64 {
 }
 
 /// Directory holding Perry's on-disk caches for a project. Precedence:
-/// `--cache-dir` → `PERRY_CACHE_DIR` → package.json `perry.cacheDir`
-/// → default `<project_root>/node_modules/.cache/perry` (the find-cache-dir
+/// `--cache-dir` → `PERRY_CACHE_DIR` → perry.toml `[perry] cacheDir` →
+/// package.json `perry.cacheDir` → default
+/// `<project_root>/node_modules/.cache/perry` (the find-cache-dir
 /// convention used by babel-loader / eslint / etc.). Relative overrides
 /// resolve against `project_root`.
 ///
@@ -81,42 +82,90 @@ pub fn resolve_cache_dir(project_root: &Path, override_dir: Option<&Path>) -> Pa
     }
 }
 
-/// Read the project's cache-dir override from the environment and
-/// package.json, applying the non-CLI half of [`resolve_cache_dir`]'s
-/// precedence: `PERRY_CACHE_DIR` env var → package.json `perry.cacheDir`.
-/// Walks up from `project_root` to find the nearest `package.json` so it
-/// behaves like the rest of the compile pipeline's config discovery.
-/// Returns `None` when neither source sets a path, leaving the default.
+/// Choose the cache-dir override from the three non-CLI sources, applying
+/// the non-CLI half of [`resolve_cache_dir`]'s precedence:
+/// `PERRY_CACHE_DIR` env var → perry.toml `[perry] cacheDir` → package.json
+/// `perry.cacheDir`. The first non-empty candidate wins; later (lower-
+/// precedence) candidates are only consulted when the higher ones are absent.
+///
+/// Pure function over the already-read candidate strings, so the precedence
+/// is unit-testable without touching the filesystem or process env. The CLI
+/// flag layers on top of this result in the caller (`--cache-dir` wins over
+/// everything), so it isn't an input here.
+pub fn pick_cache_dir_override(
+    env: Option<&str>,
+    toml: Option<&str>,
+    pkg: Option<&str>,
+) -> Option<PathBuf> {
+    [env, toml, pkg]
+        .into_iter()
+        .flatten()
+        .find(|s| !s.is_empty())
+        .map(PathBuf::from)
+}
+
+/// Read the project's cache-dir override from the environment, perry.toml,
+/// and package.json, applying the non-CLI half of [`resolve_cache_dir`]'s
+/// precedence: `PERRY_CACHE_DIR` env var → perry.toml `[perry] cacheDir` →
+/// package.json `perry.cacheDir`. Walks up from `project_root` to find the
+/// nearest `perry.toml` / `package.json` so it behaves like the rest of the
+/// compile pipeline's config discovery. Returns `None` when no source sets a
+/// path, leaving the default.
 pub fn cache_dir_override(project_root: &Path) -> Option<PathBuf> {
-    if let Some(env) = std::env::var_os("PERRY_CACHE_DIR") {
-        if !env.is_empty() {
-            return Some(PathBuf::from(env));
+    let env = std::env::var("PERRY_CACHE_DIR").ok();
+    let toml = perry_toml_cache_dir(project_root);
+    let pkg = package_json_cache_dir(project_root);
+    pick_cache_dir_override(env.as_deref(), toml.as_deref(), pkg.as_deref())
+}
+
+/// Read `[perry] cacheDir` from the nearest `perry.toml` walking up from
+/// `project_root`. Returns `None` when no `perry.toml` is found or the key is
+/// absent. Mirrors the perry.toml walk used by the strict-eval config block.
+fn perry_toml_cache_dir(project_root: &Path) -> Option<String> {
+    let mut dir = project_root.to_path_buf();
+    loop {
+        let candidate = dir.join("perry.toml");
+        if candidate.exists() {
+            return fs::read_to_string(&candidate)
+                .ok()
+                .and_then(|s| s.parse::<toml::Table>().ok())
+                .and_then(|table| {
+                    table
+                        .get("perry")
+                        .and_then(|v| v.as_table())
+                        .and_then(|t| t.get("cacheDir"))
+                        .and_then(|v| v.as_str())
+                        .map(str::to_string)
+                });
+        }
+        if !dir.pop() {
+            return None;
         }
     }
+}
+
+/// Read `perry.cacheDir` from the nearest `package.json` walking up from
+/// `project_root`. Returns `None` when no `package.json` is found or the key
+/// is absent.
+fn package_json_cache_dir(project_root: &Path) -> Option<String> {
     let mut dir = project_root.to_path_buf();
     loop {
         let candidate = dir.join("package.json");
         if candidate.exists() {
-            if let Ok(content) = fs::read_to_string(&candidate) {
-                if let Ok(pkg) = serde_json::from_str::<serde_json::Value>(&content) {
-                    if let Some(s) = pkg
-                        .get("perry")
+            return fs::read_to_string(&candidate)
+                .ok()
+                .and_then(|content| serde_json::from_str::<serde_json::Value>(&content).ok())
+                .and_then(|pkg| {
+                    pkg.get("perry")
                         .and_then(|p| p.get("cacheDir"))
                         .and_then(|v| v.as_str())
-                    {
-                        if !s.is_empty() {
-                            return Some(PathBuf::from(s));
-                        }
-                    }
-                }
-            }
-            break;
+                        .map(str::to_string)
+                });
         }
         if !dir.pop() {
-            break;
+            return None;
         }
     }
-    None
 }
 
 /// Streaming djb2 accumulator so multi-part keys don't have to build a
@@ -1690,5 +1739,141 @@ mod object_cache_tests {
         a.store(0x777, b"from-a");
         assert!(b.lookup(0x777).is_none());
         assert_eq!(a.lookup(0x777).as_deref(), Some(b"from-a".as_ref()));
+    }
+
+    // --- cache-dir override precedence ----------------------------------
+    //
+    // Full chain (highest wins): `--cache-dir` CLI flag → `PERRY_CACHE_DIR`
+    // env → perry.toml `[perry] cacheDir` → package.json `perry.cacheDir` →
+    // default. The CLI flag is layered on top by the callers
+    // (`args.cache_dir.or_else(cache_dir_override)`), so the merge tested
+    // here is the non-CLI half: env → perry.toml → package.json.
+    //
+    // `pick_cache_dir_override` is pure over the already-read candidate
+    // strings, so the precedence is checked without filesystem or env races.
+
+    #[test]
+    fn pick_override_env_beats_toml_and_pkg() {
+        // env wins over both lower layers — i.e. `PERRY_CACHE_DIR` overrides
+        // perry.toml, which is the "env beats perry.toml" guarantee.
+        let got = pick_cache_dir_override(Some("/env"), Some("/toml"), Some("/pkg"));
+        assert_eq!(got, Some(PathBuf::from("/env")));
+    }
+
+    #[test]
+    fn pick_override_toml_beats_pkg() {
+        // perry.toml overrides package.json when env is unset.
+        let got = pick_cache_dir_override(None, Some("/toml"), Some("/pkg"));
+        assert_eq!(got, Some(PathBuf::from("/toml")));
+    }
+
+    #[test]
+    fn pick_override_pkg_used_when_only_pkg_set() {
+        let got = pick_cache_dir_override(None, None, Some("/pkg"));
+        assert_eq!(got, Some(PathBuf::from("/pkg")));
+    }
+
+    #[test]
+    fn pick_override_none_when_all_unset() {
+        assert_eq!(pick_cache_dir_override(None, None, None), None);
+    }
+
+    #[test]
+    fn pick_override_skips_empty_higher_layers() {
+        // An empty string is treated as "not set", so a blank env value falls
+        // through to perry.toml and a blank perry.toml falls through to pkg.
+        assert_eq!(
+            pick_cache_dir_override(Some(""), Some("/toml"), Some("/pkg")),
+            Some(PathBuf::from("/toml"))
+        );
+        assert_eq!(
+            pick_cache_dir_override(Some(""), Some(""), Some("/pkg")),
+            Some(PathBuf::from("/pkg"))
+        );
+        assert_eq!(pick_cache_dir_override(Some(""), Some(""), Some("")), None);
+    }
+
+    #[test]
+    fn perry_toml_cache_dir_reads_perry_table() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("perry.toml"),
+            "[perry]\ncacheDir = \"/var/cache/perry\"\n",
+        )
+        .unwrap();
+        assert_eq!(
+            perry_toml_cache_dir(dir.path()).as_deref(),
+            Some("/var/cache/perry")
+        );
+    }
+
+    #[test]
+    fn perry_toml_cache_dir_none_when_key_or_file_absent() {
+        // No perry.toml at all.
+        let empty = tempdir().unwrap();
+        assert_eq!(perry_toml_cache_dir(empty.path()), None);
+
+        // perry.toml present but no `[perry] cacheDir` key.
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("perry.toml"), "[perry]\nstrict = true\n").unwrap();
+        assert_eq!(perry_toml_cache_dir(dir.path()), None);
+    }
+
+    #[test]
+    fn perry_toml_cache_dir_walks_up_to_project_root() {
+        // The reader walks up from a nested dir, mirroring how the compile
+        // pipeline discovers config from a subdirectory entry file.
+        let root = tempdir().unwrap();
+        fs::write(
+            root.path().join("perry.toml"),
+            "[perry]\ncacheDir = \".cache\"\n",
+        )
+        .unwrap();
+        let nested = root.path().join("src").join("deep");
+        fs::create_dir_all(&nested).unwrap();
+        assert_eq!(perry_toml_cache_dir(&nested).as_deref(), Some(".cache"));
+    }
+
+    #[test]
+    fn package_json_cache_dir_reads_perry_field() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join("package.json"),
+            r#"{ "perry": { "cacheDir": ".perry-cache" } }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            package_json_cache_dir(dir.path()).as_deref(),
+            Some(".perry-cache")
+        );
+    }
+
+    #[test]
+    fn toml_overrides_pkg_via_readers_and_resolver() {
+        // End-to-end (no env, no CLI): with both perry.toml and package.json
+        // present, the chosen override is perry.toml's, and a relative value
+        // resolves against the project root — matching the existing
+        // `resolve_cache_dir_relative_override_resolves_against_project_root`
+        // contract for the new perry.toml layer.
+        let root = tempdir().unwrap();
+        fs::write(
+            root.path().join("perry.toml"),
+            "[perry]\ncacheDir = \"toml-cache\"\n",
+        )
+        .unwrap();
+        fs::write(
+            root.path().join("package.json"),
+            r#"{ "perry": { "cacheDir": "pkg-cache" } }"#,
+        )
+        .unwrap();
+
+        let toml = perry_toml_cache_dir(root.path());
+        let pkg = package_json_cache_dir(root.path());
+        let chosen = pick_cache_dir_override(None, toml.as_deref(), pkg.as_deref());
+        assert_eq!(chosen.as_deref(), Some(Path::new("toml-cache")));
+
+        // Relative perry.toml value resolves against the project root.
+        let resolved = resolve_cache_dir(root.path(), chosen.as_deref());
+        assert_eq!(resolved, root.path().join("toml-cache"));
     }
 }

--- a/crates/perry/src/commands/compile/sandbox_buildrs.rs
+++ b/crates/perry/src/commands/compile/sandbox_buildrs.rs
@@ -119,14 +119,16 @@ fn which_cargo() -> std::path::PathBuf {
     std::path::PathBuf::from("cargo")
 }
 
-/// Write a per-build sandbox-exec profile to `<project>/.perry-cache/buildrs-<pkg>.sandbox`.
+/// Write a per-build sandbox-exec profile to
+/// `<cache_dir>/buildrs-<pkg>.sandbox` (default
+/// `<project>/node_modules/.cache/perry/buildrs-<pkg>.sandbox`).
 /// Returns the absolute path so `sandbox-exec -f <path>` can pick it up.
 fn write_macos_buildrs_profile(
     ctx: &CompilationContext,
     package_name: &str,
 ) -> std::io::Result<std::path::PathBuf> {
-    let dir = ctx.project_root.join(".perry-cache");
-    std::fs::create_dir_all(&dir)?;
+    let dir = &ctx.cache_dir;
+    std::fs::create_dir_all(dir)?;
     // Sanitize the package name into a single path component so a
     // hostile `name: "../etc/passwd"` can't escape the cache dir.
     let safe = package_name

--- a/crates/perry/src/commands/compile/types.rs
+++ b/crates/perry/src/commands/compile/types.rs
@@ -204,7 +204,7 @@ pub struct CompileArgs {
     #[arg(long)]
     pub debug_symbols: bool,
 
-    /// Disable the per-module object cache at `.perry-cache/objects/`.
+    /// Disable the per-module object cache.
     /// By default Perry caches each module's object bytes keyed by a
     /// hash of the source plus every `CompileOptions` field that can
     /// affect codegen, so unchanged modules skip the LLVM pipeline on
@@ -213,6 +213,18 @@ pub struct CompileArgs {
     /// around a suspected stale cache.
     #[arg(long)]
     pub no_cache: bool,
+
+    /// Directory for Perry's on-disk caches (objects, build manifests,
+    /// link manifests, audit.json). Defaults to
+    /// `<project-root>/node_modules/.cache/perry` (the find-cache-dir
+    /// convention used by babel-loader / eslint / etc.), so the cache is
+    /// auto-ignored along with `node_modules/`. Also settable via the
+    /// `PERRY_CACHE_DIR` env var or `"perry": { "cacheDir": "<path>" }`
+    /// in package.json; this flag wins over both. A relative path resolves
+    /// against the project root. Useful for CI caches, shared build farms,
+    /// or read-only project roots.
+    #[arg(long)]
+    pub cache_dir: Option<PathBuf>,
 
     /// Enable LLVM `reassoc` per-instruction fast-math flags on every
     /// f64 op. Off by default — Perry produces bit-exact f64 output with
@@ -494,10 +506,18 @@ pub struct CompilationContext {
     pub needs_stdlib: bool,
     /// Project root (where we start looking for node_modules)
     pub project_root: PathBuf,
-    /// Root for `.perry-cache` artifacts. Usually the package/config root
-    /// or current working directory; kept separate from `project_root` so
-    /// legacy module-prefix behavior does not force caches under `src/`.
+    /// Root for cache artifacts. Usually the package/config root or current
+    /// working directory; kept separate from `project_root` so legacy
+    /// module-prefix behavior does not force caches under `src/`. This is the
+    /// base the cache directory resolves against, NOT the cache directory
+    /// itself — read `cache_dir` for where bytes actually land.
     pub cache_root: PathBuf,
+    /// Resolved on-disk cache directory for this build, computed once via
+    /// `resolve_cache_dir`. Every on-disk cache (objects, audit.json, build,
+    /// link, debug dumps, sandbox profiles) lives directly under this dir.
+    /// Precedence: `--cache-dir` → `PERRY_CACHE_DIR` → package.json
+    /// `perry.cacheDir` → default `<cache_root>/node_modules/.cache/perry`.
+    pub cache_dir: PathBuf,
     /// External native libraries discovered from package dependencies
     pub native_libraries: Vec<NativeLibraryManifest>,
     /// Package aliases: maps npm package name → replacement package name (from perry.packageAliases)
@@ -926,6 +946,7 @@ impl CompilationContext {
             needs_plugins: false,
             needs_stdlib: false,
             cache_root: project_root.clone(),
+            cache_dir: super::object_cache::resolve_cache_dir(&project_root, None),
             project_root,
             native_libraries: Vec::new(),
             package_aliases: HashMap::new(),

--- a/crates/perry/src/commands/compile/types.rs
+++ b/crates/perry/src/commands/compile/types.rs
@@ -219,8 +219,9 @@ pub struct CompileArgs {
     /// `<project-root>/node_modules/.cache/perry` (the find-cache-dir
     /// convention used by babel-loader / eslint / etc.), so the cache is
     /// auto-ignored along with `node_modules/`. Also settable via the
-    /// `PERRY_CACHE_DIR` env var or `"perry": { "cacheDir": "<path>" }`
-    /// in package.json; this flag wins over both. A relative path resolves
+    /// `PERRY_CACHE_DIR` env var, `[perry] cacheDir` in perry.toml, or
+    /// `"perry": { "cacheDir": "<path>" }` in package.json; precedence is
+    /// CLI flag > env > perry.toml > package.json. A relative path resolves
     /// against the project root. Useful for CI caches, shared build farms,
     /// or read-only project roots.
     #[arg(long)]
@@ -515,8 +516,9 @@ pub struct CompilationContext {
     /// Resolved on-disk cache directory for this build, computed once via
     /// `resolve_cache_dir`. Every on-disk cache (objects, audit.json, build,
     /// link, debug dumps, sandbox profiles) lives directly under this dir.
-    /// Precedence: `--cache-dir` → `PERRY_CACHE_DIR` → package.json
-    /// `perry.cacheDir` → default `<cache_root>/node_modules/.cache/perry`.
+    /// Precedence: `--cache-dir` → `PERRY_CACHE_DIR` → perry.toml
+    /// `[perry] cacheDir` → package.json `perry.cacheDir` → default
+    /// `<cache_root>/node_modules/.cache/perry`.
     pub cache_dir: PathBuf,
     /// External native libraries discovered from package dependencies
     pub native_libraries: Vec<NativeLibraryManifest>,

--- a/crates/perry/src/commands/compile/types.rs
+++ b/crates/perry/src/commands/compile/types.rs
@@ -222,8 +222,10 @@ pub struct CompileArgs {
     /// `PERRY_CACHE_DIR` env var, `[perry] cacheDir` in perry.toml, or
     /// `"perry": { "cacheDir": "<path>" }` in package.json; precedence is
     /// CLI flag > env > perry.toml > package.json. A relative path resolves
-    /// against the project root. Useful for CI caches, shared build farms,
-    /// or read-only project roots.
+    /// against the project root. Useful for read-only project roots and
+    /// per-machine CI caches; the object cache is machine-local (native
+    /// `.o` bytes keyed by CPU/OS/toolchain), so avoid sharing one
+    /// directory across heterogeneous build machines.
     #[arg(long)]
     pub cache_dir: Option<PathBuf>,
 
@@ -515,7 +517,8 @@ pub struct CompilationContext {
     pub cache_root: PathBuf,
     /// Resolved on-disk cache directory for this build, computed once via
     /// `resolve_cache_dir`. Every on-disk cache (objects, audit.json, build,
-    /// link, debug dumps, sandbox profiles) lives directly under this dir.
+    /// link, sandbox profiles) lives directly under this dir; `--trace`
+    /// dumps are written separately under `.perry-trace/` (see that flag).
     /// Precedence: `--cache-dir` → `PERRY_CACHE_DIR` → perry.toml
     /// `[perry] cacheDir` → package.json `perry.cacheDir` → default
     /// `<cache_root>/node_modules/.cache/perry`.

--- a/crates/perry/src/commands/dev.rs
+++ b/crates/perry/src/commands/dev.rs
@@ -303,7 +303,8 @@ fn build_once(
         debug_symbols: false,
         no_cache: false,
         // `perry dev` has no `--cache-dir` flag of its own; the resolver
-        // still honors `PERRY_CACHE_DIR` / package.json `perry.cacheDir`.
+        // still honors `PERRY_CACHE_DIR` / perry.toml `[perry] cacheDir` /
+        // package.json `perry.cacheDir`.
         cache_dir: None,
         fast_math: false,
         fp_contract: None,

--- a/crates/perry/src/commands/dev.rs
+++ b/crates/perry/src/commands/dev.rs
@@ -47,6 +47,10 @@ const IGNORED_DIRS: &[&str] = &[
     "dist",
     "build",
     ".perry-dev",
+    // The default cache dir is now `node_modules/.cache/perry`, already
+    // covered by the `node_modules` entry above. Kept so a legacy
+    // `.perry-cache/` dir (or a `--cache-dir .perry-cache` override) still
+    // never triggers a rebuild.
     ".perry-cache",
 ];
 
@@ -298,6 +302,9 @@ fn build_once(
         no_auto_optimize: false,
         debug_symbols: false,
         no_cache: false,
+        // `perry dev` has no `--cache-dir` flag of its own; the resolver
+        // still honors `PERRY_CACHE_DIR` / package.json `perry.cacheDir`.
+        cache_dir: None,
         fast_math: false,
         fp_contract: None,
         verify_native_regions: false,

--- a/crates/perry/src/commands/run/mod.rs
+++ b/crates/perry/src/commands/run/mod.rs
@@ -229,6 +229,9 @@ pub fn run(args: RunArgs, format: OutputFormat, use_color: bool, verbose: u8) ->
         no_auto_optimize: false,
         debug_symbols: false,
         no_cache: false,
+        // `perry run` has no `--cache-dir` flag; the resolver still honors
+        // `PERRY_CACHE_DIR` / package.json `perry.cacheDir`.
+        cache_dir: None,
         fast_math: false,
         fp_contract: None,
         verify_native_regions: false,

--- a/crates/perry/src/commands/run/mod.rs
+++ b/crates/perry/src/commands/run/mod.rs
@@ -230,7 +230,8 @@ pub fn run(args: RunArgs, format: OutputFormat, use_color: bool, verbose: u8) ->
         debug_symbols: false,
         no_cache: false,
         // `perry run` has no `--cache-dir` flag; the resolver still honors
-        // `PERRY_CACHE_DIR` / package.json `perry.cacheDir`.
+        // `PERRY_CACHE_DIR` / perry.toml `[perry] cacheDir` / package.json
+        // `perry.cacheDir`.
         cache_dir: None,
         fast_math: false,
         fp_contract: None,

--- a/crates/perry/src/main.rs
+++ b/crates/perry/src/main.rs
@@ -146,7 +146,7 @@ enum Commands {
     /// Generate TypeScript type stubs for Perry built-in modules
     Types(commands::types::TypesArgs),
 
-    /// Manage the per-module object cache at `.perry-cache/`
+    /// Manage Perry's on-disk cache (default `node_modules/.cache/perry`)
     Cache(commands::cache::CacheArgs),
 
     /// Sign-side tooling for `@perry/updater` (closes #229).

--- a/docs/src/cli/allowed-hosts.md
+++ b/docs/src/cli/allowed-hosts.md
@@ -87,7 +87,8 @@ This is intentionally not "default-deny on greenfield" — that would
 break every existing build that calls `fetch(...)`. Migration path:
 
 1. Run the build once without the allowlist.
-2. Inspect `.perry-cache/audit.json` (the [behavioral SBOM
+2. Inspect `audit.json` in the cache dir (default
+   `node_modules/.cache/perry/audit.json`) (the [behavioral SBOM
    (`#495`)](perry-audit-sbom.md)) and see what egress the binary
    currently performs.
 3. Populate `allowedHosts` with the surface you actually use.

--- a/docs/src/cli/cache-dir.md
+++ b/docs/src/cli/cache-dir.md
@@ -10,18 +10,24 @@ the link-cache manifest (`link/`), the behavioral SBOM (`audit.json`),
 sandbox-exec profiles (`buildrs-<pkg>.sandbox`), and HIR miss dumps
 (`debug/`) when `PERRY_CACHE_DEBUG_HIR=1`.
 
-## Three ways to set it
+## Four ways to set it
 
-CLI flag wins over env var, env var wins over package.json:
+Precedence, highest to lowest: CLI flag, then `PERRY_CACHE_DIR`, then
+`perry.toml`, then `package.json`. So `perry.toml` overrides `package.json`,
+and the env var and CLI flag override `perry.toml`:
 
-```bash
-# 1. Per-build CLI flag
+```
+# 1. Per-build CLI flag (wins over everything)
 perry --cache-dir /var/cache/perry myapp.ts
 
 # 2. Per-shell environment
 PERRY_CACHE_DIR=/var/cache/perry perry myapp.ts
 
-# 3. Per-project package.json (most common)
+# 3. Per-project perry.toml, alongside the other [perry] settings
+[perry]
+cacheDir = "/var/cache/perry"
+
+# 4. Per-project package.json (most common)
 {
   "perry": {
     "cacheDir": ".perry-cache"
@@ -30,7 +36,7 @@ PERRY_CACHE_DIR=/var/cache/perry perry myapp.ts
 ```
 
 A relative path resolves against the project root, so two projects that
-both set `"cacheDir": ".cache"` keep separate caches. An absolute path is
+both set `cacheDir = ".cache"` keep separate caches. An absolute path is
 used as-is.
 
 ## Notes

--- a/docs/src/cli/cache-dir.md
+++ b/docs/src/cli/cache-dir.md
@@ -1,0 +1,55 @@
+# Cache directory
+
+Where Perry writes its on-disk caches for a project. Defaults to
+`<project-root>/node_modules/.cache/perry`, the find-cache-dir convention
+used by babel-loader, eslint, and most of the JS toolchain.
+
+Everything Perry caches lands directly under this directory: per-module
+object files (`objects/<target>/`), the build-cache manifest (`build/`),
+the link-cache manifest (`link/`), the behavioral SBOM (`audit.json`),
+sandbox-exec profiles (`buildrs-<pkg>.sandbox`), and HIR miss dumps
+(`debug/`) when `PERRY_CACHE_DEBUG_HIR=1`.
+
+## Three ways to set it
+
+CLI flag wins over env var, env var wins over package.json:
+
+```bash
+# 1. Per-build CLI flag
+perry --cache-dir /var/cache/perry myapp.ts
+
+# 2. Per-shell environment
+PERRY_CACHE_DIR=/var/cache/perry perry myapp.ts
+
+# 3. Per-project package.json (most common)
+{
+  "perry": {
+    "cacheDir": ".perry-cache"
+  }
+}
+```
+
+A relative path resolves against the project root, so two projects that
+both set `"cacheDir": ".cache"` keep separate caches. An absolute path is
+used as-is.
+
+## Notes
+
+- The directory is created automatically on the first build. If it can't
+  be created (read-only root, permission error), Perry silently degrades
+  to a no-op cache for that run rather than failing the build.
+- The cache directory must be writable for caching to take effect.
+- The default `node_modules/.cache/perry` rides along with the
+  already-ignored `node_modules/`, so nothing new lands in `git status`.
+- Older Perry versions wrote to `<project-root>/.perry-cache/`. That
+  directory is now stale and can be deleted; Perry no longer reads or
+  writes it. Run `perry cache clean` to wipe the current cache.
+- An explicit `--cache-dir` is useful for CI caches (point it at a path
+  your CI restores between runs), shared build farms (a fast local SSD
+  instead of an NFS-mounted project root), and read-only project roots
+  (relocate the cache to a writable scratch dir).
+
+The object cache is machine-local — it bakes in `-mcpu=native` codegen —
+so sharing a cache directory across machines with different CPUs (rsync,
+NFS, a Docker bind-mount) can produce `SIGILL` at runtime. Scope a shared
+`--cache-dir` to a single CPU family.

--- a/docs/src/cli/cache-dir.md
+++ b/docs/src/cli/cache-dir.md
@@ -18,10 +18,10 @@ and the env var and CLI flag override `perry.toml`:
 
 ```
 # 1. Per-build CLI flag (wins over everything)
-perry --cache-dir /var/cache/perry myapp.ts
+perry compile --cache-dir /var/cache/perry myapp.ts
 
 # 2. Per-shell environment
-PERRY_CACHE_DIR=/var/cache/perry perry myapp.ts
+PERRY_CACHE_DIR=/var/cache/perry perry compile myapp.ts
 
 # 3. Per-project perry.toml, alongside the other [perry] settings
 [perry]

--- a/docs/src/cli/fast-math.md
+++ b/docs/src/cli/fast-math.md
@@ -139,7 +139,8 @@ flag.
 
 ## Object-cache interaction
 
-Perry's per-module `.o` cache (in `.perry-cache/objects/`) keys on the
+Perry's per-module `.o` cache (in `node_modules/.cache/perry/objects/`,
+or wherever `--cache-dir` points) keys on the
 `fast_math` and `fp_contract` settings alongside source hash and other
 compile options. Toggling either invalidates affected cache entries —
 `perry --fast-math` or `perry --fp-contract=on` right after `perry`

--- a/docs/src/cli/perry-audit-sbom.md
+++ b/docs/src/cli/perry-audit-sbom.md
@@ -70,7 +70,8 @@ capability a dependency reaches surfaces as added lines.
 
 - Reads the manifest from `audit.json` in the resolved cache dir
   (default `<PATH>/node_modules/.cache/perry/audit.json`; honors
-  `--cache-dir` / `PERRY_CACHE_DIR` / `perry.cacheDir`), walking up
+  `--cache-dir` / `PERRY_CACHE_DIR` / perry.toml `[perry] cacheDir` /
+  package.json `perry.cacheDir`), walking up
   the directory tree if needed (same shape `perry compile` walks up
   to find `package.json`).
 - Default `PATH`: current directory.

--- a/docs/src/cli/perry-audit-sbom.md
+++ b/docs/src/cli/perry-audit-sbom.md
@@ -1,7 +1,8 @@
 # Behavioral SBOM (`perry audit --sbom`)
 
-Every Perry compile writes a behavioral SBOM to
-`<project>/.perry-cache/audit.json` — a per-module manifest of the
+Every Perry compile writes a behavioral SBOM to `audit.json` in the
+project's cache dir (default
+`<project>/node_modules/.cache/perry/audit.json`) — a per-module manifest of the
 stdlib symbols the build actually calls. The manifest is the
 foundation for the rest of the supply-chain hardening series and gives
 reviewers a way to see exactly what surface a dependency touches
@@ -67,9 +68,11 @@ capability a dependency reaches surfaces as added lines.
 
 `perry audit --sbom [PATH]`
 
-- Reads the manifest from `<PATH>/.perry-cache/audit.json`, walking
-  up the directory tree if needed (same shape `perry compile` walks
-  up to find `package.json`).
+- Reads the manifest from `audit.json` in the resolved cache dir
+  (default `<PATH>/node_modules/.cache/perry/audit.json`; honors
+  `--cache-dir` / `PERRY_CACHE_DIR` / `perry.cacheDir`), walking up
+  the directory tree if needed (same shape `perry compile` walks up
+  to find `package.json`).
 - Default `PATH`: current directory.
 - In `--format json` mode dumps the raw manifest pretty-printed.
 - In text mode groups modules by owning npm package; host source is
@@ -90,7 +93,7 @@ Scope of this first cut (MVP):
 - **`perry audit --sbom --diff`** — the bytes-deterministic JSON
   shape already enables the diff workflow via plain `diff` /
   `git diff`; a built-in `--diff` is a follow-up that picks a
-  baseline (`.perry-cache/audit.last.json`) and pretty-prints the
+  baseline (`audit.last.json` in the cache dir) and pretty-prints the
   change set.
 
 The manifest shape is versioned (`version: 1`) so consumers can


### PR DESCRIPTION
## What

Make Perry's on-disk cache directory configurable, and change the default from `<project_root>/.perry-cache/` to `<project_root>/node_modules/.cache/perry/`.

## Why

Today every Perry cache (compiled object cache, `audit.json`, build/link caches, sandbox profiles) lives in `<project_root>/.perry-cache/`. That means every project has to add `.perry-cache/` to its `.gitignore` by hand.

`node_modules/.cache/<tool>` is the long-standing JavaScript-ecosystem convention for tool caches (it's what `find-cache-dir` returns, and what babel-loader, eslint, and others use). Because `node_modules/` is already gitignored in basically every JS project, defaulting there means Perry's cache is auto-ignored — no per-project `.gitignore` entry needed.

## How

A single resolver decides the cache directory, reading from four sources with this precedence (highest wins):

1. `--cache-dir <path>` CLI flag (a `perry compile` flag)
2. `PERRY_CACHE_DIR` environment variable
3. `perry.toml` → `[perry] cacheDir = "<path>"`
4. `package.json` → `"perry": { "cacheDir": "<path>" }`
5. default: `<project_root>/node_modules/.cache/perry`

This matches Perry's existing "package.json → perry.toml → env → CLI, last wins" config layering (the same shape as `[perry] strict` / `eval`). An absolute override is used as-is; a relative override resolves against the project root. The resolved directory replaces the old `<root>/.perry-cache` everywhere, so all cache artifacts move together (e.g. the object cache is now `node_modules/.cache/perry/objects/<target>/`).

All cache-writing sites go through one resolver (`resolve_cache_dir`), so there's one source of truth. `--cache-dir`, `PERRY_CACHE_DIR`, `perry.toml`, and `perry.cacheDir` are documented in `--help` and a new `docs/src/cli/cache-dir.md` page.

## Migration

Existing `.perry-cache/` directories are now stale and safe to delete — Perry won't read or write them anymore (unless you point `--cache-dir` back at one). The cache is machine-local and content-addressed, so nothing is lost; the next build repopulates it under the new location.

The object cache holds native `.o` bytes keyed by CPU/OS/toolchain, so it's machine-local — point a per-machine `--cache-dir`/`PERRY_CACHE_DIR` at a CI cache or a writable dir for a read-only project root, but don't share one directory across heterogeneous build machines.

## Tests

Added unit tests for the resolver and the source-precedence merge: default path, absolute override, relative override (resolved against the project root), env-beats-toml-beats-package.json, and `perry.toml`/`package.json` readers end to end. `cargo check -p perry` is clean (no new warnings) and the object-cache tests pass.

## Review follow-ups

- `--cache-dir` help no longer advertises "shared build farms" (the object cache is machine-local).
- The `cache_dir` field doc no longer claims debug dumps live under the cache dir; `--trace` output stays under `.perry-trace/` (one location contract).
- Usage examples use the `perry compile` subcommand (`--cache-dir` is a compile flag, not global).
- Added `perry.toml [perry] cacheDir` as a config source so the cache dir isn't package.json-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cache directory resolution now follows a clear precedence order: `--cache-dir` > `PERRY_CACHE_DIR` > `perry.toml` `[perry] cacheDir` > `package.json` `perry.cacheDir` (relative paths resolved to the project root).

* **Bug Fixes**
  * Updated default cache location from `.perry-cache` to `node_modules/.cache/perry`.
  * `perry audit --sbom` now reads `audit.json` from the resolved cache directory while searching parent folders.

* **Documentation**
  * Refreshed CLI help and cache/audit docs to match the new cache layout (including where objects and `audit.json` are stored).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->