### PR TITLE
fix(hir): queue with-statement bodies as nested forward-capture scopes (#6098 follow-up)

### DIFF
--- a/crates/perry-hir/src/lower_decl/block.rs
+++ b/crates/perry-hir/src/lower_decl/block.rs
@@ -291,6 +291,10 @@ fn push_nested_block_stmt_lists<'a>(
         While(w) => push_nested_block_stmt_lists(&w.body, worklist),
         DoWhile(w) => push_nested_block_stmt_lists(&w.body, worklist),
         Labeled(l) => push_nested_block_stmt_lists(&l.body, worklist),
+        // Sloppy-mode `with (o) { … }` — a block-scoped `let` in the body is
+        // nearer than the with-object's properties, so it forward-captures
+        // like any other nested block (mirrors the `With` arm in `cic_stmt`).
+        With(w) => push_nested_block_stmt_lists(&w.body, worklist),
         Switch(sw) => {
             for c in &sw.cases {
                 worklist.push_back((&c.cons[..], true));


### PR DESCRIPTION
## Summary

Follow-up to #6098, addressing the one finding from CodeRabbit's re-review that landed after the PR was merged: `push_nested_block_stmt_lists` handled `if`/loop/labeled wrappers but not `With`, so a block-scoped forward-captured `let` inside a sloppy-mode `with (o) { … }` body never pre-registered and the earlier closure fell back to a global read (mirrors the existing `With` arm in `cic_stmt`).

One-line matcher arm + comment. A `with`-shape forward-capture compiles and returns the block-lexical binding per spec (block env is nearer than the with object); the 11-case nested-forward-capture parity battery from #6098 still matches Node.

The original commit (aa21608e7) was pushed to the #6098 branch minutes after the PR merged, so it never entered a CI run — this PR re-lands it on current `main`.

## Note for reviewers

The #6098 merge-ref conformance run (28849487152) had shard 7 fail with 4 gap failures (`fs_fd_2749`, `iterator_helpers_2874`, `perfhooks_3088_3008_3010_3011`, `v8_2_3680plus`). Local byte-comparison shows those tests' perry outputs are **identical** across the CI-green base (`ae3ef5904`), the #6098 commits, #6095, and #6099 on macOS/arm64 — i.e., not caused by #6098's lowering changes. A rerun of the failed shard is in flight to distinguish CI flake from a Linux-specific main regression (prime suspect if deterministic: #6099's GC-trigger re-baseline changing collection frequency). This PR's conformance run doubles as a second data point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected nested scope handling for `with` statements so block-scoped bindings inside them are detected reliably.
  * Improved capture scanning for `let` and `const` declarations within nested blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->