### PR TITLE
fix(hir): capture forward-refs bound later in the same `let` declaration

### DIFF
--- a/crates/perry-hir/src/lower_decl/block.rs
+++ b/crates/perry-hir/src/lower_decl/block.rs
@@ -81,6 +81,27 @@ pub(crate) fn pre_register_forward_captured_lets(
                             ctx.lexical_forward_decls.insert(span_lo, id);
                         }
                     }
+                    // A closure in an EARLIER declarator of THIS same
+                    // `let`/`const` can forward-reference a name bound by a LATER
+                    // declarator in the SAME declaration:
+                    //   `let z = (w) => { … O … Y … A … },
+                    //        Y = () => z(false),
+                    //        A = () => clearTimeout(O),
+                    //        O = setTimeout(z, K);`
+                    // (the minified `new Promise` executor shape). Record this
+                    // declarator's closure refs NOW so the later declarators are
+                    // seen as forward-captured too — `seen_closure_refs` is
+                    // otherwise only updated by the trailing `cic_stmt` AFTER the
+                    // whole declaration, so intra-declaration forward-refs were
+                    // missed: the later names never got pre-registered, so the
+                    // ref fell through to `js_global_get_or_throw_unresolved` and
+                    // the closure captured a global instead of the local box —
+                    // e.g. a `new Promise` `resolve` that never fires, hanging
+                    // the awaiting caller. Cross-statement forward-refs were
+                    // already handled by the trailing `cic_stmt`.
+                    if let Some(init) = &decl.init {
+                        cic_expr(init, false, &mut seen_closure_refs);
+                    }
                 }
             } else {
                 // `var` bindings are already predefined + boxed by

--- a/crates/perry/tests/issue_forward_captured_lets_comma_decl.rs
+++ b/crates/perry/tests/issue_forward_captured_lets_comma_decl.rs
@@ -1,0 +1,122 @@
+//! Regression test: a closure declared FIRST in a single `let`/`const`
+//! declaration that forward-references names bound by LATER declarators of the
+//! SAME declaration must capture them (as boxed locals), not fall through to a
+//! global-by-name lookup.
+//!
+//! The minified `new Promise` executor shape triggers this:
+//! ```js
+//! new Promise((resolve) => {
+//!   let z = (w) => { clearTimeout(O); q.off(...); resolve(w); },
+//!       Y = () => z(false),
+//!       A = () => clearTimeout(O),
+//!       O = setTimeout(z, K);   // z forward-refs O/Y/A in the same `let`
+//!   ...
+//! })
+//! ```
+//! Before the fix, `pre_register_forward_captured_lets` only recorded a
+//! statement's closure-refs AFTER the whole declaration, so the later
+//! declarators (`O`/`Y`/`A`) were never seen as forward-captured and lowered to
+//! `js_global_get_or_throw_unresolved`. That globalization shifted the closure's
+//! capture slots so its captured `resolve` read the wrong value — the promise
+//! never settled and the awaiting caller hung forever.
+
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile(dir: &std::path::Path, source: &str) -> PathBuf {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    output
+}
+
+/// Run `bin`, failing if it doesn't exit within `secs` (the bug is a hang —
+/// the promise never settles so `await` never returns).
+fn run_with_timeout(bin: &std::path::Path, secs: u64) -> String {
+    let mut child = Command::new(bin)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .stdin(Stdio::null())
+        .spawn()
+        .expect("spawn compiled binary");
+    let mut piped = child.stdout.take().expect("piped stdout");
+    let reader = std::thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = piped.read_to_string(&mut buf);
+        buf
+    });
+    let deadline = Instant::now() + Duration::from_secs(secs);
+    loop {
+        match child.try_wait().expect("try_wait") {
+            Some(status) => {
+                let stdout = reader.join().unwrap_or_default();
+                assert!(
+                    status.success(),
+                    "binary exited non-zero: {status:?}\n{stdout}"
+                );
+                return stdout;
+            }
+            None if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let stdout = reader.join().unwrap_or_default();
+                panic!(
+                    "regression: process hung >{secs}s — a closure's forward-ref to \
+                     a later declarator in the same `let` globalized, so its captured \
+                     `resolve` never settled the promise.\nstdout so far:\n{stdout}"
+                );
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    }
+}
+
+#[test]
+fn forward_captured_lets_in_comma_declaration_resolve_promise() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let bin = compile(
+        dir.path(),
+        r#"
+function makeP(): Promise<string> {
+  return new Promise<string>((resolve) => {
+    // z (declared FIRST) forward-references O/Y/A declared LATER in this
+    // same `let`, and captures the executor param `resolve`.
+    let z = (w: string) => { clearTimeout(O); off(Y); off(A); resolve(w); },
+        Y = () => z("via-Y"),
+        A = () => {},
+        O: any = setTimeout(() => resolve("TIMEOUT"), 10000);
+    function off(_f: any) {}
+    setTimeout(Y, 5);   // fire Y -> z -> resolve("via-Y")
+  });
+}
+
+async function main() {
+  const r = await makeP();
+  process.stdout.write("RESULT=" + r + "\n");
+}
+main();
+"#,
+    );
+    let stdout = run_with_timeout(&bin, 20);
+    assert_eq!(stdout, "RESULT=via-Y\n");
+}


### PR DESCRIPTION
## Summary
A closure declared in an **earlier declarator** of a `let`/`const` declaration that references names bound by **later declarators of the same declaration** failed to capture them — they lowered to `js_global_get_or_throw_unresolved` (a global-by-name lookup) instead of a captured local box.

The minified `new Promise` executor shape triggers this:
```js
new Promise((resolve) => {
  let z = (w) => { clearTimeout(O); q.off("end", Y); q.off("data", A); resolve(w); },
      Y = () => z(false),
      A = () => clearTimeout(O),
      O = setTimeout(z, K);   // z (declarator 1) forward-refs O/Y/A (later declarators)
  q.once("end", Y);
  q.once("data", A);
})
```

## Root cause
`pre_register_forward_captured_lets` (`crates/perry-hir/src/lower_decl/block.rs`) builds `seen_closure_refs` only via the trailing `cic_stmt`, which runs **after** the whole `var_decl` is processed. So for a single `let` with multiple declarators, when the later declarators (`O`/`Y`/`A`) are checked, `seen_closure_refs` is still empty — z's references to them aren't recorded yet — and they're never pre-registered. The forward-ref then falls through to `js_global_get_or_throw_unresolved`.

That globalization also shifts the closure's capture-slot indices, so the closure's captured `resolve` reads the wrong slot: the promise never settles and the awaiting caller hangs forever.

Cross-*statement* forward-refs (`let z = () => O; let O = …;`) were already handled by the trailing `cic_stmt`; only the intra-*declaration* case was missed.

## Fix
Record each declarator's closure-refs immediately (via `cic_expr(decl.init, …)`) so subsequent declarators in the same declaration are seen as forward-captured and pre-registered.

## Test
`crates/perry/tests/issue_forward_captured_lets_comma_decl.rs` — compiles and runs the comma-`let` forward-ref → `new Promise` shape and asserts the promise resolves (regression is a hang the harness catches). Passes; `perry-hir` lib tests: 221 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed closure capture for comma-separated `let`/`const` declarations by ensuring forward-referenced locals in the same statement are handled correctly.
  * Improved execution correctness for programs that rely on these forward-captured closures, preventing hangs/stalled async behavior.
* **Tests**
  * Added a new end-to-end regression test that compiles and runs a TypeScript case to confirm the promise resolves as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->