### PR TITLE
fix(hir): #5195 — inline property-access `.indexOf`/`.includes` miscompiled as array search

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/array_only_methods.rs
@@ -909,29 +909,32 @@ pub(super) fn try_array_only_methods(
                             // Fall through to string/generic dispatch.
                         } else {
                             let array_expr = lower_expr(ctx, &member.obj)?;
-                            let is_known_string_prop = matches!(&array_expr,
-                                Expr::PropertyGet { property, .. }
-                                if matches!(
-                                    property.as_str(),
-                                    "stack" | "message" | "name" | "sourceSQL" | "expandedSQL"
-                                )
-                            );
-                            if !is_known_string_prop
-                                && matches!(
-                                    &array_expr,
-                                    Expr::ArrayMap { .. }
-                                        | Expr::ArrayFilter { .. }
-                                        | Expr::ArraySort { .. }
-                                        | Expr::ArraySlice { .. }
-                                        | Expr::Array(_)
-                                        | Expr::ArrayFrom(_)
-                                        | Expr::ArrayFromArrayLikeHoley(_)
-                                        | Expr::StringSplit(_, _)
-                                        | Expr::ObjectKeys(_)
-                                        | Expr::ObjectValues(_)
-                                        | Expr::PropertyGet { .. }
-                                )
-                            {
+                            // #5195: a `PropertyGet` receiver
+                            // (`arr[i].id.indexOf(...)`, `p.id.indexOf(...)`) is
+                            // NOT necessarily an array — the property is very often
+                            // a string. Folding it to `ArrayIndexOf` (an
+                            // element-equality search) silently returned the wrong
+                            // result for string-typed properties; the old hardcoded
+                            // `stack|message|name|…` allowlist only patched a
+                            // handful of property names. Only fold receivers that
+                            // are *provably* array-producing; every other receiver
+                            // (all property accesses included) falls through to the
+                            // generic method dispatch, which checks the runtime
+                            // value type and routes string- vs. array-`indexOf`
+                            // correctly — exactly as the `slice` arm above does.
+                            if matches!(
+                                &array_expr,
+                                Expr::ArrayMap { .. }
+                                    | Expr::ArrayFilter { .. }
+                                    | Expr::ArraySort { .. }
+                                    | Expr::ArraySlice { .. }
+                                    | Expr::Array(_)
+                                    | Expr::ArrayFrom(_)
+                                    | Expr::ArrayFromArrayLikeHoley(_)
+                                    | Expr::StringSplit(_, _)
+                                    | Expr::ObjectKeys(_)
+                                    | Expr::ObjectValues(_)
+                            ) {
                                 let mut it = args.into_iter();
                                 let value_expr = it.next().unwrap();
                                 let from_index = it.next().map(Box::new);
@@ -948,30 +951,26 @@ pub(super) fn try_array_only_methods(
                             // Fall through to string/generic dispatch.
                         } else {
                             let array_expr = lower_expr(ctx, &member.obj)?;
-                            // Don't treat known string-valued properties as arrays.
-                            let is_known_string_prop = matches!(&array_expr,
-                                Expr::PropertyGet { property, .. }
-                                if matches!(
-                                    property.as_str(),
-                                    "stack" | "message" | "name" | "sourceSQL" | "expandedSQL"
-                                )
-                            );
-                            if !is_known_string_prop
-                                && matches!(
-                                    &array_expr,
-                                    Expr::ArrayMap { .. }
-                                        | Expr::ArrayFilter { .. }
-                                        | Expr::ArraySort { .. }
-                                        | Expr::ArraySlice { .. }
-                                        | Expr::Array(_)
-                                        | Expr::ArrayFrom(_)
-                                        | Expr::ArrayFromArrayLikeHoley(_)
-                                        | Expr::StringSplit(_, _)
-                                        | Expr::ObjectKeys(_)
-                                        | Expr::ObjectValues(_)
-                                        | Expr::PropertyGet { .. }
-                                )
-                            {
+                            // #5195: see the `indexOf` arm above — a `PropertyGet`
+                            // receiver is not necessarily an array (the property is
+                            // often a string), so folding it to `ArrayIncludes`
+                            // silently returned `false` on string properties. Only
+                            // fold provably array-producing receivers; property
+                            // accesses fall through to the runtime-type-checked
+                            // generic dispatch.
+                            if matches!(
+                                &array_expr,
+                                Expr::ArrayMap { .. }
+                                    | Expr::ArrayFilter { .. }
+                                    | Expr::ArraySort { .. }
+                                    | Expr::ArraySlice { .. }
+                                    | Expr::Array(_)
+                                    | Expr::ArrayFrom(_)
+                                    | Expr::ArrayFromArrayLikeHoley(_)
+                                    | Expr::StringSplit(_, _)
+                                    | Expr::ObjectKeys(_)
+                                    | Expr::ObjectValues(_)
+                            ) {
                                 let mut it = args.into_iter();
                                 let value_expr = it.next().unwrap();
                                 let from_index = it.next().map(Box::new);

--- a/crates/perry/tests/issue_5195_property_method_chain.rs
+++ b/crates/perry/tests/issue_5195_property_method_chain.rs
@@ -1,0 +1,138 @@
+//! Regression tests for #5195 — an inline property-access chained into an
+//! array/string-overlapping method call (`arr[i].id.indexOf(x)`,
+//! `p.id.includes(x)`) miscompiled and returned the wrong result.
+//!
+//! Root cause: `lower/expr_call/array_only_methods.rs` folded a `PropertyGet`
+//! receiver of `.indexOf` / `.includes` to `ArrayIndexOf` / `ArrayIncludes`
+//! (an element-equality search) unless the property name happened to be in a
+//! hardcoded `stack|message|name|sourceSQL|expandedSQL` allowlist. A genuine
+//! string property (`id: string`) fell through that allowlist and was searched
+//! as an array, so `arr[i].id.indexOf("PRO")` returned -1 (and the equivalent
+//! `.filter(p => p.id.indexOf("PRO") >= 0)` predicate returned 0 matches) with
+//! no error — silently breaking a StoreKit product lookup downstream.
+//!
+//! The fix only folds receivers that are *provably* array-producing
+//! (`.map`/`.filter`/`.split`/`Object.keys`/array literals/…). Every property
+//! access now falls through to `js_native_call_method`, which checks the
+//! runtime value type and routes string- vs. array-`indexOf` correctly — the
+//! same way the `slice` arm already behaved.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, entry: &std::path::Path) -> String {
+    let output = dir.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).to_string()
+}
+
+/// The exact issue shape: a string property read inline and immediately
+/// `.indexOf`/`.includes`'d, both in a loop and inside a `.filter` predicate.
+/// Pre-fix every count was 0; they must match the extract-to-local form.
+#[test]
+fn string_property_indexof_includes_inline_match() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+interface P { id: string }
+const arr: P[] = [{ id: "GSC_PRO_MONTHLY" }, { id: "GSC_AGENCY_MONTHLY" }, { id: "GSC_PRO_ANNUAL" }]
+
+let inlineIdx = 0
+for (let i = 0; i < arr.length; i++) { if (arr[i].id.indexOf("PRO") >= 0) inlineIdx++ }
+console.log("inlineIdx=" + inlineIdx)
+
+let inlineInc = 0
+for (let i = 0; i < arr.length; i++) { if (arr[i].id.includes("PRO")) inlineInc++ }
+console.log("inlineInc=" + inlineInc)
+
+console.log("filter=" + arr.filter(function (p: P) { return p.id.indexOf("PRO") >= 0 }).length)
+console.log("chain=" + arr[0].id.toLowerCase().indexOf("pro"))
+"#,
+    )
+    .expect("write entry");
+
+    let stdout = compile_and_run(dir.path(), &entry);
+    assert!(
+        stdout.contains("inlineIdx=2"),
+        "arr[i].id.indexOf(\"PRO\") must find 2 (got: {stdout})"
+    );
+    assert!(
+        stdout.contains("inlineInc=2"),
+        "arr[i].id.includes(\"PRO\") must find 2 (got: {stdout})"
+    );
+    assert!(
+        stdout.contains("filter=2"),
+        "filter(p => p.id.indexOf(\"PRO\") >= 0) must keep 2 (got: {stdout})"
+    );
+    assert!(
+        stdout.contains("chain=4"),
+        "arr[0].id.toLowerCase().indexOf(\"pro\") must be 4 (got: {stdout})"
+    );
+}
+
+/// The fix must NOT regress a genuinely array-typed property: `.indexOf` /
+/// `.includes` on an array field still search the array (via the runtime-typed
+/// generic dispatch) and return the element index / membership.
+#[test]
+fn array_typed_property_indexof_includes_still_search_array() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+class Box { tags: string[] = ["red", "green", "blue"] }
+const b = new Box()
+console.log("idx=" + b.tags.indexOf("green"))
+console.log("inc=" + b.tags.includes("blue"))
+console.log("miss=" + b.tags.indexOf("pink"))
+const cfg = { nums: [10, 20, 30] }
+console.log("nidx=" + cfg.nums.indexOf(20))
+"#,
+    )
+    .expect("write entry");
+
+    let stdout = compile_and_run(dir.path(), &entry);
+    assert!(
+        stdout.contains("idx=1"),
+        "array-property indexOf must return the element index (got: {stdout})"
+    );
+    assert!(
+        stdout.contains("inc=true"),
+        "array-property includes must return true for a member (got: {stdout})"
+    );
+    assert!(
+        stdout.contains("miss=-1"),
+        "array-property indexOf must return -1 for a non-member (got: {stdout})"
+    );
+    assert!(
+        stdout.contains("nidx=1"),
+        "numeric array-property indexOf must return the index (got: {stdout})"
+    );
+}


### PR DESCRIPTION
Fixes #5195.

## Problem

Calling `.indexOf` / `.includes` **inline on a property access** —
`arr[i].id.indexOf("PRO")`, `p.id.includes("PRO")` — returned the wrong result
with no error. Extracting the property to a local (`const pid = arr[i].id; pid.indexOf(...)`) worked.

Reproduced on the native host (`v0.5.1191`, current `main`):

```ts
interface P { id: string }
const arr: P[] = [{ id: "GSC_PRO_MONTHLY" }, { id: "GSC_AGENCY_MONTHLY" }, { id: "GSC_PRO_ANNUAL" }]
let a = 0
for (let i = 0; i < arr.length; i++) if (arr[i].id.indexOf("PRO") >= 0) a++
console.log(a)  // printed 0 ❌ (expected 2)
console.log(arr.filter(p => p.id.indexOf("PRO") >= 0).length)  // printed 0 ❌ (expected 2)
```

Downstream this silently made a StoreKit product lookup
(`products.filter(p => p.id.indexOf("PRO") >= 0)`) return empty, so an
in-app-purchase button reported the plan as unavailable.

## Root cause

`crates/perry-hir/src/lower/expr_call/array_only_methods.rs` folded a
`PropertyGet` receiver of `.indexOf` / `.includes` to `Expr::ArrayIndexOf` /
`Expr::ArrayIncludes` (an element-equality search), gated only by a hardcoded
property-name allowlist (`stack|message|name|sourceSQL|expandedSQL`). A string
property like `id` isn't on that list, so `arr[i].id` (typed `string`) was
searched as an array → `-1`. HIR confirmed it:

```
ArrayIndexOf { array: PropertyGet { object: IndexGet { LocalGet(arr), 0 }, property: "id" }, value: String("PRO") }
```

## Fix

Only fold receivers that are **provably array-producing** (`.map`/`.filter`/
`.sort`/`.slice`/`.split`/`Object.keys`/`Object.values`/array literals/
`Array.from`). Every property access now falls through to the generic
`js_native_call_method` dispatch, which checks the runtime value type and
routes string- vs. array-`indexOf`/`includes` correctly — the same way the
sibling `slice` arm already behaves and the same path a known-string local
already took. This removes the unsustainable property-name allowlist band-aid
in both arms.

Genuine **array-typed** properties keep correct semantics via that dynamic
dispatch (verified below).

## Verification

New regression test `crates/perry/tests/issue_5195_property_method_chain.rs` (2 cases, both green):
- `string_property_indexof_includes_inline_match` — the issue shape now returns 2 for the loop, `.filter`, and `.includes` forms, and `arr[0].id.toLowerCase().indexOf("pro") === 4`.
- `array_typed_property_indexof_includes_still_search_array` — `box.tags.indexOf("green") === 1`, `.includes("blue") === true`, miss `=== -1`, numeric array property `=== 1`.

Also ran a broader behavioral sweep (bare-local / literal / `.map`/`.filter`/`.split`/`Object.keys` chains, string locals, string & array properties) — all correct. `perry-hir` unit tests and the related `issue_5271_string_method_nonstring_receiver` / `issue_5139_object_arraylike_method_dispatch` integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the behavior of `indexOf` and `includes` methods when called on array properties accessed within method chains. Previously, these methods could incorrectly apply string semantics. Now the implementation properly distinguishes between array and string operations, ensuring these search methods return accurate results based on the actual data type being operated upon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->