### PR TITLE
perf(fastify): move per-request headers/body/params into the context instead of cloning

### DIFF
--- a/crates/perry-ext-fastify/src/lib.rs
+++ b/crates/perry-ext-fastify/src/lib.rs
@@ -658,4 +658,62 @@ mod tests {
         assert_eq!(route.handler, 22);
         assert_eq!(params.get("id").map(String::as_str), Some("7"));
     }
+
+    /// Regression: the per-request dispatch in `process_request` must MOVE the
+    /// pending request's headers/body/params into `FastifyContext` (via
+    /// `mem::take` / `Option::take`) rather than clone them — each is consumed
+    /// exactly once, so cloning fires three redundant per-request allocations
+    /// (two `HashMap`s + one `Vec`, dominated by the O(headers) header-map clone).
+    ///
+    /// This drives `build_context_from_pending` — the *same* helper
+    /// `process_request` uses to construct the context — so the test fails if
+    /// that construction reverts to cloning: after the call the source `pending`
+    /// collections must be empty (a clone would leave them populated, the canary),
+    /// while `method`/`path` must survive (they're reused for the route match).
+    #[test]
+    fn process_request_moves_pending_fields_not_clone() {
+        use crate::server::{build_context_from_pending, FastifyPendingRequest};
+
+        let mut headers = HashMap::new();
+        headers.insert("content-type".to_string(), "application/json".to_string());
+        headers.insert("x-trace-id".to_string(), "abc-123".to_string());
+        let mut params = HashMap::new();
+        params.insert("id".to_string(), "42".to_string());
+
+        // The response channel is irrelevant to context construction; a dropped
+        // receiver is fine — the helper never touches `response_tx`.
+        let (response_tx, _response_rx) = tokio::sync::oneshot::channel();
+        let mut pending = FastifyPendingRequest {
+            method: "POST".to_string(),
+            path: "/users/42".to_string(),
+            headers,
+            body: Some(b"{\"hello\":\"world\"}".to_vec()),
+            params,
+            response_tx,
+        };
+
+        // Exercise the production construction path.
+        let ctx = build_context_from_pending(7, &mut pending);
+
+        // (a) The context received the original values (incl. the request_id).
+        assert_eq!(ctx.request_id, 7);
+        assert_eq!(ctx.method, "POST");
+        assert_eq!(ctx.headers.len(), 2);
+        assert_eq!(
+            ctx.headers.get("content-type").map(String::as_str),
+            Some("application/json")
+        );
+        assert_eq!(ctx.params.get("id").map(String::as_str), Some("42"));
+        assert_eq!(ctx.body.as_deref(), Some(&b"{\"hello\":\"world\"}"[..]));
+
+        // (b) Move semantics — `pending`'s collections are empty post-construction.
+        // A clone-based helper would leave them populated, failing the test.
+        assert!(pending.headers.is_empty());
+        assert!(pending.params.is_empty());
+        assert!(pending.body.is_none());
+
+        // (c) method/path are intentionally NOT consumed — reused for the route match.
+        assert_eq!(pending.method, "POST");
+        assert_eq!(pending.path, "/users/42");
+    }
 }

--- a/crates/perry-ext-fastify/src/server.rs
+++ b/crates/perry-ext-fastify/src/server.rs
@@ -761,17 +761,33 @@ async fn handle_fastify_websocket_upgrade(
         .unwrap())
 }
 
-/// Process one request — fire hooks, call route handler, send the
-/// response back through the oneshot channel.
-fn process_request(app_handle: Handle, pending: FastifyPendingRequest) {
-    let ctx = FastifyContext::new(
-        0,
+/// Build the per-request [`FastifyContext`], MOVING the pending request's
+/// headers/body/params out of `pending` (via `mem::take` / `Option::take`)
+/// rather than cloning them. Each is consumed exactly once, so cloning would
+/// fire three redundant per-request allocations (two `HashMap`s + one `Vec`,
+/// dominated by the O(headers) header-map clone) on the hot dispatch path.
+/// `method`/`path` stay cloned: `process_request` reuses them for the route
+/// match (`app.match_route(&pending.method, &pending.path)`) after the context
+/// is built. This is the single construction site `process_request` uses, so a
+/// regression test can drive it directly.
+pub(crate) fn build_context_from_pending(
+    request_id: u64,
+    pending: &mut FastifyPendingRequest,
+) -> FastifyContext {
+    FastifyContext::new(
+        request_id,
         pending.method.clone(),
         pending.path.clone(),
-        pending.headers.clone(),
-        pending.body.clone(),
-        pending.params.clone(),
-    );
+        std::mem::take(&mut pending.headers),
+        pending.body.take(),
+        std::mem::take(&mut pending.params),
+    )
+}
+
+/// Process one request — fire hooks, call route handler, send the
+/// response back through the oneshot channel.
+fn process_request(app_handle: Handle, mut pending: FastifyPendingRequest) {
+    let ctx = build_context_from_pending(0, &mut pending);
     let ctx_handle = register_handle(ctx);
 
     // Snapshot hooks + matched route (need to drop the borrow before


### PR DESCRIPTION
## Summary

perry-ext-fastify's per-request dispatch cloned the pending request's headers/body/params into the `FastifyContext` even though each is consumed exactly once. This moves them out (`mem::take` / `Option::take`) instead — three fewer allocations per request on the hot path, with no behavior change.

`process_request` — the main-thread request pump in perry-ext-fastify — built the `FastifyContext` by cloning all five `FastifyPendingRequest` fields (method, path, headers, body, params), even though the context consumes headers/body/ params and they are never read again on the request thread. The three clones — a `HashMap<String,String>` (headers) + a `Vec<u8>` (body) + a `HashMap<String,String>` (params) — fired on every request; the header-map clone is O(headers) and is the largest per-request allocation after the hyper body collect.

Move them out instead: `pending` becomes `mut`, headers/params use `std::mem::take`, and body uses `Option::take`. method and path stay cloned because they're still referenced for the route-match pass (`app.match_route(&pending.method, &pending.path)`). Semantically identical — the context receives the same data — with three fewer allocations per request.

Adds a regression test (`process_request_moves_pending_fields_not_clone`) that asserts both (a) the context sees the original contents and (b) the source collections are empty after construction; a clone-based regression would leave them populated.

## Changes

- `crates/perry-ext-fastify/src/server.rs` — `process_request` now takes `mut pending`; `headers`/`params` are moved via `std::mem::take` and `body` via `Option::take` into `FastifyContext::new`. `method`/`path` stay cloned because they're reused for the route-match pass (`app.match_route(&pending.method, &pending.path)`).
- `crates/perry-ext-fastify/src/lib.rs` — added the `process_request_moves_pending_fields_not_clone` regression test (asserts the context receives the contents and the source collections are emptied).

## Related issue

n/a — standalone allocation-reduction perf change.

## Test plan

```
$ cargo test -p perry-ext-fastify
test tests::process_request_moves_pending_fields_not_clone ... ok
test result: ok. 14 passed; 0 failed; 0 ignored; ...

$ cargo build --release -p perry            # builds perry + perry-ext-fastify
    Finished `release` profile [optimized] target(s)

$ rm -rf target/perry-auto-* && scripts/run_fastify_tests.sh
fastify-tests: 12 passed, 0 failed          # request dispatch behaviorally unchanged

$ cargo fmt --check -p perry-ext-fastify     # clean
```

- [x] `cargo build --release` clean — built `-p perry` (compiles the affected chain incl. perry-ext-fastify); the full-workspace build needs the GTK/`gdk-pixbuf` system libs for the `perry-ui-*` crates, which CI provides.
- [x] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes — ran the affected crate (`cargo test -p perry-ext-fastify`, **14/14**) plus `scripts/run_fastify_tests.sh` (**12/12**); the full workspace test is deferred to CI (the base `perry-ui` crate needs `gdk-pixbuf`, unavailable locally).
- [x] (if user-facing) Added or updated a test under `test-files/` or a `#[test]` in the affected crate — added `process_request_moves_pending_fields_not_clone` in `perry-ext-fastify`.
- [ ] (if CLI / stdlib / runtime API changed) Updated `docs/src/` — n/a, internal allocation change, no public API surface.
- [ ] (if touching a platform UI backend) Built `-p perry-ui-<backend>` locally on that platform — n/a.

## Screenshots / output

n/a — internal performance change; no user-visible output difference (see the Test plan output above).

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log — `perf(fastify): …`
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling by moving headers, query parameters, and body into the per-request context to reduce unnecessary duplication on dispatch.
  * Ensures the original pending request no longer retains transferred fields after context creation, while method/path remain available for routing.

* **Tests**
  * Added a regression test covering correct context values and verifying pending headers/params/body are cleared after building the context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->