### PR TITLE
fix(runtime): allow createRequire of all implemented builtin modules (tls, dgram, vm, …)

### DIFF
--- a/crates/perry-runtime/src/module_require.rs
+++ b/crates/perry-runtime/src/module_require.rs
@@ -99,8 +99,13 @@ fn supported_require_builtin(specifier: &str) -> Option<&str> {
         | "http" | "http2" | "https" | "module" | "net" | "os" | "path" | "path/posix"
         | "path/win32" | "perf_hooks" | "process" | "punycode" | "querystring" | "readline"
         | "readline/promises" | "stream" | "stream/promises" | "string_decoder" | "sys"
-        | "test" | "test/reporters" | "timers" | "timers/promises" | "tty" | "url" | "util"
-        | "util/types" | "worker_threads" | "zlib" => Some(name),
+        | "test" | "test/reporters" | "timers" | "timers/promises" | "tls" | "tty" | "url"
+        | "util" | "util/types" | "vm" | "wasi" | "worker_threads" | "zlib"
+        // Implemented native modules that were missing from the createRequire
+        // allowlist (they have runtime registry buckets + dispatch, but
+        // `require('tls')` etc. via createRequire was rejected as "package/file").
+        | "dgram" | "domain" | "inspector" | "inspector/promises" | "repl"
+        | "sqlite" => Some(name),
         _ => None,
     }
 }

--- a/crates/perry/tests/createrequire_builtin_modules.rs
+++ b/crates/perry/tests/createrequire_builtin_modules.rs
@@ -1,0 +1,73 @@
+//! Regression test: `createRequire(...)(spec)` must resolve every implemented
+//! Node built-in module, not just a subset.
+//!
+//! `tls` (and `dgram`/`domain`/`vm`/`repl`/`sqlite`/`inspector`) are fully
+//! implemented native modules (runtime registry buckets + dispatch + exports),
+//! but they were missing from the `supported_require_builtin` allowlist in
+//! `module_require.rs`, so `require('tls')` via `createRequire` was rejected with
+//! `ERR_PERRY_UNSUPPORTED_CREATE_REQUIRE` ("package/file require('tls') is not
+//! supported"). This blocked `claude-code --help`: the bundled follow-redirects
+//! module does `const tls = require('tls')` through a `createRequire` bridge.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+#[test]
+fn createrequire_resolves_tls_and_other_implemented_builtins() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+const tls = require("tls");
+console.log("tls:", typeof tls, typeof tls.createSecureContext === "function");
+console.log("dgram:", typeof require("dgram"));
+console.log("vm:", typeof require("vm"));
+console.log("domain:", typeof require("domain"));
+console.log("ok");
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "tls: object true\ndgram: object\nvm: object\ndomain: object\nok\n"
+    );
+}


### PR DESCRIPTION
## Symptom
`claude-code --help` threw `Error: Perry createRequire() currently supports built-in modules only; package/file require('tls') is not supported under perry compile` (`ERR_PERRY_UNSUPPORTED_CREATE_REQUIRE`). `tls` is a Node built-in and is fully implemented in perry.

## Root cause
`supported_require_builtin` in `crates/perry-runtime/src/module_require.rs` — the allowlist gating `createRequire(...)(spec)` / bare `require(spec)` — was missing several modules that perry **does** implement (they have runtime registry buckets in `native_module_registry.rs`, dispatch in `native_module_dispatch.rs`, and export lists). So requiring them via the createRequire bridge was rejected as a "package/file", even though the same module resolves fine via static ESM import.

The bundled **follow-redirects** module does `const tls = require('tls')` through a `createRequire` bridge, which is why `--help` (but not `--version`) hit this.

## Fix
Add the implemented-but-missing builtins to the allowlist: `tls`, `dgram`, `domain`, `inspector`, `inspector/promises`, `repl`, `sqlite`, `vm`, `wasi`.

## Test
New e2e `crates/perry/tests/createrequire_builtin_modules.rs`: `createRequire(...)("tls"/"dgram"/"vm"/"domain")` now resolves to the native module namespaces.

Part of bringing up `@anthropic-ai/claude-code` natively (`--version` already runs; this is the next `--help` wall).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended `createRequire` module support to include additional Node.js built-ins: `tls`, `vm`, `wasi`, `dgram`, `domain`, `inspector`, `repl`, and `sqlite`.

* **Tests**
  * Added regression test for `createRequire` built-in module resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->