### PR TITLE
fix(hir): emit computed-key static fields that have no initializer

### DIFF
--- a/crates/perry-hir/src/lower_decl/static_init.rs
+++ b/crates/perry-hir/src/lower_decl/static_init.rs
@@ -34,9 +34,18 @@ pub(crate) fn build_interleaved_static_init_stmts(
     static_methods: &[Function],
 ) -> Vec<Stmt> {
     let emit_field = |out: &mut Vec<Stmt>, sf: &ClassField| {
-        let Some(init) = &sf.init else { return };
+        // A COMPUTED-key static field with no initializer still performs
+        // CreateDataProperty(F, key, undefined) at class-eval time, so it must
+        // be emitted (value = undefined) rather than dropped: (1) the key
+        // expression has observable side effects, and (2) a key that evaluates
+        // to "prototype" is a TypeError (test262 fields-computed-name-static-
+        // *propname-prototype). A NON-computed uninit static field is a plain
+        // named slot and keeps the pre-existing "skip when no init" behavior.
+        if sf.init.is_none() && sf.key_expr.is_none() {
+            return;
+        }
         // `this` in a static field initializer is the class constructor.
-        let mut init_value = init.clone();
+        let mut init_value = sf.init.clone().unwrap_or(Expr::Undefined);
         crate::analysis::substitute_lexical_this_in_expr(
             &mut init_value,
             &Expr::ClassRef(class_name.to_string()),


### PR DESCRIPTION
## Summary

A **computed-name static class field with no initializer** (`static [expr];`) was dropped entirely during lowering. `build_interleaved_static_init_stmts` bailed with `let Some(init) = &sf.init else { return }` before it ever looked at the key, skipping two behaviors required by ClassDefinitionEvaluation:

1. The key expression's **side effects** never ran.
2. `CreateDataProperty(F, key, undefined)` never happened, so the field was not defined — and a key evaluating to `"prototype"` never reached the runtime `"prototype"`-is-a-TypeError check in `js_class_register_static_symbol`. (The constructor's `prototype` slot is non-configurable, so a static field of that name throws.)

## Fix

A field is now skipped only when it is **both** un-initialized **and** has no computed key (a plain named uninit static slot — unchanged behavior). A computed-key field is always emitted, with `undefined` substituted for a missing initializer, so its `ClassStaticSymbolSet` runs the key expression and defines the property (or throws for `"prototype"`).

One-file HIR change (`static_init.rs`).

## Verification (internal Linux sweep host, test262 class cluster)

Fixes:
- `.../elements/fields-computed-name-static-propname-prototype.js`
- `.../elements/fields-computed-name-static-computed-var-propname-prototype.js`
- `.../elements/static-field-declaration.js` (statements + expressions)
- `.../static-classelementname-abrupt-completion.js`

Full `language/statements/class` + `language/expressions/class` sweep: **zero regressions** (diffed the failure sidecar before/after). Manually confirmed computed static key side effects run, uninit computed fields read back as `undefined`, initialized computed fields keep their value, and plain named static fields are unaffected.

Part of the test262 class-cluster parity work (tracker #793).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Computed static fields without an initializer are now emitted correctly instead of being skipped.
  * Side effects from computed field expressions are preserved, and `"prototype"` cases now behave consistently with expected errors.
  * Uninitialized non-computed static fields continue to be ignored as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->