### PR TITLE
fix(runtime): OrdinarySet rejects a receiver-owned accessor instead of firing its setter

### DIFF
--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -1205,8 +1205,16 @@ fn create_or_update_receiver_property(receiver: f64, key: f64, value: f64) -> bo
                     return false;
                 }
             }
-            OwnSetDescriptor::Accessor { setter_bits } => {
-                return call_setter_with_receiver(setter_bits, receiver, value);
+            OwnSetDescriptor::Accessor { .. } => {
+                // OrdinarySetWithOwnDescriptor step 2.d.i: reaching here means
+                // the source (target own) descriptor was a data property (or
+                // absent -> CreateDataProperty). A RECEIVER own accessor makes
+                // the algorithm return false WITHOUT invoking the setter -- the
+                // setter only fires when it is the descriptor found by the
+                // OrdinarySet walk itself (the Accessor arm in
+                // ordinary_set_with_receiver), never through this
+                // CreateDataProperty-on-receiver tail.
+                return false;
             }
         }
     } else if crate::closure::is_closure_ptr(extract_pointer(receiver.to_bits()) as usize) {


### PR DESCRIPTION
## Summary

`OrdinarySetWithOwnDescriptor` (sec-ordinarysetwithowndescriptor) step 2 handles the case where the descriptor found during the OrdinarySet walk is a **data** property (or absent → `CreateDataProperty`) and the write must land on a `Receiver` that differs from the object walked. In that tail the **Receiver's** own descriptor decides the outcome:

| Receiver own descriptor | result |
| --- | --- |
| accessor (2.d.i) | **return false — setter NOT called** |
| non-writable data (2.d.ii) | return false |
| writable data (2.d.iii) | redefine `{ value }` |
| none (2.e) | `CreateDataProperty` |

Perry's `create_or_update_receiver_property` tail **invoked the receiver's setter** for the accessor sub-case (2.d.i) and returned `true`. So a `Reflect.set(target, k, v, receiverWithSetter)` where `target[k]` is a data property mis-fired the receiver's setter and reported success. The receiver's setter must only run when it is the descriptor found by the OrdinarySet walk itself — served by the separate `Accessor` arm in `ordinary_set_with_receiver`, never through this `CreateDataProperty`-on-receiver tail. The accessor sub-case now returns `false` without calling the setter.

```js
var target = { x: 1 };
var setterCalled = 0;
var receiver = { set x(v) { setterCalled++; } };
Reflect.set(target, "x", 2, receiver);  // before: true / setterCalled 1 ; node & now: false / 0
```

## Validation

Built and tested on an internal Linux sweep host (`--release`).

- **test262 `built-ins/Reflect` + `Proxy` + `Object` (3875 cases):** byte-identical pass/fail between baseline and patched — **0 regressions**.
- **`built-ins/TypedArray` + `TypedArrayConstructors` (2184 cases):** **0 regressions**; combined with the typed-array `[[Set]]` fix merged in #6059 this flips `Set/key-is-valid-index-reflect-set.js` to passing (a typed-array element source with an accessor-bearing receiver — the exact data-source / accessor-receiver shape above). On its own the fix touches no other test262 verdict in these dirs but is a prerequisite for that case and is spec-correct.

`cargo fmt --all -- --check` clean; address-classification audit passes; `proxy.rs` stays under 2000 lines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted property update behavior for receiver-owned accessor properties so they are no longer treated as assignable in this path.
  * Prevents attempts to write through an accessor setter when the receiver already owns that property, returning a failure result instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->