### PR TITLE
fix(intl): #5904 — ResolveLocale for the `nu` numbering-system extension (NumberFormat/DateTimeFormat/DurationFormat)

### DIFF
--- a/crates/perry-runtime/src/intl.rs
+++ b/crates/perry-runtime/src/intl.rs
@@ -34,6 +34,8 @@ mod list_relative_plural;
 mod number_format;
 mod number_format_digits;
 mod number_format_options;
+mod numbering_system;
+use numbering_system::{is_well_formed_numbering_system, resolve_numbering_system};
 mod segmenter;
 
 pub(crate) use date_collator::{
@@ -439,50 +441,6 @@ fn currency_fraction_digits(code: &str) -> u32 {
         "BHD" | "IQD" | "JOD" | "KWD" | "LYD" | "OMR" | "TND" => 3,
         _ => 2,
     }
-}
-
-/// A `numberingSystem` value is structurally valid when it is one or more
-/// hyphen-separated subtags of 3–8 alphanumerics (the `type` Unicode nonterminal).
-fn is_well_formed_numbering_system(value: &str) -> bool {
-    !value.is_empty()
-        && value.split('-').all(|sub| {
-            (3..=8).contains(&sub.len()) && sub.bytes().all(|b| b.is_ascii_alphanumeric())
-        })
-}
-
-/// Extract the `-u-nu-<value>` numbering system from a (canonicalized) locale
-/// string, lower-cased. Returns `None` when no `nu` keyword is present.
-fn numbering_system_from_locale(locale: &str) -> Option<String> {
-    let lower = locale.to_ascii_lowercase();
-    let subtags: Vec<&str> = lower.split('-').collect();
-    let u = subtags.iter().position(|s| *s == "u")?;
-    let mut i = u + 1;
-    while i < subtags.len() {
-        let key = subtags[i];
-        // A keyword key is exactly two chars; everything up to the next key is its value.
-        if key.len() == 2 {
-            if key == "nu" {
-                let mut value = String::new();
-                let mut j = i + 1;
-                while j < subtags.len() && subtags[j].len() != 2 {
-                    if !value.is_empty() {
-                        value.push('-');
-                    }
-                    value.push_str(subtags[j]);
-                    j += 1;
-                }
-                return (!value.is_empty()).then_some(value);
-            }
-            i += 1;
-            while i < subtags.len() && subtags[i].len() != 2 {
-                i += 1;
-            }
-        } else {
-            // Hit another singleton extension (e.g. `-t-`); `nu` lives only under `u`.
-            break;
-        }
-    }
-    None
 }
 
 #[cold]
@@ -1125,15 +1083,23 @@ fn make_instance(closure: *const ClosureHeader, kind: &str, locales: f64, option
                     )),
                 }
             }
-            // `numberingSystem` must be a well-formed `type` nonterminal.
-            if let Some(ns) = get_locale_extension_option(options, "numberingSystem") {
+            // `numberingSystem` must be a well-formed `type` nonterminal. Read
+            // it here (preserving the GetOption order options-order.js asserts),
+            // then run ResolveLocale for `nu` — reconciling the option with the
+            // locale's `-u-nu-` keyword so `resolvedOptions().locale` /
+            // `.numberingSystem` reflect only the supported value actually used.
+            let dtf_opt_ns = get_locale_extension_option(options, "numberingSystem").map(|ns| {
                 if !is_well_formed_numbering_system(&ns) {
                     throw_range_error(&format!(
                         "Value {ns} out of range for Intl options property numberingSystem"
                     ));
                 }
-                set_internal_field(obj, KEY_NUMBERING_SYSTEM, string_value(&ns));
-            }
+                ns.to_ascii_lowercase()
+            });
+            let (dtf_locale, dtf_numbering) =
+                resolve_numbering_system(&locale, dtf_opt_ns.as_deref());
+            set_internal_field(obj, KEY_LOCALE, string_value(&dtf_locale));
+            set_internal_field(obj, KEY_NUMBERING_SYSTEM, string_value(&dtf_numbering));
             // hour12 (boolean) then hourCycle (enum) — both only surface in
             // `resolvedOptions` when the resolved pattern has an hour field.
             if let Some(h12) = get_bool_option(options, "hour12") {

--- a/crates/perry-runtime/src/intl/duration_format.rs
+++ b/crates/perry-runtime/src/intl/duration_format.rs
@@ -236,17 +236,23 @@ pub(super) fn configure(obj: *mut ObjectHeader, options: f64) {
         "best fit",
     );
 
-    let numbering = match df_get_option_string(options, "numberingSystem") {
+    let opt_ns = match df_get_option_string(options, "numberingSystem") {
         Some(ns) => {
             if !valid_numbering_system(&ns) {
                 throw_range_error(&format!(
                     "Value {ns} out of range for Intl.DurationFormat options property numberingSystem"
                 ));
             }
-            ns
+            Some(ns.to_ascii_lowercase())
         }
-        None => "latn".to_string(),
+        None => None,
     };
+    // ResolveLocale for `nu`: reconcile the option with the requested locale's
+    // `-u-nu-` keyword (stored in KEY_LOCALE at construction) and update both the
+    // resolved locale and numbering system.
+    let locale = get_string_field(obj, KEY_LOCALE).unwrap_or_else(|| "en-US".to_string());
+    let (resolved_locale, numbering) = super::resolve_numbering_system(&locale, opt_ns.as_deref());
+    set_internal_field(obj, KEY_LOCALE, string_value(&resolved_locale));
     set_internal_field(obj, KEY_DF_NUMBERING, string_value(&numbering));
 
     let base_style = df_enum_option(

--- a/crates/perry-runtime/src/intl/number_format_options.rs
+++ b/crates/perry-runtime/src/intl/number_format_options.rs
@@ -33,9 +33,11 @@ pub(crate) fn configure_number_format(obj: *mut ObjectHeader, locale: &str, opti
         "best fit",
     );
 
-    // numberingSystem: option (validated, lower-cased) overrides the locale
-    // `-u-nu-` keyword; default "latn".
-    let numbering = match get_option_string(options, "numberingSystem") {
+    // numberingSystem: validate the option (well-formed `type` nonterminal),
+    // then run ResolveLocale for the `nu` key — reconciling the option with the
+    // requested locale's `-u-nu-` keyword and updating the resolved locale so
+    // `resolvedOptions().locale` reflects only the supported value actually used.
+    let opt_ns = match get_option_string(options, "numberingSystem") {
         Some(value) => {
             let lower = value.to_ascii_lowercase();
             if !is_well_formed_numbering_system(&lower) {
@@ -43,10 +45,12 @@ pub(crate) fn configure_number_format(obj: *mut ObjectHeader, locale: &str, opti
                     "Value {value} out of range for Intl.NumberFormat options property numberingSystem"
                 ));
             }
-            lower
+            Some(lower)
         }
-        None => numbering_system_from_locale(locale).unwrap_or_else(|| "latn".to_string()),
+        None => None,
     };
+    let (resolved_locale, numbering) = resolve_numbering_system(locale, opt_ns.as_deref());
+    set_internal_field(obj, KEY_LOCALE, string_value(&resolved_locale));
     set_internal_field(obj, KEY_NF_NUMBERING, string_value(&numbering));
 
     // SetNumberFormatUnitOptions.

--- a/crates/perry-runtime/src/intl/numbering_system.rs
+++ b/crates/perry-runtime/src/intl/numbering_system.rs
@@ -1,0 +1,184 @@
+//! `-u-nu-` (numbering system) Unicode-extension resolution for the Intl
+//! service constructors. Splitting these BCP-47 tag helpers out of `intl.rs`
+//! keeps that namespace module under the repository's 2,000-line gate.
+
+/// A `numberingSystem` value is structurally valid when it is one or more
+/// hyphen-separated subtags of 3–8 alphanumerics (the `type` Unicode nonterminal).
+pub(super) fn is_well_formed_numbering_system(value: &str) -> bool {
+    !value.is_empty()
+        && value.split('-').all(|sub| {
+            (3..=8).contains(&sub.len()) && sub.bytes().all(|b| b.is_ascii_alphanumeric())
+        })
+}
+
+/// A numbering system is *supported* when it is the default `latn` (Latin/ASCII
+/// digits, which need no transliteration table) or Perry has a digit table for
+/// it. This is the set `resolvedOptions().numberingSystem` may report; other
+/// (e.g. algorithmic) systems are treated as unsupported and fall back to `latn`.
+pub(super) fn is_supported_numbering_system(name: &str) -> bool {
+    name == "latn" || super::number_format_digits::numbering_system_digits(name).is_some()
+}
+
+/// ResolveLocale for the `nu` (numbering system) Unicode extension key
+/// (ECMA-402): reconciles the requested locale's `-u-nu-` keyword with an
+/// explicit `options.numberingSystem`, and returns the resolved
+/// `(locale, numberingSystem)` pair. `opt_ns` is the already-validated,
+/// lower-cased option value (or `None`). The resolved locale keeps `-u-nu-X`
+/// only when `X` is the *supported* value actually used AND it originated from
+/// the locale extension (i.e. an option that differs from a supported extension
+/// drops the keyword). See NumberFormat resolved-numbering-system test262.
+pub(super) fn resolve_numbering_system(locale: &str, opt_ns: Option<&str>) -> (String, String) {
+    let ext_ns =
+        numbering_system_from_locale(locale).filter(|ns| is_supported_numbering_system(ns));
+    let opt_supported = opt_ns.filter(|ns| is_supported_numbering_system(ns));
+
+    let (resolved_ns, keep_ext) = match (opt_supported, &ext_ns) {
+        // Option present and supported: it wins; the locale keyword survives only
+        // when it names the same value.
+        (Some(opt), ext) => (opt.to_string(), ext.as_deref() == Some(opt)),
+        // No usable option: fall back to the supported extension, else default.
+        (None, Some(ext)) => (ext.clone(), true),
+        (None, None) => ("latn".to_string(), false),
+    };
+
+    let resolved_locale = if keep_ext {
+        with_numbering_system_keyword(locale, &resolved_ns)
+    } else {
+        strip_numbering_system_keyword(locale)
+    };
+    (resolved_locale, resolved_ns)
+}
+
+/// Extract the `-u-nu-<value>` numbering system from a (canonicalized) locale
+/// string, lower-cased. Returns `None` when no `nu` keyword is present.
+pub(super) fn numbering_system_from_locale(locale: &str) -> Option<String> {
+    let lower = locale.to_ascii_lowercase();
+    let subtags: Vec<&str> = lower.split('-').collect();
+    let u = subtags.iter().position(|s| *s == "u")?;
+    let mut i = u + 1;
+    while i < subtags.len() {
+        let key = subtags[i];
+        // A keyword key is exactly two chars; everything up to the next key is its value.
+        if key.len() == 2 {
+            if key == "nu" {
+                let mut value = String::new();
+                let mut j = i + 1;
+                while j < subtags.len() && subtags[j].len() != 2 {
+                    if !value.is_empty() {
+                        value.push('-');
+                    }
+                    value.push_str(subtags[j]);
+                    j += 1;
+                }
+                return (!value.is_empty()).then_some(value);
+            }
+            i += 1;
+            while i < subtags.len() && subtags[i].len() != 2 {
+                i += 1;
+            }
+        } else {
+            // Hit another singleton extension (e.g. `-t-`); `nu` lives only under `u`.
+            break;
+        }
+    }
+    None
+}
+
+/// Split a locale tag into `(base, u_keywords, tail_after_u)`, where
+/// `u_keywords` is the ordered list of `(key, value)` pairs inside the `-u-`
+/// extension and `tail` is everything from the next singleton onward (e.g. a
+/// `-t-`/`-x-` sequence). Returns `None` when the tag has no `-u-` extension.
+/// The `base` keeps its original canonical casing (`en-US`); the extension /
+/// tail regions are lower-cased per UTS #35.
+fn split_u_extension(locale: &str) -> Option<(String, Vec<(String, Vec<String>)>, String)> {
+    // Preserve the base region's casing (`en-US` must not become `en-us`); only
+    // the extension region is canonically lower-cased.
+    let subtags: Vec<&str> = locale.split('-').collect();
+    let u = subtags.iter().position(|s| s.eq_ignore_ascii_case("u"))?;
+    let base = subtags[..u].join("-");
+    let lower: Vec<String> = subtags.iter().map(|s| s.to_ascii_lowercase()).collect();
+
+    let mut keywords: Vec<(String, Vec<String>)> = Vec::new();
+    let mut i = u + 1;
+    let mut tail_start = subtags.len();
+    while i < subtags.len() {
+        let sub = lower[i].as_str();
+        if sub.len() == 1 {
+            // Next singleton (`t`/`x`/…) ends the `u` extension.
+            tail_start = i;
+            break;
+        }
+        // A keyword key is exactly two chars; the value runs until the next key.
+        if sub.len() == 2 {
+            let key = sub.to_string();
+            let mut value = Vec::new();
+            let mut j = i + 1;
+            while j < subtags.len() && lower[j].len() != 2 && lower[j].len() != 1 {
+                value.push(lower[j].clone());
+                j += 1;
+            }
+            keywords.push((key, value));
+            i = j;
+        } else {
+            // An `-u-` attribute (3+ chars with no preceding key). Keep it as a
+            // value-less pseudo-keyword so round-tripping doesn't drop it.
+            keywords.push((sub.to_string(), Vec::new()));
+            i += 1;
+        }
+    }
+    let tail = if tail_start < subtags.len() {
+        lower[tail_start..].join("-")
+    } else {
+        String::new()
+    };
+    Some((base, keywords, tail))
+}
+
+/// Reassemble a locale from a `split_u_extension` decomposition, dropping the
+/// `-u-` extension entirely when no keywords remain.
+fn rebuild_locale(base: &str, keywords: &[(String, Vec<String>)], tail: &str) -> String {
+    let mut out = base.to_string();
+    if !keywords.is_empty() {
+        out.push_str("-u");
+        for (key, value) in keywords {
+            out.push('-');
+            out.push_str(key);
+            for v in value {
+                out.push('-');
+                out.push_str(v);
+            }
+        }
+    }
+    if !tail.is_empty() {
+        out.push('-');
+        out.push_str(tail);
+    }
+    out
+}
+
+/// Remove the `-u-nu-<value>` keyword from a locale tag (dropping the whole
+/// `-u-` extension if it becomes empty). A tag with no `nu` keyword is returned
+/// unchanged.
+fn strip_numbering_system_keyword(locale: &str) -> String {
+    let Some((base, mut keywords, tail)) = split_u_extension(locale) else {
+        return locale.to_string();
+    };
+    keywords.retain(|(key, _)| key != "nu");
+    rebuild_locale(&base, &keywords, &tail)
+}
+
+/// Ensure the locale tag carries `-u-nu-<ns>` (adding a `-u-` extension if
+/// absent, or replacing an existing `nu` value).
+fn with_numbering_system_keyword(locale: &str, ns: &str) -> String {
+    let (base, mut keywords, tail) = match split_u_extension(locale) {
+        Some(parts) => parts,
+        None => (locale.to_string(), Vec::new(), String::new()),
+    };
+    let value = vec![ns.to_string()];
+    if let Some(entry) = keywords.iter_mut().find(|(key, _)| key == "nu") {
+        entry.1 = value;
+    } else {
+        keywords.push(("nu".to_string(), value));
+    }
+    rebuild_locale(&base, &keywords, &tail)
+}


### PR DESCRIPTION
## Summary

Implements the ECMA-402 **ResolveLocale** step for the `nu` (numbering system) Unicode extension key across `Intl.NumberFormat`, `Intl.DateTimeFormat`, and `Intl.DurationFormat`. The requested locale's `-u-nu-` keyword is reconciled with an explicit `options.numberingSystem`, and the **resolved locale** is rewritten so `resolvedOptions().locale` / `.numberingSystem` reflect only the *supported* value actually used:

| requested locale | `options.numberingSystem` | resolved `locale` | resolved `numberingSystem` |
|---|---|---|---|
| `en-u-nu-arab` | `invalid` (unsupported) | `en-u-nu-arab` | `arab` |
| `en-u-nu-invalid` | `invalid2` | `en` | `latn` |
| `en-u-nu-latn` | `arab` | `en` | `arab` |
| `en-u-nu-arab` | `arab` | `en-u-nu-arab` | `arab` |

Rules:
- **option present + supported** → option wins; the `-u-nu-` keyword survives in the resolved locale only when it names the same value as the (supported) option.
- **no usable option** → fall back to the supported locale-extension value, else the `latn` default (keyword dropped from the locale).

A numbering system counts as *supported* when it is `latn` (the default Latin/ASCII digits, which need no transliteration table) or Perry has a digit table for it.

## Root cause

`configure_number_format` (and the DTF / DurationFormat equivalents) only validated the `numberingSystem` option for well-formedness and never ran ResolveLocale: the resolved `locale` kept the `-u-nu-` extension verbatim regardless of whether the system was supported or overridden, and `resolvedOptions().numberingSystem` didn't reflect the option-vs-extension precedence.

## Implementation notes

- New `crates/perry-runtime/src/intl/numbering_system.rs` module holds the `-u-nu-` BCP-47 tag helpers (`resolve_numbering_system`, `split_u_extension`, `strip`/`with_numbering_system_keyword`, `is_supported_numbering_system`, plus the pre-existing `numbering_system_from_locale` / `is_well_formed_numbering_system` moved out of `intl.rs` to keep it under the 2,000-line gate).
- **Base-tag casing is preserved** — the extension parser lower-cases only the extension/tail region, so `en-US` no longer collapses to `en-us` (this was the subtle bug that would otherwise have regressed `numbering-system-options.js`).
- Wired into all three constructors at their existing `numberingSystem` GetOption read site, preserving the option-read order that `constructor-options-order.js` asserts.

## Before / after (test262, internal Linux box, Node v26.3.0)

| slice | before failing | after failing | fixed |
|---|---|---|---|
| `intl402/NumberFormat` | 28 | 27 | `resolved-numbering-system-unicode-extensions-and-options.js` |
| `intl402/DateTimeFormat` | 44 | 43 | `resolved-numbering-system-unicode-extensions-and-options.js` |
| `intl402/DurationFormat` | 11 | 10 | `resolved-numbering-system-unicode-extensions-and-options.js` |

**+3 tests, zero regressions** (verified across NumberFormat / DateTimeFormat / DurationFormat / Collator, including `numbering-system-options.js` staying green).

`cargo fmt --all -- --check` and `scripts/check_file_size.sh` pass.

Refs #5904 #5899 #5906

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Locale-based numbering system handling is now applied consistently across date/time and number formatting.
  * Formatting now resolves the effective locale and numbering system together, including Unicode locale extensions.

* **Bug Fixes**
  * Improved handling of `numberingSystem` so invalid or unsupported values are normalized correctly.
  * Fixed cases where the displayed locale could differ from the actual numbering system used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->