### PR TITLE
fix(hir): #5579 — fold module-top indirect eval of a declaration-free body to its global completion value

### DIFF
--- a/crates/perry-hir/src/lower/const_fold_fn.rs
+++ b/crates/perry-hir/src/lower/const_fold_fn.rs
@@ -729,17 +729,95 @@ pub(crate) fn try_indirect_eval_general(
     if let Some(throw) = super::eval_super_scan::check_eval_illegal_abrupt(&body_stmts) {
         return Ok(Some(throw));
     }
-    // Do NOT model value-producing execution here. Indirect eval runs as global
-    // code: its body sees only the *global* environment, not any enclosing
-    // module/function bindings. A completion-tracking IIFE necessarily captures
-    // the enclosing scope, so it would wrongly resolve module-scoped `var`s that
-    // are invisible to real global eval (e.g. `(0,eval)("y = x")` must throw
-    // ReferenceError when `x` is a module-local) and wrongly persist `var`/
-    // function/class declarations that belong in the global var environment.
-    // Defer all valid bodies to the runtime global-`eval` thunk. (Only the
-    // parse-/early-error SyntaxError cases above are modeled at compile time.)
+    // Indirect eval runs as *global* code: its body sees only the global
+    // environment, never any enclosing module/function bindings. A completion-
+    // tracking IIFE captures the *enclosing* scope, so it only matches global
+    // eval semantics where the enclosing scope already IS the global scope:
+    // module top level (`scope_depth == 0`, no enclosing class / `with` / ESM)
+    // under global-script mode, where module-top `var`s/functions and `this`
+    // are the global bindings (#5608/#5609). There, fold the body to the shared
+    // completion-value IIFE so `(0,eval)('x = 1')` mutates the global `x` and
+    // yields its completion value (test262 language/eval-code/indirect/
+    // cptn-nrml-expr-*, always-non-strict). The wrapper runs sloppy unless the
+    // body opens with its own Use Strict Directive — indirect eval never
+    // inherits the caller's strictness.
+    //
+    // Anywhere else (nested scope, or default CJS mode), capturing the
+    // enclosing scope would wrongly resolve module/function-locals that real
+    // global eval cannot see, so defer those to the runtime global-`eval`
+    // thunk. (Only the parse-/early-error SyntaxError cases above are modeled.)
+    let module_top_global = super::lower_expr::global_script_this_enabled()
+        && ctx.scope_depth == 0
+        && ctx.current_class.is_none()
+        && ctx.with_env_stack.is_empty()
+        && !ctx.is_external_module;
+    // Only fold a *declaration-free* body. A scope-capturing IIFE places any
+    // `var`/`function`/`class`/`let`/`const` the body declares inside the
+    // wrapper, but real global eval routes them to the global var environment
+    // (`var`/`function`) or the eval's own fresh lexical environment
+    // (`let`/`const`/`class`) — and Perry additionally registers class names at
+    // module scope, so a folded `class C {}` would leak `C` to the top level
+    // (test262 language/eval-code/indirect/lex-env-distinct-cls expects it to
+    // stay invisible). A body with no declarations has no such binding to
+    // misplace; it only reads/assigns the globals it names, which the IIFE
+    // resolves correctly. Any declaration → defer to the runtime thunk.
+    if module_top_global && !eval_body_declares_bindings(&body_stmts) {
+        let eval_strict = crate::lower_decl::body_has_use_strict(&body_stmts);
+        return build_eval_completion_iife(ctx, body_stmts, eval_strict, span);
+    }
     let _ = span;
     Ok(None)
+}
+
+/// Does an (indirect) eval body declare any binding — `var` / `function` /
+/// `class` / `let` / `const` / `using` — anywhere within it? Scans recursively
+/// through every statement form that can nest a declaration (a `var`/`function`
+/// hoists out of blocks, loops, `try`, `switch`, `with`, labeled and `if`
+/// statements), so the answer is conservative: a `true` defers the fold.
+fn eval_body_declares_bindings(stmts: &[ast::Stmt]) -> bool {
+    stmts.iter().any(stmt_declares_binding)
+}
+
+fn stmt_declares_binding(stmt: &ast::Stmt) -> bool {
+    use ast::Stmt;
+    match stmt {
+        Stmt::Decl(_) => true,
+        Stmt::Block(b) => eval_body_declares_bindings(&b.stmts),
+        Stmt::Labeled(l) => stmt_declares_binding(&l.body),
+        Stmt::If(i) => {
+            stmt_declares_binding(&i.cons) || i.alt.as_deref().is_some_and(stmt_declares_binding)
+        }
+        Stmt::For(f) => {
+            matches!(&f.init, Some(ast::VarDeclOrExpr::VarDecl(_)))
+                || stmt_declares_binding(&f.body)
+        }
+        Stmt::ForIn(f) => {
+            matches!(
+                &f.left,
+                ast::ForHead::VarDecl(_) | ast::ForHead::UsingDecl(_)
+            ) || stmt_declares_binding(&f.body)
+        }
+        Stmt::ForOf(f) => {
+            matches!(
+                &f.left,
+                ast::ForHead::VarDecl(_) | ast::ForHead::UsingDecl(_)
+            ) || stmt_declares_binding(&f.body)
+        }
+        Stmt::While(w) => stmt_declares_binding(&w.body),
+        Stmt::DoWhile(d) => stmt_declares_binding(&d.body),
+        Stmt::With(w) => stmt_declares_binding(&w.body),
+        Stmt::Try(t) => {
+            eval_body_declares_bindings(&t.block.stmts)
+                || t.handler
+                    .as_ref()
+                    .is_some_and(|h| eval_body_declares_bindings(&h.body.stmts))
+                || t.finalizer
+                    .as_ref()
+                    .is_some_and(|f| eval_body_declares_bindings(&f.stmts))
+        }
+        Stmt::Switch(s) => s.cases.iter().any(|c| eval_body_declares_bindings(&c.cons)),
+        _ => false,
+    }
 }
 
 pub(crate) fn try_indirect_eval_globalthis(

--- a/crates/perry-hir/src/lower/const_fold_fn.rs
+++ b/crates/perry-hir/src/lower/const_fold_fn.rs
@@ -816,7 +816,16 @@ fn stmt_declares_binding(stmt: &ast::Stmt) -> bool {
                     .is_some_and(|f| eval_body_declares_bindings(&f.stmts))
         }
         Stmt::Switch(s) => s.cases.iter().any(|c| eval_body_declares_bindings(&c.cons)),
-        _ => false,
+        // Statements that cannot introduce a binding. Listed explicitly (no
+        // `_` catch-all) so a future `ast::Stmt` variant that *can* nest a
+        // declaration is a compile error here rather than a silent miss.
+        Stmt::Expr(_)
+        | Stmt::Empty(_)
+        | Stmt::Debugger(_)
+        | Stmt::Return(_)
+        | Stmt::Break(_)
+        | Stmt::Continue(_)
+        | Stmt::Throw(_) => false,
     }
 }
 

--- a/crates/perry/tests/issue_5579_indirect_eval_global_completion.rs
+++ b/crates/perry/tests/issue_5579_indirect_eval_global_completion.rs
@@ -1,0 +1,179 @@
+//! Regression (#5579, residual): in *global-script* mode a module-top-level
+//! indirect `eval` of a constant body — `(0, eval)('<const>')` — must execute
+//! as global code and yield the body's completion value, mutating the global
+//! bindings it names.
+//!
+//! Indirect eval runs in the *global* environment, never the caller's lexical
+//! scope. Perry models a constant eval body with a scope-capturing completion
+//! IIFE (the same mechanism direct eval uses, #1679). For indirect eval that is
+//! only sound where the captured enclosing scope already IS the global scope:
+//! module top level under `PERRY_GLOBAL_SCRIPT_THIS` (where module-top `var`s
+//! and `this` are the global bindings, #5608/#5609). There Perry now folds the
+//! body instead of deferring to the runtime global-`eval` thunk (which returned
+//! `undefined` for any body that wasn't the `this`/`globalThis` idiom), so the
+//! Test262 `language/eval-code/indirect/cptn-nrml-expr-*` and
+//! `always-non-strict` completion-value cases resolve against the script-mode
+//! Node oracle.
+//!
+//! Outside that window — a nested scope, or default CJS mode — capturing the
+//! enclosing scope would wrongly resolve function/module-locals that real
+//! global eval cannot see, so those bodies still defer (this test pins that the
+//! fold is gated to module top level + global-script mode).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+/// Compile `src` and run it. `global_script` toggles `PERRY_GLOBAL_SCRIPT_THIS`.
+/// Returns (clean_exit, stdout).
+fn compile_and_run(src: &str, global_script: bool) -> (bool, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(&entry, src).expect("write entry");
+    let output = dir.path().join("main_bin");
+
+    let mut compile = Command::new(perry_bin());
+    compile
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .env("PERRY_NO_AUTO_OPTIMIZE", "1")
+        // Indirect-eval bodies are classified bucket-3 (runtime-unknown) under
+        // strict-eval; the Test262 harness runs permissively. Mirror it.
+        .env("PERRY_ALLOW_EVAL", "1");
+    if global_script {
+        compile.env("PERRY_GLOBAL_SCRIPT_THIS", "1");
+    } else {
+        compile.env_remove("PERRY_GLOBAL_SCRIPT_THIS");
+    }
+    let compiled = compile.output().expect("run perry compile");
+    assert!(
+        compiled.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&compiled.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    (
+        run.status.success(),
+        String::from_utf8_lossy(&run.stdout).to_string(),
+    )
+}
+
+/// `language/eval-code/indirect/cptn-nrml-expr-prim.js` shape: the completion
+/// value of an indirect eval is its body's expression value, and an assignment
+/// inside the body mutates the *global* (module-top) binding it names.
+const CPTN_PRIM: &str = r#"
+var x;
+console.log("assign:", (0, eval)("x = 1"));   // AssignmentExpression -> 1
+console.log("num:", (0, eval)("1"));          // NumericLiteral      -> 1
+console.log("str:", (0, eval)("'1'"));        // StringLiteral       -> '1'
+x = 1;
+console.log("update:", (0, eval)("++x"));     // UpdateExpression    -> 2
+console.log("x.after:", x);                   // global x mutated    -> 2
+console.log("DONE");
+"#;
+
+#[test]
+fn indirect_eval_completion_value_global_script() {
+    let (ok, out) = compile_and_run(CPTN_PRIM, /* global_script */ true);
+    assert!(ok, "binary did not exit cleanly\n{out}");
+    assert!(
+        out.contains("assign: 1"),
+        "x = 1 completion must be 1\n{out}"
+    );
+    assert!(out.contains("num: 1"), "`1` completion must be 1\n{out}");
+    assert!(
+        out.contains("str: 1"),
+        "`'1'` completion must be '1'\n{out}"
+    );
+    assert!(
+        out.contains("update: 2"),
+        "`++x` completion must be 2\n{out}"
+    );
+    assert!(
+        out.contains("x.after: 2"),
+        "indirect eval must mutate the global `x`\n{out}"
+    );
+}
+
+/// `cptn-nrml-expr-obj.js` shape: the eval body reads a global object and the
+/// completion is that very object (identity preserved).
+const CPTN_OBJ: &str = r#"
+var x = { tag: "obj" };
+var y;
+console.log("yx:", (0, eval)("y = x") === x);  // AssignmentExpression -> x
+console.log("id:", (0, eval)("x") === x);      // IdentifierReference  -> x
+console.log("y:", y === x);                     // global y was set     -> true
+console.log("DONE");
+"#;
+
+#[test]
+fn indirect_eval_object_identity_global_script() {
+    let (ok, out) = compile_and_run(CPTN_OBJ, /* global_script */ true);
+    assert!(ok, "binary did not exit cleanly\n{out}");
+    assert!(
+        out.contains("yx: true"),
+        "`y = x` completion must be x\n{out}"
+    );
+    assert!(out.contains("id: true"), "`x` completion must be x\n{out}");
+    assert!(
+        out.contains("y: true"),
+        "global `y` must be assigned x\n{out}"
+    );
+}
+
+/// Indirect eval is *always sloppy* (no inherited strictness), so a body that
+/// only a sloppy context admits — `with`, an undeclared assignment — runs and
+/// its side effects land. (`language/eval-code/indirect/always-non-strict.js`
+/// minus the strict-reserved-word `var static` line, a separate gap.)
+const NON_STRICT: &str = r#"
+var count = 0;
+(0, eval)('with ({}) {} count += 1;');
+(0, eval)('unresolvable = null; count += 1;');
+console.log("count:", count);  // -> 2
+console.log("DONE");
+"#;
+
+#[test]
+fn indirect_eval_is_always_sloppy_global_script() {
+    let (ok, out) = compile_and_run(NON_STRICT, /* global_script */ true);
+    assert!(ok, "binary did not exit cleanly\n{out}");
+    assert!(
+        out.contains("count: 2"),
+        "both sloppy bodies must run\n{out}"
+    );
+}
+
+/// The fold is gated to module top level: an indirect eval inside a function
+/// must NOT capture that function's locals (real global eval cannot see them).
+/// Here the inner `local` is invisible to the indirect eval, so reading it is a
+/// ReferenceError — the program exits non-zero. (Pins that the completion IIFE
+/// is not applied at nested scope, where it would wrongly resolve `local`.)
+const NESTED_NOT_FOLDED: &str = r#"
+function f() {
+  var local = 7;
+  return (0, eval)("typeof local");  // global eval can't see `local`
+}
+console.log("typeof:", f());  // -> "undefined", never "number"
+console.log("DONE");
+"#;
+
+#[test]
+fn indirect_eval_nested_does_not_capture_locals() {
+    let (ok, out) = compile_and_run(NESTED_NOT_FOLDED, /* global_script */ true);
+    // Either Perry defers to the runtime thunk (typeof -> "undefined") or the
+    // body resolves against the global env; in no case may it see the function
+    // local `local` as a "number".
+    assert!(ok, "binary did not exit cleanly\n{out}");
+    assert!(
+        !out.contains("typeof: number"),
+        "indirect eval must not capture the enclosing function's `local`\n{out}"
+    );
+}

--- a/crates/perry/tests/issue_5579_indirect_eval_global_completion.rs
+++ b/crates/perry/tests/issue_5579_indirect_eval_global_completion.rs
@@ -153,9 +153,10 @@ fn indirect_eval_is_always_sloppy_global_script() {
 
 /// The fold is gated to module top level: an indirect eval inside a function
 /// must NOT capture that function's locals (real global eval cannot see them).
-/// Here the inner `local` is invisible to the indirect eval, so reading it is a
-/// ReferenceError — the program exits non-zero. (Pins that the completion IIFE
-/// is not applied at nested scope, where it would wrongly resolve `local`.)
+/// Here the inner `local` is invisible to the indirect eval, so `typeof local`
+/// resolves as `"undefined"` in global scope and the program exits cleanly.
+/// (Pins that the completion IIFE is not applied at nested scope, where it would
+/// wrongly resolve `local` to its `number` value.)
 const NESTED_NOT_FOLDED: &str = r#"
 function f() {
   var local = 7;
@@ -168,10 +169,14 @@ console.log("DONE");
 #[test]
 fn indirect_eval_nested_does_not_capture_locals() {
     let (ok, out) = compile_and_run(NESTED_NOT_FOLDED, /* global_script */ true);
-    // Either Perry defers to the runtime thunk (typeof -> "undefined") or the
-    // body resolves against the global env; in no case may it see the function
-    // local `local` as a "number".
     assert!(ok, "binary did not exit cleanly\n{out}");
+    // Positive expectation: the body resolves against the global env (where
+    // `local` does not exist), so `typeof local` is `"undefined"` — never the
+    // function local's `number` value.
+    assert!(
+        out.contains("typeof: undefined") && out.contains("DONE"),
+        "indirect eval should resolve `typeof local` as \"undefined\" in global scope\n{out}"
+    );
     assert!(
         !out.contains("typeof: number"),
         "indirect eval must not capture the enclosing function's `local`\n{out}"


### PR DESCRIPTION
## What

Closes part of #5579 (residual `language/eval-code/indirect` cluster).

Indirect eval `(0, eval)('<const>')` runs as **global** code, but Perry's general indirect-eval path deferred every valid body to the runtime global-`eval` thunk — which only models the `this`/`globalThis` idiom and returns `undefined` for everything else. So `(0,eval)('x = 1')` yielded `undefined` instead of `1` and never mutated the global `x`, diverging from the script-mode Node oracle (`vm.runInThisContext`, #5346/#5511).

## How

Perry already models a constant **direct** eval body with a scope-capturing completion IIFE (#1679). For indirect eval that IIFE is only sound where the captured enclosing scope already **is** the global scope: module top level (`scope_depth == 0`, no enclosing class / `with` / ESM) under `PERRY_GLOBAL_SCRIPT_THIS`, where module-top `var`s and `this` are the global bindings (#5608/#5609). There `try_indirect_eval_general` now folds the body via the shared `build_eval_completion_iife` (sloppy unless the body opens with its own Use Strict Directive — indirect eval never inherits the caller's strictness).

The fold is restricted to **declaration-free** bodies. A scope-capturing IIFE places any `var`/`function`/`class`/`let`/`const` the body declares inside the wrapper, but real global eval routes `var`/`function` to the global var environment and `let`/`const`/`class` to the eval's own fresh lexical environment — and Perry additionally registers class names at module scope, so a folded `class C {}` would leak `C` to the top level (breaking `indirect/lex-env-distinct-cls`). A new recursive `eval_body_declares_bindings` scan (through blocks, loops, `try`, `switch`, `with`, labeled and `if` statements where `var`/`function` hoist) gates this; any declaration defers to the runtime thunk exactly as before.

## Validation

- **Test262 `language/eval-code/indirect`: +2** (`cptn-nrml-expr-prim`, `cptn-nrml-expr-obj`) with **0 regressions** across `language/eval-code` (47→45 fails) and `annexB/language/eval-code` (100→100, declaration-bearing annexB function-hoisting bodies unchanged), measured against a clean baseline binary built from `main`.
- Outside global-script mode (the default, and every standalone `node --experimental-strip-types` parity build) behavior is **byte-for-byte unchanged**.
- New regression test `crates/perry/tests/issue_5579_indirect_eval_global_completion.rs` (4 cases): completion values + global mutation, object identity, always-sloppy `with`/undeclared-assignment side effects, and that a nested-scope indirect eval does **not** capture the enclosing function's locals.
- Existing eval/script regression suites green (`issue_5206_deferred_eval_runtime_error`, `issue_5579_global_script_this_prop_desc`, `issue_5579_script_global_function_reflection`), full `perry-hir` test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indirect `eval` completion handling in true global-script / module top-level cases by folding completion values more precisely.
  * Folding is now restricted to declaration-free eval bodies; when declarations or disallowed context are present, behavior is deferred to runtime to avoid incorrect scope capture.

* **Tests**
  * Added regression coverage for indirect `eval` completion behavior, including global mutations, returned object identity, sloppy-mode behavior, and ensuring no function-local bindings are observed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->