### PR TITLE
chore(deps): bump crossbeam-epoch 0.9.18 -> 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v0.5.1255 — chore(deps): bump crossbeam-epoch 0.9.18 → 0.9.20 (RUSTSEC-2026-0204)
+
+RUSTSEC-2026-0204 (published 2026-07-06) flags crossbeam-epoch < 0.9.20 for an
+invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared`
+when the underlying pointer is invalid. crossbeam-epoch is a transitive dep
+(rayon → crossbeam-deque), so this is a `Cargo.lock`-only bump — no manifest
+changes. The advisory was failing the required `security-audit` check on every
+open PR (first seen on #6097/#6098).
+
 ## v0.5.1254 — metadata catch-up fold (PRs #6036–#6054)
 
 Consolidated version bump documenting the code-only merges that landed on `main` since v0.5.1240. Each PR carries its own detailed rationale in its description and commit body.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1254
+**Current Version:** 0.5.1255
 
 
 ## TypeScript Parity Status

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,9 +1428,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -5338,7 +5338,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "perry"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "anyhow",
  "base64",
@@ -5395,14 +5395,14 @@ dependencies = [
 
 [[package]]
 name = "perry-api-manifest"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "perry-audio-miniaudio"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "cc",
  "libc",
@@ -5410,7 +5410,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "anyhow",
  "log",
@@ -5425,7 +5425,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-arkts"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5434,7 +5434,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-glance"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5442,7 +5442,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-js"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "anyhow",
  "perry-dispatch",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-swiftui"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5461,7 +5461,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wasm"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "anyhow",
  "base64",
@@ -5474,7 +5474,7 @@ dependencies = [
 
 [[package]]
 name = "perry-codegen-wear-tiles"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -5482,7 +5482,7 @@ dependencies = [
 
 [[package]]
 name = "perry-container-compose"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5511,14 +5511,14 @@ dependencies = [
 
 [[package]]
 name = "perry-container-e2e"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "perry-diagnostics"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "serde",
  "serde_json",
@@ -5526,7 +5526,7 @@ dependencies = [
 
 [[package]]
 name = "perry-dispatch"
-version = "0.5.1254"
+version = "0.5.1255"
 
 [[package]]
 name = "perry-doc-fixture-my-bindings"
@@ -5537,7 +5537,7 @@ dependencies = [
 
 [[package]]
 name = "perry-doc-tests"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "anyhow",
  "clap",
@@ -5552,7 +5552,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ads"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "block2",
  "objc2",
@@ -5562,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-argon2"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "argon2",
  "perry-ffi",
@@ -5570,7 +5570,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-axios"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "perry-ffi",
  "reqwest",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-bcrypt"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "bcrypt",
  "perry-ffi",
@@ -5587,7 +5587,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-better-sqlite3"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "perry-ffi",
  "rusqlite",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cheerio"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "perry-ffi",
  "scraper",
@@ -5603,7 +5603,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-commander"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5611,7 +5611,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-cron"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "chrono",
  "cron",
@@ -5621,7 +5621,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dayjs"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5629,7 +5629,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-decimal"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "perry-ffi",
  "rust_decimal",
@@ -5637,7 +5637,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-dotenv"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "perry-ffi",
  "serde_json",
@@ -5645,7 +5645,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ethers"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "perry-ffi",
  "rand 0.8.6",
@@ -5653,7 +5653,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-events"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "perry-ffi",
  "perry-runtime",
@@ -5661,14 +5661,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-exponential-backoff"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-fastify"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "bytes",
  "http-body-util",
@@ -5686,7 +5686,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-fetch"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "bytes",
  "lazy_static",
@@ -5713,7 +5713,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-http-server"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "bytes",
  "h2",
@@ -5736,7 +5736,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ioredis"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-jsonwebtoken"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -5757,7 +5757,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-lru-cache"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "lru",
  "perry-ffi",
@@ -5765,7 +5765,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-moment"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mongodb"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "bson",
  "futures-util",
@@ -5785,7 +5785,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-mysql2"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "chrono",
  "perry-ffi",
@@ -5795,7 +5795,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nanoid"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "nanoid",
  "perry-ffi",
@@ -5804,7 +5804,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-net"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "bytes",
  "perry-ffi",
@@ -5817,7 +5817,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-nodemailer"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "lettre",
  "perry-ffi",
@@ -5827,7 +5827,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pdf"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "perry-ffi",
  "printpdf",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-pg"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "perry-ffi",
  "sqlx",
@@ -5844,7 +5844,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ratelimit"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "governor",
  "perry-ffi",
@@ -5852,7 +5852,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-sharp"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "fast_image_resize",
  "image",
@@ -5862,14 +5862,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-slugify"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "perry-ffi",
 ]
 
 [[package]]
 name = "perry-ext-streams"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "lazy_static",
  "perry-ffi",
@@ -5878,7 +5878,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-uuid"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "perry-ffi",
  "uuid",
@@ -5886,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-validator"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "perry-ffi",
  "regex",
@@ -5896,7 +5896,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-ws"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "futures-util",
  "lazy_static",
@@ -5908,7 +5908,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ext-zlib"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "brotli",
  "flate2",
@@ -5917,7 +5917,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ffi"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "dashmap",
  "once_cell",
@@ -5926,7 +5926,7 @@ dependencies = [
 
 [[package]]
 name = "perry-hir"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "anyhow",
  "perry-api-manifest",
@@ -5944,7 +5944,7 @@ dependencies = [
 
 [[package]]
 name = "perry-parser"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "anyhow",
  "perry-diagnostics",
@@ -5956,7 +5956,7 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "anyhow",
  "base64",
@@ -5989,14 +5989,14 @@ dependencies = [
 
 [[package]]
 name = "perry-runtime-static"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "perry-runtime",
 ]
 
 [[package]]
 name = "perry-stdlib"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",
@@ -6089,14 +6089,14 @@ dependencies = [
 
 [[package]]
 name = "perry-stdlib-static"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "perry-stdlib",
 ]
 
 [[package]]
 name = "perry-transform"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "anyhow",
  "perry-hir",
@@ -6106,7 +6106,7 @@ dependencies = [
 
 [[package]]
 name = "perry-types"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "anyhow",
  "thiserror 1.0.69",
@@ -6114,14 +6114,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "perry-ui-model",
 ]
 
 [[package]]
 name = "perry-ui-android"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "base64",
  "itoa",
@@ -6138,7 +6138,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-geisterhand"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "rand 0.8.6",
  "serde",
@@ -6148,7 +6148,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-gtk4"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "base64",
  "cairo-rs 0.22.0",
@@ -6171,7 +6171,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-ios"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "base64",
  "block2",
@@ -6187,7 +6187,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-macos"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "base64",
  "block2",
@@ -6202,7 +6202,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-model"
-version = "0.5.1254"
+version = "0.5.1255"
 
 [[package]]
 name = "perry-ui-test"
@@ -6210,11 +6210,11 @@ version = "0.1.0"
 
 [[package]]
 name = "perry-ui-testkit"
-version = "0.5.1254"
+version = "0.5.1255"
 
 [[package]]
 name = "perry-ui-tvos"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "base64",
  "block2",
@@ -6230,7 +6230,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-visionos"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "base64",
  "block2",
@@ -6246,7 +6246,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-watchos"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "block2",
  "libc",
@@ -6259,7 +6259,7 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "base64",
  "libc",
@@ -6276,14 +6276,14 @@ dependencies = [
 
 [[package]]
 name = "perry-ui-windows-winui"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "perry-ui-windows",
 ]
 
 [[package]]
 name = "perry-updater"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -6297,7 +6297,7 @@ dependencies = [
 
 [[package]]
 name = "perry-wasm-host"
-version = "0.5.1254"
+version = "0.5.1255"
 dependencies = [
  "wasmi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -343,7 +343,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1254"
+version = "0.5.1255"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"


### PR DESCRIPTION
## Summary

RUSTSEC-2026-0204 (published 2026-07-06) flags `crossbeam-epoch` < 0.9.20 for an invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared` when the underlying pointer is invalid.

`crossbeam-epoch` is a transitive dependency (rayon → crossbeam-deque), so this is a **`Cargo.lock`-only** bump via `cargo update -p crossbeam-epoch` — no manifest changes.

## Why now

The advisory landed in the RustSec DB yesterday and is failing the **required `security-audit` check on every open PR** (first seen on #6097 / #6098). Since the audit job checks out the PR merge ref, landing this on `main` clears the check for all open PRs on their next CI run.

Includes the standard version bump (0.5.1255) + changelog entry per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated a transitive dependency to address a known security issue and improve pointer-handling safety.
  * Resolved prior security-audit failures related to that dependency chain.

* **Chores**
  * Bumped the project version to **v0.5.1255**.
  * Added the new version entry to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->