### PR TITLE
fix(hir): allow new.target in direct eval inside class field initializers (#5780 cluster B)

### DIFF
--- a/crates/perry-hir/src/lower_decl/class_members.rs
+++ b/crates/perry-hir/src/lower_decl/class_members.rs
@@ -943,12 +943,17 @@ pub fn lower_class_prop(ctx: &mut LoweringContext, prop: &ast::ClassProp) -> Res
     // Lower initializer expression if present. Mark the field-initializer
     // context so a direct `eval` in the initializer rejects `arguments`
     // (PerformEval early error — field initializers have no arguments object).
+    // Also set `in_nonarrow_fn` so a direct eval in the initializer allows
+    // `new.target` (ES2025 §sec-performeval-rules-in-initializer: the eval
+    // runs "inside a function" for new.target purposes).
     // NamedEvaluation: an anonymous function/arrow/class initializer takes
     // the field's name (`static fromArgs = function(){}` → `.name ===
     // "fromArgs"`, test262 elements/static-field-anonymous-function-name).
     // Computed keys (key_expr) have no compile-time name to confer.
     let saved_field_init = ctx.in_class_field_init;
+    let saved_in_nonarrow_fn = ctx.in_nonarrow_fn;
     ctx.in_class_field_init = true;
+    ctx.in_nonarrow_fn = true;
     let init = prop
         .value
         .as_ref()
@@ -964,6 +969,7 @@ pub fn lower_class_prop(ctx: &mut LoweringContext, prop: &ast::ClassProp) -> Res
         })
         .transpose();
     ctx.in_class_field_init = saved_field_init;
+    ctx.in_nonarrow_fn = saved_in_nonarrow_fn;
     let init = init?;
 
     Ok(ClassField {

--- a/crates/perry-hir/src/lower_decl/private_members.rs
+++ b/crates/perry-hir/src/lower_decl/private_members.rs
@@ -377,11 +377,16 @@ pub fn lower_private_prop(
 
     // Lower initializer expression if present — field-initializer context for
     // the direct-eval `arguments` early error (see `lower_class_prop`).
+    // Also set `in_nonarrow_fn` so a direct eval in the initializer allows
+    // `new.target` (ES2025 §sec-performeval-rules-in-initializer: the eval
+    // runs "inside a function" for new.target purposes).
     // NamedEvaluation: an anonymous function initializer takes the private
     // field's name including the `#` (`static #field = function(){}` →
     // `.name === "#field"`, test262 static-field-anonymous-function-name).
     let saved_field_init = ctx.in_class_field_init;
+    let saved_in_nonarrow_fn = ctx.in_nonarrow_fn;
     ctx.in_class_field_init = true;
+    ctx.in_nonarrow_fn = true;
     let init = prop
         .value
         .as_ref()
@@ -397,6 +402,7 @@ pub fn lower_private_prop(
         })
         .transpose();
     ctx.in_class_field_init = saved_field_init;
+    ctx.in_nonarrow_fn = saved_in_nonarrow_fn;
     let init = init?;
 
     Ok(ClassField {


### PR DESCRIPTION
## Summary

Fixes cluster B of #5780: Perry was throwing `SyntaxError: new.target expression is not allowed` for `eval("new.target")` inside class field initializers, where Node does not.

**Root cause:** ES2025 §sec-performeval-rules-in-initializer says a direct `eval` inside a class field initializer runs "inside a function" for `new.target` purposes — so `eval("new.target")` is legal there. The `in_nonarrow_fn` flag introduced by #5766 was not being set when lowering class field initializer expressions (`lower_class_prop` and `lower_private_prop`), so Perry incorrectly rejected those calls.

**Fix:** Save/set/restore `in_nonarrow_fn = true` around the initializer lowering in both `lower_class_prop` (`class_members.rs`) and `lower_private_prop` (`private_members.rs`), matching the existing `in_class_field_init` pattern already present in both functions.

## Affected test262 cases (6)

```
language/expressions/class/elements/private-direct-eval-err-contains-newtarget.js
language/expressions/class/elements/arrow-body-private-direct-eval-err-contains-newtarget.js
language/expressions/class/elements/nested-private-direct-eval-err-contains-newtarget.js
language/statements/class/elements/private-direct-eval-err-contains-newtarget.js
language/statements/class/elements/arrow-body-private-direct-eval-err-contains-newtarget.js
language/statements/class/elements/nested-private-direct-eval-err-contains-newtarget.js
```

All test the pattern:
```javascript
var C = class {
  #x = eval('new.target;');  // private field initializer
}
new C();  // must not throw
```

## No regressions

`eval("new.target")` at module top-level and inside arrow functions at top-level still correctly throw `SyntaxError` (those paths leave `in_nonarrow_fn = false`).

## Checklist

- `cargo fmt --all -- --check` ✓
- `bash scripts/check_file_size.sh` ✓
- Code-only (no version bumps, no changelog, no CLAUDE.md changes)

---
_Generated by [Claude Code](https://claude.ai/code/session_0123xxNSSuYRdJLeC6JbPuMq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved class field initialization so direct `eval` and similar constructs behave more like they do inside a function during initializer evaluation.
  * Fixed private and public field initializers to temporarily use the correct execution context, then restore it afterward.
  * This helps preserve expected `new.target`-related behavior in class field initializers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->