### PR TITLE
fix(string): #5347 — substr coerces args via ToIntegerOrInfinity

### DIFF
--- a/crates/perry-codegen/src/lower_string_method.rs
+++ b/crates/perry-codegen/src/lower_string_method.rs
@@ -946,9 +946,10 @@ pub(crate) fn lower_string_method(
         "substr" => {
             // Legacy substr(start, length) — distinct from substring/slice:
             // negative start counts from the end, the 2nd arg is a LENGTH, and
-            // a non-positive length yields "". Routed to the dedicated runtime
-            // helper `js_string_substr` (#2897). The length sentinel i32::MIN
-            // signals "argument omitted" (take rest of string).
+            // a non-positive length yields "" while an `undefined` length takes
+            // the rest of the string. Routed to the dedicated runtime helper
+            // `js_string_substr`, which coerces both args via ToIntegerOrInfinity
+            // (#2897).
             if args.is_empty() || args.len() > 2 {
                 bail!(
                     "perry-codegen: String.substr expects 1 or 2 args, got {}",
@@ -963,16 +964,20 @@ pub(crate) fn lower_string_method(
             };
             let blk = ctx.block();
             let recv_handle = unbox_str_handle(blk, &recv_box);
-            let start_i32 = blk.fptosi(DOUBLE, &start_d, I32);
-            let length_i32 = match len_d {
-                Some(len_d) => blk.fptosi(DOUBLE, &len_d, I32),
-                // i32::MIN sentinel = "length omitted".
-                None => i32::MIN.to_string(),
+            // Pass the raw NaN-boxed args straight through: `js_string_substr`
+            // runs `ToIntegerOrInfinity` on both (spec order, start first) so a
+            // boolean / `{ valueOf }` / `Symbol` coerces or throws like Node,
+            // and decides "rest of string" from an `undefined` length itself —
+            // a raw `fptosi` here would mis-truncate NaN and lose that signal.
+            // An omitted length is the explicit `undefined` value.
+            let length_d = match len_d {
+                Some(len_d) => len_d,
+                None => blk.bitcast_i64_to_double(crate::nanbox::TAG_UNDEFINED_I64),
             };
             let result = blk.call(
                 I64,
                 "js_string_substr",
-                &[(I64, &recv_handle), (I32, &start_i32), (I32, &length_i32)],
+                &[(I64, &recv_handle), (DOUBLE, &start_d), (DOUBLE, &length_d)],
             );
             Ok(nanbox_string_inline(blk, &result))
         }

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -61,8 +61,9 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_string_position_to_index", I32, &[DOUBLE]);
     module.declare_function("js_string_slice", I64, &[I64, I32, I32]);
     module.declare_function("js_string_substring", I64, &[I64, I32, I32]);
-    // Legacy substr(start, length); length sentinel i32::MIN = omitted (#2897).
-    module.declare_function("js_string_substr", I64, &[I64, I32, I32]);
+    // Legacy substr(start, length); raw NaN-boxed JS values, ToIntegerOrInfinity
+    // applied in the runtime helper. An `undefined` length means "rest" (#2897).
+    module.declare_function("js_string_substr", I64, &[I64, DOUBLE, DOUBLE]);
     module.declare_function("js_string_split", I64, &[I64, I64]);
     module.declare_function("js_string_split_n", I64, &[I64, I64, I32]);
     // Boxed separator + boxed limit; full ToUint32(limit)/ToString(separator)

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -2694,12 +2694,16 @@ pub unsafe extern "C" fn js_native_call_method(
                     return f64::from_bits(JSValue::string_ptr(r).bits());
                 }
                 "substr" => {
-                    // Legacy substr(start, length); negative start from end,
-                    // 2nd arg is a length. i32::MIN = "length omitted" (#2897).
-                    let start = if args_len >= 1 { arg_i32(0) } else { 0 };
-                    let length = if args_len >= 2 { arg_i32(1) } else { i32::MIN };
+                    // Legacy substr(start, length): negative start counts from
+                    // the end, the 2nd arg is a length, and an `undefined`
+                    // length means "rest of string". `js_string_substr` runs
+                    // ToIntegerOrInfinity on the raw values itself (start before
+                    // length), so pass them through un-coerced (#2897).
+                    let undefined = f64::from_bits(JSValue::undefined().bits());
+                    let start_val = arg_at(0).unwrap_or(undefined);
+                    let length_val = arg_at(1).unwrap_or(undefined);
                     let s = receiver_string();
-                    let r = crate::string::js_string_substr(s, start, length);
+                    let r = crate::string::js_string_substr(s, start_val, length_val);
                     return f64::from_bits(JSValue::string_ptr(r).bits());
                 }
                 "toLocaleLowerCase" => {

--- a/crates/perry-runtime/src/string/slice_ops.rs
+++ b/crates/perry-runtime/src/string/slice_ops.rs
@@ -101,52 +101,63 @@ pub extern "C" fn js_string_substring(
     )
 }
 
-/// Legacy `String.prototype.substr(start, length)`.
+/// Legacy `String.prototype.substr(start, length)` (ECMA-262 Annex B.2.3.1).
 ///
 /// Differs from `substring`/`slice`:
 ///   * a negative `start` counts from the END of the string
-///     (`max(len + start, 0)`),
-///   * the second argument is a LENGTH, not an end index, and a missing /
-///     non-positive length yields the empty string vs. "rest of string" for an
-///     omitted length.
+///     (`max(size + start, 0)`),
+///   * the second argument is a LENGTH, not an end index, and an `undefined`
+///     length (omitted OR explicitly `undefined`) means "to the end of the
+///     string" — distinct from a `0`/non-positive length, which yields `""`.
 ///
-/// `start` and `length` arrive already integer-coerced from codegen. `length`
-/// uses the i32 sentinel `i32::MIN` to mean "argument omitted" — Node treats an
-/// omitted length as "to the end of the string", which a real call site can
-/// never reach with a finite numeric arg (`substr(0, undefined)` coerces the
-/// length to 0, matching JS). Closes #2897.
+/// `start` and `length` arrive as raw NaN-boxed JS values (`f64`). Both are run
+/// through `ToIntegerOrInfinity` *here*, in spec order (start first, then
+/// length), so a boolean / numeric string / `{ valueOf }` object coerces
+/// correctly and a throwing `valueOf` or a `Symbol` propagates its exception —
+/// matching `substring`/`slice`. Doing the coercion in the runtime (rather than
+/// a codegen `fptosi`, which is UB on a NaN) also avoids a sentinel collision: a
+/// `-Infinity` length must clamp to `0` (→ `""`), not be mistaken for "omitted".
+/// `s` is a live argument, so it stays pinned by the conservative stack scan
+/// across the inner `valueOf`. Closes #2897; fixes the substr tail of #5347.
 #[no_mangle]
 pub extern "C" fn js_string_substr(
     s: *const StringHeader,
-    start: i32,
-    length: i32,
+    start_val: f64,
+    length_val: f64,
 ) -> *mut StringHeader {
     if !is_valid_string_ptr(s) {
         return js_string_from_bytes(ptr::null(), 0);
     }
 
-    let len = unsafe { (*s).utf16_len } as i32;
+    let size = unsafe { (*s).utf16_len } as i64;
 
-    // Negative start counts from the end; clamp into [0, len].
-    let start = if start < 0 {
-        (len + start).max(0)
+    // Step 4: ToIntegerOrInfinity(start), observed FIRST. ±Infinity clamps to
+    // the i32 bounds; widen to i64 so `size + i32::MIN` can't overflow below.
+    let int_start = crate::string::js_string_index_to_i32(start_val) as i64;
+    // Steps 5-7: -Infinity / large-negative → max(size + start, 0); else clamp
+    // into [0, size]. (`size + i32::MIN` for -Infinity yields ≤ 0 → 0.)
+    let start = if int_start < 0 {
+        (size + int_start).max(0)
     } else {
-        start.min(len)
+        int_start.min(size)
     };
 
-    // i32::MIN is the "length omitted" sentinel → take the rest of the string.
-    let end = if length == i32::MIN {
-        len
-    } else if length <= 0 {
-        // Non-positive length yields the empty string.
-        return js_string_from_bytes(ptr::null(), 0);
+    // Step 8: an `undefined` length means the rest of the string (`size`);
+    // otherwise ToIntegerOrInfinity(length), observed AFTER start.
+    let int_length = if crate::value::JSValue::from_bits(length_val.to_bits()).is_undefined() {
+        size
     } else {
-        (start as i64 + length as i64).min(len as i64) as i32
+        crate::string::js_string_index_to_i32(length_val) as i64
     };
+    // Step 9: clamp the length into [0, size]. Step 10: end = min(start+len, size).
+    let length = int_length.clamp(0, size);
+    let end = (start + length).min(size);
 
     if start >= end {
         return js_string_from_bytes(ptr::null(), 0);
     }
+    let start = start as i32;
+    let end = end as i32;
 
     // ASCII fast path: byte offsets == UTF-16 offsets.
     // Copy GC-safely: the destination allocation can move/sweep `s` (#5062).
@@ -171,7 +182,7 @@ pub extern "C" fn js_string_substr(
 // so the whole-program auto-optimize bitcode rebuild would dead-strip it
 // without an anchor (see project_auto_optimize_keepalive_3320).
 #[used]
-static KEEP_SUBSTR: extern "C" fn(*const StringHeader, i32, i32) -> *mut StringHeader =
+static KEEP_SUBSTR: extern "C" fn(*const StringHeader, f64, f64) -> *mut StringHeader =
     js_string_substr;
 
 /// JS `TrimString` whitespace set (ECMA-262 §22.1.3.32, `WhiteSpace` +

--- a/test-files/test_gap_string_locale_2781_2845_2897.ts
+++ b/test-files/test_gap_string_locale_2781_2845_2897.ts
@@ -17,6 +17,20 @@ const dyn: any = "hello world";
 console.log(dyn.substr(6, 3)); // "wor"
 console.log(dyn.substr(-5)); // "world"
 
+// ---- #5347: substr argument ToIntegerOrInfinity coercion (test262
+// annexB/built-ins/String/prototype/substr tail) ----
+const t: any = "abc";
+console.log(t.substr(0, false)); // "" (false -> 0)
+console.log(t.substr(1, NaN)); // "" (NaN -> 0)
+console.log(t.substr(0, "")); // "" ("" -> 0)
+console.log(t.substr(0, null)); // "" (null -> 0)
+console.log(t.substr(2, undefined)); // "c" (undefined length -> rest)
+console.log(t.substr(0, Infinity)); // "abc" (+Infinity length -> size)
+console.log(t.substr(0, -Infinity)); // "" (-Infinity length -> 0, not "omitted")
+console.log(t.substr(-Infinity)); // "abc" (-Infinity start -> 0)
+console.log(t.substr("1", "1")); // "b" (numeric-string coercion)
+console.log(t.substr(0, { valueOf: () => 2 })); // "ab" (object valueOf)
+
 // ---- #2781: Turkic dotted/dotless I casing ----
 console.log("I".toLocaleLowerCase("tr")); // "ı"
 console.log("I".toLocaleLowerCase("en")); // "i"


### PR DESCRIPTION
## What

`String.prototype.substr` lowered its `start`/`length` arguments with a raw `fptosi` on the NaN-boxed JS value, instead of routing through the same `ToIntegerOrInfinity` coercion its siblings `slice`/`substring` already use (`js_string_index_to_i32`). `fptosi` is UB on a NaN-box, so non-number arguments were mis-read:

| call | before | Node / after |
|------|--------|------|
| `"abc".substr(0, false)` | `"abc"` | `""` |
| `"abc".substr(0, undefined)` | `""` | `"abc"` |
| `"a".substr(0, -Infinity)` | `"a"` | `""` |
| `"abc".substr(0, {valueOf:()=>2})` | garbage | `"ab"` |
| `"".substr(0, throwingValueOf)` | no throw | throws |
| `"".substr(0, Symbol())` | no throw | `TypeError` |

Root causes: a `false`/`-Infinity` length truncated to `i32::MIN`, which collided with the "length omitted" sentinel (→ mistaken for "rest of string"); an `undefined` length was read as `0` instead of "rest of string"; and a throwing `valueOf` / `Symbol` argument was never coerced, so no exception was raised.

## How

Move the coercion into the runtime `js_string_substr`, which now takes the raw NaN-boxed `f64` args and applies `ToIntegerOrInfinity` in spec order (start first, then length) per ECMA-262 Annex B.2.3.1:

- An `undefined` length (omitted or explicit) means "rest of string"; any other value clamps into `[0, size]`, so a `-Infinity` length yields `""` without colliding with a sentinel.
- `start` is coerced before `length`, so a throwing `start.valueOf` short-circuits before `length` is observed (test262 `start-to-int-err` checks `lengthCallCount === 0`).
- The receiver stays pinned across the inner `valueOf` via the conservative stack scan (it is a live argument).
- Both call sites updated: codegen (`lower_string_method`) and the runtime native-dispatch arm (`native_call_method`).

## Testing

- **test262** `annexB/built-ins/String/prototype/substr`: **8 → 13 pass of 14**. The single remaining failure (`surrogate-pairs`) needs lone-surrogate / WTF-8 support — a known categorical gap listed in CLAUDE.md, out of scope here.
- `built-ins/String/prototype/substring` 100% and `slice` unchanged — no regression in the methods sharing the coercion helper.
- Gap test `test_gap_string_locale_2781_2845_2897.ts` extended with the coercion cases and verified byte-for-byte against `node --experimental-strip-types`.

Chips at the `String` / missed-negatives tail of the #5347 umbrella tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `String.prototype.substr()` to properly coerce and interpret `start` and `length` arguments, ensuring correct handling of edge cases such as `NaN`, `Infinity`, `-Infinity`, and `undefined` per JavaScript specifications.

* **Tests**
  * Enhanced test coverage for `substr()` argument coercion edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->