### PR TITLE
fix(hir,codegen): #6003 — user 'class Headers' conflated with native fetch Headers

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -359,7 +359,16 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 .get(ty)
                 .map(|source| source.strip_prefix("node:").unwrap_or(source) == "net")
                 .unwrap_or(false);
+            // #6003: a user-defined class lexically shadows a same-named
+            // built-in (`class Headers {}` vs the fetch global), so the
+            // bare-identifier RHS must resolve to the USER class id before
+            // the reserved built-in mapping below. `class_ids` holds only
+            // user classes (local `hir.classes` + cross-module imported
+            // user classes); plain built-in names never appear in it, so
+            // unshadowed built-ins keep their reserved ids.
+            let user_cid = ctx.class_ids.get(ty).copied();
             let cid = match ty.as_str() {
+                _ if user_cid.is_some() => user_cid.unwrap(),
                 "Error" => 0xFFFF0001u32,
                 "TypeError" => 0xFFFF0010u32,
                 "RangeError" => 0xFFFF0011u32,

--- a/crates/perry-codegen/src/expr/literals_vars.rs
+++ b/crates/perry-codegen/src/expr/literals_vars.rs
@@ -102,6 +102,9 @@ fn is_headers_method_name(name: &str) -> bool {
 fn is_headers_instance_method(ctx: &FnCtx<'_>, object: &Expr, property: &str) -> bool {
     is_headers_method_name(property)
         && matches!(receiver_class_name(ctx, object).as_deref(), Some("Headers"))
+        // #6003: a user-defined `class Headers` owns the receiver type —
+        // its members are ordinary class members, not the native surface.
+        && !ctx.classes.contains_key("Headers")
 }
 
 fn is_classic_stream_method_name(name: &str) -> bool {

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -1019,7 +1019,13 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         &[(I64, &obj_handle), (I64, &key_handle)],
                     ));
                 }
+                // #6003: `class_name == "Headers"` only means the NATIVE
+                // fetch Headers when the user hasn't defined their own
+                // `class Headers` — a user class of that name owns the
+                // receiver type, so fall through to the user-class
+                // getter/method dispatch below.
                 if class_name == "Headers"
+                    && !ctx.classes.contains_key(&class_name)
                     && matches!(
                         property.as_str(),
                         "append"
@@ -1101,7 +1107,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             "write" | "close" | "abort" | "releaseLock"
                         )
                 );
-                if class_name == "Headers" && is_headers_method_name(property) {
+                if class_name == "Headers"
+                    && !ctx.classes.contains_key(&class_name)
+                    && is_headers_method_name(property)
+                {
                     let recv_box = lower_expr(ctx, object)?;
                     let key_idx = ctx.strings.intern(property);
                     let key_handle_global =

--- a/crates/perry-codegen/src/lower_call/property_get/fetch_chain.rs
+++ b/crates/perry-codegen/src/lower_call/property_get/fetch_chain.rs
@@ -83,7 +83,12 @@ pub(crate) fn try_lower_fetch_chain(
     }
     // Chain `new Response(...).text()` / `.json()` etc.
     if let Expr::New { class_name: nc, .. } = object {
-        let fetch_dispatch = matches!(nc.as_str(), "Response" | "Headers" | "Request");
+        // #6003: `new Headers().set(...)` only dispatches through the fetch
+        // FFI when the name still refers to the built-in — a user-defined
+        // `class Headers`/`Response`/`Request` constructs the user class,
+        // whose methods resolve via the ordinary class dispatch.
+        let fetch_dispatch = matches!(nc.as_str(), "Response" | "Headers" | "Request")
+            && !ctx.classes.contains_key(nc.as_str());
         if fetch_dispatch {
             let module = match nc.as_str() {
                 "Response" => "fetch",

--- a/crates/perry-hir/src/destructuring/var_decl/native_fetch.rs
+++ b/crates/perry-hir/src/destructuring/var_decl/native_fetch.rs
@@ -186,8 +186,20 @@ pub(crate) fn register_native_fetch_and_streams(
         // Also handle Response.json(...) and Response.redirect(...) static factories.
         if let ast::Expr::New(new_expr) = init_expr.as_ref() {
             if let ast::Expr::Ident(class_ident) = new_expr.callee.as_ref() {
+                // #6003: a user class/function/binding that happens to share a
+                // Web-API constructor name (`class Headers { ... }`) lexically
+                // shadows the global — `new Headers()` constructs the USER
+                // class, so tagging the binding as a native instance here
+                // would reroute every method call (`h.set(...)`) through the
+                // native FFI and silently skip the user's methods. Same
+                // shadowing rule as #5912's `new URL()` fix. The alias arm
+                // below checks the RESOLVED name instead: the alias local
+                // (`const B = Blob`) is itself a binding, but the name that
+                // must be unshadowed is the underlying constructor.
+                let ctor_shadowed =
+                    ctx.shadows_unqualified_global(class_ident.sym.as_ref());
                 match class_ident.sym.as_ref() {
-                    "Response" => {
+                    "Response" if !ctor_shadowed => {
                         ctx.register_native_instance(
                             name.to_string(),
                             "fetch".to_string(),
@@ -195,7 +207,7 @@ pub(crate) fn register_native_fetch_and_streams(
                         );
                         ctx.uses_fetch = true;
                     }
-                    "Headers" => {
+                    "Headers" if !ctor_shadowed => {
                         ctx.register_native_instance(
                             name.to_string(),
                             "Headers".to_string(),
@@ -203,7 +215,7 @@ pub(crate) fn register_native_fetch_and_streams(
                         );
                         ctx.uses_fetch = true;
                     }
-                    "Request" => {
+                    "Request" if !ctor_shadowed => {
                         ctx.register_native_instance(
                             name.to_string(),
                             "Request".to_string(),
@@ -211,7 +223,7 @@ pub(crate) fn register_native_fetch_and_streams(
                         );
                         ctx.uses_fetch = true;
                     }
-                    "FormData" => {
+                    "FormData" if !ctor_shadowed => {
                         ctx.register_native_instance(
                             name.to_string(),
                             "FormData".to_string(),
@@ -225,7 +237,7 @@ pub(crate) fn register_native_fetch_and_streams(
                     // `.lastModified` regardless of class tag, so File
                     // tracks as a Blob instance with the class tag
                     // available for future File-only property checks.
-                    "Blob" => {
+                    "Blob" if !ctor_shadowed => {
                         ctx.register_native_instance(
                             name.to_string(),
                             "blob".to_string(),
@@ -233,7 +245,7 @@ pub(crate) fn register_native_fetch_and_streams(
                         );
                         ctx.uses_fetch = true;
                     }
-                    "File" => {
+                    "File" if !ctor_shadowed => {
                         ctx.register_native_instance(
                             name.to_string(),
                             "blob".to_string(),
@@ -245,7 +257,10 @@ pub(crate) fn register_native_fetch_and_streams(
                         if ctx
                             .resolve_class_alias(other)
                             .as_deref()
-                            .is_some_and(|resolved| matches!(resolved, "Blob" | "File")) =>
+                            .is_some_and(|resolved| {
+                                matches!(resolved, "Blob" | "File")
+                                    && !ctx.shadows_unqualified_global(resolved)
+                            }) =>
                     {
                         let resolved = ctx.resolve_class_alias(other).unwrap();
                         ctx.register_native_instance(
@@ -256,7 +271,7 @@ pub(crate) fn register_native_fetch_and_streams(
                         ctx.uses_fetch = true;
                     }
                     // Issue #237: Web Streams API constructors.
-                    "ReadableStream" => {
+                    "ReadableStream" if !ctor_shadowed => {
                         ctx.register_native_instance(
                             name.to_string(),
                             "readable_stream".to_string(),
@@ -267,7 +282,7 @@ pub(crate) fn register_native_fetch_and_streams(
                     // #4915: `new ReadableStreamBYOBReader(stream)` —
                     // the handle is a reader, same module tag as
                     // `stream.getReader({ mode: "byob" })`.
-                    "ReadableStreamBYOBReader" => {
+                    "ReadableStreamBYOBReader" if !ctor_shadowed => {
                         ctx.register_native_instance(
                             name.to_string(),
                             "readable_stream_reader".to_string(),
@@ -275,7 +290,7 @@ pub(crate) fn register_native_fetch_and_streams(
                         );
                         ctx.uses_fetch = true;
                     }
-                    "WritableStream" => {
+                    "WritableStream" if !ctor_shadowed => {
                         ctx.register_native_instance(
                             name.to_string(),
                             "writable_stream".to_string(),
@@ -283,7 +298,7 @@ pub(crate) fn register_native_fetch_and_streams(
                         );
                         ctx.uses_fetch = true;
                     }
-                    "TransformStream" => {
+                    "TransformStream" if !ctor_shadowed => {
                         ctx.register_native_instance(
                             name.to_string(),
                             "transform_stream".to_string(),

--- a/crates/perry-hir/src/destructuring/var_decl/native_fetch.rs
+++ b/crates/perry-hir/src/destructuring/var_decl/native_fetch.rs
@@ -196,8 +196,7 @@ pub(crate) fn register_native_fetch_and_streams(
                 // below checks the RESOLVED name instead: the alias local
                 // (`const B = Blob`) is itself a binding, but the name that
                 // must be unshadowed is the underlying constructor.
-                let ctor_shadowed =
-                    ctx.shadows_unqualified_global(class_ident.sym.as_ref());
+                let ctor_shadowed = ctx.shadows_unqualified_global(class_ident.sym.as_ref());
                 match class_ident.sym.as_ref() {
                     "Response" if !ctor_shadowed => {
                         ctx.register_native_instance(

--- a/crates/perry-hir/src/lower/expr_function.rs
+++ b/crates/perry-hir/src/lower/expr_function.rs
@@ -286,6 +286,12 @@ pub(super) fn lower_arrow(ctx: &mut LoweringContext, arrow: &ast::ArrowExpr) -> 
     // Register arrow function parameters with known native types as native instances
     for param in &params {
         if let Type::Named(type_name) = &param.ty {
+            // #6003: a param typed with a USER class that shares a native
+            // name (`class Headers { ... }; (h: Headers) => ...`) must
+            // dispatch through the user class, not the native FFI.
+            if ctx.lookup_class(type_name).is_some() {
+                continue;
+            }
             let native_info = match type_name.as_str() {
                 "PluginApi" => Some(("perry/plugin", "PluginApi")),
                 "WebSocket" | "WebSocketServer" => Some(("ws", type_name.as_str())),

--- a/crates/perry-hir/src/lower_decl/fn_decl.rs
+++ b/crates/perry-hir/src/lower_decl/fn_decl.rs
@@ -166,6 +166,12 @@ pub fn lower_fn_decl(ctx: &mut LoweringContext, fn_decl: &ast::FnDecl) -> Result
     // Register parameters with known native types as native instances
     for param in &params {
         if let Type::Named(type_name) = &param.ty {
+            // #6003: a param typed with a USER class that shares a native
+            // name (`class Headers { ... }; function f(h: Headers)`) must
+            // dispatch through the user class, not the native FFI.
+            if ctx.lookup_class(type_name).is_some() {
+                continue;
+            }
             let native_info = match type_name.as_str() {
                 "PluginApi" => Some(("perry/plugin", "PluginApi")),
                 "WebSocket" | "WebSocketServer" => Some(("ws", type_name.as_str())),

--- a/test-files/test_issue_6003_user_headers_class_shadow.ts
+++ b/test-files/test_issue_6003_user_headers_class_shadow.ts
@@ -36,7 +36,18 @@ function fill(target: Headers): string {
 }
 console.log("PARAM", fill(new Headers()));
 
+// Same shape through an ARROW function — the arrow-param registration path
+// (expr_function.rs) is separate from the fn-decl one exercised above.
+const fillArrow = (target: Headers): string => {
+  target.set({ arrow: "also-yes" });
+  return target.get("arrow");
+};
+console.log("ARROW", fillArrow(new Headers()));
+
 // Sibling reserved name: a user `class Response` collides identically.
+// `text` is a reserved NATIVE Response method name — calling it through a
+// let-bound instance checks that the construction-site native tagging (not
+// just inline chaining) backs off for the shadowed name.
 class Response {
   private code = 0;
   set(c: number): void {
@@ -45,7 +56,11 @@ class Response {
   get status(): number {
     return this.code;
   }
+  text(): string {
+    return `user-text:${this.code}`;
+  }
 }
 const r = new Response();
 r.set(204);
 console.log("RESPONSE", r.status, r instanceof Response);
+console.log("TEXT", r.text());

--- a/test-files/test_issue_6003_user_headers_class_shadow.ts
+++ b/test-files/test_issue_6003_user_headers_class_shadow.ts
@@ -1,0 +1,51 @@
+// Issue #6003 — a user-defined `class Headers` was conflated with the native
+// fetch Headers: `const h = new Headers()` tagged `h` as a native fetch
+// instance by name alone, so `h.set(...)` dispatched through the Headers FFI
+// (silently skipping the user's method) and every property the method stored
+// vanished. The same lexical-shadowing gap covered the sibling reserved
+// names (`Request`, `Response`, ...) and the `instanceof` reserved-id map.
+
+class Headers {
+  set(o: Record<string, string>): void {
+    const self: any = this;
+    for (const k of Object.keys(o)) self[k] = String(o[k]);
+  }
+  get(name: string): string {
+    return (this as any)[name] ?? "<missing>";
+  }
+}
+
+const h = new Headers();
+h.set({ "x-one": "1", two: "2", "x-three": "3" });
+console.log("KEYS", Object.keys(h).join("|"));
+console.log("GET", h.get("two"));
+
+// Inline chained call on the construction — no intermediate binding — must
+// also resolve to the user class, not the fetch FFI chain dispatch.
+console.log("CHAIN", new Headers().get("absent"));
+
+// `instanceof` with the shadowed bare name must test against the USER class
+// id, not the reserved native-fetch-Headers class id.
+console.log("INSTANCEOF", h instanceof Headers);
+
+// A typed parameter (`(h: Headers)`) previously re-tagged the param as a
+// native fetch instance inside the callee, re-breaking method dispatch.
+function fill(target: Headers): string {
+  target.set({ filled: "yes" });
+  return target.get("filled");
+}
+console.log("PARAM", fill(new Headers()));
+
+// Sibling reserved name: a user `class Response` collides identically.
+class Response {
+  private code = 0;
+  set(c: number): void {
+    this.code = c;
+  }
+  get status(): number {
+    return this.code;
+  }
+}
+const r = new Response();
+r.set(204);
+console.log("RESPONSE", r.status, r instanceof Response);


### PR DESCRIPTION
Fixes #6003.

## Problem

A user-defined class named like a Web-API constructor (`class Headers`, `class Response`, …) was conflated with the native built-in **by name alone**. In the issue's repro, `h.set({...})` on a user `class Headers` dispatched through the native fetch-Headers FFI instead of the user's method, so every property store the method should have made silently vanished — `Object.keys(h)` printed empty where node prints `x-one|two|x-three`.

## Root cause & fix

The HIR trace shows the failing path: `const h = new Headers()` unconditionally registered `h` as a native fetch instance, so `h.set(...)` lowered to `NativeMethodCall { module: "Headers" }` and the user method never ran. Several sibling by-name routings had the same lexical-shadowing gap. Each now honors shadowing, mirroring the #5912 `new URL()` fix:

- **`perry-hir/src/destructuring/var_decl/native_fetch.rs`** — the primary path. All direct fetch / Web-Streams constructor arms (`Response`, `Headers`, `Request`, `FormData`, `Blob`, `File`, `ReadableStream`, `ReadableStreamBYOBReader`, `WritableStream`, `TransformStream`) now skip native-instance tagging when the constructor name is shadowed (`shadows_unqualified_global`). The Blob/File **alias** arm checks the ALIAS-RESOLVED name instead — the alias local (`const B = Blob`) is itself a binding, so checking the alias name would break the legitimate alias case.
- **`perry-hir/src/lower_decl/fn_decl.rs` + `perry-hir/src/lower/expr_function.rs`** — params typed `(h: Headers)` etc. were re-tagged as native instances inside the callee by type name, re-breaking dispatch even after the var-decl fix. Skipped when the annotation resolves to a user class.
- **`perry-codegen/src/expr/instance_misc1.rs`** — `x instanceof Headers` mapped the RHS name to the reserved built-in class id (`0xFFFF002A`) *before* consulting user `class_ids`, so `h instanceof Headers` tested against the native id and returned `false`. User class ids now take precedence. `class_ids` holds only user classes (local `hir.classes` + cross-module imported user classes), so unshadowed built-ins keep their reserved ids — this covers the sibling reserved names (`Response`, `Request`, `Date`, `Map`, `Set`, …) the issue flagged, in one spot.
- **`perry-codegen/src/expr/property_get.rs`** (Headers method-value reads), **`perry-codegen/src/expr/literals_vars.rs`** (`typeof h.get` fold), **`perry-codegen/src/lower_call/property_get/fetch_chain.rs`** (inline `new Headers().get(...)` chain) — the `receiver_class_name == "Headers"` native routing now backs off when the module defines its own `class Headers`, falling through to ordinary user-class dispatch.

Deliberately unchanged: `globalThis.Headers` / `globalThis.Blob` escape hatches (pattern_binding.rs, alias_tracking.rs, `is_global_this_builtin_name`) still resolve to the real globals per the #5912 convention, and codegen's `lower_new_impl` already preferred user classes at construction time.

## Verification

- New regression test `test-files/test_issue_6003_user_headers_class_shadow.ts` matches node byte-for-byte: the issue's exact repro (computed stores via user method), a getter round-trip, inline chained construction, `instanceof` against the shadowed name, typed-param dispatch, and a sibling user `class Response`.
- Targeted parity subset (21 tests: headers/fetch iteration and chaining, instanceof matrix, request/response bodies, blob/streams, plus the #5912 shadow test) run node-vs-perry: all match except `test_gap_fetch_response_json_init`, which fails **byte-identically on pristine main** (standing #5917 known failure — verified by stashing the fix and rerunning on the same build config).
- `cargo test -p perry-hir -p perry-codegen`: green except `pod_field_read_after_dynamic_materialization_uses_number_coerce` (native_proof_regressions), which also fails identically on pristine main — pre-existing, unrelated.

Per the external-contributor convention in CLAUDE.md, no version bump or CHANGELOG entry — metadata to be folded in at merge time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resolution for user-defined classes that share names with built-in web types like `Headers`, `Response`, and `Request`.
  * `instanceof`, `typeof`, property/method access, and typed parameters now prioritize the user class when it lexically shadows a built-in.
  * Prevented native fetch/web dispatch from triggering for shadowed constructors and related chaining patterns.
  * Added expanded regression tests covering `Headers` and `Response` name-collision scenarios, including arrow-parameter typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->