### PR TITLE
fix(http): implement IncomingMessage.pipe() so node-fetch/gaxios bodies flow

### DIFF
--- a/crates/perry-ext-http/src/client_events.rs
+++ b/crates/perry-ext-http/src/client_events.rs
@@ -4,6 +4,52 @@
 
 use super::*;
 
+extern "C" {
+    /// perry-runtime method dispatch by string key (`obj[name](args)`,
+    /// binding `this = obj`). Used to drive `dest.write(chunk)` / `dest.end()`
+    /// on a `.pipe(dest)` destination.
+    fn js_native_call_method_str_key(
+        object: f64,
+        name_handle: i64,
+        args_ptr: *const f64,
+        args_len: usize,
+    ) -> f64;
+}
+
+/// Forward a body chunk to a `.pipe(dest)` destination: `dest.write(chunk)`.
+/// `dest_bits` is the NaN-boxed destination value captured by `pipe()`.
+unsafe fn forward_pipe_write(dest_bits: u64, bytes: &[u8], encoding: Option<&str>) {
+    if bytes.is_empty() {
+        return;
+    }
+    let name = alloc_string("write");
+    let name_ptr = name.as_raw();
+    if name_ptr.is_null() {
+        return;
+    }
+    let chunk = body_chunk_value(bytes, encoding);
+    if chunk.to_bits() == TAG_UNDEFINED {
+        return;
+    }
+    let args = [chunk];
+    js_native_call_method_str_key(f64::from_bits(dest_bits), name_ptr as i64, args.as_ptr(), 1);
+}
+
+/// Finish a `.pipe(dest)` destination once the response body ends: `dest.end()`.
+unsafe fn forward_pipe_end(dest_bits: u64) {
+    let name = alloc_string("end");
+    let name_ptr = name.as_raw();
+    if name_ptr.is_null() {
+        return;
+    }
+    js_native_call_method_str_key(
+        f64::from_bits(dest_bits),
+        name_ptr as i64,
+        std::ptr::null(),
+        0,
+    );
+}
+
 /// Fire a client request's `event` listeners with no arguments.
 ///
 /// # Safety
@@ -132,6 +178,7 @@ pub(crate) unsafe fn handle_response_event(
         body,
         listeners: HashMap::new(),
         encoding: None,
+        pipes: Vec::new(),
     });
 
     // Hand the IncomingMessage handle to the user's `(res) => { ... }`
@@ -191,6 +238,17 @@ pub(crate) unsafe fn handle_response_event(
         }
     }
 
+    // Forward the buffered body to any `.pipe(dest)` destinations registered
+    // during the response callback above (node-fetch: `res.pipe(new
+    // PassThrough())`). Deliver the whole body as one write, then end.
+    let pipes = get_handle_mut::<IncomingMessageHandle>(incoming)
+        .map(|r| r.pipes.clone())
+        .unwrap_or_default();
+    for dest in pipes {
+        forward_pipe_write(dest, &body_clone, encoding.as_deref());
+        forward_pipe_end(dest);
+    }
+
     // Node emits `'close'` on the request once the response has fully
     // ended (#4905).
     fire_request_close_once(request_handle);
@@ -226,6 +284,7 @@ pub(crate) unsafe fn handle_response_head_event(
         body: Vec::new(),
         listeners: HashMap::new(),
         encoding: None,
+        pipes: Vec::new(),
     });
     let response_callback = with_handle_mut::<ClientRequestHandle, _, _>(request_handle, |req| {
         req.incoming_handle = incoming;
@@ -267,17 +326,27 @@ pub(crate) unsafe fn handle_response_chunk_event(request_handle: Handle, chunk: 
     if incoming == 0 || done {
         return;
     }
-    let (data_listeners, encoding) = get_handle_mut::<IncomingMessageHandle>(incoming)
+    let (data_listeners, encoding, pipes) = get_handle_mut::<IncomingMessageHandle>(incoming)
         .map(|r| {
             (
                 r.listeners.get("data").cloned().unwrap_or_default(),
                 r.encoding.clone(),
+                r.pipes.clone(),
             )
         })
         .unwrap_or_default();
+    // Forward to `.pipe(dest)` destinations (node-fetch streams the body out
+    // this way and registers no `'data'` listener).
+    for dest in &pipes {
+        forward_pipe_write(*dest, chunk.as_ref(), encoding.as_deref());
+    }
     if data_listeners.is_empty() {
-        if let Some(im) = get_handle_mut::<IncomingMessageHandle>(incoming) {
-            im.body.extend_from_slice(&chunk);
+        // Buffer for a late `'data'` listener only when the body isn't being
+        // piped out (a pipe consumes it eagerly above).
+        if pipes.is_empty() {
+            if let Some(im) = get_handle_mut::<IncomingMessageHandle>(incoming) {
+                im.body.extend_from_slice(&chunk);
+            }
         }
         return;
     }
@@ -349,6 +418,15 @@ pub(crate) unsafe fn handle_response_end_event(request_handle: Handle) {
             let closure = JsClosure::from_raw(cb as *const RawClosureHeader);
             let _ = closure.call0();
         }
+    }
+
+    // End any `.pipe(dest)` destinations now that the body is complete (the
+    // body chunks were forwarded as they arrived).
+    let pipes = get_handle_mut::<IncomingMessageHandle>(incoming)
+        .map(|r| r.pipes.clone())
+        .unwrap_or_default();
+    for dest in pipes {
+        forward_pipe_end(dest);
     }
 
     fire_request_close_once(request_handle);

--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -251,6 +251,11 @@ fn scan_http_roots(visitor: &mut GcRootVisitor<'_>) {
                 visitor.visit_i64_slot(cb);
             }
         }
+        // `.pipe(dest)` destinations are live JS values held until the body
+        // streams through them; relocate them if the copying GC moves them.
+        for dest in &mut msg.pipes {
+            visitor.visit_nanbox_u64_slot(dest);
+        }
     });
 
     // #2154: stored `agent.createConnection` / `.createSocket` closures.
@@ -367,6 +372,12 @@ pub struct IncomingMessageHandle {
     pub body: Vec<u8>,
     pub listeners: HashMap<String, Vec<i64>>,
     pub encoding: Option<String>,
+    /// `.pipe(dest)` destinations as NaN-boxed value bits. Node's
+    /// `readable.pipe(writable)` forwards every body chunk to `dest.write()`
+    /// and ends it with `dest.end()`; node-fetch reads the response body this
+    /// way (`res.pipe(new PassThrough())`), so without it the destination
+    /// stream never receives data and `response.text()` never settles.
+    pub pipes: Vec<u64>,
 }
 
 unsafe impl Send for IncomingMessageHandle {}
@@ -1386,6 +1397,20 @@ pub unsafe extern "C" fn js_http_incoming_message_set_encoding(
         js_node_http_im_set_encoding(handle, encoding_ptr);
     }
     handle
+}
+
+/// `res.pipe(dest)` for a client `IncomingMessage`: remember the destination
+/// writable so the body-delivery handlers forward each chunk to `dest.write()`
+/// and finish it with `dest.end()`. Returns `dest` per Node's
+/// pipe-returns-destination contract (node-fetch keeps only the return value:
+/// `const body = res.pipe(new PassThrough())`). Without this the destination
+/// never receives data and `response.text()` hangs forever.
+#[no_mangle]
+pub unsafe extern "C" fn js_http_incoming_message_pipe(handle: Handle, dest: f64) -> f64 {
+    with_handle_mut::<IncomingMessageHandle, _, _>(handle, |res| {
+        res.pipes.push(dest.to_bits());
+    });
+    dest
 }
 
 /// Distinct external-client setter for stdlib fallback dispatch. The legacy

--- a/crates/perry-ext-http/src/tests.rs
+++ b/crates/perry-ext-http/src/tests.rs
@@ -88,6 +88,7 @@ fn gc_mutable_scanner_rewrites_request_response_listener_roots() {
         body: Vec::new(),
         listeners: incoming_listeners,
         encoding: None,
+        pipes: Vec::new(),
     });
 
     let _ = perry_runtime::gc::gc_collect_minor();

--- a/crates/perry-stdlib/src/common/dispatch_http.rs
+++ b/crates/perry-stdlib/src/common/dispatch_http.rs
@@ -145,7 +145,7 @@ pub(super) unsafe fn dispatch_client_incoming_method(
     method_name: &str,
     args: &[f64],
 ) -> Option<f64> {
-    if !matches!(method_name, "setEncoding" | "on" | "addListener") {
+    if !matches!(method_name, "setEncoding" | "on" | "addListener" | "pipe") {
         return None;
     }
 
@@ -160,6 +160,7 @@ pub(super) unsafe fn dispatch_client_incoming_method(
             event_ptr: *const perry_runtime::StringHeader,
             callback: i64,
         ) -> i64;
+        fn js_http_incoming_message_pipe(handle: i64, dest: f64) -> f64;
     }
 
     if unsafe { js_http_is_incoming_message(handle) } == 0 {
@@ -183,6 +184,10 @@ pub(super) unsafe fn dispatch_client_incoming_method(
             }
             self_ref
         }
+        // `res.pipe(dest)` — register the destination and return it (Node's
+        // pipe-returns-destination contract; node-fetch reads the response
+        // body via `res.pipe(new PassThrough())`).
+        "pipe" if !args.is_empty() => unsafe { js_http_incoming_message_pipe(handle, args[0]) },
         _ => f64::from_bits(0x7FFC_0000_0000_0001),
     };
     Some(value)

--- a/crates/perry/tests/incoming_message_pipe.rs
+++ b/crates/perry/tests/incoming_message_pipe.rs
@@ -1,0 +1,131 @@
+//! Regression (#5783): `IncomingMessage.pipe(dest)` must (a) return `dest`
+//! and (b) forward the response body to `dest.write()` / `dest.end()`.
+//!
+//! Before the fix, a client response's `.pipe()` was unimplemented: it returned
+//! `undefined` and never moved any bytes into the destination stream. The
+//! canonical victim is node-fetch, which reads every response body as
+//! `const body = res.pipe(new PassThrough())` and then consumes `body`. With a
+//! dead PassThrough, `response.text()` never settled, so the gaxios/node-fetch
+//! request promise hung forever — which stalled the TUI onboarding's preflight
+//! connectivity check (its `await client.get(...)` never returned), so the app
+//! painted the splash and then hung awaiting a step that could never advance.
+//!
+//! This drives the exact shape against a local HTTP server (deterministic, no
+//! external network): `http.get(...).pipe(new PassThrough())`, read the
+//! PassThrough, and assert the full body arrives and the process exits.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    // Run under a wall-clock timeout: this is a regression test for a HANG, so
+    // a plain `output()` would stall until the job-level timeout if the bug
+    // returns. Poll `try_wait`, kill + fail fast otherwise.
+    let mut child = Command::new(&output)
+        .current_dir(dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn compiled binary");
+    let timeout = Duration::from_secs(30);
+    let start = Instant::now();
+    let status = loop {
+        if let Some(status) = child.try_wait().expect("try_wait on compiled binary") {
+            break status;
+        }
+        if start.elapsed() > timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!(
+                "compiled binary did not exit within {timeout:?} — \
+                 IncomingMessage.pipe() likely regressed to a no-op/hang"
+            );
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    };
+    let mut stdout = String::new();
+    if let Some(mut out) = child.stdout.take() {
+        out.read_to_string(&mut stdout).ok();
+    }
+    let mut stderr = String::new();
+    if let Some(mut err) = child.stderr.take() {
+        err.read_to_string(&mut stderr).ok();
+    }
+    assert!(
+        status.success(),
+        "compiled binary failed\nstatus: {status:?}\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    stdout
+}
+
+#[test]
+fn incoming_message_pipe_forwards_body_and_returns_dest() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = compile_and_run(
+        dir.path(),
+        r#"
+import http from "http";
+import { PassThrough } from "stream";
+
+const BODY = '{"ok":true,"x":12345}';
+const srv = http.createServer((req: any, res: any): void => {
+  res.writeHead(200, { "Content-Type": "application/json", "Content-Length": String(BODY.length) });
+  res.end(BODY);
+});
+srv.listen(0, (): void => {
+  const port = (srv.address() as any).port;
+  http.get(`http://127.0.0.1:${port}/`, (res: any): void => {
+    // node-fetch's exact pattern: pipe the response into a PassThrough and
+    // keep only the return value as the readable body.
+    const body = res.pipe(new PassThrough());
+    if (!body) {
+      console.log("RET:undefined");
+      srv.close();
+      return;
+    }
+    console.log("RET:dest");
+    const chunks: any[] = [];
+    body.on("data", (c: any): void => { chunks.push(c); });
+    body.on("end", (): void => {
+      console.log("BODY:" + Buffer.concat(chunks).toString());
+      srv.close();
+    });
+  });
+});
+"#,
+    );
+
+    assert!(
+        out.contains("RET:dest"),
+        "pipe() must return the destination stream, not undefined: {out}"
+    );
+    assert!(
+        out.contains(r#"BODY:{"ok":true,"x":12345}"#),
+        "piped PassThrough never received the full response body: {out}"
+    );
+}


### PR DESCRIPTION
## Problem

A client `http.IncomingMessage` (response) had **no `.pipe()` method**. Calling `res.pipe(dest)` fell through to `undefined` and forwarded zero bytes — so any library that reads a response body by piping it got a **dead body stream** and hung:

- **node-fetch** reads the body as `res.pipe(new PassThrough())`.
- **gaxios** / **Got** are built on node-fetch / node streams.

`response.text()` / `.json()` never settled → the request promise never resolved.

This blocked real startup paths: a connectivity **preflight** that does two gaxios GETs hung indefinitely (socket `ESTABLISHED`, response received but never drained), wedging everything downstream of it.

## Fix

Implement `IncomingMessage.pipe(dest)` in `perry-ext-http`:
- store the destination on the `IncomingMessageHandle` (GC-scanned),
- forward the response body to it via `dest.write(chunk)` + `dest.end()` (mirroring the existing zlib `js_native_call_method_str_key` forwarding) for both the **buffered** and **streaming** response paths,
- return `dest` (Node's pipe-returns-the-destination contract).

`dispatch_http::dispatch_client_incoming_method` routes the `"pipe"` method to the new `js_http_incoming_message_pipe`.

## Test

`crates/perry/tests/incoming_message_pipe.rs`: `http.get(...).pipe(new PassThrough())`, asserts the full body arrives and the destination is returned, under a wall-clock timeout so a regression of the hang fails fast. `cargo test -p perry-ext-http` green (24/0), and validated end-to-end in a real bundle (the preflight that previously hung now completes).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for piping HTTP response bodies into a destination stream.
  * `pipe()` now returns the destination stream, matching expected client behavior.
* **Bug Fixes**
  * Forwarded response body data to all registered pipe destinations during both streaming and buffered delivery.
  * Fixed cases where piped responses could stall or never finish.
  * Improved buffering behavior so it only applies when no pipe destination is present.
* **Tests**
  * Added a regression test to verify `IncomingMessage.pipe(dest)` returns the destination and forwards the full response body.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->