### PR TITLE
feat(nestjs): native NestJS bring-up — Walls 2–16 (decorators, generators, collections, HTTP, DI)

### DIFF
--- a/crates/perry-codegen/src/expr/call_spread.rs
+++ b/crates/perry-codegen/src/expr/call_spread.rs
@@ -305,6 +305,61 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 }
             }
 
+            // Computed-member method call with spread: `recv[key](...args)`.
+            // The literal `recv.method(...args)` shape is handled by the
+            // PropertyGet arm above; the computed sibling lowers to a
+            // `Call`/`CallSpread` with an `IndexGet` callee. Without this arm it
+            // fell through to the closure-callee path below, which lowers
+            // `recv[key]` to a bare method VALUE and calls it with no `this` —
+            // so the method observed `this` = a field-less prototype stub
+            // (missing instance data fields AND inherited methods). This is the
+            // spread counterpart of the non-spread `js_native_call_method_{str_key,
+            // value}` routing in `lower_call/early_branches.rs`. Bundle every
+            // regular + spread arg into one array, then dispatch through
+            // `js_native_call_method_value_apply`, which resolves the method by
+            // the runtime key and binds `this = recv`. Skip a numeric index on a
+            // non-class receiver (`arr[i](...)` array-element call), mirroring
+            // the non-spread path, so element-call semantics are unchanged.
+            if let Expr::IndexGet { object, index } = callee.as_ref() {
+                let object_is_class_ref = matches!(object.as_ref(), Expr::ClassRef(_))
+                    || matches!(object.as_ref(), Expr::ExternFuncRef { name, .. } if ctx.class_ids.contains_key(name));
+                if !(crate::type_analysis::is_numeric_expr(ctx, index) && !object_is_class_ref) {
+                    let recv_box = lower_expr(ctx, object)?;
+                    let key_box = lower_expr(ctx, index)?;
+                    let mut acc_handle = ctx.block().call(I64, "js_array_alloc", &[(I32, "0")]);
+                    for a in args {
+                        match a {
+                            CallArg::Expr(e) => {
+                                let v = lower_expr(ctx, e)?;
+                                acc_handle = ctx.block().call(
+                                    I64,
+                                    "js_array_push_f64",
+                                    &[(I64, &acc_handle), (DOUBLE, &v)],
+                                );
+                            }
+                            CallArg::Spread(e) => {
+                                let part_box = lower_expr(ctx, e)?;
+                                let part_handle = ctx.block().call(
+                                    I64,
+                                    "js_array_like_to_array",
+                                    &[(DOUBLE, &part_box)],
+                                );
+                                acc_handle = ctx.block().call(
+                                    I64,
+                                    "js_array_concat",
+                                    &[(I64, &acc_handle), (I64, &part_handle)],
+                                );
+                            }
+                        }
+                    }
+                    return Ok(ctx.block().call(
+                        DOUBLE,
+                        "js_native_call_method_value_apply",
+                        &[(DOUBLE, &recv_box), (DOUBLE, &key_box), (I64, &acc_handle)],
+                    ));
+                }
+            }
+
             // Closure callee path: `cb(reg0, reg1, ..., ...spread)` where
             // `cb` is a closure value (not a known FuncRef). We lower the
             // callee to its NaN-boxed value, marshal regular args into a

--- a/crates/perry-codegen/src/expr/compare.rs
+++ b/crates/perry-codegen/src/expr/compare.rs
@@ -197,13 +197,44 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // — the correct answer when the unknown side isn't a
             // string at runtime.
             let both_strings_check = is_string_expr(ctx, left) && is_string_expr(ctx, right);
+            // The non-statically-string operand collides through this
+            // fast path when, at runtime, it is ALSO a non-string. Both
+            // operands then funnel through `js_get_string_pointer_unified`,
+            // which returns 0 for any non-string NaN-boxed value (numbers,
+            // class refs / InjectionTokens, plain objects, …). The
+            // subsequent `js_string_equals(0, 0)` returns 1 (its
+            // pointer-identity / both-null branches both report "equal"),
+            // so two *distinct* non-string values wrongly compare `===`.
+            //
+            // This is exactly the NestJS DI `token === name` bug:
+            // `name` is statically `string` (the destructured
+            // `dependencyContext.name`) but at runtime holds a class ref
+            // (e.g. `AppService`), and `token` is `any` holding a
+            // *different* class ref (`AppController`) — both coerce to 0
+            // and the inline `===` reports `true`, throwing
+            // `UnknownDependencies` and aborting the app.
+            //
+            // The static `string` type is therefore a lie here (like the
+            // #3576 number-vs-object case). When the OTHER operand is
+            // statically `Any` (its runtime value is unconstrained and may
+            // be a non-string), this fast path is unsound: route through
+            // `js_eq`, which content-compares real strings (SSO + heap) AND
+            // correctly distinguishes class refs / objects by identity.
+            let other_side_is_any = |other: &Expr| -> bool {
+                matches!(
+                    crate::type_analysis::static_type_of(ctx, other),
+                    Some(HirType::Any) | None
+                )
+            };
             let one_side_string = !both_strings_check
                 && ((is_string_expr(ctx, left)
                     && !is_numeric_expr(ctx, right)
-                    && !is_bool_expr(ctx, right))
+                    && !is_bool_expr(ctx, right)
+                    && !other_side_is_any(right))
                     || (is_string_expr(ctx, right)
                         && !is_numeric_expr(ctx, left)
-                        && !is_bool_expr(ctx, left)));
+                        && !is_bool_expr(ctx, left)
+                        && !other_side_is_any(left)));
             // Only STRICT eq/ne use this string-pointer fast path. Loose `==`/`!=`
             // must fall through to `js_loose_eq` below: when one side is a boxed
             // String/primitive *wrapper* (a POINTER_TAG object, not a STRING_TAG

--- a/crates/perry-codegen/src/expr/this_super_call.rs
+++ b/crates/perry-codegen/src/expr/this_super_call.rs
@@ -172,6 +172,44 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 Some(slot) => ctx.block().load(DOUBLE, &slot),
                 None => double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)),
             };
+            // `class X extends Map | Set` with a spread super (`super(...args)`,
+            // e.g. NestJS's `ModulesContainer`'s `super(...arguments)`) — install
+            // the hidden collection backing from the (possibly spread) args
+            // array instead of dispatching the uncallable builtin ctor. The
+            // first array element (if any) is the iterable; `js_map_from_iterable`
+            // / `js_set_from_iterable` ignore extra elements. Mirrors the
+            // non-spread `Expr::SuperCall` Map/Set arm.
+            let map_set_kind = ctx
+                .classes
+                .get(&current_class_name)
+                .and_then(|c| c.extends_name.as_deref())
+                .and_then(|p| match p {
+                    "Map" => Some(0i32),
+                    "Set" => Some(1i32),
+                    _ => None,
+                });
+            if let Some(kind) = map_set_kind {
+                let blk = ctx.block();
+                let arr_box = nanbox_pointer_inline(blk, &arr);
+                let zero_idx = "0".to_string();
+                let first = ctx.block().call(
+                    DOUBLE,
+                    "js_array_get_f64",
+                    &[(I64, &arr), (I32, &zero_idx)],
+                );
+                let _ = arr_box;
+                ctx.block().call(
+                    DOUBLE,
+                    "js_map_set_subclass_init",
+                    &[(DOUBLE, &this_box), (I32, &kind.to_string()), (DOUBLE, &first)],
+                );
+                crate::lower_call::apply_field_initializers_recursive(
+                    ctx,
+                    &current_class_name,
+                    crate::lower_call::FieldInitMode::SelfOnly,
+                )?;
+                return Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));
+            }
             if let Some(&child_cid) = ctx.class_ids.get(&current_class_name) {
                 let cid_str = child_cid.to_string();
                 let blk = ctx.block();
@@ -477,6 +515,52 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             crate::lower_call::FieldInitMode::SelfOnly,
                         )?;
                         return Ok(result);
+                    }
+                    // `class X extends Map` / `extends Set` — `super(iterable?)`
+                    // allocates a real Map/Set backing store, stashes it on
+                    // `this` under a hidden field, and installs the collection
+                    // method surface (`has`/`get`/`set`/`delete`/`clear`/
+                    // `forEach`/`keys`/`values`/`entries`/`size`/`Symbol.iterator`)
+                    // so a source-compiled subclass (e.g. NestJS's
+                    // `ModulesContainer extends Map`) actually behaves as a Map.
+                    // Perry models the instance as a plain object (not a real
+                    // exotic Map), so without this `super()` was a no-op and
+                    // `m.has(...)` threw "has is not a function".
+                    let map_set_kind = match parent_name.as_str() {
+                        "Map" => Some(0i32),
+                        "Set" => Some(1i32),
+                        _ => None,
+                    };
+                    if let Some(kind) = map_set_kind {
+                        let iterable = if let Some(first) = super_args.first() {
+                            lower_expr(ctx, first)?
+                        } else {
+                            double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+                        };
+                        for a in super_args.iter().skip(1) {
+                            let _ = lower_expr(ctx, a)?;
+                        }
+                        let this_box = match ctx.this_stack.last().cloned() {
+                            Some(slot) => ctx.block().load(DOUBLE, &slot),
+                            None => double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)),
+                        };
+                        ctx.block().call(
+                            DOUBLE,
+                            "js_map_set_subclass_init",
+                            &[
+                                (DOUBLE, &this_box),
+                                (I32, &kind.to_string()),
+                                (DOUBLE, &iterable),
+                            ],
+                        );
+                        let current_class_name =
+                            ctx.class_stack.last().cloned().unwrap_or_default();
+                        crate::lower_call::apply_field_initializers_recursive(
+                            ctx,
+                            &current_class_name,
+                            crate::lower_call::FieldInitMode::SelfOnly,
+                        )?;
+                        return Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));
                     }
                     // #5137: `class X extends EventEmitter` (node:events) —
                     // `super()` installs the bare EventEmitter listener/emit

--- a/crates/perry-codegen/src/lower_call/console_promise.rs
+++ b/crates/perry-codegen/src/lower_call/console_promise.rs
@@ -737,12 +737,44 @@ pub fn try_lower_native_method_str_dispatch(
                 // missing method as a non-callable property read and throw.
                 | "__perry_using_check__"
         );
+        // A `class X extends Map | Set` instance's collection methods
+        // (`has`/`get`/`set`/`delete`/`clear`/`forEach`/`keys`/`values`/
+        // `entries` and the Set composition methods) are NOT class methods —
+        // they live on the hidden runtime backing installed by
+        // `js_map_set_subclass_init`. The static class-dispatch tower would read
+        // them as a non-callable property and throw "value is not a function",
+        // so route them through `js_native_call_method` (whose `dispatch_map_set`
+        // redirects onto the backing collection). Mirrors the
+        // `is_well_known_proto_method` carve-out.
+        let is_collection_subclass_method = class_name_opt
+            .as_deref()
+            .is_some_and(|n| class_extends_builtin_collection(ctx, n))
+            && matches!(
+                property.as_str(),
+                "has" | "get"
+                    | "set"
+                    | "add"
+                    | "delete"
+                    | "clear"
+                    | "forEach"
+                    | "keys"
+                    | "values"
+                    | "entries"
+                    | "union"
+                    | "intersection"
+                    | "difference"
+                    | "symmetricDifference"
+                    | "isSubsetOf"
+                    | "isSupersetOf"
+                    | "isDisjointFrom"
+            );
         let skip_native = matches!(object.as_ref(), Expr::GlobalGet(_))
             || matches!(object.as_ref(), Expr::NativeModuleRef(_))
             || (class_name_opt.is_some()
                 && !is_buffer_class
                 && !class_unknown_to_codegen
-                && !is_well_known_proto_method);
+                && !is_well_known_proto_method
+                && !is_collection_subclass_method);
         if !skip_native {
             // Issue #92 fast path: intrinsify Buffer numeric reads
             // (`buf.readInt32BE(off)` etc.) when the receiver is a tracked
@@ -853,6 +885,35 @@ fn is_message_port_closure_method(object: &Expr, property: &str) -> bool {
 /// call (those miss because the name lives in CLASS_STATIC_ACCESSORS, not
 /// CLASS_STATIC_METHODS). Returns `None` when `prop` is not a static accessor on
 /// the chain. Refs test262 language/arguments-object cls-*-static-* getter calls.
+/// True when `cls_name` (or any class on its `extends` chain) directly extends
+/// the builtin `Map` or `Set` constructor — i.e. a source-compiled
+/// `class X extends Map {}`. Such instances get a hidden Map/Set backing at
+/// `super()` (`js_map_set_subclass_init`) and their collection methods dispatch
+/// through the runtime, not the class vtable.
+pub fn class_extends_builtin_collection(ctx: &FnCtx<'_>, cls_name: &str) -> bool {
+    let mut cur = Some(cls_name.to_string());
+    let mut depth = 0usize;
+    while let Some(c) = cur {
+        if depth > 32 {
+            break;
+        }
+        let Some(ci) = ctx.classes.get(&c) else {
+            // The chain reached a name codegen doesn't track — it may be the
+            // builtin `Map`/`Set` heritage itself.
+            return matches!(c.as_str(), "Map" | "Set" | "WeakMap" | "WeakSet");
+        };
+        if matches!(
+            ci.extends_name.as_deref(),
+            Some("Map") | Some("Set") | Some("WeakMap") | Some("WeakSet")
+        ) {
+            return true;
+        }
+        cur = ci.extends_name.clone();
+        depth += 1;
+    }
+    false
+}
+
 pub fn try_lower_class_static_accessor_call(
     ctx: &mut FnCtx<'_>,
     cls_name: &str,

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi/streams_events.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi/streams_events.rs
@@ -10,6 +10,7 @@ pub(crate) fn declare_streams_events(module: &mut LlModule) {
     // ========== node:stream stubs (issue #631) ==========
     module.declare_function("js_event_emitter_subclass_init", DOUBLE, &[DOUBLE]); // #5137 EE subclass init
     module.declare_function("js_array_subclass_init", DOUBLE, &[DOUBLE, DOUBLE]); // class extends Array
+    module.declare_function("js_map_set_subclass_init", DOUBLE, &[DOUBLE, I32, DOUBLE]); // class extends Map/Set
     module.declare_function("js_node_stream_readable_new", DOUBLE, &[DOUBLE]);
     module.declare_function(
         "js_node_stream_readable_subclass_init",

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -848,6 +848,15 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
         DOUBLE,
         &[DOUBLE, DOUBLE, PTR, I64],
     );
+    // Apply form of obj[key](...args): runtime-value key + args as a JS array
+    // handle. Materialises the array and forwards to js_native_call_method_value
+    // (binds `this = obj`). Used by `Expr::CallSpread` for the computed-member
+    // `recv[prop](...args)` shape, which otherwise dropped `this`.
+    module.declare_function(
+        "js_native_call_method_value_apply",
+        DOUBLE,
+        &[DOUBLE, DOUBLE, I64],
+    );
     module.declare_function("js_promise_resolve", VOID, &[I64, DOUBLE]);
     module.declare_function("js_promise_reject", VOID, &[I64, DOUBLE]);
     module.declare_function("js_promise_resolved", I64, &[DOUBLE]);

--- a/crates/perry-ext-http-server/src/dispatch_ext.rs
+++ b/crates/perry-ext-http-server/src/dispatch_ext.rs
@@ -1,0 +1,485 @@
+//! Runtime handle-dispatch EXTENSION registration for HTTP-server handles.
+//!
+//! ## Why this exists
+//!
+//! perry-stdlib's `js_handle_property_dispatch` / `js_handle_method_dispatch`
+//! (and the property-SET twin) carry the HTTP-server handle arms behind the
+//! `external-http-server-pump` Cargo feature (see
+//! `perry-stdlib/src/common/dispatch/{property,method}_dispatch.rs`). That
+//! feature is only compiled in when the *workspace* auto-optimize rebuilds
+//! perry-stdlib for a program that imports `node:http`.
+//!
+//! An out-of-tree install — and `PERRY_NO_AUTO_OPTIMIZE=1` — instead links the
+//! prebuilt `full` `libperry_stdlib.a`, which is built **without**
+//! `external-http-server-pump`. In that build those dispatch arms are compiled
+//! OUT, so an erased-receiver `req.url` / `res.end(...)` (the handler params are
+//! `any`, so codegen emits a generic property-get / method-call that routes
+//! through the runtime's `HANDLE_*_DISPATCH` slow path) finds no HTTP-server arm
+//! and silently reads `undefined` / no-ops. The server binds and the handler
+//! fires (the pump is already kept alive out-of-tree via the
+//! `js_register_aux_pump` mechanism, #2532), but the request object is empty and
+//! the response never flushes — the Wall-10 symptom.
+//!
+//! ## The fix
+//!
+//! perry-runtime exposes `js_register_handle_{property,method,property_set}_dispatch_extension`
+//! (the same mechanism perry-ext-net uses, see `perry-ext-net/src/dispatch.rs`).
+//! Registered extensions are consulted by the runtime's composite dispatcher
+//! *before* the stdlib primary, regardless of which perry-stdlib features were
+//! compiled. We register one extension per dispatch kind here; each probes the
+//! handle against our registry and, for a name that is a genuine native member
+//! of that handle type, forwards to the existing `js_ext_http_*_dispatch_*`
+//! entry points.
+//!
+//! ## CRITICAL: gate on the native member-name lists
+//!
+//! A server-side `ServerResponse` / `IncomingMessage` handle is routinely
+//! wrapped by a user prototype that ADDS methods — Express augments the response
+//! prototype with `res.send` / `res.json` / `res.status` / … and the request
+//! with `req.fresh` / `req.accepts` / …. Those methods live on a JS prototype
+//! object in the chain above the native handle. If this extension claimed EVERY
+//! name once the handle type matched, it would shadow `res.send` (returning
+//! `undefined` instead of letting the prototype's real `send` run) and Express's
+//! `res.send('...')` would silently no-op — exactly the bug this caused on the
+//! first cut. So each name is matched against the SAME `matches!` vocabularies
+//! perry-stdlib's gated arms use; an unrecognised name returns "not claimed" (0)
+//! so the runtime falls through to the prototype-chain / user-method resolution.
+//! Keep these lists in sync with
+//! `perry-stdlib/src/common/dispatch/{method,property}_dispatch.rs`.
+
+use std::sync::Once;
+
+extern "C" {
+    fn js_register_handle_method_dispatch_extension(
+        f: unsafe extern "C" fn(i64, *const u8, usize, *const f64, usize, *mut f64) -> i32,
+    );
+    fn js_register_handle_property_dispatch_extension(
+        f: unsafe extern "C" fn(i64, *const u8, usize, *mut f64) -> i32,
+    );
+    fn js_register_handle_property_set_dispatch_extension(
+        f: unsafe extern "C" fn(i64, *const u8, usize, f64) -> i32,
+    );
+}
+
+/// Register the three HTTP-server handle-dispatch extensions with perry-runtime.
+/// Idempotent (`Once` here + the runtime de-dupes by fn pointer). Called from
+/// `ensure_gc_scanner_registered`, so it runs the first time any HTTP/HTTPS/HTTP2
+/// server is created — before any request handler can fire.
+pub(crate) fn ensure_dispatch_extensions_registered() {
+    static REGISTER: Once = Once::new();
+    REGISTER.call_once(|| unsafe {
+        js_register_handle_method_dispatch_extension(http_server_method_dispatch_ext);
+        js_register_handle_property_dispatch_extension(http_server_property_dispatch_ext);
+        js_register_handle_property_set_dispatch_extension(http_server_property_set_dispatch_ext);
+    });
+}
+
+// ---- native member-name vocabularies (mirror perry-stdlib's gated arms) ----
+
+fn is_http_server_method(name: &str) -> bool {
+    matches!(
+        name,
+        "listen"
+            | "close"
+            | "address"
+            | "on"
+            | "addListener"
+            | "setTimeout"
+            | "closeAllConnections"
+            | "closeIdleConnections"
+            | "removeAllListeners"
+            | "removeListener"
+            | "off"
+            | "ref"
+            | "unref"
+            | "@@__perry_wk_asyncDispose"
+    )
+}
+
+fn is_http_server_property(name: &str) -> bool {
+    is_http_server_method(name)
+        || matches!(
+            name,
+            "@@kConnectionsCheckingInterval"
+                | "listening"
+                | "headersTimeout"
+                | "keepAliveTimeout"
+                | "keepAliveTimeoutBuffer"
+                | "requestTimeout"
+                | "timeout"
+                | "maxHeadersCount"
+                | "maxRequestsPerSocket"
+        )
+}
+
+fn is_incoming_message_member(name: &str) -> bool {
+    matches!(
+        name,
+        "on" | "addListener"
+            | "setEncoding"
+            | "setTimeout"
+            | "pause"
+            | "resume"
+            | "destroy"
+            | "read"
+            | "_addHeaderLine"
+            | "__set_socket"
+            | "__set_connection"
+    ) || matches!(
+        name,
+        "method"
+            | "url"
+            | "rawBody"
+            | "httpVersion"
+            | "httpVersionMajor"
+            | "httpVersionMinor"
+            | "headers"
+            | "rawHeaders"
+            | "headersDistinct"
+            | "trailers"
+            | "rawTrailers"
+            | "trailersDistinct"
+            | "complete"
+            | "aborted"
+            | "destroyed"
+            | "socket"
+            | "connection"
+            | "signal"
+            | "remoteAddress"
+            | "remotePort"
+    ) || matches!(
+        name,
+        "__get_method"
+            | "__get_url"
+            | "__get_httpVersion"
+            | "__get_headers"
+            | "__get_headersDistinct"
+            | "__get_trailers"
+            | "__get_rawHeaders"
+            | "__get_rawTrailers"
+            | "__get_trailersDistinct"
+            | "__get_complete"
+            | "__get_aborted"
+            | "__get_destroyed"
+            | "__get_socket"
+            | "__get_connection"
+            | "__get_signal"
+            | "__get_remoteAddress"
+            | "__get_remotePort"
+            | "constructor"
+    )
+}
+
+fn is_server_response_member(name: &str) -> bool {
+    matches!(
+        name,
+        "setHeader"
+            | "getHeader"
+            | "removeHeader"
+            | "hasHeader"
+            | "getHeaders"
+            | "getHeaderNames"
+            | "appendHeader"
+            | "setHeaders"
+            | "writeHead"
+            | "write"
+            | "addTrailers"
+            | "end"
+            | "flushHeaders"
+            | "cork"
+            | "uncork"
+            | "destroy"
+            | "pipe"
+            | "setTimeout"
+            | "writeEarlyHints"
+            | "writeContinue"
+            | "writeProcessing"
+            | "assignSocket"
+            | "detachSocket"
+            | "on"
+            | "addListener"
+            | "setStatus"
+            | "getStatus"
+    ) || matches!(
+        name,
+        "statusCode"
+            | "statusMessage"
+            | "headersSent"
+            | "writableEnded"
+            | "writableFinished"
+            | "finished"
+            | "writableCorked"
+            | "writableHighWaterMark"
+            | "writableLength"
+            | "writableObjectMode"
+            | "writableNeedDrain"
+            | "sendDate"
+            | "strictContentLength"
+            | "req"
+            | "socket"
+            | "connection"
+            | "constructor"
+    ) || matches!(
+        name,
+        "__get_statusCode"
+            | "__get_statusMessage"
+            | "__set_statusCode"
+            | "__set_statusMessage"
+            | "__get_headersSent"
+            | "__get_writableEnded"
+            | "__get_writableFinished"
+            | "__get_finished"
+            | "__get_sendDate"
+            | "__set_sendDate"
+            | "__get_strictContentLength"
+            | "__set_strictContentLength"
+            | "__get_req"
+            | "__get_socket"
+            | "__get_connection"
+    )
+}
+
+fn is_h2_session_member(name: &str) -> bool {
+    matches!(
+        name,
+        "request"
+            | "on"
+            | "addListener"
+            | "close"
+            | "destroy"
+            | "ref"
+            | "unref"
+            | "setTimeout"
+            | "setLocalWindowSize"
+            | "ping"
+            | "settings"
+            | "goaway"
+            | "type"
+            | "encrypted"
+            | "connecting"
+            | "closed"
+            | "destroyed"
+            | "alpnProtocol"
+            | "pendingSettingsAck"
+            | "localSettings"
+            | "remoteSettings"
+            | "state"
+            | "socket"
+    )
+}
+
+fn is_h2_stream_member(name: &str) -> bool {
+    matches!(
+        name,
+        "on" | "addListener"
+            | "setEncoding"
+            | "respond"
+            | "end"
+            | "close"
+            | "setTimeout"
+            | "priority"
+            | "additionalHeaders"
+            | "pushStream"
+            | "respondWithFD"
+            | "respondWithFile"
+            | "sendTrailers"
+            | "id"
+            | "pending"
+            | "closed"
+            | "destroyed"
+            | "aborted"
+            | "rstCode"
+            | "headersSent"
+            | "sentHeaders"
+            | "session"
+            | "state"
+            | "bufferSize"
+            | "endAfterHeaders"
+    )
+}
+
+#[inline]
+unsafe fn name_str<'a>(ptr: *const u8, len: usize) -> &'a str {
+    if ptr.is_null() || len == 0 {
+        ""
+    } else {
+        std::str::from_utf8(std::slice::from_raw_parts(ptr, len)).unwrap_or("")
+    }
+}
+
+/// Method-call extension. Claims (returns 1, sets `*out`) ONLY when `handle`
+/// belongs to one of our registries AND `method` is a native member of that
+/// type. Returns 0 for any other name so user-prototype-augmented methods
+/// (Express `res.send`, etc.) resolve through the prototype chain.
+unsafe extern "C" fn http_server_method_dispatch_ext(
+    handle: i64,
+    method_ptr: *const u8,
+    method_len: usize,
+    args_ptr: *const f64,
+    args_len: usize,
+    out: *mut f64,
+) -> i32 {
+    let name = name_str(method_ptr, method_len);
+    if name.is_empty() {
+        return 0;
+    }
+    let value = if is_http_server_method(name)
+        && crate::handle_dispatch::js_ext_http_server_is_handle(handle) != 0
+    {
+        Some(crate::handle_dispatch::js_ext_http_server_dispatch_method(
+            handle, method_ptr, method_len, args_ptr, args_len,
+        ))
+    } else if is_incoming_message_member(name)
+        && crate::handle_dispatch::js_ext_http_incoming_message_is_handle(handle) != 0
+    {
+        Some(
+            crate::handle_dispatch::js_ext_http_incoming_message_dispatch_method(
+                handle, method_ptr, method_len, args_ptr, args_len,
+            ),
+        )
+    } else if is_server_response_member(name)
+        && crate::handle_dispatch::js_ext_http_server_response_is_handle(handle) != 0
+    {
+        Some(
+            crate::handle_dispatch::js_ext_http_server_response_dispatch_method(
+                handle, method_ptr, method_len, args_ptr, args_len,
+            ),
+        )
+    } else if is_h2_session_member(name)
+        && crate::http2_server::dispatch::js_ext_http2_session_is_handle(handle) != 0
+    {
+        Some(crate::http2_server::dispatch::js_ext_http2_session_dispatch_method(
+            handle, method_ptr, method_len, args_ptr, args_len,
+        ))
+    } else if is_h2_stream_member(name)
+        && crate::http2_server::dispatch::js_ext_http2_stream_is_handle(handle) != 0
+    {
+        Some(crate::http2_server::dispatch::js_ext_http2_stream_dispatch_method(
+            handle, method_ptr, method_len, args_ptr, args_len,
+        ))
+    } else {
+        None
+    };
+    match value {
+        Some(v) => {
+            if !out.is_null() {
+                *out = v;
+            }
+            1
+        }
+        None => 0,
+    }
+}
+
+/// Property-read extension. Same name-gating discipline as the method path.
+unsafe extern "C" fn http_server_property_dispatch_ext(
+    handle: i64,
+    property_ptr: *const u8,
+    property_len: usize,
+    out: *mut f64,
+) -> i32 {
+    let name = name_str(property_ptr, property_len);
+    if name.is_empty() {
+        return 0;
+    }
+    let value = if is_http_server_property(name)
+        && crate::handle_dispatch::js_ext_http_server_is_handle(handle) != 0
+    {
+        Some(crate::handle_dispatch::js_ext_http_server_dispatch_property(
+            handle,
+            property_ptr,
+            property_len,
+        ))
+    } else if is_incoming_message_member(name)
+        && crate::handle_dispatch::js_ext_http_incoming_message_is_handle(handle) != 0
+    {
+        Some(
+            crate::handle_dispatch::js_ext_http_incoming_message_dispatch_property(
+                handle,
+                property_ptr,
+                property_len,
+            ),
+        )
+    } else if is_server_response_member(name)
+        && crate::handle_dispatch::js_ext_http_server_response_is_handle(handle) != 0
+    {
+        Some(
+            crate::handle_dispatch::js_ext_http_server_response_dispatch_property(
+                handle,
+                property_ptr,
+                property_len,
+            ),
+        )
+    } else if is_h2_session_member(name)
+        && crate::http2_server::dispatch::js_ext_http2_session_is_handle(handle) != 0
+    {
+        Some(
+            crate::http2_server::dispatch::js_ext_http2_session_dispatch_property(
+                handle,
+                property_ptr,
+                property_len,
+            ),
+        )
+    } else if is_h2_stream_member(name)
+        && crate::http2_server::dispatch::js_ext_http2_stream_is_handle(handle) != 0
+    {
+        Some(crate::http2_stream_props::js_ext_http2_stream_dispatch_property(
+            handle,
+            property_ptr,
+            property_len,
+        ))
+    } else {
+        None
+    };
+    match value {
+        Some(v) => {
+            if !out.is_null() {
+                *out = v;
+            }
+            1
+        }
+        None => 0,
+    }
+}
+
+/// Property-write extension. Claims only the writable NATIVE keys of each handle
+/// type — `res.statusCode` / `res.statusMessage` / `res.sendDate` /
+/// `res.strictContentLength` / `res.socket` / `res.connection`, and
+/// `req.socket` / `req.connection`. Express's `res.status(n)` lowers to
+/// `this.statusCode = n`, so the response set MUST route to the native handle;
+/// without it Express responses keep status 200 but, more importantly, the set
+/// would silently no-op. Every OTHER set (Express stashing `res.locals`,
+/// `req.app`, `req.baseUrl`, …) returns 0 so the user expando lands on the
+/// object as usual. The underlying dispatch returns 1/0 itself, so an
+/// unrecognised key on a matched handle still falls through.
+unsafe extern "C" fn http_server_property_set_dispatch_ext(
+    handle: i64,
+    property_ptr: *const u8,
+    property_len: usize,
+    value: f64,
+) -> i32 {
+    let name = name_str(property_ptr, property_len);
+    if matches!(
+        name,
+        "statusCode" | "statusMessage" | "sendDate" | "strictContentLength" | "socket" | "connection"
+    ) && crate::handle_dispatch::js_ext_http_server_response_is_handle(handle) != 0
+    {
+        return crate::handle_dispatch::js_ext_http_server_response_dispatch_property_set(
+            handle,
+            property_ptr,
+            property_len,
+            value,
+        );
+    }
+    if matches!(name, "socket" | "connection")
+        && crate::handle_dispatch::js_ext_http_incoming_message_is_handle(handle) != 0
+    {
+        return crate::handle_dispatch::js_ext_http_incoming_message_dispatch_property_set(
+            handle,
+            property_ptr,
+            property_len,
+            value,
+        );
+    }
+    0
+}

--- a/crates/perry-ext-http-server/src/http2_server.rs
+++ b/crates/perry-ext-http-server/src/http2_server.rs
@@ -64,7 +64,7 @@ extern "C" {
 }
 
 mod controls;
-mod dispatch;
+pub(crate) mod dispatch;
 mod pump;
 mod session;
 

--- a/crates/perry-ext-http-server/src/lib.rs
+++ b/crates/perry-ext-http-server/src/lib.rs
@@ -53,6 +53,7 @@ use std::sync::Once;
 use perry_ffi::{gc_register_mutable_root_scanner_named, iter_handles_of_mut, GcRootVisitor};
 
 mod cluster_bind;
+mod dispatch_ext;
 // Unit-test binaries do not link the host stdlib/runtime archive that
 // provides the perry_ffi async bridge; without these the test link is at the
 // mercy of --gc-sections keeping/dropping the perry-ffi references pulled in
@@ -113,6 +114,13 @@ pub(crate) fn ensure_gc_scanner_registered() {
             js_register_aux_pump(crate::server::js_node_http_server_process_pending);
             js_register_aux_has_active(crate::server::js_node_http_server_has_active);
         }
+        // Wall 10 — register the handle property/method/property-set dispatch
+        // extensions so erased-receiver `req.url` / `res.end(...)` etc. route to
+        // our handles even when the linked perry-stdlib was built WITHOUT
+        // `external-http-server-pump` (the prebuilt `full` stdlib used by
+        // out-of-tree installs and `PERRY_NO_AUTO_OPTIMIZE=1`). See
+        // `dispatch_ext.rs`.
+        crate::dispatch_ext::ensure_dispatch_extensions_registered();
     });
 }
 

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -136,6 +136,7 @@ impl LoweringContext {
             namespace_import_sources: std::collections::HashMap::new(),
             generator_func_names: HashSet::new(),
             async_generator_func_names: HashSet::new(),
+            nested_generator_forward_referenced: HashSet::new(),
             iterator_func_for_class: std::collections::HashMap::new(),
             proxy_locals: HashSet::new(),
             builtin_proto_method_locals: HashMap::new(),

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -1097,21 +1097,34 @@ pub(super) fn try_native_module_methods(
                 }
             }
 
-            // Check for Symbol static methods: Symbol.for / Symbol.keyFor
+            // Check for Symbol static methods: Symbol.for / Symbol.keyFor.
+            // Accept BOTH the dot form (`Symbol.for(...)`) and the
+            // computed-string form (`Symbol['for'](...)`) — the latter is what
+            // the userland `buffer` package writes (`Symbol['for']('nodejs.util.
+            // inspect.custom')`). Previously only `MemberProp::Ident` matched, so
+            // `Symbol['for'](...)` fell through to generic dispatch, which dropped
+            // the `Symbol` receiver and lowered the callee as `globalThis.for`
+            // (undefined) → `TypeError: value is not a function` at buffer's
+            // module eval (the safer-buffer/iconv-lite/body-parser/express chain).
             if obj_name == "Symbol" {
-                if let ast::MemberProp::Ident(method_ident) = &member.prop {
-                    let method_name = method_ident.sym.as_ref();
-                    match method_name {
-                        "for" => {
-                            let key = args.into_iter().next().unwrap_or(Expr::Undefined);
-                            return Ok(Ok(Expr::SymbolFor(Box::new(key))));
-                        }
-                        "keyFor" => {
-                            let sym = args.into_iter().next().unwrap_or(Expr::Undefined);
-                            return Ok(Ok(Expr::SymbolKeyFor(Box::new(sym))));
-                        }
-                        _ => {} // Fall through to generic handling
+                let method_name: Option<&str> = match &member.prop {
+                    ast::MemberProp::Ident(method_ident) => Some(method_ident.sym.as_ref()),
+                    ast::MemberProp::Computed(c) => match c.expr.as_ref() {
+                        ast::Expr::Lit(ast::Lit::Str(s)) => s.value.as_str(),
+                        _ => None,
+                    },
+                    _ => None,
+                };
+                match method_name {
+                    Some("for") => {
+                        let key = args.into_iter().next().unwrap_or(Expr::Undefined);
+                        return Ok(Ok(Expr::SymbolFor(Box::new(key))));
                     }
+                    Some("keyFor") => {
+                        let sym = args.into_iter().next().unwrap_or(Expr::Undefined);
+                        return Ok(Ok(Expr::SymbolKeyFor(Box::new(sym))));
+                    }
+                    _ => {} // Fall through to generic handling
                 }
             }
 
@@ -1533,6 +1546,26 @@ pub(super) fn try_native_module_methods(
                     // This is a call on a native module (e.g., mysql.createConnection)
                     if let ast::MemberProp::Ident(method_ident) = &member.prop {
                         let method_name = method_ident.sym.to_string();
+                        // A destructured/named DATA member of a native module
+                        // (`const { METHODS } = require('node:http')` →
+                        // `imported_method = Some("METHODS")`) holds a real
+                        // Array/Object value. An Array/Object prototype method on it
+                        // (`METHODS.map(...)`, `STATUS_CODES.hasOwnProperty(...)`) is
+                        // a call on that VALUE — NOT a `module.method` native call.
+                        // Bail to generic dynamic dispatch so it runs on the member's
+                        // resolved value (express's `router` does
+                        // `METHODS.map((m) => m.toLowerCase())`). Without this the
+                        // call lowered to `NativeMethodCall { module: "http", method:
+                        // "map" }`, which returned undefined / a deferred throw.
+                        if imported_method.is_some()
+                            && (super::super::array_fold::is_known_array_prototype_method(
+                                &method_name,
+                            ) || super::super::array_fold::is_known_object_prototype_method(
+                                &method_name,
+                            ))
+                        {
+                            return Ok(Err(args));
+                        }
                         if module_name == "worker_threads" && method_name == "workerData" {
                             return Ok(Err(args));
                         }
@@ -1634,6 +1667,23 @@ pub(super) fn try_native_module_methods(
                             && !super::super::array_fold::is_known_string_prototype_method(
                                 &method_name,
                             )
+                            // A destructured/named DATA member of a native module
+                            // (`const { METHODS } = require('node:http')`,
+                            // registered with `imported_method = Some("METHODS")`)
+                            // holds a real Array/Object value, not a callable
+                            // namespace. An Array/Object prototype method on it
+                            // (`METHODS.map(...)`, `STATUS_CODES.hasOwnProperty(...)`)
+                            // is a call on that VALUE — gating it as
+                            // `http.map`/`http.hasOwnProperty` (#463) compiled it to
+                            // a deferred "not implemented" throw, breaking express's
+                            // `router` (`METHODS.map((m) => m.toLowerCase())`). Fall
+                            // through to dynamic dispatch on the real member value.
+                            && !(imported_method.is_some()
+                                && (super::super::array_fold::is_known_array_prototype_method(
+                                    &method_name,
+                                ) || super::super::array_fold::is_known_object_prototype_method(
+                                    &method_name,
+                                )))
                         {
                             // #925: this is the gate that fires
                             // for `crypto.hmacSha256(data, key)`.

--- a/crates/perry-hir/src/lower/expr_function.rs
+++ b/crates/perry-hir/src/lower/expr_function.rs
@@ -683,6 +683,21 @@ fn lower_fn_expr_anon(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) -> Resul
     // repopulates it for this body.
     let saved_annexb_block_fn_var_ids = std::mem::take(&mut ctx.annexb_block_fn_var_ids);
     let saved_annexb_block_fn_names_all = std::mem::take(&mut ctx.annexb_block_fn_names_all);
+    // Nested `function*` declarations forward-referenced by an earlier sibling
+    // in this function-expression body (the cjs_wrap IIFE: `pathToRegexp` calls
+    // `flatten`, declared below it) must use the closure-lowering path. Scope
+    // the set to this body and restore on exit.
+    let saved_nested_gen_fwd = std::mem::take(&mut ctx.nested_generator_forward_referenced);
+    ctx.nested_generator_forward_referenced = fn_expr
+        .function
+        .body
+        .as_ref()
+        .map(|b| {
+            crate::lower_decl::forward_referenced_nested_generators(&b.stmts)
+                .into_iter()
+                .collect()
+        })
+        .unwrap_or_default();
 
     // Generate Let statements for destructuring patterns BEFORE lowering body
     let mut destructuring_stmts = Vec::new();
@@ -799,8 +814,27 @@ fn lower_fn_expr_anon(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) -> Resul
         }
         for stmt in &block.stmts {
             if let ast::Stmt::Decl(ast::Decl::Fn(fn_decl)) = stmt {
-                if fn_decl.function.body.is_some() && !fn_decl.function.is_generator {
-                    let name = fn_decl.ident.sym.to_string();
+                let name = fn_decl.ident.sym.to_string();
+                // Non-generator fn-decls hoist as before. GENERATOR fn-decls
+                // only need a pre-defined+hoisted local when they take the
+                // closure-lowering path AND are forward-referenced by an earlier
+                // sibling (path-to-regexp's `pathToRegexp` → `flatten`): the
+                // closure path emits `let <name> = Closure`, which must be
+                // pre-defined so the earlier reference resolves to the local and
+                // hoisted (in `hoisted_id_set`) so the binding runs before that
+                // reference. A generator that takes the TOP-LEVEL path (the
+                // common, non-forward-referenced case) must NOT be pre-defined
+                // here — boxing/hoisting its `FuncRef` binding would make its own
+                // recursive self-call read a boxed slot instead of the callable
+                // `FuncRef` (`TypeError: value is not a function`).
+                let take = if fn_decl.function.body.is_none() {
+                    false
+                } else if fn_decl.function.is_generator {
+                    ctx.nested_generator_forward_referenced.contains(&name)
+                } else {
+                    true
+                };
+                if take {
                     let existing_in_scope = ctx
                         .locals
                         .lookup_index_in_scope(&name, outer_locals_len)
@@ -1085,11 +1119,60 @@ fn lower_fn_expr_anon(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) -> Resul
     } else {
         Vec::new()
     };
+
+    // Mirror `lower_fn_body_block_stmt`'s (block.rs) end-of-body class-capture
+    // re-registration for FUNCTION-EXPRESSION bodies — which previously skipped
+    // it (arrow / fn-decl bodies already do this; function expressions, incl.
+    // the cjs_wrap IIFE `(function() { … })()`, did not). The decl-site
+    // `RegisterClassCaptures` snapshot is taken at the class's declaration
+    // position, which runs BEFORE later statements assign captured vars: the
+    // ubiquitous tsc computed-member emit `var _a; class C { [_a]=… }; _a =
+    // Symbol.for(…)` assigns `_a` AFTER the class, so the decl-site snapshot
+    // recorded `undefined`. A statically-resolved `new C(…)` appends the live
+    // value and is fine, but a DYNAMICALLY-resolved construct (`new ns.C(…)`
+    // cross-module — how NestJS builds `InstanceWrapper`) appends no cap arg and
+    // falls back to that stale snapshot → captured field reads `undefined`.
+    // Refresh the snapshot with the FINAL values at body end (inserted before a
+    // trailing `return`).
+    if let Some(ref block) = fn_expr.function.body {
+        let mut re_regs: Vec<Stmt> = Vec::new();
+        for stmt in &block.stmts {
+            if let ast::Stmt::Decl(ast::Decl::Class(class_decl)) = stmt {
+                let cname = class_decl.ident.sym.to_string();
+                if let Some(captured) = ctx.lookup_class_captures(&cname) {
+                    if !captured.is_empty() {
+                        let captures: Vec<Expr> =
+                            captured.iter().map(|id| Expr::LocalGet(*id)).collect();
+                        let cap_args: Vec<(LocalId, LocalId)> =
+                            captured.iter().map(|id| (*id, *id)).collect();
+                        for s in body.iter_mut() {
+                            crate::lower_decl::append_new_args_stmt(s, &cname, &cap_args, true);
+                        }
+                        re_regs.push(Stmt::Expr(Expr::RegisterClassCaptures {
+                            class_name: cname,
+                            captures,
+                        }));
+                    }
+                }
+            }
+        }
+        if !re_regs.is_empty() {
+            let insert_at = if matches!(body.last(), Some(Stmt::Return(_))) {
+                body.len() - 1
+            } else {
+                body.len()
+            };
+            for (i, s) in re_regs.into_iter().enumerate() {
+                body.insert(insert_at + i, s);
+            }
+        }
+    }
     ctx.current_strict = outer_strict;
     ctx.annexb_block_fn_var_ids = saved_annexb_block_fn_var_ids;
     ctx.annexb_block_fn_names_all = saved_annexb_block_fn_names_all;
     ctx.forward_class_names = saved_forward_class_names;
     ctx.class_renames = saved_class_renames;
+    ctx.nested_generator_forward_referenced = saved_nested_gen_fwd;
 
     // Prepend destructuring statements to body
     if !destructuring_stmts.is_empty() {

--- a/crates/perry-hir/src/lower/lower_expr/arm_ident.rs
+++ b/crates/perry-hir/src/lower/lower_expr/arm_ident.rs
@@ -38,6 +38,30 @@ pub(crate) fn lower_ident_expr(ctx: &mut LoweringContext, ident: &ast::Ident) ->
     {
         return Ok(Expr::ClassRef(ctx.resolve_class_name(&name)));
     }
+    // Chained-assignment class self-alias referenced from inside one of the
+    // class's own method/getter/setter bodies. tsc's decorator-capture form
+    // `let Logger = Logger_1 = class Logger { get x(){ …Logger_1… } static
+    // error(){ …Logger_1… } }` declares `Logger_1` as a real outer-scope local
+    // and binds the class to it. Inside a STATIC method the outer local is not
+    // in scope (the method compiles to a standalone function), and inside an
+    // instance method resolving to a `LocalGet` capture forces the whole class
+    // onto the per-evaluation `ClassExprFresh` path (which drops static methods
+    // and SIGSEGVs `new`). The alias value IS the class everywhere after
+    // evaluation, so resolve it to the constructor `ClassRef` directly — exactly
+    // as JS spec resolves the inner class binding. `record_chained_class_self_
+    // aliases` populates `class_expr_aliases[alias] = <class lowering name>`
+    // before the body is lowered; gate on currently lowering that same class so
+    // an unrelated outer reference to the name is untouched. (`class_expr_
+    // aliases` is NOT a `register_class`, so this does not trip
+    // `lower_class_expr`'s collision-rename — `current_class` stays the real
+    // class name.)
+    if let Some(cur) = ctx.current_class.clone() {
+        if let Some(target) = ctx.class_expr_aliases.get(&name) {
+            if *target == cur {
+                return Ok(Expr::ClassRef(ctx.resolve_class_name(target)));
+            }
+        }
+    }
     if let Some(id) = ctx.lookup_local(&name) {
         // A with-fallback implicit global may still be the HOLE
         // sentinel (the with-env took the write) — reading it then

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -512,6 +512,16 @@ pub struct LoweringContext {
     /// the for-of generator-call path so it can wrap `__iter.next()` in
     /// `await` (async generators always return `Promise<{value, done}>`).
     pub(crate) async_generator_func_names: HashSet<String>,
+    /// Names of nested `function*` declarations that are referenced by an
+    /// EARLIER sibling statement in the same enclosing function/IIFE body
+    /// (forward reference). Such a generator cannot use the top-level-Function
+    /// hoist path — its `FuncRef` name binding is only registered while lowering
+    /// its own declaration, too late for the earlier reference, which would fall
+    /// through to a `globalThis` read (`ReferenceError: <name> is not defined`).
+    /// Populated by the Phase-1 pre-pass in `lower_fn_body_block_stmt` /
+    /// `lower_fn_expr_anon`; consumed in `lower_body_stmt`'s FnDecl arm to route
+    /// the generator through the closure path instead.
+    pub(crate) nested_generator_forward_referenced: HashSet<String>,
     /// Classes that define `*[Symbol.iterator]()`. Maps class name →
     /// `FuncId` of the synthesized top-level generator function that
     /// takes `this` as its first parameter. Consumed by `for...of` to

--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -70,6 +70,58 @@ fn emit_class_expression_value_binding(
     });
 }
 
+/// For a `let X = T1 = … = class [Y] {…}` declaration, record the chained
+/// assignment targets (`T1`, …) as class self-aliases of the class's lowering
+/// name in `ctx.class_expr_aliases`, BEFORE the init is lowered. This does NOT
+/// `register_class` the names (which would trip `lower_class_expr`'s
+/// collision-rename), it only feeds `synthesize_class_captures`'s self-alias
+/// exclusion so a method-body reference to `T1` (e.g. tsc's `Logger_1`) is not
+/// counted as an outer-scope capture — keeping the class on the shared-template
+/// `ClassRef` path instead of the static-method-dropping `ClassExprFresh` path.
+/// The class's own bind/inner name is already covered by `name` in that pass.
+pub(crate) fn record_chained_class_self_aliases(ctx: &mut LoweringContext, decl: &ast::VarDeclarator) {
+    let (ast::Pat::Ident(ident), Some(init)) = (&decl.name, &decl.init) else {
+        return;
+    };
+    let bind_name = ident.id.sym.to_string();
+    let mut chained_targets: Vec<String> = Vec::new();
+    let mut e = init.as_ref();
+    let inner_class = loop {
+        match e {
+            ast::Expr::Paren(p) => e = &p.expr,
+            ast::Expr::TsAs(a) => e = &a.expr,
+            ast::Expr::TsNonNull(n) => e = &n.expr,
+            ast::Expr::TsTypeAssertion(a) => e = &a.expr,
+            ast::Expr::Assign(assign) if assign.op == ast::AssignOp::Assign => {
+                if let ast::AssignTarget::Simple(ast::SimpleAssignTarget::Ident(target)) =
+                    &assign.left
+                {
+                    chained_targets.push(target.id.sym.to_string());
+                    e = &assign.right;
+                } else {
+                    return;
+                }
+            }
+            ast::Expr::Class(c) => break c,
+            _ => return,
+        }
+    };
+    if chained_targets.is_empty() {
+        return;
+    }
+    // The class lowers under its inner expression name if present, else the
+    // binding name (matching `lower_class_expr`'s `ident_name`/synthetic-name
+    // choice for the common non-colliding case).
+    let class_name = inner_class
+        .ident
+        .as_ref()
+        .map(|i| i.sym.to_string())
+        .unwrap_or_else(|| bind_name.clone());
+    for t in chained_targets {
+        ctx.class_expr_aliases.entry(t).or_insert(class_name.clone());
+    }
+}
+
 /// Recursively walk a destructuring pattern collecting every leaf identifier
 /// (and pre-defining each as a local). Used by the for-of binding pre-pass so
 /// the loop body can reference variables introduced by *nested* patterns like
@@ -818,6 +870,12 @@ pub(crate) fn lower_stmt(
                                 }
                             }
                         }
+                        // Record chained-assignment class self-aliases (`let
+                        // Logger = Logger_1 = class …`) so the self-reference
+                        // isn't captured (see `synthesize_class_captures`). This
+                        // top-level path is reached for any `let X = T = class`
+                        // not handled by the direct `class` fast path above.
+                        record_chained_class_self_aliases(ctx, decl);
                         let stmts = lower_var_decl_with_destructuring(ctx, decl, mutable, is_var)?;
                         // `var` is function-scoped: mark defined locals so
                         // `pop_block_scope` preserves them when leaving an inner block.

--- a/crates/perry-hir/src/lower_decl/block.rs
+++ b/crates/perry-hir/src/lower_decl/block.rs
@@ -904,6 +904,15 @@ pub fn lower_fn_body_block_stmt(
     // repopulates it for this body below.
     let saved_annexb_block_fn_var_ids = std::mem::take(&mut ctx.annexb_block_fn_var_ids);
     let saved_annexb_block_fn_names_all = std::mem::take(&mut ctx.annexb_block_fn_names_all);
+    // Nested `function*` declarations forward-referenced by an earlier sibling
+    // in THIS body must use the closure-lowering path (see `lower_body_stmt`'s
+    // FnDecl arm). Scope the set to this body and restore on every exit.
+    let saved_nested_gen_fwd =
+        std::mem::take(&mut ctx.nested_generator_forward_referenced);
+    ctx.nested_generator_forward_referenced =
+        crate::lower_decl::forward_referenced_nested_generators(&block.stmts)
+            .into_iter()
+            .collect();
     // Boundary between outer-scope locals (+ this function's params, defined by
     // the caller before entry) and locals defined while lowering THIS body.
     // Used by the Phase 1.6 forward `let`/`const` pre-registration so a const
@@ -1002,6 +1011,7 @@ pub fn lower_fn_body_block_stmt(
             ctx.forward_class_names = saved_forward_class_names;
             ctx.class_renames = saved_class_renames;
             ctx.annexb_block_fn_var_ids = saved_annexb_block_fn_var_ids;
+            ctx.nested_generator_forward_referenced = saved_nested_gen_fwd;
             ctx.annexb_block_fn_names_all = saved_annexb_block_fn_names_all;
             return Err(err);
         }
@@ -1082,6 +1092,7 @@ pub fn lower_fn_body_block_stmt(
         ctx.current_strict = parent_strict;
         ctx.annexb_block_fn_var_ids = saved_annexb_block_fn_var_ids;
         ctx.annexb_block_fn_names_all = saved_annexb_block_fn_names_all;
+        ctx.nested_generator_forward_referenced = saved_nested_gen_fwd;
         let mut result = var_slot_lets;
         result.extend(body);
         return Ok(result);
@@ -1139,6 +1150,7 @@ pub fn lower_fn_body_block_stmt(
     ctx.current_strict = parent_strict;
     ctx.annexb_block_fn_var_ids = saved_annexb_block_fn_var_ids;
     ctx.annexb_block_fn_names_all = saved_annexb_block_fn_names_all;
+    ctx.nested_generator_forward_referenced = saved_nested_gen_fwd;
     Ok(result)
 }
 

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -20,7 +20,10 @@ use super::*;
 
 mod detect;
 mod for_await;
+pub(crate) mod gen_capture_scan;
 mod nested_fn_decl;
+
+use gen_capture_scan::nested_generator_references_outer_locals;
 
 use detect::{
     insert_iterator_return_before_abrupts, is_fs_dir_for_await_target, is_node_readable_expr,
@@ -170,6 +173,10 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                             .insert(binding.id.sym.as_ref().to_string());
                     }
                 }
+                // Record chained-assignment class self-aliases (`let Logger =
+                // Logger_1 = class …`) so the self-reference isn't captured (see
+                // `synthesize_class_captures`). Function / CJS-module body path.
+                crate::lower::record_chained_class_self_aliases(ctx, decl);
                 let stmts = lower_var_decl_with_destructuring(ctx, decl, mutable, is_var)?;
                 // `var` is function-scoped: mark each defined local so
                 // `pop_block_scope` preserves it when leaving an inner block.
@@ -421,18 +428,54 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
         }
         ast::Stmt::Decl(ast::Decl::Fn(fn_decl)) => {
             // Inner function declarations are compiled as closures and assigned to local variables.
-            // EXCEPTION: nested **generator** declarations (`function*` /
-            // `async function*`) cannot be lowered as closures because the
-            // generator-state-machine transform in `perry-transform/src/
-            // generator.rs` only operates on top-level `Function`s in
-            // `hir.functions`. Closures with `yield` in their body would
-            // never run through the transform and would silently call the
-            // raw IR (returning 0). Hoist them to top-level via
-            // `lower_fn_decl` + `pending_functions` and register the local
-            // as a FuncRef so the for-of / Array.fromAsync iterator path
-            // detects them via `generator_func_names`.
+            // NESTED **generator** declarations (`function*` / `async
+            // function*`) need the generator-state-machine transform. Two routes:
+            //
+            //   (a) DEFAULT: hoist it to a top-level `Function` in
+            //       `hir.functions` (via `lower_fn_decl` + `pending_functions`)
+            //       and bind the local to a `FuncRef` so the for-of /
+            //       Array.fromAsync iterator path detects it via
+            //       `generator_func_names`. This is the historical path; it
+            //       works for generators that are NOT referenced before their
+            //       own declaration by a sibling (the `FuncRef` name binding is
+            //       registered while lowering this declaration, too late for an
+            //       earlier sibling's reference).
+            //
+            //   (b) The generator REFERENCES outer-scope free variables (e.g. a
+            //       `function* lexer()` nested in a CJS-wrap IIFE that reads
+            //       module-scope `SIMPLE_TOKENS`/`ID_START`) OR is referenced by
+            //       an EARLIER sibling in the same enclosing body (e.g.
+            //       path-to-regexp's `pathToRegexp` calls `flatten`, declared
+            //       below it, inside the CJS-wrap IIFE). The top-level `Function`
+            //       has no capture environment — free vars forward into the
+            //       step closures as nullish (`Cannot convert undefined or null
+            //       to object`), and an earlier sibling's forward reference falls
+            //       through to a `globalThis` read (`ReferenceError: <name> is
+            //       not defined`). Lower it as a generator `Expr::Closure`
+            //       instead (via `lower_nested_fn_decl`, which computes the real
+            //       `captures` and emits a hoisted `Stmt::Let { init: Closure }`
+            //       that the IIFE/fn-body hoisting moves ahead of executable
+            //       statements). The closure-aware generator transform
+            //       (`transform_generator_closures_in_stmts`) threads the
+            //       captures — including a boxed self-capture for recursion —
+            //       into the step closures. Register the name in
+            //       `generator_func_names` so iteration still detects it.
             if fn_decl.function.body.is_some() && fn_decl.function.is_generator {
                 let func_name = fn_decl.ident.sym.to_string();
+                let use_closure_path =
+                    nested_generator_references_outer_locals(ctx, &fn_decl.function, &func_name)
+                        || ctx.nested_generator_forward_referenced.contains(&func_name);
+                if use_closure_path {
+                    if ctx.lookup_local(&func_name).is_none() {
+                        ctx.define_local(func_name.clone(), Type::Any);
+                    }
+                    ctx.generator_func_names.insert(func_name.clone());
+                    if fn_decl.function.is_async {
+                        ctx.async_generator_func_names.insert(func_name.clone());
+                    }
+                    nested_fn_decl::lower_nested_fn_decl(ctx, fn_decl, &mut result)?;
+                    return Ok(result);
+                }
                 let func = lower_fn_decl(ctx, fn_decl)?;
                 let func_id = func.id;
                 ctx.register_func(func_name.clone(), func_id);

--- a/crates/perry-hir/src/lower_decl/body_stmt/gen_capture_scan.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt/gen_capture_scan.rs
@@ -1,0 +1,406 @@
+//! Conservative free-variable scan for nested generator declarations.
+//!
+//! A nested `function*` declaration that references any enclosing-scope local
+//! must be lowered as a generator `Expr::Closure` (so the closure-aware
+//! generator transform threads its captures into the synthesized step
+//! closures) rather than hoisted to a capture-less top-level `Function`.
+//! Otherwise the free variables forward into the step closures as nullish
+//! values (`Cannot convert undefined or null to object` when the body indexes
+//! them) — the path-to-regexp `lexer`/`SIMPLE_TOKENS` failure.
+//!
+//! This walker collects every identifier reference in the function body
+//! (over-approximating: collecting an extra name only routes through the
+//! closure path, which is always correct), then asks `ctx.lookup_local` whether
+//! any of them resolves to a live enclosing local. Identifiers bound *inside*
+//! the body (params, inner declarations) are not in the enclosing scope, so
+//! `lookup_local` only returns `Some` for genuine outer captures.
+
+use super::*;
+
+/// Scan an enclosing function/IIFE body's statements and return the names of
+/// nested `function*` declarations that are referenced by an EARLIER sibling
+/// statement (a forward reference). Such generators must be lowered via the
+/// closure path (see `lower_body_stmt`'s FnDecl arm), because the top-level
+/// hoist path registers the `FuncRef` name binding too late for the earlier
+/// reference. Statements are scanned in source order: a generator name is
+/// "forward referenced" if it appears in any identifier position before its own
+/// declaration statement.
+pub(crate) fn forward_referenced_nested_generators(stmts: &[ast::Stmt]) -> Vec<String> {
+    // Collect declaration order of nested generator fn-decls.
+    let mut gen_decl_index: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+    for (i, stmt) in stmts.iter().enumerate() {
+        if let ast::Stmt::Decl(ast::Decl::Fn(fd)) = stmt {
+            if fd.function.is_generator && fd.function.body.is_some() {
+                gen_decl_index
+                    .entry(fd.ident.sym.to_string())
+                    .or_insert(i);
+            }
+        }
+    }
+    if gen_decl_index.is_empty() {
+        return Vec::new();
+    }
+    let mut forward: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for (i, stmt) in stmts.iter().enumerate() {
+        // The generator's own declaration statement is not a forward reference
+        // to itself (self-recursion is handled inside its body either way).
+        let mut names: Vec<String> = Vec::new();
+        collect_idents_stmt(stmt, &mut names);
+        for n in names {
+            if let Some(&decl_i) = gen_decl_index.get(&n) {
+                if i < decl_i {
+                    forward.insert(n);
+                }
+            }
+        }
+    }
+    forward.into_iter().collect()
+}
+
+/// Does this nested generator body reference any identifier bound in an
+/// enclosing (outer) scope?
+pub(super) fn nested_generator_references_outer_locals(
+    ctx: &LoweringContext,
+    func: &ast::Function,
+    own_name: &str,
+) -> bool {
+    let Some(body) = func.body.as_ref() else {
+        return false;
+    };
+    // The generator's own name (for self-recursion) and its parameters bind
+    // inside the function, not the enclosing scope — exclude them so a purely
+    // self-recursive generator (e.g. path-to-regexp `flatten`) is NOT treated
+    // as capturing. (Function declarations are hoisted, so a pre-scan may have
+    // already registered the own name as a local; without this exclusion the
+    // self-reference would force the closure path and lose hoisting.)
+    let mut bound: std::collections::HashSet<String> = std::collections::HashSet::new();
+    bound.insert(own_name.to_string());
+    for p in &func.params {
+        collect_pat_bound_names(&p.pat, &mut bound);
+    }
+
+    let mut names: Vec<String> = Vec::new();
+    for stmt in &body.stmts {
+        collect_idents_stmt(stmt, &mut names);
+    }
+    names
+        .iter()
+        .any(|n| !bound.contains(n) && ctx.lookup_local(n).is_some())
+}
+
+fn collect_pat_bound_names(pat: &ast::Pat, out: &mut std::collections::HashSet<String>) {
+    match pat {
+        ast::Pat::Ident(i) => {
+            out.insert(i.id.sym.to_string());
+        }
+        ast::Pat::Array(a) => {
+            for e in a.elems.iter().flatten() {
+                collect_pat_bound_names(e, out);
+            }
+        }
+        ast::Pat::Rest(r) => collect_pat_bound_names(&r.arg, out),
+        ast::Pat::Object(o) => {
+            for p in &o.props {
+                match p {
+                    ast::ObjectPatProp::KeyValue(kv) => collect_pat_bound_names(&kv.value, out),
+                    ast::ObjectPatProp::Assign(a) => {
+                        out.insert(a.key.sym.to_string());
+                    }
+                    ast::ObjectPatProp::Rest(r) => collect_pat_bound_names(&r.arg, out),
+                }
+            }
+        }
+        ast::Pat::Assign(a) => collect_pat_bound_names(&a.left, out),
+        _ => {}
+    }
+}
+
+fn push_ident(name: &str, out: &mut Vec<String>) {
+    out.push(name.to_string());
+}
+
+fn collect_idents_expr(expr: &ast::Expr, out: &mut Vec<String>) {
+    use ast::Expr;
+    match expr {
+        Expr::Ident(i) => push_ident(i.sym.as_ref(), out),
+        Expr::This(_) | Expr::Lit(_) | Expr::Invalid(_) => {}
+        Expr::Array(a) => {
+            for e in a.elems.iter().flatten() {
+                collect_idents_expr(&e.expr, out);
+            }
+        }
+        Expr::Object(o) => {
+            for p in &o.props {
+                match p {
+                    ast::PropOrSpread::Spread(s) => collect_idents_expr(&s.expr, out),
+                    ast::PropOrSpread::Prop(prop) => collect_idents_prop(prop, out),
+                }
+            }
+        }
+        Expr::Fn(_) | Expr::Arrow(_) => {
+            // Nested functions/arrows form their own scopes. Their free
+            // references could still be outer captures of THIS generator, so
+            // recurse to over-approximate.
+            collect_idents_nested_callable(expr, out);
+        }
+        Expr::Unary(u) => collect_idents_expr(&u.arg, out),
+        Expr::Update(u) => collect_idents_expr(&u.arg, out),
+        Expr::Bin(b) => {
+            collect_idents_expr(&b.left, out);
+            collect_idents_expr(&b.right, out);
+        }
+        Expr::Assign(a) => {
+            collect_idents_assign_target(&a.left, out);
+            collect_idents_expr(&a.right, out);
+        }
+        Expr::Member(m) => {
+            collect_idents_expr(&m.obj, out);
+            if let ast::MemberProp::Computed(c) = &m.prop {
+                collect_idents_expr(&c.expr, out);
+            }
+        }
+        Expr::SuperProp(s) => {
+            if let ast::SuperProp::Computed(c) = &s.prop {
+                collect_idents_expr(&c.expr, out);
+            }
+        }
+        Expr::Cond(c) => {
+            collect_idents_expr(&c.test, out);
+            collect_idents_expr(&c.cons, out);
+            collect_idents_expr(&c.alt, out);
+        }
+        Expr::Call(c) => {
+            if let ast::Callee::Expr(e) = &c.callee {
+                collect_idents_expr(e, out);
+            }
+            for a in &c.args {
+                collect_idents_expr(&a.expr, out);
+            }
+        }
+        Expr::New(n) => {
+            collect_idents_expr(&n.callee, out);
+            if let Some(args) = &n.args {
+                for a in args {
+                    collect_idents_expr(&a.expr, out);
+                }
+            }
+        }
+        Expr::Seq(s) => {
+            for e in &s.exprs {
+                collect_idents_expr(e, out);
+            }
+        }
+        Expr::Tpl(t) => {
+            for e in &t.exprs {
+                collect_idents_expr(e, out);
+            }
+        }
+        Expr::TaggedTpl(t) => {
+            collect_idents_expr(&t.tag, out);
+            for e in &t.tpl.exprs {
+                collect_idents_expr(e, out);
+            }
+        }
+        Expr::Paren(p) => collect_idents_expr(&p.expr, out),
+        Expr::Yield(y) => {
+            if let Some(a) = &y.arg {
+                collect_idents_expr(a, out);
+            }
+        }
+        Expr::Await(a) => collect_idents_expr(&a.arg, out),
+        Expr::OptChain(o) => collect_idents_opt_chain(&o.base, out),
+        Expr::TsAs(t) => collect_idents_expr(&t.expr, out),
+        Expr::TsConstAssertion(t) => collect_idents_expr(&t.expr, out),
+        Expr::TsNonNull(t) => collect_idents_expr(&t.expr, out),
+        Expr::TsTypeAssertion(t) => collect_idents_expr(&t.expr, out),
+        Expr::TsSatisfies(t) => collect_idents_expr(&t.expr, out),
+        Expr::TsInstantiation(t) => collect_idents_expr(&t.expr, out),
+        // Class expressions / JSX / others: conservatively skip. A class
+        // expression's body could capture, but these are rare in generator
+        // bodies; if missed, the worst case is the old (top-level Function)
+        // path, which is exactly the prior behavior.
+        _ => {}
+    }
+}
+
+fn collect_idents_opt_chain(base: &ast::OptChainBase, out: &mut Vec<String>) {
+    match base {
+        ast::OptChainBase::Member(m) => {
+            collect_idents_expr(&m.obj, out);
+            if let ast::MemberProp::Computed(c) = &m.prop {
+                collect_idents_expr(&c.expr, out);
+            }
+        }
+        ast::OptChainBase::Call(c) => {
+            collect_idents_expr(&c.callee, out);
+            for a in &c.args {
+                collect_idents_expr(&a.expr, out);
+            }
+        }
+    }
+}
+
+fn collect_idents_prop(prop: &ast::Prop, out: &mut Vec<String>) {
+    match prop {
+        ast::Prop::Shorthand(i) => push_ident(i.sym.as_ref(), out),
+        ast::Prop::KeyValue(kv) => {
+            if let ast::PropName::Computed(c) = &kv.key {
+                collect_idents_expr(&c.expr, out);
+            }
+            collect_idents_expr(&kv.value, out);
+        }
+        ast::Prop::Assign(a) => collect_idents_expr(&a.value, out),
+        ast::Prop::Getter(_) | ast::Prop::Setter(_) | ast::Prop::Method(_) => {
+            // Method bodies are their own scopes; over-approximating recursion
+            // is unnecessary for the common cases — skip.
+        }
+    }
+}
+
+fn collect_idents_nested_callable(expr: &ast::Expr, out: &mut Vec<String>) {
+    match expr {
+        ast::Expr::Fn(f) => {
+            if let Some(b) = &f.function.body {
+                for s in &b.stmts {
+                    collect_idents_stmt(s, out);
+                }
+            }
+        }
+        ast::Expr::Arrow(a) => match &*a.body {
+            ast::BlockStmtOrExpr::BlockStmt(b) => {
+                for s in &b.stmts {
+                    collect_idents_stmt(s, out);
+                }
+            }
+            ast::BlockStmtOrExpr::Expr(e) => collect_idents_expr(e, out),
+        },
+        _ => {}
+    }
+}
+
+fn collect_idents_assign_target(t: &ast::AssignTarget, out: &mut Vec<String>) {
+    match t {
+        ast::AssignTarget::Simple(s) => match s {
+            ast::SimpleAssignTarget::Ident(i) => push_ident(i.id.sym.as_ref(), out),
+            ast::SimpleAssignTarget::Member(m) => {
+                collect_idents_expr(&m.obj, out);
+                if let ast::MemberProp::Computed(c) = &m.prop {
+                    collect_idents_expr(&c.expr, out);
+                }
+            }
+            _ => {}
+        },
+        ast::AssignTarget::Pat(_) => {}
+    }
+}
+
+fn collect_idents_var_decl(decl: &ast::VarDecl, out: &mut Vec<String>) {
+    for d in &decl.decls {
+        if let Some(init) = &d.init {
+            collect_idents_expr(init, out);
+        }
+    }
+}
+
+fn collect_idents_stmt(stmt: &ast::Stmt, out: &mut Vec<String>) {
+    use ast::Stmt;
+    match stmt {
+        Stmt::Expr(e) => collect_idents_expr(&e.expr, out),
+        Stmt::Decl(ast::Decl::Var(v)) => collect_idents_var_decl(v, out),
+        Stmt::Decl(ast::Decl::Fn(f)) => {
+            if let Some(b) = &f.function.body {
+                for s in &b.stmts {
+                    collect_idents_stmt(s, out);
+                }
+            }
+        }
+        Stmt::Decl(_) => {}
+        Stmt::Block(b) => {
+            for s in &b.stmts {
+                collect_idents_stmt(s, out);
+            }
+        }
+        Stmt::Return(r) => {
+            if let Some(a) = &r.arg {
+                collect_idents_expr(a, out);
+            }
+        }
+        Stmt::If(i) => {
+            collect_idents_expr(&i.test, out);
+            collect_idents_stmt(&i.cons, out);
+            if let Some(alt) = &i.alt {
+                collect_idents_stmt(alt, out);
+            }
+        }
+        Stmt::While(w) => {
+            collect_idents_expr(&w.test, out);
+            collect_idents_stmt(&w.body, out);
+        }
+        Stmt::DoWhile(w) => {
+            collect_idents_stmt(&w.body, out);
+            collect_idents_expr(&w.test, out);
+        }
+        Stmt::For(f) => {
+            match &f.init {
+                Some(ast::VarDeclOrExpr::Expr(e)) => collect_idents_expr(e, out),
+                Some(ast::VarDeclOrExpr::VarDecl(v)) => collect_idents_var_decl(v, out),
+                None => {}
+            }
+            if let Some(t) = &f.test {
+                collect_idents_expr(t, out);
+            }
+            if let Some(u) = &f.update {
+                collect_idents_expr(u, out);
+            }
+            collect_idents_stmt(&f.body, out);
+        }
+        Stmt::ForIn(f) => {
+            collect_idents_expr(&f.right, out);
+            if let ast::ForHead::VarDecl(v) = &f.left {
+                collect_idents_var_decl(v, out);
+            }
+            collect_idents_stmt(&f.body, out);
+        }
+        Stmt::ForOf(f) => {
+            collect_idents_expr(&f.right, out);
+            if let ast::ForHead::VarDecl(v) = &f.left {
+                collect_idents_var_decl(v, out);
+            }
+            collect_idents_stmt(&f.body, out);
+        }
+        Stmt::Switch(s) => {
+            collect_idents_expr(&s.discriminant, out);
+            for case in &s.cases {
+                if let Some(t) = &case.test {
+                    collect_idents_expr(t, out);
+                }
+                for st in &case.cons {
+                    collect_idents_stmt(st, out);
+                }
+            }
+        }
+        Stmt::Throw(t) => collect_idents_expr(&t.arg, out),
+        Stmt::Try(t) => {
+            for s in &t.block.stmts {
+                collect_idents_stmt(s, out);
+            }
+            if let Some(h) = &t.handler {
+                for s in &h.body.stmts {
+                    collect_idents_stmt(s, out);
+                }
+            }
+            if let Some(f) = &t.finalizer {
+                for s in &f.stmts {
+                    collect_idents_stmt(s, out);
+                }
+            }
+        }
+        Stmt::Labeled(l) => collect_idents_stmt(&l.body, out),
+        Stmt::With(w) => {
+            collect_idents_expr(&w.obj, out);
+            collect_idents_stmt(&w.body, out);
+        }
+        Stmt::Break(_) | Stmt::Continue(_) | Stmt::Empty(_) | Stmt::Debugger(_) => {}
+    }
+}

--- a/crates/perry-hir/src/lower_decl/body_stmt/nested_fn_decl.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt/nested_fn_decl.rs
@@ -260,7 +260,7 @@ pub(super) fn lower_nested_fn_decl(
         enclosing_class: None,
         is_arrow: false,
         is_async: fn_decl.function.is_async,
-        is_generator: false,
+        is_generator: fn_decl.function.is_generator,
         is_strict,
     };
     result.push(Stmt::Let {

--- a/crates/perry-hir/src/lower_decl/mod.rs
+++ b/crates/perry-hir/src/lower_decl/mod.rs
@@ -34,8 +34,9 @@ pub(crate) use block::{
     compute_prealloc_for_hoisted_closures, lower_block_stmt, lower_block_stmt_scoped,
     lower_fn_body_block_stmt, lower_stmts_using_aware, pre_register_forward_captured_lets,
 };
+pub(crate) use body_stmt::gen_capture_scan::forward_referenced_nested_generators;
 pub(crate) use body_stmt::{find_native_return_in_stmts, lower_body_stmt};
-pub(crate) use class_captures::synthesize_class_captures;
+pub(crate) use class_captures::{append_new_args_stmt, synthesize_class_captures};
 pub(crate) use class_computed::class_computed_member_registration_expr;
 pub(crate) use class_decl::{lower_class_decl, lower_class_from_ast};
 pub(crate) use class_members::{

--- a/crates/perry-runtime/src/array/iter_object.rs
+++ b/crates/perry-runtime/src/array/iter_object.rs
@@ -220,9 +220,63 @@ unsafe fn throw_if_typed_array_proto(arr: *const ArrayHeader, method: &str) {
     }
 }
 
+/// If `arr` (the already-unwrapped receiver pointer from the
+/// `Expr::Array{Values,Keys,Entries}` fold) is actually a Map/Set — registered
+/// directly OR a `class X extends Map|Set` instance carrying the hidden backing
+/// collection — return the matching COLLECTION iterator object instead of
+/// treating it as an array. The any-typed `.values()/.keys()/.entries()` fold
+/// (`array_only_methods.rs`, #597) routes every dynamic-receiver call through
+/// `js_array_*_iter_obj`; without this a Map/Set (or subclass) receiver was
+/// iterated as a (non-)array and yielded an EMPTY iterator — NestJS's
+/// `[...modulesContainer.values()]` (a `class ModulesContainer extends Map`)
+/// returned 0 entries, so the injector never instantiated controllers/providers
+/// and route handlers saw a field-less stub `this` (#wall14). `kind`: 0 =
+/// values, 1 = keys, 2 = entries.
+unsafe fn collection_iter_obj_for_receiver(arr: *const ArrayHeader, kind: u8) -> Option<i64> {
+    let raw = arr as usize;
+    if raw < 0x10000 {
+        return None;
+    }
+    if crate::map::is_registered_map(raw) {
+        let m = raw as *const crate::map::MapHeader;
+        return Some(match kind {
+            1 => crate::collection_iter_object::js_map_keys_iter_obj(m),
+            2 => crate::collection_iter_object::js_map_entries_iter_obj(m),
+            _ => crate::collection_iter_object::js_map_values_iter_obj(m),
+        });
+    }
+    if crate::set::is_registered_set(raw) {
+        let s = raw as *const crate::set::SetHeader;
+        return Some(match kind {
+            1 => crate::collection_iter_object::js_set_keys_iter_obj(s),
+            2 => crate::collection_iter_object::js_set_entries_iter_obj(s),
+            _ => crate::collection_iter_object::js_set_values_iter_obj(s),
+        });
+    }
+    // `class X extends Map|Set` instance — probe the hidden backing field via
+    // the reconstructed NaN-boxed pointer value.
+    let boxed = f64::from_bits(JSValue::pointer(arr as *const u8).bits());
+    match crate::object::map_set_subclass::subclass_backing_of(boxed) {
+        Some(crate::object::map_set_subclass::CollectionBacking::Map(m)) => Some(match kind {
+            1 => crate::collection_iter_object::js_map_keys_iter_obj(m as *const crate::map::MapHeader),
+            2 => crate::collection_iter_object::js_map_entries_iter_obj(m as *const crate::map::MapHeader),
+            _ => crate::collection_iter_object::js_map_values_iter_obj(m as *const crate::map::MapHeader),
+        }),
+        Some(crate::object::map_set_subclass::CollectionBacking::Set(s)) => Some(match kind {
+            1 => crate::collection_iter_object::js_set_keys_iter_obj(s as *const crate::set::SetHeader),
+            2 => crate::collection_iter_object::js_set_entries_iter_obj(s as *const crate::set::SetHeader),
+            _ => crate::collection_iter_object::js_set_values_iter_obj(s as *const crate::set::SetHeader),
+        }),
+        None => None,
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn js_array_values_iter_obj(arr: *const ArrayHeader) -> i64 {
     unsafe {
+        if let Some(it) = collection_iter_obj_for_receiver(arr, 0) {
+            return it;
+        }
         guard_coercible_this(arr, "values");
         throw_if_typed_array_proto(arr, "values");
         array_iter_obj_raw(typed_array_iter_arr(arr), KIND_VALUES)
@@ -232,6 +286,9 @@ pub extern "C" fn js_array_values_iter_obj(arr: *const ArrayHeader) -> i64 {
 #[no_mangle]
 pub extern "C" fn js_array_keys_iter_obj(arr: *const ArrayHeader) -> i64 {
     unsafe {
+        if let Some(it) = collection_iter_obj_for_receiver(arr, 1) {
+            return it;
+        }
         guard_coercible_this(arr, "keys");
         throw_if_typed_array_proto(arr, "keys");
         array_iter_obj_raw(typed_array_iter_arr(arr), KIND_KEYS)
@@ -241,6 +298,9 @@ pub extern "C" fn js_array_keys_iter_obj(arr: *const ArrayHeader) -> i64 {
 #[no_mangle]
 pub extern "C" fn js_array_entries_iter_obj(arr: *const ArrayHeader) -> i64 {
     unsafe {
+        if let Some(it) = collection_iter_obj_for_receiver(arr, 2) {
+            return it;
+        }
         guard_coercible_this(arr, "entries");
         throw_if_typed_array_proto(arr, "entries");
         array_iter_obj_raw(typed_array_iter_arr(arr), KIND_ENTRIES)

--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -42,6 +42,22 @@ pub extern "C" fn js_for_of_to_array(val_f64: f64) -> f64 {
         return js_nanbox_pointer(entries as i64);
     }
 
+    // `class X extends Map | Set` instance — iterate its hidden backing
+    // collection (`for (const [k,v] of mapSubclass)` / `for (const v of
+    // setSubclass)`). Map yields `[k, v]` pairs (=== `.entries()`), Set yields
+    // values, matching the builtins' default `[Symbol.iterator]`.
+    match crate::object::map_set_subclass::subclass_backing_of(val_f64) {
+        Some(crate::object::map_set_subclass::CollectionBacking::Map(m)) => {
+            let arr = js_map_entries_for_for_of(m as i64);
+            return js_nanbox_pointer(arr as i64);
+        }
+        Some(crate::object::map_set_subclass::CollectionBacking::Set(s)) => {
+            let arr = js_set_to_array_for_for_of(s as i64);
+            return js_nanbox_pointer(arr as i64);
+        }
+        None => {}
+    }
+
     // Strings: iterate by code point. `is_any_string` covers both heap
     // STRING_TAG and inline SSO short strings. `js_get_string_pointer_unified`
     // returns a real `*const StringHeader` for either representation
@@ -672,6 +688,21 @@ pub(crate) fn array_from_spread_value(value: f64) -> *mut ArrayHeader {
     }
     if crate::map::is_registered_map(raw_ptr) {
         return crate::map::js_map_entries(raw_ptr as *const crate::map::MapHeader);
+    }
+    // `class X extends Map | Set` instance — spread (`[...container]`,
+    // `Array.from(container)`, `fn(...container)`) over the hidden backing
+    // collection's default iterator (Map → entries, Set → values), matching
+    // the builtins. The `is_registered_*` checks above only match a real
+    // Map/Set value, so a subclass instance (a plain object with a backing
+    // field) falls through to here.
+    match crate::object::map_set_subclass::subclass_backing_of(value) {
+        Some(crate::object::map_set_subclass::CollectionBacking::Map(m)) => {
+            return crate::map::js_map_entries(m as *const crate::map::MapHeader);
+        }
+        Some(crate::object::map_set_subclass::CollectionBacking::Set(s)) => {
+            return crate::set::js_set_to_array(s as *const crate::set::SetHeader);
+        }
+        None => {}
     }
     if crate::typedarray::lookup_typed_array_kind(raw_ptr).is_some() {
         return crate::typedarray::typed_array_to_array(

--- a/crates/perry-runtime/src/closure/dynamic_props.rs
+++ b/crates/perry-runtime/src/closure/dynamic_props.rs
@@ -834,6 +834,16 @@ pub(crate) fn clone_closure_rebind_this(closure_bits: u64, recv_box: f64) -> u64
             return closure_bits;
         }
         let header = ptr as *const ClosureHeader;
+        // Arrow functions bind `this` lexically: their `this` capture slot holds
+        // the enclosing instance and must NEVER be overwritten with a call-time
+        // receiver (proxy handler, getter receiver, method-call object, …).
+        // They still carry CAPTURES_THIS_FLAG (the body reads `this`), so the
+        // flag check below does not exclude them — guard explicitly. Without this,
+        // an arrow used as a proxy trap / accessor would observe the rebind
+        // receiver and lose its captured instance's data fields (#wall11).
+        if crate::closure::closure_is_arrow(header) {
+            return closure_bits;
+        }
         let raw_count = (*header).capture_count;
         // No CAPTURES_THIS_FLAG → the closure body doesn't read `this`, no rebind needed.
         if raw_count & CAPTURES_THIS_FLAG == 0 {

--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -122,6 +122,46 @@ pub extern "C" fn js_object_get_own_property_descriptor(obj_value: f64, key_valu
             return crate::proxy::js_reflect_get_own_property_descriptor(obj_value, key_value);
         }
 
+        // A per-evaluation class object (`ClassExprFresh`, #1772/#1787) is a
+        // POINTER-tagged heap object, not a `0x7FFE` class ref, so the
+        // `class_ref_id` branch below never fires for it. Its static METHODS
+        // live in the class registry keyed by the header class_id (not as own
+        // properties), so `getOwnPropertyDescriptor(C, "staticMethod")` reported
+        // `undefined` — which broke NestJS's tslib `__decorate` chain
+        // (`descriptor.value` on undefined → "reading 'value'") when the Logger
+        // class took the fresh path (its getter/methods capture module locals
+        // like `DEFAULT_LOGGER`, forcing `ClassExprFresh`). Mirror the class-ref
+        // branch's static-method descriptor: a `static m(){}` is a `{ writable,
+        // enumerable: false, configurable }` own data property of the
+        // constructor. `is_class_object_value` is pointer-safe (it checks the
+        // NaN-box tag before any deref). Own per-evaluation static FIELDS fall
+        // through to the ordinary own-property path (checked here via
+        // `own_key_present` so a field shadows a same-named template method).
+        if super::class_registry::is_class_object_value(obj_value) {
+            if let Some(method_name) = metadata_key_to_string(key_value) {
+                let obj = extract_obj_ptr(obj_value);
+                let key_str = crate::builtins::js_string_coerce(key_value);
+                if !obj.is_null() && !key_str.is_null() && !own_key_present(obj, key_str) {
+                    let class_id = super::js_object_get_class_id(obj as *const ObjectHeader);
+                    if class_id != 0
+                        && !super::class_registry::class_is_key_deleted(class_id, &method_name)
+                        && super::class_registry::class_has_own_static_method(
+                            class_id,
+                            &method_name,
+                        )
+                    {
+                        let leaked: &'static [u8] = method_name.as_bytes().to_vec().leak();
+                        let value = super::js_class_method_bind(
+                            obj_value,
+                            leaked.as_ptr(),
+                            leaked.len(),
+                        );
+                        return build_data_descriptor(value, true, false, true);
+                    }
+                }
+            }
+        }
+
         // Private elements (`#x`) are stored on the static side / in a class
         // instance's keys_array but are never reflectable own properties, so
         // their descriptor is always undefined. (Plain `{"#fff": 1}` literals

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -4,6 +4,24 @@
 
 use super::*;
 
+/// Wall 10 — read a property a framework attached to a native registry handle
+/// via `Object.setPrototypeOf(handle, proto)` (Express's `res`/`req`). The link
+/// is keyed by the handle id in `OBJECT_PROTOTYPES`. Returns `None` (so the
+/// caller yields `undefined`) when no recorded prototype carries the key.
+/// Cheap when no prototype was recorded (the common handle case).
+fn handle_proto_inherited_field(
+    handle_id: usize,
+    key: *const crate::StringHeader,
+) -> Option<JSValue> {
+    crate::object::prototype_chain::object_static_prototype(handle_id)?;
+    let v = crate::object::prototype_chain::resolve_inherited_field(handle_id, key)?;
+    if v.bits() == crate::value::TAG_UNDEFINED {
+        None
+    } else {
+        Some(v)
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn js_object_get_field_by_name(
     obj: *const ObjectHeader,
@@ -29,6 +47,100 @@ pub extern "C" fn js_object_get_field_by_name(
                 return JSValue::from_bits(v.to_bits());
             }
         }
+    }
+    // `class X extends Map | Set` instance — `.size` reads the hidden backing
+    // collection's size (a Map/Set subclass never carries an own `size`
+    // property, so this can't shadow user state). Other backed reads
+    // (`.has`/`.get`/… as METHODS) route through `js_native_call_method`.
+    if !key.is_null() && ((obj as u64) >> 48) == 0 && (obj as usize) >= 0x10000 {
+        unsafe {
+            let name_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+            let name_len = (*key).byte_len as usize;
+            if std::slice::from_raw_parts(name_ptr, name_len) == b"size" {
+                let boxed = f64::from_bits(JSValue::pointer(obj as *const u8).bits());
+                match crate::object::map_set_subclass::subclass_backing_of(boxed) {
+                    Some(crate::object::map_set_subclass::CollectionBacking::Map(m)) => {
+                        return JSValue::number(crate::map::js_map_size(m) as f64);
+                    }
+                    Some(crate::object::map_set_subclass::CollectionBacking::Set(s)) => {
+                        return JSValue::number(crate::set::js_set_size(s) as f64);
+                    }
+                    None => {}
+                }
+            }
+        }
+    }
+    // A per-evaluation class object (`ClassExprFresh`, #1772/#1787) reaches
+    // here as a RAW heap pointer (a real ObjectHeader, so its top 16 address
+    // bits are 0 — distinguishing it from a `0x7FFE` class-ref value or any
+    // NaN-boxed value). Its static METHODS / static ACCESSORS live in the class
+    // registry keyed by the header class_id, never as own properties, so a read
+    // like `C.staticMethod` returned `undefined` (the class-ref form resolves
+    // these via the registry; this pointer-tagged class-object form did not).
+    // That is NestJS's `Logger.error` when the Logger takes the fresh path
+    // (captures `DEFAULT_LOGGER`), which the tslib `__decorate` chain then reads
+    // `.value` off → "reading 'value'". Resolve own fields first (own-property
+    // precedence), then fall back to the registry. The `(obj >> 48) == 0` guard
+    // ensures `is_class_object_ptr` only ever sees a real heap pointer (it
+    // back-reads a GcHeader), never a tagged value — which previously SIGSEGV'd.
+    if !key.is_null()
+        && ((obj as u64) >> 48) == 0
+        && (obj as usize) >= 0x10000
+        && crate::object::class_registry::is_class_object_ptr(obj as *const u8)
+    {
+        unsafe {
+            // Only resolve a registry-backed static METHOD / static ACCESSOR
+            // here, and ONLY when the object does NOT already carry the key as
+            // an own property (so a per-evaluation static field shadows a
+            // template method, preserving own-property precedence). On a match
+            // return it; otherwise FALL THROUGH to the normal resolution path
+            // below (which handles own fields, class-ref/prototype semantics,
+            // and everything else). Returning the bare own-field-tail result
+            // early here was wrong: it skipped the intervening builtin-prototype
+            // / class-ref handling and broke reads like
+            // `Object.prototype.hasOwnProperty` on objects that happen to be
+            // class-typed.
+            let class_id = super::super::js_object_get_class_id(obj);
+            if class_id != 0 {
+                let name_ptr =
+                    (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+                let name_len = (*key).byte_len as usize;
+                let name = std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len))
+                    .unwrap_or("");
+                if !name.is_empty()
+                    && !super::super::class_registry::class_is_key_deleted(class_id, name)
+                    && !super::super::own_key_present(obj as *mut ObjectHeader, key)
+                {
+                    let class_value =
+                        f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
+                    if super::super::class_registry::lookup_static_method_in_chain(
+                        class_id, name,
+                    )
+                    .is_some()
+                    {
+                        let heap_name = {
+                            let layout =
+                                std::alloc::Layout::from_size_align(name_len.max(1), 1).unwrap();
+                            let ptr = std::alloc::alloc(layout);
+                            std::ptr::copy_nonoverlapping(name_ptr, ptr, name_len);
+                            ptr
+                        };
+                        let result = js_class_method_bind(class_value, heap_name, name_len);
+                        return JSValue::from_bits(result.to_bits());
+                    }
+                    if let Some(v) =
+                        super::super::class_registry::class_static_accessor_getter_value(
+                            class_id,
+                            name,
+                            class_value,
+                        )
+                    {
+                        return JSValue::from_bits(v.to_bits());
+                    }
+                }
+            }
+        }
+        // fall through to normal resolution
     }
     if let Some(addr) =
         crate::typedarray_props::typed_array_addr_from_value(f64::from_bits(obj as u64))
@@ -282,7 +394,19 @@ pub extern "C" fn js_object_get_field_by_name(
                     }
                     if let Some(dispatch) = handle_property_dispatch() {
                         let bits = dispatch(raw as i64, key_ptr, key_len);
+                        // Wall 10 — fall back to a `setPrototypeOf(handle, proto)`
+                        // member (Express's augmented `res`/`req`) when the native
+                        // dispatch doesn't know the key. See
+                        // `handle_proto_inherited_field`.
+                        if bits.to_bits() == crate::value::TAG_UNDEFINED {
+                            if let Some(v) = handle_proto_inherited_field(raw, key) {
+                                return v;
+                            }
+                        }
                         return JSValue::from_bits(bits.to_bits());
+                    }
+                    if let Some(v) = handle_proto_inherited_field(raw, key) {
+                        return v;
                     }
                 }
             }

--- a/crates/perry-runtime/src/object/field_get_set/has_property.rs
+++ b/crates/perry-runtime/src/object/field_get_set/has_property.rs
@@ -491,6 +491,17 @@ unsafe fn ordinary_has_property(
             None => break,
         }
     }
+    // Wall 10 — a class instance's prototype METHODS / GETTERS / SETTERS live in
+    // `CLASS_VTABLE_REGISTRY`, not as a recorded `[[Prototype]]` object with a
+    // `keys_array`, so the own-key + recorded-prototype walk above misses them.
+    // Check the class chain so `'method' in instance` is `true` (e.g. NestJS's
+    // app Proxy gating on `'listen' in receiver`).
+    if let Some(name) = key_name {
+        let class_id = unsafe { (*obj_ptr).class_id };
+        if class_id != 0 && super::super::native_module::class_instance_has_member(class_id, name) {
+            return true;
+        }
+    }
     // Inherited `Object.prototype` properties (`toString`, `hasOwnProperty`, …,
     // plus any user-assigned `Object.prototype` members).
     ordinary_object_prototype_property_value(last_valid, key).is_some()

--- a/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
+++ b/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
@@ -257,7 +257,24 @@ pub extern "C" fn js_object_get_field_ic_miss(
             unsafe {
                 let key_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
                 let key_len = (*key).byte_len as usize;
-                return dispatch(obj as i64, key_ptr, key_len);
+                let bits = dispatch(obj as i64, key_ptr, key_len);
+                // Wall 10 — fall back to a `setPrototypeOf(handle, proto)` member
+                // (Express's augmented `res`/`req`) when the native dispatch
+                // doesn't know the key. Mirrors `js_object_get_field_by_name`.
+                if bits.to_bits() == crate::value::TAG_UNDEFINED {
+                    if let Some(v) =
+                        crate::object::prototype_chain::object_static_prototype(obj as usize)
+                            .and(crate::object::prototype_chain::resolve_inherited_field(
+                                obj as usize,
+                                key,
+                            ))
+                    {
+                        if v.bits() != crate::value::TAG_UNDEFINED {
+                            return f64::from_bits(v.bits());
+                        }
+                    }
+                }
+                return bits;
             }
         }
         return f64::from_bits(crate::value::TAG_UNDEFINED);

--- a/crates/perry-runtime/src/object/map_set_subclass.rs
+++ b/crates/perry-runtime/src/object/map_set_subclass.rs
@@ -1,0 +1,120 @@
+//! `class X extends Map` / `class X extends Set` — subclass backing support.
+//!
+//! Perry models a class instance as a plain `ObjectHeader`, not a real exotic
+//! Map/Set (`MapHeader`/`SetHeader` are separate, header-less-class allocations).
+//! So `super()` to a `Map`/`Set` parent used to be a best-effort no-op, leaving
+//! the subclass instance with no collection storage and no `has`/`get`/`set`/…
+//! methods — `m.has(k)` threw "has is not a function". NestJS's
+//! `ModulesContainer extends Map` (and any user `class … extends Map`) hit this.
+//!
+//! Fix: `super()` calls `js_map_set_subclass_init`, which allocates a real
+//! `MapHeader`/`SetHeader`, optionally seeds it from the constructor's iterable
+//! argument, and stashes its NaN-boxed pointer on the instance under a hidden
+//! field. Because it is a normal object field, the GC traces + relocates it.
+//!
+//! The collection method/iterator/`.size` surface is then served by checking
+//! for this backing field at the runtime dispatch points (see
+//! `subclass_backing_of` callers in `native_call_method`, `for_of`, and
+//! `field_get_set`). This is more robust than installing per-instance method
+//! closures: it covers method calls, `for…of`, and `.size` reads uniformly.
+
+use crate::map::MapHeader;
+use crate::object::{js_object_get_field_by_name_f64, js_object_set_field_by_name, ObjectHeader};
+use crate::set::SetHeader;
+use crate::value::{JSValue, POINTER_MASK};
+
+/// Hidden field on a Map/Set subclass instance holding the NaN-boxed backing
+/// `MapHeader`/`SetHeader` pointer.
+const BACKING_KEY: &[u8] = b"__perry_collection_backing__";
+
+#[derive(Clone, Copy)]
+pub(crate) enum CollectionBacking {
+    Map(*mut MapHeader),
+    Set(*mut SetHeader),
+}
+
+fn raw_ptr_from_value(value: f64) -> usize {
+    let bits = value.to_bits();
+    let jsval = JSValue::from_bits(bits);
+    if jsval.is_pointer() {
+        return (bits & POINTER_MASK) as usize;
+    }
+    if bits != 0 && bits < 0x0001_0000_0000_0000 {
+        return bits as usize;
+    }
+    0
+}
+
+unsafe fn instance_object_ptr(this: f64) -> Option<*mut ObjectHeader> {
+    let raw = raw_ptr_from_value(this);
+    if raw < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return None;
+    }
+    let header = (raw as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+    if (*header).obj_type != crate::gc::GC_TYPE_OBJECT {
+        return None;
+    }
+    Some(raw as *mut ObjectHeader)
+}
+
+/// If `value` is a Map/Set *subclass instance* (a plain object carrying the
+/// hidden backing field), return its backing collection. Returns `None` for
+/// real Maps/Sets, ordinary objects, and non-objects — so callers fall through
+/// to their existing handling.
+pub(crate) fn subclass_backing_of(value: f64) -> Option<CollectionBacking> {
+    unsafe {
+        let obj = instance_object_ptr(value)?;
+        let backing = js_object_get_field_by_name_f64(
+            obj as *const ObjectHeader,
+            crate::string::js_string_from_bytes(BACKING_KEY.as_ptr(), BACKING_KEY.len() as u32),
+        );
+        let bjs = JSValue::from_bits(backing.to_bits());
+        if !bjs.is_pointer() {
+            return None;
+        }
+        let raw = (backing.to_bits() & POINTER_MASK) as usize;
+        if raw < crate::gc::GC_HEADER_SIZE + 0x1000 {
+            return None;
+        }
+        if crate::map::is_registered_map(raw) {
+            return Some(CollectionBacking::Map(raw as *mut MapHeader));
+        }
+        if crate::set::is_registered_set(raw) {
+            return Some(CollectionBacking::Set(raw as *mut SetHeader));
+        }
+        None
+    }
+}
+
+/// `super()` for a `class X extends Map | Set`. `kind`: 0 = Map, 1 = Set.
+/// `iterable` is the (optional) first constructor argument; `undefined`/`null`
+/// seed an empty collection.
+#[no_mangle]
+pub extern "C" fn js_map_set_subclass_init(this: f64, kind: i32, iterable: f64) -> f64 {
+    let obj = match unsafe { instance_object_ptr(this) } {
+        Some(o) => o,
+        None => return this,
+    };
+    let iter_js = JSValue::from_bits(iterable.to_bits());
+    let has_iter = !(iter_js.is_undefined() || iter_js.is_null());
+
+    let backing_bits = if kind == 0 {
+        let map = if has_iter {
+            crate::map::js_map_from_iterable(iterable)
+        } else {
+            crate::map::js_map_alloc(0)
+        };
+        JSValue::pointer(map as *const u8).bits()
+    } else {
+        let set = if has_iter {
+            crate::set::js_set_from_iterable(iterable)
+        } else {
+            crate::set::js_set_alloc(0)
+        };
+        JSValue::pointer(set as *const u8).bits()
+    };
+
+    let key = crate::string::js_string_from_bytes(BACKING_KEY.as_ptr(), BACKING_KEY.len() as u32);
+    js_object_set_field_by_name(obj, key, f64::from_bits(backing_bits));
+    this
+}

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -46,6 +46,7 @@ mod global_this_tables;
 mod groupby;
 pub(crate) mod has_own_helpers;
 mod instanceof;
+pub(crate) mod map_set_subclass;
 pub(crate) mod iterator_prototypes;
 mod namespace_create;
 mod native_call_method;

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -426,6 +426,42 @@ pub unsafe extern "C" fn js_native_call_method_apply(
     js_native_call_method(object, method_name_ptr, method_name_len, args_ptr, args_len)
 }
 
+/// Apply form of `obj[key](...args)` — the spread-call sibling of
+/// `js_native_call_method_value`. `key` is a *runtime value* (computed member
+/// access, e.g. `receiver[prop](...args)`) and `args_array_handle` is a JS
+/// array holding every regular + spread arg already concatenated by codegen.
+///
+/// Without this, a CallSpread whose callee is a computed member (`IndexGet`)
+/// fell through to the plain closure-spread path (`js_closure_call_apply_with_spread`)
+/// which dropped `this`, so the invoked method saw `this` = a field-less
+/// prototype stub instead of `obj` (NestJS `receiver[prop](...args)` inside its
+/// exception-zone proxy — the instance's data fields and inherited methods all
+/// read as `undefined`). Materialise the array to a temp buffer and forward to
+/// `js_native_call_method_value`, which resolves the method by key and binds
+/// `this = obj`.
+#[no_mangle]
+pub unsafe extern "C" fn js_native_call_method_value_apply(
+    object: f64,
+    key: f64,
+    args_array_handle: i64,
+) -> f64 {
+    let arr = args_array_handle as *const crate::array::ArrayHeader;
+    let len = if arr.is_null() {
+        0
+    } else {
+        crate::array::js_array_length(arr) as usize
+    };
+    let buf: Vec<f64> = (0..len)
+        .map(|i| crate::array::js_array_get_f64(arr, i as u32))
+        .collect();
+    let (args_ptr, args_len) = if buf.is_empty() {
+        (std::ptr::null::<f64>(), 0_usize)
+    } else {
+        (buf.as_ptr(), buf.len())
+    };
+    js_native_call_method_value(object, key, args_ptr, args_len)
+}
+
 #[inline]
 fn root_string_arg_handle<'scope>(
     scope: &'scope crate::gc::RuntimeHandleScope,

--- a/crates/perry-runtime/src/object/native_call_method/collection_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/collection_methods.rs
@@ -21,6 +21,31 @@ pub(super) unsafe fn dispatch_map_set(
     let refreshed_args = || crate::gc::RuntimeHandleScope::refreshed_nanbox_f64_slice(arg_handles);
     let _ = (root_scope, object_handle, &refreshed_args, raw_bits, jsval);
     let _ = (method_name_ptr, method_name_len);
+    // `class X extends Map | Set` instance — redirect the method onto the
+    // hidden backing collection so `has`/`get`/`set`/`delete`/`clear`/`size`/
+    // `forEach`/`keys`/`values`/`entries` (and the Set composition methods)
+    // dispatch as if called on a real Map/Set.
+    if let Some(backing) = super::super::map_set_subclass::subclass_backing_of(object) {
+        let backing_value = match backing {
+            super::super::map_set_subclass::CollectionBacking::Map(m) => {
+                f64::from_bits(JSValue::pointer(m as *const u8).bits())
+            }
+            super::super::map_set_subclass::CollectionBacking::Set(s) => {
+                f64::from_bits(JSValue::pointer(s as *const u8).bits())
+            }
+        };
+        return dispatch_map_set(
+            root_scope,
+            object_handle,
+            arg_handles,
+            backing_value,
+            method_name,
+            method_name_ptr,
+            method_name_len,
+            args_ptr,
+            args_len,
+        );
+    }
     // Check Map/Set registries for raw or NaN-boxed pointers.
     // Maps/Sets are allocated with plain alloc (no GcHeader), so they can't be
     // dispatched through the ObjectHeader path below.
@@ -64,7 +89,11 @@ pub(super) unsafe fn dispatch_map_set(
                     "size" => crate::map::js_map_size(map) as f64,
                     // #2856: value-level iterator methods return real iterator
                     // OBJECTS (not arrays), dispatched via class id.
-                    "entries" => f64::from_bits(
+                    // `class X extends Map` default iterator (`[Symbol.iterator]`)
+                    // is `entries()` — matches the builtin Map. Reached when a
+                    // bound `obj[Symbol.iterator]` (from `js_class_method_bind`)
+                    // is invoked, e.g. by `iterare`'s `toIterator(modulesContainer)`.
+                    "entries" | "Symbol.iterator" | "@@iterator" => f64::from_bits(
                         JSValue::pointer(
                             crate::collection_iter_object::js_map_entries_iter_obj(map) as *mut u8,
                         )
@@ -122,7 +151,9 @@ pub(super) unsafe fn dispatch_map_set(
                     // through to `undefined` (only add/has/delete/clear/size
                     // were handled). Return real iterator objects; `entries`
                     // yields `[v, v]` pairs.
-                    "values" | "keys" => f64::from_bits(
+                    // `class X extends Set` default iterator (`[Symbol.iterator]`)
+                    // is `values()` — matches the builtin Set.
+                    "values" | "keys" | "Symbol.iterator" | "@@iterator" => f64::from_bits(
                         JSValue::pointer(
                             crate::collection_iter_object::js_set_values_iter_obj(set) as *mut u8,
                         )

--- a/crates/perry-runtime/src/object/native_call_method/handle_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/handle_methods.rs
@@ -5,6 +5,54 @@ use super::proto_dispatch::*;
 use super::typed_array::*;
 use super::*;
 
+/// Wall 10 — resolve and invoke a method that a framework attached to a native
+/// registry handle via `Object.setPrototypeOf(handle, proto)` (Express's
+/// augmented `res.send` / `req.accepts` / …). The link was recorded in the
+/// `OBJECT_PROTOTYPES` side-table keyed by the handle id (see
+/// `js_object_set_prototype_of`). Walk it via `resolve_inherited_field`; if the
+/// resolved member is a callable closure, invoke it with `this` bound to the
+/// handle value (`object`) so the method's internal `this.end(...)` /
+/// `this.statusCode = …` route back to the native handle dispatch.
+///
+/// Returns `None` when no recorded prototype yields a callable for `method_name`
+/// — the caller then falls back to JS `undefined`, preserving prior behavior for
+/// genuinely-unknown handle methods.
+unsafe fn dispatch_handle_proto_method(
+    handle_id: usize,
+    object: f64,
+    method_name: &str,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> Option<f64> {
+    // Only do the (locked) side-table walk when a prototype was actually
+    // recorded for this handle — the overwhelmingly common case (fastify /
+    // axios / ioredis handles with no user setPrototypeOf) skips it cheaply.
+    crate::object::prototype_chain::object_static_prototype(handle_id)?;
+    let key = crate::string::js_string_from_bytes(method_name.as_ptr(), method_name.len() as u32);
+    let resolved = crate::object::prototype_chain::resolve_inherited_field(
+        handle_id,
+        key as *const crate::StringHeader,
+    )?;
+    let resolved_bits = resolved.bits();
+    if (resolved_bits >> 48) != 0x7FFD {
+        return None;
+    }
+    let closure_ptr = (resolved_bits & crate::value::POINTER_MASK) as usize;
+    if closure_ptr == 0 || !crate::closure::is_closure_ptr(closure_ptr) {
+        return None;
+    }
+    let args: Vec<f64> = if args_len > 0 && !args_ptr.is_null() {
+        std::slice::from_raw_parts(args_ptr, args_len).to_vec()
+    } else {
+        Vec::new()
+    };
+    let prev = crate::object::js_implicit_this_set(object);
+    let result =
+        crate::closure::js_closure_call_array(closure_ptr as i64, args.as_ptr(), args.len() as i64);
+    crate::object::js_implicit_this_set(prev);
+    Some(result)
+}
+
 pub(super) unsafe fn dispatch_handle(
     root_scope: &crate::gc::RuntimeHandleScope,
     object_handle: &crate::gc::RuntimeHandle,
@@ -29,18 +77,43 @@ pub(super) unsafe fn dispatch_handle(
         if crate::value::addr_class::is_small_handle(raw_ptr) {
             // This is a handle, not a real memory pointer - dispatch to stdlib
             if let Some(dispatch) = handle_method_dispatch() {
-                return Some(dispatch(
+                let r = dispatch(
                     raw_ptr as i64,
                     method_name.as_ptr(),
                     method_name.len(),
                     args_ptr,
                     args_len,
-                ));
+                );
+                // Wall 10 — when the native handle dispatch doesn't recognise the
+                // method (returns `undefined`), the call may target a method that
+                // a framework attached via `Object.setPrototypeOf(handle, proto)`
+                // (Express's `res.send` / `req.accepts`, …). Walk the recorded
+                // handle prototype; if it yields a callable, invoke it with
+                // `this` bound to the handle so the method's internal
+                // `this.end(...)` / `this.statusCode = …` route back to us.
+                if r.to_bits() == crate::value::TAG_UNDEFINED {
+                    if let Some(v) = dispatch_handle_proto_method(
+                        raw_ptr,
+                        object,
+                        method_name,
+                        args_ptr,
+                        args_len,
+                    ) {
+                        return Some(v);
+                    }
+                }
+                return Some(r);
             }
-            // No dispatcher registered, return JS `undefined`. Must be
-            // TAG_UNDEFINED (0x7FFC_..._0001); the bit pattern 0x7FF8_..._0001 a
-            // prior copy used is a signaling NaN (a JS number), which leaks out
-            // as a non-object and trips `js_iterator_result_validate`.
+            // No dispatcher registered: still try a setPrototypeOf'd method.
+            if let Some(v) =
+                dispatch_handle_proto_method(raw_ptr, object, method_name, args_ptr, args_len)
+            {
+                return Some(v);
+            }
+            // Return JS `undefined`. Must be TAG_UNDEFINED (0x7FFC_..._0001); the
+            // bit pattern 0x7FF8_..._0001 a prior copy used is a signaling NaN (a
+            // JS number), which leaks out as a non-object and trips
+            // `js_iterator_result_validate`.
             return Some(f64::from_bits(crate::value::TAG_UNDEFINED));
         }
 

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1188,6 +1188,47 @@ pub(crate) fn class_has_own_method(class_id: u32, method_name: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Wall 10 — `name in instance` for a class instance: true when `name` is a
+/// prototype METHOD, GETTER, or SETTER anywhere in the instance's class chain.
+/// Class instance methods/accessors live in `CLASS_VTABLE_REGISTRY` (the
+/// instance carries no recorded `[[Prototype]]` object with a `keys_array`), so
+/// the ordinary own-key + recorded-prototype walk in `js_object_has_property`
+/// misses them — making `'method' in instance` wrongly `false`. NestJS's app
+/// Proxy gates routing on `'listen' in receiver`; the false result misrouted
+/// `app.listen`, so the server never bound. Walk the class parent chain here.
+pub(crate) fn class_instance_has_member(class_id: u32, name: &str) -> bool {
+    if class_id == 0 {
+        return false;
+    }
+    let registry = match CLASS_VTABLE_REGISTRY.read() {
+        Ok(g) => g,
+        Err(_) => return false,
+    };
+    let Some(reg) = registry.as_ref() else {
+        return false;
+    };
+    let mut cid = class_id;
+    let mut depth = 0u32;
+    while cid != 0 && depth < 32 {
+        if let Some(vtable) = reg.get(&cid) {
+            if vtable.methods.contains_key(name)
+                || vtable.getters.contains_key(name)
+                || vtable.setters.contains_key(name)
+            {
+                return true;
+            }
+        }
+        match super::class_registry::get_parent_class_id(cid) {
+            Some(p) if p != 0 && p != cid => {
+                cid = p;
+                depth += 1;
+            }
+            _ => break,
+        }
+    }
+    false
+}
+
 pub fn class_prototype_method_value_for_name(class_id: u32, method_name: &str) -> f64 {
     if let Some(bits) = CLASS_PROTOTYPE_METHOD_VALUES.with(|cache| {
         let cache = cache.borrow();

--- a/crates/perry-runtime/src/object/object_ops/define_properties.rs
+++ b/crates/perry-runtime/src/object/object_ops/define_properties.rs
@@ -211,6 +211,35 @@ pub extern "C" fn js_object_set_prototype_of(obj_value: f64, proto: f64) -> f64 
         }
     };
 
+    // Wall 10 — `Object.setPrototypeOf(handle, proto)` on a native registry
+    // handle (a POINTER-tagged small-handle id, e.g. a node:http
+    // `ServerResponse` / `IncomingMessage`). Express attaches its augmented
+    // `res.send` / `res.json` / `res.status` (and `req.fresh` / `req.accepts` /
+    // …) onto the per-request native objects via
+    // `Object.setPrototypeOf(res, app.response)`. The heap-object recording
+    // path below rejects the handle (`is_valid_obj_ptr` is false for a small
+    // id), so without this the prototype was silently dropped and every
+    // express response method no-op'd (the Wall-10 express/NestJS blocker).
+    // Record the link in the SAME `OBJECT_PROTOTYPES` side-table keyed by the
+    // handle id; the small-handle method/property dispatch fallbacks then walk
+    // it via `resolve_inherited_field`, binding `this` to the handle so the
+    // express method's internal `this.end(...)` / `this.statusCode = …` route
+    // back to the native handle. Gated on a non-zero handle id in the small
+    // band; a plain heap object (top16 0, addr above the band) still takes the
+    // canonical path below.
+    {
+        let top = obj_bits >> 48;
+        let handle_id = if top == 0x7FFD {
+            (obj_bits & 0x0000_FFFF_FFFF_FFFF) as usize
+        } else {
+            0
+        };
+        if crate::value::addr_class::is_small_handle(handle_id) {
+            super::super::prototype_chain::object_set_static_prototype(handle_id, proto_bits);
+            return obj_value;
+        }
+    }
+
     // #36 / #321: when the target is a closure (a plain function value) and the
     // proto is an object, record the (closure → proto) link in the closure
     // static-prototype side-table. effect's `Context.Tag(id)` returns a

--- a/crates/perry-runtime/src/symbol/get.rs
+++ b/crates/perry-runtime/src/symbol/get.rs
@@ -371,6 +371,28 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
     if let Some(v) = own_symbol_property(obj_f64, sym_f64) {
         return v;
     }
+    // `class X extends Map | Set` instance — its default `[Symbol.iterator]`
+    // is inherited from Map/Set.prototype, so it is NOT an own symbol prop.
+    // Reading the property (e.g. `typeof obj[Symbol.iterator] === 'function'`,
+    // as `iterare`'s `isIterable` / `toIterator` do for NestJS's
+    // `ModulesContainer extends Map`) must still resolve to a callable.
+    // Return a bound method that, when invoked, produces the backing
+    // collection's default iterator (entries for Map, values for Set — see
+    // the `"Symbol.iterator"` arms in `collection_methods.rs`).
+    {
+        let iter_wk = well_known_symbol("iterator");
+        if !iter_wk.is_null() {
+            let iter_f64 =
+                f64::from_bits(crate::value::JSValue::pointer(iter_wk as *const u8).bits());
+            let is_iter = sym_key_from_f64(sym_f64) == sym_key_from_f64(iter_f64);
+            if is_iter
+                && crate::object::map_set_subclass::subclass_backing_of(obj_f64).is_some()
+            {
+                let mname = b"Symbol.iterator";
+                return crate::object::js_class_method_bind(obj_f64, mname.as_ptr(), mname.len());
+            }
+        }
+    }
     let sym_key = sym_key_from_f64(sym_f64);
     if sym_key != 0 {
         let jsval = crate::value::JSValue::from_bits(bits);

--- a/crates/perry-runtime/src/symbol/iterator.rs
+++ b/crates/perry-runtime/src/symbol/iterator.rs
@@ -237,6 +237,23 @@ pub extern "C" fn js_get_iterator(val_f64: f64) -> f64 {
             }
         }
     }
+    // `class X extends Map | Set` instance — its default `[Symbol.iterator]`
+    // yields the hidden backing collection's entries (Map) / values (Set),
+    // returned as a real iterator object so the lazy `for…of` protocol can
+    // drive `.next()`. Matches the builtins' default iterator.
+    match crate::object::map_set_subclass::subclass_backing_of(val_f64) {
+        Some(crate::object::map_set_subclass::CollectionBacking::Map(m)) => {
+            return crate::value::js_nanbox_pointer(
+                crate::collection_iter_object::js_map_entries_iter_obj(m),
+            );
+        }
+        Some(crate::object::map_set_subclass::CollectionBacking::Set(s)) => {
+            return crate::value::js_nanbox_pointer(
+                crate::collection_iter_object::js_set_values_iter_obj(s),
+            );
+        }
+        None => {}
+    }
     // A primitive number / boolean / null / undefined is not iterable. Per
     // GetIterator this is a TypeError; bail before the `[Symbol.iterator]`
     // lookup, which would otherwise dereference a raw (non-NaN-boxed) double as

--- a/crates/perry-runtime/src/weakref.rs
+++ b/crates/perry-runtime/src/weakref.rs
@@ -134,6 +134,21 @@ fn is_valid_weak_target(value: f64) -> bool {
         return true;
     }
 
+    // A class reference (e.g. an imported `class Foo {}` passed as a value, or a
+    // class prototype) is NaN-boxed as an INT32-tagged (`0x7FFE`) class-ref ID,
+    // not a heap pointer. In JS such a value is a function/object and therefore
+    // "CanBeHeldWeakly" (ES2023) — a valid WeakMap/WeakSet/WeakRef key. NestJS
+    // relies on this: `InitializeOnPreviewAllowlist.add(InternalCoreModule)` does
+    // `weakmap.set(InternalCoreModule, true)`, and module-token factories key a
+    // WeakMap by the module class. Cross-module class imports arrive as class-ref
+    // values (not closure pointers), so without this branch they were rejected
+    // with "Invalid value used as weak map key" only inside a full module graph.
+    if crate::object::class_ref_id(value).is_some()
+        || crate::object::class_prototype_ref_id(value).is_some()
+    {
+        return true;
+    }
+
     let jv = JSValue::from_bits(value.to_bits());
     if !jv.is_pointer() {
         return false;

--- a/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
@@ -321,7 +321,16 @@ pub(in crate::commands::compile) fn wrap_commonjs_with_body_offset(
     let imports = require_specs
         .iter()
         .zip(import_local_names.iter())
-        .map(|(spec, local)| {
+        .filter_map(|(spec, local)| {
+            // `reflect-metadata` is a Perry built-in (global `Reflect` polyfill),
+            // not a compiled module — its require shim now returns a fresh `{}`
+            // directly (see `require_cases`), so don't synthesize a hoisted
+            // `import _req_N from 'reflect-metadata'` whose binding nothing
+            // resolves (it read back unbound → `ReferenceError: _req_N is not
+            // defined` inside the IIFE closure).
+            if spec == "reflect-metadata" {
+                return None;
+            }
             // #4904: Node's underscore-prefixed internal http modules are
             // require-only re-exports of the public `http` surface
             // (`require('_http_agent').Agent` etc.). Bind the hoisted import
@@ -332,7 +341,7 @@ pub(in crate::commands::compile) fn wrap_commonjs_with_body_offset(
                 | "_http_server" => "http",
                 other => other,
             };
-            format!("import {} from '{}';", local, import_spec)
+            Some(format!("import {} from '{}';", local, import_spec))
         })
         .collect::<Vec<_>>()
         .join("\n");
@@ -355,6 +364,18 @@ pub(in crate::commands::compile) fn wrap_commonjs_with_body_offset(
         .iter()
         .zip(import_local_names.iter())
         .map(|(spec, local)| {
+            // `require('reflect-metadata')` is satisfied by Perry's built-in
+            // `Reflect.*metadata` polyfill — there is no compiled module to
+            // import, so the synthesized `import _req_N from 'reflect-metadata'`
+            // binds nothing and the nested require shim's `return _req_N` reads
+            // an unresolved name (`ReferenceError: _req_N is not defined`) when
+            // it runs inside the IIFE closure (NestJS `@nestjs/common/index.js`,
+            // every reflect-metadata-importing CJS barrel). The result is always
+            // discarded (the effect is the global `Reflect` polyfill), so return
+            // a fresh empty object directly and skip the dangling binding.
+            if spec == "reflect-metadata" {
+                return format!("        if (specifier === '{spec}') return {{}};");
+            }
             if require_site_in_try(source, spec) {
                 format!(
                     "        if (specifier === '{spec}') {{ if (typeof {local} === 'boolean') \


### PR DESCRIPTION
Consolidated perry compiler + runtime fixes that take the official **nestjs/typescript-starter** from *crashes at module load* to *boots, runs full DI, serves HTTP* when compiled natively by perry.

Companion to the spread-`new` fix **#5710**. **Supersedes #5721** (Walls 2–3 — included here, with the Wall 3 fix refined to the `cjs_wrap` path); #5721 can be closed in favor of this.

### Walls (each an independent, verified bug)
| # | bug | fix area |
|---|-----|----------|
| 2 | chained static-class self-alias `let C=C_1=class C{}` → `descriptor.value` crash (@nestjs Logger) | perry-hir + perry-runtime (registry static resolution on fresh class objects) |
| 3 | `require("reflect-metadata")` → `ReferenceError: _req_N` | `cjs_wrap/wrap.rs` (bind require-shim result) |
| 4 | express load: computed `Symbol['for'](...)` mislowered; `METHODS.map`/`hasOwnProperty` on native-module member | `expr_call/native_module.rs` |
| 5–7 | nested generators capturing outer locals / forward-referenced (path-to-regexp lexer) | perry-hir (route through closure path) |
| 9 | WeakMap class-ref keys; `class extends Map\|Set` real backing (super/dispatch/iterate/size) — NestJS `ModulesContainer` | `weakref.rs`, new `map_set_subclass.rs`, codegen super-call |
| 10 | HTTP server: req/res handle-dispatch, `setPrototypeOf` on handles, `in` on class instances | new `dispatch_ext.rs` + perry-runtime |
| 11 | arrow `this` wrongly rebound by Proxy traps | `closure/dynamic_props.rs` |
| 12 | computed-member spread call `recv[prop](...args)` dropped `this` | codegen `call_spread.rs` + runtime |
| 13 | function-expression bodies didn't refresh end-of-body capture snapshots | `lower/expr_function.rs` |
| 14 | Map/Set subclass `.values()/.keys()/.entries()`/spread/`Array.from` | `array/iter_object.rs` |
| 15 | `===`: `string === Any` collided two NaN-boxed class refs via the string-pointer fast path | `expr/compare.rs` (fall through to `js_eq`) |
| 16 | Map/Set subclass iterability via `obj[Symbol.iterator]` GET | `symbol/get.rs` + runtime |

### Verification
Built on this base, the native app **boots, runs full dependency injection, and serves HTTP** (curl returns a real response through Wall 16). `cargo test -p perry-hir -p perry-runtime` green (single-threaded; the `builtin_prototype_methods_reject_dynamic_new` flake passes single-threaded). 38 files (35 modified + 3 new), +~1.7k lines.

Walls 17+ (iterare chain-fold, RegExp identity, …) continue in follow-ups toward a full `Hello World!`.

> **Rebase note:** based on the #5710 base commit (the verified base). The touched hot files have drifted on current `main`, so this needs a rebase before merge — opened now to bank/track the verified work.

https://claude.ai/code/session_017S2d3tRok3oMbi6AwfJyUU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for `Map`/`Set` subclasses, including iteration, spreading, `super()` initialization, and native collection method calls.
  * Added broader support for computed method calls and inherited prototype dispatch on native handles.

* **Bug Fixes**
  * Fixed equality checks to avoid incorrect results when mixing strings with other value types.
  * Improved property lookup for class constructors, class instances, and prototype-backed handles.
  * Fixed generator and class capture handling in nested function bodies.
  * Updated module wrapping to handle `reflect-metadata` more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->