### PR TITLE
fix(runtime): narrow Function.prototype fallback digit-key guard to canonical array indices

### DIFF
--- a/crates/perry-runtime/src/closure/dynamic_props.rs
+++ b/crates/perry-runtime/src/closure/dynamic_props.rs
@@ -543,7 +543,7 @@ pub(crate) fn function_prototype_fallback_target(ptr: usize, prop: &str) -> Opti
         // S15.2.4.7_A8 regressions caught after the initial fix).
         | "toString" | "valueOf" | "hasOwnProperty" | "isPrototypeOf"
         | "propertyIsEnumerable" | "toLocaleString"
-    ) || prop.as_bytes().first().is_some_and(|b| b.is_ascii_digit())
+    ) || crate::object::canonical_array_index(prop).is_some()
         || crate::object::reified_function_method_name(prop).is_some()
     {
         return None;


### PR DESCRIPTION
## Summary
- Trailing CodeRabbit nitpick from #5863 (merged) — the Function.prototype descriptor-fallback guard in `function_prototype_fallback_target` excluded any digit-*leading* key (`prop.as_bytes().first().is_ascii_digit()`), not just canonical array-index keys. A `Function.prototype` property with a key like `"1x"` or `"2things"` would silently never be visible through a closure receiver (`fn["1x"]`).
- This exact check predates #5863 — it was only relocated (unchanged) during that PR's refactor, so it's a pre-existing, narrowly-scoped issue rather than something introduced there. Fixing it here since it's a quick, low-risk win directly adjacent to code #5863 touched.
- Uses the existing `canonical_array_index` helper instead, so only true index keys (`"0"`, `"1"`, `"42"`, ...) are excluded.

## Verification
- `cargo test --release -p perry-runtime`: 1140 passed, 0 failed (one test showed pre-existing test-isolation flakiness under `--test-threads` default parallelism — confirmed by rerunning it in isolation, where it passes cleanly; unrelated to this change).
- `cargo fmt --all -- --check` and `scripts/check_file_size.sh`: clean.

Refs #5842.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how property names are recognized when resolving function prototype fallbacks, making behavior more consistent for index-like property keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->