### PR TITLE
fix(codegen,runtime): #6088 — typed-array out-of-bounds index reads 0 instead of undefined

### DIFF
--- a/benchmarks/compiler_output/workloads.toml
+++ b/benchmarks/compiler_output/workloads.toml
@@ -487,6 +487,7 @@ kind = "native_rep_benchmark"
 allow_hot_loop_conversions = true
 allowed_hot_loop_runtime_calls = [
   "js_buffer_get",
+  "js_buffer_index_get_value",
   "js_buffer_set",
   "js_shadow_slot_set",
 ]
@@ -520,12 +521,14 @@ allow_dynamic_property_runtime = true
 allow_hot_loop_conversions = true
 allowed_hot_loop_runtime_calls = [
   "js_buffer_get",
+  "js_buffer_index_get_value",
   "js_buffer_set",
   "js_closure_call1",
   "js_dyn_index_get",
   "js_dynamic_string_or_number_add",
   "js_number_coerce",
   "js_uint8array_get",
+  "js_uint8array_index_get_value",
   "js_uint8array_set",
   "js_value_length_f64",
 ]
@@ -1956,6 +1959,7 @@ allowed_hot_loop_runtime_calls = [
   "js_array_length",
   "js_array_push_f64",
   "js_buffer_get",
+  "js_buffer_index_get_value",
   "js_buffer_set",
   "js_handle_object_get_property",
   "js_boxed_number_new",
@@ -1972,6 +1976,7 @@ allowed_hot_loop_runtime_calls = [
   "js_shadow_slot_bind",
   "js_shadow_slot_set",
   "js_uint8array_get",
+  "js_uint8array_index_get_value",
   "js_uint8array_set",
   "js_write_barrier_root_nanbox",
 ]

--- a/crates/perry-codegen/src/expr/arrays_finds.rs
+++ b/crates/perry-codegen/src/expr/arrays_finds.rs
@@ -771,14 +771,41 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     &[(I64, &handle), (DOUBLE, &key)],
                 ));
             }
-            let value = lower_uint8array_get_i32(ctx, array, index)?;
-            let reason = buffer_access_materialization_reason(ctx, array);
-            Ok(materialize_js_value(ctx, value, reason))
+            // #6088: a proven non-negative integer key whose value is NOT
+            // proven in bounds (the inline load above bailed). The native i32
+            // accessor returns the `0` byte-sentinel for an out-of-range read;
+            // a JS-value `u8[i]` must instead read `undefined` (ECMAScript
+            // IntegerIndexedExotic `[[Get]]`). In-range reads still return the
+            // byte as a number.
+            let a = lower_expr(ctx, array)?;
+            let idx_i32 = lower_index_i32(ctx, index)?;
+            let blk = ctx.block();
+            let handle = unbox_to_i64(blk, &a);
+            Ok(blk.call(
+                DOUBLE,
+                "js_uint8array_index_get_value",
+                &[(I64, &handle), (I32, &idx_i32)],
+            ))
         }
         Expr::BufferIndexGet { buffer, index } => {
-            let value = lower_buffer_index_get_i32(ctx, buffer, index)?;
-            let reason = buffer_access_materialization_reason(ctx, buffer);
-            Ok(materialize_js_value(ctx, value, reason))
+            // Proven-bounds inline load keeps the native fast path.
+            if let Some(value) =
+                lower_buffer_load(ctx, buffer, index, BufferAccessSpec::buffer_index_get())?
+            {
+                let reason = buffer_access_materialization_reason(ctx, buffer);
+                return Ok(materialize_js_value(ctx, value, reason));
+            }
+            // #6088: out-of-range → `undefined`, not the `0` byte-sentinel the
+            // native `js_buffer_get` accessor is forced to return.
+            let a = lower_expr(ctx, buffer)?;
+            let idx_i32 = lower_index_i32(ctx, index)?;
+            let blk = ctx.block();
+            let handle = unbox_to_i64(blk, &a);
+            Ok(blk.call(
+                DOUBLE,
+                "js_buffer_index_get_value",
+                &[(I64, &handle), (I32, &idx_i32)],
+            ))
         }
         Expr::Uint8ArraySet {
             array,

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -32,7 +32,6 @@ use crate::type_analysis::{
 #[allow(unused_imports)]
 use crate::types::{DOUBLE, F32, I1, I16, I32, I64, I8, PTR};
 
-use super::arrays_finds::lower_buffer_index_get_i32;
 #[allow(unused_imports)]
 use super::{
     array_kind_fact, buffer_access_materialization_reason, buffer_alias_metadata_suffix,
@@ -1401,9 +1400,24 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         &[(I64, &arr_i64), (DOUBLE, &key_box)],
                     ));
                 }
-                let value = lower_buffer_index_get_i32(ctx, object, index)?;
-                let reason = buffer_access_materialization_reason(ctx, object);
-                return Ok(materialize_js_value(ctx, value, reason));
+                // #6088: the index is a proven non-negative i32 key, but the
+                // inline load above bailed, so its value is NOT proven in
+                // bounds. The native `js_uint8array_get` accessor returns the
+                // `0` byte-sentinel for an out-of-range read; a JS-value
+                // `buf[i]` / `uint8array[i]` must instead read `undefined`
+                // (ECMAScript IntegerIndexedExotic `[[Get]]`). Route the
+                // unproven-bounds slow path through the JS-value getter (robust
+                // for both a real Uint8Array and a Buffer-backed receiver) —
+                // in-range reads still return the byte as a number.
+                let arr_box = lower_expr(ctx, object)?;
+                let idx_i32 = lower_expr_as_i32(ctx, index)?;
+                let blk = ctx.block();
+                let handle = unbox_to_i64(blk, &arr_box);
+                return Ok(blk.call(
+                    DOUBLE,
+                    "js_uint8array_index_get_value",
+                    &[(I64, &handle), (I32, &idx_i32)],
+                ));
             }
             // Scalar-replaced array literal: `arr[k]` where arr was bound to
             // `[...]` and never escaped, and k is a compile-time index in

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -111,6 +111,7 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
         &[I64, DOUBLE, DOUBLE],
     );
     module.declare_function("js_uint8array_get", I32, &[I64, I32]);
+    module.declare_function("js_uint8array_index_get_value", DOUBLE, &[I64, I32]);
     module.declare_function("js_uint8array_set", VOID, &[I64, I32, I32]);
     module.declare_function("js_native_arena_alloc", I64, &[I64]);
     module.declare_function("js_native_arena_view", I64, &[I64, I32, I64, I64]);
@@ -800,6 +801,7 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
     module.declare_function("js_buffer_from_arraybuffer_slice", I64, &[I64, I32, I32]);
     module.declare_function("js_buffer_length", I32, &[I64]);
     module.declare_function("js_buffer_get", I32, &[I64, I32]);
+    module.declare_function("js_buffer_index_get_value", DOUBLE, &[I64, I32]);
     module.declare_function("js_native_buffer_data_ptr", PTR, &[DOUBLE]);
     module.declare_function("js_native_buffer_byte_len", I64, &[DOUBLE]);
     // console.time/count runtime functions.

--- a/crates/perry-runtime/src/buffer/access.rs
+++ b/crates/perry-runtime/src/buffer/access.rs
@@ -171,33 +171,66 @@ unsafe fn collect_buffer_set_bytes(source: BufferSetSource, source_len: usize) -
     bytes
 }
 
-/// Get a byte at the specified index
+/// Read the byte at `index`, resolving a registered view to its ultimate
+/// backing buffer. Returns `None` for a null receiver or an out-of-range
+/// index (`index < 0` or `index >= length`). Shared by the native i32
+/// accessor (`js_buffer_get`) and the JS-value accessor
+/// (`js_buffer_index_get_value`) so their read semantics never drift.
+#[inline]
+unsafe fn read_buffer_byte(buf_ptr: *const BufferHeader, index: i32) -> Option<u8> {
+    if buf_ptr.is_null() || index < 0 || index as u32 >= (*buf_ptr).length {
+        return None;
+    }
+    // Issue #1205: if the receiver is a registered view, read from
+    // the ultimate backing buffer — otherwise the view's local
+    // snapshot can lag any direct-fast-path write made to the
+    // backing through codegen.
+    let buf_addr = buf_ptr as usize;
+    if let Some(info) = super::view::lookup(buf_addr) {
+        let back_off = info.offset + index as u32;
+        let backing_ptr = info.backing as *const BufferHeader;
+        if !backing_ptr.is_null() && back_off < (*backing_ptr).length {
+            let back_data = buffer_data(backing_ptr);
+            return Some(*back_data.add(back_off as usize));
+        }
+    }
+    let data = buffer_data(buf_ptr);
+    Some(*data.add(index as usize))
+}
+
+/// Get a byte at the specified index. Native i32 accessor: an out-of-range
+/// index yields the `0` sentinel because every caller here has proven the
+/// index in bounds or consumes the byte in a native integer context. A
+/// JS-value `buf[i]` read must instead yield `undefined` for out-of-range —
+/// use `js_buffer_index_get_value` for that (#6088).
 #[no_mangle]
 pub extern "C" fn js_buffer_get(buf_ptr: *const BufferHeader, index: i32) -> i32 {
-    if buf_ptr.is_null() || index < 0 {
-        return 0;
-    }
-    unsafe {
-        if index as u32 >= (*buf_ptr).length {
-            return 0;
-        }
-        // Issue #1205: if the receiver is a registered view, read from
-        // the ultimate backing buffer — otherwise the view's local
-        // snapshot can lag any direct-fast-path write made to the
-        // backing through codegen.
-        let buf_addr = buf_ptr as usize;
-        if let Some(info) = super::view::lookup(buf_addr) {
-            let back_off = info.offset + index as u32;
-            let backing_ptr = info.backing as *const BufferHeader;
-            if !backing_ptr.is_null() && back_off < (*backing_ptr).length {
-                let back_data = buffer_data(backing_ptr);
-                return *back_data.add(back_off as usize) as i32;
-            }
-        }
-        let data = buffer_data(buf_ptr);
-        *data.add(index as usize) as i32
+    unsafe { read_buffer_byte(buf_ptr, index).map_or(0, |byte| byte as i32) }
+}
+
+/// `buf[i]` / `uint8array[i]` read as a JS value. Perry's `Uint8Array` is
+/// Buffer-backed, so both share this accessor. An out-of-range canonical
+/// integer index reads `undefined` — the ECMAScript IntegerIndexedExotic
+/// `[[Get]]` semantics — NOT the `0` byte-sentinel of the native
+/// `js_buffer_get` (#6088). Negative and fractional keys never reach here
+/// (codegen routes them to the dynamic-key helper); an in-range read returns
+/// the byte as a plain (non-NaN) f64, which is its own NaN-boxed JS number.
+#[no_mangle]
+pub extern "C" fn js_buffer_index_get_value(buf_ptr: *const BufferHeader, index: i32) -> f64 {
+    match unsafe { read_buffer_byte(buf_ptr, index) } {
+        Some(byte) => byte as f64,
+        None => f64::from_bits(crate::value::TAG_UNDEFINED),
     }
 }
+
+// #6088: force-keep the JS-value buffer index getter under LTO /
+// auto-optimize. It has zero internal Rust callers — codegen emits the only
+// call (in `perry-codegen/src/expr/index_get.rs`), so a whole-program bitcode
+// link is otherwise free to internalize and dead-strip it. The `#[used]`
+// anchor pins it (mirrors `KEEP_JS_TYPED_ARRAY_INDEX_GET_DYNAMIC`).
+#[used]
+static KEEP_JS_BUFFER_INDEX_GET_VALUE: extern "C" fn(*const BufferHeader, i32) -> f64 =
+    js_buffer_index_get_value;
 
 /// Set a byte at the specified index
 #[no_mangle]

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -73,7 +73,8 @@ pub use u8_codec::{
 
 // ---- Re-exports: indexed access / slice / Uint8Array.set ----
 pub use access::{
-    js_buffer_get, js_buffer_set, js_buffer_set_from, js_buffer_set_from_value, js_buffer_slice,
+    js_buffer_get, js_buffer_index_get_value, js_buffer_set, js_buffer_set_from,
+    js_buffer_set_from_value, js_buffer_slice,
 };
 
 // ---- Re-exports: DataView numeric accessors (#2878) ----
@@ -323,6 +324,39 @@ mod tests {
         let buf = js_buffer_alloc(5, 0);
         js_buffer_set(buf, 2, 0x42);
         assert_eq!(js_buffer_get(buf, 2), 0x42);
+    }
+
+    /// #6088: the JS-value accessor reads `undefined` for an out-of-range
+    /// canonical index (IntegerIndexedExotic `[[Get]]`), unlike the native
+    /// `js_buffer_get` which returns the `0` byte-sentinel. In-range reads
+    /// still return the byte as a plain (non-NaN) f64 number.
+    #[test]
+    fn test_buffer_index_get_value_oob_is_undefined() {
+        let buf = js_buffer_alloc(3, 0);
+        js_buffer_set(buf, 0, 5);
+        js_buffer_set(buf, 1, 6);
+        js_buffer_set(buf, 2, 7);
+        let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+
+        // In-range: the byte value as a number (not undefined).
+        assert_eq!(js_buffer_index_get_value(buf, 0), 5.0);
+        assert_eq!(js_buffer_index_get_value(buf, 2), 7.0);
+
+        // Out-of-range and negative: undefined, NOT the 0 sentinel.
+        assert_eq!(js_buffer_index_get_value(buf, 3).to_bits(), undef.to_bits());
+        assert_eq!(js_buffer_index_get_value(buf, 9).to_bits(), undef.to_bits());
+        assert_eq!(
+            js_buffer_index_get_value(buf, -1).to_bits(),
+            undef.to_bits()
+        );
+        // The native accessor keeps its 0-for-OOB contract for its callers.
+        assert_eq!(js_buffer_get(buf, 9), 0);
+
+        // Null receiver: undefined.
+        assert_eq!(
+            js_buffer_index_get_value(std::ptr::null(), 0).to_bits(),
+            undef.to_bits()
+        );
     }
 
     #[test]

--- a/crates/perry-runtime/src/typedarray/access.rs
+++ b/crates/perry-runtime/src/typedarray/access.rs
@@ -454,6 +454,43 @@ pub extern "C" fn js_uint8array_get(target: *const TypedArrayHeader, index: i32)
     }
 }
 
+/// `uint8array[i]` / `buffer[i]` read as a JS value. Mirrors the dispatch of
+/// the native i32 accessor `js_uint8array_get` (a real Uint8Array
+/// `TypedArrayHeader`, or a Buffer-backed registered buffer), but an
+/// out-of-range canonical integer index reads `undefined` — the ECMAScript
+/// IntegerIndexedExotic `[[Get]]` semantics — NOT the `0` byte-sentinel the
+/// i32 accessor is forced to return (#6088). `js_typed_array_get` and
+/// `js_buffer_index_get_value` both already yield `undefined` for out-of-range,
+/// so each arm forwards directly.
+#[no_mangle]
+pub extern "C" fn js_uint8array_index_get_value(
+    target: *const TypedArrayHeader,
+    index: i32,
+) -> f64 {
+    let undefined = f64::from_bits(crate::value::TAG_UNDEFINED);
+    let addr = strip_nanbox(target as u64);
+    if addr < 0x1000 || index < 0 {
+        return undefined;
+    }
+    if let Some(kind) = lookup_typed_array_kind(addr) {
+        if !matches!(kind, KIND_UINT8 | KIND_UINT8_CLAMPED) {
+            return undefined;
+        }
+        js_typed_array_get(addr as *const TypedArrayHeader, index)
+    } else if crate::buffer::is_registered_buffer(addr) {
+        crate::buffer::js_buffer_index_get_value(addr as *const crate::buffer::BufferHeader, index)
+    } else {
+        undefined
+    }
+}
+
+// #6088: force-keep the JS-value Uint8Array index getter under LTO /
+// auto-optimize — it has zero internal Rust callers (codegen emits the only
+// call), so a whole-program bitcode link is otherwise free to dead-strip it.
+#[used]
+static KEEP_JS_UINT8ARRAY_INDEX_GET_VALUE: extern "C" fn(*const TypedArrayHeader, i32) -> f64 =
+    js_uint8array_index_get_value;
+
 #[no_mangle]
 pub extern "C" fn js_uint8array_set(target: *mut TypedArrayHeader, index: i32, value: i32) {
     let addr = strip_nanbox(target as u64);

--- a/crates/perry/tests/issue_6088_typed_array_oob_index_undefined.rs
+++ b/crates/perry/tests/issue_6088_typed_array_oob_index_undefined.rs
@@ -1,0 +1,163 @@
+//! Regression test for #6088: an out-of-bounds integer index of a typed array
+//! returned `0` instead of `undefined`.
+//!
+//! `ta[i]` for a canonical numeric index outside `[0, length)` must read
+//! `undefined` (ECMAScript IntegerIndexedExotic `[[Get]]`), NOT `0`. Most
+//! typed-array kinds already took the correct runtime helper (`js_typed_array_get`,
+//! OOB → `undefined`). But `Uint8Array` (and Node `Buffer`) are Buffer-backed in
+//! perry and share a distinct codegen path: for a proven non-negative integer
+//! key whose value was not proven in bounds, the fallback called the native
+//! `js_buffer_get`, whose i32 return type forces a `0` byte-sentinel for
+//! out-of-range reads — so `new Uint8Array([5,6,7])[9]` read `0`, and `typeof`
+//! was `"number"`.
+//!
+//! Fix: route that unproven-bounds slow path through a new JS-value accessor
+//! (`js_buffer_index_get_value`) that returns `undefined` for out-of-range while
+//! still returning the byte as a number for in-range reads. Negative / fractional
+//! keys already routed to the dynamic-key helper and stayed correct; the
+//! proven-bounds inline load is untouched, so in-range reads keep the fast path.
+//!
+//! Expected outputs are byte-for-byte what `node --experimental-strip-types`
+//! prints. The scan-loop case is timeout-bounded: pre-fix, a typed-array index
+//! scan whose only loop exit is an OOB `undefined` spun forever (`0 !==
+//! undefined`), so a regression FAILS (spins) instead of silently misreading.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let mut child = Command::new(&output)
+        .current_dir(dir)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn compiled binary");
+
+    let timeout = Duration::from_secs(30);
+    let start = Instant::now();
+    loop {
+        match child.try_wait().expect("try_wait") {
+            Some(status) => {
+                let out = child.wait_with_output().expect("wait_with_output");
+                assert!(
+                    status.success(),
+                    "compiled binary failed (exit {:?})\nstdout:\n{}\nstderr:\n{}",
+                    status.code(),
+                    String::from_utf8_lossy(&out.stdout),
+                    String::from_utf8_lossy(&out.stderr)
+                );
+                return String::from_utf8_lossy(&out.stdout).into_owned();
+            }
+            None => {
+                if start.elapsed() > timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    panic!(
+                        "compiled binary did not finish within {:?} — a typed-array \
+                         OOB index regressed (returns 0 not undefined)",
+                        timeout
+                    );
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        }
+    }
+}
+
+/// The core bug plus the neighbours that must stay correct: OOB integer index of
+/// a Uint8Array / Buffer is `undefined` (not `0`), in-range reads are the byte,
+/// negative / fractional keys are `undefined`, `any`-typed and variable indices
+/// still reach the fix, and the already-correct kinds (Float64/Int32/Int8/Uint16)
+/// are unaffected.
+#[test]
+fn typed_array_oob_index_is_undefined() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const u8 = new Uint8Array([5, 6, 7]);
+console.log("u8 in", u8[0], u8[2], "oob", u8[9] === undefined, typeof u8[9]);
+const k = 9;
+console.log("u8 var-oob", u8[k] === undefined);
+const anyU8: any = new Uint8Array([1, 2]);
+console.log("u8 any-oob", anyU8[5] === undefined, typeof anyU8[5]);
+const z = new Uint8Array(2);
+console.log("u8 zero", z[0], z[1], "oob", z[5] === undefined);
+console.log("u8 neg/frac", u8[-1] === undefined, u8[1.5] === undefined);
+const f64 = new Float64Array([1.5, 2.5]);
+const i32 = new Int32Array([10, 20]);
+const i8 = new Int8Array([-1, -2]);
+const u16 = new Uint16Array([300, 400]);
+console.log("f64", f64[0], f64[9] === undefined);
+console.log("i32", i32[1], i32[9] === undefined);
+console.log("i8", i8[0], i8[9] === undefined);
+console.log("u16", u16[1], u16[9] === undefined);
+const buf = Buffer.from([65, 66, 67]);
+console.log("buf", buf[0], "oob", buf[9] === undefined);
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "u8 in 5 7 oob true undefined\n\
+         u8 var-oob true\n\
+         u8 any-oob true undefined\n\
+         u8 zero 0 0 oob true\n\
+         u8 neg/frac true true\n\
+         f64 1.5 true\n\
+         i32 20 true\n\
+         i8 -1 true\n\
+         u16 400 true\n\
+         buf 65 oob true\n"
+    );
+}
+
+/// A consumer that scans a Uint8Array by index in a loop whose only exit is an
+/// out-of-bounds read comparing `=== undefined` in the loop CONDITION (the
+/// IntegerIndexedExotic `[[Get]]` value context this fix targets). Pre-fix the
+/// OOB read was `0` (`0 !== undefined`), so the loop never terminated and spun
+/// forever; the timeout bound turns a regression into a FAIL rather than a hang.
+#[test]
+fn typed_array_scan_loop_terminates_on_oob() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+function scanU8(a: Uint8Array): number {
+  const out: number[] = [];
+  let i = 0;
+  while (a[i] !== undefined) {
+    out.push(a[i] as number);
+    i++;
+  }
+  return out.length;
+}
+console.log("scan", scanU8(new Uint8Array([1, 2, 3, 4])));
+"#,
+    );
+    assert_eq!(stdout, "scan 4\n");
+}


### PR DESCRIPTION
Fixes #6088.

## Problem

An out-of-range canonical integer index of a `Uint8Array` / `Buffer` read the `0` byte-sentinel instead of `undefined`:

```ts
new Uint8Array([5, 6, 7])[9]         // was 0,        should be undefined
typeof new Uint8Array([5, 6, 7])[9]  // was "number", should be "undefined"
Buffer.from([65, 66, 67])[9]         // was 0,        should be undefined
```

Per the ECMAScript IntegerIndexedExotic `[[Get]]`, a canonical numeric index outside `[0, length)` reads `undefined`.

## Root cause

Perry's `Uint8Array` is Buffer-backed, so `u8[i]` / `buf[i]` lower (as `Expr::Uint8ArrayGet` / `Expr::BufferIndexGet`, or the generic `is_uint8array_receiver` `IndexGet`) to the native i32 accessors `js_uint8array_get` / `js_buffer_get`. Their `i32` return type cannot represent `undefined`, so every out-of-range read is forced to `0`.

The other typed-array kinds (`Float64Array`, `Int32Array`, …) already route through `js_typed_array_get`, which returns `undefined` for out-of-range — so only the Buffer-backed `Uint8Array` / `Buffer` path was affected. Negative and fractional keys already routed to `js_typed_array_index_get_dynamic` and were correct; only a clean **positive** integer key past the end hit the buggy i32 fallback.

## Fix

Add JS-value (NaN-boxed f64) accessors that return `undefined` for out-of-range and the byte as a number in range:

- `js_buffer_index_get_value` (`BufferHeader`) — shares `js_buffer_get`'s exact, view-registry-aware read logic through a new `read_buffer_byte` helper, so the two never drift.
- `js_uint8array_index_get_value` — mirrors `js_uint8array_get`'s dispatch (a real `Uint8Array` `TypedArrayHeader` → the already-OOB-correct `js_typed_array_get`; a Buffer-backed registered buffer → `js_buffer_index_get_value`).

Codegen routes the **unproven-bounds slow path** of the `Uint8ArrayGet`, `BufferIndexGet`, and generic `is_uint8array_receiver` `IndexGet` lowerings through these getters. Preserved:

- **In-range fast path** — the proven-bounds inline `getelementptr`/`load` is untouched.
- **Negative / fractional keys** — still `undefined` via the dynamic-key helper.
- **Native i32 callers** — `js_uint8array_get` / `js_buffer_get` keep their `0`-sentinel contract for their many native-context byte-loop callers (atomics, hashing, buffer copy, …).

## Tests

- Runtime unit test `test_buffer_index_get_value_oob_is_undefined` (in-range byte; OOB / negative / null → `undefined`; the native accessor still returns `0`).
- E2E `issue_6088_typed_array_oob_index_undefined`, output byte-for-byte matching `node`: OOB / negative / fractional / any-typed / variable-index / `new Uint8Array(2)` / `Buffer` all `undefined`, in-range reads correct, and `Float64Array` / `Int32Array` / `Int8Array` / `Uint16Array` unaffected. Includes a timeout-bounded value-context scan loop that spun forever pre-fix (`0 !== undefined`).

`cargo test -p perry-runtime` is green (including the new unit test).

## Out of scope

A local *committed to an integer representation* that is then compared to `undefined` — e.g. `const v: number = a[i]; if (v === undefined) …; sum += v;` — is a separate representation-inference concern (`is_strictly_i32_bounded_expr` treats `Uint8ArrayGet` as strictly-i32), not the value-context `[[Get]]` semantics this PR fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Out-of-bounds reads on `Uint8Array` and `Buffer` using indexed access (`arr[i]`) now evaluate to `undefined` (matching JavaScript), rather than `0`.
  * Negative and non-integer indexing continues to return `undefined`.
* **Tests**
  * Added regression tests verifying `undefined` for out-of-range indices and correct in-range byte values.
  * Added a timeout-protected scan-loop test to ensure code terminates when checking for `undefined`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->