### PR TITLE
fix(runtime): fire process.stdin 'end'/'close' listeners on EOF

### DIFF
--- a/crates/perry-runtime/src/os_process_streams.rs
+++ b/crates/perry-runtime/src/os_process_streams.rs
@@ -156,6 +156,16 @@ static STDIN_READABLE_LISTENERS: std::sync::Mutex<Vec<i64>> = std::sync::Mutex::
 // `once()` listeners — fired exactly once then cleared, per EventEmitter.
 static STDIN_DATA_ONCE: std::sync::Mutex<Vec<i64>> = std::sync::Mutex::new(Vec::new());
 static STDIN_READABLE_ONCE: std::sync::Mutex<Vec<i64>> = std::sync::Mutex::new(Vec::new());
+// `end`/`close` listeners. Node fires `'end'` on stdin EOF; code that reads a
+// prompt via `process.stdin.once('end', …)` (racing a timeout) relies on it.
+// These fire from the main-thread pump once the reader hits EOF and the byte
+// buffer has drained (so `'data'` precedes `'end'`, per Node).
+static STDIN_END_LISTENERS: std::sync::Mutex<Vec<i64>> = std::sync::Mutex::new(Vec::new());
+static STDIN_END_ONCE: std::sync::Mutex<Vec<i64>> = std::sync::Mutex::new(Vec::new());
+// Set by the reader thread on fd-0 EOF; observed by the main-thread pump.
+static STDIN_EOF_SEEN: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+// Set once the `'end'`/`'close'` listeners have fired, so they fire at most once.
+static STDIN_END_FIRED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 static STDIN_READER_STARTED: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
@@ -186,7 +196,15 @@ fn ensure_stdin_reader() {
                     break;
                 }
                 match handle.read(&mut byte) {
-                    Ok(0) => break, // EOF
+                    Ok(0) => {
+                        // EOF: record it so the main-thread pump can fire JS
+                        // `'end'`/`'close'` listeners after the buffer drains,
+                        // and wake the loop so a final pump runs even when no
+                        // more bytes arrive (e.g. `< /dev/null`).
+                        STDIN_EOF_SEEN.store(true, std::sync::atomic::Ordering::Release);
+                        crate::event_pump::js_notify_main_thread();
+                        break;
+                    }
                     Ok(_) => {
                         if let Ok(mut q) = STDIN_BUFFER.lock() {
                             q.push(byte[0]);
@@ -247,7 +265,7 @@ fn register_stdin_listener(
     }
     let target = if is_once { once } else { persistent };
     match stdin_event_name(event).as_deref() {
-        Some("data") | Some("readable") => {
+        Some("data") | Some("readable") | Some("end") | Some("close") => {
             if let Ok(mut l) = target.lock() {
                 // EventEmitter allows the same listener registered multiple
                 // times; only `on` callers dedupe in practice, but each
@@ -257,6 +275,7 @@ fn register_stdin_listener(
                     l.push(cb);
                 }
             }
+            // Starting the reader lets it observe EOF, which drives `'end'`.
             ensure_stdin_reader();
         }
         _ => {}
@@ -289,6 +308,13 @@ extern "C" fn process_stdin_on(
                 &STDIN_READABLE_ONCE,
                 false,
             ),
+            Some("end") | Some("close") => register_stdin_listener(
+                event,
+                callback,
+                &STDIN_END_LISTENERS,
+                &STDIN_END_ONCE,
+                false,
+            ),
             _ => {}
         }
     }
@@ -316,6 +342,13 @@ extern "C" fn process_stdin_once(
                 callback,
                 &STDIN_READABLE_LISTENERS,
                 &STDIN_READABLE_ONCE,
+                true,
+            ),
+            Some("end") | Some("close") => register_stdin_listener(
+                event,
+                callback,
+                &STDIN_END_LISTENERS,
+                &STDIN_END_ONCE,
                 true,
             ),
             _ => {}
@@ -362,6 +395,13 @@ extern "C" fn process_stdin_resume(
 /// listeners (ink's flowing path) get the bytes directly; otherwise `readable`
 /// listeners are notified and pull via `read()`.
 pub fn pump_process_stdin() {
+    // Deliver any buffered bytes as `'data'`/`'readable'` first, then — once the
+    // reader has hit EOF and the buffer is empty — dispatch `'end'`/`'close'`.
+    pump_stdin_data_chunks();
+    maybe_fire_stdin_end();
+}
+
+fn pump_stdin_data_chunks() {
     let has_bytes = STDIN_BUFFER.lock().map(|b| !b.is_empty()).unwrap_or(false);
     if !has_bytes {
         return;
@@ -425,6 +465,57 @@ pub fn pump_process_stdin() {
     }
 }
 
+/// Fire `process.stdin` `'end'`/`'close'` listeners once the reader has hit EOF
+/// and all buffered bytes have drained (so `'data'` precedes `'end'`, per Node).
+/// Runs on the main thread from the pump, so calling JS is safe here. Idempotent:
+/// the `STDIN_END_FIRED` latch guarantees at-most-once, and we only latch when
+/// there is at least one listener to fire so a listener attached shortly after
+/// EOF (the prompt-reader race) still runs.
+fn maybe_fire_stdin_end() {
+    use std::sync::atomic::Ordering;
+    if !STDIN_EOF_SEEN.load(Ordering::Acquire) || STDIN_END_FIRED.load(Ordering::Acquire) {
+        return;
+    }
+    // Node emits `'end'` only after the readable side is fully consumed.
+    let has_bytes = STDIN_BUFFER.lock().map(|b| !b.is_empty()).unwrap_or(false);
+    if has_bytes {
+        return;
+    }
+    let mut end_listeners: Vec<i64> = STDIN_END_LISTENERS
+        .lock()
+        .map(|l| l.clone())
+        .unwrap_or_default();
+    let has_once = STDIN_END_ONCE
+        .lock()
+        .map(|l| !l.is_empty())
+        .unwrap_or(false);
+    if end_listeners.is_empty() && !has_once {
+        // No listener yet — leave EOF pending so a slightly-later `once('end')`
+        // (racing the reader) still fires on a subsequent pump.
+        return;
+    }
+    if STDIN_END_FIRED
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return;
+    }
+    let end_once: Vec<i64> = STDIN_END_ONCE
+        .lock()
+        .map(|mut l| std::mem::take(&mut *l))
+        .unwrap_or_default();
+    end_listeners.extend(&end_once);
+    let this = stdin_this_value();
+    for cb in end_listeners {
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let cb_handle = scope.root_raw_const_ptr(cb as *const crate::closure::ClosureHeader);
+        let closure = cb_handle.get_raw_const_ptr::<crate::closure::ClosureHeader>();
+        let prev_this = crate::object::js_implicit_this_set(this);
+        crate::closure::js_closure_call0(closure);
+        crate::object::js_implicit_this_set(prev_this);
+    }
+}
+
 /// Make a native-method closure value with the given arity registered, so the
 /// dispatch path forwards the right number of arguments.
 fn stdin_native_method(func_ptr: *const u8, name: &str, arity: u32) -> f64 {
@@ -459,6 +550,8 @@ pub fn scan_process_stream_singleton_roots_mut(visitor: &mut crate::gc::RuntimeR
         &STDIN_READABLE_LISTENERS,
         &STDIN_DATA_ONCE,
         &STDIN_READABLE_ONCE,
+        &STDIN_END_LISTENERS,
+        &STDIN_END_ONCE,
     ] {
         if let Ok(mut listeners) = registry.lock() {
             for cb in listeners.iter_mut() {

--- a/crates/perry/tests/issue_stdin_end_listener.rs
+++ b/crates/perry/tests/issue_stdin_end_listener.rs
@@ -1,0 +1,140 @@
+//! Regression test: `process.stdin.once("end", …)` (and `on("end"/"close", …)`)
+//! must fire on stdin EOF.
+//!
+//! The native `process.stdin` `on`/`once` binding only registered `"data"` and
+//! `"readable"` listeners — `"end"`/`"close"` fell into a `_ => {}` arm and were
+//! silently dropped. A prompt reader that races an EOF against a timeout
+//! (`p = new Promise(res => { stdin.once("end", () => res(false)); … })`, then
+//! `await p`) therefore never resolved: the `'end'` listener never fired, the
+//! awaiter hung, and the program stalled before doing any further work.
+//!
+//! Fix: `process_stdin_on`/`process_stdin_once` register `"end"`/`"close"`
+//! listeners in dedicated registries that the main-thread stdin pump fires once
+//! the reader hits EOF and the byte buffer has drained.
+//!
+//! Needs the default (auto-optimize) build — the native stdin reader/pump lives
+//! in perry-runtime and drives the event loop.
+
+use std::io::{Read, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile(dir: &std::path::Path, source: &str) -> PathBuf {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    output
+}
+
+/// Run `bin`, writing `stdin_bytes` then closing stdin (EOF). Fails if the
+/// process doesn't exit within `secs` (the regression is a hang: `'end'` never
+/// fires, so the awaiter never resolves).
+fn run_with_stdin(bin: &std::path::Path, stdin_bytes: &[u8], secs: u64) -> String {
+    let mut child = Command::new(bin)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn compiled binary");
+
+    // Write the input and drop the handle so the child sees EOF.
+    child
+        .stdin
+        .take()
+        .expect("piped stdin")
+        .write_all(stdin_bytes)
+        .expect("write stdin");
+
+    let mut piped = child.stdout.take().expect("piped stdout");
+    let reader = std::thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = piped.read_to_string(&mut buf);
+        buf
+    });
+
+    let deadline = Instant::now() + Duration::from_secs(secs);
+    loop {
+        match child.try_wait().expect("try_wait") {
+            Some(status) => {
+                let stdout = reader.join().unwrap_or_default();
+                assert!(
+                    status.success(),
+                    "binary exited non-zero: {status:?}\nstdout:\n{stdout}"
+                );
+                return stdout;
+            }
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let stdout = reader.join().unwrap_or_default();
+                panic!(
+                    "regression: process hung >{secs}s — process.stdin 'end' \
+                     listener never fired.\nstdout so far:\n{stdout}"
+                );
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    }
+}
+
+/// `once("end", …)` alongside a persistent `on("data", …)` (flowing mode) must
+/// fire after the piped input is consumed — the prompt-reader shape.
+#[test]
+fn stdin_once_end_fires_after_data() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let bin = compile(
+        dir.path(),
+        r#"
+let acc = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (c: string) => { acc += c; });
+process.stdin.once("end", () => {
+  process.stdout.write("END " + JSON.stringify(acc) + "\n");
+  process.exit(0);
+});
+// A regression manifests as this line (or a harness timeout) instead of END.
+setTimeout(() => { process.stdout.write("NO-END\n"); process.exit(0); }, 6000);
+"#,
+    );
+    let stdout = run_with_stdin(&bin, b"hello world\n", 20);
+    assert_eq!(stdout, "END \"hello world\\n\"\n");
+}
+
+/// EOF with no input at all (`< /dev/null` shape): `once("end")` must still fire.
+#[test]
+fn stdin_once_end_fires_on_empty_input() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let bin = compile(
+        dir.path(),
+        r#"
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", () => {});
+process.stdin.once("end", () => {
+  process.stdout.write("END-EMPTY\n");
+  process.exit(0);
+});
+setTimeout(() => { process.stdout.write("NO-END\n"); process.exit(0); }, 6000);
+"#,
+    );
+    let stdout = run_with_stdin(&bin, b"", 20);
+    assert_eq!(stdout, "END-EMPTY\n");
+}


### PR DESCRIPTION
## Summary
`process.stdin.on("end", fn)` / `process.stdin.once("end", fn)` (and the same for `"close"`) never fire. The native `process.stdin` `on`/`once`/`addListener` binding only handles `"data"` and `"readable"`; every other event name — including `"end"`/`"close"` — falls into a `_ => {}` arm and is discarded. Node fires `'end'` on stdin EOF, so any code that awaits stdin end hangs.

## Minimal repro
```ts
process.stdin.setEncoding("utf8");
process.stdin.on("data", () => {});          // flowing mode
process.stdin.once("end", () => {
  process.stdout.write("END\n");             // never prints
  process.exit(0);
});
setTimeout(() => { process.stdout.write("NO-END\n"); process.exit(0); }, 3000);
```
Run with `< /dev/null` (or `printf 'x\n' | ...`): **node** prints `END`; **before this fix, perry** prints `NO-END` — the `'end'` listener never fired.

A common real-world shape is a prompt reader that races EOF against a timeout:
```ts
function readStdin(stream, ms) {
  return new Promise((res) => {
    const t = setTimeout(() => res(true), ms);
    stream.once("data", () => clearTimeout(t));
    stream.once("end", () => { clearTimeout(t); res(false); }); // never resolves
  });
}
const input = await readStdin(process.stdin, 3000); // hangs forever
```
Because `once("end")` is dropped, the promise never resolves and the awaiting async function stalls — silently draining to exit, or hanging if another handle keeps the loop alive — never running the code after the `await`.

## Root cause
`crates/perry-runtime/src/os_process_streams.rs`: `process_stdin_on` / `process_stdin_once` (and the shared `register_stdin_listener`) match only `Some("data")` / `Some("readable")`; `"end"` / `"close"` hit `_ => {}`. The reader thread's EOF handling only broke out of the read loop; it never recorded EOF for, or notified, the JS `'end'` listeners registered on the stream object.

## Fix
- Add `STDIN_END_LISTENERS` / `STDIN_END_ONCE` registries and handle `"end"`/`"close"` in `process_stdin_on` / `process_stdin_once` / `register_stdin_listener`.
- On fd-0 EOF the reader sets `STDIN_EOF_SEEN` and wakes the loop.
- The main-thread stdin pump (`pump_process_stdin`) dispatches the `'end'`/`'close'` listeners via a new `maybe_fire_stdin_end`, but only after the byte buffer has drained (so `'data'` precedes `'end'`, per Node). It fires at most once, and latches `STDIN_END_FIRED` only once at least one listener exists, so a listener attached in the small window right after EOF (the prompt-reader race) still runs.
- The new registries are added to GC root scanning.

## Test
`crates/perry/tests/issue_stdin_end_listener.rs` — compiles and runs the `once("end")` + `on("data")` shape with both piped input and empty input, asserting the `'end'` handler fires (regression is a hang the harness catches). Both cases pass; the perry-runtime lib builds clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `process.stdin` event behavior to emit Node-like `end` and `close` after all input is fully consumed.
  * Ensured final stdin events are dispatched only after any buffered data has been drained.
  * Updated listener handling so `end`/`close` callbacks remain available until they fire, improving `once(...)` reliability.

* **Tests**
  * Added regression tests covering `process.stdin.once("end", ...)` for both streamed input and empty stdin, including timeout-based hang detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->