### PR TITLE
feat(reflect-metadata): class-prototype design:type lookups + getPrototypeOf(class) (unblocks class-transformer on flat DTOs)

### DIFF
--- a/crates/perry-hir/src/lower/decorators.rs
+++ b/crates/perry-hir/src/lower/decorators.rs
@@ -108,6 +108,15 @@ fn append_property_decorator_init(
         return;
     }
 
+    // NOTE: TypeScript's `emitDecoratorMetadata` stores instance-member
+    // `design:type` on `Class.prototype`, and class-transformer reads it back
+    // with `Reflect.getMetadata("design:type", SomeClass.prototype, prop)`.
+    // Perry stores it on the class constructor (`ClassRef`) here; the runtime
+    // metadata store folds class-prototype lookup targets onto the same class
+    // key (see `proxy/metadata.rs::normalize_target_bits`), so both the
+    // historical `getMetadata(..., Class, prop)` reads (locked in by
+    // test_decorators_legacy_property_metadata.ts) and the library's
+    // `Class.prototype` reads resolve to this entry.
     out.push(Stmt::Expr(Expr::ReflectDefineMetadata {
         key: Box::new(Expr::String("design:type".to_string())),
         value: Box::new(type_metadata_expr(&field.ty)),

--- a/crates/perry-runtime/src/object/object_ops/prototype.rs
+++ b/crates/perry-runtime/src/object/object_ops/prototype.rs
@@ -271,7 +271,21 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
                 return f64::from_bits(parent_bits);
             }
         }
-        return f64::from_bits(TAG_NULL);
+        // Root of the class hierarchy. In JS `Object.getPrototypeOf` of a base
+        // class *constructor* is `Function.prototype`, and of a base class's
+        // `.prototype` object is `Object.prototype` — NOT null. class-transformer
+        // walks `Object.getPrototypeOf(target.prototype.constructor)` and then
+        // dereferences `.prototype` on the result; the old `null` made that
+        // `null.prototype` throw, blocking class-transformer/class-validator on
+        // any flat (no-`extends`) DTO. (#420 followup)
+        if super::super::class_prototype_ref_id(obj_value).is_some() {
+            let proto = crate::object::builtin_prototype_value("Object");
+            if proto.to_bits() != crate::value::TAG_UNDEFINED {
+                return proto;
+            }
+            return f64::from_bits(TAG_NULL);
+        }
+        return function_prototype_or_null();
     }
     // Heap-pointer receiver — return the input value itself. For
     // class-id-tagged instances, `.constructor` then returns the class

--- a/crates/perry-runtime/src/proxy/metadata.rs
+++ b/crates/perry-runtime/src/proxy/metadata.rs
@@ -96,9 +96,46 @@ pub extern "C" fn js_reflect_delete_metadata(key: f64, target: f64, property_key
     f64::from_bits(if deleted { TAG_TRUE } else { TAG_FALSE })
 }
 
+/// Map a metadata `target` to a GC-stable key, folding a class's prototype onto
+/// the class itself.
+///
+/// TypeScript's `emitDecoratorMetadata` stores instance-member `design:type` on
+/// `Class.prototype`, and class-transformer reads it back with
+/// `Reflect.getMetadata("design:type", SomeClass.prototype, prop)`
+/// (TransformOperationExecutor). Perry instead emits that metadata against the
+/// class constructor (`ClassRef`), and several existing tests
+/// (`test_decorators_legacy_property_metadata.ts`) read it back off the class.
+/// To satisfy BOTH access shapes we treat a class's prototype and its
+/// constructor as one metadata bucket: any class-prototype target — the
+/// synthetic `class_prototype_ref` value or the live decl-prototype heap object
+/// — folds onto the stable class-constructor key (`INT32_TAG | class_id`).
+///
+/// This is the runtime "compatibility shim" alternative to re-targeting the
+/// emit (REFLECT-METADATA-SCOPING.md, Task B). It is also GC-safe: the
+/// decl-prototype object is a *movable* heap object (`class_decl_prototype_value`
+/// allocates and roots it; the GC slot is rewritten on evacuation), so keying on
+/// its raw bits would go stale — folding onto the class id sidesteps that with
+/// no dedicated GC scanner. Non-prototype targets (constructors, method `.value`
+/// closures, plain objects) pass through unchanged.
+fn normalize_target_bits(target: f64) -> u64 {
+    // Synthetic class-prototype ref → fold onto the class constructor key.
+    if let Some(cid) = crate::object::class_prototype_ref_id(target) {
+        return crate::object::class_constructor_ref_value(cid).to_bits();
+    }
+    // Live decl-prototype heap object → fold onto the class constructor key.
+    let bits = target.to_bits();
+    if (bits >> 48) == (POINTER_TAG >> 48) {
+        let ptr = (bits & POINTER_MASK) as usize;
+        if let Some(cid) = crate::object::class_id_for_decl_prototype_object(ptr) {
+            return crate::object::class_constructor_ref_value(cid).to_bits();
+        }
+    }
+    bits
+}
+
 fn make_metadata_key(key: f64, target: f64, property_key: f64) -> Option<MetadataKey> {
     Some(MetadataKey {
-        target_bits: target.to_bits(),
+        target_bits: normalize_target_bits(target),
         key: metadata_key_part(key)?,
         property_key: metadata_property_key_part(property_key)?,
     })
@@ -173,7 +210,7 @@ fn metadata_key_part(value: f64) -> Option<String> {
 fn get_metadata_in_prototype_chain(key: &str, target: f64, property_key: Option<&String>) -> f64 {
     let mut current = target;
     loop {
-        let current_bits = current.to_bits();
+        let current_bits = normalize_target_bits(current);
         let found = REFLECT_METADATA.with(|store| {
             store
                 .borrow()
@@ -210,7 +247,7 @@ fn metadata_keys_for(target: f64, property_key: f64, include_prototypes: bool) -
         let mut current = target;
 
         loop {
-            let current_bits = current.to_bits();
+            let current_bits = normalize_target_bits(current);
             for metadata_key in store.keys() {
                 if metadata_key.target_bits == current_bits
                     && metadata_key.property_key == wanted_property_key
@@ -245,4 +282,60 @@ fn metadata_keys_for(target: f64, property_key: f64, include_prototypes: bool) -
 
     let arr = crate::array::js_array_from_f64(values.as_ptr(), values.len() as u32);
     f64::from_bits(POINTER_TAG | ((arr as u64) & POINTER_MASK))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn register_test_class(cid: u32) {
+        let mut guard = crate::object::REGISTERED_CLASS_IDS.write().unwrap();
+        guard
+            .get_or_insert_with(std::collections::HashSet::new)
+            .insert(cid);
+    }
+
+    // A class's synthetic prototype-ref and its live decl-prototype heap object
+    // both fold onto the class-constructor key, so `getMetadata(design:type,
+    // SomeClass.prototype, prop)` (class-transformer) finds metadata stored
+    // against `ClassRef(SomeClass)` (Perry's emit).
+    #[test]
+    fn synthetic_prototype_ref_folds_onto_constructor_key() {
+        let cid = 0x4242;
+        register_test_class(cid);
+        let ctor_key = crate::object::class_constructor_ref_value(cid).to_bits();
+
+        let proto_ref = crate::object::class_prototype_ref_value(cid);
+        assert_eq!(normalize_target_bits(proto_ref), ctor_key);
+
+        // The constructor ref already IS the key — must pass through unchanged.
+        let ctor_ref = crate::object::class_constructor_ref_value(cid);
+        assert_eq!(normalize_target_bits(ctor_ref), ctor_key);
+    }
+
+    #[test]
+    fn decl_prototype_heap_object_folds_onto_constructor_key() {
+        let cid = 0x5151;
+        register_test_class(cid);
+        let fake_proto_ptr: usize = 0x1_0000; // arbitrary; only used as a map key
+        {
+            let mut guard = crate::object::CLASS_DECL_PROTOTYPE_OBJECTS.write().unwrap();
+            guard
+                .get_or_insert_with(std::collections::HashMap::new)
+                .insert(cid, fake_proto_ptr);
+        }
+        let target = f64::from_bits(POINTER_TAG | (fake_proto_ptr as u64 & POINTER_MASK));
+        assert_eq!(
+            normalize_target_bits(target),
+            crate::object::class_constructor_ref_value(cid).to_bits()
+        );
+    }
+
+    #[test]
+    fn unrelated_heap_pointer_passes_through_unchanged() {
+        // A heap pointer that is not a registered decl-prototype object is left
+        // alone (e.g. metadata keyed directly on a plain object/instance).
+        let target = f64::from_bits(POINTER_TAG | 0x0AB_CDEF);
+        assert_eq!(normalize_target_bits(target), target.to_bits());
+    }
 }


### PR DESCRIPTION
## Summary

Extends Perry's built-in `reflect-metadata` subset to unblock **real `class-transformer` / `class-validator` on flat (no-`extends`) DTOs**. Task "(c)" of the NestJS bring-up. All claims verified against `node --experimental-strip-types` + `tsc` with `experimentalDecorators` + `emitDecoratorMetadata`, compiling the **actual** npm packages (`class-validator@0.15.1`, `class-transformer@0.5.1`, `reflect-metadata@0.2.2`).

> Note: the issue title keeps the original task name, but **Symbol metadata keys were deferred** — see "Scope / deferred". The shipped fix is the prototype-target `design:type` lookup plus a prerequisite `getPrototypeOf` fix.

## M0 — what the real first failure actually was

The scoping report *inferred* the first blocker would be the prototype-vs-class `design:type` target mismatch. The **real** first failures (captured by running the repro) were earlier and different:

1. **Compile-time:** `perry compile` **stack-overflows** compiling `libphonenumber-js` (a transitive dep pulled by the `class-validator` *barrel*'s `IsPhoneNumber` re-export). `validator` and `class-transformer` compile fine. Worked around in the repro with deep imports; the overflow is a **separate compiler-recursion bug** (reported below), not reflect-metadata.
2. **Runtime (first):** `TypeError: Cannot read properties of null (reading 'prototype')` from class-transformer's base-class walk — root-caused to **`Object.getPrototypeOf(BaseClass)` returning `null`** instead of `Function.prototype`.
3. Only *then* does the prototype-target `design:type` issue matter.

## Fixes

### 1. Prototype-target `design:type` (the reflect-metadata fix)
TS `emitDecoratorMetadata` stores instance-member `design:type` on `Class.prototype`; class-transformer reads it via `Reflect.getMetadata("design:type", SomeClass.prototype, prop)` (`TransformOperationExecutor.js:254`). Perry emits it against the class **constructor** (`ClassRef`), and existing tests (`test_decorators_legacy_property_metadata.ts`) read it back off the **class** — so a faithful re-target would regress them *and* the decorators' own internal reads.

Instead, the runtime metadata store now treats a class's prototype and its constructor as **one bucket**: `proxy/metadata.rs::normalize_target_bits` folds any class-prototype lookup target — the synthetic `class_prototype_ref` value **or** the live decl-prototype heap object — onto the stable class-constructor key (`INT32_TAG | class_id`). This is the runtime "compatibility shim" alternative the scoping report sanctions (Task B), and is **GC-safe by construction**: the decl-prototype object is a *movable* heap object, so keying on its raw bits would go stale after evacuation; folding onto the (stable-bit) class id sidesteps that with **no new GC scanner**.

### 2. `Object.getPrototypeOf(BaseClass)` -> `Function.prototype` (prerequisite)
`object_ops/prototype.rs` returned `null` for a root (no-`extends`) class ref; JS returns `Function.prototype` (and `Object.prototype` for a base class's `.prototype` object). The existing drizzle `is(value, type)` chain still terminates (a couple of extra builtin hops before `null`).

## Before / after (real `Reflect` + the npm packages)

| check | BEFORE | AFTER | node |
|---|---|---|---|
| `getMetadata("design:type", Cls.prototype, "name")` defined | `false` | **`true`** | `true` |
| `getMetadata("design:type", Cls.prototype, "count")` defined | `false` | **`true`** | `true` |
| `getMetadata("design:type", Cls, "name")` defined | `true` | `true` | `false`* |
| `Object.getPrototypeOf(Cls) === null` | `true` | **`false`** | `false` |
| `class-transformer` `plainToInstance(Dto, {...})` | **throws** `null.prototype` | **works** (`name=Alice age=30`) | works |
| `class-validator` `getTargetValidationMetadatas(Dto,…)` | n/a | **works** (`length=1`) | works |

*Perry intentionally *also* exposes `design:type` on the class (locked in by `test_decorators_legacy_property_metadata.ts`); the fold preserves that while adding the spec/library prototype read.

## Scope / deferred (reported, not over-reached)
- **Symbol metadata keys** (scoping Task A): still a no-op. Verified **not needed** for basic flat-DTO class-validator — it keys its **own** storage on `object.constructor`, not reflect-metadata.
- **`libphonenumber-js` compile stack-overflow**: blocks the `class-validator` *barrel* (and therefore NestJS `ValidationPipe`, which `require('class-validator')`). Separate compiler-recursion bug; **follow-up**.
- **`validate()` / `validateSync()` `EXC_BAD_ACCESS`**: after the metadata fixes, end-to-end `validate()` still crashes inside class-validator's executor (`EXC_BAD_ACCESS address=0x18…0200` — a tagged value dereferenced as a pointer, recursive frames). Generic runtime/codegen bug **unrelated to reflect-metadata** — metadata storage *and* `getTargetValidationMetadatas` both work. **Follow-up.**
- **GC-tracked metadata store** (scoping Task C): not needed — the fold makes prototype metadata GC-safe via the stable class id.

## Tests
- `cargo test -p perry-hir -p perry-runtime --release -- --test-threads=1` passes (incl. 3 new `proxy::metadata::tests::*` for the fold).
- `cargo fmt --all -- --check` clean.
- Existing decorator-metadata e2e tests produce unchanged, correct output.

https://claude.ai/code/session_017S2d3tRok3oMbi6AwfJyUU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved metadata lookup so decorators and reflection APIs now behave more consistently on class properties and prototype-based targets.
  * Fixed `Object.getPrototypeOf` edge cases at the top of inheritance chains, returning the expected prototype when available.

* **Documentation**
  * Added clearer comments explaining how decorator metadata is stored and resolved at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->