### PR TITLE
refactor(http-server): extract in-flight request tracking into server/in_flight.rs

### DIFF
--- a/crates/perry-ext-http-server/src/server.rs
+++ b/crates/perry-ext-http-server/src/server.rs
@@ -10,7 +10,7 @@ use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::Poll;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use lazy_static::lazy_static;
 
@@ -31,8 +31,8 @@ use perry_ffi::{
 
 use crate::ensure_gc_scanner_registered;
 use crate::request::{
-    alloc_incoming_message, close_incoming_message, emit_no_arg_to_listeners,
-    handle_to_pointer_f64, with_implicit_this, IncomingMessage,
+    alloc_incoming_message, emit_no_arg_to_listeners, handle_to_pointer_f64, with_implicit_this,
+    IncomingMessage,
 };
 use crate::response::{
     alloc_server_response_for_request, HyperResponseShape, ResponseBody, ServerResponse,
@@ -41,6 +41,17 @@ use crate::types::{
     extract_host, extract_port, js_promise_run_microtasks, js_promise_state, js_value_is_closure,
     jsvalue_to_owned_string, read_string_header, Promise, POINTER_TAG, PTR_MASK, TAG_NULL,
     TAG_UNDEFINED,
+};
+
+// #4728 — in-flight (async-handler) request tracking + the reaper that
+// finalizes parked requests. Extracted to keep this file under the 2000-line
+// file-size limit; the dispatch paths here (`process_pending`,
+// `js_node_http_server_close_all_connections`, the pump) call into it.
+mod in_flight;
+use in_flight::IN_FLIGHT;
+pub(crate) use in_flight::{
+    finalize_or_park_request, finalize_request_handles_deferred, has_in_flight_requests,
+    reap_in_flight_requests, response_writable_ended,
 };
 
 /// Apply a server's per-connection `noDelay` (Node's `socket.setNoDelay`
@@ -1390,206 +1401,6 @@ pub extern "C" fn js_node_http_server_has_active() -> i32 {
         active = 1;
     }
     active
-}
-
-// ============================================================================
-// #4728 — in-flight (async-handler) request tracking.
-//
-// A `(req, res) => { … }` handler that finishes the response on a *later*
-// event-loop tick — an outbound `fetch()`, a `setTimeout`, any `await`
-// chain that calls `res.end()` from a microtask/timer/tokio resolution —
-// returns to `process_pending` before `res.end()` has run. Pre-#4728,
-// `process_pending` then synthesized a default empty 200 and freed the
-// per-request handles immediately, so the real `res.end(...)` later fired
-// on a dropped handle (no-op) and the client saw an empty/closed reply.
-//
-// Fix: when the handler returns without ending the response, park the
-// request here instead of synthesizing+freeing. The reaper runs each pump
-// tick (the codegen-emitted main loop keeps ticking while the server is a
-// live handle, draining timers / fetch resolutions / microtasks), and
-// finalizes a parked request once `res.end()` has flushed the real
-// response — or, as a safety net mirroring Node's `requestTimeout`,
-// synthesizes the default response and frees the handles if the handler
-// never responds within the grace window so a buggy handler can't pin a
-// hyper connection (and its request handles) forever.
-// ============================================================================
-
-/// A request whose handler returned before finishing the response.
-struct InFlightRequest {
-    /// Owning server — lets `closeAllConnections()` drop parked requests
-    /// whose connection it just destroyed (#4905).
-    server_handle: i64,
-    request_handle: i64,
-    response_handle: i64,
-    /// Mirrors `HttpPendingRequest::skip_default_response`: when true the
-    /// response is driven elsewhere (e.g. an upgraded/stream path) so the
-    /// reaper must not synthesize a default on timeout.
-    skip_default_response: bool,
-    /// Grace deadline. Past this, synthesize the default response (unless
-    /// `skip_default_response`) and free the handles regardless.
-    deadline: Instant,
-}
-
-static IN_FLIGHT: Mutex<Vec<InFlightRequest>> = Mutex::new(Vec::new());
-
-/// True iff `res.end()` has flushed the response (or the handle is already
-/// gone). A missing handle reads as "done" so a stray entry can't wedge
-/// the reaper.
-fn response_writable_ended(response_handle: i64) -> bool {
-    get_handle::<ServerResponse>(response_handle)
-        .map(|sr| sr.writable_ended)
-        .unwrap_or(true)
-}
-
-/// Free the per-request request + response handles. Mirrors the tail of
-/// the synchronous-handler path in `process_pending`. The response is ended
-/// (or about to be, via synthesize), so its id takes the one-tick fast path.
-fn finalize_request_handles(request_handle: i64, response_handle: i64) {
-    finalize_request_handles_deferred(request_handle, response_handle, None);
-}
-
-/// Free the per-request handles. `recycle_deadline` is `Some` only when the
-/// response is being finalized WITHOUT having ended (the reaper's
-/// peer-disconnect / server-force-close paths) — its id is then held in the
-/// deadline-gated quarantine through the request's grace window so a
-/// long-suspended handler that resumes and writes hits an empty slot rather
-/// than a recycled response (see `perry_ffi::drop_handle_until`). `None` is the
-/// ended / synchronous case. The request id always takes the one-tick path —
-/// `IncomingMessage` has no late-write surface, and it is closed here first.
-fn finalize_request_handles_deferred(
-    request_handle: i64,
-    response_handle: i64,
-    recycle_deadline: Option<Instant>,
-) {
-    close_incoming_message(request_handle);
-    perry_ffi::drop_handle(request_handle);
-    match recycle_deadline {
-        Some(deadline) => perry_ffi::drop_handle_until(response_handle, deadline),
-        None => perry_ffi::drop_handle(response_handle),
-    };
-}
-
-/// True iff any request is parked awaiting an async handler — keeps the
-/// server's handle "active" so the main loop doesn't exit before the
-/// pending response is flushed.
-fn has_in_flight_requests() -> bool {
-    IN_FLIGHT.lock().map(|g| !g.is_empty()).unwrap_or(false)
-}
-
-/// Finalize parked requests whose handler has now called `res.end()` (the
-/// common case — fetch/timer/await resolved on a later tick), or whose
-/// grace deadline has elapsed (a handler that never responds). Called each
-/// pump tick. #4728.
-fn reap_in_flight_requests() {
-    // (request_handle, response_handle, needs_synthesize, recycle_deadline)
-    let mut to_finalize: Vec<(i64, i64, bool, Option<Instant>)> = Vec::new();
-    let mut drain_listeners: Vec<Vec<i64>> = Vec::new();
-    {
-        let mut guard = match IN_FLIGHT.lock() {
-            Ok(g) => g,
-            Err(_) => return,
-        };
-        if guard.is_empty() {
-            return;
-        }
-        let now = Instant::now();
-        guard.retain(|e| {
-            let ended = response_writable_ended(e.response_handle);
-            if !ended {
-                // Streaming backpressure cleared — fire `'drain'` (outside
-                // the lock) so `res.on('drain')` producer loops resume.
-                let ls = crate::response::take_drain_listeners_if_ready(e.response_handle);
-                if !ls.is_empty() {
-                    drain_listeners.push(ls);
-                }
-            }
-            // #4905: the per-request oneshot receiver died with its
-            // connection task (client disconnected / closeAllConnections)
-            // — the response can never be flushed, so don't pin the event
-            // loop for the rest of the grace window. A streaming response
-            // whose body receiver dropped is the same edge.
-            let peer_gone = get_handle::<ServerResponse>(e.response_handle)
-                .and_then(|sr| sr.response_tx.as_ref())
-                .map(|tx| tx.is_closed())
-                .unwrap_or(false)
-                || crate::response::stream_receiver_gone(e.response_handle);
-            let expired = now >= e.deadline;
-            if ended || expired || peer_gone {
-                // Only synthesize when we're giving up on a handler
-                // that never ended the response — not when it ended
-                // it itself, never for skip-default paths, and never
-                // when the peer is gone (nothing to deliver to).
-                let needs_synth = !ended && !e.skip_default_response && !peer_gone;
-                // If the response will NOT be ended after finalize (it wasn't
-                // ended and we're not synthesizing it to ended — the peer-gone
-                // and not-ended-skip-default paths), its `writable_ended` stays
-                // unset, so a handler suspended on a slow `await` could resume
-                // later and write through the bare id. Defer recycling that id
-                // until the request's grace deadline so the late write lands on
-                // an empty slot for the whole window, not a recycled response.
-                let recycle_deadline = if ended || needs_synth {
-                    None
-                } else {
-                    Some(e.deadline)
-                };
-                to_finalize.push((
-                    e.request_handle,
-                    e.response_handle,
-                    needs_synth,
-                    recycle_deadline,
-                ));
-                false
-            } else {
-                true
-            }
-        });
-    }
-    for ls in drain_listeners {
-        crate::request::emit_no_arg_to_listeners(&ls);
-    }
-    // Finalize outside the lock — `synthesize_default_response_if_needed`
-    // and `drop_handle` don't touch `IN_FLIGHT`, but keeping them off the
-    // lock avoids any future re-entrancy surprise.
-    for (req, res, needs_synth, recycle_deadline) in to_finalize {
-        if needs_synth {
-            synthesize_default_response_if_needed(res);
-        }
-        finalize_request_handles_deferred(req, res, recycle_deadline);
-    }
-}
-
-/// Finalize a just-dispatched request, or park it for the reaper if its
-/// handler returned before finishing the response (an async handler that
-/// will call `res.end()` on a later tick). Shared by the HTTP/1 and HTTPS
-/// dispatch paths. #4728.
-pub(crate) fn finalize_or_park_request(pending: &HttpPendingRequest) {
-    if response_writable_ended(pending.response_handle) {
-        finalize_request_handles(pending.request_handle, pending.response_handle);
-        return;
-    }
-    // Grace window mirrors Node's `requestTimeout` (default 300s; `0` =
-    // disabled, so fall back to the default rather than parking forever).
-    let grace_ms = get_handle::<HttpServer>(pending.server_handle)
-        .map(|s| s.request_timeout)
-        .filter(|t| *t > 0.0)
-        .unwrap_or(300_000.0);
-    let deadline = Instant::now() + Duration::from_millis(grace_ms as u64);
-    if let Ok(mut guard) = IN_FLIGHT.lock() {
-        guard.push(InFlightRequest {
-            server_handle: pending.server_handle,
-            request_handle: pending.request_handle,
-            response_handle: pending.response_handle,
-            skip_default_response: pending.skip_default_response,
-            deadline,
-        });
-    } else {
-        // Lock poisoned — fall back to the old immediate behavior so we
-        // never leak the handles.
-        if !pending.skip_default_response {
-            synthesize_default_response_if_needed(pending.response_handle);
-        }
-        finalize_request_handles(pending.request_handle, pending.response_handle);
-    }
 }
 
 /// Drain pending requests + upgrades from every registered server,

--- a/crates/perry-ext-http-server/src/server/in_flight.rs
+++ b/crates/perry-ext-http-server/src/server/in_flight.rs
@@ -1,0 +1,208 @@
+// ============================================================================
+// #4728 — in-flight (async-handler) request tracking.
+//
+// A `(req, res) => { … }` handler that finishes the response on a *later*
+// event-loop tick — an outbound `fetch()`, a `setTimeout`, any `await`
+// chain that calls `res.end()` from a microtask/timer/tokio resolution —
+// returns to `process_pending` before `res.end()` has run. Pre-#4728,
+// `process_pending` then synthesized a default empty 200 and freed the
+// per-request handles immediately, so the real `res.end(...)` later fired
+// on a dropped handle (no-op) and the client saw an empty/closed reply.
+//
+// Fix: when the handler returns without ending the response, park the
+// request here instead of synthesizing+freeing. The reaper runs each pump
+// tick (the codegen-emitted main loop keeps ticking while the server is a
+// live handle, draining timers / fetch resolutions / microtasks), and
+// finalizes a parked request once `res.end()` has flushed the real
+// response — or, as a safety net mirroring Node's `requestTimeout`,
+// synthesizes the default response and frees the handles if the handler
+// never responds within the grace window so a buggy handler can't pin a
+// hyper connection (and its request handles) forever.
+// ============================================================================
+
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use perry_ffi::get_handle;
+
+use crate::request::close_incoming_message;
+use crate::response::ServerResponse;
+use crate::server::{synthesize_default_response_if_needed, HttpPendingRequest, HttpServer};
+
+/// A request whose handler returned before finishing the response.
+pub(crate) struct InFlightRequest {
+    /// Owning server — lets `closeAllConnections()` drop parked requests
+    /// whose connection it just destroyed (#4905).
+    pub(crate) server_handle: i64,
+    pub(crate) request_handle: i64,
+    pub(crate) response_handle: i64,
+    /// Mirrors `HttpPendingRequest::skip_default_response`: when true the
+    /// response is driven elsewhere (e.g. an upgraded/stream path) so the
+    /// reaper must not synthesize a default on timeout.
+    skip_default_response: bool,
+    /// Grace deadline. Past this, synthesize the default response (unless
+    /// `skip_default_response`) and free the handles regardless.
+    pub(crate) deadline: Instant,
+}
+
+pub(crate) static IN_FLIGHT: Mutex<Vec<InFlightRequest>> = Mutex::new(Vec::new());
+
+/// True iff `res.end()` has flushed the response (or the handle is already
+/// gone). A missing handle reads as "done" so a stray entry can't wedge
+/// the reaper.
+pub(crate) fn response_writable_ended(response_handle: i64) -> bool {
+    get_handle::<ServerResponse>(response_handle)
+        .map(|sr| sr.writable_ended)
+        .unwrap_or(true)
+}
+
+/// Free the per-request request + response handles. Mirrors the tail of
+/// the synchronous-handler path in `process_pending`. The response is ended
+/// (or about to be, via synthesize), so its id takes the one-tick fast path.
+fn finalize_request_handles(request_handle: i64, response_handle: i64) {
+    finalize_request_handles_deferred(request_handle, response_handle, None);
+}
+
+/// Free the per-request handles. `recycle_deadline` is `Some` only when the
+/// response is being finalized WITHOUT having ended (the reaper's
+/// peer-disconnect / server-force-close paths) — its id is then held in the
+/// deadline-gated quarantine through the request's grace window so a
+/// long-suspended handler that resumes and writes hits an empty slot rather
+/// than a recycled response (see `perry_ffi::drop_handle_until`). `None` is the
+/// ended / synchronous case. The request id always takes the one-tick path —
+/// `IncomingMessage` has no late-write surface, and it is closed here first.
+pub(crate) fn finalize_request_handles_deferred(
+    request_handle: i64,
+    response_handle: i64,
+    recycle_deadline: Option<Instant>,
+) {
+    close_incoming_message(request_handle);
+    perry_ffi::drop_handle(request_handle);
+    match recycle_deadline {
+        Some(deadline) => perry_ffi::drop_handle_until(response_handle, deadline),
+        None => perry_ffi::drop_handle(response_handle),
+    };
+}
+
+/// True iff any request is parked awaiting an async handler — keeps the
+/// server's handle "active" so the main loop doesn't exit before the
+/// pending response is flushed.
+pub(crate) fn has_in_flight_requests() -> bool {
+    IN_FLIGHT.lock().map(|g| !g.is_empty()).unwrap_or(false)
+}
+
+/// Finalize parked requests whose handler has now called `res.end()` (the
+/// common case — fetch/timer/await resolved on a later tick), or whose
+/// grace deadline has elapsed (a handler that never responds). Called each
+/// pump tick. #4728.
+pub(crate) fn reap_in_flight_requests() {
+    // (request_handle, response_handle, needs_synthesize, recycle_deadline)
+    let mut to_finalize: Vec<(i64, i64, bool, Option<Instant>)> = Vec::new();
+    let mut drain_listeners: Vec<Vec<i64>> = Vec::new();
+    {
+        let mut guard = match IN_FLIGHT.lock() {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+        if guard.is_empty() {
+            return;
+        }
+        let now = Instant::now();
+        guard.retain(|e| {
+            let ended = response_writable_ended(e.response_handle);
+            if !ended {
+                // Streaming backpressure cleared — fire `'drain'` (outside
+                // the lock) so `res.on('drain')` producer loops resume.
+                let ls = crate::response::take_drain_listeners_if_ready(e.response_handle);
+                if !ls.is_empty() {
+                    drain_listeners.push(ls);
+                }
+            }
+            // #4905: the per-request oneshot receiver died with its
+            // connection task (client disconnected / closeAllConnections)
+            // — the response can never be flushed, so don't pin the event
+            // loop for the rest of the grace window. A streaming response
+            // whose body receiver dropped is the same edge.
+            let peer_gone = get_handle::<ServerResponse>(e.response_handle)
+                .and_then(|sr| sr.response_tx.as_ref())
+                .map(|tx| tx.is_closed())
+                .unwrap_or(false)
+                || crate::response::stream_receiver_gone(e.response_handle);
+            let expired = now >= e.deadline;
+            if ended || expired || peer_gone {
+                // Only synthesize when we're giving up on a handler
+                // that never ended the response — not when it ended
+                // it itself, never for skip-default paths, and never
+                // when the peer is gone (nothing to deliver to).
+                let needs_synth = !ended && !e.skip_default_response && !peer_gone;
+                // If the response will NOT be ended after finalize (it wasn't
+                // ended and we're not synthesizing it to ended — the peer-gone
+                // and not-ended-skip-default paths), its `writable_ended` stays
+                // unset, so a handler suspended on a slow `await` could resume
+                // later and write through the bare id. Defer recycling that id
+                // until the request's grace deadline so the late write lands on
+                // an empty slot for the whole window, not a recycled response.
+                let recycle_deadline = if ended || needs_synth {
+                    None
+                } else {
+                    Some(e.deadline)
+                };
+                to_finalize.push((
+                    e.request_handle,
+                    e.response_handle,
+                    needs_synth,
+                    recycle_deadline,
+                ));
+                false
+            } else {
+                true
+            }
+        });
+    }
+    for ls in drain_listeners {
+        crate::request::emit_no_arg_to_listeners(&ls);
+    }
+    // Finalize outside the lock — `synthesize_default_response_if_needed`
+    // and `drop_handle` don't touch `IN_FLIGHT`, but keeping them off the
+    // lock avoids any future re-entrancy surprise.
+    for (req, res, needs_synth, recycle_deadline) in to_finalize {
+        if needs_synth {
+            synthesize_default_response_if_needed(res);
+        }
+        finalize_request_handles_deferred(req, res, recycle_deadline);
+    }
+}
+
+/// Finalize a just-dispatched request, or park it for the reaper if its
+/// handler returned before finishing the response (an async handler that
+/// will call `res.end()` on a later tick). Shared by the HTTP/1 and HTTPS
+/// dispatch paths. #4728.
+pub(crate) fn finalize_or_park_request(pending: &HttpPendingRequest) {
+    if response_writable_ended(pending.response_handle) {
+        finalize_request_handles(pending.request_handle, pending.response_handle);
+        return;
+    }
+    // Grace window mirrors Node's `requestTimeout` (default 300s; `0` =
+    // disabled, so fall back to the default rather than parking forever).
+    let grace_ms = get_handle::<HttpServer>(pending.server_handle)
+        .map(|s| s.request_timeout)
+        .filter(|t| *t > 0.0)
+        .unwrap_or(300_000.0);
+    let deadline = Instant::now() + Duration::from_millis(grace_ms as u64);
+    if let Ok(mut guard) = IN_FLIGHT.lock() {
+        guard.push(InFlightRequest {
+            server_handle: pending.server_handle,
+            request_handle: pending.request_handle,
+            response_handle: pending.response_handle,
+            skip_default_response: pending.skip_default_response,
+            deadline,
+        });
+    } else {
+        // Lock poisoned — fall back to the old immediate behavior so we
+        // never leak the handles.
+        if !pending.skip_default_response {
+            synthesize_default_response_if_needed(pending.response_handle);
+        }
+        finalize_request_handles(pending.request_handle, pending.response_handle);
+    }
+}


### PR DESCRIPTION
Extracts the #4728 in-flight request tracking cluster (`InFlightRequest`, `IN_FLIGHT`, and the `response_writable_ended` / `finalize_*` / `*_in_flight_requests` / `finalize_or_park_request` fns) from `server.rs` into a new `server/in_flight.rs` submodule.

`server.rs` was 2025 lines, over the 2000-line `check_file_size.sh` limit. That gate is red on `main`, blocking the lint check for all PRs. This brings it to 1836 lines.

Pure move, no behavior change: bodies are byte-identical apart from `pub(crate)` widening for cross-module refs and the new `use` header. No FFI symbol renamed. Build, 35 tests, fmt, and the file-size gate all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for HTTP requests that finish without explicitly ending the response, reducing premature cleanup and missed responses.
  * Added a grace period so pending requests can complete before being finalized, helping prevent late writes from failing unexpectedly.
  * The server now stays active while unfinished requests are still being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->