### PR TITLE
ci: conformance-smoke shard timeout headroom (40->55min) for required-gate safety

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -706,7 +706,11 @@ jobs:
         shard: [1, 2, 3, 4, 5, 6, 7, 8]
     if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    # Observed 19-37 min/shard on the first real sharded PR run. 40 left only
+    # ~3 min headroom over the slowest shard, so a slow-runner day could trip
+    # the timeout and (once this gate is a required context) flaky-red-block
+    # every PR. 55 gives comfortable headroom without hiding a genuine hang.
+    timeout-minutes: 55
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
First real sharded run (#6042) measured **19-37 min/shard**. The 40-min timeout left only ~3 min over the slowest shard. Before `conformance-smoke-complete` can safely become a **required** context (#9), it needs headroom — otherwise a slow-runner day tripping the timeout would flaky-red-block every PR. Bumps to 55 min (comfortable margin, still catches a genuine hang). No behavior change to the suite itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the allowed runtime for a smoke test shard, helping reduce timeouts during automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->