### PR TITLE
feat(ui): expose appSetActivationPolicy to TS + window-less launch for menu-bar apps

### DIFF
--- a/crates/perry-api-manifest/src/entries/part_4.rs
+++ b/crates/perry-api-manifest/src/entries/part_4.rs
@@ -427,6 +427,7 @@ pub(crate) const API_MANIFEST_PART_4: &[ApiEntry] = &[
     method("perry/ui", "appSetTimer", false, None),
     method("perry/ui", "appSetMinSize", false, None),
     method("perry/ui", "appSetMaxSize", false, None),
+    method("perry/ui", "appSetActivationPolicy", false, None),
     method("perry/ui", "embedNSView", false, None),
     method("perry/ui", "sheetCreate", false, None),
     method("perry/ui", "sheetPresent", false, None),

--- a/crates/perry-codegen-wasm/src/emit/ui_method_map.rs
+++ b/crates/perry-codegen-wasm/src/emit/ui_method_map.rs
@@ -245,6 +245,7 @@ pub(super) fn map_ui_method(method: &str, class_name: Option<&str>) -> &'static 
         "appOnActivate" => "perry_ui_app_on_activate",
         "appOnTerminate" => "perry_ui_app_on_terminate",
         "appSetTimer" => "perry_ui_app_set_timer",
+        "appSetActivationPolicy" => "perry_ui_app_set_activation_policy",
         // Table
         "tableSetColumnHeader" => "perry_ui_table_set_column_header",
         "tableSetColumnWidth" => "perry_ui_table_set_column_width",

--- a/crates/perry-codegen/src/lower_call/ui_tables.rs
+++ b/crates/perry-codegen/src/lower_call/ui_tables.rs
@@ -373,6 +373,14 @@ pub fn lower_perry_ui_table_call(
             .chain(args.iter().cloned())
             .collect();
         &synthesised_args[..]
+    } else if sig.method == "appSetActivationPolicy" && args.len() == 1 && sig.args.len() == 2 {
+        // User-facing `appSetActivationPolicy(policy)` → 2-arg ABI
+        // `(app_handle, policy)`; synthesise the ignored 0 app-handle,
+        // mirroring the `appSetTimer` adapter above.
+        synthesised_args = std::iter::once(Expr::Integer(0))
+            .chain(args.iter().cloned())
+            .collect();
+        &synthesised_args[..]
     } else if sig.method == "drawImage" && sig.args.len() == 9 {
         // Canvas.drawImage mirrors HTML Canvas' three overloads, but the
         // native FFI surface uses one fixed ABI:

--- a/crates/perry-dispatch/src/ui_table/part_b.rs
+++ b/crates/perry-dispatch/src/ui_table/part_b.rs
@@ -768,6 +768,19 @@ pub(crate) const PERRY_UI_TABLE_PART_B: &[MethodRow] = &[
         args: &[ArgKind::Widget, ArgKind::F64, ArgKind::F64],
         ret: ReturnKind::Void,
     },
+    // Menu-bar / background apps: set the macOS activation policy
+    // ("regular" | "accessory" | "background"). Like `appSetTimer` the
+    // native ABI is `(app_handle, value)`, but the user-facing form is the
+    // 1-arg `appSetActivationPolicy(policy)`; `lower_perry_ui_table_call`
+    // prepends a synthetic 0 app-handle. On macOS "accessory" also
+    // suppresses the auto-presented launch window (menu-bar-only apps open
+    // windows on demand). FFI helpers ignore `_app_handle` on every backend.
+    MethodRow {
+        method: "appSetActivationPolicy",
+        runtime: "perry_ui_app_set_activation_policy",
+        args: &[ArgKind::Widget, ArgKind::Str],
+        ret: ReturnKind::Void,
+    },
     // ---- (#391: removed the 1-arg `scrollviewSetOffset(scrollView, y)`
     // legacy alias here — the 2-arg `(x, y)` form is now declared
     // alongside `scrollviewGetOffset` / `scrollviewScrollTo` above and

--- a/crates/perry-ui-gtk4/src/app.rs
+++ b/crates/perry-ui-gtk4/src/app.rs
@@ -21,6 +21,10 @@ pub(crate) fn ensure_gtk_init() {
 
 thread_local! {
     static APPS: RefCell<Vec<AppEntry>> = RefCell::new(Vec::new());
+    /// Activation policy set (via `appSetActivationPolicy`) before `App()`
+    /// builds the AppEntry. Handle-agnostic, mirroring the macOS backend, so
+    /// the synthetic 0 app-handle from the 1-arg TS form still works.
+    static PENDING_ACTIVATION_POLICY: RefCell<Option<String>> = const { RefCell::new(None) };
     /// Buffered keyboard shortcuts registered before the app is running.
     static PENDING_SHORTCUTS: RefCell<Vec<PendingShortcut>> = RefCell::new(Vec::new());
     /// Callback map for keyboard shortcuts.
@@ -118,7 +122,7 @@ pub fn app_create(title_ptr: *const u8, width: f64, height: f64) -> i64 {
             level: None,
             transparent: false,
             vibrancy: None,
-            activation_policy: None,
+            activation_policy: PENDING_ACTIVATION_POLICY.with(|p| p.borrow().clone()),
             window_state: None,
         });
         apps.len() as i64 // 1-based handle
@@ -243,13 +247,15 @@ pub fn app_run(_app_handle: i64) {
                     );
                 }
 
-                // Apply activation policy (skip taskbar for accessory/background).
-                // GTK4 doesn't have skip_taskbar_hint; best-effort via deletable=false
-                // which some compositors interpret as a utility window.
-                if let Some(ref policy) = entry.activation_policy {
-                    if policy == "accessory" || policy == "background" {
-                        window.set_deletable(false);
-                    }
+                // Accessory/background apps skip the taskbar. GTK4 has no
+                // skip_taskbar_hint; best-effort via deletable=false, which
+                // some compositors interpret as a utility window.
+                let suppress_window = matches!(
+                    entry.activation_policy.as_deref(),
+                    Some("accessory") | Some("background")
+                );
+                if suppress_window {
+                    window.set_deletable(false);
                 }
 
                 if let Some(root_handle) = entry.root_handle {
@@ -295,7 +301,12 @@ pub fn app_run(_app_handle: i64) {
                     }
                 }
 
-                window.present();
+                // Accessory/background apps stay window-less at launch (the
+                // tray / status notifier owns presentation); open windows on
+                // demand instead. Mirrors the macOS backend.
+                if !suppress_window {
+                    window.present();
+                }
             }
         });
 
@@ -549,6 +560,10 @@ pub fn app_set_activation_policy(app_handle: i64, value_ptr: *const u8) {
     if policy_str.is_empty() {
         return;
     }
+    // Stash handle-agnostically (mirrors macOS): `App()` reads this when it
+    // builds the AppEntry. Also set it on an existing entry if one is already
+    // registered, so a post-create call still takes effect.
+    PENDING_ACTIVATION_POLICY.with(|p| *p.borrow_mut() = Some(policy_str.to_string()));
     APPS.with(|a| {
         let mut apps = a.borrow_mut();
         let idx = (app_handle - 1) as usize;

--- a/crates/perry-ui-macos/src/app.rs
+++ b/crates/perry-ui-macos/src/app.rs
@@ -415,6 +415,12 @@ pub fn app_run(_app_handle: i64) {
     };
     app.setActivationPolicy(activation_policy);
 
+    // Menu-bar / background apps (accessory / background activation policy)
+    // don't auto-present their main window at launch — they're driven by a
+    // status-item / tray and open windows on demand. Regular apps keep the
+    // existing behaviour of showing the window immediately.
+    let suppress_window = matches!(policy.as_deref(), Some("accessory") | Some("background"));
+
     // Apply pending dock icon
     PENDING_ICON_PATH.with(|p| {
         if let Some(path) = p.borrow().as_ref() {
@@ -481,6 +487,12 @@ pub fn app_run(_app_handle: i64) {
                         }
                     }
                 }
+            }
+
+            // Accessory/background apps stay window-less at launch (the tray
+            // owns presentation). Skip ordering the window front.
+            if suppress_window {
+                continue;
             }
 
             entry.window.makeKeyAndOrderFront(None);

--- a/crates/perry-ui-windows/src/app.rs
+++ b/crates/perry-ui-windows/src/app.rs
@@ -100,6 +100,10 @@ pub(crate) struct AppEntry {
     /// Issue #1280 — initial window state requested by App({ windowState }).
     /// Applied at app_run time; None / "normal" => SW_SHOW.
     window_state: Option<WindowState>,
+    /// Activation policy ("regular" | "accessory" | "background"). For
+    /// accessory/background apps the launch window is suppressed (the tray
+    /// owns presentation), mirroring the macOS/GTK4 backends.
+    activation_policy: Option<String>,
 }
 
 /// Issue #1280 — initial window state for the main app window.
@@ -130,6 +134,10 @@ struct TimerEntry {
 
 thread_local! {
     pub(crate) static APPS: RefCell<Vec<AppEntry>> = RefCell::new(Vec::new());
+    /// Activation policy set (via `appSetActivationPolicy`) before `App()`
+    /// builds the AppEntry. Handle-agnostic, mirroring the macOS backend, so
+    /// the synthetic 0 app-handle from the 1-arg TS form still works.
+    static PENDING_ACTIVATION_POLICY: RefCell<Option<String>> = const { RefCell::new(None) };
     static PENDING_SHORTCUTS: RefCell<Vec<PendingShortcut>> = RefCell::new(Vec::new());
     static SHORTCUTS: RefCell<Vec<ShortcutEntry>> = RefCell::new(Vec::new());
     static TIMERS: RefCell<Vec<TimerEntry>> = RefCell::new(Vec::new());
@@ -240,6 +248,7 @@ pub fn app_create(title_ptr: *const u8, width: f64, height: f64) -> i64 {
                     min_size: None,
                     max_size: None,
                     window_state: None,
+                    activation_policy: PENDING_ACTIVATION_POLICY.with(|p| p.borrow().clone()),
                 });
                 apps.len() as i64
             })
@@ -257,6 +266,7 @@ pub fn app_create(title_ptr: *const u8, width: f64, height: f64) -> i64 {
                 min_size: None,
                 max_size: None,
                 window_state: None,
+                activation_policy: PENDING_ACTIVATION_POLICY.with(|p| p.borrow().clone()),
             });
             apps.len() as i64
         })
@@ -316,44 +326,62 @@ pub fn app_run(app_handle: i64) {
             if idx < apps.len() {
                 let hwnd = apps[idx].hwnd;
                 let state = apps[idx].window_state;
-                unsafe {
-                    // Issue #1280 — apply requested initial window state.
-                    // Fullscreen on Win32 = drop WS_OVERLAPPEDWINDOW frame and
-                    // resize to the monitor's full rect (not just the work
-                    // area, which excludes the taskbar). Maximized = standard
-                    // SW_SHOWMAXIMIZED which respects the taskbar.
-                    match state {
-                        Some(WindowState::Fullscreen) => {
-                            let style = GetWindowLongW(hwnd, GWL_STYLE) as u32;
-                            let new_style = style & !WS_OVERLAPPEDWINDOW.0;
-                            SetWindowLongW(hwnd, GWL_STYLE, new_style as i32);
-                            let monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
-                            let mut mi = MONITORINFO {
-                                cbSize: std::mem::size_of::<MONITORINFO>() as u32,
-                                ..Default::default()
-                            };
-                            if GetMonitorInfoW(monitor, &mut mi).as_bool() {
-                                let r = mi.rcMonitor;
-                                let _ = SetWindowPos(
-                                    hwnd,
-                                    Some(HWND_TOP),
-                                    r.left,
-                                    r.top,
-                                    r.right - r.left,
-                                    r.bottom - r.top,
-                                    SWP_NOOWNERZORDER | SWP_FRAMECHANGED,
-                                );
-                            }
-                            let _ = ShowWindow(hwnd, SW_SHOW);
-                        }
-                        Some(WindowState::Maximized) => {
-                            let _ = ShowWindow(hwnd, SW_SHOWMAXIMIZED);
-                        }
-                        None => {
-                            let _ = ShowWindow(hwnd, SW_SHOW);
-                        }
+                // Accessory/background apps stay window-less at launch (the
+                // tray owns presentation); open windows on demand instead.
+                // Mirrors the macOS/GTK4 backends.
+                let suppress_window = matches!(
+                    apps[idx].activation_policy.as_deref(),
+                    Some("accessory") | Some("background")
+                );
+                // Pre-App() `appSetActivationPolicy` couldn't apply the
+                // taskbar style (the hwnd didn't exist yet); do it here.
+                if suppress_window {
+                    unsafe {
+                        let ex_style = GetWindowLongW(hwnd, GWL_EXSTYLE) as u32;
+                        let new_style = (ex_style & !WS_EX_APPWINDOW.0) | WS_EX_TOOLWINDOW.0;
+                        SetWindowLongW(hwnd, GWL_EXSTYLE, new_style as i32);
                     }
-                    let _ = UpdateWindow(hwnd);
+                }
+                if !suppress_window {
+                    unsafe {
+                        // Issue #1280 — apply requested initial window state.
+                        // Fullscreen on Win32 = drop WS_OVERLAPPEDWINDOW frame and
+                        // resize to the monitor's full rect (not just the work
+                        // area, which excludes the taskbar). Maximized = standard
+                        // SW_SHOWMAXIMIZED which respects the taskbar.
+                        match state {
+                            Some(WindowState::Fullscreen) => {
+                                let style = GetWindowLongW(hwnd, GWL_STYLE) as u32;
+                                let new_style = style & !WS_OVERLAPPEDWINDOW.0;
+                                SetWindowLongW(hwnd, GWL_STYLE, new_style as i32);
+                                let monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+                                let mut mi = MONITORINFO {
+                                    cbSize: std::mem::size_of::<MONITORINFO>() as u32,
+                                    ..Default::default()
+                                };
+                                if GetMonitorInfoW(monitor, &mut mi).as_bool() {
+                                    let r = mi.rcMonitor;
+                                    let _ = SetWindowPos(
+                                        hwnd,
+                                        Some(HWND_TOP),
+                                        r.left,
+                                        r.top,
+                                        r.right - r.left,
+                                        r.bottom - r.top,
+                                        SWP_NOOWNERZORDER | SWP_FRAMECHANGED,
+                                    );
+                                }
+                                let _ = ShowWindow(hwnd, SW_SHOW);
+                            }
+                            Some(WindowState::Maximized) => {
+                                let _ = ShowWindow(hwnd, SW_SHOWMAXIMIZED);
+                            }
+                            None => {
+                                let _ = ShowWindow(hwnd, SW_SHOW);
+                            }
+                        }
+                        let _ = UpdateWindow(hwnd);
+                    }
                 }
             }
         });
@@ -859,6 +887,12 @@ pub fn app_set_activation_policy(app_handle: i64, value_ptr: *const u8) {
     if policy_str.is_empty() {
         return;
     }
+    // Stash handle-agnostically (mirrors macOS): `App()` reads this when it
+    // builds the AppEntry, and `app_run` applies the taskbar style + window
+    // suppression. This is the path our 1-arg TS form (synthetic 0 handle,
+    // called before App()) takes. The block below additionally handles a
+    // post-create call where the hwnd already exists.
+    PENDING_ACTIVATION_POLICY.with(|p| *p.borrow_mut() = Some(policy_str.to_string()));
     #[cfg(target_os = "windows")]
     {
         if policy_str == "accessory" || policy_str == "background" {

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1950 entries across 114 modules
+// Coverage: 1951 entries across 114 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -2866,6 +2866,8 @@ declare module "perry/ui" {
   export function alert(...args: any[]): any;
   /** stdlib */
   export function alertWithButtons(...args: any[]): any;
+  /** stdlib */
+  export function appSetActivationPolicy(...args: any[]): any;
   /** stdlib */
   export function appSetMaxSize(...args: any[]): any;
   /** stdlib */

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2824 entries across 116 modules.
+Total: 2825 entries across 116 modules.
 
 ## Modules
 
@@ -2576,6 +2576,7 @@ Total: 2824 entries across 116 modules.
 - `addKeyboardShortcut` — module
 - `alert` — module
 - `alertWithButtons` — module
+- `appSetActivationPolicy` — module
 - `appSetMaxSize` — module
 - `appSetMinSize` — module
 - `appSetTimer` — module

--- a/types/perry/ui/index.d.ts
+++ b/types/perry/ui/index.d.ts
@@ -1844,6 +1844,23 @@ export function onActivate(callback: () => void): void;
 export function appSetTimer(intervalMs: number, callback: () => void): void;
 export function appSetTimer(app: Widget, intervalMs: number, callback: () => void): void;
 
+/**
+ * Set the application activation policy. Call before `App()`.
+ *
+ * - `"regular"` (default): normal app — dock icon, app-switcher entry,
+ *   main window auto-presented at launch.
+ * - `"accessory"`: menu-bar / status-item app — **no dock icon**, no
+ *   app-switcher entry, and on macOS the launch window is **not**
+ *   auto-presented (open windows on demand from the tray instead). The
+ *   macOS equivalent of `LSUIElement`.
+ * - `"background"`: fully background (`NSApplicationActivationPolicy.Prohibited`);
+ *   also suppresses the launch window on macOS.
+ *
+ * Windows: `accessory`/`background` hide the taskbar button. Linux/GTK4:
+ * maps to the equivalent hint. No-op on mobile/TV backends.
+ */
+export function appSetActivationPolicy(policy: "regular" | "accessory" | "background"): void;
+
 // ---------------------------------------------------------------------------
 // Embed
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Makes it possible to build a **menu-bar / status-item app** (no dock icon, no stray window) in TypeScript with perry. Two parts:

1. **Expose `appSetActivationPolicy(policy)` to TypeScript.** The `perry_ui_app_set_activation_policy` FFI already exists on every backend but had no TS binding. Wires it through, mirroring the `appSetTimer` pattern:
   - `perry-dispatch/src/ui_table.rs` — `MethodRow { method: "appSetActivationPolicy", args: &[Widget, Str] }`
   - `perry-codegen/src/lower_call/ui_tables.rs` — arity adapter: 1-arg TS form prepends a synthetic `0` app-handle
   - `perry-codegen-wasm/src/emit/ui_method_map.rs`, `perry-api-manifest/src/entries.rs` — wasm map + manifest
   - `types/perry/ui/index.d.ts` — `appSetActivationPolicy("regular" | "accessory" | "background")` + docs

2. **Suppress the auto-presented launch window** for `accessory`/`background` policy on all three desktop backends, so a tray app opens windows on demand (`Window().show()`) instead of flashing a main window at launch (LSUIElement semantics):
   - **macOS** (`perry-ui-macos`): `suppress_window` guards `makeKeyAndOrderFront`.
   - **GTK4** (`perry-ui-gtk4`): new handle-agnostic `PENDING_ACTIVATION_POLICY` thread-local populates `AppEntry.activation_policy` at construction; `window.present()` guarded.
   - **Windows** (`perry-ui-windows`): new `PENDING_ACTIVATION_POLICY` + `AppEntry.activation_policy` field; `app_run` applies `WS_EX_TOOLWINDOW` and skips `ShowWindow` when suppressed.

The thread-local is required because the 1-arg TS form is called **before** `App()` with the synthetic `0` handle, so the prior handle-indexed Windows/GTK4 setters never found an entry.

## Why

Unblocks a pure menu-bar app (built against this branch: a cross-platform Claude Code agent monitor). Today a perry tray app also shows a dock icon and a window; there was no TS-reachable way to opt into accessory mode despite the native support existing.

## Testing

- **macOS: verified end-to-end.** Built perry from this branch, compiled the menu-bar app, confirmed it runs as an accessory app — no dock icon, no window, status item present, 2s tray poll works.
- **Windows / GTK4:** code-reviewed, mirrors the macOS pattern; cross-host crates not buildable on a macOS dev host (per the repo's test exclusions), so they rely on CI for build validation.

## Notes

- Per the external-contributor convention in CLAUDE.md, this PR does **not** touch the workspace version, `CLAUDE.md` version line, or `CHANGELOG.md` — left for the maintainer to fold in at merge.
- `regular` (the default) behavior is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `appSetActivationPolicy(policy)` with `regular`, `accessory`, and `background` to control how apps are presented.
  * Apps can call it before `App()` to influence startup presentation.
  * On macOS, accessory/background apps no longer auto-present a launch window; on Windows they hide taskbar presence and suppress initial window show; on Linux/GTK4 they can launch window-less as appropriate.
* **Documentation**
  * Updated the public API typings and reference docs to include `appSetActivationPolicy`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->