### PR TITLE
fix(compile): fetch detection — scan class-method bodies + PERRY_FETCH_DIAG (follow-up #5679)

### DIFF
--- a/crates/perry/src/commands/compile/collect_modules/feature_detect.rs
+++ b/crates/perry/src/commands/compile/collect_modules/feature_detect.rs
@@ -34,7 +34,10 @@ pub(super) fn detect_optional_feature_usage(
     // matching only over-links `web-fetch` (a size cost); the rule is zero false
     // negatives.
     if !ctx.uses_fetch {
-        let hir_debug: String = format!("{:?}{:?}", &hir_module.init, &hir_module.functions);
+        let hir_debug: String = format!(
+            "{:?}{:?}{:?}",
+            &hir_module.init, &hir_module.functions, &hir_module.classes
+        );
         if hir_debug.contains("class_name: \"Headers\"")
             || hir_debug.contains("class_name: \"Request\"")
             || hir_debug.contains("class_name: \"Response\"")
@@ -48,6 +51,12 @@ pub(super) fn detect_optional_feature_usage(
             ctx.needs_stdlib = true;
             ctx.uses_fetch = true;
         }
+    }
+    if std::env::var_os("PERRY_FETCH_DIAG").is_some() {
+        eprintln!(
+            "[perry-fetch-diag] module hir.uses_fetch={} -> ctx.uses_fetch={}",
+            hir_module.uses_fetch, ctx.uses_fetch
+        );
     }
 
     // Issue #76 — auto-link the wasmi host runtime when any module


### PR DESCRIPTION
## Follow-up to #5679

#5679 added a post-lowering token-scan fallback for fetch detection (the shape-specific `ctx.uses_fetch` set-sites miss a minified bundle's `new Headers()` / `fetch()`). That scan covered `hir_module.init` + `hir_module.functions` only — but a minified bundle can construct `new Headers()` / `new Request()` inside a **class-method body**, which lives in `hir_module.classes`, not `functions`. So `uses_fetch` could still resolve false, `web-fetch` got stripped, and the no-op fetch stub linked.

## Fix

Extend the token-scan to also format `hir_module.classes`, so fetch constructors in class-method bodies are detected. Over-matching only over-links `web-fetch` (a size cost); the rule stays zero false negatives.

Also adds an opt-in `PERRY_FETCH_DIAG` env that logs each module's `hir.uses_fetch -> ctx.uses_fetch` resolution — useful for diagnosing fetch-feature detection on large minified bundles.

## Verification

On a large minified CLI bundle that constructs `Headers` inside class methods, `uses_fetch` previously resolved false (stub linked); with the `classes` scan it resolves true (confirmed via `PERRY_FETCH_DIAG`) and `web-fetch` links.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of optional `fetch` usage so code in classes is correctly recognized.
  * This helps ensure related features are enabled when `fetch` is used in more places.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->