### PR TITLE
fix(runtime): js_dynamic_mod preserves sign of zero (fmod semantics)

### DIFF
--- a/crates/perry-runtime/src/value/dynamic_arith.rs
+++ b/crates/perry-runtime/src/value/dynamic_arith.rs
@@ -498,10 +498,15 @@ pub unsafe extern "C" fn js_dynamic_mod(a: f64, b: f64) -> f64 {
     }
     let a = dynamic_number_operand(a);
     let b = dynamic_number_operand(b);
-    // Float modulo: a - trunc(a / b) * b
     let a = numify_arith_operand(a);
     let b = numify_arith_operand(b);
-    a - (a / b).trunc() * b
+    // JS `%` is C `fmod`: the result takes the *sign of the dividend*, so
+    // `-1 % -1` is `-0`, not `+0`. The old `a - (a / b).trunc() * b` closed-form
+    // lost that (`-1.0 - 1.0 * -1.0 == +0.0`) and also returned `NaN` for
+    // `x % Infinity` (should be `x`). Rust's `f64 % f64` *is* `fmod`, matching
+    // the spec exactly on the sign of zero, `x % ±Inf`, and `±Inf % y` / `x % 0`
+    // → `NaN` (test262 compound-assignment `mod-whitespace`: `-0` expected).
+    a % b
 }
 
 /// Dynamic negate: -BigInt if operand is BigInt, else -f64.


### PR DESCRIPTION
## Problem

`language/expressions/compound-assignment/mod-whitespace.js` regressed: `x %= -1` (with `x == -1`) yielded `0` where the spec wants `-0`.

`js_dynamic_mod` computed the remainder with the closed form `a - (a / b).trunc() * b`. That drops the sign of a zero result: `-1 % -1` evaluates to `-1.0 - (1.0 * -1.0) == +0.0`. But JS `%` is C `fmod`, whose result takes the **sign of the dividend**, so `-1 % -1` is `-0`. The same closed form also returned `NaN` for `x % Infinity` (should be `x`).

The bug surfaced once a compound assignment on a separately-declared int-valued local (`var x; x = -1; x %= -1`) started routing through `js_dynamic_mod` (the codegen fast path that carries the `-0` correction isn't taken for this receiver shape).

## Fix

Rust's `f64 % f64` **is** `fmod`, so replace the closed form with `a % b`. It matches the spec exactly on:

- sign of zero (`-1 % -1 == -0`, `-0 % 5 == -0`)
- `x % ±Infinity == x`
- `±Infinity % y == NaN`, `x % 0 == NaN`

## Verification

Built on an internal Linux sweep host:

- `mod-whitespace.js` passes (all whitespace variants, `-0` expected).
- `language/expressions/compound-assignment` + `language/expressions/modulus` slices are **100%** (487 cases, 0 runtime-fails).

Code-only (no version/changelog).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JavaScript-style modulo behavior for floating-point numbers, including correct handling of signed zero, infinities, and zero division cases.
  * Results now align more closely with expected remainder behavior in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->