### PR TITLE
fix(crypto): value-form async pbkdf2/randomBytes never settle; promisified generateKeyPair shape

### DIFF
--- a/crates/perry-runtime/src/util_promisify.rs
+++ b/crates/perry-runtime/src/util_promisify.rs
@@ -163,6 +163,10 @@ fn register_thunks_once() {
         js_register_closure_arity(callbackify_fulfilled_thunk as *const u8, 1);
         js_register_closure_arity(callbackify_rejected_thunk as *const u8, 1);
         js_register_closure_rest(deprecate_outer_thunk as *const u8, 0);
+        // crypto.generateKeyPair promisify wrapper: outer is a rest function;
+        // inner callback takes `(err, publicKey, privateKey)`.
+        js_register_closure_rest(gkp_outer_thunk as *const u8, 0);
+        js_register_closure_arity(gkp_inner_callback_thunk as *const u8, 3);
         crate::builtins::register_function_name_if_absent(
             deprecate_outer_thunk as *const () as usize,
             "deprecated",
@@ -189,6 +193,29 @@ pub extern "C" fn js_util_promisify(fn_value: f64) -> f64 {
     {
         if module == "child_process" && (method == "exec" || method == "execFile") {
             return crate::child_process::make_promisified_child_process(&method);
+        }
+        // Node attaches a `customPromisifyArgs` of `['publicKey','privateKey']`
+        // to `crypto.generateKeyPair`, so `promisify(generateKeyPair)` resolves
+        // to a `{ publicKey, privateKey }` object rather than the single first
+        // result the general wrapper yields. Without this, the awaited result
+        // is just the public-key PEM string and `result.publicKey` is
+        // undefined. Build a dedicated wrapper whose inner callback collects
+        // the three `(err, publicKey, privateKey)` arguments into that object.
+        if module == "crypto" && method == "generateKeyPair" {
+            register_thunks_once();
+            let scope = crate::gc::RuntimeHandleScope::new();
+            let fn_handle = scope.root_nanbox_f64(fn_value);
+            let closure = js_closure_alloc(gkp_outer_thunk as *const u8, 1);
+            if closure.is_null() {
+                return TAG_UNDEFINED_F64;
+            }
+            let closure_handle = scope.root_raw_mut_ptr(closure);
+            js_closure_set_capture_f64(
+                closure_handle.get_raw_mut_ptr(),
+                0,
+                fn_handle.get_nanbox_f64(),
+            );
+            return nanbox_pointer(closure_handle.get_raw_const_ptr::<ClosureHeader>() as *const u8);
         }
     }
 
@@ -393,6 +420,144 @@ extern "C" fn inner_callback_thunk(closure: *const ClosureHeader, err: f64, valu
     } else {
         js_promise_reject(promise_ptr, err);
     }
+    TAG_UNDEFINED_F64
+}
+
+/// Outer body for `promisify(crypto.generateKeyPair)`. Mirrors
+/// [`outer_thunk`] but installs a 3-arg inner callback so the resolved
+/// value is Node's `{ publicKey, privateKey }` object (via
+/// `customPromisifyArgs`) rather than just the public key.
+extern "C" fn gkp_outer_thunk(closure: *const ClosureHeader, rest_value: f64) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+
+    let fn_value = if closure.is_null() {
+        TAG_UNDEFINED_F64
+    } else {
+        js_closure_get_capture_f64(closure, 0)
+    };
+    let fn_handle = scope.root_nanbox_f64(fn_value);
+
+    let promise_ptr = js_promise_new();
+    if promise_ptr.is_null() {
+        return TAG_UNDEFINED_F64;
+    }
+    let promise_handle = scope.root_raw_mut_ptr(promise_ptr);
+
+    // Inner `(err, publicKey, privateKey)` callback capturing the promise.
+    let cb_closure = js_closure_alloc(gkp_inner_callback_thunk as *const u8, 1);
+    if cb_closure.is_null() {
+        return nanbox_promise(promise_handle.get_raw_mut_ptr());
+    }
+    let cb_handle = scope.root_raw_mut_ptr(cb_closure);
+    js_closure_set_capture_ptr(
+        cb_handle.get_raw_mut_ptr(),
+        0,
+        promise_handle.get_raw_const_ptr::<Promise>() as i64,
+    );
+    let cb_value = nanbox_pointer(cb_handle.get_raw_const_ptr::<ClosureHeader>() as *const u8);
+    let cb_value_handle = scope.root_nanbox_f64(cb_value);
+
+    // Compose `[...rest, inner_cb]` — same shape as `outer_thunk`.
+    let rest_bits = rest_value.to_bits();
+    let rest_arr_ptr = if (rest_bits & TAG_MASK) == POINTER_TAG {
+        (rest_bits & POINTER_MASK) as *const ArrayHeader
+    } else {
+        std::ptr::null()
+    };
+    let rest_len = if rest_arr_ptr.is_null() {
+        0
+    } else {
+        js_array_length(rest_arr_ptr) as usize
+    };
+
+    let mut combined = js_array_alloc((rest_len + 1) as u32);
+    if !rest_arr_ptr.is_null() && rest_len > 0 {
+        let rest_data = unsafe {
+            (rest_arr_ptr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64
+        };
+        for i in 0..rest_len {
+            let v = unsafe { *rest_data.add(i) };
+            combined = js_array_push_f64(combined, v);
+        }
+    }
+    combined = js_array_push_f64(combined, cb_value_handle.get_nanbox_f64());
+    let combined_handle = scope.root_raw_mut_ptr(combined);
+
+    let trap_buf = crate::exception::js_try_push();
+    let jumped = unsafe { setjmp(trap_buf as *mut c_int) };
+    if jumped == 0 {
+        let arr = combined_handle.get_raw_const_ptr::<ArrayHeader>();
+        let data =
+            unsafe { (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64 };
+        let n = js_array_length(arr) as usize;
+        unsafe {
+            crate::closure::js_native_call_value(fn_handle.get_nanbox_f64(), data, n);
+        }
+    } else {
+        let exc = crate::exception::js_get_exception();
+        crate::exception::js_clear_exception();
+        js_promise_reject(promise_handle.get_raw_mut_ptr(), exc);
+    }
+    crate::exception::js_try_end();
+
+    nanbox_promise(promise_handle.get_raw_mut_ptr())
+}
+
+/// Inner callback for the generateKeyPair promisify wrapper:
+/// `(closure, err, publicKey, privateKey)`. On success resolves with a
+/// freshly-built `{ publicKey, privateKey }` object (matching Node's
+/// `customPromisifyArgs`); otherwise rejects with `err`.
+extern "C" fn gkp_inner_callback_thunk(
+    closure: *const ClosureHeader,
+    err: f64,
+    public_key: f64,
+    private_key: f64,
+) -> f64 {
+    if closure.is_null() {
+        return TAG_UNDEFINED_F64;
+    }
+    let promise_ptr = js_closure_get_capture_ptr(closure, 0) as *mut Promise;
+    if promise_ptr.is_null() {
+        return TAG_UNDEFINED_F64;
+    }
+    if !err_is_nullish(err) {
+        js_promise_reject(promise_ptr, err);
+        return TAG_UNDEFINED_F64;
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let promise_handle = scope.root_raw_mut_ptr(promise_ptr);
+    let pub_handle = scope.root_nanbox_f64(public_key);
+    let priv_handle = scope.root_nanbox_f64(private_key);
+
+    let obj = crate::object::js_object_alloc(0, 2);
+    if obj.is_null() {
+        // Fall back to resolving with the public key alone rather than hang.
+        js_promise_resolve(
+            promise_handle.get_raw_mut_ptr(),
+            pub_handle.get_nanbox_f64(),
+        );
+        return TAG_UNDEFINED_F64;
+    }
+    let obj_handle = scope.root_raw_mut_ptr(obj);
+
+    let pub_key = js_string_from_bytes(b"publicKey".as_ptr(), b"publicKey".len() as u32);
+    let pub_key_handle = scope.root_string_ptr(pub_key);
+    crate::object::js_object_set_field_by_name(
+        obj_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>(),
+        pub_key_handle.get_raw_const_ptr::<crate::StringHeader>(),
+        pub_handle.get_nanbox_f64(),
+    );
+    let priv_key = js_string_from_bytes(b"privateKey".as_ptr(), b"privateKey".len() as u32);
+    let priv_key_handle = scope.root_string_ptr(priv_key);
+    crate::object::js_object_set_field_by_name(
+        obj_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>(),
+        priv_key_handle.get_raw_const_ptr::<crate::StringHeader>(),
+        priv_handle.get_nanbox_f64(),
+    );
+
+    let obj_value =
+        nanbox_pointer(obj_handle.get_raw_const_ptr::<crate::object::ObjectHeader>() as *const u8);
+    js_promise_resolve(promise_handle.get_raw_mut_ptr(), obj_value);
     TAG_UNDEFINED_F64
 }
 

--- a/crates/perry-stdlib/src/crypto/random.rs
+++ b/crates/perry-stdlib/src/crypto/random.rs
@@ -297,6 +297,13 @@ pub unsafe extern "C" fn js_crypto_native_dispatch(
         "decapsulate" => pointer_value(js_crypto_decapsulate(arg(0), arg(1)) as *mut u8),
         "randomUUID" => f64::from_bits(JSValue::string_ptr(js_crypto_random_uuid(arg(0))).bits()),
         "randomUUIDv7" => f64::from_bits(JSValue::string_ptr(js_crypto_random_uuidv7()).bits()),
+        // `crypto.randomBytes(size[, callback])`. Reached as a VALUE (named
+        // import / `util.promisify(crypto.randomBytes)`). The 2-arg async form
+        // must invoke `(err, buf)`; without the callback branch the
+        // promisified call returned the buffer synchronously and never
+        // settled, so the awaiting Promise hung. The 1-arg sync form returns
+        // the Buffer directly, matching Node.
+        "randomBytes" if args_len >= 2 => js_crypto_random_bytes_async(arg(0), arg(1)),
         "randomBytes" => {
             let buf = js_crypto_random_bytes_buffer(arg(0));
             f64::from_bits(JSValue::pointer(buf as *const u8).bits())
@@ -338,6 +345,29 @@ pub unsafe extern "C" fn js_crypto_native_dispatch(
             bytes_ptr(3),
             arg(4),
         ) as *mut u8),
+        // `crypto.pbkdf2(password, salt, iterations, keylen, digest, callback)`
+        // reached as a VALUE — a named import (`import { pbkdf2 } from
+        // "crypto"`) or `util.promisify(crypto.pbkdf2)`. The direct
+        // `crypto.pbkdf2(...)` call site is special-cased in codegen
+        // (→ `js_crypto_pbkdf2_async_alg`), but the value-form routes here.
+        // Without this arm the call fell to `_ => undefined`, so the
+        // callback never fired and the awaiting (promisified) Promise hung
+        // forever. Node's async pbkdf2 requires the `digest` arg, so the
+        // callback is the 6th arg (index 5); we still tolerate a missing
+        // digest by treating the last arg as the callback.
+        "pbkdf2" => {
+            // The callback is always the final argument; the digest is the
+            // arg immediately before it when present (>= 6 args).
+            let (digest, callback) = if args_len >= 6 {
+                (str_ptr(4), arg(5))
+            } else {
+                // No digest supplied (rare) — pass a null digest pointer
+                // (the runtime defaults to SHA-256) and take the last arg
+                // as the callback.
+                (0i64, arg(args_len.saturating_sub(1)))
+            };
+            js_crypto_pbkdf2_async_alg(bytes_ptr(0), bytes_ptr(1), arg(2), arg(3), digest, callback)
+        }
         "scrypt" => {
             let callback = if args_len >= 5 { arg(4) } else { arg(3) };
             js_crypto_scrypt_async(bytes_ptr(0), bytes_ptr(1), arg(2), callback)
@@ -734,5 +764,104 @@ mod tests {
         let a = read_uuid_string(js_crypto_random_uuidv7());
         let b = read_uuid_string(js_crypto_random_uuidv7());
         assert_ne!(a, b, "consecutive v7 UUIDs must differ");
+    }
+
+    // Regression: the VALUE-form of async crypto (named-import bare call /
+    // `util.promisify(crypto.pbkdf2)`) routes through
+    // `js_crypto_native_dispatch`, NOT the direct `crypto.pbkdf2(...)`
+    // codegen fast-path. Before the fix, `js_crypto_native_dispatch` had no
+    // `"pbkdf2"` / 2-arg `"randomBytes"` arm, so the call returned `undefined`
+    // and the Node-style `(err, value)` callback never fired — the awaiting
+    // (promisified) Promise hung forever. These tests assert the callback IS
+    // invoked, with a null error and a non-null Buffer result.
+    use std::cell::Cell;
+    thread_local! {
+        static CB_FIRED: Cell<bool> = const { Cell::new(false) };
+        static CB_ERR_NULLISH: Cell<bool> = const { Cell::new(false) };
+        static CB_VALUE_PTR: Cell<bool> = const { Cell::new(false) };
+    }
+
+    extern "C" fn record_cb_thunk(
+        _closure: *const perry_runtime::ClosureHeader,
+        err: f64,
+        value: f64,
+    ) -> f64 {
+        CB_FIRED.with(|f| f.set(true));
+        let err_bits = err.to_bits();
+        CB_ERR_NULLISH.with(|f| {
+            f.set(
+                err_bits == perry_runtime::JSValue::null().bits()
+                    || err_bits == perry_runtime::JSValue::undefined().bits(),
+            )
+        });
+        CB_VALUE_PTR
+            .with(|f| f.set(perry_runtime::JSValue::from_bits(value.to_bits()).is_pointer()));
+        undefined()
+    }
+
+    fn make_record_callback() -> f64 {
+        perry_runtime::closure::js_register_closure_arity(record_cb_thunk as *const u8, 2);
+        let closure = perry_runtime::closure::js_closure_alloc(record_cb_thunk as *const u8, 0);
+        boxed_ptr(closure as *const u8)
+    }
+
+    fn reset_record() {
+        CB_FIRED.with(|f| f.set(false));
+        CB_ERR_NULLISH.with(|f| f.set(false));
+        CB_VALUE_PTR.with(|f| f.set(false));
+    }
+
+    fn js_str(s: &str) -> f64 {
+        let ptr = perry_runtime::js_string_from_bytes(s.as_ptr(), s.len() as u32);
+        f64::from_bits(perry_runtime::JSValue::string_ptr(ptr).bits())
+    }
+
+    #[test]
+    fn native_dispatch_pbkdf2_value_form_fires_callback() {
+        reset_record();
+        let cb = make_record_callback();
+        // pbkdf2(password, salt, iterations, keylen, digest, callback)
+        let args = [
+            js_str("password"),
+            js_str("salt"),
+            1000.0,
+            32.0,
+            js_str("sha256"),
+            cb,
+        ];
+        let method = b"pbkdf2";
+        unsafe {
+            js_crypto_native_dispatch(method.as_ptr(), method.len(), args.as_ptr(), args.len());
+        }
+        assert!(CB_FIRED.with(|f| f.get()), "pbkdf2 callback must fire");
+        assert!(
+            CB_ERR_NULLISH.with(|f| f.get()),
+            "pbkdf2 callback err must be null/undefined"
+        );
+        assert!(
+            CB_VALUE_PTR.with(|f| f.get()),
+            "pbkdf2 callback must deliver a Buffer pointer"
+        );
+    }
+
+    #[test]
+    fn native_dispatch_random_bytes_value_form_fires_callback() {
+        reset_record();
+        let cb = make_record_callback();
+        // randomBytes(size, callback)
+        let args = [16.0, cb];
+        let method = b"randomBytes";
+        unsafe {
+            js_crypto_native_dispatch(method.as_ptr(), method.len(), args.as_ptr(), args.len());
+        }
+        assert!(CB_FIRED.with(|f| f.get()), "randomBytes callback must fire");
+        assert!(
+            CB_ERR_NULLISH.with(|f| f.get()),
+            "randomBytes callback err must be null/undefined"
+        );
+        assert!(
+            CB_VALUE_PTR.with(|f| f.get()),
+            "randomBytes callback must deliver a Buffer pointer"
+        );
     }
 }


### PR DESCRIPTION
## Problem

The **value form** of async crypto never settles its callback, so an `await` on it hangs forever:

```ts
import { pbkdf2 } from "crypto"; import { promisify } from "util";
const dk = await promisify(pbkdf2)("pw", "salt", 10000, 32, "sha256");  // never resolves
```

A program that derives a key / generates a key pair via the named-import or `promisify` form during startup stalls with the event loop idle (the awaiting Promise stays pending, keeping `js_stdlib_has_active_handles` alive).

## Root cause

There are two call shapes:
- **Direct** `crypto.pbkdf2(...)` is special-cased in codegen → `js_crypto_pbkdf2_async_alg` → callback fires. **Worked.**
- **Value form** (`import { pbkdf2 } from "crypto"`, or `promisify(crypto.pbkdf2)`) lowers to a generic `NativeMethodCall{crypto, "pbkdf2"}` routed at runtime through `js_crypto_native_dispatch` (`crypto/random.rs`). That `match` had **no `pbkdf2` arm**, and the `randomBytes` arm **ignored the callback** (returned the buffer synchronously). Both fell to `_ => undefined`, so the `(err, value)` callback never fired.

Secondary: promisified `generateKeyPair` resolved to just the public-key string because Node's `customPromisifyArgs = ['publicKey','privateKey']` wasn't honored.

## Fix

1. `crypto/random.rs` — add a `pbkdf2` dispatch arm (routes to `js_crypto_pbkdf2_async_alg` with correct digest/callback indexing) and a `randomBytes` arm for the `(size, cb)` async form (routes to `js_crypto_random_bytes_async`).
2. `util_promisify.rs` — detect `(crypto, generateKeyPair)` in `js_util_promisify` and return a wrapper that resolves to `{ publicKey, privateKey }` (mirrors the existing `child_process.exec` custom-promisify precedent).

## Verification

Value-form repros all settle: `pbkdf2`, async `randomBytes`, `scrypt`, `generateKeyPair("ec")` and `("rsa",{modulusLength:2048})`, and a `pbkdf2`×100 loop — each via the release binary with hang-guards. `cargo test -p perry-runtime --lib --test-threads=1`: **1067 passed**. Regression tests added (`native_dispatch_pbkdf2_value_form_fires_callback`, `native_dispatch_random_bytes_value_form_fires_callback`).

## Follow-up (not in scope)

Other async crypto methods may share the same value-form gap (e.g. `argon2` has no dispatch arm). Only pbkdf2/randomBytes/scrypt/generateKeyPair are covered here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed `crypto.randomBytes` and `crypto.pbkdf2` callback invocation in promise-based workflows
* Improved async dispatch handling for cryptographic operations

## New Features
* Added promisification support for `crypto.generateKeyPair` to return Promises

<!-- end of auto-generated comment: release notes by coderabbit.ai -->