### PR TITLE
fix(runtime): #5895 — global helper functions must be non-constructors

### DIFF
--- a/crates/perry-runtime/src/object/global_this/populate.rs
+++ b/crates/perry-runtime/src/object/global_this/populate.rs
@@ -468,6 +468,15 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
             crate::builtins::js_register_function_name(func_ptr, name.as_ptr(), name.len() as u32);
         }
         super::super::native_module::set_builtin_closure_length(closure_ptr as usize, arity);
+        // Every global helper installed here (parseInt/parseFloat/isNaN/
+        // isFinite/{en,de}codeURI{,Component}/escape/unescape/setTimeout/…) is a
+        // built-in *non-constructor* function: per spec it has no `.prototype`
+        // (reads back `undefined`) and `new fn()` throws a TypeError. Mark the
+        // closure so the `new`/`.prototype` paths honor that — otherwise these
+        // functions defaulted to an ordinary `.prototype` object and silently
+        // accepted `new` (test262 built-ins/{decodeURI,isNaN,parseFloat,…}
+        // */A5.6/A5.7/A2.6/A2.7/A7.6/A7.7).
+        super::super::native_module::set_builtin_closure_non_constructable(closure_ptr as usize);
         let name_bytes = name.as_bytes();
         let name_key =
             crate::string::js_string_from_bytes(name_bytes.as_ptr(), name_bytes.len() as u32);


### PR DESCRIPTION
Part of #5895 (test262 built-ins misc tail).

## Root cause
The global helper functions installed on the `globalThis` singleton — `parseInt`, `parseFloat`, `isNaN`, `isFinite`, `encodeURI`, `decodeURI`, `encodeURIComponent`, `decodeURIComponent`, `escape`, `unescape`, `setTimeout`, `queueMicrotask`, … — are all built-in **non-constructor** functions. Per spec each has no own `.prototype` (reads back `undefined`) and `new fn()` throws a TypeError. Perry allocated their closures without the non-constructable flag, so they defaulted to an ordinary, lazily-materialized `.prototype` object (`typeof decodeURI.prototype === 'object'`).

## Fix
Mark each closure `set_builtin_closure_non_constructable` at install time in `global_this/populate.rs`. `ordinary_function_prototype_value_for_read` already returns `None` (→ `undefined`) for non-constructable builtins, so `decodeURI.prototype` and friends now read back `undefined`.

Normal usage is unaffected — verified `parseInt('42px')`, `parseFloat`, `isNaN`, `isFinite`, `decodeURI('%20')`, the `const p = parseInt; p('0x1F',16)` alias, and `[1,2].map(String)` all still work, and `decodeURI.name`/`.length` are unchanged.

## Before / after (sub-slice: the 8 affected `built-ins/{decodeURI,decodeURIComponent,encodeURI,encodeURIComponent,isFinite,isNaN,parseFloat,parseInt}` dirs, jobs=6)
- Failures 22 → 14 (**−8**): fixes the `.prototype === undefined` cases (`*/A5.6`, `isFinite/isNaN A2.6`, `parseFloat A7.6`, `parseInt A9.6`).
- Zero regressions: every remaining failure was already failing on `main` (`A5.2`, the `new fn()`-throws `A5.7`/`A2.7`/`A7.7`, `tonumber-operations`, `parseInt A8`).

## Follow-up (not in this PR)
The bare `new decodeURI()` TypeError cases (`A5.7`/`A2.7`/`A7.7`) still don't throw: codegen lowers `new <known-global-fn>()` through a construct path that bypasses the closure's non-constructable flag (the runtime `js_new_function_construct` already honors it — the value form `new globalThis.decodeURI()` throws correctly). That codegen path is a separate fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Built-in helper functions now behave correctly as non-constructors, so they can no longer be used with `new`.
  * Improved consistency for common global functions and timer helpers by preventing unexpected constructor-like behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->