### PR TITLE
test(net,http): regression tests for SSO short-string value→bytes (#1781)

### DIFF
--- a/crates/perry-ext-http-server/src/types.rs
+++ b/crates/perry-ext-http-server/src/types.rs
@@ -418,7 +418,7 @@ mod tests {
     /// tag 0x7FF9, length in bits 40..=47, data little-endian in bits
     /// 0..=39. This is the exact representation codegen hands the
     /// `res.write` / `res.end` shim for a short string literal — the
-    /// repr `jsvalue_to_body_bytes` used to drop (#1781).
+    /// repr `jsvalue_to_body_bytes` must not drop.
     fn sso(bytes: &[u8]) -> f64 {
         assert!(bytes.len() <= 5);
         let mut payload: u64 = 0;
@@ -429,19 +429,18 @@ mod tests {
         f64::from_bits(bits)
     }
 
-    /// #1781 regression — a short response body (`res.end("hi")`) arrives
-    /// as an inline SSO value, not a `STRING_TAG` heap pointer. Before
-    /// the fix `jsvalue_to_body_bytes` gated on the strict `is_string()`
-    /// (STRING_TAG only); the SSO value matched no branch and the body was
-    /// silently dropped (returned `None`) — the wire response had an empty
-    /// body. It must now convert to its UTF-8 bytes, including the empty
-    /// string and the 5-byte SSO boundary.
+    /// A short response body (`res.end("hi")`) arrives as an inline SSO
+    /// value, not a `STRING_TAG` heap pointer. Gating on the strict
+    /// `is_string()` (STRING_TAG only) makes the SSO value match no branch,
+    /// so `jsvalue_to_body_bytes` silently drops the body (returns `None`)
+    /// and the wire response has an empty body. It must convert to its
+    /// UTF-8 bytes, including the empty string and the 5-byte SSO boundary.
     #[test]
     fn body_bytes_converts_sso_short_string() {
         assert_eq!(
             jsvalue_to_body_bytes(sso(b"hi")).as_deref(),
             Some(&b"hi"[..]),
-            "SSO short body must convert to its bytes, not be dropped (#1781)"
+            "SSO short body must convert to its bytes, not be dropped"
         );
         assert_eq!(
             jsvalue_to_body_bytes(sso(b"")).as_deref(),
@@ -455,9 +454,9 @@ mod tests {
         );
     }
 
-    /// A heap `STRING_TAG` body (length > 5) still converts — the #1781
-    /// widening of the string branch must not regress the long-string
-    /// path that already worked.
+    /// A heap `STRING_TAG` body (length > 5) still converts — widening the
+    /// string branch to match SSO must not regress the long-string path
+    /// that already worked.
     #[test]
     fn body_bytes_converts_heap_string() {
         let v = JsValue::from_string_ptr(perry_ffi::alloc_string("longer-than-sso").as_raw());

--- a/crates/perry-ext-http-server/src/types.rs
+++ b/crates/perry-ext-http-server/src/types.rs
@@ -413,6 +413,60 @@ mod tests {
         );
     }
 
+    /// Encode `bytes` (len ≤ 5) as an inline SSO `SHORT_STRING_TAG`
+    /// NaN-box, mirroring the runtime's `JSValue::try_short_string`:
+    /// tag 0x7FF9, length in bits 40..=47, data little-endian in bits
+    /// 0..=39. This is the exact representation codegen hands the
+    /// `res.write` / `res.end` shim for a short string literal — the
+    /// repr `jsvalue_to_body_bytes` used to drop (#1781).
+    fn sso(bytes: &[u8]) -> f64 {
+        assert!(bytes.len() <= 5);
+        let mut payload: u64 = 0;
+        for (i, &b) in bytes.iter().enumerate() {
+            payload |= (b as u64) << (i * 8);
+        }
+        let bits = 0x7FF9_0000_0000_0000_u64 | ((bytes.len() as u64) << 40) | payload;
+        f64::from_bits(bits)
+    }
+
+    /// #1781 regression — a short response body (`res.end("hi")`) arrives
+    /// as an inline SSO value, not a `STRING_TAG` heap pointer. Before
+    /// the fix `jsvalue_to_body_bytes` gated on the strict `is_string()`
+    /// (STRING_TAG only); the SSO value matched no branch and the body was
+    /// silently dropped (returned `None`) — the wire response had an empty
+    /// body. It must now convert to its UTF-8 bytes, including the empty
+    /// string and the 5-byte SSO boundary.
+    #[test]
+    fn body_bytes_converts_sso_short_string() {
+        assert_eq!(
+            jsvalue_to_body_bytes(sso(b"hi")).as_deref(),
+            Some(&b"hi"[..]),
+            "SSO short body must convert to its bytes, not be dropped (#1781)"
+        );
+        assert_eq!(
+            jsvalue_to_body_bytes(sso(b"")).as_deref(),
+            Some(&b""[..]),
+            "empty SSO body should yield empty bytes, not None"
+        );
+        assert_eq!(
+            jsvalue_to_body_bytes(sso(b"hello")).as_deref(),
+            Some(&b"hello"[..]),
+            "the 5-byte SSO boundary must convert"
+        );
+    }
+
+    /// A heap `STRING_TAG` body (length > 5) still converts — the #1781
+    /// widening of the string branch must not regress the long-string
+    /// path that already worked.
+    #[test]
+    fn body_bytes_converts_heap_string() {
+        let v = JsValue::from_string_ptr(perry_ffi::alloc_string("longer-than-sso").as_raw());
+        assert_eq!(
+            jsvalue_to_body_bytes(f64::from_bits(v.bits())).as_deref(),
+            Some(&b"longer-than-sso"[..])
+        );
+    }
+
     #[test]
     fn listen_non_closure_pointer_is_not_mistaken_for_callback() {
         // The first arg of `listen(options)` / `listen(path-ish)` is a heap

--- a/crates/perry-ffi/src/jsvalue.rs
+++ b/crates/perry-ffi/src/jsvalue.rs
@@ -424,13 +424,13 @@ mod tests {
         }
     }
 
-    /// #1781 — a JS string has TWO NaN-box representations: a heap
+    /// A JS string has TWO NaN-box representations: a heap
     /// `STRING_TAG` (real `*StringHeader`) and an inline `SHORT_STRING_TAG`
     /// SSO value (string ≤5 bytes packed into the payload). `is_any_string`
     /// must match BOTH; the strict `is_string` matches only the heap repr.
-    /// The footgun the bug hit: branching on `is_string()` silently drops
-    /// SSO short strings, so `socket.write("hi")` / `res.end("hi")` emitted
-    /// nothing. `is_short_string` must distinguish the SSO repr specifically.
+    /// The footgun: branching on `is_string()` silently drops SSO short
+    /// strings, so `socket.write("hi")` / `res.end("hi")` emit nothing.
+    /// `is_short_string` must distinguish the SSO repr specifically.
     #[test]
     fn is_any_string_matches_both_string_reprs() {
         // An inline SSO value, built the way the runtime packs one: tag
@@ -442,7 +442,7 @@ mod tests {
         assert!(sso.is_short_string(), "SSO short string is the short repr");
         assert!(
             !sso.is_string(),
-            "strict is_string() must NOT match SSO — this is the #1781 footgun"
+            "strict is_string() must NOT match SSO — this is the footgun"
         );
         assert!(!sso.is_pointer(), "SSO is not a heap pointer");
 

--- a/crates/perry-ffi/src/jsvalue.rs
+++ b/crates/perry-ffi/src/jsvalue.rs
@@ -424,6 +424,52 @@ mod tests {
         }
     }
 
+    /// #1781 — a JS string has TWO NaN-box representations: a heap
+    /// `STRING_TAG` (real `*StringHeader`) and an inline `SHORT_STRING_TAG`
+    /// SSO value (string ≤5 bytes packed into the payload). `is_any_string`
+    /// must match BOTH; the strict `is_string` matches only the heap repr.
+    /// The footgun the bug hit: branching on `is_string()` silently drops
+    /// SSO short strings, so `socket.write("hi")` / `res.end("hi")` emitted
+    /// nothing. `is_short_string` must distinguish the SSO repr specifically.
+    #[test]
+    fn is_any_string_matches_both_string_reprs() {
+        // An inline SSO value, built the way the runtime packs one: tag
+        // 0x7FF9, length in bits 40..=47, data little-endian in bits 0..=39.
+        // "hi" → len 2, payload 'h' | ('i' << 8).
+        let sso_bits = SHORT_STRING_TAG | (2u64 << 40) | (b'h' as u64) | ((b'i' as u64) << 8);
+        let sso = JsValue::from_bits(sso_bits);
+        assert!(sso.is_any_string(), "SSO short string is a string");
+        assert!(sso.is_short_string(), "SSO short string is the short repr");
+        assert!(
+            !sso.is_string(),
+            "strict is_string() must NOT match SSO — this is the #1781 footgun"
+        );
+        assert!(!sso.is_pointer(), "SSO is not a heap pointer");
+
+        // A heap STRING_TAG value (the payload pointer is never dereferenced
+        // by these predicates, so a sentinel address is fine).
+        let heap = JsValue::from_bits(STRING_TAG | 0x1234);
+        assert!(heap.is_any_string(), "heap string is a string");
+        assert!(heap.is_string(), "heap string matches strict is_string()");
+        assert!(
+            !heap.is_short_string(),
+            "a heap STRING_TAG value is not the SSO repr"
+        );
+
+        // Non-strings: neither predicate fires.
+        for (val, kind) in [
+            (JsValue::UNDEFINED, "undefined"),
+            (JsValue::NULL, "null"),
+            (JsValue::from_number(3.14), "number"),
+            (JsValue::TRUE, "bool"),
+            (JsValue::from_int32(42), "int32"),
+            (JsValue::from_bits(POINTER_TAG | 0x5678), "pointer"),
+        ] {
+            assert!(!val.is_any_string(), "{kind} is not any string");
+            assert!(!val.is_short_string(), "{kind} is not a short string");
+        }
+    }
+
     #[test]
     fn shape_hash_is_deterministic() {
         let (k1, s1) = build_object_shape(&["foo", "bar", "baz"]);


### PR DESCRIPTION
Refs #5638.

Test-only follow-up adding regression coverage for the two parts of #5638 (fix for #1781) that merged without a test. #5638 fixed the SSO short-string value→bytes conversion in four files but only added tests for the net path (`jsvalue_to_socket_bytes`); the http-server body path and the new perry-ffi predicates shipped untested.

## Background

A NaN-boxed JS string has two representations: a heap `STRING_TAG` (`0x7FFF`, a real `*StringHeader`) and an inline SSO `SHORT_STRING_TAG` (`0x7FF9`, a string ≤5 bytes packed into the NaN-box payload). The strict `is_string()` matches `STRING_TAG` only, so code gating on it silently dropped short strings — a short HTTP body such as `res.end("hi")` fell through every branch to `None` and emitted nothing. The fix gates on `JsValue::is_any_string()` and materializes via `js_get_string_pointer_unified`.

## Tests added

- `crates/perry-ext-http-server/src/types.rs` — `jsvalue_to_body_bytes` converts an SSO short string (the #1781 case), covering `""`, `"hi"`, and the 5-byte boundary `"hello"`, plus the heap `STRING_TAG` path (length > 5) so the long-body path does not regress. The non-buffer-pointer path is intentionally not asserted as `None`: unlike net's `jsvalue_to_socket_bytes`, this function falls back to the `StringHeader`/stringify path for non-buffer pointers, so a `None` assertion would not match its contract.
- `crates/perry-ffi/src/jsvalue.rs` — `is_any_string` and `is_short_string` match both string representations (heap `STRING_TAG` and inline `SHORT_STRING_TAG`) and reject non-strings, while strict `is_string()` matches only the heap representation. Documents the footgun the bug hit.
- `crates/perry-ext-http-server/src/test_async_shims.rs` — a no-op `perry_ffi_spawn_async` test-link stub. The http-server unit-test binary references this symbol through its `perry-ext-net` dependency and otherwise fails to link; the conversion tests never reach the async path, so a no-op is sufficient.

The net path (`jsvalue_to_socket_bytes`) was already covered by tests in #5638 itself and is not duplicated here.

## Fail-before / pass-after

For the http-server SSO test, reverting the fix in place (`is_any_string()` → `is_string()`, and `js_get_string_pointer_unified` → the old `bits & PTR_MASK` pointer read) makes the SSO case fail:

```
test types::tests::body_bytes_converts_heap_string ... ok
test types::tests::body_bytes_converts_sso_short_string ... FAILED

assertion `left == right` failed: SSO short body must convert to its bytes, not be dropped (#1781)
  left: None
 right: Some([104, 105])
```

With the `is_any_string()` fix restored, both pass:

```
test types::tests::body_bytes_converts_heap_string ... ok
test types::tests::body_bytes_converts_sso_short_string ... ok
```

The heap-string test passes under both gates, confirming the SSO test isolates the dropped-body regression.

The `tls.rs` `as_string` change from #5638 is a closure local to the `js_tls_connect` FFI entrypoint and is only reachable by initiating a TLS connection, so it is integration-level rather than a unit test; the `is_any_string()` predicate it relies on is covered by the perry-ffi test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversion of short inline text values to the correct UTF-8 bytes, including empty strings and the 5-character boundary.
  * Ensured heap-backed strings continue to convert correctly for longer text inputs.
  * Tightened string-type detection so predicates distinguish inline vs heap representations accurately and avoid false positives.
* **Tests**
  * Added targeted unit tests covering short-string NaN-boxed representations and mixed string predicate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->