### PR TITLE
fix(link): #6023 LNK1158 'cannot run mt.exe' on Windows MSVC UI builds

### DIFF
--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -634,6 +634,61 @@ fn read_registry_kits_root_10() -> Option<PathBuf> {
     None
 }
 
+/// Issue #6023: locate the Windows SDK `bin\<ver>\x64` (or `x86`) directory
+/// containing `mt.exe`, the manifest tool MSVC `link.exe` shells out to when
+/// given `/MANIFEST:EMBED`. Perry launches a vswhere-located `link.exe` from a
+/// plain shell — not a `vcvars64.bat` developer prompt — so the SDK bin dir is
+/// normally *not* on `PATH` and the link dies with `LNK1158: cannot run
+/// 'mt.exe'`. Probes the same SDK roots as `find_msvc_lib_paths` (registry
+/// `KitsRoot10`, ProgramFiles envs, legacy hardcoded path), newest SDK
+/// version first.
+#[cfg(target_os = "windows")]
+pub(super) fn find_windows_sdk_mt_dir() -> Option<PathBuf> {
+    let mut bin_roots: Vec<PathBuf> = Vec::new();
+    if let Some(reg_root) = read_registry_kits_root_10() {
+        bin_roots.push(reg_root.join("bin"));
+    }
+    for env_var in ["ProgramFiles", "ProgramFiles(x86)"] {
+        if let Ok(pf) = std::env::var(env_var) {
+            bin_roots.push(PathBuf::from(pf).join(r"Windows Kits\10\bin"));
+        }
+    }
+    bin_roots.push(PathBuf::from(r"C:\Program Files (x86)\Windows Kits\10\bin"));
+    bin_roots
+        .into_iter()
+        .find_map(|root| newest_mt_dir_under(&root))
+}
+
+/// Given a Windows SDK `bin` root, return the arch dir holding `mt.exe`: the
+/// newest versioned subdir's `x64` (then `x86`, which runs fine on x64 hosts),
+/// falling back to the unversioned `bin\<arch>` layout of pre-10.0.15063 SDKs.
+/// The newest-version pick mirrors the descending file-name sort
+/// `find_msvc_lib_paths` uses for `Lib\<ver>`. Host-independent so the
+/// selection logic can be unit-tested off-Windows (`windows_link_tests`).
+#[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+pub(super) fn newest_mt_dir_under(bin_root: &Path) -> Option<PathBuf> {
+    let mut version_dirs: Vec<PathBuf> = match std::fs::read_dir(bin_root) {
+        Ok(entries) => entries.filter_map(|e| e.ok()).map(|e| e.path()).collect(),
+        Err(_) => return None,
+    };
+    version_dirs.sort_by(|a, b| b.file_name().cmp(&a.file_name()));
+    for dir in version_dirs {
+        for arch in ["x64", "x86"] {
+            let cand = dir.join(arch);
+            if cand.join("mt.exe").is_file() {
+                return Some(cand);
+            }
+        }
+    }
+    for arch in ["x64", "x86"] {
+        let cand = bin_root.join(arch);
+        if cand.join("mt.exe").is_file() {
+            return Some(cand);
+        }
+    }
+    None
+}
+
 #[cfg(not(target_os = "windows"))]
 pub(super) fn find_msvc_lib_paths() -> Option<String> {
     let sysroot = std::env::var("PERRY_WINDOWS_SYSROOT").ok()?;

--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -55,6 +55,8 @@ pub(super) use link_cache::{write_link_cache_manifest, LinkCacheStatus};
 pub use platform_cmd::select_linker_command;
 #[cfg(test)]
 pub(super) use windows_link::WINDOWS_APP_MANIFEST; // consumed only by windows_link_tests
+#[cfg(test)]
+pub(super) use windows_link::{embed_app_manifest, linker_is_msvc_link_exe}; // windows_link_tests (#6023)
 
 /// Symbols a plugin host must export so `dlopen`'d / `LoadLibrary`'d plugin
 /// shared libraries can resolve them against the host process at load time.

--- a/crates/perry/src/commands/compile/link/platform_cmd.rs
+++ b/crates/perry/src/commands/compile/link/platform_cmd.rs
@@ -820,7 +820,15 @@ pub fn select_linker_command(
         .arg("/STACK:67108864")
         // Native libs (hone_editor_windows etc) bundle perry_runtime objects
         // that can't be fully stripped. Identical symbols are safe to merge.
-        .arg("/FORCE:MULTIPLE");
+        .arg("/FORCE:MULTIPLE")
+        // #6023: /FORCE:MULTIPLE makes the duplicate-definition merge
+        // deliberate, but link.exe still prints one LNK4006 line per merged
+        // symbol — hundreds of them (import descriptors duplicated inside
+        // perry_ui_windows.lib, perry_audio_* present in two members). That
+        // flood buried the real error in #6023; suppress it. lld-link
+        // silently ignores /IGNORE codes it doesn't implement, so the flag
+        // is safe on both linker paths.
+        .arg("/IGNORE:4006");
         // Set up MSVC library search paths if LIB env isn't already configured
         if std::env::var("LIB").is_err() {
             if let Some(lib_paths) = find_msvc_lib_paths() {

--- a/crates/perry/src/commands/compile/link/windows_link.rs
+++ b/crates/perry/src/commands/compile/link/windows_link.rs
@@ -11,7 +11,11 @@
 //! visual styles (the Fluent look) on Windows 10/11. See issue #4681 /
 //! discussion #3486.
 
+use std::path::Path;
 use std::process::Command;
+
+#[cfg(target_os = "windows")]
+use super::super::library_search::find_windows_sdk_mt_dir;
 
 /// Win32 application manifest embedded into UI executables. Declares the
 /// comctl32 v6 (`Microsoft.Windows.Common-Controls`) side-by-side dependency
@@ -73,13 +77,32 @@ pub(super) fn add_system_libs(cmd: &mut Command) {
 /// discussion #3486. No-op unless `needs_ui` so console-only binaries stay
 /// manifest-free.
 ///
-/// Both `link.exe` and `lld-link` embed `/MANIFESTINPUT:` content via
-/// `/MANIFEST:EMBED` with no external `mt.exe`/`rc.exe`. `/MANIFESTUAC:NO`
-/// suppresses the linker's auto-generated UAC fragment so it can't produce a
-/// second `trustInfo` element alongside the one in our input manifest (which
-/// already declares `asInvoker`).
-pub(super) fn embed_app_manifest(cmd: &mut Command, needs_ui: bool) {
+/// `lld-link` embeds `/MANIFESTINPUT:` content via `/MANIFEST:EMBED` entirely
+/// in-process, but MSVC `link.exe` shells out to the Windows SDK's `mt.exe` to
+/// merge the manifest. Perry runs a vswhere-located `link.exe` from a plain
+/// shell (no `vcvars64.bat` PATH), so `mt.exe` is normally unreachable and the
+/// link died with `LNK1158: cannot run 'mt.exe'` on every UI build since this
+/// embed landed (v0.5.1129 / #4683) — issue #6023. For MSVC we now put the SDK
+/// bin dir holding `mt.exe` on the child's PATH, and if `mt.exe` can't be
+/// found at all we skip the embed with a warning (an unthemed app that builds
+/// beats a fatal LNK1158). `/MANIFESTUAC:NO` suppresses the linker's
+/// auto-generated UAC fragment so it can't produce a second `trustInfo`
+/// element alongside the one in our input manifest (which already declares
+/// `asInvoker`).
+pub(crate) fn embed_app_manifest(cmd: &mut Command, needs_ui: bool) {
     if !needs_ui {
+        return;
+    }
+    if linker_is_msvc_link_exe(cmd) && !ensure_mt_exe_reachable(cmd) {
+        eprintln!(
+            "Warning: mt.exe (Windows SDK manifest tool) not found on PATH or under \
+             Windows Kits\\10\\bin — linking without the comctl32 v6 application \
+             manifest so the build can succeed (MSVC link.exe would otherwise fail \
+             with LNK1158, issue #6023). Common controls will render in the \
+             unthemed classic style. Fix: install the Windows 10/11 SDK via the \
+             Visual Studio Installer, or compile from a vcvars64.bat developer \
+             prompt."
+        );
         return;
     }
     let manifest_path = std::env::temp_dir().join(format!(
@@ -100,4 +123,52 @@ pub(super) fn embed_app_manifest(cmd: &mut Command, needs_ui: bool) {
             );
         }
     }
+}
+
+/// True when the link command runs MSVC `link.exe` (as opposed to `lld-link`
+/// or a cc driver) — the only linker whose manifest embed depends on `mt.exe`.
+/// Matches on the program's file stem so both bare (`link.exe`, cross-compile
+/// fallback) and vswhere-resolved absolute paths classify correctly.
+pub(crate) fn linker_is_msvc_link_exe(cmd: &Command) -> bool {
+    Path::new(cmd.get_program())
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .is_some_and(|s| s.eq_ignore_ascii_case("link"))
+}
+
+/// Make sure `link.exe` will be able to spawn `mt.exe` (#6023): if it's
+/// already on PATH (developer prompt) do nothing; otherwise locate the
+/// Windows SDK bin dir that holds it and prepend that to the child's PATH.
+/// Returns false only when `mt.exe` can't be found anywhere, in which case
+/// the caller skips the manifest embed entirely.
+#[cfg(target_os = "windows")]
+fn ensure_mt_exe_reachable(cmd: &mut Command) -> bool {
+    let on_path = Command::new("where")
+        .arg("mt.exe")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if on_path {
+        return true;
+    }
+    if let Some(dir) = find_windows_sdk_mt_dir() {
+        let mut parts = vec![dir];
+        if let Some(existing) = std::env::var_os("PATH") {
+            parts.extend(std::env::split_paths(&existing));
+        }
+        if let Ok(joined) = std::env::join_paths(parts) {
+            cmd.env("PATH", joined);
+            return true;
+        }
+    }
+    false
+}
+
+/// Non-Windows hosts can't probe a Windows SDK, and the cross-compile path
+/// links with lld-link anyway (the bare `link.exe` fallback only fires after
+/// a loud lld-link-missing warning) — keep the pre-#6023 behavior of always
+/// embedding.
+#[cfg(not(target_os = "windows"))]
+fn ensure_mt_exe_reachable(_cmd: &mut Command) -> bool {
+    true
 }

--- a/crates/perry/src/commands/compile/windows_link_tests.rs
+++ b/crates/perry/src/commands/compile/windows_link_tests.rs
@@ -2,10 +2,12 @@
 //! in v0.5.1019 (file-size CI gate). Brought back in via
 //! `#[cfg(test)] mod windows_link_tests;` in compile.rs.
 
-use super::link::WINDOWS_APP_MANIFEST;
+use super::library_search::newest_mt_dir_under;
+use super::link::{embed_app_manifest, linker_is_msvc_link_exe, WINDOWS_APP_MANIFEST};
 use super::windows_default_output_extension;
 use super::windows_pe_subsystem_flag;
 use super::windows_subsystem_needs_ui;
+use std::process::Command;
 
 // Regression guard for issue #120: without an explicit subsystem flag the
 // MSVC linker historically defaulted to WINDOWS (2), silently detaching
@@ -133,4 +135,94 @@ fn app_manifest_runs_as_invoker() {
         WINDOWS_APP_MANIFEST.contains("level=\"asInvoker\""),
         "manifest must declare the asInvoker execution level"
     );
+}
+
+// Issue #6023: only MSVC link.exe needs the mt.exe reachability treatment —
+// lld-link embeds manifests in-process. The classifier keys on the program's
+// file stem so bare names and vswhere-resolved absolute paths both match.
+#[test]
+fn msvc_link_exe_classification() {
+    assert!(linker_is_msvc_link_exe(&Command::new("link.exe")));
+    assert!(linker_is_msvc_link_exe(&Command::new("LINK.EXE")));
+    assert!(linker_is_msvc_link_exe(&Command::new("link")));
+    // Forward-slash path form keeps the test host-independent; on Windows the
+    // vswhere backslash form resolves through the same Path::file_stem.
+    assert!(linker_is_msvc_link_exe(&Command::new(
+        "C:/VS/VC/Tools/MSVC/14.44.35207/bin/Hostx64/x64/link.exe"
+    )));
+    assert!(!linker_is_msvc_link_exe(&Command::new("lld-link.exe")));
+    assert!(!linker_is_msvc_link_exe(&Command::new("lld-link")));
+    assert!(!linker_is_msvc_link_exe(&Command::new("cc")));
+}
+
+// Console-only binaries must stay manifest-free (and thus never depend on
+// mt.exe at all).
+#[test]
+fn console_build_adds_no_manifest_args() {
+    let mut cmd = Command::new("link.exe");
+    embed_app_manifest(&mut cmd, false);
+    assert_eq!(cmd.get_args().count(), 0);
+}
+
+// lld-link needs no mt.exe, so a UI build through it always gets the full
+// /MANIFEST:EMBED argument set regardless of any Windows SDK presence.
+#[test]
+fn ui_build_embeds_manifest_via_lld_link() {
+    let mut cmd = Command::new("lld-link.exe");
+    embed_app_manifest(&mut cmd, true);
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+    assert!(args.contains(&"/MANIFEST:EMBED".to_string()));
+    assert!(args.contains(&"/MANIFESTUAC:NO".to_string()));
+    assert!(
+        args.iter().any(|a| a.starts_with("/MANIFESTINPUT:")),
+        "manifest input file must be passed: {args:?}"
+    );
+}
+
+// Issue #6023: the SDK-bin probe picks the newest versioned dir that actually
+// contains mt.exe, preferring x64 over x86.
+#[test]
+fn mt_dir_probe_picks_newest_versioned_sdk() {
+    let root = tempfile::tempdir().unwrap();
+    let bin = root.path();
+    // Older SDK with both arches, newest SDK with x64 only, plus a newer
+    // version dir that lacks mt.exe entirely (must be skipped).
+    for dir in [
+        "10.0.19041.0/x64",
+        "10.0.19041.0/x86",
+        "10.0.22621.0/x64",
+        "10.0.26100.0/arm64",
+    ] {
+        std::fs::create_dir_all(bin.join(dir)).unwrap();
+    }
+    for mt in ["10.0.19041.0/x64/mt.exe", "10.0.19041.0/x86/mt.exe", "10.0.22621.0/x64/mt.exe"] {
+        std::fs::write(bin.join(mt), b"").unwrap();
+    }
+    assert_eq!(
+        newest_mt_dir_under(bin),
+        Some(bin.join("10.0.22621.0").join("x64"))
+    );
+}
+
+// Pre-10.0.15063 SDKs put tools directly under bin\<arch> with no version dir.
+#[test]
+fn mt_dir_probe_falls_back_to_unversioned_layout() {
+    let root = tempfile::tempdir().unwrap();
+    let bin = root.path();
+    std::fs::create_dir_all(bin.join("x86")).unwrap();
+    std::fs::write(bin.join("x86").join("mt.exe"), b"").unwrap();
+    assert_eq!(newest_mt_dir_under(bin), Some(bin.join("x86")));
+}
+
+// No SDK bin root / no mt.exe anywhere → None, which makes embed_app_manifest
+// skip the embed instead of letting link.exe die with LNK1158.
+#[test]
+fn mt_dir_probe_handles_missing_root_and_empty_tree() {
+    let root = tempfile::tempdir().unwrap();
+    assert_eq!(newest_mt_dir_under(&root.path().join("nope")), None);
+    std::fs::create_dir_all(root.path().join("10.0.22621.0").join("x64")).unwrap();
+    assert_eq!(newest_mt_dir_under(root.path()), None);
 }

--- a/crates/perry/src/commands/compile/windows_link_tests.rs
+++ b/crates/perry/src/commands/compile/windows_link_tests.rs
@@ -188,17 +188,24 @@ fn ui_build_embeds_manifest_via_lld_link() {
 fn mt_dir_probe_picks_newest_versioned_sdk() {
     let root = tempfile::tempdir().unwrap();
     let bin = root.path();
-    // Older SDK with both arches, newest SDK with x64 only, plus a newer
-    // version dir that lacks mt.exe entirely (must be skipped).
+    // Older SDK with both arches, newest mt-bearing SDK also with both
+    // arches (x64 must win within it), plus a newer version dir that lacks
+    // mt.exe entirely (must be skipped).
     for dir in [
         "10.0.19041.0/x64",
         "10.0.19041.0/x86",
         "10.0.22621.0/x64",
+        "10.0.22621.0/x86",
         "10.0.26100.0/arm64",
     ] {
         std::fs::create_dir_all(bin.join(dir)).unwrap();
     }
-    for mt in ["10.0.19041.0/x64/mt.exe", "10.0.19041.0/x86/mt.exe", "10.0.22621.0/x64/mt.exe"] {
+    for mt in [
+        "10.0.19041.0/x64/mt.exe",
+        "10.0.19041.0/x86/mt.exe",
+        "10.0.22621.0/x64/mt.exe",
+        "10.0.22621.0/x86/mt.exe",
+    ] {
         std::fs::write(bin.join(mt), b"").unwrap();
     }
     assert_eq!(


### PR DESCRIPTION
## Problem

Since v0.5.1129, every `perry/ui` build on Windows with the MSVC toolchain fails:

```
LINK : fatal error LNK1158: cannot run 'mt.exe'
```

preceded by hundreds of `LNK4006` duplicate-definition warnings (#6023, follow-up to #2169 which is unverifiable while the build is broken).

## Root cause

v0.5.1129 (#4683) added the comctl32 v6 application-manifest embed (`/MANIFEST:EMBED` + `/MANIFESTINPUT:`) for themed controls. `lld-link` embeds manifests in-process, but **MSVC `link.exe` shells out to the Windows SDK's `mt.exe`** for this. Perry locates `link.exe` via vswhere and spawns it from a plain shell — not a `vcvars64.bat` developer prompt — so the SDK `bin` dir is not on `PATH`, `link.exe` can't find `mt.exe`, and the link dies. The old doc comment in `windows_link.rs` explicitly (and incorrectly) claimed no external `mt.exe` was needed, which is why this shipped.

## Fix

- **`mt.exe` reachability for MSVC link.exe** (`windows_link.rs`): before embedding, check `mt.exe` is resolvable. If not on `PATH`, probe the Windows SDK `bin\<ver>\<arch>` dirs (registry `KitsRoot10`, ProgramFiles roots, legacy hardcoded path — same probe order `find_msvc_lib_paths` already uses for `Lib`) and prepend the dir holding `mt.exe` to the child's `PATH`.
- **Graceful fallback**: if `mt.exe` genuinely doesn't exist, skip the embed with a loud warning (controls render classic-style) instead of failing the link — mirrors the existing manifest-temp-file-write-failure fallback from #4683. `lld-link` path is untouched.
- **`/IGNORE:4006`** (`platform_cmd.rs`): the duplicate-definition merge is deliberate (`/FORCE:MULTIPLE`), so the per-symbol LNK4006 flood is pure noise that buried the real error in the report. lld-link silently ignores unknown `/IGNORE` codes.

## Tests

6 new unit tests in `windows_link_tests.rs` (all host-independent, run on any CI OS):
- MSVC-vs-lld linker classification (bare names, absolute paths, case)
- console builds stay manifest-free; lld-link UI builds always get the full `/MANIFEST:EMBED` arg set
- SDK bin probe: newest-version pick, x64-over-x86 preference, skipping version dirs without `mt.exe`, pre-10.0.15063 unversioned layout, missing/empty roots

`cargo test -p perry --bin perry windows_link`: 18 passed. The `cfg(target_os = "windows")` bodies were additionally type-checked standalone on the dev host (they use only cross-platform std APIs).

## Notes

- No version bump / changelog per the external-PR workflow (maintainer folds in at merge).
- The TextField `onChange` half of #6023 (originally #2169) should be re-verified on Windows once this lands and unblocks compilation; the manifest embed itself is unrelated to event delivery.

Closes #6023

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows UI linking by more reliably locating `mt.exe` (using Windows SDK search) and skipping manifest embedding with a warning if it can’t be reached.
  * Reduced noisy `LNK4006` output when merging duplicate symbols.
* **Tests**
  * Added Windows linker regression coverage for MSVC link detection, conditional manifest embedding, and SDK `mt.exe` path/version selection across common layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->