### PR TITLE
fix(runtime): proxy [[Get]] forwarding for numeric-index keys and proxy prototypes

### DIFF
--- a/crates/perry-runtime/src/object/prototype_chain.rs
+++ b/crates/perry-runtime/src/object/prototype_chain.rs
@@ -186,6 +186,32 @@ pub(crate) fn resolve_inherited_field(
     if proto_ptr == 0 || proto_ptr == obj_ptr {
         return None;
     }
+    // A Proxy prototype (`Object.create(proxy).x`) is a small fake pointer in
+    // the proxy id band, which passes the loose `is_valid_obj_ptr` heap-range
+    // check below and would then be dereferenced as an `ObjectHeader` — a
+    // SIGSEGV. Route the inherited read through the proxy's `[[Get]]` (which
+    // fires the get trap or forwards to the target), binding the original
+    // instance as the receiver. (test262
+    // Proxy/get/trap-is-{null,undefined}-target-is-proxy via
+    // `Object.create(proxy)[k]`.)
+    {
+        let proto_val = f64::from_bits(proto_bits);
+        if crate::proxy::js_proxy_is_proxy(proto_val) != 0 {
+            if key.is_null() {
+                return None;
+            }
+            let key_val = f64::from_bits(crate::value::js_nanbox_string(key as i64).to_bits());
+            let receiver =
+                f64::from_bits(crate::value::js_nanbox_pointer(obj_ptr as i64).to_bits());
+            let previous_this = super::js_implicit_this_set(receiver);
+            let v = crate::proxy::js_proxy_get(proto_val, key_val);
+            super::js_implicit_this_set(previous_this);
+            if v.to_bits() == crate::value::TAG_UNDEFINED {
+                return None;
+            }
+            return Some(crate::value::JSValue::from_bits(v.to_bits()));
+        }
+    }
     let proto = proto_ptr as *const crate::ObjectHeader;
     if !super::is_valid_obj_ptr(proto as *const u8) {
         return None;

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -562,6 +562,28 @@ pub extern "C" fn js_proxy_get(proxy_boxed: f64, key: f64) -> f64 {
         Some(id) => id,
         None => return f64::from_bits(TAG_UNDEFINED),
     };
+    // `[[Get]] ( P, Receiver )` receives an already-computed property key P, but
+    // codegen calls this helper with the raw index value for a computed read on
+    // a statically-known proxy (`proxy[10]` lowers to
+    // `js_proxy_get(proxy, 10.0)`). Apply `ToPropertyKey` so a numeric index is
+    // seen by the trap as the canonical string key (`10` -> `"10"`) and the
+    // forward-to-target path below stringifies consistently. Symbols and
+    // strings pass through unchanged. Without this the get trap received a raw
+    // number and key-equality checks (`key === "10"`) silently failed (test262
+    // Proxy/get/trap-is-{null,undefined}-target-is-proxy `proxy[10]`). A key
+    // that is already a string (the overwhelmingly common `proxy.foo` case) or
+    // a symbol is left untouched, so this only pays `ToPropertyKey` for the
+    // numeric / object-index forms.
+    let key = {
+        let tag = key.to_bits() & 0xFFFF_0000_0000_0000;
+        let is_string_key =
+            tag == crate::value::STRING_TAG || tag == crate::value::SHORT_STRING_TAG;
+        if is_string_key || unsafe { crate::symbol::js_is_symbol(key) } != 0 {
+            key
+        } else {
+            unsafe { crate::object::js_to_property_key(key) }
+        }
+    };
     let (target, handler, revoked) = PROXIES.with(|p| {
         p.borrow()
             .get(id as usize)


### PR DESCRIPTION
## Problem

Two related bugs on the proxy `[[Get]]` forwarding path:

1. **Numeric index keys reached the get trap un-stringified.** A computed read on a statically-known proxy — `proxy[10]` — lowers to `js_proxy_get(proxy, 10.0)`, passing the raw number. `[[Get]] ( P, Receiver )` is defined over an already-computed property *key*, so the trap must see the canonical string `"10"`. Perry handed the trap a raw number, so a trap doing `key === "10"` silently missed and the read returned `undefined`.

2. **A proxy in the prototype chain crashed.** `Object.create(proxy).x` records the proxy as `o`'s prototype. Resolving the inherited read (`resolve_inherited_field`) took the proxy's small fake pointer — which lives in the proxy id band and passes the loose heap-range check — and dereferenced it as an `ObjectHeader`, a SIGSEGV.

```js
var target = new Proxy({}, { get: (t, k) => (k === "10" ? 2 : undefined) });
var proxy  = new Proxy(target, { get: null });

proxy[10];                    // was undefined, should be 2
Object.create(proxy)[10];     // was a SIGSEGV
```

## Fix

- `js_proxy_get`: apply `ToPropertyKey` to the incoming key (numeric `10` → `"10"`) before dispatching the trap and before forwarding to the target. Keys that are already a string (the common `proxy.foo` case) or a symbol short-circuit, so `ToPropertyKey` only runs for the numeric / object-index forms.
- `resolve_inherited_field`: when the recorded prototype is a registered proxy, route the inherited read through the proxy's `[[Get]]` (binding the original instance as the receiver) instead of dereferencing the fake pointer.

## Tests

Fixes test262 `built-ins/Proxy/get/trap-is-null-target-is-proxy`.

Verified on an internal Linux sweep host: `built-ins/Proxy` +1 passing, and no regressions across the `built-ins/{Array,Object,Proxy}` slice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inherited property lookups so objects using proxy-based prototypes no longer crash in edge cases.
  * Improved proxy property access to handle numeric and object-style keys consistently, so property reads now match expected JavaScript behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->