### PR TITLE
fix(compile): #5987 — guard class_canonical_path against ClassId collisions

### DIFF
--- a/crates/perry/src/commands/compile/helpers.rs
+++ b/crates/perry/src/commands/compile/helpers.rs
@@ -102,13 +102,20 @@ pub(crate) fn is_windows_reserved_file_stem(stem: &str) -> bool {
 
 pub(crate) fn canonical_class_source_prefix(
     class: &perry_hir::Class,
-    class_canonical_path: &HashMap<perry_hir::ClassId, String>,
+    class_canonical_path: &HashMap<perry_hir::ClassId, (String, String)>,
     project_root: &Path,
     fallback_prefix: &str,
 ) -> String {
+    // Issue #5987: `ClassId` is meant to be globally unique, but a large
+    // multi-module compile can still produce a collision (two unrelated
+    // classes assigned the same id). Only trust the recorded path if its
+    // class NAME also matches this class — a mismatch means the id
+    // collided with some other class, and `fallback_prefix` (derived from
+    // the caller's own already-verified origin lookup) is reliable.
     class_canonical_path
         .get(&class.id)
-        .map(|path| compute_module_prefix(path, project_root))
+        .filter(|(_, name)| name == &class.name)
+        .map(|(path, _)| compute_module_prefix(path, project_root))
         .unwrap_or_else(|| fallback_prefix.to_string())
 }
 
@@ -258,7 +265,10 @@ mod tests {
         let mut class_canonical_path = HashMap::new();
         class_canonical_path.insert(
             class.id,
-            "/repo/node_modules/rxjs/src/internal/Observable.ts".to_string(),
+            (
+                "/repo/node_modules/rxjs/src/internal/Observable.ts".to_string(),
+                "Observable".to_string(),
+            ),
         );
 
         assert_eq!(
@@ -269,6 +279,62 @@ mod tests {
                 "node_modules_rxjs_src_index_ts",
             ),
             "node_modules_rxjs_src_internal_Observable_ts"
+        );
+    }
+
+    #[test]
+    fn canonical_class_source_prefix_falls_back_on_id_collision() {
+        // Issue #5987: a `ClassId` collision (two unrelated classes assigned
+        // the same id) must not silently misattribute the wrong module —
+        // the recorded entry's name has to match this class's own name, or
+        // the caller's fallback (already verified correct by the caller)
+        // wins instead.
+        let class = perry_hir::Class {
+            id: 7,
+            name: "ClientAbort".to_string(),
+            type_params: Vec::new(),
+            extends: None,
+            extends_name: None,
+            native_extends: None,
+            extends_expr: None,
+            heritage_lexically_shadowed: false,
+            fields: Vec::new(),
+            constructor: None,
+            methods: Vec::new(),
+            getters: Vec::new(),
+            setters: Vec::new(),
+            static_accessor_names: Vec::new(),
+            static_accessor_fn_ids: Vec::new(),
+            static_fields: Vec::new(),
+            static_methods: Vec::new(),
+            computed_members: Vec::new(),
+            decorators: Vec::new(),
+            is_exported: true,
+            is_nested: false,
+            aliases: Vec::new(),
+        };
+        let project_root = PathBuf::from("/repo");
+        let mut class_canonical_path = HashMap::new();
+        // Same id (7), but recorded for a DIFFERENT class ("SchemaAST") —
+        // simulates an id collision from an unrelated module.
+        class_canonical_path.insert(
+            class.id,
+            (
+                "/repo/node_modules/effect/src/SchemaAST.ts".to_string(),
+                "SchemaAST".to_string(),
+            ),
+        );
+
+        assert_eq!(
+            canonical_class_source_prefix(
+                &class,
+                &class_canonical_path,
+                &project_root,
+                "node_modules_effect_src_unstable_rpc_RpcSchema_ts",
+            ),
+            "node_modules_effect_src_unstable_rpc_RpcSchema_ts",
+            "name mismatch on the ClassId entry must fall back to the caller's \
+             already-verified prefix, not the colliding entry's path"
         );
     }
 

--- a/crates/perry/src/commands/compile/run_pipeline.rs
+++ b/crates/perry/src/commands/compile/run_pipeline.rs
@@ -541,7 +541,20 @@ pub fn run_with_parse_cache(
     // closure (`MySqlPreparedQuery extends QueryPromise`), but the
     // canonical path is `query-promise.js`, not `index.js` which
     // re-exports it via `export *`.
-    let mut class_canonical_path: std::collections::HashMap<perry_hir::ClassId, String> =
+    // Issue #5987: `ClassId` is meant to be unique across the whole program
+    // (module lowering threads a `next_class_id` counter forward precisely
+    // to guarantee this), but a real multi-thousand-module compile can still
+    // produce two unrelated classes with the same id (e.g. via parallel
+    // lowering or object-cache reuse of a previously-lowered module) — this
+    // showed up for `effect`'s two distinct `ClientAbort` classes (in
+    // `RpcSchema.ts` and `HttpServerError.ts`) resolving to a third,
+    // unrelated module (`SchemaAST.ts`) that doesn't define either. Store
+    // the class's own name alongside its path so a lookup can detect an id
+    // collision (name mismatch) and refuse the entry rather than silently
+    // trusting it — every caller already has a reliable fallback for this
+    // case (the compound `(path, name)` key that found `class` in the first
+    // place already proves the origin is correct).
+    let mut class_canonical_path: std::collections::HashMap<perry_hir::ClassId, (String, String)> =
         std::collections::HashMap::new();
     for (path, hir_module) in &ctx.native_modules {
         let path_str = path.to_string_lossy().to_string();
@@ -550,7 +563,7 @@ pub fn run_with_parse_cache(
                 exported_classes.insert((path_str.clone(), class.name.clone()), class);
                 class_canonical_path
                     .entry(class.id)
-                    .or_insert_with(|| path_str.clone());
+                    .or_insert_with(|| (path_str.clone(), class.name.clone()));
             }
         }
         // Issue #485: handle `export { Local as Exported }` for classes.
@@ -3783,10 +3796,16 @@ pub fn run_with_parse_cache(
                 let field_types_clone = imported_classes[idx].field_types.clone();
                 let parent_name_clone = imported_classes[idx].parent_name.clone();
                 // The child's own canonical source path, used to resolve its
-                // `extends` parent in the child's module scope.
+                // `extends` parent in the child's module scope. Issue #5987:
+                // guard against a `ClassId` collision the same way
+                // `canonical_class_source_prefix` does — only trust the
+                // recorded path if its name matches this child's own name.
+                let child_name_clone = imported_classes[idx].name.clone();
                 let child_src_path: Option<String> = imported_classes[idx]
                     .source_class_id
-                    .and_then(|cid| class_canonical_path.get(&cid).cloned());
+                    .and_then(|cid| class_canonical_path.get(&cid).cloned())
+                    .filter(|(_, name)| name == &child_name_clone)
+                    .map(|(path, _)| path);
                 // Issue #485: include the class's parent in the transitive
                 // closure too. Without this, `import { Sub } from 'pkg'` where
                 // `Sub extends Base` (and Base lives in another file inside
@@ -3839,7 +3858,7 @@ pub fn run_with_parse_cache(
                                 cname == &ref_name
                                     && class_canonical_path
                                         .get(&class.id)
-                                        .map(|cp| cp == path)
+                                        .map(|(cp, cid_name)| cp == path && cid_name == cname)
                                         .unwrap_or(true)
                             })
                         })


### PR DESCRIPTION
Closes #5987. Found via continued real-world `sst/opencode` source-compile verification after #5984 (PR #5985) cleared the previous wall.

## Bug

`ClassId` (`perry-hir/src/ir/constants.rs`, a bare `u32`) is meant to be unique across the whole program — module lowering explicitly threads a `next_class_id` counter forward from one module to the next specifically to guarantee this. But a real multi-thousand-module compile can still produce a collision: confirmed via temporary debug instrumentation that `effect`'s two distinct `ClientAbort` classes (defined separately in `unstable/rpc/RpcSchema.ts` and `unstable/http/HttpServerError.ts`) ended up resolving, at cross-module link time, to a third, unrelated module (`SchemaAST.ts`) that defines neither.

The mechanism: `class_canonical_path` (`run_pipeline.rs`) is a global `HashMap<ClassId, String>` used by `canonical_class_source_prefix` (`helpers.rs`) to resolve a class's "true" defining module when computing cross-module symbol prefixes. If two classes share a `ClassId` (however that collision actually arises — I didn't trace the exact allocation-collision site, likely something in how modules are processed at scale that isn't captured by the sequential-threading path I found), whichever one registered first silently wins the lookup for both, and the second class's cross-module symbol references get emitted against the wrong module prefix — an undefined-symbol link error.

## Fix

Rather than reworking `ClassId` allocation (which I couldn't fully trace across the whole module-processing pipeline, and didn't want to risk a blind fix to a core, widely-relied-on invariant), this guards every consumer of `class_canonical_path` against trusting a collided entry: the map now stores each entry's class name alongside its path, and every lookup site validates the name matches the class being resolved before trusting the entry, falling back to the caller's own (already independently verified) prefix on a mismatch. Every one of the three call sites already has a reliable fallback for this — the compound `(path, name)` key that found the class via `exported_classes` in the first place already proves the correct origin, so this doesn't reduce precision for the non-colliding, common case; it just stops a collision from producing a confidently wrong answer.

## Testing

- New unit test `canonical_class_source_prefix_falls_back_on_id_collision`, reproducing the exact collision scenario from the real bug (`ClientAbort`/`SchemaAST` shape) — verifies the guard falls back correctly. Existing `canonical_class_source_prefix_prefers_defining_path` still passes, confirming the non-colliding case is unaffected.
- Full existing namespace/effect regression suite — unaffected, all real fixtures MATCH.
- `cargo test --release -p perry --bin perry`: 671/671 passed.
- `cargo test --release -p perry-codegen --lib`: 152/152 passed.
- `cargo test --release -p perry --test issue_5920_wrapper_bundled_runtime_async_starvation`: passes.

Note: this does not, on its own, get a real opencode compile all the way to a working binary — that compile hits a separate, unresolved architectural duplicate-symbol issue (tracked on #5928) unrelated to this fix. This specifically closes the one undefined-symbol class of bug #5987 was filed for.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where class ID collisions could cause the wrong module path to be used during class resolution.
  * Improved fallback behavior so class lookup now avoids incorrect parent/module attribution when identifiers overlap.
  * Updated related tests to cover both normal resolution and collision cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->