### PR TITLE
fix(fetch): #5757 — send Buffer/Uint8Array request bodies byte-for-byte

### DIFF
--- a/crates/perry-stdlib/src/fetch/dispatch.rs
+++ b/crates/perry-stdlib/src/fetch/dispatch.rs
@@ -174,6 +174,32 @@ pub(crate) unsafe fn body_addr_buffer_bytes(addr: usize) -> Option<Vec<u8>> {
     None
 }
 
+/// Extract a fetch *request* body as raw bytes for the send paths
+/// (`js_fetch_with_options`, `js_fetch_post`). The `body_ptr` codegen hands us is
+/// the body value unboxed to its raw heap address (`unbox_to_i64`), so it can be
+/// either a binary body — a Buffer / Uint8Array / typed array / ArrayBuffer, data
+/// at offset 8 — or a `StringHeader` (a string body, data at offset 20). Probe
+/// the buffer / typed-array registry first so a binary body round-trips
+/// byte-for-byte; only fall back to the `string_from_header` read when the
+/// address isn't a registered binary body.
+///
+/// Reading a binary body straight through `string_from_header` took the byte
+/// length off the right field but the data off the StringHeader data offset (20)
+/// instead of the buffer data offset (8), shifting every binary payload left by
+/// 12 bytes — `fetch(url, { body: Buffer.from("0123456789ABCDEF") })` arrived as
+/// `"CDEF" + zero-fill` (#5757). This is the `fetch(url, init)` twin of
+/// #5435/#5483, which fixed the Response body and the `Request` constructor but
+/// left the fetch send path reading the body as a string.
+pub(crate) unsafe fn fetch_request_body_bytes(body_ptr: *const StringHeader) -> Option<Vec<u8>> {
+    if body_ptr.is_null() || (body_ptr as usize) < 0x1000 {
+        return None;
+    }
+    if let Some(bytes) = body_addr_buffer_bytes(body_ptr as usize) {
+        return Some(bytes);
+    }
+    super::string_from_header(body_ptr).map(String::into_bytes)
+}
+
 lazy_static::lazy_static! {
     static ref FORM_DATA_METHOD_VALUE_CACHE: Mutex<HashMap<(usize, &'static str), u64>> =
         Mutex::new(HashMap::new());

--- a/crates/perry-stdlib/src/fetch/mod.rs
+++ b/crates/perry-stdlib/src/fetch/mod.rs
@@ -539,7 +539,11 @@ pub unsafe extern "C" fn js_fetch_post(
         }
     };
 
-    let body = string_from_header(body_ptr).unwrap_or_default();
+    // Probe the buffer/typed-array registry before falling back to a string read
+    // so a binary body (Buffer / Uint8Array / typed array / ArrayBuffer) is sent
+    // byte-for-byte instead of being shifted left 12 bytes by the StringHeader
+    // data offset (#5757). `reqwest::Body` accepts `Vec<u8>` directly.
+    let body = fetch_request_body_bytes(body_ptr).unwrap_or_default();
     let content_type =
         string_from_header(content_type_ptr).unwrap_or_else(|| "application/json".to_string());
 
@@ -630,7 +634,10 @@ pub unsafe extern "C" fn js_fetch_with_options(
     let inputs = match request_handle::resolve_fetch_inputs(
         string_from_header(url_ptr),
         string_from_header(method_ptr),
-        string_from_header(body_ptr),
+        // Read the body as raw bytes (binary bodies probe the buffer/typed-array
+        // registry first) so a Buffer/Uint8Array body isn't corrupted by a lossy
+        // StringHeader read (#5757).
+        fetch_request_body_bytes(body_ptr),
         string_from_header(headers_json_ptr),
         url_ptr as usize,
     ) {

--- a/crates/perry-stdlib/src/fetch/request_handle.rs
+++ b/crates/perry-stdlib/src/fetch/request_handle.rs
@@ -51,7 +51,7 @@ fn request_fields_from_handle(maybe_handle: usize) -> Option<RequestFetchFields>
 pub(crate) fn resolve_fetch_inputs(
     url_from_header: Option<String>,
     method_from_header: Option<String>,
-    body_from_header: Option<String>,
+    body_bytes: Option<Vec<u8>>,
     headers_json: Option<String>,
     url_handle: usize,
 ) -> Result<FetchInputs, u64> {
@@ -73,9 +73,10 @@ pub(crate) fn resolve_fetch_inputs(
         .or_else(|| request_fields.as_ref().map(|rf| rf.method.clone()))
         .unwrap_or_else(|| "GET".to_string());
 
-    let body = body_from_header
-        .map(String::into_bytes)
-        .or_else(|| request_fields.as_ref().and_then(|rf| rf.body.clone()));
+    // `body_bytes` is already raw bytes (binary bodies preserved byte-for-byte by
+    // the caller's buffer/typed-array probe; string bodies read as their UTF-8
+    // bytes), so use it as-is and only fall back to the Request's own body.
+    let body = body_bytes.or_else(|| request_fields.as_ref().and_then(|rf| rf.body.clone()));
 
     // Start from the `Request`'s own headers (the `fetch(Request)` form), then
     // let any `init.headers` override per-key. WHATWG says init headers win, but


### PR DESCRIPTION
## What

Fixes the **body-corruption** half of #5757: `fetch(url, { body: Buffer.from(...) })` (and `Uint8Array` / typed-array / `ArrayBuffer` bodies) arrived at the server corrupted.

### Root cause

The fetch send paths (`js_fetch_post`, `js_fetch_with_options`) read the body via `string_from_header(body_ptr)`. A binary body is a `BufferHeader` (`{length@0, capacity@4}`, data at offset **8**) / `TypedArrayHeader`, **not** a `StringHeader` (`{utf16_len@0, byte_len@4, …}`, data at offset **20**). So the read took the length off the wrong field and the data **12 bytes past** the payload — shifting every binary body left by 12 bytes and zero-filling the tail.

For the issue's repro, `Buffer.from("0123456789ABCDEF")` (16 bytes) arrived as `"CDEF"` + 12 NULs.

### Fix

New `fetch_request_body_bytes()` probes the buffer/typed-array registry first (binary body → real bytes copied byte-for-byte) and only falls back to the `string_from_header` read for genuine string bodies. `resolve_fetch_inputs` now carries the body as `Option<Vec<u8>>`. String bodies are unchanged.

This is the `fetch(url, init)` twin of #5435 / #5483, which fixed the `Response` body and the `Request` constructor but left the fetch **send** path reading the body as a string.

### Verification

- `fetch(url, { body: Buffer.from("0123456789ABCDEF") })` → server receives `0123456789ABCDEF` (was `CDEF\0\0…`).
- Variants confirmed byte-for-byte: string, `Buffer`, `Uint8Array`, short string.
- Existing `perry-stdlib` fetch unit tests pass (incl. `init_headers_are_lowercased_so_they_override`).

## Out of scope (separate, deeper bug)

#5757 also reports the POST **response** not arriving. That turned out to be a **distinct, pre-existing concurrency bug**, independent of the body: when one process is both an HTTP server and a fetch client, a reqwest request to the in-process hyper server on the shared tokio runtime can hit a **lost-wakeup** (the request future parks forever). It is load-sensitive and reproduces on `main` without this change (and with plain string bodies). Neither disabling connection pooling nor giving fetch its own runtime fully resolved it under load, so it needs its own focused fix — filed separately. This PR is scoped to the body corruption, which it fixes cleanly.

https://claude.ai/code/session_01GrSceRSWwEPaRZZd8TNBKv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed fetch requests with binary bodies so Buffers, typed arrays, and ArrayBuffers are sent byte-for-byte without offset or encoding corruption.
  * Improved handling of POST and request-based fetch calls to preserve raw body content more reliably.
  * Existing header merging behavior for fetch options remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->