### PR TITLE
docs(CLAUDE.md): document dev vs shipping build profiles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,12 @@ PRs from outside contributors should **not** touch `[workspace.package] version`
 
 ## Build Commands
 
+### Which profile to use
+
+- **Local dev / testing (default choice)**: `cargo check -p perry` for fastest feedback, then `cargo build --profile perry-dev -p perry` (opt-level=1, codegen-units=16, incremental, no LTO — minutes instead of ~30). Use this for iterating on the compiler, running gap/parity tests, and reproducing bugs. Only fall back to `--release` if a bug is optimization-sensitive.
+- **Shipping / official artifacts**: `--profile dist` (mirrors `release`: thin LTO, codegen-units=1, opt-level=3, strip). Slow by design — LLVM codegen runs single-threaded per crate at codegen-units=1, and the giant crates (perry-runtime ~340k lines, perry-codegen, perry-hir) serialize the build regardless of core count. Don't use it for iteration.
+- **Local release-ish build when you need release perf**: override the compile-time killer, keep the optimization: `CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 cargo build --release` (2–4× faster, ~1–3% runtime cost).
+
 ```bash
 cargo build --release                          # Build all crates
 cargo build --profile perry-dev -p perry       # Fast local dev build (#5422; perry-dev profile)


### PR DESCRIPTION
## Summary
Adds a short **Which profile to use** note at the top of CLAUDE.md's Build Commands section so sessions stop reaching for `--release` when iterating:

- **Local dev / testing**: `cargo check -p perry` → `cargo build --profile perry-dev -p perry` (opt-level=1, cgu=16, incremental, no LTO).
- **Shipping**: `--profile dist` — slow by design; codegen-units=1 serializes LLVM codegen per crate, and perry-runtime (~340k lines) / perry-codegen / perry-hir dominate the critical path regardless of core count.
- **Release-perf locally**: `CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 cargo build --release` (2–4× faster, ~1–3% runtime cost).

Docs-only; no version bump / changelog per contributor-PR convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for choosing the right build profile for local development, shipping artifacts, and faster release-like builds.
  * Clarified build command recommendations by placing the profile selection notes alongside existing command examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->