### PR TITLE
feat(init): scaffold package.json with perry.compilePackages

### DIFF
--- a/crates/perry/src/commands/init.rs
+++ b/crates/perry/src/commands/init.rs
@@ -39,6 +39,22 @@ out_dir = "dist"
 opt_level = 2
 "#;
 
+// package.json carries the npm-interop layer. Notably it is the *only* home for
+// `perry.compilePackages` (the list of npm packages to compile natively) — that
+// setting is read exclusively from here, never from perry.toml. We seed it empty
+// so the field is discoverable. `private: true` keeps tooling from treating the
+// scaffold as a publishable package, and `main` mirrors perry.toml's `entry`.
+const DEFAULT_PACKAGE_JSON: &str = r#"{
+  "name": "{name}",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/main.ts",
+  "perry": {
+    "compilePackages": []
+  }
+}
+"#;
+
 const DEFAULT_GITIGNORE: &str = r#"# Perry build outputs
 dist/
 *.o
@@ -103,6 +119,22 @@ pub fn run(args: InitArgs, format: OutputFormat, _use_color: bool) -> Result<()>
     } else {
         match format {
             OutputFormat::Text => println!("  Skipped perry.toml (already exists)"),
+            OutputFormat::Json => {}
+        }
+    }
+
+    // Create package.json (npm-interop layer; sole home for perry.compilePackages)
+    let package_json_path = project_path.join("package.json");
+    if !package_json_path.exists() {
+        let package_json_content = DEFAULT_PACKAGE_JSON.replace("{name}", &name);
+        fs::write(&package_json_path, package_json_content)?;
+        match format {
+            OutputFormat::Text => println!("  Created package.json"),
+            OutputFormat::Json => {}
+        }
+    } else {
+        match format {
+            OutputFormat::Text => println!("  Skipped package.json (already exists)"),
             OutputFormat::Json => {}
         }
     }

--- a/crates/perry/src/commands/init.rs
+++ b/crates/perry/src/commands/init.rs
@@ -44,8 +44,10 @@ opt_level = 2
 // setting is read exclusively from here, never from perry.toml. We seed it empty
 // so the field is discoverable. `private: true` keeps tooling from treating the
 // scaffold as a publishable package, and `main` mirrors perry.toml's `entry`.
+// `{name}` is substituted with a JSON-escaped, already-quoted string (see `run`)
+// so a project name containing `"` or `\` still produces a parseable manifest.
 const DEFAULT_PACKAGE_JSON: &str = r#"{
-  "name": "{name}",
+  "name": {name},
   "version": "0.1.0",
   "private": true,
   "main": "src/main.ts",
@@ -126,7 +128,10 @@ pub fn run(args: InitArgs, format: OutputFormat, _use_color: bool) -> Result<()>
     // Create package.json (npm-interop layer; sole home for perry.compilePackages)
     let package_json_path = project_path.join("package.json");
     if !package_json_path.exists() {
-        let package_json_content = DEFAULT_PACKAGE_JSON.replace("{name}", &name);
+        // Escape via serde so names with `"`/`\`/control chars stay valid JSON.
+        // `to_string` returns the value already wrapped in quotes.
+        let name_json = serde_json::to_string(&name)?;
+        let package_json_content = DEFAULT_PACKAGE_JSON.replace("{name}", &name_json);
         fs::write(&package_json_path, package_json_content)?;
         match format {
             OutputFormat::Text => println!("  Created package.json"),

--- a/docs/src/cli/commands.md
+++ b/docs/src/cli/commands.md
@@ -184,7 +184,7 @@ cd my-project
 |------|-------------|
 | `--name <NAME>` | Project name (defaults to directory name) |
 
-Creates `perry.toml`, `src/main.ts`, and `.gitignore`.
+Creates `perry.toml`, `package.json`, `src/main.ts`, `.gitignore`, and `tsconfig.json` (plus Perry type stubs under `.perry/types/`). The generated `package.json` carries the npm-interop layer, including an empty `perry.compilePackages` array — the sole config home for [compiling npm packages natively](../packages/porting.md).
 
 ## doctor
 

--- a/docs/src/getting-started/project-config.md
+++ b/docs/src/getting-started/project-config.md
@@ -45,6 +45,26 @@ List npm packages to compile natively instead of routing through the JavaScript 
 }
 ```
 
+> **Two-key opt-in.** Listing a package is not sufficient on its own. Compiling
+> third-party TypeScript into your binary is a privileged operation, so every
+> entry in `compilePackages` must *also* be matched by an entry in
+> `perry.allow.compilePackages` in the same `package.json` — otherwise the build
+> refuses. Patterns accept exact names, scope wildcards (`"@scope/*"`), or the
+> universal `"*"`:
+>
+> ```json
+> {
+>   "perry": {
+>     "compilePackages": ["@noble/curves", "@noble/hashes"],
+>     "allow": { "compilePackages": ["@noble/*"] }
+>   }
+> }
+> ```
+>
+> For one-off builds where editing `package.json` isn't an option, set
+> `PERRY_ALLOW_PERRY_FEATURES=1` to opt every name in (and `=0` to force the
+> refusal even when `package.json` opted in).
+
 When a package is listed here, Perry:
 1. Resolves the package in `node_modules/`
 2. Prefers TypeScript source (`src/index.ts`) over compiled JavaScript (`lib/index.js`)

--- a/docs/src/getting-started/project-config.md
+++ b/docs/src/getting-started/project-config.md
@@ -11,15 +11,18 @@ perry init my-project
 cd my-project
 ```
 
-This creates a `package.json` and a starter `src/index.ts`.
+This scaffolds `perry.toml`, `package.json`, a starter `src/main.ts`, `.gitignore`, and `tsconfig.json` (plus Perry type stubs under `.perry/types/`).
 
 ## package.json
+
+The generated `package.json` carries the npm-interop layer. The `perry.compilePackages` array is seeded empty — it is the sole config home for that setting (it is read only from `package.json`, never from `perry.toml`):
 
 ```json
 {
   "name": "my-project",
-  "version": "1.0.0",
-  "main": "src/index.ts",
+  "version": "0.1.0",
+  "private": true,
+  "main": "src/main.ts",
   "perry": {
     "compilePackages": []
   }


### PR DESCRIPTION
## Summary

A user ran `perry init` and noticed there was no `package.json` — contradicting the docs. This fixes that, and the fix matters beyond cosmetics: **`package.json` is the only config source Perry reads `perry.compilePackages` from.**

- `compile/host_config.rs` reads it exclusively from `package.json` (the `"perry"` key).
- `perry.toml`'s schema has no `compilePackages` field (its `[perry]` section only parses `strict`/`eval`/`dynamicImport`).

So before this change, a fresh `perry init` project gave you no on-disk hint that native npm-package compilation exists, and the docs claimed a `package.json` was created when it wasn't.

## Changes

- **`perry init` now scaffolds `package.json`** with an empty `perry.compilePackages` array, `"private": true`, and `"main": "src/main.ts"` (mirrors `perry.toml`'s `entry`). Uses the existing `if !path.exists()` skip pattern, so re-running `init` won't clobber an existing file.
- **Docs corrected** (`cli/commands.md`, `getting-started/project-config.md`): the full list of generated files, `src/main.ts` (was incorrectly documented as `src/index.ts`), and the example `package.json` now matches real output (`version: 0.1.0`, `private: true`, `main: src/main.ts`).

## Generated package.json

```json
{
  "name": "my-project",
  "version": "0.1.0",
  "private": true,
  "main": "src/main.ts",
  "perry": {
    "compilePackages": []
  }
}
```

## Verification

- `perry init` prints `Created package.json` and writes the file above.
- Re-running over an existing project prints `Skipped package.json (already exists)`.
- The scaffolded project still compiles and runs (`perry compile src/main.ts` → `Hello from Perry!`).

> Code-only PR — version bump / CHANGELOG left to the maintainer at merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `perry init` now generates a `package.json` in new projects (only when missing), including default npm-interop configuration and an entry point aligned with the generated starter.

* **Documentation**
  * Updated CLI and getting-started guides to reflect the expanded scaffold (`perry.toml`, `package.json`, `src/main.ts`, `.gitignore`, `tsconfig.json`, and type stubs).
  * Clarified that `perry.compilePackages` is configured via `package.json`, including the required opt-in rules and related environment variable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->