### PR TITLE
fix(runtime): #5838 — HasProperty misses indexed keys when prototype chain hops through a real Array

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set/has_property.rs
+++ b/crates/perry-runtime/src/object/field_get_set/has_property.rs
@@ -462,10 +462,26 @@ unsafe fn ordinary_has_property(
             break;
         }
         last_valid = cur;
-        // Own data / overflow key present (value-agnostic: `delete` removes the
-        // key, so a present key — even one holding `undefined` — is an own
-        // property).
-        if super::super::own_key_present(cur as *mut ObjectHeader, key) {
+        // A prototype hop can land on a real Array (`Foo.prototype = [1,2,3]`,
+        // test262 reduce/reduceRight `subclassed array` cases): its layout is
+        // `ArrayHeader { length, capacity }` + inline elements, NOT the
+        // `ObjectHeader.keys_array` shape `own_key_present` expects, so reading
+        // `(*cur).keys_array` off an array node finds garbage (or nothing) and
+        // every indexed/`"length"` lookup wrongly reports absent. Detect the
+        // GC type and route to the array-aware own-key check instead.
+        let cur_is_array = crate::value::addr_class::try_read_gc_header(cur as usize)
+            .is_some_and(|hdr| hdr.obj_type == crate::gc::GC_TYPE_ARRAY);
+        if cur_is_array {
+            if super::super::has_own_helpers::array_own_key_present(
+                cur as *const crate::array::ArrayHeader,
+                key,
+            ) {
+                return true;
+            }
+        } else if super::super::own_key_present(cur as *mut ObjectHeader, key) {
+            // Own data / overflow key present (value-agnostic: `delete`
+            // removes the key, so a present key — even one holding
+            // `undefined` — is an own property).
             return true;
         }
         // Own accessor property (also mirrored into `keys_array`, but check the


### PR DESCRIPTION
## Summary
- `ordinary_has_property`'s manual `[[Prototype]]` walk treated every hop as a plain `ObjectHeader` and called `own_key_present`, which assumes the `keys_array` field layout. A hop onto a real `ArrayHeader` (e.g. `Foo.prototype = [1,2,3]` / `new Array(...)`) has no `keys_array` field at all, so every indexed/`"length"` lookup on that node silently reported absent.
- This broke `HasProperty` for array-like-via-prototype receivers (`function Foo(){}; Foo.prototype = [1,2,3,4]; var f = new Foo();`), which `Array.prototype.reduce`/`reduceRight` rely on (via `js_array_from_arraylike`) to distinguish holes from present elements when materializing an array-like `this`.
- Fix: detect the GC type per hop and route array nodes to the existing `array_own_key_present` helper (already used on the direct-array-receiver `hasOwnProperty`/`in` path) instead of the object-only helper.

Part of the self-contained worklist in #5838 (61 failing built-ins/Array test262 cases). This PR fixes the `reduce`/`reduceRight` "subclassed array" sub-cluster (8 cases): `15.4.4.21-10-{3,4,6,7}`, `15.4.4.22-10-{3,4,6,7}`.

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `bash scripts/check_file_size.sh` passes
- [x] `cargo test --release -p perry-runtime --lib` — all tests pass (2 flaky test-isolation failures reproduce identically on unmodified `main` when run in isolation they pass; unrelated to this change)
- [x] `scripts/test262_subset.py --dir built-ins/Array` before/after diff: 2464→2472 pass, 63→55 rt-fail, **0 regressions**, exactly the 8 targeted cases now pass
- [x] Targeted regression sweep (`language/expressions/in`, `language/statements/for-in`, `built-ins/Proxy`, `built-ins/Reflect`, `built-ins/Object`): no new failures; all failures present are pre-existing categorical gaps (Proxy trap invariants, defineProperty descriptor edge cases, TDZ scoping) unrelated to this change

No version bump / CHANGELOG entry per CLAUDE.md external-contributor convention — maintainer folds in metadata at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed property lookups so they correctly continue through prototype chains when an Array is encountered.
  * Improved handling of inherited properties on array-backed objects, reducing cases where valid properties could be missed during lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->