### PR TITLE
fix(stdin): add process.stdin.setEncoding (no-op stub) to the stdin stream shape

### DIFF
--- a/crates/perry-runtime/src/os_process_streams.rs
+++ b/crates/perry-runtime/src/os_process_streams.rs
@@ -70,6 +70,18 @@ extern "C" fn process_stream_on_once_stub(
     f64::from_bits(crate::value::TAG_UNDEFINED)
 }
 
+/// `setEncoding` impl for `process.stdin`. A Readable's `setEncoding(enc)`
+/// returns the stream itself so callers can chain
+/// (`process.stdin.setEncoding("utf8").on("data", …)`). The receiver is the
+/// `IMPLICIT_THIS` bound by the method-dispatch path, so returning it mirrors
+/// Node's `this`-returning contract. Encoding-aware reads remain future work.
+extern "C" fn process_stream_set_encoding_stub(
+    _closure: *const crate::closure::ClosureHeader,
+    _arg: f64,
+) -> f64 {
+    crate::object::js_implicit_this_get()
+}
+
 /// #3962: set when a TUI tears down stdin via `process.stdin.destroy()`,
 /// `.pause()`, or `.unref()`. `perry-stdlib`'s readline `has_active` consults
 /// `stdin_is_detached()` so the runtime stops holding the event loop open for
@@ -312,11 +324,7 @@ fn build_stream_object_with_write(
         if is_stdin {
             set_field_with_stub(start + 7, process_stream_on_once_stub); // ref
             set_field_with_stub(start + 8, lifecycle); // destroy
-                                                       // `process.stdin.setEncoding(enc)` — a Readable returns the stream
-                                                       // for chaining; callers (e.g. raw-mode TUI setup) discard the
-                                                       // return, so a no-op stub is sufficient and avoids a "setEncoding is
-                                                       // not a function" throw. Encoding-aware reads remain future work.
-            set_field_with_stub(start + 9, process_stream_on_once_stub); // setEncoding
+            set_field_with_stub(start + 9, process_stream_set_encoding_stub); // setEncoding
         } else {
             set_field_with_stub(start + 7, lifecycle); // destroy
         }

--- a/crates/perry-runtime/src/os_process_streams.rs
+++ b/crates/perry-runtime/src/os_process_streams.rs
@@ -312,10 +312,10 @@ fn build_stream_object_with_write(
         if is_stdin {
             set_field_with_stub(start + 7, process_stream_on_once_stub); // ref
             set_field_with_stub(start + 8, lifecycle); // destroy
-            // `process.stdin.setEncoding(enc)` — a Readable returns the stream
-            // for chaining; callers (e.g. raw-mode TUI setup) discard the
-            // return, so a no-op stub is sufficient and avoids a "setEncoding is
-            // not a function" throw. Encoding-aware reads remain future work.
+                                                       // `process.stdin.setEncoding(enc)` — a Readable returns the stream
+                                                       // for chaining; callers (e.g. raw-mode TUI setup) discard the
+                                                       // return, so a no-op stub is sufficient and avoids a "setEncoding is
+                                                       // not a function" throw. Encoding-aware reads remain future work.
             set_field_with_stub(start + 9, process_stream_on_once_stub); // setEncoding
         } else {
             set_field_with_stub(start + 7, lifecycle); // destroy

--- a/crates/perry-runtime/src/os_process_streams.rs
+++ b/crates/perry-runtime/src/os_process_streams.rs
@@ -177,7 +177,7 @@ fn build_stream_object_with_write(
     // stdin shapes. The TTY *write* stream keeps its existing shape; generic
     // non-TTY streams keep `main`'s no-op teardown surface.
     const STDIN_TEARDOWN_KEYS: &[u8] =
-        b"addListener\0removeListener\0off\0removeAllListeners\0pause\0resume\0unref\0ref\0destroy\0";
+        b"addListener\0removeListener\0off\0removeAllListeners\0pause\0resume\0unref\0ref\0destroy\0setEncoding\0";
     const GENERIC_TEARDOWN_KEYS: &[u8] =
         b"addListener\0removeListener\0off\0removeAllListeners\0pause\0resume\0unref\0destroy\0";
     let is_stdin = fd_i == 0;
@@ -192,7 +192,7 @@ fn build_stream_object_with_write(
                     0
                 },
                 keys,
-                21,
+                22,
                 Some(12),
             )
         } else if is_tty {
@@ -312,6 +312,11 @@ fn build_stream_object_with_write(
         if is_stdin {
             set_field_with_stub(start + 7, process_stream_on_once_stub); // ref
             set_field_with_stub(start + 8, lifecycle); // destroy
+            // `process.stdin.setEncoding(enc)` — a Readable returns the stream
+            // for chaining; callers (e.g. raw-mode TUI setup) discard the
+            // return, so a no-op stub is sufficient and avoids a "setEncoding is
+            // not a function" throw. Encoding-aware reads remain future work.
+            set_field_with_stub(start + 9, process_stream_on_once_stub); // setEncoding
         } else {
             set_field_with_stub(start + 7, lifecycle); // destroy
         }


### PR DESCRIPTION
## Problem

`process.stdin`'s stream object exposed `write`/`on`/`once`/`ref`/`pause`/`resume`/`unref`/`destroy`/… but NOT `setEncoding`. So `process.stdin.setEncoding(enc)` — used by raw-mode TTY input setup — dispatched through `js_native_call_method`, found no method, and threw `setEncoding is not a function` (caught by callers' try/catch, silently disabling stdin setup).

## Fix

A `Readable`'s `setEncoding` returns the stream for chaining and callers discard the result, so a no-op stub suffices. Append `setEncoding` to the stdin shape's teardown-key list + bump its `field_count`, installed like `ref`/`pause`. Encoding-aware reads remain future work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `process.stdin` stream compatibility by adding support for additional lifecycle/control behavior, including `setEncoding` to enable chaining patterns like `process.stdin.setEncoding(...).on(...)`.
  * Updated internal stream teardown handling so the new lifecycle method integrates cleanly with existing pause/resume and reference behavior (`pause`, `resume`, `ref`, `unref`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->