### PR TITLE
fix(hir): #5579 — global-script mode top-level `this` is globalThis (78-case global prop-desc cluster)

### DIFF
--- a/crates/perry-hir/src/lower/const_fold_fn.rs
+++ b/crates/perry-hir/src/lower/const_fold_fn.rs
@@ -798,8 +798,7 @@ fn try_direct_eval_this_fold(ctx: &mut LoweringContext, call: &ast::CallExpr) ->
     // direct `eval('this')` must fold to the same — keeping `eval('this') ===
     // this` true under a conforming Test262 host (#5579). See `lower_expr`'s
     // `ast::Expr::This` arm for the matching default-vs-script split.
-    let module_top_this_global =
-        module_top_this && super::lower_expr::global_script_this_enabled();
+    let module_top_this_global = module_top_this && super::lower_expr::global_script_this_enabled();
     if let Some(normalized) = normalize_eval_this_body(&body) {
         return match normalized.as_str() {
             "globalThis" => Some(Expr::GlobalThisExpr),

--- a/crates/perry-hir/src/lower/const_fold_fn.rs
+++ b/crates/perry-hir/src/lower/const_fold_fn.rs
@@ -794,9 +794,16 @@ fn try_direct_eval_this_fold(ctx: &mut LoweringContext, call: &ast::CallExpr) ->
         && ctx.current_class.is_none()
         && ctx.with_env_stack.is_empty()
         && !ctx.is_external_module;
+    // In global-script mode the module top-level `this` IS `globalThis`, so a
+    // direct `eval('this')` must fold to the same — keeping `eval('this') ===
+    // this` true under a conforming Test262 host (#5579). See `lower_expr`'s
+    // `ast::Expr::This` arm for the matching default-vs-script split.
+    let module_top_this_global =
+        module_top_this && super::lower_expr::global_script_this_enabled();
     if let Some(normalized) = normalize_eval_this_body(&body) {
         return match normalized.as_str() {
             "globalThis" => Some(Expr::GlobalThisExpr),
+            "this" if module_top_this_global => Some(Expr::GlobalThisExpr),
             "this" if module_top_this => Some(Expr::ModuleTopThis),
             "this" if ctx.current_strict && ctx.scope_depth > 0 => Some(Expr::Undefined),
             "this" => Some(Expr::This),

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -41,6 +41,25 @@ pub(crate) const MAX_EXPR_CHAIN_LOWER_DEPTH: u32 = 512;
 const EXPR_LOWER_STACK_RED_ZONE: usize = 256 * 1024;
 const EXPR_LOWER_STACK_SEGMENT: usize = 2 * 1024 * 1024;
 
+/// Whether `PERRY_GLOBAL_SCRIPT_THIS` is set — compile the program as a
+/// *global script* rather than a CJS module, so module top-level `this`
+/// lowers to `globalThis` instead of the `module.exports` stand-in
+/// (`Expr::ModuleTopThis`). This matches a conforming Test262 host (and the
+/// Node oracle's `vm.runInThisContext`, #5346/#5511); the default stays
+/// CJS so standalone builds match `node --experimental-strip-types`. Read
+/// once per process — the env is fixed for the lifetime of a compile (#5579).
+pub(crate) fn global_script_this_enabled() -> bool {
+    use std::sync::OnceLock;
+    static FLAG: OnceLock<bool> = OnceLock::new();
+    *FLAG.get_or_init(|| match std::env::var("PERRY_GLOBAL_SCRIPT_THIS") {
+        Ok(v) => {
+            let v = v.trim().to_ascii_lowercase();
+            !matches!(v.as_str(), "" | "0" | "off" | "false" | "no")
+        }
+        Err(_) => false,
+    })
+}
+
 pub(crate) fn throw_reference_error_expr(helper_name: &str) -> Expr {
     Expr::Call {
         callee: Box::new(Expr::ExternFuncRef {
@@ -1838,14 +1857,27 @@ fn lower_expr_impl(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<Expr> 
         ast::Expr::Object(obj) => expr_object::lower_object(ctx, obj),
         ast::Expr::This(_) => {
             // Module TOP-LEVEL `this` is Node-CJS `module.exports` — a fresh
-            // plain object, not `globalThis` (the oracle runs assembled test
-            // files as CommonJS). Function/class/with bodies keep dynamic
-            // `Expr::This` semantics, handled by codegen's ThisContext.
+            // plain object, not `globalThis` (the default `node
+            // --experimental-strip-types` parity oracle runs files as
+            // CommonJS, where top-level `this === module.exports === {}`).
+            // Function/class/with bodies keep dynamic `Expr::This` semantics,
+            // handled by codegen's ThisContext.
             if ctx.scope_depth == 0
                 && ctx.current_class.is_none()
                 && ctx.with_env_stack.is_empty()
                 && !ctx.is_external_module
             {
+                // Global-script mode (`PERRY_GLOBAL_SCRIPT_THIS`): a conforming
+                // Test262 host evaluates each assembled case as a *global
+                // script* (the Node oracle does this via
+                // `vm.runInThisContext`, #5346/#5511), where top-level `this`
+                // is `globalThis`, not a CJS exports object. Opt-in only: the
+                // default stays CJS-`{}` so standalone builds still match
+                // `node --experimental-strip-types`. (#5579 global prop-desc
+                // cluster — `verifyProperty(this, "decodeURI", ...)`.)
+                if global_script_this_enabled() {
+                    return Ok(Expr::GlobalThisExpr);
+                }
                 return Ok(Expr::ModuleTopThis);
             }
             Ok(Expr::This)

--- a/crates/perry/tests/issue_5579_global_script_this_prop_desc.rs
+++ b/crates/perry/tests/issue_5579_global_script_this_prop_desc.rs
@@ -1,0 +1,151 @@
+//! Regression (#5579): in *global-script* mode the module top-level `this`
+//! must be `globalThis`, so the standard Test262 `verifyProperty` shape over
+//! global builtins (`verifyProperty(this, "decodeURI", ...)` /
+//! `verifyPrimordialCallableProperty(this, "parseFloat", ...)`) resolves.
+//!
+//! Root cause: #4868 lowered module top-level `this` to a CJS `module.exports`
+//! stand-in (a fresh `{}`) to match the Test262 Node oracle, which back then
+//! ran each assembled case as a CommonJS module (`this === module.exports`).
+//! #5346/#5511 switched that oracle to a conforming *global script*
+//! (`vm.runInThisContext`, where `this === globalThis`). Perry kept emitting the
+//! `{}` stand-in, so `this["parseFloat"]` was `undefined` and
+//! `Object.getOwnPropertyDescriptor(this, "decodeURI")` was `undefined` —
+//! 78 `built-ins/*/prop-desc.js` (and friends) regressed.
+//!
+//! Fix: `PERRY_GLOBAL_SCRIPT_THIS=1` opts a compile into global-script
+//! semantics — top-level `this` lowers to `globalThis`. It is opt-in: the
+//! default stays the CJS `{}` stand-in so a standalone build keeps matching
+//! `node --experimental-strip-types <file>` (which runs the file as a CJS
+//! module, where top-level `this` is NOT `globalThis`). The Test262 harness
+//! sets the flag so Perry matches the script-mode Node oracle.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+/// Compile `src` and run it. `global_script` toggles `PERRY_GLOBAL_SCRIPT_THIS`.
+fn compile_and_run(src: &str, global_script: bool) -> (bool, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(&entry, src).expect("write entry");
+    let output = dir.path().join("main_bin");
+
+    let mut compile = Command::new(perry_bin());
+    compile
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        // Keep codegen deterministic and skip the whole-program optimize step
+        // (mirrors the Test262 harness compile env).
+        .env("PERRY_NO_AUTO_OPTIMIZE", "1");
+    if global_script {
+        compile.env("PERRY_GLOBAL_SCRIPT_THIS", "1");
+    } else {
+        // Be explicit so an ambient value in the test env can't leak in.
+        compile.env_remove("PERRY_GLOBAL_SCRIPT_THIS");
+    }
+    let compiled = compile.output().expect("run perry compile");
+    assert!(
+        compiled.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&compiled.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    (
+        run.status.success(),
+        String::from_utf8_lossy(&run.stdout).to_string(),
+    )
+}
+
+/// The actual shape `propertyHelper.js` checks for a primordial global builtin:
+/// an own, writable, non-enumerable, configurable function property of `this`.
+const PROBE: &str = r#"
+const hasOwn = Object.prototype.hasOwnProperty;
+console.log("this===globalThis:", (this as any) === globalThis);
+console.log("typeof.this.parseFloat:", typeof (this as any)["parseFloat"]);
+console.log("own.decodeURI:", hasOwn.call(this, "decodeURI"));
+const d = Object.getOwnPropertyDescriptor(this as any, "decodeURI");
+console.log("desc.decodeURI:", d
+  ? `${d.writable}/${d.enumerable}/${d.configurable}/${typeof d.value}`
+  : "undefined");
+console.log("DONE");
+"#;
+
+#[test]
+fn global_script_mode_top_level_this_is_global_this() {
+    let (ok, out) = compile_and_run(PROBE, /* global_script */ true);
+    assert!(ok, "compiled binary did not exit cleanly\n{out}");
+    assert!(
+        out.contains("this===globalThis: true"),
+        "global-script top-level `this` must be `globalThis`\n{out}"
+    );
+    assert!(
+        out.contains("typeof.this.parseFloat: function"),
+        "`this.parseFloat` must read back as a function (verifyPrimordialCallableProperty)\n{out}"
+    );
+    assert!(
+        out.contains("own.decodeURI: true"),
+        "`decodeURI` must be an own property of `this` (verifyProperty)\n{out}"
+    );
+    assert!(
+        out.contains("desc.decodeURI: true/false/true/function"),
+        "global builtin descriptor must be {{writable, !enumerable, configurable, function}}\n{out}"
+    );
+    assert!(out.contains("DONE"), "program must run to completion\n{out}");
+}
+
+#[test]
+fn default_mode_top_level_this_stays_cjs_exports() {
+    // Without the flag, top-level `this` must remain the CJS `module.exports`
+    // stand-in (`{}`) so standalone builds keep matching the default
+    // `node --experimental-strip-types` (CommonJS) parity oracle.
+    let (ok, out) = compile_and_run(PROBE, /* global_script */ false);
+    assert!(ok, "compiled binary did not exit cleanly\n{out}");
+    assert!(
+        out.contains("this===globalThis: false"),
+        "default top-level `this` must NOT be `globalThis`\n{out}"
+    );
+    assert!(
+        out.contains("typeof.this.parseFloat: undefined"),
+        "default top-level `this` is a fresh object: `this.parseFloat` is undefined\n{out}"
+    );
+    assert!(
+        out.contains("own.decodeURI: false"),
+        "default top-level `this` owns no global builtins\n{out}"
+    );
+    assert!(
+        out.contains("desc.decodeURI: undefined"),
+        "default top-level `this` has no `decodeURI` descriptor\n{out}"
+    );
+    assert!(out.contains("DONE"), "program must run to completion\n{out}");
+}
+
+#[test]
+fn global_script_mode_direct_eval_this_matches_this() {
+    // A conforming host evaluates `eval("this")` in the caller's `this`, so at
+    // global-script top level `eval("this") === this === globalThis`. (test262
+    // language/eval-code/direct/this-value-global.)
+    let src = r#"
+console.log("eval.this===globalThis:", (eval("this") as any) === globalThis);
+console.log("eval.this===this:", (eval("this") as any) === (this as any));
+console.log("DONE");
+"#;
+    let (ok, out) = compile_and_run(src, /* global_script */ true);
+    assert!(ok, "compiled binary did not exit cleanly\n{out}");
+    assert!(
+        out.contains("eval.this===globalThis: true"),
+        "direct `eval(\"this\")` must fold to `globalThis` in global-script mode\n{out}"
+    );
+    assert!(
+        out.contains("eval.this===this: true"),
+        "`eval(\"this\") === this` must hold in global-script mode\n{out}"
+    );
+    assert!(out.contains("DONE"), "program must run to completion\n{out}");
+}

--- a/crates/perry/tests/issue_5579_global_script_this_prop_desc.rs
+++ b/crates/perry/tests/issue_5579_global_script_this_prop_desc.rs
@@ -98,7 +98,10 @@ fn global_script_mode_top_level_this_is_global_this() {
         out.contains("desc.decodeURI: true/false/true/function"),
         "global builtin descriptor must be {{writable, !enumerable, configurable, function}}\n{out}"
     );
-    assert!(out.contains("DONE"), "program must run to completion\n{out}");
+    assert!(
+        out.contains("DONE"),
+        "program must run to completion\n{out}"
+    );
 }
 
 #[test]
@@ -124,7 +127,10 @@ fn default_mode_top_level_this_stays_cjs_exports() {
         out.contains("desc.decodeURI: undefined"),
         "default top-level `this` has no `decodeURI` descriptor\n{out}"
     );
-    assert!(out.contains("DONE"), "program must run to completion\n{out}");
+    assert!(
+        out.contains("DONE"),
+        "program must run to completion\n{out}"
+    );
 }
 
 #[test]
@@ -147,5 +153,8 @@ console.log("DONE");
         out.contains("eval.this===this: true"),
         "`eval(\"this\") === this` must hold in global-script mode\n{out}"
     );
-    assert!(out.contains("DONE"), "program must run to completion\n{out}");
+    assert!(
+        out.contains("DONE"),
+        "program must run to completion\n{out}"
+    );
 }

--- a/scripts/test262_subset.py
+++ b/scripts/test262_subset.py
@@ -475,7 +475,8 @@ def main() -> int:
                 # the case's own `assert.*` self-checks (#4792).
                 out_bin = workdir / "case.out"
                 c_env = dict(base_env, PERRY_ALLOW_UNIMPLEMENTED="1",
-                             PERRY_NO_AUTO_OPTIMIZE="1")
+                             PERRY_NO_AUTO_OPTIMIZE="1",
+                             PERRY_GLOBAL_SCRIPT_THIS="1")
                 c_exit, c_out = run(
                     [str(args.perry_bin), "compile", str(staged), "-o",
                      str(out_bin)], c_env, args.timeout, cwd=str(workdir))
@@ -497,8 +498,16 @@ def main() -> int:
             node_clean = n_exit == 0
             # 2) Perry compile (permissive — unimplemented surfaces as a gap).
             out_bin = workdir / "case.out"
+            # Compile each case as a *global script* so module top-level
+            # `this` is `globalThis` — matching the Node oracle, which runs
+            # the assembled case via `vm.runInThisContext` (host-run.cjs,
+            # #5346/#5511). Without it, Perry models top-level `this` as the
+            # CJS `module.exports` `{}` and the global prop-desc cluster
+            # (`verifyProperty(this, "decodeURI", ...)`) spuriously fails
+            # against the script-mode oracle (#5579).
             c_env = dict(base_env, PERRY_ALLOW_UNIMPLEMENTED="1",
-                         PERRY_NO_AUTO_OPTIMIZE="1", PERRY_ALLOW_EVAL="1")
+                         PERRY_NO_AUTO_OPTIMIZE="1", PERRY_ALLOW_EVAL="1",
+                         PERRY_GLOBAL_SCRIPT_THIS="1")
             c_exit, c_out = run(
                 [str(args.perry_bin), "compile", str(staged), "-o",
                  str(out_bin)], c_env, args.timeout, cwd=str(workdir))


### PR DESCRIPTION
## Summary

Fixes the **78-case global-builtin prop-desc cluster** of #5579: test262 cases
reporting **`parseFloat should be a function`** / **`decodeURI should be an own
property`** (`built-ins/parseFloat/prop-desc.js`, `built-ins/decodeURI/prop-desc.js`,
`built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-10.js`, …).

These run the standard `verifyProperty(this, NAME, ...)` /
`verifyPrimordialCallableProperty(this, NAME, 1)` shape against the global
object **via top-level `this`**.

## Root cause — *not* a runtime regression

The issue's ranked suspects (#5471/#5451/#5478) are object-model commits; this
cluster has a different cause. It's a **test-oracle/Perry-model mismatch**, not
a change in how descriptors are read.

- **#4868** lowered module top-level `this` to a CJS `module.exports` stand-in
  (a fresh `{}`) — explicitly *"to match the node oracle"*, which back then ran
  each assembled case as a **CommonJS module** (`this === module.exports === {}`).
- In-window **#5346/#5511** (`84eea0c20`, `host-run.cjs`) switched that oracle
  to a conforming **global script** via `vm.runInThisContext`, where top-level
  **`this === globalThis`**.

Before #5511 both runtimes saw `this === {}` (the cases failed under *both* →
"both reject", not charged to Perry). After #5511 Node passes (`this` owns the
global builtins) while Perry still emits the `{}` stand-in, so
`this["parseFloat"]` is `undefined` and
`Object.getOwnPropertyDescriptor(this, "decodeURI")` is `undefined` → the 78
cases became Perry-only failures.

## Why not just flip Perry's default

The gap suite compares **byte-for-byte against `node --experimental-strip-types
<file>`**, which runs the file as a **CommonJS module** where top-level `this`
is *not* `globalThis` (`this.parseFloat === undefined`, `this === module.exports`).
Making `this = globalThis` the default would diverge there (e.g.
`console.log(this)`).

## Fix

Add an **opt-in** global-script mode, `PERRY_GLOBAL_SCRIPT_THIS`:

- `lower_expr.rs` — module top-level `this` lowers to `globalThis`
  (`Expr::GlobalThisExpr`) instead of `Expr::ModuleTopThis` when the flag is set.
- `const_fold_fn.rs` — a direct `eval("this")` at global-script top level folds
  to `globalThis` too, keeping `eval("this") === this` true under a conforming
  host (test262 `language/eval-code/direct/this-value-global`).
- `scripts/test262_subset.py` — the harness sets the flag in the Perry compile
  env, so Perry runs in the **same** mode as the script-mode Node oracle.

The default stays the CJS `{}` stand-in, so standalone builds keep matching
`node --experimental-strip-types`.

## Validation

- New `issue_5579_global_script_this_prop_desc` (3 tests) — **pass**:
  - script-mode `this === globalThis` + the `verifyProperty` descriptor shape
    (`decodeURI` own, `{writable:true, enumerable:false, configurable:true,
    value:function}`);
  - **default-mode** `this` stays the CJS `{}` (`this.parseFloat === undefined`)
    — guards against accidentally changing the default;
  - script-mode `eval("this") === this`.
- Focused test262 (parseFloat / decodeURI / decodeURIComponent / encodeURI /
  parseInt / isNaN / isFinite + Object/getOwnPropertyDescriptor / built-ins/global
  / eval-code/direct / global-code): **every `prop-desc.js` now passes**.
- **A/B** over the `this`-sensitive dirs (flag off vs on, same binary): **12+
  fixed, 0 newly-failing** — the change only ever flips failures to passes.

## Scope / not addressed here

#5579 bundles several clusters. The 296-case class m-descriptor cluster was
fixed in #5597. This PR fixes the **78-case global prop-desc** cluster. The
remaining `with`-scope (~104) and async-harness (~43, top-level `function`
declarations as `globalThis` own properties) clusters are separate facets of
the same Script-vs-CJS semantics and are tracked/handled independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added opt-in support for global-script mode via `PERRY_GLOBAL_SCRIPT_THIS`, making module top-level `this` behave like `globalThis` (including matching descriptor behavior for global built-ins).

* **Bug Fixes**
  * Improved `eval("this")` folding in global-script mode to resolve to `globalThis`.

* **Tests**
  * Added a regression test for the global-script `this` behavior.
  * Updated the Test262 subset runner to enable global-script mode consistently during execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->