### PR TITLE
fix(ui-ios): adbanner uses perry_runtime::string::StringHeader (fix simctl build)

### DIFF
--- a/crates/perry-ui-ios/src/widgets/adbanner.rs
+++ b/crates/perry-ui-ios/src/widgets/adbanner.rs
@@ -25,9 +25,9 @@ fn str_from_header(ptr: *const u8) -> &'static str {
         return "";
     }
     unsafe {
-        let header = ptr as *const crate::string_header::StringHeader;
+        let header = ptr as *const perry_runtime::string::StringHeader;
         let len = (*header).byte_len as usize;
-        let data = ptr.add(std::mem::size_of::<crate::string_header::StringHeader>());
+        let data = ptr.add(std::mem::size_of::<perry_runtime::string::StringHeader>());
         std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
     }
 }


### PR DESCRIPTION
## Problem

The `v0.5.1205` release tag's `simctl-tests.yml` failed at **Build perry + iOS UI lib**:

```
error[E0433]: cannot find `string_header` in `crate`
  --> crates/perry-ui-ios/src/widgets/adbanner.rs:28
```

`perry-ui-ios` has no `string_header` module (only `perry-ui-macos` declares `pub mod string_header`). `adbanner.rs` was the lone file using `crate::string_header::StringHeader`; every sibling (`background`/`drag_drop`/`state`/`websocket`/`media_playback`) uses `perry_runtime::string::StringHeader`.

## Why CI missed it

`perry-ui-ios` is Apple-only and **excluded from the `cargo-test` gate**; it's built only by `simctl-tests.yml`, which runs on tags. Same blind spot as the blocklist cargo-test regression.

## Fix

`adbanner.rs` now uses `perry_runtime::string::StringHeader`, matching its siblings.

## Validation

Built locally for both simctl targets:
- `cargo build --release -p perry-ui-ios --target aarch64-apple-ios-sim` → ok
- `cargo build --release -p perry-ui-ios --features geisterhand --target aarch64-apple-ios` → ok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how banner text is read and displayed, helping prevent incorrect or corrupted strings from appearing in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->