### PR TITLE
fix(fastify): keep req/reply native tags on untyped handler params

### DIFF
--- a/crates/perry-ext-fastify/src/server.rs
+++ b/crates/perry-ext-fastify/src/server.rs
@@ -260,9 +260,22 @@ pub unsafe extern "C" fn js_fastify_listen(app_handle: Handle, opts: f64, callba
     let upgrade_tx_for_spawn = upgrade_tx.clone();
     let routes_for_spawn = routes_arc.clone();
 
-    perry_ffi::spawn_blocking(move || {
-        let handle = tokio::runtime::Handle::current();
-        handle.block_on(async move {
+    // The accept loop must run as a cooperative task on the shared
+    // multi-thread runtime. A plain `spawn_blocking` thread does not
+    // reliably carry the runtime's reactor/worker context: with
+    // `Handle::current().block_on(accept_loop)` the listener bound and
+    // accepted connections, but the per-connection
+    // `tokio::spawn(serve_connection)` tasks below were never driven — the
+    // request bytes sat unread and every response hung (the "in release the
+    // IO loop silently failed to start" brittleness the net/ws adapters
+    // hit). `spawn_blocking_with_reactor` runs the closure inside a worker
+    // task (`runtime().spawn(async { … })`), so `tokio::spawn`-ing the
+    // accept loop drives it and its fan-out serve tasks on the worker pool —
+    // mirroring perry-ext-http-server / -net / -ws. (A bare
+    // `Handle::current().block_on` here would panic "Cannot start a runtime
+    // from within a runtime" inside the worker task; spawn instead.)
+    perry_ffi::spawn_blocking_with_reactor(move || {
+        tokio::spawn(async move {
             let addr = SocketAddr::from(([0, 0, 0, 0], port));
             let listener = match TcpListener::bind(addr).await {
                 Ok(l) => l,

--- a/crates/perry-hir/src/lower/expr_call/prescans.rs
+++ b/crates/perry-hir/src/lower/expr_call/prescans.rs
@@ -40,17 +40,37 @@ pub(super) fn run_call_prescans(
     let fastify_handler_names: Option<(String, String)> =
         pre_scan_fastify_handler_params(ctx, call);
     if let Some((req_name, reply_name)) = &fastify_handler_names {
-        ctx.register_native_instance(
+        // The arrow's own `req`/`reply` param bindings would otherwise tombstone
+        // these fresh tags via `shadow_native_instance_if_present` (the arrow
+        // param-shadowing added in #5438) — protect them so `request.header(...)`
+        // and `reply.code(...).send(...)` inside the handler keep dispatching
+        // through the fastify Request/Reply table rows. Protect only when
+        // registration actually happened (it no-ops under a `perry.compilePackages`
+        // override), else a later same-named param would skip tombstoning a
+        // genuinely stale tag — same gating as the `wsId`/`sock` sites below.
+        //
+        // Without this, an untyped `(req, reply) =>` handler lost the Reply tag,
+        // so every `reply.*` lowered to the generic fallback and silently no-op'd:
+        // `reply.code(n)`/`status(n)` were ignored (status stayed 200),
+        // `reply.send(x)` left the body empty, and `reply.code(n).send(x)` threw
+        // (the un-dispatched `.code(n)` returned undefined). Typed
+        // `reply: FastifyReply` handlers were masked by the post-shadow type-based
+        // re-registration, which is why only the common untyped JS form broke.
+        if ctx.register_native_instance(
             req_name.clone(),
             "fastify".to_string(),
             "Request".to_string(),
-        );
-        if !reply_name.is_empty() {
-            ctx.register_native_instance(
+        ) {
+            ctx.protect_native_param(req_name.clone());
+        }
+        if !reply_name.is_empty()
+            && ctx.register_native_instance(
                 reply_name.clone(),
                 "fastify".to_string(),
                 "Reply".to_string(),
-            );
+            )
+        {
+            ctx.protect_native_param(reply_name.clone());
         }
     }
 


### PR DESCRIPTION
> **Stacked on #5554.** This branch includes the #5554 serving fix as its first commit — the Fastify integration test can't run until the server actually serves. Once #5554 merges, this PR's diff reduces to the single `prescans.rs` change. Both are needed for the CI-gated `run_fastify_tests.sh` step to be green.

## Symptom

In a Fastify route / hook / error handler written the common untyped way —
`async (req, reply) => …` (no `reply: FastifyReply` annotation) — every
`reply.*` call silently no-op'd:

- `reply.code(n)` / `reply.status(n)` ignored — status stayed 200
- `reply.send(x)` produced an empty `{}` body
- `reply.code(n).send(x)` threw `Cannot read properties of undefined (reading 'send')`

Routes that only `return` a value were unaffected. `scripts/run_fastify_tests.sh`
(CI-gated) failed 5/12 on exactly these (POST /echo status, and the
`setErrorHandler` `reply.code(n).send(...)` routes).

## Root cause

The fastify handler pre-scan (`run_call_prescans`) registers the arrow's
`req`/`reply` params as `("fastify","Request")` / `("fastify","Reply")` native
instances so `request.header(...)` / `reply.code(...)` dispatch through the
static fastify table. But it never called `protect_native_param` — so when the
arrow's own param binding ran `shadow_native_instance_if_present` (the arrow
param-shadowing added in #5438), it **tombstoned the freshly-registered tag**.
With `reply` untagged in the handler body, every `reply.*` lowered to the
generic fallback, which has no external-fastify reply arm and no-ops.

The three sibling pre-scans — http `res`, ws `wsId`, net `sock` — were all given
`protect_native_param` when the shadowing landed; the fastify one was missed.
Typed `reply: FastifyReply` handlers kept working via the post-shadow
type-based re-registration, which is why only the untyped JS form regressed.

## Fix

One block in `crates/perry-hir/src/lower/expr_call/prescans.rs`: protect the
`req`/`reply` params on successful registration, mirroring the `wsId`/`sock`
sites. The tag survives the param binding, `reply.*` lowers to a
`NativeMethodCall`, and the static table (send/code/status/header/type, with the
chain methods returning the reply handle) dispatches to the already-correct
runtime `js_fastify_reply_*`. No runtime or table change needed.

## Verification

- `scripts/run_fastify_tests.sh`: **7/12 → 12/12** (on top of #5554).
- `reply.status(n)` / `code(n)` / `send(x)` / `code(n).send(x)` confirmed correct
  on a live server.
- In-process fastify test: `ok=true`.
- `cargo test -p perry-hir` (41) and `-p perry-ext-fastify` (13) green;
  `-p perry-codegen` green except one pre-existing unrelated failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Fastify server listener initialization for improved runtime stability.
  * Optimized handler parameter registration with conditional validation for native instances.

* **Refactor**
  * Streamlined server accept loop and per-connection task execution patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->