### PR TITLE
fix(inline): keep comma-sequence arg-binding setup at its source position

### DIFF
--- a/crates/perry-transform/src/inline/call_inliner.rs
+++ b/crates/perry-transform/src/inline/call_inliner.rs
@@ -1198,17 +1198,59 @@ pub fn inline_calls_in_expr(
             ));
         }
         Expr::Sequence(exprs) => {
-            for item in exprs {
-                hoisted.extend(inline_calls_in_expr(
-                    item,
+            // A comma-sequence evaluates its elements left-to-right; element
+            // `i>0` runs only AFTER the side effects of elements `0..i`. Inline
+            // setup statements (the `let <param> = <arg>` arg-bindings) bubble
+            // up to *before the enclosing statement*, so hoisting a later
+            // element's setup would move its arg reads ahead of the earlier
+            // stores those reads depend on. For an esbuild `__esm` schema
+            // factory — one big comma-sequence of `Global = ctor({...})`
+            // assignments where a later object literal reads an
+            // earlier-assigned schema var (`C31 = KP({ k: YE7.optional() })`) —
+            // that reorders the read of `YE7` ahead of its store, yielding
+            // `undefined` and a `Cannot read properties of undefined` throw.
+            //
+            // Only the first element is evaluated before any sibling side
+            // effect, so only its setup may safely hoist. For later elements,
+            // inline into a candidate clone and commit only when it needs no
+            // hoisted setup (a pure substitution stays in place); otherwise
+            // leave the element as its original runtime call — always correct,
+            // just un-inlined. Mirrors the clone-and-revert guard the
+            // short-circuit `Logical` / `Conditional` arms already use.
+            for (idx, item) in exprs.iter_mut().enumerate() {
+                if idx == 0 {
+                    hoisted.extend(inline_calls_in_expr(
+                        item,
+                        func_candidates,
+                        method_candidates,
+                        local_types,
+                        exact_receiver_facts,
+                        next_local_id,
+                        enclosing_class,
+                        class_field_types,
+                    ));
+                    continue;
+                }
+                let before_facts = exact_receiver_facts.clone();
+                let mut candidate = item.clone();
+                let mut candidate_facts = before_facts.clone();
+                let item_hoisted = inline_calls_in_expr(
+                    &mut candidate,
                     func_candidates,
                     method_candidates,
                     local_types,
-                    exact_receiver_facts,
+                    &mut candidate_facts,
                     next_local_id,
                     enclosing_class,
                     class_field_types,
-                ));
+                );
+                if item_hoisted.is_empty() {
+                    *item = candidate;
+                    *exact_receiver_facts = candidate_facts;
+                } else {
+                    *exact_receiver_facts = before_facts;
+                    invalidate_exact_receivers_for_expr(item, exact_receiver_facts);
+                }
             }
         }
         // Descend into closure bodies. Without this, the inliner never

--- a/crates/perry/tests/issue_inline_seq_arg_binding_hoist.rs
+++ b/crates/perry/tests/issue_inline_seq_arg_binding_hoist.rs
@@ -1,0 +1,142 @@
+//! Regression: the function inliner hoisted a later comma-sequence element's
+//! argument-binding `let`s *above* earlier elements' side effects, reordering a
+//! read ahead of the store it depends on.
+//!
+//! Root cause: `inline_calls_in_expr`'s `Expr::Sequence` arm bubbled the inline
+//! setup statements (`let <param> = <arg>`) of EVERY element up to before the
+//! enclosing statement. A comma-sequence evaluates left-to-right, so element
+//! `i>0` runs only after the side effects of elements `0..i`; hoisting its
+//! setup above them moves its argument reads ahead of the earlier stores.
+//!
+//! The triggering shape is an esbuild `__esm` module factory: one big
+//! comma-sequence of `Global = ctor({...})` assignments where a later object
+//! literal reads an earlier-assigned schema var, e.g.
+//! `C = build({ a: Earlier.optional() })`. Inlining `build`/the obj wrapper
+//! hoisted `let q = { a: Earlier.optional() }` above the store of `Earlier`,
+//! so `Earlier` was still `undefined` → `Cannot read properties of undefined
+//! (reading 'optional')`.
+//!
+//! Fix: only the first sequence element (evaluated before any sibling side
+//! effect) may hoist its inline setup; later elements inline only when no setup
+//! needs hoisting, otherwise they stay as a plain runtime call.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, entry: &std::path::Path) -> String {
+    let output = dir.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).to_string()
+}
+
+/// Minimal trigger: a comma-sequence of bare assignments to pre-declared vars
+/// where a later element does a member access on an earlier-assigned var, and
+/// the inlinable callee forces an arg-binding temp. Pre-fix the temp was
+/// hoisted above the earlier store → read-before-write.
+#[test]
+fn later_seq_element_reads_earlier_assigned_var() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+function mk(): any { return { x: 1 }; }
+function f(v: any): any { return v; }
+var A: any, B: any;
+// Bare assignments in a comma-sequence; B's RHS reads A.x via an inlinable
+// call whose non-trivial arg forces a `let` arg-binding.
+A = mk(), B = f(A.x);
+console.log("A=" + JSON.stringify(A));
+console.log("B=" + B);
+"#,
+    )
+    .expect("write entry");
+
+    let stdout = compile_and_run(dir.path(), &entry);
+    assert!(
+        stdout.contains(r#"A={"x":1}"#),
+        "A must be assigned before B reads A.x (got: {stdout})"
+    );
+    assert!(
+        stdout.contains("B=1"),
+        "B = f(A.x) must read A.x = 1, not undefined (got: {stdout})"
+    );
+}
+
+/// The esbuild `__esm` schema-factory shape: a lazy-init wrapper around one big
+/// comma-sequence of `Global = ctor({...})` assignments, where a later object
+/// literal with a computed key reads two earlier-assigned schema vars via
+/// `.optional()`. This is the exact reorder that threw
+/// `Cannot read properties of undefined (reading 'optional')`.
+#[test]
+fn esm_schema_factory_computed_key_reads_earlier_vars() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+// esbuild __esm lazy-init memoizer: first call runs the factory once.
+var L = (q: any, K?: any) => () => (q && (K = q((q = 0))), K);
+
+function mkSchema(kind: string, props?: any): any {
+  return { optional() { return mkSchema("opt"); }, kind, props };
+}
+function KP(o: any): any { return mkSchema("KP", o); }
+function G4(o: any): any { return mkSchema("G4", o); }
+function dw(a: any): any { return mkSchema("dw"); }
+function O1(): any { return mkSchema("O1"); }
+
+var COMPUTED = "io/related";
+// Hoisted module vars assigned inside the factory (esbuild style):
+var YE7: any, Wy5: any, C31: any, $h: any;
+
+var factory = L(() => {
+  YE7 = dw([O1()]),
+  Wy5 = G4({ taskId: O1() }),
+  // Computed key + reads of YE7 and Wy5 assigned earlier in THIS sequence.
+  C31 = KP({ progressToken: YE7.optional(), [COMPUTED]: Wy5.optional() }),
+  $h = G4({ _meta: C31.optional() });
+});
+
+factory();
+console.log("C31kind=" + C31.kind);
+console.log("done");
+"#,
+    )
+    .expect("write entry");
+
+    let stdout = compile_and_run(dir.path(), &entry);
+    assert!(
+        stdout.contains("C31kind=KP"),
+        "C31 must build from YE7/Wy5 stored earlier in the sequence (got: {stdout})"
+    );
+    assert!(
+        stdout.contains("done"),
+        "factory must run to completion without a TypeError (got: {stdout})"
+    );
+}


### PR DESCRIPTION
## Problem

`inline_calls_in_expr`'s `Expr::Sequence` arm bubbled **every** element's inline arg-binding `let`s (`let <param> = <arg>`) up to *before the enclosing statement*. A comma-sequence evaluates left-to-right, so a later element's setup got hoisted **above earlier elements' side effects**, moving its argument reads ahead of the stores those reads depend on.

The triggering shape is an esbuild `__esm` module factory — one big comma-sequence of `Global = ctor({...})` assignments where a later object literal reads an earlier-assigned schema var (zod-style):

```js
var L = (q, K) => () => (q && (K = q((q = 0))), K); // esbuild __esm memoizer
var YE7, Wy5, C31;
var factory = L(() => {
  YE7 = dw([O1()]),
  Wy5 = G4({ taskId: O1() }),
  C31 = KP({ progressToken: YE7.optional(), [k]: Wy5.optional() }), // reads YE7/Wy5
});
```

Inlining the `KP(...)` call hoisted `let q = { progressToken: YE7.optional(), ... }` **above** the `YE7`/`Wy5` stores, so they were still `undefined` at module init:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'optional')
```

Node runs the same source correctly, so this is a miscompile — an evaluation-order violation introduced by the inliner, not by the source.

## Fix

Only the **first** sequence element is evaluated before any sibling side effect, so only its setup may safely hoist to before the statement. Later elements now inline via a **clone-and-revert candidate** — the same guard the short-circuit `Logical` / `Conditional` arms already use:

- inline into a cloned candidate; commit only when it needs **no** hoisted setup (a pure substitution stays in place);
- otherwise leave the element as its original runtime call — always correct, just un-inlined.

This trades a module-init-only micro-optimization for correct left-to-right evaluation order. The reverted inlines are cold (module initialization), so there is no hot-path cost.

## Tests

Adds `crates/perry/tests/issue_inline_seq_arg_binding_hoist.rs`:
- the minimal trigger (`A = mk(), B = f(A.x)` — later element member-reads an earlier-assigned var), and
- the esbuild `__esm` schema-factory shape with a computed-key object reading two earlier-assigned vars via `.optional()`.

Both reproduce the crash before the fix and pass after. `cargo test -p perry-transform -p perry-hir -p perry-codegen` is green (no behavior change beyond the more conservative sequence inlining).

https://claude.ai/code/session_01MhVU2CpQb2Aug9ZhG1CA4T

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed function inlining optimization that incorrectly reordered side effects in comma-separated expressions, preventing reads from occurring before dependent values are written.

* **Tests**
  * Added regression tests to ensure correct evaluation semantics in complex nested expressions and lazy factory patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->