### PR TITLE
fix(runtime,codegen): #5849 — Promise own-property dispatch + poisoned-iterator fixes (8 test262 cases)

### DIFF
--- a/crates/perry-codegen/src/lower_call/property_get/promise_chain.rs
+++ b/crates/perry-codegen/src/lower_call/property_get/promise_chain.rs
@@ -6,7 +6,7 @@ use super::*;
 use anyhow::Result;
 use perry_hir::Expr;
 
-use crate::expr::{lower_expr, nanbox_pointer_inline, nanbox_string_inline, unbox_to_i64, FnCtx};
+use crate::expr::{lower_expr, nanbox_pointer_inline, nanbox_string_inline, FnCtx};
 use crate::lower_array_method::lower_array_method;
 use crate::lower_string_method::{is_known_string_method_name, lower_string_method};
 use crate::nanbox::double_literal;
@@ -16,10 +16,24 @@ use crate::type_analysis::{
 };
 use crate::types::{DOUBLE, I32, I64};
 
-/// Promise pointers are NaN-boxed with POINTER_TAG. We unbox to get the raw
-/// i64 promise handle, then call the runtime `js_promise_then(promise,
-/// on_fulfilled, on_rejected)` which returns a new promise handle that we
-/// re-box with POINTER_TAG. `.catch(cb)` is sugar for `.then(undefined, cb)`.
+/// `undefined`, boxed — the "no handler" default for an omitted
+/// `.then`/`.catch`/`.finally` argument. `js_promise_then_checked` /
+/// `_catch_checked` / `_finally_checked` tag-check this before treating it
+/// as a closure pointer (§`arg_to_closure`), so it correctly resolves to the
+/// spec's `IsCallable(x) is false` default ("Identity"/"Thrower").
+fn undefined_arg() -> String {
+    double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
+}
+
+/// Promise receivers stay NaN-boxed (POINTER_TAG) end-to-end here: we call
+/// the runtime's own-property-aware `js_promise_then_checked` /
+/// `_catch_checked` / `_finally_checked` entries (which internally fall
+/// back to the raw `js_promise_then`/`catch`/`finally` fast path when the
+/// receiver has no own "then"/"constructor" override), passing the boxed
+/// receiver and handler args directly — no unboxing/reboxing needed, and no
+/// risk of `unbox_to_i64` misreading a non-pointer handler arg
+/// (`undefined`/`null`/a number) as a garbage closure address. `.catch(cb)`
+/// is sugar for `.then(undefined, cb)`.
 pub(crate) fn try_lower_promise_chain_method(
     ctx: &mut FnCtx<'_>,
     object: &Expr,
@@ -74,15 +88,26 @@ pub(crate) fn try_lower_promise_chain_method(
                                 let on_rejected_box = if args.len() >= 2 {
                                     lower_expr(ctx, &args[1])?
                                 } else {
-                                    "0".to_string()
+                                    undefined_arg()
                                 };
                                 let blk = ctx.block();
-                                let on_fulfilled_handle = unbox_to_i64(blk, &on_fulfilled_box);
-                                let on_rejected_handle = if args.len() >= 2 {
-                                    unbox_to_i64(blk, &on_rejected_box)
-                                } else {
-                                    "0".to_string()
-                                };
+                                // `js_promise_resolved_then` takes already-unboxed
+                                // `ClosurePtr` args (unlike the `_checked` entries
+                                // below); `js_promise_closure_arg` performs the
+                                // same tag-safe conversion `arg_to_closure` does at
+                                // the `_checked` call sites, so `undefined`/`null`/
+                                // a number correctly becomes "no handler" (null)
+                                // instead of a garbage low address.
+                                let on_fulfilled_handle = blk.call(
+                                    I64,
+                                    "js_promise_closure_arg",
+                                    &[(DOUBLE, &on_fulfilled_box)],
+                                );
+                                let on_rejected_handle = blk.call(
+                                    I64,
+                                    "js_promise_closure_arg",
+                                    &[(DOUBLE, &on_rejected_box)],
+                                );
                                 let new_promise = blk.call(
                                     I64,
                                     "js_promise_resolved_then",
@@ -102,64 +127,50 @@ pub(crate) fn try_lower_promise_chain_method(
                     let on_rejected_box = if args.len() >= 2 {
                         lower_expr(ctx, &args[1])?
                     } else {
-                        "0".to_string() // null → no rejection handler
+                        undefined_arg()
                     };
                     let blk = ctx.block();
-                    let promise_handle = unbox_to_i64(blk, &promise_box);
-                    let on_fulfilled_handle = unbox_to_i64(blk, &on_fulfilled_box);
-                    let on_rejected_i64 = if args.len() >= 2 {
-                        unbox_to_i64(blk, &on_rejected_box)
-                    } else {
-                        "0".to_string() // null i64
-                    };
                     let new_promise = blk.call(
-                        I64,
-                        "js_promise_then",
+                        DOUBLE,
+                        "js_promise_then_checked",
                         &[
-                            (I64, &promise_handle),
-                            (I64, &on_fulfilled_handle),
-                            (I64, &on_rejected_i64),
+                            (DOUBLE, &promise_box),
+                            (DOUBLE, &on_fulfilled_box),
+                            (DOUBLE, &on_rejected_box),
                         ],
                     );
-                    return Ok(Some(nanbox_pointer_inline(blk, &new_promise)));
+                    return Ok(Some(new_promise));
                 }
             "catch"
                 if !args.is_empty() => {
                     let promise_box = lower_expr(ctx, object)?;
                     let on_rejected_box = lower_expr(ctx, &args[0])?;
                     let blk = ctx.block();
-                    let promise_handle = unbox_to_i64(blk, &promise_box);
-                    let on_rejected_handle = unbox_to_i64(blk, &on_rejected_box);
-                    let null_i64 = "0".to_string();
                     let new_promise = blk.call(
-                        I64,
-                        "js_promise_then",
-                        &[
-                            (I64, &promise_handle),
-                            (I64, &null_i64),
-                            (I64, &on_rejected_handle),
-                        ],
+                        DOUBLE,
+                        "js_promise_catch_checked",
+                        &[(DOUBLE, &promise_box), (DOUBLE, &on_rejected_box)],
                     );
-                    return Ok(Some(nanbox_pointer_inline(blk, &new_promise)));
+                    return Ok(Some(new_promise));
                 }
             "finally"
                 // .finally(cb) — per spec: call cb() ignoring its return value,
                 // then propagate the upstream value/reason unchanged.
-                // Routes through js_promise_finally which wraps cb in
+                // Routes through js_promise_finally_checked, which wraps cb in
                 // fulfill/reject proxy closures that call cb() and then
-                // return the upstream value (or re-throw the upstream reason).
+                // return the upstream value (or re-throw the upstream reason)
+                // — unless the receiver has an own "then"/"constructor"
+                // override, in which case it defers to the spec-path thunk.
                 if !args.is_empty() => {
                     let promise_box = lower_expr(ctx, object)?;
                     let on_finally_box = lower_expr(ctx, &args[0])?;
                     let blk = ctx.block();
-                    let promise_handle = unbox_to_i64(blk, &promise_box);
-                    let on_finally_handle = unbox_to_i64(blk, &on_finally_box);
                     let new_promise = blk.call(
-                        I64,
-                        "js_promise_finally",
-                        &[(I64, &promise_handle), (I64, &on_finally_handle)],
+                        DOUBLE,
+                        "js_promise_finally_checked",
+                        &[(DOUBLE, &promise_box), (DOUBLE, &on_finally_box)],
                     );
-                    return Ok(Some(nanbox_pointer_inline(blk, &new_promise)));
+                    return Ok(Some(new_promise));
                 }
             _ => {}
         }

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -870,6 +870,13 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
     module.declare_function("js_promise_then", I64, &[I64, I64, I64]);
     module.declare_function("js_promise_resolved_then", I64, &[DOUBLE, I64, I64]);
     module.declare_function("js_promise_finally", I64, &[I64, I64]);
+    // #5849: own-property-aware `.then`/`.catch`/`.finally` entries for a
+    // statically-known-Promise receiver — boxed f64 in, boxed f64 out (see
+    // `lower_call/property_get/promise_chain.rs`).
+    module.declare_function("js_promise_then_checked", DOUBLE, &[DOUBLE, DOUBLE, DOUBLE]);
+    module.declare_function("js_promise_catch_checked", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_promise_finally_checked", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_promise_closure_arg", I64, &[DOUBLE]);
     module.declare_function("js_promise_all", I64, &[I64]);
     module.declare_function("js_promise_race", I64, &[I64]);
     module.declare_function("js_promise_any", I64, &[I64]);

--- a/crates/perry-runtime/src/promise/async_step.rs
+++ b/crates/perry-runtime/src/promise/async_step.rs
@@ -4,6 +4,21 @@
 //! transform calls per `await`.
 
 use super::*;
+
+/// Inverse of `then::arg_to_closure` — reboxes an already-unboxed
+/// `ClosurePtr` handler arg back into a boxed `f64` JS value so it can be
+/// forwarded to `js_promise_then_checked`. Null (the "no handler" sentinel)
+/// becomes `undefined`, matching what `IsCallable(x) is false` resolves to
+/// on the `_checked` entry's own tag check.
+#[inline]
+fn closure_ptr_to_arg(ptr: ClosurePtr) -> f64 {
+    if ptr.is_null() {
+        f64::from_bits(crate::value::TAG_UNDEFINED)
+    } else {
+        f64::from_bits(crate::value::JSValue::pointer(ptr as *const u8).bits())
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn js_promise_resolved(value: f64) -> *mut Promise {
     bump(&MT_PROMISE_RESOLVED_COUNT);
@@ -131,9 +146,30 @@ pub extern "C" fn js_promise_resolved_then(
     // Skip the wrapper allocation: directly chain `.then()` off the
     // existing promise.
     if js_value_is_promise(value) != 0 {
-        bump(&MT_FAST_PATH_HIT);
         let inner = crate::value::js_nanbox_get_pointer(value) as *mut Promise;
         if !inner.is_null() {
+            // #5849: an own "then"/"constructor" expando on `inner` (e.g. a
+            // native Promise whose `.then` was reassigned) must still be
+            // invoked via `Invoke`/SpeciesConstructor semantics — the raw
+            // `js_promise_then` below operates directly on the native
+            // reaction slots and would silently ignore the override
+            // (test262 resolve/resolve-prms-cstm-then). `promise_has_own_*`
+            // bail out on a single cheap thread-local flag when no expando
+            // has ever been installed on ANY value, so this costs nothing
+            // in the steady-state await path this fast path exists for.
+            let inner_addr = inner as usize;
+            if super::promise_has_own_property(inner_addr, "then")
+                || super::promise_has_own_constructor(inner_addr)
+            {
+                bump(&MT_FAST_PATH_MISS);
+                let promise_val = box_promise_ptr(inner);
+                let fulfilled_val = closure_ptr_to_arg(on_fulfilled);
+                let rejected_val = closure_ptr_to_arg(on_rejected);
+                let result =
+                    super::js_promise_then_checked(promise_val, fulfilled_val, rejected_val);
+                return crate::value::js_nanbox_get_pointer(result) as *mut Promise;
+            }
+            bump(&MT_FAST_PATH_HIT);
             return js_promise_then(inner, on_fulfilled, on_rejected);
         }
     }

--- a/crates/perry-runtime/src/promise/checked_dispatch.rs
+++ b/crates/perry-runtime/src/promise/checked_dispatch.rs
@@ -1,0 +1,112 @@
+//! Codegen entries for `.then`/`.catch`/`.finally` calls whose receiver is
+//! STATICALLY known to be a Promise (`is_promise_expr` in perry-codegen).
+//! Split out of `then.rs` to stay under the file-size cap (#5849).
+//!
+//! Mirrors the own-property guard the dynamic dispatch path already applies
+//! in `object/native_call_method/primitive_methods.rs::dispatch_primitive`:
+//! an own "then" expando must be invoked directly (`Invoke(promise, "then",
+//! args)` per spec — the call site resolves the method via `Get` before
+//! `Promise.prototype.then`'s own algorithm ever runs), an own "constructor"
+//! expando must route through the full SpeciesConstructor-aware thunk, and
+//! everything else stays on the native fast path (test262
+//! then/ctor-access-count, resolve/resolve-prms-cstm-then). `.catch`/
+//! `.finally` always end up invoking "then" (per spec, `catch(r)` is sugar
+//! for `then(undefined, r)`), so either own-property hit routes them
+//! through the existing thunks, which already funnel through
+//! `call_receiver_then`.
+//!
+//! These also replace codegen's blind `unbox_to_i64` of the handler
+//! arguments: `undefined`/`null`/numbers must resolve to "no handler" (the
+//! IsCallable-false default), not a garbage low address reinterpreted as a
+//! `ClosureHeader*` (test262 then/S25.4.5.3_A4.1_T1/T2) — `arg_to_closure`
+//! tag-checks before treating the bits as a pointer.
+
+use super::*;
+use then::arg_to_closure;
+
+#[no_mangle]
+pub extern "C" fn js_promise_then_checked(
+    promise_val: f64,
+    on_fulfilled: f64,
+    on_rejected: f64,
+) -> f64 {
+    let promise_addr = (promise_val.to_bits() & crate::value::POINTER_MASK) as usize;
+    if promise_has_own_property(promise_addr, "then") {
+        let own_then = unsafe {
+            crate::object::exotic_expando::exotic_get_own_property(
+                promise_addr,
+                crate::object::exotic_expando::ExoticKind::Promise,
+                "then",
+                promise_val,
+            )
+        }
+        .unwrap_or_else(|| f64::from_bits(crate::value::TAG_UNDEFINED));
+        if !spec_combinators::is_callable_value(own_then) {
+            let msg = b"'then' property on Promise is not callable";
+            let msg_str = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+            let err = crate::error::js_typeerror_new(msg_str);
+            crate::exception::js_throw(f64::from_bits(
+                crate::value::JSValue::pointer(err as *const u8).bits(),
+            ));
+        }
+        let args = [on_fulfilled, on_rejected];
+        let prev = crate::object::js_implicit_this_set(promise_val);
+        let result =
+            unsafe { crate::closure::js_native_call_value(own_then, args.as_ptr(), args.len()) };
+        crate::object::js_implicit_this_set(prev);
+        return result;
+    }
+    if promise_has_own_constructor(promise_addr) {
+        let prev = crate::object::js_implicit_this_set(promise_val);
+        let result = promise_prototype_then_thunk(std::ptr::null(), on_fulfilled, on_rejected);
+        crate::object::js_implicit_this_set(prev);
+        return result;
+    }
+    let promise = promise_addr as *mut Promise;
+    box_promise_ptr(js_promise_then(
+        promise,
+        arg_to_closure(on_fulfilled),
+        arg_to_closure(on_rejected),
+    ))
+}
+
+#[no_mangle]
+pub extern "C" fn js_promise_catch_checked(promise_val: f64, on_rejected: f64) -> f64 {
+    let promise_addr = (promise_val.to_bits() & crate::value::POINTER_MASK) as usize;
+    if promise_has_own_property(promise_addr, "then") || promise_has_own_constructor(promise_addr) {
+        let prev = crate::object::js_implicit_this_set(promise_val);
+        let result = promise_prototype_catch_thunk(std::ptr::null(), on_rejected);
+        crate::object::js_implicit_this_set(prev);
+        return result;
+    }
+    let promise = promise_addr as *mut Promise;
+    box_promise_ptr(js_promise_catch(promise, arg_to_closure(on_rejected)))
+}
+
+#[no_mangle]
+pub extern "C" fn js_promise_finally_checked(promise_val: f64, on_finally: f64) -> f64 {
+    let promise_addr = (promise_val.to_bits() & crate::value::POINTER_MASK) as usize;
+    if promise_has_own_property(promise_addr, "then") || promise_has_own_constructor(promise_addr) {
+        let prev = crate::object::js_implicit_this_set(promise_val);
+        let result = promise_prototype_finally_thunk(std::ptr::null(), on_finally);
+        crate::object::js_implicit_this_set(prev);
+        return result;
+    }
+    let promise = promise_addr as *mut Promise;
+    box_promise_ptr(js_promise_finally(promise, arg_to_closure(on_finally)))
+}
+
+/// Codegen-safe conversion of a `.then`/`.catch`/`.finally` handler argument
+/// (still boxed) to a `ClosurePtr`, exposed for the codegen fused
+/// `Promise.resolve(x).then(cb_f, cb_e)` fast path
+/// (`js_promise_resolved_then`), which — unlike the entries above — takes
+/// already-unboxed `ClosurePtr` args. Delegates to `arg_to_closure`'s tag
+/// check: `undefined`/`null`/numbers become `0` (null / "no handler"), never
+/// a garbage low address reinterpreted as a `ClosureHeader*` (the naive
+/// `unbox_to_i64` codegen helper this replaces masked the low 48 bits
+/// unconditionally, turning e.g. `undefined`'s `0x7FFC_0000_0000_0001` into
+/// address `1`).
+#[no_mangle]
+pub extern "C" fn js_promise_closure_arg(value: f64) -> i64 {
+    arg_to_closure(value) as i64
+}

--- a/crates/perry-runtime/src/promise/combinators.rs
+++ b/crates/perry-runtime/src/promise/combinators.rs
@@ -316,8 +316,24 @@ pub(crate) fn combinator_iterable_to_array(
 ) -> Result<*mut crate::array::ArrayHeader, f64> {
     use crate::value::JSValue;
 
-    // Arrays and strings are always iterable.
+    // Arrays and strings are always iterable. #5849: `GetIterator` still
+    // performs `Get(obj, @@iterator)` first — a poisoned/throwing own
+    // `[Symbol.iterator]` accessor (`Object.defineProperty(arr,
+    // Symbol.iterator, {get(){throw ...}})`) must reject the combinator
+    // promise with that thrown value, not be silently skipped by this
+    // fast path. `own_symbol_property` performs that `Get` (invoking an
+    // own accessor getter, which throws via the normal longjmp path
+    // straight through to `combinator_iterable_to_array_caught`'s
+    // setjmp) purely for its side effect; arrays with no own override
+    // (the overwhelming common case) pay one extra side-table probe and
+    // keep the existing raw clone.
     if crate::array::js_array_is_array(value).to_bits() == crate::value::TAG_TRUE {
+        let iter_sym = crate::symbol::well_known_symbol("iterator");
+        if !iter_sym.is_null() {
+            let sym_f64 =
+                f64::from_bits(crate::value::JSValue::pointer(iter_sym as *const u8).bits());
+            let _ = unsafe { crate::symbol::own_symbol_property(value, sym_f64) };
+        }
         return Ok(crate::array::js_array_clone(
             crate::value::js_nanbox_get_pointer(value) as *const crate::array::ArrayHeader,
         ));

--- a/crates/perry-runtime/src/promise/mod.rs
+++ b/crates/perry-runtime/src/promise/mod.rs
@@ -20,6 +20,7 @@ use crate::async_context::{
 
 pub mod assimilate;
 pub mod async_step;
+pub mod checked_dispatch;
 pub mod combinators;
 pub mod microtasks;
 pub mod native_async;
@@ -35,6 +36,10 @@ pub use async_step::{
     js_array_from_async, js_async_first_call, js_async_step_chain, js_async_step_done,
     js_get_current_step_closure, js_promise_resolved, js_promise_resolved_then,
     scan_async_step_thunk_cache, scan_async_step_thunk_cache_mut,
+};
+pub use checked_dispatch::{
+    js_promise_catch_checked, js_promise_closure_arg, js_promise_finally_checked,
+    js_promise_then_checked,
 };
 pub use combinators::{
     js_assimilate_thenable, js_await_any_promise, js_is_promise, js_promise_all,
@@ -63,9 +68,10 @@ pub use spec_combinators::{
     js_promise_with_resolvers_spec,
 };
 pub(crate) use then::{
-    js_promise_attach_handlers, js_promise_attach_settle_listener, mark_rejection_handled,
-    promise_has_own_constructor, promise_has_own_property, promise_proto_method,
-    promise_prototype_catch_thunk, promise_prototype_finally_thunk, promise_prototype_then_thunk,
+    box_promise_ptr, js_promise_attach_handlers, js_promise_attach_settle_listener,
+    mark_rejection_handled, promise_has_own_constructor, promise_has_own_property,
+    promise_proto_method, promise_prototype_catch_thunk, promise_prototype_finally_thunk,
+    promise_prototype_then_thunk,
 };
 pub use then::{
     js_promise_bound_method, js_promise_catch, js_promise_finally, js_promise_free,

--- a/crates/perry-runtime/src/promise/then.rs
+++ b/crates/perry-runtime/src/promise/then.rs
@@ -1110,7 +1110,7 @@ pub extern "C" fn js_promise_finally(
 // `typeof p.then === "function"` and a deferred `p.then(cb)` both behave.
 
 #[inline]
-fn arg_to_closure(v: f64) -> ClosurePtr {
+pub(crate) fn arg_to_closure(v: f64) -> ClosurePtr {
     let bits = v.to_bits();
     let top = bits >> 48;
     // Pointer- or string-tagged values carry a heap pointer in the low 48 bits;
@@ -1123,7 +1123,7 @@ fn arg_to_closure(v: f64) -> ClosurePtr {
 }
 
 #[inline]
-fn box_promise_ptr(p: *mut Promise) -> f64 {
+pub(crate) fn box_promise_ptr(p: *mut Promise) -> f64 {
     f64::from_bits(crate::value::JSValue::pointer(p as *const u8).bits())
 }
 


### PR DESCRIPTION
## Summary

Fixes a self-contained subcluster of the 29 failing `built-ins/Promise` test262 cases from #5849. The remaining 21 need real `class X extends Promise` subclass internal slots (the "meaty bit" the issue flags as follow-up work) or are out of scope (2 are a Node/V8 quirk — Node itself rejects `Promise.all([42])` after `Object.defineProperty(Array.prototype, 0, {set:...})`, which Perry correctly does not reproduce).

- **Codegen static fast-path bypassed own-property overrides** (4 tests): `.then`/`.catch`/`.finally` on a statically-known-Promise receiver called the raw native fast path unconditionally, ignoring an own `then`/`constructor` expando — the gap left by #5821, which only fixed the *dynamic* dispatch path. New `js_promise_then_checked`/`_catch_checked`/`_finally_checked` entries (split into a new `promise/checked_dispatch.rs` module to stay under the file-size cap) mirror the existing dynamic-dispatch guard. Fixes `then/ctor-access-count.js`, `resolve/resolve-prms-cstm-then.js`, `finally/{rejected,resolved}-observable-then-calls.js`.
- **Codegen unboxed handler args unsafely** (2 tests): the same fast path used a blind `unbox_to_i64` instead of a tag-safe check, so `undefined` became a bogus closure pointer. New `js_promise_closure_arg` helper reuses the existing tag check. Fixes `then/S25.4.5.3_A4.1_T1.js` and `T2.js`.
- **Poisoned array `[Symbol.iterator]` skipped by combinators** (2 tests): the "arrays are always iterable" fast path never performed `Get(obj, @@iterator)`, so a throwing own accessor was silently ignored instead of rejecting. Fixes `allSettled/iter-arg-is-poisoned.js` and `any/iter-arg-is-poisoned.js`.

All own-property checks bail out on a single cheap thread-local flag when no expando has ever been installed anywhere, so steady-state fast paths (including the per-`await` fusion) are unaffected.

## Test plan

- [x] `scripts/test262_subset.py --dir built-ins/Promise --jobs 8`: 26/574 → 21/574 judged-fail (8 fixed, **zero regressions** — remaining 21 are an exact subset of the original 29 minus the 8 fixed here)
- [x] `cargo fmt --all -- --check` clean
- [x] `bash scripts/check_file_size.sh` clean
- [x] `cargo test --release -p perry-runtime -p perry-codegen -p perry-hir -p perry`: 0 new failures. The 1 failing test (`issue_4873_message_channel_global_new::bare_new_message_channel_delegates_to_worker_threads`) already fails on `main` HEAD — confirmed via CI run [28572924603](https://github.com/PerryTS/perry/actions/runs/28572924603), unrelated to this change.

Code-only PR per #5849's instructions — no version bump / CHANGELOG entry (maintainer folds metadata at merge).

Refs #5849.

🤖 Generated with [Claude Code](https://claude.com/claude-code)