### PR TITLE
fix(windows): wgpu-on-win64 link/ABI papercuts (#5812)

### DIFF
--- a/crates/perry-codegen/src/lower_call/extern_func.rs
+++ b/crates/perry-codegen/src/lower_call/extern_func.rs
@@ -1602,6 +1602,111 @@ pub fn try_lower_extern_func_call(
                 abi_slot_index += 1;
             }
         }
+
+        // Issue #5812 item 4 — pad omitted trailing manifest params.
+        //
+        // The loop above only marshals the arguments the caller actually
+        // passed. When a call omits trailing params that the
+        // `perry.nativeLibrary.functions` manifest declares — e.g.
+        // `textureCreateView(tex)` where the `descriptor` param is
+        // optional — the emitted call and its `pending_declares`
+        // declaration had fewer ABI slots than the native function reads.
+        // The C/Rust function then read an uninitialized register/stack
+        // slot for the missing param; for a `JsValue`/`string` descriptor
+        // that garbage got dereferenced (the `read_string` crash on win64
+        // in #5812).
+        //
+        // Fill each omitted slot with a defined null/zero sentinel of the
+        // correct ABI type. This is deliberately NOT routed through the
+        // `js_native_abi_check_*` validators the present-arg path uses:
+        // those throw on `undefined`, which would turn a previously
+        // (luckily) working "native fn ignores the trailing param" call
+        // into a runtime throw. A raw null/zero is what the wrappers
+        // already expect for absent optionals — `read_string`/`read_bytes`
+        // null-check the handle and return `None`, and numeric defaults
+        // read as 0. Structural multi-slot descriptors (pod / pod+count /
+        // buffer+len) genuinely need an object/buffer and have no sound
+        // empty form, so an omitted one routes through the normal helper
+        // (defined error) rather than fabricating a struct.
+        if let Some((manifest_params, _)) = manifest_sig.as_ref() {
+            if manifest_params.len() > args.len() {
+                // `manifest_sig` is owned, but the `lower_*` helpers borrow
+                // `ctx` mutably — clone the omitted descriptors so the loop
+                // doesn't hold a borrow on `manifest_sig`.
+                let omitted: Vec<(usize, NativeAbiType)> = manifest_params
+                    .iter()
+                    .enumerate()
+                    .skip(args.len())
+                    .map(|(idx, d)| (idx, d.clone()))
+                    .collect();
+                for (idx, descriptor) in &omitted {
+                    match descriptor {
+                        NativeAbiType::Pod(pod) => {
+                            lower_manifest_pod_param(
+                                ctx, descriptor, pod, *idx, abi_slot_index,
+                                &Expr::Undefined, &mut lowered, &mut arg_types,
+                            )?;
+                        }
+                        NativeAbiType::PodAndCount(pod) => {
+                            lower_manifest_pod_view_param(
+                                ctx, descriptor, pod, *idx, abi_slot_index,
+                                &Expr::Undefined, &mut lowered, &mut arg_types,
+                            )?;
+                        }
+                        NativeAbiType::BufferAndLen => {
+                            lower_buffer_and_len_param(
+                                ctx, descriptor, *idx, abi_slot_index,
+                                &double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)),
+                                &mut lowered, &mut arg_types,
+                            );
+                        }
+                        // Single-slot scalars / pointers / handles: emit a
+                        // null/zero of the right ABI type directly.
+                        // `String` and `Json` both occupy a single `*const
+                        // StringHeader` slot; a null header decodes to
+                        // `None`/empty in the wrapper (`read_string`/serde
+                        // null-check), which is the right "absent" value.
+                        NativeAbiType::String | NativeAbiType::Json => {
+                            let null_ptr = ctx.block().inttoptr(I64, "0");
+                            lowered.push(null_ptr);
+                            arg_types.push(PTR);
+                        }
+                        NativeAbiType::F32 => {
+                            lowered.push("0.0".to_string());
+                            arg_types.push(F32);
+                        }
+                        NativeAbiType::Bool
+                        | NativeAbiType::I32
+                        | NativeAbiType::U32
+                        | NativeAbiType::BufferLen => {
+                            lowered.push("0".to_string());
+                            arg_types.push(I32);
+                        }
+                        NativeAbiType::I64
+                        | NativeAbiType::I64String
+                        | NativeAbiType::U64
+                        | NativeAbiType::USize
+                        | NativeAbiType::Ptr
+                        | NativeAbiType::HandleId
+                        | NativeAbiType::Handle(_)
+                        | NativeAbiType::Promise(_) => {
+                            lowered.push("0".to_string());
+                            arg_types.push(I64);
+                        }
+                        // JsValue / F64 / Void all occupy a NaN-boxed
+                        // `double` slot; `undefined` is the natural empty.
+                        NativeAbiType::JsValue | NativeAbiType::F64 | NativeAbiType::Void => {
+                            lowered.push(double_literal(f64::from_bits(
+                                crate::nanbox::TAG_UNDEFINED,
+                            )));
+                            arg_types.push(DOUBLE);
+                        }
+                    }
+                    abi_slot_index += descriptor.abi_slot_count();
+                }
+            }
+        }
+
         let arg_slices: Vec<(crate::types::LlvmType, &str)> = arg_types
             .iter()
             .zip(lowered.iter())

--- a/crates/perry-codegen/src/lower_call/extern_func.rs
+++ b/crates/perry-codegen/src/lower_call/extern_func.rs
@@ -70,7 +70,7 @@ fn record_native_abi_return(
     );
 }
 
-fn lower_buffer_and_len_param(
+pub(super) fn lower_buffer_and_len_param(
     ctx: &mut FnCtx<'_>,
     descriptor: &NativeAbiType,
     js_argument_index: usize,
@@ -414,7 +414,7 @@ fn build_pod_temp_from_object_value(
     data_slot
 }
 
-fn lower_manifest_pod_param(
+pub(super) fn lower_manifest_pod_param(
     ctx: &mut FnCtx<'_>,
     descriptor: &NativeAbiType,
     pod: &NativePodAbi,
@@ -649,7 +649,7 @@ fn record_native_abi_pod_view_param(
     );
 }
 
-fn lower_manifest_pod_view_param(
+pub(super) fn lower_manifest_pod_view_param(
     ctx: &mut FnCtx<'_>,
     descriptor: &NativeAbiType,
     pod: &NativePodAbi,
@@ -786,7 +786,7 @@ fn materialize_native_handle_return(
     boxed
 }
 
-fn lower_manifest_param(
+pub(super) fn lower_manifest_param(
     ctx: &mut FnCtx<'_>,
     descriptor: &NativeAbiType,
     js_argument_index: usize,
@@ -1603,123 +1603,20 @@ pub fn try_lower_extern_func_call(
             }
         }
 
-        // Issue #5812 item 4 — pad omitted trailing manifest params.
-        //
-        // The loop above only marshals the arguments the caller actually
-        // passed. When a call omits trailing params that the
-        // `perry.nativeLibrary.functions` manifest declares — e.g.
-        // `textureCreateView(tex)` where the `descriptor` param is
-        // optional — the emitted call and its `pending_declares`
-        // declaration had fewer ABI slots than the native function reads.
-        // The C/Rust function then read an uninitialized register/stack
-        // slot for the missing param; for a `JsValue`/`string` descriptor
-        // that garbage got dereferenced (the `read_string` crash on win64
-        // in #5812).
-        //
-        // Fill each omitted slot with a defined null/zero sentinel of the
-        // correct ABI type. This is deliberately NOT routed through the
-        // `js_native_abi_check_*` validators the present-arg path uses:
-        // those throw on `undefined`, which would turn a previously
-        // (luckily) working "native fn ignores the trailing param" call
-        // into a runtime throw. A raw null/zero is what the wrappers
-        // already expect for absent optionals — `read_string`/`read_bytes`
-        // null-check the handle and return `None`, and numeric defaults
-        // read as 0. Structural multi-slot descriptors (pod / pod+count /
-        // buffer+len) genuinely need an object/buffer and have no sound
-        // empty form, so an omitted one routes through the normal helper
-        // (defined error) rather than fabricating a struct.
+        // Issue #5812 item 4 — pad omitted trailing manifest params with
+        // defined null/zero sentinels so the emitted call/declaration has
+        // the same ABI slot count the native function reads (otherwise it
+        // reads an uninitialized register — the win64 `read_string` crash).
+        // See `omitted_native_params::pad_omitted_native_params`.
         if let Some((manifest_params, _)) = manifest_sig.as_ref() {
-            if manifest_params.len() > args.len() {
-                // `manifest_sig` is owned, but the `lower_*` helpers borrow
-                // `ctx` mutably — clone the omitted descriptors so the loop
-                // doesn't hold a borrow on `manifest_sig`.
-                let omitted: Vec<(usize, NativeAbiType)> = manifest_params
-                    .iter()
-                    .enumerate()
-                    .skip(args.len())
-                    .map(|(idx, d)| (idx, d.clone()))
-                    .collect();
-                for (idx, descriptor) in &omitted {
-                    match descriptor {
-                        NativeAbiType::Pod(pod) => {
-                            lower_manifest_pod_param(
-                                ctx,
-                                descriptor,
-                                pod,
-                                *idx,
-                                abi_slot_index,
-                                &Expr::Undefined,
-                                &mut lowered,
-                                &mut arg_types,
-                            )?;
-                        }
-                        NativeAbiType::PodAndCount(pod) => {
-                            lower_manifest_pod_view_param(
-                                ctx,
-                                descriptor,
-                                pod,
-                                *idx,
-                                abi_slot_index,
-                                &Expr::Undefined,
-                                &mut lowered,
-                                &mut arg_types,
-                            )?;
-                        }
-                        NativeAbiType::BufferAndLen => {
-                            lower_buffer_and_len_param(
-                                ctx,
-                                descriptor,
-                                *idx,
-                                abi_slot_index,
-                                &double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)),
-                                &mut lowered,
-                                &mut arg_types,
-                            );
-                        }
-                        // Single-slot scalars / pointers / handles: emit a
-                        // null/zero of the right ABI type directly.
-                        // `String` and `Json` both occupy a single `*const
-                        // StringHeader` slot; a null header decodes to
-                        // `None`/empty in the wrapper (`read_string`/serde
-                        // null-check), which is the right "absent" value.
-                        NativeAbiType::String | NativeAbiType::Json => {
-                            let null_ptr = ctx.block().inttoptr(I64, "0");
-                            lowered.push(null_ptr);
-                            arg_types.push(PTR);
-                        }
-                        NativeAbiType::F32 => {
-                            lowered.push("0.0".to_string());
-                            arg_types.push(F32);
-                        }
-                        NativeAbiType::Bool
-                        | NativeAbiType::I32
-                        | NativeAbiType::U32
-                        | NativeAbiType::BufferLen => {
-                            lowered.push("0".to_string());
-                            arg_types.push(I32);
-                        }
-                        NativeAbiType::I64
-                        | NativeAbiType::I64String
-                        | NativeAbiType::U64
-                        | NativeAbiType::USize
-                        | NativeAbiType::Ptr
-                        | NativeAbiType::HandleId
-                        | NativeAbiType::Handle(_)
-                        | NativeAbiType::Promise(_) => {
-                            lowered.push("0".to_string());
-                            arg_types.push(I64);
-                        }
-                        // JsValue / F64 / Void all occupy a NaN-boxed
-                        // `double` slot; `undefined` is the natural empty.
-                        NativeAbiType::JsValue | NativeAbiType::F64 | NativeAbiType::Void => {
-                            lowered
-                                .push(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));
-                            arg_types.push(DOUBLE);
-                        }
-                    }
-                    abi_slot_index += descriptor.abi_slot_count();
-                }
-            }
+            super::omitted_native_params::pad_omitted_native_params(
+                ctx,
+                manifest_params,
+                args.len(),
+                abi_slot_index,
+                &mut lowered,
+                &mut arg_types,
+            )?;
         }
 
         let arg_slices: Vec<(crate::types::LlvmType, &str)> = arg_types

--- a/crates/perry-codegen/src/lower_call/extern_func.rs
+++ b/crates/perry-codegen/src/lower_call/extern_func.rs
@@ -1643,21 +1643,37 @@ pub fn try_lower_extern_func_call(
                     match descriptor {
                         NativeAbiType::Pod(pod) => {
                             lower_manifest_pod_param(
-                                ctx, descriptor, pod, *idx, abi_slot_index,
-                                &Expr::Undefined, &mut lowered, &mut arg_types,
+                                ctx,
+                                descriptor,
+                                pod,
+                                *idx,
+                                abi_slot_index,
+                                &Expr::Undefined,
+                                &mut lowered,
+                                &mut arg_types,
                             )?;
                         }
                         NativeAbiType::PodAndCount(pod) => {
                             lower_manifest_pod_view_param(
-                                ctx, descriptor, pod, *idx, abi_slot_index,
-                                &Expr::Undefined, &mut lowered, &mut arg_types,
+                                ctx,
+                                descriptor,
+                                pod,
+                                *idx,
+                                abi_slot_index,
+                                &Expr::Undefined,
+                                &mut lowered,
+                                &mut arg_types,
                             )?;
                         }
                         NativeAbiType::BufferAndLen => {
                             lower_buffer_and_len_param(
-                                ctx, descriptor, *idx, abi_slot_index,
+                                ctx,
+                                descriptor,
+                                *idx,
+                                abi_slot_index,
                                 &double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)),
-                                &mut lowered, &mut arg_types,
+                                &mut lowered,
+                                &mut arg_types,
                             );
                         }
                         // Single-slot scalars / pointers / handles: emit a
@@ -1696,9 +1712,8 @@ pub fn try_lower_extern_func_call(
                         // JsValue / F64 / Void all occupy a NaN-boxed
                         // `double` slot; `undefined` is the natural empty.
                         NativeAbiType::JsValue | NativeAbiType::F64 | NativeAbiType::Void => {
-                            lowered.push(double_literal(f64::from_bits(
-                                crate::nanbox::TAG_UNDEFINED,
-                            )));
+                            lowered
+                                .push(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));
                             arg_types.push(DOUBLE);
                         }
                     }

--- a/crates/perry-codegen/src/lower_call/mod.rs
+++ b/crates/perry-codegen/src/lower_call/mod.rs
@@ -50,6 +50,7 @@ mod native_module_dispatch;
 mod native_table;
 mod new;
 mod new_helpers;
+mod omitted_native_params;
 mod options;
 mod property_get;
 mod ui_styling;

--- a/crates/perry-codegen/src/lower_call/omitted_native_params.rs
+++ b/crates/perry-codegen/src/lower_call/omitted_native_params.rs
@@ -1,0 +1,131 @@
+//! Pad omitted trailing native-library call arguments with defined
+//! sentinels (#5812 item 4).
+//!
+//! A `perry.nativeLibrary.functions` call only marshals the arguments the
+//! caller actually passed. When the call omits trailing params the manifest
+//! declares — e.g. `textureCreateView(tex)` where the `descriptor` param is
+//! optional — the emitted LLVM call and its `pending_declares` declaration
+//! end up with fewer ABI slots than the native function reads. The C/Rust
+//! function then reads an uninitialized register/stack slot for the missing
+//! param; for a `JsValue`/string descriptor that garbage gets dereferenced
+//! (the `read_string` crash the #5812 reporter hit on win64).
+//!
+//! [`pad_omitted_native_params`] fills each omitted slot with a defined
+//! null/zero sentinel of the correct ABI type. The sentinel is deliberately
+//! NOT routed through the `js_native_abi_check_*` validators the present-arg
+//! path uses: those throw on `undefined`, which would turn a previously
+//! (luckily) working "native fn ignores the trailing param" call into a
+//! runtime throw. A raw null/zero is what the wrappers already expect for an
+//! absent optional — `read_string`/`read_bytes` null-check the handle and
+//! return `None`, and numeric defaults read as 0. Structural multi-slot
+//! descriptors (pod / pod+count / buffer+len) genuinely need an object/buffer
+//! and have no sound empty form, so an omitted one routes through the normal
+//! lowering helper (defined error) rather than fabricating a struct.
+
+use anyhow::Result;
+use perry_api_manifest::NativeAbiType;
+use perry_hir::Expr;
+
+use super::extern_func::{
+    lower_buffer_and_len_param, lower_manifest_param, lower_manifest_pod_param,
+    lower_manifest_pod_view_param,
+};
+use crate::expr::FnCtx;
+use crate::nanbox::double_literal;
+use crate::types::{LlvmType, DOUBLE, F32, I32, I64, PTR};
+
+/// Append a sentinel for every manifest param past `passed_args`. No-op when
+/// the caller passed at least as many args as the manifest declares.
+/// `abi_slot_index` is the running ABI slot count after the present args.
+pub(super) fn pad_omitted_native_params(
+    ctx: &mut FnCtx<'_>,
+    manifest_params: &[NativeAbiType],
+    passed_args: usize,
+    abi_slot_index: usize,
+    lowered: &mut Vec<String>,
+    arg_types: &mut Vec<LlvmType>,
+) -> Result<()> {
+    if manifest_params.len() <= passed_args {
+        return Ok(());
+    }
+    // The `lower_*` helpers borrow `ctx` mutably, so clone the omitted
+    // descriptors up front rather than holding a borrow on the slice.
+    let omitted: Vec<(usize, NativeAbiType)> = manifest_params
+        .iter()
+        .enumerate()
+        .skip(passed_args)
+        .map(|(idx, descriptor)| (idx, descriptor.clone()))
+        .collect();
+    let mut abi_slot_index = abi_slot_index;
+    for (idx, descriptor) in &omitted {
+        match descriptor {
+            NativeAbiType::Pod(pod) => lower_manifest_pod_param(
+                ctx,
+                descriptor,
+                pod,
+                *idx,
+                abi_slot_index,
+                &Expr::Undefined,
+                lowered,
+                arg_types,
+            )?,
+            NativeAbiType::PodAndCount(pod) => lower_manifest_pod_view_param(
+                ctx,
+                descriptor,
+                pod,
+                *idx,
+                abi_slot_index,
+                &Expr::Undefined,
+                lowered,
+                arg_types,
+            )?,
+            NativeAbiType::BufferAndLen => lower_buffer_and_len_param(
+                ctx,
+                descriptor,
+                *idx,
+                abi_slot_index,
+                &double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)),
+                lowered,
+                arg_types,
+            ),
+            // `String` and `Json` both occupy a single `*const StringHeader`
+            // slot; a null header decodes to `None`/empty in the wrapper
+            // (`read_string`/serde null-check), the right "absent" value.
+            NativeAbiType::String | NativeAbiType::Json => {
+                let null_ptr = ctx.block().inttoptr(I64, "0");
+                lowered.push(null_ptr);
+                arg_types.push(PTR);
+            }
+            NativeAbiType::F32 => {
+                lowered.push("0.0".to_string());
+                arg_types.push(F32);
+            }
+            NativeAbiType::Bool
+            | NativeAbiType::I32
+            | NativeAbiType::U32
+            | NativeAbiType::BufferLen => {
+                lowered.push("0".to_string());
+                arg_types.push(I32);
+            }
+            NativeAbiType::I64
+            | NativeAbiType::I64String
+            | NativeAbiType::U64
+            | NativeAbiType::USize
+            | NativeAbiType::Ptr
+            | NativeAbiType::HandleId
+            | NativeAbiType::Handle(_)
+            | NativeAbiType::Promise(_) => {
+                lowered.push("0".to_string());
+                arg_types.push(I64);
+            }
+            // JsValue / F64 / Void all occupy a NaN-boxed `double` slot;
+            // `undefined` is the natural empty.
+            NativeAbiType::JsValue | NativeAbiType::F64 | NativeAbiType::Void => {
+                lowered.push(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));
+                arg_types.push(DOUBLE);
+            }
+        }
+        abi_slot_index += descriptor.abi_slot_count();
+    }
+    Ok(())
+}

--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -1597,7 +1597,10 @@ mod native_lib_artifact_tests {
     #[test]
     fn variant_set_translates_unix_static_lib_to_msvc_on_windows() {
         let variants = super::lib_name_variants("libperry_ext_webgpu.a", Some("windows"));
-        assert_eq!(variants.first().map(String::as_str), Some("libperry_ext_webgpu.a"));
+        assert_eq!(
+            variants.first().map(String::as_str),
+            Some("libperry_ext_webgpu.a")
+        );
         assert!(
             variants.iter().any(|v| v == "perry_ext_webgpu.lib"),
             "expected perry_ext_webgpu.lib in {:?}",

--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -111,9 +111,6 @@ pub(crate) fn locate_native_lib_artifact(
 /// cargo lib name (refs issue #792).
 fn lib_name_variants(lib_name: &str, target: Option<&str>) -> Vec<String> {
     let mut out = vec![lib_name.to_string()];
-    if std::path::Path::new(lib_name).extension().is_some() {
-        return out;
-    }
     let is_windows = matches!(target, Some("windows") | Some("windows-winui"))
         || (target.is_none() && cfg!(target_os = "windows"));
     let is_macos = matches!(
@@ -128,6 +125,25 @@ fn lib_name_variants(lib_name: &str, target: Option<&str>) -> Vec<String> {
             | Some("visionos-simulator")
             | Some("macos")
     ) || (target.is_none() && cfg!(target_os = "macos"));
+
+    if std::path::Path::new(lib_name).extension().is_some() {
+        // A wrapper may hard-code the Unix static-lib filename (e.g.
+        // `libperry_ext_webgpu.a`) in its manifest `lib` field even when
+        // targeting Windows, where cargo actually emits
+        // `perry_ext_webgpu.lib` (MSVC drops the `lib` prefix and uses
+        // the `.lib` extension). When the declared name carries the `.a`
+        // extension but we're building for Windows, also probe the
+        // MSVC-translated names so the artifact resolves without forcing
+        // the wrapper to special-case the filename per platform. Refs #5812.
+        if is_windows && std::path::Path::new(lib_name).extension() == Some("a".as_ref()) {
+            let stem = lib_name.strip_suffix(".a").unwrap_or(lib_name);
+            out.push(format!("{}.lib", stem));
+            if let Some(stripped) = stem.strip_prefix("lib") {
+                out.push(format!("{}.lib", stripped));
+            }
+        }
+        return out;
+    }
 
     // MSVC staticlib has no `lib` prefix — the cargo crate name *is* the
     // filename stem. Try the literal name first (covers crates legitimately
@@ -1570,6 +1586,48 @@ mod native_lib_artifact_tests {
             "expected libfoo.lib in {:?}",
             variants
         );
+    }
+
+    /// Refs #5812 — a wrapper that hard-codes the Unix static-lib
+    /// filename (`libperry_ext_webgpu.a`) in its manifest must still
+    /// resolve when targeting Windows, where cargo emits
+    /// `perry_ext_webgpu.lib` (MSVC drops the `lib` prefix and the
+    /// extension is `.lib`). The literal `.a` name is still tried first
+    /// so Unix builds keep working unchanged.
+    #[test]
+    fn variant_set_translates_unix_static_lib_to_msvc_on_windows() {
+        let variants = super::lib_name_variants("libperry_ext_webgpu.a", Some("windows"));
+        assert_eq!(variants.first().map(String::as_str), Some("libperry_ext_webgpu.a"));
+        assert!(
+            variants.iter().any(|v| v == "perry_ext_webgpu.lib"),
+            "expected perry_ext_webgpu.lib in {:?}",
+            variants
+        );
+    }
+
+    /// The `.a` → `.lib` translation is Windows-only; a Unix target must
+    /// not start probing for `.lib` files.
+    #[test]
+    fn variant_set_does_not_translate_static_lib_on_unix() {
+        let variants = super::lib_name_variants("libperry_ext_webgpu.a", Some("linux"));
+        assert_eq!(variants, vec!["libperry_ext_webgpu.a".to_string()]);
+    }
+
+    /// End-to-end: a manifest declaring `libperry_ext_webgpu.a` resolves
+    /// the on-disk `perry_ext_webgpu.lib` that cargo actually produced on
+    /// Windows. Refs #5812.
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn locates_msvc_artifact_from_unix_manifest_name() {
+        let tmp = tempfile::tempdir().expect("create tmpdir");
+        let target_dir = tmp.path().join("target");
+        let release_dir = target_dir.join("release");
+        fs::create_dir_all(&release_dir).expect("mkdir release");
+        let lib_path = release_dir.join("perry_ext_webgpu.lib");
+        fs::write(&lib_path, b"fake archive").expect("write lib");
+
+        let found = locate_native_lib_artifact(&target_dir, None, "libperry_ext_webgpu.a");
+        assert_eq!(found.as_deref(), Some(lib_path.as_path()));
     }
 
     #[test]

--- a/crates/perry/src/commands/compile/link/build_and_run.rs
+++ b/crates/perry/src/commands/compile/link/build_and_run.rs
@@ -1700,6 +1700,18 @@ pub(crate) fn build_and_run_link(
                 }
             }
 
+            // Issue #5812 item 2 — auto-append the Windows system libs that
+            // wgpu's graphics backends reference but cargo's `#[link]` attrs
+            // on the wgpu crate don't cover (d3dcompiler / opengl32). Without
+            // them a Windows app linking a wgpu-backed native ext failed with
+            // LNK2019 unresolved externals (the reporter patched the link
+            // line by hand). See `windows_wgpu_backend_syslibs`.
+            if is_windows {
+                for syslib in super::windows_wgpu_backend_syslibs(target_config) {
+                    cmd.arg(syslib);
+                }
+            }
+
             // Compile manifest-declared Swift sources to object files and
             // append them to the link line. Used by `--features watchos-swift-app`
             // so a native lib can ship its own `@main struct App: App`.

--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -297,7 +297,8 @@ mod native_package_selection_tests {
     #[test]
     fn vulkan_backend_appends_only_opengl32() {
         let mut tc = target_config();
-        tc.backends.push(backend_config(NativeBackend::Vulkan, true));
+        tc.backends
+            .push(backend_config(NativeBackend::Vulkan, true));
         assert_eq!(
             super::windows_wgpu_backend_syslibs(&tc),
             vec!["opengl32.lib"]
@@ -310,7 +311,8 @@ mod native_package_selection_tests {
     #[test]
     fn d3d12_backend_appends_syslibs_even_when_unavailable() {
         let mut tc = target_config();
-        tc.backends.push(backend_config(NativeBackend::D3d12, false));
+        tc.backends
+            .push(backend_config(NativeBackend::D3d12, false));
         assert_eq!(
             super::windows_wgpu_backend_syslibs(&tc),
             vec!["d3dcompiler.lib", "opengl32.lib"]

--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -159,6 +159,42 @@ fn select_available_backend_link_metadata(
         .collect()
 }
 
+/// Windows system libraries that wgpu's graphics backends reference but
+/// the wgpu crate's own `#[link]` attrs don't cover (#5812 item 2):
+///
+/// - `d3dcompiler.lib` — the d3d12 backend calls `D3DCompile` (HLSL →
+///   DXBC shader compilation).
+/// - `opengl32.lib` — wgpu's gl backend (compiled in alongside
+///   d3d12/vulkan on Windows) calls the `wgl*` context entry points.
+///
+/// Without these, a Windows app linking a wgpu-backed native ext fails
+/// with LNK2019 unresolved externals. Keyed off the manifest's *declared*
+/// backends (not the `available` prebuilt flag): the unresolved symbols
+/// come from the main staticlib's references, and appending an
+/// unreferenced `.lib` is harmless on MSVC (only referenced objects are
+/// pulled). d3d12 is Windows-only, so its presence reliably signals the
+/// ext pulls wgpu's d3d12 + gl backends; vulkan-on-Windows still compiles
+/// the gl fallback, so it needs `opengl32` too. Returns the `.lib` names
+/// in link order.
+fn windows_wgpu_backend_syslibs(target_config: &super::TargetNativeConfig) -> Vec<&'static str> {
+    let has_d3d12 = target_config
+        .backends
+        .iter()
+        .any(|backend| backend.backend.as_str() == "d3d12");
+    let has_vulkan = target_config
+        .backends
+        .iter()
+        .any(|backend| backend.backend.as_str() == "vulkan");
+    let mut libs = Vec::new();
+    if has_d3d12 {
+        libs.push("d3dcompiler.lib");
+    }
+    if has_d3d12 || has_vulkan {
+        libs.push("opengl32.lib");
+    }
+    libs
+}
+
 #[cfg(test)]
 mod native_package_selection_tests {
     use super::*;
@@ -242,6 +278,58 @@ mod native_package_selection_tests {
         let selection = select_available_backend_link_metadata(&tc);
 
         assert!(selection.is_empty());
+    }
+
+    /// #5812 item 2 — a d3d12 backend pulls both `D3DCompile`
+    /// (d3dcompiler.lib) and wgpu's gl fallback (opengl32.lib).
+    #[test]
+    fn d3d12_backend_appends_d3dcompiler_and_opengl32() {
+        let mut tc = target_config();
+        tc.backends.push(backend_config(NativeBackend::D3d12, true));
+        assert_eq!(
+            super::windows_wgpu_backend_syslibs(&tc),
+            vec!["d3dcompiler.lib", "opengl32.lib"]
+        );
+    }
+
+    /// vulkan-on-Windows still compiles wgpu's gl fallback (opengl32.lib)
+    /// but does not need d3dcompiler.
+    #[test]
+    fn vulkan_backend_appends_only_opengl32() {
+        let mut tc = target_config();
+        tc.backends.push(backend_config(NativeBackend::Vulkan, true));
+        assert_eq!(
+            super::windows_wgpu_backend_syslibs(&tc),
+            vec!["opengl32.lib"]
+        );
+    }
+
+    /// The syslibs are keyed off *declared* backends, not the `available`
+    /// prebuilt flag — the unresolved symbols come from the main staticlib,
+    /// and an unreferenced `.lib` is harmless on MSVC.
+    #[test]
+    fn d3d12_backend_appends_syslibs_even_when_unavailable() {
+        let mut tc = target_config();
+        tc.backends.push(backend_config(NativeBackend::D3d12, false));
+        assert_eq!(
+            super::windows_wgpu_backend_syslibs(&tc),
+            vec!["d3dcompiler.lib", "opengl32.lib"]
+        );
+    }
+
+    /// A non-graphics native lib (no wgpu backends) gets no extra syslibs.
+    #[test]
+    fn no_backends_appends_no_syslibs() {
+        let tc = target_config();
+        assert!(super::windows_wgpu_backend_syslibs(&tc).is_empty());
+    }
+
+    /// Metal is Apple-only and never triggers the Windows wgpu syslibs.
+    #[test]
+    fn metal_backend_appends_no_windows_syslibs() {
+        let mut tc = target_config();
+        tc.backends.push(backend_config(NativeBackend::Metal, true));
+        assert!(super::windows_wgpu_backend_syslibs(&tc).is_empty());
     }
 }
 


### PR DESCRIPTION
Three Perry-side fixes from the `@perryts/webgpu`-on-Windows-x64 report (#5812), where a community user got wgpu building and presenting frames but hit several link/ABI papercuts along the way. Code-only PR — no version bump or changelog (maintainer folds those in at merge).

### 1. Manifest `lib*.a` → MSVC `*.lib` resolution (item 1)
`lib_name_variants` (`library_search.rs`) early-returned the moment a declared lib name carried *any* extension, so a manifest declaring `"lib": "libperry_ext_webgpu.a"` only ever probed that literal name on Windows — but cargo emits `perry_ext_webgpu.lib` there (MSVC drops the `lib` prefix + uses `.lib`), so the link failed with "Native library not found". Now also probes the MSVC-translated names (`{stem}.lib` and the `lib`-stripped variant) when the name ends in `.a` and the target is Windows. The literal `.a` name is still tried first, so Unix is unchanged.

### 2. Auto-link `d3dcompiler` + `opengl32` for wgpu backends on Windows (item 2)
wgpu's d3d12 backend calls `D3DCompile` (HLSL→DXBC, in `d3dcompiler.lib`) and its gl backend — compiled in alongside d3d12/vulkan on Windows — calls the `wgl*` entry points (in `opengl32.lib`). The wgpu crate's own `#[link]` attrs cover `d3d12.lib`/`dxgi.lib` but not these two, so apps hit LNK2019 unresolved externals (the reporter patched the link line by hand). New `windows_wgpu_backend_syslibs` helper auto-appends them, keyed off the manifest's *declared* backends: `d3dcompiler.lib` for d3d12, `opengl32.lib` for d3d12-or-vulkan. Keyed off declared (not `available`) backends because the unresolved symbols come from the main staticlib, and an unreferenced `.lib` is harmless on MSVC.

### 3. Omitted trailing native-library args no longer pass register garbage (item 4)
A `perry.nativeLibrary.functions` call that *omitted* trailing declared params (e.g. `textureCreateView(tex)` where `descriptor` is optional) only marshalled the args the caller passed, so the emitted LLVM call + declaration had fewer ABI slots than the native fn reads. The fn then read an uninitialized register/stack slot for the missing param; for a `JsValue`/string descriptor that garbage got dereferenced — the `read_string` crash on win64. The native-FFI lowering (`extern_func.rs`) now pads omitted trailing params with a defined null/zero sentinel of the correct ABI slot type (null ptr for string/json/handle/promise, 0 for scalars, NaN-boxed `undefined` for JsValue/f64/void). The sentinel deliberately bypasses the `js_native_abi_check_*` validators (which throw on `undefined`) so it stays non-regressive for functions that ignore the trailing param — `read_string`/`read_bytes` already null-check.

**Note:** plain TS optional/default/object args were verified correct on win64 in isolation — item 4 is specific to the native-ABI marshalling path, *not* general default-arg lowering.

### Out of scope (tracked on the issue)
Items 3 (`request_adapter` `compatible_surface`) and 5 (gray window / present) live in the external `@perryts/webgpu` package and/or need a Windows GPU box.

### Tests
- 3 new `native_lib_artifact_tests` (item 1): Windows translation, Unix no-op, end-to-end resolve.
- 5 new `native_package_selection_tests` (item 2): d3d12, vulkan-only, unavailable-still-appends, no-backends, Apple Metal.
- All pass; `perry` + `perry-codegen` compile clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved native library resolution on Windows by translating `.a` manifest names into matching `.lib` candidates (including `lib`-prefixed variants).
  * Enhanced Windows linking for wgpu-backed native extensions by automatically adding required Windows graphics system libraries based on the selected backends.
* **Bug Fixes**
  * Fixed potential incomplete native calls by padding missing trailing ABI arguments with ABI-compatible placeholder values to preserve the expected call layout.
* **Tests**
  * Added/extended Windows-focused coverage for `.a`→`.lib` resolution and for the selected Windows graphics system libraries during linking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->