### PR TITLE
fix(runtime+codegen): #5504 — throw TypeError when calling a non-callable number instead of SIGSEGV

### DIFF
--- a/crates/perry-codegen/src/lower_call/console_promise.rs
+++ b/crates/perry-codegen/src/lower_call/console_promise.rs
@@ -14,7 +14,7 @@ use perry_hir::Expr;
 use perry_types::Type as HirType;
 
 use crate::expr::{
-    emit_typed_feedback_register_site, lower_expr, nanbox_pointer_inline, unbox_to_i64, FnCtx,
+    emit_typed_feedback_register_site, lower_expr, nanbox_pointer_inline, FnCtx,
     TypedFeedbackContract, TypedFeedbackKind,
 };
 use crate::nanbox::{double_literal, POINTER_MASK_I64};
@@ -1008,7 +1008,14 @@ pub fn try_lower_closure_call_fallthrough(
 
     let result = if lowered_args.len() <= 16 {
         let blk = ctx.block();
-        let closure_handle = unbox_to_i64(blk, &recv_box);
+        // #5504: tag-check the callee before masking to a closure pointer.
+        // A non-callable value (number/string/bool/null/undefined) whose
+        // low-48 bits form an in-range address would otherwise be handed to
+        // `js_closure_callN` as a wild `*const ClosureHeader` and SIGSEGV on
+        // the header read. The checked unbox throws `TypeError: value is not
+        // a function` for any non-`POINTER_TAG` value.
+        let closure_handle =
+            blk.call(I64, "js_closure_unbox_callee_checked", &[(DOUBLE, &recv_box)]);
         let runtime_fn = format!("js_closure_call{}", lowered_args.len());
         let mut call_args: Vec<(crate::types::LlvmType, &str)> = vec![(I64, &closure_handle)];
         for v in &lowered_args {
@@ -1028,7 +1035,14 @@ pub fn try_lower_closure_call_fallthrough(
             let slot = blk.gep(DOUBLE, &buf, &[(I64, &format!("{}", i))]);
             blk.store(DOUBLE, v, &slot);
         }
-        let closure_handle = unbox_to_i64(blk, &recv_box);
+        // #5504: tag-check the callee before masking to a closure pointer.
+        // A non-callable value (number/string/bool/null/undefined) whose
+        // low-48 bits form an in-range address would otherwise be handed to
+        // `js_closure_callN` as a wild `*const ClosureHeader` and SIGSEGV on
+        // the header read. The checked unbox throws `TypeError: value is not
+        // a function` for any non-`POINTER_TAG` value.
+        let closure_handle =
+            blk.call(I64, "js_closure_unbox_callee_checked", &[(DOUBLE, &recv_box)]);
         let argc = n.to_string();
         blk.call(
             DOUBLE,

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -182,6 +182,10 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_register_closure_async_function", VOID, &[PTR]);
     module.declare_function("js_register_closure_generator_function", VOID, &[PTR]);
     module.declare_function("js_register_closure_async_generator_function", VOID, &[PTR]);
+    // #5504: tag-checking unbox for dynamic call callees — throws
+    // `TypeError: value is not a function` instead of masking a
+    // non-pointer value's low 48 bits into a wild closure pointer.
+    module.declare_function("js_closure_unbox_callee_checked", I64, &[DOUBLE]);
     module.declare_function("js_closure_call0", DOUBLE, &[I64]);
     module.declare_function("js_closure_call1", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_closure_call2", DOUBLE, &[I64, DOUBLE, DOUBLE]);

--- a/crates/perry-runtime/src/closure/dispatch.rs
+++ b/crates/perry-runtime/src/closure/dispatch.rs
@@ -502,6 +502,32 @@ pub fn get_valid_func_ptr(closure: *const ClosureHeader) -> *const u8 {
     func_ptr
 }
 
+/// Unbox a dynamic-call callee to its closure pointer, throwing
+/// `TypeError: value is not a function` when the value is not a heap
+/// pointer.
+///
+/// Issue #5504: the call-emission path used to mask the callee's low 48
+/// bits unconditionally and hand them to `js_closure_callN` as a
+/// `*const ClosureHeader`. For a non-callable NUMBER whose mantissa's low
+/// 48 bits happen to form an in-range address (e.g. `1e-8` →
+/// `0x798E_E230_8C3A`), `get_valid_func_ptr`'s range check passed and the
+/// subsequent `read_volatile(closure + 12)` dereferenced a wild pointer →
+/// SIGSEGV. A range check alone cannot distinguish a real closure pointer
+/// from a mantissa-derived address; only a tag check on the full
+/// NaN-boxed value can, and it must happen BEFORE the low-48 mask. This
+/// runs at the codegen unbox site where the original `f64` is still
+/// available. A callable value (closure, bound method/function, native
+/// handle) is always `POINTER_TAG`; numbers, strings, bigints, booleans,
+/// null and undefined are not, and throw here.
+#[no_mangle]
+pub extern "C" fn js_closure_unbox_callee_checked(callee: f64) -> i64 {
+    let bits = callee.to_bits();
+    if bits & crate::value::TAG_MASK != crate::value::POINTER_TAG {
+        throw_not_callable();
+    }
+    (bits & crate::value::POINTER_MASK) as i64
+}
+
 /// Call a closure with 0 arguments, returning f64
 #[no_mangle]
 pub extern "C" fn js_closure_call0(closure: *const ClosureHeader) -> f64 {

--- a/test-files/test_issue_5504_noncallable_number_call.ts
+++ b/test-files/test_issue_5504_noncallable_number_call.ts
@@ -1,0 +1,79 @@
+// Issue #5504 — calling a non-callable value must throw a TypeError, not
+// SIGSEGV. The old call-emission path masked the callee's low 48 bits and
+// handed them to `js_closure_callN` as a closure pointer without checking the
+// NaN-box tag. A non-callable NUMBER whose mantissa's low 48 bits happen to
+// form an in-range address (e.g. `1e-8` → 0x798E_E230_8C3A) passed the
+// runtime's range check and faulted on the closure-header read.
+//
+// We compare byte-for-byte against `node --experimental-strip-types`, so we
+// normalize on `instanceof TypeError` rather than the engine-specific error
+// text (Node: "g is not a function" vs Perry: "value is not a function").
+
+function callThrows(label: string, f: () => void): void {
+  try {
+    f();
+    console.log(label + " -> NO THROW");
+  } catch (e) {
+    console.log(label + " -> " + (e instanceof TypeError ? "TypeError" : String(e)));
+  }
+}
+
+// Numbers whose low-48 mantissa bits form an in-range "pointer" (the crashing
+// cases) and ones that mask to zero (already threw). All must throw TypeError.
+callThrows("1e-8()", () => {
+  const g: any = (() => 1e-8)();
+  g(1);
+});
+callThrows("Math.PI()", () => {
+  const g: any = (() => Math.PI)();
+  g();
+});
+callThrows("0xf0001-scaled()", () => {
+  const g: any = (() => 0xf0001 * 1e-300)();
+  g();
+});
+callThrows("5()", () => {
+  const g: any = (() => 5)();
+  g(1, 2);
+});
+callThrows("2.5()", () => {
+  const g: any = (() => 2.5)();
+  g();
+});
+
+// Other non-callable primitives.
+callThrows('"hi"()', () => {
+  const g: any = (() => "hi")();
+  g();
+});
+callThrows("true()", () => {
+  const g: any = (() => true)();
+  g();
+});
+callThrows("undefined()", () => {
+  const g: any = (() => undefined)();
+  g();
+});
+callThrows("null()", () => {
+  const g: any = (() => null)();
+  g();
+});
+
+// Valid callables (dynamically typed) must still dispatch correctly.
+const add: any = (a: number, b: number) => a + b;
+console.log("add(40, 2) =", add(40, 2));
+
+const noArg: any = () => "ok";
+console.log("noArg() =", noArg());
+
+class Counter {
+  v = 7;
+  get(): number {
+    return this.v;
+  }
+}
+const c = new Counter();
+const bound: any = c.get.bind(c);
+console.log("bound() =", bound());
+
+console.log("survived all calls");


### PR DESCRIPTION
## Summary

Fixes #5504. Calling a non-callable **number** whose low-48 mantissa bits happen to form an in-range address (e.g. `1e-8` → `0x798E_E230_8C3A`) **segfaulted** instead of throwing `TypeError: ... is not a function`.

The dynamic call-emission path (`try_lower_closure_call_fallthrough` — the `any`-typed-callee fallthrough) masked the callee's low 48 bits and handed them to `js_closure_callN` as a `*const ClosureHeader` **without checking the value's NaN-box tag**. `get_valid_func_ptr`'s only guard is a numeric range check (`0x1000 ..< 2^48`), which a mantissa-derived address passes, so the subsequent `read_volatile(closure + 12)` dereferenced a wild pointer. Integers and simple fractions mask to `0` and accidentally hit the null/throw path, which is why it slipped past tests. It surfaced compiling the OpenAI Codex CLI bundle, which segfaulted at startup.

## Fix

A range check alone can't distinguish a real closure pointer from a mantissa-derived address, so the callee is **tag-checked before masking**, at the codegen unbox site where the full `f64` is still available:

- New runtime helper `js_closure_unbox_callee_checked(f64) -> i64` (`perry-runtime/src/closure/dispatch.rs`): throws `throw_not_callable()` for any non-`POINTER_TAG` value (number / string / bigint / bool / null / undefined) and returns the masked closure pointer otherwise. Callables (closures, bound methods/functions, native handles) are always `POINTER_TAG`.
- Both arity branches of the dynamic-call fallthrough (`<=16` args and the `js_closure_call_array` `>16` path) now route the unbox through it instead of the unchecked low-48 mask.

## Test

`test-files/test_issue_5504_noncallable_number_call.ts` exercises the crashing values (`1e-8`, `Math.PI`, `0xf0001`-scaled) and other non-callables, plus valid closures / no-arg / bound-method calls. It normalizes on `instanceof TypeError` (engine error text differs: Node `"g is not a function"` vs Perry `"value is not a function"`) and matches `node --experimental-strip-types` **byte-for-byte**.

## Validation

- Repro now throws `TypeError` (exit 1) instead of SIGSEGV (exit 139).
- 8/8 callee-type behavior checks pass (5 non-callables throw, 3 valid closures incl. bound method work).
- Existing node-compatible closure tests (`test_edge_closures`, `test_edge_higher_order`, `test_gap_closures`, `test_gap_2143_builtin_bind`) still match node byte-for-byte.
- `cargo clippy` on changed crates: no new warnings; runtime closure-dispatch unit tests pass.

Per maintainer convention, no version bump / CHANGELOG entry — left for merge-time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a critical crash (segmentation fault) that could occur when attempting to call non-callable values such as numbers, strings, booleans, `undefined`, or `null`. The application now properly validates callable values and throws a descriptive `TypeError: value is not a function` error message instead of crashing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->