### PR TITLE
perf(codegen): register typed-shape layout on standalone-constructor new path

### DIFF
--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -457,6 +457,52 @@ fn call_local_constructor_symbol(
     Some(ctx.block().call(DOUBLE, &ctor_name, &ctor_args))
 }
 
+/// Emit the `js_gc_init_typed_shape_layout` call that registers the freshly
+/// constructed instance's raw-f64 / pointer slot masks with the GC so the
+/// typed-feedback class-field fast path engages. Must run AFTER the constructor
+/// body has set the declared fields to their numeric values (the runtime
+/// validates each raw-f64 slot currently holds a plain double before promoting).
+/// No-op for classes without an inline-keys shape global. Refs the standalone
+/// `<class>_constructor` symbol path, which previously returned before reaching
+/// this — leaving every numeric class field permanently on the by-name hashmap
+/// fallback (10M `counter.increment()` ran ~640ns/call instead of slot-direct).
+fn emit_typed_shape_layout_init(ctx: &mut FnCtx<'_>, class_name: &str, obj_handle: &str) {
+    let Some(keys_global_name) = ctx.class_keys_globals.get(class_name).cloned() else {
+        return;
+    };
+    let typed_layout = crate::typed_shape::class_typed_layout(ctx.classes, class_name);
+    let slot_count_str = typed_layout.slot_count.to_string();
+    let raw_mask_word_count_str = typed_layout.raw_f64_mask_words.len().to_string();
+    let pointer_mask_word_count_str = typed_layout.pointer_mask_words.len().to_string();
+    let raw_mask_ref = if typed_layout.raw_f64_mask_words.is_empty() {
+        "null".to_string()
+    } else {
+        format!(
+            "@{}",
+            crate::typed_shape::raw_f64_mask_global_name_from_keys_global(&keys_global_name)
+        )
+    };
+    let pointer_mask_ref = if typed_layout.pointer_mask_words.is_empty() {
+        "null".to_string()
+    } else {
+        format!(
+            "@{}",
+            crate::typed_shape::mask_global_name_from_keys_global(&keys_global_name)
+        )
+    };
+    ctx.block().call_void(
+        "js_gc_init_typed_shape_layout",
+        &[
+            (I64, obj_handle),
+            (I32, &slot_count_str),
+            (PTR, &raw_mask_ref),
+            (I32, &raw_mask_word_count_str),
+            (PTR, &pointer_mask_ref),
+            (I32, &pointer_mask_word_count_str),
+        ],
+    );
+}
+
 /// Lower `new ClassName(args…)` — Phase C.1.
 ///
 /// Strategy: allocate an anonymous object via `js_object_alloc(0, N)`
@@ -1174,6 +1220,12 @@ fn lower_new_impl(
                 ctx.block()
                     .call(DOUBLE, "js_new_target_set", &[(DOUBLE, prev)]);
             }
+            // The constructor body has run and set the declared fields; register
+            // the typed raw-f64/pointer slot layout so class-field accesses hit
+            // the slot-direct fast path instead of the by-name hashmap fallback.
+            // The inline-ctor path does this at its tail (below); this
+            // standalone-symbol path returns here, so it must do it too.
+            emit_typed_shape_layout_init(ctx, class_name, &obj_handle);
             let is_derived = class.extends.is_some()
                 || class.extends_name.is_some()
                 || class.native_extends.is_some()
@@ -1869,39 +1921,7 @@ fn lower_new_impl(
             apply_field_initializers_recursive(ctx, class_name, FieldInitMode::AfterRoot)?;
         }
     }
-    if let Some(keys_global_name) = ctx.class_keys_globals.get(class_name).cloned() {
-        let typed_layout = crate::typed_shape::class_typed_layout(ctx.classes, class_name);
-        let slot_count_str = typed_layout.slot_count.to_string();
-        let raw_mask_word_count_str = typed_layout.raw_f64_mask_words.len().to_string();
-        let pointer_mask_word_count_str = typed_layout.pointer_mask_words.len().to_string();
-        let raw_mask_ref = if typed_layout.raw_f64_mask_words.is_empty() {
-            "null".to_string()
-        } else {
-            format!(
-                "@{}",
-                crate::typed_shape::raw_f64_mask_global_name_from_keys_global(&keys_global_name)
-            )
-        };
-        let pointer_mask_ref = if typed_layout.pointer_mask_words.is_empty() {
-            "null".to_string()
-        } else {
-            format!(
-                "@{}",
-                crate::typed_shape::mask_global_name_from_keys_global(&keys_global_name)
-            )
-        };
-        ctx.block().call_void(
-            "js_gc_init_typed_shape_layout",
-            &[
-                (I64, &obj_handle),
-                (I32, &slot_count_str),
-                (PTR, &raw_mask_ref),
-                (I32, &raw_mask_word_count_str),
-                (PTR, &pointer_mask_ref),
-                (I32, &pointer_mask_word_count_str),
-            ],
-        );
-    }
+    emit_typed_shape_layout_init(ctx, class_name, &obj_handle);
 
     // Close the inline-constructor return: fall through (or branch) to the
     // shared after-block, then apply the spec return-override at construction


### PR DESCRIPTION
## Problem

`new ClassName(...)` for any class with its **own constructor** takes the
standalone `<class>_constructor` symbol-call path in `lower_new_impl` (the
default since `PERRY_INLINE_CTOR` is unset — see the `force_ctor_call` branch).
That branch `return`s right after the constructor call and **never reaches the
`js_gc_init_typed_shape_layout(...)` registration** emitted at the tail of
`lower_new_impl` for the inline-constructor path.

With the instance's raw-f64 / pointer slot masks never registered in the GC's
`TYPED_LAYOUTS`, every typed-feedback class-field guard
(`js_typed_feedback_class_field_{get,set}_guard`) fails its `require_raw_f64`
contract. So every `this.field` read/write falls back to the by-name hashmap
path (`js_object_get_field_by_name_f64` / `js_class_field_set_fallback`) — a
string-keyed lookup under a lock, on every single access.

## Fix

Extract the layout emission into `emit_typed_shape_layout_init(...)` and call it
on the standalone-constructor path too, right after the constructor body has run
(so the declared fields already hold their numeric values, which the runtime
validates before promoting each raw-f64 slot). The inline path keeps calling the
same helper at its tail — no behavioral change there.

## Measurement — `benchmarks/suite/09_method_calls.ts` (10M `counter.increment()`)

| | time | per call |
|---|---|---|
| before | ~6396 ms | ~640 ns |
| after  | ~3216 ms | ~322 ns |

**1.99× faster (−50%)**, output unchanged (`value:10000000`). This brings the
default standalone-ctor path to parity with the pre-existing
`PERRY_INLINE_CTOR=1` inline path (~3170 ms), which already registered the
layout.

## Validation

- `cargo test -p perry-codegen` — 20 passed, 0 failed.
- `cargo fmt --check` — clean.
- Full `benchmarks/suite` compiles + runs; outputs unchanged, no new compile failures.
- Class / method / inheritance gap-test sweep vs `node --experimental-strip-types`:
  no new failures — the handful that differ from Node fail **identically on
  `origin/main`** (pre-existing gaps: `new.target`, class-expression static
  `this`, top-level await), confirmed by rebuilding the baseline.

## Follow-up — #5654

Even after this fix, the codegen-inlined class-field fast path (#5093 — the
`class_field_inline.deref` precheck) never engages in normal runs: the
process-global `PERRY_CLASS_FIELD_INLINE_GUARD_DISABLED` is set at startup, so
every field access still pays a full guard call. That is orthogonal to this PR
(which fixes the hashmap-fallback cliff, the larger win) and is tracked in #5654.
Once that lands, the typed layout this PR registers is exactly what the inline
precheck reads — the two together should close most of the `09_method_calls` gap.

> **Draft:** the broader inline-precheck gap (#5654) is still open, so this is
> intentionally the first, well-scoped step rather than a complete fix of the
> method-dispatch gap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization for newly created objects so typed-shape GC registration happens consistently across different construction paths.
  * Fixed a case where some objects could miss setup needed for optimized runtime behavior, making object creation more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->