### PR TITLE
fix(temporal): preserve locale/options in toLocaleString, fix DTF-compatible defaults (#5580)

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/url_date_instance.rs
+++ b/crates/perry-hir/src/lower/expr_call/url_date_instance.rs
@@ -313,8 +313,20 @@ pub(super) fn try_url_date_weakref_instance(
                         return Ok(Ok(Expr::DateToLocaleTimeString(Box::new(date_expr))));
                     }
                     "toLocaleString" => {
-                        let date_expr = lower_expr(ctx, &member.obj)?;
-                        return Ok(Ok(Expr::DateToLocaleString(Box::new(date_expr))));
+                        // When args (locale / options) are present and the
+                        // receiver is not statically a Date, skip the
+                        // DateToLocaleString fold so the arguments are
+                        // preserved on the generic method-call path.  Temporal
+                        // types need this: their dispatch layer already accepts
+                        // locale and options arguments correctly, but the fold
+                        // was silently dropping them (see #5580).  Zero-arg
+                        // calls and statically-Date receivers still use the
+                        // fast path to preserve existing Date behaviour.
+                        if args.is_empty() || recv_class == Some("Date") {
+                            let date_expr = lower_expr(ctx, &member.obj)?;
+                            return Ok(Ok(Expr::DateToLocaleString(Box::new(date_expr))));
+                        }
+                        // fall through to generic method call with args intact
                     }
                     "getTimezoneOffset" => {
                         let date_expr = lower_expr(ctx, &member.obj)?;

--- a/crates/perry-runtime/src/intl/date_collator.rs
+++ b/crates/perry-runtime/src/intl/date_collator.rs
@@ -388,45 +388,49 @@ fn format_components(
     let has_time = hour_opt.is_some() || minute_opt.is_some() || second_opt.is_some();
 
     let date_part = if has_date {
+        let has_m = month_opt.is_some();
+        let has_d = day_opt.is_some();
+        let has_y = year_opt.is_some();
         let fmt_month = match month_opt {
             Some("long") => MONTH_FULL[month.saturating_sub(1).min(11) as usize].to_string(),
             Some("short") | Some("narrow") => {
                 MONTH_ABBR[month.saturating_sub(1).min(11) as usize].to_string()
             }
             Some("2-digit") => format!("{:02}", month),
-            _ => month.to_string(),
+            Some(_) => month.to_string(), // "numeric" or unrecognised
+            None => String::new(),        // absent — do NOT leak the raw month
         };
         let fmt_day = match day_opt {
             Some("2-digit") => format!("{:02}", day),
-            _ if day_opt.is_some() => day.to_string(),
-            _ => String::new(),
+            Some(_) => day.to_string(),
+            None => String::new(),
         };
         let fmt_year = match year_opt {
             Some("2-digit") => format!("{:02}", year.rem_euclid(100)),
-            _ if year_opt.is_some() => year.to_string(),
-            _ => String::new(),
+            Some(_) => year.to_string(),
+            None => String::new(),
         };
-        // Use named-month format for long/short/narrow, numeric M/D/YYYY otherwise.
+        // Named-month styles (long/short/narrow) use word-first layout.
+        // Numeric styles assemble the present fields with "/" separators —
+        // only fields whose option is Some appear in the output.
         match month_opt {
-            Some("long") | Some("short") | Some("narrow") => {
-                let has_y = year_opt.is_some();
-                let has_d = day_opt.is_some();
-                Some(match (has_d, has_y) {
-                    (true, true) => format!("{} {}, {}", fmt_month, fmt_day, fmt_year),
-                    (true, false) => format!("{} {}", fmt_month, fmt_day),
-                    (false, true) => format!("{} {}", fmt_month, fmt_year),
-                    (false, false) => fmt_month,
-                })
-            }
+            Some("long") | Some("short") | Some("narrow") => Some(match (has_d, has_y) {
+                (true, true) => format!("{} {}, {}", fmt_month, fmt_day, fmt_year),
+                (true, false) => format!("{} {}", fmt_month, fmt_day),
+                (false, true) => format!("{} {}", fmt_month, fmt_year),
+                (false, false) => fmt_month,
+            }),
             _ => {
-                let has_y = year_opt.is_some();
-                let has_d = day_opt.is_some();
-                Some(match (has_d, has_y) {
-                    (true, true) => format!("{}/{}/{}", fmt_month, fmt_day, fmt_year),
-                    (true, false) => format!("{}/{}", fmt_month, fmt_day),
-                    (false, true) => format!("{}/{}", fmt_month, fmt_year),
-                    (false, false) => fmt_month,
-                })
+                // Build "M/D/YYYY" using only the fields that are present.
+                let parts: Vec<&str> = [
+                    if has_m { fmt_month.as_str() } else { "" },
+                    if has_d { fmt_day.as_str() } else { "" },
+                    if has_y { fmt_year.as_str() } else { "" },
+                ]
+                .into_iter()
+                .filter(|s| !s.is_empty())
+                .collect();
+                Some(parts.join("/"))
             }
         }
     } else {
@@ -652,59 +656,46 @@ pub(crate) fn temporal_locale_string(
                 second_opt.as_deref(),
             )
         } else {
-            // No options given — apply spec defaults for this Temporal type.
+            // No options given — apply ECMA-402 defaults for this Temporal
+            // type.  The spec says `toLocaleString(locales, options)` is
+            // equivalent to `new Intl.DateTimeFormat(locales, options).format(this)`.
+            // With `options = undefined`, DTF always resolves to
+            // `{ year: "numeric", month: "numeric", day: "numeric" }`.
+            // Each Temporal type maps its fields to an epoch-ms value for
+            // formatting; the date components of that value are what the DTF
+            // defaults select.  Type-specific component overrides (e.g.
+            // time for PlainTime) only apply when the user explicitly passes
+            // options — not as defaults.
+            //
+            // ZonedDateTime is the sole exception: its toLocaleString spec
+            // mandates that the output includes both date and time components
+            // when no options are given (analogous to how ZDT carries a
+            // timezone that no ordinary DTF object can represent).
             match ctx {
-                TemporalLocaleCtx::PlainDate => (
-                    None,
-                    None,
-                    Some("numeric"),
-                    Some("numeric"),
-                    Some("numeric"),
-                    None,
-                    None,
-                    None,
-                ),
-                TemporalLocaleCtx::PlainDateTime
+                TemporalLocaleCtx::PlainDate
+                | TemporalLocaleCtx::PlainDateTime
                 | TemporalLocaleCtx::Instant
-                | TemporalLocaleCtx::ZonedDateTime => (
+                | TemporalLocaleCtx::PlainTime
+                | TemporalLocaleCtx::PlainYearMonth
+                | TemporalLocaleCtx::PlainMonthDay => (
                     None,
                     None,
                     Some("numeric"),
                     Some("numeric"),
                     Some("numeric"),
-                    Some("numeric"),
-                    Some("2-digit"),
-                    Some("2-digit"),
-                ),
-                TemporalLocaleCtx::PlainTime => (
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    Some("numeric"),
-                    Some("2-digit"),
-                    Some("2-digit"),
-                ),
-                TemporalLocaleCtx::PlainYearMonth => (
-                    None,
-                    None,
-                    Some("numeric"),
-                    Some("numeric"),
-                    None,
                     None,
                     None,
                     None,
                 ),
-                TemporalLocaleCtx::PlainMonthDay => (
-                    None,
+                TemporalLocaleCtx::ZonedDateTime => (
                     None,
                     None,
                     Some("numeric"),
                     Some("numeric"),
-                    None,
-                    None,
-                    None,
+                    Some("numeric"),
+                    Some("numeric"),
+                    Some("2-digit"),
+                    Some("2-digit"),
                 ),
             }
         };

--- a/crates/perry-runtime/src/object/native_call_method/object_proto.rs
+++ b/crates/perry-runtime/src/object/native_call_method/object_proto.rs
@@ -86,10 +86,11 @@ pub(crate) unsafe fn js_object_default_to_locale_string(receiver: f64) -> f64 {
     }
     // #5580: a `Temporal.*` value formats via its own `toLocaleString` (a
     // calendar-aware, type-specific rendering plus the spec's calendar-mismatch
-    // `RangeError`) rather than the `[object Object]` default. The HIR lowers
-    // `value.toLocaleString(...)` to the arg-less `Expr::DateToLocaleString`, so
-    // the locale/options arguments are not visible here; the no-argument form is
-    // dispatched through the Temporal method router.
+    // `RangeError`) rather than the `[object Object]` default.  Calls that
+    // carry locale/options args bypass `Expr::DateToLocaleString` and reach
+    // the Temporal dispatch via the generic method-call path (which preserves
+    // args).  Only the zero-arg form arrives here; dispatch it with an empty
+    // slice so the Temporal method applies its type-appropriate defaults.
     #[cfg(feature = "temporal")]
     if crate::temporal::is_temporal_value(receiver) {
         return crate::temporal::dispatch::call_method(receiver, "toLocaleString", &[]);


### PR DESCRIPTION
## Root Cause

Three bugs combined to cause all 61 `intl402/Temporal` `toLocaleString` test262 failures:

### Bug 1 — HIR args-dropping (`perry-hir`)

`value.toLocaleString(locale, opts)` was intercepted in
`try_url_date_weakref_instance` and unconditionally folded to
`Expr::DateToLocaleString(receiver)`, silently discarding the `locale`
and `options` arguments. Every Temporal `toLocaleString` call with any
arguments was therefore formatted with *no* locale or options.

**Fix** (`crates/perry-hir/src/lower/expr_call/url_date_instance.rs`):
The fold now fires only when args are absent (zero-arg call) or the
receiver is statically typed as `Date`. Calls that carry locale/options
fall through to the generic method-call path, which routes Temporal
values to `temporal::dispatch::call_method` with all args intact.

### Bug 2 — DTF-incompatible per-type defaults (`perry-runtime`)

When `options` is `undefined`, `Intl.DateTimeFormat(locale, undefined)`
defaults to `{year:"numeric", month:"numeric", day:"numeric"}` for every
type. Perry's Temporal formatters each had bespoke defaults:
`Instant`/`PlainDateTime` showed full date+time, `PlainTime` showed
time-only, `PlainYearMonth` showed year+month, `PlainMonthDay` showed
month+day. This caused the basic / `locales-undefined` / `options-undefined`
test families to fail for every non-Date Temporal type.

**Fix** (`crates/perry-runtime/src/intl/date_collator.rs`):
All non-`ZonedDateTime` types now default to `{year, month, day}`.
`ZonedDateTime` keeps `{year, month, day, hour, minute, second}` per the
spec's requirement to include time in the default ZDT output.

### Bug 3 — `format_components` leaking raw month number

When `month` was absent from the requested options (e.g.
`{year:"numeric"}`), the fallthrough `_ => month.to_string()` arm in
`format_components` matched `None` and appended the raw month integer to
the output string.

**Fix** (`crates/perry-runtime/src/intl/date_collator.rs`):
Replaced the fallthrough arm with explicit `Some(_)` / `None =>
String::new()` branches and added `has_m/has_d/has_y` guards that only
join the fields that were actually requested.

## Before / After

| Category | Before | After (estimated) |
|---|---|---|
| `intl402/Temporal` failures | 61 | ~18–20 |

Test families expected to pass after this PR:
- `basic.js` for all 6 Temporal types
- `locales-undefined.js` / `options-undefined.js` (5–6 types each)
- `dateStyle`, `timeStyle`, `dateStyle-timeStyle-undefined` combinations
- `options-conflict` (RangeError on conflicting dateStyle + component)
- `hourCycle` options
- `lone-options-accepted` (single component like `{year:"numeric"}`)
- `calendar-mismatch` RangeError families

Still-failing categories (out of scope for this PR):
- `ZonedDateTime` timezone name / offset-timezone formatting (requires IANA lookup)
- DST/BigInt disambiguation (`0` vs `1n`)
- Hebrew calendar
- `Duration.prototype.toLocaleString`
- Full locale-aware number formatting

## Verification

```
cargo build --release -p perry-hir -p perry-runtime   # exit 0
cargo fmt --all -- --check                             # clean
bash scripts/check_file_size.sh                        # OK
cargo test --release -p perry-hir -p perry-runtime     # exit 0
```

Refs: #5580

---
_Generated by [Claude Code](https://claude.ai/code/session_01BuBDMw68HECA6jhBAhx4EY)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `toLocaleString` handling so locale and options arguments are preserved instead of being dropped in some cases.
  * Fixed date and temporal formatting to better match expected output, including month/day/year layout and default date-time behavior for `ZonedDateTime`.
  * Updated locale string formatting to handle missing date parts more consistently across numeric and named-month styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->