### PR TITLE
fix(hir+runtime): #5579 — `with`-statement sloppy-implicit reads resolve against globalThis (104-case cluster)

### DIFF
--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -835,12 +835,32 @@ pub fn lower_module_full(
         let mut implicit_globals: Vec<Stmt> = ctx
             .sloppy_implicit_globals
             .iter()
-            .map(|(name, id)| Stmt::Let {
-                id: *id,
-                name: name.clone(),
-                ty: Type::Any,
-                mutable: true,
-                init: Some(Expr::Undefined),
+            .map(|(name, id)| {
+                // #5579: a `with`-set FALLBACK sloppy global (`with (o) { p1 =
+                // 'x1'; }`) must hoist as the HOLE sentinel, NOT `undefined`.
+                // The HOLE routes a later bare read through
+                // `js_with_implicit_read`, which resolves the name against the
+                // global object (so `globalThis.p1` set independently reads
+                // back) and only throws when it is genuinely unresolvable. A
+                // plain `undefined` hoist instead makes the read silently yield
+                // `undefined`. This module-scope hoist is the ONLY declaration
+                // site for the slot when the `with` is nested inside a function
+                // (the in-body HOLE init lands in the callee's own frame), so
+                // without this the function-nested cases regress
+                // (S12.10_A1.2/A1.3/A3.2). Plain sloppy implicit globals
+                // (`undeclared = 1` outside any `with`) keep the `undefined`
+                // hoist.
+                if ctx.with_sloppy_implicit_ids.contains_key(id) {
+                    with_implicit_unset_let(*id, name.clone())
+                } else {
+                    Stmt::Let {
+                        id: *id,
+                        name: name.clone(),
+                        ty: Type::Any,
+                        mutable: true,
+                        init: Some(Expr::Undefined),
+                    }
+                }
             })
             .collect();
         implicit_globals.append(&mut module.init);

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -1846,7 +1846,6 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                     "`with` statement is forbidden in strict mode"
                 );
             }
-            let insert_at = result.len();
             let env_id = ctx.define_local("__perry_with_env".to_string(), Type::Any);
             result.push(Stmt::Let {
                 id: env_id,
@@ -1859,14 +1858,20 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
             let body_result = lower_body_stmt(ctx, &with_stmt.body);
             ctx.pop_with_env();
             result.extend(body_result?);
-            // Sentinel slots for implicit globals minted by with-set
-            // fallbacks inside this body (see with_set_fallback_for_ident).
-            for (i, (id, name)) in ctx.pending_with_implicit_inits.drain(..).enumerate() {
-                result.insert(
-                    insert_at + i,
-                    crate::lower::with_implicit_unset_let(id, name),
-                );
-            }
+            // #5579: a with-set fallback sloppy implicit is a MODULE-level
+            // binding (`define_sloppy_implicit_global` marks it so), and its
+            // HOLE-sentinel init is emitted at module scope by the
+            // sloppy-implicit-globals hoist (lower_module_fn). Do NOT *also*
+            // declare it as a function-LOCAL here: a local `Let` would shadow
+            // the module slot inside this frame, so a fallback write that DOES
+            // fire (the with-env lacks the name → the assignment creates a real
+            // global, e.g. `with (o) { p5 = 'x5'; }` where `o` has no `p5`)
+            // would land in the throwaway shadow and a later module-scope read
+            // would miss it (S12.10_A1.2/A1.3 `p5`). Just clear the queue so the
+            // pending ids don't leak into a sibling `with` body; the module
+            // hoist owns the declaration. (Module-scope `with` keeps inserting
+            // its own init in `lower::stmt`, where the slot IS the module slot.)
+            ctx.pending_with_implicit_inits.clear();
         }
         // Final catch-all: any genuinely unexpected variant (e.g. a future
         // swc Stmt variant we haven't enumerated) bails instead of silently

--- a/crates/perry-runtime/src/object/with_env.rs
+++ b/crates/perry-runtime/src/object/with_env.rs
@@ -136,15 +136,29 @@ pub extern "C" fn js_with_implicit_read(value: f64, name: f64) -> f64 {
     if value.to_bits() == crate::value::TAG_HOLE {
         // The HOLE sentinel means this with-set FALLBACK never fired: the
         // with-env object took the write, so no binding was created *here*.
-        // That does NOT make the name unresolvable — it may still name a real
-        // property of the global object set independently of the `with`
-        // (`globalThis.p1 = 1; with (o) { p1 = 'x1'; } p1` must read back the
-        // global `1`, since `o` owns `p1` and the assignment went to `o`, not
-        // the global — test262 with/S12.10_A1.*). Defer to the same resolution
-        // the bare unqualified-global read uses: return `globalThis[name]` when
-        // present, else throw the spec `ReferenceError: <name> is not defined`.
-        // When the global lacks the name (`var o = {foo:1}; with(o){foo=42} foo`
-        // — with/12.10-0-7), that path throws exactly as before.
+        // That does NOT make the name unresolvable — it resolves against the
+        // global object exactly like a bare unqualified read
+        // (`globalThis.p1 = 1; with (o) { p1 = 'x1'; } p1` reads the global
+        // `1`, since `o` owns `p1` and the assignment went to `o`, not the
+        // global — test262 with/S12.10_A1.*).
+        //
+        // Use an EXISTENCE check (GlobalEnvironmentRecord HasBinding), NOT a
+        // value check: a global property explicitly set to `undefined` is
+        // present and must read back `undefined` rather than mis-throw. Only a
+        // name that exists nowhere on the global is the spec ReferenceError
+        // (`var o = {foo:1}; with (o) { foo = 42; } foo` — with/12.10-0-7).
+        let g = crate::object::js_get_global_this();
+        if js_is_truthy(crate::object::js_object_has_property(g, name)) != 0 {
+            let gj = JSValue::from_bits(g.to_bits());
+            let gptr = (gj.bits() & crate::value::POINTER_MASK) as *const ObjectHeader;
+            let key = crate::builtins::js_string_coerce(name);
+            if !gptr.is_null() && !key.is_null() {
+                let v = unsafe { crate::object::js_object_get_field_by_name(gptr, key) };
+                return f64::from_bits(v.bits());
+            }
+        }
+        // Not present anywhere on the global → spec ReferenceError. Reuse the
+        // shared bare-global path so the thrown error's message/shape match.
         return crate::error::js_global_get_or_throw_unresolved(name);
     }
     value

--- a/crates/perry-runtime/src/object/with_env.rs
+++ b/crates/perry-runtime/src/object/with_env.rs
@@ -134,20 +134,18 @@ static KEEP_JS_WITH_IMPLICIT_READ: extern "C" fn(f64, f64) -> f64 = js_with_impl
 #[no_mangle]
 pub extern "C" fn js_with_implicit_read(value: f64, name: f64) -> f64 {
     if value.to_bits() == crate::value::TAG_HOLE {
-        let name_ptr = crate::value::js_get_string_pointer_unified(name) as *const StringHeader;
-        let name_str = if name_ptr.is_null() {
-            "<ident>".to_string()
-        } else {
-            unsafe {
-                let ptr = (name_ptr as *const u8).add(std::mem::size_of::<StringHeader>());
-                let len = (*name_ptr).byte_len as usize;
-                String::from_utf8_lossy(std::slice::from_raw_parts(ptr, len)).into_owned()
-            }
-        };
-        let msg = format!("{} is not defined", name_str);
-        let msg_str = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
-        let err = crate::error::js_referenceerror_new(msg_str);
-        crate::exception::js_throw(js_nanbox_pointer(err as i64));
+        // The HOLE sentinel means this with-set FALLBACK never fired: the
+        // with-env object took the write, so no binding was created *here*.
+        // That does NOT make the name unresolvable — it may still name a real
+        // property of the global object set independently of the `with`
+        // (`globalThis.p1 = 1; with (o) { p1 = 'x1'; } p1` must read back the
+        // global `1`, since `o` owns `p1` and the assignment went to `o`, not
+        // the global — test262 with/S12.10_A1.*). Defer to the same resolution
+        // the bare unqualified-global read uses: return `globalThis[name]` when
+        // present, else throw the spec `ReferenceError: <name> is not defined`.
+        // When the global lacks the name (`var o = {foo:1}; with(o){foo=42} foo`
+        // — with/12.10-0-7), that path throws exactly as before.
+        return crate::error::js_global_get_or_throw_unresolved(name);
     }
     value
 }

--- a/crates/perry/tests/with_implicit_global_fallback.rs
+++ b/crates/perry/tests/with_implicit_global_fallback.rs
@@ -1,0 +1,134 @@
+//! Regression test (#5579, `with`-statement cluster): a bare unqualified read
+//! of a name AFTER a `with` block, where the `with`-set fallback never fired,
+//! must resolve against the global object — not unconditionally throw.
+//!
+//! `with (o) { p1 = 'x1'; }` lowers the assignment to a `WithSet` whose
+//! fallback is a sloppy-implicit global that starts as a HOLE sentinel. When
+//! `o` OWNS `p1`, the write goes to `o` and the sentinel is never replaced. A
+//! later bare `p1` routes through `js_with_implicit_read`, which used to throw
+//! `ReferenceError` whenever the slot was still the HOLE — even when `p1` was a
+//! real own property of `globalThis` set independently of the `with`. Per a
+//! conforming host (and Node's `vm.runInThisContext` Test262 oracle) the read
+//! must observe the global value (`globalThis.p1`). This is the with-statement
+//! analogue of the #5579 global-scope regression
+//! (`language/statements/with/S12.10_A1.*`).
+//!
+//! The fix makes the HOLE path defer to `js_global_get_or_throw_unresolved`,
+//! so a present global property reads back and a genuinely unresolvable name
+//! (`with/12.10-0-7`: `var o = {foo:1}; with(o){foo=42} foo`) still throws.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+#[test]
+fn with_implicit_read_falls_back_to_global() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+// Case 1: the with-env object OWNS the name, so `p1 = 'x1'` writes the object
+// and the sloppy-implicit fallback never fires. The bare `p1` read after the
+// `with` must still see the independently-set global property (=== 1), not
+// throw a ReferenceError off the unfilled HOLE sentinel.
+(globalThis as any).p1 = 1;
+const o1: any = { p1: "a" };
+with (o1) {
+  p1 = "x1";
+}
+if (p1 !== 1) throw new Error("case1: expected p1===1, got " + p1);
+if (o1.p1 !== "x1") throw new Error("case1b: expected o1.p1==='x1', got " + o1.p1);
+console.log("case1-ok");
+
+// Case 2: the global genuinely lacks the name, so the bare read after the
+// `with` must still throw ReferenceError (test262 with/12.10-0-7 preserved).
+const o2: any = { foo: 1 };
+with (o2) {
+  foo = 42;
+}
+let threw = false;
+try {
+  foo;
+} catch (e) {
+  threw = e instanceof ReferenceError;
+}
+if (!threw) throw new Error("case2: expected ReferenceError for unresolved `foo`");
+console.log("case2-ok");
+
+// Case 3: the `with` is nested INSIDE a function, so the sloppy-implicit
+// slot is only declared at module scope by the hoist (the in-body HOLE init
+// lands in the callee's own frame). The hoist must seed that slot with the
+// HOLE sentinel — not `undefined` — so the bare module-scope read still falls
+// back to the global (S12.10_A1.2/A1.3/A3.2).
+(globalThis as any).q1 = 7;
+const o3: any = { q1: "a" };
+function g() {
+  with (o3) {
+    q1 = "z1";
+  }
+}
+g();
+if (q1 !== 7) throw new Error("case3: expected q1===7, got " + q1);
+if (o3.q1 !== "z1") throw new Error("case3b: expected o3.q1==='z1', got " + o3.q1);
+console.log("case3-ok");
+
+// Case 4: function-nested `with` whose env LACKS the name, so the assignment
+// must CREATE the binding (not write a throwaway shadow). The module-scope
+// slot is the one the fallback writes and the later read observes — exercises
+// that the with-set fallback inside a callee targets the module slot, not a
+// function-local shadow (S12.10_A1.2/A1.3 `p5`).
+const o4: any = {}; // no `r1`
+function h() {
+  with (o4) {
+    r1 = "made-global";
+  }
+}
+h();
+if (r1 !== "made-global") throw new Error("case4: expected r1==='made-global', got " + r1);
+console.log("case4-ok");
+
+console.log("ok");
+"#,
+    );
+    assert_eq!(
+        stdout, "case1-ok\ncase2-ok\ncase3-ok\ncase4-ok\nok\n",
+        "with-implicit read must fall back to globalThis, still throwing for truly-unresolved names"
+    );
+}

--- a/crates/perry/tests/with_implicit_global_fallback.rs
+++ b/crates/perry/tests/with_implicit_global_fallback.rs
@@ -124,11 +124,29 @@ h();
 if (r1 !== "made-global") throw new Error("case4: expected r1==='made-global', got " + r1);
 console.log("case4-ok");
 
+// Case 5: a global property explicitly set to `undefined` is PRESENT, so the
+// post-`with` read must observe `undefined` — not mis-throw a ReferenceError
+// off the unfilled HOLE. The fallback resolves by existence, not value.
+(globalThis as any).u1 = undefined;
+const o5: any = { u1: 0 };
+with (o5) {
+  u1 = 1;
+}
+let u1WasUndefined = false;
+try {
+  u1WasUndefined = u1 === undefined;
+} catch (e) {
+  throw new Error("case5: present-but-undefined global must not throw");
+}
+if (!u1WasUndefined) throw new Error("case5: expected u1===undefined");
+if (o5.u1 !== 1) throw new Error("case5b: expected o5.u1===1, got " + o5.u1);
+console.log("case5-ok");
+
 console.log("ok");
 "#,
     );
     assert_eq!(
-        stdout, "case1-ok\ncase2-ok\ncase3-ok\ncase4-ok\nok\n",
+        stdout, "case1-ok\ncase2-ok\ncase3-ok\ncase4-ok\ncase5-ok\nok\n",
         "with-implicit read must fall back to globalThis, still throwing for truly-unresolved names"
     );
 }


### PR DESCRIPTION
## Summary

Fixes the **`with`-statement scope-resolution cluster** of #5579 (~104 newly-failing `language/statements/with/*` cases). A bare unqualified read *after* a `with` block — where the with-set fallback never fired — was throwing `ReferenceError` (or yielding a spurious `undefined`) instead of resolving the name against the **global object**.

### Root cause (not the issue's suspected commits)

The issue ranked #5471 / #5451 (native-instance member reads) as suspects, but those don't touch the `with`/global-this path — the HIR for the failing cases is byte-identical across the regression window. The real trigger is the Test262 subset oracle switching to **global-script semantics** (`vm.runInThisContext`, host-run.cjs, #5346): the Node oracle now runs each case as a Script where top-level `this === globalThis`, so `this.p1 = 1; with (o) { p1 = 'x1'; } p1` must read back the global `1` (since `o` owns `p1`, the assignment went to `o`). Perry instead threw off the unfilled HOLE sentinel or read a hoisted `undefined`.

### Fixes (all scoped to the `with`-fallback path)

1. **runtime `js_with_implicit_read`** — on the HOLE sentinel, defer to `js_global_get_or_throw_unresolved` (return `globalThis[name]` if present, else throw the spec `ReferenceError`) rather than always throwing. `with/12.10-0-7` (global lacks the name) still throws.
2. **`lower_module_fn` hoist** — seed a with-fallback sloppy-implicit's module-scope slot with the **HOLE sentinel**, not `undefined`, so a bare read routes through (1). This is the slot's only declaration site for a function-nested `with`. Plain sloppy implicits (`undeclared = 1` outside any `with`) keep the `undefined` hoist.
3. **`lower_decl::body_stmt`** — stop emitting a function-LOCAL HOLE `Let` that **shadows** the module slot. A fallback write that fires (env lacks the name → creates a global, `with(o){p5='x5'}`) must land in the module/global slot the later read observes, not a throwaway shadow.

### Results

`language/statements/with` differential (with the in-progress `PERRY_GLOBAL_SCRIPT_THIS` foundation applied):

| state | parity |
|---|---|
| global-script-this only | 42.4% |
| + fix (1) | 88.2% |
| + fix (2) | 94.7% |
| + fix (3) | **98.2%** |

**0 new failures** at every step. Remaining 3 are orthogonal: direct-`eval`-with, Proxy with-env record, strict-mode `with`.

### Coordination note

The `with` cluster's *other* half — top-level `this === globalThis` in global-script mode — is the separately-tracked **`PERRY_GLOBAL_SCRIPT_THIS`** work (the global-prop-desc cluster). This PR is the `with`-statement-specific complement and does **not** include that foundation. The new regression test uses explicit `globalThis.x = v`, so it validates these fixes **standalone** (passes on `main` without global-script-this).

## Test

- New `crates/perry/tests/with_implicit_global_fallback.rs` — 4 cases: env-owns read-back, unresolved-still-throws (12.10-0-7), function-nested read-back, function-nested global creation.
- Existing `native_instance_own_property` / `native_instance_prototype_read` (the #5471/#5451 intended behavior) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected `with`-statement implicit global fallback so reads properly distinguish between values supplied by the `with` environment and properties on `globalThis`.
  * Improved resolution behavior when the global property is missing versus explicitly present (including when its value is `undefined`), and fixed initialization behavior for nested scoping cases.

* **Tests**
  * Expanded the `with` implicit global fallback regression coverage with an additional scenario and clearer runtime assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->