### PR TITLE
fix(runtime): include the old-gen arena in process.memoryUsage() heapUsed/heapTotal

### DIFF
--- a/crates/perry-runtime/src/arena/stats.rs
+++ b/crates/perry-runtime/src/arena/stats.rs
@@ -38,6 +38,18 @@ pub extern "C" fn js_arena_stats(out_used: *mut u64, out_total: *mut u64) {
             total += block.size as u64;
         }
     });
+    // Old-generation arena. Large objects (>16 KB — typed arrays, big arrays /
+    // strings) are born here, and minor-GC survivors are promoted here. Without
+    // this region `heapUsed` / `heapTotal` collapse toward 0 while RSS climbs,
+    // since the live/large heap lives entirely in old-gen. Mirrors the old-gen
+    // phase of `arena_in_use_bytes` (walk.rs) so the two accounts agree.
+    OLD_ARENA.with(|arena| {
+        let arena = unsafe { &*arena.get() };
+        for block in &arena.blocks {
+            used += block.offset as u64;
+            total += block.size as u64;
+        }
+    });
     unsafe {
         *out_used = used;
         *out_total = total;


### PR DESCRIPTION
<!--
Thanks for contributing to Perry! A few things to know before you submit:

1. Please do NOT bump `[workspace.package] version` in Cargo.toml.
2. Please do NOT edit the "**Current Version:**" line or add a "Recent
   Changes" entry in CLAUDE.md.
3. Please do NOT edit CHANGELOG.md.

The maintainer folds all of that metadata in at merge time — Perry
releases frequently, and version bumps conflict if they live on the
PR branch. See CONTRIBUTING.md for the reasoning.
-->

## Summary

`process.memoryUsage().heapUsed` (and `heapTotal`) reported ~0 regardless of
allocations — an 80 MB array showed `heapUsed: 0`, `heapTotal: ~4 MB` while
`rss` correctly showed ~97 MB.

`js_arena_stats` (which backs those fields) summed only the general/nursery,
longlived, and two survivor arenas — it **omitted `OLD_ARENA`**. But large
objects (>16 KB: typed arrays, big arrays/strings) are born in old-gen, and
minor-GC survivors are promoted there, so the live/large heap lives almost
entirely in old-gen. The result was `heapUsed`/`heapTotal` collapsing toward 0.

## Changes

- `crates/perry-runtime/src/arena/stats.rs` — add the `OLD_ARENA` region to the
  `js_arena_stats` walk, mirroring the old-gen phase already present in
  `arena_in_use_bytes` (`walk.rs`) so the two accounts agree.

## Related issue

n/a — `process.memoryUsage()` heap-field accuracy.

## Test plan

```
# Before: an 80MB array -> heapUsed=0, heapTotal=4 (rss=97).
# After:
$ perry compile mem.ts -o mem && ./mem
start  heapUsed=0  heapTotal=5  rss=7
alloc  heapUsed=77 heapTotal=82 rss=97     # heapUsed/heapTotal now reflect the 80MB

$ cargo test -p perry-runtime --lib arena   # 51 passed
$ cargo fmt --check -p perry-runtime         # clean
```

Caveats (unchanged, out of scope): `gc_malloc`/system-malloc'd objects
(promises, maps, large closures, bigints) are still not counted — matching the
existing `arena_in_use_bytes`/`arena_total_bytes` accessors — and
`external`/`arrayBuffers` remain 0. `rss` is the OS-truthful field.

- [x] `cargo build --release` clean — built `-p perry-runtime` / `-p perry`; full-workspace build needs the GTK/`gdk-pixbuf` libs for `perry-ui-*`, which CI provides.
- [x] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes — ran `cargo test -p perry-runtime --lib arena` (51/51) plus the end-to-end `memoryUsage()` check; full workspace deferred to CI.
- [x] (if user-facing) Added or updated a test — `arena` unit tests cover `js_arena_stats`; behavior verified end to end above.
- [ ] (if CLI / stdlib / runtime API changed) Updated `docs/src/` — n/a.
- [ ] (if touching a platform UI backend) Built `-p perry-ui-<backend>` — n/a.

## Screenshots / output

n/a — see the `heapUsed` before/after in the test plan.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention — `fix(runtime): …`
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Heap usage reporting now includes old-generation arena memory, improving the accuracy of displayed heap used/total values.
  * Allocation and reservation totals now account for all managed memory spaces, avoiding underreporting when live data resides in older generations.
  * Heap used/total values no longer collapse toward zero when activity occurs in old-generation allocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->