### PR TITLE
fix(deforest): rewrite producer call sites in class member bodies

### DIFF
--- a/crates/perry-transform/src/deforest/detect.rs
+++ b/crates/perry-transform/src/deforest/detect.rs
@@ -39,6 +39,15 @@ pub fn detect_producers(module: &Module) -> HashMap<FuncId, ProducerInfo> {
         if let Some(ctor) = &class.constructor {
             scan_funcref_misuses(&ctor.body, &candidates, &mut by_ref_used);
         }
+        for (_, getter) in &class.getters {
+            scan_funcref_misuses(&getter.body, &candidates, &mut by_ref_used);
+        }
+        for (_, setter) in &class.setters {
+            scan_funcref_misuses(&setter.body, &candidates, &mut by_ref_used);
+        }
+        for m in &class.static_methods {
+            scan_funcref_misuses(&m.body, &candidates, &mut by_ref_used);
+        }
     }
     candidates.retain(|id, _| !by_ref_used.contains(id));
     if candidates.is_empty() {
@@ -63,6 +72,15 @@ pub fn detect_producers(module: &Module) -> HashMap<FuncId, ProducerInfo> {
         if let Some(ctor) = &class.constructor {
             scan_unsafe_call_sites(&ctor.body, &candidates, &mut unsupported_call);
         }
+        for (_, getter) in &class.getters {
+            scan_unsafe_call_sites(&getter.body, &candidates, &mut unsupported_call);
+        }
+        for (_, setter) in &class.setters {
+            scan_unsafe_call_sites(&setter.body, &candidates, &mut unsupported_call);
+        }
+        for m in &class.static_methods {
+            scan_unsafe_call_sites(&m.body, &candidates, &mut unsupported_call);
+        }
     }
     candidates.retain(|id, _| !unsupported_call.contains(id));
     if candidates.is_empty() {
@@ -85,6 +103,15 @@ pub fn detect_producers(module: &Module) -> HashMap<FuncId, ProducerInfo> {
         }
         if let Some(ctor) = &class.constructor {
             scan_producers_used_in_closures(&ctor.body, &candidates, &mut in_closure);
+        }
+        for (_, getter) in &class.getters {
+            scan_producers_used_in_closures(&getter.body, &candidates, &mut in_closure);
+        }
+        for (_, setter) in &class.setters {
+            scan_producers_used_in_closures(&setter.body, &candidates, &mut in_closure);
+        }
+        for m in &class.static_methods {
+            scan_producers_used_in_closures(&m.body, &candidates, &mut in_closure);
         }
     }
     candidates.retain(|id, _| !in_closure.contains(id));

--- a/crates/perry-transform/src/deforest/mod.rs
+++ b/crates/perry-transform/src/deforest/mod.rs
@@ -174,4 +174,58 @@ pub fn run(module: &mut Module) {
         }
         rewrite_call_sites_in_stmts(&mut func.body, &producers, &out_param_ids, &mut next_local);
     }
+
+    // Class member bodies (constructors, methods, accessors, static methods)
+    // are equally valid producer call sites — `detect_producers` already
+    // scans them for unsafe usages, so a producer admitted here may have its
+    // only `let x = f(...)` call inside a method. Without rewriting those
+    // sites the call keeps its original arity while the producer's signature
+    // gained the `__deforest_out` param; codegen then passes `undefined` for
+    // the missing arg and the body operates on a non-array, SIGSEGVing (same
+    // class of arity-mismatch miscompile as the in-closure bail-out, #5136 —
+    // but here the call sites are ordinary statement bodies we can rewrite
+    // rather than bail on). Producers are only ever free functions
+    // (`analyze_producer` runs on `module.functions`), so no skip is needed.
+    for class in &mut module.classes {
+        if let Some(ctor) = &mut class.constructor {
+            rewrite_call_sites_in_stmts(
+                &mut ctor.body,
+                &producers,
+                &out_param_ids,
+                &mut next_local,
+            );
+        }
+        for method in &mut class.methods {
+            rewrite_call_sites_in_stmts(
+                &mut method.body,
+                &producers,
+                &out_param_ids,
+                &mut next_local,
+            );
+        }
+        for (_, getter) in &mut class.getters {
+            rewrite_call_sites_in_stmts(
+                &mut getter.body,
+                &producers,
+                &out_param_ids,
+                &mut next_local,
+            );
+        }
+        for (_, setter) in &mut class.setters {
+            rewrite_call_sites_in_stmts(
+                &mut setter.body,
+                &producers,
+                &out_param_ids,
+                &mut next_local,
+            );
+        }
+        for method in &mut class.static_methods {
+            rewrite_call_sites_in_stmts(
+                &mut method.body,
+                &producers,
+                &out_param_ids,
+                &mut next_local,
+            );
+        }
+    }
 }

--- a/crates/perry-transform/src/deforest/tests.rs
+++ b/crates/perry-transform/src/deforest/tests.rs
@@ -279,6 +279,124 @@ fn still_deforests_when_caller_is_not_a_closure() {
     );
 }
 
+#[test]
+fn deforests_producer_called_from_class_method() {
+    // Regression: a producer called via `let v = helper()` inside a CLASS
+    // METHOD must have its call site rewritten in lock-step with the
+    // producer's signature. `detect_producers` already scans method bodies,
+    // so it admits the producer — but before phase-3 covered class member
+    // bodies the method's call site kept its original 0-arg form while
+    // `helper` gained the `__deforest_out` param. Codegen then passed
+    // `undefined` for the missing arg and the body operated on a non-array,
+    // SIGSEGVing (same arity-mismatch class as the in-closure bail, #5136).
+    //
+    //   function helper() { const out = []; out.push(1); return out; }
+    //   class C { m() { const v = helper(); return v.length; } }
+    let helper = make_simple_producer(); // id=1, the producer
+
+    let method = Function {
+        id: 2,
+        name: "m".to_string(),
+        type_params: vec![],
+        params: vec![],
+        return_type: Type::Number,
+        body: vec![
+            Stmt::Let {
+                id: 30,
+                name: "v".to_string(),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(Expr::Call {
+                    callee: Box::new(Expr::FuncRef(1)),
+                    args: vec![],
+                    type_args: vec![],
+                    byte_offset: 0,
+                }),
+            },
+            Stmt::Return(Some(Expr::PropertyGet {
+                object: Box::new(Expr::LocalGet(30)),
+                property: "length".to_string(),
+            })),
+        ],
+        is_async: false,
+        is_generator: false,
+        is_strict: false,
+        is_exported: false,
+        captures: vec![],
+        decorators: vec![],
+        was_plain_async: false,
+        was_unrolled: false,
+    };
+
+    let class = perry_hir::Class {
+        id: 10,
+        name: "C".to_string(),
+        type_params: Vec::new(),
+        extends: None,
+        extends_name: None,
+        native_extends: None,
+        extends_expr: None,
+        heritage_lexically_shadowed: false,
+        fields: Vec::new(),
+        constructor: None,
+        methods: vec![method],
+        getters: Vec::new(),
+        setters: Vec::new(),
+        static_accessor_names: Vec::new(),
+        static_accessor_fn_ids: Vec::new(),
+        static_fields: Vec::new(),
+        static_methods: Vec::new(),
+        computed_members: Vec::new(),
+        decorators: Vec::new(),
+        is_exported: false,
+        is_nested: false,
+        aliases: Vec::new(),
+    };
+
+    let mut module = Module::new("m");
+    module.functions = vec![helper];
+    module.classes = vec![class];
+
+    assert!(
+        !detect_producers(&module).is_empty(),
+        "producer with a class-method caller should still deforest"
+    );
+
+    run(&mut module);
+
+    let helper_after = module.functions.iter().find(|f| f.id == 1).unwrap();
+    assert_eq!(
+        helper_after.params.len(),
+        1,
+        "producer should gain the synthetic accumulator param"
+    );
+
+    // Every call to the producer (id=1) in the method body must now match
+    // the rewritten arity (1). The rewrite turns `let v = helper()` into
+    // `let v = []; helper(v);`, so the surviving call is a `Stmt::Expr`
+    // passing the accumulator. A stale `[0]` here is exactly the miscompile.
+    let method_after = &module.classes[0].methods[0];
+    let mut arities = Vec::new();
+    for stmt in &method_after.body {
+        let init = match stmt {
+            Stmt::Let { init: Some(e), .. } => Some(e),
+            Stmt::Expr(e) | Stmt::Throw(e) => Some(e),
+            Stmt::Return(Some(e)) => Some(e),
+            _ => None,
+        };
+        if let Some(Expr::Call { callee, args, .. }) = init {
+            if matches!(callee.as_ref(), Expr::FuncRef(1)) {
+                arities.push(args.len());
+            }
+        }
+    }
+    assert_eq!(
+        arities,
+        vec![1],
+        "the method's producer call site must be rewritten to pass the out-param"
+    );
+}
+
 fn make_simple_producer() -> Function {
     Function {
         id: 1,

--- a/crates/perry-transform/src/deforest/walk.rs
+++ b/crates/perry-transform/src/deforest/walk.rs
@@ -52,6 +52,27 @@ pub fn max_local_id(module: &Module) -> LocalId {
             }
             max_in_stmts(&ctor.body, &mut max_id);
         }
+        // Accessors and statics hold call sites too (see the matching
+        // detection scans + phase-3 rewrite). Cover them so the fresh-id
+        // seed never collides with a local already living in those bodies.
+        for (_, getter) in &c.getters {
+            for p in &getter.params {
+                max_id = max_id.max(p.id);
+            }
+            max_in_stmts(&getter.body, &mut max_id);
+        }
+        for (_, setter) in &c.setters {
+            for p in &setter.params {
+                max_id = max_id.max(p.id);
+            }
+            max_in_stmts(&setter.body, &mut max_id);
+        }
+        for m in &c.static_methods {
+            for p in &m.params {
+                max_id = max_id.max(p.id);
+            }
+            max_in_stmts(&m.body, &mut max_id);
+        }
     }
     max_id
 }


### PR DESCRIPTION
## Problem

Deforestation promotes an array-producer function

```ts
function f() { const out = []; /* ...out.push(x)... */ return out; }
```

to take the accumulator as a synthetic trailing `__deforest_out` parameter, then rewrites every call site to allocate the array and pass it in.

`detect_producers` scans free functions, module-init, **and class member bodies** (methods + constructors) when deciding whether a producer is safe to rewrite — a plain `let v = f()` inside a method counts as a *supported* call site, so the producer is admitted. But phase 3 only rewrote call sites in **module-init and free functions**.

So a producer whose call site lives in a class method had its signature rewritten (gaining the out-param) while the method's call kept its **original arity**. Codegen then passes `undefined` for the missing argument, and the body runs `out.push(...)` / `return out` on a non-array:

```ts
function build() { const out = []; out.push(1); return out; }   // becomes build(__deforest_out)
class C { m() { const v = build(); return v.length; } }         // call site NOT rewritten → build(undefined)
new C().m();   // SIGSEGV (push on undefined)
```

When the (now `undefined`) result is later spread / `for…of`'d, it surfaces instead as `TypeError: is not iterable`.

This is the same arity-mismatch class as the in-closure bail-out (#5136). There the fix was to drop the producer; method/ctor/accessor bodies are ordinary statement lists, so we can **rewrite** them rather than bail.

## Fix

Make detection, fresh-id seeding, and the phase-3 rewrite cover the **identical** complete set of code bodies — module-init, free functions, constructors, methods, getters, setters, and static methods:

- **`deforest/mod.rs`** (phase 3): rewrite producer call sites in every class member body, not just module-init + free functions.
- **`deforest/detect.rs`**: extend the three safety scans (funcref misuse, unsafe call sites, in-closure usage) to getters/setters/static methods so admission and rewrite stay symmetric (previously they covered only methods + constructors).
- **`deforest/walk.rs`** (`max_local_id`): include getter/setter/static-method locals so the synthetic-id seed can't collide with a local already living in those bodies.

## Test

Adds `deforests_producer_called_from_class_method`: a producer called via `let v = helper()` inside a class method is deforested **and** its call site is rewritten to pass the accumulator (the surviving call's arity matches the rewritten producer). Full `perry-transform` suite green (40 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deforestation so call sites inside class methods, getters, setters, and static methods are rewritten correctly.
  * Fixed producer detection to consider these class member bodies when deciding whether a producer can be transformed.
  * Prevented identifier conflicts by including class accessors and static members in local ID tracking.

* **Tests**
  * Added regression coverage for producer calls inside class methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->