### PR TITLE
ci: warm release compiler + gap-suite auto-opt variants in cache-warm

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -41,7 +41,10 @@ jobs:
     # Best-effort cache population — must never block or fail anything.
     continue-on-error: true
     # Comfortably above the cold first run; later runs are far shorter.
-    timeout-minutes: 120
+    # 150: the release-compiler + gap-suite variant warm below adds up to
+    # ~60 min on a cold variant set (it is the same bill the smoke job was
+    # paying per-PR; here it is paid once per merge, off the critical path).
+    timeout-minutes: 150
     env:
       RUSTC_WRAPPER: sccache
       # Mirror test.yml's sccache config EXACTLY (local disk cache, NOT the GHA
@@ -96,6 +99,33 @@ jobs:
             echo "::endgroup::"
             find target/debug/deps -maxdepth 1 -type f -perm -111 ! -name '*.so' -delete || true
           done
+
+      # Warm the RELEASE compiler + the auto-optimize archive variants for the
+      # conformance-smoke job. Diagnosis (2026-07-04, cancelled smoke job
+      # 85123031828): smoke restored this cache with a FULL match yet still
+      # timed out at 60 min — the debug units above share nothing with its
+      # release build (~10 min), and every gap test whose feature combo
+      # (`auto_optimized_cache_key`: regex/temporal/url/… × stdlib set) had no
+      # `target/perry-auto-<hash>` archive triggered an in-job cargo build of
+      # the runtime — orphan `cargo`/`rustc` processes were still compiling at
+      # the timeout. Running the gap suite ONCE here builds every variant the
+      # suite needs; they land in `target/perry-auto-*`, which rust-cache
+      # saves under the shared key. Variant keys embed CARGO_PKG_VERSION, and
+      # code-only PRs carry main's version, so PR smokes restore exact
+      # matches until the next merge bumps the version — at which point THIS
+      # workflow re-warms on that very push. `|| true`: this is a cache warm,
+      # not a gate — the smoke job is where gap failures are reported.
+      - name: Warm release compiler + gap-suite auto-opt variants
+        run: |
+          echo "::group::cargo build --release -p perry"
+          cargo build --release -p perry
+          echo "::endgroup::"
+          echo "::group::run_gap_tests (variant warm)"
+          ./scripts/run_gap_tests.sh || true
+          echo "::endgroup::"
+          echo "perry-auto variants warmed:"
+          du -sh target/perry-auto-* 2>/dev/null || echo "(none)"
+          df -h /home/runner 2>/dev/null | tail -1 || true
 
       - name: sccache stats
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.5.1233 — CI: cache-warm primes the release compiler + gap-suite auto-opt variants
+
+The conformance-smoke job restored the shared rust-cache with a full match and still hit its 60-minute timeout: the warmed DEBUG units share nothing with its RELEASE build, and every gap test whose auto-optimize feature combination had no `target/perry-auto-<hash>` archive kicked off an in-job cargo build of the runtime (orphan cargo/rustc still compiling at cancellation). cache-warm now builds the release compiler and runs the gap suite once per main merge so every variant lands under the shared key; code-only PRs carry main's `CARGO_PKG_VERSION`, so their smoke jobs restore exact variant matches until the next merge re-warms (job timeout 120 → 150 for the cold first run).
+
+Also brings the version stream back in sync with two code-only fleet merges that landed without metadata: #5953 (#5898 — mutating array methods throw on frozen/non-writable length) and #5954 (#5909 — `JSON.stringify` of a toJSON-returned cycle throws instead of SIGSEGV).
+
 ## v0.5.1232 — anchor inliner + deforest max-LocalId scans on the hardened id_scan
 
 The inliner (`inline/analysis.rs`) and deforestation (`deforest/walk.rs`) each carried their own ad-hoc max-LocalId scan to mint fresh locals; both were shallower than `generator::compute_max_local_id` (the scan hardened for #5143 to cover class field/static/computed-member/extends closures). A fresh local minted from an under-counting scan can collide with a LocalId owned by a closure the scan missed — the same defect class as #5143's FuncId collision. Both passes now seed from `crate::generator::compute_max_local_id(module)` and only extend it with their local maxima, so every future descent fix to the shared scan protects all three passes at once.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1232
+**Current Version:** 0.5.1233
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5338,7 +5338,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "anyhow",
  "base64",
@@ -5395,14 +5395,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "cc",
  "libc",
@@ -5410,7 +5410,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "anyhow",
  "log",
@@ -5425,7 +5425,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5461,7 +5461,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "anyhow",
  "base64",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5511,14 +5511,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "serde",
  "serde_json",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1232"
+version = "0.5.1233"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "anyhow",
  "clap",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "block2",
  "objc2",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5570,7 +5570,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5611,7 +5611,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "chrono",
  "cron",
@@ -5621,7 +5621,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5629,7 +5629,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5637,7 +5637,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5645,7 +5645,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5653,7 +5653,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5661,14 +5661,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5686,7 +5686,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5713,7 +5713,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "bytes",
  "h2",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5757,7 +5757,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5765,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "bson",
  "futures-util",
@@ -5785,7 +5785,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5795,7 +5795,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5804,7 +5804,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -5817,7 +5817,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5827,7 +5827,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5844,7 +5844,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5852,7 +5852,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -5862,14 +5862,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5878,7 +5878,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5908,7 +5908,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "brotli",
  "flate2",
@@ -5917,7 +5917,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5926,7 +5926,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5944,7 +5944,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5956,7 +5956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "anyhow",
  "base64",
@@ -5989,14 +5989,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6089,14 +6089,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6106,7 +6106,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6114,14 +6114,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "base64",
  "itoa",
@@ -6138,7 +6138,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6148,7 +6148,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6171,7 +6171,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "base64",
  "block2",
@@ -6187,7 +6187,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "base64",
  "block2",
@@ -6202,7 +6202,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1232"
+version = "0.5.1233"
 
 [[package]]
 name = "perry-ui-test"
@@ -6210,11 +6210,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1232"
+version = "0.5.1233"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "base64",
  "block2",
@@ -6230,7 +6230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "base64",
  "block2",
@@ -6246,7 +6246,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "block2",
  "libc",
@@ -6259,7 +6259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "base64",
  "libc",
@@ -6276,14 +6276,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6297,7 +6297,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1232"
+version = "0.5.1233"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -301,7 +301,7 @@ strip = false
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1232"
+version = "0.5.1233"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"


### PR DESCRIPTION
The conformance-smoke job (#5947) is timing out at 60 minutes despite a full rust-cache hit. Diagnosis from cancelled job 85123031828: the cache only holds DEBUG units (cache-warm runs `cargo test --no-run`), so smoke pays a ~10-minute release compiler build — and, much worse, every gap test whose auto-optimize feature combination (`auto_optimized_cache_key`: regex/temporal/url/… × stdlib feature set) has no `target/perry-auto-<hash>` archive triggers an **in-job cargo build of the runtime**. Orphan `cargo`/`rustc` processes were still compiling at the moment of the timeout cancellation.

Fix: cache-warm now builds the release compiler and runs the gap suite once per main merge, so every auto-opt variant the suite needs lands in `target/perry-auto-*` and is saved under the existing shared key. Variant cache keys embed `CARGO_PKG_VERSION`; code-only PRs carry main's version, so PR smoke jobs restore exact matches until the next merge bumps the version — at which point cache-warm re-warms on that very push. The gap run here is `|| true` (cache warm, not a gate — smoke is where failures report). Job timeout 120 → 150 for the cold-variant first run.

Expected smoke wall time once warm: ~10 min build + ~5-8 min tests, comfortably inside the 60-minute budget — which is what unblocks the #9 plan of flipping conformance-smoke to a required check.

Code-only; metadata folded at merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved cache-warming in the CI build workflow by priming the release compiler and running the gap-suite warm path to populate shared cache artifacts.
  * Extended the warm-job timeout to better handle longer cache warmups.
  * Added best-effort disk usage reporting and non-blocking cache checks to keep the workflow resilient.
  * Bumped the workspace version metadata to **v0.5.1233** and updated the current version in the project docs/notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->