### PR TITLE
fix(hir): bracket access with a string-literal key missed builtin static folds

### DIFF
--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -79,6 +79,26 @@ pub(crate) fn unwrap_transparent(e: &ast::Expr) -> &ast::Expr {
     }
 }
 
+/// The property name of a member access as a source-visible STATIC string, for
+/// EITHER a dot access (`obj.name`) or a bracket access with a string-literal
+/// key (`obj[\"name\"]`). Per spec these are equivalent for string keys, so the
+/// builtin constant-fold / reified-static-value paths that key off a dot
+/// property name must fire for the string-literal computed form too — otherwise
+/// `Number[\"POSITIVE_INFINITY\"]` / `Math[\"E\"]` / `Array[\"prototype\"]` fall
+/// through the static resolution and collapse to a bare `globalThis.<key>` read
+/// (undefined). Returns `None` for a dynamic (non-string-literal) computed key,
+/// which must keep the runtime index path. (Test262 property-accessors.)
+pub(crate) fn static_member_prop_name(prop: &ast::MemberProp) -> Option<String> {
+    match prop {
+        ast::MemberProp::Ident(p) => Some(p.sym.to_string()),
+        ast::MemberProp::Computed(c) => match c.expr.as_ref() {
+            ast::Expr::Lit(ast::Lit::Str(s)) => s.value.as_str().map(|v| v.to_string()),
+            _ => None,
+        },
+        ast::MemberProp::PrivateName(_) => None,
+    }
+}
+
 pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Result<Expr> {
     // #1723: when THIS access is the auditable `ns[dynamicKey].staticMember`
     // shape — a dynamic stdlib SUB-namespace selection (`path.win32` /
@@ -738,8 +758,8 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
     // Check for Math constants (e.g., Math.PI, Math.E)
     if let ast::Expr::Ident(obj_ident) = member.obj.as_ref() {
         if obj_ident.sym.as_ref() == "Math" {
-            if let ast::MemberProp::Ident(prop_ident) = &member.prop {
-                let val = match prop_ident.sym.as_ref() {
+            if let Some(prop_name) = static_member_prop_name(&member.prop) {
+                let val = match prop_name.as_str() {
                     "PI" => Some(std::f64::consts::PI),
                     "E" => Some(std::f64::consts::E),
                     "LN2" => Some(std::f64::consts::LN_2),
@@ -760,8 +780,8 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
     // Check for Number constants (e.g., Number.MAX_SAFE_INTEGER)
     if let ast::Expr::Ident(obj_ident) = member.obj.as_ref() {
         if obj_ident.sym.as_ref() == "Number" {
-            if let ast::MemberProp::Ident(prop_ident) = &member.prop {
-                let val = match prop_ident.sym.as_ref() {
+            if let Some(prop_name) = static_member_prop_name(&member.prop) {
+                let val = match prop_name.as_str() {
                     "MAX_SAFE_INTEGER" => Some(9007199254740991.0),
                     "MIN_SAFE_INTEGER" => Some(-9007199254740991.0),
                     "MAX_VALUE" => Some(f64::MAX),

--- a/crates/perry-hir/src/lower/expr_member/member_tail.rs
+++ b/crates/perry-hir/src/lower/expr_member/member_tail.rs
@@ -134,10 +134,14 @@ pub(crate) fn lower_member_tail(
                     // would drop the receiver, and codegen lowers
                     // `globalThis.__proto__` through the no-name path → literal
                     // `0.0` (a number), which is the symptom reported in #2145.
+                    // Accept BOTH `Ctor.prototype` and `Ctor[\"prototype\"]`
+                    // (string-literal computed key) — the reified constructor
+                    // receiver must survive for either form, else the read
+                    // collapses to `globalThis.prototype` (undefined). Test262
+                    // property-accessors `Ctor[\"prototype\"]`.
                     let outer_is_prototype_or_proto = matches!(
-                        &member.prop,
-                        ast::MemberProp::Ident(p) if p.sym.as_ref() == "prototype"
-                            || p.sym.as_ref() == "__proto__"
+                        static_member_prop_name(&member.prop).as_deref(),
+                        Some("prototype") | Some("__proto__")
                     );
                     let receiver_is_namespace_value = matches!(
                         property.as_str(),


### PR DESCRIPTION
## Summary

`Number["POSITIVE_INFINITY"]`, `Math["E"]`, `Array["prototype"]`, `Object["prototype"]` and similar **bracket** accesses on a builtin constructor/namespace returned `undefined`, while the equivalent **dot** form (`Number.POSITIVE_INFINITY`, `Math.E`, `Array.prototype`) worked. Per spec `obj["name"]` === `obj.name` for any string key, so both must resolve identically.

### Root cause

The builtin static-member resolution in member lowering keyed only off `MemberProp::Ident` (dot access):

- A **dynamic** key (`Number[k]`) works — it routes through the runtime `globalThis.Number` object, which has the statics installed.
- A **string-literal computed** key (`Number["POSITIVE_INFINITY"]`) took the compile-time static path, where (a) the Math/Number constant-fold arms never matched (they required `MemberProp::Ident`), and (b) the `Ctor.prototype` reroute-undo guard did not recognize the literal `["prototype"]` form. So the receiver collapsed to bare `globalThis` and the outer key was read off `globalThis` → `undefined`.

### Fix

Add `static_member_prop_name`, which returns the property name for **either** a dot access or a bracket access with a string-literal key, and use it in the three affected static-resolution sites:

- the `Math.*` constant fold (`Math["PI"]`, `Math["E"]`, ...);
- the `Number.*` constant fold (`Number["MAX_VALUE"]`, `Number["POSITIVE_INFINITY"]`, ...);
- the `Ctor.prototype` / `Ctor.__proto__` reroute-undo guard, so `Array["prototype"]` / `Object["prototype"]` keep the reified constructor receiver instead of collapsing to `globalThis.prototype`.

Dynamic (non-string-literal) computed keys are unaffected — the helper returns `None` and the runtime index path is kept.

## Test262 impact

Measured on an internal Linux sweep host:

- `language/expressions/property-accessors`: **+4 cases** (11 → 15 pass).
- Zero regressions across the `super` / `object` / `property-accessors` / `delete` / `for-of` / `function` slice.
- Zero computed-access regressions in a `built-ins/{Math,Number,Array,Object}` slice (98.3% parity; the 10 remaining fails are pre-existing `-0` rounding / `Number.prototype.toString` receiver-brand gaps, unrelated to this change).

## Notes

Code-only. `cargo test -p perry-hir` green, `cargo fmt --all -- --check` clean, both touched files under the 2000-line gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of property access so dot notation and string-literal bracket notation behave consistently.
  * Fixed constant folding for well-known numeric values accessed through either `obj.prop` or `obj["prop"]` forms.
  * Preserved the correct receiver when accessing prototype-related properties such as `prototype` and `__proto__` through bracket string-literal syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->