### PR TITLE
fix(generator): #5592 yield* reads final IteratorValue at statement level

### DIFF
--- a/crates/perry-transform/src/generator/linearize.rs
+++ b/crates/perry-transform/src/generator/linearize.rs
@@ -101,8 +101,11 @@ fn delegate_next_call(del_next_id: LocalId, del_iter_id: LocalId, arg: Expr) -> 
 /// Emit the common `yield *` delegation prelude + driving loop into `current`
 /// and linearize it. Shared by all three desugar positions (statement-level
 /// `yield* e`, `return yield* e`, `let x = yield* e`). Returns the local id
-/// holding the delegated iterator's most-recent result object (`{value, done}`),
-/// whose `.value` the caller uses for the completion value.
+/// holding the delegated iterator's completion value — spec
+/// `IteratorValue(innerResult)` read once from the final `{value, done: true}`
+/// result. The read happens unconditionally even at statement level (where the
+/// value is discarded), because a `value` getter that throws must still fire and
+/// reject the generator (test262 yield-star-next-call-value-get-abrupt).
 #[allow(clippy::too_many_arguments)]
 fn emit_yield_star_loop(
     inner: &Expr,
@@ -194,7 +197,21 @@ fn emit_yield_star_loop(
         finallys,
     );
 
-    del_result_id
+    // Spec step 6.a.vi: `If done is true, then Return ? IteratorValue(innerResult)`.
+    // Read the final result's `.value` exactly once into a dedicated local. This
+    // runs on the loop-exit (done) path, so a throwing `value` getter rejects the
+    // generator here regardless of position — including bare statement-level
+    // `yield* e`, where the value is otherwise discarded.
+    let del_value_id = alloc_local(next_local_id);
+    current.push(Stmt::Expr(Expr::LocalSet(
+        del_value_id,
+        Box::new(Expr::PropertyGet {
+            object: Box::new(Expr::LocalGet(del_result_id)),
+            property: "value".to_string(),
+        }),
+    )));
+
+    del_value_id
 }
 
 pub struct State {
@@ -348,7 +365,7 @@ pub fn linearize_body(
                 value: Some(inner),
                 delegate: true,
             })) => {
-                let del_result_id = emit_yield_star_loop(
+                let del_value_id = emit_yield_star_loop(
                     inner,
                     states,
                     current,
@@ -360,15 +377,12 @@ pub fn linearize_body(
                     finallys,
                 );
 
-                // After the loop, the iterator's final `value` (from
-                // {value, done:true}) is the value of `yield* inner`, which is
+                // The iterator's final `value` (read once by `emit_yield_star_loop`
+                // as spec `IteratorValue`) is the value of `yield* inner`, which is
                 // exactly what `return yield* inner` returns. Wrap it as the
                 // generator's terminal {value, done:true} and flush a Done state.
                 current.push(Stmt::Return(Some(make_iter_result(
-                    Expr::PropertyGet {
-                        object: Box::new(Expr::LocalGet(del_result_id)),
-                        property: "value".to_string(),
-                    },
+                    Expr::LocalGet(del_value_id),
                     true,
                 ))));
                 let cont_state = *state_num;
@@ -1066,7 +1080,7 @@ pub fn linearize_body(
                 ty,
                 name,
             } => {
-                let del_result_id = emit_yield_star_loop(
+                let del_value_id = emit_yield_star_loop(
                     inner,
                     states,
                     current,
@@ -1078,14 +1092,11 @@ pub fn linearize_body(
                     finallys,
                 );
 
-                // After the loop, the iterator's final `value` (from
-                // {value, done:true}) becomes the value of `yield* expr`.
+                // The iterator's final `value` (read once by `emit_yield_star_loop`
+                // as spec `IteratorValue`) becomes the value of `yield* expr`.
                 current.push(Stmt::Let {
                     id: *id,
-                    init: Some(Expr::PropertyGet {
-                        object: Box::new(Expr::LocalGet(del_result_id)),
-                        property: "value".to_string(),
-                    }),
+                    init: Some(Expr::LocalGet(del_value_id)),
                     mutable: *mutable,
                     ty: ty.clone(),
                     name: name.clone(),

--- a/test-files/test_gap_5592_yield_star_value_get_abrupt.ts
+++ b/test-files/test_gap_5592_yield_star_value_get_abrupt.ts
@@ -1,0 +1,101 @@
+// Test: statement-level `yield* inner` must read the delegated iterator's final
+// `.value` exactly once (spec `IteratorValue(innerResult)`, step 6.a.vi), even
+// though the value is discarded — so a throwing `value` getter on the final
+// `{ done: true }` result fires and rejects/throws (test262
+// language/.../async-gen-method-static/yield-star-next-call-value-get-abrupt and
+// the sync `class/.../gen-method` analogues). Perry previously skipped the read
+// at statement level, so the getter never ran and execution wrongly continued
+// past the `yield*`.
+//
+// Validated byte-for-byte against `node --experimental-strip-types`.
+
+// --- sync: statement-level yield* surfaces a throwing final value getter ---
+const reason = { tag: "reason" };
+const syncObj: any = {
+  [Symbol.iterator]() {
+    return {
+      next() {
+        return {
+          done: true,
+          get value() {
+            throw reason;
+          },
+        };
+      },
+    };
+  },
+};
+function* sg() {
+  yield* syncObj;
+  yield "unreachable";
+}
+try {
+  for (const _ of sg()) {
+    /* drain */
+  }
+  console.log("sync: NO THROW (wrong)");
+} catch (e) {
+  console.log("sync threw:", e === reason ? "reason (correct)" : "wrong");
+}
+
+// --- async: same, in a STATIC async generator method (the #5592 cluster) ---
+const asyncObj: any = {
+  [Symbol.asyncIterator]() {
+    return {
+      next() {
+        return {
+          done: true,
+          get value() {
+            throw reason;
+          },
+        };
+      },
+    };
+  },
+};
+class C {
+  static async *gen() {
+    yield* asyncObj;
+    throw new Error("unreachable");
+  }
+}
+
+// --- the completion value still propagates when the getter does NOT throw ---
+function* innerVal() {
+  yield 1;
+  yield 2;
+  return "RET";
+}
+function* letPos() {
+  const x = yield* innerVal() as any;
+  yield "x=" + x;
+}
+function* retPos() {
+  return yield* innerVal() as any;
+}
+function drain(g: any) {
+  const v: any[] = [];
+  let r = g.next();
+  while (!r.done) {
+    v.push(r.value);
+    r = g.next();
+  }
+  return JSON.stringify({ v, ret: r.value });
+}
+
+async function main() {
+  const iter = C.gen();
+  try {
+    await iter.next();
+    console.log("async: NO THROW (wrong)");
+  } catch (e) {
+    console.log("async threw:", e === reason ? "reason (correct)" : "wrong");
+  }
+  const r = await iter.next();
+  console.log("async after:", r.done, r.value);
+
+  console.log("let:", drain(letPos()));
+  console.log("ret:", drain(retPos()));
+  console.log("ALL YIELD-STAR-VALUE-GET TESTS PASSED");
+}
+main();


### PR DESCRIPTION
## Summary

Part of the #5592 test262 class-tail parity gap. Fixes the
`async-gen-method-static/yield-star-next-call-value-get-abrupt` cluster (and its
sync class/generator analogues): statement-level `yield* inner` did not read the
delegated iterator's final `.value`.

Per spec (`YieldExpression : yield * AssignmentExpression`, step 6.a.vi —
`If done is true, then Return ? IteratorValue(innerResult)`), the final `.value`
must be read **exactly once even when the value is discarded**, so a `value`
getter that throws on the terminal `{ done: true }` result fires and
rejects/throws the (async) generator. Perry previously skipped that read at
statement position, so the getter never ran and execution wrongly continued past
the `yield*`.

## Fix

`emit_yield_star_loop` now reads the final result's `.value` once into a
dedicated local on the loop-exit (done) path and returns that local. The
return-position (`return yield* e`) and let-position (`let x = yield* e`)
desugars consume the returned local directly instead of re-reading `.value`,
keeping the read at exactly one. The statement-level position gets the read (and
thus the abrupt-completion side effect) for free.

Single change in `crates/perry-transform/src/generator/linearize.rs`; applies to
both sync and async generators (shared desugar).

## Validation

- New gap test `test-files/test_gap_5592_yield_star_value_get_abrupt.ts` covers
  statement-level throwing-getter (sync + async static method), plus
  completion-value propagation in let/return positions — byte-for-byte against
  `node --experimental-strip-types`.
- All existing generator/`yield*` gap tests pass (0 diffs) and `perry-transform`
  unit tests are green. The one pre-existing failure
  (`test_gap_yieldstar_inherited_iterator_this`, a separate `GetIterator`
  `this`-binding gap) is unchanged — it fails identically on `main`.

No version bump / CHANGELOG entry (left to maintainer per CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `yield*` expressions to correctly handle delegated iterator completion values.

* **Tests**
  * Added comprehensive test coverage for `yield*` completion value handling in generator methods, including edge cases with throwing value getters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->