### PR TITLE
fix(runtime): reject a tag-stripped capture fallback (NaN-box tag-loss of a captured undefined)

### DIFF
--- a/crates/perry-runtime/src/object/class_constructors.rs
+++ b/crates/perry-runtime/src/object/class_constructors.rs
@@ -187,12 +187,52 @@ pub extern "C" fn js_class_capture_value_or(class_id: u32, index: u32, fallback:
             // absent slot (out-of-range index) also falls back. Same shape as
             // the require-derived getSpan fix (no snapshot → fallback), extended
             // to the snapshot-present-but-`undefined`-slot case.
+            //
+            // #5437 (captured-`undefined` tag-loss, Next.js dynamic/API routes):
+            // a capture whose value is *genuinely* `undefined` (the bundle's
+            // `let t_ = process.env.X ? fn : void 0` debug logger, `undefined`
+            // by default) records `TAG_UNDEFINED` in the snapshot — which is the
+            // CORRECT value, not a TDZ artifact. At giant-module scale the
+            // `new`-site appended `fallback` for that same capture materializes
+            // as a tag-stripped raw word `0x0000_0000_0000_0001` (the low bits of
+            // `TAG_UNDEFINED` with the `0x7FFC` NaN-box tag stripped by a
+            // multi-level capture mis-box). Blindly preferring that `fallback`
+            // over the `undefined` snapshot handed `t_` the non-callable `0x1`,
+            // so `null == t_` was false → `t_(…)` was called → "value is not a
+            // function" → route init aborted → HTTP 500.
+            //
+            // A legitimate captured value is ALWAYS either NaN-boxed (top 16 bits
+            // ≥ 0x7FF9 for ptr/string/int32/bigint/SSO/special) or a normal
+            // IEEE-754 double (non-zero biased exponent). A `fallback` whose top
+            // 16 bits are all zero is therefore a tag-stripped/mis-boxed raw word,
+            // NEVER a real captured JSValue — so it must not override the
+            // snapshot. When the snapshot slot is `undefined` and the fallback is
+            // such a corrupt word, the snapshot's `undefined` is authoritative.
+            // (A valid fallback over an `undefined` snapshot still wins, keeping
+            // the hoisted-class/TDZ fix above.)
             Some(v) => match v.get(index as usize).copied() {
                 Some(bits) if bits != crate::value::TAG_UNDEFINED => f64::from_bits(bits),
-                _ => fallback,
+                slot => {
+                    if fallback_is_tag_stripped(fallback) {
+                        // Corrupt fallback — trust the snapshot (its `undefined`
+                        // for an undefined-valued capture, or `undefined` for an
+                        // absent slot).
+                        f64::from_bits(slot.unwrap_or(crate::value::TAG_UNDEFINED))
+                    } else {
+                        fallback
+                    }
+                }
             },
-            // No snapshot registered: use the `new`-site appended cap value.
-            None => fallback,
+            // No snapshot registered: use the `new`-site appended cap value —
+            // unless it is a tag-stripped/mis-boxed raw word, in which case the
+            // only safe interpretation is `undefined` (calling a `0x1` throws).
+            None => {
+                if fallback_is_tag_stripped(fallback) {
+                    f64::from_bits(crate::value::TAG_UNDEFINED)
+                } else {
+                    fallback
+                }
+            }
         }
     })
 }
@@ -234,6 +274,24 @@ pub extern "C" fn js_param_or_class_capture_value(param: f64, class_id: u32, ind
             .map(f64::from_bits)
             .unwrap_or(param)
     })
+}
+
+/// A legitimate JSValue is either NaN-boxed (top 16 bits ≥ 0x7FF9 — the boxed
+/// tags: SSO/BIGINT/special/POINTER/INT32/STRING) or a normal IEEE-754 double.
+/// A NON-ZERO value whose top 16 bits are all zero is a positive subnormal
+/// (< 2^-996) — a magnitude no program meaningfully captures — and is in
+/// practice the `0x7FFC_…_0001 → 0x0000_…_0001` signature of a captured
+/// `undefined` (or any heap pointer) that lost its NaN-box tag through a
+/// low-bits extraction at giant-module scale. Such a word is never a real
+/// captured value, so the capture-snapshot fallback must reject it. See #5437.
+///
+/// `+0.0`/`-0.0` are excluded: the number `0` is a legitimate captured value
+/// (its bits are `0x0000_…_0000` / `0x8000_…_0000`, the latter has a non-zero
+/// top 16), and a TDZ fallback that is genuinely `0` must still win.
+#[inline]
+pub(crate) fn fallback_is_tag_stripped(fallback: f64) -> bool {
+    let bits = fallback.to_bits();
+    (bits >> 48) == 0 && bits != 0
 }
 
 /// Keepalive anchors (generated-code-only callees).

--- a/crates/perry-runtime/src/object/tests.rs
+++ b/crates/perry-runtime/src/object/tests.rs
@@ -787,3 +787,89 @@ fn object_to_string_rejects_handle_band_ids() {
         );
     }
 }
+
+/// #5437 — captured-`undefined` tag-loss on Next.js dynamic/API routes.
+///
+/// `js_class_capture_value_or` must NOT replace a snapshot whose slot is a
+/// genuinely-undefined capture (`TAG_UNDEFINED`) with a tag-stripped/mis-boxed
+/// raw-word `fallback` (`0x0000_0000_0000_0001` — `TAG_UNDEFINED` with its
+/// `0x7FFC` NaN-box tag stripped). The bundle's `let t_ = cond ? fn : void 0`
+/// debug logger is `undefined`; at giant-module scale the `new`-site appended
+/// fallback for it materialized as `0x1`, so the snapshot's correct `undefined`
+/// was discarded → `t_` became `0x1` → `null == t_` false → `t_(…)` called →
+/// "value is not a function" → route 500.
+#[test]
+fn class_capture_value_or_rejects_tag_stripped_fallback() {
+    const TAG_UNDEFINED: u64 = crate::value::TAG_UNDEFINED; // 0x7FFC_0000_0000_0001
+    const STRIPPED: u64 = 0x0000_0000_0000_0001; // tag-stripped undefined
+    let undef = f64::from_bits(TAG_UNDEFINED);
+    let stripped = f64::from_bits(STRIPPED);
+
+    // Case 1 (THE BUG): snapshot slot is genuinely `undefined`, fallback is the
+    // tag-stripped `0x1`. Must return `undefined`, NOT the corrupt fallback.
+    let cid_a: u32 = 0x5437_0001;
+    let snap_a = [TAG_UNDEFINED, TAG_UNDEFINED, TAG_UNDEFINED];
+    unsafe {
+        js_class_register_capture_values(cid_a, snap_a.as_ptr() as *const f64, snap_a.len());
+    }
+    let got = js_class_capture_value_or(cid_a, 1, stripped).to_bits();
+    assert_eq!(
+        got, TAG_UNDEFINED,
+        "undefined snapshot + tag-stripped fallback must yield undefined, got {got:#018x}"
+    );
+
+    // Case 2 (W6 — snapshot wins): a real pointer in the snapshot stays
+    // authoritative even when the fallback is a (different) real value.
+    let cid_b: u32 = 0x5437_0002;
+    let real_ptr = crate::value::POINTER_TAG | 0x1234_5678;
+    let snap_b = [real_ptr];
+    unsafe {
+        js_class_register_capture_values(cid_b, snap_b.as_ptr() as *const f64, snap_b.len());
+    }
+    let other = f64::from_bits(crate::value::POINTER_TAG | 0xDEAD);
+    let got_b = js_class_capture_value_or(cid_b, 0, other).to_bits();
+    assert_eq!(
+        got_b, real_ptr,
+        "non-undefined snapshot slot must win over the fallback (W6), got {got_b:#018x}"
+    );
+
+    // Case 3 (#5437 hoisted-class/TDZ — VALID fallback over undefined snapshot
+    // still wins): snapshot slot is `undefined` (class decl hoisted above the
+    // local's assignment) but the fallback is a legitimate NaN-boxed value.
+    let cid_c: u32 = 0x5437_0003;
+    let snap_c = [TAG_UNDEFINED];
+    unsafe {
+        js_class_register_capture_values(cid_c, snap_c.as_ptr() as *const f64, snap_c.len());
+    }
+    let valid_fb = crate::value::POINTER_TAG | 0xCAFE;
+    let got_c = js_class_capture_value_or(cid_c, 0, f64::from_bits(valid_fb)).to_bits();
+    assert_eq!(
+        got_c, valid_fb,
+        "undefined snapshot + VALID fallback must keep the fallback (TDZ fix), got {got_c:#018x}"
+    );
+
+    // Case 4 (no snapshot + tag-stripped fallback): with no registered snapshot
+    // a corrupt `0x1` fallback is not callable, so resolve to `undefined`.
+    let cid_d: u32 = 0x5437_0004; // never registered
+    let got_d = js_class_capture_value_or(cid_d, 0, stripped).to_bits();
+    assert_eq!(
+        got_d, TAG_UNDEFINED,
+        "no snapshot + tag-stripped fallback must yield undefined, got {got_d:#018x}"
+    );
+
+    // Case 5 (no snapshot + valid fallback): the appended cap value is used
+    // (getSpan/require-derived-capture path preserved).
+    let cid_e: u32 = 0x5437_0005; // never registered
+    let valid2 = crate::value::POINTER_TAG | 0xBEEF;
+    let got_e = js_class_capture_value_or(cid_e, 0, f64::from_bits(valid2)).to_bits();
+    assert_eq!(
+        got_e, valid2,
+        "no snapshot + valid fallback must use the fallback, got {got_e:#018x}"
+    );
+
+    // Sanity: `0.0` (the number zero) is a legitimate captured value and must
+    // NOT be treated as a tag-stripped word.
+    assert!(!fallback_is_tag_stripped(0.0_f64));
+    assert!(fallback_is_tag_stripped(stripped));
+    assert!(!fallback_is_tag_stripped(undef));
+}


### PR DESCRIPTION
## What
`js_class_capture_value_or(cid, slot, fallback)` returns the new-site `fallback` when the decl-site snapshot slot is `undefined` (the hoisted-class/TDZ + require-derived fixes). But at giant-minified-module scale a multi-level capture can deliver a **tag-stripped** fallback — a NaN-boxed `undefined` (`0x7FFC_0000_0000_0001`) whose top-16 tag bits got stripped to a raw `0x0000_0000_0000_0001`. Returning that `0x1` (instead of the snapshot's correct `undefined`) makes `null == x` false → the value gets *called* → `value is not a function`.

Found via Next.js (#5437): the app-route-turbo `loadCustomCacheHandlers` captures `t_` (the `NEXT_PRIVATE_DEBUG_CACHE` debug logger, `undefined` by default); the tag-stripped `0x1` made `null == t_` false → `t_(...)` called → route `__init` aborted → 500 on dynamic/API routes. Bit evidence: snapshot held `0x7FFC…01`, returned fallback `0x1`.

## Fix
`fallback_is_tag_stripped(bits) = (bits >> 48) == 0 && bits != 0` (excludes +0.0/-0.0 so the number `0` stays valid). When the snapshot slot is undefined/absent **and** the fallback is such a corrupt word, keep the snapshot's `undefined` rather than the corrupt fallback. Valid fallbacks over an undefined snapshot still win (preserves the hoisted-class/TDZ + require-derived fixes); a non-undefined snapshot still wins (preserves W6). A legit captured JSValue is always NaN-boxed (top-16 ≥ 0x7FF9) or a normal double, so a non-zero word with top-16 == 0 is never a real captured value.

## Validation
- Regression test `class_capture_value_or_rejects_tag_stripped_fallback` (5 cases + sanity).
- Probe-confirmed on the bundle: the captured-`undefined`→`0x1` tag-loss + its `value is not a function` throw are eliminated (non-callable-`0x1` count 1→0); the render advances past the wall. Static routes stay byte-identical.
- `cargo test -p perry-hir -p perry-codegen -p perry-runtime`: 1732 passed, 0 failed; capture/inheritance tests (issue_4972, cross-module-#2, W6/TDZ) unregressed.

(Dynamic/API routes still 500 on a *separate* downstream wall — tracked separately.)

Refs #5437.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved captured class value resolution to correctly preserve genuine `undefined` snapshots.
  * Prevented suspicious “tag-stripped” fallback values from being used when they could produce an invalid result instead of `undefined` (or the intended fallback).
* **Tests**
  * Added regression coverage for combinations of registered snapshots and fallbacks, including genuine `undefined`, real captured values, and invalid tag-stripped inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->