### PR TITLE
fix(object): #5736 — make own_key_present O(1) on wide objects so Object.values/entries aren't O(n²)

### DIFF
--- a/crates/perry-runtime/src/object/object_ops/keys_array.rs
+++ b/crates/perry-runtime/src/object/object_ops/keys_array.rs
@@ -181,6 +181,32 @@ pub(crate) unsafe fn own_key_present(
     if key_count > 65536 {
         return false;
     }
+    // #5736: a wide object — e.g. a barrel `export *` namespace with thousands
+    // of re-exported bindings — made this an O(n) keys_array scan, so callers
+    // that re-check every own key in a loop (`Object.values` / `Object.entries`,
+    // which call `own_key_present` per key) ran O(n²). Probe the shared
+    // wide-object key→slot index first: a hit is O(1). A miss falls through to
+    // the linear scan below, so an absent key — or a present key whose index
+    // entry was dropped as stale — is still answered correctly. The index is an
+    // accelerator, never authoritative (it revalidates every hit against the
+    // live slot via `js_string_key_matches`), and is the same map the read-path
+    // getter maintains for these objects.
+    if key_count >= super::super::field_get_set::WIDE_KEY_INDEX_MIN_KEYS {
+        let key_bytes_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        let key_len = (*key).byte_len as usize;
+        let key_bytes = std::slice::from_raw_parts(key_bytes_ptr, key_len);
+        if super::super::field_get_set::wide_key_index_lookup(
+            keys as usize,
+            key_bytes,
+            key,
+            keys,
+            key_count,
+        )
+        .is_some()
+        {
+            return true;
+        }
+    }
     for i in 0..key_count {
         let stored = crate::array::js_array_get(keys, i as u32);
         // #1781: SSO-aware match — `hasOwnProperty("id")` previously

--- a/crates/perry-runtime/src/object/tests.rs
+++ b/crates/perry-runtime/src/object/tests.rs
@@ -795,15 +795,21 @@ fn wide_object_own_key_present_uses_index_and_object_values_is_complete() {
             n,
             "Object.values must yield one value per key"
         );
-        let mut sum = 0.0;
+        // Track each payload so a balanced duplicate/omission can't slip past a
+        // length+sum check: every value 0..n must appear exactly once.
+        let mut seen = vec![false; n as usize];
         for i in 0..n {
             let v = crate::array::js_array_get(values, i);
-            sum += f64::from_bits(v.bits());
+            let num = f64::from_bits(v.bits());
+            let idx = num as usize;
+            assert_eq!(num, idx as f64, "Object.values must yield integer payloads");
+            assert!((idx as u32) < n, "Object.values yielded out-of-range value {num}");
+            assert!(!seen[idx], "Object.values yielded duplicate value {idx}");
+            seen[idx] = true;
         }
-        // 0 + 1 + … + 599 = 599*600/2 = 179700
-        assert_eq!(
-            sum, 179_700.0,
-            "Object.values must yield exactly the set values"
+        assert!(
+            seen.into_iter().all(|hit| hit),
+            "Object.values missed at least one value"
         );
     }
 }

--- a/crates/perry-runtime/src/object/tests.rs
+++ b/crates/perry-runtime/src/object/tests.rs
@@ -778,7 +778,10 @@ fn wide_object_own_key_present_uses_index_and_object_values_is_complete() {
         for i in [0u32, 1, 42, 256, 257, 300, 599] {
             let name = format!("w{}", i);
             let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-            assert!(own_key_present(obj, key), "present key {name} must be found");
+            assert!(
+                own_key_present(obj, key),
+                "present key {name} must be found"
+            );
         }
         // Absent keys fall through the index miss to the linear scan → false.
         for name in ["nope", "w600", "w-1", ""] {
@@ -803,7 +806,10 @@ fn wide_object_own_key_present_uses_index_and_object_values_is_complete() {
             let num = f64::from_bits(v.bits());
             let idx = num as usize;
             assert_eq!(num, idx as f64, "Object.values must yield integer payloads");
-            assert!((idx as u32) < n, "Object.values yielded out-of-range value {num}");
+            assert!(
+                (idx as u32) < n,
+                "Object.values yielded out-of-range value {num}"
+            );
             assert!(!seen[idx], "Object.values yielded duplicate value {idx}");
             seen[idx] = true;
         }

--- a/crates/perry-runtime/src/object/tests.rs
+++ b/crates/perry-runtime/src/object/tests.rs
@@ -759,6 +759,55 @@ fn wide_object_index_reads_and_descriptor_writes() {
     }
 }
 
+/// #5736: `own_key_present` on a wide object (≥257 keys — e.g. a barrel
+/// `export *` namespace) must use the O(1) wide-key index rather than an O(n)
+/// keys_array scan, so `Object.values`/`Object.entries` (which re-check every
+/// own key) don't degrade to O(n²). Correctness must be preserved: present keys
+/// resolve, absent keys don't, and `Object.values` yields every value.
+#[test]
+fn wide_object_own_key_present_uses_index_and_object_values_is_complete() {
+    unsafe {
+        let obj = js_object_alloc(0, 0);
+        let n = 600u32;
+        for i in 0..n {
+            let name = format!("w{}", i);
+            let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+            js_object_set_field_by_name(obj, key, i as f64);
+        }
+        // Every present key is found through the wide-index probe.
+        for i in [0u32, 1, 42, 256, 257, 300, 599] {
+            let name = format!("w{}", i);
+            let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+            assert!(own_key_present(obj, key), "present key {name} must be found");
+        }
+        // Absent keys fall through the index miss to the linear scan → false.
+        for name in ["nope", "w600", "w-1", ""] {
+            let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+            assert!(
+                !own_key_present(obj, key),
+                "absent key {name:?} must not be found"
+            );
+        }
+        // `Object.values` must still enumerate every value exactly once.
+        let values = crate::object::js_object_values(obj as *const ObjectHeader);
+        assert_eq!(
+            crate::array::js_array_length(values),
+            n,
+            "Object.values must yield one value per key"
+        );
+        let mut sum = 0.0;
+        for i in 0..n {
+            let v = crate::array::js_array_get(values, i);
+            sum += f64::from_bits(v.bits());
+        }
+        // 0 + 1 + … + 599 = 599*600/2 = 179700
+        assert_eq!(
+            sum, 179_700.0,
+            "Object.values must yield exactly the set values"
+        );
+    }
+}
+
 /// `js_object_to_string` must NOT dereference a handle-band value (a Web Fetch
 /// `Headers`/`Request`/`Response`/`Blob` registry id, or any other small native
 /// handle) as a heap pointer. Such ids are NaN-boxed as `POINTER_TAG` values but


### PR DESCRIPTION
## Problem

Fixes #5736 (reported by @jdalton). Compiled-binary cold start appeared to scale ~linearly at **~3.4 ms/module**. Profiling the repro shows the cost is **not** module init — 240 trivial modules behind a barrel initialize in ~5 ms (~0.02 ms/module). The cost is the entry's `Object.values(mods)` over the `export *` **barrel namespace**, which was **O(modules²)**.

## Root cause

`Object.values` / `Object.entries` re-check every own key via `own_key_present` (an earlier value read can fire a getter that deletes a later key, so the key set is re-validated per element). `own_key_present` did an **O(n) linear scan** of the object's `keys_array`. For a star-export namespace with thousands of bindings, that's O(n) × n = **O(n²)**.

Isolation confirms it:
- `Object.keys(ns)` (names only) — **flat** (K=240: 10.4 ms)
- `Object.values(ns)` (resolves each value → per-key `own_key_present`) — **O(n²)** (K=240: 140 ms)
- barrel imported but *not* enumerated — 5.5 ms (modules init fine)

## Fix

The read-path getter already builds an O(1) key→slot index for wide objects (≥257 keys, #5054). `own_key_present` simply wasn't using it. Probe that index first; a hit is O(1), a **miss falls through to the existing linear scan**, so an absent key (or a present key whose index entry was dropped as stale) is still answered correctly — the index revalidates every hit against the live slot via `js_string_key_matches`. The change is a **no-op below the 257-key threshold**, so ordinary objects are unaffected.

## Validation

Repro (`gen.mjs` from the issue: K trivial modules, a barrel, entry does `Object.values(mods).filter(...)`):

| K | before | after |
| --- | --- | --- |
| 60 | 16.9 ms | 9.8 ms |
| 120 | 42.0 ms | 10.7 ms |
| 240 | **140.1 ms** | **12.3 ms** |

Per-module slope: **~3.4 ms/module → ~0** (flat). Output is identical before/after.

- Full `perry-runtime object::` test suite passes (the lone `closure_name_and_length_ignore_plain_assignment` blip is the repo's known parallel-execution side-table flake — passes in isolation, and is on a path my change doesn't touch).
- Adds `wide_object_own_key_present_uses_index_and_object_values_is_complete`: on a 600-key object, asserts present keys resolve, absent keys are rejected, and `Object.values` enumerates every value exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance of property existence checks for large objects by using a faster key lookup path first, while preserving exact behavior via a safe fallback.
  * Strengthened correctness of `Object.values` for large objects to ensure all expected values are returned with no duplicates or omissions, including boundary cases.
* **Tests**
  * Added a regression test for wide objects (600 keys) covering `ownKeyPresent` and `Object.values`, including present, absent, malformed, and edge-case keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->