### PR TITLE
fix(codegen): resolve method dispatch on a monomorphized generic-class receiver

### DIFF
--- a/crates/perry-codegen/src/type_analysis/predicates.rs
+++ b/crates/perry-codegen/src/type_analysis/predicates.rs
@@ -207,6 +207,20 @@ pub(crate) fn receiver_class_name(ctx: &FnCtx<'_>, e: &Expr) -> Option<String> {
             // type parameters anyway, so the dispatch is identical
             // to the non-generic Named form.
             HirType::Generic { base, .. } if ctx.classes.contains_key(base) => Some(base.clone()),
+            // #5982-adjacent / #5917 `generic_class`: when the class was
+            // MONOMORPHIZED (the `new` site was rewritten to
+            // `SimpleContainer$num` but the local's declared type kept the
+            // un-mangled `Generic { base, type_args }` spelling), the base
+            // name isn't in `ctx.classes` — only the specialized name is.
+            // Resolve to the specialized name so method dispatch finds the
+            // real class instead of falling through to the number/native
+            // fast path (`(number).get is not a function`).
+            HirType::Generic { base, type_args } => {
+                let specialized = perry_hir::monomorph::generate_specialized_name(base, type_args);
+                ctx.classes
+                    .contains_key(&specialized)
+                    .then_some(specialized)
+            }
             _ => None,
         },
         // `new ClassName(...)` — the receiver class is the constructed class.

--- a/crates/perry-hir/src/monomorph/mangle.rs
+++ b/crates/perry-hir/src/monomorph/mangle.rs
@@ -11,7 +11,7 @@ pub(crate) fn mangle_type_args(type_args: &[Type]) -> String {
 
 /// Generate a mangled name for a specialized function/class
 /// e.g., "identity" with [Type::Number] becomes "identity$number"
-pub(crate) fn generate_specialized_name(base_name: &str, type_args: &[Type]) -> String {
+pub fn generate_specialized_name(base_name: &str, type_args: &[Type]) -> String {
     if type_args.is_empty() {
         return base_name.to_string();
     }
@@ -22,7 +22,7 @@ pub(crate) fn generate_specialized_name(base_name: &str, type_args: &[Type]) -> 
 }
 
 /// Mangle a type into a string suitable for use in identifiers
-pub(crate) fn mangle_type(ty: &Type) -> String {
+pub fn mangle_type(ty: &Type) -> String {
     match ty {
         Type::Void => "void".to_string(),
         Type::Null => "null".to_string(),

--- a/crates/perry-hir/src/monomorph/mod.rs
+++ b/crates/perry-hir/src/monomorph/mod.rs
@@ -46,8 +46,7 @@ pub(crate) use infer::{
     unify_rest_param_types, unify_types,
 };
 pub(crate) use inference_lookup::{ClassInfo, FuncInfo, InferenceLookup};
-#[cfg(test)]
-pub(crate) use mangle::mangle_type;
-pub(crate) use mangle::{generate_specialized_name, mangle_type_args};
+pub(crate) use mangle::mangle_type_args;
+pub use mangle::{generate_specialized_name, mangle_type};
 pub(crate) use substitute_expr::{substitute_expr, substitute_stmts};
 pub(crate) use update_call_sites::update_call_sites;

--- a/crates/perry/tests/issue_6040_generic_class_dispatch.rs
+++ b/crates/perry/tests/issue_6040_generic_class_dispatch.rs
@@ -1,0 +1,108 @@
+//! Regression tests for generic-class method dispatch on a MONOMORPHIZED
+//! receiver (part of the #5917 `generic_class` triage; the scalar-replacement
+//! half of `test_edge_interfaces` is tracked separately as #6040).
+//!
+//! `class C<T> { get(): T {...} }; new C<string>(...).get()` monomorphizes to
+//! `C$str`, but the receiver local kept the un-mangled `Generic { base: "C",
+//! type_args: [String] }` type. `receiver_class_name` looked up the base
+//! `C` (absent from `ctx.classes` — only `C$str` is registered), returned
+//! `None`, and dispatch fell to the number/native fast path
+//! (`(string).get is not a function`). It now resolves the specialized
+//! `base$mangled` name.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn run(dir: &std::path::Path, src: &str) -> String {
+    let entry = dir.join("main.ts");
+    let out = dir.join("main_bin");
+    std::fs::write(&entry, src).expect("write");
+    let c = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&out)
+        .arg("--no-cache")
+        .output()
+        .expect("compile");
+    assert!(
+        c.status.success(),
+        "compile failed\n{}",
+        String::from_utf8_lossy(&c.stderr)
+    );
+    let r = Command::new(&out).current_dir(dir).output().expect("run");
+    assert!(
+        r.status.success(),
+        "run failed\n{}",
+        String::from_utf8_lossy(&r.stderr)
+    );
+    String::from_utf8_lossy(&r.stdout).into_owned()
+}
+
+#[test]
+fn generic_class_string_arg_method_dispatch() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = run(
+        dir.path(),
+        r#"
+class SimpleContainer<T> {
+    private _value: T;
+    constructor(initial: T) { this._value = initial; }
+    get(): T { return this._value; }
+    set(value: T): void { this._value = value; }
+}
+const c = new SimpleContainer<string>("hello");
+console.log(c.get());
+c.set("world");
+console.log(c.get());
+"#,
+    );
+    assert_eq!(out, "hello\nworld\n");
+}
+
+#[test]
+fn generic_class_multi_field_numeric_arg_method_dispatch() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = run(
+        dir.path(),
+        r#"
+class Multi<T> {
+    a: T; b: number;
+    constructor(x: T) { this.a = x; this.b = 99; }
+    getA(): T { return this.a; }
+}
+const m = new Multi<number>(7);
+console.log(m.getA(), m.b);
+"#,
+    );
+    assert_eq!(out, "7 99\n");
+}
+
+/// The single-field NUMERIC generic instance is scalar-replaced down to its
+/// raw-f64 field, so the instance becomes the number and method dispatch on
+/// it throws. Distinct from the dispatch fix above — tracked as #6040.
+#[ignore = "#6040: single-field numeric generic instance scalar-replaced to its raw-f64 field"]
+#[test]
+fn generic_class_single_field_numeric_arg_method_dispatch() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = run(
+        dir.path(),
+        r#"
+class SimpleContainer<T> {
+    private _value: T;
+    constructor(initial: T) { this._value = initial; }
+    get(): T { return this._value; }
+    set(value: T): void { this._value = value; }
+}
+const c = new SimpleContainer<number>(0);
+c.set(42);
+console.log(c.get());
+"#,
+    );
+    assert_eq!(out, "42\n");
+}


### PR DESCRIPTION
`class C<T> { get(): T {...} }; new C<string>(...).get()` monomorphizes to `C$str`, but the receiver local kept the un-mangled `Generic { base: "C", type_args: [String] }` type. `receiver_class_name` looked up the base `C` — absent from `ctx.classes` (only the specialized `C$str` is registered) — returned `None`, and method dispatch fell through to the number/native fast path: **`(string).get is not a function`**.

**Fix:** when the base isn't a registered class, resolve the specialized `base$mangled` name (exposing perry-hir's `generate_specialized_name` / `mangle_type`) and dispatch to that.

Restores generic-class method dispatch for:
- `SimpleContainer<string>` (`hello` / `world`)
- multi-field `Multi<number>` (`7 99`)

Both were failing on main (part of the #5917 `generic_class` triage and `test_edge_interfaces`). New guard suite `issue_6040_generic_class_dispatch` (2 passing + 1 `#[ignore]`d).

The single-field **numeric** case (`SimpleContainer<number>`) still fails — its instance is scalar-replaced down to its raw-f64 field, so no object exists for method dispatch. That's a distinct optimization-eligibility bug, filed as **#6040** and guarded here as the ignored test.

Verified: generic/class/capture/5437/w6/interface sweep — 27 suites, all green. Code-only; metadata folded at merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved method dispatch for generic receiver types, ensuring monomorphized/specialized classes are correctly recognized.
  * Fixed scenarios where instance method calls on generic containers could fail to resolve (for example `get`/`set`).
* **Tests**
  * Added regression tests covering generic-class dispatch on monomorphized receivers, including passing cases and one ignored edge-case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->