### PR TITLE
fix(ui-macos): #3073 guard NSImageView-only selectors against non-image handles

### DIFF
--- a/crates/perry-ui-macos/src/widgets/image.rs
+++ b/crates/perry-ui-macos/src/widgets/image.rs
@@ -225,6 +225,12 @@ fn load_remote(handle: i64, url: String) {
                         Some(v) => v,
                         None => return,
                     };
+                    // #3073: `setImage:` below is NSImageView-only. If the
+                    // handle no longer resolves to an image view, skip the
+                    // apply rather than risk a method-not-found abort.
+                    if !is_image_view(&view) {
+                        return;
+                    }
                     let ns_data_cls = match objc2::runtime::AnyClass::get(c"NSData") {
                         Some(c) => c,
                         None => return,
@@ -261,9 +267,30 @@ fn load_remote(handle: i64, url: String) {
     });
 }
 
+/// True when `view` is an `NSImageView` (or a subclass). Used to gate
+/// the NSImageView-only selectors below so a handle that resolves to a
+/// non-image view becomes a safe no-op instead of an objc
+/// "method not found" abort. Mirrors the `isKindOfClass:` guards used
+/// for `NSStackView` selectors in `widgets/mod.rs`.
+fn is_image_view(view: &NSView) -> bool {
+    match objc2::runtime::AnyClass::get(c"NSImageView") {
+        Some(cls) => unsafe { msg_send![view, isKindOfClass: cls] },
+        None => false,
+    }
+}
+
 /// Set the frame size of an image widget.
 pub fn set_size(handle: i64, width: f64, height: f64) {
     if let Some(view) = super::get_widget(handle) {
+        // #3073: inside a virtualized `LazyVStack` row the handle can
+        // resolve to the list's backing `NSScrollView` rather than the
+        // row's `NSImageView`. Sending the NSImageView-only `-image`
+        // selector to that view aborts the process. Skip safely when the
+        // handle is not an image view — sizing a non-image view here
+        // (e.g. `setFrameSize` on the scroll view) would be wrong anyway.
+        if !is_image_view(&view) {
+            return;
+        }
         unsafe {
             // Resize the NSImage itself so intrinsic content size matches the desired display size
             let image: *mut objc2::runtime::AnyObject = msg_send![&*view, image];
@@ -280,6 +307,11 @@ pub fn set_size(handle: i64, width: f64, height: f64) {
 /// Set the content tint color of an image widget (for SF Symbols).
 pub fn set_tint(handle: i64, r: f64, g: f64, b: f64, a: f64) {
     if let Some(view) = super::get_widget(handle) {
+        // #3073: `setContentTintColor:` is NSImageView-only; guard against
+        // a handle that resolved to a non-image view (see `set_size`).
+        if !is_image_view(&view) {
+            return;
+        }
         unsafe {
             let color: *mut objc2::runtime::AnyObject = msg_send![
                 objc2::runtime::AnyClass::get(c"NSColor").unwrap(),


### PR DESCRIPTION
## Summary
Fixes #3073 — calling `imageSetSize()` on an `Image(url)` created inside a `LazyVStack` row-render closure aborts the app with a hard objc `method not found` failure:

```
FATAL: invalid message send to -[NSKVONotifying_NSScrollView image]: method not found
       at crates/perry-ui-macos/src/widgets/image.rs (set_size)
```

Inside a virtualized `LazyVStack` row, the widget handle passed to `imageSetSize` can resolve (via `get_widget`) to the list's backing **`NSScrollView`** instead of the row's `NSImageView`. `set_size` then sends the `NSImageView`-only `-image` selector to a non-image view, which the objc runtime cannot dispatch — aborting the process (a panic across the `extern "C"` boundary that cannot unwind).

## Fix
Gate the `NSImageView`-only selectors with an `isKindOfClass: NSImageView` check (`is_image_view`), mirroring the existing `NSStackView` `isKindOfClass:` guards in `widgets/mod.rs` (`set_distribution`, `set_detaches_hidden_views`). Three call sites are covered:

- `set_size` — sends `-image` / `-setImage:setSize:` / `-setFrameSize:`
- `set_tint` — sends `-setContentTintColor:`
- `load_remote`'s async apply — sends `-setImage:`

A handle that doesn't resolve to an image view now becomes a **safe no-op** instead of aborting. The normal case (handle resolves to the `NSImageView`) is unchanged and still sizes/tints exactly as before, so the common `Image` sizing path is unaffected.

This removes the hard crash and lets the documented pattern — icons/avatars sized inside virtualized lists — run without aborting.

## Testing
- `cargo build --release -p perry-ui-macos` — clean.
- `cargo fmt -p perry-ui-macos --check` — clean.
- Runtime GUI verification was not possible in the headless CI/dev environment used here (no perry/ui app — including a trivial one — can bootstrap an AppKit main-thread run loop in this context). The fix is a localized, type-checked guard that follows the codebase's established `isKindOfClass:` idiom; reviewers with a desktop session can confirm with the issue's minimal repro.

## Notes
Per maintainer convention, this PR intentionally omits the version bump and CHANGELOG entry (to be folded in at merge time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability of image operations to safely handle edge cases involving different view types during image loading and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->