### PR TITLE
fix(runtime): reduce test262 built-ins/Object failures (#5588)

### DIFF
--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -1205,8 +1205,12 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
             })
             .collect();
         for i in 0..n {
-            // js_array_get yields `undefined` for a hole; array literals and
-            // pushed arrays are dense, matching Node for the common case.
+            // Holes (absent indices) in a sparse array are NOT own enumerable
+            // properties and must be skipped — Object.assign only copies own
+            // enumerable properties (test262 assign/target-Array.js).
+            if !crate::array::array_spec_has_index(arr, i) {
+                continue;
+            }
             let value = crate::array::js_array_get(arr, i);
             let key = i.to_string();
             let key_ptr = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);

--- a/crates/perry-runtime/src/object/global_this/populate.rs
+++ b/crates/perry-runtime/src/object/global_this/populate.rs
@@ -601,6 +601,32 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
             crate::navigator::navigator_object_with_constructor(f64::from_bits(nav_ctor.bits()));
         js_object_set_field_by_name(singleton, nkey, nval);
     }
+    // ECMA-262 19.1/19.2/19.3: NaN, Infinity, and undefined are own data
+    // properties of the global object with {writable:false, enumerable:false,
+    // configurable:false}.  Install them so that
+    // `Object.getOwnPropertyDescriptor(globalThis, "NaN")` returns a real
+    // descriptor (test262 15.2.3.3-4-178/179/180) and
+    // `Object.getOwnPropertyNames(globalThis)` includes them (15.2.3.4-4-1).
+    {
+        let non_writable = super::super::PropertyAttrs::new(false, false, false);
+        for (name, value) in [("NaN", f64::NAN), ("Infinity", f64::INFINITY)] {
+            let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+            js_object_set_field_by_name(singleton, key, value);
+            super::super::set_builtin_property_attrs(
+                singleton as usize,
+                name.to_string(),
+                non_writable,
+            );
+        }
+        let undef_key = crate::string::js_string_from_bytes(b"undefined".as_ptr(), 9);
+        let undef_val = f64::from_bits(crate::value::TAG_UNDEFINED);
+        js_object_set_field_by_name(singleton, undef_key, undef_val);
+        super::super::set_builtin_property_attrs(
+            singleton as usize,
+            "undefined".to_string(),
+            super::super::PropertyAttrs::new(false, false, false),
+        );
+    }
 }
 
 /// Re-point a `Number.<name>` static at the global function of the same name so

--- a/crates/perry-runtime/src/object/object_ops/define_properties.rs
+++ b/crates/perry-runtime/src/object/object_ops/define_properties.rs
@@ -227,9 +227,20 @@ pub extern "C" fn js_object_set_prototype_of(obj_value: f64, proto: f64) -> f64 
             if tortoise == TAG_NULL_U64 {
                 break;
             }
-            // Advance tortoise one step, hare two steps.
+            // Advance tortoise one step, hare two steps.  Guard the second
+            // advance: if the first step lands on null, calling advance(null)
+            // would invoke js_object_get_prototype_of(null) which throws
+            // "Cannot convert undefined or null to object" (test262
+            // setPrototypeOf/success.js — plain object proto chain ends at null).
             tortoise = advance(tortoise);
-            hare = advance(advance(hare));
+            hare = {
+                let h1 = advance(hare);
+                if h1 == TAG_NULL_U64 {
+                    TAG_NULL_U64
+                } else {
+                    advance(h1)
+                }
+            };
             // If they meet, the existing chain already has a cycle — the walk
             // will never reach null, so we also can never form a new one by
             // setting obj's proto. Just break; the set is safe.


### PR DESCRIPTION
## Summary

Three focused runtime fixes targeting the `built-ins/Object` test262 failure cluster tracked in #5588. All changes are in `perry-runtime`; no Cargo version bump, no CLAUDE.md edit, no CHANGELOG entry.

## Changes

- **`crates/perry-runtime/src/object/global_this/populate.rs`** — Install `NaN`, `Infinity`, and `undefined` as own data properties of the global object (`{writable:false, enumerable:false, configurable:false}`) per ECMA-262 §19.1–19.3. Previously absent from `populate_global_this_builtins`, so `Object.getOwnPropertyDescriptor(this, "NaN")` returned `undefined` and `Object.getOwnPropertyNames` omitted them.

- **`crates/perry-runtime/src/object/object_ops/define_properties.rs`** — Guard the second advance in the Floyd's tortoise-and-hare cycle detector inside `js_object_set_prototype_of`. When the first advance reached `null` (end of a plain object's prototype chain), the second `advance(null)` called `js_object_get_prototype_of(null)` which throws "Cannot convert undefined or null to object", aborting legitimate `setPrototypeOf` calls via longjmp.

- **`crates/perry-runtime/src/object/alloc.rs`** — Skip absent (hole) indices in `js_object_assign_one` when the source is an array. `Object.assign` only copies own enumerable properties; sparse-array holes are not own properties (ECMA-262 §20.2.2.2).

## Related issue

Refs #5588

## Test plan

```
cargo build --release -p perry-runtime -p perry-stdlib          # clean
cargo fmt --all -- --check                                       # passes
bash scripts/check_file_size.sh                                  # passes (no file >2000 lines)
```

Expected test262 impact (against the 48-failure snapshot from 2026-06-29):

| Fix | Tests addressed |
|-----|----------------|
| NaN/Infinity/undefined in globalThis | `getOwnPropertyDescriptor/15.2.3.3-4-178`, `-179`, `-180`; `getOwnPropertyNames/15.2.3.4-4-1` |
| setPrototypeOf null guard | `setPrototypeOf/success.js` |
| Object.assign sparse array holes | `assign/target-Array.js` |

Before: 48 failing — After: ~42 failing

- [x] `cargo build --release` clean
- [ ] Full workspace test suite (no regression on logic covered by the three fixes; broader suite requires platform access)
- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] Commits follow the `fix:` prefix convention

---
_Generated by [Claude Code](https://claude.ai/code/session_01YB2cBjVBvzYrJtkU3amy5J)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `Object.assign` so sparse array holes are skipped correctly when copying from arrays.
  * Ensured the global values `NaN`, `Infinity`, and `undefined` are defined with the expected non-writable, non-enumerable, non-configurable behavior.
  * Improved prototype-chain checks to avoid errors when traversing to the end of a chain, making prototype updates more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->