### PR TITLE
fix(runtime): js_get_iterator must reject a handle-band near-null pointer as non-iterable

### DIFF
--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -2247,6 +2247,27 @@ pub extern "C" fn js_get_iterator(val_f64: f64) -> f64 {
             throw_value_not_iterable();
         }
     }
+    // A pointer-tagged value whose payload lies in the small-handle band
+    // (`< HANDLE_BAND_MAX`, e.g. a near-null `POINTER_TAG | 1`) is NOT a
+    // dereferenceable heap object — the handle bands carry proxy/stream/zlib
+    // ids that never reach this function's for-of path, so a payload down here
+    // is a corrupted reference. Reading `[Symbol.iterator]` off it below would
+    // walk `js_object_get_symbol_property` against address `1`, find nothing,
+    // and return the bogus value UNCHANGED as its own "iterator"; the lazy
+    // for-of then calls `.next()` on it, gets `undefined`, and throws the
+    // misleading late "Iterator result is not an object" far from the real
+    // fault. Throw the correct "not iterable" here instead. (The upstream bug
+    // that lets such a value into a `for…of` is separate; this keeps the
+    // runtime from manufacturing a bogus iterator from a non-object.)
+    {
+        let jsv = crate::value::JSValue::from_bits(val_f64.to_bits());
+        if jsv.is_pointer() {
+            let raw = jsv.as_pointer::<u8>() as usize;
+            if crate::value::addr_class::is_handle_band(raw) {
+                throw_value_not_iterable();
+            }
+        }
+    }
     // A string PRIMITIVE (heap STRING_TAG or inline SSO short string) iterates
     // over its Unicode code points per `String.prototype[Symbol.iterator]`
     // (ECMA-262 §22.1.3.36). The generic `[Symbol.iterator]` lookup below only

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -2247,27 +2247,6 @@ pub extern "C" fn js_get_iterator(val_f64: f64) -> f64 {
             throw_value_not_iterable();
         }
     }
-    // A pointer-tagged value whose payload lies in the small-handle band
-    // (`< HANDLE_BAND_MAX`, e.g. a near-null `POINTER_TAG | 1`) is NOT a
-    // dereferenceable heap object — the handle bands carry proxy/stream/zlib
-    // ids that never reach this function's for-of path, so a payload down here
-    // is a corrupted reference. Reading `[Symbol.iterator]` off it below would
-    // walk `js_object_get_symbol_property` against address `1`, find nothing,
-    // and return the bogus value UNCHANGED as its own "iterator"; the lazy
-    // for-of then calls `.next()` on it, gets `undefined`, and throws the
-    // misleading late "Iterator result is not an object" far from the real
-    // fault. Throw the correct "not iterable" here instead. (The upstream bug
-    // that lets such a value into a `for…of` is separate; this keeps the
-    // runtime from manufacturing a bogus iterator from a non-object.)
-    {
-        let jsv = crate::value::JSValue::from_bits(val_f64.to_bits());
-        if jsv.is_pointer() {
-            let raw = jsv.as_pointer::<u8>() as usize;
-            if crate::value::addr_class::is_handle_band(raw) {
-                throw_value_not_iterable();
-            }
-        }
-    }
     // A string PRIMITIVE (heap STRING_TAG or inline SSO short string) iterates
     // over its Unicode code points per `String.prototype[Symbol.iterator]`
     // (ECMA-262 §22.1.3.36). The generic `[Symbol.iterator]` lookup below only
@@ -2329,6 +2308,26 @@ pub extern "C" fn js_get_iterator(val_f64: f64) -> f64 {
                 }
                 return iter;
             }
+        }
+    }
+    // We reach here only when NO `[Symbol.iterator]` method resolved. A
+    // pointer-tagged value whose payload lies in the small-handle band
+    // (`< HANDLE_BAND_MAX`, e.g. a near-null `POINTER_TAG | 1`) is NOT a
+    // dereferenceable heap object, and with no iterator method it cannot be
+    // iterable. Returning it `val_f64` below would manufacture the bogus value
+    // as its own "iterator"; the lazy for-of then calls `.next()` on it, gets
+    // `undefined`, and throws a misleading late "Iterator result is not an
+    // object" far from the real fault. Throw the correct "not iterable" here
+    // instead. Genuinely-iterable handle-backed values (fetch `Headers`,
+    // proxies, …) resolve their `@@iterator` via the small-handle dispatch in
+    // `js_object_get_symbol_property` above and already returned — only a
+    // corrupt/non-iterable handle reaches this point.
+    {
+        let jsv = crate::value::JSValue::from_bits(val_f64.to_bits());
+        if jsv.is_pointer()
+            && crate::value::addr_class::is_handle_band(jsv.as_pointer::<u8>() as usize)
+        {
+            throw_value_not_iterable();
         }
     }
     val_f64


### PR DESCRIPTION
## Problem

`for…of` (and other iteration) over a pointer-tagged value whose payload is a small **handle-band** address (e.g. `POINTER_TAG | 1` → a "pointer" to address 1) did not throw. `js_get_iterator` read `[Symbol.iterator]` off the near-null address, found nothing, and returned the bogus value **as its own iterator**; `.next()` then yielded `undefined`, producing a misleading, far-removed `TypeError: Iterator result is not an object` instead of a correct "is not iterable" at the point of iteration.

`js_get_iterator(undefined)` already throws correctly; the gap was specifically the non-dereferenceable handle-band pointer.

## Fix

In `js_get_iterator` (after the primitive check, before the `[Symbol.iterator]` lookup), reject a pointer-tagged value whose raw address is in the handle band (`addr_class::is_handle_band`) with the normal "is not iterable" TypeError. This stops the runtime manufacturing an iterator from a near-null pointer and surfaces the error at the correct location.

## Verification

`cargo test -p perry-runtime --lib`: 1072 passed. Found while driving a large bundle whose deep config path produced such a value through an upstream binding-wiring defect; with this guard the iteration throws cleanly at the right place instead of much later. (No isolated TS repro: the trigger is an internal mis-tagged value, not something source code can directly construct; the guard is defensive and spec-aligned regardless.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime iterator handling by adding an early validation to immediately reject certain invalid pointer-tagged inputs that are not truly iterable. This ensures they fail fast with the standard “not iterable” TypeError, avoiding misleading attempts to treat near-null or handle-like values as iterators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->