### PR TITLE
fix(intl): #5581 — formatRange equal endpoints use approximate form

### DIFF
--- a/crates/perry-runtime/src/intl/number_format.rs
+++ b/crates/perry-runtime/src/intl/number_format.rs
@@ -1720,19 +1720,13 @@ fn number_range_endpoints(method: &str, start: f64, end: f64) -> (f64, f64) {
     (x, y)
 }
 
-/// Two endpoints are "mathematically equal" for range-collapse purposes when
-/// they are the same Number — including `+0`/`-0`, which compare equal — so the
-/// range renders as a single value rather than the approximate (`~`) form.
-fn range_endpoints_equal(x: f64, y: f64) -> bool {
-    x == y
-}
-
 /// `Intl.NumberFormat.prototype.formatRange` — a best-effort
 /// PartitionNumberRangePattern: render both endpoints with the instance's
-/// formatter, collapse to a single value when the endpoints are mathematically
-/// equal, mark the result approximate (`~`) when distinct endpoints round to the
-/// same string, and otherwise join the two renderings with an en dash. The exact
-/// ICU field-collapsing / locale range pattern is not reproduced.
+/// formatter, mark the result approximate (`~`) whenever the two endpoints
+/// produce the same string — including mathematically equal endpoints such as
+/// `formatRange(3, 3)`, which ECMA-402 still renders approximately — and
+/// otherwise join the two renderings with an en dash. The exact ICU
+/// field-collapsing / locale range pattern is not reproduced.
 pub(crate) fn number_format_range_value(
     obj: *const ObjectHeader,
     method: &str,
@@ -1745,9 +1739,6 @@ pub(crate) fn number_format_range_value(
         .iter()
         .map(|(_, v)| v.as_str())
         .collect();
-    if range_endpoints_equal(x, y) {
-        return string_value(&sx);
-    }
     let sy: String = number_parts_from_resolved(&r, y)
         .iter()
         .map(|(_, v)| v.as_str())
@@ -1761,8 +1752,9 @@ pub(crate) fn number_format_range_value(
 
 /// `Intl.NumberFormat.prototype.formatRangeToParts` — the parts shape of
 /// [`number_format_range_value`]. Each segment carries a `source`
-/// (`"startRange"`/`"endRange"`/`"shared"`); a collapsed range tags every
-/// segment `"shared"`, and the approximate form prepends an `approximatelySign`.
+/// (`"startRange"`/`"endRange"`/`"shared"`); the approximate form (endpoints
+/// that render identically, equal inputs included) prepends an
+/// `approximatelySign` and tags every segment `"shared"`.
 pub(crate) fn number_format_range_parts_value(
     obj: *const ObjectHeader,
     method: &str,
@@ -1775,10 +1767,6 @@ pub(crate) fn number_format_range_parts_value(
         parts.into_iter().map(move |(t, v)| (t, v, source))
     };
     let x_parts = number_parts_from_resolved(&r, x);
-    if range_endpoints_equal(x, y) {
-        let shared: Vec<_> = tag(x_parts, "shared").collect();
-        return super::date_collator::range_parts_to_js_array(&shared);
-    }
     let y_parts = number_parts_from_resolved(&r, y);
     let sx: String = x_parts.iter().map(|(_, v)| v.as_str()).collect();
     let sy: String = y_parts.iter().map(|(_, v)| v.as_str()).collect();


### PR DESCRIPTION
## Summary

Follow-up to #5771 addressing a CodeRabbit correctness flag that landed after that PR merged.

Per ECMA-402 `PartitionNumberRangePattern`, `Intl.NumberFormat.prototype.formatRange` renders the approximate (`~`) form whenever the two endpoints format to the **same string** — and this includes mathematically equal endpoints. #5771 special-cased equal endpoints to a plain single value, diverging from the spec and from the Node oracle:

```js
new Intl.NumberFormat("en-US").formatRange(3, 3)        // spec/Node: "~3"  — was "3"
new Intl.NumberFormat("en-US").formatRangeToParts(3, 3) // spec/Node: [{approximatelySign,"~",shared},{integer,"3",shared}] — omitted the sign
```

## Change

Drop the `range_endpoints_equal` fast path so equal endpoints flow through the existing `sx == sy` approximate branch in both `formatRange` and `formatRangeToParts`.

## Validation

- Output now matches `node v26` byte-for-byte for `formatRange(3,3)` / `formatRangeToParts(3,3)`.
- Pinned test262 corpus (`intl402/NumberFormat/prototype/{formatRange,formatRangeToParts}`): **16 pass / 3 fail unchanged, 0 compile failures** — no test-count regression (the remaining 3 are the exact-ICU-formatting cases out of scope for #5771).

Refs #5581.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved range formatting so identical-looking values are shown as approximate ranges rather than exact collapsed values.
  * Updated parts output to include an approximation marker when both endpoints render the same, while keeping distinct ranges clearly separated with an en dash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->