### PR TITLE
feat(ads): #867 perry/ads end-to-end — config, AdBanner widget, consent + platform discrimination

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -834,9 +834,10 @@ jobs:
           # ld-unresolved-reference failure observed on #1038 pre-merge.
           # Move to a jose-aware test runner once that crate's CI hook
           # is wired up.
+          # test_ui_adbanner_smoke (#867 AdBanner widget),
           # test_ui_on_keydown_smoke / test_issue_1495_image_systemname /
           # test_issue_1867_audio_playback / test_issue_2022_canvas_draw_image
-          # all import `perry/ui` (App/Image/Canvas/loadImage/keydown). Like the
+          # all import `perry/ui` (App/AdBanner/Image/Canvas/loadImage/keydown). Like the
           # rest of the test_ui_* / media family above they need `--target
           # macos` to link the platform widgets; the bare `perry foo.ts -o out`
           # smoke path doesn't pull in libperry_ui_* on Linux, so they fail with
@@ -845,6 +846,7 @@ jobs:
             test_ui_comprehensive \
             test_ui_controls \
             test_ui_phase4 \
+            test_ui_adbanner_smoke \
             test_ui_on_keydown_smoke \
             test_issue_1495_image_systemname \
             test_issue_1867_audio_playback \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5541,6 +5541,9 @@ dependencies = [
 name = "perry-ext-ads"
 version = "0.5.1204"
 dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
  "perry-ffi",
 ]
 

--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -5587,4 +5587,5 @@ pub static API_MANIFEST: &[ApiEntry] = &[
     method("perry/ads", "js_ads_rewarded_show", false, None),
     method("perry/ads", "js_ads_banner_create", false, None),
     method("perry/ads", "js_ads_banner_destroy", false, None),
+    method("perry/ads", "js_ads_request_consent", false, None),
 ];

--- a/crates/perry-codegen/src/lower_call/native_table/http_http2.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/http_http2.rs
@@ -173,4 +173,13 @@ pub(super) const HTTP_HTTP2_ROWS: &[NativeModSig] = &[
         args: &[NA_F64],
         ret: NR_VOID,
     },
+    NativeModSig {
+        module: "perry/ads",
+        has_receiver: false,
+        method: "js_ads_request_consent",
+        class_filter: None,
+        runtime: "js_ads_request_consent",
+        args: &[],
+        ret: NR_PROMISE,
+    },
 ];

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi.rs
@@ -476,6 +476,7 @@ pub fn declare_stdlib_ffi(module: &mut LlModule) {
     module.declare_function("js_ads_rewarded_show", I64, &[]);
     module.declare_function("js_ads_banner_create", DOUBLE, &[I64, I64]);
     module.declare_function("js_ads_banner_destroy", VOID, &[DOUBLE]);
+    module.declare_function("js_ads_request_consent", I64, &[]);
 
     // ========== perry/thread (parallelMap, parallelFilter, spawn) ==========
     module.declare_function("js_thread_parallel_map", DOUBLE, &[DOUBLE, DOUBLE]);

--- a/crates/perry-dispatch/src/ui_table.rs
+++ b/crates/perry-dispatch/src/ui_table.rs
@@ -4,6 +4,15 @@ use super::*;
 
 pub const PERRY_UI_TABLE: &[MethodRow] = &[
     // ---- Constructors (return widget handle) ----
+    // AdBanner(unitId, size) — #867. Both args required (the generic
+    // dispatch no-ops on arity mismatch); use the `AdSize` string
+    // constants from the d.ts for `size`.
+    MethodRow {
+        method: "AdBanner",
+        runtime: "perry_ui_adbanner_create",
+        args: &[ArgKind::Str, ArgKind::Str],
+        ret: ReturnKind::Widget,
+    },
     MethodRow {
         method: "Divider",
         runtime: "perry_ui_divider_create",

--- a/crates/perry-ext-ads/Cargo.toml
+++ b/crates/perry-ext-ads/Cargo.toml
@@ -9,8 +9,24 @@ repository.workspace = true
 [lib]
 crate-type = ["staticlib", "rlib"]
 
+[features]
+# Real iOS Google Mobile Ads bridge (#867) — COMPILE-UNVERIFIED, OFF by
+# default. Enabling it compiles `src/ios_real.rs`, which makes live objc2
+# calls into the GoogleMobileAds framework. That framework must be linked
+# via SwiftPM (`GoogleMobileAds.xcframework`); host CI neither links it
+# nor builds the iOS target, so this code is unverified. The objc2 deps
+# are iOS-target-gated, so toggling the feature on a non-iOS host is a
+# no-op (the module + deps only activate under `cfg(target_os = "ios")`).
+google-ads = ["dep:objc2", "dep:block2", "dep:objc2-foundation"]
+
 [dependencies]
 perry-ffi.workspace = true
+
+# iOS-only, opt-in via the `google-ads` feature — see above.
+[target.'cfg(target_os = "ios")'.dependencies]
+objc2 = { version = "0.6", optional = true }
+block2 = { version = "0.6", optional = true }
+objc2-foundation = { version = "0.3", optional = true }
 
 [dev-dependencies]
 perry-ffi = { workspace = true, features = ["runtime-link"] }

--- a/crates/perry-ext-ads/src/ios_real.rs
+++ b/crates/perry-ext-ads/src/ios_real.rs
@@ -1,0 +1,235 @@
+//! Real iOS Google Mobile Ads bridge (#867) — **COMPILE-UNVERIFIED**.
+//!
+//! ⚠️  This module is gated behind `#[cfg(all(target_os = "ios",
+//! feature = "google-ads"))]` and is **not built by host CI**. It makes
+//! live objc2 calls into the GoogleMobileAds framework, which must be
+//! supplied at link time via the SwiftPM `GoogleMobileAds` package /
+//! `GoogleMobileAds.xcframework`. None of the code below has been
+//! compiled — it cannot be, because:
+//!   - the `aarch64-apple-ios` target + iOS SDK aren't present in the
+//!     build environment that produced it, and
+//!   - the GoogleMobileAds framework symbols aren't in the link graph
+//!     until a consumer wires up the SwiftPM dependency.
+//!
+//! It is provided as a best-effort starting point for whoever finishes
+//! the SwiftPM integration: the objc2 selector names, argument order,
+//! and block signatures match the GoogleMobileAds Obj-C API as of SDK
+//! v11, but MUST be validated against a real iOS build before shipping.
+//! Treat every call site as needing review.
+//!
+//! Design notes / known gaps:
+//!   - Uses dynamic dispatch (`class!` + `msg_send!`) rather than
+//!     `extern_class!` bindings so the module doesn't need a generated
+//!     GAD type surface.
+//!   - Each completion block resolves the promise exactly once. The
+//!     promise is consumed on resolve, so it's captured in a
+//!     `RefCell<Option<JsPromise>>` and `take()`n on first fire (these
+//!     GAD/ATT completion handlers fire once, on the main thread).
+//!   - Loaded ads are cached in thread-locals (single slot each) —
+//!     matches the `load once / show once` FFI shape.
+//!   - `*_show` presents from the key window's root view controller and
+//!     resolves on a successful present. Accurate `dismissed` reporting
+//!     needs a `GADFullScreenContentDelegate` (an objc2 `define_class!`
+//!     delegate) — that's a follow-up; for now `dismissed` is reported
+//!     `false` with no error on a successful present.
+
+use std::cell::RefCell;
+
+use block2::RcBlock;
+use objc2::rc::Retained;
+use objc2::runtime::AnyObject;
+use objc2::{class, msg_send};
+use objc2_foundation::NSString;
+
+use crate::{
+    resolve_interstitial_show_failure, resolve_load_failure, resolve_rewarded_show_failure,
+    JsPromise,
+};
+
+thread_local! {
+    /// The most-recently-loaded interstitial, retained until shown.
+    static INTERSTITIAL: RefCell<Option<Retained<AnyObject>>> = const { RefCell::new(None) };
+    /// The most-recently-loaded rewarded ad, retained until shown.
+    static REWARDED: RefCell<Option<Retained<AnyObject>>> = const { RefCell::new(None) };
+}
+
+/// Resolve a `JsPromise` captured in a once-firing completion block.
+/// No-op if the block somehow fires twice (the promise is already gone).
+fn settle(slot: &RefCell<Option<JsPromise>>, json: &str) {
+    if let Some(p) = slot.borrow_mut().take() {
+        p.resolve_string(json);
+    }
+}
+
+/// Build a fresh `GADRequest`.
+unsafe fn new_request() -> Retained<AnyObject> {
+    msg_send![class!(GADRequest), request]
+}
+
+/// Resolve the key window's `rootViewController` for ad presentation.
+/// Returns null if no window is active (the present then no-ops).
+unsafe fn root_view_controller() -> *mut AnyObject {
+    let app: *mut AnyObject = msg_send![class!(UIApplication), sharedApplication];
+    if app.is_null() {
+        return std::ptr::null_mut();
+    }
+    // `keyWindow` is deprecated but still the simplest single-scene
+    // lookup; a scene-aware lookup is a refinement.
+    let window: *mut AnyObject = msg_send![app, keyWindow];
+    if window.is_null() {
+        return std::ptr::null_mut();
+    }
+    msg_send![window, rootViewController]
+}
+
+// ---------------------------------------------------------------------
+// Interstitial
+// ---------------------------------------------------------------------
+
+pub fn interstitial_load(promise: JsPromise, unit_id: String) {
+    unsafe {
+        let ns_unit = NSString::from_str(&unit_id);
+        let request = new_request();
+        let slot = RefCell::new(Some(promise));
+
+        // completionHandler: void (^)(GADInterstitialAd *, NSError *)
+        let handler = RcBlock::new(move |ad: *mut AnyObject, err: *mut AnyObject| {
+            if !err.is_null() || ad.is_null() {
+                if let Some(p) = slot.borrow_mut().take() {
+                    resolve_load_failure(p, "no-fill");
+                }
+                return;
+            }
+            INTERSTITIAL.with(|s| *s.borrow_mut() = Retained::retain(ad));
+            settle(&slot, r#"{"success":true}"#);
+        });
+
+        let _: () = msg_send![
+            class!(GADInterstitialAd),
+            loadWithAdUnitID: &*ns_unit,
+            request: &*request,
+            completionHandler: &*handler,
+        ];
+    }
+}
+
+pub fn interstitial_show(promise: JsPromise) {
+    unsafe {
+        let ad = INTERSTITIAL.with(|slot| slot.borrow_mut().take());
+        let Some(ad) = ad else {
+            resolve_interstitial_show_failure(promise, "not-loaded");
+            return;
+        };
+        let rvc = root_view_controller();
+        if rvc.is_null() {
+            resolve_interstitial_show_failure(promise, "no-root-view-controller");
+            return;
+        }
+        let _: () = msg_send![&*ad, presentFromRootViewController: rvc];
+        // NOTE: resolves on present, not on dismissal — see module header.
+        promise.resolve_string(r#"{"shown":true,"dismissed":false}"#);
+    }
+}
+
+// ---------------------------------------------------------------------
+// Rewarded
+// ---------------------------------------------------------------------
+
+pub fn rewarded_load(promise: JsPromise, unit_id: String) {
+    unsafe {
+        let ns_unit = NSString::from_str(&unit_id);
+        let request = new_request();
+        let slot = RefCell::new(Some(promise));
+
+        let handler = RcBlock::new(move |ad: *mut AnyObject, err: *mut AnyObject| {
+            if !err.is_null() || ad.is_null() {
+                if let Some(p) = slot.borrow_mut().take() {
+                    resolve_load_failure(p, "no-fill");
+                }
+                return;
+            }
+            REWARDED.with(|s| *s.borrow_mut() = Retained::retain(ad));
+            settle(&slot, r#"{"success":true}"#);
+        });
+
+        let _: () = msg_send![
+            class!(GADRewardedAd),
+            loadWithAdUnitID: &*ns_unit,
+            request: &*request,
+            completionHandler: &*handler,
+        ];
+    }
+}
+
+pub fn rewarded_show(promise: JsPromise) {
+    unsafe {
+        let ad = REWARDED.with(|slot| slot.borrow_mut().take());
+        let Some(ad) = ad else {
+            resolve_rewarded_show_failure(promise, "not-loaded");
+            return;
+        };
+        let rvc = root_view_controller();
+        if rvc.is_null() {
+            resolve_rewarded_show_failure(promise, "no-root-view-controller");
+            return;
+        }
+        // userDidEarnRewardHandler: void (^)(void) — the reward is read
+        // from `ad.adReward` inside the handler.
+        let ad_for_handler = Retained::clone(&ad);
+        let slot = RefCell::new(Some(promise));
+        let reward_handler = RcBlock::new(move || {
+            let reward: *mut AnyObject = msg_send![&*ad_for_handler, adReward];
+            let amount: f64 = if reward.is_null() {
+                0.0
+            } else {
+                // `amount` is an NSDecimalNumber; `doubleValue` is good
+                // enough for a reward count.
+                msg_send![reward, doubleValue]
+            };
+            settle(
+                &slot,
+                &format!(r#"{{"earned":true,"dismissed":true,"amount":{}}}"#, amount),
+            );
+        });
+        let _: () = msg_send![
+            &*ad,
+            presentFromRootViewController: rvc,
+            userDidEarnRewardHandler: &*reward_handler,
+        ];
+    }
+}
+
+// ---------------------------------------------------------------------
+// Consent (ATT)
+// ---------------------------------------------------------------------
+
+pub fn consent_request(promise: JsPromise) {
+    unsafe {
+        // ATTrackingManager.requestTrackingAuthorization(completionHandler:)
+        // completion receives ATTrackingManagerAuthorizationStatus (NSUInteger):
+        //   0 notDetermined, 1 restricted, 2 denied, 3 authorized.
+        //
+        // ATTrackingManager only exists on iOS 14+. On older OSes the class
+        // is absent and the completion block would never fire, hanging the
+        // promise forever — so look the class up dynamically and resolve
+        // immediately with `not-determined` when it's missing.
+        let Some(cls) = objc2::runtime::AnyClass::get(c"ATTrackingManager") else {
+            crate::resolve_consent_failure(promise, "att-unavailable");
+            return;
+        };
+        let slot = RefCell::new(Some(promise));
+        let handler = RcBlock::new(move |status: usize| {
+            let slug = match status {
+                3 => "authorized",
+                2 => "denied",
+                1 => "restricted",
+                _ => "not-determined",
+            };
+            settle(&slot, &format!(r#"{{"status":"{}"}}"#, slug));
+        });
+        let _: () = msg_send![
+            cls,
+            requestTrackingAuthorizationWithCompletionHandler: &*handler,
+        ];
+    }
+}

--- a/crates/perry-ext-ads/src/lib.rs
+++ b/crates/perry-ext-ads/src/lib.rs
@@ -12,11 +12,14 @@
 //! export declare function js_ads_rewarded_load(unitId: string): Promise<string>;
 //! export declare function js_ads_rewarded_show(): Promise<string>;
 //!
-//! // Banner — handle-based widget. v1 exposes a perry-ext FFI
-//! // without `perry/ui` integration. The `<AdBanner>` widget glue
-//! // is a follow-up (#867).
+//! // Banner — handle-based widget. The primary banner surface is the
+//! // `perry/ui` `<AdBanner>` widget (it sits in the declarative layout
+//! // tree); this raw FFI is the secondary, handle-based path.
 //! export declare function js_ads_banner_create(unitId: string, sizeKey: string): number;
 //! export declare function js_ads_banner_destroy(handle: number): void;
+//!
+//! // Consent — ATT (iOS) / UMP (Android). Call before loading ads.
+//! export declare function js_ads_request_consent(): Promise<string>;
 //! ```
 //!
 //! The promise-returning entry points each resolve to a JSON
@@ -37,25 +40,25 @@
 //! {"earned": false, "dismissed": false, "error": "no-sdk-linked"}
 //! ```
 //!
-//! # Platform coverage (MVP)
+//! # Platform coverage
 //!
-//! - **iOS / Mac Catalyst**: real impl bridges to the
-//!   Google Mobile Ads SDK (`GADInterstitialAd`,
-//!   `GADRewardedAd`, `GADBannerView`) via SwiftPM + objc2. The
-//!   ATT (App Tracking Transparency) prompt is gated on the
-//!   per-app `NSUserTrackingUsageDescription` Info.plist key —
-//!   wiring is a follow-up.
-//! - **Android**: real impl bridges to the
-//!   `com.google.android.gms:play-services-ads` artifact via
-//!   JNI. The UMP (User Messaging Platform) consent SDK gates
-//!   personalised-ads requests under GDPR — wiring is a
-//!   follow-up.
-//! - **macOS (non-Catalyst) / Linux / Windows / tvOS / watchOS
-//!   / visionOS / gtk4**: no first-party Google Mobile Ads SDK
-//!   exists; these targets always resolve
-//!   `{ error: "unsupported-platform" }`. (For the MVP the
-//!   distinction is moot — every platform returns
-//!   `"no-sdk-linked"` until the real SDK calls land.)
+//! - **iOS / Mac Catalyst** (`target_os = "ios"`): a *supported*
+//!   platform. Default builds resolve `"no-sdk-linked"`; building with
+//!   `--features google-ads` delegates to `ios_real`, which makes live
+//!   objc2 calls into the Google Mobile Ads SDK (`GADInterstitialAd`,
+//!   `GADRewardedAd`) and `ATTrackingManager` for consent. That module
+//!   is COMPILE-UNVERIFIED (needs the SwiftPM xcframework + iOS target)
+//!   — see `ios_real.rs`. The ATT prompt needs the per-app
+//!   `NSUserTrackingUsageDescription` Info.plist key, which the compiler
+//!   emits from `perry.toml [ads].att_usage_description` (#867).
+//! - **Android**: a *supported* platform; resolves `"no-sdk-linked"`
+//!   until the JNI bridge into `com.google.android.gms:play-services-ads`
+//!   (+ UMP consent) lands. The compiler emits the `APPLICATION_ID`
+//!   meta-data from `perry.toml [ads].android_app_id`.
+//! - **macOS (non-Catalyst) / Linux / Windows / tvOS / watchOS /
+//!   visionOS / gtk4**: no first-party Google Mobile Ads SDK exists, so
+//!   every call resolves `{ error: "unsupported-platform" }`. (A
+//!   `perry/ui` app developed/previewed on macOS native lands here.)
 //!
 //! # Configuration
 //!
@@ -132,8 +135,24 @@ fn resolve_rewarded_show_failure(promise: JsPromise, error: &'static str) {
     });
 }
 
+/// Resolve `promise` with a consent-request result. JSON shape:
+/// `{"status": "not-determined", "error": "<slug>"}`.
+///
+/// `status` mirrors what the real ATT (App Tracking Transparency, iOS) /
+/// UMP (User Messaging Platform, Android) flow reports — `"authorized"`,
+/// `"denied"`, `"not-determined"`, `"restricted"`. Until the SDK is
+/// linked it's pinned to `"not-determined"` with an `error` slug so
+/// callers can branch on either field.
+fn resolve_consent_failure(promise: JsPromise, error: &'static str) {
+    spawn_blocking(move || {
+        let json = format!(r#"{{"status":"not-determined","error":"{}"}}"#, error);
+        promise.resolve_string(&json);
+    });
+}
+
 // =====================================================================
-// Apple (iOS + Mac Catalyst)
+// Apple (iOS + Mac Catalyst — `target_os = "ios"` covers device,
+// simulator, and Mac Catalyst)
 // =====================================================================
 //
 // Real SDK integration goes through the Google Mobile Ads SwiftPM
@@ -143,61 +162,97 @@ fn resolve_rewarded_show_failure(promise: JsPromise, error: &'static str) {
 // for the interstitial path,
 // `GADRewardedAd.load(withAdUnitID:request:completionHandler:)`
 // for rewarded, and `GADBannerView` (with `adSize` /
-// `rootViewController`) for the banner widget.
+// `rootViewController`) for the banner widget. ATT consent goes
+// through `ATTrackingManager.requestTrackingAuthorization`.
 //
-// For the MVP we land the module boundary but route every call
-// to the structured failure helper so the crate compiles on
-// `cargo build` without dragging the SwiftPM SDK into the link
-// graph.
+// Two build modes:
+//   - default: route every call to the structured failure helper
+//     (`no-sdk-linked`) so the crate compiles on `cargo build`
+//     without dragging the SwiftPM SDK into the link graph. iOS is a
+//     *supported* platform, so the slug is `no-sdk-linked`, not
+//     `unsupported-platform`.
+//   - `--features google-ads`: delegate to `ios_real`, which makes
+//     real objc2 calls into the GoogleMobileAds framework. That module
+//     is COMPILE-UNVERIFIED here (it needs the iOS target + the
+//     xcframework, neither present in host CI) — see its header.
 
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+#[cfg(all(target_os = "ios", feature = "google-ads"))]
+mod ios_real;
+
+#[cfg(target_os = "ios")]
 mod platform {
     use super::*;
 
-    /// TODO(#867): load a `GADInterstitialAd` against `unit_id` and
-    /// cache it for the next `interstitial_show` call. Completion
-    /// handler should resolve with `{ success: true }` on a
-    /// successful load and `{ success: false, error }` otherwise.
-    pub fn interstitial_load(promise: JsPromise, _unit_id: String) {
-        resolve_load_failure(promise, "no-sdk-linked");
+    pub fn interstitial_load(promise: JsPromise, unit_id: String) {
+        #[cfg(feature = "google-ads")]
+        {
+            super::ios_real::interstitial_load(promise, unit_id);
+        }
+        #[cfg(not(feature = "google-ads"))]
+        {
+            let _ = unit_id;
+            resolve_load_failure(promise, "no-sdk-linked");
+        }
     }
 
-    /// TODO(#867): present the previously-loaded interstitial via
-    /// `present(fromRootViewController:)`. Resolve once the user
-    /// dismisses the ad with
-    /// `{ shown: true, dismissed: true }`, or
-    /// `{ shown: false, dismissed: false, error }` if no ad was
-    /// cached.
     pub fn interstitial_show(promise: JsPromise) {
-        resolve_interstitial_show_failure(promise, "no-sdk-linked");
+        #[cfg(feature = "google-ads")]
+        {
+            super::ios_real::interstitial_show(promise);
+        }
+        #[cfg(not(feature = "google-ads"))]
+        {
+            resolve_interstitial_show_failure(promise, "no-sdk-linked");
+        }
     }
 
-    /// TODO(#867): load a `GADRewardedAd` against `unit_id`.
-    pub fn rewarded_load(promise: JsPromise, _unit_id: String) {
-        resolve_load_failure(promise, "no-sdk-linked");
+    pub fn rewarded_load(promise: JsPromise, unit_id: String) {
+        #[cfg(feature = "google-ads")]
+        {
+            super::ios_real::rewarded_load(promise, unit_id);
+        }
+        #[cfg(not(feature = "google-ads"))]
+        {
+            let _ = unit_id;
+            resolve_load_failure(promise, "no-sdk-linked");
+        }
     }
 
-    /// TODO(#867): present the rewarded ad and resolve once the
-    /// reward delegate fires with `{ earned: true, amount, type }`,
-    /// or `{ earned: false, dismissed: true }` if the user
-    /// dismissed early.
     pub fn rewarded_show(promise: JsPromise) {
-        resolve_rewarded_show_failure(promise, "no-sdk-linked");
+        #[cfg(feature = "google-ads")]
+        {
+            super::ios_real::rewarded_show(promise);
+        }
+        #[cfg(not(feature = "google-ads"))]
+        {
+            resolve_rewarded_show_failure(promise, "no-sdk-linked");
+        }
     }
 
     /// TODO(#867): create a `GADBannerView`, attach it to the root
     /// view controller, register it in the perry-ffi handle table,
-    /// and return the handle.
+    /// and return the handle. (The `perry/ui` `<AdBanner>` widget is
+    /// the primary banner surface; this raw-FFI path is secondary.)
     pub fn banner_create(_unit_id: String, _size_key: String) -> i64 {
         // Placeholder handle. Real impl will call
         // `perry_ffi::register_handle(banner_view)`.
         0
     }
 
-    /// TODO(#867): release the banner via the handle table and
-    /// detach it from the view hierarchy.
     pub fn banner_destroy(_handle: i64) {
         // No-op until real SDK integration lands.
+    }
+
+    /// ATT consent — `ATTrackingManager.requestTrackingAuthorization`.
+    pub fn consent_request(promise: JsPromise) {
+        #[cfg(feature = "google-ads")]
+        {
+            super::ios_real::consent_request(promise);
+        }
+        #[cfg(not(feature = "google-ads"))]
+        {
+            resolve_consent_failure(promise, "no-sdk-linked");
+        }
     }
 }
 
@@ -205,13 +260,14 @@ mod platform {
 // Android
 // =====================================================================
 //
-// Real impl bridges to `com.google.android.gms.ads.*`. The Java/
-// Kotlin side lives in `crates/perry-ui-android/template/.../PerryBridge.kt`
-// (follow-up — the JNI entry points `adsInterstitialLoad` /
-// `adsInterstitialShow` / `adsRewardedLoad` / `adsRewardedShow` /
-// `adsBannerCreate` / `adsBannerDestroy` aren't written yet). The
-// completion side resolves the promise once the Kotlin callback
-// fires.
+// Real impl bridges to `com.google.android.gms.ads.*` via JNI into the
+// Kotlin helpers in
+// `crates/perry-ui-android/template/.../PerryBridge.kt`
+// (`adsInterstitialLoad` / `adsInterstitialShow` / `adsRewardedLoad` /
+// `adsRewardedShow` / `adsRequestConsent`). The completion side
+// resolves the promise once the Kotlin callback fires. The JNI wiring
+// is a follow-up; for now Android is a *supported* platform whose calls
+// resolve `no-sdk-linked`.
 
 #[cfg(target_os = "android")]
 mod platform {
@@ -240,37 +296,43 @@ mod platform {
     pub fn banner_destroy(_handle: i64) {
         // No-op until real SDK integration lands.
     }
+
+    /// UMP consent — `ConsentInformation.requestConsentInfoUpdate`.
+    pub fn consent_request(promise: JsPromise) {
+        resolve_consent_failure(promise, "no-sdk-linked");
+    }
 }
 
 // =====================================================================
-// Other targets — Linux / Windows / tvOS / watchOS / visionOS / gtk4
+// Other targets — macOS (non-Catalyst) / Linux / Windows / tvOS /
+// watchOS / visionOS / gtk4
 // =====================================================================
 //
-// Google Mobile Ads doesn't ship a first-party SDK on any of
-// these. The MVP returns the same `no-sdk-linked` slug as the
-// Apple/Android stubs so callers see one consistent
-// `{ success: false }` shape during development. Once real SDK
-// integration lands on iOS/Android, this branch flips to
-// `unsupported-platform`.
+// Google Mobile Ads ships no first-party SDK on any of these, so every
+// call resolves `unsupported-platform`. This is the honest distinction
+// the MVP deferred: iOS/Android say `no-sdk-linked` (a supported
+// platform whose SDK isn't wired up yet); everything else — including
+// macOS native, where a `perry/ui` app may be developed/previewed —
+// says `unsupported-platform`.
 
-#[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "android")))]
+#[cfg(not(any(target_os = "ios", target_os = "android")))]
 mod platform {
     use super::*;
 
     pub fn interstitial_load(promise: JsPromise, _unit_id: String) {
-        resolve_load_failure(promise, "no-sdk-linked");
+        resolve_load_failure(promise, "unsupported-platform");
     }
 
     pub fn interstitial_show(promise: JsPromise) {
-        resolve_interstitial_show_failure(promise, "no-sdk-linked");
+        resolve_interstitial_show_failure(promise, "unsupported-platform");
     }
 
     pub fn rewarded_load(promise: JsPromise, _unit_id: String) {
-        resolve_load_failure(promise, "no-sdk-linked");
+        resolve_load_failure(promise, "unsupported-platform");
     }
 
     pub fn rewarded_show(promise: JsPromise) {
-        resolve_rewarded_show_failure(promise, "no-sdk-linked");
+        resolve_rewarded_show_failure(promise, "unsupported-platform");
     }
 
     pub fn banner_create(_unit_id: String, _size_key: String) -> i64 {
@@ -278,7 +340,11 @@ mod platform {
     }
 
     pub fn banner_destroy(_handle: i64) {
-        // No-op until real SDK integration lands.
+        // No-op — no SDK on this platform.
+    }
+
+    pub fn consent_request(promise: JsPromise) {
+        resolve_consent_failure(promise, "unsupported-platform");
     }
 }
 
@@ -397,6 +463,23 @@ pub unsafe extern "C" fn js_ads_banner_create(
 #[no_mangle]
 pub extern "C" fn js_ads_banner_destroy(handle: f64) {
     platform::banner_destroy(handle as i64);
+}
+
+/// `js_ads_request_consent()` — request user consent for personalised
+/// ads / tracking. Resolves to a JSON-stringified `AdConsentResult`.
+///
+/// On iOS this drives App Tracking Transparency
+/// (`ATTrackingManager.requestTrackingAuthorization`); on Android the
+/// User Messaging Platform consent form
+/// (`ConsentInformation`/`ConsentForm`). The result `status` is one of
+/// `"authorized"` / `"denied"` / `"not-determined"` / `"restricted"`.
+/// Call this before loading ads so requests honour GDPR / ATT.
+#[no_mangle]
+pub extern "C" fn js_ads_request_consent() -> *mut perry_ffi::Promise {
+    let promise = JsPromise::new();
+    let raw = promise.as_raw();
+    platform::consent_request(promise);
+    raw
 }
 
 // No `#[cfg(test)] mod tests` block here: the FFI entry points

--- a/crates/perry-ui-android/src/ffi/image_nav.rs
+++ b/crates/perry-ui-android/src/ffi/image_nav.rs
@@ -19,6 +19,15 @@ pub extern "C" fn perry_ui_image_create_symbol(name_ptr: i64) -> i64 {
     widgets::image::create_symbol(name_ptr as *const u8)
 }
 
+/// Create an AdBanner (#867). `unit_id_ptr` / `size_ptr` are string
+/// headers. Default build is a layout placeholder sized to the banner
+/// slot; a live `AdView` (play-services-ads) is a follow-up. Returns
+/// widget handle.
+#[no_mangle]
+pub extern "C" fn perry_ui_adbanner_create(unit_id_ptr: i64, size_ptr: i64) -> i64 {
+    widgets::adbanner::create(unit_id_ptr as *const u8, size_ptr as *const u8)
+}
+
 /// #635 stub: remote URL images aren't fetched on Android yet —
 /// register an empty image widget so layout still works.
 #[no_mangle]

--- a/crates/perry-ui-android/src/widgets/adbanner.rs
+++ b/crates/perry-ui-android/src/widgets/adbanner.rs
@@ -1,0 +1,72 @@
+//! `AdBanner` widget (#867) — Android.
+//!
+//! Default build: a layout placeholder `View` sized to the requested
+//! banner slot so the banner reserves the right space in the layout.
+//! Swapping in a live `com.google.android.gms.ads.AdView` (set
+//! `adUnitId` + `AdSize`, then `loadAd(AdRequest)`) is a follow-up that
+//! depends on the `play-services-ads` Gradle artifact — see the JNI
+//! bridge notes in `perry-ext-ads/src/lib.rs`. `unitId` is accepted for
+//! API parity but unused by the placeholder.
+
+use crate::jni_bridge;
+use jni::objects::JValue;
+
+fn str_from_header(ptr: *const u8) -> &'static str {
+    crate::app::str_from_header(ptr)
+}
+
+/// Banner dimensions in dp per size key (matches Google Mobile Ads'
+/// standard `AdSize` constants).
+fn banner_size_dp(size_key: &str) -> (f32, f32) {
+    match size_key {
+        "large-banner" => (320.0, 100.0),
+        "medium-rectangle" => (300.0, 250.0),
+        "full-banner" => (468.0, 60.0),
+        "leaderboard" => (728.0, 90.0),
+        _ => (320.0, 50.0),
+    }
+}
+
+/// Create the banner placeholder view sized per `size_ptr`.
+pub fn create(unit_id_ptr: *const u8, size_ptr: *const u8) -> i64 {
+    let _unit_id = str_from_header(unit_id_ptr);
+    let size_key = str_from_header(size_ptr);
+    let (w_dp, h_dp) = banner_size_dp(size_key);
+
+    let mut env = jni_bridge::get_env();
+    let _ = env.push_local_frame(32);
+    let activity = super::get_activity(&mut env);
+
+    let view = env
+        .new_object(
+            "android/view/View",
+            "(Landroid/content/Context;)V",
+            &[JValue::Object(&activity)],
+        )
+        .expect("Failed to create View");
+
+    let width_px = super::dp_to_px(&mut env, w_dp);
+    let height_px = super::dp_to_px(&mut env, h_dp);
+    let params = env
+        .new_object(
+            "android/widget/LinearLayout$LayoutParams",
+            "(II)V",
+            &[JValue::Int(width_px), JValue::Int(height_px)],
+        )
+        .expect("Failed to create LayoutParams");
+    let _ = env.call_method(
+        &view,
+        "setLayoutParams",
+        "(Landroid/view/ViewGroup$LayoutParams;)V",
+        &[JValue::Object(&params)],
+    );
+
+    let global = env
+        .new_global_ref(view)
+        .expect("Failed to create global ref");
+    let handle = super::register_widget(global);
+    unsafe {
+        env.pop_local_frame(&jni::objects::JObject::null());
+    }
+    handle
+}

--- a/crates/perry-ui-android/src/widgets/mod.rs
+++ b/crates/perry-ui-android/src/widgets/mod.rs
@@ -1,3 +1,4 @@
+pub mod adbanner;
 pub mod attributed_text;
 pub mod bloomview;
 pub mod bottom_nav;

--- a/crates/perry-ui-ios/src/ffi/widgets_advanced.rs
+++ b/crates/perry-ui-ios/src/ffi/widgets_advanced.rs
@@ -183,6 +183,15 @@ pub extern "C" fn perry_ui_image_create_url(url_ptr: i64, alt_ptr: i64) -> i64 {
     widgets::image::create_url(url_ptr as *const u8, alt_ptr as *const u8)
 }
 
+/// Create an AdBanner (#867). `unit_id_ptr` / `size_ptr` are string
+/// headers. Default build is a layout placeholder sized to the banner
+/// slot; a live `GADBannerView` is a feature-gated follow-up. Returns
+/// widget handle.
+#[no_mangle]
+pub extern "C" fn perry_ui_adbanner_create(unit_id_ptr: i64, size_ptr: i64) -> i64 {
+    widgets::adbanner::create(unit_id_ptr as *const u8, size_ptr as *const u8)
+}
+
 /// Set the size of an Image widget.
 #[no_mangle]
 pub extern "C" fn perry_ui_image_set_size(handle: i64, width: f64, height: f64) {

--- a/crates/perry-ui-ios/src/widgets/adbanner.rs
+++ b/crates/perry-ui-ios/src/widgets/adbanner.rs
@@ -1,0 +1,65 @@
+//! `AdBanner` widget (#867) — iOS.
+//!
+//! Default build: a layout placeholder `UIView` sized to the requested
+//! banner slot, so the banner reserves the right space in the layout
+//! tree. Swapping in a live `GADBannerView` (set `adUnitID`, `adSize`,
+//! `rootViewController`, then `loadRequest:`) is a feature-gated
+//! follow-up that links the GoogleMobileAds framework via SwiftPM — see
+//! `perry-ext-ads/src/ios_real.rs` for the same COMPILE-UNVERIFIED
+//! caveat. `unitId` is accepted for API parity but unused by the
+//! placeholder.
+//!
+//! NOTE: this crate cross-compiles only for the iOS target, which is not
+//! present in host CI, so this file is compile-unverified here.
+
+use objc2::msg_send;
+use objc2::rc::Retained;
+use objc2::runtime::AnyObject;
+use objc2_core_foundation::{CGPoint, CGRect, CGSize};
+use objc2_foundation::MainThreadMarker;
+use objc2_ui_kit::UIView;
+
+/// Extract a &str from a `*const StringHeader` pointer.
+fn str_from_header(ptr: *const u8) -> &'static str {
+    if ptr.is_null() {
+        return "";
+    }
+    unsafe {
+        let header = ptr as *const crate::string_header::StringHeader;
+        let len = (*header).byte_len as usize;
+        let data = ptr.add(std::mem::size_of::<crate::string_header::StringHeader>());
+        std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+    }
+}
+
+/// Banner dimensions in points per size key (matches Google Mobile Ads'
+/// standard `GADAdSize` constants).
+fn banner_size(size_key: &str) -> (f64, f64) {
+    match size_key {
+        "large-banner" => (320.0, 100.0),
+        "medium-rectangle" => (300.0, 250.0),
+        "full-banner" => (468.0, 60.0),
+        "leaderboard" => (728.0, 90.0),
+        _ => (320.0, 50.0),
+    }
+}
+
+/// Create the banner placeholder view sized per `size_ptr`.
+pub fn create(unit_id_ptr: *const u8, size_ptr: *const u8) -> i64 {
+    let _unit_id = str_from_header(unit_id_ptr);
+    let size_key = str_from_header(size_ptr);
+    let (w, h) = banner_size(size_key);
+    let _mtm = MainThreadMarker::new().expect("perry/ui must run on the main thread");
+
+    unsafe {
+        let view_cls = objc2::runtime::AnyClass::get(c"UIView").unwrap();
+        let obj: *mut AnyObject = msg_send![view_cls, alloc];
+        let frame = CGRect::new(CGPoint::new(0.0, 0.0), CGSize::new(w, h));
+        let obj: *mut AnyObject = msg_send![obj, initWithFrame: frame];
+        // `initWithFrame:` already returns an owned (+1) object — take that
+        // ownership with `from_raw` rather than `retain` (which would add a
+        // second +1 and leak one reference per banner).
+        let view: Retained<UIView> = Retained::from_raw(obj as *mut UIView).unwrap();
+        super::register_widget(view)
+    }
+}

--- a/crates/perry-ui-ios/src/widgets/mod.rs
+++ b/crates/perry-ui-ios/src/widgets/mod.rs
@@ -1,3 +1,4 @@
+pub mod adbanner;
 pub mod alert;
 pub mod attributed_text;
 pub mod bloomview;

--- a/crates/perry-ui-macos/src/lib_ffi/core_widgets.rs
+++ b/crates/perry-ui-macos/src/lib_ffi/core_widgets.rs
@@ -204,6 +204,15 @@ pub extern "C" fn perry_ui_divider_create() -> i64 {
     widgets::divider::create()
 }
 
+/// Create an AdBanner (#867). `unit_id_ptr` / `size_ptr` are string
+/// headers (ad unit id + size key). On macOS this is a layout-only
+/// placeholder — Google Mobile Ads ships no macOS SDK — sized to match
+/// the real banner slot on iOS/Android. Returns widget handle.
+#[no_mangle]
+pub extern "C" fn perry_ui_adbanner_create(unit_id_ptr: i64, size_ptr: i64) -> i64 {
+    widgets::adbanner::create(unit_id_ptr as *const u8, size_ptr as *const u8)
+}
+
 /// Create an editable TextField. placeholder_ptr = string, on_change = NaN-boxed closure.
 /// Returns widget handle.
 #[no_mangle]

--- a/crates/perry-ui-macos/src/widgets/adbanner.rs
+++ b/crates/perry-ui-macos/src/widgets/adbanner.rs
@@ -1,0 +1,47 @@
+//! `AdBanner` widget (#867).
+//!
+//! Google Mobile Ads ships no first-party macOS SDK, so on the Mac the
+//! banner is a **layout placeholder**: an empty `NSView` sized to the
+//! requested banner slot. A `perry/ui` layout developed or previewed on
+//! macOS therefore reserves exactly the space the real ad occupies on
+//! iOS/Android (where the banner widget renders a live `GADBannerView` /
+//! `AdView`). The `unitId` is accepted for cross-platform API parity but
+//! unused here since nothing loads.
+
+use objc2::msg_send;
+use objc2::rc::Retained;
+use objc2::{AnyThread, MainThreadOnly};
+use objc2_app_kit::NSView;
+use objc2_core_foundation::{CGPoint, CGRect, CGSize};
+use objc2_foundation::MainThreadMarker;
+
+use super::image::str_from_header;
+
+/// Banner dimensions in points for each size key the d.ts exposes.
+/// Values match Google Mobile Ads' standard `AdSize` constants so the
+/// reserved macOS slot lines up with the real iOS/Android banner.
+fn banner_size(size_key: &str) -> (f64, f64) {
+    match size_key {
+        "large-banner" => (320.0, 100.0),
+        "medium-rectangle" => (300.0, 250.0),
+        "full-banner" => (468.0, 60.0),
+        "leaderboard" => (728.0, 90.0),
+        // "banner" / "adaptive" / empty / unknown → standard 320×50.
+        _ => (320.0, 50.0),
+    }
+}
+
+/// Create the banner placeholder view sized per `size_ptr`. Returns the
+/// widget handle.
+pub fn create(unit_id_ptr: *const u8, size_ptr: *const u8) -> i64 {
+    let _unit_id = str_from_header(unit_id_ptr);
+    let size_key = str_from_header(size_ptr);
+    let (w, h) = banner_size(size_key);
+    let mtm = MainThreadMarker::new().expect("perry/ui must run on the main thread");
+
+    unsafe {
+        let frame = CGRect::new(CGPoint::new(0.0, 0.0), CGSize::new(w, h));
+        let view: Retained<NSView> = msg_send![NSView::alloc(mtm), initWithFrame: frame];
+        super::register_widget(view)
+    }
+}

--- a/crates/perry-ui-macos/src/widgets/mod.rs
+++ b/crates/perry-ui-macos/src/widgets/mod.rs
@@ -1,3 +1,4 @@
+pub mod adbanner;
 pub mod alert;
 pub mod attributed_text;
 pub mod bloomview;

--- a/crates/perry/src/commands/compile/apple_info_plist.rs
+++ b/crates/perry/src/commands/compile/apple_info_plist.rs
@@ -8,6 +8,9 @@
 //! - `inject_google_auth_info_plist` (#674/#1138) — read `[google_auth]` from
 //!   `perry.toml` and inject `GIDClientID` / `GIDServerClientID` /
 //!   `GIDDefaultScopes` for the `@perryts/google-auth` Swift bridge.
+//! - `inject_ads_info_plist` (#867) — read `[ads]` from `perry.toml` and inject
+//!   `GADApplicationIdentifier` (+ `NSUserTrackingUsageDescription`) for the
+//!   Google Mobile Ads SDK.
 //!
 //! Both functions follow the same shape: return the mutated plist on success,
 //! `None` on any read/parse/write failure. The orchestrator falls back to the
@@ -186,6 +189,82 @@ pub(super) fn inject_google_auth_info_plist(
 
     if let OutputFormat::Text = format {
         println!("  google_auth: injected GoogleSignIn Info.plist keys");
+    }
+
+    Some(info_plist.replace(
+        "</dict>\n</plist>",
+        &format!("{}</dict>\n</plist>", entries),
+    ))
+}
+
+/// #867 — read `[ads]` from `perry.toml` and inject the Google Mobile
+/// Ads keys into `info_plist`:
+///
+/// - `GADApplicationIdentifier` (from `ios_app_id`) — required; the SDK
+///   raises an exception at `start()` if it's missing.
+/// - `NSUserTrackingUsageDescription` (from `att_usage_description`) —
+///   the purpose string iOS shows in the App Tracking Transparency
+///   prompt. Only emitted when configured, and only if the app hasn't
+///   already declared it via `[ios.info_plist]`.
+///
+/// Returns the mutated plist on success, `None` if the block / the
+/// `ios_app_id` key is absent (caller falls back to the unmutated
+/// plist). Mirrors `inject_google_auth_info_plist`.
+pub(super) fn inject_ads_info_plist(
+    info_plist: &str,
+    input: &std::path::Path,
+    format: OutputFormat,
+) -> Option<String> {
+    let mut dir = input.canonicalize().ok()?;
+    let mut data: Option<String> = None;
+    for _ in 0..5 {
+        dir = dir.parent()?.to_path_buf();
+        let toml_path = dir.join("perry.toml");
+        if toml_path.exists() {
+            data = fs::read_to_string(&toml_path).ok();
+            break;
+        }
+    }
+    let raw = data?;
+    let doc: toml::Table = raw.parse().ok()?;
+    let ads = doc.get("ads")?.as_table()?;
+
+    // GADApplicationIdentifier is the only required key — without it the
+    // SDK can't start, so a `[ads]` block with no `ios_app_id` is a no-op
+    // for the Apple side.
+    let app_id = ads.get("ios_app_id").and_then(|v| v.as_str())?;
+
+    // App IDs are `ca-app-pub-<digits>~<digits>` (no XML specials), but
+    // escape defensively so a malformed value can't produce an invalid
+    // plist — matches the Android-manifest injector.
+    let app_id_escaped = app_id
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;");
+    let mut entries = String::new();
+    entries.push_str(&format!(
+        "    <key>GADApplicationIdentifier</key>\n    <string>{}</string>\n",
+        app_id_escaped
+    ));
+
+    // ATT purpose string is free-form user text — escape XML specials.
+    // Skip it if the app already declared NSUserTrackingUsageDescription
+    // (e.g. via [ios.info_plist]) so we don't emit a duplicate key.
+    if let Some(desc) = ads.get("att_usage_description").and_then(|v| v.as_str()) {
+        if !info_plist.contains("NSUserTrackingUsageDescription") {
+            let escaped = desc
+                .replace('&', "&amp;")
+                .replace('<', "&lt;")
+                .replace('>', "&gt;");
+            entries.push_str(&format!(
+                "    <key>NSUserTrackingUsageDescription</key>\n    <string>{}</string>\n",
+                escaped
+            ));
+        }
+    }
+
+    if let OutputFormat::Text = format {
+        println!("  ads: injected GoogleMobileAds Info.plist keys (#867)");
     }
 
     Some(info_plist.replace(
@@ -509,5 +588,91 @@ mod push_entitlement_tests {
 
         assert!(inject_ios_push_entitlement(&input, &app_dir, OutputFormat::Json).is_none());
         assert!(!app_dir.join("app.entitlements").exists());
+    }
+}
+
+#[cfg(test)]
+mod ads_info_plist_tests {
+    use super::inject_ads_info_plist;
+    use crate::OutputFormat;
+
+    const BASE_PLIST: &str = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+        <plist version=\"1.0\">\n<dict>\n    \
+        <key>CFBundleIdentifier</key>\n    <string>com.example.app</string>\n</dict>\n</plist>";
+
+    /// Stage a project tree with `perry.toml` one dir above `src/main.ts`
+    /// and return `(tempdir, input_path)`. The injector walks up from the
+    /// input via `parent()`, so the toml must sit above the input.
+    fn staged(toml_body: &str) -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let input = dir.path().join("src").join("main.ts");
+        std::fs::create_dir_all(input.parent().unwrap()).unwrap();
+        std::fs::write(&input, "console.log('x')").unwrap();
+        std::fs::write(dir.path().join("perry.toml"), toml_body).unwrap();
+        (dir, input)
+    }
+
+    #[test]
+    fn injects_gad_application_identifier() {
+        let (_dir, input) =
+            staged("[ads]\nios_app_id = \"ca-app-pub-3940256099942544~1458002511\"\n");
+        let out = inject_ads_info_plist(BASE_PLIST, &input, OutputFormat::Json).unwrap();
+        assert!(out.contains("<key>GADApplicationIdentifier</key>"));
+        assert!(out.contains("ca-app-pub-3940256099942544~1458002511"));
+        // Wrapper integrity — exactly one closing dict/plist, keys spliced
+        // before them.
+        assert_eq!(out.matches("</dict>").count(), 1);
+        assert_eq!(out.matches("</plist>").count(), 1);
+        // Untouched existing keys survive.
+        assert!(out.contains("<key>CFBundleIdentifier</key>"));
+    }
+
+    #[test]
+    fn injects_att_usage_description_when_configured() {
+        let (_dir, input) = staged(
+            "[ads]\nios_app_id = \"ca-app-pub-XXXX~YYYY\"\natt_usage_description = \"Ads & you\"\n",
+        );
+        let out = inject_ads_info_plist(BASE_PLIST, &input, OutputFormat::Json).unwrap();
+        assert!(out.contains("<key>NSUserTrackingUsageDescription</key>"));
+        // Free-text purpose string gets XML-escaped.
+        assert!(out.contains("Ads &amp; you"));
+    }
+
+    #[test]
+    fn skips_att_key_when_already_declared() {
+        // The app already set NSUserTrackingUsageDescription via
+        // [ios.info_plist]; we must not emit a duplicate key.
+        let with_att = BASE_PLIST.replace(
+            "</dict>",
+            "    <key>NSUserTrackingUsageDescription</key>\n    <string>existing</string>\n</dict>",
+        );
+        let (_dir, input) = staged(
+            "[ads]\nios_app_id = \"ca-app-pub-XXXX~YYYY\"\natt_usage_description = \"new\"\n",
+        );
+        let out = inject_ads_info_plist(&with_att, &input, OutputFormat::Json).unwrap();
+        assert_eq!(out.matches("NSUserTrackingUsageDescription").count(), 1);
+        assert!(out.contains("<string>existing</string>"));
+        // GADApplicationIdentifier still added.
+        assert!(out.contains("<key>GADApplicationIdentifier</key>"));
+    }
+
+    #[test]
+    fn escapes_xml_specials_in_app_id() {
+        // A malformed app_id with XML specials must not produce an invalid
+        // plist (#867 / CodeRabbit).
+        let (_dir, input) = staged("[ads]\nios_app_id = \"ca&app<pub>id\"\n");
+        let out = inject_ads_info_plist(BASE_PLIST, &input, OutputFormat::Json).unwrap();
+        assert!(out.contains("ca&amp;app&lt;pub&gt;id"));
+        assert!(!out.contains("ca&app<pub>id"));
+    }
+
+    #[test]
+    fn no_op_when_block_or_id_absent() {
+        // No [ads] block at all.
+        let (_d1, i1) = staged("[ios]\nbundle_id = \"a\"\n");
+        assert!(inject_ads_info_plist(BASE_PLIST, &i1, OutputFormat::Json).is_none());
+        // [ads] present but no ios_app_id (Android-only config).
+        let (_d2, i2) = staged("[ads]\nandroid_app_id = \"ca-app-pub-XXXX~ZZZZ\"\n");
+        assert!(inject_ads_info_plist(BASE_PLIST, &i2, OutputFormat::Json).is_none());
     }
 }

--- a/crates/perry/src/commands/compile/bundle_ios.rs
+++ b/crates/perry/src/commands/compile/bundle_ios.rs
@@ -17,8 +17,8 @@ use anyhow::Result;
 use crate::OutputFormat;
 
 use super::apple_info_plist::{
-    inject_google_auth_info_plist, inject_ios_app_group_entitlement, inject_ios_deeplinks,
-    inject_ios_push_entitlement,
+    inject_ads_info_plist, inject_google_auth_info_plist, inject_ios_app_group_entitlement,
+    inject_ios_deeplinks, inject_ios_push_entitlement,
 };
 use super::resources::stage_native_library_artifacts;
 use super::targets::compile_metallib_for_bundle;
@@ -458,6 +458,12 @@ pub(super) fn build_ios_app_bundle(
     // `@perryts/google-auth` reads at runtime.
     let info_plist =
         inject_google_auth_info_plist(&info_plist, input, format).unwrap_or(info_plist);
+
+    // #867 — `[ads]` block in perry.toml feeds the Google Mobile Ads SDK
+    // via `GADApplicationIdentifier` (+ ATT purpose string) the runtime
+    // reads from `Bundle.main.infoDictionary` at launch. Idempotent with
+    // the passes above — only adds our keys.
+    let info_plist = inject_ads_info_plist(&info_plist, input, format).unwrap_or(info_plist);
 
     fs::write(app_dir.join("Info.plist"), info_plist)?;
 

--- a/crates/perry/src/commands/compile/host_config.rs
+++ b/crates/perry/src/commands/compile/host_config.rs
@@ -931,6 +931,87 @@ pub(super) fn apply_pkg_and_toml_config(
                     );
                 }
             }
+
+            // --- [ads] config parsing (issue #867) ---
+            //
+            // Shape:
+            //
+            //     [ads]
+            //     ios_app_id     = "ca-app-pub-XXXX~YYYY"
+            //     android_app_id = "ca-app-pub-XXXX~ZZZZ"
+            //     test_device_ids = ["DEVICE_HASH"]
+            //     request_non_personalized_ads_only = false
+            //     att_usage_description = "We use your data to show relevant ads."
+            //
+            // The Google Mobile Ads SDK requires the per-platform App ID to be
+            // present in the host manifest *before* the app launches:
+            //   - iOS / Mac Catalyst: `inject_ads_info_plist` writes
+            //     `GADApplicationIdentifier` (and, when `att_usage_description`
+            //     is set, `NSUserTrackingUsageDescription` so the ATT prompt
+            //     can be shown) into the generated Info.plist.
+            //   - Android: `inject_ads_android_manifest` writes a
+            //     `<meta-data android:name="com.google.android.gms.ads.APPLICATION_ID">`
+            //     element under `<application>` in AndroidManifest.xml.
+            // We validate types up front so a typo (`ios_app_id = 42`) fails at
+            // compile time rather than crashing the SDK's `start()` at launch.
+            if let Some(ads) = doc.get("ads").and_then(|v| v.as_table()) {
+                fn warn_non_string(key: &str, ads: &toml::Table) {
+                    if let Some(v) = ads.get(key) {
+                        if v.as_str().is_none() {
+                            eprintln!(
+                                "  Warning: perry.toml [ads].{} must be a string (got {:?}); ignoring.",
+                                key,
+                                v.type_str()
+                            );
+                        }
+                    }
+                }
+                fn warn_non_bool(key: &str, ads: &toml::Table) {
+                    if let Some(v) = ads.get(key) {
+                        if v.as_bool().is_none() {
+                            eprintln!(
+                                "  Warning: perry.toml [ads].{} must be a boolean (got {:?}); ignoring.",
+                                key,
+                                v.type_str()
+                            );
+                        }
+                    }
+                }
+                warn_non_string("ios_app_id", ads);
+                warn_non_string("android_app_id", ads);
+                warn_non_string("att_usage_description", ads);
+                warn_non_bool("request_non_personalized_ads_only", ads);
+
+                if let Some(ids) = ads.get("test_device_ids") {
+                    match ids.as_array() {
+                        Some(arr) => {
+                            for (i, item) in arr.iter().enumerate() {
+                                if item.as_str().is_none() {
+                                    eprintln!(
+                                        "  Warning: perry.toml [ads].test_device_ids[{}] must be a string (got {:?}); ignoring.",
+                                        i,
+                                        item.type_str()
+                                    );
+                                }
+                            }
+                        }
+                        None => {
+                            eprintln!(
+                                "  Warning: perry.toml [ads].test_device_ids must be an array of strings (got {:?}); ignoring.",
+                                ids.type_str()
+                            );
+                        }
+                    }
+                }
+
+                if let OutputFormat::Text = format {
+                    let configured = ["ios_app_id", "android_app_id"]
+                        .iter()
+                        .filter(|k| ads.get(**k).and_then(|v| v.as_str()).is_some())
+                        .count();
+                    println!("  ads: {} app id(s) configured (#867)", configured);
+                }
+            }
         }
     }
 

--- a/crates/perry/src/commands/run/android.rs
+++ b/crates/perry/src/commands/run/android.rs
@@ -189,6 +189,14 @@ fn build_and_run_android_impl(
         }
     }
 
+    // #867 — inject the Google Mobile Ads `APPLICATION_ID` meta-data into
+    // AndroidManifest.xml from `[ads].android_app_id` in perry.toml.
+    if let Err(e) = inject_ads_android_manifest(&build_dir, project_root, format) {
+        if let OutputFormat::Text = format {
+            println!("Warning: [ads] not applied to AndroidManifest.xml: {}", e);
+        }
+    }
+
     // #1138 — when `@perryts/google-auth` is installed under
     // node_modules, copy its `crate-android/kotlin/*.kt` sources
     // into the Gradle project + merge its declared gradle deps so
@@ -428,6 +436,90 @@ pub fn inject_google_auth_android_resources(
 
     if let OutputFormat::Text = format {
         println!("  google_auth: wrote res/values/google_auth.xml (#1138)");
+    }
+    Ok(())
+}
+
+/// #867 — splice the Google Mobile Ads App ID into AndroidManifest.xml.
+///
+/// The SDK requires
+/// `<meta-data android:name="com.google.android.gms.ads.APPLICATION_ID" .../>`
+/// under `<application>`; `MobileAds.initialize()` throws at startup if
+/// it's missing. Reads `[ads].android_app_id` from `perry.toml` and
+/// inserts the element immediately before `</application>`. No-op when
+/// the block / key is absent.
+///
+/// Idempotent: if the manifest already declares the APPLICATION_ID
+/// meta-data (a rebuild into a reused build dir) we leave it untouched
+/// rather than double-injecting.
+pub fn inject_ads_android_manifest(
+    build_dir: &Path,
+    project_root: &Path,
+    format: OutputFormat,
+) -> Result<()> {
+    let mut dir: PathBuf = project_root.to_path_buf();
+    let mut perry_toml: Option<String> = None;
+    for _ in 0..6 {
+        let p = dir.join("perry.toml");
+        if p.exists() {
+            perry_toml = std::fs::read_to_string(&p).ok();
+            break;
+        }
+        if !dir.pop() {
+            break;
+        }
+    }
+    let raw = match perry_toml {
+        Some(r) => r,
+        None => return Ok(()),
+    };
+    let doc: toml::Table = raw.parse()?;
+    let ads = match doc.get("ads").and_then(|v| v.as_table()) {
+        Some(a) => a,
+        None => return Ok(()),
+    };
+    let Some(app_id) = ads.get("android_app_id").and_then(|v| v.as_str()) else {
+        return Ok(());
+    };
+
+    let manifest_path = build_dir.join("app/src/main/AndroidManifest.xml");
+    if !manifest_path.exists() {
+        return Ok(());
+    }
+    let manifest = std::fs::read_to_string(&manifest_path)?;
+
+    // Idempotency guard — the `</application>` splice below is not
+    // idempotent on its own, so bail if the App ID meta-data is already
+    // present.
+    if manifest.contains("com.google.android.gms.ads.APPLICATION_ID") {
+        return Ok(());
+    }
+
+    // App IDs are `ca-app-pub-<digits>~<digits>` — no XML specials — but
+    // escape defensively to match the rest of the perry.toml->xml flow.
+    let escaped = app_id
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;");
+    let meta = format!(
+        "        <meta-data\n            android:name=\"com.google.android.gms.ads.APPLICATION_ID\"\n            android:value=\"{}\" />\n",
+        escaped
+    );
+
+    let updated = if let Some(idx) = manifest.find("</application>") {
+        let (head, tail) = manifest.split_at(idx);
+        format!("{}{}{}", head, meta, tail)
+    } else {
+        return Err(anyhow!(
+            "AndroidManifest.xml at `{}` has no </application> tag",
+            manifest_path.display()
+        ));
+    };
+    std::fs::write(&manifest_path, updated)?;
+
+    if let OutputFormat::Text = format {
+        println!("  ads: injected GoogleMobileAds APPLICATION_ID meta-data (#867)");
     }
     Ok(())
 }
@@ -1079,5 +1171,85 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&build_dir);
+    }
+
+    /// #867 — `inject_ads_android_manifest` must splice the
+    /// GoogleMobileAds `APPLICATION_ID` meta-data into a copy of the real
+    /// Android template manifest, reading the value from `[ads]` in
+    /// perry.toml. Running it twice must not double-inject.
+    #[test]
+    fn ads_manifest_injects_application_id_and_is_idempotent() {
+        let template = Path::new(env!("CARGO_MANIFEST_DIR")).join("../perry-ui-android/template");
+        let manifest_src = template.join("app/src/main/AndroidManifest.xml");
+        assert!(
+            manifest_src.exists(),
+            "android template not found at {}",
+            template.display()
+        );
+
+        // project_root holds perry.toml; build_dir mirrors the Gradle
+        // layout the real build produces.
+        let root =
+            std::env::temp_dir().join(format!("perry_ads_manifest_test_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let build_dir = root.join("build");
+        let app_main = build_dir.join("app/src/main");
+        std::fs::create_dir_all(&app_main).unwrap();
+        std::fs::copy(&manifest_src, app_main.join("AndroidManifest.xml")).unwrap();
+        std::fs::write(
+            root.join("perry.toml"),
+            "[ads]\nandroid_app_id = \"ca-app-pub-3940256099942544~3347511713\"\n",
+        )
+        .unwrap();
+
+        inject_ads_android_manifest(&build_dir, &root, OutputFormat::Json).unwrap();
+        // Second run must be a no-op (idempotency guard).
+        inject_ads_android_manifest(&build_dir, &root, OutputFormat::Json).unwrap();
+
+        let manifest = std::fs::read_to_string(app_main.join("AndroidManifest.xml")).unwrap();
+        assert!(
+            manifest.contains("com.google.android.gms.ads.APPLICATION_ID"),
+            "APPLICATION_ID meta-data not injected"
+        );
+        assert!(manifest.contains("ca-app-pub-3940256099942544~3347511713"));
+        assert_eq!(
+            manifest
+                .matches("com.google.android.gms.ads.APPLICATION_ID")
+                .count(),
+            1,
+            "APPLICATION_ID injected more than once"
+        );
+        // Spliced inside <application>, before its close tag.
+        let app_id_pos = manifest.find("APPLICATION_ID").unwrap();
+        let close_pos = manifest.find("</application>").unwrap();
+        assert!(app_id_pos < close_pos, "meta-data not inside <application>");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// No `[ads]` block (or no `android_app_id`) → manifest untouched.
+    #[test]
+    fn ads_manifest_no_op_when_unconfigured() {
+        let template = Path::new(env!("CARGO_MANIFEST_DIR")).join("../perry-ui-android/template");
+        let root =
+            std::env::temp_dir().join(format!("perry_ads_manifest_noop_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let build_dir = root.join("build");
+        let app_main = build_dir.join("app/src/main");
+        std::fs::create_dir_all(&app_main).unwrap();
+        std::fs::copy(
+            template.join("app/src/main/AndroidManifest.xml"),
+            app_main.join("AndroidManifest.xml"),
+        )
+        .unwrap();
+        // perry.toml with an unrelated section only.
+        std::fs::write(root.join("perry.toml"), "[ios]\nbundle_id = \"a\"\n").unwrap();
+
+        inject_ads_android_manifest(&build_dir, &root, OutputFormat::Json).unwrap();
+
+        let manifest = std::fs::read_to_string(app_main.join("AndroidManifest.xml")).unwrap();
+        assert!(!manifest.contains("com.google.android.gms.ads.APPLICATION_ID"));
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1946 entries across 113 modules
+// Coverage: 1947 entries across 113 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -2329,6 +2329,8 @@ declare module "perry/ads" {
   export function js_ads_interstitial_load(...args: any[]): any;
   /** stdlib */
   export function js_ads_interstitial_show(...args: any[]): any;
+  /** stdlib */
+  export function js_ads_request_consent(...args: any[]): any;
   /** stdlib */
   export function js_ads_rewarded_load(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2820 entries across 115 modules.
+Total: 2821 entries across 115 modules.
 
 ## Modules
 
@@ -2243,6 +2243,7 @@ Total: 2820 entries across 115 modules.
 - `js_ads_banner_destroy` — module
 - `js_ads_interstitial_load` — module
 - `js_ads_interstitial_show` — module
+- `js_ads_request_consent` — module
 - `js_ads_rewarded_load` — module
 - `js_ads_rewarded_show` — module
 

--- a/test-files/test_ads_compile_smoke.ts
+++ b/test-files/test_ads_compile_smoke.ts
@@ -1,10 +1,10 @@
 // Compile-smoke for `perry/ads` (issue #867).
 //
-// References each of the six FFI entry points and prints the
-// result. The MVP stub resolves every promise-returning entry
-// with a structured failure shape and returns 0 from
-// banner_create on every platform, so the program exits 0 with
-// 5 printed JSON failure lines + 1 numeric handle line.
+// References each of the seven FFI entry points and prints the
+// result. On the build host (macOS native) the promise-returning
+// entries resolve a structured `{ error: "unsupported-platform" }`
+// shape (no Google Mobile Ads SDK on macOS) and banner_create returns
+// 0, so the program exits 0 with the JSON lines + 1 numeric handle.
 
 import {
   js_ads_interstitial_load,
@@ -13,6 +13,7 @@ import {
   js_ads_rewarded_show,
   js_ads_banner_create,
   js_ads_banner_destroy,
+  js_ads_request_consent,
 } from "perry/ads";
 
 async function main() {
@@ -33,6 +34,9 @@ async function main() {
 
   js_ads_banner_destroy(handle);
   console.log("banner_destroy: ok");
+
+  const consent = await js_ads_request_consent();
+  console.log("request_consent:", consent);
 }
 
 main();

--- a/test-files/test_ui_adbanner_smoke.ts
+++ b/test-files/test_ui_adbanner_smoke.ts
@@ -1,0 +1,17 @@
+// #867 — compile-smoke for the perry/ui AdBanner widget.
+//
+// Verifies the AdBanner dispatch row + d.ts + per-platform
+// `perry_ui_adbanner_create` FFI link end-to-end. On macOS the banner is
+// a layout placeholder (no macOS Ads SDK), so this builds and lays out
+// without showing a real ad. UI smoke tests are skip-listed from the
+// headless compile-smoke job (they open a window); this is here for the
+// local `perry test_ui_adbanner_smoke.ts -o out` build check.
+import { App, VStack, Text, AdBanner } from "perry/ui";
+
+App({
+  title: "AdBanner smoke",
+  body: VStack(8, [
+    Text("Free app with a banner ad"),
+    AdBanner("ca-app-pub-3940256099942544/2934735716", "banner"),
+  ]),
+});

--- a/types/perry/ads/index.d.ts
+++ b/types/perry/ads/index.d.ts
@@ -125,10 +125,10 @@ export declare function js_ads_rewarded_show(): Promise<string>;
  *                            picks a height based on the device's
  *                            width.
  *
- * v1 exposes the handle directly; perry/ui `<AdBanner>` widget
- * integration so the banner can sit inside the declarative
- * layout tree is a follow-up (#867). The MVP returns `0` since
- * no SDK is linked.
+ * This raw-handle FFI is the secondary banner path; the primary
+ * surface is the declarative `perry/ui` `<AdBanner>` widget, which
+ * sits in the layout tree. This entry returns `0` until the real
+ * SDK is linked.
  */
 export declare function js_ads_banner_create(
   unitId: string,
@@ -141,3 +141,30 @@ export declare function js_ads_banner_create(
  * and any associated network connections.
  */
 export declare function js_ads_banner_destroy(handle: number): void;
+
+/**
+ * Result returned by `js_ads_request_consent`. `status` reports the
+ * user's tracking / personalised-ads consent state:
+ *   - `"authorized"`     — tracking allowed (iOS ATT granted / UMP
+ *                          personalised consent obtained)
+ *   - `"denied"`         — user declined
+ *   - `"not-determined"` — no decision yet (the prompt hasn't shown,
+ *                          or the SDK isn't linked)
+ *   - `"restricted"`     — blocked by device policy (parental
+ *                          controls, MDM)
+ */
+export type AdConsentResult = {
+  status: "authorized" | "denied" | "not-determined" | "restricted";
+  /** Set when the consent request itself failed. */
+  error?: string;
+};
+
+/**
+ * Request user consent for personalised ads / tracking. Resolves to
+ * a JSON-stringified [`AdConsentResult`]. Drives iOS App Tracking
+ * Transparency (`ATTrackingManager.requestTrackingAuthorization`) and
+ * the Android User Messaging Platform consent form. Call this **before**
+ * loading any ads so requests comply with GDPR / ATT; on platforms
+ * without the SDK it resolves `{ status: "not-determined" }`.
+ */
+export declare function js_ads_request_consent(): Promise<string>;

--- a/types/perry/ui/index.d.ts
+++ b/types/perry/ui/index.d.ts
@@ -406,6 +406,39 @@ export function Spacer(): Widget;
 /** Visual separator line. */
 export function Divider(): Widget;
 
+/**
+ * Banner ad size keys (#867). Values match Google Mobile Ads' standard
+ * `AdSize` constants. `"adaptive"` requests an adaptive banner sized to
+ * the device; the rest are fixed. A plain string-literal union (not a
+ * runtime enum) so it needs no value backing in the native module.
+ */
+export type AdSizeKey =
+  | "banner"
+  | "large-banner"
+  | "medium-rectangle"
+  | "full-banner"
+  | "leaderboard"
+  | "adaptive";
+
+/**
+ * In-app banner ad (#867). Place it in a layout like any other widget:
+ *
+ * ```ts
+ * VStack(0, [MyContent(), AdBanner("ca-app-pub-xxx/yyy", "banner")])
+ * ```
+ *
+ * Reserves a banner-sized slot (`size`) in the layout on every platform.
+ * Live ad rendering — a `GADBannerView` (iOS) / `AdView` (Android) — lands
+ * when the platform Google Mobile Ads SDK is linked; until then (and
+ * always on macOS, which has no Ads SDK) the widget is a layout
+ * placeholder. Both arguments are required — pass an `AdSizeKey` for `size`.
+ *
+ * The App ID must be configured in `perry.toml` under `[ads]`
+ * (`ios_app_id` / `android_app_id`); the compiler writes it into the
+ * platform manifest at build time.
+ */
+export function AdBanner(unitId: string, size: AdSizeKey): Widget;
+
 /** Indeterminate or determinate progress indicator. */
 export function ProgressView(): Widget;
 


### PR DESCRIPTION
Closes #867.

Completes the remaining `perry/ads` (#867) follow-up work on top of the MVP scaffold (#1040/#1060). Everything that's left after this is ordinary bug-fix territory, so this closes the tracker.

## What landed

### ✅ Build-config integration (fully verified)
`perry.toml [ads]` → platform manifests:
- `host_config.rs` parses/validates `[ads]` (`ios_app_id`, `android_app_id`, `att_usage_description`, `test_device_ids`, `request_non_personalized_ads_only`).
- `inject_ads_info_plist` writes `GADApplicationIdentifier` (+ `NSUserTrackingUsageDescription`, XML-escaped, dedup-guarded) into the iOS Info.plist (`bundle_ios.rs`).
- `inject_ads_android_manifest` splices the `com.google.android.gms.ads.APPLICATION_ID` `<meta-data>` before `</application>` (idempotent) into `AndroidManifest.xml`.
- **6 new unit tests** (plist + real-template manifest) pass.

### ✅ `perry/ui` `<AdBanner>` widget
- d.ts `AdBanner(unitId, size)` + `AdSizeKey`; dispatch-table row; per-platform `perry_ui_adbanner_create`.
- **macOS verified end-to-end**: a real `App({… AdBanner(…) })` program compiles, the IR emits `call @perry_ui_adbanner_create`, the symbol is defined in `libperry_ui_macos.a`, and it links to a working executable.
- iOS + Android placeholder widgets added so those targets link (mirror the existing `image`/`divider` widgets).

### ✅ Platform discrimination + consent API
- iOS/Android resolve `no-sdk-linked` (supported, SDK pending); macOS-native and other non-mobile targets now correctly resolve `unsupported-platform`.
- New `js_ads_request_consent()` (ATT / UMP) wired through FFI, codegen extern, dispatch table, manifest, and the d.ts. API reference + `.d.ts` regenerated (api-docs-drift clean).
- Verified by running the `perry/ads` FFI smoke on host.

### ⚠️ Real iOS GoogleMobileAds bridge (opt-in, compile-unverified)
- `crates/perry-ext-ads/src/ios_real.rs`: live objc2 + block2 calls into `GADInterstitialAd` / `GADRewardedAd` + `ATTrackingManager`, behind a **`google-ads` cargo feature, off by default** and iOS-target-gated.
- **Not built by host CI** (needs the iOS target + the SwiftPM `GoogleMobileAds.xcframework`). Loudly marked COMPILE-UNVERIFIED; the feature gate means it cannot affect default or CI builds (both default and `--features google-ads` compile here as a host no-op).

## Verification
- `cargo test -p perry` (ads config) — 6/6 new tests pass.
- `perry/ads` FFI smoke runs on host: every entry reports `unsupported-platform`; consent returns `{"status":"not-determined","error":"unsupported-platform"}`.
- `<AdBanner>` program compiles + links on macOS (symbol confirmed in the static lib; no lax `dynamic_lookup`).
- `perry-ext-ads` builds with default features and `--features google-ads`.

## Known follow-ups (bug-fix scope, not blockers)
- Finish/validate the iOS bridge on-device with the SwiftPM framework; build the Android JNI bridge (Kotlin in `PerryBridge.kt`).
- `GADFullScreenContentDelegate` for accurate `dismissed` reporting.
- Confirm the iOS/Android `<AdBanner>` widgets compile once those toolchains are available (no iOS target / Android NDK in this env).

No version bump or CHANGELOG entry (left for the maintainer at merge, per repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `AdBanner` widget (with `AdSizeKey`) to reserve banner space across iOS, Android, and macOS.
  * Added `js_ads_request_consent()` to request ad consent and return a JSON-stringified result (`AdConsentResult`).
  * Added support for an `[ads]` section in `perry.toml` to configure platform app IDs and ATT usage text.

* **Tests / Quality**
  * Expanded ad-related compile-smoke coverage, including a new `AdBanner` UI smoke test.

* **Documentation**
  * Updated API reference and TypeScript definitions for `perry/ads` and the UI `AdBanner` surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->