### PR TITLE
fix(runtime): #5763 regression — setPrototypeOf cycle walk must not advance past chain end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.5.1214 — setPrototypeOf cycle walk must not advance past chain end (#5866)
+
+Fixes the #5763 regression that broke `Object.setPrototypeOf(obj, proto)` for every acyclic prototype chain of ≥2 links ("Cannot convert undefined or null to object"): the OrdinarySetPrototypeOf Floyd walk advanced the hare past the chain end, and fed exotic `undefined` prototype reports back into the next advance. Every transpiled `__extends` (`setPrototypeOf(Derived, Base)` — a 3-link function proto chain) threw; comment-json's `__extends` + its `{ __proto__: [] }` feature test killed Next.js server boot. The hare now freezes at null (the tortoise completes the membership walk alone, so cycle detection is unchanged) and `undefined` ends the walk like null. e2e regression suite: `crates/perry/tests/issue_5763_setprototypeof_chain_end.rs` (chains of length 2/4, the `__extends` statics link, the feature-test evaluation, and a genuine-cycle negative), byte-for-byte vs `node --experimental-strip-types`.
+
 ## v0.5.1213 — representation-aware type lowering + native-ABI material evidence gate (#5466)
 
 Lands the type-lowering track on main (builds on #5291; integrates #5462's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1213
+**Current Version:** 0.5.1214
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5307,7 +5307,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "anyhow",
  "base64",
@@ -5364,14 +5364,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "cc",
  "libc",
@@ -5379,7 +5379,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "anyhow",
  "log",
@@ -5394,7 +5394,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5403,7 +5403,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5411,7 +5411,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5421,7 +5421,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "anyhow",
  "base64",
@@ -5443,7 +5443,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5451,7 +5451,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5480,14 +5480,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "serde",
  "serde_json",
@@ -5495,7 +5495,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1213"
+version = "0.5.1214"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5506,7 +5506,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "anyhow",
  "clap",
@@ -5521,7 +5521,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "block2",
  "objc2",
@@ -5531,7 +5531,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5539,7 +5539,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5548,7 +5548,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5556,7 +5556,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5564,7 +5564,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5572,7 +5572,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5580,7 +5580,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "chrono",
  "cron",
@@ -5590,7 +5590,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5598,7 +5598,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5606,7 +5606,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5622,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5630,14 +5630,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5668,7 +5668,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5682,7 +5682,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "bytes",
  "h2",
@@ -5705,7 +5705,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5715,7 +5715,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5726,7 +5726,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5734,7 +5734,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "bson",
  "futures-util",
@@ -5754,7 +5754,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5764,7 +5764,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -5786,7 +5786,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5804,7 +5804,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5813,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5821,7 +5821,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -5831,14 +5831,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5847,7 +5847,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5855,7 +5855,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5865,7 +5865,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5877,7 +5877,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "brotli",
  "flate2",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5895,7 +5895,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5913,7 +5913,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5925,7 +5925,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "anyhow",
  "base64",
@@ -5958,14 +5958,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6057,14 +6057,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6074,7 +6074,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6082,14 +6082,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "base64",
  "itoa",
@@ -6106,7 +6106,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6116,7 +6116,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "base64",
  "cairo-rs",
@@ -6139,7 +6139,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "base64",
  "block2",
@@ -6155,7 +6155,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "base64",
  "block2",
@@ -6170,7 +6170,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1213"
+version = "0.5.1214"
 
 [[package]]
 name = "perry-ui-test"
@@ -6178,11 +6178,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1213"
+version = "0.5.1214"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "base64",
  "block2",
@@ -6198,7 +6198,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "base64",
  "block2",
@@ -6214,7 +6214,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "block2",
  "libc",
@@ -6227,7 +6227,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "base64",
  "libc",
@@ -6244,14 +6244,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6265,7 +6265,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1213"
+version = "0.5.1214"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -301,7 +301,7 @@ strip = false
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1213"
+version = "0.5.1214"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-runtime/src/object/object_ops/define_properties.rs
+++ b/crates/perry-runtime/src/object/object_ops/define_properties.rs
@@ -242,7 +242,18 @@ pub extern "C" fn js_object_set_prototype_of(obj_value: f64, proto: f64) -> f64 
             // "Cannot convert undefined or null to object" (test262
             // setPrototypeOf/success.js — plain object proto chain ends at null).
             tortoise = advance(tortoise);
-            hare = {
+            // The hare reaches the chain end (null) before the tortoise on any
+            // acyclic chain longer than one link (e.g. a function proto:
+            // fn → Function.prototype → Object.prototype → null). Freeze it at
+            // null instead of advancing again — advance(null) would call
+            // js_object_get_prototype_of(null), which throws "Cannot convert
+            // undefined or null to object". comment-json's `__extends` hit this
+            // on every transpiled subclass at Next.js server boot. The tortoise
+            // still walks the remaining chain alone, so the obj-membership
+            // (cycle) check stays complete.
+            hare = if hare == TAG_NULL_U64 {
+                TAG_NULL_U64
+            } else {
                 let h1 = advance(hare);
                 if h1 == TAG_NULL_U64 {
                     TAG_NULL_U64

--- a/crates/perry-runtime/src/object/object_ops/define_properties.rs
+++ b/crates/perry-runtime/src/object/object_ops/define_properties.rs
@@ -206,11 +206,20 @@ pub extern "C" fn js_object_set_prototype_of(obj_value: f64, proto: f64) -> f64 
     // can't form a fresh cycle by setting obj's proto to `proto`.
     if !proto_is_null {
         const TAG_NULL_U64: u64 = 0x7FFC_0000_0000_0002;
+        const TAG_UNDEFINED_U64: u64 = 0x7FFC_0000_0000_0001;
         let advance = |bits: u64| -> u64 {
             let val = f64::from_bits(bits);
             let next = js_object_get_prototype_of(val);
             let nb = next.to_bits();
-            if nb == TAG_NULL_U64 {
+            // Treat undefined as chain-end like null: `js_object_get_prototype_of`
+            // returns undefined (not spec's object-or-null) for some exotic
+            // receivers, and feeding that back into the next advance would call
+            // `js_object_get_prototype_of(undefined)`, which throws "Cannot
+            // convert undefined or null to object". comment-json's `__extends`
+            // feature-test `{__proto__: []}` hit this at Next.js server boot. A
+            // genuine cycle can never contain undefined, so ending the walk is
+            // sound.
+            if nb == TAG_NULL_U64 || nb == TAG_UNDEFINED_U64 {
                 TAG_NULL_U64
             } else {
                 nb

--- a/crates/perry/tests/issue_5763_setprototypeof_chain_end.rs
+++ b/crates/perry/tests/issue_5763_setprototypeof_chain_end.rs
@@ -1,0 +1,181 @@
+//! Regression tests for the setPrototypeOf cycle-walk chain-end bug
+//! (regression introduced by 1f4a2c5bd / #5763, bisected via the Next.js
+//! boot failure).
+//!
+//! The OrdinarySetPrototypeOf cycle check uses Floyd's tortoise-and-hare.
+//! Two chain-end bugs made `Object.setPrototypeOf(obj, proto)` throw
+//! "Cannot convert undefined or null to object" on perfectly ordinary,
+//! acyclic prototype chains:
+//!
+//! 1. Only the hare's SECOND step was null-guarded. On any acyclic chain
+//!    longer than one link (every function/class proto:
+//!    fn -> Function.prototype -> Object.prototype -> null) the hare reached
+//!    null first and the next iteration called advance(null) ->
+//!    js_object_get_prototype_of(null) -> TypeError. comment-json's
+//!    `__extends` hit this on every transpiled subclass, killing Next.js
+//!    server boot.
+//!
+//! 2. `js_object_get_prototype_of` returns undefined (not spec's
+//!    object-or-null) for some exotic receivers; the walk fed that back into
+//!    the next advance and threw. comment-json's `__extends` feature-test
+//!    `{ __proto__: [] }` hit this at boot. Undefined can never be part of a
+//!    genuine cycle, so it must end the walk like null.
+//!
+//! All expected outputs are byte-for-byte what `node
+//! --experimental-strip-types` prints.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed (exit {:?})\nstdout:\n{}\nstderr:\n{}",
+        run.status.code(),
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+/// Bug 1 guard: setPrototypeOf onto acyclic chains of length 2 and 4 must
+/// succeed and establish inheritance. Pre-fix the hare walked past the chain
+/// end and every one of these threw "Cannot convert undefined or null to
+/// object".
+#[test]
+fn set_prototype_of_acyclic_chain_longer_than_one_link() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const base = {
+  greet() {
+    return "hi";
+  },
+};
+
+// Chain length 2: base -> Object.prototype -> null.
+const obj: any = {};
+Object.setPrototypeOf(obj, base);
+console.log(obj.greet());
+
+// Chain length 4: deep2 -> deep1 -> base -> Object.prototype -> null.
+const deep1 = Object.create(base);
+const deep2 = Object.create(deep1);
+const target: any = {};
+Object.setPrototypeOf(target, deep2);
+console.log(target.greet());
+console.log("ok");
+"#,
+    );
+    assert_eq!(
+        stdout, "hi\nhi\nok\n",
+        "setPrototypeOf onto an acyclic chain of length >= 2 must not throw \
+         (hare must freeze at chain end)"
+    );
+}
+
+/// The `__extends` statics link that killed Next.js boot: setPrototypeOf of
+/// one function onto another. The proto chain of a function is
+/// fn -> Function.prototype -> Object.prototype -> null (three links), so
+/// pre-fix this threw on every transpiled subclass.
+#[test]
+fn set_prototype_of_function_statics_link() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+function Base() {}
+function Derived() {}
+Object.setPrototypeOf(Derived, Base);
+console.log(Object.getPrototypeOf(Derived) === Base);
+console.log("statics linked");
+"#,
+    );
+    assert_eq!(
+        stdout, "true\nstatics linked\n",
+        "setPrototypeOf(fn, fn) — a 3-link proto chain — must not throw"
+    );
+}
+
+/// Bug 2 guard: comment-json's `__extends` feature test. The object-literal
+/// `{ __proto__: [] }` routes through the same cycle walk with an exotic
+/// receiver whose getPrototypeOf reports undefined mid-walk; undefined must
+/// terminate the walk like null instead of being fed back into the next
+/// advance. Pre-fix, merely EVALUATING the literal threw and killed boot.
+///
+/// NOTE: this deliberately does not assert `probe instanceof Array` — that
+/// is `true` in node but still `false` in perry (a separate, pre-existing
+/// instanceof/literal-`__proto__` gap unchanged by this fix). This test
+/// guards only the throw.
+#[test]
+fn object_literal_proto_array_feature_test() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const probe: any = { __proto__: [] };
+console.log(typeof probe);
+console.log("feature test ok");
+"#,
+    );
+    assert_eq!(
+        stdout, "object\nfeature test ok\n",
+        "evaluating {{ __proto__: [] }} must not throw \
+         (undefined getPrototypeOf ends the walk)"
+    );
+}
+
+/// The cycle check itself must keep working: setting a prototype that would
+/// form a cycle still throws a TypeError, and the object stays usable.
+#[test]
+fn cycle_detection_still_throws() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const a: any = {};
+const b: any = {};
+Object.setPrototypeOf(b, a);
+let threw = false;
+try {
+  Object.setPrototypeOf(a, b);
+} catch (e) {
+  threw = true;
+}
+console.log("cycle detected:", threw);
+"#,
+    );
+    assert_eq!(
+        stdout, "cycle detected: true\n",
+        "a genuine prototype cycle must still be rejected with a TypeError"
+    );
+}


### PR DESCRIPTION
## What

Two chain-end bugs in the OrdinarySetPrototypeOf Floyd cycle walk made `Object.setPrototypeOf(obj, proto)` throw `TypeError: Cannot convert undefined or null to object` on perfectly ordinary, **acyclic** prototype chains:

1. **Hare walks past chain end.** Only the hare's *second* step was null-guarded. On any acyclic chain longer than one link the hare reaches null first, and the next iteration calls `advance(null)` → `js_object_get_prototype_of(null)` → throw. A function's proto chain is `fn → Function.prototype → Object.prototype → null` — three links — so **every** `setPrototypeOf(Derived, Base)` throws.
2. **Undefined fed back into the walk.** `js_object_get_prototype_of` returns `undefined` (not spec's object-or-null) for some exotic receivers; the walk fed that into the next advance and threw. `undefined` can never be part of a genuine cycle, so it must end the walk like null.

## Impact

Regression introduced by 1f4a2c5bd (#5763). Every transpiled subclass breaks (`__extends` does `setPrototypeOf(d, b)` with `b` a function), and comment-json's `__extends` — including its `{ __proto__: [] }` feature test — kills Next.js server boot on current `main`. Bisected during the #5437 SSR investigation.

## Fix

- Freeze the hare at null instead of advancing again. The tortoise still walks the remaining chain alone, so the obj-membership (cycle) check stays complete; a truly cyclic chain never yields a null hare, so cycle detection is unchanged.
- Treat an `undefined` prototype report as chain end, like null.

## Testing

New e2e regression suite `crates/perry/tests/issue_5763_setprototypeof_chain_end.rs` (expected outputs byte-for-byte from `node --experimental-strip-types`):

- `setPrototypeOf` onto acyclic chains of length 2 and 4 (method inheritance verified through the new chain)
- the `__extends` statics link (`setPrototypeOf(fn, fn)`, 3-link chain)
- the comment-json feature test: evaluating `{ __proto__: [] }` must not throw
- a genuine prototype cycle still throws `TypeError`

Known separate gap (pre-existing, unchanged by this PR): `({ __proto__: [] }) instanceof Array` is `true` in node but still `false` in perry — the literal-`__proto__` prototype isn't visible to `instanceof`. This PR only removes the boot-killing throw; the test documents the gap without asserting it.

Code-only PR: no version bump / changelog (folded at merge).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `Object.setPrototypeOf` handling for acyclic prototype chains (including multi-link cases), preventing erroneous failures near the chain end.
  * Updated prototype traversal so the walk terminates correctly when `getPrototypeOf` yields an `undefined`-like end marker (matching `null` behavior).
  * Continued to correctly reject genuine prototype cycles with a `TypeError`.

* **Tests**
  * Added regression tests covering multi-link chains, function/static prototype links, object literal `__proto__` scenarios, and cycle rejection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->