### PR TITLE
fix(gc): #6010 — Map/Set external buffers exert GC pressure; dead collections finalize everywhere

### DIFF
--- a/crates/perry-runtime/src/gc/cycle.rs
+++ b/crates/perry-runtime/src/gc/cycle.rs
@@ -1120,6 +1120,24 @@ impl GcCycleState {
     }
 
     fn step_block_persistence(&mut self, budget: GcWorkBudget) {
+        // #6010: block persistence exists to protect REGISTER-HELD recent
+        // objects that precise (shadow-stack) roots can't see (#43/#44). A
+        // cycle whose root scan ran the FULL conservative stack+register
+        // scan (`ManualGcScanGuard::force_full_scan` — every automatic
+        // direct-arm collection in a compiled program, and explicit `gc()`)
+        // has already pinned exactly those objects, so resurrecting every
+        // dead neighbor in the recent-block window is pure over-retention.
+        // Low-allocation workloads never rotate the active block out of the
+        // window, which made garbage there immortal — dead Maps/Sets kept
+        // multi-MB external buffers for the life of the process (#6010:
+        // 1.4 GB RSS on a Map-churn benchmark whose live heap was ~1 MB).
+        if matches!(
+            super::roots::conservative_stack_scan_decision(),
+            super::roots::ConservativeStackScanDecision::Scan
+        ) {
+            self.phase = GcCyclePhase::AtomicFinalize;
+            return;
+        }
         let valid_ptrs = self.valid_ptrs.as_ref().expect("valid pointer set built");
         let phase_start = trace_phase_start(&self.trace);
         let block_persist = if budget.work_units == usize::MAX && self.block_persist.is_none() {
@@ -1366,6 +1384,18 @@ impl GcCycleState {
     fn step_sweep(&mut self, budget: GcWorkBudget) {
         let phase_start = trace_phase_start(&self.trace);
         if self.sweep_state.is_none() {
+            // #6010: free dead Maps'/Sets' external side buffers by registry
+            // walk while this cycle's marks are still fresh (nothing cleared
+            // yet). The object sweep below never reaches collections that die
+            // inside the ACTIVE nursery allocation block, and bulk block
+            // resets skip per-object finalizers — either way the multi-MB
+            // buffers leaked. A minor trace never marks the old generation,
+            // so the registry pass only trusts unmarked-means-dead for
+            // nursery-resident, untenured headers there; a full trace frees
+            // dead collections anywhere.
+            let full_trace = self.minor.is_none();
+            crate::map::finalize_dead_registered_maps_post_trace(full_trace);
+            crate::set::finalize_dead_registered_sets_post_trace(full_trace);
             let (do_age_bump, reclaim_dead_old_blocks, targeted_old_blocks, sweep_malloc) =
                 if let Some(minor) = self.minor.as_ref() {
                     let targeted_old_blocks = (minor.evacuation.old_page_moved_bytes > 0)

--- a/crates/perry-runtime/src/gc/cycle.rs
+++ b/crates/perry-runtime/src/gc/cycle.rs
@@ -1384,18 +1384,7 @@ impl GcCycleState {
     fn step_sweep(&mut self, budget: GcWorkBudget) {
         let phase_start = trace_phase_start(&self.trace);
         if self.sweep_state.is_none() {
-            // #6010: free dead Maps'/Sets' external side buffers by registry
-            // walk while this cycle's marks are still fresh (nothing cleared
-            // yet). The object sweep below never reaches collections that die
-            // inside the ACTIVE nursery allocation block, and bulk block
-            // resets skip per-object finalizers — either way the multi-MB
-            // buffers leaked. A minor trace never marks the old generation,
-            // so the registry pass only trusts unmarked-means-dead for
-            // nursery-resident, untenured headers there; a full trace frees
-            // dead collections anywhere.
             let full_trace = self.minor.is_none();
-            crate::map::finalize_dead_registered_maps_post_trace(full_trace);
-            crate::set::finalize_dead_registered_sets_post_trace(full_trace);
             let (do_age_bump, reclaim_dead_old_blocks, targeted_old_blocks, sweep_malloc) =
                 if let Some(minor) = self.minor.as_ref() {
                     let targeted_old_blocks = (minor.evacuation.old_page_moved_bytes > 0)
@@ -1404,12 +1393,22 @@ impl GcCycleState {
                 } else {
                     (false, true, None, true)
                 };
-            self.sweep_state = Some(IncrementalSweepState::new(
-                do_age_bump,
-                reclaim_dead_old_blocks,
-                targeted_old_blocks,
-                sweep_malloc,
-            ));
+            self.sweep_state = Some(
+                IncrementalSweepState::new(
+                    do_age_bump,
+                    reclaim_dead_old_blocks,
+                    targeted_old_blocks,
+                    sweep_malloc,
+                )
+                // #6010: dead Maps'/Sets' external side buffers are freed as
+                // the first sweep subphase, budget-chunked — no ordinary
+                // sweep path reaches collections that die inside the ACTIVE
+                // nursery allocation block, and bulk block resets skip
+                // per-object finalizers. Minor traces never mark the old
+                // generation, so deadness there is only trusted for
+                // untenured nursery headers.
+                .with_dead_collection_finalize(full_trace),
+            );
         }
         let done = self
             .sweep_state

--- a/crates/perry-runtime/src/gc/oldgen.rs
+++ b/crates/perry-runtime/src/gc/oldgen.rs
@@ -1040,6 +1040,16 @@ fn legacy_sweep_with_age_bump_and_old_reclaim_targets(
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum SweepCycleSubphase {
+    /// #6010: budget-chunked finalization of dead registered Maps/Sets whose
+    /// external side buffers no ordinary sweep path frees (dead in the ACTIVE
+    /// nursery allocation block, or reclaimed by bulk block resets that skip
+    /// per-object hooks). The dead lists are collected once at sweep entry
+    /// (marks fresh — a cheap flag-check walk of the registries), and each
+    /// buffer free consumes one work unit here so budgeted cycles keep their
+    /// pause bound. Deadness is stable across the incremental steps: an
+    /// unreachable header can't be revived, and interior block space is never
+    /// re-allocated before this sweep's own BlockCleanup subphase runs.
+    CollectionSideBuffers,
     Malloc,
     ArenaObjects,
     BlockCleanup,
@@ -1048,6 +1058,8 @@ enum SweepCycleSubphase {
 
 pub(super) struct IncrementalSweepState {
     subphase: SweepCycleSubphase,
+    dead_maps: Vec<usize>,
+    dead_sets: Vec<usize>,
     malloc: MallocSweepCycleState,
     arena: ArenaSweepObjectsState,
     cleanup: Option<ArenaSweepCleanupState>,
@@ -1065,6 +1077,8 @@ impl IncrementalSweepState {
     ) -> Self {
         Self {
             subphase: SweepCycleSubphase::Malloc,
+            dead_maps: Vec::new(),
+            dead_sets: Vec::new(),
             malloc: MallocSweepCycleState::new(sweep_malloc),
             arena: ArenaSweepObjectsState::new(do_age_bump, reclaim_dead_old_blocks),
             cleanup: None,
@@ -1074,8 +1088,38 @@ impl IncrementalSweepState {
         }
     }
 
+    /// #6010: collect the dead registered Maps/Sets NOW (marks are fresh at
+    /// sweep entry) and finalize their external buffers budget-chunked as the
+    /// first sweep subphase. See `SweepCycleSubphase::CollectionSideBuffers`.
+    pub(super) fn with_dead_collection_finalize(mut self, full_trace: bool) -> Self {
+        self.dead_maps = crate::map::collect_dead_registered_maps_post_trace(full_trace);
+        self.dead_sets = crate::set::collect_dead_registered_sets_post_trace(full_trace);
+        if !self.dead_maps.is_empty() || !self.dead_sets.is_empty() {
+            self.subphase = SweepCycleSubphase::CollectionSideBuffers;
+        }
+        self
+    }
+
     pub(super) fn step(&mut self, budget: usize) -> bool {
         match self.subphase {
+            SweepCycleSubphase::CollectionSideBuffers => {
+                let mut spent = 0usize;
+                while spent < budget {
+                    if let Some(addr) = self.dead_maps.pop() {
+                        crate::map::finalize_collected_dead_map(addr);
+                    } else if let Some(addr) = self.dead_sets.pop() {
+                        crate::set::finalize_collected_dead_set(addr);
+                    } else {
+                        self.subphase = SweepCycleSubphase::Malloc;
+                        break;
+                    }
+                    spent += 1;
+                }
+                if self.dead_maps.is_empty() && self.dead_sets.is_empty() {
+                    self.subphase = SweepCycleSubphase::Malloc;
+                }
+                false
+            }
             SweepCycleSubphase::Malloc => {
                 if self.malloc.step(budget) {
                     self.subphase = SweepCycleSubphase::ArenaObjects;

--- a/crates/perry-runtime/src/gc/policy.rs
+++ b/crates/perry-runtime/src/gc/policy.rs
@@ -311,6 +311,69 @@ thread_local! {
         const { std::cell::Cell::new(GC_MALLOC_COUNT_STEP_INITIAL) };
 }
 
+/// #6010: external side-buffer GC pressure. Map entry arrays and Set element
+/// arrays are raw `std::alloc` allocations reachable only through a tiny
+/// arena header — invisible to every trigger input (arena bytes, malloc
+/// object count, old-gen bytes). A workload that churns large Maps/Sets
+/// without arena pressure therefore never collected, and once a dead
+/// header was conservatively pinned across two cycles it tenured into the
+/// old generation, whose reclaim pressure counted only its 16 header bytes
+/// — the multi-megabyte buffer leaked for the life of the process (issue
+/// #6010: 1.4 GB RSS across a benchmark suite whose live heap never left
+/// ~20 MB).
+///
+/// Two counters close the hole:
+/// - ALLOC CHURN (`GC_EXTERNAL_SIDE_ALLOC_PENDING`): every
+///   `GC_EXTERNAL_SIDE_ALLOC_STEP` bytes of fresh external allocation pokes
+///   `gc_check_trigger()`, so collections happen at all in arena-quiet
+///   Map/Set workloads.
+/// - LIVE BYTES (`GC_EXTERNAL_SIDE_LIVE_BYTES`): maintained by the
+///   alloc/realloc sites and the GC finalizers, and added to `old_in_use`
+///   wherever old-reclaim pressure is computed — so tenured-then-dead
+///   collections escalate to the full mark-sweep (whose old-gen sweep runs
+///   the Map/Set side-allocation finalizers) instead of leaking.
+const GC_EXTERNAL_SIDE_ALLOC_STEP: usize = 16 * 1024 * 1024;
+
+thread_local! {
+    static GC_EXTERNAL_SIDE_ALLOC_PENDING: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static GC_EXTERNAL_SIDE_LIVE_BYTES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// Live bytes currently held by external Map/Set side buffers on this thread.
+#[inline]
+pub(super) fn external_side_live_bytes() -> usize {
+    GC_EXTERNAL_SIDE_LIVE_BYTES.with(Cell::get)
+}
+
+/// Record `bytes` of fresh external side-buffer allocation (Map entries /
+/// Set elements — creation or growth delta) and poke the trigger check when
+/// the accumulated churn window fills. Callers must invoke this only when
+/// the owning collection header is in a consistent state: a triggered cycle
+/// scans conservatively at this call point (`gc_check_trigger`'s direct
+/// arms use `force_full_scan`), which also keeps it non-moving, so raw
+/// header pointers held by the caller stay valid across the call.
+pub(crate) fn gc_note_external_side_alloc(bytes: usize) {
+    GC_EXTERNAL_SIDE_LIVE_BYTES.with(|c| c.set(c.get().saturating_add(bytes)));
+    let due = GC_EXTERNAL_SIDE_ALLOC_PENDING.with(|c| {
+        let now = c.get().saturating_add(bytes);
+        if now >= GC_EXTERNAL_SIDE_ALLOC_STEP {
+            c.set(0);
+            true
+        } else {
+            c.set(now);
+            false
+        }
+    });
+    if due {
+        gc_check_trigger();
+    }
+}
+
+/// Record that a Map/Set side buffer of `bytes` was freed (GC finalizer).
+pub(crate) fn gc_note_external_side_free(bytes: usize) {
+    GC_EXTERNAL_SIDE_LIVE_BYTES.with(|c| c.set(c.get().saturating_sub(bytes)));
+}
+
 #[inline]
 pub(super) fn gc_trace_enabled() -> bool {
     #[cfg(test)]
@@ -757,13 +820,19 @@ pub(super) fn copied_minor_promotion_handoff_due(trigger_kind: GcTriggerKind) ->
         return false;
     }
     let promotable = copied_minor_promotable_active_survivor_bytes();
-    let old_in_use = crate::arena::old_gen_in_use_bytes();
+    let old_in_use =
+        crate::arena::old_gen_in_use_bytes().saturating_add(external_side_live_bytes());
     let baseline = GC_LAST_OLD_RECLAIM_IN_USE_BYTES.with(|bytes| bytes.get());
     copied_minor_promotion_handoff_pressure_due(promotable, old_in_use, baseline)
 }
 
 pub(super) fn maybe_schedule_old_reclaim_after_copied_minor() {
-    let old_in_use = crate::arena::old_gen_in_use_bytes();
+    // #6010: external Map/Set side buffers count toward old-gen pressure —
+    // a tenured-then-dead Map holds its multi-MB buffer until a full
+    // reclaim's old-gen sweep finalizes it, so the buffer bytes must be
+    // able to escalate that reclaim.
+    let old_in_use =
+        crate::arena::old_gen_in_use_bytes().saturating_add(external_side_live_bytes());
     let baseline = GC_LAST_OLD_RECLAIM_IN_USE_BYTES.with(|bytes| bytes.get());
     if old_reclaim_pressure_due(old_in_use, baseline) {
         GC_OLD_RECLAIM_PENDING.with(|pending| pending.set(true));
@@ -771,7 +840,10 @@ pub(super) fn maybe_schedule_old_reclaim_after_copied_minor() {
 }
 
 pub(super) fn finish_full_old_reclaim_baseline() {
-    let old_in_use = crate::arena::old_gen_in_use_bytes();
+    // Baseline includes external side-buffer bytes (#6010) so the growth
+    // delta in `old_reclaim_pressure_due` stays unit-consistent.
+    let old_in_use =
+        crate::arena::old_gen_in_use_bytes().saturating_add(external_side_live_bytes());
     GC_LAST_OLD_RECLAIM_IN_USE_BYTES.with(|bytes| bytes.set(old_in_use));
     GC_OLD_RECLAIM_PENDING.with(|pending| pending.set(false));
 }
@@ -1139,7 +1211,7 @@ struct BudgetedGcCycle {
     rebaseline: BudgetedGcRebaseline,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 enum BudgetedGcTrigger {
     OldReclaim,
     ArenaBytes,
@@ -1181,7 +1253,9 @@ pub(super) fn gc_old_reclaim_debt_bytes(old_in_use: usize, baseline: usize) -> u
 
 fn gc_budgeted_due_trigger() -> Option<BudgetedGcTrigger> {
     let old_pending = GC_OLD_RECLAIM_PENDING.with(Cell::get);
-    let old_in_use = crate::arena::old_gen_in_use_bytes();
+    // #6010: external Map/Set side-buffer bytes escalate to OldReclaim too.
+    let old_in_use =
+        crate::arena::old_gen_in_use_bytes().saturating_add(external_side_live_bytes());
     let old_baseline = GC_LAST_OLD_RECLAIM_IN_USE_BYTES.with(|bytes| bytes.get());
     if old_pending || old_reclaim_pressure_due(old_in_use, old_baseline) {
         return Some(BudgetedGcTrigger::OldReclaim);

--- a/crates/perry-runtime/src/map.rs
+++ b/crates/perry-runtime/src/map.rs
@@ -313,6 +313,7 @@ pub(crate) unsafe fn finalize_map_side_allocation_for_gc(map: *mut MapHeader) {
     let capacity = (*map).capacity as usize;
     if !entries.is_null() && capacity > 0 {
         dealloc(entries as *mut u8, entries_layout(capacity));
+        crate::gc::gc_note_external_side_free(entries_layout(capacity).size());
     }
     // GC_STORE_AUDIT(POINTER_FREE): finalizer clears external entries side-allocation pointer after deregistration/deallocation.
     (*map).entries = std::ptr::null_mut();
@@ -339,6 +340,65 @@ fn is_dead_copied_minor_from_space_map(addr: usize) -> bool {
         flags & crate::gc::GC_FLAG_ARENA != 0
             && flags & (crate::gc::GC_FLAG_MARKED | crate::gc::GC_FLAG_FORWARDED) == 0
     }
+}
+
+/// #6010: registry-driven finalization of DEAD Maps at sweep entry, for the
+/// non-copying cycle kinds (fallback minor / full mark-sweep). A dead Map
+/// sitting in the ACTIVE nursery allocation block is never processed by any
+/// sweeper — the block is still being bump-allocated into, so it is neither
+/// reset nor object-walked — and bulk block resets skip per-object finalize
+/// hooks anyway. Its multi-megabyte external entries buffer therefore leaked
+/// for the life of the process. Walk the registry right after trace (marks
+/// fresh, nothing cleared yet) and free the buffers of provably-dead maps;
+/// the 16-byte headers stay behind as ordinary dead bytes for whichever
+/// block operation eventually reclaims them.
+///
+/// Deadness: unmarked ∧ not pinned ∧ not forwarded, and — for a MINOR trace,
+/// which never traces the old generation — additionally not tenured and
+/// physically in the nursery (the same "unmarked nursery object is garbage"
+/// invariant the ordinary sweeper relies on, backed by the write-barrier
+/// remembered set for old→young edges).
+pub(crate) fn finalize_dead_registered_maps_post_trace(full_trace: bool) -> usize {
+    let dead: Vec<usize> = MAP_REGISTRY.with(|r| {
+        r.borrow()
+            .iter()
+            .copied()
+            .filter(|&addr| unsafe { registered_map_is_dead_post_trace(addr, full_trace) })
+            .collect()
+    });
+    let count = dead.len();
+    for addr in dead {
+        unsafe {
+            finalize_map_side_allocation_for_gc(addr as *mut MapHeader);
+        }
+    }
+    count
+}
+
+unsafe fn registered_map_is_dead_post_trace(addr: usize, full_trace: bool) -> bool {
+    let Some(header) = crate::value::addr_class::try_read_gc_header(addr) else {
+        return false;
+    };
+    if header.obj_type != crate::gc::GC_TYPE_MAP {
+        return false;
+    }
+    let flags = header.gc_flags;
+    if flags
+        & (crate::gc::GC_FLAG_MARKED | crate::gc::GC_FLAG_PINNED | crate::gc::GC_FLAG_FORWARDED)
+        != 0
+    {
+        return false;
+    }
+    if full_trace {
+        return true;
+    }
+    if flags & crate::gc::GC_FLAG_TENURED != 0 {
+        return false;
+    }
+    matches!(
+        crate::arena::classify_heap_generation(addr),
+        crate::arena::HeapGeneration::Nursery
+    )
 }
 
 pub(crate) fn finalize_dead_copied_minor_from_space_maps() -> usize {
@@ -654,6 +714,13 @@ pub extern "C" fn js_map_alloc(capacity: u32) -> *mut MapHeader {
                 .insert(ptr as usize, std::collections::HashMap::new());
         });
 
+        // #6010: the entries buffer is invisible to the arena/malloc GC
+        // triggers; record its bytes as external churn so Map-heavy
+        // workloads still collect (and finalize dead siblings). Safe here:
+        // the header is fully initialized + registered, and the triggered
+        // cycle is conservative + non-moving, so `ptr` stays valid.
+        crate::gc::gc_note_external_side_alloc(ent_layout.size());
+
         ptr
     }
 }
@@ -839,6 +906,10 @@ unsafe fn ensure_capacity(map: *mut MapHeader) -> bool {
     // GC_STORE_AUDIT(INIT): map external buffer pointer moves; live entry slots are dirtied by caller.
     (*map).entries = new_entries;
     (*map).capacity = new_capacity;
+    // #6010: growth delta counts as external churn (see js_map_alloc). The
+    // header is consistent again, and a triggered cycle is conservative +
+    // non-moving, so the caller's raw `map`/entries pointers stay valid.
+    crate::gc::gc_note_external_side_alloc(new_layout.size() - old_layout.size());
     true
 }
 

--- a/crates/perry-runtime/src/map.rs
+++ b/crates/perry-runtime/src/map.rs
@@ -358,21 +358,21 @@ fn is_dead_copied_minor_from_space_map(addr: usize) -> bool {
 /// physically in the nursery (the same "unmarked nursery object is garbage"
 /// invariant the ordinary sweeper relies on, backed by the write-barrier
 /// remembered set for old→young edges).
-pub(crate) fn finalize_dead_registered_maps_post_trace(full_trace: bool) -> usize {
-    let dead: Vec<usize> = MAP_REGISTRY.with(|r| {
+pub(crate) fn collect_dead_registered_maps_post_trace(full_trace: bool) -> Vec<usize> {
+    MAP_REGISTRY.with(|r| {
         r.borrow()
             .iter()
             .copied()
             .filter(|&addr| unsafe { registered_map_is_dead_post_trace(addr, full_trace) })
             .collect()
-    });
-    let count = dead.len();
-    for addr in dead {
-        unsafe {
-            finalize_map_side_allocation_for_gc(addr as *mut MapHeader);
-        }
+    })
+}
+
+/// Finalize one collected-dead Map (budget-chunked by the sweep state).
+pub(crate) fn finalize_collected_dead_map(addr: usize) {
+    unsafe {
+        finalize_map_side_allocation_for_gc(addr as *mut MapHeader);
     }
-    count
 }
 
 unsafe fn registered_map_is_dead_post_trace(addr: usize, full_trace: bool) -> bool {

--- a/crates/perry-runtime/src/set.rs
+++ b/crates/perry-runtime/src/set.rs
@@ -277,21 +277,21 @@ fn is_dead_copied_minor_from_space_set(addr: usize) -> bool {
 /// analog of `finalize_dead_registered_maps_post_trace` (see map.rs for the
 /// full rationale: dead collections in the ACTIVE nursery block are never
 /// object-walked by any sweeper, leaking their external elements buffers).
-pub(crate) fn finalize_dead_registered_sets_post_trace(full_trace: bool) -> usize {
-    let dead: Vec<usize> = SET_REGISTRY.with(|r| {
+pub(crate) fn collect_dead_registered_sets_post_trace(full_trace: bool) -> Vec<usize> {
+    SET_REGISTRY.with(|r| {
         r.borrow()
             .iter()
             .copied()
             .filter(|&addr| unsafe { registered_set_is_dead_post_trace(addr, full_trace) })
             .collect()
-    });
-    let count = dead.len();
-    for addr in dead {
-        unsafe {
-            finalize_set_side_allocation_for_gc(addr as *mut SetHeader);
-        }
+    })
+}
+
+/// Finalize one collected-dead Set (budget-chunked by the sweep state).
+pub(crate) fn finalize_collected_dead_set(addr: usize) {
+    unsafe {
+        finalize_set_side_allocation_for_gc(addr as *mut SetHeader);
     }
-    count
 }
 
 unsafe fn registered_set_is_dead_post_trace(addr: usize, full_trace: bool) -> bool {

--- a/crates/perry-runtime/src/set.rs
+++ b/crates/perry-runtime/src/set.rs
@@ -244,6 +244,7 @@ pub(crate) unsafe fn finalize_set_side_allocation_for_gc(set: *mut SetHeader) {
     let capacity = (*set).capacity as usize;
     if !elements.is_null() && capacity > 0 {
         dealloc(elements as *mut u8, elements_layout(capacity));
+        crate::gc::gc_note_external_side_free(elements_layout(capacity).size());
     }
     // GC_STORE_AUDIT(POINTER_FREE): finalizer clears external elements side-allocation pointer after deregistration/deallocation.
     (*set).elements = std::ptr::null_mut();
@@ -270,6 +271,53 @@ fn is_dead_copied_minor_from_space_set(addr: usize) -> bool {
         flags & crate::gc::GC_FLAG_ARENA != 0
             && flags & (crate::gc::GC_FLAG_MARKED | crate::gc::GC_FLAG_FORWARDED) == 0
     }
+}
+
+/// #6010: registry-driven finalization of DEAD Sets at sweep entry — the Set
+/// analog of `finalize_dead_registered_maps_post_trace` (see map.rs for the
+/// full rationale: dead collections in the ACTIVE nursery block are never
+/// object-walked by any sweeper, leaking their external elements buffers).
+pub(crate) fn finalize_dead_registered_sets_post_trace(full_trace: bool) -> usize {
+    let dead: Vec<usize> = SET_REGISTRY.with(|r| {
+        r.borrow()
+            .iter()
+            .copied()
+            .filter(|&addr| unsafe { registered_set_is_dead_post_trace(addr, full_trace) })
+            .collect()
+    });
+    let count = dead.len();
+    for addr in dead {
+        unsafe {
+            finalize_set_side_allocation_for_gc(addr as *mut SetHeader);
+        }
+    }
+    count
+}
+
+unsafe fn registered_set_is_dead_post_trace(addr: usize, full_trace: bool) -> bool {
+    let Some(header) = crate::value::addr_class::try_read_gc_header(addr) else {
+        return false;
+    };
+    if header.obj_type != crate::gc::GC_TYPE_SET {
+        return false;
+    }
+    let flags = header.gc_flags;
+    if flags
+        & (crate::gc::GC_FLAG_MARKED | crate::gc::GC_FLAG_PINNED | crate::gc::GC_FLAG_FORWARDED)
+        != 0
+    {
+        return false;
+    }
+    if full_trace {
+        return true;
+    }
+    if flags & crate::gc::GC_FLAG_TENURED != 0 {
+        return false;
+    }
+    matches!(
+        crate::arena::classify_heap_generation(addr),
+        crate::arena::HeapGeneration::Nursery
+    )
 }
 
 pub(crate) fn finalize_dead_copied_minor_from_space_sets() -> usize {
@@ -571,6 +619,10 @@ unsafe fn ensure_capacity(set: *mut SetHeader) -> bool {
     // GC_STORE_AUDIT(INIT): set external buffer pointer moves; live slots are dirtied by caller.
     (*set).elements = new_elements;
     (*set).capacity = new_capacity;
+    // #6010: growth delta counts as external churn (see js_set_alloc). The
+    // header is consistent again, and a triggered cycle is conservative +
+    // non-moving, so the caller's raw `set`/elements pointers stay valid.
+    crate::gc::gc_note_external_side_alloc(new_layout.size() - old_layout.size());
     true
 }
 
@@ -605,6 +657,13 @@ pub extern "C" fn js_set_alloc(capacity: u32) -> *mut SetHeader {
             idx.borrow_mut()
                 .insert(ptr as usize, crate::fast_hash::new_ptr_hash_map());
         });
+
+        // #6010: the elements buffer is invisible to the arena/malloc GC
+        // triggers; record its bytes as external churn so Set-heavy
+        // workloads still collect (and finalize dead siblings). Safe here:
+        // the header is fully initialized + registered, and the triggered
+        // cycle is conservative + non-moving, so `ptr` stays valid.
+        crate::gc::gc_note_external_side_alloc(elem_layout.size());
 
         ptr
     }


### PR DESCRIPTION
Closes #6010.

## Problem

The issue's benchmark suite drove RSS to **1.4GB** (Node: 315MB) while `heapUsed` sat at ~17MB, with the big jump (+760MB) during the Map benchmark. Root cause is threefold — Map entry arrays and Set element arrays are raw `std::alloc` buffers reachable only through 16-byte arena headers, and they were invisible to the collector three separate ways:

1. **No pressure**: buffer bytes counted toward no GC trigger input (arena bytes, malloc-object count, old-gen bytes). A Map/Set-churn workload with a quiet arena never collected at all — diagnostics showed a 100k-entry Map loop leaking ~3.7MB/iter with **zero** GC cycles.
2. **Immortal garbage via block persistence**: every automatic collection in a compiled program runs with the full conservative stack+register scan (the #5476 direct arms) — which already pins register-held objects — yet the block-persistence phase still resurrected every dead object sharing a "recent" arena block with any live one. Low-allocation workloads never rotate the active block out of the 5-block recency window, so dead Maps there were re-marked forever (verified via mark-path backtraces: `mark_block_persisting_arena_objects` marked all of them each cycle).
3. **Never swept in the active block**: dead collections in the active nursery allocation block are never object-walked by any sweeper (the block is still being bump-allocated into), and bulk block resets skip per-object finalize hooks — so even when cycles ran, the buffers stayed.

## Fix

1. **External side-alloc accounting** (`gc/policy.rs`, alloc/realloc sites in `map.rs`/`set.rs`, frees in the GC finalizers): every 16MB of fresh buffer allocation pokes `gc_check_trigger()`; live buffer bytes are added to `old_in_use` wherever old-reclaim pressure is computed (and to its baseline), so tenured-then-dead collections escalate to the full mark-sweep whose old-gen sweep runs the side-allocation finalizers.
2. **Block-persistence gate** (`gc/cycle.rs`): skip the phase when the cycle's root scan ran the full conservative scan — the conservative scan strictly subsumes the register-safety rationale block persistence exists for (#43/#44).
3. **Registry-driven finalization at sweep entry** (`map.rs`, `set.rs`, `gc/cycle.rs`): while the cycle's marks are still fresh, free the buffers of provably-dead registered Maps/Sets — unmarked ∧ unpinned ∧ unforwarded, restricted on minor traces to untenured nursery-resident headers (the same unmarked-nursery-is-garbage invariant the ordinary sweeper relies on). Headers stay behind as dead bytes for whichever block operation eventually reclaims them.

## Results (M-series macOS, release)

| | before | after | node |
|---|---|---|---|
| Isolated 100k-entry Map churn, RSS @ iter 50 | 221MB, growing linearly forever | **133MB, flattening** | — |
| Full issue benchmark suite, peak RSS | **1342MB** | **306MB** | 315MB (issue) / ~250MB (measured) |
| `map-set-get-100k` phase RSS | 835MB | **135MB** | 243MB |

(Peak-RSS numbers measured composed with the #6011 branch; the Map/Set behavior is fully contained in this PR and reproduces standalone.)

## Verification

- `cargo test -p perry-runtime -- --test-threads=1`: 1155/1155 (the 2 parallel-run flakes reproduce on unmodified main).
- `cargo fmt --check`, file-size gate, address-classification audit green.
- The registry finalize pass reuses the existing copied-minor finalizer (`finalize_map_side_allocation_for_gc`) — no new free paths; double-finalize is prevented by the existing registry-membership check.

Note: per maintainer convention, no version bump / CHANGELOG in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage-collection memory pressure tracking for external (non-arena) Map and Set side buffers, including correct accounting during allocation and free.
  * Updated old-generation reclaim decisions to consider these external side-buffer bytes.
  * Prevented dead registered Maps and Sets from lingering after tracing by adding post-trace collection and finalization (budgeted in incremental sweep).
* **Performance**
  * Optimized GC cycle behavior by skipping block-persistence work when conservative scanning indicates it’s unnecessary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->