### PR TITLE
fix(runtime): enforce preventExtensions/seal on function objects

### DIFF
--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -1385,6 +1385,25 @@ fn ordinary_set_with_receiver(target: f64, key: f64, value: f64, receiver: f64) 
                 ) {
                     return true;
                 }
+                // `Object.preventExtensions(fn)` / `Object.seal(fn)` set
+                // NO_EXTEND / SEALED in the closure's GcHeader (functions are
+                // GcHeader-backed closures). A [[Set]] that would ADD a new own
+                // property must fail (OrdinaryDefineOwnProperty returns false,
+                // silent in non-strict, TypeError in strict); an existing own
+                // key can still be updated. (test262
+                // Object/preventExtensions/15.2.3.10-3-{3,13}.)
+                if !crate::closure::closure_has_own_dynamic_prop(cur_ptr, &name) {
+                    let non_extensible = unsafe {
+                        let gc = (cur_ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE)
+                            as *const crate::gc::GcHeader;
+                        (*gc)._reserved
+                            & (crate::gc::OBJ_FLAG_NO_EXTEND | crate::gc::OBJ_FLAG_SEALED)
+                            != 0
+                    };
+                    if non_extensible {
+                        return false;
+                    }
+                }
             }
             return create_or_update_receiver_property(receiver, key, value);
         }


### PR DESCRIPTION
## Problem

`Object.preventExtensions(fn)` / `Object.seal(fn)` set the NO_EXTEND / SEALED flag in a function's header (functions are GcHeader-backed closures), and `Object.isExtensible` correctly reported `false` afterwards — but the property-write path never consulted the flag, so a subsequent `fn.newProp = v` still created the property:

```js
var fn = function () {};
Object.preventExtensions(fn);
fn.exName = 1;
fn.hasOwnProperty("exName");   // was true, should be false
```

## Fix

In `ordinary_set_with_receiver`'s closure branch (the `[[Set]]` path that materializes a new own property on a function), before creating a **new** own property, check the closure's GcHeader for `OBJ_FLAG_NO_EXTEND` / `OBJ_FLAG_SEALED`. If set, the set fails (`OrdinaryDefineOwnProperty` returns false — silent in non-strict, TypeError in strict via the existing `js_put_value_set` strict handling). An existing own key can still be updated; only new-key creation is blocked.

## Tests

Fixes test262:

- `built-ins/Object/preventExtensions/15.2.3.10-3-3`
- `built-ins/Object/preventExtensions/15.2.3.10-3-13`

Verified on an internal Linux sweep host against the full `built-ins/Object` (and `built-ins/Array`) slice: +2 passing, **zero regressions** — an existing own property on a non-extensible function is still writable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `Object.preventExtensions()` and `Object.seal()` now correctly block adding new properties to function objects.
  * Existing properties on function objects can still be updated as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->