### PR TITLE
fix(hir): #5257 — default-imported CJS Node builtins dispatch member methods (unblocks cross-spawn)

### DIFF
--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -305,7 +305,18 @@ pub(crate) fn lower_module_decl(
                                 source.clone(),
                                 native_method,
                             );
-                            if source == "process" {
+                            // #5257: a CJS-style Node builtin's default import
+                            // binds the whole module namespace — `const cp =
+                            // require('child_process')` is adopted as `import cp
+                            // from 'child_process'`, and member calls like
+                            // `cp.spawnSync(...)` must resolve through the
+                            // builtin-module alias. The `import * as cp` form
+                            // already registers it (Namespace branch below); the
+                            // default form only did so for `process`, so
+                            // `cp.spawnSync` lowered to nothing and returned
+                            // `undefined` — breaking cross-spawn / execa / which
+                            // (via isexe) under the require() adoption rewrite.
+                            if source == "process" || is_cjs_style_native_default_import(&source) {
                                 ctx.register_builtin_module_alias(local.clone(), source.clone());
                             }
                         } else if node_submodule_default_export_key(&source).is_some() {

--- a/crates/perry/tests/issue_5257_default_import_builtin_method_dispatch.rs
+++ b/crates/perry/tests/issue_5257_default_import_builtin_method_dispatch.rs
@@ -1,0 +1,90 @@
+//! Regression test for #5257 — default-imported CJS Node builtins dispatch
+//! their member methods.
+//!
+//! `const cp = require('child_process')` is adopted as `import cp from
+//! 'child_process'`. A CJS builtin's default import binds the whole module
+//! namespace, so `cp.spawnSync(...)` must resolve through the builtin-module
+//! alias — exactly as `import * as cp from 'child_process'` already did. The
+//! default-import path only registered that alias for `process`, so
+//! `cp.spawnSync(...)` lowered to nothing and returned `undefined`, breaking
+//! cross-spawn / execa / which (via isexe) under the require() adoption rewrite.
+//!
+//! Fixed in `lower/module_decl.rs`: register the builtin-module alias for
+//! every CJS-style native default import, not just `process`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn run_ts(src: &str) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(&entry, src).expect("write");
+    let out = dir.path().join("bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&out)
+        .output()
+        .expect("compile");
+    assert!(
+        compile.status.success(),
+        "compile failed:\n{}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let run = Command::new(&out).output().expect("run");
+    assert!(
+        run.status.success(),
+        "compiled binary exited with {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status.code(),
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).to_string()
+}
+
+// POSIX-only: spawns `echo` directly (no shell), which isn't a standalone
+// executable on Windows, and asserts a status-0/stdout shape specific to it.
+// The fix under test (default-import alias registration) is platform-agnostic;
+// this just exercises it through a concrete builtin call.
+#[cfg(unix)]
+#[test]
+fn default_imported_child_process_spawn_sync_dispatches() {
+    // `cp.spawnSync` via a DEFAULT import (the require()-adoption shape) must
+    // return the result object, not `undefined`.
+    let stdout = run_ts(
+        r#"
+import cp from "node:child_process"
+const r: any = cp.spawnSync("echo", ["perry5257"], { encoding: "utf8" })
+console.log("typeof:", typeof r)
+console.log("status:", r && r.status)
+console.log("stdout:", r && (r.stdout || "").toString().trim())
+"#,
+    );
+    assert!(stdout.contains("typeof: object"), "got:\n{stdout}");
+    assert!(stdout.contains("status: 0"), "got:\n{stdout}");
+    assert!(stdout.contains("stdout: perry5257"), "got:\n{stdout}");
+}
+
+#[test]
+fn default_imported_cjs_builtins_still_dispatch_methods() {
+    // Regression guard: other CJS-style builtins keep working through the
+    // default-import alias.
+    let stdout = run_ts(
+        r#"
+import path from "node:path"
+import util from "node:util"
+// Normalize the separator so the assertion is platform-agnostic (Windows
+// joins with "\", POSIX with "/").
+console.log("join:", path.join("a", "b", "c").split(path.sep).join("/"))
+console.log("fmt:", util.format("%s-%d", "x", 7))
+"#,
+    );
+    assert!(stdout.contains("join: a/b/c"), "got:\n{stdout}");
+    assert!(stdout.contains("fmt: x-7"), "got:\n{stdout}");
+}


### PR DESCRIPTION
Fixes the live blocker in #5257.

## Problem

`const cp = require('child_process')` is adopted (require()-rewrite, #665/#1721) as `import cp from 'child_process'`, then `cp.spawnSync(...)` is called. A CJS Node builtin's **default** import binds the whole module namespace, so member calls must resolve through the builtin-module alias — but the default-import branch in `lower/module_decl.rs` registered that alias only for `process`. So `cp.spawnSync(...)` lowered to nothing and returned `undefined`:

```ts
import cp from "node:child_process"
cp.spawnSync("echo", ["hi"], { encoding: "utf8" })   // undefined  (Node: result object)
```

The `import * as cp` and named (`import { spawnSync }`) forms worked — only the default form (the one the require() adoption produces) was broken. This is what made cross-spawn fail at runtime (`result.error` on an `undefined` `cp.spawnSync` result).

## Fix

Register the builtin-module alias for every **CJS-style native default import** (`is_cjs_style_native_default_import`: child_process, events, os, path, util, url, …), not just `process` — mirroring the Namespace branch, which already registers it for all `is_native` modules.

## Verification

- `cp.spawnSync` via default import returns the result object (was `undefined`);
- **cross-spawn runs a subprocess end-to-end** (`spawn.sync('echo', …)` → status 0, captured stdout);
- `which` (via isexe) now compiles and runs (was a hard compile error);
- no regression — default imports of `path`/`util`/`os`, plus the named and `* as` `child_process` forms, all still match Node.

Regression test: `crates/perry/tests/issue_5257_default_import_builtin_method_dispatch.rs`.

## Note

The original #5257 headline (`does not provide an export named 'default'` at import time) is already resolved on `main` — cross-spawn now compiles; this fixes the remaining runtime dispatch blocker. `which.sync` still returns `null` for a found executable due to a *separate*, deeper isexe file-mode-detection gap (not import dispatch), so I'd suggest keeping #5257 open for that tail if it matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default-import handling for Node.js built-in modules in CJS-style cases, ensuring the full module namespace is bound and member method calls (e.g., `child_process.spawnSync`, `path.join`, `util.format`) dispatch correctly.

* **Tests**
  * Added regression coverage for issue `#5257`, validating default-import dispatch behavior and asserting expected stdout output across supported platforms (with POSIX-specific coverage).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->