### PR TITLE
fix(hir): delete of a module-level var/let/const binding wrongly returned true

### DIFF
--- a/crates/perry-hir/src/lower/lower_expr/arm_unary.rs
+++ b/crates/perry-hir/src/lower/lower_expr/arm_unary.rs
@@ -562,19 +562,18 @@ pub(crate) fn lower_unary_expr(ctx: &mut LoweringContext, unary: &ast::UnaryExpr
                 if ctx.sloppy_implicit_global_ids.contains(&lid) {
                     return Ok(Expr::Bool(true));
                 }
-                // At module top level a bare `x = 1` becomes an ordinary
-                // module-level local indistinguishable from `var x = 1`
-                // (the implicit-global path isn't taken there), so we
-                // can't statically tell a non-configurable `var`/`let`
-                // binding from a configurable implicit global — defer to
-                // the runtime delete (Test262 S11.4.1_A3.2_T1). Inside a
-                // function, an implicit global *does* go through the
-                // sloppy-global set, so a plain local here is a genuine
-                // binding → false.
-                if !ctx.module_level_ids.contains(&lid) {
-                    return Ok(Expr::Bool(false));
-                }
-                // module-level local: fall through to the dynamic path.
+                // Any resolvable binding NOT in the implicit-global set is a
+                // real `var`/`let`/`const`/param declaration — non-configurable,
+                // so `delete <ident>` is `false` (spec 13.5.1.2), at module top
+                // level too. A module-level bare `x = 1` implicit global is
+                // distinguishable: `define_sloppy_implicit_global` records it in
+                // `sloppy_implicit_global_ids` even at scope depth 0, so it took
+                // the `true` arm above (Test262 S11.4.1_A3.2_T1). Reaching here
+                // therefore means a genuine `var x = 1` / `let` / `const`
+                // binding, which must be `false` (Test262 S11.4.1_A3.1) rather
+                // than deferred to a runtime delete that removes it and returns
+                // `true`.
+                return Ok(Expr::Bool(false));
             } else if ctx.lookup_func(name).is_some()
                 || ctx.lookup_class(name).is_some()
                 || ctx.lookup_imported_func(name).is_some()


### PR DESCRIPTION
## Summary

`delete x` where `x` is a module-top-level `var` / `let` / `const` binding returned `true` (and removed the binding at runtime) instead of the spec-required `false`. Per spec 13.5.1.2 these bindings are non-configurable, so `delete <ident>` is a no-op that returns `false`.

### Root cause

The `delete <ident>` fold already returned `false` for function-scoped bindings, function declarations, classes, and imports, and `true` for a bare implicit global (`x = 1`, no declaration). But at module top level it gave up and deferred a real `var` / `let` / `const` binding to a runtime delete — on the stale premise that a module-level declaration is indistinguishable from an implicit global.

That premise is wrong: `define_sloppy_implicit_global` records an implicit global in `sloppy_implicit_global_ids` at scope depth 0 too, so the implicit-global case already takes the `true` arm. Any resolvable module-level binding that reaches the fall-through is therefore a genuine declaration and must be `false`.

### Fix

Return `Expr::Bool(false)` for a resolved binding not in the implicit-global set, at module level as well — removing the runtime-delete fall-through.

## Test262 impact

Measured on an internal Linux sweep host:

- `language/expressions/delete`: **+5 cases** (59 → 64 pass), including `S11.4.1_A3.3_T4` and the `11.4.1-4.a` / `11.4.1-5` series.
- The implicit-global `delete x` (`S11.4.1_A3.2_T1`, must stay `true`) is preserved.
- Zero regressions across the `super` / `object` / `property-accessors` / `delete` / `for-of` / `function` slice.

## Notes

Code-only, single HIR file. `cargo test -p perry-hir` green, `cargo fmt --all -- --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of `delete` on simple identifiers in sloppy mode, so resolvable non-global bindings now consistently evaluate to `false`.
  * Fixed cases involving module-level locals that were previously treated like configurable implicit globals, making behavior more predictable and aligned with runtime rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->