### PR TITLE
test(fastify): drive context_handle_dropped_after_dispatch through process_request

### DIFF
--- a/crates/perry-ext-fastify/src/lib.rs
+++ b/crates/perry-ext-fastify/src/lib.rs
@@ -546,39 +546,50 @@ mod tests {
     /// request and must drop that handle once the response is sent. Without the
     /// trailing `drop_handle`, every served request would leak one context — its
     /// headers map, body, params, and response state — into the global registry,
-    /// growing unbounded under sustained load until allocation fails. This pins
-    /// the register → drop → gone invariant: a change that removed the cleanup at
-    /// the tail of `process_request` would leave the handle live and fail here.
+    /// growing unbounded under sustained load until allocation fails.
+    ///
+    /// This drives an actual request *through* `process_request` rather than
+    /// calling `drop_handle` directly, so it pins the real dispatch invariant: a
+    /// change that removed the cleanup at the tail of `process_request` leaves
+    /// the handle live and fails here. The request matches no route, so the
+    /// dispatcher takes the no-handler path (`undefined` result →
+    /// `build_response_body` short-circuits to `{}` with no JS allocation),
+    /// while still exercising the full register → build response → drop
+    /// lifecycle. `process_request` returns the context handle it registered
+    /// (and must have freed) so the assertion targets that exact handle —
+    /// race-free under parallel test execution.
     #[test]
     fn context_handle_dropped_after_dispatch() {
-        let ctx = FastifyContext::new(
-            42,
-            "GET".to_string(),
-            "/health".to_string(),
-            HashMap::new(),
-            None,
-            HashMap::new(),
-        );
-        let ctx_handle = register_handle(ctx);
+        let app_handle = register_handle(FastifyApp::new());
+        let (response_tx, mut response_rx) = tokio::sync::oneshot::channel();
+        let pending = crate::server::FastifyPendingRequest {
+            method: "GET".to_string(),
+            path: "/health".to_string(),
+            headers: HashMap::new(),
+            body: None,
+            params: HashMap::new(),
+            response_tx,
+        };
 
-        // Live immediately after registration.
+        // Drive the real dispatcher; it returns the context handle it
+        // registered and freed.
+        let ctx_handle = crate::server::process_request(app_handle, pending);
+
+        // The request actually flowed through: the no-route path still sends a
+        // `{}` response, so the oneshot has a value.
         assert!(
-            get_handle::<FastifyContext>(ctx_handle).is_some(),
-            "handle should be live after register_handle"
+            response_rx.try_recv().is_ok(),
+            "process_request should send a response even for an unmatched route"
         );
 
-        // The dispatcher drops the handle at the end of `process_request`.
-        let removed = drop_handle(ctx_handle);
-        assert!(
-            removed,
-            "drop_handle should report a live handle as removed"
-        );
-
-        // Gone from the registry — no per-request leak.
+        // The invariant: the context handle `process_request` created must be
+        // gone. A missing `drop_handle` at the tail would leave it live here.
         assert!(
             get_handle::<FastifyContext>(ctx_handle).is_none(),
-            "FastifyContext handle leaked: still present after drop_handle"
+            "FastifyContext handle leaked: still present after process_request"
         );
+
+        drop_handle(app_handle);
     }
 
     #[test]

--- a/crates/perry-ext-fastify/src/server.rs
+++ b/crates/perry-ext-fastify/src/server.rs
@@ -786,7 +786,7 @@ pub(crate) fn build_context_from_pending(
 
 /// Process one request — fire hooks, call route handler, send the
 /// response back through the oneshot channel.
-fn process_request(app_handle: Handle, mut pending: FastifyPendingRequest) {
+pub(crate) fn process_request(app_handle: Handle, mut pending: FastifyPendingRequest) -> Handle {
     let ctx = build_context_from_pending(0, &mut pending);
     let ctx_handle = register_handle(ctx);
 
@@ -948,6 +948,13 @@ fn process_request(app_handle: Handle, mut pending: FastifyPendingRequest) {
 
     // Free the context handle so it doesn't leak.
     perry_ffi::drop_handle(ctx_handle);
+
+    // Return the (now-freed) context handle so the register → drop lifecycle
+    // is observable: the `context_handle_dropped_after_dispatch` regression
+    // test drives a real request through this function and asserts the handle
+    // is gone, which a missing `drop_handle` above would fail. The live
+    // dispatch loop calls this as a statement and discards the value.
+    ctx_handle
 }
 
 /// Call a hook closure, await any returned Promise, and report whether it


### PR DESCRIPTION
<!--
Thanks for contributing to Perry! A few things to know before you submit:

1. Please do NOT bump `[workspace.package] version` in Cargo.toml.
2. Please do NOT edit the "**Current Version:**" line or add a "Recent
   Changes" entry in CLAUDE.md.
3. Please do NOT edit CHANGELOG.md.

The maintainer folds all of that metadata in at merge time — Perry
releases frequently, and version bumps conflict if they live on the
PR branch. See CONTRIBUTING.md for the reasoning.
-->

## Summary

`context_handle_dropped_after_dispatch` is meant to pin the per-request
cleanup invariant: `process_request` registers a fresh `FastifyContext`
for every request and must drop that handle once the response is sent
(without it, every served request leaks one context — headers, body,
params, response state — into the global registry, growing unbounded
under load until allocation fails).

But the test called `drop_handle` directly. It exercised the handle
**registry**, not `process_request`'s register → drop lifecycle — so it
would still pass even if `process_request` forgot its trailing cleanup
entirely. This makes the test actually drive that path.

## Changes

- `crates/perry-ext-fastify/src/server.rs` — `process_request` now returns
  the `Handle` it registered (and freed) at the tail. The live dispatch
  loop calls it as a statement and discards the value (`Handle` is a plain
  `i64`, not `#[must_use]`); the return exists purely so the lifecycle is
  observable from a test. No behavioral change to dispatch.
- `crates/perry-ext-fastify/src/lib.rs` — rewrote
  `context_handle_dropped_after_dispatch` to drive a real request through
  `process_request` rather than calling `drop_handle` itself. An app with
  no routes takes the no-handler path (`undefined` result →
  `build_response_body` short-circuits to `{}` with **no** JS allocation,
  so the test needs no runtime/GC setup) while still exercising the full
  register → build response → drop lifecycle. The assertion targets the
  exact handle `process_request` returned, so it's race-free under
  parallel test execution (no reliance on a global handle count, which the
  membership test could perturb).

## Related issue

n/a — test-hardening follow-up to a review note on the per-request context
cleanup (#5695's `process_request` drop invariant). No production behavior
change.

## Test plan

```
$ cargo test -p perry-ext-fastify
test tests::context_handle_dropped_after_dispatch ... ok
test result: ok. 24 passed; 0 failed; ...

# Mutation proof — the test now actually catches a missing cleanup:
$ # (temporarily comment out `perry_ffi::drop_handle(ctx_handle);` in process_request)
$ cargo test -p perry-ext-fastify context_handle_dropped_after_dispatch
thread '...context_handle_dropped_after_dispatch' panicked:
  FastifyContext handle leaked: still present after process_request
test result: FAILED. 0 passed; 1 failed; ...
# (the previous direct-drop_handle version passed here — it never touched process_request)

$ rm -rf target/perry-auto-* && scripts/run_fastify_tests.sh   # no serving regression
fastify-tests: 12 passed, 0 failed

$ cargo fmt --check -p perry-ext-fastify     # clean
```

The **mutation check** is the point: with the trailing `drop_handle`
removed, the rewritten test fails (leak detected); the old version passed
regardless, because it dropped the handle itself. Serving is unaffected
end to end (`run_fastify_tests.sh` 12/12), confirming the `process_request`
signature change is invisible to the dispatch loop.

- [x] `cargo build --release` clean — built `-p perry` and
  `-p perry-ext-fastify`; the full-workspace build needs the GTK/`gdk-pixbuf`
  libs for `perry-ui-*`, which CI provides.
- [x] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes — ran the affected crate (`cargo test -p perry-ext-fastify`, **24/24**) plus `scripts/run_fastify_tests.sh` (**12/12**); the full workspace test is deferred to CI (the base `perry-ui` crate needs `gdk-pixbuf`, unavailable locally).
- [x] (if user-facing) Added or updated a test under `test-files/` or a `#[test]` in the affected crate — hardened `context_handle_dropped_after_dispatch`.
- [ ] (if CLI / stdlib / runtime API changed) Updated `docs/src/` — n/a, internal test + a discarded-by-callers return value, no public API surface.
- [ ] (if touching a platform UI backend) Built `-p perry-ui-<backend>` locally on that platform — n/a.

## Screenshots / output

n/a — test-only behavior change (plus a return value the live caller discards).

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log — `test(fastify): …`
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling cleanup so transient request context is reliably released after dispatch.
  * Strengthened regression coverage for unmatched routes to ensure a response is still returned and cleanup happens correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->