### PR TITLE
fix(runtime,codegen,hir): #5898 — array mutators throw on frozen/non-writable length

### DIFF
--- a/crates/perry-codegen/src/expr/array_push.rs
+++ b/crates/perry-codegen/src/expr/array_push.rs
@@ -31,7 +31,7 @@ use crate::type_analysis::{
     is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
 };
 #[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::types::{DOUBLE, I1, I16, I32, I64, I8, PTR};
 
 #[allow(unused_imports)]
 use super::{
@@ -323,18 +323,43 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     blk.br(&merge_label);
                 }
 
-                // No forwarding — read length & capacity, branch on
-                // capacity. inline_store on length < capacity, slow
-                // call on full.
+                // No forwarding — check the integrity flags, then read
+                // length & capacity and branch on capacity. inline_store on
+                // length < capacity, slow call on full.
+                //
+                // A frozen / sealed / non-extensible array, or one carrying
+                // per-index/`length` descriptors (`OBJ_FLAG_ARRAY_DESCRIPTORS`),
+                // must NOT take the raw inline store: `push` performs
+                // `Set(O,"length",…,true)`, so a frozen array or one whose
+                // `length` was made non-writable must throw a **TypeError**
+                // (test262 push/set-length-zero-array-is-frozen and
+                // set-length-zero-array-length-is-non-writable), and a
+                // descriptor-carrying array needs the descriptor-aware runtime
+                // store. All of these route to `js_array_push_f64`, which
+                // throws / handles them correctly. The integrity bits live in
+                // the GcHeader `_reserved` u16 at `arr - 6` (obj_type u8 at -8,
+                // gc_flags u8 at -7, `_reserved` u16 at -6): mask
+                // FROZEN|SEALED|NO_EXTEND|ARRAY_DESCRIPTORS = 0x407.
                 ctx.current_block = nofwd_idx;
                 {
                     let blk = ctx.block();
+                    let flags_addr = blk.sub(I64, &arr_handle, "6");
+                    let flags_ptr = blk.inttoptr(I64, &flags_addr);
+                    let obj_flags = blk.load(I16, &flags_ptr);
+                    // FROZEN(0x1)|SEALED(0x2)|NO_EXTEND(0x4)|ARRAY_DESCRIPTORS(0x400).
+                    let integrity_bits = blk.and(I16, &obj_flags, "1031");
+                    let clean = blk.icmp_eq(I16, &integrity_bits, "0");
                     let length = blk.safe_load_i32_from_ptr(&arr_handle);
                     let cap_addr = blk.add(I64, &arr_handle, "4");
                     let cap_ptr = blk.inttoptr(I64, &cap_addr);
                     let capacity = blk.load(I32, &cap_ptr);
                     let has_room = blk.icmp_ult(I32, &length, &capacity);
-                    blk.cond_br(&has_room, &inbounds_label, &realloc_label);
+                    // Take the inline store only when there is room AND no
+                    // integrity flag is set; otherwise fall to the runtime
+                    // (`js_array_push_f64` throws for frozen / non-writable
+                    // length and applies descriptors correctly).
+                    let inline_ok = blk.and(I1, &has_room, &clean);
+                    blk.cond_br(&inline_ok, &inbounds_label, &realloc_label);
                 }
 
                 // Inline store: arr+8+length*8 = value, length++.

--- a/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
+++ b/crates/perry-hir/src/lower/expr_call/local_array_methods.rs
@@ -302,9 +302,21 @@ pub(super) fn try_local_array_methods(
                         match method_name {
                             "push" => {
                                 if args.is_empty() {
-                                    return Ok(Ok(Expr::PropertyGet {
-                                        object: Box::new(Expr::LocalGet(array_id)),
-                                        property: "length".to_string(),
+                                    // `arr.push()` with no items still performs
+                                    // `Set(O,"length",…,true)` (ECMA-262
+                                    // §23.1.3.21 step 6), so a frozen array or one
+                                    // whose `length` is non-writable must throw a
+                                    // TypeError — it is NOT a pure `length` read
+                                    // (test262 push/set-length-zero-array-is-frozen
+                                    // and set-length-zero-array-length-is-non-writable).
+                                    // Route through the native push dispatch, which
+                                    // emits `js_array_push_guard`.
+                                    return Ok(Ok(Expr::NativeMethodCall {
+                                        module: "array".to_string(),
+                                        class_name: None,
+                                        object: Some(Box::new(Expr::LocalGet(array_id))),
+                                        method: "push".to_string(),
+                                        args: vec![],
                                     }));
                                 }
                                 // Check if any argument has spread operator —

--- a/crates/perry-runtime/src/array/generic.rs
+++ b/crates/perry-runtime/src/array/generic.rs
@@ -1219,9 +1219,46 @@ fn al_set_length(recv: f64, len: i64) {
             }
         }
     }
+    // `Set(O, "length", …, true)` (Throw=true) must throw a TypeError when the
+    // set fails: a frozen array, an array/object whose `length` is a
+    // non-writable data property (`defineProperty(o,"length",{writable:false})`
+    // or a function's intrinsic `length`), or a frozen plain object. The
+    // by-name setter below silently no-ops in those cases (PutValue's
+    // non-strict fall-through), so detect the failure up front and throw.
+    if al_length_write_would_fail(recv, raw_addr) {
+        crate::collection_iter::throw_type_error(
+            "Cannot assign to read only property 'length' of object",
+        );
+    }
     let raw = raw_addr as *mut crate::object::ObjectHeader;
     let key = crate::string::js_string_from_bytes(b"length".as_ptr(), 6);
     crate::object::js_object_set_field_by_name(raw, key, len as f64);
+}
+
+/// True when `Set(recv, "length", …)` would fail (and so must throw under
+/// `Throw=true`): a frozen array, a non-writable `length` data property, or a
+/// callable receiver (a function's `length` is non-writable by spec).
+fn al_length_write_would_fail(recv: f64, raw_addr: usize) -> bool {
+    // Frozen array: `length` is non-writable after `Object.freeze`.
+    let arr = as_real_array(recv);
+    if !arr.is_null() {
+        if crate::array::array_is_frozen(arr) {
+            return true;
+        }
+        return crate::object::get_property_attrs(raw_addr, "length")
+            .map(|a| !a.writable())
+            .unwrap_or(false);
+    }
+    // Non-array receivers: a recorded non-writable `length` descriptor
+    // (`defineProperty(o,"length",{writable:false})`) or a callable receiver
+    // whose intrinsic `length` is non-writable.
+    if crate::object::get_property_attrs(raw_addr, "length")
+        .map(|a| !a.writable())
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    crate::closure::is_closure_ptr(raw_addr)
 }
 
 /// `ToIntegerOrInfinity(v)` as an `f64` (NaN → 0; ±Infinity preserved).


### PR DESCRIPTION
## Summary

Fixes three spec-conformance gaps in `Array.prototype` mutating methods that perform `Set(O,"length",…,true)` (ECMA-262 §23.1.3.\*) and so must throw a `TypeError` when that set fails. Part of #5898 (built-ins/Array worklist).

## Root causes

**1. `arr.push()` with no items was folded to a bare `length` read.** The HIR local-array fast path (`local_array_methods.rs`) lowered zero-arg `push()` to `PropertyGet{length}`, eliding the mandatory `Set(O,"length",…)` step (§23.1.3.21 step 6). A frozen array — or one whose `length` was made non-writable — silently no-op'd instead of throwing. Now routes through the native push dispatch so `js_array_push_guard` fires.

**2. The codegen inline dense-push fast path bypassed the integrity flags.** `apush.inbounds` wrote the element and bumped length directly, checking only the GcHeader FORWARDED bit. An empty array frozen via `Object.freeze([])` (capacity present → in-bounds store) was mutated without throwing. Now loads the GcHeader `_reserved` u16 (at `arr-6`) and bails to `js_array_push_f64` when `FROZEN|SEALED|NO_EXTEND|ARRAY_DESCRIPTORS` (0x407) is set.

**3. The generic `Set(O,"length",…)` helper (`al_set_length`) silently no-op'd on failure.** Used by the borrowed-receiver mutators, it called the by-name setter, which is a non-strict no-op for a frozen array / non-writable `length` / callable receiver. Now detects that failure and throws, matching `Throw=true`.

## Before / after (test262 `built-ins/Array/prototype`)

| slice | before | after |
|-------|--------|-------|
| push | 6 fail | 4 fail (`set-length-zero-{is-frozen,length-is-non-writable}` fixed) |
| shift | 5 fail | 4 fail (`throws-when-this-value-length-is-writable-false` fixed) |

**Zero regressions** across pop / shift / push / unshift / splice (100%) / sort (100%) / concat (100%) / slice / reverse. Verified `console.log` and normal/borrowed array mutators behave correctly with and without a polluted `Array.prototype`.

The remaining #5898 frozen/non-writable cases where the array is frozen *during* an `Array.prototype[i]` accessor trap need the `ARRAY_PROTO_HAS_INDEX` machinery to fire inherited index accessors on dense-array reads/writes; wiring that up currently corrupts internal formatting arrays (a latent issue that also breaks Node parity for that pattern), so it is deferred.

## Validation

`cargo fmt --all -- --check` clean; `scripts/check_file_size.sh` clean. Built and tested on an internal Linux box.

Refs #5898.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `push()` now behaves correctly on frozen or otherwise non-writable arrays, including the no-argument form.
  * Array updates now check array integrity before using fast inline writes, falling back to a safer path when needed.
  * Setting an array-like `"length"` now throws a `TypeError` when the property can’t be written, instead of failing silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->