### PR TITLE
hir: prealloc closure-capture boxes for lets nested in Try/If (array destructuring)

### DIFF
--- a/crates/perry-hir/src/lower_decl/block.rs
+++ b/crates/perry-hir/src/lower_decl/block.rs
@@ -1351,8 +1351,54 @@ fn collect_refs_in_closure_bodies_expr(expr: &Expr, out: &mut std::collections::
 /// NOT recurse into nested blocks (those are block-scoped — their lets
 /// aren't hoisted to function-entry).
 pub fn collect_top_level_let_ids_stmt(stmt: &Stmt, out: &mut std::collections::HashSet<LocalId>) {
-    if let Stmt::Let { id, .. } = stmt {
-        out.insert(*id);
+    match stmt {
+        Stmt::Let { id, .. } => {
+            out.insert(*id);
+        }
+        // Array-destructuring bindings (`let [a, b] = it`) lower to the iterator
+        // protocol wrapped in a `Try` (see
+        // `destructuring::pattern_binding::lower_array_pattern_binding`), so the
+        // leaf `let`s live INSIDE the try body / its `if`s, not at the top level.
+        // Recurse into those so a hoisted FnDecl that captures a destructured var
+        // still gets its box preallocated at function entry. Without this, the
+        // hoisted closure captures the not-yet-assigned, unboxed slot and reads
+        // `undefined` — e.g. `const [K,_] = useState(0)` captured by a hoisted
+        // handler. Loops are intentionally NOT recursed: a per-iteration `let`
+        // needs a fresh box, not a single entry-prealloc.
+        Stmt::Try {
+            body,
+            catch,
+            finally,
+        } => {
+            for s in body {
+                collect_top_level_let_ids_stmt(s, out);
+            }
+            if let Some(c) = catch {
+                for s in &c.body {
+                    collect_top_level_let_ids_stmt(s, out);
+                }
+            }
+            if let Some(f) = finally {
+                for s in f {
+                    collect_top_level_let_ids_stmt(s, out);
+                }
+            }
+        }
+        Stmt::If {
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            for s in then_branch {
+                collect_top_level_let_ids_stmt(s, out);
+            }
+            if let Some(eb) = else_branch {
+                for s in eb {
+                    collect_top_level_let_ids_stmt(s, out);
+                }
+            }
+        }
+        _ => {}
     }
 }
 


### PR DESCRIPTION
## What

A hoisted function declaration that captures an **array-destructured** binding read `undefined` instead of the binding's value:

```js
function component() {
  const [k, setK] = pair(0);      // array destructuring
  function advance() {            // hoisted FnDecl capturing k
    if (k < steps.length - 1) setK(k + 1);
    else finish();                // ← always taken: k was undefined
  }
  ...
}
```

Real-world shape: React's `const [state, setState] = useState(0)` captured by a hoisted handler — the handler saw `state === undefined`, so state-dependent logic (e.g. a step machine's advance) silently took the wrong branch.

## Why

`compute_prealloc_for_hoisted_closures` builds the function-entry prealloc-box set via `collect_top_level_let_ids_stmt`, which only matched **top-level** `Stmt::Let`. But array-destructuring bindings lower through the iterator protocol wrapped in a `Try` (for iterator close — see `destructuring::pattern_binding::lower_array_pattern_binding`), so the leaf `let`s live *inside* the Try body and its `if`s, never at the statement top level. Those ids were omitted from the prealloc set, so the hoisted closure captured the un-boxed, not-yet-assigned slot.

Plain `let`, arrow functions, and function *expressions* were unaffected (arrows/fn-exprs aren't hoisted, so they don't take the prealloc path) — which made the failure look sporadic: the same capture worked or broke depending on the closure's syntactic form.

## Fix

Recurse into `Stmt::Try` (body / catch / finally) and `Stmt::If` (then / else) — the constructs the destructuring lowering emits — when collecting hoisted-let ids. **Loops are intentionally not recursed:** a per-iteration `let` needs a fresh box per iteration, not a single function-entry prealloc.

## Testing

- `cargo test -p perry-hir`: **221 passed, 0 failed** (plus sub-suites, all green); `perry-transform` / `perry` compile clean against the changed function.
- Verified end-to-end on an 8-shape capture matrix (plain let / destructured × arrow / fn-expr / hoisted FnDecl / post-await state machine): the three previously-failing hoisted-FnDecl shapes now read the correct value; all previously-passing shapes unchanged.

A `crates/perry/tests/` e2e regression test (hoisted FnDecl capturing a destructured binding, asserting the captured value) can be added to this PR on request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of top-level `let` bindings in lowered code, so destructuring and conditional/exception-wrapped blocks are recognized more reliably.
  * Fixed cases where valid bindings could be missed when they appeared inside certain wrapped statements, helping preserve expected behavior after compilation or transformation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->