### PR TITLE
fix(native-module): dynamic require/getBuiltinModule namespaces dispatch object-valued exports

### DIFF
--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -8616,7 +8616,20 @@ unsafe fn vt_get_own_field(
             bound_native_callable_export_value(module_name, property_name).to_bits(),
         ));
     }
-    Some(JSValue::undefined())
+    // Object-valued exports (e.g. `perf_hooks.performance` / `.constants`) are
+    // resolved by the shared per-property dispatch but are not covered by the
+    // override / constant / callable checks above. Without delegating, a DYNAMIC
+    // namespace read (`createRequire(...)("perf_hooks").performance`,
+    // `process.getBuiltinModule(...)`) returned undefined for them while the
+    // static codegen path resolved them via `js_native_module_property_by_name`.
+    // Defer to that authoritative resolver so dynamic namespaces match static.
+    let resolved = js_native_module_property_by_name(
+        module_name.as_ptr(),
+        module_name.len(),
+        key_ptr,
+        key_len,
+    );
+    Some(JSValue::from_bits(resolved.to_bits()))
 }
 
 /// `Object.keys(namespace)` — fresh array of the module's enumerable

--- a/crates/perry/tests/issue_dynamic_native_module_object_exports.rs
+++ b/crates/perry/tests/issue_dynamic_native_module_object_exports.rs
@@ -1,0 +1,94 @@
+//! Dynamic native-module namespaces — those produced by `createRequire(...)(spec)`
+//! and `process.getBuiltinModule(spec)` — must dispatch OBJECT-VALUED exports
+//! (e.g. `perf_hooks.performance` / `perf_hooks.constants`), not only methods
+//! and constructors.
+//!
+//! Before the fix, `vt_get_own_field` resolved overrides / constants / callable
+//! exports but returned `undefined` for object-valued exports, while the static
+//! codegen path resolved them via `js_native_module_property_by_name`. So
+//! `createRequire(...)("perf_hooks").performance` was `undefined` and a later
+//! `.performance.mark(...)` threw `Cannot read properties of undefined (reading
+//! 'mark')`. The fix delegates the fall-through to the authoritative resolver,
+//! so dynamic namespaces match the static path (and preserve singleton identity).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, entry: &std::path::Path) -> (bool, String) {
+    let output = dir.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let run = Command::new(&output).output().expect("run compiled binary");
+    (
+        run.status.success(),
+        String::from_utf8_lossy(&run.stdout).to_string(),
+    )
+}
+
+#[test]
+fn dynamic_native_module_namespace_dispatches_object_valued_exports() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+import { createRequire } from "module";
+const req: any = createRequire(import.meta.url);
+const ph: any = req("perf_hooks");
+
+// Object-valued exports must resolve (not undefined), and methods/ctors still work.
+console.log("performance:", typeof ph.performance);
+console.log("perf.mark:", typeof ph.performance?.mark);
+console.log("constants:", typeof ph.constants);
+console.log("now:", typeof ph.now, "PerformanceObserver:", typeof ph.PerformanceObserver);
+
+// A real call through the object-valued export must not throw.
+ph.performance.mark("test-mark");
+console.log("mark-called: ok");
+
+// Singleton identity: the dynamic and static perf objects are the same object.
+const g: any = require("perf_hooks");
+console.log("identity:", ph.performance === g.performance);
+
+// node: prefix form resolves the same way.
+const ph2: any = req("node:perf_hooks");
+console.log("node-prefix performance:", typeof ph2.performance);
+console.log("DONE");
+"#,
+    )
+    .expect("write entry");
+
+    let (ok, stdout) = compile_and_run(dir.path(), &entry);
+    assert!(ok, "binary failed\nstdout:\n{stdout}");
+    for needle in [
+        "performance: object",
+        "perf.mark: function",
+        "constants: object",
+        "now: function PerformanceObserver: function",
+        "mark-called: ok",
+        "identity: true",
+        "node-prefix performance: object",
+        "DONE",
+    ] {
+        assert!(
+            stdout.contains(needle),
+            "expected `{needle}` in output:\n{stdout}"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

A native-module namespace produced by the **dynamic** resolver — `createRequire(...)(spec)` or `process.getBuiltinModule(spec)` — routes property reads through `vt_get_own_field`, which resolved overrides / constants / callable exports but returned `undefined` for **object-valued** exports (e.g. `perf_hooks.performance`, `perf_hooks.constants`).

The **static** codegen path resolves these via `js_native_module_property_by_name` (the authoritative per-property dispatch — `perf_hooks.performance` → the singleton). So the two paths disagreed:

```js
const req = createRequire(import.meta.url);
req("perf_hooks").performance        // undefined  ❌  (methods/ctors like .now / .PerformanceObserver worked)
require("perf_hooks").performance     // object     ✅  (static)
```

A consumer doing `createRequire(...)("perf_hooks").performance.mark(...)` then threw `Cannot read properties of undefined (reading 'mark')`.

## Fix

Delegate `vt_get_own_field`'s fall-through (previously `Some(undefined)`) to `js_native_module_property_by_name` so a dynamic namespace resolves exactly what the static path resolves. Methods/constructors still short-circuit earlier, so the only behavior change is that object-valued exports now resolve instead of returning undefined. Singleton identity is preserved: `createRequire(...)("perf_hooks").performance === require("perf_hooks").performance`.

## Test

`crates/perry/tests/issue_dynamic_native_module_object_exports.rs` — `createRequire`'s `perf_hooks`: `performance`/`constants` resolve, `now`/`PerformanceObserver` still work, `performance.mark(...)` runs, identity matches static, and the `node:`-prefixed form behaves identically. Full `perry-runtime` lib suite passes single-threaded (1067/1067).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dynamic imports of native modules to correctly handle object-valued exports. Previously, dynamically resolved objects would return undefined instead of the actual exported object. This fix ensures that object exports resolve correctly and maintain proper singleton identity across multiple imports, matching the behavior of static imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->