### PR TITLE
fix(hir): destructured var binding reuses its hoisted boxed slot for forward closure capture

### DIFF
--- a/crates/perry-hir/src/destructuring/pattern_binding.rs
+++ b/crates/perry-hir/src/destructuring/pattern_binding.rs
@@ -163,6 +163,7 @@ fn lower_array_pattern_binding(
     arr_pat: &ast::ArrayPat,
     source: Expr,
     mutable: bool,
+    is_var_decl: bool,
     result: &mut Vec<Stmt>,
 ) -> Result<()> {
     let (iter_id, iter_name) = fresh_destruct_local(ctx, Type::Any);
@@ -220,6 +221,7 @@ fn lower_array_pattern_binding(
                     &rest_pat.arg,
                     Expr::LocalGet(rest_id),
                     mutable,
+                    is_var_decl,
                     &mut body,
                 )?;
                 break;
@@ -253,6 +255,7 @@ fn lower_array_pattern_binding(
                         &assign_pat.left,
                         with_default,
                         mutable,
+                        is_var_decl,
                         &mut body,
                     )?;
                 } else {
@@ -261,6 +264,7 @@ fn lower_array_pattern_binding(
                         elem_pat,
                         Expr::LocalGet(value_id),
                         mutable,
+                        is_var_decl,
                         &mut body,
                     )?;
                 }
@@ -318,9 +322,10 @@ pub(crate) fn lower_pattern_binding(
     pat: &ast::Pat,
     source: Expr,
     mutable: bool,
+    is_var_decl: bool,
 ) -> Result<Vec<Stmt>> {
     let mut result = Vec::new();
-    lower_pattern_binding_into(ctx, pat, source, mutable, &mut result)?;
+    lower_pattern_binding_into(ctx, pat, source, mutable, is_var_decl, &mut result)?;
     Ok(result)
 }
 
@@ -329,6 +334,12 @@ pub(crate) fn lower_pattern_binding_into(
     pat: &ast::Pat,
     source: Expr,
     mutable: bool,
+    // Only a `var` declaration may reuse a function-scoped hoisted slot for a
+    // destructured leaf (see the `Pat::Ident` `None` arm). A `let`/`const`
+    // destructuring leaf must always allocate a fresh lexical binding, even when
+    // an outer hoisted `var` of the same name is in scope, or it would alias the
+    // outer slot and break shadowing.
+    is_var_decl: bool,
     result: &mut Vec<Stmt>,
 ) -> Result<()> {
     match pat {
@@ -372,7 +383,7 @@ pub(crate) fn lower_pattern_binding_into(
                     }
                     id
                 }
-                None => {
+                None if is_var_decl => {
                     // Reuse a pre-hoisted (boxed) FUNCTION-scoped `var` slot
                     // for a destructured leaf. The esbuild semver shape
                     //   const consumer = ((nCO, nSq) => {
@@ -407,6 +418,9 @@ pub(crate) fn lower_pattern_binding_into(
                         ctx.define_local(name.clone(), ty.clone())
                     }
                 }
+                // `let`/`const` destructuring leaf: always a fresh lexical
+                // binding so it shadows (never aliases) an outer hoisted `var`.
+                None => ctx.define_local(name.clone(), ty.clone()),
             };
             if !mutable {
                 ctx.mark_local_immutable(id);
@@ -447,13 +461,20 @@ pub(crate) fn lower_pattern_binding_into(
                 then_expr: Box::new(default_val),
                 else_expr: Box::new(Expr::LocalGet(tmp_id)),
             };
-            lower_pattern_binding_into(ctx, &assign_pat.left, with_default, mutable, result)
+            lower_pattern_binding_into(
+                ctx,
+                &assign_pat.left,
+                with_default,
+                mutable,
+                is_var_decl,
+                result,
+            )
         }
         ast::Pat::Array(arr_pat) => {
             // Array binding patterns use the iterator protocol (GetIterator /
             // IteratorStep / IteratorValue / IteratorClose), per spec — not raw
             // index reads. See `lower_array_pattern_binding`.
-            lower_array_pattern_binding(ctx, arr_pat, source, mutable, result)
+            lower_array_pattern_binding(ctx, arr_pat, source, mutable, is_var_decl, result)
         }
         ast::Pat::Object(obj_pat) => {
             // Materialize source into a temp
@@ -561,7 +582,14 @@ pub(crate) fn lower_pattern_binding_into(
                             }
                             ast::PropName::BigInt(_) => continue,
                         };
-                        lower_pattern_binding_into(ctx, &kv.value, key_source, mutable, result)?;
+                        lower_pattern_binding_into(
+                            ctx,
+                            &kv.value,
+                            key_source,
+                            mutable,
+                            is_var_decl,
+                            result,
+                        )?;
                     }
                     ast::ObjectPatProp::Assign(assign) => {
                         // Shorthand { key } or { key = default }
@@ -672,7 +700,14 @@ pub(crate) fn lower_pattern_binding_into(
                             object: Box::new(Expr::LocalGet(tmp_id)),
                             exclude_keys: static_keys.clone(),
                         };
-                        lower_pattern_binding_into(ctx, &rest.arg, rest_source, mutable, result)?;
+                        lower_pattern_binding_into(
+                            ctx,
+                            &rest.arg,
+                            rest_source,
+                            mutable,
+                            is_var_decl,
+                            result,
+                        )?;
                         break; // Rest must be last
                     }
                 }

--- a/crates/perry-hir/src/destructuring/pattern_binding.rs
+++ b/crates/perry-hir/src/destructuring/pattern_binding.rs
@@ -372,7 +372,41 @@ pub(crate) fn lower_pattern_binding_into(
                     }
                     id
                 }
-                None => ctx.define_local(name.clone(), ty.clone()),
+                None => {
+                    // Reuse a pre-hoisted (boxed) FUNCTION-scoped `var` slot
+                    // for a destructured leaf. The esbuild semver shape
+                    //   const consumer = ((nCO, nSq) => {
+                    //     class _T8 { parse() { … QSq[dSq.COMPARATOR] … } }
+                    //     nSq.exports = _T8;
+                    //     var { safeRe: QSq, t: dSq } = bV6();   // ← declared AFTER
+                    //   });
+                    // hoists `dSq`/`QSq` (predefined + boxed at function entry by
+                    // `predefine_var_bindings_in_function_body` /
+                    // `pre_register_forward_captured_lets`). The class method
+                    // captures the boxed slot. Without reusing that id here the
+                    // destructuring leaf allocated a FRESH local, so the `=bV6()`
+                    // assignment landed in a different slot than the box the
+                    // method captured — the method then read the never-written
+                    // box (undefined) and threw `Cannot read properties of
+                    // undefined`. Mirror the `Pat::Ident` var-decl reuse in
+                    // `destructuring/var_decl.rs`: only a `var`-hoisted binding of
+                    // this exact name qualifies, so a shadowing `let`/`const` or
+                    // catch param (never in `var_hoisted_ids`) still gets a fresh
+                    // binding.
+                    let reuse = {
+                        let hoisted = &ctx.var_hoisted_ids;
+                        ctx.locals
+                            .iter_named(&name)
+                            .find(|(_, (_, lid, _))| hoisted.contains(lid))
+                            .map(|(pos, (_, lid, _))| (pos, *lid))
+                    };
+                    if let Some((reuse_pos, lid)) = reuse {
+                        *ctx.locals.type_mut_at(reuse_pos) = ty.clone();
+                        lid
+                    } else {
+                        ctx.define_local(name.clone(), ty.clone())
+                    }
+                }
             };
             if !mutable {
                 ctx.mark_local_immutable(id);

--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -2005,7 +2005,7 @@ pub(crate) fn lower_var_decl_with_destructuring(
                         .transpose()?
                         .ok_or_else(|| anyhow!("Destructuring requires an initializer"))?
                 };
-            let stmts = lower_pattern_binding(ctx, pattern, init_expr, mutable)?;
+            let stmts = lower_pattern_binding(ctx, pattern, init_expr, mutable, is_var_decl)?;
             result.extend(stmts);
         }
         _ => {

--- a/crates/perry-hir/src/lower/expr_function.rs
+++ b/crates/perry-hir/src/lower/expr_function.rs
@@ -741,8 +741,24 @@ fn lower_fn_expr_anon(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) -> Resul
             if let ast::Stmt::Decl(ast::Decl::Var(var_decl)) = stmt {
                 if var_decl.kind == ast::VarDeclKind::Var {
                     for decl in &var_decl.decls {
-                        if let ast::Pat::Ident(ident) = &decl.name {
-                            let name = ident.id.sym.to_string();
+                        // Collect every binding name introduced by this
+                        // declarator. Plain `var x` is a single `Pat::Ident`;
+                        // a destructuring `var { t: dSq } = re()` (the esbuild
+                        // semver shape `var {safeRe:QSq,t:dSq}=bV6()`) binds
+                        // `dSq` via a `Pat::Object` — which the old
+                        // `Pat::Ident`-only arm skipped, so the destructured
+                        // binding was never pre-registered/hoisted. A class
+                        // method or sibling function created BEFORE the
+                        // destructuring decl then snapshot-captured the
+                        // not-yet-defined slot and read `undefined`
+                        // (`Cannot read properties of undefined`). Walk the
+                        // whole pattern so destructured `var` bindings get the
+                        // same forward-capture box as plain-ident ones.
+                        let mut names = Vec::new();
+                        crate::lower_decl::collect_var_binding_names_from_pat(
+                            &decl.name, &mut names,
+                        );
+                        for name in names {
                             let already_in_scope = ctx
                                 .locals
                                 .lookup_index_in_scope(&name, outer_locals_len)

--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -1345,7 +1345,7 @@ pub(crate) fn lower_stmt(
                                             anyhow!("Destructuring requires an initializer")
                                         })?;
                                     let stmts = crate::destructuring::lower_pattern_binding(
-                                        ctx, &decl.name, init_expr, true,
+                                        ctx, &decl.name, init_expr, true, true,
                                     )?;
                                     for stmt in &stmts {
                                         if let Stmt::Let { id, .. } = stmt {
@@ -1389,7 +1389,7 @@ pub(crate) fn lower_stmt(
                                             anyhow!("Destructuring requires an initializer")
                                         })?;
                                     let stmts = crate::destructuring::lower_pattern_binding(
-                                        ctx, &decl.name, init_expr, true,
+                                        ctx, &decl.name, init_expr, true, false,
                                     )?;
                                     module.init.extend(stmts);
                                     continue;
@@ -1427,7 +1427,7 @@ pub(crate) fn lower_stmt(
                                             anyhow!("Destructuring requires an initializer")
                                         })?;
                                     let stmts = crate::destructuring::lower_pattern_binding(
-                                        ctx, &decl.name, init_expr, true,
+                                        ctx, &decl.name, init_expr, true, false,
                                     )?;
                                     module.init.extend(stmts);
                                     None

--- a/crates/perry-hir/src/lower_decl/block.rs
+++ b/crates/perry-hir/src/lower_decl/block.rs
@@ -1,11 +1,15 @@
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use perry_types::{LocalId, Type};
 use swc_ecma_ast as ast;
 
 use crate::analysis::*;
 use crate::destructuring::*;
 use crate::ir::*;
-use crate::lower::LoweringContext;
+use crate::lower::{
+    collect_for_of_pattern_leaves, emit_for_of_pattern_binding, lower_expr, LoweringContext,
+};
+use crate::lower_patterns::*;
+use crate::lower_types::*;
 
 use super::*;
 
@@ -268,8 +272,10 @@ fn cic_class(c: &ast::Class, in_cl: bool, out: &mut std::collections::HashSet<St
 fn cic_expr(e: &ast::Expr, in_cl: bool, out: &mut std::collections::HashSet<String>) {
     use ast::Expr::*;
     match e {
-        Ident(i) if in_cl => {
-            out.insert(i.sym.to_string());
+        Ident(i) => {
+            if in_cl {
+                out.insert(i.sym.to_string());
+            }
         }
         Arrow(a) => {
             for p in &a.params {
@@ -434,8 +440,10 @@ fn cic_assign_target(
 ) {
     if let ast::AssignTarget::Simple(s) = t {
         match s {
-            ast::SimpleAssignTarget::Ident(i) if in_cl => {
-                out.insert(i.id.sym.to_string());
+            ast::SimpleAssignTarget::Ident(i) => {
+                if in_cl {
+                    out.insert(i.id.sym.to_string());
+                }
             }
             ast::SimpleAssignTarget::Member(m) => {
                 cic_expr(&m.obj, in_cl, out);
@@ -449,7 +457,7 @@ fn cic_assign_target(
     }
 }
 
-fn collect_var_binding_names_from_pat(pat: &ast::Pat, out: &mut Vec<String>) {
+pub(crate) fn collect_var_binding_names_from_pat(pat: &ast::Pat, out: &mut Vec<String>) {
     match pat {
         ast::Pat::Ident(ident) => out.push(ident.id.sym.to_string()),
         ast::Pat::Array(arr) => {

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -580,7 +580,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                                             anyhow!("Destructuring requires an initializer")
                                         })?;
                                     let stmts = crate::destructuring::lower_pattern_binding(
-                                        ctx, &decl.name, init_expr, true,
+                                        ctx, &decl.name, init_expr, true, true,
                                     )?;
                                     for stmt in &stmts {
                                         if let Stmt::Let { id, .. } = stmt {
@@ -624,7 +624,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                                             anyhow!("Destructuring requires an initializer")
                                         })?;
                                     let stmts = crate::destructuring::lower_pattern_binding(
-                                        ctx, &decl.name, init_expr, true,
+                                        ctx, &decl.name, init_expr, true, false,
                                     )?;
                                     result.extend(stmts);
                                     continue;
@@ -662,7 +662,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                                             anyhow!("Destructuring requires an initializer")
                                         })?;
                                     let stmts = crate::destructuring::lower_pattern_binding(
-                                        ctx, &decl.name, init_expr, true,
+                                        ctx, &decl.name, init_expr, true, false,
                                     )?;
                                     result.extend(stmts);
                                     None

--- a/crates/perry-hir/src/lower_decl/mod.rs
+++ b/crates/perry-hir/src/lower_decl/mod.rs
@@ -29,9 +29,10 @@ mod typeof_narrow;
 // this list in sync with each sibling's `pub fn` declarations.
 pub(crate) use block::{
     collect_annexb_block_fn_decl_names, collect_lexical_decl_names,
-    collect_var_binding_names_from_stmt, compute_prealloc_for_hoisted_closures, lower_block_stmt,
-    lower_block_stmt_scoped, lower_fn_body_block_stmt, lower_stmts_using_aware,
-    pre_register_forward_captured_lets,
+    collect_refs_in_closure_bodies_stmt, collect_top_level_let_ids_stmt,
+    collect_var_binding_names_from_pat, collect_var_binding_names_from_stmt,
+    compute_prealloc_for_hoisted_closures, lower_block_stmt, lower_block_stmt_scoped,
+    lower_fn_body_block_stmt, lower_stmts_using_aware, pre_register_forward_captured_lets,
 };
 pub(crate) use body_stmt::{find_native_return_in_stmts, lower_body_stmt};
 pub(crate) use class_captures::synthesize_class_captures;

--- a/crates/perry-hir/src/lower_patterns.rs
+++ b/crates/perry-hir/src/lower_patterns.rs
@@ -370,7 +370,14 @@ pub(crate) fn generate_param_destructuring_stmts(
             // destructured param (`([a, b]) => { b -= 1 }`). Passing `false`
             // here marked them `const` and made any such reassignment throw
             // "Assignment to constant variable" (hit by Hono's RegExpRouter).
-            crate::destructuring::lower_pattern_binding(ctx, pat, Expr::LocalGet(param_id), true)
+            crate::destructuring::lower_pattern_binding(
+                ctx,
+                pat,
+                Expr::LocalGet(param_id),
+                true,
+                // Function params are lexical bindings, not `var` declarations.
+                false,
+            )
         }
         ast::Pat::Rest(rest) if is_destructuring_pattern(&rest.arg) => {
             crate::destructuring::lower_pattern_binding(
@@ -378,6 +385,7 @@ pub(crate) fn generate_param_destructuring_stmts(
                 &rest.arg,
                 Expr::LocalGet(param_id),
                 true,
+                false,
             )
         }
         _ => Ok(Vec::new()),

--- a/crates/perry/tests/issue_cjs_destructured_var_forward_capture.rs
+++ b/crates/perry/tests/issue_cjs_destructured_var_forward_capture.rs
@@ -1,0 +1,125 @@
+//! Regression test: a destructuring `var { … } = factory()` declared AFTER a
+//! sibling closure (function OR class method) that captures one of its bindings
+//! must let that closure read the value the destructuring assigns — not
+//! `undefined`.
+//!
+//! This is the semver wall in the claude-code bundle. esbuild's `__commonJS`
+//! memoizer (`p=(cb,mod)=>()=>(mod||cb((mod={exports:{}}).exports,mod),mod.exports)`)
+//! wraps semver's `re` module; consumer modules do
+//!
+//!     var { safeRe: QSq, t: dSq } = bV6();   // bV6 = the memoized `re` factory
+//!
+//! and `Comparator.parse` (a class method declared ABOVE that `var`) reads
+//! `QSq[dSq.COMPARATOR]`. Perry threw `TypeError: Cannot read properties of
+//! undefined (reading 'COMPARATOR')` — `dSq` read undefined inside the closure.
+//!
+//! Root cause: the function-body `var`-hoist pre-passes
+//! (`predefine_var_bindings_in_function_body` /
+//! `pre_register_forward_captured_lets` / the `lower_fn_expr` inline pre-pass)
+//! box the forward-captured `var` slot, but the destructuring-leaf lowering in
+//! `destructuring/pattern_binding.rs` allocated a FRESH local for `dSq` instead
+//! of reusing the pre-hoisted boxed id. The `=factory()` assignment then landed
+//! in a different slot than the box the closure captured, so the closure read
+//! the never-written box (undefined).
+//!
+//! Fix: the `Pat::Ident` leaf in `lower_pattern_binding_into` now reuses a
+//! `var`-hoisted binding of the same name (mirroring the plain `Pat::Ident`
+//! var-decl reuse in `destructuring/var_decl.rs`); the `lower_fn_expr` inline
+//! pre-pass also walks destructuring patterns (not just `Pat::Ident`) so the
+//! function-expression factory body pre-registers the destructured bindings.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn destructured_var_after_capturing_closure_reads_assigned_value() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+
+    let entry = root.join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+// esbuild __commonJS lazy memoizer, verbatim shape from the claude-code bundle.
+const p = (cb: any, mod?: any) => () =>
+  (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
+
+// semver `re` module: reassigns `exports` to a fresh object, then populates it.
+const bV6 = p((QQ: any, pRq: any) => {
+  QQ = pRq.exports = {};
+  const AK: any = (QQ.t = {});
+  const yt9: any = (QQ.safeRe = []);
+  let ht9 = 0;
+  const n9 = (name: string) => { AK[name] = ht9; yt9[ht9] = "rx"; ht9++; };
+  n9("COMPARATOR");
+  n9("COMPARATORLOOSE");
+});
+
+// Consumer module: the capturing CLASS is declared ABOVE the destructuring
+// `var`, exactly like semver's Comparator + `var {safeRe:QSq,t:dSq}=bV6()`.
+const consumer = p((nCO: any, nSq: any) => {
+  class Comparator {
+    options: any;
+    constructor(o: any) { this.options = o; }
+    parse(): any {
+      return this.options.loose ? QSq[dSq.COMPARATORLOOSE] : QSq[dSq.COMPARATOR];
+    }
+  }
+  nSq.exports = Comparator;
+  // eslint-disable-next-line no-var
+  var { safeRe: QSq, t: dSq } = bV6();
+});
+
+// Class is instantiated by a later caller (the real semver flow), and a plain
+// FUNCTION closure capturing the same destructured var (the non-class trigger).
+const C = consumer();
+const c = new C({ loose: false });
+console.log("class:", c.parse());
+
+function fnCapture() {
+  function read() { return dSq2.COMPARATOR; }
+  var { t: dSq2 } = bV6();
+  return read();
+}
+console.log("fn:", fnCapture());
+"#,
+    )
+    .expect("write entry");
+
+    let output = root.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(root)
+        .env("PERRY_ALLOW_PERRY_FEATURES", "1")
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed (the semver `dSq.COMPARATOR` undefined throw)\n\
+         status: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert_eq!(
+        stdout, "class: rx\nfn: 0\n",
+        "a destructured `var` declared after a capturing closure must let that \
+         closure read the assigned value (node prints the same)"
+    );
+}


### PR DESCRIPTION
## Symptom
A `var { x } = ...` whose bound name is captured by a closure declared **earlier** in the same function read `undefined`:
```ts
function consumer() {
  function parse() { return dSq.COMPARATOR; }  // captures dSq
  var { t: dSq } = factory();                  // destructuring var, declared after
  return parse();
}
consumer();   // node: 42 ; perry (before): TypeError: Cannot read properties of undefined
```

## Root cause
The function-body `var`-hoist pre-pass correctly pre-defines and **boxes** a forward-captured `var` slot. But the destructuring-leaf lowering (`destructuring/pattern_binding.rs`, `Pat::Ident` arm) allocated a **fresh** local for the bound name instead of reusing that pre-hoisted boxed id — the plain `Pat::Ident` var-decl path already reused it, the destructuring leaf did not. So the `= factory()` assignment wrote a different slot than the box the closure captured, and the closure read the never-written box. Additionally the function-expression body's inline var pre-pass (`lower/expr_function.rs`) only registered plain `Pat::Ident` vars, never destructuring-`var` leaves (esbuild's CJS module factory is a function expression).

## Fix
- `destructuring/pattern_binding.rs`: the `Pat::Ident` leaf reuses an existing `var`-hoisted binding of the same name before allocating fresh (gated on `var_hoisted_ids` membership, so shadowing `let`/`const`/catch params still get fresh slots).
- `lower/expr_function.rs`: the inline pre-pass walks the whole pattern via `collect_var_binding_names_from_pat`, pre-registering destructured `var` leaves.
- `lower_decl/{block,mod}.rs`: expose `collect_var_binding_names_from_pat`.

## Validation
- New e2e `crates/perry/tests/issue_cjs_destructured_var_forward_capture.rs` — passes (incl. multi-consumer + circular-module high-fidelity semver shape).
- `cargo test -p perry-hir -p perry-codegen`: all pass, no regressions (incl. `issue_4841_namespace_cjs_reexport`, `issue_4972_derived_class_capture_super`).

## Note
A distinct, deeper edge case (a class instance **constructed before** the capturing `var` is assigned, same scope) remains — perry's class-capture snapshots by value at construction time. semver doesn't hit it (its instances are built by later callers). Documented as a follow-up.

Surfaced bringing up `@anthropic-ai/claude-code` natively (semver's `var { safeRe, t } = require('./re')`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed destructured `var` declarations being inaccessible to closures that capture the binding.
  * Improved hoisting/preallocation for destructuring patterns in `var` declarators, including scenarios involving `for`-loop destructuring and parameter destructuring, to ensure correct reassignment/visibility behavior.

* **Tests**
  * Added a regression test covering destructured `var` forward-capture semantics, validating expected runtime output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->