### PR TITLE
fix(hir): #5588 — reify the full set of Object static methods as first-class values

### DIFF
--- a/crates/perry-hir/src/lower/expr_member/member_tail.rs
+++ b/crates/perry-hir/src/lower/expr_member/member_tail.rs
@@ -162,17 +162,37 @@ pub(crate) fn lower_member_tail(
                             &member.prop,
                             ast::MemberProp::Ident(p) if matches!(
                                 p.sym.as_ref(),
+                                // Keep in sync with the Object statics installed
+                                // on the reified constructor in
+                                // global_this/install_static.rs — every name
+                                // here resolves to a real native function object
+                                // (correct `typeof`/`.name`/`.length`) when read
+                                // as a value (`const f = Object.isExtensible`).
+                                // Omitting one collapses the read to the
+                                // intrinsic `GlobalGet(0).<name>` path, which has
+                                // no value form and yields `undefined` (#5588).
                                 "assign"
                                     | "create"
+                                    | "defineProperties"
                                     | "defineProperty"
                                     | "entries"
                                     | "freeze"
                                     | "fromEntries"
                                     | "getOwnPropertyDescriptor"
+                                    | "getOwnPropertyDescriptors"
                                     | "getOwnPropertyNames"
+                                    | "getOwnPropertySymbols"
                                     | "getPrototypeOf"
+                                    | "groupBy"
                                     | "hasOwn"
+                                    | "is"
+                                    | "isExtensible"
+                                    | "isFrozen"
+                                    | "isSealed"
                                     | "keys"
+                                    | "preventExtensions"
+                                    | "seal"
+                                    | "setPrototypeOf"
                                     | "values"
                             )
                         );

--- a/test-files/test_issue_5588_object_static_values.ts
+++ b/test-files/test_issue_5588_object_static_values.ts
@@ -1,0 +1,40 @@
+// Issue #5588: Object static methods read AS VALUES (not in call position) —
+// e.g. `const f = Object.isExtensible` — collapsed to `undefined` for the
+// methods missing from the HIR reification allow-list (isExtensible,
+// preventExtensions, setPrototypeOf, seal, isFrozen, isSealed, is,
+// defineProperties, getOwnPropertyDescriptors, getOwnPropertySymbols, groupBy).
+// They are real native functions in Node, so `typeof` must be "function", the
+// `.name`/`.length` own-properties must read, and the bound value must call.
+
+// --- typeof of each static read as a bare value ---
+const statics: any = Object;
+for (const k of [
+  "assign", "create", "defineProperties", "defineProperty", "entries",
+  "freeze", "fromEntries", "getOwnPropertyDescriptor",
+  "getOwnPropertyDescriptors", "getOwnPropertyNames", "getOwnPropertySymbols",
+  "getPrototypeOf", "groupBy", "hasOwn", "is", "isExtensible", "isFrozen",
+  "isSealed", "keys", "preventExtensions", "seal", "setPrototypeOf", "values",
+]) {
+  console.log(k, typeof statics[k]);
+}
+
+// --- assigned to a const, then inspected (the failing #5588 shape) ---
+const f = Object.isExtensible;
+console.log("isExtensible.name:", f.name, "len:", f.length, "typeof:", typeof f);
+const s = Object.setPrototypeOf;
+console.log("setPrototypeOf.name:", s.name, "len:", s.length);
+const p = Object.preventExtensions;
+console.log("preventExtensions.name:", p.name, "len:", p.length);
+
+// --- the bound values are actually callable through the alias ---
+const target: any = {};
+console.log("alias setProto identity:", s(target, { greet() { return "hi"; } }) === target);
+console.log("alias greet:", target.greet());
+console.log("alias isExtensible:", f(target), f(p({})));
+
+// --- getOwnPropertyDescriptor identity for a static function value ---
+const desc = Object.getOwnPropertyDescriptor(Object, "preventExtensions")!;
+console.log(
+  "desc:", desc.value === Object.preventExtensions,
+  desc.writable, desc.enumerable, desc.configurable,
+);


### PR DESCRIPTION
## Summary

Part of #5588 (test262 `built-ins/Object` parity). Fixes a clean root-cause cluster: several `Object` static methods read **as values** (not in call position) resolved to `undefined`.

```js
const f = Object.isExtensible;
typeof f;            // was "undefined", now "function"
f.name;              // was unreachable, now "isExtensible"
Object.setPrototypeOf.length;  // was undefined, now 2
```

## Root cause

`Object.isExtensible`, `preventExtensions`, `setPrototypeOf`, `seal`, `isFrozen`, `isSealed`, `is`, `defineProperties`, `getOwnPropertyDescriptors`, `getOwnPropertySymbols`, and `groupBy` are all installed on the reified `Object` constructor (`global_this/install_static.rs`), but the `outer_is_reified_object_static_value` allow-list in member lowering (`crates/perry-hir/src/lower/expr_member/member_tail.rs`) only named a subset (`assign`, `create`, `keys`, …).

For an omitted method, a value read collapsed the receiver to `GlobalGet(0)`, whose intrinsic property path has no value form and yields `undefined`. The codegen fallback in `globalget.rs` deliberately **cannot** recover these names, because once the receiver is collapsed they're ambiguous with `Reflect.*` / `Map.groupBy` — so the fix belongs in HIR: route the value reads through the reified `Object` receiver, matching the methods that already worked.

Direct calls (`Object.setPrototypeOf(a, b)`) already routed through the reified receiver and are unaffected.

## Impact

test262 `built-ins/Object` subtree (3173 cases, local sweep): **77 → 69 failures, 0 regressions**. Cases fixed:

- `isExtensible/name.js`, `isExtensible/15.2.3.13-0-1.js`
- `preventExtensions/name.js`, `preventExtensions/15.2.3.10-0-1.js`
- `setPrototypeOf/name.js`, `setPrototypeOf/length.js`
- `getOwnPropertyDescriptor/15.2.3.3-4-22.js`, `getOwnPropertyDescriptor/15.2.3.3-4-25.js`

## Testing

- New parity test `test-files/test_issue_5588_object_static_values.ts` — byte-for-byte match with `node --experimental-strip-types`.
- `cargo test -p perry-hir` green.
- Direct + aliased calls of every routed method verified functionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)