### PR TITLE
fix(watchos): link AVFAudio + fix mic-permission FourCC so device audio works

### DIFF
--- a/crates/perry-ui-watchos/src/audio.rs
+++ b/crates/perry-ui-watchos/src/audio.rs
@@ -34,6 +34,7 @@ pub fn start() -> i64 {
     unsafe {
         let session_cls = match AnyClass::get(c"AVAudioSession") {
             Some(cls) => cls,
+            // AVFAudio not linked / class not registered.
             None => return 0,
         };
         let session: *mut AnyObject = msg_send![session_cls, sharedInstance];
@@ -46,22 +47,48 @@ pub fn start() -> i64 {
         let mode = objc2_foundation::NSString::from_str("AVAudioSessionModeMeasurement");
         let options: usize = 0; // NSUInteger
         let mut error: *mut AnyObject = std::ptr::null_mut();
-        let _: bool = msg_send![session, setCategory: &*category
+        let _set_cat: bool = msg_send![session, setCategory: &*category
                                          mode: &*mode
                                          options: options
                                          error: &mut error];
 
-        let _: bool = msg_send![session, setActive: true error: &mut error];
+        error = std::ptr::null_mut();
+        let _set_active: bool = msg_send![session, setActive: true error: &mut error];
 
-        // recordPermission returns NSUInteger (usize on this platform)
-        let record_permission: usize = msg_send![session, recordPermission];
-        if record_permission == 1 {
+        // AVAudio{Session,Application}RecordPermission is a FourCC-coded
+        // NSInteger, NOT 0/1/2:
+        //   undetermined = 'undt' (0x756E_6474 = 1970168948)
+        //   denied       = 'deny' (0x6465_6E79 = 1684369017)
+        //   granted      = 'grnt' (0x6772_6E74 = 1735552628)
+        // The old `== 1`/`== 0` checks never matched these FourCC values, so the
+        // request was never issued (no system prompt) and the engine started
+        // without mic access → the meter sat at silence. Use the correct
+        // constants, and prefer the modern `AVAudioApplication` API which is
+        // what actually drives the permission prompt on watchOS 10+/26
+        // (AVAudioSession.requestRecordPermission is deprecated there).
+        const PERM_GRANTED: usize = 0x6772_6E74; // 'grnt' — bytes g,r,n,t
+        const PERM_DENIED: usize = 0x6465_6E79; // 'deny'
+
+        let record_permission: usize;
+        if let Some(app_cls) = AnyClass::get(c"AVAudioApplication") {
+            let app: *mut AnyObject = msg_send![app_cls, sharedInstance];
+            record_permission = msg_send![app, recordPermission];
+            if record_permission != PERM_GRANTED && record_permission != PERM_DENIED {
+                let block = block2::RcBlock::new(|_granted: objc2::runtime::Bool| {});
+                let _: () =
+                    msg_send![app_cls, requestRecordPermissionWithCompletionHandler: &*block];
+            }
+        } else {
+            record_permission = msg_send![session, recordPermission];
+            if record_permission != PERM_GRANTED && record_permission != PERM_DENIED {
+                let block = block2::RcBlock::new(|_granted: objc2::runtime::Bool| {});
+                let _: () = msg_send![session, requestRecordPermission: &*block];
+            }
+        }
+        // Not yet granted: bail so the caller retries. Undetermined means the
+        // system prompt is being shown; the next tick will pick up the grant.
+        if record_permission != PERM_GRANTED {
             return 0;
-        } // denied
-        if record_permission == 0 {
-            let permission_block = block2::RcBlock::new(|_granted: objc2::runtime::Bool| {});
-            let _: () = msg_send![session, requestRecordPermission: &*permission_block];
-            return 0; // retry after grant
         }
 
         let engine_cls = match AnyClass::get(c"AVAudioEngine") {

--- a/crates/perry/src/commands/compile/link/build_and_run.rs
+++ b/crates/perry/src/commands/compile/link/build_and_run.rs
@@ -660,6 +660,17 @@ pub(crate) fn build_and_run_link(
             .arg("CoreFoundation")
             .arg("-framework")
             .arg("Security")
+            // AVFAudio: AVAudioEngine / AVAudioSession / AVAudioApplication for
+            // microphone capture + the record-permission API (perry/system
+            // audioStart, getLevel, recording). Without this the audio classes
+            // aren't registered in the objc runtime, so `AnyClass::get` returns
+            // nil and audio silently no-ops on device — e.g. a watchOS dB meter
+            // shows no levels and never prompts for mic permission. (The iOS
+            // branch already links these; watchOS was missing them.)
+            .arg("-framework")
+            .arg("AVFAudio")
+            .arg("-framework")
+            .arg("AVFoundation")
             .arg("-lSystem")
             .arg("-lresolv");
         if is_watchos_game_loop {


### PR DESCRIPTION
## What

Two bugs kept the watchOS **microphone** path silent on device — a Perry-built watchOS dB meter showed no sound levels and never prompted for mic access.

### 1. AVFAudio / AVFoundation were never linked for watchOS
The iOS link branch already passes `-framework AVFAudio -framework AVFoundation`; the watchOS branch didn't. Without them `AVAudioSession` / `AVAudioEngine` / `AVAudioApplication` aren't registered in the Objective-C runtime, so `AnyClass::get(c"AVAudioSession")` returns `nil` and the whole audio path silently no-ops.

### 2. The record-permission check used the wrong constants
`AVAudio{Session,Application}RecordPermission` is a **FourCC-coded** `NSInteger`, not 0/1/2:

| state | value |
|---|---|
| undetermined | `'undt'` = 0x756E6474 |
| denied | `'deny'` = 0x6465_6E79 |
| granted | `'grnt'` = 0x6772_6E74 |

The old `== 1` / `== 0` checks never matched these, so the permission request was never issued (no system prompt) and the engine started without mic access. This now uses the correct constants and prefers the modern **AVAudioApplication** permission API (`AVAudioSession.requestRecordPermission` is deprecated on watchOS 10+/26), falling back to `AVAudioSession` where AVAudioApplication is unavailable.

`start()` returns `1` on success and `0` on any failure/retry. Verified on an Apple Watch Series 7 — the mic prompt appears and live dB levels track. `cargo check -p perry-ui-watchos --target aarch64-apple-watchos-sim` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watchOS microphone permission handling to only begin recording when access is actually granted, with a more reliable permission request flow.
  * Updated watchOS build/run framework linking to include the required audio and foundation frameworks, improving microphone capture and audio session setup on device.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->