### PR TITLE
fix(codegen): #806 — no-own-ctor walk binds ancestor ctor with caps-absent semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.5.1234 — #806: no-own-ctor walk binds the ancestor ctor with caps-absent semantics
+
+The parent walk for a ctor-free subclass forwarded the `new`-site's `caps_absent_from_args` into the ancestor's `CaptureFill`, deriving the user/cap tail-split from the ANCESTOR's cap params. But a bare-ident site appends the LEAF's captures, and a capturing leaf always synthesizes an own ctor — a leaf reaching the walk appended nothing, so trailing user args were eaten into cap slots (the decl-site snapshot silently rescued the cap itself; only the user args were lost). `new WrappedLogged("alpha")` bound the mixin ctor's `seed` to undefined. The ancestor fill is now unconditionally caps-absent.
+
+New e2e suite `issue_806_default_derived_ctor_forwarding` (5 node-validated cases; 3 green). Two sibling shapes remain `#[ignore]`d with traced mechanisms — the HIR fixed-arity default-ctor synthesis (rest/extends-expr parents truncate or drop forwarded args) and the sig-cap/rest gaps in the runtime construct dispatchers — tracked as #5957. `run_class_constructor_on_this_flat` gains the same `PERRY_SUPER_DEBUG` diagnostics `js_super_construct_apply` already had.
+
 ## v0.5.1233 — CI: cache-warm primes the release compiler + gap-suite auto-opt variants
 
 The conformance-smoke job restored the shared rust-cache with a full match and still hit its 60-minute timeout: the warmed DEBUG units share nothing with its RELEASE build, and every gap test whose auto-optimize feature combination had no `target/perry-auto-<hash>` archive kicked off an in-job cargo build of the runtime (orphan cargo/rustc still compiling at cancellation). cache-warm now builds the release compiler and runs the gap suite once per main merge so every variant lands under the shared key; code-only PRs carry main's `CARGO_PKG_VERSION`, so their smoke jobs restore exact variant matches until the next merge re-warms (job timeout 120 → 150 for the cold first run).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1233
+**Current Version:** 0.5.1234
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5338,7 +5338,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "anyhow",
  "base64",
@@ -5395,14 +5395,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "cc",
  "libc",
@@ -5410,7 +5410,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "anyhow",
  "log",
@@ -5425,7 +5425,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5461,7 +5461,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "anyhow",
  "base64",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5511,14 +5511,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "serde",
  "serde_json",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1233"
+version = "0.5.1234"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "anyhow",
  "clap",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "block2",
  "objc2",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5570,7 +5570,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5611,7 +5611,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "chrono",
  "cron",
@@ -5621,7 +5621,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5629,7 +5629,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5637,7 +5637,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5645,7 +5645,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5653,7 +5653,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5661,14 +5661,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5686,7 +5686,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5713,7 +5713,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "bytes",
  "h2",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5757,7 +5757,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5765,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "bson",
  "futures-util",
@@ -5785,7 +5785,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5795,7 +5795,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5804,7 +5804,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -5817,7 +5817,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5827,7 +5827,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5844,7 +5844,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5852,7 +5852,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -5862,14 +5862,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5878,7 +5878,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5908,7 +5908,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "brotli",
  "flate2",
@@ -5917,7 +5917,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5926,7 +5926,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5944,7 +5944,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5956,7 +5956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "anyhow",
  "base64",
@@ -5989,14 +5989,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6089,14 +6089,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6106,7 +6106,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6114,14 +6114,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "base64",
  "itoa",
@@ -6138,7 +6138,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6148,7 +6148,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6171,7 +6171,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "base64",
  "block2",
@@ -6187,7 +6187,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "base64",
  "block2",
@@ -6202,7 +6202,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1233"
+version = "0.5.1234"
 
 [[package]]
 name = "perry-ui-test"
@@ -6210,11 +6210,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1233"
+version = "0.5.1234"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "base64",
  "block2",
@@ -6230,7 +6230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "base64",
  "block2",
@@ -6246,7 +6246,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "block2",
  "libc",
@@ -6259,7 +6259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "base64",
  "libc",
@@ -6276,14 +6276,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6297,7 +6297,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1233"
+version = "0.5.1234"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -301,7 +301,7 @@ strip = false
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1233"
+version = "0.5.1234"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -1493,10 +1493,25 @@ fn lower_new_impl(
                 if let Some(parent_ctor) = &parent_class.constructor {
                     // #5437: fill any unfilled parent cap param from the
                     // parent's decl-site capture snapshot.
+                    //
+                    // #806: the ANCESTOR's cap params are never in
+                    // `lowered_args` here, so this fill is always
+                    // caps-absent. A bare-ident site appends the LEAF's
+                    // captures — and a capturing leaf always has a
+                    // (synthesized) own ctor (`synthesize_class_captures`
+                    // takes the no-ctor path only for capture-free
+                    // classes), so a leaf that reached this walk appended
+                    // nothing. Forwarding the SITE's flag instead made the
+                    // binder derive the tail-split from the ancestor's cap
+                    // params and eat trailing USER args: `class Wrapped
+                    // extends WithSuffix(Logged) {}` + `new Wrapped("alpha")`
+                    // bound the mixin ctor's `seed` to undefined (the
+                    // snapshot silently rescued the cap, so only the user
+                    // arg was lost).
                     let parent_capture_fill =
                         ctx.class_ids.get(pname).copied().map(|cid| CaptureFill {
                             cid,
-                            caps_absent_from_args,
+                            caps_absent_from_args: true,
                         });
                     let saved_scope = bind_inline_constructor_params(
                         ctx,

--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -1491,23 +1491,11 @@ fn lower_new_impl(
         while let Some(pname) = parent_name {
             if let Some(parent_class) = ctx.classes.get(pname).copied() {
                 if let Some(parent_ctor) = &parent_class.constructor {
-                    // #5437: fill any unfilled parent cap param from the
-                    // parent's decl-site capture snapshot.
-                    //
-                    // #806: the ANCESTOR's cap params are never in
-                    // `lowered_args` here, so this fill is always
-                    // caps-absent. A bare-ident site appends the LEAF's
-                    // captures — and a capturing leaf always has a
-                    // (synthesized) own ctor (`synthesize_class_captures`
-                    // takes the no-ctor path only for capture-free
-                    // classes), so a leaf that reached this walk appended
-                    // nothing. Forwarding the SITE's flag instead made the
-                    // binder derive the tail-split from the ancestor's cap
-                    // params and eat trailing USER args: `class Wrapped
-                    // extends WithSuffix(Logged) {}` + `new Wrapped("alpha")`
-                    // bound the mixin ctor's `seed` to undefined (the
-                    // snapshot silently rescued the cap, so only the user
-                    // arg was lost).
+                    // #5437: snapshot-fill the parent's cap params. #806:
+                    // unconditionally caps-absent — a capturing leaf always
+                    // has a synthesized own ctor, so a leaf reaching this
+                    // walk appended no cap args; the site's flag split the
+                    // tail by the ANCESTOR's caps and ate user args.
                     let parent_capture_fill =
                         ctx.class_ids.get(pname).copied().map(|cid| CaptureFill {
                             cid,

--- a/crates/perry-runtime/src/object/class_constructors.rs
+++ b/crates/perry-runtime/src/object/class_constructors.rs
@@ -647,6 +647,16 @@ pub(crate) unsafe fn run_class_constructor_on_this_flat(
         if let Some((ctor_ptr, total_params)) = lookup_class_constructor(cur) {
             let caps = class_capture_values(cur).unwrap_or_default();
             let user_params = (total_params as usize).saturating_sub(caps.len());
+            if std::env::var_os("PERRY_SUPER_DEBUG").is_some() {
+                eprintln!(
+                    "flat_super cid={} total={} caps={} args_len={} rest={:?}",
+                    cur,
+                    total_params,
+                    caps.len(),
+                    args_len,
+                    crate::closure::lookup_closure_rest(ctor_ptr as *const u8)
+                );
+            }
             let mut final_args: Vec<f64> = Vec::with_capacity(total_params as usize);
             for i in 0..user_params {
                 if !args_ptr.is_null() && i < args_len {

--- a/crates/perry/tests/issue_806_default_derived_ctor_forwarding.rs
+++ b/crates/perry/tests/issue_806_default_derived_ctor_forwarding.rs
@@ -1,0 +1,235 @@
+//! Regression tests for #806: a class with NO own constructor forwarding
+//! `new`-site args to an inherited constructor that carries synthesized
+//! `__perry_cap_*` params.
+//!
+//! The no-own-ctor walk in `lower_call/new.rs` forwarded the `new` SITE's
+//! `caps_absent_from_args` flag into the ancestor's `CaptureFill`, so the
+//! binder derived the user/cap tail-split from the ANCESTOR's cap params.
+//! But the site appends the LEAF's captures — and a capturing leaf always
+//! has a (synthesized) own ctor, so any leaf that reaches the walk appended
+//! nothing. The mis-derived split ate trailing USER args into cap slots:
+//! `class Wrapped extends WithSuffix(Logged) {}` + `new Wrapped("alpha")`
+//! bound the mixin ctor's `seed` param to `undefined` (the decl-site
+//! snapshot silently rescued the cap itself, so only the user arg was
+//! lost). The ancestor fill is now unconditionally caps-absent.
+//!
+//! All expected outputs are byte-for-byte what `node
+//! --experimental-strip-types` prints.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed (exit {:?})\nstdout:\n{}\nstderr:\n{}",
+        run.status.code(),
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+/// The #806 fixture shape: a top-level (capture-free, ctor-free) class
+/// extending a capturing mixin class. The default derived ctor must
+/// forward the user arg to the mixin ctor's USER param, not its cap slot.
+///
+/// Still failing — a DIFFERENT root than the walk: the parent here is a
+/// per-evaluation class OBJECT (extends-expr), so the leaf's codegen
+/// default-derived super forwards through `js_fetch_or_value_super` →
+/// `js_native_call_value` → the heap-class-object construct dispatch,
+/// whose `user_params = total − max(ctor_caps, snapshot)` subtraction
+/// assumes cap params ride in the ctor SIGNATURE. The mixin's compiled
+/// ctor is capless (`(this, seed)` — its parent is fetched via the
+/// dynamic-parent registry, not a cap param) while a decl-site snapshot
+/// IS registered, so user_params computes to 0 and `seed` never receives
+/// "alpha". Needs the signature cap-param count registered alongside the
+/// ctor (see the follow-up to #806).
+#[ignore = "part 2: capless-signature ctor vs snapshot subtraction in the class-object construct dispatch"]
+#[test]
+fn default_derived_forwards_through_capturing_mixin() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = compile_and_run(
+        dir.path(),
+        r#"
+class Logged {
+  log: string;
+
+  constructor(seed: string) {
+    this.log = "seed=" + seed;
+  }
+}
+
+type Ctor<T = {}> = new (...args: any[]) => T;
+
+function WithSuffix<TBase extends Ctor<Logged>>(B: TBase) {
+  return class extends B {
+    constructor(seed: string) {
+      super(seed);
+      this.log += ":wrapped";
+    }
+  };
+}
+
+class WrappedLogged extends WithSuffix(Logged) {}
+
+console.log("super-args.log:", new WrappedLogged("alpha").log);
+"#,
+    );
+    assert_eq!(out, "super-args.log: seed=alpha:wrapped\n");
+}
+
+/// In-scope bare-ident `new` of a ctor-free subclass whose parent ctor
+/// captures an enclosing local: the walk binds the parent ctor (cap param
+/// `__perry_cap_env`), and the lone user arg must reach the parent's user
+/// param while the cap fills from the decl-site snapshot.
+#[test]
+fn ctor_free_subclass_of_capturing_parent_in_scope() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = compile_and_run(
+        dir.path(),
+        r#"
+function make(env: string): string {
+  class P {
+    v: string;
+    constructor(x: string) {
+      this.v = env + ":" + x;
+    }
+  }
+  class C extends P {}
+  return new C("u").v;
+}
+
+console.log(make("E"));
+"#,
+    );
+    assert_eq!(out, "E:u\n");
+}
+
+/// Two ctor-free hops above the capturing ctor, and more than one user
+/// arg — every user arg must survive the walk.
+#[test]
+fn two_hop_walk_multiple_user_args() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = compile_and_run(
+        dir.path(),
+        r#"
+function build(tag: string): string {
+  class Base {
+    s: string;
+    constructor(a: string, b: string) {
+      this.s = tag + "/" + a + "/" + b;
+    }
+  }
+  class Mid extends Base {}
+  class Leaf extends Mid {}
+  return new Leaf("one", "two").s;
+}
+
+console.log(build("T"));
+"#,
+    );
+    assert_eq!(out, "T/one/two\n");
+}
+
+/// Guard the CAPTURING-leaf path (zod chains): a capturing subclass gets a
+/// synthesized forwarding ctor and takes the own-ctor path, whose tail-split
+/// derives from its own appended caps. Both the subclass's snapshot and the
+/// forwarded user arg must land.
+#[test]
+fn capturing_subclass_still_forwards_via_synthesized_ctor() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = compile_and_run(
+        dir.path(),
+        r##"
+function factory(kind: string): string {
+  class Type {
+    def: string;
+    constructor(def: string) {
+      this.def = def;
+    }
+    describe(): string {
+      return kind + "(" + this.def + ")";
+    }
+  }
+  class Num extends Type {
+    label(): string {
+      return kind + "#" + this.def;
+    }
+  }
+  const n = new Num("d1");
+  return n.describe() + " " + n.label();
+}
+
+console.log(factory("K"));
+"##,
+    );
+    assert_eq!(out, "K(d1) K#d1\n");
+}
+
+/// Rest-param ancestor ctor below a ctor-free leaf: ALL user args must
+/// reach the rest array (none eaten by the cap slot, none truncated).
+///
+/// Still failing — a DIFFERENT root than the walk: `Drain` unions the
+/// parent's captures (`synthesize_class_captures` inherits them), so it
+/// gets a SYNTHESIZED forwarding ctor and takes the own-ctor path. That
+/// synthesis (`class_captures.rs` "spec default ctor" arm) does NOT
+/// synthesize `constructor(...args){ super(...args) }` — it walks the
+/// nearest ancestor ctor's user arity and mints that many FIXED params
+/// (`__perry_dflt_arg_i`, `is_rest: false`). A rest-param ancestor counts
+/// as arity 1, so `new Drain("a","b","c")` binds only "a" and drops the
+/// rest → `P[a]`. (An extends-EXPR parent walks to arity 0 and drops ALL
+/// args — the mixin test above hits that variant too, beneath its
+/// dispatch-layer failure.) Fix is the spec `(...args)` synthesis via
+/// `SuperCallSpread` (see the follow-up to #806).
+#[ignore = "part 2: HIR default-ctor synthesis mints fixed arity instead of (...args) — rest ancestors truncate"]
+#[test]
+fn walk_into_rest_param_capturing_ctor() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = compile_and_run(
+        dir.path(),
+        r#"
+function collect(prefix: string): string {
+  class Sink {
+    all: string;
+    constructor(...parts: string[]) {
+      this.all = prefix + "[" + parts.join(",") + "]";
+    }
+  }
+  class Drain extends Sink {}
+  return new Drain("a", "b", "c").all;
+}
+
+console.log(collect("P"));
+"#,
+    );
+    assert_eq!(out, "P[a,b,c]\n");
+}


### PR DESCRIPTION
The no-own-ctor parent walk in `lower_call/new.rs` forwarded the `new`-site's `caps_absent_from_args` into the ancestor's `CaptureFill`. The binder then derived the user/cap tail-split from the **ancestor's** cap params — but a bare-ident site appends the **leaf's** captures, and a capturing leaf always synthesizes an own ctor (`synthesize_class_captures` early-returns only for capture-free classes), so a leaf that reaches this walk appended nothing. Result: trailing user args were eaten into cap slots while the decl-site snapshot silently rescued the cap itself — only the user args were lost.

Fixes the ctor-free-subclass-of-capturing-ancestor family from the #5917 matrix (`test_issue_806_default_derived_constructor_forwarding`'s in-scope variants):
- single-hop walk with one user arg
- two-hop walk with multiple user args
- capturing-subclass guard (zod chains — unchanged, still routed through the own-ctor path)

New e2e suite `issue_806_default_derived_ctor_forwarding.rs` (5 cases, all node-validated). Two sibling shapes remain red and are `#[ignore]`d with their traced mechanisms (HIR fixed-arity default-ctor synthesis; sig-cap/rest gaps in the runtime construct dispatchers) — follow-up tracked as **#5957**.

Also mirrors `js_super_construct_apply`'s `PERRY_SUPER_DEBUG` diagnostics into `run_class_constructor_on_this_flat`.

Code-only per contributor guidelines; metadata folded at merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed constructor forwarding for ctor-free subclass inheritance when captured parameters are involved, ensuring user-supplied arguments aren’t incorrectly split or consumed during parent constructor replay.
  * Added optional debug diagnostics for super-constructor execution when a debug environment flag is enabled.
* **Tests**
  * Added regression coverage for default/derived constructor forwarding, multi-hop ctor-free inheritance, captured-local scenarios, synthesized forwarding constructors, and rest-parameter handling, with byte-for-byte output assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->