### PR TITLE
feat(sharp): AVIF encode (.avif) + quality-aware JPEG/AVIF encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## v0.5.1195 — feat(sharp): AVIF encode + quality-aware encoding
+
+- **`.avif(quality)`** — AVIF output via the `image` crate's `avif` feature (the pure-Rust
+  `ravif`/`rav1e` encoder). `sharp(input).resize(…).avif(50).toBuffer()` produces a real
+  AVIF Buffer (`ftyp`/`avif` box); `.toFile('out.avif')` writes a valid AVIF and reports
+  `format: "avif"`. Encode-only: AVIF **decode** is intentionally out (it needs the C
+  `dav1d` library; we keep the static-binary, no-system-deps model).
+- **Quality is now honoured for JPEG and AVIF.** Encoding routes through a new
+  `encode_to_vec` helper that uses `JpegEncoder::new_with_quality` / `AvifEncoder::
+  new_with_speed_quality`. Previously `.jpeg(q)` stored a quality that the default
+  `write_to` path ignored; now `.jpeg(20)` really is smaller than `.jpeg(95)`. `toFile`
+  also encodes by the output path's extension (so `.toFile('x.avif')` works) and honours
+  quality.
+
+Wired end-to-end (dispatch row, FFI decl, manifest entry, fluent-chain allowlist); docs
+regenerated (+`avif`). Validated e2e: `.avif().toBuffer()` → AVIF `ftyp avif` box;
+`.toFile('x.avif')` → `file(1)` reports `ISO Media, AVIF Image`; JPEG quality affects output
+size; `perry-ext-sharp` unit suite 9/9.
+
+Note: enabling AVIF pulls `rav1e` (a large pure-Rust AV1 encoder) into sharp binaries —
+a deliberate size trade for AVIF output. SVG rasterization (`resvg`) was evaluated and
+**deferred** to a separate opt-in PR to avoid bloating every sharp binary with its
+dependency tree.
+
 ## v0.5.1194 — feat(sharp): EXIF auto-orient, `.extend()`, `.trim()`, `.composite()`
 
 More sharp parity, pure-Rust (no libvips):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1194
+**Current Version:** 0.5.1195
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5325,7 +5325,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "anyhow",
  "base64",
@@ -5382,14 +5382,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "cc",
  "libc",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "anyhow",
  "log",
@@ -5412,7 +5412,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5421,7 +5421,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5448,7 +5448,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "anyhow",
  "base64",
@@ -5461,7 +5461,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5469,7 +5469,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5498,14 +5498,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "serde",
  "serde_json",
@@ -5513,7 +5513,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1194"
+version = "0.5.1195"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5524,7 +5524,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "anyhow",
  "clap",
@@ -5539,14 +5539,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5554,7 +5554,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5571,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5605,7 +5605,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5613,7 +5613,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5621,7 +5621,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5629,7 +5629,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5637,7 +5637,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5645,14 +5645,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5681,7 +5681,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5695,7 +5695,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "bytes",
  "h2",
@@ -5718,7 +5718,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5728,7 +5728,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5739,7 +5739,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "bson",
  "futures-util",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5786,7 +5786,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5798,7 +5798,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5808,7 +5808,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5816,7 +5816,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5825,7 +5825,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5833,7 +5833,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -5843,14 +5843,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5859,7 +5859,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5877,7 +5877,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5889,7 +5889,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "brotli",
  "flate2",
@@ -5898,7 +5898,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5925,7 +5925,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5937,7 +5937,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "anyhow",
  "base64",
@@ -5970,7 +5970,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6062,7 +6062,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6072,7 +6072,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6080,14 +6080,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "base64",
  "itoa",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6114,7 +6114,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6137,7 +6137,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "base64",
  "block2",
@@ -6153,7 +6153,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "base64",
  "block2",
@@ -6168,7 +6168,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1194"
+version = "0.5.1195"
 
 [[package]]
 name = "perry-ui-test"
@@ -6176,11 +6176,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1194"
+version = "0.5.1195"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "base64",
  "block2",
@@ -6196,7 +6196,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "base64",
  "block2",
@@ -6212,7 +6212,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "block2",
  "libc",
@@ -6225,7 +6225,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "base64",
  "libc",
@@ -6242,14 +6242,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6263,7 +6263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1194"
+version = "0.5.1195"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ strip = false
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1194"
+version = "0.5.1195"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -2046,6 +2046,7 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("sharp", "jpeg", true, None),
     method("sharp", "png", true, None),
     method("sharp", "webp", true, None),
+    method("sharp", "avif", true, None),
     method("sharp", "toFile", true, None),
     method("sharp", "toBuffer", true, None),
     method("sharp", "metadata", true, None),

--- a/crates/perry-codegen/src/lower_call/early_branches.rs
+++ b/crates/perry-codegen/src/lower_call/early_branches.rs
@@ -144,6 +144,7 @@ fn native_method_returns_self_instance(module: &str, method: &str) -> bool {
                 | "jpeg"
                 | "png"
                 | "webp"
+                | "avif"
         ),
         _ => false,
     }

--- a/crates/perry-codegen/src/lower_call/native_table/media.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/media.rs
@@ -168,6 +168,15 @@ pub(super) const MEDIA_ROWS: &[NativeModSig] = &[
     NativeModSig {
         module: "sharp",
         has_receiver: true,
+        method: "avif",
+        class_filter: None,
+        runtime: "js_sharp_avif",
+        args: &[NA_F64],
+        ret: NR_PTR,
+    },
+    NativeModSig {
+        module: "sharp",
+        has_receiver: true,
         method: "toFile",
         class_filter: None,
         runtime: "js_sharp_to_file",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -517,6 +517,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
 
     // ========== sharp / image ==========
     module.declare_function("js_sharp_auto_orient", I64, &[I64]);
+    module.declare_function("js_sharp_avif", I64, &[I64, DOUBLE]);
     module.declare_function("js_sharp_blur", I64, &[I64, DOUBLE]);
     module.declare_function("js_sharp_composite", I64, &[I64, DOUBLE]);
     module.declare_function("js_sharp_extend", I64, &[I64, DOUBLE]);

--- a/crates/perry-ext-sharp/Cargo.toml
+++ b/crates/perry-ext-sharp/Cargo.toml
@@ -10,7 +10,9 @@ crate-type = ["staticlib", "rlib"]
 
 [dependencies]
 perry-ffi.workspace = true
-image = "0.25"
+# `avif` enables the pure-Rust ravif encoder (AVIF output). We deliberately do
+# NOT enable `avif-native` (C dav1d decoder), so AVIF is encode-only.
+image = { version = "0.25", features = ["avif"] }
 fast_image_resize = "5"
 kamadak-exif = "0.6"
 

--- a/crates/perry-ext-sharp/src/lib.rs
+++ b/crates/perry-ext-sharp/src/lib.rs
@@ -167,6 +167,7 @@ fn fmt_name(format: ImageFormat) -> &'static str {
         ImageFormat::Jpeg => "jpeg",
         ImageFormat::Png => "png",
         ImageFormat::WebP => "webp",
+        ImageFormat::Avif => "avif",
         ImageFormat::Gif => "gif",
         _ => "unknown",
     }
@@ -612,6 +613,45 @@ pub extern "C" fn js_sharp_webp(handle: Handle, quality: f64) -> Handle {
     -1
 }
 
+#[no_mangle]
+pub extern "C" fn js_sharp_avif(handle: Handle, quality: f64) -> Handle {
+    if let Some(sharp) = get_handle::<SharpHandle>(handle) {
+        return register_handle(SharpHandle {
+            image: sharp.image.clone(),
+            format: ImageFormat::Avif,
+            quality: if quality > 0.0 { quality as u8 } else { 50 },
+            orientation: sharp.orientation,
+        });
+    }
+    -1
+}
+
+/// Encode `image` to `format`, honouring `quality` for the formats whose
+/// encoders take one (JPEG, AVIF). Other formats use the default encoder.
+fn encode_to_vec(
+    image: &DynamicImage,
+    format: ImageFormat,
+    quality: u8,
+) -> image::ImageResult<Vec<u8>> {
+    let mut buf = Cursor::new(Vec::new());
+    match format {
+        ImageFormat::Jpeg => {
+            let enc = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut buf, quality);
+            image.write_with_encoder(enc)?;
+        }
+        ImageFormat::Avif => {
+            // speed 6 is a reasonable encode-time/quality balance.
+            let enc =
+                image::codecs::avif::AvifEncoder::new_with_speed_quality(&mut buf, 6, quality);
+            image.write_with_encoder(enc)?;
+        }
+        other => {
+            image.write_to(&mut buf, other)?;
+        }
+    }
+    Ok(buf.into_inner())
+}
+
 /// # Safety
 /// `path_ptr` must be null or a Perry-runtime `StringHeader`.
 #[no_mangle]
@@ -632,19 +672,29 @@ pub unsafe extern "C" fn js_sharp_to_file(
 
     spawn_blocking(move || {
         if let Some(sharp) = get_handle::<SharpHandle>(handle) {
-            match sharp.image.save(&path) {
-                Ok(_) => {
+            // Output format follows the path extension (sharp behavior),
+            // falling back to the pipeline's selected format. Encoding through
+            // `encode_to_vec` honours quality (JPEG/AVIF) and supports AVIF
+            // output, which `image::save` would do at default quality only.
+            let out_format = ImageFormat::from_path(&path).unwrap_or(sharp.format);
+            match encode_to_vec(&sharp.image, out_format, sharp.quality).and_then(|bytes| {
+                std::fs::write(&path, &bytes)
+                    .map(|_| bytes)
+                    .map_err(Into::into)
+            }) {
+                Ok(bytes) => {
                     // sharp's toFile resolves an `info` object, not a string:
                     // `{ format, width, height, channels, size }`.
                     let (width, height) = sharp.image.dimensions();
                     // Report the ENCODED output's channel count by re-reading
                     // the saved file (e.g. an RGBA source saved as JPEG is
                     // 3-channel on disk), falling back to the in-memory count.
+                    // (AVIF re-read fails — no decoder — so it uses the fallback.)
                     let channels = image::open(&path)
                         .map(|saved| saved.color().channel_count())
                         .unwrap_or_else(|_| sharp.image.color().channel_count());
-                    let format = fmt_name(sharp.format).to_string();
-                    let size = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+                    let format = fmt_name(out_format).to_string();
+                    let size = bytes.len() as u64;
                     promise.resolve_with(move || {
                         let (packed, shape_id) =
                             build_object_shape(&["format", "width", "height", "channels", "size"]);
@@ -686,10 +736,8 @@ pub extern "C" fn js_sharp_to_buffer(handle: Handle) -> *mut Promise {
 
     spawn_blocking(move || {
         if let Some(sharp) = get_handle::<SharpHandle>(handle) {
-            let mut buffer = Cursor::new(Vec::new());
-            match sharp.image.write_to(&mut buffer, sharp.format) {
-                Ok(_) => {
-                    let bytes = buffer.into_inner();
+            match encode_to_vec(&sharp.image, sharp.format, sharp.quality) {
+                Ok(bytes) => {
                     // Resolve with a REAL Node `Buffer` of the encoded image
                     // bytes. The Buffer must be allocated on the MAIN thread —
                     // the runtime arena is thread-local, so allocating it here

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2814 entries across 115 modules.
+Total: 2815 entries across 115 modules.
 
 ## Modules
 
@@ -2942,6 +2942,7 @@ Total: 2814 entries across 115 modules.
 ### Methods
 
 - `autoOrient` — instance
+- `avif` — instance
 - `blur` — instance
 - `composite` — instance
 - `default` — module


### PR DESCRIPTION
PR 2 of 2 in the sharp batch. **Stacked on #5455** (base is that branch, so this diff shows only the AVIF changes; it'll retarget to `main` once #5455 merges).

Pure-Rust, keeps the static-binary model.

## `.avif(quality)` — AVIF output
Via the `image` crate's `avif` feature (the pure-Rust `ravif`/`rav1e` encoder). `sharp(input).resize(…).avif(50).toBuffer()` yields a real AVIF Buffer (`ftyp`/`avif` box); `.toFile('out.avif')` writes a valid AVIF and reports `format: "avif"`.

**Encode-only** — AVIF *decode* is intentionally out (it needs the C `dav1d` library, which would break the no-system-deps model). `sharp('x.avif')` input isn't supported.

## Quality now honoured for JPEG + AVIF
Encoding routes through a new `encode_to_vec` helper using `JpegEncoder::new_with_quality` / `AvifEncoder::new_with_speed_quality`. This also **fixes a pre-existing gap**: `.jpeg(q)` stored a quality the default `write_to` path ignored — now `.jpeg(20)` really is smaller than `.jpeg(95)`. `toFile` encodes by the output path's extension (so `.toFile('x.avif')` works) and honours quality.

## Validation
- `.avif().toBuffer()` → AVIF `ftyp`/`avif` box; `.toFile('x.avif')` → `file(1)` reports `ISO Media, AVIF Image`.
- JPEG quality affects output size (lo < hi).
- `perry-ext-sharp` unit suite **9/9**; API docs regenerated (+`avif`).

## Size note
Enabling AVIF pulls `rav1e` (a large pure-Rust AV1 encoder) into sharp binaries — a deliberate trade for AVIF output. **SVG rasterization (`resvg`) was deferred** to a separate opt-in PR (per discussion) to avoid bloating every sharp binary with its dependency tree.

## Animated WebP
Still out — the `image` crate has no animated-WebP encoder; a separate codec path would be needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added AVIF image encoding format support to the sharp module
* Introduced quality-aware encoding for JPEG and AVIF formats with configurable quality settings
* Enhanced image output pipeline with optimized compression options

## Documentation
* Updated API reference documentation with the new sharp.avif() method and available options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->