### PR TITLE
fix(build,compile): #5928 — codegen-units alignment + cold-build dedup fix for well-known libs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,6 +229,34 @@ codegen-units = 16
 strip = false
 codegen-units = 16
 
+# Issue #5928: well-known "shared tokio" wrapper crates (#507) are built in
+# the SAME cargo invocation as perry-stdlib-static so cargo unifies their
+# shared dependency graph (tokio, hyper_util, rustls, and even core/std
+# monomorphizations) into identical compilation units. That unification only
+# holds if EVERY crate in that invocation uses the SAME `codegen-units`
+# setting — rustc partitions a crate's monomorphized code into N codegen
+# units based on this value, so two crates compiling the "same" shared
+# dependency with different `codegen-units` end up with differently-sized,
+# differently-partitioned .rcgu.o objects despite sharing an identical
+# crate/feature graph (confirmed empirically: perry-stdlib-static's `core`
+# codegen unit was 551 KB vs an ext crate's 2.4 MB for the identically
+# hash-named unit, before this fix). Without this, macOS's linker (which
+# has no `-multiply_defined suppress` / `-ld_classic` tolerance mode
+# anymore) hits thousands of `ld: duplicate symbol` errors once a program
+# needs 2+ of these wrapper crates simultaneously, because perry's
+# strip-dedup mechanism assumes same-named codegen units are byte-identical
+# and safe to drop duplicates from — an assumption this mismatch violated.
+[profile.release.package.perry-ext-fastify]
+codegen-units = 16
+[profile.release.package.perry-ext-http]
+codegen-units = 16
+[profile.release.package.perry-ext-ioredis]
+codegen-units = 16
+[profile.release.package.perry-ext-net]
+codegen-units = 16
+[profile.release.package.perry-ext-ws]
+codegen-units = 16
+
 # Fast developer profile (#5422). Optimized enough for realistic local runs but
 # without the distribution-grade settings that dominate compile time, so the
 # edit/build loop stays short. Intended local loop:
@@ -298,6 +326,20 @@ strip = false
 codegen-units = 16
 [profile.dist.package.perry-stdlib-static]
 strip = false
+codegen-units = 16
+
+# Issue #5928: mirrors the [profile.release.package.perry-ext-*] block above
+# — see its comment for why matching `codegen-units` across every crate in
+# the "shared tokio" (#507) cargo invocation is required.
+[profile.dist.package.perry-ext-fastify]
+codegen-units = 16
+[profile.dist.package.perry-ext-http]
+codegen-units = 16
+[profile.dist.package.perry-ext-ioredis]
+codegen-units = 16
+[profile.dist.package.perry-ext-net]
+codegen-units = 16
+[profile.dist.package.perry-ext-ws]
 codegen-units = 16
 
 [workspace.package]

--- a/crates/perry/src/commands/compile/optimized_libs/driver.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/driver.rs
@@ -1069,7 +1069,7 @@ pub(crate) fn build_optimized_libs(
         runtime_bc,
         stdlib_bc,
         extra_bc,
+        prefer_well_known_before_stdlib: !well_known_libs.is_empty(),
         well_known_libs,
-        prefer_well_known_before_stdlib: false,
     }
 }


### PR DESCRIPTION
Follow-up to #5923 (merged) and issue #5928. Two more real bugs found and fixed while continuing to verify a real-world `sst/opencode` source compile end-to-end after #5923 landed.

## Fix 1 — match `codegen-units` across the "shared tokio" (#507) build group

`perry-stdlib-static`/`perry-runtime-static` override `codegen-units=16` (#5140, preserving `#[no_mangle]` extern "C" exports from thin-LTO internalization). The well-known ext crates (`perry-ext-fastify/http/ioredis/net/ws`) had no override and used the workspace default of 1.

Cargo builds them in the same invocation as `perry-stdlib-static` so their crate/feature graphs are unified, but that unification doesn't survive a `codegen-units` mismatch: rustc partitions a crate's monomorphized code into that many codegen units, so a shared dependency that both sides compile the "same" way (e.g. `compiler_builtins`) ends up split differently across the two settings and produces non-identical objects — which perry's strip-dedup mechanism can't safely treat as interchangeable duplicates (it currently keys off same-named codegen units and assumes identical content).

Confirmed via md5: `compiler_builtins`' codegen units are now byte-identical between `libperry_ext_http.a` and `libperry_stdlib.a` (231/231), versus divergent sizes before this fix (the shared `core` unit was 2.4 MB in the ext lib vs 551 KB in stdlib for the identically hash-named unit).

## Fix 2 — restore well-known lib dedup on cold auto-optimize builds

`build_optimized_libs()` has three return paths that construct the final `OptimizedLibs`. Two correctly set `prefer_well_known_before_stdlib` from whether any well-known libs are in play. The third — reached when the well-known native libs must be built completely from scratch (a cold/cleared auto-optimize cache, as opposed to the "archives are fresh" cache-hit fast path) — hardcoded it to `false`.

That flag gates whether `build_and_run.rs` runs `strip_bundled_runtime_from_well_known_lib` / `strip_bundled_shared_deps_from_well_known_lib` at link time (both #5920/#5921's original fix and #5923's fixed-point generalization). With it forced `false`, any program needing 2+ well-known libs together (e.g. opencode's `fastify`+`http`+`ioredis`+`net`+`ws`) silently and non-fatally skipped dedup entirely whenever the build couldn't reuse cached archives — confirmed by comparing duplicate-symbol counts with and without a stale auto-optimize directory present for the identical program (2152 vs 1382).

Verified this is a pre-existing, independent bug via `git log` — not introduced by #5892's recent auto-opt cache work or anything in #5923 — just never exercised because normal dev workflows usually keep the cache warm.

Fixed to match the other two branches: `prefer_well_known_before_stdlib` should depend only on whether there are well-known libs to dedup, not on which of the three build/cache paths produced them.

## What's still open

Even with both fixes, opencode's specific `http`+`fastify`+`ioredis`+`net`+`ws` combination still hits ~1382 duplicate-symbol errors — unchanged by these two commits, root-caused to a deeper architectural asymmetry (most of the colliding dependencies get folded into `perry-stdlib-static`'s own `linker-plugin-lto` merge, producing structurally different compiled output than the ext crates' plain compiles of the same dependencies — not fixable by aligning settings). Full analysis, including two further approaches tried and not kept (one ineffective, one caused a real regression), is on [#5928](https://github.com/PerryTS/perry/issues/5928#issuecomment-4881457806).

## Testing

- `cargo check --release -p perry --bin perry`: clean.
- `cargo build --release -p perry --bin perry`: clean, no errors.
- `cargo test --release -p perry --test issue_5920_wrapper_bundled_runtime_async_starvation`: passes (with `PERRY_LLVM_*` env vars set) — the critical safety regression test for any strip-dedup-adjacent change.
- Verified against a real opencode compile: duplicate-symbol count for `ioredis`/`net`/`ws` stays at 0; `http`+`fastify` pair confirmed unchanged at ~1382 (residual gap tracked on #5928, not claimed fixed here).
