### PR TITLE
fix(fetch): support fetch(Request) + register the pump on early promise resolution (deadlock)

### DIFF
--- a/crates/perry-stdlib/src/common/async_bridge.rs
+++ b/crates/perry-stdlib/src/common/async_bridge.rs
@@ -259,6 +259,15 @@ where
 /// objects, or strings, use queue_deferred_resolution instead.
 pub fn queue_promise_resolution(promise_ptr: usize, is_success: bool, result_bits: u64) {
     ensure_gc_scanner_registered();
+    // The await busy-pump only drains PENDING_RESOLUTIONS via the registered
+    // STDLIB_PUMP_FN. Callers that queue a resolution *without* a preceding
+    // `spawn` (e.g. `js_fetch_with_options`'s early "Invalid URL" reject when
+    // `fetch()` is handed a non-string first arg such as a `Request` object)
+    // would otherwise leave the pump unregistered: `js_stdlib_has_active_handles`
+    // reports the pending entry so the awaiter keeps waiting, but nothing ever
+    // drains it → the awaited Promise stays pending forever (deadlock). Register
+    // the pump here so every queued resolution is guaranteed to be processed.
+    ensure_pump_registered();
     {
         let mut pending = PENDING_RESOLUTIONS.lock().unwrap();
         pending.push(PendingResolution {
@@ -283,6 +292,10 @@ where
     F: FnOnce() -> u64 + Send + 'static,
 {
     ensure_gc_scanner_registered();
+    // Same pump-registration guarantee as `queue_promise_resolution` (above):
+    // a deferred resolution queued without a preceding `spawn` must still be
+    // drained by the await busy-pump.
+    ensure_pump_registered();
     {
         let mut pending = PENDING_DEFERRED.lock().unwrap();
         pending.push(DeferredResolution {

--- a/crates/perry-stdlib/src/fetch/mod.rs
+++ b/crates/perry-stdlib/src/fetch/mod.rs
@@ -16,6 +16,7 @@ use crate::common::async_bridge::{queue_promise_resolution, spawn};
 // lint gate (#1649). The child module sees mod.rs's private items via its
 // `use super::*`.
 mod headers;
+mod request_handle;
 pub use headers::*;
 
 // Cached bound-method values for Fetch `Headers` handles — split out to keep
@@ -605,23 +606,28 @@ pub unsafe extern "C" fn js_fetch_with_options(
     let promise = perry_runtime::js_promise_new();
     let promise_ptr = promise as usize;
 
-    let url = match string_from_header(url_ptr) {
-        Some(u) => u,
-        None => {
-            let err_msg = "Invalid URL";
-            let err_bits = fetch_error_bits(err_msg);
+    // `fetch(Request)` form: callers (axios/gaxios / any WHATWG-fetch) build a
+    // `Request` object and call `fetch(request, init)`; its handle id lands in
+    // the `url_ptr` slot. Recover url/method/body/headers from the Request
+    // registry so the request is dispatched (`init` members override).
+    let request_handle::FetchInputs {
+        url,
+        method,
+        body,
+        custom_headers,
+    } = match request_handle::resolve_fetch_inputs(
+        string_from_header(url_ptr),
+        string_from_header(method_ptr),
+        string_from_header(body_ptr),
+        string_from_header(headers_json_ptr),
+        url_ptr as usize,
+    ) {
+        Ok(inputs) => inputs,
+        Err(err_bits) => {
             queue_promise_resolution(promise_ptr, false, err_bits);
             return promise;
         }
     };
-
-    let method = string_from_header(method_ptr).unwrap_or_else(|| "GET".to_string());
-    let body = string_from_header(body_ptr);
-    let headers_json = string_from_header(headers_json_ptr).unwrap_or_else(|| "{}".to_string());
-
-    // Parse headers from JSON
-    let custom_headers: HashMap<String, String> =
-        serde_json::from_str(&headers_json).unwrap_or_default();
 
     spawn(async move {
         let client = HTTP_CLIENT.clone();

--- a/crates/perry-stdlib/src/fetch/request_handle.rs
+++ b/crates/perry-stdlib/src/fetch/request_handle.rs
@@ -1,0 +1,94 @@
+//! Helpers for the `fetch(Request)` form — recovering a `Request` object's
+//! url/method/body/headers from the registry and resolving the final fetch
+//! inputs (with `init` overrides). Split out of `mod.rs` to keep it small.
+
+use std::collections::HashMap;
+
+/// Resolved inputs for a fetch call, after applying any `init` overrides over a
+/// `Request` object's own fields.
+pub(crate) struct FetchInputs {
+    pub url: String,
+    pub method: String,
+    /// Request body as raw bytes — preserved byte-for-byte so binary payloads
+    /// are never corrupted by a lossy UTF-8 round-trip.
+    pub body: Option<Vec<u8>>,
+    pub custom_headers: HashMap<String, String>,
+}
+
+/// Fields recovered from a `Request` object for the `fetch(Request)` form.
+struct RequestFetchFields {
+    url: String,
+    method: String,
+    body: Option<Vec<u8>>,
+    headers: HashMap<String, String>,
+}
+
+/// Recover url/method/body/headers from a live `Request` handle, or `None` when
+/// the id isn't a live Request handle (e.g. a genuinely bad/undefined first arg).
+fn request_fields_from_handle(maybe_handle: usize) -> Option<RequestFetchFields> {
+    let guard = super::REQUEST_REGISTRY.lock().unwrap();
+    let req = guard.get(&maybe_handle)?;
+    let headers = req
+        .headers
+        .entries
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    Some(RequestFetchFields {
+        url: req.url.clone(),
+        method: req.method.clone(),
+        // Keep the body as raw bytes; never lossy-convert to `String` (which
+        // would replace invalid UTF-8 with U+FFFD and corrupt binary bodies).
+        body: req.body.clone(),
+        headers,
+    })
+}
+
+/// Resolve the final fetch inputs from the pre-extracted `init` header strings,
+/// recovering Request-object fields for the `fetch(Request)` form. `init`
+/// members win over the Request's own fields (the WHATWG rule). Returns
+/// `Err(error_bits)` for a missing/invalid URL.
+pub(crate) fn resolve_fetch_inputs(
+    url_from_header: Option<String>,
+    method_from_header: Option<String>,
+    body_from_header: Option<String>,
+    headers_json: Option<String>,
+    url_handle: usize,
+) -> Result<FetchInputs, u64> {
+    let request_fields = if url_from_header.is_none() {
+        request_fields_from_handle(url_handle)
+    } else {
+        None
+    };
+
+    let url = match url_from_header {
+        Some(u) => u,
+        None => match request_fields.as_ref() {
+            Some(rf) => rf.url.clone(),
+            None => return Err(unsafe { super::fetch_error_bits("Invalid URL") }),
+        },
+    };
+
+    let method = method_from_header
+        .or_else(|| request_fields.as_ref().map(|rf| rf.method.clone()))
+        .unwrap_or_else(|| "GET".to_string());
+
+    let body = body_from_header
+        .map(String::into_bytes)
+        .or_else(|| request_fields.as_ref().and_then(|rf| rf.body.clone()));
+
+    let custom_headers: HashMap<String, String> = match headers_json {
+        Some(j) => serde_json::from_str(&j).unwrap_or_default(),
+        None => request_fields
+            .as_ref()
+            .map(|rf| rf.headers.clone())
+            .unwrap_or_default(),
+    };
+
+    Ok(FetchInputs {
+        url,
+        method,
+        body,
+        custom_headers,
+    })
+}


### PR DESCRIPTION
## Problem

`await fetch(new Request(url, opts))` (a `Request` object as fetch's first arg — the form axios's fetch adapter uses) **hangs forever**: the awaiting Promise never settles, with zero observable pending work.

## Root cause (two compounding bugs)

1. **`js_fetch_with_options` didn't recognize the `Request`-object form.** The Request **handle** (handle-band value, e.g. `0x40001`) is passed into the `url_ptr: *const StringHeader` slot. `string_from_header` correctly refuses to deref a handle-band value → `None` → fetch takes its early-error path `queue_promise_resolution(promise, false, "Invalid URL")` **without calling `spawn`**.

2. **`queue_promise_resolution`/`queue_deferred_resolution` didn't register the event-loop pump.** The stdlib pump is installed lazily by `spawn → ensure_pump_registered`. With no preceding `spawn`, the pump stayed null: `js_stdlib_has_active_handles()` reported the queued resolution pending (awaiter waits), but `js_run_stdlib_pump` had no drain → resolution never applied → Promise pending forever.

## Fix

1. `queue_promise_resolution`/`queue_deferred_resolution` now call `ensure_pump_registered()` — any queued resolution drains even with no prior `spawn` (this alone breaks the deadlock).
2. `js_fetch_with_options` recognizes `fetch(Request)`: recovers url/method/body/headers from the Request registry and dispatches the request (explicit `init` still overrides).

## Tests

`await fetch(new Request("https://example.com/"))`: hung before → **200 + real socket** after. `fetch(Request,{method:"POST"})` applies override; plain `fetch(url)` unchanged. `cargo test -p perry-runtime --lib`: 1074; `cargo test -p perry-stdlib --lib`: 103.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for calling `fetch()` with a `Request` object (in addition to the existing URL-based form), including correct handling of method, body, and headers.

* **Bug Fixes**
  * Prevented awaited Promises from hanging indefinitely by ensuring the stdlib pending-resolution drain loop is properly registered whenever resolution items are queued.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->