### PR TITLE
fix(runtime/hir/intl): #5800 — fix 29 Temporal/Intl regressions from #5789/#5793/#5783

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/url_date_instance.rs
+++ b/crates/perry-hir/src/lower/expr_call/url_date_instance.rs
@@ -313,16 +313,12 @@ pub(super) fn try_url_date_weakref_instance(
                         return Ok(Ok(Expr::DateToLocaleTimeString(Box::new(date_expr))));
                     }
                     "toLocaleString" => {
-                        // When args (locale / options) are present and the
-                        // receiver is not statically a Date, skip the
-                        // DateToLocaleString fold so the arguments are
-                        // preserved on the generic method-call path.  Temporal
-                        // types need this: their dispatch layer already accepts
-                        // locale and options arguments correctly, but the fold
-                        // was silently dropping them (see #5580).  Zero-arg
-                        // calls and statically-Date receivers still use the
-                        // fast path to preserve existing Date behaviour.
-                        if args.is_empty() || recv_class == Some("Date") {
+                        // Only fold zero-arg calls to the fast DateToLocaleString
+                        // path.  Calls with locale/options must fall through so
+                        // arguments are preserved — both Temporal types and Date
+                        // itself now handle locale/options on the generic path
+                        // (Date via the `date_to_locale_string_opts` thunk, #5800).
+                        if args.is_empty() {
                             let date_expr = lower_expr(ctx, &member.obj)?;
                             return Ok(Ok(Expr::DateToLocaleString(Box::new(date_expr))));
                         }

--- a/crates/perry-runtime/src/intl/date_collator.rs
+++ b/crates/perry-runtime/src/intl/date_collator.rs
@@ -656,28 +656,18 @@ pub(crate) fn temporal_locale_string(
                 second_opt.as_deref(),
             )
         } else {
-            // No options given — apply ECMA-402 defaults for this Temporal
-            // type.  The spec says `toLocaleString(locales, options)` is
-            // equivalent to `new Intl.DateTimeFormat(locales, options).format(this)`.
-            // With `options = undefined`, DTF always resolves to
-            // `{ year: "numeric", month: "numeric", day: "numeric" }`.
-            // Each Temporal type maps its fields to an epoch-ms value for
-            // formatting; the date components of that value are what the DTF
-            // defaults select.  Type-specific component overrides (e.g.
-            // time for PlainTime) only apply when the user explicitly passes
-            // options — not as defaults.
-            //
-            // ZonedDateTime is the sole exception: its toLocaleString spec
-            // mandates that the output includes both date and time components
-            // when no options are given (analogous to how ZDT carries a
-            // timezone that no ordinary DTF object can represent).
+            // No options given — apply per-type ECMA-402 / Temporal-spec
+            // defaults.  `ToDateTimeOptions(options, required, defaults)` sets
+            // the default fields differently per type:
+            //   PlainDate         → required="date",  defaults="date"
+            //   PlainDateTime     → required="any",   defaults="any"   (date+time)
+            //   PlainTime         → required="time",  defaults="time"
+            //   PlainYearMonth    → required="year month", defaults="year month"
+            //   PlainMonthDay     → required="month day",  defaults="month day"
+            //   Instant           → required="any",   defaults="all"   (date+time)
+            //   ZonedDateTime     → required="any",   defaults="all"   (date+time)
             match ctx {
-                TemporalLocaleCtx::PlainDate
-                | TemporalLocaleCtx::PlainDateTime
-                | TemporalLocaleCtx::Instant
-                | TemporalLocaleCtx::PlainTime
-                | TemporalLocaleCtx::PlainYearMonth
-                | TemporalLocaleCtx::PlainMonthDay => (
+                TemporalLocaleCtx::PlainDate => (
                     None,
                     None,
                     Some("numeric"),
@@ -687,7 +677,9 @@ pub(crate) fn temporal_locale_string(
                     None,
                     None,
                 ),
-                TemporalLocaleCtx::ZonedDateTime => (
+                TemporalLocaleCtx::PlainDateTime
+                | TemporalLocaleCtx::Instant
+                | TemporalLocaleCtx::ZonedDateTime => (
                     None,
                     None,
                     Some("numeric"),
@@ -696,6 +688,36 @@ pub(crate) fn temporal_locale_string(
                     Some("numeric"),
                     Some("2-digit"),
                     Some("2-digit"),
+                ),
+                TemporalLocaleCtx::PlainTime => (
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some("numeric"),
+                    Some("2-digit"),
+                    Some("2-digit"),
+                ),
+                TemporalLocaleCtx::PlainYearMonth => (
+                    None,
+                    None,
+                    Some("numeric"),
+                    Some("numeric"),
+                    None,
+                    None,
+                    None,
+                    None,
+                ),
+                TemporalLocaleCtx::PlainMonthDay => (
+                    None,
+                    None,
+                    None,
+                    Some("numeric"),
+                    Some("numeric"),
+                    None,
+                    None,
+                    None,
                 ),
             }
         };

--- a/crates/perry-runtime/src/intl/number_format_options.rs
+++ b/crates/perry-runtime/src/intl/number_format_options.rs
@@ -65,6 +65,12 @@ pub(crate) fn configure_number_format(obj: *mut ObjectHeader, locale: &str, opti
         }
         set_internal_field(obj, KEY_CURRENCY, string_value(&code.to_ascii_uppercase()));
     }
+    // Throw TypeError for missing currency BEFORE reading currencyDisplay /
+    // currencySign — so proxy-get traps on those keys are never triggered when
+    // currency is missing, matching the spec-observable option-read order.
+    if style == "currency" && currency.is_none() {
+        throw_type_error("Currency code is required with currency style.");
+    }
     let currency_display = get_string_option_enum(
         options,
         "currencyDisplay",
@@ -83,14 +89,6 @@ pub(crate) fn configure_number_format(obj: *mut ObjectHeader, locale: &str, opti
         string_value(&currency_display),
     );
     set_internal_field(obj, KEY_NF_CURRENCY_SIGN, string_value(&currency_sign));
-
-    // Spec step: if style=="currency" and no currency was given, throw TypeError
-    // NOW — before reading unit.  This preserves the spec-mandated observable
-    // order: a { style:"currency", unit:"<any>" } call with no currency must
-    // throw TypeError, not a RangeError from unit identifier validation.
-    if style == "currency" && currency.is_none() {
-        throw_type_error("Currency code is required with currency style.");
-    }
 
     let unit = get_option_string(options, "unit");
     if let Some(u) = &unit {

--- a/crates/perry-runtime/src/intl/number_format_options.rs
+++ b/crates/perry-runtime/src/intl/number_format_options.rs
@@ -84,6 +84,14 @@ pub(crate) fn configure_number_format(obj: *mut ObjectHeader, locale: &str, opti
     );
     set_internal_field(obj, KEY_NF_CURRENCY_SIGN, string_value(&currency_sign));
 
+    // Spec step: if style=="currency" and no currency was given, throw TypeError
+    // NOW — before reading unit.  This preserves the spec-mandated observable
+    // order: a { style:"currency", unit:"<any>" } call with no currency must
+    // throw TypeError, not a RangeError from unit identifier validation.
+    if style == "currency" && currency.is_none() {
+        throw_type_error("Currency code is required with currency style.");
+    }
+
     let unit = get_option_string(options, "unit");
     if let Some(u) = &unit {
         if !is_well_formed_unit_identifier(u) {
@@ -101,9 +109,6 @@ pub(crate) fn configure_number_format(obj: *mut ObjectHeader, locale: &str, opti
     );
     set_internal_field(obj, KEY_NF_UNIT_DISPLAY, string_value(&unit_display));
 
-    if style == "currency" && currency.is_none() {
-        throw_type_error("Currency code is required with currency style.");
-    }
     if style == "unit" && unit.is_none() {
         throw_type_error("unit is required with unit style.");
     }

--- a/crates/perry-runtime/src/object/date_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/date_proto_thunks.rs
@@ -378,6 +378,36 @@ date_setter_thunk!(date_set_utc_minutes, 1, 4);
 date_setter_thunk!(date_set_utc_seconds, 1, 5);
 date_setter_thunk!(date_set_utc_milliseconds, 1, 6);
 
+/// `Date.prototype.toLocaleString(locales?, options?)` thunk.
+///
+/// The HIR instance fast path only fires for zero-arg calls (falling through to
+/// `Expr::DateToLocaleString` → `js_date_to_locale_string`).  Non-zero-arg
+/// calls come through the generic method-call path and land here.  Brand-check
+/// `this`, then delegate to `temporal_locale_string` with `PlainDateTime`
+/// defaults ({year, month, day, hour, minute, second}) and no type-specific
+/// restrictions — `Date` accepts `timeZone`, `timeStyle`, `dateStyle`, etc.
+extern "C" fn date_to_locale_string_opts(
+    _closure: *const crate::closure::ClosureHeader,
+    rest: f64,
+) -> f64 {
+    let this = require_date_this();
+    let epoch_ms = crate::date::date_cell_timestamp(this);
+    if epoch_ms.is_nan() {
+        let s = crate::date::js_date_to_locale_string(this);
+        return crate::value::js_nanbox_string(s as i64);
+    }
+    let args = super::global_this::global_this_rest_array_values(rest);
+    let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+    let locale = args.get(0).copied().unwrap_or(undef);
+    let opts = args.get(1).copied().unwrap_or(undef);
+    crate::intl::temporal_locale_string(
+        epoch_ms,
+        locale,
+        opts,
+        crate::intl::TemporalLocaleCtx::PlainDateTime,
+    )
+}
+
 /// Install the brand-checked `Date.prototype` setter thunks. Called from
 /// `global_this::populate_builtin_prototype_methods`'s `"Date"` arm AFTER the
 /// no-op block, so these overwrite the no-op setter entries. Each is installed
@@ -415,4 +445,21 @@ pub(crate) fn install_date_proto_setters(proto_obj: *mut ObjectHeader) {
         // one thunk shape covers the 0..=4-arg setters uniformly.
         super::global_this::install_proto_method_rest_with_length(proto_obj, name, ptr, length, 0);
     }
+}
+
+/// Overwrite the no-op `Date.prototype.toLocaleString` with a real
+/// brand-checking thunk that forwards locale/options to the Intl formatter.
+/// Called from `global_this::populate_builtin_prototype_methods`'s `"Date"` arm
+/// after `install_noop_proto_methods`.
+pub(crate) fn install_date_proto_to_locale_string(proto_obj: *mut ObjectHeader) {
+    if proto_obj.is_null() {
+        return;
+    }
+    super::global_this::install_proto_method_rest_with_length(
+        proto_obj,
+        "toLocaleString",
+        date_to_locale_string_opts as *const u8,
+        0,
+        0,
+    );
 }

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -66,7 +66,13 @@ pub(crate) const TEMPORAL_SUBCLASS_CELL_FIELD: &[u8] = b"__perry_temporal_cell__
 /// longer a live Temporal cell.
 #[cfg(feature = "temporal")]
 pub(crate) unsafe fn temporal_subclass_cell(obj: usize) -> Option<f64> {
-    if obj < crate::gc::GC_HEADER_SIZE + 0x1000 || !is_valid_obj_ptr(obj as *const u8) {
+    // Reject any address that isn't a plausible heap pointer.  Proxy ids live
+    // in [0xF0000, 0x100000) — they pass a naïve `>= GC_HEADER_SIZE + 0x1000`
+    // check but are NOT heap pointers.  On Linux (HEAP_MIN = 0x1000) the old
+    // `is_valid_obj_ptr` guard passed them too, causing a SIGSEGV when the
+    // GC header was read at (proxy_id − 8).  `is_plausible_heap_addr` rejects
+    // the entire handle band [0, 0x100000) unconditionally.
+    if !crate::value::addr_class::is_plausible_heap_addr(obj) {
         return None;
     }
     let gc_header = (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;

--- a/crates/perry-runtime/src/object/global_this/proto_methods.rs
+++ b/crates/perry-runtime/src/object/global_this/proto_methods.rs
@@ -538,6 +538,9 @@ pub(crate) fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: 
             // brand-checks `this`, reads `[[DateValue]]` before coercing args,
             // then mutates the cell. Also after the OBJECT_PROTO_METHODS block.
             date_proto_thunks::install_date_proto_setters(proto_obj);
+            // Overwrite the no-op toLocaleString with a real Intl-aware thunk
+            // that forwards locale/options to temporal_locale_string.
+            date_proto_thunks::install_date_proto_to_locale_string(proto_obj);
             install_proto_method(
                 proto_obj,
                 "isPrototypeOf",


### PR DESCRIPTION
## Summary

Fixes the 29 newly-failing test262 cases introduced by the overnight batch (#5789, #5793, #5783), grouped into three clusters.

**Cluster A — 12 tests** (`Temporal/**/from/order-of-operations.js`)

`temporal_subclass_cell` in `field_get_set.rs` used `is_valid_obj_ptr` to guard against non-heap pointers. On Linux (HEAP_MIN=0x1000) revocable Proxy ids in `[0xF0000, 0x100000)` pass that guard, and reading the GC header at `proxy_id − 8` segfaulted. Fixed by switching to `is_plausible_heap_addr`, which unconditionally rejects the entire handle band `[0, 0x100000)`.

**Cluster B — 16 tests** (Temporal `toLocaleString` regressions)

Two sub-issues introduced by #5789:

1. **Wrong per-type defaults**: #5789 unified all non-ZDT Temporal types to `{year, month, day}` defaults. Restored ECMA-402 spec defaults: `PlainDate→{y,m,d}`, `PlainDateTime/Instant/ZDT→{y,m,d,h,min,sec}`, `PlainTime→{h,min,sec}`, `PlainYearMonth→{y,m}`, `PlainMonthDay→{m,d}`.

2. **Date args-dropping divergence**: Tests comparing `Date.toLocaleString(locale, opts)` with a Temporal type now diverge because #5789 fixed Temporal args-dropping but left `Date` on the HIR fold path (dropping args). Added a real `Date.prototype.toLocaleString` thunk (`date_to_locale_string_opts`) that delegates to `temporal_locale_string` with `PlainDateTime` defaults. Removed `recv_class == Some("Date")` from the HIR fold so Date calls with args use the thunk.

**Cluster C — 1 test** (`intl402/NumberFormat/constructor-order.js`)

`NumberFormat({style:"currency", unit:"test"})` threw `RangeError` (from the stricter `is_well_formed_unit_identifier` added in #5783 rejecting `"test"`) before the `TypeError` for the missing `currency` field. Moved the currency `TypeError` check ahead of the unit reads to restore spec-mandated observable order.

## Test plan

- [x] `cargo test --release -p perry-runtime -p perry-hir -p perry-codegen -p perry-transform` — all pass
- [ ] CI: `lint`, `cargo-test`, `api-docs-drift`, `security-audit` green

Closes #5800

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved `Date.prototype.toLocaleString()` behavior so calls with locale and options no longer take an incorrect fast-path and instead preserve provided arguments.
  * Enhanced default date/time component selection for Temporal-style `toLocaleString` formatting when no options are supplied.

* **Bug Fixes**
  * Fixed currency formatting error reporting by validating missing currency earlier for currency style.
  * Improved internal receiver validation to prevent unsafe handling of invalid heap addresses in Temporal-related lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->