### PR TITLE
ci(security-audit): ignore RUSTSEC-2026-0187 (lopdf, transitive via printpdf, no upstream fix)

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -42,6 +42,14 @@ jobs:
         #   amplification + DoS surface; transitive via reqwest's
         #   tls-rustls path. Upstream hickory has a fix in main but
         #   not yet released; tracking.
+        # - RUSTSEC-2026-0187 (lopdf) — stack overflow via deeply nested
+        #   PDF objects. Fixed in lopdf >=0.42.0, but lopdf is transitive
+        #   via printpdf (perry-ext-pdf); printpdf's latest (0.9.1) still
+        #   pins lopdf ^0.39, so there is no actionable upstream bump yet.
+        #   perry-ext-pdf is a PDF *creation* API (createPdf/addText/…),
+        #   not a parser of untrusted PDFs, so the deeply-nested-input
+        #   surface is not reached. Tracking for a printpdf release that
+        #   moves to lopdf >=0.42.
         #
         # Previously the job ran `--deny warnings` which also
         # escalated every "unmaintained crate" notice into a hard
@@ -53,4 +61,5 @@ jobs:
           cargo audit \
             --ignore RUSTSEC-2023-0071 \
             --ignore RUSTSEC-2026-0118 \
-            --ignore RUSTSEC-2026-0119
+            --ignore RUSTSEC-2026-0119 \
+            --ignore RUSTSEC-2026-0187


### PR DESCRIPTION
## Why every PR is red

`security-audit` is failing on **RUSTSEC-2026-0187** — *stack overflow in lopdf via deeply nested PDF objects*. The advisory hit main's `Cargo.lock`, so **every open PR inherits the failure** (it's the only red item; the rest are unmaintained-crate *warnings*).

## Why not just bump lopdf

The advisory's fix is lopdf `>=0.42.0`, but `lopdf` is **transitive**: `perry-ext-pdf → printpdf 0.9.1 → lopdf 0.39`. printpdf's latest release (0.9.1) still pins `lopdf ^0.39`, so there's no semver-compatible bump available upstream yet.

## Fix

Add `--ignore RUSTSEC-2026-0187`, matching the workflow's existing tracked transitive-dep exceptions (rsa, hickory-proto). `perry-ext-pdf` is a PDF **creation** API (createPdf/addText/addLine), not a parser of untrusted PDFs, so the deeply-nested-input stack-overflow surface isn't reached. Tracking for a printpdf release that moves to lopdf `>=0.42`.

Verified locally: `cargo audit` with all four ignores exits 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the security audit checks to account for a newly ignored Rust advisory related to a dependency chain issue.
  * Added guidance in the audit workflow so the warning is documented until an upstream fix becomes available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->