### PR TITLE
fix(runtime): #5836 — RegExp constructor edge cases (not-a-constructor, class-range order)

### DIFF
--- a/crates/perry-runtime/src/object/class_registry/construct.rs
+++ b/crates/perry-runtime/src/object/class_registry/construct.rs
@@ -223,6 +223,16 @@ pub unsafe extern "C" fn js_new_function_construct(
     if crate::builtins::boxed_primitive_payload(func_value).is_some() {
         super::super::object_ops::throw_object_type_error(b"is not a constructor");
     }
+    // `new (new RegExp())` — a RegExp instance has no [[Construct]] internal
+    // method (Test262 `S15.10.7_A2_T2`). Without this it fell through to the
+    // empty-object construction fallback and silently produced `{}` instead
+    // of throwing.
+    {
+        let jv = crate::value::JSValue::from_bits(func_value.to_bits());
+        if jv.is_pointer() && crate::regex::is_registered_regex(jv.as_pointer::<u8>() as usize) {
+            super::super::object_ops::throw_object_type_error(b"is not a constructor");
+        }
+    }
     // #3656: `new p()` where `p` is a Proxy dispatches through its `construct`
     // trap (or forwards to the target). Reached when the compiler can't prove
     // the callee is a proxy statically (e.g. `new record.proxy()`). newTarget

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -29,6 +29,8 @@ type CompiledRegex = regex::Regex;
 type CompiledRegex = ();
 
 #[cfg(feature = "regex-engine")]
+mod class_range_validate;
+#[cfg(feature = "regex-engine")]
 mod compile;
 mod escape;
 #[cfg(feature = "regex-engine")]
@@ -40,6 +42,8 @@ mod match_all;
 #[cfg(feature = "regex-engine")]
 mod replace_expand;
 mod replace_fn;
+#[cfg(feature = "regex-engine")]
+use class_range_validate::has_out_of_order_double_dash_class_range;
 #[cfg(feature = "regex-engine")]
 pub use compile::js_regexp_compile_value;
 pub use escape::js_regexp_escape;
@@ -582,6 +586,12 @@ pub extern "C" fn js_regexp_new(
         });
         if !in_cache {
             if has_invalid_repeated_quantifier(pattern_str) {
+                throw_regexp_syntax_error(&format!(
+                    "Invalid regular expression: /{}/: invalid pattern",
+                    pattern_str
+                ));
+            }
+            if has_out_of_order_double_dash_class_range(pattern_str) {
                 throw_regexp_syntax_error(&format!(
                     "Invalid regular expression: /{}/: invalid pattern",
                     pattern_str

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -591,7 +591,11 @@ pub extern "C" fn js_regexp_new(
                     pattern_str
                 ));
             }
-            if has_out_of_order_double_dash_class_range(pattern_str) {
+            // `--` is the real ClassSetExpression subtraction operator under
+            // the `v` flag (UTS #51) — `[a--z]` there means "a minus z", not
+            // a malformed range — so only legacy/`u`-mode patterns are
+            // subject to the doubled-hyphen range-order check.
+            if !flags_str.contains('v') && has_out_of_order_double_dash_class_range(pattern_str) {
                 throw_regexp_syntax_error(&format!(
                     "Invalid regular expression: /{}/: invalid pattern",
                     pattern_str

--- a/crates/perry-runtime/src/regex/class_range_validate.rs
+++ b/crates/perry-runtime/src/regex/class_range_validate.rs
@@ -1,0 +1,68 @@
+//! JS-spec character-class range validation the underlying `regex` /
+//! `fancy-regex` crates don't perform themselves. Split out of `grammar.rs`
+//! to keep that file under the 2000-line size gate.
+
+/// Detect a character-class range made out of order by a doubled hyphen
+/// (`[a--z]`): JS parses the class contents "a--z" as ClassAtom `a`, a `-`
+/// range operator, ClassAtom `-` (a literal hyphen is itself a valid
+/// ClassAtom) — i.e. the range `a`..`-`. Since `a` (U+0061) is greater than
+/// `-` (U+002D), `CharacterRange` (22.2.1.1) requires the low bound's code
+/// point to be no greater than the high bound's, so this is a SyntaxError.
+/// The Rust `regex` crate parses the doubled hyphen differently and
+/// silently accepts patterns like this, so Perry must catch it before
+/// delegating to the crate (test262 `S15.10.4.1_A9_T3`).
+pub(super) fn has_out_of_order_double_dash_class_range(pattern: &str) -> bool {
+    let chars: Vec<char> = pattern.chars().collect();
+    let mut i = 0;
+    let mut in_class = false;
+    while i < chars.len() {
+        match chars[i] {
+            '\\' => i += 2,
+            '[' if !in_class => {
+                in_class = true;
+                i += 1;
+            }
+            ']' if in_class => {
+                in_class = false;
+                i += 1;
+            }
+            c if in_class
+                && c != '^'
+                && chars.get(i + 1) == Some(&'-')
+                && chars.get(i + 2) == Some(&'-')
+                && !matches!(chars.get(i + 3), None | Some(']')) =>
+            {
+                if (c as u32) > ('-' as u32) {
+                    return true;
+                }
+                i += 1;
+            }
+            _ => i += 1,
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::has_out_of_order_double_dash_class_range;
+
+    #[test]
+    fn rejects_descending_double_dash_ranges() {
+        assert!(has_out_of_order_double_dash_class_range("[a--z]"));
+        assert!(has_out_of_order_double_dash_class_range("[a---z]"));
+    }
+
+    #[test]
+    fn accepts_ascending_double_dash_ranges() {
+        assert!(!has_out_of_order_double_dash_class_range("[!--z]"));
+        assert!(!has_out_of_order_double_dash_class_range("[+--z]"));
+    }
+
+    #[test]
+    fn ignores_unrelated_class_hyphens() {
+        assert!(!has_out_of_order_double_dash_class_range("[a-z-]"));
+        assert!(!has_out_of_order_double_dash_class_range("[a-z]"));
+        assert!(!has_out_of_order_double_dash_class_range("abc"));
+    }
+}

--- a/crates/perry-runtime/src/regex/class_range_validate.rs
+++ b/crates/perry-runtime/src/regex/class_range_validate.rs
@@ -15,19 +15,30 @@ pub(super) fn has_out_of_order_double_dash_class_range(pattern: &str) -> bool {
     let chars: Vec<char> = pattern.chars().collect();
     let mut i = 0;
     let mut in_class = false;
+    // True for the first ClassAtom position of the current class — `^` is
+    // only a negation marker there (`[^a]`); a `^` anywhere else (`[x^--z]`)
+    // is an ordinary ClassAtom and must still be range-order-checked.
+    let mut at_class_start = false;
     while i < chars.len() {
         match chars[i] {
-            '\\' => i += 2,
+            '\\' => {
+                i += 2;
+                at_class_start = false;
+            }
             '[' if !in_class => {
                 in_class = true;
+                at_class_start = true;
                 i += 1;
             }
             ']' if in_class => {
                 in_class = false;
                 i += 1;
             }
+            '^' if in_class && at_class_start => {
+                at_class_start = false;
+                i += 1;
+            }
             c if in_class
-                && c != '^'
                 && chars.get(i + 1) == Some(&'-')
                 && chars.get(i + 2) == Some(&'-')
                 && !matches!(chars.get(i + 3), None | Some(']')) =>
@@ -35,9 +46,13 @@ pub(super) fn has_out_of_order_double_dash_class_range(pattern: &str) -> bool {
                 if (c as u32) > ('-' as u32) {
                     return true;
                 }
+                at_class_start = false;
                 i += 1;
             }
-            _ => i += 1,
+            _ => {
+                at_class_start = false;
+                i += 1;
+            }
         }
     }
     false
@@ -64,5 +79,14 @@ mod tests {
         assert!(!has_out_of_order_double_dash_class_range("[a-z-]"));
         assert!(!has_out_of_order_double_dash_class_range("[a-z]"));
         assert!(!has_out_of_order_double_dash_class_range("abc"));
+    }
+
+    #[test]
+    fn caret_is_only_a_negation_marker_at_class_start() {
+        // A leading `^` negates the class and is not itself a range atom.
+        assert!(!has_out_of_order_double_dash_class_range("[^--z]"));
+        // A non-leading `^` is an ordinary ClassAtom (U+005E > U+002D `-`),
+        // so `^--z` is the same out-of-order range as `a--z`.
+        assert!(has_out_of_order_double_dash_class_range("[x^--z]"));
     }
 }

--- a/crates/perry-runtime/src/regex/compile.rs
+++ b/crates/perry-runtime/src/regex/compile.rs
@@ -93,7 +93,9 @@ pub extern "C" fn js_regexp_compile_value(
             pattern_str
         ));
     }
-    if has_out_of_order_double_dash_class_range(pattern_str) {
+    // `--` is the real ClassSetExpression subtraction operator under the `v`
+    // flag (UTS #51) — see the matching comment in `js_regexp_new`.
+    if !flags_str.contains('v') && has_out_of_order_double_dash_class_range(pattern_str) {
         throw_regexp_syntax_error(&format!(
             "Invalid regular expression: /{}/: invalid pattern",
             pattern_str

--- a/crates/perry-runtime/src/regex/compile.rs
+++ b/crates/perry-runtime/src/regex/compile.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use regex::Regex;
 
+use super::class_range_validate::has_out_of_order_double_dash_class_range;
 use super::grammar::{
     has_invalid_repeated_quantifier, has_unicode_forbidden_legacy_escape,
     has_unicode_forbidden_pattern, js_regex_to_rust,
@@ -87,6 +88,12 @@ pub extern "C" fn js_regexp_compile_value(
     // Same SyntaxError validation as `js_regexp_new`: only reject patterns that
     // neither the `regex` crate nor `fancy-regex` accept.
     if has_invalid_repeated_quantifier(pattern_str) {
+        throw_regexp_syntax_error(&format!(
+            "Invalid regular expression: /{}/: invalid pattern",
+            pattern_str
+        ));
+    }
+    if has_out_of_order_double_dash_class_range(pattern_str) {
         throw_regexp_syntax_error(&format!(
             "Invalid regular expression: /{}/: invalid pattern",
             pattern_str


### PR DESCRIPTION
## Summary
- `new` on a RegExp instance now throws `TypeError` — a RegExp instance has no `[[Construct]]` internal method (ECMA-262 22.2.7) — instead of silently returning an empty placeholder object.
- Character classes made out-of-order by a doubled hyphen (e.g. `[a--z]`) now throw `SyntaxError`. JS parses the class contents `"a--z"` as `ClassAtom "a"`, a `-` range operator, then `ClassAtom "-"` (a literal hyphen is itself a valid `ClassAtom`) — i.e. the range `a`..`-`. Since `a` (U+0061) is greater than `-` (U+002D), `CharacterRange` (22.2.1.1) requires this to be a `SyntaxError`, but the Rust `regex`/`fancy-regex` crates parse the doubled hyphen differently and silently accept the pattern — Perry now catches it before delegating.
- New `has_out_of_order_double_dash_class_range` lives in its own module (`regex/class_range_validate.rs`) rather than growing `regex/grammar.rs`, which is already at the 2000-line size-gate ceiling.

Fixes test262 `built-ins/RegExp/S15.10.7_A2_T2.js` and `built-ins/RegExp/S15.10.4.1_A9_T3.js` — 2 of the 91 cases tracked in #5836.

## Test plan
- [x] `cargo test --release -p perry-runtime --lib regex` — 34 passed (incl. 3 new unit tests)
- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/check_file_size.sh`
- [x] Manually verified both fixed test262 cases pass against a fresh build
- [x] `scripts/test262_subset.py --root vendor/test262 --dir built-ins/RegExp --jobs 8` — before/after diff shows exactly the 2 targeted cases now passing with zero regressions (the run flagged 2 unrelated `property-escapes/generated` cases as newly failing, but both pass on an isolated re-run with more time — a transient compile-timeout flake from a heavily loaded shared CI-adjacent box, not a regression)

Refs #5836.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `RegExp` syntax validation to reject out-of-order double-hyphen character ranges like `[a--z]` (in legacy mode), returning a consistent `SyntaxError`.
  * Fixed `new` handling so attempts to construct from RegExp-derived values no longer incorrectly fall back to object construction, and instead report “is not a constructor.”
* **Tests**
  * Added coverage for the new character-range validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->