### PR TITLE
fix(typed-feedback): bound representation-invalidation scan to avoid O(n²) startup hang

### DIFF
--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -1859,6 +1859,18 @@ pub(crate) fn invalidate_method_change(class_id: u32) {
     }
 }
 
+/// Upper bound on the cumulative `O(sites)` scan work spent across all
+/// [`invalidate_representation_change`] calls. A large object/array built
+/// incrementally (a startup spread that sets thousands of properties) triggers
+/// a representation-invalidation scan on *every* layout transition; with a big
+/// feedback registry that becomes `O(N²)` and effectively hangs the process.
+/// The scan only updates per-site deopt counters, and every speculative site
+/// re-guards its representation at runtime (`js_typed_feedback_record_guard_*`),
+/// so once the estimated total scan work exceeds this budget the scan can be
+/// skipped without affecting correctness — churny sites simply deopt less
+/// eagerly while their runtime guards still catch any representation mismatch.
+const REPRESENTATION_INVALIDATION_SCAN_BUDGET: u64 = 50_000_000;
+
 pub(crate) fn invalidate_representation_change(obj_addr: usize) {
     if obj_addr == 0 {
         return;
@@ -1866,6 +1878,15 @@ pub(crate) fn invalidate_representation_change(obj_addr: usize) {
     let (shape_addr, class_id, heap_type) = object_shape(obj_addr);
     let mut reg = registry();
     reg.representation_invalidations = reg.representation_invalidations.saturating_add(1);
+    // `representation_invalidations * sites` upper-bounds the cumulative scan
+    // work; past the budget, skip the scan (see the const docs above).
+    if reg
+        .representation_invalidations
+        .saturating_mul(reg.sites.len() as u64)
+        > REPRESENTATION_INVALIDATION_SCAN_BUDGET
+    {
+        return;
+    }
     for site in reg.sites.values_mut() {
         if site.observations.iter().any(|obs| {
             obs.affected_by_representation_change(obj_addr, shape_addr, class_id, heap_type)


### PR DESCRIPTION
## Problem

`invalidate_representation_change` scans **every** feedback site (`for site in reg.sites.values_mut()`) on **each** object/array layout transition. When a large object/array is built incrementally — e.g. a startup lazy-initializer that does a big `[...spread]` / sets thousands of properties — against a large feedback registry, this is **O(n²)** and the process effectively hangs (no error, just spins).

Observed via `sample`: a startup spread spent the bulk of its time in `invalidate_representation_change` (scanning the full site registry per property set). A non-trivial-startup program could not get past init — it ran for 30s+ with no output and was killed.

## Fix

The scan only updates **per-site deopt counters** (an optimization hint). Every speculative site **re-guards its representation at runtime** (`js_typed_feedback_record_guard_pass`/`record_guard_fail`), so skipping the bookkeeping is **correctness-safe**: a site that doesn't get its counter bumped simply stays specialized and its runtime guard catches any representation mismatch (falling back to the generic path).

So once the estimated cumulative scan work (`representation_invalidations × sites`) exceeds a budget, skip the scan. This bounds the total invalidation cost. After the fix, the same startup completes in ~4s and runs to completion instead of hanging.

## Trade-off / follow-up

The budget is a heuristic, and once tripped it disables representation-deopt for the remainder of the process (correctness-safe; churny sites stay specialized with guard fallbacks). A cleaner follow-up is to **index observations by object_addr / shape_addr / array heap_type** so `invalidate_representation_change` is O(affected) instead of O(all sites), keeping deopt fully active. Filing that separately; this change unblocks the immediate hang.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance for large registry operations by implementing a scan-work budget that prevents excessive rescanning in repeated invalidation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->