### PR TITLE
fix(fastify): bound request-pump re-entrancy to avoid MAX_TRY_DEPTH

### DIFF
--- a/crates/perry-ext-fastify/src/server.rs
+++ b/crates/perry-ext-fastify/src/server.rs
@@ -416,11 +416,82 @@ pub unsafe extern "C" fn js_fastify_app_close(app_handle: Handle) {
     }
 }
 
+/// Cap on the per-thread deferred-request queue (see
+/// `js_fastify_process_pending`). A pathological awaited-handler storm that
+/// exceeds this drops the newest pending — its `response_tx` Drop makes the
+/// awaiting hyper service-fn resolve `Err` (→ an error response), so memory is
+/// bounded (backpressure) rather than growing without limit.
+const DEFERRED_QUEUE_CAP: usize = 4096;
+
+/// Non-blocking `try_recv` of one pending request from a server's channel.
+/// Holds the `request_rx` mutex only for the `try_recv` itself, never across
+/// dispatch. Returns `None` when the channel is empty / the handle is gone.
+fn try_recv_pending_request(server_handle: Handle) -> Option<FastifyPendingRequest> {
+    let s = get_handle::<FastifyServerHandle>(server_handle)?;
+    let mut guard = s.request_rx.lock().unwrap();
+    guard.as_mut()?.try_recv().ok()
+}
+
+/// Move every currently-queued request out of one server's channel into
+/// `deferred` — the nested-pump path (see `js_fastify_process_pending`). Does
+/// NOT dispatch (dispatching in a nested frame would deepen the try-frame
+/// nesting toward `MAX_TRY_DEPTH`). Respects `cap`: once `deferred` holds `cap`
+/// entries, further pending are dropped, and dropping a `FastifyPendingRequest`
+/// drops its `response_tx`, signalling the awaiting service-fn with `Err`.
+/// Returns the number actually moved into `deferred`.
+fn drain_server_requests_into_deferred(
+    server_handle: Handle,
+    app_handle: Handle,
+    deferred: &mut std::collections::VecDeque<(Handle, FastifyPendingRequest)>,
+    cap: usize,
+) -> usize {
+    let mut moved = 0;
+    while let Some(pending) = try_recv_pending_request(server_handle) {
+        if deferred.len() < cap {
+            deferred.push_back((app_handle, pending));
+            moved += 1;
+        }
+        // else: `pending` is dropped here → response_tx Drop → service-fn Err.
+    }
+    moved
+}
+
+/// Drain & fire every queued WebSocket upgrade for one server (#1113). Upgrades
+/// are handled before request traffic — including *between* deferred-request
+/// dispatches in the pump's tail loop — so a busy / replenishing request stream
+/// can't starve them. Returns the number fired.
+fn drain_server_upgrades(server_handle: Handle) -> i32 {
+    let mut count = 0i32;
+    while let Some(up) = try_recv_fastify_upgrade(server_handle) {
+        let req_bits =
+            unsafe { crate::upgrade::build_request_object(&up.method, &up.path, &up.headers) }
+                .to_bits() as i64;
+        crate::upgrade::fire_fastify_upgrade_listeners(
+            up.app_handle,
+            req_bits,
+            up.ws_id,
+            Vec::new(),
+        );
+        count += 1;
+    }
+    count
+}
+
 /// Pump entrypoint — drain pending requests from every registered
 /// `FastifyServerHandle` and dispatch each on the main TS thread.
 /// Wired into perry-stdlib's `js_stdlib_process_pending` via the
 /// `external-fastify-pump` feature so the runtime's outer event loop
 /// drives us each tick.
+///
+/// Re-entrancy: dispatching a request runs user TS, which may `await`;
+/// `wait_for_promise` then drives `js_run_stdlib_pump`, which calls back into
+/// this pump. Each nested dispatch would push another `call_closure2_catching`
+/// try-frame (setjmp), so under sustained awaited-handler load the recursion
+/// could blow `MAX_TRY_DEPTH` (128 — "Try block nesting too deep"). An
+/// `IN_PROGRESS` thread-local guard makes a nested entry capture pending
+/// requests into a thread-local `DEFERRED` queue WITHOUT dispatching, and the
+/// outer frame drains `DEFERRED` at its tail — so every dispatch happens at the
+/// outer (bounded) try-depth.
 ///
 /// Returns the number of requests processed (matches the convention
 /// other pump arms follow — `js_ws_process_pending`,
@@ -438,7 +509,40 @@ pub extern "C" fn js_fastify_process_pending() -> i32 {
     thread_local! {
         static SCRATCH: std::cell::RefCell<Vec<Handle>> =
             const { std::cell::RefCell::new(Vec::new()) };
+        // Re-entrancy guard + deferred queue (see the fn doc-comment). Both are
+        // main-thread-only (the pump runs only on the main TS thread).
+        static IN_PROGRESS: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+        static DEFERRED: std::cell::RefCell<std::collections::VecDeque<(Handle, FastifyPendingRequest)>> =
+            const { std::cell::RefCell::new(std::collections::VecDeque::new()) };
     }
+
+    if IN_PROGRESS.with(|f| f.replace(true)) {
+        // Nested entry (a dispatched handler's await re-drove the pump): capture
+        // every server's pending into DEFERRED for the outer frame to dispatch;
+        // do NOT dispatch here — that would deepen the try-frame nesting. Collect
+        // ids first (don't call `get_handle` inside `iter_handle_ids_of`).
+        let mut ids: Vec<Handle> = Vec::new();
+        iter_handle_ids_of::<FastifyServerHandle, _>(|id| ids.push(id));
+        DEFERRED.with(|q| {
+            let mut q = q.borrow_mut();
+            for &h in &ids {
+                if let Some(app_handle) = get_handle::<FastifyServerHandle>(h).map(|s| s.app_handle)
+                {
+                    drain_server_requests_into_deferred(h, app_handle, &mut q, DEFERRED_QUEUE_CAP);
+                }
+            }
+        });
+        return 0;
+    }
+    // Reset the guard on EVERY exit path (incl. an early return / unwind).
+    struct ResetReentryGuard;
+    impl Drop for ResetReentryGuard {
+        fn drop(&mut self) {
+            IN_PROGRESS.with(|f| f.set(false));
+        }
+    }
+    let _reset = ResetReentryGuard;
+
     let mut server_handles = SCRATCH.with(|s| std::mem::take(&mut *s.borrow_mut()));
     server_handles.clear();
     iter_handle_ids_of::<FastifyServerHandle, _>(|id| {
@@ -453,37 +557,38 @@ pub extern "C" fn js_fastify_process_pending() -> i32 {
         // #1113 — drain WebSocket upgrades FIRST so a busy request
         // stream can't starve them (mirror of perry-ext-http-server's
         // `js_node_http_server_process_pending`).
-        while let Some(up) = try_recv_fastify_upgrade(h) {
-            let req_bits =
-                unsafe { crate::upgrade::build_request_object(&up.method, &up.path, &up.headers) }
-                    .to_bits() as i64;
-            crate::upgrade::fire_fastify_upgrade_listeners(
-                up.app_handle,
-                req_bits,
-                up.ws_id,
-                Vec::new(),
-            );
-            count += 1;
-        }
-        loop {
-            let pending = match get_handle::<FastifyServerHandle>(h) {
-                Some(s) => {
-                    let mut guard = s.request_rx.lock().unwrap();
-                    match guard.as_mut() {
-                        Some(rx) => rx.try_recv().ok(),
-                        None => None,
-                    }
-                }
-                None => None,
-            };
-            let pending = match pending {
-                Some(p) => p,
-                None => break,
-            };
+        count += drain_server_upgrades(h);
+        while let Some(pending) = try_recv_pending_request(h) {
             process_request(app_handle, pending);
             count += 1;
         }
     }
+
+    // Tail: dispatch anything a nested pump call captured into DEFERRED. These
+    // were already `try_recv`'d out of the per-server channels, so we dispatch
+    // the captured structs here in the OUTER frame — the try-frame depth stays
+    // at the outer (bounded) level. A dispatch here may itself await and re-enter
+    // the pump; that nested call hits the guard above and appends to DEFERRED,
+    // which this same loop then drains — still all at the outer try-depth.
+    //
+    // Re-drain upgrades before each deferred dispatch: a long (nested-await
+    // replenished) deferred drain must not starve WebSocket upgrades that arrive
+    // after the initial pass. Nested entries defer only REQUESTS, so the outer
+    // frame is where late upgrades get picked up — keep them ahead of requests
+    // here too (#1113).
+    loop {
+        for &h in server_handles.iter() {
+            count += drain_server_upgrades(h);
+        }
+        let next = DEFERRED.with(|q| q.borrow_mut().pop_front());
+        let (app_handle, pending) = match next {
+            Some(t) => t,
+            None => break,
+        };
+        process_request(app_handle, pending);
+        count += 1;
+    }
+
     server_handles.clear();
     SCRATCH.with(|s| {
         let mut slot = s.borrow_mut();
@@ -1351,4 +1456,229 @@ unsafe fn extract_port(opts: f64) -> u16 {
 #[allow(dead_code)]
 unsafe fn _force_promise_reason_link(p: *mut Promise) -> f64 {
     js_promise_reason(p)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Tests for the re-entrancy deferred-queue path of
+    //! `js_fastify_process_pending`. These exercise the real
+    //! `drain_server_requests_into_deferred` / `try_recv_pending_request`
+    //! helpers against a live `FastifyServerHandle` + mpsc channel — no JS
+    //! runtime needed (the drain path is pure Rust). The full pump re-entry
+    //! (guard → defer → outer-tail dispatch) is exercised end-to-end by
+    //! `scripts/run_fastify_tests.sh`, which runs awaited handlers.
+    use super::*;
+    use perry_ffi::drop_handle;
+    use std::collections::{HashMap, VecDeque};
+
+    /// Build a pending request tagged by `path`; return it plus its response
+    /// receiver so a test can observe `response_tx`'s fate (kept open vs dropped).
+    fn make_pending(path: &str) -> (FastifyPendingRequest, oneshot::Receiver<FastifyResponse>) {
+        let (response_tx, response_rx) = oneshot::channel::<FastifyResponse>();
+        let pending = FastifyPendingRequest {
+            method: "GET".to_string(),
+            path: path.to_string(),
+            headers: HashMap::new(),
+            body: None,
+            params: HashMap::new(),
+            response_tx,
+        };
+        (pending, response_rx)
+    }
+
+    /// Register a `FastifyServerHandle` wrapping `rx`. Returns (server, app)
+    /// handles; the caller drops both.
+    fn register_test_server(rx: mpsc::Receiver<FastifyPendingRequest>) -> (Handle, Handle) {
+        let app_handle = register_handle(FastifyApp::new());
+        let server = FastifyServerHandle {
+            port: 0,
+            app_handle,
+            shutdown_tx: None,
+            request_rx: Mutex::new(Some(rx)),
+            upgrade_rx: Mutex::new(None),
+            listening: AtomicBool::new(true),
+        };
+        (register_handle(server), app_handle)
+    }
+
+    /// Cap + FIFO + full-drain: over-cap entries are dropped, the kept ones stay
+    /// in arrival order, and — critically — the channel is fully drained even
+    /// past the cap (no request is left stranded in the mpsc).
+    #[test]
+    fn deferred_drain_respects_cap_and_drains_channel_fully() {
+        let n = 10usize;
+        let cap = 4usize;
+        let (tx, rx) = mpsc::channel::<FastifyPendingRequest>(n + 1);
+        let (server_h, app_h) = register_test_server(rx);
+        let mut rxs = Vec::new();
+        for i in 0..n {
+            let (p, r) = make_pending(&format!("req-{i}"));
+            tx.try_send(p).expect("send");
+            rxs.push(r);
+        }
+
+        let mut deferred: VecDeque<(Handle, FastifyPendingRequest)> = VecDeque::new();
+        let moved = drain_server_requests_into_deferred(server_h, app_h, &mut deferred, cap);
+
+        assert_eq!(moved, cap, "exactly `cap` entries are moved");
+        assert_eq!(deferred.len(), cap);
+        for (i, (h, p)) in deferred.iter().enumerate() {
+            assert_eq!(*h, app_h, "captured under the right app handle");
+            assert_eq!(p.path, format!("req-{i}"), "FIFO arrival order preserved");
+        }
+        assert!(
+            try_recv_pending_request(server_h).is_none(),
+            "channel must be fully drained even past the cap"
+        );
+
+        drop_handle(server_h);
+        drop_handle(app_h);
+        drop(rxs);
+    }
+
+    /// Under cap: every request is captured, in arrival order, and none is
+    /// dropped — every kept request's response channel stays open (the client
+    /// will get a real response, not an error).
+    #[test]
+    fn deferred_drain_under_cap_moves_all_without_dropping() {
+        let n = 5usize;
+        let (tx, rx) = mpsc::channel::<FastifyPendingRequest>(n + 1);
+        let (server_h, app_h) = register_test_server(rx);
+        let mut rxs = Vec::new();
+        for i in 0..n {
+            let (p, r) = make_pending(&format!("r{i}"));
+            tx.try_send(p).expect("send");
+            rxs.push(r);
+        }
+
+        let mut deferred: VecDeque<(Handle, FastifyPendingRequest)> = VecDeque::new();
+        let moved =
+            drain_server_requests_into_deferred(server_h, app_h, &mut deferred, DEFERRED_QUEUE_CAP);
+
+        assert_eq!(moved, n, "all moved when under cap");
+        for (i, (_, p)) in deferred.iter().enumerate() {
+            assert_eq!(p.path, format!("r{i}"));
+        }
+        // Nothing dropped: every response channel is still open (Empty, not Closed).
+        for r in &mut rxs {
+            assert!(
+                matches!(r.try_recv(), Err(oneshot::error::TryRecvError::Empty)),
+                "kept request's response_tx must remain alive"
+            );
+        }
+
+        drop_handle(server_h);
+        drop_handle(app_h);
+    }
+
+    /// Backpressure contract: when the cap is hit, the OVER-cap requests are
+    /// dropped, and dropping a pending drops its `response_tx`, which makes the
+    /// awaiting hyper service-fn resolve `Closed` → an error response. This
+    /// proves the client is signalled (no hang / no leak) rather than the
+    /// request silently vanishing.
+    #[test]
+    fn deferred_drain_over_cap_signals_dropped_clients() {
+        let n = 8usize;
+        let cap = 3usize;
+        let (tx, rx) = mpsc::channel::<FastifyPendingRequest>(n + 1);
+        let (server_h, app_h) = register_test_server(rx);
+        let mut rxs = Vec::new();
+        for i in 0..n {
+            let (p, r) = make_pending(&format!("q{i}"));
+            tx.try_send(p).expect("send");
+            rxs.push(r);
+        }
+
+        let mut deferred: VecDeque<(Handle, FastifyPendingRequest)> = VecDeque::new();
+        drain_server_requests_into_deferred(server_h, app_h, &mut deferred, cap);
+
+        // Kept entries: response channel still open.
+        for r in rxs.iter_mut().take(cap) {
+            assert!(
+                matches!(r.try_recv(), Err(oneshot::error::TryRecvError::Empty)),
+                "kept entries stay open"
+            );
+        }
+        // Over-cap entries: dropped → response_tx Drop → client observes Closed.
+        for r in rxs.iter_mut().skip(cap) {
+            assert!(
+                matches!(r.try_recv(), Err(oneshot::error::TryRecvError::Closed)),
+                "over-cap entries must signal the client (error response, not a hang)"
+            );
+        }
+
+        drop_handle(server_h);
+        drop_handle(app_h);
+    }
+
+    /// No-loss / no-duplication property across multiple servers + repeated
+    /// drain passes (simulating repeated nested pump entries): every queued
+    /// request lands in DEFERRED exactly once, in per-server FIFO order, and a
+    /// second pass captures nothing (channels already drained).
+    #[test]
+    fn deferred_drain_no_loss_across_servers_and_repeated_passes() {
+        let mut deferred: VecDeque<(Handle, FastifyPendingRequest)> = VecDeque::new();
+        let mut servers: Vec<(
+            Handle,
+            Handle,
+            mpsc::Sender<FastifyPendingRequest>,
+            usize,
+            usize,
+        )> = Vec::new();
+        let mut expected_total = 0usize;
+        for (s, depth) in [(0usize, 1usize), (1, 5), (2, 0), (3, 12)] {
+            let (tx, rx) = mpsc::channel::<FastifyPendingRequest>(depth + 1);
+            let (server_h, app_h) = register_test_server(rx);
+            for i in 0..depth {
+                let (p, _r) = make_pending(&format!("s{s}-r{i}"));
+                tx.try_send(p).expect("send");
+                // `_r` dropped here is harmless: it never affects the moved sender.
+            }
+            expected_total += depth;
+            servers.push((server_h, app_h, tx, s, depth));
+        }
+
+        // First pass: capture everything exactly once.
+        for (server_h, app_h, _tx, _s, _d) in &servers {
+            drain_server_requests_into_deferred(
+                *server_h,
+                *app_h,
+                &mut deferred,
+                DEFERRED_QUEUE_CAP,
+            );
+        }
+        assert_eq!(
+            deferred.len(),
+            expected_total,
+            "every request captured exactly once"
+        );
+
+        // Second pass: nothing new (no loss, no double-capture).
+        let before = deferred.len();
+        for (server_h, app_h, _tx, _s, _d) in &servers {
+            drain_server_requests_into_deferred(
+                *server_h,
+                *app_h,
+                &mut deferred,
+                DEFERRED_QUEUE_CAP,
+            );
+        }
+        assert_eq!(deferred.len(), before, "repeated drain captures nothing");
+
+        // Per-server FIFO order preserved.
+        for (_, app_h, _tx, s, depth) in &servers {
+            let seq: Vec<String> = deferred
+                .iter()
+                .filter(|(h, _)| h == app_h)
+                .map(|(_, p)| p.path.clone())
+                .collect();
+            let want: Vec<String> = (0..*depth).map(|i| format!("s{s}-r{i}")).collect();
+            assert_eq!(seq, want, "per-server FIFO order");
+        }
+
+        for (server_h, app_h, _tx, _s, _d) in servers {
+            drop_handle(server_h);
+            drop_handle(app_h);
+        }
+    }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Perry! A few things to know before you submit:

1. Please do NOT bump `[workspace.package] version` in Cargo.toml.
2. Please do NOT edit the "**Current Version:**" line or add a "Recent
   Changes" entry in CLAUDE.md.
3. Please do NOT edit CHANGELOG.md.

The maintainer folds all of that metadata in at merge time — Perry
releases frequently, and version bumps conflict if they live on the
PR branch. See CONTRIBUTING.md for the reasoning.
-->

## Summary

`js_fastify_process_pending` re-enters itself when a dispatched handler `await`s (`process_request` → `wait_for_promise` → `js_run_stdlib_pump` → back into the pump), and each nested dispatch pushes a `call_closure2_catching` try-frame (setjmp). The pump had **no re-entrancy guard**, so under sustained awaited-handler load the recursion could blow `MAX_TRY_DEPTH` (128, *"Try block nesting too deep"*) and abort the process. This adds an `IN_PROGRESS` guard + a thread-local `DEFERRED` queue so nested entries **capture** pending requests instead of dispatching them, and the outer frame drains the queue at its tail — every dispatch stays at the outer (bounded) try-depth, with no added latency. Cap-bounded (4096) with drop-newest backpressure.

## Changes

- `crates/perry-ext-fastify/src/server.rs`
  - `js_fastify_process_pending` gains a thread-local `IN_PROGRESS` re-entrancy guard and a thread-local `DEFERRED: VecDeque<(Handle, FastifyPendingRequest)>`. Nested entry drains every server's pending into `DEFERRED` (no dispatch) and returns; a `ResetReentryGuard` (Drop) clears `IN_PROGRESS` on every exit; a tail loop dispatches `DEFERRED` in the outer frame.
  - New helpers `try_recv_pending_request` (locks `request_rx` only for the `try_recv`, never across dispatch) and `drain_server_requests_into_deferred` (cap-respecting drain; over-cap pending are dropped → `response_tx` Drop → service-fn `Err` → error response).
  - **Upgrade priority preserved:** the WebSocket-upgrade drain is extracted into `drain_server_upgrades` and re-run before every deferred-request dispatch in the tail loop, so a long (nested-await-replenished) deferred drain can't starve a late upgrade (#1113).
  - The normal (non-nested) top-level dispatch path is unchanged — the inlined `try_recv` was replaced by the identical-semantics helper call.
- New `#[cfg(test)] mod tests` in `server.rs` (4 tests, below).

## Related issue

n/a — robustness fix for the request pump's re-entrancy.

## Test plan

This touches the hot request-pump path, so it was verified comprehensively — **three novel checks beyond the usual**, plus end-to-end and an adversarial audit:

**1. Real-channel drain (not a mirror).** Builds a live `FastifyServerHandle` + mpsc channel and exercises the *actual* `drain_server_requests_into_deferred`/`try_recv_pending_request` helpers — asserts the cap is enforced, FIFO order is preserved, and the channel is **fully drained even past the cap** (no request stranded).

**2. Backpressure contract.** Proves that an over-cap (dropped) request's `response_rx` resolves `Closed` — i.e. the client is signalled with an error response, **never a hang or a leak**.

**3. No-loss / no-duplication property.** Across multiple servers and *repeated* nested-entry drains, asserts every queued request lands in the deferred queue exactly once in per-server FIFO order, and a second pass captures nothing.

```
$ cargo test -p perry-ext-fastify
test server::tests::deferred_drain_respects_cap_and_drains_channel_fully ... ok
test server::tests::deferred_drain_under_cap_moves_all_without_dropping ... ok
test server::tests::deferred_drain_over_cap_signals_dropped_clients ... ok
test server::tests::deferred_drain_no_loss_across_servers_and_repeated_passes ... ok
test result: ok. 26 passed; 0 failed; ...

$ rm -rf target/perry-auto-* && scripts/run_fastify_tests.sh   # async handlers drive the guard
fastify-tests: 12 passed, 0 failed

$ cargo fmt --check -p perry-ext-fastify     # clean
```

**End-to-end:** `run_fastify_tests.sh` exercises `async` route handlers and an async error handler, which drive the exact re-entry path the guard wraps — 12/12 with the guard in place (no regression in real serving).

**Adversarial soundness audit** (independent multi-agent review of the change) confirmed, with line-level evidence: the guard prevents nested dispatch and resets on every exit (incl. unwind); the tail-drain runs at outer try-depth; no `request_rx` lock is held across dispatch and no `get_handle` runs inside `iter_handle_ids_of`; the `DEFERRED` `RefCell` is never double-borrowed; no request is lost or double-dispatched; and the top-level path is behaviorally unchanged.

- [x] `cargo build --release` clean — built `-p perry`; the full-workspace build needs the GTK/`gdk-pixbuf` libs for `perry-ui-*`, which CI provides.
- [x] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes — ran the affected crate (`cargo test -p perry-ext-fastify`, **26/26**) plus `scripts/run_fastify_tests.sh` (**12/12**); the full workspace test is deferred to CI (the base `perry-ui` crate needs `gdk-pixbuf`, unavailable locally).
- [x] (if user-facing) Added or updated a test under `test-files/` or a `#[test]` in the affected crate — 4 new `#[test]`s for the deferred-queue drain/cap/backpressure/no-loss invariants.
- [ ] (if CLI / stdlib / runtime API changed) Updated `docs/src/` — n/a, internal pump change, no public API surface.
- [ ] (if touching a platform UI backend) Built `-p perry-ui-<backend>` locally on that platform — n/a.

## Screenshots / output

n/a — internal request-pump robustness change (no user-visible output difference; correctness/latency under sustained awaited-handler load).

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log — `fix(fastify): …`
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pending-request processing during high async load to avoid recursive/overlapping dispatch behavior.
  * Added bounded, thread-local deferral for pending requests to prevent excessive “try-frame” explosions and ensure more consistent handling.
  * Preserved upgrade prioritization while draining deferred requests in FIFO order across servers.

* **Tests**
  * Added unit tests covering cap-respecting draining, under/over-cap behavior, channel-closure effects, and no-loss/no-duplication across multiple servers and repeated passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->