### PR TITLE
fix(runtime): guard URLSearchParams shape probe against non-object receivers (Date.toString segv)

### DIFF
--- a/crates/perry-runtime/src/url/search_params.rs
+++ b/crates/perry-runtime/src/url/search_params.rs
@@ -819,6 +819,20 @@ pub(crate) fn shape_is_url_search_params(obj: *const ObjectHeader) -> bool {
         return false;
     }
     unsafe {
+        // The receiver may be *any* pointer-tagged value -- a Date/Temporal
+        // cell, buffer, closure, small handle, etc. -- because callers reach
+        // this probe on a type-erased receiver before validating the object
+        // kind (#5964's dynamic-toString arm in js_native_call_method faults on
+        // a Date cell otherwise: date.toString() twice segfaulted while reading
+        // a Date cell's bytes at ObjectHeader offsets). Only ordinary objects
+        // carry the ObjectHeader layout, so classify the address and gate on the
+        // GC header type first -- a Date cell is GC_TYPE_DATE_CELL, an array
+        // GC_TYPE_ARRAY, and so on. `try_read_gc_header` also rejects small
+        // handles / slab buffers that would otherwise deref a fake header.
+        match crate::value::addr_class::try_read_gc_header(obj as usize) {
+            Some(h) if h.obj_type == crate::gc::GC_TYPE_OBJECT => {}
+            _ => return false,
+        }
         if (*obj).class_id != 0 {
             return false;
         }


### PR DESCRIPTION
## Problem

`language/expressions/addition/S11.6.1_A2.2_T2.js` regressed to a **segfault** (SIGSEGV, "no output") after #5964.

#5964 made native `URLSearchParams` methods reachable through dynamic access by probing the receiver in `js_native_call_method` for `append`/`set`/`get`/`has`/`delete`/**`toString`**. The probe masks the receiver bits into an `*ObjectHeader` and calls `shape_is_url_search_params`, which reads `class_id` / `keys_array` / `length` at `ObjectHeader` offsets.

But the receiver can be *any* pointer-tagged value. A `Date` value is a pointer to a `GC_TYPE_DATE_CELL`, whose bytes at those offsets are unrelated. Reading `keys_array` as a pointer and dereferencing its `length` faulted — so the test's `date.toString() + date.toString()` (two `toString` calls, each firing the probe) crashed.

## Fix

Gate `shape_is_url_search_params` on the GC header type: proceed only when the allocation is `GC_TYPE_OBJECT`. A Date cell, array, buffer, closure, etc. now returns `false` immediately instead of reading `ObjectHeader` fields off a foreign layout. This protects **every** caller of the shared probe, not just the new `toString` arm — mirroring the `is_plain_matcher_object` GC-header check already used elsewhere.

## Verification

Built on an internal Linux sweep host:

- `language/expressions/addition/S11.6.1_A2.2_T2.js` passes (was SIGSEGV).
- `date.toString() + date.toString()` no longer segfaults.
- `URLSearchParams` dynamic `get` / `toString` / `size` still work (no regression to #5964's fix).
- `language/expressions/addition` slice is clean; remaining `built-ins/Date` runtime-fails are pre-existing unrelated gaps (`toTemporalInstant`, MakeTime precision, etc.).

Refs #5961. Code-only (no version/changelog).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety when handling URL search parameters so invalid or non-object internal values are no longer misidentified.
  * Prevents crashes or incorrect behavior from type-erased/native method checks on unusual pointer-tagged inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->