### PR TITLE
fix(ui-windows): #5283 — notificationSend shows a real toast, not a modal MessageBox

### DIFF
--- a/crates/perry-ui-windows/src/system.rs
+++ b/crates/perry-ui-windows/src/system.rs
@@ -283,9 +283,7 @@ pub fn notification_send(title_ptr: *const u8, body_ptr: *const u8) {
         // registration failed). A blocking MessageBox at least surfaces the
         // message rather than silently dropping it.
         use windows::core::PCWSTR;
-        use windows::Win32::UI::WindowsAndMessaging::{
-            MessageBoxW, MB_ICONINFORMATION, MB_OK,
-        };
+        use windows::Win32::UI::WindowsAndMessaging::{MessageBoxW, MB_ICONINFORMATION, MB_OK};
         let title_wide: Vec<u16> = title.encode_utf16().chain(std::iter::once(0)).collect();
         let body_wide: Vec<u16> = body.encode_utf16().chain(std::iter::once(0)).collect();
         MessageBoxW(
@@ -310,8 +308,6 @@ pub fn notification_send(title_ptr: *const u8, body_ptr: *const u8) {
 /// the shell to hand it to the Action Center, then tear everything down.
 #[cfg(target_os = "windows")]
 mod win_notify {
-    use std::sync::atomic::{AtomicU32, Ordering};
-
     use windows::core::PCWSTR;
     use windows::Win32::Foundation::{HINSTANCE, HWND, LPARAM, LRESULT, WPARAM};
     use windows::Win32::System::LibraryLoader::GetModuleHandleW;
@@ -322,9 +318,10 @@ mod win_notify {
         NOTIFYICONDATAW,
     };
     use windows::Win32::UI::WindowsAndMessaging::{
-        CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, LoadIconW, PeekMessageW,
-        RegisterClassW, TranslateMessage, CW_USEDEFAULT, HICON, IDI_APPLICATION, MSG, PM_REMOVE,
-        WINDOW_EX_STYLE, WM_USER, WNDCLASSW, WS_OVERLAPPED,
+        CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, GetWindowLongPtrW,
+        LoadIconW, PeekMessageW, RegisterClassW, SetWindowLongPtrW, TranslateMessage,
+        CW_USEDEFAULT, GWLP_USERDATA, HICON, IDI_APPLICATION, MSG, PM_REMOVE, WINDOW_EX_STYLE,
+        WM_USER, WNDCLASSW, WS_OVERLAPPED,
     };
 
     /// Per-window callback message for the transient notification icon. Offset
@@ -332,10 +329,15 @@ mod win_notify {
     /// distinct from `tray.rs`'s `WM_USER + 200` for clarity (different window).
     const WM_PERRY_NOTIF: u32 = WM_USER + 201;
 
-    /// Balloon lifecycle, written by `wnd_proc`, polled by the pump loop:
-    /// 0 = pending, 1 = shown (now queued into the Action Center and surviving
-    /// icon removal), 2 = dismissed/timed-out.
-    static BALLOON_STATE: AtomicU32 = AtomicU32::new(0);
+    /// Balloon lifecycle, stored per-window in `GWLP_USERDATA` (written by
+    /// `wnd_proc`, polled by the pump loop): 0 = pending, 1 = shown (now queued
+    /// into the Action Center and surviving icon removal), 2 = dismissed/timed-
+    /// out. Keeping the state on the window — rather than in a process-global —
+    /// means two concurrent `show_toast` calls (e.g. one from a `perry/thread`
+    /// worker) each own a separate window and can't stomp each other's state.
+    /// `GWLP_USERDATA` defaults to 0 (pending) on a fresh window.
+    const STATE_SHOWN: isize = 1;
+    const STATE_DISMISSED: isize = 2;
 
     /// Notification-area balloon events. `windows` 0.62 doesn't surface the
     /// `NIN_BALLOON*` constants under our enabled features, so we spell them
@@ -369,12 +371,16 @@ mod win_notify {
             // Legacy v0 semantics (we never call NIM_SETVERSION): the low word
             // of lParam carries the notification event. Mirrors tray.rs.
             let event = (lparam.0 & 0xFFFF) as u32;
-            match event {
-                NIN_BALLOONSHOW => BALLOON_STATE.store(1, Ordering::SeqCst),
-                NIN_BALLOONTIMEOUT | NIN_BALLOONHIDE | NIN_BALLOONUSERCLICK => {
-                    BALLOON_STATE.store(2, Ordering::SeqCst)
-                }
-                _ => {}
+            let new_state = match event {
+                NIN_BALLOONSHOW => STATE_SHOWN,
+                NIN_BALLOONTIMEOUT | NIN_BALLOONHIDE | NIN_BALLOONUSERCLICK => STATE_DISMISSED,
+                _ => return LRESULT(0),
+            };
+            // Monotonic: never let a stray late event downgrade dismissed back
+            // to shown. The window proc runs on the same thread that created
+            // the window, so this read-modify-write needs no synchronization.
+            if new_state > GetWindowLongPtrW(hwnd, GWLP_USERDATA) {
+                SetWindowLongPtrW(hwnd, GWLP_USERDATA, new_state);
             }
             return LRESULT(0);
         }
@@ -423,8 +429,7 @@ mod win_notify {
         if hwnd.is_invalid() {
             return false;
         }
-
-        BALLOON_STATE.store(0, Ordering::SeqCst);
+        // GWLP_USERDATA defaults to 0 (STATE_PENDING) on a fresh window.
 
         // IDI_APPLICATION is a shared system icon — we intentionally never
         // DestroyIcon it (a documented no-op on shared icons anyway).
@@ -454,7 +459,7 @@ mod win_notify {
         // notifications disabled and no event ever arrives.
         let deadline = GetTickCount64() + 4000;
         loop {
-            if BALLOON_STATE.load(Ordering::SeqCst) == 2 {
+            if GetWindowLongPtrW(hwnd, GWLP_USERDATA) == STATE_DISMISSED {
                 break;
             }
             let mut msg = MSG::default();
@@ -462,7 +467,7 @@ mod win_notify {
                 let _ = TranslateMessage(&msg);
                 DispatchMessageW(&msg);
             }
-            if BALLOON_STATE.load(Ordering::SeqCst) >= 1 {
+            if GetWindowLongPtrW(hwnd, GWLP_USERDATA) >= STATE_SHOWN {
                 // Shown — give the shell a brief moment to finish handing the
                 // toast to the Action Center before we tear the icon down.
                 Sleep(250);

--- a/crates/perry-ui-windows/src/system.rs
+++ b/crates/perry-ui-windows/src/system.rs
@@ -260,26 +260,222 @@ pub fn keychain_delete(key_ptr: *const u8) {
     save_keychain();
 }
 
-/// Send a notification.
+/// Send a notification (#5283).
+///
+/// Shows a real Windows toast/balloon via `Shell_NotifyIconW(NIM_ADD, …)` with
+/// `NIF_INFO` — the same notification-area mechanism `tray.rs` uses, but with a
+/// transient hidden owner window so a plain console program (no widgets, no
+/// event loop) can post one. Previously this popped a modal `MessageBoxW`,
+/// which is a blocking dialog the user must dismiss — not a notification — and
+/// in practice looked like "nothing happened" next to the macOS banner
+/// (`UNUserNotificationCenter`) behavior. The blocking `MessageBox` survives
+/// only as a last-resort fallback if the toast can't be created.
 pub fn notification_send(title_ptr: *const u8, body_ptr: *const u8) {
-    let _title = str_from_header(title_ptr);
-    let _body = str_from_header(body_ptr);
+    let title = str_from_header(title_ptr);
+    let body = str_from_header(body_ptr);
 
     #[cfg(target_os = "windows")]
-    {
-        // Win32 notification via Shell_NotifyIconW is complex.
-        // For now, use a simple MessageBox as fallback.
-        use windows::core::PCWSTR;
-        use windows::Win32::UI::WindowsAndMessaging::*;
-        let title_wide: Vec<u16> = _title.encode_utf16().chain(std::iter::once(0)).collect();
-        let body_wide: Vec<u16> = _body.encode_utf16().chain(std::iter::once(0)).collect();
-        unsafe {
-            MessageBoxW(
-                None,
-                PCWSTR(body_wide.as_ptr()),
-                PCWSTR(title_wide.as_ptr()),
-                MB_OK | MB_ICONINFORMATION,
-            );
+    unsafe {
+        if win_notify::show_toast(title, body) {
+            return;
         }
+        // Fallback: the toast could not be created (e.g. window/class
+        // registration failed). A blocking MessageBox at least surfaces the
+        // message rather than silently dropping it.
+        use windows::core::PCWSTR;
+        use windows::Win32::UI::WindowsAndMessaging::{
+            MessageBoxW, MB_ICONINFORMATION, MB_OK,
+        };
+        let title_wide: Vec<u16> = title.encode_utf16().chain(std::iter::once(0)).collect();
+        let body_wide: Vec<u16> = body.encode_utf16().chain(std::iter::once(0)).collect();
+        MessageBoxW(
+            None,
+            PCWSTR(body_wide.as_ptr()),
+            PCWSTR(title_wide.as_ptr()),
+            MB_OK | MB_ICONINFORMATION,
+        );
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = (title, body);
+    }
+}
+
+/// Win32 toast-notification helper for [`notification_send`] (#5283).
+///
+/// A console program that only imports `notificationSend` has no app window and
+/// runs no message loop, so we stand up a throwaway hidden window to own the
+/// notification-area icon, post the balloon, pump messages just long enough for
+/// the shell to hand it to the Action Center, then tear everything down.
+#[cfg(target_os = "windows")]
+mod win_notify {
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use windows::core::PCWSTR;
+    use windows::Win32::Foundation::{HINSTANCE, HWND, LPARAM, LRESULT, WPARAM};
+    use windows::Win32::System::LibraryLoader::GetModuleHandleW;
+    use windows::Win32::System::SystemInformation::GetTickCount64;
+    use windows::Win32::System::Threading::Sleep;
+    use windows::Win32::UI::Shell::{
+        Shell_NotifyIconW, NIF_ICON, NIF_INFO, NIF_MESSAGE, NIIF_INFO, NIM_ADD, NIM_DELETE,
+        NOTIFYICONDATAW,
+    };
+    use windows::Win32::UI::WindowsAndMessaging::{
+        CreateWindowExW, DefWindowProcW, DestroyWindow, DispatchMessageW, LoadIconW, PeekMessageW,
+        RegisterClassW, TranslateMessage, CW_USEDEFAULT, HICON, IDI_APPLICATION, MSG, PM_REMOVE,
+        WINDOW_EX_STYLE, WM_USER, WNDCLASSW, WS_OVERLAPPED,
+    };
+
+    /// Per-window callback message for the transient notification icon. Offset
+    /// from `WM_USER` so it can't collide with the standard window messages;
+    /// distinct from `tray.rs`'s `WM_USER + 200` for clarity (different window).
+    const WM_PERRY_NOTIF: u32 = WM_USER + 201;
+
+    /// Balloon lifecycle, written by `wnd_proc`, polled by the pump loop:
+    /// 0 = pending, 1 = shown (now queued into the Action Center and surviving
+    /// icon removal), 2 = dismissed/timed-out.
+    static BALLOON_STATE: AtomicU32 = AtomicU32::new(0);
+
+    /// Notification-area balloon events. `windows` 0.62 doesn't surface the
+    /// `NIN_BALLOON*` constants under our enabled features, so we spell them
+    /// out (`WM_USER + 2..=5`, per `<shellapi.h>`).
+    const NIN_BALLOONSHOW: u32 = WM_USER + 2;
+    const NIN_BALLOONHIDE: u32 = WM_USER + 3;
+    const NIN_BALLOONTIMEOUT: u32 = WM_USER + 4;
+    const NIN_BALLOONUSERCLICK: u32 = WM_USER + 5;
+
+    fn to_wide(s: &str) -> Vec<u16> {
+        s.encode_utf16().chain(std::iter::once(0)).collect()
+    }
+
+    /// Copy `s` (truncated to fit, leaving room for the NUL) into a fixed-size
+    /// UTF-16 `NOTIFYICONDATAW` field (`szInfoTitle` is `[u16; 64]`, `szInfo`
+    /// is `[u16; 256]`). Over-long text silently truncates, matching Explorer.
+    fn write_field(field: &mut [u16], s: &str) {
+        let max = field.len().saturating_sub(1);
+        let wide: Vec<u16> = s.encode_utf16().take(max).collect();
+        field[..wide.len()].copy_from_slice(&wide);
+        field[wide.len()] = 0;
+    }
+
+    unsafe extern "system" fn wnd_proc(
+        hwnd: HWND,
+        msg: u32,
+        wparam: WPARAM,
+        lparam: LPARAM,
+    ) -> LRESULT {
+        if msg == WM_PERRY_NOTIF {
+            // Legacy v0 semantics (we never call NIM_SETVERSION): the low word
+            // of lParam carries the notification event. Mirrors tray.rs.
+            let event = (lparam.0 & 0xFFFF) as u32;
+            match event {
+                NIN_BALLOONSHOW => BALLOON_STATE.store(1, Ordering::SeqCst),
+                NIN_BALLOONTIMEOUT | NIN_BALLOONHIDE | NIN_BALLOONUSERCLICK => {
+                    BALLOON_STATE.store(2, Ordering::SeqCst)
+                }
+                _ => {}
+            }
+            return LRESULT(0);
+        }
+        DefWindowProcW(hwnd, msg, wparam, lparam)
+    }
+
+    /// Post a single toast. Returns `false` if the OS plumbing could not be set
+    /// up (caller then falls back to a `MessageBox`).
+    pub unsafe fn show_toast(title: &str, body: &str) -> bool {
+        let Ok(hmodule) = GetModuleHandleW(None) else {
+            return false;
+        };
+        let hinstance = HINSTANCE::from(hmodule);
+
+        // Register the owner-window class. Idempotent across calls: a repeat
+        // RegisterClassW for the same name fails with ERROR_CLASS_ALREADY_EXISTS,
+        // which we ignore — the class stays usable for CreateWindowExW.
+        let class_name = to_wide("PerryNotificationWindow");
+        let wc = WNDCLASSW {
+            lpfnWndProc: Some(wnd_proc),
+            hInstance: hinstance,
+            lpszClassName: PCWSTR(class_name.as_ptr()),
+            ..Default::default()
+        };
+        let _ = RegisterClassW(&wc);
+
+        // A hidden top-level window owns the icon. A message-only
+        // (HWND_MESSAGE) window can't host a notification-area icon, so we use
+        // a normal overlapped window and simply never ShowWindow it.
+        let Ok(hwnd) = CreateWindowExW(
+            WINDOW_EX_STYLE::default(),
+            PCWSTR(class_name.as_ptr()),
+            PCWSTR(class_name.as_ptr()),
+            WS_OVERLAPPED,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            0,
+            0,
+            None,
+            None,
+            Some(hinstance),
+            None,
+        ) else {
+            return false;
+        };
+        if hwnd.is_invalid() {
+            return false;
+        }
+
+        BALLOON_STATE.store(0, Ordering::SeqCst);
+
+        // IDI_APPLICATION is a shared system icon — we intentionally never
+        // DestroyIcon it (a documented no-op on shared icons anyway).
+        let hicon: HICON = LoadIconW(None, IDI_APPLICATION).unwrap_or(HICON(std::ptr::null_mut()));
+
+        let mut data = NOTIFYICONDATAW {
+            cbSize: std::mem::size_of::<NOTIFYICONDATAW>() as u32,
+            hWnd: hwnd,
+            uID: 1,
+            uFlags: NIF_ICON | NIF_MESSAGE | NIF_INFO,
+            uCallbackMessage: WM_PERRY_NOTIF,
+            hIcon: hicon,
+            dwInfoFlags: NIIF_INFO,
+            ..Default::default()
+        };
+        write_field(&mut data.szInfoTitle, title);
+        write_field(&mut data.szInfo, body);
+
+        if !Shell_NotifyIconW(NIM_ADD, &data).as_bool() {
+            let _ = DestroyWindow(hwnd);
+            return false;
+        }
+
+        // Pump messages until the shell reports the balloon shown (it is then
+        // queued into the Action Center and survives icon removal) or
+        // dismissed, capped so a console program never hangs when the user has
+        // notifications disabled and no event ever arrives.
+        let deadline = GetTickCount64() + 4000;
+        loop {
+            if BALLOON_STATE.load(Ordering::SeqCst) == 2 {
+                break;
+            }
+            let mut msg = MSG::default();
+            while PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE).as_bool() {
+                let _ = TranslateMessage(&msg);
+                DispatchMessageW(&msg);
+            }
+            if BALLOON_STATE.load(Ordering::SeqCst) >= 1 {
+                // Shown — give the shell a brief moment to finish handing the
+                // toast to the Action Center before we tear the icon down.
+                Sleep(250);
+                break;
+            }
+            if GetTickCount64() >= deadline {
+                break;
+            }
+            Sleep(30);
+        }
+
+        let _ = Shell_NotifyIconW(NIM_DELETE, &data);
+        let _ = DestroyWindow(hwnd);
+        true
     }
 }


### PR DESCRIPTION
Fixes #5283.

## Problem

On Windows 11, `notificationSend` from `perry/system` "did nothing" — the report says nothing appeared. The linking half of this bug was already fixed in #5393 (importing `notificationSend` now flips `needs_ui` so the platform UI lib is actually linked). But the Windows implementation itself was a placeholder:

```rust
// Win32 notification via Shell_NotifyIconW is complex.
// For now, use a simple MessageBox as fallback.
MessageBoxW(None, body, title, MB_OK | MB_ICONINFORMATION);
```

A modal `MessageBox` is a blocking dialog the user must click to dismiss — not a notification. Next to the macOS path (`UNUserNotificationCenter` banner) and the GTK path (`Gio.Notification` / `notify-send`), Windows was the odd one out.

## Fix

Replace the `MessageBox` with a real notification-area toast via `Shell_NotifyIconW(NIM_ADD, …)` with `NIF_INFO` — the same mechanism `tray.rs` already uses.

A console program that only imports `notificationSend` has no app window and runs no message loop, so the implementation stands up a throwaway hidden owner window to host the icon, posts the balloon, pumps messages just long enough for the shell to report `NIN_BALLOONSHOW` (at which point the toast is queued into the Action Center and survives icon removal), then tears everything down. The pump is bounded (~4 s ceiling) so it can never hang if the user has notifications disabled and no event ever arrives.

The blocking `MessageBox` survives only as a last-resort fallback if the toast plumbing can't be created (window/class registration or `NIM_ADD` failure), so behavior never regresses to "nothing happened."

## Scope / verification

- One file: `crates/perry-ui-windows/src/system.rs`.
- No version bump / changelog (per request — maintainer can fold those in at merge).
- `cargo build -p perry-ui-windows` compiles clean on a Windows 11 host. API usage mirrors the already-proven window creation in `app.rs` and the `Shell_NotifyIconW` calls in `tray.rs`.
- The toast itself is a live desktop popup, so it can't be asserted in headless CI — it needs an interactive Windows session to eyeball. Worth a manual smoke (`notificationSend("Build complete", "All targets compiled in 4.2s.")`) before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Windows notifications now display as toast-style alerts for improved visibility and user experience, with automatic fallback to standard dialogs when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->