### PR TITLE
fix(runtime): #5591 — method-dispatch depth guard leaked across longjmp throws; Uint8Array/Buffer dynamic callbacks silently no-op'd

### DIFF
--- a/crates/perry-runtime/src/exception.rs
+++ b/crates/perry-runtime/src/exception.rs
@@ -59,6 +59,13 @@ struct ExceptionState {
     /// `js_throw` / issue #1830). Indexed by try-depth, in lockstep with
     /// `jump_buffers`.
     shadow_savepoints: [ShadowSavepoint; MAX_TRY_DEPTH],
+    /// `js_native_call_method` recursion depth captured when each `try` was
+    /// pushed. A throw `longjmp`s past the in-flight method frames, skipping
+    /// their `CallMethodDepthGuard` `Drop`s; the unwind path restores this so
+    /// the counter doesn't leak (see `js_throw` / `crate::object`'s
+    /// `call_method_depth_*`). Indexed by try-depth, in lockstep with
+    /// `jump_buffers`.
+    call_method_depths: [u32; MAX_TRY_DEPTH],
     try_depth: usize,
     current_exception: f64,
     has_exception: bool,
@@ -70,6 +77,7 @@ impl ExceptionState {
         ExceptionState {
             jump_buffers: [JmpBuf::new(); MAX_TRY_DEPTH],
             shadow_savepoints: [ShadowSavepoint::EMPTY; MAX_TRY_DEPTH],
+            call_method_depths: [0; MAX_TRY_DEPTH],
             try_depth: 0,
             current_exception: 0.0,
             has_exception: false,
@@ -101,6 +109,10 @@ pub extern "C" fn js_try_push() -> *mut i32 {
         // can push any callee frames, so the unwind path can restore to
         // exactly this point and drop the frames `longjmp` orphans (#1830).
         (*s).shadow_savepoints[depth] = shadow_stack_savepoint();
+        // Capture the method-dispatch recursion depth too, so a throw caught by
+        // this `try` can restore it — `longjmp` skips the `CallMethodDepthGuard`
+        // `Drop`s of the method frames it unwinds (#5591).
+        (*s).call_method_depths[depth] = crate::object::call_method_depth_savepoint();
         (*s).try_depth += 1;
         (*s).jump_buffers[depth].as_mut_ptr()
     })
@@ -169,6 +181,12 @@ pub extern "C" fn js_throw(value: f64) -> ! {
         // already-unwound stack frames (#1830). Restore to the depth captured
         // when this `try` was pushed.
         shadow_stack_restore((*s).shadow_savepoints[depth]);
+        // Restore the method-dispatch recursion depth captured when this `try`
+        // was pushed. The frames we are about to `longjmp` past never run their
+        // `CallMethodDepthGuard` `Drop`s, so without this the counter leaks one
+        // per caught throw and eventually wedges every method call into the
+        // depth-guard fallback (#5591).
+        crate::object::call_method_depth_restore((*s).call_method_depths[depth]);
         (*s).jump_buffers[depth].as_mut_ptr()
     });
     unsafe { longjmp(jb_ptr, 1) }

--- a/crates/perry-runtime/src/object/buffer_dispatch.rs
+++ b/crates/perry-runtime/src/object/buffer_dispatch.rs
@@ -1050,6 +1050,30 @@ pub unsafe fn dispatch_buffer_method(
         // user code, so this is always false (matches Node when `buf` is
         // a Buffer instance rather than `Buffer.prototype`).
         "isPrototypeOf" => i32_bool(0),
-        _ => f64::from_bits(crate::value::TAG_UNDEFINED),
+        // A `Uint8Array` / `Uint8ClampedArray` (and Node `Buffer`, a Uint8Array
+        // subclass) reaches this buffer dispatcher via the dynamic
+        // `(ta as any).method(...)` path — `handle_methods` routes a
+        // registered-buffer receiver here before the `%TypedArray%.prototype`
+        // tower. The arms above only implement the Node `Buffer` API surface, so
+        // the inherited `%TypedArray%.prototype` iteration methods
+        // (`every`/`some`/`map`/`forEach`/`find`/`reduce`/…) fell through to this
+        // catch-all and silently returned `undefined` — never validating the
+        // callback (#5591: `every`/`some` must throw a `TypeError` for a
+        // non-callable callback) nor iterating. Delegate any method the Buffer
+        // API doesn't claim to the shared uint8 typed-array dispatcher (it
+        // validates callbacks and reads the typed store); it returns `None` for
+        // names it doesn't implement, preserving the `undefined` fallback.
+        _ => {
+            if super::typed_array_proto_thunks::is_typed_array_buffer(addr) {
+                if let Some(r) = super::typed_array_proto_thunks::dispatch_uint8_buffer_method(
+                    addr,
+                    method_name,
+                    args,
+                ) {
+                    return r;
+                }
+            }
+            f64::from_bits(crate::value::TAG_UNDEFINED)
+        }
     }
 }

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -477,6 +477,25 @@ impl Drop for CallMethodDepthGuard {
     }
 }
 
+/// Snapshot the current `js_native_call_method` recursion depth. Exception
+/// handling (`js_try_push`) records this at each `try` so the unwind path can
+/// restore it: a `js_throw` `longjmp`s past the in-flight method frames and
+/// skips their `CallMethodDepthGuard` `Drop`s, so without an explicit restore
+/// the counter leaks one per caught throw and — after `MAX_CALL_METHOD_DEPTH`
+/// throw/catch cycles — wedges every subsequent method call into the
+/// stack-overflow fallback (returning the empty null-object instead of
+/// dispatching). See `crate::exception::{js_try_push, js_throw}`.
+pub(crate) fn call_method_depth_savepoint() -> u32 {
+    CALL_METHOD_DEPTH.with(|d| d.get())
+}
+
+/// Restore the `js_native_call_method` recursion depth captured by
+/// [`call_method_depth_savepoint`]. Called on the `longjmp` unwind path so the
+/// frames the throw skips don't leak their depth increments (see above).
+pub(crate) fn call_method_depth_restore(depth: u32) {
+    CALL_METHOD_DEPTH.with(|d| d.set(depth));
+}
+
 /// Static "null object" used as a safe return value when the depth guard triggers.
 /// Instead of returning undefined (which callers may dereference as a null pointer),
 /// we return a pointer to this valid-but-empty object so downstream code doesn't crash.

--- a/crates/perry-runtime/src/object/typed_array_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/typed_array_proto_thunks.rs
@@ -184,7 +184,7 @@ unsafe fn ta_receiver_or_throw(method: &str) -> TypedArrayProtoReceiver {
     throw_not_typed_array(method)
 }
 
-fn is_typed_array_buffer(addr: usize) -> bool {
+pub(super) fn is_typed_array_buffer(addr: usize) -> bool {
     crate::buffer::is_registered_buffer(addr)
         && !crate::buffer::is_any_array_buffer(addr)
         && !crate::buffer::is_data_view(addr)
@@ -519,7 +519,11 @@ fn validate_comparator(args: &[f64]) -> *const crate::closure::ClosureHeader {
     }
 }
 
-unsafe fn dispatch_uint8_buffer_method(addr: usize, method: &str, args: &[f64]) -> Option<f64> {
+pub(super) unsafe fn dispatch_uint8_buffer_method(
+    addr: usize,
+    method: &str,
+    args: &[f64],
+) -> Option<f64> {
     let len = uint8_len(addr);
     let receiver = pointer_value(addr);
     let mut args_ptr = std::ptr::null();

--- a/crates/perry/tests/issue_5591_method_dispatch_throw_depth.rs
+++ b/crates/perry/tests/issue_5591_method_dispatch_throw_depth.rs
@@ -1,0 +1,99 @@
+//! Regression test for #5591: the `js_native_call_method` recursion-depth
+//! guard leaked across thrown-and-caught exceptions.
+//!
+//! Method dispatch is wrapped in a RAII `CallMethodDepthGuard` (a stack-overflow
+//! backstop for circular module init). Perry's exceptions unwind with
+//! `setjmp`/`longjmp`, which does NOT run Rust `Drop`s — so every exception
+//! thrown from inside a method call and caught by an outer `try` skipped the
+//! guard's decrement, leaking one count per throw/catch. After
+//! `MAX_CALL_METHOD_DEPTH` (512) such cycles the guard tripped *permanently* and
+//! every subsequent method call returned the empty null-object fallback instead
+//! of dispatching — so a method that should throw (or compute) silently no-op'd.
+//!
+//! This surfaced in test262's `%TypedArray%.prototype.{every,some}`
+//! callbackfn-not-callable cases: each runs ~11 `assert.throws` cycles per typed
+//! array across every constructor, blowing past 512 cumulative throws mid-suite,
+//! after which the next non-callable `every(NaN)` stopped throwing.
+//!
+//! The fix snapshots the dispatch depth at each `try` (`js_try_push`) and
+//! restores it on the `longjmp` unwind (`js_throw`), mirroring the existing
+//! shadow-stack / async-context restore. This test pins that a long
+//! throw-and-catch loop through method dispatch leaves dispatch fully working.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn method_dispatch_survives_many_caught_throws() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+
+    std::fs::write(
+        &entry,
+        r#"
+const u = new Uint8Array([10, 20]);
+
+// Throw-and-catch through method dispatch far more than MAX_CALL_METHOD_DEPTH
+// (512) times. Each `.every(NaN)` must throw a TypeError (NaN is not callable);
+// with the pre-fix depth leak the throws stopped firing partway through.
+let caught = 0;
+for (let i = 0; i < 2000; i++) {
+  try { (u as any).every(NaN); } catch (e) { caught++; }
+}
+console.log("caught=" + caught);
+
+// After the loop, method dispatch must STILL work — both the throwing path and
+// ordinary value-returning calls. Pre-fix, the guard was wedged and these
+// returned the empty null-object fallback (no throw / wrong value).
+let stillThrows = false;
+try { (u as any).every(NaN); } catch (e) { stillThrows = true; }
+console.log("stillThrows=" + stillThrows);
+
+// A valid callback must still iterate and compute correctly.
+console.log("every=" + (u as any).every((x: number) => x >= 10));
+console.log("map=" + Array.from((u as any).map((x: number) => x + 1)).join(","));
+console.log("len=" + (u as any).length);
+"#,
+    )
+    .expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert_eq!(
+        stdout,
+        "caught=2000\n\
+         stillThrows=true\n\
+         every=true\n\
+         map=11,21\n\
+         len=2\n",
+        "method dispatch must keep working after >512 caught throws — the \
+         depth guard must not leak across longjmp unwinds (#5591)"
+    );
+}

--- a/crates/perry/tests/issue_5591_method_dispatch_throw_depth.rs
+++ b/crates/perry/tests/issue_5591_method_dispatch_throw_depth.rs
@@ -43,7 +43,12 @@ const u = new Uint8Array([10, 20]);
 // with the pre-fix depth leak the throws stopped firing partway through.
 let caught = 0;
 for (let i = 0; i < 2000; i++) {
-  try { (u as any).every(NaN); } catch (e) { caught++; }
+  try {
+    (u as any).every(NaN);
+  } catch (e) {
+    if (!(e instanceof TypeError)) throw e;
+    caught++;
+  }
 }
 console.log("caught=" + caught);
 
@@ -51,7 +56,12 @@ console.log("caught=" + caught);
 // ordinary value-returning calls. Pre-fix, the guard was wedged and these
 // returned the empty null-object fallback (no throw / wrong value).
 let stillThrows = false;
-try { (u as any).every(NaN); } catch (e) { stillThrows = true; }
+try {
+  (u as any).every(NaN);
+} catch (e) {
+  if (!(e instanceof TypeError)) throw e;
+  stillThrows = true;
+}
 console.log("stillThrows=" + stillThrows);
 
 // A valid callback must still iterate and compute correctly.


### PR DESCRIPTION
Part of #5591 (built-ins test262 tail). Fixes the `%TypedArray%.prototype.{every,some}` **callbackfn-not-callable** subcluster, which turned out to have two distinct root causes — one of them a broad, latent correctness bug.

## 1. Method-dispatch depth guard leaked across `longjmp` throws

`js_native_call_method` is wrapped in a RAII `CallMethodDepthGuard` (a stack-overflow backstop for circular module init). Perry's exceptions unwind with `setjmp`/`longjmp`, which does **not** run Rust `Drop`s — so every exception thrown from inside a method call and caught by an outer `try` skipped the guard's decrement, leaking one count per throw/catch.

After `MAX_CALL_METHOD_DEPTH` (512) such cycles the guard tripped **permanently**: every subsequent method call returned the empty null-object fallback instead of dispatching, so a method that should throw (or compute) silently no-op'd. This is exactly the cumulative pattern test262's `every`/`some` suites hit — each runs ~11 `assert.throws` per typed array across every constructor, blowing past 512 cumulative throws mid-suite, after which the next non-callable `every(NaN)` stopped throwing.

This bug affects **any** try/catch-heavy loop that throws through method dispatch (>512 times in a run), not just typed arrays.

**Fix:** snapshot the dispatch depth at each `try` (`js_try_push`) and restore it on the `longjmp` unwind (`js_throw`), mirroring the existing shadow-stack (#1830) and async-context (#788) restores already on that path.

## 2. Uint8Array / Buffer dynamic dispatch skipped callback validation

A `Uint8Array` / `Uint8ClampedArray` / Node `Buffer` reached via the dynamic `(ta as any).method(...)` path routes through `dispatch_buffer_method`, whose match only implements the Node `Buffer` API surface. The inherited `%TypedArray%.prototype` iteration methods (`every`/`some`/`map`/`forEach`/`find`/`reduce`/…) fell through to the catch-all and silently returned `undefined` — never validating the callback nor iterating.

**Fix:** delegate any method the Buffer API doesn't claim, on a uint8-backed view, to the shared `dispatch_uint8_buffer_method` (which validates callbacks and reads the typed store) — matching the `%TypedArray%.prototype` proto-thunk path. It returns `None` for names it doesn't implement, preserving the `undefined` fallback.

## Testing

- **test262** (pinned `4249661`): `built-ins/TypedArray` **839 → 842 pass** — `every`/`some` callbackfn-not-callable and `copyWithin/BigInt/return-this` now pass, **0 regressions**. `built-ins/{Function,JSON,Proxy}` fail counts unchanged (22/27/33), confirming the global depth-guard change doesn't regress throw-heavy subtrees.
- **`cargo test -p perry-runtime`** green (1092 passed; the lone parallel-isolation flake is pre-existing and passes in isolation).
- New regression test `crates/perry/tests/issue_5591_method_dispatch_throw_depth.rs`: a >512-iteration throw-and-catch loop through method dispatch, asserting dispatch keeps throwing/computing correctly afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed method dispatch state after many caught exceptions by properly restoring per-call depth during exception unwinding, preventing dispatch from getting stuck.
  * Improved handling of typed-array-backed buffers when a method name isn’t recognized, restoring expected prototype behavior instead of returning `undefined`.
* **Tests**
  * Added a regression test for repeated throw/catch cycles to ensure dispatch continues working afterward and validates expected `Uint8Array.prototype` results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->