### PR TITLE
fix(runtime): dispatch user-assigned callable methods on exotic (RegExp/Date/Error) receivers

### DIFF
--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1546,6 +1546,31 @@ pub unsafe extern "C" fn js_native_call_method(
         }
     }
 
+    // Exotic receivers (RegExp / Date / Error) with a user-assigned own
+    // property that is a callable: `var r = /x/; r.f = function(){...}; r.f()`
+    // and `String.prototype.toLowerCase.call`-style borrows like
+    // `reg.toLowerCase = String.prototype.toLowerCase; reg.toLowerCase()`
+    // (test262 String/prototype/{toLowerCase,toUpperCase,...}/*_A1_T14). These
+    // objects store dynamic props in the exotic-expando side table, not the
+    // ObjectHeader field map, so the field/vtable/prototype dispatch above
+    // never sees them. Look the name up there; if it is a callable, invoke it
+    // with the receiver bound as `this` (via IMPLICIT_THIS, matching the
+    // closure-field dispatch path above).
+    if jsval.is_pointer() {
+        if let Some((addr, kind)) = super::exotic_expando::exotic_expando_kind_of_value(object) {
+            if let Some(bits) = super::exotic_expando::value_lookup(kind, addr, method_name) {
+                let candidate = f64::from_bits(bits);
+                if crate::collection_iter::is_callable(candidate) {
+                    let prev_this = IMPLICIT_THIS.with(|c| c.replace(object.to_bits()));
+                    let result =
+                        crate::closure::js_native_call_value(candidate, args_ptr, args_len);
+                    IMPLICIT_THIS.with(|c| c.set(prev_this));
+                    return result;
+                }
+            }
+        }
+    }
+
     crate::object::class_registry::report_dispatch_miss(
         "call-method (no method/field/proto match)",
         object,


### PR DESCRIPTION
## Problem

A callable stored as an own property of an exotic object (RegExp / Date / Error) could not be invoked as a method. Both of these threw `TypeError: <name> is not a function`:

```js
var r = /x/;
r.f = function () { return "hi"; };
r.f();                              // threw

var reg = new RegExp("ABC");
reg.toLowerCase = String.prototype.toLowerCase;
reg.toLowerCase();                  // threw (expected "/abc/")
```

These exotic objects keep their dynamic (expando) properties in a side-table, not in the `ObjectHeader` field map, so the field / vtable / prototype dispatch in `js_native_call_method` never saw the assigned property and fell through to the "is not a function" catch-all. A plain-object receiver already worked; only the exotic receivers were affected.

## Fix

Immediately before the final `is not a function` throw, when the receiver is a RegExp/Date/Error, look the method name up in the exotic-expando side-table. If it resolves to a callable, invoke it with the receiver bound as `this` (via `IMPLICIT_THIS`, mirroring the existing closure-field dispatch path a few arms above).

## Tests

Fixes test262:

- `built-ins/String/prototype/toLowerCase/S15.5.4.16_A1_T14`
- `built-ins/String/prototype/toUpperCase/S15.5.4.18_A1_T14`
- `built-ins/String/prototype/toLocaleLowerCase/S15.5.4.17_A1_T14`
- `built-ins/String/prototype/toLocaleUpperCase/S15.5.4.19_A1_T14`

(each borrows a `String.prototype` case-mapper onto a `RegExp` receiver).

Verified on an internal Linux sweep host against the `built-ins/{Array,Object,String,Proxy,JSON,Function}` slice: +4 passing, **zero regressions**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved method lookup for certain exotic object receivers, so user-assigned callable methods are found and invoked more reliably.
  * Added a fallback path that preserves the original receiver when calling these methods, reducing unexpected “method not found” errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->