### PR TITLE
fix(ui-ios): #5201 — wire Picker onChange to UISegmentedControl valueChanged

### DIFF
--- a/crates/perry-ui-ios/src/widgets/picker.rs
+++ b/crates/perry-ui-ios/src/widgets/picker.rs
@@ -1,7 +1,7 @@
-use objc2::msg_send;
 use objc2::rc::Retained;
-use objc2::runtime::AnyObject;
-use objc2_foundation::{MainThreadMarker, NSString};
+use objc2::runtime::{AnyObject, Sel};
+use objc2::{define_class, msg_send, AnyThread, DefinedClass};
+use objc2_foundation::{MainThreadMarker, NSObject, NSString};
 use objc2_ui_kit::UIView;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -9,6 +9,88 @@ use std::collections::HashMap;
 thread_local! {
     static PICKER_ITEMS: RefCell<HashMap<i64, Vec<String>>> = RefCell::new(HashMap::new());
     static PICKER_SELECTED: RefCell<HashMap<i64, i64>> = RefCell::new(HashMap::new());
+    static PICKER_CALLBACKS: RefCell<HashMap<usize, f64>> = RefCell::new(HashMap::new());
+}
+
+extern "C" {
+    fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
+    fn js_nanbox_get_pointer(value: f64) -> i64;
+    // dispatch_get_main_queue() is a macro; the actual symbol is _dispatch_main_q
+    static _dispatch_main_q: std::ffi::c_void;
+    fn dispatch_async_f(
+        queue: *const std::ffi::c_void,
+        context: *mut std::ffi::c_void,
+        work: unsafe extern "C" fn(*mut std::ffi::c_void),
+    );
+}
+
+/// Heap payload handed to the main-queue trampoline: the onChange closure and
+/// the segment index selected when the value-changed event fired.
+struct PickerDispatch {
+    closure_f64: f64,
+    index: f64,
+}
+
+unsafe extern "C" fn picker_callback_trampoline(context: *mut std::ffi::c_void) {
+    let _ = std::panic::catch_unwind(|| {
+        let payload = Box::from_raw(context as *mut PickerDispatch);
+        let closure_ptr = js_nanbox_get_pointer(payload.closure_f64);
+        js_closure_call1(closure_ptr as *const u8, payload.index);
+    });
+}
+
+pub struct PerryPickerTargetIvars {
+    callback_key: std::cell::Cell<usize>,
+    handle: std::cell::Cell<i64>,
+}
+
+define_class!(
+    #[unsafe(super(NSObject))]
+    #[name = "PerryPickerTarget"]
+    #[ivars = PerryPickerTargetIvars]
+    pub struct PerryPickerTarget;
+
+    impl PerryPickerTarget {
+        #[unsafe(method(segmentChanged:))]
+        fn segment_changed(&self, sender: &AnyObject) {
+            let key = self.ivars().callback_key.get();
+            let handle = self.ivars().handle.get();
+            PICKER_CALLBACKS.with(|cbs| {
+                if let Some(&closure_f64) = cbs.borrow().get(&key) {
+                    let index: i64 = unsafe { msg_send![sender, selectedSegmentIndex] };
+                    // Keep the cached selection in sync so get_selected() reflects
+                    // a user tap, not just programmatic set_selected().
+                    PICKER_SELECTED.with(|ps| {
+                        ps.borrow_mut().insert(handle, index);
+                    });
+                    // Dispatch async to the main queue so the JS runtime isn't
+                    // re-entered synchronously inside UIKit's valueChanged
+                    // processing (mirrors the button path; avoids iOS-26 crashes).
+                    let payload = Box::new(PickerDispatch {
+                        closure_f64,
+                        index: index as f64,
+                    });
+                    unsafe {
+                        dispatch_async_f(
+                            &_dispatch_main_q as *const _ as *const std::ffi::c_void,
+                            Box::into_raw(payload) as *mut std::ffi::c_void,
+                            picker_callback_trampoline,
+                        );
+                    }
+                }
+            });
+        }
+    }
+);
+
+impl PerryPickerTarget {
+    fn new() -> Retained<Self> {
+        let this = Self::alloc().set_ivars(PerryPickerTargetIvars {
+            callback_key: std::cell::Cell::new(0),
+            handle: std::cell::Cell::new(0),
+        });
+        unsafe { msg_send![super(this), init] }
+    }
 }
 
 fn str_from_header(ptr: *const u8) -> &'static str {
@@ -30,9 +112,23 @@ pub fn create(_label_ptr: *const u8, _on_change: f64, _style: i64) -> i64 {
         let obj: *mut AnyObject = msg_send![seg_cls, alloc];
         let obj: *mut AnyObject = msg_send![obj, init];
         let view: Retained<UIView> = Retained::retain(obj as *mut UIView).unwrap();
-        let handle = super::register_widget(view);
+        let handle = super::register_widget(view.clone());
         PICKER_ITEMS.with(|pi| pi.borrow_mut().insert(handle, Vec::new()));
         PICKER_SELECTED.with(|ps| ps.borrow_mut().insert(handle, 0));
+
+        // Wire the segmented control's valueChanged event to the onChange
+        // callback. Without this the picker is inert for real users — tapping a
+        // segment does nothing (#5201).
+        let target = PerryPickerTarget::new();
+        let target_addr = Retained::as_ptr(&target) as usize;
+        target.ivars().callback_key.set(target_addr);
+        target.ivars().handle.set(handle);
+        PICKER_CALLBACKS.with(|c| c.borrow_mut().insert(target_addr, _on_change));
+        let sel = Sel::register(c"segmentChanged:");
+        // UIControlEventValueChanged = 1 << 12 = 4096
+        let _: () = msg_send![&*view, addTarget: &*target, action: sel, forControlEvents: 4096u64];
+        std::mem::forget(target);
+
         #[cfg(feature = "geisterhand")]
         {
             extern "C" {


### PR DESCRIPTION
Fixes #5201.

## Problem

`Picker(onChange)` on iOS never invoked its callback when the user tapped a segment. The picker is a `UISegmentedControl`, but `create()` only registered the callback with the geisterhand test harness — it never called `addTarget:action:forControlEvents:UIControlEventValueChanged`, so for real users selecting a value did nothing.

## Fix

Add a `PerryPickerTarget` (mirroring `PerryToggleTarget`) wired to the control's `valueChanged` event. Its `segmentChanged:` action reads `selectedSegmentIndex` and invokes the JS `onChange` with the index.

The closure is dispatched **async to the main queue** via `dispatch_async_f` — the same pattern the button path uses — so the JS runtime isn't re-entered synchronously inside UIKit's valueChanged processing (avoids the iOS-26 view-hierarchy-mutation crashes documented on the button path). A small `PickerDispatch` payload (closure + index) is boxed across the async hop.

Also updates the cached `PICKER_SELECTED` on a user tap so `get_selected()` stays consistent with programmatic `set_selected()`.

`cargo check -p perry-ui-ios` is clean (only pre-existing warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized iOS picker widget callback handling mechanism for improved event dispatch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->