### PR TITLE
fix(runtime/codegen): #5586 — propertyIsEnumerable on RegExp instances, new /z/() TypeError

### DIFF
--- a/crates/perry-codegen/src/expr/new_dynamic.rs
+++ b/crates/perry-codegen/src/expr/new_dynamic.rs
@@ -50,7 +50,9 @@ use super::{
 /// A `new` callee that is a primitive literal — never a constructor, so
 /// `new <it>(…)` is a `TypeError`. Covers number / bool / null / undefined /
 /// string / bigint literals (the cases the runtime construct path can't always
-/// tag-reject, notably `f64` numbers).
+/// tag-reject, notably `f64` numbers) and regex literals (`new /z/()` is a
+/// TypeError: a RegExp instance has no [[Construct]] internal method,
+/// test262 S15.10.7_A2_T1 / S15.10.7_A2_T2).
 fn new_callee_is_primitive_literal(callee: &Expr) -> bool {
     matches!(
         callee,
@@ -62,6 +64,7 @@ fn new_callee_is_primitive_literal(callee: &Expr) -> bool {
             | Expr::String(_)
             | Expr::WtfString(_)
             | Expr::BigInt(_)
+            | Expr::RegExp { .. }
     )
 }
 

--- a/crates/perry-runtime/src/object/native_call_method/common_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/common_methods.rs
@@ -273,8 +273,7 @@ pub(super) unsafe fn dispatch_common(
             // `global`/`ignoreCase`/`multiline` (test262 S15.10.7.x_A8).
             if let Some(kind) = super::exotic_expando::exotic_expando_kind(raw) {
                 use super::exotic_expando::ExoticKind;
-                let Some(key_name) = super::has_own_helpers::str_from_string_header(key_str)
-                else {
+                let Some(key_name) = super::has_own_helpers::str_from_string_header(key_str) else {
                     return Some(f64::from_bits(JSValue::bool(false).bits()));
                 };
                 // User-added expando property — honour the stored descriptor.

--- a/crates/perry-runtime/src/object/native_call_method/common_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/common_methods.rs
@@ -265,6 +265,40 @@ pub(super) unsafe fn dispatch_common(
                     .unwrap_or(true);
                 return Some(f64::from_bits(JSValue::bool(enumerable).bits()));
             }
+            // exotic: Date, RegExp, Error, Temporal, Promise — none of their
+            // built-in own properties are enumerable; only user-added expando
+            // keys can be. Without this check, a regex receiver falls through to
+            // the ObjectHeader path below and mis-reads the RegExpHeader bytes,
+            // returning garbage instead of `false` for accessor properties like
+            // `global`/`ignoreCase`/`multiline` (test262 S15.10.7.x_A8).
+            if let Some(kind) = super::exotic_expando::exotic_expando_kind(raw) {
+                use super::exotic_expando::ExoticKind;
+                let Some(key_name) = super::has_own_helpers::str_from_string_header(key_str)
+                else {
+                    return Some(f64::from_bits(JSValue::bool(false).bits()));
+                };
+                // User-added expando property — honour the stored descriptor.
+                if super::exotic_expando::exotic_has_own_property(kind, raw, key_name) {
+                    let enumerable = get_property_attrs(raw, key_name)
+                        .map(|attrs| attrs.enumerable())
+                        .unwrap_or(true);
+                    return Some(f64::from_bits(JSValue::bool(enumerable).bits()));
+                }
+                // Error: delegate to the per-builtin-key enumerability table.
+                if matches!(kind, ExoticKind::Error) {
+                    let enumerable = crate::error::js_error_builtin_own_property_is_enumerable(
+                        raw as *mut crate::error::ErrorHeader,
+                        key_name,
+                    )
+                    .unwrap_or(false);
+                    return Some(f64::from_bits(JSValue::bool(enumerable).bits()));
+                }
+                // RegExp: `lastIndex` is a non-enumerable writable own property;
+                // prototype accessors (global, ignoreCase, multiline, …) are not
+                // own at all. Date / Temporal / Promise have no enumerable builtin
+                // own properties either.
+                return Some(f64::from_bits(JSValue::bool(false).bits()));
+            }
             if raw >= crate::gc::GC_HEADER_SIZE + 0x1000 {
                 let gc_header =
                     (raw as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;


### PR DESCRIPTION
## Summary

Fixes 5 non-categorical test262 failures under `built-ins/RegExp` (issue #5586).

### Fix 1 — `propertyIsEnumerable` on a RegExp receiver (`common_methods.rs`)

`re.propertyIsEnumerable('global')` returned garbage (`[object Object]`) because the `propertyIsEnumerable` handler cast the `RegExpHeader *` as `ObjectHeader *`.  `RegExpHeader.regex_ptr` (first 8 bytes) was misread as `object_type + class_id`, and `flags_ptr` (offset 16) was misread as `keys_array` — producing a real object pointer value that then stringified as `[object Object]`.

The `hasOwnProperty` arm already had an `exotic_expando_kind` guard for exactly this reason; the `propertyIsEnumerable` arm was missing it.  The new guard:
- User-added expando keys honour the stored `PropertyAttrs` (enumerable = true by default unless overridden with `Object.defineProperty`).
- `Error` built-in own properties delegate to `js_error_builtin_own_property_is_enumerable`.
- All other exotic types (RegExp, Date, Temporal, Promise) return `false` — none of their built-in own properties are enumerable.

Fixes: `S15.10.7.2_A8.js`, `S15.10.7.3_A8.js`, `S15.10.7.4_A8.js` (3 tests).

### Fix 2 — `new /z/()` must throw `TypeError` (`new_dynamic.rs`)

`new /z/()` silently fell through to the generic dynamic-`new` path instead of emitting `js_throw_not_a_constructor` at compile time.  A `RegExp` instance has no `[[Construct]]` internal method, so `new <regex-literal>(…)` must always throw `TypeError`.  Added `Expr::RegExp { .. }` to `new_callee_is_primitive_literal`, which already covers number / bool / null / undefined / string / bigint literals for the same reason.

Fixes: `S15.10.7_A2_T1.js`, `S15.10.7_A2_T2.js` (2 tests).

## Test plan

- [ ] `cargo build --profile perry-dev -p perry-runtime` — no new errors
- [ ] `cargo build --profile perry-dev -p perry-codegen` — no new errors
- [ ] Run test262 subset for `built-ins/RegExp` and verify the 5 listed tests flip from FAIL → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `propertyIsEnumerable` results for built-in exotic objects, including dates, regular expressions, errors, temporal objects, and promises.
  * Added safer handling when a property name can’t be determined, and corrected enumerability for both user-added and built-in properties on these objects.
  * Fixed `new` with regular expression literals so it now follows the expected “not a constructor” behavior (raising `TypeError`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->