### PR TITLE
fix(ui-ios): #5200 — scrollViewSetOffset binds y, restores without animation

### DIFF
--- a/crates/perry-ui-ios/src/ffi/widgets_basic.rs
+++ b/crates/perry-ui-ios/src/ffi/widgets_basic.rs
@@ -643,8 +643,8 @@ pub extern "C" fn perry_ui_scrollview_get_offset(scroll_handle: i64) -> f64 {
 }
 
 #[no_mangle]
-pub extern "C" fn perry_ui_scrollview_set_offset(scroll_handle: i64, offset: f64) {
-    widgets::scrollview::set_offset(scroll_handle, offset);
+pub extern "C" fn perry_ui_scrollview_set_offset(scroll_handle: i64, x: f64, y: f64) {
+    widgets::scrollview::set_offset(scroll_handle, x, y);
 }
 
 #[no_mangle]

--- a/crates/perry-ui-ios/src/widgets/scrollview.rs
+++ b/crates/perry-ui-ios/src/widgets/scrollview.rs
@@ -190,12 +190,13 @@ pub fn get_offset(scroll_handle: i64) -> f64 {
     }
 }
 
-/// Set the vertical scroll offset.
-pub fn set_offset(scroll_handle: i64, offset: f64) {
+/// Set the scroll offset to (x, y). Used to restore scroll position across
+/// rebuilds, so it must not animate.
+pub fn set_offset(scroll_handle: i64, x: f64, y: f64) {
     if let Some(scroll_view) = super::get_widget(scroll_handle) {
         unsafe {
-            let point = CGPoint::new(0.0, offset);
-            let _: () = msg_send![&*scroll_view, setContentOffset: point, animated: true];
+            let point = CGPoint::new(x, y);
+            let _: () = msg_send![&*scroll_view, setContentOffset: point, animated: false];
         }
     }
 }


### PR DESCRIPTION
Fixes #5200.

## Problem

`scrollViewSetOffset(sv, x, y)` ignored `y` and always used `x`. The shared dispatch row already declares three args (`Widget, F64, F64`):

```rust
// crates/perry-dispatch/src/ui_table.rs
MethodRow { method: "scrollViewSetOffset", runtime: "perry_ui_scrollview_set_offset",
            args: &[ArgKind::Widget, ArgKind::F64, ArgKind::F64], ret: ReturnKind::Void },
```

…but the iOS FFI and impl took a single `offset` and bound it to the **first** f64 (x):

```rust
pub extern "C" fn perry_ui_scrollview_set_offset(scroll_handle: i64, offset: f64) { ... }
pub fn set_offset(scroll_handle: i64, offset: f64) {
    let point = CGPoint::new(0.0, offset);  // offset = x (usually 0) → contentOffset.y = 0
    ...
}
```

So `setContentOffset` received `(0, x)` with x almost always `0`, and any caller doing `scrollViewSetOffset(sv, 0, savedY)` snapped to the top instead of `savedY` — scroll-position restoration broke on every rebuild.

## Fix

Thread both coordinates through the FFI into the impl, and set the offset without animation (this path restores position, so animating is wrong):

```rust
pub extern "C" fn perry_ui_scrollview_set_offset(scroll_handle: i64, x: f64, y: f64) {
    widgets::scrollview::set_offset(scroll_handle, x, y);
}
pub fn set_offset(scroll_handle: i64, x: f64, y: f64) {
    let point = CGPoint::new(x, y);
    let _: () = msg_send![&*scroll_view, setContentOffset: point, animated: false];
}
```

`cargo check -p perry-ui-ios` is clean (only pre-existing warnings).

## Note

The same single-offset signature exists in the other native UI backends (`perry-ui-macos`, `tvos`, `visionos`, `android`, `gtk4`, `windows`) and the JS/wasm runtimes, all fed by the same 3-arg dispatch row — so they share this latent y-ignored bug. This PR is scoped to iOS per the issue; the sibling backends are worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scroll view positioning now supports both horizontal and vertical offsets independently.
  
* **Bug Fixes**
  * Updated scroll view restoration to use non-animated positioning for more reliable scroll behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->