### PR TITLE
fix(codegen): box captured+reassigned params & pad forward-ref calls (#5521)

### DIFF
--- a/crates/perry-codegen/src/boxed_vars.rs
+++ b/crates/perry-codegen/src/boxed_vars.rs
@@ -46,6 +46,48 @@ pub(crate) fn collect_boxed_vars(stmts: &[perry_hir::Stmt]) -> HashSet<u32> {
     boxed
 }
 
+/// Determine which *parameter* ids need heap-boxed storage. Mirrors the
+/// (captured AND mutated) rule of `collect_boxed_vars_scope`, but for
+/// function/closure parameters, which never appear in that function's
+/// `declared` (Stmt::Let) set and so were previously never boxed
+/// (boxed_vars.rs's standing "params … we don't box them yet" TODO).
+///
+/// #5521: bcryptjs `_crypt(b, salt, rounds, …)` reassigns `rounds =
+/// (1 << rounds) >>> 0` and the hoisted inner `next()` closure captures
+/// `rounds`. Unboxed, `next()` saw the stale pre-reassignment snapshot
+/// (the original log2 rounds, 12) instead of the live value (4096), so the
+/// key-schedule loop ran 12 iterations and produced a wrong hash.
+///
+/// A param is boxed when it is referenced inside some closure in `body`
+/// AND mutated — either inside a closure or in the enclosing scope. The
+/// synthesized `arguments` param is excluded: it carries its own
+/// mapped-box handling (`materialize_arguments_object`).
+pub(crate) fn collect_boxed_param_ids(
+    params: &[perry_hir::Param],
+    body: &[perry_hir::Stmt],
+) -> HashSet<u32> {
+    let mut out = HashSet::new();
+    if params.is_empty() {
+        return out;
+    }
+    let mut closure_refs: HashSet<u32> = HashSet::new();
+    let mut closure_writes: HashSet<u32> = HashSet::new();
+    collect_closure_refs_and_writes_in_stmts(body, &mut closure_refs, &mut closure_writes);
+    let mut outer_writes: HashSet<u32> = HashSet::new();
+    collect_outer_writes_in_stmts(body, &mut outer_writes);
+    for p in params {
+        if p.arguments_object.is_some() {
+            continue;
+        }
+        if closure_refs.contains(&p.id)
+            && (closure_writes.contains(&p.id) || outer_writes.contains(&p.id))
+        {
+            out.insert(p.id);
+        }
+    }
+    out
+}
+
 fn collect_prealloc_box_ids_in_stmts(stmts: &[perry_hir::Stmt], out: &mut HashSet<u32>) {
     use perry_hir::Stmt;
     for s in stmts {
@@ -282,7 +324,7 @@ fn collect_nested_closure_boxed_vars_in_stmt(stmt: &perry_hir::Stmt, out: &mut H
 fn collect_nested_closure_boxed_vars_in_expr(expr: &perry_hir::Expr, out: &mut HashSet<u32>) {
     use perry_hir::Expr;
     match expr {
-        Expr::Closure { body, .. } => {
+        Expr::Closure { params, body, .. } => {
             // Each closure is its own lexical scope — run the scope
             // analysis on the body, then recurse into any closures
             // that appear inside it. Issue #633 followup: also collect
@@ -293,6 +335,10 @@ fn collect_nested_closure_boxed_vars_in_expr(expr: &perry_hir::Expr, out: &mut H
             // slot would skip `js_box_get`.
             let inner = collect_boxed_vars_scope(body);
             out.extend(inner);
+            // #5521: a closure parameter captured+mutated by a deeper
+            // nested closure needs the same param boxing as a top-level
+            // function param.
+            out.extend(collect_boxed_param_ids(params, body));
             collect_prealloc_box_ids_in_stmts(body, out);
             collect_nested_closure_boxed_vars_in_stmts(body, out);
         }

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -67,7 +67,7 @@ use helpers::{
 };
 
 // Collector and boxing-analysis walkers live in dedicated modules.
-use crate::boxed_vars::{collect_boxed_vars, collect_let_types_in_stmts};
+use crate::boxed_vars::{collect_boxed_param_ids, collect_boxed_vars, collect_let_types_in_stmts};
 use crate::collectors::{collect_closures_in_stmts, collect_let_ids, collect_ref_ids_in_stmts};
 
 pub(super) fn spec_function_length(params: &[perry_hir::Param]) -> usize {
@@ -2041,25 +2041,37 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
     let mut module_boxed_vars: std::collections::HashSet<u32> = std::collections::HashSet::new();
     for f in &hir.functions {
         module_boxed_vars.extend(collect_boxed_vars(&f.body));
+        // #5521: box captured+mutated params (never in the Stmt::Let
+        // `declared` set, so missed by `collect_boxed_vars`).
+        module_boxed_vars.extend(collect_boxed_param_ids(&f.params, &f.body));
     }
     for c in &hir.classes {
         for m in &c.methods {
             module_boxed_vars.extend(collect_boxed_vars(&m.body));
+            module_boxed_vars.extend(collect_boxed_param_ids(&m.params, &m.body));
         }
         for (_, getter_fn) in &c.getters {
             module_boxed_vars.extend(collect_boxed_vars(&getter_fn.body));
+            module_boxed_vars.extend(collect_boxed_param_ids(&getter_fn.params, &getter_fn.body));
         }
         for (_, setter_fn) in &c.setters {
             module_boxed_vars.extend(collect_boxed_vars(&setter_fn.body));
+            module_boxed_vars.extend(collect_boxed_param_ids(&setter_fn.params, &setter_fn.body));
         }
         for sm in &c.static_methods {
             module_boxed_vars.extend(collect_boxed_vars(&sm.body));
+            module_boxed_vars.extend(collect_boxed_param_ids(&sm.params, &sm.body));
         }
         for member in &c.computed_members {
             module_boxed_vars.extend(collect_boxed_vars(&member.function.body));
+            module_boxed_vars.extend(collect_boxed_param_ids(
+                &member.function.params,
+                &member.function.body,
+            ));
         }
         if let Some(ctor) = &c.constructor {
             module_boxed_vars.extend(collect_boxed_vars(&ctor.body));
+            module_boxed_vars.extend(collect_boxed_param_ids(&ctor.params, &ctor.body));
         }
     }
     module_boxed_vars.extend(collect_boxed_vars(&hir.init));

--- a/crates/perry-hir/src/monomorph/defaults.rs
+++ b/crates/perry-hir/src/monomorph/defaults.rs
@@ -4,11 +4,34 @@ use super::*;
 // Default Argument Filling
 // ============================================================================
 
+/// Resolved padding context for a single module: constructor param defaults
+/// keyed by class name, plus free-function fixed-param boundaries keyed by
+/// `FuncId`.
+pub(crate) struct DefaultFill {
+    /// Class name → fixed (pre-rest) constructor param defaults.
+    ctors: HashMap<String, Vec<Option<Expr>>>,
+    /// `FuncId` → `(fill_end, has_synth_args)`. `fill_end` is the rest-param
+    /// position (or the param count when there is no rest) — the boundary up
+    /// to which a `FuncRef` call site pads missing args with `undefined`.
+    /// `has_synth_args` flags callees that materialize `arguments`; those are
+    /// padded by codegen's synth-args path instead, so this pass must skip
+    /// them (#5521 — same contract as the during-lowering padding in
+    /// `lower/expr_call/mod.rs`).
+    funcs: HashMap<FuncId, (usize, bool)>,
+}
+
 /// Fill in default arguments for New expressions where fewer args are provided
-/// than the constructor expects
+/// than the constructor expects, and pad missing trailing args on direct
+/// `FuncRef` calls. The latter closes #5521: HIR lowering pads a call only
+/// when the callee's signature is already registered, so a call to a
+/// *forward-referenced* function (defined later in the module — e.g.
+/// bcryptjs `hashSync` calling `_hash`) left the missing params reading
+/// uninitialized arg registers (a stray `0`). This post-lowering pass has
+/// every function's final shape, so padding no longer depends on source
+/// order.
 pub(crate) fn fill_default_arguments(module: &mut Module) {
     // Build a map of class name -> constructor param defaults
-    let mut ctor_defaults: HashMap<String, Vec<Option<Expr>>> = HashMap::new();
+    let mut ctors: HashMap<String, Vec<Option<Expr>>> = HashMap::new();
     for class in &module.classes {
         if let Some(ref ctor) = class.constructor {
             // Stop at a trailing rest parameter. `constructor(...e)` (or
@@ -25,46 +48,66 @@ pub(crate) fn fill_default_arguments(module: &mut Module) {
                 .take_while(|p| !p.is_rest)
                 .map(|p| p.default.clone())
                 .collect();
-            ctor_defaults.insert(class.name.clone(), defaults);
+            ctors.insert(class.name.clone(), defaults);
         }
     }
 
+    // Build a map of FuncId -> (fill boundary, synth-args flag) for every
+    // free function in the module. Mirrors `lookup_func_defaults`: fill up to
+    // the rest param (or the full param count), and never pad synth-`arguments`
+    // callees (codegen sizes their `arguments` array from the real arg count).
+    let mut funcs: HashMap<FuncId, (usize, bool)> = HashMap::new();
+    for func in &module.functions {
+        let fill_end = func
+            .params
+            .iter()
+            .position(|p| p.is_rest)
+            .unwrap_or(func.params.len());
+        let has_synth_args = func
+            .params
+            .last()
+            .is_some_and(|p| p.arguments_object.is_some());
+        funcs.insert(func.id, (fill_end, has_synth_args));
+    }
+
+    let cx = DefaultFill { ctors, funcs };
+
     // Fill defaults in init statements
-    fill_defaults_in_stmts(&mut module.init, &ctor_defaults);
+    fill_defaults_in_stmts(&mut module.init, &cx);
 
     // Fill defaults in function bodies
     for func in &mut module.functions {
-        fill_defaults_in_stmts(&mut func.body, &ctor_defaults);
+        fill_defaults_in_stmts(&mut func.body, &cx);
     }
 
     // Fill defaults in class methods
     for class in &mut module.classes {
         if let Some(ref mut ctor) = class.constructor {
-            fill_defaults_in_stmts(&mut ctor.body, &ctor_defaults);
+            fill_defaults_in_stmts(&mut ctor.body, &cx);
         }
         for method in &mut class.methods {
-            fill_defaults_in_stmts(&mut method.body, &ctor_defaults);
+            fill_defaults_in_stmts(&mut method.body, &cx);
         }
     }
 }
 
-fn fill_defaults_in_stmts(stmts: &mut [Stmt], ctor_defaults: &HashMap<String, Vec<Option<Expr>>>) {
+fn fill_defaults_in_stmts(stmts: &mut [Stmt], cx: &DefaultFill) {
     for stmt in stmts {
-        fill_defaults_in_stmt(stmt, ctor_defaults);
+        fill_defaults_in_stmt(stmt, cx);
     }
 }
 
-fn fill_defaults_in_stmt(stmt: &mut Stmt, ctor_defaults: &HashMap<String, Vec<Option<Expr>>>) {
+fn fill_defaults_in_stmt(stmt: &mut Stmt, cx: &DefaultFill) {
     match stmt {
         Stmt::Let { init, .. } => {
             if let Some(expr) = init {
-                fill_defaults_in_expr(expr, ctor_defaults);
+                fill_defaults_in_expr(expr, cx);
             }
         }
-        Stmt::Expr(expr) => fill_defaults_in_expr(expr, ctor_defaults),
+        Stmt::Expr(expr) => fill_defaults_in_expr(expr, cx),
         Stmt::Return(expr) => {
             if let Some(e) = expr {
-                fill_defaults_in_expr(e, ctor_defaults);
+                fill_defaults_in_expr(e, cx);
             }
         }
         Stmt::If {
@@ -72,22 +115,22 @@ fn fill_defaults_in_stmt(stmt: &mut Stmt, ctor_defaults: &HashMap<String, Vec<Op
             then_branch,
             else_branch,
         } => {
-            fill_defaults_in_expr(condition, ctor_defaults);
-            fill_defaults_in_stmts(then_branch, ctor_defaults);
+            fill_defaults_in_expr(condition, cx);
+            fill_defaults_in_stmts(then_branch, cx);
             if let Some(else_b) = else_branch {
-                fill_defaults_in_stmts(else_b, ctor_defaults);
+                fill_defaults_in_stmts(else_b, cx);
             }
         }
         Stmt::While { condition, body } => {
-            fill_defaults_in_expr(condition, ctor_defaults);
-            fill_defaults_in_stmts(body, ctor_defaults);
+            fill_defaults_in_expr(condition, cx);
+            fill_defaults_in_stmts(body, cx);
         }
         Stmt::DoWhile { body, condition } => {
-            fill_defaults_in_stmts(body, ctor_defaults);
-            fill_defaults_in_expr(condition, ctor_defaults);
+            fill_defaults_in_stmts(body, cx);
+            fill_defaults_in_expr(condition, cx);
         }
         Stmt::Labeled { body, .. } => {
-            fill_defaults_in_stmt(body, ctor_defaults);
+            fill_defaults_in_stmt(body, cx);
         }
         Stmt::For {
             init,
@@ -96,37 +139,37 @@ fn fill_defaults_in_stmt(stmt: &mut Stmt, ctor_defaults: &HashMap<String, Vec<Op
             body,
         } => {
             if let Some(init_stmt) = init {
-                fill_defaults_in_stmt(init_stmt, ctor_defaults);
+                fill_defaults_in_stmt(init_stmt, cx);
             }
             if let Some(cond) = condition {
-                fill_defaults_in_expr(cond, ctor_defaults);
+                fill_defaults_in_expr(cond, cx);
             }
             if let Some(upd) = update {
-                fill_defaults_in_expr(upd, ctor_defaults);
+                fill_defaults_in_expr(upd, cx);
             }
-            fill_defaults_in_stmts(body, ctor_defaults);
+            fill_defaults_in_stmts(body, cx);
         }
-        Stmt::Throw(expr) => fill_defaults_in_expr(expr, ctor_defaults),
+        Stmt::Throw(expr) => fill_defaults_in_expr(expr, cx),
         Stmt::Try {
             body,
             catch,
             finally,
         } => {
-            fill_defaults_in_stmts(body, ctor_defaults);
+            fill_defaults_in_stmts(body, cx);
             if let Some(ref mut c) = catch {
-                fill_defaults_in_stmts(&mut c.body, ctor_defaults);
+                fill_defaults_in_stmts(&mut c.body, cx);
             }
             if let Some(f) = finally {
-                fill_defaults_in_stmts(f, ctor_defaults);
+                fill_defaults_in_stmts(f, cx);
             }
         }
         Stmt::Switch {
             discriminant,
             cases,
         } => {
-            fill_defaults_in_expr(discriminant, ctor_defaults);
+            fill_defaults_in_expr(discriminant, cx);
             for case in cases {
-                fill_defaults_in_stmts(&mut case.body, ctor_defaults);
+                fill_defaults_in_stmts(&mut case.body, cx);
             }
         }
         Stmt::Break | Stmt::Continue | Stmt::LabeledBreak(_) | Stmt::LabeledContinue(_) => {}
@@ -134,18 +177,18 @@ fn fill_defaults_in_stmt(stmt: &mut Stmt, ctor_defaults: &HashMap<String, Vec<Op
     }
 }
 
-fn fill_defaults_in_expr(expr: &mut Expr, ctor_defaults: &HashMap<String, Vec<Option<Expr>>>) {
+fn fill_defaults_in_expr(expr: &mut Expr, cx: &DefaultFill) {
     match expr {
         Expr::New {
             class_name, args, ..
         } => {
             // First, recurse into the arguments
             for arg in args.iter_mut() {
-                fill_defaults_in_expr(arg, ctor_defaults);
+                fill_defaults_in_expr(arg, cx);
             }
 
             // Check if we need to fill in defaults
-            if let Some(defaults) = ctor_defaults.get(class_name) {
+            if let Some(defaults) = cx.ctors.get(class_name) {
                 let param_count = defaults.len();
                 let arg_count = args.len();
 
@@ -162,16 +205,16 @@ fn fill_defaults_in_expr(expr: &mut Expr, ctor_defaults: &HashMap<String, Vec<Op
         }
         // Recurse into sub-expressions
         Expr::LocalSet(_, val) | Expr::GlobalSet(_, val) => {
-            fill_defaults_in_expr(val, ctor_defaults);
+            fill_defaults_in_expr(val, cx);
         }
         Expr::Binary { left, right, .. }
         | Expr::Compare { left, right, .. }
         | Expr::Logical { left, right, .. } => {
-            fill_defaults_in_expr(left, ctor_defaults);
-            fill_defaults_in_expr(right, ctor_defaults);
+            fill_defaults_in_expr(left, cx);
+            fill_defaults_in_expr(right, cx);
         }
         Expr::Unary { operand, .. } => {
-            fill_defaults_in_expr(operand, ctor_defaults);
+            fill_defaults_in_expr(operand, cx);
         }
         Expr::Update { .. } => {
             // Update expressions (++/--) don't contain sub-expressions
@@ -181,84 +224,101 @@ fn fill_defaults_in_expr(expr: &mut Expr, ctor_defaults: &HashMap<String, Vec<Op
             then_expr,
             else_expr,
         } => {
-            fill_defaults_in_expr(condition, ctor_defaults);
-            fill_defaults_in_expr(then_expr, ctor_defaults);
-            fill_defaults_in_expr(else_expr, ctor_defaults);
+            fill_defaults_in_expr(condition, cx);
+            fill_defaults_in_expr(then_expr, cx);
+            fill_defaults_in_expr(else_expr, cx);
         }
         Expr::Call { callee, args, .. } => {
-            fill_defaults_in_expr(callee, ctor_defaults);
-            for arg in args {
-                fill_defaults_in_expr(arg, ctor_defaults);
+            fill_defaults_in_expr(callee, cx);
+            for arg in args.iter_mut() {
+                fill_defaults_in_expr(arg, cx);
+            }
+            // #5521: pad missing trailing args on a direct call to a known
+            // free function. During-lowering padding (lower/expr_call/mod.rs)
+            // only fires when the callee's signature is already registered, so
+            // a forward-referenced callee (defined later in the module) is left
+            // under-padded and reads uninitialized arg registers. Here every
+            // function shape is final, so pad up to the rest boundary. Skip
+            // synth-`arguments` callees (codegen pads those) and never inflate
+            // a call that already supplies enough args.
+            if let Expr::FuncRef(func_id) = callee.as_ref() {
+                if let Some(&(fill_end, has_synth_args)) = cx.funcs.get(func_id) {
+                    if !has_synth_args {
+                        for _ in args.len()..fill_end {
+                            args.push(Expr::Undefined);
+                        }
+                    }
+                }
             }
         }
         Expr::Array(elements) => {
             for elem in elements {
-                fill_defaults_in_expr(elem, ctor_defaults);
+                fill_defaults_in_expr(elem, cx);
             }
         }
         Expr::Object(fields) => {
             for (_, val) in fields {
-                fill_defaults_in_expr(val, ctor_defaults);
+                fill_defaults_in_expr(val, cx);
             }
         }
         Expr::ObjectSpread { parts } => {
             for (_, val) in parts {
-                fill_defaults_in_expr(val, ctor_defaults);
+                fill_defaults_in_expr(val, cx);
             }
         }
         Expr::IndexGet { object, index } => {
-            fill_defaults_in_expr(object, ctor_defaults);
-            fill_defaults_in_expr(index, ctor_defaults);
+            fill_defaults_in_expr(object, cx);
+            fill_defaults_in_expr(index, cx);
         }
         Expr::IndexSet {
             object,
             index,
             value,
         } => {
-            fill_defaults_in_expr(object, ctor_defaults);
-            fill_defaults_in_expr(index, ctor_defaults);
-            fill_defaults_in_expr(value, ctor_defaults);
+            fill_defaults_in_expr(object, cx);
+            fill_defaults_in_expr(index, cx);
+            fill_defaults_in_expr(value, cx);
         }
         Expr::PropertyGet { object, .. } => {
-            fill_defaults_in_expr(object, ctor_defaults);
+            fill_defaults_in_expr(object, cx);
         }
         Expr::PropertySet { object, value, .. } => {
-            fill_defaults_in_expr(object, ctor_defaults);
-            fill_defaults_in_expr(value, ctor_defaults);
+            fill_defaults_in_expr(object, cx);
+            fill_defaults_in_expr(value, cx);
         }
         Expr::PropertyUpdate { object, .. } => {
-            fill_defaults_in_expr(object, ctor_defaults);
+            fill_defaults_in_expr(object, cx);
         }
         Expr::Await(inner) => {
-            fill_defaults_in_expr(inner, ctor_defaults);
+            fill_defaults_in_expr(inner, cx);
         }
         Expr::TypeOf(inner) => {
-            fill_defaults_in_expr(inner, ctor_defaults);
+            fill_defaults_in_expr(inner, cx);
         }
         Expr::Void(inner) => {
-            fill_defaults_in_expr(inner, ctor_defaults);
+            fill_defaults_in_expr(inner, cx);
         }
         Expr::Yield { value, .. } => {
             if let Some(v) = value {
-                fill_defaults_in_expr(v, ctor_defaults);
+                fill_defaults_in_expr(v, cx);
             }
         }
         Expr::InstanceOf { expr, .. } => {
-            fill_defaults_in_expr(expr, ctor_defaults);
+            fill_defaults_in_expr(expr, cx);
         }
         Expr::Closure { body, .. } => {
-            fill_defaults_in_stmts(body, ctor_defaults);
+            fill_defaults_in_stmts(body, cx);
         }
         Expr::NativeMethodCall { object, args, .. } => {
             if let Some(obj) = object {
-                fill_defaults_in_expr(obj, ctor_defaults);
+                fill_defaults_in_expr(obj, cx);
             }
             for arg in args {
-                fill_defaults_in_expr(arg, ctor_defaults);
+                fill_defaults_in_expr(arg, cx);
             }
         }
         Expr::NativeArenaAlloc(size) | Expr::NativeArenaDispose(size) => {
-            fill_defaults_in_expr(size, ctor_defaults);
+            fill_defaults_in_expr(size, cx);
         }
         Expr::NativeArenaView {
             owner,
@@ -266,9 +326,9 @@ fn fill_defaults_in_expr(expr: &mut Expr, ctor_defaults: &HashMap<String, Vec<Op
             length,
             ..
         } => {
-            fill_defaults_in_expr(owner, ctor_defaults);
-            fill_defaults_in_expr(byte_offset, ctor_defaults);
-            fill_defaults_in_expr(length, ctor_defaults);
+            fill_defaults_in_expr(owner, cx);
+            fill_defaults_in_expr(byte_offset, cx);
+            fill_defaults_in_expr(length, cx);
         }
         Expr::NativePodView {
             owner,
@@ -276,26 +336,26 @@ fn fill_defaults_in_expr(expr: &mut Expr, ctor_defaults: &HashMap<String, Vec<Op
             count,
             ..
         } => {
-            fill_defaults_in_expr(owner, ctor_defaults);
-            fill_defaults_in_expr(byte_offset, ctor_defaults);
-            fill_defaults_in_expr(count, ctor_defaults);
+            fill_defaults_in_expr(owner, cx);
+            fill_defaults_in_expr(byte_offset, cx);
+            fill_defaults_in_expr(count, cx);
         }
         Expr::NativeMemoryFillU32 { view, value } => {
-            fill_defaults_in_expr(view, ctor_defaults);
-            fill_defaults_in_expr(value, ctor_defaults);
+            fill_defaults_in_expr(view, cx);
+            fill_defaults_in_expr(value, cx);
         }
         Expr::NativeMemoryCopy { dst, src } => {
-            fill_defaults_in_expr(dst, ctor_defaults);
-            fill_defaults_in_expr(src, ctor_defaults);
+            fill_defaults_in_expr(dst, cx);
+            fill_defaults_in_expr(src, cx);
         }
         Expr::StaticMethodCall { args, .. } => {
             for arg in args {
-                fill_defaults_in_expr(arg, ctor_defaults);
+                fill_defaults_in_expr(arg, cx);
             }
         }
         Expr::SuperMethodCall { args, .. } => {
             for arg in args {
-                fill_defaults_in_expr(arg, ctor_defaults);
+                fill_defaults_in_expr(arg, cx);
             }
         }
         Expr::ObjectSuperPropertyGet {
@@ -303,13 +363,13 @@ fn fill_defaults_in_expr(expr: &mut Expr, ctor_defaults: &HashMap<String, Vec<Op
             key,
             receiver,
         } => {
-            fill_defaults_in_expr(home, ctor_defaults);
-            fill_defaults_in_expr(key, ctor_defaults);
-            fill_defaults_in_expr(receiver, ctor_defaults);
+            fill_defaults_in_expr(home, cx);
+            fill_defaults_in_expr(key, cx);
+            fill_defaults_in_expr(receiver, cx);
         }
         Expr::SuperPropertySet { key, value, .. } => {
-            fill_defaults_in_expr(key, ctor_defaults);
-            fill_defaults_in_expr(value, ctor_defaults);
+            fill_defaults_in_expr(key, cx);
+            fill_defaults_in_expr(value, cx);
         }
         Expr::ObjectSuperPropertySet {
             home,
@@ -317,10 +377,10 @@ fn fill_defaults_in_expr(expr: &mut Expr, ctor_defaults: &HashMap<String, Vec<Op
             value,
             receiver,
         } => {
-            fill_defaults_in_expr(home, ctor_defaults);
-            fill_defaults_in_expr(key, ctor_defaults);
-            fill_defaults_in_expr(value, ctor_defaults);
-            fill_defaults_in_expr(receiver, ctor_defaults);
+            fill_defaults_in_expr(home, cx);
+            fill_defaults_in_expr(key, cx);
+            fill_defaults_in_expr(value, cx);
+            fill_defaults_in_expr(receiver, cx);
         }
         Expr::ObjectSuperMethodCall {
             home,
@@ -328,22 +388,22 @@ fn fill_defaults_in_expr(expr: &mut Expr, ctor_defaults: &HashMap<String, Vec<Op
             receiver,
             args,
         } => {
-            fill_defaults_in_expr(home, ctor_defaults);
-            fill_defaults_in_expr(key, ctor_defaults);
-            fill_defaults_in_expr(receiver, ctor_defaults);
+            fill_defaults_in_expr(home, cx);
+            fill_defaults_in_expr(key, cx);
+            fill_defaults_in_expr(receiver, cx);
             for arg in args {
-                fill_defaults_in_expr(arg, ctor_defaults);
+                fill_defaults_in_expr(arg, cx);
             }
         }
         Expr::SuperCall(args) => {
             for arg in args {
-                fill_defaults_in_expr(arg, ctor_defaults);
+                fill_defaults_in_expr(arg, cx);
             }
         }
         Expr::JsCallMethod { object, args, .. } => {
-            fill_defaults_in_expr(object, ctor_defaults);
+            fill_defaults_in_expr(object, cx);
             for arg in args {
-                fill_defaults_in_expr(arg, ctor_defaults);
+                fill_defaults_in_expr(arg, cx);
             }
         }
         _ => {}

--- a/crates/perry/tests/issue_5521_bcryptjs_hash.rs
+++ b/crates/perry/tests/issue_5521_bcryptjs_hash.rs
@@ -1,0 +1,117 @@
+//! Regression test for #5521: two codegen bugs that together broke
+//! bcryptjs's Blowfish core (`hashSync` returned `undefined`, then the
+//! cipher computed a wrong digest).
+//!
+//! 1. **Forward-referenced callee not arg-padded.** HIR call-site padding
+//!    pads missing trailing args only when the callee's signature is already
+//!    registered, so a call to a function defined *later* in the module read
+//!    uninitialized arg registers (a stray `0`) for the skipped params.
+//!    bcryptjs: `hashSync` calls the later `_hash`, whose `callback` param
+//!    read as `0` → `typeof callback === 'number'` → async branch → returned
+//!    `undefined`. Fixed by the post-lowering `fill_default_arguments` pass,
+//!    which has every function's final shape and pads regardless of order.
+//!
+//! 2. **Captured + reassigned parameter not boxed.** A parameter captured by
+//!    a (hoisted) nested closure and reassigned in the enclosing scope was
+//!    never heap-boxed (the boxing analysis only considered `Stmt::Let`
+//!    locals), so the hoisted closure read a stale by-value snapshot taken at
+//!    function entry. bcryptjs: `_crypt(b, salt, rounds, …)` does
+//!    `rounds = (1 << rounds) >>> 0` (12 → 4096) and the hoisted `next()`
+//!    closure captures `rounds`; unboxed, `next()` saw 12, so the key
+//!    schedule ran 12 iterations instead of 4096 → wrong hash. Fixed by
+//!    `collect_boxed_param_ids` boxing captured+mutated params.
+//!
+//! This test exercises both bugs directly (no bcryptjs dependency) so it
+//! runs in CI without `node_modules`: the forward-ref arity shape and the
+//! captured-reassigned-parameter shape, including the exact
+//! `(1 << rounds) >>> 0` reassignment bcryptjs uses.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn bcryptjs_hash_core_codegen_shapes() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+
+    std::fs::write(
+        &entry,
+        r#"
+// Bug 1: a forward-referenced callee must still have its missing trailing
+// args padded to `undefined`. `sync` is lowered before `inner` is defined.
+function sync(a, b) {
+  return inner(a, b);
+}
+function inner(a, b, callback, prog) {
+  // `callback`/`prog` were never passed → must read as `undefined`, not 0.
+  return (typeof callback) + "," + (typeof prog);
+}
+console.log("A=" + sync("p", "s"));
+
+// Bug 2: a parameter reassigned in the enclosing scope and captured by a
+// hoisted function declaration must share a boxed cell (closure sees the
+// reassigned value, not the entry snapshot). This is bcryptjs `_crypt`'s
+// exact `rounds = (1 << rounds) >>> 0` shape.
+function crypt(rounds) {
+  rounds = (1 << rounds) >>> 0;     // 12 -> 4096
+  function next() { return rounds; } // hoisted decl capturing `rounds`
+  return next();
+}
+console.log("B=" + crypt(12));
+
+// Plain f64 reassignment captured by a hoisted decl — same boxing path.
+function f(x) {
+  x = x * 2;
+  function g() { return x; }
+  return g();
+}
+console.log("C=" + f(21));
+
+// Loop-driven mutation of a captured parameter (the bcryptjs round loop
+// shape): closure reads the live value across iterations.
+function loop(n) {
+  var acc = 0;
+  function step() { acc = acc + n; }
+  for (var i = 0; i < 4; i++) step();
+  return acc;
+}
+console.log("D=" + loop(10));
+"#,
+    )
+    .expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert_eq!(
+        stdout, "A=undefined,undefined\nB=4096\nC=42\nD=40\n",
+        "forward-ref arg padding (#5521 bug 1) and captured-reassigned-param \
+         boxing (#5521 bug 2) must both hold"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #5521. `bcryptjs@3.0.2` `hashSync()` returned `undefined` under Perry (and `compareSync` then threw `Cannot read properties of undefined (reading 'length')`); once that was fixed, the Blowfish core still computed a **wrong** digest. Root cause is two distinct codegen bugs, each reduced to a minimal repro (no bcryptjs dependency).

### Bug 1 — forward-referenced callee not arg-padded
HIR call-site padding (`lower/expr_call/mod.rs`) pads missing trailing args only when the callee's signature is already registered, so a call to a function **defined later in the module** read uninitialized arg registers (a stray `0`) for the skipped params.

```ts
function sync(a, b) { return inner(a, b); }      // inner defined below
function inner(a, b, callback) {
  return typeof callback === "undefined" ? "sync" : "async";
}
console.log(sync("p", "s"));   // before: "async" (callback === 0)   Node: "sync"
```

bcryptjs: `hashSync` (line 153) calls the later `_hash` (line 1035); `callback` read as `0` → `typeof callback === "number"` → async branch → returned `undefined`.

**Fix:** pad direct `FuncRef` calls in the post-lowering `fill_default_arguments` pass (`monomorph/defaults.rs`), which has every function's final shape, so padding no longer depends on source order. The during-lowering padding still handles backward refs; this tops up forward refs (idempotent — a call already at the fill boundary isn't touched; synth-`arguments` callees are skipped, codegen pads those).

### Bug 2 — captured + reassigned parameter not boxed
A function **parameter** captured by a hoisted nested closure and reassigned in the enclosing scope was never heap-boxed (the boxing analysis only considered `Stmt::Let` locals — a standing "params … we don't box them yet" TODO in `boxed_vars.rs`), so the hoisted closure read a stale by-value snapshot taken at function entry.

```ts
function decl(x) { x = x * 2; function g() { return x; } return g(); }
console.log(decl(5));   // before: 5   Node: 10
```

bcryptjs: `_crypt(b, salt, rounds, …)` does `rounds = (1 << rounds) >>> 0` (12 → 4096) and the hoisted `next()` closure captures `rounds`. Unboxed, `next()` saw `12`, so the key schedule ran 12 iterations instead of 4096 → wrong hash.

**Fix:** `collect_boxed_param_ids` boxes captured+mutated params (same captured-AND-mutated rule as locals). The existing `store_param_slot` codegen path already boxes a param when its id is in the boxed set, so no codegen change is needed — only the analysis gap.

## Verification
- `hashSync(pw, 12)` now matches Node byte-for-byte for a fixed salt; `compareSync(pw, hash)` returns true/false without throwing (end-to-end against the real `bcryptjs` package).
- New `crates/perry/tests/issue_5521_bcryptjs_hash.rs` exercises both shapes (incl. the exact `(1 << rounds) >>> 0` reassignment) with no bcryptjs dependency.
- Regression-checked closure/boxing/arg-padding suites — all green: `issue_4926_boxed_slot_skipped_init`, `issue_4972_derived_class_capture_super`, `issue_5458_request_init_dynamic_method`, `issue_5459_module_global_array_push_in_closure`, `issue_cjs_destructured_var_forward_capture`, `issue_inline_seq_arg_binding_hoist`.

Unblocks pure-JS bcrypt admin login in Verrano CMS. Context: #5485 / #5514.

https://claude.ai/code/session_018PieJ9dS4AFAa2qrWcSKcw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed code generation issues preventing bcryptjs-style hash functions from compiling and running correctly
  * Improved parameter handling in nested closures to correctly reflect value reassignments
  * Corrected default argument padding when calling functions with missing parameters

* **Tests**
  * Added regression tests for bcryptjs hash compilation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->