### PR TITLE
fix(runtime): implement Date.prototype[Symbol.toPrimitive]

### DIFF
--- a/crates/perry-runtime/src/object/date_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/date_proto_thunks.rs
@@ -184,6 +184,113 @@ pub(crate) fn test_date_to_json_current_this() -> f64 {
     date_to_json(std::ptr::null())
 }
 
+/// True iff `value` is an ECMAScript Object (`Type(O) is Object`). Objects are
+/// the pointer-tagged heap values EXCEPT registered `Symbol`s (which share the
+/// pointer band) and `BigInt`s (distinct tag). All the primitive tags
+/// (undefined/null/bool/number/int32/string/bigint/symbol) are NOT Objects.
+fn value_is_object(value: f64) -> bool {
+    let jsv = crate::value::JSValue::from_bits(value.to_bits());
+    if !jsv.is_pointer() {
+        return false;
+    }
+    let raw = (value.to_bits() & crate::value::POINTER_MASK) as usize;
+    !crate::symbol::is_registered_symbol(raw)
+}
+
+/// `Date.prototype [ @@toPrimitive ] ( hint )` (ECMA-262 §21.4.4.45).
+///
+/// Unlike the other `Date.prototype` methods this is NOT brand-checked to a
+/// Date and does NOT read the time value — it is a *generic* `OrdinaryToPrimitive`
+/// dispatcher installed on `Date.prototype` and invoked with `this` = whatever
+/// the caller supplies (`.call(obj, hint)`). Steps:
+///   1. Let O be the `this` value. If `Type(O)` is not Object, throw a TypeError.
+///   2. If `hint` is "string" or "default" → `tryFirst = string`.
+///   3. Else if `hint` is "number" → `tryFirst = number`.
+///   4. Else throw a TypeError.
+///   5. Return `OrdinaryToPrimitive(O, tryFirst)`.
+///
+/// The `hint` comparison is against the primitive String value only: a
+/// `new String("number")` wrapper or any non-string is an invalid hint
+/// (TypeError), matching test262 `hint-invalid.js`.
+extern "C" fn date_to_primitive(_closure: *const crate::closure::ClosureHeader, hint: f64) -> f64 {
+    let this = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    // Step 1: brand-check `Type(O) is Object` (throws for undefined/null/86/''/true).
+    if !value_is_object(this) {
+        super::object_ops::throw_object_type_error(
+            b"Date.prototype[Symbol.toPrimitive] called on non-object",
+        );
+    }
+    // Steps 2-4: resolve `tryFirst` from the primitive-string hint.
+    let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    let try_string_first = match crate::string::str_bytes_from_jsvalue(hint, &mut scratch) {
+        Some((ptr, len)) => {
+            let bytes = unsafe { std::slice::from_raw_parts(ptr, len as usize) };
+            match bytes {
+                b"string" | b"default" => true,
+                b"number" => false,
+                _ => super::object_ops::throw_object_type_error(
+                    b"Date.prototype[Symbol.toPrimitive] called with invalid hint",
+                ),
+            }
+        }
+        // Not a primitive string (undefined, a `new String(...)` wrapper, …).
+        None => super::object_ops::throw_object_type_error(
+            b"Date.prototype[Symbol.toPrimitive] called with invalid hint",
+        ),
+    };
+    // Step 5: OrdinaryToPrimitive(O, tryFirst).
+    unsafe { crate::value::ordinary_to_primitive_for_toprimitive(this, try_string_first) }
+}
+
+/// Install `Date.prototype[Symbol.toPrimitive]` — a non-enumerable own method
+/// keyed by the real well-known `Symbol.toPrimitive` (not an `@@`-string own
+/// property, which would leak into `getOwnPropertyNames`). Its property
+/// descriptor is `{ writable: false, enumerable: false, configurable: true }`
+/// and the function's own `name` is `"[Symbol.toPrimitive]"` with `.length` 1
+/// (test262 `built-ins/Date/prototype/Symbol.toPrimitive/{prop-desc,name,
+/// length}.js`). Called from `populate_builtin_prototype_methods`'s `"Date"`
+/// arm.
+pub(crate) fn install_date_proto_to_primitive(proto_obj: *mut ObjectHeader) {
+    if proto_obj.is_null() {
+        return;
+    }
+    let func_ptr = date_to_primitive as *const u8;
+    crate::closure::js_register_closure_arity(func_ptr, 1);
+    let closure = crate::closure::js_closure_alloc(func_ptr, 0);
+    if closure.is_null() {
+        return;
+    }
+    super::native_module::set_bound_native_closure_name(closure, "[Symbol.toPrimitive]");
+    super::native_module::set_builtin_closure_length(closure as usize, 1);
+    super::native_module::set_builtin_closure_non_constructable(closure as usize);
+    // The function's own `name`/`length` are `{ writable:false, enumerable:false,
+    // configurable:true }` per ES §17.
+    let name_len_attrs = super::PropertyAttrs::new(false, false, true);
+    super::set_builtin_property_attrs(closure as usize, "name".to_string(), name_len_attrs);
+    super::set_builtin_property_attrs(closure as usize, "length".to_string(), name_len_attrs);
+    let sym = crate::symbol::well_known_symbol("toPrimitive");
+    if sym.is_null() {
+        return;
+    }
+    let proto_value = crate::value::js_nanbox_pointer(proto_obj as i64);
+    let sym_value = f64::from_bits(crate::value::JSValue::pointer(sym as *const u8).bits());
+    let fn_value = crate::value::js_nanbox_pointer(closure as i64);
+    unsafe {
+        crate::symbol::js_object_set_symbol_property(proto_value, sym_value, fn_value);
+    }
+    // The property is `{ writable:false, enumerable:false, configurable:true }`
+    // (test262 `prop-desc.js`). Symbol props default to
+    // `{ writable:true, enumerable:true, configurable:true }`, so record the
+    // spec attrs explicitly.
+    let sym_key = unsafe { crate::symbol::sym_key_from_f64(sym_value) };
+    let proto_key = proto_obj as usize;
+    crate::symbol::set_symbol_property_attrs(
+        proto_key,
+        sym_key,
+        super::PropertyAttrs::new(false, false, true),
+    );
+}
+
 // --- Date constructor static methods (Date.now / Date.parse / Date.UTC) ---
 //
 // The functional call forms are codegen intrinsics (`Expr::DateNow` /

--- a/crates/perry-runtime/src/object/global_this/proto_methods.rs
+++ b/crates/perry-runtime/src/object/global_this/proto_methods.rs
@@ -564,6 +564,10 @@ pub(crate) fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: 
                 date_prototype_to_string_thunk as *const u8,
                 0,
             );
+            // `Date.prototype[Symbol.toPrimitive]` — a generic `OrdinaryToPrimitive`
+            // dispatcher (non-enumerable own method, `.name` "[Symbol.toPrimitive]",
+            // `.length` 1). test262 `built-ins/Date/prototype/Symbol.toPrimitive/*`.
+            date_proto_thunks::install_date_proto_to_primitive(proto_obj);
         }
         "RegExp" => {
             // Real accessor getters (`source`/`flags`/`global`/…) so reflection

--- a/crates/perry-runtime/src/symbol/get.rs
+++ b/crates/perry-runtime/src/symbol/get.rs
@@ -257,6 +257,26 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
     if crate::proxy::js_proxy_is_proxy(obj_f64) != 0 {
         return crate::proxy::js_proxy_get(obj_f64, sym_f64);
     }
+    // A `Date` is a `DateCell` (NaN-boxed pointer, NOT an `ObjectHeader`). A
+    // symbol-keyed read (`d[Symbol.toPrimitive]`, `d[Symbol.iterator]`) must
+    // NOT reach the pointer-deref paths below — they reinterpret the cell as an
+    // `ObjectHeader` (`js_object_get_class_id`, prototype walk) and read
+    // garbage. Resolve OWN symbol props from the side table first (a user may
+    // `d[sym] = x`), then inherit from `Date.prototype` (which carries the
+    // installed `[Symbol.toPrimitive]`). This is the DateCell analogue of the
+    // ordinary object's own-then-prototype symbol walk.
+    if crate::date::is_date_value(obj_f64) {
+        if let Some(v) = own_symbol_property(obj_f64, sym_f64) {
+            return v;
+        }
+        let proto = crate::object::builtin_prototype_value("Date");
+        if (proto.to_bits() >> 48) == 0x7FFD {
+            if let Some(v) = own_symbol_property(proto, sym_f64) {
+                return v;
+            }
+        }
+        return f64::from_bits(TAG_UNDEFINED);
+    }
     // Check CLASS_STATIC_SYMBOLS first when receiver is a class ref
     // (top16 == 0x7FFE, INT32_TAG).
     let bits = obj_f64.to_bits();

--- a/crates/perry-runtime/src/symbol/iterator.rs
+++ b/crates/perry-runtime/src/symbol/iterator.rs
@@ -398,6 +398,20 @@ pub unsafe extern "C" fn js_to_primitive(value: f64, hint: i32) -> f64 {
             return crate::value::js_nanbox_string(p as i64);
         }
     }
+    // A `Date` is a `DateCell` cell, NOT an `ObjectHeader`. `Date.prototype`
+    // now carries an installed `[Symbol.toPrimitive]` (its own reflective
+    // `.call(obj, hint)` surface), but implicit `+`/`String()`/template
+    // coercion of a Date is already handled by the dedicated Date fast paths
+    // downstream (`js_add_coerce_to_primitive` string-coerces via
+    // `js_date_to_string`; `js_number_coerce` reads the timestamp). Returning
+    // the value unchanged here keeps that proven coercion path — and the
+    // installed method is still reachable through the explicit read+call form
+    // (`d[Symbol.toPrimitive](hint)` / `Date.prototype[@@toPrimitive].call(…)`),
+    // which does not route through `js_to_primitive`. This mirrors the Temporal
+    // short-circuit above and avoids re-routing a hot, well-tested path.
+    if crate::date::is_date_value(value) {
+        return value;
+    }
     // Look up obj[Symbol.toPrimitive].
     let wk_ptr = well_known_symbol("toPrimitive");
     let sym_f64 = f64::from_bits(POINTER_TAG | (wk_ptr as u64 & POINTER_MASK));

--- a/crates/perry-runtime/src/value/mod.rs
+++ b/crates/perry-runtime/src/value/mod.rs
@@ -113,7 +113,8 @@ pub use dyn_index::{js_dyn_index_get, js_dyn_index_set, js_is_undefined_or_bare_
 // ----- to-string conversion helpers -----
 pub(crate) use to_string::{
     coerce_validate_radix, function_to_primitive_for_add, function_to_string_method_result,
-    ordinary_to_primitive_number_for_add, to_primitive_number, OrdinaryToPrimitiveOutcome,
+    ordinary_to_primitive_for_toprimitive, ordinary_to_primitive_number_for_add,
+    to_primitive_number, OrdinaryToPrimitiveOutcome,
 };
 pub use to_string::{
     js_ensure_string_ptr, js_jsvalue_to_string, js_jsvalue_to_string_coerce,

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -142,6 +142,63 @@ fn throw_cannot_convert_to_primitive() -> ! {
     crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
 }
 
+/// Spec-faithful `OrdinaryToPrimitive(O, hint)` (ES2024 §7.1.1.1) for the
+/// `Date.prototype[@@toPrimitive]` thunk. Unlike the coercion helpers above
+/// (which special-case a *missing* `toString` as the inherited
+/// `Object.prototype.toString` → `"[object Object]"` for `String()`/`+`), this
+/// implements the abstract operation directly: it `Get`s each of the ordered
+/// method names off the receiver (firing accessor getters + walking the
+/// prototype chain via `js_reflect_get`), and — only when the resolved value
+/// `IsCallable` — invokes it with `this = value` and returns the first
+/// *primitive* result. A non-callable slot (including `null`/`undefined`) is
+/// SKIPPED, not treated as the default. If no method yields a primitive, it
+/// throws `TypeError`.
+///
+/// `try_string_first`: `true` for hint "string"/"default" (order `toString`
+/// then `valueOf`), `false` for hint "number" (order `valueOf` then
+/// `toString`). `value` MUST already be an Object (the thunk brand-checks
+/// `Type(O) is Object` first).
+pub(crate) unsafe fn ordinary_to_primitive_for_toprimitive(
+    value: f64,
+    try_string_first: bool,
+) -> f64 {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let value_handle = scope.root_nanbox_f64(value);
+    let order: [&[u8]; 2] = if try_string_first {
+        [b"toString", b"valueOf"]
+    } else {
+        [b"valueOf", b"toString"]
+    };
+    for name in order {
+        let recv = value_handle.get_nanbox_f64();
+        let key_ptr = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        let key = f64::from_bits(crate::value::js_nanbox_string(key_ptr as i64).to_bits());
+        // `Get(O, name)` — fires accessor getters and walks the prototype chain,
+        // exactly like the spec's abstract `Get` (so `{ get valueOf() {…} }` is
+        // observed and a getter throw propagates).
+        let method = crate::proxy::js_reflect_get(recv, key, recv);
+        if !crate::collection_iter::is_callable(method) {
+            // Non-callable (or absent) — skip to the next name.
+            continue;
+        }
+        let method_handle = scope.root_nanbox_f64(method);
+        let recv = value_handle.get_nanbox_f64();
+        let prev_this = crate::object::js_implicit_this_set(recv);
+        let result = crate::closure::js_native_call_value(
+            method_handle.get_nanbox_f64(),
+            std::ptr::null(),
+            0,
+        );
+        crate::object::js_implicit_this_set(prev_this);
+        if is_primitive_value(result) {
+            return result;
+        }
+        // A callable that returned an Object: continue to the next name (spec
+        // step 5.a.iii only returns when the result is NOT an Object).
+    }
+    throw_cannot_convert_to_primitive()
+}
+
 /// Outcome of resolving a function/closure's custom `toString`/`valueOf` for
 /// the string-hint `ToPrimitive`. Distinct from a bare `Option` so the
 /// "no custom method at all" case (fall back to the function's own source


### PR DESCRIPTION
## Summary

Implements `Date.prototype[Symbol.toPrimitive]` per ECMA-262 §21.4.4.45 — previously entirely missing (`typeof Date.prototype[Symbol.toPrimitive]` was `undefined`).

`Date.prototype[Symbol.toPrimitive](hint)` is installed as a non-enumerable own method of `Date.prototype`, keyed by the real well-known `Symbol.toPrimitive`. It is a *generic* `OrdinaryToPrimitive` dispatcher (not brand-checked to Date, not reading the time value):

1. Let `O` be the `this` value. If `Type(O)` is not Object → **TypeError**.
2. If `hint` is `"string"`/`"default"` → `tryFirst = "string"`; if `"number"` → `tryFirst = "number"`; any other hint (including `undefined`, a `new String("number")` wrapper, an object) → **TypeError**.
3. Return `OrdinaryToPrimitive(O, tryFirst)`.

The property descriptor is `{ writable: false, enumerable: false, configurable: true }`, the function's own `name` is `"[Symbol.toPrimitive]"` and `.length` is `1`, matching the spec.

## Implementation

- **`object/date_proto_thunks.rs`** — the `date_to_primitive` thunk (brand-check + hint parse) and `install_date_proto_to_primitive` (installs the symbol-keyed method with the spec descriptor + `name`/`length`), wired into the `"Date"` arm of `populate_builtin_prototype_methods`.
- **`value/to_string.rs`** — a spec-faithful `ordinary_to_primitive_for_toprimitive(value, try_string_first)`: `Get`s each ordered method (`js_reflect_get`, so accessor getters fire and getter throws propagate), invokes it only when `IsCallable`, returns the first *primitive* result, and throws `TypeError` if none yields a primitive. A non-callable slot is skipped (not treated as the default), unlike the `String()`/`+` coercion helpers.
- **`symbol/get.rs`** — a `DateCell` receiver (`d[Symbol.toPrimitive]`, `d[Symbol.iterator]`) now resolves symbol reads off its own side-table then `Date.prototype`, instead of falling into the pointer-deref paths (a `DateCell` is not an `ObjectHeader`).
- **`symbol/iterator.rs`** — `js_to_primitive` short-circuits Date values (mirroring the existing Temporal short-circuit) so implicit `+`/`String()`/template coercion of a Date stays on the proven dedicated Date fast paths. The installed method remains reachable through the explicit read+call form, which does not route through `js_to_primitive` — so no hot coercion path is re-routed.

## Testing (internal Linux sweep host)

Target slice `built-ins/Date/prototype/Symbol.toPrimitive` (`--all-features`): **18/18 pass (100%)**, was 4/18.

`built-ins/Date` + `built-ins/Symbol` differential vs Node v26:
- before: 602 pass / 70 runtime-fail
- after:  616 pass / 56 runtime-fail
- **+14 fixed, 0 regressions** — every fixed case is a `Symbol.toPrimitive/*` case; the regressed set is empty.

Broad `language` + `built-ins` regression sweep: **0 new regressions** (before/after `.failures.txt` diff is net-positive with an empty regressed set).

`cargo fmt --all -- --check` clean; touched runtime files stay well under 2000 lines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `Date.prototype[Symbol.toPrimitive]`, improving how dates convert to strings or numbers.
  * Date values now follow the expected conversion rules for `"string"`, `"default"`, and `"number"` hints.

* **Bug Fixes**
  * Fixed symbol-property handling for Date values so lookups behave correctly on Date instances and their prototype.
  * Improved Date coercion paths to avoid incorrect behavior during primitive conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->