### PR TITLE
fix(streams): drive pull when draining a ReadableStream body into a Response

### DIFF
--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -690,17 +690,34 @@ extern "C" fn readable_pull_microtask(closure: *const ClosureHeader) -> f64 {
 }
 
 pub(super) unsafe fn maybe_pull(stream_id: usize) {
+    maybe_pull_inner(stream_id, false);
+}
+
+/// `maybe_pull` that pulls whenever the source can produce more, ignoring the
+/// highWaterMark / read-request gate. Used by the synchronous body drain
+/// (`new Response(stream)` / `new Request(url, { body: stream })`): that drain
+/// has no parked reader, so for a `highWaterMark: 0` stream the normal
+/// `maybe_pull` would refuse to pull and the body would drain EMPTY (CodeRabbit
+/// #5776). Forcing the pull when the queue is empty drives such a stream to
+/// completion regardless of its strategy.
+pub(super) unsafe fn maybe_pull_force(stream_id: usize) {
+    maybe_pull_inner(stream_id, true);
+}
+
+unsafe fn maybe_pull_inner(stream_id: usize, force: bool) {
     // ShouldCallPull (#4915): a parked read request always justifies a
     // pull (this is what drives byte streams with highWaterMark 0 — the
     // pull only fires once a `read()` / `read(view)` is waiting);
-    // otherwise pull while the queue is under the highWaterMark.
+    // otherwise pull while the queue is under the highWaterMark. `force`
+    // (drain path) pulls whenever the queue is empty regardless of strategy.
     let has_byob_pending = byob::has_pending(stream_id);
     let (cb, controller, should_pull, pull_returns_byte_chunk) = {
         let mut g = READABLE_STREAMS.lock().unwrap();
         match g.get_mut(&stream_id) {
             Some(s) if s.state == ReadableState::Readable && !s.pulling && s.started => {
                 let has_read_request = !s.pending_reads.is_empty() || has_byob_pending;
-                let need = has_read_request
+                let need = (force && s.chunks.is_empty())
+                    || has_read_request
                     || (s.chunks.is_empty() && s.high_water_mark > 0.0)
                     || (!s.chunks.is_empty() && s.queue_total_size < s.high_water_mark);
                 if need && s.pull_cb != 0 {

--- a/crates/perry-stdlib/src/streams/subclass.rs
+++ b/crates/perry-stdlib/src/streams/subclass.rs
@@ -366,28 +366,77 @@ pub unsafe extern "C" fn js_transform_stream_subclass_init(
     f64::from_bits(TAG_UNDEFINED)
 }
 
-/// Read every queued chunk into a Vec<u8>, draining the stream. Used by
-/// `new Response(stream)` / `new Request(url, { body: stream })` — we
-/// drain the buffered chunks at construction time so the resulting
-/// Response.body bytes match what a real serializer would produce.
+/// Drain a ReadableStream's body to bytes, DRIVING its `pull` source. Used by
+/// `new Response(stream)` / `new Request(url, { body: stream })` to materialize
+/// the body at construction time.
+///
+/// The previous implementation snapshotted only the chunks already queued at
+/// the synchronous call instant and force-closed the stream. That worked for a
+/// body whose data was enqueued in `start(controller)` (already queued), but
+/// any data produced by a `pull(controller)` callback — sync OR async — was
+/// silently dropped: `maybe_pull` defers the pull to a microtask that hadn't
+/// run yet, and an async pull defers its `enqueue` further (past `await`). The
+/// canonical victim is axios's `trackStream`, which wraps `response.body` in a
+/// new stream whose async `pull` does `await reader.read()`; `new Response(...)`
+/// then read an empty body and the request never settled.
+///
+/// Instead we loop: collect queued chunks, then ask for the next one
+/// (`maybe_pull`) and run the microtask queue so the (possibly async) pull's
+/// `enqueue`/`close` land, until the stream reaches a terminal state. An idle
+/// counter bounds the loop: a still-open stream that produces nothing through
+/// the microtask runner (a genuinely live source awaiting external I/O) can't
+/// be drained synchronously here and falls back to whatever has arrived. This
+/// mirrors the `await_maybe_promise` pump already used for `node:stream`
+/// consumers (streams.rs).
 #[doc(hidden)]
 pub fn drain_readable_into_bytes(stream_id: usize) -> Vec<u8> {
     let mut out = Vec::new();
-    let chunks: Vec<u64> = {
-        let mut g = READABLE_STREAMS.lock().unwrap();
-        match g.get_mut(&stream_id) {
-            Some(s) => {
-                let drained = s.drain_chunks();
-                s.state = ReadableState::Closed;
-                drained
+    let mut idle = 0u32;
+    // Absolute cap mirrors `await_maybe_promise` — a backstop against a stream
+    // whose pull re-arms forever without ever closing.
+    for _ in 0..1_000_000 {
+        let (chunks, terminal) = {
+            let mut g = READABLE_STREAMS.lock().unwrap();
+            match g.get_mut(&stream_id) {
+                Some(s) => {
+                    let drained = s.drain_chunks();
+                    let terminal =
+                        matches!(s.state, ReadableState::Closed | ReadableState::Errored);
+                    (drained, terminal)
+                }
+                None => break,
             }
-            None => return out,
+        };
+        let mut got_chunk = false;
+        for chunk in chunks {
+            unsafe {
+                if let Some(bytes) = read_bytes_from_chunk(chunk) {
+                    out.extend_from_slice(&bytes);
+                    got_chunk = true;
+                }
+            }
         }
-    };
-    for chunk in chunks {
+        if terminal {
+            break;
+        }
+        // Request the next chunk and let the (possibly async) pull run.
+        // `maybe_pull_force` ignores the highWaterMark/read-request gate so a
+        // `highWaterMark: 0` stream (which has no parked reader here) is still
+        // driven to completion instead of draining empty (CodeRabbit #5776).
         unsafe {
-            if let Some(bytes) = read_bytes_from_chunk(chunk) {
-                out.extend_from_slice(&bytes);
+            maybe_pull_force(stream_id);
+        }
+        perry_runtime::promise::js_promise_run_microtasks();
+        if got_chunk {
+            idle = 0;
+        } else {
+            // No new chunk this round. Give the pull a few microtask turns to
+            // produce one (an async pull's enqueue lands a turn after its
+            // `await`); if it stays empty and unclosed, treat it as a live
+            // source we can't drain here and stop.
+            idle += 1;
+            if idle >= 16 {
+                break;
             }
         }
     }

--- a/crates/perry/tests/response_stream_body_pull.rs
+++ b/crates/perry/tests/response_stream_body_pull.rs
@@ -1,0 +1,210 @@
+//! Regression: `new Response(readableStream).text()` must DRIVE the stream's
+//! `pull` source, not just snapshot the chunks already queued at construction.
+//!
+//! Before the fix, `drain_readable_into_bytes` (perry-stdlib streams/subclass.rs)
+//! drained only the chunks present at the synchronous `new Response(stream)`
+//! instant and force-closed the stream. Data enqueued in `start(controller)`
+//! survived (already queued), but anything produced by a `pull(controller)`
+//! callback — sync OR async — was dropped, so `.text()` returned `""`. The
+//! canonical victim is axios's `trackStream`, which wraps `response.body` in a
+//! new stream whose async `pull` does `await reader.read()`; the empty body
+//! left the request promise unsettled and hung the app at startup.
+//!
+//! Fix: the drain now loops `maybe_pull` + the microtask runner until the
+//! stream reaches a terminal state, so the (possibly async) pull's
+//! `enqueue`/`close` land.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    // Run under a wall-clock timeout: this is a regression test for a HANG, so
+    // `Command::output()` (which waits forever) would stall CI until the
+    // job-level timeout if the bug returns. Poll `try_wait` and kill + fail
+    // fast instead. The program's output is a handful of short lines, so the
+    // stdout/stderr pipes can't fill before exit.
+    let mut child = Command::new(&output)
+        .current_dir(dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn compiled binary");
+    let timeout = Duration::from_secs(30);
+    let start = Instant::now();
+    let status = loop {
+        if let Some(status) = child.try_wait().expect("try_wait on compiled binary") {
+            break status;
+        }
+        if start.elapsed() > timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!(
+                "compiled binary did not exit within {timeout:?} — the Response stream-body \
+                 drain likely regressed to a hang"
+            );
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    };
+    let mut stdout = String::new();
+    if let Some(mut out) = child.stdout.take() {
+        out.read_to_string(&mut stdout).ok();
+    }
+    let mut stderr = String::new();
+    if let Some(mut err) = child.stderr.take() {
+        err.read_to_string(&mut stderr).ok();
+    }
+    assert!(
+        status.success(),
+        "compiled binary failed\nstatus: {status:?}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    stdout
+}
+
+#[test]
+fn response_text_drives_stream_pull() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = compile_and_run(
+        dir.path(),
+        r#"
+async function main(): Promise<void> {
+  const enc = new TextEncoder();
+
+  // 1. Data enqueued in start() — already queued (worked before the fix).
+  const startStream = new ReadableStream({
+    start(c: any): void {
+      c.enqueue(enc.encode("from-start"));
+      c.close();
+    },
+  });
+  console.log("START:" + (await new Response(startStream).text()));
+
+  // 2. Data enqueued by a SYNC pull() — dropped before the fix.
+  const syncPull = new ReadableStream({
+    pull(c: any): void {
+      c.enqueue(enc.encode("from-sync-pull"));
+      c.close();
+    },
+  });
+  console.log("SYNC:" + (await new Response(syncPull).text()));
+
+  // 3. Data enqueued by an ASYNC pull(), produced over multiple turns.
+  let n = 0;
+  const asyncPull = new ReadableStream({
+    async pull(c: any): Promise<void> {
+      await Promise.resolve();
+      n++;
+      c.enqueue(enc.encode("p" + n));
+      if (n >= 3) c.close();
+    },
+  });
+  console.log("ASYNC:" + (await new Response(asyncPull).text()));
+
+  // 4. The axios trackStream shape: a new stream whose async pull reads from
+  //    another stream's reader. This is the exact pattern that hung startup.
+  function track(src: any): ReadableStream<Uint8Array> {
+    const rd = src.getReader();
+    return new ReadableStream({
+      async pull(c: any): Promise<void> {
+        const r = await rd.read();
+        if (r.done) c.close();
+        else c.enqueue(r.value);
+      },
+    });
+  }
+  const base = new ReadableStream({
+    start(c: any): void {
+      c.enqueue(enc.encode("tracked-"));
+      c.enqueue(enc.encode("body"));
+      c.close();
+    },
+  });
+  console.log("TRACK:" + (await new Response(track(base)).text()));
+
+  // 5. arrayBuffer() and json() must drain the pull too.
+  const abStream = new ReadableStream({
+    async pull(c: any): Promise<void> {
+      await Promise.resolve();
+      c.enqueue(enc.encode("xyz"));
+      c.close();
+    },
+  });
+  const ab = await new Response(abStream).arrayBuffer();
+  console.log("ARRBUF:" + new Uint8Array(ab).length);
+
+  const jsonStream = new ReadableStream({
+    async pull(c: any): Promise<void> {
+      await Promise.resolve();
+      c.enqueue(enc.encode('{"k":'));
+      c.enqueue(enc.encode("42}"));
+      c.close();
+    },
+  });
+  const parsed = await new Response(jsonStream).json();
+  console.log("JSON:" + parsed.k);
+
+  // 6. highWaterMark: 0 stream — maybe_pull only pulls a zero-HWM stream when
+  //    a read is pending, and the drain has no parked reader, so the drain
+  //    must FORCE the pull or this returns empty (CodeRabbit #5776).
+  const hwm0 = new ReadableStream(
+    {
+      pull(c: any): void {
+        c.enqueue(enc.encode("hwm0-body"));
+        c.close();
+      },
+    },
+    { highWaterMark: 0 },
+  );
+  console.log("HWM0:" + (await new Response(hwm0).text()));
+}
+main();
+"#,
+    );
+
+    assert!(
+        out.contains("START:from-start"),
+        "start-enqueued body lost: {out}"
+    );
+    assert!(
+        out.contains("SYNC:from-sync-pull"),
+        "sync-pull body lost: {out}"
+    );
+    assert!(out.contains("ASYNC:p1p2p3"), "async-pull body lost: {out}");
+    assert!(
+        out.contains("TRACK:tracked-body"),
+        "trackStream body lost: {out}"
+    );
+    assert!(
+        out.contains("ARRBUF:3"),
+        "async-pull arrayBuffer lost: {out}"
+    );
+    assert!(out.contains("JSON:42"), "async-pull json lost: {out}");
+    assert!(
+        out.contains("HWM0:hwm0-body"),
+        "highWaterMark:0 pull body lost: {out}"
+    );
+}


### PR DESCRIPTION
## Problem

`new Response(stream)` / `new Request(url, { body: stream })` materialize the body at construction via `drain_readable_into_bytes` (`perry-stdlib/src/streams/subclass.rs`). That function snapshotted **only the chunks already queued** at the synchronous call instant, then force-closed the stream.

So a body whose data is enqueued in `start(controller)` survived (already queued), but anything produced by a **`pull(controller)`** callback — sync *or* async — was silently dropped (`.text()` / `.arrayBuffer()` / `.json()` returned `""`):

- `maybe_pull` defers the pull to a microtask that hasn't run yet at construction time, and
- an async `pull` defers its `enqueue` further still (past `await`).

```ts
// Empty before this fix:
const rs = new ReadableStream({ async pull(c) { await Promise.resolve(); c.enqueue(enc.encode("hi")); c.close(); } });
await new Response(rs).text();   // "" — should be "hi"
```

The canonical real-world victim is **axios's fetch adapter**: when `onDownloadProgress` is set it wraps the response body in `trackStream` — a new `ReadableStream` whose async `pull` does `await reader.read()` on the original body — then `await new Response(trackStream(body)).text()`. The empty body left the read (and the request) promise unsettled, which **hangs apps at startup** while they wait on that request.

## Fix

`drain_readable_into_bytes` now **drives the source**: loop — collect queued chunks, then `maybe_pull` + run the microtask queue so the (possibly async) pull's `enqueue`/`close` land — until the stream reaches a terminal state.

An idle counter plus an absolute iteration cap bound the loop (mirroring the `await_maybe_promise` pump already used for `node:stream` consumers in `streams.rs`): a genuinely live source still awaiting external I/O can't be drained synchronously here, so it falls back to whatever has arrived rather than spinning. The microtask runner is re-entrancy-safe (`MICROTASK_RUN_DEPTH`), so driving it from the construction call is sound.

Bodies whose data was already queued in `start()` are byte-for-byte unaffected.

## Test

`crates/perry/tests/response_stream_body_pull.rs` compiles + runs a program covering start-, sync-pull-, async-pull-, multi-async-pull-, and trackStream-shaped bodies across `.text()`, `.arrayBuffer()`, and `.json()`. All return the full body; before the fix the pull-sourced cases returned empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed readable stream draining so data produced by `pull()` callbacks (including async `pull()`) is no longer dropped.
  * Improved stream consumption behavior as streams close, error, or stop producing, ensuring full output is collected.
  * `Response.text()`, `Response.arrayBuffer()`, and `Response.json()` now properly drive `pull()` instead of only consuming already-queued chunks (including a `highWaterMark: 0` scenario).

* **Tests**
  * Added an integration regression test covering multiple production patterns and `pull()`-driven consumption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->