### PR TITLE
fix: #5957 — default-derived ctor forwarding part 2 (rest + dynamic-parent mixin)

### DIFF
--- a/crates/perry-codegen/src/codegen/string_pool.rs
+++ b/crates/perry-codegen/src/codegen/string_pool.rs
@@ -528,7 +528,12 @@ pub(super) fn emit_string_pool(
     // constructor + field initializers on the new instance. Only consulted by
     // the heap-class-object arm of `js_new_function_construct`, so it's
     // behavior-neutral for top-level class declarations (INT32 ref `new`).
-    let mut ctor_triples: Vec<(u32, String, u32)> = Vec::new();
+    // (cid, symbol, total_param_count, sig_cap_count). #5957: `sig_cap_count`
+    // is how many TRAILING params are synthesized `__perry_cap_*` capture
+    // params IN THE SIGNATURE — the runtime construct dispatchers split the
+    // user/cap boundary from this (signature truth), not the decl-site snapshot
+    // length, which mis-split dynamic-parent (capless-sig-with-snapshot) ctors.
+    let mut ctor_triples: Vec<(u32, String, u32, u32)> = Vec::new();
     // #wall3: class ctors with a rest param (`constructor(...args)`) need their
     // standalone `_constructor` func_ptr registered in CLOSURE_REST_REGISTRY so
     // a member-new (`new ns.Sub(opts)` → js_new_function_construct →
@@ -681,7 +686,22 @@ pub(super) fn emit_string_pool(
                 ctor_flag_regs.push((cid, ctor_has_synth, ctor_has_rest));
             }
         }
-        ctor_triples.push((cid, ctor_symbol, ctor_params));
+        // #5957: count the ctor's trailing `__perry_cap_*` signature params.
+        // An arity-override (no own ctor) class is capture-free by the
+        // synthesized-ctor invariant → 0; a function-nested class that captures
+        // has its cap params appended by `synthesize_class_captures` and they
+        // are reflected in `class.constructor` at codegen time.
+        let ctor_sig_caps = class
+            .constructor
+            .as_ref()
+            .map(|c| {
+                c.params
+                    .iter()
+                    .filter(|p| p.name.starts_with("__perry_cap_"))
+                    .count() as u32
+            })
+            .unwrap_or(0);
+        ctor_triples.push((cid, ctor_symbol, ctor_params, ctor_sig_caps));
     }
     method_triples.sort_unstable();
     for (cid, method_name, llvm_name, param_count, has_synth_args, has_rest, spec_length) in
@@ -776,7 +796,7 @@ pub(super) fn emit_string_pool(
     // CLASS_CONSTRUCTORS. ptrtoint @symbol both stores the function pointer
     // and keeps the constructor alive past dead-code elimination.
     ctor_triples.sort_unstable();
-    for (cid, ctor_symbol, ctor_params) in ctor_triples {
+    for (cid, ctor_symbol, ctor_params, ctor_sig_caps) in ctor_triples {
         chunker.roll_if_full();
         let blk = chunker.current_block();
         let func_ref = format!("@{}", ctor_symbol);
@@ -787,6 +807,7 @@ pub(super) fn emit_string_pool(
                 (I64, &cid.to_string()),
                 (I64, &func_i64),
                 (I64, &ctor_params.to_string()),
+                (I64, &ctor_sig_caps.to_string()),
             ],
         );
     }

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi/language_core.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi/language_core.rs
@@ -341,7 +341,7 @@ pub(crate) fn declare_core(module: &mut LlModule) {
     );
     // #1787: register a class's standalone constructor so `new
     // <classObjectValue>()` can replay it on a dynamically-allocated instance.
-    module.declare_function("js_register_class_constructor", VOID, &[I64, I64, I64]);
+    module.declare_function("js_register_class_constructor", VOID, &[I64, I64, I64, I64]);
     // Constructor synth/rest flags: (class_id, has_synthetic_arguments,
     // has_rest) — consulted by the `super(...spread)` apply path so it packs a
     // pass-through parent ctor's `arguments` / rest slot correctly.

--- a/crates/perry-hir/src/lower_decl/class_captures.rs
+++ b/crates/perry-hir/src/lower_decl/class_captures.rs
@@ -414,63 +414,42 @@ pub fn synthesize_class_captures(
     let mut ctor = match constructor.take() {
         Some(c) => c,
         None => {
-            // The spec default ctor FORWARDS its args:
-            // `constructor(...args) { super(...args) }`. A bare
-            // `SuperCall([])` dropped the construction-site user args, so
-            // `new Derived({def})` left the parent ctor's params undefined
-            // (vendored zod: ZodString.create → new ZodString({...}) →
-            // ZodType ctor never saw `def`, `this._def` stayed undefined).
-            // Synthesize explicit forwarding params matching the closest
-            // pending-ancestor ctor's USER arity (its `__perry_cap_*`
-            // params excluded). Ancestors outside `pending_classes`
-            // (module-level / native parents) keep the no-arg baseline.
-            let parent_user_arity = if has_heritage {
-                let mut arity = 0usize;
-                let mut walker: Option<String> = extends_name.map(|s| s.to_string());
-                while let Some(pname) = walker.take() {
-                    let Some(pc) = ctx.pending_classes.iter().find(|c| c.name == pname) else {
-                        break;
-                    };
-                    if let Some(pctor) = pc.constructor.as_ref() {
-                        arity = pctor
-                            .params
-                            .iter()
-                            .filter(|p| !p.name.starts_with("__perry_cap_"))
-                            .count();
-                        break;
-                    }
-                    walker = pc.extends_name.clone();
-                }
-                arity
-            } else {
-                0
-            };
-            let mut params: Vec<Param> = Vec::with_capacity(parent_user_arity);
-            let mut super_args: Vec<Expr> = Vec::with_capacity(parent_user_arity);
-            for i in 0..parent_user_arity {
+            // #5957: synthesize the REAL spec default ctor,
+            // `constructor(...args) { super(...args) }`. The previous
+            // fixed-arity approximation walked the nearest pending-ancestor
+            // ctor's USER arity and minted that many positional params — a
+            // REST-param ancestor counted as arity 1 (`new Drain("a","b","c")`
+            // forwarded only "a"), and an extends-EXPR / non-pending parent
+            // walked to arity 0 (ALL user args dropped: the #806 mixin's
+            // `seed` was undefined). One rest param + `SuperCallSpread`
+            // forwards everything for every parent shape; the spread-super
+            // dispatchers split user/cap slots by the registered signature cap
+            // count and pack ancestor rest params via the closure-rest table.
+            let (params, body) = if has_heritage {
                 let pid = ctx.fresh_local();
-                params.push(Param {
+                let params = vec![Param {
                     id: pid,
-                    name: format!("__perry_dflt_arg_{}", i),
+                    name: "__perry_dflt_args".to_string(),
                     ty: Type::Any,
                     default: None,
                     decorators: Vec::new(),
-                    is_rest: false,
+                    is_rest: true,
                     arguments_object: None,
-                });
-                super_args.push(Expr::LocalGet(pid));
-            }
+                }];
+                let body = vec![Stmt::Expr(Expr::SuperCallSpread(vec![CallArg::Spread(
+                    Expr::LocalGet(pid),
+                )]))];
+                (params, body)
+            } else {
+                (Vec::new(), Vec::new())
+            };
             Function {
                 id: ctx.fresh_func(),
                 name: format!("{}::constructor", name),
                 type_params: Vec::new(),
                 params,
                 return_type: Type::Void,
-                body: if has_heritage {
-                    vec![Stmt::Expr(Expr::SuperCall(super_args))]
-                } else {
-                    Vec::new()
-                },
+                body,
                 is_async: false,
                 is_generator: false,
                 is_strict: true,

--- a/crates/perry-runtime/src/object/class_constructors.rs
+++ b/crates/perry-runtime/src/object/class_constructors.rs
@@ -30,17 +30,25 @@ use super::ObjectHeader;
 /// Top-level class DECLARATIONS keep the INT32 class-ref `new` path and do not
 /// consult this table, so registering every class's constructor is
 /// behavior-neutral for them.
-pub static CLASS_CONSTRUCTORS: RwLock<Option<HashMap<u32, (usize, u32)>>> = RwLock::new(None);
+pub static CLASS_CONSTRUCTORS: RwLock<Option<HashMap<u32, (usize, u32, u32)>>> = RwLock::new(None);
 
 /// #1787: register a class's standalone constructor in `CLASS_CONSTRUCTORS`,
 /// keyed by the (template) class_id, so `new <classObjectValue>()` can replay
 /// the constructor / field initializers on a dynamically-allocated instance.
 /// Emitted by codegen at module init alongside the vtable registration.
+/// `sig_caps` (#5957): how many of the ctor's TRAILING params are synthesized
+/// `__perry_cap_*` capture params IN THE SIGNATURE. The construct dispatchers
+/// used to derive the user/cap split from the decl-site SNAPSHOT length —
+/// wrong for dynamic-parent classes whose ctors compile CAPLESS signatures
+/// (parent fetched via the per-cid registry) while a snapshot IS registered
+/// (extends-expr refs join the capture union): the subtraction ate user args
+/// (`new WrappedLogged("alpha")` bound the mixin ctor's `seed` to undefined).
 #[no_mangle]
 pub unsafe extern "C" fn js_register_class_constructor(
     class_id: i64,
     func_ptr: i64,
     param_count: i64,
+    sig_caps: i64,
 ) {
     if class_id == 0 || func_ptr == 0 {
         return;
@@ -49,14 +57,15 @@ pub unsafe extern "C" fn js_register_class_constructor(
     if guard.is_none() {
         *guard = Some(HashMap::new());
     }
-    guard
-        .as_mut()
-        .unwrap()
-        .insert(class_id as u32, (func_ptr as usize, param_count as u32));
+    guard.as_mut().unwrap().insert(
+        class_id as u32,
+        (func_ptr as usize, param_count as u32, sig_caps as u32),
+    );
 }
 
-/// Look up a class's registered constructor `(fn_ptr, total_param_count)`.
-fn lookup_class_constructor(class_id: u32) -> Option<(usize, u32)> {
+/// Look up a class's registered constructor
+/// `(fn_ptr, total_param_count, sig_cap_count)`.
+fn lookup_class_constructor(class_id: u32) -> Option<(usize, u32, u32)> {
     CLASS_CONSTRUCTORS
         .read()
         .ok()?
@@ -383,71 +392,100 @@ pub unsafe extern "C" fn js_super_construct_apply(
     let mut cur = crate::object::get_parent_class_id(child_cid).unwrap_or(0);
     let mut depth = 0usize;
     while cur != 0 && depth < 64 {
-        if let Some((ctor_ptr, total_params)) = lookup_class_constructor(cur) {
+        if let Some((ctor_ptr, total_params, sig_caps)) = lookup_class_constructor(cur) {
             if std::env::var_os("PERRY_SUPER_DEBUG").is_some() {
                 eprintln!(
-                    "super_apply resolved ancestor cid={} total={}",
-                    cur, total_params
+                    "super_apply resolved ancestor cid={} total={} sig_caps={}",
+                    cur, total_params, sig_caps
                 );
             }
             let caps = class_capture_values(cur).unwrap_or_default();
-            let user_params = (total_params as usize).saturating_sub(caps.len());
+            // #5957: split user/cap slots from the SIGNATURE cap count, NOT the
+            // decl-site snapshot length. A dynamic-parent ctor compiles a
+            // CAPLESS signature (sig_caps == 0) yet may have a registered
+            // snapshot (extends-expr refs joined the capture union) — the old
+            // `total - caps.len()` ate user args (`new WrappedLogged("alpha")`
+            // bound the mixin ctor's `seed` to undefined).
+            let user_params = (total_params as usize).saturating_sub(sig_caps as usize);
             let n = if arr.is_null() {
                 0
             } else {
                 crate::array::js_array_length(arr)
             } as usize;
-            // Flatten every SPREAD-expanded arg into a contiguous f64 buffer and
-            // let `call_vtable_method` pack the trailing param. When the parent
-            // ctor uses `arguments` (a zero-declared-param pass-through ctor:
-            // `super(...[3,4,5])` → parent reads `arguments.length`), the
-            // synthesized `arguments` slot must hold ALL args (packed from index
-            // 0); a user rest param (`constructor(a, ...rest)`) holds only the
-            // args from the rest position onward. The old truncation to
-            // `user_params` (and `has_synth=false`/`has_rest=false`) dropped the
-            // extra spread args and left `arguments.length == 0`. `caps` (the
-            // decl-site capture snapshot for a function-nested class) are
-            // appended AFTER the user args, mirroring the fixed-arity super path.
-            // `call_vtable_method`'s synth/rest packing bundles the trailing
-            // param from the flat arg buffer — but it packs from index 0 for
-            // synthesized `arguments` and would swallow any trailing capture
-            // params. Function-nested capturing ctors never combine caps with a
-            // synth/rest trailing param in practice, so only take the flat-
-            // forward path when there are no caps; otherwise keep the original
-            // fixed-arity truncation (caps appended after user args).
-            let (mut has_synth, mut has_rest_flag) = lookup_class_constructor_flags(cur);
-            if !caps.is_empty() {
-                has_synth = false;
-                has_rest_flag = false;
-            }
-            let mut final_args: Vec<f64> = Vec::with_capacity(user_params.max(n) + caps.len());
-            if has_synth || has_rest_flag {
-                // Forward all n spread args flat; call_vtable_method packs the
-                // trailing synthesized-`arguments` / rest slot (from index 0 for
-                // `arguments`, from the rest position for a user rest param).
-                for i in 0..n {
-                    final_args.push(crate::array::js_array_get_f64(arr, i as u32));
+            let (has_synth, has_rest_flag) = lookup_class_constructor_flags(cur);
+            let (final_args, call_synth, call_rest) = if sig_caps == 0 {
+                // No signature cap params: #6018's synth/rest handling applies
+                // cleanly — forward all spread args flat and let
+                // `call_vtable_method` pack the trailing synthesized-`arguments`
+                // (from index 0) or user-rest (from the rest position) slot.
+                let mut fa: Vec<f64> = Vec::with_capacity(user_params.max(n));
+                if has_synth || has_rest_flag {
+                    for i in 0..n {
+                        fa.push(crate::array::js_array_get_f64(arr, i as u32));
+                    }
+                    (fa, has_synth, has_rest_flag)
+                } else {
+                    for i in 0..user_params {
+                        fa.push(if i < n {
+                            crate::array::js_array_get_f64(arr, i as u32)
+                        } else {
+                            undef
+                        });
+                    }
+                    (fa, false, false)
                 }
             } else {
-                for i in 0..user_params {
-                    if i < n {
-                        final_args.push(crate::array::js_array_get_f64(arr, i as u32));
-                    } else {
-                        final_args.push(undef);
+                // #5957: the signature HAS trailing `__perry_cap_*` params.
+                // Pack the user args ourselves — rest-aware (a `constructor(
+                // ...parts)` that ALSO captures combines a rest param with
+                // trailing caps, which `call_vtable_method`'s own rest packing
+                // would swallow) — then append exactly `sig_caps` snapshot
+                // values. Call with synth/rest OFF since we packed the trailing
+                // slot manually.
+                let mut fa: Vec<f64> = Vec::with_capacity(total_params as usize);
+                let rest_idx = crate::closure::lookup_closure_rest(ctor_ptr as *const u8)
+                    .map(|ri| ri as usize)
+                    .filter(|ri| *ri < user_params);
+                if let Some(ri) = rest_idx {
+                    for i in 0..ri {
+                        fa.push(if i < n {
+                            crate::array::js_array_get_f64(arr, i as u32)
+                        } else {
+                            undef
+                        });
+                    }
+                    let mut rest_arr = crate::array::js_array_alloc(0);
+                    let mut i = ri;
+                    while i < n {
+                        rest_arr = crate::array::js_array_push_f64(
+                            rest_arr,
+                            crate::array::js_array_get_f64(arr, i as u32),
+                        );
+                        i += 1;
+                    }
+                    fa.push(crate::value::js_nanbox_pointer(rest_arr as i64));
+                } else {
+                    for i in 0..user_params {
+                        fa.push(if i < n {
+                            crate::array::js_array_get_f64(arr, i as u32)
+                        } else {
+                            undef
+                        });
                     }
                 }
-                for bits in &caps {
-                    final_args.push(f64::from_bits(*bits));
+                for slot in 0..sig_caps as usize {
+                    fa.push(caps.get(slot).map(|b| f64::from_bits(*b)).unwrap_or(undef));
                 }
-            }
+                (fa, false, false)
+            };
             let _ = call_vtable_method(
                 ctor_ptr,
                 this_raw,
                 final_args.as_ptr(),
                 final_args.len(),
                 total_params,
-                has_synth,
-                has_rest_flag,
+                call_synth,
+                call_rest,
             );
             return undef;
         }
@@ -723,29 +761,55 @@ pub(crate) unsafe fn run_class_constructor_on_this_flat(
     let mut cur = parent_cid;
     let mut depth = 0usize;
     while cur != 0 && depth < 64 {
-        if let Some((ctor_ptr, total_params)) = lookup_class_constructor(cur) {
+        if let Some((ctor_ptr, total_params, sig_caps)) = lookup_class_constructor(cur) {
+            // #5957: signature-truth user/cap split + rest-aware packing (see
+            // `js_super_construct_apply`). This flat dispatcher is the one the
+            // dynamic-parent super leg reaches (`js_fetch_or_value_super` →
+            // ClassRef fallback), so the capless-sig-with-snapshot mixin case
+            // resolves here: sig_caps == 0 ⇒ user_params == total_params ⇒ the
+            // forwarded user args survive.
             let caps = class_capture_values(cur).unwrap_or_default();
-            let user_params = (total_params as usize).saturating_sub(caps.len());
+            let user_params = (total_params as usize).saturating_sub(sig_caps as usize);
             if std::env::var_os("PERRY_SUPER_DEBUG").is_some() {
                 eprintln!(
-                    "flat_super cid={} total={} caps={} args_len={} rest={:?}",
+                    "flat_super cid={} total={} sig_caps={} snapshot={} args_len={} rest={:?}",
                     cur,
                     total_params,
+                    sig_caps,
                     caps.len(),
                     args_len,
                     crate::closure::lookup_closure_rest(ctor_ptr as *const u8)
                 );
             }
-            let mut final_args: Vec<f64> = Vec::with_capacity(total_params as usize);
-            for i in 0..user_params {
+            let get = |i: usize| -> f64 {
                 if !args_ptr.is_null() && i < args_len {
-                    final_args.push(*args_ptr.add(i));
+                    unsafe { *args_ptr.add(i) }
                 } else {
-                    final_args.push(undef);
+                    undef
+                }
+            };
+            let mut final_args: Vec<f64> = Vec::with_capacity(total_params as usize);
+            let rest_idx = crate::closure::lookup_closure_rest(ctor_ptr as *const u8)
+                .map(|ri| ri as usize)
+                .filter(|ri| *ri < user_params);
+            if let Some(ri) = rest_idx {
+                for i in 0..ri {
+                    final_args.push(get(i));
+                }
+                let mut rest_arr = crate::array::js_array_alloc(0);
+                let mut i = ri;
+                while i < args_len {
+                    rest_arr = crate::array::js_array_push_f64(rest_arr, get(i));
+                    i += 1;
+                }
+                final_args.push(crate::value::js_nanbox_pointer(rest_arr as i64));
+            } else {
+                for i in 0..user_params {
+                    final_args.push(get(i));
                 }
             }
-            for bits in &caps {
-                final_args.push(f64::from_bits(*bits));
+            for slot in 0..sig_caps as usize {
+                final_args.push(caps.get(slot).map(|b| f64::from_bits(*b)).unwrap_or(undef));
             }
             let _ = call_vtable_method(
                 ctor_ptr,
@@ -836,7 +900,7 @@ pub(crate) unsafe fn replay_class_object_constructor(
     args_ptr: *const f64,
     args_len: usize,
 ) {
-    let Some((ctor_ptr, total_params)) = lookup_class_constructor(class_cid) else {
+    let Some((ctor_ptr, total_params, sig_caps)) = lookup_class_constructor(class_cid) else {
         return;
     };
 
@@ -871,8 +935,10 @@ pub(crate) unsafe fn replay_class_object_constructor(
     } else {
         Vec::new()
     };
-    let effective_caps = (n_caps as usize).max(snapshot_caps.len());
-    let user_params = (total_params as usize).saturating_sub(effective_caps);
+    // #5957: user/cap split from the SIGNATURE cap count (not the per-eval /
+    // snapshot length — a dynamic-parent ctor is capless while a snapshot
+    // exists, and the old `max(per-eval, snapshot)` subtraction ate user args).
+    let user_params = (total_params as usize).saturating_sub(sig_caps as usize);
     let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
     let mut final_args: Vec<f64> = Vec::with_capacity(total_params as usize);
     // #wall3: a `constructor(...args)` (rest param) called via the dynamic
@@ -913,11 +979,18 @@ pub(crate) unsafe fn replay_class_object_constructor(
             }
         }
     }
-    for j in 0..n_caps {
-        final_args.push(crate::array::js_array_get_f64(caps_arr, j));
-    }
-    for bits in &snapshot_caps {
-        final_args.push(f64::from_bits(*bits));
+    // Exactly `sig_caps` trailing cap slots: per-evaluation snapshot first
+    // (class EXPRESSIONS carry `__perry_ctor_caps`), decl-site snapshot second
+    // (class DECLARATIONS reached as heap values), undefined last.
+    for slot in 0..sig_caps as usize {
+        let v = if (slot as u32) < n_caps {
+            crate::array::js_array_get_f64(caps_arr, slot as u32)
+        } else if let Some(bits) = snapshot_caps.get(slot) {
+            f64::from_bits(*bits)
+        } else {
+            undef
+        };
+        final_args.push(v);
     }
     let _ = call_vtable_method(
         ctor_ptr,
@@ -942,15 +1015,16 @@ pub(crate) unsafe fn replay_registered_class_constructor(
     args_ptr: *const f64,
     args_len: usize,
 ) {
-    let Some((ctor_ptr, total_params)) = lookup_class_constructor(class_cid) else {
+    let Some((ctor_ptr, total_params, sig_caps)) = lookup_class_constructor(class_cid) else {
         return;
     };
 
     // A function-nested class declaration may carry a decl-site capture
     // snapshot (see CLASS_CAPTURE_VALUES). The ctor's trailing
     // `__perry_cap_<id>` params are filled from it; user args fill the rest.
+    // #5957: the split is the SIGNATURE cap count, not the snapshot length.
     let caps = class_capture_values(class_cid).unwrap_or_default();
-    let user_params = (total_params as usize).saturating_sub(caps.len());
+    let user_params = (total_params as usize).saturating_sub(sig_caps as usize);
 
     let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
     let mut final_args: Vec<f64> = Vec::with_capacity(total_params as usize);
@@ -993,8 +1067,8 @@ pub(crate) unsafe fn replay_registered_class_constructor(
             }
         }
     }
-    for bits in &caps {
-        final_args.push(f64::from_bits(*bits));
+    for slot in 0..sig_caps as usize {
+        final_args.push(caps.get(slot).map(|b| f64::from_bits(*b)).unwrap_or(undef));
     }
     let _ = call_vtable_method(
         ctor_ptr,

--- a/crates/perry-runtime/src/object/class_registry/parent_static.rs
+++ b/crates/perry-runtime/src/object/class_registry/parent_static.rs
@@ -210,14 +210,33 @@ pub extern "C" fn js_register_class_parent_dynamic(class_id: u32, parent_value: 
 #[no_mangle]
 pub extern "C" fn js_get_dynamic_parent_value(class_id: u32) -> f64 {
     const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+    const INT32_TAG: u64 = 0x7FFE_0000_0000_0000;
     if class_id == 0 {
         return f64::from_bits(TAG_UNDEFINED);
     }
-    let guard = CLASS_DYNAMIC_PARENT_VALUE.read().unwrap();
-    match guard.as_ref().and_then(|m| m.get(&class_id)) {
-        Some(&bits) => f64::from_bits(bits),
-        None => f64::from_bits(TAG_UNDEFINED),
+    {
+        let guard = CLASS_DYNAMIC_PARENT_VALUE.read().unwrap();
+        if let Some(&bits) = guard.as_ref().and_then(|m| m.get(&class_id)) {
+            return f64::from_bits(bits);
+        }
     }
+    // #5957/#806: no dynamic VALUE stashed — fall back to the STATIC
+    // parent-id edge as a ClassRef. An `extends <call>(...)` mixin
+    // materialized by the HIR inline-init can resolve the chain statically
+    // (module init registers `js_register_class_parent(child, parent)`)
+    // while the per-value `js_register_class_parent_dynamic` side effect
+    // lived in a body that never runs; before this fallback the
+    // dynamic-parent super leg dispatched `undefined` and silently no-op'd
+    // — the ancestor ctor never saw the forwarded args (the #806 mixin's
+    // `seed` stayed undefined). A ClassRef routes the caller into the
+    // registered-constructor flat dispatch, which fills user args and
+    // snapshot caps by the signature split.
+    if let Some(parent_cid) = crate::object::get_parent_class_id(class_id) {
+        if parent_cid != 0 {
+            return f64::from_bits(INT32_TAG | parent_cid as u64);
+        }
+    }
+    f64::from_bits(TAG_UNDEFINED)
 }
 
 /// #1789: stamp a freshly-allocated object as a heap "class object" (the

--- a/crates/perry/tests/issue_806_default_derived_ctor_forwarding.rs
+++ b/crates/perry/tests/issue_806_default_derived_ctor_forwarding.rs
@@ -73,7 +73,6 @@ fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
 /// IS registered, so user_params computes to 0 and `seed` never receives
 /// "alpha". Needs the signature cap-param count registered alongside the
 /// ctor (see the follow-up to #806).
-#[ignore = "part 2: capless-signature ctor vs snapshot subtraction in the class-object construct dispatch"]
 #[test]
 fn default_derived_forwards_through_capturing_mixin() {
     let dir = tempfile::tempdir().expect("tempdir");
@@ -210,7 +209,6 @@ console.log(factory("K"));
 /// args — the mixin test above hits that variant too, beneath its
 /// dispatch-layer failure.) Fix is the spec `(...args)` synthesis via
 /// `SuperCallSpread` (see the follow-up to #806).
-#[ignore = "part 2: HIR default-ctor synthesis mints fixed arity instead of (...args) — rest ancestors truncate"]
 #[test]
 fn walk_into_rest_param_capturing_ctor() {
     let dir = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
Closes the two shapes the #806 fix left open (both were `#[ignore]`d acceptance tests in `issue_806_default_derived_ctor_forwarding`). Now **5/5**.

**1. HIR default-ctor synthesis minted FIXED-ARITY params.** A rest-param ancestor counted as arity 1 (`new Drain("a","b","c")` forwarded only `"a"` → `P[a]`); an extends-EXPR / non-pending parent walked to arity 0 (the mixin dropped ALL user args). Now synthesizes the real spec `constructor(...args) { super(...args) }` — one rest param + `SuperCallSpread` forwards everything for every parent shape (`class_captures.rs`).

**2. The runtime construct dispatchers split user/cap args by the decl-site SNAPSHOT length.** A dynamic-parent ctor compiles a CAPLESS signature yet registers a snapshot (extends-expr refs join the capture union), so `total − snapshot.len()` ate user args (`new WrappedLogged("alpha")` bound the mixin ctor's `seed` to undefined). Adds `sig_caps` (the SIGNATURE cap count) as a 4th arg on `js_register_class_constructor` and splits on THAT in all four dispatchers. This **coexists with #6018's `CLASS_CONSTRUCTOR_FLAGS`** (merged after the original #5957 draft was parked) — separate tables, reconciled in the dispatcher bodies (`sig_caps == 0` keeps #6018's synth/rest path; `sig_caps > 0` does rest-aware packing WITH trailing caps, which #6018 explicitly punted on for the caps+rest case).

**3. `js_get_dynamic_parent_value` falls back to the STATIC parent-id edge as a ClassRef** when no dynamic value was stashed — an `extends <call>` mixin whose `RegisterClassParentDynamic` side effect never ran now routes into the registered-ctor flat dispatch instead of no-op'ing on `undefined`.

**Verification:** issue_806 suite 5/5 (mixin = `seed=alpha:wrapped`, rest = `P[a,b,c]`). Wide regression sweep — capture / 5437 / w6 / temporal(5587) / derived-capture / renamed-class suites (17 suites, the zod/Next.js class-construction paths) all green. One suite (`issue_cjs_destructured_var_forward_capture`) fails, but **it fails identically on clean `origin/main`** (verified with the verbatim repro) — a pre-existing bug, not introduced here; filing separately. File-size + addr-class gates pass.

Code-only; metadata folded at merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved derived-class constructor behavior so forwarded arguments are handled more reliably, including rest/spread cases.
  * Fixed class parent lookup to fall back to the registered static parent when no dynamic parent is available.
  * Corrected constructor registration and replay so trailing captured parameters are preserved more consistently.

* **Tests**
  * Enabled additional regression tests for default derived constructor forwarding and rest-parameter capturing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->