### PR TITLE
fix(runtime): typed-feedback method dispatch faults on short-string receivers

### DIFF
--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -676,6 +676,21 @@ fn helper_return_facts(bits: u64) -> (usize, u32, u16, u64, u16) {
 fn normalize_raw_object_addr(bits: u64) -> usize {
     let top = bits >> 48;
     let addr = if top >= 0x7FF8 {
+        // NaN-boxed: only POINTER/STRING/BIGINT tags carry a real, dereferenceable
+        // heap address. SHORT_STRING/INT32/primitive/handle pack INLINE data in
+        // the low 48 bits — masking that to an "address" and probing
+        // `addr - header` as a GC object faults. A short (SSO) string receiver
+        // such as `email = "jo"` (inline bytes `0x..6f6a`) reaching
+        // `email.includes("@")` through typed-feedback method dispatch otherwise
+        // dereferences those bytes as a pointer (EXC_BAD_ACCESS in
+        // `object_shape`). Mirrors the heap-pointer check at `value_tag` /
+        // `gc::barrier::decode_heap_addr`. (Heap-allocated receivers hide this;
+        // small-string-optimized values such as `JSON.parse(...).value` expose
+        // it.)
+        let tag = bits & TAG_MASK;
+        if tag != POINTER_TAG && tag != STRING_TAG && tag != BIGINT_TAG {
+            return 0;
+        }
         bits & POINTER_MASK
     } else {
         bits

--- a/crates/perry-runtime/src/typed_feedback/tests.rs
+++ b/crates/perry-runtime/src/typed_feedback/tests.rs
@@ -1272,3 +1272,65 @@ fn typed_feedback_roots_rewrite_shape_observations() {
     assert_eq!(shape_addr, forwarded_user as usize);
     assert_ne!(shape_addr, shape_user as usize);
 }
+
+/// Typed-feedback method dispatch must never dereference a NaN-boxed *inline*
+/// receiver (SHORT_STRING / INT32) as a heap object. Only POINTER / STRING /
+/// BIGINT tags carry a real, dereferenceable heap pointer in the low 48 bits;
+/// SHORT_STRING (small-string optimization) and INT32 pack their payload
+/// inline, so masking that payload to an "address" and probing `addr - header`
+/// in `object_shape` reads unmapped memory and faults.
+///
+/// Regression: a short receiver string such as `email = "jo"` reaching
+/// `email.includes("@")` through native-method dispatch had its inline bytes
+/// (`0x..6f6a`) treated as a pointer and dereferenced (EXC_BAD_ACCESS in
+/// `object_shape`). The guard returns 0 — the "not a GC object" sentinel — for
+/// every non-heap-pointer tag in the NaN-box band, so dispatch falls back to the
+/// safe generic path. Heap pointers (POINTER/STRING/BIGINT) still pass through.
+#[test]
+fn normalize_raw_object_addr_rejects_inline_nanboxed_receivers() {
+    // The inline payloads below are deliberately >= the native-handle band
+    // ceiling (`addr_class::HANDLE_BAND_MAX`, 0x100000) and < 2^48, i.e. they
+    // alias *plausible heap addresses*. That is the case only the tag check
+    // catches: the downstream `is_handle_band` / `addr >> 48` fallbacks already
+    // reject tiny or out-of-range payloads, so a small value like 0x6f6a would
+    // pass this test even without the guard. A real SSO string's inline bytes
+    // can land anywhere in the 48-bit space, including this dereferenceable-
+    // looking range — which is exactly what faulted.
+
+    // SHORT_STRING (SSO): inline UTF-8 bytes in the low 48 bits, NOT a heap
+    // pointer, but a bit pattern that looks like a valid address. Must
+    // normalize to 0 rather than be dereferenced.
+    let sso = crate::value::SHORT_STRING_TAG | 0x0000_5566_7788_99aa;
+    assert_eq!(
+        normalize_raw_object_addr(sso),
+        0,
+        "short-string receiver must not be dereferenced as an object",
+    );
+
+    // INT32: inline integer payload (max i32, well above the handle band).
+    let int32 = crate::value::INT32_TAG | 0x7fff_ffff;
+    assert_eq!(
+        normalize_raw_object_addr(int32),
+        0,
+        "int32 receiver must not be dereferenced as an object",
+    );
+
+    // POINTER: a genuine heap address (above every native-handle band, below
+    // 2^48) is preserved so real object receivers still dispatch natively.
+    let heap_addr: u64 = 0x0000_0001_0000_0000; // 4 GiB — clear of the handle bands
+    let ptr = crate::value::POINTER_TAG | heap_addr;
+    assert_eq!(
+        normalize_raw_object_addr(ptr),
+        heap_addr as usize,
+        "real heap-pointer receiver must pass through unchanged",
+    );
+
+    // STRING: heap string headers are dereferenceable; the tag passes through.
+    let str_addr: u64 = 0x0000_0002_0000_0000;
+    let strv = crate::value::STRING_TAG | str_addr;
+    assert_eq!(
+        normalize_raw_object_addr(strv),
+        str_addr as usize,
+        "heap-string receiver must pass through unchanged",
+    );
+}


### PR DESCRIPTION
## Summary

`normalize_raw_object_addr` — the typed-feedback method-dispatch fast path — treats any NaN-boxed value in the high-tag band as a heap pointer and probes `addr - header` to read its object shape. For NaN-boxed values that pack their payload **inline** (small-string-optimized strings `SHORT_STRING`, and `INT32`), that masks the inline bytes into a bogus address and dereferences them, faulting (`EXC_BAD_ACCESS`) whenever those bytes don't happen to point at mapped memory.

This guards the dispatch so only the tags that carry a real, dereferenceable heap pointer (`POINTER` / `STRING` / `BIGINT`) are normalized to an address; every other high-band tag returns the existing "not a GC object" sentinel (`0`) and dispatch falls back to the safe generic path.

## Changes

- `crates/perry-runtime/src/typed_feedback.rs`: in `normalize_raw_object_addr`, return `0` for any high-band NaN-box tag other than `POINTER`/`STRING`/`BIGINT` before masking to an address. Mirrors the heap-pointer check already used by `value_tag` / `gc::barrier::decode_heap_addr`.
- `crates/perry-runtime/src/typed_feedback/tests.rs`: add `normalize_raw_object_addr_rejects_inline_nanboxed_receivers`, covering `SHORT_STRING` + `INT32` rejection and `POINTER`/`STRING` pass-through. The inline payloads are deliberately above the native-handle band so that only the new tag check — not the pre-existing `is_handle_band` fallback — can reject them.

## Related issue

n/a

## Test plan

```
cargo test -p perry-runtime normalize_raw_object_addr_rejects_inline_nanboxed_receivers
cargo build --release -p perry-runtime
```

Verified the new test **fails without** the guard (the SSO receiver normalizes to its inline payload `0x5566778899AA` instead of `0`) and passes with it, so it genuinely discriminates the fix.

- [x] `cargo build --release` clean (affected crate)
- [ ] `cargo test --workspace …` passes — the affected crate's targeted tests pass; the full workspace has pre-existing, unrelated failures on `main` (`smax.i32` integer cases; a `blocklist_*` test's `TempDir::join` compile break) not touched by this change.
- [x] Added a `#[test]` in the affected crate
- [ ] (if CLI / stdlib / runtime API changed) Updated `docs/src/` — n/a (internal dispatch path only)
- [ ] (if touching a platform UI backend) — n/a

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime handling of NaN-boxed receiver values by tightening validation of inline/primitive patterns, preventing incorrect interpretation as dereferenceable heap addresses.

* **Tests**
  * Added a regression test covering NaN-boxed inline cases to ensure unsafe patterns are rejected while true pointer/string encodings are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->