### PR TITLE
fix(codegen): run own field initializers for a no-ctor subclass of a built-in

### DIFF
--- a/crates/perry-codegen/src/lower_call/field_init.rs
+++ b/crates/perry-codegen/src/lower_call/field_init.rs
@@ -147,7 +147,15 @@ pub(crate) fn apply_field_initializers_recursive(
             if chain.len() > 1 {
                 chain[1..].to_vec()
             } else {
-                Vec::new()
+                // The leaf directly extends a NON-user parent (a built-in like
+                // `Error`, or an imported class) — such a parent is not in the
+                // user-class `chain`, so there is no root ancestor to skip. Its
+                // own field initializers must still run after the (built-in)
+                // super; without this a no-own-ctor `class A extends Error {
+                // v = 42 }` left `v` at the raw-0 slot, and a later
+                // `this.arr.includes(x)` on an unset field threw
+                // `Cannot read properties of undefined`.
+                chain
             }
         }
     };

--- a/tests/test_subclass_builtin_field_init.sh
+++ b/tests/test_subclass_builtin_field_init.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# A no-own-constructor subclass of a BUILT-IN (Error, etc.) must still run its
+# OWN field initializers. The implicit ctor is
+# `constructor(...args){ super(...args); <own field inits> }`.
+#
+# The field-init chain only contains USER classes, so a built-in parent is not
+# in it: `class A extends Error {}` has chain `["A"]` (length 1). The no-own-ctor
+# path applied `FieldInitMode::AfterRoot`, which keeps `chain[1..]` — EMPTY for a
+# length-1 chain — so A's own field initializers never ran. Fields read the
+# raw-0 slot; a later `this.arr.includes(x)` on an unset array field then threw
+# `Cannot read properties of undefined (reading 'includes')`. (A two-level
+# `class B extends A extends Error` worked because its chain is `["A","B"]`.)
+#
+# Fix: when the chain has no user root to skip (built-in / imported parent),
+# `AfterRoot` applies the leaf's own initializers.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$REPO_ROOT/target/release/perry}}"
+if [[ ! -x "$PERRY" ]]; then PERRY="$REPO_ROOT/target/debug/perry"; fi
+if [[ ! -x "$PERRY" ]]; then
+    echo "SKIP: perry binary not found (build with cargo build -p perry)"
+    exit 0
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+cat >"$TMPDIR/f.ts" <<'TS'
+class A extends Error {
+  pubv = 42;          // public field initializer
+  #priv = 7;          // private field initializer
+  arr = [1, 2, 3];    // reference-typed field
+  readPub() { return this.pubv; }
+  readPriv() { return this.#priv; }
+  readArr() { return this.arr; }
+}
+const a = new A();
+if (a.readPub() !== 42) throw new Error("pubv: " + a.readPub());
+if (a.readPriv() !== 7) throw new Error("priv: " + a.readPriv());
+if (!a.readArr().includes(2)) throw new Error("arr uninitialized: " + JSON.stringify(a.readArr()));
+console.log("OK");
+TS
+
+OUT="$("$PERRY" run "$TMPDIR/f.ts" 2>&1)" || { echo "FAIL: perry run errored"; echo "$OUT"; exit 1; }
+if ! grep -q "^OK$" <<<"$OUT"; then echo "FAIL: expected OK, got:"; echo "$OUT"; exit 1; fi
+echo "PASS: subclass-of-builtin own field initializers run"


### PR DESCRIPTION
## Problem

`apply_field_initializers_recursive` builds its inheritance chain from **user classes only** (`ctx.class_init_chains` / walking `ctx.classes` by `extends_name`), so a **built-in** parent (`Error`, `Map`, `Array`, the NativeError family, …) is not in the chain.

For a no-own-constructor `class A extends Error {}` the chain is just `["A"]` (length 1). The no-own-ctor construction path applies `FieldInitMode::AfterRoot`, which keeps `chain[1..]` — **empty** for a length-1 chain — and the up-front `AncestorsOnly` pass also returns empty for a length-1 chain. So **A's own field initializers never run**: its fields read the raw-0 slot, and a later `this.arr.includes(x)` on an unset array/string field throws:

```
TypeError: Cannot read properties of undefined (reading 'includes')
```

A two-level `class B extends A extends Error` was unaffected, because its chain is `["A","B"]` — `AncestorsOnly` applies A up front and `AfterRoot` applies B.

Repro (before the fix, all three read as unset):

```ts
class A extends Error { pubv = 42; #priv = 7; arr = [1,2,3];
  readPub(){return this.pubv} readPriv(){return this.#priv} readArr(){return this.arr} }
const a = new A();
a.readPub();            // 0   (want 42)
a.readPriv();           // 0   (want 7)
a.readArr().includes(2) // false / throws (want true)
```

## Fix

In `FieldInitMode::AfterRoot`, when the chain has no user root ancestor to skip (length ≤ 1 — the leaf directly extends a built-in or imported parent), apply the leaf's own initializers instead of nothing. Plain user-class parents (chain length ≥ 2) are unchanged, as are base classes (which don't reach this path).

## Test

`tests/test_subclass_builtin_field_init.sh` — `class A extends Error` with public, private, and array field initializers; asserts all are set after `new A()` (the array one exercises the exact `.includes` failure). Complements the existing `test_subclass_own_field_init_after_super.sh`, which covers the user-parent case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed field initializers for classes that extend built-in or imported parents, so subclass fields now run correctly after the parent initialization step.
  * Improved handling for subclasses of built-in types to avoid skipping leaf field initialization in these cases.

* **Tests**
  * Added an integration test covering subclasses of built-in classes to ensure public, private, and array field initializers are applied as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->