### PR TITLE
fix(sharp): toBuffer() resolves a real Buffer instead of a base64 string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+## v0.5.1190 — fix(sharp): `toBuffer()` resolves a real Buffer instead of a base64 string
+
+`sharp().toBuffer()` now resolves its Promise with a real Node `Buffer` (binary
+bytes) instead of a base64-encoded **string**. The previous behavior silently
+corrupted output for the common `img.toBuffer().then(b => res.end(b))` /
+`fs.writeFile(p, await img.toBuffer())` pattern — callers got base64 text where
+they expected raw image bytes.
+
+- `crates/perry-ext-sharp/src/lib.rs`: `js_sharp_to_buffer` encodes the image in the
+  `spawn_blocking` worker (pure-Rust, off the main thread) and resolves via
+  `JsPromise::resolve_with(|| JsValue::from_object_ptr(alloc_buffer(&bytes)))`. The
+  Buffer is allocated on the **main thread** inside the deferred `resolve_with`
+  closure — allocating it in the blocking-pool worker would dangle once that thread
+  idles (the runtime arena is thread-local, #1824). Dropped the now-unused `base64`
+  dependency. Verified against the existing `perry-ext-sharp` unit suite (6/6).
+
+Follow-ups uncovered while validating this (NOT in scope here — each needs its own
+change): real-world sharp chaining (`sharp(input).resize(w,h).jpeg().toBuffer()`) does
+not yet work end-to-end — a native handle returned by a fluent transform is not
+re-registered as a `sharp` instance, so the second method in any chain falls to
+dynamic dispatch (`(number).toBuffer is not a function`). This is a pre-existing
+type-propagation gap in `register_native_instance` (perry-hir
+`destructuring/var_decl.rs`), which only tags an allowlist of RHS shapes and has no
+general "fluent native method returns a same-module instance" rule. Also pending:
+`.metadata()`/`.toFile()` resolve a JSON **string** rather than an object;
+`sharp(buffer)` Buffer-input factory + `.extract()` (the implemented-but-unreachable
+`from_buffer`/`crop` paths); and de-duplicating the inactive `perry-stdlib/src/sharp.rs`
+copy.
+
 ## v0.5.1189 — feat: synchronous computed `require(expr)` resolves compiled package modules — Tier 2 of #5389
 
 Builds on the Tier 1 ambient `require` (v0.5.1183). A **computed** `require(expr)`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1189
+**Current Version:** 0.5.1190
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5283,7 +5283,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "anyhow",
  "base64",
@@ -5340,14 +5340,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "cc",
  "libc",
@@ -5355,7 +5355,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "anyhow",
  "log",
@@ -5370,7 +5370,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5379,7 +5379,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5387,7 +5387,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "anyhow",
  "base64",
@@ -5419,7 +5419,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5456,14 +5456,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "serde",
  "serde_json",
@@ -5471,7 +5471,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1189"
+version = "0.5.1190"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "anyhow",
  "clap",
@@ -5497,14 +5497,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5512,7 +5512,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5529,7 +5529,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5545,7 +5545,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5571,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5603,14 +5603,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5627,7 +5627,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5639,7 +5639,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "lazy_static",
  "perry-ext-http-server",
@@ -5652,7 +5652,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "bytes",
  "h2",
@@ -5675,7 +5675,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5685,7 +5685,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5696,7 +5696,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5704,7 +5704,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5712,7 +5712,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "bson",
  "futures-util",
@@ -5724,7 +5724,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5734,7 +5734,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5765,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5782,7 +5782,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5790,23 +5790,22 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
- "base64",
  "image",
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5815,7 +5814,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5823,7 +5822,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5833,7 +5832,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5845,7 +5844,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "brotli",
  "flate2",
@@ -5854,7 +5853,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5863,7 +5862,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5881,7 +5880,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5893,7 +5892,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "anyhow",
  "base64",
@@ -5926,7 +5925,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6018,7 +6017,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6028,7 +6027,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6036,14 +6035,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "base64",
  "itoa",
@@ -6060,7 +6059,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6070,7 +6069,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6093,7 +6092,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "base64",
  "block2",
@@ -6109,7 +6108,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "base64",
  "block2",
@@ -6124,7 +6123,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1189"
+version = "0.5.1190"
 
 [[package]]
 name = "perry-ui-test"
@@ -6132,11 +6131,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1189"
+version = "0.5.1190"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "base64",
  "block2",
@@ -6152,7 +6151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "base64",
  "block2",
@@ -6168,7 +6167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "block2",
  "libc",
@@ -6181,7 +6180,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "base64",
  "libc",
@@ -6198,14 +6197,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6219,7 +6218,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1189"
+version = "0.5.1190"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ strip = false
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1189"
+version = "0.5.1190"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-ext-sharp/Cargo.toml
+++ b/crates/perry-ext-sharp/Cargo.toml
@@ -11,7 +11,6 @@ crate-type = ["staticlib", "rlib"]
 [dependencies]
 perry-ffi.workspace = true
 image = "0.25"
-base64 = "0.22"
 
 [dev-dependencies]
 perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-sharp/src/lib.rs
+++ b/crates/perry-ext-sharp/src/lib.rs
@@ -4,11 +4,10 @@
 //! async exports (`toFile` / `toBuffer` / `metadata`) bridged
 //! through `spawn_blocking` + `JsPromise`.
 
-use base64::Engine;
 use image::{imageops::FilterType, DynamicImage, GenericImageView, ImageFormat};
 use perry_ffi::{
-    alloc_string, get_handle, read_bytes, read_string, register_handle, spawn_blocking, Handle,
-    JsPromise, JsString, Promise, StringHeader,
+    alloc_buffer, alloc_string, get_handle, read_bytes, read_string, register_handle,
+    spawn_blocking, Handle, JsPromise, JsString, JsValue, Promise, StringHeader,
 };
 use std::io::Cursor;
 
@@ -288,8 +287,19 @@ pub extern "C" fn js_sharp_to_buffer(handle: Handle) -> *mut Promise {
             match sharp.image.write_to(&mut buffer, sharp.format) {
                 Ok(_) => {
                     let bytes = buffer.into_inner();
-                    let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
-                    promise.resolve_string(&encoded);
+                    // Resolve with a REAL Node `Buffer` of the encoded image
+                    // bytes. The Buffer must be allocated on the MAIN thread —
+                    // the runtime arena is thread-local, so allocating it here
+                    // on the blocking-pool thread would dangle once this thread
+                    // idles (#1824). `resolve_with` defers construction to the
+                    // resolution pump on the main thread. Previously this
+                    // base64-encoded the bytes into a string, which silently
+                    // corrupted binary output for the common
+                    // `.toBuffer().then(b => res.end(b))` pattern.
+                    promise.resolve_with(move || {
+                        let buf = alloc_buffer(&bytes);
+                        JsValue::from_object_ptr(buf)
+                    });
                 }
                 Err(e) => promise.reject_string(&format!("Failed to encode image: {}", e)),
             }


### PR DESCRIPTION
## Problem

`sharp().toBuffer()` resolved its Promise with a **base64-encoded string** instead of a real Node `Buffer`. This silently corrupted output for the most common sharp usage:

```ts
res.end(await sharp(input).toBuffer());          // wrote base64 text
fs.writeFileSync(out, await sharp(input).toBuffer()); // wrote base64 text
```

Callers got base64 characters where they expected raw image bytes.

## Fix

`js_sharp_to_buffer` (`crates/perry-ext-sharp/src/lib.rs`) now:
- encodes the image in the `spawn_blocking` worker (pure-Rust, off the main thread), then
- resolves via `resolve_with(|| JsValue::from_object_ptr(alloc_buffer(&bytes)))`.

The Buffer is allocated on the **main thread** inside the deferred `resolve_with` closure — allocating it in the blocking-pool worker would dangle once that thread idles (the runtime arena is thread-local, #1824). This mirrors the established pattern in `perry-ext-fetch` (`alloc_buffer` + `from_object_ptr`) and `perry-ext-mysql2` (`resolve_with` deferral).

Dropped the now-unused `base64` dependency from the crate.

## Validation

- `perry-ext-sharp` unit suite: **6/6 pass**.
- e2e: `sharp('/tmp/in.png').toBuffer()` → `Buffer.isBuffer` **true**, PNG magic bytes **137 80 78 71** (a base64 string would index as `105`/'i'), and `fs.writeFileSync(p, buf)` produces a file `file(1)` reports as valid `PNG image data, 8 x 8, 8-bit/color RGBA`.

## Not in scope (follow-ups uncovered while validating)

- **Chained sharp doesn't work e2e** — `sharp(input).resize(w,h).jpeg().toBuffer()` throws `(number).toBuffer is not a function`. A native handle returned by a fluent transform isn't re-registered as a `sharp` instance, so the 2nd method in any chain falls to dynamic dispatch. Pre-existing type-propagation gap in `register_native_instance` (perry-hir `destructuring/var_decl.rs`), which only tags an allowlist of RHS shapes. Tracked separately.
- `.metadata()`/`.toFile()` resolve a JSON **string** rather than an object.
- `sharp(buffer)` Buffer-input factory + `.extract()` (implemented-but-unreachable `from_buffer`/`crop`).
- De-dup the inactive `perry-stdlib/src/sharp.rs` copy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `sharp().toBuffer()` to return a binary Buffer instead of a base64-encoded string.

* **Chores**
  * Removed unused base64 dependency.
  * Version bumped to 0.5.1190.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->