### PR TITLE
fix(hir,runtime): #5846 — 7 built-ins/Function test262 fixes

### DIFF
--- a/crates/perry-hir/src/lower/expr_object.rs
+++ b/crates/perry-hir/src/lower/expr_object.rs
@@ -347,6 +347,39 @@ fn lower_method_prop(
     ctx.exit_scope(scope_mark);
     ctx.in_nonarrow_fn = saved_in_nonarrow_fn;
 
+    // #5846: retain the method's own source for `Function.prototype.toString`.
+    // Per spec a concise/object-literal method's toString is
+    // `PropertyName ( params ) { body }` — no "function" keyword — so slice
+    // from the key's start (the `[` for a computed key) through the function
+    // body's closing brace, mirroring `capture_function_source`'s use for
+    // declarations/expressions/arrows. Without this, `{ a(){} }.a` fell back
+    // to the synthesized `function a() { [native code] }` form, which is
+    // wrong when that source is itself used (e.g. as a ToPropertyKey
+    // coercion target for a computed key elsewhere) — test262
+    // toString/method-computed-property-name.
+    //
+    // Scoped to plain (non-async, non-generator) methods only: an
+    // `async`/`*` modifier sits BEFORE the key in source (`async *[k](){}`),
+    // so `method_key_span.lo` would truncate it off the front — and
+    // toString/{async,generator}-method* were already passing via the
+    // synthesized-native-form fallback (which conforms to the loose
+    // NativeFunction-syntax check `assertToStringOrNativeFunction` falls
+    // back to on an exact-match miss); capturing a truncated real slice here
+    // would regress them to neither an exact match nor valid NativeFunction
+    // syntax. TODO: extend to async/generator methods once the modifier
+    // (and any comments before the key) can be included in the span.
+    if !method.function.is_async && !method.function.is_generator {
+        let method_key_span = match &method.key {
+            ast::PropName::Ident(i) => i.span,
+            ast::PropName::Str(s) => s.span,
+            ast::PropName::Num(n) => n.span,
+            ast::PropName::Computed(c) => c.span,
+            ast::PropName::BigInt(b) => b.span,
+        };
+        let method_src_span = swc_common::Span::new(method_key_span.lo, method.function.span.hi);
+        super::capture_function_source(ctx, func_id, &method_src_span, false);
+    }
+
     // Capture analysis (same pattern as arrow/function expressions)
     let mut all_refs = Vec::new();
     let mut visited_closures = std::collections::HashSet::new();

--- a/crates/perry-hir/src/lower/fn_ctor_env.rs
+++ b/crates/perry-hir/src/lower/fn_ctor_env.rs
@@ -111,10 +111,61 @@ pub(crate) fn dyn_fn_ctor_kind_of(
     while let ast::Expr::Paren(p) = obj {
         obj = p.expr.as_ref();
     }
+    // `Object.getPrototypeOf(<fn-literal>).constructor` — the standard idiom
+    // for reaching the hidden `AsyncFunction`/`GeneratorFunction`/
+    // `AsyncGeneratorFunction` global constructors, which (unlike `Function`)
+    // aren't reachable as named globals. `Object.getPrototypeOf(fnExpr)`
+    // yields fnExpr's `[[Prototype]]` (e.g. `%GeneratorFunction.prototype%`
+    // for a generator literal), and `.constructor` on THAT is the matching
+    // hidden constructor — same kind as `fnExpr` itself (test262
+    // toString/GeneratorFunction.js).
+    if let Some(kind) = dyn_fn_ctor_kind_via_get_prototype_of(obj, known_literals) {
+        return Some(kind);
+    }
     if let Some(kind) = fn_literal_kind_of(obj) {
         return Some(kind);
     }
     if let ast::Expr::Ident(id) = obj {
+        return known_literals.get(id.sym.as_str()).copied();
+    }
+    None
+}
+
+/// Match `Object.getPrototypeOf(<arg>)` and resolve `<arg>`'s dynamic-ctor
+/// kind (function literal or known single-assignment variable).
+fn dyn_fn_ctor_kind_via_get_prototype_of(
+    obj: &ast::Expr,
+    known_literals: &HashMap<String, DynFnCtorKind>,
+) -> Option<DynFnCtorKind> {
+    let ast::Expr::Call(call) = obj else {
+        return None;
+    };
+    if call.args.len() != 1 || call.args[0].spread.is_some() {
+        return None;
+    }
+    let ast::Callee::Expr(callee) = &call.callee else {
+        return None;
+    };
+    let mut c = callee.as_ref();
+    while let ast::Expr::Paren(p) = c {
+        c = p.expr.as_ref();
+    }
+    let ast::Expr::Member(gm) = c else {
+        return None;
+    };
+    let is_get_proto = matches!(&gm.prop, ast::MemberProp::Ident(id) if id.sym.as_ref() == "getPrototypeOf")
+        && matches!(gm.obj.as_ref(), ast::Expr::Ident(oid) if oid.sym.as_ref() == "Object");
+    if !is_get_proto {
+        return None;
+    }
+    let mut inner = call.args[0].expr.as_ref();
+    while let ast::Expr::Paren(p) = inner {
+        inner = p.expr.as_ref();
+    }
+    if let Some(kind) = fn_literal_kind_of(inner) {
+        return Some(kind);
+    }
+    if let ast::Expr::Ident(id) = inner {
         return known_literals.get(id.sym.as_str()).copied();
     }
     None

--- a/crates/perry-runtime/src/object/class_registry/construct.rs
+++ b/crates/perry-runtime/src/object/class_registry/construct.rs
@@ -216,6 +216,19 @@ pub unsafe extern "C" fn js_new_function_construct(
             );
         }
     }
+    // `new boundFn(...)` — delegate entirely to the newTarget-aware path,
+    // which unwinds the bind chain to the real target before re-dispatching
+    // (see `unwrap_bound_construct_chain`). `new`'s implicit newTarget is
+    // `func_value` itself, matching spec step "If NewTarget is not present,
+    // set newTarget to F" for a plain `new`. Bypasses everything below —
+    // primitive/proxy/non-constructable/native-module checks all re-run on
+    // the UNWRAPPED target, which is what they need to see (a bound wrapper
+    // around `Date`, a bound wrapper around a non-constructor, etc.).
+    if is_bound_function_closure_value(func_value) {
+        return js_new_function_construct_with_new_target(
+            func_value, args_ptr, args_len, func_value,
+        );
+    }
     // `new (new String(""))` / `new (new Number(1))` — a boxed primitive WRAPPER
     // object is an ordinary object, never a constructor, so `new` on it throws
     // `TypeError` (Test262 `S15.5.5_A2`). Without this it fell through to the
@@ -1013,6 +1026,12 @@ fn constructor_class_ref_id(value: f64) -> Option<u32> {
 /// (non-arrow, non-builtin-method) function closures; false for primitives,
 /// arrow functions, and non-constructable builtin functions (e.g. `eval`).
 pub(crate) fn js_value_is_constructor(value: f64) -> bool {
+    // A bound function is a constructor iff its ultimate target is (10.4.1.3
+    // BoundFunctionExoticObjects don't have their own [[Construct]] slot
+    // independent of the target's constructibility) — resolve through any
+    // number of `.bind()` layers first so the checks below (class ref,
+    // proxy, arrow, non-constructable builtin) see the real callee.
+    let value = resolve_bound_target(value);
     if constructor_class_ref_id(value).is_some() {
         return true;
     }
@@ -1091,6 +1110,105 @@ pub(crate) fn extends_target_must_throw(value: f64) -> bool {
     }
     // A pointer we don't recognize as callable: stay conservative (no throw).
     false
+}
+
+/// Whether `value` is itself a `Function.prototype.bind` result (not
+/// recursive — a single-layer tag check).
+fn is_bound_function_closure_value(value: f64) -> bool {
+    let jv = crate::value::JSValue::from_bits(value.to_bits());
+    if !jv.is_pointer() {
+        return false;
+    }
+    let ptr = jv.as_pointer::<crate::closure::ClosureHeader>();
+    if ptr.is_null() || unsafe { (*ptr).type_tag } != crate::closure::CLOSURE_MAGIC {
+        return false;
+    }
+    crate::closure::get_valid_func_ptr(ptr) == crate::closure::BOUND_FUNCTION_FUNC_PTR
+}
+
+/// Walk through any number of `Function.prototype.bind` wrapper layers to the
+/// ultimate non-bound target. Returns `value` unchanged when it isn't a bound
+/// closure (including when it isn't a closure at all) — cheap no-op on the
+/// overwhelmingly common non-bound path.
+fn resolve_bound_target(value: f64) -> f64 {
+    let mut cur = value;
+    loop {
+        let jv = crate::value::JSValue::from_bits(cur.to_bits());
+        if !jv.is_pointer() {
+            return cur;
+        }
+        let ptr = jv.as_pointer::<crate::closure::ClosureHeader>();
+        if ptr.is_null() || unsafe { (*ptr).type_tag } != crate::closure::CLOSURE_MAGIC {
+            return cur;
+        }
+        if crate::closure::get_valid_func_ptr(ptr) != crate::closure::BOUND_FUNCTION_FUNC_PTR {
+            return cur;
+        }
+        cur = crate::closure::js_closure_get_capture_f64(ptr, 0);
+    }
+}
+
+/// Unwind a `Function.prototype.bind` construct chain of any depth per
+/// `BoundFunctionExoticObjects.[[Construct]]` (10.4.1.2): each layer
+/// prepends its own bound args to the call-time args before delegating to
+/// its target, and resets `newTarget` to the unwrapped target whenever it
+/// `SameValue`s the layer being unwound (so a plain `new boundFn()` — where
+/// `newTarget` starts out equal to `boundFn` itself — cascades all the way
+/// down to the ultimate target, while a `Reflect.construct(boundFn, args,
+/// OtherCtor)` leaves `OtherCtor` untouched).
+///
+/// Returns `None` (no-op, no allocation) when `func_value` isn't a bound
+/// closure. Otherwise returns `(target, combined_args, resolved_new_target)`
+/// — the caller should re-dispatch construction on `target` with these.
+unsafe fn unwrap_bound_construct_chain(
+    func_value: f64,
+    args_ptr: *const f64,
+    args_len: usize,
+    new_target: f64,
+) -> Option<(f64, Vec<f64>, f64)> {
+    let mut cur = func_value;
+    let mut nt = new_target;
+    let mut unwrapped = false;
+    let mut args: Vec<f64> = if args_ptr.is_null() {
+        Vec::new()
+    } else {
+        std::slice::from_raw_parts(args_ptr, args_len).to_vec()
+    };
+    loop {
+        let jv = crate::value::JSValue::from_bits(cur.to_bits());
+        if !jv.is_pointer() {
+            break;
+        }
+        let ptr = jv.as_pointer::<crate::closure::ClosureHeader>();
+        if ptr.is_null() || (*ptr).type_tag != crate::closure::CLOSURE_MAGIC {
+            break;
+        }
+        if crate::closure::get_valid_func_ptr(ptr) != crate::closure::BOUND_FUNCTION_FUNC_PTR {
+            break;
+        }
+        unwrapped = true;
+        let target = crate::closure::js_closure_get_capture_f64(ptr, 0);
+        if nt.to_bits() == cur.to_bits() {
+            nt = target;
+        }
+        let bound_args_ptr =
+            crate::closure::js_closure_get_capture_ptr(ptr, 2) as *const crate::array::ArrayHeader;
+        if !bound_args_ptr.is_null() {
+            let n = crate::array::js_array_length(bound_args_ptr) as usize;
+            let mut prefix: Vec<f64> = Vec::with_capacity(n + args.len());
+            for i in 0..n {
+                prefix.push(crate::array::js_array_get_f64(bound_args_ptr, i as u32));
+            }
+            prefix.extend(args);
+            args = prefix;
+        }
+        cur = target;
+    }
+    if unwrapped {
+        Some((cur, args, nt))
+    } else {
+        None
+    }
 }
 
 fn class_object_class_id(value: f64) -> Option<u32> {
@@ -1214,6 +1332,24 @@ pub unsafe extern "C" fn js_new_function_construct_with_new_target(
     } else {
         new_target
     };
+    // Unwind any `Function.prototype.bind` wrapper chain BEFORE the
+    // `nt == func_value` shortcut below — a plain `new boundFn()` arrives
+    // here with `nt == func_value == boundFn`, and re-dispatching that
+    // through `js_new_function_construct(boundFn, ...)` would just loop back
+    // into this same bound closure. Unwrapping first replaces `func_value`
+    // with the real (non-bound) target and resolves `nt` per
+    // `BoundFunctionExoticObjects.[[Construct]]`, so the shortcut below (and
+    // everything after it) sees the real target either way.
+    if let Some((target, combined_args, resolved_nt)) =
+        unwrap_bound_construct_chain(func_value, args_ptr, args_len, nt)
+    {
+        let (ptr, len) = if combined_args.is_empty() {
+            (std::ptr::null::<f64>(), 0usize)
+        } else {
+            (combined_args.as_ptr(), combined_args.len())
+        };
+        return js_new_function_construct_with_new_target(target, ptr, len, resolved_nt);
+    }
     if nt.to_bits() == func_value.to_bits() {
         return js_new_function_construct(func_value, args_ptr, args_len);
     }

--- a/crates/perry-runtime/src/object/class_registry/construct.rs
+++ b/crates/perry-runtime/src/object/class_registry/construct.rs
@@ -1044,6 +1044,18 @@ pub(crate) fn js_value_is_constructor(value: f64) -> bool {
     if is_arrow_function_value(value) {
         return false;
     }
+    // %Function.prototype% itself is callable but has no [[Construct]] slot
+    // (ECMA-262 20.2.3) — `is_non_constructable_builtin_function_value` only
+    // covers the separate "reified builtin closure" registry (`eval`, a
+    // reified `.apply`/`.call`/`.bind` value, …), not this singleton, so it
+    // needs its own check here too (mirrors `js_new_function_construct`'s
+    // dedicated `is_function_prototype_object_value` guard). Without this, a
+    // bound wrapper around it — `Function.prototype.bind()` — would resolve
+    // through `resolve_bound_target` to Function.prototype and read back as
+    // constructible.
+    if super::super::global_this::is_function_prototype_object_value(value) {
+        return false;
+    }
     if is_non_constructable_builtin_function_value(value) {
         return false;
     }
@@ -1114,16 +1126,30 @@ pub(crate) fn extends_target_must_throw(value: f64) -> bool {
 
 /// Whether `value` is itself a `Function.prototype.bind` result (not
 /// recursive — a single-layer tag check).
-fn is_bound_function_closure_value(value: f64) -> bool {
+///
+/// `get_valid_func_ptr` re-validates the address range and `CLOSURE_MAGIC`
+/// tag itself before touching `func_ptr`, so it's safe to call on ANY
+/// pointer-shaped `JSValue` — including a small-handle-band id (Fetch/ws/
+/// proxy registry ids) or an otherwise-invalid heap address — without a
+/// separate `is_closure_ptr` pre-check. A prior version of this helper
+/// dereferenced `(*ptr).type_tag` directly first, which is exactly the
+/// unguarded-pointer-shaped-value read this codebase has been bitten by
+/// before (#4740-class SIGSEGV on a mis-boxed/handle-band value).
+fn bound_function_target_ptr(value: f64) -> Option<*mut crate::closure::ClosureHeader> {
     let jv = crate::value::JSValue::from_bits(value.to_bits());
     if !jv.is_pointer() {
-        return false;
+        return None;
     }
     let ptr = jv.as_pointer::<crate::closure::ClosureHeader>();
-    if ptr.is_null() || unsafe { (*ptr).type_tag } != crate::closure::CLOSURE_MAGIC {
-        return false;
+    if crate::closure::get_valid_func_ptr(ptr) == crate::closure::BOUND_FUNCTION_FUNC_PTR {
+        Some(ptr as *mut crate::closure::ClosureHeader)
+    } else {
+        None
     }
-    crate::closure::get_valid_func_ptr(ptr) == crate::closure::BOUND_FUNCTION_FUNC_PTR
+}
+
+fn is_bound_function_closure_value(value: f64) -> bool {
+    bound_function_target_ptr(value).is_some()
 }
 
 /// Walk through any number of `Function.prototype.bind` wrapper layers to the
@@ -1133,17 +1159,9 @@ fn is_bound_function_closure_value(value: f64) -> bool {
 fn resolve_bound_target(value: f64) -> f64 {
     let mut cur = value;
     loop {
-        let jv = crate::value::JSValue::from_bits(cur.to_bits());
-        if !jv.is_pointer() {
+        let Some(ptr) = bound_function_target_ptr(cur) else {
             return cur;
-        }
-        let ptr = jv.as_pointer::<crate::closure::ClosureHeader>();
-        if ptr.is_null() || unsafe { (*ptr).type_tag } != crate::closure::CLOSURE_MAGIC {
-            return cur;
-        }
-        if crate::closure::get_valid_func_ptr(ptr) != crate::closure::BOUND_FUNCTION_FUNC_PTR {
-            return cur;
-        }
+        };
         cur = crate::closure::js_closure_get_capture_f64(ptr, 0);
     }
 }
@@ -1175,17 +1193,9 @@ unsafe fn unwrap_bound_construct_chain(
         std::slice::from_raw_parts(args_ptr, args_len).to_vec()
     };
     loop {
-        let jv = crate::value::JSValue::from_bits(cur.to_bits());
-        if !jv.is_pointer() {
+        let Some(ptr) = bound_function_target_ptr(cur) else {
             break;
-        }
-        let ptr = jv.as_pointer::<crate::closure::ClosureHeader>();
-        if ptr.is_null() || (*ptr).type_tag != crate::closure::CLOSURE_MAGIC {
-            break;
-        }
-        if crate::closure::get_valid_func_ptr(ptr) != crate::closure::BOUND_FUNCTION_FUNC_PTR {
-            break;
-        }
+        };
         unwrapped = true;
         let target = crate::closure::js_closure_get_capture_f64(ptr, 0);
         if nt.to_bits() == cur.to_bits() {
@@ -1408,6 +1418,17 @@ pub unsafe extern "C" fn js_new_function_construct_with_new_target(
     }
     if !is_callable_function_value(func_value) {
         return js_new_function_construct(func_value, args_ptr, args_len);
+    }
+    // %Function.prototype% has no [[Construct]] slot (ECMA-262 20.2.3) but
+    // isn't covered by `is_non_constructable_builtin_function_value` (a
+    // separate "reified builtin closure" registry) — reachable here directly
+    // via `Reflect.construct(Function.prototype, …, distinctNewTarget)`, or
+    // after `unwrap_bound_construct_chain` resolves a bound wrapper down to
+    // it with a non-cascading newTarget.
+    if super::super::global_this::is_function_prototype_object_value(func_value)
+        || super::super::global_this::is_function_prototype_object_value(nt)
+    {
+        throw_non_constructable_builtin_function();
     }
     if is_non_constructable_builtin_function_value(func_value)
         || is_non_constructable_builtin_function_value(nt)

--- a/crates/perry-runtime/src/object/class_registry/prototype_objects.rs
+++ b/crates/perry-runtime/src/object/class_registry/prototype_objects.rs
@@ -197,7 +197,19 @@ pub extern "C" fn js_set_function_prototype(func: f64, proto: f64) -> u32 {
         // DROPPED: store it as the closure's `prototype` dynamic prop so reads
         // reflect it and `js_new_function_construct` links instances to it
         // (test262 filter/15.4.4.20-6-*, some/15.4.4.17-8-*, map/15.4.4.19-9-3).
-        if obj_type == crate::gc::GC_TYPE_ARRAY || obj_type == crate::gc::GC_TYPE_LAZY_ARRAY {
+        // `foo.prototype = someOtherFunction` — a function/closure-valued
+        // prototype can't join the class-id machinery either (it has no
+        // ObjectHeader): store it the same way as the array case so
+        // `js_new_function_construct`'s `linked_user_proto` check links new
+        // instances to it (test262 built-ins/Function/prototype/apply/
+        // S15.3.4.3_A1_T1, call/S15.3.4.4_A1_T1 — `FACTORY.prototype =
+        // Function()` was silently dropped, so `new FACTORY` instances kept
+        // the auto-created empty prototype instead of inheriting the real
+        // function's methods).
+        if obj_type == crate::gc::GC_TYPE_ARRAY
+            || obj_type == crate::gc::GC_TYPE_LAZY_ARRAY
+            || obj_type == crate::gc::GC_TYPE_CLOSURE
+        {
             let func_ptr = (func_bits & crate::value::POINTER_MASK) as usize;
             if func_ptr != 0 && crate::closure::is_closure_ptr(func_ptr) {
                 crate::closure::closure_set_dynamic_prop(func_ptr, "prototype", proto);

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -26,7 +26,7 @@ pub(crate) use array_error::{
     array_prototype_shift_thunk, array_prototype_slice_thunk, array_prototype_sort_thunk,
     array_prototype_splice_thunk, array_prototype_unshift_thunk, date_prototype_to_string_thunk,
     error_prototype_to_string_thunk, function_prototype_apply_thunk, function_prototype_bind_thunk,
-    function_prototype_call_thunk, function_prototype_to_string_thunk,
+    function_prototype_call_thunk, function_prototype_to_string_thunk, generic_array_like_to_vec,
     global_this_clear_immediate_thunk, global_this_clear_interval_thunk,
     global_this_clear_timeout_thunk, global_this_queue_microtask_thunk,
     global_this_rest_array_values, global_this_set_immediate_thunk, global_this_set_interval_thunk,

--- a/crates/perry-runtime/src/object/global_this/array_error.rs
+++ b/crates/perry-runtime/src/object/global_this/array_error.rs
@@ -402,8 +402,10 @@ unsafe fn function_apply_args(args_array: f64) -> Vec<f64> {
     // Boolean/BigInt was passed directly to `.apply` (test262
     // apply/argarray-not-object). Nullish was already handled above; a real
     // Array and an arguments object were handled above too, so anything left
-    // that isn't an Object must be a primitive.
-    if !value.is_pointer() {
+    // that isn't an Object must be a primitive. A `Symbol` is POINTER_TAG'd
+    // like a real heap object, so `!value.is_pointer()` alone doesn't catch
+    // it — check `js_is_symbol` explicitly.
+    if !value.is_pointer() || crate::symbol::js_is_symbol(args_array) != 0 {
         throw_type_error_message(b"CreateListFromArrayLike called on non-object");
     }
     generic_array_like_to_vec(args_array)

--- a/crates/perry-runtime/src/object/global_this/array_error.rs
+++ b/crates/perry-runtime/src/object/global_this/array_error.rs
@@ -364,24 +364,63 @@ unsafe fn function_apply_args(args_array: f64) -> Vec<f64> {
         }
     }
     let is_array = JSValue::from_bits(crate::array::js_array_is_array(args_array).to_bits());
-    if !is_array.is_bool() || !is_array.as_bool() {
-        return Vec::new();
+    if is_array.is_bool() && is_array.as_bool() {
+        let arr = if value.is_pointer() {
+            value.as_pointer::<crate::array::ArrayHeader>()
+        } else if (args_array.to_bits() >> 48) == 0 {
+            args_array.to_bits() as *const crate::array::ArrayHeader
+        } else {
+            std::ptr::null()
+        };
+        if arr.is_null() {
+            return Vec::new();
+        }
+        let len = crate::array::js_array_length(arr) as usize;
+        let mut out = Vec::with_capacity(len);
+        for i in 0..len {
+            out.push(f64::from_bits(
+                crate::array::js_array_get(arr, i as u32).bits(),
+            ));
+        }
+        return out;
     }
-    let arr = if value.is_pointer() {
-        value.as_pointer::<crate::array::ArrayHeader>()
-    } else if (args_array.to_bits() >> 48) == 0 {
-        args_array.to_bits() as *const crate::array::ArrayHeader
+    generic_array_like_to_vec(args_array)
+}
+
+/// Generic `CreateListFromArrayLike` (spec 7.3.24) for an `argArray` that is
+/// neither an arguments object nor a real Array — notably a Proxy or plain
+/// object with a numeric `length` and indexed properties. Reads `length` via
+/// `Get` (ToNumber-coerced, clamped to `ToLength`), then reads each index
+/// `0..length` via `Get` in order. `js_get_property` is the generic
+/// dynamic-property-get entry point (Proxy-trap aware, throws through on
+/// failure) also used by codegen for computed member access — so a throwing
+/// `length`/indexed `Get` trap propagates as the abrupt completion the spec
+/// requires (test262 built-ins/Function/prototype/apply/get-index-abrupt),
+/// instead of being silently swallowed into an empty list.
+pub(crate) unsafe fn generic_array_like_to_vec(args_array: f64) -> Vec<f64> {
+    let len_key = b"length";
+    let len_val =
+        crate::value::js_get_property(args_array, len_key.as_ptr() as i64, len_key.len() as i64);
+    let len_num = crate::builtins::js_number_coerce(len_val);
+    let len = if len_num.is_nan() {
+        0
     } else {
-        std::ptr::null()
+        let n = len_num.trunc();
+        if n <= 0.0 {
+            0
+        } else if n > 9_007_199_254_740_991.0 {
+            9_007_199_254_740_991_i64
+        } else {
+            n as i64
+        }
     };
-    if arr.is_null() {
-        return Vec::new();
-    }
-    let len = crate::array::js_array_length(arr) as usize;
-    let mut out = Vec::with_capacity(len);
+    let mut out = Vec::with_capacity(len.min(1024) as usize);
     for i in 0..len {
-        out.push(f64::from_bits(
-            crate::array::js_array_get(arr, i as u32).bits(),
+        let key = i.to_string();
+        out.push(crate::value::js_get_property(
+            args_array,
+            key.as_ptr() as i64,
+            key.len() as i64,
         ));
     }
     out

--- a/crates/perry-runtime/src/object/global_this/array_error.rs
+++ b/crates/perry-runtime/src/object/global_this/array_error.rs
@@ -348,6 +348,19 @@ pub(crate) extern "C" fn object_prototype_to_locale_string_thunk(
     unsafe { super::super::js_object_default_to_locale_string(this_value) }
 }
 
+/// Spec `CreateListFromArrayLike`'s implementation-defined cap on the
+/// generic index-walk (Node/V8 throw a `RangeError` — "Maximum call stack
+/// size exceeded" or "Invalid array length" depending on magnitude — well
+/// before honoring a huge `length`). Chosen generously above any legitimate
+/// argument list while still bounding the loop/allocation below.
+const MAX_GENERIC_ARRAY_LIKE_LENGTH: i64 = 1_000_000;
+
+fn throw_apply_range_error(message: &[u8]) -> ! {
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_rangeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
 unsafe fn function_apply_args(args_array: f64) -> Vec<f64> {
     let value = JSValue::from_bits(args_array.to_bits());
     if value.is_undefined() || value.is_null() {
@@ -384,7 +397,22 @@ unsafe fn function_apply_args(args_array: f64) -> Vec<f64> {
         }
         return out;
     }
+    // Spec `CreateListFromArrayLike` (7.3.24) step 2: a non-nullish,
+    // non-object `argArray` is a `TypeError` — a Symbol/Number/String/
+    // Boolean/BigInt was passed directly to `.apply` (test262
+    // apply/argarray-not-object). Nullish was already handled above; a real
+    // Array and an arguments object were handled above too, so anything left
+    // that isn't an Object must be a primitive.
+    if !value.is_pointer() {
+        throw_type_error_message(b"CreateListFromArrayLike called on non-object");
+    }
     generic_array_like_to_vec(args_array)
+}
+
+fn throw_type_error_message(message: &[u8]) -> ! {
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_typeerror_new(msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
 }
 
 /// Generic `CreateListFromArrayLike` (spec 7.3.24) for an `argArray` that is
@@ -397,10 +425,30 @@ unsafe fn function_apply_args(args_array: f64) -> Vec<f64> {
 /// `length`/indexed `Get` trap propagates as the abrupt completion the spec
 /// requires (test262 built-ins/Function/prototype/apply/get-index-abrupt),
 /// instead of being silently swallowed into an empty list.
+///
+/// `args_array` and every collected element are rooted in a
+/// `RuntimeHandleScope` for the duration of the walk: each `js_get_property`
+/// call can run arbitrary JS (a getter, a Proxy trap) that may trigger a GC
+/// cycle, and a plain `Vec<f64>` accumulator lives on the Rust heap — outside
+/// the conservative stack scanner's reach — so an already-collected heap
+/// pointer would go stale under a moving/evacuating cycle without explicit
+/// rooting.
 pub(crate) unsafe fn generic_array_like_to_vec(args_array: f64) -> Vec<f64> {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let array_handle = scope.root_nanbox_f64(args_array);
     let len_key = b"length";
-    let len_val =
-        crate::value::js_get_property(args_array, len_key.as_ptr() as i64, len_key.len() as i64);
+    let len_val = crate::value::js_get_property(
+        array_handle.get_nanbox_f64(),
+        len_key.as_ptr() as i64,
+        len_key.len() as i64,
+    );
+    // Spec `ToLength` runs `ToIntegerOrInfinity`, which itself runs
+    // `ToNumber` — and `ToNumber(BigInt)` is a `TypeError`, not an implicit
+    // narrowing conversion (test262 length-property-is-bigint-value).
+    // `js_number_coerce` doesn't special-case BigInt, so reject it here first.
+    if JSValue::from_bits(len_val.to_bits()).is_bigint() {
+        throw_type_error_message(b"Cannot convert a BigInt value to a number");
+    }
     let len_num = crate::builtins::js_number_coerce(len_val);
     let len = if len_num.is_nan() {
         0
@@ -414,16 +462,20 @@ pub(crate) unsafe fn generic_array_like_to_vec(args_array: f64) -> Vec<f64> {
             n as i64
         }
     };
-    let mut out = Vec::with_capacity(len.min(1024) as usize);
+    if len > MAX_GENERIC_ARRAY_LIKE_LENGTH {
+        throw_apply_range_error(b"Maximum call stack size exceeded");
+    }
+    let mut handles = Vec::with_capacity(len as usize);
     for i in 0..len {
         let key = i.to_string();
-        out.push(crate::value::js_get_property(
-            args_array,
+        let v = crate::value::js_get_property(
+            array_handle.get_nanbox_f64(),
             key.as_ptr() as i64,
             key.len() as i64,
-        ));
+        );
+        handles.push(scope.root_nanbox_f64(v));
     }
-    out
+    crate::gc::RuntimeHandleScope::refreshed_nanbox_f64_slice(&handles)
 }
 
 pub(crate) extern "C" fn function_prototype_apply_thunk(

--- a/crates/perry-runtime/src/object/has_own_helpers.rs
+++ b/crates/perry-runtime/src/object/has_own_helpers.rs
@@ -33,37 +33,6 @@ pub(crate) fn closure_own_key_present(ptr: usize, key: &str) -> bool {
                 super::class_registry::function_would_have_own_prototype(val)
             }
         }
-        // `Function.prototype` is installed with a full set of generic
-        // Object.prototype methods as real dynamic props (so they dispatch
-        // when called on it), but per spec it only inherits these from
-        // `Object.prototype` — they are NOT its own properties. Only the
-        // %Function.prototype% singleton is special-cased here (an ordinary
-        // user function never gets these dynamic props at all, so the `_`
-        // arm below is unaffected). Test262 built-ins/Function/prototype/
-        // S15.3.4_A4.
-        //
-        // This doesn't distinguish an explicit `Object.defineProperty
-        // (Function.prototype, "valueOf", {value: f})` override (which
-        // spec-wise WOULD make the key a genuine own property) from the
-        // install-time shim — attempting that distinction via a func-ptr
-        // comparison against the shim's expected thunk turned out to be
-        // unreliable (it broke the untouched-key baseline case too) and was
-        // reverted; no test262 case in scope exercises that edge case.
-        "hasOwnProperty"
-        | "isPrototypeOf"
-        | "propertyIsEnumerable"
-        | "toLocaleString"
-        | "valueOf"
-        | "__defineGetter__"
-        | "__defineSetter__"
-        | "__lookupGetter__"
-        | "__lookupSetter__"
-            if super::is_function_prototype_object_value(crate::value::js_nanbox_pointer(
-                ptr as i64,
-            )) =>
-        {
-            false
-        }
         // User props are real own dynamic props in the side table.
         _ => crate::closure::closure_has_own_dynamic_prop(ptr, key),
     }

--- a/crates/perry-runtime/src/object/has_own_helpers.rs
+++ b/crates/perry-runtime/src/object/has_own_helpers.rs
@@ -33,6 +33,29 @@ pub(crate) fn closure_own_key_present(ptr: usize, key: &str) -> bool {
                 super::class_registry::function_would_have_own_prototype(val)
             }
         }
+        // `Function.prototype` is installed with a full set of generic
+        // Object.prototype methods as real dynamic props (so they dispatch
+        // when called on it), but per spec it only inherits these from
+        // `Object.prototype` — they are NOT its own properties. Only the
+        // %Function.prototype% singleton is special-cased here (an ordinary
+        // user function never gets these dynamic props at all, so the `_`
+        // arm below is unaffected). Test262 built-ins/Function/prototype/
+        // S15.3.4_A4.
+        "hasOwnProperty"
+        | "isPrototypeOf"
+        | "propertyIsEnumerable"
+        | "toLocaleString"
+        | "valueOf"
+        | "__defineGetter__"
+        | "__defineSetter__"
+        | "__lookupGetter__"
+        | "__lookupSetter__"
+            if super::is_function_prototype_object_value(crate::value::js_nanbox_pointer(
+                ptr as i64,
+            )) =>
+        {
+            false
+        }
         // User props are real own dynamic props in the side table.
         _ => crate::closure::closure_has_own_dynamic_prop(ptr, key),
     }

--- a/crates/perry-runtime/src/object/has_own_helpers.rs
+++ b/crates/perry-runtime/src/object/has_own_helpers.rs
@@ -41,6 +41,14 @@ pub(crate) fn closure_own_key_present(ptr: usize, key: &str) -> bool {
         // user function never gets these dynamic props at all, so the `_`
         // arm below is unaffected). Test262 built-ins/Function/prototype/
         // S15.3.4_A4.
+        //
+        // This doesn't distinguish an explicit `Object.defineProperty
+        // (Function.prototype, "valueOf", {value: f})` override (which
+        // spec-wise WOULD make the key a genuine own property) from the
+        // install-time shim — attempting that distinction via a func-ptr
+        // comparison against the shim's expected thunk turned out to be
+        // unreliable (it broke the untouched-key baseline case too) and was
+        // reverted; no test262 case in scope exercises that edge case.
         "hasOwnProperty"
         | "isPrototypeOf"
         | "propertyIsEnumerable"

--- a/crates/perry-runtime/src/object/native_call_method/common_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/common_methods.rs
@@ -601,11 +601,26 @@ pub(super) unsafe fn dispatch_common(
                     ) {
                         values
                     } else {
-                        let arr_ptr = arr_raw as *const crate::array::ArrayHeader;
-                        let n = crate::array::js_array_length(arr_ptr) as usize;
-                        (0..n)
-                            .map(|i| crate::array::js_array_get_f64(arr_ptr, i as u32))
-                            .collect()
+                        let is_array = JSValue::from_bits(
+                            crate::array::js_array_is_array(args_arr_val).to_bits(),
+                        );
+                        if is_array.is_bool() && is_array.as_bool() {
+                            let arr_ptr = arr_raw as *const crate::array::ArrayHeader;
+                            let n = crate::array::js_array_length(arr_ptr) as usize;
+                            (0..n)
+                                .map(|i| crate::array::js_array_get_f64(arr_ptr, i as u32))
+                                .collect()
+                        } else {
+                            // #5846: a plain array-like object or Proxy (not a
+                            // real Array, not an arguments object) —
+                            // `arr_raw` is NOT a genuine `ArrayHeader*` here,
+                            // so reading it as one is a type-confusion bug.
+                            // Fall through to the generic `Get("length")` +
+                            // indexed-`Get` walk, which also correctly
+                            // propagates a throwing `length`/indexed trap
+                            // (test262 apply/get-index-abrupt).
+                            generic_array_like_to_vec(args_arr_val)
+                        }
                     }
                 } else {
                     Vec::new()

--- a/crates/perry-runtime/src/object/object_ops/has_own.rs
+++ b/crates/perry-runtime/src/object/object_ops/has_own.rs
@@ -239,25 +239,66 @@ pub extern "C" fn js_object_has_own(obj_value: f64, key_value: f64) -> f64 {
         // installed with a full set of generic `Object.prototype` methods as
         // real own data properties so they dispatch when called directly on
         // it. Per spec (20.2.3) it only *inherits* these from
-        // `Object.prototype`; they are not its own. Reject the known shim
-        // keys here, before the generic `own_key_present` keys_array scan
-        // below would find them installed and report `true` (test262
-        // built-ins/Function/prototype/S15.3.4_A4).
+        // `Object.prototype`; they are not its own (test262 built-ins/
+        // Function/prototype/S15.3.4_A4) — UNLESS user code has since
+        // overwritten the slot (`Object.defineProperty(Function.prototype,
+        // "valueOf", …)`), which per spec DOES create a genuine own property.
+        // Distinguish the two by checking whether the currently-installed
+        // value is still the exact install-time thunk closure: an explicit
+        // redefine always stores a different value (a new closure, or a
+        // non-function entirely), never literally the same `func_ptr`.
         if super::super::global_this::is_function_prototype_object_value(obj_value) {
             if let Some(key) = super::super::has_own_helpers::str_from_string_header(key_str) {
-                if matches!(
-                    key,
-                    "hasOwnProperty"
-                        | "isPrototypeOf"
-                        | "propertyIsEnumerable"
-                        | "toLocaleString"
-                        | "valueOf"
-                        | "__defineGetter__"
-                        | "__defineSetter__"
-                        | "__lookupGetter__"
-                        | "__lookupSetter__"
-                ) {
-                    return f64::from_bits(TAG_FALSE);
+                // `install_noop_proto_methods` (the actual installer Function.
+                // prototype goes through) backs most of `OBJECT_PROTO_METHODS`
+                // with the shared `global_this_builtin_noop_thunk` — only
+                // `isPrototypeOf` and the four Annex B accessor helpers get a
+                // dedicated per-method thunk there. `object_prototype_has_own_
+                // property_thunk` et al. are real thunks too, but they're wired
+                // up only for `Object.prototype` itself (a different install
+                // call site), never for `Function.prototype` — so comparing
+                // against them here would always mismatch and defeat the
+                // still-default check entirely.
+                let expected_thunk: Option<*const u8> = match key {
+                    "hasOwnProperty" | "propertyIsEnumerable" | "toLocaleString" | "valueOf" => {
+                        Some(super::super::global_this::global_this_builtin_noop_thunk as *const u8)
+                    }
+                    "isPrototypeOf" => Some(
+                        super::super::global_this::object_prototype_is_prototype_of_thunk
+                            as *const u8,
+                    ),
+                    "__defineGetter__" => Some(
+                        super::super::global_this::object_prototype_define_getter_thunk
+                            as *const u8,
+                    ),
+                    "__defineSetter__" => Some(
+                        super::super::global_this::object_prototype_define_setter_thunk
+                            as *const u8,
+                    ),
+                    "__lookupGetter__" => Some(
+                        super::super::global_this::object_prototype_lookup_getter_thunk
+                            as *const u8,
+                    ),
+                    "__lookupSetter__" => Some(
+                        super::super::global_this::object_prototype_lookup_setter_thunk
+                            as *const u8,
+                    ),
+                    _ => None,
+                };
+                if let Some(expected) = expected_thunk {
+                    let current = js_object_get_field_by_name(obj, key_str);
+                    let still_default_shim = if current.is_pointer() {
+                        let cur_ptr = current.as_pointer::<u8>() as usize;
+                        crate::closure::is_closure_ptr(cur_ptr)
+                            && crate::closure::get_valid_func_ptr(
+                                cur_ptr as *const crate::closure::ClosureHeader,
+                            ) == expected
+                    } else {
+                        false
+                    };
+                    if still_default_shim {
+                        return f64::from_bits(TAG_FALSE);
+                    }
                 }
             }
         }

--- a/crates/perry-runtime/src/object/object_ops/has_own.rs
+++ b/crates/perry-runtime/src/object/object_ops/has_own.rs
@@ -234,6 +234,34 @@ pub extern "C" fn js_object_has_own(obj_value: f64, key_value: f64) -> f64 {
             return f64::from_bits(TAG_FALSE);
         }
 
+        // `%Function.prototype%` is an ordinary object — `is_closure_ptr` is
+        // false for it, so the closure branch above never sees it — but it's
+        // installed with a full set of generic `Object.prototype` methods as
+        // real own data properties so they dispatch when called directly on
+        // it. Per spec (20.2.3) it only *inherits* these from
+        // `Object.prototype`; they are not its own. Reject the known shim
+        // keys here, before the generic `own_key_present` keys_array scan
+        // below would find them installed and report `true` (test262
+        // built-ins/Function/prototype/S15.3.4_A4).
+        if super::super::global_this::is_function_prototype_object_value(obj_value) {
+            if let Some(key) = super::super::has_own_helpers::str_from_string_header(key_str) {
+                if matches!(
+                    key,
+                    "hasOwnProperty"
+                        | "isPrototypeOf"
+                        | "propertyIsEnumerable"
+                        | "toLocaleString"
+                        | "valueOf"
+                        | "__defineGetter__"
+                        | "__defineSetter__"
+                        | "__lookupGetter__"
+                        | "__lookupSetter__"
+                ) {
+                    return f64::from_bits(TAG_FALSE);
+                }
+            }
+        }
+
         if (*obj).class_id == super::super::native_module::NATIVE_MODULE_CLASS_ID {
             let present = super::super::native_module::read_native_module_name(obj)
                 .as_deref()


### PR DESCRIPTION
## Summary

Fixes 7 of the 23 self-contained test262 `built-ins/Function` cases tracked in #5846 (`435→442` pass, parity `95.2%→96.7%`, zero regressions against the original 22-failure baseline). Code-only PR per the issue's instructions — no version bump / CHANGELOG entry.

### Fixed

- **Bound-function `[[Construct]]`/newTarget cascade** (`BoundFunctionExoticObjects` 10.4.1.2). `new boundFn()` and `Reflect.construct(boundFn, args, nt)` now unwind through any depth of `.bind()` layers — prepending each layer's bound args and resolving `newTarget` per spec — before re-dispatching construction on the real target.
  - `bind/instance-construct-newtarget-boundtarget-bound.js`
  - `bind/instance-construct-newtarget-self-new.js`
  - `bind/instance-construct-newtarget-self-reflect.js`
  - `bind/S15.3.4.5_A5.js` (bind curries `[[Construct]]` onto a native constructor like `Date`)
- **`Function.prototype = someOtherFunction` reassignment silently dropped.** `js_set_function_prototype` only handled a plain-object/array prototype value; a closure-typed one fell through its GC-type guard untouched.
- **Concise/object-literal method `toString`.** Now retains the method's own source (`PropertyName ( params ) { body }`) instead of a synthesized native-code fallback — needed because that source is itself used as a `ToPropertyKey` coercion target elsewhere. Scoped to non-async/non-generator methods (those already passed via the loose NativeFunction-syntax fallback; correctly including a leading `async`/`*` modifier in the span needs more work).
  - `toString/method-computed-property-name.js`
- **`GeneratorFunction`/`AsyncFunction`/`AsyncGeneratorFunction` recognition** now covers the standard `Object.getPrototypeOf(fnLiteral).constructor` idiom (previously only `fnLiteral.constructor` was recognized).
  - `toString/GeneratorFunction.js`
- **`Function.prototype.hasOwnProperty` false positive** on Object.prototype-inherited method names (`valueOf`, `isPrototypeOf`, etc. — installed as real dynamic props on the singleton for dispatch, but inherited, not own). Partial fix — `prototype/S15.3.4_A4.js`'s first assertion now passes; a separate assertion about shared closure identity is unrelated and still open.
- **`apply()`'s array-like coercion** (`CreateListFromArrayLike`) had two separate implementations, both limited to real Arrays/arguments objects. The direct-dispatch path (hit by a literal `fn.apply(...)` call site) read the array-like's raw pointer as an `ArrayHeader` — a type-confusion bug. Both now fall back to a generic `Get("length")` + indexed-`Get` walk (Proxy-trap aware), so a throwing trap propagates as the abrupt completion the spec requires.
  - `apply/get-index-abrupt.js`

### Known still-open (documented, not attempted here)

- `S15.3_A3_T2/T5/T6` — blocked on deferred var→globalThis live reflection (tracked under #5833).
- `S15.3.2.1_A2_T6` — a Function-ctor arg-resolution const-fold bug: a compile-time-simulated `++i` counter isn't synced back to the real runtime variable.
- `15.3.5.4_2-13gs` — needs `.caller`/strict-mode poison-pill tracking, not currently modeled.
- `toString/symbol-named-builtins.js` — needs real `RegExp.prototype[Symbol.match]` / `RegExp[Symbol.species]` as callable values.
- `internals/Construct/base-ctor-revoked-proxy.js` — needs `GetFunctionRealm` semantics for a Proxy revoked via a `get`-trap side effect mid-construct.
- `bind/15.3.4.5-6-6.js`, `apply/S15.3.4.3_A1_T1.js`, `call/S15.3.4.4_A1_T1.js` — need a second prototype-chain hop for an inherited accessor property reached transitively through `%Function.prototype%`; root cause traced to `closure_get_dynamic_prop`'s expando fallback, not yet fixed.
- `bind/instance-length-default-value.js`, `apply/S15.3.4.3_A5_T4.js` — not yet root-caused.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `bash scripts/check_file_size.sh`
- [x] `python3 scripts/gc_store_site_inventory.py --self-test && python3 scripts/gc_store_site_inventory.py`
- [x] `python3 scripts/addr_class_inventory.py --self-test && python3 scripts/addr_class_inventory.py`
- [x] `scripts/test262_subset.py --dir built-ins/Function` — 442 pass / 15 fail (was 435/22), zero regressions vs. baseline
- [x] `cargo check -p perry-runtime -p perry-hir`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved spec-aligned handling of array-like inputs in `Function.prototype.apply`, converting them via `CreateListFromArrayLike` rather than assuming true Arrays.

* **Bug Fixes**
  * Fixed `Function.prototype.toString` output for certain object-literal methods to preserve correct formatting.
  * Corrected constructor behavior for bound functions across `new` and `Reflect.construct`, including proper `new.target`.
  * Fixed `prototype` property persistence when assigning function values.
  * Corrected `Object.hasOwn(Function.prototype, <shimKey>)` for shim properties so inheritance is reported accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->