### PR TITLE
feat(fastify): bind with SO_REUSEPORT for cluster workers and the reusePort option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5671,6 +5671,7 @@ dependencies = [
  "perry-ffi",
  "perry-runtime",
  "serde_json",
+ "socket2",
  "tokio",
  "tokio-tungstenite",
 ]

--- a/crates/perry-ext-fastify/Cargo.toml
+++ b/crates/perry-ext-fastify/Cargo.toml
@@ -26,6 +26,14 @@ tokio-tungstenite = { workspace = true }
 serde_json = "1"
 lazy_static = "1.5"
 
+# #cluster — SO_REUSEPORT bind for `cluster.fork()` workers (unix only),
+# mirroring perry-ext-http-server's cluster_bind. The
+# `perry_cluster_worker_listening` symbol it reports to resolves at final link
+# (defined in perry-runtime), like perry-ffi's runtime helpers — no Cargo dep on
+# perry-runtime is needed.
+[target.'cfg(unix)'.dependencies]
+socket2 = "0.6"
+
 [dev-dependencies]
 perry-ffi = { workspace = true, features = ["runtime-link"] }
 perry-runtime = { workspace = true, features = ["external-ws-symbols"] }

--- a/crates/perry-ext-fastify/src/cluster_bind.rs
+++ b/crates/perry-ext-fastify/src/cluster_bind.rs
@@ -1,0 +1,141 @@
+//! `node:cluster` worker port sharing for the Fastify listen site.
+//!
+//! When this process is a `cluster.fork()`ed worker (Node's convention: a
+//! non-empty `NODE_UNIQUE_ID` in the environment, set by the runtime's
+//! `cluster.fork`), the TCP bind goes through SO_REUSEPORT so N workers can
+//! share one port — the kernel load-balances accepts across them, with no
+//! primary-accept hop. The bound address is reported to the primary over the
+//! cluster IPC so `cluster.on('listening')` fires Node-style.
+//!
+//! This wires Fastify into the cluster machinery that already exists in
+//! perry-runtime (`worker_reuseport_bind`, `perry_cluster_worker_listening`)
+//! and is used by `net` and perry-ext-http-server. It mirrors the SO_REUSEPORT
+//! (`SCHED_NONE`) path of perry-ext-http-server's HTTP/2 & HTTPS listen sites.
+//! Round-robin fd-passing (`SCHED_RR`) and the shared ephemeral port for
+//! `listen(0)` (#4962) are a follow-up here, exactly as for those sites today.
+
+use std::net::{SocketAddr, TcpListener};
+
+/// True when this process is a `cluster.fork()`ed worker (non-empty
+/// `NODE_UNIQUE_ID` in the environment — the same check the runtime and
+/// perry-ext-http-server use).
+pub(crate) fn is_cluster_worker() -> bool {
+    std::env::var("NODE_UNIQUE_ID")
+        .map(|s| !s.is_empty())
+        .unwrap_or(false)
+}
+
+/// Bind `addr` with SO_REUSEPORT (+SO_REUSEADDR) so multiple cluster workers can
+/// share the port (kernel-balanced accepts). Unix-only; the caller falls back
+/// to the plain path elsewhere.
+#[cfg(unix)]
+fn reuseport_bind(addr: SocketAddr) -> std::io::Result<TcpListener> {
+    use socket2::{Domain, Protocol, Socket, Type};
+    let socket = Socket::new(Domain::for_address(addr), Type::STREAM, Some(Protocol::TCP))?;
+    socket.set_reuse_address(true)?;
+    socket.set_reuse_port(true)?;
+    socket.bind(&addr.into())?;
+    // Node's default listen backlog.
+    socket.listen(511)?;
+    Ok(socket.into())
+}
+
+/// Bind `addr`, enabling SO_REUSEPORT when this process is a cluster worker
+/// **or** when the caller explicitly requested it via the `reusePort: true`
+/// listen option, so multiple processes can share the port (kernel-balanced
+/// accepts). `reusePort` is a real Node (`net`/`http` `listen`) and Bun
+/// (`Bun.serve`) option; honoring it lets a non-cluster program opt into port
+/// sharing directly. Non-worker, non-`reusePort` (or non-unix) binds keep the
+/// plain `TcpListener::bind` path.
+pub(crate) fn bind_listener(addr: SocketAddr, reuse_port: bool) -> std::io::Result<TcpListener> {
+    #[cfg(unix)]
+    if reuse_port || is_cluster_worker() {
+        return reuseport_bind(addr);
+    }
+    // On non-unix targets SO_REUSEPORT isn't wired (matching the HTTP listen
+    // sites); the explicit request is a no-op there rather than an error.
+    #[cfg(not(unix))]
+    let _ = reuse_port;
+    TcpListener::bind(addr)
+}
+
+extern "C" {
+    // Defined in perry-runtime's cluster module. This crate has no Cargo dep on
+    // perry-runtime (dev-dep only); the symbol resolves at final link, the same
+    // way perry-ffi's runtime helpers do — matching perry-ext-http-server's
+    // `cluster_bind`.
+    fn perry_cluster_worker_listening(
+        addr_ptr: *const u8,
+        addr_len: u32,
+        port: i32,
+        address_type: i32,
+    );
+}
+
+/// Report this worker's bound `host:port` to the primary so
+/// `cluster.on('listening')` fires Node-style. No-op unless this is a cluster
+/// worker (re-checked on the runtime side as well).
+pub(crate) fn notify_listening(host: &str, port: u16) {
+    if !is_cluster_worker() {
+        return;
+    }
+    let address_type = if host.contains(':') { 6 } else { 4 };
+    unsafe {
+        perry_cluster_worker_listening(host.as_ptr(), host.len() as u32, port as i32, address_type);
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    /// SO_REUSEPORT lets two listeners share one live port — the mechanism that
+    /// makes `cluster.fork()` workers able to each `listen()` on the same port.
+    #[test]
+    fn reuseport_bind_lets_workers_share_a_port() {
+        let any: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let first = reuseport_bind(any).expect("first reuseport bind");
+        let port = first.local_addr().unwrap().port();
+        let shared: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+
+        // A second SO_REUSEPORT bind on the SAME live port succeeds.
+        let second = reuseport_bind(shared).expect("second reuseport bind on the same port");
+        assert_eq!(second.local_addr().unwrap().port(), port);
+
+        // ...whereas a PLAIN bind on that live port is refused — proving the
+        // shared bind above is SO_REUSEPORT doing the work, not an accident.
+        assert!(
+            TcpListener::bind(shared).is_err(),
+            "a plain bind must be refused on a port already in use"
+        );
+    }
+
+    /// `reusePort: true` enables SO_REUSEPORT even when this process is NOT a
+    /// cluster worker — the explicit-option path (a real Node/Bun listen
+    /// option). Two `bind_listener(_, true)` calls share one live port, while
+    /// the non-worker, no-option path keeps the plain bind and is refused.
+    #[test]
+    fn explicit_reuse_port_option_shares_a_port_without_cluster() {
+        // Sharing here comes purely from the explicit `reusePort = true`
+        // argument, not from worker auto-detection — guard that invariant so a
+        // stray NODE_UNIQUE_ID can't make this pass for the wrong reason.
+        assert!(
+            !is_cluster_worker(),
+            "this test must not run as a cluster worker"
+        );
+        let any: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let first = bind_listener(any, true).expect("first reusePort bind");
+        let port = first.local_addr().unwrap().port();
+        let shared: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
+
+        let _second =
+            bind_listener(shared, true).expect("second reusePort bind shares the same port");
+
+        // Without the option (and not a worker), `bind_listener` takes the
+        // plain path, which is refused on the SO_REUSEPORT-held port.
+        assert!(
+            bind_listener(shared, false).is_err(),
+            "bind_listener(_, false) off-cluster must not share a reusePort-held port"
+        );
+    }
+}

--- a/crates/perry-ext-fastify/src/lib.rs
+++ b/crates/perry-ext-fastify/src/lib.rs
@@ -62,6 +62,7 @@ use std::sync::Once;
 use perry_ffi::{gc_register_mutable_root_scanner_named, iter_handles_of_mut, GcRootVisitor};
 
 mod app;
+mod cluster_bind;
 mod context;
 mod router;
 mod server;

--- a/crates/perry-ext-fastify/src/server.rs
+++ b/crates/perry-ext-fastify/src/server.rs
@@ -229,6 +229,31 @@ pub unsafe extern "C" fn js_fastify_listen(app_handle: Handle, opts: f64, callba
     // Extract port — accepts `{ port: 3000 }`, a bare number, or
     // falls back to 3000.
     let port = extract_port(opts);
+    // Honor an explicit `{ reusePort: true }` (the Node/Bun listen option) in
+    // addition to auto-enabling SO_REUSEPORT for cluster workers.
+    let reuse_port = extract_reuse_port(opts);
+
+    // Bind synchronously, BEFORE registering the server or firing the success
+    // callback, so a bind failure (e.g. EADDRINUSE) reaches the `(err, address)`
+    // callback as an error instead of being silently dropped inside the accept
+    // task while the caller has already been told listening succeeded. Only
+    // `from_std` needs a runtime context, so it stays in the spawned task below;
+    // the bind + `set_nonblocking` that actually fail on a port clash run here.
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    let std_listener = match crate::cluster_bind::bind_listener(addr, reuse_port) {
+        Ok(l) => l,
+        Err(e) => {
+            fire_listen_error(callback, &e, port);
+            return;
+        }
+    };
+    if let Err(e) = std_listener.set_nonblocking(true) {
+        fire_listen_error(callback, &e, port);
+        return;
+    }
+    // `listen(0)` asks the OS for an ephemeral port; read the real one back so
+    // the registered handle + callback report the actual bound port.
+    let actual_port = std_listener.local_addr().map(|a| a.port()).unwrap_or(port);
 
     let (request_tx, request_rx) = mpsc::channel::<FastifyPendingRequest>(1024);
     // #1113 — separate channel for WebSocket upgrade events so a busy
@@ -276,11 +301,16 @@ pub unsafe extern "C" fn js_fastify_listen(app_handle: Handle, opts: f64, callba
     // from within a runtime" inside the worker task; spawn instead.)
     perry_ffi::spawn_blocking_with_reactor(move || {
         tokio::spawn(async move {
-            let addr = SocketAddr::from(([0, 0, 0, 0], port));
-            let listener = match TcpListener::bind(addr).await {
+            // The bind already succeeded on the caller thread (so a port clash
+            // was reported to the listen callback). Here we only report the
+            // bound address for `cluster.on('listening')` and adopt the std
+            // listener into the tokio reactor — `from_std` is the one step that
+            // needs the runtime context this task provides.
+            crate::cluster_bind::notify_listening("0.0.0.0", actual_port);
+            let listener = match TcpListener::from_std(std_listener) {
                 Ok(l) => l,
                 Err(e) => {
-                    eprintln!("Failed to bind to port {}: {}", port, e);
+                    eprintln!("[fastify] adopting listener failed: {}", e);
                     return;
                 }
             };
@@ -339,7 +369,7 @@ pub unsafe extern "C" fn js_fastify_listen(app_handle: Handle, opts: f64, callba
     // handle so the pump (driven from perry-stdlib's main loop) can
     // drain it after `listen()` returns.
     let _server_handle = register_handle(FastifyServerHandle {
-        port,
+        port: actual_port,
         app_handle,
         shutdown_tx: Some(shutdown_tx),
         request_rx: Mutex::new(Some(request_rx)),
@@ -355,7 +385,7 @@ pub unsafe extern "C" fn js_fastify_listen(app_handle: Handle, opts: f64, callba
         } else {
             callback as *const RawClosureHeader
         };
-        let address = format!("http://0.0.0.0:{}", port);
+        let address = format!("http://0.0.0.0:{}", actual_port);
         let addr_str = alloc_string(&address);
         let addr_val = JsValue::from_string_ptr(addr_str.as_raw());
         let null_val = f64::from_bits(TAG_NULL);
@@ -365,7 +395,7 @@ pub unsafe extern "C" fn js_fastify_listen(app_handle: Handle, opts: f64, callba
         }
     }
 
-    println!("Server listening on http://0.0.0.0:{}", port);
+    println!("Server listening on http://0.0.0.0:{}", actual_port);
 
     // `listen()` is now non-blocking — the accept loop is already
     // spawned above, and `js_fastify_process_pending` drains pending
@@ -1470,6 +1500,66 @@ unsafe fn extract_port(opts: f64) -> u16 {
         }
     }
     3000
+}
+
+/// Read `reusePort: true` from a `{ port, reusePort }` listen-options object.
+/// `reusePort` is a real Node (`net` / `http` `listen`) and Bun (`Bun.serve`)
+/// option that sets SO_REUSEPORT so multiple processes can share one port;
+/// honoring it lets a non-cluster program opt into port sharing directly.
+/// Defaults to false for a bare-number `listen(port)` or a missing option.
+unsafe fn extract_reuse_port(opts: f64) -> bool {
+    let v = JsValue::from_bits(opts.to_bits());
+    if v.is_pointer() {
+        if let Some(json) = perry_ffi::json_stringify(v) {
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&json) {
+                return parsed
+                    .get("reusePort")
+                    .and_then(|p| p.as_bool())
+                    .unwrap_or(false);
+            }
+        }
+    }
+    false
+}
+
+/// Hand a failed bind to the `(err, address)` listen callback as a Node-style
+/// system `Error` (`.code` / `.syscall` / `.errno`), so user code branching on
+/// `err.code === 'EADDRINUSE'` sees the failure instead of being told the
+/// server is listening. Called before any server registration or success
+/// callback, so a port clash can no longer masquerade as a successful listen.
+unsafe fn fire_listen_error(callback: i64, e: &std::io::Error, port: u16) {
+    eprintln!("[fastify] listen on 0.0.0.0:{} failed: {}", port, e);
+    if callback == 0 {
+        return;
+    }
+    let raw = if (callback as u64 & 0xFFFF_0000_0000_0000) == POINTER_TAG {
+        (callback as u64 & PTR_MASK) as *const RawClosureHeader
+    } else {
+        callback as *const RawClosureHeader
+    };
+    let closure = JsClosure::from_raw(raw);
+    if closure.is_null() {
+        return;
+    }
+    let code: std::borrow::Cow<'static, str> = match e.kind() {
+        std::io::ErrorKind::AddrInUse => "EADDRINUSE".into(),
+        std::io::ErrorKind::PermissionDenied => "EACCES".into(),
+        std::io::ErrorKind::AddrNotAvailable => "EADDRNOTAVAIL".into(),
+        // Any other bind/setup errno: carry it through as `E<errno>` so the
+        // error stays truthy and inspectable rather than being mislabeled.
+        _ => match e.raw_os_error() {
+            Some(n) => format!("E{}", n).into(),
+            None => "EUNKNOWN".into(),
+        },
+    };
+    // Node/libuv reports the negated OS errno.
+    let errno = e.raw_os_error().map(|n| -(n as i64)).unwrap_or(0);
+    let msg = format!("listen {} 0.0.0.0:{}", code, port);
+    let err_val = perry_ffi::system_error_value(&msg, &code, "listen", errno);
+    let _ = closure.call2(
+        f64::from_bits(err_val.bits()),
+        f64::from_bits(TAG_UNDEFINED),
+    );
 }
 
 // `js_promise_reason` is declared so wrappers that want to surface


### PR DESCRIPTION
<!--
Thanks for contributing to Perry! A few things to know before you submit:

1. Please do NOT bump `[workspace.package] version` in Cargo.toml.
2. Please do NOT edit the "**Current Version:**" line or add a "Recent
   Changes" entry in CLAUDE.md.
3. Please do NOT edit CHANGELOG.md.

The maintainer folds all of that metadata in at merge time — Perry
releases frequently, and version bumps conflict if they live on the
PR branch. See CONTRIBUTING.md for the reasoning.
-->

## Summary

A Fastify app under `node:cluster` (`if (cluster.isPrimary) { cluster.fork() } else { app.listen(port) }`) couldn't scale across workers: the Fastify listen path bound with a plain `TcpListener::bind`, so only the first worker held the port and the rest failed with `EADDRINUSE`. The runtime's cluster machinery already does SO_REUSEPORT worker-binding (used by `net` and perry-ext-http-server); this **wires Fastify into that existing machinery** so forked workers share a port (kernel-balanced accepts) and `cluster.on('listening')` fires.

It also honors an explicit **`{ reusePort: true }`** listen option (a real Node `net`/`http` and Bun `Bun.serve` option) so a non-cluster program can opt into SO_REUSEPORT directly — and hardens the listen path so a bind failure is reported to the callback instead of masquerading as a successful listen.

## Changes

- `crates/perry-ext-fastify/src/cluster_bind.rs` (new) — mirrors perry-ext-http-server's `cluster_bind`:
  - `is_cluster_worker()` (non-empty `NODE_UNIQUE_ID`), `bind_listener(addr, reuse_port)` (SO_REUSEPORT + SO_REUSEADDR via `socket2`, `listen(511)` when a **worker OR `reuse_port` was requested**; plain `TcpListener::bind` otherwise), `notify_listening(host, port)` (reports the bind to the primary via the runtime's `perry_cluster_worker_listening`, resolved at final link).
- `crates/perry-ext-fastify/src/server.rs`:
  - **Explicit option** — `extract_reuse_port(opts)` reads `{ reusePort: true }` and passes it to `bind_listener`, so SO_REUSEPORT can be enabled without `node:cluster`.
  - **Bind-failure propagation** (addresses the CodeRabbit review) — the bind + `set_nonblocking` now run **synchronously in `js_fastify_listen`, before** the server handle is registered or the success callback fires. On failure, `fire_listen_error` hands the `(err, address)` callback a Node-style system `Error` (`err.code === 'EADDRINUSE'` / `.syscall` / `.errno`) instead of letting the failure be silently dropped inside the accept task while the caller is told listening succeeded. Only `TcpListener::from_std` stays in the spawned task (it's the one step needing the tokio runtime context). The accept loop is otherwise unchanged.
  - `listen(0)` now reports the **actual** OS-assigned port to the handle + callback.
- `crates/perry-ext-fastify/src/lib.rs` — `mod cluster_bind;`.
- `Cargo.toml` / `Cargo.lock` — unix-only `socket2 = "0.6"` (the one-line lock edge; socket2 is already in the workspace lock via http-server).

Scope: the SO_REUSEPORT (`SCHED_NONE`) default path. Round-robin fd-passing (`SCHED_RR`) and the shared ephemeral port for `listen(0)` are a follow-up, as they are for the HTTP/2 & HTTPS sites today.

## Related issue

Extends `node:cluster` port-sharing (`#4914` family) to the Fastify adapter; `#4962` covers the SCHED_RR follow-up.

## Test plan

```
$ cargo test -p perry-ext-fastify
test cluster_bind::tests::reuseport_bind_lets_workers_share_a_port ... ok
test cluster_bind::tests::explicit_reuse_port_option_shares_a_port_without_cluster ... ok
test result: ok. 24 passed; 0 failed; ...

$ rm -rf target/perry-auto-* && scripts/run_fastify_tests.sh   # serving, end to end
fastify-tests: 12 passed, 0 failed

# End-to-end check of the two behaviors (compiled + run through perry):
#  - second plain listen on an occupied port  -> callback gets err.code EADDRINUSE
#  - two listens with { reusePort: true }      -> both succeed (shared port)
plain#1: OK
plain#2: ERR EADDRINUSE
reuse#1: OK
reuse#2: OK (shared port)

$ cargo fmt --check -p perry-ext-fastify     # clean
```

**SO_REUSEPORT mechanism** is verified by `reuseport_bind_lets_workers_share_a_port` (two reuseport listeners share one live port; a plain bind is refused). The **explicit option** is verified by `explicit_reuse_port_option_shares_a_port_without_cluster` (off-cluster, `bind_listener(_, true)` shares the port; `bind_listener(_, false)` does not). The **bind-failure propagation** + **reusePort sharing** are shown end to end above. **Non-worker bind+serve** is covered by `run_fastify_tests.sh` (12/12). The `perry_cluster_worker_listening` FFI symbol links (matches perry-ext-http-server's declaration exactly); end-to-end multi-worker sharing rides on the runtime machinery validated by `crates/perry/tests/issue_4914_cluster_port_sharing.rs`.

- [x] `cargo build --release` clean — built `-p perry-ext-fastify`; the full-workspace build needs the GTK/`gdk-pixbuf` libs for `perry-ui-*`, which CI provides.
- [x] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes — ran the affected crate (`cargo test -p perry-ext-fastify`, **24/24**) plus `scripts/run_fastify_tests.sh` (**12/12**) and the end-to-end reusePort/EADDRINUSE check; the full workspace test is deferred to CI (the base `perry-ui` crate needs `gdk-pixbuf`, unavailable locally).
- [x] (if user-facing) Added or updated a test under `test-files/` or a `#[test]` in the affected crate — `reuseport_bind_lets_workers_share_a_port`, `explicit_reuse_port_option_shares_a_port_without_cluster`.
- [ ] (if CLI / stdlib / runtime API changed) Updated `docs/src/` — n/a, internal listen-path change, no public API surface.
- [ ] (if touching a platform UI backend) Built `-p perry-ui-<backend>` locally on that platform — n/a.

## Screenshots / output

n/a — internal listen-path change (enables multi-worker port sharing + an opt-in option; surfaces a previously-silent bind failure to the callback).

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log — `feat(fastify): …`
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Unix-only clustered TCP listener port sharing using `SO_REUSEPORT`-style socket binds.
  * Added a `reusePort` listen option to control shared-port binding behavior.
  * Improved cluster “listening” notifications and server reporting to use the actual bound host/port (including ephemeral ports).

* **Bug Fixes**
  * Listener socket binding now happens synchronously, with bind/setup errors returned immediately via the `(err, address)` callback.

* **Tests**
  * Expanded reuse-port coverage to verify shared vs non-shared binding on the same port, both on and off-cluster.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->