### PR TITLE
fix(hir): class own-name binding is const inside the class body

### DIFF
--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -76,6 +76,8 @@ impl LoweringContext {
             current_strict: false,
             ui_widget_type_aliases: HashMap::new(),
             current_class: None,
+            current_class_inner_name: None,
+            pending_class_inner_name: None,
             current_class_member_is_static: false,
             private_scopes: Vec::new(),
             object_super_home_stack: Vec::new(),

--- a/crates/perry-hir/src/lower/expr_assign.rs
+++ b/crates/perry-hir/src/lower/expr_assign.rs
@@ -439,6 +439,17 @@ fn lower_assignment_target(
                     ]));
                 }
                 Ok(Expr::LocalSet(id, value))
+            } else if ctx.current_class_inner_name.as_deref() == Some(name.as_str()) {
+                // Assigning to the class own-name binding from inside the class
+                // body targets the immutable inner `const` binding -> TypeError
+                // (test262 language/statements/class/name-binding/const). Evaluate
+                // the RHS for side effects first, then throw. A local/param that
+                // shadows the name was already handled by the `lookup_local` arm
+                // above, so this only fires for the genuine class binding.
+                Ok(Expr::Sequence(vec![
+                    *value,
+                    throw_type_error_const_assignment(&name),
+                ]))
             } else if ctx.lookup_class(&name).is_some() || ctx.lookup_func(&name).is_some() {
                 // v0.5.757: don't shadow a class/function binding with an
                 // implicit local for `<Name> = X` patterns. Drizzle's

--- a/crates/perry-hir/src/lower/expr_new/non_ident.rs
+++ b/crates/perry-hir/src/lower/expr_new/non_ident.rs
@@ -132,6 +132,7 @@ pub(crate) fn lower_new_non_ident(
     };
     if let Some(class_expr) = class_expr_opt {
         let synthetic_name = format!("__anon_class_{}", ctx.fresh_class());
+        ctx.pending_class_inner_name = class_expr.ident.as_ref().map(|i| i.sym.to_string());
         let class = lower_class_from_ast(ctx, &class_expr.class, &synthetic_name, false)?;
         ctx.pending_classes.push(class);
         let mut args: Vec<Expr> = new_expr

--- a/crates/perry-hir/src/lower/lower_expr/arm_class.rs
+++ b/crates/perry-hir/src/lower/lower_expr/arm_class.rs
@@ -84,6 +84,9 @@ pub(crate) fn lower_class_expr(
             }
         }
     };
+    // Record the source-level inner binding name for the const-assignment
+    // guard (assigning to it inside the body throws a TypeError).
+    ctx.pending_class_inner_name = class_expr.ident.as_ref().map(|i| i.sym.to_string());
     let class = lower_class_from_ast(ctx, &class_expr.class, &synthetic_name, false)?;
     if let Some(display) = display_override {
         ctx.class_display_names.insert(class.id, display);

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -218,6 +218,18 @@ pub struct LoweringContext {
     pub(crate) ui_widget_type_aliases: HashMap<String, String>,
     /// Current class being lowered (for arrow function `this` capture)
     pub(crate) current_class: Option<String>,
+    /// Source-level inner name of the class currently being lowered — the
+    /// binding visible *inside* the class body (`class C {...}` -> `C`,
+    /// `const K = class Named {...}` -> `Named`). Unlike `current_class`
+    /// (which for a class expression may be a synthetic dedup key), this is
+    /// the identifier the user writes. Assigning to it inside the body is a
+    /// `const`-binding violation and must throw a TypeError.
+    pub(crate) current_class_inner_name: Option<String>,
+    /// Set by a class-EXPRESSION caller to the source ident of the class
+    /// about to be lowered, so `lower_class_from_ast` can record the inner
+    /// binding name (the synthetic dedup key it receives is not the
+    /// user-visible name). Consumed (taken) at the start of lowering.
+    pub(crate) pending_class_inner_name: Option<String>,
     /// True while lowering a static class member body.
     pub(crate) current_class_member_is_static: bool,
     /// Lexical stack of private-name scopes — one entry per enclosing class

--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -691,6 +691,15 @@ pub(crate) fn lower_stmt(
                                         ctx.class_expr_aliases
                                             .insert(inner_name.clone(), bind_name.clone());
                                     }
+                                    // The inner (const) binding visible inside the
+                                    // body is the class expression's own source ident
+                                    // (`var cls = class C {...}` -> `C`); feed it so the
+                                    // const-assignment guard uses the user-visible name,
+                                    // not the `bind_name` registration key.
+                                    ctx.pending_class_inner_name = class_expr
+                                        .ident
+                                        .as_ref()
+                                        .map(|i| i.sym.to_string());
                                     // Lower the class with the binding name so
                                     // `new BindName(...)` works unchanged.
                                     let mut lowered_class =

--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -326,6 +326,9 @@ pub fn lower_class_decl(
     // Set current class for arrow function `this` capture tracking
     let old_class = ctx.current_class.take();
     ctx.current_class = Some(name.clone());
+    let old_inner_name = ctx.current_class_inner_name.take();
+    // The inner (const) binding visible in the body is the source ident.
+    ctx.current_class_inner_name = Some(class_decl.ident.sym.to_string());
     let old_is_derived = ctx.current_class_is_derived;
     ctx.current_class_is_derived = class_decl.class.super_class.is_some();
 
@@ -1325,6 +1328,7 @@ pub fn lower_class_decl(
 
     // Restore previous current_class
     ctx.current_class = old_class;
+    ctx.current_class_inner_name = old_inner_name;
     ctx.current_class_is_derived = old_is_derived;
     ctx.pop_private_scope();
     // Issue #562: restore the prior super-ident slot.
@@ -1424,6 +1428,13 @@ pub fn lower_class_from_ast(
 
     let old_class = ctx.current_class.take();
     ctx.current_class = Some(name.to_string());
+    let old_inner_name = ctx.current_class_inner_name.take();
+    // A class-expression caller stashes the source ident here; fall back
+    // to the (possibly synthetic) registration name when absent.
+    ctx.current_class_inner_name = ctx
+        .pending_class_inner_name
+        .take()
+        .or_else(|| Some(name.to_string()));
     let old_is_derived = ctx.current_class_is_derived;
     ctx.current_class_is_derived = class.super_class.is_some();
 
@@ -1880,6 +1891,7 @@ pub fn lower_class_from_ast(
         ctx.register_class_native_extends(name.to_string(), module.clone(), class.clone());
     }
     ctx.current_class = old_class;
+    ctx.current_class_inner_name = old_inner_name;
     ctx.current_class_is_derived = old_is_derived;
     ctx.pop_private_scope();
     // Issue #562: restore prior super-ident slot.


### PR DESCRIPTION
## Summary

The binding for a class's own name is an **immutable (const) binding** in the class scope — the declarative environment record created for the class body. Assigning to that name from anywhere inside the class body (constructor, method, accessor, or an expression in the heritage clause) must throw a `TypeError`. The outer declaration binding introduced by a `class C {}` statement is a *separate, mutable* binding, so reassigning `C` from **outside** the body stays legal.

Perry previously dropped such an assignment silently: the `<Name> = X` branch in the identifier-assignment lowering evaluated the RHS for side effects and returned, treating the class binding as a no-op target. So none of the `assert.throws(TypeError, ...)` cases fired.

## Fix

Track the source-level inner binding name on the lowering context:

- `current_class_inner_name` — saved/restored around each class body (both `lower_class_decl` and `lower_class_from_ast`).
- `pending_class_inner_name` — fed by the class-*expression* call sites (`arm_class.rs`, `expr_new/non_ident.rs`, and the `var C = class Named {...}` fast path in `stmt.rs`), because those receive a synthetic dedup registration key rather than the user-visible name.

When an identifier assignment target matches that inner name — and no local/param shadows it (the `lookup_local` arm runs first, so a shadowing binding wins) — the lowering now evaluates the RHS and then throws via the existing `js_throw_type_error_const_assignment` runtime helper.

Handles constructor, method, accessor (get/set), and heritage-expression forms, for both class declarations and named class expressions. Outer-binding reassignment is unchanged.

## Tests (internal Linux sweep host, test262 class cluster)

- Fixes `language/statements/class/name-binding/const.js`.
- Full `language/statements/class` + `language/expressions/class` sweep: **+1 pass, zero regressions** (diffed the failure sidecar before/after).
- Manually verified: constructor / method / getter / setter / class-expression forms all throw `TypeError`; shadowing param/local, nested-class own-name, and outer-scope reassignment do **not** false-throw.

Part of the test262 class-cluster parity work (tracker #793).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of class inner bindings so assignments to a class’s own immutable name inside the class body now correctly raise a `TypeError`.
  * Preserved the correct class name context during class lowering, including for class expressions, to ensure binding checks use the visible inner name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->