### PR TITLE
feat(runtime): #2656 — make WeakMap/WeakSet actually weak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## v0.5.1197 — feat(runtime): #2656 — make WeakMap/WeakSet actually weak
+
+WeakMap/WeakSet previously stored entries as plain `[key, value]` pair arrays that the
+GC traced strongly, so keys were never collected — weak in API only. Entries are now
+`CLASS_ID_WEAK_ENTRY` objects whose field-0 key is a weak GC slot (skipped by the
+strong-edge scanners, exactly like a WeakRef target / finalization-record target), with
+the value in field 1 (strong; `undefined` for a WeakSet, so the member isn't pinned
+through the value slot). The post-mark weak pass tombstones entries whose key was
+collected — nulling both slots so the value is released — and lookups treat a
+tombstoned (undefined-key) entry as empty. `set` reuses tombstone slots and `delete`
+compacts them, bounding growth. This directly reuses the existing WeakRef/
+FinalizationRegistry weak-slot machinery (`is_weak_target_trace_slot`,
+`weak_target_should_clear`, the post-mark walk) — no new GC phase.
+
+A key/value reachable only through the collection is now collectible; live entries are
+retained and values released when their key dies. Verified under the default GC and the
+auto-evacuation policy. Regression test:
+`crates/perry/tests/issue_2656_weak_collections_actually_weak.rs`.
+
+Out of scope: the `PERRY_GC_FORCE_EVACUATE` full-evacuation debug-stress mode
+over-collects weak targets in general (FinalizationRegistry has the same limitation) and
+is also subject to the separate strong-array-in-closure bug #5467 — no production GC mode
+(default, auto-evacuation) is affected.
+
 ## v0.5.1196 — fix(codegen): #5431 — cross-module call to a `$`-named exported function returned `undefined`
 
 Calling an exported function whose name contains a non-`[A-Za-z0-9_]` character (e.g.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1196
+**Current Version:** 0.5.1197
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5325,7 +5325,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "anyhow",
  "base64",
@@ -5382,14 +5382,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "cc",
  "libc",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "anyhow",
  "log",
@@ -5412,7 +5412,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5421,7 +5421,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5448,7 +5448,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "anyhow",
  "base64",
@@ -5461,7 +5461,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5469,7 +5469,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5498,14 +5498,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "serde",
  "serde_json",
@@ -5513,7 +5513,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1196"
+version = "0.5.1197"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5524,7 +5524,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "anyhow",
  "clap",
@@ -5539,14 +5539,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5554,7 +5554,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5571,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5605,7 +5605,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5613,7 +5613,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5621,7 +5621,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5629,7 +5629,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5637,7 +5637,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5645,14 +5645,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5681,7 +5681,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5695,7 +5695,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "bytes",
  "h2",
@@ -5718,7 +5718,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5728,7 +5728,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5739,7 +5739,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "bson",
  "futures-util",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5786,7 +5786,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5798,7 +5798,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5808,7 +5808,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5816,7 +5816,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5825,7 +5825,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5833,7 +5833,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -5843,14 +5843,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5859,7 +5859,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5877,7 +5877,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5889,7 +5889,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "brotli",
  "flate2",
@@ -5898,7 +5898,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5925,7 +5925,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5937,7 +5937,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "anyhow",
  "base64",
@@ -5970,7 +5970,7 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6062,7 +6062,7 @@ dependencies = [
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6072,7 +6072,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6080,14 +6080,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "base64",
  "itoa",
@@ -6104,7 +6104,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6114,7 +6114,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6137,7 +6137,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "base64",
  "block2",
@@ -6153,7 +6153,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "base64",
  "block2",
@@ -6168,7 +6168,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1196"
+version = "0.5.1197"
 
 [[package]]
 name = "perry-ui-test"
@@ -6176,11 +6176,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1196"
+version = "0.5.1197"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "base64",
  "block2",
@@ -6196,7 +6196,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "base64",
  "block2",
@@ -6212,7 +6212,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "block2",
  "libc",
@@ -6225,7 +6225,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "base64",
  "libc",
@@ -6242,14 +6242,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6263,7 +6263,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1196"
+version = "0.5.1197"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ strip = false
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1196"
+version = "0.5.1197"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/weakref.rs
+++ b/crates/perry-runtime/src/weakref.rs
@@ -5,8 +5,8 @@
 //! FinalizationRegistry cleanup jobs, which are queued after explicit `gc()`.
 
 use crate::array::{
-    js_array_alloc, js_array_alloc_with_length, js_array_get_f64, js_array_length,
-    js_array_push_f64, js_array_set_f64, ArrayHeader,
+    js_array_alloc, js_array_get_f64, js_array_length, js_array_push_f64, js_array_set_f64,
+    ArrayHeader,
 };
 use crate::object::{
     js_object_alloc_with_shape, js_object_get_field_by_name, js_object_set_field, ObjectHeader,
@@ -26,6 +26,13 @@ const FINREG_RECORD_SHAPE_ID: u32 = 0x7FFF_FE14;
 pub const CLASS_ID_WEAKREF: u32 = 0xFFFF_0029;
 pub const CLASS_ID_FINALIZATION_REGISTRY: u32 = 0xFFFF_002A;
 pub const CLASS_ID_FINALIZATION_RECORD: u32 = 0xFFFF_002B;
+/// A single WeakMap/WeakSet entry. Field 0 holds the key — a *weak* slot,
+/// skipped by the GC's strong-edge scanners exactly like a WeakRef target or a
+/// finalization record's target (see `is_weak_target_trace_slot`). Field 1
+/// holds the value (strong; for a WeakSet it is `undefined`). When the key is
+/// collected the post-mark pass tombstones both fields to `undefined`, which
+/// the lookups treat as an empty slot. Issue #2656.
+pub const CLASS_ID_WEAK_ENTRY: u32 = 0xFFFF_002C;
 
 const WEAKREF_TARGET_FIELD: usize = 0;
 const FINREG_CALLBACK_FIELD: usize = 0;
@@ -98,12 +105,18 @@ pub(crate) fn weak_collection_entries(obj: *const ObjectHeader) -> Vec<(f64, f64
         let len = js_array_length(entries_ptr) as usize;
         let mut entries = Vec::with_capacity(len);
         for i in 0..len {
-            let pair_val_f = js_array_get_f64(entries_ptr, i as u32);
-            let pair_ptr = (pair_val_f.to_bits() & 0x0000_FFFF_FFFF_FFFF) as *mut ArrayHeader;
-            if pair_ptr.is_null() {
+            let entry = weak_entry_at(entries_ptr, i);
+            if entry.is_null() {
                 continue;
             }
-            entries.push((js_array_get_f64(pair_ptr, 0), js_array_get_f64(pair_ptr, 1)));
+            let key_bits = object_field_bits(entry, WEAK_ENTRY_KEY_FIELD);
+            if key_bits == TAG_UNDEFINED {
+                continue; // tombstoned (key collected)
+            }
+            entries.push((
+                f64::from_bits(key_bits),
+                f64::from_bits(object_field_bits(entry, WEAK_ENTRY_VALUE_FIELD)),
+            ));
         }
         entries
     }
@@ -258,7 +271,9 @@ pub(crate) unsafe fn is_weak_target_trace_slot(
     }
     let obj = (header as *mut u8).add(crate::gc::GC_HEADER_SIZE) as *mut ObjectHeader;
     match (*obj).class_id {
-        CLASS_ID_WEAKREF | CLASS_ID_FINALIZATION_RECORD => {
+        // Field 0 is the weak target for all three: WeakRef's referent, a
+        // finalization record's target, and a WeakMap/WeakSet entry's key.
+        CLASS_ID_WEAKREF | CLASS_ID_FINALIZATION_RECORD | CLASS_ID_WEAK_ENTRY => {
             (*obj).field_count > 0 && slot == object_field_slot(obj, 0)
         }
         _ => false,
@@ -519,6 +534,12 @@ pub(crate) fn process_weak_targets_after_mark(
             CLASS_ID_FINALIZATION_REGISTRY => {
                 process_finreg_after_mark(obj, valid_ptrs, minor_only, enqueue_callbacks);
             }
+            // Each WeakMap/WeakSet entry is its own GcHeader-backed object, so
+            // the arena walk reaches it directly — exactly like a WeakRef. This
+            // mirrors the `CLASS_ID_WEAKREF` arm (which is correct under
+            // evacuation): the weak key slot's address is repaired by the
+            // copy/rewrite pass before this pass reads it.
+            CLASS_ID_WEAK_ENTRY => process_weak_entry_after_mark(obj, valid_ptrs, minor_only),
             _ => {}
         }
     });
@@ -532,6 +553,23 @@ unsafe fn process_weakref_after_mark(
     let target_bits = object_field_bits(obj, WEAKREF_TARGET_FIELD);
     if weak_target_should_clear(target_bits, valid_ptrs, minor_only) {
         write_object_field_bits_raw(obj, WEAKREF_TARGET_FIELD, TAG_UNDEFINED);
+    }
+}
+
+/// A live WeakMap/WeakSet entry whose key was collected is tombstoned: both the
+/// key and the value slots are set to `undefined` so the value becomes
+/// collectible (next cycle) and the lookups skip the slot. The entry object
+/// itself is reclaimed when `delete`/`set` next compacts the entries array (or
+/// when the whole collection dies). Mirrors `process_weakref_after_mark`.
+unsafe fn process_weak_entry_after_mark(
+    entry: *mut ObjectHeader,
+    valid_ptrs: &crate::gc::ValidPointerSet,
+    minor_only: bool,
+) {
+    let key_bits = object_field_bits(entry, WEAK_ENTRY_KEY_FIELD);
+    if weak_target_should_clear(key_bits, valid_ptrs, minor_only) {
+        write_object_field_bits_raw(entry, WEAK_ENTRY_KEY_FIELD, TAG_UNDEFINED);
+        write_object_field_bits_raw(entry, WEAK_ENTRY_VALUE_FIELD, TAG_UNDEFINED);
     }
 }
 
@@ -677,6 +715,47 @@ fn remove_finalization_record_from_registry(registry: f64, record: f64) {
 
 const WEAKMAP_SHAPE_ID: u32 = 0x7FFF_FE12;
 const WEAKSET_SHAPE_ID: u32 = 0x7FFF_FE13;
+const WEAK_ENTRY_SHAPE_ID: u32 = 0x7FFF_FE15;
+
+const WEAK_ENTRY_KEY_FIELD: usize = 0;
+const WEAK_ENTRY_VALUE_FIELD: usize = 1;
+
+/// Allocate a WeakMap/WeakSet entry object (`CLASS_ID_WEAK_ENTRY`). Field 0 is
+/// the key — a weak slot the GC's strong scanners skip (see
+/// `is_weak_target_trace_slot`), so a key reachable only through the collection
+/// is collectible. Field 1 is the value, traced strongly while the key is live.
+fn weak_entry_new(key: f64, value: f64) -> *mut ObjectHeader {
+    // Sentinel-named slots so `(entry as any).key` can't leak storage and the
+    // names never collide with user fields.
+    let packed = b"__perry_we_key\0__perry_we_value\0";
+    let entry =
+        js_object_alloc_with_shape(WEAK_ENTRY_SHAPE_ID, 2, packed.as_ptr(), packed.len() as u32);
+    js_object_set_field(
+        entry,
+        WEAK_ENTRY_KEY_FIELD as u32,
+        JSValue::from_bits(key.to_bits()),
+    );
+    js_object_set_field(
+        entry,
+        WEAK_ENTRY_VALUE_FIELD as u32,
+        JSValue::from_bits(value.to_bits()),
+    );
+    // Stamp the weak-entry class_id last (mirrors js_weakref_new) so the GC's
+    // weak-slot recognition keys off it on the next mark.
+    unsafe {
+        (*entry).class_id = CLASS_ID_WEAK_ENTRY;
+    }
+    entry
+}
+
+/// Read the entry-object pointer stored at `entries[i]`, or null. Entries hold
+/// `CLASS_ID_WEAK_ENTRY` object pointers (POINTER_TAG); the low 48 bits are the
+/// address regardless of tag.
+#[inline]
+unsafe fn weak_entry_at(entries: *mut ArrayHeader, i: usize) -> *mut ObjectHeader {
+    let v = js_array_get_f64(entries, i as u32);
+    (v.to_bits() & 0x0000_FFFF_FFFF_FFFF) as *mut ObjectHeader
+}
 
 // Reserved `ObjectHeader.class_id` markers for WeakMap/WeakSet instances.
 // These follow the same `0xFFFF00xx` reserved-builtin convention as
@@ -847,25 +926,42 @@ pub extern "C" fn js_weakmap_set(map: f64, key: f64, value: f64) -> f64 {
             return f64::from_bits(TAG_UNDEFINED);
         }
         let len = js_array_length(entries_ptr) as usize;
-        // Update existing pair if key matches.
+        // Update the existing entry if the key matches; remember the first
+        // tombstone (an entry whose key the GC collected) so a new key can
+        // reuse the freed slot instead of growing the array unboundedly.
+        let mut first_tomb: i64 = -1;
         for i in 0..len {
-            let pair_val_f = js_array_get_f64(entries_ptr, i as u32);
-            let pair_ptr = (pair_val_f.to_bits() & 0x0000_FFFF_FFFF_FFFF) as *mut ArrayHeader;
-            if pair_ptr.is_null() {
+            let entry = weak_entry_at(entries_ptr, i);
+            if entry.is_null() {
                 continue;
             }
-            let stored_key = js_array_get_f64(pair_ptr, 0);
-            if stored_key.to_bits() == key.to_bits() {
-                js_array_set_f64(pair_ptr, 1, value);
+            let stored_key = object_field_bits(entry, WEAK_ENTRY_KEY_FIELD);
+            if stored_key == TAG_UNDEFINED {
+                if first_tomb < 0 {
+                    first_tomb = i as i64;
+                }
+                continue;
+            }
+            if stored_key == key.to_bits() {
+                write_object_field_bits_raw(entry, WEAK_ENTRY_VALUE_FIELD, value.to_bits());
                 return map;
             }
         }
-        // Append new [key, value] pair.
-        let pair = js_array_alloc_with_length(2);
-        js_array_set_f64(pair, 0, key);
-        js_array_set_f64(pair, 1, value);
-        let pair_val = f64::from_bits(JSValue::array_ptr(pair).bits());
-        js_array_push_f64(entries_ptr, pair_val);
+        // Not present — build a fresh entry. This allocation may move objects,
+        // but `map`/`key`/`value` and the pointers below are live on the
+        // conservatively-scanned stack, so they stay pinned across it (same
+        // contract the rest of this module relies on).
+        let entry = weak_entry_new(key, value);
+        let entry_val = f64::from_bits(JSValue::pointer(entry as *const u8).bits());
+        let entries_ptr = entries_array(map_ptr);
+        if first_tomb >= 0 {
+            js_array_set_f64(entries_ptr, first_tomb as u32, entry_val);
+        } else {
+            // js_array_push_f64 may reallocate; rebind the entries field to the
+            // (possibly new) header so the append isn't lost.
+            let grown = js_array_push_f64(entries_ptr, entry_val);
+            js_object_set_field(map_ptr, 0, JSValue::array_ptr(grown));
+        }
     }
     map
 }
@@ -883,14 +979,16 @@ pub extern "C" fn js_weakmap_get(map: f64, key: f64) -> f64 {
         }
         let len = js_array_length(entries_ptr) as usize;
         for i in 0..len {
-            let pair_val_f = js_array_get_f64(entries_ptr, i as u32);
-            let pair_ptr = (pair_val_f.to_bits() & 0x0000_FFFF_FFFF_FFFF) as *mut ArrayHeader;
-            if pair_ptr.is_null() {
+            let entry = weak_entry_at(entries_ptr, i);
+            if entry.is_null() {
                 continue;
             }
-            let stored_key = js_array_get_f64(pair_ptr, 0);
-            if stored_key.to_bits() == key.to_bits() {
-                return js_array_get_f64(pair_ptr, 1);
+            let stored_key = object_field_bits(entry, WEAK_ENTRY_KEY_FIELD);
+            if stored_key == TAG_UNDEFINED {
+                continue; // tombstoned (key collected)
+            }
+            if stored_key == key.to_bits() {
+                return f64::from_bits(object_field_bits(entry, WEAK_ENTRY_VALUE_FIELD));
             }
         }
     }
@@ -910,13 +1008,15 @@ pub extern "C" fn js_weakmap_has(map: f64, key: f64) -> f64 {
         }
         let len = js_array_length(entries_ptr) as usize;
         for i in 0..len {
-            let pair_val_f = js_array_get_f64(entries_ptr, i as u32);
-            let pair_ptr = (pair_val_f.to_bits() & 0x0000_FFFF_FFFF_FFFF) as *mut ArrayHeader;
-            if pair_ptr.is_null() {
+            let entry = weak_entry_at(entries_ptr, i);
+            if entry.is_null() {
                 continue;
             }
-            let stored_key = js_array_get_f64(pair_ptr, 0);
-            if stored_key.to_bits() == key.to_bits() {
+            let stored_key = object_field_bits(entry, WEAK_ENTRY_KEY_FIELD);
+            if stored_key == TAG_UNDEFINED {
+                continue; // tombstoned (key collected)
+            }
+            if stored_key == key.to_bits() {
                 return f64::from_bits(TAG_TRUE);
             }
         }
@@ -937,19 +1037,24 @@ pub extern "C" fn js_weakmap_delete(map: f64, key: f64) -> f64 {
         }
         let len = js_array_length(entries_ptr) as usize;
         let mut found = false;
-        let new_arr = js_array_alloc(0);
+        // Rebuild without the deleted key AND without tombstones (entries whose
+        // key the GC already collected), reclaiming the entry objects.
+        let mut new_arr = js_array_alloc(0);
         for i in 0..len {
-            let pair_val_f = js_array_get_f64(entries_ptr, i as u32);
-            let pair_ptr = (pair_val_f.to_bits() & 0x0000_FFFF_FFFF_FFFF) as *mut ArrayHeader;
-            if pair_ptr.is_null() {
+            let entry = weak_entry_at(entries_ptr, i);
+            if entry.is_null() {
                 continue;
             }
-            let stored_key = js_array_get_f64(pair_ptr, 0);
-            if stored_key.to_bits() == key.to_bits() {
+            let stored_key = object_field_bits(entry, WEAK_ENTRY_KEY_FIELD);
+            if stored_key == TAG_UNDEFINED {
+                continue; // drop tombstone
+            }
+            if stored_key == key.to_bits() {
                 found = true;
                 continue;
             }
-            js_array_push_f64(new_arr, pair_val_f);
+            let entry_val = f64::from_bits(JSValue::pointer(entry as *const u8).bits());
+            new_arr = js_array_push_f64(new_arr, entry_val);
         }
         js_object_set_field(map_ptr, 0, JSValue::array_ptr(new_arr));
         if found {
@@ -1006,8 +1111,11 @@ pub extern "C" fn js_weakset_add(set: f64, value: f64) -> f64 {
     if !crate::collection_iter::is_entry_object(value) {
         throw_invalid_weakset_value();
     }
-    // Reuse js_weakmap_set with value as both key and value (matches JS Set spec).
-    js_weakmap_set(set, value, value);
+    // Store the member as the entry KEY (weak) with an `undefined` value. Using
+    // the member as the value too would pin it through the strong value slot and
+    // defeat weakness (#2656); a WeakSet only needs key presence, so the value
+    // is unused. `has`/`delete` match on the key alone.
+    js_weakmap_set(set, value, f64::from_bits(TAG_UNDEFINED));
     set
 }
 

--- a/crates/perry/tests/issue_2656_weak_collections_actually_weak.rs
+++ b/crates/perry/tests/issue_2656_weak_collections_actually_weak.rs
@@ -1,0 +1,115 @@
+//! Regression tests for #2656 — WeakMap/WeakSet are *actually* weak.
+//!
+//! Entries are stored as `CLASS_ID_WEAK_ENTRY` objects whose field-0 key is a
+//! weak GC slot (skipped by the strong-edge scanners, like a WeakRef target).
+//! A post-mark pass tombstones entries whose key was collected, so a key/value
+//! reachable only through the collection becomes collectible — while live
+//! entries are retained and values are released when their key dies.
+//!
+//! Verified under the default GC (and the auto-evacuation policy). The
+//! `PERRY_GC_FORCE_EVACUATE` full-evacuation stress mode is out of scope here:
+//! it over-collects weak targets generally (FinalizationRegistry too) and is
+//! also subject to the separate strong-array-in-closure bug #5467.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, entry: &std::path::Path) -> (bool, String) {
+    let output = dir.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let run = Command::new(&output).output().expect("run compiled binary");
+    (
+        run.status.success(),
+        String::from_utf8_lossy(&run.stdout).to_string(),
+    )
+}
+
+/// A WeakMap key reachable only through the map is collected (deref→undefined),
+/// its value is released, a live key's entry is retained, and a WeakSet member
+/// behaves the same.
+#[test]
+fn weakmap_weakset_keys_are_collectible() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+declare function gc(): void;
+function churn(n: number): void {
+  let j: any[] = [];
+  for (let i = 0; i < n; i++) { j.push({ i, p: "weak-" + i }); if (j.length > 64) j = []; }
+}
+
+const wm = new WeakMap<object, object>();
+const ws = new WeakSet<object>();
+const liveKey: any = { tag: "liveKey" };     // kept alive on purpose
+let weakDeadKey = new WeakRef({ m: "ph" });
+let weakDeadVal = new WeakRef({ m: "ph" });
+let weakLiveVal = new WeakRef({ m: "ph" });
+let weakDeadMember = new WeakRef({ m: "ph" });
+
+(function setup() {
+  // live key -> its value must be retained
+  const lv: any = { v: "liveVal" };
+  wm.set(liveKey, lv);
+  weakLiveVal = new WeakRef(lv);
+  // dead key -> key collected AND value released
+  let dk: any = { m: "deadKey" };
+  let dv: any = { m: "deadVal" };
+  wm.set(dk, dv);
+  weakDeadKey = new WeakRef(dk);
+  weakDeadVal = new WeakRef(dv);
+  dk = null; dv = null;
+  // live + dead WeakSet members
+  ws.add(liveKey);
+  let dm: any = { m: "deadMember" };
+  ws.add(dm);
+  weakDeadMember = new WeakRef(dm);
+  dm = null;
+})();
+
+for (let i = 0; i < 8; i++) { churn(40000); gc(); await Promise.resolve(); }
+
+console.log("deadKey collected:", weakDeadKey.deref() === undefined);
+console.log("deadVal released:", weakDeadVal.deref() === undefined);
+console.log("deadMember collected:", weakDeadMember.deref() === undefined);
+console.log("liveKey entry kept:", wm.has(liveKey) && (wm.get(liveKey) as any)?.v === "liveVal");
+console.log("liveVal kept:", weakLiveVal.deref() !== undefined);
+console.log("liveKey in set:", ws.has(liveKey));
+"#,
+    )
+    .expect("write entry");
+
+    let (ok, stdout) = compile_and_run(dir.path(), &entry);
+    assert!(ok, "binary crashed\nstdout:\n{stdout}");
+    for needle in [
+        "deadKey collected: true",
+        "deadVal released: true",
+        "deadMember collected: true",
+        "liveKey entry kept: true",
+        "liveVal kept: true",
+        "liveKey in set: true",
+    ] {
+        assert!(
+            stdout.contains(needle),
+            "expected `{needle}` in output:\n{stdout}"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #2656 (the WeakMap/WeakSet portion; WeakRef + FinalizationRegistry were already weak).

> **Stacked on #5461** (the array-push UAF fix). This branch includes that commit; review/merge #5461 first. The weakness work depends on it — `WeakMap` keys are commonly held in module-global arrays, which crashed before #5461.

## Problem

WeakMap/WeakSet stored entries as plain `[key, value]` pair arrays that the GC traced **strongly**, so keys reachable only through the collection were never collected — weak in name/API only. Repro: a key held only by a WeakMap stays alive across `gc()`.

## Fix

Store each entry as a `CLASS_ID_WEAK_ENTRY` object:
- **field 0 = key** — a *weak* GC slot, skipped by the strong-edge scanners exactly like a WeakRef target / finalization record target (`is_weak_target_trace_slot`).
- **field 1 = value** — strong (traced while the key is live); `undefined` for a WeakSet (storing the member as the value too would pin it and defeat weakness).

The existing post-mark weak pass tombstones entries whose key was collected (nulling both slots, so the value is released next cycle); lookups skip tombstoned (undefined-key) entries. `set` reuses tombstone slots and `delete` compacts them, bounding growth. This is a direct reuse of the proven WeakRef/FinalizationRegistry machinery — no new GC phase.

## Behavior (verified)

Under default GC **and** the auto-evacuation policy (`PERRY_GEN_GC_EVACUATE=1`):
- A WeakMap key / WeakSet member reachable only through the collection is collected (observed via a `WeakRef` + churn + `gc()`).
- Its value is released.
- Live entries are retained; `has`/`get` keep working; `instanceof`, iteration-placeholder inspect, and brand checks unaffected.

Regression test `crates/perry/tests/issue_2656_weak_collections_actually_weak.rs` (dead key collected, dead value released, dead WeakSet member collected, live entry + value retained, live member retained) is green. `perry-runtime` weakref unit test + 15 weak/collection `test_gap_*` files pass; the existing `issue_2656` WeakRef/FinalizationRegistry GC test is unaffected.

## Scope note (FORCE_EVACUATE)

The `PERRY_GC_FORCE_EVACUATE` full-evacuation **debug stress** mode (gc-stress CI; tag-gated, skips on PRs) over-collects weak targets in general — **FinalizationRegistry has the identical limitation** (its records are likewise non-root entry objects with a weak field-0). Root cause: `valid_ptrs` is built pre-copy, and a weak wrapper that is *itself* evacuated isn't resolvable in the post-mark liveness pass; non-moved WeakRef wrappers sidestep it. Fixing it needs GC copy-machinery changes (repairing weak slots of evacuated objects) and is left as a follow-up. The **crashes** seen under that mode come from the separate, pre-existing strong-array-in-closure bug **#5467**, not this change. No production GC mode (default, auto-evacuation) is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated `WeakMap` and `WeakSet` so entries are truly weak: collected keys are cleared correctly, and empty/tombstoned slots are handled so live entries remain available while dead ones are released.

* **Tests**
  * Added a regression test covering `WeakMap`/`WeakSet` behavior across garbage-collection churn, ensuring correctness for both keys and members.

* **Documentation / Release**
  * Updated the changelog and bumped the runtime version to `v0.5.1197`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->