### PR TITLE
fix(runtime): #5893 — reading a private method as a value then calling it

### DIFF
--- a/crates/perry-runtime/src/closure/dispatch/bound.rs
+++ b/crates/perry-runtime/src/closure/dispatch/bound.rs
@@ -13,6 +13,45 @@ pub unsafe fn dispatch_bound_method(closure: *const ClosureHeader, args: &[f64])
     let method_name_ptr = js_closure_get_capture_ptr(closure, 1) as *const i8;
     let method_name_len = js_closure_get_capture_ptr(closure, 2) as usize;
 
+    // Private-method value (`const f = this.#m; f.call(o)`): a `#`-named method
+    // read off an instance yields the OWNER class's method function. Unlike a
+    // public method, its invocation must dispatch the OWNER's `#m` body with the
+    // call-time `this` — NOT re-resolve `#m` on the receiver's own class (a plain
+    // object has no `#m`, so the by-name path throws "#m is not a function").
+    // The brand check already happened at the READ site (`this.#m`), so here we
+    // simply bind the owner's body to whatever `this` the call supplies (spec:
+    // `PrivateMethodOrAccessorAdd` installs the shared function; calling it does
+    // no brand check). The canonical closure captures the owner class's
+    // prototype-ref in slot 0, which carries the owner id.
+    if method_name_len > 0 && !method_name_ptr.is_null() {
+        if let Ok(name) = std::str::from_utf8(std::slice::from_raw_parts(
+            method_name_ptr as *const u8,
+            method_name_len,
+        )) {
+            if name.starts_with('#') {
+                if let Some(owner_id) = crate::object::class_prototype_ref_id(namespace_obj) {
+                    if let Some((func_ptr, param_count, has_synth_args, has_rest)) =
+                        crate::object::lookup_class_method_in_chain(owner_id, name)
+                    {
+                        // The call-time `this` (IMPLICIT_THIS) is the receiver the
+                        // private method body runs against — for `f.call(o)` it is
+                        // `o`, for a bare `f()` it is undefined.
+                        let call_this = crate::object::js_implicit_this_get();
+                        return crate::object::call_vtable_method(
+                            func_ptr,
+                            call_this.to_bits() as i64,
+                            args.as_ptr(),
+                            args.len(),
+                            param_count,
+                            has_synth_args,
+                            has_rest,
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     // Canonical class method value (test262 method identity): a class method is
     // a single shared function object whose captured receiver is the OWNER
     // class's prototype-ref — a marker, not the real `this`. The actual receiver


### PR DESCRIPTION
Part of #5893 (test262 language/class tail).

## Root cause
Reading a private method off an instance (`const f = this.#m`) yields the OWNER class's method function. Per spec, calling that function (`f.call(o)`) runs the owner's body with the supplied `this` and does **no** brand check — the brand check happens once, at the read site (`this.#m`). Perry's bound-method dispatch instead re-resolved `#m` on the **call-time** receiver's own class. A plain object has no `#m`, so `c.getPrivateMethod().call({_v:'x'})` threw `#m is not a function`.

## Fix
In `dispatch_bound_method` (`closure/dispatch/bound.rs`): when the bound method name is `#`-prefixed **and** the captured receiver (slot 0) is the owner class's prototype-ref — the canonical marker minted by `class_prototype_method_value_for_name` for a private-method value — resolve the method in the OWNER's vtable chain (`lookup_class_method_in_chain`) and invoke it directly (`call_vtable_method`) with the call-time `this` (`IMPLICIT_THIS`), bypassing the receiver-class by-name lookup.

Public-method dispatch is untouched: the new path is gated on the `#` prefix, and when the capture isn't a prototype-ref the code falls through to the existing logic unchanged.

## Before / after (slice `language/statements/class language/expressions/class`, jobs=6)
- Fixes: `language/expressions/class/elements/private-method-get-and-call.js`, `language/statements/class/elements/private-method-get-and-call.js` (both were `TypeError: #m is not a function`).
- `private-method-get-and-call` failures 2 → 0; **zero regressions** (every remaining failure in the slice was already present on `main`; the diff of current-vs-baseline failure paths is empty aside from the two fixed cases).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bound private methods now work more reliably when invoked directly or with `.call()`.
  * Calls to a captured private method now use the runtime `this` value, so `f.call(obj)` runs against `obj`, while bare calls continue to behave normally.
  * Private method access is now resolved through the class hierarchy before falling back to prior behavior when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->