### PR TITLE
fix(runtime): #5588 — Object test262 correctness (ToPropertyKey symbols, proxy toString/defineProperty, array-index accessor reads, forwarding equality)

### DIFF
--- a/crates/perry-runtime/src/object/native_call_method/common_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/common_methods.rs
@@ -59,12 +59,23 @@ pub(super) unsafe fn dispatch_common(
             if jsval.is_undefined() || jsval.is_null() {
                 return Some(f64::from_bits(JSValue::bool(false).bits()));
             }
+            // ToPropertyKey(V) (19.1.3.3 step 1) BEFORE the string coercion
+            // below: an object argument whose `toString`/`valueOf` yields a
+            // Symbol must be treated as that Symbol, not stringified to
+            // "[object Object]" (test262 hasOwnProperty/symbol_property_*). A
+            // resolved Symbol key routes through the symbol-aware own-property
+            // check in the canonical entry point. The conversion runs once here
+            // so a user `toString` is invoked exactly once.
+            let key_value = if args_len >= 1 && !args_ptr.is_null() {
+                *args_ptr
+            } else {
+                f64::from_bits(crate::value::TAG_UNDEFINED)
+            };
+            let key_value = crate::object::js_to_property_key(key_value);
+            if crate::symbol::js_is_symbol(key_value) != 0 {
+                return Some(super::object_ops::js_object_has_own(object, key_value));
+            }
             if (object.to_bits() >> 48) == 0x7FFE {
-                let key_value = if args_len >= 1 && !args_ptr.is_null() {
-                    *args_ptr
-                } else {
-                    f64::from_bits(crate::value::TAG_UNDEFINED)
-                };
                 let key_str = crate::builtins::js_string_coerce(key_value);
                 let class_id = (object.to_bits() & 0xFFFF_FFFF) as u32;
                 let present = if key_str.is_null() {
@@ -80,11 +91,6 @@ pub(super) unsafe fn dispatch_common(
                 return Some(f64::from_bits(JSValue::bool(present).bits()));
             }
             if jsval.is_pointer() {
-                let key_value = if args_len >= 1 && !args_ptr.is_null() {
-                    *args_ptr
-                } else {
-                    f64::from_bits(crate::value::TAG_UNDEFINED)
-                };
                 let key_str = crate::builtins::js_string_coerce(key_value);
                 if key_str.is_null() {
                     return Some(f64::from_bits(JSValue::bool(false).bits()));
@@ -204,6 +210,11 @@ pub(super) unsafe fn dispatch_common(
             } else {
                 f64::from_bits(crate::value::TAG_UNDEFINED)
             };
+            // ToPropertyKey(V) (19.1.3.4 step 1): an object argument whose
+            // `toString`/`valueOf` yields a Symbol must be treated as that
+            // Symbol (test262 propertyIsEnumerable/symbol_property_*), invoking
+            // the user conversion exactly once.
+            let key_value = crate::object::js_to_property_key(key_value);
             // Symbol keys must not be string-coerced — route through the
             // canonical entry, which consults the SYMBOL_PROPERTIES side
             // table (mirrors hasOwnProperty's symbol arm).

--- a/crates/perry-runtime/src/object/object_ops/has_own.rs
+++ b/crates/perry-runtime/src/object/object_ops/has_own.rs
@@ -73,6 +73,11 @@ pub extern "C" fn js_object_has_own(obj_value: f64, key_value: f64) -> f64 {
             super::super::has_own_helpers::throw_to_object_nullish_type_error();
         }
 
+        // ToPropertyKey(V): fold an object argument (e.g. one whose `toString`
+        // returns a Symbol) into its canonical key before the symbol/string
+        // split. A no-op for keys that are already primitives.
+        let key_value = super::super::js_to_property_key(key_value);
+
         // A Proxy is a small registered id, not a heap object — route
         // `hasOwnProperty` through `[[GetOwnProperty]]` (a present own property
         // is one whose descriptor is not undefined) rather than dereferencing
@@ -318,6 +323,11 @@ pub extern "C" fn js_object_property_is_enumerable(obj_value: f64, key_value: f6
         if obj_jv.is_null() || obj_jv.is_undefined() {
             super::super::has_own_helpers::throw_to_object_nullish_type_error();
         }
+
+        // ToPropertyKey(V): fold an object argument (e.g. one whose `toString`
+        // returns a Symbol) into its canonical key before the symbol/string
+        // split. A no-op for keys that are already primitives.
+        let key_value = super::super::js_to_property_key(key_value);
 
         // Proxy receiver: resolve the descriptor via `[[GetOwnProperty]]` and
         // report its `enumerable` attribute (absent property → false) rather

--- a/crates/perry-runtime/src/object/property_key.rs
+++ b/crates/perry-runtime/src/object/property_key.rs
@@ -19,11 +19,86 @@ pub unsafe extern "C" fn js_to_property_key(value: f64) -> f64 {
     if crate::symbol::js_is_symbol(primitive) != 0 {
         return primitive;
     }
+    // `js_to_primitive` only consults a user `@@toPrimitive` method; when none
+    // is present it returns the object unchanged. Complete `ToPrimitive` here
+    // via `OrdinaryToPrimitive(value, "string")` so that a `toString`/`valueOf`
+    // returning a Symbol yields that Symbol as the property key rather than
+    // being stringified by `js_jsvalue_to_string` below (test262
+    // hasOwnProperty/propertyIsEnumerable `symbol_property_{toString,valueOf}`).
+    if primitive.to_bits() == value.to_bits() {
+        if let Some(p) = ordinary_to_primitive_string_key(primitive) {
+            if crate::symbol::js_is_symbol(p) != 0 {
+                return p;
+            }
+            let key = crate::value::js_jsvalue_to_string(p);
+            if key.is_null() {
+                return f64::from_bits(crate::value::TAG_UNDEFINED);
+            }
+            return crate::value::js_nanbox_string(key as i64);
+        }
+    }
     let key = crate::value::js_jsvalue_to_string(primitive);
     if key.is_null() {
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
     crate::value::js_nanbox_string(key as i64)
+}
+
+/// True when `v` is not a JS Object — i.e. a usable primitive result from
+/// `OrdinaryToPrimitive` (undefined/null/boolean/number/string/bigint and,
+/// crucially, **Symbol**, the one `POINTER_TAG` primitive).
+fn js_value_is_not_object(v: f64) -> bool {
+    let bits = v.to_bits();
+    if (bits & 0xFFFF_0000_0000_0000) != crate::value::POINTER_TAG {
+        return true;
+    }
+    // A Symbol is the one POINTER_TAG primitive. Use `js_is_symbol` (not the
+    // narrower registered-handle table) so a fresh heap `Symbol()` returned
+    // from `toString`/`valueOf` is recognized and preserved as the key.
+    unsafe { crate::symbol::js_is_symbol(v) != 0 }
+}
+
+/// `OrdinaryToPrimitive(O, "string")` with Symbol preservation. The spec
+/// fallback (when no `@@toPrimitive` exists) invokes `toString` then `valueOf`
+/// and uses the first result whose type is not Object — and a Symbol is not an
+/// Object, so it is returned verbatim instead of being coerced to a string.
+/// Returns `None` for a non-object receiver, when neither method is a callable
+/// closure, or when both yield Objects, so the caller falls back to its
+/// ordinary string coercion (preserving prior behavior for those cases — most
+/// notably plain objects whose only `toString` is the native
+/// `Object.prototype.toString`, which is not stored as a closure field here).
+unsafe fn ordinary_to_primitive_string_key(value: f64) -> Option<f64> {
+    if extract_obj_ptr(value).is_null() {
+        return None;
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let value_handle = scope.root_nanbox_f64(value);
+    for name in [b"toString".as_slice(), b"valueOf".as_slice()] {
+        let receiver = value_handle.get_nanbox_f64();
+        let recv_ptr = extract_obj_ptr(receiver);
+        if recv_ptr.is_null() {
+            return None;
+        }
+        let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        let method = js_object_get_field_by_name(recv_ptr as *const ObjectHeader, key);
+        let method_bits = method.bits();
+        if (method_bits & 0xFFFF_0000_0000_0000) != crate::value::POINTER_TAG {
+            continue;
+        }
+        let method_ptr = (method_bits & crate::value::POINTER_MASK) as usize;
+        if !crate::closure::is_closure_ptr(method_ptr) {
+            continue;
+        }
+        let bound = crate::closure::clone_closure_rebind_this(method_bits, receiver);
+        let prev_this = crate::object::js_implicit_this_set(receiver);
+        let result =
+            crate::closure::js_native_call_value(f64::from_bits(bound), std::ptr::null(), 0);
+        crate::object::js_implicit_this_set(prev_this);
+        if js_value_is_not_object(result) {
+            return Some(result);
+        }
+    }
+    None
 }
 
 /// `obj[ToPropertyKey(key)] = value` for object-literal computed definitions.

--- a/crates/perry-runtime/src/object/to_string_tag.rs
+++ b/crates/perry-runtime/src/object/to_string_tag.rs
@@ -147,6 +147,43 @@ pub unsafe extern "C" fn js_object_to_string(value: f64) -> f64 {
     } else {
         0
     };
+    // Proxy receiver (§20.1.3.6). A revocable Proxy is a POINTER_TAG value
+    // whose payload is a small id in the proxy band, NOT a heap pointer, so it
+    // must be handled before the brand blocks below dereference `raw_addr`.
+    // Spec order: (1) IsArray(O) — recurses through the [[ProxyTarget]] chain
+    // and throws a TypeError if any link is revoked (test262 proxy-revoked);
+    // (2) builtinTag from arrayness/callability; (3) Get(O, @@toStringTag)
+    // through the get trap, falling back to builtinTag when it is not a String
+    // (a proxy revoked DURING that Get returns undefined, so it does not throw —
+    // test262 proxy-revoked-during-get-call).
+    if jsv.is_pointer()
+        && crate::value::addr_class::is_proxy_id_band(raw_addr)
+        && crate::proxy::js_proxy_is_proxy(value) != 0
+    {
+        const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
+        let is_array = crate::array::js_array_is_array(value).to_bits() == TAG_TRUE;
+        let builtin_tag = if is_array {
+            "Array"
+        } else if crate::proxy::proxy_wraps_callable(value) {
+            "Function"
+        } else {
+            "Object"
+        };
+        let sym = crate::symbol::well_known_symbol("toStringTag");
+        let tag = if sym.is_null() {
+            None
+        } else {
+            let sym_f64 = f64::from_bits(POINTER_TAG | (sym as u64 & POINTER_MASK));
+            string_value_to_owned(crate::proxy::js_proxy_get(value, sym_f64))
+        };
+        let formatted = match tag {
+            Some(tag) => format!("[object {}]", tag),
+            None => format!("[object {}]", builtin_tag),
+        };
+        let str_ptr =
+            crate::string::js_string_from_bytes(formatted.as_ptr(), formatted.len() as u32);
+        return f64::from_bits(STRING_TAG | (str_ptr as u64 & POINTER_MASK));
+    }
     if raw_addr >= 0x1000 && crate::date::is_date_cell_addr(raw_addr) {
         let str_ptr = crate::string::js_string_from_bytes(b"[object Date]".as_ptr(), 13);
         return f64::from_bits(STRING_TAG | (str_ptr as u64 & POINTER_MASK));

--- a/crates/perry-runtime/src/proxy/invariants.rs
+++ b/crates/perry-runtime/src/proxy/invariants.rs
@@ -204,6 +204,20 @@ fn is_compatible_descriptor(current: &TargetProp, descriptor: f64) -> bool {
     }
     let ptr = extract_pointer(descriptor.to_bits()) as *const crate::ObjectHeader;
     let desc_is_accessor = desc_has(descriptor, b"get") || desc_has(descriptor, b"set");
+    let desc_is_data = desc_has(descriptor, b"value") || desc_has(descriptor, b"writable");
+
+    // A generic descriptor — only `configurable`/`enumerable`, with no
+    // type-defining field (get/set or value/writable) — is compatible with
+    // any non-configurable current property. Per ValidateAndApplyProperty-
+    // Descriptor, IsGenericDescriptor short-circuits the data/accessor-type
+    // and value/writable checks. `Object.freeze`/`Object.seal` of a Proxy
+    // drives exactly such a descriptor (`{configurable:false}`) onto every
+    // own key, including an accessor key, so treating it as a data descriptor
+    // here wrongly aborted with "incompatible descriptor" (test262
+    // freeze/seal proxy-with-defineProperty-handler).
+    if !desc_is_accessor && !desc_is_data {
+        return true;
+    }
 
     // A non-configurable property cannot switch between data and accessor.
     if desc_is_accessor != current.is_accessor {

--- a/crates/perry-runtime/src/value/dyn_index.rs
+++ b/crates/perry-runtime/src/value/dyn_index.rs
@@ -211,6 +211,18 @@ pub extern "C" fn js_dyn_index_get(value: f64, index: f64) -> f64 {
                 return f64::from_bits(TAG_UNDEFINED);
             }
             let arr = raw_ptr as *const crate::array::ArrayHeader;
+            // When any property descriptor is live, an array element read may
+            // resolve to an index accessor descriptor — own (`Object.define-
+            // Property(arr, "0", {get})`) or inherited from a polluted
+            // `Array.prototype`/`Object.prototype` — rather than the raw slot.
+            // Route through `js_array_get_f64`, which fires the getter and
+            // applies the out-of-bounds prototype fallback. The raw-slot fast
+            // path below is preserved for the common no-descriptor case so the
+            // hot dynamic-index path is unchanged. (test262 Object/define-
+            // Propert{y,ies} Array-index accessor reads.)
+            if crate::object::descriptors_in_use() {
+                return crate::array::js_array_get_f64(arr, idx_i32 as u32);
+            }
             let length = unsafe { (*arr).length };
             if (idx_i32 as u32) >= length {
                 return f64::from_bits(TAG_UNDEFINED);

--- a/crates/perry-runtime/src/value/equality.rs
+++ b/crates/perry-runtime/src/value/equality.rs
@@ -157,8 +157,56 @@ pub extern "C" fn js_jsvalue_equals(a: f64, b: f64) -> i32 {
         return if a == b { 1 } else { 0 };
     }
 
+    // Array-grow / GC-evacuation forwarding identity. After `js_array_grow`
+    // (or a copying-GC evacuation) relocates an object, an aliased reference —
+    // e.g. the result of `Object(arr)`, or a `var b = arr` captured before the
+    // grow — can still hold the stale pre-grow pointer while another reference
+    // holds the relocated head. They are the SAME object, so `===` must be
+    // true. Both operands are POINTER_TAG here (numbers/strings/bigint/int32
+    // returned above); resolve each through its `GC_FLAG_FORWARDED` chain (the
+    // same follow `clean_arr_ptr` performs) and compare the resolved addresses.
+    // Gated on the forwarding flag: distinct, non-forwarded objects keep their
+    // own address and fall straight through to `0`, so the common case is a
+    // couple of cheap GcHeader flag loads. (test262 Object S15.2.1.1_A2_T10 /
+    // S15.2.2.1_A2_T3: `Object(arr) === arr`.)
+    if a_val.is_pointer() && b_val.is_pointer() {
+        let ra = resolve_forwarding((abits & crate::value::POINTER_MASK) as usize);
+        let rb = resolve_forwarding((bbits & crate::value::POINTER_MASK) as usize);
+        if ra != 0 && ra == rb {
+            return 1;
+        }
+    }
+
     // Different types or different NaN-boxed values → not equal
     0
+}
+
+/// Follow an object's `GC_FLAG_FORWARDED` chain to its current heap address,
+/// mirroring `clean_arr_ptr`'s forwarding walk. Returns `addr` unchanged when
+/// it is not a forwarded heap pointer (handle/proxy-band registry ids, small
+/// slab allocations, out-of-heap addresses, or live non-forwarded objects), so
+/// callers can compare resolved addresses for object identity. `try_read_gc_-
+/// header` performs the band/heap classification (never dereferencing a
+/// non-heap id). Depth-capped to defend against corrupted GC cycles.
+fn resolve_forwarding(mut addr: usize) -> usize {
+    unsafe {
+        let mut steps = 0u32;
+        while let Some(header) = crate::value::addr_class::try_read_gc_header(addr) {
+            if header.gc_flags & crate::gc::GC_FLAG_FORWARDED == 0 {
+                break;
+            }
+            let new_user = crate::gc::forwarding_address(header) as usize;
+            if new_user == 0 || new_user == addr {
+                break;
+            }
+            addr = new_user;
+            steps += 1;
+            if steps > 64 {
+                break;
+            }
+        }
+    }
+    addr
 }
 
 /// JS Abstract Equality Comparison (==).


### PR DESCRIPTION
## Summary

Addresses **18 of the 69** failing `built-ins/Object` test262 cases tracked in #5588, with **no regressions** in the `built-ins/Object` subset (69 → 51 failing). All changes are confined to `crates/perry-runtime` and each is gated so the hot paths stay unchanged.

Root causes were triaged per-cluster; only the high-confidence, well-localized fixes are included here. The remaining clusters (toLocaleString-on-primitive-this delegation, strict-mode symbol-write TypeErrors, getOwnPropertyDescriptor of value-globals, seal-of-function intrinsics, proxy observable-operation ordering, enumeration order) stay open in #5588 for follow-up PRs.

## Fixes

**ToPropertyKey — Symbol-aware OrdinaryToPrimitive (4 tests).** `js_to_primitive` only honored a user `@@toPrimitive` method and otherwise returned the object unchanged. `js_to_property_key` now completes `ToPrimitive(hint string)` itself: an object argument whose `toString`/`valueOf` yields a Symbol becomes that Symbol key instead of being stringified. `hasOwnProperty`/`propertyIsEnumerable` (prototype-method dispatch + the canonical `js_object_has_own`/`js_object_property_is_enumerable` entry points) route the converted key through the symbol-aware own-property check.
`hasOwnProperty,propertyIsEnumerable / symbol_property_{toString,valueOf}`

**`Object.prototype.toString` on a Proxy (3 tests).** New proxy branch: runs `IsArray` through the `[[ProxyTarget]]` chain (throws `TypeError` on a revoked proxy), derives the builtin tag, then reads `@@toStringTag` via the get trap — falling back to the builtin tag (not throwing) when the proxy is revoked mid-`Get`.
`toString/proxy-array.js, proxy-revoked.js, proxy-revoked-during-get-call.js`

**Proxy `[[DefineOwnProperty]]` invariant (2 tests).** A generic descriptor (`configurable`/`enumerable` only, no type-defining field) is now compatible with any non-configurable target property, matching `IsGenericDescriptor`. `Object.freeze`/`Object.seal` of a Proxy drives exactly such a descriptor onto each own key and no longer aborts with "incompatible descriptor".
`freeze/proxy-with-defineProperty-handler.js, seal/proxy-with-defineProperty-handler.js`

**Dynamic array index read (7 tests).** When property descriptors are live, an array element read routes through `js_array_get_f64` so an index accessor — own, or inherited from a polluted `Array.prototype`/`Object.prototype` — fires its getter and the OOB prototype fallback applies. Gated on `descriptors_in_use()`; the hot no-descriptor path is unchanged.
`defineProperties/15.2.3.7-6-a-{169,171,173,189,191,193}.js, defineProperty/15.2.3.6-4-193.js`

**Object identity after array grow / GC evacuation (2 tests).** `js_jsvalue_equals` resolves `GC_FLAG_FORWARDED` chains in the pointer-vs-pointer mismatch tail (the same follow `clean_arr_ptr` performs), so `Object(arr) === arr` stays true after the array relocates. Gated on the forwarding flag; the equal-bits fast path is untouched.
`S15.2.1.1_A2_T10.js, S15.2.2.1_A2_T3.js`

## Verification

`scripts/test262_subset.py --dir built-ins/Object` (Node v26 oracle):
- **before:** 69 runtime-fail
- **after:** 51 runtime-fail, 0 compile-fail, 0 diff — **18 fixed, 0 regressions**

The 3 transient `(no output)` entries seen in a `--jobs 6` run were confirmed flaky (archive/linker contention at startup) — they pass deterministically on a low-parallelism re-run and as standalone programs. Each fix was additionally confirmed with a standalone repro.

> Version bump / CHANGELOG intentionally omitted — folded in by the maintainer at merge to avoid patch-version collisions while `main` advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved property key handling so objects, symbols, and inherited conversions are treated more consistently across property checks and enumeration.
  * `Object.prototype.toString` now better recognizes proxy-wrapped values and returns the expected built-in tag more reliably.

* **Bug Fixes**
  * Fixed `Object.hasOwn` and `propertyIsEnumerable` for symbol-based and object-coercible keys.
  * Improved proxy property-definition checks for generic descriptors.
  * Array reads now respect live property descriptors and accessor behavior.
  * Strict equality now works more reliably for objects that have been relocated during memory management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->