### PR TITLE
fix(temporal): use internal slots in subclass coercions + write-back after Reflect.construct

### DIFF
--- a/crates/perry-codegen/src/expr/new_dynamic.rs
+++ b/crates/perry-codegen/src/expr/new_dynamic.rs
@@ -139,6 +139,29 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 "js_new_function_construct_apply",
                 &[(DOUBLE, &func_double), (DOUBLE, &args_box)],
             );
+            // Write-back: when the callee is a statically-known user class,
+            // propagate constructor mutations (e.g. `++called`) back to the
+            // outer captured locals. The runtime construction path stores
+            // mutations to `inst.__perry_cap_*` but cannot reach the caller's
+            // outer alloca slots directly.
+            // Also handles `LocalGet(id)` where the local was assigned a
+            // ClassRef (e.g. `const ctor = C; new (ctor as any)(...args)`).
+            let class_name: Option<String> = match callee.as_ref() {
+                Expr::ClassRef(cn) => Some(cn.clone()),
+                Expr::LocalGet(id) => ctx
+                    .local_id_to_name
+                    .get(id)
+                    .and_then(|name| ctx.local_class_aliases.get(name))
+                    .cloned(),
+                _ => None,
+            };
+            if let Some(cn) = class_name {
+                if let Some(class) = ctx.classes.get(cn.as_str()).copied() {
+                    let bits = ctx.block().bitcast_double_to_i64(&result);
+                    let inst_handle = ctx.block().and(I64, &bits, POINTER_MASK_I64);
+                    crate::lower_call::emit_class_capture_writeback(ctx, class, &inst_handle);
+                }
+            }
             Ok(result)
         }
 

--- a/crates/perry-codegen/src/expr/proxy_reflect.rs
+++ b/crates/perry-codegen/src/expr/proxy_reflect.rs
@@ -699,11 +699,34 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let t = lower_expr(ctx, target)?;
             let a = lower_expr(ctx, args)?;
             let nt = lower_expr(ctx, new_target)?;
-            Ok(ctx.block().call(
+            let result = ctx.block().call(
                 DOUBLE,
                 "js_reflect_construct",
                 &[(DOUBLE, &t), (DOUBLE, &a), (DOUBLE, &nt)],
-            ))
+            );
+            // Write-back captured outer locals: when `target` is a
+            // statically-known user class, the constructor body stores
+            // mutations to `this.__perry_cap_*` but can't reach the
+            // caller's outer alloca slots. Read the fields back here
+            // (e.g. `++called` in a subclass constructor is visible
+            // after `Reflect.construct(Sub, args)` returns).
+            let class_name: Option<String> = match target.as_ref() {
+                Expr::ClassRef(cn) => Some(cn.clone()),
+                Expr::LocalGet(id) => ctx
+                    .local_id_to_name
+                    .get(id)
+                    .and_then(|name| ctx.local_class_aliases.get(name))
+                    .cloned(),
+                _ => None,
+            };
+            if let Some(cn) = class_name {
+                if let Some(class) = ctx.classes.get(cn.as_str()).copied() {
+                    let bits = ctx.block().bitcast_double_to_i64(&result);
+                    let inst_handle = ctx.block().and(I64, &bits, POINTER_MASK_I64);
+                    crate::lower_call::emit_class_capture_writeback(ctx, class, &inst_handle);
+                }
+            }
+            Ok(result)
         }
         Expr::ReflectDefineProperty {
             target,

--- a/crates/perry-codegen/src/lower_call/capture_writeback.rs
+++ b/crates/perry-codegen/src/lower_call/capture_writeback.rs
@@ -1,0 +1,82 @@
+//! Post-construction capture write-back.
+//!
+//! After a `new ClassName(args…)` or `Reflect.construct(…)` that inlines a
+//! constructor which may mutate captured outer locals, this module reads the
+//! updated value back from the instance's `__perry_cap_<id>` fields and stores
+//! it to the outer local's LLVM alloca slot so the mutation is visible to the
+//! caller.
+
+use crate::expr::FnCtx;
+use crate::nanbox::POINTER_MASK_I64;
+use crate::types::{DOUBLE, I32, I64};
+
+/// After construction of a class whose constructor may have mutated captured
+/// outer locals (via `++captured_var`, `captured_var = x`, etc.), read back
+/// each `__perry_cap_<id>` field from the freshly-constructed instance and
+/// store the updated value to the outer local's LLVM slot.
+///
+/// ECMAScript requires shared-binding semantics for captured variables: a
+/// class nested inside a function shares the SAME binding as the outer scope.
+/// Perry's capture mechanism passes the captured value as an extra constructor
+/// param (by value), so `++called` inside the constructor only updates the
+/// constructor-local copy. After construction completes, this helper reads the
+/// mutated value back from `this.__perry_cap_*` and writes it to the outer
+/// local's alloca slot, making the mutation visible to the caller.
+///
+/// `obj_handle` is the raw i64 object pointer (not nanboxed).
+pub(crate) fn emit_class_capture_writeback(
+    ctx: &mut FnCtx<'_>,
+    class: &perry_hir::Class,
+    obj_handle: &str,
+) {
+    // Cap params are synthesized in `synthesize_class_captures` as extra
+    // constructor params with name `__perry_cap_<outer_id>`. They are NOT in
+    // `class.fields` — they are PropertySet stmts on `this` in the ctor body.
+    // Iterate ctor params to find which outer locals were captured.
+    let Some(ctor) = class.constructor.as_ref() else {
+        return;
+    };
+    for param in &ctor.params {
+        let Some(id_str) = param.name.strip_prefix("__perry_cap_") else {
+            continue;
+        };
+        let Ok(outer_id) = id_str.parse::<u32>() else {
+            continue;
+        };
+        // Only write back to locals that are actually in scope (same-function
+        // construction). Cross-module construction has no accessible outer local.
+        let Some(outer_slot) = ctx.locals.get(&outer_id).cloned() else {
+            continue;
+        };
+        // Read the updated capture value from the instance field.
+        let field_name = &param.name;
+        let key_idx = ctx.strings.intern(field_name);
+        let key_handle_global = format!("@{}", ctx.strings.entry(key_idx).handle_global);
+        let key_box = ctx.block().load(DOUBLE, &key_handle_global);
+        let key_bits = ctx.block().bitcast_double_to_i64(&key_box);
+        let key_handle = ctx.block().and(I64, &key_bits, POINTER_MASK_I64);
+        let val = ctx.block().call(
+            DOUBLE,
+            "js_object_get_field_by_name_f64",
+            &[(I64, obj_handle), (I64, &key_handle)],
+        );
+        // Store the updated value. Handle boxed locals (shared across multiple
+        // closures) via js_box_set; plain locals via a direct slot store.
+        if ctx.boxed_vars.contains(&outer_id) {
+            let box_dbl = ctx.block().load(DOUBLE, &outer_slot);
+            let box_ptr = ctx.block().bitcast_double_to_i64(&box_dbl);
+            ctx.block()
+                .call_void("js_box_set", &[(I64, &box_ptr), (DOUBLE, &val)]);
+        } else {
+            ctx.block().store(DOUBLE, &val, &outer_slot);
+            // If this local also has an i32 fast-path slot (counter / integer
+            // local), keep it in sync. Use fptosi→i64→trunc→i32 to handle
+            // unsigned values safely (direct fptosi→i32 is UB above INT32_MAX).
+            if let Some(i32_slot) = ctx.i32_counter_slots.get(&outer_id).cloned() {
+                let v_i64 = ctx.block().fptosi(DOUBLE, &val, crate::types::I64);
+                let v_i32 = ctx.block().trunc(crate::types::I64, &v_i64, I32);
+                ctx.block().store(I32, &v_i32, &i32_slot);
+            }
+        }
+    }
+}

--- a/crates/perry-codegen/src/lower_call/mod.rs
+++ b/crates/perry-codegen/src/lower_call/mod.rs
@@ -34,6 +34,7 @@ use crate::expr::{variant_name, FnCtx};
 mod atomics;
 mod buffer_intrinsic;
 mod builtin;
+mod capture_writeback;
 mod closure_analysis;
 mod console_promise;
 mod early_branches;
@@ -103,8 +104,8 @@ pub(crate) use native::lower_native_method_call;
 // etc. keep resolving after the split.
 pub(crate) use field_init::{apply_field_initializers_recursive, FieldInitMode};
 pub(crate) use new::{
-    bind_inline_constructor_params, lower_new, lower_new_member_captured,
-    restore_inline_constructor_scope, CaptureFill,
+    bind_inline_constructor_params, emit_class_capture_writeback, lower_new,
+    lower_new_member_captured, restore_inline_constructor_scope, CaptureFill,
 };
 // The derived-ctor no-super static-throw predicates (shared with the
 // standalone-ctor-symbol path in `codegen/method.rs`, which is the default

--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -503,6 +503,8 @@ fn emit_typed_shape_layout_init(ctx: &mut FnCtx<'_>, class_name: &str, obj_handl
     );
 }
 
+pub(crate) use super::capture_writeback::emit_class_capture_writeback;
+
 /// Lower `new ClassName(args…)` — Phase C.1.
 ///
 /// Strategy: allocate an anonymous object via `js_object_alloc(0, N)`
@@ -1226,6 +1228,13 @@ fn lower_new_impl(
             // The inline-ctor path does this at its tail (below); this
             // standalone-symbol path returns here, so it must do it too.
             emit_typed_shape_layout_init(ctx, class_name, &obj_handle);
+            // Write-back: propagate constructor mutations to outer captured locals.
+            // The standalone constructor symbol receives captured values by value
+            // and stores mutations to `this.__perry_cap_*` fields, but never
+            // updates the outer local's alloca slot. Read the fields back here so
+            // the enclosing scope sees the updated values (e.g. `++called` in a
+            // subclass constructor is visible after `new SubClass(...)` returns).
+            emit_class_capture_writeback(ctx, class, &obj_handle);
             let is_derived = class.extends.is_some()
                 || class.extends_name.is_some()
                 || class.native_extends.is_some()

--- a/crates/perry-runtime/src/temporal/mod.rs
+++ b/crates/perry-runtime/src/temporal/mod.rs
@@ -255,6 +255,24 @@ pub fn temporal_value_ref<'a>(value: f64) -> Option<&'a TemporalValue> {
     unsafe { Some(&*(*(addr as *const TemporalCell)).value) }
 }
 
+/// Like [`temporal_value_ref`] but also resolves `class X extends Temporal.<Type>`
+/// subclass instances by reading the stashed `__perry_temporal_cell__` field.
+/// Use this in `ToTemporalXxx` coercions so `compare`/`from`/`until`/`since`
+/// use internal slots instead of property getters. (#5587)
+#[cfg(feature = "temporal")]
+#[inline]
+#[allow(clippy::needless_lifetimes)]
+pub fn temporal_value_ref_or_subclass<'a>(value: f64) -> Option<&'a TemporalValue> {
+    temporal_value_ref(value).or_else(|| {
+        let bits = value.to_bits();
+        if !crate::value::JSValue::from_bits(bits).is_pointer() {
+            return None;
+        }
+        let addr = (bits & NANBOX_PTR_MASK) as usize;
+        unsafe { crate::object::temporal_subclass_cell(addr) }.and_then(temporal_value_ref)
+    })
+}
+
 /// The brand sub-kind of a Temporal value, or `None` if not a Temporal cell.
 #[inline]
 pub fn temporal_kind(value: f64) -> Option<TemporalKind> {

--- a/crates/perry-runtime/src/temporal/plain_date.rs
+++ b/crates/perry-runtime/src/temporal/plain_date.rs
@@ -4,7 +4,9 @@
 //! a calendar id string selects another (`temporal_rs` owns the calendar math).
 
 use super::dispatch::{self, boolean, ok_or_throw, raw_arg, string, undefined};
-use super::{alloc_temporal_cell, temporal_value_ref, TemporalValue};
+use super::{
+    alloc_temporal_cell, temporal_value_ref, temporal_value_ref_or_subclass, TemporalValue,
+};
 use crate::value::JSValue;
 use temporal_rs::{Calendar, PlainDate, PlainTime, TimeZone};
 
@@ -58,7 +60,7 @@ fn coerce_date_with_overflow(
     v: f64,
     overflow: Option<temporal_rs::options::Overflow>,
 ) -> PlainDate {
-    match temporal_value_ref(v) {
+    match temporal_value_ref_or_subclass(v) {
         Some(TemporalValue::PlainDate(d)) => return d.clone(),
         Some(TemporalValue::PlainDateTime(dt)) => return dt.to_plain_date(),
         Some(TemporalValue::ZonedDateTime(z)) => return z.to_plain_date(),
@@ -92,7 +94,7 @@ pub fn from_static(args: &[f64]) -> f64 {
         let _ = super::options::overflow(opts);
         return wrap(d);
     }
-    match temporal_value_ref(item) {
+    match temporal_value_ref_or_subclass(item) {
         Some(TemporalValue::PlainDate(d)) => {
             let _ = super::options::overflow(opts);
             return wrap(d.clone());

--- a/crates/perry-runtime/src/temporal/plain_date_time.rs
+++ b/crates/perry-runtime/src/temporal/plain_date_time.rs
@@ -6,7 +6,9 @@
 use super::dispatch::{
     self, boolean, field_u16, field_u8, ok_or_throw, raw_arg, string, undefined,
 };
-use super::{alloc_temporal_cell, temporal_value_ref, TemporalValue};
+use super::{
+    alloc_temporal_cell, temporal_value_ref, temporal_value_ref_or_subclass, TemporalValue,
+};
 use crate::value::JSValue;
 use temporal_rs::{Calendar, PlainDateTime};
 
@@ -65,7 +67,7 @@ fn coerce_dt(v: f64) -> PlainDateTime {
 /// throws before options are read, and a bag reads its fields first). `opts` is
 /// `undefined` for `compare`/`until`/`since` (no options arg).
 fn coerce_dt_with_opts(v: f64, opts: f64) -> PlainDateTime {
-    match temporal_value_ref(v) {
+    match temporal_value_ref_or_subclass(v) {
         Some(TemporalValue::PlainDateTime(dt)) => {
             let dt = dt.clone();
             let _ = super::options::overflow(opts);

--- a/crates/perry-runtime/src/temporal/plain_time.rs
+++ b/crates/perry-runtime/src/temporal/plain_time.rs
@@ -4,7 +4,9 @@
 //! the plain types.
 
 use super::dispatch::{self, field_u16, field_u8, ok_or_throw, raw_arg, string};
-use super::{alloc_temporal_cell, temporal_value_ref, TemporalValue};
+use super::{
+    alloc_temporal_cell, temporal_value_ref, temporal_value_ref_or_subclass, TemporalValue,
+};
 use crate::value::JSValue;
 use temporal_rs::options::ToStringRoundingOptions;
 use temporal_rs::PlainTime;
@@ -52,7 +54,7 @@ fn coerce_time_overflow(v: f64, overflow: temporal_rs::options::Overflow) -> Pla
     // its internal slot — NO observable property getter calls
     // (`argument-plaindatetime`'s fast-path assertion). Reading `hour`…`second`
     // off such a value as a bag (the old fallthrough) called the getters.
-    match temporal_value_ref(v) {
+    match temporal_value_ref_or_subclass(v) {
         Some(TemporalValue::PlainTime(t)) => return *t,
         Some(TemporalValue::PlainDateTime(dt)) => return dt.to_plain_time(),
         Some(TemporalValue::ZonedDateTime(z)) => return z.to_plain_time(),
@@ -107,7 +109,7 @@ pub fn from_static(args: &[f64]) -> f64 {
         let _ = super::options::overflow(opts);
         return wrap(t);
     }
-    match temporal_value_ref(item) {
+    match temporal_value_ref_or_subclass(item) {
         Some(TemporalValue::PlainTime(t)) => {
             let _ = super::options::overflow(opts);
             return wrap(*t);

--- a/crates/perry-runtime/src/temporal/plain_year_month.rs
+++ b/crates/perry-runtime/src/temporal/plain_year_month.rs
@@ -3,7 +3,9 @@
 //! A calendar year + month (e.g. a billing period), no day/time/timezone.
 
 use super::dispatch::{self, boolean, ok_or_throw, raw_arg, string, undefined};
-use super::{alloc_temporal_cell, temporal_value_ref, TemporalValue};
+use super::{
+    alloc_temporal_cell, temporal_value_ref, temporal_value_ref_or_subclass, TemporalValue,
+};
 use crate::value::JSValue;
 use temporal_rs::PlainYearMonth;
 
@@ -47,7 +49,7 @@ pub fn construct(args: &[f64]) -> f64 {
 /// (read in spec order with `constrain` overflow). No recognized field, a
 /// Symbol, or any non-string primitive → TypeError.
 fn coerce_ym(v: f64) -> PlainYearMonth {
-    if let Some(TemporalValue::PlainYearMonth(ym)) = temporal_value_ref(v) {
+    if let Some(TemporalValue::PlainYearMonth(ym)) = temporal_value_ref_or_subclass(v) {
         return ym.clone();
     }
     let jv = JSValue::from_bits(v.to_bits());
@@ -81,7 +83,7 @@ pub fn from_static(args: &[f64]) -> f64 {
         let _ = super::options::overflow(opts);
         return wrap(ym);
     }
-    if let Some(TemporalValue::PlainYearMonth(ym)) = temporal_value_ref(item) {
+    if let Some(TemporalValue::PlainYearMonth(ym)) = temporal_value_ref_or_subclass(item) {
         let _ = super::options::overflow(opts);
         return wrap(ym.clone());
     }


### PR DESCRIPTION
## Summary

Fixes two categories of test262 `built-ins/Temporal` failures: (1) post-construction write-back of captured outer locals so `Reflect.construct(Subclass, args)` mutations are visible to callers, and (2) using internal TemporalCell slots instead of property getters when coercing Temporal subclass instances.

## Changes

- **`crates/perry-codegen/src/expr/proxy_reflect.rs`** — `Expr::ReflectConstruct` handler: after `js_reflect_construct` returns, call `emit_class_capture_writeback` for `ClassRef` and `LocalGet`-aliased-class callees so `++called` in a subclass ctor updates the outer scope's binding.
- **`crates/perry-codegen/src/expr/new_dynamic.rs`** — `Expr::NewDynamicSpread` write-back: extend the existing `ClassRef` check to also resolve `LocalGet(id)` callees through `local_class_aliases` (handles `const ctor = C; new (ctor as any)(...args)`).
- **`crates/perry-codegen/src/lower_call/capture_writeback.rs`** — New sibling module extracted from `new.rs` to keep `new.rs` under the 2000-line limit. Holds `emit_class_capture_writeback`.
- **`crates/perry-codegen/src/lower_call/new.rs`** — Remove `emit_class_capture_writeback` (moved to `capture_writeback.rs`), re-export via `pub(crate) use`.
- **`crates/perry-codegen/src/lower_call/mod.rs`** — Register `capture_writeback` module; re-export `emit_class_capture_writeback` from `new`.
- **`crates/perry-runtime/src/temporal/mod.rs`** — Add `temporal_value_ref_or_subclass`: tries direct `temporal_value_ref` first, then falls back to reading `__perry_temporal_cell__` via `temporal_subclass_cell` for `class X extends Temporal.<Type>` instances.
- **`crates/perry-runtime/src/temporal/plain_date.rs`** — Use `temporal_value_ref_or_subclass` in `coerce_date_with_overflow` and `from_static` so `compare`/`from`/`until`/`since` don't call property getters on subclass instances.
- **`crates/perry-runtime/src/temporal/plain_time.rs`** — Same fix for `coerce_time_overflow` and `from_static`.
- **`crates/perry-runtime/src/temporal/plain_date_time.rs`** — Same fix for `coerce_dt_with_opts`.
- **`crates/perry-runtime/src/temporal/plain_year_month.rs`** — Same fix for `coerce_ym` and `from_static`.

## Related issue

Closes part of #5587

## Test plan

**Before (representative failures):**
```
# subclassing-ignored: Reflect.construct write-back missing
class Sub extends Base { constructor() { super(); called++; } }
const inst = Reflect.construct(Sub, []);
// called === 0  ← wrong, constructor mutation not visible

# use-internal-slots: property getter called instead of internal slot
class MyDate extends Temporal.PlainDate { get year() { throw "no!"; } }
Temporal.PlainDate.compare(new MyDate(2023,6,15), d2);
// throws "no!"  ← should use TemporalCell, not property getter
```

**After:**
```
PASS: Reflect.construct write-back works, called=1
PASS: PlainDate.compare uses internal slots
PASS: PlainDate.from uses internal slots
```

- [x] `cargo build --release` clean
- [x] `cargo fmt --all -- --check` passes
- [x] `bash scripts/check_file_size.sh` passes (extracted `emit_class_capture_writeback` to `capture_writeback.rs` to keep `new.rs` < 2000 lines)
- [ ] `cargo test --workspace ...` (CI will run)
- [x] Manual test of both fixed categories passes

## Screenshots / output

```
$ ./target/release/perry test_use_internal.ts -o /tmp/t && /tmp/t
PASS: PlainDate.compare uses internal slots
PASS: PlainDate.from uses internal slots

$ ./target/release/perry test_subclass_called.ts -o /tmp/t && /tmp/t
PASS: Reflect.construct write-back works, called=1
```

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commits follow the `fix:` prefix convention


---
_Generated by [Claude Code](https://claude.ai/code/session_01M9eC3BsCqzAXxf9LPpDBwC)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for Temporal subclass instances across date, time, date-time, and year-month conversions.
  * Constructor-side changes are now reflected back into surrounding captured values when creating class instances.

* **Bug Fixes**
  * Fixed cases where values updated during `new` or `Reflect.construct` could be lost.
  * Temporal conversions now recognize subclass instances more reliably instead of treating them like generic objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->