### PR TITLE
fix(runtime): #3986 own `valueOf` wins over default in member dispatch

### DIFF
--- a/crates/perry-runtime/src/date.rs
+++ b/crates/perry-runtime/src/date.rs
@@ -1074,6 +1074,28 @@ pub extern "C" fn js_date_value_of(timestamp: f64) -> f64 {
     if let Some((_, payload)) = crate::builtins::boxed_primitive_payload(timestamp) {
         return payload;
     }
+    // A real Date cell yields its numeric timestamp.
+    if is_date_value(timestamp) {
+        return date_cell_timestamp(timestamp);
+    }
+    // Any other ordinary object: `obj.valueOf()` follows ordinary member
+    // dispatch, so a user-defined own `valueOf` wins over the default
+    // Object.prototype.valueOf (which returns the receiver). `Object(x)`
+    // returns `x` unchanged, so `Object(x).valueOf()` must run x's own
+    // `valueOf` (test262 built-ins/Object/S9.9_A6). Route through the shared
+    // `valueOf` dispatch in `js_native_call_method`, which performs the own-
+    // property lookup and falls back to the default for plain objects.
+    if crate::value::JSValue::from_bits(timestamp.to_bits()).is_pointer() {
+        return unsafe {
+            crate::object::js_native_call_method(
+                timestamp,
+                b"valueOf".as_ptr() as *const i8,
+                "valueOf".len(),
+                std::ptr::null(),
+                0,
+            )
+        };
+    }
 
     date_cell_timestamp(timestamp)
 }

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -4681,6 +4681,23 @@ pub unsafe extern "C" fn js_native_call_method(
         // while ordinary objects now get the inherited default instead of
         // falling through to "valueOf is not a function".
         "valueOf" => {
+            // A user-defined own `valueOf` wins over the default, mirroring the
+            // `toLocaleString` arm below. `Object(x)` returns `x` unchanged, so
+            // `Object(x).valueOf()` must run x's own `valueOf`
+            // (test262 built-ins/Object/S9.9_A6). The explicit-base form
+            // `Object.prototype.valueOf.call(x)` goes through
+            // `object_prototype_value_of_thunk` instead and correctly skips this
+            // own-property lookup.
+            let own =
+                crate::object::js_object_get_own_field_or_undef(object, b"valueOf".as_ptr(), 7);
+            if let Some(result) = call_primitive_closure_value(
+                object,
+                JSValue::from_bits(own.to_bits()),
+                args_ptr,
+                args_len,
+            ) {
+                return result;
+            }
             return js_object_default_value_of(object);
         }
 

--- a/test-parity/node-suite/object/valueof-tolocalestring.ts
+++ b/test-parity/node-suite/object/valueof-tolocalestring.ts
@@ -38,3 +38,29 @@ logTypeError("call toLocaleString null-prototype", () =>
 );
 logCall("call valueOf null", () => Object.prototype.valueOf.call(null));
 logCall("call toLocaleString undefined", () => Object.prototype.toLocaleString.call(undefined));
+
+// #3986: a user-defined own `valueOf` wins over the default Object.prototype
+// .valueOf during ordinary member dispatch. `Object(x)` returns `x` unchanged,
+// so `Object(x).valueOf()` must run x's own `valueOf` (test262 S9.9_A6). The
+// explicit-base form `Object.prototype.valueOf.call(x)` must NOT consult the
+// own property (it returns the receiver) — guarding against infinite recursion.
+function MyValue(this: any, v: number) {
+  this.value = v;
+  this.valueOf = function () {
+    return this.value;
+  };
+}
+const mv = new (MyValue as any)(1);
+const boxed: any = Object(mv);
+logCall("Object(x) identity", () => boxed === mv);
+logCall("Object(x) own valueOf", () => boxed.valueOf());
+logCall("Object(x) coercion", () => boxed + 4);
+logCall("own valueOf via member", () => mv.valueOf());
+logCall("own valueOf base-call identity", () => Object.prototype.valueOf.call(boxed) === mv);
+const litValueOf = {
+  valueOf() {
+    return 42;
+  },
+};
+logCall("object literal own valueOf", () => litValueOf.valueOf());
+logCall("object literal valueOf coercion", () => (litValueOf as any) * 2);


### PR DESCRIPTION
## Summary

Closes the live, in-scope slice of #3986 (ToObject / `valueOf` / object identity). Most of the issue's representative failures were already fixed by the merged #4161 / #4239 / #4269 cuts — re-running the issue's `built-ins/Object --max 180` subset now shows **170 pass / 10 runtime-fail (94.4%)**, up from the 97 pass / 83 runtime-fail (53.9%) recorded when the issue was filed.

This PR fixes the one remaining failure squarely in the issue's named scope — *"preserve wrapper `valueOf()` … core is ToObject, `valueOf`, constructor/prototype identity"*:

`built-ins/Object/S9.9_A6.js` — `var y = Object(x); y.valueOf()` must run x's **own** `valueOf`. Perry returned `x` unchanged (`y === x` was already correct), but the default `Object.prototype.valueOf` ran instead of x's own method.

## Root cause

`.valueOf()` reaches two dispatch entry points, neither of which consulted an own `valueOf` property:

1. `js_native_call_method`'s `"valueOf"` arm returned the default directly.
2. `js_date_value_of` — the `Expr::DateValueOf` codegen path that a statically-`any` `.valueOf()` lowers to — returned the receiver unchanged for any non-Date object.

## Fix

- The `"valueOf"` arm now reads the own `valueOf` field and invokes it when callable before the default, mirroring the existing `toLocaleString` arm.
- `js_date_value_of` routes an ordinary non-Date pointer object through that shared dispatch. Date cells, boxed primitives, and Temporal values are unchanged.
- The explicit-base `Object.prototype.valueOf.call(x)` still goes through `object_prototype_value_of_thunk`, which intentionally skips own-property lookup (spec: returns ToObject(this)) — **no infinite recursion**.

## Validation

- test262 `built-ins/Object --max 180`: **170 → 171 pass**, S9.9_A6 fixed, no regressions, nothing moved to skip.
- Manual probe matches Node byte-for-byte: `Date.valueOf`/`+date`, `Object(5/true/'x').valueOf()`, plain-object default identity, object-literal & class-instance own `valueOf`, numeric coercion, and the explicit `Object.prototype.valueOf.call(lit) === lit` non-recursion guard.
- `cargo test -p perry-runtime` green (the 1 nondeterministic test-isolation flake passes in isolation and also occurs on `main`).
- Extended the `node-suite/object/valueof-tolocalestring` parity fixture with own-`valueOf` coverage (passes under Node 26).
- `cargo fmt --all -- --check`, `git diff --check`, `./scripts/check_file_size.sh` all pass.

## Out of scope (left for separate issues)

The other 9 remaining `built-ins/Object` failures are not this issue's ToObject/`valueOf` slice: `assign/source-own-prop-*` and `strings-and-symbol-order-proxy` are Proxy internals the issue author explicitly excluded; `S15.2.1.1_A2_T10` / `S15.2.2.1_A2_T3` / `target-Array` stem from a separate general array-growth pointer-identity bug (reproduces with a plain identity function, not Object-specific); `S15.2_A1` (`this.Object`) and `create/15.2.3.5-4-15` are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed valueOf dispatch precedence to correctly respect user-defined valueOf implementations when boxing objects with Object(), ensuring custom behavior is preserved over defaults.
  * Improved Date.prototype.valueOf handling for non-Date objects by properly invoking their custom valueOf method.

* **Tests**
  * Added regression test coverage validating valueOf dispatch behavior for boxed objects with custom valueOf implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->