### PR TITLE
fix(codegen): #5437 — inline method-dispatch tower must build args per-case arity, not one global rest decision

### DIFF
--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -1546,8 +1546,7 @@ pub fn try_lower_property_get_method_call(
                     for ((cls, mname), reg_fname) in ctx.methods.iter() {
                         if reg_fname == fname && mname == property {
                             let key = (cls.clone(), mname.clone());
-                            let has_rest =
-                                matches!(ctx.method_has_rest.get(&key), Some(&true));
+                            let has_rest = matches!(ctx.method_has_rest.get(&key), Some(&true));
                             let decl = ctx.method_param_counts.get(&key).copied().unwrap_or(0);
                             return (has_rest, decl);
                         }
@@ -1757,12 +1756,14 @@ pub fn try_lower_property_get_method_call(
                         }
                         let rest_count = static_user_args.len().saturating_sub(fixed_user);
                         let cap = (rest_count as u32).to_string();
-                        let mut rest_arr =
-                            ctx.block().call(I64, "js_array_alloc", &[(I32, &cap)]);
+                        let mut rest_arr = ctx.block().call(I64, "js_array_alloc", &[(I32, &cap)]);
                         for v in static_user_args.iter().skip(fixed_user) {
                             let blk = ctx.block();
-                            rest_arr =
-                                blk.call(I64, "js_array_push_f64", &[(I64, &rest_arr), (DOUBLE, v)]);
+                            rest_arr = blk.call(
+                                I64,
+                                "js_array_push_f64",
+                                &[(I64, &rest_arr), (DOUBLE, v)],
+                            );
                         }
                         let rest_box = nanbox_pointer_inline(ctx.block(), &rest_arr);
                         case_args.push(rest_box);

--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -1505,21 +1505,19 @@ pub fn try_lower_property_get_method_call(
         }
         if !implementors.is_empty() {
             let recv_box = lower_expr(ctx, object)?;
-            let mut lowered_args: Vec<String> = Vec::with_capacity(args.len() + 1);
-            lowered_args.push(recv_box.clone());
+            // #1758 / epic #1785: the raw user args (no `this`, no issue-#235
+            // padding, no rest-bundling) drive every concrete callee below. A
+            // `perry_static_*` implementor (a class-object value reaching this
+            // instance-method tower — e.g. `class X extends
+            // (make(...)).annotations(y) {}`) must dispatch through
+            // `js_class_static_method_call`, which binds `this` and applies
+            // static arity/rest semantics; the instance-style `fname(recv,
+            // args…)` direct call would pass recv as arg0 and never set
+            // IMPLICIT_THIS (the #1787 broken-tower bug).
+            let mut static_user_args: Vec<String> = Vec::with_capacity(args.len());
             for a in args {
-                lowered_args.push(lower_expr(ctx, a)?);
+                static_user_args.push(lower_expr(ctx, a)?);
             }
-            // #1758 / epic #1785: capture the raw user args (no `this`, no
-            // issue-#235 padding, no rest-bundling) before any of the
-            // instance-calling-convention mangling below. A `perry_static_*`
-            // implementor (a class-object value reaching this instance-method
-            // tower — e.g. `class X extends (make(...)).annotations(y) {}`)
-            // must dispatch through `js_class_static_method_call`, which binds
-            // `this` and applies static arity/rest semantics; the
-            // instance-style `fname(recv, args…)` direct call would pass recv
-            // as arg0 and never set IMPLICIT_THIS (the #1787 broken-tower bug).
-            let static_user_args: Vec<String> = lowered_args[1..].to_vec();
             // Issue #235: pad lowered_args with TAG_UNDEFINED so the callee's
             // default-param desugaring fires when the call site passed fewer
             // args than the method declares. Pre-fix the dispatch tower
@@ -1529,74 +1527,35 @@ pub fn try_lower_property_get_method_call(
             // real heap pointer that hung the dispatch chain on
             // `options.session` deref.
             //
-            // Take max arity across all implementors so the same arg_slices
-            // works for every concrete callee. Implementations with smaller
-            // arity silently ignore extra trailing args at runtime.
-            let mut max_explicit_arity: usize = 0;
-            for (_, fname) in &implementors {
-                for ((cls, mname), reg_fname) in ctx.methods.iter() {
-                    if reg_fname == fname && mname == property {
-                        if let Some(&n) = ctx.method_param_counts.get(&(cls.clone(), mname.clone()))
-                        {
-                            if n > max_explicit_arity {
-                                max_explicit_arity = n;
-                            }
+            // #5437: each implementor of `property` has its OWN declared arity
+            // and rest-ness. The rest-bundle (and default-param padding) MUST be
+            // applied per-implementor, not once globally — otherwise a single
+            // rest-bearing implementor forces EVERY case (including non-rest
+            // ones with more positional params) to receive a single bundled rest
+            // array, dropping the real positional args. That was the Next.js
+            // `f.get(r,u,context)` bug: `get` has rest- and non-rest impls
+            // (`LRUCache.get`/`CacheHandler.get`/`ResponseCache.get`, arities
+            // 1/2/3), so the global rest-bundle truncated `nh.get`'s 3 args into
+            // one array passed as arg0 → `context` (the 3rd param) read 0.0.
+            //
+            // Precompute (has_rest, decl_param_count) per implementor, aligned
+            // with `implementors`; each case block builds its own args below.
+            let impl_meta: Vec<(bool, usize)> = implementors
+                .iter()
+                .map(|(_, fname)| {
+                    for ((cls, mname), reg_fname) in ctx.methods.iter() {
+                        if reg_fname == fname && mname == property {
+                            let key = (cls.clone(), mname.clone());
+                            let has_rest =
+                                matches!(ctx.method_has_rest.get(&key), Some(&true));
+                            let decl = ctx.method_param_counts.get(&key).copied().unwrap_or(0);
+                            return (has_rest, decl);
                         }
-                        break;
                     }
-                }
-            }
-            let target_total = max_explicit_arity + 1; // +1 for `this`
+                    (false, 0)
+                })
+                .collect();
             let undefined_lit = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
-            // Issue #672: bundle trailing args into a rest array on the
-            // dynamic-dispatch path too. Mirrors the static-dispatch arm
-            // below — without it, `conn.command("SET","k","v")` on a
-            // `conn: any` (the @perryts/redis case) reached the callee with
-            // `name="SET"`, `args="k"` and the trailing `"v"` silently
-            // dropped, since the LLVM signature only declares N+1 doubles
-            // and any 4th double is just discarded.
-            let mut method_has_rest_dyn = false;
-            let mut method_decl_count_dyn = max_explicit_arity;
-            for (_, fname) in &implementors {
-                for ((cls, mname), reg_fname) in ctx.methods.iter() {
-                    if reg_fname == fname && mname == property {
-                        let key = (cls.clone(), mname.clone());
-                        if let Some(&true) = ctx.method_has_rest.get(&key) {
-                            method_has_rest_dyn = true;
-                            if let Some(&n) = ctx.method_param_counts.get(&key) {
-                                method_decl_count_dyn = n;
-                            }
-                            break;
-                        }
-                    }
-                }
-                if method_has_rest_dyn {
-                    break;
-                }
-            }
-            if method_has_rest_dyn {
-                let fixed_user = method_decl_count_dyn.saturating_sub(1);
-                while lowered_args.len() - 1 < fixed_user {
-                    lowered_args.push(undefined_lit.clone());
-                }
-                let split_at = 1 + fixed_user;
-                let rest_count = lowered_args.len().saturating_sub(split_at);
-                let cap = (rest_count as u32).to_string();
-                let mut rest_arr = ctx.block().call(I64, "js_array_alloc", &[(I32, &cap)]);
-                for v in &lowered_args[split_at..] {
-                    let blk = ctx.block();
-                    rest_arr = blk.call(I64, "js_array_push_f64", &[(I64, &rest_arr), (DOUBLE, v)]);
-                }
-                let rest_box = nanbox_pointer_inline(ctx.block(), &rest_arr);
-                lowered_args.truncate(split_at);
-                lowered_args.push(rest_box);
-            } else {
-                while lowered_args.len() < target_total {
-                    lowered_args.push(undefined_lit.clone());
-                }
-            }
-            let arg_slices: Vec<(crate::types::LlvmType, &str)> =
-                lowered_args.iter().map(|s| (DOUBLE, s.as_str())).collect();
 
             // Issue #628 followup (#620 in dynamic-dispatch shape): probe
             // own-property override BEFORE the class-id switch tower. The
@@ -1733,7 +1692,11 @@ pub fn try_lower_property_get_method_call(
             }
 
             let mut phi_inputs: Vec<(String, String)> = Vec::new();
-            for ((_, fname), &case_idx) in implementors.iter().zip(case_idxs.iter()) {
+            for (((_, fname), &case_idx), &(impl_has_rest, impl_decl_count)) in implementors
+                .iter()
+                .zip(case_idxs.iter())
+                .zip(impl_meta.iter())
+            {
                 ctx.current_block = case_idx;
                 // #1758: a `perry_static_*` implementor is a STATIC method on a
                 // class-object receiver. Route it through the runtime
@@ -1773,7 +1736,50 @@ pub fn try_lower_property_get_method_call(
                         ],
                     )
                 } else {
-                    ctx.block().call(DOUBLE, fname, &arg_slices)
+                    // #5437: build THIS implementor's args from the raw user
+                    // args (`static_user_args`), applying its own declared arity
+                    // + rest-ness. A non-rest callee gets its positional params
+                    // padded with `undefined`; a rest callee gets the trailing
+                    // args bundled into a single array at its rest slot. This is
+                    // per-case so one rest-bearing sibling can't force the others
+                    // to receive a bundled array in place of positional params.
+                    let mut case_args: Vec<String> = Vec::with_capacity(impl_decl_count + 1);
+                    case_args.push(recv_box.clone());
+                    if impl_has_rest {
+                        let fixed_user = impl_decl_count.saturating_sub(1);
+                        for i in 0..fixed_user {
+                            case_args.push(
+                                static_user_args
+                                    .get(i)
+                                    .cloned()
+                                    .unwrap_or_else(|| undefined_lit.clone()),
+                            );
+                        }
+                        let rest_count = static_user_args.len().saturating_sub(fixed_user);
+                        let cap = (rest_count as u32).to_string();
+                        let mut rest_arr =
+                            ctx.block().call(I64, "js_array_alloc", &[(I32, &cap)]);
+                        for v in static_user_args.iter().skip(fixed_user) {
+                            let blk = ctx.block();
+                            rest_arr =
+                                blk.call(I64, "js_array_push_f64", &[(I64, &rest_arr), (DOUBLE, v)]);
+                        }
+                        let rest_box = nanbox_pointer_inline(ctx.block(), &rest_arr);
+                        case_args.push(rest_box);
+                    } else {
+                        for v in &static_user_args {
+                            case_args.push(v.clone());
+                        }
+                        // Issue #235: pad to the declared arity so the callee's
+                        // default-param desugaring fires for skipped trailing
+                        // params instead of reading an uninitialized arg slot.
+                        while case_args.len() < impl_decl_count + 1 {
+                            case_args.push(undefined_lit.clone());
+                        }
+                    }
+                    let case_arg_slices: Vec<(crate::types::LlvmType, &str)> =
+                        case_args.iter().map(|s| (DOUBLE, s.as_str())).collect();
+                    ctx.block().call(DOUBLE, fname, &case_arg_slices)
                 };
                 let after_label = ctx.block().label.clone();
                 if !ctx.block().is_terminated() {

--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -1488,6 +1488,10 @@ pub fn try_lower_property_get_method_call(
         // C's parent chain and find the FIRST class that has `property`
         // in `ctx.methods`. Register (C's id → that ancestor's fn_name).
         let mut implementors: Vec<(u32, String)> = Vec::new();
+        // #5437: (has_rest, decl_param_count) per implementor, built in the
+        // discovery loop below (aligned 1:1 with `implementors`) so each case
+        // block can build its own per-arity args without rescanning `ctx.methods`.
+        let mut impl_meta: Vec<(bool, usize)> = Vec::new();
         let mut seen_pairs: std::collections::HashSet<(u32, String)> =
             std::collections::HashSet::new();
         for (start_cls, &start_cid) in ctx.class_ids.iter() {
@@ -1496,7 +1500,12 @@ pub fn try_lower_property_get_method_call(
                 let key = (c.clone(), property.clone());
                 if let Some(fname) = ctx.methods.get(&key).cloned() {
                     if seen_pairs.insert((start_cid, fname.clone())) {
+                        // `key` is the exact (defining-class, property) where the
+                        // method resolved, so its arity metadata is available now.
+                        let has_rest = matches!(ctx.method_has_rest.get(&key), Some(&true));
+                        let decl = ctx.method_param_counts.get(&key).copied().unwrap_or(0);
                         implementors.push((start_cid, fname));
+                        impl_meta.push((has_rest, decl));
                     }
                     break;
                 }
@@ -1538,22 +1547,9 @@ pub fn try_lower_property_get_method_call(
             // 1/2/3), so the global rest-bundle truncated `nh.get`'s 3 args into
             // one array passed as arg0 → `context` (the 3rd param) read 0.0.
             //
-            // Precompute (has_rest, decl_param_count) per implementor, aligned
-            // with `implementors`; each case block builds its own args below.
-            let impl_meta: Vec<(bool, usize)> = implementors
-                .iter()
-                .map(|(_, fname)| {
-                    for ((cls, mname), reg_fname) in ctx.methods.iter() {
-                        if reg_fname == fname && mname == property {
-                            let key = (cls.clone(), mname.clone());
-                            let has_rest = matches!(ctx.method_has_rest.get(&key), Some(&true));
-                            let decl = ctx.method_param_counts.get(&key).copied().unwrap_or(0);
-                            return (has_rest, decl);
-                        }
-                    }
-                    (false, 0)
-                })
-                .collect();
+            // (has_rest, decl_param_count) per implementor was built in the
+            // discovery loop above (`impl_meta`, aligned 1:1 with `implementors`);
+            // each case block builds its own per-arity args below.
             let undefined_lit = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
 
             // Issue #628 followup (#620 in dynamic-dispatch shape): probe

--- a/crates/perry/tests/issue_5437_idispatch_per_case_arity.rs
+++ b/crates/perry/tests/issue_5437_idispatch_per_case_arity.rs
@@ -1,0 +1,103 @@
+//! Regression test for #5437 (Next.js `f.get(r, u, context)` wall): the inline
+//! method-dispatch tower (`idispatch`) used a SINGLE arg-bundling decision for
+//! ALL candidate implementors of a method name. When at least one implementor
+//! had a `...rest` param, every case — including non-rest implementors with
+//! more positional params — received the args bundled into a single rest array
+//! passed as arg0, so the other positional params read uninitialized `0.0`.
+//!
+//! In the Next.js bundle, `get` is implemented by `LRUCache.get` (arity 1),
+//! `CacheHandler.get` (arity 2), `ResponseCache.get` (arity 3, the `(key,
+//! responseGenerator, context)` async method) and several rest-bearing webpack
+//! `get`s. The rest-bundle therefore collapsed `nh.get(key, gen, context)` into
+//! `nh.get([key, gen, context])`, leaving `context` (the 3rd param) as `0.0`.
+//! Destructuring `const { incrementalCache } = context` then read off the
+//! number `0.0` → `incrementalCache` undefined → `Cannot read properties of
+//! undefined (reading 'get')` at render time.
+//!
+//! Fix: the dispatch tower builds each case's args from the raw user args
+//! applying THAT implementor's own arity/rest-ness — a non-rest callee gets its
+//! positional params (padded with `undefined`), a rest callee gets the trailing
+//! args bundled at its rest slot.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+/// A method name (`get`) implemented by both a `...rest` class and non-rest
+/// classes with differing positional arity, dispatched on an `any` receiver so
+/// codegen emits the inline class-id switch tower. The 3-arg call must reach
+/// `ThreeArg.get` with all three positional params (pre-fix the 3rd param read
+/// `0.0`), the rest implementor must still receive a bundled array, and the
+/// 1-arg implementor must still see only its first param.
+#[test]
+fn idispatch_tower_uses_per_implementor_arity() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+class WithRest {
+  get(...r: any[]): string { return "rest:" + r.length; }
+}
+class ThreeArg {
+  get(a: any, b: any, c: any): string {
+    return "three:" + String(a) + "," + String(b) + "," + String(c);
+  }
+}
+class OneArg {
+  get(a: any): string { return "one:" + String(a); }
+}
+
+function pick(n: number): any {
+  if (n === 0) return new WithRest();
+  if (n === 1) return new ThreeArg();
+  return new OneArg();
+}
+
+const r0: any = pick(0);
+const r1: any = pick(1);
+const r2: any = pick(2);
+console.log(r0.get(10, 20, 30));
+console.log(r1.get(10, 20, 30));
+console.log(r2.get(10, 20, 30));
+"#,
+    );
+    // node --experimental-strip-types prints exactly this.
+    assert_eq!(stdout, "rest:3\nthree:10,20,30\none:10\n");
+}


### PR DESCRIPTION
## What
Fixes the long-standing Next.js #5437 "wall#1" (`handleGet` → `Cannot read properties of undefined (reading 'get')`) — the deepest defect in the issue, which resisted ~9 prior investigation sessions under wrong framings (capture-fill, GC, await-drop, field-read, async-param). The real root is a **method-dispatch arity bug**, and it's **minimally reproducible** (never scale-only).

## Root cause
When a method name has multiple implementors with mixed arity/rest-ness, the inline dispatch tower (`lower_call/property_get.rs`) made **one global decision**: if *any* implementor had a `...rest` param, it bundled ALL call args into a single array and passed it as arg0 to **every** case. So for `f.get(r, u, context)` where `get` has `LRUCache.get`/1, `CacheHandler.get`/2, `ResponseCache.get`/3, and rest-bearing webpack `get`s, the non-rest `ResponseCache.get(key, gen, context)` received only the bundled array as arg0 — its `gen`/`context` params were never passed and read `0.0`. IR proof: `idispatch.case3: call @…_nh__get(double %r4273, double %r4562)` with `%r4562 = js_array_alloc(3)`. Then `const { incrementalCache } = context` destructured off `0.0` → undefined → the wall.

## Fix
The tower now builds **each case's args according to that implementor's own `(has_rest, decl_param_count)`**: a non-rest callee gets its positional params (padded with `undefined` as needed); a rest callee bundles its trailing args at its rest slot. Per-case instead of one global rest decision. Preserves the existing #235 / #672 / #1758 dispatch behaviors.

## Validation
- **Minimal repro** (the missing ingredient was multi-implementor + mixed-rest, not scale): `WithRest{get(...r)}` + `ThreeArg{get(a,b,c)}` + `OneArg{get(a)}` dispatched on an `any` receiver; `x.get(10,20,30)`. Pre-fix dropped args; post-fix matches node byte-for-byte. Regression test `issue_5437_idispatch_per_case_arity`.
- **Bundle (rigorous gate):** the `reading 'get'` wall is **eliminated (0)**; the render **advances to a new deeper wall** (`get is not a function`, tracked separately) — the downstream advance proving the fix is real, not masking. undefined-ctor=0, getSpan=0 hold; server boots + serves + stays alive.
- `cargo test` perry-codegen/perry-hir green (only the documented pre-existing `non_entry_module_init_body_gets_post_init_shadow_frame` flake); dispatch integration tests (#5139/#5257) + gap dispatch-tower tests pass.

Refs #5437.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dynamic method dispatch so each matching implementation receives arguments according to its own declared parameter list.
  * Correctly supports mixed fixed-arity and rest-parameter methods, including the right `undefined` padding when needed.
  * Ensures rest-parameter implementations receive bundled trailing arguments as expected.
* **Tests**
  * Added a regression test covering dispatch among multiple `get` implementations with different arities and a rest variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->