### PR TITLE
bench: untyped-vs-typed typed-array element-access guard (#5525)

### DIFF
--- a/benchmarks/suite/bench_typed_array_untyped_access.ts
+++ b/benchmarks/suite/bench_typed_array_untyped_access.ts
@@ -85,6 +85,20 @@ const typed = Date.now() - t;
 
 // Same input → identical state proves the untyped fast path matches the typed
 // path bit-for-bit (the #5525 inline path must never diverge from the slow one).
+// Fail fast — a divergence is a miscompile, not a slow number, so this guard
+// aborts rather than printing a sentinel.
+if (lrU[0] !== lrT[0] || lrU[1] !== lrT[1]) {
+  throw new Error(
+    `checksum mismatch: untyped=[${lrU[0]},${lrU[1]}] typed=[${lrT[0]},${lrT[1]}]`,
+  );
+}
+
+// The untyped/typed ratio is the #5525 metric: it normalizes out machine speed
+// (Node ≈ 1.0 — no gap; Perry > 1 until static typed-array-kind inference
+// lands). Emit it first so a single-line metric consumer (the suite runner reads
+// only the first `label:number` line) tracks the *gap*, not absolute time.
+const ratio = untyped / typed;
+console.log("ta_untyped_typed_ratio:" + ratio);
 console.log("ta_untyped_access:" + untyped);
 console.log("ta_typed_access:" + typed);
-console.log("checksum:" + (lrU[0] === lrT[0] && lrU[1] === lrT[1] ? lrU[0] : -1));
+console.log("checksum:" + lrU[0]);

--- a/benchmarks/suite/bench_typed_array_untyped_access.ts
+++ b/benchmarks/suite/bench_typed_array_untyped_access.ts
@@ -1,0 +1,90 @@
+// Benchmark: untyped vs typed typed-array element access (issue #5525)
+//
+// bcryptjs's Blowfish core reaches its `S`/`P` Int32Array boxes through
+// *untyped* function parameters and does ~600M `S[i]`/`P[i]` reads. Each
+// untyped element read carries a per-element kind guard (the
+// `PERRY_TA_KIND_CACHE` probe + view-guard + kind dispatch) that the
+// statically-typed-array path skips — historically ~6x, and even after the
+// inline-load fast path (#5537/#5544/#5551) still measurably above the typed
+// path because the `any` receiver is shadow-stack-rooted, so LLVM cannot hoist
+// the loop-invariant guard. This benchmark pins that gap: the `untyped/typed`
+// ratio is the #5525 metric. Closing it to ~1.0 needs static typed-array-kind
+// inference for `any` params; this guard also protects the 28s -> ~7s win
+// already landed from regressing back toward the per-element thread-local
+// `lookup_typed_array_kind` cost.
+//
+// Mirrors bcryptjs `_encipher`'s inner loop shape: P/S reached as untyped
+// params, indexed with `>>>`/`|` expressions, accumulated with `+`/`^`.
+
+function encipherUntyped(lr: any, off: number, P: any, S: any): void {
+  let n: number;
+  let l = lr[off];
+  let r = lr[off + 1];
+  l ^= P[0];
+  let i = 0;
+  while (i < 16) {
+    n = S[l >>> 24];
+    n += S[0x100 | ((l >> 16) & 0xff)];
+    n ^= S[0x200 | ((l >> 8) & 0xff)];
+    n += S[0x300 | (l & 0xff)];
+    r ^= n ^ P[++i];
+    n = S[r >>> 24];
+    n += S[0x100 | ((r >> 16) & 0xff)];
+    n ^= S[0x200 | ((r >> 8) & 0xff)];
+    n += S[0x300 | (r & 0xff)];
+    l ^= n ^ P[++i];
+  }
+  lr[off] = r ^ P[17];
+  lr[off + 1] = l;
+}
+
+function encipherTyped(
+  lr: number[],
+  off: number,
+  P: Int32Array,
+  S: Int32Array,
+): void {
+  let n: number;
+  let l = lr[off];
+  let r = lr[off + 1];
+  l ^= P[0];
+  let i = 0;
+  while (i < 16) {
+    n = S[l >>> 24];
+    n += S[0x100 | ((l >> 16) & 0xff)];
+    n ^= S[0x200 | ((l >> 8) & 0xff)];
+    n += S[0x300 | (l & 0xff)];
+    r ^= n ^ P[++i];
+    n = S[r >>> 24];
+    n += S[0x100 | ((r >> 16) & 0xff)];
+    n ^= S[0x200 | ((r >> 8) & 0xff)];
+    n += S[0x300 | (r & 0xff)];
+    l ^= n ^ P[++i];
+  }
+  lr[off] = r ^ P[17];
+  lr[off + 1] = l;
+}
+
+const P = new Int32Array(18);
+const S = new Int32Array(1024);
+for (let i = 0; i < P.length; i++) P[i] = (i * 40503 + 7) | 0;
+for (let i = 0; i < S.length; i++) S[i] = (i * 2654435761) | 0;
+
+// ~4.27M calls ≈ one bcryptjs cost-12 `compareSync`'s _encipher count.
+const CALLS = 4270000;
+
+const lrU = [0x01234567, 0x89abcdef];
+let t = Date.now();
+for (let c = 0; c < CALLS; c++) encipherUntyped(lrU, 0, P, S);
+const untyped = Date.now() - t;
+
+const lrT = [0x01234567, 0x89abcdef];
+t = Date.now();
+for (let c = 0; c < CALLS; c++) encipherTyped(lrT, 0, P, S);
+const typed = Date.now() - t;
+
+// Same input → identical state proves the untyped fast path matches the typed
+// path bit-for-bit (the #5525 inline path must never diverge from the slow one).
+console.log("ta_untyped_access:" + untyped);
+console.log("ta_typed_access:" + typed);
+console.log("checksum:" + (lrU[0] === lrT[0] && lrU[1] === lrT[1] ? lrU[0] : -1));


### PR DESCRIPTION
## Summary

Adds `benchmarks/suite/bench_typed_array_untyped_access.ts` — a microbenchmark that pins the **#5525** metric: the cost of `S[i]`/`P[i]` typed-array element reads reached through an **untyped** (`any`) param vs a **statically-typed** (`Int32Array`) param, in bcryptjs `_encipher`'s exact inner-loop shape (~4.27M calls ≈ one cost-12 `compareSync`).

This does **not** itself close the gap — it captures it as a tracked, correctness-gated guard. See *Investigation* for why a localized fix isn't available and what the real fix is.

## Measured (this machine, user-CPU, min-of-N)

| path | Perry | Node |
|------|-------|------|
| untyped `any` param `S[i]` | ~3.47s | ~0.30s |
| typed `Int32Array` param `S[i]` | ~1.94s | ~0.29s |
| **untyped / typed ratio** | **~1.79x** | **~1.00x** |

Node has no untyped/typed gap; Perry's ~1.8x is the residual #5525 cost. The bench also asserts the untyped and typed paths produce a **bit-identical** result (`checksum:-821955270` on both Perry and Node), pinning the #5525 invariant that the inline fast path never diverges from the slow path.

## Investigation (why no perf fix here)

The already-merged inline fast path (#5537 / #5544 / #5551 / #5566) took bcryptjs cost-12 from **~28s → ~7s**. Profiling the residual (macOS `sample` + `clang -O3 -S` disasm of `_encipher`):

- Time is ~100% inlined user code — no hot runtime/GC/alloc symbols; the slow `js_dyn_index_get` path is **not** executed.
- The untyped path pays ~25 instr/access vs the typed path's ~5: a per-element `PERRY_TA_KIND_CACHE` probe + view-guard load + addr-match + kind dispatch that the typed path skips because it knows the kind statically.
- **Root cause:** the `any` receiver is shadow-stack-rooted, so its stack slot address-escapes to opaque `js_shadow_slot_bind`. LLVM must therefore reload the receiver and cannot hoist the loop-invariant guard out of `_encipher`'s inner loop.

Two localized fixes were prototyped and **rejected**:
1. Splitting the guard into an index-independent prefix so LLVM could unswitch it → byte-identical optimized asm (LLVM already normalizes it into `ccmp` chains). No effect.
2. A per-receiver inline cache in mem2reg-promotable entry allocas (replacing the un-hoistable global-cache probe) → only **~4.5%** while *growing* `_encipher` ~15% (the phi merges `{0, raw}`, so LLVM still can't prove "always hit" and keeps a per-access compare+branch, plus the resolve fallback stays inline). Not worth the complexity/risk on a hot, `issue_5525`-tested path.

**The real fix** is static typed-array-kind inference for `any` params (so the hot path uses the typed-array feedback path with no per-element guard) — a larger, cross-module change tracked separately. This benchmark lets that work be measured and guards the 28s→7s win from regressing back toward the per-element thread-local `lookup_typed_array_kind` cost.

## Notes
- Benchmark-only; no version bump / CHANGELOG (maintainer folds metadata at merge per CLAUDE.md).
- Follows the existing standalone `suite/bench_*.ts` convention (e.g. `bench_numeric_array_*.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new benchmark script comparing performance between untyped and typed element access in a Blowfish-style inner loop.
  * Includes a correctness check to verify both approaches produce identical final results, and reports timing plus a ratio metric for easy comparison.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->