### PR TITLE
test: fix blocklist_addsubnet_prefix TempDir path (unblock cargo-test gate)

### DIFF
--- a/crates/perry/tests/blocklist_addsubnet_prefix.rs
+++ b/crates/perry/tests/blocklist_addsubnet_prefix.rs
@@ -16,8 +16,8 @@ fn perry_bin() -> PathBuf {
 #[test]
 fn block_list_add_subnet_respects_numeric_prefix() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let entry = dir.join("main.ts");
-    let out = dir.join("main_bin");
+    let entry = dir.path().join("main.ts");
+    let out = dir.path().join("main_bin");
     std::fs::write(
         &entry,
         r#"


### PR DESCRIPTION
## Problem

The full-workspace `cargo-test` gate (`test.yml`) has been **red on the nightly cron since 2026-06-20** — last green June 19. Tagging a release fails `release-packages.yml`'s `await-tests` gate, blocking publish.

Root cause: `crates/perry/tests/blocklist_addsubnet_prefix.rs` (added in #5473) calls `.join()` directly on a `tempfile::TempDir`, which has no such method:

```
error[E0599]: no method named `join` found for struct `TempDir`
  --> crates/perry/tests/blocklist_addsubnet_prefix.rs:19:21
```

## Fix

`dir.join(...)` → `dir.path().join(...)` (2 lines). `tempfile::tempdir()` returns a `TempDir`; `.path()` yields the `&Path` to join against.

## Why it slipped past CI

The per-PR `cargo-test` is scoped to `--lib`/`--bins` and never builds `tests/*.rs` integration tests. The full per-package run only happens on **tags + the nightly cron**, so the regression went undetected by the originating PR's required checks.

## Validation

`cargo test -p perry --test blocklist_addsubnet_prefix` → `test result: ok. 1 passed` locally on the merge-base of current `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated an existing test to build file paths more reliably when compiling and running the sample project.
  * No user-facing behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->