### PR TITLE
fix(runtime): #5484 — TypedArray iterating methods null-receiver below the macOS heap floor

### DIFF
--- a/crates/perry-runtime/src/array/header.rs
+++ b/crates/perry-runtime/src/array/header.rs
@@ -690,21 +690,35 @@ pub(crate) fn normalize_array_receiver(arr: *const ArrayHeader) -> *const ArrayH
                 as *const crate::gc::GcHeader;
             (*hdr).obj_type
         };
-        if obj_type == crate::gc::GC_TYPE_OBJECT
-            // Guard out registered typed arrays / buffers that (theoretically)
-            // carry a plain-object GC tag — those have their own delegation arms
-            // in the callers and must not be materialized as array-likes.
-            && crate::typedarray::lookup_typed_array_kind(raw_addr).is_none()
-            && !crate::buffer::is_registered_buffer(raw_addr)
-        {
-            // Generic array-like object receiver
-            // (`Array.prototype.<m>.call({length, 0:…}, …)`): materialize
-            // `length` + indexed keys into a real array and operate on that.
-            return unsafe {
-                crate::array::js_array_from_arraylike(
-                    raw_addr as *const crate::object::ObjectHeader,
-                )
-            } as *const ArrayHeader;
+        // A genuine `Array` is GC_TYPE_ARRAY and skips this whole block (one
+        // compare), keeping the hot `[1,2,3].map(...)` path cheap. Everything
+        // else — generic array-like objects, typed arrays, buffers — resolves
+        // its registry membership once here.
+        if obj_type != crate::gc::GC_TYPE_ARRAY {
+            let is_typed_array = crate::typedarray::lookup_typed_array_kind(raw_addr).is_some();
+            let is_buffer = crate::buffer::is_registered_buffer(raw_addr);
+            if obj_type == crate::gc::GC_TYPE_OBJECT && !is_typed_array && !is_buffer {
+                // Generic array-like object receiver
+                // (`Array.prototype.<m>.call({length, 0:…}, …)`): materialize
+                // `length` + indexed keys into a real array and operate on that.
+                return unsafe {
+                    crate::array::js_array_from_arraylike(
+                        raw_addr as *const crate::object::ObjectHeader,
+                    )
+                } as *const ArrayHeader;
+            }
+            // #5484: a registered typed array / buffer is a valid receiver
+            // regardless of `clean_arr_ptr`'s macOS 2 TB heap-window heuristic.
+            // Typed arrays are old-arena allocations (`arena_alloc_gc_old`) that
+            // can land BELOW that floor, where `clean_arr_ptr` would null them —
+            // yet `clean_ta_ptr` (4 KB floor) accepts the same address, so
+            // `.length`/index access worked while `reduce`/`forEach`/`map`/
+            // `join`/`indexOf` (which funnel through here) silently saw an empty
+            // array. The registry membership IS the liveness check; return the
+            // raw address so the caller's typed-array / buffer dispatch fires.
+            if is_typed_array || is_buffer {
+                return raw_addr as *const ArrayHeader;
+            }
         }
     }
     // Real array / lazy array / typed array / null / garbage: existing path.

--- a/crates/perry/tests/issue_5484_typedarray_iter_after_structured_clone.rs
+++ b/crates/perry/tests/issue_5484_typedarray_iter_after_structured_clone.rs
@@ -1,0 +1,88 @@
+//! Regression test for #5484 — a TypedArray's iterating methods must work even
+//! when the array's backing landed below `clean_arr_ptr`'s (macOS) 2 TB heap
+//! window.
+//!
+//! Typed arrays are old-arena allocations (`arena_alloc_gc_old`). On macOS they
+//! can land below `clean_arr_ptr`'s `HEAP_MIN` floor, where it would null the
+//! receiver — while `clean_ta_ptr` (4 KB floor) accepts the same address. So
+//! `.length`/index access worked but every `Array.prototype` iterating method
+//! (`reduce`/`forEach`/`map`/`join`/`indexOf`, which funnel through
+//! `normalize_array_receiver`) silently saw an empty array. A preceding
+//! `structuredClone(<non-empty object>)` reliably shifts allocation so the
+//! typed array lands in that range.
+//!
+//! Fix: `normalize_array_receiver` returns registered typed arrays / buffers
+//! un-nulled (registry membership is the real liveness check), so the caller's
+//! typed-array dispatch fires.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn run_ts(src: &str) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(&entry, src).expect("write");
+    let out = dir.path().join("bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&out)
+        .output()
+        .expect("compile");
+    assert!(
+        compile.status.success(),
+        "compile failed:\n{}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let run = Command::new(&out).output().expect("run");
+    assert!(
+        run.status.success(),
+        "binary exited with {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status.code(),
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).to_string()
+}
+
+#[test]
+fn typed_array_iter_methods_work_after_structured_clone() {
+    let stdout = run_ts(
+        r#"
+// structuredClone of a non-empty object shifts allocation so the following
+// typed array lands below clean_arr_ptr's macOS heap floor (the #5484 trigger).
+const sc = structuredClone({ a: 1, b: [2, 3] })
+
+const f = new Float64Array([1.5, 2.5, 3.5])
+console.log("length:", f.length)              // unaffected before the fix
+console.log("reduce:", f.reduce((a, b) => a + b, 0))
+console.log("join:", f.join(","))
+console.log("indexOf:", f.indexOf(2.5))
+let s = 0
+f.forEach((x) => { s += x })
+console.log("forEach:", s)
+console.log("map:", Array.from(f.map((x) => x * 2)).join(","))
+
+const i = new Int32Array([10, 20, 30])
+console.log("i32reduce:", i.reduce((a, b) => a + b, 0))
+"#,
+    );
+
+    for needle in [
+        "length: 3",
+        "reduce: 7.5",
+        "join: 1.5,2.5,3.5",
+        "indexOf: 1",
+        "forEach: 7.5",
+        "map: 3,5,7",
+        "i32reduce: 60",
+    ] {
+        assert!(stdout.contains(needle), "missing `{needle}` in:\n{stdout}");
+    }
+}


### PR DESCRIPTION
Fixes #5484.

## Problem

A `TypedArray`'s iterating methods — `reduce`, `reduceRight`, `forEach`, `map`, `join`, `indexOf`, … — silently behaved as if the array were **empty**, while `.length`, `.byteLength`, and indexed element access read correctly:

```ts
const sc = structuredClone({ a: 1 })
const ta = new Float64Array([1.5, 2.5, 3.5])
ta.length                       // 3      ✅
ta[0]                           // 1.5    ✅
ta.reduce((a, b) => a + b, 0)   // 0      ❌  (Node: 7.5)
ta.join(",")                    // ""     ❌
ta.indexOf(2.5)                 // -1     ❌
```

## Root cause

Typed arrays are old-arena allocations (`arena_alloc_gc_old`). On macOS they can land **below** `clean_arr_ptr`'s `HEAP_MIN` (2 TB) heap-window floor, where `clean_arr_ptr` nulls the receiver. The two access paths disagree:

- `.length` / index → `clean_ta_ptr` (4 KB floor) → **accepts** the address ✅
- iterating methods → `normalize_array_receiver` → `clean_arr_ptr` (2 TB floor on macOS) → **nulls** it → `js_array_reduce` & co. return the empty/initial result ❌

A preceding `structuredClone(<non-empty object>)` reliably shifts allocation into that sub-2 TB range, which is how it surfaced (deterministic, macOS-specific; other platforms use a 4 KB floor in both).

## Fix

`normalize_array_receiver` now returns a registered typed array / buffer **un-nulled** — registry membership (`lookup_typed_array_kind` / `is_registered_buffer`) is the real liveness check; the 2 TB window is only a corrupt-handle heuristic. The caller's existing typed-array dispatch then fires.

Gated on `obj_type != GC_TYPE_ARRAY`, so the hot `[1,2,3].map(...)` path is unchanged (a genuine `Array` still skips the whole block on a single compare).

## Verification

- All iterating methods on `Float64Array`/`Int32Array` return correct results **before and after** `structuredClone` (matches Node).
- No regression: regular arrays (`map`/`reduce`/`filter`/`find`/`flat`), `Array.prototype.<m>.call(arrayLike, …)` materialization, and the runtime array (60) + typedarray (7) unit suites all pass.
- Regression test: `crates/perry/tests/issue_5484_typedarray_iter_after_structured_clone.rs`.

## Out of scope

The separate, pre-existing `Uint8Array.prototype.map` / `toSorted` gaps (`test_compat_buffers_typed.ts` already fails on `main`) are unrelated to receiver-nulling and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where TypedArray iteration and array-like methods (reduce, join, indexOf, forEach, map) would fail or return incorrect results after performing structured clone operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->