### PR TITLE
fix(test262): #5591 — Proxy / TypedArray / Function / AsyncFromSync invariant fixes

### DIFF
--- a/crates/perry-codegen/src/expr/property_get/globalget.rs
+++ b/crates/perry-codegen/src/expr/property_get/globalget.rs
@@ -57,6 +57,12 @@ pub(crate) fn lower_globalget_property(ctx: &mut FnCtx<'_>, property: &str) -> R
     ) {
         return Ok(lower_global_builtin_static_value(ctx, "Promise", property));
     }
+    // `Proxy.revocable` read as a VALUE (not in a call) — the receiver is
+    // collapsed to GlobalGet(0) so we route by property name. Resolves the
+    // closure installed by `install_builtin_constructor_statics("Proxy", …)`.
+    if property == "revocable" {
+        return Ok(lower_global_builtin_static_value(ctx, "Proxy", property));
+    }
     // #2904: V8/Node static Error members read as values
     // (`typeof Error.isError`, `Error.stackTraceLimit`, …). The
     // HIR collapses every builtin global receiver to

--- a/crates/perry-runtime/src/array/iterator.rs
+++ b/crates/perry-runtime/src/array/iterator.rs
@@ -368,6 +368,10 @@ fn async_from_sync_call_raw(iter: f64, method: &[u8], args: &[f64]) -> Result<Op
         // to method dispatch (string/typed-array iterators tower their `next`
         // through the class-id method table).
         false
+    } else if crate::JSValue::from_bits(method_value.to_bits()).is_null() {
+        // ECMA-262 §27.1.4.2.2: GetMethod treats null the same as undefined —
+        // a null `return`/`throw` method means the method is absent → Ok(None).
+        return Ok(None);
     } else if !is_callable_value(method_value) {
         return Err(async_from_sync_type_error(
             b"Async-from-sync iterator method is not callable",

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -67,7 +67,7 @@ pub(crate) use builtin_thunks::{
     global_this_string_thunk, global_this_structured_clone_thunk, global_this_unescape_thunk,
     math_atan2_thunk, math_clz32_thunk, math_f16round_thunk, math_hypot_thunk, math_imul_thunk,
     math_max_thunk, math_min_thunk, math_pow_thunk, math_random_thunk, math_round_thunk,
-    math_sign_thunk,
+    math_sign_thunk, proxy_revocable_thunk,
 };
 pub use ctor_thunks::js_webcrypto_illegal_constructor;
 pub(crate) use ctor_thunks::{

--- a/crates/perry-runtime/src/object/global_this/builtin_thunks.rs
+++ b/crates/perry-runtime/src/object/global_this/builtin_thunks.rs
@@ -503,3 +503,13 @@ pub(crate) extern "C" fn global_this_error_prepare_stack_trace_thunk(
     let empty = crate::string::js_string_from_bytes(b"".as_ptr(), 0);
     crate::value::js_nanbox_string(empty as i64)
 }
+
+/// `Proxy.revocable(target, handler)` static method thunk. Delegates to the
+/// existing `js_proxy_revocable` implementation in `crate::proxy`.
+pub(crate) extern "C" fn proxy_revocable_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    target: f64,
+    handler: f64,
+) -> f64 {
+    crate::proxy::js_proxy_revocable(target, handler)
+}

--- a/crates/perry-runtime/src/object/global_this/install_static.rs
+++ b/crates/perry-runtime/src/object/global_this/install_static.rs
@@ -641,6 +641,15 @@ pub(crate) fn install_builtin_constructor_statics(
                 super::super::PropertyAttrs::new(true, true, true),
             );
         }
+        "Proxy" => {
+            install_constructor_static(
+                ctor,
+                "revocable",
+                proxy_revocable_thunk as *const u8,
+                2,
+                false,
+            );
+        }
         _ => {}
     }
 }

--- a/crates/perry-runtime/src/object/global_this/populate.rs
+++ b/crates/perry-runtime/src/object/global_this/populate.rs
@@ -627,6 +627,51 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
             super::super::PropertyAttrs::new(false, false, false),
         );
     }
+    // ECMA-262 §23.2.3.33: `%TypedArray%.prototype.toString` must be the
+    // same function object as `Array.prototype.toString`. Alias it now that
+    // both the Array constructor and the TypedArray intrinsic are set up.
+    alias_typed_array_proto_to_string(singleton);
+}
+
+/// Install `%TypedArray%.prototype.toString` as the same closure object as
+/// `Array.prototype.toString` (ECMA-262 §23.2.3.33).
+fn alias_typed_array_proto_to_string(singleton: *mut ObjectHeader) {
+    let ta_proto_addr = crate::object::TYPED_ARRAY_INTRINSIC_PROTO_PTR.load(Ordering::Acquire);
+    if ta_proto_addr == 0 {
+        return;
+    }
+    let ta_proto = ta_proto_addr as *mut ObjectHeader;
+    // Read Array constructor from globalThis, then Array.prototype.toString.
+    let arr_key = crate::string::js_string_from_bytes(b"Array".as_ptr(), 5);
+    let arr_ctor = js_object_get_field_by_name(singleton, arr_key);
+    if (arr_ctor.bits() >> 48) != 0x7FFD {
+        return;
+    }
+    let arr_ctor_ptr = (arr_ctor.bits() & crate::value::POINTER_MASK) as *mut ObjectHeader;
+    if arr_ctor_ptr.is_null() {
+        return;
+    }
+    let proto_key = crate::string::js_string_from_bytes(b"prototype".as_ptr(), 9);
+    let arr_proto = js_object_get_field_by_name(arr_ctor_ptr, proto_key);
+    if (arr_proto.bits() >> 48) != 0x7FFD {
+        return;
+    }
+    let arr_proto_ptr = (arr_proto.bits() & crate::value::POINTER_MASK) as *mut ObjectHeader;
+    if arr_proto_ptr.is_null() {
+        return;
+    }
+    let ts_key = crate::string::js_string_from_bytes(b"toString".as_ptr(), 8);
+    let to_string_fn = js_object_get_field_by_name(arr_proto_ptr, ts_key);
+    if to_string_fn.bits() == crate::value::TAG_UNDEFINED {
+        return;
+    }
+    let ts_key2 = crate::string::js_string_from_bytes(b"toString".as_ptr(), 8);
+    js_object_set_field_by_name(ta_proto, ts_key2, f64::from_bits(to_string_fn.bits()));
+    super::super::set_builtin_property_attrs(
+        ta_proto as usize,
+        "toString".to_string(),
+        super::super::PropertyAttrs::new(true, false, true),
+    );
 }
 
 /// Re-point a `Number.<name>` static at the global function of the same name so

--- a/crates/perry-runtime/src/object/global_this/typed_array.rs
+++ b/crates/perry-runtime/src/object/global_this/typed_array.rs
@@ -380,12 +380,10 @@ fn install_typed_array_iterator_symbol(proto_obj: *mut ObjectHeader) {
     if proto_obj.is_null() {
         return;
     }
-    install_proto_method(
-        proto_obj,
-        "values",
-        global_this_builtin_noop_thunk as *const u8,
-        0,
-    );
+    // Read the already-installed `values` method (installed by
+    // `install_typed_array_proto_methods` just before this call) and bind it as
+    // `@@iterator`. ECMA-262 §23.2.3.35: `%TypedArray%.prototype[@@iterator]`
+    // is the same function object as `%TypedArray%.prototype.values`.
     unsafe {
         let values_key = crate::string::js_string_from_bytes(b"values".as_ptr(), 6);
         let values = js_object_get_field_by_name(proto_obj, values_key);
@@ -467,7 +465,6 @@ pub(crate) fn ensure_typed_array_intrinsic(
     // `Object.getOwnPropertyDescriptor(getPrototypeOf(Int8Array.prototype),
     // "length")` to keep working.
     install_typed_array_proto_accessors(proto);
-    install_typed_array_iterator_symbol(proto);
     install_typed_array_to_string_tag(proto);
     // The per-kind prototypes (`Int8Array.prototype`, …) inherit ALL of their
     // methods from this shared `%TypedArray%.prototype` (their `[[Prototype]]`),
@@ -475,14 +472,15 @@ pub(crate) fn ensure_typed_array_intrinsic(
     // `Int8Array.prototype.map === %TypedArray%.prototype.map` (test262's
     // `prototype/*/inherited.js`).
     //
-    // NOTE: the generic `Object.prototype` data methods + a `toString` are
-    // intentionally NOT installed here. The intrinsic prototype is allocated
-    // with zero inline field slots and already carries ~34 own properties
-    // (accessors + `@@iterator` + the spec methods below); adding the extra ~6
-    // crosses an inline-storage boundary that trips a latent field-count
+    // NOTE: the generic `Object.prototype` data methods (`hasOwnProperty`,
+    // `valueOf`, …) are intentionally NOT installed here. The intrinsic prototype
+    // is allocated with zero inline field slots and already carries ~34 own
+    // properties (accessors + `@@iterator` + the spec methods below); adding the
+    // extra ~5 crosses an inline-storage boundary that trips a latent field-count
     // overflow (a heap-layout-dependent SIGSEGV under GC pressure). They are not
-    // needed for parity — `toLocaleString` is already a brand-checking method
-    // below, and `hasOwnProperty`/`valueOf`/etc. dispatch natively on instances.
+    // needed for parity — `hasOwnProperty`/`valueOf`/etc. dispatch natively.
+    // `toString` is aliased after all constructors are set up in
+    // `populate.rs:alias_typed_array_proto_to_string` (ECMA-262 §23.2.3.33).
     // Install the brand-checking spec methods on the shared `%TypedArray%`
     // intrinsic prototype. test262's `testTypedArray.js` harness reads
     // `TypedArray.prototype.<m>` (where `TypedArray ===
@@ -491,6 +489,10 @@ pub(crate) fn ensure_typed_array_intrinsic(
     // is read off the intrinsic, and the per-kind protos resolve their reads
     // here via the `[[Prototype]]` chain.
     typed_array_proto_thunks::install_typed_array_proto_methods(proto);
+    // @@iterator must be installed AFTER install_typed_array_proto_methods so
+    // that it captures the final `values` closure (the `%TypedArray%.prototype
+    // [@@iterator] === %TypedArray%.prototype.values` identity invariant).
+    install_typed_array_iterator_symbol(proto);
     install_constructor_static_with_call_arity(
         ctor,
         "from",

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -25,6 +25,12 @@ pub(crate) fn value_is_callable(value: f64) -> bool {
     if crate::value::is_js_handle(value) && crate::value::js_handle_is_function(value) {
         return true;
     }
+    // INT32-tagged class references (top 16 bits = 0x7FFE) are callable
+    // constructors emitted by codegen. `is_pointer()` only checks 0x7FFD,
+    // so they would fall through to `return false` without this guard.
+    if (value.to_bits() >> 48) == 0x7FFE {
+        return true;
+    }
     let jv = crate::JSValue::from_bits(value.to_bits());
     if !jv.is_pointer() {
         return false;

--- a/crates/perry-runtime/src/proxy/invariants.rs
+++ b/crates/perry-runtime/src/proxy/invariants.rs
@@ -206,6 +206,13 @@ fn is_compatible_descriptor(current: &TargetProp, descriptor: f64) -> bool {
     let desc_is_accessor = desc_has(descriptor, b"get") || desc_has(descriptor, b"set");
     let desc_is_data = desc_has(descriptor, b"value") || desc_has(descriptor, b"writable");
 
+    // ECMA-262 §10.5.6 step 7.a.i: a descriptor that attempts to set
+    // `configurable:true` on a non-configurable own property is always invalid,
+    // regardless of whether it is generic, data, or accessor.
+    if desc_has(descriptor, b"configurable") && truthy(desc_field(ptr, b"configurable")) {
+        return false;
+    }
+
     // A generic descriptor — only `configurable`/`enumerable`, with no
     // type-defining field (get/set or value/writable) — is compatible with
     // any non-configurable current property. Per ValidateAndApplyProperty-


### PR DESCRIPTION
## Summary

Fixes the remaining test262 failure categories from #5591:
**Proxy (33 cases)**, **TypedArray (6 cases)**, **Function (23 cases)**,
**AsyncFromSyncIteratorPrototype (5 cases)**.

### Fix 1 — AsyncFromSyncIteratorPrototype: null `return`/`throw` method
`async_from_sync_call_raw` treated null as a callable (reaching the `!is_callable_value` TypeError path) instead of treating it as absent per ECMA-262 §27.1.4.2.2 (GetMethod: null → `undefined` → absent → `Ok(None)`). A `for await` loop over a sync iterable whose `return` method is `null` and then exits via `break` no longer throws a TypeError.
- `crates/perry-runtime/src/array/iterator.rs`

### Fix 2 — `%TypedArray%.prototype[@@iterator] === %TypedArray%.prototype.values`
`install_typed_array_iterator_symbol` was called before `install_typed_array_proto_methods`, so `@@iterator` was set from a transient no-op closure, not the real `values` thunk installed by the method installer. Fixed by:
1. Moving the `@@iterator` install step to after `install_typed_array_proto_methods`.
2. Removing the redundant no-op `values` install from `install_typed_array_iterator_symbol` — it now reads the already-installed `values` closure and aliases it.
- `crates/perry-runtime/src/object/global_this/typed_array.rs`

### Fix 3 — INT32-tagged class constructor callable check
`value_is_callable` checked for POINTER_TAG (0x7FFD) only. Codegen emits class constructor references with INT32_TAG (top 16 bits = 0x7FFE). Added a guard so these are recognised as callable, making `typeof MyClass === "function"` hold in all evaluation contexts including Proxy handler traps.
- `crates/perry-runtime/src/object/instanceof.rs`

### Fix 4 — Proxy `getOwnPropertyDescriptor` configurable:true invariant
`is_compatible_descriptor` returned `true` for a generic descriptor (one with no `value`/`writable`/`get`/`set` fields) before checking whether `configurable:true` was present. Added an early-return `false` for the `configurable:true`-on-non-configurable-own-property case, per ECMA-262 §10.5.6 step 7.a.i.
- `crates/perry-runtime/src/proxy/invariants.rs`

### Fix 5 — `Proxy.revocable` as a runtime property value
`Proxy.revocable(target, handler)` CALLS already worked via HIR-level static dispatch (`Expr::ProxyRevocable`), but reading `Proxy.revocable` as a value returned `undefined` because:
- The runtime never installed `revocable` on the Proxy constructor object.
- The codegen `lower_globalget_property` returned `undefined` for any unrecognised property name.

Both sides fixed:
- Runtime: `proxy_revocable_thunk` + a new "Proxy" arm in `install_builtin_constructor_statics` installs the thunk as an own property.
- Codegen: `property == "revocable"` routes to `lower_global_builtin_static_value(ctx, "Proxy", …)`, so `typeof Proxy.revocable === "function"` holds.
- `crates/perry-runtime/src/object/global_this/{builtin_thunks,install_static,global_this}.rs`
- `crates/perry-codegen/src/expr/property_get/globalget.rs`

### Fix 6 — `%TypedArray%.prototype.toString === Array.prototype.toString`
ECMA-262 §23.2.3.33 requires the TypedArray intrinsic prototype's `toString` to be exactly `Array.prototype.toString`. Added `alias_typed_array_proto_to_string`, called at the end of `populate_global_this_builtins` after both the TypedArray intrinsic and the Array constructor are installed. It reads `Array.prototype.toString` from the live global and writes it onto the TypedArray proto.
- `crates/perry-runtime/src/object/global_this/populate.rs`

## Test plan

- [x] All 6 fixes confirmed via smoke tests (compiled + run locally)
- [x] Fix 1: `for await` over sync iterable with `return: null` exits cleanly
- [x] Fix 2: `%TypedArray%.prototype[@@iterator] === %TypedArray%.prototype.values` → `true`
- [x] Fix 3: `typeof MyClass === "function"` in Proxy trap context → `true`
- [x] Fix 4: Proxy `getOwnPropertyDescriptor` configurable:true invariant → `TypeError`
- [x] Fix 5: `typeof Proxy.revocable === "function"` → `true`; `Proxy.revocable({}, {})` works
- [x] Fix 6: `%TypedArray%.prototype.toString === Array.prototype.toString` → `true`
- [ ] CI cargo-test / lint

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `Proxy.revocable()` and made it available on the global `Proxy` constructor.
  * Improved typed array compatibility by aligning `toString` and iterator behavior with standard JavaScript objects.

* **Bug Fixes**
  * Fixed async iterator handling so a missing method is correctly treated as absent when it is `null`.
  * Corrected callable detection for certain constructor values.
  * Tightened proxy property-setting checks to preserve non-configurable properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->