### PR TITLE
fix(runtime,codegen): bitnot ToNumber coercion + modulus zero/sign-of-zero

### DIFF
--- a/crates/perry-codegen/src/expr/binary.rs
+++ b/crates/perry-codegen/src/expr/binary.rs
@@ -216,11 +216,16 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // fptosi, producing the wrong result. `is_integer_valued_expr`
             // only returns true when we can prove the value is a whole
             // number (integer literals, integer loop counters, or nested
-            // integer arithmetic). For everything else we fall through
-            // to the `frem` path.
+            // integer arithmetic). A zero RHS falls through to `frem`
+            // because srem(x,0) is UB in LLVM (on ARM the CPU silently
+            // gives 0, but JS requires NaN for any x % 0). For everything
+            // else we fall through to the `frem` path.
+            let right_is_known_zero = matches!(**right, Expr::Integer(0))
+                || matches!(**right, Expr::Number(v) if v == 0.0);
             if matches!(op, BinaryOp::Mod)
                 && crate::type_analysis::is_integer_valued_expr(ctx, left)
                 && crate::type_analysis::is_integer_valued_expr(ctx, right)
+                && !right_is_known_zero
             {
                 let l_raw = lower_expr(ctx, left)?;
                 let r_raw = lower_expr(ctx, right)?;
@@ -228,7 +233,16 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 let li = blk.fptosi(DOUBLE, &l_raw, I64);
                 let ri = blk.fptosi(DOUBLE, &r_raw, I64);
                 let m = blk.srem(I64, &li, &ri);
-                return Ok(blk.sitofp(I64, &m, DOUBLE));
+                // IEEE 754: when the integer remainder is 0 and the
+                // dividend was negative, the result must be -0.0.
+                // srem gives 0i64 → sitofp always produces +0.0,
+                // so correct: if m==0 && l<0 → fneg(0.0) = -0.0.
+                let result_f = blk.sitofp(I64, &m, DOUBLE);
+                let m_is_zero = blk.icmp_eq(I64, &m, "0");
+                let l_neg = blk.fcmp("olt", &l_raw, "0.0");
+                let need_neg = blk.and(I1, &m_is_zero, &l_neg);
+                let neg_result = blk.fneg(&result_f);
+                return Ok(blk.select(I1, &need_neg, DOUBLE, &neg_result, &result_f));
             }
 
             let (l_raw, l_fallback_coerced) = lower_arithmetic_operand(ctx, left)?;

--- a/crates/perry-runtime/src/value/dynamic_arith.rs
+++ b/crates/perry-runtime/src/value/dynamic_arith.rs
@@ -458,7 +458,13 @@ pub unsafe extern "C" fn js_dynamic_bitnot(a: f64) -> f64 {
         );
         return js_nanbox_bigint(result as i64);
     }
-    (!(a as i64 as i32)) as f64
+    // Apply ToNumber first so that ~"3", ~true, ~new Boolean(true), etc.
+    // coerce correctly before the ToInt32 truncation.
+    let a_num = crate::builtins::js_number_coerce(a);
+    // ES ToInt32: NaN, ±0, ±Infinity all map to 0; finite values use
+    // C-style i64 truncation (equivalent to modulo-2^32 + sign-extend).
+    let a_i32 = if a_num.is_nan() || !a_num.is_finite() { 0i32 } else { a_num as i64 as i32 };
+    (!a_i32) as f64
 }
 
 /// Dynamic right shift: BigInt >> if either operand is BigInt, else i32 >> for numbers.

--- a/crates/perry-runtime/src/value/dynamic_arith.rs
+++ b/crates/perry-runtime/src/value/dynamic_arith.rs
@@ -463,7 +463,11 @@ pub unsafe extern "C" fn js_dynamic_bitnot(a: f64) -> f64 {
     let a_num = crate::builtins::js_number_coerce(a);
     // ES ToInt32: NaN, ±0, ±Infinity all map to 0; finite values use
     // C-style i64 truncation (equivalent to modulo-2^32 + sign-extend).
-    let a_i32 = if a_num.is_nan() || !a_num.is_finite() { 0i32 } else { a_num as i64 as i32 };
+    let a_i32 = if a_num.is_nan() || !a_num.is_finite() {
+        0i32
+    } else {
+        a_num as i64 as i32
+    };
     (!a_i32) as f64
 }
 


### PR DESCRIPTION
## Summary

Fixes two spec compliance bugs found during the test262 grind (#5815):

### `~x` — `js_dynamic_bitnot` (runtime)

- **Missing ToNumber**: `~new Boolean(true)`, `~new String("3")`, `~{valueOf(){return 2}}` were treating the NaN-boxed pointer as `0` (yielding `-1`) instead of coercing through `js_number_coerce` first. Added `js_number_coerce(a)` before the `ToInt32` truncation.
- **Wrong ToInt32 for ±Infinity/NaN**: Rust's saturating `f64 as i64` gives `i64::MAX` for `+Infinity`, then `i64::MAX as i32 = -1`, so `~Infinity` returned `0` instead of `-1`. The ES spec says `ToInt32(±Infinity) = 0`, so `~Infinity = ~0 = -1`. Fixed with an explicit `if is_nan || !is_finite { 0i32 }` guard.

Fixes `S11.4.8_A2.2_T1`, `S11.4.8_A3_T1`, `S11.4.8_A3_T2`, `S11.4.8_A3_T3` → **100% parity on `language/expressions/bitwise-not`** (15/15).

### `x % y` — integer modulus fast path (codegen)

- **Zero-divisor UB**: `srem(x, 0)` is LLVM undefined behaviour (ARM silently gives `0`; JS requires `NaN` for `x % 0`). Added a `right_is_known_zero` guard that skips the `fptosi/srem` fast path when the RHS is a literal `0` or `0.0`, falling through to `frem` which is IEEE 754 correct.
- **Sign-of-zero**: `srem` always produces an integer `0`, and `sitofp` converts that to `+0.0`. JS requires `-0.0` when the dividend is negative (e.g. `-1 % -1 === -0`, checked via `1 / (-1 % -1) === -Infinity`). Fixed by emitting: `if m == 0 && l < 0.0 { fneg(0.0) } else { sitofp(m) }`.

Fixes `S11.5.3_A4_T2`, `S11.5.3_A4_T4`.

## Test plan

- [x] Manual test: `bitnot: -2 1 -2 -4` (was `-1 -1 -1 ...` for wrapper objects)
- [x] Manual test: `mod: -0 -Infinity NaN -Infinity` (was `0 Infinity 0 Infinity`)
- [x] `language/expressions/bitwise-not` test262 subset: 15/15 pass (was 11/15)
- [x] `language/expressions/modulus` test262 subset: 36/37 pass (remaining 1 is pre-existing `Object(1n) % 1` BigInt-wrapper TypeError, unrelated to this PR)
- [ ] Full CI (`lint`, `cargo-test`, `api-docs-drift`, `security-audit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modulo (`%`) behavior to better match JavaScript, including correct handling of `-0` results and cases involving zero divisors.
  * Refined bitwise NOT (`~`) for non-`BigInt` values so inputs are coerced and truncated according to JavaScript rules, with non-finite values treated as `0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->