### PR TITLE
fix(native-abi): #5626 — add `json` manifest param that JSON-serializes objects at the FFI boundary

### DIFF
--- a/crates/perry-api-manifest/src/native_abi.rs
+++ b/crates/perry-api-manifest/src/native_abi.rs
@@ -217,6 +217,13 @@ pub enum NativeAbiType {
     JsValue,
     /// JavaScript string passed/returned through a raw runtime string pointer.
     String,
+    /// JavaScript value serialized to a JSON string before the call. The arg is
+    /// run through `JSON.stringify` at the call site and the resulting runtime
+    /// string pointer is passed in a single `string` ABI slot, so the native
+    /// side receives a `*const StringHeader` it can `serde_json`-deserialize —
+    /// identical wire shape to [`NativeAbiType::String`], but the JS argument
+    /// may be an object, array, or any other serializable value. Param-only.
+    Json,
     /// JavaScript truthiness lowered to a C `i32` boolean slot.
     Bool,
     /// Signed 32-bit integer slot.
@@ -271,6 +278,7 @@ impl NativeAbiType {
         match lower.as_str() {
             "jsvalue" | "js_value" => Ok(Self::JsValue),
             "string" => Ok(Self::String),
+            "json" => Ok(Self::Json),
             "bool" | "boolean" => Ok(Self::Bool),
             "i32" => Ok(Self::I32),
             "i64" => Ok(Self::I64),
@@ -328,6 +336,7 @@ impl NativeAbiType {
         match self {
             Self::JsValue => "jsvalue",
             Self::String => "string",
+            Self::Json => "json",
             Self::Bool => "bool",
             Self::I32 => "i32",
             Self::I64 => "i64",
@@ -439,7 +448,7 @@ impl NativeAbiType {
     pub fn is_valid_return(&self) -> bool {
         !matches!(
             self,
-            Self::BufferAndLen | Self::Pod(_) | Self::PodAndCount(_) | Self::HandleId
+            Self::BufferAndLen | Self::Pod(_) | Self::PodAndCount(_) | Self::HandleId | Self::Json
         )
     }
 
@@ -451,7 +460,7 @@ impl NativeAbiType {
             Self::Bool => "boolean",
             Self::Void => "void",
             Self::Promise(_) => "Promise<any>",
-            Self::Handle(_) | Self::Ptr | Self::JsValue => "any",
+            Self::Handle(_) | Self::Ptr | Self::JsValue | Self::Json => "any",
             Self::Pod(_) => "object",
             Self::PodAndCount(_) => "PerryPodView<any>",
             Self::BufferAndLen => "Buffer",
@@ -543,3 +552,28 @@ impl fmt::Display for NativeAbiParseError {
 }
 
 impl std::error::Error for NativeAbiParseError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_descriptor_parses_and_is_param_only() {
+        // #5626: `"json"` is an opt-in param type that JSON-serializes its JS
+        // argument into a single `string` ABI slot at the call site.
+        let json = NativeAbiType::parse_str("json").expect("json must parse");
+        assert_eq!(json, NativeAbiType::Json);
+        assert_eq!(json.canonical_kind(), "json");
+        assert_eq!(json.to_string(), "json");
+        // Whitespace/case insensitivity, matching the other spellings.
+        assert_eq!(NativeAbiType::parse_str("  JSON ").unwrap(), json);
+
+        // One ABI slot, JS-facing `any`, valid as a param but not as a return.
+        assert_eq!(json.abi_slot_count(), 1);
+        assert_eq!(json.js_type_name(), "any");
+        assert!(json.is_valid_param());
+        assert!(!json.is_valid_return());
+        // Not a scalar POD field.
+        assert!(!json.is_valid_pod_field());
+    }
+}

--- a/crates/perry-codegen/src/lower_call/extern_func.rs
+++ b/crates/perry-codegen/src/lower_call/extern_func.rs
@@ -845,6 +845,28 @@ fn lower_manifest_param(
             lowered.push(ptr_val);
             arg_types.push(PTR);
         }
+        NativeAbiType::Json => {
+            // #5626: the JS argument (object/array/primitive) is serialized to
+            // a JSON string at the call site, then passed through the same
+            // single `string` ABI slot as `NativeAbiType::String`. The native
+            // side receives a `*const StringHeader` and `serde_json`-decodes it.
+            // `type_hint` 0 == TYPE_UNKNOWN (let the runtime classify the value).
+            let blk = ctx.block();
+            let raw_ptr = blk.call(I64, "js_json_stringify", &[(DOUBLE, val), (I32, "0")]);
+            let ptr_val = blk.inttoptr(I64, &raw_ptr);
+            let native = LoweredValue::native_handle(raw_ptr);
+            record_native_abi_param(
+                ctx,
+                descriptor,
+                js_argument_index,
+                abi_slot_index,
+                &native,
+                Some(("js_json_stringify", "json_serialized_string")),
+                "json.stringified_pointer",
+            );
+            lowered.push(ptr_val);
+            arg_types.push(PTR);
+        }
         NativeAbiType::Bool => {
             let raw = ctx.block().call(I32, "js_is_truthy", &[(DOUBLE, val)]);
             let native = LoweredValue::i32(raw.clone());

--- a/crates/perry-codegen/src/native_value/verify.rs
+++ b/crates/perry-codegen/src/native_value/verify.rs
@@ -675,6 +675,7 @@ fn valid_runtime_guard_helper(kind: &str, helper: &str) -> bool {
     match kind {
         "jsvalue" => false,
         "string" => helper == "js_native_abi_check_string_ptr",
+        "json" => helper == "js_json_stringify",
         "bool" => helper == "js_is_truthy",
         "i32" => helper == "js_native_abi_check_i32",
         "i64" | "i64_str" => helper == "js_native_abi_check_i64",

--- a/crates/perry-codegen/tests/native_proof_regressions.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions.rs
@@ -1916,6 +1916,56 @@ fn native_library_manifest_lowercase_abi_params_emit_c_abi_signature() {
     }
 }
 
+#[test]
+fn native_library_manifest_json_param_serializes_before_call() {
+    // #5626: a `"json"` manifest param JSON-serializes its JS argument at the
+    // call site (via `js_json_stringify`) and passes the resulting string
+    // pointer through a single `ptr` ABI slot — identical wire shape to a
+    // `"string"` param, so the native side `serde_json`-deserializes it
+    // unchanged. This is what lets descriptor-object bindings (e.g.
+    // `deviceCreateBuffer(d, { size, usage })`) work after #5621 rewrote the
+    // call site directly to the FFI symbol, bypassing the TS wrapper body that
+    // used to do the `JSON.stringify`.
+    let opts = native_library_opts(vec![("native_take_descriptor", vec!["i64", "json"], "i64")]);
+    let module = module(
+        "native_library_json_param.ts",
+        vec![Stmt::Return(Some(extern_call(
+            "native_take_descriptor",
+            vec![Expr::Number(7.0), Expr::Number(42.0)],
+            Type::Number,
+        )))],
+    );
+    let ir = String::from_utf8(compile_module(&module, opts.clone()).unwrap()).unwrap();
+
+    assert!(
+        ir.contains("call i64 @js_json_stringify(")
+            // The serialized descriptor occupies a `ptr` ABI slot, like `string`.
+            && ir.contains("declare i64 @native_take_descriptor(i64, ptr)"),
+        "expected json manifest param to stringify and pass a string pointer:\n{ir}"
+    );
+    // The strict string validator must NOT run for a json param — the whole
+    // point is to accept a non-string (object) argument. (It is always
+    // `declare`d as a runtime symbol; what must be absent is a *call* to it.)
+    assert!(
+        !ir.contains("call i64 @js_native_abi_check_string_ptr"),
+        "json param must not route through the strict string validator:\n{ir}"
+    );
+
+    let artifact = compile_artifact_json_for_module_with_opts(module, opts);
+    let records = artifact["records"].as_array().unwrap();
+    assert!(
+        records.iter().any(|record| {
+            record["expr_kind"] == "NativeLibraryParam"
+                && record["native_abi_type"]["display"] == "json"
+                && record["native_abi_type"]["direction"] == "param"
+                && record["native_abi_type"]["abi_slot_index"] == 1
+                && record["native_abi_type"]["abi_slot_count"] == 1
+                && record["native_abi_type"]["runtime_guard"]["helper"] == "js_json_stringify"
+        }),
+        "expected native-library json param ABI record:\n{artifact:#}"
+    );
+}
+
 #[path = "native_proof_regressions/pod_manifest.rs"]
 mod pod_manifest;
 

--- a/crates/perry/src/commands/compile/resolve/tests.rs
+++ b/crates/perry/src/commands/compile/resolve/tests.rs
@@ -451,6 +451,37 @@ mod manifest_parse_tests {
     }
 
     #[test]
+    fn native_abi_json_param_parses_and_is_param_only() {
+        // #5626: `"json"` is accepted as a param (the call site JSON-serializes
+        // the JS argument into a string ABI slot)...
+        let dir = tempfile::tempdir().expect("tempdir");
+        let parsed = parse_manifest_from_functions(
+            dir.path(),
+            serde_json::json!([
+                {
+                    "name": "take_descriptor",
+                    "params": ["i64", "json"],
+                    "returns": "i64"
+                }
+            ]),
+        )
+        .expect("parse manifest")
+        .expect("manifest");
+        assert_eq!(parsed.functions[0].params[1], NativeAbiType::Json);
+
+        // ...but rejected as a return (it has no value-materialization path).
+        let err = parse_manifest_error(serde_json::json!({
+            "name": "bad_json_return",
+            "params": [],
+            "returns": "json"
+        }));
+        assert!(err.contains("package.json"), "{err}");
+        assert!(err.contains("bad_json_return"), "{err}");
+        assert!(err.contains("returns"), "{err}");
+        assert!(err.contains("json"), "{err}");
+    }
+
+    #[test]
     fn native_abi_handle_id_is_valid_only_inside_pod_fields() {
         let err = parse_manifest_error(serde_json::json!({
             "name": "bad_handle_id_param",

--- a/docs/src/native-libraries/manifest-v1.md
+++ b/docs/src/native-libraries/manifest-v1.md
@@ -199,6 +199,7 @@ rejected in POD fields.
 |---|---|---|
 | `"jsvalue"` | `f64` | raw Perry NaN-boxed value |
 | `"string"` | `*const StringHeader` | `string` |
+| `"json"` | `*const StringHeader` | any JSON-serializable value (`JSON.stringify`d at the callsite) |
 | `"bool"` | `i32` truthy flag | `boolean` |
 | `"i32"` | `i32` | `number` truncated to signed 32-bit |
 | `"i64"` | `i64` | `number` converted to signed 64-bit |
@@ -242,11 +243,20 @@ rejected in POD fields.
 > it's `-> i64` and the value happens to be a `StringHeader` address
 > (closes [#222]).
 
-`"void"` is valid only as a return descriptor. `"buffer+len"` and
-`{ "kind": "pod", ... }` are valid only as parameter descriptors:
+`"void"` is valid only as a return descriptor. `"buffer+len"`, `"json"`,
+and `{ "kind": "pod", ... }` are valid only as parameter descriptors:
 `"buffer+len"` expands one JavaScript argument into two native ABI
 slots, while `pod` lowers one object-shaped argument to a pointer to
 verifier-backed C-layout storage.
+
+> Note on `"json"`: the callsite runs the JavaScript argument through
+> `JSON.stringify` and passes the resulting `*const StringHeader` in a
+> single ABI slot — the exact wire shape of a `"string"` param, so the
+> native side reads it with `read_string` and `serde_json`-deserializes
+> it unchanged (no binding Rust change versus a `"string"` param). Use it
+> for descriptor-object arguments where `"string"` would reject the live
+> object. It is opt-in and param-only, so real-string `"string"` params
+> keep their strict non-string-rejecting check.
 
 Native-only numeric descriptors (`f32`, `u32`, `u64`, `usize`,
 `buffer_len`) render as TypeScript `number`. Handles remain opaque

--- a/docs/src/native-libraries/manifest-v1.md
+++ b/docs/src/native-libraries/manifest-v1.md
@@ -121,7 +121,7 @@ Existing string spellings remain valid. The canonical descriptor
 vocabulary is:
 
 ```text
-jsvalue, string, bool, i32, i64, i64_str, u32, u64, usize,
+jsvalue, string, json, bool, i32, i64, i64_str, u32, u64, usize,
 f32, f64, number, ptr, buffer_len, buffer+len, handle<T>,
 promise<T>, pod, void
 ```
@@ -131,7 +131,9 @@ are compatibility aliases for `jsvalue` and `bool`. Bare `handle` is
 the same as an untyped `handle<T>`. Bare `promise` is the same as
 `promise<jsvalue>`. Unlike handles and promises, `pod` has no
 string-only spelling; use object form so the field order and scalar ABI
-types are explicit.
+types are explicit. `json` is parameter-only: it serializes its argument
+with `JSON.stringify` at the callsite and passes the result in a
+`string`-shaped slot (see "Param types").
 
 Descriptors with metadata may also use object form:
 
@@ -189,9 +191,9 @@ i32, i64, u32, u64, usize, f32, f64, number, buffer_len
 ```
 
 `number` aliases `f64`; `buffer_len` is a `u32` byte-length scalar.
-Dynamic or pointerful descriptors such as `jsvalue`, `string`, `bool`,
-`ptr`, `buffer+len`, `handle`, `promise`, nested `pod`, and `void` are
-rejected in POD fields.
+Dynamic or pointerful descriptors such as `jsvalue`, `string`, `json`,
+`bool`, `ptr`, `buffer+len`, `handle`, `promise`, nested `pod`, and
+`void` are rejected in POD fields.
 
 ### Param types
 


### PR DESCRIPTION
Fixes #5626.

## Problem

#5621 routes ergonomic camelCase native-library exports directly to their `js_<pkg>_*` FFI symbol, **bypassing the package's TS wrapper body**. Descriptor-object bindings used to rely on that wrapper to `JSON.stringify(descriptor)` before passing a `"string"` ABI param; with the wrapper gone the live object reaches `js_native_abi_check_string_ptr` (`native_abi.rs:137`), which *validates* rather than coerces and throws:

```
TypeError: Expected string for native string parameter
```

This blocks `@perryts/webgpu` end-to-end — ~20 of its 69 functions take a `GPUBufferDescriptor` / `GPURenderPipelineDescriptor` / `GPUCanvasConfiguration` object declared as a `"string"` manifest param. Routing already works for no-arg / handle-arg / real-string-arg functions; only **object → `"string"` param** fails.

## Fix

Add a `"json"` ABI param descriptor (the issue's preferred option) that moves the marshalling into the FFI boundary itself:

```jsonc
{ "name": "js_webgpu_device_create_buffer", "params": ["i64", "json"], "returns": "i64" }
```

At the call site a `"json"` param lowers its argument through the existing `js_json_stringify` runtime entry and passes the resulting `*const StringHeader` in a single `string`-shaped ABI slot. The native side reads it with `read_string` and `serde_json`-deserializes it **unchanged** — so **no binding Rust change is needed beyond the manifest edit**. Objects, arrays, and primitives all serialize. It is explicit and opt-in, so existing `"string"` params keep their strict non-string-rejecting check.

`"json"` is **param-only** (it has no value-materialization path as a return); declaring it as a return is rejected at manifest resolution.

## Changes

- **perry-api-manifest**: new `NativeAbiType::Json` — parses `"json"`, canonical kind `json`, one ABI slot, JS-facing type `any`, valid param, invalid return.
- **perry-codegen**: `lower_manifest_param` emits `js_json_stringify` and passes a `ptr`; the proof verifier accepts the `js_json_stringify` runtime guard for the `json` kind.
- **docs**: `manifest-v1.md` param-type table row + a note contrasting `"json"` with `"string"`.

## Tests

- `perry-api-manifest`: `json_descriptor_parses_and_is_param_only` — parse/validity contract.
- `perry` resolver: `native_abi_json_param_parses_and_is_param_only` — accepted as a param, rejected as a return.
- `perry-codegen`: `native_library_manifest_json_param_serializes_before_call` — IR + proof-artifact regression asserting the call site emits `js_json_stringify`, declares `native_take_descriptor(i64, ptr)`, and does **not** route through the strict string validator.

All targeted suites pass (`native_proof_regressions` 53, `perry-api-manifest` 33+4, resolver `manifest_parse_tests` 39, codegen `native_value` 41). No version bump or changelog (left to the maintainer per repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new `"json"` ABI type for native-library parameters.
  * JSON arguments are now serialized automatically at the call site and passed as a single pointer-style ABI slot.

* **Bug Fixes**
  * Validation now correctly accepts `"json"` as a parameter type and rejects it as a return type.
  * Runtime guard handling updated so `"json"` parameters use the appropriate stringification guard.

* **Tests**
  * Added regression coverage for correct `"json"` parameter parsing, IR generation, and runtime-guard behavior.

* **Documentation**
  * Updated the v1 manifest spec to define `"json"` as parameter-only and describe its call-site serialization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->