### PR TITLE
fix(fastify): serve responses again — run the accept loop on the shared reactor

### DIFF
--- a/crates/perry-ext-fastify/src/server.rs
+++ b/crates/perry-ext-fastify/src/server.rs
@@ -260,9 +260,22 @@ pub unsafe extern "C" fn js_fastify_listen(app_handle: Handle, opts: f64, callba
     let upgrade_tx_for_spawn = upgrade_tx.clone();
     let routes_for_spawn = routes_arc.clone();
 
-    perry_ffi::spawn_blocking(move || {
-        let handle = tokio::runtime::Handle::current();
-        handle.block_on(async move {
+    // The accept loop must run as a cooperative task on the shared
+    // multi-thread runtime. A plain `spawn_blocking` thread does not
+    // reliably carry the runtime's reactor/worker context: with
+    // `Handle::current().block_on(accept_loop)` the listener bound and
+    // accepted connections, but the per-connection
+    // `tokio::spawn(serve_connection)` tasks below were never driven — the
+    // request bytes sat unread and every response hung (the "in release the
+    // IO loop silently failed to start" brittleness the net/ws adapters
+    // hit). `spawn_blocking_with_reactor` runs the closure inside a worker
+    // task (`runtime().spawn(async { … })`), so `tokio::spawn`-ing the
+    // accept loop drives it and its fan-out serve tasks on the worker pool —
+    // mirroring perry-ext-http-server / -net / -ws. (A bare
+    // `Handle::current().block_on` here would panic "Cannot start a runtime
+    // from within a runtime" inside the worker task; spawn instead.)
+    perry_ffi::spawn_blocking_with_reactor(move || {
+        tokio::spawn(async move {
             let addr = SocketAddr::from(([0, 0, 0, 0], port));
             let listener = match TcpListener::bind(addr).await {
                 Ok(l) => l,


### PR DESCRIPTION
## Symptom

A Perry-compiled Fastify server binds and logs `Server listening …` but never
answers any request — TCP connects, then hangs with no response. The end-to-end
test fails completely: `scripts/run_fastify_tests.sh` → **0/12**, every route
empty / status 000.

## Root cause

A live probe (`lsof`/`netstat`) pinned the exact stall: the listener **binds and
accepts** the connection (it reaches `ESTABLISHED`), but the request bytes sit
**unread** in the socket — the per-connection `tokio::spawn(serve_connection)`
tasks are never driven.

`js_fastify_listen` launched the hyper accept loop with:

```rust
perry_ffi::spawn_blocking(move || {
    let handle = tokio::runtime::Handle::current();
    handle.block_on(async move { /* bind + accept loop */ });
});
```

A plain `spawn_blocking` thread does **not** carry the shared multi-thread
runtime's reactor/worker context, so the accept loop's fan-out `tokio::spawn`s
are orphaned — the "in release the IO loop silently failed to start" brittleness
already documented in the net/ws adapters. Fastify was the only HTTP extension
still using this pattern; `perry-ext-net`, `perry-ext-ws`, and
`perry-ext-http-server` all run their accept loops as cooperative tasks on the
shared runtime.

## Fix

Mirror the proven `perry-ext-http-server` pattern: spawn via
`perry_ffi::spawn_blocking_with_reactor` (which runs the closure inside
`runtime().spawn(async { … })`, a worker task with full reactor + handle access)
and `tokio::spawn` the accept loop. The accept-loop body is unchanged.

## Verification

- `scripts/run_fastify_tests.sh`: **0/12 → 7/12** — every serving path now passes
  (routing, path params, JSON/text bodies, 404, error status codes).
- In-process fastify test (`await app.listen()` + same-process `fetch`): `ok=true`.
- `cargo test -p perry-ext-fastify`: 13/13.
- All three honest_bench `http_fastify` kernels serve in ~1 ms.

The 5 remaining `run_fastify_tests.sh` failures are a **pre-existing, unrelated**
bug in the `setErrorHandler` path: `reply.code(n).send()` chaining returns
`undefined` because the error-handler closure's `reply`/`req` params aren't
tagged as Fastify native instances during codegen (same family as the test's
documented issue #1070). That lives in `perry-codegen`, not the serving path, and
is out of scope here. Follow-up PR planned to address.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized server connection handling to more efficiently utilize the shared Tokio runtime, improving overall stability and performance when serving requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->