### PR TITLE
fix(hir): a bound local/param shadows a same-named class in static-method dispatch

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/static_and_instance.rs
+++ b/crates/perry-hir/src/lower/expr_call/static_and_instance.rs
@@ -75,7 +75,29 @@ pub(super) fn try_static_method_and_instance(
     if let ast::Expr::Member(member) = expr {
         if let ast::Expr::Ident(obj_ident) = unwrap_ts_wrappers(member.obj.as_ref()) {
             let obj_name = obj_ident.sym.to_string();
-            if let Some((module_name, Some(class_name))) = ctx.lookup_native_module(&obj_name) {
+            // A bound LOCAL variable / parameter shadows any class, imported
+            // class, or native-module binding of the SAME name (JS lexical
+            // scoping). Minified bundles frequently reuse single-letter names:
+            // Next.js's `app-route-turbo` defines `class n { static has(e,t){…} }`
+            // at module scope AND a `let n = new Set` inside its implicit-tags
+            // builder. Without this guard, `n.has(key)` (Set.has) was lowered to
+            // `StaticMethodCall { class_name: "n", method: "has" }`, calling the
+            // class's static `has(e,t)` with `(key, undefined)` →
+            // `Reflect.has("…", undefined)` → "Reflect.has called on non-object"
+            // (Next.js dynamic/API routes 500'd). The local must win.
+            //
+            // Scope this guard to the STATIC-class / native-module-static arms
+            // below — NOT to the native-INSTANCE arm (line ~191), which is
+            // itself keyed on a local/param binding via `lookup_native_instance`
+            // (e.g. an upgrade handler's `wsId.send(...)` parameter) and must
+            // still dispatch.
+            let local_shadows_class = ctx.lookup_local(&obj_name).is_some();
+            if local_shadows_class {
+                // fall through past the static arms to native-instance / generic
+                // dispatch below.
+            } else if let Some((module_name, Some(class_name))) =
+                ctx.lookup_native_module(&obj_name)
+            {
                 if let ast::MemberProp::Ident(method_ident) = &member.prop {
                     let method_name = method_ident.sym.to_string();
                     let normalized_module =
@@ -127,7 +149,8 @@ pub(super) fn try_static_method_and_instance(
                     .next()
                     .map(|c| c.is_uppercase())
                     .unwrap_or(false);
-            if ctx.lookup_class(&obj_name).is_some() || is_imported_upper {
+            if !local_shadows_class && (ctx.lookup_class(&obj_name).is_some() || is_imported_upper)
+            {
                 match &member.prop {
                     ast::MemberProp::Ident(method_ident) => {
                         let method_name = method_ident.sym.to_string();

--- a/crates/perry-hir/tests/local_shadows_class_static_call.rs
+++ b/crates/perry-hir/tests/local_shadows_class_static_call.rs
@@ -1,0 +1,74 @@
+use perry_diagnostics::SourceCache;
+use perry_hir::lower_module;
+use perry_parser::parse_typescript_with_cache;
+
+fn lower_debug(src: &str) -> String {
+    let mut cache = SourceCache::new();
+    let parsed = parse_typescript_with_cache(src, "local_shadows_class_static_call.ts", &mut cache)
+        .expect("parse should succeed");
+    let module = lower_module(&parsed.module, "test", "local_shadows_class_static_call.ts")
+        .expect("lowering should succeed");
+    format!("{module:#?}")
+}
+
+/// #5437 (Next.js dynamic/API routes 500): minified bundles reuse single-letter
+/// names, so a function can have a LOCAL `let n = new Set()` while a same-named
+/// `class n { static has(e, t) { ... } }` lives at module scope. JS lexical
+/// scoping says the local shadows the class, so `n.has(x)` must be an instance
+/// call on the Set local — NOT a static call on the class.
+///
+/// Before the fix, `try_static_method_and_instance` saw `ctx.lookup_class("n")`
+/// succeed and lowered `n.has(x)` to `StaticMethodCall { class_name: "n",
+/// method_name: "has" }`, calling the class's `static has(e, t)` with
+/// `(x, undefined)` → `Reflect.has(x, undefined)` → "Reflect.has called on
+/// non-object". (This is exactly Next.js's `app-route-turbo` implicit-tags
+/// builder hitting its own `class n` proxy-handler.)
+#[test]
+fn local_set_shadows_same_named_class_static_has() {
+    let debug = lower_debug(
+        r#"
+        class n {
+            static has(e: any, t: any): any { return e; }
+        }
+
+        function build(): any {
+            const n = new Set<string>();
+            n.add("a");
+            return n.has("a");
+        }
+
+        const out = build();
+        const ref: any = n; // keep the class live so it is not pruned
+        "#,
+    );
+
+    assert!(
+        !debug.contains("StaticMethodCall {\n            class_name: \"n\""),
+        "shadowed local `n.has()` must not lower to a StaticMethodCall on class n: {debug}"
+    );
+    // The local Set's `.has` should lower to the Set intrinsic.
+    assert!(
+        debug.contains("SetHas"),
+        "the local Set's `.has` should lower to SetHas: {debug}"
+    );
+}
+
+/// Companion: a genuine static-method call on a class that is NOT shadowed by a
+/// local of the same name must still lower to `StaticMethodCall` — the fix must
+/// not regress real static calls.
+#[test]
+fn unshadowed_class_static_call_stays_static() {
+    let debug = lower_debug(
+        r#"
+        class Helper {
+            static run(x: number): number { return x + 1; }
+        }
+        const out = Helper.run(41);
+        "#,
+    );
+
+    assert!(
+        debug.contains("StaticMethodCall"),
+        "unshadowed `Helper.run()` must still lower to StaticMethodCall: {debug}"
+    );
+}


### PR DESCRIPTION
## What
`n.has(k)` where `n` is a bound **local** (e.g. a `Set`) was lowered to a **static** method call on a same-named module-scope `class n` — because `try_static_method_and_instance` checked `ctx.lookup_class("n")` but never checked that a bound local shadows the class. Per JS lexical scoping, the local wins.

Found via Next.js (#5437): the implicit-tags builder's `n.has("_N_T_/")` (a real `Set.has`) was dispatched to a bundled `class n { static has(e,t){return Reflect.has(e,t)} }`, so it ran `Reflect.has("_N_T_/", undefined)` → `TypeError: Reflect.has called on non-object` → 500 on every dynamic/API route. But the bug is general (any local shadowing a same-named class/import).

## Fix
Gate the two **static** dispatch arms on `local_shadows_class = ctx.lookup_local(obj_name).is_some()` (covers same-name class, imported class, native-module binding). The native **instance** arm stays reachable (a broad early-return regressed `wsId.send()` param dispatch — guarded by `ws_upgrade_param_native_dispatch`). +2 regression tests; standalone repro matches node; the `Reflect.has` throw is gone from the bundle; perry-hir/codegen/transform suites pass.

Refs #5437.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed method-call lowering so local variables or parameters that shadow a class name no longer get treated as static class calls.
  * Improved handling of calls like `obj.method(...)` to fall back to the correct instance/generic behavior when the name is shadowed.
  * Added coverage for both shadowed and non-shadowed cases to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->