### PR TITLE
fix(hir): propertyIsEnumerable on built-in prototypes returned non-boolean

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/mod.rs
+++ b/crates/perry-hir/src/lower/expr_call/mod.rs
@@ -70,8 +70,9 @@ use nested_namespace::{
     try_web_crypto_subtle,
 };
 use post_args_dispatch::{
-    try_array_static_alias_call, try_direct_has_own_call, try_object_has_own_call,
-    try_object_prototype_call, try_object_static_alias_call, try_proxy_call,
+    try_array_static_alias_call, try_direct_has_own_call, try_direct_property_is_enumerable_call,
+    try_object_has_own_call, try_object_prototype_call, try_object_static_alias_call,
+    try_proxy_call,
 };
 use prescans::run_call_prescans;
 use regex_string::try_regex_string_methods;
@@ -324,6 +325,10 @@ fn lower_call_inner(ctx: &mut LoweringContext, call: &ast::CallExpr) -> Result<E
         Err(args) => args,
     };
     args = match try_direct_has_own_call(ctx, call, args, has_spread) {
+        Ok(expr) => return Ok(expr),
+        Err(args) => args,
+    };
+    args = match try_direct_property_is_enumerable_call(ctx, call, args, has_spread) {
         Ok(expr) => return Ok(expr),
         Err(args) => args,
     };

--- a/crates/perry-hir/src/lower/expr_call/post_args_dispatch.rs
+++ b/crates/perry-hir/src/lower/expr_call/post_args_dispatch.rs
@@ -215,6 +215,48 @@ pub(super) fn try_direct_has_own_call(
     Err(args)
 }
 
+/// `obj.propertyIsEnumerable(key)` → `js_object_property_is_enumerable(obj, key)`.
+///
+/// Mirrors [`try_direct_has_own_call`]. Needed because on built-in prototype
+/// objects (`RegExp.prototype`, `Date.prototype`, …) `propertyIsEnumerable`
+/// is installed as a no-op closure that shadows the real
+/// `native_call_method` dispatch, so `RegExp.prototype.propertyIsEnumerable("global")`
+/// resolved to the closure and returned garbage instead of `false`
+/// (test262 built-ins/RegExp/prototype/{global,ignoreCase,multiline}/S15.10.7.*_A8).
+/// Routing directly to the canonical FFI entry point makes it descriptor-aware
+/// for every receiver, exactly as `hasOwnProperty` already is.
+pub(super) fn try_direct_property_is_enumerable_call(
+    ctx: &mut LoweringContext,
+    call: &ast::CallExpr,
+    args: Vec<Expr>,
+    has_spread: bool,
+) -> Result<Expr, Vec<Expr>> {
+    if has_spread || args.len() != 1 {
+        return Err(args);
+    }
+    if let ast::Callee::Expr(callee_expr) = &call.callee {
+        if let ast::Expr::Member(member) = callee_expr.as_ref() {
+            if let ast::MemberProp::Ident(prop) = &member.prop {
+                if prop.sym.as_ref() == "propertyIsEnumerable" {
+                    let receiver =
+                        lower_expr(ctx, member.obj.as_ref()).map_err(|_| args.clone())?;
+                    return Ok(Expr::Call {
+                        callee: Box::new(Expr::ExternFuncRef {
+                            name: "js_object_property_is_enumerable".to_string(),
+                            param_types: Vec::new(),
+                            return_type: Type::Any,
+                        }),
+                        args: vec![receiver, args[0].clone()],
+                        type_args: Vec::new(),
+                        byte_offset: 0,
+                    });
+                }
+            }
+        }
+    }
+    Err(args)
+}
+
 /// `Object.prototype.toString.call(x)` → `js_object_to_string(x)` and
 /// `Object.prototype.hasOwnProperty.call(obj, key)` → `js_object_has_own(obj, key)`.
 ///


### PR DESCRIPTION
## Summary

`obj.propertyIsEnumerable(key)` returned garbage (an object, printed as
`[object Object]`) instead of a boolean when the receiver was a **built-in
prototype object** — `RegExp.prototype`, `Date.prototype`, etc.

```js
RegExp.prototype.propertyIsEnumerable("global");   // [object Object]  (want: false)
Date.prototype.propertyIsEnumerable("getTime");    // [object Object]  (want: false)
```

Ordinary objects, arrays, and RegExp *instances* were already correct — only
built-in prototypes were affected.

## Root cause

On a built-in constructor's prototype, the `Object.prototype` methods
(`hasOwnProperty`, `propertyIsEnumerable`, …) are installed as **no-op
closures** so that introspection like `typeof RegExp.prototype.hasOwnProperty
=== "function"` agrees with Node. Those no-op closures *shadow* the real
`native_call_method` dispatch.

For `hasOwnProperty` this is masked by an existing HIR rewrite
(`try_direct_has_own_call`) that lowers `obj.hasOwnProperty(key)` directly to
the FFI entry point `js_object_has_own`, bypassing the shadowing closure for
every receiver. There was **no equivalent rewrite for
`propertyIsEnumerable`**, so `p.propertyIsEnumerable(k)` resolved to the no-op
closure and returned a non-boolean.

## Fix

Add `try_direct_property_is_enumerable_call`, a mechanical mirror of
`try_direct_has_own_call`, that lowers `obj.propertyIsEnumerable(key)` to the
canonical `js_object_property_is_enumerable(obj, key)` FFI entry point. That
function is already descriptor-aware for every receiver kind (plain objects,
arrays, typed arrays, buffers, closures, proxies, Date/RegExp/Error exotics,
string primitives, class refs), so routing through it is correct across the
board — exactly as `hasOwnProperty` already is.

The `Object.propertyIsEnumerable.call(obj, key)` static/`.call` shape was
already handled (#2891); this only closes the direct-method-call gap.

## Validation

Fixes these test262 cases (an internal Linux sweep host, `built-ins/RegExp`):

- `prototype/global/S15.10.7.2_A8`
- `prototype/ignoreCase/S15.10.7.3_A8`
- `prototype/multiline/S15.10.7.4_A8`

Full `built-ins/RegExp` re-sweep: the three targeted cases flip to pass with
**zero new regressions** (the remaining failures are Unicode-database vintage
in the `regex` crate and JS-vs-crate engine semantics, unrelated to this
change). Spot-checked no regression on plain objects, arrays, typed arrays,
RegExp instances (expando + `lastIndex`), `Object.prototype`, and the `.call`
form.

Code-only; no behavior change for any receiver that was already correct.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for lowering direct `propertyIsEnumerable` calls.
  * Eligible calls like `obj.propertyIsEnumerable(key)` are now rewritten to use the runtime’s standard object-enumerability helper.
  * Calls that don’t match the expected shape continue through the usual fallback path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->