### PR TITLE
fix(deforest): bail on producers called from super-containing member bodies (#5780)

### DIFF
--- a/crates/perry-transform/src/deforest/detect.rs
+++ b/crates/perry-transform/src/deforest/detect.rs
@@ -92,6 +92,14 @@ pub fn detect_producers(module: &Module) -> HashMap<FuncId, ProducerInfo> {
     // inside a closure would have its signature rewritten while the
     // in-closure call site kept the original arity — a mismatch that
     // miscompiles to a SIGSEGV. Refs #5136.
+    //
+    // Additionally, bail on any candidate called from a class member
+    // body that contains a super reference. Phase 3 skips those bodies
+    // (the `body_has_super_ref` guard in mod.rs) to avoid disturbing the
+    // [[HomeObject]] context. If the producer were still deforested, its
+    // call site in the super-containing body would keep the original
+    // arity while the producer gained the +1 out-param — same
+    // arity-mismatch class as the in-closure bail. Refs #5780.
     let mut in_closure: HashSet<FuncId> = HashSet::new();
     for func in &module.functions {
         scan_producers_used_in_closures(&func.body, &candidates, &mut in_closure);
@@ -99,19 +107,39 @@ pub fn detect_producers(module: &Module) -> HashMap<FuncId, ProducerInfo> {
     scan_producers_used_in_closures(&module.init, &candidates, &mut in_closure);
     for class in &module.classes {
         for m in &class.methods {
-            scan_producers_used_in_closures(&m.body, &candidates, &mut in_closure);
+            if body_has_super_ref(&m.body) {
+                scan_candidate_funcrefs_in_stmts(&m.body, &candidates, &mut in_closure);
+            } else {
+                scan_producers_used_in_closures(&m.body, &candidates, &mut in_closure);
+            }
         }
         if let Some(ctor) = &class.constructor {
-            scan_producers_used_in_closures(&ctor.body, &candidates, &mut in_closure);
+            if body_has_super_ref(&ctor.body) {
+                scan_candidate_funcrefs_in_stmts(&ctor.body, &candidates, &mut in_closure);
+            } else {
+                scan_producers_used_in_closures(&ctor.body, &candidates, &mut in_closure);
+            }
         }
         for (_, getter) in &class.getters {
-            scan_producers_used_in_closures(&getter.body, &candidates, &mut in_closure);
+            if body_has_super_ref(&getter.body) {
+                scan_candidate_funcrefs_in_stmts(&getter.body, &candidates, &mut in_closure);
+            } else {
+                scan_producers_used_in_closures(&getter.body, &candidates, &mut in_closure);
+            }
         }
         for (_, setter) in &class.setters {
-            scan_producers_used_in_closures(&setter.body, &candidates, &mut in_closure);
+            if body_has_super_ref(&setter.body) {
+                scan_candidate_funcrefs_in_stmts(&setter.body, &candidates, &mut in_closure);
+            } else {
+                scan_producers_used_in_closures(&setter.body, &candidates, &mut in_closure);
+            }
         }
         for m in &class.static_methods {
-            scan_producers_used_in_closures(&m.body, &candidates, &mut in_closure);
+            if body_has_super_ref(&m.body) {
+                scan_candidate_funcrefs_in_stmts(&m.body, &candidates, &mut in_closure);
+            } else {
+                scan_producers_used_in_closures(&m.body, &candidates, &mut in_closure);
+            }
         }
     }
     candidates.retain(|id, _| !in_closure.contains(id));
@@ -377,4 +405,207 @@ pub fn stmt_contains_return(stmt: &Stmt) -> bool {
         Stmt::Labeled { body, .. } => stmt_contains_return(body),
         _ => false,
     }
+}
+
+/// Returns true if any expression anywhere in `stmts` (or nested stmts)
+/// is a super reference variant. Used to gate deforestation and Phase 3
+/// call-site rewriting on class member bodies — rewriting those bodies
+/// can disturb the [[HomeObject]] context that super reads rely on
+/// (issue #5780).
+pub fn body_has_super_ref(stmts: &[Stmt]) -> bool {
+    stmts.iter().any(stmt_has_super_ref)
+}
+
+fn stmt_has_super_ref(stmt: &Stmt) -> bool {
+    match stmt {
+        Stmt::Let { init, .. } => init.as_ref().is_some_and(|e| expr_has_super_ref(e)),
+        Stmt::Expr(e) | Stmt::Throw(e) => expr_has_super_ref(e),
+        Stmt::Return(opt) => opt.as_ref().is_some_and(|e| expr_has_super_ref(e)),
+        Stmt::If {
+            condition,
+            then_branch,
+            else_branch,
+        } => {
+            expr_has_super_ref(condition)
+                || body_has_super_ref(then_branch)
+                || else_branch
+                    .as_ref()
+                    .is_some_and(|eb| body_has_super_ref(eb))
+        }
+        Stmt::While { condition, body } | Stmt::DoWhile { body, condition } => {
+            expr_has_super_ref(condition) || body_has_super_ref(body)
+        }
+        Stmt::For {
+            init,
+            condition,
+            update,
+            body,
+        } => {
+            init.as_ref().is_some_and(|i| stmt_has_super_ref(i))
+                || condition.as_ref().is_some_and(|e| expr_has_super_ref(e))
+                || update.as_ref().is_some_and(|e| expr_has_super_ref(e))
+                || body_has_super_ref(body)
+        }
+        Stmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            body_has_super_ref(body)
+                || catch.as_ref().is_some_and(|c| body_has_super_ref(&c.body))
+                || finally.as_ref().is_some_and(|f| body_has_super_ref(f))
+        }
+        Stmt::Switch {
+            discriminant,
+            cases,
+        } => {
+            expr_has_super_ref(discriminant)
+                || cases.iter().any(|c| {
+                    c.test.as_ref().is_some_and(|e| expr_has_super_ref(e))
+                        || body_has_super_ref(&c.body)
+                })
+        }
+        Stmt::Labeled { body, .. } => stmt_has_super_ref(body),
+        _ => false,
+    }
+}
+
+fn expr_has_super_ref(e: &Expr) -> bool {
+    if matches!(
+        e,
+        Expr::SuperCall(_)
+            | Expr::SuperCallSpread(_)
+            | Expr::SuperMethodCall { .. }
+            | Expr::SuperMethodCallSpread { .. }
+            | Expr::SuperPropertyGet { .. }
+            | Expr::SuperPropertySet { .. }
+            | Expr::ObjectSuperPropertyGet { .. }
+            | Expr::ObjectSuperPropertySet { .. }
+            | Expr::ObjectSuperMethodCall { .. }
+    ) {
+        return true;
+    }
+    let mut found = false;
+    walk_expr_children(e, &mut |child| {
+        if !found {
+            found = expr_has_super_ref(child);
+        }
+    });
+    found
+}
+
+/// Marks every `FuncRef(id)` that appears anywhere in `stmts` —
+/// including inside closure bodies and all control-flow branches —
+/// as excluded from deforestation. Used in the fourth detection pass
+/// for class member bodies that contain super references: since Phase 3
+/// skips those bodies, any producer called there would gain the +1
+/// out-param while its call site kept the original arity (the same
+/// arity-mismatch miscompile as the in-closure case, #5780).
+fn scan_candidate_funcrefs_in_stmts(
+    stmts: &[Stmt],
+    candidates: &HashMap<FuncId, ProducerInfo>,
+    out: &mut HashSet<FuncId>,
+) {
+    for s in stmts {
+        scan_candidate_funcrefs_in_stmt(s, candidates, out);
+    }
+}
+
+fn scan_candidate_funcrefs_in_stmt(
+    stmt: &Stmt,
+    candidates: &HashMap<FuncId, ProducerInfo>,
+    out: &mut HashSet<FuncId>,
+) {
+    match stmt {
+        Stmt::Let { init, .. } => {
+            if let Some(e) = init {
+                scan_candidate_funcrefs_in_expr(e, candidates, out);
+            }
+        }
+        Stmt::Expr(e) | Stmt::Throw(e) => scan_candidate_funcrefs_in_expr(e, candidates, out),
+        Stmt::Return(opt) => {
+            if let Some(e) = opt {
+                scan_candidate_funcrefs_in_expr(e, candidates, out);
+            }
+        }
+        Stmt::If {
+            condition,
+            then_branch,
+            else_branch,
+        } => {
+            scan_candidate_funcrefs_in_expr(condition, candidates, out);
+            scan_candidate_funcrefs_in_stmts(then_branch, candidates, out);
+            if let Some(eb) = else_branch {
+                scan_candidate_funcrefs_in_stmts(eb, candidates, out);
+            }
+        }
+        Stmt::While { condition, body } | Stmt::DoWhile { body, condition } => {
+            scan_candidate_funcrefs_in_expr(condition, candidates, out);
+            scan_candidate_funcrefs_in_stmts(body, candidates, out);
+        }
+        Stmt::For {
+            init,
+            condition,
+            update,
+            body,
+        } => {
+            if let Some(i) = init {
+                scan_candidate_funcrefs_in_stmt(i, candidates, out);
+            }
+            if let Some(c) = condition {
+                scan_candidate_funcrefs_in_expr(c, candidates, out);
+            }
+            if let Some(u) = update {
+                scan_candidate_funcrefs_in_expr(u, candidates, out);
+            }
+            scan_candidate_funcrefs_in_stmts(body, candidates, out);
+        }
+        Stmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            scan_candidate_funcrefs_in_stmts(body, candidates, out);
+            if let Some(c) = catch {
+                scan_candidate_funcrefs_in_stmts(&c.body, candidates, out);
+            }
+            if let Some(f) = finally {
+                scan_candidate_funcrefs_in_stmts(f, candidates, out);
+            }
+        }
+        Stmt::Switch {
+            discriminant,
+            cases,
+        } => {
+            scan_candidate_funcrefs_in_expr(discriminant, candidates, out);
+            for c in cases {
+                if let Some(t) = &c.test {
+                    scan_candidate_funcrefs_in_expr(t, candidates, out);
+                }
+                scan_candidate_funcrefs_in_stmts(&c.body, candidates, out);
+            }
+        }
+        Stmt::Labeled { body, .. } => scan_candidate_funcrefs_in_stmt(body, candidates, out),
+        _ => {}
+    }
+}
+
+fn scan_candidate_funcrefs_in_expr(
+    e: &Expr,
+    candidates: &HashMap<FuncId, ProducerInfo>,
+    out: &mut HashSet<FuncId>,
+) {
+    if let Expr::FuncRef(id) = e {
+        if candidates.contains_key(id) {
+            out.insert(*id);
+        }
+    }
+    // walk_expr_children only visits closure param defaults, not bodies;
+    // recurse explicitly so nested closures are covered too.
+    if let Expr::Closure { body, .. } = e {
+        scan_candidate_funcrefs_in_stmts(body, candidates, out);
+    }
+    walk_expr_children(e, &mut |child| {
+        scan_candidate_funcrefs_in_expr(child, candidates, out)
+    });
 }

--- a/crates/perry-transform/src/deforest/mod.rs
+++ b/crates/perry-transform/src/deforest/mod.rs
@@ -82,7 +82,9 @@ mod walk;
 mod tests;
 
 pub use call_sites::{rewrite_call_sites_in_stmts, rewrite_call_sites_in_stmts_with_local_pass};
-pub use detect::{analyze_producer, body_has_closure, detect_producers, stmt_contains_return};
+pub use detect::{
+    analyze_producer, body_has_closure, body_has_super_ref, detect_producers, stmt_contains_return,
+};
 pub use out_usage::OutUsageAnalyzer;
 pub use producer_rewrite::{rewrite_producer_body, SubstituteLocal};
 pub use scan::{scan_funcref_misuses, scan_producers_used_in_closures, scan_unsafe_call_sites};
@@ -186,46 +188,65 @@ pub fn run(module: &mut Module) {
     // but here the call sites are ordinary statement bodies we can rewrite
     // rather than bail on). Producers are only ever free functions
     // (`analyze_producer` runs on `module.functions`), so no skip is needed.
+    //
+    // Exception: skip member bodies that contain super references. Super
+    // property reads resolve their [[HomeObject]] through runtime context
+    // that can be disrupted by injecting new locals (the `let v = []`
+    // temp that the rewrite inserts) before the super expression. The
+    // fourth detection pass already excludes producers whose only call
+    // sites live in super-containing bodies, so this guard is defence in
+    // depth — it ensures Phase 3 never touches those bodies even if the
+    // detection pass misses an edge case. Refs #5780.
     for class in &mut module.classes {
         if let Some(ctor) = &mut class.constructor {
-            rewrite_call_sites_in_stmts(
-                &mut ctor.body,
-                &producers,
-                &out_param_ids,
-                &mut next_local,
-            );
+            if !body_has_super_ref(&ctor.body) {
+                rewrite_call_sites_in_stmts(
+                    &mut ctor.body,
+                    &producers,
+                    &out_param_ids,
+                    &mut next_local,
+                );
+            }
         }
         for method in &mut class.methods {
-            rewrite_call_sites_in_stmts(
-                &mut method.body,
-                &producers,
-                &out_param_ids,
-                &mut next_local,
-            );
+            if !body_has_super_ref(&method.body) {
+                rewrite_call_sites_in_stmts(
+                    &mut method.body,
+                    &producers,
+                    &out_param_ids,
+                    &mut next_local,
+                );
+            }
         }
         for (_, getter) in &mut class.getters {
-            rewrite_call_sites_in_stmts(
-                &mut getter.body,
-                &producers,
-                &out_param_ids,
-                &mut next_local,
-            );
+            if !body_has_super_ref(&getter.body) {
+                rewrite_call_sites_in_stmts(
+                    &mut getter.body,
+                    &producers,
+                    &out_param_ids,
+                    &mut next_local,
+                );
+            }
         }
         for (_, setter) in &mut class.setters {
-            rewrite_call_sites_in_stmts(
-                &mut setter.body,
-                &producers,
-                &out_param_ids,
-                &mut next_local,
-            );
+            if !body_has_super_ref(&setter.body) {
+                rewrite_call_sites_in_stmts(
+                    &mut setter.body,
+                    &producers,
+                    &out_param_ids,
+                    &mut next_local,
+                );
+            }
         }
         for method in &mut class.static_methods {
-            rewrite_call_sites_in_stmts(
-                &mut method.body,
-                &producers,
-                &out_param_ids,
-                &mut next_local,
-            );
+            if !body_has_super_ref(&method.body) {
+                rewrite_call_sites_in_stmts(
+                    &mut method.body,
+                    &producers,
+                    &out_param_ids,
+                    &mut next_local,
+                );
+            }
         }
     }
 }

--- a/crates/perry-transform/src/deforest/tests.rs
+++ b/crates/perry-transform/src/deforest/tests.rs
@@ -397,6 +397,110 @@ fn deforests_producer_called_from_class_method() {
     );
 }
 
+#[test]
+fn rejects_producer_called_from_super_containing_method() {
+    // Refs #5780. A producer called from a class method that ALSO
+    // contains a super reference must NOT be deforested: Phase 3 skips
+    // super-containing method bodies (to avoid disturbing [[HomeObject]]
+    // context), so rewriting the producer's signature (adding the +1
+    // out-param) while leaving the call site with original arity would
+    // miscompile — same class as the in-closure bail (#5136).
+    //
+    //   function helper() { const out = []; out.push(1); return out; }
+    //   class C extends Base {
+    //     m() {
+    //       const data = helper();   // ← call site in super-containing body
+    //       return super.count + data.length;
+    //     }
+    //   }
+    let helper = make_simple_producer(); // id=1, the producer
+
+    let method = Function {
+        id: 2,
+        name: "m".to_string(),
+        type_params: vec![],
+        params: vec![],
+        return_type: Type::Number,
+        body: vec![
+            Stmt::Let {
+                id: 30,
+                name: "data".to_string(),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(Expr::Call {
+                    callee: Box::new(Expr::FuncRef(1)),
+                    args: vec![],
+                    type_args: vec![],
+                    byte_offset: 0,
+                }),
+            },
+            // return super.count + data.length  (super ref present)
+            Stmt::Return(Some(Expr::Binary {
+                op: perry_hir::BinaryOp::Add,
+                left: Box::new(Expr::SuperPropertyGet {
+                    property: "count".to_string(),
+                }),
+                right: Box::new(Expr::PropertyGet {
+                    object: Box::new(Expr::LocalGet(30)),
+                    property: "length".to_string(),
+                }),
+            })),
+        ],
+        is_async: false,
+        is_generator: false,
+        is_strict: false,
+        is_exported: false,
+        captures: vec![],
+        decorators: vec![],
+        was_plain_async: false,
+        was_unrolled: false,
+    };
+
+    let class = perry_hir::Class {
+        id: 10,
+        name: "C".to_string(),
+        type_params: Vec::new(),
+        extends: None,
+        extends_name: None,
+        native_extends: None,
+        extends_expr: None,
+        heritage_lexically_shadowed: false,
+        fields: Vec::new(),
+        constructor: None,
+        methods: vec![method],
+        getters: Vec::new(),
+        setters: Vec::new(),
+        static_accessor_names: Vec::new(),
+        static_accessor_fn_ids: Vec::new(),
+        static_fields: Vec::new(),
+        static_methods: Vec::new(),
+        computed_members: Vec::new(),
+        decorators: Vec::new(),
+        is_exported: false,
+        is_nested: false,
+        aliases: Vec::new(),
+    };
+
+    let mut module = Module::new("m");
+    module.functions = vec![helper];
+    module.classes = vec![class];
+
+    // Detection must drop the producer: its only call site is in a
+    // super-containing method body, and Phase 3 will skip that body.
+    assert!(
+        detect_producers(&module).is_empty(),
+        "producer called from a super-containing method must not be deforested"
+    );
+
+    // And `run` must leave the producer's signature untouched.
+    run(&mut module);
+    let helper_after = module.functions.iter().find(|f| f.id == 1).unwrap();
+    assert!(
+        helper_after.params.is_empty(),
+        "producer signature must be unchanged when called from a super-containing method"
+    );
+}
+
 fn make_simple_producer() -> Function {
     Function {
         id: 1,


### PR DESCRIPTION
Fixes #5780.

## What broke

Commit 5d47364 extended the deforestation Phase 3 call-site rewriter to
class member bodies (constructors, methods, getters, setters,
static_methods). When a member body also contains a `super` property
read or method call, injecting the deforest temporaries (`let v = []`
before the call) can disturb the `[[HomeObject]]` context that `super`
reads rely on at runtime. The result is `super.prop` resolving to
`undefined`/`null` and throwing `TypeError: Cannot convert undefined or
null to object` (24 failing cases in the gap suite, cluster A).

## Fix

Treat a class member body that contains any super expression as an
**unsafe context for deforestation** — the same conservative bail
already used for closure bodies (#5136).

### `detect.rs` — 4th detection pass

When `body_has_super_ref(&body)` is true for a class member body, call
`scan_candidate_funcrefs_in_stmts` (new helper) instead of
`scan_producers_used_in_closures`. The new helper marks **all**
candidate `FuncRef`s in that body — not only those inside closures —
as excluded. This prevents a producer from being deforested when its
only call site lives in a super-containing member body: without this
gate the producer gains the `+1` out-param while its call site keeps
the original arity, an arity-mismatch SIGSEGV of the same class as #5136.

### `mod.rs` — Phase 3

Added `if !body_has_super_ref(&body)` guards around every class member
rewrite block as defence-in-depth. Detection already excludes the
affected producers, so these guards never fire in practice — but they
make the invariant explicit and protect against future detection gaps.

### New helpers

`body_has_super_ref` / `stmt_has_super_ref` / `expr_has_super_ref`
cover all 9 `Super*` HIR variants:
`SuperCall`, `SuperCallSpread`, `SuperMethodCall`,
`SuperMethodCallSpread`, `SuperPropertyGet`, `SuperPropertySet`,
`ObjectSuperPropertyGet`, `ObjectSuperPropertySet`,
`ObjectSuperMethodCall`.

### `tests.rs`

Added `rejects_producer_called_from_super_containing_method` to lock in
both the detection exclusion (producer not in the candidates map) and
the signature-preservation invariant (no synthetic out-param added).

## What is NOT changed

- Super-free class member bodies continue to have their call sites
  rewritten as before (the fix is surgical — super-free methods are
  unaffected).
- `analyze_producer`, `body_has_closure`, all detection passes 1–3,
  and the existing `deforests_producer_called_from_class_method`
  regression test are unchanged.
- No version bumps (contributor PR).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PLzH9ydQwwr243t1rp9E9Q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved class-member processing so methods containing `super` references are no longer rewritten in ways that could change behavior.
  * Preserved original function parameters and call behavior when a producer is only used inside such a member body.
  * Added coverage to prevent regressions for this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->