### PR TITLE
fix(hir): read prototype/__proto__/constructor on native instances as property GET, not method call

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -1146,6 +1146,30 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
         if let Some((module_name, class_name)) = native_instance {
             if let ast::MemberProp::Ident(prop_ident) = &member.prop {
                 let property_name = prop_ident.sym.to_string();
+                // #wall (follow-redirects): JS object-metadata / prototype-chain
+                // properties are never native instance methods/getters. Reading
+                // `inst.prototype` / `inst.__proto__` / `inst.constructor` on a
+                // value the HIR tagged as a native instance (e.g. `const lN =
+                // Readable.from(...)`) must NOT route to the 0-arg
+                // NativeMethodCall fallback below — that lowers to
+                // `js_native_call_method_nullsafe(inst, "prototype", 0 args)`,
+                // which *invokes* the resolved value → `TypeError: prototype is
+                // not a function`. Node returns the real metadata value (e.g.
+                // `undefined` for an instance's `.prototype`). Lower these as a
+                // plain PropertyGet so the runtime reads the property instead of
+                // calling it. (`constructor` for the bare-stream classes is also
+                // remapped to the module export above; this catches the general
+                // case for every other native-instance module/class.)
+                if matches!(
+                    property_name.as_str(),
+                    "prototype" | "__proto__" | "constructor"
+                ) {
+                    let object_expr = lower_expr(ctx, &member.obj)?;
+                    return Ok(Expr::PropertyGet {
+                        object: Box::new(object_expr),
+                        property: property_name,
+                    });
+                }
                 // Issue #562: stream subclass instances (e.g.
                 // `class W extends WritableStream`) carry the bare-stream
                 // module/class tag for inherited-method dispatch

--- a/crates/perry/tests/native_instance_prototype_read.rs
+++ b/crates/perry/tests/native_instance_prototype_read.rs
@@ -1,0 +1,76 @@
+//! Regression test: reading object-metadata properties (`prototype`,
+//! `__proto__`, `constructor`) on a value the HIR tagged as a *native
+//! instance* must be a property GET, not an invoking native method call.
+//!
+//! `const lN = Readable.from([...])` tags `lN` as a `stream`/`Readable`
+//! native instance. Pre-fix, `lN.prototype` fell through to the 0-arg
+//! `NativeMethodCall` fallback, lowering to
+//! `js_native_call_method_nullsafe(lN, "prototype", 0 args)` — which
+//! *invokes* the resolved prototype value → `TypeError: prototype is not a
+//! function`. Node returns the real metadata (`undefined` for an instance's
+//! `.prototype`).
+//!
+//! This is the wall that blocked `claude-code --help` (the bundled
+//! follow-redirects `RedirectableRequest` hits the same native-instance
+//! mis-classification when reading `lN.prototype` to attach methods).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+#[test]
+fn native_instance_prototype_read_is_a_property_get() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+import { Readable } from "stream";
+const lN: any = Readable.from(["a", "b"]);
+// `.prototype` / `.constructor` / `.__proto__` are metadata reads, not calls.
+console.log("prototype:", typeof lN.prototype);
+console.log("constructor-is-fn:", typeof lN.constructor === "function");
+console.log("ok");
+"#,
+    );
+    assert_eq!(
+        stdout, "prototype: undefined\nconstructor-is-fn: true\nok\n",
+        "metadata property reads on a native instance must not be invoked"
+    );
+}


### PR DESCRIPTION
## Symptom

`claude-code --help` (and interactive mode) threw `TypeError: value is not a function` during the bundled **follow-redirects** HTTP module init. `--version` worked. Node runs the source fine.

## Root cause

In `crates/perry-hir/src/lower/expr_member.rs`, when a receiver is HIR-tagged as a **native instance**, a property read that doesn't match one of the special-case arms falls through to a 0-arg `NativeMethodCall` fallback. For object-metadata properties that's wrong: `inst.prototype` lowered to `js_native_call_method_nullsafe(inst, "prototype", 0 args)` (codegen `lower_call/native/mod.rs`), which **invokes** the resolved prototype value instead of returning it → `prototype is not a function`.

`prototype` / `__proto__` / `constructor` are JS object metadata — never native instance methods or getters — so they must be plain property GETs. Node returns the real value (e.g. `undefined` for an instance's `.prototype`).

The bundle hits this because follow-redirects' `RedirectableRequest` does `lN.prototype = Object.create(Writable.prototype); lN.prototype.abort = function(){...}` where `lN`'s value is stream-tagged.

## Fix

Guard at the top of the native-instance property-read block: if the property is `prototype`/`__proto__`/`constructor`, lower as `Expr::PropertyGet` instead of the invoking `NativeMethodCall`.

## Repro (perry-wrong → node-right)
```ts
import { Readable } from "stream";
const lN: any = Readable.from(["a", "b"]);
console.log(typeof lN.prototype);   // pre-fix: TypeError; post-fix: "undefined" (matches Node)
```
`Readable.from(...)` is the trigger (tags `lN` native-instance) — the same mis-classification follow-redirects hits.

## Tests
New e2e `crates/perry/tests/native_instance_prototype_read.rs`; `cargo test -p perry-hir -p perry-codegen` = 642 passed; the working `function lN(){}; lN.prototype=Object.create(Writable.prototype); ...` case still passes.

## Follow-up (noted, not in scope)
Arbitrary non-metadata property reads/writes on a native-instance handle (`lN.foo` after `lN.foo = 99`) also route through the same `NativeMethodCall` fallback — a candidate fix if the bundle later needs own-property storage on stream-tagged values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of metadata properties on native instances. Properties like `prototype`, `constructor`, and `__proto__` now correctly return their values instead of attempting function invocation, preventing runtime errors when these properties are undefined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->