### PR TITLE
fix(ffi): quarantine freed handle ids one tick to close use-after-recycle (stacked on #5643)

### DIFF
--- a/crates/perry-ext-http-server/src/server.rs
+++ b/crates/perry-ext-http-server/src/server.rs
@@ -918,20 +918,29 @@ pub extern "C" fn js_node_http_server_close_all_connections(handle: i64) {
     // Parked async requests on the destroyed connections can never flush
     // a response (the per-request oneshot receiver died with the
     // connection task) — drop them now so `has_in_flight_requests()`
-    // doesn't pin the event loop for the 300s grace window.
-    let mut to_finalize: Vec<(i64, i64)> = Vec::new();
+    // doesn't pin the event loop for the 300s grace window. The response
+    // never ended, so a handler still suspended on a slow `await` could
+    // resume and write through the bare id; defer recycling that id until the
+    // request's grace deadline (same use-after-recycle guard as the reaper's
+    // peer-gone path) so a late write hits an empty slot, not a recycled one.
+    let mut to_finalize: Vec<(i64, i64, Option<Instant>)> = Vec::new();
     if let Ok(mut guard) = IN_FLIGHT.lock() {
         guard.retain(|e| {
             if e.server_handle == handle {
-                to_finalize.push((e.request_handle, e.response_handle));
+                let recycle_deadline = if response_writable_ended(e.response_handle) {
+                    None
+                } else {
+                    Some(e.deadline)
+                };
+                to_finalize.push((e.request_handle, e.response_handle, recycle_deadline));
                 false
             } else {
                 true
             }
         });
     }
-    for (req, res) in to_finalize {
-        finalize_request_handles(req, res);
+    for (req, res, recycle_deadline) in to_finalize {
+        finalize_request_handles_deferred(req, res, recycle_deadline);
     }
 }
 
@@ -1404,11 +1413,31 @@ fn response_writable_ended(response_handle: i64) -> bool {
 }
 
 /// Free the per-request request + response handles. Mirrors the tail of
-/// the synchronous-handler path in `process_pending`.
+/// the synchronous-handler path in `process_pending`. The response is ended
+/// (or about to be, via synthesize), so its id takes the one-tick fast path.
 fn finalize_request_handles(request_handle: i64, response_handle: i64) {
+    finalize_request_handles_deferred(request_handle, response_handle, None);
+}
+
+/// Free the per-request handles. `recycle_deadline` is `Some` only when the
+/// response is being finalized WITHOUT having ended (the reaper's
+/// peer-disconnect / server-force-close paths) — its id is then held in the
+/// deadline-gated quarantine through the request's grace window so a
+/// long-suspended handler that resumes and writes hits an empty slot rather
+/// than a recycled response (see `perry_ffi::drop_handle_until`). `None` is the
+/// ended / synchronous case. The request id always takes the one-tick path —
+/// `IncomingMessage` has no late-write surface, and it is closed here first.
+fn finalize_request_handles_deferred(
+    request_handle: i64,
+    response_handle: i64,
+    recycle_deadline: Option<Instant>,
+) {
     close_incoming_message(request_handle);
     perry_ffi::drop_handle(request_handle);
-    perry_ffi::drop_handle(response_handle);
+    match recycle_deadline {
+        Some(deadline) => perry_ffi::drop_handle_until(response_handle, deadline),
+        None => perry_ffi::drop_handle(response_handle),
+    };
 }
 
 /// True iff any request is parked awaiting an async handler — keeps the
@@ -1423,8 +1452,8 @@ fn has_in_flight_requests() -> bool {
 /// grace deadline has elapsed (a handler that never responds). Called each
 /// pump tick. #4728.
 fn reap_in_flight_requests() {
-    // (request_handle, response_handle, needs_synthesize)
-    let mut to_finalize: Vec<(i64, i64, bool)> = Vec::new();
+    // (request_handle, response_handle, needs_synthesize, recycle_deadline)
+    let mut to_finalize: Vec<(i64, i64, bool, Option<Instant>)> = Vec::new();
     let mut drain_listeners: Vec<Vec<i64>> = Vec::new();
     {
         let mut guard = match IN_FLIGHT.lock() {
@@ -1457,14 +1486,28 @@ fn reap_in_flight_requests() {
                 || crate::response::stream_receiver_gone(e.response_handle);
             let expired = now >= e.deadline;
             if ended || expired || peer_gone {
+                // Only synthesize when we're giving up on a handler
+                // that never ended the response — not when it ended
+                // it itself, never for skip-default paths, and never
+                // when the peer is gone (nothing to deliver to).
+                let needs_synth = !ended && !e.skip_default_response && !peer_gone;
+                // If the response will NOT be ended after finalize (it wasn't
+                // ended and we're not synthesizing it to ended — the peer-gone
+                // and not-ended-skip-default paths), its `writable_ended` stays
+                // unset, so a handler suspended on a slow `await` could resume
+                // later and write through the bare id. Defer recycling that id
+                // until the request's grace deadline so the late write lands on
+                // an empty slot for the whole window, not a recycled response.
+                let recycle_deadline = if ended || needs_synth {
+                    None
+                } else {
+                    Some(e.deadline)
+                };
                 to_finalize.push((
                     e.request_handle,
                     e.response_handle,
-                    // Only synthesize when we're giving up on a handler
-                    // that never ended the response — not when it ended
-                    // it itself, never for skip-default paths, and never
-                    // when the peer is gone (nothing to deliver to).
-                    !ended && !e.skip_default_response && !peer_gone,
+                    needs_synth,
+                    recycle_deadline,
                 ));
                 false
             } else {
@@ -1478,11 +1521,11 @@ fn reap_in_flight_requests() {
     // Finalize outside the lock — `synthesize_default_response_if_needed`
     // and `drop_handle` don't touch `IN_FLIGHT`, but keeping them off the
     // lock avoids any future re-entrancy surprise.
-    for (req, res, needs_synth) in to_finalize {
+    for (req, res, needs_synth, recycle_deadline) in to_finalize {
         if needs_synth {
             synthesize_default_response_if_needed(res);
         }
-        finalize_request_handles(req, res);
+        finalize_request_handles_deferred(req, res, recycle_deadline);
     }
 }
 

--- a/crates/perry-ext-http-server/src/server.rs
+++ b/crates/perry-ext-http-server/src/server.rs
@@ -1621,6 +1621,19 @@ where
 pub extern "C" fn js_node_http_server_process_pending() -> i32 {
     let mut count = 0i32;
 
+    // Promote ids freed on PRIOR ticks from quarantine to the reusable
+    // freelist — at the top of the tick, before this tick's finalizations
+    // quarantine fresh ids. The one-tick deferral closes the same-tick ABA
+    // hazard: a handler that returned before `res.end()` leaves a stale `res`
+    // (a bare tagged handle id) outstanding, and recycling its id immediately
+    // would let the next request re-occupy it and a microtask-deferred
+    // `res.write`/`res.end` corrupt the new request's response. Holding the id
+    // in quarantine for a full tick lets those stale calls spend themselves
+    // against an empty slot first. (A write deferred MORE than a tick past
+    // finalization is a write-after-end use error and out of scope — see
+    // `perry_ffi::drain_quarantined_handles`.)
+    perry_ffi::drain_quarantined_handles();
+
     // #4728 — finalize any async-handler requests that have flushed their
     // response since the last tick (or timed out) before draining new ones.
     reap_in_flight_requests();

--- a/crates/perry-ffi/src/handle.rs
+++ b/crates/perry-ffi/src/handle.rs
@@ -34,6 +34,15 @@
 //! handles live at any instant — a recycled id is only parked after
 //! its prior entry was removed from the map.
 //!
+//! A freed id is NOT reusable the instant it is freed: it first sits
+//! in a quarantine and is promoted to the freelist only by
+//! [`drain_quarantined_handles`], which the host event loop calls
+//! once per tick. This deferral closes an ABA / use-after-recycle
+//! hazard — a consumer holding a stale bare id (e.g. an HTTP handler's
+//! `res` after the response was finalized) would otherwise see its id
+//! re-occupied by the next registration within the same tick and
+//! silently mutate a different object. See [`QUARANTINED_HANDLES`].
+//!
 //! perry-stdlib has its own copy of this same registry (in
 //! `crates/perry-stdlib/src/common/handle.rs`). They are separate
 //! integer spaces — perry-ffi-allocated handles cannot be looked
@@ -107,17 +116,97 @@ static FREE_HANDLES: Lazy<Mutex<Vec<Handle>>> = Lazy::new(|| Mutex::new(Vec::new
 /// before recycling existed.
 const FREE_HANDLES_CAP: usize = 64 * 1024;
 
+/// Quarantine for ids that have just been removed from [`HANDLES`] but are NOT
+/// yet eligible for reuse.
+///
+/// # Why a quarantine, not direct recycling (ABA / use-after-recycle)
+///
+/// The visible handle is a bare integer with no generation/epoch (the i64 ABI
+/// is fixed and published — a generation cannot be packed into the id). A
+/// consumer that resolves an object purely by id therefore cannot distinguish
+/// "the object I was given" from "a *different* object that happens to occupy
+/// the same recycled id now." `perry-ext-http-server` hits this: a request
+/// handler can return before `res.end()`, leaving a stale JS-side `res` value
+/// (a bare tagged id) outstanding; once that request is finalized its id is
+/// freed. If the id were recycled *immediately*, the very next
+/// [`register_handle`] (e.g. the next incoming request's response) would
+/// re-occupy it, and a late `res.write`/`res.end` from the retired handler
+/// would resolve the id to — and mutate — the *new* request's response,
+/// bleeding one request's body into another's. Before the freelist existed a
+/// freed id stayed dead, so such a stale write was a safe no-op; the freelist
+/// removed that safety. The quarantine restores it.
+///
+/// A freed id is parked here first and only promoted to [`FREE_HANDLES`] by
+/// [`drain_quarantined_handles`], which the host event loop calls once per
+/// pump tick. One full tick covers the dominant case: a stale `res.*` that the
+/// retired handler defers via a microtask or a same-turn continuation runs
+/// before the next tick's drain, and while the id sits in quarantine it maps
+/// to nothing in [`HANDLES`], so that stale call re-fetches an empty slot and
+/// no-ops (exactly the pre-freelist behavior) instead of corrupting a live
+/// object.
+///
+/// The window is one tick, not unbounded: a stale write deferred MORE than a
+/// tick past finalization (e.g. `res.end(); setTimeout(() => res.write(x))`)
+/// can still land after the id was promoted and possibly re-occupied. That is
+/// out of scope here — writing after `res.end()` is a use error Node itself
+/// rejects (`ERR_STREAM_WRITE_AFTER_END`), and closing it generally needs a
+/// per-handle generation, which the fixed/published i64 handle ABI forbids
+/// (packing a generation into the id is the rejected option-A). The one-tick
+/// quarantine restores the pre-freelist safety for the realistic async-handler
+/// shape (`await`/`fetch`/microtask, then `res.end()`).
+///
+/// Embedders that never call [`drain_quarantined_handles`] simply never
+/// recycle ids — they fall back to fresh-id minting, which is the pre-freelist
+/// behavior and is safe (it only forgoes the id-reuse optimization).
+static QUARANTINED_HANDLES: Lazy<Mutex<Vec<Handle>>> = Lazy::new(|| Mutex::new(Vec::new()));
+
 /// Pop a recycled id, or `None` when the freelist is empty.
 fn pop_free_handle() -> Option<Handle> {
     FREE_HANDLES.lock().unwrap_or_else(|p| p.into_inner()).pop()
 }
 
-/// Return a no-longer-live id to the freelist for reuse. Caller MUST have
-/// already removed `handle` from [`HANDLES`] (see the safety note above).
-/// Drops the id when the freelist is at [`FREE_HANDLES_CAP`].
+/// Park a no-longer-live id in the quarantine (NOT the freelist — see
+/// [`QUARANTINED_HANDLES`]). Caller MUST have already removed `handle` from
+/// [`HANDLES`] (see the safety note above). Drops the id when the quarantine
+/// is at [`FREE_HANDLES_CAP`], in which case the id is simply never reused
+/// (the fresh-id path still serves it), matching the freelist's overflow
+/// behavior.
 fn recycle_handle(handle: Handle) {
+    let mut q = QUARANTINED_HANDLES
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    push_bounded(&mut q, handle, FREE_HANDLES_CAP);
+}
+
+/// Promote every currently-quarantined id to the freelist, making it eligible
+/// for reuse by [`register_handle`]. The host event loop calls this once per
+/// pump tick, AT THE TOP of the tick — before any of this tick's finalizations
+/// quarantine new ids — so an id freed during tick N is released no earlier
+/// than the start of tick N+1, by which point tick N's handler microtasks have
+/// drained and any stale handle reference has been spent against an empty slot.
+/// See [`QUARANTINED_HANDLES`] for the full rationale.
+///
+/// Returns the number of ids promoted (for diagnostics/tests).
+pub fn drain_quarantined_handles() -> usize {
+    let drained: Vec<Handle> = {
+        let mut q = QUARANTINED_HANDLES
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        std::mem::take(&mut *q)
+    };
+    if drained.is_empty() {
+        return 0;
+    }
     let mut free = FREE_HANDLES.lock().unwrap_or_else(|p| p.into_inner());
-    push_bounded(&mut free, handle, FREE_HANDLES_CAP);
+    let mut promoted = 0;
+    for handle in drained {
+        let before = free.len();
+        push_bounded(&mut free, handle, FREE_HANDLES_CAP);
+        if free.len() != before {
+            promoted += 1;
+        }
+    }
+    promoted
 }
 
 /// Push `handle` onto `free` unless it is already at `cap`. Factored out so
@@ -727,26 +816,36 @@ mod tests {
     /// returning the reused handle. Each non-reusing attempt is dropped so it
     /// re-parks an id for the next try.
     ///
+    /// A freed id now sits in QUARANTINE until [`drain_quarantined_handles`]
+    /// promotes it to the freelist (the ABA fix), so each attempt drains first
+    /// — exactly what the host event loop does once per tick. A no-reclaim
+    /// `drop_handle` would quarantine NOTHING, so the drain promotes nothing
+    /// and reuse never happens: the contract still fails hard against a build
+    /// that doesn't reclaim.
+    ///
     /// The bounded retry is what makes the reuse assertion both robust and
     /// meaningful on the *process-wide* freelist. The non-serialized registry
     /// tests (`round_trip_simple_value` etc.) run in parallel and can pop the
     /// very id we just freed in the window before our register — so a single
     /// observation can legitimately miss reuse. But recycling guarantees reuse
-    /// happens *eventually* (we keep re-parking ids), whereas a no-reclaim
-    /// `drop_handle` parks NOTHING, so every attempt mints fresh and the loop
-    /// exhausts — turning "reuse never happens" into a hard failure.
+    /// happens *eventually* (we keep re-parking + re-draining ids), whereas a
+    /// no-reclaim `drop_handle` parks NOTHING, so every attempt mints fresh and
+    /// the loop exhausts — turning "reuse never happens" into a hard failure.
     fn drop_then_register_reusing<T: 'static + Send + Sync>(id: Handle, value: T) -> Handle
     where
         T: Clone,
     {
         assert!(drop_handle(id), "the id to recycle must have been live");
         for _ in 0..10_000 {
+            // Promote prior-tick quarantined ids to the freelist (the host
+            // pump's per-tick drain), then observe whether register reuses one.
+            drain_quarantined_handles();
             let (handle, reused) = register_observing_reuse(value.clone());
             if reused {
                 return handle;
             }
             // A parallel test popped our parked id first and we minted fresh;
-            // drop it (re-parking an id) and try again.
+            // drop it (re-quarantining an id) and try again.
             assert!(drop_handle(handle));
         }
         panic!(
@@ -793,7 +892,101 @@ mod tests {
     }
 
     #[test]
+    fn freed_id_is_not_reusable_until_drained_no_cross_request_bleed() {
+        // The ABA / use-after-recycle regression. Models the HTTP cross-request
+        // body bleed in handle-registry terms (the layer where the hazard lives,
+        // independent of perry-ext-http-server's reaper plumbing):
+        //
+        //   1. A request's response object R1 is registered under id `h`.
+        //   2. The handler returns before `res.end()`; later the request is
+        //      finalized → `drop_handle(h)`. R1's id `h` is now FREED.
+        //   3. WITHIN THE SAME TICK a new request registers its response R2.
+        //   4. A stale `res.write`/`res.end` from the retired handler fires,
+        //      carrying only the bare id `h`, and mutates whatever `h` resolves
+        //      to.
+        //
+        // The hazard: if step 2's free made `h` immediately reusable, step 3
+        // would re-occupy `h` with R2, and step 4 would mutate R2 — one
+        // request's body bleeding into another's response. The quarantine fix
+        // makes a freed id reusable only after `drain_quarantined_handles`
+        // (the host pump's per-tick promotion, which runs only AFTER the
+        // finalizing handler's microtasks — and thus any stale writes — have
+        // drained). So within the tick `h` resolves to NOTHING, and the stale
+        // write no-ops against the empty slot exactly as it did before the
+        // freelist existed.
+        let _serial = RECYCLE_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+        // A `ServerResponse`-shaped stand-in: the field a bleed would corrupt.
+        #[derive(Clone)]
+        struct Response {
+            buffered_body: Vec<u8>,
+        }
+
+        // Step 1: register R1, capturing its id (the stale `res` holds this).
+        let h = register_handle(Response {
+            buffered_body: b"request-1-body".to_vec(),
+        });
+
+        // Step 2: finalize R1 — it is removed from the registry and its id
+        // freed (quarantined, NOT yet on the freelist).
+        assert!(drop_handle(h));
+
+        // Step 3: a new request registers R2 in the SAME tick (no drain yet).
+        // Because `h` is quarantined, register_handle CANNOT hand `h` back —
+        // R2 gets a different id. This is the load-bearing assertion: revert
+        // the quarantine (recycle straight to the freelist) and `h2 == h`, so
+        // the stale write below lands on R2 and the final assertion fails.
+        let h2 = register_handle(Response {
+            buffered_body: b"request-2-body".to_vec(),
+        });
+        assert_ne!(
+            h2, h,
+            "a just-freed id must not be reusable within the same tick — \
+             reusing it lets a stale handle holder corrupt the new request"
+        );
+
+        // Step 4: the stale write fires against `h`. With the quarantine, `h`
+        // resolves to nothing — a safe no-op (mirrors how the HTTP FFI's
+        // `get_handle::<ServerResponse>(h)` returns None → early-return).
+        let appended = with_handle_mut::<Response, _, _>(h, |r| {
+            r.buffered_body.extend_from_slice(b"-STALE-WRITE");
+        });
+        assert!(
+            appended.is_none(),
+            "a stale write to a finalized (quarantined) id must hit an empty \
+             slot, not a live object"
+        );
+
+        // R2's body is pristine — the stale write did NOT bleed into it.
+        let r2_body = with_handle::<Response, _, _>(h2, |r| r.buffered_body.clone())
+            .expect("R2 is still live");
+        assert_eq!(
+            r2_body, b"request-2-body",
+            "the second request's response body must be untouched by the \
+             stale write to the finalized first request's id"
+        );
+
+        // After a tick boundary (drain), `h` is safely reusable again — and a
+        // fresh registration under it carries no stale R1 state.
+        drain_quarantined_handles();
+        let h3 = drop_then_register_reusing(
+            h2,
+            Response {
+                buffered_body: b"request-3-body".to_vec(),
+            },
+        );
+        let r3_body =
+            with_handle::<Response, _, _>(h3, |r| r.buffered_body.clone()).expect("R3 is live");
+        assert_eq!(r3_body, b"request-3-body");
+        drop_handle(h3);
+    }
+
+    #[test]
     fn live_handles_never_share_an_id() {
+        // Serialized: this test drains the quarantine, which mutates the shared
+        // recycle state the other recycle-sensitive tests depend on.
+        let _serial = RECYCLE_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
         // Recycling must never hand the same id to two live handles. Hold a
         // batch live (none dropped) and assert every id is distinct, then
         // free them and re-allocate the same count, again all-distinct.
@@ -814,7 +1007,9 @@ mod tests {
         for h in &first {
             drop_handle(*h);
         }
-        // The recycled ids are reused here; still must be mutually distinct.
+        // Promote the just-quarantined ids so the next batch reuses them (the
+        // host pump's per-tick drain); they must still all be mutually distinct.
+        drain_quarantined_handles();
         let second = batch_all_distinct();
         for h in &second {
             drop_handle(*h);
@@ -858,6 +1053,12 @@ mod tests {
         for n in 0..iterations {
             let h = register_handle(n as i64);
             assert!(drop_handle(h));
+            // The dropped id is quarantined, not yet reusable — drain it back
+            // to the freelist (the host pump's per-tick promotion) so the next
+            // register reuses it rather than minting fresh and exhausting the
+            // band. A no-reclaim build quarantines nothing, so this drain is a
+            // no-op and the counter still runs away.
+            drain_quarantined_handles();
         }
         let after = NEXT_HANDLE.load(Ordering::SeqCst);
         let fresh_minted = (after - before) as usize;

--- a/crates/perry-ffi/src/handle.rs
+++ b/crates/perry-ffi/src/handle.rs
@@ -70,6 +70,7 @@ use std::ffi::c_void;
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Mutex;
+use std::time::Instant;
 
 use dashmap::DashMap;
 use once_cell::sync::Lazy;
@@ -145,20 +146,50 @@ const FREE_HANDLES_CAP: usize = 64 * 1024;
 /// no-ops (exactly the pre-freelist behavior) instead of corrupting a live
 /// object.
 ///
-/// The window is one tick, not unbounded: a stale write deferred MORE than a
-/// tick past finalization (e.g. `res.end(); setTimeout(() => res.write(x))`)
-/// can still land after the id was promoted and possibly re-occupied. That is
-/// out of scope here — writing after `res.end()` is a use error Node itself
-/// rejects (`ERR_STREAM_WRITE_AFTER_END`), and closing it generally needs a
-/// per-handle generation, which the fixed/published i64 handle ABI forbids
-/// (packing a generation into the id is the rejected option-A). The one-tick
-/// quarantine restores the pre-freelist safety for the realistic async-handler
-/// shape (`await`/`fetch`/microtask, then `res.end()`).
+/// # The two quarantine tiers
+///
+/// The one-tick window only covers ids whose owner is *provably done writing*
+/// at free time — an HTTP response that reached `res.end()` (its
+/// `writable_ended` is set, so any further `res.write`/`res.end` is a no-op the
+/// caller can't ride into a recycled object). For those, one tick is enough:
+/// the stale call spends itself against an empty slot on the same turn.
+///
+/// But a response can be finalized *without* ever ending — the HTTP reaper
+/// frees a parked request's handles when its peer disconnects, or when the
+/// owning server is force-closed, neither of which sets `writable_ended`. The
+/// handler is still suspended on a slow `await`/`fetch` and may resume many
+/// ticks later and call `res.write`. A one-tick quarantine would have promoted
+/// (and possibly re-minted) that id long before, so the late write would land
+/// on a *live* response — silent cross-request body corruption that is NOT a
+/// write-after-end (the handler never called `end()`, so nothing rejects it).
+///
+/// For that case the id goes into [`QUARANTINED_UNTIL`] with a *deadline*
+/// instead — the request's grace deadline, which the reaper already tracks
+/// (Node's `requestTimeout`, default ~300s). The id is held until that deadline
+/// passes, by which point the request is definitively dead: a handler that
+/// resumes within grace finds its id still parked (the write no-ops against an
+/// empty slot); once the deadline elapses no legitimate resume can write, so
+/// the id is safe to recycle. This closes the window for arbitrarily-long-async
+/// handlers without a per-handle generation (which the fixed i64 ABI forbids).
+///
+/// Bound: the deadline-gated quarantine holds at most one id per response per
+/// in-flight grace window — the same population the reaper's `IN_FLIGHT` list
+/// already bounds — and is capped at [`FREE_HANDLES_CAP`] like every other
+/// tier, so it cannot grow without limit.
 ///
 /// Embedders that never call [`drain_quarantined_handles`] simply never
 /// recycle ids — they fall back to fresh-id minting, which is the pre-freelist
 /// behavior and is safe (it only forgoes the id-reuse optimization).
 static QUARANTINED_HANDLES: Lazy<Mutex<Vec<Handle>>> = Lazy::new(|| Mutex::new(Vec::new()));
+
+/// Deadline-gated quarantine: ids freed before their owner finished writing
+/// (the HTTP reaper's peer-disconnect / force-close paths, where
+/// `writable_ended` was never set). Each id is held until `Instant::now()`
+/// passes its paired deadline, then promoted to [`FREE_HANDLES`] by
+/// [`drain_quarantined_handles`]. See [`QUARANTINED_HANDLES`] for the full
+/// rationale (the "two quarantine tiers" section).
+static QUARANTINED_UNTIL: Lazy<Mutex<Vec<(Handle, Instant)>>> =
+    Lazy::new(|| Mutex::new(Vec::new()));
 
 /// Pop a recycled id, or `None` when the freelist is empty.
 fn pop_free_handle() -> Option<Handle> {
@@ -178,28 +209,68 @@ fn recycle_handle(handle: Handle) {
     push_bounded(&mut q, handle, FREE_HANDLES_CAP);
 }
 
-/// Promote every currently-quarantined id to the freelist, making it eligible
-/// for reuse by [`register_handle`]. The host event loop calls this once per
-/// pump tick, AT THE TOP of the tick — before any of this tick's finalizations
-/// quarantine new ids — so an id freed during tick N is released no earlier
-/// than the start of tick N+1, by which point tick N's handler microtasks have
-/// drained and any stale handle reference has been spent against an empty slot.
-/// See [`QUARANTINED_HANDLES`] for the full rationale.
+/// Park a no-longer-live id in the DEADLINE-GATED quarantine — held until
+/// `Instant::now()` passes `deadline`, not merely until the next tick. For ids
+/// freed before their owner finished writing (the HTTP reaper's
+/// peer-disconnect / force-close paths); see [`QUARANTINED_UNTIL`]. Caller MUST
+/// have already removed `handle` from [`HANDLES`]. Bounded exactly like
+/// [`recycle_handle`] — past the cap the id is dropped and the fresh-id path
+/// serves future registrations.
+fn recycle_handle_until(handle: Handle, deadline: Instant) {
+    let mut q = QUARANTINED_UNTIL.lock().unwrap_or_else(|p| p.into_inner());
+    if q.len() < FREE_HANDLES_CAP {
+        q.push((handle, deadline));
+    }
+}
+
+/// Promote quarantined ids to the freelist, making them eligible for reuse by
+/// [`register_handle`]. The host event loop calls this once per pump tick, AT
+/// THE TOP of the tick — before any of this tick's finalizations quarantine new
+/// ids.
+///
+/// Two tiers are drained (see [`QUARANTINED_HANDLES`]):
+///
+/// * The one-tick tier ([`QUARANTINED_HANDLES`]) is drained whole. An id freed
+///   during tick N is released no earlier than the start of tick N+1, by which
+///   point tick N's handler microtasks have drained and any stale handle
+///   reference has been spent against an empty slot.
+/// * The deadline-gated tier ([`QUARANTINED_UNTIL`]) is drained SELECTIVELY:
+///   only entries whose deadline has elapsed are promoted; the rest are
+///   retained for a future tick. This holds an id freed before its owner
+///   finished writing until the request's grace window closes, so a
+///   long-suspended handler that resumes within grace still no-ops against an
+///   empty slot.
 ///
 /// Returns the number of ids promoted (for diagnostics/tests).
 pub fn drain_quarantined_handles() -> usize {
-    let drained: Vec<Handle> = {
+    let now = Instant::now();
+    let one_tick: Vec<Handle> = {
         let mut q = QUARANTINED_HANDLES
             .lock()
             .unwrap_or_else(|p| p.into_inner());
         std::mem::take(&mut *q)
     };
-    if drained.is_empty() {
+    let elapsed: Vec<Handle> = {
+        let mut q = QUARANTINED_UNTIL.lock().unwrap_or_else(|p| p.into_inner());
+        // Retain entries still within their grace window; harvest the elapsed
+        // ones for promotion.
+        let mut ready = Vec::new();
+        q.retain(|(handle, deadline)| {
+            if now >= *deadline {
+                ready.push(*handle);
+                false
+            } else {
+                true
+            }
+        });
+        ready
+    };
+    if one_tick.is_empty() && elapsed.is_empty() {
         return 0;
     }
     let mut free = FREE_HANDLES.lock().unwrap_or_else(|p| p.into_inner());
     let mut promoted = 0;
-    for handle in drained {
+    for handle in one_tick.into_iter().chain(elapsed) {
         let before = free.len();
         push_bounded(&mut free, handle, FREE_HANDLES_CAP);
         if free.len() != before {
@@ -485,6 +556,24 @@ pub fn drop_handle(handle: Handle) -> bool {
     }
 }
 
+/// Remove a handle and drop its value, but defer recycling its id until
+/// `deadline` rather than the next tick. Returns `true` if the handle existed.
+///
+/// For ids freed before their owner finished writing — the HTTP reaper frees a
+/// parked response on peer-disconnect / server-force-close without ever setting
+/// `writable_ended`, so a handler suspended on a slow `await` can resume many
+/// ticks later and write through the bare id. Holding the id until the
+/// request's grace deadline keeps it parked (a no-op slot) across that whole
+/// window. See [`QUARANTINED_UNTIL`].
+pub fn drop_handle_until(handle: Handle, deadline: Instant) -> bool {
+    if HANDLES.remove(&handle).is_some() {
+        recycle_handle_until(handle, deadline);
+        true
+    } else {
+        false
+    }
+}
+
 /// True if the handle currently maps to a registered object.
 pub fn handle_exists(handle: Handle) -> bool {
     HANDLES.contains_key(&handle)
@@ -724,6 +813,7 @@ extern "C" fn scan_registered_mutable_root_by_id(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
 
     #[test]
     fn round_trip_simple_value() {
@@ -895,25 +985,21 @@ mod tests {
     fn freed_id_is_not_reusable_until_drained_no_cross_request_bleed() {
         // The ABA / use-after-recycle regression. Models the HTTP cross-request
         // body bleed in handle-registry terms (the layer where the hazard lives,
-        // independent of perry-ext-http-server's reaper plumbing):
+        // independent of perry-ext-http-server's reaper plumbing): a response R1
+        // is registered under id `h`; the handler returns before `res.end()` and
+        // the request is later finalized, freeing `h`; within the SAME tick a new
+        // request registers its response R2; then a stale `res.write`/`res.end`
+        // from the retired handler fires, carrying only the bare id `h`, and
+        // mutates whatever `h` resolves to.
         //
-        //   1. A request's response object R1 is registered under id `h`.
-        //   2. The handler returns before `res.end()`; later the request is
-        //      finalized → `drop_handle(h)`. R1's id `h` is now FREED.
-        //   3. WITHIN THE SAME TICK a new request registers its response R2.
-        //   4. A stale `res.write`/`res.end` from the retired handler fires,
-        //      carrying only the bare id `h`, and mutates whatever `h` resolves
-        //      to.
-        //
-        // The hazard: if step 2's free made `h` immediately reusable, step 3
-        // would re-occupy `h` with R2, and step 4 would mutate R2 — one
-        // request's body bleeding into another's response. The quarantine fix
-        // makes a freed id reusable only after `drain_quarantined_handles`
-        // (the host pump's per-tick promotion, which runs only AFTER the
-        // finalizing handler's microtasks — and thus any stale writes — have
-        // drained). So within the tick `h` resolves to NOTHING, and the stale
-        // write no-ops against the empty slot exactly as it did before the
-        // freelist existed.
+        // The hazard: if the free made `h` immediately reusable, the new
+        // registration would re-occupy `h` with R2 and the stale write would
+        // mutate R2 — one request's body bleeding into another's. The quarantine
+        // makes a freed id reusable only after `drain_quarantined_handles` (the
+        // host pump's per-tick promotion, which runs only AFTER the finalizing
+        // handler's microtasks — and thus any stale writes — have drained). So
+        // within the tick `h` resolves to NOTHING, and the stale write no-ops
+        // against the empty slot exactly as it did before the freelist existed.
         let _serial = RECYCLE_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
 
         // A `ServerResponse`-shaped stand-in: the field a bleed would corrupt.
@@ -922,20 +1008,20 @@ mod tests {
             buffered_body: Vec<u8>,
         }
 
-        // Step 1: register R1, capturing its id (the stale `res` holds this).
+        // Register R1, capturing its id (the stale `res` holds this).
         let h = register_handle(Response {
             buffered_body: b"request-1-body".to_vec(),
         });
 
-        // Step 2: finalize R1 — it is removed from the registry and its id
-        // freed (quarantined, NOT yet on the freelist).
+        // Finalize R1 — it is removed from the registry and its id freed
+        // (quarantined, NOT yet on the freelist).
         assert!(drop_handle(h));
 
-        // Step 3: a new request registers R2 in the SAME tick (no drain yet).
-        // Because `h` is quarantined, register_handle CANNOT hand `h` back —
-        // R2 gets a different id. This is the load-bearing assertion: revert
-        // the quarantine (recycle straight to the freelist) and `h2 == h`, so
-        // the stale write below lands on R2 and the final assertion fails.
+        // A new request registers R2 in the SAME tick (no drain yet). Because
+        // `h` is quarantined, register_handle CANNOT hand `h` back — R2 gets a
+        // different id. This is the load-bearing assertion: revert the
+        // quarantine (recycle straight to the freelist) and `h2 == h`, so the
+        // stale write below lands on R2 and the final assertion fails.
         let h2 = register_handle(Response {
             buffered_body: b"request-2-body".to_vec(),
         });
@@ -945,8 +1031,8 @@ mod tests {
              reusing it lets a stale handle holder corrupt the new request"
         );
 
-        // Step 4: the stale write fires against `h`. With the quarantine, `h`
-        // resolves to nothing — a safe no-op (mirrors how the HTTP FFI's
+        // The stale write fires against `h`. With the quarantine, `h` resolves
+        // to nothing — a safe no-op (mirrors how the HTTP FFI's
         // `get_handle::<ServerResponse>(h)` returns None → early-return).
         let appended = with_handle_mut::<Response, _, _>(h, |r| {
             r.buffered_body.extend_from_slice(b"-STALE-WRITE");
@@ -979,6 +1065,115 @@ mod tests {
             with_handle::<Response, _, _>(h3, |r| r.buffered_body.clone()).expect("R3 is live");
         assert_eq!(r3_body, b"request-3-body");
         drop_handle(h3);
+    }
+
+    #[test]
+    fn deadline_gated_id_survives_ticks_until_grace_then_recycles() {
+        // The LONG-ASYNC use-after-recycle regression — the residual window the
+        // one-tick quarantine does NOT cover. Models the HTTP reaper finalizing a
+        // response that never ended (`writable_ended` unset — peer disconnect or
+        // server force-close) while its handler is still suspended on a slow
+        // upstream `await`: response R1 is registered under id `h`; the reaper
+        // finalizes the request WITHOUT the handler ending the response
+        // (`drop_handle_until(h, grace_deadline)`) because the peer is gone, so
+        // `h` enters the deadline-gated quarantine; many pump ticks pass (each
+        // draining); then the handler resumes — still within the grace window —
+        // and its stale `res.write` fires carrying only the bare id `h`.
+        //
+        // With a one-tick quarantine, the first drain would have promoted `h`
+        // (and a new request could have re-minted it), so the resumed write would
+        // mutate a LIVE response — cross-request body corruption that is NOT a
+        // write-after-end (the handler never called `end()`). The deadline-gated
+        // quarantine keeps `h` parked across EVERY tick until the grace deadline
+        // passes, so the stale write no-ops against an empty slot for the whole
+        // window — then `h` recycles cleanly once the request is definitively
+        // dead.
+        let _serial = RECYCLE_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+        #[derive(Clone)]
+        struct Response {
+            buffered_body: Vec<u8>,
+        }
+
+        // Register R1 (the suspended handler holds this bare id).
+        let h = register_handle(Response {
+            buffered_body: b"request-1-body".to_vec(),
+        });
+
+        // The reaper finalizes WITHOUT end — defer recycling until a grace
+        // deadline well in the future (stand-in for `requestTimeout`).
+        let grace = Instant::now() + Duration::from_secs(3600);
+        assert!(drop_handle_until(h, grace));
+
+        // Several pump ticks pass. Each drain must leave `h` parked because its
+        // deadline has not elapsed — so a new request can never be handed `h`.
+        // (Fail-before: a one-tick quarantine promotes `h` on the first drain,
+        // making the assertion below fail.)
+        for _ in 0..5 {
+            drain_quarantined_handles();
+            let probe = register_handle(0_i64);
+            assert_ne!(
+                probe, h,
+                "a deadline-gated id must not be recycled before its grace \
+                 deadline — reusing it lets a long-suspended handler corrupt a \
+                 new request's response"
+            );
+            drop_handle(probe);
+        }
+
+        // The stale write fires against `h`. While `h` is parked it maps to
+        // nothing, so the write no-ops against an empty slot — no bleed.
+        let appended = with_handle_mut::<Response, _, _>(h, |r| {
+            r.buffered_body.extend_from_slice(b"-STALE-WRITE");
+        });
+        assert!(
+            appended.is_none(),
+            "a stale write to a deadline-gated id must hit an empty slot, not a \
+             live object"
+        );
+
+        // Drain the far-future entry away so it can't leak into later tests
+        // (its deadline hasn't elapsed, so this is a no-op for `h` — but it
+        // clears the one-tick tier). Then prove the elapsed-deadline path DOES
+        // recycle: a separate id parked with an already-past deadline is
+        // promoted by the very next drain and reused cleanly, carrying no stale
+        // state. This is the post-grace tick, modeled deterministically (no
+        // sleep) with an id we fully control.
+        drain_quarantined_handles();
+        let dead = register_handle(Response {
+            buffered_body: b"to-be-finalized".to_vec(),
+        });
+        assert!(drop_handle_until(
+            dead,
+            Instant::now() - Duration::from_secs(1)
+        ));
+        // The elapsed-deadline entry is eligible immediately; retry to absorb
+        // parallel tests racing the shared freelist (same pattern as
+        // `drop_then_register_reusing`).
+        let mut recycled = None;
+        for _ in 0..10_000 {
+            drain_quarantined_handles();
+            let candidate = register_handle(Response {
+                buffered_body: b"request-2-body".to_vec(),
+            });
+            if candidate == dead {
+                recycled = Some(candidate);
+                break;
+            }
+            drop_handle(candidate);
+        }
+        let h2 = recycled.expect("an elapsed-deadline id must recycle once its grace passes");
+        let body = with_handle::<Response, _, _>(h2, |r| r.buffered_body.clone())
+            .expect("the recycled id resolves to the new response");
+        assert_eq!(
+            body, b"request-2-body",
+            "the recycled id carries the NEW response, never the finalized one"
+        );
+        drop_handle(h2);
+
+        // `h`'s far-future deadline entry stays parked — that is the point of
+        // the test. The freelist is bounded and the process-wide registry
+        // tolerates a held id, so this leaks nothing that matters across tests.
     }
 
     #[test]

--- a/crates/perry-ffi/src/lib.rs
+++ b/crates/perry-ffi/src/lib.rs
@@ -63,7 +63,7 @@ mod handle;
 #[allow(deprecated)]
 pub use handle::gc_register_root_scanner;
 pub use handle::{
-    drain_quarantined_handles, drop_handle, gc_register_mutable_root_scanner,
+    drain_quarantined_handles, drop_handle, drop_handle_until, gc_register_mutable_root_scanner,
     gc_register_mutable_root_scanner_named, get_handle, get_handle_mut, handle_exists,
     iter_handle_ids_of, iter_handles_of, iter_handles_of_mut, register_handle, take_handle,
     with_handle, with_handle_mut, GcMutableRootScanner, GcRootVisitor, Handle, INVALID_HANDLE,

--- a/crates/perry-ffi/src/lib.rs
+++ b/crates/perry-ffi/src/lib.rs
@@ -63,10 +63,10 @@ mod handle;
 #[allow(deprecated)]
 pub use handle::gc_register_root_scanner;
 pub use handle::{
-    drop_handle, gc_register_mutable_root_scanner, gc_register_mutable_root_scanner_named,
-    get_handle, get_handle_mut, handle_exists, iter_handle_ids_of, iter_handles_of,
-    iter_handles_of_mut, register_handle, take_handle, with_handle, with_handle_mut,
-    GcMutableRootScanner, GcRootVisitor, Handle, INVALID_HANDLE,
+    drain_quarantined_handles, drop_handle, gc_register_mutable_root_scanner,
+    gc_register_mutable_root_scanner_named, get_handle, get_handle_mut, handle_exists,
+    iter_handle_ids_of, iter_handles_of, iter_handles_of_mut, register_handle, take_handle,
+    with_handle, with_handle_mut, GcMutableRootScanner, GcRootVisitor, Handle, INVALID_HANDLE,
 };
 
 mod jsvalue;


### PR DESCRIPTION
## Summary

Closes the ABA / use-after-recycle hazard that the handle-id freelist in #5643 introduces, without touching the published `i64` handle encoding.

The freelist recycles a freed handle id *immediately*. Any consumer that resolves an object purely by its bare integer id (the id is a NaN-boxed `POINTER_TAG | id` with no generation) can then suffer cross-object reuse. `perry-ext-http-server` hits it concretely: an async request handler can return before `res.end()`, so the request/response handles are parked `IN_FLIGHT` and later finalized by the reaper, which `drop_handle`s both. With immediate recycling, the next incoming request's `register_handle` re-occupies that id, and a microtask-deferred `res.write`/`res.end` from the retired handler mutates the *new* request's `ServerResponse.buffered_body` — one request's body bleeding into another's response. The `Box<dyn Any>` downcast catches different-type reuse but not `ServerResponse` -> `ServerResponse`. Before the freelist a freed id stayed dead, so the stale write was a safe no-op; the freelist removed that safety. This restores it.

## Changes

- **`crates/perry-ffi/src/handle.rs`** — freed ids are parked in a new `QUARANTINED_HANDLES` list instead of going straight onto `FREE_HANDLES`. A new `pub fn drain_quarantined_handles()` promotes quarantined ids to the reusable freelist. The quarantine is bounded by the same `FREE_HANDLES_CAP` (overflow falls back to fresh-id minting, the pre-freelist behavior).
- **`crates/perry-ffi/src/lib.rs`** — re-export `drain_quarantined_handles`.
- **`crates/perry-ext-http-server/src/server.rs`** — the HTTP pump (`js_node_http_server_process_pending`) calls `drain_quarantined_handles()` once per tick, at the top, before the tick's finalizations quarantine new ids. So an id freed during tick N is not reusable until tick N+1's drain — by which point the finalizing handler's microtasks (and any stale `res.*`) have run against an empty slot and no-op'd.

Fixing it at the freelist covers HTTP/1, HTTPS, and HTTP/2 in one place, since all three free through `drop_handle`. The `i64` handle ABI, the `1..0x40000` small-int band, `POINTER_TAG`/`PTR_MASK`, and `handle_to_pointer_f64` are all untouched — the fix is purely a side list + a drain fn + a pump call. (This is the surgical revocation fix; packing a generation into the id, which would change the published ABI, was the rejected alternative.)

**Scope of the guarantee:** the one-tick quarantine closes the realistic async-handler shape (`await`/`fetch`/microtask, then `res.end()`). A write deferred *more* than a tick past finalization (e.g. `res.end(); setTimeout(() => res.write(x))`) is a write-after-end use error Node itself rejects, and closing it generally needs a per-handle generation the fixed `i64` ABI forbids — out of scope here.

## Related issue

Closes the hazard raised in #5643's review thread (`3468515061`). This PR is **stacked on #5643** (base branch `perf/handle-pool-freelist`); until #5643 merges, the diff here will also show #5643's commits — that is expected and auto-cleans once #5643 lands. The ABA fix is the single commit `fix(ffi): quarantine freed handle ids one tick to close use-after-recycle`.

## Test plan

Added a fail-before/pass-after regression test, `freed_id_is_not_reusable_until_drained_no_cross_request_bleed` in `crates/perry-ffi/src/handle.rs`, that reproduces the cross-request bleed at the registry layer: register a response, finalize it (freeing its id), register a second response in the same tick, then issue a stale write against the first id. It asserts (a) the freed id is not reusable within the tick, (b) the stale write hits an empty slot and no-ops, and (c) the second response's body is uncorrupted.

- Reverting the quarantine (recycle straight to the freelist, the #5643 behavior) makes the test **fail** at `assert_ne!(h2, h)` (`left: 1, right: 1` — the freed id is immediately reused and the stale write lands on the new response).
- With the quarantine it passes. The existing recycle tests were updated to drive the per-tick drain and still fail hard against a no-reclaim build.

Verified locally:

- [x] `cargo test --lib -p perry-ffi` passes (19/19, including the new regression test)
- [x] `cargo fmt --check` clean
- [x] `cargo check --tests -p perry-ext-http-server` clean
- [x] `bash scripts/check_file_size.sh` OK (no file over 2000 lines)

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commits follow the `fix:` prefix convention
- [x] I've read CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added quarantine-based handle ID recycling with grace deadlines, delaying reuse to improve safety under long-running, high-churn workloads.

* **Bug Fixes**
  * Prevented late response writes/ends from affecting reused response identifiers by deferring finalization until safe.
  * Improved in-flight request finalization by holding response handles until the appropriate recycle window elapses.
  * Promotes quarantined handle IDs back into the reusable pool at the start of each processing tick.

* **Tests**
  * Expanded tests to verify same-tick non-reuse, deadline-gated reuse, and ABA/use-after-recycle hazard prevention under churn.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->