### PR TITLE
fix(runtime): cap object keys-array length at capacity in property walks (prevents multi-GB / spin on a corrupt keys length)

### DIFF
--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -393,6 +393,30 @@ fn array_get_property_by_key(arr: *const ArrayHeader, key: *const crate::StringH
 }
 
 #[no_mangle]
+/// Reported length of an object's keys/property array, capped at its physical
+/// capacity.
+///
+/// Object property walks (the wide-key field-get index and `Object.assign`'s
+/// source enumeration) size their work by the keys array's length. A dense
+/// keys array's logical length can never exceed its capacity, so for a
+/// well-formed array this is a no-op. But when a keys array is malformed and
+/// `js_array_length` reports a bogus, oversized value (observed: a pointer-
+/// sized length ~= the keys pointer's own low bits, far beyond the real key
+/// count), an unclamped `for i in 0..len` / `HashMap::with_capacity(len)` turns
+/// a single missing-property read or `Object.assign` into a multi-GB / minutes-
+/// long spin. Capping to capacity bounds that work to physically-present slots.
+///
+/// FOR DENSE KEYS/PROPERTY ARRAYS ONLY — general JS arrays may have
+/// `length > capacity` (sparse), where this cap would be incorrect.
+pub(crate) unsafe fn keys_array_len_capped_to_capacity(arr: *const ArrayHeader) -> usize {
+    let raw = js_array_length(arr) as usize;
+    if arr.is_null() {
+        raw
+    } else {
+        raw.min((*arr).capacity as usize)
+    }
+}
+
 pub extern "C" fn js_array_length(arr: *const ArrayHeader) -> u32 {
     // #5135: a Proxy typed (statically) as an array (immer drafts) reaches here
     // with the masked proxy id. Read `length` through the proxy `get` trap
@@ -1623,5 +1647,37 @@ fn canonical_index_of_set_key(idx: f64) -> Option<u32> {
         Some(n as u32)
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod keys_len_cap_tests {
+    use super::{js_array_length, keys_array_len_capped_to_capacity};
+
+    #[test]
+    fn keys_len_capped_bounds_bogus_length_to_capacity() {
+        // Freshly-allocated array: well-formed (length 0 <= capacity), so the
+        // cap is a no-op and returns the real length.
+        let arr = crate::array::js_array_alloc(8);
+        let capacity = unsafe { (*arr).capacity } as usize;
+        assert!(capacity >= 8);
+        assert_eq!(unsafe { keys_array_len_capped_to_capacity(arr) }, 0);
+
+        // Simulate a malformed keys array whose length field reports a bogus,
+        // pointer-sized value — the pathology the object property walks guard
+        // against. Un-capped, callers would iterate/allocate ~645M slots.
+        unsafe {
+            (*arr).length = 645_115_168;
+        }
+        assert_eq!(
+            js_array_length(arr) as usize,
+            645_115_168,
+            "sanity: js_array_length reflects the forged length"
+        );
+        assert_eq!(
+            unsafe { keys_array_len_capped_to_capacity(arr) },
+            capacity,
+            "cap must bound a bogus oversized length to the array's capacity"
+        );
     }
 }

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -75,8 +75,9 @@ pub use self::immutable::{
 pub(crate) use self::indexing::{
     array_has_own_index, array_iteration_is_exotic, array_proto_iterator_modified,
     array_prototype_addr, array_prototype_has_index_flag, array_spec_get, array_spec_has_index,
-    note_array_proto_iterator_write, note_object_prototype_index_write, object_prototype_addr,
-    object_prototype_addr_matches, object_prototype_has_index_flag,
+    keys_array_len_capped_to_capacity, note_array_proto_iterator_write,
+    note_object_prototype_index_write, object_prototype_addr, object_prototype_addr_matches,
+    object_prototype_has_index_flag,
 };
 pub use self::indexing::{
     js_array_get_element, js_array_get_element_f64, js_array_get_f64, js_array_get_f64_unchecked,

--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -1245,7 +1245,12 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
     } else {
         let src_keys = (*src).keys_array;
         if !src_keys.is_null() && (src_keys as usize) >= 0x10000 {
-            let key_count = crate::array::js_array_length(src_keys) as usize;
+            // Cap the key count at the keys array's capacity: a malformed keys
+            // array can report a bogus, pointer-sized length, and an unclamped
+            // `0..key_count` copy loop turns Object.assign / object spread into a
+            // minutes-long spin (each `js_array_get` on the phantom tail walks
+            // the slow sparse path). Same guard as the wide-key field-get walk.
+            let key_count = crate::array::keys_array_len_capped_to_capacity(src_keys);
             // Use the public [[Get]] path, not raw field slots, so accessors run
             // and abrupt completions propagate the way Object.assign requires.
             for i in 0..key_count {

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
@@ -1574,7 +1574,11 @@ pub(crate) fn get_field_by_name_object_tail(
         };
         let keys_id = keys as usize;
 
-        let key_count = crate::array::js_array_length(keys) as usize;
+        // Clamp the keys length to capacity so a bogus/oversized length can't
+        // drive the wide-key map build or the linear scan below into unbounded
+        // work (see `keys_array_len_capped_to_capacity`). No-op for well-formed
+        // arrays.
+        let key_count = crate::array::keys_array_len_capped_to_capacity(keys);
 
         // Thread-local inline cache: fixed-size direct-mapped cache (no allocation, no HashMap)
         // Each entry stores (keys_ptr, key_hash, field_index). Copied-minor


### PR DESCRIPTION
## Problem

Two object property walks size their work by an object's keys-array length via `js_array_length`:
- the wide-key index in `get_field_by_name` (`get_field_by_name_tail.rs`), which does `HashMap::with_capacity(key_count)` + a `0..key_count` build in `wide_key_index_lookup`; and
- `Object.assign`'s source enumeration (`js_object_assign_one`), which does a `0..key_count` copy loop.

A dense keys array's logical length can never exceed its capacity. But when a keys array is **malformed and `js_array_length` reports a bogus, pointer-sized length** (observed ≈ the keys pointer's own low bits — hundreds of millions), both walks are driven into unbounded work: a single missing-property read allocates a multi-hundred-million-bucket `HashMap` (multi-GB RSS), and an `Object.assign` spins for minutes walking a phantom tail through the slow sparse-array `js_array_get` path. On a large bundled application this manifested as the process pinning ~100% CPU at 9 GB RSS (the map build) or a flat-RSS spin (the copy loop), never making progress.

## Fix

Add `keys_array_len_capped_to_capacity` (`array/indexing.rs`) — `min(js_array_length(arr), (*arr).capacity)` — and use it in both walks. For a well-formed dense keys array `length <= capacity`, so this is a **no-op on the common path** and a hard bound otherwise (work is limited to physically-present slots). Scoped to object keys/property arrays; general JS arrays may legitimately have `length > capacity` (sparse), so the helper is documented as keys-array-only.

## Test

`keys_len_capped_bounds_bogus_length_to_capacity` forges an oversized length on a small array and asserts the cap returns `capacity` (not the bogus length). Full suite: `cargo test --release -p perry-runtime` → **1162 passed / 0 failed**.

## Note

This is defensive hardening at the two consumers. The **upstream cause** — `js_array_length` returning a pointer-sized value for a particular object's keys array (a length/pointer that looks transiently stale) — is a separate, deeper issue worth its own fix; other keys-array walks (field-set, arguments enumeration) share the same iterate-by-length pattern and would benefit from the same guard or, better, the root fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of object key lists to avoid excessive work when key data is malformed.
  * Made object property copying and lookup more resilient by limiting key iteration to the actual array size.
  * Added coverage for normal and corrupted key-list cases to keep behavior stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->