### PR TITLE
fix(runtime): #5625 — array own-accessor setter dispatch + /u-mode legacy-escape rejection

### DIFF
--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -497,6 +497,43 @@ pub extern "C" fn js_object_set_field_by_name(
                 crate::array::js_array_set_f64_extend(arr, index, value);
                 return;
             }
+            // Own-accessor short-circuit — an Array can carry a named accessor
+            // property installed via `Object.defineProperty(arr, k, {get,set})`.
+            // A `[[Set]]` on such a property must invoke the setter (a
+            // getter-only accessor is read-only), exactly as the generic-object
+            // path below does. The array branch otherwise dropped the write at
+            // the writable gate (an accessor has no `[[Writable]]`) and never
+            // ran the setter (test262 Object/defineProperty + defineProperties
+            // accessor-on-Array cases, e.g. 15.2.3.6-4-278).
+            //
+            // Gated on the per-array `OBJ_FLAG_ARRAY_DESCRIPTORS` flag (the
+            // ArrayHeader analogue of `object_has_descriptors` — the ObjectHeader
+            // `OBJ_FLAG_HAS_DESCRIPTORS` is never set for an ArrayHeader). The
+            // flag is set unconditionally by `define_array_property` whenever any
+            // descriptor is installed on the array and travels with it across
+            // evacuation; `ACCESSOR_DESCRIPTORS` is keyed by raw address, so a
+            // fresh array reusing a freed address (its `_reserved` zeroed at
+            // allocation) skips this lookup and can't fire a previous tenant's
+            // stale accessor.
+            if ACCESSORS_IN_USE.with(|c| c.get())
+                && (*gc_header)._reserved & crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS != 0
+            {
+                if let Some(acc) = get_accessor_descriptor(obj as usize, name) {
+                    if acc.set != 0 {
+                        let closure = (acc.set & crate::value::POINTER_MASK)
+                            as *const crate::closure::ClosureHeader;
+                        if !closure.is_null() {
+                            let receiver = crate::value::js_nanbox_pointer(obj as i64);
+                            let previous_this = super::js_implicit_this_set(receiver);
+                            crate::closure::js_closure_call1(closure, value);
+                            super::js_implicit_this_set(previous_this);
+                        }
+                    } else {
+                        crate::error::throw_immutable_write(0, name);
+                    }
+                    return;
+                }
+            }
             if let Some(attrs) = super::get_property_attrs(obj as usize, name) {
                 if !attrs.writable() {
                     return;

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -49,7 +49,9 @@ use exec_array::{
     set_exec_array_indices_fancy, set_exec_array_metadata,
 };
 #[cfg(feature = "regex-engine")]
-use grammar::{has_invalid_repeated_quantifier, js_regex_to_rust};
+use grammar::{
+    has_invalid_repeated_quantifier, has_unicode_forbidden_legacy_escape, js_regex_to_rust,
+};
 #[cfg(feature = "regex-engine")]
 pub use match_all::{
     dispatch_regexp_string_iterator_method, js_string_match_all, js_string_match_all_value,
@@ -427,6 +429,17 @@ pub extern "C" fn js_regexp_new(
     // the regex crate fails but fancy-regex succeeds; check both here.
     {
         if has_invalid_repeated_quantifier(pattern_str) {
+            throw_regexp_syntax_error(&format!(
+                "Invalid regular expression: /{}/: invalid pattern",
+                pattern_str
+            ));
+        }
+        // Annex B.1.4 legacy escapes (`\1` non-backref octal, `\0DD`, `\8`/`\9`,
+        // `\c` without a control letter) are accepted in sloppy patterns but are
+        // a hard SyntaxError under the `/u` (and `/v`) flag — `js_regex_to_rust`
+        // would otherwise silently relax them. (test262 RegExp/
+        // unicode_restricted_octal_escape + unicode_restricted_identity_escape_c)
+        if unicode && has_unicode_forbidden_legacy_escape(pattern_str) {
             throw_regexp_syntax_error(&format!(
                 "Invalid regular expression: /{}/: invalid pattern",
                 pattern_str

--- a/crates/perry-runtime/src/regex/grammar.rs
+++ b/crates/perry-runtime/src/regex/grammar.rs
@@ -96,6 +96,63 @@ fn is_forward_backreference(spans: &[CaptureSpan], escape_pos: usize, group: usi
     span.close == usize::MAX || escape_pos < span.close
 }
 
+/// Annex B.1.4 does NOT apply to Unicode-mode (`/u` or `/v`) patterns: the
+/// legacy escapes that `js_regex_to_rust` silently relaxes for sloppy patterns
+/// (a `LegacyOctalEscapeSequence`, a `NonOctalDecimalEscapeSequence`, or a `\c`
+/// not followed by an ASCII control letter) are a hard `SyntaxError` under
+/// `/u`. Returns `true` if `pattern` contains any such escape, so the caller
+/// can throw at construction instead of compiling a relaxed pattern.
+///
+/// Mirrors exactly the escapes the sloppy-mode translator would reinterpret:
+/// any other escape (a valid backreference, `\d`, `\x41`, `\u{…}`, an escaped
+/// metacharacter, …) is left for the normal translation path.
+pub(super) fn has_unicode_forbidden_legacy_escape(pattern: &str) -> bool {
+    let chars: Vec<char> = pattern.chars().collect();
+    let spans = collect_capture_spans(&chars);
+    let num_groups = spans.len();
+    let mut in_class = false;
+    let mut i = 0;
+    while i < chars.len() {
+        match chars[i] {
+            '\\' if i + 1 < chars.len() => {
+                match chars[i + 1] {
+                    // `\c` is a valid control escape only when followed by an
+                    // ASCII control letter (`A`–`Z` / `a`–`z`); anything else
+                    // (a digit, `_`, a non-ASCII letter, end-of-pattern) is the
+                    // Annex B identity escape, forbidden under `/u`.
+                    'c' if !matches!(chars.get(i + 2), Some(c) if c.is_ascii_alphabetic()) => {
+                        return true;
+                    }
+                    // `\0` is the NUL escape (valid under `/u`) only when not
+                    // followed by a decimal digit; `\0DD` is a legacy octal.
+                    '0' if matches!(chars.get(i + 2), Some(c) if c.is_ascii_digit()) => {
+                        return true;
+                    }
+                    // `\1`–`\9`: a backreference to an existing group is valid;
+                    // anything else is a legacy octal / non-octal decimal escape.
+                    // Inside a class a decimal escape is never a backreference.
+                    '1'..='9' => {
+                        let (group, _) = parse_decimal_escape(&chars, i + 1);
+                        if in_class || group == 0 || group > num_groups {
+                            return true;
+                        }
+                    }
+                    _ => {}
+                }
+                // Any backslash escape consumes the following char, so `\[`,
+                // `\]`, and `\\` never toggle class state.
+                i += 2;
+                continue;
+            }
+            '[' => in_class = true,
+            ']' => in_class = false,
+            _ => {}
+        }
+        i += 1;
+    }
+    false
+}
+
 fn is_regex_identity_escape(ch: char) -> bool {
     matches!(
         ch,

--- a/test-files/test_issue_5625_regexp_unicode_legacy_escape.ts
+++ b/test-files/test_issue_5625_regexp_unicode_legacy_escape.ts
@@ -1,0 +1,66 @@
+// #5625: Annex B.1.4 legacy RegExp escapes are NOT applied under the `/u`
+// (and `/v`) flag — they must throw a SyntaxError at construction instead of
+// being silently relaxed the way #5594 relaxes them for sloppy patterns.
+// (test262 built-ins/RegExp/unicode_restricted_octal_escape +
+// unicode_restricted_identity_escape_c)
+
+function throwsSyntax(name: string, fn: () => void) {
+  try {
+    fn();
+  } catch (e) {
+    if (e instanceof SyntaxError) {
+      console.log(name + ": ok");
+      return;
+    }
+    throw new Error(name + ": expected SyntaxError, got " + e);
+  }
+  throw new Error(name + ": expected SyntaxError, none thrown");
+}
+
+function ok(name: string, value: boolean) {
+  if (!value) {
+    throw new Error(name);
+  }
+  console.log(name + ": ok");
+}
+
+// Decimal escapes without a matching capture group are forbidden under /u.
+throwsSyntax("octal-1-u", () => { new RegExp("\\1", "u"); });
+throwsSyntax("octal-7-u", () => { new RegExp("\\7", "u"); });
+throwsSyntax("octal-8-u", () => { new RegExp("\\8", "u"); });
+throwsSyntax("octal-9-u", () => { new RegExp("\\9", "u"); });
+throwsSyntax("octal-class-1-u", () => { new RegExp("[\\1]", "u"); });
+throwsSyntax("octal-class-7-u", () => { new RegExp("[\\7]", "u"); });
+
+// Leading-zero legacy octal forms `\0DD`.
+throwsSyntax("octal-00-u", () => { new RegExp("\\00", "u"); });
+throwsSyntax("octal-07-u", () => { new RegExp("\\07", "u"); });
+throwsSyntax("octal-class-00-u", () => { new RegExp("[\\00]", "u"); });
+
+// `\c` not followed by an ASCII control letter is forbidden under /u.
+throwsSyntax("control-bare-u", () => { new RegExp("\\c", "u"); });
+throwsSyntax("control-digit-u", () => { new RegExp("\\c1", "u"); });
+throwsSyntax("control-underscore-u", () => { new RegExp("\\c_", "u"); });
+throwsSyntax("control-class-bare-u", () => { new RegExp("[\\c]", "u"); });
+const cyrillic = String.fromCharCode(0x0410);
+throwsSyntax("control-cyrillic-u", () => { new RegExp("\\c" + cyrillic, "u"); });
+
+// The `/v` (unicodeSets) flag is just as strict.
+throwsSyntax("octal-1-v", () => { new RegExp("\\1", "v"); });
+throwsSyntax("control-bare-v", () => { new RegExp("\\c", "v"); });
+
+// Constructs that stay VALID under /u must not be rejected:
+//  - a real backreference to an existing group,
+ok("backref-u-ok", new RegExp("(a)\\1", "u").test("aa"));
+//  - bare `\0` (NUL) when not followed by a decimal digit,
+ok("nul-u-ok", new RegExp("\\0", "u").test(String.fromCharCode(0)));
+//  - a valid `\cA` control escape,
+ok("control-A-u-ok", new RegExp("\\cA", "u").test(String.fromCharCode(1)));
+//  - ordinary character-class escapes.
+ok("digit-class-u-ok", new RegExp("[\\d]", "u").test("5"));
+
+// And in sloppy (non-/u) mode the Annex B relaxation from #5594 still holds.
+ok("octal-1-sloppy-ok", /\1/.source === "\\1");
+// `\c` with no control letter lowers to the literal two chars `\` + `c`
+// (#5594), so the pattern matches the string "\c".
+ok("control-bare-sloppy-ok", new RegExp("\\c").test("\\c"));


### PR DESCRIPTION
Fixes the net-new test262 regressions reported in #5625 surfaced by the #5579 fix batch.

## 1. `Object.defineProperty` / `defineProperties` accessor on an Array/Arguments receiver (15 cases)

Writing through a setter installed on an Array via `Object.defineProperty(arr, "p", {get, set})` silently dropped the write: the `GC_TYPE_ARRAY` branch of `js_object_set_field_by_name` had **no own-accessor short-circuit**, so the accessor (which has no `[[Writable]]`) hit the writable gate and the setter never ran. `verifyWritable` in `propertyHelper.js` then reported the property "not writable".

Fix: dispatch the own-accessor setter (or throw on a getter-only accessor) in the array SET branch, mirroring what the generic-object SET path and the array GET path already do. Gated only on `ACCESSORS_IN_USE` — the `object_has_descriptors` flag lives in the `ObjectHeader` and does not apply to an `ArrayHeader` receiver, which is exactly why the array GET path also omits it.

Recovers: `defineProperty/15.2.3.6-4-278, -285, -531-11, -540-7, -547-3` and `defineProperties/15.2.3.7-6-a-267, -268, -274..-277, -279, -286..-288`.

## 2. RegExp Annex B.1.4 legacy escapes under `/u` (and `/v`) (2 cases)

#5594 relaxed legacy escapes (`\1` non-backref → octal, `\0DD`, `\8`/`\9`, invalid `\c`) for sloppy patterns, but these must still throw `SyntaxError` under Unicode mode. Added `has_unicode_forbidden_legacy_escape()` and reject in `js_regexp_new` when the unicode flag is set; the sloppy-mode relaxation from #5594 is unchanged.

Recovers: `RegExp/unicode_restricted_octal_escape`, `RegExp/unicode_restricted_identity_escape_c`.

## 3. TypedArray `speciesctor` sub-cluster — no change needed

`%TypedArray%.prototype.slice`/`map`/`subarray` already throw the expected `TypeError` for a non-object `constructor` on current `main`. Verified by assembling and running the actual test262 cases (all pass, exit 0) — this sub-cluster is not a live runtime regression.

## Validation

- All 15 `defineProperty`/`defineProperties` cases: **15/15 pass** (assembled with `sta.js`+`assert.js`+`propertyHelper.js`).
- Both `/u` regex cases + the 4 TypedArray cases: **6/6 pass**.
- Existing accessor/regex fixtures (`test_issue_5594`, `test_issue_450_defineProperty_accessor`, `test_gap_2442/2817 object accessors`, `test_getters_setters`, `test_issue_2060 typed-array accessor descriptors`, …) still match Node byte-for-byte.
- The handful of unrelated gap-test divergences in the area (TypedArray `.sort(null)` validation, Date `toLocaleString` dispatch, top-level-await, object-literal symbol setter) were confirmed **pre-existing** against a baseline build with these changes stashed.

Adds regression test `test-files/test_issue_5625_regexp_unicode_legacy_escape.ts`. No version bump / changelog entry (left to maintainer at merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RegExp handling in Unicode (`/u`) and Unicode sets (`/v`) modes: disallowed Annex B legacy escape sequences now fail during `RegExp` construction with a `SyntaxError`.
  * Refined array property assignment behavior to better honor own-accessor setters, including correct handling of getter-only accessors.
* **Tests**
  * Added targeted test coverage for Unicode-mode legacy RegExp escapes, including both newly rejected invalid patterns and still-valid cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->