### PR TITLE
fix(runtime): no-dispatcher method-call fallback returned a signaling NaN, not undefined

### DIFF
--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -179,6 +179,44 @@ fn boxed_promise_value(promise: *mut crate::promise::Promise) -> f64 {
     crate::value::js_nanbox_pointer(promise as i64)
 }
 
+/// PERRY_ITER_BT diagnostic: dump which throw site fired, the offending
+/// value's decoded shape, and a native backtrace. Gated on env var so it has
+/// zero cost in normal builds. Used to localize the bundle's
+/// "Iterator result is not an object" wall.
+pub(crate) fn iter_bt_dump(tag: &str, value: f64) {
+    if std::env::var("PERRY_ITER_BT").is_err() {
+        return;
+    }
+    let bits = value.to_bits();
+    let jv = crate::value::JSValue::from_bits(bits);
+    let raw = crate::value::js_nanbox_get_pointer(value) as usize;
+    let kind = if jv.is_number() {
+        "number"
+    } else if jv.is_int32() {
+        "int32"
+    } else if jv.is_bool() {
+        "bool"
+    } else if jv.is_undefined() {
+        "undefined"
+    } else if jv.is_null() {
+        "null"
+    } else if jv.is_any_string() {
+        "string"
+    } else if jv.is_bigint() {
+        "bigint"
+    } else if jv.is_pointer() {
+        "pointer"
+    } else {
+        "other"
+    };
+    let in_handle_band = crate::value::addr_class::is_handle_band(raw);
+    eprintln!(
+        "[PERRY_ITER_BT] site={tag} bits={bits:#018x} kind={kind} raw={raw:#x} handle_band={in_handle_band}",
+    );
+    let bt = std::backtrace::Backtrace::force_capture();
+    eprintln!("{bt}");
+}
+
 fn async_from_sync_type_error(message: &[u8]) -> f64 {
     let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
     let err = crate::error::js_typeerror_new(msg);
@@ -245,6 +283,7 @@ extern "C" fn async_from_sync_rejected_value(
 fn async_from_sync_continue(iter: f64, step_result: f64, close_on_rejection: bool) -> f64 {
     let ptr = crate::value::js_nanbox_get_pointer(step_result);
     if ptr == 0 {
+        iter_bt_dump("async_from_sync_continue", step_result);
         return async_from_sync_rejected(b"Iterator result is not an object");
     }
 
@@ -795,6 +834,10 @@ fn is_object_like_value(value: f64) -> bool {
 
 #[cold]
 fn throw_iterator_result_not_object() -> ! {
+    iter_bt_dump(
+        "array_throw_iterator_result_not_object",
+        f64::from_bits(crate::value::TAG_UNDEFINED),
+    );
     let msg = b"Iterator result is not an object";
     let msg_str = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
     let err = crate::error::js_typeerror_new(msg_str);
@@ -812,6 +855,7 @@ pub extern "C" fn js_iterator_next_result(iter_f64: f64) -> f64 {
     let result = unsafe { crate::closure::js_native_call_value(next, std::ptr::null(), 0) };
     crate::object::js_implicit_this_set(prev_this);
     if !is_object_like_value(result) {
+        iter_bt_dump("js_iterator_next_result", result);
         throw_iterator_result_not_object();
     }
     result

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -93,6 +93,7 @@ pub use self::iter_object::{
     ARRAY_ITERATOR_CLASS_ID,
 };
 pub(crate) use self::iterator::is_builtin_iterator_class_id;
+pub(crate) use self::iterator::iter_bt_dump;
 pub use self::iterator::{
     js_array_spread_append, js_for_of_to_array, js_get_async_iterator, js_iterator_to_array,
 };

--- a/crates/perry-runtime/src/collection_iter.rs
+++ b/crates/perry-runtime/src/collection_iter.rs
@@ -304,6 +304,7 @@ pub(crate) fn iterator_next_value(iter: f64) -> Option<f64> {
         )
     };
     if !is_entry_object(result) {
+        crate::array::iter_bt_dump("collection_iter_next_value", result);
         throw_type_error("Iterator result is not an object");
     }
     let result_ptr = js_nanbox_get_pointer(result) as *const crate::object::ObjectHeader;

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1681,7 +1681,14 @@ pub unsafe extern "C" fn js_native_call_method(
             let result = func(object, method_name_ptr, method_name_len, args_ptr, args_len);
             return result;
         }
-        return f64::from_bits(0x7FF8_0000_0000_0001); // undefined
+        // No JS-handle dispatcher: return JS `undefined`. The literal must be
+        // TAG_UNDEFINED (0x7FFC_..._0001); an earlier copy used the bit pattern
+        // 0x7FF8_..._0001, which is a *signaling NaN* (a JS number), not
+        // undefined. A method call that fell through here (e.g. an iterator's
+        // `.next()` whose receiver reached this path) then returned that sNaN,
+        // which the `for…of` lazy-loop's `js_iterator_result_validate` rejected
+        // with "Iterator result is not an object".
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
 
     // #4661 follow-up: a *fused* method call `proxy.method(args)` on a Proxy
@@ -2308,7 +2315,11 @@ pub unsafe extern "C" fn js_native_call_method(
                 args.len(),
             );
         }
-        return f64::from_bits(0x7FF8_0000_0000_0001); // undefined
+        // No handle dispatcher registered: return JS `undefined`, NOT the
+        // signaling-NaN bit pattern 0x7FF8_..._0001 (a JS *number*) that a prior
+        // copy of this line used. See the JS-handle fallback above for why the
+        // sNaN surfaced as a spurious "Iterator result is not an object".
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
 
     // #1545: Web Streams handles are returned as `id as f64` (a normal float),
@@ -3021,8 +3032,11 @@ pub unsafe extern "C" fn js_native_call_method(
                     args_len,
                 );
             }
-            // No dispatcher registered, return undefined
-            return f64::from_bits(0x7FF8_0000_0000_0001);
+            // No dispatcher registered, return JS `undefined`. Must be
+            // TAG_UNDEFINED (0x7FFC_..._0001); the bit pattern 0x7FF8_..._0001 a
+            // prior copy used is a signaling NaN (a JS number), which leaks out
+            // as a non-object and trips `js_iterator_result_validate`.
+            return f64::from_bits(crate::value::TAG_UNDEFINED);
         }
 
         // Guard: null pointer (raw_ptr == 0) means null POINTER_TAG (0x7FFD_0000_0000_0000)
@@ -5423,4 +5437,59 @@ pub unsafe extern "C" fn js_native_call_method(
         method_name.as_ptr(),
         method_name.len(),
     );
+}
+
+#[cfg(test)]
+mod undefined_fallback_tests {
+    //! Regression: a method call that falls through to a "no dispatcher →
+    //! return undefined" path must hand back JS `undefined`
+    //! (`TAG_UNDEFINED` = 0x7FFC_..._0001), NOT the bit pattern
+    //! 0x7FF8_..._0001. The latter is a *signaling NaN* — i.e. a JS *number* —
+    //! so it slips past every "is this an object?" check. In a `for…of` loop
+    //! the lazy desugar validates each `iter.next()` result with
+    //! `js_iterator_result_validate`; an sNaN there is reported as the
+    //! confusing `TypeError: Iterator result is not an object`. This bit
+    //! ~9 fallback returns across `native_call_method.rs` and the stdlib handle
+    //! dispatcher; the test pins the JS-handle arm (its dispatcher is null in
+    //! unit tests, so the fallback is taken deterministically).
+
+    #[test]
+    fn js_handle_method_with_no_dispatcher_returns_real_undefined() {
+        // A JS-handle-tagged receiver. `JS_HANDLE_CALL_METHOD` is unset in the
+        // test process, so `js_native_call_method` takes the no-dispatcher
+        // fallback that previously returned an sNaN.
+        let handle = f64::from_bits(crate::value::JS_HANDLE_TAG | 7);
+        let method = b"next";
+        let result = unsafe {
+            super::js_native_call_method(
+                handle,
+                method.as_ptr() as *const i8,
+                method.len(),
+                std::ptr::null(),
+                0,
+            )
+        };
+
+        // Must be exactly JS `undefined`, and crucially must NOT be a number —
+        // an sNaN would pass `is_number()` and masquerade as a value.
+        assert_eq!(
+            result.to_bits(),
+            crate::value::TAG_UNDEFINED,
+            "no-dispatcher handle method call must return TAG_UNDEFINED, got {:#018x}",
+            result.to_bits()
+        );
+        assert!(
+            !crate::value::JSValue::from_bits(result.to_bits()).is_number(),
+            "fallback result must not classify as a JS number (sNaN regression)"
+        );
+
+        // And it must satisfy the iterator-result validator's object check the
+        // same way real `undefined` does (i.e. it is correctly *rejected* as a
+        // non-object, rather than crashing or being misread as a value).
+        assert_ne!(
+            result.to_bits(),
+            0x7FF8_0000_0000_0001,
+            "must not be the signaling-NaN sentinel that tripped for…of"
+        );
+    }
 }

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -2141,6 +2141,7 @@ static KEEP_JS_ITERATOR_RESULT_VALIDATE: extern "C" fn(f64) -> f64 = js_iterator
 #[no_mangle]
 pub extern "C" fn js_iterator_result_validate(result: f64) -> f64 {
     if !is_object_value(result) {
+        crate::array::iter_bt_dump("js_iterator_result_validate", result);
         let msg = b"Iterator result is not an object";
         let msg_str = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
         let err = crate::error::js_typeerror_new(msg_str);

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -1227,7 +1227,7 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
     }
 
     // Unknown handle type - return undefined
-    f64::from_bits(0x7FF8_0000_0000_0001)
+    TAG_UNDEFINED_F64
 }
 
 /// Dispatch method calls on Fastify app handles
@@ -1371,7 +1371,7 @@ unsafe fn dispatch_fastify_app(handle: i64, method: &str, args: &[f64]) -> f64 {
             let opts = if args.len() >= 2 {
                 args[1]
             } else {
-                f64::from_bits(0x7FF8_0000_0000_0001)
+                TAG_UNDEFINED_F64
             };
             let result = crate::fastify::js_fastify_register(handle, plugin, opts);
             if result {
@@ -1387,7 +1387,7 @@ unsafe fn dispatch_fastify_app(handle: i64, method: &str, args: &[f64]) -> f64 {
                 0
             };
             crate::fastify::js_fastify_listen(handle, args[0], callback);
-            f64::from_bits(0x7FF8_0000_0000_0001) // undefined (void)
+            TAG_UNDEFINED_F64 // undefined (void)
         }
         "close" => {
             // `app.close()` — shut down every server bound to this
@@ -1398,7 +1398,7 @@ unsafe fn dispatch_fastify_app(handle: i64, method: &str, args: &[f64]) -> f64 {
             // routed here — fell through to "unknown method" and was a
             // no-op, so the server kept the loop alive forever.
             crate::fastify::js_fastify_app_close(handle);
-            f64::from_bits(0x7FF8_0000_0000_0001) // undefined (void)
+            TAG_UNDEFINED_F64 // undefined (void)
         }
         "on" if args.len() >= 2 => {
             // #1113: `app.server.on(event, cb)` — see the function-level
@@ -1420,7 +1420,7 @@ unsafe fn dispatch_fastify_app(handle: i64, method: &str, args: &[f64]) -> f64 {
         }
         _ => {
             // Unknown method - return undefined
-            f64::from_bits(0x7FF8_0000_0000_0001)
+            TAG_UNDEFINED_F64
         }
     }
 }
@@ -1482,7 +1482,7 @@ unsafe fn dispatch_fastify_context(handle: i64, method: &str, args: &[f64]) -> f
         }
         _ => {
             // Unknown method - return undefined
-            f64::from_bits(0x7FF8_0000_0000_0001)
+            TAG_UNDEFINED_F64
         }
     }
 }


### PR DESCRIPTION
## Problem

Nine "no JS-handle dispatcher registered → return undefined" fallback paths (3 in `object/native_call_method.rs`, 6 in `perry-stdlib/src/common/dispatch.rs`) returned the literal bit pattern `0x7FF8_0000_0000_0001` — which is a **signaling NaN, i.e. a JS `number`** — instead of `TAG_UNDEFINED` (`0x7FFC_0000_0000_0001`).

When a method call routed to one of these fallbacks (e.g. an iterator's `.next()` whose receiver lands on the small-handle dispatcher with no `next` method), it returned a *number* instead of `undefined`. Most visibly this surfaces through iteration:

```
TypeError: Iterator result is not an object
```

because `js_iterator_result_validate` correctly rejects a non-object result — but the value should have been `undefined` (also wrong, but a different and more debuggable failure) rather than a number masquerading as one. More generally, any code that distinguishes `undefined` from a number on these fallback paths (`typeof`, `=== undefined`, nullish coalescing) saw the wrong type.

## Fix

Return `crate::value::TAG_UNDEFINED` from all nine fallbacks instead of the signaling-NaN literal. Verified the produced value flips from `0x7ff8…0001` (kind=number) to `0x7ffc…0001` (kind=undefined).

## Test

Unit regression `undefined_fallback_tests::js_handle_method_with_no_dispatcher_returns_real_undefined` — asserts the fallback returns `TAG_UNDEFINED` and is not a number. `cargo test -p perry-runtime --lib`: 1069 passed.

## Note

This change also adds a **gated** (`PERRY_ITER_BT` env var) native-backtrace diagnostic at the iterator-result throw sites — it's a no-op unless the env var is set, and it was instrumental in localizing this bug. Happy to drop it from this PR if you'd prefer the fix standalone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed method call dispatcher fallback to return proper JavaScript `undefined` instead of an incorrect value
  * Enhanced iterator error diagnostics with detailed type information when `next()` result validation fails, improving debugging capabilities
  * Improved validation logic across iterator result checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->