### PR TITLE
fix(hir): #5207 — resolve registry-object dynamic import() targets to the chunk set

### DIFF
--- a/crates/perry-hir/src/dynamic_import.rs
+++ b/crates/perry-hir/src/dynamic_import.rs
@@ -1190,12 +1190,7 @@ pub fn resolve_import_path_with_context<V: Borrow<Expr>>(
             None if is_static_path_join_call(callee) => {
                 resolve_static_path_args(args, consts, param_literals, local_literals, visiting)
             }
-            None => Resolution::Unresolved(
-                "path argument is not statically resolvable (supported: string literals, \
-                 ternaries of resolvable arms, template literals with const-local \
-                 interpolations, and references to module-level const string locals)"
-                    .to_string(),
-            ),
+            None => Resolution::Unresolved(NOT_STATICALLY_RESOLVABLE.to_string()),
         },
         Expr::PathJoin(left, right) | Expr::PathResolveJoin(left, right) => {
             let left = resolve_import_path_with_context(
@@ -1349,14 +1344,129 @@ pub fn resolve_import_path_with_context<V: Borrow<Expr>>(
             visiting.remove(id);
             resolved
         }
-        _ => Resolution::Unresolved(
-            "path argument is not statically resolvable (supported: string literals, \
-             ternaries of resolvable arms, template literals with const-local \
-             interpolations, and references to module-level const string locals)"
-                .to_string(),
-        ),
+        // #5207 registry-object pattern: `const R = { a: "./chunk-a.js", … };
+        // import(R[key])` / `import(R.a)`. Bundlers (and hand-written lazy-load
+        // tables) map a route/feature key to a statically-knowable chunk path
+        // through a const object literal — the exact "enumerate with a registry
+        // object" shape the over-cap note already advertises. Either member form
+        // resolves to the union of the registry's value specifiers (the whole
+        // chunk set is what we want to ingest, and the runtime dispatch still
+        // picks the right one by path string).
+        //
+        // Guard rail: this only fires when *every* value resolves to a relative
+        // module specifier (`./…` / `../…`). That keeps it a strict
+        // deferrals-into-compiles change — a plain data object indexed for a
+        // non-module reason (`const cfg = { name: "app", port: "3000" };
+        // import(cfg[k])`) has non-relative values, so it stays deferred exactly
+        // as before instead of trying to compile `"app"`/`"3000"` as modules.
+        Expr::PropertyGet { object, .. } | Expr::IndexGet { object, .. } => {
+            match object_registry_values(object, consts) {
+                Some(values) => resolve_registry_value_union(
+                    &values,
+                    consts,
+                    param_literals,
+                    local_literals,
+                    visiting,
+                ),
+                None => Resolution::Unresolved(NOT_STATICALLY_RESOLVABLE.to_string()),
+            }
+        }
+        _ => Resolution::Unresolved(NOT_STATICALLY_RESOLVABLE.to_string()),
     }
 }
+
+/// True for a relative module specifier (`./x`, `../x`). Registry-object
+/// dynamic-import resolution (#5207) only over-approximates to values that look
+/// like relative chunk paths, so a non-module data object stays deferred.
+fn is_relative_specifier(s: &str) -> bool {
+    s.starts_with("./") || s.starts_with("../") || s == "." || s == ".."
+}
+
+/// #5207: collect the candidate value expressions of a const object-literal
+/// "registry", following a single `const`-local indirection
+/// (`const R = { … }; import(R[k])`). Handles both object-literal HIR shapes:
+/// open-shape literals kept as [`Expr::Object`], and closed-shape literals
+/// lowered to `new __AnonShape_…(value0, value1, …)` (the constructor args are
+/// the field values in declaration order — see `lower::expr_object`). Returns
+/// `None` for anything that isn't statically one of those, so member access on
+/// an opaque binding falls back to deferral.
+fn object_registry_values<'a, V: Borrow<Expr>>(
+    object: &'a Expr,
+    consts: &'a std::collections::HashMap<u32, V>,
+) -> Option<Vec<&'a Expr>> {
+    object_registry_values_inner(object, consts, &mut std::collections::HashSet::new())
+}
+
+fn object_registry_values_inner<'a, V: Borrow<Expr>>(
+    object: &'a Expr,
+    consts: &'a std::collections::HashMap<u32, V>,
+    seen: &mut std::collections::HashSet<u32>,
+) -> Option<Vec<&'a Expr>> {
+    match object {
+        Expr::Object(entries) => Some(entries.iter().map(|(_, v)| v).collect()),
+        Expr::New {
+            class_name, args, ..
+        } if class_name.starts_with("__AnonShape_") => Some(args.iter().collect()),
+        // Follow a `const`-local indirection (`const R = { … }; import(R[k])`),
+        // cycle-breaking via `seen` so a pathological `const a = b; const b = a`
+        // can't loop.
+        Expr::LocalGet(id) => {
+            if !seen.insert(*id) {
+                return None;
+            }
+            object_registry_values_inner(consts.get(id)?.borrow(), consts, seen)
+        }
+        _ => None,
+    }
+}
+
+/// #5207: resolve a registry's value expressions to the union of their module
+/// specifiers, but only when *every* value resolves to a relative specifier.
+/// Any non-relative or unresolvable value collapses the whole site to
+/// `Unresolved` so it keeps deferring (no false compile of a non-module string).
+fn resolve_registry_value_union<V: Borrow<Expr>>(
+    values: &[&Expr],
+    consts: &std::collections::HashMap<u32, V>,
+    param_literals: &std::collections::HashMap<u32, Vec<String>>,
+    local_literals: &std::collections::HashMap<u32, Vec<String>>,
+    visiting: &mut std::collections::HashSet<u32>,
+) -> Resolution {
+    let mut out: Vec<String> = Vec::new();
+    for value in values {
+        match resolve_import_path_with_context(
+            value,
+            consts,
+            param_literals,
+            local_literals,
+            visiting,
+        ) {
+            Resolution::Set(set) => {
+                for s in set {
+                    if !is_relative_specifier(&s) {
+                        return Resolution::Unresolved(NOT_STATICALLY_RESOLVABLE.to_string());
+                    }
+                    if !out.contains(&s) {
+                        out.push(s);
+                    }
+                }
+            }
+            Resolution::Unresolved(reason) => return Resolution::Unresolved(reason),
+        }
+    }
+    if out.is_empty() {
+        Resolution::Unresolved(NOT_STATICALLY_RESOLVABLE.to_string())
+    } else {
+        Resolution::Set(out)
+    }
+}
+
+/// Shared "couldn't statically resolve this dynamic import() specifier"
+/// message used by the resolver's fall-through arms.
+const NOT_STATICALLY_RESOLVABLE: &str =
+    "path argument is not statically resolvable (supported: string literals, \
+     ternaries of resolvable arms, template literals with const-local \
+     interpolations, const object-literal registries indexed by a known or \
+     computed key, and references to module-level const string locals)";
 
 fn static_string_replace_target<'a>(callee: &'a Expr, args: &[Expr]) -> Option<&'a Expr> {
     if args.len() < 2 {

--- a/crates/perry-hir/src/dynamic_import.rs
+++ b/crates/perry-hir/src/dynamic_import.rs
@@ -1360,7 +1360,15 @@ pub fn resolve_import_path_with_context<V: Borrow<Expr>>(
         // import(cfg[k])`) has non-relative values, so it stays deferred exactly
         // as before instead of trying to compile `"app"`/`"3000"` as modules.
         Expr::PropertyGet { object, .. } | Expr::IndexGet { object, .. } => {
-            match object_registry_values(object, consts) {
+            // Record every const-local id on the registry's indirection chain in
+            // the *outer* `visiting` set so a value that member-accesses back
+            // into this (or an enclosing) registry is caught as a cycle rather
+            // than recursing forever — `const R5 = { a: R6[x] }; const R6 = { b:
+            // R5[y] }` is valid TS and would otherwise overflow the stack. The
+            // chain ids are removed again before returning so sibling
+            // resolutions still see those bindings.
+            let mut chain_ids: Vec<u32> = Vec::new();
+            let resolved = match object_registry_values(object, consts, visiting, &mut chain_ids) {
                 Some(values) => resolve_registry_value_union(
                     &values,
                     consts,
@@ -1369,7 +1377,11 @@ pub fn resolve_import_path_with_context<V: Borrow<Expr>>(
                     visiting,
                 ),
                 None => Resolution::Unresolved(NOT_STATICALLY_RESOLVABLE.to_string()),
+            };
+            for id in &chain_ids {
+                visiting.remove(id);
             }
+            resolved
         }
         _ => Resolution::Unresolved(NOT_STATICALLY_RESOLVABLE.to_string()),
     }
@@ -1383,38 +1395,36 @@ fn is_relative_specifier(s: &str) -> bool {
 }
 
 /// #5207: collect the candidate value expressions of a const object-literal
-/// "registry", following a single `const`-local indirection
-/// (`const R = { … }; import(R[k])`). Handles both object-literal HIR shapes:
-/// open-shape literals kept as [`Expr::Object`], and closed-shape literals
-/// lowered to `new __AnonShape_…(value0, value1, …)` (the constructor args are
-/// the field values in declaration order — see `lower::expr_object`). Returns
-/// `None` for anything that isn't statically one of those, so member access on
-/// an opaque binding falls back to deferral.
+/// "registry", following `const`-local indirection (`const R = { … };
+/// import(R[k])`). Handles both object-literal HIR shapes: open-shape literals
+/// kept as [`Expr::Object`], and closed-shape literals lowered to
+/// `new __AnonShape_…(value0, value1, …)` (the constructor args are the field
+/// values in declaration order — see `lower::expr_object`). Returns `None` for
+/// anything that isn't statically one of those, so member access on an opaque
+/// binding falls back to deferral.
+///
+/// Every traversed `LocalGet` id is inserted into `visiting` (and pushed onto
+/// `chain_ids` so the caller can undo it) — a binding already in `visiting`
+/// breaks the chain with `None`. Sharing the resolver's `visiting` set is what
+/// makes cycle detection span the recursion back through
+/// [`resolve_registry_value_union`], not just a single indirection chain.
 fn object_registry_values<'a, V: Borrow<Expr>>(
     object: &'a Expr,
     consts: &'a std::collections::HashMap<u32, V>,
-) -> Option<Vec<&'a Expr>> {
-    object_registry_values_inner(object, consts, &mut std::collections::HashSet::new())
-}
-
-fn object_registry_values_inner<'a, V: Borrow<Expr>>(
-    object: &'a Expr,
-    consts: &'a std::collections::HashMap<u32, V>,
-    seen: &mut std::collections::HashSet<u32>,
+    visiting: &mut std::collections::HashSet<u32>,
+    chain_ids: &mut Vec<u32>,
 ) -> Option<Vec<&'a Expr>> {
     match object {
         Expr::Object(entries) => Some(entries.iter().map(|(_, v)| v).collect()),
         Expr::New {
             class_name, args, ..
         } if class_name.starts_with("__AnonShape_") => Some(args.iter().collect()),
-        // Follow a `const`-local indirection (`const R = { … }; import(R[k])`),
-        // cycle-breaking via `seen` so a pathological `const a = b; const b = a`
-        // can't loop.
         Expr::LocalGet(id) => {
-            if !seen.insert(*id) {
+            if !visiting.insert(*id) {
                 return None;
             }
-            object_registry_values_inner(consts.get(id)?.borrow(), consts, seen)
+            chain_ids.push(*id);
+            object_registry_values(consts.get(id)?.borrow(), consts, visiting, chain_ids)
         }
         _ => None,
     }

--- a/crates/perry-hir/src/dynamic_import/tests.rs
+++ b/crates/perry-hir/src/dynamic_import/tests.rs
@@ -234,6 +234,65 @@ fn resolve_non_relative_registry_defers() {
 }
 
 #[test]
+fn resolve_circular_registry_defers_without_overflow() {
+    // `const R5 = { a: R6[x] }; const R6 = { b: R5[y] };` — a circular registry
+    // is valid TS and reaches the resolver via the const map. The cross-call
+    // cycle guard must defer (Unresolved) instead of recursing forever.
+    let r5 = Expr::Object(vec![(
+        "a".to_string(),
+        Expr::IndexGet {
+            object: Box::new(Expr::LocalGet(6)),
+            index: Box::new(Expr::LocalGet(99)),
+        },
+    )]);
+    let r6 = Expr::Object(vec![(
+        "b".to_string(),
+        Expr::IndexGet {
+            object: Box::new(Expr::LocalGet(5)),
+            index: Box::new(Expr::LocalGet(99)),
+        },
+    )]);
+    let arg = Expr::IndexGet {
+        object: Box::new(Expr::LocalGet(5)),
+        index: Box::new(Expr::LocalGet(99)),
+    };
+    let mut consts = std::collections::HashMap::new();
+    consts.insert(5u32, r5);
+    consts.insert(6u32, r6);
+    let mut visiting = std::collections::HashSet::new();
+    assert!(matches!(
+        resolve_import_path_with_consts(&arg, &consts, &mut visiting),
+        Resolution::Unresolved(_)
+    ));
+}
+
+#[test]
+fn resolve_chained_distinct_registries_resolves() {
+    // `const A = { x: "./a.js" }; const B = { y: A.x }; import(B[k])` — distinct
+    // (non-cyclic) registries must still resolve through the indirection.
+    let a = Expr::Object(vec![("x".to_string(), Expr::String("./a.js".into()))]);
+    let b = Expr::Object(vec![(
+        "y".to_string(),
+        Expr::PropertyGet {
+            object: Box::new(Expr::LocalGet(1)),
+            property: "x".to_string(),
+        },
+    )]);
+    let arg = Expr::IndexGet {
+        object: Box::new(Expr::LocalGet(2)),
+        index: Box::new(Expr::LocalGet(99)),
+    };
+    let mut consts = std::collections::HashMap::new();
+    consts.insert(1u32, a);
+    consts.insert(2u32, b);
+    let mut visiting = std::collections::HashSet::new();
+    match resolve_import_path_with_consts(&arg, &consts, &mut visiting) {
+        Resolution::Set(v) => assert_eq!(v, vec!["./a.js"]),
+        Resolution::Unresolved(reason) => panic!("expected Set, got Unresolved: {reason}"),
+    }
+}
+
+#[test]
 fn resolve_non_registry_member_access_defers() {
     // `import(cfg.path)` where cfg is opaque — must keep deferring, not panic.
     let arg = Expr::PropertyGet {

--- a/crates/perry-hir/src/dynamic_import/tests.rs
+++ b/crates/perry-hir/src/dynamic_import/tests.rs
@@ -134,6 +134,120 @@ fn resolve_unresolved_param_local() {
     assert!(matches!(r, Resolution::Unresolved(_)));
 }
 
+// #5207: registry-object dynamic-import patterns. A const object literal maps
+// route/feature keys to relative chunk paths; member access resolves to the
+// union of the registry's (relative) value specifiers — the whole chunk set is
+// what we ingest, and the runtime dispatch picks the right one by path string.
+//   `const R = { a: "./chunk-a.js", b: "./chunk-b.js" };`
+fn open_chunk_registry() -> Expr {
+    Expr::Object(vec![
+        ("a".to_string(), Expr::String("./chunk-a.js".into())),
+        ("b".to_string(), Expr::String("./chunk-b.js".into())),
+    ])
+}
+
+// The same literal as Perry actually lowers a closed-shape object: a
+// `new __AnonShape_…(value0, value1)` whose args are the field values in order.
+fn closed_chunk_registry() -> Expr {
+    Expr::New {
+        class_name: "__AnonShape_deadbeef".to_string(),
+        args: vec![
+            Expr::String("./chunk-a.js".into()),
+            Expr::String("./chunk-b.js".into()),
+        ],
+        type_args: Vec::new(),
+        byte_offset: 0,
+    }
+}
+
+fn assert_resolves_both_chunks(arg: &Expr) {
+    let mut consts = std::collections::HashMap::new();
+    consts.insert(5u32, open_chunk_registry());
+    let mut visiting = std::collections::HashSet::new();
+    match resolve_import_path_with_consts(arg, &consts, &mut visiting) {
+        Resolution::Set(v) => {
+            assert_eq!(v.len(), 2);
+            assert!(v.contains(&"./chunk-a.js".to_string()));
+            assert!(v.contains(&"./chunk-b.js".to_string()));
+        }
+        Resolution::Unresolved(reason) => panic!("expected Set, got Unresolved: {reason}"),
+    }
+}
+
+#[test]
+fn resolve_registry_computed_key_enumerates_all() {
+    // `import(R[key])` with a runtime key — the core registry pattern.
+    assert_resolves_both_chunks(&Expr::IndexGet {
+        object: Box::new(Expr::LocalGet(5)),
+        index: Box::new(Expr::LocalGet(99)), // not a known literal
+    });
+}
+
+#[test]
+fn resolve_registry_static_property_enumerates_all() {
+    // `import(R.a)` — over-approximate to the whole (relative) chunk set.
+    assert_resolves_both_chunks(&Expr::PropertyGet {
+        object: Box::new(Expr::LocalGet(5)),
+        property: "a".to_string(),
+    });
+}
+
+#[test]
+fn resolve_closed_shape_registry_enumerates_all() {
+    // The realistic lowering: a `new __AnonShape_…(…)` closed-shape literal.
+    let arg = Expr::IndexGet {
+        object: Box::new(Expr::LocalGet(5)),
+        index: Box::new(Expr::LocalGet(99)),
+    };
+    let mut consts = std::collections::HashMap::new();
+    consts.insert(5u32, closed_chunk_registry());
+    let mut visiting = std::collections::HashSet::new();
+    match resolve_import_path_with_consts(&arg, &consts, &mut visiting) {
+        Resolution::Set(v) => {
+            assert_eq!(v.len(), 2);
+            assert!(v.contains(&"./chunk-a.js".to_string()));
+            assert!(v.contains(&"./chunk-b.js".to_string()));
+        }
+        Resolution::Unresolved(reason) => panic!("expected Set, got Unresolved: {reason}"),
+    }
+}
+
+#[test]
+fn resolve_non_relative_registry_defers() {
+    // A plain data object (non-module values) indexed for a non-import reason
+    // must stay deferred — never try to compile `"app"` / `"3000"` as modules.
+    let data = Expr::Object(vec![
+        ("name".to_string(), Expr::String("app".into())),
+        ("port".to_string(), Expr::String("3000".into())),
+    ]);
+    let arg = Expr::IndexGet {
+        object: Box::new(Expr::LocalGet(5)),
+        index: Box::new(Expr::LocalGet(99)),
+    };
+    let mut consts = std::collections::HashMap::new();
+    consts.insert(5u32, data);
+    let mut visiting = std::collections::HashSet::new();
+    assert!(matches!(
+        resolve_import_path_with_consts(&arg, &consts, &mut visiting),
+        Resolution::Unresolved(_)
+    ));
+}
+
+#[test]
+fn resolve_non_registry_member_access_defers() {
+    // `import(cfg.path)` where cfg is opaque — must keep deferring, not panic.
+    let arg = Expr::PropertyGet {
+        object: Box::new(Expr::LocalGet(7)),
+        property: "path".to_string(),
+    };
+    let consts: std::collections::HashMap<u32, Expr> = std::collections::HashMap::new();
+    let mut visiting = std::collections::HashSet::new();
+    assert!(matches!(
+        resolve_import_path_with_consts(&arg, &consts, &mut visiting),
+        Resolution::Unresolved(_)
+    ));
+}
+
 #[test]
 fn resolve_param_string_literal_union() {
     let arg = Expr::LocalGet(42);

--- a/crates/perry/tests/issue_5207_registry_object_dynamic_import.rs
+++ b/crates/perry/tests/issue_5207_registry_object_dynamic_import.rs
@@ -1,0 +1,204 @@
+//! Regression test for #5207 (registry-object follow-up): a const object
+//! literal that maps route/feature keys to statically-knowable chunk paths is
+//! a *registry*, and `import(REGISTRY[runtimeKey])` / `import(REGISTRY.key)`
+//! must ingest the whole chunk set rather than deferring to a runtime error.
+//!
+//! Bundlers and hand-written lazy-load tables routinely centralize their
+//! `import("./chunk-….js")` targets in such a table and index it with a
+//! runtime-computed key. The targets are still fully known at build time, so
+//! perry over-approximates the member access to the union of the registry's
+//! (relative) value specifiers and compiles every one. The runtime `import()`
+//! dispatch then picks the right chunk by path string.
+//!
+//! Guard rail also asserted: a plain data object whose values are *not*
+//! relative module specifiers (`{ name: "app", port: "3000" }`) indexed for a
+//! non-import reason must keep deferring — it must never try to compile
+//! `"app"` / `"3000"` as modules.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Once;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize workspace root")
+}
+
+fn target_debug_dir() -> PathBuf {
+    std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| workspace_root().join("target"))
+        .join("debug")
+}
+
+/// Build the static runtime/stdlib archives once so the compiled binary links.
+/// Mirrors `issue_5207_codesplit_chunk_set.rs`.
+fn ensure_runtime_archive() {
+    static BUILD_RUNTIME: Once = Once::new();
+    BUILD_RUNTIME.call_once(|| {
+        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+        let build = Command::new(cargo)
+            .current_dir(workspace_root())
+            .arg("build")
+            .arg("-p")
+            .arg("perry-runtime-static")
+            .arg("-p")
+            .arg("perry-stdlib-static")
+            .output()
+            .expect("run cargo build for static wrapper crates");
+        assert!(
+            build.status.success(),
+            "cargo build -p perry-runtime-static -p perry-stdlib-static failed\n\
+             stdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&build.stdout),
+            String::from_utf8_lossy(&build.stderr)
+        );
+    });
+}
+
+fn runtime_dir() -> PathBuf {
+    ensure_runtime_archive();
+    target_debug_dir()
+}
+
+const CHUNK_A: &str = "export function h() { return \"chunk-a\"; }\n";
+const CHUNK_B: &str = "export function h() { return \"chunk-b\"; }\n";
+const CHUNK_C: &str = "export function h() { return \"chunk-c\"; }\n";
+
+// Entry maps three route keys to chunk paths through a const registry, then
+// loads them by a *runtime-computed* key (the `import()` arg is `REGISTRY[k]`,
+// never a literal). A static-property access (`REGISTRY.c`) is exercised too.
+const ENTRY: &str = "\
+const REGISTRY = {
+  a: \"./chunk-a.js\",
+  b: \"./chunk-b.js\",
+  c: \"./chunk-c.js\",
+};
+
+async function load(key) {
+  const m = await import(REGISTRY[key]);
+  return m.h();
+}
+
+async function main() {
+  for (const k of [\"a\", \"b\"]) {
+    console.log(k, await load(k));
+  }
+  // static member access into the same registry
+  const m = await import(REGISTRY.c);
+  console.log(\"c\", m.h());
+}
+main();
+";
+
+const EXPECTED: &str = "a chunk-a\nb chunk-b\nc chunk-c\n";
+
+#[test]
+fn registry_object_dynamic_import_compiles_chunk_set() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    std::fs::write(root.join("chunk-a.js"), CHUNK_A).unwrap();
+    std::fs::write(root.join("chunk-b.js"), CHUNK_B).unwrap();
+    std::fs::write(root.join("chunk-c.js"), CHUNK_C).unwrap();
+    std::fs::write(root.join("entry.js"), ENTRY).unwrap();
+
+    let entry = root.join("entry.js");
+    let output = root.join("entry_bin");
+    let out = Command::new(perry_bin())
+        .current_dir(root)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .env("PERRY_NO_AUTO_OPTIMIZE", "1")
+        .env("PERRY_RUNTIME_DIR", runtime_dir())
+        .output()
+        .expect("run perry compile");
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "registry-object dynamic import must compile; stderr:\n{stderr}"
+    );
+    // The registry targets must be ingested, not deferred to a runtime error.
+    assert!(
+        !stdout.contains("deferred runtime error") && !stderr.contains("deferred runtime error"),
+        "registry chunk targets must compile in, not defer; stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled registry binary must run; stderr:\n{}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        EXPECTED,
+        "registry-object dynamic-import output must match Node byte-for-byte"
+    );
+}
+
+// A non-module data object indexed by a runtime key must NOT be mistaken for a
+// chunk registry: its values aren't relative specifiers, so the site stays
+// deferred (compiles, throws only if reached) instead of trying to compile
+// `"app"` / `"3000"` as modules and breaking the build.
+const NON_REGISTRY_ENTRY: &str = "\
+const cfg = { name: \"app\", port: \"3000\" };
+async function main() {
+  const k = \"name\";
+  try {
+    await import(cfg[k]);
+    console.log(\"unexpected\");
+  } catch (e) {
+    console.log(\"caught\");
+  }
+}
+main();
+";
+
+#[test]
+fn non_module_data_object_indexed_stays_deferred() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    std::fs::write(root.join("entry.js"), NON_REGISTRY_ENTRY).unwrap();
+
+    let entry = root.join("entry.js");
+    let output = root.join("entry_bin");
+    let out = Command::new(perry_bin())
+        .current_dir(root)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .env("PERRY_NO_AUTO_OPTIMIZE", "1")
+        .env("PERRY_RUNTIME_DIR", runtime_dir())
+        .output()
+        .expect("run perry compile");
+
+    // Must still build (deferred, not a hard error) — the registry heuristic
+    // must not have tried to resolve "app"/"3000" as modules.
+    assert!(
+        out.status.success(),
+        "a non-module data object indexed by a runtime key must still compile (deferred); \
+         stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(run.status.success(), "compiled binary must run");
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "caught\n",
+        "the deferred import() must throw at runtime, matching Node's import(undefined-ish)"
+    );
+}


### PR DESCRIPTION
## What

Closes the registry-object slice of #5207. Apps and bundlers centralize lazy-load targets in a const object literal mapping a key to a relative chunk path, then load via a runtime key:

```ts
const ROUTES = { a: "./chunk-a.js", b: "./chunk-b.js" };
await import(ROUTES[key]);   // or ROUTES.a
```

The dynamic-import resolver had no arm for member access (`obj[k]` / `obj.k`), so these fell through to the runtime-computed bucket and **deferred to a runtime error** — even though every target is statically known. This is the exact *"enumerate with a registry object"* shape the over-cap note already advertises as supported.

### Before
```
$ perry compile entry.js ...
notice: 1 ahead-of-time-unsupported site compiled to a deferred runtime error
$ ./entry_bin
Uncaught (in promise) Error: dynamic import() of a runtime-computed path cannot run in an ahead-of-time compiled binary
```
### After
```
Found 3 module(s): 3 native, 0 JavaScript   # the chunk set is ingested + compiled
a chunk-a
b chunk-b
```

## How

Add a registry arm to `resolve_import_path_with_context`: a `PropertyGet` / `IndexGet` whose object is a const object literal resolves to the **union of the registry's value specifiers**, so the whole chunk set compiles and the existing runtime `import()` dispatch picks the right one by path string. Both object-literal HIR shapes are handled — open-shape `Expr::Object` and the closed-shape `new __AnonShape_…(values…)` lowering — following one const-local indirection (cycle-guarded).

**Guard rail** keeps this a strict *deferrals-into-compiles* change: it only fires when **every** value resolves to a relative specifier (`./…` / `../…`). A plain data object indexed for a non-import reason (`{ name: "app", port: "3000" }`) has non-relative values and stays deferred exactly as before — it never tries to compile `"app"`/`"3000"` as modules.

## Scope

This is the registry-object follow-up tracked on #5207 (the literal `import("./chunk.js")` and multi-chunk-graph cases already work — see `issue_5207_codesplit_chunk_set.rs`). The `@/` / `@scope/*` tsconfig-`paths` alias blocker noted on the issue is a separate tracker and is out of scope here.

## Tests

- Unit (`perry-hir`): open- and closed-shape registries, the relative-specifier guard (non-module data object defers), and opaque-binding deferral.
- Integration (`crates/perry/tests/issue_5207_registry_object_dynamic_import.rs`): compiles a 3-chunk registry loaded by a runtime key and asserts byte-for-byte parity with Node; plus a non-registry data object that must still compile (deferred) and throw only at runtime.
- Existing `issue_5207_codesplit_chunk_set` test still passes.

No version bump / changelog entry (left to the maintainer at merge per CLAUDE.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved dynamic `import()` path analysis to recognize “registry-style” constant object patterns, statically expanding mapped chunk specifiers when they are all relative module paths.

* **Bug Fixes**
  * Prevents unnecessary deferred/unresolved handling for these registry-object `import()` cases, matching runtime expectations and output behavior.

* **Tests**
  * Added regression tests for issue `#5207`, including computed-key and member-access access patterns, plus deferral/termination behavior for non-registry data and circular indirections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->