### PR TITLE
perf(http): carry streamed body chunks as Bytes, not Vec<u8>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5641,6 +5641,7 @@ dependencies = [
 name = "perry-ext-http"
 version = "0.5.1189"
 dependencies = [
+ "bytes",
  "lazy_static",
  "perry-ext-http-server",
  "perry-ffi",

--- a/crates/perry-ext-http/Cargo.toml
+++ b/crates/perry-ext-http/Cargo.toml
@@ -26,6 +26,12 @@ perry-ext-http-server = { path = "../perry-ext-http-server" }
 perry-runtime = { workspace = true, features = ["external-ws-symbols"] }
 reqwest = { version = "0.12", features = ["json", "rustls-tls", "http2"], default-features = false }
 tokio = { workspace = true }
+# Zero-copy body chunks: reqwest::Response::chunk() yields a refcounted
+# `Bytes` that slices the receive buffer. Carrying that `Bytes` through the
+# streaming event enum (instead of `.to_vec()`-ing it) drops one heap alloc
+# + memcpy per response chunk. Already in the lockfile via reqwest/hyper, so
+# declaring it pulls nothing new.
+bytes = "1"
 serde_json = "1"
 lazy_static = "1.5"
 

--- a/crates/perry-ext-http/src/client_dispatch.rs
+++ b/crates/perry-ext-http/src/client_dispatch.rs
@@ -144,7 +144,7 @@ pub(crate) fn dispatch_request(
                             Ok(Some(bytes)) => {
                                 push_event(PendingHttpEvent::ResponseChunk {
                                     request_handle,
-                                    chunk: bytes.to_vec(),
+                                    chunk: bytes,
                                 });
                             }
                             Ok(None) => {

--- a/crates/perry-ext-http/src/client_events.rs
+++ b/crates/perry-ext-http/src/client_events.rs
@@ -257,7 +257,7 @@ pub(crate) unsafe fn handle_response_head_event(
 /// # Safety
 ///
 /// Same listener-liveness contract as [`fire_request_event_listeners`].
-pub(crate) unsafe fn handle_response_chunk_event(request_handle: Handle, chunk: Vec<u8>) {
+pub(crate) unsafe fn handle_response_chunk_event(request_handle: Handle, chunk: Bytes) {
     let (incoming, done) = get_handle_mut::<ClientRequestHandle>(request_handle)
         .map(|r| (r.incoming_handle, r.completed))
         .unwrap_or((0, true));

--- a/crates/perry-ext-http/src/continue_client.rs
+++ b/crates/perry-ext-http/src/continue_client.rs
@@ -18,6 +18,8 @@ use std::collections::HashMap;
 use perry_ffi::{spawn_blocking_with_reactor as spawn_blocking, with_handle_mut, Handle};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
+use bytes::Bytes;
+
 use crate::plain_client::parse_http_response;
 use crate::{push_event, ClientRequestHandle, PendingHttpEvent};
 
@@ -270,7 +272,7 @@ async fn run_exchange(
     if !parsed.body.is_empty() {
         push_event(PendingHttpEvent::ResponseChunk {
             request_handle,
-            chunk: parsed.body,
+            chunk: Bytes::from(parsed.body),
         });
     }
     push_event(PendingHttpEvent::ResponseEnd { request_handle });

--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -96,6 +96,7 @@ mod transport_error;
 mod response_headers;
 use response_headers::build_response_headers_object;
 
+use bytes::Bytes;
 use lazy_static::lazy_static;
 use perry_ffi::{
     alloc_string, gc_register_mutable_root_scanner_named, get_handle_mut, iter_handles_of_mut,
@@ -140,10 +141,13 @@ pub(crate) enum PendingHttpEvent {
         status_message: String,
         headers: Vec<(String, String)>,
     },
-    /// One streamed body chunk following a `ResponseHead`.
+    /// One streamed body chunk following a `ResponseHead`. Carried as a
+    /// refcounted `Bytes` (reqwest hands `chunk()` out this way) so the
+    /// streaming path stays zero-copy from the receive buffer to the drain
+    /// handler, which only ever borrows it as `&[u8]`.
     ResponseChunk {
         request_handle: Handle,
-        chunk: Vec<u8>,
+        chunk: Bytes,
     },
     /// The streamed body finished — `'end'` on the message, `'close'` on
     /// the request.


### PR DESCRIPTION
## What

`reqwest::Response::chunk()` hands back a refcounted `Bytes` that slices the receive buffer. The streaming client path was `.to_vec()`-ing each chunk into a fresh `Vec<u8>` before queueing it onto `PendingHttpEvent::ResponseChunk` — a heap allocation plus a memcpy on **every body chunk of every response**.

The drain handler (`handle_response_chunk_event`) only ever borrows the chunk as `&[u8]` (`im.body.extend_from_slice(&chunk)` / `body_chunk_value(&chunk, …)`), so nothing needs to own a `Vec`.

## Change

- `PendingHttpEvent::ResponseChunk.chunk` is now `bytes::Bytes` instead of `Vec<u8>`.
- The reqwest producer drops `.to_vec()` and moves the `Bytes` straight through (zero-copy).
- The 100-continue raw-socket producer wraps its owned `Vec<u8>` via `Bytes::from(...)` (a zero-copy move).
- The drain handler signature takes `Bytes`; its body is unchanged because `Bytes: Deref<Target = [u8]>`.

No behavioral change — same events, same order, same bytes delivered.

## Dependency

`bytes` is declared as a direct dependency of `perry-ext-http`. It is already in `Cargo.lock` transitively via reqwest/hyper, so this pulls nothing new (lockfile delta is a single line).

## Validation

`cargo check -p perry-ext-http` passes. The only warnings emitted are pre-existing and unrelated to this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized HTTP response streaming to reduce memory consumption during data transfer and processing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->