### PR TITLE
fix(runtime): #5625 — Temporal brand probe must skip header-less typed arrays/buffers

### DIFF
--- a/crates/perry-runtime/src/temporal/mod.rs
+++ b/crates/perry-runtime/src/temporal/mod.rs
@@ -210,6 +210,16 @@ pub fn alloc_temporal_cell(value: TemporalValue) -> f64 {
 /// then read the `GcHeader.obj_type`.
 #[inline]
 pub fn is_temporal_cell_addr(addr: usize) -> bool {
+    // #5625: small typed arrays and `Buffer`s are raw-`alloc`'d off the GC heap
+    // with NO `GcHeader` prefix, so the word at `addr - GC_HEADER_SIZE` is
+    // unrelated heap memory that can coincidentally hold the `GC_TYPE_TEMPORAL`
+    // tag (observed: a 4-element typed array whose stale back-read obj_type was
+    // 18 → `<TA>.slice()` mis-routed through Temporal dispatch and deref'd a
+    // garbage cell). They are never `TemporalCell`s; reject them via the side
+    // tables first, exactly as `crate::date::is_date_cell_addr` does.
+    if crate::typedarray::is_offheap_sidetable_alloc(addr) {
+        return false;
+    }
     match unsafe { crate::value::addr_class::try_read_gc_header(addr) } {
         Some(header) => header.obj_type == crate::gc::GC_TYPE_TEMPORAL,
         None => false,


### PR DESCRIPTION
## What

Fixes the **TypedArray species-constructor crashes** — the net-new #5579-batch test262 regressions tracked in #5625 (the other 17 from that issue were already resolved by #5628).

## Root cause

`temporal::is_temporal_cell_addr` brand-probed a candidate receiver by reading `GcHeader.obj_type` at `addr - GC_HEADER_SIZE` **without first excluding off-GC-heap, header-less allocations**. Small typed arrays and `Buffer`s are raw-`alloc`'d with **no** 8-byte `GcHeader` prefix, so that back-read lands on unrelated preceding heap bytes — which can coincidentally equal `GC_TYPE_TEMPORAL` (18).

When it did, a method call on such a typed array (`<TA>.slice()` / `.subarray()` / `.every()`) was mis-routed through `temporal::dispatch::call_method`, which then dereferenced the "cell"'s value box (actually the typed array's `{length, capacity}` words, e.g. `0x0000000400000004` for a 4-element array) as a `Box<TemporalValue>` and segfaulted. This surfaced as the silent `(no output)` crashes in the report.

Because the trigger is a coincidental byte value in adjacent heap memory, the crash was allocation-layout dependent (deterministic under the test262 harness, masked by extra allocations from `print`/auto-optimize — which is why it only reproduced under `PERRY_NO_AUTO_OPTIMIZE`).

## Fix

Reject header-less side-table allocations via `crate::typedarray::is_offheap_sidetable_alloc` before the deref — exactly as `crate::date::is_date_cell_addr` already does for the identical reason (the `Map`/`Set` brand probes are safe because they consult their registries first). A real `TemporalCell` is never registered as a typed array or buffer, so the guard never rejects a genuine Temporal value.

## Verification

The 4 affected cases now pass deterministically (each 5×), and the broader `built-ins/TypedArray/prototype/{slice,map,subarray,every}` sweep is **160/161** (the 1 remaining — `every/callbackfn-not-callable-throws` — is a pre-existing, unrelated argument-validation gap):

```
built-ins/TypedArray/prototype/slice/speciesctor-get-ctor-returns-throws.js    => exit=0
built-ins/TypedArray/prototype/map/speciesctor-get-ctor-returns-throws.js      => exit=0
built-ins/TypedArray/prototype/subarray/speciesctor-get-ctor-returns-throws.js => exit=0
built-ins/TypedArray/prototype/every/returns-true-if-every-cb-returns-true.js  => exit=0
```

Temporal is unaffected — `built-ins/Temporal/{Duration,PlainDate,Instant}` self-validated sweep stays at 97.8% (1620/1657), and a Temporal smoke test (`Duration`/`PlainDate`/`Instant` arithmetic + formatting) passes.

## Out of scope

The remaining `built-ins/Array/prototype/copyWithin/coerced-values-start-change-start` case in #5625 is a **separate, pre-existing, flaky generational-GC bug**: an array's custom `[[Prototype]]` (set via `Object.setPrototypeOf` and stored as an old→young edge in an external side-table) is not rewritten when the prototype is evacuated by a minor GC, so an inherited index read intermittently sees a stale/forwarded pointer. It is independent of this regression and needs dedicated remembered-set work; #5625 can stay open for it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of typed arrays and buffers so off-heap allocations are no longer mistaken for temporal cells.
  * Prevented incorrect routing caused by reading unrelated heap data during temporal address checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->