### PR TITLE
fix(array): exotic index propagation for Object.prototype + join/slice

### DIFF
--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -219,6 +219,9 @@ pub(crate) fn array_iteration_is_exotic(arr: *const ArrayHeader) -> bool {
     if ARRAY_PROTO_HAS_INDEX.load(Ordering::Relaxed) {
         return true;
     }
+    if OBJECT_PROTO_HAS_INDEX.load(Ordering::Relaxed) {
+        return true;
+    }
     // Live indices beyond the dense backing store are stored in the sparse
     // named-property map, which the raw element loop never reads.
     unsafe { (*arr).length > (*arr).capacity }

--- a/crates/perry-runtime/src/array/iter_methods.rs
+++ b/crates/perry-runtime/src/array/iter_methods.rs
@@ -734,6 +734,7 @@ pub extern "C" fn js_array_join(
         }
 
         let elements_ptr = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        let exotic = crate::array::array_iteration_is_exotic(arr);
 
         // Get separator string
         let sep_str = if separator.is_null() {
@@ -750,26 +751,22 @@ pub extern "C" fn js_array_join(
             if i > 0 {
                 result.push_str(sep_str);
             }
-            let element_bits = (*elements_ptr.add(i)).to_bits();
+            let element_bits = if exotic {
+                if !crate::array::array_spec_has_index(arr, i as u32) {
+                    // absent slot (own or inherited) → empty string per spec
+                    continue;
+                }
+                crate::array::array_spec_get(arr, i as u32).to_bits()
+            } else {
+                let bits = (*elements_ptr.add(i)).to_bits();
+                // Issue #907: `Array(n)` initializes slots to TAG_HOLE; per
+                // ES2015 §22.1.3.13 holes stringify to the empty string.
+                if bits == crate::value::TAG_HOLE {
+                    continue;
+                }
+                bits
+            };
             let jsvalue = JSValue::from_bits(element_bits);
-
-            // Issue #907: `Array(n)` initializes slots to TAG_HOLE
-            // (see `js_array_alloc_with_length`). Per ES2015 §22.1.3.13
-            // (Array.prototype.join), holes go through Get which returns
-            // undefined → the spec's ToString step turns them into the
-            // empty string. Without this check the catch-all below
-            // emitted "[object Object]", so `Array(3).join("0")` returned
-            // `"[object Object]0[object Object]0[object Object]"` instead
-            // of `"00"`. dayjs's `m(t,e,n)` pad utility builds the UTC
-            // offset string via `Array(e+1-r.length).join(n)` and the
-            // result silently corrupted `b.z(this)` (the format `i`
-            // capture), which downstream triggered
-            // `TypeError: (number).replace is not a function` once the
-            // catch-all fallthrough reached `i.replace(":","")`.
-            if element_bits == crate::value::TAG_HOLE {
-                // hole → empty string per spec
-                continue;
-            }
 
             // Convert element to string based on its type
             if jsvalue.is_string() {

--- a/crates/perry-runtime/src/array/splice_slice.rs
+++ b/crates/perry-runtime/src/array/splice_slice.rs
@@ -290,7 +290,11 @@ pub extern "C" fn js_array_slice(
                     }
                     crate::array::array_spec_get(arr, src_idx as u32)
                 } else {
-                    ptr::read(src_elements.add(src_idx))
+                    let v = ptr::read(src_elements.add(src_idx));
+                    if v.to_bits() == crate::value::TAG_HOLE {
+                        continue; // hole → no property created in result
+                    }
+                    v
                 };
                 crate::array::species::species_result_set(result_box, i, v);
             }

--- a/crates/perry-runtime/src/array/splice_slice.rs
+++ b/crates/perry-runtime/src/array/splice_slice.rs
@@ -255,24 +255,43 @@ pub extern "C" fn js_array_slice(
         let is_plain = crate::array::species::species_result_is_plain_array(result_box);
         let result = crate::value::js_nanbox_get_pointer(result_box) as *mut ArrayHeader;
 
-        // Copy elements
+        // Copy elements — use spec-generic Get when the source is exotic
+        // (has Array.prototype or Object.prototype indexed properties) so
+        // inherited indices appear in the result just as [[Get]] would return
+        // them (ECMA-262 §23.1.3.25 step 8b "If HasProperty(O, from)…").
         let src_elements = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        let src_exotic = crate::array::array_iteration_is_exotic(arr);
         if is_plain {
             (*result).length = slice_len;
             let dst_elements =
                 (result as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
             for i in 0..slice_len as usize {
-                // GC_STORE_AUDIT(BARRIERED): slice result init is followed by layout/barrier rebuild.
-                ptr::write(
-                    dst_elements.add(i),
-                    ptr::read(src_elements.add(start_idx as usize + i)),
-                );
+                let src_idx = start_idx as usize + i;
+                let v = if src_exotic {
+                    if crate::array::array_spec_has_index(arr, src_idx as u32) {
+                        crate::array::array_spec_get(arr, src_idx as u32)
+                    } else {
+                        f64::from_bits(crate::value::TAG_HOLE)
+                    }
+                } else {
+                    // GC_STORE_AUDIT(BARRIERED): slice result init is followed by layout/barrier rebuild.
+                    ptr::read(src_elements.add(src_idx))
+                };
+                ptr::write(dst_elements.add(i), v);
             }
             rebuild_array_layout(result);
         } else {
             // Custom species container: CreateDataPropertyOrThrow per element.
             for i in 0..slice_len as usize {
-                let v = ptr::read(src_elements.add(start_idx as usize + i));
+                let src_idx = start_idx as usize + i;
+                let v = if src_exotic {
+                    if !crate::array::array_spec_has_index(arr, src_idx as u32) {
+                        continue; // absent slot → no property created in result
+                    }
+                    crate::array::array_spec_get(arr, src_idx as u32)
+                } else {
+                    ptr::read(src_elements.add(src_idx))
+                };
                 crate::array::species::species_result_set(result_box, i, v);
             }
         }


### PR DESCRIPTION
## Summary

Three focused runtime fixes that extend Perry's "exotic array" slow-path to cover `Object.prototype` numeric indices and two previously unguarded methods (`join`, `slice`), reducing test262 `built-ins/Array` failures tracked in #5589.

## Changes

- **`crates/perry-runtime/src/array/indexing.rs`** — `array_iteration_is_exotic`: add `OBJECT_PROTO_HAS_INDEX` check alongside the existing `ARRAY_PROTO_HAS_INDEX` one. Every iteration method (`reduce`, `reduceRight`, `forEach`, `map`, `filter`, `find`, `findIndex`, `every`, `some`, `indexOf`, `lastIndexOf`, `flat`, `flatMap`, `sort`) already delegates to this predicate; without the extra check, a numeric property on `Object.prototype` was invisible to all of them.

- **`crates/perry-runtime/src/array/iter_methods.rs`** — `js_array_join`: add the exotic fast/slow-path split that every other iteration method already uses. Previously `join` (and thus `Array.prototype.toString`) always read directly from the dense element store, so inherited numeric properties on `Array.prototype` or `Object.prototype` were silently skipped.

- **`crates/perry-runtime/src/array/splice_slice.rs`** — `js_array_slice`: same exotic-path split for both the plain-array and species-container branches. Per ECMA-262 §23.1.3.25 step 8b, `slice` must use `[[HasProperty]]`/`[[Get]]` per element, so an inherited index should appear in the result.

## Related issue

Refs #5589

## Test plan

Before/after comparison against the test262 `built-ins/Array` subset is not directly runnable (network policy blocks the `tc39/test262` clone in this environment), but each fix was verified with a hand-written Perry script covering the three cases:

```typescript
// Fix 1: Object.prototype numeric index visible to join/reduce
(Object.prototype as any)[1] = 999;
const a1: any[] = [0, , 2];
console.assert(a1.join(",") === "0,999,2");
console.assert(a1.reduce((acc: number, v: number) => acc + v, 0) === 1001);
delete (Object.prototype as any)[1];

// Fix 2: Array.prototype numeric index visible to join
(Array.prototype as any)[1] = 777;
const a2: any[] = [0, , 2];
console.assert(a2.join(",") === "0,777,2");
delete (Array.prototype as any)[1];

// Fix 3: slice picks up inherited index
(Array.prototype as any)[2] = "x";
const a3: any[] = [0, 1]; a3.length = 3;
console.assert(a3.slice(0, 3)[2] === "x");
delete (Array.prototype as any)[2];
```

Output: `all tests passed` (Perry exit 0).

- [x] `cargo build --release` clean (perry, perry-runtime, perry-stdlib — all warnings, zero errors)
- [x] `cargo fmt --all -- --check` passes
- [x] `bash scripts/check_file_size.sh` passes

## Screenshots / output

```
$ cargo build --release -p perry -p perry-runtime -p perry-stdlib
   Finished `release` profile [optimized] target(s) in 4m 45s
$ cargo fmt --all -- --check
(no output — clean)
$ bash scripts/check_file_size.sh
OK: no Rust source files exceed 2000 lines.
$ ./target/release/perry test_array_exotic.ts -o test_array_exotic && ./test_array_exotic
all tests passed
```

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log


---
_Generated by [Claude Code](https://claude.ai/code/session_019DE4dRzmwx4o8h8XBp1xnW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed array iteration, `join`, and `slice` to correctly account for indexed properties inherited from `Object.prototype`, avoiding incorrect dense-element reads.
  * Corrected `join` behavior for special/exotic array forms by skipping missing indices and preserving correct element presence.
  * Improved `slice` so absent entries are kept as holes and missing indices aren’t turned into result properties, including for custom/spec species behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->