### PR TITLE
fix(codegen): #6039 over-filtered module_local_types — 17 test262 regressions from swallowed receiver-typed throws

### DIFF
--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -1775,15 +1775,33 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
     // closure through `@perry_global_*`, NOT the closure's capture array —
     // `closure.rs` filters module globals OUT of `closure_captures`, so the
     // closure is `alloc_singleton` with no capture slots. But advertising the
-    // local's type here made the typed-ABI specialization
-    // (`__typed_f64`/i32/…) read `js_closure_get_capture_bits(this, 0)` — an
-    // UNSET slot (0) — while the generic variant correctly loads the global;
-    // the dispatcher picked the typed body, so every closure returned 0.
-    // Repro (bisected to #5466 representation lowering):
+    // local's type to the typed-ABI closure specialization
+    // (`__typed_f64`/i32/…) made it read `js_closure_get_capture_bits(this,
+    // 0)` — an UNSET slot (0) — while the generic variant correctly loads the
+    // global; the dispatcher picked the typed body, so every closure returned
+    // 0. Repro (bisected to #5466 representation lowering):
     //   for (let i=0;i<5;i++){ const c=i; fns.push(()=>c); }  // → 0,0,0,0,0
     // A module-global capture has no capture-slot representation, so — like a
-    // boxed slot — it must not feed the type-directed unboxed capture path.
-    module_local_types.retain(|id, _| !module_globals.contains_key(id));
+    // boxed slot — it must not feed the type-directed unboxed *capture* path.
+    //
+    // #6039 originally stripped these ids from `module_local_types` outright,
+    // but that map is ALSO the receiver-type oracle for every function body
+    // (`FnCtx.local_types` → `static_type_of` / `is_array_expr`). Dropping a
+    // module-global's declared type there mis-classified a captured array
+    // receiver as untyped inside a closure, so `arr.every()` (undefined
+    // callbackfn) fell to the generic dynamic dispatch that skips the
+    // `js_validate_array_callback` throw — the test262 harness's
+    // `assert.throws(TypeError, () => arr.every())` then saw no exception
+    // (24 regressions: Array HOF + symbol-strict [[Set]], all via harness
+    // closures). Only the typed-ABI *specialization* decision needs the
+    // module-globals removed, so scope the filter to a dedicated copy and
+    // leave `module_local_types` (the receiver oracle) module-global-inclusive.
+    let typed_abi_local_types: std::collections::HashMap<u32, perry_types::Type> =
+        module_local_types
+            .iter()
+            .filter(|(id, _)| !module_globals.contains_key(id))
+            .map(|(id, ty)| (*id, ty.clone()))
+            .collect();
 
     // Cross-module function declares are emitted lazily by `lower_call`
     // via `FnCtx.pending_declares` (drained back into `llmod` at the
@@ -1815,7 +1833,8 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
     cross_module.typed_string_closure_capture_counts.clear();
     cross_module.typed_i1_closure_param_reps.clear();
     for (func_id, expr) in &closures {
-        match typed_abi::typed_f64_closure_rejection_reason_with_types(expr, &module_local_types) {
+        match typed_abi::typed_f64_closure_rejection_reason_with_types(expr, &typed_abi_local_types)
+        {
             None => {
                 cross_module.typed_f64_closures.insert(*func_id);
                 if let perry_hir::Expr::Closure { params, .. } = expr {
@@ -1844,7 +1863,8 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
                 ],
             ),
         }
-        match typed_abi::typed_i1_closure_rejection_reason_with_types(expr, &module_local_types) {
+        match typed_abi::typed_i1_closure_rejection_reason_with_types(expr, &typed_abi_local_types)
+        {
             None => {
                 cross_module.typed_i1_closures.insert(*func_id);
                 if let perry_hir::Expr::Closure { params, .. } = expr {
@@ -1873,7 +1893,8 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
                 ],
             ),
         }
-        match typed_abi::typed_i32_closure_rejection_reason_with_types(expr, &module_local_types) {
+        match typed_abi::typed_i32_closure_rejection_reason_with_types(expr, &typed_abi_local_types)
+        {
             None => {
                 cross_module.typed_i32_closures.insert(*func_id);
                 if let perry_hir::Expr::Closure { params, .. } = expr {
@@ -1902,8 +1923,10 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
                 ],
             ),
         }
-        match typed_abi::typed_string_closure_rejection_reason_with_types(expr, &module_local_types)
-        {
+        match typed_abi::typed_string_closure_rejection_reason_with_types(
+            expr,
+            &typed_abi_local_types,
+        ) {
             None => {
                 cross_module.typed_string_closures.insert(*func_id);
                 if let perry_hir::Expr::Closure { params, .. } = expr {
@@ -1914,7 +1937,7 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
                     }
                 }
                 let capture_count =
-                    typed_abi::typed_string_closure_capture_reps(expr, &module_local_types)
+                    typed_abi::typed_string_closure_capture_reps(expr, &typed_abi_local_types)
                         .map(|captures| captures.len())
                         .unwrap_or(0);
                 cross_module


### PR DESCRIPTION
## Summary

A consolidation test262 sweep found the recent mechanism-PR wave shipped 24 regressions (net was still +16, but 24 previously-passing cases now failed). Bisected the dominant clusters to a single culprit and forward-fixed it.

**Culprit:** `09f2f24895` (#6039) — *"fix(codegen): #5982 — module-global captures must not feed the typed-ABI closure specialization"*.

## Root cause

`#6039` correctly stopped a closure that captures a **module-global** local (read via `@perry_global_*`, not the capture array) from feeding the typed-ABI closure specialization — which otherwise read an unset capture slot and returned 0 (`for(let i…){const c=i; fns.push(()=>c)}` → `0,0,0,0,0`).

It did so by stripping every module-global id out of `module_local_types`. But that map is used for **two** distinct purposes in `compile_module`:

1. the typed-ABI closure-clone **decision** (`typed_{f64,i1,i32,string}_closure_rejection_reason_with_types`), and
2. the per-function-body **receiver-type oracle** — it is handed to `emit_module_artifacts` → `FnCtx.local_types`, which drives `static_type_of` / `is_array_expr`.

Removing a module-global's declared type from (2) mis-classified a captured **array** receiver as untyped *inside a closure*. `arr.every()` with an undefined `callbackfn` then lowered to the generic dynamic method dispatch (`js_arraylike_*`) instead of the array-typed path that emits `js_validate_array_callback`, so the mandatory `TypeError` was never thrown.

The test262 harness runs every negative case as `assert.throws(TypeError, function () { … })` — a module-level closure that captures the module-global under test — so the swallowed throw surfaced as 24 conformance regressions:

- **8 Array HOF** callbackfn-not-callable cases (`every`/`filter`/`forEach`/`map`/`reduce`/`reduceRight`/`some` `15.4.4.*-4-1`)
- **3 symbol-strict [[Set]]** cases (`Object.defineProperty`/`freeze`/`seal` `*-strict`: `obj[sym]=2` on a non-writable prop must throw)
- **4 private-async-method**, **1 Proxy set**, **2 Temporal `Instant` limits** — all reach the same harness-closure path.

## Fix

Keep the module-globals filter scoped to the typed-ABI specialization **only**. Build a dedicated `typed_abi_local_types` (module-locals minus module-globals) and feed it to the four closure-clone decisions and the capture-rep probe; leave `module_local_types` (the receiver oracle passed to `emit_module_artifacts`) module-global-**inclusive**.

Decision and emission never disagree: the emission side (`compile_typed_*_closure`) is only reached for closures the decision accepted, and a closure capturing a module-global is always rejected by the decision (its capture type is absent from `typed_abi_local_types`, so `typed_closure_capture_reps` returns `None`). So `#5982`'s win holds — `for(let i…){const c=i; fns.push(()=>c)}` still returns `0,1,2,3,4`, not `0,0,0,0,0`.

## Verification (internal Linux sweep host)

- Bisected `8e303627e` (GOOD, #6024 baseline: witness 10/10) → `c5246ece6` (BAD: 0/10) to `09f2f24895` (#6039). The originally-suspected `[[Set]]` PRs `#6059`/`#6063` were cleared: the witness already fails at their common parent.
- Minimal repro: `assert.throws`-style closure capturing a module-global `arr` now throws again (`CAUGHT`); `#5982` guard held (`0,1,2,3,4`).
- **Witness slice restored to 10/10** (8 Array HOF + 3 symbol-strict; the 11th shares the Object cluster).
- **Focused differential sweep** (`built-ins/Array` + `Object` + `TypedArrayConstructors` + `Reflect` + `Proxy`, jobs=4) vs the GOOD baseline:
  - **NEW regressions: 0**
  - FIXED: 4 — including the `TypedArrayConstructors/internals/Set/…/key-is-valid-index-reflect-set.js` (+ BigInt variant) **mechanism-PR wins from #6059/#6063 preserved**.
  - `defineProperty/freeze/seal` symbol-strict + Array-HOF + Proxy-set witness cases all PASS.

## Scope note

7 of the 24 flagged cases (`annexB createdynfn`, `Function`/`GeneratorFunction` `instance-length`, `S15.3*`) are a **separate, intentional** trade-off from `#6031` (`new Function("")` capability probe now honestly reports dynamic-codegen unavailable so zod 4 et al. take the interpreter fallback; opt-out `PERRY_EVAL_CSP=0`). Not attributable to the bisected culprit and out of scope here.

## Files

- `crates/perry-codegen/src/codegen/mod.rs` — scope the module-globals filter to the typed-ABI specialization; keep the receiver oracle module-global-inclusive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved closure handling for values defined at module scope, so they can be captured and specialized more reliably.
  * Fixed cases where typed closures could be missed or treated inconsistently when they referenced module-level values.
  * Strengthened support for optimized closure behavior across several data types, with more consistent runtime results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->