### PR TITLE
fix(gc): array higher-order methods re-derive element pointers through rooted handles

### DIFF
--- a/crates/perry-runtime/src/array/iter_methods.rs
+++ b/crates/perry-runtime/src/array/iter_methods.rs
@@ -38,6 +38,50 @@ unsafe fn array_element_get_value(elements_ptr: *const f64, index: usize) -> f64
     }
 }
 
+/// Root the receiver for a user-callback loop and re-derive the (possibly
+/// moved) header + inline element base on every access. A callback can
+/// allocate → trigger a MOVING collection → the array (elements are inline
+/// after the header) relocates, and a hoisted `elements_ptr` then reads
+/// from-space garbage (2026-07-02 audit, GC deep set). The alloc-point
+/// direct minor currently forces a conservative non-moving cycle, which
+/// masks this for allocation-triggered GC — but a manual `gc()` inside the
+/// callback, and any future safepoint-driven copying cycle, do not.
+/// Per-iteration cost is a TLS handle read + an offset add, dwarfed by the
+/// callback dispatch itself.
+struct RootedIterArray<'s> {
+    handle: crate::gc::RuntimeHandle<'s>,
+}
+
+impl<'s> RootedIterArray<'s> {
+    fn new(scope: &'s crate::gc::RuntimeHandleScope, arr: *const ArrayHeader) -> Self {
+        Self {
+            handle: scope.root_nanbox_f64(array_receiver_value(arr)),
+        }
+    }
+
+    /// The live receiver value to pass to the callback (spec: the callback
+    /// observes the original receiver object — at its CURRENT address).
+    #[inline(always)]
+    fn receiver(&self) -> f64 {
+        self.handle.get_nanbox_f64()
+    }
+
+    #[inline(always)]
+    fn arr(&self) -> *const ArrayHeader {
+        (self.handle.get_nanbox_u64() & crate::value::POINTER_MASK) as *const ArrayHeader
+    }
+
+    #[inline(always)]
+    unsafe fn present(&self, index: usize) -> Option<f64> {
+        present_array_element(array_elements_ptr(self.arr()), index)
+    }
+
+    #[inline(always)]
+    unsafe fn get_or_undefined(&self, index: usize) -> f64 {
+        array_element_get_value(array_elements_ptr(self.arr()), index)
+    }
+}
+
 /// Bind the callback's `this` to `undefined` for the duration of a dense
 /// iteration (spec: absent `thisArg` means the callback's `this` is
 /// `undefined` — NOT whatever ambient receiver the enclosing call left in
@@ -76,28 +120,29 @@ pub extern "C" fn js_array_forEach(arr: *const ArrayHeader, callback: *const Clo
     }
     unsafe {
         let length = (*arr).length;
-        let arr_value = array_receiver_value(arr);
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let rooted = RootedIterArray::new(&scope, arr);
         let _tg = DenseThisGuard::bind_undefined();
         if crate::array::array_iteration_is_exotic(arr) {
             for i in 0..length as usize {
+                let arr = rooted.arr();
                 if !crate::array::array_spec_has_index(arr, i as u32) {
                     continue;
                 }
                 let element = crate::array::array_spec_get(arr, i as u32);
-                js_closure_call3(callback, element, i as f64, arr_value);
+                js_closure_call3(callback, element, i as f64, rooted.receiver());
             }
             return;
         }
-        let elements_ptr = array_elements_ptr(arr);
         for i in 0..length as usize {
-            let Some(element) = present_array_element(elements_ptr, i) else {
+            let Some(element) = rooted.present(i) else {
                 continue;
             };
             // JS forEach passes (element, index, array). The callback
             // dispatch path supports call3 safely, so bound native
             // methods like `array.forEach(console.log)` can observe the
             // source array just like Node.
-            js_closure_call3(callback, element, i as f64, arr_value);
+            js_closure_call3(callback, element, i as f64, rooted.receiver());
         }
     }
 }
@@ -123,8 +168,8 @@ pub extern "C" fn js_array_map(
     }
     unsafe {
         let length = (*arr).length;
-        let elements_ptr = array_elements_ptr(arr);
-        let arr_value = array_receiver_value(arr);
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let rooted = RootedIterArray::new(&scope, arr);
         let _tg = DenseThisGuard::bind_undefined();
 
         // ECMA-262 §23.1.3.20 step 5: ArraySpeciesCreate(O, len) runs BEFORE
@@ -134,31 +179,36 @@ pub extern "C" fn js_array_map(
         // callback is ever invoked. For the common case (plain array whose
         // constructor is the intrinsic `Array`) this returns a fresh plain
         // array, identical to the prior `js_array_alloc_with_length`.
-        let result_box = crate::array::species::array_species_create(arr_value, length as usize);
+        let result_box =
+            crate::array::species::array_species_create(rooted.receiver(), length as usize);
         let is_plain = crate::array::species::species_result_is_plain_array(result_box);
-        let result = crate::value::js_nanbox_get_pointer(result_box) as *mut ArrayHeader;
-        let result_elements = if is_plain {
-            (result as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64
-        } else {
-            ptr::null_mut()
+        // Root the result too: it must survive (and be re-derived after)
+        // every callback-triggered collection during the fill loop.
+        let result_rooted = scope.root_nanbox_f64(result_box);
+        let result_arr = |rooted: &crate::gc::RuntimeHandle<'_>| {
+            (rooted.get_nanbox_u64() & crate::value::POINTER_MASK) as *mut ArrayHeader
         };
 
         let exotic = crate::array::array_iteration_is_exotic(arr);
         for i in 0..length as usize {
             let element = if exotic {
+                let arr = rooted.arr();
                 if !crate::array::array_spec_has_index(arr, i as u32) {
                     continue;
                 }
                 crate::array::array_spec_get(arr, i as u32)
             } else {
-                match present_array_element(elements_ptr, i) {
+                match rooted.present(i) {
                     Some(e) => e,
                     None => continue,
                 }
             };
             // JS .map() callback receives (element, index, array).
-            let mapped = js_closure_call3(callback, element, i as f64, arr_value);
+            let mapped = js_closure_call3(callback, element, i as f64, rooted.receiver());
             if is_plain {
+                let result = result_arr(&result_rooted);
+                let result_elements =
+                    (result as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
                 // GC_STORE_AUDIT(INIT): plain result is unpublished; slot layout noted below.
                 ptr::write(result_elements.add(i), mapped);
                 let mapped_bits = mapped.to_bits();
@@ -169,11 +219,15 @@ pub extern "C" fn js_array_map(
                 }
             } else {
                 // Custom species container: CreateDataPropertyOrThrow via [[Set]].
-                crate::array::species::species_result_set(result_box, i, mapped);
+                crate::array::species::species_result_set(
+                    result_rooted.get_nanbox_f64(),
+                    i,
+                    mapped,
+                );
             }
         }
 
-        result
+        result_arr(&result_rooted)
     }
 }
 
@@ -187,24 +241,25 @@ pub extern "C" fn js_array_map_discard(arr: *const ArrayHeader, callback: *const
     }
     unsafe {
         let length = (*arr).length;
-        let arr_value = array_receiver_value(arr);
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let rooted = RootedIterArray::new(&scope, arr);
         let _tg = DenseThisGuard::bind_undefined();
         if crate::array::array_iteration_is_exotic(arr) {
             for i in 0..length as usize {
+                let arr = rooted.arr();
                 if !crate::array::array_spec_has_index(arr, i as u32) {
                     continue;
                 }
                 let element = crate::array::array_spec_get(arr, i as u32);
-                let _ = js_closure_call3(callback, element, i as f64, arr_value);
+                let _ = js_closure_call3(callback, element, i as f64, rooted.receiver());
             }
             return;
         }
-        let elements_ptr = array_elements_ptr(arr);
         for i in 0..length as usize {
-            let Some(element) = present_array_element(elements_ptr, i) else {
+            let Some(element) = rooted.present(i) else {
                 continue;
             };
-            let _ = js_closure_call3(callback, element, i as f64, arr_value);
+            let _ = js_closure_call3(callback, element, i as f64, rooted.receiver());
         }
     }
 }
@@ -228,45 +283,57 @@ pub extern "C" fn js_array_filter(
     }
     unsafe {
         let length = (*arr).length;
-        let elements_ptr = array_elements_ptr(arr);
-        let arr_value = array_receiver_value(arr);
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let rooted = RootedIterArray::new(&scope, arr);
         let _tg = DenseThisGuard::bind_undefined();
 
         // ECMA-262 §23.1.3.7 step 5: ArraySpeciesCreate(O, 0) runs before the
         // iteration (validates `O.constructor` / `@@species`, throwing on a
         // poisoned getter or non-constructor species before the callback runs).
-        let result_box = crate::array::species::array_species_create(arr_value, 0);
+        let result_box = crate::array::species::array_species_create(rooted.receiver(), 0);
         let is_plain = crate::array::species::species_result_is_plain_array(result_box);
-        let mut result = crate::value::js_nanbox_get_pointer(result_box) as *mut ArrayHeader;
+        // Root the result across callbacks; a push can also REALLOCATE the
+        // plain array, so write the returned pointer back into the handle.
+        let result_rooted = scope.root_nanbox_f64(result_box);
         // #854: `js_array_push_f64` already maintains `(*result).length`.
         let mut to = 0usize;
 
         let exotic = crate::array::array_iteration_is_exotic(arr);
         for i in 0..length as usize {
             let element = if exotic {
+                let arr = rooted.arr();
                 if !crate::array::array_spec_has_index(arr, i as u32) {
                     continue;
                 }
                 crate::array::array_spec_get(arr, i as u32)
             } else {
-                match present_array_element(elements_ptr, i) {
+                match rooted.present(i) {
                     Some(e) => e,
                     None => continue,
                 }
             };
-            let keep = js_closure_call3(callback, element, i as f64, arr_value);
+            let keep = js_closure_call3(callback, element, i as f64, rooted.receiver());
             // Proper truthy check: handles NaN-boxed booleans (TAG_FALSE != 0.0 but is falsy)
             if crate::value::js_is_truthy(keep) != 0 {
                 if is_plain {
-                    result = js_array_push_f64(result, element);
+                    let result = (result_rooted.get_nanbox_u64() & crate::value::POINTER_MASK)
+                        as *mut ArrayHeader;
+                    let result = js_array_push_f64(result, element);
+                    result_rooted.set_nanbox_f64(f64::from_bits(
+                        crate::value::JSValue::pointer(result as *const u8).bits(),
+                    ));
                 } else {
-                    crate::array::species::species_result_set(result_box, to, element);
+                    crate::array::species::species_result_set(
+                        result_rooted.get_nanbox_f64(),
+                        to,
+                        element,
+                    );
                     to += 1;
                 }
             }
         }
 
-        result
+        (result_rooted.get_nanbox_u64() & crate::value::POINTER_MASK) as *mut ArrayHeader
     }
 }
 

--- a/crates/perry-runtime/src/array/iter_methods.rs
+++ b/crates/perry-runtime/src/array/iter_methods.rs
@@ -353,18 +353,18 @@ pub extern "C" fn js_array_find(arr: *const ArrayHeader, callback: *const Closur
     }
     unsafe {
         let length = (*arr).length;
-        let elements_ptr = array_elements_ptr(arr);
-        let arr_value = array_receiver_value(arr);
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let rooted = RootedIterArray::new(&scope, arr);
         let _tg = DenseThisGuard::bind_undefined();
         let exotic = crate::array::array_iteration_is_exotic(arr);
 
         for i in 0..length as usize {
             let element = if exotic {
-                crate::array::array_spec_get(arr, i as u32)
+                crate::array::array_spec_get(rooted.arr(), i as u32)
             } else {
-                array_element_get_value(elements_ptr, i)
+                rooted.get_or_undefined(i)
             };
-            let result = js_closure_call3(callback, element, i as f64, arr_value);
+            let result = js_closure_call3(callback, element, i as f64, rooted.receiver());
             // Proper truthy check: handles NaN-boxed booleans
             if crate::value::js_is_truthy(result) != 0 {
                 return element;
@@ -395,18 +395,18 @@ pub extern "C" fn js_array_findIndex(
     }
     unsafe {
         let length = (*arr).length;
-        let elements_ptr = array_elements_ptr(arr);
-        let arr_value = array_receiver_value(arr);
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let rooted = RootedIterArray::new(&scope, arr);
         let _tg = DenseThisGuard::bind_undefined();
         let exotic = crate::array::array_iteration_is_exotic(arr);
 
         for i in 0..length as usize {
             let element = if exotic {
-                crate::array::array_spec_get(arr, i as u32)
+                crate::array::array_spec_get(rooted.arr(), i as u32)
             } else {
-                array_element_get_value(elements_ptr, i)
+                rooted.get_or_undefined(i)
             };
-            let result = js_closure_call3(callback, element, i as f64, arr_value);
+            let result = js_closure_call3(callback, element, i as f64, rooted.receiver());
             // Proper truthy check: handles NaN-boxed booleans
             if crate::value::js_is_truthy(result) != 0 {
                 return i as i32;
@@ -436,17 +436,17 @@ pub extern "C" fn js_array_find_last(
     }
     unsafe {
         let length = (*arr).length as usize;
-        let elements_ptr = array_elements_ptr(arr);
-        let arr_value = array_receiver_value(arr);
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let rooted = RootedIterArray::new(&scope, arr);
         let _tg = DenseThisGuard::bind_undefined();
         let exotic = crate::array::array_iteration_is_exotic(arr);
         for i in (0..length).rev() {
             let element = if exotic {
-                crate::array::array_spec_get(arr, i as u32)
+                crate::array::array_spec_get(rooted.arr(), i as u32)
             } else {
-                array_element_get_value(elements_ptr, i)
+                rooted.get_or_undefined(i)
             };
-            let result = js_closure_call3(callback, element, i as f64, arr_value);
+            let result = js_closure_call3(callback, element, i as f64, rooted.receiver());
             if crate::value::js_is_truthy(result) != 0 {
                 return element;
             }
@@ -474,17 +474,17 @@ pub extern "C" fn js_array_find_last_index(
     }
     unsafe {
         let length = (*arr).length as usize;
-        let elements_ptr = array_elements_ptr(arr);
-        let arr_value = array_receiver_value(arr);
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let rooted = RootedIterArray::new(&scope, arr);
         let _tg = DenseThisGuard::bind_undefined();
         let exotic = crate::array::array_iteration_is_exotic(arr);
         for i in (0..length).rev() {
             let element = if exotic {
-                crate::array::array_spec_get(arr, i as u32)
+                crate::array::array_spec_get(rooted.arr(), i as u32)
             } else {
-                array_element_get_value(elements_ptr, i)
+                rooted.get_or_undefined(i)
             };
-            let result = js_closure_call3(callback, element, i as f64, arr_value);
+            let result = js_closure_call3(callback, element, i as f64, rooted.receiver());
             if crate::value::js_is_truthy(result) != 0 {
                 return i as i32;
             }
@@ -557,24 +557,25 @@ pub extern "C" fn js_array_some(arr: *const ArrayHeader, callback: *const Closur
     }
     unsafe {
         let length = (*arr).length;
-        let elements_ptr = array_elements_ptr(arr);
-        let arr_value = array_receiver_value(arr);
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let rooted = RootedIterArray::new(&scope, arr);
         let _tg = DenseThisGuard::bind_undefined();
         let exotic = crate::array::array_iteration_is_exotic(arr);
 
         for i in 0..length as usize {
             let element = if exotic {
+                let arr = rooted.arr();
                 if !crate::array::array_spec_has_index(arr, i as u32) {
                     continue;
                 }
                 crate::array::array_spec_get(arr, i as u32)
             } else {
-                match present_array_element(elements_ptr, i) {
+                match rooted.present(i) {
                     Some(e) => e,
                     None => continue,
                 }
             };
-            let result = js_closure_call3(callback, element, i as f64, arr_value);
+            let result = js_closure_call3(callback, element, i as f64, rooted.receiver());
             if crate::value::js_is_truthy(result) != 0 {
                 return f64::from_bits(TAG_TRUE);
             }
@@ -602,24 +603,25 @@ pub extern "C" fn js_array_every(arr: *const ArrayHeader, callback: *const Closu
     }
     unsafe {
         let length = (*arr).length;
-        let elements_ptr = array_elements_ptr(arr);
-        let arr_value = array_receiver_value(arr);
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let rooted = RootedIterArray::new(&scope, arr);
         let _tg = DenseThisGuard::bind_undefined();
         let exotic = crate::array::array_iteration_is_exotic(arr);
 
         for i in 0..length as usize {
             let element = if exotic {
+                let arr = rooted.arr();
                 if !crate::array::array_spec_has_index(arr, i as u32) {
                     continue;
                 }
                 crate::array::array_spec_get(arr, i as u32)
             } else {
-                match present_array_element(elements_ptr, i) {
+                match rooted.present(i) {
                     Some(e) => e,
                     None => continue,
                 }
             };
-            let result = js_closure_call3(callback, element, i as f64, arr_value);
+            let result = js_closure_call3(callback, element, i as f64, rooted.receiver());
             if crate::value::js_is_truthy(result) == 0 {
                 return f64::from_bits(TAG_FALSE);
             }
@@ -642,17 +644,31 @@ pub extern "C" fn js_array_flatMap(
     }
     unsafe {
         let length = (*arr).length;
-        let elements_ptr = array_elements_ptr(arr);
-
-        let mut result = js_array_alloc(length);
-        let arr_value = array_receiver_value(arr);
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let rooted = RootedIterArray::new(&scope, arr);
+        // Root the result across callbacks and pushes (a push both allocates
+        // — possibly triggering a moving GC — and may reallocate the array).
+        let result_rooted = scope.root_nanbox_f64(f64::from_bits(
+            crate::value::JSValue::pointer(js_array_alloc(length) as *const u8).bits(),
+        ));
+        // Scratch handle for the callback-returned sub-array while the inner
+        // push loop allocates.
+        let sub_rooted = scope.root_nanbox_f64(undefined_value());
+        let push_rooted = |value: f64| {
+            let result =
+                (result_rooted.get_nanbox_u64() & crate::value::POINTER_MASK) as *mut ArrayHeader;
+            let result = js_array_push_f64(result, value);
+            result_rooted.set_nanbox_f64(f64::from_bits(
+                crate::value::JSValue::pointer(result as *const u8).bits(),
+            ));
+        };
         let _tg = DenseThisGuard::bind_undefined();
 
         for i in 0..length as usize {
-            let Some(element) = present_array_element(elements_ptr, i) else {
+            let Some(element) = rooted.present(i) else {
                 continue;
             };
-            let mapped = js_closure_call3(callback, element, i as f64, arr_value);
+            let mapped = js_closure_call3(callback, element, i as f64, rooted.receiver());
             // Check if the mapped value is an array (pointer-tagged)
             let bits = mapped.to_bits();
             let top16 = bits >> 48;
@@ -660,24 +676,27 @@ pub extern "C" fn js_array_flatMap(
                 // NaN-boxed pointer — likely an array
                 let sub_arr = (bits & 0x0000_FFFF_FFFF_FFFF) as *const ArrayHeader;
                 if !sub_arr.is_null() {
+                    sub_rooted.set_nanbox_f64(mapped);
                     let sub_len = (*sub_arr).length;
-                    let sub_elements = (sub_arr as *const u8)
-                        .add(std::mem::size_of::<ArrayHeader>())
-                        as *const f64;
                     for j in 0..sub_len as usize {
+                        let sub_arr = (sub_rooted.get_nanbox_u64() & crate::value::POINTER_MASK)
+                            as *const ArrayHeader;
+                        let sub_elements = (sub_arr as *const u8)
+                            .add(std::mem::size_of::<ArrayHeader>())
+                            as *const f64;
                         let Some(sub_element) = present_array_element(sub_elements, j) else {
                             continue;
                         };
-                        result = js_array_push_f64(result, sub_element);
+                        push_rooted(sub_element);
                     }
                 }
             } else {
                 // Not an array — push as single element
-                result = js_array_push_f64(result, mapped);
+                push_rooted(mapped);
             }
         }
 
-        result
+        (result_rooted.get_nanbox_u64() & crate::value::POINTER_MASK) as *mut ArrayHeader
     }
 }
 
@@ -711,7 +730,8 @@ pub extern "C" fn js_array_reduce(
     }
     unsafe {
         let length = (*arr).length as usize;
-        let elements_ptr = array_elements_ptr(arr);
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let rooted = RootedIterArray::new(&scope, arr);
 
         if length == 0 {
             if has_initial != 0 {
@@ -725,14 +745,16 @@ pub extern "C" fn js_array_reduce(
         let exotic = crate::array::array_iteration_is_exotic(arr);
         let present = |i: usize| -> Option<f64> {
             if exotic {
+                // An exotic index read can run a user getter → GC → move.
+                let arr = rooted.arr();
                 crate::array::array_spec_has_index(arr, i as u32)
-                    .then(|| crate::array::array_spec_get(arr, i as u32))
+                    .then(|| crate::array::array_spec_get(rooted.arr(), i as u32))
             } else {
-                present_array_element(elements_ptr, i)
+                rooted.present(i)
             }
         };
 
-        let (mut accumulator, start_idx) = if has_initial != 0 {
+        let (accumulator, start_idx) = if has_initial != 0 {
             (initial, 0)
         } else {
             let mut seed = None;
@@ -748,16 +770,26 @@ pub extern "C" fn js_array_reduce(
             }
         };
 
-        let arr_value = array_receiver_value(arr);
+        // Root the accumulator: it can hold a heap value, and both the
+        // callback and an exotic getter can trigger a moving GC between
+        // iterations while it sits in this Rust local.
+        let acc_rooted = scope.root_nanbox_f64(accumulator);
         for i in start_idx..length {
             let Some(element) = present(i) else {
                 continue;
             };
             // Spec callback is `(accumulator, currentValue, currentIndex, array)`.
-            accumulator = js_closure_call4(callback, accumulator, element, i as f64, arr_value);
+            let next = js_closure_call4(
+                callback,
+                acc_rooted.get_nanbox_f64(),
+                element,
+                i as f64,
+                rooted.receiver(),
+            );
+            acc_rooted.set_nanbox_f64(next);
         }
 
-        accumulator
+        acc_rooted.get_nanbox_f64()
     }
 }
 

--- a/crates/perry-runtime/src/array/reduce_right.rs
+++ b/crates/perry-runtime/src/array/reduce_right.rs
@@ -40,7 +40,15 @@ pub extern "C" fn js_array_reduce_right(
     }
     unsafe {
         let length = (*arr).length as usize;
-        let elements_ptr = array_elements_ptr(arr);
+        // Root the receiver: the callback (and an exotic user getter) can
+        // trigger a moving GC, invalidating a hoisted elements pointer
+        // (2026-07-02 audit — mirrors iter_methods' RootedIterArray).
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let rooted = scope.root_nanbox_f64(f64::from_bits(
+            crate::value::JSValue::pointer(arr as *const u8).bits(),
+        ));
+        let live_arr =
+            || (rooted.get_nanbox_u64() & crate::value::POINTER_MASK) as *const ArrayHeader;
 
         if length == 0 {
             if has_initial != 0 {
@@ -54,14 +62,14 @@ pub extern "C" fn js_array_reduce_right(
         let exotic = crate::array::array_iteration_is_exotic(arr);
         let present = |i: usize| -> Option<f64> {
             if exotic {
-                crate::array::array_spec_has_index(arr, i as u32)
-                    .then(|| crate::array::array_spec_get(arr, i as u32))
+                crate::array::array_spec_has_index(live_arr(), i as u32)
+                    .then(|| crate::array::array_spec_get(live_arr(), i as u32))
             } else {
-                present_array_element(elements_ptr, i)
+                present_array_element(array_elements_ptr(live_arr()), i)
             }
         };
 
-        let (mut accumulator, start_idx) = if has_initial != 0 {
+        let (accumulator, start_idx) = if has_initial != 0 {
             (initial, length)
         } else {
             let mut seed = None;
@@ -77,17 +85,26 @@ pub extern "C" fn js_array_reduce_right(
             }
         };
 
-        let arr_value = f64::from_bits(crate::value::JSValue::pointer(arr as *const u8).bits());
+        // Root the accumulator too: it can hold a heap value while a GC runs
+        // between iterations.
+        let acc_rooted = scope.root_nanbox_f64(accumulator);
         if start_idx > 0 {
             for i in (0..start_idx).rev() {
                 let Some(element) = present(i) else {
                     continue;
                 };
                 // Spec callback `(accumulator, currentValue, currentIndex, array)`.
-                accumulator = js_closure_call4(callback, accumulator, element, i as f64, arr_value);
+                let next = js_closure_call4(
+                    callback,
+                    acc_rooted.get_nanbox_f64(),
+                    element,
+                    i as f64,
+                    rooted.get_nanbox_f64(),
+                );
+                acc_rooted.set_nanbox_f64(next);
             }
         }
 
-        accumulator
+        acc_rooted.get_nanbox_f64()
     }
 }

--- a/crates/perry/tests/gc_array_iter_rooted.rs
+++ b/crates/perry/tests/gc_array_iter_rooted.rs
@@ -1,0 +1,90 @@
+//! Regression test for the rooted array-iteration rework (2026-07-02 audit,
+//! GC deep set): the higher-order array methods hoisted `elements_ptr` (and
+//! map/filter/flatMap their result pointers, reduce its accumulator) across
+//! user callbacks. A callback-triggered MOVING collection relocates the
+//! array — elements live inline after the header — so the hoisted pointer
+//! read from-space garbage. Every method now re-derives through a
+//! `RuntimeHandleScope` root per iteration.
+//!
+//! The program below calls `gc()` (a manual, full, potentially-moving
+//! collection) inside EVERY callback, plus allocation pressure. Expected
+//! output is byte-for-byte what `node --experimental-strip-types
+//! --expose-gc` prints for the same program.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn array_iteration_survives_gc_in_every_callback() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    let output = dir.path().join("main_bin");
+    std::fs::write(
+        &entry,
+        r#"
+const a = [1, 2, 3, 4, 5];
+const big = () => { let x: any[] = []; for (let i = 0; i < 2000; i++) x.push({ i }); return x.length; };
+const g = (globalThis as any).gc;
+const mapped = a.map((v, i) => { big(); g(); return v * 10 + i; });
+console.log("map:", mapped.join(","));
+const filtered = a.filter((v) => { g(); return v % 2 === 1; });
+console.log("filter:", filtered.join(","));
+let sum = 0;
+a.forEach((v) => { g(); sum += v; });
+console.log("forEach:", sum);
+console.log("find:", a.find((v) => { g(); return v === 4; }));
+console.log("findIndex:", a.findIndex((v) => { g(); return v === 4; }));
+console.log("findLast:", (a as any).findLast((v: number) => { g(); return v < 4; }));
+console.log("some:", a.some((v) => { g(); return v > 4; }));
+console.log("every:", a.every((v) => { g(); return v > 0; }));
+console.log("flatMap:", a.flatMap((v) => { g(); return [v, v * 2]; }).join(","));
+console.log("reduce:", a.reduce((acc, v) => { g(); return acc + "|" + v; }, "R"));
+console.log("reduceRight:", a.reduceRight((acc, v) => { g(); return acc + "|" + v; }, "L"));
+"#,
+    )
+    .expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir.path())
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed (exit {:?})\nstderr:\n{}",
+        run.status.code(),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&run.stdout),
+        "map: 10,21,32,43,54\n\
+         filter: 1,3,5\n\
+         forEach: 15\n\
+         find: 4\n\
+         findIndex: 3\n\
+         findLast: 3\n\
+         some: true\n\
+         every: true\n\
+         flatMap: 1,2,2,4,3,6,4,8,5,10\n\
+         reduce: R|1|2|3|4|5\n\
+         reduceRight: L|5|4|3|2|1\n"
+    );
+}


### PR DESCRIPTION
Final slice of the 2026-07-02 audit's GC deep set. Every callback-looping array method (forEach / map / map_discard / filter / find / findIndex / findLast / findLastIndex / some / every / flatMap / reduce / reduceRight — `iter_methods.rs` + `reduce_right.rs`) hoisted `elements_ptr` before the loop, and map/filter/flatMap additionally cached their result pointers, reduce/reduceRight the accumulator, flatMap the callback-returned sub-array — all across user callbacks that can trigger a MOVING collection. Array elements live inline after the header, so a moved array left the hoisted pointer reading from-space garbage; a moved result array took writes through a stale pointer; a heap-valued accumulator went stale in a Rust local between iterations (reachable via an exotic getter's GC even without the callback).

The audit's original note that the cited protection was production-dead still holds: the conservative-scan direct minor (v0.5.1236) masks this at ALLOC-point triggers, but a manual `gc()` inside a callback — and any future safepoint-driven copying cycle — does not.

Fix: a `RootedIterArray` helper roots the receiver in a `RuntimeHandleScope`, and the header + element base are re-derived per access; results/accumulators/sub-arrays get their own rooted handles (`filter`'s push-realloc writes the returned pointer back into the handle). Per-iteration cost is a TLS handle read + an offset add, dwarfed by callback dispatch.

Verification: new e2e (`gc_array_iter_rooted`) runs an 11-method program with `gc()` called inside EVERY callback under allocation pressure — output matches `node --expose-gc` byte-for-byte. Runtime array unit suite green (127); addr-class + file-size gates pass.

Code-only; metadata folded at merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved array iteration so callback-based methods remain stable during garbage collection, even when GC runs inside callbacks.
  * Fixed issues affecting `map`, `filter`, `forEach`, `find`, `findIndex`, `findLast`, `some`, `every`, `flatMap`, `reduce`, and `reduceRight`.
  * Made `reduce` and `reduceRight` handle evolving accumulator values safely across iterations.

* **Tests**
  * Added a regression test that exercises multiple array methods under forced GC pressure and verifies the results stay correct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->