### PR TITLE
fix(hir): clear callee marker when lowering short-circuit/conditional operands

### DIFF
--- a/crates/perry-hir/src/lower/expr_misc.rs
+++ b/crates/perry-hir/src/lower/expr_misc.rs
@@ -31,13 +31,24 @@ use crate::lower_patterns::unescape_template;
 use super::{lower_expr, LoweringContext};
 
 pub(super) fn lower_cond(ctx: &mut LoweringContext, cond: &ast::CondExpr) -> Result<Expr> {
-    let condition = Box::new(lower_expr(ctx, &cond.test)?);
-    let then_expr = Box::new(lower_expr(ctx, &cond.cons)?);
-    let else_expr = Box::new(lower_expr(ctx, &cond.alt)?);
+    // A conditional in callee position — `(c ? a : JSON.parse)(x)` — is itself
+    // the callee; its branches are values, not the immediate callee member, so
+    // `lowering_call_callee` must not leak into them. Left set, the member-tail
+    // reroute-undo collapses a builtin-namespace member in a branch
+    // (`JSON.parse`) to the value-less intrinsic form, which lowers to
+    // `undefined` → the result throws "value is not a function" when called.
+    // See `arm_bin.rs` for the full rationale; a nested *call* branch re-sets
+    // the flag for its own callee, so direct intrinsic calls are unaffected.
+    let prev_call_callee = ctx.lowering_call_callee;
+    ctx.lowering_call_callee = false;
+    let condition = lower_expr(ctx, &cond.test);
+    let then_expr = lower_expr(ctx, &cond.cons);
+    let else_expr = lower_expr(ctx, &cond.alt);
+    ctx.lowering_call_callee = prev_call_callee;
     Ok(Expr::Conditional {
-        condition,
-        then_expr,
-        else_expr,
+        condition: Box::new(condition?),
+        then_expr: Box::new(then_expr?),
+        else_expr: Box::new(else_expr?),
     })
 }
 
@@ -260,10 +271,16 @@ pub(super) fn lower_seq(ctx: &mut LoweringContext, seq: &ast::SeqExpr) -> Result
     // the last value. e.g., `(a++, b++, c)` evaluates a++, then b++,
     // then returns c. All sub-exprs run for side effects (the for-loop
     // update slot uses this when chaining `it3--, i++`).
-    let mut exprs = Vec::new();
-    for expr in &seq.exprs {
-        exprs.push(lower_expr(ctx, expr)?);
-    }
+    // A comma sequence in callee position — `(a, JSON.parse)(x)` — is itself
+    // the callee; its elements are values, not the immediate callee member, so
+    // `lowering_call_callee` must not leak into them (else a builtin-namespace
+    // member collapses to the value-less intrinsic form → `undefined` → "value
+    // is not a function" when called). See `arm_bin.rs` for the full rationale.
+    let prev_call_callee = ctx.lowering_call_callee;
+    ctx.lowering_call_callee = false;
+    let lowered: Result<Vec<Expr>> = seq.exprs.iter().map(|e| lower_expr(ctx, e)).collect();
+    ctx.lowering_call_callee = prev_call_callee;
+    let mut exprs = lowered?;
     if exprs.len() == 1 {
         Ok(exprs.pop().unwrap())
     } else {

--- a/crates/perry-hir/src/lower/lower_expr/arm_bin.rs
+++ b/crates/perry-hir/src/lower/lower_expr/arm_bin.rs
@@ -163,8 +163,26 @@ pub(crate) fn lower_bin_expr(ctx: &mut LoweringContext, bin: &ast::BinExpr) -> R
         return Ok(Expr::InstanceOf { expr, ty, ty_expr });
     }
 
-    let left = Box::new(lower_expr(ctx, &bin.left)?);
-    let right = Box::new(lower_expr(ctx, &bin.right)?);
+    // `lowering_call_callee` flags the IMMEDIATE callee member so a direct
+    // `JSON.parse(x)` / `Date.now()` takes the intrinsic fast path (and the
+    // member-tail reroute-undo collapses the receiver to bare `GlobalGet(0)`).
+    // A binary/logical expression in callee position — `(K || JSON.parse)(x)`,
+    // `(a ?? B.method)(x)`, `(a && f)(x)` — is ITSELF the callee; its operands
+    // are values, never the immediate callee member. The flag must not leak
+    // into them: left set, the reroute-undo (#4596/#4627) would collapse a
+    // nested builtin-namespace member (`JSON.parse`) to the value-less
+    // intrinsic form `PropertyGet { GlobalGet(0), <method> }`, which has no
+    // value materialization (the namespace name is gone) and lowers to
+    // `undefined` — so the short-circuit result throws "value is not a
+    // function" when called. A nested *call* operand (`(f() + 1)`) re-sets the
+    // flag for its own callee, so direct intrinsic calls are unaffected.
+    let prev_call_callee = ctx.lowering_call_callee;
+    ctx.lowering_call_callee = false;
+    let left = lower_expr(ctx, &bin.left);
+    let right = lower_expr(ctx, &bin.right);
+    ctx.lowering_call_callee = prev_call_callee;
+    let left = Box::new(left?);
+    let right = Box::new(right?);
 
     match bin.op {
         // Arithmetic

--- a/crates/perry/tests/short_circuit_builtin_callee.rs
+++ b/crates/perry/tests/short_circuit_builtin_callee.rs
@@ -1,0 +1,144 @@
+//! Regression: a native builtin (`JSON.parse` / `JSON.stringify`) used as the
+//! result of a `||` / `??` / `&&` short-circuit expression that is then CALLED
+//! must materialize the real callable, not `undefined`.
+//!
+//! Before the fix, `(K || JSON.parse)('...')` threw `TypeError: value is not a
+//! function`. Root cause was in perry-hir: lowering a call sets the
+//! `lowering_call_callee` marker before lowering the callee, but a logical
+//! expression in callee position (`(K || JSON.parse)`) is itself the callee —
+//! its operands are values, not the immediate callee member. The marker leaked
+//! through `lower_bin_expr` into the `JSON.parse` operand, so the member-tail
+//! reroute-undo collapsed it to the value-less intrinsic form
+//! `PropertyGet { GlobalGet(0), "parse" }` (the namespace name dropped), which
+//! lowers to `undefined`. Stored-then-called (`let g = K || JSON.parse; g(x)`)
+//! and direct calls (`JSON.parse(x)`) were unaffected because the marker was
+//! correctly false / true there.
+//!
+//! Fix: `lower_bin_expr` clears `lowering_call_callee` while lowering its
+//! operands, so a nested builtin-namespace member keeps its reified value form.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    // Wall-clock timeout: kill + fail fast rather than stalling CI if the
+    // compiled binary misbehaves. Output is a few short lines, so the pipes
+    // can't fill before exit.
+    let mut child = Command::new(&output)
+        .current_dir(dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn compiled binary");
+    let timeout = Duration::from_secs(30);
+    let start = Instant::now();
+    let status = loop {
+        if let Some(status) = child.try_wait().expect("try_wait on compiled binary") {
+            break status;
+        }
+        if start.elapsed() > timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("compiled binary did not exit within {timeout:?}");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    };
+    let mut stdout = String::new();
+    if let Some(mut out) = child.stdout.take() {
+        out.read_to_string(&mut stdout).ok();
+    }
+    let mut stderr = String::new();
+    if let Some(mut err) = child.stderr.take() {
+        err.read_to_string(&mut stderr).ok();
+    }
+    assert!(
+        status.success(),
+        "compiled binary failed\nstatus: {status:?}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    stdout
+}
+
+#[test]
+fn short_circuit_native_builtin_callee() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = compile_and_run(
+        dir.path(),
+        r#"
+// Native builtin reached via || in callee position, then called.
+function viaOr(K: any): any { return (K || JSON.parse)('{"x":1}'); }
+// Native builtin via ?? in callee position.
+function viaCoalesce(K: any): any { return (K ?? JSON.parse)('{"x":2}'); }
+// JSON.stringify via || in callee position.
+function stringifyViaOr(K: any): string { return (K || JSON.stringify)({ y: 3 }); }
+// Native builtin via && in callee position (K truthy -> returns JSON.parse).
+function viaAnd(K: any): any { return (K && JSON.parse)('{"x":6}'); }
+// USER function via || must keep working.
+function userViaOr(K: any): any { const u = (s: string) => JSON.parse(s); return (K || u)('{"x":4}'); }
+// Stored-then-called must keep working.
+function stored(K: any): any { let g = K || JSON.parse; return g('{"x":7}'); }
+// Direct intrinsic call must keep its fast path.
+function direct(s: string): any { return JSON.parse(s); }
+// Native builtin via ternary in callee position.
+function viaTernary(K: any): any { return (K ? K : JSON.parse)('{"x":8}'); }
+// Native builtin via comma sequence in callee position.
+function viaComma(K: any): any { return (0, JSON.parse)('{"x":9}'); }
+
+console.log("OR:" + viaOr(undefined).x);
+console.log("COALESCE:" + viaCoalesce(undefined).x);
+console.log("STRINGIFY:" + stringifyViaOr(undefined));
+console.log("AND:" + viaAnd("truthy").x);
+console.log("USER:" + userViaOr(undefined).x);
+console.log("STORED:" + stored(undefined).x);
+console.log("DIRECT:" + direct('{"x":5}').x);
+console.log("TERNARY:" + viaTernary(undefined).x);
+console.log("COMMA:" + viaComma(undefined).x);
+"#,
+    );
+
+    assert!(out.contains("OR:1"), "JSON.parse via || lost: {out}");
+    assert!(out.contains("COALESCE:2"), "JSON.parse via ?? lost: {out}");
+    assert!(
+        out.contains("STRINGIFY:{\"y\":3}"),
+        "JSON.stringify via || lost: {out}"
+    );
+    assert!(out.contains("AND:6"), "JSON.parse via && lost: {out}");
+    assert!(out.contains("USER:4"), "user fn via || regressed: {out}");
+    assert!(
+        out.contains("STORED:7"),
+        "stored-then-called regressed: {out}"
+    );
+    assert!(
+        out.contains("DIRECT:5"),
+        "direct JSON.parse call regressed: {out}"
+    );
+    assert!(
+        out.contains("TERNARY:8"),
+        "JSON.parse via ternary lost: {out}"
+    );
+    assert!(out.contains("COMMA:9"), "JSON.parse via comma lost: {out}");
+}


### PR DESCRIPTION
## Problem

Calling a native builtin reached through a short-circuit or conditional expression threw `TypeError: value is not a function` when the builtin branch was taken:

```ts
(K || JSON.parse)(x)      // K falsy  → throws
(K ?? JSON.parse)(x)      // K nullish → throws
(c ? a : JSON.parse)(x)   // c falsy  → throws
(0, JSON.parse)(x)        // comma     → throws
```

A user function via `||`, a builtin stored-then-called (`let g = K || JSON.parse; g(x)`), and a direct intrinsic call (`JSON.parse(x)`) all worked — only the *inline* short-circuit/conditional callee broke.

## Root cause (perry-hir)

Lowering a call sets `ctx.lowering_call_callee = true` before lowering the callee, so a **direct** intrinsic call (`JSON.parse(x)`, `Date.now()`) takes the fast path: the member-tail reroute-undo collapses the receiver to a bare `GlobalGet(0)` and codegen emits the intrinsic directly.

But a binary/logical/conditional/sequence expression in callee position is **itself** the callee — its operands/branches are *values*, not the immediate callee member. The marker leaked through `lower_bin_expr` / `lower_cond` / `lower_seq` into those operands, so a nested builtin-namespace member (`JSON.parse`) was collapsed to the value-less intrinsic form `PropertyGet { GlobalGet(0), "parse" }` (the namespace name dropped). That form has no value materialization and lowers to `undefined` — so the short-circuit/conditional result threw when called.

Verified via `--trace hir`: the buggy `||`-callee form was `PropertyGet { GlobalGet(0), "parse" }`; the working let-init form was `PropertyGet { PropertyGet { GlobalGet(0), "JSON" }, "parse" }`. Routing the collapsed form by property name alone would be unsound (`JSON.parse` and `Date.parse` both collapse to `…, "parse"`), so the fix is to not collapse it.

## Fix

Save/clear/restore `lowering_call_callee` around lowering the operands in `lower_bin_expr` (`||`/`??`/`&&`/all binary ops), `lower_cond` (ternary), and `lower_seq` (comma). A nested *call* operand re-sets the flag for its own callee, so direct intrinsic calls keep their fast path.

This is the runtime shape behind axios's `transformRequest` (`(K || JSON.parse)(data)`) and other `(x || nativeBuiltin)()` sites.

## Test

`crates/perry/tests/short_circuit_builtin_callee.rs` (run under a wall-clock timeout): native builtin via `||` / `??` / `&&` / ternary / comma callees, plus user-fn-via-`||`, stored-then-called, and direct `JSON.parse(x)` (all must keep working). `cargo test -p perry-hir` and `-p perry-codegen` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed short-circuit, conditional, comma, and binary expression lowering so nested call targets are handled correctly.
  * Prevented built-in callees like `JSON.parse` and `JSON.stringify` from being misread as non-callable values in these expression forms.

* **Tests**
  * Added a regression test covering direct calls, stored calls, and short-circuit/conditional callee patterns to verify expected runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->