### PR TITLE
fix(codegen): route fastify request/reply `.header()` by receiver class

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_module_dispatch.rs
+++ b/crates/perry-codegen/src/lower_call/native_module_dispatch.rs
@@ -374,4 +374,37 @@ mod ffi_return_type_tests {
         assert!(returns_i64_str);
         assert!(returns_string); // also true — but i64_str branch fires first
     }
+
+    #[test]
+    fn fastify_header_routes_by_receiver_class() {
+        // Regression: the request getter `request.header(name)` and the reply
+        // setter `reply.header(name, value)` are distinct rows in FASTIFY_ROWS
+        // sharing method "header". When both were `class_filter: None`, the
+        // arity-blind generic pass matched BOTH to whichever row came first
+        // (the request getter), so `reply.header(...)` silently no-op'd. Tagging
+        // them Some("Request") / Some("Reply") lets the exact-class first pass
+        // route each by receiver. (Fastify handler params are registered as
+        // ("fastify","Request") / ("fastify","Reply") by position.)
+        let req = super::native_module_lookup("fastify", true, "header", Some("Request"))
+            .expect("request.header must resolve");
+        assert_eq!(
+            req.runtime, "js_fastify_req_header",
+            "request.header(name) must route to the 1-arg getter"
+        );
+        assert_eq!(req.args.len(), 1, "request getter takes one arg");
+
+        let reply = super::native_module_lookup("fastify", true, "header", Some("Reply"))
+            .expect("reply.header must resolve");
+        assert_eq!(
+            reply.runtime, "js_fastify_reply_header",
+            "reply.header(name, value) must route to the 2-arg setter, not the getter"
+        );
+        assert_eq!(reply.args.len(), 2, "reply setter takes two args");
+
+        // The two receiver classes must NOT collide on the same runtime symbol.
+        assert_ne!(
+            req.runtime, reply.runtime,
+            "request and reply `.header` must resolve to different runtime symbols"
+        );
+    }
 }

--- a/crates/perry-codegen/src/lower_call/native_table/fastify.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/fastify.rs
@@ -256,7 +256,16 @@ pub(super) const FASTIFY_ROWS: &[NativeModSig] = &[
         module: "fastify",
         has_receiver: true,
         method: "header",
-        class_filter: None,
+        // Receiver-scoped so `request.header(name)` (1-arg getter) and
+        // `reply.header(name, value)` (2-arg setter) don't collide: both
+        // rows previously had `class_filter: None`, so the arity-blind
+        // first-match-wins generic lookup routed BOTH at this request
+        // getter and `reply.header` silently no-op'd (`Location` / CSP
+        // headers set via the method form evaporated). Fastify handler
+        // params are registered as ("fastify","Request") / ("fastify",
+        // "Reply") by position (`pre_scan_fastify_handler_params`), so the
+        // matcher's exact-class first pass now disambiguates them.
+        class_filter: Some("Request"),
         runtime: "js_fastify_req_header",
         args: &[NA_JSV],
         ret: NR_STR,
@@ -314,7 +323,12 @@ pub(super) const FASTIFY_ROWS: &[NativeModSig] = &[
         module: "fastify",
         has_receiver: true,
         method: "header",
-        class_filter: None,
+        // Receiver-scoped (see the request `.header` getter row above):
+        // tagging this reply setter `Some("Reply")` lets the matcher's
+        // exact-class first pass pick it for `reply.header(name, value)`
+        // instead of the arity-blind generic pass falling through to the
+        // request getter (which silently dropped the set header).
+        class_filter: Some("Reply"),
         runtime: "js_fastify_reply_header",
         args: &[NA_JSV, NA_JSV],
         ret: NR_PTR,


### PR DESCRIPTION
<!--
Thanks for contributing to Perry! A few things to know before you submit:

1. Please do NOT bump `[workspace.package] version` in Cargo.toml.
2. Please do NOT edit the "**Current Version:**" line or add a "Recent
   Changes" entry in CLAUDE.md.
3. Please do NOT edit CHANGELOG.md.

The maintainer folds all of that metadata in at merge time — Perry
releases frequently, and version bumps conflict if they live on the
PR branch. See CONTRIBUTING.md for the reasoning.
-->

## Summary

`reply.header(name, value)` was a silent no-op in compiled Fastify handlers —
response headers set via the method form (`Location`, CSP, `Cache-Control`,
etc.) never reached the wire.

The two `header` rows in `FASTIFY_ROWS` both declared `class_filter: None`: one
maps the 1-arg getter `request.header(name)` → `js_fastify_req_header`, the
other the 2-arg setter `reply.header(name, value)` → `js_fastify_reply_header`.
`native_module_lookup` resolves in two passes — an exact `class_filter ==
class_name` pass, then a generic `class_filter.is_none()` **first-match-wins**
pass. With both rows generic, the arity-blind generic pass routed BOTH calls to
whichever row came first (the request getter), so the setter silently dropped
the header.

Fastify handler params are already registered by position as
`("fastify","Request")` / `("fastify","Reply")` during HIR lowering
(`pre_scan_fastify_handler_params`), and the dispatch table's exact-class pass
is already used by many other modules (`http_server`, `net`, `databases`, …).
This change just uses that existing mechanism for the two `header` rows.

## Changes

- `crates/perry-codegen/src/lower_call/native_table/fastify.rs` — tag the
  request `header` getter row `class_filter: Some("Request")` and the reply
  `header` setter row `Some("Reply")`, so the exact-class first pass routes
  each `.header()` call to its correct runtime symbol by receiver.
- `crates/perry-codegen/src/lower_call/native_module_dispatch.rs` — regression
  test `fastify_header_routes_by_receiver_class`: asserts the `Request` lookup
  resolves to the 1-arg `js_fastify_req_header` and the `Reply` lookup to the
  2-arg `js_fastify_reply_header`, and that the two never collide on one symbol.

No runtime/adapter change — the routed symbols (`js_fastify_req_header` /
`js_fastify_reply_header`) already exist in `perry-ext-fastify`.

## Related issue

n/a — codegen dispatch fix for `reply.header(...)`.

## Test plan

```
$ cargo test -p perry-codegen --lib
test ...::fastify_header_routes_by_receiver_class ... ok
test result: ok. 130 passed; 0 failed; ...

$ rm -rf target/perry-auto-* && scripts/run_fastify_tests.sh   # no serving regression
fastify-tests: 12 passed, 0 failed

$ cargo fmt --check -p perry-codegen     # clean
```

**End-to-end** (compiled a handler that does `request.header("host")` +
`reply.header("x-test-header","works")` + `reply.header("location","/redirected")`
through `perry`, then `curl -i`):

```
# Before (unfixed codegen): reply.header evaporates
HTTP/1.1 200 OK
content-type: application/json
...                                  # no x-test-header, no location

# After (this fix):
HTTP/1.1 200 OK
x-test-header: works                 # setter now applied
location: /redirected
content-type: application/json
{"host":"127.0.0.1:..."}             # getter still works
```

The regression test is **mutation-checked**: reverting either/both rows to
`class_filter: None` makes `fastify_header_routes_by_receiver_class` fail
(*"reply.header… must route to the 2-arg setter, not the getter"*).

- [x] `cargo build --release` clean — built `-p perry` (the codegen change); the
  full-workspace build needs the GTK/`gdk-pixbuf` libs for `perry-ui-*`, which CI provides.
- [x] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes — ran the affected crate (`cargo test -p perry-codegen --lib`, **130/130**) plus `scripts/run_fastify_tests.sh` (**12/12**) and the end-to-end header check; the full workspace test is deferred to CI (the base `perry-ui` crate needs `gdk-pixbuf`, unavailable locally).
- [x] (if user-facing) Added or updated a test under `test-files/` or a `#[test]` in the affected crate — `fastify_header_routes_by_receiver_class`.
- [ ] (if CLI / stdlib / runtime API changed) Updated `docs/src/` — n/a, internal dispatch-table fix, no public API surface.
- [ ] (if touching a platform UI backend) Built `-p perry-ui-<backend>` locally on that platform — n/a.

## Screenshots / output

n/a — see the `curl -i` before/after in the test plan.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log — `fix(codegen): …`
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Fastify `.header` handling so request and reply calls are matched correctly based on the receiver type.
  * Prevented the request-side getter and reply-side setter from colliding, improving reliability of header-related behavior.
  * Added coverage for the two Fastify routes to ensure they resolve to the correct runtime symbols and argument counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->