### PR TITLE
fix(runtime): #6006 — content-validate shape transition-cache edges (stale-pointer false match)

### DIFF
--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -769,16 +769,6 @@ fn transition_cache_slot(prev_keys: usize, key_ptr: usize) -> usize {
     (mixed as usize) & (TRANSITION_CACHE_SIZE - 1)
 }
 
-/// Transition cache lookup using interned string pointer identity.
-///
-/// On HIT we ensure the returned keys_array has
-/// `GC_FLAG_SHAPE_SHARED` because the caller is about to reuse it for
-/// a SECOND object — any future extension on either object must now
-/// clone-before-mutate. We eagerly stabilize small dynamic shapes on
-/// insert so repeated row-object builders get valid cache targets;
-/// larger shapes stay lazy to avoid O(N²) prefix cloning for one-off
-/// dictionaries and are validated on lookup.
-#[inline(always)]
 /// #6006: verify the cached transition edge really adds `key` at `slot_idx`,
 /// i.e. `next_keys[slot_idx]` string-matches `key`. Guards against a stale
 /// pointer-keyed cache entry (freed keys_array address recycled by GC) that
@@ -815,6 +805,16 @@ fn transition_edge_places_key(
     }
 }
 
+/// Transition cache lookup using interned string pointer identity.
+///
+/// On HIT we ensure the returned keys_array has
+/// `GC_FLAG_SHAPE_SHARED` because the caller is about to reuse it for
+/// a SECOND object — any future extension on either object must now
+/// clone-before-mutate. We eagerly stabilize small dynamic shapes on
+/// insert so repeated row-object builders get valid cache targets;
+/// larger shapes stay lazy to avoid O(N²) prefix cloning for one-off
+/// dictionaries and are validated on lookup.
+#[inline(always)]
 fn transition_cache_lookup(
     prev_keys: usize,
     interned_key: *const crate::StringHeader,

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -779,6 +779,35 @@ fn transition_cache_slot(prev_keys: usize, key_ptr: usize) -> usize {
 /// larger shapes stay lazy to avoid O(N²) prefix cloning for one-off
 /// dictionaries and are validated on lookup.
 #[inline(always)]
+/// #6006: verify the cached transition edge really adds `key` at `slot_idx`,
+/// i.e. `next_keys[slot_idx]` string-matches `key`. Guards against a stale
+/// pointer-keyed cache entry (freed keys_array address recycled by GC) that
+/// pointer-matches but describes a different shape. Returns false on any
+/// structural mismatch so the caller falls back to the (correct) slow path.
+#[inline]
+fn transition_edge_places_key(
+    next_keys: usize,
+    slot_idx: u32,
+    key: *const crate::StringHeader,
+) -> bool {
+    if next_keys < crate::gc::GC_HEADER_SIZE || key.is_null() {
+        return false;
+    }
+    unsafe {
+        let gc_header = (next_keys as *const u8).wrapping_sub(crate::gc::GC_HEADER_SIZE)
+            as *const crate::gc::GcHeader;
+        if (*gc_header).obj_type != crate::gc::GC_TYPE_ARRAY {
+            return false;
+        }
+        let keys = next_keys as *const ArrayHeader;
+        if slot_idx >= (*keys).length {
+            return false;
+        }
+        let stored = crate::array::js_array_get(keys, slot_idx);
+        crate::string::js_string_key_matches(stored, key)
+    }
+}
+
 fn transition_cache_lookup(
     prev_keys: usize,
     interned_key: *const crate::StringHeader,
@@ -787,6 +816,19 @@ fn transition_cache_lookup(
     let slot = transition_cache_slot(prev_keys, kp);
     let entry = with_transition_cache(|t| unsafe { (*t)[slot] });
     if entry.next_keys != 0 && entry.prev_keys == prev_keys && entry.key_ptr == kp {
+        // #6006: `prev_keys` / `key_ptr` are raw addresses, NOT GC roots (only
+        // `next_keys` is scanned/relocated). After GC frees a keys_array and
+        // recycles its address into an unrelated array, a stale entry here can
+        // pointer-match falsely — the object would then adopt `next_keys` and
+        // store the value at `slot_idx`, which belongs to a *different* shape.
+        // At bundle scale (frequent GC address reuse) this silently mis-places
+        // property values (keys_array looks right, but reads return undefined
+        // for the mis-slotted keys). Content-validate that the cached
+        // transition actually places THIS key at `slot_idx` before trusting it;
+        // a genuine edge always does, a recycled-address false match never will.
+        if !transition_edge_places_key(entry.next_keys, entry.slot_idx, interned_key) {
+            return None;
+        }
         let expected_len = entry.slot_idx.checked_add(1)?;
         if entry.target_len == expected_len {
             return Some((entry.next_keys, entry.slot_idx));

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -800,7 +800,14 @@ fn transition_edge_places_key(
             return false;
         }
         let keys = next_keys as *const ArrayHeader;
-        if slot_idx >= (*keys).length {
+        // A single-key transition edge (prev + key) always produces a target
+        // shape of exactly `slot_idx + 1` keys, with `key` at the last slot.
+        // Requiring the EXACT length (not just `slot_idx < length`) also
+        // rejects the "shared target grew in place after caching" case — where
+        // the cached `target_len` still matches but the actual array is now
+        // longer, so adopting it would give the object a keys_array with more
+        // keys than field_count tracks (keys present, values undefined).
+        if (*keys).length != slot_idx.wrapping_add(1) {
             return false;
         }
         let stored = crate::array::js_array_get(keys, slot_idx);

--- a/crates/perry-runtime/src/object/tests.rs
+++ b/crates/perry-runtime/src/object/tests.rs
@@ -715,7 +715,10 @@ fn transition_cache_lookup_rejects_grown_shared_target() {
     let keys2 = crate::array::js_array_push(keys, JSValue::string_ptr(extra));
     // `js_array_push` grows in place when capacity allows (cap was 4), so the
     // cached `next_keys` pointer still points at the now-length-2 array.
-    assert_eq!(keys2, keys, "test setup: push must grow in place, not realloc");
+    assert_eq!(
+        keys2, keys,
+        "test setup: push must grow in place, not realloc"
+    );
 
     assert!(
         transition_cache_lookup(0, key).is_none(),

--- a/crates/perry-runtime/src/object/tests.rs
+++ b/crates/perry-runtime/src/object/tests.rs
@@ -692,6 +692,50 @@ fn transition_cache_lookup_rejects_slot_key_mismatch() {
 }
 
 #[test]
+fn transition_cache_lookup_rejects_grown_shared_target() {
+    // #6006: a cached edge's `target_len` is a snapshot. The shared target
+    // keys_array can grow IN PLACE after caching (a later object extends the
+    // same shape), so `target_len == slot_idx + 1` still passes while the
+    // actual array is now longer. Adopting it would give the object a
+    // keys_array with more keys than field_count tracks — keys present, values
+    // undefined. The exact-length content check must catch the grown array.
+    let key = crate::string::js_string_from_bytes(b"gamma".as_ptr(), 5);
+    let extra = crate::string::js_string_from_bytes(b"delta".as_ptr(), 5);
+
+    // A 1-key target with spare capacity, cached as a slot-0 edge (target_len=1).
+    let keys = crate::array::js_array_alloc(4);
+    let keys = crate::array::js_array_push(keys, JSValue::string_ptr(key));
+    transition_cache_insert(0, key, keys as usize, 0);
+    assert!(
+        transition_cache_lookup(0, key).is_some(),
+        "sanity: a genuine 1-key edge hits before the target grows (#6006)"
+    );
+
+    // Grow the SAME array in place to length 2 (as a sibling object would).
+    let keys2 = crate::array::js_array_push(keys, JSValue::string_ptr(extra));
+    // `js_array_push` grows in place when capacity allows (cap was 4), so the
+    // cached `next_keys` pointer still points at the now-length-2 array.
+    assert_eq!(keys2, keys, "test setup: push must grow in place, not realloc");
+
+    assert!(
+        transition_cache_lookup(0, key).is_none(),
+        "a cache edge whose shared target grew past slot_idx+1 must be rejected (#6006)"
+    );
+
+    let slot = transition_cache_slot(0, key as usize);
+    with_transition_cache(|t| unsafe {
+        // GC_STORE_AUDIT(ROOT): test cleanup writes non-pointer sentinels into scanned TRANSITION_CACHE_GLOBAL roots.
+        (*t)[slot] = TransitionEntry {
+            prev_keys: 0,
+            key_ptr: 0,
+            next_keys: 0,
+            slot_idx: 0,
+            target_len: 0,
+        };
+    });
+}
+
+#[test]
 fn entries_and_values_skip_non_enumerable_descriptor_slots() {
     // #5046: Object.defineProperty(o, 'hidden', { value: 1 }) defaults to
     // enumerable: false. Object.keys filtered it; entries/values did not.

--- a/crates/perry-runtime/src/object/tests.rs
+++ b/crates/perry-runtime/src/object/tests.rs
@@ -644,6 +644,54 @@ fn transition_cache_lookup_rejects_mutated_edge_target() {
 }
 
 #[test]
+fn transition_cache_lookup_rejects_slot_key_mismatch() {
+    // #6006: `prev_keys` / `key_ptr` are raw addresses that GC does not
+    // relocate. When GC frees a keys_array and recycles its address into an
+    // unrelated array, a stale entry can pointer-match a *different* shape —
+    // one where `next_keys[slot_idx]` is a DIFFERENT key. Adopting that edge
+    // would store the value at the wrong slot (keys_array looks right but the
+    // read returns undefined). The content check must reject such an edge so
+    // the caller falls back to the correct slow path.
+    let want = crate::string::js_string_from_bytes(b"alpha".as_ptr(), 5);
+    let other = crate::string::js_string_from_bytes(b"beta".as_ptr(), 4);
+
+    // A target shape whose slot 0 holds `beta`, not `alpha`.
+    let keys = crate::array::js_array_alloc(4);
+    let keys = crate::array::js_array_push(keys, JSValue::string_ptr(other));
+
+    // Insert an edge keyed on (prev=0, `alpha`) but targeting the `beta` shape,
+    // mirroring a recycled-address false match (target_len is set because the
+    // length matches slot_idx+1, so only the content check can catch it).
+    transition_cache_insert(0, want, keys as usize, 0);
+
+    assert!(
+        transition_cache_lookup(0, want).is_none(),
+        "a cache edge whose target slot holds a different key must be rejected (#6006)"
+    );
+
+    // Sanity: an edge whose target slot DOES hold the key still hits.
+    let good_keys = crate::array::js_array_alloc(4);
+    let good_keys = crate::array::js_array_push(good_keys, JSValue::string_ptr(want));
+    transition_cache_insert(0, want, good_keys as usize, 0);
+    assert!(
+        transition_cache_lookup(0, want).is_some(),
+        "a genuine edge (target slot holds the key) must still hit (#6006)"
+    );
+
+    let slot = transition_cache_slot(0, want as usize);
+    with_transition_cache(|t| unsafe {
+        // GC_STORE_AUDIT(ROOT): test cleanup writes non-pointer sentinels into scanned TRANSITION_CACHE_GLOBAL roots.
+        (*t)[slot] = TransitionEntry {
+            prev_keys: 0,
+            key_ptr: 0,
+            next_keys: 0,
+            slot_idx: 0,
+            target_len: 0,
+        };
+    });
+}
+
+#[test]
 fn entries_and_values_skip_non_enumerable_descriptor_slots() {
     // #5046: Object.defineProperty(o, 'hidden', { value: 1 }) defaults to
     // enumerable: false. Object.keys filtered it; entries/values did not.


### PR DESCRIPTION
## Problem

`transition_cache_lookup` (perry-runtime `object/mod.rs`) validates a cache hit by **raw pointer equality**:

```rust
if entry.next_keys != 0 && entry.prev_keys == prev_keys && entry.key_ptr == kp {
```

But `prev_keys` and `key_ptr` are plain `usize` addresses that the GC does **not** track or relocate — only `next_keys` is a scanned root (stored via `runtime_store_root_usize_slot`, see `transition_cache_insert`). When the GC frees a keys_array and later **recycles that same address** for an unrelated array, a stale entry pointer-matches falsely. The object then adopts the cached `next_keys` shape and stores the value at the cached `slot_idx`, which belongs to a **different shape**. The keys_array ends up looking correct (`Object.keys` is fine), but value slots are mis-placed, so property reads return `undefined` for the mis-slotted keys.

This is a real GC-safety hole. It only manifests at scale, where the GC actually recycles keys_array addresses — a large app's dynamically-grown objects silently lose property values past a leading prefix. Every isolated reproduction passes (no GC pressure → no address reuse → no false match), which is what makes it so slippery.

Observed on a 13 MB bundle: an HTTP header set built by repeated `obj[k]=v` lost several headers (they read back `undefined`, got dropped from serialization). This PR is **one** contributor to that symptom (#6006) — it demonstrably improves it (a request that consistently 404'd on a missing beta header now reaches 200) but the header-desync symptom has at least one additional cause still under investigation, so #6006 stays open.

## Fix

`transition_edge_places_key(next_keys, slot_idx, key)` — before trusting a cached edge, content-validate that `next_keys[slot_idx]` actually string-matches the key being stored. A genuine transition always places the key there; a recycled-address false match never will, so the lookup returns `None` and the caller falls back to the correct slow path.

The check can only ever make a lookup **more conservative** (reject an unverifiable edge → slow path, which is always correct) — it can never adopt a wrong shape, so it cannot introduce incorrectness; worst case is a marginal extra slow-path fallback. It guards all three fast-write callers through the single `transition_cache_lookup` choke point.

## Test

`transition_cache_lookup_rejects_slot_key_mismatch` inserts an edge whose target slot holds a **different** key (with `target_len` matching `slot_idx+1`, so only the content check can catch it), asserts the lookup rejects it, and that a genuine edge still hits. **Fails without the fix, passes with it.** Full perry-runtime suite green (1153 tests).

Refs #6006.

https://claude.ai/code/session_01K1w6WLaFNKhf4aNxeSWHy6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of cached object transition lookups by validating cache entries before using them.
  * Prevented stale or incompatible cached mappings from being reused when the cached target’s stored key or the target array length/shape no longer matches.

* **Tests**
  * Added regression coverage for stale transition-cache edges and for cases where the underlying target keys array changes after caching, ensuring lookups correctly return no hit when inconsistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->