### PR TITLE
fix(runtime): honor Object.defineProperty(C, Symbol.hasInstance) in instanceof (class + function)

### DIFF
--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -125,18 +125,13 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
     {
         let hi_sym = crate::symbol::well_known_symbol("hasInstance");
         if !hi_sym.is_null() {
-            let hi_f64 =
-                f64::from_bits(crate::value::JSValue::pointer(hi_sym as *const u8).bits());
+            let hi_f64 = f64::from_bits(crate::value::JSValue::pointer(hi_sym as *const u8).bits());
             if unsafe { crate::symbol::js_object_has_own_symbol(type_ref, hi_f64) } {
                 let cb = unsafe { crate::symbol::js_object_get_symbol_property(type_ref, hi_f64) };
-                if value_is_callable(cb) {
-                    let args = [value];
-                    let r = unsafe { crate::closure::js_native_call_value(cb, args.as_ptr(), 1) };
-                    return if crate::value::js_is_truthy(r) != 0 {
-                        f64::from_bits(crate::value::TAG_TRUE)
-                    } else {
-                        f64::from_bits(TAG_FALSE)
-                    };
+                // A present-but-non-callable own `@@hasInstance` throws; only a
+                // `null`/`undefined` value falls through to the default below.
+                if let HasInstanceOutcome::Result(r) = dispatch_own_has_instance(cb, value) {
+                    return r;
                 }
             }
         }
@@ -511,6 +506,38 @@ fn throw_type_error(message: &[u8]) -> ! {
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
 }
 
+/// Outcome of consulting an own `@@hasInstance` on the `instanceof` RHS.
+enum HasInstanceOutcome {
+    /// The own `@@hasInstance` was callable; this is the NaN-boxed boolean it
+    /// produced (already `ToBoolean`-normalized).
+    Result(f64),
+    /// No usable own `@@hasInstance` — the property held `undefined`/`null`, so
+    /// fall through to the ordinary `instanceof` algorithm.
+    Fallthrough,
+}
+
+/// Spec `InstanceofOperator` / `GetMethod(C, @@hasInstance)`: a `null`/`undefined`
+/// value means "no hook" (→ ordinary `instanceof`), but a present **non-callable**
+/// value is a `TypeError` rather than a silent fall-through. `cb` is the already
+/// resolved OWN `@@hasInstance` value; this never resolves the inherited
+/// `Function.prototype` default thunk, so there is no `instanceof` recursion.
+fn dispatch_own_has_instance(cb: f64, value: f64) -> HasInstanceOutcome {
+    let jv = crate::JSValue::from_bits(cb.to_bits());
+    if jv.is_undefined() || jv.is_null() {
+        return HasInstanceOutcome::Fallthrough;
+    }
+    if !value_is_callable(cb) {
+        throw_type_error(b"Symbol(Symbol.hasInstance) is not a function");
+    }
+    let args = [value];
+    let r = unsafe { crate::closure::js_native_call_value(cb, args.as_ptr(), 1) };
+    HasInstanceOutcome::Result(if crate::value::js_is_truthy(r) != 0 {
+        f64::from_bits(crate::value::TAG_TRUE)
+    } else {
+        f64::from_bits(crate::value::TAG_FALSE)
+    })
+}
+
 fn is_event_emitter_instance_value(value: f64) -> bool {
     if let Some(handle) = small_native_handle_id(value) {
         if let Some(probe) = crate::object::event_emitter_handle_probe() {
@@ -562,6 +589,53 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
             depth += 1;
         }
     }
+    // User-defined `Symbol.hasInstance` takes precedence over the built-in
+    // prototype-chain walk — and over the ordinary class-chain fast path below.
+    // `new C() instanceof C` must run a class-level `@@hasInstance` rather than
+    // short-circuit on the chain (the hook can return `false` for a real
+    // instance), so both hook forms are consulted here, ahead of that walk.
+    //
+    // Form 1: the HIR lifts `static [Symbol.hasInstance](v)` to a top-level
+    // function `__perry_wk_hasinstance_<class>` and the LLVM backend registers a
+    // pointer to it against the class id at module init.
+    if let Some(func_ptr) = lookup_has_instance_hook(class_id) {
+        let hook: extern "C" fn(f64) -> f64 = unsafe { std::mem::transmute(func_ptr as *const u8) };
+        let result = hook(value);
+        // Normalize: any truthy NaN-boxed bool stays as the TAG_TRUE/FALSE
+        // sentinel. User-written `return typeof v === "number" && ...`
+        // already returns a NaN-boxed bool, so this is usually a no-op.
+        let rbits = result.to_bits();
+        if rbits == TAG_TRUE || rbits == TAG_FALSE {
+            return result;
+        }
+        // Fallback: treat as truthy → TRUE, zero/undefined → FALSE.
+        if result.is_nan() && rbits & 0xFFFF_0000_0000_0000 == 0x7FFC_0000_0000_0000 {
+            return false_val;
+        }
+        if result == 0.0 || result.is_nan() {
+            return false_val;
+        }
+        return true_val;
+    }
+
+    // Form 2: the `Object.defineProperty(C, Symbol.hasInstance, { value: fn })`
+    // form (zod 4) stores the closure in the class static-symbol table. Read it
+    // off the class id (OWN lookup only — never resolves Function.prototype's
+    // default @@hasInstance thunk, so no recursion). A present-but-non-callable
+    // value throws; only `null`/`undefined` falls through to the chain.
+    {
+        let hi_sym = crate::symbol::well_known_symbol("hasInstance");
+        if !hi_sym.is_null() {
+            let hi_f64 = f64::from_bits(crate::value::JSValue::pointer(hi_sym as *const u8).bits());
+            if let Some(vb) = crate::symbol::class_static_symbol_lookup(class_id, hi_f64) {
+                let cb = f64::from_bits(vb);
+                if let HasInstanceOutcome::Result(r) = dispatch_own_has_instance(cb, value) {
+                    return r;
+                }
+            }
+        }
+    }
+
     // Subclass-of-built-in: `class S extends Array {}` produces a real
     // ObjectHeader instance whose class-id chain reaches the built-in's
     // reserved class id (a parent edge registered at module init). The
@@ -734,57 +808,6 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
         } else {
             false_val
         };
-    }
-
-    // User-defined `Symbol.hasInstance` takes precedence over the built-in
-    // prototype-chain walk. The HIR lifts `static [Symbol.hasInstance](v)`
-    // to a top-level function `__perry_wk_hasinstance_<class>` and the
-    // LLVM backend registers a pointer to it against the class's id at
-    // module init. If a hook is present, call it with the candidate value
-    // and return the boolean-shaped result directly.
-    if let Some(func_ptr) = lookup_has_instance_hook(class_id) {
-        let hook: extern "C" fn(f64) -> f64 = unsafe { std::mem::transmute(func_ptr as *const u8) };
-        let result = hook(value);
-        // Normalize: any truthy NaN-boxed bool stays as the TAG_TRUE/FALSE
-        // sentinel. User-written `return typeof v === "number" && ...`
-        // already returns a NaN-boxed bool, so this is usually a no-op.
-        let rbits = result.to_bits();
-        if rbits == TAG_TRUE || rbits == TAG_FALSE {
-            return result;
-        }
-        // Fallback: treat as truthy → TRUE, zero/undefined → FALSE.
-        if result.is_nan() && rbits & 0xFFFF_0000_0000_0000 == 0x7FFC_0000_0000_0000 {
-            return false_val;
-        }
-        if result == 0.0 || result.is_nan() {
-            return false_val;
-        }
-        return true_val;
-    }
-
-    // `Object.defineProperty(C, Symbol.hasInstance, { value: fn })` form (zod 4):
-    // unlike `static [Symbol.hasInstance]` (a registered hook, handled above),
-    // this stores the closure in the class static-symbol table. Read it off the
-    // class id (OWN lookup only — never resolves Function.prototype's default
-    // @@hasInstance thunk, so no recursion) and call it with the candidate value.
-    {
-        let hi_sym = crate::symbol::well_known_symbol("hasInstance");
-        if !hi_sym.is_null() {
-            let hi_f64 =
-                f64::from_bits(crate::value::JSValue::pointer(hi_sym as *const u8).bits());
-            if let Some(vb) = crate::symbol::class_static_symbol_lookup(class_id, hi_f64) {
-                let cb = f64::from_bits(vb);
-                if value_is_callable(cb) {
-                    let args = [value];
-                    let r = unsafe { crate::closure::js_native_call_value(cb, args.as_ptr(), 1) };
-                    return if crate::value::js_is_truthy(r) != 0 {
-                        true_val
-                    } else {
-                        false_val
-                    };
-                }
-            }
-        }
     }
 
     let bits = value.to_bits();

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -115,6 +115,32 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
             f64::from_bits(TAG_FALSE)
         };
     }
+    // Spec step (InstanceofOperator): consult the RHS's OWN `@@hasInstance`
+    // first. zod 4 builds `ZodType` as a plain FUNCTION and installs its brand
+    // check via `Object.defineProperty(ZodTypeFn, Symbol.hasInstance, { value })`,
+    // so the function RHS would otherwise fall through to the prototype-walk tail
+    // and return false. Read OWN only (`has_own` ⇒ `get` returns the own value,
+    // never the inherited Function.prototype default thunk → no recursion). Also
+    // catches a dynamic class-ref RHS (own @@hasInstance lives in CLASS_STATIC_SYMBOLS).
+    {
+        let hi_sym = crate::symbol::well_known_symbol("hasInstance");
+        if !hi_sym.is_null() {
+            let hi_f64 =
+                f64::from_bits(crate::value::JSValue::pointer(hi_sym as *const u8).bits());
+            if unsafe { crate::symbol::js_object_has_own_symbol(type_ref, hi_f64) } {
+                let cb = unsafe { crate::symbol::js_object_get_symbol_property(type_ref, hi_f64) };
+                if value_is_callable(cb) {
+                    let args = [value];
+                    let r = unsafe { crate::closure::js_native_call_value(cb, args.as_ptr(), 1) };
+                    return if crate::value::js_is_truthy(r) != 0 {
+                        f64::from_bits(crate::value::TAG_TRUE)
+                    } else {
+                        f64::from_bits(TAG_FALSE)
+                    };
+                }
+            }
+        }
+    }
     let bits = type_ref.to_bits();
     let top16 = bits >> 48;
     if top16 == 0x7FFE {
@@ -734,6 +760,31 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
             return false_val;
         }
         return true_val;
+    }
+
+    // `Object.defineProperty(C, Symbol.hasInstance, { value: fn })` form (zod 4):
+    // unlike `static [Symbol.hasInstance]` (a registered hook, handled above),
+    // this stores the closure in the class static-symbol table. Read it off the
+    // class id (OWN lookup only — never resolves Function.prototype's default
+    // @@hasInstance thunk, so no recursion) and call it with the candidate value.
+    {
+        let hi_sym = crate::symbol::well_known_symbol("hasInstance");
+        if !hi_sym.is_null() {
+            let hi_f64 =
+                f64::from_bits(crate::value::JSValue::pointer(hi_sym as *const u8).bits());
+            if let Some(vb) = crate::symbol::class_static_symbol_lookup(class_id, hi_f64) {
+                let cb = f64::from_bits(vb);
+                if value_is_callable(cb) {
+                    let args = [value];
+                    let r = unsafe { crate::closure::js_native_call_value(cb, args.as_ptr(), 1) };
+                    return if crate::value::js_is_truthy(r) != 0 {
+                        true_val
+                    } else {
+                        false_val
+                    };
+                }
+            }
+        }
     }
 
     let bits = value.to_bits();

--- a/crates/perry-runtime/src/object/object_ops/define_property.rs
+++ b/crates/perry-runtime/src/object/object_ops/define_property.rs
@@ -294,8 +294,12 @@ pub extern "C" fn js_object_define_property(
             // `js_instanceof` consults — so `x instanceof C` honors the user hook
             // (zod 4 installs its brand-check `@@hasInstance` exactly this way).
             if crate::symbol::js_is_symbol(key_value) != 0 {
-                let value_field = desc_read_field(descriptor_value, b"value");
-                if !value_field.is_undefined() {
+                // Gate on descriptor-field *presence*, not on the value being
+                // non-`undefined`: `Object.defineProperty(C, sym, { value: undefined })`
+                // must still register an own entry. A generic redefine like
+                // `{ enumerable: true }` (no `value`) leaves any existing entry intact.
+                if desc_has_field(descriptor_value, b"value") {
+                    let value_field = desc_read_field(descriptor_value, b"value");
                     crate::symbol::js_class_register_static_symbol(
                         target_cid,
                         key_value,
@@ -380,7 +384,12 @@ pub extern "C" fn js_object_define_property(
                         crate::symbol::set_symbol_accessor_property(
                             obj_value, key_value, get_bits, set_bits,
                         );
-                    } else {
+                    } else if desc_has_field(descriptor_value, b"value") {
+                        // Only write a value when the descriptor actually carries
+                        // one. A generic redefine like `{ enumerable: true }` must
+                        // preserve the existing `fn[sym]` rather than clobber it
+                        // with `undefined`. (`value: undefined` is honored — it is
+                        // a present field.)
                         let value_field = desc_read_field(descriptor_value, b"value");
                         crate::symbol::js_object_set_symbol_property(
                             obj_value,

--- a/crates/perry-runtime/src/object/object_ops/define_property.rs
+++ b/crates/perry-runtime/src/object/object_ops/define_property.rs
@@ -286,6 +286,24 @@ pub extern "C" fn js_object_define_property(
         // db.select().from(x)` saw `instance.then === undefined` and `await`
         // unwrapped the builder unchanged.
         if let Some(target_cid) = super::super::class_ref_id(obj_value) {
+            // `Object.defineProperty(C, Symbol.hasInstance, { value: fn })` (and
+            // any symbol-keyed static define on a class): `metadata_key_to_string`
+            // can't stringify a Symbol, so the value would be silently dropped.
+            // Route it into the class static-symbol table (CLASS_STATIC_SYMBOLS) —
+            // the same table `static [Symbol.hasInstance]` registers into and that
+            // `js_instanceof` consults — so `x instanceof C` honors the user hook
+            // (zod 4 installs its brand-check `@@hasInstance` exactly this way).
+            if crate::symbol::js_is_symbol(key_value) != 0 {
+                let value_field = desc_read_field(descriptor_value, b"value");
+                if !value_field.is_undefined() {
+                    crate::symbol::js_class_register_static_symbol(
+                        target_cid,
+                        key_value,
+                        f64::from_bits(value_field.bits()),
+                    );
+                }
+                return obj_value;
+            }
             if let Some(name) = super::super::metadata_key_to_string(key_value) {
                 let desc_ptr = extract_obj_ptr(descriptor_value);
                 if !desc_ptr.is_null() {
@@ -332,6 +350,47 @@ pub extern "C" fn js_object_define_property(
             }
         };
         if let Some(closure_ptr) = target_closure_ptr {
+            // A Symbol key on a function value (zod 4 installs its `instanceof`
+            // brand check via `Object.defineProperty(ZodTypeFn, Symbol.hasInstance,
+            // { value })`). Route into the SAME symbol side table
+            // (`SYMBOL_PROPERTIES`, keyed by the closure pointer) that
+            // `js_object_has_own_symbol` / `js_object_get_symbol_property` read —
+            // string-coercing the symbol (below) would file it under a
+            // "Symbol(...)" STRING key, unreachable by the symbol-keyed reader and
+            // breaking the function-RHS `@@hasInstance` instanceof hook. Mirrors
+            // the typed-array symbol-define branch below.
+            if crate::symbol::js_is_symbol(key_value) != 0 {
+                let desc_ptr = extract_obj_ptr(descriptor_value);
+                if !desc_ptr.is_null() {
+                    let has_get = desc_has_field(descriptor_value, b"get");
+                    let has_set = desc_has_field(descriptor_value, b"set");
+                    if has_get || has_set {
+                        let get_field = desc_read_field(descriptor_value, b"get");
+                        let set_field = desc_read_field(descriptor_value, b"set");
+                        let get_bits = if !has_get || get_field.is_undefined() {
+                            0
+                        } else {
+                            crate::closure::clone_closure_rebind_this(get_field.bits(), obj_value)
+                        };
+                        let set_bits = if !has_set || set_field.is_undefined() {
+                            0
+                        } else {
+                            crate::closure::clone_closure_rebind_this(set_field.bits(), obj_value)
+                        };
+                        crate::symbol::set_symbol_accessor_property(
+                            obj_value, key_value, get_bits, set_bits,
+                        );
+                    } else {
+                        let value_field = desc_read_field(descriptor_value, b"value");
+                        crate::symbol::js_object_set_symbol_property(
+                            obj_value,
+                            key_value,
+                            f64::from_bits(value_field.bits()),
+                        );
+                    }
+                }
+                return obj_value;
+            }
             let key_str = crate::builtins::js_string_coerce(key_value);
             if key_str.is_null() {
                 return obj_value;

--- a/crates/perry/tests/issue_5667_instanceof_define_property_hasinstance.rs
+++ b/crates/perry/tests/issue_5667_instanceof_define_property_hasinstance.rs
@@ -1,0 +1,111 @@
+//! Regression tests for #5667: `Object.defineProperty(C, Symbol.hasInstance, …)`
+//! must be honored by `instanceof`, on both class and function receivers.
+//!
+//! Spec `InstanceofOperator` consults the RHS's OWN `@@hasInstance` first:
+//!   - a callable own hook is invoked and its `ToBoolean` result returned —
+//!     this takes precedence over the ordinary class-chain walk, so even
+//!     `new C() instanceof C` runs the hook (it may return `false`);
+//!   - a present-but-non-callable own hook (e.g. `{ value: 1 }`) is a
+//!     `TypeError`, not a silent fall-through;
+//!   - an own value of `undefined`/`null` means "no hook" → ordinary instanceof;
+//!   - a generic redefine (`{ enumerable: true }`) must not clobber the
+//!     existing hook value.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(src: &str) -> (bool, String, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.js");
+    let output = dir.path().join("main_bin");
+    std::fs::write(&entry, src).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    (
+        run.status.success(),
+        String::from_utf8_lossy(&run.stdout).into_owned(),
+        String::from_utf8_lossy(&run.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn define_property_hasinstance_overrides_class_chain_and_brand_checks() {
+    let src = r#"
+"use strict";
+// Hook returning false wins over the ordinary class-chain fast path.
+class C1 {}
+Object.defineProperty(C1, Symbol.hasInstance, { value() { return false; } });
+console.log("1:" + (new C1() instanceof C1));
+
+// Brand-style hook (zod 4 installs its instanceof check exactly this way).
+class D {}
+Object.defineProperty(D, Symbol.hasInstance, { value: (x) => !!(x && x.__d) });
+console.log("2a:" + (({ __d: 1 }) instanceof D));
+console.log("2b:" + (({}) instanceof D));
+
+// Explicit `value: undefined` is "no hook" → ordinary instanceof (no throw).
+class C3 {}
+Object.defineProperty(C3, Symbol.hasInstance, { value: undefined });
+console.log("3:" + (new C3() instanceof C3));
+
+// Function receiver, plus a generic redefine that must NOT clobber the hook.
+function F() {}
+Object.defineProperty(F, Symbol.hasInstance, { value: (x) => x === 42, configurable: true });
+console.log("5a:" + ((42) instanceof F));
+Object.defineProperty(F, Symbol.hasInstance, { enumerable: true });
+console.log("5b:" + ((42) instanceof F));
+
+// Plain inheritance still works (no own hook present).
+class A {}
+class B extends A {}
+console.log("6a:" + (new B() instanceof A));
+console.log("6b:" + (new A() instanceof B));
+"#;
+    let (ok, stdout, stderr) = compile_and_run(src);
+    assert!(ok, "binary failed\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    assert_eq!(
+        stdout, "1:false\n2a:true\n2b:false\n3:true\n5a:true\n5b:true\n6a:true\n6b:false\n",
+        "defineProperty(@@hasInstance) must drive instanceof (own hook before class chain), \
+         honor explicit value:undefined as no-hook, and survive a generic redefine"
+    );
+}
+
+#[test]
+fn non_callable_own_hasinstance_throws_type_error() {
+    let src = r#"
+"use strict";
+class C {}
+Object.defineProperty(C, Symbol.hasInstance, { value: 1 });
+try {
+    void (({}) instanceof C);
+    console.log("no-throw");
+} catch (e) {
+    console.log(e && e.constructor ? e.constructor.name : String(e));
+}
+"#;
+    let (ok, stdout, stderr) = compile_and_run(src);
+    assert!(ok, "binary failed\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    assert_eq!(
+        stdout, "TypeError\n",
+        "a present-but-non-callable own @@hasInstance must throw TypeError, not fall through"
+    );
+}


### PR DESCRIPTION
## Problem

A user-defined `static [Symbol.hasInstance]() {}` was honored by `instanceof`, but the **`Object.defineProperty(C, Symbol.hasInstance, { value })`** form was not — `instanceof` ignored it and fell through to the prototype-chain walk.

This breaks libraries that install their `instanceof` brand check via `defineProperty`. zod 4 does exactly this on its base class:

```js
Object.defineProperty(ZodType, Symbol.hasInstance, { value: (x) => /* brand check */ });
```

so `someSchema instanceof z.ZodType` returned `false`, and zod's own `z.object({...})` shape validation (`!(shape[k] instanceof ZodType)`) then threw `Invalid element at key "...": expected a Zod schema`.

## Root cause + fix (two parts)

**Store** — `object_ops/define_property.rs`: a Symbol key passed to `Object.defineProperty(target, sym, desc)` was mishandled:
- for a **class-ref** target the symbol key was dropped (the string-key path can't stringify a Symbol);
- for a **function** target it was string-coerced to a `"Symbol(Symbol.hasInstance)"` STRING key in the closure dynamic-prop table — unreachable by the symbol-keyed reader.

Route both into the symbol side table the reader consults (`CLASS_STATIC_SYMBOLS` for a class-ref via `js_class_register_static_symbol`; `SYMBOL_PROPERTIES` for a function via `js_object_set_symbol_property`), mirroring the existing typed-array symbol-define branch.

**Consult** — `object/instanceof.rs`: `js_instanceof` and `js_instanceof_dynamic` now read the RHS's **own** `@@hasInstance` and, if callable, call it with the value and return `ToBoolean` — before the prototype walk. The lookup is **own-only**, so it never resolves the inherited `Function.prototype[@@hasInstance]` default thunk (which would re-enter `instanceof` → infinite recursion). Covers both class and function constructors.

## No regressions

- Plain classes/functions with no own `@@hasInstance` fall through unchanged.
- Built-ins (Array/Map/…), whose `@@hasInstance` is *inherited* from `Function.prototype`, are not intercepted (own-only).
- Basic class-inheritance `instanceof` (`B extends A`, multi-level) verified green.

## Repros now passing

```js
class D {}; Object.defineProperty(D, Symbol.hasInstance, { value: (x) => !!x?.__d });
({ __d: 1 }) instanceof D;                                  // true (was false)
z.record(z.string(), z.string()) instanceof z.ZodType;     // true (was false)
z.union([z.string(), z.number()]) instanceof z.ZodType;    // true (was false)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced `instanceof` to honor an RHS own `Symbol.hasInstance`, including callable “brand-style” behavior.
  * `Object.defineProperty` now supports symbol-keyed descriptors on class-like and function/closure-like receivers, including both data values and accessors.

* **Bug Fixes**
  * `instanceof` now consults an own `Symbol.hasInstance` earlier, taking precedence over class-chain and related checks.
  * If an own `Symbol.hasInstance` is present but non-callable, `instanceof` throws `TypeError`; `{ value: undefined }`/`{ value: null }` is treated as no hook.

* **Tests**
  * Added regression coverage for `instanceof`/`defineProperty` `Symbol.hasInstance` override and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->