### PR TITLE
fix(temporal): #5580 — Temporal toLocaleString rendering + reject bare 'islamic' calendar

### DIFF
--- a/crates/perry-runtime/src/object/native_call_method/object_proto.rs
+++ b/crates/perry-runtime/src/object/native_call_method/object_proto.rs
@@ -84,6 +84,16 @@ pub(crate) unsafe fn js_object_default_to_locale_string(receiver: f64) -> f64 {
         let s = crate::date::js_date_to_locale_string(ts);
         return f64::from_bits(JSValue::string_ptr(s).bits());
     }
+    // #5580: a `Temporal.*` value formats via its own `toLocaleString` (a
+    // calendar-aware, type-specific rendering plus the spec's calendar-mismatch
+    // `RangeError`) rather than the `[object Object]` default. The HIR lowers
+    // `value.toLocaleString(...)` to the arg-less `Expr::DateToLocaleString`, so
+    // the locale/options arguments are not visible here; the no-argument form is
+    // dispatched through the Temporal method router.
+    #[cfg(feature = "temporal")]
+    if crate::temporal::is_temporal_value(receiver) {
+        return crate::temporal::dispatch::call_method(receiver, "toLocaleString", &[]);
+    }
     if !jsval.is_pointer() {
         return js_native_call_method(
             receiver,

--- a/crates/perry-runtime/src/temporal/options.rs
+++ b/crates/perry-runtime/src/temporal/options.rs
@@ -21,7 +21,10 @@ use temporal_rs::options::{
 use temporal_rs::parsers::Precision;
 use temporal_rs::partial::{PartialTime, PartialZonedDateTime};
 use temporal_rs::provider::TransitionDirection;
-use temporal_rs::{Calendar, MonthCode, PlainTime, TimeZone, TinyAsciiStr, UtcOffset};
+use temporal_rs::{
+    Calendar, MonthCode, PlainDate, PlainDateTime, PlainMonthDay, PlainTime, PlainYearMonth,
+    TimeZone, TinyAsciiStr, UtcOffset, ZonedDateTime,
+};
 
 // ---- low-level JS object field reads --------------------------------------
 
@@ -336,7 +339,9 @@ pub fn calendar_slot(v: f64) -> temporal_rs::Calendar {
     }
     let jv = JSValue::from_bits(v.to_bits());
     if jv.is_string() {
-        return ok_or_throw(read_string(v).parse::<Calendar>());
+        let s = read_string(v);
+        reject_bare_islamic(&s);
+        return ok_or_throw(s.parse::<Calendar>());
     }
     if let Some(tv) = super::temporal_value_ref(v) {
         return match tv {
@@ -360,11 +365,112 @@ pub fn calendar_slot(v: f64) -> temporal_rs::Calendar {
 /// value → its `[[Calendar]]`, anything else → TypeError).
 pub fn calendar_identifier(v: f64) -> temporal_rs::Calendar {
     if JSValue::from_bits(v.to_bits()).is_string() {
-        return ok_or_throw(temporal_rs::Calendar::try_from_utf8(
-            read_string(v).as_bytes(),
-        ));
+        let s = read_string(v);
+        reject_bare_islamic(&s);
+        return ok_or_throw(temporal_rs::Calendar::try_from_utf8(s.as_bytes()));
     }
     calendar_slot(v)
+}
+
+/// `islamic` (the bare Hijri identifier, with no `-civil` / `-tbla` /
+/// `-umalqura` variant) is *accepted* by `temporal_rs` — it falls back to the
+/// tabular-Friday epoch — but per the Intl-Era-monthcode proposal a bare
+/// `islamic` is recognized only by the `Intl.DateTimeFormat` constructor, never
+/// as a Temporal calendar identifier. Reject it with a `RangeError` so
+/// `Temporal.PlainDate.from({ calendar: "islamic", … })` and friends throw as
+/// the spec requires, instead of silently constructing a Hijri date.
+fn reject_bare_islamic(id: &str) {
+    if id.eq_ignore_ascii_case("islamic") {
+        range("unknown calendar: islamic is only supported by Intl.DateTimeFormat, not Temporal");
+    }
+}
+
+// ---- `Temporal.*.prototype.toLocaleString` ---------------------------------
+
+/// `Temporal.*.prototype.toLocaleString` calendar check. A Temporal value
+/// renders only when its calendar matches the formatter's: the ISO-8601
+/// calendar (always permitted) or the calendar the locale resolves to. With no
+/// explicit `calendar` option that resolved calendar is the locale default,
+/// which Perry's `Intl.DateTimeFormat` reports as `gregory`. Any other calendar
+/// is a `RangeError` (the test262 `toLocaleString/calendar-mismatch` cases).
+///
+/// Only the calendar-bearing types (`PlainDate`/`PlainDateTime`/`PlainYearMonth`
+/// /`PlainMonthDay`/`ZonedDateTime`) call this; `Instant`/`PlainTime` have no
+/// calendar slot.
+///
+/// NOTE: the `locales`/`options` arguments — which could name a *different*
+/// calendar to validate against — are dropped by the `Expr::DateToLocaleString`
+/// HIR lowering before the call reaches the runtime, so only the locale-default
+/// calendar is consulted here. Honoring an explicit `calendar`/`dateStyle`/
+/// `timeStyle` option (and the spec's option-conflict `TypeError`s) is a
+/// follow-up that depends on threading those arguments through that lowering.
+pub fn assert_locale_string_calendar(instance_calendar: &str) {
+    if instance_calendar != "iso8601" && instance_calendar != "gregory" {
+        range("calendar mismatch: the value's calendar differs from the locale calendar");
+    }
+}
+
+/// `H:MM:SS AM/PM`, the en-US default wall-clock rendering shared by the
+/// time-bearing `toLocaleString` formatters below.
+fn locale_time_12h(hour: u8, minute: u8, second: u8) -> String {
+    let (h12, suffix) = match hour {
+        0 => (12, "AM"),
+        1..=11 => (hour, "AM"),
+        12 => (12, "PM"),
+        _ => (hour - 12, "PM"),
+    };
+    format!("{h12}:{minute:02}:{second:02} {suffix}")
+}
+
+// The valid-path formatters render straight from the calendar-aware accessors.
+// Because the ISO-8601 calendar *is* the proleptic Gregorian calendar, those
+// accessors return identical numbers for an `iso8601` and a `gregory` instance
+// of the same date — and `assert_locale_string_calendar` has already rejected every
+// other calendar — so the output is calendar-agnostic, exactly as the
+// `calendar-mismatch` conformance tests require (an ISO and a Gregorian
+// instance must format identically).
+
+/// `M/D/YYYY` — `Temporal.PlainDate.prototype.toLocaleString` default form.
+pub fn plain_date_locale_string(d: &PlainDate) -> String {
+    format!("{}/{}/{}", d.month(), d.day(), d.year())
+}
+
+/// `M/D/YYYY, H:MM:SS AM/PM` — `Temporal.PlainDateTime` default form.
+pub fn plain_date_time_locale_string(dt: &PlainDateTime) -> String {
+    format!(
+        "{}/{}/{}, {}",
+        dt.month(),
+        dt.day(),
+        dt.year(),
+        locale_time_12h(dt.hour(), dt.minute(), dt.second())
+    )
+}
+
+/// `H:MM:SS AM/PM` — `Temporal.PlainTime` default form.
+pub fn plain_time_locale_string(t: &PlainTime) -> String {
+    locale_time_12h(t.hour(), t.minute(), t.second())
+}
+
+/// `M/YYYY` — `Temporal.PlainYearMonth` default form (no day component).
+pub fn plain_year_month_locale_string(ym: &PlainYearMonth) -> String {
+    format!("{}/{}", ym.month(), ym.year())
+}
+
+/// `M/D` — `Temporal.PlainMonthDay` default form (no year component).
+pub fn plain_month_day_locale_string(md: &PlainMonthDay) -> String {
+    format!("{}/{}", md.month_code().to_month_integer(), md.day())
+}
+
+/// `M/D/YYYY, H:MM:SS AM/PM` rendered in the instance's own time zone —
+/// `Temporal.ZonedDateTime` default form.
+pub fn zoned_date_time_locale_string(z: &ZonedDateTime) -> String {
+    format!(
+        "{}/{}/{}, {}",
+        z.month(),
+        z.day(),
+        z.year(),
+        locale_time_12h(z.hour(), z.minute(), z.second())
+    )
 }
 
 /// `GetOptionsObject`: an options argument must be `undefined` or an Object.

--- a/crates/perry-runtime/src/temporal/plain_date.rs
+++ b/crates/perry-runtime/src/temporal/plain_date.rs
@@ -223,7 +223,11 @@ pub fn call(recv: f64, d: &PlainDate, name: &str, args: &[f64]) -> f64 {
         "toString" => {
             string(&d.to_ixdtf_string(super::options::display_calendar(raw_arg(args, 0))))
         }
-        "toJSON" | "toLocaleString" => string(&d.to_string()),
+        "toJSON" => string(&d.to_string()),
+        "toLocaleString" => {
+            super::options::assert_locale_string_calendar(d.calendar().identifier());
+            string(&super::options::plain_date_locale_string(d))
+        }
         "valueOf" => dispatch::throw_value_of(TYPE_NAME),
         "with" => {
             let obj = super::options::require_fields_obj(raw_arg(args, 0), TYPE_NAME, "with");

--- a/crates/perry-runtime/src/temporal/plain_date_time.rs
+++ b/crates/perry-runtime/src/temporal/plain_date_time.rs
@@ -181,7 +181,11 @@ pub fn call(recv: f64, dt: &PlainDateTime, name: &str, args: &[f64]) -> f64 {
             let (rounding, calendar) = super::options::pdt_to_string_options(raw_arg(args, 0));
             string(&ok_or_throw(dt.to_ixdtf_string(rounding, calendar)))
         }
-        "toJSON" | "toLocaleString" => string(&dt.to_string()),
+        "toJSON" => string(&dt.to_string()),
+        "toLocaleString" => {
+            super::options::assert_locale_string_calendar(dt.calendar().identifier());
+            string(&super::options::plain_date_time_locale_string(dt))
+        }
         "valueOf" => dispatch::throw_value_of(TYPE_NAME),
         "with" => {
             let obj = super::options::require_fields_obj(raw_arg(args, 0), TYPE_NAME, "with");

--- a/crates/perry-runtime/src/temporal/plain_month_day.rs
+++ b/crates/perry-runtime/src/temporal/plain_month_day.rs
@@ -129,7 +129,11 @@ pub fn call(recv: f64, md: &PlainMonthDay, name: &str, args: &[f64]) -> f64 {
         "toString" => {
             string(&md.to_ixdtf_string(super::options::display_calendar(raw_arg(args, 0))))
         }
-        "toJSON" | "toLocaleString" => string(&md.to_string()),
+        "toJSON" => string(&md.to_string()),
+        "toLocaleString" => {
+            super::options::assert_locale_string_calendar(md.calendar().identifier());
+            string(&super::options::plain_month_day_locale_string(md))
+        }
         "valueOf" => dispatch::throw_value_of(TYPE_NAME),
         "with" => {
             let obj = super::options::require_fields_obj(raw_arg(args, 0), TYPE_NAME, "with");

--- a/crates/perry-runtime/src/temporal/plain_time.rs
+++ b/crates/perry-runtime/src/temporal/plain_time.rs
@@ -190,10 +190,11 @@ pub fn call(recv: f64, t: &PlainTime, name: &str, args: &[f64]) -> f64 {
         "toString" => string(&ok_or_throw(t.to_ixdtf_string(
             super::options::to_string_rounding_options(raw_arg(args, 0)),
         ))),
-        "toJSON" | "toLocaleString" => string(
+        "toJSON" => string(
             &t.to_ixdtf_string(ToStringRoundingOptions::default())
                 .unwrap_or_default(),
         ),
+        "toLocaleString" => string(&super::options::plain_time_locale_string(t)),
         "valueOf" => dispatch::throw_value_of(TYPE_NAME),
         "with" => {
             let obj = super::options::require_fields_obj(raw_arg(args, 0), TYPE_NAME, "with");

--- a/crates/perry-runtime/src/temporal/plain_year_month.rs
+++ b/crates/perry-runtime/src/temporal/plain_year_month.rs
@@ -155,7 +155,11 @@ pub fn call(recv: f64, ym: &PlainYearMonth, name: &str, args: &[f64]) -> f64 {
         "toString" => {
             string(&ym.to_ixdtf_string(super::options::display_calendar(raw_arg(args, 0))))
         }
-        "toJSON" | "toLocaleString" => string(&ym.to_string()),
+        "toJSON" => string(&ym.to_string()),
+        "toLocaleString" => {
+            super::options::assert_locale_string_calendar(ym.calendar().identifier());
+            string(&super::options::plain_year_month_locale_string(ym))
+        }
         "valueOf" => dispatch::throw_value_of(TYPE_NAME),
         "with" => {
             let obj = super::options::require_fields_obj(raw_arg(args, 0), TYPE_NAME, "with");

--- a/crates/perry-runtime/src/temporal/zoned_date_time.rs
+++ b/crates/perry-runtime/src/temporal/zoned_date_time.rs
@@ -222,7 +222,11 @@ pub fn call(recv: f64, z: &ZonedDateTime, name: &str, args: &[f64]) -> f64 {
                 z.to_ixdtf_string(offset, time_zone, calendar, rounding),
             ))
         }
-        "toJSON" | "toLocaleString" => string(&z.to_string()),
+        "toJSON" => string(&z.to_string()),
+        "toLocaleString" => {
+            super::options::assert_locale_string_calendar(z.calendar().identifier());
+            string(&super::options::zoned_date_time_locale_string(z))
+        }
         "valueOf" => dispatch::throw_value_of(TYPE_NAME),
         "with" => {
             let obj = super::options::require_fields_obj(raw_arg(args, 0), TYPE_NAME, "with");


### PR DESCRIPTION
## Summary

Closes part of #5580 (test262 intl402/Temporal `toLocaleString` + calendar tail). Two conformance gaps, **+29 test262 cases** fixed with **no regressions** — intl402/Temporal `runtime-fail` **105 → 76**, parity **94.8% → 96.3%** (measured locally against the pinned test262 sha on `intl402/Temporal`).

### 1. Reject the bare `islamic` calendar in Temporal
`temporal_rs` accepts `islamic` (no `-civil`/`-tbla`/`-umalqura` variant) by falling back to the tabular-Friday Hijri epoch, but per Intl-Era-monthcode a bare `islamic` is only valid in the `Intl.DateTimeFormat` constructor — never as a Temporal calendar identifier. `calendar_slot` / `calendar_identifier` now throw a `RangeError`, so `Temporal.PlainDate.from({ calendar: "islamic" })` and the other constructor/`from` paths reject as required.

### 2. Render `Temporal.*.prototype.toLocaleString` instead of `[object Object]`
The runtime `toLocaleString` tag-dispatcher (`js_object_default_to_locale_string`) now routes a Temporal value to a per-type formatter and enforces the spec's calendar-mismatch `RangeError`. Output is derived from the calendar-aware accessors: since the ISO-8601 calendar *is* the proleptic Gregorian calendar, those accessors are identical for an `iso8601` and a `gregory` instance of the same date, and `assert_locale_string_calendar` rejects every other calendar — so the rendering is calendar-agnostic, exactly as the `calendar-mismatch` cases require.

## Tests fixed (29)
- `*/from/islamic.js` ×5 (PlainDate, PlainDateTime, PlainMonthDay, PlainYearMonth, ZonedDateTime)
- `toLocaleString/calendar-mismatch.js` ×3 (PlainDate, PlainDateTime, ZonedDateTime)
- `toLocaleString/{era, default-includes/excludes-field, ignore-timezone, resolved-time-zone, datestyle-and-timestyle, lone-options-accepted}.js` across the six Temporal types

## Known follow-up (not in this PR)
The `locales`/`options` arguments are dropped by the `Expr::DateToLocaleString` HIR lowering before reaching the runtime, so the spec's option-conflict `TypeError`s (`dateStyle`+`timeStyle`, component+style, a `timeZone` on a `ZonedDateTime`) and explicit non-default `calendar`/style formatting (`dateStyle: "long"` month names, etc.) are not yet honored. Threading those arguments through that lowering — which touches the LLVM/JS/WASM `DateToLocaleString` backends — is the next step; the remaining 76 failures are that work plus real locale-aware (ICU) formatting.

## Verification
Local `scripts/test262_subset.py --dir intl402/Temporal` before/after: failure path-set diff shows 29 newly-passing, 0 regressed. `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Temporal values now use locale-aware formatting for `toLocaleString()` across date, time, month-day, year-month, date-time, and zoned date-time types.
  * `Object.prototype.toLocaleString()` now recognizes Temporal values and routes them through the appropriate Temporal stringification path.

* **Bug Fixes**
  * Improved calendar validation during Temporal string conversion.
  * Rejected the bare `"islamic"` calendar identifier in Temporal calendar parsing to avoid invalid locale output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->