### PR TITLE
fix(runtime): #5839 — PlainYearMonth/PlainMonthDay toLocaleString reject ISO calendar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.5.1212 — fix(runtime): #5839 — PlainYearMonth/PlainMonthDay toLocaleString reject ISO calendar
+
+Part of the #5839 Temporal test262 worklist (56 failing built-ins/Temporal + intl402/Temporal cases). Picked the `toLocaleString/calendar-mismatch.js` "even when instance has the ISO calendar" cluster as a coherent, self-contained fix.
+
+`Temporal.PlainYearMonth.prototype.toLocaleString` and `Temporal.PlainMonthDay.prototype.toLocaleString` shared the same calendar-mismatch check as `PlainDate`/`PlainDateTime`/`ZonedDateTime` (`assert_locale_string_calendar` in `crates/perry-runtime/src/temporal/options.rs`), which permits the instance calendar to be either `"iso8601"` or the locale's resolved calendar (`"gregory"`, Perry's default). Per ecma402 `HandleDateTimeTemporalYearMonth`/`HandleDateTimeTemporalMonthDay` (sup-intl.html #1132, #1157), year-month and month-day values do **not** get that ISO carve-out — unlike the other three types, an ISO-calendar `PlainYearMonth`/`PlainMonthDay` must always throw a `RangeError` against the locale-default calendar. Added `assert_locale_string_calendar_no_iso_carveout` (rejects everything but `"gregory"`) and switched `plain_year_month.rs`/`plain_month_day.rs` to call it instead.
+
+Fixes `intl402/Temporal/{PlainYearMonth,PlainMonthDay}/prototype/toLocaleString/calendar-mismatch.js`. The remaining 54 cases in the #5839 worklist are unrelated root causes (Duration rounding `ceil` behavior in the vendored `temporal_rs` crate, and full `dateStyle`/`timeStyle`/`hourCycle`/locale-calendar option threading through Temporal's `toLocaleString`, a materially larger change) — left as follow-ups.
+
 ## v0.5.1211 — fix(intl): #5840 — Intl.DateTimeFormat dayPeriod-only formatting (6 test262 cases)
 
 Fixes the `dayPeriod`-only subcluster of the #5840 DateTimeFormat worklist: `new Intl.DateTimeFormat('en', {dayPeriod: 'long'})` (with no other date/time component options) silently fell back to the default `M/D/YYYY` date string in both `format` and `formatToParts`, because `dtf_primary_mask` (`crates/perry-runtime/src/intl/date_collator.rs`) never counted `dayPeriod` toward its "has a time-dimension field" bit, and neither `format_components` nor `build_parts_from_components` had any dayPeriod rendering path at all — `dayPeriod` was only ever emitted as a byproduct of the AM/PM 12-hour clock.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1211
+**Current Version:** 0.5.1212
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5307,7 +5307,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "anyhow",
  "base64",
@@ -5364,14 +5364,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "cc",
  "libc",
@@ -5379,7 +5379,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "anyhow",
  "log",
@@ -5394,7 +5394,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5403,7 +5403,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5411,7 +5411,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5421,7 +5421,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "anyhow",
  "base64",
@@ -5443,7 +5443,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5451,7 +5451,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5480,14 +5480,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "serde",
  "serde_json",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1211"
+version = "0.5.1212"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5506,7 +5506,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "anyhow",
  "clap",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "block2",
  "objc2",
@@ -5531,7 +5531,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5539,7 +5539,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5548,7 +5548,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5556,7 +5556,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5564,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5580,7 +5580,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "chrono",
  "cron",
@@ -5590,7 +5590,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5598,7 +5598,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5606,7 +5606,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5630,14 +5630,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5668,7 +5668,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5682,7 +5682,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "bytes",
  "h2",
@@ -5705,7 +5705,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5715,7 +5715,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5726,7 +5726,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5734,7 +5734,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "bson",
  "futures-util",
@@ -5754,7 +5754,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5764,7 +5764,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -5786,7 +5786,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5804,7 +5804,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -5831,14 +5831,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5877,7 +5877,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "brotli",
  "flate2",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5895,7 +5895,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5913,7 +5913,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5925,7 +5925,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "anyhow",
  "base64",
@@ -5958,14 +5958,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6057,14 +6057,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6082,14 +6082,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "base64",
  "itoa",
@@ -6106,7 +6106,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6116,7 +6116,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6139,7 +6139,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "base64",
  "block2",
@@ -6155,7 +6155,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "base64",
  "block2",
@@ -6170,7 +6170,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1211"
+version = "0.5.1212"
 
 [[package]]
 name = "perry-ui-test"
@@ -6178,11 +6178,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1211"
+version = "0.5.1212"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "base64",
  "block2",
@@ -6198,7 +6198,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "base64",
  "block2",
@@ -6214,7 +6214,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "block2",
  "libc",
@@ -6227,7 +6227,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "base64",
  "libc",
@@ -6244,14 +6244,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6265,7 +6265,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1211"
+version = "0.5.1212"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -301,7 +301,7 @@ strip = false
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1211"
+version = "0.5.1212"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/temporal/options.rs
+++ b/crates/perry-runtime/src/temporal/options.rs
@@ -387,16 +387,18 @@ fn reject_bare_islamic(id: &str) {
 
 // ---- `Temporal.*.prototype.toLocaleString` ---------------------------------
 
-/// `Temporal.*.prototype.toLocaleString` calendar check. A Temporal value
-/// renders only when its calendar matches the formatter's: the ISO-8601
-/// calendar (always permitted) or the calendar the locale resolves to. With no
-/// explicit `calendar` option that resolved calendar is the locale default,
-/// which Perry's `Intl.DateTimeFormat` reports as `gregory`. Any other calendar
-/// is a `RangeError` (the test262 `toLocaleString/calendar-mismatch` cases).
+/// `Temporal.*.prototype.toLocaleString` calendar check for `PlainDate`,
+/// `PlainDateTime`, and `ZonedDateTime` — per `HandleDateTimeTemporalDate`
+/// (ecma402 sup-intl.html #1107) and the analogous `ZonedDateTime` clause
+/// (#1953), a value renders only when its calendar matches the formatter's:
+/// the ISO-8601 calendar (always permitted) or the calendar the locale
+/// resolves to. With no explicit `calendar` option that resolved calendar is
+/// the locale default, which Perry's `Intl.DateTimeFormat` reports as
+/// `gregory`. Any other calendar is a `RangeError` (the test262
+/// `toLocaleString/calendar-mismatch` cases).
 ///
-/// Only the calendar-bearing types (`PlainDate`/`PlainDateTime`/`PlainYearMonth`
-/// /`PlainMonthDay`/`ZonedDateTime`) call this; `Instant`/`PlainTime` have no
-/// calendar slot.
+/// `PlainYearMonth`/`PlainMonthDay` do NOT get the ISO carve-out — see
+/// [`assert_locale_string_calendar_no_iso_carveout`].
 ///
 /// NOTE: the `locales`/`options` arguments — which could name a *different*
 /// calendar to validate against — are dropped by the `Expr::DateToLocaleString`
@@ -406,6 +408,21 @@ fn reject_bare_islamic(id: &str) {
 /// follow-up that depends on threading those arguments through that lowering.
 pub fn assert_locale_string_calendar(instance_calendar: &str) {
     if instance_calendar != "iso8601" && instance_calendar != "gregory" {
+        range("calendar mismatch: the value's calendar differs from the locale calendar");
+    }
+}
+
+/// `Temporal.PlainYearMonth`/`Temporal.PlainMonthDay` `toLocaleString` calendar
+/// check. `HandleDateTimeTemporalYearMonth`/`HandleDateTimeTemporalMonthDay`
+/// (ecma402 sup-intl.html #1132, #1157) require the instance calendar to
+/// equal the formatter's calendar exactly — unlike `PlainDate`/`PlainDateTime`
+/// /`ZonedDateTime`, there is no `"iso8601"`-is-always-permitted carve-out, so
+/// an ISO-calendar year-month/month-day always mismatches the locale's
+/// default (`gregory`) calendar and throws (test262
+/// `toLocaleString/calendar-mismatch` "even when instance has the ISO
+/// calendar" cases).
+pub fn assert_locale_string_calendar_no_iso_carveout(instance_calendar: &str) {
+    if instance_calendar != "gregory" {
         range("calendar mismatch: the value's calendar differs from the locale calendar");
     }
 }

--- a/crates/perry-runtime/src/temporal/plain_month_day.rs
+++ b/crates/perry-runtime/src/temporal/plain_month_day.rs
@@ -131,7 +131,9 @@ pub fn call(recv: f64, md: &PlainMonthDay, name: &str, args: &[f64]) -> f64 {
         }
         "toJSON" => string(&md.to_string()),
         "toLocaleString" => {
-            super::options::assert_locale_string_calendar(md.calendar().identifier());
+            super::options::assert_locale_string_calendar_no_iso_carveout(
+                md.calendar().identifier(),
+            );
             let epoch_ms = crate::date::components_to_timestamp(
                 1970,
                 md.month_code().to_month_integer() as u32,

--- a/crates/perry-runtime/src/temporal/plain_year_month.rs
+++ b/crates/perry-runtime/src/temporal/plain_year_month.rs
@@ -159,7 +159,9 @@ pub fn call(recv: f64, ym: &PlainYearMonth, name: &str, args: &[f64]) -> f64 {
         }
         "toJSON" => string(&ym.to_string()),
         "toLocaleString" => {
-            super::options::assert_locale_string_calendar(ym.calendar().identifier());
+            super::options::assert_locale_string_calendar_no_iso_carveout(
+                ym.calendar().identifier(),
+            );
             let epoch_ms =
                 crate::date::components_to_timestamp(ym.year(), ym.month() as u32, 1, 0, 0, 0)
                     as f64


### PR DESCRIPTION
## Summary
- `Temporal.PlainYearMonth.prototype.toLocaleString` and `Temporal.PlainMonthDay.prototype.toLocaleString` shared the same calendar-mismatch check as `PlainDate`/`PlainDateTime`/`ZonedDateTime` (`assert_locale_string_calendar`), which permits the instance calendar to be either `"iso8601"` or the locale's resolved calendar. Per ecma402 `HandleDateTimeTemporalYearMonth`/`HandleDateTimeTemporalMonthDay` (sup-intl.html #1132, #1157), year-month/month-day do **not** get that ISO carve-out — an ISO-calendar instance must always throw `RangeError` against the locale-default calendar.
- Added `assert_locale_string_calendar_no_iso_carveout` and switched `plain_year_month.rs`/`plain_month_day.rs` to it.
- Picked from the #5839 self-contained worklist (56 failing built-ins/Temporal + intl402/Temporal test262 cases) as a coherent, self-contained single-root-cause fix. The remaining 54 cases are unrelated root causes (Duration rounding `ceil` behavior inside the vendored `temporal_rs` crate — no upstream fix available yet as of temporal_rs 0.2.4 — and full `dateStyle`/`timeStyle`/`hourCycle`/locale-calendar option threading through Temporal's `toLocaleString`, a materially larger change) and are left as follow-ups.
- Code-only change plus the required version bump / changelog entry (this is the repo's own worktree, not an external contributor PR).

## Changes
- `crates/perry-runtime/src/temporal/options.rs`: add `assert_locale_string_calendar_no_iso_carveout`, doc updates on the existing `assert_locale_string_calendar` clarifying the ISO carve-out only applies to `PlainDate`/`PlainDateTime`/`ZonedDateTime`.
- `crates/perry-runtime/src/temporal/plain_year_month.rs`, `crates/perry-runtime/src/temporal/plain_month_day.rs`: call the new no-carve-out assertion from `toLocaleString`.
- `Cargo.toml`, `Cargo.lock`, `CLAUDE.md`, `CHANGELOG.md`: version bump 0.5.1210 → 0.5.1211 + changelog entry.

## Related issue
Refs #5839.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/check_file_size.sh`
- [x] `cargo check -p perry-runtime --features temporal` (clean, only pre-existing warnings)
- [x] Built `perry` in release mode and ran the two fixed test262 cases directly (assembled with the project's test262 harness): `intl402/Temporal/PlainYearMonth/prototype/toLocaleString/calendar-mismatch.js` and `intl402/Temporal/PlainMonthDay/prototype/toLocaleString/calendar-mismatch.js` — both now exit 0 (pass).
- [x] Regression spot-check: `PlainDate`/`ZonedDateTime` `toLocaleString/basic.js` still pass unchanged; `PlainDateTime/toLocaleString/basic.js` still fails with its pre-existing, unrelated `de-AT locale has a 24-hour format` error (already listed in issue #5839, not introduced by this change).

## Screenshots/output
N/A — runtime/CLI change, no user-facing UI.

## Checklist
- [x] `cargo fmt --all -- --check` passes
- [x] `bash scripts/check_file_size.sh` passes
- [x] Targeted test262 cases verified passing, no regressions in spot-checked siblings
- [x] Version bumped and CHANGELOG updated per CLAUDE.md workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `Temporal.PlainYearMonth.prototype.toLocaleString()` and `Temporal.PlainMonthDay.prototype.toLocaleString()` to correctly reject ISO-calendar values when the locale uses the default calendar.
  * Calendar matching is now enforced more strictly for these Temporal types, preventing incorrect formatting results in mismatch cases.

* **Chores**
  * Bumped the release version to `v0.5.1212`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->