### PR TITLE
chore(deps): bump quinn-proto 0.11.14 → 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6807,9 +6807,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## What

Lockfile-only bump of `quinn-proto` 0.11.14 → 0.11.15.

## Why

The `security-audit` CI job started failing on **every open PR** (and `main`) the moment **RUSTSEC-2026-0185** landed in the advisory DB — unrelated to any in-tree code change. The advisory:

- **Crate:** `quinn-proto` v0.11.14
- **Title:** Remote memory exhaustion from unbounded out-of-order stream reassembly
- **Solution:** Upgrade to `>=0.11.15`

`quinn-proto` is a transitive dependency (HTTP/3 path via the reqwest/quinn stack).

## How

```
cargo update -p quinn-proto --precise 0.11.15
```

Touches only the two `Cargo.lock` lines (version + checksum) — no other dependency churn.

## Verification

Ran `cargo audit` locally with CI's exact ignore set:

```
cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0118 --ignore RUSTSEC-2026-0119
```

→ exit 0, only the 7 pre-existing allowed warnings remain.

Once this lands on `main`, other open PRs (e.g. #5559) clear the same audit failure on rebase.