### PR TITLE
fix(codegen): #5869 residual — boxed locals must not feed the typed-ABI closure specializations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.5.1231 — #5869 residual: boxed locals must not feed the typed-ABI closure specializations
+
+A BOXED local's slot holds a box POINTER, never the typed value — but its declared type stayed in `module_local_types`, so the typed-ABI closure specialization (`__typed_f64`/i1/i32/string capture reps) read the capture RAW while only the generic variant went through `js_box_get`; the dispatcher picked the typed body and calls returned box-pointer bits as a denormal number (`2.58e-311` instead of `42`). Exposed by #5871's Labeled-descent fix, which made the type visible for closures inside labeled blocks. Fix: filter boxed ids out of `module_local_types` (`crates/perry-codegen/src/codegen/mod.rs`), so every type-directed unboxed access on a boxed slot is disqualified in one place and falls back to the generic box-aware paths. Un-ignores the `closure_inside_labeled_block_counts_as_capture` e2e.
+
 ## v0.5.1230 — class-capture snapshot P0 pair: resolved-name re-registration + same-body assignment tracking
 
 Two defects in the decl-site class-capture snapshot (`js_class_register_capture_values`), both extracted from the #5437 Next.js branch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1230
+**Current Version:** 0.5.1231
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5338,7 +5338,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "anyhow",
  "base64",
@@ -5395,14 +5395,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "cc",
  "libc",
@@ -5410,7 +5410,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "anyhow",
  "log",
@@ -5425,7 +5425,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5461,7 +5461,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "anyhow",
  "base64",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5511,14 +5511,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "serde",
  "serde_json",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1230"
+version = "0.5.1231"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "anyhow",
  "clap",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "block2",
  "objc2",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5570,7 +5570,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5611,7 +5611,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "chrono",
  "cron",
@@ -5621,7 +5621,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5629,7 +5629,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5637,7 +5637,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5645,7 +5645,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5653,7 +5653,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5661,14 +5661,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5686,7 +5686,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5713,7 +5713,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "bytes",
  "h2",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5757,7 +5757,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5765,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "bson",
  "futures-util",
@@ -5785,7 +5785,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5795,7 +5795,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5804,7 +5804,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -5817,7 +5817,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5827,7 +5827,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5844,7 +5844,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5852,7 +5852,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -5862,14 +5862,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5878,7 +5878,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5908,7 +5908,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "brotli",
  "flate2",
@@ -5917,7 +5917,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5926,7 +5926,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5944,7 +5944,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5956,7 +5956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "anyhow",
  "base64",
@@ -5989,14 +5989,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6089,14 +6089,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6106,7 +6106,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6114,14 +6114,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "base64",
  "itoa",
@@ -6138,7 +6138,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6148,7 +6148,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6171,7 +6171,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "base64",
  "block2",
@@ -6187,7 +6187,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "base64",
  "block2",
@@ -6202,7 +6202,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1230"
+version = "0.5.1231"
 
 [[package]]
 name = "perry-ui-test"
@@ -6210,11 +6210,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1230"
+version = "0.5.1231"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "base64",
  "block2",
@@ -6230,7 +6230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "base64",
  "block2",
@@ -6246,7 +6246,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "block2",
  "libc",
@@ -6259,7 +6259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "base64",
  "libc",
@@ -6276,14 +6276,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6297,7 +6297,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1230"
+version = "0.5.1231"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -301,7 +301,7 @@ strip = false
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1230"
+version = "0.5.1231"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/codegen/boxed_locals.rs
+++ b/crates/perry-codegen/src/codegen/boxed_locals.rs
@@ -66,6 +66,30 @@ pub(crate) fn collect_module_boxed_vars(hir: &HirModule) -> std::collections::Ha
             module_boxed_vars.extend(collect_boxed_vars(&ctor.body));
             module_boxed_vars.extend(collect_boxed_param_ids(&ctor.params, &ctor.body));
         }
+        // 2026-07-02 audit (#684/S1 candidate): closures inside class FIELD
+        // initializers (instance + static), computed-member key expressions,
+        // and the extends expression ARE compiled, but were invisible to
+        // this module-wide union — a captured+mutated local there was never
+        // boxed, so reads skipped js_box_get and returned box-pointer bits
+        // as a denormal (the documented #907 `(number).replace` signature).
+        let mut extra_stmts: Vec<perry_hir::Stmt> = Vec::new();
+        for f in c.fields.iter().chain(c.static_fields.iter()) {
+            if let Some(init) = &f.init {
+                extra_stmts.push(perry_hir::Stmt::Expr(init.clone()));
+            }
+            if let Some(k) = &f.key_expr {
+                extra_stmts.push(perry_hir::Stmt::Expr(k.clone()));
+            }
+        }
+        for member in &c.computed_members {
+            extra_stmts.push(perry_hir::Stmt::Expr(member.key_expr.clone()));
+        }
+        if let Some(ext) = &c.extends_expr {
+            extra_stmts.push(perry_hir::Stmt::Expr((**ext).clone()));
+        }
+        if !extra_stmts.is_empty() {
+            module_boxed_vars.extend(collect_boxed_vars(&extra_stmts));
+        }
     }
     module_boxed_vars.extend(collect_boxed_vars(&hir.init));
     module_boxed_vars

--- a/crates/perry-codegen/src/codegen/boxed_locals.rs
+++ b/crates/perry-codegen/src/codegen/boxed_locals.rs
@@ -66,30 +66,6 @@ pub(crate) fn collect_module_boxed_vars(hir: &HirModule) -> std::collections::Ha
             module_boxed_vars.extend(collect_boxed_vars(&ctor.body));
             module_boxed_vars.extend(collect_boxed_param_ids(&ctor.params, &ctor.body));
         }
-        // 2026-07-02 audit (#684/S1 candidate): closures inside class FIELD
-        // initializers (instance + static), computed-member key expressions,
-        // and the extends expression ARE compiled, but were invisible to
-        // this module-wide union — a captured+mutated local there was never
-        // boxed, so reads skipped js_box_get and returned box-pointer bits
-        // as a denormal (the documented #907 `(number).replace` signature).
-        let mut extra_stmts: Vec<perry_hir::Stmt> = Vec::new();
-        for f in c.fields.iter().chain(c.static_fields.iter()) {
-            if let Some(init) = &f.init {
-                extra_stmts.push(perry_hir::Stmt::Expr(init.clone()));
-            }
-            if let Some(k) = &f.key_expr {
-                extra_stmts.push(perry_hir::Stmt::Expr(k.clone()));
-            }
-        }
-        for member in &c.computed_members {
-            extra_stmts.push(perry_hir::Stmt::Expr(member.key_expr.clone()));
-        }
-        if let Some(ext) = &c.extends_expr {
-            extra_stmts.push(perry_hir::Stmt::Expr((**ext).clone()));
-        }
-        if !extra_stmts.is_empty() {
-            module_boxed_vars.extend(collect_boxed_vars(&extra_stmts));
-        }
     }
     module_boxed_vars.extend(collect_boxed_vars(&hir.init));
     module_boxed_vars

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -1745,7 +1745,21 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
 
     // Module-wide boxed-var union + LocalId→Type map. See `boxed_locals`.
     let module_boxed_vars = boxed_locals::collect_module_boxed_vars(hir);
-    let module_local_types = boxed_locals::collect_module_local_types(hir);
+    let mut module_local_types = boxed_locals::collect_module_local_types(hir);
+    // #5869 residual: a BOXED local's slot holds a BOX POINTER, never the
+    // typed value — advertising its declared type to the typed-ABI layer
+    // made the typed closure specializations (typed_f64/i1/i32/string
+    // capture reps) read the capture RAW while the generic variant
+    // box_get's, and the dispatcher picked the typed body: the call
+    // returned box-pointer bits as a denormal number. Observable repro:
+    //   let n = 0; let get: any = null;
+    //   tag: { get = () => n; break tag; }
+    //   n = 42; get()          // → 2.58e-311 instead of 42
+    // (#5871's Labeled-descent fix EXPOSED this — the type became visible
+    // for closures inside labeled blocks.) Removing boxed ids here
+    // disqualifies every type-directed unboxed access on a boxed slot in
+    // one place; consumers fall back to the generic (box-aware) paths.
+    module_local_types.retain(|id, _| !module_boxed_vars.contains(id));
 
     // Cross-module function declares are emitted lazily by `lower_call`
     // via `FnCtx.pending_declares` (drained back into `llmod` at the

--- a/crates/perry/tests/issue_5869_labeled_block_capture_boxing.rs
+++ b/crates/perry/tests/issue_5869_labeled_block_capture_boxing.rs
@@ -85,15 +85,14 @@ factory();
     );
 }
 
-/// Closure created INSIDE the labeled block, reassignment outside. The
-/// codegen-side walkers now see it, but perry-hir's lowering still
-/// classifies the capture as non-mutable (`--trace hir` shows the closure
-/// under `Labeled { body: DoWhile }` with `mutable_captures: []`), so the
-/// creation site stores the box pointer while the body reads it raw — the
-/// call returns a denormal number (box-pointer bits). Tracked as the
-/// residual half of #5869; un-ignore when the HIR mutable-capture
-/// classifier learns the Labeled wrapper.
-#[ignore = "residual #5869: HIR mutable_captures misses closures under Labeled wrappers"]
+/// Closure created INSIDE the labeled block, reassignment outside. Root
+/// cause of the former residual (un-ignored by the fix): a BOXED local's
+/// declared type stayed in `module_local_types`, so the typed-ABI closure
+/// specialization (`__typed_f64`) read the capture RAW while the generic
+/// variant went through `js_box_get` — and the dispatcher picked the typed
+/// body, returning box-pointer bits as a denormal. Boxed ids are now
+/// filtered out of `module_local_types`, so boxed captures always take the
+/// generic (box-aware) paths.
 #[test]
 fn closure_inside_labeled_block_counts_as_capture() {
     let dir = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
Closes the residual half of #5869 (the codegen walkers landed in #5871).

**Root cause** (pinpointed by IR trace): a BOXED local's slot holds a **box pointer**, never the typed value — but `collect_module_local_types` advertised its declared type to the typed-ABI layer, so the typed closure specializations (`typed_f64/i1/i32/string` capture reps) compiled a body that reads the capture RAW while the generic variant goes through `js_box_get` — and the dispatcher picks the typed body. The call returned box-pointer bits as a denormal:

```ts
let n = 0; let get: any = null;
tag: { get = () => n; break tag; }
n = 42; get()   // 2.58e-311 instead of 42
```

IR tell: three definitions — `__1__typed_f64` (raw `js_closure_get_capture_bits`), `__1__generic` (`js_box_get_bits`), dispatcher calling the typed one. #5871's Labeled-descent fix *exposed* this: the capture's type became visible exactly where the boxing analysis had just learned the capture was boxed.

**Fix**: filter boxed ids out of `module_local_types` at construction — one line disqualifies every type-directed unboxed access on a boxed slot; consumers fall back to the generic (box-aware) paths.

**Verification**: the previously-`#[ignore]`d e2e `closure_inside_labeled_block_counts_as_capture` is un-ignored (probe: `n: 42`, was denormal); the write-inside-label repro stays green (`len: 4`).

Code-only PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of captured values so boxed local variables are no longer treated like unboxed typed values, reducing incorrect access behavior in closures and related runtime paths.
  * Fixed closure behavior inside labeled blocks to reflect the correct boxing and capture semantics.
* **Tests**
  * Enabled a previously skipped regression test so this behavior is now covered automatically.
* **Chores**
  * Bumped the project version to **v0.5.1231** and updated version references in project metadata/docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->