### PR TITLE
fix(compile): #5984 — computed-key static fields leak synthetic name into cross-module externs

### DIFF
--- a/crates/perry/src/commands/compile/run_pipeline.rs
+++ b/crates/perry/src/commands/compile/run_pipeline.rs
@@ -2437,6 +2437,7 @@ pub fn run_with_parse_cache(
                                         static_field_names: class
                                             .static_fields
                                             .iter()
+                                            .filter(|f| f.key_expr.is_none())
                                             .map(|f| f.name.clone())
                                             .collect(),
                                         getter_names: class
@@ -2745,6 +2746,7 @@ pub fn run_with_parse_cache(
                                             static_field_names: class
                                                 .static_fields
                                                 .iter()
+                                                .filter(|f| f.key_expr.is_none())
                                                 .map(|f| f.name.clone())
                                                 .collect(),
                                             getter_names: class
@@ -3019,6 +3021,7 @@ pub fn run_with_parse_cache(
                                 static_field_names: class
                                     .static_fields
                                     .iter()
+                                    .filter(|f| f.key_expr.is_none())
                                     .map(|f| f.name.clone())
                                     .collect(),
                                 getter_names: class
@@ -3086,6 +3089,7 @@ pub fn run_with_parse_cache(
                             static_field_names: class
                                 .static_fields
                                 .iter()
+                                .filter(|f| f.key_expr.is_none())
                                 .map(|f| f.name.clone())
                                 .collect(),
                             getter_names: class.getters.iter().map(|(n, _)| n.clone()).collect(),
@@ -3244,6 +3248,7 @@ pub fn run_with_parse_cache(
                             static_field_names: class
                                 .static_fields
                                 .iter()
+                                .filter(|f| f.key_expr.is_none())
                                 .map(|f| f.name.clone())
                                 .collect(),
                             getter_names: class.getters.iter().map(|(n, _)| n.clone()).collect(),
@@ -3717,6 +3722,7 @@ pub fn run_with_parse_cache(
                             static_field_names: class
                                 .static_fields
                                 .iter()
+                                .filter(|f| f.key_expr.is_none())
                                 .map(|f| f.name.clone())
                                 .collect(),
                             getter_names: class.getters.iter().map(|(n, _)| n.clone()).collect(),
@@ -3916,6 +3922,7 @@ pub fn run_with_parse_cache(
                             static_field_names: class
                                 .static_fields
                                 .iter()
+                                .filter(|f| f.key_expr.is_none())
                                 .map(|f| f.name.clone())
                                 .collect(),
                             getter_names: class.getters.iter().map(|(n, _)| n.clone()).collect(),

--- a/test-files/fixtures/issue_5984_pkg/base.ts
+++ b/test-files/fixtures/issue_5984_pkg/base.ts
@@ -1,0 +1,8 @@
+import { entityKind } from "./entity.ts";
+
+export abstract class BaseSession {
+  static readonly [entityKind]: string = "BaseSession";
+  tag(): string {
+    return "base";
+  }
+}

--- a/test-files/fixtures/issue_5984_pkg/entity.ts
+++ b/test-files/fixtures/issue_5984_pkg/entity.ts
@@ -1,0 +1,1 @@
+export const entityKind: unique symbol = Symbol.for("entityKind");

--- a/test-files/test_issue_5984_computed_static_field_cross_module.ts
+++ b/test-files/test_issue_5984_computed_static_field_cross_module.ts
@@ -1,0 +1,13 @@
+import { entityKind } from "./fixtures/issue_5984_pkg/entity.ts";
+import { BaseSession } from "./fixtures/issue_5984_pkg/base.ts";
+
+class EffectSession extends BaseSession {
+  static override readonly [entityKind]: string = "EffectSession";
+  tag(): string {
+    return "effect";
+  }
+}
+
+console.log((BaseSession as any)[entityKind]);
+console.log((EffectSession as any)[entityKind]);
+console.log(new EffectSession().tag());


### PR DESCRIPTION
Closes #5984. Found via continued real-world `sst/opencode` source-compile verification, after #5918/#5922/#5924/#5927/#5928 (PR #5923, merged) and #5928's follow-up fixes (PR #5980) cleared every prior wall — this is a genuinely new, previously-unreached bug that only surfaces once a program needs both the class with the computed field *and* imports it from a different module than where it's defined.

## Bug

A computed-key static field (`static [Symbol.for(...)] = init`) gets a synthetic HIR name `__computed_field_<span.lo>_<span.hi>` (`perry-hir/src/lower_decl/class_members.rs`). `module_globals_emit.rs`'s emission loop correctly skips creating a backing `perry_static_<mod>__<class>__<field>` global for these — computed fields are stored via a runtime side table instead (see the existing comment referencing #420/#894) — so the defining module never emits that symbol.

But the cross-module class-export metadata built in `run_pipeline.rs` (`ImportedClass.static_field_names`, populated at 7 call sites) collected **every** static field's `.name`, including the computed ones' synthetic placeholder, with no filter. An importing module took that list at face value and declared an `external global` reference for the synthetic name — which the source module never defines, producing an undefined-symbol link error.

This is invisible for a same-module class (no cross-module declaration needed) or an unimported one, which is presumably why drizzle-orm's pervasive `static readonly [entityKind]: string = "ClassName"` tagging pattern (used on dozens of classes) never surfaced this before — it takes a subclass or consumer of the class in a *different* file that also needs the class's other, non-computed statics to pull the whole `ImportedClass` metadata across the module boundary.

## Fix

Filter out computed-key fields (`f.key_expr.is_none()`) before collecting `static_field_names`, matching the filter `module_globals_emit.rs` already applies on the defining side. Same one-line change at all 7 call sites.

## Testing

- New regression fixture (`test_issue_5984_computed_static_field_cross_module.ts`): base class with a computed-key static field in one module, subclass overriding it in another that also uses the class's instance method — reproduces the undefined-symbol error pre-fix, links and runs correctly post-fix, output verified byte-for-byte against Node.
- Full existing namespace/effect regression suite (16 fixtures) — unaffected, all still MATCH.
- `cargo test --release -p perry --bin perry`: 669/670 passed (one known flaky, resource-contention-only test — `install::lifecycle::run_lifecycle_executes_script` — confirmed unrelated and passing in isolation).
- `cargo test --release -p perry-codegen --lib`: 152/152 passed.
- `cargo test --release -p perry --test issue_5920_wrapper_bundled_runtime_async_starvation`: passes (with `PERRY_LLVM_*` env vars set).
- Verified against the real opencode compile: this exact class of "undefined symbol referencing a computed-field synthetic name" (10+ distinct classes across `effect-drizzle-sqlite` and `drizzle-orm` itself, including `SQLiteEffectSession`, `SQLiteEffectPreparedQuery`, `SQLiteEffectTransaction`, drizzle's `Relation`/`Relations`/`Cache`/alias-proxy classes, and more) is completely gone after this fix — the compile proceeds past this wall entirely to a different, unrelated undefined symbol (tracked separately, not part of this fix's scope).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of computed static properties on imported and re-exported classes, including cases with inheritance and unresolved type references.
  * Static field lists now exclude keyed entries where appropriate, helping preserve accurate class metadata.

* **Tests**
  * Added coverage for cross-module inheritance with computed static fields to verify expected runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->