### PR TITLE
fix(compile): auto-optimize archives-fresh fast-path drops non-tokio routed ext staticlibs

### DIFF
--- a/crates/perry/src/commands/compile/optimized_libs/driver.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/driver.rs
@@ -587,21 +587,30 @@ pub(crate) fn build_optimized_libs(
             &build_stamp,
         )
     {
-        let well_known_libs = resolve_auto_well_known_libs(
+        // The "archives fresh" fast-path must still carry the NON-tokio
+        // routed well-known libs collected by the routing loop above (e.g.
+        // perry-ext-zlib for `node:zlib`, perry-ext-events, …). They live in
+        // the outer `well_known_libs`; `resolve_auto_well_known_libs` only
+        // resolves the tokio-using bindings. Without merging them, the routed
+        // CPU-only ext staticlibs are dropped here and the link fails with
+        // undefined `js_ext_zlib_*` / `js_zlib_*` (and other non-tokio
+        // well-known) symbols — even though the archive is on disk.
+        let mut well_known_libs = well_known_libs;
+        well_known_libs.extend(resolve_auto_well_known_libs(
             &workspace_root,
             &release_dir,
             &tokio_using_bindings,
             target,
             format,
-        );
+        ));
         return OptimizedLibs {
             runtime: Some(runtime_path),
             stdlib: Some(stdlib_path),
             runtime_bc: None,
             stdlib_bc: None,
             extra_bc: Vec::new(),
+            prefer_well_known_before_stdlib: !well_known_libs.is_empty(),
             well_known_libs,
-            prefer_well_known_before_stdlib: false,
         };
     }
 


### PR DESCRIPTION
## Problem

When the auto-optimized archives are already fresh, the fast-path in `optimized_libs/driver.rs` returned:

```rust
let well_known_libs = resolve_auto_well_known_libs(&workspace_root, &release_dir, &tokio_using_bindings, target, format);
return OptimizedLibs { /* ... */ well_known_libs, prefer_well_known_before_stdlib: false };
```

`resolve_auto_well_known_libs` only resolves the **tokio-using** routed bindings. The **non-tokio** routed well-known ext staticlibs collected earlier in the same call (CPU-only wrappers like the compression crate that `node:zlib` flips to, events, …) were silently **dropped** from `well_known_libs`.

Result: a program importing `node:zlib` (or another non-tokio well-known) **fails to link** with undefined `js_ext_zlib_*` / `js_zlib_*` symbols — even though the routed `.a` is on disk and was logged as routed. Only the non-fresh (full-rebuild) path linked correctly, so this surfaced intermittently depending on archive freshness.

## Fix

Merge the outer `well_known_libs` (the non-tokio routed libs gathered by the routing loop) into the fresh-path return instead of replacing it with the tokio-only set, and set `prefer_well_known_before_stdlib` accordingly. The full-rebuild path already carried these libs.

```rust
let mut well_known_libs = well_known_libs;
well_known_libs.extend(resolve_auto_well_known_libs(/* tokio libs */));
return OptimizedLibs { /* ... */ prefer_well_known_before_stdlib: !well_known_libs.is_empty(), well_known_libs };
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved library selection in the fast path for optimized builds, so previously detected CPU-only libraries are now retained instead of being dropped.
  * Better handling of well-known libraries when auto-detected libraries are added, helping preserve the expected build order and library preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->