### PR TITLE
fix(json): serialize int32-tagged numbers instead of emitting null

### DIFF
--- a/crates/perry-runtime/src/json/mod.rs
+++ b/crates/perry-runtime/src/json/mod.rs
@@ -184,7 +184,9 @@ pub(crate) const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
 pub(crate) const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
 pub(crate) const STRING_TAG: u64 = 0x7FFF_0000_0000_0000;
 pub(crate) const BIGINT_TAG: u64 = 0x7FFA_0000_0000_0000;
+pub(crate) const INT32_TAG: u64 = 0x7FFE_0000_0000_0000;
 pub(crate) const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
+pub(crate) const INT32_MASK: u64 = 0x0000_0000_FFFF_FFFF;
 
 pub(crate) const TYPE_UNKNOWN: u32 = 0;
 pub(crate) const TYPE_OBJECT: u32 = 1;
@@ -798,6 +800,53 @@ mod tests {
         let outer_boxed = crate::value::js_nanbox_pointer(outer as i64);
         let output = unsafe { js_json_stringify(outer_boxed, TYPE_UNKNOWN) };
         assert_eq!(unsafe { str_from_header(output).unwrap() }, r#"{"o":{}}"#);
+    }
+
+    #[test]
+    fn stringify_int32_fields_emit_integers_not_null() {
+        // An int32 is NaN-boxed (INT32_TAG = 0x7FFE); its bits ARE an IEEE NaN.
+        // Before the `write_number` int32 funnel, an int32 object field — e.g. a
+        // sqlite INTEGER column from the better-sqlite3 binding — fell into the
+        // `is_nan()` → "null" arm and serialized as `null`, silently corrupting
+        // integers crossing JSON/IPC. They must emit the integer value.
+        let obj = crate::object::js_object_alloc(0, 3);
+        let k_id = js_string_from_bytes(b"id".as_ptr(), 2);
+        let k_neg = js_string_from_bytes(b"neg".as_ptr(), 3);
+        let k_zero = js_string_from_bytes(b"zero".as_ptr(), 4);
+        crate::object::js_object_set_field_by_name(
+            obj,
+            k_id,
+            f64::from_bits(JSValue::int32(42).bits()),
+        );
+        crate::object::js_object_set_field_by_name(
+            obj,
+            k_neg,
+            f64::from_bits(JSValue::int32(-7).bits()),
+        );
+        crate::object::js_object_set_field_by_name(
+            obj,
+            k_zero,
+            f64::from_bits(JSValue::int32(0).bits()),
+        );
+        let boxed = crate::value::js_nanbox_pointer(obj as i64);
+        let output = unsafe { js_json_stringify(boxed, TYPE_UNKNOWN) };
+        assert_eq!(
+            unsafe { str_from_header(output).unwrap() },
+            r#"{"id":42,"neg":-7,"zero":0}"#
+        );
+    }
+
+    #[test]
+    fn stringify_int32_array_elements_emit_integers_not_null() {
+        // Same INT32_TAG funnel for array elements (drizzle raw-mode rows,
+        // integer arrays over IPC).
+        let mut arr = crate::array::js_array_alloc(3);
+        arr = crate::array::js_array_push_f64(arr, f64::from_bits(JSValue::int32(1).bits()));
+        arr = crate::array::js_array_push_f64(arr, f64::from_bits(JSValue::int32(2).bits()));
+        arr = crate::array::js_array_push_f64(arr, f64::from_bits(JSValue::int32(-9).bits()));
+        let boxed = crate::value::js_nanbox_pointer(arr as i64);
+        let output = unsafe { js_json_stringify(boxed, TYPE_ARRAY) };
+        assert_eq!(unsafe { str_from_header(output).unwrap() }, "[1,2,-9]");
     }
 
     #[test]

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -276,6 +276,18 @@ pub(crate) unsafe fn write_number(buf: &mut String, value: f64) {
         serialize_bigint(value, buf);
         return;
     }
+    // An int32 is NaN-boxed (INT32_TAG = 0x7FFE); its bits ARE an IEEE NaN, so it
+    // would otherwise fall into the `is_nan()` → "null" arm below and silently
+    // drop the value. Decode and emit the signed integer. Integer columns from
+    // the sqlite binding (and other int32-tagged numbers) funnel here; numeric
+    // literals are stored as plain f64 doubles by codegen and never take this
+    // branch. Mirrors the BigInt funnel above.
+    if (value.to_bits() & 0xFFFF_0000_0000_0000) == INT32_TAG {
+        let n = (value.to_bits() & INT32_MASK) as u32 as i32;
+        let mut itoa_buf = itoa::Buffer::new();
+        buf.push_str(itoa_buf.format(n));
+        return;
+    }
     // #2089: a Date is now a NaN-boxed `DateCell` pointer, handled in
     // `stringify_value`/`stringify_value_depth` before this numeric funnel —
     // so no Date detection is needed here anymore.


### PR DESCRIPTION
## Problem

`JSON.stringify` drops **every int32-tagged value to `null`**.

An int32 is NaN-boxed (`INT32_TAG = 0x7FFE`), so its bits *are* an IEEE NaN. `write_number` — the central numeric funnel that `stringify_value`, object fields, array elements, and both shape fast-paths all route through — had no int32 branch, so an int32 fell straight into the `is_nan()` → `"null"` arm.

Numeric **literals** dodge this because codegen stores them as plain f64 doubles. But values produced *as int32* are silently corrupted. The most visible source is the **better-sqlite3 binding**: `sqlite_value_to_jsvalue` boxes `SQLITE_INTEGER` columns as `JSValue::int32`, so:

```ts
const rows = db.select().from(notes).all()
JSON.stringify(rows)   // {"id":null,"created_at":null,...}  ← every integer column lost
```

This was surfaced on the electron-compat stress test as *"INTEGER PRIMARY KEY / integer columns return null in Drizzle SELECT results."* The values are fine in memory (`rows[0].id === 1`) — they vanish only when serialized, which is exactly what the IPC bridge does on the way to the renderer.

## Fix

Decode `INT32_TAG` in `write_number` before the NaN check, mirroring the existing BigInt funnel right above it. One branch; every serialization path funnels through here.

## Tests

- New unit tests: int32 object fields → `{"id":42,"neg":-7,"zero":0}`, int32 array elements → `[1,2,-9]`.
- Full `json::` module suite passes (17 tests).
- End-to-end (raw better-sqlite3 + JSON), built from this branch:

  | | before | after |
  |---|---|---|
  | `JSON.stringify(row)` | `{"id":null,"n":null,"s":"hello"}` | `{"id":1,"n":42,"s":"hello"}` |

## Scope / not in this PR

A separate, pre-existing quirk remains where a **rowid/PRIMARY-KEY** value reports `typeof === "function"` and misbehaves in arithmetic (`row.id + 100 === 1`). It predates this change, is unrelated to JSON, and does not affect the serialization path fixed here (JSON now reads the int32 bits correctly regardless). Tracking it separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON stringification so encoded 32-bit integers now appear as proper numbers instead of `null`.
  * Fixed handling for both object fields and array elements, including negative values and zero.
  * Preserved correct formatting for regular numbers while avoiding misinterpretation of integer-encoded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->