### PR TITLE
fix(parser): #5498 — classify minified esbuild ESM bundles as ESM, not CJS

### DIFF
--- a/crates/perry/src/commands/compile/cjs_wrap/detect.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/detect.rs
@@ -275,31 +275,88 @@ pub(crate) fn strip_comments_and_strings(source: &str) -> String {
     String::from_utf8_lossy(&out).into_owned()
 }
 
-/// Returns true if `source` contains an unindented `import ` / `import{` /
-/// `import"` / `import'` / `export ` / `export{` / `export*` / `export"` /
-/// `export'` / `export=` (TS) statement on any line — a strong signal that
-/// this file is an ES module regardless of any `module.exports`-style
-/// content deeper in nested function bodies. Lines starting with leading
-/// whitespace are treated as nested and ignored, because `import` /
-/// `export` statements MUST be at module-top-level in ECMAScript. Comment
-/// and string-literal contexts are not stripped — a `// import ` line is
-/// already excluded by the leading-whitespace filter when indented; an
-/// inline `/* import x */` followed by a real statement still triggers a
-/// match on the real statement line. Worst case is a false positive on a
-/// pathological file where the only top-level `import`/`export` lives
-/// inside a multi-line string literal at column 0; we accept that risk
-/// since the alternative is `ImportExportInScript` on real Rollup output.
+/// Returns true if `source` contains a top-level (bracket-depth-0) `import` /
+/// `export` statement — a strong signal that this file is an ES module
+/// regardless of any `module.exports`-style content deeper in nested function
+/// bodies. Expects `source` to have already been run through
+/// `strip_comments_and_strings`, so comment and string-literal contexts are
+/// masked to spaces and never trip a false match.
+///
+/// We track bracket depth (`()[]{}`) and statement starts rather than scanning
+/// line-by-line. A line-start scan suffices for pretty-printed bundles but
+/// MISSES minified ones: issue #5498's esbuild ESM bundle (the OpenAI Codex
+/// CLI) joins every top-level statement onto one giant line, so its real
+/// `import{createRequire as NDe}from"module"` lands mid-line as
+/// `…})();import{createRequire…}…` — never at a line start. A minifier still
+/// separates statements with `;`/`}`, so a statement-aware scan at depth 0
+/// finds it while continuing to ignore `import`/`export` tokens nested inside
+/// function bodies (an indented dynamic `import('./x')` stays at depth ≥ 1).
+///
+/// Worst case is a false positive on a pathological file whose only top-level
+/// `import`/`export` lives inside a string literal that `strip_comments_and_strings`
+/// failed to mask (e.g. a desynced regex); we accept that risk since the
+/// alternative is `ImportExportInScript` on real Rollup/esbuild output.
 pub fn has_top_level_esm(source: &str) -> bool {
-    for raw_line in source.lines() {
-        // Skip indented lines — `import`/`export` statements are only
-        // valid at module top-level, so any indented occurrence is
-        // either inside a function body, a comment, or a string.
-        if raw_line.starts_with(' ') || raw_line.starts_with('\t') {
-            continue;
-        }
-        let line = raw_line.trim_start();
-        if starts_with_esm_keyword(line, "import") || starts_with_esm_keyword(line, "export") {
-            return true;
+    fn is_ident_start(b: u8) -> bool {
+        b == b'_' || b == b'$' || b.is_ascii_alphabetic()
+    }
+    fn is_ident_byte(b: u8) -> bool {
+        b == b'_' || b == b'$' || b.is_ascii_alphanumeric()
+    }
+
+    let bytes = source.as_bytes();
+    let mut depth: i32 = 0;
+    // True when the next identifier read begins a statement: at start of
+    // input, or just after `;`, `{`, `}`, or a newline. Whitespace and
+    // comments (already masked to spaces) preserve it.
+    let mut stmt_start = true;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b' ' | b'\t' | b'\r' => i += 1,
+            b'\n' | b';' => {
+                stmt_start = true;
+                i += 1;
+            }
+            b'{' => {
+                depth += 1;
+                stmt_start = true;
+                i += 1;
+            }
+            b'}' => {
+                depth -= 1;
+                stmt_start = true;
+                i += 1;
+            }
+            b'(' | b'[' => {
+                depth += 1;
+                stmt_start = false;
+                i += 1;
+            }
+            b')' | b']' => {
+                depth -= 1;
+                stmt_start = false;
+                i += 1;
+            }
+            b if is_ident_start(b) => {
+                let start = i;
+                while i < bytes.len() && is_ident_byte(bytes[i]) {
+                    i += 1;
+                }
+                if stmt_start && depth == 0 {
+                    let word = &source[start..i];
+                    if (word == "import" || word == "export")
+                        && starts_with_esm_keyword(&source[start..], word)
+                    {
+                        return true;
+                    }
+                }
+                stmt_start = false;
+            }
+            _ => {
+                stmt_start = false;
+                i += 1;
+            }
         }
     }
     false

--- a/crates/perry/src/commands/compile/cjs_wrap/mod.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/mod.rs
@@ -277,6 +277,59 @@ module.exports = inner;
     }
 
     #[test]
+    fn issue_5498_minified_mid_line_import_is_esm() {
+        // esbuild ESM bundles (the OpenAI Codex CLI) are minified: every
+        // top-level statement is joined onto one giant line, so the real
+        // `import{createRequire …}from"module"` lands mid-line, after a `;`
+        // that terminates the prior statement — never at a line start. A
+        // line-based scan misses it and the file was misclassified as CJS.
+        let src = "var a=Object.create;var Ke=(e=>typeof require<\"u\")(function(){});\
+                   import{createRequire as NDe}from\"module\";var b=1;";
+        assert!(
+            !is_commonjs(src),
+            "minified bundle with a mid-line top-level import must be ESM"
+        );
+    }
+
+    #[test]
+    fn issue_5498_esbuild_cjs_shims_do_not_force_cjs() {
+        // The Codex bundle inlines CJS deps, so esbuild emits its
+        // `__commonJS`/`createRequire`/`require(` helper machinery alongside a
+        // genuine top-level `import`. The top-level import must win — the
+        // helper tokens are just identifiers in nested bodies.
+        let src = "#!/usr/bin/env node\n\
+                   import{createRequire as NDe}from\"module\";\
+                   var __require=NDe(import.meta.url);\
+                   var __commonJS=(cb,mod)=>function(){return mod||(0,cb[__getOwnPropNames(cb)[0]])((mod={exports:{}}).exports,mod),mod.exports};\
+                   var x=__commonJS({\"a.js\"(exports,module){module.exports=require(\"fs\")}});";
+        assert!(
+            !is_commonjs(src),
+            "esbuild ESM bundle with CJS helper shims must be classified as ESM"
+        );
+    }
+
+    #[test]
+    fn issue_5498_shebang_cjs_wraps_and_parses() {
+        // A genuine CommonJS file carrying a leading shebang (CLI entry point)
+        // must still wrap cleanly: the `#!` is neutralized to a `//` line
+        // comment in place so it does not land mid-template as an illegal
+        // token. Without the fix SWC errors `ExpectedIdent` on the buried `#`.
+        let src = "#!/usr/bin/env node\nmodule.exports = function greet(n) { return n; };\n";
+        assert!(is_commonjs(src));
+        let wrapped = wrap_commonjs(src, &PathBuf::from("/tmp/cli/index.js"));
+        assert!(
+            !wrapped.contains("#!"),
+            "shebang must be neutralized, got:\n{}",
+            wrapped
+        );
+        assert!(
+            perry_parser::parse_typescript(&wrapped, "cli/index.js").is_ok(),
+            "wrapped shebang module must parse, got:\n{}",
+            wrapped
+        );
+    }
+
+    #[test]
     fn extracts_named_exports() {
         let src = "exports.foo = 1; exports.bar = function() {}; exports.__esModule = true;";
         let names = extract_exports_from_source(src);

--- a/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
@@ -92,6 +92,19 @@ pub(in crate::commands::compile) fn wrap_commonjs_with_body_offset(
 ) -> (String, Option<usize>) {
     let mut source_cow = Cow::Borrowed(source);
 
+    // Issue #5498: a genuine CommonJS file may carry a leading shebang
+    // (`#!/usr/bin/env node`) — common for CLI entry points. The wrap splices
+    // the source into the MIDDLE of the wrapper template, so a `#!` left intact
+    // is no longer at byte 0 and SWC rejects it (a shebang is only a valid
+    // token as the file's first bytes). Neutralize it into a line comment in
+    // place: `#!` and `//` are both two bytes, so every downstream byte offset
+    // — including the #5247 body-offset mapping — is preserved exactly.
+    if source_cow.starts_with("#!") {
+        let mut owned = source_cow.into_owned();
+        owned.replace_range(0..2, "//");
+        source_cow = Cow::Owned(owned);
+    }
+
     if is_depd_index_path(source_path) {
         if let Some(rewritten) = rewrite_depd_dynamic_wrapper(source_cow.as_ref()) {
             source_cow = Cow::Owned(rewritten);


### PR DESCRIPTION
## Summary

Fixes #5498. An esbuild **ESM** bundle that also carries esbuild's CommonJS helper machinery (`__commonJS`/`createRequire`/`require(` shims for the CJS deps it inlined) was misclassified as CommonJS and run through Perry's CJS-to-ESM wrap. The file is unambiguously an ES module — top-level `import { createRequire } from "module"` + `import.meta.url` — so wrapping it as a CJS script moved the genuine top-level import *inside* the IIFE and the parse failed before any real compilation (`ImportExportInScript` / `ExpectedIdent`).

## Root cause

`has_top_level_esm` (in `cjs_wrap/detect.rs`) scanned **line-by-line** for a top-level `import`/`export`. But minifiers join every top-level statement onto one giant line, so the real `import{createRequire as NDe}from"module"` lands **mid-line** after a `;` (e.g. `…})();import{createRequire…}…`) — never at a line start. The line scan missed it, the file fell through to the CJS arm (it does contain `module.exports`/`require(` from the inlined shims), and got wrapped.

## Fix

- **Classifier (primary):** replace the line scan with a **bracket-depth-aware statement scan** over the comment/string-stripped source. A top-level (depth-0) `import`/`export` at a statement boundary (`;`, `}`, `{`, newline, or start) is decisive ESM, while `import`/`export` tokens nested in function bodies (depth ≥ 1, e.g. an indented dynamic `import('./x')`) are still ignored. Strictly a superset of the old line-based behavior — all existing #851/#5275 tests stay green.
- **Shebang (secondary, same wrap path):** a genuine CommonJS file carrying a leading shebang (`#!/usr/bin/env node`, common for CLI entry points) is now neutralized to a `//` line comment **in place** before the wrap splices it mid-template. `#!` and `//` are both two bytes, so the #5247 body-offset mapping is preserved exactly.

## Verification

- The OpenAI Codex CLI bundle (`@openai/codex@0.1.2505291658`, `dist/cli.js`, ~3.9MB, `type: module`) now classifies as ESM and parses straight through into compile-time semantics instead of failing at parse.
- New unit tests: minified mid-line top-level import → ESM; esbuild ESM bundle with CJS helper shims → ESM; shebang-bearing CJS file wraps and parses (`!wrapped.contains("#!")` + `parse_typescript().is_ok()`).
- `cargo test -p perry --bin perry` cjs_wrap suite: 625 passed, 0 failed. `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CommonJS vs. ESM module detection to correctly identify top-level imports in minified and bundled code.
  * Fixed handling of Unix shebangs in CommonJS files to prevent parsing errors while preserving source map accuracy.

* **Tests**
  * Added regression tests for edge cases: minified bundles with top-level imports, ESM bundles with CommonJS helper shims, and CommonJS files with shebangs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->