### PR TITLE
Apply automatic clippy fixes in CLI

### DIFF
--- a/crates/perry/src/commands/check.rs
+++ b/crates/perry/src/commands/check.rs
@@ -201,7 +201,7 @@ pub fn run(args: CheckArgs, format: OutputFormat, use_color: bool, verbose: u8) 
             }
         };
 
-        all_diagnostics.extend(parse_result.diagnostics.into_iter());
+        all_diagnostics.extend(parse_result.diagnostics);
 
         // Run fixer analysis if --fix or --fix-dry-run is enabled
         if args.fix || args.fix_dry_run {

--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -1,8 +1,6 @@
 //! Compile command - compiles TypeScript to native executable
 
 use anyhow::{anyhow, Result};
-use clap::Args;
-use perry_hir::{Module as HirModule, ModuleKind};
 use rayon::prelude::*;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs;
@@ -741,7 +739,7 @@ pub fn run_with_parse_cache(
     // Named("BlockTag") -> Union([...]) for correct ABI types in function signatures.
     let mut all_type_aliases: std::collections::BTreeMap<String, perry_types::Type> =
         std::collections::BTreeMap::new();
-    for (_path, hir_module) in &ctx.native_modules {
+    for hir_module in ctx.native_modules.values() {
         for ta in &hir_module.type_aliases {
             if ta.type_params.is_empty() {
                 all_type_aliases.insert(ta.name.clone(), ta.ty.clone());
@@ -773,7 +771,7 @@ pub fn run_with_parse_cache(
     // `hir_module.imports` doesn't even mention the source module.
     let mut all_program_type_names: std::collections::HashSet<String> =
         std::collections::HashSet::new();
-    for (_path, hir_module) in &ctx.native_modules {
+    for hir_module in ctx.native_modules.values() {
         for class in &hir_module.classes {
             all_program_type_names.insert(class.name.clone());
         }
@@ -1019,9 +1017,7 @@ pub fn run_with_parse_cache(
         BTreeMap::new();
     for (path, hir_module) in &ctx.native_modules {
         let path_str = path.to_string_lossy().to_string();
-        let exports = all_module_exports
-            .entry(path_str.clone())
-            .or_insert_with(BTreeMap::new);
+        let exports = all_module_exports.entry(path_str.clone()).or_default();
         // Exported functions
         for func in &hir_module.functions {
             if func.is_exported {
@@ -1110,7 +1106,7 @@ pub fn run_with_parse_cache(
                 {
                     all_module_export_origin_names
                         .entry(path_str.clone())
-                        .or_insert_with(BTreeMap::new)
+                        .or_default()
                         .insert(exported.clone(), local.clone());
                 }
             }
@@ -1292,7 +1288,7 @@ pub fn run_with_parse_cache(
         for (module_path, name, origin, origin_name) in new_export_entries {
             all_module_exports
                 .entry(module_path.clone())
-                .or_insert_with(BTreeMap::new)
+                .or_default()
                 .insert(name.clone(), origin);
             // Only record the origin-name entry when it actually differs
             // from the export name (the common identity case is implicit —
@@ -1302,7 +1298,7 @@ pub fn run_with_parse_cache(
             if origin_name != name {
                 all_module_export_origin_names
                     .entry(module_path)
-                    .or_insert_with(BTreeMap::new)
+                    .or_default()
                     .insert(name, origin_name);
             }
         }
@@ -1914,7 +1910,7 @@ pub fn run_with_parse_cache(
     // Set of native-module paths that are dynamic-import targets. We
     // also build a parallel set keyed by Module::name for flatten_exports.
     let mut dyn_target_paths: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
-    for (_path, hir_module) in &ctx.native_modules {
+    for hir_module in ctx.native_modules.values() {
         for import in &hir_module.imports {
             // `is_dynamic` covers dynamic-only synthetic edges;
             // `is_dynamic_target` (#1672) covers a static edge that is
@@ -1974,9 +1970,7 @@ pub fn run_with_parse_cache(
                     .iter()
                     .find(|c| c.name == fe.source_local)
                 {
-                    perry_codegen::NamespaceEntryKind::LocalClass {
-                        class_id: class.id as u32,
-                    }
+                    perry_codegen::NamespaceEntryKind::LocalClass { class_id: class.id }
                 } else if let Some(global) = target_hir
                     .globals
                     .iter()
@@ -2013,9 +2007,7 @@ pub fn run_with_parse_cache(
                     } else if let Some(class) =
                         src.classes.iter().find(|c| c.name == fe.source_local)
                     {
-                        perry_codegen::NamespaceEntryKind::LocalClass {
-                            class_id: class.id as u32,
-                        }
+                        perry_codegen::NamespaceEntryKind::LocalClass { class_id: class.id }
                     } else {
                         perry_codegen::NamespaceEntryKind::ForeignVar {
                             source_prefix: source_prefix.clone(),
@@ -2370,7 +2362,7 @@ pub fn run_with_parse_cache(
                 }
                 for spec in &import.specifiers {
                     if let perry_hir::ImportSpecifier::Namespace { local } = spec {
-                        if !namespace_imports.contains(&local) {
+                        if !namespace_imports.contains(local) {
                             namespace_imports.push(local.clone());
                         }
                     }
@@ -4217,14 +4209,14 @@ pub fn run_with_parse_cache(
                     stored_cache_path: true,
                 });
             }
-            return Ok(NativeObjectArtifact {
+            Ok(NativeObjectArtifact {
                 path: obj_path,
                 bytes: Some(object_code),
                 fingerprint: object_fingerprint,
                 cleanup_after_link: true,
                 reused_cache_path: false,
                 stored_cache_path: false,
-            });
+            })
         })
         .collect();
 

--- a/crates/perry/src/commands/compile/audit_manifest.rs
+++ b/crates/perry/src/commands/compile/audit_manifest.rs
@@ -59,8 +59,7 @@ fn write_audit_manifest(ctx: &CompilationContext) -> std::io::Result<()> {
     let dir = ctx.cache_root.join(".perry-cache");
     fs::create_dir_all(&dir)?;
     let path = dir.join("audit.json");
-    let json = serde_json::to_string_pretty(&manifest)
-        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+    let json = serde_json::to_string_pretty(&manifest).map_err(|e| std::io::Error::other(e))?;
     fs::write(&path, json)?;
     Ok(())
 }

--- a/crates/perry/src/commands/compile/bundle_ios.rs
+++ b/crates/perry/src/commands/compile/bundle_ios.rs
@@ -46,8 +46,8 @@ pub(super) fn build_ios_app_bundle(
     let app_dir = exe_path.with_extension("app");
     let _ = fs::create_dir_all(&app_dir);
     let bundle_exe = app_dir.join(exe_path.file_name().unwrap_or_default());
-    fs::copy(&exe_path, &bundle_exe)?;
-    let _ = fs::remove_file(&exe_path);
+    fs::copy(exe_path, &bundle_exe)?;
+    let _ = fs::remove_file(exe_path);
 
     let exe_stem = exe_path
         .file_stem()
@@ -437,7 +437,7 @@ pub(super) fn build_ios_app_bundle(
     // time; the existing `perry publish` flow picks it up
     // automatically when present alongside the .app bundle.
     let info_plist =
-        inject_ios_deeplinks(&info_plist, &input, &app_dir, format).unwrap_or(info_plist);
+        inject_ios_deeplinks(&info_plist, input, &app_dir, format).unwrap_or(info_plist);
 
     // #1178 — augment `app.entitlements` with the
     // `com.apple.security.application-groups` array when
@@ -451,13 +451,13 @@ pub(super) fn build_ios_app_bundle(
     // `[ios] push_notifications = true` is set in perry.toml. Without it
     // `registerForRemoteNotifications` always fails and no APNs token is
     // produced. Idempotent with the deeplinks / app-group passes above.
-    inject_ios_push_entitlement(&input, &app_dir, format);
+    inject_ios_push_entitlement(input, &app_dir, format);
 
     // #1138 — `[google_auth]` block in perry.toml feeds the
     // GoogleSignIn SDK via Info.plist keys the Swift bridge in
     // `@perryts/google-auth` reads at runtime.
     let info_plist =
-        inject_google_auth_info_plist(&info_plist, &input, format).unwrap_or(info_plist);
+        inject_google_auth_info_plist(&info_plist, input, format).unwrap_or(info_plist);
 
     fs::write(app_dir.join("Info.plist"), info_plist)?;
 
@@ -525,8 +525,7 @@ pub(super) fn build_ios_app_bundle(
             };
 
             let image_views = if image_path.is_some() {
-                format!(
-                    r#"
+                r#"
                     <subviews>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="splash_image" translatesAutoresizingMaskIntoConstraints="NO" id="img-splash-1">
                             <rect key="frame" x="132.5" y="362" width="128" height="128"/>
@@ -539,8 +538,7 @@ pub(super) fn build_ios_app_bundle(
                     <constraints>
                         <constraint firstItem="img-splash-1" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="cx-1"/>
                         <constraint firstItem="img-splash-1" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="cy-1"/>
-                    </constraints>"#
-                )
+                    </constraints>"#.to_string()
             } else {
                 String::new()
             };
@@ -665,7 +663,7 @@ pub(super) fn build_ios_app_bundle(
     }
 
     // --- i18n: generate .lproj bundles for iOS/macOS ---
-    if let (Some(ref table), Some(ref config)) = (&i18n_table, &i18n_config) {
+    if let (Some(table), Some(config)) = (&i18n_table, &i18n_config) {
         if !table.keys.is_empty() {
             for (locale_idx, locale) in config.locales.iter().enumerate() {
                 let lproj_dir = app_dir.join(format!("{}.lproj", locale));
@@ -697,7 +695,7 @@ pub(super) fn build_ios_app_bundle(
         }
     }
 
-    compile_metallib_for_bundle(&ctx, target, &app_dir, format)?;
+    compile_metallib_for_bundle(ctx, target, &app_dir, format)?;
     stage_native_library_artifacts(ctx, &app_dir, format)?;
 
     // Issue #676: build any [[widget]] entries declared in perry.toml,
@@ -706,7 +704,7 @@ pub(super) fn build_ios_app_bundle(
     // inside the helper.
     let widgets_built = {
         let is_ios_sim = matches!(target, Some("ios-simulator"));
-        widget_build::build_declared_widgets_ios(&input, &app_dir, is_ios_sim, &bundle_id, format)?
+        widget_build::build_declared_widgets_ios(input, &app_dir, is_ios_sim, &bundle_id, format)?
     };
 
     match format {

--- a/crates/perry/src/commands/compile/cjs_wrap/extract_requires.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/extract_requires.rs
@@ -300,7 +300,7 @@ pub fn function_local_specs(source: &str) -> std::collections::HashSet<String> {
     // spec → (seen any site, all sites so far in-function).
     let mut state: HashMap<&str, (bool, bool)> = HashMap::new();
     let mut next_site = 0usize;
-    let in_function = |scopes: &[Scope]| scopes.iter().any(|s| *s == Scope::Function);
+    let in_function = |scopes: &[Scope]| scopes.contains(&Scope::Function);
 
     let mut i = 0usize;
     while i < mbytes.len() {

--- a/crates/perry/src/commands/compile/cjs_wrap/mod.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/mod.rs
@@ -43,17 +43,17 @@ mod hoist_classes;
 mod wrap;
 
 // Cross-sibling helpers — siblings reach for these via `use super::*;`.
-pub(self) use detect::is_js_reserved_word;
-pub(self) use extract_exports::{
+use detect::is_js_reserved_word;
+use extract_exports::{
     extract_exports_from_source, extract_named_exports_from_require,
     extract_object_literal_exports_from_require, extract_single_module_exports_assignment,
     module_reexport_specs,
 };
-pub(self) use extract_requires::{
+use extract_requires::{
     extract_export_star_specs, extract_require_aliases_with_ranges, extract_require_specifiers,
     function_local_specs, identifier_is_declared_binding, identifier_is_reassigned,
 };
-pub(self) use hoist_classes::{
+use hoist_classes::{
     extract_top_level_class_decls, rewrite_module_exports_class_expression,
     source_has_top_level_return, top_level_class_names,
 };

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -481,7 +481,7 @@ fn collect_module_one(
         ..Default::default()
     });
     let ast_module_owned: swc_ecma_ast::Module;
-    let ast_module: &swc_ecma_ast::Module = match parse_cache.as_deref_mut() {
+    let ast_module: &swc_ecma_ast::Module = match parse_cache {
         Some(cache) => match parse_cached(cache, &canonical, &source, parse_filename) {
             Ok(m) => m,
             Err(e) => {
@@ -1624,14 +1624,14 @@ fn collect_module_one(
         }
     }
 
-    return Ok(ModuleDiscovery {
+    Ok(ModuleDiscovery {
         finish: Some(PreparedModule {
             canonical,
             module_name,
             hir_module,
         }),
         children: pending,
-    });
+    })
 }
 
 fn collect_module_finish(

--- a/crates/perry/src/commands/compile/collect_modules/dynamic_glob.rs
+++ b/crates/perry/src/commands/compile/collect_modules/dynamic_glob.rs
@@ -1,8 +1,6 @@
 //! Dynamic-`import()` glob expansion (#1674 sub-part B). Split out of
 //! `collect_modules.rs` to keep that file under the file-size gate.
 
-use super::*;
-
 /// #1674 sub-part B: expand a dynamic-`import()` glob pattern
 /// (`<prefix>*<suffix>`, where `prefix` is a relative, directory-anchored
 /// path) into concrete relative specifiers by reading the importing module's

--- a/crates/perry/src/commands/compile/link/build_and_run.rs
+++ b/crates/perry/src/commands/compile/link/build_and_run.rs
@@ -332,7 +332,7 @@ pub(crate) fn build_and_run_link(
                     }
                 }
                 // Tier-3 (tvOS/watchOS) std-duplication dedup; no-op elsewhere.
-                cmd.arg(&dedup_stdlib_for_tier3(target, stdlib));
+                cmd.arg(dedup_stdlib_for_tier3(target, stdlib));
                 // #466 Phase 4 step 2: well-known bindings normally join the
                 // link line right after perry-stdlib so they cover the exact
                 // `_js_*` symbol gap that was just opened by stripping the
@@ -351,7 +351,7 @@ pub(crate) fn build_and_run_link(
                 // Also link runtime for symbols DCE'd from stdlib's bundled
                 // perry-runtime; on tier-3 it's first stripped of stdlib's objects.
                 if !is_android && !is_windows {
-                    cmd.arg(&dedup_runtime_for_tier3(target, runtime_lib, stdlib));
+                    cmd.arg(dedup_runtime_for_tier3(target, runtime_lib, stdlib));
                 }
             } else {
                 if ctx.needs_stdlib {
@@ -826,7 +826,7 @@ pub(crate) fn build_and_run_link(
                 if let Ok(ref output) = pc_out {
                     if output.status.success() {
                         let libs = String::from_utf8_lossy(&output.stdout);
-                        for flag in libs.trim().split_whitespace() {
+                        for flag in libs.split_whitespace() {
                             cmd.arg(flag);
                         }
                         got_gtk_libs = true;
@@ -894,7 +894,7 @@ pub(crate) fn build_and_run_link(
                 if let Ok(ref output) = gst_pc_out {
                     if output.status.success() {
                         let libs = String::from_utf8_lossy(&output.stdout);
-                        for flag in libs.trim().split_whitespace() {
+                        for flag in libs.split_whitespace() {
                             cmd.arg(flag);
                         }
                         got_gst_libs = true;
@@ -939,7 +939,7 @@ pub(crate) fn build_and_run_link(
                 if let Ok(ref output) = shumate_pc_out {
                     if output.status.success() {
                         let libs = String::from_utf8_lossy(&output.stdout);
-                        for flag in libs.trim().split_whitespace() {
+                        for flag in libs.split_whitespace() {
                             cmd.arg(flag);
                         }
                         got_shumate_libs = true;
@@ -977,7 +977,7 @@ pub(crate) fn build_and_run_link(
                 if let Ok(ref output) = webkit_pc_out {
                     if output.status.success() {
                         let libs = String::from_utf8_lossy(&output.stdout);
-                        for flag in libs.trim().split_whitespace() {
+                        for flag in libs.split_whitespace() {
                             cmd.arg(flag);
                         }
                         got_webkit_libs = true;
@@ -1362,7 +1362,7 @@ pub(crate) fn build_and_run_link(
                                 && native_lib.module.contains("plugin");
                             if force_load {
                                 cmd.arg(format!("-Wl,-force_load,{}", lib.display()));
-                            } else if is_windows && lib.extension().map_or(false, |e| e == "lib") {
+                            } else if is_windows && lib.extension().is_some_and(|e| e == "lib") {
                                 // On Windows, link native staticlibs directly —
                                 // /FORCE:MULTIPLE handles duplicate symbols.
                                 cmd.arg(&lib);
@@ -1474,7 +1474,7 @@ pub(crate) fn build_and_run_link(
                 if let Ok(output) = Command::new("pkg-config").args(["--libs", pkg]).output() {
                     if output.status.success() {
                         let libs = String::from_utf8_lossy(&output.stdout);
-                        for flag in libs.trim().split_whitespace() {
+                        for flag in libs.split_whitespace() {
                             cmd.arg(flag);
                         }
                     }
@@ -1542,7 +1542,7 @@ pub(crate) fn build_and_run_link(
                     if let Ok(output) = Command::new("pkg-config").args(["--libs", pkg]).output() {
                         if output.status.success() {
                             let libs = String::from_utf8_lossy(&output.stdout);
-                            for flag in libs.trim().split_whitespace() {
+                            for flag in libs.split_whitespace() {
                                 cmd.arg(flag);
                             }
                         }

--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -50,7 +50,8 @@ pub(super) use build_and_run::build_and_run_link;
 use link_cache::prepare_link_cache_status;
 pub(super) use link_cache::{write_link_cache_manifest, LinkCacheStatus};
 pub use platform_cmd::select_linker_command;
-// guarded by windows_link_tests
+#[cfg(test)]
+pub(super) use windows_link::WINDOWS_APP_MANIFEST; // consumed only by windows_link_tests
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct NativeBackendLinkMetadata {

--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -50,7 +50,7 @@ pub(super) use build_and_run::build_and_run_link;
 use link_cache::prepare_link_cache_status;
 pub(super) use link_cache::{write_link_cache_manifest, LinkCacheStatus};
 pub use platform_cmd::select_linker_command;
-pub(super) use windows_link::WINDOWS_APP_MANIFEST; // guarded by windows_link_tests
+// guarded by windows_link_tests
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct NativeBackendLinkMetadata {

--- a/crates/perry/src/commands/compile/resolve.rs
+++ b/crates/perry/src/commands/compile/resolve.rs
@@ -740,10 +740,8 @@ pub(super) fn resolve_exports_candidates(
     const CONDITIONS: &[&str] = &["perry", "node", "import", "module", "default", "require"];
     fn collect(value: &serde_json::Value, subpath: &str, out: &mut Vec<String>) {
         match value {
-            serde_json::Value::String(s) => {
-                if !out.contains(s) {
-                    out.push(s.clone());
-                }
+            serde_json::Value::String(s) if !out.contains(s) => {
+                out.push(s.clone());
             }
             // Node "exports" fallback arrays (e.g. y18n's
             // `[{ "import": "./index.mjs", "require": "./build/index.cjs" }, "./build/index.cjs"]`).

--- a/crates/perry/src/commands/compile/strip_dedup.rs
+++ b/crates/perry/src/commands/compile/strip_dedup.rs
@@ -42,7 +42,7 @@ const RUST_ALLOCATOR_SYMBOL_PARTS: &[&str] = &[
 ];
 
 fn force_localize_symbol(symbol: &str) -> bool {
-    FORCE_EXCLUDE_SYMBOLS.iter().any(|forced| symbol == *forced)
+    FORCE_EXCLUDE_SYMBOLS.contains(&symbol)
         || RUST_ALLOCATOR_SYMBOL_PARTS
             .iter()
             .any(|part| symbol.contains(part))

--- a/crates/perry/src/commands/compile/targets.rs
+++ b/crates/perry/src/commands/compile/targets.rs
@@ -85,14 +85,14 @@ pub(super) fn generate_embedded_js_object(
         ));
         c.push_str(&format!(
             "static const size_t PERRY_EMB_PATH_LEN_{idx} = {};\n",
-            specifier.as_bytes().len()
+            specifier.len()
         ));
         c.push_str(&format!(
             "static const char PERRY_EMB_SRC_{idx}[] = {src_lit};\n"
         ));
         c.push_str(&format!(
             "static const size_t PERRY_EMB_SRC_LEN_{idx} = {};\n",
-            module.source.as_bytes().len()
+            module.source.len()
         ));
     }
 
@@ -134,14 +134,14 @@ pub(super) fn generate_embedded_js_object(
         ));
         c.push_str(&format!(
             "static const size_t PERRY_ALIAS_SPEC_LEN_{idx} = {};\n",
-            specifier.as_bytes().len()
+            specifier.len()
         ));
         c.push_str(&format!(
             "static const char PERRY_ALIAS_PATH_{idx}[] = {path_lit};\n"
         ));
         c.push_str(&format!(
             "static const size_t PERRY_ALIAS_PATH_LEN_{idx} = {};\n",
-            path.as_bytes().len()
+            path.len()
         ));
     }
 

--- a/crates/perry/src/commands/compile/types.rs
+++ b/crates/perry/src/commands/compile/types.rs
@@ -13,8 +13,6 @@ use std::path::PathBuf;
 use perry_hir::{Module as HirModule, ModuleKind};
 use serde::{Deserialize, Serialize};
 
-use crate::OutputFormat;
-
 /// Result of a successful compilation
 pub struct CompileResult {
     pub output_path: PathBuf,

--- a/crates/perry/src/commands/i18n.rs
+++ b/crates/perry/src/commands/i18n.rs
@@ -134,7 +134,6 @@ fn run_extract(args: ExtractArgs, format: OutputFormat) -> Result<()> {
         let mut new_count = 0;
         // #854: `removed_count` was init'd to 0 then unconditionally
         // overwritten — declared without an initial value.
-        let removed_count: usize;
 
         // Add new keys
         for key in &keys {
@@ -154,7 +153,7 @@ fn run_extract(args: ExtractArgs, format: OutputFormat) -> Result<()> {
             .filter(|k| !keys.contains(*k))
             .cloned()
             .collect();
-        removed_count = stale.len();
+        let removed_count: usize = stale.len();
 
         // Write updated file (keep stale keys but report them)
         let json = serde_json::to_string_pretty(&existing)?;

--- a/crates/perry/src/commands/install/allowlist.rs
+++ b/crates/perry/src/commands/install/allowlist.rs
@@ -83,7 +83,7 @@ const PREFIXES: &[&str] = &[
 
 /// Is this package on the bundled trust allowlist?
 pub fn is_bundled(name: &str) -> bool {
-    EXACT.iter().any(|n| *n == name) || PREFIXES.iter().any(|p| name.starts_with(p))
+    EXACT.contains(&name) || PREFIXES.iter().any(|p| name.starts_with(p))
 }
 
 #[cfg(test)]

--- a/crates/perry/src/commands/native/init.rs
+++ b/crates/perry/src/commands/native/init.rs
@@ -73,13 +73,11 @@ pub fn run(args: InitArgs, format: OutputFormat, _use_color: bool) -> Result<()>
     let rust_crate_name = format!("perry-ext-{}", crate_name);
     let target = PathBuf::from(&dir_name);
 
-    if target.exists() {
-        if !args.force {
-            return Err(anyhow!(
-                "directory `{}` already exists; pass --force to overwrite",
-                target.display()
-            ));
-        }
+    if target.exists() && !args.force {
+        return Err(anyhow!(
+            "directory `{}` already exists; pass --force to overwrite",
+            target.display()
+        ));
     }
 
     let npm_name = args.npm_name.unwrap_or_else(|| name.to_string());

--- a/crates/perry/src/commands/perry_lock.rs
+++ b/crates/perry/src/commands/perry_lock.rs
@@ -28,8 +28,9 @@ pub struct NativeLibraryLock {
     pub sha256_per_target: BTreeMap<String, String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum LockMode {
+    #[default]
     Default,
     Update(Vec<String>),
     Frozen,
@@ -44,12 +45,6 @@ impl LockMode {
             LockMode::Update(pkgs) => pkgs.is_empty() || pkgs.iter().any(|p| p == package),
             _ => false,
         }
-    }
-}
-
-impl Default for LockMode {
-    fn default() -> Self {
-        LockMode::Default
     }
 }
 

--- a/crates/perry/src/commands/publish/mod.rs
+++ b/crates/perry/src/commands/publish/mod.rs
@@ -36,6 +36,8 @@ pub(crate) use saved_config::{
     check_beta_consent, config_path, is_interactive, load_config, prompt_input, report_beta_error,
     save_config, AndroidSavedConfig, AppleSavedConfig, HarmonyosSavedConfig, PerryConfig,
 };
+#[cfg(test)]
+pub(crate) use saved_config::IosSavedConfig; // consumed only by tests
 pub(crate) use tarball::{create_project_tarball, create_project_tarball_with_excludes};
 
 // Sibling-only items used by run_async and tests.

--- a/crates/perry/src/commands/publish/mod.rs
+++ b/crates/perry/src/commands/publish/mod.rs
@@ -32,12 +32,12 @@ mod tests;
 
 // Re-exports — explicit names only (no globs).
 pub use args::PublishArgs;
+#[cfg(test)]
+pub(crate) use saved_config::IosSavedConfig; // consumed only by tests
 pub(crate) use saved_config::{
     check_beta_consent, config_path, is_interactive, load_config, prompt_input, report_beta_error,
     save_config, AndroidSavedConfig, AppleSavedConfig, HarmonyosSavedConfig, PerryConfig,
 };
-#[cfg(test)]
-pub(crate) use saved_config::IosSavedConfig; // consumed only by tests
 pub(crate) use tarball::{create_project_tarball, create_project_tarball_with_excludes};
 
 // Sibling-only items used by run_async and tests.

--- a/crates/perry/src/commands/publish/mod.rs
+++ b/crates/perry/src/commands/publish/mod.rs
@@ -34,8 +34,7 @@ mod tests;
 pub use args::PublishArgs;
 pub(crate) use saved_config::{
     check_beta_consent, config_path, is_interactive, load_config, prompt_input, report_beta_error,
-    save_config, AndroidSavedConfig, AppleSavedConfig, BetaConfig, HarmonyosSavedConfig,
-    IosSavedConfig, PerryConfig,
+    save_config, AndroidSavedConfig, AppleSavedConfig, HarmonyosSavedConfig, PerryConfig,
 };
 pub(crate) use tarball::{create_project_tarball, create_project_tarball_with_excludes};
 

--- a/crates/perry/src/commands/publish/tarball.rs
+++ b/crates/perry/src/commands/publish/tarball.rs
@@ -106,7 +106,7 @@ pub(crate) fn create_project_tarball_with_excludes(
 /// (e.g. the GoogleSignIn SDK declared via `perry.toml [google_auth]
 /// framework_dir`) contains the static archive binary (extension-less, often
 /// >1 MB) and would otherwise be dropped, leaving the worker to link the
-/// no-SDK stub.
+/// > no-SDK stub.
 pub(crate) fn create_project_tarball(
     project_dir: &Path,
     extra_excludes: &[String],

--- a/crates/perry/src/commands/run/mod.rs
+++ b/crates/perry/src/commands/run/mod.rs
@@ -17,36 +17,21 @@ mod metadata;
 mod remote;
 mod resign;
 
-pub use android::{
-    build_and_run_android, build_and_run_wearos, debug_sign_apk, find_apksigner,
-    find_latest_build_tool, get_android_pid, inject_android_deeplinks,
-    inject_google_auth_android_resources, inject_gradle_dependencies, install_and_launch_android,
-    wire_native_lib_kotlin_sources,
-};
+pub use android::{build_and_run_android, build_and_run_wearos, install_and_launch_android};
 pub use devices::{
     detect_android_devices, detect_booted_simulators, detect_booted_tv_simulators,
     detect_booted_visionos_simulators, detect_booted_watch_simulators, detect_ios_devices,
     is_wear_os_device, pick_device, pick_from_list, DeviceInfo,
 };
-pub use entry::{
-    can_compile_locally, read_perry_toml_entry, resolve_entry_file, resolve_target,
-    rust_target_triple,
-};
-pub use launch::{launch, launch_ios_device, launch_ios_simulator, launch_native, launch_web};
+pub use entry::{can_compile_locally, resolve_entry_file, resolve_target, rust_target_triple};
+pub use launch::{launch, launch_ios_device, launch_ios_simulator, launch_native};
 pub use metadata::{
-    auto_export_p12, build_device_credentials, detect_signing_identity,
-    find_development_provisioning_profile, find_project_root, is_development_profile,
-    read_app_metadata, read_perry_toml_ios,
+    build_device_credentials, find_project_root, read_app_metadata, read_perry_toml_ios,
 };
-pub use remote::{
-    bundle_project_resources, copy_dir_recursive, embed_app_icon, extract_app_from_ipa,
-    find_icon_source, remote_build_and_launch,
-};
+pub use remote::{copy_dir_recursive, remote_build_and_launch};
 pub use resign::{
-    create_dev_profile_via_api, embed_profile_and_sign, find_dev_identity_for_team,
-    find_identity_for_team, find_system_dev_profile, generate_asc_jwt, read_bundle_id_from_app,
-    read_ios_app_group_from_toml, read_ios_push_notifications_from_toml, resign_for_development,
-    try_sign_existing_dev_profile,
+    create_dev_profile_via_api, read_ios_app_group_from_toml,
+    read_ios_push_notifications_from_toml, resign_for_development, try_sign_existing_dev_profile,
 };
 
 #[derive(Args, Debug)]

--- a/crates/perry/src/commands/run/remote.rs
+++ b/crates/perry/src/commands/run/remote.rs
@@ -456,7 +456,7 @@ pub async fn remote_build_and_launch(
         }
     } else if target == "android" {
         let serial = device_udid.ok_or_else(|| anyhow!("No Android device serial — use perry run android with a connected device or emulator"))?;
-        install_and_launch_android(&dest, &bundle_id, &serial, format)
+        install_and_launch_android(&dest, &bundle_id, serial, format)
     } else {
         // Native binary
         launch_native(&dest, program_args, format)

--- a/crates/perry/src/commands/run/resign.rs
+++ b/crates/perry/src/commands/run/resign.rs
@@ -397,7 +397,7 @@ pub async fn create_dev_profile_via_api(
         first["id"].as_str().unwrap_or("").to_string()
     } else {
         // Create App ID
-        let app_name = bundle_id.split('.').last().unwrap_or("app");
+        let app_name = bundle_id.split('.').next_back().unwrap_or("app");
         let resp = client
             .post(format!("{base}/bundleIds"))
             .bearer_auth(&token)

--- a/crates/perry/src/commands/setup/android.rs
+++ b/crates/perry/src/commands/setup/android.rs
@@ -1,14 +1,8 @@
-use anyhow::{anyhow, bail, Context, Result};
-use clap::Args;
+use anyhow::{bail, Result};
 use console::style;
-use dialoguer::{Confirm, Input, Password, Select};
-use std::path::PathBuf;
-use std::process::Command;
+use dialoguer::{Confirm, Input, Password};
 
-use super::super::publish::{
-    config_path, is_interactive, load_config, save_config, AndroidSavedConfig, AppleSavedConfig,
-    HarmonyosSavedConfig, PerryConfig,
-};
+use super::super::publish::{config_path, AndroidSavedConfig, PerryConfig};
 
 use super::*;
 

--- a/crates/perry/src/commands/setup/common_apple.rs
+++ b/crates/perry/src/commands/setup/common_apple.rs
@@ -1,14 +1,5 @@
-use anyhow::{anyhow, bail, Context, Result};
-use clap::Args;
-use console::style;
-use dialoguer::{Confirm, Input, Password, Select};
-use std::path::PathBuf;
-use std::process::Command;
-
-use super::super::publish::{
-    config_path, is_interactive, load_config, save_config, AndroidSavedConfig, AppleSavedConfig,
-    HarmonyosSavedConfig, PerryConfig,
-};
+use anyhow::{Context, Result};
+use dialoguer::Input;
 
 use super::*;
 

--- a/crates/perry/src/commands/setup/harmonyos.rs
+++ b/crates/perry/src/commands/setup/harmonyos.rs
@@ -1,16 +1,10 @@
-use anyhow::{anyhow, bail, Context, Result};
-use clap::Args;
+use anyhow::{bail, Result};
 use console::style;
 use dialoguer::{Confirm, Input, Password, Select};
 use std::path::PathBuf;
 use std::process::Command;
 
-use super::super::publish::{
-    config_path, is_interactive, load_config, save_config, AndroidSavedConfig, AppleSavedConfig,
-    HarmonyosSavedConfig, PerryConfig,
-};
-
-use super::*;
+use super::super::publish::{config_path, HarmonyosSavedConfig, PerryConfig};
 
 pub fn harmonyos_wizard(saved: &mut PerryConfig) -> Result<()> {
     println!("  {}", style("HarmonyOS Setup").bold());

--- a/crates/perry/src/commands/setup/helpers.rs
+++ b/crates/perry/src/commands/setup/helpers.rs
@@ -1,16 +1,6 @@
-use anyhow::{anyhow, bail, Context, Result};
-use clap::Args;
+use anyhow::{bail, Context, Result};
 use console::style;
-use dialoguer::{Confirm, Input, Password, Select};
-use std::path::PathBuf;
-use std::process::Command;
-
-use super::super::publish::{
-    config_path, is_interactive, load_config, save_config, AndroidSavedConfig, AppleSavedConfig,
-    HarmonyosSavedConfig, PerryConfig,
-};
-
-use super::*;
+use dialoguer::Input;
 
 // ---------------------------------------------------------------------------
 // Shared helpers

--- a/crates/perry/src/commands/setup/ios.rs
+++ b/crates/perry/src/commands/setup/ios.rs
@@ -1,13 +1,10 @@
 use anyhow::{anyhow, bail, Context, Result};
-use clap::Args;
 use console::style;
-use dialoguer::{Confirm, Input, Password, Select};
-use std::path::PathBuf;
+use dialoguer::{Confirm, Input, Select};
 use std::process::Command;
 
 use super::super::publish::{
-    config_path, is_interactive, load_config, save_config, AndroidSavedConfig, AppleSavedConfig,
-    HarmonyosSavedConfig, PerryConfig,
+    config_path, is_interactive, save_config, AppleSavedConfig, PerryConfig,
 };
 
 use super::*;

--- a/crates/perry/src/commands/setup/macos.rs
+++ b/crates/perry/src/commands/setup/macos.rs
@@ -1,14 +1,9 @@
-use anyhow::{anyhow, bail, Context, Result};
-use clap::Args;
+use anyhow::{bail, Context, Result};
 use console::style;
-use dialoguer::{Confirm, Input, Password, Select};
-use std::path::PathBuf;
+use dialoguer::{Confirm, Select};
 use std::process::Command;
 
-use super::super::publish::{
-    config_path, is_interactive, load_config, save_config, AndroidSavedConfig, AppleSavedConfig,
-    HarmonyosSavedConfig, PerryConfig,
-};
+use super::super::publish::{config_path, save_config, AppleSavedConfig, PerryConfig};
 
 use super::*;
 

--- a/crates/perry/src/commands/setup/mod.rs
+++ b/crates/perry/src/commands/setup/mod.rs
@@ -24,7 +24,7 @@ mod windows;
 
 // Per-platform wizards — used by `run` below.
 pub(crate) use android::android_wizard;
-pub(crate) use harmonyos::{harmonyos_wizard, prompt_password};
+pub(crate) use harmonyos::harmonyos_wizard;
 pub(crate) use ios::{ios_development_setup, ios_wizard};
 pub(crate) use macos::macos_wizard;
 pub(crate) use tvos::tvos_wizard;
@@ -41,15 +41,8 @@ pub(crate) use helpers::{
 };
 
 // Cert utilities used by macos (re-exported in case any other module wants them).
-pub(crate) use macos::{
-    create_apple_certificate, create_p12_from_cert_content, export_cert_from_keychain,
-    merge_p12_files,
-};
 
 // Per-platform per-bundle-id savers.
-pub(crate) use tvos::save_tvos_bundle_id;
-pub(crate) use visionos::save_visionos_bundle_id;
-pub(crate) use watchos::save_watchos_bundle_id;
 
 use super::publish::{is_interactive, load_config, save_config};
 

--- a/crates/perry/src/commands/setup/tvos.rs
+++ b/crates/perry/src/commands/setup/tvos.rs
@@ -1,14 +1,8 @@
-use anyhow::{anyhow, bail, Context, Result};
-use clap::Args;
+use anyhow::{Context, Result};
 use console::style;
-use dialoguer::{Confirm, Input, Password, Select};
-use std::path::PathBuf;
-use std::process::Command;
+use dialoguer::{Confirm, Input};
 
-use super::super::publish::{
-    config_path, is_interactive, load_config, save_config, AndroidSavedConfig, AppleSavedConfig,
-    HarmonyosSavedConfig, PerryConfig,
-};
+use super::super::publish::{config_path, AppleSavedConfig, PerryConfig};
 
 use super::*;
 

--- a/crates/perry/src/commands/setup/visionos.rs
+++ b/crates/perry/src/commands/setup/visionos.rs
@@ -1,14 +1,8 @@
-use anyhow::{anyhow, bail, Context, Result};
-use clap::Args;
+use anyhow::{Context, Result};
 use console::style;
-use dialoguer::{Confirm, Input, Password, Select};
-use std::path::PathBuf;
-use std::process::Command;
+use dialoguer::{Confirm, Input};
 
-use super::super::publish::{
-    config_path, is_interactive, load_config, save_config, AndroidSavedConfig, AppleSavedConfig,
-    HarmonyosSavedConfig, PerryConfig,
-};
+use super::super::publish::{config_path, AppleSavedConfig, PerryConfig};
 
 use super::*;
 

--- a/crates/perry/src/commands/setup/watchos.rs
+++ b/crates/perry/src/commands/setup/watchos.rs
@@ -1,14 +1,8 @@
-use anyhow::{anyhow, bail, Context, Result};
-use clap::Args;
+use anyhow::{Context, Result};
 use console::style;
-use dialoguer::{Confirm, Input, Password, Select};
-use std::path::PathBuf;
-use std::process::Command;
+use dialoguer::{Confirm, Input};
 
-use super::super::publish::{
-    config_path, is_interactive, load_config, save_config, AndroidSavedConfig, AppleSavedConfig,
-    HarmonyosSavedConfig, PerryConfig,
-};
+use super::super::publish::{config_path, AppleSavedConfig, PerryConfig};
 
 use super::*;
 

--- a/crates/perry/src/commands/setup/windows.rs
+++ b/crates/perry/src/commands/setup/windows.rs
@@ -1,14 +1,7 @@
-use anyhow::{anyhow, bail, Context, Result};
-use clap::Args;
+use anyhow::{bail, Context, Result};
 use console::style;
-use dialoguer::{Confirm, Input, Password, Select};
-use std::path::PathBuf;
+use dialoguer::Confirm;
 use std::process::Command;
-
-use super::super::publish::{
-    config_path, is_interactive, load_config, save_config, AndroidSavedConfig, AppleSavedConfig,
-    HarmonyosSavedConfig, PerryConfig,
-};
 
 use super::*;
 


### PR DESCRIPTION
## Summary
- Applies mechanical `cargo clippy --fix` suggestions in the Perry CLI crate.
- Keeps changes scoped to compile, setup, run, publish, install, and helper command modules.

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p perry`

Remaining warning output is pre-existing warning debt not covered by automatic fixes in this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined build/compile orchestration, module wiring, and internal helper imports.
  * Cleaned up linking flag handling and iOS app bundle assembly details.
  * Simplified internal checks and consistency improvements across build steps.
* **Bug Fixes**
  * Preserved diagnostic collection behavior during compilation and refined audit manifest error handling.
  * Minor correctness tweaks to symbol/scope and generated length calculations.
* **Documentation**
  * Adjusted a tarball-generation comment formatting.

*Note: Changes are internal maintenance with no expected end-user impact.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->