### PR TITLE
fix(runtime): #5579 — static-method delete reborn after #5490 (296-case class m-descriptor cluster)

### DIFF
--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -351,6 +351,17 @@ pub extern "C" fn js_object_delete_field_value(
     obj_value: f64,
     key: *const crate::StringHeader,
 ) -> i32 {
+    // A class reference (`delete C.m` for a `static m()`) is INT32-tagged, so
+    // `is_pointer` is false and the guard below would no-op it. But a static
+    // member delete must still unregister the method/field. `js_object_delete_field`
+    // already treats a sub-0x10000 "pointer" as a class id, so forward the id
+    // there. (#5579: #5490 rerouted `delete` through this value-form wrapper,
+    // whose primitive guard silently dropped class-ref receivers → static
+    // `delete C.m` became a vacuous no-op and verifyProperty's configurable
+    // check failed "m descriptor should be configurable".)
+    if let Some(class_id) = super::native_module::class_ref_id(obj_value) {
+        return js_object_delete_field(class_id as usize as *mut ObjectHeader, key);
+    }
     if !delete_receiver_is_pointer(obj_value) {
         return 1;
     }
@@ -362,6 +373,10 @@ pub extern "C" fn js_object_delete_field_value(
 /// `js_object_delete_field_value`, delegating real objects to the dynamic path.
 #[no_mangle]
 pub extern "C" fn js_object_delete_dynamic_value(obj_value: f64, key: f64) -> i32 {
+    // Class-ref receiver (`delete C["m"]`): see `js_object_delete_field_value`.
+    if let Some(class_id) = super::native_module::class_ref_id(obj_value) {
+        return js_object_delete_dynamic(class_id as usize as *mut ObjectHeader, key);
+    }
     if !delete_receiver_is_pointer(obj_value) {
         return 1;
     }

--- a/crates/perry/tests/issue_5579_class_static_delete_configurable.rs
+++ b/crates/perry/tests/issue_5579_class_static_delete_configurable.rs
@@ -88,10 +88,7 @@ console.log("DONE");
     .expect("write entry");
 
     let (ok, out) = compile_and_run(dir.path(), &entry);
-    assert!(
-        ok,
-        "compiled binary did not exit cleanly\nstdout:\n{out}"
-    );
+    assert!(ok, "compiled binary did not exit cleanly\nstdout:\n{out}");
     assert!(
         out.contains("static.configurable: true"),
         "static method descriptor must be configurable\n{out}"
@@ -112,5 +109,8 @@ console.log("DONE");
         out.contains("proto.deleted: true"),
         "delete D.prototype.m must still remove the instance method\n{out}"
     );
-    assert!(out.contains("DONE"), "program must run to completion\n{out}");
+    assert!(
+        out.contains("DONE"),
+        "program must run to completion\n{out}"
+    );
 }

--- a/crates/perry/tests/issue_5579_class_static_delete_configurable.rs
+++ b/crates/perry/tests/issue_5579_class_static_delete_configurable.rs
@@ -1,0 +1,116 @@
+//! Regression (#5579): `delete C.m` for a `static m()` must actually unregister
+//! the static method so it stops being an own property of the class constructor.
+//!
+//! Root cause: #5490 rerouted the codegen `delete` arms through the value-form
+//! wrappers `js_object_delete_field_value` / `js_object_delete_dynamic_value`,
+//! whose `is_pointer` guard (added to make `delete (5).x` a no-op) silently
+//! dropped class-reference receivers — a class ref is INT32-tagged, not a heap
+//! pointer. So `delete C.m` returned `true` without ever calling
+//! `class_mark_key_deleted`, leaving `hasOwnProperty(C, "m")` true after the
+//! delete. test262's `verifyProperty` configurable check (delete-then-assert the
+//! key is gone) then failed "m descriptor should be configurable" across ~296
+//! generated `language/.../class/elements/*-static-method-rs-*` cases.
+//!
+//! Fix: the value-form wrappers detect a class-ref receiver via `class_ref_id`
+//! and forward the class id to the existing class-delete path (which
+//! `js_object_delete_field` already handles for sub-0x10000 "pointers").
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, entry: &std::path::Path) -> (bool, String) {
+    let output = dir.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let run = Command::new(&output).output().expect("run compiled binary");
+    (
+        run.status.success(),
+        String::from_utf8_lossy(&run.stdout).to_string(),
+    )
+}
+
+#[test]
+fn delete_class_static_method_is_configurable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+// Mirrors test262 propertyHelper.verifyProperty's `configurable` check:
+// delete the property through a parameter receiver, then assert it is gone.
+function verifyConfigurable(obj: any, name: string): boolean {
+  delete obj[name];
+  return !Object.prototype.hasOwnProperty.call(obj, name);
+}
+
+class C {
+  static m() { return 1; }
+}
+// Descriptor must report configurable BEFORE the delete...
+const d = Object.getOwnPropertyDescriptor(C, "m");
+console.log("static.configurable:", d ? d.configurable : "(undefined)");
+// ...and the delete must actually remove it.
+console.log("static.deleted:", verifyConfigurable(C, "m"));
+console.log("static.descAfter:", JSON.stringify(Object.getOwnPropertyDescriptor(C, "m")));
+
+// Dynamic-key form: `delete C["m"]`.
+class C2 {
+  static m() { return 2; }
+}
+console.log("static.dyn.deleted:", verifyConfigurable(C2, "m"));
+
+// Instance methods on the reflective prototype were already correct — keep
+// them covered so the static fix doesn't regress them.
+class D {
+  m() { return 3; }
+}
+console.log("proto.deleted:", verifyConfigurable(D.prototype, "m"));
+
+console.log("DONE");
+"#,
+    )
+    .expect("write entry");
+
+    let (ok, out) = compile_and_run(dir.path(), &entry);
+    assert!(
+        ok,
+        "compiled binary did not exit cleanly\nstdout:\n{out}"
+    );
+    assert!(
+        out.contains("static.configurable: true"),
+        "static method descriptor must be configurable\n{out}"
+    );
+    assert!(
+        out.contains("static.deleted: true"),
+        "delete C.m must remove the static method (hasOwnProperty false after)\n{out}"
+    );
+    assert!(
+        out.contains("static.descAfter: undefined"),
+        "getOwnPropertyDescriptor(C, \"m\") must be undefined after delete\n{out}"
+    );
+    assert!(
+        out.contains("static.dyn.deleted: true"),
+        "delete C[\"m\"] (dynamic key) must remove the static method\n{out}"
+    );
+    assert!(
+        out.contains("proto.deleted: true"),
+        "delete D.prototype.m must still remove the instance method\n{out}"
+    );
+    assert!(out.contains("DONE"), "program must run to completion\n{out}");
+}


### PR DESCRIPTION
## Summary

Fixes the **largest, in-window cluster** of #5579: the **296** newly-failing
`language/.../class/elements/*-static-method-rs-*` test262 cases reporting
**`m descriptor should be configurable`** — the issue's #1-ranked "#5441
signature reborn" cluster.

`delete C.m` / `delete C["m"]` for a `static m() {}` returned `true` but left
the method as an own property of the class constructor. test262's
`verifyProperty` tests configurability by deleting the property and asserting it
is gone; the method survived, so the check failed.

## Root cause

**#5490** (`190f5742f`, *"`delete <primitive>.field` no-ops to true instead of
crashing"*) rerouted the three codegen `delete` arms through the value-form
wrappers `js_object_delete_field_value` / `js_object_delete_dynamic_value`,
whose `is_pointer` guard makes `delete (5).x` a no-op. A **class reference is
INT32-tagged, not a heap pointer**, so the guard *also* silently dropped
class-ref receivers — they never reached `js_object_delete_field`'s class-id
branch (which calls `class_mark_key_deleted`). Static-method delete became a
vacuous no-op and `hasOwnProperty(C, "m")` stayed true.

Before #5490 the arms called `js_object_delete_field` with the unboxed class id
(a sub-`0x10000` value), which that function handles as a class id — so static
delete worked. #5490 regressed it.

## Fix

Both value-form wrappers now detect a class-ref receiver via `class_ref_id` and
forward the class id to the existing class-delete path. The primitive no-op
behavior from #5490 and instance-prototype method delete (already correct via a
real `keys_array` field) are both unaffected.

## Validation

- New regression test `issue_5579_class_static_delete_configurable` (mirrors
  `verifyProperty`'s configurable check: static method, dynamic-key form, and
  instance-prototype) — **passes**.
- `issue_delete_primitive_receiver_noop` (the #5490 test) — **still passes**.
- `issue_5024_class_prototype_assignment_enumeration`,
  `issue_object_proto_descriptor_fast_path` — **pass**.

## Scope / not addressed here

#5579 bundles several clusters with distinct root causes. This PR fixes the
dominant, cleanly-reproducible one. The remaining clusters appear **separate**
and could not be reproduced with compiled `.ts` modules in this environment
(they surface under the test262 global-script harness, `vm.runInThisContext`):

- **`with`-scope (~104, `p1 === undefined` / ReferenceError)** — a compiled-`.ts`
  `with` block resolves identifiers correctly; the failures are tied to
  global-script identifier resolution. (A *separate, likely pre-existing*
  codegen gap — method calls whose receiver is a `WithGet` — was observed but is
  not in the regression window and is out of scope here.)
- **global prop-desc (~78, `parseFloat`/`decodeURI`)** and **async harness (~43)**
  — not reproducible without the test262 corpus.

These should be tracked/fixed separately; verifying them needs the test262
sweep on arb.skelpo.net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JavaScript `delete` handling for class-reference receivers, ensuring both `delete Class.method` and `delete Class["method"]` correctly remove static class methods from the constructor.
* **Tests**
  * Added a regression test covering `delete` semantics for static class methods (including computed property access) to prevent future regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->