### PR TITLE
fix(hir): new ClassName(...spread) dropped the spread, passing the array as one arg (SIGBUS)

### DIFF
--- a/crates/perry-hir/src/lower/expr_new/helpers.rs
+++ b/crates/perry-hir/src/lower/expr_new/helpers.rs
@@ -201,6 +201,18 @@ pub(crate) fn callee_is_generic_construct_shape(ctx: &LoweringContext, callee: &
         if ctx.lookup_local(ident.sym.as_ref()).is_some() {
             return true;
         }
+        // A bare-identifier callee naming a known USER CLASS (`class S {…}`;
+        // `new S(...args)`). The dedicated static-class `new` lowering maps over
+        // `a.expr` and DROPS the `a.spread` marker, collapsing `new S(...arr)`
+        // into a single array argument (`this.field = arr` instead of `arr[0]`),
+        // which SIGBUSes on the first method call (NestJS DI:
+        // `new Provider(...resolvedDeps)`). Route it through `NewDynamicSpread`
+        // so the spread positions survive; the generic apply path allocates the
+        // instance with the class's registered inline-keys shape and replays the
+        // constructor, so the result is identical to the fixed-arity `new S(arg)`.
+        if ctx.lookup_class(ident.sym.as_ref()).is_some() {
+            return true;
+        }
     }
     matches!(
         callee,


### PR DESCRIPTION
## Bug

`new S(...arr)` where `S` is a top-level user class drops the spread and passes the **whole array as a single argument**.

```ts
class Dep { hello(){ return 'hi'; } }
class S { constructor(public dep: Dep){} run(){ return this.dep.hello(); } }
const arr = [new Dep()];
console.log('direct:', new S(arr[0]).run()); // direct: hi
const s = new S(...arr);
console.log('spread:', s.run());             // SIGBUS (exit 139)
```

The constructor receives `this.dep = arr` instead of `this.dep = arr[0]`, so the first method call dereferences an array as the instance and SIGBUSes (exit 138/139).

This is exactly the **NestJS dependency-injection** pattern `new Provider(...resolvedDeps)`, where the container spreads a resolved-dependency array into a provider constructor.

## Root cause

A bare-identifier `new` callee that names a top-level user class is lowered through the dedicated static-class `new` path. That path maps over `a.expr` and **drops the `a.spread` marker**, collapsing `new S(...arr)` into a single array argument.

`callee_is_generic_construct_shape` (in `crates/perry-hir/src/lower/expr_new/helpers.rs`) already routes local-binding identifiers and `Fn`/`Class`/`Arrow`/`Call`/`Member` callees through `NewDynamicSpread` (which preserves spread positions), but it did **not** cover a bare identifier naming a known user class.

## Fix

One case added: recognize a bare-identifier callee that resolves to a known user class (`ctx.lookup_class(...)`) as a generic constructable shape. Spread-`new` on it now routes through `NewDynamicSpread`, which preserves spread positions as `CallArg::Spread`, allocates the instance with the class's registered inline-keys shape, and replays the constructor — producing a result identical to the fixed-arity `new S(arg)`.

## Verification

All match Node:

| case | result |
|---|---|
| original repro | `direct: hi` / `spread: hi` (was SIGBUS) |
| multi-param + number field | `7` |
| rest-param constructor | `10` |
| default-param (under-applied) | `15` |
| default-param (fully applied) | `25` |
| mixed regular + spread `new M(1, ...tail)` | `6` |
| `extends` + `super(...args)` | `15` |
| plain (non-constructor) fn spread | `123` |

`cargo test -p perry-hir --release` passes with no regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of `new` expressions so calls that resolve to user-defined classes preserve spread arguments correctly.
  * Fixed an issue where `new Class(...items)` could be treated like a single array argument instead of keeping the spread position intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->