### PR TITLE
fix(codegen): #5345 — dedup duplicate static-field LLVM global emission

### DIFF
--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -1619,6 +1619,12 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
     // <class>__<field>` initialized to 0.0. The init expression runs
     // in compile_module_entry's main/init function before user code.
     let mut static_field_globals: HashMap<(String, String), String> = HashMap::new();
+    // Track which `@perry_static_*` globals we've already emitted (defining or
+    // external) so a repeated symbol — a duplicate static field name within one
+    // class (#5345), or the same imported class pulled in twice — never emits a
+    // second LLVM global, which clang rejects as a redefinition.
+    let mut external_globals_emitted: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
     for c in &hir.classes {
         for sf in &c.static_fields {
             // Computed-key static fields (`static [Symbol.for(...)] = init`)
@@ -1642,7 +1648,17 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
             // when Sub is in a different file from Base; without external
             // linkage, the importing module's `StaticFieldGet { Base, Symbol }`
             // had no symbol to resolve and silently produced 0.0.
-            llmod.add_global(&name, DOUBLE, "0.0");
+            //
+            // #5345: a class may declare the SAME static field name twice
+            // (`static f = 'a'; static f = this.f + 'b';`) — both initializers
+            // run in declaration order against one shared slot (last write
+            // wins). They mangle to the same global symbol, so emit the
+            // defining global only once; clang rejects a redefined `@…__f`.
+            // The init loop still walks every `c.static_fields` entry, so both
+            // assignments execute against this single slot.
+            if external_globals_emitted.insert(name.clone()) {
+                llmod.add_global(&name, DOUBLE, "0.0");
+            }
             static_field_globals.insert((c.name.clone(), sf.name.clone()), name);
         }
     }
@@ -1650,9 +1666,8 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
     // module emits the defining external global (above); the consumer just
     // declares a reference and adds it to its own `static_field_globals` map
     // so `Expr::StaticFieldGet/Set` lowering finds it.
-    // Track which globals we've already emitted to avoid double-declarations.
-    let mut external_globals_emitted: std::collections::HashSet<String> =
-        std::collections::HashSet::new();
+    // (external_globals_emitted is declared above, shared with the local-class
+    // loop, to avoid double-declarations.)
     for ic in &opts.imported_classes {
         let effective_name = ic.local_alias.as_deref().unwrap_or(&ic.name);
         // Skip imported-class entries whose source matches this module's

--- a/test-files/test_gap_5345_dup_static_field.ts
+++ b/test-files/test_gap_5345_dup_static_field.ts
@@ -1,0 +1,38 @@
+// #5345 — a class may declare the SAME static field name more than once.
+// Per ECMAScript (ClassDefinitionEvaluation), every static field initializer
+// runs in declaration order against one shared slot; the last write wins. A
+// later initializer can read the value the earlier one left via `this.f`.
+//
+// Pre-fix, Perry emitted one `@perry_static_<mod>__<Class>__<field>` LLVM
+// global PER declaration, so two `static f = …` lines produced a redefined
+// global and clang rejected the module ("redefinition of global
+// '@perry_static_…__C__f'"). The fix dedups the global emission (one defining
+// global per (class, field)) while still running every initializer in order.
+// Mirrors test262 language/statements/class/elements/static-field-redeclaration.
+
+class C {
+  static f = "test";
+  static f = (this.f as string) + "262";
+  static g() {
+    return 45;
+  }
+  static g = this.g();
+}
+console.log("(1) C.f:", C.f);
+console.log("(2) C.g:", C.g);
+
+// Three redeclarations, each reading the prior value — order must hold.
+class Layered {
+  static v = 1;
+  static v = (this.v as number) + 10;
+  static v = (this.v as number) * 2;
+}
+console.log("(3) Layered.v:", Layered.v);
+
+// A redeclared field whose later initializer has a side effect: both run.
+const order: string[] = [];
+class Seq {
+  static x = (order.push("first") as unknown) as number;
+  static x = (order.push("second") as unknown) as number;
+}
+console.log("(4) Seq.x:", Seq.x, "order:", JSON.stringify(order));


### PR DESCRIPTION
## What

Part of the **class tail** (#5345). Fixes a codegen crash on classes that declare the **same static field name more than once**:

```ts
class C {
  static f = 'test';
  static f = this.f + '262';   // reads the prior value
  static g() { return 45; }
  static g = this.g();
}
// spec: C.f === 'test262', C.g === 45
```

Per ECMAScript *ClassDefinitionEvaluation*, every static-field initializer runs in declaration order against one shared slot (last write wins); a later initializer can read the earlier value via `this.f`.

## The bug

Codegen emitted one `@perry_static_<mod>__<Class>__<field>` **defining global per declaration**, so two same-named static fields produced a redefined LLVM global and clang rejected the whole module:

```
error: redefinition of global '@perry_static_…__C__f'
```

This sank several **test262 `language/.../class`** cases as `compile-fail`, e.g.:
- `elements/static-field-redeclaration`
- `static-init-sequence` (interleaved duplicate `static x`)

## The fix

Dedup the *defining global* via the existing emitted-symbol set (hoisted so it also covers the local-class loop): emit **one** global per `(class, field)` while the init loop still walks every `c.static_fields` entry — so both assignments execute in order against the single slot. No change to initializer ordering or semantics.

## Validation

- `static-field-redeclaration`-style program now compiles and prints `test262 / 45` (was: clang redefinition error).
- New gap test `test_gap_5345_dup_static_field.ts` (duplicate static fields incl. `this.f` chaining, a `static g = this.g()` self-call, and ordered side effects) — **byte-for-byte parity with `node --experimental-strip-types`**.
- Existing `test_gap_class_static_blocks` and `test_gap_2899_2779_2777_static_helpers` still match Node (no regression).

Per maintainer convention, no version bump / CHANGELOG entry (left to maintainer at merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved compilation errors that occurred when classes declared the same static field multiple times. Static field initializers now execute correctly in declaration order, with proper value assignment.

* **Tests**
  * Added regression test for static field redeclaration scenarios, verifying initialization semantics and side effect execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->