### PR TITLE
fix(codegen): any-typed startsWith/endsWith/lastIndexOf must dynamic-dispatch, not the static String builtin

### DIFF
--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -132,9 +132,19 @@ pub fn try_lower_property_get_method_call(
             // through routes both to `js_native_call_method`, which
             // dispatches on the runtime type and handles string + array
             // (with content-aware element comparison). Refs #1341.
-            // startsWith / endsWith only exist on String — both 1-arg
-            // and 2-arg (searchString, position) forms route here.
-            "startsWith" | "endsWith" if args.len() == 1 || args.len() == 2 => true,
+            // startsWith / endsWith are NOT string-forced here: an Any-typed
+            // receiver may be a user/library object with its OWN same-named
+            // method that returns something other than the String builtin's
+            // boolean — e.g. Zod's `z.string().startsWith("./")` returns a
+            // refined ZodString schema, not a boolean. Forcing the static
+            // string path made `.startsWith()`/`.endsWith()` return a boolean,
+            // so a chained `.describe()`/`.optional()` threw
+            // `(boolean).describe is not a function` (broke the bundled-CLI TUI
+            // schema init). Falling through routes to `js_native_call_method`,
+            // which dispatches on the runtime type and still services a genuine
+            // Any-typed string receiver via its `jsval.is_string()` arm (the
+            // runtime grew full string-method arms in #421/#514). Refs #1341
+            // (the same fix already applied to indexOf/includes above).
             // `normalize` is NOT force-routed to the string path for Any-typed
             // receivers at any arity. User classes commonly define a 1-arg
             // `normalize(pathname)` method (Next.js route normalizers:
@@ -146,7 +156,10 @@ pub fn try_lower_property_get_method_call(
             // statically-typed-string fast path above (`is_string_expr`), and the
             // `jsval.is_string()` arm of `js_native_call_method` for Any-typed
             // strings. So nothing is lost by falling through here.
-            "lastIndexOf" if args.len() == 1 => true,
+            // `lastIndexOf` (number-returning) shares the startsWith/endsWith
+            // hazard above — an Any-typed object's own `lastIndexOf` would be
+            // clobbered by the String builtin. Fall through to the runtime,
+            // which services a genuine string receiver via `jsval.is_string()`.
             _ => false,
         };
         // Don't route buffer/Uint8Array methods through the string path —

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -125,18 +125,13 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
     {
         let hi_sym = crate::symbol::well_known_symbol("hasInstance");
         if !hi_sym.is_null() {
-            let hi_f64 =
-                f64::from_bits(crate::value::JSValue::pointer(hi_sym as *const u8).bits());
+            let hi_f64 = f64::from_bits(crate::value::JSValue::pointer(hi_sym as *const u8).bits());
             if unsafe { crate::symbol::js_object_has_own_symbol(type_ref, hi_f64) } {
                 let cb = unsafe { crate::symbol::js_object_get_symbol_property(type_ref, hi_f64) };
-                if value_is_callable(cb) {
-                    let args = [value];
-                    let r = unsafe { crate::closure::js_native_call_value(cb, args.as_ptr(), 1) };
-                    return if crate::value::js_is_truthy(r) != 0 {
-                        f64::from_bits(crate::value::TAG_TRUE)
-                    } else {
-                        f64::from_bits(TAG_FALSE)
-                    };
+                // A present-but-non-callable own `@@hasInstance` throws; only a
+                // `null`/`undefined` value falls through to the default below.
+                if let HasInstanceOutcome::Result(r) = dispatch_own_has_instance(cb, value) {
+                    return r;
                 }
             }
         }
@@ -511,6 +506,38 @@ fn throw_type_error(message: &[u8]) -> ! {
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
 }
 
+/// Outcome of consulting an own `@@hasInstance` on the `instanceof` RHS.
+enum HasInstanceOutcome {
+    /// The own `@@hasInstance` was callable; this is the NaN-boxed boolean it
+    /// produced (already `ToBoolean`-normalized).
+    Result(f64),
+    /// No usable own `@@hasInstance` — the property held `undefined`/`null`, so
+    /// fall through to the ordinary `instanceof` algorithm.
+    Fallthrough,
+}
+
+/// Spec `InstanceofOperator` / `GetMethod(C, @@hasInstance)`: a `null`/`undefined`
+/// value means "no hook" (→ ordinary `instanceof`), but a present **non-callable**
+/// value is a `TypeError` rather than a silent fall-through. `cb` is the already
+/// resolved OWN `@@hasInstance` value; this never resolves the inherited
+/// `Function.prototype` default thunk, so there is no `instanceof` recursion.
+fn dispatch_own_has_instance(cb: f64, value: f64) -> HasInstanceOutcome {
+    let jv = crate::JSValue::from_bits(cb.to_bits());
+    if jv.is_undefined() || jv.is_null() {
+        return HasInstanceOutcome::Fallthrough;
+    }
+    if !value_is_callable(cb) {
+        throw_type_error(b"Symbol(Symbol.hasInstance) is not a function");
+    }
+    let args = [value];
+    let r = unsafe { crate::closure::js_native_call_value(cb, args.as_ptr(), 1) };
+    HasInstanceOutcome::Result(if crate::value::js_is_truthy(r) != 0 {
+        f64::from_bits(crate::value::TAG_TRUE)
+    } else {
+        f64::from_bits(crate::value::TAG_FALSE)
+    })
+}
+
 fn is_event_emitter_instance_value(value: f64) -> bool {
     if let Some(handle) = small_native_handle_id(value) {
         if let Some(probe) = crate::object::event_emitter_handle_probe() {
@@ -562,6 +589,53 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
             depth += 1;
         }
     }
+    // User-defined `Symbol.hasInstance` takes precedence over the built-in
+    // prototype-chain walk — and over the ordinary class-chain fast path below.
+    // `new C() instanceof C` must run a class-level `@@hasInstance` rather than
+    // short-circuit on the chain (the hook can return `false` for a real
+    // instance), so both hook forms are consulted here, ahead of that walk.
+    //
+    // Form 1: the HIR lifts `static [Symbol.hasInstance](v)` to a top-level
+    // function `__perry_wk_hasinstance_<class>` and the LLVM backend registers a
+    // pointer to it against the class id at module init.
+    if let Some(func_ptr) = lookup_has_instance_hook(class_id) {
+        let hook: extern "C" fn(f64) -> f64 = unsafe { std::mem::transmute(func_ptr as *const u8) };
+        let result = hook(value);
+        // Normalize: any truthy NaN-boxed bool stays as the TAG_TRUE/FALSE
+        // sentinel. User-written `return typeof v === "number" && ...`
+        // already returns a NaN-boxed bool, so this is usually a no-op.
+        let rbits = result.to_bits();
+        if rbits == TAG_TRUE || rbits == TAG_FALSE {
+            return result;
+        }
+        // Fallback: treat as truthy → TRUE, zero/undefined → FALSE.
+        if result.is_nan() && rbits & 0xFFFF_0000_0000_0000 == 0x7FFC_0000_0000_0000 {
+            return false_val;
+        }
+        if result == 0.0 || result.is_nan() {
+            return false_val;
+        }
+        return true_val;
+    }
+
+    // Form 2: the `Object.defineProperty(C, Symbol.hasInstance, { value: fn })`
+    // form (zod 4) stores the closure in the class static-symbol table. Read it
+    // off the class id (OWN lookup only — never resolves Function.prototype's
+    // default @@hasInstance thunk, so no recursion). A present-but-non-callable
+    // value throws; only `null`/`undefined` falls through to the chain.
+    {
+        let hi_sym = crate::symbol::well_known_symbol("hasInstance");
+        if !hi_sym.is_null() {
+            let hi_f64 = f64::from_bits(crate::value::JSValue::pointer(hi_sym as *const u8).bits());
+            if let Some(vb) = crate::symbol::class_static_symbol_lookup(class_id, hi_f64) {
+                let cb = f64::from_bits(vb);
+                if let HasInstanceOutcome::Result(r) = dispatch_own_has_instance(cb, value) {
+                    return r;
+                }
+            }
+        }
+    }
+
     // Subclass-of-built-in: `class S extends Array {}` produces a real
     // ObjectHeader instance whose class-id chain reaches the built-in's
     // reserved class id (a parent edge registered at module init). The
@@ -734,57 +808,6 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
         } else {
             false_val
         };
-    }
-
-    // User-defined `Symbol.hasInstance` takes precedence over the built-in
-    // prototype-chain walk. The HIR lifts `static [Symbol.hasInstance](v)`
-    // to a top-level function `__perry_wk_hasinstance_<class>` and the
-    // LLVM backend registers a pointer to it against the class's id at
-    // module init. If a hook is present, call it with the candidate value
-    // and return the boolean-shaped result directly.
-    if let Some(func_ptr) = lookup_has_instance_hook(class_id) {
-        let hook: extern "C" fn(f64) -> f64 = unsafe { std::mem::transmute(func_ptr as *const u8) };
-        let result = hook(value);
-        // Normalize: any truthy NaN-boxed bool stays as the TAG_TRUE/FALSE
-        // sentinel. User-written `return typeof v === "number" && ...`
-        // already returns a NaN-boxed bool, so this is usually a no-op.
-        let rbits = result.to_bits();
-        if rbits == TAG_TRUE || rbits == TAG_FALSE {
-            return result;
-        }
-        // Fallback: treat as truthy → TRUE, zero/undefined → FALSE.
-        if result.is_nan() && rbits & 0xFFFF_0000_0000_0000 == 0x7FFC_0000_0000_0000 {
-            return false_val;
-        }
-        if result == 0.0 || result.is_nan() {
-            return false_val;
-        }
-        return true_val;
-    }
-
-    // `Object.defineProperty(C, Symbol.hasInstance, { value: fn })` form (zod 4):
-    // unlike `static [Symbol.hasInstance]` (a registered hook, handled above),
-    // this stores the closure in the class static-symbol table. Read it off the
-    // class id (OWN lookup only — never resolves Function.prototype's default
-    // @@hasInstance thunk, so no recursion) and call it with the candidate value.
-    {
-        let hi_sym = crate::symbol::well_known_symbol("hasInstance");
-        if !hi_sym.is_null() {
-            let hi_f64 =
-                f64::from_bits(crate::value::JSValue::pointer(hi_sym as *const u8).bits());
-            if let Some(vb) = crate::symbol::class_static_symbol_lookup(class_id, hi_f64) {
-                let cb = f64::from_bits(vb);
-                if value_is_callable(cb) {
-                    let args = [value];
-                    let r = unsafe { crate::closure::js_native_call_value(cb, args.as_ptr(), 1) };
-                    return if crate::value::js_is_truthy(r) != 0 {
-                        true_val
-                    } else {
-                        false_val
-                    };
-                }
-            }
-        }
     }
 
     let bits = value.to_bits();

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -115,6 +115,32 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
             f64::from_bits(TAG_FALSE)
         };
     }
+    // Spec step (InstanceofOperator): consult the RHS's OWN `@@hasInstance`
+    // first. zod 4 builds `ZodType` as a plain FUNCTION and installs its brand
+    // check via `Object.defineProperty(ZodTypeFn, Symbol.hasInstance, { value })`,
+    // so the function RHS would otherwise fall through to the prototype-walk tail
+    // and return false. Read OWN only (`has_own` ⇒ `get` returns the own value,
+    // never the inherited Function.prototype default thunk → no recursion). Also
+    // catches a dynamic class-ref RHS (own @@hasInstance lives in CLASS_STATIC_SYMBOLS).
+    {
+        let hi_sym = crate::symbol::well_known_symbol("hasInstance");
+        if !hi_sym.is_null() {
+            let hi_f64 =
+                f64::from_bits(crate::value::JSValue::pointer(hi_sym as *const u8).bits());
+            if unsafe { crate::symbol::js_object_has_own_symbol(type_ref, hi_f64) } {
+                let cb = unsafe { crate::symbol::js_object_get_symbol_property(type_ref, hi_f64) };
+                if value_is_callable(cb) {
+                    let args = [value];
+                    let r = unsafe { crate::closure::js_native_call_value(cb, args.as_ptr(), 1) };
+                    return if crate::value::js_is_truthy(r) != 0 {
+                        f64::from_bits(crate::value::TAG_TRUE)
+                    } else {
+                        f64::from_bits(TAG_FALSE)
+                    };
+                }
+            }
+        }
+    }
     let bits = type_ref.to_bits();
     let top16 = bits >> 48;
     if top16 == 0x7FFE {
@@ -734,6 +760,31 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
             return false_val;
         }
         return true_val;
+    }
+
+    // `Object.defineProperty(C, Symbol.hasInstance, { value: fn })` form (zod 4):
+    // unlike `static [Symbol.hasInstance]` (a registered hook, handled above),
+    // this stores the closure in the class static-symbol table. Read it off the
+    // class id (OWN lookup only — never resolves Function.prototype's default
+    // @@hasInstance thunk, so no recursion) and call it with the candidate value.
+    {
+        let hi_sym = crate::symbol::well_known_symbol("hasInstance");
+        if !hi_sym.is_null() {
+            let hi_f64 =
+                f64::from_bits(crate::value::JSValue::pointer(hi_sym as *const u8).bits());
+            if let Some(vb) = crate::symbol::class_static_symbol_lookup(class_id, hi_f64) {
+                let cb = f64::from_bits(vb);
+                if value_is_callable(cb) {
+                    let args = [value];
+                    let r = unsafe { crate::closure::js_native_call_value(cb, args.as_ptr(), 1) };
+                    return if crate::value::js_is_truthy(r) != 0 {
+                        true_val
+                    } else {
+                        false_val
+                    };
+                }
+            }
+        }
     }
 
     let bits = value.to_bits();

--- a/crates/perry-runtime/src/object/object_ops/define_property.rs
+++ b/crates/perry-runtime/src/object/object_ops/define_property.rs
@@ -294,8 +294,12 @@ pub extern "C" fn js_object_define_property(
             // `js_instanceof` consults — so `x instanceof C` honors the user hook
             // (zod 4 installs its brand-check `@@hasInstance` exactly this way).
             if crate::symbol::js_is_symbol(key_value) != 0 {
-                let value_field = desc_read_field(descriptor_value, b"value");
-                if !value_field.is_undefined() {
+                // Gate on descriptor-field *presence*, not on the value being
+                // non-`undefined`: `Object.defineProperty(C, sym, { value: undefined })`
+                // must still register an own entry. A generic redefine like
+                // `{ enumerable: true }` (no `value`) leaves any existing entry intact.
+                if desc_has_field(descriptor_value, b"value") {
+                    let value_field = desc_read_field(descriptor_value, b"value");
                     crate::symbol::js_class_register_static_symbol(
                         target_cid,
                         key_value,
@@ -380,7 +384,12 @@ pub extern "C" fn js_object_define_property(
                         crate::symbol::set_symbol_accessor_property(
                             obj_value, key_value, get_bits, set_bits,
                         );
-                    } else {
+                    } else if desc_has_field(descriptor_value, b"value") {
+                        // Only write a value when the descriptor actually carries
+                        // one. A generic redefine like `{ enumerable: true }` must
+                        // preserve the existing `fn[sym]` rather than clobber it
+                        // with `undefined`. (`value: undefined` is honored — it is
+                        // a present field.)
                         let value_field = desc_read_field(descriptor_value, b"value");
                         crate::symbol::js_object_set_symbol_property(
                             obj_value,

--- a/crates/perry-runtime/src/object/object_ops/define_property.rs
+++ b/crates/perry-runtime/src/object/object_ops/define_property.rs
@@ -286,6 +286,24 @@ pub extern "C" fn js_object_define_property(
         // db.select().from(x)` saw `instance.then === undefined` and `await`
         // unwrapped the builder unchanged.
         if let Some(target_cid) = super::super::class_ref_id(obj_value) {
+            // `Object.defineProperty(C, Symbol.hasInstance, { value: fn })` (and
+            // any symbol-keyed static define on a class): `metadata_key_to_string`
+            // can't stringify a Symbol, so the value would be silently dropped.
+            // Route it into the class static-symbol table (CLASS_STATIC_SYMBOLS) —
+            // the same table `static [Symbol.hasInstance]` registers into and that
+            // `js_instanceof` consults — so `x instanceof C` honors the user hook
+            // (zod 4 installs its brand-check `@@hasInstance` exactly this way).
+            if crate::symbol::js_is_symbol(key_value) != 0 {
+                let value_field = desc_read_field(descriptor_value, b"value");
+                if !value_field.is_undefined() {
+                    crate::symbol::js_class_register_static_symbol(
+                        target_cid,
+                        key_value,
+                        f64::from_bits(value_field.bits()),
+                    );
+                }
+                return obj_value;
+            }
             if let Some(name) = super::super::metadata_key_to_string(key_value) {
                 let desc_ptr = extract_obj_ptr(descriptor_value);
                 if !desc_ptr.is_null() {
@@ -332,6 +350,47 @@ pub extern "C" fn js_object_define_property(
             }
         };
         if let Some(closure_ptr) = target_closure_ptr {
+            // A Symbol key on a function value (zod 4 installs its `instanceof`
+            // brand check via `Object.defineProperty(ZodTypeFn, Symbol.hasInstance,
+            // { value })`). Route into the SAME symbol side table
+            // (`SYMBOL_PROPERTIES`, keyed by the closure pointer) that
+            // `js_object_has_own_symbol` / `js_object_get_symbol_property` read —
+            // string-coercing the symbol (below) would file it under a
+            // "Symbol(...)" STRING key, unreachable by the symbol-keyed reader and
+            // breaking the function-RHS `@@hasInstance` instanceof hook. Mirrors
+            // the typed-array symbol-define branch below.
+            if crate::symbol::js_is_symbol(key_value) != 0 {
+                let desc_ptr = extract_obj_ptr(descriptor_value);
+                if !desc_ptr.is_null() {
+                    let has_get = desc_has_field(descriptor_value, b"get");
+                    let has_set = desc_has_field(descriptor_value, b"set");
+                    if has_get || has_set {
+                        let get_field = desc_read_field(descriptor_value, b"get");
+                        let set_field = desc_read_field(descriptor_value, b"set");
+                        let get_bits = if !has_get || get_field.is_undefined() {
+                            0
+                        } else {
+                            crate::closure::clone_closure_rebind_this(get_field.bits(), obj_value)
+                        };
+                        let set_bits = if !has_set || set_field.is_undefined() {
+                            0
+                        } else {
+                            crate::closure::clone_closure_rebind_this(set_field.bits(), obj_value)
+                        };
+                        crate::symbol::set_symbol_accessor_property(
+                            obj_value, key_value, get_bits, set_bits,
+                        );
+                    } else {
+                        let value_field = desc_read_field(descriptor_value, b"value");
+                        crate::symbol::js_object_set_symbol_property(
+                            obj_value,
+                            key_value,
+                            f64::from_bits(value_field.bits()),
+                        );
+                    }
+                }
+                return obj_value;
+            }
             let key_str = crate::builtins::js_string_coerce(key_value);
             if key_str.is_null() {
                 return obj_value;

--- a/crates/perry/src/commands/compile/optimized_libs/driver.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/driver.rs
@@ -587,21 +587,30 @@ pub(crate) fn build_optimized_libs(
             &build_stamp,
         )
     {
-        let well_known_libs = resolve_auto_well_known_libs(
+        // The "archives fresh" fast-path must still carry the NON-tokio
+        // routed well-known libs collected by the routing loop above (e.g.
+        // perry-ext-zlib for `node:zlib`, perry-ext-events, …). They live in
+        // the outer `well_known_libs`; `resolve_auto_well_known_libs` only
+        // resolves the tokio-using bindings. Without merging them, the routed
+        // CPU-only ext staticlibs are dropped here and the link fails with
+        // undefined `js_ext_zlib_*` / `js_zlib_*` (and other non-tokio
+        // well-known) symbols — even though the archive is on disk.
+        let mut well_known_libs = well_known_libs;
+        well_known_libs.extend(resolve_auto_well_known_libs(
             &workspace_root,
             &release_dir,
             &tokio_using_bindings,
             target,
             format,
-        );
+        ));
         return OptimizedLibs {
             runtime: Some(runtime_path),
             stdlib: Some(stdlib_path),
             runtime_bc: None,
             stdlib_bc: None,
             extra_bc: Vec::new(),
+            prefer_well_known_before_stdlib: !well_known_libs.is_empty(),
             well_known_libs,
-            prefer_well_known_before_stdlib: false,
         };
     }
 


### PR DESCRIPTION
## Problem

When the receiver of `.startsWith()` / `.endsWith()` / `.lastIndexOf()` is **any-typed** (its TS type was erased at bundle time), codegen routed the call to the static `String.prototype` builtin, which returns a boolean/number. But an any-typed receiver may be an **object with its own same-named method** that returns something else.

Minimal repro (zod):

```js
const s = z.string().startsWith("./");   // perry: boolean (wrong)   node: ZodString
s.describe("x");                          // → "(boolean).describe is not a function"
```

`ZodString.startsWith()` returns a refined schema, not a boolean, so a chained `.describe()` / `.optional()` then threw on a primitive. This blocks compiled programs that build zod schemas with these string refinements.

## Fix

Drop `startsWith` / `endsWith` / `lastIndexOf` from the any-typed string-method fallback in `lower_call/property_get.rs`, so they **dynamic-dispatch**: an object's own method wins, while a genuine any-typed *string* receiver is still serviced by the runtime's `jsval.is_string()` arm of `js_native_call_method`.

This is exactly the fix already applied to `indexOf` / `includes` (#1341) for the same reason (an any-typed receiver that is actually an array).

## Testing

Regression-tested against Node: typed and any-typed `startsWith`/`endsWith`/`lastIndexOf`, plus array `includes`/`indexOf`, all still match. `z.string().startsWith("./").describe("x")` now returns a `ZodString` as in Node.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `instanceof` behavior to honor `Symbol.hasInstance` with correct precedence, own-property lookup, and proper handling of non-callable cases.
  * Fixed `defineProperty` for `Symbol` keys on classes and functions so descriptors are applied correctly for `value`, `get`, and `set`.
  * Corrected method dispatch for `startsWith`, `endsWith`, and `lastIndexOf` on `Any`-typed string receivers to prevent incorrect string-only routing.
* **Build**
  * Resolved an optimized library build path that could omit routed well-known libraries, avoiding missing-symbol link failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->