### PR TITLE
fix(codegen): class extending a function base must run the parent constructor (preserve derived identity)

### DIFF
--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -1745,8 +1745,17 @@ fn lower_new_impl(
     // super + applies SelfOnly) or has an explicit body. Drizzle's
     // `BetterSQLiteSession` (explicit ctor) and arrow-field cross-
     // module classes are both load-bearing. Refs #420 / #618 followup.
-    if !has_own_ctor && has_extends && !has_imported_ctor {
-        if builtin_parent_runtime.is_some() || fetch_parent_runtime.is_some() {
+    // `extends_expr` (dynamic-parent, e.g. zod 4's `$constructor`) classes also
+    // need their own field initializers re-applied here — AFTER the parent body
+    // ran via `js_fetch_or_value_super` above. ECMAScript runs derived-class
+    // field initializers after `super()` returns; `has_extends` only covers
+    // static `extends_name`, so include the `extends_expr` case (SelfOnly,
+    // mirroring the explicit-`SuperCall` dynamic-parent arm in this_super_call.rs).
+    if !has_own_ctor && (has_extends || class.extends_expr.is_some()) && !has_imported_ctor {
+        if builtin_parent_runtime.is_some()
+            || fetch_parent_runtime.is_some()
+            || (class.extends_expr.is_some() && !has_extends)
+        {
             apply_field_initializers_recursive(ctx, class_name, FieldInitMode::SelfOnly)?;
         } else if let Some(stop_at) = inherited_ctor_class {
             apply_field_initializers_recursive(

--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -1656,8 +1656,70 @@ fn lower_new_impl(
                     .push((ctor.symbol.clone(), DOUBLE, ctor_param_types));
                 let ctor_ret = ctx.block().call(DOUBLE, &ctor.symbol, &ctor_args);
                 ctx.block().store(DOUBLE, &ctor_ret, &ctor_result_slot);
+                found_inherited_ctor = true;
             }
         } // end !found_inherited_ctor
+
+        // A no-own-ctor class whose parent is a DYNAMIC runtime value
+        // (`class D extends <fn/value> {}`, captured as `extends_expr`) gets
+        // an implicit default derived ctor `constructor(...args){ super(...args) }`.
+        // The inline `new` path above only finds inherited ctors that live in
+        // `ctx.classes` / `imported_class_ctors`; a parent that resolves to a
+        // plain function value at runtime (zod 4's `$constructor` pattern, where
+        // a class extends another `$constructor`-returned function) matches none
+        // of those, so without this branch `super(...)` is never emitted and the
+        // parent function body never runs on the new instance — its
+        // `this.<field> = …` / `Object.defineProperty(this, …)` writes are lost,
+        // and (when the parent function returns its own `this`) the derived
+        // instance is left uninitialized. Mirrors the synthesized-default-ctor
+        // dynamic-parent super in `codegen/method.rs` (the standalone-symbol
+        // path) and the explicit `Expr::SuperCall` dynamic-parent arm in
+        // `expr/this_super_call.rs`: resolve the decl-time-registered parent
+        // value and dispatch it on `this` via `js_fetch_or_value_super`, which
+        // binds IMPLICIT_THIS to the instance for the duration of the call.
+        if !found_inherited_ctor && class.extends_expr.is_some() {
+            if let Some(cid) = ctx.class_ids.get(class_name).copied().filter(|c| *c != 0) {
+                let undef_lit = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+                let parent_val = ctx.block().call(
+                    DOUBLE,
+                    "js_get_dynamic_parent_value",
+                    &[(I32, &cid.to_string())],
+                );
+                let (args_ptr, args_len) = if lowered_args.is_empty() {
+                    ("null".to_string(), "0".to_string())
+                } else {
+                    let buf_reg = ctx.func.alloca_entry_array(DOUBLE, lowered_args.len());
+                    for (i, a_val) in lowered_args.iter().enumerate() {
+                        let slot = ctx
+                            .block()
+                            .gep(DOUBLE, &buf_reg, &[(I64, &format!("{}", i))]);
+                        ctx.block().store(DOUBLE, a_val, &slot);
+                    }
+                    let ptr_reg = ctx.block().next_reg();
+                    ctx.block().emit_raw(format!(
+                        "{} = getelementptr [{} x double], ptr {}, i64 0, i64 0",
+                        ptr_reg,
+                        lowered_args.len(),
+                        buf_reg
+                    ));
+                    (ptr_reg, lowered_args.len().to_string())
+                };
+                let this_box = match ctx.this_stack.last().cloned() {
+                    Some(slot) => ctx.block().load(DOUBLE, &slot),
+                    None => undef_lit.clone(),
+                };
+                let _ = ctx.block().call(
+                    DOUBLE,
+                    "js_fetch_or_value_super",
+                    &[
+                        (DOUBLE, &parent_val),
+                        (DOUBLE, &this_box),
+                        (PTR, &args_ptr),
+                        (I64, &args_len),
+                    ],
+                );
+            }
+        }
     }
 
     // Now that the parent body chain has run (setting `this.config`, etc.),


### PR DESCRIPTION
Clean re-cut of #5610 (which was accidentally opened with `build/latest` as head, so it carried the whole stack and showed as CONFLICTING). This is the single fix `ee9b56559` on top of `origin/main`.

## Problem
For a class with no own constructor that extends a value resolving to a **runtime function** (`class D extends <fnValue> {}`), the inline `new` lowering walked only `ctx.classes` / `imported_class_ctors` for an inherited ctor. A function-value parent matches none, so no implicit `super(...)` was emitted and the parent body never ran on the derived instance — JS's default derived ctor `constructor(...args){ super(...args) }` silently dropped for dynamic-function parents. (The synthesized-ctor and explicit-`SuperCall` paths already handled this via `js_fetch_or_value_super`; the inline path was the lone gap.)

## Fix
When no inherited ctor is found and `class.extends_expr.is_some()`, resolve the decl-time-registered parent value (`js_get_dynamic_parent_value`) and dispatch it on `this` via `js_fetch_or_value_super`. General fix, no library special-casing. +62 lines, one file.

## Tests
`cargo test -p perry-codegen --lib` 128/128, `perry-hir` 196/196. fmt+check clean.

## Follow-up (CodeRabbit on #5610)
Two Major hardening items will land as a follow-up commit here, verified locally: (a) fall back to re-evaluating the `extends` expression when `js_get_dynamic_parent_value` returns `undefined` (else `super()` no-ops), and (b) preserve the `js_fetch_or_value_super` return so a base that returns a new object replaces the constructed `this`. Current tested paths (parent stashed + returns `this`) are unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved class constructor initialization for inheritance, ensuring the correct parent `super`/constructor logic runs reliably in more cases.
  * Added better handling when a class’s parent is determined dynamically at runtime, including proper propagation of initialization for derived classes.
  * Ensures field initializers are correctly re-applied when construction goes through the runtime-based inherited initialization path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->