### PR TITLE
fix(hir): register captures for class EXPRESSIONS with heritage (shared-template path)

### DIFF
--- a/crates/perry-hir/src/lower/lower_expr/arm_class.rs
+++ b/crates/perry-hir/src/lower/lower_expr/arm_class.rs
@@ -196,6 +196,19 @@ pub(crate) fn lower_class_expr(
     // `Cannot read properties of undefined (reading 'default')`. Emitting the
     // snapshot here mirrors the class-decl path's `RegisterClassCaptures` and
     // closes the gap for every heritage/module-top capturing class expression.
+    //
+    // Known limitation (matches the class-DECLARATION path): the snapshot is
+    // keyed by `synthetic_name`, which is stable per source location, so it
+    // occupies a single `CLASS_CAPTURE_VALUES` slot. A heritage class
+    // expression re-evaluated with different captures (e.g. inside a function
+    // called more than once) overwrites the previous snapshot; a `ClassRef`
+    // from an earlier evaluation that is *constructed* after a later evaluation
+    // would observe the newer capture values. The shared-template `ClassRef`
+    // mechanism is name-keyed by design, so this is not made per-evaluation
+    // here — the captured-at-construction `ClassExprFresh` path above is the
+    // per-instance route. In practice the snapshot is written immediately
+    // before the class is registered/constructed, so the common case (build
+    // then construct, including the p-queue `PQueue` repro) is unaffected.
     if !captured_args.is_empty() {
         seq.push(Expr::RegisterClassCaptures {
             class_name: synthetic_name.clone(),

--- a/crates/perry-hir/src/lower/lower_expr/arm_class.rs
+++ b/crates/perry-hir/src/lower/lower_expr/arm_class.rs
@@ -178,6 +178,30 @@ pub(crate) fn lower_class_expr(
             parent_expr: p,
         });
     }
+    // #5437 (p-queue PQueue undefined-`.default` capture): a class EXPRESSION
+    // that captures enclosing-scope locals AND reaches the shared-template
+    // (`ClassRef`) path — i.e. one with heritage (`class extends t { … uses
+    // n … }`) or evaluated at module top — must snapshot its decl-site capture
+    // values, exactly like the class-DECLARATION path does
+    // (`lower_decl/body_stmt.rs`). The `ClassExprFresh` path above carries
+    // captures via `captured_args` at construction, but the shared-template
+    // path produces a stable `ClassRef` constructed later through the runtime
+    // construct path (`construct_registered_class_ref` →
+    // `replay_registered_class_constructor`), which fills the synthesized
+    // `__perry_cap_*` ctor params SOLELY from `CLASS_CAPTURE_VALUES`. Without a
+    // registered snapshot those params arrive `undefined`. The Next.js route
+    // bundle's p-queue `PQueue` (`c.default = class extends t { … queueClass:
+    // n.default … }`, instantiated via `new (tH())()` → the runtime construct
+    // path) read its captured module ref `n` (idx 1) as `undefined` and threw
+    // `Cannot read properties of undefined (reading 'default')`. Emitting the
+    // snapshot here mirrors the class-decl path's `RegisterClassCaptures` and
+    // closes the gap for every heritage/module-top capturing class expression.
+    if !captured_args.is_empty() {
+        seq.push(Expr::RegisterClassCaptures {
+            class_name: synthetic_name.clone(),
+            captures: captured_args.clone(),
+        });
+    }
     seq.extend(computed_member_registrations);
     for (k, v) in static_symbol_registrations {
         seq.push(Expr::RegisterClassStaticSymbol {

--- a/crates/perry/tests/issue_5437_class_expr_heritage_capture.rs
+++ b/crates/perry/tests/issue_5437_class_expr_heritage_capture.rs
@@ -1,0 +1,131 @@
+//! Regression test for #5437 (Next.js Wall #6, p-queue `PQueue` undefined
+//! `.default` capture): a class EXPRESSION that EXTENDS a captured local and
+//! reads a property off ANOTHER captured local in its constructor — assigned
+//! to a member (`c.default = class extends Base { … dep.default … }`) and
+//! constructed through the runtime dynamic-construct path (`new (getCls())()`,
+//! where the class name is not statically known) — read the captured module
+//! ref as `undefined` and threw
+//! `TypeError: Cannot read properties of undefined (reading 'default')`.
+//!
+//! Root: a class EXPRESSION with heritage (or evaluated at module top) takes
+//! the shared-template (`ClassRef`) lowering path in `lower_class_expr`, which
+//! — unlike the class-DECLARATION path — never emitted a `RegisterClassCaptures`
+//! decl-site snapshot. The construct then routes through the runtime
+//! `construct_registered_class_ref` → `replay_registered_class_constructor`,
+//! which fills the synthesized `__perry_cap_*` ctor params SOLELY from the
+//! `CLASS_CAPTURE_VALUES` snapshot. With no snapshot registered, those params
+//! arrive `undefined`, so the captured module ref `dep` (and Next.js bundled
+//! p-queue's `n.default`) read `undefined`.
+//!
+//! Fix: emit `RegisterClassCaptures` in the shared-template path of
+//! `lower_class_expr` whenever the class expression captures enclosing-scope
+//! locals, mirroring the class-declaration path. The snapshot then exists and
+//! `replay_registered_class_constructor` fills the cap params correctly for
+//! every construction path, including the runtime dynamic one.
+//!
+//! Mirrors the minimal repro that pinned the wall: the interop default-getter
+//! (`() => mod.default`) returning the class + construction from inside another
+//! class's constructor via `new (tH())()` are the discriminating ingredients
+//! (a bare `new (mod.default)()` at top level already worked).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn class_expr_with_heritage_capture_via_dynamic_construct_resolves() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.js");
+    let output = dir.path().join("main_bin");
+    std::fs::write(
+        &entry,
+        r#"
+"use strict";
+// Faithful to Next.js's bundled p-queue: a nested IIFE "webpack module" with
+// module-scope `let` bindings assigned from an inner require, then a class
+// EXPRESSION assigned to `c.default` that EXTENDS a captured `Base` and reads
+// `.default` off a captured `dep` in its constructor.
+const pqMod = (() => {
+  let Base, dep;
+  var inner = {
+    993: (m) => { m.exports = class { ping() { return "base"; } }; },
+    821: (m) => { m.exports = { default: "DEP_DEFAULT" }; },
+  };
+  const cache = {};
+  function req(id) {
+    if (cache[id]) return cache[id].exports;
+    const m = (cache[id] = { exports: {} });
+    inner[id](m);
+    return m.exports;
+  }
+  Base = req(993);
+  dep = req(821);
+  const c = {};
+  Object.defineProperty(c, "__esModule", { value: true });
+  c.default = class extends Base {
+    constructor(opts) {
+      super();
+      this.q = Object.assign({ queueClass: dep.default }, opts).queueClass;
+    }
+    who() { return this.q; }
+  };
+  return c;
+})();
+
+// webpack interop default-getter (`__webpack_require__.n`): returns a function
+// that yields module.default.
+function interopDefault(mod) {
+  return mod && mod.__esModule ? () => mod.default : () => mod;
+}
+const tH = interopDefault(pqMod);
+
+// Another class that constructs the captured class from INSIDE its ctor, via
+// the runtime dynamic-construct path `new (tH())()` (class name not static).
+class Consumer {
+  constructor() {
+    this.cb = new (tH())();
+  }
+  result() {
+    return this.cb.who() + "|" + this.cb.ping();
+  }
+}
+const inst = new Consumer();
+console.log("r=" + inst.result());
+"#,
+    )
+    .expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert_eq!(
+        stdout, "r=DEP_DEFAULT|base\n",
+        "a class-expression with heritage that captures enclosing locals and is \
+         constructed via the runtime dynamic path must resolve its captures from \
+         the decl-site snapshot (not undefined) — #5437 p-queue PQueue Wall #6"
+    );
+}


### PR DESCRIPTION
## What
A class **expression** with heritage (`x = class extends Base {…}`) or at module scope takes the shared-template (`ClassRef`) lowering path in `lower_class_expr` (`arm_class.rs`), which — unlike the class-**declaration** path — **never emitted `RegisterClassCaptures`**. So when such a class captures enclosing locals, the runtime construct (`replay_registered_class_constructor`) fills the `__perry_cap_*` params solely from the (absent) snapshot → captures are `undefined`.

Found via Next.js (#5437): the bundled p-queue `PQueue` (`c.default = class extends … {}`) captures a module ref; its ctor read `n.default` off the undefined capture → `TypeError: Cannot read properties of undefined (reading 'default')` → 500 on API routes. **With this fix, `/api/hello` GET+POST go 500 → 200.** General fix — covers every heritage/module-top capturing class expression, not just PQueue.

## Fix
Emit `RegisterClassCaptures` in the shared-template path when the class expression captures enclosing locals, mirroring the class-declaration path (`arm_class.rs`, HIR-only).

## Validation
- Regression test `issue_5437_class_expr_heritage_capture`: fails on base (`reading 'default'`), passes with fix.
- 1782 tests pass (perry-hir/codegen/runtime/transform); all capture-family tests green.
- Bundle: API routes 500→200; static byte-identical. (Remaining: API body-streaming + dynamic-page req.url — separate walls, tracked.)

Refs #5437.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed class expressions with captured outer-scope values so they are preserved correctly during runtime/dynamic construction, including scenarios involving class heritage.
  * Prevented captured class/module-related references from being replayed as `undefined`.

* **Tests**
  * Added a regression test for the previously failing case where a dynamically constructed class expression captures inherited and outer values correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->