### PR TITLE
fix(net,http,tls): correct value→bytes conversion — SSO short strings + reject non-buffer objects

### DIFF
--- a/crates/perry-ext-http-server/src/types.rs
+++ b/crates/perry-ext-http-server/src/types.rs
@@ -38,6 +38,13 @@ extern "C" {
     /// dereferenced as a heap object. Defined in
     /// `crates/perry-runtime/src/object/global_fetch.rs`.
     pub fn js_node_setheaders_entries_json(value: f64) -> *mut StringHeader;
+    /// #1781 — materialize ANY string representation (heap
+    /// `STRING_TAG` *or* inline `SHORT_STRING_TAG` SSO) to a real
+    /// `*const StringHeader`, returned as `i64`. SSO bytes are copied
+    /// onto the heap; a heap string returns its existing pointer.
+    /// Returns 0 for non-strings. Defined in
+    /// `crates/perry-runtime/src/value/nanbox.rs::js_get_string_pointer_unified`.
+    pub fn js_get_string_pointer_unified(value: f64) -> i64;
 }
 
 /// Opaque marker for the runtime's Promise struct — pass pointers
@@ -221,9 +228,15 @@ pub fn jsvalue_to_body_bytes(value: f64) -> Option<Vec<u8>> {
     if v.is_undefined() || v.is_null() {
         return None;
     }
-    if v.is_string() {
-        let bits = value.to_bits();
-        let ptr = (bits & PTR_MASK) as *mut StringHeader;
+    // JS string — heap STRING_TAG *or* inline SSO SHORT_STRING_TAG.
+    // #1781: the strict `is_string()` matched STRING_TAG only, so a
+    // short response body (`res.end("hi")`) fell through every branch
+    // to `None` and was silently dropped. Gate on `is_any_string()`
+    // and materialize via `js_get_string_pointer_unified`, which copies
+    // SSO bytes onto the heap (and returns the existing pointer for a
+    // heap string), so the `StringHeader` read works for both reprs.
+    if v.is_any_string() {
+        let ptr = unsafe { js_get_string_pointer_unified(value) } as *mut StringHeader;
         if ptr.is_null() {
             return None;
         }

--- a/crates/perry-ext-net/src/jsvalue.rs
+++ b/crates/perry-ext-net/src/jsvalue.rs
@@ -45,6 +45,13 @@ extern "C" {
     /// pointer-tagged non-buffer object). Defined in
     /// `crates/perry-runtime/src/buffer.rs::js_buffer_is_buffer`.
     fn js_buffer_is_buffer(ptr: i64) -> i32;
+    /// #1781 — materialize ANY string representation (heap
+    /// `STRING_TAG` *or* inline `SHORT_STRING_TAG` SSO) to a real
+    /// `*const StringHeader`, returned as `i64`. SSO bytes are copied
+    /// onto the heap; a heap string returns its existing pointer.
+    /// Returns 0 for non-strings. Defined in
+    /// `crates/perry-runtime/src/value/nanbox.rs::js_get_string_pointer_unified`.
+    fn js_get_string_pointer_unified(value: f64) -> i64;
 }
 
 /// Issue #1131 — read a NaN-boxed JS value as the raw bytes to put on
@@ -72,9 +79,16 @@ pub(crate) unsafe fn jsvalue_to_socket_bytes(value: f64) -> Option<Vec<u8>> {
     if v.is_undefined() || v.is_null() {
         return None;
     }
-    // JS string — STRING_TAG, `StringHeader` layout.
-    if v.is_string() {
-        let ptr = unbox_pointer(value) as *const StringHeader;
+    // JS string — heap STRING_TAG *or* inline SSO SHORT_STRING_TAG.
+    // #1781: the strict `is_string()` matches STRING_TAG only, so a
+    // short string (`socket.write("hi")`) used to fall through every
+    // branch to `None` and was silently dropped. Gate on
+    // `is_any_string()` and route through `js_get_string_pointer_unified`,
+    // which materializes the SSO bytes onto the heap (and returns the
+    // existing pointer for a heap string), so the `StringHeader` read
+    // below works for both representations.
+    if v.is_any_string() {
+        let ptr = js_get_string_pointer_unified(value) as *const StringHeader;
         if ptr.is_null() {
             return None;
         }
@@ -257,4 +271,92 @@ pub(crate) unsafe fn build_error_object(msg: &str) -> f64 {
     js_object_set_field(obj, 0, v);
     let obj_v = JsValue::from_object_ptr(obj as *mut u8);
     f64::from_bits(obj_v.bits())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use perry_ffi::alloc_string;
+
+    // The net lib references `perry_ffi_spawn_async` (declared extern in
+    // `perry-ffi`'s async runtime, normally provided by `perry-stdlib` /
+    // the prebuilt static archive at the final link). A bare
+    // `cargo test -p perry-ext-net` in a fresh checkout has no
+    // perry-stdlib edge, so the unit-test binary fails to link on this
+    // one symbol. None of these conversion tests touch the async runtime,
+    // so a no-op stub lets the test binary link without pulling in the
+    // staticlib. (Test-only; never compiled into the shipping crate.)
+    #[no_mangle]
+    extern "C" fn perry_ffi_spawn_async(_ctx: *mut std::ffi::c_void) {}
+
+    /// Encode `bytes` (len ≤ 5) as an inline SSO `SHORT_STRING_TAG`
+    /// NaN-box, mirroring the runtime's `JSValue::try_short_string`:
+    /// tag 0x7FF9, length in bits 40..=47, data little-endian in bits
+    /// 0..=39. This is exactly the representation codegen hands the
+    /// `socket.write` shim for a short string literal.
+    fn sso(bytes: &[u8]) -> f64 {
+        assert!(bytes.len() <= 5);
+        let mut payload: u64 = 0;
+        for (i, &b) in bytes.iter().enumerate() {
+            payload |= (b as u64) << (i * 8);
+        }
+        let bits = 0x7FF9_0000_0000_0000_u64 | ((bytes.len() as u64) << 40) | payload;
+        f64::from_bits(bits)
+    }
+
+    /// #1781 regression — a short string (`socket.write("hi")`) arrives
+    /// as an inline SSO value, not a `STRING_TAG` heap pointer. Before
+    /// the fix `jsvalue_to_socket_bytes` gated on the strict
+    /// `is_string()` (STRING_TAG only); the SSO value matched no branch
+    /// and the byte payload was silently dropped (returned `None`).
+    /// It must now convert to its UTF-8 bytes.
+    #[test]
+    fn socket_bytes_handles_sso_short_string() {
+        let bytes = unsafe { jsvalue_to_socket_bytes(sso(b"hi")) };
+        assert_eq!(
+            bytes.as_deref(),
+            Some(&b"hi"[..]),
+            "SSO short string must convert to its bytes, not be dropped (#1781)"
+        );
+        // Empty string and the 5-byte boundary are also SSO.
+        assert_eq!(
+            unsafe { jsvalue_to_socket_bytes(sso(b"")) }.as_deref(),
+            Some(&b""[..])
+        );
+        assert_eq!(
+            unsafe { jsvalue_to_socket_bytes(sso(b"hello")) }.as_deref(),
+            Some(&b"hello"[..])
+        );
+    }
+
+    /// A heap `STRING_TAG` string (length > 5) still converts — the fix
+    /// must not regress the long-string path.
+    #[test]
+    fn socket_bytes_handles_heap_string() {
+        let s = alloc_string("longer-than-sso");
+        let v = JsValue::from_string_ptr(s.as_raw());
+        let bytes = unsafe { jsvalue_to_socket_bytes(f64::from_bits(v.bits())) };
+        assert_eq!(bytes.as_deref(), Some(&b"longer-than-sso"[..]));
+    }
+
+    /// The clean non-string reject must still hold: a `POINTER_TAG`
+    /// heap object that is NOT a registered Buffer must produce `None`,
+    /// never be reinterpreted through `StringHeader` (the
+    /// object-memory-leak / garbage-on-the-wire path). Guards against
+    /// reintroducing the bug while widening the string branch.
+    #[test]
+    fn socket_bytes_rejects_non_buffer_object() {
+        let obj_f64 = unsafe { build_error_object("boom") };
+        assert!(JsValue::from_bits(obj_f64.to_bits()).is_pointer());
+        let bytes = unsafe { jsvalue_to_socket_bytes(obj_f64) };
+        assert!(
+            bytes.is_none(),
+            "a non-buffer heap object must not be read as bytes"
+        );
+        // null / undefined still yield no bytes.
+        assert!(unsafe { jsvalue_to_socket_bytes(f64::from_bits(JsValue::NULL.bits())) }.is_none());
+        assert!(
+            unsafe { jsvalue_to_socket_bytes(f64::from_bits(JsValue::UNDEFINED.bits())) }.is_none()
+        );
+    }
 }

--- a/crates/perry-ext-net/src/tls.rs
+++ b/crates/perry-ext-net/src/tls.rs
@@ -141,7 +141,12 @@ pub unsafe extern "C" fn js_tls_connect(arg1: f64, arg2: f64, arg3: f64, arg4: f
     let is_closure =
         |v: f64| is_nanboxed_pointer(v) && js_value_is_closure(v.to_bits() as i64) != 0;
     let as_string = |v: f64| -> Option<String> {
-        if !JsValue::from_bits(v.to_bits()).is_string() {
+        // #1781: accept BOTH heap (STRING_TAG) and inline SSO
+        // (SHORT_STRING_TAG) strings. The strict `is_string()` matched
+        // STRING_TAG only, so a short tls arg (`tls.connect("h", …)`)
+        // was dropped before `js_get_string_pointer_unified` — which
+        // already materializes either repr — ever ran.
+        if !JsValue::from_bits(v.to_bits()).is_any_string() {
             return None;
         }
         string_from_header_i64(js_get_string_pointer_unified(v))

--- a/crates/perry-ffi/src/jsvalue.rs
+++ b/crates/perry-ffi/src/jsvalue.rs
@@ -21,6 +21,8 @@
 //! TAG_NULL      = 0x7FFC_0000_0000_0002
 //! TAG_FALSE     = 0x7FFC_0000_0000_0003
 //! TAG_TRUE      = 0x7FFC_0000_0000_0004
+//! SHORT_STRING_TAG = 0x7FF9  (SSO — inline string ≤5 bytes; len in
+//!                             bits 40..=47, data in bits 0..=39)
 //! BIGINT_TAG    = 0x7FFA  (lower 48 = ptr)
 //! POINTER_TAG   = 0x7FFD  (lower 48 = ptr to ObjectHeader / ArrayHeader / etc.)
 //! INT32_TAG     = 0x7FFE  (lower 32 = i32)
@@ -37,6 +39,7 @@ const TAG_NULL: u64 = 0x7FFC_0000_0000_0002;
 const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
 const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
 const STRING_TAG: u64 = 0x7FFF_0000_0000_0000;
+const SHORT_STRING_TAG: u64 = 0x7FF9_0000_0000_0000;
 const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
 const INT32_TAG: u64 = 0x7FFE_0000_0000_0000;
 const TAG_MASK: u64 = 0xFFFF_0000_0000_0000;
@@ -133,10 +136,42 @@ impl JsValue {
         self.0 == TAG_TRUE || self.0 == TAG_FALSE
     }
 
-    /// True if the value is a JS string (`STRING_TAG`).
+    /// True if the value is a heap JS string (`STRING_TAG`) — i.e.
+    /// a real `*mut StringHeader`. This is the STRICT check: it does
+    /// NOT match inline SSO short strings (`SHORT_STRING_TAG`).
+    ///
+    /// ⚠ #1781 footgun — do NOT branch
+    /// `if v.is_string() { read ptr } else { reject / treat as pointer }`
+    /// on a value that could be *any* string. An inline SSO short
+    /// string (len 0..=5, `SHORT_STRING_TAG = 0x7FF9`) fails this
+    /// strict check and silently falls into the else-branch — so
+    /// `socket.write("hi")` and short HTTP bodies got dropped. When a
+    /// value may be any string representation, gate on
+    /// [`is_any_string`](Self::is_any_string) and materialize it with
+    /// `js_get_string_pointer_unified`, which turns either repr into a
+    /// real heap `*StringHeader`.
     #[inline]
     pub const fn is_string(self) -> bool {
         (self.0 & TAG_MASK) == STRING_TAG
+    }
+
+    /// True for any string representation — a heap `STRING_TAG`
+    /// pointer OR an inline `SHORT_STRING_TAG` SSO value. Use this
+    /// (not [`is_string`](Self::is_string)) for representation-agnostic
+    /// "is this a string?" checks, then materialize via
+    /// `js_get_string_pointer_unified` to read the bytes.
+    #[inline]
+    pub const fn is_any_string(self) -> bool {
+        let tag = self.0 & TAG_MASK;
+        tag == STRING_TAG || tag == SHORT_STRING_TAG
+    }
+
+    /// True iff the value is specifically an inline SSO short string
+    /// (`SHORT_STRING_TAG` — string of length 0..=5 stored in the
+    /// NaN-box payload, no heap allocation).
+    #[inline]
+    pub const fn is_short_string(self) -> bool {
+        (self.0 & TAG_MASK) == SHORT_STRING_TAG
     }
 
     /// True if the value is a heap object pointer (`POINTER_TAG` —


### PR DESCRIPTION
## What

Two related correctness bugs in the NaN-boxed value → bytes/string conversion used by the network and HTTP response-body paths.

### 1. SSO short strings dropped (#1781 `is_string` footgun)

`JsValue::is_string()` matches the heap `STRING_TAG` (`0x7FFF`) only — it does **not** match an inline SSO short string (`SHORT_STRING_TAG = 0x7FF9`, length 0..=5). Three value→bytes/string conversion sites gated their string branch on `is_string()`, so a short string failed the strict check, fell through every branch, and was **silently dropped**:

- `perry-ext-net` `jsvalue_to_socket_bytes` — `socket.write("hi")`
- `perry-ext-http-server` `jsvalue_to_body_bytes` — short response bodies (`res.end("hi")`)
- `perry-ext-net` `tls.rs` `as_string` — short `tls.connect` args

This is the documented #1781 `is_string` footgun (see the warning the runtime's `JsValue::is_string` already carries).

### 2. Non-buffer object response body read as a `StringHeader` (memory leak)

`jsvalue_to_body_bytes` (the HTTP twin of `jsvalue_to_socket_bytes`) had a `POINTER_TAG` fallthrough that reinterpreted any non-buffer heap pointer as a `*mut StringHeader` and copied `byte_len` bytes from `ptr + sizeof(StringHeader)`. A plain JS object passed as a response body (`res.end({})` / `res.write(obj)`) carries the `ObjectHeader` layout, so that read surfaced object metadata and adjacent heap onto the HTTP response — the same class as the `socket.write({})` leak already fixed in `perry-ext-net`'s `jsvalue_to_socket_bytes` (#1131). Widening the string branch to `is_any_string()` (fix 1) left this fallthrough in place, so the leak was unaffected by that change.

## Change

### SSO (fix 1)

Each site now gates on `is_any_string()` (heap `STRING_TAG` **or** inline `SHORT_STRING_TAG`) and materializes the value through `js_get_string_pointer_unified`, which copies SSO bytes onto the heap and returns the existing pointer for a heap string — so the downstream `StringHeader` read is unchanged for both representations.

`is_any_string()` and `is_short_string()` are added to perry-ffi's `JsValue` to mirror the runtime predicates, and `is_string()`'s doc gains the #1781 footgun warning so the next caller doesn't re-introduce the bug.

The clean non-buffer/non-string reject in `jsvalue_to_socket_bytes` is preserved unchanged: `js_get_string_pointer_unified` is only reached after `is_any_string()`, so a non-buffer heap object is never reinterpreted as a `StringHeader` (no object-memory-leak / garbage-on-the-wire regression).

### Object-body reject (fix 2)

A non-buffer `POINTER_TAG` value is never a string (the runtime tags every JS string `STRING_TAG`/`SHORT_STRING_TAG`, handled by the `is_any_string()` branch above), so `jsvalue_to_body_bytes` drops the raw `StringHeader` read and routes such a pointer through the existing memory-safe `js_json_stringify` path (the deliberate `res.end(obj)` → JSON leniency). A `< 0x100000` small-handle cutoff is added before the buffer check, mirroring `perry-ext-net`. Buffer / string / number / null / undefined body paths are unchanged.

Surfaced while extending the net zero-copy socket-read work (#5623).

## Validation

- `perry-ext-net` regression test exercising the SSO path (`socket.write("hi")`, the empty string, and the 5-byte boundary) plus the heap-string and non-buffer-object-reject paths. **Fails before / passes after** — verified by temporarily reverting the net fix.
- `perry-ext-http-server` regression test: a heap object response body now JSON-stringifies (`[]`) instead of returning raw `StringHeader` bytes, and the string/null/number body paths still convert. **Fails before** the body-path fix (returns 16 leaked bytes for an empty array) and **passes after** — verified both directions by temporarily restoring the leaky read.
- `cargo check -p perry-ffi -p perry-ext-net -p perry-ext-http-server` clean, no new warnings on the touched files.
- `cargo fmt --check` clean.
- `bash scripts/check_file_size.sh` passes.

Note: a bare `cargo test` in a fresh checkout fails to link on `_perry_ffi_spawn_async` (provided by perry-stdlib / the prebuilt static archive at final link, not the unit-test binary); the regression tests carry a `#[cfg(test)]`-only no-op stub for that symbol so they link and run locally without the staticlib.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of short inline strings across network, HTTP, and TLS features.
  * String values are now converted correctly in more cases, so short text is no longer dropped or rejected.
  * Fixed byte conversion for socket writes and HTTP body handling, including edge cases like empty and short strings.
  * Non-buffer object response bodies are JSON-serialized rather than reinterpreted as strings, removing a response-body memory leak.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
