### PR TITLE
fix(codegen,hir): cross-module member-new fills captures from the class's decl-site snapshot

### DIFF
--- a/crates/perry-codegen/src/expr/static_field_meta.rs
+++ b/crates/perry-codegen/src/expr/static_field_meta.rs
@@ -168,17 +168,46 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // Read slot `index` of the class's decl-site capture snapshot —
         // STATIC method prologue rebinds (no instance to carry the
         // `__perry_cap_*` fields).
-        Expr::ClassCaptureValue { class_name, index } => {
+        Expr::ClassCaptureValue {
+            class_name,
+            index,
+            fallback,
+        } => {
+            // The fallback (a synthesized `__perry_cap_*` ctor param) must be
+            // lowered FIRST so its value is available regardless of whether the
+            // class id resolves — and so its side-effect-free read happens in
+            // program order.
+            let fallback_v = match fallback {
+                Some(fb) => Some(lower_expr(ctx, fb)?),
+                None => None,
+            };
             if let Some(&class_id) = ctx.class_ids.get(class_name) {
                 let cid_str = class_id.to_string();
                 let idx_str = index.to_string();
-                return Ok(ctx.block().call(
-                    DOUBLE,
-                    "js_class_capture_value",
-                    &[(crate::types::I32, &cid_str), (crate::types::I32, &idx_str)],
-                ));
+                return Ok(match &fallback_v {
+                    // #5437: snapshot-or-fallback. The decl-site snapshot wins
+                    // when it holds a real value (W6: the appended cap arg may
+                    // be a mis-boxed multi-level capture, or — cross-module —
+                    // absent entirely); otherwise the fallback is used.
+                    Some(fb) => ctx.block().call(
+                        DOUBLE,
+                        "js_class_capture_value_or",
+                        &[
+                            (crate::types::I32, &cid_str),
+                            (crate::types::I32, &idx_str),
+                            (DOUBLE, fb),
+                        ],
+                    ),
+                    None => ctx.block().call(
+                        DOUBLE,
+                        "js_class_capture_value",
+                        &[(crate::types::I32, &cid_str), (crate::types::I32, &idx_str)],
+                    ),
+                });
             }
-            Ok(double_literal(f64::from_bits(0x7FFC_0000_0000_0001)))
+            // Class id unknown in this module: keep the fallback if we have one
+            // (the cap param the construct supplied), else `undefined`.
+            Ok(fallback_v.unwrap_or_else(|| double_literal(f64::from_bits(0x7FFC_0000_0000_0001))))
         }
         // Issue #894: `static [Symbol.for("k")] = init` inside a
         // class expression returned from a factory function. Emitted

--- a/crates/perry-codegen/src/expr/static_field_meta.rs
+++ b/crates/perry-codegen/src/expr/static_field_meta.rs
@@ -172,6 +172,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             class_name,
             index,
             fallback,
+            prefer_fallback,
         } => {
             // The fallback (a synthesized `__perry_cap_*` ctor param) must be
             // lowered FIRST so its value is available regardless of whether the
@@ -184,12 +185,29 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             if let Some(&class_id) = ctx.class_ids.get(class_name) {
                 let cid_str = class_id.to_string();
                 let idx_str = index.to_string();
-                return Ok(match &fallback_v {
-                    // #5437: snapshot-or-fallback. The decl-site snapshot wins
-                    // when it holds a real value (W6: the appended cap arg may
-                    // be a mis-boxed multi-level capture, or — cross-module —
-                    // absent entirely); otherwise the fallback is used.
-                    Some(fb) => ctx.block().call(
+                return Ok(match (&fallback_v, *prefer_fallback) {
+                    // #5437 (param-first): the LIVE param (the `new`-site cap
+                    // arg) wins whenever present; the decl-site snapshot is
+                    // consulted ONLY when the param is `undefined` (the
+                    // cross-module construct path drops the cap arg). Used by the
+                    // synthesized constructor's capture rebind so a SAME-module
+                    // `new C(...)`'s current (possibly mutated) outer is NOT
+                    // overridden by a stale snapshot.
+                    (Some(fb), true) => ctx.block().call(
+                        DOUBLE,
+                        "js_param_or_class_capture_value",
+                        &[
+                            (DOUBLE, fb),
+                            (crate::types::I32, &cid_str),
+                            (crate::types::I32, &idx_str),
+                        ],
+                    ),
+                    // #5437: snapshot-or-fallback (snapshot-first). The decl-site
+                    // snapshot wins when it holds a real value (W6: the appended
+                    // cap arg may be a mis-boxed multi-level capture, or —
+                    // cross-module — absent entirely); otherwise the fallback is
+                    // used.
+                    (Some(fb), false) => ctx.block().call(
                         DOUBLE,
                         "js_class_capture_value_or",
                         &[
@@ -198,7 +216,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             (DOUBLE, fb),
                         ],
                     ),
-                    None => ctx.block().call(
+                    (None, _) => ctx.block().call(
                         DOUBLE,
                         "js_class_capture_value",
                         &[(crate::types::I32, &cid_str), (crate::types::I32, &idx_str)],

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1168,7 +1168,11 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // #5437 (param-first): the live `new`-site cap param wins when present; the
     // decl-site snapshot is consulted only when the param is `undefined` (the
     // cross-module construct path). Used by the synthesized ctor capture rebind.
-    module.declare_function("js_param_or_class_capture_value", DOUBLE, &[DOUBLE, I32, I32]);
+    module.declare_function(
+        "js_param_or_class_capture_value",
+        DOUBLE,
+        &[DOUBLE, I32, I32],
+    );
     // `super(...spread)` — dynamic-arity ancestor ctor invocation on `this`.
     module.declare_function("js_super_construct_apply", VOID, &[I32, DOUBLE, DOUBLE]);
     // `super.method(...)` on a class with a runtime-registered (dynamic) parent

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1165,6 +1165,10 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // #5437: snapshot slot read with a `new`-site appended cap-arg fallback
     // (used when no decl-site snapshot was registered for the class).
     module.declare_function("js_class_capture_value_or", DOUBLE, &[I32, I32, DOUBLE]);
+    // #5437 (param-first): the live `new`-site cap param wins when present; the
+    // decl-site snapshot is consulted only when the param is `undefined` (the
+    // cross-module construct path). Used by the synthesized ctor capture rebind.
+    module.declare_function("js_param_or_class_capture_value", DOUBLE, &[DOUBLE, I32, I32]);
     // `super(...spread)` — dynamic-arity ancestor ctor invocation on `this`.
     module.declare_function("js_super_construct_apply", VOID, &[I32, DOUBLE, DOUBLE]);
     // `super.method(...)` on a class with a runtime-registered (dynamic) parent

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -430,6 +430,17 @@ pub enum Expr {
         /// `class_name` resolves to its real `class_id` there). `None` keeps
         /// the plain snapshot read used by STATIC method prologue rebinds.
         fallback: Option<Box<Expr>>,
+        /// #5437 (param-first rebind): when `true`, the `fallback` (the LIVE
+        /// `new`-site cap param) WINS whenever it is present; the decl-site
+        /// snapshot is consulted ONLY when the param is `undefined` (the
+        /// cross-module construct signal — that path drops the cap arg). Codegen
+        /// emits `js_param_or_class_capture_value(param, cid, index)`. This is
+        /// the correct policy for the synthesized constructor's capture rebind:
+        /// a SAME-module `new C(...)` supplies the current (possibly mutated)
+        /// outer, which must not be overridden by a stale decl-site snapshot.
+        /// `false` (default) keeps the snapshot-first
+        /// `js_class_capture_value_or` behavior used by every other caller.
+        prefer_fallback: bool,
     },
 
     /// Issue #894: `class C { static [keyExpr] = initExpr }` where the

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -417,6 +417,19 @@ pub enum Expr {
     ClassCaptureValue {
         class_name: String,
         index: u32,
+        /// #5437 (cross-module member-`new`): when present, codegen emits
+        /// `js_class_capture_value_or(cid, index, <fallback>)` — the decl-site
+        /// snapshot wins WHEN IT HOLDS A REAL VALUE, otherwise the fallback
+        /// (the `new`-site appended/synthesized cap arg) is used. The
+        /// synthesized constructor stashes its `__perry_cap_*` fields through
+        /// this form so a CROSS-MODULE `new ns.C(...)` — which routes to the
+        /// runtime construct path (`construct_registered_class_ref`) and
+        /// supplies NO cap args, leaving the cap params bound to garbage —
+        /// still recovers the captured value from the class's own decl-site
+        /// snapshot (the ctor body is compiled in the class's home module, so
+        /// `class_name` resolves to its real `class_id` there). `None` keeps
+        /// the plain snapshot read used by STATIC method prologue rebinds.
+        fallback: Option<Box<Expr>>,
     },
 
     /// Issue #894: `class C { static [keyExpr] = initExpr }` where the

--- a/crates/perry-hir/src/lower_decl/class_captures.rs
+++ b/crates/perry-hir/src/lower_decl/class_captures.rs
@@ -329,6 +329,7 @@ pub fn synthesize_class_captures(
                     class_name: name.to_string(),
                     index: index as u32,
                     fallback: None,
+                    prefer_fallback: false,
                 }),
             });
         }
@@ -371,6 +372,7 @@ pub fn synthesize_class_captures(
                     class_name: name.to_string(),
                     index: index as u32,
                     fallback: None,
+                    prefer_fallback: false,
                 }),
             });
         }
@@ -505,13 +507,19 @@ pub fn synthesize_class_captures(
             is_rest: false,
             arguments_object: None,
         });
-        // param = js_class_capture_value_or(class_id, slot, param)
+        // param = js_param_or_class_capture_value(param, class_id, slot)
+        // — PARAM-FIRST: the live `new`-site cap arg wins whenever present; the
+        // decl-site snapshot is only used when the param is `undefined` (the
+        // cross-module construct path drops the cap arg → undefined). This
+        // avoids overriding a SAME-module `new C(...)`'s current (possibly
+        // mutated) outer with the stale decl-site snapshot.
         rebind_stmts.push(Stmt::Expr(Expr::LocalSet(
             fresh_param_id,
             Box::new(Expr::ClassCaptureValue {
                 class_name: name.to_string(),
                 index: index as u32,
                 fallback: Some(Box::new(Expr::LocalGet(fresh_param_id))),
+                prefer_fallback: true,
             }),
         )));
         assignment_stmts.push(Stmt::Expr(Expr::PropertySet {
@@ -524,16 +532,26 @@ pub fn synthesize_class_captures(
     // stmts (which already reference the fresh ids directly).
     crate::analysis::remap_local_ids_in_stmts(&mut ctor.body, &ctor_id_map);
     append_self_sites(&mut ctor.body, &ctor_id_map);
+    // Finding #2: the param REBINDS (`param = param-or-snapshot`) go at
+    // FUNCTION ENTRY (index 0), BEFORE any pre-`super()` user code — a derived
+    // ctor may read a captured outer before calling `super()`, and that read
+    // must already see the recovered value. Only the `this.__perry_cap_* =
+    // param` field STASHES must wait until after `super()` (no `this` exists
+    // before super). A non-derived ctor has no `super`, so both groups land at
+    // entry (assignments right after the rebinds).
+    let rebind_count = rebind_stmts.len();
+    for (i, stmt) in rebind_stmts.into_iter().enumerate() {
+        ctor.body.insert(i, stmt);
+    }
+    // `super_pos` is recomputed AFTER inserting the rebinds (they shifted the
+    // body), so the assignments land just past the (now-relocated) `super()`.
     let super_pos = ctor
         .body
         .iter()
         .position(|s| matches!(s, Stmt::Expr(Expr::SuperCall(_) | Expr::SuperCallSpread(_))));
-    let insert_at = super_pos.map(|p| p + 1).unwrap_or(0);
-    // Order at `insert_at`: rebinds (param = snapshot-or-param) FIRST, then
-    // the `this.__perry_cap_* = param` field stashes, then the user body.
-    let prologue: Vec<Stmt> = rebind_stmts.into_iter().chain(assignment_stmts).collect();
-    for (i, stmt) in prologue.into_iter().enumerate() {
-        ctor.body.insert(insert_at + i, stmt);
+    let assignment_insert_at = super_pos.map(|p| p + 1).unwrap_or(rebind_count);
+    for (i, stmt) in assignment_stmts.into_iter().enumerate() {
+        ctor.body.insert(assignment_insert_at + i, stmt);
     }
     *constructor = Some(ctor);
 

--- a/crates/perry-hir/src/lower_decl/class_captures.rs
+++ b/crates/perry-hir/src/lower_decl/class_captures.rs
@@ -328,6 +328,7 @@ pub fn synthesize_class_captures(
                 init: Some(Expr::ClassCaptureValue {
                     class_name: name.to_string(),
                     index: index as u32,
+                    fallback: None,
                 }),
             });
         }
@@ -369,6 +370,7 @@ pub fn synthesize_class_captures(
                 init: Some(Expr::ClassCaptureValue {
                     class_name: name.to_string(),
                     index: index as u32,
+                    fallback: None,
                 }),
             });
         }
@@ -465,8 +467,29 @@ pub fn synthesize_class_captures(
     };
     let mut ctor_id_map: std::collections::HashMap<LocalId, LocalId> =
         std::collections::HashMap::new();
+    // #5437 (cross-module member-`new`): recover each capture from the
+    // class's decl-site snapshot at ctor entry. A SAME-module bare-`new
+    // C(...)` / inline construct appends the live cap arg, so the param
+    // holds the correct value and — because the snapshot for this class was
+    // registered with that same value at decl-time —
+    // `js_class_capture_value_or` returns the identical value (no behavior
+    // change). But a CROSS-MODULE `new ns.C(...)` (Next's `new
+    // w.AppRouteRouteModule(...)`, where the class lives in a different
+    // compiled module) cannot resolve the class statically, so it routes to
+    // the runtime construct path (`construct_registered_class_ref`) which
+    // supplies NO cap args — the param is then garbage/undefined. Rebinding
+    // the param FROM the class's own decl-site snapshot (the ctor body is
+    // compiled in the class's home module, where `class_name` → its real
+    // `class_id`) recovers the captured value before EITHER the user ctor
+    // body reads it (`this.methods = r_(e)` — `r_` is remapped to this param)
+    // OR the `this.__perry_cap_*` field is stashed from it. This generalizes
+    // the W6 inline-construct snapshot fix
+    // (`inline_constructor_param_values_with_class`) — which only covered the
+    // statically-inlined construct — to EVERY construction path, including
+    // the runtime cross-module one.
+    let mut rebind_stmts: Vec<Stmt> = Vec::with_capacity(captures_vec.len());
     let mut assignment_stmts: Vec<Stmt> = Vec::with_capacity(captures_vec.len());
-    for &outer_id in &captures_vec {
+    for (index, &outer_id) in captures_vec.iter().enumerate() {
         let fresh_param_id = ctx.fresh_local();
         ctor_id_map.insert(outer_id, fresh_param_id);
         let ty = captured_outer_types
@@ -482,13 +505,22 @@ pub fn synthesize_class_captures(
             is_rest: false,
             arguments_object: None,
         });
+        // param = js_class_capture_value_or(class_id, slot, param)
+        rebind_stmts.push(Stmt::Expr(Expr::LocalSet(
+            fresh_param_id,
+            Box::new(Expr::ClassCaptureValue {
+                class_name: name.to_string(),
+                index: index as u32,
+                fallback: Some(Box::new(Expr::LocalGet(fresh_param_id))),
+            }),
+        )));
         assignment_stmts.push(Stmt::Expr(Expr::PropertySet {
             object: Box::new(Expr::This),
             property: format!("__perry_cap_{}", outer_id),
             value: Box::new(Expr::LocalGet(fresh_param_id)),
         }));
     }
-    // Rewrite user-written ctor body BEFORE inserting the assignment
+    // Rewrite user-written ctor body BEFORE inserting the rebind + assignment
     // stmts (which already reference the fresh ids directly).
     crate::analysis::remap_local_ids_in_stmts(&mut ctor.body, &ctor_id_map);
     append_self_sites(&mut ctor.body, &ctor_id_map);
@@ -497,7 +529,10 @@ pub fn synthesize_class_captures(
         .iter()
         .position(|s| matches!(s, Stmt::Expr(Expr::SuperCall(_) | Expr::SuperCallSpread(_))));
     let insert_at = super_pos.map(|p| p + 1).unwrap_or(0);
-    for (i, stmt) in assignment_stmts.into_iter().enumerate() {
+    // Order at `insert_at`: rebinds (param = snapshot-or-param) FIRST, then
+    // the `this.__perry_cap_* = param` field stashes, then the user body.
+    let prologue: Vec<Stmt> = rebind_stmts.into_iter().chain(assignment_stmts).collect();
+    for (i, stmt) in prologue.into_iter().enumerate() {
         ctor.body.insert(insert_at + i, stmt);
     }
     *constructor = Some(ctor);

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -638,7 +638,7 @@ impl SH for Expr {
             Expr::TemplateRaw(e) => { tag(h, 446); e.as_ref().hash(h); }
             Expr::RegisterClassParentDynamic { class_name, parent_expr, } => { tag(h, 447); class_name.hash(h); parent_expr.as_ref().hash(h); }
             Expr::RegisterClassCaptures { class_name, captures } => { tag(h, 12241); class_name.hash(h); for c in captures { c.hash(h); } }
-            Expr::ClassCaptureValue { class_name, index, fallback } => { tag(h, 12242); class_name.hash(h); index.hash(h); fallback.hash(h); }
+            Expr::ClassCaptureValue { class_name, index, fallback, prefer_fallback } => { tag(h, 12242); class_name.hash(h); index.hash(h); fallback.hash(h); prefer_fallback.hash(h); }
             Expr::RegisterClassStaticSymbol { class_name, key_expr, value_expr, } => { tag(h, 12025); class_name.hash(h); key_expr.as_ref().hash(h); value_expr.as_ref().hash(h); }
             Expr::RegisterClassComputedMethod { class_name, key_expr, method_name, is_static, param_count, has_rest } => { tag(h, 12233); class_name.hash(h); key_expr.as_ref().hash(h); method_name.hash(h); is_static.hash(h); param_count.hash(h); has_rest.hash(h); }
             Expr::RegisterClassComputedAccessor { class_name, key_expr, getter_name, setter_name, is_static } => { tag(h, 12234); class_name.hash(h); key_expr.as_ref().hash(h); getter_name.hash(h); setter_name.hash(h); is_static.hash(h); }

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -638,7 +638,7 @@ impl SH for Expr {
             Expr::TemplateRaw(e) => { tag(h, 446); e.as_ref().hash(h); }
             Expr::RegisterClassParentDynamic { class_name, parent_expr, } => { tag(h, 447); class_name.hash(h); parent_expr.as_ref().hash(h); }
             Expr::RegisterClassCaptures { class_name, captures } => { tag(h, 12241); class_name.hash(h); for c in captures { c.hash(h); } }
-            Expr::ClassCaptureValue { class_name, index } => { tag(h, 12242); class_name.hash(h); index.hash(h); }
+            Expr::ClassCaptureValue { class_name, index, fallback } => { tag(h, 12242); class_name.hash(h); index.hash(h); fallback.hash(h); }
             Expr::RegisterClassStaticSymbol { class_name, key_expr, value_expr, } => { tag(h, 12025); class_name.hash(h); key_expr.as_ref().hash(h); value_expr.as_ref().hash(h); }
             Expr::RegisterClassComputedMethod { class_name, key_expr, method_name, is_static, param_count, has_rest } => { tag(h, 12233); class_name.hash(h); key_expr.as_ref().hash(h); method_name.hash(h); is_static.hash(h); param_count.hash(h); has_rest.hash(h); }
             Expr::RegisterClassComputedAccessor { class_name, key_expr, getter_name, setter_name, is_static } => { tag(h, 12234); class_name.hash(h); key_expr.as_ref().hash(h); getter_name.hash(h); setter_name.hash(h); is_static.hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -586,7 +586,11 @@ where
                 f(c);
             }
         }
-        Expr::ClassCaptureValue { .. } => {}
+        Expr::ClassCaptureValue { fallback, .. } => {
+            if let Some(fb) = fallback {
+                f(fb);
+            }
+        }
         Expr::RegisterClassStaticSymbol {
             key_expr,
             value_expr,

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -587,7 +587,11 @@ where
                 f(c);
             }
         }
-        Expr::ClassCaptureValue { .. } => {}
+        Expr::ClassCaptureValue { fallback, .. } => {
+            if let Some(fb) = fallback {
+                f(fb);
+            }
+        }
         Expr::RegisterClassStaticSymbol {
             key_expr,
             value_expr,

--- a/crates/perry-runtime/src/object/class_constructors.rs
+++ b/crates/perry-runtime/src/object/class_constructors.rs
@@ -197,12 +197,54 @@ pub extern "C" fn js_class_capture_value_or(class_id: u32, index: u32, fallback:
     })
 }
 
+/// #5437 (cross-module member-`new`, param-first): inverse of
+/// `js_class_capture_value_or` — the LIVE `param` (the value the `new`-site
+/// appended as the capture arg) wins WHENEVER IT IS PRESENT; the decl-site
+/// snapshot is only consulted when `param` is `undefined`.
+///
+/// This is the correct policy for the synthesized constructor's capture
+/// rebind. A SAME-module `new C(...)` supplies the current (possibly mutated)
+/// outer as `param` — and that must NOT be overridden by a stale decl-site
+/// snapshot taken when the class was declared:
+///
+/// ```ignore
+/// let x = "a"; class C { constructor(){ this.x = x } } x = "b"; new C();
+/// // node: this.x === "b" (the live param), NOT the "a" decl-site snapshot.
+/// ```
+///
+/// A CROSS-MODULE `new ns.C(...)` routes to the runtime construct path
+/// (`construct_registered_class_ref`) which supplies NO capture args, so the
+/// synthesized cap param arrives `undefined`. In that case — and only that
+/// case — we recover the captured value from the class's own decl-site
+/// snapshot (the ctor body is compiled in the class's home module, so
+/// `class_id` resolves to the real registered snapshot there). If no snapshot
+/// (or no slot) exists either, the result is `undefined` — same as the param.
+#[no_mangle]
+pub extern "C" fn js_param_or_class_capture_value(param: f64, class_id: u32, index: u32) -> f64 {
+    if param.to_bits() != crate::value::TAG_UNDEFINED {
+        return param;
+    }
+    // param is `undefined` (cross-module construct dropped the cap arg):
+    // recover from the decl-site snapshot when one is registered for this
+    // class; otherwise stay `undefined`.
+    CLASS_CAPTURE_VALUES.with(|m| {
+        m.borrow()
+            .get(&class_id)
+            .and_then(|v| v.get(index as usize).copied())
+            .map(f64::from_bits)
+            .unwrap_or(param)
+    })
+}
+
 /// Keepalive anchors (generated-code-only callees).
 #[used]
 static KEEP_JS_CLASS_CAPTURE_VALUE: extern "C" fn(u32, u32) -> f64 = js_class_capture_value;
 #[used]
 static KEEP_JS_CLASS_CAPTURE_VALUE_OR: extern "C" fn(u32, u32, f64) -> f64 =
     js_class_capture_value_or;
+#[used]
+static KEEP_JS_PARAM_OR_CLASS_CAPTURE_VALUE: extern "C" fn(f64, u32, u32) -> f64 =
+    js_param_or_class_capture_value;
 
 /// `super(...spread)` — invoke the closest registered ancestor constructor
 /// of `child_cid` on the EXISTING `this`, with args from the materialized

--- a/crates/perry/tests/issue_5437_capture_rebind_param_first.rs
+++ b/crates/perry/tests/issue_5437_capture_rebind_param_first.rs
@@ -1,0 +1,134 @@
+//! Regression tests for the two CodeRabbit correctness findings on the #5437
+//! cross-module member-`new` capture fix (the synthesized-constructor capture
+//! rebind in `synthesize_class_captures`).
+//!
+//! FINDING 1 (param-first): the original rebind used
+//! `js_class_capture_value_or` (SNAPSHOT-first) — the decl-site snapshot won
+//! whenever it held a real value, even over the LIVE `new`-site cap arg. That
+//! is wrong for a SAME-module `new` of a class whose captured outer was MUTATED
+//! after the class declaration: the stale decl-site snapshot overrode the live
+//! mutated value. The rebind is now PARAM-first
+//! (`js_param_or_class_capture_value`): the live param wins whenever present;
+//! the decl-site snapshot is consulted ONLY when the param is `undefined` (the
+//! cross-module construct path, which drops the cap arg).
+//!
+//! FINDING 2 (rebind placement): the param rebinds were inserted AFTER
+//! `super()`, so a derived ctor that reads a captured outer BEFORE calling
+//! `super()` ran before the snapshot recovery. The rebinds now go at FUNCTION
+//! ENTRY (before any pre-`super()` user code); only the `this.__perry_cap_*`
+//! field stashes wait until after `super()`.
+//!
+//! Both expected outputs are byte-for-byte what `node
+//! --experimental-strip-types` prints.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed (exit {:?})\nstdout:\n{}\nstderr:\n{}",
+        run.status.code(),
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+/// FINDING 1 guard: a same-module `new C()` whose captured outer (`x`) was
+/// MUTATED after the class declaration must read the LIVE value `"b"`, not the
+/// stale decl-site snapshot `"a"`. Pre-rework (snapshot-first) this printed
+/// `"a"`. node `--experimental-strip-types` prints `"b"`.
+#[test]
+fn same_module_mutated_capture_uses_live_param_not_stale_snapshot() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+let x = "a";
+class C {
+  x: any;
+  constructor() {
+    this.x = x;
+  }
+}
+x = "b";
+const c = new C();
+console.log(c.x);
+"#,
+    );
+    assert_eq!(
+        stdout, "b\n",
+        "same-module `new` must use the LIVE mutated capture (param-first), \
+         not the stale decl-site snapshot"
+    );
+}
+
+/// FINDING 2 guard: a DERIVED ctor reads a captured outer (`cap`) BEFORE
+/// calling `super()`. The capture rebind must already be in effect at that
+/// point (rebinds at function entry), so `cap` resolves to its live value.
+/// Pre-rework the rebinds sat after `super()`, so the pre-`super()` read saw
+/// the un-recovered param. node prints `base` / `live-cap`.
+#[test]
+fn derived_ctor_reads_capture_before_super() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+function make() {
+  const cap = "live-cap";
+  class B {
+    b: any;
+    constructor() {
+      this.b = "base";
+    }
+  }
+  class D extends B {
+    v: any;
+    constructor() {
+      const v = cap; // read captured outer BEFORE super()
+      super();
+      this.v = v;
+    }
+  }
+  return new D();
+}
+const d = make();
+console.log(d.b);
+console.log(d.v);
+"#,
+    );
+    assert_eq!(
+        stdout, "base\nlive-cap\n",
+        "derived ctor reading a captured outer before super() must see the \
+         recovered value (rebinds at function entry)"
+    );
+}

--- a/crates/perry/tests/issue_5437_cross_module_member_new_capture.rs
+++ b/crates/perry/tests/issue_5437_cross_module_member_new_capture.rs
@@ -1,0 +1,134 @@
+//! Regression test for #5437 (Next.js dynamic/API routes — the `rJ`
+//! constructor "value is not a function" blocker).
+//!
+//! Root: a function-nested class that captures an enclosing-scope local
+//! (e.g. a hoisted sibling `function helper`) is exported from module A and
+//! constructed via a member-callee `new ns.C(...)` in a DIFFERENT module B.
+//! Because module B's codegen context doesn't contain class `C` (it lives in
+//! module A), `try_static_class_name` can't resolve the member callee, so the
+//! construct falls through to the runtime construct path
+//! (`construct_registered_class_ref`) which supplies NO capture args. The
+//! synthesized `__perry_cap_*` ctor params then bound to garbage/undefined and
+//! the captured local (`helper`) read as a non-callable —
+//! `new ns.C(); c.run()` threw `TypeError: value is not a function`.
+//!
+//! This is the cross-module variant of the W6 same-module member-new fix.
+//! The earlier fix only filled captures from the decl-site snapshot when the
+//! `new` site was statically routed to `lower_new_member_captured`; the
+//! cross-module runtime construct path never reached it. The fix routes the
+//! snapshot read INTO the synthesized constructor body itself
+//! (`this.__perry_cap_X = js_class_capture_value_or(cid, slot, param)`), so
+//! EVERY construction path — inline, member, or runtime cross-module —
+//! recovers the captured value from the class's own home-module snapshot.
+//!
+//! Mirrors Next's app-route-turbo `rJ` ctor (`this.methods = r_(e)` where
+//! `r_` is a hoisted sibling function captured by the class, constructed via
+//! `new w.AppRouteRouteModule({...})` from the app-route template chunk).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn cross_module_member_new_recovers_captures_from_snapshot() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    // Module A: a run-once factory IIFE that hoists a sibling `function
+    // tag()` and declares a class `Mod` whose constructor and method both
+    // call the captured `tag`. `Mod` is the default export, re-exported under
+    // a namespace by B. This mirrors the giant turbopack module factory that
+    // holds `function r_` + `class rJ { constructor(){ this.methods=r_(e) } }`.
+    std::fs::write(
+        dir.path().join("a.ts"),
+        r#"
+// A run-once factory IIFE (the turbopack module-factory shape) that hoists a
+// sibling `function tag` captured by the class, and exposes the class under a
+// DIFFERENT export name (`Mod`) than its internal class name (`InnerMod`) —
+// exactly mirroring `class rJ {}` exported as `AppRouteRouteModule`. The
+// export-name ≠ class-key mismatch is what makes the importing module unable
+// to resolve the member callee statically, forcing the runtime construct
+// path.
+const built = (function () {
+  function tag(x: any) {
+    return "tag:" + String(x);
+  }
+  function plain(x: any) {
+    return "plain:" + String(x);
+  }
+  class InnerMod {
+    label: any;
+    kind: any;
+    constructor(opts: any) {
+      // the throwing-site analog: `this.methods = r_(e)` — call the captured
+      // sibling function inside the ctor.
+      this.label = tag(opts.name);
+      this.kind = plain(opts.name);
+    }
+    describe() {
+      return tag(this.label);
+    }
+  }
+  return { InnerMod };
+})();
+export const Mod: any = built.InnerMod;
+"#,
+    )
+    .expect("write a.ts");
+
+    // Module B: imports A as a NAMESPACE and constructs `new ns.Mod(...)` — a
+    // CROSS-MODULE member-callee new of the captured class. `ns.Mod` cannot be
+    // resolved to the class statically here (the class lives in module A, and
+    // its key `InnerMod` ≠ the export `Mod`), so the construct routes to the
+    // runtime construct path which supplies no capture args.
+    std::fs::write(
+        dir.path().join("main.ts"),
+        r#"
+import * as ns from "./a.ts";
+const c: any = new (ns as any).Mod({ name: "hello" });
+console.log(c.label);
+console.log(c.kind);
+console.log(c.describe());
+"#,
+    )
+    .expect("write main.ts");
+
+    let output = dir.path().join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(dir.path().join("main.ts"))
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "compile failed:\n{}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    let stderr = String::from_utf8_lossy(&run.stderr);
+    assert!(
+        run.status.success(),
+        "compiled binary failed (exit {:?}):\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        run.status.code()
+    );
+    assert!(
+        !stderr.contains("value is not a function"),
+        "captured sibling function read as non-callable:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    // tag("hello") = "tag:hello"; plain("hello") = "plain:hello";
+    // describe() = tag("tag:hello") = "tag:tag:hello".
+    let expected = "tag:hello\nplain:hello\ntag:tag:hello\n";
+    assert_eq!(
+        stdout, expected,
+        "cross-module member-new must recover captured `tag` from the decl-site \
+         snapshot (matches node):\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
## What
A `new ns.Class(...)` construct where `Class` is imported from another module supplied **no capture args** — the captures live in the class's *home* module and aren't visible at the cross-module `new` site — so a captured value (e.g. a hoisted function) resolved to garbage/undefined and method calls on it threw `value is not a function`.

Found via Next.js dynamic/API routes (#5437): the app-route-turbo `rJ` route-module-class constructor does `this.methods = r_(e)` where `r_` is a captured module-scope fn; cross-module member-new dropped it → route `__init` aborted → `require(route.js)` undefined → 500 on every dynamic/API route.

## Fix
At ctor entry, rebind cross-module-captured params from the class's **decl-site capture snapshot** via `js_class_capture_value_or` (the same mechanism as the W6/TDZ capture fixes), driven by a new additive HIR `Expr` node emitted at the cross-module member-new site. (`perry-hir` ir/walkers/hash + `static_field_meta.rs` codegen.)

## Validation
- Regression test `issue_5437_cross_module_member_new_capture` (1 passed); broad capture/inheritance test `issue_4972_derived_class_capture_super` (3 passed) — no regression. 5 minimal repros of the cross-module member-new-capture shape match node.
- In the bundle: the `rJ`/`r_` `value is not a function` is eliminated; static routes stay byte-identical (no #5622 regression). (Dynamic routes still 500 on a *separate*, deeper scale-only blocker — captured `undefined` losing its NaN-box tag — tracked separately.)

Refs #5437.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cross-module class construction so captured values are recovered correctly when a class is instantiated via a namespace import.
  * Improved constructor capture rebinds to support param-first selection with correct fallback to decl-site snapshots.
  * Ensured capture rebinds are applied early enough (at constructor entry) so captured reads work correctly before `super()`.
* **Tests**
  * Added regression tests for issue `#5437`, including param-first behavior and cross-module “member-new” capture recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->