### PR TITLE
fix(ui): #5491 — Picker onChange never fires on Windows (ABI arg mismatch)

### DIFF
--- a/crates/perry-ui-android/src/ffi/canvas_picker.rs
+++ b/crates/perry-ui-android/src/ffi/canvas_picker.rs
@@ -301,8 +301,10 @@ pub extern "C" fn perry_ui_combobox_get_value(handle: i64) -> f64 {
 }
 
 #[no_mangle]
-pub extern "C" fn perry_ui_picker_create(label_ptr: i64, on_change: f64, style: i64) -> i64 {
-    widgets::picker::create(label_ptr as *const u8, on_change, style)
+pub extern "C" fn perry_ui_picker_create(on_change: f64) -> i64 {
+    // Single `Closure` arg to match the dispatch-table ABI; a 3-arg
+    // signature mis-binds `on_change` on the Windows x64 ABI (issue #5491).
+    widgets::picker::create(std::ptr::null(), on_change, 0)
 }
 
 #[no_mangle]

--- a/crates/perry-ui-gtk4/src/ffi/chart_cal_table_tree_combo_picker.rs
+++ b/crates/perry-ui-gtk4/src/ffi/chart_cal_table_tree_combo_picker.rs
@@ -118,8 +118,10 @@ pub extern "C" fn perry_ui_combobox_get_value(handle: i64) -> f64 {
 }
 
 #[no_mangle]
-pub extern "C" fn perry_ui_picker_create(label_ptr: i64, on_change: f64, style: i64) -> i64 {
-    widgets::picker::create(label_ptr as *const u8, on_change, style)
+pub extern "C" fn perry_ui_picker_create(on_change: f64) -> i64 {
+    // Single `Closure` arg to match the dispatch-table ABI; a 3-arg
+    // signature mis-binds `on_change` on the Windows x64 ABI (issue #5491).
+    widgets::picker::create(std::ptr::null(), on_change, 0)
 }
 
 /// Add an item to a Picker.

--- a/crates/perry-ui-ios/src/ffi/widgets_advanced.rs
+++ b/crates/perry-ui-ios/src/ffi/widgets_advanced.rs
@@ -411,8 +411,10 @@ pub extern "C" fn perry_ui_combobox_get_value(handle: i64) -> f64 {
 }
 
 #[no_mangle]
-pub extern "C" fn perry_ui_picker_create(label_ptr: i64, on_change: f64, style: i64) -> i64 {
-    widgets::picker::create(label_ptr as *const u8, on_change, style)
+pub extern "C" fn perry_ui_picker_create(on_change: f64) -> i64 {
+    // Single `Closure` arg to match the dispatch-table ABI; a 3-arg
+    // signature mis-binds `on_change` on the Windows x64 ABI (issue #5491).
+    widgets::picker::create(std::ptr::null(), on_change, 0)
 }
 
 /// Add an item to a Picker.

--- a/crates/perry-ui-macos/src/lib_ffi/advanced_widgets.rs
+++ b/crates/perry-ui-macos/src/lib_ffi/advanced_widgets.rs
@@ -68,8 +68,10 @@ pub extern "C" fn perry_ui_qrcode_set_data(handle: i64, data_ptr: i64) {
 
 /// Create a Picker (dropdown). style: 0=dropdown, 1=segmented. Returns widget handle.
 #[no_mangle]
-pub extern "C" fn perry_ui_picker_create(label_ptr: i64, on_change: f64, style: i64) -> i64 {
-    widgets::picker::create(label_ptr as *const u8, on_change, style)
+pub extern "C" fn perry_ui_picker_create(on_change: f64) -> i64 {
+    // Single `Closure` arg to match the dispatch-table ABI; a 3-arg
+    // signature mis-binds `on_change` on the Windows x64 ABI (issue #5491).
+    widgets::picker::create(std::ptr::null(), on_change, 0)
 }
 
 /// Add an item to a Picker.

--- a/crates/perry-ui-tvos/src/ffi/advanced_widgets.rs
+++ b/crates/perry-ui-tvos/src/ffi/advanced_widgets.rs
@@ -241,8 +241,10 @@ pub extern "C" fn perry_ui_combobox_get_value(_handle: i64) -> f64 {
 }
 
 #[no_mangle]
-pub extern "C" fn perry_ui_picker_create(label_ptr: i64, on_change: f64, style: i64) -> i64 {
-    widgets::picker::create(label_ptr as *const u8, on_change, style)
+pub extern "C" fn perry_ui_picker_create(on_change: f64) -> i64 {
+    // Single `Closure` arg to match the dispatch-table ABI; a 3-arg
+    // signature mis-binds `on_change` on the Windows x64 ABI (issue #5491).
+    widgets::picker::create(std::ptr::null(), on_change, 0)
 }
 
 /// Add an item to a Picker.

--- a/crates/perry-ui-visionos/src/ffi_widgets_extra.rs
+++ b/crates/perry-ui-visionos/src/ffi_widgets_extra.rs
@@ -273,8 +273,10 @@ pub extern "C" fn perry_ui_combobox_get_value(handle: i64) -> f64 {
 }
 
 #[no_mangle]
-pub extern "C" fn perry_ui_picker_create(label_ptr: i64, on_change: f64, style: i64) -> i64 {
-    widgets::picker::create(label_ptr as *const u8, on_change, style)
+pub extern "C" fn perry_ui_picker_create(on_change: f64) -> i64 {
+    // Single `Closure` arg to match the dispatch-table ABI; a 3-arg
+    // signature mis-binds `on_change` on the Windows x64 ABI (issue #5491).
+    widgets::picker::create(std::ptr::null(), on_change, 0)
 }
 
 /// Add an item to a Picker.

--- a/crates/perry-ui-watchos/src/lib.rs
+++ b/crates/perry-ui-watchos/src/lib.rs
@@ -156,9 +156,11 @@ pub extern "C" fn perry_ui_image_create_url(_url_ptr: i64, _alt_ptr: i64) -> i64
 }
 
 #[no_mangle]
-pub extern "C" fn perry_ui_picker_create(label_ptr: i64, on_change: f64, _style: i64) -> i64 {
+pub extern "C" fn perry_ui_picker_create(on_change: f64) -> i64 {
+    // Single `Closure` arg to match the dispatch-table ABI; a 3-arg
+    // signature mis-binds `on_change` on the Windows x64 ABI (issue #5491).
+    // No label is wired from TS, so the picker has no leading text.
     let mut node = NodeData::new(NodeKind::Picker);
-    node.text = cstring_from_header(label_ptr as *const u8);
     node.on_change_closure = Some(on_change);
     tree::register_node(node)
 }

--- a/crates/perry-ui-windows/src/ffi/table_tree_combo_picker.rs
+++ b/crates/perry-ui-windows/src/ffi/table_tree_combo_picker.rs
@@ -76,8 +76,17 @@ pub extern "C" fn perry_ui_combobox_get_value(handle: i64) -> f64 {
 }
 
 #[no_mangle]
-pub extern "C" fn perry_ui_picker_create(label_ptr: i64, on_change: f64, style: i64) -> i64 {
-    widgets::picker::create(label_ptr as *const u8, on_change, style)
+pub extern "C" fn perry_ui_picker_create(on_change: f64) -> i64 {
+    // The dispatch table (perry-dispatch `ui_table`) passes a single
+    // `Closure` arg, matching the TS `Picker(onChange)` API. A 3-arg
+    // `(label_ptr, on_change, style)` signature mis-binds `on_change` on
+    // the Windows x64 ABI, where register slots are assigned by argument
+    // position regardless of type: the lone f64 lands in XMM0, but a
+    // positional arg-1 f64 is read from XMM1, so the callback pointer is
+    // never stored and `onChange` never fires (issue #5491). On SysV
+    // (macOS/Linux) float args are classed independently, so it happened
+    // to work. label/style were never wired from TS — pass null/0.
+    widgets::picker::create(std::ptr::null(), on_change, 0)
 }
 
 /// Add an item to a Picker.


### PR DESCRIPTION
Fixes #5491.

## Root cause

The perry/ui dispatch table (`perry-dispatch::ui_table`) declares `Picker` with a single `ArgKind::Closure`, so codegen emits a **1-argument** call: `perry_ui_picker_create(<closure as f64>)`. But every platform's FFI was:

```rust
pub extern "C" fn perry_ui_picker_create(label_ptr: i64, on_change: f64, style: i64) -> i64
```

where `on_change` is the **second positional** argument.

- **SysV AMD64 (macOS/Linux):** float args are classified into XMM registers *independently* of integer args, so the lone f64 closure lands in XMM0 = `on_change`. The picker works; `label_ptr`/`style` read garbage from unused integer registers but are effectively ignored.
- **Windows x64:** register slots are assigned by argument **position** regardless of type (arg0→RCX/XMM0, arg1→RDX/XMM1). The caller placed the closure in XMM0, but the callee reads `on_change` from XMM1 — so the callback pointer is never stored. `CBN_SELCHANGE` then has no callback to invoke, and `onChange` never fires (and the bound `State` never updates).

This is why it reproduces on Windows but not on macOS/Linux.

## Fix

Align every `perry_ui_picker_create` with the dispatch-table ABI: take a single `on_change: f64`. The TS `Picker(onChange)` API only ever passed the callback — `label`/`style` were never wired from TypeScript — so the inner `picker::create` is called with a null label and style `0`. This also removes the latent garbage-`label_ptr` deref on the SysV platforms.

Touches all platform FFI wrappers (windows/macos/ios/tvos/visionos/watchos/android/gtk4) so the signature is consistent everywhere.

## Testing

- `cargo build -p perry-ui-windows --release` succeeds.
- ABI reasoning verified against the SysV vs Windows-x64 register-assignment rules; the single-f64 signature now lands `on_change` in the slot the callee reads on both ABIs.

_No version bump / changelog entry per request — maintainer to fold in at merge._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed picker control functionality across all supported platforms including Android, iOS, macOS, tvOS, visionOS, watchOS, Windows, and GTK4 to ensure consistent and reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->