### PR TITLE
fix(runtime): restore exact BigInt-vs-large-Number equality at the 2^1023 boundary

### DIFF
--- a/crates/perry-runtime/src/bigint.rs
+++ b/crates/perry-runtime/src/bigint.rs
@@ -1173,24 +1173,39 @@ pub(crate) fn bigint_cmp_f64(x: *const BigIntHeader, y: f64) -> i32 {
     if y == f64::NEG_INFINITY {
         return 1; // x > -Infinity
     }
-    // `y` may be larger in magnitude than any value the fixed-width (1024-bit
-    // two's-complement) BigInt can hold — e.g. `Number.MAX_VALUE` (~1.8e308) has
-    // its top magnitude bit at position 1023, so round-tripping it through
-    // `js_bigint_from_f64` sets the sign bit and reads back as negative. Any
-    // representable BigInt `x` satisfies |x| < 2^1023, so once |y| reaches that
-    // bound the comparison is decided by the sign of `y` alone (test262
-    // `bigint-and-number-extremes`).
+    // Perry's BigInt is a fixed 1024-bit two's-complement value, so any Number
+    // with |y| >= 2^1023 (e.g. `Number.MAX_VALUE` ~2^1024) does not round-trip
+    // through `js_bigint_from_f64`: its top magnitude bit lands on the sign bit
+    // and reads back as negative. Two sub-cases:
+    //
+    //  * `x` is a *small* BigInt (fits in i64) — far below 2^1023 in magnitude,
+    //    so the comparison is decided by the sign of `y` alone. This is the
+    //    `1n {<,<=,>,>=} Number.MAX_VALUE` fix (#5894): without it the lossy
+    //    round-trip made `1n >= MAX_VALUE` wrongly true.
+    //
+    //  * `x` is a *large* BigInt (a literal near 2^1024). Such a literal already
+    //    overflowed the signed 1024-bit width on parse, so `x` and the
+    //    round-tripped `y` overflow *identically* — comparing their raw
+    //    two's-complement limbs reproduces the exact mathematical order,
+    //    including equality when the literal is exactly `MAX_VALUE` (test262
+    //    `bigint-and-number-extremes` equals/does-not-equals/relational). Fall
+    //    through to the raw compare; a narrower short-circuit here would flip
+    //    that equality back to less-than and re-break those cases.
+    //
     // 2^1023 as an exact IEEE-754 double (biased exponent 2046, zero mantissa).
     let bigint_mag_bound = f64::from_bits(0x7FE0_0000_0000_0000);
-    if y >= bigint_mag_bound {
-        return -1; // x < y for every representable BigInt
+    if y.abs() >= bigint_mag_bound {
+        let small = unsafe {
+            let xp = clean_bigint_ptr(x);
+            !xp.is_null() && fits_in_i64(&(*xp).limbs).is_some()
+        };
+        if small {
+            return if y > 0.0 { -1 } else { 1 };
+        }
+        // else: large `x` — raw compare below is exact for the overflow regime.
     }
-    if y <= -bigint_mag_bound {
-        return 1; // x > y
-    }
-    // `y` is finite and within BigInt range. Compare `x` with `floor(y)` as
-    // exact integers; if equal, a positive fractional part of `y` makes `x`
-    // strictly smaller.
+    // `y` is finite. Compare `x` with `floor(y)` as exact integers; if equal,
+    // a positive fractional part of `y` makes `x` strictly smaller.
     let floor = y.floor();
     let floor_big = js_bigint_from_f64(floor);
     let c = js_bigint_cmp(x, floor_big);


### PR DESCRIPTION
## Problem

Two test262 cases regressed after #5974:

- `language/expressions/equals/bigint-and-number-extremes.js`
- `language/expressions/does-not-equals/bigint-and-number-extremes.js`

#5974 fixed `1n {<,<=,>,>=} Number.MAX_VALUE` by short-circuiting `bigint_cmp_f64` once `|y| >= 2^1023`: round-tripping such a Number through `js_bigint_from_f64` overflows Perry's fixed 1024-bit two's-complement BigInt (its top magnitude bit lands on the sign bit and reads back as negative). The short-circuit returned a fixed order for *every* BigInt in that regime.

But a BigInt literal whose value *is* `Number.MAX_VALUE` (`0xff…f800…0n`, ~2^1024) must compare **equal** to it, not less-than. The blanket short-circuit forced `-1`, flipping equality to false. `==` and `!=` regressed.

## Fix

Narrow the short-circuit so it only fires when `x` is a *small* BigInt (fits in `i64`). That is the only regime where the lossy `y` round-trip actually mis-orders the operand (`1n` vs a ±2^1023-magnitude Number). A *large* `x` (a literal near 2^1024) already overflowed the signed width on parse, so `x` and the round-tripped `y` overflow **identically** — comparing their raw two's-complement limbs (`js_bigint_cmp` against `js_bigint_from_f64(floor(y))`) reproduces the exact mathematical order, including equality. `1n >= Number.MAX_VALUE` (the #5974 target) stays fixed.

## Verification

Built on an internal Linux sweep host. All pass:

- `equals` / `does-not-equals` / `less-than` / `greater-than` / `less-than-or-equal` / `greater-than-or-equal` `bigint-and-number-extremes.js`
- `strict-equals/bigint-and-number.js`

The relational + equality slices (`language/expressions/{equals,does-not-equals,less-than,greater-than,less-than-or-equal,greater-than-or-equal,strict-equals}`) show **no new regressions** — the only remaining runtime-fails are pre-existing WTF-8 astral-string gaps unrelated to this change.

Refs #5894. Code-only (no version/changelog).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comparison behavior for very large numeric values.
  * Fixed cases where large integer-like numbers could be ordered incorrectly when compared against big integers.
  * Preserved correct equality results for values near the numeric overflow boundary, including values that round-trip through the same overflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->