### PR TITLE
Apply automatic clippy fixes in extensions

### DIFF
--- a/crates/perry-container-compose/src/backend.rs
+++ b/crates/perry-container-compose/src/backend.rs
@@ -1831,7 +1831,7 @@ async fn probe_candidate(name: &str) -> std::result::Result<Box<dyn ContainerBac
             let bin = which_bin("podman")?;
             if cfg!(target_os = "macos") {
                 let out = Command::new(&bin)
-                    .args(&["machine", "list", "--format", "json"])
+                    .args(["machine", "list", "--format", "json"])
                     .output()
                     .await
                     .map_err(|_| "podman machine list failed")?;
@@ -1869,7 +1869,7 @@ async fn probe_candidate(name: &str) -> std::result::Result<Box<dyn ContainerBac
         "lima" => {
             let bin = which_bin("limactl")?;
             let out = Command::new(&bin)
-                .args(&["list", "--json"])
+                .args(["list", "--json"])
                 .output()
                 .await
                 .map_err(|_| "limactl list failed")?;

--- a/crates/perry-container-compose/src/installer.rs
+++ b/crates/perry-container-compose/src/installer.rs
@@ -16,6 +16,12 @@ struct InstallOption {
     docs_url: &'static str,
 }
 
+impl Default for BackendInstaller {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl BackendInstaller {
     pub fn new() -> Self {
         let no_prompt = std::env::var("PERRY_NO_INSTALL_PROMPT").is_ok();

--- a/crates/perry-container-compose/src/project.rs
+++ b/crates/perry-container-compose/src/project.rs
@@ -2,8 +2,7 @@ use crate::config::ProjectConfig;
 use crate::error::{ComposeError, Result};
 use crate::types::ComposeSpec;
 use crate::yaml;
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 pub struct ComposeProject {
     pub spec: ComposeSpec,

--- a/crates/perry-container-compose/src/service.rs
+++ b/crates/perry-container-compose/src/service.rs
@@ -1,4 +1,3 @@
-use crate::error::Result;
 use md5::{Digest, Md5};
 
 pub fn generate_name(input: &str) -> String {

--- a/crates/perry-container-compose/src/types.rs
+++ b/crates/perry-container-compose/src/types.rs
@@ -14,7 +14,9 @@ fn yaml_value_to_str(v: &serde_yaml::Value) -> String {
         serde_yaml::Value::Number(n) => n.to_string(),
         serde_yaml::Value::Bool(b) => b.to_string(),
         serde_yaml::Value::Null => String::new(),
-        _ => format!("{}", serde_yaml::to_string(v).unwrap_or_default())
+        _ => serde_yaml::to_string(v)
+            .unwrap_or_default()
+            .to_string()
             .trim()
             .to_owned(),
     }
@@ -754,7 +756,7 @@ impl ComposeSpec {
 
     /// Serialize to YAML.
     pub fn to_yaml(&self) -> Result<String, crate::error::ComposeError> {
-        serde_yaml::to_string(self).map_err(|e| crate::error::ComposeError::ParseError(e))
+        serde_yaml::to_string(self).map_err(crate::error::ComposeError::ParseError)
     }
 
     /// Merge another ComposeSpec into this one (last-writer-wins for all maps).

--- a/crates/perry-container-compose/src/workload.rs
+++ b/crates/perry-container-compose/src/workload.rs
@@ -15,17 +15,17 @@ use tokio::sync::Mutex;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
+#[derive(Default)]
 pub enum RuntimeSpec {
     Oci,
-    Microvm { config: Option<serde_json::Value> },
-    Wasm { module: Option<String> },
+    Microvm {
+        config: Option<serde_json::Value>,
+    },
+    Wasm {
+        module: Option<String>,
+    },
+    #[default]
     Auto,
-}
-
-impl Default for RuntimeSpec {
-    fn default() -> Self {
-        Self::Auto
-    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -308,21 +308,22 @@ impl WorkloadGraphEngine {
             // when the backend supports it we'll route there; until then,
             // returning `BackendNotAvailable` makes the missing capability
             // visible instead of silently dropping the isolation guarantee.
-            if policy.requires_microvm() && !matches!(node.runtime, RuntimeSpec::Microvm { .. }) {
-                if std::env::var("PERRY_ALLOW_UNTRUSTED_SHARED_KERNEL").is_err() {
-                    return Err(ComposeError::BackendNotAvailable {
-                        name: self.backend.backend_name().to_string(),
-                        reason: format!(
-                            "node '{}' has policy tier 'untrusted' which requires \
+            if policy.requires_microvm()
+                && !matches!(node.runtime, RuntimeSpec::Microvm { .. })
+                && std::env::var("PERRY_ALLOW_UNTRUSTED_SHARED_KERNEL").is_err()
+            {
+                return Err(ComposeError::BackendNotAvailable {
+                    name: self.backend.backend_name().to_string(),
+                    reason: format!(
+                        "node '{}' has policy tier 'untrusted' which requires \
                              microVM isolation, but the active backend doesn't \
                              expose one. Either select RuntimeSpec::MicroVm \
                              explicitly on the node or set \
                              PERRY_ALLOW_UNTRUSTED_SHARED_KERNEL=1 to opt out \
                              (NOT recommended for actually-untrusted code).",
-                            node_id
-                        ),
-                    });
-                }
+                        node_id
+                    ),
+                });
             }
 
             let spec = ContainerSpec {

--- a/crates/perry-ext-events/src/error_monitor.rs
+++ b/crates/perry-ext-events/src/error_monitor.rs
@@ -31,10 +31,7 @@ pub(super) unsafe fn dispatch_error_monitor(
     }
     for l in snapshot {
         if l.callback != 0 {
-            let args: &[f64] = match arg.as_ref() {
-                Some(a) => std::slice::from_ref(a),
-                None => &[],
-            };
+            let args: &[f64] = arg.as_slice();
             let _ = call_emitter_listener(handle, l.callback, args);
         }
     }

--- a/crates/perry-ext-events/src/lib.rs
+++ b/crates/perry-ext-events/src/lib.rs
@@ -373,7 +373,7 @@ static EVENT_EMITTERS: OnceLock<Mutex<EventEmitterRegistry>> = OnceLock::new();
 static EVENTS_RUNTIME_HOOKS_REGISTERED: Once = Once::new();
 
 thread_local! {
-    static EVENTS_GC_REGISTERED: std::cell::Cell<bool> = std::cell::Cell::new(false);
+    static EVENTS_GC_REGISTERED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
 fn event_emitters() -> &'static Mutex<EventEmitterRegistry> {

--- a/crates/perry-ext-fastify/src/server.rs
+++ b/crates/perry-ext-fastify/src/server.rs
@@ -512,7 +512,7 @@ pub extern "C" fn js_fastify_has_active() -> i32 {
             // perry-ext-http-server's `server_is_active`).
             if let Ok(guard) = s.upgrade_rx.lock() {
                 if let Some(rx) = guard.as_ref() {
-                    if !rx.is_closed() && rx.len() > 0 {
+                    if !rx.is_closed() && !rx.is_empty() {
                         active = 1;
                     }
                 }

--- a/crates/perry-ext-http/src/agent.rs
+++ b/crates/perry-ext-http/src/agent.rs
@@ -325,10 +325,8 @@ unsafe fn raw_object_ptr_is_null(val_f64: f64) -> bool {
     let upper = bits >> 48;
     if upper >= 0x7FF8 {
         (bits & PTR_MASK) == 0
-    } else if upper == 0 && bits >= 0x10000 {
-        false
     } else {
-        true
+        !(upper == 0 && bits >= 0x10000)
     }
 }
 

--- a/crates/perry-ext-http/src/tls_client.rs
+++ b/crates/perry-ext-http/src/tls_client.rs
@@ -180,11 +180,9 @@ fn collect_pems(v: &serde_json::Value, out: &mut Vec<Vec<u8>>) {
     use serde_json::Value;
     match v {
         Value::String(s) => out.push(s.as_bytes().to_vec()),
-        Value::Object(map) => {
-            if map.get("type").and_then(|t| t.as_str()) == Some("Buffer") {
-                if let Some(data) = map.get("data").and_then(|d| d.as_array()) {
-                    out.push(numeric_array_to_bytes(data));
-                }
+        Value::Object(map) if map.get("type").and_then(|t| t.as_str()) == Some("Buffer") => {
+            if let Some(data) = map.get("data").and_then(|d| d.as_array()) {
+                out.push(numeric_array_to_bytes(data));
             }
         }
         Value::Array(arr) => {

--- a/crates/perry-ext-http/src/validation.rs
+++ b/crates/perry-ext-http/src/validation.rs
@@ -108,7 +108,7 @@ pub(crate) fn validate_client_options(opts: &serde_json::Value, default_protocol
     if let Some(path) = obj.get("path").and_then(|v| v.as_str()) {
         if path.chars().any(|c| {
             let cp = c as u32;
-            cp < 0x21 || cp > 0xff
+            !(0x21..=0xff).contains(&cp)
         }) {
             throw_type_error_with_code(
                 "Request path contains unescaped characters",

--- a/crates/perry-ext-slugify/src/lib.rs
+++ b/crates/perry-ext-slugify/src/lib.rs
@@ -101,11 +101,11 @@ fn slugify_to_string(input: &str, replacement: char, strict: bool) -> String {
                 result.push(replacement);
                 last_was_separator = true;
             }
-        } else if c.is_whitespace() || c == '_' || c == '-' || c == '/' || c == '\\' {
-            if !last_was_separator {
-                result.push(replacement);
-                last_was_separator = true;
-            }
+        } else if (c.is_whitespace() || c == '_' || c == '-' || c == '/' || c == '\\')
+            && !last_was_separator
+        {
+            result.push(replacement);
+            last_was_separator = true;
         }
         // Otherwise the char is stripped silently.
     }

--- a/crates/perry-ext-ws/src/lib.rs
+++ b/crates/perry-ext-ws/src/lib.rs
@@ -416,7 +416,7 @@ pub unsafe extern "C" fn js_ws_on_client_i64(
         entry
             .listeners
             .entry(event_name.clone())
-            .or_insert_with(Vec::new)
+            .or_default()
             .push(callback_ptr);
     }
     // Issue #577 Phase 4 — drain any messages that arrived before this

--- a/crates/perry-ext-zlib/src/lib.rs
+++ b/crates/perry-ext-zlib/src/lib.rs
@@ -149,7 +149,7 @@ pub unsafe extern "C" fn js_zlib_inflate_sync(data_bits: i64) -> *mut BufferHead
 /// `data_value` and `callback_value` are raw NaN-boxed JS values.
 #[no_mangle]
 pub unsafe extern "C" fn js_zlib_gzip(data_value: f64, callback_value: f64) {
-    stream::queue_one_shot_callback(data_value, callback_value, "Gzip", |b| gzip_bytes(b));
+    stream::queue_one_shot_callback(data_value, callback_value, "Gzip", gzip_bytes);
 }
 
 /// `zlib.gunzip(data, callback) -> undefined`.
@@ -158,7 +158,7 @@ pub unsafe extern "C" fn js_zlib_gzip(data_value: f64, callback_value: f64) {
 /// `data_value` and `callback_value` are raw NaN-boxed JS values.
 #[no_mangle]
 pub unsafe extern "C" fn js_zlib_gunzip(data_value: f64, callback_value: f64) {
-    stream::queue_one_shot_callback(data_value, callback_value, "Gunzip", |b| gunzip_bytes(b));
+    stream::queue_one_shot_callback(data_value, callback_value, "Gunzip", gunzip_bytes);
 }
 
 /// `zlib.deflate(data, callback) -> undefined`.
@@ -167,7 +167,7 @@ pub unsafe extern "C" fn js_zlib_gunzip(data_value: f64, callback_value: f64) {
 /// `data_value` and `callback_value` are raw NaN-boxed JS values.
 #[no_mangle]
 pub unsafe extern "C" fn js_zlib_deflate(data_value: f64, callback_value: f64) {
-    stream::queue_one_shot_callback(data_value, callback_value, "Deflate", |b| deflate_bytes(b));
+    stream::queue_one_shot_callback(data_value, callback_value, "Deflate", deflate_bytes);
 }
 
 /// `zlib.inflate(data, callback) -> undefined`.
@@ -176,7 +176,7 @@ pub unsafe extern "C" fn js_zlib_deflate(data_value: f64, callback_value: f64) {
 /// `data_value` and `callback_value` are raw NaN-boxed JS values.
 #[no_mangle]
 pub unsafe extern "C" fn js_zlib_inflate(data_value: f64, callback_value: f64) {
-    stream::queue_one_shot_callback(data_value, callback_value, "Inflate", |b| inflate_bytes(b));
+    stream::queue_one_shot_callback(data_value, callback_value, "Inflate", inflate_bytes);
 }
 
 #[cfg(test)]

--- a/crates/perry-ext-zlib/src/stream.rs
+++ b/crates/perry-ext-zlib/src/stream.rs
@@ -611,7 +611,7 @@ fn stream_write(handle: i64, bytes: &[u8]) {
                 Some(cs) => match cs.write_chunk(bytes) {
                     Ok(()) => {
                         let out = cs.drain();
-                        (!out.is_empty()).then(|| ZlibEvent::Data(handle, out))
+                        (!out.is_empty()).then_some(ZlibEvent::Data(handle, out))
                     }
                     Err(e) => Some(ZlibEvent::Error(handle, e.to_string())),
                 },


### PR DESCRIPTION
## Summary
- Applies mechanical `cargo clippy --fix` suggestions in extension crates and container compose.
- Covers `perry-ext-events`, `perry-ext-fastify`, `perry-ext-http`, `perry-ext-slugify`, `perry-ext-ws`, `perry-ext-zlib`, and `perry-container-compose`.

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p perry-ext-events -p perry-ext-fastify -p perry-ext-http -p perry-ext-slugify -p perry-ext-ws -p perry-ext-zlib -p perry-container-compose`

Remaining warning output is pre-existing warning debt not covered by automatic fixes in this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal code organization and maintainability across core modules through simplified conditional logic, streamlined error handling patterns, and modernized Rust idioms.

* **Chores**
  * Cleaned up unused imports and reorganized import statements for better code structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->