### PR TITLE
fix(stdlib): auto-opt link break — dispatch_http path refs after the dispatch-module split (#1435)

### DIFF
--- a/crates/perry-stdlib/src/common/dispatch/method_dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch/method_dispatch.rs
@@ -524,14 +524,14 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
 
     #[cfg(feature = "external-http-client-pump")]
     if let Some(value) =
-        unsafe { super::dispatch_http::dispatch_client_request_method(handle, method_name, &args) }
+        unsafe { super::super::dispatch_http::dispatch_client_request_method(handle, method_name, &args) }
     {
         return value;
     }
 
     #[cfg(feature = "external-http-client-pump")]
     if let Some(value) =
-        unsafe { super::dispatch_http::dispatch_client_incoming_method(handle, method_name, &args) }
+        unsafe { super::super::dispatch_http::dispatch_client_incoming_method(handle, method_name, &args) }
     {
         return value;
     }

--- a/crates/perry-stdlib/src/common/dispatch/method_dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch/method_dispatch.rs
@@ -523,16 +523,16 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
     }
 
     #[cfg(feature = "external-http-client-pump")]
-    if let Some(value) =
-        unsafe { super::super::dispatch_http::dispatch_client_request_method(handle, method_name, &args) }
-    {
+    if let Some(value) = unsafe {
+        super::super::dispatch_http::dispatch_client_request_method(handle, method_name, &args)
+    } {
         return value;
     }
 
     #[cfg(feature = "external-http-client-pump")]
-    if let Some(value) =
-        unsafe { super::super::dispatch_http::dispatch_client_incoming_method(handle, method_name, &args) }
-    {
+    if let Some(value) = unsafe {
+        super::super::dispatch_http::dispatch_client_incoming_method(handle, method_name, &args)
+    } {
         return value;
     }
 

--- a/crates/perry-stdlib/src/common/dispatch/property_dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch/property_dispatch.rs
@@ -640,16 +640,16 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
     }
 
     #[cfg(feature = "external-http-client-pump")]
-    if let Some(value) =
-        unsafe { super::super::dispatch_http::dispatch_client_request_property(handle, property_name) }
-    {
+    if let Some(value) = unsafe {
+        super::super::dispatch_http::dispatch_client_request_property(handle, property_name)
+    } {
         return value;
     }
 
     #[cfg(feature = "external-http-client-pump")]
-    if let Some(value) =
-        unsafe { super::super::dispatch_http::dispatch_client_incoming_property(handle, property_name) }
-    {
+    if let Some(value) = unsafe {
+        super::super::dispatch_http::dispatch_client_incoming_property(handle, property_name)
+    } {
         return value;
     }
 

--- a/crates/perry-stdlib/src/common/dispatch/property_dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch/property_dispatch.rs
@@ -641,14 +641,14 @@ pub unsafe extern "C" fn js_handle_property_dispatch(
 
     #[cfg(feature = "external-http-client-pump")]
     if let Some(value) =
-        unsafe { super::dispatch_http::dispatch_client_request_property(handle, property_name) }
+        unsafe { super::super::dispatch_http::dispatch_client_request_property(handle, property_name) }
     {
         return value;
     }
 
     #[cfg(feature = "external-http-client-pump")]
     if let Some(value) =
-        unsafe { super::dispatch_http::dispatch_client_incoming_property(handle, property_name) }
+        unsafe { super::super::dispatch_http::dispatch_client_incoming_property(handle, property_name) }
     {
         return value;
     }


### PR DESCRIPTION
## What
PR #1435 split `method_dispatch.rs`/`property_dispatch.rs` into `common/dispatch/` but left **4 `super::dispatch_http::…` references** that now resolve to the nonexistent `common::dispatch::dispatch_http` instead of `common::dispatch_http`. The path is gated on the `external-http-client-pump` feature — **off in the default/CI build (so cargo-test stays green) but ON in the auto-optimize build** → `E0433` → **link break for any auto-opt app doing node:http client traffic**. (This is the CI-invisible `project_autoopt_ffi_symbol_link_break` class.)

Discovered because a Next.js standalone bundle would not compile under auto-opt until this was fixed.

## Fix
`super::dispatch_http` → `super::super::dispatch_http` at all 4 sites in `common/dispatch/{method,property}_dispatch.rs`. Verified: the auto-opt Next.js bundle now links + compiles.

Refs #5437 (found there).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved routing for the external HTTP client pump so client request methods are dispatched through the correct handling path.
  * Updated property dispatch for client requests and incoming responses to use the proper routing, improving reliability and consistency of HTTP interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->