### PR TITLE
fix(runtime,codegen): #5894 — x instanceof <non-constructor namespace> throws TypeError

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -329,6 +329,22 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     ));
                 }
             }
+            // A known non-constructor built-in namespace RHS (`Math`, `JSON`,
+            // `Reflect`, `Atomics`) has no [[Call]]/[[Construct]], so
+            // `x instanceof Math` throws a TypeError rather than folding to
+            // `false`. These never map to a real class id, so without this they
+            // would take the `cid == 0` → `js_instanceof(_, 0)` → `false` path.
+            // The LHS `v` was already lowered above (its side effects run), so
+            // just emit the throwing helper. Only fires for a bare identifier
+            // RHS (no member/dynamic `ty_expr`) that isn't shadowed by a user
+            // binding — a user `const Math = class {}` lands in `class_ids`.
+            if matches!(ty.as_str(), "Math" | "JSON" | "Reflect" | "Atomics")
+                && !ctx.class_ids.contains_key(ty)
+            {
+                return Ok(ctx
+                    .block()
+                    .call(DOUBLE, "js_instanceof_noncallable_rhs", &[]));
+            }
             // Built-in Error subclasses have reserved CLASS_ID_* constants
             // in the runtime (see crates/perry-runtime/src/error.rs). Map
             // them by name here so `e instanceof TypeError` works even

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1168,6 +1168,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // v0.5.749: dynamic instanceof — `value instanceof type` where type
     // is a runtime expression (function arg holding class ref).
     module.declare_function("js_instanceof_dynamic", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_instanceof_noncallable_rhs", DOUBLE, &[]);
     module.declare_function("js_register_class_extends_error", VOID, &[I32]);
     module.declare_function("js_register_class_extends_data_view", VOID, &[I32]);
     module.declare_function("js_register_class_id", VOID, &[I32]);

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -631,6 +631,22 @@ fn is_event_emitter_async_resource_instance_value(value: f64) -> bool {
     false
 }
 
+/// `x instanceof <non-constructor built-in>` — the RHS (e.g. `Math`, `JSON`,
+/// `Reflect`, `Atomics`) is a namespace object with no `[[Call]]`/`[[Construct]]`,
+/// so `InstanceofOperator` throws a `TypeError` ("Right-hand side ... is not
+/// callable") regardless of the LHS. The codegen recognizes these statically
+/// (they never map to a real class id) and calls this instead of the
+/// `js_instanceof(_, 0)` fold, which would wrongly return `false`. Honors the
+/// `SUPPRESS_INSTANCEOF_RHS_THROW` scope used by `Symbol.hasInstance` helpers.
+#[no_mangle]
+pub extern "C" fn js_instanceof_noncallable_rhs() -> f64 {
+    const TAG_FALSE: u64 = 0x7FFC_0000_0000_0003;
+    if SUPPRESS_INSTANCEOF_RHS_THROW.with(|c| c.get()) {
+        return f64::from_bits(TAG_FALSE);
+    }
+    throw_type_error(b"Right-hand side of 'instanceof' is not callable");
+}
+
 /// Check if a value is an instance of a class with the given class_id
 /// Walks the inheritance chain to check parent classes
 /// Returns NaN-boxed TAG_TRUE / TAG_FALSE so the result identifies as a boolean.


### PR DESCRIPTION
## Summary
`1 instanceof Math` (and `JSON`/`Reflect`/`Atomics`) must throw a `TypeError` — these namespace objects have no `[[Call]]`/`[[Construct]]`, so `InstanceofOperator` rejects them regardless of the LHS.

Perry's static-`instanceof` codegen mapped an unrecognized RHS name to `class_id = 0`, and `js_instanceof(_, 0)` folds to `false` (the #585 `class_id == 0` guard). So `1 instanceof Math` wrongly returned `false` instead of throwing. (The *dynamic* RHS path — `1 instanceof (Math as any)` — already threw correctly; only the statically-folded bare-identifier form was wrong.)

## Fix
- **Runtime:** add `js_instanceof_noncallable_rhs()` — throws `TypeError: Right-hand side of 'instanceof' is not callable`, honoring the existing `SUPPRESS_INSTANCEOF_RHS_THROW` scope used by the `Symbol.hasInstance` helpers.
- **Codegen:** when the bare-identifier RHS is a known non-constructor built-in namespace (`Math`/`JSON`/`Reflect`/`Atomics`) and isn't shadowed by a user class, emit that helper instead of the `js_instanceof(_, 0)` fold. The LHS is still lowered first, so its side effects run.

## Before / after (`language/expressions/instanceof`)
pass 29 → **30**, same other failures (zero regressions). **Fixed:** `S11.8.6_A6_T2` (`1 instanceof Math`).

Verified normal usage is untouched: `b instanceof B/A/Object`, `[] instanceof Array`, `new Error() instanceof Error` all still `true`.

The remaining instanceof failures (`F.prototype` not an object; `Function.prototype` as RHS; getter side effects) are a separate, more involved root in `js_instanceof_dynamic` and are out of scope here.

## Validation
- `cargo fmt --all -- --check` clean; `check_file_size.sh` OK.

Refs #5894. Code-only per contributor guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `instanceof` now handles built-in namespace objects like `Math`, `JSON`, `Reflect`, and `Atomics` correctly.
  * Invalid right-hand-side checks now raise the expected `TypeError` instead of silently returning `false` in cases where the value is not callable.
  * Existing `instanceof` behavior for other values remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->