### PR TITLE
perf(fastify): copy string response bytes directly, skip the String round-trip

### DIFF
--- a/crates/perry-ext-fastify/src/context.rs
+++ b/crates/perry-ext-fastify/src/context.rs
@@ -13,6 +13,14 @@ use perry_ffi::{
 
 const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
 
+/// Mirror of `perry_runtime::string::STRING_FLAG_HAS_LONE_SURROGATES` — the
+/// `StringHeader::flags` bit marking a WTF-8 string that holds lone surrogates
+/// (so it isn't well-formed UTF-8). Defined locally because this crate's
+/// library code links only `perry-ffi`, not `perry-runtime` (same local-mirror
+/// pattern as the `extern "C"` runtime symbols below); the value is part of the
+/// stable runtime ABI.
+const STRING_FLAG_HAS_LONE_SURROGATES: u32 = 1;
+
 // Runtime symbols that perry-ffi hasn't yet wrapped — these are
 // stable `extern "C"` exports from perry-runtime. Declaring them
 // locally is the same pattern perry-ext-{net,http,ws} use for the
@@ -637,6 +645,35 @@ pub unsafe extern "C" fn js_fastify_ctx_redirect(ctx_handle: Handle, url: i64, s
 pub(crate) unsafe fn jsvalue_to_response_body(value: f64) -> (Vec<u8>, BodyKind) {
     let jsv = JsValue::from_bits(value.to_bits());
     if jsv.is_string() {
+        // Fast path: copy the StringHeader's bytes straight into the response
+        // Vec, skipping the `extract_jsvalue_string` round-trip
+        // (`String::from_utf8_lossy(..).to_string().into_bytes()` — one extra
+        // heap allocation plus a redundant UTF-8 validity scan). The body
+        // writer streams the bytes out unchanged, so the intermediate `String`
+        // buys nothing on the common text-response path. The pointer math
+        // mirrors `string_from_header`.
+        //
+        // Only well-formed UTF-8 is safe to copy verbatim. Perry strings are
+        // WTF-8 and may carry lone surrogates (flagged
+        // `STRING_FLAG_HAS_LONE_SURROGATES`); copying those raw would emit
+        // invalid UTF-8 in the response. For flagged strings fall through to
+        // the `extract_jsvalue_string` path, whose `from_utf8_lossy` substitutes
+        // U+FFFD — preserving the pre-fast-path output.
+        let ptr = js_get_string_pointer_unified(value);
+        if ptr != 0 {
+            let header = ptr as *const StringHeader;
+            let well_formed = (*header).flags & STRING_FLAG_HAS_LONE_SURROGATES == 0;
+            if well_formed {
+                let len = (*header).byte_len as usize;
+                let data_ptr = (header as *const u8).add(std::mem::size_of::<StringHeader>());
+                let mut bytes = Vec::with_capacity(len);
+                bytes.extend_from_slice(std::slice::from_raw_parts(data_ptr, len));
+                return (bytes, BodyKind::TextOrJson);
+            }
+        }
+        // Fallback to the lossy `String` round-trip — taken for WTF-8 strings
+        // with lone surrogates, and defensively if the unified pointer accessor
+        // returns 0 (should not happen for an `is_string()` value).
         if let Some(s) = extract_jsvalue_string(value) {
             return (s.into_bytes(), BodyKind::TextOrJson);
         }

--- a/crates/perry-ext-fastify/src/lib.rs
+++ b/crates/perry-ext-fastify/src/lib.rs
@@ -801,4 +801,70 @@ mod tests {
         assert_eq!(pending.method, "POST");
         assert_eq!(pending.path, "/users/42");
     }
+
+    /// The string fast path in `jsvalue_to_response_body` copies the
+    /// `StringHeader` bytes directly, bypassing the `extract_jsvalue_string`
+    /// round-trip. It must reproduce the source bytes exactly — including
+    /// multi-byte UTF-8 — and tag the body `TextOrJson`.
+    #[test]
+    fn jsvalue_to_response_body_string_fast_path() {
+        let _guard = GcTestGuard::new();
+        // SAFETY: `alloc_string` returns a live `StringHeader`; we NaN-box it and
+        // read it back synchronously with no intervening GC.
+        unsafe {
+            for sample in ["Status: UP [200]", "héllo → 世界 🚀", ""] {
+                let s = perry_ffi::alloc_string(sample);
+                assert!(!s.is_null(), "alloc_string returned null for {sample:?}");
+                let value = f64::from_bits(perry_ffi::nanbox_string_bits(s.as_raw()));
+
+                let (bytes, kind) = crate::context::jsvalue_to_response_body(value);
+                assert_eq!(bytes, sample.as_bytes(), "byte-exact round-trip");
+                assert_eq!(kind, crate::context::BodyKind::TextOrJson);
+            }
+        }
+    }
+
+    /// A WTF-8 string carrying a lone surrogate must NOT take the verbatim-copy
+    /// fast path (that would emit invalid UTF-8). It has to fall back to the
+    /// lossy `String` round-trip, substituting U+FFFD — exactly the
+    /// pre-fast-path behaviour.
+    #[test]
+    fn jsvalue_to_response_body_lone_surrogate_falls_back_to_lossy() {
+        let _guard = GcTestGuard::new();
+        unsafe {
+            // "hi" + lone surrogate U+D800 (WTF-8: ED A0 80) + "!".
+            let wtf8: &[u8] = b"hi\xED\xA0\x80!";
+            let ptr =
+                perry_runtime::string::js_string_from_wtf8_bytes(wtf8.as_ptr(), wtf8.len() as u32);
+            assert!(!ptr.is_null());
+            // The constructor flags the string as carrying lone surrogates, so the
+            // fast path must skip it (otherwise this test wouldn't exercise the guard).
+            assert_ne!(
+                (*ptr).flags & perry_runtime::string::STRING_FLAG_HAS_LONE_SURROGATES,
+                0,
+                "expected js_string_from_wtf8_bytes to flag the lone surrogate"
+            );
+            // The two `StringHeader` types are layout-identical across crates.
+            let value = f64::from_bits(perry_ffi::nanbox_string_bits(
+                ptr as *mut perry_ffi::StringHeader,
+            ));
+
+            let (bytes, kind) = crate::context::jsvalue_to_response_body(value);
+            // Output is the lossy form (valid UTF-8), not the raw WTF-8 bytes.
+            assert_eq!(
+                bytes,
+                String::from_utf8_lossy(wtf8).into_owned().into_bytes()
+            );
+            assert!(
+                std::str::from_utf8(&bytes).is_ok(),
+                "response body must be valid UTF-8"
+            );
+            assert_ne!(
+                bytes.as_slice(),
+                wtf8,
+                "raw WTF-8 bytes must not be emitted verbatim"
+            );
+            assert_eq!(kind, crate::context::BodyKind::TextOrJson);
+        }
+    }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Perry! A few things to know before you submit:

1. Please do NOT bump `[workspace.package] version` in Cargo.toml.
2. Please do NOT edit the "**Current Version:**" line or add a "Recent
   Changes" entry in CLAUDE.md.
3. Please do NOT edit CHANGELOG.md.

The maintainer folds all of that metadata in at merge time — Perry
releases frequently, and version bumps conflict if they live on the
PR branch. See CONTRIBUTING.md for the reasoning.
-->

## Summary

A Fastify handler returning a plain string had its body built through a `String` round-trip — `String::from_utf8_lossy(bytes).to_string().into_bytes()` — which costs a redundant O(len) UTF-8 validity scan plus an extra heap allocation before reaching the `Vec<u8>` hyper streams out. This adds a fast path that copies the `StringHeader`'s bytes straight into the response `Vec` for well-formed UTF-8. Per-call cost of `jsvalue_to_response_body` drops **~2×** for a small body and **~16×** for a 1 KB body, with no behavior change.

## Changes

- `crates/perry-ext-fastify/src/context.rs`
  - In `jsvalue_to_response_body`'s `is_string()` branch, read the `StringHeader` directly (`js_get_string_pointer_unified` → `byte_len` → data after the header, the same layout `string_from_header` reads) and `extend_from_slice` into a capacity-exact `Vec`, returning `BodyKind::TextOrJson`.
  - **WTF-8 safety:** the verbatim copy is gated on the string being well-formed UTF-8. Perry strings can carry lone surrogates (`STRING_FLAG_HAS_LONE_SURROGATES`); for those — and defensively if the pointer accessor returns 0 — the code falls back to the `extract_jsvalue_string` round-trip, whose `from_utf8_lossy` substitutes U+FFFD, preserving the prior valid-UTF-8 output exactly.
- `crates/perry-ext-fastify/src/lib.rs` — two regression tests (see Test plan).

## Related issue

n/a — standalone response-body perf change.

## Test plan

Microbenchmark of `jsvalue_to_response_body` on a NaN-boxed string (release, 5M iterations), before (old `String` round-trip) vs after (fast path):

```
small (16 B):  before 11.6 ns  →  after  5.9 ns   (~2.0×)
large (1 KB):  before  288 ns  →  after 17.0 ns   (~16.5×)
```

(The gap widens with body size because the old path's UTF-8 validity scan is O(len) while the fast path is a single sized copy.)

```
$ cargo test -p perry-ext-fastify
test tests::jsvalue_to_response_body_string_fast_path ... ok
test tests::jsvalue_to_response_body_lone_surrogate_falls_back_to_lossy ... ok
test result: ok. 15 passed; 0 failed; ...

$ cargo build --release -p perry            # builds perry + perry-ext-fastify
    Finished `release` profile [optimized] target(s)

$ rm -rf target/perry-auto-* && scripts/run_fastify_tests.sh
fastify-tests: 12 passed, 0 failed          # every string response exercises the fast path

$ cargo fmt --check -p perry-ext-fastify     # clean
```

- [x] `cargo build --release` clean — built `-p perry` (compiles the affected chain incl. perry-ext-fastify); the full-workspace build needs the GTK/`gdk-pixbuf` system libs for the `perry-ui-*` crates, which CI provides.
- [x] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes — ran the affected crate (`cargo test -p perry-ext-fastify`, **15/15**) plus `scripts/run_fastify_tests.sh` (**12/12**); the full workspace test is deferred to CI (the base `perry-ui` crate needs `gdk-pixbuf`, unavailable locally).
- [x] (if user-facing) Added or updated a test under `test-files/` or a `#[test]` in the affected crate — `jsvalue_to_response_body_string_fast_path` and `jsvalue_to_response_body_lone_surrogate_falls_back_to_lossy` in `perry-ext-fastify`.
- [ ] (if CLI / stdlib / runtime API changed) Updated `docs/src/` — n/a, internal response-body construction, no public API surface.
- [ ] (if touching a platform UI backend) Built `-p perry-ui-<backend>` locally on that platform — n/a.

## Screenshots / output

`jsvalue_to_response_body` microbenchmark (release, 5M iterations, before vs after):

```
BENCH string-body small-16B: before(String round-trip)=11.6 ns  after(fast path)= 5.9 ns  (~2.0x)
BENCH string-body large-1KB: before(String round-trip)= 288 ns  after(fast path)=17.0 ns  (~16.5x)
```

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log — `perf(fastify): …`
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of string responses by adding a fast conversion path that preserves the original UTF-8 bytes exactly for standard strings.
  * Ensures correct behavior for special/invalid encodings by falling back to the existing conversion logic when byte-accurate output isn’t safe.

* **Tests**
  * Added coverage to confirm string responses match the original bytes exactly (including multi-byte UTF-8) and are tagged as text.
  * Added coverage to confirm lone-surrogate (WTF-8) inputs produce valid, lossy UTF-8 output with the expected text tagging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->