### PR TITLE
fix(hir): #6037 — refresh class-capture snapshot after a forward-captured var is re-bound by destructuring

### DIFF
--- a/crates/perry-hir/src/lower/expr_function.rs
+++ b/crates/perry-hir/src/lower/expr_function.rs
@@ -1473,6 +1473,27 @@ pub(crate) fn insert_class_capture_refresh_after_assignments(
         // collector) assign any watched capture?
         let mut assigned = Vec::new();
         collect_assigned_locals_stmt(&stmts[i], &mut assigned);
+        // #6037: a forward-captured `var`/`let` re-bound later in the same body
+        // — including a DESTRUCTURING leaf (`var { t: dSq } = f()`) — lowers to
+        // a `Stmt::Let` that REUSES the pre-registered forward-decl id (see the
+        // `lexical_forward_decls` / `PreallocateBoxes` machinery). Such a Let
+        // IS an assignment of the captured value, but `collect_assigned_locals_
+        // stmt` classifies every `Let` as a fresh binding and skips it, so the
+        // decl-site snapshot (taken while the forward-decl still held
+        // `undefined`) was never refreshed and the class method read the
+        // capture as undefined (semver's `Comparator` reading `dSq.COMPARATOR`).
+        // A non-`undefined` init re-binding a watched id triggers the refresh;
+        // the `undefined` forward-decl init itself is skipped (it snapshots the
+        // same pre-assignment value the decl-site `RegisterClassCaptures`
+        // already recorded).
+        if let Stmt::Let {
+            id, init: Some(v), ..
+        } = &stmts[i]
+        {
+            if !matches!(v, Expr::Undefined) {
+                assigned.push(*id);
+            }
+        }
         if !assigned.is_empty() {
             let mut inserts: Vec<Stmt> = Vec::new();
             for (re_reg, capset) in regs {


### PR DESCRIPTION
A class capturing a `var`/`let` declared LATER in the same body reads it through the decl-site capture snapshot (class captures are value-based). The snapshot is taken while the forward-decl still holds `undefined` and is refreshed after each later assignment of the captured id — but a **destructuring** re-bind (`var { t: dSq } = f()`) lowers to a `Stmt::Let` that reuses the pre-registered forward-decl id, and `collect_assigned_locals_stmt` classifies every `Let` as a fresh binding (not an assignment). So no refresh fired and the class method read the capture as `undefined`.

Real-world shape (the repro in #6037): semver's `Comparator` reading `dSq.COMPARATOR` where `var { safeRe: QSq, t: dSq } = requireModule()` is declared after the class — the esbuild `__commonJS` + destructured-exports pattern in the semver / claude-code bundles.

**Fix:** in `insert_class_capture_refresh_after_assignments`, treat a `Let { id, init: Some(v) }` whose non-`undefined` init re-binds a watched capture id as an assignment that triggers the refresh (the `undefined` forward-decl init is skipped — it would re-snapshot the same pre-assignment value the decl-site `RegisterClassCaptures` already recorded).

**Verified:** `issue_cjs_destructured_var_forward_capture` passes (was failing on main); the semver repro prints `class: rx` (was a TypeError). Wide capture/5437/w6/forward-capture sweep — 19 suites, all green.

Note: this bug regressed on main during the recent code-only merge window and CI's change-scoping (#5960) never runs `crates/perry` integration suites, so it landed unflagged. Code-only; metadata folded at merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved class-capture refresh behavior when a captured `var`/`let` is reassigned later in the same function.
  * Fixed handling for rebindings created through `let` statements, including destructuring forms.
  * Refresh updates now occur after valid reassignments and are skipped for `undefined` initializers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->