### PR TITLE
fix(signal): registered signal listeners must not keep the event loop alive (ref-neutral)

### DIFF
--- a/crates/perry-runtime/src/os/signal.rs
+++ b/crates/perry-runtime/src/os/signal.rs
@@ -334,12 +334,30 @@ pub(crate) fn set_process_signal_listener_count(name: &str, count: usize) {
     }
 }
 
+/// Whether a *pending, undelivered* signal is waiting to be drained.
+///
+/// Node semantics: a registered `process.on('SIGINT', …)` listener is
+/// ref-NEUTRAL — it does NOT keep the event loop alive on its own (the
+/// docs' own example calls `process.stdin.resume()` precisely because a
+/// signal listener alone won't keep the process running). The loop must
+/// only be held open when a signal has actually arrived and its
+/// listener callbacks still need to fire on the main thread.
+///
+/// Pre-fix this returned `listeners > 0`, so any CLI that installs a
+/// SIGINT/SIGTERM/SIGHUP handler at startup (the common graceful-shutdown
+/// pattern) pinned the event loop forever: once its real work drained,
+/// the loop had no microtasks/timers/async ops left, yet
+/// `js_stdlib_has_active_handles` kept returning 1 from this check and
+/// the program hung at idle instead of exiting. Now we gate on a pending
+/// signal so the listener registration alone no longer keeps the loop
+/// alive; a delivered signal still wakes the loop via the self-pipe
+/// notify and is drained by `js_process_signal_drain` on the next tick.
 pub(crate) fn has_active_process_signal_listeners() -> bool {
     #[cfg(unix)]
     {
-        PROCESS_SIGNAL_SLOTS
-            .iter()
-            .any(|slot| slot.listeners.load(Ordering::Acquire) > 0)
+        PROCESS_SIGNAL_SLOTS.iter().any(|slot| {
+            slot.pending.load(Ordering::Acquire) > 0 && slot.listeners.load(Ordering::Acquire) > 0
+        })
     }
     #[cfg(not(unix))]
     {

--- a/crates/perry/tests/issue_signal_listener_ref_neutral.rs
+++ b/crates/perry/tests/issue_signal_listener_ref_neutral.rs
@@ -1,0 +1,64 @@
+//! A registered `process.on('SIGINT'|'SIGTERM'|…)` listener must be **ref-neutral**:
+//! per Node, installing a signal listener does NOT keep the event loop alive on its
+//! own (the docs' example calls `process.stdin.resume()` precisely because the
+//! listener alone won't keep the process running). Pre-fix, perry's
+//! `has_active_process_signal_listeners()` returned true for any slot with
+//! `listeners > 0`, so a CLI that installs SIGINT/SIGTERM handlers at startup (the
+//! universal graceful-shutdown pattern) idled forever after its real work drained —
+//! the program hung instead of exiting. This test installs several signal handlers,
+//! does trivial work, and asserts the program EXITS on its own (if the bug is
+//! present, the compiled binary never exits and this test times out).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn signal_listeners_do_not_pin_the_event_loop() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+let count = 0;
+process.on("SIGINT", () => { count++; });
+process.on("SIGTERM", () => { count++; });
+process.on("SIGHUP", () => { count++; });
+// Some async work that completes, then nothing else keeps the loop alive
+// except the (ref-neutral) signal listeners. The program must exit on its own.
+setTimeout(() => {
+  console.log("work done, handlers:", count);
+  console.log("DONE");
+}, 10);
+"#,
+    )
+    .expect("write entry");
+
+    let output = dir.path().join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .args([
+            "compile",
+            entry.to_str().unwrap(),
+            "-o",
+            output.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "compile failed:\n{}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    // If the signal listeners wrongly pinned the loop, this run would never return.
+    let run = Command::new(&output).output().expect("run compiled binary");
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert!(stdout.contains("DONE"), "expected DONE, got:\n{stdout}");
+    assert!(
+        stdout.contains("work done, handlers: 0"),
+        "expected handlers count 0, got:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Problem

A program that installs a signal handler at startup — `process.on('SIGINT'|'SIGTERM'|'SIGHUP'|'SIGCONT', …)`, the universal graceful-shutdown pattern — **hangs forever at idle** instead of exiting once its real work completes. No timers, microtasks, or async ops remain, yet the process never exits.

## Root cause

`has_active_process_signal_listeners()` (`crates/perry-runtime/src/os/signal.rs`) returned `true` for any signal slot with `listeners > 0`. The event-loop liveness umbrella (`js_stdlib_has_active_handles`) consults it, so a mere *registered* listener kept the loop "alive" indefinitely.

This diverges from Node: **a signal listener is ref-neutral** — registering it does not keep the process alive. (Node's own docs example calls `process.stdin.resume()` precisely because a signal listener alone won't keep the process running.)

## Fix

Gate the check on a **pending, undelivered** signal rather than registration:

```rust
PROCESS_SIGNAL_SLOTS.iter().any(|slot| {
    slot.pending.load(Ordering::Acquire) > 0 && slot.listeners.load(Ordering::Acquire) > 0
})
```

Signal *delivery* is unchanged — a delivered signal still wakes the loop via the self-pipe notify and is drained by `js_process_signal_drain` on the next tick (`js_run_stdlib_pump` runs it every tick).

## Test

`crates/perry/tests/issue_signal_listener_ref_neutral.rs` — installs SIGINT/SIGTERM/SIGHUP handlers + does brief async work, and asserts the compiled program **exits on its own** (pre-fix the binary never returns). `cargo test -p perry-runtime --lib`: 1068 passed.

Found while driving a large real-world CLI bundle to run natively: it installs 25 such handlers at startup, so every subcommand hung at idle until this gate was corrected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed signal listener behavior to prevent unnecessary event loop blocking. Signal handlers now correctly allow the application to exit when no signals are pending, aligning with standard event-loop semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->