### PR TITLE
fix(parser): #5207 — look through banner comments when classifying .js chunks as ESM

### DIFF
--- a/crates/perry-parser/src/lib.rs
+++ b/crates/perry-parser/src/lib.rs
@@ -342,16 +342,23 @@ fn looks_like_es_module(source: &str) -> bool {
         b == b'_' || b == b'$' || b.is_ascii_alphanumeric()
     }
 
-    fn prev_allows_module_item(bytes: &[u8], mut i: usize) -> bool {
-        while i > 0 {
-            i -= 1;
-            match bytes[i] {
-                b' ' | b'\t' | b'\r' | b'\n' => continue,
-                b';' | b'{' | b'}' => return true,
-                _ => return false,
-            }
-        }
-        true
+    // Whether a top-level `import`/`export` keyword found here can begin a
+    // module item, given `last_sig` — the last significant *code* byte seen so
+    // far (0 = start of input). A module item starts at input start or right
+    // after a statement boundary (`;`, `{`, `}`); anything else (an operator, an
+    // identifier byte, a string/regex terminator) means the keyword is part of a
+    // larger expression and not a real `import`/`export` statement.
+    //
+    // `last_sig` is tracked during the forward scan rather than recovered by
+    // walking the raw bytes backward, because a backward walk cannot tell that
+    // the preceding bytes were inside a comment. Bundler chunks almost always
+    // open with a banner comment (`// chunk-….js`) immediately followed by a
+    // top-level `export`/`import`; a raw backward walk would see the comment's
+    // last character (e.g. the `)` of "(cross-chunk re-export)") and wrongly
+    // conclude the keyword can't start a module item, so the `.js` chunk parsed
+    // as a Script and SWC raised `ImportExportInScript` (issue #5207).
+    fn allows_module_item(last_sig: u8) -> bool {
+        matches!(last_sig, 0 | b';' | b'{' | b'}')
     }
 
     fn next_after_keyword(bytes: &[u8], i: usize, keyword: &[u8]) -> Option<usize> {
@@ -438,6 +445,12 @@ fn looks_like_es_module(source: &str) -> bool {
     let bytes = source.as_bytes();
     let mut i = 0;
     let mut state = State::Code;
+    // Last significant code byte seen (0 = start of input). Comments are
+    // transparent — they never update this — so a banner comment before a
+    // top-level `import`/`export` no longer hides the keyword. Strings and
+    // regex literals leave their terminator (`"`/`'`/`` ` ``/`/`) as the last
+    // significant byte, matching the old backward walk's behavior.
+    let mut last_sig: u8 = 0;
     while i < bytes.len() {
         match state {
             State::Code => {
@@ -455,8 +468,12 @@ fn looks_like_es_module(source: &str) -> bool {
                         Some(end) => i = end,
                         None => i += 1,
                     }
+                    // A regex literal (or a `/` division operator) is an
+                    // expression token — a following keyword can't begin a
+                    // module item.
+                    last_sig = b'/';
                 } else {
-                    if prev_allows_module_item(bytes, i) {
+                    if allows_module_item(last_sig) {
                         if let Some(end) = next_after_keyword(bytes, i, b"export") {
                             if matches!(
                                 bytes.get(end),
@@ -475,6 +492,9 @@ fn looks_like_es_module(source: &str) -> bool {
                             }
                         }
                     }
+                    if !matches!(bytes[i], b' ' | b'\t' | b'\r' | b'\n') {
+                        last_sig = bytes[i];
+                    }
                     i += 1;
                 }
             }
@@ -484,6 +504,7 @@ fn looks_like_es_module(source: &str) -> bool {
                 } else {
                     if bytes[i] == quote {
                         state = State::Code;
+                        last_sig = quote;
                     }
                     i += 1;
                 }
@@ -803,6 +824,45 @@ mod tests {
         let source = "const re = /(^[*!]|[/()[\\]{}\"])/;\nconst x = \"ok\";\nexport default x;\n";
         let module = parse_typescript(source, "vendored.js").unwrap();
         assert_eq!(module.body.len(), 3);
+    }
+
+    #[test]
+    fn test_banner_comment_before_top_level_export_is_module() {
+        // Regression for #5207: a bundler code-split chunk almost always opens
+        // with a banner comment immediately followed by a top-level `export`
+        // (or `import`). The module-detection scan must look through the comment
+        // — its last character (here the `)` of "(cross-chunk re-export)") must
+        // not be mistaken for a preceding code token that bars a module item, or
+        // the `.js` chunk parses as a Script and SWC raises ImportExportInScript.
+        let cases = [
+            "// runtime chunk (cross-chunk re-export)\nexport function rt(x) { return x; }\n",
+            "// banner foo\nexport const V = 1;\n",
+            "/* block banner */\nimport { x } from \"./chunk-shared.js\";\n",
+            "// a\n// b\n// c\nexport { y } from \"./other.js\";\n",
+        ];
+        for src in cases {
+            assert!(
+                looks_like_es_module(src),
+                "expected ESM classification for chunk:\n{src}"
+            );
+            // And it must actually parse as a module rather than a Script.
+            parse_typescript(src, "chunk-abc.js")
+                .unwrap_or_else(|e| panic!("chunk failed to parse as a module {src:?}: {e:?}"));
+        }
+    }
+
+    #[test]
+    fn test_comment_does_not_create_false_module_classification() {
+        // The transparency fix must not flip a genuinely CommonJS chunk to ESM:
+        // a comment ending in `;`/`{`/`}` followed by a non-keyword leaves the
+        // file a Script, and `exportFoo`/`importMap`-style identifiers after a
+        // comment still don't match the `export`/`import` keywords.
+        assert!(!looks_like_es_module(
+            "// helper;\nconst exportFoo = 1;\nmodule.exports = exportFoo;\n"
+        ));
+        assert!(!looks_like_es_module(
+            "// note\nconst importMap = {};\nmodule.exports = importMap;\n"
+        ));
     }
 
     #[test]

--- a/crates/perry/tests/issue_5207_codesplit_chunk_set.rs
+++ b/crates/perry/tests/issue_5207_codesplit_chunk_set.rs
@@ -1,0 +1,175 @@
+//! Regression test for #5207: perry ingests a bundler's code-split chunk-set
+//! (an entry chunk plus a set of `import("./chunk-….js")` chunks) and compiles
+//! the whole graph to native code.
+//!
+//! The concrete blocker this guards: `bun build --splitting` / esbuild emit
+//! every chunk with a leading banner comment immediately followed by a
+//! top-level `export`/`import`. The `.js` module-vs-script detector
+//! (`looks_like_es_module`) used to read the banner comment's last character as
+//! if it were code, decide the `export` could not begin a module item, and
+//! parse the chunk as a Script — SWC then raised `ImportExportInScript` and the
+//! whole build failed. The chunk-set below exercises:
+//!   * the entry chunk and every code-split chunk opening with a banner comment,
+//!   * a statically-knowable `import("./chunk-….js")` per route (compiled in,
+//!     not deferred),
+//!   * a shared chunk imported statically by the entry AND by the route chunks
+//!     (dedup), and
+//!   * a cross-chunk re-export (`export { … } from "./chunk-runtime.js"`).
+//! The compiled binary's output must match Node's byte-for-byte.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Once;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize workspace root")
+}
+
+fn target_debug_dir() -> PathBuf {
+    std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| workspace_root().join("target"))
+        .join("debug")
+}
+
+/// Build `libperry_runtime.a` / `libperry_stdlib.a` once so the compiled binary
+/// can link. Since #5422 runtime/stdlib are rlib-only; the staticlibs come from
+/// the `perry-{runtime,stdlib}-static` wrapper crates. The CI `cargo-test` job
+/// doesn't pre-build them.
+fn ensure_runtime_archive() {
+    static BUILD_RUNTIME: Once = Once::new();
+    BUILD_RUNTIME.call_once(|| {
+        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+        let build = Command::new(cargo)
+            .current_dir(workspace_root())
+            .arg("build")
+            .arg("-p")
+            .arg("perry-runtime-static")
+            .arg("-p")
+            .arg("perry-stdlib-static")
+            .output()
+            .expect("run cargo build for static wrapper crates");
+        assert!(
+            build.status.success(),
+            "cargo build -p perry-runtime-static -p perry-stdlib-static failed\n\
+             stdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&build.stdout),
+            String::from_utf8_lossy(&build.stderr)
+        );
+    });
+}
+
+fn runtime_dir() -> PathBuf {
+    ensure_runtime_archive();
+    target_debug_dir()
+}
+
+// --- the chunk-set, shaped like a `bun build --splitting` output ---
+
+const CHUNK_SHARED: &str = "\
+// chunk-shared.js — shared chunk imported by the entry and by route chunks
+export const VERSION = \"1.0.0\";
+export function fmt(name) { return `[${VERSION}] ${name}`; }
+";
+
+const CHUNK_RUNTIME: &str = "\
+// chunk-runtime.js — runtime chunk re-exported by a route chunk (cross-chunk re-export)
+export function runtimeTag(x) { return \"rt:\" + x; }
+";
+
+const CHUNK_ROUTE_A: &str = "\
+// chunk-route-a.js (code-split route)
+import { fmt } from \"./chunk-shared.js\";
+export function handler() { return fmt(\"route-a\"); }
+";
+
+const CHUNK_ROUTE_B: &str = "\
+// chunk-route-b.js (code-split route, cross-chunk re-export)
+import { fmt } from \"./chunk-shared.js\";
+export { runtimeTag } from \"./chunk-runtime.js\";
+import { runtimeTag } from \"./chunk-runtime.js\";
+export function handler() { return fmt(\"route-b\") + \" \" + runtimeTag(\"b\"); }
+";
+
+const ENTRY: &str = "\
+// entry.js (bundle entry; opens with a banner comment like every chunk)
+import { VERSION } from \"./chunk-shared.js\";
+
+async function loadRoute(name) {
+  if (name === \"a\") {
+    const m = await import(\"./chunk-route-a.js\");
+    return m.handler();
+  } else {
+    const m = await import(\"./chunk-route-b.js\");
+    return m.handler() + \" \" + m.runtimeTag(\"re\");
+  }
+}
+
+async function main() {
+  console.log(\"entry version\", VERSION);
+  console.log(await loadRoute(\"a\"));
+  console.log(await loadRoute(\"b\"));
+}
+main();
+";
+
+const EXPECTED: &str = "entry version 1.0.0\n[1.0.0] route-a\n[1.0.0] route-b rt:b rt:re\n";
+
+fn write_chunk_set(root: &std::path::Path) {
+    std::fs::write(root.join("chunk-shared.js"), CHUNK_SHARED).unwrap();
+    std::fs::write(root.join("chunk-runtime.js"), CHUNK_RUNTIME).unwrap();
+    std::fs::write(root.join("chunk-route-a.js"), CHUNK_ROUTE_A).unwrap();
+    std::fs::write(root.join("chunk-route-b.js"), CHUNK_ROUTE_B).unwrap();
+    std::fs::write(root.join("entry.js"), ENTRY).unwrap();
+}
+
+#[test]
+fn codesplit_chunk_set_compiles_and_runs() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    write_chunk_set(root);
+
+    let entry = root.join("entry.js");
+    let output = root.join("entry_bin");
+    let out = Command::new(perry_bin())
+        .current_dir(root)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .env("PERRY_NO_AUTO_OPTIMIZE", "1")
+        .env("PERRY_RUNTIME_DIR", runtime_dir())
+        .output()
+        .expect("run perry compile");
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "compiling a banner-commented code-split chunk-set must succeed; stderr:\n{stderr}"
+    );
+    // The pre-fix failure mode was a hard parse error on a chunk.
+    assert!(
+        !stderr.contains("ImportExportInScript"),
+        "a banner-commented `.js` chunk must parse as a module, not a script; stderr:\n{stderr}"
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled chunk-set binary must run; stderr:\n{}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert_eq!(
+        stdout, EXPECTED,
+        "chunk-set output must match Node byte-for-byte; got:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Summary
Closes the concrete blocker behind #5207 (ingest a bundler's code-split chunk-set so statically-knowable dynamic `import()` targets compile).

Real bundler code-split output (`bun build --splitting`, esbuild) emits **every chunk with a leading banner comment** immediately followed by a top-level `export`/`import`. perry's `.js` module-vs-script detector (`looks_like_es_module`) decided whether a keyword could begin a module item by walking the **raw bytes backward** — which can't tell that the preceding bytes were inside a comment. The banner's last character (e.g. the `)` of `"(cross-chunk re-export)"`) was read as a preceding code token, the keyword was rejected, the chunk parsed as a **Script**, and SWC raised `ImportExportInScript` — failing the whole build.

## Fix
Track the last significant **code** byte during the forward scan (which already skips comment/string/regex content) and use it for the module-item-start check, instead of the backward walk. Comments are transparent; strings and regex literals leave their terminator as the last significant byte, matching the old walk's behavior — so genuinely-CommonJS chunks are **not** misclassified as ESM.

## Result
An entry chunk plus its code-split chunk set now compiles and runs, matching Node byte-for-byte:
- shared chunks imported by multiple chunks (dedup),
- cross-chunk re-exports (`export { … } from "./chunk-runtime.js"`),
- statically-knowable `import("./chunk-….js")` targets compiled in (not deferred).

Genuinely runtime-computed `import()` paths remain handled by the existing #5230 defer-with-notice policy.

## Tests
- `crates/perry-parser`: unit tests for both directions — banner-commented chunks classify/parse as ESM; comment-preceded CommonJS still stays a Script.
- `crates/perry/tests/issue_5207_codesplit_chunk_set.rs`: end-to-end compile+run of a `bun build --splitting`-shaped chunk set, asserting output matches Node.

Per maintainer convention, no version bump / CHANGELOG entry in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved module detection robustness to correctly handle comments before top-level imports and exports.
  * Fixed parsing issues with code-split chunks that have banner comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->