### PR TITLE
fix(runtime): #5842 — Function.prototype defineProperty accessor inheritance through closures

### DIFF
--- a/crates/perry-runtime/src/closure/dynamic_props.rs
+++ b/crates/perry-runtime/src/closure/dynamic_props.rs
@@ -570,18 +570,21 @@ pub(crate) fn function_prototype_fallback_target(ptr: usize, prop: &str) -> Opti
 }
 
 /// SET-side analog of `closure_get_dynamic_prop`'s inherited-accessor read:
-/// if `prop` resolves to an ACCESSOR installed on the real
+/// if `prop` resolves to a descriptor installed on the real
 /// `%Function.prototype%` object (`Object.defineProperty(Function.prototype,
-/// k, {get,set})`), invoke its setter (if any) with `receiver` as `this` and
-/// report the write handled. Returns `false` for a plain inherited DATA
-/// property — an ordinary `[[Set]]` on a writable inherited data property
-/// creates a new OWN property on the receiver, which the caller's existing
-/// own-dynamic-prop fallback already does correctly. `ptr` is the closure
-/// being checked against (used only to reject the Function.prototype
-/// self-reference); `receiver` is the spec `[[Set]]` receiver — ordinarily
-/// the same object, but callers reached via `Reflect.set(target, k, v, R)`
-/// pass a distinct `R`.
-pub(crate) fn closure_set_via_function_prototype_accessor(
+/// k, {...})`), apply spec `[[Set]]` semantics for it and report the write
+/// handled — an ACCESSOR invokes its setter (if any) with `receiver` as
+/// `this`; a non-writable DATA property blocks the write (matches the
+/// silent-no-op convention this file already uses for a non-writable OWN
+/// attrs record, just above this function's callers). Returns `false` when
+/// there's no inherited descriptor at all, or it's a writable DATA property —
+/// an ordinary `[[Set]]` on those creates a new OWN property on the receiver,
+/// which the caller's existing own-dynamic-prop fallback already does
+/// correctly. `ptr` is the closure being checked against (used only to
+/// reject the Function.prototype self-reference); `receiver` is the spec
+/// `[[Set]]` receiver — ordinarily the same object, but callers reached via
+/// `Reflect.set(target, k, v, R)` pass a distinct `R`.
+pub(crate) fn closure_set_via_function_prototype_descriptor(
     ptr: usize,
     prop: &str,
     value: f64,
@@ -590,19 +593,24 @@ pub(crate) fn closure_set_via_function_prototype_accessor(
     let Some(proto_ptr) = function_prototype_fallback_target(ptr, prop) else {
         return false;
     };
-    let Some(acc) = crate::object::get_accessor_descriptor(proto_ptr, prop) else {
-        return false;
-    };
-    if acc.set == 0 {
-        // Getter-only: matches `al_set_length`'s getter-only `length` throw
-        // (array/generic.rs) — a strict-mode write to an accessor with no
-        // setter is a TypeError, not a silent no-op.
-        crate::collection_iter::throw_type_error(&format!(
-            "Cannot set property {prop} of #<Function> which has only a getter"
-        ));
+    if let Some(acc) = crate::object::get_accessor_descriptor(proto_ptr, prop) {
+        if acc.set == 0 {
+            // Getter-only: matches `al_set_length`'s getter-only `length` throw
+            // (array/generic.rs) — a strict-mode write to an accessor with no
+            // setter is a TypeError, not a silent no-op.
+            crate::collection_iter::throw_type_error(&format!(
+                "Cannot set property {prop} of #<Function> which has only a getter"
+            ));
+        }
+        unsafe { crate::object::invoke_accessor_setter(acc.set, receiver, value) };
+        return true;
     }
-    unsafe { crate::object::invoke_accessor_setter(acc.set, receiver, value) };
-    true
+    if let Some(attrs) = crate::object::get_property_attrs(proto_ptr, prop) {
+        if !attrs.writable() {
+            return true;
+        }
+    }
+    false
 }
 
 /// Set a dynamic property on a closure.

--- a/crates/perry-runtime/src/closure/dynamic_props.rs
+++ b/crates/perry-runtime/src/closure/dynamic_props.rs
@@ -478,80 +478,131 @@ pub fn closure_get_dynamic_prop(ptr: usize, prop: &str) -> f64 {
         break;
     }
     // Every function's [[Prototype]] is %Function.prototype% — an expando
-    // installed there (`Function.prototype.property = 12`) must be readable
-    // through any closure (`fn.property`, `boundFn.property`,
-    // `Function.indicator`). Synthesized own slots (`prototype`/`name`/
-    // `length`/`caller`/`arguments`/`constructor`) never come from the
-    // expando walk; excluding `prototype` also breaks the recursion through
-    // `builtin_prototype_value` (which reads `Function.prototype` via this
-    // very function). A re-entrancy guard covers the rest of that resolution
-    // cycle.
-    if !matches!(
-        prop,
-        "prototype" | "name" | "length" | "caller" | "arguments" | "constructor"
-    ) && !prop.as_bytes().first().is_some_and(|b| b.is_ascii_digit())
-    {
-        thread_local! {
-            static IN_FN_PROTO_FALLBACK: std::cell::Cell<bool> =
-                const { std::cell::Cell::new(false) };
-        }
-        let reentrant = IN_FN_PROTO_FALLBACK.with(|c| c.replace(true));
-        if !reentrant {
-            let proto_val = crate::object::builtin_prototype_value("Function");
-            IN_FN_PROTO_FALLBACK.with(|c| c.set(false));
-            let proto_jv = crate::value::JSValue::from_bits(proto_val.to_bits());
-            if proto_jv.is_pointer() {
-                let proto_ptr = (proto_jv.bits() & crate::value::POINTER_MASK) as usize;
-                // ONLY user expandos walk through (a `Function.prototype.x
-                // = …` write records no attrs). Methods installed at init
-                // (`apply`, `call`, `hasOwnProperty`, …) stay excluded:
-                // serving those generic thunks to closure reads hijacks the
-                // dedicated dispatch arms (`p.call(...)`'s undefined-read
-                // fallback to method-dispatch-by-name is what routes the
-                // proxy APPLY trap). `fn.apply`-style VALUE reads through a
-                // proxy are reified receiver-correctly by `js_proxy_get`.
-                let routed_method = false;
-                if proto_ptr != 0
-                    && proto_ptr != ptr
-                    && !is_closure_ptr(proto_ptr)
-                    && (routed_method
-                        || crate::object::get_property_attrs(proto_ptr, prop).is_none())
-                {
-                    // A defineProperty accessor on Function.prototype
-                    // (`{ get: () => 12 }`) is invoked with the reading
-                    // closure as receiver.
-                    if !routed_method {
-                        if let Some(acc) = crate::object::get_accessor_descriptor(proto_ptr, prop) {
-                            if acc.get != 0 {
-                                let getter = (acc.get & crate::value::POINTER_MASK)
-                                    as *const crate::closure::ClosureHeader;
-                                if !getter.is_null() {
-                                    let receiver = crate::value::js_nanbox_pointer(ptr as i64);
-                                    let prev = crate::object::js_implicit_this_set(receiver);
-                                    let result = crate::closure::js_closure_call0(getter);
-                                    crate::object::js_implicit_this_set(prev);
-                                    return result;
-                                }
-                            }
-                            return f64::from_bits(crate::value::TAG_UNDEFINED);
-                        }
-                    }
-                    unsafe {
-                        let key_hdr =
-                            crate::string::js_string_from_bytes(prop.as_ptr(), prop.len() as u32);
-                        let v = crate::object::js_object_get_field_by_name(
-                            proto_ptr as *const crate::object::ObjectHeader,
-                            key_hdr as *const crate::StringHeader,
-                        );
-                        if !v.is_undefined() {
-                            return f64::from_bits(v.bits());
-                        }
-                    }
+    // installed there (`Function.prototype.property = 12`), or a property
+    // installed via `Object.defineProperty(Function.prototype, k, {...})`,
+    // must be readable through any closure (`fn.property`, `boundFn.property`,
+    // `Function.indicator`).
+    if let Some(proto_ptr) = function_prototype_fallback_target(ptr, prop) {
+        // A defineProperty accessor on Function.prototype
+        // (`{ get: () => 12 }`) is invoked with the reading
+        // closure as receiver.
+        if let Some(acc) = crate::object::get_accessor_descriptor(proto_ptr, prop) {
+            if acc.get != 0 {
+                let getter =
+                    (acc.get & crate::value::POINTER_MASK) as *const crate::closure::ClosureHeader;
+                if !getter.is_null() {
+                    let receiver = crate::value::js_nanbox_pointer(ptr as i64);
+                    let prev = crate::object::js_implicit_this_set(receiver);
+                    let result = crate::closure::js_closure_call0(getter);
+                    crate::object::js_implicit_this_set(prev);
+                    return result;
                 }
+            }
+            return f64::from_bits(crate::value::TAG_UNDEFINED);
+        }
+        unsafe {
+            let key_hdr = crate::string::js_string_from_bytes(prop.as_ptr(), prop.len() as u32);
+            let v = crate::object::js_object_get_field_by_name(
+                proto_ptr as *const crate::object::ObjectHeader,
+                key_hdr as *const crate::StringHeader,
+            );
+            if !v.is_undefined() {
+                return f64::from_bits(v.bits());
             }
         }
     }
     f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+/// Resolve the real, mutable `%Function.prototype%` object pointer for a
+/// closure-receiver fallback (GET or SET), or `None` if `prop` doesn't
+/// qualify — a synthesized own slot, a reified method name (`apply`, `call`,
+/// `bind`, …: serving those generic thunks to closure reads/writes hijacks
+/// the dedicated dispatch arms, e.g. `p.call(...)`'s undefined-read fallback
+/// to method-dispatch-by-name routes the proxy APPLY trap — `fn.apply`-style
+/// VALUE reads through a proxy are reified receiver-correctly by
+/// `js_proxy_get` instead), an array-index-shaped key, or resolving would
+/// recurse back into `Function.prototype` itself. Shared by
+/// [`closure_get_dynamic_prop`]'s expando/defineProperty walk and the
+/// closure SET path in `object::field_set_by_name`, so
+/// `Object.defineProperty(Function.prototype, k, {get,set})` round-trips
+/// through `boundFn.k = v` the same way it does through `boundFn.k`. A
+/// re-entrancy guard covers the recursion through `builtin_prototype_value`
+/// (which reads `Function.prototype` via `closure_get_dynamic_prop` itself).
+pub(crate) fn function_prototype_fallback_target(ptr: usize, prop: &str) -> Option<usize> {
+    if matches!(
+        prop,
+        "prototype" | "name" | "length" | "caller" | "arguments" | "constructor"
+        // Universal Object.prototype method names: every receiver (closures
+        // included) resolves these through a dedicated native dispatch arm,
+        // not a literal field on the walked prototype object. Serving a
+        // generic-lookup result for one of these hijacks that dispatch —
+        // e.g. `m.propertyIsEnumerable` resolved a same-named-but-wrong
+        // value via this fallback, so `m.propertyIsEnumerable("length")`
+        // called the wrong thing (test262 S15.2.4.3_A8 / S15.2.4.4_A8 /
+        // S15.2.4.7_A8 regressions caught after the initial fix).
+        | "toString" | "valueOf" | "hasOwnProperty" | "isPrototypeOf"
+        | "propertyIsEnumerable" | "toLocaleString"
+    ) || prop.as_bytes().first().is_some_and(|b| b.is_ascii_digit())
+        || crate::object::reified_function_method_name(prop).is_some()
+    {
+        return None;
+    }
+    thread_local! {
+        static IN_FN_PROTO_FALLBACK: std::cell::Cell<bool> =
+            const { std::cell::Cell::new(false) };
+    }
+    let reentrant = IN_FN_PROTO_FALLBACK.with(|c| c.replace(true));
+    if reentrant {
+        return None;
+    }
+    let proto_val = crate::object::builtin_prototype_value("Function");
+    IN_FN_PROTO_FALLBACK.with(|c| c.set(false));
+    let proto_jv = crate::value::JSValue::from_bits(proto_val.to_bits());
+    if !proto_jv.is_pointer() {
+        return None;
+    }
+    let proto_ptr = (proto_jv.bits() & crate::value::POINTER_MASK) as usize;
+    if proto_ptr == 0 || proto_ptr == ptr || is_closure_ptr(proto_ptr) {
+        return None;
+    }
+    Some(proto_ptr)
+}
+
+/// SET-side analog of `closure_get_dynamic_prop`'s inherited-accessor read:
+/// if `prop` resolves to an ACCESSOR installed on the real
+/// `%Function.prototype%` object (`Object.defineProperty(Function.prototype,
+/// k, {get,set})`), invoke its setter (if any) with `receiver` as `this` and
+/// report the write handled. Returns `false` for a plain inherited DATA
+/// property — an ordinary `[[Set]]` on a writable inherited data property
+/// creates a new OWN property on the receiver, which the caller's existing
+/// own-dynamic-prop fallback already does correctly. `ptr` is the closure
+/// being checked against (used only to reject the Function.prototype
+/// self-reference); `receiver` is the spec `[[Set]]` receiver — ordinarily
+/// the same object, but callers reached via `Reflect.set(target, k, v, R)`
+/// pass a distinct `R`.
+pub(crate) fn closure_set_via_function_prototype_accessor(
+    ptr: usize,
+    prop: &str,
+    value: f64,
+    receiver: f64,
+) -> bool {
+    let Some(proto_ptr) = function_prototype_fallback_target(ptr, prop) else {
+        return false;
+    };
+    let Some(acc) = crate::object::get_accessor_descriptor(proto_ptr, prop) else {
+        return false;
+    };
+    if acc.set == 0 {
+        // Getter-only: matches `al_set_length`'s getter-only `length` throw
+        // (array/generic.rs) — a strict-mode write to an accessor with no
+        // setter is a TypeError, not a silent no-op.
+        crate::collection_iter::throw_type_error(&format!(
+            "Cannot set property {prop} of #<Function> which has only a getter"
+        ));
+    }
+    unsafe { crate::object::invoke_accessor_setter(acc.set, receiver, value) };
+    true
 }
 
 /// Set a dynamic property on a closure.

--- a/crates/perry-runtime/src/closure/mod.rs
+++ b/crates/perry-runtime/src/closure/mod.rs
@@ -58,7 +58,8 @@ pub use unbox::js_closure_unbox_callee_checked;
 pub(crate) use dynamic_props::test_clear_closure_side_tables;
 pub(crate) use dynamic_props::{
     clone_closure_rebind_this, closure_dynamic_props_owner_moved,
-    visit_closure_dynamic_prop_value_slots_mut, visit_closure_static_prototype_slot_mut,
+    closure_set_via_function_prototype_accessor, visit_closure_dynamic_prop_value_slots_mut,
+    visit_closure_static_prototype_slot_mut,
 };
 pub use dynamic_props::{
     closure_delete_own_dynamic_prop, closure_dynamic_props_snapshot, closure_get_dynamic_prop,

--- a/crates/perry-runtime/src/closure/mod.rs
+++ b/crates/perry-runtime/src/closure/mod.rs
@@ -58,7 +58,7 @@ pub use unbox::js_closure_unbox_callee_checked;
 pub(crate) use dynamic_props::test_clear_closure_side_tables;
 pub(crate) use dynamic_props::{
     clone_closure_rebind_this, closure_dynamic_props_owner_moved,
-    closure_set_via_function_prototype_accessor, visit_closure_dynamic_prop_value_slots_mut,
+    closure_set_via_function_prototype_descriptor, visit_closure_dynamic_prop_value_slots_mut,
     visit_closure_static_prototype_slot_mut,
 };
 pub use dynamic_props::{

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -175,9 +175,9 @@ unsafe fn string_key_eq(key: *const crate::StringHeader, expected: &[u8]) -> boo
 /// GcHeader-typed pointer, and the raw `CLOSURE_MAGIC`-tagged fallback for a
 /// pointer reached without a full GC header). #3143: honors a non-writable
 /// registered descriptor (a built-in method's `.name`/`.length` are spec'd
-/// `writable: false`); `Object.defineProperty(Function.prototype, k,
-/// {get,set})` round-trips via `closure_set_via_function_prototype_accessor`
-/// before falling back to a plain own-property write.
+/// `writable: false`); `Object.defineProperty(Function.prototype, k, {...})`
+/// round-trips via `closure_set_via_function_prototype_descriptor` before
+/// falling back to a plain own-property write.
 unsafe fn closure_set_field_by_name(
     obj: *mut ObjectHeader,
     key: *const crate::StringHeader,
@@ -213,17 +213,18 @@ unsafe fn closure_set_field_by_name(
     } else if matches!(name_str, "name" | "length") {
         return;
     } else if !crate::closure::closure_has_own_dynamic_prop(obj as usize, name_str)
-        && crate::closure::closure_set_via_function_prototype_accessor(
+        && crate::closure::closure_set_via_function_prototype_descriptor(
             obj as usize,
             name_str,
             value,
             crate::value::js_nanbox_pointer(obj as i64),
         )
     {
-        // Handled by an inherited %Function.prototype% accessor
-        // (`Object.defineProperty(Function.prototype, k, {get,set})`) — the
-        // setter ran (or threw for a getter-only accessor); no own property
-        // is created.
+        // Handled by an inherited %Function.prototype% descriptor
+        // (`Object.defineProperty(Function.prototype, k, {...})`) — an
+        // accessor's setter ran (or threw for a getter-only accessor), or a
+        // non-writable data property blocked the write; no own property is
+        // created.
         return;
     }
     crate::closure::closure_set_dynamic_prop(obj as usize, name_str, value);

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -170,6 +170,65 @@ unsafe fn string_key_eq(key: *const crate::StringHeader, expected: &[u8]) -> boo
     std::slice::from_raw_parts(data, len) == expected
 }
 
+/// Shared closure-receiver named-property WRITE path — used by both ways a
+/// closure is recognized in `js_object_set_field_by_name` (a `GC_TYPE_CLOSURE`
+/// GcHeader-typed pointer, and the raw `CLOSURE_MAGIC`-tagged fallback for a
+/// pointer reached without a full GC header). #3143: honors a non-writable
+/// registered descriptor (a built-in method's `.name`/`.length` are spec'd
+/// `writable: false`); `Object.defineProperty(Function.prototype, k,
+/// {get,set})` round-trips via `closure_set_via_function_prototype_accessor`
+/// before falling back to a plain own-property write.
+unsafe fn closure_set_field_by_name(
+    obj: *mut ObjectHeader,
+    key: *const crate::StringHeader,
+    value: f64,
+) {
+    if key.is_null() {
+        return;
+    }
+    let name_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+    let name_len = (*key).byte_len as usize;
+    let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
+    let Ok(name_str) = std::str::from_utf8(name_bytes) else {
+        return;
+    };
+    // ECMAScript "poison pill" — assigning `caller`/`arguments` on any
+    // strict-mode function (Perry compiles everything strict: declarations,
+    // expressions, bound and built-in closures, arrows) throws via the
+    // %ThrowTypeError% accessor's missing setter. A genuine own data prop of
+    // that name (defineProperty round-trip) still wins.
+    // Refs test262 13.2-*-s / StrictFunction_restricted-*.
+    if matches!(name_str, "caller" | "arguments")
+        && !crate::closure::closure_has_own_dynamic_prop(obj as usize, name_str)
+    {
+        crate::fs::validate::throw_type_error_with_code(
+            "Restricted function property assignment",
+            "ERR_INVALID_ARG_TYPE",
+        );
+    }
+    if let Some(attrs) = super::get_property_attrs(obj as usize, name_str) {
+        if !attrs.writable() {
+            return;
+        }
+    } else if matches!(name_str, "name" | "length") {
+        return;
+    } else if !crate::closure::closure_has_own_dynamic_prop(obj as usize, name_str)
+        && crate::closure::closure_set_via_function_prototype_accessor(
+            obj as usize,
+            name_str,
+            value,
+            crate::value::js_nanbox_pointer(obj as i64),
+        )
+    {
+        // Handled by an inherited %Function.prototype% accessor
+        // (`Object.defineProperty(Function.prototype, k, {get,set})`) — the
+        // setter ran (or threw for a getter-only accessor); no own property
+        // is created.
+        return;
+    }
+    crate::closure::closure_set_dynamic_prop(obj as usize, name_str, value);
+}
+
 /// Set a field value by its string key name (dynamic property access)
 /// This searches the keys array for a match and sets the corresponding value.
 /// If the key doesn't exist, it adds it to the object.
@@ -581,49 +640,7 @@ pub extern "C" fn js_object_set_field_by_name(
         }
 
         if gc_type == crate::gc::GC_TYPE_CLOSURE {
-            if !key.is_null() {
-                let name_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
-                let name_len = (*key).byte_len as usize;
-                let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
-                if let Ok(name_str) = std::str::from_utf8(name_bytes) {
-                    // ECMAScript "poison pill" — assigning `caller`/`arguments`
-                    // on any strict-mode function (Perry compiles everything
-                    // strict: declarations, expressions, bound and built-in
-                    // closures, arrows) throws via the %ThrowTypeError%
-                    // accessor's missing setter. A genuine own data prop of
-                    // that name (defineProperty round-trip) still wins.
-                    // Refs test262 13.2-*-s / StrictFunction_restricted-*.
-                    if matches!(name_str, "caller" | "arguments")
-                        && !crate::closure::closure_has_own_dynamic_prop(obj as usize, name_str)
-                    {
-                        crate::fs::validate::throw_type_error_with_code(
-                            "Restricted function property assignment",
-                            "ERR_INVALID_ARG_TYPE",
-                        );
-                    }
-                    if let Some(attrs) = super::get_property_attrs(obj as usize, name_str) {
-                        if !attrs.writable() {
-                            return;
-                        }
-                    } else if matches!(name_str, "name" | "length") {
-                        return;
-                    } else if !crate::closure::closure_has_own_dynamic_prop(obj as usize, name_str)
-                        && crate::closure::closure_set_via_function_prototype_accessor(
-                            obj as usize,
-                            name_str,
-                            value,
-                            crate::value::js_nanbox_pointer(obj as i64),
-                        )
-                    {
-                        // Handled by an inherited %Function.prototype%
-                        // accessor (`Object.defineProperty(Function.prototype,
-                        // k, {get,set})`) — the setter ran (or threw for a
-                        // getter-only accessor); no own property is created.
-                        return;
-                    }
-                    crate::closure::closure_set_dynamic_prop(obj as usize, name_str, value);
-                }
-            }
+            closure_set_field_by_name(obj, key, value);
             return;
         }
 
@@ -633,57 +650,7 @@ pub extern "C" fn js_object_set_field_by_name(
         let type_tag_at_12 =
             *((obj as *const u8).add(crate::closure::CLOSURE_TYPE_TAG_OFFSET) as *const u32);
         if type_tag_at_12 == crate::closure::CLOSURE_MAGIC {
-            if !key.is_null() {
-                let name_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
-                let name_len = (*key).byte_len as usize;
-                let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
-                if let Ok(name_str) = std::str::from_utf8(name_bytes) {
-                    // ECMAScript "poison pill" — assigning `caller`/`arguments`
-                    // on any strict-mode function (Perry compiles everything
-                    // strict: declarations, expressions, bound and built-in
-                    // closures, arrows) throws via the %ThrowTypeError%
-                    // accessor's missing setter. A genuine own data prop of
-                    // that name (defineProperty round-trip) still wins.
-                    // Refs test262 13.2-*-s / StrictFunction_restricted-*.
-                    if matches!(name_str, "caller" | "arguments")
-                        && !crate::closure::closure_has_own_dynamic_prop(obj as usize, name_str)
-                    {
-                        crate::fs::validate::throw_type_error_with_code(
-                            "Restricted function property assignment",
-                            "ERR_INVALID_ARG_TYPE",
-                        );
-                    }
-                    // #3143: honor a non-writable registered descriptor — a
-                    // built-in method's `.name`/`.length` are spec'd
-                    // `writable: false`, so a sloppy-mode write must be a silent
-                    // no-op (this is what Test262's `verifyProperty` checks).
-                    // Only fires when a descriptor was actually recorded for
-                    // this closure+key (built-in proto methods, or a user
-                    // `Object.defineProperty`); plain `fn.x = 1` finds none and
-                    // proceeds. Closure writes are not the object hot path.
-                    if let Some(attrs) = super::get_property_attrs(obj as usize, name_str) {
-                        if !attrs.writable() {
-                            return;
-                        }
-                    } else if matches!(name_str, "name" | "length") {
-                        return;
-                    } else if !crate::closure::closure_has_own_dynamic_prop(obj as usize, name_str)
-                        && crate::closure::closure_set_via_function_prototype_accessor(
-                            obj as usize,
-                            name_str,
-                            value,
-                            crate::value::js_nanbox_pointer(obj as i64),
-                        )
-                    {
-                        // Handled by an inherited %Function.prototype%
-                        // accessor (`Object.defineProperty(Function.prototype,
-                        // k, {get,set})`) — the setter ran (or threw for a
-                        // getter-only accessor); no own property is created.
-                        return;
-                    }
-                    crate::closure::closure_set_dynamic_prop(obj as usize, name_str, value);
-                }
-            }
+            closure_set_field_by_name(obj, key, value);
             return;
         }
 

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -607,6 +607,19 @@ pub extern "C" fn js_object_set_field_by_name(
                         }
                     } else if matches!(name_str, "name" | "length") {
                         return;
+                    } else if !crate::closure::closure_has_own_dynamic_prop(obj as usize, name_str)
+                        && crate::closure::closure_set_via_function_prototype_accessor(
+                            obj as usize,
+                            name_str,
+                            value,
+                            crate::value::js_nanbox_pointer(obj as i64),
+                        )
+                    {
+                        // Handled by an inherited %Function.prototype%
+                        // accessor (`Object.defineProperty(Function.prototype,
+                        // k, {get,set})`) — the setter ran (or threw for a
+                        // getter-only accessor); no own property is created.
+                        return;
                     }
                     crate::closure::closure_set_dynamic_prop(obj as usize, name_str, value);
                 }
@@ -653,6 +666,19 @@ pub extern "C" fn js_object_set_field_by_name(
                             return;
                         }
                     } else if matches!(name_str, "name" | "length") {
+                        return;
+                    } else if !crate::closure::closure_has_own_dynamic_prop(obj as usize, name_str)
+                        && crate::closure::closure_set_via_function_prototype_accessor(
+                            obj as usize,
+                            name_str,
+                            value,
+                            crate::value::js_nanbox_pointer(obj as i64),
+                        )
+                    {
+                        // Handled by an inherited %Function.prototype%
+                        // accessor (`Object.defineProperty(Function.prototype,
+                        // k, {get,set})`) — the setter ran (or threw for a
+                        // getter-only accessor); no own property is created.
                         return;
                     }
                     crate::closure::closure_set_dynamic_prop(obj as usize, name_str, value);

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -1410,6 +1410,17 @@ fn ordinary_set_with_receiver(target: f64, key: f64, value: f64, receiver: f64) 
                 {
                     throw_type_error("Restricted function property assignment");
                 }
+                // Every function's [[Prototype]] is %Function.prototype% — an
+                // accessor installed there via `Object.defineProperty(Function.
+                // prototype, k, {get,set})` must intercept a plain `boundFn.k =
+                // v` write (invoke the setter, or throw for a getter-only
+                // accessor) instead of silently shadowing it with a new own
+                // data property on the receiver.
+                if crate::closure::closure_set_via_function_prototype_accessor(
+                    cur_ptr, &name, value, receiver,
+                ) {
+                    return true;
+                }
             }
             return create_or_update_receiver_property(receiver, key, value);
         }

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -1410,13 +1410,14 @@ fn ordinary_set_with_receiver(target: f64, key: f64, value: f64, receiver: f64) 
                 {
                     throw_type_error("Restricted function property assignment");
                 }
-                // Every function's [[Prototype]] is %Function.prototype% — an
-                // accessor installed there via `Object.defineProperty(Function.
-                // prototype, k, {get,set})` must intercept a plain `boundFn.k =
-                // v` write (invoke the setter, or throw for a getter-only
-                // accessor) instead of silently shadowing it with a new own
+                // Every function's [[Prototype]] is %Function.prototype% — a
+                // descriptor installed there via `Object.defineProperty(
+                // Function.prototype, k, {...})` must intercept a plain
+                // `boundFn.k = v` write (invoke an accessor's setter, throw
+                // for a getter-only accessor, or block a non-writable data
+                // property) instead of silently shadowing it with a new own
                 // data property on the receiver.
-                if crate::closure::closure_set_via_function_prototype_accessor(
+                if crate::closure::closure_set_via_function_prototype_descriptor(
                     cur_ptr, &name, value, receiver,
                 ) {
                     return true;


### PR DESCRIPTION
## Summary
- `Object.defineProperty(Function.prototype, k, {value|get,set,...})` wasn't visible through any closure receiver (plain functions, bound functions via `.bind()`). The GET-side fallback in `closure_get_dynamic_prop` gated on `get_property_attrs(...).is_none()`, which a `defineProperty` call always fails (it always records attrs) — so only a bare `Function.prototype.x = 12` expando write ever got through.
- The SET side had no `Function.prototype` fallback at all: a plain `boundFn.k = v` always created a shadowing own data property on the receiver instead of invoking the inherited accessor's setter (or throwing for a getter-only accessor, per spec strict-mode semantics).
- Root cause for the SET path specifically: plain member-assignment codegen (`obj.prop = value`) lowers to `Expr::PutValueSet` → `js_put_value_set` → `ordinary_set_with_receiver` (`proxy.rs`), a different runtime entry point than `js_object_set_field_by_name` — both needed the fix.

## Fixes
- `built-ins/Object/defineProperty/15.2.3.6-4-417.js`
- `built-ins/Object/defineProperty/15.2.3.6-4-593.js`
- `built-ins/Object/defineProperty/15.2.3.6-4-594.js`
- `built-ins/Object/defineProperty/15.2.3.6-4-596.js`

(from the #5842 self-contained worklist)

## Verification
- Full `built-ins/Object` test262 subset (3411 cases, `scripts/test262_subset.py`): the 4 cases above now pass, zero new regressions (diffed failure lists before/after).
- `cargo test --release -p perry-runtime`: 1108 passed, 0 failed.
- `cargo fmt --all -- --check` and `scripts/check_file_size.sh`: clean.

Refs #5842.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved closure dynamic function property reads so inherited `Function.prototype` accessors (getters) are honored more consistently.
  * Updated function/closure property writes to route through `Function.prototype` descriptors when applicable, invoking setters and avoiding unintended shadowing.
  * Fixed edge cases where closure/function writes to `caller`/`arguments` could bypass strict-mode restrictions or existing prototype accessors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->