### PR TITLE
fix(codegen): derive GC raw-f64/pointer masks from the authoritative init chain (#26/#321, refs #5094)

### DIFF
--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -886,7 +886,7 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
         // Issue #26: record the authoritative root→leaf init chain. `parent_chain`
         // was pushed direct-parent-first, so reverse it (deepest ancestor first),
         // then append the leaf class `c` (with its own fields, init exprs intact).
-        {
+        let chain: Vec<(String, Vec<perry_hir::ClassField>)> = {
             let mut chain: Vec<(String, Vec<perry_hir::ClassField>)> =
                 parent_chain.iter().rev().cloned().collect();
             chain.push((c.name.clone(), c.fields.clone()));
@@ -896,7 +896,8 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
                     .entry(alias.clone())
                     .or_insert_with(|| chain.clone());
             }
-        }
+            chain
+        };
         // Refs #486: register self-binding aliases (`_X` from `var X = class _X`)
         // so the inline-alloc fast path at lower_call.rs:2532 finds the keys
         // global when the class is referenced by its inner name. Without this,
@@ -908,7 +909,12 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
                 .entry(alias.clone())
                 .or_insert_with(|| global_name.clone());
         }
-        let typed_layout = crate::typed_shape::class_typed_layout(&class_table, &c.name);
+        // Refs #5094: derive the GC raw-f64/pointer masks from the SAME
+        // prefix-disambiguated chain that built `packed_keys` above, so mask
+        // bits stay aligned with the actual slot layout when same-named
+        // cross-module parents exist (the name-keyed `class_typed_layout`
+        // walk picks whichever stub won the bare-name race).
+        let typed_layout = crate::typed_shape::class_typed_layout_from_chain(&chain);
         class_field_counts_map.insert(c.name.clone(), total_field_count);
         for alias in &c.aliases {
             class_field_counts_map
@@ -999,18 +1005,23 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
             packed_keys.push_str(&f.name);
             packed_keys.push('\0');
         }
-        let typed_layout = crate::typed_shape::class_typed_layout(&class_table, &c.name);
         class_field_counts_map
             .entry(c.name.clone())
             .or_insert(total_field_count);
         // Issue #26: authoritative root→leaf init chain for the imported class
         // (prefix-disambiguated parents + this stub's own fields as the leaf).
-        {
+        // Refs #5094: the GC raw-f64/pointer masks derive from this same chain
+        // (not the name-keyed `class_typed_layout` walk) so mask bits stay
+        // aligned with the packed-keys slot layout under same-named
+        // cross-module parents.
+        let typed_layout = {
             let mut chain: Vec<(String, Vec<perry_hir::ClassField>)> =
                 parent_chain.iter().rev().cloned().collect();
             chain.push((c.name.clone(), c.fields.clone()));
+            let typed_layout = crate::typed_shape::class_typed_layout_from_chain(&chain);
             class_init_chains_map.entry(c.name.clone()).or_insert(chain);
-        }
+            typed_layout
+        };
         class_keys_init_data.push((
             global_name,
             packed_keys,

--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -414,7 +414,14 @@ fn emit_typed_shape_layout_init(ctx: &mut FnCtx<'_>, class_name: &str, obj_handl
     let Some(keys_global_name) = ctx.class_keys_globals.get(class_name).cloned() else {
         return;
     };
-    let typed_layout = crate::typed_shape::class_typed_layout(ctx.classes, class_name);
+    // Refs #5094: prefer the prefix-disambiguated chain so slot/word counts
+    // agree with the mask globals emitted in compile_module (same-named
+    // cross-module parents mis-resolve in the name-keyed walk).
+    let typed_layout = ctx
+        .class_init_chains
+        .get(class_name)
+        .map(|chain| crate::typed_shape::class_typed_layout_from_chain(chain))
+        .unwrap_or_else(|| crate::typed_shape::class_typed_layout(ctx.classes, class_name));
     let slot_count_str = typed_layout.slot_count.to_string();
     let raw_mask_word_count_str = typed_layout.raw_f64_mask_words.len().to_string();
     let pointer_mask_word_count_str = typed_layout.pointer_mask_words.len().to_string();

--- a/crates/perry-codegen/src/lower_call/scalar_method.rs
+++ b/crates/perry-codegen/src/lower_call/scalar_method.rs
@@ -625,7 +625,14 @@ fn emit_materialized_scalar_receiver_typed_shape_init(
     let Some(keys_global_name) = ctx.class_keys_globals.get(class_name).cloned() else {
         return;
     };
-    let typed_layout = crate::typed_shape::class_typed_layout(ctx.classes, class_name);
+    // Refs #5094: prefer the prefix-disambiguated chain so slot/word counts
+    // agree with the mask globals emitted in compile_module (same-named
+    // cross-module parents mis-resolve in the name-keyed walk).
+    let typed_layout = ctx
+        .class_init_chains
+        .get(class_name)
+        .map(|chain| crate::typed_shape::class_typed_layout_from_chain(chain))
+        .unwrap_or_else(|| crate::typed_shape::class_typed_layout(ctx.classes, class_name));
     let slot_count_str = typed_layout.slot_count.to_string();
     let raw_mask_word_count_str = typed_layout.raw_f64_mask_words.len().to_string();
     let pointer_mask_word_count_str = typed_layout.pointer_mask_words.len().to_string();

--- a/crates/perry-codegen/src/typed_shape.rs
+++ b/crates/perry-codegen/src/typed_shape.rs
@@ -62,10 +62,36 @@ pub(crate) fn class_typed_layout(
     }
     chain.reverse();
 
+    typed_layout_from_fields(chain.iter().flat_map(|class| class.fields.iter()))
+}
+
+/// Issue #26 / #321 (refs #5094): typed layout from an authoritative,
+/// source-prefix-disambiguated root→leaf chain (`class_init_chains`). The
+/// name-keyed walk in [`class_typed_layout`] mis-resolves same-named
+/// cross-module parents (effect's `Type` in SchemaAST.ts vs ParseResult.ts),
+/// which misaligns every mask bit after the wrong parent's field count. The
+/// GC scanner reads these masks per slot, so a misaligned mask is only kept
+/// from corrupting memory by the install-time backstop in
+/// `js_gc_init_typed_shape_layout` (each raw-f64 slot is validated to hold a
+/// plain double before the descriptor is promoted) — which also means
+/// dup-named classes silently never get a typed descriptor, so the #5093
+/// class-field fast path never engages for them. The chain is built in
+/// `compile_module` by the SAME walk that emits the packed-keys global and
+/// field count, so masks derived from it are consistent with the slot layout
+/// instances actually get.
+pub(crate) fn class_typed_layout_from_chain(
+    chain: &[(String, Vec<perry_hir::ClassField>)],
+) -> TypedShapeLayout {
+    typed_layout_from_fields(chain.iter().flat_map(|(_, fields)| fields.iter()))
+}
+
+fn typed_layout_from_fields<'a>(
+    fields: impl Iterator<Item = &'a perry_hir::ClassField>,
+) -> TypedShapeLayout {
     let mut raw_f64_mask_words = Vec::new();
     let mut pointer_mask_words = Vec::new();
     let mut slot_count = 0u32;
-    for field in chain.iter().flat_map(|class| class.fields.iter()) {
+    for field in fields {
         if field.key_expr.is_some() {
             continue;
         }


### PR DESCRIPTION
## Summary

Closes the remaining compile-time layout-derivation gap in the #26/#321 duplicate-class-name family, under the #5094 umbrella: **the GC raw-f64/pointer masks are still built by a bare-name parent walk** (`class_typed_layout`), while the packed-keys global, field count, constructor field-init, and — since #6057 — the class-field slot index all derive from the authoritative source-prefix-disambiguated chain (`class_init_chains`). This PR moves the masks (and the new-site slot/word counts that must agree with them) onto that same chain, so all layout derivations for a class come from one walk by construction.

## Why it matters

When same-named cross-module parents collide (effect's `Type` in SchemaAST.ts vs ParseResult.ts), the bare-name walk counts the wrong parent's fields and misaligns every mask bit after it — and can disagree with the keys-global's slot count entirely.

The GC scanner consumes these masks per slot, so a misaligned mask is a memory-corruption-shaped hazard. In practice it is currently backstopped: `js_gc_init_typed_shape_layout` validates each raw-f64-marked slot holds a plain double before promoting the typed descriptor, so a wrong mask is rejected at install time rather than acted on. I verified this empirically — a constructed dup-name repro (numeric `Payload` winning the bare-name race over a string-fielded `Payload` + subclass) survives `PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1`, `PERRY_GEN_GC=0`, and `PERRY_VERIFY_TYPED_INTACT=1` on main. That leaves two real consequences on main:

1. **Dup-named classes silently never get a typed descriptor** (the backstop rejects the misaligned mask), so the intact bit is never set and the #5093/#5198/#6057 inline class-field fast path never engages for exactly the effect-style code the dup-name fixes target.
2. The masks are only *accidentally* safe — one hazard away from the backstop. #6061-style work leans progressively harder on compile-time layout facts; the masks should be correct by construction, not by rejection.

## Change

- `typed_shape.rs`: add `class_typed_layout_from_chain` (mask/slot-count builder over a resolved `(name, fields)` chain); the legacy name-keyed `class_typed_layout` keeps its behavior and shares the accumulation helper.
- `compile_module` (both the local-class and imported-stub keys-global emission): build the masks from the same `parent_chain + leaf` the packed keys, field count, and `class_init_chains` entry are built from in that iteration.
- `lower_new` / `scalar_method` typed-shape-layout init: prefer `ctx.class_init_chains` for the slot/word counts so they agree with the mask globals emitted above; fall back to the legacy walk only for classes with no chain entry.

No version bump / changelog per the external-contribution convention.

## Verification (perry-dev profile, vs `node --experimental-strip-types`)

- `test_gap_dup_class_name_field_layout` and `test_gap_5654_class_field_inline_descriptor` (the #6057 test): byte-identical to node.
- Dup-name GC repro (300 surviving subclass instances with pointer-bearing fields under allocation churn): byte-identical under plain run, `PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1`, `PERRY_GEN_GC=0`, and `PERRY_VERIFY_TYPED_INTACT=1`.
- Adversarial class-field suite (instance `defineProperty` getters on raw-f64 + boxed fields, getter installed mid-loop on the hot receiver, setter interception, non-writable strict-mode throw, freeze, delete + re-read, raw-f64 downgrade via `any` alias, subclass polymorphism) plus a hot-loop/allocation-pressure/mid-loop-downgrade GC-stress test: byte-identical to node under all of the above configs.
- Full gap-suite sweep (258 tests, byte-compare vs node, run without the parity normalizer): 219 pass; every non-pass is a triaged `known_failures.json` entry, a strip-mode-unsupported test (TS parameter properties), or fails identically on pristine main (temporal/console/net families) — zero new regressions.
- `09_method_calls`: 104 ms, unchanged from post-#6057 main.
- `cargo test -p perry-codegen`: only the pre-existing `pod_field_read_after_dynamic_materialization_uses_number_coerce` failure (fails identically on pristine main).

## Relationship to in-flight work

Complements merged #6057 (slot-index side of the same family) and is disjoint from open #6061 (loop versioning) — no shared files, and correct masks are exactly what lets the typed descriptor install so those fast paths engage for dup-named classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed typed layout generation so class data is now aligned more reliably across inheritance chains, including cases with same-named parents from different modules.
  * Improved runtime shape initialization for classes and scalar receivers to use a more consistent layout calculation, reducing masking/layout mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->