### PR TITLE
fix(async): #5745 — async-generator yield* .throw() delegation + resume

### DIFF
--- a/crates/perry-transform/src/generator/linearize.rs
+++ b/crates/perry-transform/src/generator/linearize.rs
@@ -49,6 +49,18 @@ pub struct DelegationRoute {
     pub suspend_state_lo: u32,
     pub suspend_state_hi: u32,
     pub iter_id: LocalId,
+    /// The drive loop's iter-result local (`__del_result`). `gen.throw(e)`
+    /// forwards into the delegated iterator's `throw`, stores the awaited
+    /// result here, then re-drives the state machine so the loop's condition
+    /// state observes `__del_result.done` (spec `yield *` step 6.b.ii.5-7).
+    pub result_id: LocalId,
+    /// The drive loop's condition-check state — where `gen.throw(e)` re-enters
+    /// the dispatch loop after writing `result_id`, so a `done` inner result
+    /// resumes the outer body after the `yield *` and a not-`done` result
+    /// re-yields. This is the `while` loop's `cond_state`, which the linearizer
+    /// emits as `suspend_state_lo + 1` (the non-empty pre-loop state always
+    /// takes `suspend_state_lo`).
+    pub resume_state: u32,
 }
 
 /// Resolve a `yield*` operand into its iterator. An async generator delegates
@@ -290,6 +302,11 @@ fn emit_yield_star_loop(
                 suspend_state_lo: deleg_lo,
                 suspend_state_hi: deleg_hi,
                 iter_id: del_iter_id,
+                result_id: del_result_id,
+                // `current` always holds the iterator-setup prelude pushed above,
+                // so the `while` linearizer emits a non-empty pre-loop state at
+                // `deleg_lo` and the condition state at `deleg_lo + 1`.
+                resume_state: deleg_lo + 1,
             })
         });
     }

--- a/crates/perry-transform/src/generator/lower.rs
+++ b/crates/perry-transform/src/generator/lower.rs
@@ -17,8 +17,9 @@ mod yield_await;
 pub(crate) use abrupt::{
     build_abrupt_routing, build_async_catch_route_body, build_async_throw_body,
     build_completion_resume_stmts, build_dispatch_catch_handler, build_finally_run_stmts,
-    build_yield_star_return_routes, catch_route_condition, finally_abrupt_condition,
-    finally_route_condition, rewrite_dispatch_continue_to_suspend, wrap_dispatch_loop,
+    build_yield_star_return_routes, build_yield_star_throw_routes, catch_route_condition,
+    finally_abrupt_condition, finally_route_condition, rewrite_dispatch_continue_to_suspend,
+    wrap_dispatch_loop,
 };
 pub(crate) use async_step::{
     build_async_catch_route_body_direct, build_async_step_driver_direct,
@@ -838,6 +839,21 @@ pub fn transform_generator_function_with_extra_captures(
             *next_func_id += 1;
             id
         };
+        // #5745: spec `yield *` step 6.b — when an async generator is suspended
+        // inside a `yield *` and `gen.throw(e)` is called, forward the error into
+        // the delegated iterator's `throw` (re-yielding or, on a `done` result,
+        // resuming the outer body past the `yield *`) rather than routing it into
+        // the outer generator's own catch handlers. Each route re-drives the
+        // state machine via the `while_body_for_throw` continuation loop, so it
+        // is built BEFORE the loop is moved into `throw_continuation` below.
+        // Empty for sync generators (`delegations` is only recorded for async).
+        let yield_star_throw_routes = build_yield_star_throw_routes(
+            &delegations,
+            state_id,
+            throw_param_id,
+            &while_body_for_throw,
+            next_local_id,
+        );
         // #4374: sync generators continue the state machine after a catch
         // (running the inlined finally + reaching the next yield/completion);
         // async generators keep the existing deferred-resume behavior to stay
@@ -854,6 +870,10 @@ pub fn transform_generator_function_with_extra_captures(
             executing_id,
             Box::new(Expr::Bool(true)),
         ))];
+        // The `yield *` throw routes return/throw from inside their own
+        // continuation loop on a match, so they precede the catch-routing body
+        // and only fall through to it when not suspended in a delegation.
+        throw_resume_body.extend(yield_star_throw_routes);
         throw_resume_body.extend(build_async_throw_body(
             &catches,
             &finallys,

--- a/crates/perry-transform/src/generator/lower.rs
+++ b/crates/perry-transform/src/generator/lower.rs
@@ -849,9 +849,14 @@ pub fn transform_generator_function_with_extra_captures(
         // Empty for sync generators (`delegations` is only recorded for async).
         let yield_star_throw_routes = build_yield_star_throw_routes(
             &delegations,
+            &catches,
+            &finallys,
             state_id,
             throw_param_id,
+            pending_type_id,
+            pending_value_id,
             &while_body_for_throw,
+            &hoisted_ids,
             next_local_id,
         );
         // #4374: sync generators continue the state machine after a catch

--- a/crates/perry-transform/src/generator/lower/abrupt.rs
+++ b/crates/perry-transform/src/generator/lower/abrupt.rs
@@ -979,7 +979,14 @@ pub(crate) fn build_yield_star_throw_routes(
         // escaping straight to the generator-level rejection. `state` is still
         // the delegation suspend state here (set_state runs last, only on the
         // success path), so it falls inside the outer try's protected interval.
-        // When no catch matches, run pending non-yielding finallys and re-throw.
+        // When no catch matches, run pending non-yielding finallys and re-throw
+        // — identical to `build_async_throw_body`'s own async fallback. Routing
+        // an abrupt completion *into* a YIELDING finally needs the
+        // pending-completion re-raise machinery that is gated `!is_async_generator`
+        // (an async yielding finally never re-raises the pending throw, so routing
+        // there would swallow the error). That async-wide limitation is out of
+        // scope here; matching the existing async fallback keeps the error
+        // propagating rather than being silently dropped.
         let mut fallback = build_finally_run_stmts(finallys, state_id, hoisted_ids);
         fallback.push(Stmt::Throw(Expr::LocalGet(de_id)));
         let route_to_outer_catch = build_abrupt_routing(

--- a/crates/perry-transform/src/generator/lower/abrupt.rs
+++ b/crates/perry-transform/src/generator/lower/abrupt.rs
@@ -798,14 +798,30 @@ pub(crate) fn build_yield_star_return_routes(
 /// loop is the async-generator abrupt-resume machinery the `.return()` path does
 /// not need (a `return` always completes or re-yields, never resumes the body).
 ///
+/// An abrupt completion *of the delegation protocol itself* — `iterator.throw`
+/// rejecting, a non-object inner result, or the `throw`-undefined TypeError —
+/// occurs at the `yield *` site, so an outer `try/catch` around the delegation
+/// must be able to handle it (spec `?`/`ReturnIfAbrupt` semantics). The protocol
+/// work is therefore wrapped in a generated `try/catch` whose handler routes the
+/// caught error into the matching outer catch's linearized states (via
+/// [`build_abrupt_routing`], then re-driving the dispatch loop, so a `yield`
+/// inside that catch suspends) or, when no catch matches, runs pending
+/// non-yielding finallys and re-throws to reject the generator.
+///
 /// Each route returns or throws from inside its `while(true)` continuation loop,
 /// so control falls through to the catch-routing fallback only when not
 /// suspended in a delegation. Empty for sync generators (no routes recorded).
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn build_yield_star_throw_routes(
     delegations: &[DelegationRoute],
+    catches: &[CatchRoute],
+    finallys: &[FinallyRoute],
     state_id: LocalId,
     throw_param_id: LocalId,
+    pending_type_id: LocalId,
+    pending_value_id: LocalId,
     while_body: &[Stmt],
+    hoisted_ids: &std::collections::HashSet<LocalId>,
     next_local_id: &mut u32,
 ) -> Vec<Stmt> {
     let mut out = Vec::with_capacity(delegations.len());
@@ -813,6 +829,7 @@ pub(crate) fn build_yield_star_throw_routes(
         let m_id = alloc_local(next_local_id); // captured `throw` method
         let ret_m_id = alloc_local(next_local_id); // `return` method (close path)
         let ic_id = alloc_local(next_local_id); // awaited inner-close result
+        let de_id = alloc_local(next_local_id); // caught delegation-protocol error
 
         let in_interval = Expr::Logical {
             op: LogicalOp::And,
@@ -948,13 +965,47 @@ pub(crate) fn build_yield_star_throw_routes(
             else_branch: None,
         };
 
-        // Re-drive the dispatch loop from the drive loop's condition state: it
-        // reads `__del_result.done` and either exits the loop (resuming the
-        // outer body past the `yield *`) or re-yields `__del_result.value`.
+        // On success, re-drive the dispatch loop from the drive loop's condition
+        // state: it reads `__del_result.done` and either exits the loop (resuming
+        // the outer body past the `yield *`) or re-yields `__del_result.value`.
         let set_state = Stmt::Expr(Expr::LocalSet(
             state_id,
             Box::new(Expr::Number(route.resume_state as f64)),
         ));
+
+        // Wrap the protocol work so an abrupt completion at the `yield *` site
+        // (inner `throw` rejection / non-object result / `throw`-undefined
+        // TypeError) routes into the enclosing `try`'s catch states instead of
+        // escaping straight to the generator-level rejection. `state` is still
+        // the delegation suspend state here (set_state runs last, only on the
+        // success path), so it falls inside the outer try's protected interval.
+        // When no catch matches, run pending non-yielding finallys and re-throw.
+        let mut fallback = build_finally_run_stmts(finallys, state_id, hoisted_ids);
+        fallback.push(Stmt::Throw(Expr::LocalGet(de_id)));
+        let route_to_outer_catch = build_abrupt_routing(
+            catches,
+            &[], // async can't re-raise from a yielding finally; finallys handled in fallback
+            state_id,
+            pending_type_id,
+            pending_value_id,
+            &Expr::LocalGet(de_id),
+            true,
+            1.0,
+            false,
+            false,
+            fallback,
+        );
+        let protocol = Stmt::Try {
+            body: vec![read_method, no_method, call_throw, obj_check, set_state],
+            catch: Some(CatchClause {
+                param: Some((de_id, "__yield_star_throw_e".to_string())),
+                body: route_to_outer_catch,
+            }),
+            finally: None,
+        };
+        // Both the success path (state = resume_state) and a routed catch (state
+        // = catch_entry_state) fall through to this loop, which dispatches from
+        // the freshly-set state.
         let drive = Stmt::While {
             condition: Expr::Bool(true),
             body: while_body.to_vec(),
@@ -962,14 +1013,7 @@ pub(crate) fn build_yield_star_throw_routes(
 
         out.push(Stmt::If {
             condition: in_interval,
-            then_branch: vec![
-                read_method,
-                no_method,
-                call_throw,
-                obj_check,
-                set_state,
-                drive,
-            ],
+            then_branch: vec![protocol, drive],
             else_branch: None,
         });
     }

--- a/crates/perry-transform/src/generator/lower/abrupt.rs
+++ b/crates/perry-transform/src/generator/lower/abrupt.rs
@@ -769,3 +769,209 @@ pub(crate) fn build_yield_star_return_routes(
     }
     out
 }
+
+/// Build the `gen.throw(e)` forwarding routes for an async generator's `.throw`
+/// closure. When the generator is suspended inside a `yield *` delegation
+/// (`state` within a recorded [`DelegationRoute`] interval), `throw(e)` must
+/// forward to the delegated iterator's `throw` method rather than routing the
+/// error into the outer generator's own catch handlers — spec `yield *` step 6.b:
+///
+/// ```text
+///   throw = GetMethod(iterator, "throw")
+///   if throw is undefined ->                         // close inner, then TypeError
+///       AsyncIteratorClose(iterator, normal); throw a TypeError
+///   innerResult = ? Await(? Call(throw, iterator, «e»))
+///   if Type(innerResult) is not Object -> throw a TypeError
+///   if IteratorComplete(innerResult) -> resume the outer body after the `yield *`
+///                                       with IteratorValue(innerResult)
+///   else -> AsyncGeneratorYield(IteratorValue(innerResult))   // re-yield, stay suspended
+/// ```
+///
+/// Unlike `return`, the *done* case does NOT complete the outer generator — it
+/// resumes execution after the `yield *` (which may yield again or run to
+/// completion). Both the done (resume) and not-done (re-yield) cases are handled
+/// uniformly: the awaited inner result is stored into the delegation's
+/// `result_id`, the state is set to the drive loop's condition state
+/// (`resume_state`), and a clone of the state-dispatch loop (`while_body`) is
+/// re-driven. The condition state reads `result.done` and either exits the loop
+/// (continuing the outer body) or re-yields `result.value`. This continuation
+/// loop is the async-generator abrupt-resume machinery the `.return()` path does
+/// not need (a `return` always completes or re-yields, never resumes the body).
+///
+/// Each route returns or throws from inside its `while(true)` continuation loop,
+/// so control falls through to the catch-routing fallback only when not
+/// suspended in a delegation. Empty for sync generators (no routes recorded).
+pub(crate) fn build_yield_star_throw_routes(
+    delegations: &[DelegationRoute],
+    state_id: LocalId,
+    throw_param_id: LocalId,
+    while_body: &[Stmt],
+    next_local_id: &mut u32,
+) -> Vec<Stmt> {
+    let mut out = Vec::with_capacity(delegations.len());
+    for route in delegations {
+        let m_id = alloc_local(next_local_id); // captured `throw` method
+        let ret_m_id = alloc_local(next_local_id); // `return` method (close path)
+        let ic_id = alloc_local(next_local_id); // awaited inner-close result
+
+        let in_interval = Expr::Logical {
+            op: LogicalOp::And,
+            left: Box::new(Expr::Compare {
+                op: CompareOp::Gt,
+                left: Box::new(Expr::LocalGet(state_id)),
+                right: Box::new(Expr::Number(route.suspend_state_lo as f64)),
+            }),
+            right: Box::new(Expr::Compare {
+                op: CompareOp::Le,
+                left: Box::new(Expr::LocalGet(state_id)),
+                right: Box::new(Expr::Number(route.suspend_state_hi as f64)),
+            }),
+        };
+
+        // let __m = iterator.throw;
+        let read_method = Stmt::Let {
+            id: m_id,
+            name: "__yield_star_throw_m".to_string(),
+            ty: Type::Any,
+            mutable: false,
+            init: Some(Expr::PropertyGet {
+                object: Box::new(Expr::LocalGet(route.iter_id)),
+                property: "throw".to_string(),
+            }),
+        };
+
+        // Spec step 6.b.iii: `throw` undefined ⇒ AsyncIteratorClose the inner
+        // iterator (give it a chance to run `return`) and then throw a TypeError.
+        //   let __ret = iterator.return;
+        //   if (__ret !== undefined && __ret !== null) {
+        //       let __ic = await __ret.call(iterator);
+        //       if (Type(__ic) is not Object) throw new TypeError(...);
+        //   }
+        //   throw new TypeError("The iterator does not provide a 'throw' method");
+        let read_return = Stmt::Let {
+            id: ret_m_id,
+            name: "__yield_star_close_m".to_string(),
+            ty: Type::Any,
+            mutable: false,
+            init: Some(Expr::PropertyGet {
+                object: Box::new(Expr::LocalGet(route.iter_id)),
+                property: "return".to_string(),
+            }),
+        };
+        let close_inner = Stmt::If {
+            condition: Expr::Logical {
+                op: LogicalOp::And,
+                left: Box::new(Expr::Compare {
+                    op: CompareOp::Ne,
+                    left: Box::new(Expr::LocalGet(ret_m_id)),
+                    right: Box::new(Expr::Undefined),
+                }),
+                right: Box::new(Expr::Compare {
+                    op: CompareOp::Ne,
+                    left: Box::new(Expr::LocalGet(ret_m_id)),
+                    right: Box::new(Expr::Null),
+                }),
+            },
+            then_branch: vec![
+                Stmt::Let {
+                    id: ic_id,
+                    name: "__yield_star_close_r".to_string(),
+                    ty: Type::Any,
+                    mutable: false,
+                    init: Some(Expr::Await(Box::new(Expr::Call {
+                        callee: Box::new(Expr::PropertyGet {
+                            object: Box::new(Expr::LocalGet(ret_m_id)),
+                            property: "call".to_string(),
+                        }),
+                        args: vec![Expr::LocalGet(route.iter_id)],
+                        type_args: vec![],
+                        byte_offset: 0,
+                    }))),
+                },
+                Stmt::If {
+                    condition: not_object_condition(Expr::LocalGet(ic_id)),
+                    then_branch: vec![Stmt::Throw(Expr::TypeErrorNew(Box::new(Expr::String(
+                        "Iterator result is not an object".to_string(),
+                    ))))],
+                    else_branch: None,
+                },
+            ],
+            else_branch: None,
+        };
+        let no_method = Stmt::If {
+            condition: Expr::Logical {
+                op: LogicalOp::Or,
+                left: Box::new(Expr::Compare {
+                    op: CompareOp::Eq,
+                    left: Box::new(Expr::LocalGet(m_id)),
+                    right: Box::new(Expr::Undefined),
+                }),
+                right: Box::new(Expr::Compare {
+                    op: CompareOp::Eq,
+                    left: Box::new(Expr::LocalGet(m_id)),
+                    right: Box::new(Expr::Null),
+                }),
+            },
+            then_branch: vec![
+                read_return,
+                close_inner,
+                Stmt::Throw(Expr::TypeErrorNew(Box::new(Expr::String(
+                    "The iterator does not provide a 'throw' method".to_string(),
+                )))),
+            ],
+            else_branch: None,
+        };
+
+        // __del_result = await __m.call(iterator, e);
+        let call_throw = Stmt::Expr(Expr::LocalSet(
+            route.result_id,
+            Box::new(Expr::Await(Box::new(Expr::Call {
+                callee: Box::new(Expr::PropertyGet {
+                    object: Box::new(Expr::LocalGet(m_id)),
+                    property: "call".to_string(),
+                }),
+                args: vec![
+                    Expr::LocalGet(route.iter_id),
+                    Expr::LocalGet(throw_param_id),
+                ],
+                type_args: vec![],
+                byte_offset: 0,
+            }))),
+        ));
+
+        // if (Type(__del_result) is not Object) throw new TypeError(...);
+        let obj_check = Stmt::If {
+            condition: not_object_condition(Expr::LocalGet(route.result_id)),
+            then_branch: vec![Stmt::Throw(Expr::TypeErrorNew(Box::new(Expr::String(
+                "Iterator result is not an object".to_string(),
+            ))))],
+            else_branch: None,
+        };
+
+        // Re-drive the dispatch loop from the drive loop's condition state: it
+        // reads `__del_result.done` and either exits the loop (resuming the
+        // outer body past the `yield *`) or re-yields `__del_result.value`.
+        let set_state = Stmt::Expr(Expr::LocalSet(
+            state_id,
+            Box::new(Expr::Number(route.resume_state as f64)),
+        ));
+        let drive = Stmt::While {
+            condition: Expr::Bool(true),
+            body: while_body.to_vec(),
+        };
+
+        out.push(Stmt::If {
+            condition: in_interval,
+            then_branch: vec![
+                read_method,
+                no_method,
+                call_throw,
+                obj_check,
+                set_state,
+                drive,
+            ],
+            else_branch: None,
+        });
+    }
+    out
+}


### PR DESCRIPTION
Closes #5745.

## Problem

When an async generator is suspended inside a `yield *` and `gen.throw(e)` is called, spec `yield *` step 6.b requires forwarding the error to the delegated iterator's `throw` method. Perry already forwarded `.return()` (#5751), but `.throw()` fell through to the outer generator's own catch routing — so the inner iterator's `throw` never fired, the post-resume yielded value was dropped, and the delegation loop could not resume. This is the `.throw()` half called out in #5745 (the `.return()` half landed in #5751).

## Why it needs the continuation machinery

Unlike `return`, a `throw` whose inner result is `done` does **not** complete the outer generator — it resumes execution *after* the `yield *` (which may yield again or run to completion). That requires the async-generator abrupt-resume continuation loop that sync generators have (#4374) but the async path deliberately omitted (`throw_continuation = None`).

## Implementation

- `DelegationRoute` now records the drive loop's iter-result local (`result_id`) and its condition-check state (`resume_state`, the `while` loop's `cond_state`).
- New `build_yield_star_throw_routes` (async generators only), mirroring `build_yield_star_return_routes`:
  - `GetMethod(iterator, "throw")`; if undefined → `AsyncIteratorClose` the inner iterator (give it a chance to run `return`) then throw a `TypeError` (spec step 6.b.iii);
  - else `await throw.call(iterator, e)`, enforce the result is an Object, store it into `result_id`, set state to `resume_state`, and re-drive a clone of the state-dispatch loop.
  - The condition state then reads `result.done` and either exits the loop (resuming the outer body past the `yield *`) or re-yields `result.value` — reproducing spec operation order (`get throw` → `call throw` → await → `get done` → `get value`) exactly.
- Injected into the `.throw()` closure **before** the catch-routing fallback, so it only fires while suspended in a delegation and otherwise falls through to existing behavior.

## Safety / scope

Strictly additive and async-only: `delegations` is recorded solely under `linearize_async_generator()`, so `build_yield_star_throw_routes` returns empty and `throw_resume_body.extend(empty)` is a no-op for **sync generators** and for **async generators without a `yield *`** — those codegen paths are byte-identical to before. The only behavioral change is the async `yield* .throw()` path.

## Validation

- `scripts/test262_subset.py --dir language/expressions/class/async-gen-method-static`: **96 pass / 1 diff** (was ~10 failing).
- Same for `language/statements/class/async-gen-method-static`: **96 pass / 1 diff**.
- The single remaining diff in each (`yield-star-sync-next`, a `get [Symbol.iterator]` thisValue gap) is unrelated to `.throw()`/`.return()`.
- Standalone repro confirms spec order: first `.throw()` (inner `done:false`) re-yields `throw-value-1`; second `.throw()` (inner `done:true`) resumes the outer body (`after yield*`) and completes with the function's `return`.
- `cargo test -p perry-transform`: green.

### Known out-of-scope remainder

`yield-star-{normal,return,throw}-notdone-iter-value-throws` still diff: when a **not-done** re-yield's `value` getter throws, the error must route into the outer generator's own `try/catch` during re-dispatch. The async dispatch loop isn't wrapped in try/catch routing (the async analog of sync #4438) — this affects the `normal` `.next()` path identically, so it is a pre-existing gap independent of this change, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced async generator `yield*` handling so delegated generators now correctly forward `.throw()` into the suspended inner iterator and resume with the proper continuation state.

* **Bug Fixes**
  * Fixed completion/resumption routing when `.throw()` occurs while an async `yield*` delegation is suspended.
  * Improved behavior when the inner iterator lacks `.throw()`, ensuring correct cleanup, consistent error handling, and a clear `TypeError` instead of incorrect control flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->