### PR TITLE
fix(watchos): arm64_32 entry-symbol rename via ld -r (objcopy SIGSEGVs)

### DIFF
--- a/crates/perry/src/commands/compile/link/platform_cmd.rs
+++ b/crates/perry/src/commands/compile/link/platform_cmd.rs
@@ -116,26 +116,53 @@ pub fn select_linker_command(
                         .unwrap_or(false)
                 })
             });
-        // arm64_32: rust-objcopy crashes on these Mach-O objects, so the entry
-        // symbol was emitted directly by codegen (PERRY_ENTRY_SYMBOL) instead of
-        // renamed here. Skip the objcopy pass entirely.
-        if let Some(entry_obj) = entry_obj.filter(|_| !arm64_32) {
-            let objcopy = std::env::var("HOME").ok()
-                .map(|h| PathBuf::from(h).join(".rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/rust-objcopy"))
-                .filter(|p| p.exists())
-                .or_else(|| std::env::var("HOME").ok()
-                    .map(|h| PathBuf::from(h).join(".rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-objcopy"))
-                    .filter(|p| p.exists()))
-                .unwrap_or_else(|| PathBuf::from("rust-objcopy"));
-            let rename = if is_watchos_game_loop || is_watchos_swift_app {
-                "_main=__perry_user_main"
+        if let Some(entry_obj) = entry_obj {
+            // Entry-symbol rename: the TS `_main` must move out of the way so
+            // the Swift `@main` (default tree-renderer shell) or the native
+            // lib's own `@main` (game-loop / swift-app) owns the process entry,
+            // while the compiled TS init is still reachable under a stable name.
+            let (from_sym, to_sym) = if is_watchos_game_loop || is_watchos_swift_app {
+                ("_main", "__perry_user_main")
             } else {
-                "_main=_perry_main_init"
+                ("_main", "_perry_main_init")
             };
-            let _ = Command::new(&objcopy)
-                .args(["--redefine-sym", rename])
-                .arg(entry_obj)
-                .status();
+            if arm64_32 {
+                // arm64_32: rust-objcopy / llvm-objcopy SIGSEGV writing these
+                // Mach-O objects with `--redefine-sym` (LLVM MachOWriter bug,
+                // still present through LLVM 22). Do the rename via `ld -r`
+                // instead — a different Mach-O writer that doesn't crash:
+                // `-alias` exposes the entry at `_main`'s address and
+                // `-unexported_symbol` demotes the original `_main` to a local
+                // so it can't collide with the Swift/native `@main`. Without
+                // this the default shell's `perry_main_init` is never defined
+                // and every arm64_32 device link fails "undefined
+                // _perry_main_init" (the old code skipped the rename for
+                // arm64_32 expecting a codegen PERRY_ENTRY_SYMBOL emit that is
+                // never wired up).
+                let tmp = entry_obj.with_extension("aliased.o");
+                let status = Command::new("ld")
+                    .args(["-r", "-arch", "arm64_32"])
+                    .arg(entry_obj)
+                    .arg("-o")
+                    .arg(&tmp)
+                    .args(["-alias", from_sym, to_sym, "-unexported_symbol", from_sym])
+                    .status();
+                if matches!(status, Ok(s) if s.success()) && tmp.exists() {
+                    let _ = std::fs::rename(&tmp, entry_obj);
+                }
+            } else {
+                let objcopy = std::env::var("HOME").ok()
+                    .map(|h| PathBuf::from(h).join(".rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/rust-objcopy"))
+                    .filter(|p| p.exists())
+                    .or_else(|| std::env::var("HOME").ok()
+                        .map(|h| PathBuf::from(h).join(".rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-objcopy"))
+                        .filter(|p| p.exists()))
+                    .unwrap_or_else(|| PathBuf::from("rust-objcopy"));
+                let _ = Command::new(&objcopy)
+                    .args(["--redefine-sym", &format!("{from_sym}={to_sym}")])
+                    .arg(entry_obj)
+                    .status();
+            }
         }
 
         if is_watchos_game_loop {


### PR DESCRIPTION
## Summary

Default-mode (SwiftUI tree-renderer) watchOS apps failed to link for **arm64_32** device targets (`PERRY_WATCHOS_ARM64_32=1`) with `Undefined symbols: _perry_main_init`. The entry-symbol rename that the tree-renderer shell depends on was being skipped on arm64_32, and nothing replaced it — so `perry_main_init` was never defined.

Found building a real app (dbmeter, a mic dB-meter) for a physical Apple Watch Series 7 (arm64_32).

## Root cause

The watchOS link renames the compiled TS `_main` so the Swift `@main` (default shell) or a native lib's own `@main` (game-loop / swift-app) owns the process entry, while the TS init stays reachable (`perry_main_init` / `perry_user_main`). That rename used `rust-objcopy --redefine-sym`.

On arm64_32, `llvm-objcopy` / `rust-objcopy` **SIGSEGV** writing the Mach-O object (`llvm::objcopy::macho::MachOWriter::writeSections`) — reproducible with both the rust-toolchain objcopy and Homebrew LLVM 22.1.4:

```
$ llvm-objcopy --redefine-sym _main=_perry_main_init entry.arm64_32.o
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ ...
$ nm entry.arm64_32.o | grep _main     # rename did NOT apply
0000184c T _main
```

The existing code *skipped* the objcopy pass for arm64_32 with a comment that codegen emits the entry symbol directly via `PERRY_ENTRY_SYMBOL` — but **nothing sets that env var** (`entry.rs` reads it, defaulting to `"main"`, and no call site writes it), so codegen emits `_main` and the rename never happens. Result: `perry_main_init` undefined on every arm64_32 default-mode link.

## Fix

Do the arm64_32 rename via `ld -r` instead of the crashing objcopy — a different Mach-O writer that doesn't crash:

```
ld -r -arch arm64_32 entry.o -o entry.aliased.o \
   -alias _main _perry_main_init -unexported_symbol _main
```

`-alias` exposes the entry symbol at `_main`'s address; `-unexported_symbol` demotes the original `_main` to a local (`t`) so it can't collide with the Swift/native `@main`. Verified:

```
$ nm entry.aliased.o | grep -wE '_perry_main_init|_main'
0000184c t _main
0000184c T _perry_main_init
```

arm64 (and simulator) keep the existing objcopy path unchanged — the crash is arm64_32-specific.

## Related issue

n/a — found in the field. (Upstream LLVM bug is the `MachOWriter` crash; this works around it in perry.)

## Test plan

- [x] `cargo build --release -p perry` clean
- [x] Manually verified end-to-end: `PERRY_WATCHOS_ARM64_32=1 perry compile --target watchos src/main.ts` on a real perry/ui app now gets past the entry-symbol link stage — before: `Undefined symbols for architecture arm64_32: "_perry_main_init"`; after: `perry_main_init` resolves (`nm` shows it global `T`, original `_main` demoted to local `t`).
- [ ] No automated test: arm64_32 device links require the tier-3 toolchain + device UI libs (`cargo +nightly build -Z build-std ... --target arm64_32-apple-watchos`), which isn't in the standard CI matrix (`perry-ui-watchos` is in the excluded set). Verification is manual as above.

> Note: this unblocks the *entry-symbol* stage specifically. A full arm64_32 UI-app device build surfaces two further arm64_32 items downstream (the same objcopy crash in the native-lib allocator-`--localize-symbol` dedup pass, and the arm64_32 64KB TLS cap for the full stdlib) — separate from this entry-rename fix and tracked independently.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] Commits follow the `fix:` prefix convention
- [x] Read CONTRIBUTING.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watchOS builds on `arm64_32` by correctly handling entry-symbol renaming during linking.
  * Fixed cases where the app entry point could be left unchanged, helping ensure the correct startup symbol is used for watchOS apps and game loops.
  * Kept the existing symbol-renaming behavior for other build targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->