### PR TITLE
fix(hir): propagate ws Client handle class across function-call boundaries

### DIFF
--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -72,6 +72,7 @@ impl LoweringContext {
             type_param_scopes: Vec::new(),
             type_param_constraints: Vec::new(),
             native_instances: Vec::new(),
+            param_native_hints: HashMap::new(),
             current_strict: false,
             ui_widget_type_aliases: HashMap::new(),
             current_class: None,

--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -376,6 +376,13 @@ pub fn lower_module_full(
     // the member instead of silently lowering to 0.
     pre_register_module_enums(ast_module, &mut ctx);
 
+    // Propagate a native host-handle's class across direct function-call
+    // boundaries (the `("ws","Client")` upgrade `wsId` handed to a helper) so
+    // `wsId.send(...)` inside the callee dispatches to the Client runtime
+    // instead of a silent generic no-op. Must run before any function body is
+    // lowered so `lower_fn_decl` can tag the receiving parameter.
+    pre_scan_cross_fn_native_params(ast_module, &mut ctx);
+
     // JSX expressions lower directly to the built-in `jsx`/`jsxs` externs in
     // `jsx.rs`. Do not synthesize a `react/jsx-runtime` import here: codegen
     // routes those extern names to Perry's runtime adapter, and making the

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -193,6 +193,15 @@ pub struct LoweringContext {
     /// Native class instances: local_name -> (module_name, class_name)
     /// Tracks variables that hold instances of native module classes (e.g., EventEmitter)
     pub(crate) native_instances: Vec<(String, String, String)>,
+    /// Cross-function native-instance hints: (function_name, param_index) ->
+    /// (module_name, class_name). Populated by `pre_scan_cross_fn_native_params`
+    /// BEFORE any function body is lowered, so `lower_fn_decl` can tag an
+    /// otherwise-untyped parameter as a native instance when a known native
+    /// handle (e.g. the `("ws","Client")` upgrade `wsId`) is passed across the
+    /// call boundary into it. Without this, `wsId.send(...)` inside a helper
+    /// reached as `handleConnection(req, wsId)` lowers to a generic (silent
+    /// no-op) dispatch instead of `js_ws_send_client_i64`.
+    pub(crate) param_native_hints: HashMap<(String, usize), (String, String)>,
     /// True while lowering code governed by ECMAScript strict mode.
     pub(crate) current_strict: bool,
     /// #1483: type-only perry/ui widget import aliases — local_name ->

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -193,7 +193,7 @@ pub struct LoweringContext {
     /// Native class instances: local_name -> (module_name, class_name)
     /// Tracks variables that hold instances of native module classes (e.g., EventEmitter)
     pub(crate) native_instances: Vec<(String, String, String)>,
-    /// Cross-function native-instance hints: (function_name, param_index) ->
+    /// Cross-function native-instance hints: (fn_ident_span_lo, param_index) ->
     /// (module_name, class_name). Populated by `pre_scan_cross_fn_native_params`
     /// BEFORE any function body is lowered, so `lower_fn_decl` can tag an
     /// otherwise-untyped parameter as a native instance when a known native
@@ -201,7 +201,12 @@ pub struct LoweringContext {
     /// call boundary into it. Without this, `wsId.send(...)` inside a helper
     /// reached as `handleConnection(req, wsId)` lowers to a generic (silent
     /// no-op) dispatch instead of `js_ws_send_client_i64`.
-    pub(crate) param_native_hints: HashMap<(String, usize), (String, String)>,
+    ///
+    /// Keyed by the function declaration's identifier span (its `lo` byte
+    /// offset) — a stable AST identity — rather than its name, so a hint seeded
+    /// for one declaration never leaks onto an unrelated same-named (shadowed or
+    /// redeclared) function.
+    pub(crate) param_native_hints: HashMap<(u32, usize), (String, String)>,
     /// True while lowering code governed by ECMAScript strict mode.
     pub(crate) current_strict: bool,
     /// #1483: type-only perry/ui widget import aliases — local_name ->

--- a/crates/perry-hir/src/lower/pre_scan.rs
+++ b/crates/perry-hir/src/lower/pre_scan.rs
@@ -334,69 +334,384 @@ pub(crate) fn pre_scan_cross_fn_native_params(ast_module: &ast::Module, ctx: &mu
     let mut server_idents: HashSet<String> = HashSet::new();
     collect_server_idents_in_module(ast_module, &mut server_idents);
 
-    // Seed work items from each gated upgrade handler.
-    let mut work: Vec<(Vec<&ast::CallExpr>, HashMap<String, (String, String)>)> = Vec::new();
+    // Walk each gated upgrade handler's body with the `wsId` handle tainted,
+    // recording a hint for every top-level user function the handle flows into.
+    // The walk is scope-aware (`walk_taint_*`): descending into a nested
+    // function/arrow drops any name that scope rebinds as a parameter, so a
+    // shadowing `function later(wsId) {…}` cannot inherit the outer handle —
+    // while legitimate captures (`wsId.on('message', m => helper(req, wsId))`)
+    // still propagate. Hints are keyed by callee identity (span) and applied
+    // after the walk so the immutable `fn_*` tables can stay borrowed throughout.
+    let tcx = TaintCtx {
+        fn_params: &fn_params,
+        fn_bodies: &fn_bodies,
+        fn_spans: &fn_spans,
+    };
+    let mut applied: HashSet<(u32, usize, String, String)> = HashSet::new();
+    let mut hints: Vec<((u32, usize), (String, String))> = Vec::new();
+    let mut guard = 0usize;
     let mut all_calls: Vec<&ast::CallExpr> = Vec::new();
     collect_calls_in_module(ast_module, &mut all_calls);
     for call in &all_calls {
         if let Some((ws_id, handler)) = upgrade_handler_ws_id(call, &server_idents) {
-            let mut calls = Vec::new();
-            collect_calls_in_callback_body(handler, &mut calls);
-            let mut tainted = HashMap::new();
-            tainted.insert(ws_id, ("ws".to_string(), "Client".to_string()));
-            work.push((calls, tainted));
+            let mut taint: HashMap<String, (String, String)> = HashMap::new();
+            taint.insert(ws_id, ("ws".to_string(), "Client".to_string()));
+            walk_taint_callback_body(handler, &taint, &tcx, &mut applied, &mut hints, &mut guard);
         }
     }
+    for (key, val) in hints {
+        ctx.param_native_hints.insert(key, val);
+    }
+}
 
-    // Fixpoint propagation. `applied` dedups (callee, param, module, class) so
-    // mutual recursion / repeated call sites terminate.
-    let mut applied: HashSet<(String, usize, String, String)> = HashSet::new();
-    let mut guard = 0usize;
-    while let Some((calls, tainted)) = work.pop() {
-        guard += 1;
-        if guard > 50_000 {
-            break; // pathological-input backstop
+/// Immutable top-level-function tables shared by the scope-aware taint walk.
+struct TaintCtx<'a> {
+    fn_params: &'a HashMap<String, Vec<Option<String>>>,
+    fn_bodies: &'a HashMap<String, &'a ast::BlockStmt>,
+    fn_spans: &'a HashMap<String, u32>,
+}
+
+type Taint = HashMap<String, (String, String)>;
+type Applied = HashSet<(u32, usize, String, String)>;
+type Hints = Vec<((u32, usize), (String, String))>;
+
+/// Clone `taint`, dropping any name the arrow rebinds as a parameter (shadowing).
+fn prune_for_arrow(taint: &Taint, arrow: &ast::ArrowExpr) -> Taint {
+    let mut t = taint.clone();
+    for p in &arrow.params {
+        if let Some(n) = cross_fn_pat_name(p) {
+            t.remove(&n);
         }
-        for call in calls {
-            let Some(callee) = cross_fn_call_ident(call) else {
-                continue;
-            };
-            let Some(params) = fn_params.get(&callee) else {
-                continue;
-            };
-            for (i, arg) in call.args.iter().enumerate() {
-                if arg.spread.is_some() {
-                    continue;
-                }
-                let ast::Expr::Ident(id) = arg.expr.as_ref() else {
-                    continue;
-                };
-                let Some((module, class)) = tainted.get(id.sym.as_ref()) else {
-                    continue;
-                };
-                let Some(Some(param_name)) = params.get(i) else {
-                    continue;
-                };
-                let key = (callee.clone(), i, module.clone(), class.clone());
-                if !applied.insert(key) {
-                    continue;
-                }
-                // Key by the callee declaration's identifier span, not its name,
-                // so a same-named distinct declaration never picks up this hint.
-                if let Some(&callee_span) = fn_spans.get(&callee) {
-                    ctx.param_native_hints
-                        .insert((callee_span, i), (module.clone(), class.clone()));
-                }
-                // Follow the handle into the callee: its param[i] is now tainted.
-                if let Some(body) = fn_bodies.get(&callee) {
-                    let mut next_calls = Vec::new();
-                    collect_calls_in_stmts(&body.stmts, &mut next_calls);
-                    let mut next = HashMap::new();
-                    next.insert(param_name.clone(), (module.clone(), class.clone()));
-                    work.push((next_calls, next));
+    }
+    t
+}
+
+/// Clone `taint`, dropping any name the function rebinds as a parameter.
+fn prune_for_fn(taint: &Taint, func: &ast::Function) -> Taint {
+    let mut t = taint.clone();
+    for p in &func.params {
+        if let Some(n) = cross_fn_pat_name(&p.pat) {
+            t.remove(&n);
+        }
+    }
+    t
+}
+
+/// Walk a callback expression's body (arrow/function) under the seed taint. The
+/// callback's own params already account for the tainted handle, so no pruning.
+fn walk_taint_callback_body(
+    handler: &ast::Expr,
+    taint: &Taint,
+    tcx: &TaintCtx,
+    applied: &mut Applied,
+    hints: &mut Hints,
+    guard: &mut usize,
+) {
+    match handler {
+        ast::Expr::Arrow(a) => match a.body.as_ref() {
+            ast::BlockStmtOrExpr::BlockStmt(b) => {
+                walk_taint_stmts(&b.stmts, taint, tcx, applied, hints, guard)
+            }
+            ast::BlockStmtOrExpr::Expr(e) => walk_taint_expr(e, taint, tcx, applied, hints, guard),
+        },
+        ast::Expr::Fn(f) => {
+            if let Some(b) = &f.function.body {
+                walk_taint_stmts(&b.stmts, taint, tcx, applied, hints, guard);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn walk_taint_stmts(
+    stmts: &[ast::Stmt],
+    taint: &Taint,
+    tcx: &TaintCtx,
+    applied: &mut Applied,
+    hints: &mut Hints,
+    guard: &mut usize,
+) {
+    for s in stmts {
+        walk_taint_stmt(s, taint, tcx, applied, hints, guard);
+    }
+}
+
+fn walk_taint_stmt(
+    stmt: &ast::Stmt,
+    taint: &Taint,
+    tcx: &TaintCtx,
+    applied: &mut Applied,
+    hints: &mut Hints,
+    guard: &mut usize,
+) {
+    macro_rules! e {
+        ($x:expr) => {
+            walk_taint_expr($x, taint, tcx, applied, hints, guard)
+        };
+    }
+    macro_rules! s {
+        ($x:expr) => {
+            walk_taint_stmt($x, taint, tcx, applied, hints, guard)
+        };
+    }
+    match stmt {
+        ast::Stmt::Expr(x) => e!(&x.expr),
+        ast::Stmt::Return(r) => {
+            if let Some(a) = &r.arg {
+                e!(a);
+            }
+        }
+        ast::Stmt::Decl(ast::Decl::Var(v)) => {
+            for d in &v.decls {
+                if let Some(init) = &d.init {
+                    e!(init);
                 }
             }
         }
+        // A nested function declaration is a new scope — prune its params.
+        ast::Stmt::Decl(ast::Decl::Fn(f)) => {
+            if let Some(b) = &f.function.body {
+                let pruned = prune_for_fn(taint, &f.function);
+                walk_taint_stmts(&b.stmts, &pruned, tcx, applied, hints, guard);
+            }
+        }
+        ast::Stmt::Block(b) => walk_taint_stmts(&b.stmts, taint, tcx, applied, hints, guard),
+        ast::Stmt::If(i) => {
+            e!(&i.test);
+            s!(&i.cons);
+            if let Some(alt) = &i.alt {
+                s!(alt);
+            }
+        }
+        ast::Stmt::While(w) => {
+            e!(&w.test);
+            s!(&w.body);
+        }
+        ast::Stmt::DoWhile(w) => {
+            s!(&w.body);
+            e!(&w.test);
+        }
+        ast::Stmt::For(f) => {
+            if let Some(ast::VarDeclOrExpr::VarDecl(vd)) = &f.init {
+                for d in &vd.decls {
+                    if let Some(init) = &d.init {
+                        e!(init);
+                    }
+                }
+            } else if let Some(ast::VarDeclOrExpr::Expr(x)) = &f.init {
+                e!(x);
+            }
+            if let Some(t) = &f.test {
+                e!(t);
+            }
+            if let Some(u) = &f.update {
+                e!(u);
+            }
+            s!(&f.body);
+        }
+        ast::Stmt::ForIn(f) => {
+            e!(&f.right);
+            s!(&f.body);
+        }
+        ast::Stmt::ForOf(f) => {
+            e!(&f.right);
+            s!(&f.body);
+        }
+        ast::Stmt::Throw(t) => e!(&t.arg),
+        ast::Stmt::Try(t) => {
+            walk_taint_stmts(&t.block.stmts, taint, tcx, applied, hints, guard);
+            if let Some(h) = &t.handler {
+                walk_taint_stmts(&h.body.stmts, taint, tcx, applied, hints, guard);
+            }
+            if let Some(f) = &t.finalizer {
+                walk_taint_stmts(&f.stmts, taint, tcx, applied, hints, guard);
+            }
+        }
+        ast::Stmt::Switch(sw) => {
+            e!(&sw.discriminant);
+            for c in &sw.cases {
+                if let Some(t) = &c.test {
+                    e!(t);
+                }
+                walk_taint_stmts(&c.cons, taint, tcx, applied, hints, guard);
+            }
+        }
+        ast::Stmt::Labeled(l) => s!(&l.body),
+        _ => {}
+    }
+}
+
+fn walk_taint_expr(
+    expr: &ast::Expr,
+    taint: &Taint,
+    tcx: &TaintCtx,
+    applied: &mut Applied,
+    hints: &mut Hints,
+    guard: &mut usize,
+) {
+    *guard += 1;
+    if *guard > 200_000 {
+        return; // pathological-input backstop
+    }
+    macro_rules! e {
+        ($x:expr) => {
+            walk_taint_expr($x, taint, tcx, applied, hints, guard)
+        };
+    }
+    match expr {
+        ast::Expr::Call(c) => {
+            // Record a cross-fn hint when this is a top-level user-fn call that
+            // receives a currently-tainted ident argument.
+            if let Some(callee) = cross_fn_call_ident(c) {
+                if let (Some(params), Some(&span)) =
+                    (tcx.fn_params.get(&callee), tcx.fn_spans.get(&callee))
+                {
+                    for (i, arg) in c.args.iter().enumerate() {
+                        if arg.spread.is_some() {
+                            continue;
+                        }
+                        let ast::Expr::Ident(id) = arg.expr.as_ref() else {
+                            continue;
+                        };
+                        let Some((module, class)) = taint.get(id.sym.as_ref()) else {
+                            continue;
+                        };
+                        let Some(Some(param_name)) = params.get(i) else {
+                            continue;
+                        };
+                        if !applied.insert((span, i, module.clone(), class.clone())) {
+                            continue;
+                        }
+                        hints.push(((span, i), (module.clone(), class.clone())));
+                        // Follow the handle into the callee body with a FRESH
+                        // scoped taint binding only its receiving parameter.
+                        if let Some(body) = tcx.fn_bodies.get(&callee) {
+                            let mut fresh: Taint = HashMap::new();
+                            fresh.insert(param_name.clone(), (module.clone(), class.clone()));
+                            walk_taint_stmts(&body.stmts, &fresh, tcx, applied, hints, guard);
+                        }
+                    }
+                }
+            }
+            // Descend into the callee + args (this scope; nested closures inside
+            // an arg get pruned by their own arms below).
+            if let ast::Callee::Expr(ce) = &c.callee {
+                e!(ce);
+            }
+            for arg in &c.args {
+                e!(&arg.expr);
+            }
+        }
+        ast::Expr::New(n) => {
+            e!(&n.callee);
+            if let Some(args) = &n.args {
+                for a in args {
+                    e!(&a.expr);
+                }
+            }
+        }
+        ast::Expr::Member(m) => {
+            e!(&m.obj);
+            if let ast::MemberProp::Computed(c) = &m.prop {
+                e!(&c.expr);
+            }
+        }
+        ast::Expr::Bin(b) => {
+            e!(&b.left);
+            e!(&b.right);
+        }
+        ast::Expr::Unary(u) => e!(&u.arg),
+        ast::Expr::Update(u) => e!(&u.arg),
+        ast::Expr::Assign(a) => e!(&a.right),
+        ast::Expr::Cond(c) => {
+            e!(&c.test);
+            e!(&c.cons);
+            e!(&c.alt);
+        }
+        ast::Expr::Paren(p) => e!(&p.expr),
+        ast::Expr::Seq(s) => {
+            for x in &s.exprs {
+                e!(x);
+            }
+        }
+        ast::Expr::Await(a) => e!(&a.arg),
+        ast::Expr::Yield(y) => {
+            if let Some(a) = &y.arg {
+                e!(a);
+            }
+        }
+        ast::Expr::Tpl(t) => {
+            for x in &t.exprs {
+                e!(x);
+            }
+        }
+        ast::Expr::TaggedTpl(t) => {
+            e!(&t.tag);
+            for x in &t.tpl.exprs {
+                e!(x);
+            }
+        }
+        ast::Expr::Array(a) => {
+            for el in a.elems.iter().flatten() {
+                e!(&el.expr);
+            }
+        }
+        ast::Expr::Object(o) => {
+            for prop in &o.props {
+                match prop {
+                    ast::PropOrSpread::Spread(s) => e!(&s.expr),
+                    ast::PropOrSpread::Prop(p) => match p.as_ref() {
+                        ast::Prop::KeyValue(kv) => e!(&kv.value),
+                        // Object methods are new scopes — prune their params.
+                        ast::Prop::Method(m) => {
+                            if let Some(b) = &m.function.body {
+                                let pruned = prune_for_fn(taint, &m.function);
+                                walk_taint_stmts(&b.stmts, &pruned, tcx, applied, hints, guard);
+                            }
+                        }
+                        _ => {}
+                    },
+                }
+            }
+        }
+        // New lexical scope — drop any name it rebinds as a parameter.
+        ast::Expr::Arrow(a) => {
+            let pruned = prune_for_arrow(taint, a);
+            match a.body.as_ref() {
+                ast::BlockStmtOrExpr::BlockStmt(b) => {
+                    walk_taint_stmts(&b.stmts, &pruned, tcx, applied, hints, guard)
+                }
+                ast::BlockStmtOrExpr::Expr(x) => {
+                    walk_taint_expr(x, &pruned, tcx, applied, hints, guard)
+                }
+            }
+        }
+        ast::Expr::Fn(f) => {
+            if let Some(b) = &f.function.body {
+                let pruned = prune_for_fn(taint, &f.function);
+                walk_taint_stmts(&b.stmts, &pruned, tcx, applied, hints, guard);
+            }
+        }
+        ast::Expr::OptChain(o) => match o.base.as_ref() {
+            ast::OptChainBase::Member(m) => {
+                e!(&m.obj);
+                if let ast::MemberProp::Computed(c) = &m.prop {
+                    e!(&c.expr);
+                }
+            }
+            ast::OptChainBase::Call(c) => {
+                e!(&c.callee);
+                for arg in &c.args {
+                    e!(&arg.expr);
+                }
+            }
+        },
+        ast::Expr::TsAs(t) => e!(&t.expr),
+        ast::Expr::TsNonNull(t) => e!(&t.expr),
+        ast::Expr::TsTypeAssertion(t) => e!(&t.expr),
+        ast::Expr::TsConstAssertion(t) => e!(&t.expr),
+        ast::Expr::TsInstantiation(t) => e!(&t.expr),
+        _ => {}
     }
 }
 
@@ -778,22 +1093,6 @@ fn collect_calls_in_module<'a>(ast_module: &'a ast::Module, out: &mut Vec<&'a as
             },
             _ => {}
         }
-    }
-}
-
-/// Collect calls in a callback expression's body (arrow or function).
-fn collect_calls_in_callback_body<'a>(handler: &'a ast::Expr, out: &mut Vec<&'a ast::CallExpr>) {
-    match handler {
-        ast::Expr::Arrow(a) => match a.body.as_ref() {
-            ast::BlockStmtOrExpr::BlockStmt(b) => collect_calls_in_stmts(&b.stmts, out),
-            ast::BlockStmtOrExpr::Expr(e) => collect_calls_in_expr(e, out),
-        },
-        ast::Expr::Fn(f) => {
-            if let Some(b) = &f.function.body {
-                collect_calls_in_stmts(&b.stmts, out);
-            }
-        }
-        _ => {}
     }
 }
 

--- a/crates/perry-hir/src/lower/pre_scan.rs
+++ b/crates/perry-hir/src/lower/pre_scan.rs
@@ -347,111 +347,173 @@ pub(crate) fn pre_scan_cross_fn_native_params(ast_module: &ast::Module, ctx: &mu
         fn_bodies: &fn_bodies,
         fn_spans: &fn_spans,
     };
-    let mut applied: HashSet<(u32, usize, String, String)> = HashSet::new();
-    let mut hints: Vec<((u32, usize), (String, String))> = Vec::new();
-    let mut guard = 0usize;
     let mut all_calls: Vec<&ast::CallExpr> = Vec::new();
     collect_calls_in_module(ast_module, &mut all_calls);
+    let mut acc = TaintAcc {
+        tcx: &tcx,
+        applied: HashSet::new(),
+        hints: Vec::new(),
+        ws_fed: HashSet::new(),
+        deps: HashMap::new(),
+        source: None,
+        guard: 0,
+    };
     for call in &all_calls {
         if let Some((ws_id, handler)) = upgrade_handler_ws_id(call, &server_idents) {
-            let mut taint: HashMap<String, (String, String)> = HashMap::new();
+            let mut taint: Taint = HashMap::new();
             taint.insert(ws_id, ("ws".to_string(), "Client".to_string()));
-            walk_taint_callback_body(handler, &taint, &tcx, &mut applied, &mut hints, &mut guard);
+            walk_taint_callback_body(handler, &taint, &mut acc);
         }
     }
-    for (key, val) in hints {
-        ctx.param_native_hints.insert(key, val);
-    }
-}
 
-/// Immutable top-level-function tables shared by the scope-aware taint walk.
-struct TaintCtx<'a> {
-    fn_params: &'a HashMap<String, Vec<Option<String>>>,
-    fn_bodies: &'a HashMap<String, &'a ast::BlockStmt>,
-    fn_spans: &'a HashMap<String, u32>,
-}
+    // Polymorphism guard. A hint tags a function PARAMETER, which fixes the
+    // dispatch for that parameter across EVERY call site of the function — not
+    // just the upgrade-fed one. So only keep a hint when the function is
+    // provably always handed the ws handle at that parameter. If any caller
+    // passes a non-ws value there (or any caller uses a spread arg, whose
+    // positional mapping is unreliable), tagging the param would silently
+    // re-route that caller's `.send()/.on()/.close()` to the Client runtime and
+    // drop the frame — the exact bug this pass fixes. Detect such functions and
+    // drop their hints. The caller scan is scope-aware so a nested function that
+    // SHADOWS a top-level name is not mistaken for a call to the top-level one.
+    let candidate_keys: HashSet<(u32, usize)> = acc.hints.iter().map(|(k, _)| *k).collect();
+    let mut shadowed_call_ids: HashSet<usize> = HashSet::new();
+    collect_shadowed_callee_calls(ast_module, &fn_spans, &mut shadowed_call_ids);
 
-type Taint = HashMap<String, (String, String)>;
-type Applied = HashSet<(u32, usize, String, String)>;
-type Hints = Vec<((u32, usize), (String, String))>;
-
-/// Clone `taint`, dropping any name the arrow rebinds as a parameter (shadowing).
-fn prune_for_arrow(taint: &Taint, arrow: &ast::ArrowExpr) -> Taint {
-    let mut t = taint.clone();
-    for p in &arrow.params {
-        if let Some(n) = cross_fn_pat_name(p) {
-            t.remove(&n);
+    let mut invalid: HashSet<(u32, usize)> = HashSet::new();
+    for call in &all_calls {
+        let call_id = *call as *const ast::CallExpr as usize;
+        // A call whose callee NAME is shadowed by a nearer binding does not
+        // reach the top-level function — skip it.
+        if shadowed_call_ids.contains(&call_id) {
+            continue;
         }
-    }
-    t
-}
-
-/// Clone `taint`, dropping any name the function rebinds as a parameter.
-fn prune_for_fn(taint: &Taint, func: &ast::Function) -> Taint {
-    let mut t = taint.clone();
-    for p in &func.params {
-        if let Some(n) = cross_fn_pat_name(&p.pat) {
-            t.remove(&n);
-        }
-    }
-    t
-}
-
-/// Walk a callback expression's body (arrow/function) under the seed taint. The
-/// callback's own params already account for the tainted handle, so no pruning.
-fn walk_taint_callback_body(
-    handler: &ast::Expr,
-    taint: &Taint,
-    tcx: &TaintCtx,
-    applied: &mut Applied,
-    hints: &mut Hints,
-    guard: &mut usize,
-) {
-    match handler {
-        ast::Expr::Arrow(a) => match a.body.as_ref() {
-            ast::BlockStmtOrExpr::BlockStmt(b) => {
-                walk_taint_stmts(&b.stmts, taint, tcx, applied, hints, guard)
+        let Some(callee) = cross_fn_call_ident(call) else {
+            continue;
+        };
+        let Some(&span) = fn_spans.get(&callee) else {
+            continue;
+        };
+        if call.args.iter().any(|a| a.spread.is_some()) {
+            // Spread args defeat positional matching — invalidate every
+            // candidate param of this callee.
+            for key in &candidate_keys {
+                if key.0 == span {
+                    invalid.insert(*key);
+                }
             }
-            ast::BlockStmtOrExpr::Expr(e) => walk_taint_expr(e, taint, tcx, applied, hints, guard),
-        },
-        ast::Expr::Fn(f) => {
-            if let Some(b) = &f.function.body {
-                walk_taint_stmts(&b.stmts, taint, tcx, applied, hints, guard);
+            continue;
+        }
+        for i in 0..call.args.len() {
+            if candidate_keys.contains(&(span, i)) && !acc.ws_fed.contains(&(span, i, call_id)) {
+                invalid.insert((span, i));
             }
         }
-        _ => {}
+    }
+
+    // Transitive demotion: a hint reached by following the handle THROUGH an
+    // upstream param P is only as valid as P. Once P is invalid (polymorphic),
+    // P can deliver a non-ws value downstream, so demote everything that
+    // depended on it. Iterate to a fixpoint.
+    loop {
+        let mut changed = false;
+        for (key, deps) in &acc.deps {
+            if !invalid.contains(key) && deps.iter().any(|d| invalid.contains(d)) {
+                invalid.insert(*key);
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    for (key, val) in acc.hints {
+        if !invalid.contains(&key) {
+            ctx.param_native_hints.insert(key, val);
+        }
     }
 }
 
-fn walk_taint_stmts(
-    stmts: &[ast::Stmt],
-    taint: &Taint,
-    tcx: &TaintCtx,
-    applied: &mut Applied,
-    hints: &mut Hints,
-    guard: &mut usize,
+/// Scope-aware pass that records the AST pointer identity of every bare-ident
+/// call `name(...)` whose callee `name` is a top-level function (`fn_names`) but
+/// is SHADOWED at the call site by a nearer binding (an enclosing
+/// function/arrow/method param, or a function declaration hoisted into the
+/// enclosing function body). Such a call does NOT reach the top-level function,
+/// so the polymorphism guard must not treat it as a caller of it.
+///
+/// Conservative by construction: it only records calls it can prove are
+/// shadowed. A missed shadow leaves the call counted as a real caller, which can
+/// only DROP a hint (safe), never keep an unsound one.
+fn collect_shadowed_callee_calls(
+    ast_module: &ast::Module,
+    fn_names: &HashMap<String, u32>,
+    out: &mut HashSet<usize>,
 ) {
-    for s in stmts {
-        walk_taint_stmt(s, taint, tcx, applied, hints, guard);
+    // Shadowing names introduced by a function/arrow/method body: its params
+    // plus the names of function declarations hoisted to the top of that body.
+    fn body_shadows<'a>(
+        params: impl Iterator<Item = &'a ast::Pat>,
+        stmts: &[ast::Stmt],
+        base: &HashSet<String>,
+    ) -> HashSet<String> {
+        let mut s = base.clone();
+        for p in params {
+            if let Some(n) = cross_fn_pat_name(p) {
+                s.insert(n);
+            }
+        }
+        for st in stmts {
+            if let ast::Stmt::Decl(ast::Decl::Fn(f)) = st {
+                s.insert(f.ident.sym.to_string());
+            }
+        }
+        s
+    }
+    for item in &ast_module.body {
+        match item {
+            ast::ModuleItem::Stmt(s) => shadow_scan_stmt(s, &HashSet::new(), fn_names, out),
+            ast::ModuleItem::ModuleDecl(ast::ModuleDecl::ExportDecl(e)) => match &e.decl {
+                ast::Decl::Var(v) => {
+                    for d in &v.decls {
+                        if let Some(init) = &d.init {
+                            shadow_scan_expr(init, &HashSet::new(), fn_names, out);
+                        }
+                    }
+                }
+                ast::Decl::Fn(f) => {
+                    if let Some(b) = &f.function.body {
+                        let sh = body_shadows(
+                            f.function.params.iter().map(|p| &p.pat),
+                            &b.stmts,
+                            &HashSet::new(),
+                        );
+                        for st in &b.stmts {
+                            shadow_scan_stmt(st, &sh, fn_names, out);
+                        }
+                    }
+                }
+                _ => {}
+            },
+            _ => {}
+        }
     }
 }
 
-fn walk_taint_stmt(
+fn shadow_scan_stmt(
     stmt: &ast::Stmt,
-    taint: &Taint,
-    tcx: &TaintCtx,
-    applied: &mut Applied,
-    hints: &mut Hints,
-    guard: &mut usize,
+    shadowed: &HashSet<String>,
+    fn_names: &HashMap<String, u32>,
+    out: &mut HashSet<usize>,
 ) {
     macro_rules! e {
         ($x:expr) => {
-            walk_taint_expr($x, taint, tcx, applied, hints, guard)
+            shadow_scan_expr($x, shadowed, fn_names, out)
         };
     }
     macro_rules! s {
         ($x:expr) => {
-            walk_taint_stmt($x, taint, tcx, applied, hints, guard)
+            shadow_scan_stmt($x, shadowed, fn_names, out)
         };
     }
     match stmt {
@@ -468,14 +530,29 @@ fn walk_taint_stmt(
                 }
             }
         }
-        // A nested function declaration is a new scope — prune its params.
         ast::Stmt::Decl(ast::Decl::Fn(f)) => {
             if let Some(b) = &f.function.body {
-                let pruned = prune_for_fn(taint, &f.function);
-                walk_taint_stmts(&b.stmts, &pruned, tcx, applied, hints, guard);
+                let mut sh = shadowed.clone();
+                for p in &f.function.params {
+                    if let Some(n) = cross_fn_pat_name(&p.pat) {
+                        sh.insert(n);
+                    }
+                }
+                for st in &b.stmts {
+                    if let ast::Stmt::Decl(ast::Decl::Fn(inner)) = st {
+                        sh.insert(inner.ident.sym.to_string());
+                    }
+                }
+                for st in &b.stmts {
+                    shadow_scan_stmt(st, &sh, fn_names, out);
+                }
             }
         }
-        ast::Stmt::Block(b) => walk_taint_stmts(&b.stmts, taint, tcx, applied, hints, guard),
+        ast::Stmt::Block(b) => {
+            for st in &b.stmts {
+                s!(st);
+            }
+        }
         ast::Stmt::If(i) => {
             e!(&i.test);
             s!(&i.cons);
@@ -519,12 +596,18 @@ fn walk_taint_stmt(
         }
         ast::Stmt::Throw(t) => e!(&t.arg),
         ast::Stmt::Try(t) => {
-            walk_taint_stmts(&t.block.stmts, taint, tcx, applied, hints, guard);
+            for st in &t.block.stmts {
+                s!(st);
+            }
             if let Some(h) = &t.handler {
-                walk_taint_stmts(&h.body.stmts, taint, tcx, applied, hints, guard);
+                for st in &h.body.stmts {
+                    s!(st);
+                }
             }
             if let Some(f) = &t.finalizer {
-                walk_taint_stmts(&f.stmts, taint, tcx, applied, hints, guard);
+                for st in &f.stmts {
+                    s!(st);
+                }
             }
         }
         ast::Stmt::Switch(sw) => {
@@ -533,7 +616,9 @@ fn walk_taint_stmt(
                 if let Some(t) = &c.test {
                     e!(t);
                 }
-                walk_taint_stmts(&c.cons, taint, tcx, applied, hints, guard);
+                for st in &c.cons {
+                    s!(st);
+                }
             }
         }
         ast::Stmt::Labeled(l) => s!(&l.body),
@@ -541,21 +626,355 @@ fn walk_taint_stmt(
     }
 }
 
-fn walk_taint_expr(
+fn shadow_scan_expr(
     expr: &ast::Expr,
-    taint: &Taint,
-    tcx: &TaintCtx,
-    applied: &mut Applied,
-    hints: &mut Hints,
-    guard: &mut usize,
+    shadowed: &HashSet<String>,
+    fn_names: &HashMap<String, u32>,
+    out: &mut HashSet<usize>,
 ) {
-    *guard += 1;
-    if *guard > 200_000 {
-        return; // pathological-input backstop
-    }
     macro_rules! e {
         ($x:expr) => {
-            walk_taint_expr($x, taint, tcx, applied, hints, guard)
+            shadow_scan_expr($x, shadowed, fn_names, out)
+        };
+    }
+    // Walk into a nested function/arrow/method body with its params (and hoisted
+    // fn-decls) added to the shadow set.
+    macro_rules! into_body {
+        ($params:expr, $stmts:expr) => {{
+            let mut sh = shadowed.clone();
+            for p in $params {
+                if let Some(n) = cross_fn_pat_name(p) {
+                    sh.insert(n);
+                }
+            }
+            for st in $stmts {
+                if let ast::Stmt::Decl(ast::Decl::Fn(inner)) = st {
+                    sh.insert(inner.ident.sym.to_string());
+                }
+            }
+            for st in $stmts {
+                shadow_scan_stmt(st, &sh, fn_names, out);
+            }
+        }};
+    }
+    match expr {
+        ast::Expr::Call(c) => {
+            if let ast::Callee::Expr(ce) = &c.callee {
+                if let ast::Expr::Ident(id) = ce.as_ref() {
+                    let name = id.sym.as_ref();
+                    if fn_names.contains_key(name) && shadowed.contains(name) {
+                        out.insert(c as *const ast::CallExpr as usize);
+                    }
+                }
+                e!(ce);
+            }
+            for a in &c.args {
+                e!(&a.expr);
+            }
+        }
+        ast::Expr::New(n) => {
+            e!(&n.callee);
+            if let Some(args) = &n.args {
+                for a in args {
+                    e!(&a.expr);
+                }
+            }
+        }
+        ast::Expr::Member(m) => {
+            e!(&m.obj);
+            if let ast::MemberProp::Computed(c) = &m.prop {
+                e!(&c.expr);
+            }
+        }
+        ast::Expr::Bin(b) => {
+            e!(&b.left);
+            e!(&b.right);
+        }
+        ast::Expr::Unary(u) => e!(&u.arg),
+        ast::Expr::Update(u) => e!(&u.arg),
+        ast::Expr::Assign(a) => e!(&a.right),
+        ast::Expr::Cond(c) => {
+            e!(&c.test);
+            e!(&c.cons);
+            e!(&c.alt);
+        }
+        ast::Expr::Paren(p) => e!(&p.expr),
+        ast::Expr::Seq(s) => {
+            for x in &s.exprs {
+                e!(x);
+            }
+        }
+        ast::Expr::Await(a) => e!(&a.arg),
+        ast::Expr::Yield(y) => {
+            if let Some(a) = &y.arg {
+                e!(a);
+            }
+        }
+        ast::Expr::Tpl(t) => {
+            for x in &t.exprs {
+                e!(x);
+            }
+        }
+        ast::Expr::TaggedTpl(t) => {
+            e!(&t.tag);
+            for x in &t.tpl.exprs {
+                e!(x);
+            }
+        }
+        ast::Expr::Array(a) => {
+            for el in a.elems.iter().flatten() {
+                e!(&el.expr);
+            }
+        }
+        ast::Expr::Object(o) => {
+            for prop in &o.props {
+                match prop {
+                    ast::PropOrSpread::Spread(s) => e!(&s.expr),
+                    ast::PropOrSpread::Prop(p) => match p.as_ref() {
+                        ast::Prop::KeyValue(kv) => e!(&kv.value),
+                        ast::Prop::Method(m) => {
+                            if let Some(b) = &m.function.body {
+                                into_body!(m.function.params.iter().map(|p| &p.pat), &b.stmts);
+                            }
+                        }
+                        _ => {}
+                    },
+                }
+            }
+        }
+        ast::Expr::Arrow(a) => match a.body.as_ref() {
+            ast::BlockStmtOrExpr::BlockStmt(b) => {
+                into_body!(a.params.iter(), &b.stmts);
+            }
+            ast::BlockStmtOrExpr::Expr(x) => {
+                let mut sh = shadowed.clone();
+                for p in &a.params {
+                    if let Some(n) = cross_fn_pat_name(p) {
+                        sh.insert(n);
+                    }
+                }
+                shadow_scan_expr(x, &sh, fn_names, out);
+            }
+        },
+        ast::Expr::Fn(f) => {
+            if let Some(b) = &f.function.body {
+                into_body!(f.function.params.iter().map(|p| &p.pat), &b.stmts);
+            }
+        }
+        ast::Expr::OptChain(o) => match o.base.as_ref() {
+            ast::OptChainBase::Member(m) => {
+                e!(&m.obj);
+                if let ast::MemberProp::Computed(c) = &m.prop {
+                    e!(&c.expr);
+                }
+            }
+            ast::OptChainBase::Call(c) => {
+                e!(&c.callee);
+                for a in &c.args {
+                    e!(&a.expr);
+                }
+            }
+        },
+        ast::Expr::TsAs(t) => e!(&t.expr),
+        ast::Expr::TsNonNull(t) => e!(&t.expr),
+        ast::Expr::TsTypeAssertion(t) => e!(&t.expr),
+        ast::Expr::TsConstAssertion(t) => e!(&t.expr),
+        ast::Expr::TsInstantiation(t) => e!(&t.expr),
+        _ => {}
+    }
+}
+
+/// Immutable top-level-function tables shared by the scope-aware taint walk.
+struct TaintCtx<'a> {
+    fn_params: &'a HashMap<String, Vec<Option<String>>>,
+    fn_bodies: &'a HashMap<String, &'a ast::BlockStmt>,
+    fn_spans: &'a HashMap<String, u32>,
+}
+
+type Taint = HashMap<String, (String, String)>;
+
+/// Mutable accumulators + the immutable function tables for the scope-aware
+/// taint walk, bundled so the recursive walkers take a single `&mut` and so the
+/// "current upstream source" can be saved/restored around a cross-fn descent
+/// without threading another argument through every arm.
+struct TaintAcc<'a> {
+    tcx: &'a TaintCtx<'a>,
+    /// Dedup: a `(fn_span, param_idx, module, class)` hint is pushed / recursed
+    /// into at most once.
+    applied: HashSet<(u32, usize, String, String)>,
+    /// Recorded hints, validated (polymorphism guard + transitive demotion) by
+    /// the caller after the walk.
+    hints: Vec<((u32, usize), (String, String))>,
+    /// Call sites — by AST pointer identity — that passed a ws-tainted handle at
+    /// `(callee_span, param_idx)`. After the walk, a hinted param whose function
+    /// ALSO has a non-ws-feeding caller is dropped: tagging the param would
+    /// mis-route that other caller's `.send()/.on()/.close()` to the Client
+    /// runtime (a silent no-op for the non-ws value).
+    ws_fed: HashSet<(u32, usize, usize)>,
+    /// Validity dependencies: a hint recorded while following the handle THROUGH
+    /// an upstream param P only holds when P is itself validly tagged. Seed-level
+    /// hints carry no dep. Drives transitive demotion.
+    deps: HashMap<(u32, usize), HashSet<(u32, usize)>>,
+    /// The upstream param the current descent is flowing the handle from (`None`
+    /// at the upgrade-handler seed level). Set when recursing into a callee body.
+    source: Option<(u32, usize)>,
+    guard: usize,
+}
+
+/// Clone `taint`, dropping any name the arrow rebinds as a parameter (shadowing).
+fn prune_for_arrow(taint: &Taint, arrow: &ast::ArrowExpr) -> Taint {
+    let mut t = taint.clone();
+    for p in &arrow.params {
+        if let Some(n) = cross_fn_pat_name(p) {
+            t.remove(&n);
+        }
+    }
+    t
+}
+
+/// Clone `taint`, dropping any name the function rebinds as a parameter.
+fn prune_for_fn(taint: &Taint, func: &ast::Function) -> Taint {
+    let mut t = taint.clone();
+    for p in &func.params {
+        if let Some(n) = cross_fn_pat_name(&p.pat) {
+            t.remove(&n);
+        }
+    }
+    t
+}
+
+/// Walk a callback expression's body (arrow/function) under the seed taint. The
+/// callback's own params already account for the tainted handle, so no pruning.
+fn walk_taint_callback_body(handler: &ast::Expr, taint: &Taint, acc: &mut TaintAcc) {
+    match handler {
+        ast::Expr::Arrow(a) => match a.body.as_ref() {
+            ast::BlockStmtOrExpr::BlockStmt(b) => walk_taint_stmts(&b.stmts, taint, acc),
+            ast::BlockStmtOrExpr::Expr(e) => walk_taint_expr(e, taint, acc),
+        },
+        ast::Expr::Fn(f) => {
+            if let Some(b) = &f.function.body {
+                walk_taint_stmts(&b.stmts, taint, acc);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn walk_taint_stmts(stmts: &[ast::Stmt], taint: &Taint, acc: &mut TaintAcc) {
+    for s in stmts {
+        walk_taint_stmt(s, taint, acc);
+    }
+}
+
+fn walk_taint_stmt(stmt: &ast::Stmt, taint: &Taint, acc: &mut TaintAcc) {
+    macro_rules! e {
+        ($x:expr) => {
+            walk_taint_expr($x, taint, acc)
+        };
+    }
+    macro_rules! s {
+        ($x:expr) => {
+            walk_taint_stmt($x, taint, acc)
+        };
+    }
+    match stmt {
+        ast::Stmt::Expr(x) => e!(&x.expr),
+        ast::Stmt::Return(r) => {
+            if let Some(a) = &r.arg {
+                e!(a);
+            }
+        }
+        ast::Stmt::Decl(ast::Decl::Var(v)) => {
+            for d in &v.decls {
+                if let Some(init) = &d.init {
+                    e!(init);
+                }
+            }
+        }
+        // A nested function declaration is a new scope — prune its params.
+        ast::Stmt::Decl(ast::Decl::Fn(f)) => {
+            if let Some(b) = &f.function.body {
+                let pruned = prune_for_fn(taint, &f.function);
+                walk_taint_stmts(&b.stmts, &pruned, acc);
+            }
+        }
+        ast::Stmt::Block(b) => walk_taint_stmts(&b.stmts, taint, acc),
+        ast::Stmt::If(i) => {
+            e!(&i.test);
+            s!(&i.cons);
+            if let Some(alt) = &i.alt {
+                s!(alt);
+            }
+        }
+        ast::Stmt::While(w) => {
+            e!(&w.test);
+            s!(&w.body);
+        }
+        ast::Stmt::DoWhile(w) => {
+            s!(&w.body);
+            e!(&w.test);
+        }
+        ast::Stmt::For(f) => {
+            if let Some(ast::VarDeclOrExpr::VarDecl(vd)) = &f.init {
+                for d in &vd.decls {
+                    if let Some(init) = &d.init {
+                        e!(init);
+                    }
+                }
+            } else if let Some(ast::VarDeclOrExpr::Expr(x)) = &f.init {
+                e!(x);
+            }
+            if let Some(t) = &f.test {
+                e!(t);
+            }
+            if let Some(u) = &f.update {
+                e!(u);
+            }
+            s!(&f.body);
+        }
+        ast::Stmt::ForIn(f) => {
+            e!(&f.right);
+            s!(&f.body);
+        }
+        ast::Stmt::ForOf(f) => {
+            e!(&f.right);
+            s!(&f.body);
+        }
+        ast::Stmt::Throw(t) => e!(&t.arg),
+        ast::Stmt::Try(t) => {
+            walk_taint_stmts(&t.block.stmts, taint, acc);
+            if let Some(h) = &t.handler {
+                walk_taint_stmts(&h.body.stmts, taint, acc);
+            }
+            if let Some(f) = &t.finalizer {
+                walk_taint_stmts(&f.stmts, taint, acc);
+            }
+        }
+        ast::Stmt::Switch(sw) => {
+            e!(&sw.discriminant);
+            for c in &sw.cases {
+                if let Some(t) = &c.test {
+                    e!(t);
+                }
+                walk_taint_stmts(&c.cons, taint, acc);
+            }
+        }
+        ast::Stmt::Labeled(l) => s!(&l.body),
+        _ => {}
+    }
+}
+
+fn walk_taint_expr(expr: &ast::Expr, taint: &Taint, acc: &mut TaintAcc) {
+    acc.guard += 1;
+    if acc.guard > 200_000 {
+        return; // pathological-input backstop
+    }
+    // Copy the shared function tables out (a `&` is Copy) so reading them below
+    // doesn't conflict with the `&mut acc` mutations in the call arm.
+    let tcx = acc.tcx;
+    macro_rules! e {
+        ($x:expr) => {
+            walk_taint_expr($x, taint, acc)
         };
     }
     match expr {
@@ -579,16 +998,33 @@ fn walk_taint_expr(
                         let Some(Some(param_name)) = params.get(i) else {
                             continue;
                         };
-                        if !applied.insert((span, i, module.clone(), class.clone())) {
+                        let (module, class) = (module.clone(), class.clone());
+                        // Record this ws-feeding call site (by AST pointer
+                        // identity) BEFORE the dedup below, so EVERY ws caller is
+                        // captured for the polymorphism guard even when the hint
+                        // itself was already recorded from another seed.
+                        let call_id = c as *const ast::CallExpr as usize;
+                        acc.ws_fed.insert((span, i, call_id));
+                        // This hint only holds if the upstream param we are
+                        // flowing through is itself validly tagged.
+                        if let Some(src) = acc.source {
+                            acc.deps.entry((span, i)).or_default().insert(src);
+                        }
+                        if !acc.applied.insert((span, i, module.clone(), class.clone())) {
                             continue;
                         }
-                        hints.push(((span, i), (module.clone(), class.clone())));
+                        acc.hints.push(((span, i), (module.clone(), class.clone())));
                         // Follow the handle into the callee body with a FRESH
-                        // scoped taint binding only its receiving parameter.
+                        // scoped taint binding only its receiving parameter, and
+                        // mark this callee param as the upstream source so any
+                        // deeper hint records its dependency on us.
                         if let Some(body) = tcx.fn_bodies.get(&callee) {
                             let mut fresh: Taint = HashMap::new();
-                            fresh.insert(param_name.clone(), (module.clone(), class.clone()));
-                            walk_taint_stmts(&body.stmts, &fresh, tcx, applied, hints, guard);
+                            fresh.insert(param_name.clone(), (module, class));
+                            let prev = acc.source;
+                            acc.source = Some((span, i));
+                            walk_taint_stmts(&body.stmts, &fresh, acc);
+                            acc.source = prev;
                         }
                     }
                 }
@@ -666,7 +1102,7 @@ fn walk_taint_expr(
                         ast::Prop::Method(m) => {
                             if let Some(b) = &m.function.body {
                                 let pruned = prune_for_fn(taint, &m.function);
-                                walk_taint_stmts(&b.stmts, &pruned, tcx, applied, hints, guard);
+                                walk_taint_stmts(&b.stmts, &pruned, acc);
                             }
                         }
                         _ => {}
@@ -678,18 +1114,14 @@ fn walk_taint_expr(
         ast::Expr::Arrow(a) => {
             let pruned = prune_for_arrow(taint, a);
             match a.body.as_ref() {
-                ast::BlockStmtOrExpr::BlockStmt(b) => {
-                    walk_taint_stmts(&b.stmts, &pruned, tcx, applied, hints, guard)
-                }
-                ast::BlockStmtOrExpr::Expr(x) => {
-                    walk_taint_expr(x, &pruned, tcx, applied, hints, guard)
-                }
+                ast::BlockStmtOrExpr::BlockStmt(b) => walk_taint_stmts(&b.stmts, &pruned, acc),
+                ast::BlockStmtOrExpr::Expr(x) => walk_taint_expr(x, &pruned, acc),
             }
         }
         ast::Expr::Fn(f) => {
             if let Some(b) = &f.function.body {
                 let pruned = prune_for_fn(taint, &f.function);
-                walk_taint_stmts(&b.stmts, &pruned, tcx, applied, hints, guard);
+                walk_taint_stmts(&b.stmts, &pruned, acc);
             }
         }
         ast::Expr::OptChain(o) => match o.base.as_ref() {
@@ -849,7 +1281,7 @@ fn collect_http_create_server_refs(ast_module: &ast::Module) -> HttpCreateRefs {
                 } else if let ast::ObjectPatProp::KeyValue(kv) = prop {
                     if let ast::PropName::Ident(k) = &kv.key {
                         let key = k.sym.as_ref();
-                        if (key == "createServer" || key == "createSecureServer") {
+                        if key == "createServer" || key == "createSecureServer" {
                             if let ast::Pat::Ident(local) = kv.value.as_ref() {
                                 refs.bare.insert(local.id.sym.to_string());
                             }

--- a/crates/perry-hir/src/lower/pre_scan.rs
+++ b/crates/perry-hir/src/lower/pre_scan.rs
@@ -291,6 +291,9 @@ pub(crate) fn pre_scan_cross_fn_native_params(ast_module: &ast::Module, ctx: &mu
     // name -> body block to follow the handle into.
     let mut fn_params: HashMap<String, Vec<Option<String>>> = HashMap::new();
     let mut fn_bodies: HashMap<String, &ast::BlockStmt> = HashMap::new();
+    // name -> identifier span `lo` (stable AST identity) for keying hints, so a
+    // hint never leaks onto an unrelated same-named declaration.
+    let mut fn_spans: HashMap<String, u32> = HashMap::new();
     for item in &ast_module.body {
         let fd = match item {
             ast::ModuleItem::Stmt(ast::Stmt::Decl(ast::Decl::Fn(fd))) => fd,
@@ -318,6 +321,7 @@ pub(crate) fn pre_scan_cross_fn_native_params(ast_module: &ast::Module, ctx: &mu
             // hint/param index by one for `function f(this: T, req, wsId)`.
             .filter(|name| name.as_deref() != Some("this"))
             .collect();
+        fn_spans.insert(name.clone(), fd.ident.span.lo.0);
         fn_params.insert(name.clone(), names);
         fn_bodies.insert(name, body);
     }
@@ -377,8 +381,12 @@ pub(crate) fn pre_scan_cross_fn_native_params(ast_module: &ast::Module, ctx: &mu
                 if !applied.insert(key) {
                     continue;
                 }
-                ctx.param_native_hints
-                    .insert((callee.clone(), i), (module.clone(), class.clone()));
+                // Key by the callee declaration's identifier span, not its name,
+                // so a same-named distinct declaration never picks up this hint.
+                if let Some(&callee_span) = fn_spans.get(&callee) {
+                    ctx.param_native_hints
+                        .insert((callee_span, i), (module.clone(), class.clone()));
+                }
                 // Follow the handle into the callee: its param[i] is now tainted.
                 if let Some(body) = fn_bodies.get(&callee) {
                     let mut next_calls = Vec::new();

--- a/crates/perry-hir/src/lower/pre_scan.rs
+++ b/crates/perry-hir/src/lower/pre_scan.rs
@@ -312,6 +312,11 @@ pub(crate) fn pre_scan_cross_fn_native_params(ast_module: &ast::Module, ctx: &mu
             .params
             .iter()
             .map(|p| cross_fn_pat_name(&p.pat))
+            // Drop the TypeScript `this:` type-only param exactly as
+            // `lower_fn_decl` does before enumerating real params. Call sites
+            // never pass `this` positionally, so keeping it would shift every
+            // hint/param index by one for `function f(this: T, req, wsId)`.
+            .filter(|name| name.as_deref() != Some("this"))
             .collect();
         fn_params.insert(name.clone(), names);
         fn_bodies.insert(name, body);

--- a/crates/perry-hir/src/lower/pre_scan.rs
+++ b/crates/perry-hir/src/lower/pre_scan.rs
@@ -465,10 +465,128 @@ fn upgrade_handler_ws_id<'a>(
     Some((ws_id, handler.expr.as_ref()))
 }
 
-/// Record idents bound to a `createServer(...)` / `createSecureServer(...)`
-/// call (bare or `http.`/`https.`/`http2.`-qualified) anywhere in the module.
+/// Node HTTP-family module specifiers whose `createServer`/`createSecureServer`
+/// produce a real `("http","HttpServer")` handle.
+fn is_http_module_specifier(src: &str) -> bool {
+    matches!(
+        src,
+        "http" | "node:http" | "https" | "node:https" | "http2" | "node:http2"
+    )
+}
+
+/// References that resolve to an HTTP-family `createServer`/`createSecureServer`,
+/// gathered from the module's imports and `require(...)`s. `bare` holds local
+/// names that ARE the function (named import / destructured require); `ns` holds
+/// namespace locals so `<ns>.createServer(...)` is recognised.
+#[derive(Default)]
+struct HttpCreateRefs {
+    bare: HashSet<String>,
+    ns: HashSet<String>,
+}
+
+/// Is `expr` a `require("<http-module>")` call? Returns the specifier text.
+fn require_http_specifier(expr: &ast::Expr) -> Option<&str> {
+    let ast::Expr::Call(call) = expr else {
+        return None;
+    };
+    let ast::Callee::Expr(callee) = &call.callee else {
+        return None;
+    };
+    let ast::Expr::Ident(i) = callee.as_ref() else {
+        return None;
+    };
+    if i.sym.as_ref() != "require" {
+        return None;
+    }
+    let arg = call.args.first()?;
+    let ast::Expr::Lit(ast::Lit::Str(s)) = arg.expr.as_ref() else {
+        return None;
+    };
+    let src = s.value.as_str()?;
+    is_http_module_specifier(src).then_some(src)
+}
+
+/// Build the set of HTTP-imported `createServer`/`createSecureServer` references
+/// (named/default/namespace imports + `require(...)` aliases, top-level scan).
+fn collect_http_create_server_refs(ast_module: &ast::Module) -> HttpCreateRefs {
+    let mut refs = HttpCreateRefs::default();
+    let note_require_binding = |pat: &ast::Pat, refs: &mut HttpCreateRefs| match pat {
+        // `const http = require("node:http")` → namespace binding.
+        ast::Pat::Ident(id) => {
+            refs.ns.insert(id.id.sym.to_string());
+        }
+        // `const { createServer } = require("node:http")` → bare binding.
+        ast::Pat::Object(obj) => {
+            for prop in &obj.props {
+                if let ast::ObjectPatProp::Assign(a) = prop {
+                    let key = a.key.sym.as_ref();
+                    if key == "createServer" || key == "createSecureServer" {
+                        refs.bare.insert(a.key.sym.to_string());
+                    }
+                } else if let ast::ObjectPatProp::KeyValue(kv) = prop {
+                    if let ast::PropName::Ident(k) = &kv.key {
+                        let key = k.sym.as_ref();
+                        if (key == "createServer" || key == "createSecureServer") {
+                            if let ast::Pat::Ident(local) = kv.value.as_ref() {
+                                refs.bare.insert(local.id.sym.to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        _ => {}
+    };
+    for item in &ast_module.body {
+        match item {
+            ast::ModuleItem::ModuleDecl(ast::ModuleDecl::Import(imp)) => {
+                if !is_http_module_specifier(imp.src.value.as_str().unwrap_or("")) {
+                    continue;
+                }
+                for spec in &imp.specifiers {
+                    match spec {
+                        ast::ImportSpecifier::Named(n) => {
+                            let imported = match &n.imported {
+                                Some(ast::ModuleExportName::Ident(i)) => i.sym.to_string(),
+                                Some(ast::ModuleExportName::Str(s)) => {
+                                    s.value.as_str().unwrap_or("").to_string()
+                                }
+                                None => n.local.sym.to_string(),
+                            };
+                            if imported == "createServer" || imported == "createSecureServer" {
+                                refs.bare.insert(n.local.sym.to_string());
+                            }
+                        }
+                        ast::ImportSpecifier::Default(d) => {
+                            refs.ns.insert(d.local.sym.to_string());
+                        }
+                        ast::ImportSpecifier::Namespace(ns) => {
+                            refs.ns.insert(ns.local.sym.to_string());
+                        }
+                    }
+                }
+            }
+            ast::ModuleItem::Stmt(ast::Stmt::Decl(ast::Decl::Var(v))) => {
+                for d in &v.decls {
+                    if let Some(init) = &d.init {
+                        if require_http_specifier(init).is_some() {
+                            note_require_binding(&d.name, &mut refs);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    refs
+}
+
+/// Record idents bound to an HTTP-family `createServer(...)` /
+/// `createSecureServer(...)` call (verified import/require provenance) anywhere
+/// in the module.
 fn collect_server_idents_in_module(ast_module: &ast::Module, out: &mut HashSet<String>) {
-    fn is_create_server_call(expr: &ast::Expr) -> bool {
+    let refs = collect_http_create_server_refs(ast_module);
+    fn is_create_server_call(expr: &ast::Expr, refs: &HttpCreateRefs) -> bool {
         let mut e = expr;
         loop {
             match e {
@@ -487,86 +605,94 @@ fn collect_server_idents_in_module(ast_module: &ast::Module, out: &mut HashSet<S
         let ast::Callee::Expr(callee) = &call.callee else {
             return false;
         };
-        let name = match callee.as_ref() {
-            ast::Expr::Ident(i) => i.sym.to_string(),
-            ast::Expr::Member(m) => match &m.prop {
-                ast::MemberProp::Ident(i) => i.sym.to_string(),
-                _ => return false,
-            },
-            _ => return false,
-        };
-        name == "createServer" || name == "createSecureServer"
+        match callee.as_ref() {
+            // Bare `createServer(...)` — only when the name is an HTTP-imported
+            // binding (named import or destructured require), not a user factory.
+            ast::Expr::Ident(i) => refs.bare.contains(i.sym.as_ref()),
+            // `<ns>.createServer(...)` — `<ns>` must be an HTTP namespace import.
+            ast::Expr::Member(m) => {
+                let ast::MemberProp::Ident(prop) = &m.prop else {
+                    return false;
+                };
+                let prop = prop.sym.as_ref();
+                if prop != "createServer" && prop != "createSecureServer" {
+                    return false;
+                }
+                matches!(m.obj.as_ref(), ast::Expr::Ident(o) if refs.ns.contains(o.sym.as_ref()))
+            }
+            _ => false,
+        }
     }
-    fn record_decl(decl: &ast::VarDeclarator, out: &mut HashSet<String>) {
+    fn record_decl(decl: &ast::VarDeclarator, refs: &HttpCreateRefs, out: &mut HashSet<String>) {
         if let (ast::Pat::Ident(id), Some(init)) = (&decl.name, decl.init.as_ref()) {
-            if is_create_server_call(init) {
+            if is_create_server_call(init, refs) {
                 out.insert(id.id.sym.to_string());
             }
         }
     }
-    fn walk_stmt(stmt: &ast::Stmt, out: &mut HashSet<String>) {
+    fn walk_stmt(stmt: &ast::Stmt, refs: &HttpCreateRefs, out: &mut HashSet<String>) {
         match stmt {
             ast::Stmt::Decl(ast::Decl::Var(v)) => {
                 for d in &v.decls {
-                    record_decl(d, out);
+                    record_decl(d, refs, out);
                 }
             }
             ast::Stmt::Decl(ast::Decl::Fn(f)) => {
                 if let Some(b) = &f.function.body {
                     for s in &b.stmts {
-                        walk_stmt(s, out);
+                        walk_stmt(s, refs, out);
                     }
                 }
             }
-            ast::Stmt::Expr(e) => walk_expr(&e.expr, out),
+            ast::Stmt::Expr(e) => walk_expr(&e.expr, refs, out),
             ast::Stmt::Block(b) => {
                 for s in &b.stmts {
-                    walk_stmt(s, out);
+                    walk_stmt(s, refs, out);
                 }
             }
             ast::Stmt::If(i) => {
-                walk_stmt(&i.cons, out);
+                walk_stmt(&i.cons, refs, out);
                 if let Some(alt) = &i.alt {
-                    walk_stmt(alt, out);
+                    walk_stmt(alt, refs, out);
                 }
             }
-            ast::Stmt::While(w) => walk_stmt(&w.body, out),
-            ast::Stmt::DoWhile(w) => walk_stmt(&w.body, out),
+            ast::Stmt::While(w) => walk_stmt(&w.body, refs, out),
+            ast::Stmt::DoWhile(w) => walk_stmt(&w.body, refs, out),
             ast::Stmt::For(f) => {
                 if let Some(ast::VarDeclOrExpr::VarDecl(vd)) = &f.init {
                     for d in &vd.decls {
-                        record_decl(d, out);
+                        record_decl(d, refs, out);
                     }
                 }
-                walk_stmt(&f.body, out);
+                walk_stmt(&f.body, refs, out);
             }
-            ast::Stmt::ForIn(f) => walk_stmt(&f.body, out),
-            ast::Stmt::ForOf(f) => walk_stmt(&f.body, out),
+            ast::Stmt::ForIn(f) => walk_stmt(&f.body, refs, out),
+            ast::Stmt::ForOf(f) => walk_stmt(&f.body, refs, out),
             ast::Stmt::Try(t) => {
                 for s in &t.block.stmts {
-                    walk_stmt(s, out);
+                    walk_stmt(s, refs, out);
                 }
                 if let Some(h) = &t.handler {
                     for s in &h.body.stmts {
-                        walk_stmt(s, out);
+                        walk_stmt(s, refs, out);
                     }
                 }
                 if let Some(f) = &t.finalizer {
                     for s in &f.stmts {
-                        walk_stmt(s, out);
+                        walk_stmt(s, refs, out);
                     }
                 }
             }
             ast::Stmt::Switch(s) => {
                 for c in &s.cases {
                     for s in &c.cons {
-                        walk_stmt(s, out);
+                        walk_stmt(s, refs, out);
                     }
                 }
             }
             ast::Stmt::Return(r) => {
                 if let Some(a) = &r.arg {
-                    walk_expr(a, out);
+                    walk_expr(a, refs, out);
                 }
             }
             _ => {}
@@ -574,44 +700,44 @@ fn collect_server_idents_in_module(ast_module: &ast::Module, out: &mut HashSet<S
     }
     // Descend into callback bodies (e.g. a server created inside `main()` or a
     // `.listen(0, () => { const server = createServer(...) })`).
-    fn walk_expr(expr: &ast::Expr, out: &mut HashSet<String>) {
+    fn walk_expr(expr: &ast::Expr, refs: &HttpCreateRefs, out: &mut HashSet<String>) {
         match expr {
             ast::Expr::Call(c) => {
                 for a in &c.args {
-                    walk_expr(&a.expr, out);
+                    walk_expr(&a.expr, refs, out);
                 }
             }
             ast::Expr::Arrow(a) => match a.body.as_ref() {
                 ast::BlockStmtOrExpr::BlockStmt(b) => {
                     for s in &b.stmts {
-                        walk_stmt(s, out);
+                        walk_stmt(s, refs, out);
                     }
                 }
-                ast::BlockStmtOrExpr::Expr(e) => walk_expr(e, out),
+                ast::BlockStmtOrExpr::Expr(e) => walk_expr(e, refs, out),
             },
             ast::Expr::Fn(f) => {
                 if let Some(b) = &f.function.body {
                     for s in &b.stmts {
-                        walk_stmt(s, out);
+                        walk_stmt(s, refs, out);
                     }
                 }
             }
-            ast::Expr::Paren(p) => walk_expr(&p.expr, out),
+            ast::Expr::Paren(p) => walk_expr(&p.expr, refs, out),
             _ => {}
         }
     }
     for item in &ast_module.body {
         match item {
-            ast::ModuleItem::Stmt(s) => walk_stmt(s, out),
+            ast::ModuleItem::Stmt(s) => walk_stmt(s, &refs, out),
             ast::ModuleItem::ModuleDecl(ast::ModuleDecl::ExportDecl(e)) => {
                 if let ast::Decl::Var(v) = &e.decl {
                     for d in &v.decls {
-                        record_decl(d, out);
+                        record_decl(d, &refs, out);
                     }
                 } else if let ast::Decl::Fn(f) = &e.decl {
                     if let Some(b) = &f.function.body {
                         for s in &b.stmts {
-                            walk_stmt(s, out);
+                            walk_stmt(s, &refs, out);
                         }
                     }
                 }

--- a/crates/perry-hir/src/lower/pre_scan.rs
+++ b/crates/perry-hir/src/lower/pre_scan.rs
@@ -266,6 +266,604 @@ pub(crate) fn pre_scan_mixin_functions(ast_module: &ast::Module, ctx: &mut Lower
     }
 }
 
+/// Cross-function native-instance propagation — the `("ws","Client")` upgrade
+/// handle delivered to `server.on("upgrade", (req, wsId, head) => …)` only
+/// dispatches its `.send()/.on()/.close()` to the `js_ws_*_client_i64` runtime
+/// when codegen statically knows the receiver is the upgrade `Client`. That
+/// class is tagged at the upgrade callback's parameter, but is NOT propagated
+/// when `wsId` is handed to a helper (`handleConnection(req, wsId)`): inside the
+/// callee the parameter is plain/`any`, the `class_filter: Some("Client")` row
+/// no longer matches, and `wsId.send(...)` silently lowers to a generic no-op —
+/// the frame is dropped, no error thrown.
+///
+/// This pre-pass runs BEFORE any function body is lowered. It seeds from the
+/// HTTP-upgrade idiom (gated on the receiver being a `createServer(...)` result,
+/// mirroring the runtime `("http","HttpServer")` check) and follows the handle
+/// through subsequent `userFn(…, wsId, …)` calls — transitively — recording a
+/// `(callee_name, param_index) -> (module, class)` hint in
+/// `ctx.param_native_hints`. `lower_fn_decl` consults the hint to register the
+/// otherwise-untyped parameter as a native instance, so the callee's
+/// `wsId.send(...)` dispatches to `js_ws_send_client_i64` exactly like the
+/// inline call would.
+pub(crate) fn pre_scan_cross_fn_native_params(ast_module: &ast::Module, ctx: &mut LoweringContext) {
+    // Top-level user functions: name -> ordered param names (None marks a
+    // destructuring/rest param that can't be a simple handle binding), and
+    // name -> body block to follow the handle into.
+    let mut fn_params: HashMap<String, Vec<Option<String>>> = HashMap::new();
+    let mut fn_bodies: HashMap<String, &ast::BlockStmt> = HashMap::new();
+    for item in &ast_module.body {
+        let fd = match item {
+            ast::ModuleItem::Stmt(ast::Stmt::Decl(ast::Decl::Fn(fd))) => fd,
+            ast::ModuleItem::ModuleDecl(ast::ModuleDecl::ExportDecl(e)) => {
+                if let ast::Decl::Fn(fd) = &e.decl {
+                    fd
+                } else {
+                    continue;
+                }
+            }
+            _ => continue,
+        };
+        let Some(body) = &fd.function.body else {
+            continue;
+        };
+        let name = fd.ident.sym.to_string();
+        let names: Vec<Option<String>> = fd
+            .function
+            .params
+            .iter()
+            .map(|p| cross_fn_pat_name(&p.pat))
+            .collect();
+        fn_params.insert(name.clone(), names);
+        fn_bodies.insert(name, body);
+    }
+    if fn_params.is_empty() {
+        return;
+    }
+
+    // Idents bound to a `createServer(...)` / `createSecureServer(...)` result
+    // — the static proxy for a `("http","HttpServer")` native instance.
+    let mut server_idents: HashSet<String> = HashSet::new();
+    collect_server_idents_in_module(ast_module, &mut server_idents);
+
+    // Seed work items from each gated upgrade handler.
+    let mut work: Vec<(Vec<&ast::CallExpr>, HashMap<String, (String, String)>)> = Vec::new();
+    let mut all_calls: Vec<&ast::CallExpr> = Vec::new();
+    collect_calls_in_module(ast_module, &mut all_calls);
+    for call in &all_calls {
+        if let Some((ws_id, handler)) = upgrade_handler_ws_id(call, &server_idents) {
+            let mut calls = Vec::new();
+            collect_calls_in_callback_body(handler, &mut calls);
+            let mut tainted = HashMap::new();
+            tainted.insert(ws_id, ("ws".to_string(), "Client".to_string()));
+            work.push((calls, tainted));
+        }
+    }
+
+    // Fixpoint propagation. `applied` dedups (callee, param, module, class) so
+    // mutual recursion / repeated call sites terminate.
+    let mut applied: HashSet<(String, usize, String, String)> = HashSet::new();
+    let mut guard = 0usize;
+    while let Some((calls, tainted)) = work.pop() {
+        guard += 1;
+        if guard > 50_000 {
+            break; // pathological-input backstop
+        }
+        for call in calls {
+            let Some(callee) = cross_fn_call_ident(call) else {
+                continue;
+            };
+            let Some(params) = fn_params.get(&callee) else {
+                continue;
+            };
+            for (i, arg) in call.args.iter().enumerate() {
+                if arg.spread.is_some() {
+                    continue;
+                }
+                let ast::Expr::Ident(id) = arg.expr.as_ref() else {
+                    continue;
+                };
+                let Some((module, class)) = tainted.get(id.sym.as_ref()) else {
+                    continue;
+                };
+                let Some(Some(param_name)) = params.get(i) else {
+                    continue;
+                };
+                let key = (callee.clone(), i, module.clone(), class.clone());
+                if !applied.insert(key) {
+                    continue;
+                }
+                ctx.param_native_hints
+                    .insert((callee.clone(), i), (module.clone(), class.clone()));
+                // Follow the handle into the callee: its param[i] is now tainted.
+                if let Some(body) = fn_bodies.get(&callee) {
+                    let mut next_calls = Vec::new();
+                    collect_calls_in_stmts(&body.stmts, &mut next_calls);
+                    let mut next = HashMap::new();
+                    next.insert(param_name.clone(), (module.clone(), class.clone()));
+                    work.push((next_calls, next));
+                }
+            }
+        }
+    }
+}
+
+/// Plain-ident name of a pattern, else `None` (destructuring / rest).
+fn cross_fn_pat_name(pat: &ast::Pat) -> Option<String> {
+    match pat {
+        ast::Pat::Ident(i) => Some(i.id.sym.to_string()),
+        _ => None,
+    }
+}
+
+/// `g(...)` where the callee is a bare identifier — returns `g`.
+fn cross_fn_call_ident(call: &ast::CallExpr) -> Option<String> {
+    match &call.callee {
+        ast::Callee::Expr(e) => match e.as_ref() {
+            ast::Expr::Ident(i) => Some(i.sym.to_string()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// `X.on("upgrade", (req, wsId, head) => …)` / `.addListener` / `.once`, where
+/// `X` is a `createServer(...)` result. Returns the `wsId` param name and the
+/// handler expression (whose body carries the handle in scope).
+fn upgrade_handler_ws_id<'a>(
+    call: &'a ast::CallExpr,
+    server_idents: &HashSet<String>,
+) -> Option<(String, &'a ast::Expr)> {
+    let ast::Callee::Expr(callee) = &call.callee else {
+        return None;
+    };
+    let ast::Expr::Member(member) = callee.as_ref() else {
+        return None;
+    };
+    // Receiver must be a known http server ident.
+    let ast::Expr::Ident(obj) = member.obj.as_ref() else {
+        return None;
+    };
+    if !server_idents.contains(obj.sym.as_ref()) {
+        return None;
+    }
+    let method = match &member.prop {
+        ast::MemberProp::Ident(i) => i.sym.as_ref(),
+        _ => return None,
+    };
+    if method != "on" && method != "addListener" && method != "once" {
+        return None;
+    }
+    let event = call.args.first()?;
+    if event.spread.is_some() {
+        return None;
+    }
+    let is_upgrade = matches!(
+        event.expr.as_ref(),
+        ast::Expr::Lit(ast::Lit::Str(s)) if s.value.as_str() == Some("upgrade")
+    );
+    if !is_upgrade {
+        return None;
+    }
+    let handler = call.args.get(1)?;
+    if handler.spread.is_some() {
+        return None;
+    }
+    let ws_id = match handler.expr.as_ref() {
+        ast::Expr::Arrow(a) => a.params.get(1).and_then(cross_fn_pat_name),
+        ast::Expr::Fn(f) => f
+            .function
+            .params
+            .get(1)
+            .and_then(|p| cross_fn_pat_name(&p.pat)),
+        _ => None,
+    }?;
+    Some((ws_id, handler.expr.as_ref()))
+}
+
+/// Record idents bound to a `createServer(...)` / `createSecureServer(...)`
+/// call (bare or `http.`/`https.`/`http2.`-qualified) anywhere in the module.
+fn collect_server_idents_in_module(ast_module: &ast::Module, out: &mut HashSet<String>) {
+    fn is_create_server_call(expr: &ast::Expr) -> bool {
+        let mut e = expr;
+        loop {
+            match e {
+                ast::Expr::Paren(p) => e = &p.expr,
+                ast::Expr::TsAs(t) => e = &t.expr,
+                ast::Expr::TsNonNull(t) => e = &t.expr,
+                // `createServer(...).listen(...)` still binds the server to the
+                // chained receiver, but the bound ident is the chain result, not
+                // the server — so only treat a *direct* call result as a server.
+                _ => break,
+            }
+        }
+        let ast::Expr::Call(call) = e else {
+            return false;
+        };
+        let ast::Callee::Expr(callee) = &call.callee else {
+            return false;
+        };
+        let name = match callee.as_ref() {
+            ast::Expr::Ident(i) => i.sym.to_string(),
+            ast::Expr::Member(m) => match &m.prop {
+                ast::MemberProp::Ident(i) => i.sym.to_string(),
+                _ => return false,
+            },
+            _ => return false,
+        };
+        name == "createServer" || name == "createSecureServer"
+    }
+    fn record_decl(decl: &ast::VarDeclarator, out: &mut HashSet<String>) {
+        if let (ast::Pat::Ident(id), Some(init)) = (&decl.name, decl.init.as_ref()) {
+            if is_create_server_call(init) {
+                out.insert(id.id.sym.to_string());
+            }
+        }
+    }
+    fn walk_stmt(stmt: &ast::Stmt, out: &mut HashSet<String>) {
+        match stmt {
+            ast::Stmt::Decl(ast::Decl::Var(v)) => {
+                for d in &v.decls {
+                    record_decl(d, out);
+                }
+            }
+            ast::Stmt::Decl(ast::Decl::Fn(f)) => {
+                if let Some(b) = &f.function.body {
+                    for s in &b.stmts {
+                        walk_stmt(s, out);
+                    }
+                }
+            }
+            ast::Stmt::Expr(e) => walk_expr(&e.expr, out),
+            ast::Stmt::Block(b) => {
+                for s in &b.stmts {
+                    walk_stmt(s, out);
+                }
+            }
+            ast::Stmt::If(i) => {
+                walk_stmt(&i.cons, out);
+                if let Some(alt) = &i.alt {
+                    walk_stmt(alt, out);
+                }
+            }
+            ast::Stmt::While(w) => walk_stmt(&w.body, out),
+            ast::Stmt::DoWhile(w) => walk_stmt(&w.body, out),
+            ast::Stmt::For(f) => {
+                if let Some(ast::VarDeclOrExpr::VarDecl(vd)) = &f.init {
+                    for d in &vd.decls {
+                        record_decl(d, out);
+                    }
+                }
+                walk_stmt(&f.body, out);
+            }
+            ast::Stmt::ForIn(f) => walk_stmt(&f.body, out),
+            ast::Stmt::ForOf(f) => walk_stmt(&f.body, out),
+            ast::Stmt::Try(t) => {
+                for s in &t.block.stmts {
+                    walk_stmt(s, out);
+                }
+                if let Some(h) = &t.handler {
+                    for s in &h.body.stmts {
+                        walk_stmt(s, out);
+                    }
+                }
+                if let Some(f) = &t.finalizer {
+                    for s in &f.stmts {
+                        walk_stmt(s, out);
+                    }
+                }
+            }
+            ast::Stmt::Switch(s) => {
+                for c in &s.cases {
+                    for s in &c.cons {
+                        walk_stmt(s, out);
+                    }
+                }
+            }
+            ast::Stmt::Return(r) => {
+                if let Some(a) = &r.arg {
+                    walk_expr(a, out);
+                }
+            }
+            _ => {}
+        }
+    }
+    // Descend into callback bodies (e.g. a server created inside `main()` or a
+    // `.listen(0, () => { const server = createServer(...) })`).
+    fn walk_expr(expr: &ast::Expr, out: &mut HashSet<String>) {
+        match expr {
+            ast::Expr::Call(c) => {
+                for a in &c.args {
+                    walk_expr(&a.expr, out);
+                }
+            }
+            ast::Expr::Arrow(a) => match a.body.as_ref() {
+                ast::BlockStmtOrExpr::BlockStmt(b) => {
+                    for s in &b.stmts {
+                        walk_stmt(s, out);
+                    }
+                }
+                ast::BlockStmtOrExpr::Expr(e) => walk_expr(e, out),
+            },
+            ast::Expr::Fn(f) => {
+                if let Some(b) = &f.function.body {
+                    for s in &b.stmts {
+                        walk_stmt(s, out);
+                    }
+                }
+            }
+            ast::Expr::Paren(p) => walk_expr(&p.expr, out),
+            _ => {}
+        }
+    }
+    for item in &ast_module.body {
+        match item {
+            ast::ModuleItem::Stmt(s) => walk_stmt(s, out),
+            ast::ModuleItem::ModuleDecl(ast::ModuleDecl::ExportDecl(e)) => {
+                if let ast::Decl::Var(v) = &e.decl {
+                    for d in &v.decls {
+                        record_decl(d, out);
+                    }
+                } else if let ast::Decl::Fn(f) = &e.decl {
+                    if let Some(b) = &f.function.body {
+                        for s in &b.stmts {
+                            walk_stmt(s, out);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Collect every `CallExpr` reachable in the module (statement position and
+/// nested closures) — used to find the upgrade-handler seed.
+fn collect_calls_in_module<'a>(ast_module: &'a ast::Module, out: &mut Vec<&'a ast::CallExpr>) {
+    for item in &ast_module.body {
+        match item {
+            ast::ModuleItem::Stmt(s) => collect_calls_in_stmt(s, out),
+            ast::ModuleItem::ModuleDecl(ast::ModuleDecl::ExportDecl(e)) => match &e.decl {
+                ast::Decl::Var(v) => {
+                    for d in &v.decls {
+                        if let Some(init) = &d.init {
+                            collect_calls_in_expr(init, out);
+                        }
+                    }
+                }
+                ast::Decl::Fn(f) => {
+                    if let Some(b) = &f.function.body {
+                        collect_calls_in_stmts(&b.stmts, out);
+                    }
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+}
+
+/// Collect calls in a callback expression's body (arrow or function).
+fn collect_calls_in_callback_body<'a>(handler: &'a ast::Expr, out: &mut Vec<&'a ast::CallExpr>) {
+    match handler {
+        ast::Expr::Arrow(a) => match a.body.as_ref() {
+            ast::BlockStmtOrExpr::BlockStmt(b) => collect_calls_in_stmts(&b.stmts, out),
+            ast::BlockStmtOrExpr::Expr(e) => collect_calls_in_expr(e, out),
+        },
+        ast::Expr::Fn(f) => {
+            if let Some(b) = &f.function.body {
+                collect_calls_in_stmts(&b.stmts, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_calls_in_stmts<'a>(stmts: &'a [ast::Stmt], out: &mut Vec<&'a ast::CallExpr>) {
+    for s in stmts {
+        collect_calls_in_stmt(s, out);
+    }
+}
+
+fn collect_calls_in_stmt<'a>(stmt: &'a ast::Stmt, out: &mut Vec<&'a ast::CallExpr>) {
+    match stmt {
+        ast::Stmt::Expr(e) => collect_calls_in_expr(&e.expr, out),
+        ast::Stmt::Return(r) => {
+            if let Some(a) = &r.arg {
+                collect_calls_in_expr(a, out);
+            }
+        }
+        ast::Stmt::Decl(ast::Decl::Var(v)) => {
+            for d in &v.decls {
+                if let Some(init) = &d.init {
+                    collect_calls_in_expr(init, out);
+                }
+            }
+        }
+        ast::Stmt::Decl(ast::Decl::Fn(f)) => {
+            if let Some(b) = &f.function.body {
+                collect_calls_in_stmts(&b.stmts, out);
+            }
+        }
+        ast::Stmt::Block(b) => collect_calls_in_stmts(&b.stmts, out),
+        ast::Stmt::If(i) => {
+            collect_calls_in_expr(&i.test, out);
+            collect_calls_in_stmt(&i.cons, out);
+            if let Some(alt) = &i.alt {
+                collect_calls_in_stmt(alt, out);
+            }
+        }
+        ast::Stmt::While(w) => {
+            collect_calls_in_expr(&w.test, out);
+            collect_calls_in_stmt(&w.body, out);
+        }
+        ast::Stmt::DoWhile(w) => {
+            collect_calls_in_stmt(&w.body, out);
+            collect_calls_in_expr(&w.test, out);
+        }
+        ast::Stmt::For(f) => {
+            if let Some(ast::VarDeclOrExpr::VarDecl(vd)) = &f.init {
+                for d in &vd.decls {
+                    if let Some(init) = &d.init {
+                        collect_calls_in_expr(init, out);
+                    }
+                }
+            } else if let Some(ast::VarDeclOrExpr::Expr(e)) = &f.init {
+                collect_calls_in_expr(e, out);
+            }
+            if let Some(t) = &f.test {
+                collect_calls_in_expr(t, out);
+            }
+            if let Some(u) = &f.update {
+                collect_calls_in_expr(u, out);
+            }
+            collect_calls_in_stmt(&f.body, out);
+        }
+        ast::Stmt::ForIn(f) => {
+            collect_calls_in_expr(&f.right, out);
+            collect_calls_in_stmt(&f.body, out);
+        }
+        ast::Stmt::ForOf(f) => {
+            collect_calls_in_expr(&f.right, out);
+            collect_calls_in_stmt(&f.body, out);
+        }
+        ast::Stmt::Throw(t) => collect_calls_in_expr(&t.arg, out),
+        ast::Stmt::Try(t) => {
+            collect_calls_in_stmts(&t.block.stmts, out);
+            if let Some(h) = &t.handler {
+                collect_calls_in_stmts(&h.body.stmts, out);
+            }
+            if let Some(f) = &t.finalizer {
+                collect_calls_in_stmts(&f.stmts, out);
+            }
+        }
+        ast::Stmt::Switch(s) => {
+            collect_calls_in_expr(&s.discriminant, out);
+            for c in &s.cases {
+                if let Some(t) = &c.test {
+                    collect_calls_in_expr(t, out);
+                }
+                collect_calls_in_stmts(&c.cons, out);
+            }
+        }
+        ast::Stmt::Labeled(l) => collect_calls_in_stmt(&l.body, out),
+        _ => {}
+    }
+}
+
+fn collect_calls_in_expr<'a>(expr: &'a ast::Expr, out: &mut Vec<&'a ast::CallExpr>) {
+    match expr {
+        ast::Expr::Call(c) => {
+            out.push(c);
+            if let ast::Callee::Expr(e) = &c.callee {
+                collect_calls_in_expr(e, out);
+            }
+            for a in &c.args {
+                collect_calls_in_expr(&a.expr, out);
+            }
+        }
+        ast::Expr::New(n) => {
+            collect_calls_in_expr(&n.callee, out);
+            if let Some(args) = &n.args {
+                for a in args {
+                    collect_calls_in_expr(&a.expr, out);
+                }
+            }
+        }
+        ast::Expr::Member(m) => {
+            collect_calls_in_expr(&m.obj, out);
+            if let ast::MemberProp::Computed(c) = &m.prop {
+                collect_calls_in_expr(&c.expr, out);
+            }
+        }
+        ast::Expr::Bin(b) => {
+            collect_calls_in_expr(&b.left, out);
+            collect_calls_in_expr(&b.right, out);
+        }
+        ast::Expr::Unary(u) => collect_calls_in_expr(&u.arg, out),
+        ast::Expr::Update(u) => collect_calls_in_expr(&u.arg, out),
+        // Assignment LHS rarely carries a handle-passing call; follow the RHS.
+        ast::Expr::Assign(a) => collect_calls_in_expr(&a.right, out),
+        ast::Expr::Cond(c) => {
+            collect_calls_in_expr(&c.test, out);
+            collect_calls_in_expr(&c.cons, out);
+            collect_calls_in_expr(&c.alt, out);
+        }
+        ast::Expr::Paren(p) => collect_calls_in_expr(&p.expr, out),
+        ast::Expr::Seq(s) => {
+            for e in &s.exprs {
+                collect_calls_in_expr(e, out);
+            }
+        }
+        ast::Expr::Await(a) => collect_calls_in_expr(&a.arg, out),
+        ast::Expr::Yield(y) => {
+            if let Some(a) = &y.arg {
+                collect_calls_in_expr(a, out);
+            }
+        }
+        ast::Expr::Tpl(t) => {
+            for e in &t.exprs {
+                collect_calls_in_expr(e, out);
+            }
+        }
+        ast::Expr::TaggedTpl(t) => {
+            collect_calls_in_expr(&t.tag, out);
+            for e in &t.tpl.exprs {
+                collect_calls_in_expr(e, out);
+            }
+        }
+        ast::Expr::Array(a) => {
+            for el in a.elems.iter().flatten() {
+                collect_calls_in_expr(&el.expr, out);
+            }
+        }
+        ast::Expr::Object(o) => {
+            for p in &o.props {
+                match p {
+                    ast::PropOrSpread::Spread(s) => collect_calls_in_expr(&s.expr, out),
+                    ast::PropOrSpread::Prop(prop) => match prop.as_ref() {
+                        ast::Prop::KeyValue(kv) => collect_calls_in_expr(&kv.value, out),
+                        ast::Prop::Method(m) => {
+                            if let Some(b) = &m.function.body {
+                                collect_calls_in_stmts(&b.stmts, out);
+                            }
+                        }
+                        _ => {}
+                    },
+                }
+            }
+        }
+        ast::Expr::Arrow(a) => match a.body.as_ref() {
+            ast::BlockStmtOrExpr::BlockStmt(b) => collect_calls_in_stmts(&b.stmts, out),
+            ast::BlockStmtOrExpr::Expr(e) => collect_calls_in_expr(e, out),
+        },
+        ast::Expr::Fn(f) => {
+            if let Some(b) = &f.function.body {
+                collect_calls_in_stmts(&b.stmts, out);
+            }
+        }
+        ast::Expr::OptChain(o) => match o.base.as_ref() {
+            ast::OptChainBase::Member(m) => {
+                collect_calls_in_expr(&m.obj, out);
+                if let ast::MemberProp::Computed(c) = &m.prop {
+                    collect_calls_in_expr(&c.expr, out);
+                }
+            }
+            ast::OptChainBase::Call(c) => {
+                collect_calls_in_expr(&c.callee, out);
+                for a in &c.args {
+                    collect_calls_in_expr(&a.expr, out);
+                }
+            }
+        },
+        ast::Expr::TsAs(t) => collect_calls_in_expr(&t.expr, out),
+        ast::Expr::TsNonNull(t) => collect_calls_in_expr(&t.expr, out),
+        ast::Expr::TsTypeAssertion(t) => collect_calls_in_expr(&t.expr, out),
+        ast::Expr::TsConstAssertion(t) => collect_calls_in_expr(&t.expr, out),
+        ast::Expr::TsInstantiation(t) => collect_calls_in_expr(&t.expr, out),
+        _ => {}
+    }
+}
+
 /// #4510: pre-register module-level `enum` declarations so a forward
 /// reference (an enum used in a function body or earlier statement, before its
 /// textual declaration) resolves instead of falling through to the

--- a/crates/perry-hir/src/lower/pre_scan.rs
+++ b/crates/perry-hir/src/lower/pre_scan.rs
@@ -1143,6 +1143,55 @@ fn walk_taint_expr(expr: &ast::Expr, taint: &Taint, acc: &mut TaintAcc) {
         ast::Expr::TsTypeAssertion(t) => e!(&t.expr),
         ast::Expr::TsConstAssertion(t) => e!(&t.expr),
         ast::Expr::TsInstantiation(t) => e!(&t.expr),
+        ast::Expr::TsSatisfies(t) => e!(&t.expr),
+        // A class expression's member bodies are new scopes: prune each
+        // method/constructor's params before recursing (like object methods);
+        // field initializers and static blocks run in the surrounding taint.
+        ast::Expr::Class(c) => {
+            for member in &c.class.body {
+                match member {
+                    ast::ClassMember::Method(m) => {
+                        if let Some(b) = &m.function.body {
+                            let pruned = prune_for_fn(taint, &m.function);
+                            walk_taint_stmts(&b.stmts, &pruned, acc);
+                        }
+                    }
+                    ast::ClassMember::PrivateMethod(m) => {
+                        if let Some(b) = &m.function.body {
+                            let pruned = prune_for_fn(taint, &m.function);
+                            walk_taint_stmts(&b.stmts, &pruned, acc);
+                        }
+                    }
+                    ast::ClassMember::Constructor(ctor) => {
+                        if let Some(b) = &ctor.body {
+                            let mut pruned = taint.clone();
+                            for p in &ctor.params {
+                                if let ast::ParamOrTsParamProp::Param(param) = p {
+                                    if let Some(n) = cross_fn_pat_name(&param.pat) {
+                                        pruned.remove(&n);
+                                    }
+                                }
+                            }
+                            walk_taint_stmts(&b.stmts, &pruned, acc);
+                        }
+                    }
+                    ast::ClassMember::ClassProp(p) => {
+                        if let Some(v) = &p.value {
+                            e!(v);
+                        }
+                    }
+                    ast::ClassMember::PrivateProp(p) => {
+                        if let Some(v) = &p.value {
+                            e!(v);
+                        }
+                    }
+                    ast::ClassMember::StaticBlock(s) => {
+                        walk_taint_stmts(&s.body.stmts, taint, acc);
+                    }
+                    _ => {}
+                }
+            }
+        }
         _ => {}
     }
 }

--- a/crates/perry-hir/src/lower_decl/fn_decl.rs
+++ b/crates/perry-hir/src/lower_decl/fn_decl.rs
@@ -201,15 +201,20 @@ pub fn lower_fn_decl(ctx: &mut LoweringContext, fn_decl: &ast::FnDecl) -> Result
     // known native handle across a call boundary (e.g. the `("ws","Client")`
     // upgrade `wsId` passed as `handleConnection(req, wsId)`) is untyped here,
     // so the type-annotation loop above can't tag it. `pre_scan_cross_fn_native_params`
-    // recorded a `(fn_name, param_index) -> (module, class)` hint before any
-    // body lowered; apply it now (before the body lowers) so `wsId.send(...)`
+    // recorded a `(fn_ident_span_lo, param_index) -> (module, class)` hint before
+    // any body lowered; apply it now (before the body lowers) so `wsId.send(...)`
     // inside this function dispatches to `js_ws_send_client_i64` like the inline
-    // call. Only registers when the param isn't already a native instance, so an
-    // explicit annotation always wins.
-    for (idx, param) in params.iter().enumerate() {
-        if let Some((module, class)) = ctx.param_native_hints.get(&(name.clone(), idx)).cloned() {
-            if ctx.lookup_native_instance(&param.name).is_none() {
-                ctx.register_native_instance(param.name.clone(), module, class);
+    // call. The key is this declaration's identifier span (not its name), so a
+    // hint seeded for a same-named but distinct function never leaks here. Only
+    // registers when the param isn't already a native instance, so an explicit
+    // annotation always wins.
+    if !ctx.param_native_hints.is_empty() {
+        let fn_span_lo = fn_decl.ident.span.lo.0;
+        for (idx, param) in params.iter().enumerate() {
+            if let Some((module, class)) = ctx.param_native_hints.get(&(fn_span_lo, idx)).cloned() {
+                if ctx.lookup_native_instance(&param.name).is_none() {
+                    ctx.register_native_instance(param.name.clone(), module, class);
+                }
             }
         }
     }

--- a/crates/perry-hir/src/lower_decl/fn_decl.rs
+++ b/crates/perry-hir/src/lower_decl/fn_decl.rs
@@ -197,6 +197,23 @@ pub fn lower_fn_decl(ctx: &mut LoweringContext, fn_decl: &ast::FnDecl) -> Result
         }
     }
 
+    // Cross-function native-handle propagation: a parameter that receives a
+    // known native handle across a call boundary (e.g. the `("ws","Client")`
+    // upgrade `wsId` passed as `handleConnection(req, wsId)`) is untyped here,
+    // so the type-annotation loop above can't tag it. `pre_scan_cross_fn_native_params`
+    // recorded a `(fn_name, param_index) -> (module, class)` hint before any
+    // body lowered; apply it now (before the body lowers) so `wsId.send(...)`
+    // inside this function dispatches to `js_ws_send_client_i64` like the inline
+    // call. Only registers when the param isn't already a native instance, so an
+    // explicit annotation always wins.
+    for (idx, param) in params.iter().enumerate() {
+        if let Some((module, class)) = ctx.param_native_hints.get(&(name.clone(), idx)).cloned() {
+            if ctx.lookup_native_instance(&param.name).is_none() {
+                ctx.register_native_instance(param.name.clone(), module, class);
+            }
+        }
+    }
+
     // #1483: perry/ui widget parameters (e.g. `canvas: Canvas` or, via a
     // type-only import alias, `canvas: CanvasType`) must dispatch instance
     // methods through perry/ui `NativeMethodCall` exactly like a local

--- a/crates/perry/tests/ws_client_handle_cross_function_dispatch.rs
+++ b/crates/perry/tests/ws_client_handle_cross_function_dispatch.rs
@@ -73,6 +73,14 @@ fn ir_has_call(ir: &str, symbol: &str) -> bool {
         .any(|l| l.contains("call ") && l.contains(&needle))
 }
 
+/// Number of `call` instructions targeting `@<symbol>`.
+fn ir_call_count(ir: &str, symbol: &str) -> usize {
+    let needle = format!("@{symbol}(");
+    ir.lines()
+        .filter(|l| l.contains("call ") && l.contains(&needle))
+        .count()
+}
+
 fn compile_and_run(dir: &Path, source: &str) -> String {
     let entry = dir.join("main.ts");
     let output = dir.join("main_bin");
@@ -243,5 +251,132 @@ deliver(sink, "hi");
     assert!(
         !ir_has_call(&ir, "js_ws_send_client_i64"),
         "a plain object's `.send` must NOT be mis-dispatched to the ws Client runtime"
+    );
+}
+
+// ─── PR #5493 review fixes — edge cases ──────────────────────────────────────
+
+/// Review #2: a leading TypeScript `this:` param must not shift the hint index;
+/// the `wsId` (2nd real param) still dispatches to the Client runtime.
+#[test]
+fn leading_this_param_keeps_hint_index_aligned() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let ir = compile_to_ir(
+        dir.path(),
+        r#"
+import { createServer } from "node:http";
+
+function deliver(this: any, req: any, wsId: any) {
+  wsId.send("hi");
+}
+
+const server = createServer((req: any, res: any) => { res.statusCode = 200; res.end("ok"); });
+server.on("upgrade", (req: any, wsId: any, _head: any) => {
+  deliver(req, wsId);
+});
+server.listen(0, () => {});
+"#,
+    );
+    assert!(
+        ir_has_call(&ir, "js_ws_send_client_i64"),
+        "wsId after a TS `this:` param must still dispatch to the Client runtime"
+    );
+}
+
+/// Review #3: a `createServer` that is NOT a `node:http` import must not seed ws
+/// taint — a user factory of the same name is ignored.
+#[test]
+fn non_http_create_server_does_not_seed_ws_taint() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let ir = compile_to_ir(
+        dir.path(),
+        r#"
+// A user-defined factory that happens to be named `createServer`.
+function createServer(): any {
+  return { on(_e: string, _cb: any) {} };
+}
+function deliver(wsId: any) {
+  wsId.send("nope");
+}
+const server: any = createServer();
+server.on("upgrade", (req: any, wsId: any, _head: any) => {
+  deliver(wsId);
+});
+"#,
+    );
+    assert!(
+        !ir_has_call(&ir, "js_ws_send_client_i64"),
+        "a non-http `createServer` must not seed the ws Client dispatch"
+    );
+}
+
+/// Review #4: a nested function that shadows `wsId` must not inherit the outer
+/// handle — its callee stays untagged even though it is reached from the
+/// upgrade callback's lexical scope.
+#[test]
+fn shadowing_nested_param_does_not_inherit_taint() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let ir = compile_to_ir(
+        dir.path(),
+        r#"
+import { createServer } from "node:http";
+
+function deliver(ch: any) {
+  ch.send("shadow");
+}
+
+const server = createServer((req: any, res: any) => { res.statusCode = 200; res.end("ok"); });
+server.on("upgrade", (req: any, wsId: any, _head: any) => {
+  // `later` rebinds `wsId`, so the value flowing into `deliver` is NOT the
+  // upgrade handle — `deliver` must not be tagged as a ws Client receiver.
+  function later(wsId: any) {
+    deliver(wsId);
+  }
+  later(req);
+});
+server.listen(0, () => {});
+"#,
+    );
+    assert!(
+        !ir_has_call(&ir, "js_ws_send_client_i64"),
+        "a shadowing nested param must not propagate the outer Client handle"
+    );
+}
+
+/// Review #1: two functions named `pushFrame` — only the upgrade-fed top-level
+/// declaration is tagged; a same-named nested declaration receiving a non-ws
+/// value is keyed by a distinct identity and left untouched (exactly one Client
+/// dispatch in the module).
+#[test]
+fn same_named_function_is_not_cross_tagged() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let ir = compile_to_ir(
+        dir.path(),
+        r#"
+import { createServer } from "node:http";
+
+function pushFrame(wsId: any, m: string) {
+  wsId.send(m);
+}
+function elsewhere() {
+  function pushFrame(x: any) {
+    x.send("nope");
+  }
+  pushFrame({ send(s: string) { console.log(s); } });
+}
+
+const server = createServer((req: any, res: any) => { res.statusCode = 200; res.end("ok"); });
+server.on("upgrade", (req: any, wsId: any, _head: any) => {
+  pushFrame(wsId, "real");
+  elsewhere();
+});
+server.listen(0, () => {});
+"#,
+    );
+    assert_eq!(
+        ir_call_count(&ir, "js_ws_send_client_i64"),
+        1,
+        "only the upgrade-fed `pushFrame` dispatches to the Client runtime, not \
+         the same-named nested declaration"
     );
 }

--- a/crates/perry/tests/ws_client_handle_cross_function_dispatch.rs
+++ b/crates/perry/tests/ws_client_handle_cross_function_dispatch.rs
@@ -380,3 +380,110 @@ server.listen(0, () => {});
          the same-named nested declaration"
     );
 }
+
+// ─── Polymorphism guard — a helper fed BOTH a ws Client and a non-ws value ───
+
+/// A hint tags a function PARAMETER, fixing the dispatch for that param across
+/// EVERY call site. So a helper that is fed the upgrade `wsId` from one caller
+/// AND a plain object from another must NOT be tagged — otherwise the plain
+/// object's `.send(...)` would silently re-route to `js_ws_send_client_i64`
+/// (a no-op handle miss) instead of running the object's own method. The pass
+/// must only tag a param it can prove is ALWAYS the ws handle.
+#[test]
+fn polymorphic_helper_fed_ws_and_nonws_is_not_tagged() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let ir = compile_to_ir(
+        dir.path(),
+        r#"
+import { createServer } from "node:http";
+
+// `emit` is reused for BOTH the ws upgrade handle and a plain emitter.
+function emit(target: any, msg: string) {
+  target.send(msg);
+}
+
+const server = createServer((req: any, res: any) => { res.statusCode = 200; res.end("ok"); });
+server.on("upgrade", (req: any, wsId: any, _head: any) => {
+  emit(wsId, "ws-bound");
+});
+
+// A non-ws caller of the same helper — must keep running the value's own method.
+const bus: any = { send(m: string) { console.log("bus:" + m); } };
+emit(bus, "not-ws");
+
+server.listen(0, () => {});
+"#,
+    );
+    assert!(
+        !ir_has_call(&ir, "js_ws_send_client_i64"),
+        "a helper that is ALSO called with a non-ws value must not be tagged as \
+         a ws Client receiver (would silently drop the non-ws caller's frame)"
+    );
+}
+
+/// Transitive demotion: the handle is forwarded `mid` → `inner`, but `mid` is
+/// ALSO called with a non-ws value. `mid` is polymorphic, so on that path it
+/// delivers a non-ws value to `inner` — therefore NEITHER `mid` nor `inner` may
+/// be tagged. Exercises the dependency fixpoint, not just the direct caller.
+#[test]
+fn transitive_through_polymorphic_intermediate_is_not_tagged() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let ir = compile_to_ir(
+        dir.path(),
+        r#"
+import { createServer } from "node:http";
+
+function inner(target: any, msg: string) {
+  target.send(msg);
+}
+function mid(target: any, msg: string) {
+  inner(target, msg);
+}
+
+const server = createServer((req: any, res: any) => { res.statusCode = 200; res.end("ok"); });
+server.on("upgrade", (req: any, wsId: any, _head: any) => {
+  mid(wsId, "ws-bound");
+});
+
+// `mid` is also fed a non-ws value — taint through it is unsound.
+const bus: any = { send(m: string) { console.log("bus:" + m); } };
+mid(bus, "not-ws");
+
+server.listen(0, () => {});
+"#,
+    );
+    assert!(
+        !ir_has_call(&ir, "js_ws_send_client_i64"),
+        "a handle forwarded through a polymorphic intermediate must not tag the \
+         downstream helper (transitive demotion)"
+    );
+}
+
+/// Guardrail for over-correction: a helper that is ONLY ever fed the ws handle
+/// (across two distinct upgrade callbacks) must STILL be tagged — the
+/// polymorphism guard must not drop a legitimately ws-exclusive helper.
+#[test]
+fn ws_exclusive_helper_with_multiple_ws_callers_stays_tagged() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let ir = compile_to_ir(
+        dir.path(),
+        r#"
+import { createServer } from "node:http";
+
+function push(wsId: any, msg: string) {
+  wsId.send(msg);
+}
+
+const a = createServer((req: any, res: any) => { res.end("a"); });
+const b = createServer((req: any, res: any) => { res.end("b"); });
+a.on("upgrade", (req: any, wsId: any, _h: any) => { push(wsId, "from-a"); });
+b.on("upgrade", (req: any, wsId: any, _h: any) => { push(wsId, "from-b"); });
+a.listen(0, () => {});
+b.listen(0, () => {});
+"#,
+    );
+    assert!(
+        ir_has_call(&ir, "js_ws_send_client_i64"),
+        "a helper fed ONLY ws handles (from multiple upgrade callbacks) must stay tagged"
+    );
+}

--- a/crates/perry/tests/ws_client_handle_cross_function_dispatch.rs
+++ b/crates/perry/tests/ws_client_handle_cross_function_dispatch.rs
@@ -1,0 +1,247 @@
+//! Regression: the `("ws","Client")` upgrade handle delivered to
+//! `server.on("upgrade", (req, wsId, head) => …)` must keep dispatching its
+//! `.send()` / `.on()` / `.close()` to the dedicated `js_ws_*_client_i64`
+//! runtime even when `wsId` is handed to a helper function.
+//!
+//! Before the fix, that host-class was tagged only at the upgrade callback's
+//! parameter and was NOT propagated across a call boundary: inside a
+//! `handleConnection(req, wsId)` helper the parameter was plain/`any`, the
+//! codegen dispatch table's `class_filter: Some("Client")` rows no longer
+//! matched, and `wsId.send(...)` silently lowered to a generic no-op — the
+//! frame was dropped with no error. (The downstream workaround was to inline
+//! every `wsId` use in the upgrade callback.)
+//!
+//! These are codegen-dispatch assertions: a WS network round-trip needs a live
+//! socket + client, but the bug is purely *which runtime symbol the call site
+//! lowers to*. So we compile to LLVM IR and assert the helper's `wsId.send`
+//! lowers to a `call` to `js_ws_send_client_i64` (present after the fix, absent
+//! before — verified by toggling the fix).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+/// Compile `source` and return the concatenated LLVM IR text of all emitted
+/// modules (via `PERRY_SAVE_LL`). Asserts the compile succeeds.
+fn compile_to_ir(dir: &Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    let ll_dir = dir.join("ll");
+    std::fs::create_dir_all(&ll_dir).expect("mk ll dir");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        // Emit per-module .ll and force a full (uncached) codegen so the IR is
+        // actually written for this build.
+        .env("PERRY_SAVE_LL", &ll_dir)
+        .env("PERRY_LLVM_KEEP_IR", "1")
+        .env("PERRY_NO_CACHE", "1")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let mut ir = String::new();
+    for entry in std::fs::read_dir(&ll_dir).expect("read ll dir") {
+        let path = entry.expect("dir entry").path();
+        if path.extension().and_then(|e| e.to_str()) == Some("ll") {
+            ir.push_str(&std::fs::read_to_string(&path).expect("read .ll"));
+            ir.push('\n');
+        }
+    }
+    assert!(!ir.is_empty(), "no .ll IR was emitted");
+    ir
+}
+
+/// True if the IR contains a `call` instruction targeting `@<symbol>` (i.e. a
+/// real call site, not merely the unconditional `declare`).
+fn ir_has_call(ir: &str, symbol: &str) -> bool {
+    let needle = format!("@{symbol}(");
+    ir.lines()
+        .any(|l| l.contains("call ") && l.contains(&needle))
+}
+
+fn compile_and_run(dir: &Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+/// The reported failure: the ONLY `wsId.send` is inside a helper reached as
+/// `pushFrame(wsId, …)`. After the fix it must lower to the Client runtime.
+#[test]
+fn helper_wsid_send_dispatches_to_client_runtime() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let ir = compile_to_ir(
+        dir.path(),
+        r#"
+import { createServer } from "node:http";
+
+function pushFrame(wsId: any, msg: string) {
+  wsId.send(msg);
+}
+
+const server = createServer((req: any, res: any) => { res.statusCode = 200; res.end("ok"); });
+
+server.on("upgrade", (req: any, wsId: any, _head: any) => {
+  pushFrame(wsId, "hello-from-helper");
+});
+
+server.listen(0, () => {});
+"#,
+    );
+    assert!(
+        ir_has_call(&ir, "js_ws_send_client_i64"),
+        "helper `wsId.send` must dispatch to js_ws_send_client_i64 (the upgrade \
+         Client handle), not a silent generic no-op"
+    );
+}
+
+/// The handle is forwarded through TWO helpers — exercises the transitive
+/// fixpoint propagation, not just one hop.
+#[test]
+fn transitively_forwarded_wsid_send_dispatches_to_client_runtime() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let ir = compile_to_ir(
+        dir.path(),
+        r#"
+import { createServer } from "node:http";
+
+function sendFrame(wsId: any, msg: string) {
+  wsId.send(msg);
+}
+function handleConnection(req: any, wsId: any) {
+  sendFrame(wsId, "mount");
+}
+
+const server = createServer((req: any, res: any) => { res.statusCode = 200; res.end("ok"); });
+
+server.on("upgrade", (req: any, wsId: any, _head: any) => {
+  handleConnection(req, wsId);
+});
+
+server.listen(0, () => {});
+"#,
+    );
+    assert!(
+        ir_has_call(&ir, "js_ws_send_client_i64"),
+        "wsId.send two call-hops away from the upgrade callback must still \
+         dispatch to the Client runtime"
+    );
+}
+
+/// `.on(...)` and `.close()` on the forwarded handle must likewise reach the
+/// Client runtime, not just `.send`.
+#[test]
+fn helper_wsid_on_and_close_dispatch_to_client_runtime() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let ir = compile_to_ir(
+        dir.path(),
+        r#"
+import { createServer } from "node:http";
+
+function wire(wsId: any) {
+  wsId.on("message", (m: any) => { wsId.send("echo:" + m); });
+  wsId.close();
+}
+
+const server = createServer((req: any, res: any) => { res.statusCode = 200; res.end("ok"); });
+
+server.on("upgrade", (req: any, wsId: any, _head: any) => {
+  wire(wsId);
+});
+
+server.listen(0, () => {});
+"#,
+    );
+    assert!(
+        ir_has_call(&ir, "js_ws_on_client_i64"),
+        "helper `wsId.on` must dispatch to js_ws_on_client_i64"
+    );
+    assert!(
+        ir_has_call(&ir, "js_ws_close_client_i64"),
+        "helper `wsId.close` must dispatch to js_ws_close_client_i64"
+    );
+    assert!(
+        ir_has_call(&ir, "js_ws_send_client_i64"),
+        "the nested `wsId.send` (inside the helper's own `.on` callback) must \
+         dispatch to js_ws_send_client_i64"
+    );
+}
+
+/// Gate / no-regression control: a `.send`-bearing parameter that is NOT an
+/// upgrade Client handle must keep invoking the value's OWN `send` method — the
+/// propagation must not mis-tag arbitrary parameters as `("ws","Client")`.
+/// (Also confirms the `createServer`-origin gate: there is no upgrade seed at
+/// all here.)
+#[test]
+fn unrelated_send_param_runs_its_own_method() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = compile_and_run(
+        dir.path(),
+        r#"
+function deliver(ch: any, msg: string) {
+  ch.send(msg);
+}
+const sink = { send(m: string) { console.log("own-send:" + m); } };
+deliver(sink, "hi");
+"#,
+    );
+    assert!(
+        out.contains("own-send:hi"),
+        "a non-ws object's own `send` must run when passed to a helper (got: {out:?})"
+    );
+    // And it must NOT have been routed to the ws Client runtime.
+    let ir = compile_to_ir(
+        dir.path(),
+        r#"
+function deliver(ch: any, msg: string) {
+  ch.send(msg);
+}
+const sink = { send(m: string) { console.log("own-send:" + m); } };
+deliver(sink, "hi");
+"#,
+    );
+    assert!(
+        !ir_has_call(&ir, "js_ws_send_client_i64"),
+        "a plain object's `.send` must NOT be mis-dispatched to the ws Client runtime"
+    );
+}


### PR DESCRIPTION
## Summary

The `("ws","Client")` handle delivered to a WebSocket-upgrade callback
`server.on("upgrade", (req, wsId, head) => …)` (raw `node:http`) only dispatched its
`.send()`/`.on()`/`.close()` to the dedicated `js_ws_*_client_i64` runtime when used **inline**
in the callback. Passing `wsId` into a helper made those calls a **silent no-op** — the frame
was dropped with no error. This propagates the handle's host class across the call boundary so
the helper dispatches correctly.

## Changes

- `crates/perry-hir/src/lower/pre_scan.rs` — new `pre_scan_cross_fn_native_params` pass (run
  before any function body lowers). It seeds from the upgrade idiom `X.on("upgrade", (req,
  wsId, head) => …)` — **gated on `X` being a `createServer(...)` result** (static proxy for a
  `("http","HttpServer")` instance; mirrors the runtime check, avoids false positives on
  arbitrary `.on("upgrade")`) — and follows the handle through `userFn(…, wsId, …)` calls
  **transitively** (fixpoint), recording a `(fn_name, param_index) -> (module, class)` hint.
- `crates/perry-hir/src/lower/lowering_context.rs` + `…/lower/context.rs` — add the
  `param_native_hints` map.
- `crates/perry-hir/src/lower/lower_module_fn.rs` — invoke the pass alongside the other pre-scans.
- `crates/perry-hir/src/lower_decl/fn_decl.rs` — apply the hint (only when the param isn't
  already a native instance, so an explicit annotation wins) before the body lowers.
- `crates/perry/tests/ws_client_handle_cross_function_dispatch.rs` — regression tests.

## Related issue

## Test plan

```
cargo test -p perry --test ws_client_handle_cross_function_dispatch   # 4 passed
cargo fmt -p perry-hir -p perry --check                               # clean
cargo build --release --workspace --exclude perry-ui-{ios,tvos,watchos,gtk4,android,windows}
```

A live WS round-trip needs a socket + client and Perry's raw-upgrade `wsId` has no
Node-`ws`-compatible API to diff against, so the bug (which runtime symbol the call site lowers
to) is asserted at the LLVM-IR level. TDD red→green: for the helper-only case the IR went from
**0** `call @js_ws_send_client_i64` sites (silent no-op) to **1**. Tests also cover transitive
forwarding, `.on`/`.close`, and a control proving a non-ws `.send` param keeps running its own
method (no mis-tagging).

- [x] `cargo build --release -p perry` clean (the crates this change touches). The full
      `--workspace` release build fails only on `windows-future` — a Windows-only transitive
      dep that can't compile on this macOS host (env limitation, unrelated to this change).
- [ ] `cargo test --workspace …` passes — my new tests pass; the suite's only failures
      (`integer_locals_provenance`, `functional_batch2_regressions`, and a
      `blocklist_addsubnet_prefix` `TempDir::join` compile break) reproduce **identically on
      clean `main` without this change**, so they are pre-existing and unrelated.
- [x] (if user-facing) Added a `#[test]` in the affected crate (`crates/perry/tests/`)
- [ ] (if CLI / stdlib / runtime API changed) Updated `docs/src/` — N/A (internal HIR dispatch)
- [ ] (if touching a platform UI backend) — N/A

## Screenshots / output

```
function handleConnection(req, wsId) { wsId.send("hi"); }   // before: dropped; after: delivered
server.on("upgrade", (req, wsId, head) => { handleConnection(req, wsId); });
// IR: helper `wsId.send` -> `call void @js_ws_send_client_i64(...)`  (0 sites before, 1 after)
```

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commits follow the loose `fix:` prefix convention
- [x] I've read CONTRIBUTING.md and agree to the Code of Conduct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / New Features**
  * Improved WebSocket upgrade-handle behavior so `send`, `on`, and `close` dispatch to the correct Client runtime even when the `wsId` handle is forwarded through helper call chains, including nested callbacks.
  * Added safeguards for edge cases such as parameter shadowing, polymorphic forwarding, and correct behavior when mixed with non-WebSocket objects.
* **Tests**
  * Expanded the WebSocket cross-function dispatch regression suite with helper chains, negative controls, and additional scenarios for parameter indexing and `createServer` provenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->