### PR TITLE
fix(transform): #5925 — keep comma-sequence operands ahead of hoisted awaits

### DIFF
--- a/crates/perry-transform/src/async_to_generator.rs
+++ b/crates/perry-transform/src/async_to_generator.rs
@@ -633,6 +633,18 @@ fn hoist_awaits_in_expr_full(expr: &mut Expr, next_id: &mut LocalId, hoisted: &m
         lift_logical_with_await_rhs(expr, next_id, hoisted);
         return;
     }
+    // A sequence like `this.l = new L, this.p = await this.l.start()`
+    // would otherwise have the await hoisted above the containing
+    // statement, evaluating the awaited operand BEFORE the sequence's
+    // earlier operands ran — the awaited receiver reads its
+    // pre-assignment value (issue #5925; minifiers emit this shape
+    // constantly). Lift the non-final operands to statements first, in
+    // evaluation order, then continue with the final operand.
+    if matches!(expr, Expr::Sequence(_)) && expr_contains_await(expr) {
+        lift_sequence_with_await(expr, next_id, hoisted);
+        hoist_awaits_in_expr_full(expr, next_id, hoisted);
+        return;
+    }
     // Recurse into children first (innermost-first hoisting).
     perry_hir::walker::walk_expr_children_mut(expr, &mut |child| {
         hoist_awaits_in_expr_full(child, next_id, hoisted);
@@ -765,11 +777,47 @@ fn hoist_awaits_avoiding_top_level(
         lift_logical_with_await_rhs(expr, next_id, hoisted);
         return;
     }
+    // Top-level sequence with an await, e.g. the minified
+    // `this.l = new L, this.p = await this.l.start();` — see the matching
+    // note in `hoist_awaits_in_expr_full` (issue #5925). Lift the earlier
+    // operands to statements, then re-process the final operand as the new
+    // top-level expression (it may itself be a directly-handled await).
+    if matches!(expr, Expr::Sequence(_)) && expr_contains_await(expr) {
+        lift_sequence_with_await(expr, next_id, hoisted);
+        hoist_awaits_avoiding_top_level(expr, next_id, hoisted);
+        return;
+    }
     // Outer is NOT an await. Children may contain awaits which ARE
     // nested — fully hoist them.
     perry_hir::walker::walk_expr_children_mut(expr, &mut |child| {
         hoist_awaits_in_expr_full(child, next_id, hoisted);
     });
+}
+
+/// Lift a sequence (comma) expression's non-final operands into statements
+/// pushed onto `hoisted`, leaving `expr` as the final operand (issue #5925).
+///
+/// Each lifted operand is itself fully hoisted first, so awaits inside
+/// earlier operands suspend in evaluation order, before anything in the
+/// final operand. With the operands lifted, the `let __await_N = await …`
+/// the caller hoists for the final operand lands AFTER them — preserving JS
+/// comma semantics (`a = new X, b = await a.m()` must run the assignment
+/// before evaluating `a.m()`), where previously the await jumped the whole
+/// sequence.
+fn lift_sequence_with_await(expr: &mut Expr, next_id: &mut LocalId, hoisted: &mut Vec<Stmt>) {
+    let Expr::Sequence(ops) = expr else {
+        return;
+    };
+    let mut ops = std::mem::take(ops);
+    let Some(last) = ops.pop() else {
+        *expr = Expr::Undefined;
+        return;
+    };
+    for mut op in ops {
+        hoist_awaits_in_expr_full(&mut op, next_id, hoisted);
+        hoisted.push(Stmt::Expr(op));
+    }
+    *expr = last;
 }
 
 /// Returns true if either branch of `expr` (assumed `Expr::Conditional`)

--- a/crates/perry/tests/issue_5925_seq_await_order.rs
+++ b/crates/perry/tests/issue_5925_seq_await_order.rs
@@ -1,0 +1,140 @@
+//! Regression test for #5925: an await inside a comma-sequence was hoisted
+//! above the containing statement, so the awaited operand evaluated BEFORE
+//! the sequence's earlier operands ran. The minified shape
+//! `this.l = new L, this.p = await this.l.start()` then read `this.l`'s
+//! pre-assignment value (`null`) and threw
+//! "Cannot read properties of null (reading 'start')" — while node prints
+//! the awaited result. Minifiers comma-fold consecutive statements, so any
+//! `const x = new X(); const y = await x.m();` pair in bundled async code
+//! hits this.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+/// The #5925 shape: assignment comma-chained with an await whose receiver is
+/// the just-assigned field. Pre-fix: "ERR TypeError: Cannot read properties
+/// of null (reading 'start')".
+#[test]
+fn seq_assignment_runs_before_awaited_receiver_read() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+class Listener {
+  async start() {
+    return 42;
+  }
+}
+
+class Flow {
+  authCodeListener: any = null;
+  port: any = null;
+
+  async go() {
+    this.authCodeListener = new Listener, this.port = await this.authCodeListener.start();
+    return this.port;
+  }
+}
+
+const f = new Flow();
+f.go()
+  .then((v) => console.log("GOT", v))
+  .catch((e) => console.log("ERR", String(e)));
+"#,
+    );
+    assert!(
+        stdout.contains("GOT 42"),
+        "sequence operand must run before the awaited receiver is read\nstdout:\n{stdout}"
+    );
+}
+
+/// Sequences in let-init and return position, and awaits in an EARLIER
+/// operand: all operands must still run in evaluation order.
+#[test]
+fn seq_await_order_let_return_and_early_operand() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const order: string[] = [];
+
+async function tag(name: string, v: number) {
+  order.push(name);
+  return v;
+}
+
+let sink = 0;
+
+async function letInit() {
+  // let-init position: seq's first operand must run before the awaited call
+  let x = (sink = 7, await tag("after-sink", sink + 1));
+  return x;
+}
+
+async function returnPos() {
+  // return position, await in the EARLIER operand too
+  return (await tag("first", 1), sink = 9, await tag("second", sink + 1));
+}
+
+async function main() {
+  const a = await letInit();
+  console.log("LET", a, "sink", sink);
+  const b = await returnPos();
+  console.log("RET", b, "sink", sink);
+  console.log("ORDER", order.join(","));
+}
+
+main().catch((e) => console.log("ERR", String(e)));
+"#,
+    );
+    assert!(
+        stdout.contains("LET 8 sink 7"),
+        "let-init sequence must assign before the await\nstdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("RET 10 sink 9"),
+        "return-position sequence must evaluate operands in order\nstdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("ORDER after-sink,first,second"),
+        "awaits must run in source evaluation order\nstdout:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Problem — #5925

The plain-async pre-pass hoists every nested `Expr::Await` into a `let __await_N = await <operand>;` **above the containing statement**. For a comma sequence, that moves the awaited operand's evaluation above the sequence's earlier operands:

```ts
this.authCodeListener = new Listener, this.port = await this.authCodeListener.start();
```

hoists to (pre-fix):

```
let __await_N = await this.authCodeListener.start();   // reads the field's PRE-assignment value: null
this.authCodeListener = new Listener, this.port = __await_N;
```

- node: `GOT 42`
- perry-compiled: `ERR TypeError: Cannot read properties of null (reading 'start')`

Minifiers comma-fold consecutive statements, so any `const x = new X(); const y = await x.m();` pair in bundled async code hits this — observed in a real-world 13 MB bundle where it broke an auth flow's listener startup. Conditional branches (#342) and logical RHS (#5434) already have dedicated lifts for this class of unsound hoist; `Expr::Sequence` had none. Reproduces on current `origin/main` (v0.5.1219).

## Fix

`lift_sequence_with_await`: when a sequence contains an await, lift the non-final operands to statements pushed onto `hoisted` (each recursively hoisted first, so awaits inside earlier operands suspend in evaluation order), leaving the final operand as the expression value. The `__await_N` let the caller hoists for the final operand then lands AFTER the lifted operands. Wired into:

- `hoist_awaits_in_expr_full` (nested sequences), and
- `hoist_awaits_avoiding_top_level` (statement-position sequences — re-processed after the lift so a final-operand await stays in the linearizer's directly-handled position).

The generator **yield** hoist (`generator/hoist_yields.rs`) has the same latent gap for `yield`-in-sequence; noted in #5925 as a follow-up rather than piggybacking untested changes here.

## Validation

- Repro passes post-fix (`GOT 42`); fails on stock main.
- New e2e tests `crates/perry/tests/issue_5925_seq_await_order.rs`:
  - the #5925 field-assignment shape (`GOT 42`);
  - sequences in let-init and return position, plus an await in an *earlier* operand — asserts values AND cross-function side-effect ordering (`ORDER after-sink,first,second`). Both pass locally with `cargo test --release -p perry --test issue_5925_seq_await_order` (2 passed).

Fixes #5925.

https://claude.ai/code/session_01K1w6WLaFNKhf4aNxeSWHy6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `await` handling in comma-separated expressions so evaluation order is preserved correctly in more cases.
  * Resolved an issue where earlier parts of a sequence could be skipped or read in the wrong order around `await`.

* **Tests**
  * Added regression coverage for sequence-and-`await` ordering in assignment, `let` initialization, and return scenarios.
  * Verified expected output order for async evaluation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->