### PR TITLE
fix(runtime): String built-ins throw TypeError on Symbol arg coercion (#5591)

### DIFF
--- a/crates/perry-codegen/src/lower_string_method.rs
+++ b/crates/perry-codegen/src/lower_string_method.rs
@@ -1006,7 +1006,12 @@ pub(crate) fn lower_string_method(
                 &[(DOUBLE, &other_box), (I32, &method_id)],
             );
             let result_i32 = if let Some(pos_d) = pos_d {
-                let pos_i32 = blk.fptosi(DOUBLE, &pos_d, I32);
+                // ToIntegerOrInfinity(position): route through the runtime
+                // coercion (not a raw `fptosi` on the NaN-boxed value) so a
+                // boolean/numeric-string/`{valueOf}` coerces per spec and a
+                // Symbol position throws a TypeError (matches the dynamic
+                // dispatch path and the `includes` arm below).
+                let pos_i32 = blk.call(I32, "js_string_index_to_i32", &[(DOUBLE, &pos_d)]);
                 let runtime_fn = if property == "startsWith" {
                     "js_string_starts_with_at"
                 } else {

--- a/crates/perry-runtime/src/builtins/mod.rs
+++ b/crates/perry-runtime/src/builtins/mod.rs
@@ -104,7 +104,7 @@ pub(crate) use globals::{drain_queued_microtasks_count, queued_microtasks_pendin
 pub use numbers::{
     js_is_finite, js_is_nan, js_number_coerce, js_number_is_finite, js_number_is_integer,
     js_number_is_nan, js_number_is_safe_integer, js_parse_float, js_parse_int, js_string_coerce,
-    js_to_integer_or_infinity,
+    js_to_integer_or_infinity, reject_symbol_to_string,
 };
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/builtins/numbers.rs
+++ b/crates/perry-runtime/src/builtins/numbers.rs
@@ -611,6 +611,21 @@ pub extern "C" fn js_string_coerce(value: f64) -> *mut StringHeader {
     js_string_from_bytes(result.as_ptr(), result.len() as u32)
 }
 
+/// Spec `ToString` (ECMA-262 §7.1.17) rejects a Symbol with a `TypeError`.
+/// The lenient `js_string_coerce` / `js_jsvalue_to_string` paths instead
+/// produce a `"Symbol(desc)"` descriptive string — correct for `String(sym)`,
+/// `console.log`, etc., but NOT for the abstract ToString operation invoked by
+/// string built-ins on their arguments (`"".padEnd(1, sym)`,
+/// `"".startsWith(sym)`, `String.raw({raw:[sym]})`, `"".normalize(sym)`). Those
+/// call sites invoke this guard *before* coercing so a Symbol argument throws as
+/// the spec requires.
+#[inline]
+pub fn reject_symbol_to_string(value: f64) {
+    if unsafe { crate::symbol::js_is_symbol(value) } != 0 {
+        crate::collection_iter::throw_type_error("Cannot convert a Symbol value to a string");
+    }
+}
+
 /// isNaN(value) -> boolean
 /// Returns true if value is NaN.
 #[no_mangle]

--- a/crates/perry-runtime/src/string/compare.rs
+++ b/crates/perry-runtime/src/string/compare.rs
@@ -196,6 +196,9 @@ pub extern "C" fn js_string_search_value_to_string(
     if string_search_is_regexp(value) {
         throw_regexp_search_type_error(method_id);
     }
+    // ToString(searchString): a Symbol throws a TypeError (§7.1.17) rather than
+    // stringifying to "Symbol(...)".
+    crate::builtins::reject_symbol_to_string(value);
     crate::value::js_jsvalue_to_string(value)
 }
 
@@ -405,6 +408,9 @@ pub extern "C" fn js_string_normalize(
     let form_owned: String = if form_jsval.is_undefined() {
         "NFC".to_string()
     } else {
+        // ToString(form) runs before the form-validity check, so a Symbol form
+        // throws a TypeError (§7.1.17) — not the RangeError of an invalid form.
+        crate::builtins::reject_symbol_to_string(form_value);
         let form_ptr = crate::value::js_jsvalue_to_string(form_value);
         if is_valid_string_ptr(form_ptr) {
             string_as_str(form_ptr).to_string()

--- a/crates/perry-runtime/src/string/pad.rs
+++ b/crates/perry-runtime/src/string/pad.rs
@@ -21,6 +21,9 @@ pub extern "C" fn js_string_pad_fill(value: f64) -> *mut StringHeader {
     if jv.is_undefined() {
         return std::ptr::null_mut();
     }
+    // ToString(fillString): a Symbol fill throws a TypeError (§7.1.17), it does
+    // NOT stringify to "Symbol(...)" the way the lenient `String()` path would.
+    crate::builtins::reject_symbol_to_string(value);
     crate::builtins::js_string_coerce(value)
 }
 

--- a/crates/perry-runtime/src/string/raw.rs
+++ b/crates/perry-runtime/src/string/raw.rs
@@ -46,8 +46,9 @@ pub extern "C" fn js_string_raw(call_site: f64, substitutions: f64) -> *mut Stri
     let mut result = String::new();
     let mut i: u64 = 0;
     loop {
-        // ToString(raw[i])
+        // ToString(raw[i]) — a Symbol segment throws a TypeError (§7.1.17).
         let seg = crate::object::js_object_get_index_polymorphic(raw_handle, i as f64);
+        crate::builtins::reject_symbol_to_string(seg);
         let seg_ptr = crate::value::js_jsvalue_to_string(seg);
         if is_valid_string_ptr(seg_ptr) {
             result.push_str(string_as_str(seg_ptr));
@@ -61,6 +62,8 @@ pub extern "C" fn js_string_raw(call_site: f64, substitutions: f64) -> *mut Stri
         let sub = crate::object::js_object_get_index_polymorphic(subs_handle, i as f64);
         let sub_jsval = crate::value::JSValue::from_bits(sub.to_bits());
         if !sub_jsval.is_undefined() {
+            // ToString(substitution) — a Symbol throws a TypeError (§7.1.17).
+            crate::builtins::reject_symbol_to_string(sub);
             let sub_ptr = crate::value::js_jsvalue_to_string(sub);
             if is_valid_string_ptr(sub_ptr) {
                 result.push_str(string_as_str(sub_ptr));


### PR DESCRIPTION
Part of #5591 (built-ins test262 tail). Fixes the **String-method Symbol/abrupt argument-coercion** subcluster.

## Subcluster
ECMA-262 `ToString` (§7.1.17) and `ToIntegerOrInfinity` reject a Symbol with a `TypeError`; only the lenient `String(sym)` / `console` path is allowed to produce `"Symbol(desc)"`. Several `String` built-ins coerced their arguments through the lenient path (and `startsWith`/`endsWith` *position* used a raw `fptosi` on the NaN-boxed value), so:

- a Symbol argument silently stringified to `"Symbol(...)"` instead of throwing, and
- a boolean / numeric-string / `{valueOf}` position miscoerced or skipped its `valueOf`.

## Fix
A shared `reject_symbol_to_string` guard applies spec `ToString`/`ToInteger` at the affected coercion sites:

- `padStart`/`padEnd` fillString (`js_string_pad_fill`)
- `startsWith`/`endsWith`/`includes` searchString (`js_string_search_value_to_string`)
- `startsWith`/`endsWith` **position**: route through `js_string_index_to_i32` (ToIntegerOrInfinity) instead of `fptosi` — throws on Symbol, runs `valueOf`, and coerces bool/string per spec, matching the dynamic-dispatch and `includes` paths
- `String.prototype.normalize` form (`TypeError` *before* the form-validity `RangeError`)
- `String.raw` `raw[i]` / substitution segments

## Before / after (test262, pinned SHA)
`String/prototype/{padEnd,padStart,startsWith,endsWith,includes}` + `String/raw` slice: **12 → 4** failing. The 4 remaining (`padEnd`/`padStart` `normal-operation` + `observable-operations`) are a separate surrogate/observable-order root cause. `String/prototype/normalize`'s `return-abrupt-from-form-as-symbol` also now passes.

Tests fixed in this subcluster:
- `padEnd`/`padStart`/`exception-fill-string-symbol`
- `startsWith`/`return-abrupt-from-searchstring-as-symbol`
- `startsWith`/`return-abrupt-from-position-as-symbol`
- `startsWith`/`return-abrupt-from-position`
- `startsWith`/`coerced-values-of-position`
- `raw`/`nextkey-is-symbol-throws`
- `raw`/`returns-abrupt-from-substitution-symbol`
- `prototype/normalize`/`return-abrupt-from-form-as-symbol`

No regressions: the full `built-ins/String` slice still shows the same 39 pre-existing failures (all different root causes — `replace`/`indexOf`/`lastIndexOf` boxed-receiver `.call`, `localeCompare`, `split` regex, `toString`/`valueOf` non-generic, `symbol-wrapping`, etc.). `String(sym)`, template-literal and `'' + sym` behavior unchanged.

## Out of scope
`built-ins/String/symbol-wrapping.js` (`new String(sym)`) is intentionally left: that path pre-coerces the arg in the HIR via the `StringCoerce` node shared with bare `String()`, so a correct fix is a separate HIR-level change rather than a runtime guard.