### PR TITLE
fix(runtime): #5894 — exact BigInt-vs-large-Number comparison (Number.MAX_VALUE)

### DIFF
--- a/crates/perry-runtime/src/bigint.rs
+++ b/crates/perry-runtime/src/bigint.rs
@@ -1173,8 +1173,24 @@ pub(crate) fn bigint_cmp_f64(x: *const BigIntHeader, y: f64) -> i32 {
     if y == f64::NEG_INFINITY {
         return 1; // x > -Infinity
     }
-    // `y` is finite. Compare `x` with `floor(y)` as exact integers; if equal,
-    // a positive fractional part of `y` makes `x` strictly smaller.
+    // `y` may be larger in magnitude than any value the fixed-width (1024-bit
+    // two's-complement) BigInt can hold — e.g. `Number.MAX_VALUE` (~1.8e308) has
+    // its top magnitude bit at position 1023, so round-tripping it through
+    // `js_bigint_from_f64` sets the sign bit and reads back as negative. Any
+    // representable BigInt `x` satisfies |x| < 2^1023, so once |y| reaches that
+    // bound the comparison is decided by the sign of `y` alone (test262
+    // `bigint-and-number-extremes`).
+    // 2^1023 as an exact IEEE-754 double (biased exponent 2046, zero mantissa).
+    let bigint_mag_bound = f64::from_bits(0x7FE0_0000_0000_0000);
+    if y >= bigint_mag_bound {
+        return -1; // x < y for every representable BigInt
+    }
+    if y <= -bigint_mag_bound {
+        return 1; // x > y
+    }
+    // `y` is finite and within BigInt range. Compare `x` with `floor(y)` as
+    // exact integers; if equal, a positive fractional part of `y` makes `x`
+    // strictly smaller.
     let floor = y.floor();
     let floor_big = js_bigint_from_f64(floor);
     let c = js_bigint_cmp(x, floor_big);


### PR DESCRIPTION
## Summary
Comparing a BigInt with a Number whose magnitude reaches `2^1023` — e.g. `1n >= Number.MAX_VALUE` — round-tripped the Number through `js_bigint_from_f64`, which overflows Perry's fixed 1024-bit two's-complement BigInt. `Number.MAX_VALUE`'s top magnitude bit lands on the sign bit and reads back as *negative*, so `bigint_cmp_f64` saw `Number.MAX_VALUE` as a negative BigInt and `1n >= Number.MAX_VALUE` wrongly returned `true`.

## Fix
Any representable BigInt `x` satisfies `|x| < 2^1023`, so once `|y|` reaches that bound the comparison is decided by the sign of `y` alone. Add that short-circuit in `bigint_cmp_f64` *before* the lossy `f64 → BigInt` conversion (using the exact IEEE-754 double for `2^1023`).

## Before / after
```
1n >= MAX:  true → false   ✓
MAX >= 1n:  false → true    ✓
1n >= -MAX: false → true    ✓
1n <  MAX:  false → true    ✓
1n >  MAX:  true → false    ✓
```
Small-value comparisons (`2n > 1`, `1n < 2`) and same-type BigInt/Number comparisons are unchanged. `built-ins/BigInt` unchanged (53 pass / 3 fail) — **no regressions**.

## Scope note
This fixes every `1n {<,<=,>,>=} Number.MAX_VALUE` (and `±MAX_VALUE`) case. The **remaining** `bigint-and-number-extremes` assertions use BigInt *literals* near `2^1024` (e.g. `0xfffffffffffff800…001n`), which exceed Perry's fixed **1024-bit** BigInt width — that BigInt itself truncates on parse (`huge > 0n` is already wrong), a separate architectural limit (arbitrary-precision BigInt) outside this change. So this improves correctness broadly but does not by itself close `bigint-and-number-extremes.js`.

## Validation
- `cargo fmt --all -- --check` clean; `check_file_size.sh` OK.

Refs #5894. Code-only per contributor guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric comparisons between very large integers and floating-point values.
  * Large finite decimal values now short-circuit correctly, preventing incorrect comparison results at extreme magnitudes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->