### PR TITLE
fix(runtime): #5834 — WeakMap/WeakSet constructor + instance-identity test262 fixes

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -392,11 +392,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 // `ArrayBuffer` — runtime detects BufferHeader storage marked
                 // with Perry's ArrayBuffer side registry.
                 "ArrayBuffer" => 0xFFFF0025u32,
-                // WeakMap / WeakSet / DataView — no runtime probe for real
-                // instances yet (those return false independently), but the
-                // reserved ids let a `class S extends WeakMap {}` subclass
-                // instance match via the class-chain walk in
-                // perry-runtime/src/object/instanceof.rs. Refs
+                // WeakMap / WeakSet: real instances match via a runtime probe
+                // (CLASS_ID_WEAKMAP/CLASS_ID_WEAKSET in weakref.rs, #5834) —
+                // see the matching arm in perry-runtime/src/object/instanceof.rs.
+                // DataView has no such probe yet (returns false independently),
+                // but this reserved id still lets a `class S extends DataView {}`
+                // subclass instance match via the class-chain walk. Refs
                 // class/subclass-builtins/subclass-{WeakMap,WeakSet,DataView}.
                 "DataView" => 0xFFFF002Bu32,
                 "WeakMap" => 0xFFFF002Cu32,

--- a/crates/perry-runtime/src/collection_iter.rs
+++ b/crates/perry-runtime/src/collection_iter.rs
@@ -183,6 +183,30 @@ pub(crate) fn normalize_callable_value(value: f64) -> f64 {
     value
 }
 
+/// `Get(receiver, method_name)` resolved off `builtin_name`'s `.prototype`,
+/// honoring an accessor descriptor installed there
+/// (`Object.defineProperty(WeakMap.prototype, 'set', {get(){throw ...}})`) so
+/// a throwing getter propagates per the constructor spec's
+/// `ReturnIfAbrupt(adder)` step. Falls back to the plain installed method
+/// value — [`builtin_prototype_method`] — for the common case (a normal data
+/// property, whether the built-in thunk or a user override).
+pub(crate) fn builtin_prototype_adder(builtin_name: &str, method_name: &str, receiver: f64) -> f64 {
+    let proto = crate::object::builtin_prototype_value(builtin_name);
+    let proto_addr = js_nanbox_get_pointer(proto) as usize;
+    if proto_addr == 0 {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    if let Some(acc) = crate::object::get_accessor_descriptor(proto_addr, method_name) {
+        if acc.get == 0 {
+            return f64::from_bits(TAG_UNDEFINED);
+        }
+        return f64::from_bits(
+            unsafe { crate::object::invoke_accessor_getter(acc.get, receiver) }.bits(),
+        );
+    }
+    builtin_prototype_method(builtin_name, method_name)
+}
+
 pub(crate) fn builtin_prototype_method(builtin_name: &str, method_name: &str) -> f64 {
     let key = crate::string::js_string_from_bytes(method_name.as_ptr(), method_name.len() as u32);
     let proto = crate::object::builtin_prototype_value(builtin_name);

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
@@ -1302,6 +1302,21 @@ pub(crate) fn get_field_by_name_object_tail(
                     return v;
                 }
                 let class_id = (*obj).class_id;
+                // #5834: WeakMap/WeakSet instances carry a reserved class_id
+                // (not a registered declared-class one), so none of the
+                // arms below resolve them and `(new WeakMap()).constructor`
+                // fell through to `undefined`.
+                if class_id == crate::weakref::CLASS_ID_WEAKMAP
+                    || class_id == crate::weakref::CLASS_ID_WEAKSET
+                {
+                    let name: &[u8] = if class_id == crate::weakref::CLASS_ID_WEAKMAP {
+                        b"WeakMap"
+                    } else {
+                        b"WeakSet"
+                    };
+                    let v = js_get_global_this_builtin_value(name.as_ptr(), name.len());
+                    return JSValue::from_bits(v.to_bits());
+                }
                 if class_id != 0 && class_has_own_method(class_id, "constructor") {
                     let value = class_prototype_method_value_for_name(class_id, "constructor");
                     return JSValue::from_bits(value.to_bits());

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -374,6 +374,12 @@ pub(crate) fn global_builtin_constructor_class_id(name: &str) -> u32 {
     match name {
         "Map" => 0xFFFF0022,
         "Set" => 0xFFFF0023,
+        // #5834: kept in sync with the reserved ids in
+        // perry-codegen/src/expr/instance_misc1.rs so a dynamic
+        // `x instanceof ctorVar` (ctorVar holding WeakMap/WeakSet) resolves
+        // through the same runtime probe as the compile-time-literal form.
+        "WeakMap" => 0xFFFF002C,
+        "WeakSet" => 0xFFFF002D,
         "RegExp" => 0xFFFF0021,
         "ArrayBuffer" => 0xFFFF0025,
         "Array" => 0xFFFF0024,
@@ -1029,6 +1035,33 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
             }
         }
         return false_val;
+    }
+    // #5834: `x instanceof WeakMap`/`WeakSet` for a REAL instance. These
+    // reserved ids (kept in sync with perry-codegen/src/expr/instance_misc1.rs)
+    // are distinct from the runtime `CLASS_ID_WEAKMAP`/`CLASS_ID_WEAKSET`
+    // stamped on actual instances (weakref.rs) — the subclass-chain walk above
+    // only matches a `class S extends WeakMap {}` instance (whose chain reaches
+    // this reserved id), so a genuine `new WeakMap()` still needs its own probe
+    // here, same shape as Map/Set above.
+    const CLASS_ID_WEAKMAP_RESERVED: u32 = 0xFFFF002C;
+    const CLASS_ID_WEAKSET_RESERVED: u32 = 0xFFFF002D;
+    if class_id == CLASS_ID_WEAKMAP_RESERVED {
+        return if crate::weakref::weak_class_id_from_receiver(value)
+            == Some(crate::weakref::CLASS_ID_WEAKMAP)
+        {
+            true_val
+        } else {
+            false_val
+        };
+    }
+    if class_id == CLASS_ID_WEAKSET_RESERVED {
+        return if crate::weakref::weak_class_id_from_receiver(value)
+            == Some(crate::weakref::CLASS_ID_WEAKSET)
+        {
+            true_val
+        } else {
+            false_val
+        };
     }
     if class_id == CLASS_ID_REGEXP {
         if jsval.is_pointer() {

--- a/crates/perry-runtime/src/object/object_ops/prototype.rs
+++ b/crates/perry-runtime/src/object/object_ops/prototype.rs
@@ -209,6 +209,27 @@ pub extern "C" fn js_object_get_prototype_of(obj_value: f64) -> f64 {
                 return Some(proto);
             }
         }
+        // #5834: WeakMap/WeakSet instances are `GC_TYPE_OBJECT`s stamped with
+        // a reserved `class_id` (CLASS_ID_WEAKMAP/CLASS_ID_WEAKSET), not a
+        // registered declared-class id, so the generic class-id prototype
+        // walk further down never resolves them and instance receivers fell
+        // through to `return obj_value` (i.e. `getPrototypeOf(wm) === wm`).
+        // `weak_class_id_from_receiver` pre-validates the address via the
+        // GC-header read (safe for a garbage/foreign pointer) before
+        // comparing `class_id`, matching the `is_registered_map`/
+        // `is_registered_set` safety bar above.
+        let receiver = crate::value::js_nanbox_pointer(addr as i64);
+        if let Some(class_id) = crate::weakref::weak_class_id_from_receiver(receiver) {
+            let name = if class_id == crate::weakref::CLASS_ID_WEAKMAP {
+                "WeakMap"
+            } else {
+                "WeakSet"
+            };
+            let proto = crate::object::builtin_prototype_value(name);
+            if proto.to_bits() != crate::value::TAG_UNDEFINED {
+                return Some(proto);
+            }
+        }
         None
     };
     let buffer_backed_prototype = |addr: usize| -> Option<f64> {

--- a/crates/perry-runtime/src/weakref.rs
+++ b/crates/perry-runtime/src/weakref.rs
@@ -815,13 +815,20 @@ pub unsafe fn try_weak_method_dispatch(
     } else {
         &[]
     };
+    // #5834: dispatch regardless of arg count, padding missing positions with
+    // `undefined` — mirrors calling the real thunks reflectively. Arity-gating
+    // these arms let `s.add()` (zero args) fall through to the `_ => undefined`
+    // no-op, skipping `js_weakset_add`'s CanBeHeldWeakly check entirely (it
+    // must throw `TypeError` since `undefined` cannot be held weakly).
+    let undef = f64::from_bits(TAG_UNDEFINED);
+    let arg = |i: usize| args.get(i).copied().unwrap_or(undef);
     let result = match method_name {
-        "set" if args.len() >= 2 => js_weakmap_set(receiver, args[0], args[1]),
-        "add" if !args.is_empty() => js_weakset_add(receiver, args[0]),
-        "get" if !args.is_empty() => js_weakmap_get(receiver, args[0]),
-        "has" if !args.is_empty() => js_weakmap_has(receiver, args[0]),
-        "delete" if !args.is_empty() => js_weakmap_delete(receiver, args[0]),
-        _ => f64::from_bits(TAG_UNDEFINED),
+        "set" => js_weakmap_set(receiver, arg(0), arg(1)),
+        "add" => js_weakset_add(receiver, arg(0)),
+        "get" => js_weakmap_get(receiver, arg(0)),
+        "has" => js_weakmap_has(receiver, arg(0)),
+        "delete" => js_weakmap_delete(receiver, arg(0)),
+        _ => undef,
     };
     Some(result)
 }
@@ -875,34 +882,97 @@ pub extern "C" fn js_weakmap_new() -> *mut ObjectHeader {
     obj
 }
 
+/// `WeakMap ( [ iterable ] )`'s `AddEntriesFromIterable` step. `map` is the
+/// already-allocated (empty) WeakMap from `js_weakmap_new`; this only
+/// populates it. #5834: only fetches/validates the `set` adder when
+/// `iterable` is present (spec steps 6-7 — null/undefined return BEFORE
+/// `Get(map, "set")`, so a poisoned `WeakMap.prototype.set` getter must not
+/// fire for `new WeakMap()` / `new WeakMap(null)`), then drives the iterable
+/// with lazy per-item stepping (`iterator_next_value`) so an abrupt
+/// `Get`/adder-call closes the iterator (`IteratorClose`) before rethrowing.
+/// Mirrors `js_map_from_iterable` (`map.rs`).
 #[no_mangle]
 pub extern "C" fn js_weakmap_init_iterable(map: f64, iterable: f64) -> f64 {
-    use crate::collection_iter::{classify_init, InitIter};
+    use crate::collection_iter::{constructor_iter, ConstructorIter};
 
-    // #2772: consume ANY iterable (Map/Set/custom), throw on non-iterables,
-    // require each yielded value to be an entry object, and require each key
-    // to be an object (`js_weakmap_set` validates the key).
-    let arr_ptr = match classify_init(iterable) {
-        InitIter::Empty => return map,
-        InitIter::Values(p) => p as *const ArrayHeader,
-    };
-    if arr_ptr.is_null() {
+    if crate::collection_iter::is_null_or_undefined(iterable) {
         return map;
     }
-    unsafe {
-        let len = js_array_length(arr_ptr) as usize;
-        for i in 0..len {
-            let entry = js_array_get_f64(arr_ptr, i as u32);
-            if !crate::collection_iter::is_entry_object(entry) {
-                crate::collection_iter::throw_not_entry_object(entry);
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let map_handle = scope.root_nanbox_f64(map);
+    let iterable_handle = scope.root_nanbox_f64(iterable);
+
+    let adder = crate::collection_iter::require_callable(
+        crate::collection_iter::builtin_prototype_adder(
+            "WeakMap",
+            "set",
+            map_handle.get_nanbox_f64(),
+        ),
+        "WeakMap.prototype.set",
+    );
+    let adder = crate::collection_iter::normalize_callable_value(adder);
+    let adder_handle = scope.root_nanbox_f64(adder);
+
+    fn add_entry(
+        map_handle: crate::gc::RuntimeHandle<'_>,
+        adder_handle: crate::gc::RuntimeHandle<'_>,
+        entry: f64,
+        iter_to_close: Option<f64>,
+    ) {
+        if !crate::collection_iter::is_entry_object(entry) {
+            if let Some(iter) = iter_to_close {
+                crate::collection_iter::iterator_close(iter);
             }
-            let entry_bits = entry.to_bits() as i64;
+            crate::collection_iter::throw_not_entry_object(entry);
+        }
+        let entry_bits = entry.to_bits() as i64;
+        let result = crate::collection_iter::call_capturing_throw(|| {
             let key = crate::object::js_object_get_index_polymorphic(entry_bits, 0.0);
             let val = crate::object::js_object_get_index_polymorphic(entry_bits, 1.0);
-            js_weakmap_set(map, key, val);
+            let adder = adder_handle.get_nanbox_f64();
+            let map = map_handle.get_nanbox_f64();
+            crate::collection_iter::call_with_this_capturing_throw(adder, map, &[key, val])
+                .unwrap_or_else(|exc| crate::exception::js_throw(exc))
+        });
+        if let Err(exc) = result {
+            if let Some(iter) = iter_to_close {
+                crate::collection_iter::iterator_close(iter);
+            }
+            crate::exception::js_throw(exc);
         }
     }
-    map
+
+    match constructor_iter(iterable_handle.get_nanbox_f64()) {
+        ConstructorIter::Empty => {}
+        ConstructorIter::Array(arr_value) => {
+            let arr_handle = scope.root_nanbox_f64(arr_value);
+            let arr_ptr = js_nanbox_get_pointer(arr_handle.get_nanbox_f64()) as *mut ArrayHeader;
+            if !arr_ptr.is_null() {
+                let len = unsafe { js_array_length(arr_ptr) as usize };
+                for i in 0..len {
+                    let entry = unsafe {
+                        let arr = js_nanbox_get_pointer(arr_handle.get_nanbox_f64())
+                            as *const ArrayHeader;
+                        js_array_get_f64(arr, i as u32)
+                    };
+                    add_entry(map_handle, adder_handle, entry, None);
+                }
+            }
+        }
+        ConstructorIter::Iterator(iter) => {
+            let iter_handle = scope.root_nanbox_f64(iter);
+            loop {
+                let iter = iter_handle.get_nanbox_f64();
+                let Some(entry) = crate::collection_iter::iterator_next_value(iter) else {
+                    break;
+                };
+                add_entry(map_handle, adder_handle, entry, Some(iter));
+            }
+        }
+    }
+
+    map_handle.get_nanbox_f64()
 }
 
 /// Throw `TypeError: Invalid value used as weak map key` (WeakMap key must be
@@ -1100,26 +1170,77 @@ pub extern "C" fn js_weakset_new() -> *mut ObjectHeader {
     obj
 }
 
+/// `WeakSet ( [ iterable ] )`'s iterable-consumption loop. `set` is the
+/// already-allocated (empty) WeakSet from `js_weakset_new`; this only
+/// populates it. See [`js_weakmap_init_iterable`] for the shared rationale
+/// (adder fetched only when `iterable` is present; lazy per-item stepping
+/// with `IteratorClose` on an abrupt `add` call). Mirrors `js_set_from_iterable`
+/// (`set.rs`).
 #[no_mangle]
 pub extern "C" fn js_weakset_init_iterable(set: f64, iterable: f64) -> f64 {
-    use crate::collection_iter::{classify_init, InitIter};
+    use crate::collection_iter::{constructor_iter, ConstructorIter};
 
-    // #2772: consume ANY iterable (Map/Set/custom), throw on non-iterables,
-    // and require each value to be an object (`js_weakset_add` validates).
-    let arr_ptr = match classify_init(iterable) {
-        InitIter::Empty => return set,
-        InitIter::Values(p) => p as *const ArrayHeader,
-    };
-    if arr_ptr.is_null() {
+    if crate::collection_iter::is_null_or_undefined(iterable) {
         return set;
     }
-    unsafe {
-        let len = js_array_length(arr_ptr) as usize;
-        for i in 0..len {
-            js_weakset_add(set, js_array_get_f64(arr_ptr, i as u32));
+
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let set_handle = scope.root_nanbox_f64(set);
+    let iterable_handle = scope.root_nanbox_f64(iterable);
+
+    let adder = crate::collection_iter::require_callable(
+        crate::collection_iter::builtin_prototype_adder(
+            "WeakSet",
+            "add",
+            set_handle.get_nanbox_f64(),
+        ),
+        "WeakSet.prototype.add",
+    );
+    let adder = crate::collection_iter::normalize_callable_value(adder);
+    let adder_handle = scope.root_nanbox_f64(adder);
+
+    let add_value = |element: f64, iter_to_close: Option<f64>| {
+        let adder = adder_handle.get_nanbox_f64();
+        let set = set_handle.get_nanbox_f64();
+        let result = crate::collection_iter::call_with_this_capturing_throw(adder, set, &[element]);
+        if let Err(exc) = result {
+            if let Some(iter) = iter_to_close {
+                crate::collection_iter::iterator_close(iter);
+            }
+            crate::exception::js_throw(exc);
+        }
+    };
+
+    match constructor_iter(iterable_handle.get_nanbox_f64()) {
+        ConstructorIter::Empty => {}
+        ConstructorIter::Array(arr_value) => {
+            let arr_handle = scope.root_nanbox_f64(arr_value);
+            let arr_ptr = js_nanbox_get_pointer(arr_handle.get_nanbox_f64()) as *mut ArrayHeader;
+            if !arr_ptr.is_null() {
+                let len = unsafe { js_array_length(arr_ptr) as usize };
+                for i in 0..len {
+                    let element = unsafe {
+                        let arr = js_nanbox_get_pointer(arr_handle.get_nanbox_f64())
+                            as *const ArrayHeader;
+                        js_array_get_f64(arr, i as u32)
+                    };
+                    add_value(element, None);
+                }
+            }
+        }
+        ConstructorIter::Iterator(iter) => {
+            let iter_handle = scope.root_nanbox_f64(iter);
+            loop {
+                let iter = iter_handle.get_nanbox_f64();
+                let Some(element) = crate::collection_iter::iterator_next_value(iter) else {
+                    break;
+                };
+                add_value(element, Some(iter));
+            }
         }
     }
-    set
+
+    set_handle.get_nanbox_f64()
 }
 
 #[no_mangle]

--- a/crates/perry-runtime/src/weakref.rs
+++ b/crates/perry-runtime/src/weakref.rs
@@ -789,12 +789,15 @@ pub const CLASS_ID_WEAKSET: u32 = 0xFFFF_0028;
 /// Dynamic-dispatch entry point for WeakMap/WeakSet method calls (issue
 /// #1757/#1758). `js_native_call_method` calls this for any heap object;
 /// it returns `Some(result)` only when `obj` carries the reserved
-/// WeakMap/WeakSet `class_id` and `method_name` is one of their methods,
-/// and `None` otherwise so the caller falls through to its normal
+/// WeakMap/WeakSet `class_id` and `method_name` is one of *that class's own*
+/// methods, and `None` otherwise so the caller falls through to its normal
 /// dispatch. `receiver` is the NaN-boxed f64 the `js_weak*` helpers expect.
 ///
-/// Unknown methods on a known WeakMap/WeakSet resolve to `undefined`,
-/// mirroring the Map/Set registry arms in the dynamic dispatcher.
+/// A method that isn't one of the receiver's own (e.g. `"add"` on a WeakMap,
+/// or any name outside `set`/`add`/`get`/`has`/`delete`) falls through to
+/// `None` so the ordinary property lookup resolves it — correctly missing
+/// and raising `TypeError: ... is not a function` on a call, rather than
+/// this function silently answering `undefined`.
 ///
 /// # Safety
 /// `obj` must be a valid, readable `ObjectHeader` pointer (the caller has
@@ -817,18 +820,25 @@ pub unsafe fn try_weak_method_dispatch(
     };
     // #5834: dispatch regardless of arg count, padding missing positions with
     // `undefined` — mirrors calling the real thunks reflectively. Arity-gating
-    // these arms let `s.add()` (zero args) fall through to the `_ => undefined`
-    // no-op, skipping `js_weakset_add`'s CanBeHeldWeakly check entirely (it
-    // must throw `TypeError` since `undefined` cannot be held weakly).
+    // these arms let `s.add()` (zero args) fall through to a no-op, skipping
+    // `js_weakset_add`'s CanBeHeldWeakly check entirely (it must throw
+    // `TypeError` since `undefined` cannot be held weakly).
+    //
+    // Also gate each method by the receiver's actual class: `"set"`/`"get"`
+    // only exist on WeakMap, `"add"` only on WeakSet (`"has"`/`"delete"` are
+    // shared). Without this a WeakMap receiver could reach `js_weakset_add`
+    // for a `.add(...)` call (and vice versa) instead of falling through to
+    // the ordinary property lookup, which correctly resolves the missing
+    // method to `undefined` and throws `TypeError: ... is not a function`.
     let undef = f64::from_bits(TAG_UNDEFINED);
     let arg = |i: usize| args.get(i).copied().unwrap_or(undef);
-    let result = match method_name {
-        "set" => js_weakmap_set(receiver, arg(0), arg(1)),
-        "add" => js_weakset_add(receiver, arg(0)),
-        "get" => js_weakmap_get(receiver, arg(0)),
-        "has" => js_weakmap_has(receiver, arg(0)),
-        "delete" => js_weakmap_delete(receiver, arg(0)),
-        _ => undef,
+    let result = match (method_name, class_id) {
+        ("set", CLASS_ID_WEAKMAP) => js_weakmap_set(receiver, arg(0), arg(1)),
+        ("add", CLASS_ID_WEAKSET) => js_weakset_add(receiver, arg(0)),
+        ("get", CLASS_ID_WEAKMAP) => js_weakmap_get(receiver, arg(0)),
+        ("has", _) => js_weakmap_has(receiver, arg(0)),
+        ("delete", _) => js_weakmap_delete(receiver, arg(0)),
+        _ => return None,
     };
     Some(result)
 }


### PR DESCRIPTION
## Summary

Fixes the `built-ins/WeakMap` (11) and `built-ins/WeakSet` (7) test262 failures from the #5834 worklist — a coherent single-root subcluster: WeakMap/WeakSet constructor semantics and instance identity.

- **Constructor iterable handling**: `js_weakmap_init_iterable`/`js_weakset_init_iterable` previously drained the whole iterable eagerly via a native helper and never actually read/called the `set`/`add` adder through a real property `Get`. Rewrote both to mirror `js_map_from_iterable`/`js_set_from_iterable`: fetch the adder only when `iterable` is non-null/undefined (matching spec step order, so a poisoned `WeakMap.prototype.set` accessor getter must not fire for `new WeakMap()`/`new WeakMap(null)`), honor an accessor descriptor on `set`/`add` via a new `collection_iter::builtin_prototype_adder` helper, and drive the iterable with lazy per-item stepping (`iterator_next_value`) so an abrupt `Get`/adder-call closes the iterator (`IteratorClose`) before rethrowing.
- **Arity-gated dispatch bug**: `try_weak_method_dispatch`'s `"add"`/`"set"`/etc. arms were gated on `args.len()`, so an under-arity call like `s.add()` fell through to a no-op instead of running `WeakSet.prototype.add`'s `CanBeHeldWeakly` check (which must throw `TypeError` for `undefined`). Now always dispatches, padding missing positions with `undefined`.
- **Instance identity**: `Object.getPrototypeOf(new WeakMap())` and `(new WeakMap()).constructor` had no arm for WeakMap/WeakSet instances (a reserved, non-declared-class `class_id`), so both fell through to the receiver itself / `undefined`. Added arms in `prototype.rs`'s `collection_prototype` closure and `get_field_by_name_tail.rs`'s `constructor` special case.
- **`instanceof`**: `x instanceof WeakMap`/`WeakSet` had no runtime probe for real instances — this was a documented, deliberate gap in `perry-codegen/src/expr/instance_misc1.rs` ("no runtime probe for real instances yet"). Added a probe in `js_instanceof` (compile-time-literal path) plus the `global_builtin_constructor_class_id` counterpart for the dynamic `x instanceof ctorVar` form.

## Test plan

- [x] `scripts/test262_subset.py --dir built-ins/WeakMap built-ins/WeakSet`: 18/18 originally-failing cases now pass; **100% parity** (158/158 judged), 0 regressions.
- [x] `cargo fmt --all -- --check` clean.
- [x] `bash scripts/check_file_size.sh` clean.
- [x] `cargo test --release -p perry-runtime -p perry-codegen`: 1107 passed / 1 failed. The 1 failure (`object::tests::builtin_prototype_methods_reject_dynamic_new`, asserting `Date.prototype.toJSON`) is unrelated to this change (no Date/global_this code touched) and matches a known pre-existing test-isolation flake in this suite (shared global builtin-population state races under parallel test threads).

No version bump / CHANGELOG update, per the #5834 worklist's code-only-PR instructions.

Refs #5834.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `WeakMap`/`WeakSet` handling for `constructor`, `prototype`, and `instanceof` checks, including correct resolution for internally-reserved class-id cases.
  * Corrected `getPrototypeOf` behavior so `getPrototypeOf(new WeakMap())`/`getPrototypeOf(new WeakSet())` no longer falls back to returning the receiver itself.
  * Fixed `WeakMap`/`WeakSet` method dispatch and iterable initialization for missing arguments, lazy consumption, and proper iterator cleanup on abrupt failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->