### PR TITLE
fix(runtime): `delete <primitive>.field` no-ops to true instead of crashing

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -638,13 +638,14 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         format!("@{}", ctx.strings.entry(key_idx).handle_global);
                     let strict = if ctx.is_strict_fn { "1" } else { "0" };
                     let blk = ctx.block();
-                    let obj_handle = unbox_to_i64(blk, &obj_box);
                     let key_box = blk.load(DOUBLE, &key_handle_global);
                     let key_handle = unbox_to_i64(blk, &key_box);
+                    // Pass the RAW receiver: `delete (primitive).field` must no-op
+                    // to `true`, not unbox a non-object as a garbage ObjectHeader*.
                     let i32_v = blk.call(
                         I32,
-                        "js_object_delete_field",
-                        &[(I64, &obj_handle), (I64, &key_handle)],
+                        "js_object_delete_field_value",
+                        &[(DOUBLE, &obj_box), (I64, &key_handle)],
                     );
                     Ok(blk.call(DOUBLE, "js_delete_result", &[(I32, &i32_v), (I32, strict)]))
                 }
@@ -659,14 +660,14 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         .call(DOUBLE, "js_require_object_coercible", &[(DOUBLE, &obj_box)]);
                     let strict = if ctx.is_strict_fn { "1" } else { "0" };
                     let blk = ctx.block();
-                    let obj_handle = unbox_to_i64(blk, &obj_box);
                     // SSO-safe key unbox — `js_object_delete_field`
                     // dereferences the key as `*StringHeader`. #214 class.
                     let key_handle = unbox_str_handle(blk, &key_box);
+                    // Raw receiver: primitive `delete prim[k]` no-ops to `true`.
                     let i32_v = blk.call(
                         I32,
-                        "js_object_delete_field",
-                        &[(I64, &obj_handle), (I64, &key_handle)],
+                        "js_object_delete_field_value",
+                        &[(DOUBLE, &obj_box), (I64, &key_handle)],
                     );
                     Ok(blk.call(DOUBLE, "js_delete_result", &[(I32, &i32_v), (I32, strict)]))
                 }
@@ -681,11 +682,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         .call(DOUBLE, "js_require_object_coercible", &[(DOUBLE, &obj_box)]);
                     let strict = if ctx.is_strict_fn { "1" } else { "0" };
                     let blk = ctx.block();
-                    let obj_handle = unbox_to_i64(blk, &obj_box);
+                    // Raw receiver: primitive `delete prim[expr]` no-ops to `true`.
                     let i32_v = blk.call(
                         I32,
-                        "js_object_delete_dynamic",
-                        &[(I64, &obj_handle), (DOUBLE, &idx_box)],
+                        "js_object_delete_dynamic_value",
+                        &[(DOUBLE, &obj_box), (DOUBLE, &idx_box)],
                     );
                     Ok(blk.call(DOUBLE, "js_delete_result", &[(I32, &i32_v), (I32, strict)]))
                 }

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -911,6 +911,11 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_inline_arena_state", PTR, &[]);
     module.declare_function("js_inline_arena_slow_alloc", PTR, &[PTR, I64, I64]);
     module.declare_function("js_object_delete_field", I32, &[I64, I64]);
+    // Primitive-safe `delete` wrappers: take the RAW NaN-boxed receiver (DOUBLE)
+    // so `delete (number).x` / `delete (number)[k]` no-op to `true` instead of
+    // unboxing the primitive's bits as a garbage ObjectHeader* (EXC_BAD_ACCESS).
+    module.declare_function("js_object_delete_field_value", I32, &[DOUBLE, I64]);
+    module.declare_function("js_object_delete_dynamic_value", I32, &[DOUBLE, DOUBLE]);
     // Box a `delete` success bit into a JS boolean, throwing TypeError in
     // strict mode when the delete was refused (non-configurable property).
     module.declare_function("js_delete_result", DOUBLE, &[I32, I32]);

--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -330,6 +330,45 @@ pub extern "C" fn js_object_delete_field(
     }
 }
 
+/// True when `value` is a heap object the delete path may dereference (object,
+/// array, function, string, class-ref, proxy, …) — i.e. a NaN-boxed pointer.
+/// Primitive numbers/booleans are NOT pointers; unboxing their bits as an
+/// `ObjectHeader*` yields a garbage address that crashes when the GC/kind header
+/// at `[ptr-8]` is read.
+#[inline]
+fn delete_receiver_is_pointer(obj_value: f64) -> bool {
+    crate::value::JSValue::from_bits(obj_value.to_bits()).is_pointer()
+}
+
+/// `delete prim.field` (static key): once RequireObjectCoercible has rejected
+/// null/undefined, a primitive receiver (number/boolean/…) has no deletable own
+/// property, so `delete` is a no-op that evaluates to `true` (spec ToObject of a
+/// primitive produces a throwaway wrapper). Takes the RAW NaN-boxed receiver so
+/// the pointer/primitive tag survives; the previous codegen unboxed primitives
+/// to a garbage `ObjectHeader*` → EXC_BAD_ACCESS in `js_object_delete_field`.
+#[no_mangle]
+pub extern "C" fn js_object_delete_field_value(
+    obj_value: f64,
+    key: *const crate::StringHeader,
+) -> i32 {
+    if !delete_receiver_is_pointer(obj_value) {
+        return 1;
+    }
+    let obj = crate::value::js_nanbox_get_pointer(obj_value) as *mut ObjectHeader;
+    js_object_delete_field(obj, key)
+}
+
+/// `delete prim[key]` (dynamic key) — same primitive-receiver no-op guard as
+/// `js_object_delete_field_value`, delegating real objects to the dynamic path.
+#[no_mangle]
+pub extern "C" fn js_object_delete_dynamic_value(obj_value: f64, key: f64) -> i32 {
+    if !delete_receiver_is_pointer(obj_value) {
+        return 1;
+    }
+    let obj = crate::value::js_nanbox_get_pointer(obj_value) as *mut ObjectHeader;
+    js_object_delete_dynamic(obj, key)
+}
+
 /// Delete a field from an object using a dynamic key (could be string or number index)
 /// Returns 1 if successful, 0 otherwise
 #[no_mangle]

--- a/crates/perry/tests/issue_delete_primitive_receiver_noop.rs
+++ b/crates/perry/tests/issue_delete_primitive_receiver_noop.rs
@@ -1,0 +1,90 @@
+//! Regression: `delete <primitive>.field` must be a no-op evaluating to `true`,
+//! not unbox the primitive's bits as an `ObjectHeader*` and crash.
+//!
+//! Surfaced by an esbuild `__esm` zod-style schema-init shape:
+//! `function Fq(q){ let K=q; ...; if(delete K.message, typeof K.error==="string")... }`
+//! invoked with a non-object `q` (a number). `RequireObjectCoercible` passes for
+//! a number (numbers ARE coercible), so the codegen unboxed the number to a
+//! garbage `ObjectHeader*` and `js_object_delete_field` faulted (EXC_BAD_ACCESS)
+//! reading the kind byte at `[ptr-8]`. Per spec, `delete (5).message` ToObjects
+//! the primitive to a throwaway wrapper whose property is not own → returns
+//! `true`, no mutation. Fixed via `js_object_delete_field_value` /
+//! `js_object_delete_dynamic_value`, which no-op for non-pointer receivers.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, entry: &std::path::Path) -> (bool, String) {
+    let output = dir.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let run = Command::new(&output).output().expect("run compiled binary");
+    (
+        run.status.success(),
+        String::from_utf8_lossy(&run.stdout).to_string(),
+    )
+}
+
+#[test]
+fn delete_on_primitive_receiver_is_noop_true() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+let n: any = 5;
+console.log("num.static:", delete n.message);
+console.log("num.dynamic:", delete n["message"]);
+let b: any = true;
+console.log("bool.static:", delete b.foo);
+let s: any = "hello";
+console.log("str.static:", delete s.nope);
+
+// Real-object delete still reaches the runtime path (returns true).
+let o: any = {};
+o.x = 1;
+console.log("obj.dynamic:", delete o.x);
+
+// The exact crash shape: `delete K.message` where K is a non-object primitive.
+function Fq(q: any) {
+  let K = q;
+  if (delete K.message, typeof K.error === "string") return "err";
+  return "ok";
+}
+console.log("Fq(5):", Fq(5));
+console.log("Fq(obj):", Fq({ error: "x" }));
+console.log("DONE");
+"#,
+    )
+    .expect("write entry");
+
+    let (ok, out) = compile_and_run(dir.path(), &entry);
+    assert!(
+        ok,
+        "compiled binary did not exit cleanly (delete-on-primitive crash regressed)\nstdout:\n{out}"
+    );
+    assert!(out.contains("num.static: true"), "delete num.field → true\n{out}");
+    assert!(out.contains("num.dynamic: true"), "delete num[k] → true\n{out}");
+    assert!(out.contains("bool.static: true"), "delete bool.field → true\n{out}");
+    assert!(out.contains("str.static: true"), "delete str.field → true\n{out}");
+    assert!(out.contains("obj.dynamic: true"), "delete obj.dynProp → true\n{out}");
+    assert!(out.contains("Fq(5): ok"), "Fq(5) must not crash\n{out}");
+    assert!(out.contains("Fq(obj): err"), "Fq(object) still reads error\n{out}");
+    assert!(out.contains("DONE"), "program must run to completion\n{out}");
+}

--- a/crates/perry/tests/issue_delete_primitive_receiver_noop.rs
+++ b/crates/perry/tests/issue_delete_primitive_receiver_noop.rs
@@ -79,12 +79,33 @@ console.log("DONE");
         ok,
         "compiled binary did not exit cleanly (delete-on-primitive crash regressed)\nstdout:\n{out}"
     );
-    assert!(out.contains("num.static: true"), "delete num.field → true\n{out}");
-    assert!(out.contains("num.dynamic: true"), "delete num[k] → true\n{out}");
-    assert!(out.contains("bool.static: true"), "delete bool.field → true\n{out}");
-    assert!(out.contains("str.static: true"), "delete str.field → true\n{out}");
-    assert!(out.contains("obj.dynamic: true"), "delete obj.dynProp → true\n{out}");
+    assert!(
+        out.contains("num.static: true"),
+        "delete num.field → true\n{out}"
+    );
+    assert!(
+        out.contains("num.dynamic: true"),
+        "delete num[k] → true\n{out}"
+    );
+    assert!(
+        out.contains("bool.static: true"),
+        "delete bool.field → true\n{out}"
+    );
+    assert!(
+        out.contains("str.static: true"),
+        "delete str.field → true\n{out}"
+    );
+    assert!(
+        out.contains("obj.dynamic: true"),
+        "delete obj.dynProp → true\n{out}"
+    );
     assert!(out.contains("Fq(5): ok"), "Fq(5) must not crash\n{out}");
-    assert!(out.contains("Fq(obj): err"), "Fq(object) still reads error\n{out}");
-    assert!(out.contains("DONE"), "program must run to completion\n{out}");
+    assert!(
+        out.contains("Fq(obj): err"),
+        "Fq(object) still reads error\n{out}"
+    );
+    assert!(
+        out.contains("DONE"),
+        "program must run to completion\n{out}"
+    );
 }


### PR DESCRIPTION
## Problem
`delete obj.field` / `delete obj[key]` lowered to `js_object_delete_field` / `js_object_delete_dynamic` on the **unboxed** receiver. `js_require_object_coercible` only rejects `null`/`undefined`, so a **primitive** receiver (number/boolean/string — all object-coercible) passed through, its NaN-boxed bits were masked to a bogus `ObjectHeader*`, and the runtime read the kind byte at `[ptr-8]` → **EXC_BAD_ACCESS**.

Per spec, `delete (5).x` ToObjects the primitive to a throwaway wrapper whose property is not own ⇒ a no-op returning `true`.

## Fix
Add `js_object_delete_field_value` / `js_object_delete_dynamic_value` that take the **raw** NaN-boxed receiver, return `true` (no-op) when it is not a pointer (`JSValue::is_pointer` is false for numbers/booleans/strings/bigints), and delegate real heap objects to the existing path unchanged. The three codegen delete arms (PropertyGet, IndexGet string-key, IndexGet dynamic key) now pass the raw receiver. Also removes the prior #1781 footgun of dereferencing a string receiver as an object.

## Surfaced by
An esbuild `__esm` schema-init shape: `function Fq(q){ ...; delete K.message; ... }` invoked with a numeric `q`.

## Test
Adds `crates/perry/tests/issue_delete_primitive_receiver_noop.rs` (primitives no-op to `true`; the `Fq` crash shape runs clean; object delete still reaches the runtime path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes and unsafe handling when using `delete` on primitive values (numbers, strings, booleans), including both static and computed property forms like `delete (5).property` and `delete myNumber["key"]`.
  * `delete` on non-object receivers now deterministically returns `true` (no-op), while object property deletion behavior remains correct.  
* **Tests**
  * Added a regression test covering primitive-receiver `delete` for both dot and bracket syntax, plus a focused repro to prevent future crashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->