### PR TITLE
fix(hir): a?.b?.method(args) must short-circuit when a?.b is undefined (threw on undefined receiver)

### DIFF
--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -1977,6 +1977,19 @@ fn lower_expr_impl(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<Expr> 
                     // "X is not a function" (issue #4699: zod `safeParse`'s
                     // `iss.inst?._zod.def?.error?.(iss)` error-map probe).
                     let mut callee_from_chain = false;
+                    // True when the CALLEE's member access itself is optional
+                    // (`recv?.method(args)` — the `?.` before the method name),
+                    // as opposed to `callee_from_chain` which tracks the optional
+                    // CALL token (`recv.method?.(args)`). Needed for the
+                    // inner-Conditional nesting path below: when the receiver is
+                    // produced by an upstream optional chain (`a?.b?.method(args)`)
+                    // its lowered form is itself a Conditional, so the standard
+                    // receiver null-guard (built on the non-Conditional path) is
+                    // skipped — leaving `(a.b).method(args)` to dereference an
+                    // `undefined` receiver and throw "reading 'method'" instead of
+                    // short-circuiting (the `a?.b?.some(...)` wall). This flag lets
+                    // the nesting branch re-add that receiver guard.
+                    let mut opt_member_chain = false;
                     // Receiver of an `obj.method?.(args)` callee, captured so the
                     // function-value nullish guard can avoid false-short-circuiting
                     // on string builtins (`type?.split?.(...)`) — see
@@ -2050,6 +2063,11 @@ fn lower_expr_impl(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<Expr> 
                                 //    callee + dispatches the builtin normally.
                                 ast::OptChainBase::Member(m) => {
                                     callee_from_chain = opt_chain.optional;
+                                    // `inner.optional` is the `?.` on the method
+                                    // member itself (`recv?.method`). Capture it so
+                                    // the inner-Conditional nesting path can guard
+                                    // the receiver when it is `undefined`.
+                                    opt_member_chain = inner.optional;
                                     let (obj, prop) = lower_member_flat(m)?;
                                     opt_call_member_receiver = Some(obj.clone());
                                     (obj, prop)
@@ -2075,6 +2093,23 @@ fn lower_expr_impl(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<Expr> 
                         else_expr: inner_else,
                     } = check_expr
                     {
+                        // The receiver of the method call is `inner_else` (the
+                        // un-short-circuited result of the upstream chain, e.g.
+                        // `a.b` for `a?.b?.method(args)`). Keep a copy so an
+                        // optional method member (`?.method`) can null-guard it.
+                        // Captured whenever the method member is optional and the
+                        // receiver is side-effect-free (it appears twice: in the
+                        // guard and in the call). Used by BOTH the optional-call
+                        // (`?.method?.(args)`) and plain-call (`?.method(args)`)
+                        // branches — in the optional-call branch the function-value
+                        // nullish guard would otherwise read `(a.b).method` off a
+                        // null/undefined `a.b` and throw before short-circuiting.
+                        let receiver_for_member_guard =
+                            if opt_member_chain && opt_call_receiver_repeatable(&inner_else) {
+                                Some(inner_else.as_ref().clone())
+                            } else {
+                                None
+                            };
                         // Build the callee with inner_else as the object (not the full Conditional)
                         let fixed_callee = match callee_expr {
                             Expr::PropertyGet { property, .. } => Expr::PropertyGet {
@@ -2108,6 +2143,51 @@ fn lower_expr_impl(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<Expr> 
                                     left: Box::new(fixed_callee),
                                     right: Box::new(Expr::Null),
                                 },
+                            };
+                            let guarded_call = Expr::Conditional {
+                                condition: Box::new(guard_cond),
+                                then_expr: Box::new(Expr::Undefined),
+                                else_expr: Box::new(outer_call),
+                            };
+                            // `a?.b?.method?.(args)` — the function-value guard above
+                            // reads `(a.b).method`, which THROWS when the upstream
+                            // `a.b` is null/undefined (it lowered to a Conditional, so
+                            // the receiver here is the un-short-circuited `a.b`). Wrap
+                            // it in an outer receiver-nullish short-circuit so the
+                            // chain returns `undefined` instead of throwing
+                            // "Cannot read properties of <nullish> (reading 'method')".
+                            match receiver_for_member_guard {
+                                Some(recv) => Box::new(Expr::Conditional {
+                                    condition: Box::new(Expr::Compare {
+                                        op: CompareOp::LooseEq,
+                                        left: Box::new(recv),
+                                        right: Box::new(Expr::Null),
+                                    }),
+                                    then_expr: Box::new(Expr::Undefined),
+                                    else_expr: Box::new(guarded_call),
+                                }),
+                                None => Box::new(guarded_call),
+                            }
+                        } else if let Some(recv) = receiver_for_member_guard {
+                            // `a?.b?.method(args)` — the method member (`?.method`)
+                            // is optional and its receiver (`a.b`) comes from an
+                            // upstream optional chain, so it lowered to a Conditional
+                            // and this branch lost the per-receiver null-guard that
+                            // the non-Conditional path applies. Re-add it: if the
+                            // RECEIVER is nullish, short-circuit to undefined instead
+                            // of reading `.method` off `undefined` and throwing
+                            // "Cannot read properties of undefined (reading 'method')"
+                            // (the `a?.b?.some(...)` wall). The guard tests the
+                            // receiver value directly — NOT the function value
+                            // `(a.b).method`, which would itself throw while reading
+                            // `.method` off the `undefined` receiver during guard
+                            // evaluation. The receiver appears twice (guard + call),
+                            // so this is only reached when it is side-effect-free
+                            // (`receiver_for_member_guard` is None otherwise).
+                            let guard_cond = Expr::Compare {
+                                op: CompareOp::LooseEq,
+                                left: Box::new(recv),
+                                right: Box::new(Expr::Null),
                             };
                             Box::new(Expr::Conditional {
                                 condition: Box::new(guard_cond),

--- a/tests/test_optional_chain_double_member_call.sh
+++ b/tests/test_optional_chain_double_member_call.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Regression: a double-optional chain that calls a method on the result of an
+# upstream optional member access — `a?.b?.method(args)` — threw
+# `TypeError: Cannot read properties of undefined (reading 'method')` when the
+# upstream `a.b` was `undefined`, instead of short-circuiting to `undefined`.
+#
+# Root cause: in the HIR optional-call lowering (lower_expr.rs OptChain(Call)),
+# when the receiver of an optional method member (`?.method`) is itself produced
+# by an upstream optional chain, the receiver lowers to a Conditional. The
+# inner-Conditional nesting branch reused the un-short-circuited receiver
+# (`a.b`) directly as the call's object WITHOUT re-applying the per-receiver
+# null-guard that the non-Conditional path emits — so `(a.b).method(args)`
+# dereferenced an `undefined` receiver and threw. The fix re-adds a
+# receiver-nullish guard (`a.b == null ? undefined : (a.b).method(args)`) for
+# the optional-member case, gated on a side-effect-free receiver.
+#
+# This is the `_?.allowModels?.some(...)` startup wall.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PERRY="$SCRIPT_DIR/../target/release/perry"
+[ ! -f "$PERRY" ] && PERRY="$SCRIPT_DIR/../target/debug/perry"
+if [ ! -f "$PERRY" ]; then
+  echo "SKIP: perry binary not found (build with cargo build --release)"
+  exit 0
+fi
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+cat > "$TMPDIR/main.ts" << 'EOF'
+const cfg: any = {};                 // cfg.allowModels is undefined
+const u: any = undefined;
+const obj: any = { a: { arr: [1, 2, 3] } };
+
+// The wall: optional member access feeding an optional-member method call.
+// cfg.allowModels is undefined, so `?.some(...)` must short-circuit, not throw.
+const r1 = cfg?.allowModels?.some((m: string) => m === "x");
+console.log("r1=" + (r1 === undefined ? "undefined" : r1));  // undefined
+
+// Plain undefined receiver via a double chain.
+const r2 = u?.missing?.some((x: number) => x > 0);
+console.log("r2=" + (r2 === undefined ? "undefined" : r2));  // undefined
+
+// Positive path: the chain resolves to a real array → method runs.
+const r3 = obj?.a?.arr?.some((x: number) => x === 2);
+console.log("r3=" + r3);                                      // true
+
+// Positive path with a transform method (no false short-circuit).
+const r4 = obj?.a?.arr?.map((x: number) => x * 2).join(",");
+console.log("r4=" + r4);                                      // "2,4,6"
+
+// Optional-CALL variant: `a?.b?.method?.(args)` where `a.b` is undefined —
+// the function-value guard must NOT read `(a.b).method` off the undefined
+// receiver (which would throw); the receiver short-circuit comes first.
+const r5 = u?.missing?.foo?.((x: number) => x > 0);
+console.log("r5=" + (r5 === undefined ? "undefined" : r5));  // undefined
+
+// Optional-CALL variant, positive: real function value resolves and is called.
+const o2: any = { fn: () => 99 };
+const r6 = o2?.fn?.();
+console.log("r6=" + r6);                                      // 99
+EOF
+
+cd "$TMPDIR"
+"$PERRY" compile main.ts --output test_bin >/dev/null 2>&1
+RUN_OUTPUT=$(./test_bin 2>&1)
+
+EXPECTED='r1=undefined
+r2=undefined
+r3=true
+r4=2,4,6
+r5=undefined
+r6=99'
+
+if [ "$RUN_OUTPUT" = "$EXPECTED" ]; then
+  echo "PASS"
+  exit 0
+fi
+
+echo "FAIL: double-optional member call short-circuit returned wrong value"
+echo "Expected:"
+echo "$EXPECTED"
+echo ""
+echo "Got:"
+echo "$RUN_OUTPUT"
+exit 1


### PR DESCRIPTION
## Problem

```js
a?.b?.some(x => ...)   // when a?.b is undefined → TypeError: Cannot read properties of undefined (reading 'some')
a.b?.some(...)         // works
```

A double optional-member method call threw on an undefined intermediate receiver instead of short-circuiting to `undefined` per spec.

## Root cause

`crates/perry-hir/src/lower/lower_expr.rs`, OptChain(Call) lowering. When the upstream `a?.b` is undefined, the receiver lowers to a Conditional; the inner-Conditional nesting branch reused the **un-short-circuited** receiver (`a.b`) as the call object **without re-applying the per-receiver nullish guard** the non-Conditional path emits. So `(undefined).some(args)` was evaluated. The optional-CALL variant `a?.b?.method?.(args)` had the same gap: the function-value guard read `(a.b).method` off the nullish receiver and threw during guard evaluation.

## Fix

Re-apply a receiver-nullish short-circuit (`a.b == null ? undefined : (a.b).method(args)`) for the optional-member case in both the plain-call and optional-call branches, gated on a side-effect-free receiver (no double evaluation).

## Tests

`tests/test_optional_chain_double_member_call.sh` (runnable: `o?.missing?.some(...)` → undefined, not a throw; chained and optional-call variants). `cargo test -p perry-hir`: 196 + new pass; `cargo test -p perry-runtime --lib`: 1074 passed. Verified end-to-end: a real bundle's `_?.allowModels?.some(...)` config check no longer throws.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved optional chaining behavior for method calls, ensuring `undefined` is returned instead of throwing when receivers in the chain are nullish.

* **Tests**
  * Added regression tests covering optional chaining edge cases with nested optional member access and optional call patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->