### PR TITLE
fix(runtime): #5588 Object.assign drives Proxy-source traps

### DIFF
--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -995,6 +995,57 @@ unsafe fn object_assign_string_source(
     }
 }
 
+/// Copy a Proxy source's own enumerable properties onto `target`, driving the
+/// proxy's `ownKeys` / `getOwnPropertyDescriptor` / `get` traps in spec order.
+/// Any trap that throws longjmps straight past this frame to the caller's
+/// `try`/`catch`, which is exactly the abrupt-completion propagation
+/// `Object.assign` requires.
+unsafe fn object_assign_proxy_source(
+    target: *mut ObjectHeader,
+    target_f64: f64,
+    target_is_array: bool,
+    source_f64: f64,
+) {
+    // `[[OwnPropertyKeys]]` — fires the ownKeys trap (throw propagates).
+    let keys_arr = crate::proxy::js_proxy_own_keys(source_f64);
+    let keys_val = JSValue::from_bits(keys_arr.to_bits());
+    if !keys_val.is_pointer() {
+        return;
+    }
+    let arr = keys_val.as_pointer::<crate::array::ArrayHeader>();
+    if arr.is_null() {
+        return;
+    }
+    let n = crate::array::js_array_length(arr);
+    for i in 0..n {
+        let key = crate::array::js_array_get(arr, i);
+        let key_f64 = f64::from_bits(key.bits());
+        // `[[GetOwnProperty]]` — fires the getOwnPropertyDescriptor trap.
+        let desc = crate::proxy::js_reflect_get_own_property_descriptor(source_f64, key_f64);
+        let desc_ptr = (desc.to_bits() & crate::value::POINTER_MASK) as *const ObjectHeader;
+        if desc.to_bits() == JSValue::undefined().bits() || desc_ptr.is_null() {
+            continue;
+        }
+        let ek = crate::string::js_string_from_bytes(b"enumerable".as_ptr(), 10);
+        if crate::value::js_is_truthy(crate::object::js_object_get_field_by_name_f64(desc_ptr, ek))
+            == 0
+        {
+            continue;
+        }
+        // `[[Get]]` — fires the get trap.
+        let value_f64 = crate::proxy::js_proxy_get(source_f64, key_f64);
+        if key.is_any_string() {
+            let key_ptr =
+                crate::value::js_get_string_pointer_unified(key_f64) as *const crate::StringHeader;
+            if !key_ptr.is_null() {
+                object_assign_set_string_key(target, target_is_array, key_ptr, value_f64);
+            }
+        } else if key.is_pointer() {
+            crate::symbol::js_object_set_symbol_property(target_f64, key_f64, value_f64);
+        }
+    }
+}
+
 /// Per spec, undefined/null target throws TypeError. Non-object sources
 /// are skipped except string primitives, which expose enumerable index
 /// properties (`Object.assign({}, "ab") -> {0:"a",1:"b"}`).
@@ -1035,6 +1086,18 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
     }
     if source.is_any_string() {
         object_assign_string_source(target, target_is_array, source_f64);
+        return target_f64;
+    }
+
+    // A Proxy source isn't an `ObjectHeader` (its NaN-box payload is a small
+    // registry id, not a heap pointer), so the raw `keys_array` walk below
+    // would skip it silently. Spec requires enumerating it through its traps —
+    // `[[OwnPropertyKeys]]` (ownKeys), `[[GetOwnProperty]]`
+    // (getOwnPropertyDescriptor) for the enumerable test, then `[[Get]]` for
+    // each value — with every trap's abrupt completion propagating out (test262
+    // Object/assign/source-own-prop-error + source-own-prop-keys-error).
+    if crate::proxy::js_proxy_is_proxy(source_f64) != 0 {
+        object_assign_proxy_source(target, target_f64, target_is_array, source_f64);
         return target_f64;
     }
 

--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -938,6 +938,34 @@ fn throw_object_assign_readonly(name: &str) -> ! {
     )
 }
 
+/// Strict `Set(to, sym, value, true)` rejection check for a symbol-keyed
+/// `Object.assign` write: a non-writable existing symbol data property, an
+/// accessor symbol property with no setter, or a new symbol property on a
+/// non-extensible target each make the write fail, which under throwing `Set`
+/// semantics is a `TypeError`. The string-keyed counterpart is
+/// `object_assign_throw_if_set_rejected`.
+unsafe fn object_assign_throw_if_symbol_set_rejected(target: *mut ObjectHeader, sym_ptr: usize) {
+    let owner = target as usize;
+    let existing = crate::symbol::symbol_property_root_bits(owner, sym_ptr).is_some()
+        || crate::symbol::symbol_accessor_descriptor_bits(owner, sym_ptr).is_some();
+    if existing {
+        if let Some((_get, set)) = crate::symbol::symbol_accessor_descriptor_bits(owner, sym_ptr) {
+            if set == 0 {
+                throw_object_assign_readonly("Symbol()");
+            }
+        } else if let Some(attrs) = crate::symbol::get_symbol_property_attrs(owner, sym_ptr) {
+            if !attrs.writable() {
+                throw_object_assign_readonly("Symbol()");
+            }
+        }
+    } else {
+        let gc = gc_header_for(target);
+        if (*gc)._reserved & crate::gc::OBJ_FLAG_NO_EXTEND != 0 {
+            throw_object_assign_readonly("Symbol()");
+        }
+    }
+}
+
 unsafe fn object_assign_set_string_key(
     target: *mut ObjectHeader,
     target_is_array: bool,
@@ -1041,6 +1069,9 @@ unsafe fn object_assign_proxy_source(
                 object_assign_set_string_key(target, target_is_array, key_ptr, value_f64);
             }
         } else if key.is_pointer() {
+            // Strict `Set` semantics for symbol keys, same as the ordinary path.
+            let sym_ptr = (key.bits() & crate::value::POINTER_MASK) as usize;
+            object_assign_throw_if_symbol_set_rejected(target, sym_ptr);
             crate::symbol::js_object_set_symbol_property(target_f64, key_f64, value_f64);
         }
     }
@@ -1266,30 +1297,7 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
         // copy already uses `[[Get]]` via `js_object_get_field_by_name`.
         let value_f64 = crate::symbol::js_object_get_symbol_property(source_f64, sym_f64);
         // Strict `Set` semantics for symbol-keyed writes too.
-        {
-            let owner = tgt_raw;
-            let existing = crate::symbol::symbol_property_root_bits(owner, sym_ptr).is_some()
-                || crate::symbol::symbol_accessor_descriptor_bits(owner, sym_ptr).is_some();
-            if existing {
-                if let Some((_get, set)) =
-                    crate::symbol::symbol_accessor_descriptor_bits(owner, sym_ptr)
-                {
-                    if set == 0 {
-                        throw_object_assign_readonly("Symbol()");
-                    }
-                } else if let Some(attrs) = crate::symbol::get_symbol_property_attrs(owner, sym_ptr)
-                {
-                    if !attrs.writable() {
-                        throw_object_assign_readonly("Symbol()");
-                    }
-                }
-            } else {
-                let gc = gc_header_for(target);
-                if (*gc)._reserved & crate::gc::OBJ_FLAG_NO_EXTEND != 0 {
-                    throw_object_assign_readonly("Symbol()");
-                }
-            }
-        }
+        object_assign_throw_if_symbol_set_rejected(target, sym_ptr);
         crate::symbol::js_object_set_symbol_property(target_f64, sym_f64, value_f64);
     }
 

--- a/test-files/test_gap_5588_object_assign_proxy_source.ts
+++ b/test-files/test_gap_5588_object_assign_proxy_source.ts
@@ -1,0 +1,46 @@
+// Gap test for #5588 — Object.assign with a PROXY source.
+// A Proxy's NaN-box payload is a small registry id, not a heap ObjectHeader
+// pointer, so the raw keys_array walk used to skip it silently: no traps fired
+// and a throwing ownKeys/getOwnPropertyDescriptor never propagated. Spec drives
+// the source through [[OwnPropertyKeys]] -> [[GetOwnProperty]] (enumerable test)
+// -> [[Get]], propagating any abrupt completion (test262
+// built-ins/Object/assign/source-own-prop-error + source-own-prop-keys-error).
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+function thrown(fn: () => void): string {
+  try { fn(); return "no throw"; } catch (e: any) { return e.constructor.name; }
+}
+
+// ---- throwing ownKeys trap propagates ----
+const ownKeysThrows = new Proxy({}, {
+  ownKeys() { throw new TypeError("ownKeys"); },
+});
+console.log(thrown(() => Object.assign({}, ownKeysThrows)));          // TypeError
+
+// ---- throwing getOwnPropertyDescriptor trap propagates ----
+const gopdThrows = new Proxy({ attr: null }, {
+  getOwnPropertyDescriptor() { throw new TypeError("gopd"); },
+});
+console.log(thrown(() => Object.assign({}, gopdThrows)));            // TypeError
+
+// ---- throwing get trap propagates ----
+const getThrows = new Proxy({ a: 1 }, {
+  get() { throw new RangeError("get"); },
+});
+console.log(thrown(() => Object.assign({}, getThrows)));            // RangeError
+
+// ---- plain proxy source: enumerable own props copied via the traps ----
+const plain = new Proxy({ a: 1, b: 2 }, {});
+console.log(JSON.stringify(Object.assign({}, plain)));             // {"a":1,"b":2}
+
+// ---- non-enumerable own props are skipped (descriptor enumerable:false) ----
+const hidden: any = {};
+Object.defineProperty(hidden, "secret", { value: 9, enumerable: false });
+hidden.shown = 1;
+console.log(JSON.stringify(Object.assign({}, new Proxy(hidden, {})))); // {"shown":1}
+
+// ---- get trap actually sources the values ----
+const doubler = new Proxy({ x: 2, y: 3 }, {
+  get(t: any, k) { return typeof t[k] === "number" ? t[k] * 2 : t[k]; },
+});
+console.log(JSON.stringify(Object.assign({}, doubler)));          // {"x":4,"y":6}

--- a/test-files/test_gap_5588_object_assign_proxy_source.ts
+++ b/test-files/test_gap_5588_object_assign_proxy_source.ts
@@ -53,9 +53,13 @@ const symOut: any = Object.assign({}, new Proxy(symSrc, {}));
 console.log("symbol copied: " + (symOut[sym] === 42 && symOut.plain === 1)); // true
 
 // ---- strict Set: a symbol key onto a non-extensible target throws ----
+// Source carries ONLY a symbol key, so the throw must come from the symbol
+// write path (a stray string key would otherwise throw first and mask it).
+const symOnly: any = {};
+symOnly[Symbol("only")] = 1;
+const symOnlyProxy = new Proxy(symOnly, {});
 const frozenTarget = Object.preventExtensions({});
-const symProxy = new Proxy(symSrc, {});
-console.log(thrown(() => Object.assign(frozenTarget, symProxy)));   // TypeError
+console.log(thrown(() => Object.assign(frozenTarget, symOnlyProxy)));   // TypeError
 
 // ---- trap order: ownKeys -> getOwnPropertyDescriptor -> get, per key ----
 const order: string[] = [];

--- a/test-files/test_gap_5588_object_assign_proxy_source.ts
+++ b/test-files/test_gap_5588_object_assign_proxy_source.ts
@@ -44,3 +44,28 @@ const doubler = new Proxy({ x: 2, y: 3 }, {
   get(t: any, k) { return typeof t[k] === "number" ? t[k] * 2 : t[k]; },
 });
 console.log(JSON.stringify(Object.assign({}, doubler)));          // {"x":4,"y":6}
+
+// ---- symbol keys are copied through the traps ----
+const sym = Symbol("s");
+const symSrc: any = { plain: 1 };
+symSrc[sym] = 42;
+const symOut: any = Object.assign({}, new Proxy(symSrc, {}));
+console.log("symbol copied: " + (symOut[sym] === 42 && symOut.plain === 1)); // true
+
+// ---- strict Set: a symbol key onto a non-extensible target throws ----
+const frozenTarget = Object.preventExtensions({});
+const symProxy = new Proxy(symSrc, {});
+console.log(thrown(() => Object.assign(frozenTarget, symProxy)));   // TypeError
+
+// ---- trap order: ownKeys -> getOwnPropertyDescriptor -> get, per key ----
+const order: string[] = [];
+const ordered = new Proxy({ k: 7 }, {
+  ownKeys(t) { order.push("ownKeys"); return Reflect.ownKeys(t); },
+  getOwnPropertyDescriptor(t, k) {
+    order.push("gopd:" + String(k));
+    return Reflect.getOwnPropertyDescriptor(t, k);
+  },
+  get(t: any, k) { order.push("get:" + String(k)); return t[k]; },
+});
+Object.assign({}, ordered);
+console.log("trap order: " + order.join(","));   // ownKeys,gopd:k,get:k


### PR DESCRIPTION
## Summary

Part of #5588 (test262 `built-ins/Object` tail). Fixes the `Object.assign` source-property **error-propagation** subcluster.

A `Proxy` source's NaN-box payload is a small registry id, not a heap `ObjectHeader` pointer, so `js_object_assign_one`'s raw `keys_array` walk hit the `src_raw < 0x10000` guard and **skipped the source silently** — no traps fired, and a throwing `ownKeys` / `getOwnPropertyDescriptor` / `get` trap never propagated. `Object.assign({}, proxy)` returned a stale empty target instead of throwing.

The fix detects a Proxy source up front and enumerates it the way the spec requires:

1. `[[OwnPropertyKeys]]` → ownKeys trap
2. `[[GetOwnProperty]]` → getOwnPropertyDescriptor trap (for the enumerable test)
3. `[[Get]]` → get trap, per enumerable key

copying enumerable own (string + symbol) props onto the target. Each trap's abrupt completion longjmps straight to the caller's `try`/`catch`, giving the `ReturnIfAbrupt` propagation `Object.assign` mandates.

## test262 cases fixed
- `built-ins/Object/assign/source-own-prop-error.js` (throwing `getOwnPropertyDescriptor`)
- `built-ins/Object/assign/source-own-prop-keys-error.js` (throwing `ownKeys`)

## Validation
- New `test-files/test_gap_5588_object_assign_proxy_source.ts` — byte-for-byte match vs `node --experimental-strip-types` (throwing ownKeys/gopd/get propagate; plain/enumerable/get-trap-sourced copies correct).
- Existing `test_gap_5347_object_assign_array_source`, `test_gap_object_string_wrappers`, `test_compat_objects_symbols` still match Node.

No version bump / changelog (left to maintainer at merge time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `Object.assign` when the source is a `Proxy`, ensuring the proxy traps are invoked in the correct order and only enumerable own properties are copied.
  * Improved `Object.assign` behavior for symbol keys, including correct error handling when copying into non-extensible targets.

* **Tests**
  * Added a regression test covering `Proxy` trap failures (`ownKeys`, `getOwnPropertyDescriptor`, `get`), enumerable vs. non-enumerable properties, symbol-key copying, and non-extensible target errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->