### PR TITLE
fix(runtime): latch array iterator done state after exhaustion

### DIFF
--- a/crates/perry-runtime/src/array/iter_object.rs
+++ b/crates/perry-runtime/src/array/iter_object.rs
@@ -359,6 +359,14 @@ pub unsafe fn dispatch_array_iterator_method(
             // Field 0: backing array pointer (NaN-boxed).
             let backing_field = js_object_get_field(iter_obj, 0);
             let backing_f64 = f64::from_bits(backing_field.bits());
+            // Once the iterator is exhausted the backing array is cleared to
+            // `undefined` (spec: `[[IteratedArrayLike]]` set to undefined), so a
+            // later `.next()` stays done even if the array grew after exhaustion
+            // (test262 Array/prototype/{values,keys,entries}/iteration-mutable:
+            // pushing AFTER the iterator reported done must not resurface).
+            if JSValue::from_bits(backing_f64.to_bits()).is_undefined() {
+                return make_iter_result(JSValue::undefined(), true);
+            }
             let arr_ptr = js_nanbox_get_pointer(backing_f64) as *const ArrayHeader;
             // Field 1: current index.
             let idx_field = js_object_get_field(iter_obj, 1);
@@ -374,6 +382,7 @@ pub unsafe fn dispatch_array_iterator_method(
             };
 
             if idx >= len {
+                js_object_set_field(iter_obj, 0, JSValue::undefined());
                 return make_iter_result(JSValue::undefined(), true);
             }
 


### PR DESCRIPTION
## Problem

An array iterator (`arr.values()` / `arr.keys()` / `arr.entries()`) re-read the backing array's length on every `.next()` and never latched a "done" state. Once the iterator was exhausted, pushing a new element and calling `.next()` again resurfaced the new element:

```js
var array = [];
var it = array.values();
array.push('a');
it.next();            // { value: 'a', done: false }
it.next();            // { value: undefined, done: true }  — exhausted
array.push('b');
it.next();            // was { value: 'b', done: false }, should stay done
```

Per spec (22.1.5.2.1), when the iterator finishes it sets `[[IteratedArrayLike]]` to undefined, so it stays done regardless of later mutation.

## Fix

On the exhausted branch (`idx >= len`), clear the backing-array field to `undefined`, and short-circuit to `{ value: undefined, done: true }` when that field is already undefined. Elements added while the iterator is still live (before exhaustion) are unaffected — only additions *after* exhaustion stay invisible.

## Tests

Fixes test262:

- `built-ins/Array/prototype/values/iteration-mutable`
- `built-ins/Array/prototype/keys/iteration-mutable`
- `built-ins/Array/prototype/entries/iteration-mutable`

Verified on an internal Linux sweep host against the full `built-ins/Array` slice: +3 passing, no regressions (grow-while-live and entries/keys/values pair shapes still correct).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Array iterators now stay finished after exhaustion, so repeated `.next()` calls consistently return `done: true`.
  - Changes to the original array after iteration completes no longer cause a completed iterator to resume yielding items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->