### PR TITLE
fix(runtime): #5477 — install EventEmitter methods on EventEmitter.prototype (unblocks pino)

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -551,6 +551,28 @@ pub(crate) fn ensure_function_prototype_object(
         unsafe { mirror_prototype_method_on_object(proto, &name, value_bits) };
     }
 
+    // #5477: the bound `events.EventEmitter` / `EventEmitterAsyncResource` export's
+    // synthetic prototype must carry the EventEmitter methods (`emit`/`on`/`once`/
+    // …) so the `Object.setPrototypeOf(x, EventEmitter.prototype)` mixin pattern
+    // (pino's logger prototype) gives `x` a working `emit`/`on`. The installed
+    // closures read IMPLICIT_THIS, so a plain object that merely inherits this
+    // prototype dispatches against ITSELF (listener state is keyed by the receiver
+    // object, not a captured instance). Mirrors what `Stream.prototype` already
+    // does. This proto is cached (`class_prototype_object_root_store` above), so
+    // the install runs once.
+    if let Some((module, method)) =
+        unsafe { super::native_module::bound_native_callable_module_and_method(func_value) }
+    {
+        if module.trim_start_matches("node:") == "events"
+            && matches!(
+                method.as_str(),
+                "EventEmitter" | "EventEmitterAsyncResource"
+            )
+        {
+            crate::node_stream::install_event_emitter_prototype_methods(proto);
+        }
+    }
+
     let func_bits = func_value.to_bits();
     if (func_bits >> 48) == 0x7FFD {
         let func_ptr = (func_bits & crate::value::POINTER_MASK) as usize;

--- a/crates/perry/tests/issue_5477_event_emitter_prototype_methods.rs
+++ b/crates/perry/tests/issue_5477_event_emitter_prototype_methods.rs
@@ -1,0 +1,101 @@
+//! Regression test for #5477 — `EventEmitter.prototype` carries the emitter
+//! methods, so the `Object.setPrototypeOf(x, EventEmitter.prototype)` mixin
+//! pattern (pino's logger prototype) gives `x` a working `emit`/`on`.
+//!
+//! Before the fix, `EventEmitter.prototype.emit` was `undefined` (the #5269
+//! synthetic prototype object existed but had no methods), even though
+//! instances dispatched `emit` natively. pino's `lib/proto.js` does
+//! `Object.setPrototypeOf(prototype, EventEmitter.prototype)` then
+//! `lib/levels.js` calls `this.emit('level-change', …)` → "emit is not a
+//! function".
+//!
+//! Fix: when the bound `events.EventEmitter` export's synthetic `.prototype`
+//! is materialized, install the EventEmitter methods on it via
+//! `install_event_emitter_prototype_methods` (the same dynamic-`this` closures
+//! `Stream.prototype` already uses), so an object inheriting the prototype
+//! dispatches against itself.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, entry: &std::path::Path) -> (bool, String) {
+    let output = dir.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let run = Command::new(&output).output().expect("run compiled binary");
+    (
+        run.status.success(),
+        String::from_utf8_lossy(&run.stdout).to_string(),
+    )
+}
+
+#[test]
+fn event_emitter_prototype_mixin_has_working_emit() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+import { EventEmitter } from "node:events"
+
+// EventEmitter.prototype now carries the methods.
+console.log("proto.emit:", typeof (EventEmitter.prototype as any).emit)
+console.log("proto.on:", typeof (EventEmitter.prototype as any).on)
+
+// pino's mixin shape: a plain prototype whose __proto__ is EventEmitter.prototype.
+const proto: any = { tag: "logger" }
+Object.setPrototypeOf(proto, EventEmitter.prototype)
+const inst: any = Object.create(proto)
+console.log("mixin.emit:", typeof inst.emit)
+let payload = ""
+inst.on("level-change", (p: string) => { payload = p })
+inst.emit("level-change", "PAYLOAD")
+console.log("mixin emit dispatched:", payload)
+
+// Direct instances and subclasses must still work (regression guard).
+const e: any = new EventEmitter()
+let direct = ""
+e.on("x", (v: string) => { direct = v }); e.emit("x", "direct")
+console.log("direct:", direct)
+
+class Sub extends EventEmitter { fire() { this.emit("s", "sub") } }
+const s: any = new Sub()
+let sub = ""
+s.on("s", (v: string) => { sub = v }); s.fire()
+console.log("subclass:", sub)
+"#,
+    )
+    .expect("write entry");
+
+    let (ok, stdout) = compile_and_run(dir.path(), &entry);
+    assert!(ok, "binary failed\nstdout:\n{stdout}");
+    for needle in [
+        "proto.emit: function",
+        "proto.on: function",
+        "mixin.emit: function",
+        "mixin emit dispatched: PAYLOAD",
+        "direct: direct",
+        "subclass: sub",
+    ] {
+        assert!(
+            stdout.contains(needle),
+            "expected `{needle}` in output:\n{stdout}"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #5477.

## Problem

`EventEmitter.prototype.emit` (and `.on`/`.once`/…) resolved to **`undefined`**, even though EventEmitter *instances* dispatch them fine. So the common mixin `Object.setPrototypeOf(myProto, EventEmitter.prototype)` produced objects with no `emit`.

This breaks **pino** (a top npm logger): `lib/proto.js:77` does `Object.setPrototypeOf(prototype, EventEmitter.prototype)`, then `lib/levels.js:98` calls `this.emit('level-change', …)` → `TypeError: emit is not a function`.

Minimal repro (no package):
```ts
import { EventEmitter } from "node:events"
typeof (EventEmitter.prototype as any).emit          // undefined   (Node: function)
const p: any = { tag: "x" }
Object.setPrototypeOf(p, EventEmitter.prototype)
typeof Object.create(p).emit                          // undefined   (Node: function)
```

## Root cause / fix

This is the layer beyond #5269 (which made the bound `events.EventEmitter` export expose a real synthetic `.prototype` *object*). That object existed but carried **no methods** — instances dispatch `emit` via the handle path, but a property GET on the prototype resolved nothing.

`install_event_emitter_prototype_methods` already exists — it installs the emitter methods on a prototype as **dynamic-`this` (IMPLICIT_THIS) closures** (used for `Stream.prototype`, e.g. readable-stream's `Stream.prototype.on.call(this, …)`). The fix wires it into `ensure_function_prototype_object`: when the synthetic prototype being materialized belongs to `events.EventEmitter` / `EventEmitterAsyncResource`, install those methods. The proto is cached (`class_prototype_object_root_store`), so the install runs once.

Because the closures read the call-site receiver, a plain object that merely inherits the prototype dispatches `emit`/`on` against **itself** (listener state is keyed by the receiver object) — so the `setPrototypeOf` mixin works, not just a direct property read.

## Verification

- **pino logs end-to-end** — `info`/`warn` emit correct JSON, and `log.level = "debug"` (the original `levels.js:98` `level-change` emit crash site) succeeds.
- `EventEmitter.prototype.emit`/`.on` are functions; the mixin's `on`+`emit` round-trips on a plain object (`setPrototypeOf` → `Object.create` → `on`/`emit`).
- **No regression**: direct `new EventEmitter()` instances, `class … extends EventEmitter` subclasses, and the `EventEmitter.prototype.on.call(obj, …)` borrow all still work; the existing #5269 integration test (`issue_5268_native_ctor_prototype_undefined`) still passes.
- New regression test `crates/perry/tests/issue_5477_event_emitter_prototype_methods.rs` (green on a fresh build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `EventEmitter.prototype` so event methods (`emit`, `on`, etc.) work correctly when used as a prototype mixin via the prototype chain.
  * Ensured event-emitter behavior remains correct for direct `EventEmitter` instances and subclasses.  
* **Tests**
  * Added a regression test that compiles and runs a TypeScript scenario validating prototype-mixin event dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->