### PR TITLE
fix(watchos): make the SwiftUI tree-shell pipeline work end-to-end

### DIFF
--- a/crates/perry-codegen/src/codegen/entry.rs
+++ b/crates/perry-codegen/src/codegen/entry.rs
@@ -811,9 +811,13 @@ pub(super) fn compile_module_entry(
                 //   loop_body:   tick all queues, sleep 10ms, jump to header
                 //   loop_exit:   ret 0
                 let header_idx = ctx.new_block("event_loop.header");
+                let pending_idx = ctx.new_block("event_loop.check_pending");
+                let host_ret_idx = ctx.new_block("event_loop.host_return");
                 let body_idx = ctx.new_block("event_loop.body");
                 let exit_idx = ctx.new_block("event_loop.exit");
                 let header_label = ctx.block_label(header_idx);
+                let pending_label = ctx.block_label(pending_idx);
+                let host_ret_label = ctx.block_label(host_ret_idx);
                 let body_label = ctx.block_label(body_idx);
                 let exit_label = ctx.block_label(exit_idx);
 
@@ -829,14 +833,29 @@ pub(super) fn compile_module_entry(
                 ctx.block().call_void("js_run_stdlib_pump", &[]);
                 ctx.block().br(&header_label);
 
-                // loop_header: check if there's any reason to keep running.
-                // Host-driven shells (watchOS SwiftUI tree renderer) flag the
-                // loop via js_set_event_loop_host_driven from perry_ui_app_run:
-                // the shell owns the run loop and ticks timers itself, so the
-                // entry must return (Swift calls it as perry_main_init and
-                // renders only after it comes back) even while timers are live.
+                // loop_header: host-driven shells (watchOS SwiftUI tree
+                // renderer) flag the loop via js_set_event_loop_host_driven
+                // from perry_ui_app_run: the shell owns the run loop and
+                // ticks timers itself, so the entry must return (Swift calls
+                // it as perry_main_init and renders only after it comes back)
+                // even while timers are live. Return PLAINLY — the process is
+                // not exiting, so the drained-exit epilogue below (beforeExit,
+                // exit finalization, unhandled-rejection reporting) must not
+                // run at what is effectively app launch.
                 ctx.current_block = header_idx;
+                let zero = "0".to_string();
                 let host_driven = ctx.block().call(I32, "js_event_loop_host_driven", &[]);
+                let host_cmp = ctx.block().icmp_ne(I32, &host_driven, &zero);
+                ctx.block()
+                    .cond_br(&host_cmp, &host_ret_label, &pending_label);
+
+                // host_return: hand control back to the host shell without
+                // the drained-exit epilogue.
+                ctx.current_block = host_ret_idx;
+                ctx.block().ret(I32, "0");
+
+                // check_pending: is there any reason to keep running?
+                ctx.current_block = pending_idx;
                 let has_timers = ctx.block().call(I32, "js_timer_has_pending", &[]);
                 let has_callbacks = ctx.block().call(I32, "js_callback_timer_has_pending", &[]);
                 let has_intervals = ctx.block().call(I32, "js_interval_timer_has_pending", &[]);
@@ -852,11 +871,8 @@ pub(super) fn compile_module_entry(
                 let any2 = ctx.block().or(I32, &has_intervals, &has_stdlib);
                 let any3 = ctx.block().or(I32, &any1, &any2);
                 let any = ctx.block().or(I32, &any3, &has_microtasks);
-                let zero = "0".to_string();
                 let cmp = ctx.block().icmp_ne(I32, &any, &zero);
-                let not_host = ctx.block().icmp_eq(I32, &host_driven, &zero);
-                let keep = ctx.block().and(crate::types::I1, &cmp, &not_host);
-                ctx.block().cond_br(&keep, &body_label, &exit_label);
+                ctx.block().cond_br(&cmp, &body_label, &exit_label);
 
                 // loop_body: tick everything, sleep, loop
                 ctx.current_block = body_idx;

--- a/crates/perry-codegen/src/codegen/entry.rs
+++ b/crates/perry-codegen/src/codegen/entry.rs
@@ -829,8 +829,14 @@ pub(super) fn compile_module_entry(
                 ctx.block().call_void("js_run_stdlib_pump", &[]);
                 ctx.block().br(&header_label);
 
-                // loop_header: check if there's any reason to keep running
+                // loop_header: check if there's any reason to keep running.
+                // Host-driven shells (watchOS SwiftUI tree renderer) flag the
+                // loop via js_set_event_loop_host_driven from perry_ui_app_run:
+                // the shell owns the run loop and ticks timers itself, so the
+                // entry must return (Swift calls it as perry_main_init and
+                // renders only after it comes back) even while timers are live.
                 ctx.current_block = header_idx;
+                let host_driven = ctx.block().call(I32, "js_event_loop_host_driven", &[]);
                 let has_timers = ctx.block().call(I32, "js_timer_has_pending", &[]);
                 let has_callbacks = ctx.block().call(I32, "js_callback_timer_has_pending", &[]);
                 let has_intervals = ctx.block().call(I32, "js_interval_timer_has_pending", &[]);
@@ -848,7 +854,9 @@ pub(super) fn compile_module_entry(
                 let any = ctx.block().or(I32, &any3, &has_microtasks);
                 let zero = "0".to_string();
                 let cmp = ctx.block().icmp_ne(I32, &any, &zero);
-                ctx.block().cond_br(&cmp, &body_label, &exit_label);
+                let not_host = ctx.block().icmp_eq(I32, &host_driven, &zero);
+                let keep = ctx.block().and(crate::types::I1, &cmp, &not_host);
+                ctx.block().cond_br(&keep, &body_label, &exit_label);
 
                 // loop_body: tick everything, sleep, loop
                 ctx.current_block = body_idx;

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -696,6 +696,9 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
     // after enqueueing onto a queue the pump drains; otherwise sleeps until
     // the next timer deadline (or 1s safety cap).
     module.declare_function("js_wait_for_event", VOID, &[]);
+    // Host-driven event loop flag (watchOS SwiftUI tree shell): the entry's
+    // drain loop exits when perry_ui_app_run marked the loop host-driven.
+    module.declare_function("js_event_loop_host_driven", I32, &[]);
     module.declare_function("js_unsettled_top_level_await_exit", VOID, &[]);
     module.declare_function("js_throw", VOID, &[DOUBLE]);
 

--- a/crates/perry-runtime/src/event_pump.rs
+++ b/crates/perry-runtime/src/event_pump.rs
@@ -454,6 +454,25 @@ pub extern "C" fn perry_next_wake_ms() -> f64 {
     best
 }
 
+/// Host-driven event loop (watchOS SwiftUI tree shell). When set, the
+/// generated entry's event-drain loop exits after its initial microtask
+/// flush instead of parking: the host shell (PerryWatchApp.swift) owns the
+/// run loop and calls js_callback_timer_tick / js_interval_timer_tick each
+/// frame, and `perry_main_init` must return so SwiftUI can render the tree.
+/// Set by perry-ui-watchos `app_run()` — i.e. only when the user program
+/// actually built a perry/ui App on a Swift-shell platform.
+static EVENT_LOOP_HOST_DRIVEN: AtomicBool = AtomicBool::new(false);
+
+#[no_mangle]
+pub extern "C" fn js_set_event_loop_host_driven(v: i32) {
+    EVENT_LOOP_HOST_DRIVEN.store(v != 0, Ordering::Relaxed);
+}
+
+#[no_mangle]
+pub extern "C" fn js_event_loop_host_driven() -> i32 {
+    EVENT_LOOP_HOST_DRIVEN.load(Ordering::Relaxed) as i32
+}
+
 /// Block until the next scheduled timer fires, a notify arrives, or the
 /// 1-second idle cap elapses — whichever is earliest. Returns immediately
 /// if a notify arrived since the last call (the flag is cleared on

--- a/crates/perry-ui-watchos/src/app.rs
+++ b/crates/perry-ui-watchos/src/app.rs
@@ -31,12 +31,19 @@ pub fn app_run(_app_handle: i64) {
     // but on watchOS this is a no-op — the Swift @main struct drives the loop.
     //
     // perry_main_init() is called from Swift before the app body is rendered,
-    // so by the time SwiftUI queries the tree, it's fully built.
+    // so by the time SwiftUI queries the tree, it's fully built. Flag the
+    // event loop as host-driven so the generated entry's drain loop exits
+    // instead of parking on live timers — otherwise perry_main_init never
+    // returns and SwiftUI never renders (the shell drives timer ticks).
+    unsafe { js_set_event_loop_host_driven(1) };
     register_cross_platform_text_handlers();
     install_test_mode_exit_timer();
 }
 
 extern "C" {
+    /// Defined in `perry-runtime/src/event_pump.rs`. Tells the generated
+    /// entry's event-drain loop that the Swift shell owns the run loop.
+    fn js_set_event_loop_host_driven(v: i32);
     /// Defined in `perry-runtime/src/ui_text_registry.rs`. Stores the
     /// passed handler in an AtomicPtr that `perry_arkts_show_toast`
     /// consults on each call. No-op when `ohos-napi` is on.

--- a/crates/perry-ui-watchos/src/audio.rs
+++ b/crates/perry-ui-watchos/src/audio.rs
@@ -112,8 +112,6 @@ pub fn start() -> i64 {
         ENGINE.with(|e| {
             *e.borrow_mut() = Some(engine);
         });
-        // DEBUG: write a test value so we can tell if engine started vs tap not firing
-        CURRENT_DB.store(42.0_f64.to_bits(), Ordering::Relaxed);
         1
     }
 }
@@ -134,14 +132,50 @@ pub fn stop() {
 }
 
 pub fn get_level() -> f64 {
-    // DEBUG: always return 55 to verify this function is called
-    return 55.0;
-    #[allow(unreachable_code)]
     f64::from_bits(CURRENT_DB.load(Ordering::Relaxed))
 }
 
 pub fn get_peak() -> f64 {
     f64::from_bits(CURRENT_PEAK.load(Ordering::Relaxed))
+}
+
+/// Device identifier (e.g. "Watch7,5") as a JS string handle, from
+/// sysctl hw.machine — same source as the iOS/tvOS implementations.
+pub fn get_device_model() -> i64 {
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    let model = get_sysctl_model();
+    unsafe { js_string_from_bytes(model.as_ptr(), model.len() as i32) }
+}
+
+fn get_sysctl_model() -> String {
+    use std::ffi::CStr;
+    let mut size: libc::size_t = 0;
+    let name = c"hw.machine";
+    unsafe {
+        libc::sysctlbyname(
+            name.as_ptr(),
+            std::ptr::null_mut(),
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        );
+        if size == 0 {
+            return "Unknown".to_string();
+        }
+        let mut buf = vec![0u8; size];
+        libc::sysctlbyname(
+            name.as_ptr(),
+            buf.as_mut_ptr() as *mut _,
+            &mut size,
+            std::ptr::null_mut(),
+            0,
+        );
+        CStr::from_ptr(buf.as_ptr() as *const i8)
+            .to_string_lossy()
+            .into_owned()
+    }
 }
 
 unsafe fn process_audio_buffer(buffer: *mut AnyObject, sample_rate: f64) {

--- a/crates/perry-ui-watchos/src/lib.rs
+++ b/crates/perry-ui-watchos/src/lib.rs
@@ -1304,7 +1304,7 @@ pub extern "C" fn perry_system_app_group_delete(_key_ptr: i64) {
 pub extern "C" fn perry_system_request_location(_cb: f64) {}
 #[no_mangle]
 pub extern "C" fn perry_system_audio_start() -> f64 {
-    1.0
+    audio::start() as f64
 }
 #[no_mangle]
 pub extern "C" fn perry_system_audio_stop() {
@@ -1324,7 +1324,7 @@ pub extern "C" fn perry_system_audio_get_waveform(_count: f64) -> f64 {
 }
 #[no_mangle]
 pub extern "C" fn perry_system_get_device_model() -> i64 {
-    0
+    audio::get_device_model()
 }
 /// Bug-report-flow utility: stable OS-version string. watchOS stub.
 #[no_mangle]

--- a/crates/perry-ui-watchos/swift/PerryWatchApp.swift
+++ b/crates/perry-ui-watchos/swift/PerryWatchApp.swift
@@ -17,6 +17,13 @@ import WatchKit
 @_silgen_name("perry_watchos_dispatch_background_task")
 func perry_watchos_dispatch_background_task(_ id: UnsafePointer<CChar>)
 
+// Timer ticks — drive setTimeout/setInterval from the JS runtime. Without
+// these the TS event loop never advances on watchOS (there is no
+// CADisplayLink here; the render Timer below is the only recurring host
+// callback).
+@_silgen_name("js_callback_timer_tick") func js_callback_timer_tick() -> Int32
+@_silgen_name("js_interval_timer_tick") func js_interval_timer_tick() -> Int32
+
 // Tree query
 @_silgen_name("perry_watchos_root_node") func perry_watchos_root_node() -> Int64
 @_silgen_name("perry_watchos_tree_version") func perry_watchos_tree_version() -> UInt64
@@ -104,6 +111,9 @@ class PerryBridge: ObservableObject {
     func start() {
         timer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
             guard let self = self else { return }
+            // Drive JS runtime timers (setInterval, setTimeout) each frame.
+            _ = js_callback_timer_tick()
+            _ = js_interval_timer_tick()
             let v = perry_watchos_tree_version()
             if v != self.version {
                 self.version = v

--- a/crates/perry/src/commands/compile/bundle_apple.rs
+++ b/crates/perry/src/commands/compile/bundle_apple.rs
@@ -276,12 +276,13 @@ pub(super) fn bundle_for_watchos(
                     if let Some(s) = value.as_str() {
                         entries.push_str(&format!(
                             "    <key>{}</key>\n    <string>{}</string>\n",
-                            key, s
+                            xml_escape(key),
+                            xml_escape(s)
                         ));
                     } else if let Some(b) = value.as_bool() {
                         entries.push_str(&format!(
                             "    <key>{}</key>\n    <{}/>\n",
-                            key,
+                            xml_escape(key),
                             if b { "true" } else { "false" }
                         ));
                     }

--- a/crates/perry/src/commands/compile/bundle_apple.rs
+++ b/crates/perry/src/commands/compile/bundle_apple.rs
@@ -256,6 +256,52 @@ pub(super) fn bundle_for_watchos(
 </dict>
 </plist>"#
     );
+
+    // Append custom Info.plist entries from [watchos.info_plist] in
+    // perry.toml (same walk as the iOS bundler) — required for usage
+    // descriptions like NSMicrophoneUsageDescription, without which
+    // watchOS denies the permission request outright.
+    let custom_plist_entries = (|| -> Option<String> {
+        let mut dir = input.canonicalize().ok()?;
+        for _ in 0..5 {
+            dir = dir.parent()?.to_path_buf();
+            let toml_path = dir.join("perry.toml");
+            if toml_path.exists() {
+                let data = fs::read_to_string(&toml_path).ok()?;
+                let doc: toml::Table = data.parse().ok()?;
+                let watchos = doc.get("watchos")?.as_table()?;
+                let info_plist_table = watchos.get("info_plist")?.as_table()?;
+                let mut entries = String::new();
+                for (key, value) in info_plist_table {
+                    if let Some(s) = value.as_str() {
+                        entries.push_str(&format!(
+                            "    <key>{}</key>\n    <string>{}</string>\n",
+                            key, s
+                        ));
+                    } else if let Some(b) = value.as_bool() {
+                        entries.push_str(&format!(
+                            "    <key>{}</key>\n    <{}/>\n",
+                            key,
+                            if b { "true" } else { "false" }
+                        ));
+                    }
+                }
+                if !entries.is_empty() {
+                    return Some(entries);
+                }
+            }
+        }
+        None
+    })()
+    .unwrap_or_default();
+    let info_plist = if !custom_plist_entries.is_empty() {
+        info_plist.replace(
+            "</dict>\n</plist>",
+            &format!("{}</dict>\n</plist>", custom_plist_entries),
+        )
+    } else {
+        info_plist
+    };
     fs::write(app_dir.join("Info.plist"), info_plist)?;
 
     // Copy project resource directories into the bundle so

--- a/crates/perry/src/commands/compile/targets.rs
+++ b/crates/perry/src/commands/compile/targets.rs
@@ -726,7 +726,17 @@ pub(super) fn find_watchos_swift_runtime() -> Option<PathBuf> {
         }
     }
 
-    // 2. Check in the source tree (development builds)
+    // 2. Check the workspace checkout (PERRY_WORKSPACE_ROOT / exe / cwd
+    // walk) so npm/homebrew installs pointed at a source tree resolve the
+    // Swift shell the same way they resolve runtime/stdlib.
+    if let Some(root) = super::find_perry_workspace_root() {
+        let candidate = root.join("crates/perry-ui-watchos/swift/PerryWatchApp.swift");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+    }
+
+    // 3. Check in the source tree (development builds)
     let source_candidate = PathBuf::from("crates/perry-ui-watchos/swift/PerryWatchApp.swift");
     if source_candidate.exists() {
         return Some(source_candidate);
@@ -752,6 +762,13 @@ pub(super) fn find_visionos_swift_runtime() -> Option<PathBuf> {
                     return Some(candidate);
                 }
             }
+        }
+    }
+
+    if let Some(root) = super::find_perry_workspace_root() {
+        let candidate = root.join("crates/perry-ui-visionos/swift/PerryVisionApp.swift");
+        if candidate.exists() {
+            return Some(candidate);
         }
     }
 


### PR DESCRIPTION
## Summary

Makes the default watchOS mode (the fixed `PerryWatchApp.swift` SwiftUI tree renderer — no `watchos-game-loop` / `watchos-swift-app` feature) work end to end. Exercised with a real app (dbmeter, a `setInterval`-driven microphone dB meter): before this PR it hung on the launch spinner forever with a stubbed 55.0 dB level; after it renders, updates live, and reads real AVAudioEngine mic levels on the watchOS simulator.

## Changes

- **`crates/perry-ui-watchos/src/{audio,lib}.rs` — wire up the audio surface.** `perry_system_audio_start` was a `1.0` stub that never called `audio::start()` (the AVAudioEngine tap was never installed), `audio::get_level()` had a debug `return 55.0;` short-circuit, `start()` seeded a debug `42.0`, and `perry_system_get_device_model` returned `0` — an invalid string handle that user code then indexed with. Wired start, removed the debug returns, and implemented `get_device_model` via `sysctl hw.machine` exactly like the iOS backend.
- **`crates/perry-ui-watchos/swift/PerryWatchApp.swift` — drive JS timers from the shell.** The 60 Hz bridge timer now calls `js_callback_timer_tick` / `js_interval_timer_tick` each frame. There is no CADisplayLink on watchOS and (with the fix below) the generated drain loop no longer runs, so without this the TS event loop never advances — `setTimeout`/`setInterval` simply never fired in the tree shell.
- **`crates/perry-runtime/src/event_pump.rs`, `crates/perry-codegen/src/codegen/entry.rs`, `runtime_decls/strings_part2.rs` — host-driven event-loop flag.** The tree shell calls the TS entry as `perry_main_init` from `PerryApp.init()` and SwiftUI can only render after it returns — but the generated epilogue parks in the `js_wait_for_event` drain loop whenever a timer is live, so any `setInterval` app hung on the launch spinner forever (sampled: main thread in `perry_main_init → js_wait_for_event → pthread_cond_wait`). `perry_ui_app_run` (watchOS) now calls the new `js_set_event_loop_host_driven(1)`, and the generated loop header exits when the flag is set. No-op everywhere else: nothing but the watchOS tree-mode `app_run` sets the flag, `watchos-game-loop` / `watchos-swift-app` builds never call `App()` so their background-thread event loop keeps draining as before, and console apps still drain and exit normally (verified).
- **`crates/perry/src/commands/compile/bundle_apple.rs` — honor `[watchos.info_plist]`.** `bundle_for_watchos` wrote a fixed plist and ignored the config table (unlike the iOS bundler), so a locally built watch `.app` never carried `NSMicrophoneUsageDescription` — watchOS denies the mic permission outright without it. Now merged with the same 5-level `perry.toml` walk as `bundle_ios.rs`.
- **`crates/perry/src/commands/compile/targets.rs` — resolve the Swift shells from the workspace.** `find_watchos_swift_runtime` / `find_visionos_swift_runtime` only probed next-to-binary and CWD, so an npm-installed CLI pointed at a source checkout failed with `PerryWatchApp.swift not found` even though runtime/stdlib resolved fine. Both now probe `find_perry_workspace_root()` (which honors `PERRY_WORKSPACE_ROOT`).

## Related issue

n/a — found while migrating a real app (dbmeter) from a hand-maintained watch Xcode project to the native `perry compile --target watchos` pipeline.

## Test plan

- [x] `cargo build --release -p perry` clean on this branch
- [x] `cargo +nightly build -Z build-std=std,panic_abort --release -p perry-ui-watchos --target aarch64-apple-watchos-sim` clean
- [x] End-to-end on watchOS 26.5 simulator (Apple Watch Series 11), with these changes applied on ed952eb12(+#5437): compiled a `setInterval`-driven perry/ui mic-meter app with `--target watchos-simulator`, installed + launched — UI renders (previously: stuck on launch spinner), dB value/label/stats update live at 10 fps with real mic input (previously: would have shown the constant 55.0 stub), `Info.plist` carries `WKApplication`/`WKWatchOnly` + `NSMicrophoneUsageDescription` from `[watchos.info_plist]`
- [x] Regression check on macOS host: `console.log` app and a `setInterval`+`clearInterval` console app still run, drain, and exit normally; a perry/ui macOS app still compiles and links
- [ ] Full `cargo test --workspace` not run locally — deferring to CI

> **Note:** re-running the same e2e demo with this branch rebased onto current main crashes at app startup in `getDeviceModel()` → object-key lookup — that is the orthogonal dispatch/nanboxing regression filed as #5972 (it reproduces with the unmodified npm 0.5.1220 CLI on macOS and dies before any code path this PR touches). The tree-shell fixes themselves were verified working end-to-end pre-rebase as described above.

## Screenshots / output

Simulator run, ~5 s apart (live mic input): `39 dB / "Very quiet" / MIN 4 AVG 34 MAX 42` → `44 dB / "Normal" / MIN 4 AVG 42 MAX 52`.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom watchOS Info.plist metadata from project configuration.
  * watchOS apps can now report live audio level and device model (plus current peak).
  * watchOS timer progression is driven more reliably each render tick.

* **Bug Fixes**
  * Improved watchOS event-loop behavior so the app-owned run loop exits correctly in host-driven mode.
  * Replaced remaining watchOS placeholder runtime values with real results.

* **Chores**
  * Improved Swift runtime discovery for watchOS and visionOS across workspace layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->