### PR TITLE
test(http): pin streamed-body byte-identity reassembly contract (Refs #5419)

### DIFF
--- a/crates/perry-ext-http/src/tests.rs
+++ b/crates/perry-ext-http/src/tests.rs
@@ -105,13 +105,12 @@ fn gc_mutable_scanner_rewrites_request_response_listener_roots() {
     drop_handle(incoming_handle);
 }
 
-/// #5419 — the streamed-response drain (`ResponseHead` → N×`ResponseChunk`
-/// → `ResponseEnd`) must reassemble a body byte-identically no matter how
-/// the transport split it into chunks. The PR swapped the chunk carrier
-/// from `Vec<u8>` to `Bytes`; both deliver to the drain as `&[u8]`, so this
-/// pins the reassembly contract the type change must preserve — a future
-/// refactor that corrupted a chunk, reordered chunks, or mishandled a
-/// boundary would fail here.
+/// The streamed-response drain (`ResponseHead` → N×`ResponseChunk` →
+/// `ResponseEnd`) must reassemble a body byte-identically no matter how the
+/// transport split it into chunks. The chunk carrier (`Bytes`) delivers to
+/// the drain as `&[u8]`, so this pins the reassembly contract a carrier-type
+/// change must preserve — a future refactor that corrupted a chunk,
+/// reordered chunks, or mishandled a boundary would fail here.
 ///
 /// Drives the buffering branch (no `'data'` listener registered): each
 /// chunk is appended to `IncomingMessageHandle::body`, and `ResponseEnd`
@@ -152,7 +151,7 @@ fn drain_streamed_body(chunks: &[&[u8]]) -> Vec<u8> {
         );
         // Each production chunk is a refcounted `Bytes` (reqwest's
         // `response.chunk()` shape) — build the input the same way so the
-        // test exercises the actual carrier type the PR introduced.
+        // test exercises the actual carrier type the drain receives.
         for c in chunks {
             client_events::handle_response_chunk_event(request_handle, Bytes::copy_from_slice(c));
         }

--- a/crates/perry-ext-http/src/tests.rs
+++ b/crates/perry-ext-http/src/tests.rs
@@ -105,6 +105,101 @@ fn gc_mutable_scanner_rewrites_request_response_listener_roots() {
     drop_handle(incoming_handle);
 }
 
+/// #5419 — the streamed-response drain (`ResponseHead` → N×`ResponseChunk`
+/// → `ResponseEnd`) must reassemble a body byte-identically no matter how
+/// the transport split it into chunks. The PR swapped the chunk carrier
+/// from `Vec<u8>` to `Bytes`; both deliver to the drain as `&[u8]`, so this
+/// pins the reassembly contract the type change must preserve — a future
+/// refactor that corrupted a chunk, reordered chunks, or mishandled a
+/// boundary would fail here.
+///
+/// Drives the buffering branch (no `'data'` listener registered): each
+/// chunk is appended to `IncomingMessageHandle::body`, and `ResponseEnd`
+/// leaves the unconsumed body on the handle. Reading it back is the
+/// reassembly assertion. This branch never calls a JS closure, so it needs
+/// no live codegen — only the handle registry the other tests already use.
+fn drain_streamed_body(chunks: &[&[u8]]) -> Vec<u8> {
+    let request_handle = register_handle(ClientRequestHandle {
+        method: "GET".to_string(),
+        url: "http://localhost/".to_string(),
+        headers: HashMap::new(),
+        body: Vec::new(),
+        response_callback: 0,
+        listeners: HashMap::new(),
+        timeout_ms: None,
+        ended: false,
+        flushed_early: false,
+        pending_write_callbacks: Vec::new(),
+        end_callback: 0,
+        completed: false,
+        timeout_fired: false,
+        close_emitted: false,
+        agent_handle: 0,
+        tls: crate::tls_client::TlsOptions::default(),
+        incoming_handle: 0,
+        expects_continue: false,
+        continue_body_tx: None,
+    });
+
+    unsafe {
+        // Head: allocates the IncomingMessage and stores its handle on the
+        // request, so the following chunk/end events route to it.
+        client_events::handle_response_head_event(
+            request_handle,
+            200,
+            "OK".to_string(),
+            Vec::new(),
+        );
+        // Each production chunk is a refcounted `Bytes` (reqwest's
+        // `response.chunk()` shape) — build the input the same way so the
+        // test exercises the actual carrier type the PR introduced.
+        for c in chunks {
+            client_events::handle_response_chunk_event(request_handle, Bytes::copy_from_slice(c));
+        }
+        client_events::handle_response_end_event(request_handle);
+    }
+
+    let incoming_handle = get_handle::<ClientRequestHandle>(request_handle)
+        .expect("request handle should remain live")
+        .incoming_handle;
+    let body = get_handle::<IncomingMessageHandle>(incoming_handle)
+        .expect("incoming message handle should remain live")
+        .body
+        .clone();
+
+    drop_handle(incoming_handle);
+    drop_handle(request_handle);
+    body
+}
+
+#[test]
+fn streamed_response_reassembles_chunks_byte_identically() {
+    let _guard = GcTestGuard::new();
+
+    // Empty body — zero chunks then end.
+    assert_eq!(drain_streamed_body(&[]), Vec::<u8>::new());
+
+    // Single chunk delivered whole.
+    assert_eq!(drain_streamed_body(&[b"hello world"]), b"hello world");
+
+    // Multi-chunk: the reassembled body is the in-order concatenation,
+    // independent of the (arbitrary) chunk boundaries the transport chose.
+    assert_eq!(drain_streamed_body(&[b"foo", b"bar", b"baz"]), b"foobarbaz");
+
+    // Boundary-shift: the SAME bytes split differently must reassemble to
+    // the same body — the property the streaming path actually guarantees.
+    let payload: &[u8] = b"the quick brown fox jumps over the lazy dog";
+    let split_a = drain_streamed_body(&[&payload[..10], &payload[10..25], &payload[25..]]);
+    let split_b = drain_streamed_body(&[&payload[..1], &payload[1..2], &payload[2..]]);
+    assert_eq!(split_a, payload);
+    assert_eq!(split_b, payload);
+
+    // Binary payload with embedded NULs and high bytes — the carrier is
+    // bytes, not a string, so nothing is lost or re-encoded.
+    let bin: &[u8] = &[0x00, 0xFF, 0x10, 0x00, 0x80, 0x7F, 0xC3, 0x28];
+    assert_eq!(drain_streamed_body(&[&bin[..3], &bin[3..]]), bin);
+}
+
 #[test]
 fn has_pending_zero_when_idle() {
     // Drain anything other tests left; then assert zero.


### PR DESCRIPTION
Adds a behavior-preserving unit test for the streamed HTTP-client response path. No production code changes.

## What this pins (Refs #5419)

#5419 swapped the streamed-body chunk carrier from `Vec<u8>` to `Bytes`:
`PendingHttpEvent::ResponseChunk { chunk: Vec<u8> }` → `{ chunk: Bytes }`, and
`handle_response_chunk_event(.., chunk: Vec<u8>)` → `(.., chunk: Bytes)`. The drain
only ever borrows the chunk as `&[u8]`, so the swap is byte-transparent by construction —
but nothing in the suite pinned the *reassembly* contract it has to preserve.

The new test (`streamed_response_reassembles_chunks_byte_identically` in
`crates/perry-ext-http/src/tests.rs`) drives the real drain handlers in sequence —
`handle_response_head_event` → N × `handle_response_chunk_event(.., Bytes)` →
`handle_response_end_event` — through the **buffering branch** (no `'data'` listener
registered, so each chunk lands in `IncomingMessageHandle::body` via
`extend_from_slice(&chunk)`), then reads the reassembled body back off the handle.
It uses the same handle-registry + `GcTestGuard` machinery the existing GC-root test
in this module already uses, and drops every handle it registers.

Cases: empty body, single chunk, multi-chunk, boundary-shifted (the *same* payload split
two different ways must reassemble identically), and a binary payload with embedded NULs /
high bytes (the carrier is bytes, not a lossily-decoded string).

The test is non-tautological: a mutation that drops the first byte of each buffered chunk
makes it fail with a clear byte-level diff. It is mutex-serialized against the other
`GcTestGuard` test and never touches the shared pending-event queue, so it is order-independent
and parallel-safe.

## Why no test for #5488

#5488 (run sockets + the server accept loop on the shared reactor via `spawn_async`) is
**integration-level, not unit-testable**, and a unit test would be ceremonial:

- The socket path runs each future via `perry_ffi::spawn_async` → the `extern "C"`
  symbol `perry_ffi_spawn_async`, which is only implemented by `perry-stdlib`
  (`async_bridge::runtime().spawn(future)`) at the final program link. In every crate's
  unit-test binary that symbol is a **no-op stub** that drops the future on the floor
  (`crates/perry-ext-net/src/jsvalue.rs`: `extern "C" fn perry_ffi_spawn_async(_ctx) {}`),
  and `perry-ffi`'s own `async_runtime.rs` test module documents the same gap. So a socket
  future never actually runs in a unit test — there is no harness in which the
  ">512 concurrent sockets succeed" ceiling claim can be exercised.
- The headline claim (removing the ~512-socket ceiling that the old per-socket
  `spawn_blocking` design imposed) is a *runtime thread-pool* property, not a pure-function
  contract — it requires the live multi-thread reactor + a real socket fleet.

The real verification for #5488 is the **node-suite parity harness**
(`test-parity/node-suite/net/`, run print-and-diff against the Node 26 oracle and gated by
`.github/workflows/node-suite-guard.yml`), where sockets run on the fully-linked runtime
that provides the real `perry_ffi_spawn_async`. A concurrent-socket scenario belongs there
(or in `tests/e2e/`), not in a crate unit test. Faking a unit test for it would assert
nothing about the ceiling and would only test the no-op stub.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for streamed HTTP responses to ensure the reassembled response body is byte-for-byte identical to the original payload.
  * Verified correctness for empty bodies, single-chunk delivery, multi-chunk concatenation, and the same payload split using different chunk boundaries.
  * Included binary payload scenarios (e.g., NUL/high-byte data) to prevent encoding or buffering regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->