### PR TITLE
fix(hir): forward-class shadows a captured local only at a nearer scope (JS nearest-binding)

### DIFF
--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -150,6 +150,7 @@ impl LoweringContext {
             mixin_funcs: HashMap::new(),
             anon_shape_classes: HashMap::new(),
             forward_class_names: std::collections::HashSet::new(),
+            forward_class_decl_depth: std::collections::HashMap::new(),
             class_renames: std::collections::HashMap::new(),
             next_class_rename_id: 0,
             module_class_decl_names: std::collections::HashSet::new(),
@@ -796,6 +797,24 @@ impl LoweringContext {
 
     fn lookup_local_index(&self, name: &str) -> Option<usize> {
         self.locals.lookup_index(name)
+    }
+
+    /// The function-scope depth at which the nearest local binding of `name`
+    /// was declared, or `None` if there is no such binding. A binding's depth
+    /// is the number of `enter_scope` (function/closure-boundary) marks that
+    /// precede-or-equal its position in the locals stack — i.e. how deeply
+    /// nested the function it lives in is. Used to resolve a bare-ident
+    /// reference between a same-named `class` and a captured outer local by JS
+    /// nearest-binding rules: the binding at the GREATER depth (nearer the
+    /// reference) wins.
+    pub(crate) fn local_decl_scope_depth(&self, name: &str) -> Option<usize> {
+        let pos = self.lookup_local_index(name)?;
+        let depth = self
+            .scope_local_marks
+            .iter()
+            .filter(|&&mark| mark <= pos)
+            .count();
+        Some(depth)
     }
 
     /// #5216: drop the most-recently-bound local named `name` (if any), e.g. a

--- a/crates/perry-hir/src/lower/expr_function.rs
+++ b/crates/perry-hir/src/lower/expr_function.rs
@@ -1011,7 +1011,9 @@ fn lower_fn_expr_anon(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) -> Resul
     // `js_global_get_or_throw_unresolved("X")` → `ReferenceError: X is not
     // defined` (Next.js RSCPathnameNormalizer). Scoped: restored after the body.
     let saved_forward_class_names = ctx.forward_class_names.clone();
+    let saved_forward_class_decl_depth = ctx.forward_class_decl_depth.clone();
     let saved_class_renames = ctx.class_renames.clone();
+    let fn_body_scope_depth = ctx.scope_depth;
     if let Some(ref block) = fn_expr.function.body {
         for stmt in &block.stmts {
             if let ast::Stmt::Decl(ast::Decl::Class(class_decl)) = stmt {
@@ -1020,8 +1022,12 @@ fn lower_fn_expr_anon(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) -> Resul
                 // `Struct` = `class s`, which collided with other `class s` in
                 // the bundle and was dedup-skipped). See `class_renames`.
                 ctx.maybe_rename_colliding_class(class_decl.ident.sym.as_str());
-                ctx.forward_class_names
-                    .insert(class_decl.ident.sym.to_string());
+                let cname = class_decl.ident.sym.to_string();
+                ctx.forward_class_decl_depth
+                    .entry(cname.clone())
+                    .and_modify(|d| *d = (*d).min(fn_body_scope_depth))
+                    .or_insert(fn_body_scope_depth);
+                ctx.forward_class_names.insert(cname);
             }
         }
     }
@@ -1089,6 +1095,7 @@ fn lower_fn_expr_anon(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) -> Resul
     ctx.annexb_block_fn_var_ids = saved_annexb_block_fn_var_ids;
     ctx.annexb_block_fn_names_all = saved_annexb_block_fn_names_all;
     ctx.forward_class_names = saved_forward_class_names;
+    ctx.forward_class_decl_depth = saved_forward_class_decl_depth;
     ctx.class_renames = saved_class_renames;
 
     // Prepend destructuring statements to body

--- a/crates/perry-hir/src/lower/lower_expr/arm_ident.rs
+++ b/crates/perry-hir/src/lower/lower_expr/arm_ident.rs
@@ -36,7 +36,30 @@ pub(crate) fn lower_ident_expr(ctx: &mut LoweringContext, ident: &ast::Ident) ->
     // name (a sibling param/var/let still wins).
     if ctx.forward_class_names.contains(&name) && ctx.lookup_local_in_current_scope(&name).is_none()
     {
-        return Ok(Expr::ClassRef(ctx.resolve_class_name(&name)));
+        // A `class <name>` in `forward_class_names` shadows a SAME-named local
+        // only when JS lexical scoping says the class binding is the nearest:
+        // i.e. there is no local of that name at all, OR the class was declared
+        // at a scope depth deeper than (nearer the reference than) the nearest
+        // enclosing local. The class binding lives in whatever function body
+        // declared it; a captured local declared in a NEARER scope (a deeper
+        // or sibling function whose local lingered in the inherited set) must
+        // win. Without this depth check, a `class <name>` in a SIBLING factory
+        // (its name still present in the inherited `forward_class_names`)
+        // wrongly shadowed a legitimate captured local — Next.js
+        // app-page-turbo's route-render closure read its captured params local
+        // `ej` as the `class ej` (= NextURL) reference, which then flowed into
+        // a WeakMap key and threw "Invalid value used as weak map key".
+        let class_wins = match (
+            ctx.local_decl_scope_depth(&name),
+            ctx.forward_class_decl_depth.get(&name).copied(),
+        ) {
+            (None, _) => true,       // no local: class wins (TimeoutError etc.)
+            (Some(_), None) => true, // depth unknown: keep prior behavior
+            (Some(local_depth), Some(class_depth)) => class_depth > local_depth,
+        };
+        if class_wins {
+            return Ok(Expr::ClassRef(ctx.resolve_class_name(&name)));
+        }
     }
     if let Some(id) = ctx.lookup_local(&name) {
         // A with-fallback implicit global may still be the HOLE

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -588,6 +588,18 @@ pub struct LoweringContext {
     /// call dispatched into `Object.create`. Scoped save/restore in
     /// `lower_fn_body_block_stmt`.
     pub(crate) forward_class_names: std::collections::HashSet<String>,
+    /// For each name in `forward_class_names`, the `scope_depth` at which the
+    /// `class <name>` declaration was registered. A bare-ident reference may
+    /// only resolve to the class (shadowing an outer-scope local of the same
+    /// name) when the class lexically encloses the reference — i.e. it was
+    /// declared at a scope depth no greater than the reference's. Without this,
+    /// a class in a SIBLING function factory (its name lingering in the
+    /// inherited `forward_class_names` set) wrongly shadowed a legitimate
+    /// captured local of the same name (Next.js app-page-turbo: a route-render
+    /// closure's captured params local `ej` resolved to the `class ej`
+    /// =`NextURL` reference, which then flowed into a WeakMap key and threw
+    /// "Invalid value used as weak map key").
+    pub(crate) forward_class_decl_depth: std::collections::HashMap<String, usize>,
     /// Scope-local class-name aliases disambiguating distinct same-named classes
     /// across nested function/factory scopes within ONE module (class refs are
     /// name-keyed: `Expr::New { class_name }` / `ClassRef(name)`). When a body

--- a/crates/perry-hir/src/lower_decl/block.rs
+++ b/crates/perry-hir/src/lower_decl/block.rs
@@ -951,15 +951,24 @@ pub fn lower_fn_body_block_stmt(
     // module function). Scoped: the previous set is restored on exit so
     // names don't leak across function bodies.
     let saved_forward_class_names = ctx.forward_class_names.clone();
+    let saved_forward_class_decl_depth = ctx.forward_class_decl_depth.clone();
     let saved_class_renames = ctx.class_renames.clone();
+    let cur_scope_depth = ctx.scope_depth;
     for stmt in &block.stmts {
         if let ast::Stmt::Decl(ast::Decl::Class(class_decl)) = stmt {
             // Disambiguate a distinct same-named class declared in this body so
             // its references don't bind to a colliding `class X` elsewhere in
             // the bundled module (see `class_renames`).
             ctx.maybe_rename_colliding_class(class_decl.ident.sym.as_str());
-            ctx.forward_class_names
-                .insert(class_decl.ident.sym.to_string());
+            let cname = class_decl.ident.sym.to_string();
+            // Record the (shallowest) scope depth this class is declared at so a
+            // later bare-ident reference can compare it against a same-named
+            // local by JS nearest-binding rules.
+            ctx.forward_class_decl_depth
+                .entry(cname.clone())
+                .and_modify(|d| *d = (*d).min(cur_scope_depth))
+                .or_insert(cur_scope_depth);
+            ctx.forward_class_names.insert(cname);
         }
     }
 
@@ -1000,6 +1009,7 @@ pub fn lower_fn_body_block_stmt(
         Err(err) => {
             ctx.current_strict = parent_strict;
             ctx.forward_class_names = saved_forward_class_names;
+            ctx.forward_class_decl_depth = saved_forward_class_decl_depth;
             ctx.class_renames = saved_class_renames;
             ctx.annexb_block_fn_var_ids = saved_annexb_block_fn_var_ids;
             ctx.annexb_block_fn_names_all = saved_annexb_block_fn_names_all;
@@ -1007,6 +1017,7 @@ pub fn lower_fn_body_block_stmt(
         }
     };
     ctx.forward_class_names = saved_forward_class_names;
+    ctx.forward_class_decl_depth = saved_forward_class_decl_depth;
     ctx.class_renames = saved_class_renames;
 
     // Re-register capture snapshots for classes declared in this body at

--- a/test-files/test_gap_5437_class_ref_shadows_captured_local.ts
+++ b/test-files/test_gap_5437_class_ref_shadows_captured_local.ts
@@ -1,0 +1,67 @@
+// Issue #5437 regression (Next.js app-page-turbo): a bare-ident reference to a
+// captured outer-scope local must NOT resolve to a same-named `class`
+// declared in a SIBLING function factory.
+//
+// Perry's class system is name-keyed + module-global, and minified bundles
+// reuse short names (`ej`) for many distinct bindings. The lowerer kept a
+// `forward_class_names` set (inherited into nested function bodies) so a
+// `class X` declared in the current body could shadow a same-named OUTER
+// captured local (p-timeout's `class a extends Error` overwriting an
+// undefined placeholder `a`). That rule was too broad: the class name lingered
+// in the inherited set while lowering a SIBLING factory, so a deeper nested
+// closure's reference to its OWN captured local `ej` resolved to the
+// `class ej` (= NextURL) reference instead of the local. The class ref then
+// flowed into a WeakMap key (`O.set(ej, ...)`) and threw
+// "Invalid value used as weak map key", 500ing every dynamic page route.
+//
+// The fix records the scope depth each forward class is declared at and, at a
+// reference where both a same-named class and a local exist, applies JS
+// nearest-binding rules: the class shadows the local only when it was declared
+// at a deeper (nearer) scope.
+//
+// Expected output:
+// NextURL
+// 42
+// inner-42
+// 7
+
+function makeClassFactory(): any {
+  class ej {
+    kind = "NextURL";
+  }
+  return ej;
+}
+
+function renderFactory(t: any): any {
+  let ej = t; // captured local, referenced from the nested closure below
+  if (t.flag) {
+    ej = { ...t, value: t.value };
+  }
+  const inner = () => ej.value; // current-scope lookup misses; ej is captured
+  const nested = () => {
+    const deeper = () => ej; // even deeper closure: still the captured local
+    return deeper().value;
+  };
+  return [inner(), nested()];
+}
+
+const C = makeClassFactory();
+console.log(new C().kind);
+
+const r = renderFactory({ value: 42, flag: false });
+console.log(r[0]);
+console.log("inner-" + r[1]);
+
+// The class still wins when it genuinely shadows an outer placeholder (the
+// p-timeout TimeoutError shape): an outer `Sentinel` is reassigned to a class
+// declared in a nested body, and a closure in that body must read the class.
+let Sentinel: any = undefined;
+function timeoutFactory() {
+  class Sentinel {
+    code = 7;
+  }
+  const get = () => Sentinel; // class declared in THIS body shadows the outer
+  return get();
+}
+const TE = timeoutFactory();
+console.log(new TE().code);


### PR DESCRIPTION
## What
Perry's classes are name-keyed + module-global. The `forward_class_names` shadow-set — which lets a `class X {}` correctly shadow a same-named captured outer local (the p-timeout `TimeoutError` fix) — is **cloned into nested function bodies**, and local lookup only checks the current scope. In a minified bundle that reuses short names (`ej`) across many factory closures, a deep nested closure's reference to **its own captured local** `ej` resolved to a same-named `class ej` lingering in the inherited set from a sibling factory → it lowered to a `ClassRef` instead of the local.

Found via Next.js (#5437): `ej` = Next's `NextURL` class; the route-params local resolved to the NextURL **constructor ref**, which then flowed in as a memoization **WeakMap key** → `TypeError: Invalid value used as weak map key` → 500 on dynamic page routes. (The "int32 393" prior sessions chased was this ClassRef — class refs are NaN-boxed with INT32_TAG, the same bit shape as a small int.)

## Fix
Record the scope depth at which each forward class is declared (`forward_class_decl_depth`). At a bare-ident reference where BOTH a same-named class and a local exist, apply JS nearest-binding: the class shadows the local only when declared at a **deeper (nearer) scope** (`class_depth > local_depth`). No local, or unknown class depth → prior behavior (TimeoutError shadow still works).

## Validation
- New gap test `test_gap_5437_class_ref_shadows_captured_local`: covers both the fixed case (captured local wins in a nested closure) and the preserved case (class shadows a same-scope local) — byte-identical to node.
- `cargo test -p perry-hir -p perry-codegen -p perry-runtime -p perry-stdlib -p perry-transform`: 0 failed; class-ref/closure/capture tests green.
- Bundle: the WeakMap class-ref throw is gone; the dynamic-page render advances past it.

Refs #5437.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where a class name could incorrectly override a captured local variable in nested function scopes.
  * Improved handling of class references so the nearest valid binding is chosen more reliably.
  * Added a regression test covering class-vs-local name resolution in nested closures and factory-style code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->