### PR TITLE
fix(runtime,transform): #5941 — eliminate the async-step deadlock class (shared-promise adoption severing + swallowed step-resume rejections + id-scan param-default gap)

### DIFF
--- a/crates/perry-runtime/src/promise/async_step.rs
+++ b/crates/perry-runtime/src/promise/async_step.rs
@@ -618,7 +618,49 @@ extern "C" fn async_step_fulfill_thunk(
     });
     let result = crate::closure::js_closure_call2(step, value, false_bits);
     INLINE_TRAP.with(|c| c.set(prev));
+    forward_swallowed_rejection(result, captured_trap_next);
     result
+}
+
+/// #5941: a thunk-resumed step that exits through its internal catch arm
+/// (a `throw` after the await, or an awaited rejection with no matching
+/// catch route) returns a FRESH rejected promise
+/// (`return Promise.reject(e)` in the step body's catch) — historically
+/// DISCARDED by the thunks, so the machine's real result promise (the
+/// captured per-activation `trap_next`, #5485) stayed Pending and every
+/// awaiter of the async fn hung instead of observing the throw. On the
+/// first_call path the wrapper returns the rejected promise to the caller
+/// directly, so only the resumed path leaked. Forward the rejection into
+/// the activation's result. The normal resume paths return `trap_next`
+/// itself (chain/done reuse) and are skipped by the identity check;
+/// `js_async_step_done`'s non-reuse arm returning a user
+/// `return <rejected promise>` also lands here, which matches spec (the
+/// async fn's result rejects with the inner reason).
+fn forward_swallowed_rejection(result: f64, trap_next: *mut Promise) {
+    if trap_next.is_null() {
+        return;
+    }
+    let bits = result.to_bits();
+    if bits & 0xFFFF_0000_0000_0000 != 0x7FFD_0000_0000_0000 {
+        return;
+    }
+    if js_value_is_promise(result) == 0 {
+        return;
+    }
+    let ret = (bits & 0x0000_FFFF_FFFF_FFFF) as *mut Promise;
+    if ret.is_null() || ret == trap_next {
+        return;
+    }
+    unsafe {
+        if (*ret).state != PromiseState::Rejected || (*trap_next).state != PromiseState::Pending {
+            return;
+        }
+        let reason = (*ret).reason;
+        // The rejection is consumed by forwarding it into the result —
+        // the discarded wrapper must not be reported as unhandled.
+        crate::promise::mark_rejection_handled(ret);
+        js_promise_reject(trap_next, reason);
+    }
 }
 
 extern "C" fn async_step_reject_thunk(
@@ -643,6 +685,7 @@ extern "C" fn async_step_reject_thunk(
     });
     let result = crate::closure::js_closure_call2(step, value, true_bits);
     INLINE_TRAP.with(|c| c.set(prev));
+    forward_swallowed_rejection(result, captured_trap_next);
     result
 }
 

--- a/crates/perry-runtime/src/promise/then.rs
+++ b/crates/perry-runtime/src/promise/then.rs
@@ -699,15 +699,25 @@ pub extern "C" fn js_promise_resolve_with_promise(outer: *mut Promise, inner: *m
                     ptr::null_mut(),
                     capture_context(),
                 );
-                // Keep the original next-nulling: the forwarder handles adoption,
-                // and leaving a stale `inner.next` chained to `outer` can form a
-                // resolution cycle ("Chaining cycle detected"). The awaiter's
-                // reaction lives in on_fulfilled (untouched above), not in `next`.
-                store_promise_next_slot(
-                    inner,
-                    std::ptr::addr_of_mut!((*inner).next),
-                    ptr::null_mut(),
-                );
+                // #5941: null `inner.next` ONLY when it already points at
+                // `outer` — the re-adoption case where leaving it would have
+                // the runner's settle propagation resolve `outer` on top of
+                // the forwarder ("Chaining cycle detected"). Any OTHER
+                // promise in `inner.next` is an EARLIER dependent's chain —
+                // a prior adoption's fast-path edge (the `store_promise_next_slot`
+                // above) or a `.then` child — and the old unconditional null
+                // severed it: with two dependents adopting one shared inner
+                // promise (Next.js RSC render, shared React work promises),
+                // the second adoption orphaned the first dependent, its
+                // async-step machine's result never settled, and the render
+                // parked forever (the #5437/#5941 dynamic-route deadlock).
+                if outer == (*inner).next {
+                    store_promise_next_slot(
+                        inner,
+                        std::ptr::addr_of_mut!((*inner).next),
+                        ptr::null_mut(),
+                    );
+                }
             }
         }
     }

--- a/crates/perry-transform/src/generator/id_scan.rs
+++ b/crates/perry-transform/src/generator/id_scan.rs
@@ -2,13 +2,61 @@
 
 use super::*;
 
+/// #5941: fold a parameter LIST's ids into the max — not just `param.id`.
+/// A parameter's DEFAULT VALUE is a full expression
+/// (`function f(cb = (x) => heavy(x)) {}`) that can hold closures whose
+/// LocalIds/FuncIds live in this same module-wide namespace. The expr
+/// walker only reaches defaults of NESTED `Expr::Closure` params; the
+/// hand-rolled per-container loops below never scanned the OUTER
+/// function/method/ctor/getter/setter param defaults, so the async/
+/// generator transform could mint a state/done/sent LocalId (or a step
+/// FuncId) colliding with one inside a default-value closure — the
+/// #1029/#5143 PreallocateBoxes corruption class (a collided boxed id
+/// silently shares one box between two variables; at Next.js bundle
+/// scale the async-step state var stops advancing and the render
+/// deadlocks). Legacy decorator factory args (`@dec(x => x)`) and the
+/// hidden arguments-object binding carry ids the same way. A too-high
+/// max is always safe; a missed id collides.
+fn scan_params_for_max_local(params: &[Param], max_id: &mut LocalId) {
+    for param in params {
+        *max_id = (*max_id).max(param.id);
+        if let Some(default) = &param.default {
+            scan_expr_for_max_local(default, max_id);
+        }
+        for dec in &param.decorators {
+            for arg in &dec.args {
+                scan_expr_for_max_local(arg, max_id);
+            }
+        }
+        if let Some(meta) = &param.arguments_object {
+            for (_, local) in &meta.mapped_parameter_ids {
+                *max_id = (*max_id).max(*local);
+            }
+        }
+    }
+}
+
+/// FuncId companion to [`scan_params_for_max_local`]: default-value and
+/// decorator-arg expressions can hold closures whose FuncIds must be
+/// visible to `compute_max_func_id` (params themselves carry no FuncId).
+fn scan_params_for_max_func(params: &[Param], max_id: &mut FuncId) {
+    for param in params {
+        if let Some(default) = &param.default {
+            scan_expr_for_max_func(default, max_id);
+        }
+        for dec in &param.decorators {
+            for arg in &dec.args {
+                scan_expr_for_max_func(arg, max_id);
+            }
+        }
+    }
+}
+
 /// Find the maximum local ID used in the module.
 pub fn compute_max_local_id(module: &Module) -> LocalId {
     let mut max_id: LocalId = 0;
     for func in &module.functions {
-        for param in &func.params {
-            max_id = max_id.max(param.id);
-        }
+        scan_params_for_max_local(&func.params, &mut max_id);
         scan_stmts_for_max_local(&func.body, &mut max_id);
     }
     for stmt in &module.init {
@@ -32,40 +80,28 @@ pub fn compute_max_local_id(module: &Module) -> LocalId {
     // class-method codegen.
     for class in &module.classes {
         for method in &class.methods {
-            for param in &method.params {
-                max_id = max_id.max(param.id);
-            }
+            scan_params_for_max_local(&method.params, &mut max_id);
             scan_stmts_for_max_local(&method.body, &mut max_id);
         }
         for static_method in &class.static_methods {
-            for param in &static_method.params {
-                max_id = max_id.max(param.id);
-            }
+            scan_params_for_max_local(&static_method.params, &mut max_id);
             scan_stmts_for_max_local(&static_method.body, &mut max_id);
         }
         for member in &class.computed_members {
             scan_expr_for_max_local(&member.key_expr, &mut max_id);
-            for param in &member.function.params {
-                max_id = max_id.max(param.id);
-            }
+            scan_params_for_max_local(&member.function.params, &mut max_id);
             scan_stmts_for_max_local(&member.function.body, &mut max_id);
         }
         if let Some(ctor) = &class.constructor {
-            for param in &ctor.params {
-                max_id = max_id.max(param.id);
-            }
+            scan_params_for_max_local(&ctor.params, &mut max_id);
             scan_stmts_for_max_local(&ctor.body, &mut max_id);
         }
         for getter in &class.getters {
-            for param in &getter.1.params {
-                max_id = max_id.max(param.id);
-            }
+            scan_params_for_max_local(&getter.1.params, &mut max_id);
             scan_stmts_for_max_local(&getter.1.body, &mut max_id);
         }
         for setter in &class.setters {
-            for param in &setter.1.params {
-                max_id = max_id.max(param.id);
-            }
+            scan_params_for_max_local(&setter.1.params, &mut max_id);
             scan_stmts_for_max_local(&setter.1.body, &mut max_id);
         }
         // Issue #5143 (LocalId parallel): class FIELD initializers and
@@ -267,6 +303,7 @@ pub fn compute_max_func_id(module: &Module) -> FuncId {
     let mut max_id: FuncId = 0;
     for func in &module.functions {
         max_id = max_id.max(func.id);
+        scan_params_for_max_func(&func.params, &mut max_id);
         scan_stmts_for_max_func(&func.body, &mut max_id);
     }
     for stmt in &module.init {
@@ -300,6 +337,7 @@ pub fn compute_max_func_id(module: &Module) -> FuncId {
             .chain(class.getters.iter().map(|(_, f)| f))
             .chain(class.setters.iter().map(|(_, f)| f))
         {
+            scan_params_for_max_func(&m.params, &mut max_id);
             scan_stmts_for_max_func(&m.body, &mut max_id);
         }
         for member in &class.computed_members {
@@ -636,6 +674,134 @@ mod tests {
             compute_max_local_id(&module),
             91,
             "field-initializer closure param LocalId must be counted"
+        );
+    }
+
+    /// #5941: a DEFAULT-VALUE closure on a top-level function's parameter
+    /// (`function f(cb = (x) => x) {}`) carries LocalIds/FuncIds reachable
+    /// only through `Param.default` — the per-container loops read only
+    /// `param.id`, and the expr walker never sees the outer function's own
+    /// param list. Before the fix the async/generator transform could mint
+    /// a state/done/sent LocalId or step FuncId colliding with ids inside
+    /// the default closure (the Next.js async-step per-activation-identity
+    /// deadlock class).
+    #[test]
+    fn default_param_closure_ids_visible_to_max_scans() {
+        let default_closure = Expr::Closure {
+            func_id: 42,
+            params: vec![Param {
+                id: 77,
+                name: "x".to_string(),
+                ty: Type::Any,
+                default: None,
+                decorators: Vec::new(),
+                is_rest: false,
+                arguments_object: None,
+            }],
+            return_type: Type::Any,
+            body: vec![Stmt::Return(Some(Expr::LocalGet(77)))],
+            captures: Vec::new(),
+            mutable_captures: Vec::new(),
+            captures_this: false,
+            captures_new_target: false,
+            enclosing_class: None,
+            is_arrow: true,
+            is_async: false,
+            is_generator: false,
+            is_strict: false,
+        };
+        let mut module = Module::new("test");
+        module.functions.push(Function {
+            id: 1,
+            name: "f".to_string(),
+            type_params: Vec::new(),
+            params: vec![Param {
+                id: 2,
+                name: "cb".to_string(),
+                ty: Type::Any,
+                default: Some(default_closure),
+                decorators: Vec::new(),
+                is_rest: false,
+                arguments_object: None,
+            }],
+            return_type: Type::Any,
+            body: Vec::new(),
+            is_strict: false,
+            is_async: false,
+            is_generator: false,
+            is_exported: false,
+            captures: Vec::new(),
+            decorators: Vec::new(),
+            was_plain_async: false,
+            was_unrolled: false,
+        });
+        assert_eq!(
+            compute_max_local_id(&module),
+            77,
+            "default-value closure param LocalId must be counted"
+        );
+        assert_eq!(
+            compute_max_func_id(&module),
+            42,
+            "default-value closure FuncId must be counted"
+        );
+    }
+
+    /// Companion: the same gap on a CLASS METHOD's parameter default
+    /// (methods/ctor/getters/setters share the hand-rolled param loops).
+    #[test]
+    fn method_default_param_closure_ids_visible_to_max_scans() {
+        let default_closure = Expr::Closure {
+            func_id: 60,
+            params: Vec::new(),
+            return_type: Type::Any,
+            body: vec![Stmt::Return(Some(Expr::LocalGet(88)))],
+            captures: Vec::new(),
+            mutable_captures: Vec::new(),
+            captures_this: false,
+            captures_new_target: false,
+            enclosing_class: None,
+            is_arrow: true,
+            is_async: false,
+            is_generator: false,
+            is_strict: false,
+        };
+        let mut class = class_with_fields("C", Vec::new());
+        class.methods.push(Function {
+            id: 2,
+            name: "m".to_string(),
+            type_params: Vec::new(),
+            params: vec![Param {
+                id: 3,
+                name: "cb".to_string(),
+                ty: Type::Any,
+                default: Some(default_closure),
+                decorators: Vec::new(),
+                is_rest: false,
+                arguments_object: None,
+            }],
+            return_type: Type::Any,
+            body: Vec::new(),
+            is_strict: false,
+            is_async: false,
+            is_generator: false,
+            is_exported: false,
+            captures: Vec::new(),
+            decorators: Vec::new(),
+            was_plain_async: false,
+            was_unrolled: false,
+        });
+        let mut module = Module::new("test");
+        module.classes.push(class);
+        assert_eq!(
+            compute_max_local_id(&module),
+            88,
+            "method default-closure body LocalId must be counted"
+        );
+        assert_eq!(
+            compute_max_func_id(&module),
+            60,
+            "method default-closure FuncId must be counted"
         );
     }
 }

--- a/crates/perry-transform/src/generator/id_scan.rs
+++ b/crates/perry-transform/src/generator/id_scan.rs
@@ -23,11 +23,7 @@ fn scan_params_for_max_local(params: &[Param], max_id: &mut LocalId) {
         if let Some(default) = &param.default {
             scan_expr_for_max_local(default, max_id);
         }
-        for dec in &param.decorators {
-            for arg in &dec.args {
-                scan_expr_for_max_local(arg, max_id);
-            }
-        }
+        scan_decorators_for_max_local(&param.decorators, max_id);
         if let Some(meta) = &param.arguments_object {
             for (_, local) in &meta.mapped_parameter_ids {
                 *max_id = (*max_id).max(*local);
@@ -44,19 +40,48 @@ fn scan_params_for_max_func(params: &[Param], max_id: &mut FuncId) {
         if let Some(default) = &param.default {
             scan_expr_for_max_func(default, max_id);
         }
-        for dec in &param.decorators {
-            for arg in &dec.args {
-                scan_expr_for_max_func(arg, max_id);
-            }
+        scan_decorators_for_max_func(&param.decorators, max_id);
+    }
+}
+
+/// Decorator factory args (`@dec(x => x)`) are full expressions that can
+/// hold closures — their LocalIds/FuncIds live in the same module-wide
+/// namespace as everything else. Used for param-, function/method-,
+/// class-, and field-level decorators.
+fn scan_decorators_for_max_local(decorators: &[Decorator], max_id: &mut LocalId) {
+    for dec in decorators {
+        for arg in &dec.args {
+            scan_expr_for_max_local(arg, max_id);
         }
     }
+}
+
+fn scan_decorators_for_max_func(decorators: &[Decorator], max_id: &mut FuncId) {
+    for dec in decorators {
+        for arg in &dec.args {
+            scan_expr_for_max_func(arg, max_id);
+        }
+    }
+}
+
+/// Fold a Function-shaped container's non-body id carriers (params +
+/// function-level decorator args) into the LocalId max.
+fn scan_function_shell_for_max_local(func: &Function, max_id: &mut LocalId) {
+    scan_params_for_max_local(&func.params, max_id);
+    scan_decorators_for_max_local(&func.decorators, max_id);
+}
+
+/// FuncId companion to [`scan_function_shell_for_max_local`].
+fn scan_function_shell_for_max_func(func: &Function, max_id: &mut FuncId) {
+    scan_params_for_max_func(&func.params, max_id);
+    scan_decorators_for_max_func(&func.decorators, max_id);
 }
 
 /// Find the maximum local ID used in the module.
 pub fn compute_max_local_id(module: &Module) -> LocalId {
     let mut max_id: LocalId = 0;
     for func in &module.functions {
-        scan_params_for_max_local(&func.params, &mut max_id);
+        scan_function_shell_for_max_local(func, &mut max_id);
         scan_stmts_for_max_local(&func.body, &mut max_id);
     }
     for stmt in &module.init {
@@ -80,28 +105,28 @@ pub fn compute_max_local_id(module: &Module) -> LocalId {
     // class-method codegen.
     for class in &module.classes {
         for method in &class.methods {
-            scan_params_for_max_local(&method.params, &mut max_id);
+            scan_function_shell_for_max_local(method, &mut max_id);
             scan_stmts_for_max_local(&method.body, &mut max_id);
         }
         for static_method in &class.static_methods {
-            scan_params_for_max_local(&static_method.params, &mut max_id);
+            scan_function_shell_for_max_local(static_method, &mut max_id);
             scan_stmts_for_max_local(&static_method.body, &mut max_id);
         }
         for member in &class.computed_members {
             scan_expr_for_max_local(&member.key_expr, &mut max_id);
-            scan_params_for_max_local(&member.function.params, &mut max_id);
+            scan_function_shell_for_max_local(&member.function, &mut max_id);
             scan_stmts_for_max_local(&member.function.body, &mut max_id);
         }
         if let Some(ctor) = &class.constructor {
-            scan_params_for_max_local(&ctor.params, &mut max_id);
+            scan_function_shell_for_max_local(ctor, &mut max_id);
             scan_stmts_for_max_local(&ctor.body, &mut max_id);
         }
         for getter in &class.getters {
-            scan_params_for_max_local(&getter.1.params, &mut max_id);
+            scan_function_shell_for_max_local(&getter.1, &mut max_id);
             scan_stmts_for_max_local(&getter.1.body, &mut max_id);
         }
         for setter in &class.setters {
-            scan_params_for_max_local(&setter.1.params, &mut max_id);
+            scan_function_shell_for_max_local(&setter.1, &mut max_id);
             scan_stmts_for_max_local(&setter.1.body, &mut max_id);
         }
         // Issue #5143 (LocalId parallel): class FIELD initializers and
@@ -121,7 +146,11 @@ pub fn compute_max_local_id(module: &Module) -> LocalId {
             if let Some(key_expr) = &field.key_expr {
                 scan_expr_for_max_local(key_expr, &mut max_id);
             }
+            scan_decorators_for_max_local(&field.decorators, &mut max_id);
         }
+        // Class-level decorator factory args (`@dec(x => x) class C {}`)
+        // carry ids the same way the member-level ones do.
+        scan_decorators_for_max_local(&class.decorators, &mut max_id);
         if let Some(extends_expr) = &class.extends_expr {
             scan_expr_for_max_local(extends_expr, &mut max_id);
         }
@@ -303,7 +332,7 @@ pub fn compute_max_func_id(module: &Module) -> FuncId {
     let mut max_id: FuncId = 0;
     for func in &module.functions {
         max_id = max_id.max(func.id);
-        scan_params_for_max_func(&func.params, &mut max_id);
+        scan_function_shell_for_max_func(func, &mut max_id);
         scan_stmts_for_max_func(&func.body, &mut max_id);
     }
     for stmt in &module.init {
@@ -337,7 +366,7 @@ pub fn compute_max_func_id(module: &Module) -> FuncId {
             .chain(class.getters.iter().map(|(_, f)| f))
             .chain(class.setters.iter().map(|(_, f)| f))
         {
-            scan_params_for_max_func(&m.params, &mut max_id);
+            scan_function_shell_for_max_func(m, &mut max_id);
             scan_stmts_for_max_func(&m.body, &mut max_id);
         }
         for member in &class.computed_members {
@@ -358,7 +387,10 @@ pub fn compute_max_func_id(module: &Module) -> FuncId {
             if let Some(key_expr) = &field.key_expr {
                 scan_expr_for_max_func(key_expr, &mut max_id);
             }
+            scan_decorators_for_max_func(&field.decorators, &mut max_id);
         }
+        // Class-level decorator factory args carry FuncIds the same way.
+        scan_decorators_for_max_func(&class.decorators, &mut max_id);
         if let Some(extends_expr) = &class.extends_expr {
             scan_expr_for_max_func(extends_expr, &mut max_id);
         }
@@ -802,6 +834,63 @@ mod tests {
             compute_max_func_id(&module),
             60,
             "method default-closure FuncId must be counted"
+        );
+    }
+
+    /// CodeRabbit follow-up on the #5941 scan fix: FUNCTION-level and
+    /// CLASS-level decorator factory args (`@dec(x => x)`) carry closures
+    /// whose ids must be visible too — not just Param.decorators.
+    #[test]
+    fn function_and_class_decorator_arg_closure_ids_visible_to_max_scans() {
+        let dec_with_closure = |func_id: FuncId, local_id: LocalId| Decorator {
+            name: "dec".to_string(),
+            args: vec![Expr::Closure {
+                func_id,
+                params: Vec::new(),
+                return_type: Type::Any,
+                body: vec![Stmt::Return(Some(Expr::LocalGet(local_id)))],
+                captures: Vec::new(),
+                mutable_captures: Vec::new(),
+                captures_this: false,
+                captures_new_target: false,
+                enclosing_class: None,
+                is_arrow: true,
+                is_async: false,
+                is_generator: false,
+                is_strict: false,
+            }],
+            is_factory: true,
+            is_reflect_metadata: false,
+        };
+        let mut module = Module::new("test");
+        module.functions.push(Function {
+            id: 1,
+            name: "f".to_string(),
+            type_params: Vec::new(),
+            params: Vec::new(),
+            return_type: Type::Any,
+            body: Vec::new(),
+            is_strict: false,
+            is_async: false,
+            is_generator: false,
+            is_exported: false,
+            captures: Vec::new(),
+            decorators: vec![dec_with_closure(55, 95)],
+            was_plain_async: false,
+            was_unrolled: false,
+        });
+        let mut class = class_with_fields("C", Vec::new());
+        class.decorators.push(dec_with_closure(56, 96));
+        module.classes.push(class);
+        assert_eq!(
+            compute_max_local_id(&module),
+            96,
+            "function/class decorator-arg closure LocalIds must be counted"
+        );
+        assert_eq!(
+            compute_max_func_id(&module),
+            56,
+            "function/class decorator-arg closure FuncIds must be counted"
         );
     }
 }

--- a/crates/perry/tests/issue_5941_shared_promise_adoption.rs
+++ b/crates/perry/tests/issue_5941_shared_promise_adoption.rs
@@ -1,0 +1,122 @@
+//! Regression (#5941): the Next.js dynamic-RSC render deadlock's two runtime
+//! roots, each with a minimal repro.
+//!
+//! 1. Shared-promise adoption severing: `js_promise_resolve_with_promise`'s
+//!    slow path unconditionally nulled `inner.next` after parking its
+//!    forwarders in the overflow table. `inner.next` can hold a PRIOR
+//!    dependent's fast-path adoption edge (the first adoption of a
+//!    reaction-free inner chains its outer there), so a SECOND adoption of
+//!    the same shared inner promise severed the first dependent's only
+//!    edge — its promise never settled. At Next.js App Router scale the
+//!    render chain's async-step machines adopt shared React work promises
+//!    in exactly this shape; the severed machine's result parked the whole
+//!    await graph (the request-time dynamic routes hung with 18 suspended
+//!    machines).
+//!
+//! 2. Swallowed step-resume rejection: an async-step machine resumed via
+//!    the promise thunks that exits through its step body's internal catch
+//!    arm (`throw` after a pending `await`) returned a FRESH rejected
+//!    promise that the thunks discarded — the machine's real result
+//!    promise (the captured per-activation `trap_next`, #5485) stayed
+//!    Pending and the caller's `catch` never ran.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+/// Compile `src` and run it. Returns (exit_ok, stdout).
+fn compile_and_run(src: &str) -> (bool, String) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.ts");
+    std::fs::write(&entry, src).expect("write entry");
+    let output = dir.path().join("main_bin");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir.path())
+        .args([
+            "compile",
+            entry.to_str().unwrap(),
+            "-o",
+            output.to_str().unwrap(),
+        ])
+        .env("PERRY_NO_AUTO_OPTIMIZE", "1")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    (
+        run.status.success(),
+        String::from_utf8_lossy(&run.stdout).to_string(),
+    )
+}
+
+/// Two async fns adopting ONE shared pending promise: the first adoption
+/// takes resolve_with_promise's fast path (`shared.next = resultA`), the
+/// second takes the slow path — which used to null `shared.next`,
+/// orphaning `pa` forever (the run then exits non-zero via the
+/// unsettled-top-level-await detector instead of printing).
+#[test]
+fn second_adoption_of_shared_promise_preserves_first_adopters_chain() {
+    let (ok, stdout) = compile_and_run(
+        r#"
+let release: (v: string) => void;
+const shared = new Promise<string>((res) => {
+  release = res;
+});
+// `await 0` forces a real state transition so js_async_step_done runs
+// with a live trap_next and ADOPTS `shared` (without it, Promise.resolve
+// identity short-circuits and no adoption happens).
+async function a(): Promise<string> {
+  await 0;
+  return shared;
+}
+async function b(): Promise<string> {
+  await 0;
+  return shared;
+}
+const pa = a();
+const pb = b();
+setTimeout(() => release!("done"), 10);
+const ra = await pa;
+const rb = await pb;
+console.log(ra, rb);
+"#,
+    );
+    assert!(ok, "run must exit cleanly (first adopter's await hung)");
+    assert_eq!(stdout, "done done\n");
+}
+
+/// A throw AFTER a pending await must reject the async fn's result so the
+/// caller's catch runs (the resume thunks used to discard the step's
+/// catch-arm `Promise.reject` return, hanging the caller instead).
+#[test]
+fn throw_after_pending_await_rejects_the_result_promise() {
+    let (ok, stdout) = compile_and_run(
+        r#"
+async function boom(): Promise<string> {
+  await new Promise<void>((r) => setTimeout(r, 10));
+  throw new Error("x");
+}
+async function outer(): Promise<void> {
+  try {
+    await boom();
+    console.log("no-throw");
+  } catch (e) {
+    console.log("caught", (e as Error).message);
+  }
+}
+await outer();
+"#,
+    );
+    assert!(ok, "run must exit cleanly (caller's catch never ran)");
+    assert_eq!(stdout, "caught x\n");
+}


### PR DESCRIPTION
Fixes the async-step deadlock class behind #5941 (the last-3/8 Next.js dynamic-RSC routes tracker). Three independent fixes, each with regression coverage. **Important scope note up front:** the dynamic routes do not render yet — the #5941 *deadlock* (parked machines / promise cycle that never settles) is eliminated and measured gone, but a further, different wall remains (details at the bottom). Filing that separately.

## Finding 1: #5941's stated mechanism is refuted by direct measurement

The issue proposed that simultaneously-active state machines lose per-activation identity (shared boxed state-var / step closure via the capture-value-keyed singleton cache, #1029/#5143 family). I re-added the perturbation-proof stuck-machine toolkit specified in the issue, plus a **live-activation collision detector** in `js_async_first_call` (fires if a step-closure pointer re-enters first_call while a prior activation is live). On the full repro (`/plain` with 18 parked machines — the exact frame set named in the issue, verified by `atos`):

- **Zero collisions.** Every parked machine had exactly one `first_call`.
- Statically consistent: a step closure's singleton-cache key always contains ≥4 per-activation box pointers, and boxes are never freed/recycled — cross-activation cache hits cannot happen.
- Also refuted along the way: GC-evacuation staleness (`PERRY_GEN_GC=0` still hangs) and LocalId-collision-into-non-box-slot (no `PERRY_DEBUG` box warnings).

The await-graph instead bottomed out at promises whose **registered dependents were severed or discarded by the runtime promise machinery** — the two runtime fixes below.

## Fix 1 (transform): id scans miss outer param defaults — `generator/id_scan.rs`

`compute_max_local_id` / `compute_max_func_id` read only `param.id` in every hand-rolled container loop (module functions, class methods/static methods/computed members/ctor/getters/setters). A parameter's **default value** is a full expression that can hold closures with fresh LocalIds/FuncIds; the expr walker only reaches defaults of *nested* `Expr::Closure` params, never the outer containers'. Since the CPS/generator transform seeds `next_local_id`/`next_func_id` from these maxes, a default-value closure anywhere in a module could collide with freshly-minted state-machine ids — the same corruption class as #5143 (a collided boxed id silently shares one box between two variables). Not the live root of the #5941 hang, but a real member of exactly the family the issue targets — folded param defaults, legacy decorator factory args, and arguments-object mapped ids into both scans, with unit tests that fail pre-fix.

## Fix 2 (runtime): second adoption of a shared promise severed the first adopter's chain — `promise/then.rs`

`js_promise_resolve_with_promise`'s slow path parked forwarders in the overflow table (#5932) but kept the **unconditional `inner.next = null`**. `inner.next` can legitimately hold a *prior* dependent's fast-path adoption edge (the first adoption of a reaction-free inner chains its outer there) or a `.then` child. With two dependents adopting one shared inner promise, the second adoption severed the first's only edge — its promise never settled. The render chain's machines adopt shared React work promises in exactly this shape, which is why it only bites at bundle scale (and why every prior single-machine probe came back clean). The stuck-dump smoking gun: a **SETTLED promise with a PENDING adopter whose recorded adoption edge had vanished**.

Now nulls `inner.next` only when it already points at *this* outer (the self-cycle case the null protected against).

**Effect on the repro: 18 parked machines → 2.**

Minimal repro (dissolves the issue's "no minimal repro exists"): two async fns doing `await 0; return shared;` — `await a()` hung (unsettled-TLA exit 13) before, prints `done done` after.

## Fix 3 (runtime): thunk-resumed step's catch-arm rejection was discarded — `promise/async_step.rs`

A step resumed via the async-step thunks that exits through its internal catch (a `throw` after a pending `await`, or an awaited rejection with no matching catch route) returns a fresh rejected promise (`return Promise.reject(e)`), which the thunks **discarded** — the machine's real result promise (the captured per-activation `trap_next`, #5485) stayed Pending and every awaiter hung instead of observing the throw. Only the resumed path leaks (first_call hands the rejected promise straight to the caller). Forward the rejection into the captured `trap_next` (identity-checked so normal chain/done-reuse returns are untouched).

**Effect on the repro: 2 parked machines → 0; the async-step graph fully settles.** This also unblinded the render's real errors (previously silent hangs — e.g. Next's expected-and-caught `PageNotFoundError: Cannot find module for page: /_document` probes now propagate as rejections, matching node).

Minimal repro: async fn that throws after `await` of a timer promise — caller's `catch` never ran (exit 13) before, prints `caught x` after.

## Validation

- `cargo test -p perry-runtime promise`: 53/53 (note: `-- --test-threads=1` segfaults in `node_submodules::fs_parent_promises_property_exposes_namespace` on **pristine origin/main** too — pre-existing ordering flake, not from this branch)
- `cargo test -p perry-transform`: 47/47
- New integration tests (`crates/perry/tests/issue_5941_shared_promise_adoption.rs`): both fail on base, pass with the fixes
- Gap spot-check (9 async/promise/generator `test_gap_*`): all byte-identical vs node
- Next.js matrix: statics (`/`, `/about`, `/counter`) stay byte-identical; **no stuck machines remain** on the dynamic routes
- `cargo fmt --all -- --check` clean

## What still blocks 8/8 (separate follow-ups)

1. The dynamic routes still return no bytes — but the failure is no longer a deadlock: the async-step graph is empty, all promises settle, rejections propagate. The request dies silently after two *expected* sync ENOENT throws (optional manifests `subresource-integrity-manifest.json` / `dynamic-css-manifest`, absent in the build and caught in node too). The render/error-recovery flow diverges somewhere after that with a clean async graph — a different, narrower bug than #5941's deadlock. Will file with the diagnostic details.
2. **Fresh main regression, unrelated to this PR**: `GET /api/hello` segfaults the compiled server on current main (it was byte-identical at the #5932 validation earlier the same day; window = 2026-07-04's commits). Reproduces on an unmodified-main build. Will file separately.

The diagnostic toolkit (env-gated stuck-machine dumper, await-graph walker with adoption edges + settlement annotation, collision detector) lives on the investigation branch `fix/async-step-per-activation-identity-5941` if anyone wants to replay the diagnosis; this PR is probe-free.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented hanging awaits by preserving existing promise reaction chains during promise adoption/chaining, and by correctly forwarding “swallowed” rejections into the activation result.
  * Ensured that when an awaited promise remains pending and the async step later throws, the caller’s `catch` executes as expected.
  * Fixed rare generator/async state-machine ID collisions by expanding max-ID scanning to include parameter defaults, decorator arguments, and mapped argument-object parameters.
* **Tests**
  * Added integration tests for shared-promise adoption and for throw-after-pending-await behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->