### PR TITLE
fix(compile): #5918 — import_function_prefixes collides on exported name across unrelated imports

### DIFF
--- a/crates/perry/src/commands/compile/run_pipeline.rs
+++ b/crates/perry/src/commands/compile/run_pipeline.rs
@@ -2668,9 +2668,30 @@ pub fn run_with_parse_cache(
                         source_prefix.clone()
                     };
 
-                    import_function_prefixes
-                        .insert(exported_name.clone(), effective_prefix.clone());
-                    if local_name != exported_name {
+                    // Issue #<TBD>: only key by `exported_name` in the
+                    // no-rename case (`local_name == exported_name`), where
+                    // the HIR's `ExternFuncRef` genuinely carries that
+                    // string. In the aliased case (#35/#321 above:
+                    // `ExternFuncRef` carries the LOCAL name, unique per
+                    // import site), inserting under `exported_name` too is
+                    // not just redundant — `exported_name` is whatever the
+                    // ORIGIN module happens to call it, so it can collide
+                    // with an unrelated LOCAL alias elsewhere in the same
+                    // file. Concrete repro: `import { a as n, c as a } from
+                    // "./x"; import { a as t } from "./y"` — the second
+                    // specifier's exported name "a" overwrote the first
+                    // import's *local* alias "a" (from `c as a`), silently
+                    // repointing `ExternFuncRef { name: "a" }` at module y
+                    // instead of x. Only inserting the ALIASED case under
+                    // `local_name` (never also under `exported_name`) keeps
+                    // every key in this map unique per file — local names
+                    // can't collide with each other (each `let`/import
+                    // binding needs a distinct identifier), but exported
+                    // names from different source modules can and do.
+                    if local_name == exported_name {
+                        import_function_prefixes
+                            .insert(exported_name.clone(), effective_prefix.clone());
+                    } else {
                         import_function_prefixes
                             .insert(local_name.clone(), effective_prefix.clone());
                     }

--- a/test-files/fixtures/issue_5918_pkg/chunk_anxbdsui.ts
+++ b/test-files/fixtures/issue_5918_pkg/chunk_anxbdsui.ts
@@ -1,0 +1,9 @@
+// Mirrors remeda's dist/chunk-ANXBDSUI.js shape (shared "done"/"hasNext"
+// iterator-result singletons + constructors). Exports THREE bindings under
+// short names "a"/"b"/"c" — "c" is the one a sibling chunk's local alias
+// "a" will point at, which is what the colliding-key bug clobbers.
+const e = { done: true, hasNext: false }
+const s = { done: false, hasNext: false }
+const a = () => e
+const o = (t: unknown) => ({ hasNext: true, next: t, done: false })
+export { s as a, a as b, o as c }

--- a/test-files/fixtures/issue_5918_pkg/chunk_d6fck2ga.ts
+++ b/test-files/fixtures/issue_5918_pkg/chunk_d6fck2ga.ts
@@ -1,0 +1,9 @@
+// Mirrors remeda's dist/chunk-D6FCK2GA.js shape (a `purry`-style curry
+// helper). Exported under the short, minifier-style name "a" on purpose —
+// the bug this fixture reproduces only fires when multiple chunks in the
+// same import graph happen to export under colliding short names.
+function u(o: (...args: any[]) => any, n: any[], a: unknown) {
+  const t = (r: any) => o(r, ...n)
+  return a === void 0 ? t : Object.assign(t, { lazy: a, lazyArgs: n })
+}
+export { u as a }

--- a/test-files/fixtures/issue_5918_pkg/chunk_wimgwyzl.ts
+++ b/test-files/fixtures/issue_5918_pkg/chunk_wimgwyzl.ts
@@ -1,0 +1,14 @@
+// Mirrors remeda's dist/chunk-WIMGWYZL.js shape (arity-dispatching purry
+// core). Imports "a" from chunk_d6fck2ga (renamed to "t" here) and
+// exports its own "u" as "a" — this file's EXPORTED name "a" is the one
+// that, pre-fix, clobbered an unrelated LOCAL alias "a" in a sibling
+// chunk that also imports from here.
+import { a as t } from "./chunk_d6fck2ga.ts"
+
+function u(r: (...args: any[]) => any, n: any[], o: unknown): any {
+  const a = r.length - n.length
+  if (a === 0) return r(...n)
+  if (a === 1) return t(r, n, o)
+  throw new Error("Wrong number of arguments")
+}
+export { u as a }

--- a/test-files/fixtures/issue_5918_pkg/chunk_wmcgp7py.ts
+++ b/test-files/fixtures/issue_5918_pkg/chunk_wmcgp7py.ts
@@ -1,0 +1,26 @@
+// Mirrors remeda's dist/chunk-WMCGP7PY.js shape (a `dropFirstBy`-style
+// helper built on the two chunks above). This is where issue #5918 fires:
+//
+//   import { a as n, c as a } from "./chunk_anxbdsui.ts"   <- local "a" -> anxbdsui's "c"
+//   import { a as t } from "./chunk_wimgwyzl.ts"           <- EXPORTED name "a" (wimgwyzl's)
+//
+// Pre-fix, `import_function_prefixes` was keyed by BOTH the local alias
+// AND the exported/origin name for every named import. The second
+// import's exported name "a" (from chunk_wimgwyzl) overwrote the first
+// import's *local* alias "a" (bound to chunk_anxbdsui's "c") in that same
+// map, so codegen resolved local `a` — used inside `o` below — against
+// chunk_wimgwyzl instead of chunk_anxbdsui, which doesn't export anything
+// named "c" there. Link failure ensued.
+import { a as n, c as a } from "./chunk_anxbdsui.ts"
+import { a as t } from "./chunk_wimgwyzl.ts"
+
+function s(...e: unknown[]) {
+  return t(p, e, o)
+}
+const p = (e: unknown[], r: number) => (r < 0 ? [...e] : e.slice(r))
+function o(e: number): any {
+  if (e <= 0) return a
+  let r = e
+  return (i: unknown) => (r > 0 ? ((r -= 1), n) : { done: false, hasNext: true, next: i })
+}
+export { s as a }

--- a/test-files/test_issue_5918_import_prefix_name_collision.ts
+++ b/test-files/test_issue_5918_import_prefix_name_collision.ts
@@ -1,0 +1,17 @@
+// Issue #5918 — `import_function_prefixes` was keyed by both the local
+// alias AND the exported/origin name for every named import. The origin
+// name isn't unique per file (it's whatever the SOURCE module happens to
+// call it), so two unrelated imports in the same file whose origin names
+// collide (very common in minifier/esbuild chunk-splitting output, where
+// nearly everything is named "a"/"b"/"c") silently overwrite each other's
+// map entry — even when the collision has nothing to do with the local
+// alias the HIR's `ExternFuncRef` actually carries.
+//
+// This shape is lifted directly from `remeda`'s real (unmodified)
+// dist/chunk-*.js build output — found via a real-world source compile of
+// `sst/opencode`, where nearly every remeda function transitively imports
+// these exact four chunks.
+import { a as dropFrom } from "./fixtures/issue_5918_pkg/chunk_wmcgp7py.ts"
+
+console.log(JSON.stringify(dropFrom([1, 2, 3, 4, 5], 2)))
+console.log(JSON.stringify(dropFrom([1, 2, 3, 4, 5], -1)))


### PR DESCRIPTION
Fixes #5918.

## Problem

`import_function_prefixes` (imported name → source module prefix, consumed by `ExternFuncRef` codegen to form `perry_fn_<prefix>__<name>`) was populated by inserting **both** the exported/origin name and the local alias for every renamed `Named` import:

```rust
import_function_prefixes.insert(exported_name.clone(), effective_prefix.clone());
if local_name != exported_name {
    import_function_prefixes.insert(local_name.clone(), effective_prefix.clone());
}
```

Per the #35/#321 precedent right above this in the same function, a renamed import's `Expr::ExternFuncRef` in the HIR always carries the **local** name (unique per import site) — the `exported_name` insert only ever mattered in the no-rename case (`local == exported`).

Running it unconditionally meant: when two different import statements in the same file rename to different locals from modules whose *origin* export names happen to collide (very common with short, minifier-style names — exactly what esbuild's chunk-splitting produces), the second insert silently overwrote the first's entry, even repointing a completely unrelated local alias at the wrong module.

## Real-world impact

Found via a real-world source compile of `sst/opencode` with `perry.compilePackages: ["*"]`. `remeda`'s real, unmodified `dist/chunk-*.js` build output has this exact 4-chunk collision shape, and nearly every remeda function transitively imports the affected chunks — this single bug blocked the entire package from linking.

## Fix

Only insert under `exported_name` when `local_name == exported_name`; the aliased case inserts under `local_name` only. This keeps every key in the map unique per file — local identifiers can't collide with each other within one file, but export names from different origin modules can and do.

## Testing

- Added `test_issue_5918_import_prefix_name_collision.ts` + a 4-file fixture reproducing the exact collision shape (lifted directly from remeda's real build output). Output verified byte-for-byte against `node --experimental-strip-types`.
- Verified the three existing tests covering this same code path are unaffected: `test_gap_renamed_class_export_namespace.ts`, `test_issue_836_zod_class_reexports.ts`, `test_issue_678_reexport_default.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where aliased imports could conflict with other imports in the same module, causing incorrect resolution at runtime.
  * Improved handling of import name collisions so aliased symbols remain stable and deterministic.

* **Tests**
  * Added regression coverage for the import alias collision scenario.
  * Added supporting test fixtures to simulate the affected module shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->