### PR TITLE
fix(hir,codegen,runtime): #5843 — 6 built-ins/String test262 fixes

### DIFF
--- a/crates/perry-codegen/src/expr/arrays_finds.rs
+++ b/crates/perry-codegen/src/expr/arrays_finds.rs
@@ -214,14 +214,38 @@ pub(crate) fn lower_buffer_index_get_i32(
 
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {
-        Expr::BoxedPrimitiveNew { kind, arg } => {
+        Expr::BoxedPrimitiveNew {
+            kind,
+            arg,
+            arg_present,
+        } => {
             let v = lower_expr(ctx, arg)?;
-            let runtime = match kind {
-                perry_hir::BoxedPrimitiveKind::Number => "js_boxed_number_new",
-                perry_hir::BoxedPrimitiveKind::String => "js_boxed_string_new",
-                perry_hir::BoxedPrimitiveKind::Boolean => "js_boxed_boolean_new",
-            };
-            Ok(ctx.block().call(DOUBLE, runtime, &[(DOUBLE, &v)]))
+            match kind {
+                perry_hir::BoxedPrimitiveKind::Number => {
+                    Ok(ctx
+                        .block()
+                        .call(DOUBLE, "js_boxed_number_new", &[(DOUBLE, &v)]))
+                }
+                perry_hir::BoxedPrimitiveKind::Boolean => {
+                    Ok(ctx
+                        .block()
+                        .call(DOUBLE, "js_boxed_boolean_new", &[(DOUBLE, &v)]))
+                }
+                // `has_arg` is an explicit compile-time flag, not an
+                // `undefined`-value sentinel: a present argument that
+                // evaluates to `undefined` at runtime (`new String(x)` where
+                // `x` holds `undefined`) must still box to `"undefined"`, not
+                // the no-arg `""` default — see the `arg_present` doc comment
+                // on `Expr::BoxedPrimitiveNew`.
+                perry_hir::BoxedPrimitiveKind::String => {
+                    let has_arg = if *arg_present { "1" } else { "0" };
+                    Ok(ctx.block().call(
+                        DOUBLE,
+                        "js_boxed_string_new",
+                        &[(DOUBLE, &v), (I32, has_arg)],
+                    ))
+                }
+            }
         }
         Expr::DateNew(args) => match args.len() {
             0 => Ok(ctx.block().call(DOUBLE, "js_date_new", &[])),

--- a/crates/perry-codegen/src/lower_string_method.rs
+++ b/crates/perry-codegen/src/lower_string_method.rs
@@ -695,6 +695,18 @@ pub(crate) fn lower_string_method(
                 );
             }
             let len_d = lower_expr(ctx, &args[0])?;
+            // `ToLength(maxLength)` (ECMA-262 §22.1.3.16 `StringPad` step 1)
+            // must run — including any `valueOf`/`toString` on an object
+            // `maxLength` — BEFORE `ToString(fillString)` below. Coercing
+            // eagerly here (rather than leaving the raw boxed value for the
+            // runtime `to_length` helper to interpret as a plain f64) also
+            // fixes a correctness bug: a non-number `maxLength` (e.g. an
+            // object) was previously read as garbage/NaN bit-pattern instead
+            // of running `ToNumber`.
+            let len_d = {
+                let blk = ctx.block();
+                blk.call(DOUBLE, "js_number_coerce", &[(DOUBLE, &len_d)])
+            };
             // Optional pad string; defaults to " " when missing. A provided
             // fill is `ToString`-coerced (ECMA-262 §22.1.3.16) via
             // `js_string_pad_fill` — `undefined` → null handle (runtime falls

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -648,7 +648,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     module.declare_function("js_util_transferable_abort_signal", DOUBLE, &[DOUBLE]);
     module.declare_function("js_util_parse_args", DOUBLE, &[DOUBLE]);
     module.declare_function("js_boxed_number_new", DOUBLE, &[DOUBLE]);
-    module.declare_function("js_boxed_string_new", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_boxed_string_new", DOUBLE, &[DOUBLE, I32]);
     module.declare_function("js_boxed_boolean_new", DOUBLE, &[DOUBLE]);
     module.declare_function("js_util_types_is_arguments_object", DOUBLE, &[DOUBLE]);
     module.declare_function("js_util_types_is_promise", DOUBLE, &[DOUBLE]);

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -1768,6 +1768,17 @@ pub enum Expr {
     BoxedPrimitiveNew {
         kind: BoxedPrimitiveKind,
         arg: Box<Expr>,
+        // Whether an argument was syntactically given (`new String(x)`) vs.
+        // omitted (`new String()`). `arg` alone can't disambiguate an omitted
+        // argument from a present one that evaluates to `undefined` at
+        // runtime (e.g. `new String(x)` where `x` holds `undefined`) — both
+        // would otherwise collapse to the same NaN-boxed `undefined` value at
+        // the `js_boxed_*_new` runtime boundary. Only `BoxedPrimitiveKind::
+        // String` currently reads this (see `js_boxed_string_new`); Number/
+        // Boolean disambiguate implicitly because their present-arg coercion
+        // (`NumberCoerce`/`BooleanCoerce`) always produces a non-`undefined`
+        // primitive.
+        arg_present: bool,
     },
 
     // Date operations

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -729,31 +729,26 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 // ToNumber(x), `new String(x)` → ToString(x). This matters for
                 // an explicit `undefined`: `new Number(undefined)` is NaN and
                 // `new String(undefined)` is "undefined" — distinct from the
-                // *no-arg* forms `new Number()`/`new String()` which box +0/""
-                // (handled by the undefined sentinel in `js_boxed_*_new`).
-                // Without this, both collapse to `Expr::Undefined` and the
-                // runtime can't tell them apart.
+                // *no-arg* forms `new Number()`/`new String()` which box +0/"".
+                // `Number`/`Boolean` disambiguate for free: `NumberCoerce`/
+                // `BooleanCoerce` always produce a non-`undefined` primitive
+                // (NaN / `false`) for a present `undefined` argument. `String`
+                // cannot use the same trick — `Expr::StringCoerce`
+                // (`js_string_coerce`) is the *lenient* ToString used by the
+                // `String(x)` call form, which renders a Symbol as its
+                // descriptive string ("Symbol(desc)") instead of throwing
+                // (ECMA-262 §22.1.1 step 2b requires the `new String(sym)`
+                // TypeError, test262 `symbol-wrapping.js`) — so the argument is
+                // passed raw and `js_boxed_string_new` applies `ToString` +
+                // the Symbol rejection itself, gated on the explicit
+                // `arg_present` flag below rather than an `undefined` sentinel
+                // (a present-but-`undefined`-valued argument must still box to
+                // `"undefined"`, not the no-arg `""` default).
+                let arg_present = !args.is_empty();
                 let arg = match args.drain(..).next() {
                     Some(inner) => match kind {
                         crate::BoxedPrimitiveKind::Number => Expr::NumberCoerce(Box::new(inner)),
-                        // Only an explicit `undefined` argument needs a pre-pass
-                        // coercion here — to distinguish it from the true no-arg
-                        // sentinel below ("undefined" vs. the boxed-empty-string
-                        // default). Any other present value is passed raw so
-                        // `js_boxed_string_new` applies `ToString` itself,
-                        // including rejecting a Symbol argument with a
-                        // `TypeError` (ECMA-262 §22.1.1 step 2b, test262
-                        // `symbol-wrapping.js`) — the lenient `Expr::StringCoerce`
-                        // (`js_string_coerce`) instead renders a Symbol as its
-                        // descriptive string, which would defeat that check by
-                        // stringifying the Symbol away before it ever runs.
-                        crate::BoxedPrimitiveKind::String => {
-                            if matches!(inner, Expr::Undefined) {
-                                Expr::StringCoerce(Box::new(inner))
-                            } else {
-                                inner
-                            }
-                        }
+                        crate::BoxedPrimitiveKind::String => inner,
                         crate::BoxedPrimitiveKind::Boolean => Expr::BooleanCoerce(Box::new(inner)),
                     },
                     None => Expr::Undefined,
@@ -761,6 +756,7 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 return Ok(Expr::BoxedPrimitiveNew {
                     kind,
                     arg: Box::new(arg),
+                    arg_present,
                 });
             }
             if ctx.proxy_locals.contains(&class_name) {

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -736,7 +736,24 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 let arg = match args.drain(..).next() {
                     Some(inner) => match kind {
                         crate::BoxedPrimitiveKind::Number => Expr::NumberCoerce(Box::new(inner)),
-                        crate::BoxedPrimitiveKind::String => Expr::StringCoerce(Box::new(inner)),
+                        // Only an explicit `undefined` argument needs a pre-pass
+                        // coercion here — to distinguish it from the true no-arg
+                        // sentinel below ("undefined" vs. the boxed-empty-string
+                        // default). Any other present value is passed raw so
+                        // `js_boxed_string_new` applies `ToString` itself,
+                        // including rejecting a Symbol argument with a
+                        // `TypeError` (ECMA-262 §22.1.1 step 2b, test262
+                        // `symbol-wrapping.js`) — the lenient `Expr::StringCoerce`
+                        // (`js_string_coerce`) instead renders a Symbol as its
+                        // descriptive string, which would defeat that check by
+                        // stringifying the Symbol away before it ever runs.
+                        crate::BoxedPrimitiveKind::String => {
+                            if matches!(inner, Expr::Undefined) {
+                                Expr::StringCoerce(Box::new(inner))
+                            } else {
+                                inner
+                            }
+                        }
                         crate::BoxedPrimitiveKind::Boolean => Expr::BooleanCoerce(Box::new(inner)),
                     },
                     None => Expr::Undefined,

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -443,10 +443,15 @@ impl SH for Expr {
             Expr::Sequence(es) => { tag(h, 309); es.hash(h); }
             Expr::DateNow => tag(h, 310),
             Expr::DateNew(es) => { tag(h, 311); es.hash(h); }
-            Expr::BoxedPrimitiveNew { kind, arg } => {
+            Expr::BoxedPrimitiveNew {
+                kind,
+                arg,
+                arg_present,
+            } => {
                 tag(h, 12017);
                 (*kind as u8).hash(h);
                 arg.as_ref().hash(h);
+                arg_present.hash(h);
             }
             Expr::DateGetTime(e) => { tag(h, 312); e.as_ref().hash(h); }
             Expr::DateToISOString(e) => { tag(h, 313); e.as_ref().hash(h); }

--- a/crates/perry-runtime/src/array/generic.rs
+++ b/crates/perry-runtime/src/array/generic.rs
@@ -90,7 +90,7 @@ pub(super) fn to_object(recv: f64) -> f64 {
     // object, so `obj instanceof String` is true. (test262
     // Array.prototype.{every,some,reduce,reduceRight,...}/15.4.4.*-1-7.)
     if is_string_value(b) {
-        return crate::builtins::js_boxed_string_new(recv);
+        return crate::builtins::js_boxed_string_new(recv, 1);
     }
     if b == TAG_TRUE || b == crate::value::TAG_FALSE {
         return crate::builtins::js_boxed_boolean_new(recv);

--- a/crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs
+++ b/crates/perry-runtime/src/builtins/formatting/boxed_primitives.rs
@@ -289,11 +289,18 @@ pub extern "C" fn js_boxed_number_new(value: f64) -> f64 {
     crate::value::js_nanbox_pointer(obj as i64)
 }
 
+/// `has_arg` is an explicit compile-time flag (codegen passes 0/1 based on
+/// whether `new String(...)` was given an argument), NOT an inference from
+/// `value.is_undefined()` — a *present* argument that evaluates to
+/// `undefined` at runtime (`new String(x)` where `x` holds `undefined`) must
+/// still box to `"undefined"`, distinct from the no-arg `""` default. Both
+/// would otherwise collapse to the same NaN-boxed `undefined` bits and be
+/// indistinguishable here.
 #[no_mangle]
-pub extern "C" fn js_boxed_string_new(value: f64) -> f64 {
+pub extern "C" fn js_boxed_string_new(value: f64, has_arg: i32) -> f64 {
     let obj = crate::object::js_object_alloc(CLASS_ID_BOXED_STRING, 0);
     // `new String()` (no args) is spec'd to box "", not "undefined".
-    let ptr = if crate::value::JSValue::from_bits(value.to_bits()).is_undefined() {
+    let ptr = if has_arg == 0 {
         crate::string::js_string_from_bytes(std::ptr::null(), 0)
     } else {
         // ECMA-262 §22.1.1 step 2b: ToString(value) — throws TypeError for Symbol.

--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -90,7 +90,7 @@ pub extern "C" fn js_object_coerce(value: f64) -> f64 {
         return crate::builtins::js_boxed_boolean_new(value);
     }
     if jsval.is_any_string() {
-        return crate::builtins::js_boxed_string_new(value);
+        return crate::builtins::js_boxed_string_new(value, 1);
     }
     crate::builtins::js_boxed_number_new(value)
 }

--- a/crates/perry-runtime/src/object/this_binding.rs
+++ b/crates/perry-runtime/src/object/this_binding.rs
@@ -137,7 +137,7 @@ pub extern "C" fn js_implicit_this_get_sloppy() -> f64 {
         return crate::builtins::js_boxed_boolean_new(value);
     }
     if jv.is_any_string() {
-        return crate::builtins::js_boxed_string_new(value);
+        return crate::builtins::js_boxed_string_new(value, 1);
     }
     // #5515: a class reference is an INT32-tagged class id, but it is
     // conceptually the class constructor OBJECT, not a primitive number.

--- a/crates/perry-runtime/src/string/char_ops.rs
+++ b/crates/perry-runtime/src/string/char_ops.rs
@@ -344,7 +344,7 @@ pub(crate) fn string_from_code_unit(unit: u16) -> *mut StringHeader {
 /// `true` if a lone surrogate was appended (so the caller knows to use the
 /// WTF-8 string-construction path that sets `HAS_LONE_SURROGATES`).
 #[inline]
-fn push_code_unit_wtf8(out: &mut Vec<u8>, unit: u16) -> bool {
+pub(super) fn push_code_unit_wtf8(out: &mut Vec<u8>, unit: u16) -> bool {
     if unit < 0x80 {
         out.push(unit as u8);
         false

--- a/crates/perry-runtime/src/string/pad.rs
+++ b/crates/perry-runtime/src/string/pad.rs
@@ -66,6 +66,53 @@ fn to_length(target_length: f64) -> usize {
     }
 }
 
+/// Decode raw WTF-8 bytes (as stored by a `StringHeader`, which may contain
+/// 3-byte lone-surrogate sequences per `STRING_FLAG_HAS_LONE_SURROGATES`)
+/// into UTF-16 code units. Operates on bytes directly rather than through
+/// `str`/`char` — a lone surrogate is not a valid Unicode scalar value, so
+/// `str::encode_utf16()` over a `str::from_utf8_unchecked` buffer containing
+/// one is undefined behavior (the decoder assumes well-formed UTF-8), not
+/// just wrong output.
+fn decode_wtf8_units(bytes: &[u8]) -> Vec<u16> {
+    let mut units = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let b0 = bytes[i];
+        if b0 < 0x80 {
+            units.push(b0 as u16);
+            i += 1;
+        } else if b0 < 0xE0 {
+            // 2-byte sequence: U+0080..U+07FF, always one code unit.
+            let b1 = bytes[i + 1];
+            let cp = ((b0 as u32 & 0x1F) << 6) | (b1 as u32 & 0x3F);
+            units.push(cp as u16);
+            i += 2;
+        } else if b0 < 0xF0 {
+            // 3-byte sequence: U+0800..U+FFFF, including a WTF-8 lone
+            // surrogate (U+D800..U+DFFF) — always one code unit either way.
+            let b1 = bytes[i + 1];
+            let b2 = bytes[i + 2];
+            let cp = ((b0 as u32 & 0x0F) << 12) | ((b1 as u32 & 0x3F) << 6) | (b2 as u32 & 0x3F);
+            units.push(cp as u16);
+            i += 3;
+        } else {
+            // 4-byte sequence: an astral code point, encoded as a surrogate pair.
+            let b1 = bytes[i + 1];
+            let b2 = bytes[i + 2];
+            let b3 = bytes[i + 3];
+            let cp = ((b0 as u32 & 0x07) << 18)
+                | ((b1 as u32 & 0x3F) << 12)
+                | ((b2 as u32 & 0x3F) << 6)
+                | (b3 as u32 & 0x3F);
+            let astral = cp - 0x10000;
+            units.push(0xD800 + (astral >> 10) as u16);
+            units.push(0xDC00 + (astral & 0x3FF) as u16);
+            i += 4;
+        }
+    }
+    units
+}
+
 /// Build exactly `pad_needed` UTF-16 code units of padding by cycling through
 /// `pad_units`, encoded as WTF-8. A complete high+low surrogate pair straddled
 /// across a cycle boundary is combined into its astral code point (ordinary
@@ -148,10 +195,10 @@ pub extern "C" fn js_string_pad_start(
         return js_string_from_bytes(ptr::null(), 0);
     }
     let str_data = string_as_str(s);
-    let pad_data = if is_valid_string_ptr(pad_string) {
-        string_as_str(pad_string)
+    let pad_bytes: &[u8] = if is_valid_string_ptr(pad_string) {
+        unsafe { slice::from_raw_parts(string_data(pad_string), (*pad_string).byte_len as usize) }
     } else {
-        " "
+        b" "
     };
 
     let current_len = unsafe { (*s).utf16_len } as usize;
@@ -159,9 +206,12 @@ pub extern "C" fn js_string_pad_start(
 
     // ToLength itself never throws; the receiver is returned unchanged when
     // it's already long enough or the filler is empty — even for an
-    // unrepresentable target like Infinity (Node parity, #2786/#2880).
-    if current_len >= target_len || pad_data.is_empty() {
-        return js_string_from_bytes(str_data.as_ptr(), str_data.len() as u32);
+    // unrepresentable target like Infinity (Node parity, #2786/#2880). Route
+    // through `finish_pad_result` (empty pad chunk) rather than a bare
+    // `js_string_from_bytes` so a receiver already flagged
+    // `STRING_FLAG_HAS_LONE_SURROGATES` keeps that flag on the result.
+    if current_len >= target_len || pad_bytes.is_empty() {
+        return finish_pad_result(s, str_data, &[], false, true);
     }
 
     // Only now, when a longer string must actually be produced, reject
@@ -171,7 +221,7 @@ pub extern "C" fn js_string_pad_start(
     }
 
     let pad_needed = target_len - current_len;
-    let pad_units: Vec<u16> = pad_data.encode_utf16().collect();
+    let pad_units = decode_wtf8_units(pad_bytes);
     let (pad_chunk, pad_has_lone_surrogate) = build_pad_chunk(&pad_units, pad_needed);
     finish_pad_result(s, str_data, &pad_chunk, pad_has_lone_surrogate, true)
 }
@@ -188,10 +238,10 @@ pub extern "C" fn js_string_pad_end(
         return js_string_from_bytes(ptr::null(), 0);
     }
     let str_data = string_as_str(s);
-    let pad_data = if is_valid_string_ptr(pad_string) {
-        string_as_str(pad_string)
+    let pad_bytes: &[u8] = if is_valid_string_ptr(pad_string) {
+        unsafe { slice::from_raw_parts(string_data(pad_string), (*pad_string).byte_len as usize) }
     } else {
-        " "
+        b" "
     };
 
     let current_len = unsafe { (*s).utf16_len } as usize;
@@ -199,9 +249,12 @@ pub extern "C" fn js_string_pad_end(
 
     // ToLength itself never throws; the receiver is returned unchanged when
     // it's already long enough or the filler is empty — even for an
-    // unrepresentable target like Infinity (Node parity, #2786/#2880).
-    if current_len >= target_len || pad_data.is_empty() {
-        return js_string_from_bytes(str_data.as_ptr(), str_data.len() as u32);
+    // unrepresentable target like Infinity (Node parity, #2786/#2880). Route
+    // through `finish_pad_result` (empty pad chunk) rather than a bare
+    // `js_string_from_bytes` so a receiver already flagged
+    // `STRING_FLAG_HAS_LONE_SURROGATES` keeps that flag on the result.
+    if current_len >= target_len || pad_bytes.is_empty() {
+        return finish_pad_result(s, str_data, &[], false, false);
     }
 
     // Only now, when a longer string must actually be produced, reject
@@ -211,7 +264,7 @@ pub extern "C" fn js_string_pad_end(
     }
 
     let pad_needed = target_len - current_len;
-    let pad_units: Vec<u16> = pad_data.encode_utf16().collect();
+    let pad_units = decode_wtf8_units(pad_bytes);
     let (pad_chunk, pad_has_lone_surrogate) = build_pad_chunk(&pad_units, pad_needed);
     finish_pad_result(s, str_data, &pad_chunk, pad_has_lone_surrogate, false)
 }

--- a/crates/perry-runtime/src/string/pad.rs
+++ b/crates/perry-runtime/src/string/pad.rs
@@ -66,6 +66,69 @@ fn to_length(target_length: f64) -> usize {
     }
 }
 
+/// Build exactly `pad_needed` UTF-16 code units of padding by cycling through
+/// `pad_units`, encoded as WTF-8. A complete high+low surrogate pair straddled
+/// across a cycle boundary is combined into its astral code point (ordinary
+/// 4-byte UTF-8); only a surrogate pair *truncated* by `pad_needed` (the spec
+/// counts by code unit, not code point — ECMA-262 §22.1.3.16 `StringPad`)
+/// survives as a genuinely lone surrogate, encoded as 3-byte WTF-8. Returns
+/// whether any lone surrogate was emitted so the caller can pick the
+/// WTF-8-flagged construction path.
+fn build_pad_chunk(pad_units: &[u16], pad_needed: usize) -> (Vec<u8>, bool) {
+    let mut out = Vec::with_capacity(pad_needed * 3);
+    let mut has_lone_surrogate = false;
+    let mut produced = 0usize;
+    let mut idx = 0usize;
+    while produced < pad_needed {
+        let unit = pad_units[idx % pad_units.len()];
+        if (0xD800..=0xDBFF).contains(&unit) && produced + 2 <= pad_needed {
+            let next = pad_units[(idx + 1) % pad_units.len()];
+            if (0xDC00..=0xDFFF).contains(&next) {
+                let astral = 0x10000 + (((unit as u32) - 0xD800) << 10) + ((next as u32) - 0xDC00);
+                let ch = unsafe { char::from_u32_unchecked(astral) };
+                let mut buf = [0u8; 4];
+                out.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+                produced += 2;
+                idx += 2;
+                continue;
+            }
+        }
+        if super::char_ops::push_code_unit_wtf8(&mut out, unit) {
+            has_lone_surrogate = true;
+        }
+        produced += 1;
+        idx += 1;
+    }
+    (out, has_lone_surrogate)
+}
+
+/// Assemble the padded result from the receiver's raw bytes and a padding
+/// chunk, using the WTF-8-flagged constructor when either side may hold a
+/// lone surrogate (the receiver's existing flag, or one newly introduced by
+/// truncating the pad string mid-surrogate-pair).
+fn finish_pad_result(
+    s: *const StringHeader,
+    str_data: &str,
+    pad_chunk: &[u8],
+    pad_has_lone_surrogate: bool,
+    prepend_pad: bool,
+) -> *mut StringHeader {
+    let receiver_has_lone_surrogate = unsafe { (*s).flags & STRING_FLAG_HAS_LONE_SURROGATES != 0 };
+    let mut bytes = Vec::with_capacity(str_data.len() + pad_chunk.len());
+    if prepend_pad {
+        bytes.extend_from_slice(pad_chunk);
+        bytes.extend_from_slice(str_data.as_bytes());
+    } else {
+        bytes.extend_from_slice(str_data.as_bytes());
+        bytes.extend_from_slice(pad_chunk);
+    }
+    if pad_has_lone_surrogate || receiver_has_lone_surrogate {
+        js_string_from_wtf8_bytes(bytes.as_ptr(), bytes.len() as u32)
+    } else {
+        js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32)
+    }
+}
+
 fn throw_invalid_string_length() -> ! {
     let message = "Invalid string length";
     let msg = js_string_from_bytes(message.as_ptr(), message.len() as u32);
@@ -108,29 +171,9 @@ pub extern "C" fn js_string_pad_start(
     }
 
     let pad_needed = target_len - current_len;
-    let _pad_u16: Vec<u16> = pad_data.encode_utf16().collect();
-    let mut result = String::with_capacity(target_len * 4);
-
-    // Build padding by UTF-16 code units
-    let mut u16_added = 0;
-    let pad_chars: Vec<char> = pad_data.chars().collect();
-    let mut pad_idx = 0;
-    while u16_added < pad_needed {
-        let ch = pad_chars[pad_idx % pad_chars.len()];
-        let ch_u16_len = ch.len_utf16();
-        if u16_added + ch_u16_len > pad_needed {
-            break;
-        }
-        result.push(ch);
-        u16_added += ch_u16_len;
-        pad_idx += 1;
-    }
-
-    result.push_str(str_data);
-
-    let ret = js_string_from_bytes(result.as_ptr(), result.len() as u32);
-    std::hint::black_box(&result);
-    ret
+    let pad_units: Vec<u16> = pad_data.encode_utf16().collect();
+    let (pad_chunk, pad_has_lone_surrogate) = build_pad_chunk(&pad_units, pad_needed);
+    finish_pad_result(s, str_data, &pad_chunk, pad_has_lone_surrogate, true)
 }
 
 /// Pad the end of a string to reach target length (in UTF-16 code units).
@@ -168,28 +211,9 @@ pub extern "C" fn js_string_pad_end(
     }
 
     let pad_needed = target_len - current_len;
-    let mut result = String::with_capacity(target_len * 4);
-
-    result.push_str(str_data);
-
-    // Build padding by UTF-16 code units
-    let pad_chars: Vec<char> = pad_data.chars().collect();
-    let mut pad_idx = 0;
-    let mut u16_added = 0;
-    while u16_added < pad_needed {
-        let ch = pad_chars[pad_idx % pad_chars.len()];
-        let ch_u16_len = ch.len_utf16();
-        if u16_added + ch_u16_len > pad_needed {
-            break;
-        }
-        result.push(ch);
-        u16_added += ch_u16_len;
-        pad_idx += 1;
-    }
-
-    let ret = js_string_from_bytes(result.as_ptr(), result.len() as u32);
-    std::hint::black_box(&result);
-    ret
+    let pad_units: Vec<u16> = pad_data.encode_utf16().collect();
+    let (pad_chunk, pad_has_lone_surrogate) = build_pad_chunk(&pad_units, pad_needed);
+    finish_pad_result(s, str_data, &pad_chunk, pad_has_lone_surrogate, false)
 }
 
 /// Repeat a string a specified number of times

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -74,6 +74,25 @@ unsafe fn ordinary_to_primitive_string_inner(value: f64) -> Option<f64> {
         // (`String(Object.create(null))` throws; Test262 ToPropertyKey on a
         // null-proto computed key).
         MethodOutcome::Absent => {
+            // A boxed primitive wrapper (`new Number/String/Boolean/BigInt(x)`,
+            // or a reflective `Object(x)`) stores its `[[PrimitiveData]]` in a
+            // side table (`BOXED_PRIMITIVE_PAYLOADS`), not as a regular own
+            // field — so `call_method_for_primitive`'s `js_object_get_field_by_name`
+            // lookup for `toString` misses even though `Number.prototype.toString`
+            // /etc. are real installed methods, and this arm would otherwise
+            // treat the wrapper like a plain object and render `"[object
+            // Object]"`. The "default"/number-hint ToPrimitive path
+            // (`OrdinaryToPrimitiveOutcome`) already special-cases this via the
+            // same `boxed_primitive_payload` lookup; mirror it here for the
+            // string hint so `String(new Boolean(true))`, a reflective
+            // `Number.prototype.indexOf = String.prototype.indexOf` receiver
+            // coercion, etc. render the wrapped value instead of the object
+            // default (test262 indexOf/lastIndexOf/replace/concat
+            // generic-receiver cases).
+            if let Some((_class_id, payload)) = crate::builtins::boxed_primitive_payload(value) {
+                let s = js_jsvalue_to_string(payload);
+                return Some(crate::value::js_nanbox_string(s as i64));
+            }
             if !value_is_null_proto_object(value) {
                 return None;
             }
@@ -125,15 +144,40 @@ fn throw_cannot_convert_to_primitive() -> ! {
 
 /// Function objects are closure headers, not `ObjectHeader`s, so the ordinary
 /// object helper cannot see the default `%Function.prototype%` chain. Resolve
-/// the function `toString` method explicitly so monkeypatching
+/// the function `toString`/`valueOf` methods explicitly so monkeypatching
 /// `Function.prototype.toString` affects `String(fn)` and template coercion.
+/// Faithful to `OrdinaryToPrimitive(fn, "string")`: try `toString` first: a
+/// primitive result wins; a non-primitive result falls through to `valueOf`
+/// (ECMA-262 §7.1.1.1) instead of giving up and rendering the function's own
+/// source text — test262 `S15.5.2.1_A1_T11` overrides `toString` to return a
+/// non-primitive and expects the `valueOf` result to be used.
 unsafe fn function_to_string_via_prototype(value: f64) -> Option<*mut crate::string::StringHeader> {
-    let primitive = function_to_string_method_result(value)?;
-    if is_primitive_value(primitive) {
-        Some(js_jsvalue_to_string(primitive))
-    } else {
-        None
+    let depth = TO_PRIMITIVE_DEPTH.with(|c| c.get());
+    if depth >= 200 {
+        return None;
     }
+    TO_PRIMITIVE_DEPTH.with(|c| c.set(depth + 1));
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let value_handle = scope.root_nanbox_f64(value);
+    let mut result = None;
+    if let FunctionMethodOutcome::Value(ret) =
+        call_function_method(&scope, &value_handle, b"toString")
+    {
+        if is_primitive_value(ret) {
+            result = Some(js_jsvalue_to_string(ret));
+        }
+    }
+    if result.is_none() {
+        if let FunctionMethodOutcome::Value(ret) =
+            call_function_method(&scope, &value_handle, b"valueOf")
+        {
+            if is_primitive_value(ret) {
+                result = Some(js_jsvalue_to_string(ret));
+            }
+        }
+    }
+    TO_PRIMITIVE_DEPTH.with(|c| c.set(depth));
+    result
 }
 
 /// Same lookup as `function_to_string_via_prototype`, but returns the raw
@@ -353,6 +397,57 @@ pub extern "C" fn js_value_to_str_ptr_for_ffi(value: f64) -> i64 {
 /// callable closure, invoke it with `this = obj` (no args). Returns whether
 /// the result was a primitive, a non-primitive, or whether the method was
 /// absent / non-callable.
+/// `Array.prototype.toString` override check for `String(arr)` / `` `${arr}` ``
+/// / `"" + arr` (test262 `S15.5.1.1_A1_T8`). Arrays are `GC_TYPE_ARRAY`, not
+/// `ObjectHeader`s, so unlike ordinary objects their `toString` can't be
+/// looked up as an "own/inherited field" on the array value itself — the
+/// hardcoded `Array.prototype.join(",")` fallback normally used for arrays
+/// must instead be skipped when `Array.prototype.toString` has been
+/// reassigned away from its installed default (a noop thunk kept only for
+/// `typeof`/`.name` introspection, see `populate_builtin_prototype_methods`).
+/// Returns `Some(primitive)` when a real user override produced a primitive
+/// result; `None` means "still the default (or a non-primitive result) — fall
+/// back to `join`".
+unsafe fn array_prototype_to_string_override(value: f64) -> Option<f64> {
+    let proto = crate::object::builtin_prototype_value("Array");
+    let proto_bits = proto.to_bits();
+    if (proto_bits & 0xFFFF_0000_0000_0000) != POINTER_TAG {
+        return None;
+    }
+    let proto_ptr = (proto_bits & POINTER_MASK) as *mut crate::object::ObjectHeader;
+    if proto_ptr.is_null() {
+        return None;
+    }
+    let key = crate::string::js_string_from_bytes(b"toString".as_ptr(), 8);
+    let method = crate::object::js_object_get_field_by_name(proto_ptr, key);
+    let method_bits = method.bits();
+    if (method_bits & 0xFFFF_0000_0000_0000) != POINTER_TAG {
+        return None;
+    }
+    let method_ptr = (method_bits & POINTER_MASK) as usize;
+    if !crate::closure::is_closure_ptr(method_ptr) {
+        return None;
+    }
+    let closure = method_ptr as *const crate::closure::ClosureHeader;
+    if (*closure).func_ptr == crate::object::global_this_builtin_noop_thunk as *const u8 {
+        return None;
+    }
+    let bound = crate::closure::clone_closure_rebind_this(method_bits, value);
+    let prev_this = crate::object::js_implicit_this_set(value);
+    let ret = crate::closure::js_native_call_value(f64::from_bits(bound), std::ptr::null(), 0);
+    crate::object::js_implicit_this_set(prev_this);
+    let ret_jsv = JSValue::from_bits(ret.to_bits());
+    let is_primitive = ret_jsv.is_any_string()
+        || ret_jsv.is_number()
+        || ret_jsv.is_int32()
+        || ret_jsv.is_bool()
+        || ret_jsv.is_null()
+        || ret_jsv.is_undefined()
+        || ret_jsv.is_bigint()
+        || crate::symbol::js_is_symbol(ret) != 0;
+    is_primitive.then_some(ret)
+}
+
 unsafe fn call_method_for_primitive(
     scope: &crate::gc::RuntimeHandleScope,
     value_handle: &crate::gc::RuntimeHandle<'_>,
@@ -728,6 +823,11 @@ pub extern "C" fn js_jsvalue_to_string(value: f64) -> *mut crate::string::String
             unsafe {
                 let gc_header = ptr.sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
                 if (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY {
+                    // A reassigned `Array.prototype.toString` must run instead
+                    // of the hardcoded join (test262 S15.5.1.1_A1_T8).
+                    if let Some(primitive) = array_prototype_to_string_override(value) {
+                        return js_jsvalue_to_string(primitive);
+                    }
                     // Use js_array_join with a "," separator to match Array.prototype.toString.
                     let sep = crate::string::js_string_from_bytes(b",".as_ptr(), 1);
                     return crate::array::js_array_join(

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -142,6 +142,22 @@ fn throw_cannot_convert_to_primitive() -> ! {
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
 }
 
+/// Outcome of resolving a function/closure's custom `toString`/`valueOf` for
+/// the string-hint `ToPrimitive`. Distinct from a bare `Option` so the
+/// "no custom method at all" case (fall back to the function's own source
+/// text) can be told apart from "a custom method existed and ran, but
+/// neither it nor the `valueOf` fallback produced a primitive" (must throw,
+/// per `OrdinaryToPrimitive` — rendering source text there would be wrong).
+enum FunctionToStringOutcome {
+    /// Neither `toString` nor `valueOf` resolved to a callable — use the
+    /// function's own source-text default.
+    NoCustomMethod,
+    Primitive(*mut crate::string::StringHeader),
+    /// A custom `toString`/`valueOf` was callable but exhausted without
+    /// producing a primitive.
+    TypeError,
+}
+
 /// Function objects are closure headers, not `ObjectHeader`s, so the ordinary
 /// object helper cannot see the default `%Function.prototype%` chain. Resolve
 /// the function `toString`/`valueOf` methods explicitly so monkeypatching
@@ -150,19 +166,23 @@ fn throw_cannot_convert_to_primitive() -> ! {
 /// primitive result wins; a non-primitive result falls through to `valueOf`
 /// (ECMA-262 §7.1.1.1) instead of giving up and rendering the function's own
 /// source text — test262 `S15.5.2.1_A1_T11` overrides `toString` to return a
-/// non-primitive and expects the `valueOf` result to be used.
-unsafe fn function_to_string_via_prototype(value: f64) -> Option<*mut crate::string::StringHeader> {
+/// non-primitive and expects the `valueOf` result to be used. If BOTH are
+/// callable and neither yields a primitive, `OrdinaryToPrimitive` throws
+/// rather than falling back to the source-text default.
+unsafe fn function_to_string_via_prototype(value: f64) -> FunctionToStringOutcome {
     let depth = TO_PRIMITIVE_DEPTH.with(|c| c.get());
     if depth >= 200 {
-        return None;
+        return FunctionToStringOutcome::NoCustomMethod;
     }
     TO_PRIMITIVE_DEPTH.with(|c| c.set(depth + 1));
     let scope = crate::gc::RuntimeHandleScope::new();
     let value_handle = scope.root_nanbox_f64(value);
+    let mut tried_custom_method = false;
     let mut result = None;
     if let FunctionMethodOutcome::Value(ret) =
         call_function_method(&scope, &value_handle, b"toString")
     {
+        tried_custom_method = true;
         if is_primitive_value(ret) {
             result = Some(js_jsvalue_to_string(ret));
         }
@@ -171,13 +191,18 @@ unsafe fn function_to_string_via_prototype(value: f64) -> Option<*mut crate::str
         if let FunctionMethodOutcome::Value(ret) =
             call_function_method(&scope, &value_handle, b"valueOf")
         {
+            tried_custom_method = true;
             if is_primitive_value(ret) {
                 result = Some(js_jsvalue_to_string(ret));
             }
         }
     }
     TO_PRIMITIVE_DEPTH.with(|c| c.set(depth));
-    result
+    match result {
+        Some(s) => FunctionToStringOutcome::Primitive(s),
+        None if tried_custom_method => FunctionToStringOutcome::TypeError,
+        None => FunctionToStringOutcome::NoCustomMethod,
+    }
 }
 
 /// Same lookup as `function_to_string_via_prototype`, but returns the raw
@@ -405,47 +430,54 @@ pub extern "C" fn js_value_to_str_ptr_for_ffi(value: f64) -> i64 {
 /// must instead be skipped when `Array.prototype.toString` has been
 /// reassigned away from its installed default (a noop thunk kept only for
 /// `typeof`/`.name` introspection, see `populate_builtin_prototype_methods`).
-/// Returns `Some(primitive)` when a real user override produced a primitive
-/// result; `None` means "still the default (or a non-primitive result) — fall
-/// back to `join`".
-unsafe fn array_prototype_to_string_override(value: f64) -> Option<f64> {
+/// Outcome of consulting `Array.prototype.toString` for the string-hint
+/// `ToPrimitive`. `UseDefaultJoin` covers both "still the installed noop
+/// default" and any shape we don't have a callable method for (e.g. the
+/// property was overwritten with a non-callable value) — those fall back to
+/// the ordinary `join(",")` behavior. A callable override that's actually
+/// invoked must otherwise follow `OrdinaryToPrimitive`: a primitive result
+/// wins, a non-primitive result exhausts `ToPrimitive` (no separate
+/// `valueOf` override path exists for arrays here) and throws, rather than
+/// silently falling back to `join`.
+enum ArrayToStringOutcome {
+    UseDefaultJoin,
+    Primitive(f64),
+    TypeError,
+}
+
+unsafe fn array_prototype_to_string_override(value: f64) -> ArrayToStringOutcome {
     let proto = crate::object::builtin_prototype_value("Array");
     let proto_bits = proto.to_bits();
     if (proto_bits & 0xFFFF_0000_0000_0000) != POINTER_TAG {
-        return None;
+        return ArrayToStringOutcome::UseDefaultJoin;
     }
     let proto_ptr = (proto_bits & POINTER_MASK) as *mut crate::object::ObjectHeader;
     if proto_ptr.is_null() {
-        return None;
+        return ArrayToStringOutcome::UseDefaultJoin;
     }
     let key = crate::string::js_string_from_bytes(b"toString".as_ptr(), 8);
     let method = crate::object::js_object_get_field_by_name(proto_ptr, key);
     let method_bits = method.bits();
     if (method_bits & 0xFFFF_0000_0000_0000) != POINTER_TAG {
-        return None;
+        return ArrayToStringOutcome::UseDefaultJoin;
     }
     let method_ptr = (method_bits & POINTER_MASK) as usize;
     if !crate::closure::is_closure_ptr(method_ptr) {
-        return None;
+        return ArrayToStringOutcome::UseDefaultJoin;
     }
     let closure = method_ptr as *const crate::closure::ClosureHeader;
     if (*closure).func_ptr == crate::object::global_this_builtin_noop_thunk as *const u8 {
-        return None;
+        return ArrayToStringOutcome::UseDefaultJoin;
     }
     let bound = crate::closure::clone_closure_rebind_this(method_bits, value);
     let prev_this = crate::object::js_implicit_this_set(value);
     let ret = crate::closure::js_native_call_value(f64::from_bits(bound), std::ptr::null(), 0);
     crate::object::js_implicit_this_set(prev_this);
-    let ret_jsv = JSValue::from_bits(ret.to_bits());
-    let is_primitive = ret_jsv.is_any_string()
-        || ret_jsv.is_number()
-        || ret_jsv.is_int32()
-        || ret_jsv.is_bool()
-        || ret_jsv.is_null()
-        || ret_jsv.is_undefined()
-        || ret_jsv.is_bigint()
-        || crate::symbol::js_is_symbol(ret) != 0;
-    is_primitive.then_some(ret)
+    if is_primitive_value(ret) {
+        ArrayToStringOutcome::Primitive(ret)
+    } else {
+        ArrayToStringOutcome::TypeError
+    }
 }
 
 unsafe fn call_method_for_primitive(
@@ -756,8 +788,10 @@ pub extern "C" fn js_jsvalue_to_string(value: f64) -> *mut crate::string::String
             // Function.prototype.toString — covers `String(fn)` and
             // `` `${fn}` `` rather than "[object Object]".
             if crate::closure::is_closure_ptr(ptr as usize) {
-                if let Some(result) = unsafe { function_to_string_via_prototype(value) } {
-                    return result;
+                match unsafe { function_to_string_via_prototype(value) } {
+                    FunctionToStringOutcome::Primitive(result) => return result,
+                    FunctionToStringOutcome::TypeError => throw_cannot_convert_to_primitive(),
+                    FunctionToStringOutcome::NoCustomMethod => {}
                 }
                 let func_ptr =
                     unsafe { (*(ptr as *const crate::closure::ClosureHeader)).func_ptr as usize };
@@ -825,8 +859,12 @@ pub extern "C" fn js_jsvalue_to_string(value: f64) -> *mut crate::string::String
                 if (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY {
                     // A reassigned `Array.prototype.toString` must run instead
                     // of the hardcoded join (test262 S15.5.1.1_A1_T8).
-                    if let Some(primitive) = array_prototype_to_string_override(value) {
-                        return js_jsvalue_to_string(primitive);
+                    match array_prototype_to_string_override(value) {
+                        ArrayToStringOutcome::Primitive(primitive) => {
+                            return js_jsvalue_to_string(primitive)
+                        }
+                        ArrayToStringOutcome::TypeError => throw_cannot_convert_to_primitive(),
+                        ArrayToStringOutcome::UseDefaultJoin => {}
                     }
                     // Use js_array_join with a "," separator to match Array.prototype.toString.
                     let sep = crate::string::js_string_from_bytes(b",".as_ptr(), 1);


### PR DESCRIPTION
## Summary
Fixes 6 of the 38 `built-ins/String` test262 failures listed in #5843, with zero regressions on the rest of the subset (verified via `scripts/test262_subset.py --dir built-ins/String`).

- **padStart/padEnd**: `ToLength(maxLength)` now runs (`js_number_coerce`) before `ToString(fillString)`, matching the spec order — a non-number `maxLength` was previously read as garbage bits instead of coerced. Padding truncation is now WTF-8/surrogate-pair aware: cycles the fill string by UTF-16 code unit, combining a complete surrogate pair into its astral code point but preserving a genuinely truncated pair as a lone surrogate (`js_string_from_wtf8_bytes`) instead of silently dropping the trailing partial character.
- **`String(new Array)`**: now respects a reassigned `Array.prototype.toString` instead of always hardcoding `Array.prototype.join(",")` — arrays are `GC_TYPE_ARRAY`, not `ObjectHeader`s, so their `toString` wasn't discoverable via the normal field walk.
- **`OrdinaryToPrimitive(fn, "string")`**: now falls through to `valueOf` when a custom `toString` returns a non-primitive, instead of giving up and rendering the function's own source text.
- **`OrdinaryToPrimitive(obj, "string")`**: now recognizes a boxed primitive wrapper (`new Number/String/Boolean/BigInt(x)`, or `Object(x)`) when it has no discoverable own/inherited `toString` — its `[[PrimitiveData]]` lives in a side table, not a regular field, so it previously rendered as `"[object Object]"`. Mirrors the existing fallback already used by the "default"/number-hint `ToPrimitive` path.
- **`new String(symbol)`**: throws `TypeError` again — the boxed-primitive constructor's argument was being pre-coerced through the lenient `String()` semantics (which stringify a Symbol to `"Symbol(desc)"`) before `js_boxed_string_new`'s own Symbol-rejection check ever ran, silently defeating it.

## Scope note
The remaining ~32 failures were triaged but are out of scope here — most trace to one deeper root cause plus a few architectural/categorical gaps, detailed in the commit message. Filing follow-ups:
- `js_native_call_method` doesn't correctly route a method reassigned from `String.prototype` onto a non-string receiver (e.g. `__instance.indexOf = String.prototype.indexOf`) through the generic own-key closure-call fallback — affects indexOf/lastIndexOf/replace/concat/toString/valueOf-non-generic (~18 cases). Confirmed **not** caused by this PR (directly verified `String(x)` renders correctly in isolation for the same receivers); needs its own investigation into the dispatcher's routing order in `crates/perry-runtime/src/object/native_call_method.rs`.
- `delete String.prototype.toString` fallback, sloppy-mode non-writable-property no-op, `String` inheriting `Function.prototype` properties, top-level `String(this)`, `localeCompare` Unicode canonical equivalence, and `\k<x>` named-backreference regex are all pre-existing, deliberate-or-categorical gaps (see commit message for specifics).

## Test plan
- [x] `cargo check -p perry-runtime -p perry-hir -p perry-codegen` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `bash scripts/check_file_size.sh` — clean
- [x] `python3 scripts/gc_store_site_inventory.py` / `addr_class_inventory.py` — clean
- [x] `cargo test -p perry-runtime pad_length_tests` — pass
- [x] `scripts/test262_subset.py --dir built-ins/String`: 900/932 pass, same 32 remaining failures minus the 6 listed above fixed; zero new regressions (diffed against the issue's original 38-failure list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `padStart`/`padEnd` behavior to preserve lone surrogates and handle surrogate-pair boundaries correctly.
  * Fixed coercion for padding lengths so non-number inputs are interpreted as runtime numbers rather than raw bits.
  * Corrected boxed primitive and `new String(...)` semantics by properly distinguishing between omitted and explicitly provided arguments.
  * Updated `toString` behavior for boxed values, functions (`toString`/`valueOf` dispatch), and arrays so custom `Array.prototype.toString` overrides are respected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->