### PR TITLE
fix(compile): don't localize panic/unwind symbols on ELF (PIE link break)

### DIFF
--- a/crates/perry/src/commands/compile/strip_dedup.rs
+++ b/crates/perry/src/commands/compile/strip_dedup.rs
@@ -28,11 +28,22 @@ const RUST_ALLOCATOR_SYMBOL_PARTS: &[&str] = &[
     "__rdl_realloc",
     "__rdl_alloc_zeroed",
     "__rdl_alloc_error_handler",
-    // Panic / unwind runtime shims. On tier-3 targets (tvOS/watchOS) with no
-    // prebuilt std, perry-runtime and perry-stdlib are each built with
-    // -Zbuild-std, so both bundle std's single-definition panic runtime →
-    // `ld64.lld: duplicate symbol` for these. Localize them like the allocator
-    // shims so only one staticlib provides them.
+];
+
+// Panic / unwind runtime shims. On tier-3 Mach-O targets (tvOS/watchOS) with no
+// prebuilt std, perry-runtime and perry-stdlib are each built with -Zbuild-std,
+// so both bundle std's single-definition panic runtime → `ld64.lld: duplicate
+// symbol` for these; localizing them so only one staticlib provides them fixes
+// that on Mach-O.
+//
+// They are NOT localized on ELF (see `object_is_elf` guard in the well-known
+// localizer): `--localize-symbol rust_eh_personality` also matches the
+// compiler-emitted `DW.ref.rust_eh_personality` (substring), and localizing
+// that breaks its PC32 relocation → `relocation R_X86_64_PC32 against undefined
+// hidden symbol DW.ref.rust_eh_personality can not be used when making a PIE
+// object` at link time. ELF tier-1/2 builds take the panic runtime from the
+// prebuilt std (single definition), so there is no duplicate to dedup anyway.
+const RUST_PANIC_UNWIND_SYMBOL_PARTS: &[&str] = &[
     "__rust_drop_panic",
     "__rust_foreign_exception",
     "rust_begin_unwind",
@@ -41,11 +52,34 @@ const RUST_ALLOCATOR_SYMBOL_PARTS: &[&str] = &[
     "rust_panic",
 ];
 
+/// Panic/unwind personality shims (incl. the compiler-emitted
+/// `DW.ref.rust_eh_personality`, which substring-matches `rust_eh_personality`).
+/// These must not be `--localize-symbol`'d on ELF — it breaks PIE relocations.
+fn is_panic_unwind_symbol(symbol: &str) -> bool {
+    RUST_PANIC_UNWIND_SYMBOL_PARTS
+        .iter()
+        .any(|part| symbol.contains(part))
+}
+
 fn force_localize_symbol(symbol: &str) -> bool {
     FORCE_EXCLUDE_SYMBOLS.contains(&symbol)
         || RUST_ALLOCATOR_SYMBOL_PARTS
             .iter()
             .any(|part| symbol.contains(part))
+        || is_panic_unwind_symbol(symbol)
+}
+
+/// True if `path` is an ELF object file (first four bytes `0x7F 'E' 'L' 'F'`).
+/// Used to skip panic/unwind-symbol localization on ELF, where localizing
+/// `rust_eh_personality` / `DW.ref.rust_eh_personality` breaks PIE relocations
+/// (see [`RUST_PANIC_UNWIND_SYMBOL_PARTS`]).
+fn object_is_elf(path: &Path) -> bool {
+    use std::io::Read;
+    let mut magic = [0u8; 4];
+    std::fs::File::open(path)
+        .and_then(|mut f| f.read_exact(&mut magic))
+        .map(|_| magic == [0x7f, b'E', b'L', b'F'])
+        .unwrap_or(false)
 }
 
 fn find_path_tool(name: &str) -> Option<PathBuf> {
@@ -718,7 +752,16 @@ pub(super) fn strip_duplicate_objects_from_well_known_lib(lib_path: &PathBuf) ->
 
     for (member, symbols) in &forced_symbols_by_member {
         let member_path = extract_dir.join(member);
+        // On ELF, localizing the panic/unwind personality symbols (including the
+        // compiler-emitted `DW.ref.rust_eh_personality`) breaks PIE relocations
+        // → "undefined hidden symbol ... can not be used when making a PIE
+        // object". That dedup is only needed for tier-3 Mach-O (-Zbuild-std);
+        // skip it for ELF members and keep localizing the allocator shims.
+        let skip_panic_unwind = object_is_elf(&member_path);
         for symbol in symbols {
+            if skip_panic_unwind && is_panic_unwind_symbol(symbol) {
+                continue;
+            }
             let out = Command::new(&objcopy)
                 .arg("--localize-symbol")
                 .arg(symbol)
@@ -1362,7 +1405,30 @@ pub(super) fn strip_members_present_in_reference(
 
 #[cfg(test)]
 mod strip_dedup_tests {
-    use super::parse_nm_archive_output;
+    use super::{force_localize_symbol, is_panic_unwind_symbol, parse_nm_archive_output};
+
+    #[test]
+    fn panic_unwind_classification_matches_dwref() {
+        // The compiler-emitted `DW.ref.rust_eh_personality` substring-matches
+        // `rust_eh_personality`; both must be treated as panic/unwind so the
+        // well-known localizer skips them on ELF (PIE relocation breakage).
+        assert!(is_panic_unwind_symbol("rust_eh_personality"));
+        assert!(is_panic_unwind_symbol("DW.ref.rust_eh_personality"));
+        assert!(is_panic_unwind_symbol("rust_begin_unwind"));
+        assert!(is_panic_unwind_symbol("rust_panic"));
+        // Allocator shims and ordinary symbols are not panic/unwind.
+        assert!(!is_panic_unwind_symbol("__rust_alloc"));
+        assert!(!is_panic_unwind_symbol("__rdl_dealloc"));
+        assert!(!is_panic_unwind_symbol("js_fetch_with_options"));
+
+        // Candidate collection is unchanged: allocator shims and the
+        // panic/unwind group are both still force-localize candidates (the ELF
+        // skip happens per-object in the well-known localizer, not here).
+        assert!(force_localize_symbol("rust_eh_personality"));
+        assert!(force_localize_symbol("__rust_alloc"));
+        assert!(force_localize_symbol("js_stdlib_init_dispatch"));
+        assert!(!force_localize_symbol("js_some_regular_export"));
+    }
 
     #[test]
     fn parser_handles_bare_member_headers() {


### PR DESCRIPTION
## Problem

The full `cargo-test` gate has been red on the nightly cron; after the blocklist + BYOB fixes, the current blocker (June 26 nightly) is a **Linux link failure** during any test that does an internal `perry compile` of a net/stdlib program:

```
[strip-dedup] libperry_ext_net.a: localized wrapper-only globals in 25 member(s)
/usr/bin/ld: relocation R_X86_64_PC32 against undefined hidden symbol
            `DW.ref.rust_eh_personality' can not be used when making a PIE object
ld: final link failed: bad value
```

## Root cause

`strip_duplicate_objects_from_well_known_lib` force-localizes `rust_eh_personality` (and other panic/unwind shims) in well-known wrapper archives. The match is **substring**, so it also catches the compiler-emitted `DW.ref.rust_eh_personality`. On ELF, `--localize-symbol` on that symbol breaks its PC32 relocation → the PIE link fails. This breaks Linux integration tests **and real Linux user builds** of any net/stdlib program.

The panic/unwind localization exists only for **tier-3 Mach-O** (`-Zbuild-std`, where runtime+stdlib each bundle std's panic runtime → `ld64` duplicate symbol). ELF tier-1/2 take the panic runtime from prebuilt std — nothing to dedup.

## Fix

Split the panic/unwind shims into `RUST_PANIC_UNWIND_SYMBOL_PARTS` and **skip localizing them for ELF objects** (detected by magic bytes → cross-compile-correct). Allocator-shim localization and the Mach-O behavior are unchanged.

## Validation

- Unit test `panic_unwind_classification_matches_dwref` covers the `DW.ref` substring match (runs in per-PR cargo-test).
- Can't reproduce the ELF/PIE link locally (macOS arm64, Mach-O). Validating via a full-Linux `cargo-test` run (`workflow_dispatch run_extended_tests=true`) on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of panic/unwind symbols during object deduplication so ELF PIE relocations are preserved.
  * Avoided over-localizing certain symbols in ELF object files, reducing the risk of unwind-related breakage.
  * Continued applying allocator-related symbol localization as before.

* **Tests**
  * Added coverage for identifying panic/unwind symbols and confirming they are treated correctly alongside allocator shim symbols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->