### PR TITLE
fix(rxjs): recognize perry Observable/Promise/iterable as ObservableInput (NestJS interceptors)

### DIFF
--- a/crates/perry-hir/src/monomorph/driver.rs
+++ b/crates/perry-hir/src/monomorph/driver.rs
@@ -273,7 +273,26 @@ fn collect_instantiations_in_expr(
                     };
 
                     if let Some(ta) = resolved_type_args {
-                        ctx.request_class_specialization(class_name, ta);
+                        // Never monomorphize a class instantiation whose type
+                        // argument is still an unresolved type variable, e.g.
+                        // `new Observable<R>()` inside `lift<R>()`. TypeScript
+                        // class generics are erased at runtime, so `new C<R>()`
+                        // must construct the SAME class `C` as `new C()`.
+                        // Specializing on an unknown type var instead produced a
+                        // bogus `C$R` class whose instances are NOT `instanceof
+                        // C` and do not inherit `C`'s prototype (e.g. rxjs's
+                        // `Observable.prototype[Symbol.observable]`). That broke
+                        // rxjs `innerFrom`/`from` ObservableInput detection —
+                        // every NestJS interceptor (`next.handle().pipe(...)`)
+                        // 500'd because the piped Observable failed both the
+                        // `input instanceof Observable` and `isInteropObservable`
+                        // checks. Erase the type args and construct the base class.
+                        if !ta
+                            .iter()
+                            .any(crate::monomorph::infer::type_contains_type_var)
+                        {
+                            ctx.request_class_specialization(class_name, ta);
+                        }
                     }
                 }
             }

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -641,7 +641,22 @@ pub extern "C" fn js_object_get_field_by_name(
                     }
                     return JSValue::from_bits(value.to_bits());
                 }
-                if class_id != 0 && class_has_own_method(class_id, name) {
+                // Instance (prototype) methods must only resolve when reading
+                // off the prototype ref (`C.prototype.m`), NOT off the class ref
+                // itself (`C.m`). In JS a class object does not expose its
+                // prototype methods as static members: `class C { m(){} }` has
+                // `C.m === undefined` (the method lives on `C.prototype`). The
+                // earlier unconditional lookup leaked instance methods onto the
+                // class ref, so `C.m` returned a (mis-bound) function. This
+                // broke NestJS interceptor/guard/pipe resolution: its
+                // `getInterceptorInstance` duck-types `!!metatype.intercept` to
+                // decide "is this a class or an already-built instance"; a
+                // truthy `Class.intercept` made it treat the CLASS as the
+                // instance, so `intercept()` ran with a broken receiver and
+                // returned `{}`, which rxjs `innerFrom` then rejected. Real
+                // static methods are resolved below via
+                // `lookup_static_method_in_chain`.
+                if is_prototype_ref && class_id != 0 && class_has_own_method(class_id, name) {
                     let value = class_prototype_method_value_for_name(class_id, name);
                     return JSValue::from_bits(value.to_bits());
                 }


### PR DESCRIPTION
## Summary
A NestJS `@UseInterceptors(TransformInterceptor)` whose `intercept()` returns `next.handle().pipe(map(x => ({ data: x })))` 500'd on native perry. The symptom surfaced inside rxjs `innerFrom` ("You provided an invalid object where a stream was expected…"), but the root cause was **two distinct perry bugs**, both reduced to standalone repros and validated against Node.

## Root cause

### Bug 1 — instance methods leaked onto the class reference (runtime)
Reading an instance (prototype) method as a **static** member off a class ref returned the method instead of `undefined`:

```ts
class C { intercept(a:any){return a} }
typeof (C as any).intercept   // perry: "function"  — Node: "undefined"
```

`crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs` resolved `vtable.methods` (instance methods) for **any** class-ref read, not just prototype-ref reads (`C.prototype.m`). NestJS `InterceptorsContextCreator.getInterceptorInstance` duck-types `const isObject = !!metatype.intercept; if (isObject) return metatype;` to decide "is this a class or an already-built instance". The truthy `Class.intercept` made NestJS treat the interceptor **class** as the instance, so `interceptors[i].intercept(ctx, next)` ran the prototype method with a broken receiver and returned `{}`.

**Fix:** only resolve prototype methods when the receiver is the prototype ref (`is_prototype_ref`). Real static methods still resolve via `lookup_static_method_in_chain`.

### Bug 2 — `new C<TypeVar>()` monomorphized into a distinct class (HIR)
perry's monomorphization specialized `new Observable<R>()` (R = `lift`'s type parameter) into a synthetic class `Observable$R`, whose instances are **not** `instanceof Observable` and do **not** inherit `Observable.prototype` (including `[Symbol.observable]`).

```ts
class Obs<T>{ lift<R>(){ return new Obs<R>(); } }   // new Obs<R>() -> "Obs$R"
new Obs<number>() instanceof Obs   // perry: false — Node: true
```

So in rxjs `innerFrom`, both `input instanceof Observable` **and** `isInteropObservable(input)` (`input[Symbol.observable]`) failed for every piped Observable → `createInvalidObservableTypeError`. TypeScript class generics are erased at runtime; `new C<R>()` must construct `C`.

**Fix:** in `crates/perry-hir/src/monomorph/driver.rs`, never request class specialization at a `new` site when a type argument contains an unresolved type variable (`type_contains_type_var`).

## Repro + proof
Minimal NestJS app: `@Controller @UseInterceptors(TransformInterceptor)` with handlers returning a string / object / array / Promise. Compiled native (`PERRY_NO_AUTO_OPTIMIZE=1`, fresh feature-unified staticlibs).

Before: every route → `{"statusCode":500,"message":"Internal server error"}` (rxjs `innerFrom` reject).

After (native perry == Node):
```
GET /hello   -> {"data":"Hello World!"}
GET /obj     -> {"data":{"a":1,"b":"two"}}
GET /arr     -> {"data":[1,2,3]}
GET /promise -> {"data":"from promise"}
```

## Tests
- `cargo test -p perry-hir -p perry-runtime --release -- --test-threads=1` — pass, 0 failures.
- `cargo fmt --all -- --check` — clean.

## Known residual (out of scope)
`new C<ConcreteType>()` with an explicit **concrete** type argument on a regular class still monomorphizes and breaks `instanceof` (e.g. `new Obs<number>()`). The NestJS/rxjs hot path uses only type-parameter args, so this PR fully fixes interceptors; the concrete-type-arg case is a separate latent issue (it touches the POD/native-layout class-specialization feature).

https://claude.ai/code/session_017S2d3tRok3oMbi6AwfJyUU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed class instantiation handling so specialized versions are only created when type arguments are fully known.
  * Corrected property lookup on class objects so prototype methods no longer appear as bound members when accessed from the class itself.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->