### PR TITLE
fix(hir,codegen): #5832 — static field/block interleaving, var-scope, double-invocation

### DIFF
--- a/crates/perry-codegen/src/codegen/helpers.rs
+++ b/crates/perry-codegen/src/codegen/helpers.rs
@@ -966,22 +966,54 @@ pub(super) fn init_static_fields_late(
     Ok(())
 }
 
-/// Returns true if `stmt` is a top-level `Expr(StaticMethodCall)`
-/// invoking the (`class_name`, `method_name`) pair — the shape HIR
-/// lowering emits at the class-decl position for each
+/// Returns true if `stmt` contains, at any nesting depth (through
+/// if/while/do-while/for/labeled/try/switch bodies), an `Expr(
+/// StaticMethodCall)` invoking the (`class_name`, `method_name`) pair —
+/// the shape HIR lowering emits at the class-decl position for each
 /// `__perry_static_init_*` synthetic method. Used by
 /// `init_static_fields_late` to skip per-(class, block) pairs that
 /// have already been invoked inline. (#2278)
+///
+/// Must recurse: a class declared inside `try { class C { static {...}
+/// } }` (test262 static-init-abrupt.js wraps its whole class this way)
+/// lowers its inline `StaticMethodCall` into the `Try`'s `body`, not at
+/// `hir.init`'s top level. A shallow top-level-only scan missed it, so
+/// this late fallback re-invoked the block a second time — outside the
+/// user's `try`, so a throwing block's second run surfaced as an
+/// uncaught exception instead of staying silently absent.
 fn init_calls_static_block(stmt: &perry_hir::Stmt, class_name: &str, method_name: &str) -> bool {
-    if let perry_hir::Stmt::Expr(perry_hir::Expr::StaticMethodCall {
-        class_name: c,
-        method_name: m,
-        ..
-    }) = stmt
-    {
-        c == class_name && m == method_name
-    } else {
-        false
+    use perry_hir::Stmt;
+    let any_calls = |stmts: &[Stmt]| {
+        stmts
+            .iter()
+            .any(|s| init_calls_static_block(s, class_name, method_name))
+    };
+    match stmt {
+        Stmt::Expr(perry_hir::Expr::StaticMethodCall {
+            class_name: c,
+            method_name: m,
+            ..
+        }) => c == class_name && m == method_name,
+        Stmt::If {
+            then_branch,
+            else_branch,
+            ..
+        } => any_calls(then_branch) || else_branch.as_ref().is_some_and(|b| any_calls(b)),
+        Stmt::While { body, .. } | Stmt::DoWhile { body, .. } | Stmt::For { body, .. } => {
+            any_calls(body)
+        }
+        Stmt::Labeled { body, .. } => init_calls_static_block(body, class_name, method_name),
+        Stmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            any_calls(body)
+                || catch.as_ref().is_some_and(|c| any_calls(&c.body))
+                || finally.as_ref().is_some_and(|f| any_calls(f))
+        }
+        Stmt::Switch { cases, .. } => cases.iter().any(|case| any_calls(&case.body)),
+        _ => false,
     }
 }
 

--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -756,48 +756,16 @@ pub(crate) fn lower_stmt(
                                     // statements — so `C.x` read immediately after the
                                     // binding saw the uninitialized (0.0) slot, and a
                                     // static method's `this.#priv` read undefined.
-                                    let static_field_inits: Vec<Stmt> = lowered_class
-                                        .static_fields
-                                        .iter()
-                                        .filter_map(|sf| {
-                                            sf.init.as_ref().map(|init| {
-                                                // `this` in a static initializer is
-                                                // the class constructor — see the
-                                                // matching substitution in the
-                                                // `Decl::Class` arm.
-                                                let mut init_value = init.clone();
-                                                crate::analysis::substitute_lexical_this_in_expr(
-                                                    &mut init_value,
-                                                    &Expr::ClassRef(bind_name.clone()),
-                                                );
-                                                if let Some(key) = sf.key_expr.as_ref() {
-                                                    Stmt::Expr(Expr::ClassStaticSymbolSet {
-                                                        class_name: bind_name.clone(),
-                                                        key: Box::new(key.clone()),
-                                                        value: Box::new(init_value),
-                                                    })
-                                                } else {
-                                                    Stmt::Expr(Expr::StaticFieldSet {
-                                                        class_name: bind_name.clone(),
-                                                        field_name: sf.name.clone(),
-                                                        value: Box::new(init_value),
-                                                    })
-                                                }
-                                            })
-                                        })
-                                        .collect();
-                                    let static_block_calls: Vec<Stmt> = lowered_class
-                                        .static_methods
-                                        .iter()
-                                        .filter(|m| m.name.starts_with("__perry_static_init_"))
-                                        .map(|m| {
-                                            Stmt::Expr(Expr::StaticMethodCall {
-                                                class_name: bind_name.clone(),
-                                                method_name: m.name.clone(),
-                                                args: Vec::new(),
-                                            })
-                                        })
-                                        .collect();
+                                    // Interleaved in source order (see
+                                    // `build_interleaved_static_init_stmts`) rather
+                                    // than all fields then all blocks.
+                                    let static_init_stmts =
+                                        crate::lower_decl::build_interleaved_static_init_stmts(
+                                            &class_expr.class.body,
+                                            &bind_name,
+                                            &lowered_class.static_fields,
+                                            &lowered_class.static_methods,
+                                        );
                                     push_class_dedup(module, lowered_class);
                                     if let Some(reg) = parent_register {
                                         module.init.push(reg);
@@ -805,10 +773,7 @@ pub(crate) fn lower_stmt(
                                     for reg in computed_member_registrations {
                                         module.init.push(Stmt::Expr(reg));
                                     }
-                                    for s in static_field_inits {
-                                        module.init.push(s);
-                                    }
-                                    for s in static_block_calls {
+                                    for s in static_init_stmts {
                                         module.init.push(s);
                                     }
                                     // Register the alias so `new X()` → `new X()`
@@ -1113,66 +1078,32 @@ pub(crate) fn lower_stmt(
                                 member,
                             )));
                     }
-                    // Inject static-field-init statements at the source
-                    // position of the class declaration. Per ES spec, a
-                    // class declaration's static initializers run when the
-                    // declaration evaluates — i.e., here in source order,
-                    // not at the top of module init. This matters when a
-                    // static field's initializer references a top-level
-                    // const declared earlier in the module: the upfront
-                    // `init_static_fields` pass at codegen.rs:3449 runs
-                    // before any user `Let` bindings, so it captures
-                    // unbound (undefined) values. The inline statements
-                    // re-run with the correct values once we reach this
-                    // point in source order.
-                    for sf in &class.static_fields {
-                        if let Some(init) = &sf.init {
-                            // Per ClassDefinitionEvaluation the initializer
-                            // runs with `this` bound to the class constructor;
-                            // these stmts evaluate in module-init context
-                            // (empty this_stack), so substitute lexical `this`
-                            // — including inside arrows — with the class ref.
-                            let mut init_value = init.clone();
-                            crate::analysis::substitute_lexical_this_in_expr(
-                                &mut init_value,
-                                &Expr::ClassRef(class.name.clone()),
-                            );
-                            if let Some(key) = sf.key_expr.as_ref() {
-                                module.init.push(Stmt::Expr(Expr::ClassStaticSymbolSet {
-                                    class_name: class.name.clone(),
-                                    key: Box::new(key.clone()),
-                                    value: Box::new(init_value),
-                                }));
-                            } else {
-                                module.init.push(Stmt::Expr(Expr::StaticFieldSet {
-                                    class_name: class.name.clone(),
-                                    field_name: sf.name.clone(),
-                                    value: Box::new(init_value),
-                                }));
-                            }
-                        }
-                    }
-                    // Static blocks — `class { static { ... } }`. Per ES
-                    // spec, these run as part of class evaluation in
-                    // source order, right AFTER the class's static-field
-                    // initializers. HIR lifts each block to a synthetic
-                    // static method `__perry_static_init_N`; emit an
-                    // inline `StaticMethodCall` here at the class-decl
-                    // position so each block fires at the right point.
-                    // The codegen-side fallback in `init_static_fields_late`
-                    // is kept for class expressions that bypass this
-                    // declaration path; it skips blocks already invoked
-                    // via this inline call. Closes the `test_gap_class_advanced`
-                    // "static block initialized" diff (#2278).
-                    for sm in &class.static_methods {
-                        if sm.name.starts_with("__perry_static_init_") {
-                            module.init.push(Stmt::Expr(Expr::StaticMethodCall {
-                                class_name: class.name.clone(),
-                                method_name: sm.name.clone(),
-                                args: Vec::new(),
-                            }));
-                        }
-                    }
+                    // Inject static-field-init and static-block-call
+                    // statements at the source position of the class
+                    // declaration, INTERLEAVED in source order (see
+                    // `build_interleaved_static_init_stmts`) — per
+                    // ClassDefinitionEvaluation, static fields and static
+                    // blocks are a single ordered evaluation pass, not all
+                    // fields followed by all blocks. This matters both for
+                    // observable ordering (test262 static-init-sequence.js)
+                    // and for a top-level const referenced by a later
+                    // field's initializer: the upfront `init_static_fields`
+                    // pass at codegen.rs:3449 runs before any user `Let`
+                    // bindings, so it captures unbound (undefined) values —
+                    // these inline statements re-run with the correct values
+                    // once we reach this point in source order. The
+                    // codegen-side fallback in `init_static_fields_late` is
+                    // kept for class expressions that bypass this
+                    // declaration path; it skips blocks already invoked via
+                    // this inline call.
+                    module.init.extend(
+                        crate::lower_decl::build_interleaved_static_init_stmts(
+                            &class_decl.class.body,
+                            &class.name,
+                            &class.static_fields,
+                            &class.static_methods,
+                        ),
+                    );
                     append_legacy_decorator_init_for_class(ctx, &mut module.init, &class);
                     push_class_dedup(module, class);
                 }

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -318,40 +318,15 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                 // declaration is evaluated. Without this, an in-function
                 // class's `static x = …` fields and `static { … }` blocks
                 // silently stayed at their zero default — only top-level
-                // classes initialized. Mirrors the top-level emission order
-                // (fields then blocks, per ClassDefinitionEvaluation), with
-                // lexical `this` in field initializers bound to the class ref.
-                for sf in &class.static_fields {
-                    if let Some(init) = &sf.init {
-                        let mut init_value = init.clone();
-                        crate::analysis::substitute_lexical_this_in_expr(
-                            &mut init_value,
-                            &Expr::ClassRef(class.name.clone()),
-                        );
-                        if let Some(key) = sf.key_expr.as_ref() {
-                            result.push(Stmt::Expr(Expr::ClassStaticSymbolSet {
-                                class_name: class.name.clone(),
-                                key: Box::new(key.clone()),
-                                value: Box::new(init_value),
-                            }));
-                        } else {
-                            result.push(Stmt::Expr(Expr::StaticFieldSet {
-                                class_name: class.name.clone(),
-                                field_name: sf.name.clone(),
-                                value: Box::new(init_value),
-                            }));
-                        }
-                    }
-                }
-                for sm in &class.static_methods {
-                    if sm.name.starts_with("__perry_static_init_") {
-                        result.push(Stmt::Expr(Expr::StaticMethodCall {
-                            class_name: class.name.clone(),
-                            method_name: sm.name.clone(),
-                            args: Vec::new(),
-                        }));
-                    }
-                }
+                // classes initialized. Interleaved in source order (see
+                // `build_interleaved_static_init_stmts`), with lexical `this`
+                // in field initializers bound to the class ref.
+                result.extend(crate::lower_decl::build_interleaved_static_init_stmts(
+                    &class_decl.class.body,
+                    &class.name,
+                    &class.static_fields,
+                    &class.static_methods,
+                ));
                 ctx.pending_classes.push(class);
                 // #5251 follow-up — a function-nested `class X { … }` whose
                 // name collides with an OUTER same-named local must SHADOW

--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -1047,7 +1047,13 @@ pub fn lower_class_decl(
                 let scope_mark = ctx.enter_scope();
                 let saved_in_nonarrow_fn = ctx.in_nonarrow_fn;
                 ctx.in_nonarrow_fn = true;
-                let body = lower_block_stmt(ctx, &block.body)?;
+                // A static block is its own var-scope (OrdinaryFunctionCreate
+                // per ClassStaticBlockDefinitionEvaluation): `lower_block_stmt`
+                // only lowers nested statements without hoisting `var`s to this
+                // boundary, so a `var` declared in one block leaked into the
+                // next block/module scope instead of staying local (test262
+                // static-init-scope-var-close.js).
+                let body = lower_fn_body_block_stmt(ctx, &block.body)?;
                 ctx.exit_scope(scope_mark);
                 ctx.in_nonarrow_fn = saved_in_nonarrow_fn;
 
@@ -1819,7 +1825,13 @@ pub fn lower_class_from_ast(
                 let scope_mark = ctx.enter_scope();
                 let saved_in_nonarrow_fn = ctx.in_nonarrow_fn;
                 ctx.in_nonarrow_fn = true;
-                let body = lower_block_stmt(ctx, &block.body)?;
+                // A static block is its own var-scope (OrdinaryFunctionCreate
+                // per ClassStaticBlockDefinitionEvaluation): `lower_block_stmt`
+                // only lowers nested statements without hoisting `var`s to this
+                // boundary, so a `var` declared in one block leaked into the
+                // next block/module scope instead of staying local (test262
+                // static-init-scope-var-close.js).
+                let body = lower_fn_body_block_stmt(ctx, &block.body)?;
                 ctx.exit_scope(scope_mark);
                 ctx.in_nonarrow_fn = saved_in_nonarrow_fn;
 

--- a/crates/perry-hir/src/lower_decl/mod.rs
+++ b/crates/perry-hir/src/lower_decl/mod.rs
@@ -20,6 +20,7 @@ mod fn_decl;
 mod helpers;
 mod interface_decl;
 mod private_members;
+mod static_init;
 mod type_alias;
 mod typeof_narrow;
 
@@ -60,4 +61,5 @@ pub(crate) use private_members::{
     build_private_scope, lower_private_getter, lower_private_method, lower_private_prop,
     lower_private_setter,
 };
+pub(crate) use static_init::build_interleaved_static_init_stmts;
 pub(crate) use type_alias::lower_type_alias_decl;

--- a/crates/perry-hir/src/lower_decl/static_init.rs
+++ b/crates/perry-hir/src/lower_decl/static_init.rs
@@ -1,0 +1,91 @@
+//! Interleaved static field/static-block init statement emission.
+//!
+//! Split out of `class_decl.rs` to stay under the file-size CI gate.
+
+use swc_ecma_ast as ast;
+
+use crate::ir::*;
+
+/// Per ClassDefinitionEvaluation step 34, a class's static fields and
+/// static blocks evaluate in a single pass over source order — a static
+/// block sequenced between two static fields must run between them, not
+/// after every field has already been set. `static_fields` and
+/// `static_methods` (which folds each `static { ... }` block in as a
+/// synthetic `__perry_static_init_N` method, see the `StaticBlock` arm
+/// above) are each individually in source order relative to their own
+/// kind — the first pass over `class_body` appends to exactly one of the
+/// two per relevant member, never reordering within a kind — so replaying
+/// `class_body` and advancing one cursor per kind reconstructs the true
+/// interleaving without matching by name (a computed-key field's `name` is
+/// only a synthetic placeholder, see `ClassField::key_expr`).
+///
+/// Callers (module-level class decls, function-nested class decls, and
+/// `var C = class { ... }`) previously emitted ALL static-field-init
+/// statements before ANY static-block-call statement, so `static x = 1;
+/// static { blockRan = true }; static y = 2;` ran block after both fields
+/// instead of between them — test262
+/// language/statements/class/static-init-sequence.js and
+/// static-init-abrupt.js (a throw inside an earlier block must also skip
+/// this now-later-positioned field).
+pub(crate) fn build_interleaved_static_init_stmts(
+    class_body: &[ast::ClassMember],
+    class_name: &str,
+    static_fields: &[ClassField],
+    static_methods: &[Function],
+) -> Vec<Stmt> {
+    let emit_field = |out: &mut Vec<Stmt>, sf: &ClassField| {
+        let Some(init) = &sf.init else { return };
+        // `this` in a static field initializer is the class constructor.
+        let mut init_value = init.clone();
+        crate::analysis::substitute_lexical_this_in_expr(
+            &mut init_value,
+            &Expr::ClassRef(class_name.to_string()),
+        );
+        out.push(if let Some(key) = sf.key_expr.as_ref() {
+            Stmt::Expr(Expr::ClassStaticSymbolSet {
+                class_name: class_name.to_string(),
+                key: Box::new(key.clone()),
+                value: Box::new(init_value),
+            })
+        } else {
+            Stmt::Expr(Expr::StaticFieldSet {
+                class_name: class_name.to_string(),
+                field_name: sf.name.clone(),
+                value: Box::new(init_value),
+            })
+        });
+    };
+
+    let mut out = Vec::new();
+    let mut field_idx = 0usize;
+    let mut block_idx = 0usize;
+    for member in class_body {
+        match member {
+            ast::ClassMember::ClassProp(prop) if !prop.declare && prop.is_static => {
+                if let Some(sf) = static_fields.get(field_idx) {
+                    emit_field(&mut out, sf);
+                }
+                field_idx += 1;
+            }
+            ast::ClassMember::PrivateProp(prop) if prop.is_static => {
+                if let Some(sf) = static_fields.get(field_idx) {
+                    emit_field(&mut out, sf);
+                }
+                field_idx += 1;
+            }
+            ast::ClassMember::StaticBlock(_) => {
+                let method_name = format!("__perry_static_init_{}", block_idx);
+                block_idx += 1;
+                if static_methods.iter().any(|m| m.name == method_name) {
+                    out.push(Stmt::Expr(Expr::StaticMethodCall {
+                        class_name: class_name.to_string(),
+                        method_name,
+                        args: Vec::new(),
+                    }));
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}


### PR DESCRIPTION
## Summary

Part of the test262 class-tail worklist (#5832). Fixes a coherent cluster of static class-initialization semantics bugs (`crates/perry-hir/src/lower_decl/class_decl.rs` + call sites, `crates/perry-codegen/src/codegen/helpers.rs`):

- **Static field/block interleaving order** — static fields and static blocks were emitted as "all fields, then all blocks" instead of a single interleaved pass in source order per `ClassDefinitionEvaluation` step 34. `static x = 1; static { blockRan = true }; static y = 2;` ran the block after both fields instead of between them, and a throw from an earlier block didn't stop a later field's initializer. Fixed by replaying the AST class body in source order at all 3 emission sites (module-level class decl, function-nested class decl, `var C = class {...}`), advancing one cursor per field/block kind — extracted into a shared `build_interleaved_static_init_stmts` helper (new `lower_decl/static_init.rs`, split out to stay under the file-size gate).
- **Static block var-scope isolation** — a static block's body was lowered with `lower_block_stmt` instead of `lower_fn_body_block_stmt`, so a `var` declared inside one block leaked into the next block's (or the module's) scope instead of hoisting to the block's own function-like scope, per `ClassStaticBlockDefinitionEvaluation` (`OrdinaryFunctionCreate`).
- **Static block double-invocation** — fixing the abrupt-completion case surfaced a related pre-existing bug: the codegen fallback that re-invokes any static block not already found called inline (`init_static_fields_late`) only scanned `hir.init`'s top-level statements. A class declared inside `try { class C { static { throw ... } } }` had its inline call nested inside the `Try`'s body, so the shallow scan missed it and the block ran a **second** time — outside the user's `try`/`catch` — turning a caught exception into an uncaught one. Made the dedup scan (`init_calls_static_block`) recurse through `if`/`while`/`do-while`/`for`/`labeled`/`try`/`switch` bodies.

Closes: language/statements/class/static-init-sequence.js, static-init-abrupt.js, static-init-scope-var-close.js (all three test262 cases now pass).

## Test plan

- [x] 3 direct test262 repros (harness-wrapped, compiled + run standalone) all pass
- [x] 55-case sample sweep of `language/{statements,expressions}/class` (weighted toward `static`-named cases) via `scripts/test262_subset.py` — 100% parity, zero diffs/regressions
- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/check_file_size.sh`
- [x] `cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static`

Code-only PR per the issue's workflow note — no `Cargo.toml`/`CLAUDE.md` version bump or `CHANGELOG.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Class static fields and static blocks are now initialized in the same order they appear in source code.

- **Bug Fixes**
  - Fixed cases where static initialization could run twice when nested inside control-flow constructs.
  - Improved handling of `static { ... }` blocks so local `var` declarations stay scoped correctly and don’t leak into later code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->