### PR TITLE
fix(hir): indirect eval in class field initializers sees global scope (#5592)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.5.1209 — fix(hir): #5592 — indirect eval in class field initializers folds to global-scope IIFE
+
+`eval_is_module_top_global` in `const_fold_fn.rs` blocked the completion-IIFE fold with a `ctx.current_class.is_none()` guard. Class field initializers at module top level do not create a new variable environment — `scope_depth` stays 0 and the enclosing scope is still the global scope in global-script mode. The guard was overly conservative: class *methods* are already excluded by the `scope_depth == 0` check (methods call `enter_scope()`). Removing the `current_class` guard fixes four test262 cases: `language/{statements,expressions}/class/elements/{,private-}indirect-eval-contains-arguments`. Two regression tests added to `issue_5579_indirect_eval_global_completion.rs`.
+
 ## v0.5.1208 — test(net): #5540 — lock in Map-stored `socket.write()` from a `setInterval` callback reaching the wire
 
 Issue #5540 reported that `socket.write(buf)` was silently dropped (no `sendto`, bytes never hit the wire) when the socket was reached through a property of a `Map`-stored object **and** the write was issued from a timer (`setInterval`) callback — the exact pattern `@perryts/mysql`'s deferred flush pump uses (`CONN_STATES.get(id).sock.write(bytes)`), so password auth timed out. It was distinct from #5021 (write-from-`'data'`-handler) and #91 (Map-retrieved write from a `'data'` handler), both already fixed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1208
+**Current Version:** 0.5.1209
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5306,7 +5306,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "anyhow",
  "base64",
@@ -5363,14 +5363,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "cc",
  "libc",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "anyhow",
  "log",
@@ -5393,7 +5393,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5402,7 +5402,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5410,7 +5410,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5420,7 +5420,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "anyhow",
  "base64",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5450,7 +5450,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5479,14 +5479,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "serde",
  "serde_json",
@@ -5494,7 +5494,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1208"
+version = "0.5.1209"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5505,7 +5505,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "anyhow",
  "clap",
@@ -5520,7 +5520,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "block2",
  "objc2",
@@ -5530,7 +5530,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5538,7 +5538,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5547,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5555,7 +5555,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5563,7 +5563,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5571,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "chrono",
  "cron",
@@ -5589,7 +5589,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5597,7 +5597,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5605,7 +5605,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5613,7 +5613,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5621,7 +5621,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5629,14 +5629,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5654,7 +5654,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5667,7 +5667,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5681,7 +5681,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "bytes",
  "h2",
@@ -5704,7 +5704,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5714,7 +5714,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5725,7 +5725,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5733,7 +5733,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5741,7 +5741,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "bson",
  "futures-util",
@@ -5753,7 +5753,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5763,7 +5763,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -5785,7 +5785,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5795,7 +5795,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5803,7 +5803,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5812,7 +5812,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5820,7 +5820,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -5830,14 +5830,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5846,7 +5846,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5854,7 +5854,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5864,7 +5864,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5876,7 +5876,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "brotli",
  "flate2",
@@ -5885,7 +5885,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5894,7 +5894,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5912,7 +5912,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5924,7 +5924,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "anyhow",
  "base64",
@@ -5957,14 +5957,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6056,14 +6056,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6073,7 +6073,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6081,14 +6081,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "base64",
  "itoa",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6115,7 +6115,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6138,7 +6138,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "base64",
  "block2",
@@ -6154,7 +6154,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "base64",
  "block2",
@@ -6169,7 +6169,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1208"
+version = "0.5.1209"
 
 [[package]]
 name = "perry-ui-test"
@@ -6177,11 +6177,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1208"
+version = "0.5.1209"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "base64",
  "block2",
@@ -6197,7 +6197,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "base64",
  "block2",
@@ -6213,7 +6213,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "block2",
  "libc",
@@ -6226,7 +6226,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "base64",
  "libc",
@@ -6243,14 +6243,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6264,7 +6264,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1208"
+version = "0.5.1209"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -301,7 +301,7 @@ strip = false
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1208"
+version = "0.5.1209"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-hir/src/lower/const_fold_fn.rs
+++ b/crates/perry-hir/src/lower/const_fold_fn.rs
@@ -756,7 +756,7 @@ pub(crate) fn try_indirect_eval_general(
     // environment, never any enclosing module/function bindings. A completion-
     // tracking IIFE captures the *enclosing* scope, so it only matches global
     // eval semantics where the enclosing scope already IS the global scope:
-    // module top level (`scope_depth == 0`, no enclosing class / `with` / ESM)
+    // module top level (`scope_depth == 0`, no `with` / ESM)
     // under global-script mode, where module-top `var`s/functions and `this`
     // are the global bindings (#5608/#5609). There, fold the body to the shared
     // completion-value IIFE so `(0,eval)('x = 1')` mutates the global `x` and
@@ -1614,9 +1614,16 @@ fn try_const_fold_eval(
 /// place the Annex B.3.3.3 global var-scoped hoisting ([`apply_global_eval_hoist`])
 /// applies? (Mirrors the `module_top_this`/`module_top_global` guards.)
 fn eval_is_module_top_global(ctx: &LoweringContext) -> bool {
+    // `current_class` may be set when we are inside a class field initializer
+    // that is at module top level (`scope_depth == 0`). That context does not
+    // create a new variable environment — the enclosing scope is still the
+    // global scope in global-script mode. Class methods do enter their own
+    // scope (scope_depth >= 1), so they are excluded by the scope_depth check.
+    // Declaration-free bodies (checked by the caller) have no bindings to
+    // misplace, so the IIFE captures only global reads/writes — correct for
+    // global indirect eval semantics (#5592).
     super::lower_expr::global_script_this_enabled()
         && ctx.scope_depth == 0
-        && ctx.current_class.is_none()
         && ctx.with_env_stack.is_empty()
         && !ctx.is_external_module
 }

--- a/crates/perry/tests/issue_5579_indirect_eval_global_completion.rs
+++ b/crates/perry/tests/issue_5579_indirect_eval_global_completion.rs
@@ -260,3 +260,56 @@ fn eval_declaration_completion_is_empty_global_script() {
         "`function fn(){{}}{{}}` -> undefined\n{out}"
     );
 }
+
+/// Regression (#5592): `(0, eval)('arguments;')` inside a class field
+/// initializer (at module top level) must see the global `arguments` binding,
+/// not produce `undefined`. The fold was blocked by a `current_class.is_none()`
+/// guard in `eval_is_module_top_global`; class field initializers don't create a
+/// new variable environment so the guard was overly conservative.
+const CLASS_FIELD_INDIRECT_EVAL_ARGUMENTS: &str = r#"
+var arguments = 1;
+class C {
+  x = (0, eval)('arguments;');
+}
+var result = new C().x;
+console.log("result:", result);
+console.log("DONE");
+"#;
+
+#[test]
+fn indirect_eval_in_class_field_sees_global_arguments() {
+    let (ok, out) = compile_and_run(
+        CLASS_FIELD_INDIRECT_EVAL_ARGUMENTS,
+        /* global_script */ true,
+    );
+    assert!(ok, "binary did not exit cleanly\n{out}");
+    assert!(
+        out.contains("result: 1"),
+        "indirect eval in class field must see global `arguments = 1`\n{out}"
+    );
+}
+
+/// Same as above but with a private class field (#5592, private variant).
+const PRIVATE_CLASS_FIELD_INDIRECT_EVAL_ARGUMENTS: &str = r#"
+var arguments = 1;
+class C {
+  #x = (0, eval)('arguments;');
+  getX() { return this.#x; }
+}
+var result = new C().getX();
+console.log("result:", result);
+console.log("DONE");
+"#;
+
+#[test]
+fn indirect_eval_in_private_class_field_sees_global_arguments() {
+    let (ok, out) = compile_and_run(
+        PRIVATE_CLASS_FIELD_INDIRECT_EVAL_ARGUMENTS,
+        /* global_script */ true,
+    );
+    assert!(ok, "binary did not exit cleanly\n{out}");
+    assert!(
+        out.contains("result: 1"),
+        "indirect eval in private class field must see global `arguments = 1`\n{out}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes 4 test262 failures under `language/{statements,expressions}/class/elements/`:

- `indirect-eval-contains-arguments`
- `private-indirect-eval-contains-arguments`

### Root cause

`eval_is_module_top_global` in `const_fold_fn.rs` checked `ctx.current_class.is_none()` before allowing the completion-IIFE fold for indirect eval bodies. But class field initializers at module top level **don't create a new variable environment** — the enclosing scope is still the global scope in global-script mode. As a result, `(0, eval)('arguments;')` inside `class C { x = (0, eval)('arguments;') }` returned `undefined` instead of the global `arguments` binding.

### Fix

Remove the `ctx.current_class.is_none()` guard from `eval_is_module_top_global`. The fold is already gated on `scope_depth == 0`, which excludes class *methods* (they call `enter_scope()` and increment `scope_depth`). Only class field initializers at module top level keep `scope_depth == 0`, so the relaxed predicate is safe. The fold also only applies to declaration-free eval bodies (enforced by the caller), so no bindings can leak.

### Tests

Added two regression tests to `issue_5579_indirect_eval_global_completion.rs`:
- `indirect_eval_in_class_field_sees_global_arguments`
- `indirect_eval_in_private_class_field_sees_global_arguments`

## Test plan

- [x] `cargo test --release -p perry-hir --lib` — 221 passed, 0 failed
- [ ] `cargo test --release -p perry --test issue_5579_indirect_eval_global_completion` (running)
- [ ] CI: `cargo-test`, `lint`, `api-docs-drift`, `security-audit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed indirect `eval` folding for class field initializers when running in global-script mode, so `(0, eval)('arguments;')` correctly resolves to the global `arguments` binding instead of producing `undefined`.
* **Tests**
  * Added regression coverage for both public and private class fields at module top level.
* **Chores / Documentation**
  * Updated the changelog and bumped the displayed version to `v0.5.1209`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->