### PR TITLE
fix(http-server): validate requestTimeout so the deadline cast can't overflow

### DIFF
--- a/crates/perry-ext-http-server/src/https_server.rs
+++ b/crates/perry-ext-http-server/src/https_server.rs
@@ -30,8 +30,8 @@ use crate::request::{
 };
 use crate::response::{alloc_server_response_for_request, HyperResponseShape, ResponseBody};
 use crate::server::{
-    signal_connections_close, HttpPendingRequest, HttpServer, ReadActivity, TrackedConnection,
-    CONNECTIONS, NEXT_CONNECTION_ID, PENDING_CONNECTION_EVENTS,
+    sanitize_request_timeout, signal_connections_close, HttpPendingRequest, HttpServer,
+    ReadActivity, TrackedConnection, CONNECTIONS, NEXT_CONNECTION_ID, PENDING_CONNECTION_EVENTS,
 };
 use crate::tls::{
     build_certless_server_config, build_server_config, has_pem_material, json_value_to_pem_bytes,
@@ -651,7 +651,18 @@ https_server_setter!(
     keep_alive_timeout_buffer
 );
 https_server_getter!(js_node_https_server_request_timeout, request_timeout);
-https_server_setter!(js_node_https_server_set_request_timeout, request_timeout);
+/// `httpsServer.requestTimeout = ms` — sanitized rather than
+/// macro-generated, mirroring the HTTP setter, so the stored value
+/// stays in Node's finite/non-negative/`MAX_SAFE_INTEGER` domain and
+/// the in-flight reaper's `as u64` cast can't overflow.
+#[no_mangle]
+pub extern "C" fn js_node_https_server_set_request_timeout(handle: i64, value: f64) -> f64 {
+    let sanitized = sanitize_request_timeout(value);
+    if let Some(s) = get_handle_mut::<HttpsServer>(handle) {
+        s.base.request_timeout = sanitized;
+    }
+    value
+}
 https_server_getter!(js_node_https_server_idle_timeout, idle_timeout);
 https_server_setter!(js_node_https_server_set_idle_timeout, idle_timeout);
 https_server_getter!(js_node_https_server_max_headers_count, max_headers_count);

--- a/crates/perry-ext-http-server/src/lib.rs
+++ b/crates/perry-ext-http-server/src/lib.rs
@@ -428,4 +428,88 @@ mod tests {
         drop_handle(incoming_handle);
         drop_handle(response_handle);
     }
+
+    /// CodeRabbit (flagged on #5663) — `requestTimeout` was stored as a
+    /// raw `f64` and later cast straight to `u64` to build the in-flight
+    /// deadline.
+    /// A non-finite or oversized value produced a garbage deadline:
+    /// `Infinity as u64` saturates to `u64::MAX` (never times out),
+    /// oversized finite values likewise. Sanitizing at the setter keeps
+    /// the stored value in Node's `validateInteger(0, MAX_SAFE_INTEGER)`
+    /// domain so the downstream cast is always sound — matching the
+    /// behavior probed against Node v22 (`createServer({ requestTimeout })`
+    /// rejects non-finite/negative/oversized with `ERR_OUT_OF_RANGE`;
+    /// lacking a throw path here we coerce to the nearest in-range value).
+    #[test]
+    fn request_timeout_is_sanitized_to_a_u64_safe_ms_count() {
+        use crate::server::sanitize_request_timeout;
+
+        // Non-finite falls back to Node's 300s default rather than
+        // saturating the cast.
+        assert_eq!(sanitize_request_timeout(f64::INFINITY), 300_000.0);
+        assert_eq!(sanitize_request_timeout(f64::NEG_INFINITY), 300_000.0);
+        assert_eq!(sanitize_request_timeout(f64::NAN), 300_000.0);
+        // Negative clamps to 0 (Node's "disabled" sentinel).
+        assert_eq!(sanitize_request_timeout(-1.0), 0.0);
+        // Oversized clamps to MAX_SAFE_INTEGER (Node's `kMaxRequestTimeout`).
+        assert_eq!(sanitize_request_timeout(1e300), 9_007_199_254_740_991.0);
+        assert_eq!(
+            sanitize_request_timeout(9_007_199_254_740_992.0),
+            9_007_199_254_740_991.0
+        );
+        // Valid inputs pass through untouched (fractional truncated to ms).
+        assert_eq!(sanitize_request_timeout(0.0), 0.0);
+        assert_eq!(sanitize_request_timeout(5_000.0), 5_000.0);
+        assert_eq!(sanitize_request_timeout(300_000.0), 300_000.0);
+        assert_eq!(sanitize_request_timeout(1.9), 1.0);
+
+        // The whole point: every sanitized value is a finite, non-negative
+        // ms count whose `as u64` cast yields a real `Duration` — never the
+        // `u64::MAX` overflow the raw `Infinity` would have produced.
+        for raw in [f64::INFINITY, f64::NAN, -1.0, 1e300, 5_000.0] {
+            let ms = sanitize_request_timeout(raw);
+            assert!(ms.is_finite() && (0.0..=9_007_199_254_740_991.0).contains(&ms));
+            assert!(
+                ms as u64 != u64::MAX,
+                "raw {raw} must not saturate the cast"
+            );
+        }
+    }
+
+    /// Both setter paths — the `server.requestTimeout = x` property
+    /// (FFI) and the `createServer({ requestTimeout })` option — store a
+    /// sanitized value. Pre-fix, both stored the raw `f64` verbatim.
+    #[test]
+    fn request_timeout_setter_paths_store_sanitized_values() {
+        // Property-setter path: `Infinity` previously stored verbatim.
+        let handle = register_handle(HttpServer::with_handler(0));
+        let ret = crate::server::js_node_http_server_set_request_timeout(handle, f64::INFINITY);
+        // The setter returns the assigned value (JS `a = b` evaluates to `b`)…
+        assert!(ret.is_infinite());
+        // …but the *stored* field is sanitized to the safe default.
+        assert_eq!(
+            crate::server::js_node_http_server_request_timeout(handle),
+            300_000.0
+        );
+        crate::server::js_node_http_server_set_request_timeout(handle, 7_500.0);
+        assert_eq!(
+            crate::server::js_node_http_server_request_timeout(handle),
+            7_500.0
+        );
+        drop_handle(handle);
+
+        // Option path through `apply_server_options`.
+        let _guard = GcTestGuard::new_with_slots(1);
+        let options_json =
+            perry_ffi::alloc_string(r#"{"requestTimeout":1e300,"headersTimeout":222}"#);
+        let options_ptr = options_json.as_raw() as *const perry_runtime::StringHeader;
+        let options = unsafe { perry_runtime::json::js_json_parse(options_ptr) };
+        perry_runtime::gc::js_shadow_slot_set(0, options.bits());
+
+        let mut server = HttpServer::with_handler(0);
+        crate::server::apply_server_options(&mut server, f64::from_bits(options.bits()));
+        // Oversized `requestTimeout` clamped; unrelated knob untouched.
+        assert_eq!(server.request_timeout, 9_007_199_254_740_991.0);
+        assert_eq!(server.headers_timeout, 222.0);
+    }
 }

--- a/crates/perry-ext-http-server/src/server.rs
+++ b/crates/perry-ext-http-server/src/server.rs
@@ -372,6 +372,35 @@ pub unsafe extern "C" fn js_node_http_create_server_with_options(
     register_handle(server)
 }
 
+/// Largest `requestTimeout` Node accepts, mirroring its
+/// `kMaxRequestTimeout = MAX_SAFE_INTEGER` (`2**53 - 1`) ceiling in
+/// `lib/_http_server.js`.
+const MAX_REQUEST_TIMEOUT_MS: f64 = 9_007_199_254_740_991.0;
+
+/// Coerce a `requestTimeout` (ms) into the same finite, non-negative,
+/// integer, `MAX_SAFE_INTEGER`-bounded domain Node enforces via
+/// `validateInteger(value, 'requestTimeout', 0, kMaxRequestTimeout)`,
+/// so the value the in-flight reaper later casts to `u64` to build a
+/// `Duration` deadline can never overflow.
+///
+/// The bug this guards (CodeRabbit, #5663): an un-sanitized `f64`
+/// reaching `grace_ms as u64` produces a garbage deadline — Rust's
+/// saturating float→int cast turns `Infinity` into `u64::MAX` (a
+/// deadline that never fires) and an oversized finite value into a
+/// nonsensical one. Node rejects those at construction with
+/// `ERR_OUT_OF_RANGE`; lacking a throw path here, we coerce to the
+/// nearest in-range value instead — non-finite falls back to Node's
+/// 300s default, out-of-range clamps to `[0, MAX_SAFE_INTEGER]`, and
+/// the fractional part is truncated to an integer ms count. `0` is
+/// preserved (Node's "disabled" sentinel; the reaper maps it back to
+/// the default).
+pub(crate) fn sanitize_request_timeout(ms: f64) -> f64 {
+    if !ms.is_finite() {
+        return 300_000.0;
+    }
+    ms.trunc().clamp(0.0, MAX_REQUEST_TIMEOUT_MS)
+}
+
 /// Read each Node-documented timeout/socket knob off the options
 /// object and overwrite the server's default. Missing keys leave the
 /// default in place; non-numeric values silently no-op (matches
@@ -411,7 +440,7 @@ pub(crate) fn apply_server_options(server: &mut HttpServer, options_f64: f64) {
         server.keep_alive_timeout_buffer = v;
     }
     if let Some(v) = as_num("requestTimeout") {
-        server.request_timeout = v;
+        server.request_timeout = sanitize_request_timeout(v);
     }
     if let Some(v) = as_num("timeout") {
         server.idle_timeout = v;
@@ -485,7 +514,20 @@ server_setter!(
     keep_alive_timeout_buffer
 );
 server_getter!(js_node_http_server_request_timeout, request_timeout);
-server_setter!(js_node_http_server_set_request_timeout, request_timeout);
+/// `server.requestTimeout = ms` — sanitized rather than macro-generated
+/// so the stored value is always a finite, non-negative, integer,
+/// `MAX_SAFE_INTEGER`-bounded ms count (see `sanitize_request_timeout`).
+/// This keeps the in-flight reaper's `grace_ms as u64` cast from
+/// overflowing on `Infinity`/oversized values regardless of which
+/// setter path (constructor option or this property) wrote the field.
+#[no_mangle]
+pub extern "C" fn js_node_http_server_set_request_timeout(handle: i64, value: f64) -> f64 {
+    let sanitized = sanitize_request_timeout(value);
+    if let Some(s) = get_handle_mut::<HttpServer>(handle) {
+        s.request_timeout = sanitized;
+    }
+    value
+}
 server_getter!(js_node_http_server_idle_timeout, idle_timeout);
 server_setter!(js_node_http_server_set_idle_timeout, idle_timeout);
 server_getter!(js_node_http_server_max_headers_count, max_headers_count);


### PR DESCRIPTION
## Problem

`http.Server`'s `requestTimeout` (ms) is stored as a raw `f64` and later cast straight to `u64` (`Duration::from_millis(grace_ms as u64)`) to build the in-flight request deadline. Rust's float→int `as` cast is *saturating*, so a non-finite or oversized value produces a garbage deadline:

- `Infinity as u64` → `u64::MAX` — a deadline that never fires
- `NaN as u64` → `0` — immediate timeout
- negative → `0`
- oversized finite → a nonsensical value

No validation guards the cast. This is a pre-existing latent bug, flagged by CodeRabbit on #5663 — not introduced by that PR.

## Node's semantics (matched)

Probed on Node v22: `createServer({ requestTimeout: x })` validates via `validateInteger(value, 'requestTimeout', 0, kMaxRequestTimeout)`, where `kMaxRequestTimeout = 2**53 - 1` (`MAX_SAFE_INTEGER`). Node throws `ERR_OUT_OF_RANGE` for non-finite, non-integer, negative, or out-of-range values; `0` means "disabled."

## Fix

Sanitize at every setter path so the *stored* value is always a finite, non-negative, integer, `MAX_SAFE_INTEGER`-bounded ms count:

- non-finite → Node's 300s default
- out-of-range → clamps to `[0, 2**53-1]`
- fractional → truncated to an integer ms count

Applied at the `createServer` option path (shared by http and https) and the http/https property setters. The downstream `as u64` cast is then sound regardless of which setter wrote the field — so this PR does **not** touch the deadline-build site (avoiding overlap with the #5663 split that relocates it to `in_flight.rs`). No behavior change for valid inputs.

## Tests

Two regression tests in `perry-ext-http-server` (fail-before / pass-after):

- `request_timeout_is_sanitized_to_a_u64_safe_ms_count` — `Infinity`/`NaN`/negative/oversized map into the safe domain; valid values pass through; `as u64` never saturates to `u64::MAX`.
- `request_timeout_setter_paths_store_sanitized_values` — both the property setter and the `createServer` option store sanitized values (the property setter still returns the assigned value per JS `a = b` semantics while storing the sanitized one).

Gates: `cargo test -p perry-ext-http-server` (37 pass), `cargo fmt --check`.

Note: the `lint` (file-size) check may show red from the pre-existing `crates/perry-ext-http-server/src/server.rs` 2025-line violation (already over the 2000-line limit on `main`) that the separate #5663 split addresses — not introduced by this PR. `cargo-test` is the substantive gate.

Refs #5663


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of server request timeout values so invalid, negative, fractional, or extremely large inputs are safely normalized.
  * Ensured timeout settings from both server options and direct property updates use the same validated values.
  * Added coverage for timeout edge cases and confirmed other server options remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->