### PR TITLE
fix(codegen): #5703 — pad under-supplied class-expression static-method calls with undefined

### DIFF
--- a/crates/perry-codegen/src/lower_call/property_get/static_dispatch.rs
+++ b/crates/perry-codegen/src/lower_call/property_get/static_dispatch.rs
@@ -143,12 +143,33 @@ pub(crate) fn try_lower_static_dispatch(
             // then bundle the trailing args into an Array.
             let mut lowered: Vec<String> = Vec::with_capacity(args.len());
             if has_rest && is_synth_args {
-                let cap = (args.len() as u32).to_string();
-                let mut current = ctx.block().call(I64, "js_array_alloc", &[(I32, &cap)]);
+                // Lower each call arg exactly ONCE (a value may have side
+                // effects), then reuse the SSA registers both for the leading
+                // real params and for the synthesized `arguments` object.
+                let mut vals: Vec<String> = Vec::with_capacity(args.len());
                 for a in args {
-                    let v = lower_expr(ctx, a)?;
+                    vals.push(lower_expr(ctx, a)?);
+                }
+                // #5703: the leading real params BEFORE the synth `arguments`
+                // slot (`static method(x, _ = 0) { … arguments … }` →
+                // params `[x, _, <arguments>]`) must receive their positional
+                // values, padded with `undefined` when under-supplied — exactly
+                // as the class-DECLARATION (StaticMethodCall) path does.
+                // Previously this branch pushed ONLY the arguments object, so a
+                // leading param like `x` received the (empty) arguments array
+                // instead of its argument / `undefined` (test262
+                // `params-dflt-meth-static-args-unmapped`).
+                let undef = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+                let fixed_count = declared.saturating_sub(1);
+                for i in 0..fixed_count {
+                    lowered.push(vals.get(i).cloned().unwrap_or_else(|| undef.clone()));
+                }
+                // The synthesized `arguments` object holds ALL passed args.
+                let cap = (vals.len() as u32).to_string();
+                let mut current = ctx.block().call(I64, "js_array_alloc", &[(I32, &cap)]);
+                for v in &vals {
                     let blk = ctx.block();
-                    current = blk.call(I64, "js_array_push_f64", &[(I64, &current), (DOUBLE, &v)]);
+                    current = blk.call(I64, "js_array_push_f64", &[(I64, &current), (DOUBLE, v)]);
                 }
                 current =
                     ctx.block()
@@ -159,6 +180,15 @@ pub(crate) fn try_lower_static_dispatch(
                 let fixed_count = declared.saturating_sub(1);
                 for a in args.iter().take(fixed_count) {
                     lowered.push(lower_expr(ctx, a)?);
+                }
+                // #5703 (mirrors #235 in the StaticMethodCall path): when the
+                // caller under-supplies the fixed leading params, pad the
+                // missing slots with `undefined` BEFORE the rest array, so the
+                // callee's default-param prologue / destructuring fires instead
+                // of reading an uninitialized (0.0) parameter register.
+                let undef = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+                while lowered.len() < fixed_count {
+                    lowered.push(undef.clone());
                 }
                 let rest_count = args.len().saturating_sub(fixed_count);
                 let cap = (rest_count as u32).to_string();
@@ -173,6 +203,20 @@ pub(crate) fn try_lower_static_dispatch(
             } else {
                 for a in args {
                     lowered.push(lower_expr(ctx, a)?);
+                }
+                // #5703: a static method of a class EXPRESSION called with fewer
+                // args than declared (`C.m()` for `static m(a = 1)` or
+                // `static m([x, y] = […])`) reaches this fused get-static-method
+                // +call path rather than the `StaticMethodCall` path used by
+                // class DECLARATIONS. That path pads missing slots with
+                // `undefined` (#235); this one did not, so the callee read an
+                // uninitialized (0.0) register — its default-param prologue
+                // (`if (p === undefined) p = …`) and array destructuring
+                // (`GetIterator(p)` → "is not iterable") never fired. Pad here
+                // too so both paths behave identically.
+                let undef = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+                while lowered.len() < declared {
+                    lowered.push(undef.clone());
                 }
             }
             let prev_this =

--- a/crates/perry/tests/issue_5703_class_expr_static_dflt_params.rs
+++ b/crates/perry/tests/issue_5703_class_expr_static_dflt_params.rs
@@ -98,7 +98,10 @@ console.log(C.m());
 console.log(C.m([1, 2]));
 "#,
     );
-    assert_eq!(stdout, "7\n3\n", "default array destructured when no arg supplied");
+    assert_eq!(
+        stdout, "7\n3\n",
+        "default array destructured when no arg supplied"
+    );
 }
 
 /// A leading non-default param BEFORE the synthesized `arguments` slot
@@ -127,8 +130,7 @@ C.method(7, 8, 9);
 "#,
     );
     assert_eq!(
-        stdout,
-        "x=undefined _=0\na0=undefined a1=undefined len=0\nx=7 _=8\na0=7 a1=8 len=3\n",
+        stdout, "x=undefined _=0\na0=undefined a1=undefined len=0\nx=7 _=8\na0=7 a1=8 len=3\n",
         "leading param + synth arguments must match node (byte-for-byte)"
     );
 }
@@ -149,7 +151,10 @@ console.log(C.pipe());
 console.log(C.pipe(1, 2, 3));
 "#,
     );
-    assert_eq!(stdout, "0\n3\n", "arguments-only static method counts all args");
+    assert_eq!(
+        stdout, "0\n3\n",
+        "arguments-only static method counts all args"
+    );
 }
 
 /// Static async-generator method of a class expression with an
@@ -174,5 +179,8 @@ var C = class {
 })();
 "#,
     );
-    assert_eq!(stdout, "10,20\n", "default applies inside a static async generator");
+    assert_eq!(
+        stdout, "10,20\n",
+        "default applies inside a static async generator"
+    );
 }

--- a/crates/perry/tests/issue_5703_class_expr_static_dflt_params.rs
+++ b/crates/perry/tests/issue_5703_class_expr_static_dflt_params.rs
@@ -1,0 +1,178 @@
+//! Regression test for #5703 — a STATIC method of a class EXPRESSION
+//! (`var C = class { static m(...) {...} }`) called with fewer arguments than
+//! declared dropped its default-parameter / array-destructuring prologue.
+//!
+//! Root cause: `C.m()` on a class-expression value reaches the fused
+//! get-static-method+call path in
+//! `lower_call/property_get/static_dispatch.rs` (class DECLARATIONS instead
+//! lower `C.m()` to a `StaticMethodCall`, which already pads — #235). That
+//! path forwarded only the supplied args to a fixed-arity LLVM function, so
+//! missing slots arrived as an uninitialized `0.0` register rather than
+//! `undefined`. The callee's default-param prologue (`if (p === undefined) p =
+//! …`) never fired, and array destructuring of the missing slot
+//! (`GetIterator(p)`) threw `TypeError: is not iterable`. This broke ~61
+//! `language/expressions/class` test262 cases (static methods of class
+//! expressions with default params / destructuring), dominated by static
+//! async-generator methods with an array-destructuring default param.
+//!
+//! Fix: pad the missing positional slots with `undefined` in the static
+//! dispatch path, mirroring the `StaticMethodCall` path. Expected outputs are
+//! byte-for-byte what `node --experimental-strip-types` prints.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed (exit {:?})\nstdout:\n{}\nstderr:\n{}",
+        run.status.code(),
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+/// Scalar default param on a class-expression static method, called with no
+/// args. Pre-fix this printed `0` (uninitialized register), then `9`.
+#[test]
+fn class_expr_static_scalar_default_param() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+var C = class {
+  static m(x = 5) { return x; }
+};
+console.log(C.m());
+console.log(C.m(9));
+"#,
+    );
+    assert_eq!(
+        stdout, "5\n9\n",
+        "missing arg must default to 5 (undefined-padded), supplied arg wins"
+    );
+}
+
+/// Array-destructuring default param — the dominant #5703 signature. Pre-fix
+/// `C.m()` threw `TypeError: is not iterable` (the missing slot was `0.0`, not
+/// the `undefined` that triggers the default).
+#[test]
+fn class_expr_static_destructuring_default_param() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+var C = class {
+  static m([x, y] = [3, 4]) { return x + y; }
+};
+console.log(C.m());
+console.log(C.m([1, 2]));
+"#,
+    );
+    assert_eq!(stdout, "7\n3\n", "default array destructured when no arg supplied");
+}
+
+/// A leading non-default param BEFORE the synthesized `arguments` slot
+/// (`static method(x, _ = 0) { … arguments … }`) on a class expression. The
+/// synth-`arguments` dispatch branch previously pushed only the arguments
+/// object, so `x` received the (empty) arguments array — printing `x=` instead
+/// of `x=undefined` (test262 `params-dflt-meth-static-args-unmapped`). The
+/// `arguments` object must hold all passed args, independent of the (unmapped)
+/// named params.
+#[test]
+fn class_expr_static_leading_param_with_arguments() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+var C = class {
+  static method(x, _ = 0) {
+    console.log("x=" + x + " _=" + _);
+    console.log(
+      "a0=" + arguments[0] + " a1=" + arguments[1] + " len=" + arguments.length
+    );
+  }
+};
+C.method();
+C.method(7, 8, 9);
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "x=undefined _=0\na0=undefined a1=undefined len=0\nx=7 _=8\na0=7 a1=8 len=3\n",
+        "leading param + synth arguments must match node (byte-for-byte)"
+    );
+}
+
+/// A class-expression static method whose ONLY parameter is the synthesized
+/// `arguments` (effect-style `static pipe() { … arguments.length … }`) must be
+/// unaffected by the leading-param fix above — guards the fixed_count == 0 path.
+#[test]
+fn class_expr_static_arguments_only_unregressed() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+var C = class {
+  static pipe() { return arguments.length; }
+};
+console.log(C.pipe());
+console.log(C.pipe(1, 2, 3));
+"#,
+    );
+    assert_eq!(stdout, "0\n3\n", "arguments-only static method counts all args");
+}
+
+/// Static async-generator method of a class expression with an
+/// array-destructuring default param — the exact shape of the ~42
+/// `async-gen-meth-static-dflt-ary-*` test262 cases.
+#[test]
+fn class_expr_static_async_gen_destructuring_default() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+var C = class {
+  static async *agen([a, b] = [10, 20]) {
+    yield a;
+    yield b;
+  }
+};
+(async () => {
+  const out: number[] = [];
+  for await (const v of C.agen()) out.push(v);
+  console.log(out.join(","));
+})();
+"#,
+    );
+    assert_eq!(stdout, "10,20\n", "default applies inside a static async generator");
+}


### PR DESCRIPTION
## Summary

Fixes #5703. A **static method of a class EXPRESSION** (`var C = class { static m(...) {...} }`) called with fewer arguments than declared dropped its default-parameter / array-destructuring prologue — the dominant signature being `TypeError: is not iterable` on static async-generator methods with an array-destructuring default param (~61 `language/expressions/class` test262 cases).

### Root cause

`C.m()` on a class-expression value reaches the fused get-static-method+call path in `lower_call/property_get/static_dispatch.rs`. Class **declarations** instead lower `C.m()` to a `StaticMethodCall`, which already pads missing argument slots with `undefined` (#235). The dispatch path forwarded only the supplied args to a fixed-arity LLVM function, so missing slots arrived as an uninitialized `0.0` register rather than `undefined`. The callee's default-param prologue (`if (p === undefined) p = …`) never fired, and array destructuring of the missing slot (`GetIterator(p)`) threw `TypeError: is not iterable`.

> Note on the bisection: the issue's window pointed at #5662, but that commit only adds a `RegisterClassCaptures` snapshot under `if !captured_args.is_empty()`. The bug reproduces with that hunk disabled, so it is **pre-existing** in the static-dispatch path, not a #5662 regression. #5662 is a legitimate #5437 fix and is left intact.

### Fix

In `static_dispatch.rs`, pad missing positional slots with `undefined`, mirroring the `StaticMethodCall` path:
- **no-rest** and **plain-rest** branches: pad the fixed leading params up to the declared arity.
- **synthesized-`arguments`** branch: previously pushed *only* the arguments object, so a leading real param (`static method(x, _ = 0) { … arguments … }`) received the empty arguments array instead of its argument / `undefined`. It now lowers each arg once (no double side-effects), feeds leading params their positional values (undefined-padded), and builds the `arguments` object from **all** passed args.

### Validation

- New regression test `issue_5703_class_expr_static_dflt_params` — 5 cases, byte-for-byte against `node --experimental-strip-types` (all pass).
- `test262 language/expressions/class` (4028 judged): the dominant `meth-static-dflt-ary-*` cases all pass (0 remaining), plus the `params-dflt-*-meth-static-args-unmapped` and `-ref-arguments` cases now pass — **0 newly-broken**.
- Remaining residuals (object-rest destructuring with getters/non-enumerable, static setters) are separate pre-existing issues outside the default-param family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected argument binding for class-expression `static` method calls when fewer arguments are provided than declared.
  * Ensured default parameter evaluation and array-destructuring defaults receive initialized values (using `undefined` padding when needed).
  * Fixed synthesized `arguments` semantics, including correct array contents and `arguments.length` behavior, and improved handling with rest parameters and `static async *` generators.

* **Tests**
  * Added regression tests covering scalar defaults, destructuring defaults, `arguments` interactions, and generator edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->