### PR TITLE
fix(fetch): copy raw bytes for binary Response bodies (#5435)

### DIFF
--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -164,16 +164,6 @@ fn global_this_fetch_option_string_ptr(init: f64, name: &[u8]) -> *const crate::
     crate::value::js_get_string_pointer_unified(value) as *const crate::StringHeader
 }
 
-fn global_this_body_string_ptr(value: f64) -> *const crate::StringHeader {
-    if matches!(
-        value.to_bits(),
-        crate::value::TAG_UNDEFINED | crate::value::TAG_NULL
-    ) {
-        return std::ptr::null();
-    }
-    crate::value::js_get_string_pointer_unified(value) as *const crate::StringHeader
-}
-
 fn global_this_headers_handle_from_value(value: f64) -> f64 {
     if matches!(
         value.to_bits(),
@@ -237,7 +227,19 @@ pub(crate) extern "C" fn global_this_response_thunk(
     body: f64,
     init: f64,
 ) -> f64 {
-    let body_ptr = global_this_body_string_ptr(body);
+    // Route the body through the registered body-init helper (stdlib
+    // `js_response_body_init_ptr`) so a binary body — Buffer / Uint8Array /
+    // ArrayBuffer — copies its raw bytes instead of being stringified to a
+    // zero-filled payload (#5435). String bodies fall back to the ordinary
+    // coercion. Mirrors the Request thunk's body handling above.
+    let body_ptr = if matches!(
+        body.to_bits(),
+        crate::value::TAG_UNDEFINED | crate::value::TAG_NULL
+    ) {
+        std::ptr::null()
+    } else {
+        super::global_fetch::call_global_body_init_ptr(body)
+    };
     let status = global_this_fetch_option(init, b"status");
     let status = if status.to_bits() == crate::value::TAG_UNDEFINED {
         0.0

--- a/crates/perry-stdlib/src/fetch/dispatch.rs
+++ b/crates/perry-stdlib/src/fetch/dispatch.rs
@@ -30,6 +30,15 @@ use perry_runtime::js_get_string_pointer_unified;
 /// (`c.json`/`c.text`) are unaffected.
 #[no_mangle]
 pub extern "C" fn js_response_body_init_ptr(value: f64) -> i64 {
+    // A binary body — Buffer / Uint8Array / typed array / ArrayBuffer — must
+    // copy its RAW bytes. Such a value is a BufferHeader/TypedArrayHeader
+    // pointer, NOT a StringHeader; passing it straight to `string_from_header`
+    // read the byte length but data at the wrong offset (zero-fill), so the
+    // payload came back all zeroes (#5435). Materialize the bytes into a heap
+    // StringHeader so `js_response_new`'s lossless byte read recovers them.
+    if let Some(bytes) = unsafe { super::body_value_buffer_bytes(value) } {
+        return unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32) } as i64;
+    }
     // A non-integral or out-of-range value can't be a stream, so skip the
     // registry probe for the common cases.
     if value.is_finite()

--- a/crates/perry-stdlib/src/fetch/dispatch.rs
+++ b/crates/perry-stdlib/src/fetch/dispatch.rs
@@ -36,7 +36,7 @@ pub extern "C" fn js_response_body_init_ptr(value: f64) -> i64 {
     // read the byte length but data at the wrong offset (zero-fill), so the
     // payload came back all zeroes (#5435). Materialize the bytes into a heap
     // StringHeader so `js_response_new`'s lossless byte read recovers them.
-    if let Some(bytes) = unsafe { super::body_value_buffer_bytes(value) } {
+    if let Some(bytes) = unsafe { body_value_buffer_bytes(value) } {
         return unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32) } as i64;
     }
     // A non-integral or out-of-range value can't be a stream, so skip the
@@ -55,6 +55,64 @@ pub extern "C" fn js_response_body_init_ptr(value: f64) -> i64 {
         }
     }
     js_get_string_pointer_unified(value)
+}
+
+/// Read a body `*const StringHeader` losslessly as raw bytes (no UTF-8
+/// validation). Mirrors `string_from_header` but never round-trips through
+/// `str::from_utf8`, so a binary body materialized by `js_response_body_init_ptr`
+/// (a Buffer / Uint8Array / ArrayBuffer copied verbatim into a StringHeader)
+/// keeps every byte instead of being dropped when the bytes aren't valid UTF-8.
+/// Refs #5435. `None` for a null/sub-page pointer (no body).
+pub(crate) unsafe fn body_bytes_from_header(ptr: *const StringHeader) -> Option<Vec<u8>> {
+    if ptr.is_null() || (ptr as usize) < 0x1000 {
+        return None;
+    }
+    let len = (*ptr).byte_len as usize;
+    let data_ptr = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+    Some(std::slice::from_raw_parts(data_ptr, len).to_vec())
+}
+
+/// If `value` is a binary body — a typed array, Buffer/Uint8Array, or
+/// ArrayBuffer — return a copy of its raw bytes; `None` for anything else
+/// (strings, stream handles, numbers) so callers fall back to string coercion.
+///
+/// A typed array / buffer is laid out as `BufferHeader` (length at offset 0,
+/// data at offset 8) or `TypedArrayHeader`, NOT `StringHeader` (data at offset
+/// 20). Feeding such a pointer straight to `string_from_header` read the byte
+/// length correctly but the data at the wrong offset — zero-filled padding —
+/// so `new Response(new Uint8Array([1,2,3]))` came back all zeroes (#5435).
+/// Materializing the real bytes here lets the body round-trip byte-for-byte.
+pub(crate) unsafe fn body_value_buffer_bytes(value: f64) -> Option<Vec<u8>> {
+    let jsval = JSValue::from_bits(value.to_bits());
+    // A typed array / Buffer / ArrayBuffer body is a POINTER_TAG value; decode
+    // it via the shared `JSValue` accessors rather than reconstructing the tag
+    // mask here. A raw untagged heap pointer (no NaN-box tag) is also accepted.
+    // A string body is STRING_TAG, so `is_pointer()` is false and it falls
+    // through to the ordinary string coercion.
+    let addr = if jsval.is_pointer() {
+        jsval.as_pointer::<u8>() as usize
+    } else {
+        let bits = value.to_bits();
+        if (bits >> 48) == 0 && bits >= 0x10000 {
+            bits as usize
+        } else {
+            return None;
+        }
+    };
+    if addr < 0x1000 {
+        return None;
+    }
+    if perry_runtime::typedarray::lookup_typed_array_kind(addr).is_some() {
+        let ta = addr as *const perry_runtime::typedarray::TypedArrayHeader;
+        return perry_runtime::typedarray::typed_array_bytes(ta).map(|b| b.to_vec());
+    }
+    if perry_runtime::buffer::is_registered_buffer(addr) {
+        let ptr = addr as *const perry_runtime::buffer::BufferHeader;
+        let len = (*ptr).length as usize;
+        let data = perry_runtime::buffer::buffer_data(ptr);
+        return Some(std::slice::from_raw_parts(data, len).to_vec());
+    }
+    None
 }
 
 lazy_static::lazy_static! {

--- a/crates/perry-stdlib/src/fetch/mod.rs
+++ b/crates/perry-stdlib/src/fetch/mod.rs
@@ -197,6 +197,60 @@ pub(crate) unsafe fn string_from_header(ptr: *const StringHeader) -> Option<Stri
     std::str::from_utf8(bytes).ok().map(|s| s.to_string())
 }
 
+/// Read a body `*const StringHeader` losslessly as raw bytes (no UTF-8
+/// validation). Mirrors `string_from_header` but never round-trips through
+/// `str::from_utf8`, so a binary body materialized by `js_response_body_init_ptr`
+/// (a Buffer / Uint8Array / ArrayBuffer copied verbatim into a StringHeader)
+/// keeps every byte instead of being dropped when the bytes aren't valid UTF-8.
+/// Refs #5435. `None` for a null/sub-page pointer (no body).
+pub(crate) unsafe fn body_bytes_from_header(ptr: *const StringHeader) -> Option<Vec<u8>> {
+    if ptr.is_null() || (ptr as usize) < 0x1000 {
+        return None;
+    }
+    let len = (*ptr).byte_len as usize;
+    let data_ptr = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
+    Some(std::slice::from_raw_parts(data_ptr, len).to_vec())
+}
+
+/// If `value` is a binary body — a typed array, Buffer/Uint8Array, or
+/// ArrayBuffer — return a copy of its raw bytes; `None` for anything else
+/// (strings, stream handles, numbers) so callers fall back to string coercion.
+///
+/// A typed array / buffer is laid out as `BufferHeader` (length at offset 0,
+/// data at offset 8) or `TypedArrayHeader`, NOT `StringHeader` (data at offset
+/// 20). Feeding such a pointer straight to `string_from_header` read the byte
+/// length correctly but the data at the wrong offset — zero-filled padding —
+/// so `new Response(new Uint8Array([1,2,3]))` came back all zeroes (#5435).
+/// Materializing the real bytes here lets the body round-trip byte-for-byte.
+pub(crate) unsafe fn body_value_buffer_bytes(value: f64) -> Option<Vec<u8>> {
+    let bits = value.to_bits();
+    // Buffers / typed arrays are POINTER_TAG (0x7FFD); also accept a raw
+    // untagged heap pointer. STRING_TAG (0x7FFF) is deliberately excluded so a
+    // string body never takes this path.
+    let top = bits >> 48;
+    let addr = if top == 0x7FFD {
+        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
+    } else if top == 0 && bits >= 0x10000 {
+        bits as usize
+    } else {
+        return None;
+    };
+    if addr < 0x1000 {
+        return None;
+    }
+    if perry_runtime::typedarray::lookup_typed_array_kind(addr).is_some() {
+        let ta = addr as *const perry_runtime::typedarray::TypedArrayHeader;
+        return perry_runtime::typedarray::typed_array_bytes(ta).map(|b| b.to_vec());
+    }
+    if perry_runtime::buffer::is_registered_buffer(addr) {
+        let ptr = addr as *const perry_runtime::buffer::BufferHeader;
+        let len = (*ptr).length as usize;
+        let data = perry_runtime::buffer::buffer_data(ptr);
+        return Some(std::slice::from_raw_parts(data, len).to_vec());
+    }
+    None
+}
+
 /// Diagnostic: return the number of FETCH_RESPONSES entries.
 /// Useful for detecting response handle leaks in long-running services.
 #[no_mangle]
@@ -1217,10 +1271,13 @@ pub unsafe extern "C" fn js_response_new(
     status_text_ptr: *const StringHeader,
     headers_handle: f64,
 ) -> f64 {
-    let body_opt = string_from_header(body_ptr);
+    // Read the body losslessly as raw bytes. A binary body (Buffer /
+    // Uint8Array / ArrayBuffer) is materialized into a StringHeader by
+    // `js_response_body_init_ptr`; reading it via `str::from_utf8` would drop
+    // non-UTF-8 bytes (zero/empty body, #5435), so read the bytes verbatim.
+    let body_opt = body_bytes_from_header(body_ptr);
     let body_present = body_opt.is_some();
-    let body_str = body_opt.unwrap_or_default();
-    let body = body_str.into_bytes();
+    let body = body_opt.unwrap_or_default();
     // NaN / 0.0 are the codegen "no status field" sentinels. Node defaults
     // missing status to 200; any explicit value is truncated toward zero
     // then range-checked against 200..=599 (199.9 → RangeError, 599.9 →

--- a/crates/perry-stdlib/src/fetch/mod.rs
+++ b/crates/perry-stdlib/src/fetch/mod.rs
@@ -197,60 +197,6 @@ pub(crate) unsafe fn string_from_header(ptr: *const StringHeader) -> Option<Stri
     std::str::from_utf8(bytes).ok().map(|s| s.to_string())
 }
 
-/// Read a body `*const StringHeader` losslessly as raw bytes (no UTF-8
-/// validation). Mirrors `string_from_header` but never round-trips through
-/// `str::from_utf8`, so a binary body materialized by `js_response_body_init_ptr`
-/// (a Buffer / Uint8Array / ArrayBuffer copied verbatim into a StringHeader)
-/// keeps every byte instead of being dropped when the bytes aren't valid UTF-8.
-/// Refs #5435. `None` for a null/sub-page pointer (no body).
-pub(crate) unsafe fn body_bytes_from_header(ptr: *const StringHeader) -> Option<Vec<u8>> {
-    if ptr.is_null() || (ptr as usize) < 0x1000 {
-        return None;
-    }
-    let len = (*ptr).byte_len as usize;
-    let data_ptr = (ptr as *const u8).add(std::mem::size_of::<StringHeader>());
-    Some(std::slice::from_raw_parts(data_ptr, len).to_vec())
-}
-
-/// If `value` is a binary body — a typed array, Buffer/Uint8Array, or
-/// ArrayBuffer — return a copy of its raw bytes; `None` for anything else
-/// (strings, stream handles, numbers) so callers fall back to string coercion.
-///
-/// A typed array / buffer is laid out as `BufferHeader` (length at offset 0,
-/// data at offset 8) or `TypedArrayHeader`, NOT `StringHeader` (data at offset
-/// 20). Feeding such a pointer straight to `string_from_header` read the byte
-/// length correctly but the data at the wrong offset — zero-filled padding —
-/// so `new Response(new Uint8Array([1,2,3]))` came back all zeroes (#5435).
-/// Materializing the real bytes here lets the body round-trip byte-for-byte.
-pub(crate) unsafe fn body_value_buffer_bytes(value: f64) -> Option<Vec<u8>> {
-    let bits = value.to_bits();
-    // Buffers / typed arrays are POINTER_TAG (0x7FFD); also accept a raw
-    // untagged heap pointer. STRING_TAG (0x7FFF) is deliberately excluded so a
-    // string body never takes this path.
-    let top = bits >> 48;
-    let addr = if top == 0x7FFD {
-        (bits & 0x0000_FFFF_FFFF_FFFF) as usize
-    } else if top == 0 && bits >= 0x10000 {
-        bits as usize
-    } else {
-        return None;
-    };
-    if addr < 0x1000 {
-        return None;
-    }
-    if perry_runtime::typedarray::lookup_typed_array_kind(addr).is_some() {
-        let ta = addr as *const perry_runtime::typedarray::TypedArrayHeader;
-        return perry_runtime::typedarray::typed_array_bytes(ta).map(|b| b.to_vec());
-    }
-    if perry_runtime::buffer::is_registered_buffer(addr) {
-        let ptr = addr as *const perry_runtime::buffer::BufferHeader;
-        let len = (*ptr).length as usize;
-        let data = perry_runtime::buffer::buffer_data(ptr);
-        return Some(std::slice::from_raw_parts(data, len).to_vec());
-    }
-    None
-}
-
 /// Diagnostic: return the number of FETCH_RESPONSES entries.
 /// Useful for detecting response handle leaks in long-running services.
 #[no_mangle]
@@ -1271,11 +1217,8 @@ pub unsafe extern "C" fn js_response_new(
     status_text_ptr: *const StringHeader,
     headers_handle: f64,
 ) -> f64 {
-    // Read the body losslessly as raw bytes. A binary body (Buffer /
-    // Uint8Array / ArrayBuffer) is materialized into a StringHeader by
-    // `js_response_body_init_ptr`; reading it via `str::from_utf8` would drop
-    // non-UTF-8 bytes (zero/empty body, #5435), so read the bytes verbatim.
-    let body_opt = body_bytes_from_header(body_ptr);
+    // Lossless raw-byte read so binary bodies survive byte-for-byte (#5435).
+    let body_opt = dispatch::body_bytes_from_header(body_ptr);
     let body_present = body_opt.is_some();
     let body = body_opt.unwrap_or_default();
     // NaN / 0.0 are the codegen "no status field" sentinels. Node defaults

--- a/test-files/test_gap_response_binary_body_5435.ts
+++ b/test-files/test_gap_response_binary_body_5435.ts
@@ -1,0 +1,29 @@
+// Test new Response(Uint8Array/ArrayBuffer) binary body round-trips (#5435)
+// Expected output:
+// uint8array body bytes: [1,2,3,4,5]
+// arraybuffer body bytes: [1,2,3,4,5]
+// binary body bytes: [255,0,137,80,78,71]
+// string body text: hello
+
+async function main(): Promise<void> {
+  const data = new Uint8Array([1, 2, 3, 4, 5]);
+
+  const rb = new Response(data as BodyInit);
+  const got = new Uint8Array(await rb.arrayBuffer());
+  console.log("uint8array body bytes: " + JSON.stringify(Array.from(got)));
+
+  const ra = new Response(data.buffer as BodyInit);
+  const gotA = new Uint8Array(await ra.arrayBuffer());
+  console.log("arraybuffer body bytes: " + JSON.stringify(Array.from(gotA)));
+
+  // Non-UTF-8 bytes (PNG header-ish) must survive verbatim, not be dropped.
+  const bin = new Uint8Array([255, 0, 137, 80, 78, 71]);
+  const rbin = new Response(bin as BodyInit);
+  const gotBin = new Uint8Array(await rbin.arrayBuffer());
+  console.log("binary body bytes: " + JSON.stringify(Array.from(gotBin)));
+
+  // String bodies must still round-trip unchanged.
+  const rs = new Response("hello");
+  console.log("string body text: " + (await rs.text()));
+}
+void main();


### PR DESCRIPTION
## Summary

Fixes #5435. `new Response(new Uint8Array([...]))` and `new Response(arrayBuffer)` lost their payload — the byte length was preserved but every byte read back as `0`, so any binary HTTP response (e.g. serving an image file) came back zero-filled. String bodies were unaffected.

```ts
const data = new Uint8Array([1, 2, 3, 4, 5]);
const rb = new Response(data);
const got = new Uint8Array(await rb.arrayBuffer());
// before: [0,0,0,0,0]   after: [1,2,3,4,5]
```

## Root cause

The body-init coercion treated the body value as a `*const StringHeader` and read `byte_len` bytes at the StringHeader data offset (20). A `Buffer`/`Uint8Array`/`ArrayBuffer` is a `BufferHeader` (data at offset 8) or `TypedArrayHeader`, so the length read happened to line up (it read the capacity, also 5) but the data read landed on zero-filled padding. And even with the right offset, the downstream `str::from_utf8` body extraction would have dropped any non-UTF-8 bytes — breaking real binary payloads.

## Fix

- `js_response_body_init_ptr` now detects a typed-array / Buffer / ArrayBuffer body and materializes its **raw bytes** into a heap `StringHeader`.
- `js_response_new` reads the body losslessly as raw bytes (no UTF-8 validation), so non-UTF-8 binary survives byte-for-byte.
- The global `Response` constructor thunk routes its body through the same buffer-aware helper instead of the plain string coercion.

## Testing

- New gap test `test-files/test_gap_response_binary_body_5435.ts` matches `node --experimental-strip-types` byte-for-byte (Uint8Array, ArrayBuffer, non-UTF-8 bytes, and string bodies).
- Existing `test_gap_fetch_response` / `test_gap_fetch_reqresp_2640_2643` still match Node.
- `cargo fmt --all -- --check`, the address-classification audit, the GC store-site inventory, and the file-size gate all pass; `cargo test -p perry-stdlib` is green (100 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed binary `Response` body handling so data from `Buffer`, typed arrays, and `ArrayBuffer` round-trips correctly via `arrayBuffer()` with no corruption.
  * Updated `globalThis` fetch/response body initialization to follow the same registered body-init logic as `Request`, avoiding incorrect byte offsets and lossy conversions.

* **Tests**
  * Added coverage for binary `Response` body round-trip across `Uint8Array`, `ArrayBuffer`, and non-UTF8 byte inputs, while keeping string bodies working via `text()`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->