### PR TITLE
fix(system): getDeviceModel/getOSVersion return a string, not NaN (#5972)

### DIFF
--- a/crates/perry-dispatch/src/system_table.rs
+++ b/crates/perry-dispatch/src/system_table.rs
@@ -166,21 +166,28 @@ pub static PERRY_SYSTEM_TABLE: &[MethodRow] = &[
         args: &[ArgKind::F64],
         ret: ReturnKind::F64,
     },
+    // Returns the device model identifier (e.g. "iPhone15,2") as a JS
+    // string. The runtime fn returns a raw `*mut StringHeader` (i64) via
+    // `js_string_from_bytes`, so the return kind MUST be `Str` (NaN-box
+    // with STRING_TAG) — same as `getLocale` below. `F64` would pass the
+    // raw pointer bits through as a double → `NaN`, and any downstream use
+    // (e.g. `table[getDeviceModel()]`) then dereferences NaN as a string
+    // pointer and segfaults (#5972).
     MethodRow {
         method: "getDeviceModel",
         runtime: "perry_system_get_device_model",
         args: &[],
-        ret: ReturnKind::F64,
+        ret: ReturnKind::Str,
     },
-    // Bug-report-flow utility: stable OS-version string per
-    // platform. Returns a NaN-boxed JS string the user can splice
-    // into crash reports / telemetry. Same dispatch shape as
-    // getDeviceModel.
+    // Bug-report-flow utility: stable OS-version string per platform,
+    // for splicing into crash reports / telemetry. Same raw
+    // `*mut StringHeader` return shape as `getDeviceModel` — must be
+    // `Str`, not `F64` (#5972).
     MethodRow {
         method: "getOSVersion",
         runtime: "perry_system_get_os_version",
         args: &[],
-        ret: ReturnKind::F64,
+        ret: ReturnKind::Str,
     },
     MethodRow {
         method: "audioSetOutputFilename",

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -27,6 +27,18 @@ pub extern "C" fn js_object_get_field_by_name(
     obj: *const ObjectHeader,
     key: *const crate::StringHeader,
 ) -> JSValue {
+    // #5972: a null key reaches here when the property-key expression didn't
+    // yield a usable string handle — e.g. `js_get_string_pointer_unified`
+    // returned 0 for a NaN/number key that fell through its coercion branches.
+    // Several arms below deref `(*key).byte_len` without a null check, so a
+    // null key would SIGSEGV at offset 4 (KERN_INVALID_ADDRESS at 0x4). Per JS
+    // semantics such a lookup simply misses → undefined. Same defensive shape
+    // as the #2128 invalid-key guard further down. Every in-runtime caller
+    // passes an interned non-null key, so this only affects the codegen
+    // computed-access path.
+    if key.is_null() {
+        return JSValue::undefined();
+    }
     // #2846: the receiver may be a Proxy value that arrived through a generic
     // property read (e.g. `rec.proxy.a` where `rec = Proxy.revocable(...)`).
     // Proxies are encoded as small fake pointers; deref-ing one as an
@@ -1015,4 +1027,33 @@ pub extern "C" fn js_object_get_field_by_name(
         }
     }
     get_field_by_name_object_tail(obj, key)
+}
+
+#[cfg(test)]
+mod null_key_guard_5972 {
+    use super::*;
+
+    /// #5972 part 2: a null key (produced when a NaN/number property-key
+    /// coerces to no usable string handle) must miss → `undefined`, never
+    /// SIGSEGV by dereferencing `(*key).byte_len` at offset 4.
+    #[test]
+    fn null_key_returns_undefined_not_segfault() {
+        unsafe {
+            let obj = crate::object::js_object_alloc(0, 0);
+            let key = crate::string::js_string_from_bytes(b"present".as_ptr(), 7);
+            crate::object::js_object_set_field_by_name(obj, key, 42.0);
+
+            // Sanity: the real key resolves.
+            let hit = js_object_get_field_by_name(obj, key);
+            assert_eq!(f64::from_bits(hit.bits()), 42.0);
+
+            // The regression: a null key must not crash and must read undefined.
+            let miss = js_object_get_field_by_name(obj, std::ptr::null());
+            assert_eq!(
+                miss.bits(),
+                crate::value::TAG_UNDEFINED,
+                "null key should miss → undefined"
+            );
+        }
+    }
 }

--- a/crates/perry/tests/issue_5972_getdevicemodel_object_key.rs
+++ b/crates/perry/tests/issue_5972_getdevicemodel_object_key.rs
@@ -1,0 +1,142 @@
+//! Regression test for #5972: `getDeviceModel()` returned `NaN` instead of a
+//! JS string, and using that value as an object key segfaulted.
+//!
+//! Two stacked bugs, both fixed:
+//!  1. `perry/system` `getDeviceModel` / `getOSVersion` were declared
+//!     `ReturnKind::F64` in the dispatch table, but their runtime fns return a
+//!     raw `*mut StringHeader` (i64) via `js_string_from_bytes`. `F64` passed
+//!     the pointer bits straight through as a double → `NaN`. Fixed to
+//!     `ReturnKind::Str` (NaN-box with STRING_TAG), matching `getLocale`.
+//!  2. A property-key expression that yields no usable string handle (e.g.
+//!     `js_get_string_pointer_unified` returning 0 for a NaN key) reached
+//!     `js_object_get_field_by_name` as a null key, which several arms
+//!     dereferenced without a null check → SIGSEGV at offset 4. Now guarded:
+//!     a null key misses → `undefined`, per JS semantics.
+//!
+//! The program mirrors the dbmeter calibration-table shape that first hit this:
+//! look up a `Record<string, number>` keyed by `getDeviceModel()` at module
+//! top level. On any host it must run without crashing and take the
+//! unknown-device default (the CI host's model isn't in the table).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary crashed (status {:?}) — #5972 regression\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+/// Part 1: `getDeviceModel()` is a real string, and indexing a
+/// `Record<string, number>` with it works (known key hits, unknown misses).
+#[test]
+fn get_device_model_is_a_string_usable_as_object_key() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+import { getDeviceModel } from "perry/system";
+import { Text } from "perry/ui"; // pull in the UI backend that defines perry_system_*
+
+const offsets: Record<string, number> = {
+  "iPhone15,2": 1.0,
+  "Watch7,5": 1.3,
+};
+
+function offsetFor(model: string): number {
+  const o = offsets[model];
+  return o !== undefined ? o : 0.0;
+}
+
+const model = getDeviceModel();
+// typeof must be "string", never "number" (was NaN → "number").
+console.log("TYPE", typeof model);
+// A known key hits; an unknown key misses → default. The host's real
+// model is (almost certainly) not in the table, so it takes the default
+// WITHOUT crashing — that is the #5972 repro.
+console.log("KNOWN", offsetFor("iPhone15,2"));
+console.log("HOST", offsetFor(model));
+const _t = Text("keep the UI backend linked");
+console.log("DONE");
+"#,
+    );
+    assert!(
+        stdout.contains("TYPE string"),
+        "getDeviceModel must be a string, not NaN: {stdout}"
+    );
+    assert!(stdout.contains("KNOWN 1"), "known-key lookup: {stdout}");
+    assert!(
+        stdout.contains("HOST 0"),
+        "unknown host model → default 0 without crash: {stdout}"
+    );
+    assert!(
+        stdout.contains("DONE"),
+        "reached end without crash: {stdout}"
+    );
+}
+
+/// Part 2 (defense-in-depth): indexing an object with a numeric / NaN key
+/// through a type-erased receiver must never segfault. Per JS the key coerces
+/// to a string and the lookup misses → `undefined`.
+#[test]
+fn numeric_and_nan_object_keys_do_not_crash() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const obj: any = { "1": "one", "NaN": "not-a-number" };
+
+const numKey: any = 1;
+const nanKey: any = NaN;
+const floatKey: any = 2.5;
+
+// obj[1] → obj["1"]; obj[NaN] → obj["NaN"]; obj[2.5] → obj["2.5"] (miss).
+console.log("NUM", obj[numKey]);
+console.log("NAN", obj[nanKey]);
+console.log("FLOAT", String(obj[floatKey]));
+console.log("DONE");
+"#,
+    );
+    assert!(stdout.contains("NUM one"), "numeric key coercion: {stdout}");
+    assert!(
+        stdout.contains("NAN not-a-number"),
+        "NaN key coerces to \"NaN\": {stdout}"
+    );
+    assert!(
+        stdout.contains("FLOAT undefined"),
+        "unknown float key misses → undefined: {stdout}"
+    );
+    assert!(stdout.contains("DONE"), "no crash: {stdout}");
+}


### PR DESCRIPTION
## Summary

`getDeviceModel()` (and `getOSVersion()`) returned `NaN` instead of a JS string, and using that value as an object key segfaulted at startup (`EXC_BAD_ACCESS`, `KERN_INVALID_ADDRESS at 0x4`). Found while migrating a real app (dbmeter — a decibel meter whose calibration `Record<string, number>` is keyed by device model at module scope). Two stacked bugs, both fixed.

## Changes

### 1. Dispatch return kind (the actual bug)
`perry_system_get_device_model` / `perry_system_get_os_version` return a raw `*mut StringHeader` (i64) via `js_string_from_bytes` — the same shape as `getLocale`, which is correctly `ReturnKind::Str`. But both were declared `ReturnKind::F64`. The LLVM backend lowers `F64` as `call(DOUBLE, …)` and passes the result straight through, so the raw pointer bits are reinterpreted as an `f64` → `NaN` (`typeof` reads `"number"`). Changed both rows to `ReturnKind::Str`, which calls with an `i64` return and NaN-boxes the handle with `STRING_TAG` into a real JS string.

Only the LLVM backend consumes `ReturnKind`; `perry-codegen-js` / `perry-codegen-wasm` use the table solely for the method→symbol name map (`ui_method_to_runtime`), so the web/wasm backends are unaffected.

### 2. Null-key segfault guard (defense-in-depth)
When a property-key expression doesn't yield a usable string handle — e.g. `js_get_string_pointer_unified` returns `0` for a NaN key that falls through its coercion branches — a null key reached `js_object_get_field_by_name`, whose arms dereference `(*key).byte_len` without a null check → SIGSEGV at offset 4. Added an early guard: a null key misses → `undefined`, per JS semantics (same defensive shape as the existing #2128 invalid-key guard). Every in-runtime caller passes an interned non-null key, so only the codegen computed-access path is affected. This converts any future type-unsound value from a memory-corruption crash into a defined miss.

## Related issue

Fixes #5972.

## Test plan

- [x] `cargo build --release -p perry` clean
- [x] New e2e regression: `crates/perry/tests/issue_5972_getdevicemodel_object_key.rs` (2 tests) — pass
  - `get_device_model_is_a_string_usable_as_object_key`: `typeof getDeviceModel()` is `"string"`; known key hits; the host's real model misses → default, **without crashing** (the exact repro shape)
  - `numeric_and_nan_object_keys_do_not_crash`: numeric/NaN/float keys through a type-erased receiver, output matches the node oracle (`NUM one` / `NAN not-a-number` / `FLOAT undefined`)
- [x] New runtime unit test `null_key_guard_5972::null_key_returns_undefined_not_segfault` — pass
- [x] `cargo test -p perry-runtime object::` — 38/38 pass single-threaded (one parallel-only pre-existing flake in `closure_name_and_length_ignore_plain_assignment`, unrelated: shared closure side-tables; it uses only non-null keys so the null-key guard can't affect it, and it passes in isolation)
- [x] Manually verified the fix against the real app: dbmeter now compiles and runs on macOS without the startup crash, and `getDeviceModel()` returns the real host model (`MacBookPro18,2`)

## Before / after (8-line repro from the issue, macOS)

```ts
import { getDeviceModel } from "perry/system";
import { Text } from "perry/ui";
const offsets: Record<string, number> = { "iPhone15,2": 1.0 };
const model = getDeviceModel();
console.log(typeof model, model);
console.log(offsets[model] ?? 0);   // before: SIGSEGV
```

- **Before:** `typeof` is `number`, value `NaN`; the lookup segfaults.
- **After:** `string MacBookPro18,2`; lookup returns `0` (miss) cleanly.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `fix:` prefix convention used in the log
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated device model and OS version to return proper JavaScript strings (instead of number-like values), improving reliability when used as text and object keys.
  * Prevented possible crashes during object property lookups when the property key is null or otherwise unusual, returning `undefined` safely instead.

* **Tests**
  * Added a regression test suite covering the crash fixes and verifying correct JavaScript coercion/lookup semantics (including known-key hits and safe misses).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->