### PR TITLE
fix(native): chained fluent method calls keep their module identity (sharp pipelines)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,38 @@
+## v0.5.1191 — fix(native): chained fluent method calls keep their module identity (sharp pipelines)
+
+Real-world sharp usage chains: `sharp(input).resize(w, h).jpeg().toBuffer()`. Before
+this, only the *first* method dispatched natively — the handle returned by a fluent
+transform lost its `sharp` identity, so the second link fell to dynamic dispatch and
+threw `(number).toBuffer is not a function`. Now the full chain works at any depth, in
+sync and async functions, awaited or not.
+
+Root cause: a native method whose receiver is itself a chained native call. The codegen
+chain-dispatch helper `try_lower_native_chain_method_call`
+(`crates/perry-codegen/src/lower_call/early_branches.rs`, #1113) only recognized a
+receiver that was *directly* a `NativeMethodCall` node. For `a().b().c()`, the receiver
+of `.c()` is a plain `Call { PropertyGet { <b() call>, "c" } }`, not a `NativeMethodCall`,
+so the module wasn't resolved.
+
+Fix: resolve the receiver's module **recursively**. New `native_receiver_module(expr)`
+walks the receiver — a `NativeMethodCall { module }` yields its module directly; a nested
+`Call { PropertyGet { object, property } }` yields `object`'s module iff `(module,
+property)` is a *fluent* method (returns another instance of the same module, per
+`native_method_returns_self_instance`). Each chain link then re-lowers through the same
+native dispatch path, so the fix composes to arbitrary depth and is independent of
+async/await lowering (it operates on the final lowered HIR, unlike the HIR-pass approach,
+which can't see chains buried under `await` after async→generator lowering).
+
+Scope: codegen-only, single file. The fluent allowlist currently covers sharp's
+transforms (`resize`/`rotate`/`flip`/`flop`/`grayscale`/`blur`/`jpeg`/`png`/`webp` + the
+`sharp(...)` factory); terminals (`toBuffer`/`toFile`/`metadata` → Promise,
+`width`/`height` → number) are excluded so they can't masquerade as instances. cheerio is
+unaffected — its chains are already rewritten to nested `NativeMethodCall`s by the HIR
+`fix_local_native_instances` pass, so codegen sees an `NativeMethodCall` receiver directly
+(the recursion's `Call` arm never fires for it). Validated: sync/async × awaited/non-
+awaited × depths up to 4 all produce correct results (incl. JPEG magic `255 216` through
+`resize().jpeg().toBuffer()`); cheerio output unchanged; `perry-codegen` suite green
+(20/20).
+
 ## v0.5.1190 — fix(sharp): `toBuffer()` resolves a real Buffer instead of a base64 string
 
 `sharp().toBuffer()` now resolves its Promise with a real Node `Buffer` (binary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1190
+**Current Version:** 0.5.1191
 
 
 ## TypeScript Parity Status

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ strip = false
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1190"
+version = "0.5.1191"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/lower_call/early_branches.rs
+++ b/crates/perry-codegen/src/lower_call/early_branches.rs
@@ -59,7 +59,7 @@ pub fn try_lower_native_chain_method_call(
     // native module exposes"). Scoped narrowly — falls back to the
     // existing call lowering if the lookup misses.
     if let Expr::PropertyGet { object, property } = callee {
-        if let Expr::NativeMethodCall { module, .. } = object.as_ref() {
+        if let Some(module) = native_receiver_module(object.as_ref()) {
             if super::native_module_lookup(module, true, property, None).is_some() {
                 return Ok(Some(super::lower_native_method_call(
                     ctx,
@@ -73,6 +73,68 @@ pub fn try_lower_native_chain_method_call(
         }
     }
     Ok(None)
+}
+
+/// Resolve the native module a (possibly chained) receiver expression
+/// evaluates to, for native-method chain dispatch (#1113 + fluent chains).
+/// Returns the module name borrowed from `expr`.
+///
+/// - A `NativeMethodCall { module }` is directly that module's value (the
+///   call-site `native_module_lookup` then decides whether the outer
+///   `property` is a real method of it).
+/// - A nested `Call { PropertyGet { object, property } }` is itself a chained
+///   method call: it evaluates to `object`'s module iff that module's
+///   `property` returns another instance of the same module (a fluent
+///   transform). This recursion is what lets
+///   `sharp(input).resize(w,h).jpeg().toBuffer()` keep dispatching natively
+///   past the first link instead of falling to the generic
+///   "(number) is not a function" runtime error. cheerio doesn't need it —
+///   its chains are already rewritten to nested `NativeMethodCall`s by the
+///   HIR `fix_local_native_instances` pass, so its receiver is matched by the
+///   `NativeMethodCall` arm directly.
+fn native_receiver_module(expr: &Expr) -> Option<&str> {
+    match expr {
+        Expr::NativeMethodCall { module, .. } => Some(module.as_str()),
+        Expr::Call { callee, .. } => {
+            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+                let module = native_receiver_module(object.as_ref())?;
+                if native_method_returns_self_instance(module, property) {
+                    return Some(module);
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+/// `(module, method)` pairs whose return value is another instance of the
+/// SAME native module — fluent/builder methods that can be chained. Used by
+/// [`native_receiver_module`] to thread a module identity through a chained
+/// call. Terminals are intentionally excluded so a value of a different type
+/// can't masquerade as a same-module instance (sharp `toBuffer`/`toFile`/
+/// `metadata` → Promise, `width`/`height` → number).
+fn native_method_returns_self_instance(module: &str, method: &str) -> bool {
+    match module {
+        // sharp image transforms, plus the factory call itself
+        // (`sharp(input)` lowers to method "default"/"sharp"). Each returns
+        // the Sharp instance for further chaining.
+        "sharp" => matches!(
+            method,
+            "default"
+                | "sharp"
+                | "resize"
+                | "rotate"
+                | "flip"
+                | "flop"
+                | "grayscale"
+                | "blur"
+                | "jpeg"
+                | "png"
+                | "webp"
+        ),
+        _ => false,
+    }
 }
 
 pub fn try_lower_index_get_call(

--- a/crates/perry-codegen/src/lower_call/early_branches.rs
+++ b/crates/perry-codegen/src/lower_call/early_branches.rs
@@ -119,6 +119,19 @@ fn native_method_returns_self_instance(module: &str, method: &str) -> bool {
         // sharp image transforms, plus the factory call itself
         // (`sharp(input)` lowers to method "default"/"sharp"). Each returns
         // the Sharp instance for further chaining.
+        //
+        // This list mirrors the *dispatchable* fluent methods — every name
+        // here also has an instance-returning (`NR_PTR`) row in
+        // `native_table/media.rs`. It is deliberately NOT the full set of
+        // Sharp-returning methods in the sharp API: `sharpen`/`crop` are
+        // implemented in perry-ext-sharp but have no dispatch row yet (and
+        // `crop` should land as sharp's real `.extract({...})` shape), so
+        // they are unreachable from JS. Listing them here without a dispatch
+        // row would be worse than omitting them: `recv.sharpen()` still
+        // wouldn't resolve (native_module_lookup misses), so the chain's
+        // terminal would run on a garbage receiver and reject with "Invalid
+        // sharp handle" instead of a clean "sharpen is not a function". Add
+        // a name here only together with its `media.rs` row.
         "sharp" => matches!(
             method,
             "default"


### PR DESCRIPTION
## Problem

Real-world sharp usage is a chain:

```ts
const buf = await sharp(input).resize(800, 600).jpeg(90).toBuffer();
```

Before this, only the **first** method dispatched natively. The handle returned by a fluent transform lost its `sharp` identity, so the second link fell to dynamic dispatch and threw:

```
TypeError: (number).toBuffer is not a function
```

This made sharp effectively unusable for actual image pipelines (single-method calls like `sharp(p).toBuffer()` worked; anything chained did not).

## Root cause

The codegen chain-dispatch helper `try_lower_native_chain_method_call` (`crates/perry-codegen/src/lower_call/early_branches.rs`, originally #1113) only recognized a receiver that was **directly** a `NativeMethodCall` node. For `a().b().c()`, the receiver of `.c()` is a plain `Call { PropertyGet { <b() call>, "c" } }` — not a `NativeMethodCall` — so the module was never resolved and dispatch fell through.

## Fix

Resolve the receiver's module **recursively**. New `native_receiver_module(expr)`:
- a `NativeMethodCall { module }` → that module directly;
- a nested `Call { PropertyGet { object, property } }` → `object`'s module **iff** `(module, property)` is a *fluent* method (returns another instance of the same module, per `native_method_returns_self_instance`).

Each chain link then re-lowers through the same native dispatch path, so the fix composes to arbitrary depth. It operates on the **final lowered HIR**, so it's independent of async→generator lowering — unlike an HIR-pass approach, which can't see chains buried under `await` (I tried that first; it worked for sync chains but not awaited ones).

## Scope / safety

- **Codegen-only, single file.** No HIR/runtime changes.
- Fluent allowlist currently covers sharp's transforms (`resize`/`rotate`/`flip`/`flop`/`grayscale`/`blur`/`jpeg`/`png`/`webp` + the `sharp(...)` factory). Terminals (`toBuffer`/`toFile`/`metadata` → Promise, `width`/`height` → number) are excluded so they can't masquerade as instances.
- **cheerio is unaffected** — its chains are already rewritten to nested `NativeMethodCall`s by the HIR `fix_local_native_instances` pass, so codegen sees an `NativeMethodCall` receiver directly and the recursion's `Call` arm never fires for it. For all non-sharp, non-NMC receivers `native_receiver_module` returns `None`, i.e. identical behavior to the previous inline match.

## Validation

- Full matrix — sync/async × awaited/non-awaited × depths up to 4 — all correct:
  - `sharp(p).resize(3,7).width()` → 3
  - `sharp(p).resize(9,0).rotate(90).height()` → 9
  - `await sharp(p).resize(5,5).jpeg(90).toBuffer()` → real Buffer, JPEG magic `255 216`
  - `await sharp(p).resize(8,8).grayscale().png().toBuffer()` → valid PNG bytes
- cheerio regression: output unchanged (`$('li').first().text()`, `.length`, `.find().last().text()`).
- `perry-codegen` test suite: **20 passed, 0 failed**.

Builds on #5444 (toBuffer real Buffer). Follow-ups still open: `.metadata()`/`.toFile()` resolve a JSON string rather than an object; `sharp(buffer)` Buffer-input factory; pure-Rust `fast_image_resize` swap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed native code generation for chained fluent method calls to preserve native module identity across arbitrary chain depths, including async/sync and awaited/non-awaited scenarios. This prevents later links in a chain from falling back to dynamic dispatch.
* **Documentation**
  * Updated the changelog entry for the latest release.
  * Updated the current version metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->