### PR TITLE
fix(runtime): #5579 — string-keyed dynamic write to an arguments object clobbered element 0

### DIFF
--- a/crates/perry-runtime/src/value/dyn_index.rs
+++ b/crates/perry-runtime/src/value/dyn_index.rs
@@ -360,6 +360,32 @@ pub extern "C" fn js_dyn_index_set(obj: f64, index: f64, value: f64) -> f64 {
     if !jsval.is_pointer() && !crate::object::is_valid_obj_ptr(raw_ptr as *const u8) {
         return value;
     }
+    // #5579 / Issue #957 (set side): a STRING index (`obj["foo"] = v`) must
+    // route through the ordinary receiver-aware `[[Set]]`, NOT the numeric
+    // element path below. The `index.is_nan() -> idx_i32 = 0` coercion
+    // otherwise sent every string-keyed write to element 0 — for an arguments
+    // object that meant `args["gp"] = v` clobbered `args[0]` (via
+    // `arguments_object_set_index`) and silently dropped the named property, so
+    // test262 propertyHelper's `isWritable(args, name)` (`args[name] = v` with
+    // an untyped `name` param) reported a writable property as non-writable.
+    // #5544 widened unknown-receiver string-key writes onto this helper,
+    // exposing the gap. `js_put_value_set` is the canonical `[[Set]]` the
+    // pre-#5544 path used: it invokes accessor setters with the correct
+    // receiver and honours data-property writability across arrays / arguments
+    // objects / plain objects / typed arrays, mirroring the IndexGet
+    // string-index arm above (`js_object_get_field_by_name_f64`). Numeric
+    // indices keep the fast element path below, so the #5544 perf win stands.
+    let idx_top16 = index.to_bits() >> 48;
+    if idx_top16 == 0x7FFF || idx_top16 == 0x7FF9 {
+        // `target`/`receiver` must be a tagged value, not the raw heap address
+        // (`obj` arrives as a module-slot raw I64 when top16 == 0).
+        let target = if jsval.is_pointer() {
+            obj
+        } else {
+            f64::from_bits(crate::value::js_nanbox_pointer(raw_ptr as i64).to_bits())
+        };
+        return crate::proxy::js_put_value_set(target, index, value, target, 0);
+    }
     let idx_i32 = if index.is_nan() || index.is_infinite() {
         0
     } else {

--- a/crates/perry/tests/issue_5579_arguments_string_key_dyn_set.rs
+++ b/crates/perry/tests/issue_5579_arguments_string_key_dyn_set.rs
@@ -1,0 +1,119 @@
+//! Regression test for #5579: a STRING-keyed write to an `arguments` object
+//! through an untyped receiver (`obj[name] = v` where `obj`/`name` are plain
+//! `any` parameters) must set the *named* property — not clobber element 0.
+//!
+//! Such writes lower to the runtime `js_dyn_index_set` dispatcher. That helper
+//! coerced any non-numeric index to `0` (`index.is_nan() -> idx_i32 = 0`) and
+//! then unconditionally tried `arguments_object_set_index(obj, 0, value)`, so
+//! `args["gp"] = v` on an arguments object wrote `args[0]` and silently dropped
+//! the named property. #5544 widened unknown-receiver string-key writes onto
+//! this path, which surfaced ~33 newly-failing `built-ins/Object/define
+//! Propert{y,ies}` test262 cases (their propertyHelper `isWritable(args, name)`
+//! probe does exactly `args[name] = v` with an untyped `name`, then re-reads
+//! the property and saw the stale value -> "descriptor should be writable").
+//!
+//! The fix mirrors the IndexGet string-index arm: a string index routes through
+//! `js_object_set_field_by_name`, which honours arrays / arguments objects /
+//! plain objects with the correct descriptor + writable semantics. This test
+//! pins the behaviour without a test262 checkout, so it runs in CI.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn arguments_string_key_write_through_untyped_receiver() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+
+    std::fs::write(
+        &entry,
+        r#"
+// Untyped receiver + untyped key — the exact shape test262 propertyHelper's
+// isWritable(obj, name) uses: `obj[name] = v` reaches js_dyn_index_set with a
+// NaN-boxed string index.
+function set(obj: any, name: any, v: any): void { obj[name] = v; }
+function get(obj: any, name: any): any { return obj[name]; }
+
+// (A) defineProperty'd writable own property on `arguments`: the named write
+// must update "gp" and leave element 0 (the first parameter) untouched.
+(function () {
+  Object.defineProperty(arguments, "gp", {
+    value: 1001, writable: true, enumerable: true, configurable: true,
+  });
+  set(arguments, "gp", "X");
+  console.log("A=" + arguments[0] + "," + (arguments as any)["gp"]);
+}(1, 2, 3));
+
+// (B) verifyProperty-style writable probe: read back through getOwnPropertyDescriptor.
+(function () {
+  Object.defineProperty(arguments, "p", {
+    value: 7, writable: true, enumerable: true, configurable: true,
+  });
+  set(arguments, "p", "Y");
+  const d = Object.getOwnPropertyDescriptor(arguments, "p");
+  console.log("B=" + d!.value + "," + get(arguments, "p"));
+}(10, 20));
+
+// (C) a brand-new named property created via the dynamic write must persist.
+(function () {
+  set(arguments, "fresh", 99);
+  console.log("C=" + arguments[0] + "," + (arguments as any)["fresh"]);
+}(5, 6));
+
+// (D) numeric string-keyed write to arguments still addresses the element.
+(function () {
+  set(arguments, "0", "Z");
+  console.log("D=" + arguments[0]);
+}(40, 41));
+
+// (E) plain objects / arrays unaffected (no regression).
+const o: any = {};
+Object.defineProperty(o, "k", { value: 1, writable: true, configurable: true });
+set(o, "k", "OK");
+const a: any = [1, 2, 3];
+set(a, "named", "NM");
+console.log("E=" + o.k + "," + a.named + "," + a[0]);
+"#,
+    )
+    .expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert_eq!(
+        stdout,
+        "A=1,X\n\
+         B=Y,Y\n\
+         C=5,99\n\
+         D=Z\n\
+         E=OK,NM,1\n",
+        "a string-keyed dynamic write to an arguments object must set the named \
+         property (not clobber element 0); node output is the oracle"
+    );
+}


### PR DESCRIPTION
## #5579 — string-keyed dynamic writes to an `arguments` object clobber element 0

Part of the #5579 test262 regression cleanup. This fixes the largest "misc"
sub-cluster: **~34 newly-failing `built-ins/Object/defineProperty[ies]` cases**
(`*-writable*`, `*genericProperty descriptor should be writable*`,
`foo descriptor should not be writable`, `Expected true but got false`).

### Root cause

`js_dyn_index_set` (the runtime dispatcher for `obj[k] = v` where `obj` has
unknown static type) coerced a **non-numeric string index** to `0`
(`index.is_nan() -> idx_i32 = 0`) and then unconditionally tried
`arguments_object_set_index(obj, 0, value)`. For an `arguments` object that
short-circuit **wrote element 0** and returned `true`, silently dropping the
named-property write. So `args["gp"] = v` clobbered `args[0]` and left `gp`
untouched.

test262's `propertyHelper.isWritable(obj, name)` probes writability with
`obj[name] = v` where `name` is an untyped (`any`) parameter, then re-reads the
property — it saw the stale value and reported a *writable* defineProperty'd
property as **non-writable**.

The GET side (`js_dyn_index_get`) already guards this (Issue #957): a string
index routes to `js_object_get_field_by_name_f64` *before* the numeric path. The
SET side was missing the symmetric guard.

### Why it surfaced now (regression window)

`#5544` (`d4e8b140f`, "route untyped typed-array element access through the fast
path") widened codegen so **unknown-receiver, non-statically-string-typed** index
writes route through `js_dyn_index_set`. Before #5544 these `obj[name] = v`
writes went through the generic `js_put_value_set` `[[Set]]`, which handled
string keys correctly. Confirmed by building #5544's parent commit
(`d4e8b140f^`), where the repro passes.

### Fix

Mirror the IndexGet string-index arm: in `js_dyn_index_set`, a string index
(`STRING_TAG` / `SHORT_STRING_TAG`) routes through the canonical
`js_put_value_set` `[[Set]]`. That helper invokes accessor setters with the
correct receiver and honours data-property writability across arrays /
arguments objects / plain objects / typed arrays. Numeric indices keep the fast
element path, so the #5544 perf win stands.

### Validation

Methodology: built a baseline binary at the pre-window commit, ran a direct A/B
(node oracle + baseline-perry + fixed-perry) over the candidate set to isolate
*true* regressions (pass-on-baseline, fail-on-main) from pre-existing gaps.

- **Before:** 36 true regressions in `language/{statements,expressions}/class` +
  `built-ins/{Object,Function}`.
- **After:** 34 resolved (now pass on both baseline and fixed binary). The
  remaining 2 (`static-private-method-and-instance-method-brand-check`) are an
  unrelated private-method brand-check cluster, tracked separately.
- New e2e regression test
  `crates/perry/tests/issue_5579_arguments_string_key_dyn_set.rs` (data property,
  accessor-style probe, fresh property, numeric-string element, and
  plain-object/array no-regression cases) — passes; node is the oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect routing of computed property assignments with string indices. Previously, string-keyed property writes to certain object types, particularly arguments objects, were incorrectly treated as array element operations instead of performing proper property updates. This has been corrected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->