### PR TITLE
fix(runtime): Date.prototype.toString brand-check + own-expando method shadow

### DIFF
--- a/crates/perry-runtime/src/object/global_this/array_error.rs
+++ b/crates/perry-runtime/src/object/global_this/array_error.rs
@@ -226,6 +226,13 @@ pub(crate) extern "C" fn date_prototype_to_string_thunk(
     _closure: *const crate::closure::ClosureHeader,
 ) -> f64 {
     let this_value = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    // ECMA-262 21.4.4.41 Date.prototype.toString does `thisTimeValue(this)`,
+    // which throws a TypeError when the receiver has no [[DateValue]] slot
+    // (`Date.prototype.toString.call(0)`, `.call({})`, `Date.prototype.toString()`
+    // with this === Date.prototype). test262 Date/prototype/toString/non-date-receiver.
+    if !crate::date::is_date_value(this_value) {
+        super::super::object_ops::throw_object_type_error(b"this is not a Date object.");
+    }
     let string = crate::date::js_date_to_string(this_value);
     crate::value::js_nanbox_string(string as i64)
 }

--- a/crates/perry-runtime/src/object/native_call_method/primitive_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/primitive_methods.rs
@@ -572,6 +572,31 @@ pub(super) unsafe fn dispatch_primitive(
     // through and silently dropped setter mutations — e.g. dayjs's
     // `this.$d[l]($)` made `.add()`/`.date(n)` no-ops (#5133).
     if crate::date::is_date_value(object) {
+        // An own callable expando shadows the intrinsic Date.prototype method:
+        // `Object.defineProperty(d, "toString", {value: Number.prototype.toString});
+        // d.toString()` must run the *transferred* method (which brand-checks its
+        // receiver and throws a TypeError), not Date.prototype.toString (test262
+        // Number/prototype/{toString,valueOf}/*_A*_T03 and Boolean/prototype/
+        // {toString,valueOf}/*_A2_T3 — transfer-to-Date). Date instances are
+        // DateCell exotics, so own props live in the exotic expando table, not
+        // the ordinary object keys_array read by js_object_get_own_field_or_undef.
+        let recv_bits = object.to_bits();
+        let recv_addr = (recv_bits & 0x0000_FFFF_FFFF_FFFF) as usize;
+        if let Some(v) = super::exotic_expando::exotic_get_own_property(
+            recv_addr,
+            super::exotic_expando::ExoticKind::Date,
+            method_name,
+            object,
+        ) {
+            if (v.to_bits() & crate::value::TAG_MASK) == crate::value::POINTER_TAG
+                && crate::closure::is_closure_ptr((v.to_bits() & 0x0000_FFFF_FFFF_FFFF) as usize)
+            {
+                let prev_this = IMPLICIT_THIS.with(|c| c.replace(recv_bits));
+                let result = crate::closure::js_native_call_value(v, args_ptr, args_len);
+                IMPLICIT_THIS.with(|c| c.set(prev_this));
+                return Some(result);
+            }
+        }
         let ctor = crate::object::js_get_global_this_builtin_value(b"Date".as_ptr(), 4);
         let ctor_ptr = crate::value::js_nanbox_get_pointer(ctor) as usize;
         if ctor_ptr != 0 {


### PR DESCRIPTION
## Summary

Two Date-receiver handling gaps surfaced by the Test262 `built-ins` slice (measured on an internal Linux sweep host). Both are small, self-contained runtime fixes.

**1. `Date.prototype.toString` had no `thisTimeValue` brand check.**
The thunk read `IMPLICIT_THIS` and called `js_date_to_string` unconditionally, so a non-Date receiver produced a bogus date string instead of throwing:

```js
Date.prototype.toString.call(0);    // returned "Thu Jan 01 1970 …", should throw TypeError
Date.prototype.toString.call({});   // same
Date.prototype.toString();          // this === Date.prototype, same
```

The getters/setters already brand-check via `require_date_timestamp`; `toString` now does the equivalent (`is_date_value` guard → `throw_object_type_error`).

**2. A callable own expando on a Date instance did not shadow the intrinsic `Date.prototype` method.**
Date instances are `DateCell` exotics, so their own properties live in the exotic-expando table rather than the ordinary object `keys_array`. The dynamic Date-method dispatch resolved straight to `Date.prototype` and skipped a user override:

```js
var d = new Date(0);
Object.defineProperty(d, "toString", { value: Number.prototype.toString });
d.toString();   // ran Date.prototype.toString, should run the transferred method (which brand-checks and throws)
```

This mirrors the existing Promise own-`then` shadow: look up the method name in the Date exotic expando first, and when it is a callable, dispatch it with `this` bound to the receiver.

## Verification

Test262 `built-ins` slice (Boolean, Symbol, JSON, Reflect, Map, Set, parseInt, parseFloat, Object/prototype, Date, Number, Math — 2004 judged cases) run before/after against Node as the oracle:

- **Fixed (+2):** `Date/prototype/toString/non-date-receiver.js`, `Number/prototype/toString/S15.7.4.2_A4_T03.js`
- **New regressions: 0** (failure-list diff is empty)

Normal Date usage is unaffected: the expando lookup only fires for user-assigned own callables, and `Date.prototype` methods still resolve for the common path (verified `new Date(0).toString()` / `.getTime()` unchanged).

## Files

- `crates/perry-runtime/src/object/global_this/array_error.rs` — brand-check in `date_prototype_to_string_thunk`
- `crates/perry-runtime/src/object/native_call_method/primitive_methods.rs` — own-expando shadow in the Date dispatch block


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `Date` handling so methods on `Date` objects now respect object-specific overrides when present.
  * Fixed `Date` string conversion to validate the receiver first, returning a clear error if it is not a valid `Date`.
  * `Date` method calls now more reliably use the correct object method instead of falling back to the built-in default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->