### PR TITLE
fix(intl): #5835 — new.target requirement + Reflect.construct prototype for Intl service ctors

### DIFF
--- a/crates/perry-runtime/src/intl.rs
+++ b/crates/perry-runtime/src/intl.rs
@@ -17,6 +17,8 @@ use crate::StringHeader;
 #[cfg(feature = "intl-segmenter")]
 use unicode_segmentation::UnicodeSegmentation;
 
+mod ctor_guard;
+use ctor_guard::{constructor_target_prototype, require_new_target};
 mod display_names;
 mod duration_format;
 mod locale;
@@ -1600,7 +1602,7 @@ fn make_instance(closure: *const ClosureHeader, kind: &str, locales: f64, option
         _ => {}
     }
 
-    let proto = crate::closure::closure_get_dynamic_prop(closure as usize, "prototype");
+    let proto = constructor_target_prototype(closure);
     if JSValue::from_bits(proto.to_bits()).is_pointer() {
         crate::object::prototype_chain::object_set_static_prototype(obj as usize, proto.to_bits());
     }
@@ -1654,6 +1656,7 @@ extern "C" fn collator_constructor_thunk(closure: *const ClosureHeader, rest: f6
 }
 
 extern "C" fn segmenter_constructor_thunk(closure: *const ClosureHeader, rest: f64) -> f64 {
+    require_new_target("Segmenter");
     make_instance(
         closure,
         KIND_SEGMENTER,
@@ -1663,6 +1666,7 @@ extern "C" fn segmenter_constructor_thunk(closure: *const ClosureHeader, rest: f
 }
 
 extern "C" fn list_format_constructor_thunk(closure: *const ClosureHeader, rest: f64) -> f64 {
+    require_new_target("ListFormat");
     make_instance(
         closure,
         KIND_LIST_FORMAT,
@@ -1675,6 +1679,7 @@ extern "C" fn relative_time_format_constructor_thunk(
     closure: *const ClosureHeader,
     rest: f64,
 ) -> f64 {
+    require_new_target("RelativeTimeFormat");
     make_instance(
         closure,
         KIND_RELATIVE_TIME,
@@ -1684,6 +1689,7 @@ extern "C" fn relative_time_format_constructor_thunk(
 }
 
 extern "C" fn plural_rules_constructor_thunk(closure: *const ClosureHeader, rest: f64) -> f64 {
+    require_new_target("PluralRules");
     make_instance(
         closure,
         KIND_PLURAL_RULES,

--- a/crates/perry-runtime/src/intl/ctor_guard.rs
+++ b/crates/perry-runtime/src/intl/ctor_guard.rs
@@ -1,0 +1,40 @@
+//! Shared `[[Construct]]`-only checks and `new.target`-aware prototype
+//! resolution used by the Intl service constructors (#5835). Split out of
+//! `intl.rs` to keep that file under the repository's 2,000-line gate.
+
+use crate::closure::ClosureHeader;
+use crate::object::{js_object_get_field_by_name_f64, ObjectHeader};
+use crate::string::js_string_from_bytes;
+use crate::value::JSValue;
+
+/// `GetPrototypeFromConstructor(new.target, "%<Ctor>Prototype%")`: a
+/// `Reflect.construct(Intl.X, args, CustomCtor)` call should install
+/// `CustomCtor.prototype` on the result (test262 `ctor-custom-prototype.js`),
+/// falling back to the invoked closure's own `"prototype"` when `new.target`
+/// is absent (a bare `new Intl.X()`) or its `prototype` isn't an object.
+pub(super) fn constructor_target_prototype(closure: *const ClosureHeader) -> f64 {
+    const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
+    const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
+    let new_target = crate::object::js_new_target_get();
+    let bits = new_target.to_bits();
+    if (bits & !POINTER_MASK) == POINTER_TAG {
+        let raw = (bits & POINTER_MASK) as usize;
+        if raw != 0 {
+            let key = js_string_from_bytes(b"prototype".as_ptr(), b"prototype".len() as u32);
+            let proto = js_object_get_field_by_name_f64(raw as *const ObjectHeader, key);
+            if JSValue::from_bits(proto.to_bits()).is_pointer() {
+                return proto;
+            }
+        }
+    }
+    crate::closure::closure_get_dynamic_prop(closure as usize, "prototype")
+}
+
+/// `Intl.<X>` is `[[Construct]]`-only per ECMA-402 (unlike the legacy
+/// factory-pattern `NumberFormat`/`DateTimeFormat`/`Collator`): a bare call
+/// or `.call(obj)` must throw a `TypeError` rather than silently `new`-ing.
+pub(super) fn require_new_target(name: &str) {
+    if crate::object::js_new_target_get().to_bits() == crate::value::TAG_UNDEFINED {
+        super::throw_type_error(&format!("Constructor Intl.{name} requires 'new'"));
+    }
+}

--- a/crates/perry-runtime/src/intl/locale.rs
+++ b/crates/perry-runtime/src/intl/locale.rs
@@ -650,6 +650,7 @@ fn transform_instance(obj: *const ObjectHeader, transform: fn(&mut ParsedLocale)
 }
 
 extern "C" fn locale_constructor_thunk(closure: *const ClosureHeader, rest: f64) -> f64 {
+    super::require_new_target("Locale");
     let tag_value = super::rest_arg(rest, 0);
     let options_value = super::rest_arg(rest, 1);
     let tag_js = JSValue::from_bits(tag_value.to_bits());
@@ -682,7 +683,7 @@ extern "C" fn locale_constructor_thunk(closure: *const ClosureHeader, rest: f64)
     }
     apply_options(&mut parsed, options);
 
-    let proto = crate::closure::closure_get_dynamic_prop(closure as usize, "prototype");
+    let proto = super::constructor_target_prototype(closure);
     make_locale_instance(proto.to_bits(), &parsed)
 }
 

--- a/test-files/test_gap_intl_ctor_mechanics_5835.ts
+++ b/test-files/test_gap_intl_ctor_mechanics_5835.ts
@@ -1,0 +1,51 @@
+// #5835 — Intl service constructor mechanics: `new.target` requirement and
+// `Reflect.construct`-driven prototype selection.
+//
+// ECMA-402 step 1 for ListFormat/RelativeTimeFormat/Segmenter/PluralRules/
+// Locale is "If NewTarget is undefined, throw a TypeError exception" — unlike
+// the legacy factory-pattern NumberFormat/DateTimeFormat/Collator, which
+// silently `new`-ed on a bare call. And OrdinaryCreateFromConstructor means
+// `Reflect.construct(Intl.X, args, Custom)` must install `Custom.prototype`
+// on the result, not `Intl.X.prototype`. Both must match
+// `node --experimental-strip-types` byte-for-byte.
+function probe(name: string, fn: () => unknown): string {
+  try {
+    fn();
+    return "no throw";
+  } catch (e) {
+    return (e as Error).constructor.name;
+  }
+}
+
+const I: any = (globalThis as any).Intl;
+
+console.log("ListFormat()", probe("ListFormat", () => I.ListFormat()));
+console.log("RelativeTimeFormat()", probe("RelativeTimeFormat", () => I.RelativeTimeFormat()));
+console.log("Segmenter()", probe("Segmenter", () => I.Segmenter()));
+console.log("PluralRules()", probe("PluralRules", () => I.PluralRules()));
+console.log("PluralRules.call(undefined)", probe("PluralRules.call", () => I.PluralRules.call(undefined)));
+console.log("Locale()", probe("Locale", () => I.Locale()));
+console.log("Locale('en')", probe("Locale('en')", () => I.Locale("en")));
+
+// Legacy factory-pattern constructors still allow a bare call (no `new`).
+console.log("NumberFormat bare call", probe("NumberFormat", () => I.NumberFormat("en")));
+console.log("DateTimeFormat bare call", probe("DateTimeFormat", () => I.DateTimeFormat("en")));
+console.log("Collator bare call", probe("Collator", () => I.Collator("en")));
+
+// `Reflect.construct(Intl.X, args, Custom)` installs `Custom.prototype`.
+{
+  const custom: any = new Function();
+  custom.prototype = {};
+  const obj = Reflect.construct(I.DisplayNames, [undefined, { type: "language" }], custom);
+  console.log("DisplayNames custom prototype", Object.getPrototypeOf(obj) === custom.prototype);
+}
+{
+  const custom: any = new Function();
+  custom.prototype = {};
+  const obj = Reflect.construct(I.Segmenter, [], custom);
+  console.log("Segmenter custom prototype", Object.getPrototypeOf(obj) === custom.prototype);
+}
+
+// Ordinary (non-Reflect.construct) instances still resolve the default prototype.
+console.log("plain ListFormat prototype", Object.getPrototypeOf(new I.ListFormat("en")) === I.ListFormat.prototype);
+console.log("plain Locale prototype", Object.getPrototypeOf(new I.Locale("en")) === I.Locale.prototype);


### PR DESCRIPTION
## Summary
- `Intl.ListFormat`/`RelativeTimeFormat`/`Segmenter`/`PluralRules`/`Locale` now throw a `TypeError` when `NewTarget` is undefined (ECMA-402 step 1), matching the spec's `[[Construct]]`-only constructors — the legacy factory-pattern `NumberFormat`/`DateTimeFormat`/`Collator` are untouched and still allow a bare call.
- The shared `make_instance()` tail (used by NumberFormat/DateTimeFormat/Collator/Segmenter/ListFormat/RelativeTimeFormat/PluralRules/DurationFormat/DisplayNames) and `Intl.Locale`'s own constructor now resolve the instance prototype via `new.target.prototype` (falling back to the invoked closure's own prototype), so `Reflect.construct(Intl.X, args, Custom)` correctly installs `Custom.prototype` instead of silently dropping it.
- New helper module `crates/perry-runtime/src/intl/ctor_guard.rs` holds the two small shared helpers (`require_new_target`, `constructor_target_prototype`) — split out to keep `intl.rs` under the repo's 2,000-line file-size gate.

Fixes 7 of the 108 test262 `intl402` failures cataloged in #5835:
- `ListFormat/constructor/constructor/newtarget-undefined.js`
- `RelativeTimeFormat/constructor/constructor/newtarget-undefined.js`
- `Segmenter/constructor/constructor/newtarget-undefined.js`
- `PluralRules/undefined-newtarget-throws.js`
- `Locale/constructor-newtarget-undefined.js`
- `DisplayNames/ctor-custom-prototype.js`
- `Segmenter/ctor-custom-prototype.js`

**Out of scope** (per the issue's "pick a coherent subcluster" guidance): `class extends Intl.X { constructor(){ super(...) } }` subclassing (`ListFormat/subclassing.js`, `RelativeTimeFormat/subclassing.js`, `Segmenter/subclassing.js`, `PluralRules/can-be-subclassed.js`, `Locale/subclassing.js`) is a separate, deeper issue: the native-parent `super()` runtime dispatch (`js_fetch_or_value_super`) calls the Intl constructor with implicit `this` bound to the pre-existing derived instance, but `make_instance()` ignores implicit `this` and returns a fresh object whose own properties (e.g. `select`) never reach the real instance. That needs a Temporal-style `attach_*_to_this` adapter and is a bigger, separate change. Likewise the `supportedLocalesOf(locales, options)` `options-toobject.js` cases (options-read getter-call-count) are the same category as the already-tracked #5581 (Intl option reads bypass a real spec `[[Get]]`/`ToObject`), not a constructor-mechanics bug.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/check_file_size.sh`
- [x] `cargo test --release -p perry-runtime` (1106 passed; the 2 failures reproduce in isolation as pre-existing, unrelated flakes — `object::tests::builtin_prototype_methods_reject_dynamic_new` and `url::node_compat::tests::path_to_file_url_posix_preserves_relative_trailing_slash` both pass individually)
- [x] New differential regression test `test-files/test_gap_intl_ctor_mechanics_5835.ts` matches `node --experimental-strip-types` byte-for-byte
- [x] `scripts/test262_subset.py --root vendor/test262 --dir intl402/Collator intl402/DisplayNames intl402/ListFormat intl402/PluralRules intl402/RelativeTimeFormat intl402/Segmenter intl402/Locale` — the 7 targeted cases now pass, zero regressions vs the #5835 baseline in that scope

Reference: #5835

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `Intl` constructor behavior to better match expected JavaScript semantics.
  * `Intl.Locale`, `Intl.ListFormat`, `Intl.RelativeTimeFormat`, `Intl.Segmenter`, and `Intl.PluralRules` now require `new` when constructed.
  * Instance prototypes now resolve more consistently, including when using `Reflect.construct` with a custom constructor.
  * Added coverage for constructor and prototype behavior across several `Intl` APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->