### PR TITLE
perf(fetch): zero-copy response body + fix arrayBuffer binary corruption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5679,6 +5679,7 @@ dependencies = [
 name = "perry-ext-fetch"
 version = "0.5.1206"
 dependencies = [
+ "bytes",
  "lazy_static",
  "perry-ffi",
  "perry-runtime",

--- a/crates/perry-ext-fetch/Cargo.toml
+++ b/crates/perry-ext-fetch/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["staticlib", "rlib"]
 [dependencies]
 perry-ffi.workspace = true
 reqwest = { version = "0.12", features = ["json", "rustls-tls", "http2"], default-features = false }
+bytes = "1"
 tokio = { workspace = true }
 serde_json = "1"
 lazy_static = "1.5"

--- a/crates/perry-ext-fetch/src/lib.rs
+++ b/crates/perry-ext-fetch/src/lib.rs
@@ -8,6 +8,7 @@
 //! (closes #236), per-handle Response / Headers / Blob / Request /
 //! Stream pools.
 //!
+use bytes::Bytes;
 use lazy_static::lazy_static;
 use perry_ffi::{
     alloc_string, get_handle, register_handle, spawn_blocking, JsClosure, JsPromise, JsString,
@@ -69,7 +70,14 @@ struct FetchResponse {
     status: u16,
     status_text: String,
     headers: HeadersStore,
-    body: Vec<u8>,
+    // `Bytes` (not `Vec<u8>`): the body is filled once from `reqwest`'s
+    // `response.bytes()` and then read by several accessors
+    // (`text`/`json`/`arrayBuffer`/`bytes`/`blob`/`formData`). With a
+    // `Vec<u8>` every accessor `.clone()`d the whole payload to drop the
+    // registry lock before allocating into the arena — a full body copy
+    // per read. `Bytes` is a refcounted slice, so that same `.clone()` is
+    // an O(1) atomic bump (zero copy); the decode is what allocates, once.
+    body: Bytes,
     type_name: String,
     url: String,
     redirected: bool,
@@ -423,7 +431,7 @@ fn do_fetch(
                     let response_url = response.url().to_string();
                     let redirected = response_url != url;
                     let headers = headers_from_header_map(response.headers());
-                    let body = response.bytes().await.unwrap_or_default().to_vec();
+                    let body = response.bytes().await.unwrap_or_default();
                     Ok(FetchResponse {
                         status,
                         status_text,
@@ -473,10 +481,6 @@ pub unsafe extern "C" fn js_fetch_get_with_auth(
     let promise = JsPromise::new();
     let raw = promise.as_raw();
     let Some(url) = read_str(url_ptr) else {
-        eprintln!(
-            "[ext-fetch GET-auth] url_ptr null/invalid (ptr={:?})",
-            url_ptr
-        );
         promise.reject_string("Invalid URL");
         return raw;
     };
@@ -486,11 +490,6 @@ pub unsafe extern "C" fn js_fetch_get_with_auth(
             headers.insert("Authorization".to_string(), auth);
         }
     }
-    eprintln!(
-        "[ext-fetch GET-auth] url='{}' headers.len={}",
-        &url[..url.len().min(80)],
-        headers.len()
-    );
     do_fetch("GET".to_string(), url, headers, None, promise);
     raw
 }
@@ -579,16 +578,7 @@ pub unsafe extern "C" fn js_fetch_with_options(
 pub extern "C" fn js_fetch_response_status(handle: f64) -> f64 {
     let id = handle_id(handle);
     let map = FETCH_RESPONSES.lock().unwrap();
-    let result = map.get(&id).map(|r| r.status as f64).unwrap_or(0.0);
-    eprintln!(
-        "[ext-fetch resp.status] handle={} bits=0x{:016x} id={} keys={:?} -> {}",
-        handle,
-        handle.to_bits(),
-        id,
-        map.keys().collect::<Vec<_>>(),
-        result
-    );
-    result
+    map.get(&id).map(|r| r.status as f64).unwrap_or(0.0)
 }
 
 #[no_mangle]
@@ -652,8 +642,12 @@ pub unsafe extern "C" fn js_fetch_response_text(handle: f64) -> *mut Promise {
         .map(|r| r.body.clone());
     match body {
         Some(b) => {
-            let s = String::from_utf8_lossy(&b).to_string();
-            promise.resolve(JsValue::from_string_ptr(alloc_string(&s).as_raw()));
+            // `from_utf8_lossy` borrows when the body is already valid
+            // UTF-8 (the common case), so the decode adds no allocation;
+            // `alloc_string` then writes straight into the arena.
+            promise.resolve(JsValue::from_string_ptr(
+                alloc_string(&String::from_utf8_lossy(&b)).as_raw(),
+            ));
         }
         None => promise.reject_string("Invalid response handle"),
     }
@@ -676,9 +670,11 @@ pub unsafe extern "C" fn js_fetch_response_json(handle: f64) -> *mut Promise {
         Some(b) => {
             // Return the body as a JSON string — user code does
             // JSON.parse(text) on the JS side. Same shape as
-            // perry-stdlib's existing copy.
-            let s = String::from_utf8_lossy(&b).to_string();
-            promise.resolve(JsValue::from_string_ptr(alloc_string(&s).as_raw()));
+            // perry-stdlib's existing copy. `from_utf8_lossy` borrows on
+            // valid UTF-8, so the decode is allocation-free into the arena.
+            promise.resolve(JsValue::from_string_ptr(
+                alloc_string(&String::from_utf8_lossy(&b)).as_raw(),
+            ));
         }
         None => promise.reject_string("Invalid response handle"),
     }
@@ -1114,7 +1110,7 @@ pub unsafe extern "C" fn js_response_new(
         status,
         status_text,
         headers,
-        body,
+        body: Bytes::from(body),
         type_name: "default".to_string(),
         url: String::new(),
         redirected: false,
@@ -1143,6 +1139,18 @@ pub extern "C" fn js_response_clone(handle: f64) -> f64 {
     }
 }
 
+/// Wrap arbitrary body bytes as the `JsValue` that `arrayBuffer()` /
+/// `bytes()` resolve with: a runtime Buffer (`POINTER_TAG`), byte-exact.
+///
+/// The body must NOT go through a `String`: `new Uint8Array(value)` on
+/// the JS side dispatches on the buffer tag, so a `STRING_TAG` value is
+/// read as an empty buffer — and `from_utf8_unchecked` on a non-UTF-8
+/// payload (a fetched PNG/protobuf) is both UB and lossy. Handing the
+/// raw bytes to `alloc_buffer` is the only correct shape.
+fn body_to_buffer_value(bytes: &[u8]) -> JsValue {
+    JsValue::from_object_ptr(perry_ffi::alloc_buffer(bytes))
+}
+
 /// # Safety
 /// `handle` must come from a previous fetch.
 #[no_mangle]
@@ -1156,12 +1164,7 @@ pub unsafe extern "C" fn js_response_array_buffer(handle: f64) -> *mut Promise {
         .get(&id)
         .map(|r| r.body.clone());
     match body {
-        Some(b) => {
-            // Resolve with the bytes as a string (caller wraps in
-            // Uint8Array on JS side).
-            let s = unsafe { std::str::from_utf8_unchecked(&b) }.to_string();
-            promise.resolve(JsValue::from_string_ptr(alloc_string(&s).as_raw()));
-        }
+        Some(b) => promise.resolve(body_to_buffer_value(&b)),
         None => promise.reject_string("Invalid response handle"),
     }
     raw
@@ -1180,10 +1183,7 @@ pub unsafe extern "C" fn js_response_bytes(handle: f64) -> *mut Promise {
         .get(&id)
         .map(|r| r.body.clone());
     match body {
-        Some(b) => {
-            let buf = perry_ffi::alloc_buffer(&b);
-            promise.resolve(JsValue::from_object_ptr(buf));
-        }
+        Some(b) => promise.resolve(body_to_buffer_value(&b)),
         None => promise.reject_string("Invalid response handle"),
     }
     raw
@@ -1226,7 +1226,7 @@ pub unsafe extern "C" fn js_response_blob(handle: f64) -> *mut Promise {
                 .get("content-type")
                 .unwrap_or_else(|| "application/octet-stream".to_string());
             let blob_id = store_blob(BlobData {
-                bytes: r.body,
+                bytes: r.body.to_vec(),
                 content_type,
             });
             promise.resolve(JsValue::from_number(blob_id as f64));
@@ -1294,7 +1294,7 @@ pub unsafe extern "C" fn js_response_static_json(
         status,
         status_text,
         headers,
-        body: body.into_bytes(),
+        body: Bytes::from(body),
         type_name: "default".to_string(),
         url: String::new(),
         redirected: false,
@@ -1323,7 +1323,7 @@ pub unsafe extern "C" fn js_response_static_redirect(
         status: status as u16,
         status_text: String::new(),
         headers,
-        body: Vec::new(),
+        body: Bytes::new(),
         type_name: "default".to_string(),
         url: String::new(),
         redirected: false,
@@ -1336,7 +1336,7 @@ pub extern "C" fn js_response_static_error() -> f64 {
         status: 0,
         status_text: String::new(),
         headers: HeadersStore::default(),
-        body: Vec::new(),
+        body: Bytes::new(),
         type_name: "error".to_string(),
         url: String::new(),
         redirected: false,
@@ -1379,10 +1379,11 @@ pub unsafe extern "C" fn js_blob_array_buffer(handle: f64) -> *mut Promise {
         .get(&id)
         .map(|b| b.bytes.clone());
     match bytes {
-        Some(b) => {
-            let s = unsafe { std::str::from_utf8_unchecked(&b) }.to_string();
-            promise.resolve(JsValue::from_string_ptr(alloc_string(&s).as_raw()));
-        }
+        // Resolve a real Buffer object, not a string: the same non-UTF-8
+        // corruption the Response `arrayBuffer` path had — `blob.arrayBuffer()`
+        // (and `blob.bytes()`, which forwards here) must return the stored
+        // bytes byte-exact.
+        Some(b) => promise.resolve(body_to_buffer_value(&b)),
         None => promise.reject_string("Invalid blob handle"),
     }
     raw
@@ -1829,170 +1830,4 @@ fn _ensure_handle_imports() -> Option<()> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn response_count_starts_at_zero() {
-        let initial = js_fetch_response_count();
-        // Other tests may have populated, but it can't be negative.
-        assert!(initial >= 0);
-    }
-
-    #[test]
-    fn response_status_invalid_handle() {
-        assert_eq!(js_fetch_response_status(99_999_999.0), 0.0);
-    }
-
-    #[test]
-    fn headers_round_trip() {
-        let h = js_headers_new();
-        let key = alloc_string("Content-Type");
-        let value = alloc_string("application/json");
-        let set = unsafe { js_headers_set(h, key.as_raw(), value.as_raw()) };
-        assert_eq!(set, 1.0);
-        let got_ptr = unsafe { js_headers_get(h, key.as_raw()) };
-        let got = perry_ffi::read_string(unsafe { JsString::from_raw(got_ptr) }).expect("non-null");
-        assert_eq!(got, "application/json");
-        let has = unsafe { js_headers_has(h, key.as_raw()) };
-        assert_eq!(has, 1.0);
-        let del = unsafe { js_headers_delete(h, key.as_raw()) };
-        assert_eq!(del, 1.0);
-        let has2 = unsafe { js_headers_has(h, key.as_raw()) };
-        assert_eq!(has2, 0.0);
-    }
-
-    #[test]
-    fn headers_append_combines_values() {
-        let h = js_headers_new();
-        let key = alloc_string("X-Test");
-        let first = alloc_string("a");
-        let second = alloc_string("b");
-
-        let append_first = unsafe { js_headers_append(h, key.as_raw(), first.as_raw()) };
-        let append_second = unsafe { js_headers_append(h, key.as_raw(), second.as_raw()) };
-        assert_eq!(append_first, 1.0);
-        assert_eq!(append_second, 1.0);
-
-        let got_ptr = unsafe { js_headers_get(h, key.as_raw()) };
-        let got = perry_ffi::read_string(unsafe { JsString::from_raw(got_ptr) }).expect("non-null");
-        assert_eq!(got, "a, b");
-    }
-
-    #[test]
-    fn blob_slice_basic() {
-        let id = store_blob(BlobData {
-            bytes: b"hello, world".to_vec(),
-            content_type: "text/plain".to_string(),
-        });
-        let null = std::ptr::null::<StringHeader>();
-        let sliced = unsafe { js_blob_slice(id as f64, 7.0, 12.0, null) };
-        assert!(sliced > 0.0);
-        let size = js_blob_size(sliced);
-        assert_eq!(size, 5.0);
-    }
-
-    #[test]
-    fn request_round_trip() {
-        let url = alloc_string("https://example.com");
-        let method = alloc_string("POST");
-        let body = alloc_string(r#"{"x":1}"#);
-        let null = std::ptr::null::<StringHeader>();
-        let h = unsafe {
-            js_request_new(
-                url.as_raw(),
-                method.as_raw(),
-                body.as_raw(),
-                0.0,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                0.0,
-                null,
-                0.0,
-            )
-        };
-        assert!(h > 0.0);
-        let url_ptr = js_request_get_url(h);
-        let url_str =
-            perry_ffi::read_string(unsafe { JsString::from_raw(url_ptr) }).expect("non-null");
-        assert_eq!(url_str, "https://example.com");
-        let method_ptr = js_request_get_method(h);
-        let method_str =
-            perry_ffi::read_string(unsafe { JsString::from_raw(method_ptr) }).expect("non-null");
-        assert_eq!(method_str, "POST");
-    }
-
-    #[test]
-    fn response_static_json() {
-        let v = JsValue::from_string_ptr(alloc_string("hello").as_raw());
-        // No init: status defaults to 200, no statusText, no headers.
-        let resp = unsafe {
-            js_response_static_json(f64::from_bits(v.bits()), 0.0, std::ptr::null(), 0.0)
-        };
-        assert!(resp > 0.0);
-        let status = js_fetch_response_status(resp);
-        assert_eq!(status, 200.0);
-    }
-
-    // #1688: request.text()/.json()/.arrayBuffer() were unimplemented. The
-    // FFIs build a JsPromise (runtime symbols unavailable in the unittest
-    // binary, as with every other promise-returning fetch FFI), so this
-    // exercises the shared body data path they consume: a stored body
-    // round-trips, a bodiless request reads as "", and an invalid handle is
-    // None (→ the FFI rejects).
-    #[test]
-    fn request_body_data_path() {
-        let url = alloc_string("https://example.com");
-        let method = alloc_string("POST");
-        let body = alloc_string(r#"{"x":1}"#);
-        let null = std::ptr::null::<StringHeader>();
-        let h = unsafe {
-            js_request_new(
-                url.as_raw(),
-                method.as_raw(),
-                body.as_raw(),
-                0.0,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                0.0,
-                null,
-                0.0,
-            )
-        };
-        assert!(h > 0.0);
-        assert_eq!(request_body_string(h).as_deref(), Some(r#"{"x":1}"#));
-
-        let url2 = alloc_string("https://example.com/empty");
-        let h2 = unsafe {
-            js_request_new(
-                url2.as_raw(),
-                null,
-                null,
-                0.0,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                0.0,
-                null,
-                0.0,
-            )
-        };
-        assert_eq!(request_body_string(h2).as_deref(), Some(""));
-
-        assert_eq!(request_body_string(99_999_999.0), None);
-    }
-}
+mod tests;

--- a/crates/perry-ext-fetch/src/tests.rs
+++ b/crates/perry-ext-fetch/src/tests.rs
@@ -1,0 +1,263 @@
+//! Unit tests for the fetch FFI surface. Split out of `lib.rs` to keep
+//! that file under the 2,000-line lint gate. As a child module of the
+//! crate root, `use super::*` reaches every crate-private item.
+
+use super::*;
+
+#[test]
+fn response_count_starts_at_zero() {
+    let initial = js_fetch_response_count();
+    // Other tests may have populated, but it can't be negative.
+    assert!(initial >= 0);
+}
+
+#[test]
+fn response_status_invalid_handle() {
+    assert_eq!(js_fetch_response_status(99_999_999.0), 0.0);
+}
+
+#[test]
+fn headers_round_trip() {
+    let h = js_headers_new();
+    let key = alloc_string("Content-Type");
+    let value = alloc_string("application/json");
+    let set = unsafe { js_headers_set(h, key.as_raw(), value.as_raw()) };
+    assert_eq!(set, 1.0);
+    let got_ptr = unsafe { js_headers_get(h, key.as_raw()) };
+    let got = perry_ffi::read_string(unsafe { JsString::from_raw(got_ptr) }).expect("non-null");
+    assert_eq!(got, "application/json");
+    let has = unsafe { js_headers_has(h, key.as_raw()) };
+    assert_eq!(has, 1.0);
+    let del = unsafe { js_headers_delete(h, key.as_raw()) };
+    assert_eq!(del, 1.0);
+    let has2 = unsafe { js_headers_has(h, key.as_raw()) };
+    assert_eq!(has2, 0.0);
+}
+
+#[test]
+fn headers_append_combines_values() {
+    let h = js_headers_new();
+    let key = alloc_string("X-Test");
+    let first = alloc_string("a");
+    let second = alloc_string("b");
+
+    let append_first = unsafe { js_headers_append(h, key.as_raw(), first.as_raw()) };
+    let append_second = unsafe { js_headers_append(h, key.as_raw(), second.as_raw()) };
+    assert_eq!(append_first, 1.0);
+    assert_eq!(append_second, 1.0);
+
+    let got_ptr = unsafe { js_headers_get(h, key.as_raw()) };
+    let got = perry_ffi::read_string(unsafe { JsString::from_raw(got_ptr) }).expect("non-null");
+    assert_eq!(got, "a, b");
+}
+
+#[test]
+fn blob_slice_basic() {
+    let id = store_blob(BlobData {
+        bytes: b"hello, world".to_vec(),
+        content_type: "text/plain".to_string(),
+    });
+    let null = std::ptr::null::<StringHeader>();
+    let sliced = unsafe { js_blob_slice(id as f64, 7.0, 12.0, null) };
+    assert!(sliced > 0.0);
+    let size = js_blob_size(sliced);
+    assert_eq!(size, 5.0);
+}
+
+#[test]
+fn request_round_trip() {
+    let url = alloc_string("https://example.com");
+    let method = alloc_string("POST");
+    let body = alloc_string(r#"{"x":1}"#);
+    let null = std::ptr::null::<StringHeader>();
+    let h = unsafe {
+        js_request_new(
+            url.as_raw(),
+            method.as_raw(),
+            body.as_raw(),
+            0.0,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            0.0,
+            null,
+            0.0,
+        )
+    };
+    assert!(h > 0.0);
+    let url_ptr = js_request_get_url(h);
+    let url_str = perry_ffi::read_string(unsafe { JsString::from_raw(url_ptr) }).expect("non-null");
+    assert_eq!(url_str, "https://example.com");
+    let method_ptr = js_request_get_method(h);
+    let method_str =
+        perry_ffi::read_string(unsafe { JsString::from_raw(method_ptr) }).expect("non-null");
+    assert_eq!(method_str, "POST");
+}
+
+#[test]
+fn response_static_json() {
+    let v = JsValue::from_string_ptr(alloc_string("hello").as_raw());
+    // No init: status defaults to 200, no statusText, no headers.
+    let resp =
+        unsafe { js_response_static_json(f64::from_bits(v.bits()), 0.0, std::ptr::null(), 0.0) };
+    assert!(resp > 0.0);
+    let status = js_fetch_response_status(resp);
+    assert_eq!(status, 200.0);
+}
+
+// #1688: request.text()/.json()/.arrayBuffer() were unimplemented. The
+// FFIs build a JsPromise (runtime symbols unavailable in the unittest
+// binary, as with every other promise-returning fetch FFI), so this
+// exercises the shared body data path they consume: a stored body
+// round-trips, a bodiless request reads as "", and an invalid handle is
+// None (→ the FFI rejects).
+#[test]
+fn request_body_data_path() {
+    let url = alloc_string("https://example.com");
+    let method = alloc_string("POST");
+    let body = alloc_string(r#"{"x":1}"#);
+    let null = std::ptr::null::<StringHeader>();
+    let h = unsafe {
+        js_request_new(
+            url.as_raw(),
+            method.as_raw(),
+            body.as_raw(),
+            0.0,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            0.0,
+            null,
+            0.0,
+        )
+    };
+    assert!(h > 0.0);
+    assert_eq!(request_body_string(h).as_deref(), Some(r#"{"x":1}"#));
+
+    let url2 = alloc_string("https://example.com/empty");
+    let h2 = unsafe {
+        js_request_new(
+            url2.as_raw(),
+            null,
+            null,
+            0.0,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            0.0,
+            null,
+            0.0,
+        )
+    };
+    assert_eq!(request_body_string(h2).as_deref(), Some(""));
+
+    assert_eq!(request_body_string(99_999_999.0), None);
+}
+
+// A body holding non-UTF-8 bytes (here: 0xFF 0xFE 0x00 0x80 — invalid
+// UTF-8, with an embedded NUL). Asserts the same bytes survive every
+// stage that matters.
+const NON_UTF8: &[u8] = &[0xFF, 0xFE, 0x00, 0x80, b'P', b'N', b'G'];
+
+fn store_with_body(body: Bytes) -> usize {
+    store_response(FetchResponse {
+        status: 200,
+        status_text: "OK".to_string(),
+        headers: HeadersStore::default(),
+        body,
+        type_name: "basic".to_string(),
+        url: "https://example.com/bin".to_string(),
+        redirected: false,
+    })
+}
+
+// Regression for the `arrayBuffer`/`bytes` non-UTF-8 corruption bug. The
+// old path round-tripped the body through `from_utf8_unchecked` → String
+// → `from_string_ptr`, which (a) is UB on non-UTF-8 and (b) resolved a
+// STRING_TAG value that the JS `new Uint8Array(...)` dispatch reads as an
+// empty buffer. FAIL-BEFORE: a string-tagged value, not a buffer, so
+// `is_pointer()` is false and `read_buffer_bytes` cannot recover the
+// payload. PASS-AFTER: a POINTER_TAG Buffer whose bytes are byte-exact.
+#[test]
+fn array_buffer_value_is_byte_exact_buffer() {
+    let value = body_to_buffer_value(NON_UTF8);
+    assert!(
+        value.is_pointer(),
+        "arrayBuffer()/bytes() must resolve a Buffer (POINTER_TAG), not a string"
+    );
+    assert!(!value.is_string());
+    let buf = value.as_pointer::<perry_ffi::BufferHeader>();
+    let read = perry_ffi::read_buffer_bytes(buf).expect("non-null buffer");
+    assert_eq!(read, NON_UTF8, "fetched binary body must be byte-exact");
+}
+
+// The blob path covers the two halves `js_blob_array_buffer` composes:
+// `blob()` stores the body bytes intact, and the buffer seam those bytes
+// flow through resolves them byte-exact. (The FFI itself returns a
+// `*mut Promise`; the promise-resolution machinery is unavailable in the
+// unittest binary, as for every promise-returning fetch FFI — hence the
+// two-halves decomposition rather than an end-to-end call. The end-to-end
+// `blob().arrayBuffer()` chain is exercised by the e2e shell test.)
+#[test]
+fn blob_round_trips_non_utf8_bytes() {
+    let blob_id = store_blob(BlobData {
+        bytes: NON_UTF8.to_vec(),
+        content_type: "image/png".to_string(),
+    });
+    // The stored blob keeps the exact bytes that `js_blob_array_buffer`
+    // reads and hands to `body_to_buffer_value`.
+    let stored = BLOB_HANDLES
+        .lock()
+        .unwrap()
+        .get(&blob_id)
+        .map(|b| b.bytes.clone())
+        .expect("blob stored");
+    assert_eq!(stored, NON_UTF8);
+    // …and the seam resolves those bytes as a byte-exact Buffer.
+    let value = body_to_buffer_value(&stored);
+    assert!(value.is_pointer());
+    let read = perry_ffi::read_buffer_bytes(value.as_pointer::<perry_ffi::BufferHeader>())
+        .expect("non-null buffer");
+    assert_eq!(read, NON_UTF8);
+}
+
+// Output-preserving regression guard for the `Vec<u8>` → `Bytes` migration
+// (NOT a fail-before-the-bug test — it guards part 1 of the change, the
+// decode fold + zero-copy body, against future regression). A valid-UTF-8
+// body must still decode (via `from_utf8_lossy`, as `text()`/`json()` do)
+// to the identical string, and the `Bytes` body must preserve arbitrary
+// bytes verbatim across `store_response` + the refcount clone.
+#[test]
+fn text_decode_preserves_utf8_and_bytes_round_trip() {
+    let utf8 = "héllo, wörld — 𝓊𝓃𝒾𝒸ℴ𝒹ℯ";
+    let id = store_with_body(Bytes::from(utf8.as_bytes().to_vec()));
+    let stored = FETCH_RESPONSES
+        .lock()
+        .unwrap()
+        .get(&id)
+        .map(|r| r.body.clone())
+        .expect("response stored");
+    // What `text()`/`json()` now produce: a lossless decode of valid UTF-8.
+    assert_eq!(String::from_utf8_lossy(&stored), utf8);
+    // The `Bytes` body holds arbitrary bytes verbatim (no copy on clone).
+    let bin_id = store_with_body(Bytes::from(NON_UTF8.to_vec()));
+    let bin = FETCH_RESPONSES
+        .lock()
+        .unwrap()
+        .get(&bin_id)
+        .map(|r| r.body.clone())
+        .expect("response stored");
+    assert_eq!(&bin[..], NON_UTF8);
+}

--- a/tests/test_fetch_binary_body_round_trip.sh
+++ b/tests/test_fetch_binary_body_round_trip.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Regression: a fetch/Blob/Response body that is NOT valid UTF-8 (e.g. a
+# fetched PNG/protobuf) must survive `arrayBuffer()` byte-exact, and a
+# UTF-8 body must still decode losslessly through `text()`/`json()`.
+#
+# Bug: `js_response_array_buffer` / `js_blob_array_buffer` round-tripped the
+# body through `from_utf8_unchecked` → String → a STRING_TAG JsValue. That
+# was UB on non-UTF-8 bytes, and the JS `new Uint8Array(value)` dispatch keys
+# on the Buffer POINTER_TAG — a STRING_TAG value reads as an EMPTY buffer. So
+# `new Uint8Array(await res.arrayBuffer())` came back empty / corrupted for
+# any binary payload.
+#
+# Fix: resolve a real Buffer (`alloc_buffer` + POINTER_TAG), byte-exact —
+# the same shape `bytes()` already used.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PERRY="$SCRIPT_DIR/../target/release/perry"
+[ ! -f "$PERRY" ] && PERRY="$SCRIPT_DIR/../target/debug/perry"
+if [ ! -f "$PERRY" ]; then
+  echo "SKIP: perry binary not found (build with cargo build --release)"
+  exit 0
+fi
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+cat > "$TMPDIR/main.ts" << 'EOF'
+async function main() {
+  // Non-UTF-8 bytes: 0xFF 0xFE are invalid UTF-8, 0x00 is an embedded NUL.
+  const bin = new Uint8Array([0xFF, 0xFE, 0x00, 0x80, 0x50, 0x4E, 0x47]);
+
+  // Blob.arrayBuffer() — binary must round-trip byte-exact.
+  const ab = await new Blob([bin]).arrayBuffer();
+  console.log("blob.arrayBuffer:", Array.from(new Uint8Array(ab)).join(","));
+
+  // Response.text() — UTF-8 body (incl. a multi-byte char) preserved.
+  const res = new Response('{"msg":"héllo","n":42}');
+  console.log("res.text:", await res.text());
+
+  // Response.json() — body parsed to an object.
+  const j = await new Response('{"msg":"héllo","n":42}').json();
+  console.log("res.json:", (j as any).msg, (j as any).n);
+
+  // Response.arrayBuffer() — bytes of a (UTF-8) body, byte-exact.
+  const ab2 = await new Response("ABC").arrayBuffer();
+  console.log("res.arrayBuffer:", Array.from(new Uint8Array(ab2)).join(","));
+}
+main().catch((e) => console.log("ERR:", e?.message ?? e));
+EOF
+
+cd "$TMPDIR"
+"$PERRY" compile main.ts --output test_bin >/dev/null 2>&1
+RUN_OUTPUT=$(./test_bin 2>&1)
+
+EXPECTED="blob.arrayBuffer: 255,254,0,128,80,78,71
+res.text: {\"msg\":\"héllo\",\"n\":42}
+res.json: héllo 42
+res.arrayBuffer: 65,66,67"
+
+if [ "$RUN_OUTPUT" = "$EXPECTED" ]; then
+  echo "PASS"
+  exit 0
+fi
+
+echo "FAIL: fetch/Blob binary body round-trip regressed"
+echo "Expected:"
+echo "$EXPECTED"
+echo ""
+echo "Got:"
+echo "$RUN_OUTPUT"
+exit 1


### PR DESCRIPTION
Perf-quest follow-up bundling the deferred fetch client-body perf win with two correctness fixes, all in `crates/perry-ext-fetch`.

## Perf: zero-copy response body

`FetchResponse.body` is now `bytes::Bytes` instead of `Vec<u8>`. The body is filled once from reqwest's `response.bytes()` and then read by several accessors (`text`/`json`/`arrayBuffer`/`bytes`/`blob`/`formData`), each of which cloned the whole payload to release the registry lock before allocating into the arena — so a single `res.json()` / `res.text()` copied the body roughly four times. With `Bytes` that per-accessor clone is an O(1) refcount bump (no data copy), and the `text`/`json` UTF-8 decode is folded into one arena write (`from_utf8_lossy` borrows when the body is already valid UTF-8). Net: ~4× body copy → ~1× on the hot read paths. Output is unchanged for `text()`/`json()`.

## Fix: arrayBuffer non-UTF-8 corruption

`js_response_array_buffer` and `js_blob_array_buffer` round-tripped the body through `from_utf8_unchecked` into a `String` and resolved a `STRING_TAG` value. That is UB on non-UTF-8 bytes (a fetched PNG/protobuf), and the JS `new Uint8Array(value)` dispatch keys on the Buffer `POINTER_TAG` — so a string-tagged value was read as an *empty* buffer. Both paths now resolve a real Buffer via `alloc_buffer` (byte-exact), matching the existing `bytes()` accessor.

## Cleanup

Removes three debug `eprintln!` calls, including one in `js_fetch_response_status` that ran on every `.status` read and collected the response-id map under the lock.

## Tests

- **Unit (fail-before/pass-after):** the byte-exact buffer resolve is a real guard — reverting it to the old string path makes the test fail with "must resolve a Buffer (POINTER_TAG), not a string". Plus a `text()`/`json()` output-preservation guard for the `Bytes` migration. (The existing inline test module moved to `src/tests.rs` to keep `lib.rs` under the 2,000-line file-size gate; the move is verbatim.)
- **e2e shell test** (`tests/test_fetch_binary_body_round_trip.sh`) exercising the full real-JS chain: `new Uint8Array(await new Blob([bin]).arrayBuffer())` byte-exact for non-UTF-8 bytes, `Response.text()`/`Response.json()` preserved, `Response.arrayBuffer()` byte-exact.

Gates green locally: `cargo test -p perry-ext-fetch`, `cargo fmt --check`, `scripts/check_file_size.sh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Binary response and blob data now round-trip more reliably through `arrayBuffer()` and `bytes()`.
  * `text()` and `json()` continue to work correctly for valid UTF-8 content.

* **Bug Fixes**
  * Improved handling of non-UTF-8 bodies so raw bytes are preserved instead of being altered during reads.
  * Reduced unnecessary data copying when accessing response bodies.

* **Tests**
  * Added regression coverage for binary body round-tripping and UTF-8 decoding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->