### PR TITLE
fix(codegen): #6040 monomorphized-generic scalar method dispatch (uninitialized receiver)

### DIFF
--- a/crates/perry-codegen/src/type_analysis/predicates.rs
+++ b/crates/perry-codegen/src/type_analysis/predicates.rs
@@ -202,24 +202,28 @@ pub(crate) fn receiver_class_name(ctx: &FnCtx<'_>, e: &Expr) -> Option<String> {
     match e {
         Expr::LocalGet(id) => match ctx.local_types.get(id)? {
             HirType::Named(name) => Some(name.clone()),
-            // Generic instantiation `Box<number>` — strip the type
-            // args and use the base class name. The codegen erases
-            // type parameters anyway, so the dispatch is identical
-            // to the non-generic Named form.
-            HirType::Generic { base, .. } if ctx.classes.contains_key(base) => Some(base.clone()),
-            // #5982-adjacent / #5917 `generic_class`: when the class was
-            // MONOMORPHIZED (the `new` site was rewritten to
-            // `SimpleContainer$num` but the local's declared type kept the
-            // un-mangled `Generic { base, type_args }` spelling), the base
-            // name isn't in `ctx.classes` — only the specialized name is.
-            // Resolve to the specialized name so method dispatch finds the
-            // real class instead of falling through to the number/native
-            // fast path (`(number).get is not a function`).
+            // Generic instantiation `SimpleContainer<number>`: prefer the
+            // MONOMORPHIZED specialization `base$mangled` whenever it is
+            // registered. The instance is genuinely a `SimpleContainer$num`
+            // (concrete field types), and — critically — the escape analysis
+            // that authorizes scalar replacement keys off the `new`'s
+            // specialized class name (collect_non_escaping_news). If codegen
+            // resolved to the base `SimpleContainer` instead (whose fields are
+            // still `T`), the scalar-method summary would reject `get()` and a
+            // scalar-replaced receiver would fall through to normal dispatch on
+            // an uninitialized dummy slot (#6040: `(number).get is not a
+            // function`). Resolving to the specialization keeps the two passes
+            // consistent. Fall back to the base template when no specialization
+            // exists (fully-generic code paths), then give up.
             HirType::Generic { base, type_args } => {
                 let specialized = perry_hir::monomorph::generate_specialized_name(base, type_args);
-                ctx.classes
-                    .contains_key(&specialized)
-                    .then_some(specialized)
+                if ctx.classes.contains_key(&specialized) {
+                    Some(specialized)
+                } else if ctx.classes.contains_key(base) {
+                    Some(base.clone())
+                } else {
+                    None
+                }
             }
             _ => None,
         },

--- a/crates/perry/tests/issue_6040_generic_class_dispatch.rs
+++ b/crates/perry/tests/issue_6040_generic_class_dispatch.rs
@@ -84,9 +84,13 @@ console.log(m.getA(), m.b);
 }
 
 /// The single-field NUMERIC generic instance is scalar-replaced down to its
-/// raw-f64 field, so the instance becomes the number and method dispatch on
-/// it throws. Distinct from the dispatch fix above — tracked as #6040.
-#[ignore = "#6040: single-field numeric generic instance scalar-replaced to its raw-f64 field"]
+/// raw-f64 field. Its `get()` reads the (private, now concrete-numeric) field,
+/// so the scalar-method summary can inline it — but only when codegen resolves
+/// the receiver to the monomorphized `SimpleContainer$num` (matching the class
+/// the escape analysis used to authorize scalar replacement). #6040 was the
+/// mismatch where codegen resolved to the base `SimpleContainer` (fields still
+/// `T`), the summary rejected `get()`, and dispatch fell through to an
+/// uninitialized dummy-slot receiver (`(number).get is not a function`).
 #[test]
 fn generic_class_single_field_numeric_arg_method_dispatch() {
     let dir = tempfile::tempdir().expect("tempdir");


### PR DESCRIPTION
## Bug (#6040)

```ts
class SimpleContainer<T> {
    private _value: T;
    constructor(initial: T) { this._value = initial; }
    get(): T { return this._value; }
    set(value: T): void { this._value = value; }
}
const c = new SimpleContainer<number>(0);
c.set(42);
console.log(c.get());   // TypeError: (number).get is not a function
```

A single-numeric-field generic instance is scalar-replaced down to its raw-f64 field (no heap object). `c.set(42)` is fine — the HIR lowers it to a direct field write (`PutValueSet`). `c.get()` stays a real method `Call`, and the scalar-method summary *can* inline `return this._value` as a raw-f64 load — but it bailed, and dispatch fell through to normal method lookup on a **scalar-replaced receiver**, i.e. the never-initialized dummy alloca. The receiver was garbage, hence `(number).get is not a function`.

## Root cause — two passes disagreeing on the receiver's class

- **Escape analysis** (`collect_non_escaping_news`) keys its summarizability check off the `new`'s specialized class `SimpleContainer$num`, whose `_value` is `number`. `get()` is summarizable there ⇒ it green-lights scalar replacement.
- **Codegen** (`receiver_class_name`) resolved the local's `Generic { base: "SimpleContainer", type_args: [Number] }` type to the **base template** `SimpleContainer` — because that template is still registered in `ctx.classes`, the first `Generic` arm matched. The #6041 specialized arm only fired when the base was *absent*. On the base class `_value` is still `T` (not numeric), so `simple_scalar_method_summary` rejected `get()` → `try_lower_scalar_replaced_method_call` returned `None`.

So the escape pass authorized an optimization that codegen then couldn't complete, and the fallback path read an uninitialized receiver slot.

## Fix

`receiver_class_name` now prefers the monomorphized specialization `base$mangled` when it's registered, falling back to the base template only when no specialization exists:

```rust
HirType::Generic { base, type_args } => {
    let specialized = generate_specialized_name(base, type_args);
    if ctx.classes.contains_key(&specialized) { Some(specialized) }
    else if ctx.classes.contains_key(base)    { Some(base.clone()) }
    else                                       { None }
}
```

This matches the class the escape analysis used and is simply the more accurate answer — the instance is genuinely a `SimpleContainer$num` with concrete field types.

## Verification

16-case direct-compile battery, all green: single/multi-field and string containers; compute + boolean methods; method chaining; upcast to a base-typed variable; array-element and nested-field dispatch; two specializations of one generic in the same program; escaping instances passed to a function; and the non-generic single-field scalar baseline. Un-ignores the `#6040` guard test (now 3/3 passing).

Closes #6040.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generic class dispatch now resolves to the specialized class name when available, improving method lookup for instantiated generic types.
  * This fixes a case where calls on single-field numeric generic instances could fail with a “not a function” error.
* **Tests**
  * Enabled a previously ignored regression test covering generic instance dispatch and scalar replacement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->