### PR TITLE
fix(temporal): enforce require_construct, fix timezone-arg validation, bigint mul sign bug, and duration-before-overflow ordering

### DIFF
--- a/crates/perry-runtime/src/bigint.rs
+++ b/crates/perry-runtime/src/bigint.rs
@@ -672,19 +672,33 @@ pub extern "C" fn js_bigint_mul(
         return bigint_alloc_with_limbs(result);
     }
 
-    // Slow path: 16-limb school multiplication (keeping lower 1024 bits).
-    // Skip trailing all-zero limbs on both operands so e.g. multiplying a
-    // value that uses 3 limbs by one that uses 2 only does 3*2 = 6 word
-    // multiplies instead of 16*16 = 256.
-    let a_len = effective_limb_len(&a_limbs);
-    let b_len = effective_limb_len(&b_limbs);
+    // Slow path: unsigned schoolbook multiplication on the magnitudes, then
+    // apply the sign. Using two's-complement limbs directly would require
+    // carrying the sign-extension words through every row of the accumulation,
+    // which is subtle to get right — sign-and-magnitude is cleaner.
+    let a_neg = is_negative(&a_limbs);
+    let b_neg = is_negative(&b_limbs);
+    let a_mag = if a_neg {
+        negate_limbs(&a_limbs)
+    } else {
+        a_limbs
+    };
+    let b_mag = if b_neg {
+        negate_limbs(&b_limbs)
+    } else {
+        b_limbs
+    };
+
+    // Skip trailing all-zero limbs so e.g. multiplying a value that uses 3
+    // limbs by one that uses 2 only does 3×2 = 6 word multiplies.
+    let a_len = effective_limb_len(&a_mag);
+    let b_len = effective_limb_len(&b_mag);
     let mut result = ZERO_LIMBS;
     for i in 0..a_len {
         let mut carry = 0u128;
         let inner_max = b_len.min(BIGINT_LIMBS - i);
         for j in 0..inner_max {
-            let product =
-                (a_limbs[i] as u128) * (b_limbs[j] as u128) + (result[i + j] as u128) + carry;
+            let product = (a_mag[i] as u128) * (b_mag[j] as u128) + (result[i + j] as u128) + carry;
             result[i + j] = product as u64;
             carry = product >> 64;
         }
@@ -697,6 +711,9 @@ pub extern "C" fn js_bigint_mul(
             carry = sum >> 64;
             k += 1;
         }
+    }
+    if a_neg != b_neg {
+        result = negate_limbs(&result);
     }
     bigint_alloc_with_limbs(result)
 }

--- a/crates/perry-runtime/src/temporal/dispatch.rs
+++ b/crates/perry-runtime/src/temporal/dispatch.rs
@@ -105,7 +105,19 @@ pub(crate) fn to_integer_if_integral(raw: f64) -> i128 {
             "Temporal duration fields must be integers",
         );
     }
-    n as i128
+    let i = n as i128;
+    // Guard against values that are finite and integral in IEEE-754 terms but
+    // exceed the i128 range (e.g. Number.MAX_VALUE ≈ 1.8×10^308 > i128::MAX
+    // ≈ 1.7×10^38). Such a cast silently saturates, then the narrowing to i64
+    // wraps (e.g. i128::MAX as i64 = -1), producing a nonsensical field value
+    // that temporal_rs accepts without complaint. Round-tripping back to f64
+    // detects the saturation.
+    if i as f64 != n {
+        crate::fs::validate::throw_range_error_with_code(
+            "Temporal duration fields must be integers",
+        );
+    }
+    i
 }
 
 /// `ToIntegerIfIntegral(args[i])`, defaulting an absent / `undefined` argument

--- a/crates/perry-runtime/src/temporal/duration.rs
+++ b/crates/perry-runtime/src/temporal/duration.rs
@@ -25,6 +25,7 @@ pub(crate) fn wrap(d: Duration) -> f64 {
 /// `new Temporal.Duration(years?, months?, …, nanoseconds?)` — every argument
 /// is an optional integer defaulting to 0.
 pub fn construct(args: &[f64]) -> f64 {
+    dispatch::require_construct(TYPE_NAME);
     let d = ok_or_throw(Duration::new(
         integral_arg(args, 0) as i64, // years
         integral_arg(args, 1) as i64, // months

--- a/crates/perry-runtime/src/temporal/plain_date.rs
+++ b/crates/perry-runtime/src/temporal/plain_date.rs
@@ -192,18 +192,15 @@ fn to_zoned_args(v: f64) -> (TimeZone, Option<PlainTime>) {
 pub fn call(recv: f64, d: &PlainDate, name: &str, args: &[f64]) -> f64 {
     match name {
         "add" => {
+            // Spec reads the duration argument's fields BEFORE the options bag.
+            let dur = super::duration::coerce_duration(raw_arg(args, 0));
             let overflow = super::options::overflow(raw_arg(args, 1));
-            wrap(ok_or_throw(d.add(
-                &super::duration::coerce_duration(raw_arg(args, 0)),
-                overflow,
-            )))
+            wrap(ok_or_throw(d.add(&dur, overflow)))
         }
         "subtract" => {
+            let dur = super::duration::coerce_duration(raw_arg(args, 0));
             let overflow = super::options::overflow(raw_arg(args, 1));
-            wrap(ok_or_throw(d.subtract(
-                &super::duration::coerce_duration(raw_arg(args, 0)),
-                overflow,
-            )))
+            wrap(ok_or_throw(d.subtract(&dur, overflow)))
         }
         "until" => super::duration::wrap(ok_or_throw(d.until(
             &coerce_date(raw_arg(args, 0)),

--- a/crates/perry-runtime/src/temporal/plain_date_time.rs
+++ b/crates/perry-runtime/src/temporal/plain_date_time.rs
@@ -29,6 +29,7 @@ fn calendar_id_arg(v: f64) -> Calendar {
 
 /// `new Temporal.PlainDateTime(year, month, day, hour?, …, nanosecond?, calendar?)`.
 pub fn construct(args: &[f64]) -> f64 {
+    dispatch::require_construct(TYPE_NAME);
     // Each field is `ToIntegerWithTruncation`: a non-finite (`Infinity`/`NaN` /
     // absent required field) is a RangeError, a Symbol/BigInt a TypeError — not
     // a silently-mangled `as i32`/`0`. `try_new` = overflow "reject" (out-of-range

--- a/crates/perry-runtime/src/temporal/zoned_date_time.rs
+++ b/crates/perry-runtime/src/temporal/zoned_date_time.rs
@@ -52,10 +52,17 @@ fn require_ns(v: f64) -> i128 {
 fn timezone_arg(v: f64) -> TimeZone {
     let jv = JSValue::from_bits(v.to_bits());
     if jv.is_string() {
-        return ok_or_throw(TimeZone::try_from_str(&dispatch::read_string(v)));
+        // `ToTemporalTimeZoneIdentifier` (strict): only IANA names and UTC-offset
+        // strings are accepted. An ISO-datetime string like
+        // "1997-12-04T12:34[+01:00]" must throw a RangeError.
+        // Use `try_from_identifier_str` (not `try_from_str`, which also accepts
+        // ISO datetime strings by extracting their bracket annotation).
+        return ok_or_throw(TimeZone::try_from_identifier_str(&dispatch::read_string(v)));
     }
-    crate::fs::validate::throw_range_error_with_code(
-        "Temporal.ZonedDateTime requires a time-zone identifier string",
+    // Every non-string primitive (null, boolean, number, bigint, symbol, undefined)
+    // is a TypeError per `ToTemporalTimeZoneIdentifier`.
+    crate::object::throw_object_type_error(
+        b"Temporal.ZonedDateTime timeZone must be a string identifier",
     )
 }
 
@@ -69,6 +76,7 @@ fn calendar_arg(v: f64) -> Calendar {
 
 /// `new Temporal.ZonedDateTime(epochNanoseconds: bigint, timeZone, calendar?)`.
 pub fn construct(args: &[f64]) -> f64 {
+    dispatch::require_construct(TYPE_NAME);
     let ns = require_ns(raw_arg(args, 0));
     let tz = timezone_arg(raw_arg(args, 1));
     // Constructor calendar arg is a strict identifier (an ISO date string is a


### PR DESCRIPTION
Closes part of #5587 — reduces test262 `built-ins/Temporal` failures (74 before → ~61 after estimated).

## Root causes & fixes

### 1. Missing `require_construct` in three Temporal constructors (3 tests)

`Temporal.Duration`, `Temporal.PlainDateTime`, and `Temporal.ZonedDateTime` could be called as plain functions without `new`. The spec requires a `TypeError` in that case. Added `dispatch::require_construct(TYPE_NAME)` as the first line of each `construct()` function.

Files: `temporal/duration.rs`, `temporal/plain_date_time.rs`, `temporal/zoned_date_time.rs`

### 2. Wrong error type and wrong timezone parser in `timezone_arg` (2 tests)

Two bugs in `ZonedDateTime`'s `timezone_arg`:

- **Non-string timezone → `RangeError`** should be `TypeError` (`ToTemporalTimeZoneIdentifier` mandates TypeError for non-strings). Fixed by switching to `throw_object_type_error`.
- **ISO datetime strings accepted silently** — `TimeZone::try_from_str` is the lenient parser (`ParseTemporalTimeZoneString`) that extracts a bracket annotation from `"1997-12-04T12:34[+01:00]"`. The constructor must use the strict `TimeZone::try_from_identifier_str` (`ToTemporalTimeZoneIdentifier`), which rejects such strings with a `RangeError`.

File: `temporal/zoned_date_time.rs`

### 3. `to_integer_if_integral` missed values > i128::MAX (1 test, ~20 assertions)

`Number.MAX_VALUE` (~1.8×10^308) is far beyond `i128::MAX` (~1.7×10^38). Casting to `i128` silently saturates; the subsequent narrowing in `temporal_rs` then wraps, producing a wildly wrong value instead of throwing. Added a round-trip guard: if `(i as f64) != n` the cast saturated → `RangeError`.

File: `temporal/dispatch.rs`

### 4. BigInt slow-path multiplication sign bug (5 tests)

`effective_limb_len` strips trailing sign-extension limbs (all `0xFFFFFFFF_FFFFFFFF` words for two's-complement negatives). Treating those stripped limbs as unsigned gave wrong products for negative × positive when either operand exceeded `i64::MAX`. Example: `-864n * 10n**19n` produced a 57-digit positive number instead of `-8640000000000000000000`.

Fix: convert both operands to sign-and-magnitude before unsigned schoolbook multiplication, then negate the result if the input signs differed. Uses the existing `is_negative` / `negate_limbs` helpers.

File: `bigint.rs`

### 5. `PlainDate.add` / `PlainDate.subtract` read overflow before duration (2 tests)

The spec requires the duration argument to be coerced (`ToTemporalDuration`) before the options bag is consulted. The previous code read `overflow` from `args[1]` first. Swapped evaluation order.

File: `temporal/plain_date.rs`

## Remaining failures (~13 uncovered by this PR)

- **35 subclassing tests** — `class MyDate extends Temporal.PlainDate` goes through the dynamic parent dispatch path (`js_fetch_or_value_super`) rather than the statically-dispatched Temporal path. Subclass construction is a broader codegen issue outside the scope of this fix.
- **Precision / rounding edge cases** — A small cluster of `round`/`until`/`since` tests with nanosecond-level precision that appear to be `temporal_rs` version mismatches.

## Verification

- All 30 existing `perry-runtime` BigInt unit tests continue to pass.
- Manual integration test confirmed fixes for all 8 targeted cases (require_construct ×3, timezone-wrong-type, timezone-iso-string, large-number Duration, BigInt multiplication, PlainDate add order).
- `cargo fmt --all -- --check` clean.
- `bash scripts/check_file_size.sh` clean (all files < 2000 lines).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CXg2BXqoL7tiuACVV19tRX)_