### PR TITLE
fix(deps): pin bson to mongodb's re-exported major — restores the extended CI gate (#5872)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,16 @@ updates:
     # aes-gcm 0.11 lands and the whole AEAD surface can move in one PR.
     # Patch bumps still flow through.
     ignore:
+      # bson must stay on the major that `mongodb` re-exports (mongodb 3.x
+      # -> bson 2.x): perry-stdlib/perry-ext-mongodb build `bson::Document`s
+      # and pass them into mongodb APIs, so a solo bson major bump splits
+      # the graph into TWO bson versions and every mongodb call fails E0308
+      # ("expected mongodb::bson::Document, found bson::Document") — but
+      # only in the feature-gated bundled-mongodb builds (parity/smokes),
+      # never default cargo-test. Bump bson together with a mongodb major
+      # that re-exports it (#5872).
+      - dependency-name: "bson"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "aes"
         update-types: ["version-update:semver-minor"]
       - dependency-name: "aes-gcm"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,27 +841,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bson"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3f109694c4f45353972af96bf97d8a057f82e2d6e496457f4d135b9867a518c"
-dependencies = [
- "ahash 0.8.12",
- "base64",
- "bitvec",
- "getrandom 0.3.4",
- "hex",
- "indexmap",
- "js-sys",
- "rand 0.9.4",
- "serde_bytes",
- "simdutf8",
- "thiserror 2.0.18",
- "time",
- "uuid",
-]
-
-[[package]]
 name = "built"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4603,7 +4582,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da0cd419a51a5fb44819e290fbdb0665a54f21dead8923446a799c7f4d26ad9"
 dependencies = [
- "bson 2.15.0",
+ "bson",
  "mongocrypt-sys",
  "once_cell",
  "serde",
@@ -4623,7 +4602,7 @@ checksum = "276ba0cd571553d1f6936c6f180964776ece6ab7507dc8765f8a9c9c49d8cd00"
 dependencies = [
  "base64",
  "bitflags 2.12.1",
- "bson 2.15.0",
+ "bson",
  "derive-where",
  "derive_more",
  "futures-core",
@@ -5797,7 +5776,7 @@ dependencies = [
 name = "perry-ext-mongodb"
 version = "0.5.1217"
 dependencies = [
- "bson 3.1.0",
+ "bson",
  "futures-util",
  "mongodb",
  "perry-ffi",
@@ -6028,7 +6007,7 @@ dependencies = [
  "base64",
  "bcrypt",
  "brotli",
- "bson 3.1.0",
+ "bson",
  "bytes",
  "cbc",
  "chacha20poly1305",

--- a/crates/perry-ext-mongodb/Cargo.toml
+++ b/crates/perry-ext-mongodb/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["staticlib", "rlib"]
 [dependencies]
 perry-ffi.workspace = true
 mongodb = { version = "3.7", default-features = false, features = ["compat-3-0-0", "rustls-tls", "dns-resolver"] }
-bson = "3.1"
+bson = "2.15"
 tokio = { workspace = true }
 futures-util = "0.3"
 serde_json = "1"

--- a/crates/perry-stdlib/Cargo.toml
+++ b/crates/perry-stdlib/Cargo.toml
@@ -378,7 +378,7 @@ rustls-pemfile = { version = "2", optional = true }
 sqlx = { version = "0.9.0", default-features = false, features = ["runtime-tokio", "mysql", "postgres", "chrono"], optional = true }
 redis = { version = "1.2", features = ["tokio-comp", "connection-manager"], optional = true }
 mongodb = { version = "3.7", default-features = false, features = ["compat-3-0-0", "rustls-tls", "dns-resolver"], optional = true }
-bson = { version = "3.1", optional = true }
+bson = { version = "2.15", optional = true }
 rusqlite = { version = "0.37", features = ["bundled", "column_decltype", "limits", "session"], optional = true }
 
 # Crypto


### PR DESCRIPTION
Restores the extended CI gate (addresses the build-breakage half of #5872).

## What broke

#5830 bumped the direct `bson` dependency 2.15 → 3.1, but `mongodb 3.7` still re-exports **bson 2.x**. perry-stdlib/perry-ext-mongodb build `bson::Document`s from the direct crate and pass them into mongodb APIs, so the graph now carried TWO bson versions and every mongodb call failed:

```
error[E0308]: mismatched types — expected `mongodb::bson::Document`, found `bson::Document`
note: there are multiple different versions of crate `bson` in the dependency graph
```

Default builds never compile the mongodb module (it's behind the `bundled-mongodb` feature), so `cargo-test`/`lint` stayed green while **parity, every smoke, gc-stress, and doc-tests failed to build** — since 09:10Z the entire extended gate has been blind (zero parity tests executed on any labeled run; see #5872 for the log evidence from PR #5885's run).

## Fix

- Pin `bson = "2.15"` in `perry-stdlib` and `perry-ext-mongodb` — the lockfile unifies back to a single bson version.
- Add a `dependabot.yml` ignore for bson **semver-major** bumps with the rationale inline (same pattern as the AEAD-stack block): bson must move together with a mongodb major that re-exports it.

## Follow-ups (tracked on #5872)

- Durable fix: import `mongodb::bson` instead of the direct crate in mongodb-facing code, so a solo bson bump can't split the graph.
- #5872's other signature — the issue-945 scalar-method IR guard failing in compile-smoke — **predates** the bson bump (it fired 2026-07-02 on a successfully-built binary) and remains open after this lands.

## Verification

The previously-failing jobs are the test: this PR carries the `run-extended-tests` label, so parity/smokes/doc-tests must now build and run again. (`compile-smoke` is expected to fail on the pre-existing scalar-guard signature — that's the remaining half of #5872.)

Code-only PR: no version bump / changelog (folded at merge).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Aligned BSON dependency versions across components to match supported MongoDB compatibility.
  * Updated automated dependency update rules to avoid unnecessary major-version upgrade suggestions for BSON.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->