### PR TITLE
perf(runtime,codegen): stop unrelated descriptor installs disabling the class-field inline fast path (#5654)

### DIFF
--- a/crates/perry-codegen/src/expr/class_field_inline_guard.rs
+++ b/crates/perry-codegen/src/expr/class_field_inline_guard.rs
@@ -36,6 +36,7 @@ const GC_FLAG_FORWARDED_I8: &str = "-128"; // 0x80 as i8
 const OBJECT_TYPE_REGULAR: &str = "1";
 const TYPED_LAYOUT_INTACT_BIT: &str = "4096"; // GC_OBJ_TYPED_LAYOUT_INTACT (0x1000)
 const OBJ_FLAG_FROZEN_BIT: &str = "1"; // OBJ_FLAG_FROZEN (0x01)
+const OBJ_FLAG_HAS_DESCRIPTORS_BIT: &str = "2048"; // OBJ_FLAG_HAS_DESCRIPTORS (0x800)
 const F64_EXP_MASK: &str = "9218868437227405312"; // 0x7FF0_0000_0000_0000
 
 /// Emit the inline class-field shape pre-check.
@@ -140,6 +141,17 @@ pub(crate) fn emit_class_field_inline_precheck(
         acc = blk.and(I1, &acc, &cid_ok);
         acc = blk.and(I1, &acc, &fc_ok);
         acc = blk.and(I1, &acc, &ka_ok);
+
+        // #5654: a receiver that has ever had a property / accessor descriptor
+        // installed on it (Object.defineProperty / freeze / seal) needs the
+        // guard's descriptor-aware dispatch — an accessor must fire, a
+        // non-writable slot must reject the store. The per-object flag lets the
+        // process-global gate above stay open for such installs (only
+        // prototype-level descriptors flip it), so unrelated instances keep the
+        // fast path.
+        let has_desc = blk.and(I16, &reserved, OBJ_FLAG_HAS_DESCRIPTORS_BIT);
+        let no_desc = blk.icmp_eq(I16, &has_desc, "0");
+        acc = blk.and(I1, &acc, &no_desc);
 
         if require_raw_f64 {
             // The slot is read/written as a raw double, so the per-object typed

--- a/crates/perry-codegen/src/type_analysis_class_fields.rs
+++ b/crates/perry-codegen/src/type_analysis_class_fields.rs
@@ -107,6 +107,41 @@ pub(crate) fn class_field_global_index(
     if accessor_in_chain(ctx, class_name, property) {
         return None;
     }
+    // Issue #26 / #321 (via #5654): prefer the authoritative, source-prefix-
+    // disambiguated ancestor chain — the SAME data the packed-keys global and
+    // constructor field-init are built from — so the returned index matches
+    // the runtime keys array even when same-named cross-module classes collide
+    // in the name-keyed `ctx.classes` (effect's `Type` in SchemaAST.ts vs
+    // ParseResult.ts made `PropertySignature.isOptional` resolve to slot 4
+    // instead of 2). The always-on guard call used to mask the wrong index at
+    // runtime (`object_key_matches_field` missed → by-name fallback); with the
+    // #5654 inline fast path live, the index must actually be correct.
+    if let Some(chain) = ctx.class_init_chains.get(class_name) {
+        // Slot layout is the chain's keyable fields, root → leaf. The
+        // most-derived declaration wins (TS shadowing), so search leaf → root.
+        let mut prefix_counts: Vec<u32> = Vec::with_capacity(chain.len());
+        let mut acc = 0u32;
+        for (_, fields) in chain {
+            prefix_counts.push(acc);
+            acc += count_keyable(fields);
+        }
+        for (i, (_, fields)) in chain.iter().enumerate().rev() {
+            let mut own_idx = 0u32;
+            for f in fields {
+                if f.key_expr.is_some() {
+                    continue;
+                }
+                if f.name == property {
+                    return Some(prefix_counts[i] + own_idx);
+                }
+                own_idx += 1;
+            }
+        }
+        // The chain is authoritative for this class's layout: absent means the
+        // property is not an inline slot. Do NOT fall through to the name-keyed
+        // walk — it could "find" the field on a wrong same-named stub.
+        return None;
+    }
     fn walk(
         ctx: &FnCtx<'_>,
         class_name: &str,
@@ -183,6 +218,21 @@ pub(crate) fn class_field_declared_type(
     class_name: &str,
     property: &str,
 ) -> Option<HirType> {
+    // Issue #26 / #321 (via #5654): same authoritative-chain preference as
+    // `class_field_global_index` — the declared type gates the raw-f64 slot
+    // contract, so it must come from the class that actually owns the slot,
+    // not a same-named cross-module impostor from the name-keyed table.
+    if let Some(chain) = ctx.class_init_chains.get(class_name) {
+        for (_, fields) in chain.iter().rev() {
+            if let Some(field) = fields
+                .iter()
+                .find(|field| field.key_expr.is_none() && field.name == property)
+            {
+                return Some(field.ty.clone());
+            }
+        }
+        return None;
+    }
     let mut current = ctx.classes.get(class_name).copied();
     // Guard against cyclic parent links so the walk terminates.
     let mut seen_class_names: std::collections::HashSet<String> = std::collections::HashSet::new();

--- a/crates/perry-runtime/src/object/descriptor_state.rs
+++ b/crates/perry-runtime/src/object/descriptor_state.rs
@@ -101,11 +101,14 @@ pub(crate) fn descriptors_in_use() -> bool {
 /// relaxed load, hoistable out of hot loops) via the
 /// `@PERRY_CLASS_FIELD_INLINE_GUARD_DISABLED` symbol and falls back to the full
 /// `js_typed_feedback_class_field_{get,set}_guard` call whenever it is non-zero.
-/// It flips to 1 the moment either (a) any accessor / property descriptor comes
-/// into use — the guard then has to perform descriptor-aware dispatch the inline
-/// path doesn't model — or (b) typed-feedback tracing is enabled, where the
-/// guard records observations the inline path would silently skip. Both are
-/// monotonic ("in use" never reverts), so the flag is set-only.
+/// It flips to 1 the moment either (a) an accessor / property descriptor is
+/// installed on an object the inline path cannot vet per-receiver — a
+/// registered class prototype or the canonical `Object.prototype` (#5654;
+/// receiver-level descriptors are instead rejected by the emitted
+/// `OBJ_FLAG_HAS_DESCRIPTORS` check, so they don't poison the process) — or
+/// (b) typed-feedback tracing is enabled, where the guard records observations
+/// the inline path would silently skip. Both are monotonic ("in use" never
+/// reverts), so the flag is set-only.
 #[no_mangle]
 pub static PERRY_CLASS_FIELD_INLINE_GUARD_DISABLED: AtomicU8 = AtomicU8::new(0);
 
@@ -118,6 +121,38 @@ pub(crate) fn disable_class_field_inline_guard() {
 /// True when the inline class-field fast path is still permitted.
 pub(crate) fn class_field_inline_guard_enabled() -> bool {
     PERRY_CLASS_FIELD_INLINE_GUARD_DISABLED.load(Ordering::Relaxed) == 0
+}
+
+/// #5654: flip the process-wide inline gate only when the descriptor target can
+/// intercept a `this.field` access that the inline precheck cannot reject on
+/// its own. Receiver-level installs are visible to the precheck via
+/// `OBJ_FLAG_HAS_DESCRIPTORS` in the receiver's GcHeader (set by
+/// [`note_descriptor_target`], checked by the emitted IR), so only
+/// prototype-level targets still need the global disable:
+///   - a class prototype — either the reflective decl-prototype object that
+///     `C.prototype` materializes (`CLASS_DECL_PROTOTYPE_OBJECTS`) or a
+///     synthetic `function Base() {}; Base.prototype = obj` prototype
+///     (`CLASS_PROTOTYPE_OBJECTS`) — intercepts `this.field` on every instance
+///     of that class, which the per-receiver flag cannot see;
+///   - the canonical `Object.prototype` sits at the tail of every instance's
+///     chain.
+/// Any other target (plain object, array, closure, builtin namespace) never
+/// appears in the guard's descriptor checks — those walk the receiver and the
+/// class-registry prototype chain only — so unrelated installs (the builtin
+/// setup that runs during every program's startup, `Object.freeze` on a config
+/// object, …) no longer disable the #5093 fast path process-wide.
+///
+/// The prototype-registry probes scan by value (O(#classes)); descriptor
+/// installs are rare and never on the hot property path, so the scan cost is
+/// acceptable. Finer granularity (flip only when the key collides with a
+/// declared field of that class hierarchy) is possible follow-up work.
+pub(crate) fn disable_class_field_inline_guard_for_target(obj: usize) {
+    if crate::array::object_prototype_addr_matches(obj)
+        || class_registry::is_registered_class_prototype_object(obj)
+        || class_registry::class_id_for_decl_prototype_object(obj).is_some()
+    {
+        disable_class_field_inline_guard();
+    }
 }
 
 /// #5054: a descriptor (any kind) has been installed on the canonical
@@ -301,7 +336,7 @@ pub(crate) fn set_property_attrs(obj: usize, key: String, attrs: PropertyAttrs) 
     note_descriptor_target(obj);
     PROPERTY_ATTRS_IN_USE.with(|c| c.set(true));
     GLOBAL_DESCRIPTORS_IN_USE.store(true, Ordering::Relaxed);
-    disable_class_field_inline_guard();
+    disable_class_field_inline_guard_for_target(obj);
     PROPERTY_DESCRIPTORS.with(|m| {
         m.borrow_mut().insert((obj, key), attrs);
     });
@@ -431,7 +466,7 @@ pub(crate) fn set_accessor_descriptor(obj: usize, key: String, acc: AccessorDesc
     note_descriptor_target(obj);
     ACCESSORS_IN_USE.with(|c| c.set(true));
     GLOBAL_DESCRIPTORS_IN_USE.store(true, Ordering::Relaxed);
-    disable_class_field_inline_guard();
+    disable_class_field_inline_guard_for_target(obj);
     ACCESSOR_DESCRIPTORS.with(|m| {
         m.borrow_mut().insert((obj, key), acc);
     });

--- a/test-files/test_gap_5654_class_field_inline_descriptor.ts
+++ b/test-files/test_gap_5654_class_field_inline_descriptor.ts
@@ -1,0 +1,106 @@
+// #5654: the #5093 codegen-inlined class-field fast path must stay enabled for
+// unrelated descriptor installs (they used to disable it process-wide — so it
+// never engaged in ordinary programs), while descriptors that actually target a
+// class instance or a class prototype still intercept `this.field` accesses.
+//
+// Scenarios:
+//   1. warm inline fast path, then install an accessor on THE INSTANCE —
+//      subsequent reads/writes must route through the accessor (per-object
+//      OBJ_FLAG_HAS_DESCRIPTORS rejects the inline path for that receiver);
+//   2. non-writable data descriptor on the instance — writes must throw
+//      (strict mode) and leave the value unchanged;
+//   3. accessor on the CLASS PROTOTYPE (flips the process-wide gate) — the
+//      own field defined by the class body shadows it (strip-types leaves
+//      `p;`, an own-property define), so reads/writes keep hitting the own
+//      slot: both engines must agree the inherited accessor does NOT fire;
+//   4. unrelated descriptors (plain object defineProperty / freeze) must not
+//      disturb class-field behavior on untouched instances.
+
+class Box {
+    v: number;
+    constructor(x: number) {
+        this.v = x;
+    }
+    bump(): number {
+        this.v = this.v + 1;
+        return this.v;
+    }
+}
+
+// ── 1. accessor installed directly on a warmed instance ────────────────────
+const a = new Box(0);
+for (let i = 0; i < 2000; i++) a.bump();
+console.log("warmed:" + a.v); // 2000
+
+let backing = 500;
+let getCount = 0;
+let setCount = 0;
+Object.defineProperty(a, "v", {
+    get() {
+        getCount++;
+        return backing;
+    },
+    set(x: number) {
+        setCount++;
+        backing = x;
+    },
+    configurable: true,
+});
+console.log("acc-read:" + a.v); // 500
+a.v = 7;
+console.log("acc-write:" + backing); // 7
+a.bump(); // method path: get + set through the accessor
+console.log("acc-bump:" + backing); // 8
+console.log("counts:" + (getCount >= 2) + ":" + (setCount >= 2)); // true:true
+
+// ── 2. non-writable data descriptor on another warmed instance ─────────────
+const b = new Box(10);
+for (let i = 0; i < 2000; i++) b.bump();
+Object.defineProperty(b, "v", { value: 123, writable: false });
+let threw = false;
+try {
+    b.v = 999;
+} catch (e) {
+    threw = true;
+}
+console.log("ro-threw:" + threw); // true (module code is strict)
+console.log("ro-value:" + b.v); // 123
+
+// ── 3. accessor on the class prototype intercepts later instances ──────────
+class Probe {
+    p: number;
+    constructor(x: number) {
+        this.p = x;
+    }
+}
+const before = new Probe(1);
+console.log("proto-before:" + before.p); // 1
+
+let protoBacking = -1;
+Object.defineProperty(Probe.prototype, "p", {
+    get() {
+        return protoBacking;
+    },
+    set(x: number) {
+        protoBacking = x * 10;
+    },
+    configurable: true,
+});
+// The class body's `p;` field define creates an own `p` before the ctor body
+// runs, so `this.p = 4` writes the own slot — the inherited setter must NOT
+// fire (own data property shadows the prototype accessor).
+const after = new Probe(4);
+console.log("proto-backing:" + protoBacking); // -1
+console.log("proto-read:" + after.p); // 4
+
+// ── 4. unrelated descriptors leave untouched instances alone ───────────────
+const plain: { k: number } = { k: 1 };
+Object.defineProperty(plain, "k", { value: 2, writable: false });
+Object.freeze({ other: true });
+
+const c = new Box(100);
+let sum = 0;
+for (let i = 0; i < 2000; i++) sum += c.bump();
+console.log("clean-v:" + c.v); // 2100
+console.log("clean-sum:" + sum); // sum of 101..2100
+console.log("plain-k:" + plain.k); // 2


### PR DESCRIPTION
Fixes #5654.

## Problem

The #5093 codegen-inlined class-field fast path never engaged in ordinary programs: `PERRY_CLASS_FIELD_INLINE_GUARD_DISABLED` flipped to 1 during **every** program's startup, before `main` ran, so every `this.field` access paid the full `js_typed_feedback_class_field_{get,set}_guard` call forever.

Root cause (found by instrumenting the first descriptor install): `set_bound_native_closure_name` (`native_module/callable_exports.rs`) pins the spec `name` descriptor (`{writable:false, enumerable:false, configurable:true}`) on every bound native-module closure during builtin namespace setup. That goes through `set_property_attrs`, which unconditionally called `disable_class_field_inline_guard()` — a process-wide, monotonic kill switch — even though a **closure** can never be a class-field receiver or sit on a class instance's registry prototype chain. The same poisoning hit any later userland `Object.defineProperty` / `Object.freeze` / object-literal accessor on unrelated objects.

## Fix

Split the "descriptors are in use" signal by **where the descriptor lands**, preserving the invariant that the inline precheck passes only where the guard would have returned "fast":

1. **Receiver-level installs** (descriptor directly on some object): the emitted inline precheck now also requires `OBJ_FLAG_HAS_DESCRIPTORS == 0` in the receiver's GcHeader `_reserved` word — the per-object flag `note_descriptor_target` already maintains (and that travels with the object across evacuation). A decorated instance falls back to the guard's descriptor-aware dispatch; every other instance keeps the inline path. Cost: one `and` + `icmp` on an already-loaded value.
2. **Prototype-level installs** (the cases a per-receiver flag cannot see) still flip the process-wide gate, via the new `disable_class_field_inline_guard_for_target(obj)`: targets that are a decl class prototype (`CLASS_DECL_PROTOTYPE_OBJECTS`, what `C.prototype` materializes), a synthetic prototype (`CLASS_PROTOTYPE_OBJECTS`, the `function Base(){}; Base.prototype = obj` pattern), or the canonical `Object.prototype`.
3. **Any other target** (closure, plain object, array, builtin namespace) no longer disables anything — matching the guard's own descriptor checks, which only consult the receiver address and the class-registry prototype chain.

`GLOBAL_DESCRIPTORS_IN_USE` / `ACCESSORS_IN_USE` / `PROPERTY_ATTRS_IN_USE` semantics are unchanged; the guard-call path is exactly as before. The `js_gc_init` escape hatches (`PERRY_DISABLE_CLASS_FIELD_INLINE`, `PERRY_VERIFY_TYPED_INTACT`, typed-feedback tracing) are untouched.

## Results (perry-dev profile, Apple Silicon)

Issue repro (10M `c.value = c.value + 1` iterations):

| | before (main behavior = force-disabled) | after |
|---|---|---|
| repro loop | 8502 ms | **84 ms** |
| `benchmarks/suite/09_method_calls.ts` | 3022 ms | **104 ms** |

Force-disabling now *slows the loop down* (the A/B signature the issue asked for), confirming the inline path is active by default. A `defineProperty` on `C.prototype` measurably flips the gate (loop returns to ~2960 ms), confirming the conservative prototype-level disable still engages.

## Correctness verification

New parity test `test-files/test_gap_5654_class_field_inline_descriptor.ts` (byte-identical vs `node --experimental-strip-types`):
- accessor installed on a **warmed instance** re-routes reads/writes/method accesses through the getter/setter (per-object flag path);
- non-writable data descriptor on a warmed instance throws on write and preserves the value;
- accessor on the **class prototype** (flips the global gate) — the own field define shadows it, and both engines agree it doesn't fire;
- unrelated plain-object descriptors / freeze leave other instances' behavior untouched.

Also byte-identical vs node: `test_class_field_raw_f64_downgrade`, `test_gap_5592_class_field_init_new_target`, `test_gap_class_field_named_stack_index`, `test_issue_261/302/305`, `test_issue_886_indirect_object_define_property`, `test_issue_2060_typed_array_accessor_descriptors`, `test_gap_object_get_own_property_descriptors`. (`test_class_field_layout` is a Perry-only file — node rejects its `0000` legacy-octal literal; `test_three_like_native_class_descriptors` needs the harness's extensionless-import resolution. Both diff identically with the inline path force-disabled, i.e. pre-existing harness artifacts, not regressions.)

`cargo test -p perry-runtime -p perry-codegen`: green except the pre-existing `pod_field_read_after_dynamic_materialization_uses_number_coerce` failure in perry-codegen's `native_proof_regressions` (present on pristine main).

## Pre-existing gap noticed while testing (not addressed here)

`delete (instance as any).field` followed by a read returns the stale slot value instead of `undefined` — on **both** the inline path and the guard/fallback path (verified with `PERRY_DISABLE_CLASS_FIELD_INLINE=1`, which reproduces the old behavior exactly). Independent of this change; can file separately.

## Granularity note

Prototype-level installs are still process-wide (a `defineProperty(C.prototype, …)` from e.g. a mixin copier disables the fast path for all classes). Finer follow-up granularity — flip only when the key collides with a declared field of that class hierarchy — is possible, but this PR keeps the conservative behavior for those cases; the win here is that the overwhelmingly common non-prototype installs (builtin startup setup, object-literal accessors, `Object.freeze` on data) no longer poison the process.

Per the external-contributor convention, no version bump / changelog edit — maintainer folds those in at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Class field reads/writes now correctly account for installed property descriptors, including accessor overrides and non-writable data descriptors in strict mode.
  * Descriptor installs on specific targets no longer unnecessarily disable the optimized class-field fast path for unrelated objects.
  * Improved class-field resolution accuracy for inline fields across class initialization chains.
* **Tests**
  * Added a new test covering accessor overrides, strict-mode assignment behavior, prototype vs. own-slot shadowing, and ensuring unrelated objects remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->