### PR TITLE
fix(codegen): value-form/named imports of native-module fns route to runtime dispatch (returned undefined)

### DIFF
--- a/crates/perry-codegen/src/lower_call/native/mod.rs
+++ b/crates/perry-codegen/src/lower_call/native/mod.rs
@@ -2010,6 +2010,58 @@ pub(crate) fn lower_native_method_call(
     // inline .length guard checks ptr < 4096, and TAG_UNDEFINED's
     // lower 48 bits = 1).
     let Some(recv) = object else {
+        // Named/value-form imports of node-core native-module functions
+        // (`import { realpathSync } from "fs"; realpathSync(p)`) reach here
+        // as a receiver-less `NativeMethodCall` with no static-table row.
+        // Pre-fix they fell straight to the TAG_UNDEFINED sentinel below, so
+        // the call returned `undefined` even though the member form
+        // (`fs.realpathSync(p)`) works — the member form routes through the
+        // runtime by-name dispatcher (`dispatch_native_module_method`), which
+        // DOES implement these. Bridge the value form onto that same path by
+        // synthesizing the module namespace receiver (exactly what
+        // `NativeModuleRef(module)` lowers to) and dispatching the method on
+        // it via `js_native_call_method`. Scope strictly to modules that own a
+        // runtime dispatch bucket (`nm_install_symbol(module).is_some()`) so
+        // perry/* internal modules and genuinely-unimplemented modules keep
+        // the historical undefined fall-through and never mis-dispatch.
+        // Fixes the realpathSync class (fs/os/path/url/... named-import fns).
+        if crate::nm_install::nm_install_symbol(module).is_some() {
+            let recv_box =
+                crate::expr::lower_expr(ctx, &Expr::NativeModuleRef(module.to_string()))?;
+            let mut lowered_args: Vec<String> = Vec::with_capacity(args.len());
+            for arg in args {
+                lowered_args.push(lower_expr(ctx, arg)?);
+            }
+            let (args_ptr, args_len) = if lowered_args.is_empty() {
+                ("null".to_string(), "0".to_string())
+            } else {
+                let n = lowered_args.len();
+                let buf = ctx.func.alloca_entry_array(DOUBLE, n);
+                {
+                    let blk = ctx.block();
+                    for (i, value) in lowered_args.iter().enumerate() {
+                        let slot = blk.gep(DOUBLE, &buf, &[(I64, &i.to_string())]);
+                        blk.store(DOUBLE, value, &slot);
+                    }
+                }
+                (buf, n.to_string())
+            };
+            let method_idx = ctx.strings.intern(method);
+            let entry = ctx.strings.entry(method_idx);
+            let bytes_global = format!("@{}", entry.bytes_global);
+            let name_len = entry.byte_len.to_string();
+            return Ok(ctx.block().call(
+                DOUBLE,
+                "js_native_call_method",
+                &[
+                    (DOUBLE, &recv_box),
+                    (PTR, &bytes_global),
+                    (I64, &name_len),
+                    (PTR, &args_ptr),
+                    (I64, &args_len),
+                ],
+            ));
+        }
         for a in args {
             let _ = lower_expr(ctx, a)?;
         }

--- a/crates/perry-codegen/tests/native_proof_regressions.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions.rs
@@ -2197,5 +2197,42 @@ fn artifact_records_raw_numeric_class_field_f64_fast_paths_and_fallback_reasons(
     );
 }
 
+/// Regression: a named/value-form import of a node-core native-module
+/// function (`import { realpathSync } from "fs"; realpathSync(p)`) reaches
+/// codegen as a receiver-less `NativeMethodCall { module: "fs", object: None,
+/// method: "realpathSync" }` with no static `NATIVE_MODULE_TABLE` row.
+/// Pre-fix this hit the receiver-less fall-through and emitted a TAG_UNDEFINED
+/// sentinel, so the call returned `undefined` even though the member form
+/// (`fs.realpathSync(p)`) works. The fix bridges value-form calls of modules
+/// that own a runtime dispatch bucket onto the same runtime by-name dispatcher
+/// the member form uses (`js_native_call_method` on the module namespace). This
+/// asserts the bridge fires (real dispatch call emitted) for an fs method that
+/// has no dedicated table row / HIR fast-path.
+#[test]
+fn named_import_native_fn_routes_to_runtime_dispatch() {
+    let body = vec![
+        Stmt::Expr(native_module_call(
+            "fs",
+            "realpathSync",
+            vec![Expr::String("/tmp".to_string())],
+        )),
+        Stmt::Return(Some(int(0))),
+    ];
+    let ir = compile_ir("named_import_native_fn_dispatch.ts", body);
+    // The value-form call must reach the runtime by-name dispatcher (the same
+    // path the member form `fs.realpathSync(...)` uses), not the dead-end
+    // TAG_UNDEFINED sentinel.
+    assert!(
+        ir.contains("@js_native_call_method"),
+        "named-import native fn must route through js_native_call_method:\n{ir}"
+    );
+    // It must also install the fs dispatch bucket via the module-namespace
+    // receiver synthesis so the method actually resolves at runtime.
+    assert!(
+        ir.contains("@js_nm_install_fs") || ir.contains("@js_create_native_module_namespace"),
+        "fs module namespace receiver must be synthesized:\n{ir}"
+    );
+}
+
 #[path = "native_proof_regressions/invalidation.rs"]
 mod invalidation;


### PR DESCRIPTION
## Problem

A **named/value-form import** of a node-core native function returns `undefined` when called, while the member form works:

```js
import { realpathSync } from "fs";
realpathSync(p);     // → undefined  (BUG)
fs.realpathSync(p);  // → "/real/path"  (works)
```

Affects `realpathSync`, `statSync`, `readdirSync`, `mkdirSync`, `writeFileSync`, `readFileSync`, `rmSync`, `os.hostname`, `os.tmpdir`, and the function-reference form `wrap(realpathSync)(x)` — any node-core native-module fn imported by name/alias/value that lacks a dedicated HIR fast-path or a `NATIVE_MODULE_TABLE` row.

## Root cause

`crates/perry-codegen/src/lower_call/native/mod.rs` — a value-form native fn call reaches codegen as a **receiver-less** `NativeMethodCall` with no row in the static `NATIVE_MODULE_TABLE` (which only carries a few specials). It fell through to a `TAG_UNDEFINED` sentinel, so the call returned `undefined`. The member form `fs.realpathSync(p)` works because it routes through the runtime by-name dispatcher `dispatch_native_module_method` (which has `("fs","realpathSync")`).

## Fix

In the receiver-less fall-through, synthesize the module-namespace receiver (`NativeModuleRef(module)` — identical to what the member form lowers to) and dispatch via `js_native_call_method`, the same proven runtime path. Scoped to modules that actually have a dispatch bucket (`nm_install_symbol(module).is_some()`), so `perry/*` and unknown modules keep the historical `undefined` behavior.

## Tests

IR-assertion regression in `native_proof_regressions.rs` (value-form call lowers to the dispatch, not the undefined sentinel). `cargo test -p perry-runtime --lib`: 1074 passed; `cargo test -p perry-codegen --test native_proof_regressions`: 52 passed. Verified end-to-end: a real bundle's cwd resolver (`realpathSync(cwd).normalize()`) no longer throws `Cannot read properties of undefined`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed support for named imports of Node.js core module functions (e.g., `import { realpathSync } from "fs"`), which previously would return undefined.

* **Tests**
  * Added regression test for named imports of native module functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->