### PR TITLE
fix(net): unbox BlockList.addSubnet's numeric prefix argument

### DIFF
--- a/crates/perry-ext-net/src/dispatch.rs
+++ b/crates/perry-ext-net/src/dispatch.rs
@@ -398,7 +398,11 @@ unsafe fn block_list_method(handle: i64, method: &str, args: &[f64]) -> Option<f
             // as a non-numeric value so it throws `ERR_INVALID_ARG_TYPE`, matching
             // Node (the parameter is required). Defaulting to a real number here
             // would silently accept the call as a `/0` subnet.
-            let prefix = args.get(1).copied().map(unbox_to_f64).unwrap_or_else(undefined);
+            let prefix = args
+                .get(1)
+                .copied()
+                .map(unbox_to_f64)
+                .unwrap_or_else(undefined);
             let family = args.get(2).copied().map(unbox_to_i64).unwrap_or(0);
             crate::js_net_block_list_add_subnet(handle, address, prefix, family)
         }

--- a/crates/perry-ext-net/src/dispatch.rs
+++ b/crates/perry-ext-net/src/dispatch.rs
@@ -77,6 +77,22 @@ fn unbox_to_i64(v: f64) -> i64 {
     (v.to_bits() & POINTER_MASK) as i64
 }
 
+/// Coerce a nanboxed JS number to a plain `f64`. perry stores small integers as
+/// a tagged int32 (`0x7FFE` high bits), not a raw double, so passing the raw
+/// nanboxed value where a real number is expected (e.g. `BlockList.addSubnet`'s
+/// `prefix: f64`) yields garbage bits. A non-int-tagged value is already an
+/// IEEE double and passes through unchanged.
+fn unbox_to_f64(v: f64) -> f64 {
+    const INT32_TAG: u64 = 0x7FFE_0000_0000_0000;
+    const INT32_MASK: u64 = 0x0000_0000_FFFF_FFFF;
+    let bits = v.to_bits();
+    if (bits & 0xFFFF_0000_0000_0000) == INT32_TAG {
+        ((bits & INT32_MASK) as u32 as i32) as f64
+    } else {
+        v
+    }
+}
+
 fn property_name<'a>(ptr: *const u8, len: usize) -> &'a str {
     if ptr.is_null() || len == 0 {
         ""
@@ -378,7 +394,7 @@ unsafe fn block_list_method(handle: i64, method: &str, args: &[f64]) -> Option<f
         }
         "addSubnet" => {
             let address = args.first().copied().map(unbox_to_i64).unwrap_or(0);
-            let prefix = args.get(1).copied().unwrap_or_else(undefined);
+            let prefix = args.get(1).copied().map(unbox_to_f64).unwrap_or(0.0);
             let family = args.get(2).copied().map(unbox_to_i64).unwrap_or(0);
             crate::js_net_block_list_add_subnet(handle, address, prefix, family)
         }

--- a/crates/perry-ext-net/src/dispatch.rs
+++ b/crates/perry-ext-net/src/dispatch.rs
@@ -394,7 +394,11 @@ unsafe fn block_list_method(handle: i64, method: &str, args: &[f64]) -> Option<f
         }
         "addSubnet" => {
             let address = args.first().copied().map(unbox_to_i64).unwrap_or(0);
-            let prefix = args.get(1).copied().map(unbox_to_f64).unwrap_or(0.0);
+            // A missing `prefix` must reach `js_net_validate_block_list_prefix`
+            // as a non-numeric value so it throws `ERR_INVALID_ARG_TYPE`, matching
+            // Node (the parameter is required). Defaulting to a real number here
+            // would silently accept the call as a `/0` subnet.
+            let prefix = args.get(1).copied().map(unbox_to_f64).unwrap_or_else(undefined);
             let family = args.get(2).copied().map(unbox_to_i64).unwrap_or(0);
             crate::js_net_block_list_add_subnet(handle, address, prefix, family)
         }

--- a/crates/perry/tests/blocklist_addsubnet_prefix.rs
+++ b/crates/perry/tests/blocklist_addsubnet_prefix.rs
@@ -31,11 +31,24 @@ console.log("out:", b.check("10.0.1.5", "ipv4"));     // outside /24
     .unwrap();
     let c = Command::new(perry_bin())
         .current_dir(dir.path())
-        .args(["compile", entry.to_str().unwrap(), "-o", out.to_str().unwrap()])
+        .args([
+            "compile",
+            entry.to_str().unwrap(),
+            "-o",
+            out.to_str().unwrap(),
+        ])
         .output()
         .unwrap();
-    assert!(c.status.success(), "compile failed: {}", String::from_utf8_lossy(&c.stderr));
+    assert!(
+        c.status.success(),
+        "compile failed: {}",
+        String::from_utf8_lossy(&c.stderr)
+    );
     let r = Command::new(&out).current_dir(dir.path()).output().unwrap();
-    assert!(r.status.success(), "run failed: {}", String::from_utf8_lossy(&r.stderr));
+    assert!(
+        r.status.success(),
+        "run failed: {}",
+        String::from_utf8_lossy(&r.stderr)
+    );
     assert_eq!(String::from_utf8_lossy(&r.stdout), "in: true\nout: false\n");
 }

--- a/crates/perry/tests/blocklist_addsubnet_prefix.rs
+++ b/crates/perry/tests/blocklist_addsubnet_prefix.rs
@@ -1,0 +1,41 @@
+//! Regression: net.BlockList.addSubnet must unbox its numeric `prefix` argument.
+//!
+//! The net-extension dispatch passed `prefix` to `js_net_block_list_add_subnet`
+//! (which takes `prefix: f64`) as the RAW nanboxed value. perry stores small
+//! integers as a tagged int32 (0x7FFE high bits), so the raw bits are not the
+//! real number — the subnet boundary was computed from garbage. A /24 must
+//! cover its 256 addresses and nothing beyond.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn block_list_add_subnet_respects_numeric_prefix() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.join("main.ts");
+    let out = dir.join("main_bin");
+    std::fs::write(
+        &entry,
+        r#"
+import { BlockList } from "net";
+const b: any = new BlockList();
+b.addSubnet("10.0.0.0", 24, "ipv4");
+console.log("in:", b.check("10.0.0.200", "ipv4"));    // inside /24
+console.log("out:", b.check("10.0.1.5", "ipv4"));     // outside /24
+"#,
+    )
+    .unwrap();
+    let c = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .args(["compile", entry.to_str().unwrap(), "-o", out.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(c.status.success(), "compile failed: {}", String::from_utf8_lossy(&c.stderr));
+    let r = Command::new(&out).current_dir(dir.path()).output().unwrap();
+    assert!(r.status.success(), "run failed: {}", String::from_utf8_lossy(&r.stderr));
+    assert_eq!(String::from_utf8_lossy(&r.stdout), "in: true\nout: false\n");
+}


### PR DESCRIPTION
## Symptom
`new BlockList().addSubnet(ip, 24, family)` computed the wrong subnet boundary (mis-classifying addresses), and in some paths surfaced as `Error: Invalid socket address`. Affects both aliased and un-aliased `net.BlockList`.

## Root cause
`crates/perry-ext-net/src/dispatch.rs` `addSubnet` arm passed `prefix` to `js_net_block_list_add_subnet` (signature `prefix: f64`) as the **raw nanboxed value** (`args.get(1).copied().unwrap_or_else(undefined)`), while `address`/`family` and the sibling methods (`addAddress`/`addRange`/`check`) unbox their numeric args. perry stores small integers as a **tagged int32** (`0x7FFE` high bits), so the raw bits are not the real number — `js_net_validate_block_list_prefix` received garbage.

## Fix
Add `unbox_to_f64` (tagged-int32 → `f64`, or pass through an already-`f64` double) and use it for `prefix`.

## Validation
- New `crates/perry/tests/blocklist_addsubnet_prefix.rs`: a `/24` covers `10.0.0.200` (true) but not `10.0.1.5` (false) — perry == node.
- Full sequence `addSubnet("127.0.0.0",8,"ipv4")` + IPv6 `addSubnet("::ffff:127.0.0.0",104,"ipv6")` + `check` matches node.

Found while bringing up `@anthropic-ai/claude-code` natively (its proxy parsing builds a `BlockList` of no-proxy CIDRs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `net.BlockList.addSubnet` so the `prefix` argument is correctly interpreted as a standard numeric value (including correct behavior when `prefix` is omitted), ensuring accurate subnet/IP inclusion and exclusion.

* **Tests**
  * Added a regression test that builds and runs a small program to verify IPv4 `/24` subnet inclusion/exclusion outcomes exactly match expectations based on the provided `prefix`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->