### PR TITLE
fix(intl): BigInt.prototype.toLocaleString via Intl.NumberFormat

### DIFF
--- a/crates/perry-runtime/src/intl.rs
+++ b/crates/perry-runtime/src/intl.rs
@@ -60,9 +60,9 @@ pub(crate) use list_relative_plural::{
     rtf_singular_unit, rtf_to_parts_thunk,
 };
 pub(crate) use number_format::{
-    captured_intl_object, compact_round, compact_suffix, currency_instance_parts,
-    decimal_msd_exponent, format_number_instance, grouping_enabled, increment_decimal,
-    intl_object_from_value, nf_coerce_number, nf_load, nf_resolved_default,
+    bigint_to_locale_string, captured_intl_object, compact_round, compact_suffix,
+    currency_instance_parts, decimal_msd_exponent, format_number_instance, grouping_enabled,
+    increment_decimal, intl_object_from_value, nf_coerce_number, nf_load, nf_resolved_default,
     number_format_bound_format_thunk, number_format_bound_resolved_options_thunk,
     number_format_bound_to_parts_thunk, number_format_format_getter_thunk,
     number_format_format_object, number_format_range_thunk, number_format_range_to_parts_thunk,

--- a/crates/perry-runtime/src/intl/number_format.rs
+++ b/crates/perry-runtime/src/intl/number_format.rs
@@ -1524,7 +1524,18 @@ pub(crate) fn push_style_suffix(
     _decimal_sep: char,
 ) {
     match r.style.as_str() {
-        "percent" => parts.push(("percentSign", "%".to_string())),
+        // German (and most European) locales separate the percent sign from
+        // the number with a non-breaking space; en-US glues it directly on
+        // (test262 intl402/BigInt/prototype/toLocaleString/de-DE.js expects
+        // "8.878.000.000 %", en-US.js expects "8,878,000,000%" with no
+        // space — same `push_style_suffix` call, locale-gated literal).
+        "percent" => {
+            let de_style = r.locale.eq_ignore_ascii_case("de") || r.locale.starts_with("de-");
+            if de_style {
+                parts.push(("literal", "\u{a0}".to_string()));
+            }
+            parts.push(("percentSign", "%".to_string()));
+        }
         "unit" => {
             if let Some(unit) = &r.unit {
                 parts.push(("literal", " ".to_string()));
@@ -1623,6 +1634,99 @@ pub(crate) fn format_number_instance(obj: *const ObjectHeader, value: f64) -> St
         .iter()
         .map(|(_, v)| v.as_str())
         .collect()
+}
+
+/// Read a `StringHeader` pointer as a Rust `&str` (the data bytes immediately
+/// follow the header, same layout `str_bytes_from_jsvalue` reads for a
+/// NaN-boxed string value). `js_bigint_to_string`'s output is always ASCII
+/// decimal digits (with an optional leading `-`), so `from_utf8_unchecked` is
+/// safe here.
+unsafe fn string_header_as_str<'a>(s: *const StringHeader) -> &'a str {
+    let len = (*s).byte_len as usize;
+    let data = (s as *const u8).add(std::mem::size_of::<StringHeader>());
+    std::str::from_utf8_unchecked(std::slice::from_raw_parts(data, len))
+}
+
+/// Exact-precision rendering of a `BigInt` magnitude for the "standard"
+/// notation `"decimal"` style — mirrors the `_ =>` (default) arm of
+/// [`number_parts_core`], but starts from the BigInt's own exact base-10
+/// digit string instead of an `f64`-converted magnitude. `f64` can't exactly
+/// represent integers past 2^53, which silently corrupts large `BigInt`
+/// digits (test262 intl402/BigInt/prototype/toLocaleString expects
+/// `90071992547409910n` to round-trip exactly). Every step below
+/// (`round_to_significant`/`round_fraction_or_increment`/
+/// `push_grouped_integer`) already operates on digit strings, not `f64`, so
+/// only the initial magnitude extraction needed to change.
+fn bigint_number_parts_exact(
+    r: &NfResolved,
+    negative: bool,
+    abs_digits: &str,
+) -> Vec<(&'static str, String)> {
+    let de_style = r.locale.eq_ignore_ascii_case("de") || r.locale.starts_with("de-");
+    let group_sep = if de_style { '.' } else { ',' };
+    let decimal_sep = if de_style { ',' } else { '.' };
+    set_round_ctx(&r.rounding_mode, negative);
+
+    let mut parts: Vec<(&'static str, String)> = Vec::new();
+    let (mut i_out, f_out) = if r.use_sig {
+        round_to_significant(abs_digits, "", r.min_sig, r.max_sig)
+    } else {
+        round_fraction_or_increment(abs_digits, "", r)
+    };
+    while (i_out.len() as u32) < r.min_int {
+        i_out.insert(0, '0');
+    }
+    let grouping = grouping_enabled(&r.use_grouping, i_out.len());
+    push_grouped_integer(&mut parts, &i_out, group_sep, grouping);
+    if !f_out.is_empty() {
+        parts.push(("decimal", decimal_sep.to_string()));
+        parts.push(("fraction", f_out));
+    }
+
+    let rounded_is_zero = parts
+        .iter()
+        .filter(|(t, _)| *t == "integer" || *t == "fraction")
+        .all(|(_, v)| v.bytes().all(|b| b == b'0'));
+    let mut out: Vec<(&'static str, String)> = Vec::with_capacity(parts.len() + 2);
+    push_sign(&mut out, &r.sign_display, negative, rounded_is_zero);
+    out.append(&mut parts);
+    push_style_suffix(&mut out, r, decimal_sep);
+    out
+}
+
+/// `BigInt.prototype.toLocaleString(locales?, options?)` — ECMA-402
+/// sec-bigint.prototype.tolocalestring (#5845). Builds a real
+/// `Intl.NumberFormat` from `locales`/`options` via the same `make_instance`
+/// path `new Intl.NumberFormat(...)` uses, so option/locale validation and
+/// resolution (and the exceptions they throw) match exactly. Only the
+/// "standard" notation `"decimal"` style renders from the BigInt's exact
+/// digit string; percent/currency/unit and scientific/engineering/compact
+/// notation fall back to the same `f64` coercion
+/// `Intl.NumberFormat.prototype.format` itself uses (`nf_coerce_number`), so
+/// `x.toLocaleString(...)` stays self-consistent with
+/// `new Intl.NumberFormat(...).format(x)` even where it's lossy for BigInts
+/// past 2^53 (test262 returns-same-results-as-NumberFormat.js) — no test in
+/// scope needs exact output through those styles, only agreement with
+/// `.format()`.
+pub(crate) fn bigint_to_locale_string(value: f64, locales: f64, options: f64) -> *mut StringHeader {
+    let ptr = JSValue::from_bits(value.to_bits()).as_bigint_ptr();
+    let negative = unsafe { crate::bigint::js_bigint_is_negative(ptr) } != 0;
+    let digits_ptr = crate::bigint::js_bigint_to_string(ptr);
+    let digits = unsafe { string_header_as_str(digits_ptr) };
+    let abs_digits = digits.strip_prefix('-').unwrap_or(digits);
+
+    let nf_obj_value = make_instance(std::ptr::null(), KIND_NUMBER, locales, options);
+    let nf_obj = object_ptr_from_value(nf_obj_value).expect("make_instance returns a valid object");
+    let r = nf_load(nf_obj);
+
+    let out = if r.style == "decimal" && r.notation == "standard" {
+        let mut parts = bigint_number_parts_exact(&r, negative, abs_digits);
+        transliterate_parts_digits(&mut parts, &r.numbering_system);
+        parts.iter().map(|(_, v)| v.as_str()).collect()
+    } else {
+        format_number_instance(nf_obj, nf_coerce_number(value))
+    };
+    js_string_from_bytes(out.as_ptr(), out.len() as u32)
 }
 
 /// Convert a typed-parts list into a JS array of `{ type, value }` objects —

--- a/crates/perry-runtime/src/intl/number_format.rs
+++ b/crates/perry-runtime/src/intl/number_format.rs
@@ -1650,13 +1650,10 @@ unsafe fn string_header_as_str<'a>(s: *const StringHeader) -> &'a str {
 /// Exact-precision rendering of a `BigInt` magnitude for the "standard"
 /// notation `"decimal"` style — mirrors the `_ =>` (default) arm of
 /// [`number_parts_core`], but starts from the BigInt's own exact base-10
-/// digit string instead of an `f64`-converted magnitude. `f64` can't exactly
-/// represent integers past 2^53, which silently corrupts large `BigInt`
-/// digits (test262 intl402/BigInt/prototype/toLocaleString expects
-/// `90071992547409910n` to round-trip exactly). Every step below
-/// (`round_to_significant`/`round_fraction_or_increment`/
-/// `push_grouped_integer`) already operates on digit strings, not `f64`, so
-/// only the initial magnitude extraction needed to change.
+/// digit string instead of an `f64`-converted one, which can't exactly
+/// represent integers past 2^53 (test262 expects `90071992547409910n` to
+/// round-trip exactly). Every downstream step operates on digit strings, not
+/// `f64`, so only the magnitude extraction needed to change.
 fn bigint_number_parts_exact(
     r: &NfResolved,
     negative: bool,
@@ -1668,11 +1665,10 @@ fn bigint_number_parts_exact(
     set_round_ctx(&r.rounding_mode, negative);
 
     let mut parts: Vec<(&'static str, String)> = Vec::new();
-    let (mut i_out, f_out) = if r.use_sig {
-        round_to_significant(abs_digits, "", r.min_sig, r.max_sig)
-    } else {
-        round_fraction_or_increment(abs_digits, "", r)
-    };
+    // `compact_round` also has the `compact_both` roundingPriority tie-break
+    // branch, unreachable here (only set for `notation == "compact"`) but
+    // reusing it keeps this in lockstep with that helper regardless.
+    let (mut i_out, f_out) = compact_round(abs_digits, "", r);
     while (i_out.len() as u32) < r.min_int {
         i_out.insert(0, '0');
     }
@@ -1697,30 +1693,28 @@ fn bigint_number_parts_exact(
 /// `BigInt.prototype.toLocaleString(locales?, options?)` — ECMA-402
 /// sec-bigint.prototype.tolocalestring (#5845). Builds a real
 /// `Intl.NumberFormat` from `locales`/`options` via the same `make_instance`
-/// path `new Intl.NumberFormat(...)` uses, so option/locale validation and
-/// resolution (and the exceptions they throw) match exactly. Only the
-/// "standard" notation `"decimal"` style renders from the BigInt's exact
-/// digit string; percent/currency/unit and scientific/engineering/compact
-/// notation fall back to the same `f64` coercion
-/// `Intl.NumberFormat.prototype.format` itself uses (`nf_coerce_number`), so
-/// `x.toLocaleString(...)` stays self-consistent with
-/// `new Intl.NumberFormat(...).format(x)` even where it's lossy for BigInts
-/// past 2^53 (test262 returns-same-results-as-NumberFormat.js) — no test in
-/// scope needs exact output through those styles, only agreement with
-/// `.format()`.
+/// path `new Intl.NumberFormat(...)` uses, so validation/resolution (and the
+/// exceptions they throw) match exactly. Only the "standard" notation
+/// `"decimal"` style renders from the BigInt's exact digit string; other
+/// styles/notations fall back to the same `f64` coercion
+/// `Intl.NumberFormat.prototype.format` uses (`nf_coerce_number`), so
+/// `toLocaleString` stays self-consistent with `format()` there too, even
+/// where both are lossy for BigInts past 2^53.
 pub(crate) fn bigint_to_locale_string(value: f64, locales: f64, options: f64) -> *mut StringHeader {
     let ptr = JSValue::from_bits(value.to_bits()).as_bigint_ptr();
     let negative = unsafe { crate::bigint::js_bigint_is_negative(ptr) } != 0;
     let digits_ptr = crate::bigint::js_bigint_to_string(ptr);
+    // Copy into an owned `String` right away — `digits_ptr` is GC-managed and
+    // `make_instance` below allocates, which can move/free it.
     let digits = unsafe { string_header_as_str(digits_ptr) };
-    let abs_digits = digits.strip_prefix('-').unwrap_or(digits);
+    let abs_digits = digits.strip_prefix('-').unwrap_or(digits).to_string();
 
     let nf_obj_value = make_instance(std::ptr::null(), KIND_NUMBER, locales, options);
     let nf_obj = object_ptr_from_value(nf_obj_value).expect("make_instance returns a valid object");
     let r = nf_load(nf_obj);
 
     let out = if r.style == "decimal" && r.notation == "standard" {
-        let mut parts = bigint_number_parts_exact(&r, negative, abs_digits);
+        let mut parts = bigint_number_parts_exact(&r, negative, &abs_digits);
         transliterate_parts_digits(&mut parts, &r.numbering_system);
         parts.iter().map(|(_, v)| v.as_str()).collect()
     } else {

--- a/crates/perry-runtime/src/object/global_this/proto_methods.rs
+++ b/crates/perry-runtime/src/object/global_this/proto_methods.rs
@@ -72,7 +72,7 @@ pub(crate) fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: 
                 ("propertyIsEnumerable", 1),
             ],
         );
-        if !matches!(builtin_name, "Number") {
+        if !matches!(builtin_name, "Number" | "BigInt") {
             install_noop_proto_methods(proto_obj, &[("toLocaleString", 0)]);
         }
         return;

--- a/crates/perry-runtime/src/object/native_call_method/common_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/common_methods.rs
@@ -452,7 +452,15 @@ pub(super) unsafe fn dispatch_common(
         // `toString`. If no custom method is present, fall back to the
         // default `[object Tag]` string. Primitive receivers delegate to
         // their existing `toString` behavior.
-        "toLocaleString" => {
+        //
+        // #5845: a `BigInt` receiver has its own more-specific
+        // `BigInt.prototype.toLocaleString` (ECMA-402), which must win over
+        // this generic `Object.prototype` fallback. Returning `None` here
+        // lets dispatch fall through to the primitive-builtin-prototype
+        // lookup further down `js_native_call_method`, which resolves the
+        // real installed method (and honors a user override, same as every
+        // other primitive-wrapper method).
+        "toLocaleString" if !jsval.is_bigint() => {
             return Some(js_object_default_to_locale_string(object));
         }
 

--- a/crates/perry-runtime/src/object/primitive_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/primitive_proto_thunks.rs
@@ -99,6 +99,18 @@ pub(super) fn install_primitive_proto_methods(
                 bigint_proto_value_of_thunk as *const u8,
                 0,
             );
+            // `.length` is 0 despite the optional `(locales?, options?)`
+            // params (both are optional, so neither counts per the built-in
+            // function `.length` rule) — installed rest-based like
+            // `Date.prototype.toLocaleString` so the fixed call arity stays 0
+            // while `locales`/`options` still arrive via `rest`.
+            super::global_this::install_proto_method_rest_with_length(
+                proto_obj,
+                "toLocaleString",
+                bigint_proto_to_locale_string_thunk as *const u8,
+                0,
+                0,
+            );
         }
         _ => return false,
     }
@@ -358,6 +370,20 @@ pub(super) extern "C" fn bigint_proto_to_string_thunk(
     string_value(crate::value::js_jsvalue_to_string_radix(
         bigint_receiver_or_throw("toString"),
         radix,
+    ))
+}
+
+pub(super) extern "C" fn bigint_proto_to_locale_string_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    rest: f64,
+) -> f64 {
+    let value = bigint_receiver_or_throw("toLocaleString");
+    let args = super::global_this::global_this_rest_array_values(rest);
+    let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+    let locales = args.first().copied().unwrap_or(undef);
+    let options = args.get(1).copied().unwrap_or(undef);
+    string_value(crate::intl::bigint_to_locale_string(
+        value, locales, options,
     ))
 }
 


### PR DESCRIPTION
## Summary

Self-contained fix for the `intl402/BigInt/prototype/toLocaleString` subcluster of #5845 (test262 intl402 misc tail worklist).

- `BigInt.prototype.toLocaleString` was installed as a no-op (returned `undefined`, never brand-checked `this`). It now constructs a real `Intl.NumberFormat` from the given `locales`/`options` — via the same construction path `new Intl.NumberFormat(...)` uses, so option/locale validation and the exceptions they throw match exactly — and renders the `BigInt`'s own exact base-10 digit string for the `"standard"` notation `"decimal"` style. This avoids the `f64` precision loss that would otherwise silently corrupt integers past 2^53 (e.g. `90071992547409910n`). Other styles/notations (currency, percent, scientific/engineering/compact) fall back to the same `f64` coercion `Intl.NumberFormat.prototype.format` itself uses, so `toLocaleString` stays self-consistent with `format()` for those.
- Along the way, found and fixed a real dispatch bug: `dispatch_common`'s generic `Object.prototype.toLocaleString` fallback unconditionally intercepted **every** receiver's direct `.toLocaleString()` call before the primitive-specific prototype lookup ever ran. This meant a correctly-installed `BigInt.prototype.toLocaleString` was shadowed for ordinary method-call syntax (`x.toLocaleString()`) — only the reflective `BigInt.prototype.toLocaleString.call(x)` path actually reached it. Excluding `BigInt` receivers from that generic arm lets dispatch fall through to the real method.
- `push_style_suffix` was missing the non-breaking space that de-DE (and most European locales) place before a percent sign — needed for the `de-DE.js` case. Locale-gated so `en-US` and other locales are unaffected.

## Test plan

- [x] `scripts/test262_subset.py --root vendor/test262 --dir intl402/BigInt`: 5/10 → **10/10** (100% parity)
- [x] Spot-checked `intl402/NumberFormat` + `intl402/Number` subsets for regressions from the percent-NBSP change (structurally scoped to `de`/`de-*` locale only; no currently-relevant test asserts the old no-space behavior)
- [x] `cargo test --release -p perry-runtime`: 1107 passed, 1 failed — the failure (`object::tests::builtin_prototype_methods_reject_dynamic_new`) reproduces on its own in isolation with `--test-threads=1` (passes), confirming it's the known pre-existing test-isolation flake, unrelated to this change
- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/check_file_size.sh`

Per the issue's explicit workflow instructions, this is a code-only PR — no version bump, CHANGELOG, or CLAUDE.md changes.

Refs #5845.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized `toLocaleString` support for `BigInt`, including exact formatting for standard decimal output.
  * `BigInt` now uses the correct locale-aware behavior consistent with numeric `Number` formatting.

* **Bug Fixes**
  * Improved percent formatting for German-like locales by inserting the expected non-breaking space before `%`.
  * Prevented `BigInt` from using the generic locale fallback, ensuring it dispatches to the specialized `BigInt.prototype.toLocaleString` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->