### PR TITLE
fix(runtime+codegen): #5504 non-callable number SIGSEGV + #5437 class-ref static closure dispatch

### DIFF
--- a/crates/perry-codegen/src/lower_call/console_promise.rs
+++ b/crates/perry-codegen/src/lower_call/console_promise.rs
@@ -14,7 +14,7 @@ use perry_hir::Expr;
 use perry_types::Type as HirType;
 
 use crate::expr::{
-    emit_typed_feedback_register_site, lower_expr, nanbox_pointer_inline, unbox_to_i64, FnCtx,
+    emit_typed_feedback_register_site, lower_expr, nanbox_pointer_inline, FnCtx,
     TypedFeedbackContract, TypedFeedbackKind,
 };
 use crate::nanbox::{double_literal, POINTER_MASK_I64};
@@ -1008,7 +1008,17 @@ pub fn try_lower_closure_call_fallthrough(
 
     let result = if lowered_args.len() <= 16 {
         let blk = ctx.block();
-        let closure_handle = unbox_to_i64(blk, &recv_box);
+        // #5504: tag-check the callee before masking to a closure pointer.
+        // A non-callable value (number/string/bool/null/undefined) whose
+        // low-48 bits form an in-range address would otherwise be handed to
+        // `js_closure_callN` as a wild `*const ClosureHeader` and SIGSEGV on
+        // the header read. The checked unbox throws `TypeError: value is not
+        // a function` for any non-`POINTER_TAG` value.
+        let closure_handle = blk.call(
+            I64,
+            "js_closure_unbox_callee_checked",
+            &[(DOUBLE, &recv_box)],
+        );
         let runtime_fn = format!("js_closure_call{}", lowered_args.len());
         let mut call_args: Vec<(crate::types::LlvmType, &str)> = vec![(I64, &closure_handle)];
         for v in &lowered_args {
@@ -1028,7 +1038,17 @@ pub fn try_lower_closure_call_fallthrough(
             let slot = blk.gep(DOUBLE, &buf, &[(I64, &format!("{}", i))]);
             blk.store(DOUBLE, v, &slot);
         }
-        let closure_handle = unbox_to_i64(blk, &recv_box);
+        // #5504: tag-check the callee before masking to a closure pointer.
+        // A non-callable value (number/string/bool/null/undefined) whose
+        // low-48 bits form an in-range address would otherwise be handed to
+        // `js_closure_callN` as a wild `*const ClosureHeader` and SIGSEGV on
+        // the header read. The checked unbox throws `TypeError: value is not
+        // a function` for any non-`POINTER_TAG` value.
+        let closure_handle = blk.call(
+            I64,
+            "js_closure_unbox_callee_checked",
+            &[(DOUBLE, &recv_box)],
+        );
         let argc = n.to_string();
         blk.call(
             DOUBLE,

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -182,6 +182,10 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_register_closure_async_function", VOID, &[PTR]);
     module.declare_function("js_register_closure_generator_function", VOID, &[PTR]);
     module.declare_function("js_register_closure_async_generator_function", VOID, &[PTR]);
+    // #5504: tag-checking unbox for dynamic call callees — throws
+    // `TypeError: value is not a function` instead of masking a
+    // non-pointer value's low 48 bits into a wild closure pointer.
+    module.declare_function("js_closure_unbox_callee_checked", I64, &[DOUBLE]);
     module.declare_function("js_closure_call0", DOUBLE, &[I64]);
     module.declare_function("js_closure_call1", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_closure_call2", DOUBLE, &[I64, DOUBLE, DOUBLE]);

--- a/crates/perry-runtime/src/closure/mod.rs
+++ b/crates/perry-runtime/src/closure/mod.rs
@@ -9,6 +9,7 @@ mod alloc;
 mod dispatch;
 mod dynamic_props;
 mod registry;
+mod unbox;
 mod v8_stubs;
 
 #[cfg(test)]
@@ -50,6 +51,7 @@ pub(crate) use dispatch::{
     coerce_call_this, reify_function_method_value, reset_throw_not_callable_counter,
     resolve_call2_direct,
 };
+pub use unbox::js_closure_unbox_callee_checked;
 
 #[cfg(test)]
 pub(crate) use dynamic_props::test_clear_closure_side_tables;

--- a/crates/perry-runtime/src/closure/unbox.rs
+++ b/crates/perry-runtime/src/closure/unbox.rs
@@ -1,0 +1,31 @@
+//! Checked unboxing of dynamic-call callees.
+//!
+//! Split out of `dispatch.rs` to keep that module under the 2000-line cap.
+
+use super::dispatch::throw_not_callable;
+
+/// Unbox a dynamic-call callee to its closure pointer, throwing
+/// `TypeError: value is not a function` when the value is not a heap
+/// pointer.
+///
+/// Issue #5504: the call-emission path used to mask the callee's low 48
+/// bits unconditionally and hand them to `js_closure_callN` as a
+/// `*const ClosureHeader`. For a non-callable NUMBER whose mantissa's low
+/// 48 bits happen to form an in-range address (e.g. `1e-8` →
+/// `0x798E_E230_8C3A`), `get_valid_func_ptr`'s range check passed and the
+/// subsequent `read_volatile(closure + 12)` dereferenced a wild pointer →
+/// SIGSEGV. A range check alone cannot distinguish a real closure pointer
+/// from a mantissa-derived address; only a tag check on the full
+/// NaN-boxed value can, and it must happen BEFORE the low-48 mask. This
+/// runs at the codegen unbox site where the original `f64` is still
+/// available. A callable value (closure, bound method/function, native
+/// handle) is always `POINTER_TAG`; numbers, strings, bigints, booleans,
+/// null and undefined are not, and throw here.
+#[no_mangle]
+pub extern "C" fn js_closure_unbox_callee_checked(callee: f64) -> i64 {
+    let bits = callee.to_bits();
+    if bits & crate::value::TAG_MASK != crate::value::POINTER_TAG {
+        throw_not_callable();
+    }
+    (bits & crate::value::POINTER_MASK) as i64
+}

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1776,6 +1776,54 @@ pub unsafe extern "C" fn js_native_call_method(
                 args.as_ptr(),
                 args.len(),
             );
+        } else if class_id != 0 && !method_name_ptr.is_null() && method_name_len > 0 {
+            // #5437: `C.viaFn()` where `viaFn` is a static DATA property holding a
+            // callable (`C.viaFn = fn` / `static viaFn = fn`), NOT a registered
+            // static method. A class reference VALUE is an INT32-tagged class id,
+            // not a heap object, so the generic object field-scan below can't deref
+            // it; and these statics live in CLASS_DYNAMIC_PROPS, not the static-
+            // method vtable, so the arm above misses them. The bug surfaced as a
+            // method call on a class returned from / aliased through a function
+            // (`const D = C; D.viaFn()`), where the static analyzer couldn't prove
+            // the receiver is a class object and lowered it to this dynamic path.
+            // Resolve the property exactly as the read-then-call path does
+            // (`js_object_get_field_by_name` walks the class-ref static chain),
+            // then invoke the callable with `this` bound to the class ref —
+            // mirroring `const f = C.viaFn; f()`, which already worked.
+            let key_ptr = crate::string::js_string_from_bytes(
+                method_name_ptr as *const u8,
+                method_name_len as u32,
+            );
+            let prop =
+                js_object_get_field_by_name(object.to_bits() as *const ObjectHeader, key_ptr);
+            let prop_bits = prop.bits();
+            let raw = (prop_bits & crate::value::POINTER_MASK) as usize;
+            if (prop_bits & crate::value::TAG_MASK) == crate::value::POINTER_TAG
+                && crate::closure::is_closure_ptr(raw)
+            {
+                // Rebind the closure's reserved `this` slot to the class ref, as
+                // the prototype/field method-dispatch arms above do. A static
+                // data property holding an object-literal method (`captures_this`)
+                // bakes `this` into a capture slot that `IMPLICIT_THIS` alone
+                // can't override; `clone_closure_rebind_this` is a no-op for
+                // closures that don't capture `this`, so plain functions and
+                // arrows are unaffected.
+                let bound = crate::closure::clone_closure_rebind_this(
+                    prop_bits,
+                    object_handle.get_nanbox_f64(),
+                );
+                let prop_handle = root_scope.root_nanbox_f64(f64::from_bits(bound));
+                let args = refreshed_args();
+                let prev_this =
+                    IMPLICIT_THIS.with(|c| c.replace(object_handle.get_nanbox_f64().to_bits()));
+                let result = crate::closure::js_native_call_value(
+                    prop_handle.get_nanbox_f64(),
+                    args.as_ptr(),
+                    args.len(),
+                );
+                IMPLICIT_THIS.with(|c| c.set(prev_this));
+                return result;
+            }
         }
     }
 

--- a/test-files/test_gap_5437_class_ref_static_closure_method.ts
+++ b/test-files/test_gap_5437_class_ref_static_closure_method.ts
@@ -1,0 +1,77 @@
+// Issue #5437: calling a class static DATA property that holds a captured
+// closure as a METHOD (`C.viaFn()`) where the class value reached the call as
+// a class-reference (INT32-tagged class id) rather than a heap class object —
+// i.e. the static analyzer could not prove the receiver is a class. Such
+// statics live in the class dynamic-property side table, not the static-method
+// vtable, and a class reference is not a heap object, so the dynamic method
+// dispatcher resolved nothing and the call returned `undefined`/null. The read-
+// then-call form (`const f = C.viaFn; f()`) already worked; the fused method
+// call must match it.
+//
+// Expected output:
+// returned: V
+// aliased: V
+// captured-in-ctor: scc:MF
+// object-holder: V
+
+// A class returned from a function, with a captured-closure static assigned
+// after the class declaration. The method call must resolve the static.
+function makeReturned() {
+  const uw = "V";
+  function getCache() {
+    return uw;
+  }
+  class C {}
+  (C as any).viaFn = getCache;
+  return C;
+}
+console.log("returned:", (makeReturned() as any).viaFn());
+
+// The class value flows through a local alias before the method call, so the
+// receiver is a bare class reference at the call site.
+function makeAliased() {
+  function getCache() {
+    return "V";
+  }
+  class C {}
+  (C as any).viaFn = getCache;
+  return C;
+}
+const Aliased = makeAliased();
+const D = Aliased;
+console.log("aliased:", (D as any).viaFn());
+
+// The #5437 shape: a deferred-binding value captured by a class whose method
+// reads it through the captured reference, dispatched on a returned class.
+function makeIncremental() {
+  const mod = {
+    SharedCacheControls: class {
+      manifest: string;
+      constructor(m: string) {
+        this.manifest = m;
+      }
+      hello() {
+        return "scc:" + this.manifest;
+      }
+    },
+  };
+  function build(m: string) {
+    return new mod.SharedCacheControls(m);
+  }
+  class IncrementalCache {}
+  (IncrementalCache as any).build = build;
+  return IncrementalCache;
+}
+console.log("captured-in-ctor:", (makeIncremental() as any).build("MF").hello());
+
+// Control: the same shape on a plain object holder already worked; keep it
+// green so a regression here is visible too.
+function makeObject() {
+  function getCache() {
+    return "V";
+  }
+  const o: any = {};
+  o.viaFn = getCache;
+  return o;
+}
+console.log("object-holder:", makeObject().viaFn());

--- a/test-files/test_issue_5504_noncallable_number_call.ts
+++ b/test-files/test_issue_5504_noncallable_number_call.ts
@@ -1,0 +1,85 @@
+// Issue #5504 — calling a non-callable value must throw a TypeError, not
+// SIGSEGV. The old call-emission path masked the callee's low 48 bits and
+// handed them to `js_closure_callN` as a closure pointer without checking the
+// NaN-box tag. A non-callable NUMBER whose mantissa's low 48 bits happen to
+// form an in-range address (e.g. `1e-8` → 0x798E_E230_8C3A) passed the
+// runtime's range check and faulted on the closure-header read.
+//
+// We compare byte-for-byte against `node --experimental-strip-types`, so we
+// normalize on `instanceof TypeError` rather than the engine-specific error
+// text (Node: "g is not a function" vs Perry: "value is not a function").
+
+function callThrows(label: string, f: () => void): void {
+  try {
+    f();
+    console.log(label + " -> NO THROW");
+  } catch (e) {
+    console.log(label + " -> " + (e instanceof TypeError ? "TypeError" : String(e)));
+  }
+}
+
+// Numbers whose low-48 mantissa bits form an in-range "pointer" (the crashing
+// cases) and ones that mask to zero (already threw). All must throw TypeError.
+callThrows("1e-8()", () => {
+  const g: any = (() => 1e-8)();
+  g(1);
+});
+callThrows("Math.PI()", () => {
+  const g: any = (() => Math.PI)();
+  g();
+});
+callThrows("0xf0001-scaled()", () => {
+  const g: any = (() => 0xf0001 * 1e-300)();
+  g();
+});
+callThrows("5()", () => {
+  const g: any = (() => 5)();
+  g(1, 2);
+});
+callThrows("2.5()", () => {
+  const g: any = (() => 2.5)();
+  g();
+});
+// >16 args routes through the `js_closure_call_array` branch, which was also
+// switched to the checked unbox — exercise it with a crashing-shaped number.
+callThrows("1e-8(17 args)", () => {
+  const g: any = (() => 1e-8)();
+  g(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17);
+});
+
+// Other non-callable primitives.
+callThrows('"hi"()', () => {
+  const g: any = (() => "hi")();
+  g();
+});
+callThrows("true()", () => {
+  const g: any = (() => true)();
+  g();
+});
+callThrows("undefined()", () => {
+  const g: any = (() => undefined)();
+  g();
+});
+callThrows("null()", () => {
+  const g: any = (() => null)();
+  g();
+});
+
+// Valid callables (dynamically typed) must still dispatch correctly.
+const add: any = (a: number, b: number) => a + b;
+console.log("add(40, 2) =", add(40, 2));
+
+const noArg: any = () => "ok";
+console.log("noArg() =", noArg());
+
+class Counter {
+  v = 7;
+  get(): number {
+    return this.v;
+  }
+}
+const c = new Counter();
+const bound: any = c.get.bind(c);
+console.log("bound() =", bound());
+
+console.log("survived all calls");


### PR DESCRIPTION
## Summary

Combines the two fixes from #5507 and #5510 onto a single branch, with their `cargo fmt` lint failures resolved and both tests verified byte-for-byte against `node --experimental-strip-types`.

### #5504 — throw `TypeError` when calling a non-callable number instead of SIGSEGV
The dynamic call-emission fallthrough masked the callee's low 48 bits and handed them to `js_closure_callN` as a `*const ClosureHeader` **without checking the NaN-box tag**. A non-callable number whose mantissa's low 48 bits form an in-range address (e.g. `1e-8` → `0x798E_E230_8C3A`) passed `get_valid_func_ptr`'s range check and faulted on the header read.

- New runtime helper `js_closure_unbox_callee_checked(f64) -> i64` (`perry-runtime/src/closure/dispatch.rs`): throws `throw_not_callable()` for any non-`POINTER_TAG` value and returns the masked closure pointer otherwise.
- Both arity branches of the fallthrough (`<=16` args and the `js_closure_call_array` `>16` path) route through it.
- Test: `test-files/test_issue_5504_noncallable_number_call.ts` (normalizes on `instanceof TypeError`).

### #5437 — dispatch class-ref static data-property method calls
`C.viaFn()` returned `undefined`/`null` when the receiver reached the call site as a class-reference value (INT32-tagged class id) **and** `viaFn` was a static **data** property holding a callable. Such statics live in `CLASS_DYNAMIC_PROPS`, not the static-method vtable, so the existing arm missed them; a class ref isn't a heap object, so the generic field-scan couldn't deref it.

- New `else if` arm in `js_native_call_method` resolves the property via `js_object_get_field_by_name` (the class-ref-aware getter) and, if it's a closure, invokes it with `this` bound to the class ref.
- Test: `test-files/test_gap_5437_class_ref_static_closure_method.ts`.

## Validation

- `cargo fmt --all --check`: clean (this was the failing `lint` check on both source PRs).
- Both new tests compile and run **byte-for-byte** identical to `node --experimental-strip-types`.
- `cargo clippy` on `perry-runtime`/`perry-codegen`: no new warnings or errors from these changes.

No version bump / CHANGELOG entry — left for merge time per the maintainer convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cb9u3bj1efZgYb5kuUNzDn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic function-call safety: invalid non-callable values are now reliably rejected with `TypeError` instead of risking unsafe closure-pointer reads.
* **New Features**
  * Added support for calling captured closures stored in class static properties as methods on returned classes.
* **Tests**
  * Added regression coverage for safer non-callable numeric calls and for class static closure method invocation behavior across multiple receiver shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->