### PR TITLE
test(test262): #5346 — run Node oracle as a global script (vm.runInThisContext)

### DIFF
--- a/scripts/test262_subset.py
+++ b/scripts/test262_subset.py
@@ -92,6 +92,12 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent
 TEST262_DIR = REPO_ROOT / "test-compat" / "test262"
 PREAMBLE = TEST262_DIR / "preamble.js"
+# Node host shim: runs an assembled case as a *global script* (via
+# vm.runInThisContext) rather than a CommonJS module, matching a real Test262
+# host and Perry. Without it, module-scoped harness intrinsics are invisible to
+# global-scope indirect eval, so Node spuriously rejects Annex B eval cases
+# (#5346).
+HOST_RUNNER = TEST262_DIR / "host-run.cjs"
 # Feature tags Perry implements but the Node oracle cannot run (e.g. Temporal).
 # Cases tagged with one of these are judged in self-validating mode (#4792):
 # Perry-only, scored on whether the case's own `assert.*` self-checks throw.
@@ -473,7 +479,8 @@ def main() -> int:
                           else "ran clean; expected a thrown error (negative)")
                 return (rel, cat, "runtime-fail", reason, False, True)
             # 1) Node is the oracle (negative cases legitimately exit != 0).
-            n_exit, n_out = run(["node", str(staged)], base_env, args.timeout)
+            n_exit, n_out = run(["node", str(HOST_RUNNER), str(staged)],
+                                base_env, args.timeout)
             node_clean = n_exit == 0
             # 2) Perry compile (permissive — unimplemented surfaces as a gap).
             out_bin = workdir / "case.out"

--- a/test-compat/test262/README.md
+++ b/test-compat/test262/README.md
@@ -78,6 +78,17 @@ no harness. Because both runtimes load the *same* assembled script, the
 differential compares the two runtimes' **builtins**, never their
 harnesses.
 
+The Node oracle runs the assembled script through `host-run.cjs`
+(`vm.runInThisContext`) rather than `node case.js` directly. `node file.js`
+evaluates a file as a **CommonJS module**, scoping its top-level
+`var`/`function` declarations to the module wrapper instead of the global
+object — which diverges from both a conforming Test262 host and Perry, and
+breaks any case whose harness intrinsics must be reachable from global
+scope (notably the Annex B `eval-code/indirect` family, where an indirect
+`(0,eval)(...)` runs in global scope and otherwise can't see a
+module-scoped `assert`). `runInThisContext` restores true global-script
+semantics so the oracle agrees with a conforming host (#5346).
+
 Raw CommonJS/JS runs under Perry because Perry feeds user `.js` through
 the native AOT pipeline (the same path `compilePackages` uses; see #668).
 
@@ -116,6 +127,8 @@ the negative-rejection signal stay legible.
 - `pinned-sha.txt` — the Test262 SHA the corpus is pulled from.
 - `preamble.js` — host shims (`print`, `$DONOTEVALUATE`) prepended to
   every non-`raw` assembled case under both runtimes.
+- `host-run.cjs` — Node oracle entry point; runs an assembled case as a
+  global script via `vm.runInThisContext` (see the harness note above, #5346).
 - `report.json` — written by the runner (a generated artifact; not
   committed).
 

--- a/test-compat/test262/host-run.cjs
+++ b/test-compat/test262/host-run.cjs
@@ -1,0 +1,29 @@
+// Node host runner for the Test262 subset radar (#799, #5346).
+//
+// `node file.js` executes the file as a CommonJS module: its top-level
+// `var`/`function` declarations live in the module wrapper, NOT on the global
+// object. That diverges from a real Test262 host (and from Perry), which run
+// each assembled case as a *global script*. The difference is invisible for
+// most cases but breaks any test whose harness intrinsics must be reachable
+// from global scope — notably the Annex B `eval-code/indirect` family, where
+// an indirect `(0,eval)(...)` evaluates in the global scope and so cannot see
+// a module-scoped `assert` (it throws `ReferenceError: assert is not defined`,
+// making Node spuriously "reject" a case Perry runs clean).
+//
+// Running the assembled program through `vm.runInThisContext` restores true
+// script semantics: top-level declarations become globals, top-level `this` is
+// `globalThis`, and a syntax error still throws at compile time (so negative
+// parse cases keep exiting non-zero). This makes the Node oracle agree with a
+// conforming host instead of with the CommonJS wrapper.
+//
+// The `.cjs` extension is deliberate: the repo's package.json sets
+// `"type": "module"`, so a `.js` shim would load as ESM and `require` would be
+// undefined. `.cjs` forces CommonJS for the shim itself; the case it runs is
+// still evaluated as a global script via vm.runInThisContext.
+"use strict";
+const vm = require("vm");
+const fs = require("fs");
+
+const file = process.argv[2];
+const code = fs.readFileSync(file, "utf8");
+vm.runInThisContext(code, { filename: file });


### PR DESCRIPTION
## Summary

Follow-up on the `annexB/language` tail (#5346). The remeasure after #5394/#5356 shows the **`72× missed-negative` cluster the issue flagged as "Annex B early-error semantics Perry is too lenient on" is not a Perry bug at all — it's a flaw in the subset radar's Node oracle.**

The runner invoked the oracle as `node case.js`, which evaluates the assembled case as a **CommonJS module**. That scopes the harness's top-level `assert`/`Test262Error`/etc. to the module wrapper instead of the global object. A conforming Test262 host — and Perry — run each case as a **global script**, so the two diverge wherever a harness intrinsic must be reachable from global scope.

Concretely, all 72 mis-bucketed cases are `annexB/language/eval-code/indirect/*`, where an indirect `(0,eval)(...)` evaluates in global scope and so can't see a module-scoped `assert`:

```
ReferenceError: assert is not defined
```

Node threw on cases **Perry runs correctly**, and the runner scored them `Perry ran clean; Node rejected (missed negative)`.

## Fix

Route the oracle through a committed `test-compat/test262/host-run.cjs` shim that runs the assembled script via `vm.runInThisContext`, restoring global-script semantics:
- top-level declarations become globals (indirect eval can see `assert`),
- top-level `this` is `globalThis`,
- a syntax error still throws at compile time, so negative *parse* cases keep exiting non-zero.

The `.cjs` extension is deliberate — the repo's `package.json` sets `"type": "module"`, so a `.js` shim would load as ESM and `require` would be undefined.

## Effect (annexB, `--all-features`, node v26)

- **+72** `eval-code/indirect` false failures flip to **pass**.
- The corrected oracle simultaneously **unmasks ~74 genuine B.3.3 bugs** the CommonJS wrapper had been hiding (`f should be an own property`, `binding is not reinitialized`, `SameValue("string","function")`, …). Root cause: **Perry does not reflect top-level `var`/`function` (incl. B.3.3 block functions) as own properties of the global object** — `Object.getOwnPropertyDescriptor(globalThis, "a")` is `undefined` for a top-level `var a`, where Node reports an own enumerable, writable, non-configurable property. That's a global-environment-record gap, not a contained fix; it should be its own ticket.
- Headline annexB parity is **~flat (77.3% → 77.1%)** — it was slightly *inflated* by those masked bugs (both runtimes failed → counted as agreement). The number now reflects reality.
- Default class-dir slice unaffected: **95.7%** on a 700-case sample (baseline 95.0%).

## Re-diagnosis of the remaining `annexB/language` tail

With the oracle corrected, the tail decomposes into three well-defined items:

1. **~92 global-environment-record cases** — top-level/`eval`/B.3.3 bindings not reflected as own global-object properties. One architectural feature; recommend a dedicated ticket.
2. **~78 dynamic `eval()`** — genuinely runtime-built strings; a real AOT limit to document/scope (not fixable in-process).
3. **~13 regex** — lookbehind / `\c` / named-group gaps, the known categorical regex limits.

This PR is test tooling only — **no compiler/runtime change, no version bump, no changelog** (per maintainer convention for non-shipping infra changes).

## Validation

- `scripts/test262_subset.py --dir annexB --all-features --jobs 8` before/after — 72 eval-indirect cases move fail→pass; reasons re-bucketed as above.
- Spot-checked `host-run.cjs` on a previously-passing case (`Date.prototype.getYear/length`) and a previously-mis-bucketed one (`global-block-decl-eval-global-skip-early-err`): both exit 0.
- 700-case default-dir sample: 95.7%, no regression from the oracle change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Test262 subset tests now execute through a dedicated host runner, providing improved global-script semantics compatibility with real Test262 environments.

* **Documentation**
  * Updated Test262 documentation to describe the new execution mechanism and host runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->