### PR TITLE
fix(http): gate reqwest proxy env on NODE_USE_ENV_PROXY to match Node

### DIFF
--- a/crates/perry-ext-http/src/agent.rs
+++ b/crates/perry-ext-http/src/agent.rs
@@ -210,12 +210,14 @@ pub(crate) fn client_for_agent(handle: Handle) -> reqwest::Client {
         std::time::Duration::from_millis(0)
     };
 
-    let built = reqwest::Client::builder()
-        .pool_max_idle_per_host(pool_max_idle)
-        .pool_idle_timeout(idle_timeout)
-        .tcp_keepalive(std::time::Duration::from_secs(60))
-        .build()
-        .unwrap_or_else(|_| reqwest::Client::new());
+    let built = crate::apply_node_proxy_policy(
+        reqwest::Client::builder()
+            .pool_max_idle_per_host(pool_max_idle)
+            .pool_idle_timeout(idle_timeout)
+            .tcp_keepalive(std::time::Duration::from_secs(60)),
+    )
+    .build()
+    .unwrap_or_else(|_| crate::default_client());
 
     let mut cache = AGENT_CLIENTS.lock().unwrap();
     cache.entry(handle).or_insert(built).clone()

--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -231,17 +231,72 @@ pub extern "C" fn js_ext_http_client_inflight() -> i32 {
         .clamp(0, i32::MAX as i64) as i32
 }
 
+/// Pure predicate behind [`node_env_proxy_enabled`]. Node treats its
+/// `NODE_*` boolean env vars as enabled only when the value is exactly `"1"`.
+/// Split out so the policy is unit-testable without mutating process env.
+fn proxy_enabled_from_env_value(value: Option<&str>) -> bool {
+    value == Some("1")
+}
+
+/// Whether Node's `--use-env-proxy` / `NODE_USE_ENV_PROXY=1` is active.
+///
+/// Node's built-in `fetch` and `node:http`/`node:https` ignore the standard
+/// `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` env vars unless this is set. perry
+/// mirrors that opt-in so its bindings are Node-conformant — reqwest would
+/// otherwise honor the proxy env unconditionally, diverging from Node.
+fn node_env_proxy_enabled() -> bool {
+    proxy_enabled_from_env_value(std::env::var("NODE_USE_ENV_PROXY").ok().as_deref())
+}
+
+/// Apply the Node-conformant proxy policy to a reqwest client builder: honor
+/// the standard proxy env vars only when `NODE_USE_ENV_PROXY=1`, matching Node.
+pub(crate) fn apply_node_proxy_policy(
+    builder: reqwest::ClientBuilder,
+) -> reqwest::ClientBuilder {
+    if node_env_proxy_enabled() {
+        builder
+    } else {
+        builder.no_proxy()
+    }
+}
+
+/// A default reqwest client with the Node-conformant proxy policy applied.
+/// Used as the fallback when a customized builder fails to build.
+pub(crate) fn default_client() -> reqwest::Client {
+    apply_node_proxy_policy(reqwest::Client::builder())
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new())
+}
+
+#[cfg(test)]
+mod proxy_policy_tests {
+    use super::proxy_enabled_from_env_value;
+
+    #[test]
+    fn env_proxy_enabled_only_for_exactly_one() {
+        // Matches Node's NODE_USE_ENV_PROXY parsing: enabled iff "1".
+        assert!(proxy_enabled_from_env_value(Some("1")));
+        assert!(!proxy_enabled_from_env_value(None));
+        assert!(!proxy_enabled_from_env_value(Some("0")));
+        assert!(!proxy_enabled_from_env_value(Some("")));
+        assert!(!proxy_enabled_from_env_value(Some("true")));
+        assert!(!proxy_enabled_from_env_value(Some("2")));
+    }
+}
+
 lazy_static! {
     static ref HTTP_PENDING_EVENTS: Mutex<Vec<PendingHttpEvent>> = Mutex::new(Vec::new());
     /// Shared HTTP client — reuses connection pool, DNS cache, TLS
     /// session cache. Without this each request allocs a fresh
     /// reqwest::Client (~250 KB) and the memory never gets reused.
-    pub(crate) static ref HTTP_CLIENT: reqwest::Client = reqwest::Client::builder()
-        .pool_idle_timeout(std::time::Duration::from_secs(90))
-        .pool_max_idle_per_host(16)
-        .tcp_keepalive(std::time::Duration::from_secs(60))
-        .build()
-        .unwrap_or_else(|_| reqwest::Client::new());
+    pub(crate) static ref HTTP_CLIENT: reqwest::Client = apply_node_proxy_policy(
+        reqwest::Client::builder()
+            .pool_idle_timeout(std::time::Duration::from_secs(90))
+            .pool_max_idle_per_host(16)
+            .tcp_keepalive(std::time::Duration::from_secs(60)),
+    )
+    .build()
+    .unwrap_or_else(|_| default_client());
 }
 
 static HTTP_GC_REGISTERED: Once = Once::new();

--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -250,9 +250,7 @@ fn node_env_proxy_enabled() -> bool {
 
 /// Apply the Node-conformant proxy policy to a reqwest client builder: honor
 /// the standard proxy env vars only when `NODE_USE_ENV_PROXY=1`, matching Node.
-pub(crate) fn apply_node_proxy_policy(
-    builder: reqwest::ClientBuilder,
-) -> reqwest::ClientBuilder {
+pub(crate) fn apply_node_proxy_policy(builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
     if node_env_proxy_enabled() {
         builder
     } else {

--- a/crates/perry-ext-http/src/tls_client.rs
+++ b/crates/perry-ext-http/src/tls_client.rs
@@ -82,8 +82,9 @@ impl TlsOptions {
         &self,
         pool: Option<(bool, f64, f64)>,
     ) -> Result<reqwest::Client, String> {
-        let mut builder =
-            reqwest::Client::builder().tcp_keepalive(std::time::Duration::from_secs(60));
+        let mut builder = crate::apply_node_proxy_policy(
+            reqwest::Client::builder().tcp_keepalive(std::time::Duration::from_secs(60)),
+        );
 
         if self.accept_invalid_certs() {
             builder = builder.danger_accept_invalid_certs(true);


### PR DESCRIPTION
## Problem

perry's `node:http`/`node:https`/`fetch` bindings build their clients with `reqwest::Client::builder()` / `Client::new()` and never call `.no_proxy()`. reqwest honors `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY`/`NO_PROXY` **by default**, so perry routes through the proxy unconditionally.

Real Node's built-in `fetch` (undici) and `node:http`/`node:https` **ignore** those env vars unless `--use-env-proxy` / `NODE_USE_ENV_PROXY=1` is set (added in Node 24). Verified on Node v24.10.0 — without the flag, `fetch`/`http.get` connect directly; with it, they route through `HTTP_PROXY`.

So a program that does `fetch(url)` with `HTTP_PROXY` in the environment behaves differently on perry (uses the proxy) than on Node (ignores it) — a conformance divergence.

## Fix

Gate the proxy-env behavior on `NODE_USE_ENV_PROXY`, matching Node's opt-in. Client builders in `perry-ext-http` now route through a small `apply_node_proxy_policy(builder)` helper that calls `.no_proxy()` by default and only leaves reqwest's env-proxy on when `NODE_USE_ENV_PROXY=1`. Applied at the three client-construction sites: the shared `HTTP_CLIENT`, per-agent clients (`agent.rs`), and per-request TLS clients (`tls_client.rs`), plus a policy-applied `default_client()` fallback.

## Scope

`perry-ext-http` only — the `node:http`/`https`/`fetch` bindings, where Node conformance matters. `perry-ext-axios` and the `audit` CLI also use reqwest; left as follow-ups since they aren't `node:*` module surfaces.

## Test

Pure unit test (`proxy_policy_tests`) covering the parsing — enabled iff the value is exactly `"1"`, matching Node's `NODE_*` boolean-env convention. `cargo test -p perry-ext-http` passes.

## Notes

- `NODE_USE_ENV_PROXY` covers `fetch`/`http`/`https`, not raw sockets — same as Node.
- The flag is experimental in Node 24; this just mirrors its semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated HTTP client creation to align proxy handling with Node-style behavior, honoring standard environment proxy variables only when explicitly enabled.
  * Improved error-path fallback so, if client setup fails, the fallback uses the same proxy policy rather than defaulting to a bare client.
  * Applied the same proxy-policy logic when building TLS-enabled clients to keep behavior consistent.
* **Tests**
  * Added coverage for the opt-in proxy environment value interpretation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->