### PR TITLE
fix(intl): #5906 — Intl.DurationFormat accepts Temporal.Duration + exact IsValidDurationRecord

### DIFF
--- a/crates/perry-runtime/src/intl/duration_format.rs
+++ b/crates/perry-runtime/src/intl/duration_format.rs
@@ -373,6 +373,15 @@ const DURATION_UNITS: &[&str] = &[
 /// non-string is a `TypeError`; out-of-range / non-integral / mixed-sign records are
 /// a `RangeError`.
 fn to_duration_record(value: f64) -> Vec<f64> {
+    // `ToDurationRecord` first branch: a `Temporal.Duration` (or subclass) copies
+    // its internal slots directly — no prototype getters observed, no field-order
+    // side effects. Only reachable when the Temporal engine is compiled in.
+    #[cfg(feature = "temporal")]
+    if let Some(vals) = crate::temporal::duration_unit_values(value) {
+        let vals = vals.to_vec();
+        validate_duration(&vals);
+        return vals;
+    }
     let jv = JSValue::from_bits(value.to_bits());
     if jv.is_any_string() {
         let s = string_from_string_value(value).unwrap_or_default();
@@ -449,15 +458,49 @@ fn validate_duration(vals: &[f64]) {
             throw_range_error(&format!("Intl.DurationFormat.format: {unit} out of range"));
         }
     }
-    // days*86400 + hours*3600 + minutes*60 + seconds + ms/1e3 + us/1e6 + ns/1e9
-    let normalized = vals[3] * 86_400.0
-        + vals[4] * 3_600.0
-        + vals[5] * 60.0
-        + vals[6]
-        + vals[7] / 1.0e3
-        + vals[8] / 1.0e6
-        + vals[9] / 1.0e9;
-    if !normalized.is_finite() || normalized.abs() >= 9_007_199_254_740_992.0 {
+    // `IsValidDurationRecord` step 16–17:
+    //   normalizedSeconds = days×86400 + hours×3600 + minutes×60 + seconds
+    //                       + ms×10⁻³ + µs×10⁻⁶ + ns×10⁻⁹
+    //   reject when abs(normalizedSeconds) ≥ 2⁵³.
+    // The naive f64 sum above loses ULPs at these magnitudes (days near
+    // MAX_SAFE_INTEGER/86400), spuriously rounding a maximal-but-valid duration
+    // past 2⁵³ — test262 `duration-out-of-range-3/-4` pin this exact edge. Do it
+    // in exact integer nanoseconds instead: each field is a validated integral
+    // f64, so `abs(normalizedSeconds) ≥ 2⁵³` ⇔ `abs(totalNs) ≥ 2⁵³ × 10⁹`, an
+    // exact i128 comparison.
+    const NS_PER: [i128; 7] = [
+        86_400_000_000_000, // days
+        3_600_000_000_000,  // hours
+        60_000_000_000,     // minutes
+        1_000_000_000,      // seconds
+        1_000_000,          // milliseconds
+        1_000,              // microseconds
+        1,                  // nanoseconds
+    ];
+    const LIMIT_NS: i128 = (1i128 << 53) * 1_000_000_000;
+    let mut total_ns: i128 = 0;
+    let mut overflow = false;
+    for (k, &scale) in NS_PER.iter().enumerate() {
+        let v = vals[3 + k];
+        // A non-integral / non-finite field is impossible here (fields are
+        // validated in `to_duration_record`), but stay defensive: treat it as
+        // out-of-range rather than panicking on the cast.
+        if !v.is_finite() || v.fract() != 0.0 {
+            overflow = true;
+            break;
+        }
+        match (v as i128)
+            .checked_mul(scale)
+            .and_then(|prod| total_ns.checked_add(prod))
+        {
+            Some(sum) => total_ns = sum,
+            None => {
+                overflow = true;
+                break;
+            }
+        }
+    }
+    if overflow || total_ns.unsigned_abs() >= LIMIT_NS as u128 {
         throw_range_error("Intl.DurationFormat.format: duration out of range");
     }
 }

--- a/crates/perry-runtime/src/temporal/mod.rs
+++ b/crates/perry-runtime/src/temporal/mod.rs
@@ -279,6 +279,35 @@ pub fn temporal_kind(value: f64) -> Option<TemporalKind> {
     temporal_value_ref(value).map(TemporalValue::kind)
 }
 
+/// If `value` is a `Temporal.Duration` (or subclass instance), read its ten unit
+/// values directly from the internal slots — in `[years, months, weeks, days,
+/// hours, minutes, seconds, milliseconds, microseconds, nanoseconds]` order,
+/// matching `DURATION_UNITS`. Returns `None` for any non-Duration value.
+///
+/// `Intl.DurationFormat.prototype.format`/`formatToParts` call `ToDurationRecord`,
+/// whose spec first branch (`IsTemporalDuration`) copies the internal slots and
+/// deliberately does *not* invoke the `Temporal.Duration.prototype` getters — so
+/// this must bypass property lookup entirely (test262
+/// `taint-temporal-duration-prototype`).
+#[cfg(feature = "temporal")]
+pub fn duration_unit_values(value: f64) -> Option<[f64; 10]> {
+    match temporal_value_ref_or_subclass(value)? {
+        TemporalValue::Duration(d) => Some([
+            d.years() as f64,
+            d.months() as f64,
+            d.weeks() as f64,
+            d.days() as f64,
+            d.hours() as f64,
+            d.minutes() as f64,
+            d.seconds() as f64,
+            d.milliseconds() as f64,
+            d.microseconds() as f64,
+            d.nanoseconds() as f64,
+        ]),
+        _ => None,
+    }
+}
+
 /// The calendar identifier string of a Temporal value that carries a calendar
 /// (PlainDate, PlainDateTime, PlainYearMonth, PlainMonthDay, ZonedDateTime),
 /// or `None` for types without a calendar (Instant, PlainTime, Duration) or


### PR DESCRIPTION
## Summary
Two related fixes in `Intl.DurationFormat`'s `ToDurationRecord` / `IsValidDurationRecord`, from the #5906 worklist.

### 1. Accept `Temporal.Duration` objects (4 tests)
`ToDurationRecord`'s first branch is `IsTemporalDuration`: copy the internal slots directly, and (per the taint tests) do **not** invoke the `Temporal.Duration.prototype` getters. Perry instead fell through to `object_ptr_from_value`, which fails on a Temporal cell (they aren't `ObjectHeader`s) and threw *"duration must be an object"*.

Added `temporal::duration_unit_values()` (reads the ten unit values straight off the cell, resolving subclass instances too) and a fast-path in `to_duration_record`.

### 2. Exact `IsValidDurationRecord` step 16–17 (2 tests)
The naive f64 sum `days*86400 + … + ns/1e9` loses ULPs near `MAX_SAFE_INTEGER` and spuriously rounds a maximal-but-valid duration past 2⁵³. Now accumulated in exact i128 nanoseconds and compared against `2⁵³ × 10⁹`.

## Before / after (`intl402/DurationFormat`)
| | pass | runtime-fail | parity |
|---|---|---|---|
| before | 99 | 7 | ~93% |
| after | 101 | 5 | 95.3% |

**Fixed:** `temporal-duration-object-arg` + `taint-temporal-duration-prototype` (both `format` and `formatToParts`), `duration-out-of-range-3`, `duration-out-of-range-4`.

## Note on `precision-exact-mathematical-values.js`
This case flips into the report's runtime-fail bucket *because the fix is correct*: with exact validation Perry now accepts the maximal duration and formats it (matching the reference `formatDurationFormatPattern` helper). The node v26.3.0 oracle **fails its own test** here — its `df.format` yields `0:00:9007200.256743992` where the spec helper computes `…991` (a node ULP bug). Since the harness treats node as oracle, Perry-being-more-correct is flagged as a "missed negative." Not a Perry regression.

## Validation
- `cargo fmt --all -- --check` clean; `check_file_size.sh` OK (files < 2000 lines).
- No new failures beyond the node-oracle-bug case above.

Refs #5906. Code-only per contributor guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for Temporal duration values when the Temporal feature is enabled.

* **Bug Fixes**
  * More accurately validates duration limits using exact unit calculations, helping prevent incorrect acceptance or rejection of edge-case durations.
  * Streamlined duration handling so supported Temporal duration inputs are processed more directly and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->