### PR TITLE
feat(fetch): honor AbortSignal — cancel/timeout in-flight requests

### DIFF
--- a/crates/perry-codegen-js/src/emit/exprs_more.rs
+++ b/crates/perry-codegen-js/src/emit/exprs_more.rs
@@ -39,6 +39,7 @@ impl JsEmitter {
                 body,
                 headers,
                 headers_dynamic,
+                signal,
             } => {
                 self.output.push_str("fetch(");
                 self.emit_expr(url);
@@ -62,6 +63,10 @@ impl JsEmitter {
                         self.emit_expr(val);
                     }
                     self.output.push('}');
+                }
+                if let Some(sig) = signal {
+                    self.output.push_str(", signal: ");
+                    self.emit_expr(sig);
                 }
                 self.output.push_str("})");
             }

--- a/crates/perry-codegen-wasm/src/emit/expr/net_fetch_crypto.rs
+++ b/crates/perry-codegen-wasm/src/emit/expr/net_fetch_crypto.rs
@@ -29,6 +29,9 @@ impl<'a> FuncEmitCtx<'a> {
                 body,
                 headers,
                 headers_dynamic,
+                // The WASM fetch backend has no AbortSignal cancellation (it is a
+                // separate target from the native binary), so the signal is unused.
+                signal: _,
             } => {
                 self.emit_expr(func, url);
                 self.emit_expr(func, method);

--- a/crates/perry-codegen-wasm/src/emit/js_fallback.rs
+++ b/crates/perry-codegen-wasm/src/emit/js_fallback.rs
@@ -354,6 +354,7 @@ impl WasmModuleEmitter {
                 body,
                 headers,
                 headers_dynamic,
+                signal: _,
             } => {
                 let url_js = self.emit_js_expr(url, locals);
                 let method_js = self.emit_js_expr(method, locals);

--- a/crates/perry-codegen-wasm/src/emit/string_collection.rs
+++ b/crates/perry-codegen-wasm/src/emit/string_collection.rs
@@ -972,6 +972,7 @@ impl WasmModuleEmitter {
                 body,
                 headers,
                 headers_dynamic,
+                signal,
             } => {
                 self.collect_strings_in_expr(url);
                 self.collect_strings_in_expr(method);
@@ -982,6 +983,9 @@ impl WasmModuleEmitter {
                 }
                 if let Some(hd) = headers_dynamic {
                     self.collect_strings_in_expr(hd);
+                }
+                if let Some(s) = signal {
+                    self.collect_strings_in_expr(s);
                 }
             }
             Expr::FetchGetWithAuth { url, auth_header } => {

--- a/crates/perry-codegen/src/collectors/escape_check.rs
+++ b/crates/perry-codegen/src/collectors/escape_check.rs
@@ -669,6 +669,7 @@ pub fn check_escapes_in_expr(
             body,
             headers,
             headers_dynamic,
+            signal,
         } => {
             check_escapes_in_expr(url, candidates, classes, escaped);
             check_escapes_in_expr(method, candidates, classes, escaped);
@@ -678,6 +679,9 @@ pub fn check_escapes_in_expr(
             }
             if let Some(hd) = headers_dynamic {
                 check_escapes_in_expr(hd, candidates, classes, escaped);
+            }
+            if let Some(s) = signal {
+                check_escapes_in_expr(s, candidates, classes, escaped);
             }
         }
         Expr::SuperCall(args)

--- a/crates/perry-codegen/src/collectors/escape_news.rs
+++ b/crates/perry-codegen/src/collectors/escape_news.rs
@@ -754,6 +754,7 @@ fn collect_used_new_fields_in_expr(
             body,
             headers,
             headers_dynamic,
+            signal,
         } => {
             collect_used_new_fields_in_expr(url, non_escaping_news, used);
             collect_used_new_fields_in_expr(method, non_escaping_news, used);
@@ -763,6 +764,9 @@ fn collect_used_new_fields_in_expr(
             }
             if let Some(hd) = headers_dynamic {
                 collect_used_new_fields_in_expr(hd, non_escaping_news, used);
+            }
+            if let Some(s) = signal {
+                collect_used_new_fields_in_expr(s, non_escaping_news, used);
             }
         }
         Expr::FetchGetWithAuth { url, auth_header } => {

--- a/crates/perry-codegen/src/expr/logical_collections.rs
+++ b/crates/perry-codegen/src/expr/logical_collections.rs
@@ -80,10 +80,17 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             body,
             headers,
             headers_dynamic,
+            signal,
         } => {
             let url_box = lower_expr(ctx, url)?;
             let method_box = lower_expr(ctx, method)?;
             let body_box = lower_expr(ctx, body)?;
+            // Lower `init.signal` (if any) up front so it can be stashed for
+            // `js_fetch_with_options` right before the call below.
+            let signal_box = match signal {
+                Some(s) => Some(lower_expr(ctx, s)?),
+                None => None,
+            };
 
             // Obtain the headers as a NaN-boxed object value, then JSON-stringify
             // it below. Two cases:
@@ -141,6 +148,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let url_handle = unbox_to_i64(blk, &url_box);
             let method_handle = unbox_to_i64(blk, &method_box);
             let body_handle = unbox_to_i64(blk, &body_box);
+            // Stash the AbortSignal so `js_fetch_with_options` can cancel the
+            // request when it aborts (`controller.abort()` / `AbortSignal.timeout`).
+            if let Some(sig) = &signal_box {
+                blk.call_void("js_fetch_set_pending_signal", &[(DOUBLE, sig)]);
+            }
             let promise = blk.call(
                 I64,
                 "js_fetch_with_options",

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi/language_core.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi/language_core.rs
@@ -147,6 +147,9 @@ pub(crate) fn declare_core(module: &mut LlModule) {
     module.declare_function("js_fetch_stream_status", DOUBLE, &[DOUBLE]);
     module.declare_function("js_fetch_text", I64, &[I64]);
     module.declare_function("js_fetch_with_options", I64, &[I64, I64, I64, I64]);
+    // Stashes the `fetch(url, { signal })` AbortSignal for the next
+    // `js_fetch_with_options` so the request can be aborted.
+    module.declare_function("js_fetch_set_pending_signal", VOID, &[DOUBLE]);
     // Headers-aware JSON stringify for the `fetch(url, { headers })` request
     // path: takes the headers value (f64) and returns a `*const StringHeader`
     // (i64) holding `{name:value}` JSON, treating a `Headers` handle safely.

--- a/crates/perry-hir/src/capability.rs
+++ b/crates/perry-hir/src/capability.rs
@@ -515,6 +515,7 @@ mod tests {
             body: Box::new(Expr::Undefined),
             headers: vec![],
             headers_dynamic: None,
+            signal: None,
         }));
         let v = audit_module_capabilities(
             &m,

--- a/crates/perry-hir/src/egress.rs
+++ b/crates/perry-hir/src/egress.rs
@@ -489,6 +489,7 @@ mod tests {
             body: Box::new(Expr::Undefined),
             headers: vec![],
             headers_dynamic: None,
+            signal: None,
         }));
         let v = audit_module_egress(&m, "/repo/main.ts", &pats(&["api.example.com"]), false);
         assert_eq!(v.len(), 1);
@@ -506,6 +507,7 @@ mod tests {
             body: Box::new(Expr::Undefined),
             headers: vec![],
             headers_dynamic: None,
+            signal: None,
         }));
         let v = audit_module_egress(&m, "/repo/main.ts", &pats(&["api.example.com"]), false);
         assert!(v.is_empty());
@@ -520,6 +522,7 @@ mod tests {
             body: Box::new(Expr::Undefined),
             headers: vec![],
             headers_dynamic: None,
+            signal: None,
         }));
         let v = audit_module_egress(&m, "/repo/main.ts", &pats(&["api.example.com"]), false);
         assert_eq!(v.len(), 1);
@@ -539,6 +542,7 @@ mod tests {
             body: Box::new(Expr::Undefined),
             headers: vec![],
             headers_dynamic: None,
+            signal: None,
         }));
         let v = audit_module_egress(
             &m,

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -1475,6 +1475,10 @@ pub enum Expr {
         // serialized at runtime. When `Some`, it takes precedence over the
         // static `headers` pairs above. See #4932.
         headers_dynamic: Option<Box<Expr>>,
+        // The `init.signal` AbortSignal, when present, so the request can be
+        // aborted (`controller.abort()` / `AbortSignal.timeout`). Lowered to a
+        // `js_fetch_set_pending_signal` call emitted just before the fetch.
+        signal: Option<Box<Expr>>,
     },
     FetchGetWithAuth {
         // fetchWithAuth(url, authHeader) -> Promise<Response>

--- a/crates/perry-hir/src/lower/expr_call/globals.rs
+++ b/crates/perry-hir/src/lower/expr_call/globals.rs
@@ -341,6 +341,7 @@ pub(super) fn try_global_builtins(
                             let mut body = Expr::Undefined;
                             let mut headers_obj: Vec<(String, Expr)> = Vec::new();
                             let mut headers_dynamic: Option<Box<Expr>> = None;
+                            let mut signal: Option<Box<Expr>> = None;
 
                             for prop in &obj.props {
                                 if let ast::PropOrSpread::Prop(prop) = prop {
@@ -434,6 +435,10 @@ pub(super) fn try_global_builtins(
                                                         ));
                                                     }
                                                 }
+                                                "signal" => {
+                                                    signal =
+                                                        Some(Box::new(lower_expr(ctx, &kv.value)?));
+                                                }
                                                 _ => {}
                                             }
                                         }
@@ -449,6 +454,7 @@ pub(super) fn try_global_builtins(
                                             match key.as_str() {
                                                 "method" => method = value,
                                                 "body" => body = value,
+                                                "signal" => signal = Some(Box::new(value)),
                                                 _ => {}
                                             }
                                         }
@@ -465,6 +471,7 @@ pub(super) fn try_global_builtins(
                                 body: Box::new(body),
                                 headers: headers_obj,
                                 headers_dynamic,
+                                signal,
                             }));
                         }
                     }
@@ -478,6 +485,7 @@ pub(super) fn try_global_builtins(
                     body: Box::new(Expr::Undefined),
                     headers: Vec::new(),
                     headers_dynamic: None,
+                    signal: None,
                 }));
             }
             _ => {} // Fall through to generic handling

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -368,7 +368,7 @@ impl SH for Expr {
             Expr::ChildProcessSpawnBackground { command, args, log_file, env_json, } => { tag(h, 240); command.as_ref().hash(h); args.hash(h); log_file.as_ref().hash(h); env_json.hash(h); }
             Expr::ChildProcessGetProcessStatus(e) => { tag(h, 241); e.as_ref().hash(h); }
             Expr::ChildProcessKillProcess(e) => { tag(h, 242); e.as_ref().hash(h); }
-            Expr::FetchWithOptions { url, method, body, headers, headers_dynamic, } => { tag(h, 243); url.as_ref().hash(h); method.as_ref().hash(h); body.as_ref().hash(h); headers.hash(h); if let Some(hd) = headers_dynamic { tag(h, 1); hd.as_ref().hash(h); } else { tag(h, 0); } }
+            Expr::FetchWithOptions { url, method, body, headers, headers_dynamic, signal, } => { tag(h, 243); url.as_ref().hash(h); method.as_ref().hash(h); body.as_ref().hash(h); headers.hash(h); if let Some(hd) = headers_dynamic { tag(h, 1); hd.as_ref().hash(h); } else { tag(h, 0); } if let Some(s) = signal { tag(h, 1); s.as_ref().hash(h); } else { tag(h, 0); } }
             Expr::FetchGetWithAuth { url, auth_header } => { tag(h, 244); url.as_ref().hash(h); auth_header.as_ref().hash(h); }
             Expr::FetchPostWithAuth { url, auth_header, body, } => { tag(h, 245); url.as_ref().hash(h); auth_header.as_ref().hash(h); body.as_ref().hash(h); }
             Expr::NetCreateServer { options, connection_listener, } => { tag(h, 246); options.hash(h); connection_listener.hash(h); }

--- a/crates/perry-hir/src/walker/expr_mut.rs
+++ b/crates/perry-hir/src/walker/expr_mut.rs
@@ -1464,6 +1464,7 @@ where
             body,
             headers,
             headers_dynamic,
+            signal,
         } => {
             f(url);
             f(method);
@@ -1473,6 +1474,9 @@ where
             }
             if let Some(hd) = headers_dynamic {
                 f(hd);
+            }
+            if let Some(s) = signal {
+                f(s);
             }
         }
         Expr::FetchGetWithAuth { url, auth_header } => {

--- a/crates/perry-hir/src/walker/expr_ref.rs
+++ b/crates/perry-hir/src/walker/expr_ref.rs
@@ -1441,6 +1441,7 @@ where
             body,
             headers,
             headers_dynamic,
+            signal,
         } => {
             f(url);
             f(method);
@@ -1450,6 +1451,9 @@ where
             }
             if let Some(hd) = headers_dynamic {
                 f(hd);
+            }
+            if let Some(s) = signal {
+                f(s);
             }
         }
         Expr::FetchGetWithAuth { url, auth_header } => {

--- a/crates/perry-runtime/src/object/global_fetch.rs
+++ b/crates/perry-runtime/src/object/global_fetch.rs
@@ -4,8 +4,40 @@
 //! repository's 2,000-line lint gate.
 
 use super::*;
+use std::cell::Cell;
 use std::ptr::null_mut;
 use std::sync::atomic::{AtomicPtr, Ordering};
+
+thread_local! {
+    /// The `signal` from the in-progress `fetch(url, { signal })` call, stashed
+    /// so the stdlib `js_fetch_with_options` (whose 4-arg ABI predates
+    /// AbortSignal support) can pick it up at entry without an ABI change.
+    static PENDING_FETCH_SIGNAL: Cell<f64> =
+        const { Cell::new(f64::from_bits(crate::value::TAG_UNDEFINED)) };
+}
+
+/// Stash the `signal` for the fetch call about to be dispatched. Set on the main
+/// thread immediately before the fetch call and consumed at the start of
+/// `js_fetch_with_options` — JS is single-threaded between those two points, so
+/// there is no interleaving with another fetch. The runtime
+/// `global_this_fetch_thunk` calls this for the dynamic/aliased fetch path; the
+/// codegen `fetch(url, {static init})` fast path can emit it too.
+#[no_mangle]
+pub extern "C" fn js_fetch_set_pending_signal(signal: f64) {
+    PENDING_FETCH_SIGNAL.with(|c| c.set(signal));
+}
+
+/// Consume and clear the pending fetch signal, returning `undefined` when none
+/// was set for this call (so a signal never leaks into a later signal-less
+/// fetch on the same thread).
+#[no_mangle]
+pub extern "C" fn js_fetch_take_pending_signal() -> f64 {
+    PENDING_FETCH_SIGNAL.with(|c| {
+        let v = c.get();
+        c.set(f64::from_bits(crate::value::TAG_UNDEFINED));
+        v
+    })
+}
 
 #[cfg(not(feature = "external-fetch-symbols"))]
 const FETCH_REASON: &str =
@@ -617,6 +649,10 @@ pub(super) extern "C" fn global_this_fetch_thunk(
     let method_ptr = fetch_option_string_ptr(init, b"method");
     let body_ptr = fetch_option_string_ptr(init, b"body");
     let headers_json_ptr = fetch_headers_json_ptr(init);
+
+    // Hand the `init.signal` (if any) to `js_fetch_with_options` so an
+    // `AbortController` / `AbortSignal.timeout` can cancel this request.
+    js_fetch_set_pending_signal(fetch_option(init, b"signal"));
 
     let promise =
         unsafe { call_fetch_with_options(url_ptr, method_ptr, body_ptr, headers_json_ptr) };

--- a/crates/perry-runtime/src/url/abort.rs
+++ b/crates/perry-runtime/src/url/abort.rs
@@ -125,6 +125,12 @@ fn fire_abort_listeners(signal: *mut ObjectHeader) {
     if signal.is_null() {
         return;
     }
+    // Wake any in-flight `fetch` bound to this signal so it rejects with an
+    // AbortError. Done here — before the JS-listener early return below — so the
+    // fetch is cancelled even when the signal carries no JS `abort` listener
+    // (the common `fetch(url, { signal })` case registers none). This replaces a
+    // per-fetch JS listener, so reused signals don't accumulate stale closures.
+    notify_fetch_abort(signal as i64);
     let listeners_val = crate::object::js_object_get_field_f64(signal, 2);
     let bits = listeners_val.to_bits();
     if bits == TAG_UNDEFINED_AC || bits == TAG_FALSE_AC {
@@ -188,6 +194,37 @@ pub(crate) fn abort_signal_ptr_from_value(value: f64) -> Option<*mut ObjectHeade
 
 pub(crate) fn is_abort_signal_value(value: f64) -> bool {
     abort_signal_ptr_from_value(value).is_some()
+}
+
+/// Resolve a JS value to its `AbortSignal` object pointer, or null when it is
+/// not an AbortSignal. FFI accessor over `abort_signal_ptr_from_value` for
+/// cross-crate callers — perry-stdlib's fetch abort bridge uses it to learn the
+/// signal handle behind a `fetch(url, { signal })` option.
+#[no_mangle]
+pub extern "C" fn js_abort_signal_resolve_ptr(value: f64) -> *mut ObjectHeader {
+    abort_signal_ptr_from_value(value).unwrap_or(std::ptr::null_mut())
+}
+
+/// Notify any in-flight `fetch` request bound to this signal that it has
+/// aborted (so it rejects with an AbortError and drops the request).
+///
+/// Under `external-fetch-symbols` — a fetch-using build — this calls the linked
+/// stdlib hook directly, the same link invariant `call_fetch_with_options`
+/// relies on. A non-fetch build links no stdlib fetch, so there is nothing to
+/// notify. Routing through `fire_abort_listeners` (rather than a per-fetch JS
+/// listener) means reused signals never accumulate stale listener closures.
+fn notify_fetch_abort(signal_ptr: i64) {
+    #[cfg(feature = "external-fetch-symbols")]
+    {
+        unsafe extern "C" {
+            fn js_fetch_notify_signal_aborted(signal_ptr: i64);
+        }
+        unsafe { js_fetch_notify_signal_aborted(signal_ptr) };
+    }
+    #[cfg(not(feature = "external-fetch-symbols"))]
+    {
+        let _ = signal_ptr;
+    }
 }
 
 extern "C" fn abort_error_constructor_thunk(_closure: *const crate::closure::ClosureHeader) -> f64 {
@@ -325,13 +362,53 @@ pub extern "C" fn js_abort_signal_remove_listener(
     }
 }
 
-/// `AbortSignal.timeout(ms)` — returns a signal that is initially not aborted.
-/// Perry does not spin up a real timer for this stub (tests only check the
-/// initial state), but the returned object has the full AbortSignal shape so
-/// subsequent `.aborted` / `.reason` / `.addEventListener` reads work.
+/// Build the `TimeoutError` DOMException that `AbortSignal.timeout(ms)` aborts
+/// with when its deadline elapses (Node names it `TimeoutError`, distinct from
+/// the `AbortError` used by `controller.abort()`).
+fn timeout_dom_exception_value() -> f64 {
+    let err = crate::event_target::js_dom_exception_new(
+        create_string_f64("The operation was aborted due to timeout"),
+        create_string_f64("TimeoutError"),
+    );
+    crate::value::js_nanbox_pointer(err as i64)
+}
+
+/// Callback-timer thunk: fires on the main thread (via `js_callback_timer_tick`)
+/// when an `AbortSignal.timeout(ms)` deadline elapses, aborting the captured
+/// signal with a `TimeoutError` and firing its `abort` listeners (which is how
+/// a pending `fetch` bound by the signal learns to reject — see
+/// `js_fetch_with_options`).
+extern "C" fn abort_signal_timeout_fire(closure: *const crate::closure::ClosureHeader) -> f64 {
+    let signal_bits = crate::closure::js_closure_get_capture_ptr(closure, 0) as u64;
+    let signal =
+        crate::value::js_nanbox_get_pointer(f64::from_bits(signal_bits)) as *mut ObjectHeader;
+    if !signal.is_null() {
+        abort_signal_set_aborted(signal, timeout_dom_exception_value());
+    }
+    f64::from_bits(TAG_UNDEFINED_AC)
+}
+
+/// `AbortSignal.timeout(ms)` — a signal that auto-aborts after `ms`.
+///
+/// Schedules a callback timer (drained on the main thread by
+/// `js_callback_timer_tick`) that marks the signal aborted with a
+/// `TimeoutError` and fires its listeners. The timer is `unref`'d so a pending
+/// timeout signal does not by itself keep the event loop alive (Node behavior);
+/// it still fires while any other ref'd work (e.g. an in-flight `fetch`) keeps
+/// the loop running. Previously this returned a never-aborting stub, so
+/// `fetch(url, { signal: AbortSignal.timeout(ms) })` could hang forever on a
+/// slow/held response instead of timing out.
 #[no_mangle]
-pub extern "C" fn js_abort_signal_timeout(_ms: f64) -> *mut ObjectHeader {
-    alloc_abort_signal()
+pub extern "C" fn js_abort_signal_timeout(ms: f64) -> *mut ObjectHeader {
+    let signal = alloc_abort_signal();
+    let func = abort_signal_timeout_fire as *const u8;
+    crate::closure::js_register_closure_arity(func, 0);
+    let closure = crate::closure::js_closure_alloc(func, 1);
+    let signal_value = crate::value::js_nanbox_pointer(signal as i64);
+    crate::closure::js_closure_set_capture_ptr(closure, 0, signal_value.to_bits() as i64);
+    let timer_id = crate::timer::js_set_timeout_callback(closure as i64, ms);
+    crate::timer::js_timer_unref(timer_id);
+    signal
 }
 
 /// Mark a signal as aborted with `reason` and fire its listeners. Idempotent:

--- a/crates/perry-runtime/src/url/mod.rs
+++ b/crates/perry-runtime/src/url/mod.rs
@@ -22,7 +22,8 @@ pub use self::abort::{
     js_abort_controller_abort, js_abort_controller_abort_reason, js_abort_controller_new,
     js_abort_controller_signal, js_abort_error_value, js_abort_signal_abort,
     js_abort_signal_add_listener, js_abort_signal_any, js_abort_signal_is_aborted,
-    js_abort_signal_remove_listener, js_abort_signal_throw_if_aborted, js_abort_signal_timeout,
+    js_abort_signal_remove_listener, js_abort_signal_resolve_ptr, js_abort_signal_throw_if_aborted,
+    js_abort_signal_timeout,
 };
 pub use self::node_compat::{
     js_url_domain_to_ascii, js_url_domain_to_unicode, js_url_file_url_to_path,

--- a/crates/perry-stdlib/src/fetch/abort_bridge.rs
+++ b/crates/perry-stdlib/src/fetch/abort_bridge.rs
@@ -1,0 +1,254 @@
+//! Bridges a JS `AbortSignal` to an in-flight `fetch` so the request rejects
+//! when the signal aborts — either `controller.abort()` or an
+//! `AbortSignal.timeout(ms)` deadline elapsing.
+//!
+//! The signal reaches the native fetch via the runtime's pending-signal stash
+//! (`js_fetch_set_pending_signal` / `js_fetch_take_pending_signal`), which keeps
+//! the 4-arg `js_fetch_with_options` ABI unchanged. On the main thread (at the
+//! start of `js_fetch_with_options`) we register a per-request
+//! `tokio::sync::Notify` keyed to the signal; the request future `select!`s its
+//! send/receive against that notify and, when the abort wins, rejects the fetch
+//! promise with a fresh `AbortError`.
+//!
+//! The signal's abort reaches us through the runtime: `fire_abort_listeners`
+//! (run by `controller.abort()` and the `AbortSignal.timeout` deadline) calls
+//! `js_fetch_notify_signal_aborted`, which wakes the registered notifies. There
+//! is deliberately no per-fetch JS `abort` listener, so reused signals never
+//! accumulate stale listener closures.
+//!
+//! Threading: the spawned future only awaits the `Notify` (Send/Sync) and
+//! rejects through `queue_deferred_resolution`, whose converter creates the
+//! error on the main thread — it never touches the JS heap from a worker. Refs
+//! the AbortSignal runtime in `perry_runtime::url::abort`.
+
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tokio::sync::Notify;
+
+use crate::common::async_bridge::{queue_deferred_resolution, queue_promise_resolution};
+
+unsafe extern "C" {
+    // `js_fetch_take_pending_signal` lives in perry-runtime's private
+    // `object::global_fetch` module, so it is reached as a `#[no_mangle]`
+    // extern rather than by Rust path.
+    fn js_fetch_take_pending_signal() -> f64;
+}
+
+/// AbortSignal object ptr (as `usize`) → the `Notify`s of every in-flight fetch
+/// bound to that signal. One signal can bound several concurrent requests, so
+/// the value is a list.
+static FETCH_ABORT_WATCHERS: Lazy<Mutex<HashMap<usize, Vec<Arc<Notify>>>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+fn watch(signal_ptr: usize) -> Arc<Notify> {
+    let notify = Arc::new(Notify::new());
+    FETCH_ABORT_WATCHERS
+        .lock()
+        .unwrap()
+        .entry(signal_ptr)
+        .or_default()
+        .push(notify.clone());
+    notify
+}
+
+fn unwatch(signal_ptr: usize, notify: &Arc<Notify>) {
+    let mut map = FETCH_ABORT_WATCHERS.lock().unwrap();
+    if let Some(list) = map.get_mut(&signal_ptr) {
+        list.retain(|n| !Arc::ptr_eq(n, notify));
+        if list.is_empty() {
+            map.remove(&signal_ptr);
+        }
+    }
+}
+
+/// Wake every in-flight fetch bound to `signal_ptr`. Called on the main thread
+/// by the runtime's `fire_abort_listeners` (`perry_runtime::url::abort`) when
+/// the signal aborts — `controller.abort()` or an `AbortSignal.timeout`
+/// deadline. A registry miss (no in-flight fetch for the signal) is a no-op.
+#[no_mangle]
+pub extern "C" fn js_fetch_notify_signal_aborted(signal_ptr: i64) {
+    let key = signal_ptr as usize;
+    let notifies: Vec<Arc<Notify>> = FETCH_ABORT_WATCHERS
+        .lock()
+        .unwrap()
+        .get(&key)
+        .cloned()
+        .unwrap_or_default();
+    for notify in notifies {
+        // `notify_one` stores a permit if the request future is not yet parked
+        // on `notified()`, so an abort that races the spawn is not lost.
+        notify.notify_one();
+    }
+}
+
+/// A live abort watch for one request: the `Notify` the request future selects
+/// on, plus the signal key used to deregister on completion.
+pub(crate) struct FetchAbortWatch {
+    notify: Arc<Notify>,
+    signal_ptr: usize,
+}
+
+impl FetchAbortWatch {
+    /// Resolves when the bound signal aborts.
+    pub(crate) async fn aborted(&self) {
+        self.notify.notified().await;
+    }
+}
+
+impl Drop for FetchAbortWatch {
+    fn drop(&mut self) {
+        unwatch(self.signal_ptr, &self.notify);
+    }
+}
+
+/// Outcome of consuming the pending fetch signal on the main thread.
+pub(crate) enum SignalState {
+    /// No signal, or the value was not an AbortSignal — dispatch normally.
+    None,
+    /// The signal was already aborted before the request started — the caller
+    /// should reject immediately without dispatching.
+    AlreadyAborted,
+    /// A live watch the request future must race against.
+    Watch(FetchAbortWatch),
+}
+
+/// Consume the runtime's pending fetch signal. If it is a live (not yet
+/// aborted) AbortSignal, register a `Notify` keyed to it for the request future
+/// to race against; an already-aborted signal short-circuits to a reject. MUST
+/// run on the main thread (it reads the signal object).
+pub(crate) fn take_pending_signal_watch() -> SignalState {
+    let signal_value = unsafe { js_fetch_take_pending_signal() };
+    let signal = perry_runtime::url::js_abort_signal_resolve_ptr(signal_value);
+    if signal.is_null() {
+        return SignalState::None;
+    }
+    if perry_runtime::url::js_abort_signal_is_aborted(signal) != 0 {
+        return SignalState::AlreadyAborted;
+    }
+    let signal_ptr = signal as usize;
+    SignalState::Watch(FetchAbortWatch {
+        notify: watch(signal_ptr),
+        signal_ptr,
+    })
+}
+
+/// Resolve a freshly-taken `SignalState` against the request's promise: reject
+/// up front when the signal was already aborted (returns `None`, telling the
+/// caller to return the promise immediately), otherwise yield the optional watch
+/// the request should race against.
+pub(crate) fn watch_or_reject(
+    state: SignalState,
+    promise_ptr: usize,
+) -> Option<Option<FetchAbortWatch>> {
+    match state {
+        SignalState::AlreadyAborted => {
+            queue_deferred_resolution(promise_ptr, false, abort_error_bits);
+            None
+        }
+        SignalState::Watch(watch) => Some(Some(watch)),
+        SignalState::None => Some(None),
+    }
+}
+
+/// Run `request_future`, racing it against the bound AbortSignal. If the signal
+/// aborts first, the request future is dropped (cancelling the in-flight reqwest
+/// request) and the promise rejects with an `AbortError`. The `watch`
+/// deregisters when dropped at the end of this scope.
+pub(crate) async fn race_request<F: std::future::Future<Output = ()>>(
+    promise_ptr: usize,
+    abort_watch: Option<FetchAbortWatch>,
+    request_future: F,
+) {
+    match abort_watch {
+        Some(watch) => {
+            tokio::select! {
+                _ = request_future => {}
+                _ = watch.aborted() => {
+                    queue_deferred_resolution(promise_ptr, false, abort_error_bits);
+                }
+            }
+        }
+        None => request_future.await,
+    }
+}
+
+/// Dispatch the `js_fetch_with_options` HTTP request, racing it against the
+/// bound AbortSignal. Lives here (rather than inline in `fetch::mod`) to keep
+/// that file under the line-size lint gate and to keep the abort orchestration
+/// in one place; it reaches the fetch internals through the parent module.
+pub(crate) async fn run_request(
+    promise_ptr: usize,
+    abort_watch: Option<FetchAbortWatch>,
+    inputs: super::request_handle::FetchInputs,
+) {
+    let super::request_handle::FetchInputs {
+        url,
+        method,
+        body,
+        custom_headers,
+    } = inputs;
+    let request_future = async move {
+        let client = super::HTTP_CLIENT.clone();
+        let mut request = match method.to_uppercase().as_str() {
+            "POST" => client.post(&url),
+            "PUT" => client.put(&url),
+            "DELETE" => client.delete(&url),
+            "PATCH" => client.patch(&url),
+            "HEAD" => client.head(&url),
+            _ => client.get(&url), // Default to GET
+        };
+        for (key, value) in &custom_headers {
+            request = request.header(key.as_str(), value.as_str());
+        }
+        if let Some(b) = body {
+            request = request.body(b);
+        }
+        match request.send().await {
+            Ok(response) => {
+                let status = response.status().as_u16();
+                let status_text = response
+                    .status()
+                    .canonical_reason()
+                    .unwrap_or("")
+                    .to_string();
+                let headers = super::headers_from_header_map(response.headers());
+                let body = response.bytes().await.unwrap_or_default().to_vec();
+                let response_id = super::alloc_fetch_handle_id();
+                super::FETCH_RESPONSES.lock().unwrap().insert(
+                    response_id,
+                    super::FetchResponse {
+                        status,
+                        status_text,
+                        headers,
+                        body,
+                        body_present: true,
+                        body_used: false,
+                        type_name: "basic".to_string(),
+                        url: url.clone(),
+                        redirected: false,
+                        cached_headers_id: None,
+                        cached_body_stream_id: None,
+                    },
+                );
+                let result_bits = super::handle_to_f64(response_id).to_bits();
+                queue_promise_resolution(promise_ptr, true, result_bits);
+            }
+            Err(e) => {
+                let err_msg = format!("Fetch error: {}", e);
+                // SAFETY: `fetch_error_bits` allocates an Error JSValue; this is
+                // the worker-side error path it replaces verbatim.
+                let err_bits = unsafe { super::fetch_error_bits(&err_msg) };
+                queue_promise_resolution(promise_ptr, false, err_bits);
+            }
+        }
+    };
+    race_request(promise_ptr, abort_watch, request_future).await;
+}
+
+/// NaN-boxed bits of a fresh `AbortError` for rejecting an aborted fetch. Built
+/// inside a `queue_deferred_resolution` converter so the error object is
+/// allocated on the main thread (never on a worker).
+pub(crate) fn abort_error_bits() -> u64 {
+    perry_runtime::url::js_abort_error_value().to_bits()
+}

--- a/crates/perry-stdlib/src/fetch/mod.rs
+++ b/crates/perry-stdlib/src/fetch/mod.rs
@@ -15,6 +15,8 @@ use crate::common::async_bridge::{queue_promise_resolution, spawn};
 // Web Fetch `Headers` FFI — split out to keep this file under the 2,000-line
 // lint gate (#1649). The child module sees mod.rs's private items via its
 // `use super::*`.
+mod abort_bridge;
+pub use abort_bridge::*;
 mod headers;
 mod request_handle;
 pub use headers::*;
@@ -606,19 +608,26 @@ pub unsafe extern "C" fn js_fetch_with_options(
     body_ptr: *const StringHeader,
     headers_json_ptr: *const StringHeader,
 ) -> *mut perry_runtime::Promise {
+    // Consume the pending `AbortSignal` (stashed by the fetch thunk / codegen)
+    // on the main thread BEFORE allocating the promise, so a GC during the
+    // allocation can't move the still-TLS-stashed signal before we read it.
+    let abort_state = abort_bridge::take_pending_signal_watch();
+
     let promise = perry_runtime::js_promise_new();
     let promise_ptr = promise as usize;
+
+    // An already-aborted signal rejects the request up front; otherwise keep the
+    // optional watch to race the request against.
+    let abort_watch = match abort_bridge::watch_or_reject(abort_state, promise_ptr) {
+        Some(watch) => watch,
+        None => return promise,
+    };
 
     // `fetch(Request)` form: callers (axios/gaxios / any WHATWG-fetch) build a
     // `Request` object and call `fetch(request, init)`; its handle id lands in
     // the `url_ptr` slot. Recover url/method/body/headers from the Request
     // registry so the request is dispatched (`init` members override).
-    let request_handle::FetchInputs {
-        url,
-        method,
-        body,
-        custom_headers,
-    } = match request_handle::resolve_fetch_inputs(
+    let inputs = match request_handle::resolve_fetch_inputs(
         string_from_header(url_ptr),
         string_from_header(method_ptr),
         string_from_header(body_ptr),
@@ -632,71 +641,9 @@ pub unsafe extern "C" fn js_fetch_with_options(
         }
     };
 
-    spawn(async move {
-        let client = HTTP_CLIENT.clone();
-        let mut request = match method.to_uppercase().as_str() {
-            "POST" => client.post(&url),
-            "PUT" => client.put(&url),
-            "DELETE" => client.delete(&url),
-            "PATCH" => client.patch(&url),
-            "HEAD" => client.head(&url),
-            _ => client.get(&url), // Default to GET
-        };
-
-        // Add custom headers
-        for (key, value) in &custom_headers {
-            request = request.header(key.as_str(), value.as_str());
-        }
-
-        // Add body if present
-        if let Some(b) = body {
-            request = request.body(b);
-        }
-
-        match request.send().await {
-            Ok(response) => {
-                let status = response.status().as_u16();
-                let status_text = response
-                    .status()
-                    .canonical_reason()
-                    .unwrap_or("")
-                    .to_string();
-
-                let headers = headers_from_header_map(response.headers());
-
-                let body = response.bytes().await.unwrap_or_default().to_vec();
-
-                // Store response
-                let response_id = alloc_fetch_handle_id();
-
-                FETCH_RESPONSES.lock().unwrap().insert(
-                    response_id,
-                    FetchResponse {
-                        status,
-                        status_text,
-                        headers,
-                        body,
-                        body_present: true,
-                        body_used: false,
-                        type_name: "basic".to_string(),
-                        url: url.clone(),
-                        redirected: false,
-                        cached_headers_id: None,
-                        cached_body_stream_id: None,
-                    },
-                );
-
-                // Return response handle
-                let result_bits = handle_to_f64(response_id).to_bits();
-                queue_promise_resolution(promise_ptr, true, result_bits);
-            }
-            Err(e) => {
-                let err_msg = format!("Fetch error: {}", e);
-                let err_bits = fetch_error_bits(&err_msg);
-                queue_promise_resolution(promise_ptr, false, err_bits);
-            }
-        }
-    });
+    // Dispatch + abort handling live in `abort_bridge::run_request` (keeps this
+    // file under the line-size lint gate).
+    spawn(abort_bridge::run_request(promise_ptr, abort_watch, inputs));
 
     promise
 }


### PR DESCRIPTION
## Problem

`fetch(url, { signal })` ignored the AbortSignal. `js_fetch_with_options` took only `url`/`method`/`body`/`headers` and ran the request to completion, so neither `controller.abort()` nor `AbortSignal.timeout(ms)` could cancel an in-flight request. Separately, `AbortSignal.timeout(ms)` was a no-op stub that returned a signal which *never* aborts.

Together, the common pattern

```js
await fetch(url, { signal: AbortSignal.timeout(5000) });
```

would **hang forever** on a slow or unresponsive endpoint instead of rejecting at the deadline. A minimal repro before this change: `AbortSignal.timeout(2000)` on a 10s-delay request resolved after the full 10s (the timeout was ignored).

## Fix

Wire AbortSignal through the whole fetch path:

- **`AbortSignal.timeout(ms)`** (`url/abort.rs`) now schedules a real, `unref`'d callback timer. When the deadline elapses on the main thread (via `js_callback_timer_tick`), it aborts the signal with a `TimeoutError` DOMException and fires its `abort` listeners.
- **Plumbing** — the signal reaches the stdlib fetch via a thread-local stash (`js_fetch_set_pending_signal` / `js_fetch_take_pending_signal`), which keeps the existing 4-arg `js_fetch_with_options` ABI unchanged. The runtime `fetch` thunk sets it for the dynamic/aliased path; codegen emits it just before the call for the `fetch(url, { … })` fast path (a new `signal` field threaded through the `FetchWithOptions` HIR node).
- **`js_fetch_with_options`** consumes the signal on the main thread, registers a native `abort` listener that wakes a per-request `tokio::sync::Notify`, and `select!`s the request against the abort. On abort it drops the request future (cancelling the in-flight `reqwest` request) and rejects the promise with an `AbortError`. An already-aborted signal rejects up front. Both `controller.abort()` and the `AbortSignal.timeout` deadline flow through the same listener.

Threading is safe: registration runs on the main thread; the worker only awaits the `Notify` and rejects through `queue_deferred_resolution`, whose converter builds the error on the main thread (never touching the JS heap from a worker).

## Testing

A repro covering both call paths (compiled native):

| case | result |
|---|---|
| `AbortSignal.timeout(300)` standalone | `.aborted === true` after the deadline ✓ |
| `fetch(url, { signal: AbortSignal.timeout(1000) })` (direct + aliased) | rejects `AbortError` at ~1000ms ✓ |
| `fetch(url, { signal: controller.signal })` + `controller.abort()` after 1s | rejects `AbortError` at ~1000ms ✓ |
| normal `fetch(url)` (no signal) | unchanged, resolves 200 ✓ |

- `cargo test -p perry-runtime -p perry-codegen` — green (the only failures are pre-existing test-parallelism flakiness in unrelated `closure::dynamic_props` / `object::tests`, which pass single-threaded).
- No behavior change for signal-less fetches; the WASM fetch backend keeps its existing (no-cancellation) behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fetch requests now support cancellation via a `signal` option, including `AbortSignal.timeout()` auto-abort and abort-listener behavior.
  * In-flight `fetch` operations can now be cancelled using `AbortController`/`AbortSignal`.
* **Bug Fixes**
  * Fetch IR processing now consistently carries and recognizes the optional `signal` field across string collection, escape checking, walkers, and stable hashing.
  * Updated tests to match the new fetch options shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->