### PR TITLE
fix(hir): report dynamic-codegen unavailable to `new Function("")` probes by default

### DIFF
--- a/crates/perry-hir/src/eval_classifier.rs
+++ b/crates/perry-hir/src/eval_classifier.rs
@@ -319,20 +319,34 @@ pub fn eval_override_enabled() -> bool {
     env_flag("PERRY_ALLOW_EVAL")
 }
 
-/// Whether `PERRY_EVAL_CSP` is set — present runtime dynamic-code generation as
-/// *unavailable* to capability probes. With it set, a trivial no-op
-/// `new Function("")` / `Function("")` (the canonical
-/// `try { new Function(""), true } catch { false }` feature-test — the same
-/// shape a CSP `unsafe-eval` policy blocks) throws at construction instead of
-/// const-folding to a no-op function. Libraries that probe this way (e.g. zod 4's
-/// object-validator JIT) then take their non-codegen interpreter fallback, which
-/// perry compiles normally. Default off (spec-compliant: Node returns an empty
-/// function); opt-in for ahead-of-time binaries that hit such a JIT. Only the
-/// trivial no-op shape is affected — real literal bodies (`new Function("return
+/// Whether to present runtime dynamic-code generation as *unavailable* to
+/// capability probes. A trivial no-op `new Function("")` / `Function("")` is the
+/// canonical dynamic-codegen feature-test (`try { new Function(""), true } catch
+/// { false }` — the same shape a CSP `unsafe-eval` policy blocks). When this is
+/// on, that probe throws at *construction* instead of const-folding to a no-op
+/// function, so feature-detecting libraries (e.g. zod 4's object-validator JIT)
+/// take their non-codegen interpreter fallback, which perry compiles normally.
+///
+/// **Default ON.** Perry is ahead-of-time compiled and can NEVER honor a runtime
+/// `new Function(<string built at runtime>)` — such a call throws at
+/// construction (`js_function_ctor_from_strings`). Folding the empty-body probe
+/// to a working no-op makes the capability probe *lie*: a JIT then enables its
+/// codegen path and throws on the first real dynamic body (uncaught, this rejects
+/// the surrounding async work). Reporting the capability honestly as unavailable
+/// is both more correct for an AOT binary and lets such libraries run. Opt out —
+/// restoring the spec-literal empty-function fold (Node returns an empty
+/// function) — with `PERRY_EVAL_CSP=0` (also `off`/`false`/`no`). Only the
+/// trivial no-op probe is affected: real literal bodies (`new Function("return
 /// 42")`, the `return this` globalThis polyfill) still fold, so those idioms are
 /// unaffected.
 pub fn eval_csp_probe_unavailable() -> bool {
-    env_flag("PERRY_EVAL_CSP")
+    match std::env::var("PERRY_EVAL_CSP") {
+        Ok(v) => !matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "0" | "off" | "false" | "no"
+        ),
+        Err(_) => true,
+    }
 }
 
 /// Whether `PERRY_ALLOW_UNIMPLEMENTED` is set — forces non-strict (defer) mode

--- a/crates/perry/tests/issue_dynamic_function_probe_unavailable.rs
+++ b/crates/perry/tests/issue_dynamic_function_probe_unavailable.rs
@@ -1,0 +1,105 @@
+//! A trivial no-op `new Function("")` / `Function("")` is the canonical
+//! runtime-dynamic-code-generation capability probe:
+//!
+//! ```js
+//! const allowsEval = (() => { try { return (new Function(""), true); }
+//!                             catch { return false; } })();
+//! ```
+//!
+//! Perry is ahead-of-time compiled and can NEVER honor a runtime
+//! `new Function(<string built at runtime>)` — that call throws at
+//! construction. Historically the empty-body probe const-folded to a working
+//! no-op, so the probe reported the capability as *available* — a lie. A
+//! feature-detecting JIT (e.g. zod 4's object-validator) then enabled its
+//! codegen path and threw on the first real dynamic body, rejecting the
+//! surrounding async work.
+//!
+//! By default the probe now throws at construction (dynamic-codegen reported
+//! unavailable), so such libraries take their interpreter fallback. Opt out with
+//! `PERRY_EVAL_CSP=0`, which restores the spec-literal empty-function fold. Real
+//! literal bodies (`new Function("return 42")`, the `return this` globalThis
+//! polyfill) still fold regardless.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+/// Compile `source` (optionally with `PERRY_EVAL_CSP` set) and run it, returning
+/// trimmed stdout. Panics on a compile or non-zero run.
+fn compile_and_run(dir: &std::path::Path, source: &str, csp_env: Option<&str>) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let mut cmd = Command::new(perry_bin());
+    cmd.current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output);
+    if let Some(v) = csp_env {
+        cmd.env("PERRY_EVAL_CSP", v);
+    }
+    let compile = cmd.output().expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary exited non-zero: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).trim().to_string()
+}
+
+/// The exact zod-4 feature-test shape plus real-literal-body idioms.
+const PROBE_SOURCE: &str = r#"
+const allowsEval = (() => {
+  try { return (new Function(""), true); } catch { return false; }
+})();
+
+// A real literal body must still compile+run regardless of the probe result.
+const add = new Function("a", "b", "return a + b") as (a: number, b: number) => number;
+// The `Function("return this")()` globalThis polyfill must still work.
+const g: any = Function("return this")();
+
+process.stdout.write(
+  "allowsEval=" + allowsEval +
+  " add=" + add(2, 3) +
+  " global=" + (typeof g === "object" || typeof g === "undefined" ? "ok" : "NO") + "\n"
+);
+"#;
+
+#[test]
+fn dynamic_function_probe_reports_unavailable_by_default() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = compile_and_run(dir.path(), PROBE_SOURCE, None);
+    // Default: the empty-body probe throws -> feature detected as UNAVAILABLE,
+    // while real literal bodies + the globalThis polyfill still fold.
+    assert_eq!(
+        out, "allowsEval=false add=5 global=ok",
+        "default probe output"
+    );
+}
+
+#[test]
+fn dynamic_function_probe_opt_out_restores_empty_function() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = compile_and_run(dir.path(), PROBE_SOURCE, Some("0"));
+    // Opt out (PERRY_EVAL_CSP=0): the empty-body probe folds to a no-op function,
+    // so the feature test reports AVAILABLE (spec-literal Node behavior).
+    assert_eq!(
+        out, "allowsEval=true add=5 global=ok",
+        "opt-out probe output"
+    );
+}


### PR DESCRIPTION
## Problem

Perry is ahead-of-time compiled and can never honor a runtime `new Function(<string built at runtime>)` — such a call throws at construction (`js_function_ctor_from_strings`). But the canonical dynamic-codegen capability probe

```js
try { new Function(""), true } catch { false }
```

const-folded its trivial empty body to a working no-op function, so the probe reported the capability as **available** — a lie for an AOT binary.

A feature-detecting JIT then trusts that probe and enables its codegen path. **zod 4's object-validator** is the concrete case: its feature test (`allowsEval`) passes, so it builds a real validator via `new Function(dynamicBody)`, which perry refuses at construction. Uncaught inside zod's JIT, the throw rejects the surrounding async work (object validation), stalling a program that only needed zod's interpreter fallback — the very path the probe exists to select.

## Fix

Flip `eval_csp_probe_unavailable()` to **default ON**. The empty-body probe now throws at *construction* (dynamic-codegen honestly reported as unavailable, exactly as a CSP `unsafe-eval` policy would), so feature-detecting libraries take their non-codegen interpreter fallback, which perry compiles normally.

- **Opt out** — restoring the spec-literal empty-function fold (Node returns an empty function) — with `PERRY_EVAL_CSP=0` (also `off`/`false`/`no`).
- **Only the trivial no-op probe is affected.** Real literal bodies (`new Function("return 42")`, the `Function("return this")()` globalThis polyfill) still const-fold, so those idioms are unaffected.

## Trade-off

`new Function("")` now throws by default instead of returning an empty function, which diverges from Node / the spec-literal case. For an always-AOT compiler this is the more correct answer (the capability genuinely is unavailable), and it clears the zod-4 object-validation wall out of the box. The old behavior remains one env var away.

## Test

`crates/perry/tests/issue_dynamic_function_probe_unavailable.rs` — compiles + runs the exact zod-4 feature-test shape plus real-literal-body idioms:
- **default**: `allowsEval=false`, while `new Function("a","b","return a+b")(2,3)===5` and `Function("return this")()` still work.
- **`PERRY_EVAL_CSP=0`**: `allowsEval=true` (spec-literal empty-function fold restored).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default behavior for runtime code-generation checks so the empty-function safety probe is now treated as unavailable unless explicitly enabled.
  * Improved consistency for dynamic function handling: real function bodies and global access continue to work as expected.
  * Added coverage to verify both the default behavior and the opt-out setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->