### PR TITLE
fix(hir): pop block scope before for-await early returns (scope leak corrupts module-var bindings)

### DIFF
--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -1400,6 +1400,19 @@ pub(crate) fn lower_stmt_for_of(
         && !is_iterable_typed_array
         && !proven_array;
     if for_of_stmt.is_await && needs_runtime_iterator {
+        // `lower_runtime_for_await_iterator` pushes and pops its own block
+        // scope, so the one opened above (`for_scope_mark`) must be closed
+        // here before delegating — otherwise this early return leaks an
+        // unbalanced `inside_block_scope` increment. That leak persists
+        // across the enclosing function boundary (enter/exit_scope do not
+        // save/restore `inside_block_scope`), so a later module-level
+        // `var X = <expr>` sees `inside_block_scope != 0` and the #1758
+        // pre-registration reuse gate (var_decl.rs) silently allocates a
+        // fresh LocalId instead of reusing the pre-scanned one. A sibling
+        // closure that forward-referenced `X` then binds the orphaned
+        // pre-registration slot (never written) and calling it throws
+        // `value is not a function` (claude-code bundle e8/K8).
+        ctx.pop_block_scope(for_scope_mark);
         return lower_runtime_for_await_iterator(ctx, module, for_of_stmt, arr_expr);
     }
     // #for-of lazy iterator protocol: a generic/untyped iterable (custom

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -1334,6 +1334,14 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                 && !is_iterable_typed_array
                 && !proven_array;
             if for_of_stmt.is_await && needs_runtime_iterator {
+                // `lower_runtime_for_await_iterator_body` opens and closes its
+                // own block scope, so the one pushed above (`for_scope_mark`)
+                // must be popped before this early return — otherwise it leaks
+                // an unbalanced `inside_block_scope` increment that survives the
+                // enclosing function boundary and corrupts the #1758
+                // pre-registration reuse gate for later module-level vars
+                // (see lower/stmt_loops.rs for the full rationale).
+                ctx.pop_block_scope(for_scope_mark);
                 return lower_runtime_for_await_iterator_body(ctx, for_of_stmt, arr_expr);
             }
             // Lazy iterator protocol for generic iterables (see stmt_loops.rs).

--- a/crates/perry/tests/for_await_block_scope_leak.rs
+++ b/crates/perry/tests/for_await_block_scope_leak.rs
@@ -1,0 +1,103 @@
+//! Regression test: a `for await` over an *untyped* async iterable leaked the
+//! lowering context's `inside_block_scope` counter.
+//!
+//! `lower_stmt_for_of` / `lower_body_stmt` open a block scope
+//! (`push_block_scope`) for the loop, but for the async-iterator runtime path
+//! they `return lower_runtime_for_await_iterator(...)` early — and that callee
+//! manages its own block scope, so the scope opened for the loop was never
+//! popped. The +1 leak escaped the enclosing function boundary because
+//! `enter_scope`/`exit_scope` do not save/restore `inside_block_scope`.
+//!
+//! A later module-level `var X = <expr>` then saw `inside_block_scope != 0`, so
+//! the #1758 pre-registration-reuse gate (`destructuring/var_decl.rs`) skipped
+//! reuse and allocated a *fresh* LocalId. The pre-scanned id that a
+//! forward-referencing sibling closure had already bound was orphaned and never
+//! written, so calling that closure's reference threw
+//! `TypeError: value is not a function`.
+//!
+//! This is the wall that blocked the minified `@anthropic-ai/claude-code`
+//! bundle (12 leaked `for await` loops → `inside_block_scope == 12` at the
+//! `e8`/`K8` module-var declarations). Fix: pop the loop's block scope before
+//! the async-iterator early returns.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+#[test]
+fn for_await_does_not_orphan_forward_referenced_module_var() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // `e8` forward-references `K8` (declared later); a `for await` over an
+    // untyped async iterable sits between, leaking the block-scope counter.
+    // Pre-fix, `e8()` read an orphaned (undefined) `K8` slot → "K8 is not a
+    // function"; post-fix it resolves the real wrapper.
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+var L = (q: any, K?: any) => () => (q && (K = q((q = 0) as any)), K);
+async function leak() {
+  for await (const x of (async function* () {})()) { void x; }
+}
+var e8 = L(() => "K8type:" + typeof K8);
+var K8 = L(() => "ok");
+console.log(e8());
+"#,
+    );
+    assert_eq!(stdout, "K8type:function\n");
+}
+
+#[test]
+fn for_await_over_untyped_async_iterable_still_iterates() {
+    // The fix must not break actual async iteration.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+async function main() {
+  async function* gen() { yield 1; yield 2; yield 3; }
+  let sum = 0;
+  for await (const x of (gen() as any)) { sum += x; }
+  console.log("sum", sum);
+}
+main();
+"#,
+    );
+    assert_eq!(stdout, "sum 6\n");
+}


### PR DESCRIPTION
## Symptom

A module-level closure that **forward-references** another module `var`, with a `for await` loop somewhere in between, compiles to code where the closure reads an **orphaned, never-written** slot instead of the variable's real value — so calling it throws `TypeError: value is not a function`. Node runs the same source correctly.

## Root cause

`for await (x of <untyped async iterable>)` is lowered by `lower_stmt_for_of` (`stmt_loops.rs`) and `lower_body_stmt` (`body_stmt.rs`). Both open a loop block scope via `push_block_scope()`, but for the **async-iterator runtime path** they `return lower_runtime_for_await_iterator(...)` early. That callee manages its **own** block scope, so the scope opened for the loop is never popped → `inside_block_scope` leaks **+1** per such loop.

The leak escapes the enclosing function: `enter_scope`/`exit_scope` (`context.rs`) do **not** save/restore `inside_block_scope`. So a later module-level `var X = <expr>` sees `inside_block_scope != 0` and the **#1758 pre-registration-reuse gate** (`destructuring/var_decl.rs:1488`, `scope_depth==0 && inside_block_scope==0`) silently allocates a **fresh** LocalId instead of reusing the pre-scanned one. A sibling closure that already forward-referenced `X` bound the pre-scanned id — now orphaned and never written → "value is not a function".

Verified against the real bundle HIR: the forward-referencing closure read `LocalGet(820)` while `var X` declared `id 18833`; id 820 had no `Let`/`LocalSet` anywhere. Instrumentation showed `inside_block_scope == 12` at the failing var-decls (12 leaked `for await` loops) vs `0` for an earlier, working sibling.

## Fix

Pop the loop's block scope before the async-iterator early `return` at both sites:
- `crates/perry-hir/src/lower/stmt_loops.rs`
- `crates/perry-hir/src/lower_decl/body_stmt.rs`

## Tests

New e2e `crates/perry/tests/for_await_block_scope_leak.rs`:
- `for_await_does_not_orphan_forward_referenced_module_var` — the minimal repro (forward-ref module var across a `for await`); pre-fix throws, post-fix prints `K8type:function`.
- `for_await_over_untyped_async_iterable_still_iterates` — guards that the fix doesn't break iteration (`sum 6`).

Both pass; `cargo test -p perry-hir` passes. Found while compiling the minified `@anthropic-ai/claude-code` bundle (12 leaked `for await` loops were corrupting module-var bindings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Resolved a scoping bug in `for await` loops that caused runtime errors when variables were accessed in certain patterns, particularly with forward-declared variables. This fix ensures proper scope management across loop boundaries.

## Tests
* Added regression tests to verify `for await` loop scope handling works correctly with various variable declaration and reference patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->