### PR TITLE
fix(intl): ToObject primitive options in SupportedLocalesOf

### DIFF
--- a/crates/perry-runtime/src/intl.rs
+++ b/crates/perry-runtime/src/intl.rs
@@ -878,6 +878,22 @@ fn coerce_options_reject_null(options: f64) -> f64 {
     options
 }
 
+/// `ToObject(options)` for the SupportedLocales option read: `null` / `undefined`
+/// are handled by the caller; a non-object primitive (Boolean, Number, String,
+/// Symbol, BigInt) is boxed into a fresh empty object so that reading an option
+/// key walks the standard prototype chain and fires any `Object.prototype`
+/// getter for that key exactly once (SupportedLocales step 1.a, test262
+/// `supportedLocalesOf/options-toobject.js`). A real object passes through.
+fn to_object_for_options(options: f64) -> f64 {
+    if object_ptr_from_value(options).is_some() {
+        return options;
+    }
+    // Box the primitive: an empty object has no own option keys, so every read
+    // resolves through the prototype chain — matching the boxed-wrapper behaviour
+    // the spec observes (the wrapper carries no `localeMatcher` of its own).
+    js_nanbox_pointer(js_object_alloc(0, 0) as i64)
+}
+
 /// GetBooleanOption(options, key): `undefined` → `None`, otherwise ToBoolean.
 fn get_bool_option(options: f64, key: &str) -> Option<bool> {
     let value = get_option_value(options, key);
@@ -1692,7 +1708,10 @@ fn supported_locales_array(locales: f64, options: f64) -> f64 {
     //      lookup result.
     let requested = locales_from_value(locales);
     if !JSValue::from_bits(options.to_bits()).is_undefined() {
-        let options = coerce_options_reject_null(options);
+        // SupportedLocales step 1.a: ? ToObject(options). null throws; a
+        // primitive is boxed so the localeMatcher read fires an Object.prototype
+        // getter exactly once (options-toobject.js).
+        let options = to_object_for_options(coerce_options_reject_null(options));
         let _ = enum_option_strict(
             options,
             "localeMatcher",


### PR DESCRIPTION
## Summary

`Intl.Segmenter` / `Intl.ListFormat` / `Intl.RelativeTimeFormat` `supportedLocalesOf(locales, options)` did not perform `ToObject(options)` when `options` was a non-object primitive. ECMA-402 `SupportedLocales` step 1.a is `? ToObject(options)`, which boxes a primitive into a wrapper whose prototype chain reaches `Object.prototype` — so reading `localeMatcher` fires any `Object.prototype` getter for that key exactly once.

Perry read option keys directly off the raw value, so a primitive `options` argument (`true`, `"test"`, `7`, `Symbol()`) yielded every-key-absent and never walked the prototype chain: the getter was never called (`called === 0`).

## Fix

Box a non-object primitive into a fresh empty object before the `localeMatcher` read (`null` is still rejected first). An empty object carries no own option keys, so the read resolves through the standard prototype chain — matching the boxed-wrapper behaviour the spec observes.

## Tests

Fixes 3 test262 cases (measured on an internal Linux sweep host):

- `intl402/Segmenter/constructor/supportedLocalesOf/options-toobject.js`
- `intl402/ListFormat/constructor/supportedLocalesOf/options-toobject.js`
- `intl402/RelativeTimeFormat/constructor/supportedLocalesOf/options-toobject.js`

Verified on the Segmenter/ListFormat/RelativeTimeFormat/PluralRules/DisplayNames/Collator slice: pass +3, zero regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `Intl.supportedLocalesOf` option handling so non-object option values are treated consistently.
  * Preserved rejection of `null` while ensuring locale-matching options are read in the expected order, including correct prototype lookup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->