### PR TITLE
fix(codegen): #5657 — class extends native builtin must not run the builtin as a parent function

### DIFF
--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1065,5 +1065,6 @@ mod static_method;
 mod string_regex_proc;
 mod super_method;
 mod this_super_call;
+pub(crate) use this_super_call::is_other_builtin_constructor_name;
 mod unary;
 mod url_main;

--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -1677,7 +1677,28 @@ fn lower_new_impl(
         // `expr/this_super_call.rs`: resolve the decl-time-registered parent
         // value and dispatch it on `this` via `js_fetch_or_value_super`, which
         // binds IMPLICIT_THIS to the instance for the duration of the call.
-        if !found_inherited_ctor && class.extends_expr.is_some() {
+        //
+        // #5657: a native BUILTIN base (`class X extends ArrayBuffer / Map /
+        // Promise / %TypedArray% / RegExp / Function / …`) is also captured as
+        // `extends_expr` (a bare `ArrayBuffer` Ident doesn't resolve through
+        // `lookup_class`), but its parent VALUE is a builtin constructor that
+        // rejects being *called* as a plain function — `js_fetch_or_value_super`
+        // would route it through `js_native_call_value`, throwing "X is not a
+        // function" / "Constructor X requires 'new'". Perry can't give a subclass
+        // instance the builtin's internal slots, so `super()` to such a base is a
+        // best-effort no-op (the instance is already allocated with the correct
+        // dynamic-parent prototype chain, so `instanceof` holds). Skip the
+        // dispatch for those names — mirroring the identical guard the explicit
+        // `Expr::SuperCall` arm already applies via `is_other_builtin_constructor_name`
+        // (`expr/this_super_call.rs`). Request/Response/Error are deliberately NOT
+        // in that set: they DO need the dispatch (native fetch-handle attach /
+        // callable error thunk), so they keep running it.
+        let parent_is_uncallable_builtin = class
+            .extends_name
+            .as_deref()
+            .map(crate::expr::is_other_builtin_constructor_name)
+            .unwrap_or(false);
+        if !found_inherited_ctor && class.extends_expr.is_some() && !parent_is_uncallable_builtin {
             if let Some(cid) = ctx.class_ids.get(class_name).copied().filter(|c| *c != 0) {
                 let undef_lit = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
                 let parent_val = ctx.block().call(

--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -1692,7 +1692,12 @@ fn lower_new_impl(
         // `Expr::SuperCall` arm already applies via `is_other_builtin_constructor_name`
         // (`expr/this_super_call.rs`). Request/Response/Error are deliberately NOT
         // in that set: they DO need the dispatch (native fetch-handle attach /
-        // callable error thunk), so they keep running it.
+        // callable error thunk), so they keep running it. This is a fast-path
+        // skip on the textual name; an ALIASED builtin parent (`const AB =
+        // ArrayBuffer; class X extends AB {}`) whose `extends_name` isn't a known
+        // builtin still emits the call, but the runtime backstops it by value —
+        // `js_fetch_or_value_super` no-ops the same builtin set via
+        // `is_uncallable_builtin_super_parent` (perry-runtime, kept in lockstep).
         let parent_is_uncallable_builtin = class
             .extends_name
             .as_deref()

--- a/crates/perry-runtime/src/object/global_this/fetch_globals.rs
+++ b/crates/perry-runtime/src/object/global_this/fetch_globals.rs
@@ -404,6 +404,55 @@ static KEEP_JS_REQUEST_SUBCLASS_INIT: extern "C" fn(f64, f64, f64) -> f64 =
 static KEEP_JS_RESPONSE_SUBCLASS_INIT: extern "C" fn(f64, f64, f64) -> f64 =
     js_response_subclass_init;
 
+/// #5657: native builtin constructors that REJECT being called as a plain
+/// function (`X is not a function` / `Constructor X requires 'new'`). A
+/// `class D extends <one of these> {}` must NOT run the parent as a function in
+/// `super()` — Perry can't give the instance the builtin's internal slots, so
+/// `super()` is a best-effort no-op (the instance is already allocated with the
+/// correct dynamic-parent prototype chain, so `instanceof` holds). This is the
+/// VALUE-based companion to codegen's name-based guard
+/// (`crate::expr::is_other_builtin_constructor_name` in
+/// `perry-codegen/src/expr/this_super_call.rs`); the two lists must stay in
+/// lockstep. Resolving by value (not textual name) also catches aliased parents
+/// — `const AB = ArrayBuffer; class X extends AB {}` — which the name guard
+/// can't see. `Request`/`Response` (native fetch-handle attach) and the `Error`
+/// family (callable error thunk) are deliberately EXCLUDED: they keep their
+/// dispatch.
+fn is_uncallable_builtin_super_parent(name: &str) -> bool {
+    matches!(
+        name,
+        "Map"
+            | "Set"
+            | "WeakMap"
+            | "WeakSet"
+            | "Array"
+            | "ArrayBuffer"
+            | "SharedArrayBuffer"
+            | "DataView"
+            | "Boolean"
+            | "Number"
+            | "String"
+            | "Date"
+            | "RegExp"
+            | "Promise"
+            | "Function"
+            | "BigInt"
+            | "Symbol"
+            | "Object"
+            | "Int8Array"
+            | "Uint8Array"
+            | "Uint8ClampedArray"
+            | "Int16Array"
+            | "Uint16Array"
+            | "Int32Array"
+            | "Uint32Array"
+            | "Float32Array"
+            | "Float64Array"
+            | "BigInt64Array"
+            | "BigUint64Array"
+    )
+}
+
 /// `super(...)` for `class X extends <runtime-value constructor>` where the
 /// parent expression is an alias of the global `Request`/`Response` constructor
 /// — e.g. `@hono/node-server`'s `class Request extends GlobalRequest` with
@@ -442,6 +491,15 @@ pub unsafe extern "C" fn js_fetch_or_value_super(
                 _ => None,
             }
         });
+    // #5657: a native builtin base that can't be called as a function (incl.
+    // ALIASED parents — `const AB = ArrayBuffer; class X extends AB {}` — which
+    // the codegen name guard can't see). No-op rather than throwing
+    // "X is not a function" / "Constructor X requires 'new'".
+    if let Some(name) = kind {
+        if is_uncallable_builtin_super_parent(name) {
+            return undef;
+        }
+    }
     match kind {
         Some("Request") | Some("Response") => {
             let arg0 = if args_len >= 1 && !args_ptr.is_null() {


### PR DESCRIPTION
Fixes #5657.

## Regression

The 2026-06-25 re-sweep flagged **23 `subclass-builtins` test262 cases newly broken** vs the prior sweep — every `class extends <native builtin>` under both `language/statements/class` and `language/expressions/class`, plus `built-ins/ArrayBuffer/isView/arg-is-dataview-subclass-instance`:

```
subclass-ArrayBuffer  TypeError: ArrayBuffer is not a function
subclass-Map          TypeError: Constructor Map requires 'new'
subclass-Promise      TypeError: Promise is not a function
subclass-BigInt64Array TypeError: Constructor %TypedArray% requires 'new'
…
```

## Root cause

The window pointed at **#5613** (`6de00e8f5`). That commit added a branch in the inline-`new` lowering: for a no-own-ctor class with a dynamic parent (`extends_expr`), resolve the decl-time-registered parent value and dispatch it on `this` via `js_fetch_or_value_super`, so a function-value base (zod 4's `$constructor`) runs its body.

But `class X extends ArrayBuffer / Map / Promise / %TypedArray% / RegExp / Function / …` is **also** captured as `extends_expr` — a bare builtin Ident doesn't resolve through `lookup_class`. Its parent value is a builtin constructor that rejects being *called* as a plain function, so `js_fetch_or_value_super` → `js_native_call_value` threw.

## Fix

Gate the inline-`new` dynamic-parent super on `!is_other_builtin_constructor_name(extends_name)`, mirroring the **identical guard the explicit `Expr::SuperCall` arm already applies** (`expr/this_super_call.rs`). Perry can't give a subclass instance a builtin's internal slots, so `super()` to such a base is a best-effort no-op; the instance is already allocated with the correct dynamic-parent prototype chain, so `instanceof` (and `ArrayBuffer.isView`, which walks that chain) hold.

`Request`/`Response`/`Error` are deliberately **not** in that set — they need the dispatch (native fetch-handle attach / callable error thunk) — so they keep running it, and the #5613 function-value-parent path is untouched.

## Verification

A repro covering all 11 listed builtins, an `Error` subclass, the #5613 dynamic-function parent, and `ArrayBuffer.isView` on a `DataView` subclass — all pass:

```
PASS ArrayBuffer / DataView / Function / Promise / RegExp / Map / Set
PASS WeakMap / WeakSet / BigInt64Array / BigUint64Array
PASS Error-subclass
PASS dynamic-fn-parent(#5613)
isView: true   instanceof DataView: true
```

`perry-codegen` 128/128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for `new` calls that extend native built-in constructors, avoiding an invalid `super(...)` fallback when the parent can’t be called.
  * Added a safe no-op behavior for `super(...)` when the resolved parent matches specific uncallable native built-in constructors.
  * Ensured the uncallable-constructor check is applied consistently across related `new`/`super` resolution paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->