### PR TITLE
fix(runtime): preserve class refs spread into imported functions (NestJS @UseFilters/guards/pipes)

### DIFF
--- a/crates/perry-runtime/src/closure/dispatch/value_call.rs
+++ b/crates/perry-runtime/src/closure/dispatch/value_call.rs
@@ -432,8 +432,16 @@ pub unsafe extern "C" fn js_closure_call_array(
                 let bits = raw.to_bits();
                 // Same INT32_TAG unboxing the per-arity dispatchers do
                 // below — keep the body's `fadd` arithmetic working when
-                // the args came from `v8_to_native`.
-                let unboxed = if (bits & 0xFFFF_0000_0000_0000) == 0x7FFE_0000_0000_0000 {
+                // the args came from `v8_to_native`. EXCEPT class refs: a
+                // class/class-prototype ref is ALSO 0x7FFE-tagged (the cid in
+                // the low 32 bits), so unboxing it would turn an imported
+                // class passed through `f(...args)` into the plain number
+                // `cid` — breaking `typeof Filter === 'function'` in
+                // `@nestjs` `@UseFilters`/`@UseGuards` metadata. Skip the
+                // unbox for a registered class-ref (never a v8 int32).
+                let unboxed = if (bits & 0xFFFF_0000_0000_0000) == 0x7FFE_0000_0000_0000
+                    && crate::object::class_ref_id(raw).is_none()
+                {
                     ((bits & 0xFFFF_FFFF) as i32) as f64
                 } else {
                     raw
@@ -461,7 +469,13 @@ pub unsafe extern "C" fn js_closure_call_array(
         }
         let raw = *args_ptr.add(i);
         let bits = raw.to_bits();
-        if (bits & 0xFFFF_0000_0000_0000) == 0x7FFE_0000_0000_0000 {
+        // Skip the unbox for a registered class-ref: it is 0x7FFE-tagged like
+        // a v8 int32 but must stay a class ref (see the rest-bundled loop
+        // above) so an imported class spread through `f(...args)` keeps
+        // `typeof === 'function'`.
+        if (bits & 0xFFFF_0000_0000_0000) == 0x7FFE_0000_0000_0000
+            && crate::object::class_ref_id(raw).is_none()
+        {
             let int_val = (bits & 0xFFFF_FFFF) as i32;
             return int_val as f64;
         }

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -51,6 +51,7 @@ pub(crate) mod map_set_subclass;
 mod namespace_create;
 mod native_call_method;
 mod native_module;
+pub(crate) use native_module::class_ref_id;
 pub(crate) use native_module::install_native_module_vtable;
 mod native_module_crypto_key_object;
 mod native_module_crypto_random;


### PR DESCRIPTION
## Problem
A class reference passed through a **spread call into an imported function** — `f(...args)` where `f` is an imported (compiled-package) function — was corrupted to a plain `number`.

Minimal repro (imported class `Filt`, imported `sink`):
```
sink(Filt)        // typeof arg → "function"  ✅ (direct call)
sink(...[Filt])   // typeof arg → "number"    ❌ (spread) — node: "function"
```

This broke real **NestJS** decorators: `@nestjs/common`'s `UseFilters = (...f) => addExceptionFiltersMetadata(...f)` spread-forwards the filter class, which became a number → `validateEach` threw **"Invalid filter passed to @UseFilters()"** at bootstrap. Method-level `@UseGuards`/`@Param(pipe)` (same metadata-forwarder shape) were silently dropped.

## Root cause
`js_closure_call_array` (and its per-arity `a()` marshaller) in `crates/perry-runtime/src/closure/dispatch/value_call.rs` unbox **any** `0x7FFE`-tagged argument to a numeric double — a workaround so v8-bridged integers reach the closure body's `fadd` arithmetic as plain doubles. But **class refs / class-prototype refs are also `0x7FFE` (`INT32_TAG`)-boxed** (the class id in the low 32 bits), so the unbox turned an imported class into the plain number `cid`.

Direct calls and all-local spreads were unaffected (they don't route through this dispatcher), which is why only spread-into-imported-function manifested.

## Fix
Skip the INT32 unbox when the value is a **registered class ref** (`class_ref_id(raw).is_some()`, which also matches class-prototype refs). A class ref is never a v8 int32, so integer arithmetic is unaffected. 2 sites + a `pub(crate)` re-export of `class_ref_id`.

## Verification
- Repro: `sink(...[Filt])` arg `typeof` now `function` (matches node), across variadic + fixed-arity imported callees.
- The NestJS `@UseFilters` bootstrap crash is cleared.
- No regression: the native NestJS starter (`Hello World!`) and a multi-route DI app (GET/POST/params/JSON) still serve.
- `cargo test -p perry-runtime -p perry-hir --release` green (1093 runtime tests, 0 failed); `cargo fmt --check` clean.

https://claude.ai/code/session_017S2d3tRok3oMbi6AwfJyUU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where certain class-like values could be mishandled when passed into closures.
  * Improved argument handling so these values are preserved correctly in both grouped and individual call paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->