### PR TITLE
fix(runtime): guard URLSearchParams dynamic-call fast-path against handle receivers

### DIFF
--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -725,9 +725,23 @@ pub unsafe extern "C" fn js_native_call_method(
     if matches!(
         method_name,
         "append" | "set" | "get" | "has" | "delete" | "toString"
-    ) {
+    ) && jsval.is_pointer()
+    {
         let recv_ptr = (object.to_bits() & 0x0000_FFFF_FFFF_FFFF) as *mut ObjectHeader;
-        if crate::url::search_params::shape_is_url_search_params(recv_ptr) {
+        // A native handle (Headers/fetch/timer/...) is nanbox-pointer-tagged but
+        // its "pointer" is a small integer id in the low handle band, NOT a heap
+        // ObjectHeader. `append`/`set`/`get`/`has`/`delete` are exactly the
+        // methods a `Headers` handle carries, and the WHATWG NullableHeaders
+        // builder calls `K.delete(name)` / `K.append(name, value)` on a
+        // destructured (type-erased) receiver, which fuses to a dynamic method
+        // call and lands here with a Headers handle. `shape_is_url_search_params`
+        // would deref that small id as an `ObjectHeader` and SIGSEGV (fault
+        // address in the low handle band). Skip small handles so they fall
+        // through to `handle_method_dispatch` below, which owns the fetch/Headers
+        // method surface.
+        if !crate::value::addr_class::is_small_handle(recv_ptr as usize)
+            && crate::url::search_params::shape_is_url_search_params(recv_ptr)
+        {
             if let Some(result) = crate::url::search_params::url_search_params_dynamic_call(
                 recv_ptr,
                 method_name,

--- a/crates/perry/tests/issue_dynamic_call_headers_handle.rs
+++ b/crates/perry/tests/issue_dynamic_call_headers_handle.rs
@@ -1,0 +1,97 @@
+//! A fused dynamic method call (`v.append(...)` where `v`'s static Web-Fetch
+//! type was erased — stored in an `any`/untyped local, or destructured) routes
+//! through `js_native_call_method`. Its #5961 URLSearchParams fast-path matches
+//! the method names `append`/`set`/`get`/`has`/`delete`/`toString` and derefs
+//! the receiver as a heap `ObjectHeader` to sniff the `_entries` shape.
+//!
+//! But a `Headers` instance is a native *handle* — nanbox-pointer-tagged, yet
+//! its "pointer" is a small integer id in the low handle band, not a heap
+//! object. Dereferencing it as an `ObjectHeader` SIGSEGV'd (fault address in
+//! the low handle band). The WHATWG NullableHeaders builder does exactly this:
+//!
+//! ```js
+//! for (const [name, value] of entries) {   // destructured -> type-erased
+//!   if (value === null) K.delete(name);
+//!   else K.append(name, value);
+//! }
+//! ```
+//!
+//! The fast-path now skips small handles, so a Headers handle falls through to
+//! the fetch/Headers method dispatcher.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary exited non-zero: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).trim().to_string()
+}
+
+#[test]
+fn headers_methods_dispatch_on_type_erased_receiver() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = compile_and_run(
+        dir.path(),
+        r#"
+// The WHATWG NullableHeaders builder shape: destructured (type-erased) names
+// flow into Headers `delete`/`append`, fused to dynamic method calls.
+function build(lists: Array<Array<[string, string | null]>>): Headers {
+  const K = new Headers();
+  for (const z of lists) {
+    for (const [name, value] of z) {
+      if (value === null) K.delete(name);
+      else K.append(name, value);
+    }
+  }
+  return K;
+}
+
+const h = build([
+  [["Content-Type", "application/json"], ["x-beta", null]],
+  [["x-beta", "on"]],
+]);
+
+// Read back through an untyped local — also a type-erased dynamic call.
+const v: any = h;
+process.stdout.write(
+  "ct=" + v.get("content-type") +
+  " beta=" + v.get("x-beta") +
+  " hasCT=" + v.has("Content-Type") + "\n"
+);
+"#,
+    );
+    assert_eq!(
+        out, "ct=application/json beta=on hasCT=true",
+        "Headers methods on a type-erased receiver"
+    );
+}


### PR DESCRIPTION
## Problem

A fused dynamic method call — `v.append(...)` where `v`'s static Web-Fetch type was erased (stored in an `any`/untyped local, or a destructured binding) — routes through `js_native_call_method`. Its #5961 URLSearchParams fast-path matches the method names `append`/`set`/`get`/`has`/`delete`/`toString` and dereferences the receiver as a heap `ObjectHeader` to sniff the `_entries` shape:

```rust
let recv_ptr = (object.to_bits() & POINTER_MASK) as *mut ObjectHeader;
if shape_is_url_search_params(recv_ptr) { ... }   // reads (*recv_ptr).class_id
```

But a `Headers` instance — and every fetch / timer / ... value — is a native **handle**: nanbox-pointer-tagged, yet its "pointer" is a small integer id in the low handle band, not a heap object. Dereferencing that id as an `ObjectHeader` **SIGSEGV**s (fault address in the low handle band).

The WHATWG NullableHeaders builder hits this directly — destructured (type-erased) names flow into `Headers` methods:

```js
for (const [name, value] of entries) {   // destructured -> type-erased receiver below
  if (value === null) K.delete(name);
  else K.append(name, value);
}
```

Minimal repro (SIGSEGV before the fix):

```js
const K = new Headers();
K.append("a", "1");
const v = K;          // untyped alias
v.append("b", "2");   // fused dynamic call -> deref handle id as ObjectHeader -> crash
```

## Fix

Guard the fast-path with `jsval.is_pointer()` + `!is_small_handle(recv_ptr)` before the deref, so a handle receiver falls through to `handle_method_dispatch` below (which owns the fetch/Headers method surface). Real URLSearchParams instances are heap objects and are unaffected.

## Test

`crates/perry/tests/issue_dynamic_call_headers_handle.rs` compiles + runs the NullableHeaders builder shape (destructured names into `delete`/`append`, dedup across lists) and reads the result back through an untyped local: `ct=application/json beta=on hasCT=true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety for certain dynamic method calls on URL search parameter-like objects, preventing incorrect handling of non-object receiver values.
  * Fixed dynamic dispatch behavior for header-related method calls when the receiver is type-erased, restoring correct results for common operations like reading, checking, adding, and removing values.

* **Tests**
  * Added regression coverage for dynamic header method dispatch to verify the runtime output matches expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->