### PR TITLE
fix(runtime): truly-async consumption of live Node Readable streams

### DIFF
--- a/crates/perry-runtime/src/node_stream/async_iterator.rs
+++ b/crates/perry-runtime/src/node_stream/async_iterator.rs
@@ -154,26 +154,73 @@ fn iterator_dequeue(iterator: f64) -> Option<f64> {
     Some(crate::array::js_array_shift_f64(arr))
 }
 
-/// Take (and clear) the pending-slot promise, if a `next()` is currently
-/// awaiting. A pending slot is only ever set while the queue is empty, so a
-/// present slot implies nothing is queued.
-fn iterator_take_pending(iterator: f64) -> Option<*mut crate::promise::Promise> {
-    let value = get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_PENDING_KEY))?;
+// Pending pulls are held in a FIFO queue (an iterator-local array of boxed
+// promise pointers), NOT a single slot: concurrent `next()` calls made while
+// the chunk queue is empty each get their own promise, settled in call order
+// as `data`/`end`/`error`/`return` arrive. A single slot would overwrite the
+// first promise (leaving it pending forever) on the second `next()`.
+//
+// Invariant: a pending pull is only ever enqueued while the chunk queue is
+// empty (see `ns_readable_iterator_next`), so a non-empty pending queue implies
+// nothing is buffered, and vice versa.
+
+/// Append a pending pull to the back of the FIFO queue.
+fn iterator_push_pending(iterator: f64, promise: *mut crate::promise::Promise) {
+    let existing = get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_PENDING_KEY))
+        .filter(|v| is_array_like_value(*v))
+        .unwrap_or_else(|| box_pointer(crate::array::js_array_alloc(0) as *const u8));
+    let arr = raw_ptr_from_value(existing) as *mut crate::array::ArrayHeader;
+    let arr = crate::array::js_array_push_f64(arr, box_pointer(promise as *const u8));
     set_hidden_value(
         iterator,
         hidden_key(READABLE_ITERATOR_PENDING_KEY),
-        f64::from_bits(TAG_UNDEFINED),
+        box_pointer(arr as *const u8),
     );
-    let p = crate::value::js_nanbox_get_pointer(value) as *mut crate::promise::Promise;
+}
+
+/// Take the oldest pending pull off the front of the FIFO queue, or `None`
+/// when no `next()` is currently awaiting.
+fn iterator_shift_pending(iterator: f64) -> Option<*mut crate::promise::Promise> {
+    let value = get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_PENDING_KEY))?;
+    if !is_array_like_value(value) {
+        return None;
+    }
+    let arr = raw_ptr_from_value(value) as *mut crate::array::ArrayHeader;
+    if crate::array::js_array_length(arr) == 0 {
+        return None;
+    }
+    let boxed = crate::array::js_array_shift_f64(arr);
+    let p = crate::value::js_nanbox_get_pointer(boxed) as *mut crate::promise::Promise;
     (!p.is_null()).then_some(p)
 }
 
-fn iterator_set_pending(iterator: f64, promise: *mut crate::promise::Promise) {
-    set_hidden_value(
-        iterator,
-        hidden_key(READABLE_ITERATOR_PENDING_KEY),
-        box_pointer(promise as *const u8),
-    );
+/// Whether any `next()` is currently awaiting a chunk.
+fn iterator_has_pending(iterator: f64) -> bool {
+    get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_PENDING_KEY))
+        .filter(|v| is_array_like_value(*v))
+        .is_some_and(|v| {
+            let arr = raw_ptr_from_value(v) as *mut crate::array::ArrayHeader;
+            crate::array::js_array_length(arr) != 0
+        })
+}
+
+/// Resolve every outstanding pending pull with `{done:true}` (used on `end` and
+/// `return()`), so a queued `next()` is never left unresolved.
+fn iterator_resolve_all_pending_done(iterator: f64) {
+    while let Some(p) = iterator_shift_pending(iterator) {
+        crate::promise::js_promise_resolve(p, iterator_result(f64::from_bits(TAG_UNDEFINED), true));
+    }
+}
+
+/// On `error`, reject the oldest outstanding pull with the error, then resolve
+/// the rest with `{done:true}` — mirrors an async generator, whose in-flight
+/// pull observes the throw while later-queued pulls see the now-finished
+/// iterator. Every pull is settled; none is dropped.
+fn iterator_reject_all_pending(iterator: f64, reason: f64) {
+    if let Some(first) = iterator_shift_pending(iterator) {
+        crate::promise::js_promise_reject(first, reason);
+    }
+    iterator_resolve_all_pending_done(iterator);
 }
 
 fn iterator_stream_ended(iterator: f64) -> bool {
@@ -211,9 +258,21 @@ extern "C" fn ns_readable_iter_on_data(closure: *const ClosureHeader, chunk: f64
     if iterator_is_done(iterator) {
         return f64::from_bits(TAG_UNDEFINED);
     }
-    if let Some(pending) = iterator_take_pending(iterator) {
+    if let Some(pending) = iterator_shift_pending(iterator) {
         note_yield(iterator);
-        crate::promise::js_promise_resolve(pending, iterator_result(chunk, false));
+        // Resolve the waiting `next()` with the same awaited-chunk handling the
+        // queued path (`readable_iterator_chunk_result`) uses, so a
+        // promise-valued chunk settles to its value instead of leaking as
+        // `{ value: Promise, done:false }`. `js_promise_resolve` does not
+        // assimilate thenables, so a promise chunk is adopted via
+        // `js_promise_resolve_with_promise`.
+        if crate::promise::js_value_is_promise(chunk) == 0 {
+            crate::promise::js_promise_resolve(pending, iterator_result(chunk, false));
+        } else {
+            let result = readable_iterator_chunk_result(chunk);
+            let inner = crate::value::js_nanbox_get_pointer(result) as *mut crate::promise::Promise;
+            crate::promise::js_promise_resolve_with_promise(pending, inner);
+        }
     } else {
         iterator_enqueue(iterator, chunk);
     }
@@ -231,13 +290,14 @@ extern "C" fn ns_readable_iter_on_end(closure: *const ClosureHeader) -> f64 {
     if iterator_is_done(iterator) {
         return f64::from_bits(TAG_UNDEFINED);
     }
-    if let Some(pending) = iterator_take_pending(iterator) {
+    // Outstanding pulls imply an empty chunk queue (invariant): finish the
+    // iterator and resolve every waiter with `{done:true}`. With no waiters,
+    // buffered chunks are still delivered by later `next()` calls, which then
+    // observe the ended flag.
+    if iterator_has_pending(iterator) {
         iterator_mark_done(iterator);
         iterator_remove_listeners(iterator);
-        crate::promise::js_promise_resolve(
-            pending,
-            iterator_result(f64::from_bits(TAG_UNDEFINED), true),
-        );
+        iterator_resolve_all_pending_done(iterator);
     }
     f64::from_bits(TAG_UNDEFINED)
 }
@@ -253,10 +313,10 @@ extern "C" fn ns_readable_iter_on_error(closure: *const ClosureHeader, reason: f
         return f64::from_bits(TAG_UNDEFINED);
     }
     iterator_set_error(iterator, reason);
-    if let Some(pending) = iterator_take_pending(iterator) {
+    if iterator_has_pending(iterator) {
         iterator_mark_done(iterator);
         iterator_remove_listeners(iterator);
-        crate::promise::js_promise_reject(pending, reason);
+        iterator_reject_all_pending(iterator, reason);
     }
     f64::from_bits(TAG_UNDEFINED)
 }
@@ -419,9 +479,10 @@ extern "C" fn ns_readable_iterator_next(closure: *const ClosureHeader) -> f64 {
     }
 
     // Nothing available yet: hand back a pending promise that the next
-    // `data`/`end`/`error` event resolves.
+    // `data`/`end`/`error` event settles. Concurrent `next()` calls each enqueue
+    // their own promise (FIFO) — none is overwritten or dropped.
     let promise = crate::promise::js_promise_new();
-    iterator_set_pending(iterator, promise);
+    iterator_push_pending(iterator, promise);
     box_pointer(promise as *const u8)
 }
 
@@ -429,9 +490,10 @@ extern "C" fn ns_readable_iterator_return(closure: *const ClosureHeader) -> f64 
     let iterator = this_value(closure);
     let already_done = iterator_is_done(iterator);
     iterator_mark_done(iterator);
-    // Drop a never-resolved pending pull and detach from the stream.
-    let _ = iterator_take_pending(iterator);
     iterator_remove_listeners(iterator);
+    // Settle every outstanding pull with `{done:true}` — `return()` must never
+    // drop a pending pull without resolving it.
+    iterator_resolve_all_pending_done(iterator);
     if !already_done && iterator_has_yielded(iterator) && iterator_destroys_on_return(iterator) {
         if let Some(stream) = get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_STREAM_KEY)) {
             call_source_iterator_return(stream);
@@ -509,4 +571,101 @@ pub(super) fn register_arities() {
     crate::closure::js_register_closure_arity(ns_readable_iter_on_data as *const u8, 1);
     crate::closure::js_register_closure_arity(ns_readable_iter_on_end as *const u8, 0);
     crate::closure::js_register_closure_arity(ns_readable_iter_on_error as *const u8, 1);
+}
+
+#[cfg(test)]
+mod fifo_pending_tests {
+    use super::*;
+
+    fn new_iterator() -> f64 {
+        // A dummy stream value is fine: these tests drive the pending-queue
+        // helpers/handler directly and never flow the stream.
+        build_readable_async_iterator(f64::from_bits(TAG_UNDEFINED), true)
+    }
+
+    fn result_field(promise: *mut crate::promise::Promise, field: &[u8]) -> f64 {
+        let boxed = unsafe { (*promise).value };
+        let obj = crate::value::js_nanbox_get_pointer(boxed) as *const crate::object::ObjectHeader;
+        crate::object::js_object_get_field_by_name_f64(obj, hidden_key(field))
+    }
+
+    #[test]
+    fn pending_pulls_settle_in_fifo_order_on_data() {
+        let iterator = new_iterator();
+        let p1 = crate::promise::js_promise_new();
+        let p2 = crate::promise::js_promise_new();
+        // Two `next()` pulls made while the queue is empty: both must be
+        // retained. Pre-fix the single slot dropped p1 on the second push,
+        // leaving its promise pending forever.
+        iterator_push_pending(iterator, p1);
+        iterator_push_pending(iterator, p2);
+
+        let data_cb = js_closure_alloc(ns_readable_iter_on_data as *const u8, 1);
+        js_closure_set_capture_f64(data_cb, 0, iterator);
+
+        // Two data events resolve p1 then p2 in FIFO order.
+        ns_readable_iter_on_data(data_cb, 1.0);
+        ns_readable_iter_on_data(data_cb, 2.0);
+
+        assert_eq!(
+            unsafe { (*p1).state },
+            crate::promise::PromiseState::Fulfilled
+        );
+        assert_eq!(
+            unsafe { (*p2).state },
+            crate::promise::PromiseState::Fulfilled
+        );
+        assert_eq!(result_field(p1, b"value"), 1.0);
+        assert_eq!(result_field(p2, b"value"), 2.0);
+        // Queue fully drained.
+        assert!(iterator_shift_pending(iterator).is_none());
+    }
+
+    #[test]
+    fn return_settles_every_outstanding_pull_done() {
+        let iterator = new_iterator();
+        let p1 = crate::promise::js_promise_new();
+        let p2 = crate::promise::js_promise_new();
+        iterator_push_pending(iterator, p1);
+        iterator_push_pending(iterator, p2);
+
+        // `return()`/`end` must resolve BOTH waiters with {done:true}, never
+        // drop one unsettled.
+        iterator_resolve_all_pending_done(iterator);
+
+        assert_eq!(
+            unsafe { (*p1).state },
+            crate::promise::PromiseState::Fulfilled
+        );
+        assert_eq!(
+            unsafe { (*p2).state },
+            crate::promise::PromiseState::Fulfilled
+        );
+        assert!(crate::value::js_is_truthy(result_field(p1, b"done")) != 0);
+        assert!(crate::value::js_is_truthy(result_field(p2, b"done")) != 0);
+        assert!(iterator_shift_pending(iterator).is_none());
+    }
+
+    #[test]
+    fn error_rejects_oldest_pull_and_finishes_rest() {
+        let iterator = new_iterator();
+        let p1 = crate::promise::js_promise_new();
+        let p2 = crate::promise::js_promise_new();
+        iterator_push_pending(iterator, p1);
+        iterator_push_pending(iterator, p2);
+
+        // Oldest pull observes the error; later pulls see the finished iterator.
+        iterator_reject_all_pending(iterator, 7.0);
+
+        assert_eq!(
+            unsafe { (*p1).state },
+            crate::promise::PromiseState::Rejected
+        );
+        assert_eq!(unsafe { (*p1).reason }, 7.0);
+        assert_eq!(
+            unsafe { (*p2).state },
+            crate::promise::PromiseState::Fulfilled
+        );
+        assert!(crate::value::js_is_truthy(result_field(p2, b"done")) != 0);
+    }
 }

--- a/crates/perry-runtime/src/node_stream/async_iterator.rs
+++ b/crates/perry-runtime/src/node_stream/async_iterator.rs
@@ -5,8 +5,20 @@ const READABLE_ITERATOR_STREAM_KEY: &[u8] = b"__perryReadableIteratorStream";
 const READABLE_ITERATOR_INDEX_KEY: &[u8] = b"__perryReadableIteratorIndex";
 const READABLE_ITERATOR_DONE_KEY: &[u8] = b"__perryReadableIteratorDone";
 const READABLE_ITERATOR_DESTROY_ON_RETURN_KEY: &[u8] = b"__perryReadableIteratorDestroyOnReturn";
-const READABLE_ITERATOR_STREAM_INDEX_KEY: &[u8] = b"__perryReadableIteratorStreamIndex";
-const READABLE_ITERATOR_CHUNKS_KEY: &[u8] = b"__perryReadableIteratorChunks";
+// True-async iterator state (replaces the old block-draining snapshot model).
+// The iterator attaches PERSISTENT `data`/`end`/`error` listeners on the stream
+// and buffers delivered chunks into this iterator-local queue; `next()` pulls
+// from the queue or returns a pending promise resolved by the next event. This
+// suspends on the event loop instead of synchronously spinning macrotasks, so
+// it neither re-enters unrelated work nor prematurely ends a live stream.
+const READABLE_ITERATOR_QUEUE_KEY: &[u8] = b"__perryReadableIteratorQueue";
+const READABLE_ITERATOR_PENDING_KEY: &[u8] = b"__perryReadableIteratorPending";
+const READABLE_ITERATOR_ENDED_KEY: &[u8] = b"__perryReadableIteratorEnded";
+const READABLE_ITERATOR_ERROR_KEY: &[u8] = b"__perryReadableIteratorError";
+const READABLE_ITERATOR_ATTACHED_KEY: &[u8] = b"__perryReadableIteratorAttached";
+const READABLE_ITERATOR_DATA_CB_KEY: &[u8] = b"__perryReadableIteratorDataCb";
+const READABLE_ITERATOR_END_CB_KEY: &[u8] = b"__perryReadableIteratorEndCb";
+const READABLE_ITERATOR_ERROR_CB_KEY: &[u8] = b"__perryReadableIteratorErrorCb";
 
 fn iterator_result(value: f64, done: bool) -> f64 {
     let obj = crate::object::js_object_alloc(0, 2);
@@ -45,6 +57,10 @@ extern "C" fn ns_readable_iterator_chunk_rejected(
     f64::from_bits(TAG_UNDEFINED)
 }
 
+/// Wrap a yielded chunk in a resolved `{value,done:false}` promise. A chunk that
+/// is itself a Promise (e.g. `Readable.from([Promise.resolve(x)])` whose element
+/// reached the queue unresolved) is awaited so the consumer sees the settled
+/// value — matching Node's async-iterator semantics.
 fn readable_iterator_chunk_result(value: f64) -> f64 {
     if crate::promise::js_value_is_promise(value) == 0 {
         return resolved_promise(iterator_result(value, false));
@@ -88,46 +104,249 @@ fn iterator_local_index(iterator: f64) -> u32 {
         .max(0.0) as u32
 }
 
-fn stream_consume_index(stream: f64) -> u32 {
-    get_hidden_value(stream, hidden_key(READABLE_ITERATOR_STREAM_INDEX_KEY))
-        .and_then(jsvalue_as_f64)
-        .unwrap_or(0.0)
-        .max(0.0) as u32
-}
-
-fn set_stream_consume_index(stream: f64, index: u32) {
+/// Record that a chunk has been handed to the consumer (drives
+/// `iterator_has_yielded`, which gates `return()`'s destroyOnReturn teardown).
+fn note_yield(iterator: f64) {
     set_hidden_value(
-        stream,
-        hidden_key(READABLE_ITERATOR_STREAM_INDEX_KEY),
-        index as f64,
+        iterator,
+        hidden_key(READABLE_ITERATOR_INDEX_KEY),
+        (iterator_local_index(iterator) + 1) as f64,
     );
 }
 
-fn iterator_snapshot_array(iterator: f64) -> *const crate::array::ArrayHeader {
-    let Some(chunks) = get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_CHUNKS_KEY)) else {
-        return std::ptr::null();
-    };
-    if !is_array_like_value(chunks) {
-        return std::ptr::null();
-    }
-    raw_ptr_from_value(chunks) as *const crate::array::ArrayHeader
+fn iterator_is_done(iterator: f64) -> bool {
+    get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_DONE_KEY))
+        .is_some_and(|v| crate::value::js_is_truthy(v) != 0)
 }
 
-fn readable_data_listener_snapshot(stream: f64) -> Option<f64> {
-    if stream_listener_count_for_event(stream, string_value(b"data")) == 0 {
+fn iterator_mark_done(iterator: f64) {
+    set_hidden_value(
+        iterator,
+        hidden_key(READABLE_ITERATOR_DONE_KEY),
+        f64::from_bits(TAG_TRUE),
+    );
+}
+
+// ── iterator-local queue / pending-slot / state accessors ──────────────────
+
+fn iterator_enqueue(iterator: f64, chunk: f64) {
+    let existing = get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_QUEUE_KEY))
+        .filter(|v| is_array_like_value(*v))
+        .unwrap_or_else(|| box_pointer(crate::array::js_array_alloc(0) as *const u8));
+    let arr = raw_ptr_from_value(existing) as *mut crate::array::ArrayHeader;
+    let arr = crate::array::js_array_push_f64(arr, chunk);
+    set_hidden_value(
+        iterator,
+        hidden_key(READABLE_ITERATOR_QUEUE_KEY),
+        box_pointer(arr as *const u8),
+    );
+}
+
+fn iterator_dequeue(iterator: f64) -> Option<f64> {
+    let value = get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_QUEUE_KEY))?;
+    if !is_array_like_value(value) {
         return None;
     }
-    let chunks = readable_hidden_chunks(stream)?;
-    let mut values = Vec::new();
-    push_chunk_values(chunks, &mut values, 0);
-    if values.is_empty() {
+    let arr = raw_ptr_from_value(value) as *mut crate::array::ArrayHeader;
+    if crate::array::js_array_length(arr) == 0 {
         return None;
     }
-    let mut arr = crate::array::js_array_alloc(0);
-    for value in values {
-        arr = crate::array::js_array_push_f64(arr, value);
+    Some(crate::array::js_array_shift_f64(arr))
+}
+
+/// Take (and clear) the pending-slot promise, if a `next()` is currently
+/// awaiting. A pending slot is only ever set while the queue is empty, so a
+/// present slot implies nothing is queued.
+fn iterator_take_pending(iterator: f64) -> Option<*mut crate::promise::Promise> {
+    let value = get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_PENDING_KEY))?;
+    set_hidden_value(
+        iterator,
+        hidden_key(READABLE_ITERATOR_PENDING_KEY),
+        f64::from_bits(TAG_UNDEFINED),
+    );
+    let p = crate::value::js_nanbox_get_pointer(value) as *mut crate::promise::Promise;
+    (!p.is_null()).then_some(p)
+}
+
+fn iterator_set_pending(iterator: f64, promise: *mut crate::promise::Promise) {
+    set_hidden_value(
+        iterator,
+        hidden_key(READABLE_ITERATOR_PENDING_KEY),
+        box_pointer(promise as *const u8),
+    );
+}
+
+fn iterator_stream_ended(iterator: f64) -> bool {
+    has_truthy_hidden(iterator, hidden_key(READABLE_ITERATOR_ENDED_KEY))
+}
+
+fn iterator_set_stream_ended(iterator: f64) {
+    set_hidden_value(
+        iterator,
+        hidden_key(READABLE_ITERATOR_ENDED_KEY),
+        f64::from_bits(TAG_TRUE),
+    );
+}
+
+fn iterator_stored_error(iterator: f64) -> Option<f64> {
+    get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_ERROR_KEY))
+}
+
+fn iterator_set_error(iterator: f64, err: f64) {
+    set_hidden_value(iterator, hidden_key(READABLE_ITERATOR_ERROR_KEY), err);
+}
+
+// ── persistent stream-event listeners feeding the iterator ─────────────────
+
+fn iterator_from_listener(closure: *const ClosureHeader) -> f64 {
+    js_closure_get_capture_f64(closure, 0)
+}
+
+/// `data` listener: resolve a waiting `next()` or buffer the chunk.
+extern "C" fn ns_readable_iter_on_data(closure: *const ClosureHeader, chunk: f64) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
     }
-    Some(box_pointer(arr as *const u8))
+    let iterator = iterator_from_listener(closure);
+    if iterator_is_done(iterator) {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    if let Some(pending) = iterator_take_pending(iterator) {
+        note_yield(iterator);
+        crate::promise::js_promise_resolve(pending, iterator_result(chunk, false));
+    } else {
+        iterator_enqueue(iterator, chunk);
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+/// `end` listener: a waiting `next()` resolves to `{done:true}`; otherwise the
+/// end is recorded so a later `next()` (after the queue drains) reports done.
+extern "C" fn ns_readable_iter_on_end(closure: *const ClosureHeader) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let iterator = iterator_from_listener(closure);
+    iterator_set_stream_ended(iterator);
+    if iterator_is_done(iterator) {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    if let Some(pending) = iterator_take_pending(iterator) {
+        iterator_mark_done(iterator);
+        iterator_remove_listeners(iterator);
+        crate::promise::js_promise_resolve(
+            pending,
+            iterator_result(f64::from_bits(TAG_UNDEFINED), true),
+        );
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+/// `error` listener: reject a waiting `next()` or store the error for the next
+/// pull.
+extern "C" fn ns_readable_iter_on_error(closure: *const ClosureHeader, reason: f64) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let iterator = iterator_from_listener(closure);
+    if iterator_is_done(iterator) {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    iterator_set_error(iterator, reason);
+    if let Some(pending) = iterator_take_pending(iterator) {
+        iterator_mark_done(iterator);
+        iterator_remove_listeners(iterator);
+        crate::promise::js_promise_reject(pending, reason);
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+fn attach_iterator_listener(
+    iterator: f64,
+    stream: f64,
+    event: &[u8],
+    func: *const u8,
+    store_key: &[u8],
+) {
+    let cb = js_closure_alloc(func, 1);
+    js_closure_set_capture_f64(cb, 0, iterator);
+    let cb_value = box_pointer(cb as *const u8);
+    set_hidden_value(iterator, hidden_key(store_key), cb_value);
+    add_stream_listener_for_event(stream, string_value(event), cb_value);
+}
+
+/// Attach the persistent `data`/`end`/`error` listeners on the first `next()`
+/// and start the stream flowing. Idempotent (guarded by the ATTACHED flag).
+/// Nothing is delivered synchronously here — `resume` only schedules the
+/// resume/drain microtasks, so this never re-enters the event loop.
+fn iterator_ensure_attached(iterator: f64, stream: f64) {
+    if has_truthy_hidden(iterator, hidden_key(READABLE_ITERATOR_ATTACHED_KEY)) {
+        return;
+    }
+    set_hidden_value(
+        iterator,
+        hidden_key(READABLE_ITERATOR_ATTACHED_KEY),
+        f64::from_bits(TAG_TRUE),
+    );
+
+    attach_iterator_listener(
+        iterator,
+        stream,
+        b"data",
+        ns_readable_iter_on_data as *const u8,
+        READABLE_ITERATOR_DATA_CB_KEY,
+    );
+    attach_iterator_listener(
+        iterator,
+        stream,
+        b"end",
+        ns_readable_iter_on_end as *const u8,
+        READABLE_ITERATOR_END_CB_KEY,
+    );
+    attach_iterator_listener(
+        iterator,
+        stream,
+        b"error",
+        ns_readable_iter_on_error as *const u8,
+        READABLE_ITERATOR_ERROR_CB_KEY,
+    );
+
+    mark_disturbed(stream);
+
+    // Already-terminal-before-attach: no future event will reach our listeners,
+    // so seed the terminal state directly.
+    if let Some(err) = readable_hidden_error(stream) {
+        iterator_set_error(iterator, err);
+        return;
+    }
+    if has_truthy_hidden(stream, hidden_end_emitted_key()) || stream_destroyed(stream) {
+        iterator_set_stream_ended(iterator);
+        return;
+    }
+
+    // Start flow: delivers any already-buffered chunks via `data` (on the
+    // resume/drain microtask) and schedules `end` if the source is finite.
+    resume_readable_stream(stream);
+}
+
+fn remove_iterator_listener(iterator: f64, stream: f64, event: &[u8], store_key: &[u8]) {
+    if let Some(cb_value) = get_hidden_value(iterator, hidden_key(store_key)) {
+        remove_stream_listener_for_event(stream, string_value(event), cb_value);
+        set_hidden_value(
+            iterator,
+            hidden_key(store_key),
+            f64::from_bits(TAG_UNDEFINED),
+        );
+    }
+}
+
+fn iterator_remove_listeners(iterator: f64) {
+    let Some(stream) = get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_STREAM_KEY)) else {
+        return;
+    };
+    remove_iterator_listener(iterator, stream, b"data", READABLE_ITERATOR_DATA_CB_KEY);
+    remove_iterator_listener(iterator, stream, b"end", READABLE_ITERATOR_END_CB_KEY);
+    remove_iterator_listener(iterator, stream, b"error", READABLE_ITERATOR_ERROR_CB_KEY);
 }
 
 fn settle_iterator_return_value(value: f64) {
@@ -167,100 +386,52 @@ fn call_source_iterator_return(stream: f64) {
 
 extern "C" fn ns_readable_iterator_next(closure: *const ClosureHeader) -> f64 {
     let iterator = this_value(closure);
-    if get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_DONE_KEY))
-        .is_some_and(|v| crate::value::js_is_truthy(v) != 0)
-    {
+    if iterator_is_done(iterator) {
         return readable_iterator_done();
     }
     let Some(stream) = get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_STREAM_KEY)) else {
         return readable_iterator_done();
     };
-    prepare_readable_for_iteration(stream);
 
-    let snapshot = iterator_snapshot_array(iterator);
-    if !snapshot.is_null() {
-        let index = iterator_local_index(iterator);
-        if index < crate::array::js_array_length(snapshot) {
-            let value = crate::array::js_array_get_f64(snapshot, index);
-            set_hidden_value(
-                iterator,
-                hidden_key(READABLE_ITERATOR_INDEX_KEY),
-                (index + 1) as f64,
-            );
-            mark_disturbed(stream);
-            return readable_iterator_chunk_result(value);
-        }
-        set_hidden_value(
-            iterator,
-            hidden_key(READABLE_ITERATOR_DONE_KEY),
-            f64::from_bits(TAG_TRUE),
-        );
-        return readable_iterator_done();
+    // First pull: attach persistent listeners + start flow. Listeners deliver
+    // asynchronously (resume schedules microtasks), so nothing arrives
+    // synchronously here — no event-loop re-entrancy.
+    iterator_ensure_attached(iterator, stream);
+
+    // A chunk is already buffered → resolve immediately.
+    if let Some(chunk) = iterator_dequeue(iterator) {
+        note_yield(iterator);
+        return readable_iterator_chunk_result(chunk);
     }
 
-    if !readable_object_mode(stream) {
-        let value = read_stream_available_default(stream);
-        if value.to_bits() != TAG_NULL {
-            set_hidden_value(
-                iterator,
-                hidden_key(READABLE_ITERATOR_INDEX_KEY),
-                (iterator_local_index(iterator) + 1) as f64,
-            );
-            return resolved_promise(iterator_result(value, false));
-        }
-    }
-
-    let arr = readable_chunks_array(stream);
-    let index = stream_consume_index(stream);
-    if !arr.is_null() && index < crate::array::js_array_length(arr) {
-        let value = crate::array::js_array_get_f64(arr, index);
-        set_stream_consume_index(stream, index + 1);
-        set_hidden_value(
-            iterator,
-            hidden_key(READABLE_ITERATOR_INDEX_KEY),
-            (iterator_local_index(iterator) + 1) as f64,
-        );
-        mark_disturbed(stream);
-        return readable_iterator_chunk_result(value);
-    }
-    if let Some(err) = readable_hidden_error(stream) {
-        set_hidden_value(
-            iterator,
-            hidden_key(READABLE_ITERATOR_DONE_KEY),
-            f64::from_bits(TAG_TRUE),
-        );
+    // A stored error surfaces (once) as a rejection, then the iterator is done.
+    if let Some(err) = iterator_stored_error(iterator) {
+        iterator_mark_done(iterator);
+        iterator_remove_listeners(iterator);
         return rejected_promise(err);
     }
-    if stream_destroyed(stream) {
-        set_hidden_value(
-            iterator,
-            hidden_key(READABLE_ITERATOR_DONE_KEY),
-            f64::from_bits(TAG_TRUE),
-        );
+
+    // The stream has ended and the queue is drained → done.
+    if iterator_stream_ended(iterator) {
+        iterator_mark_done(iterator);
+        iterator_remove_listeners(iterator);
         return readable_iterator_done();
     }
-    if arr.is_null() || index >= crate::array::js_array_length(arr) {
-        set_hidden_value(
-            iterator,
-            hidden_key(READABLE_ITERATOR_DONE_KEY),
-            f64::from_bits(TAG_TRUE),
-        );
-        mark_stream_ended(stream);
-        destroy_stream(stream, f64::from_bits(TAG_UNDEFINED));
-        return readable_iterator_done();
-    }
-    readable_iterator_done()
+
+    // Nothing available yet: hand back a pending promise that the next
+    // `data`/`end`/`error` event resolves.
+    let promise = crate::promise::js_promise_new();
+    iterator_set_pending(iterator, promise);
+    box_pointer(promise as *const u8)
 }
 
 extern "C" fn ns_readable_iterator_return(closure: *const ClosureHeader) -> f64 {
     let iterator = this_value(closure);
-    let already_done = get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_DONE_KEY))
-        .is_some_and(|v| crate::value::js_is_truthy(v) != 0);
-    set_hidden_value(
-        iterator,
-        hidden_key(READABLE_ITERATOR_DONE_KEY),
-        f64::from_bits(TAG_TRUE),
-    );
+    let already_done = iterator_is_done(iterator);
+    iterator_mark_done(iterator);
+    // Drop a never-resolved pending pull and detach from the stream.
+    let _ = iterator_take_pending(iterator);
+    iterator_remove_listeners(iterator);
     if !already_done && iterator_has_yielded(iterator) && iterator_destroys_on_return(iterator) {
         if let Some(stream) = get_hidden_value(iterator, hidden_key(READABLE_ITERATOR_STREAM_KEY)) {
             call_source_iterator_return(stream);
@@ -319,9 +490,6 @@ fn build_readable_async_iterator(stream: f64, destroy_on_return: bool) -> f64 {
             TAG_FALSE
         }),
     );
-    if let Some(chunks) = readable_data_listener_snapshot(stream) {
-        set_hidden_value(iterator, hidden_key(READABLE_ITERATOR_CHUNKS_KEY), chunks);
-    }
     install_async_iterator_symbol(iterator, ns_readable_iterator_self);
     iterator
 }
@@ -338,4 +506,7 @@ pub(super) fn register_arities() {
     crate::closure::js_register_closure_arity(ns_readable_iterator_self as *const u8, 0);
     crate::closure::js_register_closure_arity(ns_readable_iterator_chunk_fulfilled as *const u8, 1);
     crate::closure::js_register_closure_arity(ns_readable_iterator_chunk_rejected as *const u8, 1);
+    crate::closure::js_register_closure_arity(ns_readable_iter_on_data as *const u8, 1);
+    crate::closure::js_register_closure_arity(ns_readable_iter_on_end as *const u8, 0);
+    crate::closure::js_register_closure_arity(ns_readable_iter_on_error as *const u8, 1);
 }

--- a/crates/perry-runtime/src/node_stream_dispatch.rs
+++ b/crates/perry-runtime/src/node_stream_dispatch.rs
@@ -241,6 +241,7 @@ pub(super) fn register_stub_arities() {
     register(ns_iter_flat_map as *const u8, 2);
     register(ns_iter_take as *const u8, 1);
     register(ns_iter_drop as *const u8, 1);
+    register_consume_arities();
     async_iterator::register_arities();
 }
 

--- a/crates/perry-runtime/src/node_stream_iter_helpers.rs
+++ b/crates/perry-runtime/src/node_stream_iter_helpers.rs
@@ -340,19 +340,26 @@ pub(super) fn extend_with_array(
 
 pub(super) extern "C" fn ns_iter_to_array(closure: *const ClosureHeader, opts: f64) -> f64 {
     let this = this_value(closure);
-    prepare_readable_for_iteration(this);
-    let arr = readable_chunks_array(this);
-    let mut out = crate::array::js_array_alloc(0);
-    if !arr.is_null() {
-        out = extend_with_array(out, arr);
+    // An already-errored stream rejects immediately (matches the error-first
+    // check `settle_consuming` used).
+    if let Some(err) = readable_hidden_error(this) {
+        return rejected_promise(err);
     }
-    let result = settle_consuming(this, opts, box_pointer(out as *const u8));
-    if readable_hidden_error(this).is_none() {
-        mark_stream_ended(this);
-        clear_readable_buffer(this);
-        destroy_stream(this, f64::from_bits(TAG_UNDEFINED));
+    // An already-aborted signal rejects before consuming anything.
+    if let Some(sig) = effective_signal(this, opts) {
+        if signal_is_aborted(sig) {
+            return rejected_promise(abort_error());
+        }
     }
-    result
+    // Consume the stream TRULY ASYNCHRONOUSLY through its `[Symbol.asyncIterator]`
+    // (the same pending-promise iterator `for await` uses): `js_array_from_async`
+    // drives `.next()` via a then-chain that accumulates each chunk and resolves
+    // when the stream ends. This replaces the previous snapshot + block-drain
+    // path, which spun the event loop synchronously — re-entering unrelated
+    // macrotasks (the React #327 hazard) and returning an empty array for a
+    // live (socket/`setImmediate`-fed) source whose data had not buffered yet.
+    let undefined = f64::from_bits(TAG_UNDEFINED);
+    crate::promise::js_array_from_async(this, undefined, undefined)
 }
 
 pub(super) extern "C" fn ns_iter_map(closure: *const ClosureHeader, mapper: f64, opts: f64) -> f64 {
@@ -418,48 +425,278 @@ pub(super) extern "C" fn ns_iter_filter(
     result
 }
 
+// ─────────────────────────────────────────────────────────────────
+// Truly-async consuming helpers (forEach / reduce / find / some /
+// every). Like `toArray`, these drive the stream's
+// `[Symbol.asyncIterator]().next()` via a then-chain — suspending on a
+// pending promise and awaiting each (possibly-async) callback through
+// `.then`, instead of block-draining the event loop with
+// `settle_result`/`prepare_readable_for_iteration`. Block-draining ran
+// unrelated macrotasks (timers/setImmediate — the React #327 re-entrancy
+// hazard) and returned wrong results for live sources whose data hadn't
+// buffered yet. A synchronous source (`Readable.from([...])`) still works:
+// its iterator yields the buffered chunks through resolved promises.
+// ─────────────────────────────────────────────────────────────────
+
+const CONSUME_OP_FOR_EACH: f64 = 0.0;
+const CONSUME_OP_REDUCE: f64 = 1.0;
+const CONSUME_OP_FIND: f64 = 2.0;
+const CONSUME_OP_SOME: f64 = 3.0;
+const CONSUME_OP_EVERY: f64 = 4.0;
+
+// Capture-slot layout for the `consume_on_next` state closure.
+const SC_RESULT: u32 = 0; // result promise (ptr)
+const SC_ITER: u32 = 1; // async iterator (f64)
+const SC_CB: u32 = 2; // user callback (f64)
+const SC_OP: u32 = 3; // operation code (f64)
+const SC_ACC: u32 = 4; // accumulator / found / boolean result (f64)
+const SC_REJECT: u32 = 5; // reject closure (ptr)
+const SC_ON_CB: u32 = 6; // on-callback-result closure (ptr)
+const SC_CUR: u32 = 7; // current element (f64) — find returns it
+const SC_HAS_ACC: u32 = 8; // reduce: an accumulator exists yet (f64 bool)
+
+#[inline]
+fn bool_bits(b: bool) -> f64 {
+    f64::from_bits(if b { TAG_TRUE } else { TAG_FALSE })
+}
+
+#[inline]
+fn consume_op_default(op: f64) -> f64 {
+    if op == CONSUME_OP_SOME {
+        f64::from_bits(TAG_FALSE)
+    } else if op == CONSUME_OP_EVERY {
+        f64::from_bits(TAG_TRUE)
+    } else {
+        f64::from_bits(TAG_UNDEFINED) // forEach / find / reduce
+    }
+}
+
+/// Read `{ value, done }` off an iterator-result object. A non-object
+/// (malformed / undefined) result is treated as `done`.
+fn consume_read_iter_result(iter_result: f64) -> (bool, f64) {
+    let Some(obj) = object_ptr_from_value(iter_result) else {
+        return (true, f64::from_bits(TAG_UNDEFINED));
+    };
+    let done = js_object_get_field_by_name_f64(obj as *const ObjectHeader, hidden_key(b"done"));
+    let value = js_object_get_field_by_name_f64(obj as *const ObjectHeader, hidden_key(b"value"));
+    (crate::value::js_is_truthy(done) != 0, value)
+}
+
+/// Pull the next element: `iterator.next()` → `.then(on_next, reject)`.
+/// Always routed through a promise so each step runs on a microtask (no
+/// synchronous recursion, no block-drain).
+fn consume_drive_next(iter: f64, on_next: *const ClosureHeader, reject: *const ClosureHeader) {
+    let next_result = unsafe {
+        crate::object::js_native_call_method(
+            iter,
+            b"next".as_ptr() as *const i8,
+            4,
+            std::ptr::null(),
+            0,
+        )
+    };
+    let promise = if crate::promise::js_value_is_promise(next_result) != 0 {
+        crate::value::js_nanbox_get_pointer(next_result) as *mut crate::promise::Promise
+    } else {
+        crate::promise::js_promise_resolved(next_result)
+    };
+    crate::promise::js_promise_then(promise, on_next, reject);
+}
+
+fn consume_resolve(state: *const ClosureHeader, value: f64) {
+    let result = js_closure_get_capture_ptr(state, SC_RESULT) as *mut crate::promise::Promise;
+    if !result.is_null() {
+        crate::promise::js_promise_resolve(result, value);
+    }
+}
+
+fn consume_finalize(state: *const ClosureHeader) {
+    let op = js_closure_get_capture_f64(state, SC_OP);
+    let result = js_closure_get_capture_ptr(state, SC_RESULT) as *mut crate::promise::Promise;
+    if op == CONSUME_OP_REDUCE
+        && crate::value::js_is_truthy(js_closure_get_capture_f64(state, SC_HAS_ACC)) == 0
+    {
+        // reduce over an empty stream with no initial value rejects.
+        if !result.is_null() {
+            crate::promise::js_promise_reject(result, reduce_missing_initial_error());
+        }
+        return;
+    }
+    consume_resolve(state, js_closure_get_capture_f64(state, SC_ACC));
+}
+
+/// `.then` fulfilment for `iterator.next()`: read the iter-result, then
+/// either finalize (done) or invoke the user callback and await its result.
+extern "C" fn consume_on_next(state: *const ClosureHeader, iter_result: f64) -> f64 {
+    if state.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let (done, value) = consume_read_iter_result(iter_result);
+    if done {
+        consume_finalize(state);
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    js_closure_set_capture_f64(state as *mut ClosureHeader, SC_CUR, value);
+
+    let iter = js_closure_get_capture_f64(state, SC_ITER);
+    let reject = js_closure_get_capture_ptr(state, SC_REJECT) as *const ClosureHeader;
+    let cb = callback_closure(js_closure_get_capture_f64(state, SC_CB));
+    if cb.is_null() {
+        // No callback: still consume to the end (matches the old skip-loop,
+        // which yielded the op default / accumulated nothing).
+        consume_drive_next(iter, state, reject);
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+
+    let op = js_closure_get_capture_f64(state, SC_OP);
+    let cb_result = if op == CONSUME_OP_REDUCE {
+        if crate::value::js_is_truthy(js_closure_get_capture_f64(state, SC_HAS_ACC)) == 0 {
+            // First element seeds the accumulator (no callback call).
+            js_closure_set_capture_f64(state as *mut ClosureHeader, SC_ACC, value);
+            js_closure_set_capture_f64(state as *mut ClosureHeader, SC_HAS_ACC, bool_bits(true));
+            consume_drive_next(iter, state, reject);
+            return f64::from_bits(TAG_UNDEFINED);
+        }
+        let acc = js_closure_get_capture_f64(state, SC_ACC);
+        catch_pipeline_throw(|| crate::closure::js_closure_call2(cb, acc, value))
+    } else {
+        catch_pipeline_throw(|| crate::closure::js_closure_call1(cb, value))
+    };
+
+    match cb_result {
+        Ok(result) => {
+            // Await the (possibly-promise) callback result, then continue.
+            let on_cb = js_closure_get_capture_ptr(state, SC_ON_CB) as *const ClosureHeader;
+            let p = crate::promise::js_promise_resolved(result);
+            crate::promise::js_promise_then(p, on_cb, reject);
+        }
+        Err(err) => {
+            let result =
+                js_closure_get_capture_ptr(state, SC_RESULT) as *mut crate::promise::Promise;
+            if !result.is_null() {
+                crate::promise::js_promise_reject(result, err);
+            }
+        }
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+/// `.then` fulfilment for the awaited callback result: update the
+/// accumulator / short-circuit, then pull the next element.
+extern "C" fn consume_on_cb(closure: *const ClosureHeader, cb_result: f64) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let state = js_closure_get_capture_ptr(closure, 0) as *const ClosureHeader;
+    if state.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let op = js_closure_get_capture_f64(state, SC_OP);
+    let truthy = crate::value::js_is_truthy(cb_result) != 0;
+    let short_circuit = if op == CONSUME_OP_REDUCE {
+        js_closure_set_capture_f64(state as *mut ClosureHeader, SC_ACC, cb_result);
+        None
+    } else if op == CONSUME_OP_FIND {
+        truthy.then(|| js_closure_get_capture_f64(state, SC_CUR))
+    } else if op == CONSUME_OP_SOME {
+        truthy.then(|| f64::from_bits(TAG_TRUE))
+    } else if op == CONSUME_OP_EVERY {
+        (!truthy).then(|| f64::from_bits(TAG_FALSE))
+    } else {
+        None // forEach ignores the result
+    };
+
+    if let Some(value) = short_circuit {
+        consume_resolve(state, value);
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+
+    let iter = js_closure_get_capture_f64(state, SC_ITER);
+    let reject = js_closure_get_capture_ptr(state, SC_REJECT) as *const ClosureHeader;
+    consume_drive_next(iter, state, reject);
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+extern "C" fn consume_reject(closure: *const ClosureHeader, reason: f64) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let result = js_closure_get_capture_ptr(closure, 0) as *mut crate::promise::Promise;
+    if !result.is_null() {
+        crate::promise::js_promise_reject(result, reason);
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+pub(super) fn register_consume_arities() {
+    crate::closure::js_register_closure_arity(consume_on_next as *const u8, 1);
+    crate::closure::js_register_closure_arity(consume_on_cb as *const u8, 1);
+    crate::closure::js_register_closure_arity(consume_reject as *const u8, 1);
+}
+
+/// Drive a consuming helper truly-asynchronously over the stream's async
+/// iterator. `initial`/`has_initial` apply to `reduce`.
+fn consume_stream(stream: f64, callback: f64, op: f64, initial: f64, opts: f64) -> f64 {
+    // Already-errored stream / already-aborted signal reject up front.
+    if let Some(err) = readable_hidden_error(stream) {
+        return rejected_promise(err);
+    }
+    if let Some(sig) = effective_signal(stream, opts) {
+        if signal_is_aborted(sig) {
+            return rejected_promise(abort_error());
+        }
+    }
+
+    let has_initial = op == CONSUME_OP_REDUCE && initial.to_bits() != TAG_UNDEFINED;
+    let acc = if op == CONSUME_OP_REDUCE {
+        initial
+    } else {
+        consume_op_default(op)
+    };
+
+    let Some(iter) = crate::array::call_symbol_async_iterator_for_flat_map(stream) else {
+        // Not async-iterable (shouldn't happen for a readable): empty result.
+        if op == CONSUME_OP_REDUCE && !has_initial {
+            return rejected_promise(reduce_missing_initial_error());
+        }
+        return resolved_promise(acc);
+    };
+
+    let result = crate::promise::js_promise_new();
+    let state = js_closure_alloc(consume_on_next as *const u8, 9);
+    let on_cb = js_closure_alloc(consume_on_cb as *const u8, 1);
+    let reject = js_closure_alloc(consume_reject as *const u8, 1);
+
+    js_closure_set_capture_ptr(reject, 0, result as i64);
+    js_closure_set_capture_ptr(on_cb, 0, state as i64);
+
+    js_closure_set_capture_ptr(state, SC_RESULT, result as i64);
+    js_closure_set_capture_f64(state, SC_ITER, iter);
+    js_closure_set_capture_f64(state, SC_CB, callback);
+    js_closure_set_capture_f64(state, SC_OP, op);
+    js_closure_set_capture_f64(state, SC_ACC, acc);
+    js_closure_set_capture_ptr(state, SC_REJECT, reject as i64);
+    js_closure_set_capture_ptr(state, SC_ON_CB, on_cb as i64);
+    js_closure_set_capture_f64(state, SC_CUR, f64::from_bits(TAG_UNDEFINED));
+    js_closure_set_capture_f64(state, SC_HAS_ACC, bool_bits(has_initial));
+
+    consume_drive_next(iter, state, reject);
+    box_pointer(result as *const u8)
+}
+
 pub(super) extern "C" fn ns_iter_reduce(
     closure: *const ClosureHeader,
     reducer: f64,
     initial: f64,
     opts: f64,
 ) -> f64 {
-    let this = this_value(closure);
-    prepare_readable_for_iteration(this);
-    let arr = readable_chunks_array(this);
-    let cb = callback_closure(reducer);
-    let len = if arr.is_null() {
-        0
-    } else {
-        crate::array::js_array_length(arr)
-    };
-    let has_initial = initial.to_bits() != TAG_UNDEFINED;
-    let (mut acc, start) = if has_initial {
-        (initial, 0)
-    } else if len > 0 {
-        (crate::array::js_array_get_f64(arr, 0), 1)
-    } else {
-        if readable_hidden_error(this).is_some() {
-            return settle_consuming(this, opts, f64::from_bits(TAG_UNDEFINED));
-        }
-        if let Some(sig) = effective_signal(this, opts) {
-            if signal_is_aborted(sig) {
-                return rejected_promise(abort_error());
-            }
-        }
-        return rejected_promise(reduce_missing_initial_error());
-    };
-    if readable_hidden_error(this).is_none() && !cb.is_null() {
-        for i in start..len {
-            let el = crate::array::js_array_get_f64(arr, i);
-            // Node's stream reducer is (accumulator, current) — no index.
-            match settle_result(crate::closure::js_closure_call2(cb, acc, el)) {
-                Ok(value) => acc = value,
-                Err(err) => return rejected_promise(err),
-            }
-        }
-    }
-    settle_consuming(this, opts, acc)
+    consume_stream(
+        this_value(closure),
+        reducer,
+        CONSUME_OP_REDUCE,
+        initial,
+        opts,
+    )
 }
 
 pub(super) extern "C" fn ns_iter_for_each(
@@ -467,20 +704,13 @@ pub(super) extern "C" fn ns_iter_for_each(
     action: f64,
     opts: f64,
 ) -> f64 {
-    let this = this_value(closure);
-    prepare_readable_for_iteration(this);
-    let arr = readable_chunks_array(this);
-    let cb = callback_closure(action);
-    if readable_hidden_error(this).is_none() && !arr.is_null() && !cb.is_null() {
-        let len = crate::array::js_array_length(arr);
-        for i in 0..len {
-            let el = crate::array::js_array_get_f64(arr, i);
-            if let Err(err) = call_settled_result(cb, el) {
-                return rejected_promise(err);
-            }
-        }
-    }
-    settle_consuming(this, opts, f64::from_bits(TAG_UNDEFINED))
+    consume_stream(
+        this_value(closure),
+        action,
+        CONSUME_OP_FOR_EACH,
+        f64::from_bits(TAG_UNDEFINED),
+        opts,
+    )
 }
 
 pub(super) extern "C" fn ns_iter_find(
@@ -488,26 +718,13 @@ pub(super) extern "C" fn ns_iter_find(
     predicate: f64,
     opts: f64,
 ) -> f64 {
-    let this = this_value(closure);
-    prepare_readable_for_iteration(this);
-    let arr = readable_chunks_array(this);
-    let cb = callback_closure(predicate);
-    let mut found = f64::from_bits(TAG_UNDEFINED);
-    if readable_hidden_error(this).is_none() && !arr.is_null() && !cb.is_null() {
-        let len = crate::array::js_array_length(arr);
-        for i in 0..len {
-            let el = crate::array::js_array_get_f64(arr, i);
-            match call_settled_result(cb, el) {
-                Ok(value) if crate::value::js_is_truthy(value) != 0 => {
-                    found = el;
-                    break;
-                }
-                Ok(_) => {}
-                Err(err) => return rejected_promise(err),
-            }
-        }
-    }
-    settle_consuming(this, opts, found)
+    consume_stream(
+        this_value(closure),
+        predicate,
+        CONSUME_OP_FIND,
+        f64::from_bits(TAG_UNDEFINED),
+        opts,
+    )
 }
 
 pub(super) extern "C" fn ns_iter_some(
@@ -515,26 +732,13 @@ pub(super) extern "C" fn ns_iter_some(
     predicate: f64,
     opts: f64,
 ) -> f64 {
-    let this = this_value(closure);
-    prepare_readable_for_iteration(this);
-    let arr = readable_chunks_array(this);
-    let cb = callback_closure(predicate);
-    let mut result = f64::from_bits(TAG_FALSE);
-    if readable_hidden_error(this).is_none() && !arr.is_null() && !cb.is_null() {
-        let len = crate::array::js_array_length(arr);
-        for i in 0..len {
-            let el = crate::array::js_array_get_f64(arr, i);
-            match call_settled_result(cb, el) {
-                Ok(value) if crate::value::js_is_truthy(value) != 0 => {
-                    result = f64::from_bits(TAG_TRUE);
-                    break;
-                }
-                Ok(_) => {}
-                Err(err) => return rejected_promise(err),
-            }
-        }
-    }
-    settle_consuming(this, opts, result)
+    consume_stream(
+        this_value(closure),
+        predicate,
+        CONSUME_OP_SOME,
+        f64::from_bits(TAG_UNDEFINED),
+        opts,
+    )
 }
 
 pub(super) extern "C" fn ns_iter_every(
@@ -542,26 +746,13 @@ pub(super) extern "C" fn ns_iter_every(
     predicate: f64,
     opts: f64,
 ) -> f64 {
-    let this = this_value(closure);
-    prepare_readable_for_iteration(this);
-    let arr = readable_chunks_array(this);
-    let cb = callback_closure(predicate);
-    let mut result = f64::from_bits(TAG_TRUE);
-    if readable_hidden_error(this).is_none() && !arr.is_null() && !cb.is_null() {
-        let len = crate::array::js_array_length(arr);
-        for i in 0..len {
-            let el = crate::array::js_array_get_f64(arr, i);
-            match call_settled_result(cb, el) {
-                Ok(value) if crate::value::js_is_truthy(value) == 0 => {
-                    result = f64::from_bits(TAG_FALSE);
-                    break;
-                }
-                Ok(_) => {}
-                Err(err) => return rejected_promise(err),
-            }
-        }
-    }
-    settle_consuming(this, opts, result)
+    consume_stream(
+        this_value(closure),
+        predicate,
+        CONSUME_OP_EVERY,
+        f64::from_bits(TAG_UNDEFINED),
+        opts,
+    )
 }
 
 pub(super) extern "C" fn ns_iter_flat_map(

--- a/crates/perry-runtime/src/node_stream_iter_helpers.rs
+++ b/crates/perry-runtime/src/node_stream_iter_helpers.rs
@@ -359,7 +359,47 @@ pub(super) extern "C" fn ns_iter_to_array(closure: *const ClosureHeader, opts: f
     // macrotasks (the React #327 hazard) and returning an empty array for a
     // live (socket/`setImmediate`-fed) source whose data had not buffered yet.
     let undefined = f64::from_bits(TAG_UNDEFINED);
-    crate::promise::js_array_from_async(this, undefined, undefined)
+    let result = crate::promise::js_array_from_async(this, undefined, undefined);
+    // Abort after consumption starts: a signal that fires later rejects the
+    // result and cancels the stream (terminating the internal `from_async`
+    // iterator), instead of leaving the promise pending forever.
+    register_to_array_abort(this, opts, result);
+    result
+}
+
+/// Wire a late-abort listener for `toArray`: on abort, reject `result` and
+/// destroy the stream so the internal `js_array_from_async` consumer stops.
+fn register_to_array_abort(stream: f64, opts: f64, result: f64) {
+    let Some(sig) = effective_signal(stream, opts) else {
+        return;
+    };
+    let Some(sig_obj) = object_ptr_from_value(sig) else {
+        return;
+    };
+    let abort_cl = js_closure_alloc(ns_to_array_abort as *const u8, 2);
+    js_closure_set_capture_ptr(abort_cl, 0, result.to_bits() as i64);
+    js_closure_set_capture_f64(abort_cl, 1, stream);
+    crate::url::js_abort_signal_add_listener(
+        sig_obj,
+        string_value(b"abort"),
+        box_pointer(abort_cl as *const u8),
+    );
+}
+
+/// Abort-listener body for `toArray`: cancel the live stream (terminating the
+/// internal `from_async` iterator that drives it) and reject the result with an
+/// AbortError. A no-op if the result already settled.
+pub(super) extern "C" fn ns_to_array_abort(closure: *const ClosureHeader) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let result = promise_from_capture(closure, 0);
+    let stream = js_closure_get_capture_f64(closure, 1);
+    destroy_stream(stream, abort_error());
+    if !result.is_null() {
+        crate::promise::js_promise_reject(result, abort_error());
+    }
+    f64::from_bits(TAG_UNDEFINED)
 }
 
 pub(super) extern "C" fn ns_iter_map(closure: *const ClosureHeader, mapper: f64, opts: f64) -> f64 {
@@ -503,23 +543,54 @@ fn consume_drive_next(iter: f64, on_next: *const ClosureHeader, reject: *const C
     crate::promise::js_promise_then(promise, on_next, reject);
 }
 
+/// Close the async iterator driving a consuming helper, releasing the
+/// persistent stream `data`/`end`/`error` listeners and any buffered queue. A
+/// no-op once the iterator is done. Every early settle path
+/// (`consume_resolve` / `consume_reject_state`) routes through this so a
+/// short-circuit, callback throw, rejection, or abort never leaks a live
+/// stream's listeners after the helper promise settles.
+fn consume_close_iter(state: *const ClosureHeader) {
+    if state.is_null() {
+        return;
+    }
+    let iter = js_closure_get_capture_f64(state, SC_ITER);
+    if object_ptr_from_value(iter).is_none() {
+        return;
+    }
+    let _ = unsafe {
+        crate::object::js_native_call_method(
+            iter,
+            b"return".as_ptr() as *const i8,
+            6,
+            std::ptr::null(),
+            0,
+        )
+    };
+}
+
 fn consume_resolve(state: *const ClosureHeader, value: f64) {
+    consume_close_iter(state);
     let result = js_closure_get_capture_ptr(state, SC_RESULT) as *mut crate::promise::Promise;
     if !result.is_null() {
         crate::promise::js_promise_resolve(result, value);
     }
 }
 
+fn consume_reject_state(state: *const ClosureHeader, reason: f64) {
+    consume_close_iter(state);
+    let result = js_closure_get_capture_ptr(state, SC_RESULT) as *mut crate::promise::Promise;
+    if !result.is_null() {
+        crate::promise::js_promise_reject(result, reason);
+    }
+}
+
 fn consume_finalize(state: *const ClosureHeader) {
     let op = js_closure_get_capture_f64(state, SC_OP);
-    let result = js_closure_get_capture_ptr(state, SC_RESULT) as *mut crate::promise::Promise;
     if op == CONSUME_OP_REDUCE
         && crate::value::js_is_truthy(js_closure_get_capture_f64(state, SC_HAS_ACC)) == 0
     {
         // reduce over an empty stream with no initial value rejects.
-        if !result.is_null() {
-            crate::promise::js_promise_reject(result, reduce_missing_initial_error());
-        }
+        consume_reject_state(state, reduce_missing_initial_error());
         return;
     }
     consume_resolve(state, js_closure_get_capture_f64(state, SC_ACC));
@@ -571,11 +642,9 @@ extern "C" fn consume_on_next(state: *const ClosureHeader, iter_result: f64) -> 
             crate::promise::js_promise_then(p, on_cb, reject);
         }
         Err(err) => {
-            let result =
-                js_closure_get_capture_ptr(state, SC_RESULT) as *mut crate::promise::Promise;
-            if !result.is_null() {
-                crate::promise::js_promise_reject(result, err);
-            }
+            // Callback threw: close the iterator before rejecting so the live
+            // stream's listeners are released.
+            consume_reject_state(state, err);
         }
     }
     f64::from_bits(TAG_UNDEFINED)
@@ -621,10 +690,13 @@ extern "C" fn consume_reject(closure: *const ClosureHeader, reason: f64) -> f64 
     if closure.is_null() {
         return f64::from_bits(TAG_UNDEFINED);
     }
-    let result = js_closure_get_capture_ptr(closure, 0) as *mut crate::promise::Promise;
-    if !result.is_null() {
-        crate::promise::js_promise_reject(result, reason);
+    // Capture slot 0 is the consume state (not the bare result promise) so the
+    // iterator is closed before the rejection settles.
+    let state = js_closure_get_capture_ptr(closure, 0) as *const ClosureHeader;
+    if state.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
     }
+    consume_reject_state(state, reason);
     f64::from_bits(TAG_UNDEFINED)
 }
 
@@ -632,6 +704,9 @@ pub(super) fn register_consume_arities() {
     crate::closure::js_register_closure_arity(consume_on_next as *const u8, 1);
     crate::closure::js_register_closure_arity(consume_on_cb as *const u8, 1);
     crate::closure::js_register_closure_arity(consume_reject as *const u8, 1);
+    // Abort listeners are dispatched via `js_closure_call0` (0 args).
+    crate::closure::js_register_closure_arity(ns_consume_abort as *const u8, 0);
+    crate::closure::js_register_closure_arity(ns_to_array_abort as *const u8, 0);
 }
 
 /// Drive a consuming helper truly-asynchronously over the stream's async
@@ -667,7 +742,7 @@ fn consume_stream(stream: f64, callback: f64, op: f64, initial: f64, opts: f64) 
     let on_cb = js_closure_alloc(consume_on_cb as *const u8, 1);
     let reject = js_closure_alloc(consume_reject as *const u8, 1);
 
-    js_closure_set_capture_ptr(reject, 0, result as i64);
+    js_closure_set_capture_ptr(reject, 0, state as i64);
     js_closure_set_capture_ptr(on_cb, 0, state as i64);
 
     js_closure_set_capture_ptr(state, SC_RESULT, result as i64);
@@ -680,8 +755,48 @@ fn consume_stream(stream: f64, callback: f64, op: f64, initial: f64, opts: f64) 
     js_closure_set_capture_f64(state, SC_CUR, f64::from_bits(TAG_UNDEFINED));
     js_closure_set_capture_f64(state, SC_HAS_ACC, bool_bits(has_initial));
 
+    // Abort after consumption starts: a per-call (or inherited) signal that
+    // fires mid-stream rejects the result and closes the iterator, instead of
+    // leaving the promise pending forever. An already-aborted signal was
+    // rejected up front (above), so the listener only handles later aborts.
+    register_consume_abort(stream, opts, state);
+
     consume_drive_next(iter, state, reject);
     box_pointer(result as *const u8)
+}
+
+/// Register an abort listener for a consuming helper: when the governing signal
+/// fires, close the iterator (releasing the stream listeners) and reject the
+/// result with an AbortError. No-op when there is no signal.
+fn register_consume_abort(stream: f64, opts: f64, state: *const ClosureHeader) {
+    let Some(sig) = effective_signal(stream, opts) else {
+        return;
+    };
+    let Some(sig_obj) = object_ptr_from_value(sig) else {
+        return;
+    };
+    let abort_cl = js_closure_alloc(ns_consume_abort as *const u8, 1);
+    js_closure_set_capture_ptr(abort_cl, 0, state as i64);
+    crate::url::js_abort_signal_add_listener(
+        sig_obj,
+        string_value(b"abort"),
+        box_pointer(abort_cl as *const u8),
+    );
+}
+
+/// Abort-listener body for a consuming helper (`forEach`/`reduce`/`find`/
+/// `some`/`every`): close the iterator and reject the result with an
+/// AbortError. A no-op if the result already settled.
+pub(super) extern "C" fn ns_consume_abort(closure: *const ClosureHeader) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let state = js_closure_get_capture_ptr(closure, 0) as *const ClosureHeader;
+    if state.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    consume_reject_state(state, abort_error());
+    f64::from_bits(TAG_UNDEFINED)
 }
 
 pub(super) extern "C" fn ns_iter_reduce(


### PR DESCRIPTION
## Problem

Consuming a live Node `Readable` stream returned an empty/partial result or hung. This affected:

- `for await (const chunk of readable)`
- `Readable.prototype.toArray()`
- the async consume helpers `forEach` / `reduce` / `find` / `some` / `every`

The root cause: the async iterator block-drained the stream's buffered macrotask queue (a sync-over-async drain) instead of truly suspending the consumer. That approach returned an empty array / wrong result for a live source (socket- or `setImmediate`-fed) whose data had not buffered yet at the moment of the call, and it spun the event loop synchronously, re-entering unrelated macrotasks (timers / `setImmediate`).

Node's model is different: the consumer suspends on a pending promise that is resolved on the next `'data'` / `'end'` / `'error'` event via persistent listeners plus an iterator-local queue.

## Fix

- **`ns_readable_iterator_next` is now genuinely async.** On the first `next()` it attaches persistent `data` / `end` / `error` listeners and starts the stream flowing (resume only schedules microtasks, so nothing is delivered synchronously and there is no event-loop re-entrancy). Each `next()` either returns a buffered chunk from a per-iterator queue, surfaces a stored error/EOS, or hands back a pending promise that the next event resolves. No premature end-of-stream and no block-drain.
- **`toArray` is routed through `js_array_from_async`** — the same pending-promise iterator that `for await` uses — with up-front error / aborted-signal short-circuits.
- **The consume helpers (`forEach` / `reduce` / `find` / `some` / `every`) are now truly async.** They drive the stream's `[Symbol.asyncIterator]().next()` through a `.then` chain, awaiting each (possibly-async) callback result instead of block-draining, with `register_consume_arities` wiring the new closures. `reduce` over an empty stream with no initial value rejects, and an already-errored stream / already-aborted signal reject up front, matching Node.
- Lazy `map` / `filter` / `flatMap` keep their existing settle path.

A synchronous source (`Readable.from([...])`) still works: its iterator yields the buffered chunks through resolved promises.

## Validation

- `cargo build --release -p perry-runtime` succeeds.
- `cargo test -p perry-runtime` — all green (1105 passed single-threaded; node_stream / async-iterator tests pass).
- `cargo fmt` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stream iteration and consumption now work in a fully asynchronous, event-driven way.
  * `reduce`, `forEach`, `find`, `some`, and `every` now handle async callbacks more reliably.

* **Bug Fixes**
  * Improved handling of stream end, errors, and cancellation during iteration.
  * `toArray()` now respects already-aborted signals and existing stream errors immediately.
  * Buffered stream data is now delivered more consistently during async reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->