### PR TITLE
fix(hir): new.target in class field initializers returns undefined

### DIFF
--- a/crates/perry-hir/src/lower/expr_misc.rs
+++ b/crates/perry-hir/src/lower/expr_misc.rs
@@ -326,6 +326,15 @@ pub(super) fn lower_meta_prop(
             // `new.target === C` identity (a fresh object never equals the
             // class ref). `ctx.in_constructor_class` is no longer consulted
             // here.
+            //
+            // ES2025 §15.7.10: class field initializers are invoked with
+            // [[Call]] (not [[Construct]]), so [[NewTarget]] is `undefined`
+            // throughout the initializer, including inside arrow functions
+            // (which inherit it lexically) and direct eval bodies
+            // (which share the calling context's new.target binding).
+            if ctx.in_class_field_init {
+                return Ok(Expr::Undefined);
+            }
             Ok(Expr::NewTarget)
         }
     }

--- a/test-files/test_gap_5592_class_field_init_new_target.ts
+++ b/test-files/test_gap_5592_class_field_init_new_target.ts
@@ -1,0 +1,62 @@
+// #5592: new.target in class field initializers
+// ES2025 §15.7.10: field inits run with [[Call]] so [[NewTarget]] === undefined.
+
+// Direct new.target in a public field initializer
+class C1 {
+  x = new.target;
+}
+const c1 = new C1();
+console.log(String(c1.x));  // undefined
+
+// Direct new.target in an arrow inside a field initializer
+class C2 {
+  x = (() => new.target)();
+}
+const c2 = new C2();
+console.log(String(c2.x));  // undefined
+
+// eval("new.target") inside a public field initializer
+class C3 {
+  x = eval("new.target");
+}
+const c3 = new C3();
+console.log(String(c3.x));  // undefined
+
+// eval in arrow inside field init
+class C4 {
+  x = (() => eval("new.target"))();
+}
+const c4 = new C4();
+console.log(String(c4.x));  // undefined
+
+// eval in nested arrows inside field init
+class C5 {
+  x = (() => (() => eval("new.target"))())();
+}
+const c5 = new C5();
+console.log(String(c5.x));  // undefined
+
+// Private field initializer: same rule
+class C6 {
+  #x = new.target;
+  getX() { return this.#x; }
+}
+const c6 = new C6();
+console.log(String(c6.getX()));  // undefined
+
+// Subclass: new.target in base class field init is still undefined
+class Base {
+  x = new.target;
+}
+class Derived extends Base {}
+const d = new Derived();
+console.log(String(d.x));  // undefined
+
+// new.target in constructor is the actual constructor (unaffected)
+class C7 {
+  nt: unknown;
+  constructor() {
+    this.nt = new.target;
+  }
+}
+console.log(new C7().nt === C7);  // true


### PR DESCRIPTION
Closes part of #5592 (subcluster: `new.target` in class field initializers).

## Root cause

ES2025 §15.7.10 specifies that class field initializers are invoked with `[[Call]]`, not `[[Construct]]`, so `[[NewTarget]]` is `undefined` throughout the initializer — including inside arrow functions (which inherit it lexically) and direct `eval()` bodies (which share the calling context's `new.target` binding under PerformEval).

Perry was returning the live constructor reference instead of `undefined`. In `lower_meta_prop`, `Expr::NewTarget` was emitted unconditionally; codegen resolves it to the active new.target slot, which holds the class constructor when running inside `new C()`. The field initializer inherits that slot via the arrow wrapper in `build_eval_completion_iife`.

## Fix

In `lower_meta_prop` (`crates/perry-hir/src/lower/expr_misc.rs`), check `ctx.in_class_field_init` before emitting `Expr::NewTarget`. When true, emit `Expr::Undefined` instead.

`in_class_field_init` is already set to `true` by `lower_class_prop` and `lower_private_prop` for the duration of the field initializer expression. Arrow function lowering does not reset this flag (correct — arrows inherit `new.target` from the enclosing scope). Regular function expressions do reset it (also correct — a `function` expression stored in a field has its own `new.target` when called).

## Before / After

```typescript
class C { x = eval("new.target"); }
new C().x
// Before: function C() { [native code] }
// After:  undefined

class C2 { x = new.target; }
new C2().x
// Before: function C2() { [native code] }
// After:  undefined

class C3 { x = (() => new.target)(); }
new C3().x
// Before: function C3() { [native code] }
// After:  undefined
```

Constructor `new.target` is unaffected (verified: `new.target === C` inside constructors still returns the correct constructor reference).

## Test262 subcluster addressed

The failing tests under #5592 matching `*direct-eval-err-contains-newtarget.js` and related `new.target`-in-field-init paths in `language/{expressions,statements}/class/elements/`.

Gap test: `test-files/test_gap_5592_class_field_init_new_target.ts` (8 cases, all passing after fix).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PsYQU41RhMDVHh9gSjUQyb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected `new.target` behavior during class field initialization so it now evaluates to `undefined`, matching modern JavaScript semantics.
  * Applied the same behavior consistently in field initializers, nested arrow functions, and direct `eval` usage.
  * Preserved the existing constructor behavior where `new.target` still points to the active class inside constructors.

* **Tests**
  * Added coverage for class field initialization cases, including public fields, private fields, inheritance, arrows, and `eval`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->