### PR TITLE
fix(async): async-generator yield* return() forwarding + non-object next() (#5592)

### DIFF
--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -335,17 +335,35 @@ fn async_from_sync_rest_args(rest: f64) -> (usize, f64) {
 
 fn async_from_sync_call_raw(iter: f64, method: &[u8], args: &[f64]) -> Result<Option<f64>, f64> {
     let method_value = named_field(iter, method);
-    if method_value.to_bits() == crate::value::TAG_UNDEFINED {
+    // Spec `%AsyncFromSyncIteratorPrototype%.{return,throw}` (and the sync
+    // `yield *` close) do `GetMethod(syncIterator, name)` ONCE and then
+    // `Call(method, syncIterator, args)` on that captured value. Re-dispatching
+    // by NAME here re-read the property a second time, firing a `get return` /
+    // `get throw` accessor twice and diverging from Node's operation order
+    // (test262 yield-star-sync-return). So when a callable method was found,
+    // invoke the already-fetched value with `this = iter`.
+    let callable = if method_value.to_bits() == crate::value::TAG_UNDEFINED {
         let raw = crate::value::js_nanbox_get_pointer(iter) as usize;
         if method != b"next" || !is_builtin_iterator_class_id(raw) {
             return Ok(None);
         }
+        // A builtin iterator that exposes no readable `next` property: fall back
+        // to method dispatch (string/typed-array iterators tower their `next`
+        // through the class-id method table).
+        false
     } else if !is_callable_value(method_value) {
         return Err(async_from_sync_type_error(
             b"Async-from-sync iterator method is not callable",
         ));
-    }
+    } else {
+        true
+    };
 
+    let prev_this = if callable {
+        Some(crate::object::js_implicit_this_set(iter))
+    } else {
+        None
+    };
     let trap_buf = crate::exception::js_try_push();
     let jumped = unsafe { crate::ffi::setjmp::setjmp(trap_buf as *mut std::os::raw::c_int) };
     let result = if jumped == 0 {
@@ -354,14 +372,18 @@ fn async_from_sync_call_raw(iter: f64, method: &[u8], args: &[f64]) -> Result<Op
         } else {
             args.as_ptr()
         };
-        let value = unsafe {
-            crate::object::js_native_call_method(
-                iter,
-                method.as_ptr() as *const i8,
-                method.len(),
-                args_ptr,
-                args.len(),
-            )
+        let value = if callable {
+            unsafe { crate::closure::js_native_call_value(method_value, args_ptr, args.len()) }
+        } else {
+            unsafe {
+                crate::object::js_native_call_method(
+                    iter,
+                    method.as_ptr() as *const i8,
+                    method.len(),
+                    args_ptr,
+                    args.len(),
+                )
+            }
         };
         Ok(Some(value))
     } else {
@@ -369,6 +391,9 @@ fn async_from_sync_call_raw(iter: f64, method: &[u8], args: &[f64]) -> Result<Op
         crate::exception::js_clear_exception();
         Err(exc)
     };
+    if let Some(prev) = prev_this {
+        crate::object::js_implicit_this_set(prev);
+    }
     crate::exception::js_try_end();
     result
 }

--- a/crates/perry-transform/src/generator/linearize.rs
+++ b/crates/perry-transform/src/generator/linearize.rs
@@ -9,6 +9,16 @@ thread_local! {
     /// thread-local avoids threading a bool through ~14 recursive call sites).
     /// Read by the `yield*` arms to pick the async vs sync delegation protocol.
     static LINEARIZE_IS_ASYNC_GEN: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+
+    /// `yield *` delegation suspend-state intervals collected while linearizing an
+    /// async generator. After linearization the `.return()` closure consults these
+    /// so that `gen.return(v)` while suspended inside a `yield *` forwards to the
+    /// delegated iterator's `return` method (spec `yield *` step 6.c) instead of
+    /// completing the outer generator directly. Same thread-local rationale as
+    /// `LINEARIZE_IS_ASYNC_GEN` (avoids threading a sink through every recursive
+    /// `linearize_body` call site).
+    static LINEARIZE_DELEGATIONS: std::cell::RefCell<Vec<DelegationRoute>> =
+        const { std::cell::RefCell::new(Vec::new()) };
 }
 
 pub(crate) fn set_linearize_async_generator(v: bool) {
@@ -17,6 +27,28 @@ pub(crate) fn set_linearize_async_generator(v: bool) {
 
 fn linearize_async_generator() -> bool {
     LINEARIZE_IS_ASYNC_GEN.with(|c| c.get())
+}
+
+/// Clear any `yield *` delegation routes left over from a previous generator.
+pub(crate) fn reset_delegation_routes() {
+    LINEARIZE_DELEGATIONS.with(|c| c.borrow_mut().clear());
+}
+
+/// Drain the `yield *` delegation routes collected during the last linearization.
+pub(crate) fn take_delegation_routes() -> Vec<DelegationRoute> {
+    LINEARIZE_DELEGATIONS.with(|c| std::mem::take(&mut *c.borrow_mut()))
+}
+
+/// One `yield *` delegation region in an async generator. The outer generator is
+/// "suspended inside this `yield *`" whenever its state id is in
+/// `(suspend_state_lo, suspend_state_hi]` — the same exclusive-lower/inclusive-
+/// upper convention as [`FinallyRoute`]. `iter_id` is the captured delegated
+/// iterator (the `this` for its `return`/`throw` methods).
+#[derive(Clone)]
+pub struct DelegationRoute {
+    pub suspend_state_lo: u32,
+    pub suspend_state_hi: u32,
+    pub iter_id: LocalId,
 }
 
 /// Resolve a `yield*` operand into its iterator. An async generator delegates
@@ -42,6 +74,50 @@ fn delegate_await(call: Expr) -> Expr {
     } else {
         call
     }
+}
+
+/// Spec `yield *` in an **async** generator awaits each delegated
+/// `next()`/`return()`/`throw()` result and then requires it to be an Object —
+/// `If Type(innerResult) is not Object, throw a TypeError exception`
+/// (AsyncGeneratorYield delegation; also enforced by the
+/// `%AsyncFromSyncIteratorPrototype%` wrapper for a wrapped sync iterator).
+/// Returns the guard statement (empty for sync generators, where
+/// `IteratorComplete`/`IteratorValue` read `.done`/`.value` off a primitive via
+/// `GetV` and never throw). `result_id` holds the just-awaited iter-result.
+fn delegate_result_object_check(result_id: LocalId) -> Vec<Stmt> {
+    if !linearize_async_generator() {
+        return Vec::new();
+    }
+    // not Object  <=>  result === null
+    //                  || (typeof result !== "object" && typeof result !== "function")
+    let not_object = Expr::Logical {
+        op: LogicalOp::Or,
+        left: Box::new(Expr::Compare {
+            op: CompareOp::Eq,
+            left: Box::new(Expr::LocalGet(result_id)),
+            right: Box::new(Expr::Null),
+        }),
+        right: Box::new(Expr::Logical {
+            op: LogicalOp::And,
+            left: Box::new(Expr::Compare {
+                op: CompareOp::Ne,
+                left: Box::new(Expr::TypeOf(Box::new(Expr::LocalGet(result_id)))),
+                right: Box::new(Expr::String("object".to_string())),
+            }),
+            right: Box::new(Expr::Compare {
+                op: CompareOp::Ne,
+                left: Box::new(Expr::TypeOf(Box::new(Expr::LocalGet(result_id)))),
+                right: Box::new(Expr::String("function".to_string())),
+            }),
+        }),
+    };
+    vec![Stmt::If {
+        condition: not_object,
+        then_branch: vec![Stmt::Throw(Expr::TypeErrorNew(Box::new(Expr::String(
+            "Iterator result is not an object".to_string(),
+        ))))],
+        else_branch: None,
+    }]
 }
 
 /// Invoke the captured delegated `[[NextMethod]]` (`del_next_id`) with `this` =
@@ -147,10 +223,13 @@ fn emit_yield_star_loop(
             Expr::Undefined,
         ))),
     )));
+    // Async `yield *`: the awaited iter-result must be an Object or `next()`
+    // throws a TypeError (test262 yield-star-next-non-object-ignores-then).
+    current.extend(delegate_result_object_check(del_result_id));
 
     // #1832: in-loop pull forwards the outer resume value (`outer.next(v)` →
     // `sent_id`) into the delegated iterator's `next(v)`.
-    let while_body = vec![
+    let mut while_body = vec![
         // Spec step `received be AsyncGeneratorYield(? IteratorValue(innerResult))`.
         // Unlike a plain `yield x` (which is `AsyncGeneratorYield(? Await(x))` and
         // is handled by the #4777 await pass), the DELEGATED value is NOT awaited:
@@ -174,6 +253,8 @@ fn emit_yield_star_loop(
             ))),
         )),
     ];
+    // Same Object-check on the in-loop pull (async generators only).
+    while_body.extend(delegate_result_object_check(del_result_id));
     let while_stmt = Stmt::While {
         condition: Expr::Unary {
             op: UnaryOp::Not,
@@ -185,6 +266,12 @@ fn emit_yield_star_loop(
         body: while_body,
     };
 
+    // Record the suspend-state interval of the drive loop's single re-yield so
+    // an async `gen.return(v)` issued while suspended here forwards into the
+    // delegated iterator's `return` (spec `yield *` step 6.c) rather than
+    // completing the outer generator outright. The loop's only suspendable state
+    // is the inner `yield`, whose resume state lands in `(lo, hi]`.
+    let deleg_lo = *state_num;
     linearize_body(
         &[while_stmt],
         states,
@@ -196,6 +283,16 @@ fn emit_yield_star_loop(
         catches,
         finallys,
     );
+    if linearize_async_generator() {
+        let deleg_hi = *state_num;
+        LINEARIZE_DELEGATIONS.with(|c| {
+            c.borrow_mut().push(DelegationRoute {
+                suspend_state_lo: deleg_lo,
+                suspend_state_hi: deleg_hi,
+                iter_id: del_iter_id,
+            })
+        });
+    }
 
     // Spec step 6.a.vi: `If done is true, then Return ? IteratorValue(innerResult)`.
     // Read the final result's `.value` exactly once into a dedicated local. This

--- a/crates/perry-transform/src/generator/lower.rs
+++ b/crates/perry-transform/src/generator/lower.rs
@@ -17,8 +17,8 @@ mod yield_await;
 pub(crate) use abrupt::{
     build_abrupt_routing, build_async_catch_route_body, build_async_throw_body,
     build_completion_resume_stmts, build_dispatch_catch_handler, build_finally_run_stmts,
-    catch_route_condition, finally_abrupt_condition, finally_route_condition,
-    rewrite_dispatch_continue_to_suspend, wrap_dispatch_loop,
+    build_yield_star_return_routes, catch_route_condition, finally_abrupt_condition,
+    finally_route_condition, rewrite_dispatch_continue_to_suspend, wrap_dispatch_loop,
 };
 pub(crate) use async_step::{
     build_async_catch_route_body_direct, build_async_step_driver_direct,
@@ -172,6 +172,7 @@ pub fn transform_generator_function_with_extra_captures(
     // async-iterator protocol (await each delegated `next()`); see the `yield*`
     // arms in `linearize.rs`.
     super::linearize::set_linearize_async_generator(is_async_generator);
+    super::linearize::reset_delegation_routes();
     linearize_body(
         &func.body,
         &mut states,
@@ -183,6 +184,10 @@ pub fn transform_generator_function_with_extra_captures(
         &mut catches,
         &mut finallys,
     );
+    // `yield *` delegation regions (async generators only), used below so that
+    // `gen.return(v)` while suspended inside a `yield *` forwards into the
+    // delegated iterator's `return` method (spec `yield *` step 6.c).
+    let delegations = super::linearize::take_delegation_routes();
     let extra_local_ids: Vec<LocalId> = (local_id_before..*next_local_id).collect();
 
     // Push final state (code after last yield / end of function)
@@ -739,6 +744,18 @@ pub fn transform_generator_function_with_extra_captures(
             executing_id,
             Box::new(Expr::Bool(true)),
         )));
+        // Spec `yield *` step 6.c: when suspended inside a `yield *`, `return(v)`
+        // forwards to the delegated iterator's `return` method (async generators
+        // only; `delegations` is empty otherwise). Each route returns on a match,
+        // so control falls through to the generic completion below only when not
+        // suspended in a delegation.
+        return_resume_body.extend(build_yield_star_return_routes(
+            &delegations,
+            state_id,
+            return_param_id,
+            done_id,
+            next_local_id,
+        ));
         // Unhandled path: mark done, run pending non-yielding finallys, return
         // {v, true}. A finally that itself `return`s supersedes `v` (rewritten to
         // an iter-result return inside build_finally_run_stmts); a finally that

--- a/crates/perry-transform/src/generator/lower/abrupt.rs
+++ b/crates/perry-transform/src/generator/lower/abrupt.rs
@@ -599,3 +599,173 @@ pub(crate) fn finally_route_condition(route: &FinallyRoute, state_id: LocalId) -
         }),
     }
 }
+
+/// `result === null || (typeof result !== "object" && typeof result !== "function")`
+/// — `Type(result) is not Object`. Used to enforce the spec requirement that a
+/// delegated `return()`/`next()` result be an Object.
+fn not_object_condition(result: Expr) -> Expr {
+    Expr::Logical {
+        op: LogicalOp::Or,
+        left: Box::new(Expr::Compare {
+            op: CompareOp::Eq,
+            left: Box::new(result.clone()),
+            right: Box::new(Expr::Null),
+        }),
+        right: Box::new(Expr::Logical {
+            op: LogicalOp::And,
+            left: Box::new(Expr::Compare {
+                op: CompareOp::Ne,
+                left: Box::new(Expr::TypeOf(Box::new(result.clone()))),
+                right: Box::new(Expr::String("object".to_string())),
+            }),
+            right: Box::new(Expr::Compare {
+                op: CompareOp::Ne,
+                left: Box::new(Expr::TypeOf(Box::new(result))),
+                right: Box::new(Expr::String("function".to_string())),
+            }),
+        }),
+    }
+}
+
+/// Build the `gen.return(v)` forwarding routes for an async generator's `.return`
+/// closure. When the generator is suspended inside a `yield *` delegation
+/// (`state` within a recorded [`DelegationRoute`] interval), `return(v)` must
+/// forward to the delegated iterator's `return` method rather than completing
+/// the outer generator directly — spec `yield *` step 6.c:
+///
+/// ```text
+///   return = GetMethod(iterator, "return")
+///   if return is undefined -> return Completion(received)   // complete with v
+///   innerResult = ? Await(? Call(return, iterator, «v»))
+///   if Type(innerResult) is not Object -> throw a TypeError
+///   if IteratorComplete(innerResult) -> return Completion{return, IteratorValue} // complete
+///   else -> AsyncGeneratorYield(IteratorValue(innerResult))   // re-yield, stay suspended
+/// ```
+///
+/// Each route emits an `if (state in interval) { ... }`; at most one matches and
+/// it always returns, so control only falls through to the generic completion
+/// path when not suspended in a `yield *`. The thrown `TypeError` and the
+/// returned iter-results are caught / promise-wrapped by
+/// `wrap_generator_resume_body`. Empty for sync generators (no routes recorded).
+pub(crate) fn build_yield_star_return_routes(
+    delegations: &[DelegationRoute],
+    state_id: LocalId,
+    return_param_id: LocalId,
+    done_id: LocalId,
+    next_local_id: &mut u32,
+) -> Vec<Stmt> {
+    let mut out = Vec::with_capacity(delegations.len());
+    for route in delegations {
+        let m_id = alloc_local(next_local_id); // captured `return` method
+        let r_id = alloc_local(next_local_id); // awaited inner result
+
+        let in_interval = Expr::Logical {
+            op: LogicalOp::And,
+            left: Box::new(Expr::Compare {
+                op: CompareOp::Gt,
+                left: Box::new(Expr::LocalGet(state_id)),
+                right: Box::new(Expr::Number(route.suspend_state_lo as f64)),
+            }),
+            right: Box::new(Expr::Compare {
+                op: CompareOp::Le,
+                left: Box::new(Expr::LocalGet(state_id)),
+                right: Box::new(Expr::Number(route.suspend_state_hi as f64)),
+            }),
+        };
+
+        // let __m = iterator.return;
+        let read_method = Stmt::Let {
+            id: m_id,
+            name: "__yield_star_ret_m".to_string(),
+            ty: Type::Any,
+            mutable: false,
+            init: Some(Expr::PropertyGet {
+                object: Box::new(Expr::LocalGet(route.iter_id)),
+                property: "return".to_string(),
+            }),
+        };
+        // if (__m === undefined || __m === null) { done = true; return {v, true}; }
+        let no_method = Stmt::If {
+            condition: Expr::Logical {
+                op: LogicalOp::Or,
+                left: Box::new(Expr::Compare {
+                    op: CompareOp::Eq,
+                    left: Box::new(Expr::LocalGet(m_id)),
+                    right: Box::new(Expr::Undefined),
+                }),
+                right: Box::new(Expr::Compare {
+                    op: CompareOp::Eq,
+                    left: Box::new(Expr::LocalGet(m_id)),
+                    right: Box::new(Expr::Null),
+                }),
+            },
+            then_branch: vec![
+                Stmt::Expr(Expr::LocalSet(done_id, Box::new(Expr::Bool(true)))),
+                Stmt::Return(Some(make_iter_result(
+                    Expr::LocalGet(return_param_id),
+                    true,
+                ))),
+            ],
+            else_branch: None,
+        };
+        // let __r = await __m.call(iterator, v);
+        let call_ret = Stmt::Let {
+            id: r_id,
+            name: "__yield_star_ret_r".to_string(),
+            ty: Type::Any,
+            mutable: false,
+            init: Some(Expr::Await(Box::new(Expr::Call {
+                callee: Box::new(Expr::PropertyGet {
+                    object: Box::new(Expr::LocalGet(m_id)),
+                    property: "call".to_string(),
+                }),
+                args: vec![
+                    Expr::LocalGet(route.iter_id),
+                    Expr::LocalGet(return_param_id),
+                ],
+                type_args: vec![],
+                byte_offset: 0,
+            }))),
+        };
+        // if (Type(__r) is not Object) throw new TypeError(...);
+        let obj_check = Stmt::If {
+            condition: not_object_condition(Expr::LocalGet(r_id)),
+            then_branch: vec![Stmt::Throw(Expr::TypeErrorNew(Box::new(Expr::String(
+                "Iterator result is not an object".to_string(),
+            ))))],
+            else_branch: None,
+        };
+        // if (__r.done) { done = true; return {__r.value, true}; }
+        // else            return {__r.value, false};   // re-yield, generator not done
+        let dispatch_done = Stmt::If {
+            condition: Expr::PropertyGet {
+                object: Box::new(Expr::LocalGet(r_id)),
+                property: "done".to_string(),
+            },
+            then_branch: vec![
+                Stmt::Expr(Expr::LocalSet(done_id, Box::new(Expr::Bool(true)))),
+                Stmt::Return(Some(make_iter_result(
+                    Expr::PropertyGet {
+                        object: Box::new(Expr::LocalGet(r_id)),
+                        property: "value".to_string(),
+                    },
+                    true,
+                ))),
+            ],
+            else_branch: Some(vec![Stmt::Return(Some(make_iter_result(
+                Expr::PropertyGet {
+                    object: Box::new(Expr::LocalGet(r_id)),
+                    property: "value".to_string(),
+                },
+                false,
+            )))]),
+        };
+
+        out.push(Stmt::If {
+            condition: in_interval,
+            then_branch: vec![read_method, no_method, call_ret, obj_check, dispatch_done],
+            else_branch: None,
+        });
+    }
+    out
+}

--- a/crates/perry-transform/src/generator/mod.rs
+++ b/crates/perry-transform/src/generator/mod.rs
@@ -34,7 +34,9 @@ pub(crate) use helpers::{
 pub(crate) use hoist_yields::hoist_yields_in_stmts;
 pub(crate) use id_scan::{compute_max_func_id, compute_max_local_id};
 pub(crate) use iter_result_rewrite::rewrite_stmt;
-pub(crate) use linearize::{linearize_body, CatchRoute, FinallyRoute, State, StateExit};
+pub(crate) use linearize::{
+    linearize_body, CatchRoute, DelegationRoute, FinallyRoute, State, StateExit,
+};
 pub(crate) use lower::{
     transform_generator_function, transform_generator_function_with_extra_captures,
 };


### PR DESCRIPTION
## Subcluster: async-generator `yield *` delegation (#5592)

The class-tail ticket's single largest root is the async-generator `yield *`
family — 40 cases across `async-gen-method{,-static}` and
`async-gen-private-method{,-static}` (statements + expressions), all failing
because Perry only implemented the `next()` direction of `yield *` delegation.
This PR makes three spec steps correct and fixes **24 of those 40**.

### What was wrong

1. **Non-object iterator result** — after `Await(? Call(next, …))` the spec
   requires `If Type(innerResult) is not Object, throw a TypeError`. Perry read
   `.done`/`.value` off the primitive, so `gen.next()` fulfilled where it must
   reject. (`yield-star-next-non-object-ignores-then`)

2. **`return()` not forwarded** — `gen.return(v)` while suspended inside a
   `yield *` must forward to the delegated iterator's `return` method
   (`yield *` step 6.c): complete with `v` when there is no `return`, re-yield
   on `{done:false}`, or complete with the result's value on `{done:true}`.
   Perry completed the outer generator directly and never touched the inner
   iterator, so the test logs stayed empty.
   (`yield-star-{sync,async}-return`)

3. **AsyncFromSync `return`/`throw` double-read** —
   `%AsyncFromSyncIteratorPrototype%.{return,throw}` do `GetMethod` once then
   `Call` the captured value. Perry re-dispatched by name, firing a
   `get return` / `get throw` accessor **twice** and diverging from Node's
   operation order. (the sync-iterator half of the `return` cases)

### Fix

- **`perry-transform` linearize** — enforce the Object-check on every awaited
  delegated pull (async generators only; sync `yield *` reads `.done`/`.value`
  via `GetV` and never throws), and record each `yield *` suspend-state interval.
- **`perry-transform` lower/abrupt** — in an async generator's `.return()`
  closure, when suspended inside a recorded `yield *` interval, forward to the
  delegated iterator's `return` (await + Object-check + done dispatch / re-yield);
  otherwise fall through to the existing completion path. No-op for sync
  generators and for generators with no `yield *`.
- **`perry-runtime`** — `async_from_sync_call_raw` now invokes the
  already-fetched `return`/`throw` method value (`this = iter`) instead of
  re-dispatching by name.

### Before / after (8 `yield-star-*` class dirs)

| | before | after |
|---|---|---|
| non-object | fail ×8 | **pass ×8** |
| sync-return | fail ×8 | **pass ×8** |
| async-return | fail ×8 | **pass ×8** |
| sync-throw | fail ×8 | fail ×8 (remaining) |
| async-throw | fail ×8 | fail ×8 (remaining) |

`rt-fail = 0`, `compile-fail = 0` across all 8 dirs; non-class async-generator
and `for await…of` slices show no new runtime/compile failures.

### What remains

The 16 `*-throw` cases need `throw()` forwarding. Its `{done:true}` branch must
**resume the outer body after the `yield *`**, which requires the
async-generator dispatch-loop continuation that sync generators already have
(#4374) — async `.throw()`/`.return()` closures don't run the dispatch loop, so
this is a larger state-machine change left as follow-up.

### Related

- **#5745** (async-generator `yield *` delegation drops `.return()`/`.throw()`
  abrupt resume) — this PR implements the `.return()` half of that core feature;
  `.throw()` forwarding is the remaining work noted above.
- **#5591** (built-ins tail) — the `async_from_sync_call_raw` double-read fix is
  in the `AsyncFromSyncIterator` cluster called out there.

Refs #5592, #5745, #5591.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for delegated async generator flows, including better forwarding for `return()` during `yield*` handling.
  * Added more reliable handling when iterator methods are accessed by name versus from a cached value.

* **Bug Fixes**
  * Fixed cases where delegated iterator results were not validated consistently, preventing incorrect continuation on invalid results.
  * Improved behavior when a delegated iterator method is unavailable, so generator completion now follows the expected path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->