### PR TITLE
test: nested object literal must not corrupt an adjacent native (WS) handle

### DIFF
--- a/crates/perry/tests/nested_object_literal_ws_inbound.rs
+++ b/crates/perry/tests/nested_object_literal_ws_inbound.rs
@@ -1,0 +1,150 @@
+//! Regression: a deeply nested object/array literal at module scope must not
+//! corrupt an adjacent native handle. On v0.5.1206 a literal of the shape
+//! `{ a: [..], b: [{ kind, child: { a: [..], b: [{ kind }] } }] }` — an object
+//! whose array element holds a nested object that itself holds an array of objects
+//! — silently broke `node:http` WebSocket *inbound* dispatch GLOBALLY: the upgrade
+//! handler's `wsId.on("message", …)` never fired, so an echo server stopped echoing
+//! while outbound `wsId.send(...)` still worked. The literal itself read back
+//! correctly — the corruption hit a neighbouring allocation (the WS client handle),
+//! so the only observable was the dropped inbound frame. A flat, single-level
+//! literal was unaffected. Fixed after v0.5.1206; this test guards the regression.
+//!
+//! The fixture self-tests in-process: a WS echo server + a `ws` client that sends
+//! "ping" and expects "echo:ping". A miscompile -> no echo -> hang (the Rust
+//! timeout, or the fixture's own 8s `exit(1)`); a healthy build -> prints `WSOK`
+//! and exits 0.
+//!
+//! Needs the default (auto-optimize) build for the node:http/ws server symbols.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile(dir: &std::path::Path, source: &str) -> PathBuf {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    output
+}
+
+/// Run `bin`, failing if it doesn't exit on its own within `secs` — the buggy
+/// signature is a hang (inbound frame never dispatched). A reader thread drains
+/// stdout while the main thread polls for exit against the deadline.
+fn run_with_timeout(bin: &std::path::Path, secs: u64) -> String {
+    use std::io::Read;
+
+    let mut child = Command::new(bin)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn compiled binary");
+
+    let mut piped = child.stdout.take().expect("piped stdout");
+    let mut err_piped = child.stderr.take().expect("piped stderr");
+    let reader = std::thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = piped.read_to_string(&mut buf);
+        buf
+    });
+    // Capture stderr too — the fixture writes its own failure signal there
+    // (`console.error("no echo …")`), which is the most useful breadcrumb when CI fails.
+    let err_reader = std::thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = err_piped.read_to_string(&mut buf);
+        buf
+    });
+
+    let deadline = Instant::now() + Duration::from_secs(secs);
+    loop {
+        match child.try_wait().expect("try_wait") {
+            Some(status) => {
+                let stdout = reader.join().unwrap_or_default();
+                let stderr = err_reader.join().unwrap_or_default();
+                assert!(
+                    status.success(),
+                    "binary exited non-zero: {status:?}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+                );
+                return stdout;
+            }
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let stdout = reader.join().unwrap_or_default();
+                let stderr = err_reader.join().unwrap_or_default();
+                panic!(
+                    "nested-literal regression: process hung for >{secs}s — the WS \
+                     upgrade handler's inbound `message` never fired (a nested object \
+                     literal corrupted the adjacent WS handle).\nstdout so far:\n{stdout}\nstderr so far:\n{stderr}"
+                );
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    }
+}
+
+#[test]
+fn nested_object_literal_does_not_break_ws_inbound() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let bin = compile(
+        dir.path(),
+        r#"
+import { createServer } from "node:http";
+import WebSocket from "ws";
+
+// The nested literal that regressed. Defined at module scope and merely read —
+// the corruption hit a neighbouring native allocation, not the literal itself.
+const X: any = {
+  a: ["x", "y"],
+  b: [{ kind: "outer", child: { a: ["x", "y"], b: [{ kind: "inner" }] } }],
+};
+
+const server = createServer((req: any, res: any) => res.end("n=" + X.b.length));
+server.on("upgrade", (req: any, wsId: any) => {
+  wsId.on("message", (data: any) => {
+    wsId.send("echo:" + String(data));
+  });
+});
+// fail fast (rather than hang) if inbound never round-trips
+const timer = setTimeout(() => {
+  console.error("no echo — WS inbound dropped");
+  process.exit(1);
+}, 8000);
+server.listen(0, () => {
+  const port = (server.address() as { port: number }).port;
+  const ws = new WebSocket("ws://127.0.0.1:" + port);
+  ws.on("open", () => ws.send("ping"));
+  ws.on("message", (d: any) => {
+    if (String(d) === "echo:ping") {
+      console.log("WSOK");
+      clearTimeout(timer);
+      process.exit(0); // deterministic — don't depend on async close draining the loop
+    }
+  });
+});
+"#,
+    );
+    let stdout = run_with_timeout(&bin, 40);
+    assert_eq!(
+        stdout, "WSOK\n",
+        "expected the WS echo round-trip to complete"
+    );
+}


### PR DESCRIPTION
## Summary

Adds a regression test for a codegen bug — present on `v0.5.1206`, fixed since — where a **deeply nested object/array literal at module scope corrupted an adjacent native handle**: it silently broke `node:http` WebSocket *inbound* dispatch globally (the upgrade handler's `wsId.on("message", …)` stopped firing) while outbound `wsId.send(...)` kept working. The literal itself read back correctly — the corruption hit a neighbouring allocation (the WS client handle), so the only observable was the dropped inbound frame. A flat, single-level literal was unaffected.

## Changes

- `crates/perry/tests/nested_object_literal_ws_inbound.rs`: a self-testing compile+run regression test, modeled on the existing `issue_5174_headers_http_pump_hang.rs`. The fixture defines a nested literal of the shape `{ a: [..], b: [{ kind, child: { a: [..], b: [{ kind }] } }] }`, stands up a `node:http` WS echo server, connects a `ws` client to it in-process, and asserts the `ping` → `echo:ping` round-trip. A healthy build prints `WSOK` and exits 0; a miscompile drops the inbound frame and hangs — caught by both the Rust wall-clock timeout and the fixture's own 8s `exit(1)`.

## Related issue

n/a — standalone regression guard (the underlying bug is already fixed on `main`).

## Test plan

Verified the fixture compiles and completes the WS round-trip on a current `main` build:

```
$ perry run nested_literal_ws.ts
...
Running ...
WSOK          # exit 0
```

- [x] `cargo build --release` clean (`-p perry`, off `main`)
- [ ] `cargo test --workspace …` — the new `#[test]` follows the established `issue_5174` compile+run+timeout pattern; I verified the fixture's behavior directly (above) but left the full workspace test run to CI
- [x] (user-facing) Added a `#[test]` in the affected crate (`crates/perry/tests/`)
- [ ] (no CLI / stdlib / runtime API changed — docs n/a)
- [ ] (no platform UI backend touched)

## Screenshots / output

Fixture stdout on a healthy build:

```
WSOK
```

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commit follows the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention (`test:`)
- [x] I've read CONTRIBUTING.md and agree to the Code of Conduct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a regression test covering WebSocket inbound message handling with deeply nested object and array literals.
  * Ensures the compiled app echoes received messages correctly and fails safely if execution hangs, using a timeout watchdog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->