### PR TITLE
perf(fastify): cache the per-request headers JS object

### DIFF
--- a/crates/perry-ext-fastify/src/context.rs
+++ b/crates/perry-ext-fastify/src/context.rs
@@ -101,6 +101,11 @@ pub struct FastifyContext {
     /// Cached `request.query` JS object. Same encoding and invariants as
     /// `params_object_cache`.
     pub query_object_cache: AtomicU64,
+    /// Cached `request.headers` JS object. Same encoding and invariants as
+    /// `params_object_cache`. Handlers commonly read several headers per request,
+    /// so caching the constructed object after the first read makes later reads an
+    /// atomic load.
+    pub headers_object_cache: AtomicU64,
 }
 
 impl FastifyContext {
@@ -132,6 +137,7 @@ impl FastifyContext {
             user_data: TAG_UNDEFINED,
             params_object_cache: AtomicU64::new(0),
             query_object_cache: AtomicU64::new(0),
+            headers_object_cache: AtomicU64::new(0),
         }
     }
 
@@ -378,11 +384,19 @@ pub unsafe extern "C" fn js_fastify_req_json(ctx_handle: Handle) -> f64 {
     f64::from_bits(TAG_UNDEFINED)
 }
 
-/// `request.headers` — full headers as a NaN-boxed object.
+/// `request.headers` — full headers as a NaN-boxed object. Cached on the
+/// `FastifyContext` on first access — same mechanism as
+/// `js_fastify_req_params_object`.
 #[no_mangle]
 pub unsafe extern "C" fn js_fastify_req_headers(ctx_handle: Handle) -> i64 {
     if let Some(ctx) = get_handle::<FastifyContext>(ctx_handle) {
+        let cached = ctx.headers_object_cache.load(Ordering::Acquire);
+        if cached != 0 {
+            return cached as i64;
+        }
         if let Some(obj_f64) = build_string_map_object(&ctx.headers) {
+            ctx.headers_object_cache
+                .store(obj_f64.to_bits(), Ordering::Release);
             return obj_f64.to_bits() as i64;
         }
     }

--- a/crates/perry-ext-fastify/src/lib.rs
+++ b/crates/perry-ext-fastify/src/lib.rs
@@ -126,10 +126,11 @@ fn scan_fastify_roots(visitor: &mut GcRootVisitor<'_>) {
         }
     });
 
-    // Per-request `req.params` / `req.query` JS objects are cached on each live
-    // FastifyContext (`params_object_cache` / `query_object_cache`). Visit them
-    // as NaN-boxed value slots so a copying GC between the first accessor build
-    // and a later read keeps the object alive AND relocates the cached pointer.
+    // Per-request `req.params` / `req.query` / `req.headers` JS objects are
+    // cached on each live FastifyContext (`params_object_cache` /
+    // `query_object_cache` / `headers_object_cache`). Visit them as NaN-boxed
+    // value slots so a copying GC between the first accessor build and a later
+    // read keeps the object alive AND relocates the cached pointer.
     // `0` means uncached; only a real object pointer (POINTER_TAG `0x7FFD`) is
     // visited. `get_mut()` is sound here — the GC scan has exclusive access to
     // each handle.
@@ -141,6 +142,10 @@ fn scan_fastify_roots(visitor: &mut GcRootVisitor<'_>) {
         let query_slot = ctx.query_object_cache.get_mut();
         if *query_slot >> 48 == 0x7FFD {
             visitor.visit_nanbox_u64_slot(query_slot);
+        }
+        let headers_slot = ctx.headers_object_cache.get_mut();
+        if *headers_slot >> 48 == 0x7FFD {
+            visitor.visit_nanbox_u64_slot(headers_slot);
         }
     });
 }
@@ -246,6 +251,7 @@ mod tests {
         );
         assert_eq!(ctx.params_object_cache.load(Ordering::Acquire), 0);
         assert_eq!(ctx.query_object_cache.load(Ordering::Acquire), 0);
+        assert_eq!(ctx.headers_object_cache.load(Ordering::Acquire), 0);
 
         // Round-trip a synthetic NaN-boxed object pointer through each slot, so a
         // wiring regression in either cache is caught.
@@ -254,21 +260,26 @@ mod tests {
         assert_eq!(ctx.params_object_cache.load(Ordering::Acquire), nan_boxed);
         ctx.query_object_cache.store(nan_boxed, Ordering::Release);
         assert_eq!(ctx.query_object_cache.load(Ordering::Acquire), nan_boxed);
+        ctx.headers_object_cache.store(nan_boxed, Ordering::Release);
+        assert_eq!(ctx.headers_object_cache.load(Ordering::Acquire), nan_boxed);
     }
 
-    /// The `req.params` / `req.query` object accessors build the object once and
-    /// return the cached NaN-boxed pointer on subsequent calls within a request.
+    /// The `req.params` / `req.query` / `req.headers` object accessors build the
+    /// object once and return the cached NaN-boxed pointer on subsequent calls
+    /// within a request.
     #[test]
     fn req_object_accessors_cache_within_request() {
         use std::sync::atomic::Ordering;
         let _guard = GcTestGuard::new();
         let mut params = HashMap::new();
         params.insert("id".to_string(), "42".to_string());
+        let mut headers = HashMap::new();
+        headers.insert("host".to_string(), "example.com".to_string());
         let ctx = FastifyContext::new(
             0,
             "GET".to_string(),
             "/users/42?trace=1".to_string(),
-            HashMap::new(),
+            headers,
             None,
             params,
         );
@@ -308,6 +319,30 @@ mod tests {
                 c.to_bits(),
                 "query cache holds the returned object"
             );
+
+            // headers: same caching behaviour, a third distinct slot.
+            let e = js_fastify_req_headers(h);
+            let f = js_fastify_req_headers(h);
+            assert_eq!(e, f, "second headers read is cached");
+            assert_eq!((e as u64) >> 48, 0x7FFD, "headers object is POINTER_TAG'd");
+            assert_ne!(
+                e as u64,
+                a.to_bits(),
+                "headers cache must not reuse the params object"
+            );
+            assert_ne!(
+                e as u64,
+                c.to_bits(),
+                "headers cache must not reuse the query object"
+            );
+            let cached_h = get_handle::<FastifyContext>(h)
+                .unwrap()
+                .headers_object_cache
+                .load(Ordering::Acquire);
+            assert_eq!(
+                cached_h, e as u64,
+                "headers cache holds the returned object"
+            );
         }
         drop_handle(h);
     }
@@ -325,6 +360,7 @@ mod tests {
 
         let params_obj = young_gc_root();
         let query_obj = young_gc_root();
+        let headers_obj = young_gc_root();
         let nanbox = |addr: i64| 0x7FFD_0000_0000_0000u64 | (addr as u64 & 0x0000_FFFF_FFFF_FFFF);
         let mask = 0x0000_FFFF_FFFF_FFFFu64;
 
@@ -340,6 +376,8 @@ mod tests {
             .store(nanbox(params_obj), Ordering::Release);
         ctx.query_object_cache
             .store(nanbox(query_obj), Ordering::Release);
+        ctx.headers_object_cache
+            .store(nanbox(headers_obj), Ordering::Release);
         let handle = register_handle(ctx);
 
         let _ = perry_runtime::gc::gc_collect_minor();
@@ -349,12 +387,19 @@ mod tests {
                 get_handle::<FastifyContext>(handle).expect("context handle should remain live");
             let p = ctx.params_object_cache.load(Ordering::Acquire);
             let q = ctx.query_object_cache.load(Ordering::Acquire);
+            let hdr = ctx.headers_object_cache.load(Ordering::Acquire);
             // Tag preserved (visit_nanbox_u64_slot, not visit_i64_slot).
             assert_eq!(p >> 48, 0x7FFD, "params cache keeps POINTER_TAG after GC");
             assert_eq!(q >> 48, 0x7FFD, "query cache keeps POINTER_TAG after GC");
+            assert_eq!(
+                hdr >> 48,
+                0x7FFD,
+                "headers cache keeps POINTER_TAG after GC"
+            );
             // Address relocated to the moved object, still in the nursery.
             assert_rewritten(params_obj, (p & mask) as i64);
             assert_rewritten(query_obj, (q & mask) as i64);
+            assert_rewritten(headers_obj, (hdr & mask) as i64);
         }
         drop_handle(handle);
     }


### PR DESCRIPTION
<!--
Thanks for contributing to Perry! A few things to know before you submit:

1. Please do NOT bump `[workspace.package] version` in Cargo.toml.
2. Please do NOT edit the "**Current Version:**" line or add a "Recent
   Changes" entry in CLAUDE.md.
3. Please do NOT edit CHANGELOG.md.

The maintainer folds all of that metadata in at merge time — Perry
releases frequently, and version bumps conflict if they live on the
PR branch. See CONTRIBUTING.md for the reasoning.
-->

## Summary

`js_fastify_req_headers` rebuilt a fresh JS object (a shaped object allocation + one string allocation per header) on **every** call, so a handler reading several headers paid the full construction each time. This caches the headers object on the `FastifyContext` — the same mechanism as the existing `req.params` / `req.query` caches (#5696) — dropping repeated reads from **~446 ns to ~12 ns (~37×)** with no behavior change. The cached object is rooted soundly under the moving GC.

## Changes

- `crates/perry-ext-fastify/src/context.rs`
  - `FastifyContext` gains `headers_object_cache: AtomicU64` (`0` = uncached; otherwise the NaN-boxed object-pointer bits, `POINTER_TAG` top 16 = `0x7FFD`), reset to `0` in `new`.
  - `js_fastify_req_headers` returns the cached pointer on a hit; on a miss it builds via `build_string_map_object`, stores the bits (`Release`), and returns. The `undefined`/`None` fallback is not cached.
- `crates/perry-ext-fastify/src/lib.rs`
  - `scan_fastify_roots`' per-`FastifyContext` pass now also visits `headers_object_cache` with `visit_nanbox_u64_slot` (relocates + preserves the NaN-box tag under a copying GC).
  - Extends the three params/query cache tests to cover the headers slot.

`ctx.headers` is set once at construction and never mutated, so the cache cannot go stale; the context is fresh per request, so it cannot leak across requests.

## Related issue

n/a — standalone response-accessor perf change.

## Test plan

Microbenchmark of `js_fastify_req_headers` on a 6-header map (release), rebuild-every-read vs cached:

```
rebuild (build object each read):  446 ns/op
cached  (atomic load on hit):       12 ns/op     ~37× faster
```

(First read still builds; every later read in the same request is an atomic load. The win exceeds params/query because header maps are larger.)

```
$ cargo test -p perry-ext-fastify
test tests::context_object_caches_start_empty ... ok
test tests::req_object_accessors_cache_within_request ... ok
test tests::gc_scanner_rewrites_cached_object_slots ... ok    # now also covers the headers slot
test result: ok. 22 passed; 0 failed; ...

$ rm -rf target/perry-auto-* && scripts/run_fastify_tests.sh
fastify-tests: 12 passed, 0 failed

$ cargo fmt --check -p perry-ext-fastify     # clean
```

- [x] `cargo build --release` clean — built `-p perry` (compiles the affected chain incl. perry-ext-fastify); the full-workspace build needs the GTK/`gdk-pixbuf` system libs for the `perry-ui-*` crates, which CI provides.
- [x] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes — ran the affected crate (`cargo test -p perry-ext-fastify`, **22/22**) plus `scripts/run_fastify_tests.sh` (**12/12**); the full workspace test is deferred to CI (the base `perry-ui` crate needs `gdk-pixbuf`, unavailable locally).
- [x] (if user-facing) Added or updated a test under `test-files/` or a `#[test]` in the affected crate — extended the three cache tests to cover `headers_object_cache`, including the post-GC relocate + tag-preservation check.
- [ ] (if CLI / stdlib / runtime API changed) Updated `docs/src/` — n/a, internal accessor change, no public API surface.
- [ ] (if touching a platform UI backend) Built `-p perry-ui-<backend>` locally on that platform — n/a.

## Screenshots / output

`js_fastify_req_headers` microbenchmark (release, 6-header map):

```
rebuild-every-read:  446 ns/op
cached read:          12 ns/op   (~37×)
```

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log — `perf(fastify): …`
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Request headers are now cached within each request, reducing repeated rebuilding of the headers object.
  * Cached headers stay valid during garbage collection, helping preserve consistent access to request data.

* **Bug Fixes**
  * Improved reliability when accessing request headers repeatedly in the same request.
  * Fixed handling so cached headers are properly updated if moved during memory management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->