### PR TITLE
fix(runtime): #5437 — async-step result-promise + reaction preservation restore Next.js SSR statics (0/8→5/8)

### DIFF
--- a/crates/perry-ext-http-server/src/request.rs
+++ b/crates/perry-ext-http-server/src/request.rs
@@ -689,22 +689,39 @@ pub extern "C" fn js_node_http_im_set_timeout(handle: i64, _msecs: f64, _callbac
 /// `null` thereafter.
 #[no_mangle]
 pub extern "C" fn js_node_http_im_read(handle: i64) -> f64 {
-    let bytes = match get_handle_mut::<IncomingMessage>(handle) {
+    let (bytes, encoding) = match get_handle_mut::<IncomingMessage>(handle) {
         Some(im) => {
             if im.data_emitted {
                 return f64::from_bits(crate::types::TAG_NULL);
             }
             im.data_emitted = true;
-            im.body_bytes.clone()
+            (im.body_bytes.clone(), im.encoding.clone())
         }
         None => return f64::from_bits(crate::types::TAG_NULL),
     };
     if bytes.is_empty() {
         return f64::from_bits(crate::types::TAG_NULL);
     }
-    let s = String::from_utf8_lossy(&bytes).into_owned();
-    let header = alloc_string(&s);
-    f64::from_bits(STRING_TAG | (header.as_raw() as u64 & PTR_MASK))
+    // #5437 POST-body: Node's `req.read()` returns a Buffer by default and a
+    // string only after `setEncoding()`. `Readable.toWeb(req)` (Next.js App
+    // Router's request-body adapter) and the Web `Request` body reader require
+    // Uint8Array/Buffer chunks — a string chunk is dropped, so `request.json()`
+    // saw `{}`. Mirror `emit_data_to_listeners`: Buffer by default, string only
+    // when an encoding was set.
+    match encoding {
+        Some(_) => {
+            let s = String::from_utf8_lossy(&bytes).into_owned();
+            let header = alloc_string(&s);
+            f64::from_bits(STRING_TAG | (header.as_raw() as u64 & PTR_MASK))
+        }
+        None => {
+            let buf = alloc_buffer(&bytes);
+            if buf.is_null() {
+                return f64::from_bits(crate::types::TAG_NULL);
+            }
+            f64::from_bits(POINTER_TAG | (buf as u64 & PTR_MASK))
+        }
+    }
 }
 
 // ============================================================================

--- a/crates/perry-runtime/src/promise/async_step.rs
+++ b/crates/perry-runtime/src/promise/async_step.rs
@@ -195,6 +195,43 @@ pub extern "C" fn js_promise_resolved_then(
 ///   - One fewer closure dispatch per microtask (was: `then_v_arrow`
 ///     body called `step_closure`; is now `step_closure` is invoked
 ///     directly by the runner).
+///
+/// #5437: register the resume thunks on `awaited` AND keep the machine's
+/// result promise consistent so `js_async_step_done`'s reuse gate can
+/// settle it. When this machine was entered via `js_async_first_call`
+/// (which nulls `trap_next` per #691), a plain `js_promise_then` here
+/// yields a result promise that `done` cannot match (its reuse gate needs
+/// a non-null `trap_next`), so `done` mints a fresh promise and ORPHANS
+/// the result the caller awaits → the awaiter hangs (the Next.js SSR
+/// render deadlock). Allocate the result explicitly, back-patch the
+/// thunks' captured `trap_next` (capture slot 1) to it, and attach the
+/// handlers WITHOUT a chained `next` (a chained `next` would make a
+/// mid-chain await self-resolve → "Chaining cycle detected").
+fn then_backpatch_result(
+    awaited: *mut Promise,
+    fulfill: ClosurePtr,
+    reject: ClosurePtr,
+    trap_next: *mut Promise,
+) -> *mut Promise {
+    if trap_next.is_null() {
+        let result = super::then::js_promise_new_with_parent(awaited);
+        crate::closure::js_closure_set_capture_ptr(
+            fulfill as *mut crate::closure::ClosureHeader,
+            1,
+            result as i64,
+        );
+        crate::closure::js_closure_set_capture_ptr(
+            reject as *mut crate::closure::ClosureHeader,
+            1,
+            result as i64,
+        );
+        super::then::js_promise_attach_handlers(awaited, fulfill, reject);
+        result
+    } else {
+        js_promise_then(awaited, fulfill, reject)
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn js_async_step_chain(value: f64, step_closure: ClosurePtr) -> *mut Promise {
     // PR #1004 followup: if `value` is a JS_HANDLE_TAG handle to a V8
@@ -296,14 +333,14 @@ pub extern "C" fn js_async_step_chain(value: f64, step_closure: ClosurePtr) -> *
                     // that will queue the right Task when called.
                     bump(&MT_STEP_CHAIN_REUSE_MISS);
                     let (fulfill, reject) = build_async_step_thunks(step_closure, trap_next);
-                    return js_promise_then(inner, fulfill, reject);
+                    return then_backpatch_result(inner, fulfill, reject, trap_next);
                 }
             }
         } else {
             bump(&MT_STEP_CHAIN_REUSE_MISS);
             let (fulfill, reject) = build_async_step_thunks(step_closure, trap_next);
             let p = js_promise_resolved(value);
-            return js_promise_then(p, fulfill, reject);
+            return then_backpatch_result(p, fulfill, reject, trap_next);
         }
     } else {
         // Pointer-tagged but not a Promise (thenable etc.). Take the
@@ -311,7 +348,7 @@ pub extern "C" fn js_async_step_chain(value: f64, step_closure: ClosurePtr) -> *
         bump(&MT_STEP_CHAIN_REUSE_MISS);
         let (fulfill, reject) = build_async_step_thunks(step_closure, trap_next);
         let p = js_promise_resolved(value);
-        return js_promise_then(p, fulfill, reject);
+        return then_backpatch_result(p, fulfill, reject, trap_next);
     };
 
     TASK_QUEUE.with(|q| {

--- a/crates/perry-runtime/src/promise/microtasks.rs
+++ b/crates/perry-runtime/src/promise/microtasks.rs
@@ -832,6 +832,15 @@ fn propagate_callback_result(result: f64, next: *mut Promise) {
     if (bits & crate::value::TAG_MASK) == crate::value::POINTER_TAG {
         let ptr = (bits & crate::value::POINTER_MASK) as usize;
         if ptr == next as usize {
+            // #5437: `result == next` is only a genuine chaining cycle when
+            // `next` is still PENDING (`p = x.then(() => p)`). In the async-step
+            // steady state, `js_async_step_done` already resolved this result
+            // promise before the thunk returned it, so `next` is already
+            // fulfilled and re-resolving it with itself is a harmless no-op,
+            // NOT a cycle. Only reject when still pending.
+            if unsafe { (*next).state } != PromiseState::Pending {
+                return;
+            }
             let msg = b"Chaining cycle detected for promise #<Promise>";
             let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
             let err_ptr = crate::error::js_typeerror_new(s);

--- a/crates/perry-runtime/src/promise/then.rs
+++ b/crates/perry-runtime/src/promise/then.rs
@@ -676,18 +676,26 @@ pub extern "C" fn js_promise_resolve_with_promise(outer: *mut Promise, inner: *m
                     crate::closure::js_closure_alloc(promise_forward_reject as *const u8, 1);
                 crate::closure::js_closure_set_capture_ptr(reject_closure, 0, outer_i64);
 
-                // Register the forwarding callbacks on the inner promise
-                store_promise_closure_slot(
+                // #5437 bug#2: add the forwarding callbacks as an OVERFLOW
+                // reaction rather than OVERWRITING inner's inline
+                // on_fulfilled/on_rejected. The previous `store_promise_closure_slot`
+                // writes clobbered any existing reaction — e.g. an async-step
+                // awaiter's resume thunk registered by an earlier `await inner` —
+                // so when `inner` settled it fired only the forwarder and the
+                // awaiter hung forever (Next.js SSR render deadlock). Both the
+                // existing inline reaction AND this forwarder now fire when inner
+                // settles: the awaiter resumes AND `outer` adopts inner's state.
+                push_overflow_reaction(
                     inner,
-                    std::ptr::addr_of_mut!((*inner).on_fulfilled),
                     resolve_closure,
-                );
-                store_promise_closure_slot(
-                    inner,
-                    std::ptr::addr_of_mut!((*inner).on_rejected),
                     reject_closure,
+                    ptr::null_mut(),
+                    capture_context(),
                 );
-                // Don't chain; the forwarding callbacks handle resolution.
+                // Keep the original next-nulling: the forwarder handles adoption,
+                // and leaving a stale `inner.next` chained to `outer` can form a
+                // resolution cycle ("Chaining cycle detected"). The awaiter's
+                // reaction lives in on_fulfilled (untouched above), not in `next`.
                 store_promise_next_slot(
                     inner,
                     std::ptr::addr_of_mut!((*inner).next),


### PR DESCRIPTION
## Summary

The #5854 CPS transform lowered the whole Next.js App Router render chain to suspending async-step state machines. At that scale, three latent promise-machinery bugs deadlocked **even the static routes**, regressing this Next.js smoke app to **0/8** byte-identical vs `node`. This PR fixes the three runtime bugs plus a `req.read()` body-encoding bug, restoring **0/8 → 5/8** (the 5 build-prerendered + API routes are byte-identical vs node v26).

The remaining 3 routes (`/posts/[id]`, `/fetcher`, `/plain`) are **request-time dynamic RSC renders** that hang on a *separate, structural* issue — under the full transform React's server renderer never yields the shell, so the dynamicIO abort is never scheduled and the render's internal `new Promise`s never resolve (empty event loop, precisely traced to the `app-page-turbo` renderer + `app-page` template render callbacks). That is a transform-side follow-up, not addressed here.

## The four fixes (runtime-only, independent of the CPS transform)

1. **async-step result-promise orphan** (`async_step.rs`) — a machine entered via `js_async_first_call` nulls its `trap_next` (#691). The chain's pending-promise arm registered resume thunks whose captured `trap_next` was null, so `js_async_step_done`'s reuse gate failed, minted a **fresh** result promise, and **orphaned** the one the caller awaits → the awaiter hangs forever. New `then_backpatch_result` allocates the result explicitly, back-patches the thunks' captured `trap_next` (capture slot 1) to it, and attaches handlers **without a chained `next`** (a chained `next` self-resolves a mid-chain await → "Chaining cycle detected"). Applied at all 3 chain thunk-path sites.

2. **resolve-with-promise reaction clobber** (`then.rs`) — `js_promise_resolve_with_promise`'s slow path **overwrote** `inner`'s inline `on_fulfilled`/`on_rejected` to install its forwarders, clobbering a reaction already registered there (e.g. an async-step awaiter's resume thunk from an earlier `await inner`). When `inner` settled, only the forwarder fired and the awaiter hung. Now registers the forwarders as an **overflow** reaction, so both fire.

3. **microtask cycle guard** (`microtasks.rs`) — `propagate_callback_result` rejected `result == next` as a chaining cycle **unconditionally**. In the async-step steady state `js_async_step_done` already resolved that result before the thunk returned it, so `next` is already settled and re-resolving it with itself is a no-op, not a cycle. Only reject when `next` is still `Pending`.

4. **`req.read()` Buffer default** (`perry-ext-http-server/request.rs`) — `js_node_http_im_read` always returned a string; Node's `req.read()` returns a **Buffer** by default (string only after `setEncoding`). Next.js App Router's `Readable.toWeb` / the Web `Request` body reader require Buffer/Uint8Array chunks — a string chunk was dropped, so `request.json()` saw `{}`. Returns a Buffer by default, string when an encoding was set (mirrors `emit_data_to_listeners`).

## Validation

- Boots + **5/8 byte-identical** vs node v26: `/`, `/about`, `/counter`, `/api/hello` (GET + POST).
- `/posts/123`, `/fetcher`, `/plain` hang (documented structural follow-up above).
- Runtime-only; no transform changes → no interaction with the in-flight CPS transform rework.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request body handling so text and binary responses are returned in the correct format.
  * Fixed promise chain behavior in async flows to avoid mismatched or duplicated results.
  * Prevented chained promise callbacks from triggering invalid cycle handling after a promise has already settled.
  * Preserved existing async reactions when forwarding one promise to another, reducing the chance of missed callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->