### PR TITLE
fix(hir): #5835 zero-arg new Function() must not trip the CSP codegen-probe throw

### DIFF
--- a/crates/perry-hir/src/lower/const_fold_fn.rs
+++ b/crates/perry-hir/src/lower/const_fold_fn.rs
@@ -320,7 +320,18 @@ pub(crate) fn try_const_fold_function_construct_kind(
     // their non-codegen interpreter fallback. Only the trivial empty-body no-op
     // is refused; real literal bodies (`return 42`, the `return this` globalThis
     // polyfill) still fold, preserving spec behavior by default.
-    if body_src.trim().is_empty() && crate::eval_classifier::eval_csp_probe_unavailable() {
+    //
+    // The probe passes AT LEAST ONE string argument (`new Function("")`). A
+    // ZERO-argument `new Function()` is not a codegen request at all — it
+    // constructs the empty function `anonymous() {}` — so it must NEVER throw,
+    // even under the default CSP mode (#5835 Intl-ctor test regressed here:
+    // `new Function()` used purely as a constructable-with-settable-prototype
+    // scaffold for `Reflect.construct` began throwing). Gate the refusal on
+    // there actually being an argument.
+    if !consts.is_empty()
+        && body_src.trim().is_empty()
+        && crate::eval_classifier::eval_csp_probe_unavailable()
+    {
         return synth_throwing_iife(
             ctx,
             "throw new TypeError(\"Function: runtime dynamic code generation is \

--- a/crates/perry/tests/issue_5835_zero_arg_function_ctor.rs
+++ b/crates/perry/tests/issue_5835_zero_arg_function_ctor.rs
@@ -1,0 +1,96 @@
+//! #5835 regression: a ZERO-argument `new Function()` must construct the empty
+//! function `anonymous() {}`, never the CSP "dynamic code generation is
+//! unavailable" throw.
+//!
+//! The throw exists to make the zod-style codegen capability probe
+//! (`new Function("")`, which passes an argument) fail so zod takes its
+//! non-codegen interpreter fallback. It was firing for ARGUMENT-LESS
+//! `new Function()` too — which is not a codegen request at all, just an empty
+//! constructable — and regressed `test_gap_intl_ctor_mechanics_5835` (which
+//! uses `new Function()` as a settable-prototype scaffold for
+//! `Reflect.construct`). The refusal is now gated on there being ≥1 argument.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn run(dir: &std::path::Path, src: &str) -> String {
+    let entry = dir.join("main.ts");
+    let out = dir.join("main_bin");
+    std::fs::write(&entry, src).expect("write");
+    let c = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&out)
+        .arg("--no-cache")
+        .output()
+        .expect("compile");
+    assert!(
+        c.status.success(),
+        "compile failed\n{}",
+        String::from_utf8_lossy(&c.stderr)
+    );
+    let r = Command::new(&out).current_dir(dir).output().expect("run");
+    assert!(
+        r.status.success(),
+        "run failed\n{}",
+        String::from_utf8_lossy(&r.stderr)
+    );
+    String::from_utf8_lossy(&r.stdout).into_owned()
+}
+
+#[test]
+fn zero_arg_new_function_is_an_empty_callable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = run(
+        dir.path(),
+        r#"
+const f: any = new Function();
+f.prototype = {};
+console.log(typeof f, (() => { try { f(); return "ok"; } catch { return "threw"; } })(), typeof f.prototype);
+"#,
+    );
+    assert_eq!(out, "function ok object\n");
+}
+
+#[test]
+fn zero_arg_function_called_form_is_an_empty_callable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = run(
+        dir.path(),
+        "const f: any = Function();\nconsole.log(typeof f);\n",
+    );
+    assert_eq!(out, "function\n");
+}
+
+/// The argument-bearing codegen probe must still be refused so zod-style JIT
+/// feature-detection takes its non-codegen fallback (default CSP behavior).
+#[test]
+fn empty_string_arg_probe_still_throws() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = run(
+        dir.path(),
+        r#"
+try { new Function(""); console.log("no-throw"); }
+catch { console.log("threw"); }
+"#,
+    );
+    assert_eq!(out, "threw\n");
+}
+
+/// A real literal body still folds and runs — the fix must not disturb the
+/// spec-preserving `CreateDynamicFunction` path for statically-known sources.
+#[test]
+fn real_literal_body_still_folds() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = run(
+        dir.path(),
+        "const f: any = new Function(\"a\", \"b\", \"return a + b\");\nconsole.log(f(2, 3));\n",
+    );
+    assert_eq!(out, "5\n");
+}


### PR DESCRIPTION
## Regression

`test_gap_intl_ctor_mechanics_5835` (the gap suite's Intl-ctor + `Reflect.construct`-prototype test, added *green* with #5850) started failing with:

```
TypeError: Function: runtime dynamic code generation is unavailable in this ahead-of-time compiled binary
```

It uses `new Function()` purely as a constructable-with-settable-`prototype` scaffold for `Reflect.construct(Intl.X, args, custom)`:

```ts
const custom: any = new Function();
custom.prototype = {};
const obj = Reflect.construct(I.DisplayNames, [undefined, { type: "language" }], custom);
```

## Root cause

`eval_csp_probe_unavailable()` defaults to **true** when `PERRY_EVAL_CSP` is unset, so the empty-body refusal in `const_fold_fn.rs` fired for **every** empty-body `Function` constructor. That refusal is meant only for the zod-style codegen capability probe `new Function("")` — which passes an empty-**string** argument — so zod detects "no runtime codegen" and takes its interpreter fallback. But a **zero-argument** `new Function()` is not a codegen request at all: it constructs the empty function `anonymous() {}`.

## Fix

Gate the refusal on `!consts.is_empty()` (at least one resolved string argument):

- `new Function("")` → `consts == [""]` → still throws (zod fallback preserved).
- `new Function()` → `consts` empty → falls through to assemble the empty function.

## Verification (vs `node --experimental-strip-types`)

- Full `test_gap_intl_ctor_mechanics_5835` now **byte-matches** node.
- 6-case `Function` battery green: zero-arg `new Function()` and `Function()` (both `typeof === "function"`, callable, settable prototype); `new Function("")` still throws; real literal bodies still fold and run (`return 42`, `(a,b) => a+b` ⇒ `5`, the `return this` globalThis polyfill).
- Guard suite `issue_5835_zero_arg_function_ctor` (4 cases).

## Context

This was the sole untriaged gap failure in the #6042 sharded `conformance-smoke` run (shard 4). Fixing it clears the last blocker to the conformance gate being green on main — a prerequisite for promoting it to a required check (#9).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `new Function()` with zero arguments to correctly produce an empty callable instead of throwing under CSP-style restrictions.
  * Kept the prior refusal behavior for argument-bearing dynamic function creation when no body content is provided.
* **Tests**
  * Added a regression test covering zero-argument `new Function()`, the callable-returning `Function()` form, and non-empty constructor bodies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->