### PR TITLE
fix(runtime): #5740 — fix abi_trampoline replace_expr! macro so Perry builds from source on x86_64-Windows (Rust 1.96)

### DIFF
--- a/crates/perry-runtime/src/abi_trampoline.rs
+++ b/crates/perry-runtime/src/abi_trampoline.rs
@@ -231,7 +231,7 @@ unsafe fn call_all_f64_fallback(func_ptr: usize, args: &[f64]) -> f64 {
     }
     macro_rules! arm {
         ($($i:expr),*) => {{
-            let f: extern "C" fn($(replace_expr!($i f64)),*) -> f64 =
+            let f: extern "C" fn($(replace_expr!($i, f64)),*) -> f64 =
                 std::mem::transmute(func_ptr);
             f($(a(args, $i)),*)
         }};


### PR DESCRIPTION
## Problem

Partially addresses #5740 (reported by @YC-CLT). Building Perry **from source on an x86_64 Windows host** with Rust 1.96 fails to compile:

```
error: no rules expected `f64`
   --> crates/perry-runtime/src/abi_trampoline.rs:234
```

`call_all_f64_fallback` invokes `replace_expr!($i f64)` (no comma), but the macro is defined as `($_t:expr, $sub:ty)`. Rust 1.96 rejects the mismatched invocation.

This block is `#[cfg(not(any(target_arch = "aarch64", all(target_arch = "x86_64", not(target_os = "windows")))))]`, so it's inactive on the aarch64 / x86_64-unix hosts CI builds on — which is why it slipped through — but it **is** active on x86_64-Windows host builds.

## Fix

One character: pass the comma so the invocation matches the matcher.

## Verification

`rustc 1.96.0` (same as the reporter), compiling the real `call_all_f64_fallback` body standalone:
- **before** (`replace_expr!($i f64)`): `error: no rules expected f64` ✅ reproduces the report
- **after** (`replace_expr!($i, f64)`): compiles cleanly ✅

(I couldn't exercise it through a normal host build — this host is aarch64, so the fallback is cfg'd out — but the standalone compile of the exact edited function on 1.96.0 is conclusive for the macro.)

## Scope note

This is one of several issues in #5740. The remaining items are Windows-host / Android-NDK-specific (response-file backslash quoting for GNU-style clang/lld, the NDK `clang.cmd`-via-`cmd.exe` invocation, and the Android default-output path). They can't be verified without a Windows host + Android NDK (neither available here), so I've left a detailed analysis on the issue rather than submit them blind. Note the response-file mechanism for the "command line too long" error already exists on `main` (`rewrite_link_with_response_file`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for a low-level function signature conversion, helping certain calls use the correct parameter types during runtime.
  * Fixed a macro-generated fallback path so it builds the expected function signature more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->