### PR TITLE
fix(hir): #5841 — eval-created global var/function bindings must be configurable

### DIFF
--- a/crates/perry-hir/src/lower/global_eval_hoist.rs
+++ b/crates/perry-hir/src/lower/global_eval_hoist.rs
@@ -198,13 +198,19 @@ fn synth_create_if_absent_stmt(name: &str) -> Option<ast::Stmt> {
     // Use Object.defineProperty instead of a plain assignment so inherited
     // prototype setters (e.g. from Object.prototype) cannot intercept the
     // binding creation — matching CreateGlobalVarBinding step 5a which calls
-    // OrdinaryDefineOwnProperty directly on the global object.
+    // OrdinaryDefineOwnProperty directly on the global object. This module
+    // only rewrites *eval* bodies (Annex B.3.3.3 EvalDeclarationInstantiation),
+    // which always calls CreateGlobalVarBinding(vn, /* D = */ true) — unlike a
+    // top-level Script's own GlobalDeclarationInstantiation, which passes
+    // D = false. So the created binding must be configurable: true (test262
+    // `language/eval-code/*/var-env-var-init-global-new`, `annexB/language/
+    // eval-code/*/global-*-eval-global-init`).
     parse_single_stmt(&format!(
         "if (!({{}}).hasOwnProperty.call(globalThis, {name:?})) \
          {{ if (!Object.isExtensible(globalThis)) \
               {{ throw new TypeError(\"Cannot declare global var: {name}\"); }} \
             void Object.defineProperty(globalThis, {name:?}, \
-              {{ value: void 0, writable: true, enumerable: true, configurable: false }}); }}"
+              {{ value: void 0, writable: true, enumerable: true, configurable: true }}); }}"
     ))
 }
 

--- a/crates/perry/tests/issue_5841_eval_global_descriptor.rs
+++ b/crates/perry/tests/issue_5841_eval_global_descriptor.rs
@@ -107,10 +107,17 @@ fn direct_eval_new_global_var_binding_is_configurable() {
 }
 
 /// A `var` declared inside `eval` for a name that already exists as a global
-/// (declared by the enclosing script itself, non-configurable) must only
-/// update the value — the pre-existing descriptor's `configurable: false`
-/// survives untouched (test262 `language/eval-code/direct/var-env-var-init-
-/// global-exstng`).
+/// must update the value via a plain assignment, not the create-if-absent
+/// `Object.defineProperty` prelude this PR touches (test262 `language/eval-
+/// code/direct/var-env-var-init-global-exstng`, which additionally asserts the
+/// pre-existing descriptor's `configurable: false` survives untouched — not
+/// checked here: Perry does not yet reify a top-level *script* `var`
+/// declaration as a real `globalThis` own-property until something touches it
+/// via reflection, so `hasOwnProperty` reads `false` before the eval runs and
+/// the create-if-absent prelude (correctly, per its own contract) creates a
+/// fresh `configurable: true` binding — a separate, pre-existing gap in how
+/// Perry models module-top `var`, orthogonal to this PR's eval-configurable
+/// fix and out of scope here).
 const DIRECT_EXISTING_VAR_VALUE_UPDATED: &str = r#"
 var __perry_5841_existing = 23;
 eval("var __perry_5841_existing = 45;");

--- a/crates/perry/tests/issue_5841_eval_global_descriptor.rs
+++ b/crates/perry/tests/issue_5841_eval_global_descriptor.rs
@@ -1,0 +1,168 @@
+//! Regression (#5841): sloppy-eval-created global bindings must publish with
+//! `configurable: true` descriptors.
+//!
+//! `EvalDeclarationInstantiation` (Annex B.3.3.3) always calls
+//! `CreateGlobalVarBinding(vn, /* D = */ true)` and `CreateGlobalFunctionBinding
+//! (F, V, /* D = */ true)` — unlike a top-level Script's own
+//! `GlobalDeclarationInstantiation`, which passes `D = false`. Perry's
+//! `synth_create_if_absent_stmt` (the `CreateGlobalVarBinding` create-if-absent
+//! prelude shared by top-level `var` declarations and nested block/`if`/`switch`
+//! function declarations) hardcoded `configurable: false`, so every global
+//! binding freshly created by an `eval` — a top-level `var`, or a legacy-hoisted
+//! block function — published as non-configurable, failing test262's
+//! `verifyProperty(..., { configurable: true })` checks (test262
+//! `annexB/language/eval-code/{direct,indirect}/global-*-eval-global-init`,
+//! `language/eval-code/{direct,indirect}/var-env-var-init-global-new`).
+//!
+//! A *pre-existing* global (declared by the enclosing script, not by the eval
+//! itself) is untouched by the create-if-absent prelude — only its value is
+//! reassigned — so its original descriptor (including a `false` configurable
+//! from the script's own `GlobalDeclarationInstantiation`) must survive
+//! (test262 `var-env-var-init-global-exstng`).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+/// Compile `src` in global-script mode and run it. Returns (clean_exit, stdout).
+fn run_global(src: &str) -> (bool, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(&entry, src).expect("write entry");
+    let output = dir.path().join("main_bin");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .args([
+            "compile",
+            entry.to_str().unwrap(),
+            "-o",
+            output.to_str().unwrap(),
+        ])
+        .env("PERRY_NO_AUTO_OPTIMIZE", "1")
+        .env("PERRY_ALLOW_EVAL", "1")
+        .env("PERRY_GLOBAL_SCRIPT_THIS", "1")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    (
+        run.status.success(),
+        String::from_utf8_lossy(&run.stdout).to_string(),
+    )
+}
+
+/// A block-scoped function declaration hoisted by a *global* direct `eval` must
+/// publish a `configurable: true` global binding (test262 `annexB/language/
+/// eval-code/direct/global-block-decl-eval-global-init`).
+const DIRECT_BLOCK_FN_CONFIGURABLE: &str = r#"
+eval("{ function f() {} }");
+var d = Object.getOwnPropertyDescriptor(globalThis, "f");
+if (d.configurable !== true) {
+  throw new Error("expected f.configurable === true, got " + d.configurable);
+}
+console.log("PASS");
+"#;
+
+#[test]
+fn direct_eval_block_function_binding_is_configurable() {
+    let (ok, out) = run_global(DIRECT_BLOCK_FN_CONFIGURABLE);
+    assert!(ok, "binary did not exit cleanly\n{out}");
+    assert!(out.contains("PASS"), "{out}");
+}
+
+/// A top-level `var` declared inside a *global* direct `eval`, for a name with
+/// no pre-existing global, must publish a `configurable: true` binding
+/// (test262 `language/eval-code/direct/var-env-var-init-global-new`).
+const DIRECT_NEW_VAR_CONFIGURABLE: &str = r#"
+var initial;
+eval("initial = __perry_5841_new_var; var __perry_5841_new_var;");
+var d = Object.getOwnPropertyDescriptor(globalThis, "__perry_5841_new_var");
+if (d.configurable !== true) {
+  throw new Error("expected configurable === true, got " + d.configurable);
+}
+if (d.value !== undefined || d.writable !== true || d.enumerable !== true) {
+  throw new Error("unexpected descriptor: " + JSON.stringify(d));
+}
+if (initial !== undefined) {
+  throw new Error("expected pre-declaration read to be undefined, got " + initial);
+}
+console.log("PASS");
+"#;
+
+#[test]
+fn direct_eval_new_global_var_binding_is_configurable() {
+    let (ok, out) = run_global(DIRECT_NEW_VAR_CONFIGURABLE);
+    assert!(ok, "binary did not exit cleanly\n{out}");
+    assert!(out.contains("PASS"), "{out}");
+}
+
+/// A `var` declared inside `eval` for a name that already exists as a global
+/// (declared by the enclosing script itself, non-configurable) must only
+/// update the value — the pre-existing descriptor's `configurable: false`
+/// survives untouched (test262 `language/eval-code/direct/var-env-var-init-
+/// global-exstng`).
+const DIRECT_EXISTING_VAR_VALUE_UPDATED: &str = r#"
+var __perry_5841_existing = 23;
+eval("var __perry_5841_existing = 45;");
+if (__perry_5841_existing !== 45) {
+  throw new Error("expected value 45, got " + __perry_5841_existing);
+}
+console.log("PASS");
+"#;
+
+#[test]
+fn direct_eval_existing_global_var_value_is_updated() {
+    let (ok, out) = run_global(DIRECT_EXISTING_VAR_VALUE_UPDATED);
+    assert!(ok, "binary did not exit cleanly\n{out}");
+    assert!(out.contains("PASS"), "{out}");
+}
+
+/// Indirect-eval form of [`direct_eval_block_function_binding_is_configurable`]
+/// (test262 `annexB/language/eval-code/indirect/global-block-decl-eval-global-init`).
+const INDIRECT_BLOCK_FN_CONFIGURABLE: &str = r#"
+(0, eval)("{ function g() {} }");
+var d = Object.getOwnPropertyDescriptor(globalThis, "g");
+if (d.configurable !== true) {
+  throw new Error("expected g.configurable === true, got " + d.configurable);
+}
+console.log("PASS");
+"#;
+
+#[test]
+fn indirect_eval_block_function_binding_is_configurable() {
+    let (ok, out) = run_global(INDIRECT_BLOCK_FN_CONFIGURABLE);
+    assert!(ok, "binary did not exit cleanly\n{out}");
+    assert!(out.contains("PASS"), "{out}");
+}
+
+/// Indirect-eval form of [`direct_eval_new_global_var_binding_is_configurable`]
+/// (test262 `language/eval-code/indirect/var-env-var-init-global-new`).
+const INDIRECT_NEW_VAR_CONFIGURABLE: &str = r#"
+var initial;
+(0, eval)("initial = __perry_5841_new_var2; var __perry_5841_new_var2;");
+var d = Object.getOwnPropertyDescriptor(globalThis, "__perry_5841_new_var2");
+if (d.configurable !== true) {
+  throw new Error("expected configurable === true, got " + d.configurable);
+}
+if (initial !== undefined) {
+  throw new Error("expected pre-declaration read to be undefined, got " + initial);
+}
+console.log("PASS");
+"#;
+
+#[test]
+fn indirect_eval_new_global_var_binding_is_configurable() {
+    let (ok, out) = run_global(INDIRECT_NEW_VAR_CONFIGURABLE);
+    assert!(ok, "binary did not exit cleanly\n{out}");
+    assert!(out.contains("PASS"), "{out}");
+}


### PR DESCRIPTION
## Summary
- `synth_create_if_absent_stmt` (the `CreateGlobalVarBinding` create-if-absent prelude, shared by top-level `var` declarations and legacy-hoisted nested block/`if`/`switch` function declarations) hardcoded `configurable: false`.
- This module only rewrites *eval* bodies (Annex B.3.3.3 `EvalDeclarationInstantiation`), which always calls `CreateGlobalVarBinding(vn, /* D = */ true)` — unlike a top-level Script's own `GlobalDeclarationInstantiation`, which passes `D = false`. Every global binding freshly created by an `eval` (a bare top-level `var`, or a function declared in a nested block/`if`/`switch` and legacy-hoisted to global scope) was therefore published as non-configurable, failing test262's `verifyProperty(..., { configurable: true })` checks.
- Fix: publish `configurable: true` in that prelude, matching `CreateGlobalFunctionBinding`'s existing (already-correct) `configurable: true`.

Fixes 18 of the 45 test262 cases from #5841 (16 `annexB/language/eval-code/{direct,indirect}/global-*-eval-global-init` + `language/eval-code/{direct,indirect}/var-env-var-init-global-new`). Verified **zero regressions** against the full `annexB/language/eval-code` + `language/eval-code` slice (45 → 27 failing; diffed old/new failure lists — no case outside the original 45 now fails).

The remaining 27 failures are separate root causes (indirect-eval-from-dynamic-string AOT limits, `ReferenceError`-on-TDZ-read gaps, a pre-existing gap where top-level script `var` isn't reified as a real `globalThis` property until first touched, etc.) — out of scope for this single-root-cause fix per the issue's own workflow guidance.

## Test plan
- [x] New `crates/perry/tests/issue_5841_eval_global_descriptor.rs` — 5 tests covering new-var, new-block-function, and pre-existing-var-value-update, direct + indirect eval.
- [x] Existing `crates/perry-hir` unit tests for `global_eval_hoist` (15/15 pass, unaffected).
- [x] Full `annexB/language/eval-code` + `language/eval-code` test262 sweep against the pinned corpus: 45 → 27 failing, zero regressions (diffed case lists).
- [x] `cargo fmt --all -- --check` and `scripts/check_file_size.sh` clean.

Fixes #5841

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `eval` behavior for newly created global `var` bindings so the corresponding `Object.getOwnPropertyDescriptor(globalThis, ...)` reports `configurable: true` (per Annex B.3.3.3 semantics).
  * Kept behavior consistent when `eval` targets an already-defined global binding.
* **Tests**
  * Added a regression test verifying Annex B.3.3.3 “eval global binding” descriptor attributes and runtime values for both direct and indirect `eval`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->