### PR TITLE
fix(codegen): #5429 — computed-member get on a number receiver segfaulted

### DIFF
--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -145,14 +145,32 @@ pub(crate) fn index_object_is_class_or_proto_ref(ctx: &FnCtx<'_>, object: &Expr)
 }
 
 /// Compute the receiver handle to pass to `js_object_get_field_by_name`-family
-/// helpers from a NaN-boxed receiver value (`obj_bits`). Heap objects must be
-/// masked to a raw pointer, but an INT32-tagged class ref (`0x7FFE`) must keep
-/// its tag bits so the runtime routes to the static field / method / accessor
-/// tables. When the receiver's class-ref-ness is known at compile time
-/// (`static_known`), pass full bits unconditionally; otherwise branch at runtime
-/// on the tag so a runtime class-ref value (e.g. a function parameter bound to a
-/// class — `function f(C, k){ return C[k]; }`) is handled too. (test262
-/// class/elements propertyHelper `isWritable(C, name)` does `C[name]`.)
+/// helpers from a NaN-boxed receiver value (`obj_bits`). Only a *genuine heap
+/// pointer* — POINTER_TAG (`0x7FFD`, plain objects/arrays) or STRING_TAG
+/// (`0x7FFF`, heap strings) — may be masked down to a raw pointer for the runtime
+/// to dereference. Every other receiver shape keeps its full NaN-boxed bits:
+///
+/// * an INT32-tagged class ref (`0x7FFE`) keeps its tag so the runtime routes to
+///   the static field / method / accessor tables (test262 class/elements
+///   propertyHelper `isWritable(C, name)` does `C[name]`);
+/// * a plain number, SSO string, bigint, or bool/null/undefined keeps its bits
+///   so the by-name runtime helper recognizes the tag and returns `undefined`
+///   instead of masking the value's low 48 bits into a bogus heap address and
+///   dereferencing it.
+///
+/// The masking-everything-but-classref predecessor crashed on `(<number>)[k]`:
+/// the timestamp float `dayjs(1749820051142)` (`0x4279_7696_70ec_6000`) had its
+/// low 48 bits (`0x7696_70ec_6000`) masked into a plausible-looking heap pointer,
+/// and `js_typed_feedback_object_get_field_by_name_f64` then deref'd `ptr - 8`
+/// for the GcHeader → SIGSEGV (#5429). Keeping full bits routes the number
+/// through `normalize_raw_object_addr`, which rejects it (top16 `0x4279` masks to
+/// `0`), matching the dotted `n.format` path's receiver-tag triage.
+///
+/// When the receiver's heap-pointer-ness is known at compile time
+/// (`static_known` — a class or `.prototype` ref), pass full bits unconditionally;
+/// otherwise branch at runtime on the tag so a runtime class-ref value (e.g. a
+/// function parameter bound to a class — `function f(C, k){ return C[k]; }`) is
+/// handled too.
 pub(crate) fn classref_preserving_handle(
     blk: &mut crate::block::LlBlock,
     obj_bits: &str,
@@ -162,9 +180,12 @@ pub(crate) fn classref_preserving_handle(
         return obj_bits.to_string();
     }
     let top16 = blk.lshr(I64, obj_bits, "48");
-    let is_classref = blk.icmp_eq(I64, &top16, "32766"); // 0x7FFE
+    // (top16 & 0xFFFD) == 0x7FFD is true for exactly POINTER_TAG (0x7FFD) and
+    // STRING_TAG (0x7FFF) — the two heap-pointer-carrying tags.
+    let masked_tag = blk.and(I64, &top16, "65533"); // 0xFFFD
+    let is_heap_ptr = blk.icmp_eq(I64, &masked_tag, "32765"); // 0x7FFD
     let masked = blk.and(I64, obj_bits, POINTER_MASK_I64);
-    blk.select(crate::types::I1, &is_classref, I64, obj_bits, &masked)
+    blk.select(crate::types::I1, &is_heap_ptr, I64, &masked, obj_bits)
 }
 
 fn lower_class_method_bind(

--- a/test-files/test_gap_5429_computed_get_primitive_receiver.ts
+++ b/test-files/test_gap_5429_computed_get_primitive_receiver.ts
@@ -1,0 +1,44 @@
+// Gap test: computed-member get on a primitive (number) receiver must not
+// SIGSEGV. Regression for #5429 — `dayjs(1749820051142).format()` segfaulted
+// because the timestamp float (0x4279_7696_70ec_6000) had its low 48 bits
+// masked into a plausible-looking heap pointer by the computed-member get
+// path, which the by-name runtime helper then dereferenced. Reading a
+// property off a number returns `undefined` (or a bound primitive method),
+// never a crash.
+// Run: node --experimental-strip-types test_gap_5429_computed_get_primitive_receiver.ts
+
+// The exact bit pattern from the issue: a large millisecond timestamp whose
+// low 48 bits land in the platform heap range.
+const ms: any = 1749820051142;
+const key: any = "format";
+
+// Computed get — the crashing path. Must match the dotted-get result.
+console.log("computed missing:", ms[key]); // undefined
+console.log("dotted missing:", ms.format); // undefined
+
+// A primitive proto method read still resolves to a callable, not a crash.
+console.log("toString is fn:", typeof ms["toString"]); // function
+console.log("valueOf is fn:", typeof ms["valueOf"]); // function
+
+// Floats, ints, and other low-48-bit shapes all stay safe.
+const f: any = 3.141592653589793;
+const i: any = 42;
+console.log("float missing:", f["nope"], "int missing:", i["nope"]); // undefined undefined
+
+// Real object / array / string receivers keep working (heap-pointer tags are
+// still masked as before).
+const obj: any = { a: 1, b: 2 };
+const arr: any = [10, 20, 30];
+const str: any = "hello";
+const ka = "a";
+console.log("obj get:", obj[ka], "arr get:", arr["1"], "str len:", str["length"]);
+
+// Class-ref computed get (the test262 propertyHelper `C[name]` shape) is
+// unaffected — its tag bits are still preserved.
+class C {
+  static answer = 42;
+}
+function readStatic(K: any, k: string) {
+  return K[k];
+}
+console.log("classref get:", readStatic(C, "answer")); // 42


### PR DESCRIPTION
## Summary

Fixes #5429. `console.log(dayjs(1749820051142).format())` segfaulted with:

```
#0  js_typed_feedback_object_get_field_by_name_f64 ()
#1  perry_closure_node_modules...dayjs_dayjs_min_js ()
```

## Root cause

The crash reproduces without dayjs:

```ts
const n: any = 1749820051142;
const k: any = "format";
console.log(n[k]); // SIGSEGV (node: undefined)
```

A **computed** property read `n[k]` on a primitive number crashed; the **dotted** read `n.format` correctly returned `undefined`.

The computed-member get/set paths build the receiver handle via `classref_preserving_handle`, which masked *every* receiver except an INT32 class ref (`0x7FFE`) down to its low 48 bits. For the timestamp float `1749820051142` — f64 bits `0x4279_7696_70ec_6000` — masking produced `0x7696_70ec_6000`, which lands in the platform heap range. `js_typed_feedback_object_get_field_by_name_f64` then dereferenced `ptr - 8` to read the GcHeader and faulted.

The dotted path never crashed because it triages the receiver tag and only dereferences genuine pointers, routing non-pointer receivers through the runtime with their full NaN-boxed bits (so `normalize_raw_object_addr` rejects them).

## Fix

Mask only the two heap-pointer-carrying tags — POINTER_TAG (`0x7FFD`) and STRING_TAG (`0x7FFF`), i.e. `(top16 & 0xFFFD) == 0x7FFD`. Numbers, SSO strings, bigints, class refs, and bool/null/undefined keep their full bits, matching the dotted path's behavior. Class refs (`0x7FFE`) still pass full bits, so existing static-field routing (`function f(C, k){ return C[k]; }`) is unchanged.

## Verification

- The minimal repro and the full issue repro (both `dayjs(<ms>).format()` and the chained `dayjs().hour(6).minute(0)...` line) now run cleanly and print correct dates.
- Added `test-files/test_gap_5429_computed_get_primitive_receiver.ts` (byte-matches `node --experimental-strip-types`), covering number/float/int receivers plus regression coverage for object/array/string/class-ref receivers.
- `cargo test -p perry-codegen` green; the object/index/array/string/class gap-test subset shows no new failures (remaining diffs are pre-existing gaps: Object.freeze strict throws, `new.target`, `Symbol.toPrimitive` hints, TypedArray.sort validation, top-level await).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash that could occur during computed property access on primitive number receivers.

* **Tests**
  * Added regression test for computed member property access on primitive receivers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->