### PR TITLE
fix(runtime,codegen): demote heap-stored unique strings to shared

### DIFF
--- a/crates/perry-codegen/src/expr/property_set.rs
+++ b/crates/perry-codegen/src/expr/property_set.rs
@@ -220,6 +220,24 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         val_double.clone()
                     };
                     ctx.block().store(DOUBLE, &stored_value, &slot);
+                    // String-alias fix (mirror of `let y = x` in stmt/let_stmt.rs):
+                    // a string-typed local stored into a scalar-replaced field's
+                    // alloca slot aliases the same heap buffer. The runtime
+                    // write-barrier choke point (runtime_store_jsvalue_slot) can't
+                    // see this store because scalar replacement elides the real
+                    // heap object, so mark the buffer shared here. Otherwise a
+                    // later `s = s + suffix` mutates it in-place via
+                    // js_string_append's refcount==1 fast path and corrupts this
+                    // field. Only a `LocalGet` of a string-typed local can carry a
+                    // uniquely-owned buffer (concat/literal results are shared).
+                    if let Expr::LocalGet(src_id) = &**value {
+                        if matches!(ctx.local_types.get(src_id), Some(HirType::String)) {
+                            ctx.block().call_void(
+                                "js_string_addref_if_heap_string",
+                                &[(DOUBLE, &val_double)],
+                            );
+                        }
+                    }
                     let lowered_js = LoweredValue {
                         semantic: SemanticKind::JsValue,
                         rep: NativeRep::JsValue,
@@ -284,6 +302,19 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             val_double.clone()
                         };
                         ctx.block().store(DOUBLE, &stored_value, &slot);
+                        // String-alias fix: see the ScalarObjectFieldSet path
+                        // above. `this.field = s` into a scalar-replaced ctor slot
+                        // aliases the string buffer; mark it shared so a later
+                        // self-append doesn't mutate it in-place and corrupt the
+                        // field.
+                        if let Expr::LocalGet(src_id) = &**value {
+                            if matches!(ctx.local_types.get(src_id), Some(HirType::String)) {
+                                ctx.block().call_void(
+                                    "js_string_addref_if_heap_string",
+                                    &[(DOUBLE, &val_double)],
+                                );
+                            }
+                        }
                         let lowered_js = LoweredValue {
                             semantic: SemanticKind::JsValue,
                             rep: NativeRep::JsValue,

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1072,6 +1072,10 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // local failed clang with "use of undefined value
     // @js_string_addref" — pure linker-visible declaration fix.
     module.declare_function("js_string_addref", VOID, &[I64]);
+    // Tag-checked addref taking a NaN-boxed value (DOUBLE): the scalar-replaced
+    // object-field / array-element stores demote a possibly-unique string source
+    // without materializing SSO strings. Same declaration rationale as above.
+    module.declare_function("js_string_addref_if_heap_string", VOID, &[DOUBLE]);
     module.declare_function("js_bigint_from_string", I64, &[PTR, I32]);
     module.declare_function("js_bigint_from_f64", I64, &[DOUBLE]);
     module.declare_function("js_bigint_cmp", I32, &[I64, I64]);

--- a/crates/perry-runtime/src/gc/barrier.rs
+++ b/crates/perry-runtime/src/gc/barrier.rs
@@ -1177,6 +1177,23 @@ pub(crate) fn runtime_store_jsvalue_slot(
     unsafe {
         std::ptr::write(slot_addr as *mut u64, value_bits);
     }
+    // A heap string stored into an object field / array element is now aliased
+    // from the heap, so a later `js_string_append` must NOT mutate its buffer
+    // in place while this slot still references it. Demote it from "uniquely
+    // owned" (refcount==1) to shared (refcount==0). This realizes the
+    // documented `js_string_addref` contract ("stored into an array/object" —
+    // see string/alloc.rs): codegen wires the local-copy alias case (`let y =
+    // x`) but never the heap-store case, so refcount=1 strings leaked into
+    // object/array slots and were corrupted by the in-place append fast path.
+    // Concretely: code that snapshots a string into a heap slot
+    // (`slot = newState`) and later grows the same buffer via `+=` would have
+    // the in-place append silently rewrite the stored slot, so a later equality
+    // check against the snapshot wrongly saw the two as identical. Every dynamic
+    // object-field and array-element write funnels through here, so this is the
+    // single complete choke point.
+    if value_bits & TAG_MASK == STRING_TAG {
+        crate::string::js_string_addref((value_bits & POINTER_MASK) as *mut crate::StringHeader);
+    }
     layout_note_slot(parent_user, slot_index, value_bits);
     runtime_write_barrier_slot(parent_user, slot_addr, value_bits);
 }

--- a/crates/perry-runtime/src/gc/tests/barrier.rs
+++ b/crates/perry-runtime/src/gc/tests/barrier.rs
@@ -1225,6 +1225,111 @@ fn test_incremental_barrier_marks_array_element_store() {
     remembered_set_clear();
 }
 
+/// Regression: a uniquely-owned (refcount==1) string stored into an object
+/// field or array element must be demoted to shared (refcount==0) by the
+/// write-barrier choke point, so a later `js_string_append` on the original
+/// local allocates fresh instead of mutating the buffer in place and
+/// corrupting the stored alias. The manifesting shape is a heap-stored snapshot
+/// (`slot = s`) whose source is then grown (`s += chunk`): without the demote,
+/// the append rewrites the slot the snapshot still points at, so a later
+/// equality check against the snapshot wrongly sees the two as identical.
+#[test]
+fn test_store_demotes_unique_string_to_shared() {
+    let _guard = GcTestIsolationGuard::new();
+    reset_remembered_set();
+    clear_marks();
+
+    // Build a uniquely-owned string via append (refcount becomes 1).
+    let a = crate::string::js_string_from_bytes(b"john".as_ptr(), 4);
+    let b = crate::string::js_string_from_bytes(b".".as_ptr(), 1);
+    let unique = crate::string::js_string_append(a, b);
+    assert_eq!(
+        unsafe { (*unique).refcount },
+        1,
+        "js_string_append yields a uniquely-owned string"
+    );
+
+    // Store it into an object field slot via the choke point under test.
+    let (obj, fields) = unsafe { alloc_old_test_object(1) };
+    mark_user_ptr(obj as usize);
+    runtime_store_jsvalue_slot(
+        obj as usize,
+        fields as usize,
+        0,
+        string_bits(unique as usize),
+    );
+
+    // The fix demotes the stored string to shared (refcount==0).
+    assert_eq!(
+        unsafe { (*unique).refcount },
+        0,
+        "string stored into an object field is demoted to shared"
+    );
+
+    // A subsequent append must allocate fresh and leave the stored buffer intact.
+    let c = crate::string::js_string_from_bytes(b"doe".as_ptr(), 3);
+    let grown = crate::string::js_string_append(unique, c);
+    assert_ne!(
+        grown, unique,
+        "append after store allocates fresh — no in-place mutation of the aliased buffer"
+    );
+    assert_eq!(
+        unsafe { (*unique).byte_len },
+        5,
+        "the stored buffer ('john.') was not grown in place"
+    );
+    let slot_bits = unsafe { std::ptr::read(fields as *const u64) };
+    assert_eq!(
+        slot_bits,
+        string_bits(unique as usize),
+        "the object field still references the original, unmutated string"
+    );
+
+    // Same guarantee for an array element store (shares the choke point).
+    let unique2 = crate::string::js_string_append(
+        crate::string::js_string_from_bytes(b"a".as_ptr(), 1),
+        crate::string::js_string_from_bytes(b"b".as_ptr(), 1),
+    );
+    assert_eq!(unsafe { (*unique2).refcount }, 1);
+    let (arr, elements) = unsafe { alloc_old_test_array(1) };
+    mark_user_ptr(arr as usize);
+    runtime_store_jsvalue_slot(
+        arr as usize,
+        elements as usize,
+        0,
+        string_bits(unique2 as usize),
+    );
+    assert_eq!(
+        unsafe { (*unique2).refcount },
+        0,
+        "string stored into an array element is demoted to shared"
+    );
+
+    // ...and the same in-place-mutation guarantee as the object case above.
+    let d = crate::string::js_string_from_bytes(b"c".as_ptr(), 1);
+    let grown2 = crate::string::js_string_append(unique2, d);
+    assert_ne!(
+        grown2, unique2,
+        "append after array-element store allocates fresh — no in-place mutation of the aliased buffer"
+    );
+    assert_eq!(
+        unsafe { (*unique2).byte_len },
+        2,
+        "the stored array-element buffer ('ab') was not grown in place"
+    );
+    let elem_bits = unsafe { std::ptr::read(elements as *const u64) };
+    assert_eq!(
+        elem_bits,
+        string_bits(unique2 as usize),
+        "the array element still references the original, unmutated string"
+    );
+
+    clear_mark_user_ptr(obj as usize);
+    clear_mark_user_ptr(arr as usize);
+    clear_marks();
+    remembered_set_clear();
+}
+
 #[test]
 fn test_incremental_barrier_marks_closure_capture_store() {
     let _guard = GcTestIsolationGuard::new();

--- a/crates/perry-runtime/src/string/alloc.rs
+++ b/crates/perry-runtime/src/string/alloc.rs
@@ -153,6 +153,22 @@ pub extern "C" fn js_string_addref(s: *mut StringHeader) {
     }
 }
 
+/// Tag-checked [`js_string_addref`] taking a NaN-boxed value: marks the string
+/// shared ONLY when `value` is a heap `STRING_TAG` string. Small-string-optimized
+/// (`SHORT_STRING_TAG`) and non-string values are a no-op — inline strings have
+/// no refcount to demote, and there is no point materializing one to a fresh
+/// heap allocation just to addref-and-discard it. Mirrors the tag gate in
+/// `runtime_store_jsvalue_slot`, so codegen scalar-replaced field / array-element
+/// stores can demote a possibly-unique string source without forcing an SSO heap
+/// allocation for the (common) short-string case.
+#[no_mangle]
+pub extern "C" fn js_string_addref_if_heap_string(value: f64) {
+    let bits = value.to_bits();
+    if bits & crate::value::TAG_MASK == crate::value::STRING_TAG {
+        js_string_addref((bits & crate::value::POINTER_MASK) as *mut StringHeader);
+    }
+}
+
 /// Get string length in UTF-16 code units (JS `.length` semantics)
 #[no_mangle]
 pub extern "C" fn js_string_length(s: *const StringHeader) -> u32 {

--- a/crates/perry-runtime/src/string/mod.rs
+++ b/crates/perry-runtime/src/string/mod.rs
@@ -43,9 +43,9 @@ mod tests;
 // Explicit named re-exports — preserve the original `crate::string::*`
 // surface 1:1. NO glob re-exports.
 pub use alloc::{
-    js_string_addref, js_string_builder_new, js_string_from_bytes, js_string_from_bytes_longlived,
-    js_string_from_bytes_with_capacity, js_string_from_wtf8_bytes, js_string_length,
-    js_string_materialize_to_heap, js_string_new_sso,
+    js_string_addref, js_string_addref_if_heap_string, js_string_builder_new, js_string_from_bytes,
+    js_string_from_bytes_longlived, js_string_from_bytes_with_capacity, js_string_from_wtf8_bytes,
+    js_string_length, js_string_materialize_to_heap, js_string_new_sso,
 };
 pub use append::js_string_append;
 pub use base64_codec::{js_atob, js_btoa};

--- a/crates/perry/tests/string_append_heap_alias.rs
+++ b/crates/perry/tests/string_append_heap_alias.rs
@@ -1,0 +1,171 @@
+//! Regression: a string built with the in-place `+=` fast path
+//! (`js_string_append`, which mutates a refcount==1 buffer in place) must not
+//! corrupt an alias of that string that has escaped into the GC heap — an
+//! object field or array element.
+//!
+//! Root cause: the in-place optimization is opt-out — a unique (refcount==1)
+//! string is demoted to shared only at *some* alias sites. Codegen wired the
+//! `let y = x` local-copy case but never the heap-store case, so a string
+//! stored into an object field kept refcount==1 and a later `s += chunk`
+//! rewrote the stored field in place.
+//!
+//! It manifests whenever code keeps a heap-stored snapshot of a string and then
+//! keeps growing the source: `slot = s; s += chunk` leaves `slot` pointing at a
+//! buffer the append rewrote, so a later equality check against the snapshot
+//! wrongly sees the two as identical (and any read of the snapshot sees the
+//! grown value).
+//!
+//! Fix: the write-barrier choke point `runtime_store_jsvalue_slot` demotes a
+//! stored unique string to shared (dynamic/escaping object & array stores), and
+//! the scalar-replaced field-store codegen mirrors the `let y = x` addref
+//! (non-escaping object literals whose field stores are inlined).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, entry: &std::path::Path) -> String {
+    let output = dir.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).to_string()
+}
+
+/// Escaping (heap-allocated, dynamic) object field — the snapshot-then-grow
+/// shape. `o.v = s` routes through `js_object_set_field_by_name` →
+/// `runtime_store_jsvalue_slot`, which must demote `s` to shared so the later
+/// `s += "b"` allocates fresh instead of rewriting the stored field.
+#[test]
+fn unique_string_stored_in_dynamic_object_field_is_not_corrupted() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+function makeBox(): { v: string } { return { v: "" }; } // escapes -> dynamic object
+const o = makeBox();
+let s = "";
+s += "a";   // s is uniquely owned (refcount==1) after the in-place append
+o.v = s;    // s escapes into a heap field — must be demoted to shared
+s += "b";   // must NOT mutate o.v in place
+console.log("o.v=" + o.v + " s=" + s);
+"#,
+    )
+    .expect("write entry");
+    let out = compile_and_run(dir.path(), &entry);
+    assert!(
+        out.contains("o.v=a s=ab"),
+        "string stored in a dynamic object field must not be corrupted by a later += (got: {out:?})"
+    );
+}
+
+/// Non-escaping object literal whose field store is scalar-replaced / inlined by
+/// codegen (bypasses the runtime write barrier). The scalar-field-store codegen
+/// must emit the shared-demote.
+///
+/// The strings are deliberately NON-SSO (> 5 bytes) and the stored value is made
+/// uniquely owned (refcount==1) via a first append on a shared literal — only
+/// then does the later in-place `+=` corrupt the stored field without the fix.
+/// (An earlier version used `""`/`"a"`, which are small-string-optimized and
+/// carry no refcount, so it passed even with the codegen reverted.)
+#[test]
+fn unique_string_stored_in_scalar_replaced_field_is_not_corrupted() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+const o = { v: "" };  // never escapes -> scalar-replaced, field store inlined
+let s = "prefix";     // 6 bytes -> heap (non-SSO), shared literal (refcount 0)
+s += "_init";         // append on shared -> fresh heap string, refcount==1
+o.v = s;              // scalar-replaced field store -> must demote s to shared
+s += "_more";         // refcount==1 in-place append -> must NOT corrupt o.v
+console.log("o.v=" + o.v + " s=" + s);
+"#,
+    )
+    .expect("write entry");
+    let out = compile_and_run(dir.path(), &entry);
+    assert!(
+        out.contains("o.v=prefix_init s=prefix_init_more"),
+        "string stored in a scalar-replaced object field must not be corrupted by a later += (got: {out:?})"
+    );
+}
+
+// NOTE: non-escaping ARRAY element stores (`const a = [s]`, `a.push(s)`,
+// `a[i] = s`) have the same aliasing exposure as object fields, but the array
+// store paths are numerous (small-literal `js_array_alloc` + `js_array_push_f64`,
+// the inline bump-allocator, `js_array_from_values`, indexing/splice/…) and span
+// ~9 runtime files. Covering them is tracked as a follow-up rather than bundled
+// here, to keep this change focused on the object-field path it set out to fix.
+
+/// The snapshot-then-grow shape end to end: store the latest value into a heap
+/// field each step, then keep growing the source. Every stored snapshot must
+/// retain the value it had when stored (no in-place rewrite).
+#[test]
+fn stored_snapshots_retain_their_value_across_further_appends() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+function makeBox(): { last: string } { return { last: "" }; }
+const a = makeBox();
+const b = makeBox();
+let cur = "";
+cur += "x"; a.last = cur;   // a.last = "x"
+cur += "y"; b.last = cur;   // b.last = "xy", a.last must still be "x"
+console.log("a=" + a.last + " b=" + b.last + " cur=" + cur);
+"#,
+    )
+    .expect("write entry");
+    let out = compile_and_run(dir.path(), &entry);
+    assert!(
+        out.contains("a=x b=xy cur=xy"),
+        "earlier stored snapshot must not be advanced by later appends (got: {out:?})"
+    );
+}
+
+/// Control: the in-place append optimization must stay correct for the
+/// non-escaping build-loop case it targets (no aliases to corrupt).
+#[test]
+fn non_escaping_build_loop_still_correct() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+let s = "";
+for (let i = 0; i < 5; i++) s += "x";
+console.log("s=" + s + " len=" + s.length);
+"#,
+    )
+    .expect("write entry");
+    let out = compile_and_run(dir.path(), &entry);
+    assert!(
+        out.contains("s=xxxxx len=5"),
+        "non-escaping build loop must remain correct (got: {out:?})"
+    );
+}


### PR DESCRIPTION
## Summary

The in-place string `+=` fast path (`js_string_append`) mutates a uniquely-owned (refcount==1) buffer in place. That demotion-to-shared is opt-out: codegen wired the local-copy alias case (`let y = x`) but never the heap-store case. So a unique string stored into a GC heap slot (object field or array element) kept refcount==1, and a later `s += chunk` on the original local **rewrote the stored slot in place** — corrupting an alias that had already escaped into the heap.

The manifesting shape is a heap-stored snapshot whose source is then grown (`slot = s; s += chunk`): without the demote, the append rewrites the buffer the slot still points at, so a later equality check against the snapshot wrongly sees the two as identical.

## Changes

- `crates/perry-runtime/src/gc/barrier.rs`: `runtime_store_jsvalue_slot` — the single choke point every dynamic object-field and array-element write funnels through — demotes a stored unique string to shared (`js_string_addref`), realizing the documented "stored into an array/object" contract.
- `crates/perry-codegen/src/expr/property_set.rs`: scalar-replaced / inlined field stores bypass the runtime barrier, so the scalar-field-store codegen mirrors the same demote (matching the existing `let y = x` addref).
- `crates/perry-runtime/src/gc/tests/barrier.rs`: unit test `test_store_demotes_unique_string_to_shared`.
- `crates/perry/tests/string_append_heap_alias.rs`: 4 compile-and-run integration cases — escaping (dynamic) object field, scalar-replaced object field, multi-snapshot retention, and a non-escaping build-loop **control** that confirms the in-place optimization stays correct where it has no alias to corrupt.

## Related issue

n/a

## Test plan

```
cargo test -p perry-runtime test_store_demotes_unique_string_to_shared
cargo test -p perry --test string_append_heap_alias
cargo build --release -p perry-runtime -p perry-codegen
```

All 4 integration cases + the unit test pass; the control case confirms the targeted non-escaping build-loop optimization is unaffected.

- [x] `cargo build --release` clean (affected crates)
- [ ] `cargo test --workspace …` passes — the affected crates' targeted tests pass; the full workspace has pre-existing, unrelated failures on `main` (`smax.i32` integer cases; a `blocklist_*` test's `TempDir::join` compile break) not touched by this change.
- [x] Added a `#[test]` (unit) and compile-and-run integration tests under `crates/perry/tests/`
- [ ] (if CLI / stdlib / runtime API changed) Updated `docs/src/` — n/a (internal allocator/codegen behavior)
- [ ] (if touching a platform UI backend) — n/a

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed string lifetime/refcount handling when storing heap strings into object properties and array elements, including scalar-replacement field updates.
  * Ensures unique strings are correctly demoted on slot writes so later `+=` operations don’t corrupt previously stored concatenation snapshots.

* **Tests**
  * Added GC-barrier regression coverage for demotion/aliasing after slot stores.
  * Added end-to-end checks confirming `+=`/in-place concatenation never corrupts stored heap-field snapshots, including scalar-replacement cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->