### PR TITLE
fix(runtime): class constructor .caller/.arguments are poison-pill accessors

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -832,6 +832,20 @@ pub extern "C" fn js_object_get_field_by_name(
                             return JSValue::from_bits(crate::js_nanbox_string(s as i64).to_bits());
                         }
                     }
+                    // No own static / inherited entry resolved the name. A class
+                    // constructor is a function, so a bare read of `.caller` or
+                    // `.arguments` hits the poison-pill %ThrowTypeError% accessor
+                    // on `Function.prototype` — strict-mode throws (Perry only
+                    // compiles strict code). Placed last so any own static field,
+                    // accessor, or `defineProperty`-installed data prop of that
+                    // name takes precedence. Prototype-refs (`C.prototype`) are
+                    // plain objects and are excluded.
+                    if !is_prototype_ref && matches!(name, "caller" | "arguments") {
+                        crate::fs::validate::throw_type_error_with_code(
+                            "Restricted function property access",
+                            "ERR_INVALID_ARG_TYPE",
+                        );
+                    }
                 }
             }
             return JSValue::undefined();

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -431,6 +431,23 @@ pub extern "C" fn js_object_set_field_by_name(
                     {
                         return;
                     }
+                    // Writing `.caller` / `.arguments` on a class constructor
+                    // hits the poison-pill %ThrowTypeError% accessor (which has
+                    // no [[Set]]) on `Function.prototype`, so a strict-mode
+                    // assignment throws. Mirrors the read side in
+                    // get_field_by_name and the ordinary-closure setter path.
+                    // A `defineProperty`-installed own data prop was handled by
+                    // `has_own_data` above; prototype-refs (`C.prototype`) are
+                    // plain objects with no such restriction.
+                    if !has_own_data
+                        && matches!(name.as_str(), "caller" | "arguments")
+                        && super::class_prototype_ref_id(f64::from_bits(bits)).is_none()
+                    {
+                        crate::fs::validate::throw_type_error_with_code(
+                            "Restricted function property access",
+                            "ERR_INVALID_ARG_TYPE",
+                        );
+                    }
                     class_dynamic_prop_root_store(class_id, name, value);
                 }
             }


### PR DESCRIPTION
## Summary

A class constructor is a function, so reading or writing its `caller` / `arguments` property goes through the **%ThrowTypeError% poison-pill accessor** inherited from `Function.prototype`. That accessor's getter *and* setter both throw, so in strict mode (all Perry compiles is strict) `Class.caller`, `Class.arguments`, `Class.caller = x`, and `Class.arguments = x` all throw a `TypeError`, and neither name is an own property of the class.

Ordinary closures already routed these through the thrower (`get_field_by_name_tail`), but a class is represented as an **INT32-tagged class-ref**, not a closure pointer, so that path never fired: `Class.caller` returned `undefined` and `Class.caller = {}` silently no-op'd.

## Fix

Add the guard to both class-ref property paths:

- **READ** (`js_object_get_field_by_name`): after all own static / inherited / parent-chain resolution fails, a `caller`/`arguments` read on a constructor ref throws. Placed **last** so any own static field, accessor, or inherited static of that name still wins; prototype-refs (`C.prototype`, a plain object) are excluded.
- **WRITE** (`js_object_set_field_by_name`): a `caller`/`arguments` write on a constructor ref throws unless an own data prop (`CLASS_DYNAMIC_PROPS`) shadows it; prototype-refs excluded.

## Verification (internal Linux sweep host, test262 class cluster)

- Fixes `language/statements/class/restricted-properties.js` and `language/expressions/class/restricted-properties.js`.
- Full `language/statements/class` + `language/expressions/class` sweep: **zero regressions** (diffed the failure sidecar before/after).
- Manually confirmed: `Class.hasOwnProperty('caller'|'arguments')` stays `false`; subclasses inherit the restriction (also throw); normal statics (`C.name`, static fields/methods, a static method coincidentally named `caller2`) and `err.constructor.name` (used by `assert.throws`) are unaffected.

Part of the test262 class-cluster parity work (tracker #793).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Accessing restricted function properties like `caller` and `arguments` now raises a `TypeError` instead of silently returning a value.
  * Assignments to these restricted properties on class constructors are now blocked when they are not already defined as own properties.
  * Behavior for other property reads and writes remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->