### PR TITLE
fix: #5420 — remove accidental committed `vendor` symlink to an absolute machine path

### DIFF
--- a/vendor
+++ b/vendor
@@ -1,1 +1,0 @@
-/Users/amlug/projects/perry/perry/vendor


### PR DESCRIPTION
Fixes #5420.

## Problem

The repo-root `vendor` is a **committed symlink** pointing at `/Users/amlug/projects/perry/perry/vendor` — a specific developer's home directory — so it **dangles on every other checkout**:

```
$ ls -la vendor
vendor -> /Users/amlug/projects/perry/perry/vendor   # tracked, dangling everywhere else
```

It was added incidentally in `9107be1c` (#4723, an unrelated async-generator change), not intentionally.

## Why removal is the right fix

The root-level `vendor/` is meant to be **developer/CI-populated, never committed**:
- `scripts/node_core_subset.py` → `vendor/nodejs`, `scripts/test262_subset.py` → `vendor/test262` (local clones)
- `.github/workflows/node-core-subset.yml` `git clone`s into `vendor/nodejs` at runtime (it never relied on the symlink — and a dangling symlink there can only get in the way)
- `.gitignore` already contains a root-anchored `/vendor/`

So the intended shape is exactly **option 3** from the issue (git-ignored + produced by a setup/CI step). The committed symlink simply predated the ignore rule, which is why it stayed tracked.

The other `vendor/` references in the codebase (`file:./vendor/bloom`, `vendor/lib`, `vendor/google-sign-in/...`) are all **user-project** relative paths resolved at compile/publish time, not the perry repo root.

## Change

`git rm vendor` — untrack/remove the broken symlink. No other change needed:
- `/vendor/` (leading-slash anchored) keeps a freshly-populated root `vendor/` untracked **and does not affect** `crates/perry-audio-miniaudio/vendor/` (real committed C sources — verified still tracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor directory reference adjustment with no functional impact or user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->