### PR TITLE
Apply automatic clippy fixes in transform

### DIFF
--- a/crates/perry-transform/src/async_to_generator.rs
+++ b/crates/perry-transform/src/async_to_generator.rs
@@ -1053,7 +1053,7 @@ fn strip_in_expr(expr: &mut Expr, non_promise: &HashSet<LocalId>) {
     perry_hir::walker::walk_expr_children_mut(expr, &mut |c| strip_in_expr(c, non_promise));
     if let Expr::Await(inner) = expr {
         if let Some(stripped) = try_strip_promise_resolve(inner, non_promise) {
-            *inner = Box::new(stripped);
+            **inner = stripped;
         }
     }
 }

--- a/crates/perry-transform/src/deforest/call_sites.rs
+++ b/crates/perry-transform/src/deforest/call_sites.rs
@@ -176,7 +176,7 @@ pub fn rewrite_call_sites_in_stmts_with_local_pass(
                     next_local,
                     current_out,
                 );
-                *body = Box::new(tmp.into_iter().next().unwrap());
+                **body = tmp.into_iter().next().unwrap();
             }
             _ => {}
         }

--- a/crates/perry-transform/src/deforest/out_usage.rs
+++ b/crates/perry-transform/src/deforest/out_usage.rs
@@ -123,26 +123,21 @@ impl OutUsageAnalyzer {
         // below (which would otherwise flag the LocalGet(out) inside
         // them as unsafe).
         match e {
-            Expr::ArrayPush { array_id, value } => {
-                if *array_id == self.out_id {
-                    // Safe: out.push(v). Visit only `value`.
-                    self.visit_expr(value);
-                    return;
-                }
+            Expr::ArrayPush { array_id, value } if *array_id == self.out_id => {
+                // Safe: out.push(v). Visit only `value`.
+                self.visit_expr(value);
+                return;
             }
-            Expr::ArrayPushSpread { array_id, source } => {
-                if *array_id == self.out_id {
-                    self.visit_expr(source);
-                    return;
-                }
+            Expr::ArrayPushSpread { array_id, source } if *array_id == self.out_id => {
+                self.visit_expr(source);
+                return;
             }
-            Expr::PropertyGet { object, property } => {
+            Expr::PropertyGet { object, property }
                 if matches!(object.as_ref(), Expr::LocalGet(id) if *id == self.out_id)
-                    && property == "length"
-                {
-                    // Safe: out.length read.
-                    return;
-                }
+                    && property == "length" =>
+            {
+                // Safe: out.length read.
+                return;
             }
             Expr::IndexGet { object, index } => {
                 if matches!(object.as_ref(), Expr::LocalGet(id) if *id == self.out_id) {

--- a/crates/perry-transform/src/generator/break_continue.rs
+++ b/crates/perry-transform/src/generator/break_continue.rs
@@ -271,28 +271,20 @@ pub fn body_contains_yield(stmts: &[Stmt]) -> bool {
                     }
                 }
             }
-            Stmt::While { body, .. } => {
-                if body_contains_yield(body) {
-                    return true;
-                }
+            Stmt::While { body, .. } if body_contains_yield(body) => {
+                return true;
             }
             // A yield buried in a do-while or labeled loop must still be seen
             // by the enclosing construct's linearization (#1824), otherwise it
             // is never split into resume states.
-            Stmt::DoWhile { body, .. } => {
-                if body_contains_yield(body) {
-                    return true;
-                }
+            Stmt::DoWhile { body, .. } if body_contains_yield(body) => {
+                return true;
             }
-            Stmt::Labeled { body, .. } => {
-                if body_contains_yield(std::slice::from_ref(&**body)) {
-                    return true;
-                }
+            Stmt::Labeled { body, .. } if body_contains_yield(std::slice::from_ref(&**body)) => {
+                return true;
             }
-            Stmt::For { body, .. } => {
-                if body_contains_yield(body) {
-                    return true;
-                }
+            Stmt::For { body, .. } if body_contains_yield(body) => {
+                return true;
             }
             Stmt::Try {
                 body,

--- a/crates/perry-transform/src/generator/mod.rs
+++ b/crates/perry-transform/src/generator/mod.rs
@@ -24,33 +24,23 @@ mod rewrite_returns;
 // `use super::*;`. Globs don't propagate transitively, so spell every
 // cross-module symbol here.
 pub(crate) use break_continue::{
-    body_contains_yield, collect_hoisted_vars, collect_vars_recursive,
-    fix_break_continue_sentinels, fix_break_continue_sentinels_in_catches,
-    fix_break_continue_sentinels_in_stmt, fix_break_continue_sentinels_in_stmts,
-    fix_placeholder_state, rewrite_break_continue_in_stmt, rewrite_break_continue_in_stmts,
+    body_contains_yield, collect_hoisted_vars, fix_break_continue_sentinels,
+    fix_break_continue_sentinels_in_catches, fix_break_continue_sentinels_in_stmts,
+    fix_placeholder_state, rewrite_break_continue_in_stmts,
 };
 pub(crate) use helpers::{
-    alloc_local, make_iter_result, rewrite_hoisted_lets_in_stmt, rewrite_hoisted_lets_in_stmts,
-    wrap_in_promise_resolve, wrap_returns_in_promise,
+    alloc_local, make_iter_result, rewrite_hoisted_lets_in_stmts, wrap_returns_in_promise,
 };
 pub(crate) use hoist_yields::hoist_yields_in_stmts;
-pub(crate) use id_scan::{
-    compute_max_func_id, compute_max_local_id, scan_expr_for_max_func, scan_expr_for_max_local,
-    scan_stmt_for_max_func, scan_stmt_for_max_local, scan_stmts_for_max_func,
-    scan_stmts_for_max_local,
-};
-pub(crate) use iter_result_rewrite::{rewrite_expr, rewrite_expr_children, rewrite_stmt};
+pub(crate) use id_scan::{compute_max_func_id, compute_max_local_id};
+pub(crate) use iter_result_rewrite::rewrite_stmt;
 pub(crate) use linearize::{linearize_body, CatchRoute, FinallyRoute, State, StateExit};
 pub(crate) use lower::{
-    build_async_step_driver_direct, transform_generator_function,
-    transform_generator_function_with_extra_captures,
+    transform_generator_function, transform_generator_function_with_extra_captures,
 };
 pub(crate) use rewrite_returns::{
-    body_contains_return, is_iter_result, prepend_done_before_returns,
-    rewrite_catch_returns_to_iter_result, rewrite_catch_returns_to_iter_result_in_stmt,
+    body_contains_return, prepend_done_before_returns, rewrite_catch_returns_to_iter_result,
     rewrite_iter_results_in_stmts, rewrite_returns_as_done, rewrite_returns_to_labeled_break,
-    rewrite_returns_to_labeled_break_in_stmt, rewrite_yield_to_await_in_expr,
-    rewrite_yield_to_await_in_expr_children, rewrite_yield_to_await_in_stmt,
     rewrite_yield_to_await_in_stmts,
 };
 

--- a/crates/perry-transform/src/generator/rewrite_returns.rs
+++ b/crates/perry-transform/src/generator/rewrite_returns.rs
@@ -11,13 +11,12 @@ use super::*;
 pub fn rewrite_returns_as_done(stmts: &mut Vec<Stmt>) {
     for stmt in stmts.iter_mut() {
         match stmt {
-            Stmt::Return(Some(expr)) => {
+            Stmt::Return(Some(expr))
                 // Don't double-wrap if already an iter result
-                if !is_iter_result(expr) {
+                if !is_iter_result(expr) => {
                     let val = expr.clone();
                     *expr = make_iter_result(val, true);
                 }
-            }
             Stmt::Return(None) => {
                 *stmt = Stmt::Return(Some(make_iter_result(Expr::Undefined, true)));
             }
@@ -148,10 +147,10 @@ pub fn body_contains_return(stmts: &[Stmt]) -> bool {
                     }
                 }
             }
-            Stmt::While { body, .. } | Stmt::DoWhile { body, .. } | Stmt::For { body, .. } => {
-                if body_contains_return(body) {
-                    return true;
-                }
+            Stmt::While { body, .. } | Stmt::DoWhile { body, .. } | Stmt::For { body, .. }
+                if body_contains_return(body) =>
+            {
+                return true;
             }
             Stmt::Try {
                 body,
@@ -179,10 +178,10 @@ pub fn body_contains_return(stmts: &[Stmt]) -> bool {
                     }
                 }
             }
-            Stmt::Labeled { body, .. } => {
-                if body_contains_return(std::slice::from_ref(body.as_ref())) {
-                    return true;
-                }
+            Stmt::Labeled { body, .. }
+                if body_contains_return(std::slice::from_ref(body.as_ref())) =>
+            {
+                return true;
             }
             _ => {}
         }

--- a/crates/perry-transform/src/inline/analysis.rs
+++ b/crates/perry-transform/src/inline/analysis.rs
@@ -1,6 +1,6 @@
-use perry_hir::walker::{walk_expr_children, walk_expr_children_mut};
-use perry_hir::{BinaryOp, Class, Expr, Function, Module, Param, Stmt};
-use perry_types::{FuncId, LocalId, Type};
+use perry_hir::walker::walk_expr_children;
+use perry_hir::{Class, Expr, Function, Module, Stmt};
+use perry_types::{FuncId, LocalId};
 use std::collections::{HashMap, HashSet};
 
 use super::*;

--- a/crates/perry-transform/src/inline/call_inliner.rs
+++ b/crates/perry-transform/src/inline/call_inliner.rs
@@ -1,5 +1,4 @@
-use perry_hir::walker::walk_expr_children_mut;
-use perry_hir::{BinaryOp, Class, Expr, Function, Module, Param, Stmt};
+use perry_hir::{Expr, Function, Param, Stmt};
 use perry_types::{FuncId, LocalId, Type};
 use std::collections::{HashMap, HashSet};
 

--- a/crates/perry-transform/src/inline/clamp.rs
+++ b/crates/perry-transform/src/inline/clamp.rs
@@ -1,9 +1,4 @@
-use perry_hir::walker::{walk_expr_children, walk_expr_children_mut};
-use perry_hir::{BinaryOp, Class, Expr, Function, Module, Param, Stmt};
-use perry_types::{FuncId, LocalId, Type};
-use std::collections::{HashMap, HashSet};
-
-use super::*;
+use perry_hir::{Expr, Function, Stmt};
 
 pub fn is_clamp3(f: &Function) -> bool {
     if f.is_async || f.is_generator || f.params.len() != 3 || f.body.len() != 3 {

--- a/crates/perry-transform/src/inline/closure_analysis.rs
+++ b/crates/perry-transform/src/inline/closure_analysis.rs
@@ -1,7 +1,6 @@
-use perry_hir::walker::{walk_expr_children, walk_expr_children_mut};
-use perry_hir::{BinaryOp, Class, Expr, Function, Module, Param, Stmt};
-use perry_types::{FuncId, LocalId, Type};
-use std::collections::{HashMap, HashSet};
+use perry_hir::walker::walk_expr_children;
+use perry_hir::{Expr, Function, Stmt};
+use perry_types::LocalId;
 
 use super::*;
 

--- a/crates/perry-transform/src/inline/cross_module.rs
+++ b/crates/perry-transform/src/inline/cross_module.rs
@@ -1,6 +1,5 @@
-use perry_hir::walker::{walk_expr_children, walk_expr_children_mut};
-use perry_hir::{BinaryOp, Class, Expr, Function, Module, Param, Stmt};
-use perry_types::{FuncId, LocalId, Type};
+use perry_hir::walker::walk_expr_children;
+use perry_hir::{Class, Expr, Module, Stmt};
 use std::collections::{HashMap, HashSet};
 
 use super::*;
@@ -396,15 +395,13 @@ pub fn body_references_class_in_set(stmts: &[Stmt], set: &HashSet<String>) -> bo
             | Expr::ClassStaticSymbolSet { class_name, .. }
             | Expr::RegisterClassParentDynamic { class_name, .. }
             | Expr::RegisterClassStaticSymbol { class_name, .. }
-            | Expr::StaticMethodCall { class_name, .. } => {
-                if set.contains(class_name) {
-                    return true;
-                }
+            | Expr::StaticMethodCall { class_name, .. }
+                if set.contains(class_name) =>
+            {
+                return true;
             }
-            Expr::ClassExprFresh { template, .. } => {
-                if set.contains(template) {
-                    return true;
-                }
+            Expr::ClassExprFresh { template, .. } if set.contains(template) => {
+                return true;
             }
             _ => {}
         }

--- a/crates/perry-transform/src/inline/exact_receivers.rs
+++ b/crates/perry-transform/src/inline/exact_receivers.rs
@@ -1,6 +1,6 @@
-use perry_hir::walker::{walk_expr_children, walk_expr_children_mut};
-use perry_hir::{BinaryOp, Class, Expr, Function, Module, Param, Stmt};
-use perry_types::{FuncId, LocalId, Type};
+use perry_hir::walker::walk_expr_children;
+use perry_hir::{Expr, Stmt};
+use perry_types::LocalId;
 use std::collections::{HashMap, HashSet};
 
 use super::*;
@@ -287,15 +287,11 @@ pub fn collect_exact_receiver_refs_in_expr(
     out: &mut HashSet<LocalId>,
 ) {
     match expr {
-        Expr::LocalGet(id) | Expr::LocalSet(id, _) => {
-            if facts.contains_key(id) {
-                out.insert(*id);
-            }
+        Expr::LocalGet(id) | Expr::LocalSet(id, _) if facts.contains_key(id) => {
+            out.insert(*id);
         }
-        Expr::Update { id, .. } => {
-            if facts.contains_key(id) {
-                out.insert(*id);
-            }
+        Expr::Update { id, .. } if facts.contains_key(id) => {
+            out.insert(*id);
         }
         Expr::Closure {
             params,

--- a/crates/perry-transform/src/inline/factory_specialize.rs
+++ b/crates/perry-transform/src/inline/factory_specialize.rs
@@ -758,12 +758,12 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
         next_class_counter: &mut usize,
         base_class_counter_seed: &str,
     ) -> bool {
-        let Some(class) = classes.iter().find(|c| &c.name == target_name) else {
+        let Some(class) = classes.iter().find(|c| c.name == target_name) else {
             return false;
         };
         // Snapshot the args, padding with Undefined if the call passes
         // fewer args than the function declared params (rare but legal).
-        let mut padded_args: Vec<Expr> = args.iter().cloned().collect();
+        let mut padded_args: Vec<Expr> = args.to_vec();
         while padded_args.len() < param_ids.len() {
             padded_args.push(Expr::Undefined);
         }

--- a/crates/perry-transform/src/inline/imul.rs
+++ b/crates/perry-transform/src/inline/imul.rs
@@ -1,9 +1,6 @@
-use perry_hir::walker::{walk_expr_children, walk_expr_children_mut};
-use perry_hir::{BinaryOp, Class, Expr, Function, Module, Param, Stmt};
-use perry_types::{FuncId, LocalId, Type};
-use std::collections::{HashMap, HashSet};
-
-use super::*;
+use perry_hir::{BinaryOp, Expr, Function, Stmt};
+use perry_types::{FuncId, LocalId};
+use std::collections::HashSet;
 
 pub fn detect_math_imul_polyfill(f: &Function) -> bool {
     if f.is_async || f.is_generator {

--- a/crates/perry-transform/src/inline/mod.rs
+++ b/crates/perry-transform/src/inline/mod.rs
@@ -48,6 +48,8 @@ pub(crate) use substitute::{
     substitute_this_in_stmts,
 };
 pub(crate) use super_detect::{enter_inline_expr_recursion, method_contains_lexical_super};
+#[cfg(test)]
+pub(crate) use super_detect::MAX_INLINE_EXPR_RECURSION_DEPTH;
 
 use perry_hir::{Class, Expr, Function, Module, Stmt};
 use perry_types::{FuncId, LocalId, Type};

--- a/crates/perry-transform/src/inline/mod.rs
+++ b/crates/perry-transform/src/inline/mod.rs
@@ -47,9 +47,9 @@ pub(crate) use substitute::{
     collect_body_local_ids, substitute_locals, substitute_locals_in_stmts, substitute_this,
     substitute_this_in_stmts,
 };
-pub(crate) use super_detect::{enter_inline_expr_recursion, method_contains_lexical_super};
 #[cfg(test)]
 pub(crate) use super_detect::MAX_INLINE_EXPR_RECURSION_DEPTH;
+pub(crate) use super_detect::{enter_inline_expr_recursion, method_contains_lexical_super};
 
 use perry_hir::{Class, Expr, Function, Module, Stmt};
 use perry_types::{FuncId, LocalId, Type};

--- a/crates/perry-transform/src/inline/mod.rs
+++ b/crates/perry-transform/src/inline/mod.rs
@@ -27,46 +27,29 @@ pub use cross_module::{
 
 // Internal-to-crate re-exports for cross-sibling access via `use super::*;`.
 pub(crate) use analysis::{
-    body_calls_func, class_chain_property_sets, construction_expr_can_affect_method_lookup,
-    construction_stmt_can_affect_method_lookup, construction_stmts_can_affect_method_lookup,
     find_max_local_id_in_module, is_inlinable, is_inlinable_method, method_lookup_is_unshadowed,
 };
-pub(crate) use call_inliner::{
-    build_inline_arg_bindings, convert_returns_in_stmts, inline_calls_in_expr,
-    inline_calls_in_stmts, is_trivial_expr, stmt_contains_return, try_inline_call,
-    try_inline_simple_call,
-};
+pub(crate) use call_inliner::inline_calls_in_stmts;
 pub(crate) use clamp::{is_clamp3, is_clamp_u8};
 pub(crate) use closure_analysis::{
     body_contains_closure_capturing, body_contains_super_call, body_references_dynamic_this,
     collect_closure_captured_local_ids, collect_mutated_local_ids, find_max_local_id,
     has_simple_control_flow, is_pure_function, method_body_blocks_this_substitution,
 };
-pub(crate) use cross_module::{
-    body_references_class_in_set, collect_nonexported_class_names,
-    is_cross_module_safe_with_externs,
-};
 pub(crate) use exact_receivers::{
     apply_exact_receiver_stmt_effect, apply_exact_receiver_stmt_effects,
-    clear_exact_receivers_after_global_effect, collect_exact_receiver_refs_in_expr,
-    collect_exact_receiver_refs_in_stmt, intersect_exact_receiver_facts,
-    invalidate_exact_receivers_for_expr, kill_referenced_exact_receivers, resolve_receiver_class,
+    intersect_exact_receiver_facts, invalidate_exact_receivers_for_expr,
+    kill_referenced_exact_receivers,
 };
 pub(crate) use factory_specialize::specialize_captured_class_factories;
-pub(crate) use imul::{
-    detect_math_imul_polyfill, is_half_extract, rewrite_imul_calls_in_expr,
-    rewrite_imul_calls_in_stmts,
-};
+pub(crate) use imul::{detect_math_imul_polyfill, rewrite_imul_calls_in_stmts};
 pub(crate) use substitute::{
     collect_body_local_ids, substitute_locals, substitute_locals_in_stmts, substitute_this,
     substitute_this_in_stmts,
 };
-pub(crate) use super_detect::{
-    enter_inline_expr_recursion, method_contains_lexical_super, MAX_INLINE_EXPR_RECURSION_DEPTH,
-};
+pub(crate) use super_detect::{enter_inline_expr_recursion, method_contains_lexical_super};
 
-use perry_hir::walker::{walk_expr_children, walk_expr_children_mut};
-use perry_hir::{BinaryOp, Class, Expr, Function, Module, Param, Stmt};
+use perry_hir::{Class, Expr, Function, Module, Stmt};
 use perry_types::{FuncId, LocalId, Type};
 use std::collections::{BTreeMap, HashMap, HashSet};
 

--- a/crates/perry-transform/src/inline/substitute.rs
+++ b/crates/perry-transform/src/inline/substitute.rs
@@ -1,9 +1,7 @@
-use perry_hir::walker::{walk_expr_children, walk_expr_children_mut};
-use perry_hir::{BinaryOp, Class, Expr, Function, Module, Param, Stmt};
-use perry_types::{FuncId, LocalId, Type};
-use std::collections::{HashMap, HashSet};
-
-use super::*;
+use perry_hir::walker::walk_expr_children_mut;
+use perry_hir::{Expr, Stmt};
+use perry_types::LocalId;
+use std::collections::HashMap;
 
 pub fn substitute_locals(
     expr: &mut Expr,

--- a/crates/perry-transform/src/unroll/mod.rs
+++ b/crates/perry-transform/src/unroll/mod.rs
@@ -406,7 +406,7 @@ fn try_unroll_for(
     let mut out: Vec<Stmt> = Vec::with_capacity((trips as usize) * body.len());
     for n in 0..trips {
         let value = lo + n;
-        let mut cloned: Vec<Stmt> = body.iter().cloned().collect();
+        let mut cloned: Vec<Stmt> = body.to_vec();
         for s in &mut cloned {
             substitute_localget_with_int_in_stmt(s, iv_id, value);
         }
@@ -526,7 +526,7 @@ fn expr_is_unrollable(e: &Expr, iv_id: LocalId) -> bool {
         // create closures inside its blur loops, so this restriction
         // is free for the target workload.
         Expr::Closure { body, captures, .. } => {
-            if captures.iter().any(|cap| *cap == iv_id) {
+            if captures.contains(&iv_id) {
                 return false;
             }
             // Defensive: walk the closure body to catch any direct


### PR DESCRIPTION
## Summary
- Applies mechanical `cargo clippy --fix` suggestions in `crates/perry-transform`.
- Keeps the change scoped to transform, generator, deforesting, unroll, and inline helper code.

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -p perry-transform -- -A clippy::not_unsafe_ptr_arg_deref`

Remaining clippy output is pre-existing warning debt not covered by automatic fixes in this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Performance / Refactor**
  * Reduced temporary allocations in async/generator and deforestation rewrites by reusing existing AST containers during transformations.
  * Streamlined loop unrolling body cloning and improved induction-variable capture checks.

* **Style**
  * Simplified several conditional/pattern-matching branches for return/break/yield and related analyses, preserving behavior.

* **Maintenance**
  * Pruned internal imports and trimmed internal module re-exports to keep the transformation codebase leaner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->