### PR TITLE
fix(runtime): #5901 — strict write to a frozen symbol-keyed property throws TypeError

### DIFF
--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -900,8 +900,16 @@ fn own_set_descriptor(target: f64, key: f64) -> Option<OwnSetDescriptor> {
 
     if unsafe { crate::symbol::js_is_symbol(key) } != 0 {
         let value = unsafe { crate::symbol::js_object_get_symbol_property(target, key) };
-        return (value.to_bits() != TAG_UNDEFINED)
-            .then_some(OwnSetDescriptor::Data { writable: true });
+        if value.to_bits() == TAG_UNDEFINED {
+            return None;
+        }
+        // An existing symbol-keyed own data property is non-writable when the
+        // receiver is frozen or its per-symbol attrs say so — so a strict
+        // `obj[sym] = v` is rejected (throws) rather than silently no-op'd
+        // (test262 Object/freeze/frozen-object-contains-symbol-properties-strict).
+        // Mirrors the string-keyed / `set_symbol_property` guards.
+        let writable = !crate::symbol::symbol_property_is_non_writable(target, key);
+        return Some(OwnSetDescriptor::Data { writable });
     }
 
     let obj_ptr = extract_pointer(target.to_bits()) as usize;

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -41,7 +41,7 @@ pub(crate) use properties::{
     get_symbol_property_attrs, inspect_custom_symbol_ptr, js_object_define_symbol_accessor,
     js_object_delete_symbol_property, js_object_has_own_symbol_property,
     reflect_symbol_getter_closure_bits, set_symbol_property_attrs, symbol_accessor_descriptor_bits,
-    symbol_property_is_enumerable, symbol_property_root_bits,
+    symbol_property_is_enumerable, symbol_property_is_non_writable, symbol_property_root_bits,
 };
 pub use properties::{
     class_static_symbol_lookup, js_class_register_static_symbol, js_object_has_own_symbol,

--- a/crates/perry-runtime/src/symbol/properties.rs
+++ b/crates/perry-runtime/src/symbol/properties.rs
@@ -365,6 +365,33 @@ fn object_symbol_data_property_exists(obj_key: usize, sym_key: usize) -> bool {
     })
 }
 
+/// True when an existing symbol-keyed own data property is non-writable — the
+/// receiver was frozen (`Object.freeze`), or the per-symbol attrs recorded via
+/// `Object.defineProperty(obj, sym, {writable:false})` say so. Mirrors the
+/// frozen / non-writable rejection in `set_symbol_property`, but as a query so
+/// the ordinary-`[[Set]]` walk (`own_set_descriptor`) can report the slot as
+/// read-only and let a strict write throw. `obj_f64` / `sym_f64` are the same
+/// NaN-boxed values passed to the symbol setters.
+pub(crate) fn symbol_property_is_non_writable(obj_f64: f64, sym_f64: f64) -> bool {
+    let obj_key = unsafe { obj_key_from_f64(obj_f64) };
+    let sym_key = unsafe { sym_key_from_f64(sym_f64) };
+    if obj_key == 0 || sym_key == 0 {
+        return false;
+    }
+    // Only heap receivers carry the GC integrity flag word.
+    if (obj_f64.to_bits() >> 48) == 0x7FFD
+        && obj_key >= 0x10000
+        && crate::object::is_valid_obj_ptr(obj_key as *const u8)
+    {
+        let gc = (obj_key - crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        let flags = unsafe { (*gc)._reserved };
+        if flags & crate::gc::OBJ_FLAG_FROZEN != 0 {
+            return true;
+        }
+    }
+    get_symbol_property_attrs(obj_key, sym_key).is_some_and(|attrs| !attrs.writable())
+}
+
 /// `obj[sym] = value` where `sym` is a Symbol. Stores into the side table.
 /// Returns the value (NaN-boxed) for chained assignment semantics.
 #[no_mangle]


### PR DESCRIPTION
## Summary

A strict-mode `obj[sym] = v` (Symbol key) onto a **frozen** object silently no-op'd instead of throwing a `TypeError`. Fixes `Object/freeze/frozen-object-contains-symbol-properties-strict` from #5901.

## Root cause

Strict-mode `obj[sym] = v` routes through `js_put_value_set` → `ordinary_set_with_receiver` → `own_set_descriptor`. For a **symbol** key, `own_set_descriptor` returned `Data { writable: true }` unconditionally whenever the property existed — ignoring the receiver's frozen state and any per-symbol `writable:false` attribute. So the ordinary `[[Set]]` reported success, and `js_put_value_set` never threw. (The string-keyed path already reported these correctly.)

## Fix

`own_set_descriptor` now reports a symbol-keyed data property's real writability via a new `symbol::symbol_property_is_non_writable` query, which mirrors the frozen / per-symbol-attr rejection already present in `set_symbol_property`:
- frozen receiver ⇒ non-writable;
- else consult the per-symbol attrs table (`defineProperty(obj, sym, {writable:false})`).

`ordinary_set_with_receiver` then returns `false`, and `js_put_value_set` throws under strict mode. A sealed-but-not-frozen object's existing symbol property stays writable (sealed permits value changes), so only genuine non-writable slots are rejected.

## Before / after (test262 `built-ins/Object`)

- `freeze` sub-slice: **0 fail** (`frozen-object-contains-symbol-properties-strict` was the sole failure there).

Verified against Node that: a normal symbol overwrite, a `defineProperty(obj, sym, {writable:false})` strict write (throws), a sealed-but-not-frozen object's existing symbol (still writable), and `Symbol.iterator` access all behave identically. No behavioral change for non-symbol keys or non-frozen receivers — the change is scoped to the symbol branch of `own_set_descriptor`.

## Validation

`cargo fmt --all -- --check` clean; `scripts/check_file_size.sh` clean (proxy.rs 1972, properties.rs 626 lines). Built and tested on an internal Linux box.

Refs #5901.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of symbol-keyed object properties during assignment.
  * Existing symbol properties can now correctly behave as read-only when they are not writable, which helps make `Proxy` and `Reflect.set` behavior more accurate.
  * Assignment to symbol-keyed properties now better respects strict-mode rules and existing property attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->