### PR TITLE
perf(codegen,runtime): route untyped typed-array element access through the fast path (~2x bcrypt) (#5525)

### DIFF
--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -847,7 +847,18 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 recv_ty,
                 None | Some(perry_types::Type::Any) | Some(perry_types::Type::Unknown)
             );
-            if recv_unknown && is_numeric_expr(ctx, index) {
+            // #5525: route every non-static-string/symbol read on an unknown
+            // receiver through `js_dyn_index_get` (numeric, runtime-string, and
+            // runtime-symbol are all triaged in the runtime). The earlier
+            // `is_numeric_expr(index)` gate missed `lr[off]`/`lr[off + 1]`
+            // (bcryptjs `_encipher`'s `off` is an `any` param, so `off + 1` is
+            // not provably numeric); statically-known string-literal / symbol
+            // keys keep their dedicated interned-handle / symbol routes below.
+            let index_is_static_string_or_symbol = matches!(
+                index.as_ref(),
+                Expr::String(_) | Expr::WtfString(_) | Expr::SymbolFor(_)
+            ) || is_string_expr(ctx, index);
+            if recv_unknown && !index_is_static_string_or_symbol {
                 let obj_box = lower_expr(ctx, object)?;
                 let idx_d = lower_expr(ctx, index)?;
                 let blk = ctx.block();

--- a/crates/perry-codegen/src/expr/index_set.rs
+++ b/crates/perry-codegen/src/expr/index_set.rs
@@ -222,6 +222,52 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     ],
                 ));
             }
+            // #5525: when the receiver's static type is genuinely unknown
+            // (`Type::Any`/`Type::Unknown`) and the index is numeric, route the
+            // write through `js_dyn_index_set` — the exact symmetric counterpart
+            // of the IndexGet `recv_unknown` arm (index_get.rs), which routes
+            // reads through `js_dyn_index_get`. Both helpers carry the #5525
+            // process-global typed-array kind cache + inline `typed_array_fast_
+            // index_{get,set}` fast path, so a hot monomorphic `S[i]`/`P[i] = v`
+            // on an `Int32Array` reaching a function through an untyped
+            // `Array.<number>` parameter (bcryptjs's Blowfish P/S boxes) lands on
+            // a cached load/store instead of the polymorphic feedback helper's
+            // thread-local registry dispatch (`typed_array_owner_*` →
+            // `_tlv_get_addr`). Pre-fix this fell all the way through to
+            // `js_typed_feedback_object_set_index_polymorphic`, whose
+            // `typed_array_set_numeric_index` path dominated the bcrypt profile.
+            // The gate is narrow (only Any/Unknown receiver + numeric index) so
+            // every statically-typed array / typed-array / object fast path below
+            // is preserved.
+            let recv_ty = crate::type_analysis::static_type_of(ctx, object);
+            let recv_unknown = matches!(
+                recv_ty,
+                None | Some(perry_types::Type::Any) | Some(perry_types::Type::Unknown)
+            );
+            // The index may be numeric, a runtime string, or (rarely) a runtime
+            // symbol — `js_dyn_index_set` triages all three. We only keep the
+            // statically-known string-literal / symbol keys on their dedicated
+            // (interned-handle / symbol-side-table) routes below; everything else
+            // on an unknown receiver goes through the cached fast path. bcryptjs's
+            // `lr[off]`/`lr[off + 1]` writes have an `off` param typed `any`, so
+            // `off + 1` is NOT provably numeric — gating on `is_numeric_expr`
+            // (the original #5525 attempt) missed exactly those ~4M hot writes
+            // and they kept falling through to `js_put_value_set`.
+            let index_is_static_string_or_symbol = matches!(
+                index.as_ref(),
+                Expr::String(_) | Expr::WtfString(_) | Expr::SymbolFor(_)
+            ) || is_string_expr(ctx, index);
+            if recv_unknown && !index_is_static_string_or_symbol {
+                let obj_box = lower_expr(ctx, object)?;
+                let idx_d = lower_expr(ctx, index)?;
+                let val_double = lower_expr(ctx, value)?;
+                let blk = ctx.block();
+                return Ok(blk.call(
+                    DOUBLE,
+                    "js_dyn_index_set",
+                    &[(DOUBLE, &obj_box), (DOUBLE, &idx_d), (DOUBLE, &val_double)],
+                ));
+            }
             // Issue #637 / hono r2 followup: `arr[stringKey] = val` where
             // the index is statically string-typed (e.g. `for (const i in
             // sparseArr)` produces string i; then `out[i] = val`). Pre-fix

--- a/crates/perry-codegen/src/expr/proxy_reflect.rs
+++ b/crates/perry-codegen/src/expr/proxy_reflect.rs
@@ -357,13 +357,47 @@ fn is_numeric_string_key(key: &str) -> bool {
 }
 
 fn put_value_index_fast_path(ctx: &FnCtx<'_>, target: &Expr, key: &Expr, receiver: &Expr) -> bool {
-    if !same_side_effect_free_receiver(target, receiver) || !is_array_expr(ctx, target) {
+    if !same_side_effect_free_receiver(target, receiver) {
         return false;
     }
-    match key {
-        Expr::String(key) => is_numeric_string_key(key),
-        _ => true,
+    if is_array_expr(ctx, target) {
+        return match key {
+            Expr::String(key) => is_numeric_string_key(key),
+            _ => true,
+        };
     }
+    // #5525: `P[i] = v` where `P` is an *untyped* (`Type::Any`/`Type::Unknown`)
+    // receiver. The desugared `PutValueSet` otherwise falls through to the
+    // generic `js_put_value_set` ([[Set]] via `ordinary_set_with_receiver` →
+    // stringify-the-index object dispatch), which dominated the bcrypt write
+    // profile. Routing it to `index_set::lower` instead reaches that file's
+    // matching `recv_unknown` arm, which emits `js_dyn_index_set` — carrying the
+    // #5525 process-global typed-array kind cache + inline
+    // `typed_array_fast_index_set` fast path. This is the write counterpart of
+    // the IndexGet `recv_unknown → js_dyn_index_get` route that bcryptjs's
+    // Blowfish `Int32Array` P/S boxes (reached through untyped `Array.<number>`
+    // params) need. `js_dyn_index_set` carries the full spec dispatch (typed-
+    // array per-kind store, plain-array extend, object by-name set, symbol side-
+    // table) for the cases the fast path defers, so the only keys we keep off it
+    // are statically-known string-literals / symbols (their interned-handle /
+    // symbol-side-table routes below are already optimal). Every statically-
+    // typed receiver is unaffected — `recv_unknown` is false for them.
+    let recv_unknown = matches!(
+        crate::type_analysis::static_type_of(ctx, target),
+        None | Some(perry_types::Type::Any) | Some(perry_types::Type::Unknown)
+    );
+    // Mirror `index_set::lower`'s `recv_unknown` arm: keep statically-known
+    // string-literal / symbol keys on their dedicated routes; route everything
+    // else (numeric, runtime-string, or an unknown-typed index like bcryptjs's
+    // `off + 1` where `off` is an `any` param) to `index_set::lower`, which emits
+    // the `js_dyn_index_set` fast path. The earlier `is_numeric_expr(key)` gate
+    // missed `off + 1` and those ~4M hot `lr[...]` writes stayed on
+    // `js_put_value_set`.
+    let key_is_static_string_or_symbol = matches!(
+        key,
+        Expr::String(_) | Expr::WtfString(_) | Expr::SymbolFor(_)
+    ) || is_string_expr(ctx, key);
+    recv_unknown && !key_is_static_string_or_symbol
 }
 
 fn try_lower_process_env_put_value_set(

--- a/crates/perry-runtime/src/builtins/numbers.rs
+++ b/crates/perry-runtime/src/builtins/numbers.rs
@@ -371,6 +371,18 @@ pub extern "C" fn js_to_integer_or_infinity(value: f64) -> f64 {
 
 #[no_mangle]
 pub extern "C" fn js_number_coerce(value: f64) -> f64 {
+    // #5525 hot fast path: a plain IEEE-754 double (top 16 bits, sign stripped,
+    // below the 0x7FF9 Perry NaN-box tag band) is already a Number — ToNumber is
+    // identity. Returns before the undefined/null/bool/string/int32/bigint/
+    // pointer tag ladder below. bcryptjs's Blowfish core funnels every `any`-
+    // typed `S[i]` element read (which `js_dyn_index_get` returns as a plain f64)
+    // through this coercion before the Feistel arithmetic, so it was the #1 frame
+    // after the typed-array element-access + dynamic-add fast paths landed.
+    // Canonical / payload NaNs (top16 0x7FF8) and all finite/inf doubles stay on
+    // this path; tagged values (0x7FF9..=0x7FFF) fall through unchanged.
+    if (value.to_bits() & 0x7FFF_0000_0000_0000) < 0x7FF9_0000_0000_0000 {
+        return value;
+    }
     let jsval = JSValue::from_bits(value.to_bits());
 
     if jsval.is_undefined() {

--- a/crates/perry-runtime/src/object/polymorphic_index.rs
+++ b/crates/perry-runtime/src/object/polymorphic_index.rs
@@ -56,6 +56,16 @@ pub extern "C" fn js_object_get_index_polymorphic(obj_handle: i64, idx: f64) -> 
     if raw < 0x1000 {
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
+    // #5525 fast path: cached typed-array kind lookup + inline load, ahead of
+    // the thread-local `typed_array_get_numeric_index` registry dispatch.
+    // `typed_array_fast_index_get` returns `Some(value)` for an in-bounds read
+    // or `Some(undefined)` for an in-range OOB index, `None` for the BigInt /
+    // non-canonical-key cases the slow path still owns.
+    if let Some(kind) = crate::typedarray::lookup_typed_array_kind(raw as usize) {
+        if let Some(value) = crate::typedarray::typed_array_fast_index_get(raw as usize, kind, idx) {
+            return value;
+        }
+    }
     if let Some(value) =
         unsafe { crate::typedarray_props::typed_array_get_numeric_index(raw as usize, idx) }
     {
@@ -182,6 +192,17 @@ pub extern "C" fn js_object_set_index_polymorphic(obj_handle: i64, idx: f64, val
     };
     if raw < 0x1000 {
         return;
+    }
+    // #5525 fast path: a cached typed-array kind lookup + inline store, before
+    // the thread-local `typed_array_set_numeric_index` registry dispatch
+    // (`typed_array_owner_*` → `_tlv_get_addr`) that dominated the bcrypt
+    // profile. `typed_array_fast_index_set` returns `true` when it fully handled
+    // the write (in-bounds store or spec-correct OOB-canonical drop), `false`
+    // for the BigInt / non-canonical-key cases the slow dispatch still owns.
+    if let Some(kind) = crate::typedarray::lookup_typed_array_kind(raw as usize) {
+        if crate::typedarray::typed_array_fast_index_set(raw as usize, kind, idx, value) {
+            return;
+        }
     }
     let idx_i32 = idx as i32;
 

--- a/crates/perry-runtime/src/object/polymorphic_index.rs
+++ b/crates/perry-runtime/src/object/polymorphic_index.rs
@@ -62,7 +62,8 @@ pub extern "C" fn js_object_get_index_polymorphic(obj_handle: i64, idx: f64) -> 
     // or `Some(undefined)` for an in-range OOB index, `None` for the BigInt /
     // non-canonical-key cases the slow path still owns.
     if let Some(kind) = crate::typedarray::lookup_typed_array_kind(raw as usize) {
-        if let Some(value) = crate::typedarray::typed_array_fast_index_get(raw as usize, kind, idx) {
+        if let Some(value) = crate::typedarray::typed_array_fast_index_get(raw as usize, kind, idx)
+        {
             return value;
         }
     }

--- a/crates/perry-runtime/src/value/dyn_index.rs
+++ b/crates/perry-runtime/src/value/dyn_index.rs
@@ -18,6 +18,14 @@ pub extern "C" fn js_dyn_index_get(value: f64, index: f64) -> f64 {
         crate::object::has_own_helpers::throw_to_object_nullish_type_error();
     }
     let jsval = JSValue::from_bits(bits);
+    // #5525: a Symbol *index* (`obj[Symbol.iterator]`) must resolve through the
+    // symbol side-table, never the integer-index / stringify paths below (which
+    // would coerce the symbol's NaN-boxed bits to a garbage i32). The codegen
+    // routes all non-string-literal, unknown-receiver reads here, so the runtime
+    // owns the symbol triage that the codegen-side fallback used to do inline.
+    if unsafe { crate::symbol::js_is_symbol(index) } != 0 {
+        return unsafe { crate::symbol::js_object_get_symbol_property(value, index) };
+    }
     // #5525 hot fast path: `obj[i]` where `obj` is dynamically an owning numeric
     // typed array and `i` a canonical index. bcryptjs's Blowfish core reaches
     // its `Int32Array` P/S boxes through untyped `Array.<number>` params, so
@@ -259,6 +267,15 @@ pub extern "C" fn js_dyn_index_get(value: f64, index: f64) -> f64 {
 pub extern "C" fn js_dyn_index_set(obj: f64, index: f64, value: f64) -> f64 {
     let bits = obj.to_bits();
     let jsval = JSValue::from_bits(bits);
+    // #5525: a Symbol *index* (`obj[sym] = v`) routes to the symbol side-table,
+    // mirroring the get side. Codegen sends all non-string-literal unknown-
+    // receiver writes here, so the runtime owns the symbol triage.
+    if unsafe { crate::symbol::js_is_symbol(index) } != 0 {
+        unsafe {
+            crate::symbol::js_object_set_symbol_property(obj, index, value);
+        }
+        return value;
+    }
     // #5525 hot fast path mirroring `js_dyn_index_get` — an owning numeric
     // typed array with a canonical index stores inline, skipping the dynamic
     // setter chain. Placed before the `note_object_prototype_index_write`

--- a/crates/perry-runtime/src/value/dynamic_arith.rs
+++ b/crates/perry-runtime/src/value/dynamic_arith.rs
@@ -265,6 +265,27 @@ pub unsafe extern "C" fn js_numeric_step(numeric: f64, is_increment: i32) -> f64
 /// the results — turning `"c" + ""` into `NaN + 0 = NaN`).
 #[no_mangle]
 pub unsafe extern "C" fn js_dynamic_string_or_number_add(a: f64, b: f64) -> f64 {
+    // #5525 hot fast path: both operands are plain IEEE-754 doubles (not a
+    // NaN-boxed string / pointer / bigint / int32 / singleton — i.e. top 16 bits
+    // below the 0x7FF9 Perry tag band). Then `a + b` is exactly the spec result:
+    // ToPrimitive is identity on numbers, neither side is a string (no concat),
+    // neither is a BigInt or Symbol, and there are no GC pointers to root. This
+    // skips the `RuntimeHandleScope` + four `root_nanbox_f64` thread-local
+    // accesses (`_tlv_get_addr`) that otherwise run for *every* dynamic `+`.
+    // bcryptjs's Blowfish core does ~hundreds of millions of `n += S[i]` adds on
+    // `any`-typed locals whose values are always plain numbers, so this scope +
+    // rooting was the single largest remaining cost after the typed-array
+    // element-access fix (#5525). Canonical-NaN (0x7FF8) and negative-NaN
+    // payloads from real arithmetic stay on this path and add to NaN, matching
+    // IEEE semantics. Any tagged operand falls through to the full path below.
+    const TAG_BAND_FLOOR: u64 = 0x7FF9_0000_0000_0000;
+    let abits = a.to_bits();
+    let bbits = b.to_bits();
+    if (abits & 0x7FFF_0000_0000_0000) < TAG_BAND_FLOOR
+        && (bbits & 0x7FFF_0000_0000_0000) < TAG_BAND_FLOOR
+    {
+        return a + b;
+    }
     let scope = crate::gc::RuntimeHandleScope::new();
     let a_handle = scope.root_nanbox_f64(a);
     let b_handle = scope.root_nanbox_f64(b);

--- a/crates/perry/tests/issue_5525_typed_array_untyped_index.rs
+++ b/crates/perry/tests/issue_5525_typed_array_untyped_index.rs
@@ -118,3 +118,100 @@ console.log("F=" + get(whole, 1) + "," + get(view, 0));
          semantics across kinds, bounds, exotic keys, BigInt, and buffer views"
     );
 }
+
+/// #5525 follow-up: closing the bcrypt perf gap relaxed the unknown-receiver
+/// index gates so that *all* non-static-string/symbol element accesses on an
+/// `any` receiver route through `js_dyn_index_get` / `js_dyn_index_set` (which
+/// carry the cached typed-array fast path) — including the `lr[off]` /
+/// `lr[off + 1]` writes whose index is not statically numeric. That widening
+/// must not change semantics for the non-typed-array cases the same dispatchers
+/// now also serve: runtime string keys, numeric-string keys, Symbol keys, plain
+/// arrays, and plain objects. It also adds a both-operands-plain-number fast
+/// path to the dynamic `+`; this pins that `+` still concatenates strings and
+/// coerces mixed operands per spec.
+#[test]
+fn untyped_index_routing_preserves_non_typed_array_semantics() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+
+    std::fs::write(
+        &entry,
+        r#"
+// All accesses go through untyped params, so the access site can't narrow the
+// receiver and must route through the dynamic get/set dispatchers.
+function g(a: any, k: any): any { return a[k]; }
+function s(a: any, k: any, v: any): void { a[k] = v; }
+
+// (A) typed array with a NON-statically-numeric index (mirrors bcryptjs
+// `lr[off]` / `lr[off + 1]` where `off` is an `any` param).
+const ta = new Int32Array(4);
+const off: any = 0;
+s(ta, off, 100);
+s(ta, off + 1, -7);
+console.log("A=" + g(ta, off) + "," + g(ta, off + 1) + "," + (g(ta, 9) === undefined));
+
+// (B) plain object reached through the untyped path: a runtime string key and a
+// numeric-string key must land as ordinary properties, not elements.
+const o: any = {};
+const key: any = "fo" + "o"; // runtime (non-literal) string
+s(o, key, 42);
+s(o, "7", 9);
+console.log("B=" + g(o, key) + "," + o.foo + "," + g(o, "7"));
+
+// (C) a Symbol key must resolve through the symbol side-table on both get & set.
+const sym: any = Symbol("x");
+const o2: any = {};
+s(o2, sym, "viaSym");
+console.log("C=" + g(o2, sym) + "," + (g(o2, "nope") === undefined));
+
+// (D) a plain array grown through the untyped write path.
+const arr: any = [];
+s(arr, 0, 11);
+s(arr, 1, 22);
+console.log("D=" + arr[0] + "," + arr[1] + "," + arr.length);
+
+// (E) the dynamic `+` plain-number fast path must not change string concat or
+// mixed-operand coercion.
+function add(a: any, b: any): any { return a + b; }
+console.log("E=" + add(2, 3) + "," + add("x", 5) + "," + add(1, "y") + "," + add(2.5, 0.5));
+"#,
+    )
+    .expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert_eq!(
+        stdout,
+        "A=100,-7,true\n\
+         B=42,42,9\n\
+         C=viaSym,true\n\
+         D=11,22,2\n\
+         E=5,x5,1y,3\n",
+        "widening the unknown-receiver index routing must preserve spec semantics \
+         for runtime-string / numeric-string / Symbol keys, plain arrays & objects, \
+         and the dynamic `+` fast path"
+    );
+}


### PR DESCRIPTION
Part of #5525.

## Problem
`bcryptjs` cost-12 `compareSync` ran **~22s of user CPU** under perry (vs ~250ms on Node), making the Verrano CMS admin login blow past HTTP timeouts. #5537 added a typed-array kind cache + inline `typed_array_fast_index_{get,set}` fast path, but only got 28s→22s because the **hot accesses never reached those dispatchers**.

## Root cause (profiled with macOS `sample`, user CPU)
- Element **writes** (`lr[off] = …`, `P[i] = …`, `S[i] = …`) desugar to `Expr::PutValueSet`; `put_value_index_fast_path` only routed *statically-known arrays* to the element-store lowering. An untyped (`any`) param (bcryptjs's `Int32Array` P/S/lr) fell through to generic `js_put_value_set` → `ordinary_set_with_receiver` → stringify-the-index object `[[Set]]` — the single largest frame.
- The unknown-receiver gates required `is_numeric_expr(index)`. bcrypt's `lr[off + 1]` has `off: any`, so `off + 1` isn't provably numeric → ~4M hot writes (and matching reads) missed the fast route.
- After fixing routing, the dynamic `+` / `ToNumber` on every `any`-typed `S[i]` read dominated: `js_dynamic_string_or_number_add` built a `RuntimeHandleScope` + rooted 4 handles (4× `_tlv_get_addr`) per add; `js_number_coerce` walked a 7-tag ladder — both even for plain numbers.

## Fix (8 files, +264/−5)
- **Codegen** (`proxy_reflect.rs`, `index_set.rs`, `index_get.rs`): route all unknown-receiver, non-static-string/symbol element reads & writes through `js_dyn_index_{get,set}` (which carry #5537's cache + inline fast path), gating on "not a statically-known string/symbol key" instead of `is_numeric_expr`.
- **Runtime** (`dyn_index.rs`): Symbol-index guards on `js_dyn_index_{get,set}` so the widened routing stays spec-correct.
- **Runtime** (`polymorphic_index.rs`): try the cached `typed_array_fast_index_{get,set}` before the thread-local registry dispatch.
- **Runtime** (`dynamic_arith.rs`, `numbers.rs`): plain-double fast paths in `js_dynamic_string_or_number_add` and `js_number_coerce`.

## Result (user CPU, `/usr/bin/time -p`, one `compareSync` cost-12)
- Baseline (origin/main incl. #5537): **~22s**
- This change: **~11.2s** — **~1.95× faster** (independently re-measured: 10.97 / 11.22 / 11.48s; output stays `true`).
- Untyped-typed-array microbenchmark: 25.6s → 7.2s.

## Tests
- `crates/perry/tests/issue_5525_typed_array_untyped_index.rs`: existing case passes; added a second covering the widened routing (runtime-string / numeric-string / Symbol keys, plain arrays & objects, dynamic-`+`) — matches Node byte-for-byte.
- `cargo test -p perry-runtime`: 1067 pass; the 2 failures (`builtin_prototype_methods_reject_dynamic_new`, URL `path_to_file_url_*`) reproduce identically on clean `origin/main` and pass when run individually — pre-existing test-isolation flakes, unrelated.

## Remaining gap (follow-up, stacked PR)
The stretch target (<2s, needed to make the CMS login usable) isn't reached here: the residual cost is the per-element out-of-line `js_dyn_index_get` call + `js_number_coerce` on `any`-typed reads. Closing it needs a guarded **inline** typed-array load emitted at the access site — a larger codegen change tracked as a follow-up.

https://claude.ai/code/session_012nEhNZCXKSeNStMnVD5E9e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected dynamic index get/set routing for `any`/`unknown` receivers, ensuring correct behavior when keys are numeric, string/numeric-strings, or `Symbol.*`, including typed arrays.
  * Ensured `Symbol.*` index reads and writes take the proper symbol-property path.
* **Performance**
  * Improved arithmetic and number coercion with additional fast paths.
  * Faster typed-array index get/set dispatch.
* **Tests**
  * Added a regression test covering issue 5525 to preserve non–typed-array semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->