### PR TITLE
fix(link): #5892 — keep perry_ffi test shims out of production ext archives

### DIFF
--- a/crates/perry-ext-http-server/src/lib.rs
+++ b/crates/perry-ext-http-server/src/lib.rs
@@ -70,6 +70,7 @@ mod response;
 mod response_fast;
 mod server;
 #[cfg(test)]
+#[cfg(test)]
 mod test_async_shims;
 mod tls;
 mod types;

--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -1812,6 +1812,7 @@ mod tests;
 // Test-only `perry_ffi_*` async-bridge shims so the lib test links without the
 // host stdlib archive (mirrors perry-ext-net / perry-ext-http-server).
 #[cfg(test)]
+#[cfg(test)]
 mod test_async_shims;
 
 // Suppress unused-import warnings for FFI-only types.


### PR DESCRIPTION
Fixes #5892.

## Root cause

`perry-ext-http` and `perry-ext-http-server` ship their `test_async_shims` modules in production archives — the `mod` declaration is missing the `#[cfg(test)]` gate that **perry-ext-net already has**. The shims define the same `#[no_mangle]` C symbols as perry-stdlib's real perry-ffi async bridge with catastrophically different semantics:

- `perry_ffi_spawn_blocking_with_reactor` / `perry_ffi_spawn_blocking` → run the closure **inline**: no runtime context, no `ensure_pump_registered()`, so the **#5831 wait-driver never registers**
- `perry_ffi_spawn_async` → **no-op that silently drops the task**

When the linker resolves these from an ext archive instead of `libperry_stdlib.a` (single-pass archive scan; the referencing member and the shim member sit in the *same* archive), the current-thread runtime is never driven: `js_wait_for_event` falls back to the 1 s condvar park and any in-process server+client program parks forever. The auto-opt compile path is immune because strip-dedup (#5000/#5685) localizes duplicate wrapper globals — which is why only the cargo-test/debug-driver path hangs.

## Evidence (hang-lab, `debug/5892-hang-lab` branch)

- Hung binary: single thread, timed futex cycling every ~1 s (condvar fallback), server LISTENing, **zero client connections** — spawned tasks never ran (runs 28664851669, 28665408372)
- Binary-corruption and self-deadlock hypotheses eliminated (identical md5 on clean recompile; timed not infinite futex)
- With this gate: single-run repro clean + **6/6 exact cargo-test iterations clean** vs hang-on-iteration-1 in three consecutive ungated runs (run 28669296187)
- A same-run A/B (ungated loop → gate → loop) is running now for final causality confirmation; will post results here

## Impact

Unblocks: nightly full-workspace cargo-test (red since ~Jun 21 from this + the pre-#5831 write_end flake family), release-tag Tests gates, and restores real async dispatch semantics to any natively-compiled binary whose link picked the shims (`spawn_async` dropping tasks silently is not test-only behavior anyone wants in the field).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test-only code to compile conditionally in two components.
  * No user-facing behavior, APIs, or runtime functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->