### PR TITLE
fix(intl): #5906 — locale-sensitive SpecialCasing (tr/az/lt) for toLocale{Lower,Upper}Case

### DIFF
--- a/crates/perry-runtime/src/string/locale.rs
+++ b/crates/perry-runtime/src/string/locale.rs
@@ -8,11 +8,15 @@
 //!
 //!   * BCP 47 language-tag validation — an invalid `locales` argument throws a
 //!     `RangeError: Invalid language tag: <tag>`, just like V8.
-//!   * High-impact locale-specific casing: the Turkish/Azeri (`tr`/`az`)
-//!     dotted/dotless `I` rules, where `"I".toLocaleLowerCase("tr") === "ı"`
-//!     and `"i".toLocaleUpperCase("tr") === "İ"`. Every other locale (and the
-//!     no-arg form) falls back to the language-neutral Unicode casing already
-//!     implemented by `to_lowercase` / `to_uppercase`.
+//!   * Language-sensitive casing from SpecialCasing.txt:
+//!     - Turkish/Azeri (`tr`/`az`) dotted/dotless `I` — `"I".toLocaleLowerCase("tr")
+//!       === "ı"`, `"i".toLocaleUpperCase("tr") === "İ"`, plus the conditional
+//!       `After_I` / `Before_Dot` COMBINING DOT ABOVE handling.
+//!     - Lithuanian (`lt`) — the `More_Above` explicit-dot insertion when
+//!       lowercasing `I`/`J`/`Į`, the precomposed `Ì`/`Í`/`Ĩ` decompositions, and
+//!       the `After_Soft_Dotted` dot removal when uppercasing.
+//!     Every other locale (and the no-arg form) falls back to the
+//!     language-neutral Unicode casing (`to_lowercase` / `to_uppercase`).
 //!
 //! Closes #2781.
 
@@ -132,15 +136,163 @@ fn is_turkic(primary: &Option<String>) -> bool {
     matches!(primary.as_deref(), Some("tr") | Some("az"))
 }
 
-/// Turkic-aware lowercasing: `I` → `ı` (dotless), `İ` (U+0130) → `i`. All other
-/// characters use the language-neutral Unicode lowercase mapping.
-fn turkic_lower(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for ch in s.chars() {
+/// Returns true if the primary language subtag is Lithuanian (`lt`).
+fn is_lithuanian(primary: &Option<String>) -> bool {
+    matches!(primary.as_deref(), Some("lt"))
+}
+
+/// Canonical Combining Class of `ch`. The full UCD table lives in
+/// `unicode-normalization` (already a dependency, gated behind
+/// `string-normalize`); when that feature is off we fall back to a tiny table
+/// covering the marks the SpecialCasing conditions actually inspect (dot above
+/// / grave = 230, dot below / oblique-stroke = 220). Everything unlisted is 0,
+/// which is the correct default for the base letters these rules operate on.
+#[inline]
+fn ccc(ch: char) -> u8 {
+    #[cfg(feature = "string-normalize")]
+    {
+        unicode_normalization::char::canonical_combining_class(ch)
+    }
+    #[cfg(not(feature = "string-normalize"))]
+    {
         match ch {
-            'I' => out.push('\u{0131}'), // LATIN SMALL LETTER DOTLESS I
+            // Above (230)
+            '\u{0300}'..='\u{0314}'
+            | '\u{033D}'..='\u{0344}'
+            | '\u{0346}'
+            | '\u{034A}'..='\u{034C}'
+            | '\u{0350}'..='\u{0352}'
+            | '\u{0357}'
+            | '\u{035B}'
+            | '\u{0363}'..='\u{036F}'
+            | '\u{1D185}'..='\u{1D189}' => 230,
+            // Below (220)
+            '\u{0316}'..='\u{0319}'
+            | '\u{031C}'..='\u{0320}'
+            | '\u{0323}'..='\u{0333}'
+            | '\u{0339}'..='\u{033C}'
+            | '\u{0347}'..='\u{0349}'
+            | '\u{034D}'..='\u{034E}'
+            | '\u{0353}'..='\u{0356}'
+            | '\u{101FD}' => 220,
+            _ => 0,
+        }
+    }
+}
+
+/// `More_Above` (SpecialCasing.txt): starting *after* `chars[i]`, the next
+/// character of combining class 0 or 230 is class 230 (i.e. there is a following
+/// Above mark before any starter or lower/higher-blocking mark). Intervening
+/// marks of other classes (e.g. Below = 220) are skipped.
+fn more_above(chars: &[char], i: usize) -> bool {
+    for &c in &chars[i + 1..] {
+        match ccc(c) {
+            230 => return true,
+            0 => return false,
+            _ => continue,
+        }
+    }
+    false
+}
+
+/// `Before_Dot` (SpecialCasing.txt, Turkic): starting *after* `chars[i]`, the
+/// next character of combining class 0 or 230 is `COMBINING DOT ABOVE`
+/// (U+0307). Its negation is `Not_Before_Dot`.
+fn before_dot(chars: &[char], i: usize) -> bool {
+    for &c in &chars[i + 1..] {
+        if c == '\u{0307}' {
+            return true;
+        }
+        if ccc(c) == 0 || ccc(c) == 230 {
+            return false;
+        }
+    }
+    false
+}
+
+/// Soft_Dotted code points (Unicode PropList.txt) — the 46 characters the
+/// Lithuanian `After_Soft_Dotted` uppercasing condition inspects. Small and
+/// stable enough to inline rather than pull in the whole property table.
+fn is_soft_dotted(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{0069}'
+            | '\u{006A}'
+            | '\u{012F}'
+            | '\u{0249}'
+            | '\u{0268}'
+            | '\u{029D}'
+            | '\u{02B2}'
+            | '\u{03F3}'
+            | '\u{0456}'
+            | '\u{0458}'
+            | '\u{1D62}'
+            | '\u{1D96}'
+            | '\u{1DA4}'
+            | '\u{1DA8}'
+            | '\u{1E2D}'
+            | '\u{1ECB}'
+            | '\u{2071}'
+            | '\u{2148}'
+            | '\u{2149}'
+            | '\u{2C7C}'
+            | '\u{1D422}'
+            | '\u{1D423}'
+            | '\u{1D456}'
+            | '\u{1D457}'
+            | '\u{1D48A}'
+            | '\u{1D48B}'
+            | '\u{1D4BE}'
+            | '\u{1D4BF}'
+            | '\u{1D4F2}'
+            | '\u{1D4F3}'
+            | '\u{1D526}'
+            | '\u{1D527}'
+            | '\u{1D55A}'
+            | '\u{1D55B}'
+            | '\u{1D58E}'
+            | '\u{1D58F}'
+            | '\u{1D5C2}'
+            | '\u{1D5C3}'
+            | '\u{1D5F6}'
+            | '\u{1D5F7}'
+            | '\u{1D62A}'
+            | '\u{1D62B}'
+            | '\u{1D65E}'
+            | '\u{1D65F}'
+            | '\u{1D692}'
+            | '\u{1D693}'
+    )
+}
+
+/// Turkic-aware lowercasing (Turkish/Azeri SpecialCasing.txt conditionals):
+///   * `İ` (U+0130) → `i` (unconditional).
+///   * `I` → `ı` (dotless) when `Not_Before_Dot`, else → `i` (default).
+///   * `COMBINING DOT ABOVE` (U+0307) is removed when `After_I` (the last
+///     preceding class-0-or-230 character was `I`).
+/// All other characters use the language-neutral Unicode lowercase mapping.
+fn turkic_lower(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    let mut out = String::with_capacity(s.len());
+    // `After_I`: the last preceding class-0-or-230 character was `I` (U+0049).
+    let mut after_i = false;
+    for (i, &ch) in chars.iter().enumerate() {
+        match ch {
             '\u{0130}' => out.push('i'), // İ → i
+            'I' => {
+                if before_dot(&chars, i) {
+                    out.push('i'); // I → i, its following dot is removed below
+                } else {
+                    out.push('\u{0131}'); // I → ı (dotless)
+                }
+            }
+            '\u{0307}' if after_i => { /* COMBINING DOT ABOVE removed After_I */ }
             other => out.extend(other.to_lowercase()),
+        }
+        // Update the After_I state on class-0-or-230 boundaries.
+        match ccc(ch) {
+            0 | 230 => after_i = ch == 'I',
+            _ => {}
         }
     }
     out
@@ -154,6 +306,51 @@ fn turkic_upper(s: &str) -> String {
             'i' => out.push('\u{0130}'), // i → İ (LATIN CAPITAL LETTER I WITH DOT ABOVE)
             '\u{0131}' => out.push('I'), // ı → I
             other => out.extend(other.to_uppercase()),
+        }
+    }
+    out
+}
+
+/// Lithuanian lowercasing (SpecialCasing.txt `lt` conditionals): capital `I`
+/// (U+0049), `J` (U+004A) and `Į` (U+012E) gain a `COMBINING DOT ABOVE`
+/// (U+0307) after their lowercase form when `More_Above`. Other characters use
+/// the language-neutral mapping.
+fn lithuanian_lower(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    let mut out = String::with_capacity(s.len());
+    for (i, &ch) in chars.iter().enumerate() {
+        match ch {
+            // Unconditional precomposed `lt` mappings (SpecialCasing.txt): the
+            // accent-above forms decompose to `i` + COMBINING DOT ABOVE + accent.
+            '\u{00CC}' => out.push_str("\u{0069}\u{0307}\u{0300}"), // Ì
+            '\u{00CD}' => out.push_str("\u{0069}\u{0307}\u{0301}"), // Í
+            '\u{0128}' => out.push_str("\u{0069}\u{0307}\u{0303}"), // Ĩ
+            'I' | 'J' | '\u{012E}' if more_above(&chars, i) => {
+                out.extend(ch.to_lowercase());
+                out.push('\u{0307}'); // inserted COMBINING DOT ABOVE
+            }
+            other => out.extend(other.to_lowercase()),
+        }
+    }
+    out
+}
+
+/// Lithuanian uppercasing (SpecialCasing.txt `lt` conditional): a `COMBINING
+/// DOT ABOVE` (U+0307) is removed when `After_Soft_Dotted` (the last preceding
+/// class-0-or-230 character has the Soft_Dotted property). Other characters use
+/// the language-neutral uppercase mapping.
+fn lithuanian_upper(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    // `After_Soft_Dotted`: last preceding class-0-or-230 char was Soft_Dotted.
+    let mut after_soft_dotted = false;
+    for ch in s.chars() {
+        match ch {
+            '\u{0307}' if after_soft_dotted => { /* removed */ }
+            other => out.extend(other.to_uppercase()),
+        }
+        match ccc(ch) {
+            0 | 230 => after_soft_dotted = is_soft_dotted(ch),
+            _ => {}
         }
     }
     out
@@ -173,6 +370,8 @@ pub extern "C" fn js_string_to_locale_lower_case(
     let str_data = string_as_str(s);
     let lower = if is_turkic(&primary) {
         turkic_lower(str_data)
+    } else if is_lithuanian(&primary) {
+        lithuanian_lower(str_data)
     } else {
         str_data.to_lowercase()
     };
@@ -192,6 +391,8 @@ pub extern "C" fn js_string_to_locale_upper_case(
     let str_data = string_as_str(s);
     let upper = if is_turkic(&primary) {
         turkic_upper(str_data)
+    } else if is_lithuanian(&primary) {
+        lithuanian_upper(str_data)
     } else {
         str_data.to_uppercase()
     };
@@ -249,5 +450,57 @@ mod tests {
         // Non-Turkic letters keep neutral casing.
         assert_eq!(turkic_lower("ABC"), "abc");
         assert_eq!(turkic_upper("abc"), "ABC");
+    }
+
+    #[test]
+    fn turkic_special_casing_dot_above() {
+        // COMBINING DOT ABOVE removed after I (I → i).
+        assert_eq!(turkic_lower("I\u{0307}"), "i");
+        // Dot below (ccc 220) doesn't reset After_I.
+        assert_eq!(turkic_lower("I\u{0323}\u{0307}"), "i\u{0323}");
+        assert_eq!(turkic_lower("I\u{101FD}\u{0307}"), "i\u{101FD}");
+        // A class-0 char resets → I becomes dotless, dot survives.
+        assert_eq!(turkic_lower("IA\u{0307}"), "\u{0131}a\u{0307}");
+        // A class-230 char (grave / musical doit) blocks → I dotless, dot survives.
+        assert_eq!(
+            turkic_lower("I\u{0300}\u{0307}"),
+            "\u{0131}\u{0300}\u{0307}"
+        );
+        assert_eq!(
+            turkic_lower("I\u{1D185}\u{0307}"),
+            "\u{0131}\u{1D185}\u{0307}"
+        );
+    }
+
+    #[test]
+    fn lithuanian_lower_more_above() {
+        // Capital I/J/Į followed by an Above mark gain a COMBINING DOT ABOVE.
+        assert_eq!(lithuanian_lower("I\u{0300}"), "i\u{0307}\u{0300}");
+        assert_eq!(lithuanian_lower("J\u{0300}"), "j\u{0307}\u{0300}");
+        assert_eq!(
+            lithuanian_lower("\u{012E}\u{0300}"),
+            "\u{012F}\u{0307}\u{0300}"
+        );
+        assert_eq!(lithuanian_lower("I\u{1D185}"), "i\u{0307}\u{1D185}");
+        // Without an Above mark following: neutral lowercase.
+        assert_eq!(lithuanian_lower("I"), "i");
+        // A class-0 char after I suppresses the dot.
+        assert_eq!(lithuanian_lower("IA\u{0300}"), "ia\u{0300}");
+        // Precomposed accented capitals decompose to i + dot above + accent.
+        assert_eq!(lithuanian_lower("\u{00CC}"), "\u{0069}\u{0307}\u{0300}");
+        assert_eq!(lithuanian_lower("\u{00CD}"), "\u{0069}\u{0307}\u{0301}");
+        assert_eq!(lithuanian_lower("\u{0128}"), "\u{0069}\u{0307}\u{0303}");
+    }
+
+    #[test]
+    fn lithuanian_upper_after_soft_dotted() {
+        // Dot above removed when preceded by Soft_Dotted (i/j and math variants).
+        assert_eq!(lithuanian_upper("i\u{0307}"), "I");
+        assert_eq!(lithuanian_upper("j\u{0307}"), "J");
+        // Below mark between soft-dotted and dot doesn't reset.
+        assert_eq!(lithuanian_upper("i\u{0323}\u{0307}"), "I\u{0323}");
+        // Capital I/J are NOT soft-dotted → dot survives.
+        assert_eq!(lithuanian_upper("I\u{0307}"), "I\u{0307}");
+        assert_eq!(lithuanian_upper("J\u{0307}"), "J\u{0307}");
     }
 }


### PR DESCRIPTION
## Summary
Implements the conditional, language-sensitive SpecialCasing.txt case mappings that `String.prototype.toLocaleLowerCase`/`toLocaleUpperCase` were missing, from the #5906 worklist.

### Turkish / Azeri (`tr`/`az`) lowercase
- `I` → `i` with its trailing `COMBINING DOT ABOVE` removed when `After_I`/`Before_Dot`; otherwise `I` → `ı` (dotless).
- Tracks the `After_I` state across intervening non-starter / non-Above marks (e.g. dot below, class 220).

### Lithuanian (`lt`) lowercase
- `I`/`J`/`Į` gain an explicit `COMBINING DOT ABOVE` when `More_Above`.
- Precomposed `Ì`/`Í`/`Ĩ` decompose to `i` + dot-above + accent.

### Lithuanian (`lt`) uppercase
- `COMBINING DOT ABOVE` removed when `After_Soft_Dotted` (the 46-codepoint Soft_Dotted set is inlined).

### Mechanics
Adds a `ccc()` canonical-combining-class helper (uses `unicode-normalization` under the `string-normalize` feature, with a small fallback table for the marks these conditions inspect when the feature is off), plus `More_Above` / `Before_Dot` scanners. Non-`tr`/`az`/`lt` locales and the no-arg form keep the language-neutral `to_lowercase`/`to_uppercase` path untouched.

## Before / after (`intl402/String`)
| | pass | runtime-fail | parity |
|---|---|---|---|
| before | 11 | 8 | ~61% |
| after | 14 | 4 | 77.8% |

**Fixed:** `special_casing_Turkish`, `special_casing_Azeri` (toLocaleLowerCase), `special_casing_Lithuanian` (toLocaleLowerCase **and** toLocaleUpperCase). The 4 remaining String failures are unrelated (localeCompare collation ordering + locale-identifier validation edge cases).

## Validation
- 6 module unit tests (incl. new tr/az/lt cases) pass.
- `cargo fmt --all -- --check` clean; `check_file_size.sh` OK.
- Zero regressions (neutral-locale path unchanged).

Refs #5906. Code-only per contributor guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Lithuanian locale-aware casing support for text conversion, including special dot-above handling rules.
  * Improved Turkish and Azeri locale-aware lowercasing to better match expected dot and dotted-I behavior.

* **Bug Fixes**
  * Fixed locale-specific uppercasing and lowercasing cases involving combining marks, including dot-above removal and insertion in edge cases.
  * Expanded coverage for more accurate text behavior across supported locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->