### PR TITLE
fix(codegen+runtime): #5437 Next.js W6 — captured CJS module-default wrapper closure resolves exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.5.1200 — fix(codegen+runtime): #5437 Next.js W6 — captured CJS module-default wrapper closure resolves exports
+
+The Next.js standalone (turbopack `app-page-turbo`) render threw `TypeError: undefined is not a constructor` at `new uw.SharedCacheControls(...)` inside the `IncrementalCache` constructor. Root: `let uw = require(".../shared-cache-controls.external.js")` is a lazy/function-local require whose value-read takes the `imported_vars` default-getter path (`dyn_extern_i18n.rs`), which for a CJS `Object.defineProperty(exports, …)` module returns the module-default **wrapper closure** (the un-called IIFE), not `module.exports`. The class captured that closure by-value into a `__perry_cap_` field, so `uw.SharedCacheControls` read the closure → `undefined` → `new undefined()` threw. (Diverged only at giant-bundle scale; the import getter resolves the real object everywhere else.)
+
+Fix (5 files, +235): a `MODULE_DEFAULT_WRAPPER_FUNCPTRS` runtime registry + `js_register_module_default_wrapper_value` FFI; codegen at the imported-var default-getter site registers the wrapper, **gated to `origin_suffix == "default" && name.starts_with("_lazyreq_")`** so a genuine `export default <function>` is never auto-called; and a runtime fallback in the closure property-read path that, for a *registered* wrapper closure on a property miss, calls it once (`js_closure_call0`) → `module.exports` → re-reads the property (guarded against self-return / undefined / null). Regression test `module_default_wrapper_property_read_resolves_exports`.
+
+Bundle: the W6 render throw is eliminated (undefined-ctor 1→0, deterministic); the render now advances past W6 to a separate downstream wall (a `.length` read on undefined). Code-only; no behavioral change for non-`defineProperty`-CJS default imports.
+
 ## v0.5.1199 — feat(ui): BloomView live-render plumbing on every backend (#5519)
 
 Perry-UI side of #5519 (live `BloomView` rendering on all platforms; the engine

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1199
+**Current Version:** 0.5.1200
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5325,7 +5325,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "anyhow",
  "base64",
@@ -5382,14 +5382,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "cc",
  "libc",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "anyhow",
  "log",
@@ -5412,7 +5412,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5421,7 +5421,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5448,7 +5448,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "anyhow",
  "base64",
@@ -5461,7 +5461,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5469,7 +5469,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5498,14 +5498,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "serde",
  "serde_json",
@@ -5513,7 +5513,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1199"
+version = "0.5.1200"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5524,7 +5524,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "anyhow",
  "clap",
@@ -5539,14 +5539,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5554,7 +5554,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5571,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "chrono",
  "cron 0.16.0",
@@ -5605,7 +5605,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5613,7 +5613,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5621,7 +5621,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5629,7 +5629,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5637,7 +5637,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5645,14 +5645,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5681,7 +5681,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5695,7 +5695,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "bytes",
  "h2",
@@ -5718,7 +5718,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5728,7 +5728,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5739,7 +5739,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5755,7 +5755,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "bson",
  "futures-util",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5777,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5786,7 +5786,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5798,7 +5798,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5808,7 +5808,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5816,7 +5816,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5825,7 +5825,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5833,7 +5833,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -5843,14 +5843,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5859,7 +5859,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5867,7 +5867,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5877,7 +5877,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5889,7 +5889,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "brotli",
  "flate2",
@@ -5898,7 +5898,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5925,7 +5925,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5937,7 +5937,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "anyhow",
  "base64",
@@ -5970,14 +5970,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6069,14 +6069,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6086,7 +6086,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6094,14 +6094,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "base64",
  "itoa",
@@ -6118,7 +6118,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6128,7 +6128,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6151,7 +6151,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "base64",
  "block2",
@@ -6167,7 +6167,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "base64",
  "block2",
@@ -6182,7 +6182,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1199"
+version = "0.5.1200"
 
 [[package]]
 name = "perry-ui-test"
@@ -6190,11 +6190,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1199"
+version = "0.5.1200"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "base64",
  "block2",
@@ -6210,7 +6210,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "base64",
  "block2",
@@ -6226,7 +6226,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "block2",
  "libc",
@@ -6239,7 +6239,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "base64",
  "libc",
@@ -6256,14 +6256,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6277,7 +6277,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1199"
+version = "0.5.1200"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -301,7 +301,7 @@ strip = false
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1199"
+version = "0.5.1200"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
+++ b/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
@@ -633,7 +633,41 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 if ctx.imported_vars.contains(name) {
                     let fname = format!("perry_fn_{}__{}", source_prefix, origin_suffix);
                     ctx.pending_declares.push((fname.clone(), DOUBLE, vec![]));
-                    return Ok(ctx.block().call(DOUBLE, &fname, &[]));
+                    let getter_val = ctx.block().call(DOUBLE, &fname, &[]);
+                    // #5437 (Next.js W6): for a module-DEFAULT export value
+                    // (`const x = require('S')` adopted as an import, read via
+                    // the default getter), the getter result of a CJS module
+                    // whose exports are built with `Object.defineProperty(
+                    // exports, …)` is a WRAPPER CLOSURE, not the exports object.
+                    // If that wrapper is captured by-value (e.g. into a class
+                    // `__perry_cap_*` field) a later member read off the
+                    // captured snapshot (`x.SharedCacheControls`) hits the
+                    // closure rather than `module.exports` → `undefined` →
+                    // `new undefined()` throws. Thread the getter value through
+                    // a runtime registrar: it records the closure's `func_ptr`
+                    // (when the value IS a closure) so the property-read
+                    // fallback recognizes a captured wrapper, calls it once to
+                    // obtain `module.exports`, and re-reads off that object. The
+                    // value is returned unchanged, so non-closure getter results
+                    // (the common `let v = HONE_VERSION` string/number case) are
+                    // untouched. Gated to a `_lazyreq_` DEFAULT read: a
+                    // function-local `require('S')` adopted as an import, whose
+                    // value is `module.exports` by CJS semantics — never a
+                    // genuine ESM `export default <function>` (which IS a real
+                    // callable and must NOT be auto-called on a property miss).
+                    if origin_suffix == "default" && name.starts_with("_lazyreq_") {
+                        ctx.pending_declares.push((
+                            "js_register_module_default_wrapper_value".to_string(),
+                            DOUBLE,
+                            vec![DOUBLE],
+                        ));
+                        return Ok(ctx.block().call(
+                            DOUBLE,
+                            "js_register_module_default_wrapper_value",
+                            &[(DOUBLE, &getter_val)],
+                        ));
+                    }
+                    return Ok(getter_val);
                 }
                 // Drizzle / cross-module IIFE-pattern static-property fix:
                 // route through the SOURCE module's wrapper symbol +

--- a/crates/perry-runtime/src/closure/dynamic_props.rs
+++ b/crates/perry-runtime/src/closure/dynamic_props.rs
@@ -50,6 +50,87 @@ pub fn closure_is_key_deleted(ptr: usize, key: &str) -> bool {
         .unwrap_or(false)
 }
 
+// ───────────────────────────────────────────────────────────────────────────
+// #5437 (Next.js W6): module-default-export WRAPPER-closure registry.
+//
+// Some imported module-default-export VALUE reads (`const uw = require('S')`
+// for a CJS module) materialize as a 0-capture *wrapper closure* whose
+// `func_ptr` forwards to the module's default-export getter
+// (`perry_fn_<src>__default`), which returns `module.exports`. When such a
+// wrapper is then CAPTURED by-value (e.g. into a class's `__perry_cap_*`
+// field) and a member is read off the captured snapshot
+// (`uw.SharedCacheControls`), the read hits the closure itself (a function
+// value) rather than `module.exports`, so the property is `undefined` and
+// `new uw.SharedCacheControls()` throws "undefined is not a constructor".
+//
+// Codegen registers each such wrapper's `func_ptr` here at the wrapper's
+// value-read site (see `js_register_module_default_wrapper_value`). The
+// property-read fallback in `js_object_get_field_by_name` then recognizes a
+// REGISTERED wrapper closure on a property miss, calls it once
+// (`js_closure_call0`) to obtain `module.exports`, and re-reads the property
+// off that object. The registry is keyed by `func_ptr` so it is robust to the
+// many closure-singleton/capture paths that can produce the wrapper — only
+// wrappers explicitly registered by codegen are ever auto-called, so an
+// arbitrary user closure on a property miss is never invoked.
+static MODULE_DEFAULT_WRAPPER_FUNCPTRS: OnceLock<Mutex<HashSet<usize>>> = OnceLock::new();
+
+fn module_default_wrapper_funcptrs() -> &'static Mutex<HashSet<usize>> {
+    MODULE_DEFAULT_WRAPPER_FUNCPTRS.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+/// Codegen-emitted, value-threading variant: register `value` (a NaN-boxed
+/// JSValue from a module-default-export getter `perry_fn_<src>__default()`) as a
+/// module-default wrapper IF it is a closure, then return it unchanged. Used at
+/// the `imported_vars` getter site for `origin_suffix == "default"` reads, where
+/// a CJS module whose exports are built via `Object.defineProperty(exports, …)`
+/// yields a WRAPPER CLOSURE from the default getter rather than the exports
+/// object. Registering the actual closure's `func_ptr` (whatever it is) makes
+/// the property-read fallback recognize a captured snapshot of it.
+#[no_mangle]
+pub extern "C" fn js_register_module_default_wrapper_value(value: f64) -> f64 {
+    let bits = value.to_bits();
+    // Only POINTER-tagged values can be closures.
+    const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
+    const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
+    if (bits & !POINTER_MASK) == POINTER_TAG {
+        let ptr = (bits & POINTER_MASK) as usize;
+        if is_closure_ptr(ptr) {
+            let func_ptr = unsafe { (*(ptr as *const ClosureHeader)).func_ptr as usize };
+            if func_ptr != 0 {
+                if let Ok(mut set) = module_default_wrapper_funcptrs().lock() {
+                    set.insert(func_ptr);
+                }
+            }
+        }
+    }
+    value
+}
+
+/// True if the closure at `ptr` is a REGISTERED module-default-export wrapper
+/// (its `func_ptr` was registered via `js_register_module_default_wrapper_value`).
+pub fn is_module_default_wrapper(ptr: usize) -> bool {
+    if !is_closure_ptr(ptr) {
+        return false;
+    }
+    let func_ptr = unsafe { (*(ptr as *const ClosureHeader)).func_ptr as usize };
+    module_default_wrapper_funcptrs()
+        .lock()
+        .ok()
+        .map(|set| set.contains(&func_ptr))
+        .unwrap_or(false)
+}
+
+/// Call a registered module-default wrapper closure (`ptr`) and return its
+/// result — `module.exports` for the wrapped module. Returns `None` if `ptr`
+/// is not a registered wrapper closure.
+pub fn module_default_wrapper_exports(ptr: usize) -> Option<f64> {
+    if !is_module_default_wrapper(ptr) {
+        return None;
+    }
+    let closure = ptr as *const ClosureHeader;
+    Some(crate::closure::js_closure_call0(closure))
+}
+
 /// True if `prop` is an OWN dynamic property of the closure at `ptr` (does NOT
 /// walk the static-prototype chain, unlike `closure_get_dynamic_prop`). Used
 /// by `hasOwnProperty`/`getOwnPropertyNames` to report own user props and the

--- a/crates/perry-runtime/src/closure/mod.rs
+++ b/crates/perry-runtime/src/closure/mod.rs
@@ -63,8 +63,9 @@ pub use dynamic_props::{
     closure_delete_own_dynamic_prop, closure_dynamic_props_snapshot, closure_get_dynamic_prop,
     closure_get_own_dynamic_prop, closure_has_own_dynamic_prop, closure_is_key_deleted,
     closure_mark_key_deleted, closure_set_dynamic_prop, closure_set_static_prototype,
-    closure_static_prototype, is_closure_ptr, js_closure_unbind_this,
-    scan_closure_dynamic_props_roots_mut,
+    closure_static_prototype, is_closure_ptr, is_module_default_wrapper,
+    js_closure_unbind_this, js_register_module_default_wrapper_value,
+    module_default_wrapper_exports, scan_closure_dynamic_props_roots_mut,
 };
 
 // v8_stubs re-exports the AOT stubs + non-macOS Rust V8-interop stubs.

--- a/crates/perry-runtime/src/closure/mod.rs
+++ b/crates/perry-runtime/src/closure/mod.rs
@@ -63,9 +63,9 @@ pub use dynamic_props::{
     closure_delete_own_dynamic_prop, closure_dynamic_props_snapshot, closure_get_dynamic_prop,
     closure_get_own_dynamic_prop, closure_has_own_dynamic_prop, closure_is_key_deleted,
     closure_mark_key_deleted, closure_set_dynamic_prop, closure_set_static_prototype,
-    closure_static_prototype, is_closure_ptr, is_module_default_wrapper,
-    js_closure_unbind_this, js_register_module_default_wrapper_value,
-    module_default_wrapper_exports, scan_closure_dynamic_props_roots_mut,
+    closure_static_prototype, is_closure_ptr, is_module_default_wrapper, js_closure_unbind_this,
+    js_register_module_default_wrapper_value, module_default_wrapper_exports,
+    scan_closure_dynamic_props_roots_mut,
 };
 
 // v8_stubs re-exports the AOT stubs + non-macOS Rust V8-interop stubs.

--- a/crates/perry-runtime/src/closure/tests.rs
+++ b/crates/perry-runtime/src/closure/tests.rs
@@ -71,7 +71,10 @@ fn module_default_wrapper_property_read_resolves_exports() {
         wrapper as *const crate::object::ObjectHeader,
         key_str,
     );
-    assert!(!post.is_undefined(), "registered wrapper must resolve exports");
+    assert!(
+        !post.is_undefined(),
+        "registered wrapper must resolve exports"
+    );
     assert_eq!(post.to_number(), 7.0);
 
     // A non-closure value passed to the registrar is returned untouched and not

--- a/crates/perry-runtime/src/closure/tests.rs
+++ b/crates/perry-runtime/src/closure/tests.rs
@@ -14,3 +14,69 @@ fn test_closure_basic() {
     let result = js_closure_call0(closure);
     assert_eq!(result, 42.0);
 }
+
+// #5437 (Next.js W6) regression: a module-default-export WRAPPER closure whose
+// body returns `module.exports` must be recognized after registration, and a
+// property read off the captured wrapper must resolve against the exports
+// object (not the closure itself). Mirrors `new uw.SharedCacheControls` where
+// `uw` is a captured wrapper closure for the CJS shared-cache-controls module.
+extern "C" fn test_wrapper_returns_capture0(closure: *const ClosureHeader) -> f64 {
+    // Mimics `__perry_wrap_perry_fn_<src>__default` forwarding to the default
+    // getter: returns the wrapped module.exports value (stored as capture 0).
+    unsafe { js_closure_get_capture_f64(closure, 0) }
+}
+
+#[test]
+fn module_default_wrapper_property_read_resolves_exports() {
+    // Build a fake `module.exports` object carrying a `SharedCacheControls`
+    // property (the number 7.0 stands in for the class ref).
+    let exports_ptr = crate::object::js_object_alloc(0, 0);
+    assert!(!exports_ptr.is_null());
+    // `js_nanbox_pointer` returns the NaN-boxed POINTER value as raw f64 bits.
+    let exports: f64 = crate::value::js_nanbox_pointer(exports_ptr as i64);
+    let key_str = crate::string::js_string_from_bytes(b"SharedCacheControls".as_ptr(), 19);
+    crate::object::js_object_set_field_by_name(exports_ptr, key_str, 7.0);
+
+    // A wrapper closure that returns `module.exports` (the W6 shape: the default
+    // getter yields this wrapper rather than the exports object).
+    let wrapper = js_closure_alloc(test_wrapper_returns_capture0 as *const u8, 1);
+    js_closure_set_capture_f64(wrapper, 0, exports);
+    let wrapper_value: f64 = crate::value::js_nanbox_pointer(wrapper as i64);
+
+    // Before registration the wrapper is not recognized and a property read off
+    // it (as a function value) is `undefined` — the pre-fix W6 failure.
+    assert!(!is_module_default_wrapper(wrapper as usize));
+    let pre = crate::object::js_object_get_field_by_name(
+        wrapper as *const crate::object::ObjectHeader,
+        key_str,
+    );
+    assert!(
+        pre.is_undefined(),
+        "unregistered wrapper must not auto-resolve exports"
+    );
+
+    // Register the wrapper VALUE (the codegen-emitted registrar at the default
+    // getter site). It must record the closure and return the value unchanged.
+    let returned = js_register_module_default_wrapper_value(wrapper_value);
+    assert_eq!(returned.to_bits(), wrapper_value.to_bits());
+    assert!(is_module_default_wrapper(wrapper as usize));
+    assert_eq!(
+        module_default_wrapper_exports(wrapper as usize).map(|v| v.to_bits()),
+        Some(exports.to_bits())
+    );
+
+    // After registration the property-read fallback calls the wrapper and reads
+    // `SharedCacheControls` off `module.exports` → resolves to 7.0.
+    let post = crate::object::js_object_get_field_by_name(
+        wrapper as *const crate::object::ObjectHeader,
+        key_str,
+    );
+    assert!(!post.is_undefined(), "registered wrapper must resolve exports");
+    assert_eq!(post.to_number(), 7.0);
+
+    // A non-closure value passed to the registrar is returned untouched and not
+    // registered (the common `let v = HONE_VERSION` getter case).
+    let number_val = 123.0_f64;
+    let n = js_register_module_default_wrapper_value(number_val);
+    assert_eq!(n.to_bits(), number_val.to_bits());
+}

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -3833,6 +3833,56 @@ pub extern "C" fn js_object_get_field_by_name(
                 if val.to_bits() != crate::value::TAG_UNDEFINED {
                     return JSValue::from_bits(val.to_bits());
                 }
+                // #5437 (Next.js W6): the receiver is a REGISTERED
+                // module-default-export wrapper closure (`const uw =
+                // require('S')` materialized + captured by-value). A member
+                // read like `uw.SharedCacheControls` should resolve against
+                // `module.exports`, not the wrapper function itself. Call the
+                // wrapper once to obtain `module.exports` and re-read the
+                // property off that object. Gated to wrappers codegen
+                // explicitly registered (so an arbitrary user closure is never
+                // auto-called) and to non-function-meta names (`constructor`,
+                // `prototype`, `name`, `length`, `caller`, `arguments`, well-
+                // known symbols) so a genuine function-property read still
+                // takes its dedicated path below.
+                if !matches!(
+                    name_str,
+                    "constructor"
+                        | "prototype"
+                        | "name"
+                        | "length"
+                        | "caller"
+                        | "arguments"
+                        | "apply"
+                        | "call"
+                        | "bind"
+                ) && !name_str.starts_with("@@")
+                    && !name_str.starts_with("Symbol(")
+                {
+                    if let Some(exports) =
+                        crate::closure::module_default_wrapper_exports(obj as usize)
+                    {
+                        let exports_bits = exports.to_bits();
+                        // Guard against the wrapper returning itself (would
+                        // recurse) or undefined/null (nothing to read from).
+                        let exports_jsv = JSValue::from_bits(exports_bits);
+                        if exports_bits != (obj as u64)
+                            && exports_bits
+                                != crate::value::js_nanbox_pointer(obj as i64).to_bits()
+                            && !exports_jsv.is_undefined()
+                            && !exports_jsv.is_null()
+                        {
+                            let exports_ptr = crate::value::js_nanbox_get_pointer(exports)
+                                as *const ObjectHeader;
+                            if !exports_ptr.is_null() {
+                                let result = js_object_get_field_by_name(exports_ptr, key);
+                                if !result.is_undefined() {
+                                    return result;
+                                }
+                            }
+                        }
+                    }
+                }
                 if name_str == "constructor" {
                     if let Some(ctor) =
                         crate::object::generator_function_constructor_of(obj as usize)

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -3867,13 +3867,12 @@ pub extern "C" fn js_object_get_field_by_name(
                         // recurse) or undefined/null (nothing to read from).
                         let exports_jsv = JSValue::from_bits(exports_bits);
                         if exports_bits != (obj as u64)
-                            && exports_bits
-                                != crate::value::js_nanbox_pointer(obj as i64).to_bits()
+                            && exports_bits != crate::value::js_nanbox_pointer(obj as i64).to_bits()
                             && !exports_jsv.is_undefined()
                             && !exports_jsv.is_null()
                         {
-                            let exports_ptr = crate::value::js_nanbox_get_pointer(exports)
-                                as *const ObjectHeader;
+                            let exports_ptr =
+                                crate::value::js_nanbox_get_pointer(exports) as *const ObjectHeader;
                             if !exports_ptr.is_null() {
                                 let result = js_object_get_field_by_name(exports_ptr, key);
                                 if !result.is_undefined() {


### PR DESCRIPTION
## What
Closes the Next.js standalone (turbopack `app-page-turbo`) **W6** render throw: `TypeError: undefined is not a constructor` at `new uw.SharedCacheControls(...)` in the `IncrementalCache` constructor.

## Root cause
`let uw = require(".../shared-cache-controls.external.js")` is a lazy/function-local require. Its value-read takes the `imported_vars` **default-getter** path (`dyn_extern_i18n.rs`), which for a CJS `Object.defineProperty(exports, …)` module returns the module-default **wrapper closure** (the un-called IIFE), not `module.exports`. The `IncrementalCache` class captures that closure **by value** into a `__perry_cap_` field, so `uw.SharedCacheControls` reads the closure → `undefined` → `new undefined()` throws. It diverges only at giant-bundle scale — the import getter resolves the real object everywhere else (which is why this was so hard to pin; details in the issue/memory).

## Fix (5 files, +235)
- **Runtime registry** (`closure/dynamic_props.rs`): `MODULE_DEFAULT_WRAPPER_FUNCPTRS` + FFI `js_register_module_default_wrapper_value` + `is_module_default_wrapper` / `module_default_wrapper_exports`.
- **Codegen** (`dyn_extern_i18n.rs`, imported-var default getter): registers the wrapper, **gated to `origin_suffix == "default" && name.starts_with("_lazyreq_")`** so a genuine `export default <function>` is never auto-called (safety).
- **Runtime fallback** (`object/field_get_set.rs`, closure property-read): for a *registered* wrapper on a property miss + non-function-meta key, call it once (`js_closure_call0`) → `module.exports` → re-read the property (guarded against self-return / undefined / null).
- Regression test `module_default_wrapper_property_read_resolves_exports`.

## Validation
- Bundle: undefined-ctor **1 → 0, deterministic across 3 runs** (correct recipe: wait-for-bind via `lsof`, single `curl --max-time 45`). The render advances **past** W6 to a separate downstream wall (a `.length` read on undefined — the next target, tracked separately).
- `cargo test -p perry-hir -p perry-codegen -p perry-runtime`: new test passes; the only failure (`non_entry_module_init_body_gets_post_init_shadow_frame`) is **pre-existing on main** (verified via stash).
- Gap suite: no real new failures (the diffs are byte-identical Node/Perry output — local-env / `PERRY_NO_AUTO_OPTIMIZE` noise).
- Links clean. No behavior change for non-`defineProperty`-CJS default imports.

## Scope / risk
Narrowly gated (only `_lazyreq_` default-getter wrappers; generic closures are never auto-called). Found during the #5437 effort; first time the Next.js render advances past this wall.

Refs #5437.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash during Next.js W6 standalone rendering caused by a “module default export wrapper” resolution issue, eliminating the TypeError and allowing rendering to continue.
  * Added runtime support to recognize registered module-default wrapper closures and automatically forward property reads to the underlying `module.exports` when appropriate.
* **Tests**
  * Added a regression test covering module-default wrapper property resolution and non-closure handling.
* **Chores**
  * Updated version to **0.5.1200**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->