### PR TITLE
fix(runtime): test262 built-ins value/throw bugs — primitive brand, valueOf shadow, Math.round, Error.toString, radix coercion

### DIFF
--- a/crates/perry-codegen/src/expr/math_simple.rs
+++ b/crates/perry-codegen/src/expr/math_simple.rs
@@ -954,17 +954,13 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(ctx.block().call(DOUBLE, "llvm.ceil.f64", &[(DOUBLE, &v)]))
         }
         Expr::MathRound(operand) => {
-            // JS Math.round: round-half-toward-positive-infinity. We
-            // emulate via floor(x + 0.5) then fcopysign to preserve -0.
+            // JS Math.round: round-half-toward-+∞ with -0 preservation. The
+            // inline `floor(x + 0.5)` is wrong for `x = 0.5 - ε/4` (the add
+            // pre-rounds to 1.0) and large odd integers (the `.5` is lost) — see
+            // js_math_round_value / test262 Math/round/S15.8.2.15_A7 — so route
+            // through the runtime helper that compares the exact fractional part.
             let v = lower_math_operand(ctx, operand)?;
-            let blk = ctx.block();
-            let half = blk.fadd(&v, "0.5");
-            let floored = blk.call(DOUBLE, "llvm.floor.f64", &[(DOUBLE, &half)]);
-            Ok(blk.call(
-                DOUBLE,
-                "llvm.copysign.f64",
-                &[(DOUBLE, &floored), (DOUBLE, &v)],
-            ))
+            Ok(ctx.block().call(DOUBLE, "js_math_round", &[(DOUBLE, &v)]))
         }
         Expr::MathTrunc(operand) => {
             let v = lower_expr(ctx, operand)?;

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -70,6 +70,7 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // coercion + undefined/RegExp handling (ECMA-262 §22.1.3.21).
     module.declare_function("js_string_split_value", I64, &[I64, DOUBLE, DOUBLE]);
     module.declare_function("js_math_trunc", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_math_round", DOUBLE, &[DOUBLE]);
     module.declare_function("js_math_sign", DOUBLE, &[DOUBLE]);
     module.declare_function("js_math_imul", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_math_pow", DOUBLE, &[DOUBLE, DOUBLE]);

--- a/crates/perry-runtime/src/math.rs
+++ b/crates/perry-runtime/src/math.rs
@@ -26,6 +26,15 @@ pub extern "C" fn js_math_trunc(value: f64) -> f64 {
     js_math_to_number(value).trunc()
 }
 
+/// Math.round(x) -> number. ECMA-262 21.3.2.28 round-half-toward-+∞ with -0
+/// preservation. The naive `floor(x + 0.5)` mis-rounds `0.5 - ε/4` (the `+ 0.5`
+/// add pre-rounds up to 1.0) and large odd integers where the `.5` is lost; see
+/// `js_math_round_value` (test262 Math/round/S15.8.2.15_A7).
+#[no_mangle]
+pub extern "C" fn js_math_round(value: f64) -> f64 {
+    crate::object::js_math_round_value(js_math_to_number(value))
+}
+
 /// Math.sign(x) -> number
 #[no_mangle]
 pub extern "C" fn js_math_sign(value: f64) -> f64 {
@@ -436,6 +445,28 @@ mod tests {
         assert_eq!(js_math_trunc(f64::INFINITY), f64::INFINITY);
         assert_eq!(js_math_trunc(f64::NEG_INFINITY), f64::NEG_INFINITY);
         assert!(is_neg_zero(js_math_trunc(-0.0)));
+    }
+
+    #[test]
+    fn js_math_round_matches_spec_half_and_neg_zero() {
+        // Half rounds toward +∞.
+        assert_eq!(js_math_round(0.5), 1.0);
+        assert_eq!(js_math_round(2.5), 3.0);
+        assert_eq!(js_math_round(-0.5), 0.0);
+        assert!(is_neg_zero(js_math_round(-0.5)));
+        assert!(is_neg_zero(js_math_round(-0.25)));
+        // `0.5 - ε/4` is strictly below a half → +0, where floor(x+0.5) gives 1.
+        let x = 0.5 - f64::EPSILON / 4.0;
+        assert_eq!(js_math_round(x), 0.0);
+        assert!(!is_neg_zero(js_math_round(x)));
+        // Large odd integers are returned unchanged (the `.5` add would vanish).
+        let big = 1.0 / f64::EPSILON + 1.0;
+        assert_eq!(js_math_round(big), big);
+        assert_eq!(js_math_round(-big), -big);
+        // NaN / ±0 / ±Infinity pass through.
+        assert!(js_math_round(f64::NAN).is_nan());
+        assert!(is_neg_zero(js_math_round(-0.0)));
+        assert_eq!(js_math_round(f64::INFINITY), f64::INFINITY);
     }
 
     #[test]

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -65,9 +65,9 @@ pub(crate) use builtin_thunks::{
     global_this_is_finite_thunk, global_this_is_nan_thunk, global_this_number_thunk,
     global_this_object_thunk, global_this_parse_float_thunk, global_this_parse_int_thunk,
     global_this_string_thunk, global_this_structured_clone_thunk, global_this_unescape_thunk,
-    math_atan2_thunk, math_clz32_thunk, math_f16round_thunk, math_hypot_thunk, math_imul_thunk,
-    math_max_thunk, math_min_thunk, math_pow_thunk, math_random_thunk, math_round_thunk,
-    math_sign_thunk, proxy_revocable_thunk,
+    js_math_round_value, math_atan2_thunk, math_clz32_thunk, math_f16round_thunk, math_hypot_thunk,
+    math_imul_thunk, math_max_thunk, math_min_thunk, math_pow_thunk, math_random_thunk,
+    math_round_thunk, math_sign_thunk, proxy_revocable_thunk,
 };
 pub use ctor_thunks::js_webcrypto_illegal_constructor;
 pub(crate) use ctor_thunks::{

--- a/crates/perry-runtime/src/object/global_this/array_error.rs
+++ b/crates/perry-runtime/src/object/global_this/array_error.rs
@@ -288,7 +288,16 @@ pub(crate) extern "C" fn error_prototype_to_string_thunk(
 ) -> f64 {
     let this_value = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
     let this_jsv = crate::value::JSValue::from_bits(this_value.to_bits());
-    if !this_jsv.is_pointer() || this_jsv.is_null() || this_jsv.is_undefined() {
+    // ECMA-262 20.5.3.4 step 2: `If Type(O) is not Object, throw a TypeError`.
+    // A Symbol is a POINTER_TAG value (registered-symbol id), so it slips past
+    // the `is_pointer` gate — reject it explicitly (test262 Error/prototype/
+    // toString/invalid-receiver, which drives undefined/null/1/true/string/
+    // Symbol through `.call`).
+    if !this_jsv.is_pointer()
+        || this_jsv.is_null()
+        || this_jsv.is_undefined()
+        || unsafe { crate::symbol::js_is_symbol(this_value) } != 0
+    {
         super::super::object_ops::throw_object_type_error(
             b"Error.prototype.toString called on non-object",
         );
@@ -321,6 +330,11 @@ fn error_to_string_property(this_value: f64, key: &'static [u8], default: &str) 
     if value_jsv.is_undefined() {
         return default.to_string();
     }
+    // ECMA-262 20.5.3.4 step 6/10: `msg`/`name` are coerced with ToString,
+    // which throws a TypeError for a Symbol (test262 Error/prototype/toString/
+    // tostring-message-throws-symbol). `js_jsvalue_to_string` otherwise renders
+    // `Symbol(desc)` and swallows the throw.
+    crate::builtins::reject_symbol_to_string(value);
     let string = crate::value::js_jsvalue_to_string(value);
     unsafe { string_header_to_owned(string) }
 }

--- a/crates/perry-runtime/src/object/global_this/builtin_thunks.rs
+++ b/crates/perry-runtime/src/object/global_this/builtin_thunks.rs
@@ -138,10 +138,24 @@ pub(crate) extern "C" fn math_round_thunk(
     value: f64,
 ) -> f64 {
     let x = math_number_arg(value);
+    js_math_round_value(x)
+}
+
+/// ECMA-262 21.3.2.28 `Math.round`. The naive `floor(x + 0.5)` is wrong for
+/// two families the spec calls out (test262 Math/round/S15.8.2.15_A7):
+///   * `x = 0.5 - ε/4` (just under a half): `x + 0.5` rounds *up* to exactly
+///     `1.0` in f64, so `floor` yields 1 — but the true value is < 0.5 and must
+///     round to +0.
+///   * large odd integers where `x + 0.5 == x` loses the `.5`.
+/// Rounding via `r = floor(x)` then comparing the *exact* fractional part
+/// `x - r` against 0.5 avoids the pre-rounding of the `+ 0.5` add. Half rounds
+/// toward +∞ (the larger integer), and the `[-0.5, -0)` band returns -0.
+pub(crate) fn js_math_round_value(x: f64) -> f64 {
     if x == 0.0 || x.is_nan() || x.is_infinite() {
         return x;
     }
-    let rounded = (x + 0.5).floor();
+    let r = x.floor();
+    let rounded = if x - r >= 0.5 { r + 1.0 } else { r };
     if rounded == 0.0 && x.is_sign_negative() {
         -0.0
     } else {

--- a/crates/perry-runtime/src/object/native_call_method/primitive_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/primitive_methods.rs
@@ -177,6 +177,29 @@ pub(super) unsafe fn dispatch_primitive(
     }
 
     if let Some((_, payload)) = crate::builtins::boxed_primitive_payload(object) {
+        // An own `valueOf`/`toString`/`toLocaleString` data property shadows the
+        // intrinsic wrapper method: `var s = new String(); s.valueOf =
+        // Number.prototype.valueOf; s.valueOf()` must run the *transferred*
+        // method (which brand-checks its receiver and throws a TypeError),
+        // not this boxed-primitive fast path that unwraps the [[StringData]]
+        // (test262 Number/prototype/valueOf/S15.7.4.4_A2_*, Boolean/prototype/
+        // valueOf/S15.6.4.3_A2_*). Fall through to the own-property dispatch in
+        // `common_methods::dispatch_common` when such a shadow exists.
+        if jsval.is_pointer() && matches!(method_name, "valueOf" | "toString" | "toLocaleString") {
+            let own = crate::object::js_object_get_own_field_or_undef(
+                object,
+                method_name.as_ptr(),
+                method_name.len(),
+            );
+            let own_jsv = JSValue::from_bits(own.to_bits());
+            if own_jsv.is_pointer()
+                && crate::closure::is_closure_ptr(
+                    (own.to_bits() & crate::value::POINTER_MASK) as usize,
+                )
+            {
+                return None;
+            }
+        }
         match method_name {
             "valueOf" => return Some(payload),
             "toString" | "toLocaleString" => {

--- a/crates/perry-runtime/src/object/to_string_tag.rs
+++ b/crates/perry-runtime/src/object/to_string_tag.rs
@@ -273,6 +273,27 @@ pub unsafe extern "C" fn js_object_to_string(value: f64) -> f64 {
         let str_ptr = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
         return f64::from_bits(STRING_TAG | (str_ptr as u64 & POINTER_MASK));
     }
+    // Intrinsic primitive-wrapper prototypes carry the corresponding internal
+    // slot: `%Number.prototype%` has `[[NumberData]]` (+0), `%Boolean.prototype%`
+    // has `[[BooleanData]]` (false), `%String.prototype%` has `[[StringData]]`
+    // (""). ECMA-262 20.1.3.6 (`Object.prototype.toString`) therefore brands them
+    // `[object Number]` / `[object Boolean]` / `[object String]` rather than the
+    // generic `[object Object]` — observable once their own `toString` is deleted
+    // or overwritten with `Object.prototype.toString` (test262
+    // Number/prototype/S15.7.3.1_A2_T1, Boolean/prototype/S15.6.3.1_A1). This is
+    // placed after the `@@toStringTag` check so a user-installed tag still wins.
+    if jsv.is_pointer() {
+        for (name, tag) in [
+            ("Number", b"[object Number]".as_slice()),
+            ("Boolean", b"[object Boolean]".as_slice()),
+            ("String", b"[object String]".as_slice()),
+        ] {
+            if value.to_bits() == crate::object::builtin_prototype_value(name).to_bits() {
+                let str_ptr = crate::string::js_string_from_bytes(tag.as_ptr(), tag.len() as u32);
+                return f64::from_bits(STRING_TAG | (str_ptr as u64 & POINTER_MASK));
+            }
+        }
+    }
     if (raw_addr >= 0x10000 && crate::closure::is_closure_ptr(raw_addr))
         || crate::object::is_class_object_ptr(raw_addr as *const u8)
         || is_function_prototype_object_value(value)

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -1017,14 +1017,17 @@ unsafe fn radix_arg_to_number(radix_value: f64) -> f64 {
         } else {
             trimmed.parse::<f64>().unwrap_or(f64::NAN)
         }
+    } else if jsval.is_number() {
+        radix_value
     } else {
-        // Plain f64 number (or some other heap pointer that does not coerce
-        // to a finite radix — treat as NaN so it triggers RangeError).
-        if jsval.is_number() {
-            radix_value
-        } else {
-            f64::NAN
-        }
+        // An object radix runs ToNumber → OrdinaryToPrimitive(number), i.e. its
+        // `valueOf`/`toString`. An abrupt completion there must propagate rather
+        // than be swallowed into a `RangeError` (test262 Number/prototype/
+        // toString/numeric-literal-tostring-radix-poisoned:
+        // `0..toString({valueOf(){throw}})` must throw the poison, not a
+        // RangeError). `js_number_coerce` performs that coercion (and yields NaN
+        // for a non-coercible object, still landing on the RangeError path).
+        crate::builtins::js_number_coerce(radix_value)
     }
 }
 


### PR DESCRIPTION
Fixes a cluster of `built-ins/{Number,Boolean,Error,Math}` test262 value/throw
bugs found via the TS-subset test262 radar (`scripts/test262_subset.py`) on an
internal Linux sweep host. All fixes are spec-aligned and verified against
`node --experimental-strip-types`. 13 previously-failing cases now pass with
zero new regressions in the measured slice.

## Fixes

**1. `Object.prototype.toString` brands the primitive-wrapper prototypes**
(`object/to_string_tag.rs`). `%Number.prototype%` / `%Boolean.prototype%` /
`%String.prototype%` carry a `[[NumberData]]` / `[[BooleanData]]` /
`[[StringData]]` internal slot, so `Object.prototype.toString.call(Number.prototype)`
is `"[object Number]"`, not `"[object Object]"`. Observable once the wrapper's own
`toString` is deleted or overwritten with `Object.prototype.toString`.
Placed after the `@@toStringTag` check so a user tag still wins.
Fixes `Number/prototype/S15.7.3.1_A2_T1`, `_T2`, `S15.7.4_A1`, `Number/15.7.4-1`,
`Boolean/prototype/S15.6.3.1_A1`.

**2. An own `valueOf`/`toString`/`toLocaleString` shadows the boxed-primitive
fast path** (`native_call_method/primitive_methods.rs`). `var s = new String();
s.valueOf = Number.prototype.valueOf; s.valueOf()` must run the *transferred*
method (which brand-checks its receiver and throws a `TypeError`), not the
boxed-primitive fast path that unwraps `[[StringData]]`. When the wrapper object
has an own callable shadow, fall through to the own-property dispatch.
Fixes `Number/prototype/valueOf/S15.7.4.4_A2_T01`, `_T02`,
`Boolean/prototype/valueOf/S15.6.4.3_A2_T1`, `_T2`.

**3. `Math.round` uses the spec algorithm** (`math.rs`,
`object/global_this/builtin_thunks.rs`, codegen `expr/math_simple.rs` +
`runtime_decls/strings.rs`). The inline `floor(x + 0.5)` mis-rounds two families
ECMA-262 21.3.2.28 calls out: `x = 0.5 - ε/4` (the `+ 0.5` add pre-rounds up to
`1.0`) and large odd integers where the `.5` is lost. Round via `r = floor(x)`
then compare the *exact* fractional part `x - r` against `0.5`; half rounds
toward +∞ and the `[-0.5, -0)` band returns `-0`. Codegen now calls the shared
runtime `js_math_round`. Fixes `Math/round/S15.8.2.15_A7`.

**4. `Error.prototype.toString` receiver + message coercion**
(`object/global_this/array_error.rs`). A Symbol receiver (a POINTER_TAG value)
slipped past the `is_pointer` gate — reject it explicitly per step 2
(`If Type(O) is not Object, throw a TypeError`). And a Symbol `message`/`name` is
ToString-coerced (step 6/10), which must throw for a Symbol rather than render
`Symbol(desc)`. Fixes `Error/prototype/toString/invalid-receiver`,
`tostring-message-throws-symbol`.

**5. An object radix runs ToNumber (its `valueOf`)** (`value/to_string.rs`).
`(0).toString({valueOf(){throw}})` must propagate the thrown error, not swallow it
into a `RangeError`. Route an object radix through `js_number_coerce`
(OrdinaryToPrimitive number hint) before range-validating.
Fixes `Number/prototype/toString/numeric-literal-tostring-radix-poisoned`.

Adds a `js_math_round` unit test covering the half-rounding, `-0`, `0.5 - ε/4`,
and large-odd-integer cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved `Math.round` to match JavaScript semantics more closely, including correct handling of half values and negative zero.
  * `Object.prototype.toString` now recognizes primitive wrapper objects more accurately for number, boolean, and string values.

* **Bug Fixes**
  * Fixed `Error.prototype.toString` to reject symbol receivers and symbol name/message values consistently.
  * Corrected boxed primitive method dispatch so overridden methods are respected.
  * Updated number-radix handling so object values are coerced properly and user-defined errors can surface as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->