### PR TITLE
fix(intl): #5840 — Intl.DateTimeFormat dayPeriod-only formatting (6 test262 cases)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v0.5.1211 — fix(intl): #5840 — Intl.DateTimeFormat dayPeriod-only formatting (6 test262 cases)
+
+Fixes the `dayPeriod`-only subcluster of the #5840 DateTimeFormat worklist: `new Intl.DateTimeFormat('en', {dayPeriod: 'long'})` (with no other date/time component options) silently fell back to the default `M/D/YYYY` date string in both `format` and `formatToParts`, because `dtf_primary_mask` (`crates/perry-runtime/src/intl/date_collator.rs`) never counted `dayPeriod` toward its "has a time-dimension field" bit, and neither `format_components` nor `build_parts_from_components` had any dayPeriod rendering path at all — `dayPeriod` was only ever emitted as a byproduct of the AM/PM 12-hour clock.
+
+- Added `day_period_string(hour, style)`: `en` CLDR day-period boundaries at hour granularity (`0-11` morning, `12` noon, `13-17` afternoon, `18-20` evening, `21-23` night; `narrow` abbreviates only "noon" → "n", matching real ICU `en` data — verified empirically against `node`).
+- `dtf_primary_mask` now sets `BIT_TIME` when `dayPeriod` is set, so a dayPeriod-only DTF is no longer misclassified as "no primary fields" and forced through the Temporal-default fallback path.
+- `format_components`/`build_parts_from_components` both thread a new `day_period_opt` parameter through: dayPeriod-only renders just the period text (one part in `formatToParts`); dayPeriod combined with a numeric `hour` renders `"<hour> <period>"` (`[hour, literal " ", dayPeriod]` in `formatToParts`), replacing the default AM/PM suffix. Behavior is unchanged when `day_period_opt` is `None`.
+- Fixes: `prototype/format/dayPeriod-{long,narrow,short}-en.js`, `prototype/formatToParts/dayPeriod-{long,narrow,short}-en.js`. Verified via `scripts/test262_subset.py --dir intl402/DateTimeFormat` (run under `TZ=UTC` — Perry's DTF hardcodes a `UTC` default timeZone while `Date`'s local-component constructor honors the real host offset, so a non-UTC dev box shows an unrelated pre-existing hour-shift on `new Date(y,m,d,h,...)`-based cases; CI runs UTC) with zero regressions (45 remaining failures, exactly the other 45 of the original 51-case worklist).
+
 ## v0.5.1210 — fix(hir+codegen+runtime): #5833 — global-code declaration-instantiation cluster (4 test262 cases)
 
 Closes 4 of the 6 `language/global-code` + `language/identifier-resolution` cases from the #5833 worklist (the remaining `decl-var.js`/`S10.4.1_A1_T1.js` need a live-synced `var` → `globalThis` reflection, a materially larger change — left as a follow-up rather than folded into this PR).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1210
+**Current Version:** 0.5.1211
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5307,7 +5307,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "anyhow",
  "base64",
@@ -5364,14 +5364,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "cc",
  "libc",
@@ -5379,7 +5379,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "anyhow",
  "log",
@@ -5394,7 +5394,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5403,7 +5403,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5411,7 +5411,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5421,7 +5421,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "anyhow",
  "base64",
@@ -5443,7 +5443,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5451,7 +5451,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5480,14 +5480,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "serde",
  "serde_json",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1210"
+version = "0.5.1211"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5506,7 +5506,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "anyhow",
  "clap",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "block2",
  "objc2",
@@ -5531,7 +5531,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5539,7 +5539,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5548,7 +5548,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5556,7 +5556,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5564,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5580,7 +5580,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "chrono",
  "cron",
@@ -5590,7 +5590,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5598,7 +5598,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5606,7 +5606,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5630,14 +5630,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5668,7 +5668,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5682,7 +5682,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "bytes",
  "h2",
@@ -5705,7 +5705,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5715,7 +5715,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5726,7 +5726,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5734,7 +5734,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "bson",
  "futures-util",
@@ -5754,7 +5754,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5764,7 +5764,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -5786,7 +5786,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5804,7 +5804,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -5831,14 +5831,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5877,7 +5877,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "brotli",
  "flate2",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5895,7 +5895,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5913,7 +5913,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5925,7 +5925,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "anyhow",
  "base64",
@@ -5958,14 +5958,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6057,14 +6057,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6082,14 +6082,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "base64",
  "itoa",
@@ -6106,7 +6106,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6116,7 +6116,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6139,7 +6139,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "base64",
  "block2",
@@ -6155,7 +6155,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "base64",
  "block2",
@@ -6170,7 +6170,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1210"
+version = "0.5.1211"
 
 [[package]]
 name = "perry-ui-test"
@@ -6178,11 +6178,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1210"
+version = "0.5.1211"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "base64",
  "block2",
@@ -6198,7 +6198,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "base64",
  "block2",
@@ -6214,7 +6214,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "block2",
  "libc",
@@ -6227,7 +6227,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "base64",
  "libc",
@@ -6244,14 +6244,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6265,7 +6265,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1210"
+version = "0.5.1211"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -301,7 +301,7 @@ strip = false
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1210"
+version = "0.5.1211"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/intl/date_collator.rs
+++ b/crates/perry-runtime/src/intl/date_collator.rs
@@ -418,6 +418,7 @@ fn format_parts_with_dtf_obj(
             let second_opt = get_string_field(obj, KEY_SECOND);
             let weekday_opt = get_string_field(obj, KEY_WEEKDAY);
             let era_opt = get_string_field(obj, KEY_ERA);
+            let day_period_opt = get_string_field(obj, KEY_DAY_PERIOD);
             build_parts_from_components(
                 year,
                 month,
@@ -435,6 +436,7 @@ fn format_parts_with_dtf_obj(
                 second_opt.as_deref(),
                 weekday_opt.as_deref(),
                 era_opt.as_deref(),
+                day_period_opt.as_deref(),
                 use_24h,
             )
         }
@@ -459,11 +461,15 @@ fn build_parts_from_components(
     second_opt: Option<&str>,
     weekday_opt: Option<&str>,
     era_opt: Option<&str>,
+    day_period_opt: Option<&str>,
     use_24h: bool,
 ) -> Vec<(&'static str, String)> {
     let mut parts: Vec<(&'static str, String)> = Vec::new();
     let has_date = year_opt.is_some() || month_opt.is_some() || day_opt.is_some();
-    let has_time = hour_opt.is_some() || minute_opt.is_some() || second_opt.is_some();
+    let has_time = hour_opt.is_some()
+        || minute_opt.is_some()
+        || second_opt.is_some()
+        || day_period_opt.is_some();
 
     // Weekday prepended before date parts.
     if let Some(wk_s) = weekday_opt {
@@ -562,6 +568,12 @@ fn build_parts_from_components(
                 parts.push(("literal", ":".to_string()));
                 parts.push(("second", format!("{:02}", second)));
             }
+            if let Some(dp_s) = day_period_opt {
+                if hour_opt.is_some() || inc_mins {
+                    parts.push(("literal", " ".to_string()));
+                }
+                parts.push(("dayPeriod", day_period_string(hour, dp_s).to_string()));
+            }
         } else {
             let (h, ampm) = if hour == 0 {
                 (12u32, "AM")
@@ -590,7 +602,12 @@ fn build_parts_from_components(
                 parts.push(("literal", ":".to_string()));
                 parts.push(("second", format!("{:02}", second)));
             }
-            if hour_opt.is_some() || inc_mins {
+            if let Some(dp_s) = day_period_opt {
+                if hour_opt.is_some() || inc_mins {
+                    parts.push(("literal", " ".to_string()));
+                }
+                parts.push(("dayPeriod", day_period_string(hour, dp_s).to_string()));
+            } else if hour_opt.is_some() || inc_mins {
                 parts.push(("literal", " ".to_string()));
                 parts.push(("dayPeriod", ampm.to_string()));
             }
@@ -722,6 +739,7 @@ fn dtf_primary_mask(obj: *const ObjectHeader) -> u8 {
     if get_string_field(obj, KEY_HOUR).is_some()
         || get_string_field(obj, KEY_MINUTE).is_some()
         || get_string_field(obj, KEY_SECOND).is_some()
+        || get_string_field(obj, KEY_DAY_PERIOD).is_some()
         || get_number_field(obj, KEY_FRACTIONAL).is_some()
     {
         mask |= BIT_TIME;
@@ -816,6 +834,26 @@ fn weekday_name(secs: i64, style: &str) -> String {
         "short" => WEEKDAY_ABBR[wi].to_string(),
         "narrow" => WEEKDAY_NARROW[wi].to_string(),
         _ => WEEKDAY_ABBR[wi].to_string(),
+    }
+}
+
+/// `en` CLDR day-period boundaries (hour-granularity): morning covers
+/// midnight through 11:00, noon is the 12:00 hour exactly, afternoon 13:00
+/// through 17:00, evening 18:00 through 20:00, night 21:00 through 23:00.
+/// `narrow` abbreviates only "noon" to "n" — the other four periods use the
+/// same word in all three widths for `en`.
+fn day_period_string(hour: u32, style: &str) -> &'static str {
+    let wide = match hour {
+        12 => "noon",
+        13..=17 => "in the afternoon",
+        18..=20 => "in the evening",
+        21..=23 => "at night",
+        _ => "in the morning",
+    };
+    if style == "narrow" && wide == "noon" {
+        "n"
+    } else {
+        wide
     }
 }
 
@@ -946,10 +984,14 @@ fn format_components(
     second_opt: Option<&str>,
     weekday_opt: Option<&str>,
     era_opt: Option<&str>,
+    day_period_opt: Option<&str>,
     use_24h: bool,
 ) -> String {
     let has_date = year_opt.is_some() || month_opt.is_some() || day_opt.is_some();
-    let has_time = hour_opt.is_some() || minute_opt.is_some() || second_opt.is_some();
+    let has_time = hour_opt.is_some()
+        || minute_opt.is_some()
+        || second_opt.is_some()
+        || day_period_opt.is_some();
 
     let date_part = if has_date {
         let has_m = month_opt.is_some();
@@ -1006,11 +1048,26 @@ fn format_components(
         let inc_mins = minute_opt.is_some() || inc_secs;
         Some(if use_24h {
             if inc_secs {
-                format!("{:02}:{:02}:{:02}", hour, minute, second)
+                let base = format!("{:02}:{:02}:{:02}", hour, minute, second);
+                match day_period_opt {
+                    Some(s) => format!("{} {}", base, day_period_string(hour, s)),
+                    None => base,
+                }
             } else if inc_mins {
-                format!("{:02}:{:02}", hour, minute)
+                let base = format!("{:02}:{:02}", hour, minute);
+                match day_period_opt {
+                    Some(s) => format!("{} {}", base, day_period_string(hour, s)),
+                    None => base,
+                }
+            } else if hour_opt.is_some() {
+                let base = format!("{:02}", hour);
+                match day_period_opt {
+                    Some(s) => format!("{} {}", base, day_period_string(hour, s)),
+                    None => base,
+                }
             } else {
-                format!("{:02}", hour)
+                // dayPeriod-only (no hour/minute/second requested).
+                day_period_string(hour, day_period_opt.unwrap_or("long")).to_string()
             }
         } else {
             let (h, ampm) = if hour == 0 {
@@ -1022,12 +1079,18 @@ fn format_components(
             } else {
                 (hour - 12, "PM")
             };
+            let suffix = day_period_opt
+                .map(|s| day_period_string(hour, s))
+                .unwrap_or(ampm);
             if inc_secs {
-                format!("{}:{:02}:{:02} {}", h, minute, second, ampm)
+                format!("{}:{:02}:{:02} {}", h, minute, second, suffix)
             } else if inc_mins {
-                format!("{}:{:02} {}", h, minute, ampm)
+                format!("{}:{:02} {}", h, minute, suffix)
+            } else if hour_opt.is_some() {
+                format!("{} {}", h, suffix)
             } else {
-                format!("{} {}", h, ampm)
+                // dayPeriod-only (no hour/minute/second requested).
+                suffix.to_string()
             }
         })
     } else {
@@ -1196,6 +1259,7 @@ fn format_ms_with_dtf_obj(
                 };
             let weekday_opt = get_string_field(obj, KEY_WEEKDAY);
             let era_opt = get_string_field(obj, KEY_ERA);
+            let day_period_opt = get_string_field(obj, KEY_DAY_PERIOD);
             format_components(
                 year,
                 month,
@@ -1212,6 +1276,7 @@ fn format_ms_with_dtf_obj(
                 second_opt.as_deref(),
                 weekday_opt.as_deref(),
                 era_opt.as_deref(),
+                day_period_opt.as_deref(),
                 use_24h,
             )
         }
@@ -1449,6 +1514,7 @@ pub(crate) fn temporal_locale_string(
             eff_sec,
             weekday_opt.as_deref(),
             era_opt.as_deref(),
+            None,
             use_24h,
         ),
     };

--- a/crates/perry-runtime/src/intl/date_collator.rs
+++ b/crates/perry-runtime/src/intl/date_collator.rs
@@ -1341,6 +1341,7 @@ pub(crate) fn temporal_locale_string(
     let hour_cycle = get_opt("hourCycle");
     let weekday_opt = get_opt("weekday");
     let era_opt = get_opt("era");
+    let day_period_opt = get_opt("dayPeriod");
     let tz_name_opt = get_opt("timeZoneName");
     let tz_opt = get_opt("timeZone");
 
@@ -1353,6 +1354,7 @@ pub(crate) fn temporal_locale_string(
         || second_opt.is_some()
         || weekday_opt.is_some()
         || era_opt.is_some()
+        || day_period_opt.is_some()
         || tz_name_opt.is_some();
 
     // ---- validate option conflicts ----
@@ -1514,7 +1516,7 @@ pub(crate) fn temporal_locale_string(
             eff_sec,
             weekday_opt.as_deref(),
             era_opt.as_deref(),
-            None,
+            day_period_opt.as_deref(),
             use_24h,
         ),
     };


### PR DESCRIPTION
## Summary

- Fixes the `dayPeriod`-only subcluster of the #5840 `intl402/DateTimeFormat` worklist. `new Intl.DateTimeFormat('en', {dayPeriod: 'long'})` (no other date/time component options) silently fell back to the default `M/D/YYYY` date string in both `format` and `formatToParts` — `dtf_primary_mask` never counted `dayPeriod` toward its time-dimension bit, and neither `format_components` nor `build_parts_from_components` had any dayPeriod rendering path (dayPeriod was previously only ever emitted as a byproduct of the AM/PM 12-hour clock).
- Adds `day_period_string(hour, style)`: `en` CLDR day-period boundaries at hour granularity (0-11 morning, 12 noon, 13-17 afternoon, 18-20 evening, 21-23 night; `narrow` abbreviates only "noon" → "n"), verified empirically against `node`.
- Threads a `day_period_opt` parameter through `format_components`/`build_parts_from_components`: dayPeriod-only renders just the period text (one part in `formatToParts`); combined with a numeric `hour` it renders `"<hour> <period>"` (`[hour, literal " ", dayPeriod]` in `formatToParts`), replacing the default AM/PM suffix. Behavior is unchanged when `day_period_opt` is `None`.

Fixes: `prototype/format/dayPeriod-{long,narrow,short}-en.js`, `prototype/formatToParts/dayPeriod-{long,narrow,short}-en.js`.

## Test plan

- [x] `scripts/test262_subset.py --root vendor/test262 --dir intl402/DateTimeFormat` (run under `TZ=UTC` — Perry's DTF hardcodes a `UTC` default timeZone while `Date`'s local-component constructor honors the real host offset, so a non-UTC dev box shows an unrelated pre-existing hour-shift on `new Date(y,m,d,h,...)`-based cases; CI runs UTC): 6 target cases fixed, zero regressions (45 remaining failures = exactly the other 45 of the original 51-case worklist).
- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/check_file_size.sh` (date_collator.rs: 1951/2000 lines)
- [x] `scripts/run_gap_tests.sh` — pre-existing gap failures unrelated to this change confirmed via `git stash` bisection (e.g. `test_gap_console_bare_global` reproduces identically on unmodified `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Date and time formatting now supports `dayPeriod` labels (morning/afternoon/evening and equivalents) more broadly, including `formatToParts` output.
  * `format`/`formatToParts` handle `dayPeriod`-only cases and combined `dayPeriod` + numeric hour cases more consistently.

* **Bug Fixes**
  * Fixed incorrect `dayPeriod` option handling that could cause misclassification and incorrect rendering.
  * Improved locale-aware suffix/label behavior for both 24-hour and 12-hour output.

* **Documentation**
  * Updated the changelog and current version to v0.5.1211.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->