### PR TITLE
fix(compile): robust fetch detection for minified bundles + drop runtime fetch stubs when web-fetch is linked

### DIFF
--- a/crates/perry/src/commands/compile/collect_modules/feature_detect.rs
+++ b/crates/perry/src/commands/compile/collect_modules/feature_detect.rs
@@ -21,6 +21,35 @@ pub(super) fn detect_optional_feature_usage(
         ctx.uses_fetch = true;
     }
 
+    // Robust fallback for fetch detection. The ~30 `ctx.uses_fetch` set-sites in
+    // perry-hir lowering are shape-specific; a minified bundle's `new Headers()`
+    // / `new Request()` / `fetch(...)` can reach codegen as `Expr::New { class_name:
+    // "Headers" }` / a `Fetch*` variant (codegen dispatches those to
+    // `js_headers_new` / `js_request_new` / `js_fetch_with_options`) WITHOUT having
+    // hit any set-site, leaving `hir_module.uses_fetch` false. The perry-stdlib
+    // `web-fetch` feature is then stripped, only the no-op runtime stub remains, and
+    // it returns garbage the caller derefs -> SIGSEGV in `js_object_get_class_id`.
+    // Mirror the EventEmitter / URL token-grep below: scan the final HIR for the
+    // fetch web-platform constructors + the dedicated fetch call variants. Over-
+    // matching only over-links `web-fetch` (a size cost); the rule is zero false
+    // negatives.
+    if !ctx.uses_fetch {
+        let hir_debug: String = format!("{:?}{:?}", &hir_module.init, &hir_module.functions);
+        if hir_debug.contains("class_name: \"Headers\"")
+            || hir_debug.contains("class_name: \"Request\"")
+            || hir_debug.contains("class_name: \"Response\"")
+            || hir_debug.contains("class_name: \"FormData\"")
+            || hir_debug.contains("class_name: \"Blob\"")
+            || hir_debug.contains("class_name: \"File\"")
+            || hir_debug.contains("FetchWithOptions")
+            || hir_debug.contains("FetchGetWithAuth")
+            || hir_debug.contains("FetchPostWithAuth")
+        {
+            ctx.needs_stdlib = true;
+            ctx.uses_fetch = true;
+        }
+    }
+
     // Issue #76 — auto-link the wasmi host runtime when any module
     // references `WebAssembly.*`. Without this the user has to remember
     // `--enable-wasm-runtime`; with it the flag is only needed when they

--- a/crates/perry/src/commands/compile/optimized_libs/freshness.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/freshness.rs
@@ -137,6 +137,17 @@ pub(crate) fn auto_optimized_cross_features(
     if ctx.uses_dgram {
         cross_features.push("perry-runtime/mod-dgram".to_string());
     }
+    // Compile OUT perry-runtime's no-op fetch stubs (`js_fetch_with_options` /
+    // `js_headers_new` / `js_request_new`, gated `#[cfg(not(feature =
+    // "external-fetch-symbols"))]`) whenever the program uses fetch — perry-stdlib's
+    // `web-fetch` then supplies the REAL impls. Without this both the stub
+    // (perry-runtime) and the real (perry-stdlib) symbols exist; on the fresh build
+    // path the stub has won the link and returned garbage the caller derefs ->
+    // SIGSEGV in `js_object_get_class_id`. Enabling the feature drops the stubs from
+    // libperry_runtime.a so only the real symbols remain.
+    if ctx.uses_fetch {
+        cross_features.push("perry-runtime/external-fetch-symbols".to_string());
+    }
     cross_features
 }
 


### PR DESCRIPTION
## Problem

A minified bundle that uses `fetch` / `Headers` / `Request` **segfaults at startup**: the real fetch implementation isn't linked, only the no-op runtime stub, which returns garbage the caller dereferences → `EXC_BAD_ACCESS` in `js_object_get_class_id`.

Two root causes:

1. **`uses_fetch` detection is shape-fragile.** perry-stdlib's real fetch (`web-fetch`) is linked only when `uses_fetch` is set, which happens at ~30 shape-specific sites scattered through HIR lowering (`expr_new.rs`, `destructuring/*`, …). A minified bundle's `new Headers()` / `new Request()` / `fetch(...)` can reach codegen as `Expr::New { class_name: "Headers" }` / a `Fetch*` HIR variant — codegen correctly dispatches those to `js_headers_new` / `js_request_new` / `js_fetch_with_options` — **without** having hit any `uses_fetch` set-site. So `uses_fetch` stays false, `web-fetch` is stripped, and only the stub remains.

2. **The runtime fetch stubs are never compiled out.** The `js_fetch_*` / `js_headers_new` / `js_request_new` stubs in `perry-runtime` are gated `#[cfg(not(feature = "external-fetch-symbols"))]`, but `external-fetch-symbols` was enabled **nowhere** in the build. So whenever `web-fetch` *is* linked, both the stub (perry-runtime) and the real (perry-stdlib) symbols exist, and on the fresh build path the stub has won the link.

## Fix

1. **Robust fetch detection** (`feature_detect.rs`): a post-lowering token scan of the final HIR for the fetch web-platform constructors (`class_name: "Headers"|"Request"|"Response"|"FormData"|"Blob"|"File"`) and the dedicated fetch call variants (`FetchWithOptions` / `FetchGetWithAuth` / `FetchPostWithAuth`) → set `uses_fetch`. This mirrors the existing EventEmitter / URL token-scan fallbacks in the same file. Over-matching only over-links `web-fetch` (a size cost); the rule is zero false negatives.

2. **Drop the stub when the real is linked** (`freshness.rs`, `auto_optimized_cross_features`): `if ctx.uses_fetch { push("perry-runtime/external-fetch-symbols") }`, mirroring the existing per-feature lines (`regex-engine`, `url-engine`, …). This compiles the stubs out of `libperry_runtime.a`, leaving only perry-stdlib's real symbols — no dup-symbol gamble.

Both are required together: fix 1 links `web-fetch` but leaves the dup; fix 2 never fires without fix 1.

## Verification

A large minified CLI bundle that uses `fetch`/`Headers`/`Request` (7× `new Headers()`, 9× `fetch(`) previously linked only the stub and printed `[perry] warning: js_headers_new is a no-op stub … (runtime-only build)`. With both fixes, `uses_fetch` is detected, the stub warnings are gone, and the real `web-fetch` symbols are linked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of fetch-related code so the correct web-fetch runtime support is kept enabled in more cases.
  * Prevented fresh builds from incorrectly selecting placeholder fetch symbols, reducing missing-runtime issues and link problems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->