### PR TITLE
perf(fastify): cache the per-request params/query JS object

### DIFF
--- a/crates/perry-ext-fastify/src/context.rs
+++ b/crates/perry-ext-fastify/src/context.rs
@@ -87,6 +87,20 @@ pub struct FastifyContext {
     pub response_body: Option<Vec<u8>>,
     /// User data stashed by auth middleware — NaN-boxed bits.
     pub user_data: u64,
+    /// Cached `request.params` JS object, built on first access by
+    /// `js_fastify_req_params_object`. `0` means uncached; otherwise the
+    /// NaN-boxed object-pointer bits (`POINTER_TAG` top 16 = `0x7FFD`), so `0`
+    /// never collides with a real entry. `AtomicU64` (not `Cell`) because the
+    /// handle registry hands out shared `&FastifyContext` and the type must stay
+    /// `Send + Sync`. Each request gets a fresh context (reset to 0 in `new`), so
+    /// the cache is naturally request-scoped — no inter-request leak. The GC root
+    /// scanner visits this slot (`scan_fastify_roots`) so a copying GC between the
+    /// first build and a later `req.params` read keeps the object alive *and*
+    /// relocates the cached pointer.
+    pub params_object_cache: AtomicU64,
+    /// Cached `request.query` JS object. Same encoding and invariants as
+    /// `params_object_cache`.
+    pub query_object_cache: AtomicU64,
 }
 
 impl FastifyContext {
@@ -116,6 +130,8 @@ impl FastifyContext {
             sent: false,
             response_body: None,
             user_data: TAG_UNDEFINED,
+            params_object_cache: AtomicU64::new(0),
+            query_object_cache: AtomicU64::new(0),
         }
     }
 
@@ -254,6 +270,11 @@ pub unsafe extern "C" fn js_fastify_req_params(ctx_handle: Handle) -> *mut Strin
 
 /// `request.params` returning a NaN-boxed object — built via
 /// perry-ffi's shape-aware allocator.
+///
+/// Caches the constructed object on the `FastifyContext` on first access, so a
+/// handler reading `req.params.a` then `req.params.b` builds the object once.
+/// The cache holds the NaN-boxed object bits; the GC root scanner visits the
+/// slot, so a copying GC between reads keeps it alive and relocates the pointer.
 #[no_mangle]
 pub unsafe extern "C" fn js_fastify_req_params_object(ctx_handle: Handle) -> f64 {
     let undefined = f64::from_bits(TAG_UNDEFINED);
@@ -261,7 +282,20 @@ pub unsafe extern "C" fn js_fastify_req_params_object(ctx_handle: Handle) -> f64
         Some(c) => c,
         None => return undefined,
     };
-    build_string_map_object(&ctx.params).unwrap_or(undefined)
+    // Fast path: object already built earlier in this same request.
+    let cached = ctx.params_object_cache.load(Ordering::Acquire);
+    if cached != 0 {
+        return f64::from_bits(cached);
+    }
+    match build_string_map_object(&ctx.params) {
+        // Release so a later Acquire load on this context sees the bits.
+        Some(obj) => {
+            ctx.params_object_cache
+                .store(obj.to_bits(), Ordering::Release);
+            obj
+        }
+        None => undefined,
+    }
 }
 
 /// `c.req.param('id')` — single param accessor.
@@ -291,7 +325,9 @@ pub unsafe extern "C" fn js_fastify_req_query(ctx_handle: Handle) -> *mut String
     std::ptr::null_mut()
 }
 
-/// `request.query` returning a NaN-boxed object.
+/// `request.query` returning a NaN-boxed object. Cached on the
+/// `FastifyContext` on first access — same mechanism as
+/// `js_fastify_req_params_object`.
 #[no_mangle]
 pub unsafe extern "C" fn js_fastify_req_query_object(ctx_handle: Handle) -> f64 {
     let undefined = f64::from_bits(TAG_UNDEFINED);
@@ -299,8 +335,19 @@ pub unsafe extern "C" fn js_fastify_req_query_object(ctx_handle: Handle) -> f64 
         Some(c) => c,
         None => return undefined,
     };
+    let cached = ctx.query_object_cache.load(Ordering::Acquire);
+    if cached != 0 {
+        return f64::from_bits(cached);
+    }
     let params = ctx.get_query_params();
-    build_string_map_object(&params).unwrap_or(undefined)
+    match build_string_map_object(&params) {
+        Some(obj) => {
+            ctx.query_object_cache
+                .store(obj.to_bits(), Ordering::Release);
+            obj
+        }
+        None => undefined,
+    }
 }
 
 /// `request.body` — raw body as a string.

--- a/crates/perry-ext-fastify/src/lib.rs
+++ b/crates/perry-ext-fastify/src/lib.rs
@@ -125,6 +125,24 @@ fn scan_fastify_roots(visitor: &mut GcRootVisitor<'_>) {
             visitor.visit_i64_slot(cb);
         }
     });
+
+    // Per-request `req.params` / `req.query` JS objects are cached on each live
+    // FastifyContext (`params_object_cache` / `query_object_cache`). Visit them
+    // as NaN-boxed value slots so a copying GC between the first accessor build
+    // and a later read keeps the object alive AND relocates the cached pointer.
+    // `0` means uncached; only a real object pointer (POINTER_TAG `0x7FFD`) is
+    // visited. `get_mut()` is sound here — the GC scan has exclusive access to
+    // each handle.
+    iter_handles_of_mut::<FastifyContext, _>(|ctx| {
+        let params_slot = ctx.params_object_cache.get_mut();
+        if *params_slot >> 48 == 0x7FFD {
+            visitor.visit_nanbox_u64_slot(params_slot);
+        }
+        let query_slot = ctx.query_object_cache.get_mut();
+        if *query_slot >> 48 == 0x7FFD {
+            visitor.visit_nanbox_u64_slot(query_slot);
+        }
+    });
 }
 
 // ============================================================================
@@ -209,6 +227,134 @@ mod tests {
             assert_rewritten(hook, app.hooks.on_request[0]);
             assert_rewritten(error, app.error_handler.expect("error handler"));
             assert_rewritten(plugin, app.plugins[0].handler);
+        }
+        drop_handle(handle);
+    }
+
+    /// A fresh `FastifyContext` must have both per-request object caches empty
+    /// (`0`), and the slots round-trip the NaN-boxed bits they're built to hold.
+    #[test]
+    fn context_object_caches_start_empty() {
+        use std::sync::atomic::Ordering;
+        let ctx = FastifyContext::new(
+            7,
+            "GET".to_string(),
+            "/users/:id".to_string(),
+            HashMap::new(),
+            None,
+            HashMap::new(),
+        );
+        assert_eq!(ctx.params_object_cache.load(Ordering::Acquire), 0);
+        assert_eq!(ctx.query_object_cache.load(Ordering::Acquire), 0);
+
+        // Round-trip a synthetic NaN-boxed object pointer through each slot, so a
+        // wiring regression in either cache is caught.
+        let nan_boxed = 0x7FFD_0000_DEAD_BEEFu64;
+        ctx.params_object_cache.store(nan_boxed, Ordering::Release);
+        assert_eq!(ctx.params_object_cache.load(Ordering::Acquire), nan_boxed);
+        ctx.query_object_cache.store(nan_boxed, Ordering::Release);
+        assert_eq!(ctx.query_object_cache.load(Ordering::Acquire), nan_boxed);
+    }
+
+    /// The `req.params` / `req.query` object accessors build the object once and
+    /// return the cached NaN-boxed pointer on subsequent calls within a request.
+    #[test]
+    fn req_object_accessors_cache_within_request() {
+        use std::sync::atomic::Ordering;
+        let _guard = GcTestGuard::new();
+        let mut params = HashMap::new();
+        params.insert("id".to_string(), "42".to_string());
+        let ctx = FastifyContext::new(
+            0,
+            "GET".to_string(),
+            "/users/42?trace=1".to_string(),
+            HashMap::new(),
+            None,
+            params,
+        );
+        let h = register_handle(ctx);
+        unsafe {
+            // params: two reads return identical (cached) bits.
+            let a = js_fastify_req_params_object(h);
+            let b = js_fastify_req_params_object(h);
+            assert_eq!(a.to_bits(), b.to_bits(), "second params read is cached");
+            assert_eq!(a.to_bits() >> 48, 0x7FFD, "params object is POINTER_TAG'd");
+            let cached_p = get_handle::<FastifyContext>(h)
+                .unwrap()
+                .params_object_cache
+                .load(Ordering::Acquire);
+            assert_eq!(
+                cached_p,
+                a.to_bits(),
+                "params cache holds the returned object"
+            );
+
+            // query: same, and a distinct slot from params.
+            let c = js_fastify_req_query_object(h);
+            let d = js_fastify_req_query_object(h);
+            assert_eq!(c.to_bits(), d.to_bits(), "second query read is cached");
+            assert_eq!(c.to_bits() >> 48, 0x7FFD, "query object is POINTER_TAG'd");
+            assert_ne!(
+                a.to_bits(),
+                c.to_bits(),
+                "query cache must not reuse the params object"
+            );
+            let cached_q = get_handle::<FastifyContext>(h)
+                .unwrap()
+                .query_object_cache
+                .load(Ordering::Acquire);
+            assert_eq!(
+                cached_q,
+                c.to_bits(),
+                "query cache holds the returned object"
+            );
+        }
+        drop_handle(h);
+    }
+
+    /// GC soundness: the root scanner must visit each live FastifyContext's
+    /// cached object slots so a copying GC keeps them alive AND relocates the
+    /// cached pointer in place — and must preserve the NaN-box `POINTER_TAG`
+    /// (a raw `visit_i64_slot` would strip it). Without this rooting a GC between
+    /// the first `req.params` build and a later read would dangle the cache.
+    #[test]
+    fn gc_scanner_rewrites_cached_object_slots() {
+        use std::sync::atomic::Ordering;
+        let _guard = GcTestGuard::new();
+        perry_ffi::gc_register_mutable_root_scanner_named("perry-ext-fastify", scan_fastify_roots);
+
+        let params_obj = young_gc_root();
+        let query_obj = young_gc_root();
+        let nanbox = |addr: i64| 0x7FFD_0000_0000_0000u64 | (addr as u64 & 0x0000_FFFF_FFFF_FFFF);
+        let mask = 0x0000_FFFF_FFFF_FFFFu64;
+
+        let ctx = FastifyContext::new(
+            0,
+            "GET".to_string(),
+            "/x".to_string(),
+            HashMap::new(),
+            None,
+            HashMap::new(),
+        );
+        ctx.params_object_cache
+            .store(nanbox(params_obj), Ordering::Release);
+        ctx.query_object_cache
+            .store(nanbox(query_obj), Ordering::Release);
+        let handle = register_handle(ctx);
+
+        let _ = perry_runtime::gc::gc_collect_minor();
+
+        {
+            let ctx =
+                get_handle::<FastifyContext>(handle).expect("context handle should remain live");
+            let p = ctx.params_object_cache.load(Ordering::Acquire);
+            let q = ctx.query_object_cache.load(Ordering::Acquire);
+            // Tag preserved (visit_nanbox_u64_slot, not visit_i64_slot).
+            assert_eq!(p >> 48, 0x7FFD, "params cache keeps POINTER_TAG after GC");
+            assert_eq!(q >> 48, 0x7FFD, "query cache keeps POINTER_TAG after GC");
+            // Address relocated to the moved object, still in the nursery.
+            assert_rewritten(params_obj, (p & mask) as i64);
+            assert_rewritten(query_obj, (q & mask) as i64);
         }
         drop_handle(handle);
     }


### PR DESCRIPTION
<!--
Thanks for contributing to Perry! A few things to know before you submit:

1. Please do NOT bump `[workspace.package] version` in Cargo.toml.
2. Please do NOT edit the "**Current Version:**" line or add a "Recent
   Changes" entry in CLAUDE.md.
3. Please do NOT edit CHANGELOG.md.

The maintainer folds all of that metadata in at merge time — Perry
releases frequently, and version bumps conflict if they live on the
PR branch. See CONTRIBUTING.md for the reasoning.
-->

## Summary

`js_fastify_req_params_object` / `js_fastify_req_query_object` rebuilt a fresh JS object (a shaped object allocation + one string allocation per entry) on **every** call, so a handler reading `req.params` more than once paid the full construction each time. This caches the built object on the `FastifyContext` for the request's lifetime — repeated reads drop from **~188 ns to ~12 ns (~16×)** with no behavior change. The cached object is rooted soundly under the moving GC.

## Changes

- `crates/perry-ext-fastify/src/context.rs`
  - `FastifyContext` gains `params_object_cache: AtomicU64` and `query_object_cache: AtomicU64` (`0` = uncached; otherwise the NaN-boxed object-pointer bits, `POINTER_TAG` top 16 = `0x7FFD`). Reset to `0` in `new`, so the cache is request-scoped (a fresh context per request, dropped at dispatch tail). `AtomicU64` (not `Cell`) keeps `FastifyContext: Send + Sync` for the shared handle registry.
  - The two `_object` accessors return the cached pointer on a hit; on a miss they build via `build_string_map_object`, store the bits (`Release`), and return. The `undefined`/`None` fallback is **not** cached, so the scanner never roots a non-pointer.
- `crates/perry-ext-fastify/src/lib.rs`
  - `scan_fastify_roots` now also walks live `FastifyContext` handles and visits each populated cache slot with `visit_nanbox_u64_slot` (via `AtomicU64::get_mut()`), which **relocates the pointer in place and preserves the NaN-box tag** under a copying GC — a plain `visit_i64_slot` would strip the tag.
  - Three regression tests (see Test plan).

## Related issue

n/a — standalone response-accessor perf change.

## Test plan

Microbenchmark of `js_fastify_req_params_object` on a 2-key params map (release), rebuild-every-read vs cached:

```
rebuild (build object each read):  188 ns/op
cached  (atomic load on hit):       12 ns/op     ~16× faster
```

(First read still builds; every later read in the same request is an atomic load. Single-read handlers are unaffected.)

```
$ cargo test -p perry-ext-fastify
test tests::context_object_caches_start_empty ... ok
test tests::req_object_accessors_cache_within_request ... ok
test tests::gc_scanner_rewrites_cached_object_slots ... ok
test result: ok. 16 passed; 0 failed; ...

$ cargo build --release -p perry            # builds perry + perry-ext-fastify
    Finished `release` profile [optimized] target(s)

$ rm -rf target/perry-auto-* && scripts/run_fastify_tests.sh
fastify-tests: 12 passed, 0 failed

$ cargo fmt --check -p perry-ext-fastify     # clean
```

- [x] `cargo build --release` clean — built `-p perry` (compiles the affected chain incl. perry-ext-fastify); the full-workspace build needs the GTK/`gdk-pixbuf` system libs for the `perry-ui-*` crates, which CI provides.
- [x] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes — ran the affected crate (`cargo test -p perry-ext-fastify`, **16/16**) plus `scripts/run_fastify_tests.sh` (**12/12**); the full workspace test is deferred to CI (the base `perry-ui` crate needs `gdk-pixbuf`, unavailable locally).
- [x] (if user-facing) Added or updated a test under `test-files/` or a `#[test]` in the affected crate — three `#[test]`s, including `gc_scanner_rewrites_cached_object_slots` which proves the cache is relocated (not just marked) and keeps its tag after a minor GC.
- [ ] (if CLI / stdlib / runtime API changed) Updated `docs/src/` — n/a, internal accessor change, no public API surface.
- [ ] (if touching a platform UI backend) Built `-p perry-ui-<backend>` locally on that platform — n/a.

## Screenshots / output

`js_fastify_req_params_object` microbenchmark (release, 2-key params):

```
rebuild-every-read:  188 ns/op
cached read:          12 ns/op   (~16×)
```

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log — `perf(fastify): …`
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved request data handling by caching computed request `params` and `query` objects for reuse within the same request.

* **Bug Fixes**
  * Reduced repeated rebuilding of request `params` and `query` objects to improve performance.
  * Strengthened garbage-collection handling so cached request objects remain valid across memory cleanup.

* **Tests**
  * Added coverage to verify cache initialization, correct reuse of cached values, and safe behavior during minor garbage collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->