### PR TITLE
fix(intl): #5582 — emit timeZoneName part for Temporal.Instant in formatToParts

### DIFF
--- a/crates/perry-runtime/src/intl/date_collator.rs
+++ b/crates/perry-runtime/src/intl/date_collator.rs
@@ -110,19 +110,27 @@ fn date_time_format_to_parts_value(obj: *const ObjectHeader, value: f64) -> f64 
 }
 
 /// Append a `timeZoneName` part when the `timeZoneName` option is set and the
-/// value being formatted denotes a real instant (a `Date` or numeric
-/// timestamp). A Temporal *plain* value (PlainDate/PlainTime/PlainDateTime/…)
-/// carries no time zone, so it must NOT print one — see
-/// `temporal-*-formatting-timezonename.js`. Perry ships no CLDR zone-name data,
-/// so the rendered label is best-effort (the in-scope tests observe only the
-/// part's presence and string-ness, all with the UTC default zone).
+/// value being formatted is anchored to the timeline (a `Date`/number, or a
+/// `Temporal.Instant`). A Temporal *plain* value (PlainDate/PlainTime/
+/// PlainDateTime/PlainYearMonth/PlainMonthDay) carries no time zone, so it must
+/// NOT print one — see `temporal-*-formatting-timezonename.js`.
+/// (`Temporal.ZonedDateTime`/`Duration` are rejected upstream by
+/// `date_arg_to_clipped_ms` and never reach here.) Perry ships no CLDR
+/// zone-name data, so the rendered label is best-effort (the in-scope tests
+/// observe only the part's presence and string-ness, all with the UTC default).
 fn append_time_zone_name_part(
     parts: &mut Vec<(&'static str, String)>,
     obj: *const ObjectHeader,
     value: f64,
 ) {
-    if crate::temporal::is_temporal_value(value) {
-        return;
+    use crate::temporal::TemporalKind::*;
+    if let Some(kind) = crate::temporal::temporal_kind(value) {
+        if matches!(
+            kind,
+            PlainDate | PlainTime | PlainDateTime | PlainYearMonth | PlainMonthDay
+        ) {
+            return;
+        }
     }
     if let Some(style) = get_string_field(obj, KEY_TIME_ZONE_NAME) {
         let tz = get_string_field(obj, KEY_TIME_ZONE).unwrap_or_else(|| "UTC".to_string());


### PR DESCRIPTION
Follow-up to #5770 addressing a CodeRabbit review comment that arrived after that PR merged.

### Problem
The `timeZoneName`-part guard added in #5770 (`append_time_zone_name_part`) skipped **every** Temporal value:

```rust
if crate::temporal::is_temporal_value(value) { return; }
```

`Temporal.Instant` is anchored to the timeline, so — like a `Date`/number — `formatToParts` should render a zone label for it when `timeZoneName` is requested. Only the *plain* Temporal kinds (`PlainDate`/`PlainTime`/`PlainDateTime`/`PlainYearMonth`/`PlainMonthDay`) are zoneless and must stay suppressed. (`ZonedDateTime`/`Duration` are rejected upstream by `date_arg_to_clipped_ms` and never reach this path.)

### Fix
Suppress only for the plain kinds via `temporal_kind`, letting an `Instant` (and the `Date`/number path) emit the part.

### Validation
`scripts/test262_subset.py --dir intl402/DateTimeFormat`: pass **145**, runtime-fail **78** — unchanged from #5770 (the in-scope `temporal-*-formatting-timezonename` cases use only plain Temporal types, so this is a correctness fix with no test-count delta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `timeZoneName` handling for Temporal values so it now works for Temporal types with an associated time zone.
  * Plain Temporal types without a time zone continue to skip `timeZoneName`, while other supported date and time inputs still display it when enabled.
  * Updated related behavior notes to match the new formatting rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->