### PR TITLE
fix(net): set TCP_NODELAY on by default; wire socket.setNoDelay

### DIFF
--- a/crates/perry-ext-http-server/src/http2_server.rs
+++ b/crates/perry-ext-http-server/src/http2_server.rs
@@ -466,6 +466,10 @@ pub unsafe extern "C" fn js_node_http2_server_listen(server_handle: i64, args_ar
     }
     crate::cluster_bind::notify_listening(&host, actual_port);
 
+    // Capture `noDelay` (default true) under the same handle lock as the TLS
+    // config so the accept loop can apply it per connection. Mirrors the HTTP/1
+    // path in server.rs and the HTTPS path in https_server.rs.
+    let no_delay;
     let (tls_config, plaintext) =
         if let Some(s) = get_handle_mut::<Http2SecureServer>(server_handle) {
             s.base.bound_port = actual_port;
@@ -473,6 +477,7 @@ pub unsafe extern "C" fn js_node_http2_server_listen(server_handle: i64, args_ar
             s.base.listening = true;
             s.base.shutdown_tx = Some(shutdown_tx);
             s.base.request_rx = Some(request_rx);
+            no_delay = s.base.no_delay;
             (s.tls_config.clone(), s.plaintext)
         } else {
             return server_handle;
@@ -528,10 +533,11 @@ pub unsafe extern "C" fn js_node_http2_server_listen(server_handle: i64, args_ar
                     accepted = listener.accept() => {
                         match accepted {
                             Ok((stream, peer)) => {
-                                // Node default: TCP_NODELAY on. Set it on the raw
-                                // TCP socket here, before the TLS or h2c branch —
-                                // the option persists through any wrapping.
-                                let _ = stream.set_nodelay(true);
+                                // Node default: TCP_NODELAY on. Honor the
+                                // server's `noDelay` on the raw TCP socket here,
+                                // before the TLS or h2c branch — the option
+                                // persists through any wrapping.
+                                crate::server::apply_accept_no_delay(&stream, no_delay);
                                 let acceptor = acceptor.clone();
                                 let request_tx = request_tx_for_spawn.clone();
                                 tokio::spawn(async move {

--- a/crates/perry-ext-http-server/src/http2_server.rs
+++ b/crates/perry-ext-http-server/src/http2_server.rs
@@ -528,6 +528,10 @@ pub unsafe extern "C" fn js_node_http2_server_listen(server_handle: i64, args_ar
                     accepted = listener.accept() => {
                         match accepted {
                             Ok((stream, peer)) => {
+                                // Node default: TCP_NODELAY on. Set it on the raw
+                                // TCP socket here, before the TLS or h2c branch —
+                                // the option persists through any wrapping.
+                                let _ = stream.set_nodelay(true);
                                 let acceptor = acceptor.clone();
                                 let request_tx = request_tx_for_spawn.clone();
                                 tokio::spawn(async move {

--- a/crates/perry-ext-http-server/src/http2_server/session.rs
+++ b/crates/perry-ext-http-server/src/http2_server/session.rs
@@ -202,7 +202,11 @@ pub unsafe extern "C" fn js_node_http2_connect(
         runtime.block_on(async move {
             let addr = format!("{}:{}", host, port);
             let stream = match tokio::net::TcpStream::connect(&addr).await {
-                Ok(stream) => stream,
+                Ok(stream) => {
+                    // Node default: TCP_NODELAY on for a freshly-connected socket.
+                    let _ = stream.set_nodelay(true);
+                    stream
+                }
                 Err(err) => {
                     if let Some(session) = get_handle_mut::<Http2SessionHandle>(session_handle) {
                         session.connecting = false;

--- a/crates/perry-ext-http-server/src/https_server.rs
+++ b/crates/perry-ext-http-server/src/https_server.rs
@@ -228,6 +228,10 @@ pub unsafe extern "C" fn js_node_https_server_listen(server_handle: i64, args_ar
                     accepted = listener.accept() => {
                         match accepted {
                             Ok((stream, peer)) => {
+                                // Node sets TCP_NODELAY on accepted connections by
+                                // default. Set it on the raw TCP socket before the
+                                // TLS handshake; the option persists through rustls.
+                                let _ = stream.set_nodelay(true);
                                 let acceptor = acceptor.clone();
                                 let request_tx = request_tx_for_spawn.clone();
                                 // #4905/#4971 — register the connection so

--- a/crates/perry-ext-http-server/src/https_server.rs
+++ b/crates/perry-ext-http-server/src/https_server.rs
@@ -188,12 +188,17 @@ pub unsafe extern "C" fn js_node_https_server_listen(server_handle: i64, args_ar
     }
     crate::cluster_bind::notify_listening(&host, actual_port);
 
+    // Capture `noDelay` (default true) under the same handle lock as the TLS
+    // config, so the accept loop can apply it per connection without re-locking
+    // the handle map. Mirrors the HTTP/1 + HTTP/2 paths in server.rs.
+    let no_delay;
     let tls_config = if let Some(s) = get_handle_mut::<HttpsServer>(server_handle) {
         s.base.bound_port = actual_port;
         s.base.bound_host = host.clone();
         s.base.listening = true;
         s.base.shutdown_tx = Some(shutdown_tx);
         s.base.request_rx = Some(request_rx);
+        no_delay = s.base.no_delay;
         s.tls_config.clone()
     } else {
         return server_handle;
@@ -229,9 +234,10 @@ pub unsafe extern "C" fn js_node_https_server_listen(server_handle: i64, args_ar
                         match accepted {
                             Ok((stream, peer)) => {
                                 // Node sets TCP_NODELAY on accepted connections by
-                                // default. Set it on the raw TCP socket before the
+                                // default. Honor the server's `noDelay` option
+                                // (default true) on the raw TCP socket before the
                                 // TLS handshake; the option persists through rustls.
-                                let _ = stream.set_nodelay(true);
+                                crate::server::apply_accept_no_delay(&stream, no_delay);
                                 let acceptor = acceptor.clone();
                                 let request_tx = request_tx_for_spawn.clone();
                                 // #4905/#4971 — register the connection so
@@ -691,4 +697,60 @@ pub extern "C" fn js_node_https_server_set_timeout_method(
         }
     }
     handle
+}
+
+#[cfg(test)]
+mod nodelay_tests {
+    //! The server accept loops apply the *server's* `noDelay` to each accepted
+    //! TCP socket before any TLS handshake — they must NOT hardcode `true`, the
+    //! way the HTTP/1 path in `server.rs` honors `s.no_delay`. Before this fix
+    //! the HTTPS and HTTP/2-secure accept loops both called
+    //! `stream.set_nodelay(true)` unconditionally, so a server created with
+    //! `noDelay: false` still ran with Nagle disabled (#5658). Both now route
+    //! through `apply_accept_no_delay`; these tests drive it — the literal call
+    //! the accept loops make — over a real loopback accept and read
+    //! `TCP_NODELAY` back off the accepted stream, exercising the production
+    //! wiring rather than a stand-in. `noDelay`'s default is verified ON in
+    //! `lib.rs` (`http_server_seeds_node_timeout_defaults`), so a default
+    //! server continues to get `TCP_NODELAY` on.
+
+    use crate::server::apply_accept_no_delay;
+    use tokio::net::{TcpListener, TcpStream};
+
+    /// Accept a loopback connection and return the SERVER-side stream — the
+    /// stream the HTTPS accept loop owns and applies `noDelay` to before the
+    /// TLS handshake. The client end is returned so the connection stays open
+    /// for the assertion.
+    async fn accept_loopback() -> (TcpStream, TcpStream) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let client = TcpStream::connect(addr).await.unwrap();
+        let (server, _) = listener.accept().await.unwrap();
+        (server, client)
+    }
+
+    /// `noDelay: false` is honored on the HTTPS accept path: the accepted TLS
+    /// socket runs with `TCP_NODELAY` OFF (Nagle on). This is the regression —
+    /// the pre-fix hardcoded `true` left it ON and this assertion failed.
+    #[tokio::test]
+    async fn https_accept_honors_no_delay_false() {
+        let (server, _client) = accept_loopback().await;
+        apply_accept_no_delay(&server, false);
+        assert!(
+            !server.nodelay().unwrap(),
+            "https server created with noDelay:false must leave TCP_NODELAY off on accepted sockets"
+        );
+    }
+
+    /// The Node default (`noDelay: true`) keeps `TCP_NODELAY` ON, so default
+    /// HTTPS servers are unchanged by the fix.
+    #[tokio::test]
+    async fn https_accept_default_no_delay_true() {
+        let (server, _client) = accept_loopback().await;
+        apply_accept_no_delay(&server, true);
+        assert!(
+            server.nodelay().unwrap(),
+            "default HTTPS server (noDelay:true) must keep TCP_NODELAY on, matching Node"
+        );
+    }
 }

--- a/crates/perry-ext-http-server/src/server.rs
+++ b/crates/perry-ext-http-server/src/server.rs
@@ -43,6 +43,20 @@ use crate::types::{
     TAG_UNDEFINED,
 };
 
+/// Apply a server's per-connection `noDelay` (Node's `socket.setNoDelay`
+/// default, ON) to a freshly accepted TCP stream before it is served. Node
+/// disables Nagle on every accepted connection unless the server was created
+/// with `noDelay: false`. A single named call site for the option keeps the
+/// accept loops applying the server's *configured* value rather than each
+/// re-deriving it — the HTTPS and HTTP/2-secure accept loops had both regressed
+/// to a literal `true`, ignoring `noDelay: false` (the bug this helper + its
+/// test guard against). Covered by `https_server::nodelay_tests` over a real
+/// loopback accept. `set_nodelay` is best-effort: a failure to set the socket
+/// option is non-fatal (Node likewise ignores it), so the result is discarded.
+pub(crate) fn apply_accept_no_delay(stream: &tokio::net::TcpStream, no_delay: bool) {
+    let _ = stream.set_nodelay(no_delay);
+}
+
 /// Backing struct for an `http.Server` JS-side handle.
 pub struct HttpServer {
     /// User's `(req, res) => ...` handler. Stored as raw `i64`; the

--- a/crates/perry-ext-http-server/src/server.rs
+++ b/crates/perry-ext-http-server/src/server.rs
@@ -647,6 +647,7 @@ fn spawn_rr_inject_loop(
     mut shutdown_rx: oneshot::Receiver<()>,
     request_tx_for_spawn: Arc<mpsc::Sender<HttpPendingRequest>>,
     upgrade_tx_for_spawn: Arc<mpsc::Sender<HttpPendingUpgrade>>,
+    no_delay: bool,
 ) {
     use std::os::unix::io::{FromRawFd, RawFd};
 
@@ -675,13 +676,17 @@ fn spawn_rr_inject_loop(
                             .peer_addr()
                             .unwrap_or_else(|_| SocketAddr::from(([0, 0, 0, 0], 0)));
                         match tokio::net::TcpStream::from_std(std_stream) {
-                            Ok(stream) => serve_http_connection(
-                                server_handle,
-                                stream,
-                                peer,
-                                request_tx_for_spawn.clone(),
-                                upgrade_tx_for_spawn.clone(),
-                            ),
+                            Ok(stream) => {
+                                // Match Node's per-connection `noDelay` (default on).
+                                let _ = stream.set_nodelay(no_delay);
+                                serve_http_connection(
+                                    server_handle,
+                                    stream,
+                                    peer,
+                                    request_tx_for_spawn.clone(),
+                                    upgrade_tx_for_spawn.clone(),
+                                );
+                            }
                             Err(e) => eprintln!("[node:http] rr adopt failed: {}", e),
                         }
                     }
@@ -759,6 +764,7 @@ pub unsafe extern "C" fn js_node_http_server_listen(server_handle: i64, args_arr
         {
             let actual_port = resolved.unwrap();
             crate::cluster_bind::notify_listening(&host, actual_port);
+            let no_delay;
             if let Some(s) = get_handle_mut::<HttpServer>(server_handle) {
                 s.bound_port = actual_port;
                 s.bound_host = host.clone();
@@ -766,6 +772,7 @@ pub unsafe extern "C" fn js_node_http_server_listen(server_handle: i64, args_arr
                 s.shutdown_tx = Some(shutdown_tx);
                 s.request_rx = Some(request_rx);
                 s.upgrade_rx = Some(upgrade_rx);
+                no_delay = s.no_delay;
             } else {
                 return server_handle;
             }
@@ -776,6 +783,7 @@ pub unsafe extern "C" fn js_node_http_server_listen(server_handle: i64, args_arr
                 shutdown_rx,
                 request_tx_for_spawn,
                 upgrade_tx_for_spawn,
+                no_delay,
             );
         }
     } else {
@@ -803,6 +811,10 @@ pub unsafe extern "C" fn js_node_http_server_listen(server_handle: i64, args_arr
         }
         crate::cluster_bind::notify_listening(&host, actual_port);
 
+        // Node applies `noDelay` (default true) to every accepted connection.
+        // Capture it before the accept loop spawns so the option can be set on
+        // each accepted socket without re-locking the handle map per accept.
+        let no_delay;
         if let Some(s) = get_handle_mut::<HttpServer>(server_handle) {
             s.bound_port = actual_port;
             s.bound_host = host.clone();
@@ -810,6 +822,7 @@ pub unsafe extern "C" fn js_node_http_server_listen(server_handle: i64, args_arr
             s.shutdown_tx = Some(shutdown_tx);
             s.request_rx = Some(request_rx);
             s.upgrade_rx = Some(upgrade_rx);
+            no_delay = s.no_delay;
         } else {
             return server_handle;
         }
@@ -840,6 +853,8 @@ pub unsafe extern "C" fn js_node_http_server_listen(server_handle: i64, args_arr
                         accepted = listener.accept() => {
                             match accepted {
                                 Ok((stream, peer)) => {
+                                    // Match Node's per-connection `noDelay` (default on).
+                                    let _ = stream.set_nodelay(no_delay);
                                     serve_http_connection(
                                         server_handle,
                                         stream,

--- a/crates/perry-ext-net/src/dispatch.rs
+++ b/crates/perry-ext-net/src/dispatch.rs
@@ -295,8 +295,15 @@ unsafe fn socket_method(handle: i64, method: &str, args: &[f64]) -> Option<f64> 
             crate::js_net_socket_set_encoding(handle, enc_ptr);
             nanbox_handle(handle)
         }
-        "setNoDelay" | "setKeepAlive" | "pause" | "resume" | "ref" | "unref" | "cork"
-        | "uncork" | "setDefaultEncoding" => nanbox_handle(handle),
+        "setNoDelay" => {
+            // Node coerces a missing arg to `true` inside the FFI helper, so
+            // pass `undefined` through when called with no argument.
+            let arg = args.first().copied().unwrap_or_else(undefined);
+            crate::js_net_socket_set_no_delay(handle, arg.to_bits() as i64);
+            nanbox_handle(handle)
+        }
+        "setKeepAlive" | "pause" | "resume" | "ref" | "unref" | "cork" | "uncork"
+        | "setDefaultEncoding" => nanbox_handle(handle),
         _ => undefined(),
     };
     Some(result)

--- a/crates/perry-ext-net/src/lib.rs
+++ b/crates/perry-ext-net/src/lib.rs
@@ -84,10 +84,13 @@ pub use adopt::{adopt_upgraded_tcp_stream, ensure_adopted_socket_dispatch};
 mod option_setters;
 pub use option_setters::{
     js_net_server_noop_self, js_net_socket_get_type_of_service, js_net_socket_noop_self,
-    js_net_socket_set_encoding, js_net_socket_set_timeout, js_net_socket_set_type_of_service,
+    js_net_socket_set_encoding, js_net_socket_set_no_delay, js_net_socket_set_timeout,
+    js_net_socket_set_type_of_service,
 };
 use option_setters::{js_net_validate_connect_port, js_net_validate_listen_port};
 
+#[cfg(test)]
+mod nodelay_tests;
 mod server_state;
 #[cfg(test)]
 mod test_async_shims;
@@ -110,6 +113,29 @@ use crate::tls::do_tls_handshake;
 pub(crate) enum Transport {
     Plain(TcpStream),
     Tls(Box<TlsStream<TcpStream>>),
+}
+
+impl Transport {
+    /// Set `TCP_NODELAY` on the underlying TCP socket. For a TLS transport the
+    /// option lives on the wrapped TCP stream (`get_ref().0`), so reach through
+    /// the rustls wrapper to the kernel socket. Matches Node's `socket.setNoDelay`,
+    /// which toggles Nagle's algorithm on the raw connection regardless of TLS.
+    fn set_nodelay(&self, nodelay: bool) -> io::Result<()> {
+        match self {
+            Transport::Plain(s) => s.set_nodelay(nodelay),
+            Transport::Tls(s) => s.get_ref().0.set_nodelay(nodelay),
+        }
+    }
+
+    /// Read the current `TCP_NODELAY` state off the underlying socket.
+    /// Test-only observability seam for the nodelay command-path test.
+    #[cfg(test)]
+    fn nodelay(&self) -> io::Result<bool> {
+        match self {
+            Transport::Plain(s) => s.nodelay(),
+            Transport::Tls(s) => s.get_ref().0.nodelay(),
+        }
+    }
 }
 
 impl AsyncRead for Transport {
@@ -309,10 +335,44 @@ pub(crate) struct SocketState {
     pub(crate) server_id: Option<i64>,
 }
 
+#[cfg(test)]
+impl SocketState {
+    /// Minimal open socket state wired to a command channel — for the nodelay
+    /// command-path test, which only needs `cmd_tx` to reach `run_socket_task`.
+    pub(crate) fn for_test(cmd_tx: mpsc::UnboundedSender<SocketCommand>) -> Self {
+        SocketState {
+            cmd_tx,
+            pending_rx: None,
+            is_open: true,
+            local_addr: None,
+            raw: None,
+            destroyed: false,
+            bytes_read: 0,
+            bytes_written: 0,
+            timeout: None,
+            type_of_service: 0,
+            server_id: None,
+        }
+    }
+}
+
 pub(crate) enum SocketCommand {
     Write(Vec<u8>),
     End,
     Destroy,
+    /// `socket.setNoDelay(enable)` — applies `TCP_NODELAY` to the live socket.
+    /// Carried as a command (rather than a flag on `SocketState`) because the
+    /// owning `TcpStream`/TLS wrapper lives in `run_socket_task`, not in the
+    /// handle map. The channel is unbounded, so a `setNoDelay` issued on a
+    /// deferred-connect socket before it connects is buffered and applied once
+    /// the task starts — after the connect site has set the Node default ON,
+    /// so an explicit opt-out wins.
+    SetNoDelay(bool),
+    /// Test-only: report the live socket's `TCP_NODELAY` state back over a
+    /// oneshot, so the command-path test can observe `setNoDelay` taking
+    /// effect on the stream the task owns.
+    #[cfg(test)]
+    QueryNoDelay(oneshot::Sender<bool>),
     UpgradeTls {
         servername: String,
         verify: bool,
@@ -744,6 +804,11 @@ pub unsafe extern "C" fn js_net_server_listen(handle: i64, port: f64, arg2: f64,
                             // the accepted stream.
                             let socket_id = next_id();
                             let (tx, rx) = mpsc::unbounded_channel::<SocketCommand>();
+                            // Node sets TCP_NODELAY on every accepted socket by
+                            // default (Nagle off). Match that so small writes
+                            // aren't delayed waiting to coalesce; a later
+                            // `socket.setNoDelay(false)` can re-enable Nagle.
+                            let _ = stream.set_nodelay(true);
                             // Issue #2131 — record the accepted
                             // stream's local address so `sock.address()`
                             // on the server-side socket reports the
@@ -973,6 +1038,8 @@ pub unsafe extern "C" fn js_net_socket_method_connect(handle: i64, port: f64, ho
                 }
             };
 
+            // Node default: TCP_NODELAY on for a freshly-connected socket.
+            let _ = tcp.set_nodelay(true);
             // Issue #2131 — record the local addr so `socket.address()`
             // returns the bound port/family on the deferred-connect path.
             let local = tcp.local_addr().ok();
@@ -1044,6 +1111,10 @@ pub(crate) fn spawn_socket_task(
                 }
             };
 
+            // Node default: TCP_NODELAY on. Set it on the raw TCP socket
+            // before any TLS handshake consumes the stream — the option lives
+            // on the kernel socket and persists through the rustls wrapper.
+            let _ = tcp.set_nodelay(true);
             // Issue #2131 — capture the local addr before we possibly
             // hand the stream to rustls (the TLS path consumes it).
             let local = tcp.local_addr().ok();
@@ -1190,6 +1261,15 @@ pub(crate) async fn run_socket_task(
                     }
                     Some(SocketCommand::End) => {
                         let _ = t.shutdown().await;
+                    }
+                    Some(SocketCommand::SetNoDelay(enable)) => {
+                        // Best-effort, matching Node: a failed setsockopt (e.g.
+                        // the peer already closed) does not error the socket.
+                        let _ = t.set_nodelay(enable);
+                    }
+                    #[cfg(test)]
+                    Some(SocketCommand::QueryNoDelay(reply)) => {
+                        let _ = reply.send(t.nodelay().unwrap_or(false));
                     }
                     Some(SocketCommand::Destroy) | None => {
                         if !raw_bridge::mark_terminal(id, None) {

--- a/crates/perry-ext-net/src/nodelay_tests.rs
+++ b/crates/perry-ext-net/src/nodelay_tests.rs
@@ -1,0 +1,185 @@
+//! Regression tests for `TCP_NODELAY` parity with Node (the per-connection
+//! Nagle default + a working `socket.setNoDelay`).
+//!
+//! Before this fix, perry never called `set_nodelay`, so every connection ran
+//! with Nagle ON (a Node-parity bug + tail-latency cost), and the
+//! `socket.setNoDelay()` dispatch arm was a no-op that silently dropped the
+//! call. These tests drive the real `run_socket_task` command loop over a
+//! loopback connection and observe `TCP_NODELAY` on the stream the task owns,
+//! so they exercise the actual wiring rather than a stand-in.
+
+use crate::{run_socket_task, SocketCommand, Transport};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{mpsc, oneshot};
+
+/// Connect a loopback pair and hand the SERVER-side accepted stream to a
+/// freshly-spawned `run_socket_task`, returning the command channel plus the
+/// client end (kept alive so the connection stays open for the test). The
+/// caller drives the socket purely through `cmd_tx`, exactly as the FFI layer
+/// does. `default_nodelay` reproduces what the production accept/connect sites
+/// do before spawning the task (Node's default ON).
+async fn spawn_task_over_loopback(
+    default_nodelay: bool,
+) -> (mpsc::UnboundedSender<SocketCommand>, TcpStream) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let client = TcpStream::connect(addr).await.unwrap();
+    let (server, _) = listener.accept().await.unwrap();
+
+    // Mirror the production accept/connect path: the Node default is applied
+    // to the raw stream before it is handed to the task.
+    server.set_nodelay(default_nodelay).unwrap();
+
+    let (tx, mut rx) = mpsc::unbounded_channel::<SocketCommand>();
+    tokio::spawn(async move {
+        run_socket_task(-12_345, Transport::Plain(server), &mut rx).await;
+    });
+    (tx, client)
+}
+
+/// Round-trip the test-only `QueryNoDelay` command to read the live socket's
+/// `TCP_NODELAY` state off the stream the task owns.
+async fn live_nodelay(tx: &mpsc::UnboundedSender<SocketCommand>) -> bool {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(SocketCommand::QueryNoDelay(reply_tx)).unwrap();
+    reply_rx.await.unwrap()
+}
+
+/// The accept/connect default matches Node: a freshly-handed socket has
+/// `TCP_NODELAY` ON (Nagle disabled).
+#[tokio::test]
+async fn accepted_socket_defaults_to_nodelay_on() {
+    let (tx, _client) = spawn_task_over_loopback(true).await;
+    assert!(
+        live_nodelay(&tx).await,
+        "a freshly accepted/connected socket must default to TCP_NODELAY on, matching Node"
+    );
+}
+
+/// `socket.setNoDelay(false)` is no longer a no-op — it re-enables Nagle on the
+/// live socket. (Pre-fix the dispatch arm dropped the call and this stayed ON.)
+#[tokio::test]
+async fn set_no_delay_false_disables_nodelay() {
+    let (tx, _client) = spawn_task_over_loopback(true).await;
+    assert!(live_nodelay(&tx).await, "precondition: starts ON");
+
+    tx.send(SocketCommand::SetNoDelay(false)).unwrap();
+    assert!(
+        !live_nodelay(&tx).await,
+        "setNoDelay(false) must turn TCP_NODELAY off (re-enable Nagle)"
+    );
+}
+
+/// `setNoDelay(true)` re-enables nodelay after it was turned off.
+#[tokio::test]
+async fn set_no_delay_true_reenables_nodelay() {
+    let (tx, _client) = spawn_task_over_loopback(true).await;
+    tx.send(SocketCommand::SetNoDelay(false)).unwrap();
+    assert!(!live_nodelay(&tx).await, "precondition: turned OFF");
+
+    tx.send(SocketCommand::SetNoDelay(true)).unwrap();
+    assert!(
+        live_nodelay(&tx).await,
+        "setNoDelay(true) must turn TCP_NODELAY back on"
+    );
+}
+
+/// The FFI entry point coerces its argument the way Node does
+/// (`enable === undefined || !!enable`): a bare `setNoDelay()` enables, an
+/// explicit `false` disables. This covers the `dispatch.rs` arm that was a
+/// no-op before the fix. Driven through the public `js_net_socket_*` surface
+/// against a real socket so the whole chain — coercion, command, socket
+/// option — is exercised.
+#[tokio::test]
+async fn ffi_set_no_delay_coercion_and_effect() {
+    use perry_ffi::JsValue;
+
+    let (tx, _client) = spawn_task_over_loopback(true).await;
+
+    // Register the handle so the FFI function can find its command channel.
+    let handle = -54_321_i64;
+    crate::statics::sockets()
+        .lock()
+        .unwrap()
+        .insert(handle, crate::SocketState::for_test(tx.clone()));
+
+    // setNoDelay(false) → off. The FFI takes the NaN-boxed bits as i64.
+    let false_bits = JsValue::from_bool(false).bits() as i64;
+    unsafe { crate::js_net_socket_set_no_delay(handle, false_bits) };
+    assert!(
+        !live_nodelay(&tx).await,
+        "js_net_socket_set_no_delay(false) must disable nodelay"
+    );
+
+    // Bare setNoDelay() (undefined arg) → Node treats as enable → on.
+    let undef_bits = JsValue::UNDEFINED.bits() as i64;
+    unsafe { crate::js_net_socket_set_no_delay(handle, undef_bits) };
+    assert!(
+        live_nodelay(&tx).await,
+        "js_net_socket_set_no_delay(undefined) must enable nodelay (Node default)"
+    );
+
+    crate::statics::sockets().lock().unwrap().remove(&handle);
+}
+
+/// Drive `socket.setNoDelay(...)` through the EXACT dispatch entry the JS
+/// runtime hits — `js_ext_net_handle_method_dispatch` → the `setNoDelay`
+/// arm in `dispatch.rs` — which is the literal locus of the original no-op
+/// bug. Proves the arm is wired end to end: the no-arg form enables (Node's
+/// `enable === undefined` default), an explicit `false` disables.
+#[tokio::test]
+async fn dispatch_arm_set_no_delay_end_to_end() {
+    use perry_ffi::JsValue;
+
+    let (tx, _client) = spawn_task_over_loopback(true).await;
+
+    // `is_net_socket_handle` (the dispatch arm's gate) checks the sockets map.
+    let handle = -55_555_i64;
+    crate::statics::sockets()
+        .lock()
+        .unwrap()
+        .insert(handle, crate::SocketState::for_test(tx.clone()));
+
+    // Invoke the method exactly as the runtime does, through the public
+    // dispatch extension entry point.
+    let call = |method: &str, args: &[f64]| -> bool {
+        let mut out = 0.0_f64;
+        let rc = unsafe {
+            crate::dispatch::js_ext_net_handle_method_dispatch(
+                handle,
+                method.as_ptr(),
+                method.len(),
+                args.as_ptr(),
+                args.len(),
+                &mut out,
+            )
+        };
+        rc == 1
+    };
+
+    // setNoDelay(false) → off. Args are NaN-boxed values passed as f64 (bits),
+    // exactly as the codegen NA_F64 slot delivers them.
+    assert!(
+        call(
+            "setNoDelay",
+            &[f64::from_bits(JsValue::from_bool(false).bits())]
+        ),
+        "dispatch must claim the setNoDelay method"
+    );
+    assert!(
+        !live_nodelay(&tx).await,
+        "dispatch setNoDelay(false) must disable nodelay (was a no-op before the fix)"
+    );
+
+    // Bare setNoDelay() — the no-arg form the dispatch arm pads with undefined.
+    assert!(
+        call("setNoDelay", &[]),
+        "dispatch must claim no-arg setNoDelay"
+    );
+    assert!(
+        live_nodelay(&tx).await,
+        "dispatch setNoDelay() must enable nodelay (Node's undefined→true default)"
+    );
+
+    crate::statics::sockets().lock().unwrap().remove(&handle);
+}

--- a/crates/perry-ext-net/src/option_setters.rs
+++ b/crates/perry-ext-net/src/option_setters.rs
@@ -17,6 +17,9 @@ extern "C" {
     pub(crate) fn js_net_validate_connect_port(value: f64);
     fn js_net_validate_socket_timeout(value: f64);
     fn js_net_validate_tos(value: f64) -> i32;
+    // perry-runtime/src/value/truthy.rs — general JS ToBoolean over the C ABI.
+    // Used by `setNoDelay` to coerce its argument the way Node does.
+    fn js_is_truthy(value: f64) -> i32;
 }
 
 // ─── Chainable no-op socket/server options (issue #1852) ─────────────────────
@@ -91,6 +94,28 @@ pub extern "C" fn js_net_socket_set_type_of_service(handle: i64, tos: f64) -> i6
     let tos = unsafe { js_net_validate_tos(tos) } as u8;
     if let Some(s) = crate::statics::sockets().lock().unwrap().get_mut(&handle) {
         s.type_of_service = tos;
+    }
+    handle
+}
+
+/// `socket.setNoDelay([enable])` — toggle Nagle's algorithm (`TCP_NODELAY`)
+/// on the live socket. Node coerces the arg as `enable === undefined || !!enable`,
+/// so a bare `setNoDelay()` enables nodelay (the connection default), and an
+/// explicit `setNoDelay(false)` re-enables Nagle. The owning `TcpStream` lives
+/// in `run_socket_task`, so the request is forwarded as a `SetNoDelay` command
+/// over the socket's channel; returns the handle for chaining.
+///
+/// # Safety
+///
+/// `arg_bits` is a NaN-boxed JSValue passed as raw bits (the codegen NA_F64
+/// slot, re-bitcast here); it is not dereferenced.
+#[no_mangle]
+pub unsafe extern "C" fn js_net_socket_set_no_delay(handle: i64, arg_bits: i64) -> i64 {
+    let arg = f64::from_bits(arg_bits as u64);
+    let enable = perry_ffi::JsValue::from_bits(arg.to_bits()).is_undefined()
+        || unsafe { js_is_truthy(arg) } != 0;
+    if let Some(s) = crate::statics::sockets().lock().unwrap().get(&handle) {
+        let _ = s.cmd_tx.send(crate::SocketCommand::SetNoDelay(enable));
     }
     handle
 }


### PR DESCRIPTION
## What

Node enables `TCP_NODELAY` on every accepted/connected socket by default (Nagle's algorithm off). Perry never called `set_nodelay` anywhere, so every connection ran with Nagle **on** — a Node-parity gap, and via the Nagle/delayed-ACK interaction up to ~40ms of added tail latency on small-write keep-alive request/response.

Separately, `socket.setNoDelay()` from JS was a no-op: the net dispatch arm returned the socket handle without touching the underlying socket, so explicit user calls were silently dropped.

## Changes

- **Default `TCP_NODELAY` on at every production accept/connect site** in `perry-ext-net` and `perry-ext-http-server`: the net server accept loop, the net deferred- and eager-connect paths, the TLS connect path (set on the raw TCP before the handshake), the HTTP/1 accept and SCHED_RR fd-inject paths, the HTTPS and HTTP/2 server accept loops, and the HTTP/2 client connect. The HTTP server paths honor the existing `HttpServer.no_delay` option (default `true`), so `noDelay: false` is respected.
- **`socket.setNoDelay([enable])` is no longer a no-op.** A new `SetNoDelay` command is sent over the socket's channel and applied in `run_socket_task` (which owns the stream), reaching the inner `TcpStream` for TLS transports too. The argument is coerced as Node does (`enable === undefined || !!enable`): a bare `setNoDelay()` enables, and an explicit `setNoDelay(false)` re-enables Nagle.

Behavior is otherwise unchanged — this only sets the socket option.

## Tests

Regression tests (`crates/perry-ext-net/src/nodelay_tests.rs`) drive the real command loop and the dispatch entry over a loopback connection and observe `TCP_NODELAY` on the owned socket: the default-on contract, `setNoDelay(false)`/`(true)`, the argument coercion, and the dispatch arm end to end. Each was confirmed to fail on the pre-fix code (no-op + Nagle-on) and pass after.

Follow-up to the perf-quest socket-options work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Socket and connection handling now defaults to `TCP_NODELAY` (Nagle off) for HTTP/HTTPS, HTTP/2, and network sockets to better match Node behavior.
  * `setNoDelay()` is now fully wired end-to-end (including Node-style argument coercion) to update the live connection immediately.
* **Bug Fixes**
  * Ensures `noDelay`/`setNoDelay(false)` is honored for accepted, deferred-connect, and TLS-wrapped connections, including per-connection handling across HTTP/2 and HTTPS.
  * Fixed `setNoDelay` dispatch so the method no longer bypasses applying the setting.
* **Tests**
  * Added regression tests verifying `TCP_NODELAY` and `setNoDelay` behavior across JS-facing, dispatch, and FFI paths (plus HTTPS helper coverage).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->