### PR TITLE
fix(runtime): strict `arr[i]=v` / `arr.length=n` on a frozen array throws TypeError

### DIFF
--- a/crates/perry-codegen/src/expr/index.rs
+++ b/crates/perry-codegen/src/expr/index.rs
@@ -345,9 +345,14 @@ pub(crate) fn lower_index_set_fast(
             "js_typed_feedback_record_fallback_call",
             &[(I64, feedback_site_id)],
         );
+        // Strict `arr[i] = v`: a frozen array's element is non-writable and a
+        // non-extensible array rejects a new index, so route to the throwing
+        // variant. (The inline fast/medium paths above are only reached for
+        // arrays with a proven dense-numeric layout, which excludes frozen /
+        // sealed / non-extensible arrays — those always fall to this call.)
         let new_handle = blk.call(
             I64,
-            "js_array_set_f64_extend",
+            "js_array_set_f64_extend_strict",
             &[(I64, &arr_handle), (I32, &idx_i32), (DOUBLE, val_double)],
         );
         let new_box = nanbox_pointer_inline(blk, &new_handle);

--- a/crates/perry-codegen/src/expr/property_set.rs
+++ b/crates/perry-codegen/src/expr/property_set.rs
@@ -194,8 +194,11 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 let blk = ctx.block();
                 let arr_bits = blk.bitcast_double_to_i64(&arr_box);
                 let arr_handle = blk.and(I64, &arr_bits, POINTER_MASK_I64);
+                // `arr.length = v` is a strict `Set(O,"length",v,true)`: a frozen
+                // array's `length` is non-writable, so route to the throwing
+                // variant instead of the silent internal helper.
                 blk.call_void(
-                    "js_array_set_length",
+                    "js_array_set_length_strict",
                     &[(I64, &arr_handle), (DOUBLE, &val_double)],
                 );
                 return Ok(val_double);

--- a/crates/perry-codegen/src/runtime_decls/arrays.rs
+++ b/crates/perry-codegen/src/runtime_decls/arrays.rs
@@ -51,6 +51,7 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     // Extending variant: returns a possibly-realloc'd pointer that the
     // caller must write back to the local slot.
     module.declare_function("js_array_set_f64_extend", I64, &[I64, I32, DOUBLE]);
+    module.declare_function("js_array_set_f64_extend_strict", I64, &[I64, I32, DOUBLE]);
     module.declare_function("js_array_fill_f64_const_extend", I64, &[I64, I32, DOUBLE]);
     module.declare_function("js_array_fill_f64_iota_extend", I64, &[I64, I32]);
     module.declare_function("js_array_fill_f64_const_len_extend", I64, &[I64, DOUBLE]);
@@ -135,6 +136,7 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     module.declare_function("js_array_delete", I32, &[I64, I32]);
     // Closes #304: `arr.length = N` truncate / extend.
     module.declare_function("js_array_set_length", VOID, &[I64, DOUBLE]);
+    module.declare_function("js_array_set_length_strict", VOID, &[I64, DOUBLE]);
     // Array.from() — js_array_clone handles arrays, Sets, and Maps.
     module.declare_function("js_array_clone", I64, &[I64]);
     // #2773: Array.from(source) — throws TypeError for nullish sources, keeps

--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -16,6 +16,31 @@ const MAX_DENSE_ARRAY_GROW_LENGTH: u32 = 1_000_000;
 /// benchmark for 6 hours (Regression Check, v0.5.1129–v0.5.1150).
 const DENSE_ARRAY_GAP_LIMIT: u32 = 1024;
 
+/// A strict-mode element write (`arr[i] = v`) to a **frozen** array's existing
+/// index is `[[Set]]` on a non-writable data property with `Throw = true`
+/// (ECMA-262 §10.4.2.4 → OrdinarySetWithOwnDescriptor step 2.b.i), so it must
+/// throw a **TypeError** rather than silently no-op. Perry compiles everything
+/// strict, so the codegen `arr[i] = v` fast paths — which call these
+/// `js_array_set_f64*` helpers directly — carry the strict-`Set` contract.
+/// Matches V8's message. (test262 built-ins/Array element-write-on-frozen.)
+#[cold]
+fn throw_frozen_array_index_write(index: u32) -> ! {
+    crate::collection_iter::throw_type_error(&format!(
+        "Cannot assign to read only property '{index}' of object '[object Array]'"
+    ));
+}
+
+/// A strict-mode write that would *add* a new index to a non-extensible
+/// (frozen / sealed / preventExtensions'd) array — `arr[i] = v` with
+/// `i >= length` — is `CreateDataProperty` on a non-extensible object with
+/// `Throw = true`, so it must throw a **TypeError**. Matches V8's message.
+#[cold]
+fn throw_array_not_extensible_add(index: u32) -> ! {
+    crate::collection_iter::throw_type_error(&format!(
+        "Cannot add property {index}, object is not extensible"
+    ));
+}
+
 /// Lazily-memoized address of the `Array.prototype` array, and a sticky flag
 /// recording whether anyone has installed an indexed property on it. An
 /// out-of-bounds element read on an ordinary array must fall through to
@@ -830,6 +855,61 @@ pub extern "C" fn js_array_set_f64(arr: *mut ArrayHeader, index: u32, value: f64
     }
 }
 
+/// Strict-mode `arr[i] = v` — the user-visible element assignment, i.e.
+/// `Set(O, ToString(i), v, true)` (PutValue with `Throw = true`). On a frozen
+/// array this must throw a **TypeError** instead of silently no-oping: writing
+/// an existing index is a read-only violation; adding a new index (or writing
+/// any index of a sealed / preventExtensions'd array past its length) is a
+/// not-extensible violation.
+///
+/// Kept separate from `js_array_set_f64_extend` so the *internal* callers of the
+/// latter — `Object.defineProperty(arr, i, …)` (which uses it as a raw
+/// `[[DefineOwnProperty]]` slot-writer after clearing attrs),
+/// `polymorphic_index`, and freshly-allocated runtime arrays — retain their
+/// silent, non-throwing contract. Only the `arr[i] = v` assignment codegen
+/// (`index_set` / `index` / `field_set_by_name`) routes here.
+/// test262 built-ins/Array element/add on frozen|sealed|non-extensible.
+/// Strict-mode guard for a would-be `arr[index] = v` element write: throws the
+/// spec `Set`-with-`Throw` TypeError when `arr` is frozen (existing index →
+/// read-only) or non-extensible and the index is new (→ not-extensible). No-op
+/// for writable slots, buffers, and typed arrays (which own their store
+/// semantics). Shared by the strict element-write entry points.
+#[inline]
+pub(crate) fn array_strict_index_write_guard(arr: *mut ArrayHeader, index: u32) {
+    let clean = clean_arr_ptr_mut(arr);
+    if clean.is_null()
+        || crate::buffer::is_registered_buffer(clean as usize)
+        || crate::typedarray::lookup_typed_array_kind(clean as usize).is_some()
+    {
+        return;
+    }
+    let flags = array_object_flags(clean);
+    let length = unsafe { (*clean).length };
+    if index < length {
+        // Existing index: only a *frozen* array's data is non-writable; a
+        // sealed / non-extensible array still permits overwriting it.
+        if flags & crate::gc::OBJ_FLAG_FROZEN != 0 {
+            throw_frozen_array_index_write(index);
+        }
+    } else if flags
+        & (crate::gc::OBJ_FLAG_FROZEN | crate::gc::OBJ_FLAG_SEALED | crate::gc::OBJ_FLAG_NO_EXTEND)
+        != 0
+    {
+        // New index on a non-extensible array: cannot add the property.
+        throw_array_not_extensible_add(index);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_set_f64_extend_strict(
+    arr: *mut ArrayHeader,
+    index: u32,
+    value: f64,
+) -> *mut ArrayHeader {
+    array_strict_index_write_guard(arr, index);
+    js_array_set_f64_extend(arr, index, value)
+}
+
 /// Set an element in an array by index, extending the array if needed
 /// Returns the (possibly reallocated) array pointer
 /// This mimics JavaScript's arr[i] = value behavior
@@ -1484,4 +1564,64 @@ pub extern "C" fn js_array_set_index_or_string(
         }
     }
     arr
+}
+
+/// Strict-mode `arr[key] = v` (dynamic index-or-string key) — `Set` with
+/// `Throw = true`. For a canonical numeric index this enforces the frozen /
+/// non-extensible guard (throwing a TypeError) before delegating; non-index
+/// keys fall through to the ordinary path unchanged. This is the assignment
+/// entry point behind `js_typed_feedback_array_set_index_or_string`; the plain
+/// `js_array_set_index_or_string` keeps its silent contract for any internal
+/// caller. test262 built-ins/Array element-write-on-frozen (string/dynamic key).
+#[no_mangle]
+pub extern "C" fn js_array_set_index_or_string_strict(
+    arr: *mut ArrayHeader,
+    idx: f64,
+    value: f64,
+) -> *mut ArrayHeader {
+    if !arr.is_null() {
+        // Resolve the canonical array-index interpretation of the key (mirrors
+        // the numeric branch of `js_array_set_index_or_string`), and guard it.
+        // A string key that spells an index (`"0"`) also targets the element
+        // store, so ToString it and re-parse.
+        let index = canonical_index_of_set_key(idx);
+        if let Some(i) = index {
+            array_strict_index_write_guard(arr, i);
+        }
+    }
+    js_array_set_index_or_string(arr, idx, value)
+}
+
+/// The canonical array index (`0..2^32-1`) a dynamic `arr[key] = v` key targets,
+/// or `None` for a non-index key. Numbers use the array-index boundary; string
+/// keys are parsed via their ToString so `arr["3"]` on a frozen array throws
+/// like `arr[3]`.
+fn canonical_index_of_set_key(idx: f64) -> Option<u32> {
+    let bits = idx.to_bits();
+    let top16 = bits >> 48;
+    // Heap string / SSO key: parse the string as a canonical index.
+    if top16 == 0x7FFF || top16 == 0x7FF9 {
+        let s = crate::value::js_get_string_pointer_unified(idx) as *const crate::StringHeader;
+        if s.is_null() {
+            return None;
+        }
+        let len = unsafe { (*s).byte_len as usize };
+        let data = unsafe { (s as *const u8).add(std::mem::size_of::<crate::StringHeader>()) };
+        let bytes = unsafe { std::slice::from_raw_parts(data, len) };
+        let name = std::str::from_utf8(bytes).ok()?;
+        return crate::object::canonical_array_index(name);
+    }
+    // Numeric key.
+    let n = if (bits & crate::value::TAG_MASK) == crate::value::INT32_TAG {
+        crate::value::JSValue::from_bits(bits).as_int32() as f64
+    } else if !(0x7FF8..=0x7FFF).contains(&top16) {
+        idx
+    } else {
+        return None;
+    };
+    if n.is_finite() && n.trunc() == n && n >= 0.0 && n < u32::MAX as f64 {
+        Some(n as u32)
+    } else {
+        None
+    }
 }

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -79,8 +79,8 @@ pub use self::indexing::{
     js_array_get_element, js_array_get_element_f64, js_array_get_f64, js_array_get_f64_unchecked,
     js_array_get_index_or_string, js_array_get_length, js_array_length,
     js_array_numeric_get_f64_unboxed, js_array_numeric_set_f64_unboxed, js_array_set_f64,
-    js_array_set_f64_extend, js_array_set_f64_unchecked, js_array_set_index_or_string,
-    js_array_set_string_key,
+    js_array_set_f64_extend, js_array_set_f64_extend_strict, js_array_set_f64_unchecked,
+    js_array_set_index_or_string, js_array_set_index_or_string_strict, js_array_set_string_key,
 };
 pub use self::is_array::js_array_is_array;
 pub(crate) use self::iter_methods::throw_reduce_of_empty;
@@ -119,7 +119,8 @@ pub(crate) use self::push_pop::guard_writable_length;
 pub use self::push_pop::{
     js_array_delete, js_array_grow, js_array_numeric_push_f64_unboxed, js_array_pop_f64,
     js_array_push_f64, js_array_push_hole, js_array_push_spread_f64, js_array_set_length,
-    js_array_shift_f64, js_array_unshift_f64, js_array_unshift_jsvalue, js_array_unshift_variadic,
+    js_array_set_length_strict, js_array_shift_f64, js_array_unshift_f64, js_array_unshift_jsvalue,
+    js_array_unshift_variadic,
 };
 pub use self::reduce_right::js_array_reduce_right;
 pub use self::search::{

--- a/crates/perry-runtime/src/array/push_pop.rs
+++ b/crates/perry-runtime/src/array/push_pop.rs
@@ -380,6 +380,32 @@ pub extern "C" fn js_array_pop_f64(arr: *mut ArrayHeader) -> f64 {
 /// JSValue). The JS ArraySetLength path coerces it with `Number(...)`, then
 /// rejects NaN, negative, fractional, infinite, and >uint32 lengths with
 /// `RangeError: Invalid array length`.
+/// `arr.length = v` as the user-visible assignment — `Set(O, "length", v, true)`
+/// (PutValue with `Throw = true`, ECMA-262 §13.15.2). A frozen array's `length`
+/// is a non-writable data property, so the write must throw a **TypeError**
+/// rather than silently no-op — even when `v` equals the current length or is an
+/// invalid length (V8 rejects the non-writable write before coercing the value,
+/// so a frozen `arr.length = -1` is a TypeError, not a RangeError; hence the
+/// guard precedes `array_length_from_property_value_or_throw`).
+///
+/// This throwing variant is separate from `js_array_set_length` so the *internal*
+/// callers of the latter (`Object.defineProperty(arr, "length", …)`,
+/// array-object length coercion, stream/url bookkeeping) keep their silent,
+/// non-throwing `[[DefineOwnProperty]]`/no-Throw contract. Only the assignment
+/// codegen paths (`field_set_by_name` / `property_set` / proxy `PutValue`) route
+/// here. test262 built-ins/Array length-write-on-frozen.
+#[no_mangle]
+pub extern "C" fn js_array_set_length_strict(arr: *mut ArrayHeader, new_length: f64) {
+    let arr = clean_arr_ptr_mut(arr);
+    if arr.is_null() {
+        return;
+    }
+    if unsafe { array_object_flags(arr) } & crate::gc::OBJ_FLAG_FROZEN != 0 {
+        throw_non_writable_length();
+    }
+    js_array_set_length(arr, new_length);
+}
+
 #[no_mangle]
 pub extern "C" fn js_array_set_length(arr: *mut ArrayHeader, new_length: f64) {
     let arr = clean_arr_ptr_mut(arr);

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -577,7 +577,12 @@ pub extern "C" fn js_object_set_field_by_name(
             let gc_header =
                 (obj as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
             if (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY {
-                crate::array::js_array_set_length(obj as *mut crate::array::ArrayHeader, value);
+                // Assignment (`arr.length = v`) is a strict `Set` with
+                // `Throw = true`: throw on a frozen array's non-writable length.
+                crate::array::js_array_set_length_strict(
+                    obj as *mut crate::array::ArrayHeader,
+                    value,
+                );
                 return;
             }
         }
@@ -614,11 +619,13 @@ pub extern "C" fn js_object_set_field_by_name(
             };
             let arr = obj as *mut crate::array::ArrayHeader;
             if name == "length" {
-                crate::array::js_array_set_length(arr, value);
+                // Strict `Set(arr, "length", v, true)` — throw on frozen.
+                crate::array::js_array_set_length_strict(arr, value);
                 return;
             }
             if let Some(index) = super::canonical_array_index(name) {
-                crate::array::js_array_set_f64_extend(arr, index, value);
+                // Strict `Set(arr, i, v, true)` — throw on frozen/non-extensible.
+                crate::array::js_array_set_f64_extend_strict(arr, index, value);
                 return;
             }
             // Own-accessor short-circuit — an Array can carry a named accessor

--- a/crates/perry-runtime/src/proxy/put_value.rs
+++ b/crates/perry-runtime/src/proxy/put_value.rs
@@ -188,7 +188,14 @@ pub extern "C" fn js_put_value_set(
         }
         if target.to_bits() == receiver.to_bits() && key_is_length(property_key) {
             if let Some(arr) = array_ptr_from_value(target) {
-                crate::array::js_array_set_length(arr, value);
+                // PutValue(`arr.length = v`) is `Set(O, "length", v, Throw)`. In
+                // strict mode a frozen array's non-writable `length` makes the
+                // write throw a TypeError instead of silently no-oping.
+                if strict != 0 {
+                    crate::array::js_array_set_length_strict(arr, value);
+                } else {
+                    crate::array::js_array_set_length(arr, value);
+                }
                 return value;
             }
         }

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -1782,7 +1782,10 @@ pub extern "C" fn js_typed_feedback_array_set_f64_extend(
     if !pass {
         record_fallback_call(site_id);
     }
-    crate::array::js_array_set_f64_extend(arr, index, value)
+    // This wrapper is only emitted for the source-level `arr[i] = v` assignment,
+    // so it carries strict `Set`-with-`Throw` semantics: a frozen array's element
+    // is non-writable and a non-extensible array rejects a new index → TypeError.
+    crate::array::js_array_set_f64_extend_strict(arr, index, value)
 }
 
 #[no_mangle]
@@ -2029,7 +2032,9 @@ pub extern "C" fn js_typed_feedback_array_set_index_or_string(
     } else {
         record_guard_pass(site_id);
     }
-    crate::array::js_array_set_index_or_string(arr, idx, value)
+    // Assignment-site wrapper → strict `Set` with `Throw = true` (frozen /
+    // non-extensible array element write throws a TypeError).
+    crate::array::js_array_set_index_or_string_strict(arr, idx, value)
 }
 
 #[no_mangle]


### PR DESCRIPTION
## Summary

Perry compiles everything strict, so a source-level array element or `length` assignment is `Set(O, P, V, Throw = true)`. On a **frozen** array those targets are non-writable, so the write must throw a `TypeError` — Perry silently no-oped instead, a batch of test262 missed-negatives (`Perry ran clean; Node rejected`):

```js
"use strict";
const a = Object.freeze([1, 2, 3]);
a[0] = 9;       // was: silent   → now: TypeError  (read only property '0')
a[5] = 9;       // was: silent   → now: TypeError  (object is not extensible)
a.length = 1;   // was: silent   → now: TypeError  (read only property 'length')
```

Adding a **new** index to any non-extensible array (frozen / sealed / `preventExtensions`'d) likewise now throws `object is not extensible`, matching V8/Node. Overwriting an *existing* index of a sealed / non-extensible (but not frozen) array still succeeds, as it should.

## Approach

Strict variants beside the existing silent helpers, so **only** user assignments throw and every internal caller keeps its no-`Throw` contract:

- `js_array_set_f64_extend_strict` / `js_array_set_index_or_string_strict` — element writes; share `array_strict_index_write_guard` (existing index of a frozen array → read-only; new index of a non-extensible array → not-extensible; only `is_frozen` gates the in-bounds case, so sealed/non-extensible overwrites of an existing index still succeed).
- `js_array_set_length_strict` — frozen `length` write, even for an equal or invalid new value (V8 rejects the non-writable write before it coerces the value, so a frozen `arr.length = -1` is a `TypeError`, not a `RangeError`; the guard precedes the length parse).

The plain `js_array_set_{f64_extend,index_or_string,length}` helpers keep their **silent** behaviour for their internal callers — `Object.defineProperty` (which uses them as raw `[[DefineOwnProperty]]` slot-writers after clearing attrs), array-object length coercion, `polymorphic_index`, and freshly-allocated runtime arrays. Only the assignment paths are re-pointed to the strict variants:

- the `arr[i] = v` codegen — the `js_typed_feedback_array_set_{f64_extend,index_or_string}` wrappers (emitted only for the source-level assignment) plus the realloc slow path in `expr/index.rs`;
- the `arr.length = v` codegen — `expr/property_set.rs`;
- the generic runtime PutValue helper `js_object_set_field_by_name`;
- `js_put_value_set` (gated on its `strict` flag).

## Files (9)

Runtime: `array/indexing.rs`, `array/push_pop.rs`, `array/mod.rs`, `object/field_set_by_name.rs`, `proxy/put_value.rs`, `typed_feedback.rs`. Codegen: `expr/index.rs`, `expr/property_set.rs`, `runtime_decls/arrays.rs`.

## Verification (internal Linux sweep host)

Matches Node byte-for-byte in **both** default (auto-optimize) and `PERRY_NO_AUTO_OPTIMIZE` builds:

- frozen element (existing / new) + length (shrink / grow / same-value) all throw `TypeError`;
- sealed / `preventExtensions` add-new-index throws; existing-index overwrite still succeeds;
- normal (unfrozen) element / length / string-index / computed / dense-loop writes are unchanged — **no over-throw**;
- `Object.defineProperty(frozenArr, …)` (same-value ok, changed-value throws via its own validation) and frozen `concat` / `map` / `slice` / spread read-then-build ops are unaffected.

Regression sweep over `built-ins/Array` + `built-ins/Object` + `language/expressions/assignment` (5,832 pass, 98.7% parity): **zero** new over-throws — no failure carries any of the new TypeError messages, and the pre-existing failures (mutator mid-operation freeze, `defineProperty` edge cases, dynamic-`Function` AOT refusals) are unchanged.

## Out of scope

Separate, non-frozen subclusters left for follow-ups: sealed-array `.length` **shrink**, and `defineProperty`-installed non-writable index/length descriptors on writes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Array index and `length` assignments now correctly throw errors when writing to frozen or non-extensible arrays, instead of failing silently.
  * Strict assignment behavior is now applied consistently across direct property writes, indexed element writes, and fallback paths.
  * Writes to `arr.length` now respect read-only restrictions in strict mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->