### PR TITLE
perf(codegen): #5497 Lever E — unary -/+/~ and NumberCoerce are statically numeric

### DIFF
--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -1172,6 +1172,24 @@ pub(crate) fn is_numeric_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
         Expr::Binary { op, .. } => !matches!(op, BinaryOp::Add),
         Expr::Update { .. } => true,
         Expr::DateNow => true,
+        // Unary `-x` / `+x` / `~x` always evaluate to a JS number by
+        // ToNumber/ToInt32 semantics, so the result feeds the native f64
+        // path (#5497, Lever E). The unary lowering coerces the operand
+        // internally (its own `numeric` flag already factors in the
+        // raw-f64 boxed-fallback hazard), so the produced value is a clean
+        // f64 regardless of the operand's runtime shape — no downstream
+        // coerce is needed. BigInt is the sole exception: `-1n` / `~1n`
+        // stay BigInt (their lowering routes through `js_dynamic_neg` /
+        // `js_dynamic_bitnot`, which preserve the BigInt tag), so a bigint
+        // operand must not be treated as numeric. (`!x` is a boolean, not
+        // a number — handled by `is_bool_expr`.)
+        Expr::Unary { op, operand } => {
+            matches!(op, UnaryOp::Neg | UnaryOp::Pos | UnaryOp::BitNot)
+                && !is_bigint_expr(ctx, operand)
+        }
+        // Explicit numeric-coercion node — lowers to `js_number_coerce`,
+        // which always yields a clean f64.
+        Expr::NumberCoerce(_) => true,
         // `obj.field` where the field is declared as `number` on the
         // owning class. Without this, `this.value + 1` in a hot loop
         // wraps the field load in `js_number_coerce` which prevents


### PR DESCRIPTION
## Summary

First concrete increment of **Lever E — type-directed specialization** (#5497, the remaining #5334 Tier-3 lever). Where a value is statically known to be a number, emit native f64 ops instead of the dynamic form.

This PR widens `is_numeric_expr` (the predicate that already gates the native-arithmetic fast paths) to recognize two more provably-numeric node kinds:

- `Unary { Neg | Pos | BitNot }` on a non-BigInt operand — `-x` / `+x` / `~x` always evaluate to a JS number by ToNumber/ToInt32 semantics.
- `NumberCoerce(_)` — the explicit numeric-coercion node, which lowers to `js_number_coerce`.

Their results now feed the existing native paths in `expr/binary.rs` and `expr/compare.rs` (`fadd`/`fsub`/`fmul`/`fdiv`/`frem`/`fcmp`) instead of being wrapped in `js_number_coerce`. Arithmetic chains that contain a unary op — `-a + +b - ~a`, `sum += -i + (~i & 3)`, `-x < 0` — now stay in typed f64 registers, eliminating a nan-box round-trip per operand and unblocking LLVM GVN/LICM on the chain. This directly attacks the `js_*` call and coerce line-counts called out in #5334.

## Why it's safe

- The unary lowerings already coerce their operand internally (their own `numeric` flag factors in the raw-f64 boxed-fallback hazard), so the produced value is a clean f64 regardless of the operand's runtime shape — no downstream coerce needed.
- **BigInt is excluded**: `-1n` / `~1n` stay BigInt (lowered via `js_dynamic_neg` / `js_dynamic_bitnot`, which preserve the tag), and `is_bigint_expr` already recurses into `Unary{Neg|BitNot}`.
- `!x` is a boolean, not a number — left to `is_bool_expr`.
- Both consumers independently re-guard with `expr_may_return_boxed_value_from_raw_f64_fallback` and `is_bigint_expr`, so the predicate widening cannot defeat those safety nets.

## Validation

- A unary/coerce program matches `node --experimental-strip-types` **byte-for-byte**, including `+"abc"` → `NaN` and the BigInt `-7n` / `~7n` (`typeof` stays `bigint`) cases.
- `--trace llvm` on `-x * 2 + ~x` confirms native `fneg`/`fmul`/`fadd`, with the `~x` result feeding `fadd` **directly — no `js_number_coerce`** (it appears only as an unused `declare`).
- `cargo test -p perry-codegen` passes. (The one unrelated failure, `shadow_slot_hygiene::non_entry_module_init_body_gets_post_init_shadow_frame`, reproduces on `main` without this change.)

## Scope

This is an incremental step of Lever E, not the whole lever — known-shape field IC-diamond bypass and statically-`string` concat/compare specialization remain. Leaving #5497 open to track the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced numeric type detection in code generation to correctly handle unary operations and numeric conversions, ensuring proper type inference and preventing incorrect type casting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->