### PR TITLE
fix(proxy): #5905 — forward setPrototypeOf/deleteProperty through proxy targets with correct throw semantics

### DIFF
--- a/crates/perry-codegen/src/expr/proxy_reflect.rs
+++ b/crates/perry-codegen/src/expr/proxy_reflect.rs
@@ -478,11 +478,24 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::ProxyDelete { proxy, key } => {
             downgrade_unknown_call_expr(ctx, proxy);
             downgrade_unknown_call_expr(ctx, key);
+            let strict = if ctx.is_strict_fn { "1" } else { "0" };
             let p = lower_expr(ctx, proxy)?;
             let k = lower_expr(ctx, key)?;
-            Ok(ctx
-                .block()
-                .call(DOUBLE, "js_proxy_delete", &[(DOUBLE, &p), (DOUBLE, &k)]))
+            let blk = ctx.block();
+            // `js_proxy_delete` reports the `[[Delete]]` boolean; a strict-mode
+            // `delete proxy.key` that resolves to `false` (non-configurable
+            // property, forwarded through the trap chain) must throw a TypeError
+            // just like the ordinary member-delete path. Route the boolean
+            // through `js_delete_result` so both modes match spec (test262
+            // Proxy/deleteProperty/*-target-is-proxy `delete funcProxy.prototype`
+            // under "use strict").
+            let deleted_box = blk.call(DOUBLE, "js_proxy_delete", &[(DOUBLE, &p), (DOUBLE, &k)]);
+            let deleted_i32 = blk.call(I32, "js_is_truthy", &[(DOUBLE, &deleted_box)]);
+            Ok(blk.call(
+                DOUBLE,
+                "js_delete_result",
+                &[(I32, &deleted_i32), (I32, strict)],
+            ))
         }
         Expr::ProxyApply { proxy, args } => {
             downgrade_unknown_call_expr(ctx, proxy);

--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -103,6 +103,13 @@ pub extern "C" fn js_object_delete_field(
                 (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
             if (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY {
                 if let Some(name) = super::has_own_helpers::str_from_string_header(key) {
+                    // An Array's `length` is a non-configurable exotic own
+                    // property with no descriptor-table entry, so the
+                    // `get_property_attrs` check below misses it. `delete
+                    // arr.length` must report failure (throws in strict mode).
+                    if name == "length" {
+                        return 0;
+                    }
                     if let Some(attrs) = get_property_attrs(obj as usize, name) {
                         if !attrs.configurable() {
                             return 0;
@@ -144,6 +151,21 @@ pub extern "C" fn js_object_delete_field(
         // user-attached props are dropped from the dynamic-prop table outright.
         if crate::closure::is_closure_ptr(obj as usize) {
             if let Some(name) = super::has_own_helpers::str_from_string_header(key) {
+                // A plain (non-arrow, non-bound) function's `prototype` is a
+                // non-configurable own property. `get_property_attrs` only knows
+                // about it once #3655 has lazily registered a descriptor (on first
+                // access), so a fresh `function(){}` whose prototype was never
+                // read would otherwise report a successful delete. Reject it up
+                // front. (test262 Proxy/deleteProperty/*-target-is-proxy exercise
+                // `delete funcProxy.prototype` in strict mode.)
+                if name == "prototype" {
+                    let closure = obj as *const crate::closure::ClosureHeader;
+                    if !crate::closure::closure_is_arrow(closure)
+                        && !crate::closure::closure_is_bound_method(closure)
+                    {
+                        return 0;
+                    }
+                }
                 // A non-configurable slot — e.g. a constructor's `prototype`,
                 // which #3655 registers as `{configurable:false}` — can't be
                 // deleted: leave it intact and report failure (strict mode

--- a/crates/perry-runtime/src/object/object_ops/define_properties.rs
+++ b/crates/perry-runtime/src/object/object_ops/define_properties.rs
@@ -144,11 +144,18 @@ pub extern "C" fn js_object_set_prototype_of(obj_value: f64, proto: f64) -> f64 
 
     // A Proxy receiver is a small registered id, not a heap object — the
     // recording path below would deref the fake pointer and segfault. Route
-    // through the Reflect entry (which resolves the proxy to its target) and
-    // return the proxy per Object.setPrototypeOf's contract. (Proxy crash
-    // cluster.)
+    // through the Reflect entry (which resolves the proxy to its target and
+    // runs the trap chain, recursing through proxy targets). `Object.setPrototypeOf`
+    // must surface a `false` internal-method result as a `TypeError`
+    // (`Reflect.setPrototypeOf` returns the boolean without throwing). Without
+    // this, `Object.setPrototypeOf(proxyOfNonExtensibleProxy, x)` silently
+    // succeeded instead of throwing (test262
+    // Proxy/setPrototypeOf/trap-is-{missing,undefined}-target-is-proxy).
     if crate::proxy::js_proxy_is_proxy(obj_value) != 0 {
-        crate::proxy::js_reflect_set_prototype_of(obj_value, proto);
+        let ok = crate::proxy::js_reflect_set_prototype_of(obj_value, proto);
+        if crate::value::js_is_truthy(ok) == 0 {
+            throw_object_type_error(b"#<Object> is not extensible");
+        }
         return obj_value;
     }
 

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -20,6 +20,9 @@ use std::collections::HashMap;
 
 use crate::closure::{js_closure_call0, js_closure_call1, js_closure_call2, js_closure_call3};
 
+mod has_delete;
+pub(crate) use has_delete::reflect_ordinary_delete_property_key;
+pub use has_delete::{js_proxy_delete, js_proxy_has};
 mod invariants;
 mod put_value;
 pub(crate) use put_value::proxy_set_with_receiver;
@@ -793,15 +796,44 @@ fn array_ptr_from_value(value: f64) -> Option<*mut crate::array::ArrayHeader> {
     }
 }
 
-fn key_is_length(key: f64) -> bool {
+fn key_equals(key: f64, name: &[u8]) -> bool {
     let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
     let Some((ptr, len)) = crate::string::str_bytes_from_jsvalue(key, &mut scratch) else {
         return false;
     };
-    if ptr.is_null() || len != 6 {
+    if ptr.is_null() || len as usize != name.len() {
         return false;
     }
-    unsafe { std::slice::from_raw_parts(ptr, len as usize) == b"length" }
+    unsafe { std::slice::from_raw_parts(ptr, len as usize) == name }
+}
+
+fn key_is_length(key: f64) -> bool {
+    key_equals(key, b"length")
+}
+
+/// Does deleting `key` off `target` hit a non-configurable exotic own property
+/// that lives outside the ordinary descriptor table? Covers an Array's `length`
+/// and a plain (non-arrow, non-bound) function's `prototype` — both are
+/// non-configurable, so `Reflect.deleteProperty` / `delete` must report failure.
+fn is_non_configurable_exotic_own(target: f64, key: f64) -> bool {
+    if array_ptr_from_value(target).is_some() && key_is_length(key) {
+        return true;
+    }
+    if key_equals(key, b"prototype") {
+        let raw = extract_pointer(target.to_bits()) as usize;
+        if raw != 0 && crate::closure::is_closure_ptr(raw) {
+            let closure = raw as *const crate::closure::ClosureHeader;
+            // Arrow and bound functions have no own `prototype` slot at all, so
+            // deleting it succeeds vacuously; only a plain function's `prototype`
+            // is a non-configurable own property.
+            if !crate::closure::closure_is_arrow(closure)
+                && !crate::closure::closure_is_bound_method(closure)
+            {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 fn parse_canonical_nonnegative_i32(bytes: &[u8]) -> Option<i32> {
@@ -1472,143 +1504,6 @@ pub extern "C" fn js_super_put_value_set(
 
 /// `key in proxy` — if handler.has exists, call it; otherwise delegate to
 /// `js_object_has_property` on the target.
-#[no_mangle]
-pub extern "C" fn js_proxy_has(proxy_boxed: f64, key: f64) -> f64 {
-    let id = match lookup(proxy_boxed) {
-        Some(id) => id,
-        None => return f64::from_bits(TAG_FALSE),
-    };
-    let (target, handler, revoked) = PROXIES.with(|p| {
-        p.borrow()
-            .get(id as usize)
-            .and_then(|o| o.as_ref())
-            .map(|e| (e.target, e.handler, e.revoked))
-            .unwrap_or((
-                f64::from_bits(TAG_UNDEFINED),
-                f64::from_bits(TAG_UNDEFINED),
-                false,
-            ))
-    });
-    if revoked {
-        return revoked_return();
-    }
-    let trap = handler_trap(handler, "has");
-    if is_callable(trap) {
-        let scope = crate::gc::RuntimeHandleScope::new();
-        let target_h = scope.root_nanbox_f64(target);
-        let key_h = scope.root_nanbox_f64(key);
-        let trap_result = call_trap(
-            handler,
-            trap,
-            &[target_h.get_nanbox_f64(), key_h.get_nanbox_f64()],
-        );
-        // [[HasProperty]] invariant: a `false` trap result is rejected when the
-        // target owns the key non-configurably, or the target is non-extensible
-        // and owns the key.
-        if crate::value::js_is_truthy(trap_result) == 0 {
-            invariants::enforce_has_false_invariant(
-                target_h.get_nanbox_f64(),
-                key_h.get_nanbox_f64(),
-            );
-            return nanbox_bool(false);
-        }
-        return nanbox_bool(true);
-    }
-    // No has trap — forward to the target's `[[HasProperty]]`, recursing through
-    // a proxy target.
-    if lookup(target).is_some() {
-        return js_proxy_has(target, key);
-    }
-    crate::object::js_object_has_property(target, key)
-}
-
-/// `delete proxy[key]` — if handler.deleteProperty exists, call it; else
-/// delegate to `js_object_delete_field` on the target.
-#[no_mangle]
-pub extern "C" fn js_proxy_delete(proxy_boxed: f64, key: f64) -> f64 {
-    let id = match lookup(proxy_boxed) {
-        Some(id) => id,
-        None => return f64::from_bits(TAG_FALSE),
-    };
-    let (target, handler, revoked) = PROXIES.with(|p| {
-        p.borrow()
-            .get(id as usize)
-            .and_then(|o| o.as_ref())
-            .map(|e| (e.target, e.handler, e.revoked))
-            .unwrap_or((
-                f64::from_bits(TAG_UNDEFINED),
-                f64::from_bits(TAG_UNDEFINED),
-                false,
-            ))
-    });
-    if revoked {
-        return revoked_return();
-    }
-    let trap = handler_trap(handler, "deleteProperty");
-    if is_callable(trap) {
-        // #2760: the `deleteProperty` trap's boolean result is observable
-        // through `Reflect.deleteProperty(proxy, …)`.
-        let scope = crate::gc::RuntimeHandleScope::new();
-        let target_h = scope.root_nanbox_f64(target);
-        let key_h = scope.root_nanbox_f64(key);
-        let trap_result = call_trap(
-            handler,
-            trap,
-            &[target_h.get_nanbox_f64(), key_h.get_nanbox_f64()],
-        );
-        if crate::value::js_is_truthy(trap_result) == 0 {
-            return nanbox_bool(false);
-        }
-        // [[Delete]] invariant: a `true` result is rejected when the target owns
-        // the key non-configurably, or owns it and is non-extensible.
-        invariants::enforce_delete_invariant(target_h.get_nanbox_f64(), key_h.get_nanbox_f64());
-        return nanbox_bool(true);
-    }
-    // No trap — forward to the target's `[[Delete]]`, recursing through a proxy
-    // target.
-    if lookup(target).is_some() {
-        return js_proxy_delete(target, key);
-    }
-    reflect_ordinary_delete(target, key)
-}
-
-/// Perform an ordinary (non-proxy) `[[Delete]]` and report the result as a
-/// NaN-boxed boolean. Returns `false` for a non-configurable property (#2760),
-/// matching `Reflect.deleteProperty` rather than the silent-success behavior of
-/// the `delete` operator.
-fn reflect_ordinary_delete_property_key(target: f64, property_key: f64) -> f64 {
-    if unsafe { crate::symbol::js_is_symbol(property_key) } != 0 {
-        let deleted =
-            unsafe { crate::symbol::js_object_delete_symbol_property(target, property_key) };
-        return nanbox_bool(deleted != 0);
-    }
-    if let Some((_writable, configurable)) = crate::object::obj_value_attrs(target, property_key) {
-        if !configurable {
-            return nanbox_bool(false);
-        }
-    }
-    let obj_ptr = extract_pointer(target.to_bits()) as *mut crate::ObjectHeader;
-    let key_ptr =
-        crate::value::js_get_string_pointer_unified(property_key) as *const crate::StringHeader;
-    if !obj_ptr.is_null() && !key_ptr.is_null() {
-        let deleted = crate::object::js_object_delete_field(obj_ptr, key_ptr);
-        return nanbox_bool(deleted != 0);
-    }
-    nanbox_bool(true)
-}
-
-fn reflect_ordinary_delete(target: f64, key: f64) -> f64 {
-    let scope = crate::gc::RuntimeHandleScope::new();
-    let target_handle = scope.root_nanbox_f64(target);
-    let key_handle = scope.root_nanbox_f64(key);
-    let property_key_handle = scope
-        .root_nanbox_f64(unsafe { crate::object::js_to_property_key(key_handle.get_nanbox_f64()) });
-    reflect_ordinary_delete_property_key(
-        target_handle.get_nanbox_f64(),
-        property_key_handle.get_nanbox_f64(),
-    )
-}
-
 /// Is `value` a callable function value: a closure, a class-ref constructor, or
 /// a (possibly callable) proxy? Distinct from `is_callable`, which treats *any*
 /// pointer-tagged value as callable — that's too loose for trap validation,

--- a/crates/perry-runtime/src/proxy/has_delete.rs
+++ b/crates/perry-runtime/src/proxy/has_delete.rs
@@ -1,0 +1,158 @@
+//! Proxy `[[HasProperty]]` and `[[Delete]]` (ECMA-262 §10.5.7 / §10.5.10) plus
+//! the ordinary (non-proxy) `[[Delete]]` helper they forward to. Split out of
+//! `proxy.rs` to keep that file under the 2000-line size gate — pure code motion,
+//! no behavior change.
+
+use super::{
+    call_trap, handler_trap, invariants, is_callable, is_non_configurable_exotic_own, lookup,
+    nanbox_bool, revoked_return, PROXIES, TAG_FALSE, TAG_UNDEFINED,
+};
+
+/// `key in proxy` — if `handler.has` exists, call it; else forward to the
+/// target's `[[HasProperty]]` (recursing through a proxy target).
+#[no_mangle]
+pub extern "C" fn js_proxy_has(proxy_boxed: f64, key: f64) -> f64 {
+    let id = match lookup(proxy_boxed) {
+        Some(id) => id,
+        None => return f64::from_bits(TAG_FALSE),
+    };
+    let (target, handler, revoked) = PROXIES.with(|p| {
+        p.borrow()
+            .get(id as usize)
+            .and_then(|o| o.as_ref())
+            .map(|e| (e.target, e.handler, e.revoked))
+            .unwrap_or((
+                f64::from_bits(TAG_UNDEFINED),
+                f64::from_bits(TAG_UNDEFINED),
+                false,
+            ))
+    });
+    if revoked {
+        return revoked_return();
+    }
+    let trap = handler_trap(handler, "has");
+    if is_callable(trap) {
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let target_h = scope.root_nanbox_f64(target);
+        let key_h = scope.root_nanbox_f64(key);
+        let trap_result = call_trap(
+            handler,
+            trap,
+            &[target_h.get_nanbox_f64(), key_h.get_nanbox_f64()],
+        );
+        // [[HasProperty]] invariant: a `false` trap result is rejected when the
+        // target owns the key non-configurably, or the target is non-extensible
+        // and owns the key.
+        if crate::value::js_is_truthy(trap_result) == 0 {
+            invariants::enforce_has_false_invariant(
+                target_h.get_nanbox_f64(),
+                key_h.get_nanbox_f64(),
+            );
+            return nanbox_bool(false);
+        }
+        return nanbox_bool(true);
+    }
+    // No has trap — forward to the target's `[[HasProperty]]`, recursing through
+    // a proxy target.
+    if lookup(target).is_some() {
+        return js_proxy_has(target, key);
+    }
+    crate::object::js_object_has_property(target, key)
+}
+
+/// `delete proxy[key]` — if handler.deleteProperty exists, call it; else
+/// delegate to `js_object_delete_field` on the target.
+#[no_mangle]
+pub extern "C" fn js_proxy_delete(proxy_boxed: f64, key: f64) -> f64 {
+    let id = match lookup(proxy_boxed) {
+        Some(id) => id,
+        None => return f64::from_bits(TAG_FALSE),
+    };
+    let (target, handler, revoked) = PROXIES.with(|p| {
+        p.borrow()
+            .get(id as usize)
+            .and_then(|o| o.as_ref())
+            .map(|e| (e.target, e.handler, e.revoked))
+            .unwrap_or((
+                f64::from_bits(TAG_UNDEFINED),
+                f64::from_bits(TAG_UNDEFINED),
+                false,
+            ))
+    });
+    if revoked {
+        return revoked_return();
+    }
+    let trap = handler_trap(handler, "deleteProperty");
+    if is_callable(trap) {
+        // #2760: the `deleteProperty` trap's boolean result is observable
+        // through `Reflect.deleteProperty(proxy, …)`.
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let target_h = scope.root_nanbox_f64(target);
+        let key_h = scope.root_nanbox_f64(key);
+        let trap_result = call_trap(
+            handler,
+            trap,
+            &[target_h.get_nanbox_f64(), key_h.get_nanbox_f64()],
+        );
+        if crate::value::js_is_truthy(trap_result) == 0 {
+            return nanbox_bool(false);
+        }
+        // [[Delete]] invariant: a `true` result is rejected when the target owns
+        // the key non-configurably, or owns it and is non-extensible.
+        invariants::enforce_delete_invariant(target_h.get_nanbox_f64(), key_h.get_nanbox_f64());
+        return nanbox_bool(true);
+    }
+    // No trap — forward to the target's `[[Delete]]`, recursing through a proxy
+    // target.
+    if lookup(target).is_some() {
+        return js_proxy_delete(target, key);
+    }
+    reflect_ordinary_delete(target, key)
+}
+
+/// Perform an ordinary (non-proxy) `[[Delete]]` and report the result as a
+/// NaN-boxed boolean. Returns `false` for a non-configurable property (#2760),
+/// matching `Reflect.deleteProperty` rather than the silent-success behavior of
+/// the `delete` operator.
+pub(crate) fn reflect_ordinary_delete_property_key(target: f64, property_key: f64) -> f64 {
+    if unsafe { crate::symbol::js_is_symbol(property_key) } != 0 {
+        let deleted =
+            unsafe { crate::symbol::js_object_delete_symbol_property(target, property_key) };
+        return nanbox_bool(deleted != 0);
+    }
+    if let Some((_writable, configurable)) = crate::object::obj_value_attrs(target, property_key) {
+        if !configurable {
+            return nanbox_bool(false);
+        }
+    }
+    // Non-configurable exotic own properties (an Array's `length`, a plain
+    // function's `prototype`) have no entry in the ordinary descriptor table, so
+    // `obj_value_attrs` above returns `None`. `Reflect.deleteProperty` / `delete`
+    // must report `false` for them (test262
+    // Proxy/deleteProperty/trap-is-{undefined,missing,null}-target-is-proxy forward
+    // through to a real array/function). Without this the delete silently
+    // succeeded and reported `true`.
+    if is_non_configurable_exotic_own(target, property_key) {
+        return nanbox_bool(false);
+    }
+    let obj_ptr = super::extract_pointer(target.to_bits()) as *mut crate::ObjectHeader;
+    let key_ptr =
+        crate::value::js_get_string_pointer_unified(property_key) as *const crate::StringHeader;
+    if !obj_ptr.is_null() && !key_ptr.is_null() {
+        let deleted = crate::object::js_object_delete_field(obj_ptr, key_ptr);
+        return nanbox_bool(deleted != 0);
+    }
+    nanbox_bool(true)
+}
+
+fn reflect_ordinary_delete(target: f64, key: f64) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target_handle = scope.root_nanbox_f64(target);
+    let key_handle = scope.root_nanbox_f64(key);
+    let property_key_handle = scope
+        .root_nanbox_f64(unsafe { crate::object::js_to_property_key(key_handle.get_nanbox_f64()) });
+    reflect_ordinary_delete_property_key(
+        target_handle.get_nanbox_f64(),
+        property_key_handle.get_nanbox_f64(),
+    )
+}


### PR DESCRIPTION
Part of #5905 (built-ins/Proxy worklist).

## Root cause
When a Proxy's target is itself a Proxy and the outer trap is missing/undefined/null, the operation forwards down the chain. Several forwarding paths dropped the spec's throw-on-false behavior or mis-reported non-configurable exotic properties as deletable.

## Fixes
1. **`Object.setPrototypeOf(proxy, x)`** discarded the internal `[[SetPrototypeOf]]` boolean. A `false` result (a non-extensible target reached through the chain, or an inner trap returning `false`) must throw a `TypeError`, while `Reflect.setPrototypeOf` keeps returning the boolean. (`crates/perry-runtime/src/object/object_ops/define_properties.rs`)

2. **`Reflect.deleteProperty` / `delete`** never rejected an Array's non-configurable `length` or a plain (non-arrow, non-bound) function's non-configurable `prototype`. Both are exotic own properties with no descriptor-table entry, so `obj_value_attrs`/`get_property_attrs` returned `None` and the delete silently reported success. Now rejected in `reflect_ordinary_delete_property_key` and `js_object_delete_field`. (`crates/perry-runtime/src/proxy.rs`, `crates/perry-runtime/src/object/delete_rest.rs`)

3. **`delete proxy.key`** lowers to the `ProxyDelete` HIR node, whose codegen returned `js_proxy_delete`'s boolean directly and ignored strict mode. A strict-mode delete that resolves to `false` must throw, exactly like the ordinary member-delete path — now routed through `js_delete_result` with the strict flag. (`crates/perry-codegen/src/expr/proxy_reflect.rs`)

## Before/after
`built-ins/Proxy`: **218/240 → 223/240** (parity 90.8% → 92.9%).

Newly passing (5):
- `setPrototypeOf/trap-is-missing-target-is-proxy.js`
- `setPrototypeOf/trap-is-undefined-target-is-proxy.js`
- `deleteProperty/trap-is-missing-target-is-proxy.js`
- `deleteProperty/trap-is-null-target-is-proxy.js`
- `deleteProperty/trap-is-undefined-target-is-proxy.js`

Zero regressions: verified the `built-ins/Proxy` slice (no new failures) plus `built-ins/Reflect`, `built-ins/Object{,/defineProperty,/getPrototypeOf,/setPrototypeOf}`, and `language/expressions/delete` (all unchanged).

`cargo fmt --all -- --check` and `scripts/check_file_size.sh` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `delete` to correctly report failure (and thus strict-mode throwing) for special non-configurable properties like Array `length` and function `prototype`.
  * Corrected Proxy deletion behavior so strict-mode observable semantics match ordinary `delete`, rather than incorrectly succeeding.
  * Fixed Proxy-backed `Object.setPrototypeOf` to fail reliably when the operation is not permitted (instead of appearing to succeed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->