### PR TITLE
fix(runtime): #5909 — JSON.stringify(toJSON-returns-cycle) throws instead of SIGSEGV

### DIFF
--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -991,7 +991,10 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
         if (*(ptr as *const crate::ObjectHeader)).class_id != 0 {
             if let Some(to_json_val) = object_get_to_json(ptr) {
                 arm_to_json_result_guard(to_json_val);
-                stringify_value(to_json_val, TYPE_UNKNOWN, buf);
+                // Thread depth so a `toJSON` returning a cycle trips the
+                // circular-detection push instead of overflowing the stack —
+                // see the matching note in the keyed-object branch below.
+                stringify_value_depth(to_json_val, TYPE_UNKNOWN, buf, depth + 1);
                 SUPPRESS_NEXT_TO_JSON.with(|c| c.set(false));
                 return;
             }
@@ -1160,7 +1163,16 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
                 STRINGIFY_STACK.with(|s| s.borrow_mut().pop());
             }
             arm_to_json_result_guard(to_json_val);
-            stringify_value(to_json_val, TYPE_UNKNOWN, buf);
+            // Thread the current depth into the toJSON-result walk (do NOT
+            // reset to the depth-0 `stringify_value` entry). A `toJSON` that
+            // returns a structure re-entering an object still open higher in
+            // the walk (`obj.toJSON = () => circular; circular.prop = obj`)
+            // would otherwise recurse forever: each re-entry restarted at
+            // depth 0, so the `depth > MAX_FAST_DEPTH` circular-detection push
+            // never engaged and the stack overflowed (SIGSEGV). Accumulating
+            // depth makes the detection fire and throw the spec TypeError
+            // (test262 JSON/stringify/value-tojson-object-circular).
+            stringify_value_depth(to_json_val, TYPE_UNKNOWN, buf, depth + 1);
             SUPPRESS_NEXT_TO_JSON.with(|c| c.set(false));
             return;
         }


### PR DESCRIPTION
## Summary

`JSON.stringify` crashed with a stack overflow (SIGSEGV, "(no output)") instead of throwing a `TypeError` when a `toJSON` method returns a structure that re-enters an object still open in the serialization walk. Fixes `value-tojson-object-circular` from #5909 (built-ins/JSON worklist).

## Root cause

`SerializeJSONObject`'s circular-reference detection only pushes the object pointer onto `STRINGIFY_STACK` once `depth > MAX_FAST_DEPTH` (128) — a performance gate that assumes a shallow structure cannot be cyclic. But the two object toJSON-result branches in `stringify_object_inner` serialized the substituted value through the depth-0 `stringify_value` entry, **resetting depth to 0 on every re-entry**.

So for

```js
var obj = {};
var circular = { prop: obj };
obj.toJSON = function () { return circular; };
JSON.stringify(circular); // must throw TypeError
```

each `obj.toJSON()` → `circular` → `circular.prop` → `obj.toJSON()` → … re-entered at depth 0, the `depth > MAX_FAST_DEPTH` push never engaged, and the native stack overflowed.

## Fix

Thread the current depth into both object toJSON-result walks (`stringify_value_depth(result, …, depth + 1)`), matching the shape-template path that already did exactly this. Depth now accumulates across the toJSON recursion, so the circular-detection push engages, the already-open pointer is found on the stack, and `Converting circular structure to JSON` throws. The compact-array path already pushes to the stack unconditionally, so `value-tojson-array-circular` was unaffected.

## Before / after (test262 `built-ins/JSON`)

| | before | after |
|--|--------|-------|
| slice | 15 fail | 14 fail |

`value-tojson-object-circular`: SIGSEGV → passes. **Zero regressions.** Verified nested objects/arrays, class `toJSON` returning a fresh structure, `Date.toJSON`, array-element `toJSON`, and plain circular detection all still behave.

## Validation

`cargo fmt --all -- --check` clean; `scripts/check_file_size.sh` clean (stringify.rs 1895 lines). Built and tested on an internal Linux box.

Refs #5909.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON serialization for objects that define `toJSON`, especially when the returned value contains nested or circular references.
  * Prevented certain `toJSON` results from bypassing serialization safeguards, helping avoid crashes or incorrect output on deeply nested data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->