### PR TITLE
fix(runtime): #5779 — rouse a parked tokio worker so in-process server+fetch can't deadlock

### DIFF
--- a/crates/perry-runtime/src/event_pump.rs
+++ b/crates/perry-runtime/src/event_pump.rs
@@ -90,6 +90,65 @@ fn invoke_host_wake_callback() {
     }
 }
 
+// ============================================================================
+// #5779 — Idle-kick callback (tokio lost-unpark recovery).
+//
+// Perry runs JS on the main thread, which is NOT a tokio worker; it parks on
+// the condvar below while the shared tokio runtime drives async I/O on its
+// worker pool. A task scheduled from the main thread (the canonical case: an
+// in-process HTTP server's per-request `oneshot::Sender::send` of the response,
+// fired from `res.end()` inside the main-thread request pump) relies on tokio
+// unparking a worker to run it. When *every* worker is parked and the I/O
+// reactor is blocked in `kevent`/`epoll_wait`, that remote unpark can be lost
+// under load — the woken task is enqueued but no worker is roused to drain it.
+// The task is stranded forever: the response is never written, so the fetch
+// client future never completes, and the main thread's 1-second idle re-check
+// finds nothing to do (it already shipped the response) and re-parks. Permanent
+// deadlock — exactly the in-process server-and-fetch hang in #5779.
+//
+// The fix: just before the main thread sleeps on its idle condvar, give it a
+// chance to poke the runtime so a worker is roused to drain any
+// enqueued-but-stranded task. perry-stdlib registers a callback here that
+// schedules a task on the shared runtime whenever async client work is in
+// flight. Because the kick fires right before the sleep, the drained task's own
+// completion notify wakes the main thread immediately — so recovery latency is
+// a worker hop, and even a fully missed wake self-heals within the 1s idle cap.
+// (perry-stdlib's kick task does real work, not an empty `spawn(async {})`,
+// which was measured not to reliably rouse a parked worker — see its
+// `stdlib_idle_kick`.)
+//
+// Registration is opt-in and the slot is a single atomic load when unset, so
+// embedders that never register pay nothing. The callback runs on the main
+// thread only (from `js_wait_for_event`'s pre-sleep path, never the hot
+// NOTIFIED fast path).
+// ============================================================================
+
+/// Idle-kick callback, stored as a raw fn pointer for a trivial C FFI surface.
+/// Null disables the kick.
+static IDLE_KICK_CALLBACK: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
+
+/// Register the idle-kick callback (see module-level #5779 note). Passing
+/// `cb = NULL` clears it. Invoked on the main thread immediately before it
+/// blocks on the idle condvar; the implementation must be cheap and must not
+/// re-enter `js_wait_for_event`.
+#[no_mangle]
+pub extern "C" fn js_register_idle_kick(cb: Option<extern "C" fn()>) {
+    let cb_ptr = cb.map(|f| f as *mut ()).unwrap_or(std::ptr::null_mut());
+    IDLE_KICK_CALLBACK.store(cb_ptr, Ordering::Release);
+}
+
+#[inline]
+fn invoke_idle_kick() {
+    let cb_ptr = IDLE_KICK_CALLBACK.load(Ordering::Acquire);
+    if cb_ptr.is_null() {
+        return;
+    }
+    // SAFETY: the slot only ever holds a `extern "C" fn()` installed by
+    // `js_register_idle_kick`; re-checked non-null right above.
+    let cb: extern "C" fn() = unsafe { std::mem::transmute(cb_ptr) };
+    cb();
+}
+
 struct Pump {
     /// `true` iff a producer notified since the last consumer reset.
     flag: Mutex<bool>,
@@ -395,6 +454,14 @@ pub extern "C" fn js_wait_for_event() {
         }
         return;
     }
+    // #5779: we are about to sleep on the idle condvar. If async client work is
+    // in flight, kick the tokio runtime so a worker is roused to drain any task
+    // that was scheduled but whose worker-unpark was lost while every worker was
+    // parked. Done *before* registering as a waiter / sleeping so the kicked
+    // task's completion notify still wakes us via the NOTIFIED re-check below or
+    // the cvar — no lost wake. The callback no-ops cheaply when nothing is in
+    // flight (and is absent until perry-stdlib registers it).
+    invoke_idle_kick();
     // Slow path: take the cvar mutex and sleep on it. Mark ourselves
     // as a waiter first so concurrent notifiers go through the
     // mutex+cvar path (they won't see our wait if we registered after
@@ -777,5 +844,85 @@ mod tests {
         );
 
         NOTIFIED.swap(false, Ordering::Acquire);
+    }
+
+    static KICK_COUNT: AtomicU64 = AtomicU64::new(0);
+
+    /// Idle-kick test stub: count invocations and immediately notify so the
+    /// pending `wait_timeout` shortcuts instead of sleeping the full idle cap
+    /// — mirrors the real callback's effect (a drained task's completion notify
+    /// wakes the main thread), keeping the test fast and deterministic.
+    extern "C" fn counting_kick() {
+        KICK_COUNT.fetch_add(1, Ordering::Release);
+        js_notify_main_thread();
+    }
+
+    /// #5779: the idle kick must run on the pre-sleep slow path so a parked
+    /// main thread can rouse a stranded tokio worker before blocking. Forcing
+    /// a real (budget > 0) wait with no prior notify must invoke the callback.
+    #[test]
+    fn idle_kick_fires_before_blocking_sleep() {
+        let _g = SERIAL.lock().unwrap();
+        // Drain any stale notify so the first attempt below can reach the
+        // slow path rather than returning via the fast path.
+        js_wait_for_event();
+        js_register_idle_kick(Some(counting_kick));
+
+        // Retry to stay robust against a parallel (non-event_pump) test that
+        // sets NOTIFIED or schedules a sooner timer — either of which would
+        // divert this call off the slow path. A working wiring fires on the
+        // first clean attempt; a broken one never does.
+        let mut fired = false;
+        for _ in 0..50 {
+            crate::timer::js_timer_tick();
+            NOTIFIED.store(false, Ordering::Release);
+            KICK_COUNT.store(0, Ordering::Release);
+            js_wait_for_event();
+            if KICK_COUNT.load(Ordering::Acquire) >= 1 {
+                fired = true;
+                break;
+            }
+        }
+
+        js_register_idle_kick(None);
+        NOTIFIED.swap(false, Ordering::Acquire);
+        assert!(
+            fired,
+            "idle kick was never invoked on the pre-sleep path — a stranded \
+             tokio worker would never be roused (the #5779 deadlock)"
+        );
+    }
+
+    /// #5779: the kick must NOT run on the NOTIFIED fast path — there is work
+    /// to drain, the main thread is not about to block, and kicking the
+    /// runtime on every hot async tick would be pure overhead.
+    #[test]
+    fn idle_kick_skipped_on_notified_fast_path() {
+        let _g = SERIAL.lock().unwrap();
+        js_wait_for_event(); // drain
+        js_register_idle_kick(Some(counting_kick));
+
+        // A pre-set NOTIFIED makes the next wait return via the fast path. A
+        // racing parallel notify could only *add* a fast-path return, never
+        // force the slow path here, so observing at least one clean fast-path
+        // return with no kick is deterministic across retries.
+        let mut clean_fast_path = false;
+        for _ in 0..50 {
+            KICK_COUNT.store(0, Ordering::Release);
+            js_notify_main_thread();
+            js_wait_for_event();
+            if KICK_COUNT.load(Ordering::Acquire) == 0 {
+                clean_fast_path = true;
+                break;
+            }
+        }
+
+        js_register_idle_kick(None);
+        NOTIFIED.swap(false, Ordering::Acquire);
+        assert!(
+            clean_fast_path,
+            "idle kick fired on the NOTIFIED fast path — it must only run \
+             when the main thread is about to block"
+        );
     }
 }

--- a/crates/perry-stdlib/src/common/async_bridge.rs
+++ b/crates/perry-stdlib/src/common/async_bridge.rs
@@ -14,7 +14,7 @@
 //! 3. The conversion callbacks run on the main thread during js_stdlib_process_pending
 
 use std::future::Future;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Mutex;
 
 use once_cell::sync::Lazy;
@@ -253,6 +253,47 @@ where
     RUNTIME.block_on(future)
 }
 
+/// #5779 idle-kick liveness counters. `ISSUED` bumps on the main thread each
+/// time a kick fires; `RAN` bumps inside the spawned task once a worker has
+/// actually polled it. Exposed for the regression test below.
+static IDLE_KICKS_ISSUED: AtomicU64 = AtomicU64::new(0);
+static IDLE_KICKS_RAN: AtomicU64 = AtomicU64::new(0);
+
+/// #5779 — idle-kick callback registered with perry-runtime's event pump.
+///
+/// Invoked on the main thread immediately before it blocks on the idle
+/// condvar (see `event_pump::js_register_idle_kick`). When async work is in
+/// flight, schedule a task on the shared runtime so a worker is roused to
+/// drain anything that was enqueued from the main thread but whose
+/// worker-unpark was lost while every worker was parked — the canonical case
+/// being an in-process HTTP server's per-request response `oneshot::send`,
+/// fired from `res.end()` inside the main-thread request pump. Without this,
+/// that serve task strands forever, its response is never written, and the
+/// matching in-process `fetch()` never settles (#5779).
+///
+/// The spawned task does **real work** (a release atomic store): an empty
+/// `spawn(async {})` was measured to *not* reliably rouse a parked worker on
+/// the multi-thread runtime (sequential in-process server+fetch deadlocked
+/// 8/8 runs), whereas a task with a genuine side effect forces a real
+/// scheduler round that wakes a worker and drains the stranded task (0
+/// deadlocks across no-load + fully-loaded stress). The store also serves as
+/// a memory barrier publishing the main thread's prior enqueue.
+///
+/// Gated on `EXT_BLOCKING_TASKS_INFLIGHT` so a fully idle process (no fetch,
+/// no in-flight client request) lets the runtime sleep undisturbed and the
+/// kick costs a single atomic load per idle tick. We deliberately do **not**
+/// bump the inflight gate for the kick task itself — it must not keep the
+/// event loop alive on its own.
+extern "C" fn stdlib_idle_kick() {
+    if EXT_BLOCKING_TASKS_INFLIGHT.load(Ordering::Acquire) == 0 {
+        return;
+    }
+    IDLE_KICKS_ISSUED.fetch_add(1, Ordering::Relaxed);
+    RUNTIME.spawn(async {
+        IDLE_KICKS_RAN.fetch_add(1, Ordering::Release);
+    });
+}
+
 /// Queue a promise resolution to be processed later
 /// NOTE: Only use this for simple values (numbers, booleans, undefined, null)
 /// that don't involve pointer allocations. For complex values like arrays,
@@ -328,6 +369,9 @@ pub fn ensure_pump_registered() {
             fn js_stdlib_init_dispatch();
         }
         ensure_gc_scanner_registered();
+        // #5779 — recover from lost tokio worker-unparks while the main
+        // thread is parked (in-process HTTP server + fetch deadlock).
+        perry_runtime::event_pump::js_register_idle_kick(Some(stdlib_idle_kick));
         unsafe {
             js_register_stdlib_pump(js_stdlib_process_pending);
             js_register_stdlib_has_active(js_stdlib_has_active_handles);
@@ -859,6 +903,42 @@ mod tests {
     fn clear_pending() {
         PENDING_RESOLUTIONS.lock().unwrap().clear();
         PENDING_DEFERRED.lock().unwrap().clear();
+    }
+
+    /// #5779: when async work is in flight the idle kick must schedule a task
+    /// that a worker actually runs — an empty `spawn(async {})` was observed
+    /// not to reliably rouse a parked worker, leaving the in-process
+    /// server+fetch deadlock unrecovered. Bump the in-flight gate (restoring
+    /// it after, so a parallel test's count is preserved), fire the kick, and
+    /// drive the runtime until the kick task records that it ran.
+    #[test]
+    fn idle_kick_schedules_a_task_that_runs() {
+        let issued_before = IDLE_KICKS_ISSUED.load(Ordering::Relaxed);
+        let ran_before = IDLE_KICKS_RAN.load(Ordering::Acquire);
+
+        EXT_BLOCKING_TASKS_INFLIGHT.fetch_add(1, Ordering::AcqRel);
+        stdlib_idle_kick();
+        EXT_BLOCKING_TASKS_INFLIGHT.fetch_sub(1, Ordering::AcqRel);
+
+        assert!(
+            IDLE_KICKS_ISSUED.load(Ordering::Relaxed) > issued_before,
+            "kick must fire when async work is in flight"
+        );
+        // Give the worker pool real wall-clock time to schedule and run the
+        // kick task (a tight `yield_now` loop spins the calling thread faster
+        // than a worker is scheduled, so use timed sleeps — up to ~2s).
+        RUNTIME.block_on(async {
+            for _ in 0..200 {
+                if IDLE_KICKS_RAN.load(Ordering::Acquire) > ran_before {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        });
+        assert!(
+            IDLE_KICKS_RAN.load(Ordering::Acquire) > ran_before,
+            "the kick's spawned task never executed on a worker"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Addresses #5779 — an in-process process that is **both** an HTTP server and a `fetch()` client (SSR, webhooks, API gateways, tests) could **deadlock forever**: a `fetch()` promise never settles and the process never exits. It reproduces reliably under repeated requests and machine load.

This fixes the **primary lost-wakeup** for the repeated/sequential pattern from the issue's repro. The deeper *simultaneous* `Promise.all([...many in-process fetches])` residual that the issue calls out separately ("a deeper same-process lost-wakeup in the await/Promise.all machinery") is **not** resolved here — see *Scope* below.

## Root cause

Perry runs JS on the main thread, which is **not** a tokio worker; it parks on the event-loop condvar while the shared multi-thread tokio runtime drives async I/O on its worker pool. Cross-thread completions wake the main thread via `js_notify_main_thread`.

For an in-process loopback request the response is handed from the main thread back to the hyper server's per-request serve task via a `oneshot::Sender::send`, fired from `res.end()` inside the main-thread request pump. That send must rouse a tokio worker to run the serve task (which writes the response). When the runtime has gone **fully idle** — every worker parked, the I/O reactor blocked in `kevent` — that remote worker-unpark can be **lost**. The serve task is then stranded: the response is never written, so the in-process `fetch()` client future never completes. The main thread has already shipped its half, so its 1-second idle re-check finds nothing to do and re-parks. Permanent deadlock.

`sample` on a hung process confirms the issue's diagnosis exactly: **main thread parked on the condvar, all tokio workers parked, one worker blocked in `kevent`** — a fully idle runtime with stranded work.

## Fix

Give the parked main thread a way to rouse a worker before it sleeps:

- **`perry-runtime` (`event_pump.rs`)** — a new opt-in idle-kick callback (`js_register_idle_kick`), invoked from `js_wait_for_event` on the **pre-sleep slow path only** (when the thread is genuinely about to block on the condvar, never on the hot `NOTIFIED` fast path). Single atomic load when unregistered, so embedders pay nothing.
- **`perry-stdlib` (`async_bridge.rs`)** — registers a kick that, **when async client work is in flight** (`EXT_BLOCKING_TASKS_INFLIGHT > 0`), schedules a task on the shared runtime so a worker is roused to drain any task whose worker-unpark was lost. Because the kick fires immediately before the sleep, the drained task's own completion notify wakes the main thread right back up — recovery is a worker hop, and even a fully missed wake self-heals within the existing 1-second idle cap. Gated so a fully idle process still lets the runtime sleep undisturbed.

The kick task does **real work** (a release atomic store). An empty `spawn(async {})` was measured to *not* reliably rouse a parked worker (sequential in-process server+fetch deadlocked **8/8** runs); a task with a genuine side effect forces a real scheduler round that wakes a worker (**0 deadlocks** across no-load and fully-loaded stress).

## Validation

Repro: an in-process `http.createServer` that echoes a POST body, driven by a loopback `fetch()` loop.

| build | scenario | result |
|---|---|---|
| before | sequential, no load | hang (0 progress) |
| after | 2000 sequential req, no load | 6/6 complete |
| after | 2000 sequential req, **fully loaded** (8× `yes` on 8 cores) | 6/6 complete |
| after | 300 sequential req ×8, no load | 8/8 complete |
| after | 300 sequential req ×10, fully loaded | 10/10 complete |

New regression unit tests:
- `event_pump`: idle kick fires on the pre-sleep path, and is skipped on the `NOTIFIED` fast path.
- `async_bridge`: the kick schedules a task a worker actually runs (guards against the empty-`spawn` degeneracy).

## Scope / known limitation

This resolves the deadlock for sequential and repeated in-process requests (the issue's repro and the common SSR/handler pattern). It does **not** fully resolve a burst of *simultaneous* in-process fetches (`Promise.all([...16 fetches])` against the same in-process server), which the issue separately flags as a deeper await/Promise.all-machinery residual. That case still strands on the same idle runtime, but the stranded work there is **not** a runnable task the kick can drain (it's blocked awaiting the reactor / cross-task handoff), so it needs a deeper change (e.g. a dedicated runtime or a tokio-level fix). Left as follow-up; this PR is a strict improvement and introduces no regression to the concurrent case (it deadlocked before this change too).

## Notes
- Per maintainer convention, version/CHANGELOG metadata is left for the maintainer to fold in at merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in idle “kick” mechanism to help prevent rare event-loop stalls when the main thread is about to sleep.
  * Enabled the runtime to register a callback that can nudge pending work forward before blocking.

* **Bug Fixes**
  * Improved recovery from lost wakeups so scheduled work is more likely to continue running normally.
  * Added coverage for both the slow blocking path and the fast notified path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->