### PR TITLE
fix(regex): expand Unicode 17.0 script property-escapes to real ranges

### DIFF
--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -43,6 +43,8 @@ mod match_all;
 mod replace_expand;
 mod replace_fn;
 #[cfg(feature = "regex-engine")]
+mod unicode17;
+#[cfg(feature = "regex-engine")]
 use class_range_validate::has_out_of_order_double_dash_class_range;
 #[cfg(feature = "regex-engine")]
 pub use compile::js_regexp_compile_value;

--- a/crates/perry-runtime/src/regex/grammar.rs
+++ b/crates/perry-runtime/src/regex/grammar.rs
@@ -458,10 +458,8 @@ fn is_unsupported_property_value(value: &str) -> bool {
         .or_else(|| value.strip_prefix("se="))
         .or_else(|| value.strip_prefix("scriptextensions="));
     if let Some(sv) = script_val {
-        return matches!(
-            sv,
-            "unknown" | "zzzz" | "beriaerfe" | "sidetic" | "taiyo" | "tolongsiki"
-        );
+        // Beria_Erfe/Sidetic/Tai_Yo/Tolong_Siki now expand via `unicode17`; only Unknown/Zzzz stay never-matching.
+        return matches!(sv, "unknown" | "zzzz");
     }
     value == "changeswhennfkccasefolded"
 }
@@ -1434,6 +1432,16 @@ pub(super) fn js_regex_to_rust(pattern: &str) -> String {
                     // mis-compiling (Node also rejects `\P{RGI_Emoji}`).
                     // All other properties pass through to the crate unchanged.
                     match parse_unicode_property(&chars, i) {
+                        Some((value, negated, end))
+                            if super::unicode17::script_replacement(&value, negated, in_class)
+                                .is_some() =>
+                        {
+                            result.push_str(
+                                &super::unicode17::script_replacement(&value, negated, in_class)
+                                    .unwrap(),
+                            );
+                            i = end;
+                        }
                         Some((value, negated, end)) if is_unsupported_property_value(&value) => {
                             if in_class {
                                 if negated {

--- a/crates/perry-runtime/src/regex/tests.rs
+++ b/crates/perry-runtime/src/regex/tests.rs
@@ -390,3 +390,75 @@ fn high_surrogate_distributes_over_group() {
     );
     assert!(!re.is_match("AB"), "does not match plain ASCII");
 }
+
+/// Unicode 17.0 scripts (`Beria_Erfe`, `Sidetic`, `Tai_Yo`, `Tolong_Siki`) are
+/// absent from `regex-syntax`'s bundled Unicode-16 UCD. Instead of throwing a
+/// `SyntaxError` or compiling to a never-matching class, Perry expands them to
+/// the explicit code-point ranges Unicode 17 assigns — so `built-ins/RegExp/`
+/// `property-escapes` Test262 cases that expect real matches pass. Covers every
+/// alias form (`Script`/`sc`/`Script_Extensions`/`scx`) and long + short names.
+#[test]
+fn unicode17_scripts_expand_to_codepoint_ranges() {
+    // Positive `\p{Script=...}` → explicit class of the script's ranges.
+    assert_eq!(
+        js_regex_to_rust(r"\p{Script=Beria_Erfe}"),
+        r"[\x{16EA0}-\x{16EB8}\x{16EBB}-\x{16ED3}]"
+    );
+    // Short alias, `sc=` key, and `scx=` all resolve to the same body.
+    assert_eq!(
+        js_regex_to_rust(r"\p{sc=Berf}"),
+        r"[\x{16EA0}-\x{16EB8}\x{16EBB}-\x{16ED3}]"
+    );
+    assert_eq!(
+        js_regex_to_rust(r"\p{scx=Beria_Erfe}"),
+        r"[\x{16EA0}-\x{16EB8}\x{16EBB}-\x{16ED3}]"
+    );
+    assert_eq!(
+        js_regex_to_rust(r"\p{Script_Extensions=Berf}"),
+        r"[\x{16EA0}-\x{16EB8}\x{16EBB}-\x{16ED3}]"
+    );
+    // The other three scripts.
+    assert_eq!(
+        js_regex_to_rust(r"\p{sc=Sidetic}"),
+        r"[\x{10940}-\x{10959}]"
+    );
+    assert_eq!(
+        js_regex_to_rust(r"\p{sc=Tai_Yo}"),
+        r"[\x{1E6C0}-\x{1E6DE}\x{1E6E0}-\x{1E6F5}\x{1E6FE}-\x{1E6FF}]"
+    );
+    assert_eq!(
+        js_regex_to_rust(r"\p{sc=Tolong_Siki}"),
+        r"[\x{11DB0}-\x{11DDB}\x{11DE0}-\x{11DE9}]"
+    );
+    // Negated form → complemented class.
+    assert_eq!(
+        js_regex_to_rust(r"\P{sc=Sidetic}"),
+        r"[^\x{10940}-\x{10959}]"
+    );
+
+    // End-to-end: the compiled anchored regex matches the script's own code
+    // points and rejects an adjacent non-member (mirrors the Test262 shape).
+    let re = js_regexp_new(make_string(r"^\p{Script=Beria_Erfe}+$"), make_string("u"));
+    assert!(!re.is_null(), "Beria_Erfe pattern must construct");
+    assert!(
+        js_regexp_test(re, make_string("\u{16EA0}\u{16EB8}\u{16EBB}\u{16ED3}")) != 0,
+        "matches Beria_Erfe code points"
+    );
+    // U+16EB9/U+16EBA sit in the gap between the two ranges → not members.
+    assert!(
+        js_regexp_test(re, make_string("\u{16EB9}")) == 0,
+        "gap code point U+16EB9 is not Beria_Erfe"
+    );
+
+    // Negated: `\P{sc=Sidetic}` matches an ASCII letter, not a Sidetic point.
+    let rn = js_regexp_new(make_string(r"^\P{sc=Sidetic}$"), make_string("u"));
+    assert!(!rn.is_null(), "negated Sidetic pattern must construct");
+    assert!(
+        js_regexp_test(rn, make_string("A")) != 0,
+        "ASCII is non-Sidetic"
+    );
+    assert!(
+        js_regexp_test(rn, make_string("\u{10940}")) == 0,
+        "U+10940 is Sidetic, excluded by the negation"
+    );
+}

--- a/crates/perry-runtime/src/regex/unicode17.rs
+++ b/crates/perry-runtime/src/regex/unicode17.rs
@@ -1,0 +1,46 @@
+//! Unicode 17.0 script property-escape expansions.
+//!
+//! `regex-syntax` v0.8.x ships an Unicode 16.0 UCD, so `\p{sc=Beria_Erfe}` and
+//! the three other scripts added in Unicode 17.0 (`Sidetic`, `Tai_Yo`,
+//! `Tolong_Siki`) are unknown to it: left verbatim the crate rejects the whole
+//! pattern with a `SyntaxError`, and the prior stopgap compiled them to a
+//! never-matching class — which mismatches every Test262
+//! `built-ins/RegExp/property-escapes` case that expects real matches. Here we
+//! expand each to the explicit code-point ranges Unicode 17.0 assigns.
+
+/// Expand a `\p{...}`/`\P{...}` naming one of the four Unicode-17.0 scripts the
+/// bundled UCD lacks, or return `None` for everything else (which passes through
+/// to the regex crate unchanged).
+///
+/// These four are brand-new, self-contained blocks, so `Script` and
+/// `Script_Extensions` coincide — one body serves every alias key
+/// (`sc`/`script`/`scx`/`script_extensions`/`se`) and both the short and long
+/// script names. `value` is already normalized (lowercased, `_`/spaces removed).
+///
+/// Returns the fully-wrapped replacement: a positive class `[…]`, its complement
+/// `[^…]` when negated, or the bare range body for a positive in-class member.
+/// A negated *in-class* member has no character-class-union form, so it
+/// contributes nothing (an empty string) — matching the pre-existing handling of
+/// that edge case for other never-representable properties.
+pub(super) fn script_replacement(value: &str, negated: bool, in_class: bool) -> Option<String> {
+    let script = value
+        .strip_prefix("script=")
+        .or_else(|| value.strip_prefix("sc="))
+        .or_else(|| value.strip_prefix("scriptextensions="))
+        .or_else(|| value.strip_prefix("scx="))
+        .or_else(|| value.strip_prefix("se="))
+        .unwrap_or(value);
+    let body = match script {
+        "beriaerfe" | "berf" => "\\x{16EA0}-\\x{16EB8}\\x{16EBB}-\\x{16ED3}",
+        "sidetic" | "sidt" => "\\x{10940}-\\x{10959}",
+        "taiyo" | "tayo" => "\\x{1E6C0}-\\x{1E6DE}\\x{1E6E0}-\\x{1E6F5}\\x{1E6FE}-\\x{1E6FF}",
+        "tolongsiki" | "tols" => "\\x{11DB0}-\\x{11DDB}\\x{11DE0}-\\x{11DE9}",
+        _ => return None,
+    };
+    Some(match (in_class, negated) {
+        (true, true) => String::new(),
+        (true, false) => body.to_string(),
+        (false, true) => format!("[^{body}]"),
+        (false, false) => format!("[{body}]"),
+    })
+}


### PR DESCRIPTION
## Summary

Test262 `built-ins/RegExp/property-escapes` cases for the four **Unicode 17.0**
scripts — `Beria_Erfe`, `Sidetic`, `Tai_Yo`, `Tolong_Siki` — failed because
Perry's regex engine resolves `\p{…}` through `regex-syntax`, whose bundled UCD
is **Unicode 16.0** and predates these scripts. `regex` 1.12.4 / `regex-syntax`
0.8.11 are already the newest published versions, so bumping the crate does not
help — there is no release with Unicode 17 data yet.

The prior stopgap (#5781) compiled `\p{sc=Beria_Erfe}` to a **never-matching**
class so imports wouldn't throw `SyntaxError`. That kept patterns valid but made
every positive property-escape assertion mismatch Node.

These four scripts occupy **brand-new, self-contained code-point blocks**, so
`Script` and `Script_Extensions` cover the identical points and the ranges are
small and exact. This change expands each `\p{…}`/`\P{…}` reference (across all
alias forms — `sc` / `script` / `scx` / `script_extensions` / `se`, and both the
long and short script names) to its explicit Unicode 17.0 code-point ranges:

| Script | Alias | Ranges (Unicode 17.0) |
|--------|-------|-----------------------|
| Beria_Erfe | Berf | U+16EA0–16EB8, U+16EBB–16ED3 |
| Sidetic | Sidt | U+10940–10959 |
| Tai_Yo | Tayo | U+1E6C0–1E6DE, U+1E6E0–1E6F5, U+1E6FE–1E6FF |
| Tolong_Siki | Tols | U+11DB0–11DDB, U+11DE0–11DE9 |

Positive → `[…]`, negated → `[^…]`, positive in-class → the bare range body.

## Scope

This is the maximal clean win against a stale bundled UCD. The remaining
`property-escapes` failures are **code points added by Unicode 17.0 to
*existing* scripts / categories** (`Han`, `Latin`, `Arabic`, the
`General_Category` families, `Alphabetic`/`ID_Start`/… binary properties) — those
can only be fixed by regenerating and bundling full Unicode 17 property tables
(a large data drop), which is out of scope here. `Script=Unknown` / `Zzzz` name
every *un*assigned code point and are inherently un-representable against a stale
UCD, so they stay never-matching.

## Validation (internal Linux sweep host)

`built-ins/RegExp` subset radar, `--jobs 4`, byte-compared against Node:

| | pass | runtime-fail | compile-fail | parity | judged |
|--|------|------|------|--------|--------|
| before | 1087 | 86 | 0 | 92.7% | 1173 |
| after  | 1095 | 78 | 0 | 93.4% | 1173 |

Net **+8** cases, **zero** new regressions. `comm -13` on the before/after
`.failures.txt` shows the set of new failures is **empty**, and the eight
flipped cases are exactly `Script`/`Script_Extensions` ×
`{Beria_Erfe, Sidetic, Tai_Yo, Tolong_Siki}` — the whole change surface. Every
other bucket (compile-fail 0, judged 1173, skip 5) is unchanged, confirming the
translation only affects those four script names and passes everything else
through untouched.

New runtime unit test `unicode17_scripts_expand_to_codepoint_ranges` pins the
translation (all alias forms) and the end-to-end match / non-match behaviour.

`cargo fmt --all -- --check` clean; all touched files < 2000 lines (the
expansion lives in a new `regex/unicode17.rs` sibling to keep `grammar.rs`
under the file-size gate).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded regular expression support for several Unicode 17 script properties, including `Beria_Erfe`, `Sidetic`, `Tai_Yo`, and `Tolong_Siki`.
  * Property escapes like `\p{...}` and `\P{...}` now translate into explicit code-point ranges more reliably, including in negated forms.

* **Bug Fixes**
  * Improved handling of previously unsupported script property values so more patterns compile and match as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->