### PR TITLE
fix(intl): #5904 — %Intl%.[[FallbackSymbol]] legacy-constructed chain (NumberFormat/DateTimeFormat)

### DIFF
--- a/crates/perry-runtime/src/intl.rs
+++ b/crates/perry-runtime/src/intl.rs
@@ -1563,7 +1563,15 @@ fn make_instance(closure: *const ClosureHeader, kind: &str, locales: f64, option
     if JSValue::from_bits(proto.to_bits()).is_pointer() {
         crate::object::prototype_chain::object_set_static_prototype(obj as usize, proto.to_bits());
     }
-    js_nanbox_pointer(obj as i64)
+    let instance = js_nanbox_pointer(obj as i64);
+    // ChainNumberFormat / ChainDateTimeFormat only (see `chain_legacy_constructed`):
+    // Intl.Collator ignores its this-value, so it is deliberately excluded.
+    if matches!(kind, KIND_NUMBER | KIND_DATE_TIME) {
+        if let Some(this_value) = ctor_guard::chain_legacy_constructed(closure, instance) {
+            return this_value;
+        }
+    }
+    instance
 }
 
 fn install_bound_instance_function(

--- a/crates/perry-runtime/src/intl/ctor_guard.rs
+++ b/crates/perry-runtime/src/intl/ctor_guard.rs
@@ -3,9 +3,12 @@
 //! `intl.rs` to keep that file under the repository's 2,000-line gate.
 
 use crate::closure::ClosureHeader;
-use crate::object::{js_object_get_field_by_name_f64, ObjectHeader};
+use crate::object::{js_object_get_field_by_name_f64, ObjectHeader, PropertyAttrs};
 use crate::string::js_string_from_bytes;
 use crate::value::JSValue;
+
+const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
+const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
 
 /// `GetPrototypeFromConstructor(new.target, "%<Ctor>Prototype%")`: a
 /// `Reflect.construct(Intl.X, args, CustomCtor)` call should install
@@ -13,8 +16,6 @@ use crate::value::JSValue;
 /// falling back to the invoked closure's own `"prototype"` when `new.target`
 /// is absent (a bare `new Intl.X()`) or its `prototype` isn't an object.
 pub(super) fn constructor_target_prototype(closure: *const ClosureHeader) -> f64 {
-    const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
-    const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
     let new_target = crate::object::js_new_target_get();
     let bits = new_target.to_bits();
     if (bits & !POINTER_MASK) == POINTER_TAG {
@@ -37,4 +38,110 @@ pub(super) fn require_new_target(name: &str) {
     if crate::object::js_new_target_get().to_bits() == crate::value::TAG_UNDEFINED {
         super::throw_type_error(&format!("Constructor Intl.{name} requires 'new'"));
     }
+}
+
+/// The immediate `[[Prototype]]` pointer of an object at `obj_ptr`, resolved
+/// across Perry's two prototype-recording mechanisms:
+///   * the static-prototype side table (`object_set_static_prototype`, used by
+///     Intl instances and `Object.setPrototypeOf`), and
+///   * a synthetic `class_id` → `CLASS_PROTOTYPE_OBJECTS` entry (used by
+///     `Object.create(proto)`).
+/// Returns `None` when the object has its default `Object.prototype` (or a null
+/// prototype), which is never a service constructor's own `.prototype`.
+fn object_proto_ptr(obj_ptr: usize) -> Option<usize> {
+    if let Some(proto_bits) = crate::object::prototype_chain::object_static_prototype(obj_ptr) {
+        if (proto_bits & !POINTER_MASK) == POINTER_TAG {
+            let p = (proto_bits & POINTER_MASK) as usize;
+            return (p != 0).then_some(p);
+        }
+        return None;
+    }
+    let class_id = unsafe {
+        let obj = obj_ptr as *const ObjectHeader;
+        if !crate::object::is_valid_obj_ptr(obj as *const u8) {
+            return None;
+        }
+        (*obj).class_id
+    };
+    if class_id == 0 {
+        return None;
+    }
+    let proto = crate::object::class_prototype_object(class_id);
+    (!proto.is_null()).then_some(proto as usize)
+}
+
+/// True when `receiver`'s prototype chain contains `Ctor.prototype` — the
+/// `OrdinaryHasInstance(constructor, receiver)` test used by ChainNumberFormat /
+/// ChainDateTimeFormat. Walks the resolved prototype chain (bounded to avoid a
+/// cyclic-proto hang).
+fn receiver_on_constructor_chain(receiver: f64, closure: *const ClosureHeader) -> bool {
+    let ctor_proto = crate::closure::closure_get_dynamic_prop(closure as usize, "prototype");
+    let ctor_proto_bits = ctor_proto.to_bits();
+    if (ctor_proto_bits & !POINTER_MASK) != POINTER_TAG {
+        return false;
+    }
+    let ctor_proto_ptr = (ctor_proto_bits & POINTER_MASK) as usize;
+    if ctor_proto_ptr == 0 {
+        return false;
+    }
+    let mut cur = (receiver.to_bits() & POINTER_MASK) as usize;
+    for _ in 0..64 {
+        match object_proto_ptr(cur) {
+            Some(proto_ptr) => {
+                if proto_ptr == ctor_proto_ptr {
+                    return true;
+                }
+                cur = proto_ptr;
+            }
+            None => return false,
+        }
+    }
+    false
+}
+
+/// ChainNumberFormat / ChainDateTimeFormat (ECMA-402 normative-optional): when a
+/// legacy Intl service constructor is invoked as a *plain function* (no `new`)
+/// whose `this` is an object on the constructor's prototype chain, stash the
+/// freshly-built internal `instance` under `%Intl%.[[FallbackSymbol]]` on `this`
+/// (a non-writable / non-enumerable / non-configurable data property) and return
+/// `this`. Returns `Some(this)` when the chain applied, else `None` so the caller
+/// returns the plain instance.
+///
+/// V8/Node implement this for `NumberFormat` and `DateTimeFormat` only —
+/// `Intl.Collator` ignores its this-value and always returns a fresh object
+/// (test262 `Collator/this-value-ignored.js`), so the caller must not invoke
+/// this for the Collator kind.
+pub(super) fn chain_legacy_constructed(
+    closure: *const ClosureHeader,
+    instance: f64,
+) -> Option<f64> {
+    // Only the legacy path: a `new`-invocation (new.target present) always
+    // returns the fresh instance.
+    if crate::object::js_new_target_get().to_bits() != crate::value::TAG_UNDEFINED {
+        return None;
+    }
+    let this_value = crate::object::js_implicit_this_get();
+    let this_bits = this_value.to_bits();
+    // `this` must be an Object (pointer-tagged, valid heap object).
+    if (this_bits & !POINTER_MASK) != POINTER_TAG {
+        return None;
+    }
+    let this_ptr = (this_bits & POINTER_MASK) as usize;
+    if this_ptr == 0 || !crate::object::is_valid_obj_ptr(this_ptr as *const u8) {
+        return None;
+    }
+    if !receiver_on_constructor_chain(this_value, closure) {
+        return None;
+    }
+    let fallback_sym = crate::symbol::intl_legacy_constructed_symbol();
+    unsafe {
+        crate::symbol::js_object_set_symbol_property(this_value, fallback_sym, instance);
+    }
+    let sym_key = (fallback_sym.to_bits() & POINTER_MASK) as usize;
+    crate::symbol::set_symbol_property_attrs(
+        this_ptr,
+        sym_key,
+        PropertyAttrs::new(false, false, false),
+    );
+    Some(this_value)
 }

--- a/crates/perry-runtime/src/intl/number_format.rs
+++ b/crates/perry-runtime/src/intl/number_format.rs
@@ -1202,7 +1202,14 @@ pub(crate) fn intl_object_from_value(
     method: &str,
     expected_kind: &str,
 ) -> *mut ObjectHeader {
-    let Some(obj) = object_ptr_from_value(value) else {
+    // UnwrapNumberFormat / UnwrapDateTimeFormat: a receiver produced by the
+    // legacy `Intl.X.call(obj)` chain isn't itself an initialized instance — it
+    // carries the real instance under `%Intl%.[[FallbackSymbol]]`. A `Get` of
+    // that symbol also fires a Proxy `get` trap (so `resolvedOptions.call(proxy)`
+    // observes the symbol read, per intl-legacy-constructed-symbol-on-unwrap).
+    let unwrapped = unwrap_legacy_constructed(value);
+    let receiver = unwrapped.unwrap_or(value);
+    let Some(obj) = object_ptr_from_value(receiver) else {
         throw_type_error(&format!(
             "Intl.{expected_kind}.prototype.{method} called on incompatible receiver"
         ));
@@ -1214,6 +1221,36 @@ pub(crate) fn intl_object_from_value(
         ));
     }
     obj
+}
+
+/// If `value` is not itself an initialized Intl instance but carries
+/// `%Intl%.[[FallbackSymbol]]` (the legacy-constructed wrapper), return the
+/// wrapped instance value. Reads through a Proxy `get` trap when `value` is a
+/// Proxy. Returns `None` when there is nothing to unwrap.
+fn unwrap_legacy_constructed(value: f64) -> Option<f64> {
+    let js = JSValue::from_bits(value.to_bits());
+    if !js.is_pointer() {
+        return None;
+    }
+    // A Proxy is a small registered id, not a heap object — `object_ptr_from_value`
+    // would mis-classify it (its band overlaps the heap range on Linux) and
+    // dereference garbage. Route straight to the symbol `Get`, which fires the
+    // proxy `get` trap (intl-legacy-constructed-symbol-on-unwrap).
+    if crate::proxy::js_proxy_is_proxy(value) == 0 {
+        // A direct, already-initialized instance never needs unwrapping.
+        if let Some(obj) = object_ptr_from_value(value) {
+            if get_string_field(obj, KEY_KIND).is_some() {
+                return None;
+            }
+        }
+    }
+    let fallback_sym = crate::symbol::intl_legacy_constructed_symbol();
+    let wrapped = unsafe { crate::symbol::js_object_get_symbol_property(value, fallback_sym) };
+    if JSValue::from_bits(wrapped.to_bits()).is_pointer() {
+        Some(wrapped)
+    } else {
+        None
+    }
 }
 
 /// `get Intl.NumberFormat.prototype.format` — the ECMA-402 accessor. Validates

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -226,6 +226,40 @@ pub(crate) fn register_symbol_pointer(ptr: usize) {
     guard.as_mut().unwrap().insert(ptr);
 }
 
+// The `%Intl%.[[FallbackSymbol]]` — a single per-realm symbol whose description
+// is exactly `"IntlLegacyConstructedSymbol"` (no `Symbol.` prefix, so it is
+// *not* a well-known symbol). It is stashed on the receiver when a legacy Intl
+// service constructor (`Intl.NumberFormat` / `Intl.DateTimeFormat`) is called as
+// a plain function whose `this` is on the constructor's prototype chain (the
+// ChainNumberFormat / ChainDateTimeFormat normative-optional path), and read
+// back by the UnwrapXxx step so `nf.resolvedOptions()` on the wrapped object
+// still works.
+static INTL_FALLBACK_SYMBOL: Mutex<Option<usize>> = Mutex::new(None);
+
+/// Return the process-wide `%Intl%.[[FallbackSymbol]]` as a NaN-boxed
+/// (POINTER_TAG) JSValue, allocating & registering it lazily on first use.
+pub fn intl_legacy_constructed_symbol() -> f64 {
+    let mut guard = INTL_FALLBACK_SYMBOL.lock().unwrap();
+    if let Some(ptr) = *guard {
+        return f64::from_bits(POINTER_TAG | (ptr as u64 & POINTER_MASK));
+    }
+    // Persistent (leaked) symbol so it outlives every GC cycle — its identity is
+    // realm-global. Description text lives in REGISTERED_SYMBOL_DESCRIPTIONS
+    // (readers materialize a fresh StringHeader on demand), matching the
+    // well-known-symbol contract.
+    let boxed = Box::new(SymbolHeader {
+        magic: SYMBOL_MAGIC,
+        registered: 0,
+        description: std::ptr::null_mut(),
+        id: next_id(),
+    });
+    let sym_ptr = Box::into_raw(boxed) as usize;
+    record_registered_symbol_description(sym_ptr, "IntlLegacyConstructedSymbol");
+    register_symbol_pointer(sym_ptr);
+    *guard = Some(sym_ptr);
+    f64::from_bits(POINTER_TAG | (sym_ptr as u64 & POINTER_MASK))
+}
+
 /// O(1) check whether a raw pointer (already untagged) is a known Symbol.
 /// Safe to call on any pointer-shaped value — no dereference is performed.
 pub fn is_registered_symbol(ptr: usize) -> bool {


### PR DESCRIPTION
## Summary

Implements the ECMA-402 **normative-optional** ChainNumberFormat / ChainDateTimeFormat behavior (the `%Intl%.[[FallbackSymbol]]` cluster). Calling `Intl.NumberFormat` / `Intl.DateTimeFormat` as a **plain function** (no `new`) whose `this` is an object on the constructor's prototype chain now:

1. builds the internal formatter instance as usual, then
2. defines `this[%Intl%.[[FallbackSymbol]]] = instance` as a **non-writable / non-enumerable / non-configurable** data property (the symbol's `description` is exactly `"IntlLegacyConstructedSymbol"`, and it is *not* a well-known symbol), and
3. returns `this`.

The `UnwrapNumberFormat` / `UnwrapDateTimeFormat` step (`intl_object_from_value`) reads that symbol back via a `Get`, so it transparently fires a Proxy `get` trap — matching `resolvedOptions.call(proxy)` observing the symbol read.

`Intl.Collator` is **deliberately excluded**: V8/Node ignore its this-value and always return a fresh object (verified against Node 26; `intl402/Collator/this-value-ignored.js` asserts `obj !== Collator.call(obj)`). Applying the chain to Collator regressed that test, so the `matches!(kind, KIND_NUMBER | KIND_DATE_TIME)` gate keeps it out.

## Root cause

The legacy service constructors (`number_format_constructor_thunk`, `date_time_format_constructor_thunk`) unconditionally returned a fresh instance regardless of `new.target` / `this`. There was no `%Intl%.[[FallbackSymbol]]` at all, so `Object.getOwnPropertySymbols(Intl.NumberFormat.call(obj))` was empty and `Intl.NumberFormat.call(obj) !== obj`.

## Implementation notes

- New realm-global singleton `crate::symbol::intl_legacy_constructed_symbol()` (leaked persistent `SymbolHeader`, registered + description recorded — same contract as well-known symbols but without the `Symbol.` description prefix).
- The chain's `OrdinaryHasInstance(ctor, this)` walk resolves prototypes across **both** of Perry's prototype-recording mechanisms — the static-prototype side table (Intl instances / `setPrototypeOf`) and synthetic-`class_id` → `CLASS_PROTOTYPE_OBJECTS` (`Object.create(proto)`).
- The unwrap path guards against Proxies before touching `object_ptr_from_value` (a Proxy's small id falls inside the Linux heap band and would otherwise be dereferenced as a heap object → SIGSEGV); Proxy receivers go straight to the symbol `Get`.

## Before / after (test262, verified on an internal Linux box, Node v26.3.0)

| slice | before failing | after failing | fixed |
|---|---|---|---|
| `intl402/FallbackSymbol` | 1 | 0 | `description.js` |
| `intl402/NumberFormat` | 29 | 27 | `intl-legacy-constructed-symbol{,-on-unwrap}.js` |
| `intl402/DateTimeFormat` | 45 | 43 | `intl-legacy-constructed-symbol{,-on-unwrap}.js` |
| `intl402/Collator` | — | no regression | (this-value-ignored stays green) |

**+5 tests, zero regressions** across all four slices.

`intl-legacy-constructed-symbol-property.js` (NumberFormat + DateTimeFormat) additionally requires `wrappedInstance instanceof Intl.<Ctor>`, which needs Intl-instance `instanceof` support (a separate concern) and is intentionally left for a follow-up.

`cargo fmt --all -- --check` and `scripts/check_file_size.sh` pass (`intl.rs` kept at 1998 lines).

Refs #5904 #5899 #5906

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved legacy construction support for Intl number and date/time formatters, allowing existing formatter instances to be reused when created via older call patterns.

* **Bug Fixes**
  * Enhanced Intl receiver validation by correctly unwrapping legacy-constructed formatter wrappers, including cases involving proxy-like inputs.
  * Adjusted Intl instance resolution to consistently recognize and preserve already-created instances (Collator remains unchanged).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->