### PR TITLE
fix(hir): #5703 — apply default-parameter prologue for class setters

### DIFF
--- a/crates/perry-hir/src/lower_decl/class_members.rs
+++ b/crates/perry-hir/src/lower_decl/class_members.rs
@@ -805,6 +805,17 @@ pub fn lower_setter_method_with_name(
             continue;
         }
         let param_type = extract_param_type_with_ctx(&param.pat, Some(ctx));
+        // #5703: a setter with a defaulted parameter (`set a(_ = expr)`) must
+        // apply the default when invoked with `undefined` (e.g. `C.a =
+        // undefined`). Previously the setter param dropped its default
+        // (`default: None`) and emitted no prologue, so the default expression
+        // never ran. Mirror the constructor/method path: lower the default
+        // BEFORE defining the param local so its references resolve to the
+        // enclosing scope rather than the param or the body's hoisted `var`s —
+        // i.e. the separate parameter/body VariableEnvironment the spec
+        // mandates (test262 scope-*-setter-paramsbody-var-open) — then emit the
+        // `if (param === undefined) param = <default>` prologue below.
+        let param_default = get_param_default(ctx, &param.pat)?;
         let param_id = ctx.define_local(param_name.clone(), param_type.clone());
         ctx.shadow_native_instance_if_present(&param_name);
         ctx.shadow_native_module_if_present(&param_name);
@@ -812,7 +823,7 @@ pub fn lower_setter_method_with_name(
             id: param_id,
             name: param_name,
             ty: param_type,
-            default: None,
+            default: param_default,
             decorators: Vec::new(),
             is_rest: false,
             arguments_object: None,
@@ -844,6 +855,17 @@ pub fn lower_setter_method_with_name(
     if !destructuring_stmts.is_empty() {
         destructuring_stmts.append(&mut body);
         body = destructuring_stmts;
+    }
+
+    // #5703: prepend `if (param === undefined) param = <default>` for a
+    // defaulted setter parameter, so an under-supplied / `undefined` assignment
+    // (`C.a = undefined`) applies the default. Runs before any destructuring
+    // prologue (which destructures the already-defaulted param).
+    let default_stmts = build_default_param_stmts(&params);
+    if !default_stmts.is_empty() {
+        let mut new_body = default_stmts;
+        new_body.append(&mut body);
+        body = new_body;
     }
 
     ctx.exit_strict_mode();

--- a/crates/perry/tests/issue_5703_class_expr_static_dflt_params.rs
+++ b/crates/perry/tests/issue_5703_class_expr_static_dflt_params.rs
@@ -184,3 +184,35 @@ var C = class {
         "default applies inside a static async generator"
     );
 }
+
+/// A class-expression static SETTER with a defaulted parameter, invoked via
+/// assignment of `undefined` (`C.a = undefined`). Pre-fix the setter dropped
+/// its default (`default: None`, no prologue), so the default expression never
+/// ran and `probeParams` stayed `undefined`. The default must also evaluate in
+/// the parameter VariableEnvironment — its `x` closure sees the OUTER `x`
+/// ("outside"), distinct from the setter body's `var x = "inside"` — matching
+/// test262 `language/expressions/class/scope-static-setter-paramsbody-var-open`.
+#[test]
+fn class_expr_static_setter_default_param_scope() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+var x = "outside";
+var probeParams: any, probeBody: any;
+var C: any = class {
+  static set a(_ = (probeParams = function () { return x; })) {
+    var x = "inside";
+    probeBody = function () { return x; };
+  }
+};
+C.a = undefined;
+console.log(probeParams());
+console.log(probeBody());
+"#,
+    );
+    assert_eq!(
+        stdout, "outside\ninside\n",
+        "defaulted setter param runs its default in the parameter scope"
+    );
+}


### PR DESCRIPTION
## Summary

Closes 1 of the 11 residual `language/expressions/class` failures tracked in #5703 — the static-setter case `scope-static-setter-paramsbody-var-open.js` ("value is not a function"). While triaging the other 10 I found the ticket's premise is **stale/mis-scoped** (details below), so this PR ships the one genuinely-tractable, in-theme fix and documents the rest precisely.

## What this fixes

A class **setter** with a defaulted parameter (`set a(_ = expr)`) silently dropped its default. `lower_setter_method_with_name` built the `Param` with `default: None` and emitted no `if (param === undefined) param = <default>` prologue — only destructuring was handled. So `C.a = undefined` never ran the default expression.

Fix mirrors the constructor/method path:
- lower the default via `get_param_default` **in the param loop, before `define_local`**, so the default's references resolve to the enclosing scope rather than the param or the body's hoisted `var`s — the separate parameter/body *VariableEnvironment* the spec mandates;
- prepend `build_default_param_stmts(&params)` to the body.

The test's `probeParams` closure (created in the param default) then binds the **outer** `x` (`"outside"`) while the body's `var x = "inside"` closure binds the body `x` — byte-for-byte node parity. Applies to instance and static setters; inert for setters with no declared default.

```
var C = class { static set a(_ = (probeParams = function(){ return x })) { var x = "inside"; probeBody = function(){ return x } } };
C.a = undefined;
// before: probeParams === undefined  →  TypeError: value is not a function
// after:  probeParams() === "outside",  probeBody() === "inside"   (== node)
```

Regression test: `class_expr_static_setter_default_param_scope` (all 6 cases in `issue_5703_class_expr_static_dflt_params` green).

## Before / after (`language/expressions/class`)

- Before: 11 failing (per the #5703 snapshot).
- After: **10 failing** — the setter case passes; verified byte-for-byte against `node --experimental-strip-types` (which is exactly what the self-validating test262 case asserts). No regressions: instance/static setters with and without defaults all match node; the change is gated by `build_default_param_stmts` (inert unless a default is declared).

## The remaining 10 — NOT a class-expression regression

The other 10 listed cases (`async-gen-method-static/yield-star-{sync,async}-{return,throw}`, `yield-star-next-non-object-ignores-then`, and their `elements/async-gen-private-method-static` twins) are **not** about class-expression default params and **not** a #5662 regression. They are a general **`yield*` return/throw/next delegation** gap in async generators:

- They fail **identically for class *statements*** (`language/statements/class/async-gen-method-static`), for plain top-level `async function*`, and for instance methods — the class form is irrelevant. (The statement copies are bucketed `diff` rather than `runtime-fail` only because an async test's failure still exits 0, so the parity gate on `expressions/class` is what surfaced them.)
- Root cause: a `yield*`-delegating generator resumed via `.return(v)`/`.throw(e)` never forwards to the delegated iterator's `return`/`throw`. Perry *does* route `.throw()`→catch and `.return()`→finally into linearized states, but for **async** generators the abrupt-resume path (`generator/lower/abrupt.rs::build_async_catch_route_body`) hard-codes a `{value: undefined, done: false}` return and has no continuation loop (`throw_continuation = None` at `generator/lower.rs`, deliberately, "to stay byte-identical"). A desugar that drives the delegation through a `try/catch` makes the inner iterator's methods fire in the correct spec order, but the value yielded after the resume is dropped and the loop can't continue.

Closing those 10 requires enabling async-generator abrupt-resume continuation (real yielded-value packaging + continuation loop, like sync generators already have) — a substantial, higher-risk core change to the generator state machine, orthogonal to class-expression lowering. Recommend tracking it as its own issue rather than expanding this PR.

Refs #5703.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed setter parameters with default values so the default is applied when the setter is called with `undefined`.
  * Improved handling of setter parameters in class expressions to preserve the expected scope behavior.
* **Tests**
  * Added a regression test covering a static class setter with a defaulted parameter to verify the correct runtime output and scope capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->