### PR TITLE
fix(runtime): #5581 — three Intl.NumberFormat test262 gaps

### DIFF
--- a/crates/perry-runtime/src/intl.rs
+++ b/crates/perry-runtime/src/intl.rs
@@ -292,6 +292,8 @@ fn coerce_option_string(value: f64) -> Option<String> {
         Some("null".to_string())
     } else if js.is_any_string() {
         string_from_string_value(value)
+    } else if unsafe { crate::symbol::js_is_symbol(value) != 0 } {
+        throw_type_error("Cannot convert a Symbol value to a string")
     } else {
         Some(value_to_string(value))
     }

--- a/crates/perry-runtime/src/object/class_registry/construct.rs
+++ b/crates/perry-runtime/src/object/class_registry/construct.rs
@@ -883,14 +883,27 @@ pub unsafe extern "C" fn js_new_function_construct(
             let dp = JSValue::from_bits(dyn_proto.to_bits());
             if dp.is_pointer() {
                 let raw = dp.as_pointer::<u8>() as usize;
-                let is_array = raw >= crate::gc::GC_HEADER_SIZE + 0x1000 && {
-                    let hdr = unsafe {
-                        &*((raw - crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader)
-                    };
-                    hdr.obj_type == crate::gc::GC_TYPE_ARRAY
-                        || hdr.obj_type == crate::gc::GC_TYPE_LAZY_ARRAY
-                };
-                if is_array {
+                // Function objects (closures) are identified by CLOSURE_MAGIC,
+                // not a GC type tag — check them first.
+                let is_fn = crate::closure::is_closure_ptr(raw);
+                let has_user_proto = is_fn
+                    || (raw >= crate::gc::GC_HEADER_SIZE + 0x1000 && {
+                        let hdr = unsafe {
+                            &*((raw - crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader)
+                        };
+                        // Arrays: test262 filter/15.4.4.20-6-*, some/15.4.4.17-8-*.
+                        // Objects: Intl/Temporal constructors install .prototype via
+                        // closure_set_dynamic_prop (bypassing js_set_function_prototype),
+                        // so CLASS_PROTOTYPE_OBJECTS has no entry; ensure_function_prototype_object
+                        // would otherwise create a fresh empty proto and overwrite .prototype.
+                        matches!(
+                            hdr.obj_type,
+                            crate::gc::GC_TYPE_ARRAY
+                                | crate::gc::GC_TYPE_LAZY_ARRAY
+                                | crate::gc::GC_TYPE_OBJECT
+                        )
+                    });
+                if has_user_proto {
                     super::super::prototype_chain::object_set_static_prototype(
                         obj_ptr as usize,
                         dyn_proto.to_bits(),

--- a/crates/perry-runtime/src/object/to_string_tag.rs
+++ b/crates/perry-runtime/src/object/to_string_tag.rs
@@ -55,7 +55,11 @@ unsafe fn object_to_string_tag_property(value: f64) -> Option<String> {
         return None;
     }
     let sym_f64 = f64::from_bits(0x7FFD_0000_0000_0000 | (sym as u64 & 0x0000_FFFF_FFFF_FFFF));
-    let tag_value = crate::symbol::own_symbol_property(value, sym_f64)?;
+    // Spec §20.1.3.6 step 6: Get(O, @@toStringTag) — own property first, then
+    // the explicit prototype chain (set via Object.setPrototypeOf or the
+    // runtime's object_set_static_prototype).
+    let tag_value = crate::symbol::own_symbol_property(value, sym_f64)
+        .or_else(|| crate::symbol::inherited_symbol_property(value, sym_f64))?;
     string_value_to_owned(tag_value)
 }
 

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -51,7 +51,7 @@ pub use properties::{
 
 // Symbol-keyed property reads.
 pub use get::js_object_get_symbol_property;
-pub(crate) use get::own_symbol_property;
+pub(crate) use get::{inherited_symbol_property, own_symbol_property};
 
 // Iterator protocol, getOwnPropertySymbols, ToPrimitive.
 pub use iterator::{

--- a/crates/perry-runtime/src/symbol/get.rs
+++ b/crates/perry-runtime/src/symbol/get.rs
@@ -136,10 +136,20 @@ unsafe fn object_header_ptr_from_value_bits(bits: u64) -> Option<usize> {
     }
 }
 
+/// Walk the explicit static prototype chain to find an inherited symbol property.
+/// Used by `Object.prototype.toString` to implement the spec's
+/// `Get(O, @@toStringTag)` prototype-chain walk.
+pub(crate) unsafe fn inherited_symbol_property(obj_f64: f64, sym_f64: f64) -> Option<f64> {
+    resolve_explicit_object_prototype_symbol(obj_f64, sym_f64)
+}
+
 unsafe fn resolve_explicit_object_prototype_symbol(obj_f64: f64, sym_f64: f64) -> Option<f64> {
     const TAG_NULL: u64 = 0x7FFC_0000_0000_0002;
     let mut owner = object_header_ptr_from_value_bits(obj_f64.to_bits())?;
-    for _ in 0..8 {
+    let mut visited_buf = [0usize; 16];
+    let mut visited_len = 0usize;
+    let mut visited_overflow: Option<std::collections::HashSet<usize>> = None;
+    loop {
         let proto_bits = crate::object::prototype_chain::object_static_prototype(owner)?;
         if proto_bits == TAG_NULL {
             return None;
@@ -149,8 +159,21 @@ unsafe fn resolve_explicit_object_prototype_symbol(obj_f64: f64, sym_f64: f64) -
             return Some(v);
         }
         let proto_ptr = object_header_ptr_from_value_bits(proto_bits)?;
-        if proto_ptr == owner {
+        // Cycle detection.
+        let cycle = if visited_len < visited_buf.len() {
+            visited_buf[..visited_len].contains(&proto_ptr)
+        } else {
+            let set = visited_overflow.get_or_insert_with(|| visited_buf.iter().copied().collect());
+            !set.insert(proto_ptr)
+        };
+        if cycle {
             return None;
+        }
+        if visited_len < visited_buf.len() {
+            visited_buf[visited_len] = owner;
+            visited_len += 1;
+        } else if let Some(set) = &mut visited_overflow {
+            set.insert(owner);
         }
         let proto_obj = proto_ptr as *const crate::object::ObjectHeader;
         let cid = crate::object::js_object_get_class_id(proto_obj);
@@ -161,7 +184,6 @@ unsafe fn resolve_explicit_object_prototype_symbol(obj_f64: f64, sym_f64: f64) -
         }
         owner = proto_ptr;
     }
-    None
 }
 
 unsafe fn web_stream_symbol_property(obj_f64: f64, sym_f64: f64) -> Option<f64> {


### PR DESCRIPTION
## Summary

Fixes three categories of test262 `intl402/NumberFormat` failures:

1. **Symbol → TypeError in `GetOption`** (`get_option_string`): Per ECMA-262 `ToStringOrSymbol`, a Symbol value must throw `TypeError`, not coerce to a string or produce a `RangeError`. Added an early-exit branch in `get_option_string` before the `value_to_string` fallback.

2. **`IsWellFormedUnitIdentifier` uses ECMA-402 sanctioned list**: The previous implementation accepted any hyphenated lowercase string (structural check). The spec (§12.1.3 Table 2) requires membership in a specific 47-entry list of SI/customary units, or a `"X-per-Y"` compound of two sanctioned entries (e.g. `"mile-per-hour"`). Non-sanctioned strings like `"foobar"` must throw `RangeError`.

3. **Intl instance `[[Prototype]]` linking fixed**: `js_new_function_construct` only treated *array*-typed `closure.prototype` values as "user-assigned" (setting `linked_user_proto = true`). Object-typed prototypes — including those installed by Intl/Temporal constructors via `closure_set_dynamic_prop` — fell through to `ensure_function_prototype_object`, which created a fresh empty proto and **overwrote** `ctor.prototype`. This caused `Object.getPrototypeOf(new Intl.NumberFormat())` to return the wrong object and `Object.prototype.toString` to give `[object Object]`. Fix: extend `has_user_proto` to `GC_TYPE_OBJECT` so pre-installed prototypes are preserved.

   Also extend `object_to_string_tag_property` (used by `Object.prototype.toString`) to walk the explicit static prototype chain via `inherited_symbol_property`, so `Symbol.toStringTag` is found on the prototype rather than only on the instance itself.

## Root cause of fix 3

`install_constructor` uses `closure_set_dynamic_prop(ctor, "prototype", proto)` directly — bypassing `js_set_function_prototype` which registers in `CLASS_PROTOTYPE_OBJECTS`. On first `new Intl.NumberFormat()`, `ensure_function_prototype_object` finds no cache entry for the constructor's synthetic class id, allocates a fresh `{}`, and writes it back as `ctor.prototype`. Everything subsequently sees the empty proto. The fix makes the "already has an object prototype" path skip `ensure_function_prototype_object` entirely.

## Test plan

- `Object.prototype.toString.call(new Intl.NumberFormat())` → `[object Intl.NumberFormat]` ✓
- `Object.prototype.toString.call(new Intl.Collator())` → `[object Intl.Collator]` ✓
- `Object.prototype.toString.call(new Intl.DateTimeFormat())` → `[object Intl.DateTimeFormat]` ✓
- `new Intl.NumberFormat('en', { style: 'unit', unit: 'foobar' })` → `RangeError` ✓
- `new Intl.NumberFormat('en', { style: 'unit', unit: 'acre' })` → succeeds ✓
- `new Intl.NumberFormat('en', { style: 'unit', unit: 'mile-per-hour' })` → succeeds ✓
- `new Intl.NumberFormat('en', { style: Symbol() })` → `TypeError` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved indirect `eval` completion in global-script mode with safer top-level-only folding, correct strict/sloppy handling, and proper scoping isolation.
  * `Intl` options now throw a `TypeError` for `Symbol` values and validate `unit` against ECMA-402 sanctioned formats.
  * Refined function construction prototype handling, and updated `@@toStringTag` resolution to use the spec’s own-then-inherited order.
  * Enhanced `@@toStringTag` symbol lookup with explicit prototype-chain traversal and cycle detection.
* **Tests**
  * Added regression coverage for issue `#5579`: global-script indirect `eval` completion, identity, strictness/sloppiness, and nested scoping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->