### PR TITLE
fix(regexp): #5586 — RegExp(re) called as a function returns the argument unchanged

### DIFF
--- a/crates/perry-codegen/src/expr/logical_collections.rs
+++ b/crates/perry-codegen/src/expr/logical_collections.rs
@@ -694,25 +694,36 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // flags fall back to interning an empty string at codegen so
         // `js_regexp_new` always sees a real `StringHeader*`. Followup
         // to #957 / PR #959.
-        Expr::RegExpDynamic { pattern, flags } => {
+        Expr::RegExpDynamic {
+            pattern,
+            flags,
+            is_call,
+        } => {
             // Route through the full ECMAScript constructor: it handles a RegExp
             // pattern (copy / flag override), an `undefined`/`null` pattern
             // (`ToString` → `""`/`"null"`), an object pattern, and ToString-
             // coerced flags (an object flags → `"[object Object]"` → SyntaxError).
             // Passing the NaN-boxed values verbatim (NOT `unbox_str_handle`,
             // which mis-reads a non-string pattern as a StringHeader → garbage).
+            //
+            // The function-call form `RegExp(re)` (is_call) routes through
+            // `js_regexp_construct_call`, which applies the ECMA-262 22.2.4.1
+            // identity shortcut (a RegExp pattern + undefined flags returns the
+            // argument unchanged) before falling back to the same constructor.
+            // `new RegExp(re)` keeps `js_regexp_construct` so it always copies.
             let pattern_box = lower_expr(ctx, pattern)?;
             let flags_box = if let Some(flags_expr) = flags {
                 lower_expr(ctx, flags_expr)?
             } else {
                 double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
             };
+            let ctor = if *is_call {
+                "js_regexp_construct_call"
+            } else {
+                "js_regexp_construct"
+            };
             let blk = ctx.block();
-            let result = blk.call(
-                I64,
-                "js_regexp_construct",
-                &[(DOUBLE, &pattern_box), (DOUBLE, &flags_box)],
-            );
+            let result = blk.call(I64, ctor, &[(DOUBLE, &pattern_box), (DOUBLE, &flags_box)]);
             Ok(nanbox_pointer_inline(blk, &result))
         }
 

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1055,6 +1055,9 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // Full ECMAScript RegExp constructor: NaN-boxed pattern + flags in, handles
     // RegExp/undefined/object patterns and ToString-coerced flags.
     module.declare_function("js_regexp_construct", I64, &[DOUBLE, DOUBLE]);
+    // Function-call form `RegExp(x)`: identity shortcut (a RegExp arg + undefined
+    // flags returns the same object) then falls back to `js_regexp_construct`.
+    module.declare_function("js_regexp_construct_call", I64, &[DOUBLE, DOUBLE]);
     module.declare_function("js_regexp_test", I32, &[I64, I64]);
     // RegExp.escape(str) — #2899. Takes/returns NaN-boxed f64 (string).
     module.declare_function("js_regexp_escape", DOUBLE, &[DOUBLE]);

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -2143,6 +2143,14 @@ pub enum Expr {
     RegExpDynamic {
         pattern: Box<Expr>,
         flags: Option<Box<Expr>>,
+        /// `true` when this came from the *function-call* form `RegExp(x)`
+        /// (not `new RegExp(x)`). Per ECMA-262 22.2.4.1, calling `RegExp` as a
+        /// function with a RegExp `pattern` and `undefined` `flags` returns the
+        /// argument unchanged (object identity) rather than constructing a copy
+        /// — so the call form lowers to `js_regexp_construct_call` (identity
+        /// shortcut) while `new` keeps `js_regexp_construct` (always a fresh
+        /// object). See #5586.
+        is_call: bool,
     },
     /// regex.test(string) -> boolean
     RegExpTest {

--- a/crates/perry-hir/src/lower/expr_call/intrinsics/bare_builtins.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics/bare_builtins.rs
@@ -101,7 +101,7 @@ pub(crate) fn try_bare_regexp_call(
     call: &ast::CallExpr,
     has_spread: bool,
 ) -> Result<Option<Expr>> {
-    if !has_spread && !call.args.is_empty() && call.args.len() <= 2 {
+    if !has_spread && call.args.len() <= 2 {
         if let ast::Callee::Expr(callee_expr) = &call.callee {
             let mut callee_inner = callee_expr.as_ref();
             while let ast::Expr::Paren(p) = callee_inner {
@@ -112,7 +112,15 @@ pub(crate) fn try_bare_regexp_call(
                     && ctx.lookup_local("RegExp").is_none()
                     && ctx.lookup_func("RegExp").is_none()
                 {
-                    let pattern = lower_expr(ctx, &call.args[0].expr)?;
+                    // Zero-arg `RegExp()` is `RegExp(undefined)` → an empty
+                    // source `/(?:)/`. Without an explicit `Expr::Undefined`
+                    // pattern the call fell through to the bare-ident dispatch
+                    // and produced `null` (test262 S15.10.3.1_A1_T4, #5586).
+                    let pattern = if call.args.is_empty() {
+                        Expr::Undefined
+                    } else {
+                        lower_expr(ctx, &call.args[0].expr)?
+                    };
                     let flags = if call.args.len() == 2 {
                         Some(Box::new(lower_expr(ctx, &call.args[1].expr)?))
                     } else {
@@ -121,6 +129,9 @@ pub(crate) fn try_bare_regexp_call(
                     return Ok(Some(Expr::RegExpDynamic {
                         pattern: Box::new(pattern),
                         flags,
+                        // Function-call form `RegExp(x)`: eligible for the
+                        // ECMA-262 22.2.4.1 identity shortcut (#5586).
+                        is_call: true,
                     }));
                 }
             }

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -669,6 +669,9 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                         return Ok(Expr::RegExpDynamic {
                             pattern: Box::new(pattern),
                             flags,
+                            // `new RegExp(x)` always constructs a fresh object —
+                            // never the identity shortcut (#5586).
+                            is_call: false,
                         });
                     }
                 }

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -547,7 +547,7 @@ impl SH for Expr {
             Expr::NewTarget => { tag(h, 12271); }
             Expr::Closure { func_id, params, return_type, body, captures, mutable_captures, captures_this, captures_new_target, enclosing_class, is_arrow, is_async, is_generator, is_strict, } => { tag(h, 382); func_id.hash(h); params.hash(h); return_type.hash(h); body.hash(h); captures.hash(h); mutable_captures.hash(h); captures_this.hash(h); captures_new_target.hash(h); enclosing_class.hash(h); is_arrow.hash(h); is_async.hash(h); is_generator.hash(h); is_strict.hash(h); }
             Expr::RegExp { pattern, flags } => { tag(h, 383); pattern.hash(h); flags.hash(h); }
-            Expr::RegExpDynamic { pattern, flags } => { tag(h, 475); pattern.as_ref().hash(h); if let Some(f_box) = flags { tag(h, 476); f_box.as_ref().hash(h); } else { tag(h, 477); } }
+            Expr::RegExpDynamic { pattern, flags, is_call } => { tag(h, 475); pattern.as_ref().hash(h); if let Some(f_box) = flags { tag(h, 476); f_box.as_ref().hash(h); } else { tag(h, 477); } tag(h, if *is_call { 478 } else { 479 }); }
             Expr::RegExpTest { regex, string } => { tag(h, 384); regex.as_ref().hash(h); string.as_ref().hash(h); }
             Expr::StringMatch { string, regex } => { tag(h, 385); string.as_ref().hash(h); regex.as_ref().hash(h); }
             Expr::StringMatchAll { string, regex } => { tag(h, 386); string.as_ref().hash(h); regex.as_ref().hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -1091,7 +1091,11 @@ where
             f(regex);
             f(string);
         }
-        Expr::RegExpDynamic { pattern, flags } => {
+        Expr::RegExpDynamic {
+            pattern,
+            flags,
+            is_call: _,
+        } => {
             f(pattern);
             if let Some(flags_box) = flags {
                 f(flags_box);

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -1078,7 +1078,11 @@ where
             f(regex);
             f(string);
         }
-        Expr::RegExpDynamic { pattern, flags } => {
+        Expr::RegExpDynamic {
+            pattern,
+            flags,
+            is_call: _,
+        } => {
             f(pattern);
             if let Some(flags_box) = flags {
                 f(flags_box);

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -579,6 +579,48 @@ pub extern "C" fn js_regexp_construct(pattern: f64, flags: f64) -> *mut RegExpHe
     js_regexp_new(pat_ptr, flags_ptr)
 }
 
+/// `RegExp(...)` invoked as a *function* (not `new`). ECMA-262 22.2.4.1 step 2:
+/// when `NewTarget` is undefined, `pattern` is a RegExp and `flags` is
+/// `undefined`, and `pattern.constructor` is the `RegExp` intrinsic, the call
+/// returns `pattern` **unchanged** (object identity) instead of constructing a
+/// copy. So `var r = /x/i; RegExp(r) === r` is `true`, and a property added to
+/// `r` is visible through the returned reference (test262
+/// `built-ins/RegExp/S15.10.3.1_A1_T*`, #5586).
+///
+/// Perry models no user-visible RegExp subclassing, so a registered RegExp's
+/// `constructor` resolves through `RegExp.prototype` to the intrinsic `RegExp`
+/// and the `SameValue` check holds — *unless* user code has installed an own
+/// `constructor` property (e.g. `re.constructor = null`), which makes the
+/// `SameValue` check fail and forces a fresh copy
+/// (`built-ins/RegExp/call_with_regexp_not_same_constructor.js`). Every other
+/// shape (string/object/undefined pattern, or any non-`undefined` flags —
+/// which forces a fresh copy with the new flags) likewise falls through to the
+/// general [`js_regexp_construct`] path.
+#[cfg(feature = "regex-engine")]
+#[no_mangle]
+pub extern "C" fn js_regexp_construct_call(pattern: f64, flags: f64) -> *mut RegExpHeader {
+    let pv = crate::value::JSValue::from_bits(pattern.to_bits());
+    let fv = crate::value::JSValue::from_bits(flags.to_bits());
+    if fv.is_undefined() && pv.is_pointer() {
+        let addr = pv.as_pointer::<u8>() as usize;
+        if is_registered_regex(addr)
+            // SameValue(RegExp, pattern.constructor): the identity shortcut only
+            // applies while `constructor` is still the inherited intrinsic. An
+            // own `constructor` override (the only way it can differ here) must
+            // copy instead.
+            && crate::object::exotic_expando::value_lookup(
+                crate::object::exotic_expando::ExoticKind::RegExp,
+                addr,
+                "constructor",
+            )
+            .is_none()
+        {
+            return pv.as_pointer::<RegExpHeader>() as *mut RegExpHeader;
+        }
+    }
+    js_regexp_construct(pattern, flags)
+}
+
 /// Test if a string matches the regex pattern
 /// regex.test(string) -> boolean
 #[cfg(feature = "regex-engine")]

--- a/test-files/test_issue_5586_regexp_call_identity.ts
+++ b/test-files/test_issue_5586_regexp_call_identity.ts
@@ -1,0 +1,58 @@
+// #5586: `RegExp(re)` invoked as a *function* (not `new`) with a RegExp
+// argument and no `flags` returns the argument unchanged — object identity,
+// per ECMA-262 22.2.4.1. `new RegExp(re)`, or any call that supplies `flags`,
+// must construct a fresh copy instead.
+// (test262 built-ins/RegExp/S15.10.3.1_A1_T1 .. _A2_T2)
+
+function ok(name: string, value: boolean) {
+  if (!value) {
+    throw new Error(name + ": FAIL");
+  }
+  console.log(name + ": ok");
+}
+
+const re = /x/i;
+
+// Calling RegExp as a function with a RegExp and undefined flags returns the
+// SAME object: a property added afterwards is visible through the result.
+const instance = RegExp(re);
+(re as any).indicator = 1;
+ok("call-identity-same-object", instance === re);
+ok("call-identity-property-visible", (instance as any).indicator === 1);
+
+// Supplying flags forces a fresh copy (different object), even via the call form.
+const copyWithFlags = RegExp(re, "g");
+ok("call-with-flags-is-copy", copyWithFlags !== re);
+ok("call-with-flags-applies-flags", copyWithFlags.flags === "g");
+ok("call-with-flags-keeps-source", copyWithFlags.source === "x");
+
+// `new RegExp(re)` ALWAYS constructs a new object, never identity.
+const constructed = new RegExp(re);
+ok("new-is-copy", constructed !== re);
+ok("new-copies-source", constructed.source === "x");
+ok("new-copies-flags", constructed.flags === "i");
+
+// A non-RegExp argument is never the identity case — it builds a new RegExp.
+const fromString = RegExp("y");
+ok("call-from-string-source", fromString.source === "y");
+ok("call-from-string-not-input", (fromString as any) !== "y");
+
+// Zero-arg `RegExp()` (function-call form) builds an empty-source regex
+// `/(?:)/` — NOT null. It is an ordinary object that accepts expando props.
+const empty = RegExp();
+ok("call-empty-source", empty.source === "(?:)");
+ok("call-empty-no-flags", empty.flags === "");
+(empty as any).indicator = 1;
+ok("call-empty-is-object", (empty as any).indicator === 1);
+
+// The identity shortcut requires `pattern.constructor` to still be the RegExp
+// intrinsic. Overriding `constructor` makes SameValue fail → a fresh copy.
+const tweaked = /(?:)/;
+(tweaked as any).constructor = null;
+ok("call-other-constructor-is-copy", RegExp(tweaked) !== tweaked);
+
+// The copy is independent: mutating lastIndex on one must not affect the other.
+const g = /a/g;
+const gCopy = new RegExp(g);
+g.lastIndex = 3;
+ok("new-copy-independent-lastindex", gCopy.lastIndex === 0);


### PR DESCRIPTION
## What

Addresses the `RegExp(re)`-as-a-function bucket of #5586 (the `__instance.indicator` exec-result-wrong cluster, the largest non-categorical-gap group in that issue).

Per **ECMA-262 22.2.4.1**, when `RegExp` is invoked as a *function* (not `new`) with a RegExp `pattern` and `undefined` `flags`, and `pattern.constructor` is the `RegExp` intrinsic, the call returns `pattern` **unchanged** (object identity) rather than constructing a copy. Perry copied unconditionally, so:

```js
var r = /x/i;
RegExp(r) === r        // was false, should be true
r.indicator = 1;
RegExp(r).indicator    // was undefined, should be 1
```

## test262 cases fixed (`built-ins/RegExp`)

| test | gap |
|------|-----|
| `S15.10.3.1_A1_T1`, `_A1_T2`, `_A2_T1`, `_A2_T2` | identity when `flags` is undefined (incl. an expression evaluating to undefined) |
| `S15.10.3.1_A1_T4` | zero-arg `RegExp()` fell through to the bare-ident dispatch and produced `null` instead of an empty `/(?:)/` |
| `call_with_regexp_not_same_constructor` | overriding `re.constructor` must make `SameValue` fail → a fresh copy |

## How

- **HIR** — `Expr::RegExpDynamic` gains an `is_call` flag distinguishing the function-call form `RegExp(x)` from `new RegExp(x)`. Zero-arg `RegExp()` now folds with an `Expr::Undefined` pattern.
- **Runtime** — new `js_regexp_construct_call` applies the identity shortcut (gated on a RegExp pattern, undefined flags, and no own `constructor` override) then falls back to the general `js_regexp_construct`.
- **Codegen** — the call form routes to `js_regexp_construct_call`; `new RegExp` keeps `js_regexp_construct`, so it always copies.

`new RegExp(re)` and any flag-supplying call still construct a fresh, independent object.

## Validation

- `test-files/test_issue_5586_regexp_call_identity.ts` (new) — 15 assertions, byte-for-byte vs Node v26.3.0, covering identity, flag-copy, `new`-copy, zero-arg, constructor-override, and copy independence.
- `built-ins/RegExp` test262 subset: the cluster above now passes, **+2 over the in-progress baseline, 0 regressions, 0 `diff`, 0 `compile-fail`**.

The remaining #5586 failures are the deeper categorical gaps (newer-Unicode `\p{Script_Extensions=…}` scripts absent from the `regex` crate's Unicode tables, the `/v`-flag set notation, `eval()`-driven dynamic RegExp under AOT, and `RegExp`-as-a-Function-object) and are intentionally out of scope here.

Per maintainer instruction, this PR does **not** bump the version or add a CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved `RegExp(...)` handling to better match JavaScript, including the zero-argument form (`RegExp()`).
  * `RegExp(re)` can now reuse the same regex object when `re` is already a Perry RegExp and no `flags` are provided (subject to constructor conditions).

* **Bug Fixes**
  * `RegExp(re, flags)` now creates a fresh regex with the requested flags.
  * `new RegExp(re)` continues to always create a new regex object, with correct `lastIndex` and expando/property behavior.

* **Tests**
  * Added coverage for the `RegExp(re)` identity case and related edge conditions (issue `#5586`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->