### PR TITLE
fix(compile): aliased named import must not also register routing under the imported name

### DIFF
--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -3530,16 +3530,24 @@ pub fn run_with_parse_cache(
                             // would drop varargs — only the `import * as`
                             // namespace shape uses the submodule.
                             if submod_key != "timers" {
+                                // Register ONLY the local binding. For an
+                                // aliased import (`import { setTimeout as ac5 }
+                                // from "node:timers/promises"`) the in-scope
+                                // name is `ac5`; the imported name `setTimeout`
+                                // is NOT bound here — it still refers to the
+                                // GLOBAL `setTimeout(callback, delay)`. A prior
+                                // version also keyed the map by `imported` when
+                                // `local != imported`, which made the bare
+                                // global `setTimeout(fn, ms)` divert to the
+                                // delay-first promises thunk and reject with
+                                // `The "delay" argument must be of type number.
+                                // Received function`. Keying only by `local`
+                                // keeps the alias routed to the submodule export
+                                // and leaves the unshadowed global intact.
                                 import_function_node_submodule.insert(
                                     local.clone(),
                                     (submod_key.clone(), imported.clone()),
                                 );
-                                if local != imported {
-                                    import_function_node_submodule.insert(
-                                        imported.clone(),
-                                        (submod_key.clone(), imported.clone()),
-                                    );
-                                }
                             }
                         }
                         perry_hir::ImportSpecifier::Default { local } => {

--- a/crates/perry/tests/issue_aliased_timers_promises_global_setTimeout.rs
+++ b/crates/perry/tests/issue_aliased_timers_promises_global_setTimeout.rs
@@ -1,0 +1,84 @@
+//! An aliased named import of `setTimeout` from `node:timers/promises` must
+//! NOT shadow the global `setTimeout(callback, delay)`.
+//!
+//! `import { setTimeout as delayP } from "node:timers/promises"` binds only the
+//! local name `delayP`; the bare identifier `setTimeout` still refers to the
+//! GLOBAL callback-first timer. A prior version of the submodule-import
+//! registration keyed the routing map by BOTH the local alias AND the imported
+//! name whenever they differed, so the global `setTimeout(() => {}, ms)` was
+//! diverted to the delay-first `timers/promises` thunk. That thunk validated
+//! the callback as the `delay` argument and rejected the promise with
+//! `TypeError: The "delay" argument must be of type number. Received function`
+//! — an uncaught rejection (observed via a CLI bundle's `mcp list` path).
+//!
+//! Keying the map only by the local alias keeps the alias routed to the
+//! promises export while leaving the unshadowed global intact. The unaliased
+//! `import { setTimeout } from "node:timers/promises"` form (which DOES shadow
+//! the global, matching Node) is unaffected.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, entry: &std::path::Path) -> (bool, String, String) {
+    let output = dir.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let run = Command::new(&output).output().expect("run compiled binary");
+    (
+        run.status.success(),
+        String::from_utf8_lossy(&run.stdout).to_string(),
+        String::from_utf8_lossy(&run.stderr).to_string(),
+    )
+}
+
+#[test]
+fn aliased_timers_promises_set_timeout_does_not_shadow_global() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+import { setTimeout as delayP } from "node:timers/promises";
+
+(async () => {
+  // The aliased promises form: delay-first, returns a Promise.
+  await delayP(0);
+  console.log("promises-form ok");
+
+  // The GLOBAL callback-first form must still work in the same module.
+  setTimeout(() => { console.log("global cb fired"); }, 0);
+  console.log("global scheduled ok");
+})();
+"#,
+    )
+    .expect("write entry");
+
+    let (ok, stdout, stderr) = compile_and_run(dir.path(), &entry);
+    assert!(ok, "binary failed\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    assert!(
+        !stderr.contains("The \"delay\" argument must be of type number"),
+        "global setTimeout was wrongly routed to the timers/promises validator\nstderr:\n{stderr}"
+    );
+    for needle in ["promises-form ok", "global scheduled ok", "global cb fired"] {
+        assert!(
+            stdout.contains(needle),
+            "expected `{needle}` in output:\n{stdout}"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

A module that **aliases** a named import from a native submodule while *also* using the same name as a global causes the global to be mis-routed. Concretely:

```ts
import { setTimeout as delay } from "node:timers/promises";  // delay-first: setTimeout(ms, value)
setTimeout(() => {...}, 10);                                   // GLOBAL: callback-first
```

throws `TypeError: The "delay" argument must be of type number. Received function` — the **global** `setTimeout(cb, ms)` is diverted to the `timers/promises` delay-first thunk, which then validates the callback function as the numeric `delay`.

## Root cause

In the submodule-import registration loop (`crates/perry/src/commands/compile.rs`), a Named import registered the routing map (`import_function_node_submodule`) by the **local** binding (correct) **and additionally by the imported name whenever `local != imported`** (wrong). So `import { setTimeout as delay }` registered the key `"setTimeout"`, and codegen (`lower_call/extern_func.rs`) then matched the bare global `setTimeout` identifier and routed it to the promises thunk.

An aliased import introduces **only the local name** into scope — the imported name is not bound. Registering it shadows an unrelated global of that name. (Same family as the earlier aliased-named-import resolution bug.) The runtime validator (`node_submodules/timers.rs`) was correctly reporting a real arg-order mismatch caused by this upstream mis-routing.

## Fix

Key the routing map **only by the local binding**. Remove the spurious imported-name registration.

## Tests

`crates/perry/tests/issue_aliased_timers_promises_global_setTimeout.rs` — aliased `timers/promises` import coexisting with global `setTimeout(cb, ms)`: before → the TypeError; after → both work. The *unaliased* `import { setTimeout } from "node:timers/promises"` case still shadows the global (matches Node), so that legitimate behavior is preserved. `cargo test -p perry-runtime --lib`: 1072 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where aliased imports from Node submodules could interfere with global functions of the same name. Users can now safely use aliased imports without accidentally shadowing global functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->