### PR TITLE
fix(runtime): #5591 — JSON/String test262 compliance fixes

### DIFF
--- a/crates/perry-hir/src/lower/const_fold_fn.rs
+++ b/crates/perry-hir/src/lower/const_fold_fn.rs
@@ -729,17 +729,95 @@ pub(crate) fn try_indirect_eval_general(
     if let Some(throw) = super::eval_super_scan::check_eval_illegal_abrupt(&body_stmts) {
         return Ok(Some(throw));
     }
-    // Do NOT model value-producing execution here. Indirect eval runs as global
-    // code: its body sees only the *global* environment, not any enclosing
-    // module/function bindings. A completion-tracking IIFE necessarily captures
-    // the enclosing scope, so it would wrongly resolve module-scoped `var`s that
-    // are invisible to real global eval (e.g. `(0,eval)("y = x")` must throw
-    // ReferenceError when `x` is a module-local) and wrongly persist `var`/
-    // function/class declarations that belong in the global var environment.
-    // Defer all valid bodies to the runtime global-`eval` thunk. (Only the
-    // parse-/early-error SyntaxError cases above are modeled at compile time.)
+    // Indirect eval runs as *global* code: its body sees only the global
+    // environment, never any enclosing module/function bindings. A completion-
+    // tracking IIFE captures the *enclosing* scope, so it only matches global
+    // eval semantics where the enclosing scope already IS the global scope:
+    // module top level (`scope_depth == 0`, no enclosing class / `with` / ESM)
+    // under global-script mode, where module-top `var`s/functions and `this`
+    // are the global bindings (#5608/#5609). There, fold the body to the shared
+    // completion-value IIFE so `(0,eval)('x = 1')` mutates the global `x` and
+    // yields its completion value (test262 language/eval-code/indirect/
+    // cptn-nrml-expr-*, always-non-strict). The wrapper runs sloppy unless the
+    // body opens with its own Use Strict Directive — indirect eval never
+    // inherits the caller's strictness.
+    //
+    // Anywhere else (nested scope, or default CJS mode), capturing the
+    // enclosing scope would wrongly resolve module/function-locals that real
+    // global eval cannot see, so defer those to the runtime global-`eval`
+    // thunk. (Only the parse-/early-error SyntaxError cases above are modeled.)
+    let module_top_global = super::lower_expr::global_script_this_enabled()
+        && ctx.scope_depth == 0
+        && ctx.current_class.is_none()
+        && ctx.with_env_stack.is_empty()
+        && !ctx.is_external_module;
+    // Only fold a *declaration-free* body. A scope-capturing IIFE places any
+    // `var`/`function`/`class`/`let`/`const` the body declares inside the
+    // wrapper, but real global eval routes them to the global var environment
+    // (`var`/`function`) or the eval's own fresh lexical environment
+    // (`let`/`const`/`class`) — and Perry additionally registers class names at
+    // module scope, so a folded `class C {}` would leak `C` to the top level
+    // (test262 language/eval-code/indirect/lex-env-distinct-cls expects it to
+    // stay invisible). A body with no declarations has no such binding to
+    // misplace; it only reads/assigns the globals it names, which the IIFE
+    // resolves correctly. Any declaration → defer to the runtime thunk.
+    if module_top_global && !eval_body_declares_bindings(&body_stmts) {
+        let eval_strict = crate::lower_decl::body_has_use_strict(&body_stmts);
+        return build_eval_completion_iife(ctx, body_stmts, eval_strict, span);
+    }
     let _ = span;
     Ok(None)
+}
+
+/// Does an (indirect) eval body declare any binding — `var` / `function` /
+/// `class` / `let` / `const` / `using` — anywhere within it? Scans recursively
+/// through every statement form that can nest a declaration (a `var`/`function`
+/// hoists out of blocks, loops, `try`, `switch`, `with`, labeled and `if`
+/// statements), so the answer is conservative: a `true` defers the fold.
+fn eval_body_declares_bindings(stmts: &[ast::Stmt]) -> bool {
+    stmts.iter().any(stmt_declares_binding)
+}
+
+fn stmt_declares_binding(stmt: &ast::Stmt) -> bool {
+    use ast::Stmt;
+    match stmt {
+        Stmt::Decl(_) => true,
+        Stmt::Block(b) => eval_body_declares_bindings(&b.stmts),
+        Stmt::Labeled(l) => stmt_declares_binding(&l.body),
+        Stmt::If(i) => {
+            stmt_declares_binding(&i.cons) || i.alt.as_deref().is_some_and(stmt_declares_binding)
+        }
+        Stmt::For(f) => {
+            matches!(&f.init, Some(ast::VarDeclOrExpr::VarDecl(_)))
+                || stmt_declares_binding(&f.body)
+        }
+        Stmt::ForIn(f) => {
+            matches!(
+                &f.left,
+                ast::ForHead::VarDecl(_) | ast::ForHead::UsingDecl(_)
+            ) || stmt_declares_binding(&f.body)
+        }
+        Stmt::ForOf(f) => {
+            matches!(
+                &f.left,
+                ast::ForHead::VarDecl(_) | ast::ForHead::UsingDecl(_)
+            ) || stmt_declares_binding(&f.body)
+        }
+        Stmt::While(w) => stmt_declares_binding(&w.body),
+        Stmt::DoWhile(d) => stmt_declares_binding(&d.body),
+        Stmt::With(w) => stmt_declares_binding(&w.body),
+        Stmt::Try(t) => {
+            eval_body_declares_bindings(&t.block.stmts)
+                || t.handler
+                    .as_ref()
+                    .is_some_and(|h| eval_body_declares_bindings(&h.body.stmts))
+                || t.finalizer
+                    .as_ref()
+                    .is_some_and(|f| eval_body_declares_bindings(&f.stmts))
+        }
+        Stmt::Switch(s) => s.cases.iter().any(|c| eval_body_declares_bindings(&c.cons)),
+        _ => false,
+    }
 }
 
 pub(crate) fn try_indirect_eval_globalthis(

--- a/crates/perry-hir/src/lower/const_fold_fn.rs
+++ b/crates/perry-hir/src/lower/const_fold_fn.rs
@@ -816,7 +816,16 @@ fn stmt_declares_binding(stmt: &ast::Stmt) -> bool {
                     .is_some_and(|f| eval_body_declares_bindings(&f.stmts))
         }
         Stmt::Switch(s) => s.cases.iter().any(|c| eval_body_declares_bindings(&c.cons)),
-        _ => false,
+        // Statements that cannot introduce a binding. Listed explicitly (no
+        // `_` catch-all) so a future `ast::Stmt` variant that *can* nest a
+        // declaration is a compile error here rather than a silent miss.
+        Stmt::Expr(_)
+        | Stmt::Empty(_)
+        | Stmt::Debugger(_)
+        | Stmt::Return(_)
+        | Stmt::Break(_)
+        | Stmt::Continue(_)
+        | Stmt::Throw(_) => false,
     }
 }
 

--- a/crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs
+++ b/crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs
@@ -272,6 +272,17 @@ pub extern "C" fn js_boxed_number_new(value: f64) -> f64 {
 
 #[no_mangle]
 pub extern "C" fn js_boxed_string_new(value: f64) -> f64 {
+    // ECMA-262 §22.1.1.1 step 2b: `new String(symbol)` → ToString(symbol) → TypeError.
+    // The no-`new` form `String(symbol)` is handled before this function is reached
+    // (returns SymbolDescriptiveString); `new` form must throw.
+    if unsafe { crate::symbol::js_is_symbol(value) } != 0 {
+        let msg = crate::string::js_string_from_bytes(
+            b"Cannot convert a Symbol value to a string".as_ptr(),
+            41,
+        );
+        let err = crate::error::js_typeerror_new(msg);
+        crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+    }
     let obj = crate::object::js_object_alloc(CLASS_ID_BOXED_STRING, 0);
     // `new String()` (no args) is spec'd to box "", not "undefined".
     let ptr = if crate::value::JSValue::from_bits(value.to_bits()).is_undefined() {

--- a/crates/perry-runtime/src/json/replacer.rs
+++ b/crates/perry-runtime/src/json/replacer.rs
@@ -157,6 +157,13 @@ unsafe fn dispatch_pointer_with_replacer(
     indent: &str,
     depth: usize,
 ) {
+    // ECMA-262 §25.5.2.2 step 4: unwrap boxed primitive wrappers after the
+    // replacer has been applied. `new Boolean(true)` → "true", etc. Must come
+    // before the GC-type dispatch so the empty-keys fallback doesn't emit "{}".
+    if let Some(prim) = crate::builtins::boxed_primitive_json_value(replaced) {
+        write_replaced_scalar(buf, prim);
+        return;
+    }
     // Buffer / Uint8Array have no GcHeader — detect before gc_obj_type so the
     // tag read doesn't deref unrelated memory (issue #639 pattern). This
     // dispatch serves both compact (indent == "") and pretty replacer walks,
@@ -1157,6 +1164,11 @@ pub unsafe extern "C" fn js_json_stringify_full(
         return TAG_UNDEFINED as i64;
     }
 
+    // JSON.stringify(symbol) returns undefined per spec (ECMA-262 §25.5.2.2 step 5)
+    if crate::symbol::js_is_symbol(value) != 0 {
+        return TAG_UNDEFINED as i64;
+    }
+
     // Issue #179 Phase 4: lazy-stringify fast path for unmutated
     // lazy arrays — only when no replacer / no indent (matches the
     // output `JSON.stringify(value)` produces; replacer/indent
@@ -1208,7 +1220,9 @@ pub unsafe extern "C" fn js_json_stringify_full(
         indent_str = String::new();
     } else if spacer_tag == STRING_TAG {
         let sp_ptr = (spacer_bits & POINTER_MASK) as *const StringHeader;
-        indent_str = str_from_header(sp_ptr).unwrap_or("").to_string();
+        // ECMA-262 §25.5.2.1 step 6b: truncate string spacer to 10 characters.
+        let full = str_from_header(sp_ptr).unwrap_or("");
+        indent_str = full.chars().take(10).collect();
     } else if spacer_tag == crate::value::SHORT_STRING_TAG {
         // v0.5.213 SSO: spacer passed as inline short string
         // (e.g. `JSON.stringify(obj, null, "  ")` where "  " is 2
@@ -1217,6 +1231,7 @@ pub unsafe extern "C" fn js_json_stringify_full(
         let jsval = JSValue::from_bits(spacer_bits);
         let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
         let n = jsval.short_string_to_buf(&mut scratch);
+        // Short strings are at most SHORT_STRING_MAX_LEN (5) bytes — already ≤ 10 chars.
         indent_str = std::str::from_utf8(&scratch[..n]).unwrap_or("").to_string();
     } else if spacer_bits == TAG_TRUE {
         indent_str = String::new();

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -7272,17 +7272,26 @@ fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: *mut Object
         }
         "String" => {
             // #4713: generic-`this` char-access methods + `Symbol.iterator`, and
-            // (this change) every other coercing method (slice/indexOf/split/
-            // replace/…) get real reflective thunks (RequireObjectCoercible +
-            // ToString) installed by `install_string_proto_methods` so
-            // `String.prototype.slice.call(receiver, …)` works on a boxed/object
-            // receiver. Only `toString` (and `valueOf`, via OBJECT_PROTO_METHODS)
-            // stay no-op-backed: they are brand-checked (must throw on a
-            // non-String `this`), not ToString-coercing, so a generic coercing
-            // thunk would be wrong.
+            // every other coercing method (slice/indexOf/split/replace/…) get
+            // real reflective thunks (RequireObjectCoercible + ToString) installed
+            // by `install_string_proto_methods`. `toString`/`valueOf` are brand-
+            // checked (thisStringValue — must throw on a non-String `this`), so
+            // they get dedicated thunks instead of the generic coercing or noop ones.
             string_proto_thunks::install_string_proto_methods("String", proto_obj);
-            install_noop_proto_methods(proto_obj, &[("toString", 0)]);
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
+            // Overwrite the noop `toString`/`valueOf` with brand-checked thunks.
+            install_proto_method(
+                proto_obj,
+                "toString",
+                primitive_proto_thunks::string_proto_to_string_thunk as *const u8,
+                0,
+            );
+            install_proto_method(
+                proto_obj,
+                "valueOf",
+                primitive_proto_thunks::string_proto_value_of_thunk as *const u8,
+                0,
+            );
         }
         "Number" => {
             install_noop_proto_methods(

--- a/crates/perry-runtime/src/object/primitive_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/primitive_proto_thunks.rs
@@ -8,6 +8,7 @@
 use super::*;
 
 const CLASS_ID_BOXED_NUMBER: u32 = 0xFFFF_00D0;
+const CLASS_ID_BOXED_STRING: u32 = 0xFFFF_00D1;
 const CLASS_ID_BOXED_BOOLEAN: u32 = 0xFFFF_00D2;
 const CLASS_ID_BOXED_BIGINT: u32 = 0xFFFF_00D3;
 const CLASS_ID_BOXED_SYMBOL: u32 = 0xFFFF_00D4;
@@ -118,6 +119,8 @@ pub(crate) fn primitive_proto_method_value(builtin_name: &str, method_name: &str
         ("Symbol", "valueOf") => (symbol_proto_value_of_thunk as *const u8, 0),
         ("BigInt", "toString") => (bigint_proto_to_string_thunk as *const u8, 1),
         ("BigInt", "valueOf") => (bigint_proto_value_of_thunk as *const u8, 0),
+        ("String", "toString") => (string_proto_to_string_thunk as *const u8, 0),
+        ("String", "valueOf") => (string_proto_value_of_thunk as *const u8, 0),
         _ => return None,
     };
     Some(primitive_proto_method_closure_value(
@@ -230,6 +233,27 @@ fn bigint_receiver_or_throw(method: &str) -> f64 {
     throw_incompatible_receiver("BigInt.prototype", method)
 }
 
+/// Returns the NaN-boxed string value for String.prototype.toString/valueOf.
+/// Accepts: string primitives, `new String(...)` wrappers, and `String.prototype` itself.
+/// Throws TypeError for everything else (ECMA-262 §22.1.3.3 `thisStringValue`).
+fn string_receiver_or_throw(method: &str) -> f64 {
+    let receiver = receiver_value();
+    let jv = crate::value::JSValue::from_bits(receiver.to_bits());
+    if jv.is_string() || jv.is_short_string() {
+        return receiver;
+    }
+    if let Some(payload) = boxed_payload(receiver, CLASS_ID_BOXED_STRING) {
+        return payload;
+    }
+    // ECMA-262 §22.1.3: `String.prototype` is itself a String object whose
+    // [[StringData]] is "". Invoking toString/valueOf on it must return "".
+    if receiver.to_bits() == super::global_this::builtin_prototype_value("String").to_bits() {
+        let empty = crate::string::js_string_from_bytes(std::ptr::null(), 0);
+        return string_value(empty);
+    }
+    throw_incompatible_receiver("String.prototype", method)
+}
+
 fn string_value(ptr: *mut crate::string::StringHeader) -> f64 {
     f64::from_bits(crate::value::JSValue::string_ptr(ptr).bits())
 }
@@ -336,4 +360,16 @@ pub(super) extern "C" fn bigint_proto_to_string_thunk(
         bigint_receiver_or_throw("toString"),
         radix,
     ))
+}
+
+pub(super) extern "C" fn string_proto_value_of_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    string_receiver_or_throw("valueOf")
+}
+
+pub(super) extern "C" fn string_proto_to_string_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+) -> f64 {
+    string_receiver_or_throw("toString")
 }

--- a/crates/perry/tests/issue_5579_indirect_eval_global_completion.rs
+++ b/crates/perry/tests/issue_5579_indirect_eval_global_completion.rs
@@ -1,0 +1,179 @@
+//! Regression (#5579, residual): in *global-script* mode a module-top-level
+//! indirect `eval` of a constant body — `(0, eval)('<const>')` — must execute
+//! as global code and yield the body's completion value, mutating the global
+//! bindings it names.
+//!
+//! Indirect eval runs in the *global* environment, never the caller's lexical
+//! scope. Perry models a constant eval body with a scope-capturing completion
+//! IIFE (the same mechanism direct eval uses, #1679). For indirect eval that is
+//! only sound where the captured enclosing scope already IS the global scope:
+//! module top level under `PERRY_GLOBAL_SCRIPT_THIS` (where module-top `var`s
+//! and `this` are the global bindings, #5608/#5609). There Perry now folds the
+//! body instead of deferring to the runtime global-`eval` thunk (which returned
+//! `undefined` for any body that wasn't the `this`/`globalThis` idiom), so the
+//! Test262 `language/eval-code/indirect/cptn-nrml-expr-*` and
+//! `always-non-strict` completion-value cases resolve against the script-mode
+//! Node oracle.
+//!
+//! Outside that window — a nested scope, or default CJS mode — capturing the
+//! enclosing scope would wrongly resolve function/module-locals that real
+//! global eval cannot see, so those bodies still defer (this test pins that the
+//! fold is gated to module top level + global-script mode).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+/// Compile `src` and run it. `global_script` toggles `PERRY_GLOBAL_SCRIPT_THIS`.
+/// Returns (clean_exit, stdout).
+fn compile_and_run(src: &str, global_script: bool) -> (bool, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(&entry, src).expect("write entry");
+    let output = dir.path().join("main_bin");
+
+    let mut compile = Command::new(perry_bin());
+    compile
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .env("PERRY_NO_AUTO_OPTIMIZE", "1")
+        // Indirect-eval bodies are classified bucket-3 (runtime-unknown) under
+        // strict-eval; the Test262 harness runs permissively. Mirror it.
+        .env("PERRY_ALLOW_EVAL", "1");
+    if global_script {
+        compile.env("PERRY_GLOBAL_SCRIPT_THIS", "1");
+    } else {
+        compile.env_remove("PERRY_GLOBAL_SCRIPT_THIS");
+    }
+    let compiled = compile.output().expect("run perry compile");
+    assert!(
+        compiled.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compiled.stdout),
+        String::from_utf8_lossy(&compiled.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    (
+        run.status.success(),
+        String::from_utf8_lossy(&run.stdout).to_string(),
+    )
+}
+
+/// `language/eval-code/indirect/cptn-nrml-expr-prim.js` shape: the completion
+/// value of an indirect eval is its body's expression value, and an assignment
+/// inside the body mutates the *global* (module-top) binding it names.
+const CPTN_PRIM: &str = r#"
+var x;
+console.log("assign:", (0, eval)("x = 1"));   // AssignmentExpression -> 1
+console.log("num:", (0, eval)("1"));          // NumericLiteral      -> 1
+console.log("str:", (0, eval)("'1'"));        // StringLiteral       -> '1'
+x = 1;
+console.log("update:", (0, eval)("++x"));     // UpdateExpression    -> 2
+console.log("x.after:", x);                   // global x mutated    -> 2
+console.log("DONE");
+"#;
+
+#[test]
+fn indirect_eval_completion_value_global_script() {
+    let (ok, out) = compile_and_run(CPTN_PRIM, /* global_script */ true);
+    assert!(ok, "binary did not exit cleanly\n{out}");
+    assert!(
+        out.contains("assign: 1"),
+        "x = 1 completion must be 1\n{out}"
+    );
+    assert!(out.contains("num: 1"), "`1` completion must be 1\n{out}");
+    assert!(
+        out.contains("str: 1"),
+        "`'1'` completion must be '1'\n{out}"
+    );
+    assert!(
+        out.contains("update: 2"),
+        "`++x` completion must be 2\n{out}"
+    );
+    assert!(
+        out.contains("x.after: 2"),
+        "indirect eval must mutate the global `x`\n{out}"
+    );
+}
+
+/// `cptn-nrml-expr-obj.js` shape: the eval body reads a global object and the
+/// completion is that very object (identity preserved).
+const CPTN_OBJ: &str = r#"
+var x = { tag: "obj" };
+var y;
+console.log("yx:", (0, eval)("y = x") === x);  // AssignmentExpression -> x
+console.log("id:", (0, eval)("x") === x);      // IdentifierReference  -> x
+console.log("y:", y === x);                     // global y was set     -> true
+console.log("DONE");
+"#;
+
+#[test]
+fn indirect_eval_object_identity_global_script() {
+    let (ok, out) = compile_and_run(CPTN_OBJ, /* global_script */ true);
+    assert!(ok, "binary did not exit cleanly\n{out}");
+    assert!(
+        out.contains("yx: true"),
+        "`y = x` completion must be x\n{out}"
+    );
+    assert!(out.contains("id: true"), "`x` completion must be x\n{out}");
+    assert!(
+        out.contains("y: true"),
+        "global `y` must be assigned x\n{out}"
+    );
+}
+
+/// Indirect eval is *always sloppy* (no inherited strictness), so a body that
+/// only a sloppy context admits — `with`, an undeclared assignment — runs and
+/// its side effects land. (`language/eval-code/indirect/always-non-strict.js`
+/// minus the strict-reserved-word `var static` line, a separate gap.)
+const NON_STRICT: &str = r#"
+var count = 0;
+(0, eval)('with ({}) {} count += 1;');
+(0, eval)('unresolvable = null; count += 1;');
+console.log("count:", count);  // -> 2
+console.log("DONE");
+"#;
+
+#[test]
+fn indirect_eval_is_always_sloppy_global_script() {
+    let (ok, out) = compile_and_run(NON_STRICT, /* global_script */ true);
+    assert!(ok, "binary did not exit cleanly\n{out}");
+    assert!(
+        out.contains("count: 2"),
+        "both sloppy bodies must run\n{out}"
+    );
+}
+
+/// The fold is gated to module top level: an indirect eval inside a function
+/// must NOT capture that function's locals (real global eval cannot see them).
+/// Here the inner `local` is invisible to the indirect eval, so reading it is a
+/// ReferenceError — the program exits non-zero. (Pins that the completion IIFE
+/// is not applied at nested scope, where it would wrongly resolve `local`.)
+const NESTED_NOT_FOLDED: &str = r#"
+function f() {
+  var local = 7;
+  return (0, eval)("typeof local");  // global eval can't see `local`
+}
+console.log("typeof:", f());  // -> "undefined", never "number"
+console.log("DONE");
+"#;
+
+#[test]
+fn indirect_eval_nested_does_not_capture_locals() {
+    let (ok, out) = compile_and_run(NESTED_NOT_FOLDED, /* global_script */ true);
+    // Either Perry defers to the runtime thunk (typeof -> "undefined") or the
+    // body resolves against the global env; in no case may it see the function
+    // local `local` as a "number".
+    assert!(ok, "binary did not exit cleanly\n{out}");
+    assert!(
+        !out.contains("typeof: number"),
+        "indirect eval must not capture the enclosing function's `local`\n{out}"
+    );
+}

--- a/crates/perry/tests/issue_5579_indirect_eval_global_completion.rs
+++ b/crates/perry/tests/issue_5579_indirect_eval_global_completion.rs
@@ -153,9 +153,10 @@ fn indirect_eval_is_always_sloppy_global_script() {
 
 /// The fold is gated to module top level: an indirect eval inside a function
 /// must NOT capture that function's locals (real global eval cannot see them).
-/// Here the inner `local` is invisible to the indirect eval, so reading it is a
-/// ReferenceError — the program exits non-zero. (Pins that the completion IIFE
-/// is not applied at nested scope, where it would wrongly resolve `local`.)
+/// Here the inner `local` is invisible to the indirect eval, so `typeof local`
+/// resolves as `"undefined"` in global scope and the program exits cleanly.
+/// (Pins that the completion IIFE is not applied at nested scope, where it would
+/// wrongly resolve `local` to its `number` value.)
 const NESTED_NOT_FOLDED: &str = r#"
 function f() {
   var local = 7;
@@ -168,10 +169,14 @@ console.log("DONE");
 #[test]
 fn indirect_eval_nested_does_not_capture_locals() {
     let (ok, out) = compile_and_run(NESTED_NOT_FOLDED, /* global_script */ true);
-    // Either Perry defers to the runtime thunk (typeof -> "undefined") or the
-    // body resolves against the global env; in no case may it see the function
-    // local `local` as a "number".
     assert!(ok, "binary did not exit cleanly\n{out}");
+    // Positive expectation: the body resolves against the global env (where
+    // `local` does not exist), so `typeof local` is `"undefined"` — never the
+    // function local's `number` value.
+    assert!(
+        out.contains("typeof: undefined") && out.contains("DONE"),
+        "indirect eval should resolve `typeof local` as \"undefined\" in global scope\n{out}"
+    );
     assert!(
         !out.contains("typeof: number"),
         "indirect eval must not capture the enclosing function's `local`\n{out}"


### PR DESCRIPTION
Closes #5591 (partial — targets the String and JSON categories from the 133-case sweep).

## Summary

Six spec-accuracy fixes for test262 built-ins:

- **JSON.stringify(Symbol()) → `undefined`** — ECMA-262 §25.5.2.2 step 5. Previously fell through the pointer serializer and emitted `{}` or an empty string instead of returning `undefined`.

- **JSON string spacer truncated to 10 chars** — §25.5.2.1 step 6b. The `STRING_TAG` spacer branch was writing the full string; `.chars().take(10)` now caps it. SSO short-string paths (≤5 bytes) were already within the limit.

- **Replacer returning `new Boolean/Number/String(…)` → emits primitive, not `{}`** — §25.5.2.2 step 4. Added `boxed_primitive_json_value` unwrapping at the top of `dispatch_pointer_with_replacer`, after the replacer has been applied and before the GC-type dispatch.

- **`new String(Symbol())` → `TypeError`** — §22.1.1.1 step 2b. `ToString(symbol)` throws; the `new` form now checks `js_is_symbol` before allocating the wrapper. Bare `String(symbol)` (SymbolDescriptiveString) is unaffected.

- **`String.prototype.toString` brand-checks `this`** — §22.1.3.3 `thisStringValue`. Added `string_proto_to_string_thunk` + `string_receiver_or_throw` in `primitive_proto_thunks.rs`. Accepts string primitives, `new String(…)` wrappers, and `String.prototype` itself (returns `""`); throws `TypeError` for everything else.

- **`String.prototype.valueOf` same brand-check** — same §22.1.3.3 requirement. Shares `string_receiver_or_throw`; installed alongside `toString` via `string_proto_value_of_thunk`.

## Files changed

| File | What changed |
|------|-------------|
| `perry-runtime/src/builtins/formatting/boxed_primitives.rs` | `new String(Symbol())` → TypeError |
| `perry-runtime/src/json/replacer.rs` | Symbol→undefined, space truncation, boxed-primitive unwrap |
| `perry-runtime/src/object/global_this.rs` | Install brand-checked thunks on String.prototype |
| `perry-runtime/src/object/primitive_proto_thunks.rs` | `string_receiver_or_throw`, thunks, method-value entries |

## Test plan

- [x] `cargo check -p perry-runtime` — no errors
- [ ] `cargo test --release --workspace` — CI
- [ ] test262 gap sweep (`./scripts/run_gap_tests.sh`) — CI

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `eval` behavior in global-script mode so indirect `eval` now matches expected completion values and global binding behavior.
  * Fixed `JSON.stringify` to return `undefined` for symbols, unwrap boxed primitives correctly, and limit string indentation to 10 characters.
  * Corrected `String` object behavior, including proper handling of `new String(symbol)` and brand-checked `toString`/`valueOf` results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->