### PR TITLE
fix(stdlib): bridge node IncomingMessage body into web Request body (POST req.json())

### DIFF
--- a/crates/perry-stdlib/src/fetch/dispatch.rs
+++ b/crates/perry-stdlib/src/fetch/dispatch.rs
@@ -54,6 +54,34 @@ pub extern "C" fn js_response_body_init_ptr(value: f64) -> i64 {
             return unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32) } as i64;
         }
     }
+    // #5437: a Node `IncomingMessage` body — the request-body bridge Next.js's
+    // `NextRequestAdapter.fromNodeNextRequest` relies on. It sets the web
+    // `Request` body to the `NodeNextRequest`'s `.body`, which is the underlying
+    // `IncomingMessage` (a native handle: `POINTER_TAG | small id`, not bytes).
+    // Stringifying it below yielded `"[object Object]"`, so `req.json()` /
+    // `req.text()` saw garbage and POST bodies were silently lost. Read the
+    // request's buffered bytes through the handle-property dispatch — the node
+    // http impl exposes them as a Buffer under `rawBody` (`js_node_http_im_raw_body`)
+    // — and materialize a lossless StringHeader from them. Only a small-handle
+    // POINTER value is probed, so string / heap-object / buffer bodies above are
+    // untouched. A handle without a buffered `rawBody` falls through to ToString.
+    {
+        let jsval = JSValue::from_bits(value.to_bits());
+        if jsval.is_pointer() {
+            let raw = jsval.as_pointer::<u8>() as usize;
+            if raw != 0 && raw < 0x10000 {
+                let key = unsafe { js_string_from_bytes(b"rawBody".as_ptr(), 7) };
+                let raw_body = perry_runtime::object::js_object_get_field_by_name_f64(
+                    raw as *const perry_runtime::object::ObjectHeader,
+                    key,
+                );
+                if let Some(bytes) = unsafe { body_value_buffer_bytes(raw_body) } {
+                    return unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32) }
+                        as i64;
+                }
+            }
+        }
+    }
     // A heap-object body — a boxed `String` (hono's `raw()` / JSX `c.html()`
     // returns `new String(value)` with an `isEscaped` expando), an array, or a
     // plain object — is a `POINTER_TAG` value. `js_get_string_pointer_unified`


### PR DESCRIPTION
## What
`new Request(input, init)` where the body is a node **IncomingMessage** handle (as Next's `NextRequestAdapter.fromNodeNextRequest` does — it sets the web Request body to the NodeNextRequest's `.body` = the IncomingMessage) fell through to ToString in `js_response_body_init_ptr`, producing the literal bytes `"[object Object]"`. So `req.json()`/`req.text()` parsed garbage → swallowed by Next's `.catch(()=>({}))` → empty body.

Found via Next.js (#5437): `POST /api/hello` echoed `{}` regardless of payload (node: `{"echo":{"x":1}}`). Bit-proof: `[JSONBODY] len=15 text="[object Object]"`.

## Fix
In `js_response_body_init_ptr` (`crates/perry-stdlib/src/fetch/dispatch.rs`), before the ToString fallback, detect a small-handle POINTER body, read its buffered bytes via the `rawBody` handle-property dispatch (`js_node_http_im_raw_body`), and materialize a lossless body. Gated on the handle band — string/buffer/heap-object bodies are untouched; a handle without `rawBody` falls through to ToString. stdlib-only, no codegen change.

## Validation
- Bundle: `POST /api/hello {x:1}` → `{"echo":{"x":1}}` byte-identical to node. (Now 5/7 Next.js routes byte-identical: static ×3 + GET-API + POST-API; the 2 dynamic PAGE routes remain on a separate deep wall.)
- `cargo test -p perry-stdlib --lib` 104/0; `perry-ext-fetch` 11/0 — body/fetch construct tests green.

Refs #5437.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of request bodies from Node-based incoming requests, helping preserve raw binary content more reliably.
  * Reduced cases where body data could be misread or converted incorrectly, with existing behavior unchanged when raw content isn’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->