### PR TITLE
fix(runtime): assignment-added class-prototype methods are enumerable own props of the reflective prototype

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -257,6 +257,49 @@ pub static CLASS_PROTOTYPE_OBJECTS: RwLock<Option<HashMap<u32, usize>>> = RwLock
 /// `C.prototype.isPrototypeOf(instance)` without perturbing those paths.
 pub static CLASS_DECL_PROTOTYPE_OBJECTS: RwLock<Option<HashMap<u32, usize>>> = RwLock::new(None);
 
+/// #5024 followup: prototype methods registered via `Object.defineProperty(
+/// Class.prototype, name, desc)` WITHOUT an explicit `enumerable: true` are
+/// non-enumerable (spec default for defineProperty). The plain
+/// `Class.prototype.m = fn` assignment path makes them enumerable. Both funnel
+/// into `CLASS_PROTOTYPE_METHODS`, which stores only the value — so the
+/// enumerability is tracked here, keyed by `(class_id, name)`. Absence means
+/// "enumerable" (the assignment default). Consulted when mirroring a method
+/// onto a prototype OBJECT so reflective `Object.keys`/`for-in` see the
+/// correct attribute.
+pub static CLASS_PROTOTYPE_METHOD_NONENUM: RwLock<
+    Option<std::collections::HashSet<(u32, String)>>,
+> = RwLock::new(None);
+
+/// Record the enumerability of the prototype method `(class_id, name)`.
+/// `enumerable == false` (a `defineProperty` data descriptor without an
+/// explicit `enumerable: true`) inserts the key into the non-enumerable set;
+/// `enumerable == true` removes it again, so a later redefine that flips the
+/// flag back on isn't left shadowed by a stale marker.
+pub(crate) fn class_prototype_method_set_enumerable(class_id: u32, name: &str, enumerable: bool) {
+    let mut guard = CLASS_PROTOTYPE_METHOD_NONENUM.write().unwrap();
+    if enumerable {
+        if let Some(set) = guard.as_mut() {
+            set.remove(&(class_id, name.to_string()));
+        }
+        return;
+    }
+    if guard.is_none() {
+        *guard = Some(std::collections::HashSet::new());
+    }
+    guard.as_mut().unwrap().insert((class_id, name.to_string()));
+}
+
+/// Whether the prototype method `(class_id, name)` should be enumerable when
+/// mirrored onto a prototype object. Defaults to `true` (assignment semantics).
+fn class_prototype_method_is_enumerable(class_id: u32, name: &str) -> bool {
+    if let Ok(read) = CLASS_PROTOTYPE_METHOD_NONENUM.read() {
+        if let Some(set) = read.as_ref() {
+            return !set.contains(&(class_id, name.to_string()));
+        }
+    }
+    true
+}
+
 /// #36 / #321: maps a child class_id to the raw address of a parent CLOSURE
 /// (function value) when `class Child extends <function value> {}`. effect's
 /// `class Svc extends Context.Tag("Svc")<...>() {}` extends the function
@@ -436,6 +479,26 @@ pub(crate) fn class_decl_prototype_value(class_id: u32) -> f64 {
     );
     install_class_decl_prototype_method_fields(proto, class_id);
 
+    // #5024 followup: backfill assignment-registered prototype methods
+    // (`Class.prototype.m = fn`, stored in CLASS_PROTOTYPE_METHODS) onto the
+    // decl-proto object as ordinary enumerable own properties, so reflective
+    // own-key enumeration sees them. These typically run at module init,
+    // BEFORE any reflective `.prototype` read materialises this object, so the
+    // write-through in `class_prototype_method_root_store` had no decl-proto to
+    // target. Mirrors the existing CLASS_VTABLE_REGISTRY backfill above.
+    let registered: Vec<(String, u64)> = {
+        let guard = CLASS_PROTOTYPE_METHODS.read().unwrap();
+        guard
+            .as_ref()
+            .and_then(|map| map.get(&class_id))
+            .map(|per_class| per_class.iter().map(|(k, &v)| (k.clone(), v)).collect())
+            .unwrap_or_default()
+    };
+    for (name, value_bits) in registered {
+        let enumerable = class_prototype_method_is_enumerable(class_id, &name);
+        unsafe { mirror_prototype_method_on_object(proto, &name, value_bits, enumerable) };
+    }
+
     let parent_proto_bits = get_parent_class_id(class_id)
         .filter(|parent_id| *parent_id != 0 && *parent_id != class_id)
         .and_then(|parent_id| {
@@ -548,7 +611,8 @@ pub(crate) fn ensure_function_prototype_object(
             .unwrap_or_default()
     };
     for (name, value_bits) in registered {
-        unsafe { mirror_prototype_method_on_object(proto, &name, value_bits) };
+        let enumerable = class_prototype_method_is_enumerable(class_id, &name);
+        unsafe { mirror_prototype_method_on_object(proto, &name, value_bits, enumerable) };
     }
 
     let func_bits = func_value.to_bits();
@@ -1396,23 +1460,57 @@ pub(crate) fn class_prototype_method_root_store(class_id: u32, name: String, val
     // nothing, so `isReactComponent` vanished and every `extends PureComponent`
     // class rendered as a function component. Mirror the write onto the
     // materialized prototype object as an ordinary enumerable own property.
+    let enumerable = class_prototype_method_is_enumerable(class_id, &name);
     let proto = class_prototype_object(class_id);
     if !proto.is_null() {
-        unsafe { mirror_prototype_method_on_object(proto, &name, value_bits) };
+        unsafe { mirror_prototype_method_on_object(proto, &name, value_bits, enumerable) };
+    }
+    // #5024 followup: reflective `ClassName.prototype` enumeration
+    // (`Object.keys` / `getOwnPropertyNames` / `in` / `hasOwnProperty` /
+    // `for-in`) reads the DECL-prototype object (CLASS_DECL_PROTOTYPE_OBJECTS),
+    // which is a DIFFERENT object than the #711/#809 synthetic prototype cache
+    // (CLASS_PROTOTYPE_OBJECTS) the mirror above targets. Without mirroring
+    // here too, an assignment-registered method (`Class.prototype.m = fn`) was
+    // dispatchable (side table) but invisible to own-key enumeration on the
+    // reflective prototype — zod's `b1` trait factory copies base methods onto
+    // instances via `for (let H in O.prototype) ...`, which enumerated nothing,
+    // so `z.number().optional()` threw "Cannot read properties of undefined".
+    // When the decl-proto isn't materialised yet, `class_decl_prototype_value`
+    // backfills CLASS_PROTOTYPE_METHODS at materialisation time, so we only
+    // need to write through to an already-live decl-proto here.
+    let decl_proto = class_decl_prototype_object(class_id);
+    if !decl_proto.is_null() && decl_proto != proto {
+        unsafe { mirror_prototype_method_on_object(decl_proto, &name, value_bits, enumerable) };
     }
 }
 
 /// #5024: write a side-table-registered prototype method onto the
-/// materialized prototype object so the key lands in its `keys_array`
-/// (assignment semantics: enumerable data property). Values keep their
-/// full NaN-boxed bits; dispatch paths that find the property on the
-/// object see the same value the side table holds.
-unsafe fn mirror_prototype_method_on_object(proto: *mut ObjectHeader, name: &str, value_bits: u64) {
+/// materialized prototype object so the key lands in its `keys_array`.
+/// `enumerable` carries assignment semantics (`Class.prototype.m = fn` →
+/// enumerable) vs `Object.defineProperty` default (non-enumerable). Values
+/// keep their full NaN-boxed bits; dispatch paths that find the property on
+/// the object see the same value the side table holds.
+unsafe fn mirror_prototype_method_on_object(
+    proto: *mut ObjectHeader,
+    name: &str,
+    value_bits: u64,
+    enumerable: bool,
+) {
     if proto.is_null() || name.is_empty() {
         return;
     }
     let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
     js_object_set_field_by_name(proto, key, f64::from_bits(value_bits));
+    if !enumerable {
+        // `js_object_set_field_by_name` records the default (enumerable) attrs;
+        // override so reflective own-key enumeration skips a defineProperty-
+        // registered non-enumerable method.
+        set_builtin_property_attrs(
+            proto as usize,
+            name.to_string(),
+            PropertyAttrs::new(true, false, true),
+        );
+    }
 }
 
 /// Register a JS-classic prototype-method assignment on a class.

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -217,6 +217,16 @@ pub(crate) unsafe fn desc_read_field(descriptor_value: f64, name: &[u8]) -> crat
     crate::value::JSValue::from_bits(v.to_bits())
 }
 
+/// Whether a property descriptor is enumerable. Mirrors the spec default for
+/// `Object.defineProperty` (and `defineProperties`): a descriptor that omits
+/// `enumerable` defines a NON-enumerable property, so the default is `false`.
+pub(crate) unsafe fn descriptor_enumerable(descriptor_value: f64) -> bool {
+    desc_has_field(descriptor_value, b"enumerable")
+        && crate::value::js_is_truthy(f64::from_bits(
+            desc_read_field(descriptor_value, b"enumerable").bits(),
+        )) != 0
+}
+
 /// Validate a property descriptor object per ES `ToPropertyDescriptor`
 /// invariants that Node surfaces as `TypeError`s (#2817). Assumes
 /// `descriptor_value` is already known to be an object. Throws on:
@@ -1471,6 +1481,17 @@ pub extern "C" fn js_object_define_property(
                     let value_field =
                         js_object_get_field_by_name(desc_ptr as *const ObjectHeader, value_key);
                     if !value_field.is_undefined() {
+                        // #5024 followup: a `defineProperty` data descriptor is
+                        // non-enumerable unless it explicitly sets
+                        // `enumerable: true`. Record that so the prototype-object
+                        // mirror (reflective `Object.keys`/`for-in`) doesn't
+                        // surface it — `Class.prototype.m = fn` assignment, which
+                        // routes through the same side table, stays enumerable.
+                        super::class_registry::class_prototype_method_set_enumerable(
+                            target_cid,
+                            &name,
+                            descriptor_enumerable(descriptor_value),
+                        );
                         define_class_prototype_method(target_cid, &name, value_field.bits());
                     }
                 }
@@ -1802,6 +1823,16 @@ pub extern "C" fn js_object_define_property(
                 if desc_has_field(descriptor_value, b"value") {
                     let value_field = desc_read_field(descriptor_value, b"value");
                     if !value_field.is_undefined() {
+                        // #5024 followup: defineProperty data descriptor is
+                        // non-enumerable unless it sets `enumerable: true`. Mark
+                        // it so the prototype-method enumeration mirror honours
+                        // the descriptor instead of defaulting to enumerable
+                        // (the `Class.prototype.m = fn` assignment default).
+                        super::class_registry::class_prototype_method_set_enumerable(
+                            target_cid,
+                            name,
+                            descriptor_enumerable(descriptor_value),
+                        );
                         define_class_prototype_method(target_cid, name, value_field.bits());
                     }
                 }

--- a/crates/perry/tests/issue_5024_class_prototype_assignment_enumeration.rs
+++ b/crates/perry/tests/issue_5024_class_prototype_assignment_enumeration.rs
@@ -1,0 +1,135 @@
+//! Regression test for the #5024 follow-up: methods added to a class prototype
+//! by plain ASSIGNMENT (`Class.prototype.m = fn`) must be enumerable own
+//! properties of the reflective `Class.prototype` object, so `for…in` /
+//! `Object.keys` / `in` / `hasOwnProperty` see them — while methods added via
+//! `Object.defineProperty(Class.prototype, m, { value })` WITHOUT an explicit
+//! `enumerable: true` stay non-enumerable (the spec default).
+//!
+//! This is the root cause of the claude-code `--help` wall: zod's trait factory
+//! `b1` builds a constructor whose instances inherit base methods, then copies
+//! them onto each instance with
+//! ```js
+//! for (let H in O.prototype)
+//!   if (!(H in w)) Object.defineProperty(w, H, { value: O.prototype[H].bind(w) });
+//! ```
+//! Assignment-registered prototype methods (e.g. `ZodType`'s `optional`) were
+//! dispatchable via the per-class side table but INVISIBLE to `for…in` on the
+//! reflective prototype object, because the side-table mirror (#5024) targeted
+//! the synthetic `CLASS_PROTOTYPE_OBJECTS` cache, not the
+//! `CLASS_DECL_PROTOTYPE_OBJECTS` object that reflective enumeration reads. The
+//! `for…in` enumerated nothing, no methods were copied onto the instance, and
+//! `z.number().optional()` threw `TypeError: Cannot read properties of
+//! undefined (reading 'optional')`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+#[test]
+fn assignment_registered_prototype_methods_are_enumerable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+// Base/derived classes with a method added by assignment on each prototype —
+// the shape zod's `b1` trait factory produces (`class A extends Y` + proto
+// method assignment).
+class Base { }
+(Base as any).prototype.optional = function () { return "OPT"; };
+class Derived extends Base { }
+(Derived as any).prototype.int = function () { return "INT"; };
+
+// `for…in` over the prototype must enumerate own + inherited assignment-added
+// methods (Node: ["int","optional"]).
+const forin: string[] = [];
+for (const k in (Derived as any).prototype) forin.push(k);
+console.log("forin:", forin.sort().join(","));
+
+// And over a real instance.
+const inst: any = new Derived();
+const instKeys: string[] = [];
+for (const k in inst) instKeys.push(k);
+console.log("inst:", instKeys.sort().join(","));
+
+// Object.keys / `in` / hasOwnProperty agree.
+console.log("keys:", JSON.stringify(Object.keys((Derived as any).prototype).sort()));
+console.log("in:", ("int" in (Derived as any).prototype) && ("optional" in (Derived as any).prototype));
+console.log("hasOwn:", (Derived as any).prototype.hasOwnProperty("int"));
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "forin: int,optional\ninst: int,optional\nkeys: [\"int\"]\nin: true\nhasOwn: true\n",
+        "assignment-registered prototype methods must enumerate; \
+         `keys` shows only Derived's own `int` (inherited `optional` is not an \
+         own key of Derived.prototype, matching Node)"
+    );
+}
+
+#[test]
+fn define_property_without_enumerable_stays_non_enumerable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+class C { }
+// defineProperty data descriptor WITHOUT enumerable:true -> non-enumerable.
+Object.defineProperty((C as any).prototype, "m1", { value: () => 1 });
+// plain assignment -> enumerable.
+(C as any).prototype.m2 = () => 2;
+// defineProperty WITH enumerable:true -> enumerable.
+Object.defineProperty((C as any).prototype, "m3", { value: () => 3, enumerable: true });
+
+const forin: string[] = [];
+for (const k in (C as any).prototype) forin.push(k);
+console.log("forin:", forin.sort().join(","));          // m2,m3
+console.log("keys:", JSON.stringify(Object.keys((C as any).prototype).sort()));
+console.log("m1enum:", Object.getOwnPropertyDescriptor((C as any).prototype, "m1")?.enumerable);
+console.log("m2enum:", Object.getOwnPropertyDescriptor((C as any).prototype, "m2")?.enumerable);
+console.log("m3enum:", Object.getOwnPropertyDescriptor((C as any).prototype, "m3")?.enumerable);
+// All three are still readable / dispatchable regardless of enumerability.
+console.log("vals:", (C as any).prototype.m1() + (C as any).prototype.m2() + (C as any).prototype.m3());
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "forin: m2,m3\nkeys: [\"m2\",\"m3\"]\nm1enum: false\nm2enum: true\nm3enum: true\nvals: 6\n"
+    );
+}


### PR DESCRIPTION
## Symptom
Methods added to a class prototype by plain assignment (`Class.prototype.m = fn`) were dispatchable but **invisible to `for…in` / `Object.keys` / `in` / `hasOwnProperty`** on the reflective `Class.prototype` object. Libraries that copy base prototype methods onto instances via `for (let H in C.prototype) Object.defineProperty(inst, H, { value: C.prototype[H].bind(inst) })` therefore copied nothing.

## Root cause
Both `Class.prototype.m = fn` (assignment) and `Object.defineProperty(Class.prototype, m, { value })` funnel into the per-class `CLASS_PROTOTYPE_METHODS` side table, which stored only the value — losing enumerability. And the side-table→prototype-object mirror populated the synthetic `CLASS_PROTOTYPE_OBJECTS` cache, not the `CLASS_DECL_PROTOTYPE_OBJECTS` object that reflective enumeration (`for…in`/`Object.keys`) actually reads.

## Fix
- Track enumerability alongside the side-table value (`CLASS_PROTOTYPE_METHOD_NONENUM`, keyed by `(class_id, name)`; absence == enumerable, matching assignment semantics; `defineProperty` without explicit `enumerable: true` records non-enumerable; a later redefine flips it back).
- Mirror assignment-registered methods onto the reflective prototype object with the correct `enumerable` attribute.

So `Class.prototype.m = fn` → enumerable own property (for-in sees it); `Object.defineProperty(…, { value })` → non-enumerable (spec default).

## Validation
- New e2e `crates/perry/tests/issue_5024_class_prototype_assignment_enumeration.rs` — assignment vs defineProperty enumerability across `for…in`/`Object.keys`/`in`/`hasOwnProperty`.
- `for (k in Class.prototype)` over assignment-registered methods + the copy-onto-instance pattern now match Node.

Found bringing up `@anthropic-ai/claude-code` natively (the bundled zod copies base prototype methods onto each schema instance via for-in).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed enumeration of class prototype methods to ensure they are properly reflected as enumerable when assigned via direct assignment
  * Corrected handling of the enumerable flag in property descriptors applied to class prototypes
  * Ensured consistent enumeration behavior across reflection mechanisms including `Object.keys`, `for-in` loops, and property inspection operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->