### PR TITLE
fix(temporal): #5587 — validate ZonedDateTime.from options + getTimeZoneTransition direction

### DIFF
--- a/crates/perry-runtime/src/temporal/options.rs
+++ b/crates/perry-runtime/src/temporal/options.rs
@@ -1431,15 +1431,24 @@ pub fn timezone(v: f64) -> TimeZone {
 /// Parse a `getTimeZoneTransition` direction argument — a `"next"`/`"previous"`
 /// string or a `{ direction }` object.
 pub fn transition_direction(v: f64) -> TransitionDirection {
+    // `GetDirectionOption`: a String is used directly; otherwise the argument is
+    // run through `GetOptionsObject`, which throws a **TypeError** for `undefined`
+    // (the option is required) and for any non-object primitive (boolean, number,
+    // bigint, symbol, null). Only a malformed *string* / object `direction` value
+    // is a RangeError.
     let s = if JSValue::from_bits(v.to_bits()).is_string() {
         read_string(v)
+    } else if is_undefined(v) {
+        type_error("getTimeZoneTransition: direction option is required".to_string());
     } else if let Some(obj) = as_obj(v) {
         match str_field_coerce(obj, "direction") {
             Some(s) => s,
             None => range("getTimeZoneTransition requires a direction"),
         }
     } else {
-        range("getTimeZoneTransition requires a direction string or object");
+        type_error(
+            "getTimeZoneTransition: direction must be a string or an options object".to_string(),
+        );
     };
     TransitionDirection::from_str(&s).unwrap_or_else(|_| range("Invalid transition direction"))
 }

--- a/crates/perry-runtime/src/temporal/zoned_date_time.rs
+++ b/crates/perry-runtime/src/temporal/zoned_date_time.rs
@@ -87,6 +87,13 @@ fn coerce_zdt(v: f64) -> ZonedDateTime {
 /// consulted for the string + property-bag forms).
 fn coerce_zdt_with_options(v: f64, opts: f64) -> ZonedDateTime {
     if let Some(TemporalValue::ZonedDateTime(z)) = temporal_value_ref(v) {
+        // The result is a clone, but `ToTemporalZonedDateTime` still performs
+        // `GetOptionsObject` and reads disambiguation → offset → overflow in spec
+        // order, so a bad options type (TypeError) or invalid option value
+        // (RangeError) is observed *before* the instance is cloned.
+        let _ = super::options::disambiguation(opts);
+        let _ = super::options::offset_option(opts);
+        let _ = super::options::overflow(opts);
         return z.clone();
     }
     if let Some(partial) = super::options::zoned_partial(v) {
@@ -105,11 +112,25 @@ fn coerce_zdt_with_options(v: f64, opts: f64) -> ZonedDateTime {
     let jv = JSValue::from_bits(v.to_bits());
     if jv.is_string() {
         // Parse the string BEFORE reading options (spec order: an invalid string
-        // throws a RangeError before any option is touched).
+        // throws a RangeError before `GetOptionsObject` — which would otherwise
+        // throw a TypeError for a non-object options value). `from_utf8` couples
+        // parsing with offset interpretation, so validate the string structurally
+        // with a lenient offset disambiguation (`Ignore` never rejects on an
+        // offset mismatch) and discard the result; only a malformed IXDTF string
+        // throws here. The real parse below applies the requested options.
         let s = dispatch::read_string(v);
+        let _ = ok_or_throw(ZonedDateTime::from_utf8(
+            s.as_bytes(),
+            Disambiguation::Compatible,
+            OffsetDisambiguation::Ignore,
+        ));
+        // Now read + validate options in spec order: disambiguation, offset,
+        // overflow. `overflow` carries no effect for the string form but is still
+        // read (a bad value is a RangeError — `overflow-invalid-string`).
         let disambiguation =
             super::options::disambiguation(opts).unwrap_or(Disambiguation::Compatible);
         let offset = super::options::offset_option(opts).unwrap_or(OffsetDisambiguation::Reject);
+        let _ = super::options::overflow(opts);
         return ok_or_throw(ZonedDateTime::from_utf8(
             s.as_bytes(),
             disambiguation,


### PR DESCRIPTION
## Summary

Closes a coherent cluster of **12** failing `built-ins/Temporal/ZonedDateTime` test262 cases from the #5587 tracker — all *negative* tests where Perry either failed to throw, or threw the wrong error type, when validating option arguments. The bugs were pure binding-glue: `ToTemporalZonedDateTime` and `GetDirectionOption` were skipping or mis-ordering their spec validation steps.

Three fixes, all confined to the ZonedDateTime paths (no codegen / cross-type impact):

1. **`from(zdtInstance, options)` clone path** read *no* options at all — it returned the clone immediately. Per spec the options bag is still processed (`GetOptionsObject`, then `disambiguation` → `offset` → `overflow`), so a bad options **type** (TypeError) or **value** (RangeError) must be observed *before* cloning. Now reads + validates all three first.

2. **`from(string, options)` path** never read `overflow` (an invalid value is a RangeError), and validated the options object *before* parsing the string — so an invalid IXDTF string + non-object options threw a TypeError where the spec requires a RangeError (the string parse precedes `GetOptionsObject`). Now structurally pre-parses the string with a lenient offset disambiguation to surface the RangeError first, then reads `disambiguation`/`offset`/`overflow`.

3. **`getTimeZoneTransition(direction)`** threw a RangeError for `undefined` and non-object primitives; `GetOptionsObject` makes those a **TypeError** (the direction option is required). Only a malformed string/object `direction` value stays a RangeError.

## Tests fixed (12)

```
from/overflow-invalid-string.js          from/overflow-wrong-type.js
from/offset-invalid-string.js            from/offset-wrong-type.js
from/disambiguation-invalid-string.js    from/disambiguation-wrong-type.js
from/options-wrong-type.js               from/order-of-operations.js
from/observable-get-overflow-argument-primitive.js
from/observable-get-overflow-argument-string-invalid.js
prototype/getTimeZoneTransition/options-undefined.js
prototype/getTimeZoneTransition/wrong-type.js
```

## Validation

- Each of the 12 cases assembled the way the runner does and run under `perry` → all exit 0 (pass).
- Full `scripts/test262_subset.py --dir built-ins/Temporal/ZonedDateTime` sweep (901 cases): **97.8% self-validated, zero regressions** — the 20 remaining failures are all pre-existing entries from the #5587 baseline (subclassing, epoch-nanoseconds limits, toString-precision, rounding ceil — separate root causes, out of scope here).

Per repo convention, the version bump + CHANGELOG entry are left for the maintainer to fold in at merge.

Refs #5587.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for Temporal time-zone transition direction inputs, with clearer TypeError and RangeError behavior for missing, invalid, or malformed values.
  * Adjusted Temporal ZonedDateTime option handling so validation errors are raised in a more consistent order for both existing date-time values and string inputs.
  * Malformed ZonedDateTime strings now fail before option-related errors are processed, matching expected validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->