### PR TITLE
fix(runtime): #2768 — Reflect.construct validates and honors an explicit newTarget

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -1221,7 +1221,16 @@ pub(super) fn try_native_module_methods(
                             // Special case: `Reflect.construct(ClassName, [args...])`
                             // where ClassName is a known class — fold to a direct
                             // `new ClassName(...args)` expression.
-                            if call.args.len() >= 2 {
+                            //
+                            // #2768: only fold the two-argument form. With an
+                            // explicit `newTarget` (3rd arg) the result's prototype
+                            // comes from `newTarget` and `newTarget` must be
+                            // validated as a constructor — a plain `new ClassName`
+                            // would silently drop both. Fall through to
+                            // `ReflectConstruct` (runtime `js_reflect_construct`,
+                            // which runs `js_new_function_construct_with_new_target`
+                            // and the non-constructor `newTarget` TypeError check).
+                            if call.args.len() == 2 {
                                 if let ast::Expr::Ident(cls_ident) = call.args[0].expr.as_ref() {
                                     let cls_name = cls_ident.sym.to_string();
                                     if ctx.lookup_class(&cls_name).is_some() {

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -1676,7 +1676,34 @@ fn is_callable_function(value: f64) -> bool {
 }
 
 fn is_constructor_function(value: f64) -> bool {
-    is_callable_function(value) && !crate::object::builtin_closure_is_non_constructable_value(value)
+    if !is_callable_function(value) {
+        return false;
+    }
+    if crate::object::builtin_closure_is_non_constructable_value(value) {
+        return false;
+    }
+    // #2768: arrow functions have no [[Construct]]. The deep construct path
+    // already rejects an arrow *target* ("Arrow function is not a
+    // constructor"), but `Reflect.construct`'s up-front constructor checks —
+    // for both the target and the `newTarget` operand — must reject them too.
+    // Without this, `Reflect.construct(C, args, arrowFn)` silently proceeded
+    // instead of throwing the spec TypeError (newTarget is never itself
+    // constructed, so the deep path never fires for it).
+    // A POINTER_TAG value is only a closure if `is_closure_ptr` confirms it —
+    // a callable Proxy is also POINTER_TAG but its lower 48 bits are a proxy
+    // id, not a `ClosureHeader*`, so `closure_is_arrow` (which dereferences the
+    // header via `get_valid_func_ptr`) must not run on it. Mirror the guard in
+    // `is_callable_function`.
+    let bits = value.to_bits();
+    if (bits & !POINTER_MASK) == POINTER_TAG {
+        let raw = (bits & POINTER_MASK) as usize;
+        if crate::closure::is_closure_ptr(raw)
+            && crate::closure::closure_is_arrow(raw as *const crate::closure::ClosureHeader)
+        {
+            return false;
+        }
+    }
+    true
 }
 
 /// Forward a `[[Call]]` to `target` (the default behavior when a proxy has no

--- a/crates/perry/tests/issue_2768_reflect_construct_new_target.rs
+++ b/crates/perry/tests/issue_2768_reflect_construct_new_target.rs
@@ -1,0 +1,92 @@
+//! Regression test for #2768 — `Reflect.construct` newTarget validation.
+//!
+//! Two bugs, fixed together:
+//!  1. The known-class fold (`Reflect.construct(C, [args]) → new C(args)` in
+//!     `lower/expr_call/native_module.rs`) also fired for the three-argument
+//!     form, folding `Reflect.construct(C, [args], newTarget)` to a plain
+//!     `new C(args)` — silently dropping `newTarget` (both its prototype and
+//!     its constructor validation). Now only the two-argument form folds; with
+//!     an explicit `newTarget` it falls through to runtime `js_reflect_construct`.
+//!  2. `is_constructor_function` (proxy.rs) checked only the builtin
+//!     non-constructable set, not `closure_is_arrow`, so an arrow `newTarget`
+//!     passed validation. Now arrow functions are rejected, so
+//!     `Reflect.construct(C, args, arrowFn)` throws a TypeError like Node.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn run_ts(src: &str) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(&entry, src).expect("write");
+    let out = dir.path().join("bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&out)
+        .output()
+        .expect("compile");
+    assert!(
+        compile.status.success(),
+        "compile failed:\n{}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let run = Command::new(&out).output().expect("run");
+    assert!(
+        run.status.success(),
+        "compiled binary exited with {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status.code(),
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).to_string()
+}
+
+#[test]
+fn reflect_construct_new_target_prototype_and_validation() {
+    let stdout = run_ts(
+        r#"
+class A { x: number; constructor(a: number, b: number) { this.x = a + b } }
+class B {}
+const arrow = () => {}
+
+// 1. valid newTarget: result inherits newTarget's prototype, runs A's body.
+const o: any = Reflect.construct(A, [2, 3], B)
+console.log("proto_is_B:", Object.getPrototypeOf(o) === B.prototype)
+console.log("x:", o.x)
+
+// 2. arrow newTarget is not a constructor -> TypeError.
+let threw = false
+try { Reflect.construct(A, [1, 1], arrow as any) } catch (e: any) { threw = e instanceof TypeError }
+console.log("arrow_newtarget_throws:", threw)
+
+// 3. arrow target is not a constructor -> TypeError (regression guard).
+let threwTarget = false
+try { Reflect.construct(arrow as any, []) } catch (e: any) { threwTarget = e instanceof TypeError }
+console.log("arrow_target_throws:", threwTarget)
+
+// 4. two-arg fold still works, and array-like argumentsList is accepted.
+const basic: any = Reflect.construct(A, [4, 5])
+console.log("basic_x:", basic.x, "is_A:", basic instanceof A)
+const al: any = Reflect.construct(A, { 0: 10, 1: 20, length: 2 } as any)
+console.log("arraylike_x:", al.x)
+"#,
+    );
+
+    for needle in [
+        "proto_is_B: true",
+        "x: 5",
+        "arrow_newtarget_throws: true",
+        "arrow_target_throws: true",
+        "basic_x: 9 is_A: true",
+        "arraylike_x: 30",
+    ] {
+        assert!(stdout.contains(needle), "missing `{needle}` in:\n{stdout}");
+    }
+}


### PR DESCRIPTION
Partial fix for #2768.

## Problem

`Reflect.construct(target, args, newTarget)` mishandled the `newTarget` operand two ways:

1. **The known-class fold dropped `newTarget`.** `lower/expr_call/native_module.rs` folds `Reflect.construct(C, [args])` → `new C(args)` when `C` is a known class. It also fired for the 3-argument form, so `Reflect.construct(C, [args], newTarget)` became a plain `new C(args)` — silently discarding `newTarget`'s prototype contribution *and* its constructor validation.
2. **Arrow `newTarget` passed validation.** `is_constructor_function` (proxy.rs) checked only the builtin non-constructable set, not `closure_is_arrow`. An arrow `newTarget` is never itself `[[Construct]]`-ed, so the deep "Arrow function is not a constructor" path never caught it.

```ts
class A { x = 0; constructor(a, b) { this.x = a + b } }
class B {}
const arrow = () => {}

Reflect.construct(A, [2,3], B)            // Node: result inherits B.prototype, x=5
Reflect.construct(A, [1,1], arrow as any) // Node: TypeError — Perry silently constructed
```

## Fix

- Fold only the **two-argument** form; with an explicit `newTarget`, fall through to runtime `js_reflect_construct` (which already runs `js_new_function_construct_with_new_target` + validation).
- `is_constructor_function` now also rejects arrow functions via `closure_is_arrow`.

## Verification

Matched against Node (`crates/perry/tests/issue_2768_reflect_construct_new_target.rs`):
- valid `newTarget` → result inherits `newTarget.prototype`, runs the target's constructor body;
- arrow `newTarget` → `TypeError`;
- arrow / number **target** → `TypeError` (regression guard);
- two-arg fold and array-like `argumentsList` still work.

Most of #2768's original asks already landed (newTarget honoring, `CreateListFromArrayLike` array-like args, non-proxy dispatch); this closes the `newTarget`-validation gap.

## Out of scope (noted on the issue)

Non-constructor **targets** that are concise methods (`({ m(){} }).m`) or builtin non-constructors (`parseInt`) are still not rejected — they aren't flagged non-constructable yet. That's a separate, broader correctness gap, so I've left #2768 open for that follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved `Reflect.construct` lowering so `newTarget` is handled correctly for the full argument set, avoiding incorrect folding for forms that include an explicit `newTarget`.
  * Strengthened constructor detection to correctly reject arrow functions when used as constructors, matching JavaScript behavior.

* **Tests**
  * Added a regression test covering `Reflect.construct` prototype behavior and error cases for arrow functions, including the two-argument form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->