### PR TITLE
fix(codegen): #5742 — map android-x86_64 to an ELF triple in resolve_target_triple

### DIFF
--- a/crates/perry-codegen/src/codegen/helpers.rs
+++ b/crates/perry-codegen/src/codegen/helpers.rs
@@ -516,6 +516,13 @@ pub fn resolve_target_triple(name: &str) -> Option<String> {
         "harmonyos" => Some("aarch64-unknown-linux-ohos".to_string()),
         "harmonyos-simulator" => Some("x86_64-unknown-linux-ohos".to_string()),
         "android" => Some("aarch64-unknown-linux-android".to_string()),
+        // #5742: Android x86_64 (emulator / x86_64 devices). Without this arm
+        // `resolve_target_triple` returned None for `--target android-x86_64`,
+        // so codegen fell back to the host triple (e.g. x86_64-pc-windows-msvc)
+        // and emitted COFF objects, which the Android linker rejects with
+        // `unknown file type`. Mirrors the `-unknown-` LLVM-triple form of the
+        // arm64 `android` arm above (cf. harmonyos / harmonyos-simulator).
+        "android-x86_64" => Some("x86_64-unknown-linux-android".to_string()),
         // Wear OS is Android-on-a-watch: same arm64 Android object format.
         "wearos" => Some("aarch64-unknown-linux-android".to_string()),
         "linux" => Some("x86_64-unknown-linux-gnu".to_string()),
@@ -1135,4 +1142,27 @@ pub(super) fn emit_namespace_populator(
     crate::expr::emit_root_nanbox_store_on_block(blk, &result, &format!("@{}", ns_name));
     let addr_i64 = blk.ptrtoint(&format!("@{}", ns_name), I64);
     blk.call_void("js_gc_register_global_root", &[(I64, &addr_i64)]);
+}
+
+#[cfg(test)]
+mod resolve_target_triple_tests {
+    use super::resolve_target_triple;
+
+    #[test]
+    fn android_targets_resolve_to_android_elf_triples() {
+        // #5742: `android-x86_64` must resolve (it previously returned None and
+        // codegen fell back to the host triple, emitting COFF the Android
+        // linker rejects). Both Android arms use the `-unknown-linux-android`
+        // LLVM form so the emitted objects are ELF for the right arch.
+        assert_eq!(
+            resolve_target_triple("android").as_deref(),
+            Some("aarch64-unknown-linux-android")
+        );
+        assert_eq!(
+            resolve_target_triple("android-x86_64").as_deref(),
+            Some("x86_64-unknown-linux-android")
+        );
+        // Unknown targets still fall through to None.
+        assert_eq!(resolve_target_triple("android-mips"), None);
+    }
 }


### PR DESCRIPTION
## Problem

Partially addresses #5742 (reported by @YC-CLT). `--target android-x86_64` produced **Windows COFF** objects (`64 86` magic = `IMAGE_FILE_MACHINE_AMD64`) instead of Android ELF, so linking failed:

```
ld.lld: error: ...o: unknown file type
```

Root cause (the primary one in the report): `resolve_target_triple` had no `android-x86_64` arm, so it returned `None` and codegen fell back to the **host** triple (e.g. `x86_64-pc-windows-msvc`) — hence COFF.

## Fix

Add the arm mapping `android-x86_64` → `x86_64-unknown-linux-android`, mirroring the `-unknown-linux-android` LLVM form of the existing arm64 `android` arm (and consistent with the `android-x86_64` handling already present in `library_search.rs` / `optimized_libs/driver.rs`). Purely additive — it cannot affect any other target, and the current behavior is a hard link failure.

## Verification

- New unit test `android_targets_resolve_to_android_elf_triples` asserts the `android` and `android-x86_64` mappings and that unknown `android-*` still falls through to `None`. Passes.
- `perry-codegen` compiles.

I can't run an end-to-end Android x86_64 build here (no Android NDK / emulator on this host), so this PR is scoped to the codegen object-format root cause, which is self-contained and unit-testable. The remaining `is_android` / default-output / strip call sites the report lists (for full `--target android-x86_64` parity) are noted on the issue with a suggested prefix-matching/centralization approach — those need NDK verification, ideally from the reporter who has a working build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android target handling so `android-x86_64` now maps correctly to the expected build target.
  * Prevented fallback to an incompatible host target for this configuration, which helps avoid invalid output artifacts.
  * Added coverage for supported and unsupported Android target values to keep target resolution consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->