### PR TITLE
fix(runtime): #5901 — string-key 'length' write on an array resizes it

### DIFF
--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -1298,6 +1298,18 @@ pub extern "C" fn js_array_set_string_key(
             Err(_) => return arr,
         }
     };
+    // `length` is a real own property of every array — a polymorphic /
+    // computed string-key write (`arr["length"] = n`, or an `Object.assign`
+    // copying a source's own `length` onto an array target) must resize the
+    // array (truncate / extend + holes), NOT land as an inert expando. The
+    // dedicated `arr.length = n` codegen path already routes to
+    // `js_array_set_length`; this covers the by-string-key entry points.
+    // (test262 Object/assign/target-Array: `Object.assign([7,8,9], {1:2,
+    // length:2})` truncates the target to `[1,2]`.)
+    if key_str == "length" {
+        js_array_set_length(arr, value);
+        return arr;
+    }
     // Try parse as a non-negative integer in array-index range.
     if let Ok(idx) = key_str.parse::<u32>() {
         // Reject leading zeros / signs that would round-trip differently


### PR DESCRIPTION
## Summary

`Object.assign(target, source)` onto an **array** target dropped the source's own `length` property instead of resizing the array. Fixes `Object/assign/target-Array` from #5901 (built-ins/Object worklist).

## Root cause

`js_array_set_string_key` — the by-string-key array setter behind polymorphic `arr[computedKey] = v` and `Object.assign` onto an array target — handled integer-index keys (→ element set + length extend) and named keys (→ expando side table), but had **no case for `"length"`**. So a `length` write landed as an inert expando property rather than performing ArraySetLength.

```js
Object.assign([7, 8, 9], { 1: 2, length: 2 }); // Node: [1, 2]; Perry (before): [1, 2, 3]
```

Per spec, `Object.assign` copies every own enumerable string key of the source, including `length`; applied to an array target that truncates it.

## Fix

Intercept the exact canonical key `"length"` in `js_array_set_string_key` and route to the existing `js_array_set_length` (truncate / extend + holes, with the RangeError on an invalid length value) — the same helper the dedicated `arr.length = n` codegen path uses.

## Before / after (test262)

- `built-ins/Object/assign` slice: **37/37 pass (100%)** — `target-Array` was the sole failure.

**Zero regressions**: the full `built-ins/Array/prototype` slice (2329 pass) is unchanged (its 37 remaining failures are the pre-existing frozen-array / generic-receiver clusters). Verified against Node that `arr["length"]=n` truncate/extend, computed-key `length`, the invalid-length RangeError, and a non-array `Object.assign` target (keeps `length` as a plain property) all behave correctly.

## Validation

`cargo fmt --all -- --check` clean; `scripts/check_file_size.sh` clean (indexing.rs 1487 lines). Built and tested on an internal Linux box.

Refs #5901.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Writing to an array’s `"length"` property via a string key now updates the array length correctly, matching normal length assignment behavior.
  * This ensures `arr["length"] = n` truncates or extends arrays as expected instead of being handled like a regular property write.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->