### PR TITLE
fix(runtime): #5587 — subclassing a Temporal.<Type> gives the instance the Temporal brand

### DIFF
--- a/crates/perry-runtime/src/object/class_constructors.rs
+++ b/crates/perry-runtime/src/object/class_constructors.rs
@@ -279,6 +279,35 @@ pub unsafe extern "C" fn js_super_construct_apply(
         cur = next;
         depth += 1;
     }
+    // No registered Perry ancestor constructor. A `class X extends
+    // Temporal.<Type>` heritage records its parent VALUE (the Temporal ctor
+    // closure) at decl time but no class-id edge, so the walk above finds
+    // nothing. Recover that value and, if it is a Temporal constructor, run it
+    // and stash the returned cell as the subclass instance's brand — the
+    // `super(...spread)` counterpart of the `js_fetch_or_value_super` branch
+    // that handles non-spread `super(a, b)`. (#5587)
+    #[cfg(feature = "temporal")]
+    {
+        let parent_val = crate::object::class_registry::js_get_dynamic_parent_value(child_cid);
+        if crate::object::global_this::temporal_ctor_kind(parent_val).is_some() {
+            let this_box = crate::value::js_nanbox_pointer(this_raw);
+            let n = if arr.is_null() {
+                0
+            } else {
+                crate::array::js_array_length(arr)
+            } as usize;
+            let mut flat: Vec<f64> = Vec::with_capacity(n);
+            for i in 0..n {
+                flat.push(crate::array::js_array_get_f64(arr, i as u32));
+            }
+            crate::object::global_this::temporal_subclass_super(
+                parent_val,
+                this_box,
+                flat.as_ptr(),
+                flat.len(),
+            );
+        }
+    }
     undef
 }
 

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -46,6 +46,49 @@ pub(crate) unsafe fn fetch_subclass_handle_id(obj: usize) -> Option<i64> {
     }
 }
 
+/// Hidden own-field name under which a `class X extends Temporal.<Type>`
+/// instance stashes the NaN-boxed pointer to its underlying Temporal cell.
+/// Written by `js_fetch_or_value_super` (the runtime-value super dispatcher,
+/// global_this/fetch_globals.rs) when the resolved parent is a Temporal
+/// constructor; read here (getter forward), in `native_call_method.rs`
+/// (method forward), and in `instanceof.rs`. A Temporal value is a NaN-boxed
+/// cell that dispatches via brand arms, not a JS prototype chain, so a subclass
+/// instance (a plain heap object) can only reach its members through this
+/// stashed cell. Stored as a real pointer-valued field so GC keeps the cell
+/// alive and rewrites the slot on evacuation. (#5587)
+#[cfg(feature = "temporal")]
+pub(crate) const TEMPORAL_SUBCLASS_CELL_FIELD: &[u8] = b"__perry_temporal_cell__";
+
+/// If `obj` (a raw heap object address) is a `class X extends Temporal.<Type>`
+/// instance, return the NaN-boxed value of its stashed Temporal cell. Returns
+/// `None` for any non-object / non-subclass receiver (so callers fall through
+/// to their normal dispatch unchanged) or if the stashed value is somehow no
+/// longer a live Temporal cell.
+#[cfg(feature = "temporal")]
+pub(crate) unsafe fn temporal_subclass_cell(obj: usize) -> Option<f64> {
+    if obj < crate::gc::GC_HEADER_SIZE + 0x1000 || !is_valid_obj_ptr(obj as *const u8) {
+        return None;
+    }
+    let gc_header = (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+    if (*gc_header).obj_type != crate::gc::GC_TYPE_OBJECT {
+        return None;
+    }
+    let key = crate::string::js_string_from_bytes(
+        TEMPORAL_SUBCLASS_CELL_FIELD.as_ptr(),
+        TEMPORAL_SUBCLASS_CELL_FIELD.len() as u32,
+    );
+    let v = js_object_get_field_by_name(obj as *const ObjectHeader, key);
+    if v.is_undefined() {
+        return None;
+    }
+    let boxed = f64::from_bits(v.bits());
+    if crate::temporal::is_temporal_value(boxed) {
+        Some(boxed)
+    } else {
+        None
+    }
+}
+
 /// The Web-Fetch body-reading methods (`text`/`json`/`arrayBuffer`/`blob`/
 /// `bytes`/`formData`/`clone`). On a `class X extends Request/Response`
 /// instance these live on the underlying native handle, not the JS prototype

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -400,6 +400,28 @@ pub extern "C" fn js_object_get_field_by_name(
                     if let Some(v) = crate::temporal::dispatch::get_property(boxed, &name) {
                         return JSValue::from_bits(v.to_bits());
                     }
+                    // A prototype METHOD read as a value (`d.abs`, not `d.abs()`):
+                    // return a bound method that re-dispatches through
+                    // `js_native_call_method`. Needed because codegen lowers a
+                    // spread/dynamic call `d[m](...args)` to a property read + apply,
+                    // so the read must yield a callable. Only bind genuine method
+                    // names so an unknown property still reads as `undefined`. (#5587)
+                    if crate::temporal::dispatch::has_method(boxed, &name) {
+                        let heap_name = {
+                            let layout =
+                                std::alloc::Layout::from_size_align(key_bytes.len().max(1), 1)
+                                    .unwrap();
+                            let ptr = std::alloc::alloc(layout);
+                            std::ptr::copy_nonoverlapping(
+                                key_bytes.as_ptr(),
+                                ptr,
+                                key_bytes.len(),
+                            );
+                            ptr
+                        };
+                        let bound = js_class_method_bind(boxed, heap_name, key_bytes.len());
+                        return JSValue::from_bits(bound.to_bits());
+                    }
                 }
             }
             return JSValue::undefined();

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -412,11 +412,7 @@ pub extern "C" fn js_object_get_field_by_name(
                                 std::alloc::Layout::from_size_align(key_bytes.len().max(1), 1)
                                     .unwrap();
                             let ptr = std::alloc::alloc(layout);
-                            std::ptr::copy_nonoverlapping(
-                                key_bytes.as_ptr(),
-                                ptr,
-                                key_bytes.len(),
-                            );
+                            std::ptr::copy_nonoverlapping(key_bytes.as_ptr(), ptr, key_bytes.len());
                             ptr
                         };
                         let bound = js_class_method_bind(boxed, heap_name, key_bytes.len());

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
@@ -1857,6 +1857,44 @@ pub(crate) fn get_field_by_name_object_tail(
             }
         }
 
+        // `class X extends Temporal.<Type>`: inherited accessor getters
+        // (`days`/`years`/`epochNanoseconds`/…) resolve via the Temporal brand on
+        // the underlying cell, not the JS prototype chain. Forward the read to
+        // the stashed cell when this object has one. Skip BOTH the temporal and
+        // fetch marker keys: reading a marker here would re-enter this tail and
+        // (cross-) trigger the other marker's reader, an infinite recursion that
+        // stack-overflows. Methods read as fused `inst.m(...)` calls are handled
+        // in `native_call_method.rs`. (#5587)
+        #[cfg(feature = "temporal")]
+        if !key.is_null()
+            && key_bytes != crate::object::TEMPORAL_SUBCLASS_CELL_FIELD
+            && key_bytes != FETCH_SUBCLASS_HANDLE_FIELD
+        {
+            if let Some(cell) = crate::object::temporal_subclass_cell(obj as usize) {
+                let name = String::from_utf8_lossy(key_bytes);
+                if let Some(v) = crate::temporal::dispatch::get_property(cell, &name) {
+                    return JSValue::from_bits(v.to_bits());
+                }
+                // A prototype METHOD read as a value (`sub.abs`, not `sub.abs()`):
+                // return a bound method that re-dispatches through
+                // `js_native_call_method` (whose Temporal-subclass arm forwards to
+                // the cell). Only bind genuine method names so an unknown property
+                // still reads as `undefined`. Mirrors the fetch body-method bind.
+                if crate::temporal::dispatch::has_method(cell, &name) {
+                    let this_f64 = crate::value::js_nanbox_pointer(obj as i64);
+                    let heap_name = {
+                        let layout =
+                            std::alloc::Layout::from_size_align(key_bytes.len().max(1), 1).unwrap();
+                        let ptr = std::alloc::alloc(layout);
+                        std::ptr::copy_nonoverlapping(key_bytes.as_ptr(), ptr, key_bytes.len());
+                        ptr
+                    };
+                    let bound = js_class_method_bind(this_f64, heap_name, key_bytes.len());
+                    return JSValue::from_bits(bound.to_bits());
+                }
+            }
+        }
+
         // Key not found
         JSValue::undefined()
     }

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -91,6 +91,8 @@ pub(crate) use fetch_globals::{
     global_this_response_json_thunk, global_this_response_redirect_thunk,
     global_this_response_thunk,
 };
+#[cfg(feature = "temporal")]
+pub(crate) use fetch_globals::temporal_subclass_super;
 pub use fetch_globals::{
     js_fetch_or_value_super, js_get_global_this, js_global_or_console_property_by_name,
     js_module_top_this, js_request_subclass_init, js_response_subclass_init,
@@ -114,6 +116,8 @@ pub(crate) use install_static::{
 #[cfg(feature = "temporal")]
 pub(crate) use math_temporal::install_temporal_namespace;
 pub(crate) use math_temporal::{install_math_namespace, temporal_ctor_kind};
+#[cfg(feature = "temporal")]
+pub(crate) use math_temporal::temporal_kind_prototype;
 pub(crate) use populate::{
     default_prepare_stack_trace_func_ptr, populate_global_this_builtins, ERROR_CONSTRUCTOR_PTR,
 };

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -84,6 +84,8 @@ pub(crate) use ctor_thunks::{
     webcrypto_illegal_constructor_thunk, webcrypto_method_value, webcrypto_random_uuid_thunk,
     webcrypto_subtle_getter_thunk,
 };
+#[cfg(feature = "temporal")]
+pub(crate) use fetch_globals::temporal_subclass_super;
 pub(crate) use fetch_globals::{
     attach_fetch_handle_for_construction, global_this_blob_thunk, global_this_builtin_noop_thunk,
     global_this_date_thunk, global_this_eval_thunk, global_this_file_thunk,
@@ -91,8 +93,6 @@ pub(crate) use fetch_globals::{
     global_this_response_json_thunk, global_this_response_redirect_thunk,
     global_this_response_thunk,
 };
-#[cfg(feature = "temporal")]
-pub(crate) use fetch_globals::temporal_subclass_super;
 pub use fetch_globals::{
     js_fetch_or_value_super, js_get_global_this, js_global_or_console_property_by_name,
     js_module_top_this, js_request_subclass_init, js_response_subclass_init,
@@ -115,9 +115,9 @@ pub(crate) use install_static::{
 };
 #[cfg(feature = "temporal")]
 pub(crate) use math_temporal::install_temporal_namespace;
-pub(crate) use math_temporal::{install_math_namespace, temporal_ctor_kind};
 #[cfg(feature = "temporal")]
 pub(crate) use math_temporal::temporal_kind_prototype;
+pub(crate) use math_temporal::{install_math_namespace, temporal_ctor_kind};
 pub(crate) use populate::{
     default_prepare_stack_trace_func_ptr, populate_global_this_builtins, ERROR_CONSTRUCTOR_PTR,
 };

--- a/crates/perry-runtime/src/object/global_this/fetch_globals.rs
+++ b/crates/perry-runtime/src/object/global_this/fetch_globals.rs
@@ -480,9 +480,26 @@ pub unsafe extern "C" fn js_fetch_or_value_super(
     // leave the subclass instance an empty object with no Temporal brand. Stash
     // the cell on `this` instead. The native ctor never calls the subclass
     // constructor, so `called`-counter invariants hold. (#5587)
+    //
+    // `parent_val` can arrive stale/undefined for an aliased heritage
+    // (`const D = Temporal.Duration; class X extends D`) when codegen re-evaluates
+    // the extends expression in constructor scope — exactly the case the
+    // Request/Response branch below recovers via the decl-time stash. Mirror that:
+    // when the immediate value isn't a Temporal ctor, fall back to the parent
+    // value recorded against this instance's class id at declaration time.
     #[cfg(feature = "temporal")]
-    if temporal_subclass_super(parent_val, this_box, args_ptr, args_len) {
-        return undef;
+    {
+        let temporal_parent = if super::temporal_ctor_kind(parent_val).is_some() {
+            parent_val
+        } else if let Some(obj) = subclass_this_object_ptr(this_box) {
+            let cid = crate::object::js_object_get_class_id(obj);
+            crate::object::class_registry::js_get_dynamic_parent_value(cid)
+        } else {
+            parent_val
+        };
+        if temporal_subclass_super(temporal_parent, this_box, args_ptr, args_len) {
+            return undef;
+        }
     }
     // Resolve the parent constructor kind from the value first. When the
     // `extends` expression is an alias of `global.Request`/`global.Response`

--- a/crates/perry-runtime/src/object/global_this/fetch_globals.rs
+++ b/crates/perry-runtime/src/object/global_this/fetch_globals.rs
@@ -342,6 +342,57 @@ unsafe fn attach_fetch_handle_to_this(this_box: f64, handle_box: f64) {
     }
 }
 
+/// Stash the NaN-boxed Temporal cell (`cell_box`, what a `Temporal.<Type>`
+/// constructor thunk returns) on a `class X extends Temporal.<Type>` subclass
+/// instance's `this` under `__perry_temporal_cell__`. Stored as a real
+/// pointer-valued field so method/getter/instanceof dispatch can recover the
+/// cell (`temporal_subclass_cell`) and GC keeps it alive. (#5587)
+#[cfg(feature = "temporal")]
+unsafe fn attach_temporal_cell_to_this(this_box: f64, cell_box: f64) {
+    if let Some(obj) = subclass_this_object_ptr(this_box) {
+        let key = crate::string::js_string_from_bytes(
+            crate::object::TEMPORAL_SUBCLASS_CELL_FIELD.as_ptr(),
+            crate::object::TEMPORAL_SUBCLASS_CELL_FIELD.len() as u32,
+        );
+        crate::object::js_object_set_field_by_name(obj, key, cell_box);
+    }
+}
+
+/// `class X extends Temporal.<Type>` super-call handling, shared by the two
+/// `super()` lowerings: the flat-arg runtime-value dispatcher
+/// (`js_fetch_or_value_super`, the non-spread `super(a, b)` path) and the
+/// args-array `js_super_construct_apply` (the `super(...spread)` path). When
+/// `parent_val` is a Temporal constructor, run it (Temporal ctors return a
+/// fresh cell and never mutate the implicit `this`) and stash the returned cell
+/// on `this_box` so method / getter / instanceof dispatch can recover the
+/// Temporal brand. Returns `true` when handled. (#5587)
+#[cfg(feature = "temporal")]
+pub(crate) unsafe fn temporal_subclass_super(
+    parent_val: f64,
+    this_box: f64,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> bool {
+    if super::temporal_ctor_kind(parent_val).is_none() {
+        return false;
+    }
+    // Several Temporal constructors (`PlainDate`/`PlainTime`/`Instant`/…) are
+    // `[[Construct]]`-only and throw "requires 'new'" when `new.target` is
+    // undefined. Invoking the parent here IS a construct, so set `new.target`
+    // to the parent ctor for the duration of the call (the cell it returns is
+    // re-homed onto the subclass `this`; the exact new.target identity is not
+    // observable to these native ctors beyond being defined). Restore after.
+    let prev_this = crate::object::js_implicit_this_set(this_box);
+    let prev_nt = crate::object::js_new_target_set(parent_val);
+    let cell = crate::closure::js_native_call_value(parent_val, args_ptr, args_len);
+    crate::object::js_new_target_set(prev_nt);
+    crate::object::js_implicit_this_set(prev_this);
+    if crate::temporal::is_temporal_value(cell) {
+        attach_temporal_cell_to_this(this_box, cell);
+    }
+    true
+}
+
 /// Attach a native fetch handle to a freshly dynamically-constructed
 /// Request/Response subclass instance, building it from the `new` arguments.
 /// `kind` is 1 (Request) or 2 (Response). Used by the runtime
@@ -423,6 +474,16 @@ pub unsafe extern "C" fn js_fetch_or_value_super(
     args_len: usize,
 ) -> f64 {
     let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+    // `class X extends Temporal.<Type>` (non-spread `super(a, b)`): a Temporal
+    // constructor returns a fresh NaN-boxed cell and does NOT mutate the
+    // implicit `this`, so the ordinary dispatch below would drop that cell and
+    // leave the subclass instance an empty object with no Temporal brand. Stash
+    // the cell on `this` instead. The native ctor never calls the subclass
+    // constructor, so `called`-counter invariants hold. (#5587)
+    #[cfg(feature = "temporal")]
+    if temporal_subclass_super(parent_val, this_box, args_ptr, args_len) {
+        return undef;
+    }
     // Resolve the parent constructor kind from the value first. When the
     // `extends` expression is an alias of `global.Request`/`global.Response`
     // (`@hono/node-server`'s `class Request extends GlobalRequest`), the alias

--- a/crates/perry-runtime/src/object/global_this/math_temporal.rs
+++ b/crates/perry-runtime/src/object/global_this/math_temporal.rs
@@ -825,6 +825,49 @@ pub(crate) fn temporal_ctor_kind(_type_ref: f64) -> Option<crate::temporal::Temp
     None
 }
 
+/// Resolve `Temporal.<kind>.prototype` for a Temporal value's `kind` by
+/// navigating the live `globalThis.Temporal.<Name>.prototype` chain (the
+/// prototype object is stamped on each constructor closure's `prototype`
+/// dynamic prop at namespace-install time). Returns `undefined` if the
+/// namespace isn't reachable. Used by `Object.getPrototypeOf` on a Temporal
+/// cell — which has no `[[Prototype]]` link of its own (it dispatches via brand
+/// arms) but whose reflective prototype IS `Temporal.<Type>.prototype`. (#5587)
+#[cfg(feature = "temporal")]
+pub(crate) fn temporal_kind_prototype(kind: crate::temporal::TemporalKind) -> f64 {
+    use crate::temporal::TemporalKind::*;
+    let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+    let name: &[u8] = match kind {
+        Duration => b"Duration",
+        Instant => b"Instant",
+        PlainDate => b"PlainDate",
+        PlainTime => b"PlainTime",
+        PlainDateTime => b"PlainDateTime",
+        PlainYearMonth => b"PlainYearMonth",
+        PlainMonthDay => b"PlainMonthDay",
+        ZonedDateTime => b"ZonedDateTime",
+    };
+    let g = super::js_get_global_this();
+    let gp = (g.to_bits() & crate::value::POINTER_MASK) as *const ObjectHeader;
+    if gp.is_null() {
+        return undef;
+    }
+    let tkey = crate::string::js_string_from_bytes(b"Temporal".as_ptr(), 8);
+    let temporal = js_object_get_field_by_name(gp, tkey);
+    if !temporal.is_pointer() {
+        return undef;
+    }
+    let tp = (temporal.bits() & crate::value::POINTER_MASK) as *const ObjectHeader;
+    let ckey = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    let ctor = js_object_get_field_by_name(tp, ckey);
+    if !ctor.is_pointer() {
+        return undef;
+    }
+    let cp = (ctor.bits() & crate::value::POINTER_MASK) as *const ObjectHeader;
+    let pkey = crate::string::js_string_from_bytes(b"prototype".as_ptr(), 9);
+    let proto = js_object_get_field_by_name(cp, pkey);
+    f64::from_bits(proto.bits())
+}
+
 /// `Temporal.PlainDate.prototype` accessor getters and method shapes (#4691).
 #[cfg(feature = "temporal")]
 const PLAIN_DATE_GETTERS: &[&str] = &[

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -115,12 +115,21 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
         // `class X extends Temporal.<Type>` instance: a plain heap object whose
         // [[Prototype]] chain reaches `Temporal.<Type>.prototype`. It carries
         // the brand via a stashed cell rather than the Temporal-cell tag, so
-        // recover that cell and compare its kind. (#5587)
+        // recover that cell and compare its kind. The receiver reaches here both
+        // NaN-boxed (top16 == 0x7FFD) and as a raw-I64 heap pointer (top16 == 0,
+        // how module-level object vars are stored) — accept both. (#5587)
         #[cfg(feature = "temporal")]
         {
             let bits = value.to_bits();
-            if (bits >> 48) == 0x7FFD {
-                let raw = (bits & crate::value::POINTER_MASK) as usize;
+            let top16 = bits >> 48;
+            let raw = if top16 == 0x7FFD {
+                (bits & crate::value::POINTER_MASK) as usize
+            } else if top16 == 0 {
+                bits as usize
+            } else {
+                0
+            };
+            if raw != 0 {
                 if let Some(cell) = unsafe { crate::object::temporal_subclass_cell(raw) } {
                     if crate::temporal::temporal_kind(cell) == Some(kind) {
                         return f64::from_bits(crate::value::TAG_TRUE);

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -109,11 +109,26 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
     // its kind and compare against the value's brand. A non-Temporal value, or
     // a Temporal value of a different kind, yields `false`.
     if let Some(kind) = super::global_this::temporal_ctor_kind(type_ref) {
-        return if crate::temporal::temporal_kind(value) == Some(kind) {
-            f64::from_bits(crate::value::TAG_TRUE)
-        } else {
-            f64::from_bits(TAG_FALSE)
-        };
+        if crate::temporal::temporal_kind(value) == Some(kind) {
+            return f64::from_bits(crate::value::TAG_TRUE);
+        }
+        // `class X extends Temporal.<Type>` instance: a plain heap object whose
+        // [[Prototype]] chain reaches `Temporal.<Type>.prototype`. It carries
+        // the brand via a stashed cell rather than the Temporal-cell tag, so
+        // recover that cell and compare its kind. (#5587)
+        #[cfg(feature = "temporal")]
+        {
+            let bits = value.to_bits();
+            if (bits >> 48) == 0x7FFD {
+                let raw = (bits & crate::value::POINTER_MASK) as usize;
+                if let Some(cell) = unsafe { crate::object::temporal_subclass_cell(raw) } {
+                    if crate::temporal::temporal_kind(cell) == Some(kind) {
+                        return f64::from_bits(crate::value::TAG_TRUE);
+                    }
+                }
+            }
+        }
+        return f64::from_bits(TAG_FALSE);
     }
     let bits = type_ref.to_bits();
     let top16 = bits >> 48;

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1329,6 +1329,21 @@ pub unsafe extern "C" fn js_native_call_method(
         }
     }
 
+    // `class X extends Temporal.<Type>`: the prototype methods (`add`/`abs`/
+    // `toString`/…) dispatch via the Temporal brand on the underlying cell, not
+    // the JS prototype chain. All user-defined dispatch (own fields, vtable,
+    // prototype walk) has missed by here, so a subclass override still wins;
+    // only genuinely inherited Temporal methods reach this forward. Route them
+    // to the stashed cell (`temporal_subclass_cell`). (#5587)
+    #[cfg(feature = "temporal")]
+    if jsval.is_pointer() {
+        let raw = crate::value::js_nanbox_get_pointer(object) as usize;
+        if let Some(cell) = crate::object::temporal_subclass_cell(raw) {
+            let args = refreshed_args();
+            return crate::temporal::dispatch::call_method(cell, method_name, &args);
+        }
+    }
+
     // #4973: inherits-pattern instances (`http.Server.call(this, …)`) forward
     // method calls that missed every user-defined dispatch layer (own fields,
     // vtable, prototype walk) to their aliased native handle, so

--- a/crates/perry-runtime/src/object/object_ops/prototype.rs
+++ b/crates/perry-runtime/src/object/object_ops/prototype.rs
@@ -135,11 +135,19 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
     }
     // A Temporal value is a NaN-boxed opaque cell, not an `ObjectHeader` — the
     // heap-object resolution below would deref its boxed payload as a class id
-    // and crash. The reflective prototype is reachable directly as
-    // `Temporal.<Type>.prototype`, so for a cell receiver return `null` rather
-    // than faulting on the cell.
+    // and crash. Its reflective prototype IS `Temporal.<Type>.prototype`, and
+    // `assert.sameValue(Object.getPrototypeOf(result), construct.prototype)`
+    // (the test262 subclassing-ignored shape) requires that object, not `null`.
+    // Resolve it via the live namespace; fall back to `null` only if Temporal
+    // isn't reachable. (#5587)
     #[cfg(feature = "temporal")]
     if crate::temporal::is_temporal_value(obj_value) {
+        if let Some(kind) = crate::temporal::temporal_kind(obj_value) {
+            let proto = crate::object::global_this::temporal_kind_prototype(kind);
+            if crate::value::JSValue::from_bits(proto.to_bits()).is_pointer() {
+                return proto;
+            }
+        }
         return f64::from_bits(TAG_NULL);
     }
     // ES2015 ToObject(primitive): `Object.getPrototypeOf(0 | "s" | true |

--- a/crates/perry-runtime/src/temporal/dispatch.rs
+++ b/crates/perry-runtime/src/temporal/dispatch.rs
@@ -285,6 +285,88 @@ pub fn get_property(recv: f64, name: &str) -> Option<f64> {
     }
 }
 
+/// Whether `name` is an instance method of the Temporal value `recv`. Used by
+/// the `class X extends Temporal.<Type>` subclass getter forward to decide
+/// whether a non-getter property read should resolve to a (bound) callable
+/// instead of `undefined` — so `subInstance.abs` reads as a function, not just
+/// `subInstance.abs()` / `subInstance[name]()` dispatching. The name sets
+/// mirror each type's `call()` match arms (the authoritative dispatch). (#5587)
+pub fn has_method(recv: f64, name: &str) -> bool {
+    // Methods shared by (nearly) every Temporal type.
+    const COMMON: &[&str] = &["toString", "toJSON", "toLocaleString", "valueOf"];
+    if COMMON.contains(&name) {
+        return matches!(temporal_value_ref(recv), Some(_));
+    }
+    let names: &[&str] = match temporal_value_ref(recv) {
+        Some(TemporalValue::Duration(_)) => {
+            &["with", "negated", "abs", "add", "subtract", "round", "total"]
+        }
+        Some(TemporalValue::Instant(_)) => &[
+            "add",
+            "subtract",
+            "until",
+            "since",
+            "round",
+            "equals",
+            "toZonedDateTimeISO",
+        ],
+        Some(TemporalValue::PlainDate(_)) => &[
+            "add",
+            "subtract",
+            "until",
+            "since",
+            "equals",
+            "with",
+            "withCalendar",
+            "toPlainDateTime",
+            "toPlainMonthDay",
+            "toPlainYearMonth",
+            "toZonedDateTime",
+        ],
+        Some(TemporalValue::PlainTime(_)) => {
+            &["add", "subtract", "until", "since", "round", "equals", "with"]
+        }
+        Some(TemporalValue::PlainDateTime(_)) => &[
+            "add",
+            "subtract",
+            "until",
+            "since",
+            "round",
+            "equals",
+            "with",
+            "withCalendar",
+            "withPlainTime",
+            "toPlainDate",
+            "toPlainTime",
+            "toZonedDateTime",
+        ],
+        Some(TemporalValue::PlainYearMonth(_)) => {
+            &["add", "subtract", "until", "since", "equals", "with", "toPlainDate"]
+        }
+        Some(TemporalValue::PlainMonthDay(_)) => &["equals", "with", "toPlainDate"],
+        Some(TemporalValue::ZonedDateTime(_)) => &[
+            "add",
+            "subtract",
+            "until",
+            "since",
+            "round",
+            "equals",
+            "with",
+            "withCalendar",
+            "withPlainTime",
+            "withTimeZone",
+            "startOfDay",
+            "getTimeZoneTransition",
+            "toInstant",
+            "toPlainDate",
+            "toPlainTime",
+            "toPlainDateTime",
+        ],
+        None => return false,
+    };
+    names.contains(&name)
+}
+
 /// Dispatch an instance method (`duration.add(x)`, `instant.toString()`, …).
 /// The caller has already brand-checked `recv` as a Temporal value, so an
 /// unknown method name throws `TypeError` rather than returning `None`.

--- a/crates/perry-runtime/src/temporal/dispatch.rs
+++ b/crates/perry-runtime/src/temporal/dispatch.rs
@@ -295,12 +295,12 @@ pub fn has_method(recv: f64, name: &str) -> bool {
     // Methods shared by (nearly) every Temporal type.
     const COMMON: &[&str] = &["toString", "toJSON", "toLocaleString", "valueOf"];
     if COMMON.contains(&name) {
-        return matches!(temporal_value_ref(recv), Some(_));
+        return temporal_value_ref(recv).is_some();
     }
     let names: &[&str] = match temporal_value_ref(recv) {
-        Some(TemporalValue::Duration(_)) => {
-            &["with", "negated", "abs", "add", "subtract", "round", "total"]
-        }
+        Some(TemporalValue::Duration(_)) => &[
+            "with", "negated", "abs", "add", "subtract", "round", "total",
+        ],
         Some(TemporalValue::Instant(_)) => &[
             "add",
             "subtract",
@@ -323,9 +323,9 @@ pub fn has_method(recv: f64, name: &str) -> bool {
             "toPlainYearMonth",
             "toZonedDateTime",
         ],
-        Some(TemporalValue::PlainTime(_)) => {
-            &["add", "subtract", "until", "since", "round", "equals", "with"]
-        }
+        Some(TemporalValue::PlainTime(_)) => &[
+            "add", "subtract", "until", "since", "round", "equals", "with",
+        ],
         Some(TemporalValue::PlainDateTime(_)) => &[
             "add",
             "subtract",
@@ -340,9 +340,15 @@ pub fn has_method(recv: f64, name: &str) -> bool {
             "toPlainTime",
             "toZonedDateTime",
         ],
-        Some(TemporalValue::PlainYearMonth(_)) => {
-            &["add", "subtract", "until", "since", "equals", "with", "toPlainDate"]
-        }
+        Some(TemporalValue::PlainYearMonth(_)) => &[
+            "add",
+            "subtract",
+            "until",
+            "since",
+            "equals",
+            "with",
+            "toPlainDate",
+        ],
         Some(TemporalValue::PlainMonthDay(_)) => &["equals", "with", "toPlainDate"],
         Some(TemporalValue::ZonedDateTime(_)) => &[
             "add",

--- a/crates/perry/tests/issue_5587_temporal_subclass.rs
+++ b/crates/perry/tests/issue_5587_temporal_subclass.rs
@@ -1,0 +1,159 @@
+//! Regression test for #5587: subclassing a `Temporal.<Type>` constructor must
+//! produce an instance that carries the Temporal brand, so the inherited
+//! prototype methods / accessor getters dispatch and `instanceof` resolves.
+//!
+//! This is the dominant failure mode behind the test262
+//! `built-ins/Temporal/**/subclassing-ignored.js` cluster, whose
+//! `TemporalHelpers.checkSubclassingIgnored` helper does:
+//! ```js
+//! class MySubclass extends construct { constructor() { super(...args); } }
+//! const instance = new MySubclass();
+//! const result = instance[method](...methodArgs);   // <- threw pre-fix
+//! assert.sameValue(Object.getPrototypeOf(result), construct.prototype);
+//! ```
+//!
+//! Pre-fix, `super(...)` to a native Temporal constructor went through
+//! `js_fetch_or_value_super`'s generic implicit-`this`-bound dispatch, which
+//! ran the native ctor (returning a fresh Temporal cell) but DISCARDED that
+//! cell — leaving the subclass instance an empty plain object with no brand. So
+//! `instance.abs()` resolved `abs` to `undefined` and threw
+//! `TypeError: value is not a function`.
+//!
+//! Fix (perry-runtime): `js_fetch_or_value_super` now detects a Temporal parent
+//! constructor, runs it, and stashes the returned cell on `this` under
+//! `__perry_temporal_cell__`; method-call / getter / instanceof dispatch
+//! recover the cell from there.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed (pre-fix: 'TypeError: value is not a \
+         function')\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+#[test]
+fn temporal_duration_subclass_dispatches_and_ignores_subclassing() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const constructArgs = [0, 0, 0, -4, -5, -6, -7, -987, -654, -321];
+
+// Mirror TemporalHelpers.checkSubclassingIgnored's MySubclass shape.
+let called = 0;
+class MySubclass extends Temporal.Duration {
+  constructor() {
+    ++called;
+    super(...constructArgs);
+  }
+}
+
+const instance = new MySubclass();
+console.log("called:", called);                       // 1
+console.log("instanceof:", instance instanceof Temporal.Duration);  // true
+console.log("days:", (instance as any).days);         // -4 (inherited getter)
+
+// The method under test returns a BASE Temporal.Duration, never a subclass.
+const result = (instance as any).abs();
+console.log("result-proto:",
+  Object.getPrototypeOf(result) === Temporal.Duration.prototype);   // true
+console.log("result-not-sub:",
+  Object.getPrototypeOf(result) !== MySubclass.prototype);          // true
+console.log("abs-days:", result.days);                // 4
+console.log("abs-str:", result.toString());           // P4DT5H6M7.987654321S
+
+// Computed-key method call (the helper uses instance[method](...)).
+const m = "negated";
+const neg = (instance as any)[m]();
+console.log("neg-days:", neg.days);                   // 4
+
+// The subclass constructor is called exactly once across all of the above.
+console.log("called-final:", called);                 // 1
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "called: 1\n\
+         instanceof: true\n\
+         days: -4\n\
+         result-proto: true\n\
+         result-not-sub: true\n\
+         abs-days: 4\n\
+         abs-str: P4DT5H6M7.987654321S\n\
+         neg-days: 4\n\
+         called-final: 1\n"
+    );
+}
+
+#[test]
+fn temporal_plain_date_subclass_dispatches() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+class MyDate extends Temporal.PlainDate {
+  constructor() {
+    super(2021, 7, 20);
+  }
+}
+
+const d = new MyDate();
+console.log("instanceof:", d instanceof Temporal.PlainDate);   // true
+console.log("year:", (d as any).year);                         // 2021
+console.log("month:", (d as any).month);                       // 7
+console.log("day:", (d as any).day);                           // 20
+
+// add() returns a base PlainDate, not the subclass.
+const later = (d as any).add({ days: 12 });
+console.log("add-proto:",
+  Object.getPrototypeOf(later) === Temporal.PlainDate.prototype);  // true
+console.log("add-day:", later.day);                            // 1 (Aug 1)
+console.log("add-month:", later.month);                        // 8
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "instanceof: true\n\
+         year: 2021\n\
+         month: 7\n\
+         day: 20\n\
+         add-proto: true\n\
+         add-day: 1\n\
+         add-month: 8\n"
+    );
+}

--- a/crates/perry/tests/issue_5587_temporal_subclass.rs
+++ b/crates/perry/tests/issue_5587_temporal_subclass.rs
@@ -121,6 +121,36 @@ console.log("called-final:", called);                 // 1
 }
 
 #[test]
+fn temporal_duration_subclass_via_aliased_heritage() {
+    // `class X extends D` where `D` is an alias of `Temporal.Duration`. The
+    // non-spread `super(...)` path must recover the Temporal parent even when the
+    // immediate heritage value arrives stale, via the decl-time parent stash.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const D = Temporal.Duration;
+class X extends D {
+  constructor() {
+    super(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+  }
+}
+const x = new X();
+console.log("instanceof:", x instanceof Temporal.Duration);   // true
+console.log("days:", (x as any).days);                        // 4
+console.log("abs-proto:",
+  Object.getPrototypeOf((x as any).abs()) === Temporal.Duration.prototype);  // true
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "instanceof: true\n\
+         days: 4\n\
+         abs-proto: true\n"
+    );
+}
+
+#[test]
 fn temporal_plain_date_subclass_dispatches() {
     let dir = tempfile::tempdir().expect("tempdir");
     let stdout = compile_and_run(


### PR DESCRIPTION
## What

Fixes the dominant cluster behind #5587: `built-ins/Temporal/**/subclassing-ignored.js` (36 `TypeError: value is not a function` failures).

`class X extends Temporal.Duration { constructor(){ super(...args) } }` produced an **empty plain object**. `super()` ran the native Temporal constructor — which returns a fresh NaN-boxed cell rather than mutating the implicit `this` — and **discarded** the returned cell. The subclass instance had no Temporal brand, so `instance.abs()` resolved `abs` to `undefined` and threw.

## How

Mirrors the existing `class X extends Request/Response` fetch-handle pattern: when a `super()` parent resolves to a Temporal constructor, run it and stash the returned cell on `this` under `__perry_temporal_cell__`. Both `super()` lowerings are covered:

- `js_fetch_or_value_super` — non-spread `super(a, b)`
- `js_super_construct_apply` — `super(...spread)` (the form the test262 helper uses), via the decl-time-recorded dynamic parent value

Method-call (`native_call_method`), property-get (`get_field_by_name_tail`), and `instanceof` dispatch recover the cell from there.

Also fixes the surrounding real-cell gaps the same tests exercise:

- **`Object.getPrototypeOf(temporalCell)`** returned `null`; now resolves `Temporal.<Type>.prototype` via the live namespace, so `assert.sameValue(Object.getPrototypeOf(result), construct.prototype)` holds.
- **Reading a prototype method as a value** (`d.abs`, not `d.abs()`) returned `undefined`, breaking the `instance[method](...spread)` read+apply form; now returns a bound method, gated on a real per-kind method predicate so unknown properties still read as `undefined`. Applies to real cells and subclass instances.
- **Construct-only Temporal ctors** (`PlainDate`/`PlainTime`/`Instant`/…) threw "requires 'new'" when invoked from `super()`; `new.target` is now set for the call.

## Verification

- New regression test `crates/perry/tests/issue_5587_temporal_subclass.rs` (2 tests, top-level subclasses of `Temporal.Duration` and `Temporal.PlainDate`) — pass.
- Existing subclass/super/array integration tests (`issue_4908_subclass_native_member_base`, `issue_array_subclass_super_init`) — pass (no regression).
- Manual: top-level subclasses of Duration / PlainDate / Instant now have working `instanceof`, accessor getters, methods (fused / computed / spread / read-as-value), and `getPrototypeOf`.

## Known remaining limitation (out of scope)

A class method/constructor defined **inside a function** captures an enclosing `let` **by value, not by cell** — so the test262 helper's `assert.sameValue(called, 1)` still fails for the in-function subclasses it builds. This is a **general class-semantics bug** (reproduces with a plain user-class subclass — `let c=0; class K extends B { constructor(){ c++; super() } }; new K()` leaves `c === 0`), unrelated to Temporal, and deserves its own fix. With this PR, the subclassing-ignored cases now run all the way through the Temporal logic and fail **only** on that `called` assertion (previously they threw `value is not a function` immediately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Temporal subclass support for `super()` calls, inherited prototype resolution, `instanceof`, and value-based method access.
* **Bug Fixes**
  * Fixed cases where subclassed Temporal instances could lose their internal brand, fail inherited getters/methods, or return incorrect prototype objects.
* **Tests**
  * Added regression tests covering `Temporal.Duration` and `Temporal.PlainDate` subclasses, including an aliasing `super(...)` edge case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->