### PR TITLE
fix(runtime): decode int32 operands in the dynamic arithmetic helpers

### DIFF
--- a/crates/perry-runtime/src/value/dynamic_arith.rs
+++ b/crates/perry-runtime/src/value/dynamic_arith.rs
@@ -207,13 +207,29 @@ unsafe fn dynamic_bigint_binary_op_from_handles<'scope>(
     js_nanbox_bigint(result as i64)
 }
 
+/// Decode an int32-tagged operand to its plain-double value before an f64
+/// arithmetic op. An int32 is NaN-boxed (INT32_TAG = 0x7FFE), so its f64 bits
+/// ARE a NaN; a raw `a OP b` would propagate the tag through the FPU (ARM64
+/// keeps the NaN payload) and hand back the boxed operand instead of the
+/// result — e.g. a better-sqlite3 integer column `n` made `n + 100 === n`.
+/// Plain doubles (and real NaNs from arithmetic) pass through unchanged.
+#[inline]
+fn numify_arith_operand(v: f64) -> f64 {
+    let jv = JSValue::from_bits(v.to_bits());
+    if jv.is_int32() {
+        jv.as_int32() as f64
+    } else {
+        v
+    }
+}
+
 /// Dynamic multiply: BigInt * BigInt if either operand is BigInt, else f64 * f64.
 #[no_mangle]
 pub unsafe extern "C" fn js_dynamic_mul(a: f64, b: f64) -> f64 {
     if both_bigint_or_throw(a, b) {
         return dynamic_bigint_binary_op(a, b, crate::bigint::js_bigint_mul);
     }
-    a * b
+    numify_arith_operand(a) * numify_arith_operand(b)
 }
 
 /// Dynamic add: BigInt + BigInt if either operand is BigInt, else f64 + f64.
@@ -222,7 +238,7 @@ pub unsafe extern "C" fn js_dynamic_add(a: f64, b: f64) -> f64 {
     if both_bigint_or_throw(a, b) {
         return dynamic_bigint_binary_op(a, b, crate::bigint::js_bigint_add);
     }
-    a + b
+    numify_arith_operand(a) + numify_arith_operand(b)
 }
 
 /// `ToNumeric(value)` for the `++`/`--` slow path: a BigInt passes through
@@ -363,14 +379,22 @@ pub unsafe extern "C" fn js_dynamic_string_or_number_add(a: f64, b: f64) -> f64 
     }
 
     // Both numeric — coerce non-numbers (booleans, null, undefined) the
-    // same way the static fallback path did.
-    let a_num = if a_val.is_number() || a_val.is_int32() {
+    // same way the static fallback path did. An int32 must be DECODED to its
+    // plain-double value, not passed through as its NaN-boxed bits: the bits
+    // are a NaN, so `a_num + b_num` would propagate the int32 tag through fadd
+    // and return the boxed operand (a better-sqlite3 integer column `n` made
+    // `n + 100 === n`). Plain numbers already hold their value in the f64.
+    let a_num = if a_val.is_number() {
         a_prim_handle.get_nanbox_f64()
+    } else if a_val.is_int32() {
+        a_val.as_int32() as f64
     } else {
         crate::builtins::js_number_coerce(a_prim_handle.get_nanbox_f64())
     };
-    let b_num = if b_val.is_number() || b_val.is_int32() {
+    let b_num = if b_val.is_number() {
         b_prim_handle.get_nanbox_f64()
+    } else if b_val.is_int32() {
+        b_val.as_int32() as f64
     } else {
         crate::builtins::js_number_coerce(b_prim_handle.get_nanbox_f64())
     };
@@ -383,7 +407,7 @@ pub unsafe extern "C" fn js_dynamic_sub(a: f64, b: f64) -> f64 {
     if both_bigint_or_throw(a, b) {
         return dynamic_bigint_binary_op(a, b, crate::bigint::js_bigint_sub);
     }
-    a - b
+    numify_arith_operand(a) - numify_arith_operand(b)
 }
 
 /// Dynamic divide: BigInt / BigInt if either operand is BigInt, else f64 / f64.
@@ -392,7 +416,7 @@ pub unsafe extern "C" fn js_dynamic_div(a: f64, b: f64) -> f64 {
     if both_bigint_or_throw(a, b) {
         return dynamic_bigint_binary_op(a, b, crate::bigint::js_bigint_div);
     }
-    a / b
+    numify_arith_operand(a) / numify_arith_operand(b)
 }
 
 /// Dynamic modulo: BigInt % BigInt if either operand is BigInt, else f64 % f64.
@@ -402,6 +426,8 @@ pub unsafe extern "C" fn js_dynamic_mod(a: f64, b: f64) -> f64 {
         return dynamic_bigint_binary_op(a, b, crate::bigint::js_bigint_mod);
     }
     // Float modulo: a - trunc(a / b) * b
+    let a = numify_arith_operand(a);
+    let b = numify_arith_operand(b);
     a - (a / b).trunc() * b
 }
 
@@ -531,3 +557,37 @@ static KEEP_DYNAMIC_BITNOT: unsafe extern "C" fn(f64) -> f64 = js_dynamic_bitnot
 static KEEP_TO_NUMERIC: unsafe extern "C" fn(f64) -> f64 = js_to_numeric;
 #[used]
 static KEEP_NUMERIC_STEP: unsafe extern "C" fn(f64, i32) -> f64 = js_numeric_step;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn int32(n: i32) -> f64 {
+        f64::from_bits(JSValue::int32(n).bits())
+    }
+
+    // An int32-tagged operand (e.g. a better-sqlite3 integer column) must be
+    // decoded to its value before the f64 op; otherwise its NaN-boxed bits
+    // propagate through the FPU and the op returns the boxed operand. Pre-fix,
+    // `n + 100 === n` for an integer DB column.
+    #[test]
+    fn dynamic_arith_decodes_int32_operands() {
+        unsafe {
+            assert_eq!(js_dynamic_add(int32(42), 100.0), 142.0);
+            assert_eq!(js_dynamic_add(100.0, int32(42)), 142.0);
+            assert_eq!(js_dynamic_sub(int32(42), 1.0), 41.0);
+            assert_eq!(js_dynamic_mul(int32(42), 2.0), 84.0);
+            assert_eq!(js_dynamic_div(int32(84), 2.0), 42.0);
+            assert_eq!(js_dynamic_mod(int32(43), 10.0), 3.0);
+        }
+    }
+
+    #[test]
+    fn dynamic_string_or_number_add_decodes_int32() {
+        unsafe {
+            assert_eq!(js_dynamic_string_or_number_add(int32(42), 100.0), 142.0);
+            assert_eq!(js_dynamic_string_or_number_add(100.0, int32(42)), 142.0);
+            assert_eq!(js_dynamic_string_or_number_add(int32(2), int32(3)), 5.0);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The dynamic arithmetic helpers (`js_dynamic_string_or_number_add` and `js_dynamic_{add,sub,mul,div,mod}`) performed the raw f64 op directly on their operands. An int32 is NaN-boxed (`INT32_TAG = 0x7FFE`), so its f64 bits **are** an IEEE NaN — doing `a + b` propagates the tag through the FPU (ARM64 keeps the NaN payload) and hands back the **boxed operand** instead of the result.

Most visible symptom: a `better-sqlite3` integer column read through the `any`-typed path made **`n + 100 === n`** — silently wrong math on every integer DB column (timestamps + durations, sums, pagination offsets, …).

```ts
const row = db.prepare("SELECT n FROM t").get() as any   // n = 42
row.n + 100   // → 42  (WRONG; expected 142)
row.n * 2     // → 84  (ok — see below)
```

`-`/`*`/`/` happened to work because codegen eagerly coerces operands for the unambiguous numeric operators. `+` stays boxed (it might be string concat) and routes the raw int32 into `js_dynamic_string_or_number_add`, whose numeric fallback returned the operand's NaN-boxed bits for an int32 instead of decoding it — but the other four helpers had the identical latent bug for any int32 that reaches them.

## Fix

Decode int32 operands to their plain-double value before the f64 op (shared `numify_arith_operand`), in `js_dynamic_string_or_number_add` and the five `js_dynamic_{add,sub,mul,div,mod}` helpers. Plain doubles and real NaNs from arithmetic pass through unchanged; the hot all-doubles fast path in `js_dynamic_string_or_number_add` is untouched (int32 already falls out of it).

This is the same `INT32_TAG`-not-decoded class as the JSON-`null` bug in #5796 (a different code path).

## Tests
- New unit tests in `dynamic_arith` for int32 operands across `+ - * / %` and the string-or-number `+`.
- End-to-end (better-sqlite3 + the fix), built from this change:
  ```
  sqlite n = 42   +100 = 142   *2 = 84   -1 = 41     (all correct)
  bitwise int32 = 42   +100 = 142
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved arithmetic handling so integer values are now correctly converted before dynamic math operations.
  * Fixed `+`, `-`, `*`, `/`, and `%` calculations to return the expected results when integers are mixed with other numeric values.
  * Corrected string-or-number addition so numeric integer inputs are handled consistently.
  * Added coverage to verify these arithmetic behaviors across common numeric cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->