### PR TITLE
fix(intl): RelativeTimeFormat.format(0, symbol) is a TypeError

### DIFF
--- a/crates/perry-runtime/src/intl/list_relative_plural.rs
+++ b/crates/perry-runtime/src/intl/list_relative_plural.rs
@@ -325,6 +325,11 @@ pub(crate) fn rtf_instance_parts_and_unit(
     // ToNumber: a Symbol/BigInt value throws TypeError *before* the finite-ness
     // RangeError (format/value-symbol.js); an object's valueOf is invoked.
     let number = to_number_reject_bigint(value);
+    // ToString(unit): a Symbol throws TypeError (before the RangeError enum
+    // guard), matching ECMA-262 ToString — format/unit-invalid.js.
+    if unsafe { crate::symbol::js_is_symbol(unit_arg) != 0 } {
+        throw_type_error("Cannot convert a Symbol value to a string");
+    }
     let unit_str = value_to_string(unit_arg);
     if !number.is_finite() {
         throw_range_error("Value need to be finite number for Intl.RelativeTimeFormat.format()");


### PR DESCRIPTION
## Summary

`Intl.RelativeTimeFormat.prototype.format` / `formatToParts` coerce the `unit` argument with `? ToString(unit)` before the `SingularRelativeTimeUnit` `RangeError` enum check. `ToString(Symbol)` throws a `TypeError`, so `rtf.format(0, Symbol())` must throw `TypeError` — not `RangeError`.

Perry's `value_to_string` stringifies a Symbol to `"Symbol()"` (`String(sym)` semantics) rather than throwing, so a Symbol unit fell through to the `RangeError` "out of range" path.

## Fix

Reject a Symbol `unit` with `TypeError` before the ToString/enum step in the shared `format`/`formatToParts` path (`rtf_instance_parts_and_unit`). The ToNumber(value) step still runs first, matching the spec ordering.

## Tests

Fixes 2 test262 cases (measured on an internal Linux sweep host):

- `intl402/RelativeTimeFormat/prototype/format/unit-invalid.js`
- `intl402/RelativeTimeFormat/prototype/formatToParts/unit-invalid.js`

RelativeTimeFormat slice: runtime-fail 16 → 14, zero regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of relative plural formatting inputs by rejecting invalid symbol values with a clear error.
  * Kept existing number validation and unit handling behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->