### PR TITLE
fix(runtime): #5268 — getOwnPropertyNames enumerates a native module's exports, not `__module__`

### DIFF
--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -932,6 +932,22 @@ pub extern "C" fn js_object_get_own_property_names(obj_value: f64) -> f64 {
                 return f64::from_bits((empty as u64) | 0x7FFD_0000_0000_0000);
             }
         }
+        // #5268: a native-module namespace/default object (`fs`, `path`, …)
+        // must enumerate its export surface here, not the internal
+        // `__module__` sentinel that the generic field walk would return.
+        // graceful-fs's `clone.js` does
+        // `getOwnPropertyNames(fs).forEach(k => defineProperty(copy, k,
+        // getOwnPropertyDescriptor(fs, k)))`; with only `__module__` listed,
+        // the clone dropped every fs method (`readFileSync` → undefined).
+        // Mirror `Object.keys` (vt_own_keys_array → native_module_enumerable_keys).
+        if obj_jv.is_pointer() {
+            let obj_ptr = crate::value::js_nanbox_get_pointer(obj_value) as *const ObjectHeader;
+            if !obj_ptr.is_null() {
+                if let Some(arr) = super::native_module::vt_own_keys_array(obj_ptr) {
+                    return f64::from_bits((arr as u64) | 0x7FFD_0000_0000_0000);
+                }
+            }
+        }
         if let Some(str_value) = boxed_string_payload(obj_value) {
             return boxed_string_own_property_names(obj_value, str_value);
         }

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -8621,8 +8621,12 @@ unsafe fn vt_get_own_field(
 
 /// `Object.keys(namespace)` — fresh array of the module's enumerable
 /// keys. `None` when the module is unknown; caller falls back to the
-/// generic keys_array path.
-unsafe fn vt_own_keys_array(obj: *const ObjectHeader) -> Option<*mut crate::array::ArrayHeader> {
+/// generic keys_array path. Also reused by `Object.getOwnPropertyNames`
+/// (#5268): a native-module object must enumerate its export surface there
+/// too, not the internal `__module__` sentinel.
+pub(crate) unsafe fn vt_own_keys_array(
+    obj: *const ObjectHeader,
+) -> Option<*mut crate::array::ArrayHeader> {
     let module_name = read_native_module_name(obj)?;
     let keys = native_module_enumerable_keys(&module_name)?;
     let include_permission = matches!(

--- a/crates/perry/tests/issue_5268_native_module_get_own_property_names.rs
+++ b/crates/perry/tests/issue_5268_native_module_get_own_property_names.rs
@@ -1,0 +1,96 @@
+//! Regression test for #5268 — `Object.getOwnPropertyNames` on a native-module
+//! object (`fs`, `path`, …) must enumerate the module's export surface, not the
+//! internal `__module__` sentinel.
+//!
+//! graceful-fs's `clone.js` clones the `fs` module via
+//! `getOwnPropertyNames(fs).forEach(k => defineProperty(copy, k,
+//! getOwnPropertyDescriptor(fs, k)))`. Before the fix, `getOwnPropertyNames(fs)`
+//! returned only `["__module__"]` (the generic field walk saw just that
+//! sentinel), so the clone dropped every fs method — `gfs.readFileSync` resolved
+//! to `undefined`, and `fs-extra`/`graceful-fs` were unusable. (The separate
+//! `Object prototype may only be an Object or null: undefined` crash from the
+//! same issue was fixed earlier by #5269.)
+//!
+//! Fix: route native-module objects through the same `vt_own_keys_array`
+//! (`native_module_enumerable_keys`) path `Object.keys` already used.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, entry: &std::path::Path) -> (bool, String) {
+    let output = dir.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let run = Command::new(&output).output().expect("run compiled binary");
+    (
+        run.status.success(),
+        String::from_utf8_lossy(&run.stdout).to_string(),
+    )
+}
+
+#[test]
+fn native_module_get_own_property_names_lists_exports_and_clones() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+import fs from "fs"
+import path from "path"
+
+const names = Object.getOwnPropertyNames(fs)
+console.log("fs.gOPN.includes(readFileSync):", names.includes("readFileSync"))
+console.log("fs.gOPN.includes(__module__):", names.includes("__module__"))
+console.log("fs.gOPN.count>50:", names.length > 50)
+console.log("path.gOPN.includes(join):", Object.getOwnPropertyNames(path).includes("join"))
+
+// graceful-fs clone.js shape: copy fs via getOwnPropertyNames + descriptors
+const copy: any = {}
+for (const key of Object.getOwnPropertyNames(fs)) {
+  const d = Object.getOwnPropertyDescriptor(fs as any, key)
+  if (d) Object.defineProperty(copy, key, d)
+}
+console.log("clone.readFileSync:", typeof copy.readFileSync)
+console.log("clone.writeFileSync:", typeof copy.writeFileSync)
+
+// non-module objects are unchanged (getOwnPropertyNames keeps non-enumerable)
+const o: any = { a: 1 }
+Object.defineProperty(o, "hidden", { value: 2, enumerable: false })
+console.log("plain.gOPN:", JSON.stringify(Object.getOwnPropertyNames(o)))
+"#,
+    )
+    .expect("write entry");
+
+    let (ok, stdout) = compile_and_run(dir.path(), &entry);
+    assert!(ok, "binary crashed\nstdout:\n{stdout}");
+    for needle in [
+        "fs.gOPN.includes(readFileSync): true",
+        "fs.gOPN.includes(__module__): false",
+        "fs.gOPN.count>50: true",
+        "path.gOPN.includes(join): true",
+        "clone.readFileSync: function",
+        "clone.writeFileSync: function",
+        r#"plain.gOPN: ["a","hidden"]"#,
+    ] {
+        assert!(
+            stdout.contains(needle),
+            "expected `{needle}` in output:\n{stdout}"
+        );
+    }
+}


### PR DESCRIPTION
Addresses the remaining graceful-fs/fs-extra breakage in #5268. (The `Object prototype may only be an Object or null: undefined` crash was fixed earlier by #5269; this fixes why graceful-fs still didn't *work* afterward.)

## Problem

`Object.getOwnPropertyNames(fs)` returned only `["__module__"]` — the internal sentinel — instead of the module's exports. `Object.keys(fs)` already returned the full method list (it routes through the native-module vtable's `vt_own_keys_array` → `native_module_enumerable_keys`), but `js_object_get_own_property_names` had no native-module branch and fell through to the generic object field walk.

graceful-fs's `clone.js` clones `fs` via:
```js
Object.getOwnPropertyNames(fs).forEach(k =>
  Object.defineProperty(copy, k, Object.getOwnPropertyDescriptor(fs, k)))
```
With only `__module__` enumerated, the clone dropped every method — `gfs.readFileSync` → `undefined`, graceful-fs and fs-extra unusable (fs-extra even warned the fs object was "being monkey-patched").

Host repro (no package needed):
```ts
import fs from "fs"
Object.getOwnPropertyNames(fs)        // before: ["__module__"]   after: 104 names incl. readFileSync
Object.keys(fs)                       // already correct (full list) — the inconsistency
```

## Fix

Route native-module objects in `getOwnPropertyNames` through the same `vt_own_keys_array` path `Object.keys` uses (now `pub(crate)`). The branch only fires when `read_native_module_name` matches, so plain objects, arrays, class instances, and class prototypes are untouched.

## Verification

- graceful-fs read/write **round-trips** end-to-end; fs-extra loads.
- `getOwnPropertyNames(fs)` → 104 names incl. `readFileSync` (no `__module__`); `path` lists its exports.
- Non-module `getOwnPropertyNames` still returns non-enumerable own props (`{a:1}` + non-enum `hidden` → `["a","hidden"]`); arrays/instances/class-prototypes unchanged.
- New regression test `crates/perry/tests/issue_5268_native_module_get_own_property_names.rs` (green); `perry-runtime` descriptor unit tests pass; 26/27 object-descriptor `test_gap_*` pass (the 1 fail is a pre-existing unrelated top-level-await limitation in `test_gap_2159`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `Object.getOwnPropertyNames()` on native modules to correctly enumerate their public API surface instead of returning internal implementation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->