### PR TITLE
fix(regexp): #5586 — gate RegExp(re) identity shortcut on IsRegExp (@@match)

### DIFF
--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -604,6 +604,13 @@ pub extern "C" fn js_regexp_construct_call(pattern: f64, flags: f64) -> *mut Reg
     if fv.is_undefined() && pv.is_pointer() {
         let addr = pv.as_pointer::<u8>() as usize;
         if is_registered_regex(addr)
+            // IsRegExp(pattern): the shortcut is gated on `IsRegExp`, which first
+            // consults `pattern[@@match]` — a registered RegExp with an own
+            // `re[Symbol.match] = false` is NOT regexp-like and must copy
+            // (`built-ins/RegExp/call_with_regexp_match_falsy.js`). Only when
+            // `@@match` is absent does it fall back to the [[RegExpMatcher]] slot
+            // (which every registered RegExp has).
+            && regexp_pattern_is_regexp_like(pattern)
             // SameValue(RegExp, pattern.constructor): the identity shortcut only
             // applies while `constructor` is still the inherited intrinsic. An
             // own `constructor` override (the only way it can differ here) must
@@ -619,6 +626,27 @@ pub extern "C" fn js_regexp_construct_call(pattern: f64, flags: f64) -> *mut Reg
         }
     }
     js_regexp_construct(pattern, flags)
+}
+
+/// `IsRegExp(pattern)` for an already-registered RegExp header: consult an own
+/// `pattern[@@match]` override (decisive via `ToBoolean`) and only fall back to
+/// the [[RegExpMatcher]] slot — which a registered RegExp always has — when no
+/// `@@match` property is present. Used to gate the `RegExp(re)` identity
+/// shortcut so `re[Symbol.match] = false` correctly forces a fresh copy.
+#[cfg(feature = "regex-engine")]
+fn regexp_pattern_is_regexp_like(pattern: f64) -> bool {
+    let match_sym = crate::symbol::well_known_symbol("match");
+    if match_sym.is_null() {
+        return true;
+    }
+    let sym_val = f64::from_bits(crate::value::JSValue::pointer(match_sym as *const u8).bits());
+    let m = unsafe { crate::symbol::js_object_get_symbol_property(pattern, sym_val) };
+    if crate::value::JSValue::from_bits(m.to_bits()).is_undefined() {
+        // No own/inherited @@match override → registered RegExp ([[RegExpMatcher]]).
+        true
+    } else {
+        crate::value::js_is_truthy(m) != 0
+    }
 }
 
 /// Test if a string matches the regex pattern

--- a/test-files/test_issue_5586_regexp_call_identity.ts
+++ b/test-files/test_issue_5586_regexp_call_identity.ts
@@ -51,6 +51,16 @@ const tweaked = /(?:)/;
 (tweaked as any).constructor = null;
 ok("call-other-constructor-is-copy", RegExp(tweaked) !== tweaked);
 
+// The shortcut is also gated on IsRegExp, which consults `pattern[@@match]`:
+// a RegExp whose own `Symbol.match` is falsy is NOT regexp-like → fresh copy.
+const unmatched = /(?:)/;
+(unmatched as any)[Symbol.match] = false;
+ok("call-match-falsy-is-copy", RegExp(unmatched) !== unmatched);
+// A truthy `Symbol.match` override keeps it regexp-like → identity holds.
+const stillRe = /(?:)/;
+(stillRe as any)[Symbol.match] = true;
+ok("call-match-truthy-is-identity", RegExp(stillRe) === stillRe);
+
 // The copy is independent: mutating lastIndex on one must not affect the other.
 const g = /a/g;
 const gCopy = new RegExp(g);


### PR DESCRIPTION
## Summary

Follow-up to #5647 (which landed the core `RegExp(re)` object-identity fix for #5586). That implementation short-circuits to identity for any registered RegExp with `undefined` flags and no own `constructor` override — but it skips ECMA-262 22.2.4.1 **step 1, `IsRegExp(pattern)`**, which first consults `pattern[@@match]`. When `@@match` is present it is decisive (`ToBoolean`); only when absent does it fall back to the `[[RegExpMatcher]]` slot.

So on current `main`, a registered RegExp with an own `re[Symbol.match] = false` is wrongly returned **unchanged** instead of copied — `built-ins/RegExp/call_with_regexp_match_falsy.js` fails (Node returns a new object).

## Change

- Add `regexp_pattern_is_regexp_like(pattern)`: reads `pattern[@@match]`, returns `ToBoolean` when present, else `true` (the registered RegExp's `[[RegExpMatcher]]`).
- Require it in `js_regexp_construct_call` alongside the existing undefined-flags and own-`constructor` guards before short-circuiting to identity.

A falsy `@@match` override now forces a fresh copy; a truthy one keeps the object regexp-like and identity holds.

## Validation

- `built-ins/RegExp/call_with_regexp_match_falsy.js` now agrees with Node (was failing on `main`).
- No regressions: `call_with_regexp_not_same_constructor` and the whole `S15.10.3.1_A1` identity family still agree.
- `test-files/test_issue_5586_regexp_call_identity.ts` extended with both `@@match` directions; byte-for-byte match with `node --experimental-strip-types`.

> Per the request, no version bump / CHANGELOG entry — left for the maintainer at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `RegExp(...)` behavior for existing regular expression objects so identity is only preserved when the object is actually regex-like.
  * Adjusted handling of `Symbol.match` so falsy values create a new regular expression copy, while truthy values continue to return the original object.

* **Tests**
  * Added coverage for `RegExp` call-identity behavior with truthy and falsy `Symbol.match` values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->