### PR TITLE
fix(transform): #5975 — labeled `continue` in a yielding switch nested in a labeled loop spins forever

### DIFF
--- a/crates/perry-transform/src/generator/linearize.rs
+++ b/crates/perry-transform/src/generator/linearize.rs
@@ -1598,6 +1598,67 @@ fn rewrite_labeled_bc_in_stmts(stmts: &mut [Stmt], label: &str) {
                     rewrite_labeled_bc_in_stmts(f, label);
                 }
             }
+            // #5975: a `continue <label>` that targets THIS enclosing labeled
+            // loop from inside a nested `switch` case. A switch never captures
+            // `continue`, so it continues the loop — rewrite it to a plain
+            // `continue` here so the loop's linearization (and the #5868
+            // yielding-switch desugar) map it to the loop's re-entry sentinel.
+            // Without this the `LabeledContinue` survives verbatim into the
+            // desugared switch's state machine, where nothing lowers it, and a
+            // `loop: while (…) { switch (…) { case …: yield …; continue loop } }`
+            // (e.g. the `yaml` package's block-scalar / indicator lexer, a
+            // generator) spins forever. `break <label>` is deliberately NOT
+            // rewritten in a nested switch: a switch DOES capture `break`, so a
+            // plain `break` would exit only the switch, not the loop — that is
+            // the pre-existing single-sentinel limitation documented above.
+            Stmt::Switch { cases, .. } => {
+                for case in cases.iter_mut() {
+                    rewrite_labeled_continue_in_stmts(&mut case.body, label);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Rewrite `continue <label>` → plain `continue` for `label`, descending
+/// through `if` / `try` / `switch` (none of which capture `continue`) but
+/// stopping at nested loops (which bind their own `continue`). Unlike
+/// [`rewrite_labeled_bc_in_stmts`] this does NOT touch `break <label>`: it is
+/// used only when recursing into a nested `switch`, where a plain `break`
+/// would be captured by the switch rather than escaping to the loop (#5975).
+fn rewrite_labeled_continue_in_stmts(stmts: &mut [Stmt], label: &str) {
+    for s in stmts.iter_mut() {
+        match s {
+            Stmt::LabeledContinue(l) if l == label => *s = Stmt::Continue,
+            Stmt::If {
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                rewrite_labeled_continue_in_stmts(then_branch, label);
+                if let Some(eb) = else_branch.as_mut() {
+                    rewrite_labeled_continue_in_stmts(eb, label);
+                }
+            }
+            Stmt::Try {
+                body,
+                catch,
+                finally,
+            } => {
+                rewrite_labeled_continue_in_stmts(body, label);
+                if let Some(c) = catch.as_mut() {
+                    rewrite_labeled_continue_in_stmts(&mut c.body, label);
+                }
+                if let Some(f) = finally.as_mut() {
+                    rewrite_labeled_continue_in_stmts(f, label);
+                }
+            }
+            Stmt::Switch { cases, .. } => {
+                for case in cases.iter_mut() {
+                    rewrite_labeled_continue_in_stmts(&mut case.body, label);
+                }
+            }
             _ => {}
         }
     }

--- a/crates/perry/tests/issue_5975_labeled_continue_in_yielding_switch.rs
+++ b/crates/perry/tests/issue_5975_labeled_continue_in_yielding_switch.rs
@@ -1,0 +1,215 @@
+//! Regression test for #5975: a `continue <label>` inside a **yielding**
+//! `switch` case nested in a labeled loop spun forever.
+//!
+//! `loop: while (true) { switch (x) { case …: yield …; continue loop } break loop }`
+//! desugars the switch (#5868) into a guarded `if`-chain and splits it at the
+//! `yield`, but the labeled-loop linearizer's `rewrite_labeled_bc_in_stmts`
+//! never descended into the nested switch, so the `continue loop`
+//! (`LabeledContinue`) survived verbatim into the state machine. Nothing
+//! lowered it, the loop never re-entered, and the generator spun at 100% CPU
+//! and never produced a value — most visibly the `yaml` package's block-scalar
+//! / indicator lexer generators (`loop: while (true) { switch (this.charAt(0))
+//! { … continue loop } }`), which hung any `parse()` of a large minified
+//! bundle at module-init time.
+//!
+//! The unlabeled equivalent (`continue;`) always worked, because
+//! `switch_cases_have_loop_continue` detects a plain `Stmt::Continue`; only the
+//! labeled form was invisible to it. The fix rewrites `continue <label>` →
+//! plain `continue` when descending into a nested switch (a switch never
+//! captures `continue`), matching the unlabeled path.
+//!
+//! Expected outputs are byte-for-byte what `node --experimental-strip-types`
+//! prints. Each run is bounded by a timeout so a regression FAILS (with a
+//! spin) instead of hanging the test process.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+/// Compile `source`, run the binary with a wall-clock deadline, and return its
+/// stdout. Panics (fails the test) if compilation fails, the binary exits
+/// non-zero, or it does not finish within `timeout` (the pre-fix spin).
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let mut child = Command::new(&output)
+        .current_dir(dir)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn compiled binary");
+
+    let timeout = Duration::from_secs(30);
+    let start = Instant::now();
+    loop {
+        match child.try_wait().expect("try_wait") {
+            Some(status) => {
+                let out = child.wait_with_output().expect("wait_with_output");
+                assert!(
+                    status.success(),
+                    "compiled binary failed (exit {:?})\nstdout:\n{}\nstderr:\n{}",
+                    status.code(),
+                    String::from_utf8_lossy(&out.stdout),
+                    String::from_utf8_lossy(&out.stderr)
+                );
+                return String::from_utf8_lossy(&out.stdout).into_owned();
+            }
+            None => {
+                if start.elapsed() > timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    panic!(
+                        "compiled binary did not finish within {:?} — the #5975 \
+                         labeled-continue-in-yielding-switch spin regressed",
+                        timeout
+                    );
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        }
+    }
+}
+
+/// The minimal reproducer: a generator with a labeled `while (true)` whose
+/// yielding switch cases `continue loop`, and a `break loop` after the switch.
+#[test]
+fn generator_labeled_continue_in_yielding_switch_while() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+function* gen(input: string) {
+  let i = 0, n = 0;
+  loop: while (true) {
+    switch (input[i]) {
+      case 'a': yield 'A'; i++; n++; continue loop;
+      case 'b': yield 'B'; i++; n++; continue loop;
+    }
+    break loop;
+  }
+  return n;
+}
+const out: string[] = [];
+const g = gen("aabbc");
+let r = g.next();
+while (!r.done) { out.push(r.value as string); r = g.next(); }
+console.log(out.join(",") + "|n=" + r.value);
+"#,
+    );
+    assert_eq!(stdout, "A,A,B,B|n=4\n");
+}
+
+/// Same shape with a labeled `for (;;)` loop.
+#[test]
+fn generator_labeled_continue_in_yielding_switch_for() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+function* gen(input: string) {
+  let n = 0;
+  loop: for (let i = 0; ; ) {
+    switch (input[i]) {
+      case 'a': yield 'A'; i++; n++; continue loop;
+      case 'b': yield 'B'; i++; n++; continue loop;
+    }
+    break loop;
+  }
+  return n;
+}
+const out: string[] = [];
+const g = gen("abbc");
+let r = g.next();
+while (!r.done) { out.push(r.value as string); r = g.next(); }
+console.log(out.join(",") + "|n=" + r.value);
+"#,
+    );
+    assert_eq!(stdout, "A,B,B|n=3\n");
+}
+
+/// The async equivalent: `await` inside the switch case, then `continue loop`.
+#[test]
+fn async_labeled_continue_in_awaiting_switch_while() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+async function f(input: string) {
+  let i = 0, n = 0, out = "";
+  loop: while (true) {
+    switch (input[i]) {
+      case 'a': out += await Promise.resolve('A'); i++; n++; continue loop;
+      case 'b': out += await Promise.resolve('B'); i++; n++; continue loop;
+    }
+    break loop;
+  }
+  return out + "|n=" + n;
+}
+f("aabbc").then((v) => console.log(v));
+"#,
+    );
+    assert_eq!(stdout, "AABB|n=4\n");
+}
+
+/// A closer analogue of the `yaml` indicator lexer: the loop-continuing cases
+/// `yield*` a delegated generator before `continue loop`, and a `break loop`
+/// terminates when no case matches.
+#[test]
+fn generator_yield_delegate_then_labeled_continue() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+function* emit(tag: string, k: number) {
+  for (let j = 0; j < k; j++) yield tag;
+}
+function* lex(src: string) {
+  let i = 0, count = 0;
+  loop: while (true) {
+    switch (src[i]) {
+      case '!':
+        count += yield* emit("bang", 1);
+        i++;
+        continue loop;
+      case '&':
+        count += yield* emit("amp", 2);
+        i++;
+        continue loop;
+    }
+    break loop;
+  }
+  return count;
+}
+const out: string[] = [];
+const g = lex("!&!x");
+let r = g.next();
+while (!r.done) { out.push(r.value as string); r = g.next(); }
+console.log(out.join(",") + "|count=" + r.value);
+"#,
+    );
+    // `emit` yields the tag string; `count += yield* emit(...)` adds the
+    // generator's return value (undefined -> NaN in JS), matching node.
+    assert_eq!(stdout, "bang,amp,amp,bang|count=NaN\n");
+}


### PR DESCRIPTION
Addresses #5975 (fixes one of two independent async-init hangs — see the note at the end).

## What

A `continue <label>` inside a **yielding** `switch` case nested in a labeled
loop was silently dropped, so the loop never re-entered and the
generator/async state machine spun at 100% CPU forever:

```ts
loop: while (true) {
  switch (input[i]) {
    case 'a': yield 'A'; i++; continue loop;   // ← labeled continue
    case 'b': yield 'B'; i++; continue loop;
  }
  break loop;
}
```

The unlabeled equivalent (`continue;`) always worked.

## Why

When a labeled loop body contains a `switch` with a `yield`/`await` in a case,
two passes cooperate:

1. `desugar_switch_to_ifs` (#5868) turns the switch into a match-index +
   guarded-`if` chain so the yield can split into resume states, and
2. the loop linearizer rewrites loop-level `break`/`continue` into the
   state-machine's sentinels.

The loop's `rewrite_labeled_bc_in_stmts` rewrites `continue <label>` → plain
`continue` (so the loop lowering can map it to the re-entry sentinel), but it
descended only through `if` / `try` and **stopped at `switch`**. Meanwhile
#5868's `switch_cases_have_loop_continue` only detects a plain `Stmt::Continue`
— a `LabeledContinue` in a case is invisible to it. So the labeled `continue`
survived verbatim into the desugared switch's state machine, where nothing
lowers it: the loop never advanced its state and re-ran the same
`switch (input[i])` forever.

This is why the labeled form hung while the unlabeled form (caught by
`switch_cases_have_loop_continue`) was fine. The shape is common in
hand-written lexers — most notably the `yaml` package's block-scalar and
indicator lexers are generators built exactly like this
(`loop: while (true) { switch (this.charAt(0)) { … continue loop } }`), so any
`yaml.parse()` of non-trivial input compiled to native code spun forever. A
large esbuild-bundled CLI app that parses YAML front-matter during module
initialization hung at 100% CPU before producing any output.

## Fix

Descend into nested `switch` case bodies when rewriting a labeled loop's
`continue <label>` → plain `continue` (a `switch` never captures `continue`, so
it always continues the enclosing loop). This routes the labeled case through
the exact same path the unlabeled `continue;` already took.

`break <label>` is deliberately **not** rewritten inside a nested switch: a
`switch` *does* capture `break`, so a plain `break` would exit only the switch,
not the loop — that target remains the pre-existing single-sentinel limitation
already documented on `rewrite_labeled_bc_in_stmts` (`break <label>` after the
switch, in the loop body, is unaffected and keeps working).

## Testing

- `cargo test -p perry-transform`: 48 passed, 0 failed.
- New e2e suite `crates/perry/tests/issue_5975_labeled_continue_in_yielding_switch.rs`
  — 4 scenarios (generator `while`, generator `for`, `async`, and a
  `yield*`-delegating lexer analogue), each byte-for-byte vs
  `node --experimental-strip-types` and bounded by a timeout so a regression
  FAILS with the spin instead of hanging CI.
- The `switch`-in-generator regression suite `issue_5868_switch_state_machine.rs`
  still passes.

Code-only change (no version bump / changelog — folded at merge).

## Note — a second, independent hang remains in #5975

This fix is necessary but not sufficient for the reporter's 13 MB bundle. With it,
`yaml`'s indicator lexer (`pushIndicators`) no longer spins, and the bundle's
YAML-parse module-init advances past it — but then hits a **second, distinct**
infinite loop in the same path: the lexer's outer state machine
(`*lex`: `while (next && this.hasChars(1)) next = yield* this.parseNext(next)`)
never terminates (spin chain `parse → *lex → parseNext → … → pushIndicators →
js_get_iterator`, `pushIndicators` itself verified correct in isolation). That
second hang reproduces only inside the full inlined bundle — the `yaml` package
cannot be used as a standalone native repro because perry currently fails to link
its named exports (`ld: Undefined symbols: "_parse" / "_parseDocument"`), an
unrelated packaging bug. The second hang is left for a follow-up; this PR is
scoped to the labeled-`continue` mislowering, which is independently reproducible,
root-caused, and covered by the e2e suite.
