### PR TITLE
fix(codegen): ILP32 class-field access must use target-aware object-header size

### DIFF
--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -1325,10 +1325,20 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             .cond_br(&guard_pass, &fast_label, &fallback_label);
 
                         ctx.current_block = fast_idx;
+                        // arm64_32 watchOS: the object fields region begins at
+                        // `size_of::<ObjectHeader>()` past the user pointer — 24 on
+                        // 64-bit, 20 on ILP32 (the trailing `keys_array` pointer is 4
+                        // bytes there). A hardcoded 24 reads every class field 4 bytes
+                        // off on a 32-bit watch, so this inline class-field load
+                        // disagreed with the generic-PIC load / runtime setter (both
+                        // target-aware) and typed-object string fields came back as
+                        // word-swapped NaN-boxes. Derive it from the target triple
+                        // (no-op on 64-bit; see `target_layout`).
+                        let header_skip =
+                            crate::target_layout::object_header_size_bytes(ctx.target_triple)
+                                .to_string();
                         let blk = ctx.block();
                         let obj_ptr = blk.inttoptr(I64, &obj_handle);
-                        // Skip the 24-byte ObjectHeader.
-                        let header_skip = "24".to_string();
                         let fields_base = blk.gep(I8, &obj_ptr, &[(I64, &header_skip)]);
                         let field_ptr = blk.gep(DOUBLE, &fields_base, &[(I64, &field_idx_str)]);
                         let val_fast = blk.load(DOUBLE, &field_ptr);

--- a/crates/perry-codegen/src/expr/property_set.rs
+++ b/crates/perry-codegen/src/expr/property_set.rs
@@ -650,9 +650,19 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         let field_set_barrier_needed =
                             !expr_produces_non_pointer_bits_by_construction(ctx, value);
                         let raw_stored_value = {
+                            // arm64_32 watchOS: the object fields region begins at
+                            // `size_of::<ObjectHeader>()` past the user pointer — 24 on
+                            // 64-bit, 20 on ILP32 (the trailing `keys_array` pointer is
+                            // 4 bytes there). A hardcoded 24 writes every class field 4
+                            // bytes off on a 32-bit watch; the paired inline read
+                            // (`property_get`) and the runtime setter must agree, so
+                            // derive it from the target triple (no-op on 64-bit; see
+                            // `target_layout`).
+                            let header_skip =
+                                crate::target_layout::object_header_size_bytes(ctx.target_triple)
+                                    .to_string();
                             let blk = ctx.block();
                             let obj_ptr = blk.inttoptr(I64, &obj_handle);
-                            let header_skip = "24".to_string();
                             let fields_base = blk.gep(I8, &obj_ptr, &[(I64, &header_skip)]);
                             let field_ptr = blk.gep(DOUBLE, &fields_base, &[(I64, &field_idx_str)]);
                             let raw_stored_value = if requires_raw_f64 {


### PR DESCRIPTION
## What

The inline **class-field** get/set fast paths hardcoded a **24-byte** `ObjectHeader` skip when computing a field's address (`obj + 24 + slot*8`). On **arm64_32** (ILP32: 64-bit registers, 32-bit pointers) the runtime `ObjectHeader` is **20 bytes** — four `u32`s plus a 4-byte `keys_array` pointer — so these two paths read and wrote every class field 4 bytes off. Every other field-access path (the generic-PIC inline load, the runtime `js_object_set_field` setters, the GC layout walk) already derives the size from the target via `object_header_size_bytes(ctx.target_triple)`.

## Why it was sneaky

**Number** fields survived: their read *and* write both went through the class-field path (offset 24), so they stayed self-consistent. **String** fields did not — the write went through the class-field path (24) while the read fell through to the generic PIC (target-aware 20). That 4-byte skew straddles two 8-byte slots, so a NaN-boxed string `0x7FFF0000_<ptr>` came back 32-bit-word-swapped as `0x<ptr>_7FFF0000` — a value that is no longer a string tag, so it renders as a garbage float.

Concretely, for:

```ts
interface LevelInfo { label: string; context: string; r: number; g: number; b: number }
const levels: LevelInfo[] = [ { label: "Almost silent", /* … */ }, /* … */ ];
```

`levels[i].label` read back as `~1.5e-202` on Apple Watch Series 4–8 / SE, while `levels[i].r` was correct.

## The fix

Derive the header skip from `object_header_size_bytes(ctx.target_triple)` in both `property_get.rs` (class-field inline load) and `property_set.rs` (class-field inline store) — 20 on ILP32, 24 on LP64, so it's a **no-op on every 64-bit target** and the shipping arm64 / x86_64 IR is byte-identical.

## Verification

On the `arm64_32-apple-watchos` IR, the class-field get/set fast paths now emit `getelementptr i8, ptr %obj, i64 20`, identical to the generic PIC's `add i64 %obj, 20`. Confirmed end-to-end on an Apple Watch Series 7 (arm64_32): typed-object string fields now render their real text instead of a garbage float. No change to 64-bit output. Covered indirectly by the existing `target_layout::object_header_size_bytes` unit tests (20 vs 24), which this now consumes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected object field access on platforms with different object header sizes.
  * Property reads and writes now use the appropriate target-specific offset, reducing the risk of misaddressed class fields on affected architectures.
  * Existing fast-path behavior and fallback handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->