### PR TITLE
fix(intl): #5582 — era/timeZoneName must not set DTF needDefaults flag (ECMA-402 §11.1.2 step 38)

### DIFF
--- a/crates/perry-runtime/src/intl.rs
+++ b/crates/perry-runtime/src/intl.rs
@@ -294,6 +294,8 @@ fn coerce_option_string(value: f64) -> Option<String> {
         Some("null".to_string())
     } else if js.is_any_string() {
         string_from_string_value(value)
+    } else if unsafe { crate::symbol::js_is_symbol(value) != 0 } {
+        throw_type_error("Cannot convert a Symbol value to a string")
     } else {
         Some(value_to_string(value))
     }
@@ -1173,6 +1175,14 @@ fn make_instance(closure: *const ClosureHeader, kind: &str, locales: f64, option
             set_internal_field(obj, KEY_TIME_ZONE, string_value(&time_zone));
             // Date/time component options (ECMA-402 Table 7), read in order. Each
             // out-of-range value is a RangeError.
+            //
+            // `any_component` tracks the ECMA-402 §11.1.2 `needDefaults` flag.
+            // Only the fields listed in steps 38a/38b count:
+            //   date fields: weekday, year, month, day
+            //   time fields: dayPeriod, hour, minute, second, fractionalSecondDigits
+            // `era` and `timeZoneName` are read and stored but do NOT affect
+            // `needDefaults` — an era-only or timeZoneName-only DTF still gets
+            // year/month/day defaults applied (spec step 40).
             let mut any_component = false;
             any_component |= dt_component_option(
                 obj,
@@ -1181,8 +1191,8 @@ fn make_instance(closure: *const ClosureHeader, kind: &str, locales: f64, option
                 &["narrow", "short", "long"],
                 KEY_WEEKDAY,
             );
-            any_component |=
-                dt_component_option(obj, options, "era", &["narrow", "short", "long"], KEY_ERA);
+            // era is read and stored but does NOT count toward needDefaults.
+            dt_component_option(obj, options, "era", &["narrow", "short", "long"], KEY_ERA);
             any_component |=
                 dt_component_option(obj, options, "year", &["2-digit", "numeric"], KEY_YEAR);
             any_component |= dt_component_option(
@@ -1214,7 +1224,8 @@ fn make_instance(closure: *const ClosureHeader, kind: &str, locales: f64, option
                 set_internal_field(obj, KEY_FRACTIONAL, n);
                 any_component = true;
             }
-            any_component |= dt_component_option(
+            // timeZoneName is read and stored but does NOT count toward needDefaults.
+            dt_component_option(
                 obj,
                 options,
                 "timeZoneName",

--- a/crates/perry-runtime/src/intl.rs
+++ b/crates/perry-runtime/src/intl.rs
@@ -294,8 +294,6 @@ fn coerce_option_string(value: f64) -> Option<String> {
         Some("null".to_string())
     } else if js.is_any_string() {
         string_from_string_value(value)
-    } else if unsafe { crate::symbol::js_is_symbol(value) != 0 } {
-        throw_type_error("Cannot convert a Symbol value to a string")
     } else {
         Some(value_to_string(value))
     }

--- a/crates/perry-runtime/src/intl.rs
+++ b/crates/perry-runtime/src/intl.rs
@@ -1176,56 +1176,81 @@ fn make_instance(closure: *const ClosureHeader, kind: &str, locales: f64, option
             // Date/time component options (ECMA-402 Table 7), read in order. Each
             // out-of-range value is a RangeError.
             //
-            // `any_component` tracks the ECMA-402 §11.1.2 `needDefaults` flag.
-            // Only the fields listed in steps 38a/38b count:
-            //   date fields: weekday, year, month, day
-            //   time fields: dayPeriod, hour, minute, second, fractionalSecondDigits
-            // `era` and `timeZoneName` are read and stored but do NOT affect
-            // `needDefaults` — an era-only or timeZoneName-only DTF still gets
-            // year/month/day defaults applied (spec step 40).
+            // Two separate flags are tracked:
+            //
+            // • `any_component` — the ECMA-402 §11.1.2 `needDefaults` flag.
+            //   Only the fields listed in steps 38a/38b count:
+            //     date fields: weekday, year, month, day
+            //     time fields: dayPeriod, hour, minute, second, fractionalSecondDigits
+            //   `era` and `timeZoneName` are read and stored but do NOT affect
+            //   this flag — an era-only or timeZoneName-only DTF still gets
+            //   year/month/day defaults applied (spec step 40).
+            //
+            // • `has_explicit_component` — set by ALL of the above INCLUDING
+            //   `era` and `timeZoneName`.  Used for the dateStyle/timeStyle
+            //   conflict check (step 35.b: throw if style + any component option).
             let mut any_component = false;
-            any_component |= dt_component_option(
+            let mut has_explicit_component = false;
+            let has_weekday = dt_component_option(
                 obj,
                 options,
                 "weekday",
                 &["narrow", "short", "long"],
                 KEY_WEEKDAY,
             );
-            // era is read and stored but does NOT count toward needDefaults.
-            dt_component_option(obj, options, "era", &["narrow", "short", "long"], KEY_ERA);
-            any_component |=
+            any_component |= has_weekday;
+            has_explicit_component |= has_weekday;
+            // era counts toward the style-conflict check but NOT toward needDefaults.
+            has_explicit_component |=
+                dt_component_option(obj, options, "era", &["narrow", "short", "long"], KEY_ERA);
+            let has_year =
                 dt_component_option(obj, options, "year", &["2-digit", "numeric"], KEY_YEAR);
-            any_component |= dt_component_option(
+            any_component |= has_year;
+            has_explicit_component |= has_year;
+            let has_month = dt_component_option(
                 obj,
                 options,
                 "month",
                 &["2-digit", "numeric", "narrow", "short", "long"],
                 KEY_MONTH,
             );
-            any_component |=
+            any_component |= has_month;
+            has_explicit_component |= has_month;
+            let has_day =
                 dt_component_option(obj, options, "day", &["2-digit", "numeric"], KEY_DAY);
-            any_component |= dt_component_option(
+            any_component |= has_day;
+            has_explicit_component |= has_day;
+            let has_day_period = dt_component_option(
                 obj,
                 options,
                 "dayPeriod",
                 &["narrow", "short", "long"],
                 KEY_DAY_PERIOD,
             );
-            any_component |=
+            any_component |= has_day_period;
+            has_explicit_component |= has_day_period;
+            let has_hour =
                 dt_component_option(obj, options, "hour", &["2-digit", "numeric"], KEY_HOUR);
-            any_component |=
+            any_component |= has_hour;
+            has_explicit_component |= has_hour;
+            let has_minute =
                 dt_component_option(obj, options, "minute", &["2-digit", "numeric"], KEY_MINUTE);
-            any_component |=
+            any_component |= has_minute;
+            has_explicit_component |= has_minute;
+            let has_second =
                 dt_component_option(obj, options, "second", &["2-digit", "numeric"], KEY_SECOND);
+            any_component |= has_second;
+            has_explicit_component |= has_second;
             // fractionalSecondDigits is GetNumberOption(1, 3) — out of range or
             // non-numeric is a RangeError.
             if let Some(n) = get_number_option_coerced(options, "fractionalSecondDigits", 1.0, 3.0)
             {
                 set_internal_field(obj, KEY_FRACTIONAL, n);
                 any_component = true;
+                has_explicit_component = true;
             }
-            // timeZoneName is read and stored but does NOT count toward needDefaults.
-            dt_component_option(
+            // timeZoneName counts toward the style-conflict check but NOT toward needDefaults.
+            has_explicit_component |= dt_component_option(
                 obj,
                 options,
                 "timeZoneName",
@@ -1259,8 +1284,9 @@ fn make_instance(closure: *const ClosureHeader, kind: &str, locales: f64, option
                 }
             }
             let has_style = date_style.is_some() || time_style.is_some();
-            // Combining a style with an explicit component is a TypeError.
-            if has_style && any_component {
+            // ECMA-402 §11.1.2 step 35.b: combining a style with any explicit
+            // component option (including era and timeZoneName) is a TypeError.
+            if has_style && has_explicit_component {
                 throw_type_error(
                     "Intl.DateTimeFormat: dateStyle/timeStyle cannot be used with explicit date-time component options",
                 );

--- a/crates/perry-runtime/src/intl/date_collator.rs
+++ b/crates/perry-runtime/src/intl/date_collator.rs
@@ -1355,28 +1355,18 @@ pub(crate) fn temporal_locale_string(
                 second_opt.as_deref(),
             )
         } else {
-            // No options given — apply ECMA-402 defaults for this Temporal
-            // type.  The spec says `toLocaleString(locales, options)` is
-            // equivalent to `new Intl.DateTimeFormat(locales, options).format(this)`.
-            // With `options = undefined`, DTF always resolves to
-            // `{ year: "numeric", month: "numeric", day: "numeric" }`.
-            // Each Temporal type maps its fields to an epoch-ms value for
-            // formatting; the date components of that value are what the DTF
-            // defaults select.  Type-specific component overrides (e.g.
-            // time for PlainTime) only apply when the user explicitly passes
-            // options — not as defaults.
-            //
-            // ZonedDateTime is the sole exception: its toLocaleString spec
-            // mandates that the output includes both date and time components
-            // when no options are given (analogous to how ZDT carries a
-            // timezone that no ordinary DTF object can represent).
+            // No options given — apply per-type ECMA-402 / Temporal-spec
+            // defaults.  `ToDateTimeOptions(options, required, defaults)` sets
+            // the default fields differently per type:
+            //   PlainDate         → required="date",  defaults="date"
+            //   PlainDateTime     → required="any",   defaults="any"   (date+time)
+            //   PlainTime         → required="time",  defaults="time"
+            //   PlainYearMonth    → required="year month", defaults="year month"
+            //   PlainMonthDay     → required="month day",  defaults="month day"
+            //   Instant           → required="any",   defaults="all"   (date+time)
+            //   ZonedDateTime     → required="any",   defaults="all"   (date+time)
             match ctx {
-                TemporalLocaleCtx::PlainDate
-                | TemporalLocaleCtx::PlainDateTime
-                | TemporalLocaleCtx::Instant
-                | TemporalLocaleCtx::PlainTime
-                | TemporalLocaleCtx::PlainYearMonth
-                | TemporalLocaleCtx::PlainMonthDay => (
+                TemporalLocaleCtx::PlainDate => (
                     None,
                     None,
                     Some("numeric"),
@@ -1386,7 +1376,9 @@ pub(crate) fn temporal_locale_string(
                     None,
                     None,
                 ),
-                TemporalLocaleCtx::ZonedDateTime => (
+                TemporalLocaleCtx::PlainDateTime
+                | TemporalLocaleCtx::Instant
+                | TemporalLocaleCtx::ZonedDateTime => (
                     None,
                     None,
                     Some("numeric"),
@@ -1395,6 +1387,36 @@ pub(crate) fn temporal_locale_string(
                     Some("numeric"),
                     Some("2-digit"),
                     Some("2-digit"),
+                ),
+                TemporalLocaleCtx::PlainTime => (
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    Some("numeric"),
+                    Some("2-digit"),
+                    Some("2-digit"),
+                ),
+                TemporalLocaleCtx::PlainYearMonth => (
+                    None,
+                    None,
+                    Some("numeric"),
+                    Some("numeric"),
+                    None,
+                    None,
+                    None,
+                    None,
+                ),
+                TemporalLocaleCtx::PlainMonthDay => (
+                    None,
+                    None,
+                    None,
+                    Some("numeric"),
+                    Some("numeric"),
+                    None,
+                    None,
+                    None,
                 ),
             }
         };

--- a/crates/perry-runtime/src/intl/date_collator.rs
+++ b/crates/perry-runtime/src/intl/date_collator.rs
@@ -1355,68 +1355,46 @@ pub(crate) fn temporal_locale_string(
                 second_opt.as_deref(),
             )
         } else {
-            // No options given — apply per-type ECMA-402 / Temporal-spec
-            // defaults.  `ToDateTimeOptions(options, required, defaults)` sets
-            // the default fields differently per type:
-            //   PlainDate         → required="date",  defaults="date"
-            //   PlainDateTime     → required="any",   defaults="any"   (date+time)
-            //   PlainTime         → required="time",  defaults="time"
-            //   PlainYearMonth    → required="year month", defaults="year month"
-            //   PlainMonthDay     → required="month day",  defaults="month day"
-            //   Instant           → required="any",   defaults="all"   (date+time)
-            //   ZonedDateTime     → required="any",   defaults="all"   (date+time)
+            // No options given — apply ECMA-402 defaults for this Temporal
+            // type.  The spec says `toLocaleString(locales, options)` is
+            // equivalent to `new Intl.DateTimeFormat(locales, options).format(this)`.
+            // With `options = undefined`, DTF always resolves to
+            // `{ year: "numeric", month: "numeric", day: "numeric" }`.
+            // Each Temporal type maps its fields to an epoch-ms value for
+            // formatting; the date components of that value are what the DTF
+            // defaults select.  Type-specific component overrides (e.g.
+            // time for PlainTime) only apply when the user explicitly passes
+            // options — not as defaults.
+            //
+            // ZonedDateTime is the sole exception: its toLocaleString spec
+            // mandates that the output includes both date and time components
+            // when no options are given (analogous to how ZDT carries a
+            // timezone that no ordinary DTF object can represent).
             match ctx {
-                TemporalLocaleCtx::PlainDate => (
-                    None,
-                    None,
-                    Some("numeric"),
-                    Some("numeric"),
-                    Some("numeric"),
-                    None,
-                    None,
-                    None,
-                ),
-                TemporalLocaleCtx::PlainDateTime
+                TemporalLocaleCtx::PlainDate
+                | TemporalLocaleCtx::PlainDateTime
                 | TemporalLocaleCtx::Instant
-                | TemporalLocaleCtx::ZonedDateTime => (
+                | TemporalLocaleCtx::PlainTime
+                | TemporalLocaleCtx::PlainYearMonth
+                | TemporalLocaleCtx::PlainMonthDay => (
                     None,
                     None,
                     Some("numeric"),
                     Some("numeric"),
                     Some("numeric"),
-                    Some("numeric"),
-                    Some("2-digit"),
-                    Some("2-digit"),
-                ),
-                TemporalLocaleCtx::PlainTime => (
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    Some("numeric"),
-                    Some("2-digit"),
-                    Some("2-digit"),
-                ),
-                TemporalLocaleCtx::PlainYearMonth => (
-                    None,
-                    None,
-                    Some("numeric"),
-                    Some("numeric"),
-                    None,
                     None,
                     None,
                     None,
                 ),
-                TemporalLocaleCtx::PlainMonthDay => (
-                    None,
+                TemporalLocaleCtx::ZonedDateTime => (
                     None,
                     None,
                     Some("numeric"),
                     Some("numeric"),
-                    None,
-                    None,
-                    None,
+                    Some("numeric"),
+                    Some("numeric"),
+                    Some("2-digit"),
+                    Some("2-digit"),
                 ),
             }
         };


### PR DESCRIPTION
## Summary

Fixes a spec compliance bug in \`Intl.DateTimeFormat\` constructor option parsing.

Per ECMA-402 §11.1.2 (\`ToDateTimeOptions\`) steps 38a/38b, the \`needDefaults\` flag — which triggers year/month/day defaults when no date/time component is specified — is controlled only by:

> **date fields**: weekday, year, month, day  
> **time fields**: dayPeriod, hour, minute, second, fractionalSecondDigits

\`era\` and \`timeZoneName\` are explicitly absent from those lists.  Before this fix, both options incorrectly set \`any_component = true\`, so a DTF constructed with only \`{ era: "narrow" }\` or only \`{ timeZoneName: "short" }\` would have **no** date or time components stored and no defaults applied — the formatter fell through to an unspecified fallback path.

After the fix, an era-only or timeZoneName-only DTF still receives the standard year/month/day defaults (spec step 40), which matches the behaviour specified in ECMA-402 and observed in V8/SpiderMonkey.

## Changed files

- \`crates/perry-runtime/src/intl.rs\` — drop \`any_component |=\` for \`era\` and \`timeZoneName\` in \`make_instance\`; add spec citation comment

## Test plan

- [ ] CI lint + cargo-test
- [ ] test262 \`intl402/DateTimeFormat\` suite for no regression (specifically \`temporal-objects-format-with-era.js\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date and time formatting so default year/month/day fields are applied more consistently.
  * Updated option handling to more accurately detect `dateStyle`/`timeStyle` conflicts when explicit component options are provided, including `era` and time zone name settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->