### PR TITLE
perry-hir: fix ||/&& result-type inference dropping the left operand

### DIFF
--- a/crates/perry-hir/src/lower_types.rs
+++ b/crates/perry-hir/src/lower_types.rs
@@ -402,30 +402,15 @@ fn infer_type_from_expr_inner(expr: &ast::Expr, ctx: &LoweringContext) -> Type {
                 }
                 ZeroFillRShift => Type::Number,
 
-                // Logical operators → type of operands.
-                //
-                // `A || B` yields A when A is truthy, else B; `A && B` yields A
-                // when A is falsy, else B. So the result can be EITHER operand's
-                // value. Approximating it as `right`'s type is only sound when
-                // both operands already share that type — otherwise the result
-                // may be the LEFT value with a different type.
-                //
-                // Pre-fix this returned `right` whenever it wasn't `Any`, so
-                // `arr || 99` inferred `Number` (from `99`). A local bound to it
-                // then had a numeric static type, and `lower_truthy` took the
-                // numeric fast path (`fcmp one <v>, 0.0`), reinterpreting the
-                // NaN-boxed array pointer as a raw double (NaN) → `!(arr||99)`,
-                // `(arr||99) ? …`, and `Array.isArray(arr||99)` (const-folded
-                // from the static type) were all wrong, even though the stored
-                // value was the correct array (value ops like `(arr||99)[0]`,
-                // `=== arr`, `.length` were fine). Any truthy heap operand hit
-                // this. The earlier #3527 fix (return `Any` when B is `Any`)
-                // only covered one side of the same hole:
-                // `typeof Map === "function" && Map.prototype`.
-                //
-                // Only trust `right`'s type when both operands share it;
-                // otherwise the union is unknown → `Any`, which routes
-                // truthiness / `Array.isArray` through the dynamic runtime path.
+                // `A || B` / `A && B` can evaluate to EITHER operand, so typing
+                // the result as `right` is only sound when both operands share a
+                // type. Pre-fix, `arr || 99` inferred `Number`, so `lower_truthy`
+                // took the numeric `fcmp one <v>, 0.0` path and read the NaN-boxed
+                // array pointer as NaN — `!(arr||99)` / ternary / `Array.isArray`
+                // were wrong (value ops were fine). Return `right` only when the
+                // operand types match, else `Any` (dynamic truthiness/isArray).
+                // Extends the #3527 fix (right = `Any` → `Any`) to the
+                // mismatched-type case.
                 LogicalAnd | LogicalOr => {
                     let left = infer_type_from_expr(&bin.left, ctx);
                     let right = infer_type_from_expr(&bin.right, ctx);

--- a/crates/perry-hir/src/lower_types.rs
+++ b/crates/perry-hir/src/lower_types.rs
@@ -402,21 +402,34 @@ fn infer_type_from_expr_inner(expr: &ast::Expr, ctx: &LoweringContext) -> Type {
                 }
                 ZeroFillRShift => Type::Number,
 
-                // Logical operators → type of operands (simplified).
+                // Logical operators → type of operands.
                 //
-                // `A && B` yields B's value when A is truthy (else A); `A || B`
-                // yields B when A is falsy (else A). So when B has a concrete
-                // type we approximate the result as that type. But when B is
-                // `Any` we must NOT fall back to A's type: #3527 hit
-                // `var hasMap = typeof Map === "function" && Map.prototype`,
-                // where A is a boolean compare and B (`Map.prototype`) is `Any`.
-                // Returning A's `Boolean` mistyped `hasMap` as a boolean even
-                // though it holds an object, so a later `hasMap && d && d.get`
-                // chain miscompiled and dereferenced `null`. The result can be
-                // the (unknown) right value, so `Any` is the only sound type.
+                // `A || B` yields A when A is truthy, else B; `A && B` yields A
+                // when A is falsy, else B. So the result can be EITHER operand's
+                // value. Approximating it as `right`'s type is only sound when
+                // both operands already share that type — otherwise the result
+                // may be the LEFT value with a different type.
+                //
+                // Pre-fix this returned `right` whenever it wasn't `Any`, so
+                // `arr || 99` inferred `Number` (from `99`). A local bound to it
+                // then had a numeric static type, and `lower_truthy` took the
+                // numeric fast path (`fcmp one <v>, 0.0`), reinterpreting the
+                // NaN-boxed array pointer as a raw double (NaN) → `!(arr||99)`,
+                // `(arr||99) ? …`, and `Array.isArray(arr||99)` (const-folded
+                // from the static type) were all wrong, even though the stored
+                // value was the correct array (value ops like `(arr||99)[0]`,
+                // `=== arr`, `.length` were fine). Any truthy heap operand hit
+                // this. The earlier #3527 fix (return `Any` when B is `Any`)
+                // only covered one side of the same hole:
+                // `typeof Map === "function" && Map.prototype`.
+                //
+                // Only trust `right`'s type when both operands share it;
+                // otherwise the union is unknown → `Any`, which routes
+                // truthiness / `Array.isArray` through the dynamic runtime path.
                 LogicalAnd | LogicalOr => {
+                    let left = infer_type_from_expr(&bin.left, ctx);
                     let right = infer_type_from_expr(&bin.right, ctx);
-                    if !matches!(right, Type::Any) {
+                    if left == right && !matches!(right, Type::Any) {
                         right
                     } else {
                         Type::Any


### PR DESCRIPTION
## Problem
`A || B` / `A && B` were typed as B's static type (unless B was `Any`), but they can evaluate to A. When A and B have different types, the result is mistyped.

`let r = arr || 99` → `r: number`, so the truthiness fast path `fcmp one <v>, 0.0` read the array's NaN-box as NaN → `false`. `!r`, `r ? … : …`, and `Array.isArray(r)` (const-folded from the static type) were all wrong even though `r` held the correct array (value ops `r[0]` / `r === arr` / `r.length` were fine). Any truthy heap value (array/object/string) is affected. The `x || default` value idiom is pervasive, so blast radius is high.

This also unblocks a real-world Myers-diff (`buildValues(...) || true`) convergence hang: the mistyped result read falsy, so the diff's edit-distance loop never saw completion and ran unbounded.

## Fix
Return the right operand's type only when both operands share a type; otherwise `Any` (which routes truthiness / `Array.isArray` through the dynamic runtime path). Preserves #3527 (right = `Any` → `Any`) and same-type precision.

## Tests
- `arr || 99`, `obj || 99`, `str || 99`: `!!`, ternary, and `Array.isArray` now match Node (were `false` / wrong).
- Same-type precision retained: `0 || 7` → `7`; `arr && "x"` → `"x"`.
- `perry-hir` suite green (101 passed / 0 failed).

https://claude.ai/code/session_01AX7CHxCeKQvUKHokk7abfm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for logical `&&` and `||` expressions by accounting for both operands, so the result is treated as a specific type only when they clearly match.
  * When operand types don’t align, the inferred result now falls back to a more general type, reducing incorrect assumptions and improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->