### PR TITLE
fix(runtime): dynamic `new` of ArrayBuffer/SharedArrayBuffer/DataView via constructor value

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -2388,6 +2388,28 @@ pub unsafe extern "C" fn js_new_function_construct(
                 let decoder = crate::text::js_text_decoder_new(label, fatal, ignore_bom);
                 return crate::value::js_nanbox_pointer(decoder);
             }
+            // `new $ArrayBuffer(n)` / `new $DataView(buf, off?, len?)` where the
+            // constructor was obtained as a VALUE (e.g. the bundle reads
+            // `IN(globalThis, "DataView")` into a variable) rather than the
+            // syntactic `new DataView(...)` that lower_call/builtin.rs handles.
+            // Without these arms the dynamic-construct path falls through to
+            // "not a function". Mirror the static lowering exactly.
+            "ArrayBuffer" | "SharedArrayBuffer" => {
+                let size = args.first().copied().unwrap_or(0.0);
+                let buf = if name == "SharedArrayBuffer" {
+                    crate::buffer::js_shared_array_buffer_new_value(size)
+                } else {
+                    crate::buffer::js_array_buffer_new_value(size)
+                };
+                return crate::value::js_nanbox_pointer(buf as i64);
+            }
+            "DataView" => {
+                let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+                let value = args.first().copied().unwrap_or(undef);
+                let offset = args.get(1).copied().unwrap_or(undef);
+                let length = args.get(2).copied().unwrap_or(undef);
+                return crate::buffer::js_data_view_new(value, offset, length);
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
## Problem

When a builtin constructor is obtained as a **value** off the global object — e.g. `const D = globalThis["DataView"]; new D(buf)`, or `Reflect.construct(g.ArrayBuffer, [8])` — construction threw `TypeError: DataView is not a function` (and likewise for `ArrayBuffer`). The *syntactic* forms `new DataView(...)` / `new ArrayBuffer(...)` work (handled in `lower_call/builtin.rs`), but the **dynamic-construct** dispatch in `class_registry.rs` (the `identify_global_builtin_constructor` match that already handles `Map`/`Set`/`WeakMap`/`Date`/`Array`/…) had no arm for the buffer builtins, so they fell through to the "not a function" path.

Minified bundles hit this constantly: they read intrinsics into locals (`var D = IN(globalThis, "DataView")`) rather than calling the constructor syntactically.

## Fix

Add `ArrayBuffer` / `SharedArrayBuffer` / `DataView` arms to the dynamic-construct match, mirroring the static lowering exactly:
- `ArrayBuffer`/`SharedArrayBuffer` → `js_array_buffer_new_value` / `js_shared_array_buffer_new_value` + `js_nanbox_pointer` (same as `lower_call/builtin.rs` line 124).
- `DataView` → `js_data_view_new(value, offset, length)` with `undefined` defaults (same as the `"DataView"` arm in `lower_call/builtin.rs`).

## Validation
```
const D = g.DataView;  new D(new ArrayBuffer(8)).getInt8(0)   // 0  (was: throw)
Reflect.construct(g.DataView, [new ArrayBuffer(8)])           // object
const A = g.ArrayBuffer; new A(8).byteLength                  // 8  (was: throw)
```
24 existing buffer/dataview/construct runtime tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of built-in buffer constructors (ArrayBuffer, SharedArrayBuffer, DataView) when accessed dynamically and invoked as functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->