### PR TITLE
fix(runtime): any-typed Headers/collection-handle .keys()/.entries()/.values() returned empty

### DIFF
--- a/crates/perry-runtime/src/array/iter_object.rs
+++ b/crates/perry-runtime/src/array/iter_object.rs
@@ -237,6 +237,45 @@ unsafe fn collection_iter_obj_for_receiver(arr: *const ArrayHeader, kind: u8) ->
     if raw < 0x10000 {
         return None;
     }
+    // Web Fetch collection handles (Headers / FormData / URLSearchParams) are
+    // fetch-band ids, not heap `ArrayHeader`s. An any-typed
+    // `.keys()`/`.entries()`/`.values()` on such a handle — the static type
+    // erased through an object property or destructure, e.g. an SDK
+    // auth-header wrapper's `{ values: Headers }` consumed via
+    // `let { values: z } = wrapper; ...z.entries()` — folds to
+    // `Expr::Array{Keys,Entries,Values}` (perry-hir #597 any-typed catch-all)
+    // and lands here. Reading the handle id as an `ArrayHeader` yields an
+    // empty iterator; route through the dynamic method dispatch instead so it
+    // reaches the stdlib fetch handlers (`js_headers_{keys,entries,values}`,
+    // which return a materialized, iterable array). A fetch handle that lacks
+    // the requested iterator method (Response / Request / Blob) returns
+    // `undefined`; fall through to the empty-array path then.
+    if (crate::value::addr_class::FETCH_HANDLE_BAND_START
+        ..crate::value::addr_class::FETCH_HANDLE_BAND_END)
+        .contains(&raw)
+    {
+        let recv = f64::from_bits(JSValue::pointer(arr as *const u8).bits());
+        let method: &[u8] = match kind {
+            1 => b"keys",
+            2 => b"entries",
+            _ => b"values",
+        };
+        let result = crate::object::js_native_call_method(
+            recv,
+            method.as_ptr() as *const i8,
+            method.len(),
+            std::ptr::null(),
+            0,
+        );
+        let rv = JSValue::from_bits(result.to_bits());
+        if !rv.is_undefined() && !rv.is_null() {
+            let ptr = (result.to_bits() & 0x0000_FFFF_FFFF_FFFF) as i64;
+            if ptr != 0 {
+                return Some(ptr);
+            }
+        }
+        return None;
+    }
     if crate::map::is_registered_map(raw) {
         let m = raw as *const crate::map::MapHeader;
         return Some(match kind {

--- a/crates/perry/tests/issue_any_typed_collection_handle_iterator.rs
+++ b/crates/perry/tests/issue_any_typed_collection_handle_iterator.rs
@@ -1,0 +1,101 @@
+//! Regression: any-typed `.keys()` / `.entries()` / `.values()` on a Web
+//! `Headers` returned an EMPTY iterator, while `.has()` / `.get()` and the
+//! computed form `headers["keys"]()` worked.
+//!
+//! Root cause: perry-hir's #597 catch-all folds an any-typed
+//! `.keys()`/`.entries()`/`.values()` call to `Expr::Array{Keys,Entries,Values}`
+//! (so any-typed *real* arrays iterate correctly through the index-based for-of
+//! lowering). A `Headers` instance is a fetch-band registry **handle**, not a
+//! heap `ArrayHeader`, so `js_array_{keys,entries,values}_iter_obj` read the
+//! handle id as an array length and yielded nothing.
+//!
+//! Impact: a large bundled SDK builds auth headers, wraps them as
+//! `{ values: Headers }`, and merges via `yield* wrapper.values.entries()`.
+//! Because `wrapper.values` is any-typed, `.entries()` folded to `ArrayEntries`
+//! → empty → every auth header was silently dropped → the request failed its
+//! `validateHeaders` check with "Could not resolve authentication method".
+//!
+//! Fix: `collection_iter_obj_for_receiver`
+//! (`perry-runtime/src/array/iter_object.rs`) already routes Map/Set receivers
+//! to their iterators; it now also routes fetch-band handles
+//! (`Headers`/`FormData`/`URLSearchParams`) through `js_native_call_method` →
+//! `js_headers_{keys,entries,values}`, which return a materialized, iterable
+//! array. Non-collection fetch handles (Response/Request/Blob) and genuine
+//! plain objects still fall through to the empty-array path.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary exited non-zero: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).trim().to_string()
+}
+
+/// A `Headers` whose static type is erased through an object property / an
+/// `any` boundary must still iterate via `.keys()`/`.entries()`/`.values()`
+/// and `yield*` delegation — matching Node — not return an empty iterator.
+#[test]
+fn any_typed_headers_iterator_methods_return_entries() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = compile_and_run(
+        dir.path(),
+        r#"
+function anyOf(x: any): any { return x; }
+const h = new Headers();
+h.append("x-api-key", "secret");
+h.append("content-type", "application/json");
+// Type erased through a wrapper property — the shape that dropped auth headers.
+const z: any = anyOf({ values: h }).values;
+
+const keys = [...z.keys()].sort();
+const values = [...z.values()].sort();
+let entryCount = 0;
+for (const _e of z.entries()) entryCount++;
+// `yield*` delegation over the any-typed entries (the exact SDK merge shape).
+function* deleg(hh: any) { yield* hh.entries(); }
+const delegCount = [...deleg(z)].length;
+
+console.log(
+  "keys=" + JSON.stringify(keys) +
+  " values=" + JSON.stringify(values) +
+  " entries=" + entryCount +
+  " deleg=" + delegCount +
+  " has=" + z.has("x-api-key")
+);
+"#,
+    );
+    assert_eq!(
+        out,
+        r#"keys=["content-type","x-api-key"] values=["application/json","secret"] entries=2 deleg=2 has=true"#,
+    );
+}


### PR DESCRIPTION
An any-typed `.keys()`/`.entries()`/`.values()` call folds to the array-only `Expr::Array{Keys,Entries,Values}` (perry-hir #597, so any-typed *real* arrays iterate through the index-based for-of lowering). The runtime helpers behind those (`js_array_{keys,entries,values}_iter_obj`) read the receiver as a heap `ArrayHeader`.

A Web `Headers` (and `FormData` / `URLSearchParams`) instance is a **fetch-band registry handle**, not an `ArrayHeader`. So an any-typed iterator method on such a handle read the handle id as an array length and yielded an **empty iterator** — while `.has()`/`.get()` (dynamic dispatch) and the computed `headers["keys"]()` form worked correctly.

### Impact
A large esbuild-bundled CLI app builds request headers, wraps them as `{ values: Headers }`, and merges them via `yield* wrapper.values.entries()`. Because `wrapper.values` is any-typed, `.entries()` folded to `ArrayEntries` -> empty -> every header (including auth) was silently dropped, and the request failed its SDK `validateHeaders` check ("Could not resolve authentication method"). With this fix the credential reaches the wire (verified: the compiled app opens a TLS connection to the API and sends the authenticated request).

### Fix
`collection_iter_obj_for_receiver` (`perry-runtime/src/array/iter_object.rs`) already routes `Map`/`Set` receivers to their iterators. Route fetch-band handles through `js_native_call_method` -> `js_headers_{keys,entries,values}` (which return a materialized, iterable array) as well. Non-collection fetch handles (Response/Request/Blob) and genuine plain objects still fall through to the empty-array path.

### Test
`crates/perry/tests/issue_any_typed_collection_handle_iterator.rs` — an any-typed `Headers` (type erased through an object property) iterates via `.keys()`/`.entries()`/`.values()` and `yield*` delegation, byte-for-byte matching Node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed iterator behavior for `Headers`, `FormData`, and `URLSearchParams` when accessed through erased or generic object references.
  * `.keys()`, `.values()`, and `.entries()` now return proper iterable results instead of falling back to empty iteration in these cases.
  * Improved support for delegation patterns like `yield*` with these collection iterators.
  
* **Tests**
  * Added coverage for iterator behavior on `Headers` when used through an `any` boundary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->