### PR TITLE
fix(runtime): #5625 — resolve forwarded grown-array prototype in copyWithin inherited-index reads

### DIFF
--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -300,9 +300,23 @@ unsafe fn array_custom_array_prototype(arr: *const ArrayHeader) -> Option<*const
     if raw < crate::gc::GC_HEADER_SIZE + 0x1000 || raw == arr as usize {
         return None;
     }
-    let hdr = (raw as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+    // #5625: the recorded prototype may be a *grown* array whose stored pointer
+    // was left FORWARDED by `js_array_grow` — its first 8 bytes now hold the
+    // forwarding pointer to the live head instead of length+capacity. (A real
+    // array grows when `Object.setPrototypeOf(arr, p)` captured `p` before a
+    // later push reallocated it, or the proto itself was built by appends — as
+    // in test262 copyWithin/coerced-values-start-change-start, whose
+    // `longDenseArray()` fills a `[0]` to 1024 elements.) Resolve the chain so
+    // we deref the current array head; reading the defunct old location yields
+    // the forwarding pointer's low 32 bits as a garbage `length`, making
+    // inherited-index reads silently miss (nondeterministic copyWithin output).
+    let resolved = clean_arr_ptr(raw as *const ArrayHeader);
+    if resolved.is_null() || resolved as usize == arr as usize {
+        return None;
+    }
+    let hdr = (resolved as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
     if (*hdr).obj_type == crate::gc::GC_TYPE_ARRAY {
-        Some(raw as *const ArrayHeader)
+        Some(resolved)
     } else {
         None
     }


### PR DESCRIPTION
## Summary

Closes the last remaining item on #5625. `Array.prototype.copyWithin` over a receiver with a custom `[[Prototype]]` (set via `Object.setPrototypeOf`) **nondeterministically** returned an all-holes array instead of copying the inherited indices.

Failing case: `built-ins/Array/prototype/copyWithin/coerced-values-start-change-start.js` (the other 25 cases from #5625 were already fixed by #5628 and #5650).

## Root cause

`array_custom_array_prototype` (the helper behind `array_spec_has_index` / `array_spec_get`, used by copyWithin's per-index spec loop) decoded the recorded prototype pointer and dereferenced it **without resolving `js_array_grow` forwarding**.

When the prototype is a *grown* array — the test's `longDenseArray()` fills a `[0]` up to 1024 elements, reallocating its backing store — its stored pointer is left `GC_FLAG_FORWARDED`: the old location's first 8 bytes hold the forwarding pointer to the live head, not `length`+`capacity`. Reading `.length` there returns the forwarding pointer's low 32 bits as a garbage huge value, so `array_has_own_index(proto, idx)` reads unrelated memory. The inherited-index `HasProperty` check then intermittently missed, and copyWithin **deleted** the target slots instead of copying from the prototype. Whether the proto pointer was forwarded depended on allocator layout — hence the flakiness (≈60% failure locally).

## Fix

Run the decoded pointer through `clean_arr_ptr` (which already follows the forwarding chain) before validating `obj_type` / dereferencing, so we always operate on the current array head. One-function, 16-line change.

## Validation

- The failing test262 case (assembled with `sta.js`+`assert.js`+`compareArray.js`) now passes **40/40** runs (exit-0, matching node), vs ≈40% before.
- Reduced repro passes **50/50** default GC, **30/30** `PERRY_GEN_GC=0`, **30/30** `PERRY_GC_FORCE_EVACUATE=1`.
- Normal (non-grown) array-prototype inheritance still matches node deterministically.
- `cargo test -p perry-runtime` array (119) + prototype (9) suites green.

No version bump / changelog (maintainer folds those in at merge).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed array prototype handling so prototype updates work correctly even when an array has moved or grown.
  * Improved detection of the current live array before applying prototype changes, reducing incorrect behavior in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->