### PR TITLE
fix(runtime): #5961 — URLSearchParams methods reachable through dynamic access

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
@@ -1910,6 +1910,27 @@ pub(crate) fn get_field_by_name_object_tail(
             }
         }
 
+        // #5961: native URLSearchParams is an ordinary object (class_id == 0,
+        // leading `_entries` slot) whose method surface normally exists only
+        // via static type-directed lowering. A type-erased receiver lands
+        // here instead — resolve the methods dynamically so `sp.append(...)`
+        // stays callable, and `size` reads as a number.
+        if !key.is_null() && crate::url::search_params::shape_is_url_search_params(obj) {
+            if let Ok(name) = std::str::from_utf8(key_bytes) {
+                if name == "size" {
+                    let n = crate::url::search_params::js_url_search_params_size(
+                        obj as *mut ObjectHeader,
+                    );
+                    return JSValue::from_bits((n as f64).to_bits());
+                }
+                if let Some(v) =
+                    crate::url::search_params::url_search_params_method_value(obj, name)
+                {
+                    return JSValue::from_bits(v.to_bits());
+                }
+            }
+        }
+
         // Key not found
         JSValue::undefined()
     }

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -717,6 +717,27 @@ pub unsafe extern "C" fn js_native_call_method(
             args_len > 0 && !args_ptr.is_null() && { crate::value::js_is_truthy(*args_ptr) != 0 };
         return js_using_check_disposable(object, want_async);
     }
+    // #5961: native URLSearchParams is an ordinary object (class_id == 0,
+    // leading `_entries` slot) whose method surface normally resolves via
+    // static type-directed lowering. A fused dynamic call on a type-erased
+    // receiver lands here — dispatch the covered surface to the natives
+    // before the generic field-scan misses and throws "is not a function".
+    if matches!(
+        method_name,
+        "append" | "set" | "get" | "has" | "delete" | "toString"
+    ) {
+        let recv_ptr = (object.to_bits() & 0x0000_FFFF_FFFF_FFFF) as *mut ObjectHeader;
+        if crate::url::search_params::shape_is_url_search_params(recv_ptr) {
+            if let Some(result) = crate::url::search_params::url_search_params_dynamic_call(
+                recv_ptr,
+                method_name,
+                args_ptr,
+                args_len,
+            ) {
+                return result;
+            }
+        }
+    }
     // Generic `Array.prototype` mutators borrowed onto a plain array-like
     // object (`Array.prototype.splice.call(obj, …)` whose synthesized member
     // call dispatches by name with no own method). The dense array arms further

--- a/crates/perry-runtime/src/url/search_params.rs
+++ b/crates/perry-runtime/src/url/search_params.rs
@@ -797,3 +797,170 @@ pub extern "C" fn js_url_search_params_get_all(params: *mut ObjectHeader, name_v
     }
     f64::from_bits(i64::cast_unsigned(result as i64))
 }
+
+// ---- #5961: dynamic method dispatch for type-erased receivers ----
+//
+// The native URLSearchParams is an ordinary object (class_id == 0, leading
+// `_entries` slot — see `create_url_search_params_object` /
+// `try_read_as_search_params`); its method surface normally exists only via
+// static type-directed lowering (perry-codegen url_main.rs). When the
+// receiver's static type is lost (`any`, heterogeneous containers, minified
+// bundles), the generic dynamic member read used to find nothing and
+// `sp.append(...)` threw "append is not a function". These bound-method
+// thunks mirror the webcrypto_method_value pattern
+// (object/global_this/ctor_thunks.rs) with the receiver carried in a
+// GC-traced nanboxed capture slot.
+
+/// True when `obj` has the native URLSearchParams shape: an ordinary object
+/// (class_id == 0) whose leading own key is `_entries`. Mirrors the guard in
+/// [`try_read_as_search_params`] without materializing the entries.
+pub(crate) fn shape_is_url_search_params(obj: *const ObjectHeader) -> bool {
+    if obj.is_null() {
+        return false;
+    }
+    unsafe {
+        if (*obj).class_id != 0 {
+            return false;
+        }
+        let keys_arr = (*obj).keys_array;
+        if keys_arr.is_null() || (*keys_arr).length == 0 {
+            return false;
+        }
+        let key0 = crate::array::js_array_get_f64(keys_arr, 0);
+        get_string_content(key0) == "_entries"
+    }
+}
+
+fn usp_thunk_receiver(closure: *const crate::closure::ClosureHeader) -> *mut ObjectHeader {
+    let recv = crate::closure::js_closure_get_capture_f64(closure, 0);
+    (recv.to_bits() & 0x0000_FFFF_FFFF_FFFF) as *mut ObjectHeader
+}
+
+extern "C" fn usp_append_thunk(
+    closure: *const crate::closure::ClosureHeader,
+    name: f64,
+    value: f64,
+) -> f64 {
+    js_url_search_params_append(usp_thunk_receiver(closure), name, value);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+extern "C" fn usp_set_thunk(
+    closure: *const crate::closure::ClosureHeader,
+    name: f64,
+    value: f64,
+) -> f64 {
+    js_url_search_params_set(usp_thunk_receiver(closure), name, value);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+extern "C" fn usp_get_thunk(closure: *const crate::closure::ClosureHeader, name: f64) -> f64 {
+    // js_url_search_params_get returns a raw `*mut StringHeader` for the
+    // static-lowering path; rebuild the boxed value here instead.
+    let wanted = coerce_search_param_arg(name);
+    let entries = get_url_search_params_entries(usp_thunk_receiver(closure));
+    match entries.into_iter().find(|(k, _)| *k == wanted) {
+        Some((_, v)) => create_string_f64(&v),
+        None => f64::from_bits(crate::value::TAG_NULL),
+    }
+}
+
+extern "C" fn usp_has_thunk(closure: *const crate::closure::ClosureHeader, name: f64) -> f64 {
+    if js_url_search_params_has(usp_thunk_receiver(closure), name) != 0.0 {
+        f64::from_bits(crate::value::TAG_TRUE)
+    } else {
+        f64::from_bits(crate::value::TAG_FALSE)
+    }
+}
+
+extern "C" fn usp_delete_thunk(closure: *const crate::closure::ClosureHeader, name: f64) -> f64 {
+    js_url_search_params_delete(usp_thunk_receiver(closure), name);
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+/// Fused dynamic method call (`sp.append(...)` through `js_native_call_method`
+/// on a type-erased receiver): dispatch the covered URLSearchParams surface to
+/// the natives. Returns `None` for uncovered names so the generic dispatch
+/// keeps its existing behavior.
+pub(crate) fn url_search_params_dynamic_call(
+    params: *mut ObjectHeader,
+    name: &str,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> Option<f64> {
+    let undefined = f64::from_bits(crate::value::TAG_UNDEFINED);
+    let arg = |i: usize| -> f64 {
+        if !args_ptr.is_null() && i < args_len {
+            unsafe { *args_ptr.add(i) }
+        } else {
+            undefined
+        }
+    };
+    Some(match name {
+        "append" => {
+            js_url_search_params_append(params, arg(0), arg(1));
+            undefined
+        }
+        "set" => {
+            js_url_search_params_set(params, arg(0), arg(1));
+            undefined
+        }
+        "get" => {
+            let wanted = coerce_search_param_arg(arg(0));
+            match get_url_search_params_entries(params)
+                .into_iter()
+                .find(|(k, _)| *k == wanted)
+            {
+                Some((_, v)) => create_string_f64(&v),
+                None => f64::from_bits(crate::value::TAG_NULL),
+            }
+        }
+        "has" => {
+            if js_url_search_params_has(params, arg(0)) != 0.0 {
+                f64::from_bits(crate::value::TAG_TRUE)
+            } else {
+                f64::from_bits(crate::value::TAG_FALSE)
+            }
+        }
+        "delete" => {
+            js_url_search_params_delete(params, arg(0));
+            undefined
+        }
+        "toString" => {
+            let entries = get_url_search_params_entries(params);
+            let joined = entries
+                .iter()
+                .map(|(k, v)| format!("{}={}", url_encode(k), url_encode(v)))
+                .collect::<Vec<_>>()
+                .join("&");
+            create_string_f64(&joined)
+        }
+        _ => return None,
+    })
+}
+
+/// Bound-method value for a dynamic property read on a native URLSearchParams
+/// object. Returns `None` for names outside the covered surface so unknown
+/// properties still read as `undefined`.
+pub(crate) fn url_search_params_method_value(obj: *const ObjectHeader, name: &str) -> Option<f64> {
+    let (func_ptr, arity): (*const u8, u32) = match name {
+        "append" => (usp_append_thunk as *const u8, 2),
+        "set" => (usp_set_thunk as *const u8, 2),
+        "get" => (usp_get_thunk as *const u8, 1),
+        "has" => (usp_has_thunk as *const u8, 1),
+        "delete" => (usp_delete_thunk as *const u8, 1),
+        _ => return None,
+    };
+    crate::closure::js_register_closure_arity(func_ptr, arity);
+    let closure = crate::closure::js_closure_alloc(func_ptr, 1);
+    if closure.is_null() {
+        return Some(f64::from_bits(crate::value::TAG_UNDEFINED));
+    }
+    // Nanboxed (not raw-ptr) capture so the GC traces the receiver.
+    crate::closure::js_closure_set_capture_f64(
+        closure,
+        0,
+        crate::value::js_nanbox_pointer(obj as i64),
+    );
+    Some(crate::value::js_nanbox_pointer(closure as i64))
+}

--- a/crates/perry/tests/issue_5961_urlsearchparams_dynamic_dispatch.rs
+++ b/crates/perry/tests/issue_5961_urlsearchparams_dynamic_dispatch.rs
@@ -1,0 +1,88 @@
+//! Regression test for #5961: native URLSearchParams methods were unreachable
+//! through dynamically-typed access. The instance is an ordinary object
+//! (class_id == 0, `_entries`/`_owner` slots) whose method surface existed
+//! only via static type-directed lowering — the moment the receiver's static
+//! type was lost (`any`, containers, bundled/minified code), `sp.append(...)`
+//! threw "append is not a function" and `typeof sp.append` read `undefined`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+/// The #5961 shape: a type-erased receiver must still expose the callable
+/// method surface, both as a fused call and as a property read.
+#[test]
+fn type_erased_searchparams_methods_dispatch() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const u = new URL("https://x.com/p");
+const o: any = [u.searchParams][0]; // launder the static type
+
+console.log("T", typeof o.append);
+
+o.append("a", "1");
+o.append("b", "two words");
+o.set("a", "2");
+console.log("GET", o.get("a"), o.get("missing"));
+console.log("HAS", o.has("b"), o.has("nope"));
+console.log("STR", o.toString());
+console.log("SIZE", o.size);
+o.delete("b");
+console.log("AFTER", u.toString());
+
+// Property-read-then-call (non-fused) must work too.
+const m: any = o.append;
+m("c", "3");
+console.log("BOUND", o.has("c"));
+"#,
+    );
+    assert!(stdout.contains("T function"), "typeof: {stdout}");
+    assert!(stdout.contains("GET 2 null"), "get: {stdout}");
+    assert!(stdout.contains("HAS true false"), "has: {stdout}");
+    assert!(stdout.contains("STR a=2&b=two+words"), "toString: {stdout}");
+    assert!(stdout.contains("SIZE 2"), "size: {stdout}");
+    assert!(
+        stdout.contains("AFTER https://x.com/p?a=2"),
+        "delete/owner-sync: {stdout}"
+    );
+    assert!(stdout.contains("BOUND true"), "bound method: {stdout}");
+}


### PR DESCRIPTION
## Problem — #5961

```ts
const u = new URL("https://x.com/p");
const o: any = [u.searchParams][0];   // any type-erasing indirection
o.append("a", "1");                    // TypeError: append is not a function
```

The native URLSearchParams is an ordinary object (`class_id == 0`, `_entries`/`_owner` slots) whose method surface existed **only** via static type-directed lowering (`perry-codegen/expr/url_main.rs`). With the receiver's static type lost — `any`, containers, bundled/minified code where inference can't follow the value — the generic dynamic paths found nothing: `typeof sp.append` read `undefined`, and every method call threw `X is not a function`. Real-world hit: a bundle's auth-URL builder doing eleven `url.searchParams.append(...)` calls failed at runtime while the identical extracted code passed.

## Fix

Mirrors the `webcrypto_method_value` pattern, covering the three dynamic entry points:

- **`url/search_params.rs`** — `shape_is_url_search_params` (the `try_read_as_search_params` guard without materializing entries), `url_search_params_dynamic_call` (fused-call dispatch: `append/set/get/has/delete/toString`), `url_search_params_method_value` (bound-closure thunks for property reads; receiver in a GC-traced nanboxed capture). `get`/`toString` rebuild boxed results (the raw natives return `*mut StringHeader` for the static path); `has` boxes a real boolean.
- **`object/native_call_method.rs`** — dispatch arm for covered names before the generic field-scan (fused `inst.m(...)` calls resolve here, not through get_field — property-read fixes alone leave calls broken).
- **`object/field_get_set/get_field_by_name_tail.rs`** — final-miss hook: `typeof sp.append === "function"`, extracted methods (`const m = sp.append; m(...)`) are callable and receiver-bound, `size` reads as a number.

Uncovered names still read as `undefined` / fall through unchanged. All guards are shape-checked (`class_id == 0` + leading `_entries` key) so `util.MIMEParams` and plain objects are untouched.

## Validation

New e2e test `crates/perry/tests/issue_5961_urlsearchparams_dynamic_dispatch.rs`: typeof, fused calls, `get` (hit + `null` miss), boolean `has`, WHATWG `toString` (`two+words`), `size`, owner-URL sync after `set`/`delete`, and extracted-method invocation — output matches node. Passes locally (`cargo test --release -p perry --test issue_5961_...` → 1 passed). Also validated in the originating 13 MB bundle: the auth-URL builder now runs (compile in flight for the fully-unpatched confirmation).

Fixes #5961.

https://claude.ai/code/session_01K1w6WLaFNKhf4aNxeSWHy6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved `URLSearchParams` support when values are accessed dynamically, including method calls and property reads.
  * Added handling for key properties like `size` and common methods such as `append`, `set`, `get`, `has`, `delete`, and `toString`.

* **Bug Fixes**
  * Fixed cases where `URLSearchParams` methods could stop working after type information was lost.
  * Ensured method references still behave correctly when stored and called later.

* **Tests**
  * Added regression coverage for dynamic `URLSearchParams` access and method behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->