### PR TITLE
benchmarks: add honest_bench workload 4 — Fastify HTTP throughput

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,12 @@ issue42_noalloc
 enum_repro
 no_pragma_test
 
+# Compiled honest_bench workload 4 binaries (next to their .ts sources;
+# binary names are too generic to ignore bare).
+benchmarks/honest_bench/workloads/4_http_fastify/perry/minimal
+benchmarks/honest_bench/workloads/4_http_fastify/perry/parametric
+benchmarks/honest_bench/workloads/4_http_fastify/perry/text
+
 # Test output
 test-parity/output/
 test-parity/reports/

--- a/benchmarks/honest_bench/harness/run_http_bench.sh
+++ b/benchmarks/honest_bench/harness/run_http_bench.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Long-running HTTP server bench: spawn binary, drive oha load, capture
+# rps + p50/p95/p99 latencies + peak RSS, kill, emit one row per measured
+# run in the same shape as run_bench.sh so summary.py + check_output.py
+# work without modification.
+#
+# Usage:
+#   run_http_bench.sh <workload> <language> <run-cmd...> -- <route>
+#
+# Examples:
+#   run_http_bench.sh http_fastify_minimal perry \
+#     /path/to/perry_minimal_bin -- /
+#   run_http_bench.sh http_fastify_minimal node \
+#     node --import tsx /path/to/node/minimal.ts -- /
+#
+# All args between <run-cmd...> and `--` form the command launched in
+# the background; the value after `--` is the route appended to
+# http://127.0.0.1:<port>, where <port> is HONEST_BENCH_HTTP_PORT
+# (default 18080) — the same var the kernels bind.
+#
+# Per measured run:
+#   workload, language, binary, run, wall_ms, max_rss_kb, exit_code,
+#   stdout_first, stdout_last, output_match (always null for HTTP).
+#
+# Encoding:
+#   - `binary` = the run-cmd joined by spaces, truncated to 200 chars
+#   - `wall_ms = 1_000_000 / rps` — "lower is better" semantics carry
+#                through to summary.py without code change
+#   - `stdout_first` synthesizes the metric tokens so check_output.py's
+#     TOKEN_RE matches: `rps=N p50_ms=N p95_ms=N p99_ms=N rss_kb=N`
+
+set -uo pipefail
+
+if [[ $# -lt 4 ]]; then
+  echo "usage: $0 <workload> <language> <run-cmd...> -- <route>" >&2
+  exit 2
+fi
+
+WORKLOAD="$1"; shift
+LANGUAGE="$1"; shift
+
+# Split CMD ... -- ROUTE
+RUN_CMD=()
+ROUTE=""
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--" ]]; then
+    shift
+    ROUTE="${1:-/}"
+    break
+  fi
+  RUN_CMD+=("$1")
+  shift
+done
+
+if [[ ${#RUN_CMD[@]} -eq 0 || -z "$ROUTE" ]]; then
+  echo "usage: $0 <workload> <language> <run-cmd...> -- <route>" >&2
+  exit 2
+fi
+
+WARMUP="${HONEST_BENCH_WARMUP:-1}"
+MEASURED="${HONEST_BENCH_MEASURED:-5}"
+DURATION="${HONEST_BENCH_HTTP_DURATION:-15s}"
+WARMUP_DUR="${HONEST_BENCH_HTTP_WARMUP_DUR:-5s}"
+CONC="${HONEST_BENCH_HTTP_CONC:-10}"
+PORT="${HONEST_BENCH_HTTP_PORT:-18080}"
+OHA="${HONEST_BENCH_OHA:-/tmp/oha}"
+
+if [[ ! -x "$OHA" ]]; then
+  echo "ERROR: oha binary not found at $OHA (set HONEST_BENCH_OHA)" >&2
+  exit 2
+fi
+
+BIN_LABEL=$(printf '%s ' "${RUN_CMD[@]}" | head -c 200)
+
+# ---------------------------------------------------------------------
+# Spawn server, wait for TCP listen
+# ---------------------------------------------------------------------
+SERVER_LOG=$(mktemp)
+"${RUN_CMD[@]}" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+cleanup() {
+  if kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill -TERM "$SERVER_PID" 2>/dev/null || true
+    for _ in 1 2 3 4 5; do
+      kill -0 "$SERVER_PID" 2>/dev/null || break
+      sleep 0.2
+    done
+    kill -KILL "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -f "$SERVER_LOG"
+}
+trap cleanup EXIT
+
+# Up to 30s to start listening — Perry binaries cold-start fast but node
+# + tsx + fastify first-import can take a few seconds.
+ready=0
+for _ in $(seq 1 60); do
+  if curl -fsS --max-time 1 "http://127.0.0.1:${PORT}${ROUTE}" >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "ERROR: server exited before listening; first 400 chars of log:" >&2
+    head -c 400 "$SERVER_LOG" >&2
+    exit 2
+  fi
+  sleep 0.5
+done
+if [[ "$ready" != 1 ]]; then
+  echo "ERROR: server did not start listening on :${PORT}${ROUTE} within 30s" >&2
+  head -c 400 "$SERVER_LOG" >&2
+  exit 2
+fi
+
+URL="http://127.0.0.1:${PORT}${ROUTE}"
+
+# Peak RSS in KiB for the server process. VmHWM is the resident-set high-water
+# mark (matches the `max_rss_kb` row field); VmRSS would only report the current
+# instantaneous RSS. Linux /proc only — falls back to 0 elsewhere.
+read_rss_kb() {
+  # END guard so a /proc file present-but-without-VmHWM still prints 0 (never an
+  # empty string, which would break the row builder's int(rss_kb)); `|| echo 0`
+  # covers the off-Linux / missing-file case where awk exits nonzero.
+  awk '/^VmHWM:/ {print $2; f=1; exit} END {if (!f) print 0}' \
+    "/proc/${SERVER_PID}/status" 2>/dev/null || echo 0
+}
+
+run_one_measurement() {
+  local run_idx="$1"
+  local json
+  json=$(mktemp)
+
+  local start_ns end_ns
+  start_ns=$(python3 -c 'import time; print(time.monotonic_ns())')
+  # A failed oha invocation is RECORDED as a zero-throughput row (rps=0 ->
+  # exit_code 1 below) and the suite continues — matching run.sh's "record the
+  # failure, don't abort the suite" contract (run.sh header) and the sibling
+  # run_bench.sh. Aborting here would trip run.sh's `set -e` and discard every
+  # already-collected row. oha's stderr stays visible (no 2>/dev/null) so the
+  # cause is diagnosable; the empty `{}` makes the row builder emit rps=0.
+  if ! "$OHA" -z "$DURATION" -c "$CONC" -r 0 --no-tui --output-format json "$URL" >"$json"; then
+    echo "WARNING: oha failed for $WORKLOAD / $LANGUAGE (measured run $run_idx); recording a failed row" >&2
+    echo '{}' >"$json"
+  fi
+  end_ns=$(python3 -c 'import time; print(time.monotonic_ns())')
+
+  local rss_kb
+  rss_kb=$(read_rss_kb)
+
+  python3 - "$WORKLOAD" "$LANGUAGE" "$BIN_LABEL" "$run_idx" \
+           "$start_ns" "$end_ns" "$rss_kb" "$json" <<'PY'
+import json, sys
+
+(_, workload, lang, binary, run, start_ns, end_ns, rss_kb, json_path) = sys.argv
+with open(json_path) as f:
+    data = json.load(f)
+
+rps    = data.get("summary", {}).get("requestsPerSec") or 0.0
+p50    = (data.get("latencyPercentiles", {}).get("p50") or 0.0) * 1000.0
+p95    = (data.get("latencyPercentiles", {}).get("p95") or 0.0) * 1000.0
+p99    = (data.get("latencyPercentiles", {}).get("p99") or 0.0) * 1000.0
+status = data.get("statusCodeDistribution", {}) or {}
+success_rate = data.get("summary", {}).get("successRate") or 0.0
+
+# "lower is better" encoding for wall_ms — used by summary.py.
+wall_ms = 1_000_000.0 / rps if rps > 0 else 1_000_000.0
+
+# Token block parsed by check_output.py's TOKEN_RE: bare key=value pairs
+token_line = (
+    f"rps={rps:.2f} "
+    f"p50_ms={p50:.3f} "
+    f"p95_ms={p95:.3f} "
+    f"p99_ms={p99:.3f} "
+    f"rss_kb={rss_kb} "
+    f"success_rate={success_rate:.4f} "
+    f"status={','.join(f'{k}={v}' for k,v in sorted(status.items()))}"
+)
+
+row = {
+    "workload": workload,
+    "language": lang,
+    "binary": binary.strip(),
+    "run": int(run),
+    "wall_ms": wall_ms,
+    "max_rss_kb": int(rss_kb),
+    # Reflect run health like the other workloads' exit_code: a run that served
+    # no requests (rps == 0) or dropped >1% of them (e.g. crashes / 5xx under
+    # load) is a failure, so downstream tooling doesn't treat it as a clean row.
+    "exit_code": 0 if (rps > 0 and success_rate >= 0.99) else 1,
+    "stdout_first": token_line[:200],
+    "stdout_last":  token_line[-200:],
+    "output_match": None,
+    "output_match_reason": "http throughput workload — no expected output",
+    "rps": rps,
+    "p50_ms": p50,
+    "p95_ms": p95,
+    "p99_ms": p99,
+    "success_rate": success_rate,
+    "status_codes": status,
+}
+print(json.dumps(row))
+PY
+
+  rm -f "$json"
+}
+
+# Warmup runs — discard
+for _ in $(seq 1 "$WARMUP"); do
+  "$OHA" -z "$WARMUP_DUR" -c "$CONC" -r 0 --no-tui --output-format quiet "$URL" \
+      >/dev/null 2>&1 || true
+done
+
+# Measured runs — emit JSON per line
+for i in $(seq 1 "$MEASURED"); do
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "ERROR: server died before measured run $i; first 400 chars of log:" >&2
+    head -c 400 "$SERVER_LOG" >&2
+    exit 2
+  fi
+  run_one_measurement "$i"
+done

--- a/benchmarks/honest_bench/run.sh
+++ b/benchmarks/honest_bench/run.sh
@@ -15,7 +15,8 @@
 #   HONEST_BENCH_MEASURED=20
 #   HONEST_BENCH_SKIP_BUILD=1            — skip (re)building the toolchains
 #   HONEST_BENCH_ONLY=3                  — comma-separated workload ids to run
-#                                          (1=json, 3=image_convolution; 2 TBD)
+#                                          (1=json, 3=image_convolution,
+#                                           4=http_fastify; 2 TBD)
 #   HONEST_BENCH_REFRESH_EXPECTED=1      — rebuild results/expected.json from
 #                                          a fresh Bun run (output semantics
 #                                          intentionally changed)
@@ -94,6 +95,21 @@ if [[ -z "${HONEST_BENCH_SKIP_BUILD:-}" ]]; then
   echo "--- building Perry json_pipeline"
   (cd "$PERRY_ROOT" && target/release/perry "$ROOT/workloads/1_json_pipeline/perry/json_pipeline.ts" \
         -o "$ROOT/workloads/1_json_pipeline/perry/json_pipeline" 2>&1 | tail -2)
+
+  # Workload 4 (http_fastify) is opt-in — only build it when selected, since it
+  # compiles three Perry kernels and needs a one-time npm install of fastify.
+  if [[ ",${HONEST_BENCH_ONLY:-1,3}," == *,4,* ]]; then
+    HTTP_KERNEL_DIR="$ROOT/workloads/4_http_fastify"
+    for kernel in minimal text parametric; do
+      echo "--- building Perry http_fastify/$kernel"
+      (cd "$PERRY_ROOT" && target/release/perry "$HTTP_KERNEL_DIR/perry/$kernel.ts" \
+            -o "$HTTP_KERNEL_DIR/perry/$kernel" 2>&1 | tail -2)
+    done
+    if [[ ! -d "$HTTP_KERNEL_DIR/node/node_modules" ]]; then
+      echo "--- npm install fastify (http_fastify/node, one-time)"
+      (cd "$HTTP_KERNEL_DIR/node" && npm install --no-audit --no-fund --silent)
+    fi
+  fi
 fi
 
 # ------------------------------ 3. fixtures -----------------------------------
@@ -205,6 +221,35 @@ if [[ ",$ONLY," == *,1,* ]]; then
   run_one json_pipeline_full perry "$ROOT/workloads/1_json_pipeline/perry/json_pipeline"                 "$FULL_IN" "/tmp/out_perry.json"
   run_one json_pipeline_full node  "node" $NODE_FLAGS "$NODE_JSON" "$FULL_IN" "/tmp/out_node.json"
   run_one json_pipeline_full bun   "bun" "run" "$NODE_JSON" "$FULL_IN" "/tmp/out_bun.json"
+fi
+
+if [[ ",$ONLY," == *,4,* ]]; then
+  HTTP_KERNEL_DIR="$ROOT/workloads/4_http_fastify"
+  NODE_KERNEL_DIR="$HTTP_KERNEL_DIR/node"
+  # <workload> <language> <route> then the run-cmd — the harness splits the
+  # run-cmd from the route on the trailing `--`.
+  run_http() {
+    local workload="$1" lang="$2" route="$3"; shift 3
+    echo "--- running $workload / $lang"
+    # Tolerate a harness exit (e.g. a kernel that SIGSEGVs under load, or never
+    # starts listening) so one bad kernel doesn't abort the whole suite under
+    # this script's `set -e` — matching the "record the failure, don't abort"
+    # contract in the header. Already-collected rows survive and finalize runs.
+    bash "$ROOT/harness/run_http_bench.sh" "$workload" "$lang" "$@" -- "$route" >> "$RESULTS.rows" \
+      || echo "--- WARNING: $workload / $lang harness exited nonzero; continuing" >&2
+  }
+  for kernel in minimal text parametric; do
+    echo "=== workload 4: http_fastify / $kernel ==="
+    case "$kernel" in
+      parametric) route="/users/u1" ;;
+      *)          route="/" ;;
+    esac
+    run_http "http_fastify_$kernel" perry "$route" "$HTTP_KERNEL_DIR/perry/$kernel"
+    # node resolves `--import tsx` + fastify relative to cwd, so cd into the
+    # kernel dir before exec.
+    run_http "http_fastify_$kernel" node  "$route" \
+      bash -c "cd '$NODE_KERNEL_DIR' && exec node --import tsx ./$kernel.ts"
+  done
 fi
 
 # ------------------------------ 5. finalize -----------------------------------

--- a/benchmarks/honest_bench/workloads/4_http_fastify/README.md
+++ b/benchmarks/honest_bench/workloads/4_http_fastify/README.md
@@ -1,0 +1,70 @@
+# Workload 4 — Fastify HTTP throughput
+
+Long-running Fastify HTTP server driven by `oha -c 10 -z 15s` per
+measured run. Captures req/s, p50/p95/p99 latency, peak RSS.
+
+## Kernels
+
+| Kernel | Route | Response | Exercises |
+|---|---|---|---|
+| `minimal` | `GET /` | `{ok: true}` JSON | Framework overhead + JSON.stringify of one-field object |
+| `text` | `GET /` | `'pong'` text/plain | Primitive response fast path — no JSON.stringify, no per-response allocation |
+| `parametric` | `GET /users/:id` | `{id: <param>}` JSON | Router pattern match + per-request params object |
+
+Each kernel ships in two languages: `perry/` (compiles to native binary
+via `perry compile`) and `node/` (run via `node --import tsx`,
+upstream `fastify@^5.2.0` from npm).
+
+## Running
+
+Default sweep excludes workload 4 (it requires `oha` and a network
+loopback port; opt-in to keep CI deterministic):
+
+```bash
+HONEST_BENCH_ONLY=4 ./run.sh
+```
+
+Honoured env vars (overrides the defaults inside
+`harness/run_http_bench.sh`):
+
+- `HONEST_BENCH_WARMUP=1` — number of oha warmup sweeps (each
+  `HONEST_BENCH_HTTP_WARMUP_DUR` long, default 5s)
+- `HONEST_BENCH_MEASURED=5` — measured runs per kernel/language pair
+- `HONEST_BENCH_HTTP_DURATION=15s` — per-measured-run oha load duration
+- `HONEST_BENCH_HTTP_CONC=10` — oha concurrent connections (a small
+  concurrency appropriate for a per-request-latency-bound workload)
+- `HONEST_BENCH_HTTP_PORT=18080` — port the kernel binds
+- `HONEST_BENCH_OHA=/tmp/oha` — path to the oha binary
+
+## Result shape
+
+Each row in `results/results.json` has the standard honest_bench fields
+(`workload`, `language`, `binary`, `run`, `wall_ms`, `max_rss_kb`,
+`exit_code`, `stdout_first/_last`, `output_match`) plus four
+HTTP-specific keys:
+
+- `rps` — requests / second (higher is better)
+- `p50_ms`, `p95_ms`, `p99_ms` — latency percentiles in milliseconds
+- `success_rate` — fraction of 2xx/3xx responses (0..1)
+- `status_codes` — full HTTP status distribution
+
+`wall_ms` is synthesised as `1_000_000 / rps` so the existing
+`scripts/summary.py` "lower is better" sort still ranks correctly.
+
+## Why no Bun reference output
+
+Output-correctness checks (`harness/check_output.py`) are skipped for
+workload 4. There's no canonical response payload to sha256 — every
+response is `200 OK` with a small known body, and the metric of
+interest is rate, not content. `output_match` is reported as `null`.
+
+## Acceptance bar (relative to the Fastify perf work)
+
+This workload backs the per-PR verification of the Fastify perf sweep.
+It pins a fixed client load (`oha -c 10`) against each kernel so a PR's
+mean `rps` can be compared against the prior PR's run on the same
+hardware. The intent: as the Perry Fastify serving path lands its perf
+fixes, each subsequent PR's mean `rps` must beat the prior PR's run on
+at least one kernel without regressing the others. The Node kernels run
+the same routes on upstream `fastify` as a fixed external reference
+point.

--- a/benchmarks/honest_bench/workloads/4_http_fastify/node/minimal.ts
+++ b/benchmarks/honest_bench/workloads/4_http_fastify/node/minimal.ts
@@ -1,0 +1,11 @@
+// honest_bench workload 4 — http_fastify_minimal (node).
+// Same surface as perry/minimal.ts, run via
+// `node --import tsx node/minimal.ts` against the upstream npm fastify.
+
+import Fastify from 'fastify';
+
+const app = Fastify({ logger: false });
+
+app.get('/', async () => ({ ok: true }));
+
+app.listen({ port: parseInt(process.env.HONEST_BENCH_HTTP_PORT || '18080', 10), host: '127.0.0.1' });

--- a/benchmarks/honest_bench/workloads/4_http_fastify/node/package-lock.json
+++ b/benchmarks/honest_bench/workloads/4_http_fastify/node/package-lock.json
@@ -1,0 +1,1165 @@
+{
+  "name": "honest-bench-workload-4-http-fastify-node",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "honest-bench-workload-4-http-fastify-node",
+      "dependencies": {
+        "fastify": "^5.2.0"
+      },
+      "devDependencies": {
+        "tsx": "^4.19.2",
+        "typescript": "^5.6.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.5.tgz",
+      "integrity": "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0"
+      }
+    },
+    "node_modules/@fastify/error": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
+      "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.0.3.tgz",
+      "integrity": "sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-json-stringify": "^6.0.0"
+      }
+    },
+    "node_modules/@fastify/forwarded": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.1.tgz",
+      "integrity": "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@fastify/merge-json-schemas": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
+      "integrity": "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/proxy-addr": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.1.0.tgz",
+      "integrity": "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/forwarded": "^3.0.0",
+        "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+      "license": "MIT"
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/avvio": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.2.0.tgz",
+      "integrity": "sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "fastq": "^1.17.1"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stringify": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-6.4.0.tgz",
+      "integrity": "sha512-ibRCQ0GZKJIQ+P3Et1h0LhPgp3PMTYk0MH8O+kW3lNYsvmaQww5Nn3f1jf73Q0jR1Yz3a1CDP4/NZD3vOajWJQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0",
+        "json-schema-ref-resolver": "^3.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastify": {
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.5.tgz",
+      "integrity": "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/ajv-compiler": "^4.0.5",
+        "@fastify/error": "^4.0.0",
+        "@fastify/fast-json-stringify-compiler": "^5.0.0",
+        "@fastify/proxy-addr": "^5.0.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^9.0.0",
+        "fast-json-stringify": "^6.0.0",
+        "find-my-way": "^9.0.0",
+        "light-my-request": "^6.0.0",
+        "pino": "^9.14.0 || ^10.1.0",
+        "process-warning": "^5.0.0",
+        "rfdc": "^1.3.1",
+        "secure-json-parse": "^4.0.0",
+        "semver": "^7.6.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/find-my-way": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.6.0.tgz",
+      "integrity": "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/json-schema-ref-resolver": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
+      "integrity": "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/light-my-request": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
+      "integrity": "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "process-warning": "^4.0.0",
+        "set-cookie-parser": "^2.6.0"
+      }
+    },
+    "node_modules/light-my-request/node_modules/process-warning": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
+    "node_modules/safe-regex2": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.1.1.tgz",
+      "integrity": "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "ret": "~0.5.0"
+      },
+      "bin": {
+        "safe-regex2": "bin/safe-regex2.js"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
+      "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
+    },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
+      "integrity": "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/thread-stream/node_modules/real-require": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-1.0.0.tgz",
+      "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
+      "license": "MIT"
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.1.tgz",
+      "integrity": "sha512-5DXWzE4Vz7xNHsv+xQ+MGfJYyC78Aok3tEr0MNwHoRf7vZnga1mQXZ4/Nsodld4VR6Wd+VhfmqnNrsRJyYPfrQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/benchmarks/honest_bench/workloads/4_http_fastify/node/package.json
+++ b/benchmarks/honest_bench/workloads/4_http_fastify/node/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "honest-bench-workload-4-http-fastify-node",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "fastify": "^5.2.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/benchmarks/honest_bench/workloads/4_http_fastify/node/parametric.ts
+++ b/benchmarks/honest_bench/workloads/4_http_fastify/node/parametric.ts
@@ -1,0 +1,12 @@
+// honest_bench workload 4 — http_fastify_parametric (node).
+
+import Fastify from 'fastify';
+import type { FastifyRequest } from 'fastify';
+
+const app = Fastify({ logger: false });
+
+app.get('/users/:id', async (req: FastifyRequest<{ Params: { id: string } }>) => ({
+  id: req.params.id,
+}));
+
+app.listen({ port: parseInt(process.env.HONEST_BENCH_HTTP_PORT || '18080', 10), host: '127.0.0.1' });

--- a/benchmarks/honest_bench/workloads/4_http_fastify/node/text.ts
+++ b/benchmarks/honest_bench/workloads/4_http_fastify/node/text.ts
@@ -1,0 +1,12 @@
+// honest_bench workload 4 — http_fastify_text (node).
+
+import Fastify from 'fastify';
+
+const app = Fastify({ logger: false });
+
+app.get('/', async (_req, reply) => {
+  reply.type('text/plain');
+  return 'pong';
+});
+
+app.listen({ port: parseInt(process.env.HONEST_BENCH_HTTP_PORT || '18080', 10), host: '127.0.0.1' });

--- a/benchmarks/honest_bench/workloads/4_http_fastify/perry/minimal.ts
+++ b/benchmarks/honest_bench/workloads/4_http_fastify/perry/minimal.ts
@@ -1,0 +1,15 @@
+// honest_bench workload 4 — http_fastify_minimal (perry).
+//
+// Minimal Fastify GET route returning a fixed JSON body. Isolates
+// the framework overhead — JSON.stringify of {ok: true} only.
+// Bench client (oha) drives -c 10 sustained load via
+// harness/run_http_bench.sh; this process keeps listening until
+// SIGTERM'd by the harness.
+
+import Fastify from 'fastify';
+
+const app = Fastify({ logger: false });
+
+app.get('/', async () => ({ ok: true }));
+
+app.listen({ port: parseInt(process.env.HONEST_BENCH_HTTP_PORT || '18080', 10), host: '127.0.0.1' });

--- a/benchmarks/honest_bench/workloads/4_http_fastify/perry/parametric.ts
+++ b/benchmarks/honest_bench/workloads/4_http_fastify/perry/parametric.ts
@@ -1,0 +1,16 @@
+// honest_bench workload 4 — http_fastify_parametric (perry).
+//
+// Parametric route with a path parameter. Exercises the router's
+// pattern match, per-request params-object allocation, and the
+// per-request request-field plumbing.
+
+import Fastify from 'fastify';
+import type { FastifyRequest } from 'fastify';
+
+const app = Fastify({ logger: false });
+
+app.get('/users/:id', async (req: FastifyRequest<{ Params: { id: string } }>) => ({
+  id: req.params.id,
+}));
+
+app.listen({ port: parseInt(process.env.HONEST_BENCH_HTTP_PORT || '18080', 10), host: '127.0.0.1' });

--- a/benchmarks/honest_bench/workloads/4_http_fastify/perry/text.ts
+++ b/benchmarks/honest_bench/workloads/4_http_fastify/perry/text.ts
@@ -1,0 +1,16 @@
+// honest_bench workload 4 — http_fastify_text (perry).
+//
+// Plain-string response. Isolates the primitive response fast path:
+// no JSON.stringify, no object allocation per response — the cheapest
+// possible Fastify handler, so framework/runtime overhead dominates.
+
+import Fastify from 'fastify';
+
+const app = Fastify({ logger: false });
+
+app.get('/', async (_req, reply) => {
+  reply.type('text/plain');
+  return 'pong';
+});
+
+app.listen({ port: parseInt(process.env.HONEST_BENCH_HTTP_PORT || '18080', 10), host: '127.0.0.1' });


### PR DESCRIPTION
## Summary

Adds an opt-in `honest_bench` workload (#4, `http_fastify`) that measures
long-running Fastify HTTP throughput, so Fastify performance work can be checked
per-PR on the same hardware. Three kernel pairs (Perry + Node) — `minimal`,
`text`, `parametric` — driven by `oha`, emitting the standard honest_bench JSON
rows plus HTTP metrics.

## Changes

- **Kernels** (`workloads/4_http_fastify/{perry,node}/`): `minimal` (`{ok:true}`),
  `text` (`text/plain pong`), `parametric` (`GET /users/:id`) for both Perry
  (compiled native) and Node (upstream `fastify@^5.2.0` via `node --import tsx`).
  Port honours `HONEST_BENCH_HTTP_PORT` (default 18080).
- **Harness** (`harness/run_http_bench.sh`): spawns the server, waits for the TCP
  listener, drives `oha -c 10 -z 15s` per measured run, reads **peak** RSS
  (`VmHWM`), SIGTERMs the server, and emits one JSON row per run with `rps`,
  `p50/p95/p99_ms`, `success_rate`, `status_codes`, and an `exit_code` that
  reflects run health. `wall_ms = 1_000_000 / rps` keeps `summary.py`'s
  "lower is better" sort correct. A failed `oha` invocation aborts the run.
- **Wiring** (`run.sh`): opt-in build + run for workload 4 (`HONEST_BENCH_ONLY=4`),
  excluded from the default `1,3` sweep (needs `oha` + a loopback port).
- **`README.md`** + **`.gitignore`** (compiled kernel binaries, path-anchored).

## Related issue

None — net-new opt-in benchmark workload.

## Test plan

- [x] All three Perry kernels compile on current `main` and **serve**: readiness
      probe passes, bodies correct (`{"ok":true}` / `pong` / `{"id":"u1"}`), 50
      concurrent requests all return `200`, server stays up.
- [x] `text` kernel returns `Content-Type: text/plain` (exercises `reply.type`).
- [x] `HONEST_BENCH_HTTP_PORT` override honoured (kernel binds the override; falls
      back to 18080 when unset).
- [x] `bash -n harness/run_http_bench.sh` clean; `exit_code` logic verified
      (healthy→0, degraded/dead→1).
- [x] Node kernels use upstream `fastify@^5.2.0` (lockfile committed).

## Notes

Opt-in, so it does not run in the default sweep or affect CI timing. Requires the
`oha` load tester (`HONEST_BENCH_OHA`, default `/tmp/oha`); peak RSS is read from
Linux `/proc` (0 elsewhere).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP throughput benchmark workload with Fastify servers across minimal, text, and parametric variants
  * Supports both Perry and Node implementations for performance comparison
  * Introduced HTTP benchmarking harness for measuring requests per second, latency percentiles, and success rates

* **Documentation**
  * Added comprehensive workload documentation including environment variables, configuration, and result interpretation

* **Chores**
  * Updated build and run scripts to treat HTTP workload as opt-in

<!-- end of auto-generated comment: release notes by coderabbit.ai -->