### PR TITLE
perf(codegen): full-outline the generic property-GET diamond for oversized modules

### DIFF
--- a/crates/perry-codegen/src/expr/property_get/generic_dispatch.rs
+++ b/crates/perry-codegen/src/expr/property_get/generic_dispatch.rs
@@ -60,6 +60,38 @@ pub(crate) fn lower_generic_property_get(
         TypedFeedbackContract::object_get_by_name(),
     );
 
+    // #5391 path 3: oversized modules full-outline the entire generic-get diamond
+    // (receiver-tag routing + monomorphic IC + feedback + nullish-throw) to a
+    // single `js_object_get_field_ic(...)` call. This shrinks large minified user
+    // functions enough for clang to compile them at a tolerable size/time — the
+    // inline diamond is the biggest per-site __text contributor. The runtime helper
+    // reproduces the same branch ladder and calls the same entries, so behavior is
+    // unchanged; only the inline monomorphic fast-load is traded away. Mirrors the
+    // class-field GET/SET full-outline (#5334 lever B / #5391 path 2).
+    if crate::codegen::full_outline_ic_enabled() {
+        // Per-site monomorphic IC cache, allocated identically to the inline path
+        // (below) so the helper's `js_object_get_field_ic_miss` cache-priming is
+        // unchanged.
+        let cache_site = ctx.ic_site_counter;
+        ctx.ic_site_counter += 1;
+        let cache_name = format!("perry_ic_{}", cache_site);
+        ctx.pending_declares
+            .push((format!("__ic_decl_{}", cache_site), DOUBLE, vec![]));
+        ctx.ic_globals.push(cache_name.clone());
+        let cache_ref = format!("@{}", cache_name);
+        let val = ctx.block().call(
+            DOUBLE,
+            "js_object_get_field_ic",
+            &[
+                (I64, &obj_bits),
+                (I64, &key_handle),
+                (I64, &feedback_site_id),
+                (PTR, &cache_ref),
+            ],
+        );
+        return Ok(val);
+    }
+
     // Issue #70/#73/#128: guard against non-pointer receivers
     // before the PIC deref. Tag-based check on the unmasked
     // NaN-box: real heap references have high-16-bits POINTER_TAG

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -253,6 +253,11 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
     module.declare_function("js_nm_install_zlib", VOID, &[]);
     module.declare_function("js_nm_install_all", VOID, &[]);
     module.declare_function("js_object_get_field_ic_miss", DOUBLE, &[I64, I64, PTR]);
+    // #5391 path 3: full-outlined generic property GET. Collapses the inline
+    // receiver-routing + monomorphic-IC + feedback + nullish-throw diamond to a
+    // single call for oversized modules. Args: (obj_bits, key_handle, site_id,
+    // per-site IC cache global) -> field value.
+    module.declare_function("js_object_get_field_ic", DOUBLE, &[I64, I64, I64, PTR]);
     // Object rest destructuring: copy all properties from src except excluded keys.
     // Takes a src object ptr and an array of NaN-boxed strings (the excluded keys),
     // returns a new object pointer.

--- a/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
+++ b/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
@@ -334,6 +334,84 @@ pub extern "C" fn js_object_get_field_ic_miss(
     f64::from_bits(value.bits())
 }
 
+/// #5391 path 3: full-outlined generic property GET.
+///
+/// In oversized (full-outline) modules the inline generic-get diamond expands to
+/// ~60 IR instructions and ~13 basic blocks per property-get site: receiver-tag
+/// routing (SSO / INT32 class-ref / valid-pointer / nullish), a monomorphic
+/// inline cache (shape check + hit/miss), typed-feedback recording, and the
+/// nullish-throw. On a large minified bundle that is the single biggest
+/// contributor to generated `__text`. This helper collapses the whole site to one
+/// call by reproducing that branch ladder here, dispatching to the *exact same*
+/// runtime entries the inline code calls — so behavior is unchanged. The only
+/// thing dropped is the inline monomorphic fast-load: every read goes through the
+/// cache-priming slow path (`js_object_get_field_ic_miss`), trading a little speed
+/// for a large code-size win, the same trade the class-field GET/SET full-outline
+/// paths (`js_class_field_get_ic` / `js_class_field_set_ic`) already make.
+///
+/// Argument shapes mirror the inline site operands exactly:
+/// - `obj_bits`: the receiver's full (unmasked) NaN-box bits
+/// - `key`: the property-name `StringHeader`, already masked to a raw pointer
+/// - `site_id`: the typed-feedback site id
+/// - `cache`: the per-site monomorphic IC cache global (primed by `..._ic_miss`)
+#[no_mangle]
+pub extern "C" fn js_object_get_field_ic(
+    obj_bits: i64,
+    key: *const crate::StringHeader,
+    site_id: u64,
+    cache: *mut [i64; 2],
+) -> f64 {
+    // POINTER_MASK: lower 48 bits — strips the NaN-box tag to a raw heap pointer.
+    const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
+    let bits = obj_bits as u64;
+    let tag = bits >> 48;
+    // `obj_bits` reinterpreted as a pointer keeps the tag bits (the SSO / class-ref
+    // / by-name helpers need the unmasked value); `obj_handle` is the masked heap
+    // pointer the inline-cache miss handler + feedback observe expect.
+    let obj_unmasked = bits as usize as *const ObjectHeader;
+    let obj_handle = (bits & POINTER_MASK) as usize as *const ObjectHeader;
+
+    // SSO receiver (SHORT_STRING_TAG = 0x7FF9): the SSO-aware by-name helper reads
+    // `.length` from the NaN-box payload and returns undefined for other keys.
+    if tag == 0x7FF9 {
+        return js_object_get_field_by_name_f64(obj_unmasked, key);
+    }
+    // INT32-tagged class ref (0x7FFE): static-field / dynamic-prop / synthetic
+    // `constructor` lookup via the feedback-wrapped by-name helper. Passes the
+    // unmasked bits so the runtime can detect the INT32 tag.
+    if tag == 0x7FFE {
+        return crate::typed_feedback::js_typed_feedback_object_get_field_by_name_f64(
+            site_id,
+            obj_unmasked,
+            key,
+        );
+    }
+    // Valid heap pointer or string (masked tag 0x7FFD): record feedback, then route
+    // through the cache-priming inline-cache-miss handler — the same entry the
+    // inline diamond's miss arm calls (objects, closures, buffers, typed arrays,
+    // proxies, small handles all dispatch correctly there, and the per-site cache
+    // is primed for any future inline sites sharing this global).
+    if (tag & 0xFFFD) == 0x7FFD {
+        crate::typed_feedback::js_typed_feedback_observe_property_get(site_id, obj_handle, key);
+        return js_object_get_field_ic_miss(obj_handle, key, cache);
+    }
+    // Invalid (non-pointer) receiver. `undefined`/`null` throw a TypeError (#462 —
+    // matches the inline nullish path, which aborts with a node-shaped message);
+    // other primitives route through the by-name helper, which can still resolve
+    // typed-shape reads (e.g. Date `.constructor`).
+    if bits == crate::value::TAG_UNDEFINED || bits == crate::value::TAG_NULL {
+        let is_null = u32::from(bits == crate::value::TAG_NULL);
+        let (ptr, len) = unsafe {
+            match super::super::has_own_helpers::str_from_string_header(key) {
+                Some(s) => (s.as_ptr(), s.len()),
+                None => (std::ptr::null(), 0),
+            }
+        };
+        crate::error::js_throw_type_error_property_access(is_null, ptr, len);
+    }
+    js_object_get_field_by_name_f64(obj_unmasked, key)
+}
+
 // Polymorphic numeric-key get/set (`js_object_get_index_polymorphic` /
 // `js_object_set_index_polymorphic`) live in `polymorphic_index.rs`:
 // they dispatch by GC type (array vs object vs closure vs buffer) rather


### PR DESCRIPTION
## Context

Follow-up to the oversized-module size work. Attribution showed a large minified bundle's native binary is ~95% perry's **own generated code** (a representative bundle emits 253 MB of codegen `__text` of a 266 MB binary). Within that, the biggest per-site contributor is the inline property-GET diamond.

## Problem

`lower_generic_property_get` emits, **per property-get site**, ~60 IR instructions across ~13 basic blocks:

- receiver-tag routing (SSO / INT32 class-ref / valid-pointer / nullish)
- a monomorphic inline cache (shape check + hit/miss)
- typed-feedback recording (`observe` / `guard_pass` / `guard_fail` / `record_fallback`)
- the nullish-throw path

The class-field GET/SET diamonds are already collapsed to a single call in full-outline mode (`js_class_field_get_ic` / `js_class_field_set_ic`), but the **generic**-get diamond was not — so it dominated the residual IR (thousands of `js_object_get_field_by_name_f*` + `observe_property_get` calls per codegen unit).

## Fix

Mirror the class-field outline. When `full_outline_ic_enabled()` (oversized modules only — ordinary programs keep the fast inline PIC), emit a single `js_object_get_field_ic(obj_bits, key_handle, site_id, cache)` call.

The new runtime helper **reproduces the inline diamond's branch ladder exactly**, dispatching to the same runtime entries the inline code already calls:
`js_object_get_field_by_name_f64`, `js_typed_feedback_object_get_field_by_name_f64`, `js_typed_feedback_observe_property_get`, `js_object_get_field_ic_miss`, `js_throw_type_error_property_access`. Behavior is unchanged; the only thing traded away is the inline monomorphic fast-load (every read goes through the cache-priming slow path) — the same speed-for-size trade the class-field full-outline paths already make.

## Measurements

Generic-get-heavy oversized program (9000 functions, each doing several `o[k]`/`o.x` reads on an `any`):

| | binary `__text` | binary |
|---|---|---|
| inline diamonds | 42 MB | 47 MB |
| outlined | **20 MB (-52%)** | 26 MB |

Program output byte-identical.

## Correctness

- **73 gap tests** (object / property / class / array / typedarray / url / proto) confirmed to produce **byte-identical output on the outlined path vs the inline path**.
- Hand-written edge-case test (regular object / SSO `.length` / prototype-chain / chained `any` gets / nullish-throw on `undefined` and `null`) matches `node --experimental-strip-types` on both paths.
- 129 `perry-codegen` unit tests green; builds clean against current `main`.

## Notes

- Gated entirely behind `full_outline_ic_enabled()` — zero change for normal-sized programs (they keep the inline PIC fast path).
- Independent of the `-Os` oversized-unit change (#5674); they stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new fully outlined property access path for object field reads.
  * Enabled per-site caching for these reads to improve handling at larger call sites.
  * Extended runtime support for cached property lookup and fallback handling.

* **Bug Fixes**
  * Improved behavior for special receivers like `undefined` and `null` by returning a proper TypeError.
  * Preserved existing lookup behavior for strings, class references, and heap objects while using the new cached path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->