### PR TITLE
runtime: JS-loop-driven current-thread async runtime + wait-driver with gated fast-native-drive (supersedes #5779)

### DIFF
--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -187,6 +187,50 @@ pub(crate) enum PendingHttpEvent {
     DeferredArmContinue { request_handle: Handle },
 }
 
+/// #5779 follow-up — count of in-flight HTTP/HTTPS CLIENT requests (the detached
+/// reqwest task spawned per `http.request`/`http.get`, from dispatch until the
+/// response fully streams or errors).
+///
+/// `EXT_BLOCKING_TASKS_INFLIGHT` (perry-stdlib's idle-kick / active-handle gate)
+/// only stays up for the SHORT outer `spawn_blocking` closure that *launches* the
+/// reqwest task and returns; it drops to 0 while the actual fetch is still in
+/// flight. So the runtime's idle-kick never fires during a fetch, and a lost
+/// tokio worker-unpark for the reqwest task (the canonical failure under a
+/// `Promise.all` burst of fetches) is never recovered — the main thread parks
+/// forever with the responses received but undelivered. This counter, exposed via
+/// [`js_ext_http_client_inflight`], lets the idle-kick + active-handle gate honor
+/// a fetch's TRUE lifetime so a stranded reqwest task gets roused.
+static CLIENT_REQUESTS_INFLIGHT: std::sync::atomic::AtomicI64 =
+    std::sync::atomic::AtomicI64::new(0);
+
+/// RAII in-flight marker. Created right before the reqwest task is spawned and
+/// MOVED INTO the task, so the count tracks the task's full lifetime — including
+/// a task scheduled-but-stranded by a lost worker-unpark (its future, holding the
+/// guard, is never dropped while stranded). Drop wakes the main loop so its
+/// active-handle gate re-evaluates promptly.
+pub(crate) struct ClientInflightGuard;
+impl ClientInflightGuard {
+    pub(crate) fn new() -> Self {
+        CLIENT_REQUESTS_INFLIGHT.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        ClientInflightGuard
+    }
+}
+impl Drop for ClientInflightGuard {
+    fn drop(&mut self) {
+        CLIENT_REQUESTS_INFLIGHT.fetch_sub(1, std::sync::atomic::Ordering::AcqRel);
+        notify_main_thread();
+    }
+}
+
+/// Exposed for perry-stdlib's idle-kick + active-handle gate (#5779 follow-up):
+/// returns nonzero while any HTTP client fetch is outstanding.
+#[no_mangle]
+pub extern "C" fn js_ext_http_client_inflight() -> i32 {
+    CLIENT_REQUESTS_INFLIGHT
+        .load(std::sync::atomic::Ordering::Acquire)
+        .clamp(0, i32::MAX as i64) as i32
+}
+
 lazy_static! {
     static ref HTTP_PENDING_EVENTS: Mutex<Vec<PendingHttpEvent>> = Mutex::new(Vec::new());
     /// Shared HTTP client — reuses connection pool, DNS cache, TLS
@@ -648,7 +692,11 @@ fn dispatch_request_over_socket(
             return;
         }
         let handle = tokio::runtime::Handle::current();
+        // #5779 follow-up: keep this fetch counted in-flight for its whole
+        // lifetime so the idle-kick recovers a lost worker-unpark.
+        let inflight_guard = ClientInflightGuard::new();
         let jh = handle.spawn(async move {
+            let _inflight = inflight_guard;
             let vtable = match perry_ffi::raw_net() {
                 Some(v) => v,
                 None => {
@@ -1642,14 +1690,36 @@ pub extern "C" fn js_http_has_pending() -> i32 {
 /// from codegen's event-loop tick. Returns count of events drained.
 #[no_mangle]
 pub unsafe extern "C" fn js_http_process_pending() -> i32 {
-    let events: Vec<PendingHttpEvent> = match HTTP_PENDING_EVENTS.lock() {
-        Ok(mut q) => q.drain(..).collect(),
-        Err(_) => return 0,
-    };
-
-    let count = events.len() as i32;
-
-    for ev in events {
+    // Process events ONE AT A TIME, re-reading the shared queue each iteration
+    // rather than draining the whole batch into a local Vec up front.
+    //
+    // Why (#5783 follow-up): a response handler may RE-ENTER the event loop —
+    // e.g. a `ResponseHead` invokes an async response callback that drives a
+    // `for await` / `.toArray()` over a `res.pipe(PassThrough())` body. That
+    // consumer's `await` block-waits, pumping the loop (which re-enters this
+    // function), and its resolution depends on the body arriving via the LATER
+    // `ResponseChunk`/`ResponseEnd` events of this same batch. If those were
+    // already drained into a local Vec, the re-entrant pump would find an empty
+    // `HTTP_PENDING_EVENTS` and the consumer would deadlock (empty body / hang).
+    // Keeping unprocessed events in the shared queue lets the re-entrant drain
+    // deliver them. FIFO `remove(0)` preserves event order; each event is taken
+    // by exactly one (outer or re-entrant) frame, so there is no double-dispatch.
+    let mut count = 0i32;
+    loop {
+        let ev = match HTTP_PENDING_EVENTS.lock() {
+            Ok(mut q) => {
+                if q.is_empty() {
+                    None
+                } else {
+                    Some(q.remove(0))
+                }
+            }
+            Err(_) => return count,
+        };
+        let Some(ev) = ev else {
+            break;
+        };
+        count += 1;
         match ev {
             PendingHttpEvent::Response {
                 request_handle,

--- a/crates/perry-ext-ws/src/lib.rs
+++ b/crates/perry-ext-ws/src/lib.rs
@@ -523,7 +523,11 @@ pub unsafe extern "C" fn js_ws_wait_for_message(handle: i64, timeout_ms: f64) ->
         if start.elapsed() >= timeout {
             return std::ptr::null_mut();
         }
-        std::thread::sleep(std::time::Duration::from_millis(10));
+        // Unified single-thread model: the WS reader task only advances while the
+        // main thread drives the runtime, so drive one bounded tick here (which
+        // runs the reader and delivers messages) instead of `std::thread::sleep`,
+        // which would block this thread and never let a message arrive.
+        perry_ffi::run_pending(10);
     }
 }
 

--- a/crates/perry-ffi/src/async_runtime.rs
+++ b/crates/perry-ffi/src/async_runtime.rs
@@ -64,6 +64,20 @@ extern "C" {
     fn perry_ffi_spawn_blocking(ctx: *mut c_void, invoke: extern "C" fn(*mut c_void));
     fn perry_ffi_spawn_blocking_with_reactor(ctx: *mut c_void, invoke: extern "C" fn(*mut c_void));
     fn perry_ffi_spawn_async(ctx: *mut c_void);
+    fn perry_ffi_run_pending(budget_ms: u64);
+}
+
+/// Drive the shared async runtime for up to `budget_ms` (or until a producer
+/// signals work). In the unified single-thread runtime model the runtime only
+/// makes progress while the main thread drives it, so a *synchronous* native
+/// API that blocks the main thread waiting for data delivered by a spawned task
+/// (e.g. `js_ws_wait_for_message`) must call this in its poll loop instead of
+/// `std::thread::sleep` — otherwise the delivering task never runs and the wait
+/// always times out. Safe to call from the main thread outside any other
+/// `block_on`; must NOT be called from inside a spawned runtime task.
+pub fn run_pending(budget_ms: u64) {
+    // SAFETY: thin call into the perry-stdlib-provided runtime driver.
+    unsafe { perry_ffi_run_pending(budget_ms) };
 }
 
 // NaN-box tags. These values are part of perry-runtime's stable

--- a/crates/perry-ffi/src/lib.rs
+++ b/crates/perry-ffi/src/lib.rs
@@ -46,7 +46,7 @@
 
 mod async_runtime;
 pub use async_runtime::{
-    nanbox_string_bits, spawn_async, spawn_blocking, spawn_blocking_with_reactor,
+    nanbox_string_bits, run_pending, spawn_async, spawn_blocking, spawn_blocking_with_reactor,
     JsNativeAsyncCompletion, JsPromise, PERRY_NATIVE_ASYNC_ALREADY_COMPLETED,
     PERRY_NATIVE_ASYNC_CLEANUP_ON_CANCEL, PERRY_NATIVE_ASYNC_CLEANUP_ON_REJECT,
     PERRY_NATIVE_ASYNC_CLEANUP_ON_SUCCESS, PERRY_NATIVE_ASYNC_INVALID, PERRY_NATIVE_ASYNC_OK,

--- a/crates/perry-runtime/src/event_pump.rs
+++ b/crates/perry-runtime/src/event_pump.rs
@@ -525,6 +525,14 @@ pub extern "C" fn js_wait_for_event() {
                 std::thread::sleep(SPIN_THROTTLE_SLEEP);
             }
         }
+        // A due timer pins the budget at 0, but native work (a fetch's reqwest
+        // `send`, sibling fetches, net/ws round-trips) still only advances inside
+        // the wait-driver tick. A hot timer loop would otherwise take this branch
+        // every iteration and starve that work — the same starvation the
+        // notified/microtask path above guards against. Give it the same brief
+        // driven turn. No-op (atomic loads) when no driver is registered or
+        // nothing native is in flight. #1114: this path does NOT reset the streak.
+        invoke_wait_driver_fast();
         return;
     }
     // Unified single-thread async model: when perry-stdlib has installed a

--- a/crates/perry-runtime/src/event_pump.rs
+++ b/crates/perry-runtime/src/event_pump.rs
@@ -91,62 +91,99 @@ fn invoke_host_wake_callback() {
 }
 
 // ============================================================================
-// #5779 — Idle-kick callback (tokio lost-unpark recovery).
+// Wait-driver (unified single-thread async model).
 //
-// Perry runs JS on the main thread, which is NOT a tokio worker; it parks on
-// the condvar below while the shared tokio runtime drives async I/O on its
-// worker pool. A task scheduled from the main thread (the canonical case: an
-// in-process HTTP server's per-request `oneshot::Sender::send` of the response,
-// fired from `res.end()` inside the main-thread request pump) relies on tokio
-// unparking a worker to run it. When *every* worker is parked and the I/O
-// reactor is blocked in `kevent`/`epoll_wait`, that remote unpark can be lost
-// under load — the woken task is enqueued but no worker is roused to drain it.
-// The task is stranded forever: the response is never written, so the fetch
-// client future never completes, and the main thread's 1-second idle re-check
-// finds nothing to do (it already shipped the response) and re-parks. Permanent
-// deadlock — exactly the in-process server-and-fetch hang in #5779.
+// When registered, `js_wait_for_event` drives this instead of parking on the
+// condvar. perry-stdlib installs a driver that runs ONE bounded tick of the
+// (current-thread) tokio runtime — driving the I/O reactor, the timer wheel,
+// and all spawned native tasks (reqwest / net / ws) ON THE MAIN THREAD. A
+// native completion is therefore observed in-thread and queues its result with
+// no cross-thread wake to lose; the loop then drains it in `perry_poll`. This
+// replaces the two-scheduler model (JS loop on the main thread + a multi-thread
+// tokio runtime) whose cross-thread driver-unpark could be lost.
 //
-// The fix: just before the main thread sleeps on its idle condvar, give it a
-// chance to poke the runtime so a worker is roused to drain any
-// enqueued-but-stranded task. perry-stdlib registers a callback here that
-// schedules a task on the shared runtime whenever async client work is in
-// flight. Because the kick fires right before the sleep, the drained task's own
-// completion notify wakes the main thread immediately — so recovery latency is
-// a worker hop, and even a fully missed wake self-heals within the 1s idle cap.
-// (perry-stdlib's kick task does real work, not an empty `spawn(async {})`,
-// which was measured not to reliably rouse a parked worker — see its
-// `stdlib_idle_kick`.)
+//   * `sleep(budget_ms)` — block until a native event is ready OR `budget_ms`
+//     elapses, whichever first; drives the runtime meanwhile.
+//   * `wake()` — end the current tick early; fired from `js_notify_main_thread`
+//     by any producer (the in-thread native task, or a blocking-pool thread).
 //
-// Registration is opt-in and the slot is a single atomic load when unset, so
-// embedders that never register pay nothing. The callback runs on the main
-// thread only (from `js_wait_for_event`'s pre-sleep path, never the hot
-// NOTIFIED fast path).
+// Both are installed together; a null `sleep` slot reverts to the condvar park
+// (non-async embedders pay a single atomic load).
 // ============================================================================
+static WAIT_DRIVER_SLEEP: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
+static WAIT_DRIVER_WAKE: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
+/// `fast` — a brief, non-parking-when-idle native drive invoked when JS work is
+/// pending (so we're about to return to run microtasks, NOT park). On the
+/// single-thread runtime model, in-flight native tasks (a fetch's reqwest send,
+/// its h2 connection driver, sibling fetches) run ONLY inside the wait-driver
+/// tick; under constant JS microtask churn the `NOTIFIED` fast-path would
+/// otherwise return every iteration and never call `sleep`, starving those tasks
+/// forever. `fast` gives them a bounded turn each loop iteration and no-ops
+/// cheaply when nothing native is in flight (pure-JS-async is unaffected).
+static WAIT_DRIVER_FAST: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
 
-/// Idle-kick callback, stored as a raw fn pointer for a trivial C FFI surface.
-/// Null disables the kick.
-static IDLE_KICK_CALLBACK: AtomicPtr<()> = AtomicPtr::new(std::ptr::null_mut());
-
-/// Register the idle-kick callback (see module-level #5779 note). Passing
-/// `cb = NULL` clears it. Invoked on the main thread immediately before it
-/// blocks on the idle condvar; the implementation must be cheap and must not
-/// re-enter `js_wait_for_event`.
+/// Register the wait-driver (see module note above). Passing `sleep = NULL`
+/// clears it. `sleep`/`fast` are invoked on the main thread from
+/// `js_wait_for_event` (never re-entrant); `wake` is invoked from
+/// `js_notify_main_thread` on whatever thread notified, so it must be
+/// thread-safe.
 #[no_mangle]
-pub extern "C" fn js_register_idle_kick(cb: Option<extern "C" fn()>) {
-    let cb_ptr = cb.map(|f| f as *mut ()).unwrap_or(std::ptr::null_mut());
-    IDLE_KICK_CALLBACK.store(cb_ptr, Ordering::Release);
+pub extern "C" fn js_register_wait_driver(
+    sleep: Option<extern "C" fn(u64)>,
+    fast: Option<extern "C" fn()>,
+    wake: Option<extern "C" fn()>,
+) {
+    // Store wake + fast first so any notifier that observes a fresh sleep slot
+    // also sees usable companions.
+    let wake_ptr = wake.map(|f| f as *mut ()).unwrap_or(std::ptr::null_mut());
+    WAIT_DRIVER_WAKE.store(wake_ptr, Ordering::Release);
+    let fast_ptr = fast.map(|f| f as *mut ()).unwrap_or(std::ptr::null_mut());
+    WAIT_DRIVER_FAST.store(fast_ptr, Ordering::Release);
+    let sleep_ptr = sleep.map(|f| f as *mut ()).unwrap_or(std::ptr::null_mut());
+    WAIT_DRIVER_SLEEP.store(sleep_ptr, Ordering::Release);
+}
+
+/// Run one bounded tick of the registered wait-driver. Returns `true` if a
+/// driver was installed (and ran), `false` if the caller should fall back to
+/// the condvar park.
+#[inline]
+fn wait_driver_sleep(budget_ms: u64) -> bool {
+    let p = WAIT_DRIVER_SLEEP.load(Ordering::Acquire);
+    if p.is_null() {
+        return false;
+    }
+    // SAFETY: the slot only ever holds an `extern "C" fn(u64)` installed by
+    // `js_register_wait_driver`; re-checked non-null right above.
+    let f: extern "C" fn(u64) = unsafe { std::mem::transmute(p) };
+    f(budget_ms);
+    true
 }
 
 #[inline]
-fn invoke_idle_kick() {
-    let cb_ptr = IDLE_KICK_CALLBACK.load(Ordering::Acquire);
-    if cb_ptr.is_null() {
+fn invoke_wait_driver_wake() {
+    let p = WAIT_DRIVER_WAKE.load(Ordering::Acquire);
+    if p.is_null() {
         return;
     }
-    // SAFETY: the slot only ever holds a `extern "C" fn()` installed by
-    // `js_register_idle_kick`; re-checked non-null right above.
-    let cb: extern "C" fn() = unsafe { std::mem::transmute(cb_ptr) };
-    cb();
+    // SAFETY: the slot only ever holds an `extern "C" fn()` installed by
+    // `js_register_wait_driver`; re-checked non-null right above.
+    let f: extern "C" fn() = unsafe { std::mem::transmute(p) };
+    f();
+}
+
+/// Give in-flight native tasks a brief driven turn before returning to run
+/// pending JS work. No-ops cheaply (a single atomic load) when no wait-driver is
+/// registered; the driver itself no-ops when nothing native is in flight.
+#[inline]
+fn invoke_wait_driver_fast() {
+    let p = WAIT_DRIVER_FAST.load(Ordering::Acquire);
+    if p.is_null() {
+        return;
+    }
+    // SAFETY: the slot only ever holds an `extern "C" fn()` installed by
+    // `js_register_wait_driver`; re-checked non-null right above.
+    let f: extern "C" fn() = unsafe { std::mem::transmute(p) };
+    f();
 }
 
 struct Pump {
@@ -254,6 +291,21 @@ fn spin_streak_reset() {
     SPIN_STREAK.with(|s| s.set(0));
 }
 
+/// Read (without consuming) whether a producer has notified the main thread
+/// since the last `js_wait_for_event` reset.
+///
+/// Used by the perry-stdlib wait-driver tick: it parks on the I/O reactor and
+/// must end as soon as a native task queues a main-thread-visible result. The
+/// tick clears stale wakes by checking THIS flag (the single source of truth)
+/// rather than a stored notify permit, which can desync with `NOTIFIED` (the
+/// fast-path consumes `NOTIFIED` but not the permit). The main loop clears
+/// `NOTIFIED` before entering the tick, so a `true` here means a result was
+/// queued *during* the tick.
+#[no_mangle]
+pub extern "C" fn js_main_thread_notified() -> i32 {
+    i32::from(NOTIFIED.load(Ordering::Acquire))
+}
+
 /// Wake the main thread from `js_wait_for_event` (or a future call).
 ///
 /// Safe to call from any thread, including the main thread itself.
@@ -274,6 +326,13 @@ pub extern "C" fn js_notify_main_thread() {
     // is a single atomic-load when no host is listening, so callers that
     // never register pay essentially nothing.
     invoke_host_wake_callback();
+    // Unified-loop wake: if a wait-driver is installed, end its current bounded
+    // tick so the main loop drains this notify promptly. Fired before the
+    // WAITER_COUNT fast-path because the wait-driver does NOT register as a cvar
+    // waiter (it parks inside the runtime, not on `PUMP.cvar`). The driver's
+    // wake primitive coalesces (a notify with no tick in progress leaves a
+    // permit consumed on the next tick), so there is no lost wake.
+    invoke_wait_driver_wake();
     // Hot path: no consumer is currently in `cvar.wait_timeout`, so
     // we don't need to take the mutex or signal the cvar — the next
     // call to `js_wait_for_event` will see `NOTIFIED == true` on the
@@ -415,7 +474,21 @@ pub extern "C" fn js_wait_for_event() {
     // (timer deadline pinned in the past + hot notifies) silently
     // pegs a core. Only `cvar.wait_timeout` actually sleeping counts
     // as "progress" for streak-reset purposes.
-    if NOTIFIED.swap(false, Ordering::Acquire) {
+    // FAST PATH: there is pending JS work — a notify since the last wait, OR
+    // queued microtasks. Either way we must run that JS, not park for the budget.
+    // BUT in the single-thread runtime model, in-flight native tasks (a fetch's
+    // reqwest `send`, its h2 connection driver, sibling fetches) run ONLY inside
+    // the wait-driver tick. Constant JS promise churn flips `NOTIFIED` on every
+    // iteration (every `js_promise_resolve`/async-step notifies), so this path is
+    // taken every time and would otherwise STARVE those native tasks forever
+    // (the bundle hang: fetch `send().await` never progressed + sibling fetch
+    // never even started). Give them a brief driven turn here.
+    // `invoke_wait_driver_fast` no-ops cheaply when no driver is registered and
+    // when nothing native is in flight, so pure-JS-async pays only atomic loads.
+    // #1114: do NOT reset the spin streak on this path.
+    let was_notified = NOTIFIED.swap(false, Ordering::Acquire);
+    if was_notified || unsafe { js_microtasks_pending() } > 0 {
+        invoke_wait_driver_fast();
         return;
     }
 
@@ -454,14 +527,19 @@ pub extern "C" fn js_wait_for_event() {
         }
         return;
     }
-    // #5779: we are about to sleep on the idle condvar. If async client work is
-    // in flight, kick the tokio runtime so a worker is roused to drain any task
-    // that was scheduled but whose worker-unpark was lost while every worker was
-    // parked. Done *before* registering as a waiter / sleeping so the kicked
-    // task's completion notify still wakes us via the NOTIFIED re-check below or
-    // the cvar — no lost wake. The callback no-ops cheaply when nothing is in
-    // flight (and is absent until perry-stdlib registers it).
-    invoke_idle_kick();
+    // Unified single-thread async model: when perry-stdlib has installed a
+    // wait-driver (i.e. async work exists), drive ONE bounded tick of the
+    // current-thread tokio runtime here instead of parking on the condvar. The
+    // tick drives the reactor + timer wheel + native tasks on THIS thread, so a
+    // completion is observed in-thread and queued with no cross-thread wake to
+    // lose; `perry_poll` drains it on the next loop turn. A real tick yielded
+    // the core, so it counts as progress for the #1114 spin throttle.
+    if wait_driver_sleep(budget_ms) {
+        spin_streak_reset();
+        return;
+    }
+    // Fallback (no async runtime registered — non-async programs / embedders):
+    // the original condvar park (#84).
     // Slow path: take the cvar mutex and sleep on it. Mark ourselves
     // as a waiter first so concurrent notifiers go through the
     // mutex+cvar path (they won't see our wait if we registered after
@@ -844,85 +922,5 @@ mod tests {
         );
 
         NOTIFIED.swap(false, Ordering::Acquire);
-    }
-
-    static KICK_COUNT: AtomicU64 = AtomicU64::new(0);
-
-    /// Idle-kick test stub: count invocations and immediately notify so the
-    /// pending `wait_timeout` shortcuts instead of sleeping the full idle cap
-    /// — mirrors the real callback's effect (a drained task's completion notify
-    /// wakes the main thread), keeping the test fast and deterministic.
-    extern "C" fn counting_kick() {
-        KICK_COUNT.fetch_add(1, Ordering::Release);
-        js_notify_main_thread();
-    }
-
-    /// #5779: the idle kick must run on the pre-sleep slow path so a parked
-    /// main thread can rouse a stranded tokio worker before blocking. Forcing
-    /// a real (budget > 0) wait with no prior notify must invoke the callback.
-    #[test]
-    fn idle_kick_fires_before_blocking_sleep() {
-        let _g = SERIAL.lock().unwrap();
-        // Drain any stale notify so the first attempt below can reach the
-        // slow path rather than returning via the fast path.
-        js_wait_for_event();
-        js_register_idle_kick(Some(counting_kick));
-
-        // Retry to stay robust against a parallel (non-event_pump) test that
-        // sets NOTIFIED or schedules a sooner timer — either of which would
-        // divert this call off the slow path. A working wiring fires on the
-        // first clean attempt; a broken one never does.
-        let mut fired = false;
-        for _ in 0..50 {
-            crate::timer::js_timer_tick();
-            NOTIFIED.store(false, Ordering::Release);
-            KICK_COUNT.store(0, Ordering::Release);
-            js_wait_for_event();
-            if KICK_COUNT.load(Ordering::Acquire) >= 1 {
-                fired = true;
-                break;
-            }
-        }
-
-        js_register_idle_kick(None);
-        NOTIFIED.swap(false, Ordering::Acquire);
-        assert!(
-            fired,
-            "idle kick was never invoked on the pre-sleep path — a stranded \
-             tokio worker would never be roused (the #5779 deadlock)"
-        );
-    }
-
-    /// #5779: the kick must NOT run on the NOTIFIED fast path — there is work
-    /// to drain, the main thread is not about to block, and kicking the
-    /// runtime on every hot async tick would be pure overhead.
-    #[test]
-    fn idle_kick_skipped_on_notified_fast_path() {
-        let _g = SERIAL.lock().unwrap();
-        js_wait_for_event(); // drain
-        js_register_idle_kick(Some(counting_kick));
-
-        // A pre-set NOTIFIED makes the next wait return via the fast path. A
-        // racing parallel notify could only *add* a fast-path return, never
-        // force the slow path here, so observing at least one clean fast-path
-        // return with no kick is deterministic across retries.
-        let mut clean_fast_path = false;
-        for _ in 0..50 {
-            KICK_COUNT.store(0, Ordering::Release);
-            js_notify_main_thread();
-            js_wait_for_event();
-            if KICK_COUNT.load(Ordering::Acquire) == 0 {
-                clean_fast_path = true;
-                break;
-            }
-        }
-
-        js_register_idle_kick(None);
-        NOTIFIED.swap(false, Ordering::Acquire);
-        assert!(
-            clean_fast_path,
-            "idle kick fired on the NOTIFIED fast path — it must only run \
-             when the main thread is about to block"
-        );
     }
 }

--- a/crates/perry-stdlib/Cargo.toml
+++ b/crates/perry-stdlib/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["rlib"]
 default = ["full"]
 
 # Full stdlib - everything included
-full = ["http-server", "http-client", "database", "crypto", "compression", "email", "websocket", "image", "scheduler", "ids", "html-parser", "rate-limit", "validation", "net", "tls", "bundled-dotenv", "bundled-slugify", "bundled-lru-cache", "bundled-exponential-backoff", "bundled-events", "bundled-decimal", "bundled-dayjs", "bundled-moment", "bundled-commander", "bundled-streams"]
+full = ["http-server", "http-client", "external-http-client-pump", "database", "crypto", "compression", "email", "websocket", "image", "scheduler", "ids", "html-parser", "rate-limit", "validation", "net", "tls", "bundled-dotenv", "bundled-slugify", "bundled-lru-cache", "bundled-exponential-backoff", "bundled-events", "bundled-decimal", "bundled-dayjs", "bundled-moment", "bundled-commander", "bundled-streams"]
 
 # Minimal core - just what's needed for basic programs
 core = []

--- a/crates/perry-stdlib/src/common/async_bridge.rs
+++ b/crates/perry-stdlib/src/common/async_bridge.rs
@@ -14,7 +14,7 @@
 //! 3. The conversion callbacks run on the main thread during js_stdlib_process_pending
 
 use std::future::Future;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
 
 use once_cell::sync::Lazy;
@@ -104,19 +104,27 @@ pub unsafe fn js_promise_new_for_native_resolution() -> *mut perry_runtime::Prom
 pub static EXT_BLOCKING_TASKS_INFLIGHT: AtomicUsize = AtomicUsize::new(0);
 
 /// Global tokio runtime for all async stdlib operations.
-/// Falls back to current-thread runtime if multi-thread fails (e.g. on iOS).
+///
+/// Unified single-thread async model: a CURRENT-THREAD runtime, driven one
+/// bounded tick at a time by the main JS event loop (see `stdlib_wait_driver`
+/// and `js_register_wait_driver`). The I/O reactor, timer wheel, and all
+/// spawned native tasks (reqwest / net / ws) run on the main thread interleaved
+/// with JS — Node's model — so a native completion is observed in-thread and
+/// queued with no cross-thread wake to lose. `spawn_blocking` still offloads
+/// genuinely blocking / CPU-bound work to the blocking-thread pool; its result
+/// is delivered back and ends the next tick.
 pub static RUNTIME: Lazy<Runtime> = Lazy::new(|| {
-    tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(4)
+    tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
-        .unwrap_or_else(|_| {
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("Failed to create tokio runtime")
-        })
+        .expect("Failed to create tokio current-thread runtime")
 });
+
+/// Fired whenever a producer has queued main-thread-visible work (any
+/// `js_notify_main_thread`, via the wait-driver wake). Ends the current bounded
+/// tick in `stdlib_wait_driver`. `notify_one` coalesces and leaves a permit if
+/// no tick is in progress, so a notify between ticks is not lost.
+static EVENT_READY: tokio::sync::Notify = tokio::sync::Notify::const_new();
 
 /// Pending promise resolutions
 /// Format: (promise_ptr, is_success, result_value)
@@ -253,45 +261,116 @@ where
     RUNTIME.block_on(future)
 }
 
-/// #5779 idle-kick liveness counters. `ISSUED` bumps on the main thread each
-/// time a kick fires; `RAN` bumps inside the spawned task once a worker has
-/// actually polled it. Exposed for the regression test below.
-static IDLE_KICKS_ISSUED: AtomicU64 = AtomicU64::new(0);
-static IDLE_KICKS_RAN: AtomicU64 = AtomicU64::new(0);
+/// Wait-driver SLEEP side — one bounded tick of the current-thread runtime.
+///
+/// Installed via `js_register_wait_driver` and called by the main loop's
+/// `js_wait_for_event` in place of a condvar park. `block_on` drives the I/O
+/// reactor, the timer wheel, and every spawned native task (reqwest / net / ws)
+/// on THIS (main) thread until a producer fires `EVENT_READY` — i.e. a native
+/// task queued a resolution / pushed an event — or `budget_ms` elapses,
+/// whichever first. Because the producing task ran in this same tick, its
+/// completion is observed in-thread and `perry_poll` drains it on the next loop
+/// turn; there is no cross-thread wake to lose. `budget_ms` is the loop's
+/// computed sleep budget (min of the next perry-timer deadline and the 1 s idle
+/// cap); a zero budget is floored to 1 ms so native work still gets one poll
+/// cycle under a hot timer.
+extern "C" fn stdlib_wait_driver(budget_ms: u64) {
+    run_one_tick(budget_ms);
+}
 
-/// #5779 — idle-kick callback registered with perry-runtime's event pump.
-///
-/// Invoked on the main thread immediately before it blocks on the idle
-/// condvar (see `event_pump::js_register_idle_kick`). When async work is in
-/// flight, schedule a task on the shared runtime so a worker is roused to
-/// drain anything that was enqueued from the main thread but whose
-/// worker-unpark was lost while every worker was parked — the canonical case
-/// being an in-process HTTP server's per-request response `oneshot::send`,
-/// fired from `res.end()` inside the main-thread request pump. Without this,
-/// that serve task strands forever, its response is never written, and the
-/// matching in-process `fetch()` never settles (#5779).
-///
-/// The spawned task does **real work** (a release atomic store): an empty
-/// `spawn(async {})` was measured to *not* reliably rouse a parked worker on
-/// the multi-thread runtime (sequential in-process server+fetch deadlocked
-/// 8/8 runs), whereas a task with a genuine side effect forces a real
-/// scheduler round that wakes a worker and drains the stranded task (0
-/// deadlocks across no-load + fully-loaded stress). The store also serves as
-/// a memory barrier publishing the main thread's prior enqueue.
-///
-/// Gated on `EXT_BLOCKING_TASKS_INFLIGHT` so a fully idle process (no fetch,
-/// no in-flight client request) lets the runtime sleep undisturbed and the
-/// kick costs a single atomic load per idle tick. We deliberately do **not**
-/// bump the inflight gate for the kick task itself — it must not keep the
-/// event loop alive on its own.
-extern "C" fn stdlib_idle_kick() {
-    if EXT_BLOCKING_TASKS_INFLIGHT.load(Ordering::Acquire) == 0 {
+/// One bounded tick of the current-thread runtime: drive the reactor + timers +
+/// spawned native tasks until `EVENT_READY` fires or `budget_ms` (floored to
+/// 1 ms) elapses. Shared by the main-loop wait-driver and `perry_ffi_run_pending`
+/// (a synchronous native API that must let a delivering task run — see
+/// `perry-ffi::run_pending`). Must NOT be called from inside a spawned runtime
+/// task (no nested `block_on`); only from the main thread between ticks.
+pub fn run_one_tick(budget_ms: u64) {
+    extern "C" {
+        fn js_main_thread_notified() -> i32;
+    }
+    let budget = std::time::Duration::from_millis(budget_ms.max(1));
+    RUNTIME.block_on(async {
+        let notified = EVENT_READY.notified();
+        tokio::pin!(notified);
+        // Register as a waiter BEFORE checking the condition: a `notify_waiters`
+        // that lands between the check and the await still wakes us (it wakes only
+        // registered waiters). `enable()` returns false here because the wake side
+        // stores no permit.
+        notified.as_mut().enable();
+        // End immediately if a native result was already queued during this tick
+        // (the durable `NOTIFIED` flag — checked instead of a notify permit so a
+        // stale wake can't make us skip parking on the reactor). The main loop
+        // cleared `NOTIFIED` before this tick, so a set flag is fresh work.
+        if unsafe { js_main_thread_notified() } != 0 {
+            return;
+        }
+        // Otherwise park: `block_on` drives every spawned native task (reqwest /
+        // net / ws) and parks on the I/O reactor on this thread until a producer
+        // queues a result (`notify_waiters` wakes us; we re-check NOTIFIED) or the
+        // budget elapses.
+        let _ = tokio::time::timeout(budget, notified).await;
+    });
+}
+
+/// Drive the runtime for the full `budget_ms` (floored to 1 ms), parking on the
+/// I/O reactor so spawned native tasks make progress. Unlike `run_one_tick` this
+/// does NOT end early on the `NOTIFIED` flag — it is for a *synchronous* native
+/// API (`perry_ffi_run_pending`, e.g. `js_ws_wait_for_message`) that is called
+/// mid-`perry_poll` (where `NOTIFIED` may already be set for unrelated reasons)
+/// and just needs the delivering task to run for a slice before it re-checks its
+/// own condition.
+pub fn drive_pending(budget_ms: u64) {
+    let budget = std::time::Duration::from_millis(budget_ms.max(1));
+    RUNTIME.block_on(async {
+        tokio::time::sleep(budget).await;
+    });
+}
+
+/// Wait-driver WAKE side — ends the current bounded tick. Fired from
+/// `js_notify_main_thread` (via `js_register_wait_driver`) by any producer: the
+/// in-thread native task during a tick, or a blocking-pool thread cross-thread.
+/// Uses `notify_waiters` (NOT `notify_one`) so it stores NO permit: a notify
+/// outside a tick is intentionally dropped (the corresponding `NOTIFIED` flag is
+/// the durable signal the tick re-checks), which is what keeps stale permits from
+/// making every tick return instantly without parking on the reactor.
+extern "C" fn stdlib_wait_wake() {
+    EVENT_READY.notify_waiters();
+}
+
+/// Wait-driver FAST side — a brief native drive invoked by `js_wait_for_event`
+/// when JS work is pending (a notify or queued microtasks). On the single-thread
+/// runtime, in-flight native tasks (a fetch's reqwest `send`, its h2 connection
+/// driver, sibling fetches) run ONLY inside a tick; under constant JS promise
+/// churn the fast-path is taken every iteration, so without this they are starved
+/// forever (the bundle hang). When something native IS in flight, drive one short
+/// (1 ms) tick: `block_on` drains the run queue (starts freshly-spawned sibling
+/// fetches) and parks briefly on the I/O reactor (advancing TLS/h2 round-trips),
+/// ending early if a native result is queued. No-op when nothing native is in
+/// flight, so pure-JS-async pays only an atomic load.
+extern "C" fn stdlib_fast_drive() {
+    let n = EXT_BLOCKING_TASKS_INFLIGHT.load(Ordering::Acquire);
+    let native = n > 0 || ext_http_client_inflight_fast();
+    if !native {
         return;
     }
-    IDLE_KICKS_ISSUED.fetch_add(1, Ordering::Relaxed);
-    RUNTIME.spawn(async {
-        IDLE_KICKS_RAN.fetch_add(1, Ordering::Release);
+    RUNTIME.block_on(async {
+        let notified = EVENT_READY.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+        let _ = tokio::time::timeout(std::time::Duration::from_millis(1), notified).await;
     });
+}
+
+#[cfg(feature = "external-http-client-pump")]
+fn ext_http_client_inflight_fast() -> bool {
+    extern "C" {
+        fn js_ext_http_client_inflight() -> i32;
+    }
+    unsafe { js_ext_http_client_inflight() != 0 }
+}
+#[cfg(not(feature = "external-http-client-pump"))]
+fn ext_http_client_inflight_fast() -> bool {
+    false
 }
 
 /// Queue a promise resolution to be processed later
@@ -369,9 +448,18 @@ pub fn ensure_pump_registered() {
             fn js_stdlib_init_dispatch();
         }
         ensure_gc_scanner_registered();
-        // #5779 — recover from lost tokio worker-unparks while the main
-        // thread is parked (in-process HTTP server + fetch deadlock).
-        perry_runtime::event_pump::js_register_idle_kick(Some(stdlib_idle_kick));
+        // Unified single-thread async model: install the wait-driver so the main
+        // JS loop drives the current-thread tokio runtime one bounded tick per
+        // `js_wait_for_event` (see `stdlib_wait_driver`). Registered here, before
+        // any async work spawns, so the first `js_wait_for_event` after a spawn
+        // already drives the runtime. Forcing RUNTIME now also constructs it on
+        // the main thread up front.
+        perry_runtime::event_pump::js_register_wait_driver(
+            Some(stdlib_wait_driver),
+            Some(stdlib_fast_drive),
+            Some(stdlib_wait_wake),
+        );
+        Lazy::force(&RUNTIME);
         unsafe {
             js_register_stdlib_pump(js_stdlib_process_pending);
             js_register_stdlib_has_active(js_stdlib_has_active_handles);
@@ -402,7 +490,6 @@ pub extern "C" fn js_stdlib_process_pending() -> i32 {
         count += n as i32;
         pending.drain(..).collect()
     };
-
     for resolution in simple_resolutions {
         let scope = perry_runtime::gc::RuntimeHandleScope::new();
         let promise_ptr_usize = resolution.promise_ptr;
@@ -729,8 +816,16 @@ pub extern "C" fn js_stdlib_has_active_handles() -> i32 {
     {
         extern "C" {
             fn js_http_has_pending() -> i32;
+            fn js_ext_http_client_inflight() -> i32;
         }
         if unsafe { js_http_has_pending() } != 0 {
+            return 1;
+        }
+        // #5779 follow-up — also stay alive for the in-flight window BEFORE the
+        // reqwest task has pushed any event (response received but not yet
+        // delivered), so a single outstanding fetch can't let the loop exit
+        // early and so the idle-kick has a live loop to recover it on.
+        if unsafe { js_ext_http_client_inflight() } != 0 {
             return 1;
         }
     }
@@ -903,42 +998,6 @@ mod tests {
     fn clear_pending() {
         PENDING_RESOLUTIONS.lock().unwrap().clear();
         PENDING_DEFERRED.lock().unwrap().clear();
-    }
-
-    /// #5779: when async work is in flight the idle kick must schedule a task
-    /// that a worker actually runs — an empty `spawn(async {})` was observed
-    /// not to reliably rouse a parked worker, leaving the in-process
-    /// server+fetch deadlock unrecovered. Bump the in-flight gate (restoring
-    /// it after, so a parallel test's count is preserved), fire the kick, and
-    /// drive the runtime until the kick task records that it ran.
-    #[test]
-    fn idle_kick_schedules_a_task_that_runs() {
-        let issued_before = IDLE_KICKS_ISSUED.load(Ordering::Relaxed);
-        let ran_before = IDLE_KICKS_RAN.load(Ordering::Acquire);
-
-        EXT_BLOCKING_TASKS_INFLIGHT.fetch_add(1, Ordering::AcqRel);
-        stdlib_idle_kick();
-        EXT_BLOCKING_TASKS_INFLIGHT.fetch_sub(1, Ordering::AcqRel);
-
-        assert!(
-            IDLE_KICKS_ISSUED.load(Ordering::Relaxed) > issued_before,
-            "kick must fire when async work is in flight"
-        );
-        // Give the worker pool real wall-clock time to schedule and run the
-        // kick task (a tight `yield_now` loop spins the calling thread faster
-        // than a worker is scheduled, so use timed sleeps — up to ~2s).
-        RUNTIME.block_on(async {
-            for _ in 0..200 {
-                if IDLE_KICKS_RAN.load(Ordering::Acquire) > ran_before {
-                    break;
-                }
-                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-            }
-        });
-        assert!(
-            IDLE_KICKS_RAN.load(Ordering::Acquire) > ran_before,
-            "the kick's spawned task never executed on a worker"
-        );
     }
 
     #[test]

--- a/crates/perry-stdlib/src/perry_ffi_async.rs
+++ b/crates/perry-stdlib/src/perry_ffi_async.rs
@@ -316,3 +316,16 @@ pub unsafe extern "C" fn perry_ffi_spawn_async(ctx: *mut c_void) {
     let future: BoxFuture = *unsafe { Box::from_raw(ctx as *mut BoxFuture) };
     async_bridge::runtime().spawn(future);
 }
+
+/// `perry_ffi_run_pending(budget_ms)` — drive the shared current-thread runtime
+/// for one bounded tick (see `perry-ffi::run_pending`). A synchronous native API
+/// that blocks the main thread waiting for data a spawned task delivers (e.g.
+/// `js_ws_wait_for_message`) calls this in its poll loop so the delivering task
+/// actually runs; in the unified single-thread model the runtime only advances
+/// while the main thread drives it. Safe on the main thread between ticks; must
+/// not be called from inside a spawned runtime task.
+#[no_mangle]
+pub extern "C" fn perry_ffi_run_pending(budget_ms: u64) {
+    async_bridge::ensure_pump_registered();
+    async_bridge::drive_pending(budget_ms);
+}


### PR DESCRIPTION
Replaces the shared multi-thread tokio runtime (plus #5779's idle-kick worker-rouse) with a single **current-thread runtime driven by the main JS loop** via a registered wait-driver: native I/O (reqwest/net/ws) and JS run on one thread, so a native completion is observed in-thread and queues its result with no cross-thread wake to lose. This removes #5779's failure mode structurally (there are no worker threads whose unpark can be lost), so its idle-kick is superseded and dropped.

**Fast-native-drive.** Under constant JS microtask churn (a timer-driven loop that queues a promise job every turn), the loop's `NOTIFIED` fast-path returns each iteration and never calls the wait-driver's `sleep` — so in-flight native tasks (a fetch's `reqwest` send, its HTTP/2 connection driver, sibling fetches), which now only run inside a wait-driver tick, would starve. The wait-driver gains a `fast` slot that gives in-flight native work one bounded ~1 ms driven turn when native tasks are in flight (a plain atomic-load no-op otherwise, so pure-JS async is unaffected).

**Repro.** A timer loop that per-turn schedules `Promise.resolve().then(...)` + `setTimeout(render, 0)` while awaiting `Promise.all([fetch(a), fetch(b)])` over HTTPS/2: before, the fetches never resolve under the churn; after, they resolve promptly. `200k` iterations of `await Promise.resolve(i)` are unchanged (fast-drive no-ops). Supersedes #5779.

Validated: `cargo check --release` across perry-runtime (incl. `--tests`), perry-stdlib (`--features async-runtime`), perry-ext-ws, perry-ffi, perry-ext-http; `cargo fmt`. Marked draft — this is an architectural alternative to #5779, posted for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added improved main-thread async pumping with bounded “wait-driver” hooks, reducing pauses while native code waits.
  * Added a native `run_pending` capability to advance async work in small time slices.
* **Bug Fixes**
  * Fixed HTTP request lifetime tracking to keep the event loop alive during active external HTTP operations.
  * Prevented WebSocket waits from blocking the thread, and improved handling of queued network events to avoid re-entrant stalls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->