### PR TITLE
fix(intl): Spanish (es) ListFormat unit list patterns

### DIFF
--- a/crates/perry-runtime/src/intl/duration_format.rs
+++ b/crates/perry-runtime/src/intl/duration_format.rs
@@ -806,7 +806,10 @@ fn partition(obj: *const ObjectHeader, vals: &[f64]) -> Vec<DfPart> {
         .iter()
         .map(|parts| parts.iter().map(|p| p.value.as_str()).collect())
         .collect();
-    let lf_parts = super::list_format_parts(&strings, "unit", &list_style);
+    // DurationFormat historically used the base (en-US) list separators; pass
+    // "en-US" explicitly to preserve that output (locale-specific duration list
+    // patterns are out of scope here).
+    let lf_parts = super::list_format_parts("en-US", &strings, "unit", &list_style);
 
     let mut flattened: Vec<DfPart> = Vec::new();
     let mut elem = 0usize;

--- a/crates/perry-runtime/src/intl/list_relative_plural.rs
+++ b/crates/perry-runtime/src/intl/list_relative_plural.rs
@@ -124,9 +124,22 @@ pub(crate) fn collect_string_list(value: f64) -> Vec<String> {
 /// `pair` joins a 2-element list, `middle` joins all but the final boundary of a
 /// 3+-element list, and `last` joins the final boundary.
 pub(crate) fn list_separators(
+    locale: &str,
     list_type: &str,
     style: &str,
 ) -> (&'static str, &'static str, &'static str) {
+    // Spanish (`es`) `unit` list patterns (CLDR): the last boundary joins with
+    // " y " for long, but 3+-element short/narrow lists are comma/space-joined
+    // like the base. The 2-element `pair` uses " y " for long AND short.
+    // (The "y" -> "e" euphonic rule before /i/ words is not exercised here.)
+    if list_type == "unit" && (locale == "es" || locale.starts_with("es-")) {
+        match style {
+            "long" => return (" y ", ", ", " y "),
+            "short" => return (" y ", ", ", ", "),
+            // narrow: space-joined, identical to the base — fall through.
+            _ => {}
+        }
+    }
     match list_type {
         "unit" => {
             if style == "narrow" {
@@ -146,11 +159,12 @@ pub(crate) fn list_separators(
 }
 
 pub(crate) fn list_format_parts(
+    locale: &str,
     items: &[String],
     list_type: &str,
     style: &str,
 ) -> Vec<(&'static str, String)> {
-    let (pair, middle, last) = list_separators(list_type, style);
+    let (pair, middle, last) = list_separators(locale, list_type, style);
     let mut parts: Vec<(&'static str, String)> = Vec::new();
     let n = items.len();
     if n == 0 {
@@ -181,9 +195,10 @@ pub(crate) fn list_format_instance_parts(
     value: f64,
 ) -> Vec<(&'static str, String)> {
     let items = collect_string_list(value);
+    let locale = get_string_field(obj, KEY_LOCALE).unwrap_or_else(|| "en-US".to_string());
     let list_type = get_string_field(obj, KEY_TYPE).unwrap_or_else(|| "conjunction".to_string());
     let style = get_string_field(obj, KEY_LF_STYLE).unwrap_or_else(|| "long".to_string());
-    list_format_parts(&items, &list_type, &style)
+    list_format_parts(&locale, &items, &list_type, &style)
 }
 
 pub(crate) extern "C" fn list_format_format_thunk(


### PR DESCRIPTION
## Summary

`Intl.ListFormat` with locale `"es"` / `"es-*"` and `type: "unit"` must join with the Spanish connectors from CLDR:

- `long`: `"foo, bar y baz"` — last boundary `" y "`, pair `" y "`
- `short`: `"foo, bar, baz"` — comma-joined for 3+ elements, pair still `" y "`
- `narrow`: `"foo bar baz"` — space-joined, same as the base (unchanged)

`list_separators` was hardcoded to the en-US patterns, so es lists came out comma-joined (`"foo, bar"` instead of `"foo y bar"`).

## Fix

Thread the resolved locale through `list_format_parts` / `list_separators` and add the `es` unit branch. The single `DurationFormat` caller passes `"en-US"` explicitly to preserve its existing (locale-agnostic) output — DurationFormat list patterns are out of scope here.

## Tests

Fixes 4 test262 cases (measured on an internal Linux sweep host):

- `intl402/ListFormat/prototype/format/es-es-long.js`
- `intl402/ListFormat/prototype/format/es-es-short.js`
- `intl402/ListFormat/prototype/formatToParts/es-es-long.js`
- `intl402/ListFormat/prototype/formatToParts/es-es-short.js`

`es-es-narrow` (space-joined) stays passing; DurationFormat output verified unchanged. Zero regressions in the ListFormat slice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * List formatting now respects locale-specific separators, including improved behavior for Spanish unit lists.
  * Duration lists now consistently use base English-style separators for more predictable output.

* **Bug Fixes**
  * Fixed inconsistent separator patterns when formatting lists and durations across different locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->