### PR TITLE
fix(codegen): #5431 — cross-module call to a `$`-named exported function returned undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,38 @@
+## v0.5.1196 — fix(codegen): #5431 — cross-module call to a `$`-named exported function returned `undefined`
+
+Calling an exported function whose name contains a non-`[A-Za-z0-9_]` character (e.g.
+`export function $constructor`) across a module boundary returned `undefined` instead of
+running the body. The function *reference* resolved fine (`typeof` was `function`), but every
+*call* produced `undefined`. Surfaced by **zod v4** (issue #5431): `z.string()` calls
+`core._string(ZodString, params)` where `ZodString = /*@__PURE__*/ core.$constructor("ZodString", …)`.
+The `$constructor` call returned `undefined`, so `ZodString` was `undefined` and `new ZodString(…)`
+threw `TypeError: undefined is not a constructor` at `zod/v4/core/api.ts:65`.
+
+**Root cause** — a symbol-mangling desync. A function body whose name contains a non-alphanumeric
+char is emitted under the *injective* `sanitize_member` symbol
+(`perry_fn_<mod>__u__24constructor`), but cross-module callers, the #461 named-export stub loop,
+and the #836 verbatim-`$` alias all compute the symbol via plain `sanitize` (`$`→`_`,
+`perry_fn_<mod>___constructor`). The exported-function forwarding-alias loop in
+`crates/perry-codegen/src/codegen/mod.rs` early-skipped emitting an alias whenever
+`local == exported` — true for `$constructor`. With no alias bridging the two manglings, the
+#461 loop claimed the plain-`sanitize` symbol with an **undefined-returning stub**, and the #836
+alias forwarded the verbatim-`$` symbol to that stub. Net: every cross-module call to a `$`-named
+function resolved to a no-op returning `undefined`. Same-module calls were unaffected (they resolve
+through `func_names` to the real `sanitize_member` body).
+
+**Fix** — drop the `f.name == exported_name` early-skip. The existing `alias_sym == target_sym`
+check is the correct guard: it skips the plain-name no-op case (where both manglings agree) while
+still emitting the forwarding alias when they diverge. Added an `llmod.has_function(&alias_sym)`
+collision guard for the pathological `$x` + `_x` (both sanitize to `_x`) co-export case.
+
+Validated byte-for-byte against `node --experimental-strip-types`: new regression test
+`test-files/test_issue_5431_dollar_named_export_call.ts` (with `fixtures/issue_5431_pkg/`,
+faithful to zod's `$constructor`/`ZodString` shape) is identical to node. Real zod 4.0.0:
+`z.ZodString` went from `undefined` → `function`; `z.string()`, `z.object()`, and chained
+schema definition (`z.boolean().optional().describe(…)`) all work. All 30 export/module gap tests
+and the perry-codegen unit suite pass; issue-836 still clean. (Calling `.parse()` on a zod schema
+still throws "expected a Zod schema" — a separate, deeper zod-runtime gap downstream of this fix.)
+
 ## v0.5.1195 — feat(sharp): AVIF encode + quality-aware encoding
 
 - **`.avif(quality)`** — AVIF output via the `image` crate's `avif` feature (the pure-Rust

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1195
+**Current Version:** 0.5.1196
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5325,7 +5325,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "anyhow",
  "base64",
@@ -5382,14 +5382,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "cc",
  "libc",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "anyhow",
  "log",
@@ -5412,7 +5412,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5421,7 +5421,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5448,7 +5448,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "anyhow",
  "base64",
@@ -5461,7 +5461,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5469,7 +5469,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5498,14 +5498,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "serde",
  "serde_json",
@@ -5513,7 +5513,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1195"
+version = "0.5.1196"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5524,7 +5524,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "anyhow",
  "clap",
@@ -5539,14 +5539,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5554,7 +5554,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5571,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5605,7 +5605,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5613,7 +5613,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5621,7 +5621,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5629,7 +5629,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5637,7 +5637,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5645,14 +5645,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5681,7 +5681,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5695,7 +5695,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "bytes",
  "h2",
@@ -5718,7 +5718,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5728,7 +5728,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5739,7 +5739,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "bson",
  "futures-util",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5786,7 +5786,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5798,7 +5798,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5808,7 +5808,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5816,7 +5816,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5825,7 +5825,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5833,7 +5833,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -5843,14 +5843,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5859,7 +5859,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5877,7 +5877,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5889,7 +5889,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "brotli",
  "flate2",
@@ -5898,7 +5898,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5925,7 +5925,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5937,7 +5937,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "anyhow",
  "base64",
@@ -5970,7 +5970,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6062,7 +6062,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6072,7 +6072,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6080,14 +6080,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "base64",
  "itoa",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6114,7 +6114,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6137,7 +6137,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "base64",
  "block2",
@@ -6153,7 +6153,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "base64",
  "block2",
@@ -6168,7 +6168,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1195"
+version = "0.5.1196"
 
 [[package]]
 name = "perry-ui-test"
@@ -6176,11 +6176,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1195"
+version = "0.5.1196"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "base64",
  "block2",
@@ -6196,7 +6196,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "base64",
  "block2",
@@ -6212,7 +6212,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "block2",
  "libc",
@@ -6225,7 +6225,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "base64",
  "libc",
@@ -6242,14 +6242,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6263,7 +6263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1195"
+version = "0.5.1196"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ strip = false
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1195"
+version = "0.5.1196"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -2392,15 +2392,34 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
             let Some(f) = func_by_id.get(func_id) else {
                 continue;
             };
-            if &f.name == exported_name {
-                continue;
-            }
+            // NOTE: do NOT early-skip when `f.name == exported_name`. The real
+            // body is emitted under `scoped_fn_name` (the INJECTIVE
+            // `sanitize_member`), but cross-module callers and the #461
+            // undefined-stub / #836 verbatim-alias paths compute the symbol via
+            // plain `sanitize`. For a non-plain name like `$constructor`
+            // (`export function $constructor` in zod core, #5431) those two
+            // manglings diverge — body at `perry_fn_<mod>__u__24constructor`,
+            // callers at `perry_fn_<mod>___constructor` — even though local ==
+            // exported. Without a forwarding alias the #461 loop below claims
+            // `_constructor` with an undefined-returning stub and every
+            // cross-module call resolves to it (function reference is fine,
+            // every CALL returns `undefined`). The `alias_sym == target_sym`
+            // check below is the correct guard: it skips the plain-name case
+            // (where both manglings agree) while still emitting the alias when
+            // they differ.
             let alias_sym = format!("perry_fn_{}__{}", module_prefix, sanitize(exported_name));
             let target_sym = match func_names.get(func_id) {
                 Some(s) => s.clone(),
                 None => continue,
             };
             if alias_sym == target_sym {
+                continue;
+            }
+            // Guard against colliding with an already-emitted body symbol. Two
+            // exports whose names sanitize to the same string (`$x` and `_x`)
+            // would otherwise redefine the alias; the body of whichever is plain
+            // already owns `alias_sym`, so skip rather than redefine.
+            if llmod.has_function(&alias_sym) {
                 continue;
             }
             if !emitted_aliases.insert(alias_sym.clone()) {

--- a/test-files/fixtures/issue_5431_pkg/core.ts
+++ b/test-files/fixtures/issue_5431_pkg/core.ts
@@ -1,0 +1,30 @@
+// Issue #5431 — a `$`-prefixed exported function. The body is emitted
+// under the INJECTIVE `sanitize_member` symbol (`perry_fn_<mod>__u__24constructor`)
+// while cross-module callers resolve the plain-`sanitize` symbol
+// (`perry_fn_<mod>___constructor`). Pre-fix those diverged: the #461 stub
+// loop claimed the plain symbol with an undefined-returning body, so every
+// cross-module CALL returned `undefined` (the reference itself was fine).
+// This is the exact shape of zod v4's `core.$constructor`.
+export function $constructor(name: string, initializer: (inst: any) => void): any {
+  function init(inst: any) {
+    inst._zod = inst._zod ?? {};
+    inst._zod.traits ??= new Set();
+    inst._zod.traits.add(name);
+    initializer(inst);
+    inst._zod.constr = _;
+  }
+  function _(this: any, def: any) {
+    const inst = this;
+    init(inst);
+    inst._zod.def = def;
+    return inst;
+  }
+  Object.defineProperty(_, "init", { value: init });
+  Object.defineProperty(_, "name", { value: name });
+  return _ as any;
+}
+
+// `$`-prefixed function returning a plain value (not a constructor).
+export function $tag(label: string): string {
+  return "tag:" + label;
+}

--- a/test-files/fixtures/issue_5431_pkg/index.ts
+++ b/test-files/fixtures/issue_5431_pkg/index.ts
@@ -1,0 +1,2 @@
+export * from "./core.ts";
+export * from "./schemas.ts";

--- a/test-files/fixtures/issue_5431_pkg/schemas.ts
+++ b/test-files/fixtures/issue_5431_pkg/schemas.ts
@@ -1,0 +1,10 @@
+import * as core from "./core.ts";
+
+// `export const X = /*@__PURE__*/ core.$constructor(...)` — zod's ZodString shape.
+export const ZodString: any = /*@__PURE__*/ core.$constructor("ZodString", (inst: any) => {
+  inst.kind = "string";
+});
+
+export function string(): any {
+  return new ZodString({ type: "string" });
+}

--- a/test-files/test_issue_5431_dollar_named_export_call.ts
+++ b/test-files/test_issue_5431_dollar_named_export_call.ts
@@ -1,0 +1,42 @@
+// Issue #5431 — calling a `$`-prefixed exported function across a module
+// boundary returned `undefined` instead of running the body. Surfaced by
+// zod v4: `z.string()` calls `core._string(ZodString, params)` where
+// `ZodString = /*@__PURE__*/ core.$constructor("ZodString", ...)`. The
+// `$constructor` call returned `undefined`, so `ZodString` was `undefined`
+// and `new ZodString(...)` threw "TypeError: undefined is not a constructor"
+// (api.ts:65).
+//
+// Root cause: a function body whose name contains a non-`[A-Za-z0-9_]` char
+// is emitted under the injective `sanitize_member` symbol, but the
+// exported-function alias loop skipped emitting a forwarding alias whenever
+// `local == exported`. The #461 named-export stub loop then claimed the
+// plain-`sanitize` symbol with an undefined-returning body, and every
+// cross-module call resolved to that stub. Fix: emit the forwarding alias
+// whenever the plain-`sanitize` symbol differs from the real body symbol,
+// regardless of whether the local and exported names match.
+
+import * as ns from "./fixtures/issue_5431_pkg/index.ts";
+import { $tag, $constructor } from "./fixtures/issue_5431_pkg/index.ts";
+
+// Namespace-member call of a `$`-named function returning a value.
+console.log("ns.$tag:", ns.$tag("a"));
+// Named-import call of the same.
+console.log("$tag:", $tag("b"));
+
+// `$constructor` returns a function — the reference must resolve AND the
+// call must run the body (pre-fix: typeof was "function" but the result
+// was undefined).
+const Ctor = $constructor("Foo", (inst: any) => {
+  inst.kind = "foo";
+});
+console.log("typeof Ctor:", typeof Ctor);
+const inst = new Ctor({ x: 1 });
+console.log("inst.kind:", inst.kind);
+console.log("inst._zod.def.x:", inst._zod.def.x);
+
+// The zod-shaped path: `export const ZodString = core.$constructor(...)`
+// re-exported through a barrel, then consumed via `new`.
+console.log("typeof ns.ZodString:", typeof ns.ZodString);
+const s = ns.string();
+console.log("s.kind:", s.kind);
+console.log("s._zod.def.type:", s._zod.def.type);


### PR DESCRIPTION
Fixes #5431.

## Symptom

zod v4 under Perry threw `TypeError: undefined is not a constructor` at `zod/v4/core/api.ts:65` (`new Class(...)`). `Class` was `undefined` because `ZodString = /*@__PURE__*/ core.$constructor("ZodString", …)` evaluated to `undefined` — the cross-module call to `core.$constructor` returned `undefined`.

## Root cause

A symbol-mangling desync for exported functions whose name contains a non-`[A-Za-z0-9_]` character (zod has `export function $constructor`):

- The **real body** is emitted under the injective `sanitize_member` symbol → `perry_fn_<mod>__u__24constructor`.
- Cross-module callers, the #461 named-export stub loop, and the #836 verbatim-`$` alias all compute the symbol via plain `sanitize` (`$`→`_`) → `perry_fn_<mod>___constructor`.

The exported-function forwarding-alias loop in `crates/perry-codegen/src/codegen/mod.rs` **early-skipped emitting an alias whenever `local == exported`** — true for `$constructor`. With no alias bridging the two manglings, the #461 loop claimed the plain-`sanitize` symbol with an **undefined-returning stub**, and the #836 alias forwarded the verbatim-`$` symbol to that stub. Net: the function *reference* resolved (`typeof` `function`) but every cross-module *call* returned `undefined`. Same-module calls were unaffected (they resolve through `func_names` to the real `sanitize_member` body).

## Fix

Drop the `f.name == exported_name` early-skip. The existing `alias_sym == target_sym` check is the correct guard — it skips the plain-name no-op case while still emitting the forwarding alias when the two manglings diverge. Added an `llmod.has_function(&alias_sym)` collision guard for the pathological `$x` + `_x` co-export case.

## Validation

- New regression test `test-files/test_issue_5431_dollar_named_export_call.ts` (+ `fixtures/issue_5431_pkg/`, faithful to zod's `$constructor`/`ZodString` shape) — byte-identical to `node --experimental-strip-types`.
- Real zod 4.0.0: `z.ZodString` `undefined` → `function`; `z.string()`, `z.object()`, and chained schema definition (`z.boolean().optional().describe(…)`) all work.
- All 30 export/module gap tests + the perry-codegen unit suite pass; issue-836 still clean.

## Out of scope

Calling `.parse()` on a zod schema still throws "expected a Zod schema" — a separate, deeper zod-runtime gap downstream of this fix. The reporter's repro only *defines* schemas, which now works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cross-module calls to `$`-prefixed exported functions that previously returned undefined, resolving compatibility issues with libraries like Zod v4.

* **Tests**
  * Added regression test for `$`-named export function calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->