### PR TITLE
perf(runtime): #5525 — cache typed-array kind + inline fast path for untyped element access

### DIFF
--- a/crates/perry-runtime/src/native_arena.rs
+++ b/crates/perry-runtime/src/native_arena.rs
@@ -7,6 +7,7 @@
 use std::alloc::{alloc_zeroed, dealloc, Layout};
 use std::cell::RefCell;
 use std::ptr;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::typedarray::{self, TypedArrayHeader};
 
@@ -107,7 +108,17 @@ fn unregister_owner(owner: *mut NativeArenaOwnerHeader) {
     });
 }
 
+/// #5525: process-global count of live native typed views. Native arena views
+/// are an exotic perry/ui feature — an ordinary `Int32Array` is never one — but
+/// `is_native_typed_view` is on the hot per-element read path
+/// (`js_typed_array_get`), where it otherwise pays a thread-local
+/// (`_tlv_get_addr`) `RefCell` borrow + hash probe of an almost-always-empty
+/// set. Gating on this counter lets the common case answer "no" with a single
+/// relaxed atomic load and no thread-local access.
+static NATIVE_VIEW_COUNT: AtomicUsize = AtomicUsize::new(0);
+
 fn register_view(view: *mut NativeTypedViewHeader) {
+    NATIVE_VIEW_COUNT.fetch_add(1, Ordering::Relaxed);
     VIEW_REGISTRY.with(|r| {
         r.borrow_mut().insert(view as usize);
     });
@@ -115,9 +126,10 @@ fn register_view(view: *mut NativeTypedViewHeader) {
 }
 
 fn unregister_view(view: *mut NativeTypedViewHeader) {
-    VIEW_REGISTRY.with(|r| {
-        r.borrow_mut().remove(&(view as usize));
-    });
+    let removed = VIEW_REGISTRY.with(|r| r.borrow_mut().remove(&(view as usize)));
+    if removed {
+        NATIVE_VIEW_COUNT.fetch_sub(1, Ordering::Relaxed);
+    }
     typedarray::unregister_typed_array(view as *const TypedArrayHeader);
 }
 
@@ -140,6 +152,11 @@ fn owner_is_registered(owner: *const NativeArenaOwnerHeader) -> bool {
 
 #[inline]
 pub(crate) fn is_native_typed_view(ta: *const TypedArrayHeader) -> bool {
+    // Fast path: no native views exist anywhere → cannot be one, skip the
+    // thread-local set probe entirely (#5525).
+    if NATIVE_VIEW_COUNT.load(Ordering::Relaxed) == 0 {
+        return false;
+    }
     VIEW_REGISTRY.with(|r| r.borrow().contains(&(ta as usize)))
 }
 

--- a/crates/perry-runtime/src/typedarray/mod.rs
+++ b/crates/perry-runtime/src/typedarray/mod.rs
@@ -12,6 +12,7 @@
 use std::alloc::{alloc, Layout};
 use std::cell::RefCell;
 use std::ptr;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::array::ArrayHeader;
 use crate::closure::ClosureHeader;
@@ -150,7 +151,92 @@ thread_local! {
         RefCell::new(crate::fast_hash::new_ptr_hash_set());
 }
 
+/// Process-global, lock-free fast cache in front of the thread-local
+/// `TYPED_ARRAY_REGISTRY` (#5525). A single untyped `arr[i]` element access on
+/// a value whose static type was erased (e.g. a typed array reaching a function
+/// through an untyped `Array.<number>` parameter — the shape bcryptjs's
+/// Blowfish core uses for its `P`/`S` boxes) funnels through
+/// `lookup_typed_array_kind` ~5 times (`js_dyn_index_get`,
+/// `typed_array_addr_from_value`, `typed_array_get_numeric_index`,
+/// `typed_array_owner_length`, `typed_array_owner_get`). Each call is a
+/// thread-local access (`_tlv_get_addr`) plus a `RefCell` borrow + hash probe.
+/// At ~600M element reads for one cost-12 `bcrypt.compareSync` that dominated
+/// the profile (~45% of samples in `_tlv_get_addr`), turning a ~50ms operation
+/// into ~28s and reading as an infinite-loop hang.
+///
+/// The cache is a small direct-mapped table of `(addr << 8) | tag` words (0 =
+/// empty). The low byte is the element kind for a typed array, or the
+/// [`TA_CACHE_NEGATIVE`] sentinel meaning "this address is *not* a typed array".
+/// Negative entries matter because the same dispatcher serves plain-array
+/// element access too (bcryptjs's `_crypt` reads its `lr`/`cdata`/`b`/`salt`
+/// plain-array boxes through the identical untyped path), and without them
+/// every such read would still fall through to the thread-local registry on a
+/// miss. Both populations are small and stable here, so a 64-entry table keeps
+/// the hot typed *and* plain arrays resident.
+///
+/// A hit returns the same answer the registry would: the cache only records
+/// facts the registry established (positive on a registry hit, negative on a
+/// registry miss). It is process-global (not thread-local) so a hit costs no
+/// `_tlv_get_addr`; that is sound because arenas never hand out the same live
+/// address to two threads, a typed array's address is stable (off-heap raw
+/// alloc or tenured old-gen, never moved), and every registry mutation
+/// (`register`/`unregister`) overwrites/clears the matching slot below — so a
+/// freed-then-reused address can never read back a stale kind or a stale
+/// "not a typed array".
+const TA_KIND_CACHE_SLOTS: usize = 64;
+const TA_CACHE_NEGATIVE: u64 = 0xFF;
+static TA_KIND_CACHE: [AtomicU64; TA_KIND_CACHE_SLOTS] =
+    [const { AtomicU64::new(0) }; TA_KIND_CACHE_SLOTS];
+
+#[inline]
+fn ta_kind_cache_slot(addr: usize) -> usize {
+    // Addresses are 8-byte aligned; the low 3 bits are always 0. Use the bits
+    // above them so distinct live arrays (e.g. `P` and `S`) land in different
+    // slots and both stay resident across an alternating access loop.
+    (addr >> 3) & (TA_KIND_CACHE_SLOTS - 1)
+}
+
+#[inline]
+fn ta_kind_cache_store_tag(addr: usize, tag: u64) {
+    // `addr` is always > 0x10000, so `(addr << 8) | tag` is never 0 (= empty).
+    TA_KIND_CACHE[ta_kind_cache_slot(addr)].store(((addr as u64) << 8) | tag, Ordering::Relaxed);
+}
+
+#[inline]
+fn ta_kind_cache_store(addr: usize, kind: u8) {
+    ta_kind_cache_store_tag(addr, kind as u64);
+}
+
+#[inline]
+fn ta_kind_cache_invalidate(addr: usize) {
+    let slot = ta_kind_cache_slot(addr);
+    let entry = TA_KIND_CACHE[slot].load(Ordering::Relaxed);
+    if entry != 0 && (entry >> 8) as usize == addr {
+        TA_KIND_CACHE[slot].store(0, Ordering::Relaxed);
+    }
+}
+
+/// Cache probe: `None` = miss (consult the registry), `Some(None)` = cached
+/// negative ("not a typed array"), `Some(Some(kind))` = cached typed array.
+#[inline]
+fn ta_kind_cache_get(addr: usize) -> Option<Option<u8>> {
+    let entry = TA_KIND_CACHE[ta_kind_cache_slot(addr)].load(Ordering::Relaxed);
+    if entry != 0 && (entry >> 8) as usize == addr {
+        let tag = entry & 0xff;
+        if tag == TA_CACHE_NEGATIVE {
+            Some(None)
+        } else {
+            Some(Some(tag as u8))
+        }
+    } else {
+        None
+    }
+}
+
 pub fn register_typed_array(ptr: *const TypedArrayHeader, kind: u8) {
+    // Keep the cache authoritative: overwrite any colliding/stale slot so a
+    // freed-then-reused address never reads back its previous kind.
+    ta_kind_cache_store(ptr as usize, kind);
     TYPED_ARRAY_REGISTRY.with(|r| {
         r.borrow_mut().insert(ptr as usize, kind);
     });
@@ -158,6 +244,7 @@ pub fn register_typed_array(ptr: *const TypedArrayHeader, kind: u8) {
 
 pub fn unregister_typed_array(ptr: *const TypedArrayHeader) {
     let owner = ptr as usize;
+    ta_kind_cache_invalidate(owner);
     TYPED_ARRAY_REGISTRY.with(|r| {
         r.borrow_mut().remove(&owner);
     });
@@ -172,7 +259,19 @@ pub fn unregister_typed_array(ptr: *const TypedArrayHeader) {
 /// Returns Some(kind) if the (already-stripped) address is a registered
 /// typed array, else None.
 pub fn lookup_typed_array_kind(addr: usize) -> Option<u8> {
-    TYPED_ARRAY_REGISTRY.with(|r| r.borrow().get(&addr).copied())
+    // #5525 fast path: the process-global cache resolves the hot,
+    // repeated-same-address lookups without touching the thread-local
+    // registry. A miss (cold address or direct-mapped eviction) falls back to
+    // the registry and re-populates the slot.
+    if let Some(cached) = ta_kind_cache_get(addr) {
+        return cached;
+    }
+    let kind = TYPED_ARRAY_REGISTRY.with(|r| r.borrow().get(&addr).copied());
+    // Record both outcomes: a typed array (positive) or a confirmed non-typed
+    // address (negative), so repeated plain-array element access stops hitting
+    // the thread-local registry too.
+    ta_kind_cache_store_tag(addr, kind.map_or(TA_CACHE_NEGATIVE, |k| k as u64));
+    kind
 }
 
 /// True for off-GC-heap, header-less allocations — small typed arrays and
@@ -759,6 +858,70 @@ unsafe fn load_at(ta: *const TypedArrayHeader, idx: usize) -> f64 {
             crate::value::js_nanbox_bigint(crate::bigint::js_bigint_from_u64(v) as i64)
         }
         _ => 0.0,
+    }
+}
+
+/// #5525 inline fast read for `obj[i]` when `obj` is dynamically an owning
+/// numeric typed array and `i` a canonical non-negative integer index. Lets
+/// `js_dyn_index_get` collapse the multi-call dynamic-dispatch chain
+/// (`js_typed_array_index_get_dynamic` → `typed_array_index_get_dynamic` →
+/// `typed_array_addr_from_value` → `typed_array_get_numeric_index` →
+/// `typed_array_owner_get` → `js_typed_array_get`) into a single bounds check +
+/// `load_at` on the hot path. Returns `Some(undefined)` for an in-range index
+/// past `length` (spec), `Some(value)` for an in-bounds read, and `None` for
+/// the cases the full dispatcher must still own: BigInt element kinds (whose
+/// read allocates a boxed BigInt) and non-canonical / non-numeric keys
+/// (string/symbol expandos, fractional/negative indices). `kind` is the value
+/// the caller already resolved via `lookup_typed_array_kind`.
+#[inline]
+pub fn typed_array_fast_index_get(ptr: usize, kind: u8, index: f64) -> Option<f64> {
+    if kind == KIND_BIGINT64 || kind == KIND_BIGUINT64 {
+        return None;
+    }
+    if !(index.is_finite() && index >= 0.0 && index.fract() == 0.0 && index <= u32::MAX as f64) {
+        return None;
+    }
+    let ta = ptr as *const TypedArrayHeader;
+    // Native arena views need their liveness validated (the slow path's
+    // `validate_view_alive` throws on a disposed owner); defer those. The check
+    // is a cheap global-counter gate when no native views exist.
+    if crate::native_arena::is_native_typed_view(ta) {
+        return None;
+    }
+    let idx = index as u32;
+    unsafe {
+        if idx >= (*ta).length {
+            return Some(f64::from_bits(crate::value::TAG_UNDEFINED));
+        }
+        Some(load_at(ta, idx as usize))
+    }
+}
+
+/// #5525 inline fast write counterpart to [`typed_array_fast_index_get`].
+/// Returns `true` when the write was fully handled here (an in-bounds store, or
+/// a silently-dropped out-of-bounds canonical-index write — both spec-correct
+/// for integer-indexed exotic objects). Returns `false` to defer to the full
+/// dynamic setter for BigInt element kinds (ToBigInt coercion / throw) and
+/// non-canonical / non-numeric keys (string/symbol expando writes).
+#[inline]
+pub fn typed_array_fast_index_set(ptr: usize, kind: u8, index: f64, value: f64) -> bool {
+    if kind == KIND_BIGINT64 || kind == KIND_BIGUINT64 {
+        return false;
+    }
+    if !(index.is_finite() && index >= 0.0 && index.fract() == 0.0 && index <= u32::MAX as f64) {
+        return false;
+    }
+    let ta = ptr as *mut TypedArrayHeader;
+    if crate::native_arena::is_native_typed_view(ta as *const TypedArrayHeader) {
+        return false;
+    }
+    let idx = index as u32;
+    unsafe {
+        if idx < (*ta).length {
+            store_at(ta, idx as usize, value);
+        }
+        // In-bounds → stored; out-of-bounds canonical index → dropped per spec.
+        true
     }
 }
 

--- a/crates/perry-runtime/src/typedarray_view.rs
+++ b/crates/perry-runtime/src/typedarray_view.rs
@@ -10,6 +10,7 @@
 
 use std::cell::RefCell;
 use std::ptr;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::typedarray::{
     clean_ta_ptr, data_ptr_mut, elem_size_for_kind, js_typed_array_new, name_for_kind,
@@ -167,23 +168,45 @@ pub(crate) struct ViewMeta {
     pub byte_offset: u32,
 }
 
+/// #5525: process-global count of typed arrays that have a `TYPED_ARRAY_VIEW_META`
+/// entry (ArrayBuffer-aliasing or lazily-materialized `.buffer` views). The vast
+/// majority of typed arrays are owning with inline storage and never appear
+/// here, yet `view_backing_data_ptr` is on the hot per-element `data_ptr` path.
+/// `any_view_meta` lets the common case skip the thread-local map probe with one
+/// relaxed atomic load.
+static VIEW_META_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+/// True if any typed array anywhere currently aliases an ArrayBuffer. When
+/// false, no typed array can be a view, so element access can read inline
+/// storage without consulting the (empty) view-meta side table.
+#[inline]
+pub(crate) fn any_view_meta() -> bool {
+    VIEW_META_COUNT.load(Ordering::Relaxed) != 0
+}
+
 /// Record `ta` as aliasing `backing` at `byte_offset`. After this call
 /// `data_ptr(ta)` resolves into the backing store rather than `ta`'s inline
 /// region, so reads/writes are shared with the buffer and every other view.
 pub(crate) fn register_view_meta(ta: *const TypedArrayHeader, backing: usize, byte_offset: u32) {
     TYPED_ARRAY_VIEW_META.with(|r| {
-        r.borrow_mut().insert(
+        let prev = r.borrow_mut().insert(
             ta as usize,
             ViewMeta {
                 backing,
                 byte_offset,
             },
         );
+        if prev.is_none() {
+            VIEW_META_COUNT.fetch_add(1, Ordering::Relaxed);
+        }
     });
 }
 
 #[inline]
 pub(crate) fn view_meta_of(addr: usize) -> Option<ViewMeta> {
+    if !any_view_meta() {
+        return None;
+    }
     TYPED_ARRAY_VIEW_META.with(|r| r.borrow().get(&addr).copied())
 }
 
@@ -203,7 +226,9 @@ pub(crate) fn view_backing_data_ptr(addr: usize) -> Option<*mut u8> {
 /// `unregister_typed_array` when the typed array is collected).
 pub(crate) fn clear_view_meta(addr: usize) {
     TYPED_ARRAY_VIEW_META.with(|r| {
-        r.borrow_mut().remove(&addr);
+        if r.borrow_mut().remove(&addr).is_some() {
+            VIEW_META_COUNT.fetch_sub(1, Ordering::Relaxed);
+        }
     });
 }
 

--- a/crates/perry-runtime/src/value/dyn_index.rs
+++ b/crates/perry-runtime/src/value/dyn_index.rs
@@ -18,6 +18,21 @@ pub extern "C" fn js_dyn_index_get(value: f64, index: f64) -> f64 {
         crate::object::has_own_helpers::throw_to_object_nullish_type_error();
     }
     let jsval = JSValue::from_bits(bits);
+    // #5525 hot fast path: `obj[i]` where `obj` is dynamically an owning numeric
+    // typed array and `i` a canonical index. bcryptjs's Blowfish core reaches
+    // its `Int32Array` P/S boxes through untyped `Array.<number>` params, so
+    // every one of its ~600M element reads lands here. Collapsing the deep
+    // dynamic-dispatch chain into a cached kind lookup + inline `load_at` is the
+    // bulk of the #5525 speedup; non-typed-array and exotic-key cases fall
+    // through to the full dispatch below unchanged.
+    if jsval.is_pointer() {
+        let raw_ptr = (bits & POINTER_MASK) as usize;
+        if let Some(kind) = crate::typedarray::lookup_typed_array_kind(raw_ptr) {
+            if let Some(v) = crate::typedarray::typed_array_fast_index_get(raw_ptr, kind, index) {
+                return v;
+            }
+        }
+    }
     if jsval.is_string() || jsval.is_short_string() {
         let s_ptr = js_get_string_pointer_unified(value) as *const crate::StringHeader;
         if s_ptr.is_null() {
@@ -244,6 +259,20 @@ pub extern "C" fn js_dyn_index_get(value: f64, index: f64) -> f64 {
 pub extern "C" fn js_dyn_index_set(obj: f64, index: f64, value: f64) -> f64 {
     let bits = obj.to_bits();
     let jsval = JSValue::from_bits(bits);
+    // #5525 hot fast path mirroring `js_dyn_index_get` — an owning numeric
+    // typed array with a canonical index stores inline, skipping the dynamic
+    // setter chain. Placed before the `note_object_prototype_index_write`
+    // bookkeeping: that flag only governs plain-array hole/OOB reads, and a
+    // typed array is never a plain array, so the fast-path store does not need
+    // it (the slow path still flips it for the cases it owns).
+    if jsval.is_pointer() {
+        let raw_ptr = (bits & POINTER_MASK) as usize;
+        if let Some(kind) = crate::typedarray::lookup_typed_array_kind(raw_ptr) {
+            if crate::typedarray::typed_array_fast_index_set(raw_ptr, kind, index, value) {
+                return value;
+            }
+        }
+    }
     // `Object.prototype[i] = v` (computed write) makes the index visible
     // through every array's hole/OOB reads — flip the global flag.
     if jsval.is_pointer() {

--- a/crates/perry/tests/issue_5525_typed_array_untyped_index.rs
+++ b/crates/perry/tests/issue_5525_typed_array_untyped_index.rs
@@ -1,0 +1,120 @@
+//! Regression test for #5525: typed-array element access through an *untyped*
+//! receiver (the shape bcryptjs's Blowfish core uses — its `Int32Array` P/S
+//! boxes reach `_encipher`/`_key` as plain `Array.<number>` parameters).
+//!
+//! Such accesses lower to the runtime `js_dyn_index_get` / `js_dyn_index_set`
+//! dispatchers, which previously resolved "is this a typed array, and of what
+//! kind" through the thread-local `TYPED_ARRAY_REGISTRY` on *every* element —
+//! ~5 thread-local lookups per read down a deep dispatch chain. At ~600M reads
+//! for one cost-12 `bcrypt.compareSync` that turned a ~50ms operation into ~28s
+//! (mis-reported as an infinite-loop hang in #5525). The fix adds a process-
+//! global kind cache plus an inline owning-typed-array fast path. This test
+//! pins the *behavioural* correctness of that fast path across element kinds,
+//! bounds, exotic keys, BigInt kinds, and ArrayBuffer-view aliasing — no
+//! bcryptjs dependency, so it runs in CI without `node_modules`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn typed_array_untyped_index_access_is_correct() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+
+    std::fs::write(
+        &entry,
+        r#"
+// Read/write a typed array reached only through untyped params — the access
+// site cannot know the static type, so it goes through the dynamic dispatcher.
+function get(a: any, i: number): any { return a[i]; }
+function set(a: any, i: number, v: any): void { a[i] = v; }
+
+// (A) Int32Array with the exact Blowfish-style bit ops; values must round-trip
+// through the dynamic get/set path bit-for-bit.
+const s = new Int32Array(1024);
+for (let k = 0; k < 1024; k++) set(s, k, (k * 2654435761) | 0);
+let acc = 0;
+for (let k = 0; k < 1024; k++) acc = (acc ^ (get(s, k) >>> 24)) | 0;
+console.log("A=" + acc);
+
+// (B) out-of-bounds and negative reads → undefined; OOB write is dropped.
+console.log("B=" + (get(s, 1024) === undefined) + "," + (get(s, -1) === undefined));
+set(s, 5000, 123); // dropped, must not crash or grow
+console.log("B2=" + (get(s, 5000) === undefined) + "," + get(s, 0));
+
+// (C) per-kind coercion through the untyped store path.
+const u8 = new Uint8Array(4);
+set(u8, 0, 257);            // wraps to 1
+set(u8, 1, -1);            // wraps to 255
+const clamp = new Uint8ClampedArray(2);
+set(clamp, 0, 300);        // clamps to 255
+set(clamp, 1, -5);         // clamps to 0
+const f64a = new Float64Array(2);
+set(f64a, 0, 3.5);
+console.log("C=" + get(u8, 0) + "," + get(u8, 1) + "," + get(clamp, 0) + "," + get(clamp, 1) + "," + get(f64a, 0));
+
+// (D) exotic keys must still resolve as ordinary [[Get]]/[[Set]], NOT elements:
+// `length` reads the real length, a string expando round-trips.
+const anyU8: any = u8;
+anyU8["foo"] = 42;
+console.log("D=" + anyU8["length"] + "," + anyU8["foo"]);
+
+// (E) BigInt kinds (deferred to the full dispatcher) still round-trip a bigint.
+const big = new BigInt64Array(2);
+set(big, 0, 9007199254740993n);
+const bv: any = get(big, 0);
+console.log("E=" + (typeof bv) + "," + bv);
+
+// (F) an ArrayBuffer-backed offset view must still alias the buffer through the
+// dynamic path (the fast path defers buffer-backed views to the slow path).
+const buf = new ArrayBuffer(16);
+const whole = new Int32Array(buf);
+const view = new Int32Array(buf, 4, 2); // elements 1..2 of `whole`
+set(view, 0, 777);
+console.log("F=" + get(whole, 1) + "," + get(view, 0));
+"#,
+    )
+    .expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert_eq!(
+        stdout,
+        "A=116\n\
+         B=true,true\n\
+         B2=true,0\n\
+         C=1,255,255,0,3.5\n\
+         D=4,42\n\
+         E=bigint,9007199254740993\n\
+         F=777,777\n",
+        "typed-array element access through an untyped receiver must match spec \
+         semantics across kinds, bounds, exotic keys, BigInt, and buffer views"
+    );
+}


### PR DESCRIPTION
## What #5525 actually is

#5525 reports bcryptjs `compareSync`/`hashSync` *infinite-looping inside an `async function`*. Investigation shows the premise is wrong on both counts — **it is not an infinite loop, and it is not async-specific.** A cost-12 `bcrypt.compareSync` completes correctly and returns `true`; it is just pathologically slow, and equally slow everywhere:

| call site | time |
|---|---|
| top level | 28.2s |
| plain function | 29.0s |
| inside `async function` (no `await`) | 28.1s |

The reporter waited out the (fast-printing) top-level call and killed the async one early, so it read as a hang. `i` advances monotonically toward `rounds` the whole time — there is no loop that fails to terminate.

## Root cause

bcryptjs's Blowfish core (`_encipher`/`_key`) reaches its `Int32Array` `P`/`S` boxes through **untyped `Array.<number>` parameters**, so every one of its ~600M element reads lowers to the runtime `js_dyn_index_get` dynamic dispatcher instead of an inline typed load. That dispatcher resolved "is this a typed array, of what kind" through the thread-local `TYPED_ARRAY_REGISTRY` **~5 times per read**, down a deep call chain, with two more thread-local side-table probes (`is_native_typed_view`, `view_backing_data_ptr`) inside `data_ptr`. The sampled profile was **~45% in `_tlv_get_addr`** (thread-local access).

## The fix (runtime only)

- **Process-global, lock-free kind cache** in front of `TYPED_ARRAY_REGISTRY` (`lookup_typed_array_kind`), with both positive (kind) and negative ("not a typed array") entries, so repeated access to the same small set of hot typed *and* plain arrays stops touching the thread-local registry. Kept authoritative by `register`/`unregister`; sound because typed-array addresses are stable (off-heap raw alloc or tenured old-gen, never moved) and arenas never alias a live address across threads.
- **Global-counter gates** so `is_native_typed_view` / view-meta lookups answer the common case (no native views, no ArrayBuffer-aliasing views) with one relaxed atomic load and no thread-local probe.
- **Inline owning-typed-array fast path** in `js_dyn_index_get` / `js_dyn_index_set`: bounds check + `load_at`/`store_at`, skipping the whole dispatch chain. BigInt element kinds, native views, and non-canonical / string / symbol keys defer to the full path unchanged.

## Results

| metric | before | after |
|---|---|---|
| `bcrypt.compareSync` cost-12 | 28.2s | **~20.5s** |
| untyped vs typed `Int32Array` index microbench | 1551ms (6.5×) | **1047ms (4.4×)** |
| `_tlv_get_addr` share of samples | 45% | **36%** |

Output is **bit-for-bit unchanged** and the async repro now visibly completes (`A … true` / `B … true`). The remaining gap to native is untyped scalar arithmetic compiling to runtime helper calls (`js_dynamic_string_or_number_add`, `js_number_coerce`) plus per-call overhead — a broader effort, out of scope here. This removes the specific typed-array-registry hot spot.

## Tests

Adds `crates/perry/tests/issue_5525_typed_array_untyped_index.rs`, pinning the behavioural correctness of the fast path through an untyped receiver — element kinds, bounds, OOB drop, `length`/string-expando keys, BigInt round-trip, and ArrayBuffer-view aliasing — validated against the Node oracle. No bcryptjs dependency, so it runs in CI without `node_modules`. Existing `issue_5521_bcryptjs_hash`, `issue_5484_typedarray_iter_after_structured_clone`, `interface_typed_arraylike_method_dispatch`, and the `perry-runtime` typedarray unit tests still pass.

Partially addresses #5525 (reframes it from "async infinite-loop" to typed-array-through-untyped-param perf, and removes the dominant registry hot spot).

> Note for maintainer: per the contributor convention I left the version bump / `CHANGELOG.md` entry out — fold those in at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive regression test for typed array element access, validating correct behavior across multiple element kinds (Int32Array, Uint8Array, Float64Array, BigInt64Array), out-of-bounds scenarios, and aliasing behavior.

* **Refactor**
  * Optimized internal typed array lookup and dynamic element access pathways to reduce overhead on frequently accessed code paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->