### PR TITLE
fix(runtime): own_key_present must not OOB-read keys_array on non-object (Map/Set) receivers

### DIFF
--- a/crates/perry-runtime/src/object/object_ops/keys_array.rs
+++ b/crates/perry-runtime/src/object/object_ops/keys_array.rs
@@ -160,6 +160,23 @@ pub(crate) unsafe fn own_key_present(
     if obj.is_null() || (obj as usize) < 0x10000 || (obj as usize) & 0x7 != 0 || key.is_null() {
         return false;
     }
+    // Only a genuine `GC_TYPE_OBJECT` carries a `keys_array` at ObjectHeader
+    // offset 16. A non-object receiver that still cleared the alignment/range
+    // guard above — most importantly a real `Map`/`Set`, whose 16-byte header
+    // is only `size`/`capacity`/`entries` — has no such field, so reading
+    // `(*obj).keys_array` loads 8 bytes past the header into the adjacent
+    // allocation. A `Map` reaching `js_object_get_field_by_name`'s `.size`
+    // fast path (an `any`-typed `map.size` dispatched by name) did exactly
+    // that: the out-of-bounds word was a live neighbour's GC-header value,
+    // which cleared the keys-pointer guard below and then SIGBUS'd on the
+    // `[keys-8]` type-tag read. `try_read_gc_header` rejects header-less slab
+    // allocations and non-heap addresses without dereferencing them. A
+    // non-object has no own string keys, so answer false and let the caller
+    // fall through to the type-specific tail (which serves e.g. `Map.size`).
+    match crate::value::addr_class::try_read_gc_header(obj as usize) {
+        Some(h) if h.obj_type == crate::gc::GC_TYPE_OBJECT => {}
+        _ => return false,
+    }
     let keys = (*obj).keys_array;
     if keys.is_null() {
         return false;

--- a/crates/perry-runtime/src/object/tests.rs
+++ b/crates/perry-runtime/src/object/tests.rs
@@ -1029,3 +1029,40 @@ fn class_capture_value_or_rejects_tag_stripped_fallback() {
     assert!(fallback_is_tag_stripped(stripped));
     assert!(!fallback_is_tag_stripped(undef));
 }
+
+/// Reading `.size` on a `Map` *by name* — the shape a minified bundle produces
+/// when the receiver's `Map` type is erased to `any` (`map.size` dispatched
+/// through `js_object_get_field_by_name`) — reaches the `.size` fast path,
+/// which calls `own_key_present(map, "size")`. A `MapHeader` is 16 bytes
+/// (`size`/`capacity`/`entries`) with no `keys_array` field at offset 16, so
+/// `(*obj).keys_array` used to read 8 bytes past the header into the adjacent
+/// allocation; that stray word cleared the keys-pointer alignment/range guard
+/// and then SIGBUS'd on the `[keys-8]` GC-type-tag load. `own_key_present` now
+/// answers `false` for a non-`GC_TYPE_OBJECT` receiver, so the read falls
+/// through to the `Map.size` tail instead of dereferencing garbage.
+#[test]
+fn map_size_by_name_does_not_oob_read_keys_array() {
+    unsafe {
+        let size_key = crate::string::js_string_from_bytes(b"size".as_ptr(), 4);
+
+        // Empty Map — the exact shape observed crashing (size 0).
+        let empty = crate::map::js_map_alloc(4);
+        assert!(!empty.is_null());
+        // The precise frame that faulted: a Map is not an object, so it has no
+        // own string key. This must answer false without dereferencing
+        // `[obj+16]` past the 16-byte MapHeader.
+        assert!(!own_key_present(empty as *mut ObjectHeader, size_key));
+        let v0 = crate::object::js_object_get_field_by_name(empty as *const ObjectHeader, size_key);
+        assert!(v0.is_number(), "empty Map .size must be a number");
+        assert_eq!(v0.as_number(), 0.0, "empty Map .size");
+
+        // Populated Map — `.size` by name must still return the real size.
+        let m = crate::map::js_map_alloc(4);
+        crate::map::js_map_set(m, 10.0, 100.0);
+        crate::map::js_map_set(m, 20.0, 200.0);
+        assert!(!own_key_present(m as *mut ObjectHeader, size_key));
+        let v2 = crate::object::js_object_get_field_by_name(m as *const ObjectHeader, size_key);
+        assert!(v2.is_number(), "populated Map .size must be a number");
+        assert_eq!(v2.as_number(), 2.0, "populated Map .size");
+    }
+}

--- a/crates/perry/tests/issue_map_size_by_name_oob.rs
+++ b/crates/perry/tests/issue_map_size_by_name_oob.rs
@@ -1,0 +1,91 @@
+//! Regression: reading `.size` on a `Map` whose static type has been erased to
+//! `any` — as a minified/bundled program produces when a `Map` flows through a
+//! dynamically-dispatched `getX(): any` call — dispatched the read *by name*
+//! through `js_object_get_field_by_name`. Its `class X extends Map|Set` `.size`
+//! fast path calls `own_key_present(map, "size")`, which read `(*obj).keys_array`
+//! at `ObjectHeader` offset 16. A `MapHeader` is only 16 bytes
+//! (`size`/`capacity`/`entries`) with no `keys_array` field, so that load went
+//! out of bounds into the adjacent allocation; when the stray word was a live
+//! neighbour's GC-header value it cleared the keys-pointer guard and then
+//! SIGBUS'd on the `[keys-8]` GC-type-tag read.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary crashed (Bug: OOB keys_array read on a Map receiver)\n\
+         status: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+#[test]
+fn any_typed_map_size_by_name_does_not_crash() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+function makeManager(): any {
+  const q = new Map<string, { state: string }>();
+  const b = new Map<string, number>();
+  const c = new Map<string, number>();
+  q.set("s1", { state: "running" });
+  q.set("s2", { state: "error" });
+  function getAllServers() { return q; }
+  function count() { return b.size + c.size; }
+  return { getAllServers, count };
+}
+let mgr: any;
+function getManager(): any { return mgr; }
+function anyEnabled(): boolean {
+  const m = getManager();
+  if (!m) return false;
+  const servers = m.getAllServers(); // `any`: the Map's static type is erased
+  if (servers.size === 0) return false; // by-name `.size` read on a Map
+  for (const s of servers.values()) if (s.state !== "error") return true;
+  return false;
+}
+console.log("first", anyEnabled());
+mgr = makeManager();
+console.log("size", getManager().getAllServers().size);
+console.log("second", anyEnabled());
+console.log("done");
+"#,
+    );
+    assert!(stdout.contains("first false"), "first: {stdout}");
+    assert!(stdout.contains("size 2"), "map .size by name: {stdout}");
+    assert!(stdout.contains("second true"), "second: {stdout}");
+    assert!(stdout.contains("done"), "reached end: {stdout}");
+}


### PR DESCRIPTION
## Problem

`own_key_present(obj, key)` (the object own-property probe behind `hasOwnProperty`,
`Object.values`/`entries`, `Reflect.has`, and the `js_object_get_field_by_name`
`.size` / `.then` fast paths) reads `(*obj).keys_array` at `ObjectHeader` offset 16
after only a null / alignment / address-range guard — it never checks the receiver
is actually a `GC_TYPE_OBJECT`.

When a non-`ObjectHeader` receiver reaches it — most importantly a real `Map`/`Set`,
whose header is 16 bytes (`size` / `capacity` / `entries`) with no `keys_array`
field — that load reads 8 bytes past the header into the adjacent allocation.

The reachable path is `js_object_get_field_by_name`'s `class X extends Map|Set`
`.size` fast path: an `any`-typed `map.size` — as produced when a `Map`'s static
type is erased through a dynamically-dispatched `getX(): any` call (heavily
minified / bundled code) — is dispatched *by name*, hits
`name == "size" && !own_key_present(obj, key)`, and `own_key_present` dereferences
`[obj+16]`. When the out-of-bounds word is a live neighbour's GC-header value it
clears the keys-pointer alignment/range guard below and then faults on the
`[keys-8]` GC-type-tag read (`ldurb w8,[x20,#-8]; cmp #1`, EXC_BAD_ACCESS at
`0x18000002xx`). Observed as an intermittent SIGBUS on `map.size` reads in large
bundles once a neighbouring object populated the adjacent slot.

## Fix

Gate the `keys_array` read on the receiver being `GC_TYPE_OBJECT`, using the
existing `try_read_gc_header` helper (which safely rejects header-less slab
allocations and non-heap addresses without dereferencing them). Arrays / strings
/ closures already have their own `array_own_key_present` /
`string_primitive_own_key_present` / `closure_own_key_present`, so a `keys_array`
scan only ever makes sense for a genuine object.

**No regression for `Map.size`.** For a plain `Map`, `own_key_present` now returns
`false`, so the `.size` block's `!own_key_present` is true, then
`js_object_get_class_id(map) == 0` (it rejects registered maps),
`subclass_backing_of(map) == None` (`instance_object_ptr` rejects `is_registered_map`),
the block falls through, and `get_field_by_name_tail`'s `GC_TYPE_MAP` arm returns
`js_map_size(m)` — the correct size. `class X extends Map|Set` instances are
`GC_TYPE_OBJECT` (they carry an `ObjectHeader` + backing collection), so their
real own `keys_array` is still scanned.

## Repro

```ts
function makeManager(): any {
  const q = new Map<string, { state: string }>();
  q.set("s1", { state: "running" });
  function getAllServers() { return q; }
  return { getAllServers };
}
let mgr: any;
function getManager(): any { return mgr; }
mgr = makeManager();
console.log(getManager().getAllServers().size); // SIGBUS before, `1` after
```

## Tests

- `crates/perry-runtime` unit test `map_size_by_name_does_not_oob_read_keys_array`
  (asserts `own_key_present` + by-name `.size` on empty and populated Maps).
- e2e compile+run regression `issue_map_size_by_name_oob.rs`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash risk when reading `.size` from `Map` values in edge cases, preventing invalid memory access and ensuring the correct result is returned.
  * Improved handling of property lookups so non-object receivers are safely rejected instead of being treated like objects.
* **Tests**
  * Added regression coverage for `.size` access on `Map` values, including empty and populated cases.
  * Added an end-to-end test to confirm the compiled program runs successfully and prints the expected output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->