### PR TITLE
feat(hir): PERRY_EVAL_CSP — present dynamic code generation as unavailable to capability probes (zod JIT fallback)

### DIFF
--- a/crates/perry-hir/src/eval_classifier.rs
+++ b/crates/perry-hir/src/eval_classifier.rs
@@ -319,6 +319,22 @@ pub fn eval_override_enabled() -> bool {
     env_flag("PERRY_ALLOW_EVAL")
 }
 
+/// Whether `PERRY_EVAL_CSP` is set — present runtime dynamic-code generation as
+/// *unavailable* to capability probes. With it set, a trivial no-op
+/// `new Function("")` / `Function("")` (the canonical
+/// `try { new Function(""), true } catch { false }` feature-test — the same
+/// shape a CSP `unsafe-eval` policy blocks) throws at construction instead of
+/// const-folding to a no-op function. Libraries that probe this way (e.g. zod 4's
+/// object-validator JIT) then take their non-codegen interpreter fallback, which
+/// perry compiles normally. Default off (spec-compliant: Node returns an empty
+/// function); opt-in for ahead-of-time binaries that hit such a JIT. Only the
+/// trivial no-op shape is affected — real literal bodies (`new Function("return
+/// 42")`, the `return this` globalThis polyfill) still fold, so those idioms are
+/// unaffected.
+pub fn eval_csp_probe_unavailable() -> bool {
+    env_flag("PERRY_EVAL_CSP")
+}
+
 /// Whether `PERRY_ALLOW_UNIMPLEMENTED` is set — forces non-strict (defer) mode
 /// for recognized-but-unimplemented node/stdlib APIs (#5245), overriding any
 /// strict flag/config for a one-off build. This is the back-compat alias of the

--- a/crates/perry-hir/src/lower/const_fold_fn.rs
+++ b/crates/perry-hir/src/lower/const_fold_fn.rs
@@ -308,6 +308,26 @@ pub(crate) fn try_const_fold_function_construct_kind(
         None => (String::new(), String::new()),
     };
 
+    // CSP capability-probe handling (`PERRY_EVAL_CSP`). A trivial no-op
+    // `new Function("")` / `Function("")` is the canonical runtime-codegen
+    // feature-test (`try { new Function(""), true } catch { false }`). perry is
+    // ahead-of-time compiled and cannot generate code from a runtime string, so
+    // under CSP mode this probe must report "unavailable" — throw at
+    // *construction* (not when called), exactly as a CSP `unsafe-eval`-blocked
+    // environment does — so probing callers (e.g. zod 4's validator JIT) take
+    // their non-codegen interpreter fallback. Only the trivial empty-body no-op
+    // is refused; real literal bodies (`return 42`, the `return this` globalThis
+    // polyfill) still fold, preserving spec behavior by default.
+    if body_src.trim().is_empty() && crate::eval_classifier::eval_csp_probe_unavailable() {
+        return synth_throwing_iife(
+            ctx,
+            "throw new TypeError(\"Function: runtime dynamic code generation is \
+             unavailable in this ahead-of-time compiled binary\");",
+            span,
+        )
+        .map(Some);
+    }
+
     // Assemble the exact source text the spec's CreateDynamicFunction
     // prescribes: newlines around the body and *before the closing paren*
     // so a `//` comment in the params or body can't swallow a delimiter.


### PR DESCRIPTION
## Problem

An ahead-of-time compiled binary cannot generate code from a runtime-built string. Many libraries feature-test this capability with the canonical probe a CSP `unsafe-eval` policy blocks:

```js
const canCodegen = (() => { try { return new Function(""), true } catch { return false } })();
```

and fall back to a non-codegen path when it throws. perry **const-folds** the literal empty-body `new Function("")` into a real no-op function, so the probe *succeeds* — and the library then attempts runtime codegen perry can't actually do, and crashes when it invokes the result.

Concrete case — **zod 4's object-validator JIT**. zod gates its `Function`-compiled validator on exactly this probe:

```js
O = !globalConfig.jitless,
$ = O && canCodegen.value,          // canCodegen = try{ new Function(""),true } catch{ false }
... if (O && $ && opts?.async === false && opts.jitless !== true) { /* JIT via Function(...) */ }
else { /* interpreter */ }
```

With the probe succeeding, zod JIT-compiles every `z.object({...})` via `Function(...)` and crashes; with it failing, zod uses its interpreter (which perry compiles normally).

## Fix

Add an **opt-in** `PERRY_EVAL_CSP` env flag. When set, a trivial empty-body `new Function("")` / `Function("")` synthesizes a **construction-time** throw (a `TypeError`, CSP-style) instead of const-folding to a no-op function — so capability probes report "unavailable" and take their fallback.

- **Default off** → spec-compliant (Node returns an empty function); **Test262 is unaffected**.
- **Narrow** → only the trivial empty-body no-op probe is refused. Real literal bodies (`new Function("return 42")`) and the `return this` globalThis polyfill (`Function("return this")()`) still const-fold untouched.
- **Construction-time** throw (via `synth_throwing_iife`), not throw-on-call — so the `try { new Function(""), true } catch {}` probe actually catches it.
- General: any library using the standard CSP feature-test (not just zod) now falls back correctly.

## Verification

A large minified CLI bundle that uses zod 4 for its entire config/schema/validation layer previously crashed in zod's JIT (`Function is not a function` during async schema init). Built with `PERRY_EVAL_CSP=1`, zod takes its interpreter path and the full validation layer runs natively with no crash.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a runtime capability check that recognizes when dynamic code generation is unavailable.

* **Bug Fixes**
  * Improved handling of empty `Function` constructor cases so they now fail immediately with a `TypeError` when the environment blocks code generation, while other valid cases continue to work normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->