### PR TITLE
fix(stdlib): #[used] anchor zlib FFI symbols against auto-opt LTO dead-strip

### DIFF
--- a/crates/perry-stdlib/src/zlib.rs
+++ b/crates/perry-stdlib/src/zlib.rs
@@ -206,6 +206,52 @@ pub unsafe extern "C" fn js_zlib_deflate_sync(data_bits: i64, opts: f64) -> *mut
     }
 }
 
+// #5437 / project_autoopt_ffi_symbol_link_break: every zlib FFI entry point is
+// referenced ONLY from generated `.o` files (codegen-emitted calls), never from
+// within perry-stdlib itself. The auto-optimize whole-program LTO therefore
+// dead-strips them from the stdlib archive, breaking the link of any program
+// that uses zlib (surfaced by Next.js's resume-data-cache `inflateSync` once the
+// #5437 live-import fix makes that module reachable). `#[used]` keeps them.
+struct KeepZlibFfi([*const (); 32]);
+// SAFETY: a link-time keepalive anchor only — the pointers are never read or
+// dereferenced, so cross-thread sharing of the raw pointers is sound.
+unsafe impl Sync for KeepZlibFfi {}
+#[used]
+static KEEP_ZLIB_FFI: KeepZlibFfi = KeepZlibFfi([
+    js_zlib_brotli_compress as *const (),
+    js_zlib_brotli_compress_sync as *const (),
+    js_zlib_brotli_decompress as *const (),
+    js_zlib_brotli_decompress_sync as *const (),
+    js_zlib_create_brotli_compress as *const (),
+    js_zlib_create_deflate as *const (),
+    js_zlib_create_deflate_raw as *const (),
+    js_zlib_create_gunzip as *const (),
+    js_zlib_create_gzip as *const (),
+    js_zlib_create_inflate as *const (),
+    js_zlib_create_inflate_raw as *const (),
+    js_zlib_create_unzip as *const (),
+    js_zlib_create_zstd_compress as *const (),
+    js_zlib_create_zstd_decompress as *const (),
+    js_zlib_deflate as *const (),
+    js_zlib_deflate_raw as *const (),
+    js_zlib_deflate_raw_sync as *const (),
+    js_zlib_deflate_sync as *const (),
+    js_zlib_gunzip as *const (),
+    js_zlib_gunzip_sync as *const (),
+    js_zlib_gzip as *const (),
+    js_zlib_gzip_sync as *const (),
+    js_zlib_inflate as *const (),
+    js_zlib_inflate_raw as *const (),
+    js_zlib_inflate_raw_sync as *const (),
+    js_zlib_inflate_sync as *const (),
+    js_zlib_unzip as *const (),
+    js_zlib_unzip_sync as *const (),
+    js_zlib_zstd_compress as *const (),
+    js_zlib_zstd_compress_sync as *const (),
+    js_zlib_zstd_decompress as *const (),
+    js_zlib_zstd_decompress_sync as *const (),
+]);
+
 /// Inflate decompress data synchronously
 /// zlib.inflateSync(data) -> Buffer
 #[no_mangle]


### PR DESCRIPTION
## Problem
The zlib FFI entry points (`js_zlib_{inflate,deflate,gzip,gunzip,brotli_*,zstd_*,create_*}_sync/async` — 32 symbols) are referenced **only from generated `.o` files** (codegen-emitted calls), never from within perry-stdlib itself. The auto-optimize whole-program LTO can dead-strip them from the stdlib archive, breaking the link of any program that uses zlib with an `undefined reference` / `symbol(s) not found` error.

Surfaced while compiling a Next.js standalone bundle whose `resume-data-cache` uses `zlib.inflateSync`: `ld: symbol(s) not found … _js_zlib_inflate_sync`. (This is the same CI-invisible dead-strip class noted in the runtime — generated-code-only symbols need a `#[used]` anchor or the LTO pass drops them.)

## Fix
A `#[used]` static array of the 32 zlib entry points (wrapped in a `Sync` newtype, since the static holds raw `*const ()`) keeps them in the archive across the LTO pass. Link-time anchor only — the pointers are never dereferenced. Mirrors the existing `KEEP_*` anchors in `sqlite.rs`.

## Scope / risk
- One file (`crates/perry-stdlib/src/zlib.rs`), +46 lines, no behavior change.
- Defensive: ensures zlib-using programs link deterministically under auto-optimize.

## Notes
- Code-only PR — version bump + CHANGELOG entry to fold at merge per the usual maintainer flow (happy to add them here if preferred).
- Found during the Next.js standalone (#5437) compile effort; this is an isolated, independently-useful fix (the broader Next.js render chain is a separate, deeper effort).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced compression library compatibility to ensure functions remain available across different build configurations and link-time optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->