### PR TITLE
fix(runtime): #5586 — RegExp.prototype.exec reads lastIndex once and honors a non-writable lastIndex

### DIFF
--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -368,6 +368,27 @@ pub(crate) fn store_last_index_number(re: *mut RegExpHeader, n: usize) {
     }
 }
 
+/// Spec `Set(R, "lastIndex", n, true)` — the lastIndex updates in
+/// RegExpBuiltinExec (steps 14/18) are performed with the *Throw* flag set.
+/// A user can make `lastIndex` non-writable
+/// (`Object.defineProperty(re, "lastIndex", { writable: false })`); the
+/// throwing setter then raises a `TypeError` rather than silently dropping the
+/// write (test262 prototype/{exec,test}/y-fail-lastindex-no-write). When
+/// `lastIndex` is writable (the default) this just stores the number.
+#[cfg(feature = "regex-engine")]
+pub(crate) fn set_last_index_throwing(re: *mut RegExpHeader, n: usize) {
+    let writable = crate::object::get_property_attrs(re as usize, "lastIndex")
+        .map(|a| a.writable())
+        .unwrap_or(true);
+    if !writable {
+        let message = b"Cannot assign to read only property 'lastIndex' of object";
+        let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+        let err = crate::error::js_typeerror_new(msg);
+        crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64));
+    }
+    store_last_index_number(re, n);
+}
+
 /// Check if a pointer is valid (not null and not a small invalid value from bad NaN-unboxing)
 #[inline]
 pub(crate) fn is_valid_ptr<T>(p: *const T) -> bool {

--- a/crates/perry-runtime/src/regex/exec.rs
+++ b/crates/perry-runtime/src/regex/exec.rs
@@ -51,14 +51,15 @@ pub extern "C" fn js_regexp_exec(
         // BOTH global and sticky regexes (and lastIndex is reset/updated for
         // either). A sticky match must additionally *anchor* at lastIndex.
         let use_last_index = global || sticky;
-        // Spec: for non-global/non-sticky, lastIndex is treated as 0 and NOT
-        // read (so a `valueOf`-bearing lastIndex isn't observed). Only consult
-        // (and ToLength-coerce) it when stateful.
-        let last_index = if use_last_index {
-            regex_last_index_offset(re)
-        } else {
-            0
-        };
+        // Spec RegExpBuiltinExec step 4 reads `lastIndex` (Get → ToLength) once,
+        // up front and *before* the global/sticky branch (step 8). So the read
+        // — and any `valueOf`/`toString` side effect of a coercible lastIndex —
+        // is observed exactly once even for a non-global/non-sticky regex
+        // (test262 prototype/exec/{success,failure}-lastindex-access).
+        let last_index_read = regex_last_index_offset(re);
+        // Step 8: a non-global/non-sticky search always starts at 0; the value
+        // read above only drives the search start for a stateful regex.
+        let last_index = if use_last_index { last_index_read } else { 0 };
 
         let search_start_byte = if use_last_index && last_index > 0 {
             let mut byte_off = 0;
@@ -77,7 +78,7 @@ pub extern "C" fn js_regexp_exec(
 
         if search_start_byte > str_data.len() {
             if use_last_index {
-                store_last_index_number(re, 0);
+                set_last_index_throwing(re, 0);
             }
             LAST_EXEC_INDEX.with(|idx| *idx.borrow_mut() = -1.0);
             LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
@@ -120,7 +121,7 @@ pub extern "C" fn js_regexp_exec(
                     }
                     if use_last_index {
                         let match_str = full.as_str();
-                        store_last_index_number(re, match_char_offset + match_str.chars().count());
+                        set_last_index_throwing(re, match_char_offset + match_str.chars().count());
                     }
                     set_exec_array_metadata(
                         arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
@@ -153,7 +154,7 @@ pub extern "C" fn js_regexp_exec(
         if let Some(result) = fancy_captures {
             if result.is_null() {
                 if use_last_index {
-                    store_last_index_number(re, 0);
+                    set_last_index_throwing(re, 0);
                 }
                 LAST_EXEC_INDEX.with(|idx| *idx.borrow_mut() = -1.0);
                 LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());
@@ -175,7 +176,7 @@ pub extern "C" fn js_regexp_exec(
                 if use_last_index {
                     let match_end_byte = caps.get(0).unwrap().end() + search_start_byte;
                     let match_end_char = str_data[..match_end_byte].chars().count();
-                    store_last_index_number(re, match_end_char);
+                    set_last_index_throwing(re, match_end_char);
                 }
 
                 // Create match array: [fullMatch, group1, group2, ...]
@@ -268,7 +269,7 @@ pub extern "C" fn js_regexp_exec(
             }
             None => {
                 if use_last_index {
-                    store_last_index_number(re, 0);
+                    set_last_index_throwing(re, 0);
                 }
                 LAST_EXEC_INDEX.with(|idx| *idx.borrow_mut() = -1.0);
                 LAST_EXEC_GROUPS.with(|g| *g.borrow_mut() = ptr::null_mut());

--- a/test-files/test_issue_5586_regexp_exec_lastindex.ts
+++ b/test-files/test_issue_5586_regexp_exec_lastindex.ts
@@ -1,0 +1,76 @@
+// #5586: RegExp.prototype.exec lastIndex semantics (ECMA-262 22.2.7.2
+// RegExpBuiltinExec).
+//
+// Two spec details that Perry previously got wrong:
+//
+//  1. Step 4 reads `lastIndex` (Get → ToLength) exactly ONCE, up front, BEFORE
+//     the global/sticky branch (step 8). So a coercible `lastIndex` is observed
+//     once even for a non-global/non-sticky regex — and is NOT written back.
+//     (test262 prototype/exec/{success,failure}-lastindex-access)
+//
+//  2. The lastIndex updates use `Set(R, "lastIndex", v, true)` (Throw=true), so
+//     a non-writable `lastIndex` makes a stateful match raise a TypeError
+//     instead of silently dropping the write.
+//     (test262 prototype/{exec,test}/y-fail-lastindex-no-write)
+
+function ok(name: string, value: boolean) {
+  if (!value) {
+    throw new Error(name + ": FAIL");
+  }
+  console.log(name + ": ok");
+}
+
+// (1) lastIndex is read exactly once for a non-global/non-sticky regex, and the
+//     property is left untouched (no write-back).
+let gets = 0;
+const counter = {
+  valueOf() {
+    gets++;
+    return 0;
+  },
+};
+const r = /./;
+(r as any).lastIndex = counter;
+const res = r.exec("abc");
+ok("nonglobal-match", res !== null && res![0] === "a");
+ok("nonglobal-lastindex-read-once", gets === 1);
+ok("nonglobal-lastindex-not-written", (r as any).lastIndex === counter);
+
+// Same for a non-matching non-global regex: one read, no write.
+gets = 0;
+const r2 = /a/;
+(r2 as any).lastIndex = counter;
+ok("nonglobal-nomatch-null", r2.exec("nbc") === null);
+ok("nonglobal-nomatch-read-once", gets === 1);
+ok("nonglobal-nomatch-not-written", (r2 as any).lastIndex === counter);
+
+// (2) A global regex DOES advance lastIndex, and resets it to 0 on failure.
+const g = /a/g;
+ok("global-1", g.exec("banana")!.index === 1 && g.lastIndex === 2);
+ok("global-2", g.exec("banana")!.index === 3 && g.lastIndex === 4);
+ok("global-3", g.exec("banana")!.index === 5 && g.lastIndex === 6);
+ok("global-reset", g.exec("banana") === null && g.lastIndex === 0);
+
+// (3) Non-writable lastIndex + a stateful (sticky) match failure throws.
+const y = /c/y;
+Object.defineProperty(y, "lastIndex", { writable: false });
+let threw = false;
+try {
+  y.exec("abc");
+} catch (e) {
+  threw = e instanceof TypeError;
+}
+ok("sticky-nonwritable-exec-throws", threw);
+
+// `test` shares the same RegExpBuiltinExec path, so it throws too.
+const y2 = /c/y;
+Object.defineProperty(y2, "lastIndex", { writable: false });
+threw = false;
+try {
+  y2.test("abc");
+} catch (e) {
+  threw = e instanceof TypeError;
+}
+ok("sticky-nonwritable-test-throws", threw);
+
+console.log("done");


### PR DESCRIPTION
## Summary

Two `RegExp.prototype.exec` / `RegExpBuiltinExec` (ECMA-262 22.2.7.2) spec-compliance fixes toward the test262 built-ins/RegExp tracker (#5586):

1. **`lastIndex` is read exactly once, up front.** Step 4 of RegExpBuiltinExec reads `lastIndex` (`Get` → `ToLength`) *before* the global/sticky branch (step 8). Perry previously skipped the read entirely for a non-global/non-sticky regex, so a coercible `lastIndex` (`re.lastIndex = { valueOf() {…} }`) was never observed. The value still only drives the search start for a stateful regex (and is not written back for a non-stateful one).

2. **A non-writable `lastIndex` throws.** The lastIndex updates use `Set(R, "lastIndex", v, true)` (Throw=true), so a `lastIndex` made non-writable via `Object.defineProperty` must raise a `TypeError` on a stateful match instead of silently dropping the write. A new `set_last_index_throwing` helper replaces the raw header write at every stateful write site.

## Tests fixed (test262, pinned `4249661`)

- `built-ins/RegExp/prototype/exec/success-lastindex-access.js`
- `built-ins/RegExp/prototype/exec/failure-lastindex-access.js`
- `built-ins/RegExp/prototype/exec/y-fail-lastindex-no-write.js`
- `built-ins/RegExp/prototype/test/y-fail-lastindex-no-write.js`

## Validation

- `built-ins/RegExp/prototype` subset: **185 pass, 0 compile-fail, 0 diff**; the 4 cases above moved from fail → pass, and the remaining 6 failures are pre-existing categorical gaps unrelated to this change (capture-group semantics, lone-surrogate parse, UTF-16-code-unit `u`-flag lastIndex, and the `propertyIsEnumerable`-on-`RegExp.prototype` dispatch bug).
- `perry-runtime` regex unit tests: 30 pass.
- New node-parity regression test `test-files/test_issue_5586_regexp_exec_lastindex.ts` (byte-identical under Perry and `node --experimental-strip-types`); existing regex gap tests still match Node.

> Note: version bump + CHANGELOG entry intentionally omitted for the maintainer to fold in at merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regular expression `exec`/`test` behavior to follow standard `lastIndex` rules more closely.
  * Non-stateful regexes now ignore `lastIndex` changes, while global and sticky regexes update it correctly after matches and failures.
  * Attempts to update a read-only `lastIndex` now throw an error instead of failing silently.

* **Tests**
  * Added coverage for `lastIndex` reading, updating, and error handling across common regex scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->