### PR TITLE
fix(deforest): exclude super-using class member bodies from call-site rewrite (#5780 cluster A)

### DIFF
--- a/crates/perry-transform/src/deforest/detect.rs
+++ b/crates/perry-transform/src/deforest/detect.rs
@@ -67,19 +67,46 @@ pub fn detect_producers(module: &Module) -> HashMap<FuncId, ProducerInfo> {
     scan_unsafe_call_sites(&module.init, &candidates, &mut unsupported_call);
     for class in &module.classes {
         for m in &class.methods {
-            scan_unsafe_call_sites(&m.body, &candidates, &mut unsupported_call);
+            // A member body that references `super` can't have its
+            // producer call sites rewritten — the deforest rewrite
+            // introduces synthetic locals that corrupt [[HomeObject]]
+            // setup, breaking `super.x` / `super[e]` / `super(...)`.
+            // Treat any producer called from such a body as an unsafe
+            // call site to exclude it from deforestation entirely.
+            // Refs #5780 cluster A / #5772.
+            if body_has_super(&m.body) {
+                flag_producer_calls_in_super_body(&m.body, &candidates, &mut unsupported_call);
+            } else {
+                scan_unsafe_call_sites(&m.body, &candidates, &mut unsupported_call);
+            }
         }
         if let Some(ctor) = &class.constructor {
-            scan_unsafe_call_sites(&ctor.body, &candidates, &mut unsupported_call);
+            if body_has_super(&ctor.body) {
+                flag_producer_calls_in_super_body(&ctor.body, &candidates, &mut unsupported_call);
+            } else {
+                scan_unsafe_call_sites(&ctor.body, &candidates, &mut unsupported_call);
+            }
         }
         for (_, getter) in &class.getters {
-            scan_unsafe_call_sites(&getter.body, &candidates, &mut unsupported_call);
+            if body_has_super(&getter.body) {
+                flag_producer_calls_in_super_body(&getter.body, &candidates, &mut unsupported_call);
+            } else {
+                scan_unsafe_call_sites(&getter.body, &candidates, &mut unsupported_call);
+            }
         }
         for (_, setter) in &class.setters {
-            scan_unsafe_call_sites(&setter.body, &candidates, &mut unsupported_call);
+            if body_has_super(&setter.body) {
+                flag_producer_calls_in_super_body(&setter.body, &candidates, &mut unsupported_call);
+            } else {
+                scan_unsafe_call_sites(&setter.body, &candidates, &mut unsupported_call);
+            }
         }
         for m in &class.static_methods {
-            scan_unsafe_call_sites(&m.body, &candidates, &mut unsupported_call);
+            if body_has_super(&m.body) {
+                flag_producer_calls_in_super_body(&m.body, &candidates, &mut unsupported_call);
+            } else {
+                scan_unsafe_call_sites(&m.body, &candidates, &mut unsupported_call);
+            }
         }
     }
     candidates.retain(|id, _| !unsupported_call.contains(id));
@@ -331,6 +358,206 @@ fn expr_has_closure(e: &Expr) -> bool {
         }
     });
     found
+}
+
+/// Returns true if any expression anywhere in `stmts` (including
+/// nested stmts and nested control flow) is a `super` reference:
+/// `SuperPropertyGet`, `SuperCall`, `SuperMethodCall`, etc.
+///
+/// Used to exclude class member bodies that use `super` from deforest
+/// call-site rewrites — the rewrite introduces synthetic locals that
+/// corrupt [[HomeObject]] setup, breaking super property access and
+/// super calls. Refs #5780 cluster A.
+pub fn body_has_super(stmts: &[Stmt]) -> bool {
+    stmts.iter().any(stmt_has_super)
+}
+
+fn stmt_has_super(stmt: &Stmt) -> bool {
+    match stmt {
+        Stmt::Let { init, .. } => init.as_ref().is_some_and(expr_has_super),
+        Stmt::Expr(e) | Stmt::Throw(e) => expr_has_super(e),
+        Stmt::Return(opt) => opt.as_ref().is_some_and(expr_has_super),
+        Stmt::If {
+            condition,
+            then_branch,
+            else_branch,
+        } => {
+            expr_has_super(condition)
+                || body_has_super(then_branch)
+                || else_branch.as_ref().is_some_and(|eb| body_has_super(eb))
+        }
+        Stmt::While { condition, body } | Stmt::DoWhile { body, condition } => {
+            expr_has_super(condition) || body_has_super(body)
+        }
+        Stmt::For {
+            init,
+            condition,
+            update,
+            body,
+        } => {
+            init.as_ref().is_some_and(|i| stmt_has_super(i))
+                || condition.as_ref().is_some_and(expr_has_super)
+                || update.as_ref().is_some_and(expr_has_super)
+                || body_has_super(body)
+        }
+        Stmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            body_has_super(body)
+                || catch.as_ref().is_some_and(|c| body_has_super(&c.body))
+                || finally.as_ref().is_some_and(|f| body_has_super(f))
+        }
+        Stmt::Switch {
+            discriminant,
+            cases,
+        } => {
+            expr_has_super(discriminant)
+                || cases
+                    .iter()
+                    .any(|c| c.test.as_ref().is_some_and(expr_has_super) || body_has_super(&c.body))
+        }
+        Stmt::Labeled { body, .. } => stmt_has_super(body),
+        _ => false,
+    }
+}
+
+fn expr_has_super(e: &Expr) -> bool {
+    if matches!(
+        e,
+        Expr::SuperCall(_)
+            | Expr::SuperCallSpread(_)
+            | Expr::SuperMethodCall { .. }
+            | Expr::SuperMethodCallSpread { .. }
+            | Expr::SuperPropertyGet { .. }
+            | Expr::SuperPropertySet { .. }
+            | Expr::ObjectSuperPropertyGet { .. }
+            | Expr::ObjectSuperPropertySet { .. }
+            | Expr::ObjectSuperMethodCall { .. }
+    ) {
+        return true;
+    }
+    let mut found = false;
+    walk_expr_children(e, &mut |child| {
+        if !found && expr_has_super(child) {
+            found = true;
+        }
+    });
+    found
+}
+
+/// Flag every call to a candidate producer found anywhere in `stmts`
+/// as an unsafe call site. Used for class member bodies that contain
+/// `super` references — all positions are unsafe because the rewrite
+/// would corrupt [[HomeObject]].
+fn flag_producer_calls_in_super_body(
+    stmts: &[Stmt],
+    candidates: &HashMap<FuncId, ProducerInfo>,
+    out: &mut HashSet<FuncId>,
+) {
+    for s in stmts {
+        flag_producer_calls_in_stmt(s, candidates, out);
+    }
+}
+
+fn flag_producer_calls_in_stmt(
+    stmt: &Stmt,
+    candidates: &HashMap<FuncId, ProducerInfo>,
+    out: &mut HashSet<FuncId>,
+) {
+    match stmt {
+        Stmt::Let { init, .. } => {
+            if let Some(e) = init {
+                flag_producer_calls_in_expr(e, candidates, out);
+            }
+        }
+        Stmt::Expr(e) | Stmt::Throw(e) => flag_producer_calls_in_expr(e, candidates, out),
+        Stmt::Return(opt) => {
+            if let Some(e) = opt {
+                flag_producer_calls_in_expr(e, candidates, out);
+            }
+        }
+        Stmt::If {
+            condition,
+            then_branch,
+            else_branch,
+        } => {
+            flag_producer_calls_in_expr(condition, candidates, out);
+            flag_producer_calls_in_super_body(then_branch, candidates, out);
+            if let Some(eb) = else_branch {
+                flag_producer_calls_in_super_body(eb, candidates, out);
+            }
+        }
+        Stmt::While { condition, body } | Stmt::DoWhile { body, condition } => {
+            flag_producer_calls_in_expr(condition, candidates, out);
+            flag_producer_calls_in_super_body(body, candidates, out);
+        }
+        Stmt::For {
+            init,
+            condition,
+            update,
+            body,
+        } => {
+            if let Some(i) = init {
+                flag_producer_calls_in_stmt(i, candidates, out);
+            }
+            if let Some(c) = condition {
+                flag_producer_calls_in_expr(c, candidates, out);
+            }
+            if let Some(u) = update {
+                flag_producer_calls_in_expr(u, candidates, out);
+            }
+            flag_producer_calls_in_super_body(body, candidates, out);
+        }
+        Stmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            flag_producer_calls_in_super_body(body, candidates, out);
+            if let Some(c) = catch {
+                flag_producer_calls_in_super_body(&c.body, candidates, out);
+            }
+            if let Some(f) = finally {
+                flag_producer_calls_in_super_body(f, candidates, out);
+            }
+        }
+        Stmt::Switch {
+            discriminant,
+            cases,
+        } => {
+            flag_producer_calls_in_expr(discriminant, candidates, out);
+            for c in cases {
+                if let Some(t) = &c.test {
+                    flag_producer_calls_in_expr(t, candidates, out);
+                }
+                flag_producer_calls_in_super_body(&c.body, candidates, out);
+            }
+        }
+        Stmt::Labeled { body, .. } => flag_producer_calls_in_stmt(body, candidates, out),
+        _ => {}
+    }
+}
+
+fn flag_producer_calls_in_expr(
+    e: &Expr,
+    candidates: &HashMap<FuncId, ProducerInfo>,
+    out: &mut HashSet<FuncId>,
+) {
+    match e {
+        Expr::Call { callee, .. } | Expr::CallSpread { callee, .. } => {
+            if let Expr::FuncRef(id) = callee.as_ref() {
+                if candidates.contains_key(id) {
+                    out.insert(*id);
+                }
+            }
+        }
+        _ => {}
+    }
+    walk_expr_children(e, &mut |child| {
+        flag_producer_calls_in_expr(child, candidates, out)
+    });
 }
 
 /// Recursive: returns true if `stmt` (or any nested stmt inside it)

--- a/crates/perry-transform/src/deforest/mod.rs
+++ b/crates/perry-transform/src/deforest/mod.rs
@@ -82,7 +82,9 @@ mod walk;
 mod tests;
 
 pub use call_sites::{rewrite_call_sites_in_stmts, rewrite_call_sites_in_stmts_with_local_pass};
-pub use detect::{analyze_producer, body_has_closure, detect_producers, stmt_contains_return};
+pub use detect::{
+    analyze_producer, body_has_closure, body_has_super, detect_producers, stmt_contains_return,
+};
 pub use out_usage::OutUsageAnalyzer;
 pub use producer_rewrite::{rewrite_producer_body, SubstituteLocal};
 pub use scan::{scan_funcref_misuses, scan_producers_used_in_closures, scan_unsafe_call_sites};
@@ -188,44 +190,59 @@ pub fn run(module: &mut Module) {
     // (`analyze_producer` runs on `module.functions`), so no skip is needed.
     for class in &mut module.classes {
         if let Some(ctor) = &mut class.constructor {
-            rewrite_call_sites_in_stmts(
-                &mut ctor.body,
-                &producers,
-                &out_param_ids,
-                &mut next_local,
-            );
+            // Super-using bodies are excluded from deforestation by the
+            // detect phase (their producer calls are marked as unsafe
+            // call sites so no producer is admitted for them). Guard
+            // here too so the rewrite is a guaranteed no-op for those
+            // bodies and can never inadvertently corrupt [[HomeObject]].
+            if !body_has_super(&ctor.body) {
+                rewrite_call_sites_in_stmts(
+                    &mut ctor.body,
+                    &producers,
+                    &out_param_ids,
+                    &mut next_local,
+                );
+            }
         }
         for method in &mut class.methods {
-            rewrite_call_sites_in_stmts(
-                &mut method.body,
-                &producers,
-                &out_param_ids,
-                &mut next_local,
-            );
+            if !body_has_super(&method.body) {
+                rewrite_call_sites_in_stmts(
+                    &mut method.body,
+                    &producers,
+                    &out_param_ids,
+                    &mut next_local,
+                );
+            }
         }
         for (_, getter) in &mut class.getters {
-            rewrite_call_sites_in_stmts(
-                &mut getter.body,
-                &producers,
-                &out_param_ids,
-                &mut next_local,
-            );
+            if !body_has_super(&getter.body) {
+                rewrite_call_sites_in_stmts(
+                    &mut getter.body,
+                    &producers,
+                    &out_param_ids,
+                    &mut next_local,
+                );
+            }
         }
         for (_, setter) in &mut class.setters {
-            rewrite_call_sites_in_stmts(
-                &mut setter.body,
-                &producers,
-                &out_param_ids,
-                &mut next_local,
-            );
+            if !body_has_super(&setter.body) {
+                rewrite_call_sites_in_stmts(
+                    &mut setter.body,
+                    &producers,
+                    &out_param_ids,
+                    &mut next_local,
+                );
+            }
         }
         for method in &mut class.static_methods {
-            rewrite_call_sites_in_stmts(
-                &mut method.body,
-                &producers,
-                &out_param_ids,
-                &mut next_local,
-            );
+            if !body_has_super(&method.body) {
+                rewrite_call_sites_in_stmts(
+                    &mut method.body,
+                    &producers,
+                    &out_param_ids,
+                    &mut next_local,
+                );
+            }
         }
     }
 }

--- a/crates/perry-transform/src/deforest/tests.rs
+++ b/crates/perry-transform/src/deforest/tests.rs
@@ -397,6 +397,187 @@ fn deforests_producer_called_from_class_method() {
     );
 }
 
+#[test]
+fn rejects_deforest_when_class_method_uses_super() {
+    // Regression for #5780 cluster A / #5772. A producer called from a
+    // class method that also uses `super.prop` must NOT be deforested —
+    // the call-site rewrite introduces synthetic locals that corrupt the
+    // method's [[HomeObject]] setup, causing `super.x` to throw at
+    // runtime ("Cannot convert undefined or null to object").
+    //
+    //   function helper() { const out = []; out.push(1); return out; }
+    //   class C extends Base {
+    //     m() { const v = helper(); return super.foo; }
+    //   }
+    let helper = make_simple_producer(); // id=1, the producer
+
+    let method_with_super = Function {
+        id: 2,
+        name: "m".to_string(),
+        type_params: vec![],
+        params: vec![],
+        return_type: Type::Any,
+        body: vec![
+            // const v = helper();
+            Stmt::Let {
+                id: 30,
+                name: "v".to_string(),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(Expr::Call {
+                    callee: Box::new(Expr::FuncRef(1)),
+                    args: vec![],
+                    type_args: vec![],
+                    byte_offset: 0,
+                }),
+            },
+            // return super.foo;
+            Stmt::Return(Some(Expr::SuperPropertyGet {
+                property: "foo".to_string(),
+            })),
+        ],
+        is_async: false,
+        is_generator: false,
+        is_strict: false,
+        is_exported: false,
+        captures: vec![],
+        decorators: vec![],
+        was_plain_async: false,
+        was_unrolled: false,
+    };
+
+    let class = perry_hir::Class {
+        id: 10,
+        name: "C".to_string(),
+        type_params: Vec::new(),
+        extends: None,
+        extends_name: None,
+        native_extends: None,
+        extends_expr: None,
+        heritage_lexically_shadowed: false,
+        fields: Vec::new(),
+        constructor: None,
+        methods: vec![method_with_super],
+        getters: Vec::new(),
+        setters: Vec::new(),
+        static_accessor_names: Vec::new(),
+        static_accessor_fn_ids: Vec::new(),
+        static_fields: Vec::new(),
+        static_methods: Vec::new(),
+        computed_members: Vec::new(),
+        decorators: Vec::new(),
+        is_exported: false,
+        is_nested: false,
+        aliases: Vec::new(),
+    };
+
+    let mut module = Module::new("m");
+    module.functions = vec![helper];
+    module.classes = vec![class];
+
+    // Detection must exclude the producer — the super-using body makes
+    // it unsafe to deforest.
+    assert!(
+        detect_producers(&module).is_empty(),
+        "producer called from a super-using method must not be deforested (#5780)"
+    );
+
+    // run() must leave the producer's signature untouched.
+    run(&mut module);
+    let helper_after = module.functions.iter().find(|f| f.id == 1).unwrap();
+    assert!(
+        helper_after.params.is_empty(),
+        "producer signature must be unchanged when its call site is in a super-using method"
+    );
+}
+
+#[test]
+fn still_deforests_when_method_has_no_super() {
+    // Control for `rejects_deforest_when_class_method_uses_super`: the
+    // SAME producer called from a class method that does NOT use super
+    // is still deforested (the existing #5772 fix must not regress).
+    //
+    // This is the same scenario as `deforests_producer_called_from_class_method`
+    // but added here for symmetry with the super test above.
+    let helper = make_simple_producer(); // id=1
+
+    let plain_method = Function {
+        id: 2,
+        name: "m".to_string(),
+        type_params: vec![],
+        params: vec![],
+        return_type: Type::Any,
+        body: vec![
+            Stmt::Let {
+                id: 30,
+                name: "v".to_string(),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(Expr::Call {
+                    callee: Box::new(Expr::FuncRef(1)),
+                    args: vec![],
+                    type_args: vec![],
+                    byte_offset: 0,
+                }),
+            },
+            Stmt::Return(Some(Expr::PropertyGet {
+                object: Box::new(Expr::LocalGet(30)),
+                property: "length".to_string(),
+            })),
+        ],
+        is_async: false,
+        is_generator: false,
+        is_strict: false,
+        is_exported: false,
+        captures: vec![],
+        decorators: vec![],
+        was_plain_async: false,
+        was_unrolled: false,
+    };
+
+    let class = perry_hir::Class {
+        id: 10,
+        name: "C".to_string(),
+        type_params: Vec::new(),
+        extends: None,
+        extends_name: None,
+        native_extends: None,
+        extends_expr: None,
+        heritage_lexically_shadowed: false,
+        fields: Vec::new(),
+        constructor: None,
+        methods: vec![plain_method],
+        getters: Vec::new(),
+        setters: Vec::new(),
+        static_accessor_names: Vec::new(),
+        static_accessor_fn_ids: Vec::new(),
+        static_fields: Vec::new(),
+        static_methods: Vec::new(),
+        computed_members: Vec::new(),
+        decorators: Vec::new(),
+        is_exported: false,
+        is_nested: false,
+        aliases: Vec::new(),
+    };
+
+    let mut module = Module::new("m");
+    module.functions = vec![helper];
+    module.classes = vec![class];
+
+    assert!(
+        !detect_producers(&module).is_empty(),
+        "producer with a super-free class-method caller should still deforest"
+    );
+
+    run(&mut module);
+    let helper_after = module.functions.iter().find(|f| f.id == 1).unwrap();
+    assert_eq!(
+        helper_after.params.len(),
+        1,
+        "producer should gain the synthetic accumulator param"
+    );
+}
+
 fn make_simple_producer() -> Function {
     Function {
         id: 1,


### PR DESCRIPTION
## Root cause

Commit 5d47364e2 (#5772) extended the DEFOREST pass to cover class member bodies (constructors, methods, getters, setters, static methods) as valid call-site rewrite targets — fixing the arity-mismatch SIGSEGV where a producer called from a class method had its signature rewritten but the call site was never updated (#5136-class).

A member body that **also** uses `super` (`super.x`, `super[e]`, `super(…)`) had its `[[HomeObject]]` setup corrupted by the synthetic-local introduction done by the call-site rewriter, causing:

```
TypeError: Cannot convert undefined or null to object
```

at runtime for ~24 test262 cases (cluster A of #5780).

## Fix

**detect.rs** — `body_has_super(stmts)` walks a member body for any `super` expression variant (`SuperPropertyGet`, `SuperCall`, `SuperMethodCall`, `SuperMethodCallSpread`, `SuperCallSpread`, `ObjectSuper*`). In the third detection pass (unsafe-call-site scan) any class member body for which `body_has_super` returns `true` has **all its producer calls flagged as unsafe**, removing those producers from the candidate set before the rewrite phase. A producer whose only callers are super-using bodies is therefore excluded entirely; one with callers in both super-using and super-free bodies is also excluded (conservative but correct).

**mod.rs** — belt-and-suspenders guard: phase-3 skips `rewrite_call_sites_in_stmts` for any class member body where `body_has_super` is true, ensuring `[[HomeObject]]` is never disturbed even if the detect exclusion were somehow bypassed.

## Before / after

| Scenario | Before | After |
|---|---|---|
| `class C extends B { m() { super.x; } }` near a deforestable `helper()` | `super.x` throws `TypeError` | works correctly |
| `class C { m() { const v = helper(); return v.length; } }` (no super) | deforested, correct | deforested, correct (no regression) |

## Tests

Two new unit tests in `crates/perry-transform/src/deforest/tests.rs`:

- `rejects_deforest_when_class_method_uses_super` — producer called from a super-using method is excluded from deforestation; signature unchanged after `run()`.
- `still_deforests_when_method_has_no_super` — control: same producer called from a super-free method is still deforested (#5772 guard).

All 11 deforest unit tests pass; `cargo fmt --all -- --check` and `bash scripts/check_file_size.sh` clean.

Closes #5780 (cluster A — `super.prop` / `super[expr]` / `super()` in class methods adjacent to deforestable helpers).


---
_Generated by [Claude Code](https://claude.ai/code/session_015E24VBUbVcM8zxm8GChSsi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deforestation safety for class members that use `super`, preventing producer calls in those bodies from being rewritten.
  * Producer candidates are now excluded when they appear in methods, getters, setters, constructors, or static methods that reference `super`.
  * Class member bodies without `super` continue to be optimized as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->