### PR TITLE
fix(hir,runtime): native chained-static-class decorators + reflect-metadata require binding (NestJS bootstrap)

### DIFF
--- a/crates/perry-hir/src/lower/lower_expr/arm_ident.rs
+++ b/crates/perry-hir/src/lower/lower_expr/arm_ident.rs
@@ -57,8 +57,13 @@ pub(crate) fn lower_ident_expr(ctx: &mut LoweringContext, ident: &ast::Ident) ->
     // class name.)
     if let Some(cur) = ctx.current_class.clone() {
         if let Some(target) = ctx.class_expr_aliases.get(&name) {
-            if *target == cur {
-                return Ok(Expr::ClassRef(ctx.resolve_class_name(target)));
+            // Compare the RESOLVED target name: a collision-renamed class
+            // expression makes `current_class` the resolved name while the
+            // recorded `target` is still the source name, so a raw `*target ==
+            // cur` would miss. Resolving is identity when no rename happened.
+            let resolved = ctx.resolve_class_name(target);
+            if resolved == cur {
+                return Ok(Expr::ClassRef(resolved));
             }
         }
     }

--- a/crates/perry-hir/src/lower/lower_expr/arm_ident.rs
+++ b/crates/perry-hir/src/lower/lower_expr/arm_ident.rs
@@ -38,6 +38,30 @@ pub(crate) fn lower_ident_expr(ctx: &mut LoweringContext, ident: &ast::Ident) ->
     {
         return Ok(Expr::ClassRef(ctx.resolve_class_name(&name)));
     }
+    // Chained-assignment class self-alias referenced from inside one of the
+    // class's own method/getter/setter bodies. tsc's decorator-capture form
+    // `let Logger = Logger_1 = class Logger { get x(){ …Logger_1… } static
+    // error(){ …Logger_1… } }` declares `Logger_1` as a real outer-scope local
+    // and binds the class to it. Inside a STATIC method the outer local is not
+    // in scope (the method compiles to a standalone function), and inside an
+    // instance method resolving to a `LocalGet` capture forces the whole class
+    // onto the per-evaluation `ClassExprFresh` path (which drops static methods
+    // and SIGSEGVs `new`). The alias value IS the class everywhere after
+    // evaluation, so resolve it to the constructor `ClassRef` directly — exactly
+    // as JS spec resolves the inner class binding. `record_chained_class_self_
+    // aliases` populates `class_expr_aliases[alias] = <class lowering name>`
+    // before the body is lowered; gate on currently lowering that same class so
+    // an unrelated outer reference to the name is untouched. (`class_expr_
+    // aliases` is NOT a `register_class`, so this does not trip
+    // `lower_class_expr`'s collision-rename — `current_class` stays the real
+    // class name.)
+    if let Some(cur) = ctx.current_class.clone() {
+        if let Some(target) = ctx.class_expr_aliases.get(&name) {
+            if *target == cur {
+                return Ok(Expr::ClassRef(ctx.resolve_class_name(target)));
+            }
+        }
+    }
     if let Some(id) = ctx.lookup_local(&name) {
         // A with-fallback implicit global may still be the HOLE
         // sentinel (the with-env took the write) — reading it then

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -50,6 +50,41 @@ pub(crate) fn lower_module_decl(
 
             if source == "reflect-metadata" {
                 emit_reflect_metadata_shim_note();
+                // `import "reflect-metadata"` (no specifiers) is a pure
+                // side-effect import — Perry provides the `Reflect.*metadata`
+                // surface natively, so there is nothing to bind. But a CJS
+                // module that does `require("reflect-metadata")` is wrapped to
+                // `import _req_N from 'reflect-metadata'` with a default-import
+                // LOCAL, and the synthesized require shim's
+                // `if (specifier === 'reflect-metadata') return _req_N;`
+                // references that local. Without a binding the read throws
+                // `ReferenceError: _req_N is not defined` at module
+                // evaluation (NestJS's `@nestjs/common/index.js` —
+                // `require("reflect-metadata")` — and every other
+                // reflect-metadata-importing CJS barrel hit this). Bind each
+                // default/namespace/named local to an empty object: the module
+                // value is only ever the discarded result of
+                // `require("reflect-metadata")` (the real effect is the global
+                // `Reflect` polyfill, which Perry already supplies), so an
+                // empty object is a faithful, inert stand-in.
+                for spec in &import_decl.specifiers {
+                    let local = match spec {
+                        ast::ImportSpecifier::Default(d) => d.local.sym.to_string(),
+                        ast::ImportSpecifier::Namespace(n) => n.local.sym.to_string(),
+                        ast::ImportSpecifier::Named(n) => n.local.sym.to_string(),
+                    };
+                    if ctx.lookup_local(&local).is_some() {
+                        continue;
+                    }
+                    let id = ctx.define_local(local.clone(), Type::Any);
+                    module.init.push(Stmt::Let {
+                        id,
+                        name: local,
+                        ty: Type::Any,
+                        mutable: true,
+                        init: Some(Expr::Object(Vec::new())),
+                    });
+                }
                 return Ok(());
             }
 

--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -79,7 +79,10 @@ fn emit_class_expression_value_binding(
 /// counted as an outer-scope capture — keeping the class on the shared-template
 /// `ClassRef` path instead of the static-method-dropping `ClassExprFresh` path.
 /// The class's own bind/inner name is already covered by `name` in that pass.
-pub(crate) fn record_chained_class_self_aliases(ctx: &mut LoweringContext, decl: &ast::VarDeclarator) {
+pub(crate) fn record_chained_class_self_aliases(
+    ctx: &mut LoweringContext,
+    decl: &ast::VarDeclarator,
+) {
     let (ast::Pat::Ident(ident), Some(init)) = (&decl.name, &decl.init) else {
         return;
     };
@@ -118,7 +121,9 @@ pub(crate) fn record_chained_class_self_aliases(ctx: &mut LoweringContext, decl:
         .map(|i| i.sym.to_string())
         .unwrap_or_else(|| bind_name.clone());
     for t in chained_targets {
-        ctx.class_expr_aliases.entry(t).or_insert(class_name.clone());
+        ctx.class_expr_aliases
+            .entry(t)
+            .or_insert(class_name.clone());
     }
 }
 

--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -70,6 +70,58 @@ fn emit_class_expression_value_binding(
     });
 }
 
+/// For a `let X = T1 = … = class [Y] {…}` declaration, record the chained
+/// assignment targets (`T1`, …) as class self-aliases of the class's lowering
+/// name in `ctx.class_expr_aliases`, BEFORE the init is lowered. This does NOT
+/// `register_class` the names (which would trip `lower_class_expr`'s
+/// collision-rename), it only feeds `synthesize_class_captures`'s self-alias
+/// exclusion so a method-body reference to `T1` (e.g. tsc's `Logger_1`) is not
+/// counted as an outer-scope capture — keeping the class on the shared-template
+/// `ClassRef` path instead of the static-method-dropping `ClassExprFresh` path.
+/// The class's own bind/inner name is already covered by `name` in that pass.
+pub(crate) fn record_chained_class_self_aliases(ctx: &mut LoweringContext, decl: &ast::VarDeclarator) {
+    let (ast::Pat::Ident(ident), Some(init)) = (&decl.name, &decl.init) else {
+        return;
+    };
+    let bind_name = ident.id.sym.to_string();
+    let mut chained_targets: Vec<String> = Vec::new();
+    let mut e = init.as_ref();
+    let inner_class = loop {
+        match e {
+            ast::Expr::Paren(p) => e = &p.expr,
+            ast::Expr::TsAs(a) => e = &a.expr,
+            ast::Expr::TsNonNull(n) => e = &n.expr,
+            ast::Expr::TsTypeAssertion(a) => e = &a.expr,
+            ast::Expr::Assign(assign) if assign.op == ast::AssignOp::Assign => {
+                if let ast::AssignTarget::Simple(ast::SimpleAssignTarget::Ident(target)) =
+                    &assign.left
+                {
+                    chained_targets.push(target.id.sym.to_string());
+                    e = &assign.right;
+                } else {
+                    return;
+                }
+            }
+            ast::Expr::Class(c) => break c,
+            _ => return,
+        }
+    };
+    if chained_targets.is_empty() {
+        return;
+    }
+    // The class lowers under its inner expression name if present, else the
+    // binding name (matching `lower_class_expr`'s `ident_name`/synthetic-name
+    // choice for the common non-colliding case).
+    let class_name = inner_class
+        .ident
+        .as_ref()
+        .map(|i| i.sym.to_string())
+        .unwrap_or_else(|| bind_name.clone());
+    for t in chained_targets {
+        ctx.class_expr_aliases.entry(t).or_insert(class_name.clone());
+    }
+}
+
 /// Recursively walk a destructuring pattern collecting every leaf identifier
 /// (and pre-defining each as a local). Used by the for-of binding pre-pass so
 /// the loop body can reference variables introduced by *nested* patterns like
@@ -818,6 +870,12 @@ pub(crate) fn lower_stmt(
                                 }
                             }
                         }
+                        // Record chained-assignment class self-aliases (`let
+                        // Logger = Logger_1 = class …`) so the self-reference
+                        // isn't captured (see `synthesize_class_captures`). This
+                        // top-level path is reached for any `let X = T = class`
+                        // not handled by the direct `class` fast path above.
+                        record_chained_class_self_aliases(ctx, decl);
                         let stmts = lower_var_decl_with_destructuring(ctx, decl, mutable, is_var)?;
                         // `var` is function-scoped: mark defined locals so
                         // `pop_block_scope` preserves them when leaving an inner block.

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -170,6 +170,10 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                             .insert(binding.id.sym.as_ref().to_string());
                     }
                 }
+                // Record chained-assignment class self-aliases (`let Logger =
+                // Logger_1 = class …`) so the self-reference isn't captured (see
+                // `synthesize_class_captures`). Function / CJS-module body path.
+                crate::lower::record_chained_class_self_aliases(ctx, decl);
                 let stmts = lower_var_decl_with_destructuring(ctx, decl, mutable, is_var)?;
                 // `var` is function-scoped: mark each defined local so
                 // `pop_block_scope` preserves it when leaving an inner block.

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -122,6 +122,46 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
             return crate::proxy::js_reflect_get_own_property_descriptor(obj_value, key_value);
         }
 
+        // A per-evaluation class object (`ClassExprFresh`, #1772/#1787) is a
+        // POINTER-tagged heap object, not a `0x7FFE` class ref, so the
+        // `class_ref_id` branch below never fires for it. Its static METHODS
+        // live in the class registry keyed by the header class_id (not as own
+        // properties), so `getOwnPropertyDescriptor(C, "staticMethod")` reported
+        // `undefined` — which broke NestJS's tslib `__decorate` chain
+        // (`descriptor.value` on undefined → "reading 'value'") when the Logger
+        // class took the fresh path (its getter/methods capture module locals
+        // like `DEFAULT_LOGGER`, forcing `ClassExprFresh`). Mirror the class-ref
+        // branch's static-method descriptor: a `static m(){}` is a `{ writable,
+        // enumerable: false, configurable }` own data property of the
+        // constructor. `is_class_object_value` is pointer-safe (it checks the
+        // NaN-box tag before any deref). Own per-evaluation static FIELDS fall
+        // through to the ordinary own-property path (checked here via
+        // `own_key_present` so a field shadows a same-named template method).
+        if super::class_registry::is_class_object_value(obj_value) {
+            if let Some(method_name) = metadata_key_to_string(key_value) {
+                let obj = extract_obj_ptr(obj_value);
+                let key_str = crate::builtins::js_string_coerce(key_value);
+                if !obj.is_null() && !key_str.is_null() && !own_key_present(obj, key_str) {
+                    let class_id = super::js_object_get_class_id(obj as *const ObjectHeader);
+                    if class_id != 0
+                        && !super::class_registry::class_is_key_deleted(class_id, &method_name)
+                        && super::class_registry::class_has_own_static_method(
+                            class_id,
+                            &method_name,
+                        )
+                    {
+                        let leaked: &'static [u8] = method_name.as_bytes().to_vec().leak();
+                        let value = super::js_class_method_bind(
+                            obj_value,
+                            leaked.as_ptr(),
+                            leaked.len(),
+                        );
+                        return build_data_descriptor(value, true, false, true);
+                    }
+                }
+            }
+        }
+
         // Private elements (`#x`) are stored on the static side / in a class
         // instance's keys_array but are never reflectable own properties, so
         // their descriptor is always undefined. (Plain `{"#fff": 1}` literals

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -137,7 +137,13 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
         // NaN-box tag before any deref). Own per-evaluation static FIELDS fall
         // through to the ordinary own-property path (checked here via
         // `own_key_present` so a field shadows a same-named template method).
-        if super::class_registry::is_class_object_value(obj_value) {
+        // Skip Symbol keys here: `metadata_key_to_string` / `js_string_coerce`
+        // would stringify a Symbol and wrongly return a string-named static
+        // method descriptor instead of letting it reach the symbol descriptor
+        // path below.
+        if super::class_registry::is_class_object_value(obj_value)
+            && crate::symbol::js_is_symbol(key_value) == 0
+        {
             if let Some(method_name) = metadata_key_to_string(key_value) {
                 let obj = extract_obj_ptr(obj_value);
                 let key_str = crate::builtins::js_string_coerce(key_value);
@@ -151,11 +157,8 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
                         )
                     {
                         let leaked: &'static [u8] = method_name.as_bytes().to_vec().leak();
-                        let value = super::js_class_method_bind(
-                            obj_value,
-                            leaked.as_ptr(),
-                            leaked.len(),
-                        );
+                        let value =
+                            super::js_class_method_bind(obj_value, leaked.as_ptr(), leaked.len());
                         return build_data_descriptor(value, true, false, true);
                     }
                 }

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -45,7 +45,11 @@ pub extern "C" fn js_object_get_field_by_name(
     // back-reads a GcHeader), never a tagged value — which previously SIGSEGV'd.
     if !key.is_null()
         && ((obj as u64) >> 48) == 0
-        && (obj as usize) >= 0x10000
+        // Must be ABOVE the whole small-handle band (>= 0x100000), not just
+        // >= 0x10000: native handle ids in [0x10000, 0x100000) (fetch/http/…)
+        // would otherwise reach `is_class_object_ptr`, which back-reads a
+        // GcHeader and SIGSEGVs on the non-heap handle id.
+        && crate::value::addr_class::is_above_handle_band(obj as usize)
         && crate::object::class_registry::is_class_object_ptr(obj as *const u8)
     {
         let own = get_field_by_name_object_tail(obj, key);
@@ -56,22 +60,18 @@ pub extern "C" fn js_object_get_field_by_name(
             // Re-box the raw class-object pointer as a POINTER-tagged JS value
             // so `js_class_method_bind` (which expects a value, like the
             // class-ref path) binds the static method to the right receiver.
-            let class_value =
-                f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
+            let class_value = f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
             let class_id = super::super::js_object_get_class_id(obj);
             if class_id != 0 {
-                let name_ptr =
-                    (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+                let name_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
                 let name_len = (*key).byte_len as usize;
                 let name = std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len))
                     .unwrap_or("");
                 if !name.is_empty()
                     && !super::super::class_registry::class_is_key_deleted(class_id, name)
                 {
-                    if super::super::class_registry::lookup_static_method_in_chain(
-                        class_id, name,
-                    )
-                    .is_some()
+                    if super::super::class_registry::lookup_static_method_in_chain(class_id, name)
+                        .is_some()
                     {
                         let heap_name = {
                             let layout =

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -30,6 +30,73 @@ pub extern "C" fn js_object_get_field_by_name(
             }
         }
     }
+    // A per-evaluation class object (`ClassExprFresh`, #1772/#1787) reaches
+    // here as a RAW heap pointer (a real ObjectHeader, so its top 16 address
+    // bits are 0 — distinguishing it from a `0x7FFE` class-ref value or any
+    // NaN-boxed value). Its static METHODS / static ACCESSORS live in the class
+    // registry keyed by the header class_id, never as own properties, so a read
+    // like `C.staticMethod` returned `undefined` (the class-ref form resolves
+    // these via the registry; this pointer-tagged class-object form did not).
+    // That is NestJS's `Logger.error` when the Logger takes the fresh path
+    // (captures `DEFAULT_LOGGER`), which the tslib `__decorate` chain then reads
+    // `.value` off → "reading 'value'". Resolve own fields first (own-property
+    // precedence), then fall back to the registry. The `(obj >> 48) == 0` guard
+    // ensures `is_class_object_ptr` only ever sees a real heap pointer (it
+    // back-reads a GcHeader), never a tagged value — which previously SIGSEGV'd.
+    if !key.is_null()
+        && ((obj as u64) >> 48) == 0
+        && (obj as usize) >= 0x10000
+        && crate::object::class_registry::is_class_object_ptr(obj as *const u8)
+    {
+        let own = get_field_by_name_object_tail(obj, key);
+        if !own.is_undefined() {
+            return own;
+        }
+        unsafe {
+            // Re-box the raw class-object pointer as a POINTER-tagged JS value
+            // so `js_class_method_bind` (which expects a value, like the
+            // class-ref path) binds the static method to the right receiver.
+            let class_value =
+                f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
+            let class_id = super::super::js_object_get_class_id(obj);
+            if class_id != 0 {
+                let name_ptr =
+                    (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+                let name_len = (*key).byte_len as usize;
+                let name = std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len))
+                    .unwrap_or("");
+                if !name.is_empty()
+                    && !super::super::class_registry::class_is_key_deleted(class_id, name)
+                {
+                    if super::super::class_registry::lookup_static_method_in_chain(
+                        class_id, name,
+                    )
+                    .is_some()
+                    {
+                        let heap_name = {
+                            let layout =
+                                std::alloc::Layout::from_size_align(name_len.max(1), 1).unwrap();
+                            let ptr = std::alloc::alloc(layout);
+                            std::ptr::copy_nonoverlapping(name_ptr, ptr, name_len);
+                            ptr
+                        };
+                        let result = js_class_method_bind(class_value, heap_name, name_len);
+                        return JSValue::from_bits(result.to_bits());
+                    }
+                    if let Some(v) =
+                        super::super::class_registry::class_static_accessor_getter_value(
+                            class_id,
+                            name,
+                            class_value,
+                        )
+                    {
+                        return JSValue::from_bits(v.to_bits());
+                    }
+                }
+            }
+        }
+        return own;
+    }
     if let Some(addr) =
         crate::typedarray_props::typed_array_addr_from_value(f64::from_bits(obj as u64))
     {


### PR DESCRIPTION
Two independent codegen/runtime bugs that block a **NestJS** app from booting natively. Both fire at module-evaluation time (before any user code), discovered while bringing up the official `nestjs/typescript-starter` under perry.

### Wall 2 — chained static-class self-alias → `TypeError: Cannot read properties of undefined (reading 'value')`
`@nestjs/common`'s `Logger` is emitted by tsc as a decorator-captured class: `let Logger = Logger_1 = class Logger {…}`. The self-alias reference inside a member body lowered to a **capture**, forcing the class onto the per-evaluation `ClassExprFresh` path — whose fresh class object never resolved **static** methods/accessors/descriptors from the class registry. So `Object.getOwnPropertyDescriptor(Logger, 'error')` returned `undefined`, and NestJS's decorator doing `Reflect.defineMetadata(..., descriptor.value)` threw.

**Fix:** HIR resolves a class self-alias to `ClassRef` (off the fresh path); runtime resolves static methods/accessors/own-descriptors via the class registry for `ClassExprFresh` heap class objects (guarded for the tagged class-object form).

### Wall 3 — `require("reflect-metadata")` → `ReferenceError: _req_1 is not defined`
`@nestjs/common/index.js` does `require("reflect-metadata")`; the CJS wrap hoists it to `import _req_1 …` + a `return _req_1` shim, but `module_decl` special-cased reflect-metadata with an early return that **never bound the default-import local**.

**Fix:** bind reflect-metadata import specifiers to `{}` (the `require()` result is always discarded — the real effect is the global `Reflect` polyfill perry already provides). Bare `import "reflect-metadata"` is unaffected.

### Verification
- Upstream `nestjs/typescript-starter`: both module-eval crashes gone; the app now advances to the express HTTP-adapter load.
- `cargo test -p perry-hir` (388) and `-p perry-runtime` (1082) green; no regressions.

6 files, +228 lines. Follow-up to #5710 (independent files).

https://claude.ai/code/session_017S2d3tRok3oMbi6AwfJyUU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed class self-references in chained-assignment class patterns so identifiers resolve to the correct class reference during lowering.
  * Improved CommonJS `require("reflect-metadata")` module behavior when re-exported, ensuring all specifiers get initialized locals to avoid `undefined` references.
  * Corrected property descriptor and field/property lookup for fresh per-evaluation class constructors, restoring expected static method and static accessor results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->