### PR TITLE
fix(codegen): resolve private-member declaring class by unique id, not name

### DIFF
--- a/crates/perry-codegen/src/expr/logical_collections.rs
+++ b/crates/perry-codegen/src/expr/logical_collections.rs
@@ -796,6 +796,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         }
         Expr::PrivateGuard {
             class_name,
+            class_id: declaring_class_id,
             field_name,
             kind,
             op,
@@ -805,7 +806,17 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // unchanged (or throw TypeError). The enclosing PropertyGet /
             // PropertySet / method-call lowering then operates on the result.
             let obj = lower_expr(ctx, object)?;
-            let class_id = ctx.class_ids.get(class_name).copied().unwrap_or(0);
+            // Prefer the declaring class's unique HIR id carried on the node.
+            // Resolving `class_name` through `class_ids` is ambiguous: that map
+            // is keyed by name (last-writer-wins), so a minified bundle that
+            // reuses a class name would bind the brand to the wrong same-named
+            // class and reject a legal `this.#x`. Fall back to the name lookup
+            // only when the id is absent (0 = unresolved → no-op guard).
+            let class_id = if *declaring_class_id != 0 {
+                *declaring_class_id
+            } else {
+                ctx.class_ids.get(class_name).copied().unwrap_or(0)
+            };
             let key_label = emit_string_literal_global(ctx, field_name);
             Ok(ctx.block().call(
                 DOUBLE,

--- a/crates/perry-codegen/tests/private_guard_declaring_class.rs
+++ b/crates/perry-codegen/tests/private_guard_declaring_class.rs
@@ -1,0 +1,146 @@
+//! Regression: a private-member brand guard must use the DECLARING CLASS'S
+//! UNIQUE id, not a name lookup.
+//!
+//! `js_private_guard` brand-checks the receiver against a declaring class id.
+//! Codegen used to derive that id by resolving `Expr::PrivateGuard.class_name`
+//! through `class_ids` — a `name -> id` map built by
+//! `hir.classes.map(|c| (c.name, c.id)).collect()`, i.e. last-writer-wins.
+//! Minified programs reuse class names, so two distinct classes with the same
+//! name collapse to one entry: a `this.#x` inside the class that LOSES the
+//! collision then brand-checks against the OTHER same-named class, whose id is
+//! not in the receiver's class-id chain, and throws
+//!   `Cannot access private member from an object whose class did not declare it`
+//! for a legal access.
+//!
+//! A faithful end-to-end repro needs the specific duplicate-name shape a
+//! minifier produces, so this asserts the codegen contract directly on the
+//! emitted IR: `Expr::PrivateGuard` now carries the declaring class's unique
+//! id, and codegen passes THAT to `js_private_guard` rather than the collided
+//! `class_ids[name]`.
+
+use perry_codegen::{compile_module, CompileOptions};
+use perry_hir::{Class, Expr, Function, Module, ModuleInitKind, Stmt};
+use perry_types::Type;
+
+fn ir_opts() -> CompileOptions {
+    CompileOptions {
+        is_entry_module: true,
+        emit_ir_only: true,
+        output_type: "executable".to_string(),
+        ..Default::default()
+    }
+}
+
+fn class(id: u32, name: &str) -> Class {
+    Class {
+        id,
+        name: name.to_string(),
+        type_params: Vec::new(),
+        extends: None,
+        extends_name: None,
+        native_extends: None,
+        extends_expr: None,
+        heritage_lexically_shadowed: false,
+        fields: Vec::new(),
+        constructor: None,
+        methods: Vec::new(),
+        getters: Vec::new(),
+        setters: Vec::new(),
+        static_accessor_names: Vec::new(),
+        static_accessor_fn_ids: Vec::new(),
+        computed_members: Vec::new(),
+        static_fields: Vec::new(),
+        static_methods: Vec::new(),
+        decorators: Vec::new(),
+        is_exported: false,
+        aliases: Vec::new(),
+        is_nested: false,
+    }
+}
+
+fn module_with(classes: Vec<Class>, body: Vec<Stmt>) -> Module {
+    Module {
+        name: "private_guard_declaring_class.ts".to_string(),
+        imports: Vec::new(),
+        exports: Vec::new(),
+        classes,
+        interfaces: Vec::new(),
+        type_aliases: Vec::new(),
+        enums: Vec::new(),
+        globals: Vec::new(),
+        functions: vec![Function {
+            id: 1,
+            name: "probe".to_string(),
+            type_params: Vec::new(),
+            params: Vec::new(),
+            return_type: Type::Number,
+            body,
+            is_async: false,
+            is_generator: false,
+            is_strict: false,
+            is_exported: false,
+            captures: Vec::new(),
+            decorators: Vec::new(),
+            was_plain_async: false,
+            was_unrolled: false,
+        }],
+        init: Vec::new(),
+        exported_native_instances: Vec::new(),
+        exported_func_return_native_instances: Vec::new(),
+        exported_objects: Vec::new(),
+        exported_functions: Vec::new(),
+        script_global_functions: Vec::new(),
+        references_global_this: false,
+        annexb_global_undefined_names: Vec::new(),
+        widgets: Vec::new(),
+        uses_fetch: false,
+        uses_webassembly: false,
+        extern_funcs: Vec::new(),
+        init_was_unrolled: false,
+        has_top_level_await: false,
+        init_kind: ModuleInitKind::Eager,
+        async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
+        class_display_names: std::collections::HashMap::new(),
+        closure_source_text: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
+    }
+}
+
+#[test]
+fn private_guard_uses_declaring_class_id_not_name_collided_id() {
+    // Two DISTINCT classes both named "Box": ids 5 and 7. `class_ids` is a
+    // name-keyed map, so "Box" collapses to a single entry (id 7 — the last
+    // one collected). The guard below declares class id 5 (the OTHER "Box").
+    let classes = vec![class(5, "Box"), class(7, "Box")];
+    let guard = Expr::PrivateGuard {
+        class_name: "Box".to_string(),
+        class_id: 5,
+        field_name: "#v".to_string(),
+        kind: 0, // field
+        op: 0,   // instance read
+        object: Box::new(Expr::Integer(0)),
+    };
+    let ir = String::from_utf8(
+        compile_module(&module_with(classes, vec![Stmt::Expr(guard)]), ir_opts()).unwrap(),
+    )
+    .expect("LLVM IR should be UTF-8");
+
+    let call = ir
+        .lines()
+        .find(|l| l.contains("call") && l.contains("@js_private_guard"))
+        .unwrap_or_else(|| panic!("no js_private_guard CALL emitted:\n{ir}"));
+
+    // The brand must use the declaring class's own id (5), carried on the
+    // PrivateGuard node — NOT `class_ids["Box"]` (7), which resolves to the
+    // wrong same-named class.
+    assert!(
+        call.contains("i32 5"),
+        "brand must use the declaring class id 5 carried on the node:\n{call}"
+    );
+    assert!(
+        !call.contains("i32 7"),
+        "brand must NOT use the name-collided class_ids[\"Box\"] id 7:\n{call}"
+    );
+}

--- a/crates/perry-hir/src/analysis/value_types_tests.rs
+++ b/crates/perry-hir/src/analysis/value_types_tests.rs
@@ -468,6 +468,7 @@ fn infers_passthrough_expression_types() {
         infer_expr_type(
             &Expr::PrivateGuard {
                 class_name: "Widget".to_string(),
+                class_id: 0,
                 field_name: "value".to_string(),
                 kind: 0,
                 op: 0,

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -283,6 +283,13 @@ pub enum Expr {
     /// `op` are the wire codes defined by `PrivKind` / 0=get,1=set.
     PrivateGuard {
         class_name: String,
+        /// The declaring class's unique HIR id. Codegen uses this directly as
+        /// the brand's `declaring_class_id` rather than resolving `class_name`
+        /// through the `class_ids` map, whose name keys collapse duplicate
+        /// (minified) class names last-writer-wins and would otherwise bind the
+        /// brand to the wrong same-named class. 0 means "unresolved" (guard
+        /// degrades to a no-op).
+        class_id: u32,
         field_name: String,
         kind: u8,
         op: u8,

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -307,10 +307,10 @@ impl LoweringContext {
     /// class and member kind by walking the private-scope stack innermost
     /// outward — matching the lexical resolution rule for private names. A
     /// nested class that redeclares the same name shadows the outer one.
-    pub(crate) fn resolve_private(&self, field_name: &str) -> Option<(String, PrivMember)> {
+    pub(crate) fn resolve_private(&self, field_name: &str) -> Option<(String, u32, PrivMember)> {
         for scope in self.private_scopes.iter().rev() {
             if let Some(m) = scope.members.get(field_name) {
-                return Some((scope.class_name.clone(), *m));
+                return Some((scope.class_name.clone(), scope.class_id, *m));
             }
         }
         None

--- a/crates/perry-hir/src/lower/expr_member/private_guard.rs
+++ b/crates/perry-hir/src/lower/expr_member/private_guard.rs
@@ -32,12 +32,13 @@ pub(crate) fn wrap_private_guard(
     field_name: &str,
     op: u8,
 ) -> Box<Expr> {
-    if let Some((class_name, member)) = ctx.resolve_private(field_name) {
+    if let Some((class_name, class_id, member)) = ctx.resolve_private(field_name) {
         // Static members get a static brand (op + 2); instance members the
         // ordinary op code.
         let op = if member.is_static { op + 2 } else { op };
         return Box::new(Expr::PrivateGuard {
             class_name,
+            class_id,
             field_name: field_name.to_string(),
             kind: member.kind as u8,
             op,

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -43,6 +43,12 @@ pub(crate) struct PrivMember {
 #[derive(Debug, Clone)]
 pub(crate) struct PrivateScope {
     pub(crate) class_name: String,
+    /// The declaring class's unique HIR id. Carried alongside `class_name`
+    /// because the name alone is ambiguous: minified bundles reuse class names,
+    /// and codegen's `class_ids` name→id map is last-writer-wins, so resolving a
+    /// private member's declaring class by name can bind to the wrong same-named
+    /// class and make the runtime brand check reject a legal `this.#x` access.
+    pub(crate) class_id: u32,
     pub(crate) members: HashMap<String, PrivMember>,
 }
 

--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -335,7 +335,11 @@ pub fn lower_class_decl(
     // Push the private-name scope for this class body so `obj.#name` accesses
     // brand-check against the declaring class and reject illegal read/write
     // operations. Popped at the matching restore below.
-    ctx.push_private_scope(super::build_private_scope(&class_decl.class, &name));
+    ctx.push_private_scope(super::build_private_scope(
+        &class_decl.class,
+        &name,
+        class_id,
+    ));
 
     // Issue #562: track the parent class identifier so the `super({...})`
     // pre-scan in expr_call.rs can register the controller param as a
@@ -1439,7 +1443,7 @@ pub fn lower_class_from_ast(
     ctx.current_class_is_derived = class.super_class.is_some();
 
     // Private-name scope for this class-expression body (see lower_class_decl).
-    ctx.push_private_scope(super::build_private_scope(class, name));
+    ctx.push_private_scope(super::build_private_scope(class, name, class_id));
 
     // Issue #562: same as the parallel `lower_class_decl` arm — track the
     // parent class identifier so super({...}) controller-param pre-scan

--- a/crates/perry-hir/src/lower_decl/private_members.rs
+++ b/crates/perry-hir/src/lower_decl/private_members.rs
@@ -15,7 +15,11 @@ use super::*;
 /// `PrivKind::GetSet`. Used to push a `PrivateScope` for the duration of the
 /// class body lowering so `obj.#name` accesses can brand-check on the correct
 /// declaring class and reject illegal read/write operations.
-pub fn build_private_scope(class: &ast::Class, class_name: &str) -> crate::lower::PrivateScope {
+pub fn build_private_scope(
+    class: &ast::Class,
+    class_name: &str,
+    class_id: u32,
+) -> crate::lower::PrivateScope {
     use crate::lower::{PrivKind, PrivMember, PrivateScope};
     let mut members: std::collections::HashMap<String, PrivMember> =
         std::collections::HashMap::new();
@@ -59,6 +63,7 @@ pub fn build_private_scope(class: &ast::Class, class_name: &str) -> crate::lower
     }
     PrivateScope {
         class_name: class_name.to_string(),
+        class_id,
         members,
     }
 }

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -79,7 +79,7 @@ impl SH for Expr {
             Expr::InstanceOf { expr, ty, ty_expr } => { tag(h, 38); expr.as_ref().hash(h); ty.hash(h); ty_expr.hash(h); }
             Expr::In { property, object } => { tag(h, 39); property.as_ref().hash(h); object.as_ref().hash(h); }
             Expr::PrivateBrandCheck { class_name, field_name, object } => { tag(h, 12401); class_name.hash(h); field_name.hash(h); object.as_ref().hash(h); }
-            Expr::PrivateGuard { class_name, field_name, kind, op, object } => { tag(h, 12402); class_name.hash(h); field_name.hash(h); kind.hash(h); op.hash(h); object.as_ref().hash(h); }
+            Expr::PrivateGuard { class_name, class_id, field_name, kind, op, object } => { tag(h, 12402); class_name.hash(h); class_id.hash(h); field_name.hash(h); kind.hash(h); op.hash(h); object.as_ref().hash(h); }
             Expr::Await(e) => { tag(h, 40); e.as_ref().hash(h); }
             Expr::Yield { value, delegate } => { tag(h, 41); value.hash(h); delegate.hash(h); }
             // #5253: `byte_offset` is diagnostic-only — excluded from the hash


### PR DESCRIPTION
## Problem

A private-member access (`this.#x`) is guarded at runtime by `js_private_guard`, which brand-checks the receiver against the **declaring class id**. Codegen produced that id by resolving `Expr::PrivateGuard`'s **class name** through `ctx.class_ids`:

```rust
let mut class_ids: HashMap<String, u32> =
    hir.classes.iter().map(|c| (c.name.clone(), c.id)).collect();
```

That map is keyed by **name**, so duplicate names collapse (last-writer-wins). Minified programs routinely reuse class names — and anonymous/duplicate classes share a source name — so two *distinct* classes with the same name map to a single id. A `this.#x` inside the class that **loses** the collision then brand-checks against the **other** same-named class, whose id is not in the receiver's class-id chain, and throws:

```
TypeError: Cannot access private member from an object whose class did not declare it
```

This reproduced deterministically in a large minified program: an instance of class id 562 (which `extends` a built-in) doing `this.#q = …`, where `#q`'s declaring class resolved by name to a *different* class id (1490). 562's parent chain leads to the built-in and never reaches 1490, so the guard rejected a legal write.

## Fix

Every HIR class already has a unique `Class::id`, so thread it instead of the ambiguous name:

- `PrivateScope` records the declaring class's id (set when the class body's private scope is pushed).
- `resolve_private` returns that id alongside the name.
- `Expr::PrivateGuard` carries a `class_id: u32`.
- Codegen uses it directly as the brand's `declaring_class_id`, falling back to the `class_ids` name lookup only when the id is `0` (unresolved → the guard degrades to a no-op, exactly as before).

No behavior change for programs with unique class names; the guard now binds to the class that lexically declares the private name regardless of name collisions.

## Test

`crates/perry-codegen/tests/private_guard_declaring_class.rs` — builds two distinct classes both named `Box` (ids 5 and 7, so `class_ids["Box"]` collapses to 7) and a `PrivateGuard` declaring id 5, then asserts the emitted `js_private_guard` call passes `i32 5` (the node's id) and not `i32 7` (the name-collided id). Mirrors the `class_keys_gc_root` IR-contract style, since a faithful end-to-end repro needs the specific duplicate-name shape a minifier produces.

Also verified end-to-end against a large minified program: the `Cannot access private member…` throw is gone deterministically across repeated runs, and the program advances further into its pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Private member checks now use the declaring class’s unique identifier, improving correctness when classes share the same name.
  * Added regression coverage for same-named classes to ensure private-brand checks target the right class.

* **Bug Fixes**
  * Fixed private guard handling so it no longer depends only on name-based resolution.
  * Unresolved private guards continue to safely fall back without changing existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->