### PR TITLE
fix(compile): #5892 — key the auto-opt build stamp on source content, not mtimes

### DIFF
--- a/crates/perry/src/commands/compile/optimized_libs.rs
+++ b/crates/perry/src/commands/compile/optimized_libs.rs
@@ -31,7 +31,8 @@ mod paths;
 pub(crate) use driver::build_optimized_libs;
 pub(crate) use freshness::{
     auto_optimized_archives_are_fresh, auto_optimized_build_stamp, auto_optimized_cache_key,
-    auto_optimized_cross_features, binding_needs_shared_tokio, resolve_auto_well_known_libs,
+    auto_optimized_cross_features, auto_optimized_source_fingerprint, binding_needs_shared_tokio,
+    resolve_auto_well_known_libs,
 };
 pub(crate) use no_auto::{
     build_missing_prebuilt_ext_lib, resolve_no_auto_optimized_libs, resolve_prebuilt_ext_libs,

--- a/crates/perry/src/commands/compile/optimized_libs/driver.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/driver.rs
@@ -583,8 +583,18 @@ pub(crate) fn build_optimized_libs(
     };
     let runtime_path = release_dir.join(runtime_name);
     let stdlib_path = release_dir.join(stdlib_name);
-    let build_stamp =
-        auto_optimized_build_stamp(&key_input, target, &cross_features, &tokio_using_bindings);
+    // Content fingerprint of the sources that land in the archives — makes the
+    // stamp (and therefore the freshness gate) immune to mtime scrambling from
+    // cache restores / fresh checkouts (#5892 layer 2, #5778 warm-cache trap).
+    let source_fingerprint =
+        auto_optimized_source_fingerprint(&workspace_root, &tokio_using_bindings);
+    let build_stamp = auto_optimized_build_stamp(
+        &key_input,
+        target,
+        &cross_features,
+        &tokio_using_bindings,
+        &source_fingerprint,
+    );
     let build_stamp_path = target_dir.join(".perry-auto-build.stamp");
 
     // Closes #25 (the v0.5.384 NJOBS 6->3 retreat): serialize parallel

--- a/crates/perry/src/commands/compile/optimized_libs/freshness.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/freshness.rs
@@ -159,14 +159,147 @@ pub(crate) fn auto_optimized_cross_features(
     cross_features
 }
 
+/// Content fingerprint of every workspace source tree that lands in the
+/// auto-optimized archives: the crates this build compiles (the runtime/stdlib
+/// static wrappers and the tokio-using ext crates) plus their transitive
+/// workspace path-deps, plus the workspace manifests. Embedded in the build
+/// stamp so a `target/perry-auto-<hash>` dir whose archives were built from
+/// DIFFERENT sources can never pass the freshness gate. The mtime check alone
+/// is blind to that: a cache restore can hand back archives "newer" than a
+/// fresh checkout's sources, and Cargo.lock carries no checksum for path deps.
+/// #5892 layer 2 — CI's rust-cache-restored stale dir kept linking pre-#5911
+/// ext archives; same key-blindness as the #5778-era "warm auto-opt cache
+/// ignores perry-ext-http edits" trap.
+pub(crate) fn auto_optimized_source_fingerprint(
+    workspace_root: &Path,
+    tokio_using_bindings: &[(String, String, Option<String>)],
+) -> String {
+    use sha2::{Digest, Sha256};
+
+    // Seed with the crates the auto-optimize cargo invocation builds directly.
+    let mut crates: BTreeSet<String> = [
+        "perry-runtime",
+        "perry-stdlib",
+        "perry-runtime-static",
+        "perry-stdlib-static",
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect();
+    for (krate, _lib, _tracking) in tokio_using_bindings {
+        crates.insert(krate.clone());
+    }
+
+    // Transitive workspace path-dep closure: any manifest token that names an
+    // existing `crates/<name>` directory is treated as a workspace crate whose
+    // source is compiled into the archives. Over-approximating (e.g. a feature
+    // named like a crate) only hashes extra source — never misses an input.
+    let mut queue: Vec<String> = crates.iter().cloned().collect();
+    while let Some(name) = queue.pop() {
+        let manifest = workspace_root.join("crates").join(&name).join("Cargo.toml");
+        let Ok(text) = fs::read_to_string(&manifest) else {
+            continue;
+        };
+        for line in text.lines() {
+            let line = line.trim();
+            // `perry-foo = { path = ... }` / `perry-foo.workspace = true`
+            // dep lines, and `[dependencies.perry-foo]` section headers.
+            let candidate =
+                if let Some(header) = line.strip_prefix('[').and_then(|l| l.strip_suffix(']')) {
+                    header.rsplit('.').next().unwrap_or("")
+                } else {
+                    let end = line
+                        .find(|c: char| !(c.is_ascii_alphanumeric() || c == '-' || c == '_'))
+                        .unwrap_or(line.len());
+                    &line[..end]
+                };
+            if candidate.is_empty() || crates.contains(candidate) {
+                continue;
+            }
+            if workspace_root
+                .join("crates")
+                .join(candidate)
+                .join("Cargo.toml")
+                .is_file()
+            {
+                crates.insert(candidate.to_string());
+                queue.push(candidate.to_string());
+            }
+        }
+    }
+
+    fn hash_tree(hasher: &mut Sha256, label: &str, path: &Path) {
+        let Ok(meta) = fs::metadata(path) else {
+            hasher.update(label.as_bytes());
+            hasher.update(b"\0missing\0");
+            return;
+        };
+        if meta.is_file() {
+            hasher.update(label.as_bytes());
+            hasher.update(b"\0");
+            match fs::read(path) {
+                Ok(bytes) => {
+                    hasher.update((bytes.len() as u64).to_le_bytes());
+                    hasher.update(&bytes);
+                }
+                Err(_) => hasher.update(b"unreadable\0"),
+            }
+            return;
+        }
+        if !meta.is_dir() {
+            return;
+        }
+        let Ok(entries) = fs::read_dir(path) else {
+            return;
+        };
+        let mut names: Vec<String> = entries
+            .flatten()
+            .filter_map(|e| e.file_name().to_str().map(str::to_string))
+            // Same exclusions as `input_newer_than`.
+            .filter(|n| n != "target" && n != ".git")
+            .collect();
+        names.sort();
+        for name in names {
+            hash_tree(hasher, &format!("{label}/{name}"), &path.join(&name));
+        }
+    }
+
+    let mut hasher = Sha256::new();
+    hasher.update(b"perry-auto-src-v1\0");
+    hash_tree(
+        &mut hasher,
+        "Cargo.toml",
+        &workspace_root.join("Cargo.toml"),
+    );
+    hash_tree(
+        &mut hasher,
+        "Cargo.lock",
+        &workspace_root.join("Cargo.lock"),
+    );
+    for name in &crates {
+        hash_tree(
+            &mut hasher,
+            &format!("crates/{name}"),
+            &workspace_root.join("crates").join(name),
+        );
+    }
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(32);
+    for b in &digest[..16] {
+        hex.push_str(&format!("{b:02x}"));
+    }
+    hex
+}
+
 pub(crate) fn auto_optimized_build_stamp(
     key_input: &str,
     target: Option<&str>,
     cross_features: &[String],
     tokio_using_bindings: &[(String, String, Option<String>)],
+    source_fingerprint: &str,
 ) -> String {
     let mut stamp = String::new();
-    stamp.push_str("perry-auto-optimized-v1\n");
+    stamp.push_str("perry-auto-optimized-v2\n");
     stamp.push_str("key=");
     stamp.push_str(key_input);
     stamp.push('\n');
@@ -190,6 +323,11 @@ pub(crate) fn auto_optimized_build_stamp(
         stamp.push(':');
         stamp.push_str(tracking.as_deref().unwrap_or(""));
     }
+    stamp.push('\n');
+    // Source-content fingerprint (see `auto_optimized_source_fingerprint`):
+    // ties the stamp to WHAT the archives were built from, not just how.
+    stamp.push_str("srcs=");
+    stamp.push_str(source_fingerprint);
     stamp.push('\n');
     stamp
 }

--- a/crates/perry/src/commands/compile/optimized_libs/tests.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/tests.rs
@@ -112,7 +112,9 @@ fn build_optimized_libs_reuses_fresh_auto_archives_without_cargo() {
     write_file(&runtime, b"!<arch>\n");
     write_file(&stdlib, b"!<arch>\n");
     let cross_features = auto_optimized_cross_features(&ctx, &features, &[]);
-    let stamp = auto_optimized_build_stamp(&key_input, None, &cross_features, &[]);
+    let source_fingerprint = auto_optimized_source_fingerprint(&workspace_root, &[]);
+    let stamp =
+        auto_optimized_build_stamp(&key_input, None, &cross_features, &[], &source_fingerprint);
     write_file(
         &target_dir.join(".perry-auto-build.stamp"),
         stamp.as_bytes(),
@@ -194,6 +196,98 @@ fn auto_optimized_freshness_ignores_nested_target_dirs() {
         &stamp,
         "test-stamp"
     ));
+}
+
+/// #5892 layer 2 / #5778 warm-cache trap: the auto-opt freshness gate must be
+/// keyed on the CONTENT of every source tree that lands in the archives — an
+/// ext-crate edit must rotate the fingerprint even when mtimes lie (cache
+/// restores, fresh checkouts), and rewriting identical bytes must NOT.
+#[test]
+fn source_fingerprint_tracks_ext_crate_content_not_mtimes() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    minimal_auto_workspace(dir.path());
+    write_file(
+        &dir.path().join("crates/perry-ext-http/Cargo.toml"),
+        b"[package]\n",
+    );
+    write_file(
+        &dir.path().join("crates/perry-ext-http/src/lib.rs"),
+        b"pub fn http() {}\n",
+    );
+    let bindings = vec![(
+        "perry-ext-http".to_string(),
+        "perry_ext_http".to_string(),
+        None,
+    )];
+
+    let fp1 = auto_optimized_source_fingerprint(dir.path(), &bindings);
+
+    // Rewriting identical bytes (mtime-only churn) must not rotate the key.
+    std::thread::sleep(std::time::Duration::from_millis(10));
+    write_file(
+        &dir.path().join("crates/perry-ext-http/src/lib.rs"),
+        b"pub fn http() {}\n",
+    );
+    assert_eq!(
+        fp1,
+        auto_optimized_source_fingerprint(dir.path(), &bindings)
+    );
+
+    // A content edit in the ext crate must rotate it — this is exactly the
+    // stale-archive reuse that masked #5911 in CI.
+    write_file(
+        &dir.path().join("crates/perry-ext-http/src/lib.rs"),
+        b"pub fn http_changed() {}\n",
+    );
+    let fp2 = auto_optimized_source_fingerprint(dir.path(), &bindings);
+    assert_ne!(fp1, fp2);
+
+    // A binding crate that isn't routed must not affect the key.
+    assert_ne!(
+        auto_optimized_source_fingerprint(dir.path(), &[]),
+        fp2,
+        "fingerprint should include routed binding crates"
+    );
+}
+
+/// The fingerprint must follow transitive workspace path-deps: an edit in a
+/// crate reachable only through another crate's manifest (here perry-ext-net
+/// via perry-ext-http) still lands in the archives, so it must rotate the key.
+#[test]
+fn source_fingerprint_follows_workspace_dep_closure() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    minimal_auto_workspace(dir.path());
+    write_file(
+        &dir.path().join("crates/perry-ext-http/Cargo.toml"),
+        b"[package]\n[dependencies]\nperry-ext-net = { path = \"../perry-ext-net\" }\n",
+    );
+    write_file(
+        &dir.path().join("crates/perry-ext-http/src/lib.rs"),
+        b"pub fn http() {}\n",
+    );
+    write_file(
+        &dir.path().join("crates/perry-ext-net/Cargo.toml"),
+        b"[package]\n",
+    );
+    write_file(
+        &dir.path().join("crates/perry-ext-net/src/lib.rs"),
+        b"pub fn net() {}\n",
+    );
+    let bindings = vec![(
+        "perry-ext-http".to_string(),
+        "perry_ext_http".to_string(),
+        None,
+    )];
+
+    let fp1 = auto_optimized_source_fingerprint(dir.path(), &bindings);
+    write_file(
+        &dir.path().join("crates/perry-ext-net/src/lib.rs"),
+        b"pub fn net_changed() {}\n",
+    );
+    assert_ne!(
+        fp1,
+        auto_optimized_source_fingerprint(dir.path(), &bindings)
+    );
 }
 
 /// Closes #507. The well-known flip's "shared tokio" allowlist


### PR DESCRIPTION
## Problem — the durable follow-up left open in #5892 (layer 2)

The `target/perry-auto-<hash>` freshness gate compares a config-only build stamp plus source-vs-archive **mtimes**. mtimes lie under CI cache restores and fresh checkouts (a restored dir's archives can look newer than just-checked-out sources), and Cargo.lock carries no checksum for workspace path deps. Result: a restored dir kept linking optimized ext archives built from **pre-#5911 sources** even after the fix merged — which is why the v0.5.1219 gate run still hung. Same mechanism as the #5778-era "warm auto-opt cache ignores perry-ext-http edits" trap. `test.yml` now evicts the dir in CI (42e240164); this PR is the perry-side fix so stale-dir reuse is impossible everywhere.

## Fix

New `auto_optimized_source_fingerprint`: SHA-256 over the workspace manifests (`Cargo.toml`/`Cargo.lock`) plus every source tree that lands in the archives — the crates the auto-opt cargo invocation builds (`perry-runtime(-static)`, `perry-stdlib(-static)`, the tokio-using ext crates) **and their transitive workspace path-dep closure** (discovered by matching manifest dep tokens against existing `crates/<name>` dirs; over-approximation only hashes extra source, never misses an input — `perry-ffi` etc. are covered this way).

The fingerprint is embedded as a `srcs=` line in the build stamp (header bumped to `perry-auto-optimized-v2`, so all existing stamps invalidate once — one extra rebuild per cache dir, then steady state). Archives built from different sources can never pass the gate again, regardless of mtimes. The mtime check stays as a cheap first-line signal; the dir-name hash is unchanged (content changes rebuild **in place**, reusing cargo's incremental state, instead of minting new multi-GB target dirs).

Cost: ~18 MB / ~1000 files hashed per `build_optimized_libs` call — tens of ms warm, noise next to the compile itself.

## Validation

- New tests: fingerprint is stable across identical-content rewrites (mtime-only churn), rotates on ext-crate edits (the exact #5911-masking scenario) and on edits in a dep reachable only transitively, and includes routed binding crates.
- `cargo test -p perry --bin perry optimized_libs`: 15/15 (including the pre-existing freshness/stamp tests, updated for the new parameter).
- fmt + file-size + GC store-site + addr-class audits green.

Per contributor guidelines: code-only, no version bump / changelog (maintainer folds metadata at merge).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive freshness checks so optimized builds are less likely to be reused incorrectly after cache restores or timestamp changes.
  * Optimized build reuse now reflects actual source content changes, including relevant workspace dependencies, helping ensure rebuilds happen when needed.

* **Tests**
  * Added coverage for source-based freshness tracking and dependency changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->