### PR TITLE
fix(temporal): PlainDateTime/PlainTime toLocaleString keep sub-second fraction

### DIFF
--- a/crates/perry-runtime/src/temporal/plain_date_time.rs
+++ b/crates/perry-runtime/src/temporal/plain_date_time.rs
@@ -190,6 +190,11 @@ pub fn call(recv: f64, dt: &PlainDateTime, name: &str, args: &[f64]) -> f64 {
                 dt.calendar().identifier(),
                 raw_arg(args, 1),
             );
+            // `components_to_timestamp` resolves only to whole seconds, so add
+            // the millisecond-of-second back in — otherwise `toLocaleString`
+            // with `fractionalSecondDigits` always renders `.000`
+            // (test262 PlainDateTime `toLocaleString/lone-options-accepted`,
+            // `{ fractionalSecondDigits: 3 }` expects `.321`).
             let epoch_ms = crate::date::components_to_timestamp(
                 dt.year(),
                 dt.month() as u32,
@@ -198,7 +203,8 @@ pub fn call(recv: f64, dt: &PlainDateTime, name: &str, args: &[f64]) -> f64 {
                 dt.minute() as u32,
                 dt.second() as u32,
             ) as f64
-                * 1000.0;
+                * 1000.0
+                + dt.millisecond() as f64;
             crate::intl::temporal_locale_string(
                 epoch_ms,
                 raw_arg(args, 0),

--- a/crates/perry-runtime/src/temporal/plain_time.rs
+++ b/crates/perry-runtime/src/temporal/plain_time.rs
@@ -197,6 +197,9 @@ pub fn call(recv: f64, t: &PlainTime, name: &str, args: &[f64]) -> f64 {
                 .unwrap_or_default(),
         ),
         "toLocaleString" => {
+            // Include the millisecond-of-second so `fractionalSecondDigits`
+            // renders the real sub-second fraction, not `.000`
+            // (mirrors PlainDateTime toLocaleString).
             let epoch_ms = crate::date::components_to_timestamp(
                 1970,
                 1,
@@ -205,7 +208,8 @@ pub fn call(recv: f64, t: &PlainTime, name: &str, args: &[f64]) -> f64 {
                 t.minute() as u32,
                 t.second() as u32,
             ) as f64
-                * 1000.0;
+                * 1000.0
+                + t.millisecond() as f64;
             crate::intl::temporal_locale_string(
                 epoch_ms,
                 raw_arg(args, 0),


### PR DESCRIPTION
## Problem

`intl402/Temporal/PlainDateTime/prototype/toLocaleString/lone-options-accepted.js` regressed: the `{ fractionalSecondDigits: 3 }` iteration rendered `.000` instead of `.321`.

`Temporal.PlainDateTime.prototype.toLocaleString` (and `PlainTime`) built the epoch-milliseconds argument as `components_to_timestamp(...) * 1000.0`. `components_to_timestamp` resolves only to whole seconds, so the millisecond-of-second was silently dropped — `fractionalSecondDigits` then formatted `.000`.

## Fix

Add `dt.millisecond()` (resp. `t.millisecond()`) back into `epoch_ms` for `PlainDateTime` and `PlainTime` `toLocaleString`. `ZonedDateTime` already used `z.epoch_milliseconds()` (which carries ms) and was unaffected.

## Verification

Built on an internal Linux sweep host:

- `PlainDateTime/.../toLocaleString/lone-options-accepted.js` passes.
- `PlainDateTime.toLocaleString("en", { fractionalSecondDigits: 3 })` → `"12/26/2024, 11:46:40.321 AM"`; `PlainTime` → `"11:46:40.321 AM"`.
- No new regressions in the Temporal `toLocaleString` slices — remaining fails are pre-existing (`hourcycle` h24, de-AT 24h, calendar-mismatch, options-conflict TypeError).

Refs #5900. Code-only (no version/changelog).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `toLocaleString` output for temporal date-time and time values so fractional seconds now reflect the actual millisecond component instead of always showing `.000`.
  * Fixed locale formatting for millisecond precision when converting temporal values for display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->