### PR TITLE
fix(async): preserve short-circuit when logical RHS contains await (#5434)

### DIFF
--- a/crates/perry-transform/src/async_to_generator.rs
+++ b/crates/perry-transform/src/async_to_generator.rs
@@ -897,11 +897,7 @@ fn logical_rhs_contains_await(expr: &Expr) -> bool {
 /// top-level position the await→yield rewrite expects. Without this lift the
 /// general hoisting walk pulls `right`'s await unconditionally above the
 /// statement, evaluating it even when `left` short-circuits (issue #5434).
-fn lift_logical_with_await_rhs(
-    expr: &mut Expr,
-    next_id: &mut LocalId,
-    hoisted: &mut Vec<Stmt>,
-) {
+fn lift_logical_with_await_rhs(expr: &mut Expr, next_id: &mut LocalId, hoisted: &mut Vec<Stmt>) {
     let temp_id = alloc_local(next_id);
     let owned = std::mem::replace(expr, Expr::LocalGet(temp_id));
     if let Expr::Logical { op, left, right } = owned {

--- a/crates/perry-transform/src/async_to_generator.rs
+++ b/crates/perry-transform/src/async_to_generator.rs
@@ -644,6 +644,15 @@ fn hoist_awaits_in_expr_full(expr: &mut Expr, next_id: &mut LocalId, hoisted: &m
         lift_conditional_with_await_branches(expr, next_id, hoisted);
         return;
     }
+    // A `a || await b()` / `a && await b()` / `a ?? await b()` would
+    // otherwise have the RHS await hoisted unconditionally above the
+    // containing statement, evaluating `b()` even when `a` short-circuits
+    // — breaks JS semantics (issue #5434). Lift it to a guarded if/else
+    // with a temp before the general hoisting walks into it.
+    if matches!(expr, Expr::Logical { .. }) && logical_rhs_contains_await(expr) {
+        lift_logical_with_await_rhs(expr, next_id, hoisted);
+        return;
+    }
     // Recurse into children first (innermost-first hoisting).
     perry_hir::walker::walk_expr_children_mut(expr, &mut |child| {
         hoist_awaits_in_expr_full(child, next_id, hoisted);
@@ -767,6 +776,15 @@ fn hoist_awaits_avoiding_top_level(
         lift_conditional_with_await_branches(expr, next_id, hoisted);
         return;
     }
+    // Top-level logical with an await in the RHS, e.g.
+    // `return a || await b();` — see the matching note in
+    // `hoist_awaits_in_expr_full`. Lift here too so the RHS await ends up
+    // inside a guarded if-branch instead of unconditionally above the
+    // statement (issue #5434).
+    if matches!(expr, Expr::Logical { .. }) && logical_rhs_contains_await(expr) {
+        lift_logical_with_await_rhs(expr, next_id, hoisted);
+        return;
+    }
     // Outer is NOT an await. Children may contain awaits which ARE
     // nested — fully hoist them.
     perry_hir::walker::walk_expr_children_mut(expr, &mut |child| {
@@ -845,6 +863,85 @@ fn lift_conditional_with_await_branches(
             condition: *condition,
             then_branch,
             else_branch: Some(else_branch),
+        });
+    }
+}
+
+/// Returns true if the RIGHT operand of `expr` (assumed `Expr::Logical`)
+/// contains an `Expr::Await`, anywhere except inside nested closures. The
+/// LEFT operand is always evaluated, so an await there is fine to hoist
+/// normally — only a guarded RHS await needs the short-circuit lift.
+fn logical_rhs_contains_await(expr: &Expr) -> bool {
+    if let Expr::Logical { right, .. } = expr {
+        return expr_contains_await(right);
+    }
+    false
+}
+
+/// Replace `left || right` / `left && right` / `left ?? right` (where
+/// `right` contains an await) with `LocalGet(__logic_await_N)`, and emit
+/// before the containing statement:
+///
+///   let __logic_await_N: any;
+///   __logic_await_N = left;
+///   if (<short-circuit guard>) { __logic_await_N = right; }
+///
+/// The guard runs `right` only when `left` does NOT already decide the
+/// result, preserving short-circuit semantics:
+///   ||  →  if (!__logic_await_N)          (left falsy)
+///   &&  →  if (__logic_await_N)           (left truthy)
+///   ??  →  if (__logic_await_N == null)   (left null/undefined)
+///
+/// Awaits inside `left`'s assignment and inside the guarded branch are then
+/// hoisted by the recursive `hoist_awaits_in_stmts` calls so each lands at a
+/// top-level position the await→yield rewrite expects. Without this lift the
+/// general hoisting walk pulls `right`'s await unconditionally above the
+/// statement, evaluating it even when `left` short-circuits (issue #5434).
+fn lift_logical_with_await_rhs(
+    expr: &mut Expr,
+    next_id: &mut LocalId,
+    hoisted: &mut Vec<Stmt>,
+) {
+    let temp_id = alloc_local(next_id);
+    let owned = std::mem::replace(expr, Expr::LocalGet(temp_id));
+    if let Expr::Logical { op, left, right } = owned {
+        hoisted.push(Stmt::Let {
+            id: temp_id,
+            name: format!("__logic_await_{}", temp_id),
+            ty: Type::Any,
+            mutable: true,
+            init: None,
+        });
+
+        // __logic_await_N = left;  — any awaits in `left` are unconditional,
+        // so hoist them normally before the guard.
+        let mut left_stmts = vec![Stmt::Expr(Expr::LocalSet(temp_id, left))];
+        hoist_awaits_in_stmts(&mut left_stmts, next_id);
+        hoisted.extend(left_stmts);
+
+        // Short-circuit guard on the stored left value.
+        let guard = match op {
+            LogicalOp::Or => Expr::Unary {
+                op: UnaryOp::Not,
+                operand: Box::new(Expr::LocalGet(temp_id)),
+            },
+            LogicalOp::And => Expr::LocalGet(temp_id),
+            LogicalOp::Coalesce => Expr::Compare {
+                op: CompareOp::LooseEq,
+                left: Box::new(Expr::LocalGet(temp_id)),
+                right: Box::new(Expr::Null),
+            },
+        };
+
+        // if (guard) { __logic_await_N = right; }  — `right`'s awaits get
+        // hoisted into the branch so they only fire when the guard passes.
+        let mut then_branch = vec![Stmt::Expr(Expr::LocalSet(temp_id, right))];
+        hoist_awaits_in_stmts(&mut then_branch, next_id);
+
+        hoisted.push(Stmt::If {
+            condition: guard,
+            then_branch,
+            else_branch: None,
         });
     }
 }

--- a/test-files/test_gap_logical_await_short_circuit_5434.ts
+++ b/test-files/test_gap_logical_await_short_circuit_5434.ts
@@ -1,0 +1,62 @@
+// Test: `||` / `&&` / `??` short-circuit when the RHS operand contains an
+// `await` (#5434). The async→generator pre-pass hoisted any non-top-level
+// await into a `let __awaitN = await ...` placed *before* the containing
+// statement, which evaluated the guarded RHS eagerly — so a guard clause like
+// `if (!user || !(await verify(user.passwordHash)))` read `user.passwordHash`
+// even when `!user` was already true, throwing on null. The fix lifts a
+// logical whose RHS contains an await into a guarded if/else with a temp, so
+// the RHS await only fires when the LHS does not short-circuit.
+// Validated byte-for-byte against `node --experimental-strip-types`.
+
+let fired = 0;
+async function val(x: number): Promise<number> { fired++; return x; }
+async function tf(b: boolean): Promise<boolean> { fired++; return b; }
+
+async function main(): Promise<void> {
+  // --- the original repro: guard clause never reads the guarded prop ---
+  const user: { passwordHash: string } | null = null;
+  let threw = false;
+  try {
+    const bad = (!user || !(await tf((user as any).passwordHash.length > 0)));
+    console.log("guard ||:", bad); // true
+  } catch { threw = true; }
+  console.log("guard threw:", threw); // false
+
+  // --- || : LHS truthy short-circuits, RHS not fired ---
+  fired = 0;
+  console.log("A", (5 || (await val(9))), "fired", fired); // A 5 fired 0
+  // --- || : LHS falsy fires RHS ---
+  fired = 0;
+  console.log("B", (0 || (await val(9))), "fired", fired); // B 9 fired 1
+  // --- && : LHS falsy short-circuits, RHS not fired ---
+  fired = 0;
+  console.log("C", (0 && (await val(9))), "fired", fired); // C 0 fired 0
+  // --- && : LHS truthy fires RHS ---
+  fired = 0;
+  console.log("D", (5 && (await val(9))), "fired", fired); // D 9 fired 1
+  // --- ?? : LHS non-null short-circuits (falsy-but-defined stays) ---
+  fired = 0;
+  console.log("E", (0 ?? (await val(9))), "fired", fired); // E 0 fired 0
+  // --- ?? : null and undefined both fire RHS ---
+  fired = 0;
+  console.log("F", (null ?? (await val(9))), "fired", fired); // F 9 fired 1
+  fired = 0;
+  console.log("G", (undefined ?? (await val(7))), "fired", fired); // G 7 fired 1
+  // --- await in LHS is always evaluated; RHS still short-circuits ---
+  fired = 0;
+  console.log("H", ((await tf(true)) || (await val(9))), "fired", fired); // H true fired 1
+  // --- chained logicals ---
+  fired = 0;
+  console.log("I", (0 || "" || (await val(3))), "fired", fired); // I 3 fired 1
+  // --- nested logical inside the guarded RHS ---
+  fired = 0;
+  console.log("J", (false || ((await tf(true)) && (await val(2)))), "fired", fired); // J 2 fired 2
+  // --- return position ---
+  console.log("K", await retGuard(null)); // K true
+}
+
+async function retGuard(u: { p: string } | null): Promise<boolean> {
+  return !u || (await tf((u as any).p.length > 0));
+}
+
+void main();


### PR DESCRIPTION
## Summary

Fixes #5434. Logical short-circuit (`||`, `&&`, `??`) was broken when the **right** operand contained an `await`: the RHS was evaluated **eagerly**, even when the LHS already determined the result. Guard clauses like `if (!user || !(await verify(user.passwordHash)))` read `user.passwordHash` despite `!user` being `true` → threw.

## Root cause

The async→generator pre-pass (`crates/perry-transform/src/async_to_generator.rs`) hoists any non-top-level `await` into a `let __awaitN = await …` placed **before** the containing statement, so the generator state-machine transform can split states at it. For `a || (await b())` this pulled `await b()` out unconditionally, defeating short-circuit. (The analogous `cond ? await a : b` case was already handled by the #342 conditional lift.)

## Fix

When a `Expr::Logical` has an await in its RHS, lift it to a temp + guarded `if` before the general hoisting walk reaches it:

```
let __logic_await_N;
__logic_await_N = left;                       // LHS awaits hoisted normally (always evaluated)
if (<guard>) { __logic_await_N = right; }      // RHS awaits hoisted into the branch
```

Guard per operator: `||` → `!t`, `&&` → `t`, `??` → `t == null`. The RHS await now only fires when the LHS does not short-circuit. Applied in both the nested (`hoist_awaits_in_expr_full`) and top-level (`hoist_awaits_avoiding_top_level`) hoist paths.

## Testing

- New gap test `test-files/test_gap_logical_await_short_circuit_5434.ts` — matches `node --experimental-strip-types` byte-for-byte across `||`/`&&`/`??`, short-circuit vs not, LHS awaits, chaining, nesting, and return position.
- Original repro now prints the expected result with no throw.
- Spot-checked the async/await/promise/generator gap-test family: 14/15 pass; the 1 failure (`test_gap_yieldstar_inherited_iterator_this.ts`) is pre-existing on `main` and contains no logical operators.
- `cargo test -p perry-transform` green; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed async-to-generator transformation to preserve JavaScript short-circuit behavior for `||`, `&&`, and `??` when the right-hand side contains `await`. Awaited operations now run only when the logical expression requires them, including guarded cases.

* **Tests**
  * Added a new regression test suite that verifies short-circuiting across multiple scenarios (including chained and nested logicals) and ensures `await` on the RHS is executed only when appropriate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->