### PR TITLE
fix(runtime): register the per-thread globalThis cache as a GC root

### DIFF
--- a/crates/perry-runtime/src/object/global_this/fetch_globals.rs
+++ b/crates/perry-runtime/src/object/global_this/fetch_globals.rs
@@ -65,6 +65,20 @@ pub extern "C" fn js_get_global_this() -> f64 {
     // First access on this thread — allocate our own global.
     let new_ptr = js_object_alloc(0, 0) as i64;
     THREAD_GLOBAL_THIS.with(|c| c.set(new_ptr));
+    // The thread-local cache above stores a *raw* heap pointer. Unlike
+    // `GLOBAL_THIS_PTR` (a scanned static that `scan_object_cache_roots_mut`
+    // relocates), this cache slot is otherwise invisible to the GC, so a
+    // copying collection that evacuates `globalThis` leaves the cache pointing
+    // at the stale from-space address. Later `js_get_global_this()` calls then
+    // read a dead object whose overflow fields (e.g. `globalThis.Error`) have
+    // already been rekeyed to the moved copy — the reads return `undefined`.
+    // Register the cache slot as a mutable global root (mirroring
+    // `js_module_top_this`) so the collector rewrites it to the forwarding
+    // address on every move; raw-pointer slots are handled by
+    // `mark_global_root_bits` / `rewrite_value_bits`.
+    crate::gc::runtime_write_barrier_root_heap_word(new_ptr as u64);
+    let cache_slot = THREAD_GLOBAL_THIS.with(|c| c.as_ptr() as usize);
+    crate::gc::js_gc_register_global_root(cache_slot as i64);
     // Publish to the process-global GC-root slot so this thread's collector marks
     // it (the unit-test harness runs tests sequentially, so the slot always holds
     // the running thread's global). `GLOBAL_THIS_READY` is toggled around


### PR DESCRIPTION
## Problem

`js_get_global_this` caches this thread's `globalThis` in a thread-local raw-pointer cell (`THREAD_GLOBAL_THIS`) but — unlike its sibling `js_module_top_this` — never registers that cache slot as a GC root.

The authoritative `GLOBAL_THIS_PTR` static **is** scanned and relocated by `scan_object_cache_roots_mut`. So when a copying minor evacuates `globalThis`, that static and the object's overflow side-table are rekeyed to the moved address — but the thread-local cache still points at the stale from-space copy.

Subsequent `js_get_global_this()` calls hand back that dead pointer. Reading an overflow-stored builtin such as `globalThis.Error` then returns `undefined`, because the overflow entry was rekeyed onto the *moved* object. Downstream this surfaces as **`Class extends value is not a constructor`** in a program that constructs many classes during startup and happens to trigger a collection between two global reads (e.g. `class X extends Error {}` where `globalThis.Error` reads `undefined`).

## Fix

Register the `THREAD_GLOBAL_THIS` cache slot as a mutable global root (via `js_gc_register_global_root`), exactly as `js_module_top_this` already does for its own thread-local cache. The collector then rewrites the raw pointer to the forwarding address on every move.

Raw-pointer global-root slots are already handled by `mark_global_root_bits` / `rewrite_value_bits` (the same path `js_module_top_this` relies on), and their rewrite-on-move is covered by `test_rewrite_mutable_root_slots_updates_shadow_and_global_roots`.

## Validation

- Confirmed against a large esbuild-bundled CLI app whose class-heavy setup triggered a collection between two `globalThis` reads: before the fix, `globalThis.Error` read `undefined` and the app threw `Class extends value is not a constructor`; after the fix that throw is gone deterministically across repeated runs and the app proceeds further into its pipeline.
- The rewrite mechanism this fix uses is already unit-tested (`test_rewrite_mutable_root_slots_updates_shadow_and_global_roots`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when accessing the app’s shared runtime state, reducing the risk of crashes or invalid data after memory management events.
  * Fixed an issue where thread-local cached state could become outdated during cleanup, helping ensure consistent behavior across requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->