### PR TITLE
fix(runtime): #5437 — dispatch class-ref static data-property method calls

### DIFF
--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1776,6 +1776,42 @@ pub unsafe extern "C" fn js_native_call_method(
                 args.as_ptr(),
                 args.len(),
             );
+        } else if class_id != 0 && !method_name_ptr.is_null() && method_name_len > 0 {
+            // #5437: `C.viaFn()` where `viaFn` is a static DATA property holding a
+            // callable (`C.viaFn = fn` / `static viaFn = fn`), NOT a registered
+            // static method. A class reference VALUE is an INT32-tagged class id,
+            // not a heap object, so the generic object field-scan below can't deref
+            // it; and these statics live in CLASS_DYNAMIC_PROPS, not the static-
+            // method vtable, so the arm above misses them. The bug surfaced as a
+            // method call on a class returned from / aliased through a function
+            // (`const D = C; D.viaFn()`), where the static analyzer couldn't prove
+            // the receiver is a class object and lowered it to this dynamic path.
+            // Resolve the property exactly as the read-then-call path does
+            // (`js_object_get_field_by_name` walks the class-ref static chain),
+            // then invoke the callable with `this` bound to the class ref —
+            // mirroring `const f = C.viaFn; f()`, which already worked.
+            let key_ptr = crate::string::js_string_from_bytes(
+                method_name_ptr as *const u8,
+                method_name_len as u32,
+            );
+            let prop = js_object_get_field_by_name(object.to_bits() as *const ObjectHeader, key_ptr);
+            let prop_bits = prop.bits();
+            let raw = (prop_bits & crate::value::POINTER_MASK) as usize;
+            if (prop_bits & crate::value::TAG_MASK) == crate::value::POINTER_TAG
+                && crate::closure::is_closure_ptr(raw)
+            {
+                let prop_handle = root_scope.root_nanbox_f64(f64::from_bits(prop_bits));
+                let args = refreshed_args();
+                let prev_this =
+                    IMPLICIT_THIS.with(|c| c.replace(object_handle.get_nanbox_f64().to_bits()));
+                let result = crate::closure::js_native_call_value(
+                    prop_handle.get_nanbox_f64(),
+                    args.as_ptr(),
+                    args.len(),
+                );
+                IMPLICIT_THIS.with(|c| c.set(prev_this));
+                return result;
+            }
         }
     }
 

--- a/test-files/test_gap_5437_class_ref_static_closure_method.ts
+++ b/test-files/test_gap_5437_class_ref_static_closure_method.ts
@@ -1,0 +1,77 @@
+// Issue #5437: calling a class static DATA property that holds a captured
+// closure as a METHOD (`C.viaFn()`) where the class value reached the call as
+// a class-reference (INT32-tagged class id) rather than a heap class object —
+// i.e. the static analyzer could not prove the receiver is a class. Such
+// statics live in the class dynamic-property side table, not the static-method
+// vtable, and a class reference is not a heap object, so the dynamic method
+// dispatcher resolved nothing and the call returned `undefined`/null. The read-
+// then-call form (`const f = C.viaFn; f()`) already worked; the fused method
+// call must match it.
+//
+// Expected output:
+// returned: V
+// aliased: V
+// captured-in-ctor: scc:MF
+// object-holder: V
+
+// A class returned from a function, with a captured-closure static assigned
+// after the class declaration. The method call must resolve the static.
+function makeReturned() {
+  const uw = "V";
+  function getCache() {
+    return uw;
+  }
+  class C {}
+  (C as any).viaFn = getCache;
+  return C;
+}
+console.log("returned:", (makeReturned() as any).viaFn());
+
+// The class value flows through a local alias before the method call, so the
+// receiver is a bare class reference at the call site.
+function makeAliased() {
+  function getCache() {
+    return "V";
+  }
+  class C {}
+  (C as any).viaFn = getCache;
+  return C;
+}
+const Aliased = makeAliased();
+const D = Aliased;
+console.log("aliased:", (D as any).viaFn());
+
+// The #5437 shape: a deferred-binding value captured by a class whose method
+// reads it through the captured reference, dispatched on a returned class.
+function makeIncremental() {
+  const mod = {
+    SharedCacheControls: class {
+      manifest: string;
+      constructor(m: string) {
+        this.manifest = m;
+      }
+      hello() {
+        return "scc:" + this.manifest;
+      }
+    },
+  };
+  function build(m: string) {
+    return new mod.SharedCacheControls(m);
+  }
+  class IncrementalCache {}
+  (IncrementalCache as any).build = build;
+  return IncrementalCache;
+}
+console.log("captured-in-ctor:", (makeIncremental() as any).build("MF").hello());
+
+// Control: the same shape on a plain object holder already worked; keep it
+// green so a regression here is visible too.
+function makeObject() {
+  function getCache() {
+    return "V";
+  }
+  const o: any = {};
+  o.viaFn = getCache;
+  return o;
+}
+console.log("object-holder:", makeObject().viaFn());


### PR DESCRIPTION
## Summary

Fixes a runtime method-dispatch bug surfaced by #5437. A method call `C.viaFn()` returned `undefined`/`null` (instead of invoking the method) when **both**:

1. the receiver reached the call site as a **class-reference value** — an INT32-tagged class id, e.g. a class returned from or aliased through a function (`const D = C; D.viaFn()`), so the static analyzer couldn't prove it's a class object and lowered the call to the dynamic dispatcher; and
2. `viaFn` is a **static data property holding a callable** (`C.viaFn = fn` / `static viaFn = fn`), not a registered static method.

Such statics live in `CLASS_DYNAMIC_PROPS` (keyed by `class_id`), not the static-method vtable, so the existing static-method arm in `js_native_call_method` missed them — and a class reference isn't a heap object, so the generic object field-scan below it can't dereference it. The read-then-call form (`const f = C.viaFn; f()`) already worked because property-get walks the class-ref static chain via `js_object_get_field_by_name`; only the **fused method call** was broken.

## Root cause (verified via runtime instrumentation)

Minimal repro (`function f(){ const uw="V"; function getCache(){return uw;} class C{} C.viaFn=getCache; return C; }  f().viaFn()` → Perry `null`, Node `"V"`). Instrumenting `js_native_call_method` showed the receiver arriving as `obj_bits=0x7ffe000000000001` (`is_ptr=false`, `is_class_obj=false`), so neither `is_class_object_value` nor the field-scan resolved the static. This is the same family as #5437's `new uw.SharedCacheControls(...)` "undefined is not a constructor": a captured module binding read through a class member dispatched on a class-ref receiver.

## Fix

When the receiver is a class ref and the name isn't a registered static method, resolve the property through `js_object_get_field_by_name` (the same class-ref-aware getter property-get uses) and, if it's a closure, invoke it with `this` bound to the class ref — mirroring extract-then-call. 36 lines, purely additive (a new `else if` arm that only fires when the prior arms didn't match).

## Testing

- New gap test `test_gap_5437_class_ref_static_closure_method.ts`: **FAIL → PASS**, byte-for-byte vs `node --experimental-strip-types`.
- `cargo test -p perry-runtime`: 1066 passed; the single failure is the documented per-build typed-array test-isolation flake (passes in isolation), unrelated to this change.
- **No regression:** verified against a clean-`main` release baseline — the 5 pre-existing class-expr gap failures on this build (`class_expr_static_this`, `class_advanced`, `2159_defineproperty_class_prototype`, `default_param_tdz`, `class_expr_extends_static_call_this`) fail **identically with and without this patch**; only the new test flips.

No version bump / changelog entry (left to the maintainer at merge, per the external-contributor convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed method invocation on class-referenced static properties containing closures. Previously, calling such methods returned undefined; they now correctly resolve and execute with the class reference bound as `this`.

* **Tests**
  * Added test cases covering static closure property method calls under various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->