### PR TITLE
fix(temporal): #5900 — honor options.calendar + reject invalid date/time style in toLocaleString

### DIFF
--- a/crates/perry-runtime/src/intl/date_collator.rs
+++ b/crates/perry-runtime/src/intl/date_collator.rs
@@ -1357,8 +1357,8 @@ pub(crate) fn temporal_locale_string(
         }
     };
 
-    let mut date_style = get_opt("dateStyle");
-    let mut time_style = get_opt("timeStyle");
+    let date_style = get_opt("dateStyle");
+    let time_style = get_opt("timeStyle");
     let year_opt = get_opt("year");
     let month_opt = get_opt("month");
     let day_opt = get_opt("day");
@@ -1414,25 +1414,25 @@ pub(crate) fn temporal_locale_string(
             // timeStyle is silently ignored (the date-only value is formatted
             // using dateStyle alone). Only throw when timeStyle is the sole
             // style selector (no dateStyle to fall back on).
-            if time_style.is_some() && date_style.is_none() {
+            // Date-only Temporal types run `ToDateTimeOptions(options, "date",
+            // "date")`, whose `required = "date"` step throws a TypeError if ANY
+            // time-only style is present — `timeStyle` is rejected even when
+            // `dateStyle` is also supplied (test262
+            // .../toLocaleString/datestyle-and-timestyle for
+            // PlainDate/PlainYearMonth/PlainMonthDay).
+            if time_style.is_some() {
                 throw_type_error(
                     "timeStyle option is not valid for this Temporal type (no time component)",
                 );
             }
-            // Silence timeStyle so downstream formatting uses date-only logic.
-            if time_style.is_some() && date_style.is_some() {
-                time_style = None;
-            }
         }
         TemporalLocaleCtx::PlainTime => {
-            // Symmetric: dateStyle alone throws; combined → drop dateStyle.
-            if date_style.is_some() && time_style.is_none() {
+            // Symmetric: `ToDateTimeOptions(options, "time", "time")` rejects any
+            // `dateStyle` on a time-only value, combined with `timeStyle` or not.
+            if date_style.is_some() {
                 throw_type_error(
                     "dateStyle option is not valid for Temporal.PlainTime (no date component)",
                 );
-            }
-            if date_style.is_some() && time_style.is_some() {
-                date_style = None;
             }
         }
         TemporalLocaleCtx::ZonedDateTime => {

--- a/crates/perry-runtime/src/temporal/options.rs
+++ b/crates/perry-runtime/src/temporal/options.rs
@@ -387,27 +387,42 @@ fn reject_bare_islamic(id: &str) {
 
 // ---- `Temporal.*.prototype.toLocaleString` ---------------------------------
 
+/// Resolve the calendar the `Intl.DateTimeFormat` created for a
+/// `toLocaleString(locales, options)` call would use: the explicit
+/// `options.calendar` when present (validated as a real calendar identifier),
+/// otherwise the locale default — which Perry's `Intl.DateTimeFormat` reports as
+/// `gregory`. Returns a lowercase calendar id string. An `options.calendar`
+/// that isn't a valid identifier throws a `RangeError` (matching
+/// `Intl.DateTimeFormat`'s own validation).
+fn formatter_calendar(options_arg: f64) -> String {
+    if let Some(obj) = as_obj(options_arg) {
+        let raw = field(obj, "calendar");
+        if !is_undefined(raw) {
+            let s = read_string(raw);
+            // Validate against `temporal_rs`'s calendar table; an unknown id is a
+            // `RangeError`, exactly like the `Intl.DateTimeFormat` constructor.
+            ok_or_throw(temporal_rs::Calendar::try_from_utf8(s.as_bytes()));
+            return s.to_ascii_lowercase();
+        }
+    }
+    "gregory".to_string()
+}
+
 /// `Temporal.*.prototype.toLocaleString` calendar check for `PlainDate`,
 /// `PlainDateTime`, and `ZonedDateTime` — per `HandleDateTimeTemporalDate`
 /// (ecma402 sup-intl.html #1107) and the analogous `ZonedDateTime` clause
 /// (#1953), a value renders only when its calendar matches the formatter's:
-/// the ISO-8601 calendar (always permitted) or the calendar the locale
-/// resolves to. With no explicit `calendar` option that resolved calendar is
-/// the locale default, which Perry's `Intl.DateTimeFormat` reports as
-/// `gregory`. Any other calendar is a `RangeError` (the test262
+/// the ISO-8601 calendar (always permitted) or the calendar the formatter
+/// resolves to. The formatter's calendar is the explicit `options.calendar`
+/// (2nd argument) when supplied, else the locale default (`gregory`). Any other
+/// instance calendar is a `RangeError` (the test262
 /// `toLocaleString/calendar-mismatch` cases).
 ///
 /// `PlainYearMonth`/`PlainMonthDay` do NOT get the ISO carve-out — see
 /// [`assert_locale_string_calendar_no_iso_carveout`].
-///
-/// NOTE: the `locales`/`options` arguments — which could name a *different*
-/// calendar to validate against — are dropped by the `Expr::DateToLocaleString`
-/// HIR lowering before the call reaches the runtime, so only the locale-default
-/// calendar is consulted here. Honoring an explicit `calendar`/`dateStyle`/
-/// `timeStyle` option (and the spec's option-conflict `TypeError`s) is a
-/// follow-up that depends on threading those arguments through that lowering.
-pub fn assert_locale_string_calendar(instance_calendar: &str) {
-    if instance_calendar != "iso8601" && instance_calendar != "gregory" {
+pub fn assert_locale_string_calendar(instance_calendar: &str, options_arg: f64) {
+    let formatter = formatter_calendar(options_arg);
+    if instance_calendar != "iso8601" && instance_calendar != formatter {
         range("calendar mismatch: the value's calendar differs from the locale calendar");
     }
 }
@@ -416,13 +431,15 @@ pub fn assert_locale_string_calendar(instance_calendar: &str) {
 /// check. `HandleDateTimeTemporalYearMonth`/`HandleDateTimeTemporalMonthDay`
 /// (ecma402 sup-intl.html #1132, #1157) require the instance calendar to
 /// equal the formatter's calendar exactly — unlike `PlainDate`/`PlainDateTime`
-/// /`ZonedDateTime`, there is no `"iso8601"`-is-always-permitted carve-out, so
-/// an ISO-calendar year-month/month-day always mismatches the locale's
-/// default (`gregory`) calendar and throws (test262
-/// `toLocaleString/calendar-mismatch` "even when instance has the ISO
-/// calendar" cases).
-pub fn assert_locale_string_calendar_no_iso_carveout(instance_calendar: &str) {
-    if instance_calendar != "gregory" {
+/// /`ZonedDateTime`, there is no `"iso8601"`-is-always-permitted carve-out. The
+/// formatter's calendar is the explicit `options.calendar` (2nd argument) when
+/// supplied, else the locale default (`gregory`). So an ISO-calendar
+/// year-month/month-day renders only when the caller passes
+/// `{ calendar: "iso8601" }`, and mismatches the locale default otherwise
+/// (test262 `toLocaleString/calendar-mismatch` "even when instance has the ISO
+/// calendar" cases as well as `return-string` / `dateStyle`).
+pub fn assert_locale_string_calendar_no_iso_carveout(instance_calendar: &str, options_arg: f64) {
+    if instance_calendar != formatter_calendar(options_arg) {
         range("calendar mismatch: the value's calendar differs from the locale calendar");
     }
 }

--- a/crates/perry-runtime/src/temporal/plain_date.rs
+++ b/crates/perry-runtime/src/temporal/plain_date.rs
@@ -224,7 +224,10 @@ pub fn call(recv: f64, d: &PlainDate, name: &str, args: &[f64]) -> f64 {
         }
         "toJSON" => string(&d.to_string()),
         "toLocaleString" => {
-            super::options::assert_locale_string_calendar(d.calendar().identifier());
+            super::options::assert_locale_string_calendar(
+                d.calendar().identifier(),
+                raw_arg(args, 1),
+            );
             let epoch_ms = crate::date::components_to_timestamp(
                 d.year(),
                 d.month() as u32,

--- a/crates/perry-runtime/src/temporal/plain_date_time.rs
+++ b/crates/perry-runtime/src/temporal/plain_date_time.rs
@@ -186,7 +186,10 @@ pub fn call(recv: f64, dt: &PlainDateTime, name: &str, args: &[f64]) -> f64 {
         }
         "toJSON" => string(&dt.to_string()),
         "toLocaleString" => {
-            super::options::assert_locale_string_calendar(dt.calendar().identifier());
+            super::options::assert_locale_string_calendar(
+                dt.calendar().identifier(),
+                raw_arg(args, 1),
+            );
             let epoch_ms = crate::date::components_to_timestamp(
                 dt.year(),
                 dt.month() as u32,

--- a/crates/perry-runtime/src/temporal/plain_month_day.rs
+++ b/crates/perry-runtime/src/temporal/plain_month_day.rs
@@ -133,6 +133,7 @@ pub fn call(recv: f64, md: &PlainMonthDay, name: &str, args: &[f64]) -> f64 {
         "toLocaleString" => {
             super::options::assert_locale_string_calendar_no_iso_carveout(
                 md.calendar().identifier(),
+                raw_arg(args, 1),
             );
             let epoch_ms = crate::date::components_to_timestamp(
                 1970,

--- a/crates/perry-runtime/src/temporal/plain_year_month.rs
+++ b/crates/perry-runtime/src/temporal/plain_year_month.rs
@@ -161,6 +161,7 @@ pub fn call(recv: f64, ym: &PlainYearMonth, name: &str, args: &[f64]) -> f64 {
         "toLocaleString" => {
             super::options::assert_locale_string_calendar_no_iso_carveout(
                 ym.calendar().identifier(),
+                raw_arg(args, 1),
             );
             let epoch_ms =
                 crate::date::components_to_timestamp(ym.year(), ym.month() as u32, 1, 0, 0, 0)

--- a/crates/perry-runtime/src/temporal/zoned_date_time.rs
+++ b/crates/perry-runtime/src/temporal/zoned_date_time.rs
@@ -253,7 +253,10 @@ pub fn call(recv: f64, z: &ZonedDateTime, name: &str, args: &[f64]) -> f64 {
         }
         "toJSON" => string(&z.to_string()),
         "toLocaleString" => {
-            super::options::assert_locale_string_calendar(z.calendar().identifier());
+            super::options::assert_locale_string_calendar(
+                z.calendar().identifier(),
+                raw_arg(args, 1),
+            );
             let epoch_ms = z.epoch_milliseconds() as f64;
             crate::intl::temporal_locale_string(
                 epoch_ms,


### PR DESCRIPTION
Part of #5900 (Temporal built-ins + intl402 worklist). Targets the 11 `calendar mismatch` `toLocaleString` failures plus the date/time-style `TypeError` cases.

## Root cause
`Temporal.*.prototype.toLocaleString` already threads its `(locales, options)` arguments to the native method dispatch, but the calendar-match guard never consulted them — the formatter calendar was hardcoded to the locale default (`gregory`). So an ISO-calendar `PlainYearMonth`/`PlainMonthDay`/`PlainDate` threw `RangeError: calendar mismatch` even when the caller explicitly passed `{ calendar: "iso8601" }` (which matches). (The stale doc-comment claiming the options were "dropped by the `Expr::DateToLocaleString` HIR lowering" applied to the `Date` path, not the Temporal method dispatch.)

## Fixes
1. **`options.calendar` is now honored.** New `formatter_calendar(options)` resolves the `Intl.DateTimeFormat` calendar the formatter would use: the explicit `options.calendar` (validated as a real calendar identifier via `temporal_rs::Calendar::try_from_utf8`, else `RangeError`) or the locale default `gregory`. Both `assert_locale_string_calendar` (Date/DateTime/ZonedDateTime, with the ISO carve-out) and `assert_locale_string_calendar_no_iso_carveout` (YearMonth/MonthDay, exact match) compare the instance calendar against it. (`crates/perry-runtime/src/temporal/options.rs` + the 5 dispatch callers.)

2. **Date-only / time-only style validation.** Per `ToDateTimeOptions(options, "date", "date")`, a date-only Temporal type throws `TypeError` for ANY `timeStyle` — even alongside `dateStyle`. Perry previously silenced `timeStyle` when `dateStyle` was present. Now `PlainDate`/`PlainYearMonth`/`PlainMonthDay` reject `timeStyle` unconditionally and `PlainTime` rejects `dateStyle` unconditionally. (`crates/perry-runtime/src/intl/date_collator.rs`.) Fixes the `datestyle-and-timestyle` cases.

## Verification
- `built-ins/Temporal/PlainYearMonth/prototype/toLocaleString` and `.../PlainMonthDay/...`: **7/7 each (100%)**.
- Direct repros: `PlainYearMonth(1,1).toLocaleString(undefined, {calendar:"iso8601"})` returns a string; a genuine mismatch (`{calendar:"hebrew"}`) still throws `RangeError`; `PlainDate.toLocaleString("en",{dateStyle:"full",timeStyle:"full"})` throws `TypeError` while single-style still formats.
- `cargo fmt --all -- --check` + `scripts/check_file_size.sh` pass.

(A full `intl402/Temporal` zero-regression sweep is running; will note the numbers in a follow-up comment.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `toLocaleString()` now respects the calendar provided in the options argument, improving calendar matching for Temporal values.
  * ISO-only Temporal values now render only when the matching calendar is explicitly requested.
  * Invalid `dateStyle`/`timeStyle` combinations now consistently throw errors instead of being silently adjusted in some cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->