### PR TITLE
feat(compile): support eval-mode worker_threads Workers (inline source)

### DIFF
--- a/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
+++ b/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
@@ -201,6 +201,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             paths,
             filename,
             options,
+            is_eval: _,
         } => {
             let _ = lower_expr(ctx, filename)?;
             let options_val = if let Some(options) = options {

--- a/crates/perry-hir/src/dynamic_import/tests.rs
+++ b/crates/perry-hir/src/dynamic_import/tests.rs
@@ -727,6 +727,7 @@ fn worker_new_visitor_descends_into_closure_bodies() {
             paths: vec![],
             filename: Box::new(Expr::String("./worker.js".to_string())),
             options: None,
+            is_eval: false,
         })],
         captures: vec![],
         mutable_captures: vec![],

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -2622,6 +2622,10 @@ pub enum Expr {
         paths: Vec<String>,
         filename: Box<Expr>,
         options: Option<Box<Expr>>,
+        /// `true` when the Worker options carry `eval: true` — i.e. the first
+        /// argument is JS SOURCE, not a filename (Node eval-mode Worker, used by
+        /// e.g. `@perryts/threads`). Parsed from the options object at lowering.
+        is_eval: bool,
     },
 }
 

--- a/crates/perry-hir/src/lower/expr_new/helpers.rs
+++ b/crates/perry-hir/src/lower/expr_new/helpers.rs
@@ -295,6 +295,10 @@ pub(crate) fn lower_worker_messaging_new(
 }
 
 pub(crate) fn lower_worker_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> Result<Expr> {
+    // Parse `eval: true` from the raw AST options object BEFORE lowering (the
+    // lowered options become an anonymous shape-class `New`, which is much
+    // harder to inspect). This is the authoritative eval-mode signal.
+    let is_eval = worker_options_is_eval(new_expr);
     let args = new_expr
         .args
         .as_ref()
@@ -312,7 +316,41 @@ pub(crate) fn lower_worker_new(ctx: &mut LoweringContext, new_expr: &ast::NewExp
         paths: Vec::new(),
         filename: Box::new(filename),
         options,
+        is_eval,
     })
+}
+
+/// True when `new Worker(src, { eval: true })` — the second argument is an
+/// object literal with a literal `eval: true` member.
+fn worker_options_is_eval(new_expr: &ast::NewExpr) -> bool {
+    let Some(args) = new_expr.args.as_ref() else {
+        return false;
+    };
+    let Some(opts) = args.get(1) else {
+        return false;
+    };
+    let ast::Expr::Object(obj) = &*opts.expr else {
+        return false;
+    };
+    for prop in &obj.props {
+        let ast::PropOrSpread::Prop(prop) = prop else {
+            continue;
+        };
+        let ast::Prop::KeyValue(kv) = &**prop else {
+            continue;
+        };
+        let is_eval_key = match &kv.key {
+            ast::PropName::Ident(i) => &*i.sym == "eval",
+            ast::PropName::Str(s) => &*s.value == "eval",
+            _ => false,
+        };
+        if is_eval_key {
+            if let ast::Expr::Lit(ast::Lit::Bool(b)) = &*kv.value {
+                return b.value;
+            }
+        }
+    }
+    false
 }
 
 pub(crate) fn is_worker_threads_module_name(module_name: &str) -> bool {

--- a/crates/perry-hir/src/lower/expr_new/helpers.rs
+++ b/crates/perry-hir/src/lower/expr_new/helpers.rs
@@ -332,25 +332,30 @@ fn worker_options_is_eval(new_expr: &ast::NewExpr) -> bool {
     let ast::Expr::Object(obj) = &*opts.expr else {
         return false;
     };
+    // Evaluate props in order so the LAST `eval` wins (JS duplicate-key
+    // semantics), and a spread conservatively clears any earlier static
+    // `eval: true` — its runtime value could override it, and misclassifying a
+    // file Worker as eval-mode is worse than missing an obscure spread case.
+    let mut eval = false;
     for prop in &obj.props {
-        let ast::PropOrSpread::Prop(prop) = prop else {
-            continue;
-        };
-        let ast::Prop::KeyValue(kv) = &**prop else {
-            continue;
-        };
-        let is_eval_key = match &kv.key {
-            ast::PropName::Ident(i) => &*i.sym == "eval",
-            ast::PropName::Str(s) => &*s.value == "eval",
-            _ => false,
-        };
-        if is_eval_key {
-            if let ast::Expr::Lit(ast::Lit::Bool(b)) = &*kv.value {
-                return b.value;
+        match prop {
+            ast::PropOrSpread::Spread(_) => eval = false,
+            ast::PropOrSpread::Prop(prop) => {
+                let ast::Prop::KeyValue(kv) = &**prop else {
+                    continue;
+                };
+                let is_eval_key = match &kv.key {
+                    ast::PropName::Ident(i) => &*i.sym == "eval",
+                    ast::PropName::Str(s) => &*s.value == "eval",
+                    _ => false,
+                };
+                if is_eval_key {
+                    eval = matches!(&*kv.value, ast::Expr::Lit(ast::Lit::Bool(b)) if b.value);
+                }
             }
         }
     }
-    false
+    eval
 }
 
 pub(crate) fn is_worker_threads_module_name(module_name: &str) -> bool {

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -656,7 +656,7 @@ impl SH for Expr {
             Expr::WebAssemblyInstantiate(bytes) => { tag(h, 12028); bytes.as_ref().hash(h); }
             Expr::WebAssemblyCallExport { instance, name, args, } => { tag(h, 12029); instance.as_ref().hash(h); name.as_ref().hash(h); args.hash(h); }
             Expr::DynamicImport { paths, arg, byte_offset, deferred_error, synchronous } => { tag(h, 12030); for p in paths { p.hash(h); } arg.as_ref().hash(h); byte_offset.hash(h); deferred_error.hash(h); synchronous.hash(h); }
-            Expr::WorkerNew { paths, filename, options } => {
+            Expr::WorkerNew { paths, filename, options, is_eval } => {
                 tag(h, 12055);
                 for p in paths { p.hash(h); }
                 filename.as_ref().hash(h);
@@ -667,6 +667,7 @@ impl SH for Expr {
                     }
                     None => false.hash(h),
                 }
+                is_eval.hash(h);
             }
         }
     }

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -54,6 +54,31 @@ use parse_error::annotate_parse_error;
 use static_require_transform::transform_static_literal_requires;
 use wasm_asset::{is_wasm_asset, synthesize_wasm_stub_module};
 
+/// Write an eval-mode Worker's inline source to a content-addressed `.js` file
+/// under the system temp dir and return its absolute path. Content addressing
+/// keeps the path stable across compiles (so the object cache hits) and avoids
+/// races between parallel lowering threads writing the same source.
+fn materialize_eval_worker_source(source: &str) -> Result<String> {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(source.as_bytes());
+    let digest = hasher.finalize();
+    let hex: String = digest.iter().take(16).map(|b| format!("{b:02x}")).collect();
+    let dir = std::env::temp_dir().join("perry-eval-workers");
+    fs::create_dir_all(&dir).map_err(|e| anyhow!("create {}: {}", dir.display(), e))?;
+    let path = dir.join(format!("perry-eval-worker-{hex}.js"));
+    // Content-addressed: only write when missing (or size differs) so
+    // concurrent threads don't clobber an identical file mid-read.
+    let needs_write = match fs::metadata(&path) {
+        Ok(meta) => meta.len() != source.len() as u64,
+        Err(_) => true,
+    };
+    if needs_write {
+        fs::write(&path, source).map_err(|e| anyhow!("write {}: {}", path.display(), e))?;
+    }
+    Ok(path.to_string_lossy().into_owned())
+}
+
 const MAX_CROSS_MODULE_INLINE_PRIOR_MODULES: usize = 128;
 
 /// Next.js wall 54 (part 2): recursively gather every `*.js` file under `dir`
@@ -944,8 +969,14 @@ fn collect_module_one(
                 &dynamic_local_literals,
                 &mut visiting,
             ) {
-                perry_hir::Resolution::Set(set) => {
-                    if set.len() > perry_hir::DYNAMIC_IMPORT_PATH_CAP {
+                perry_hir::Resolution::Set(mut set) => {
+                    // Eval-mode Worker (`new Worker(src, { eval: true })`):
+                    // the resolved value is the worker SOURCE, not a path. A
+                    // file path / URL is always a single line, so an embedded
+                    // newline is an unambiguous "this is source code" tell
+                    // (no false positives on real worker filenames).
+                    let eval_mode = set.len() == 1 && set[0].contains('\n');
+                    if !eval_mode && set.len() > perry_hir::DYNAMIC_IMPORT_PATH_CAP {
                         dyn_errors.push(format!(
                             "worker_threads Worker in module {}: filename resolves to {} possible paths \
                              (limit: {})",
@@ -962,6 +993,25 @@ fn collect_module_one(
                             set.len()
                         ));
                         return;
+                    }
+                    if eval_mode {
+                        // Eval-mode Worker (`new Worker(src, { eval: true })`):
+                        // the resolved value is the worker SOURCE, not a path.
+                        // Materialize it to a content-addressed temp `.js` file
+                        // so the existing file-worker machinery compiles it as a
+                        // module — instead of erroring "Worker target was not
+                        // compiled" on a "path" that is actually source code.
+                        match materialize_eval_worker_source(&set[0]) {
+                            Ok(temp_path) => set[0] = temp_path,
+                            Err(e) => {
+                                dyn_errors.push(format!(
+                                    "worker_threads eval Worker in module {}: failed to \
+                                     materialize inline source: {}",
+                                    module_name, e
+                                ));
+                                return;
+                            }
+                        }
                     }
                     for p in &set {
                         if !new_dyn_imports.contains(p) {
@@ -1941,4 +1991,24 @@ fn collect_module_finish(
     });
     ctx.native_modules.insert(canonical, hir_module);
     Ok(())
+}
+
+#[cfg(test)]
+mod eval_worker_tests {
+    use super::materialize_eval_worker_source;
+
+    #[test]
+    fn materialize_is_deterministic_and_roundtrips() {
+        let src = "\"use strict\";\nvar { parentPort } = require('worker_threads');\nparentPort.postMessage(1);\n";
+        let p1 = materialize_eval_worker_source(src).expect("materialize");
+        let p2 = materialize_eval_worker_source(src).expect("materialize again");
+        // Content-addressed: identical source → identical path.
+        assert_eq!(p1, p2);
+        assert!(p1.ends_with(".js"), "worker file must be a .js module: {p1}");
+        let written = std::fs::read_to_string(&p1).expect("read back");
+        assert_eq!(written, src);
+        // Different source → different path.
+        let other = materialize_eval_worker_source("console.log('x');\n").expect("materialize other");
+        assert_ne!(p1, other);
+    }
 }

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -932,12 +932,20 @@ fn collect_module_one(
     let mut worker_path_sets: Vec<Vec<String>> = Vec::new();
     perry_hir::for_each_worker_new(&hir_module, &mut |expr| {
         if let perry_hir::Expr::WorkerNew {
-            paths, filename, ..
+            paths,
+            filename,
+            is_eval,
+            ..
         } = expr
         {
             if !paths.is_empty() {
                 return;
             }
+            // Eval-mode Worker (`new Worker(src, { eval: true })`): the resolved
+            // value is the worker SOURCE, not a path — parsed from the options
+            // object at lowering (authoritative; handles single-line sources and
+            // doesn't misclassify multi-line filenames).
+            let eval_mode = *is_eval;
             let mut visiting: std::collections::HashSet<u32> = std::collections::HashSet::new();
             match perry_hir::resolve_import_path_with_context(
                 filename.as_ref(),
@@ -947,12 +955,6 @@ fn collect_module_one(
                 &mut visiting,
             ) {
                 perry_hir::Resolution::Set(mut set) => {
-                    // Eval-mode Worker (`new Worker(src, { eval: true })`):
-                    // the resolved value is the worker SOURCE, not a path. A
-                    // file path / URL is always a single line, so an embedded
-                    // newline is an unambiguous "this is source code" tell
-                    // (no false positives on real worker filenames).
-                    let eval_mode = set.len() == 1 && set[0].contains('\n');
                     if !eval_mode && set.len() > perry_hir::DYNAMIC_IMPORT_PATH_CAP {
                         dyn_errors.push(format!(
                             "worker_threads Worker in module {}: filename resolves to {} possible paths \

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -33,6 +33,7 @@ use super::{
 
 mod crypto_ns;
 mod dynamic_glob;
+mod eval_worker;
 mod feature_detect;
 mod import_helpers;
 mod native_addon;
@@ -43,6 +44,7 @@ mod tests;
 mod wasm_asset;
 
 use dynamic_glob::expand_dynamic_import_glob;
+use eval_worker::materialize_eval_worker_source;
 use import_helpers::{
     cached_resolve_import_with_lexical_base, collect_js_module_imports, env_defines_for_lowering,
 };
@@ -53,31 +55,6 @@ use native_addon::refuse_compile_package_native_addon;
 use parse_error::annotate_parse_error;
 use static_require_transform::transform_static_literal_requires;
 use wasm_asset::{is_wasm_asset, synthesize_wasm_stub_module};
-
-/// Write an eval-mode Worker's inline source to a content-addressed `.js` file
-/// under the system temp dir and return its absolute path. Content addressing
-/// keeps the path stable across compiles (so the object cache hits) and avoids
-/// races between parallel lowering threads writing the same source.
-fn materialize_eval_worker_source(source: &str) -> Result<String> {
-    use sha2::{Digest, Sha256};
-    let mut hasher = Sha256::new();
-    hasher.update(source.as_bytes());
-    let digest = hasher.finalize();
-    let hex: String = digest.iter().take(16).map(|b| format!("{b:02x}")).collect();
-    let dir = std::env::temp_dir().join("perry-eval-workers");
-    fs::create_dir_all(&dir).map_err(|e| anyhow!("create {}: {}", dir.display(), e))?;
-    let path = dir.join(format!("perry-eval-worker-{hex}.js"));
-    // Content-addressed: only write when missing (or size differs) so
-    // concurrent threads don't clobber an identical file mid-read.
-    let needs_write = match fs::metadata(&path) {
-        Ok(meta) => meta.len() != source.len() as u64,
-        Err(_) => true,
-    };
-    if needs_write {
-        fs::write(&path, source).map_err(|e| anyhow!("write {}: {}", path.display(), e))?;
-    }
-    Ok(path.to_string_lossy().into_owned())
-}
 
 const MAX_CROSS_MODULE_INLINE_PRIOR_MODULES: usize = 128;
 
@@ -1991,28 +1968,4 @@ fn collect_module_finish(
     });
     ctx.native_modules.insert(canonical, hir_module);
     Ok(())
-}
-
-#[cfg(test)]
-mod eval_worker_tests {
-    use super::materialize_eval_worker_source;
-
-    #[test]
-    fn materialize_is_deterministic_and_roundtrips() {
-        let src = "\"use strict\";\nvar { parentPort } = require('worker_threads');\nparentPort.postMessage(1);\n";
-        let p1 = materialize_eval_worker_source(src).expect("materialize");
-        let p2 = materialize_eval_worker_source(src).expect("materialize again");
-        // Content-addressed: identical source → identical path.
-        assert_eq!(p1, p2);
-        assert!(
-            p1.ends_with(".js"),
-            "worker file must be a .js module: {p1}"
-        );
-        let written = std::fs::read_to_string(&p1).expect("read back");
-        assert_eq!(written, src);
-        // Different source → different path.
-        let other =
-            materialize_eval_worker_source("console.log('x');\n").expect("materialize other");
-        assert_ne!(p1, other);
-    }
 }

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -2004,11 +2004,15 @@ mod eval_worker_tests {
         let p2 = materialize_eval_worker_source(src).expect("materialize again");
         // Content-addressed: identical source → identical path.
         assert_eq!(p1, p2);
-        assert!(p1.ends_with(".js"), "worker file must be a .js module: {p1}");
+        assert!(
+            p1.ends_with(".js"),
+            "worker file must be a .js module: {p1}"
+        );
         let written = std::fs::read_to_string(&p1).expect("read back");
         assert_eq!(written, src);
         // Different source → different path.
-        let other = materialize_eval_worker_source("console.log('x');\n").expect("materialize other");
+        let other =
+            materialize_eval_worker_source("console.log('x');\n").expect("materialize other");
         assert_ne!(p1, other);
     }
 }

--- a/crates/perry/src/commands/compile/collect_modules/eval_worker.rs
+++ b/crates/perry/src/commands/compile/collect_modules/eval_worker.rs
@@ -1,0 +1,58 @@
+//! Eval-mode `worker_threads` Worker support.
+//!
+//! Extracted from `collect_modules.rs` (file-size split). `new Worker(src,
+//! { eval: true })` passes the worker SOURCE rather than a filename; this
+//! materializes that source to a content-addressed temp `.js` file so the
+//! existing file-worker machinery compiles it as a normal module.
+
+use anyhow::{anyhow, Result};
+use std::fs;
+
+/// Write an eval-mode Worker's inline source to a content-addressed `.js` file
+/// under the system temp dir and return its absolute path. Content addressing
+/// keeps the path stable across compiles (so the object cache hits) and avoids
+/// races between parallel lowering threads writing the same source.
+pub(super) fn materialize_eval_worker_source(source: &str) -> Result<String> {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(source.as_bytes());
+    let digest = hasher.finalize();
+    let hex: String = digest.iter().take(16).map(|b| format!("{b:02x}")).collect();
+    let dir = std::env::temp_dir().join("perry-eval-workers");
+    fs::create_dir_all(&dir).map_err(|e| anyhow!("create {}: {}", dir.display(), e))?;
+    let path = dir.join(format!("perry-eval-worker-{hex}.js"));
+    // Content-addressed: only write when missing (or size differs) so
+    // concurrent threads don't clobber an identical file mid-read.
+    let needs_write = match fs::metadata(&path) {
+        Ok(meta) => meta.len() != source.len() as u64,
+        Err(_) => true,
+    };
+    if needs_write {
+        fs::write(&path, source).map_err(|e| anyhow!("write {}: {}", path.display(), e))?;
+    }
+    Ok(path.to_string_lossy().into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::materialize_eval_worker_source;
+
+    #[test]
+    fn materialize_is_deterministic_and_roundtrips() {
+        let src = "\"use strict\";\nvar { parentPort } = require('worker_threads');\nparentPort.postMessage(1);\n";
+        let p1 = materialize_eval_worker_source(src).expect("materialize");
+        let p2 = materialize_eval_worker_source(src).expect("materialize again");
+        // Content-addressed: identical source → identical path.
+        assert_eq!(p1, p2);
+        assert!(
+            p1.ends_with(".js"),
+            "worker file must be a .js module: {p1}"
+        );
+        let written = std::fs::read_to_string(&p1).expect("read back");
+        assert_eq!(written, src);
+        // Different source → different path.
+        let other =
+            materialize_eval_worker_source("console.log('x');\n").expect("materialize other");
+        assert_ne!(p1, other);
+    }
+}

--- a/crates/perry/src/commands/compile/collect_modules/eval_worker.rs
+++ b/crates/perry/src/commands/compile/collect_modules/eval_worker.rs
@@ -7,11 +7,22 @@
 
 use anyhow::{anyhow, Result};
 use std::fs;
+use std::io::Write;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+// Per-process counter for unique temp filenames (no Date/rand needed).
+static NEXT_TMP: AtomicU64 = AtomicU64::new(0);
 
 /// Write an eval-mode Worker's inline source to a content-addressed `.js` file
 /// under the system temp dir and return its absolute path. Content addressing
-/// keeps the path stable across compiles (so the object cache hits) and avoids
-/// races between parallel lowering threads writing the same source.
+/// keeps the path stable across compiles (so the object cache hits).
+///
+/// Written atomically: a unique temp file is fully written then `rename`d into
+/// the shared content-addressed path, so a concurrent rayon lowering thread can
+/// never observe a half-written file, and reuse is gated on a full BYTE compare
+/// (a size-only check could accept a truncated/corrupt same-length file).
+/// Concurrent writers of the same source produce byte-identical content, so
+/// whichever rename wins leaves a correct file.
 pub(super) fn materialize_eval_worker_source(source: &str) -> Result<String> {
     use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
@@ -21,15 +32,30 @@ pub(super) fn materialize_eval_worker_source(source: &str) -> Result<String> {
     let dir = std::env::temp_dir().join("perry-eval-workers");
     fs::create_dir_all(&dir).map_err(|e| anyhow!("create {}: {}", dir.display(), e))?;
     let path = dir.join(format!("perry-eval-worker-{hex}.js"));
-    // Content-addressed: only write when missing (or size differs) so
-    // concurrent threads don't clobber an identical file mid-read.
-    let needs_write = match fs::metadata(&path) {
-        Ok(meta) => meta.len() != source.len() as u64,
-        Err(_) => true,
-    };
-    if needs_write {
-        fs::write(&path, source).map_err(|e| anyhow!("write {}: {}", path.display(), e))?;
+
+    // Reuse only if the existing file's bytes match exactly.
+    if let Ok(existing) = fs::read(&path) {
+        if existing == source.as_bytes() {
+            return Ok(path.to_string_lossy().into_owned());
+        }
     }
+
+    // Write to a unique temp file, then atomically rename into place.
+    let tmp = dir.join(format!(
+        "perry-eval-worker-{hex}.{}.{}.tmp",
+        std::process::id(),
+        NEXT_TMP.fetch_add(1, Ordering::Relaxed)
+    ));
+    {
+        let mut f =
+            fs::File::create(&tmp).map_err(|e| anyhow!("create {}: {}", tmp.display(), e))?;
+        f.write_all(source.as_bytes())
+            .map_err(|e| anyhow!("write {}: {}", tmp.display(), e))?;
+    }
+    fs::rename(&tmp, &path).map_err(|e| {
+        let _ = fs::remove_file(&tmp);
+        anyhow!("rename {} -> {}: {}", tmp.display(), path.display(), e)
+    })?;
     Ok(path.to_string_lossy().into_owned())
 }
 


### PR DESCRIPTION
## Problem

`new Worker(source, { eval: true })` — where the first argument is JS **source**, not a filename — failed codegen:

```
worker_threads Worker target was not compiled: <the source string>
```

The `WorkerNew` lowering only handles **file-path** workers: it resolves the filename to a compiled module and looks it up in `dynamic_import_path_to_prefix`. An inline source string has no corresponding module, so nothing is registered and codegen errors.

`@perryts/threads` (`parallelMap`/`parallelFilter`/`spawn`) builds its worker pool exactly this way (`new wt.Worker(NODE_WORKER_PREAMBLE + WORKER_SCRIPT, { eval: true })`), so the package could not be compiled at all under Perry AOT.

## Fix

In `collect_modules`, when a Worker's resolved filename is actually source code, materialize it to a **content-addressed `.js` file** under the system temp dir and feed that path through the existing file-worker machinery — so the worker compiles as a normal module.

**Detection:** the resolved value contains a newline. A worker filename (path or URL) is always single-line, so an embedded newline is an unambiguous "this is source, not a path" signal — no false positives on real worker filenames. (`{ eval: true }` itself lowers to an anonymous shape-class `New`, not a readable object literal, so the source-shape check is both simpler and more robust than trying to read the option back.)

Content addressing keeps the temp path stable across compiles (object-cache hits) and avoids races between parallel lowering threads writing the same source.

## Verification

End-to-end, with `@perryts/threads` added to `perry.compilePackages`:

```ts
import { parallelMap } from "@perryts/threads"
await parallelMap([1, 2, 3, 4], (n) => n * 2)   // → [2,4,6,8]
```

Compiles (previously a hard codegen failure) **and runs correctly** → `[2,4,6,8]`. Adds a unit test for the content-addressed materialization (determinism + round-trip).

## Known limitation

A single-**line** eval source (no newline) is not yet detected and still hits the prior error — **no regression**, and every real multi-line worker script is covered. A follow-up could read the `eval: true` option directly (requires resolving the shape-class fields) to also cover single-line sources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved compilation support for eval-mode worker threads created from inline JavaScript source.
  * Materializes inline worker source into a temporary script with deterministic reuse.

* **Bug Fixes**
  * Correctly detects `eval: true` worker options and treats the first argument as source, not a filename.
  * Skips path-limit validation when in eval mode.
  * Produces more accurate errors if inline source materialization fails.
  * Includes eval-mode state in incremental hashing for more consistent rebuilds.

* **Tests**
  * Added determinism/content round-trip checks for generated eval worker scripts.
  * Updated worker visitor coverage to include the eval flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->