### PR TITLE
fix(class): class extends Array sizes the instance and supports fill

### DIFF
--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -110,7 +110,7 @@ pub(crate) use write_barrier::{
     emit_array_numeric_write_note_on_block, emit_jsvalue_slot_store_on_block,
     emit_jsvalue_slot_store_scalar_aware_on_block, emit_layout_note_slot_on_block,
     emit_root_heap_word_store_on_block, emit_root_nanbox_store_on_block, emit_write_barrier,
-    emit_write_barrier_slot_on_block, lower_event_emitter_subclass_init,
+    emit_write_barrier_slot_on_block, lower_array_super_init, lower_event_emitter_subclass_init,
     lower_node_stream_super_init, lower_stream_super_init,
 };
 

--- a/crates/perry-codegen/src/expr/this_super_call.rs
+++ b/crates/perry-codegen/src/expr/this_super_call.rs
@@ -40,13 +40,14 @@ use super::{
     emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
     extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
     is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_event_emitter_subclass_init, lower_expr,
-    lower_expr_as_i32, lower_index_set_fast, lower_js_args_array, lower_node_stream_super_init,
-    lower_object_literal, lower_stream_super_init, lower_url_string_getter, nanbox_bigint_inline,
-    nanbox_pointer_inline, nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array,
-    try_flat_const_2d_int, try_lower_flat_const_index_get, try_match_channel_reduction,
-    try_static_class_name, unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction,
-    FlatConstInfo, FnCtx, I18nLowerCtx,
+    lower_array_literal, lower_array_super_init, lower_channel_reduction,
+    lower_event_emitter_subclass_init, lower_expr, lower_expr_as_i32, lower_index_set_fast,
+    lower_js_args_array, lower_node_stream_super_init, lower_object_literal,
+    lower_stream_super_init, lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
+    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
+    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
+    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
+    I18nLowerCtx,
 };
 
 /// Built-in constructor names (beyond Error/stream/fetch, which have their own
@@ -405,6 +406,22 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     };
                     if let Some(kind) = node_stream_kind {
                         let result = lower_node_stream_super_init(ctx, kind, super_args)?;
+                        let current_class_name =
+                            ctx.class_stack.last().cloned().unwrap_or_default();
+                        crate::lower_call::apply_field_initializers_recursive(
+                            ctx,
+                            &current_class_name,
+                            crate::lower_call::FieldInitMode::SelfOnly,
+                        )?;
+                        return Ok(result);
+                    }
+                    // `class X extends Array` — size the subclass instance and
+                    // install the Array surface (`fill`, …) it relies on. Perry
+                    // models the instance as a plain object, not a real exotic
+                    // Array (ArrayHeader has no class_id slot), so `super(n)`
+                    // would otherwise leave it length-less with no Array methods.
+                    if parent_name == "Array" {
+                        let result = lower_array_super_init(ctx, super_args)?;
                         let current_class_name =
                             ctx.class_stack.last().cloned().unwrap_or_default();
                         crate::lower_call::apply_field_initializers_recursive(

--- a/crates/perry-codegen/src/expr/write_barrier.rs
+++ b/crates/perry-codegen/src/expr/write_barrier.rs
@@ -406,6 +406,35 @@ pub(crate) fn lower_node_stream_super_init(
     Ok(undef_lit)
 }
 
+/// `super(n)` for a source-compiled `class X extends Array` (lru-cache's
+/// `ZeroArray` etc.): perry models the instance as a plain object, so size it
+/// and install the Array surface via the runtime `js_array_subclass_init`
+/// (mirrors `lower_node_stream_super_init` / the EventEmitter subclass init).
+pub(crate) fn lower_array_super_init(ctx: &mut FnCtx<'_>, super_args: &[Expr]) -> Result<String> {
+    let undef_lit = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+    let n = if let Some(first) = super_args.first() {
+        lower_expr(ctx, first)?
+    } else {
+        undef_lit.clone()
+    };
+    for arg in super_args.iter().skip(1) {
+        let _ = lower_expr(ctx, arg)?;
+    }
+
+    let this_box = match ctx.this_stack.last().cloned() {
+        Some(slot) => ctx.block().load(DOUBLE, &slot),
+        None => undef_lit.clone(),
+    };
+
+    ctx.block().call(
+        DOUBLE,
+        "js_array_subclass_init",
+        &[(DOUBLE, &this_box), (DOUBLE, &n)],
+    );
+
+    Ok(undef_lit)
+}
+
 /// #5137: install the bare EventEmitter listener/emit surface onto `this_box`
 /// for a source-compiled `class X extends EventEmitter` (node:events). Shared
 /// by the explicit-`super()` arm (`expr/this_super_call.rs`) and the

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -1262,6 +1262,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
 
     // ========== node:stream stubs (issue #631) ==========
     module.declare_function("js_event_emitter_subclass_init", DOUBLE, &[DOUBLE]); // #5137 EE subclass init
+    module.declare_function("js_array_subclass_init", DOUBLE, &[DOUBLE, DOUBLE]); // class extends Array
     module.declare_function("js_node_stream_readable_new", DOUBLE, &[DOUBLE]);
     module.declare_function(
         "js_node_stream_readable_subclass_init",

--- a/crates/perry-runtime/src/node_stream_constructors.rs
+++ b/crates/perry-runtime/src/node_stream_constructors.rs
@@ -441,6 +441,56 @@ pub extern "C" fn js_event_emitter_subclass_init(this: f64) -> f64 {
     this
 }
 
+/// `super(n)` for a source-compiled `class X extends Array` (e.g. lru-cache's
+/// `ZeroArray`: `class ZeroArray extends Array { constructor(n){ super(n);
+/// this.fill(0) } }`). Perry models the subclass instance as a plain object,
+/// not a real exotic Array, so `super(n)` otherwise left it length-less with no
+/// Array methods. Size it (`length = ToLength(n)`, a visible own property the
+/// generic array-like helpers read) and install the Array surface the instance
+/// relies on — currently `fill`, which delegates to `js_array_fill_generic`
+/// (it operates on the receiver's own `length` + indexed properties, exactly
+/// what an array-like object exposes). Indexed get/set already work as ordinary
+/// object properties. Mirrors `js_event_emitter_subclass_init` (#5494); the
+/// codegen `super()` lowering for an `Array` parent calls this. Additional
+/// Array methods can be added to `array_subclass_methods` as bundles need them.
+#[no_mangle]
+pub extern "C" fn js_array_subclass_init(this: f64, n: f64) -> f64 {
+    let raw = raw_ptr_from_value(this);
+    if raw == 0 {
+        return this;
+    }
+    if unsafe { gc_type_for_ptr(raw) } != Some(crate::gc::GC_TYPE_OBJECT) {
+        return this;
+    }
+    let obj = raw as *mut ObjectHeader;
+    // ToLength(n): undefined / NaN / <= 0 → 0; +Infinity (and any value past the
+    // max array length) clamps to 2^53 - 1; otherwise floor(n).
+    let len = {
+        const MAX_SAFE_INTEGER: f64 = 9007199254740991.0; // 2^53 - 1
+        let nv = JSValue::from_bits(n.to_bits());
+        if nv.is_undefined() || n.is_nan() || n <= 0.0 {
+            0.0
+        } else if n.is_infinite() {
+            MAX_SAFE_INTEGER
+        } else {
+            n.floor().min(MAX_SAFE_INTEGER)
+        }
+    };
+    let length_key = crate::string::js_string_from_bytes(b"length".as_ptr(), 6);
+    js_object_set_field_by_name(obj, length_key, len);
+    crate::closure::js_register_closure_arity(ns_array_fill as *const u8, 1);
+    let methods: [(&str, StubFn); 1] = [("fill", super::cast1(ns_array_fill))];
+    install_methods_on_existing_object(obj, this, &methods, &[]);
+    this
+}
+
+/// `Array.prototype.fill`-equivalent installed on an Array-subclass instance:
+/// fills the receiver's own indexed slots `0..length` with `value`. Delegates
+/// to the generic array-like fill (which reads `length` off the receiver).
+pub(super) extern "C" fn ns_array_fill(closure: *const ClosureHeader, value: f64) -> f64 {
+    crate::array::js_array_fill_generic(super::this_value(closure), value, 0, 0.0, 0, 0.0)
+}
+
 #[no_mangle]
 pub extern "C" fn js_node_stream_writable_new(opts: f64) -> f64 {
     let methods = writable_methods();

--- a/crates/perry/tests/issue_array_subclass_super_init.rs
+++ b/crates/perry/tests/issue_array_subclass_super_init.rs
@@ -1,0 +1,91 @@
+//! `class X extends Array { constructor(n){ super(n); this.fill(v) } }` —
+//! subclassing the builtin `Array`. perry models the subclass instance as a
+//! plain object, not a real exotic Array (`ArrayHeader` has no `class_id`
+//! slot), so `super(n)` used to leave it length-less with no Array methods and
+//! `this.fill(0)` threw `TypeError: value is not a function`.
+//!
+//! Fix: the `super()` lowering for an `Array` parent calls a runtime
+//! `js_array_subclass_init(this, n)` that sets a visible `length = ToLength(n)`
+//! and installs the Array surface the instance relies on (`fill`), delegating
+//! to the generic array-like impl (`js_array_fill_generic`, which operates on
+//! the receiver's own `length` + indexed properties). Indexed get/set already
+//! work as ordinary object properties. Mirrors the EventEmitter subclass-init
+//! pattern. lru-cache's `ZeroArray` is the motivating shape.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, entry: &std::path::Path) -> (bool, String) {
+    let output = dir.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let run = Command::new(&output).output().expect("run compiled binary");
+    (
+        run.status.success(),
+        String::from_utf8_lossy(&run.stdout).to_string(),
+    )
+}
+
+#[test]
+fn array_subclass_super_sizes_and_fill_works() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+// lru-cache's ZeroArray shape: a fixed-size zero-initialised indexed buffer.
+class Zero extends Array {
+  constructor(n: number) {
+    super(n)
+    this.fill(0) // must NOT throw "value is not a function"
+  }
+}
+
+const z: any = new Zero(4)
+console.log("length:", z.length)            // super(n) sizes the instance
+console.log("filled:", z[0], z[1], z[2], z[3]) // fill(0) zero-initialised slots
+z[2] = 9                                     // indexed write
+console.log("after set:", z[2])
+console.log("typeof fill:", typeof z.fill)
+
+// fill with a non-zero value on a second instance
+const z2: any = new Zero(3)
+z2.fill(7)
+console.log("z2:", z2[0], z2[1], z2[2])
+console.log("DONE")
+"#,
+    )
+    .expect("write entry");
+
+    let (ok, stdout) = compile_and_run(dir.path(), &entry);
+    assert!(ok, "binary failed\nstdout:\n{stdout}");
+    for needle in [
+        "length: 4",
+        "filled: 0 0 0 0",
+        "after set: 9",
+        "typeof fill: function",
+        "z2: 7 7 7",
+        "DONE",
+    ] {
+        assert!(
+            stdout.contains(needle),
+            "expected `{needle}` in output:\n{stdout}"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

`class X extends Array { constructor(n){ super(n); this.fill(0) } }` threw `TypeError: value is not a function` at `this.fill`. perry models a subclass instance as a plain object, not a real exotic Array (`ArrayHeader` has only `{length, capacity}` — no `class_id` slot), so `super(n)` left the instance length-less with no Array methods: `length=0`, `isArray=false`, `fill`/`push`/`map` all `undefined`. (lru-cache's `ZeroArray` is the motivating shape — a fixed-size zero-initialised indexed buffer.)

## Fix

The `super()` lowering for an `Array` parent (`expr/this_super_call.rs`) now calls a runtime `js_array_subclass_init(this, n)` that:
- sets a visible `length = ToLength(n)` own property, and
- installs the Array surface the instance relies on (currently `fill`) as a method delegating to the existing generic array-like impl `js_array_fill_generic` — which operates on the receiver's own `length` + indexed properties.

Indexed get/set already worked as ordinary object properties. This mirrors the EventEmitter subclass-init pattern (`js_event_emitter_subclass_init`). Additional Array methods can be added to the install list as needed.

## Test

`crates/perry/tests/issue_array_subclass_super_init.rs` — `class Zero extends Array` with `super(n); this.fill(0)`: asserts `length`, zero-initialised slots, indexed write, `fill` with a non-zero value, and `typeof fill === 'function'`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved initialization for source-compiled classes that extend the built-in `Array`, including correct handling of `super(n, ...)` to set the instance `length`.
  * Ensured the instance `fill` method is installed and works correctly after `super(n, ...)`, with subclass field initialization applied at the right time.
* **Bug Fixes**
  * Prevented incorrect control flow for `Array`-parent `super(...)` lowering so it no longer falls through to unrelated paths.
* **Tests**
  * Added an end-to-end regression test for `Array` subclasses using `super(n)` followed by `this.fill(0)`, verifying `length`, indexed behavior, and independent instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->