### PR TITLE
fix(runtime): bind inherited prototype-accessor methods to the receiver, not the prototype

### DIFF
--- a/crates/perry-runtime/src/object/native_call_method/handle_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/handle_methods.rs
@@ -891,10 +891,39 @@ pub(super) unsafe fn dispatch_handle(
                                     method_name.as_ptr(),
                                     method_name.len() as u32,
                                 );
+                                // An inherited method that resolves to an ACCESSOR
+                                // on the prototype must observe the instance as
+                                // `this` (spec `[[Get]](P, Receiver)`), not the
+                                // prototype object the getter lives on. Stash the
+                                // receiver so `invoke_accessor_getter` rebinds it.
+                                // Without this, a schema library's lazily-installed
+                                // `describe`/`clone` accessors — `Object.define-
+                                // Property(proto, k, { get() { const b = fn.bind(this);
+                                // Object.defineProperty(this, k, { value: b }); return b } })`
+                                // on the shared class prototype — run with
+                                // `this === prototype`, bake `this = prototype` into
+                                // the returned bound method, and cache it on the
+                                // prototype. Every downstream read of an
+                                // instance-only field via `this.<field>` then
+                                // returns `undefined` (`Cannot read properties of
+                                // undefined`) even though the instance has it.
+                                // Mirrors `resolve_proto_chain_field_with_receiver`
+                                // (the winston `get transports()` fix).
+                                let receiver_f64 = f64::from_bits(jsval.bits());
+                                let prev_this =
+                                    IMPLICIT_THIS.with(|c| c.replace(receiver_f64.to_bits()));
+                                let prev_override =
+                                    super::super::field_get_set::accessor_receiver_override_begin(
+                                        receiver_f64,
+                                    );
                                 let field_val = js_object_get_field_by_name(
                                     proto_obj as *const _,
                                     method_key as *const crate::StringHeader,
                                 );
+                                super::super::field_get_set::accessor_receiver_override_end(
+                                    prev_override,
+                                );
+                                IMPLICIT_THIS.with(|c| c.set(prev_this));
                                 if !field_val.is_undefined() && !field_val.is_null() {
                                     resolved_method = Some(ResolvedMethod::ProtoClosure {
                                         field_bits: field_val.bits(),
@@ -966,9 +995,17 @@ pub(super) unsafe fn dispatch_handle(
                     method_name.as_ptr(),
                     method_name.len() as u32,
                 );
-                if let Some(field_val) =
-                    resolve_proto_chain_field(class_id, method_key as *const crate::StringHeader)
-                {
+                // `_with_receiver` binds an inherited ACCESSOR getter's `this`
+                // to the instance (not the prototype it lives on), matching the
+                // ProtoClosure walk above and spec `[[Get]](P, Receiver)`. A
+                // prototype `Object.defineProperty(proto, k, { get })` reached
+                // through the registry-`None` (`Object.create(objLiteral)`) path
+                // would otherwise observe the prototype as `this`.
+                if let Some(field_val) = resolve_proto_chain_field_with_receiver(
+                    class_id,
+                    method_key as *const crate::StringHeader,
+                    f64::from_bits(jsval.bits()),
+                ) {
                     if !field_val.is_undefined() && !field_val.is_null() {
                         // #321 (effect Context/Layer/Scope): the closure we
                         // just resolved is an *inherited* method — by


### PR DESCRIPTION
## Problem

A method call `inst.m()` where `m` resolves to an **accessor** (getter) installed on a prototype via `Object.defineProperty(proto, "m", { get })` invoked the getter with `this === proto` (the object the accessor lives on) instead of `this === inst` (spec `[[Get]](P, Receiver)`).

This surfaced while running a large minified CLI bundle built on a schema-validation library. That library lazily installs methods such as `describe`/`clone` on the shared class prototype as accessors whose getter does:

```js
get() {
  const bound = fn.bind(this);
  Object.defineProperty(this, key, { value: bound });
  return bound;
}
```

With `this === prototype`, the bound method baked `this = prototype` and was cached on the prototype. The follow-up `clone_closure_rebind_this` is a no-op for a `.bind()`-bound function (no `CAPTURES_THIS_FLAG`), so the instance could not be recovered. Every downstream read of an instance-only field then returned `undefined` → `TypeError: Cannot read properties of undefined` for `schema.describe()` / `schema.clone()`.

## Root cause

`dispatch_handle` has two prototype-method resolution paths that invoked the getter with the **prototype** as receiver:

- the `ResolvedMethod::ProtoClosure` walk called the raw, receiver-less `js_object_get_field_by_name(proto_obj, key)`;
- the registry-`None` (`Object.create(objLiteral).m()`) fallback called the receiver-less `resolve_proto_chain_field`.

Neither stashed the original receiver, so an inherited accessor getter observed the prototype.

## Fix

Both paths now stash the receiver via the existing `accessor_receiver_override` + `IMPLICIT_THIS` mechanism (the same one `resolve_inherited_field` / `resolve_proto_chain_field_with_receiver` already use for the winston `get transports()` case), so `invoke_accessor_getter` rebinds `this` to the instance. The fallback simply switches to the already-existing `resolve_proto_chain_field_with_receiver`.

Inherited **data** methods are unaffected (the override is only consumed by a getter invocation; `clone_closure_rebind_this` still handles `captures_this` concise methods as before).

## Validation

- Byte-for-byte identical to Node for `describe`/`clone`/`optional`/`nullable`/`array`/object `parse`+`safeParse`/`meta`/`default`/`refine` method chains.
- Byte-for-byte identical to Node for an `Object.create` inherited-accessor method (the registry-`None` path).
- `cargo test -p perry-runtime -p perry-codegen` green (the only non-pass is the pre-existing `builtin_prototype_methods_reject_dynamic_new` parallel-flake, which passes in isolation).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inherited accessor getters so they use the instance as `this` instead of the prototype when resolving methods.
  * Improved fallback method lookup to keep inherited accessor behavior consistent across prototype-chain resolution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->