### PR TITLE
fix(fetch): register instanceof kind-probe under web-fetch, not http-client (#5433)

### DIFF
--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -3372,8 +3372,11 @@ pub unsafe extern "C" fn js_stdlib_init_dispatch() {
     // They are pointer-tagged small-integer ids, not heap objects, so the
     // runtime can't walk a prototype chain — register a kind-probe so
     // `x instanceof Response` (Hono's route-fallback guard) resolves. Gated on
-    // the same feature as the fetch module itself.
-    #[cfg(feature = "http-client")]
+    // `web-fetch` — the feature that actually compiles the fetch module and
+    // `js_fetch_handle_kind` (since #5174 split `http-client = ["web-fetch"]`,
+    // auto-optimize enables `web-fetch` directly for bare `new Response()`; the
+    // old `http-client` gate left the probe unregistered in that build).
+    #[cfg(feature = "web-fetch")]
     {
         extern "C" {
             fn js_register_fetch_handle_kind_probe(f: unsafe extern "C" fn(usize) -> u8);

--- a/test-files/test_gap_fetch_instanceof_5433.ts
+++ b/test-files/test_gap_fetch_instanceof_5433.ts
@@ -1,0 +1,26 @@
+// Gap test for #5433: `new Response()` / `new Request()` must satisfy
+// `instanceof Response` / `instanceof Request`. The native fetch handles are
+// pointer-tagged small-integer ids (not heap objects), so `instanceof` relies
+// on a registered kind-probe. A feature-gate mismatch (#5174 split
+// `http-client = ["web-fetch"]`) left the probe unregistered in the
+// auto-optimize `web-fetch` build, so the guard below was always false.
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+const r = new Response("hi", { status: 200 });
+console.log("typeof:", typeof r);
+console.log("r instanceof Response:", r instanceof Response);
+console.log("r instanceof Request:", r instanceof Request);
+console.log("r.status:", r.status);
+
+const q = new Request("http://example.com/");
+console.log("q instanceof Request:", q instanceof Request);
+console.log("q instanceof Response:", q instanceof Response);
+
+// The Hono route-fallback idiom: discriminate a `T | Response` union.
+function gate(ok: boolean): string | Response {
+  return ok ? "value" : new Response("denied", { status: 401 });
+}
+const a = gate(false);
+console.log("guard catches Response:", a instanceof Response);
+const b = gate(true);
+console.log("guard passes value:", b instanceof Response);


### PR DESCRIPTION
## Summary

Fixes #5433. `x instanceof Response` (and `Request`/`Headers`/`Blob`) was **always `false`** for the native WHATWG fetch handles, breaking the common `T | Response` union-guard idiom (e.g. Hono route fallbacks: `if (auth instanceof Response) return auth`).

## Root cause

These types aren't heap objects — they're pointer-tagged small-integer registry ids, so the runtime can't walk a prototype chain. `instanceof` instead resolves through a registered kind-probe (`js_fetch_handle_kind`). That probe registration in `common/dispatch.rs` was gated on `#[cfg(feature = "http-client")]`.

Since #5174 split `http-client = ["web-fetch"]`, auto-optimize enables **`web-fetch`** directly for bare `new Response()`/fetch usage and never pulls in the `http-client` umbrella. The fetch module and `js_fetch_handle_kind` are themselves compiled under `web-fetch`, so the probe was compiled out of that build and **never registered** → every `instanceof` against these types returned `false`. Property/method dispatch (`.status`, etc.) kept working because it isn't behind that cfg.

## Fix

Gate the probe registration on `web-fetch` to match the feature that actually compiles the code. `http-client` implies `web-fetch`, so legacy `--features http-client` callers are unaffected.

## Verification

The issue repro now matches Node:

```
typeof r             : object
r instanceof Response: true     (was: false)
r.status             : 200
q instanceof Request : true     (was: false)
```

- New byte-for-byte gap test `test_gap_fetch_instanceof_5433.ts` covering positive **and** negative discrimination across handle kinds (`Response`/`Request` don't cross-match), plus the Hono union-guard idiom — matches `node --experimental-strip-types`.
- Existing fetch gap tests pass unchanged: `test_gap_fetch_reqresp_2640_2643`, `test_gap_fetch_response`, `test_v8_response_request`.

## Out of scope

`r.constructor` / `.constructor.name` for these handles is a **separate, pre-existing gap** (there is no constructor link on the handles at all — no `"constructor"` arm in fetch property dispatch). This PR fixes `instanceof`, which is the reported impact. The constructor link can be addressed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `instanceof` operator behavior for Response and Request objects to ensure correct type checking works properly regardless of how the library is configured.

* **Tests**
  * Added test cases validating that `instanceof` checks work correctly for Response and Request instances, including edge cases with mixed type union patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->