### PR TITLE
fix(class): delete prototype method removes its keys_array field (#5441)

### DIFF
--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -179,12 +179,21 @@ pub extern "C" fn js_object_delete_field(
             }
         }
         // A class-declaration prototype object: instance accessors (`get x()`)
-        // and methods live in the class vtable, not the keys_array, so the scan
-        // below would "succeed vacuously" while the member stayed visible to
-        // hasOwnProperty / getOwnPropertyDescriptor. Record the key as deleted
-        // so those reflective paths agree it is gone (test262 verifyProperty's
+        // live ONLY in the class vtable, so the scan below would "succeed
+        // vacuously" while the accessor stayed visible to hasOwnProperty /
+        // getOwnPropertyDescriptor. Record the key as deleted so those
+        // reflective paths agree it is gone (test262 verifyProperty's
         // `configurable` check: `delete obj[name]` then assert the key absent —
         // class/definition/{getters,setters}-prop-desc).
+        //
+        // Instance METHODS are different: `install_class_decl_prototype_method_fields`
+        // plants each one as a REAL keys_array data field on the prototype
+        // object (writable:true, enumerable:false, configurable:true). Marking
+        // the vtable key deleted is necessary but NOT sufficient — we must also
+        // fall through to the keys scan to drop that real field, or
+        // hasOwnProperty keeps finding the method via `own_key_present` and
+        // verifyProperty fails "m descriptor should be configurable" (#5441,
+        // ~760 generated language/{statements,expressions}/class tests).
         if let Some(cid) = super::class_registry::class_id_for_decl_prototype_object(obj as usize) {
             if let Some(name) = super::has_own_helpers::str_from_string_header(key) {
                 if name != "constructor"
@@ -192,7 +201,9 @@ pub extern "C" fn js_object_delete_field(
                         || super::native_module::class_has_own_method(cid, name))
                 {
                     super::class_registry::class_mark_key_deleted(cid, name);
-                    return 1;
+                    // Accessors have no keys_array entry, so the scan below is a
+                    // vacuous success for them; methods DO, so fall through to
+                    // remove it. Either way, don't early-return.
                 }
             }
         }


### PR DESCRIPTION
## Summary
Fixes #5441 — the ~760 generated `language/{statements,expressions}/class` test262 cases that regressed to `Uncaught exception: m descriptor should be configurable` (language parity 94.5% → 89.3%).

## Root cause
The regression came from #5395. That PR made `delete C.prototype.<member>` on a class-declaration prototype mark the vtable key deleted and **early-return**, so `hasOwnProperty` / `getOwnPropertyDescriptor` would agree the member is gone.

That is correct for instance **accessors** (`get x()`) — they live only in the class vtable, with no `keys_array` entry to remove (the cases #5395 actually tested).

Instance **methods** are different: `install_class_decl_prototype_method_fields` plants each method as a **real `keys_array` data field** on the prototype object (`writable:true, enumerable:false, configurable:true`). For a method the early return marked the vtable key deleted but left the real field in place, so `hasOwnProperty` kept finding it via `own_key_present`. test262's `verifyProperty` configurable probe (`delete obj[name]` then assert the key absent) therefore failed with `m descriptor should be configurable`.

This is why isolated `getOwnPropertyDescriptor` looked fine but the full `verifyProperty` path (used by the `flags: [generated]` class tests) failed.

## Fix
Drop the early `return 1` so the class-prototype delete falls through to the existing `keys_array` scan:
- **accessors** → scan is a vacuous success (no entry), key stays marked deleted — unchanged behavior;
- **methods** → scan removes the real field, and the key is still marked deleted — now invisible to both reflective paths.

One-file change in `crates/perry-runtime/src/object/delete_rest.rs`.

## Validation (test262 radar, node v26)
| dir | parity | `descriptor should be configurable` failures |
|---|---|---|
| `language/statements/class` | 94.0% | 0 |
| `language/expressions/class` | 95.6% | 0 |

- The specific generated repro (`new-no-sc-line-method-rs-privatename-identifier-alt.js`, which also checks `writable:true`) now passes.
- Accessor `definition/{getters,setters}-prop-desc` tests (#5395's targets) still pass — no regression.
- `cargo test -p perry-runtime`: 1063 passed; the 2 failures are pre-existing/environmental (the known stream test-isolation flake and a cwd-dependent URL test that trips inside a worktree path), not related to this change.

Class-tail tracker: #5345.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incomplete property deletion behavior where certain class methods and accessors were not being fully removed from objects, improving consistency in deletion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->