### PR TITLE
fix(runtime): arm64_32 ILP32 — box oversized thread_locals, guard GC pointer classifier

### DIFF
--- a/crates/perry-runtime/Cargo.toml
+++ b/crates/perry-runtime/Cargo.toml
@@ -167,12 +167,8 @@ resolv-conf = "0.7"
 # (SockRef) for the few std lacks — set_multicast_if and source-specific
 # membership — so those are real rather than silent no-ops.
 socket2 = { version = "0.6", features = ["all"] }
-# Issue #62: mimalloc replaces the system allocator for gc_malloc/arena/etc.
-# macOS `malloc` is ~25-40ns/alloc; mimalloc's per-thread free-list is ~5-10ns.
-# Set as #[global_allocator] in lib.rs, so it covers Rust heap allocations in
-# both the `perry` CLI and the compiled-TypeScript executables linked against
-# libperry_runtime.a.
-mimalloc = { version = "0.1", default-features = false }
+# mimalloc is declared 64-bit-only below (see the target_pointer_width section) —
+# on arm64_32/ILP32 it is neither used nor compiled.
 
 # We'll add GC bindings later
 # For now, use a simple bump allocator or leak memory for MVP
@@ -182,6 +178,16 @@ mimalloc = { version = "0.1", default-features = false }
 # `Win32_System_LibraryLoader` powers `perry_plugin_load` / `perry_plugin_unload`
 # (`LoadLibraryW` / `GetProcAddress` / `FreeLibrary` — the Win32 equivalents of
 # `libc::dlopen` / `dlsym` / `dlclose` that the Unix branch uses).
+# Issue #62: mimalloc replaces the system allocator for gc_malloc/arena/etc.
+# macOS `malloc` is ~25-40ns/alloc; mimalloc's per-thread free-list is ~5-10ns.
+# Set as #[global_allocator] in lib.rs, so it covers Rust heap allocations in
+# both the `perry` CLI and the compiled-TypeScript executables linked against
+# libperry_runtime.a. 64-bit only: on arm64_32 (ILP32) mimalloc is unproven and
+# a corruption suspect, so lib.rs falls back to std::alloc::System there and we
+# avoid compiling mimalloc's C on that target entirely.
+[target.'cfg(target_pointer_width = "64")'.dependencies]
+mimalloc = { version = "0.1", default-features = false }
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = [
     "Win32_System_Console",

--- a/crates/perry-runtime/src/gc/barrier.rs
+++ b/crates/perry-runtime/src/gc/barrier.rs
@@ -760,13 +760,28 @@ pub(super) fn incremental_mark_barrier_active() -> bool {
 pub(super) fn heap_word_candidate_addr(bits: u64) -> Option<usize> {
     let tag = bits & TAG_MASK;
     if tag == POINTER_TAG || tag == STRING_TAG || tag == BIGINT_TAG {
-        let ptr = (bits & POINTER_MASK) as usize;
+        let payload = bits & POINTER_MASK;
+        // arm64_32 (ILP32): a real heap pointer fits in 32 bits, so `payload as
+        // usize` is lossless only when the high 16 payload bits are zero. A
+        // mistagged/immediate value with a >32-bit payload would otherwise
+        // truncate to a garbage 32-bit address that the GC marks/derefs,
+        // corrupting unrelated heap memory. Reject it.
+        #[cfg(not(target_pointer_width = "64"))]
+        if payload > 0xFFFF_FFFF {
+            return None;
+        }
+        let ptr = payload as usize;
         return (ptr != 0).then_some(ptr);
     }
     if tag >= 0x7FF8_0000_0000_0000 {
         return None;
     }
     if (0x1000..=0x0000_FFFF_FFFF_FFFF).contains(&bits) {
+        // Same ILP32 guard for the raw-f64 pointer path.
+        #[cfg(not(target_pointer_width = "64"))]
+        if bits > 0xFFFF_FFFF {
+            return None;
+        }
         Some(bits as usize)
     } else {
         None

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -20,8 +20,15 @@
 /// allocation dispatch from ~25-40ns (macOS `malloc`) to ~5-10ns, which is
 /// meaningful because `gc_malloc` is called ~1M+ times/sec in allocation-
 /// heavy workloads (string concat loops, JSON roundtrip, gc_pressure).
+// arm64_32: mimalloc on a 32-bit-pointer (ILP32) tier-3 target is unproven and
+// a corruption suspect; use the system allocator (libsystem_malloc, solid on
+// watchOS) on 32-bit. Keep mimalloc's speed on 64-bit.
+#[cfg(target_pointer_width = "64")]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+#[cfg(not(target_pointer_width = "64"))]
+#[global_allocator]
+static GLOBAL: std::alloc::System = std::alloc::System;
 
 pub mod abi_trampoline;
 pub mod app_group;

--- a/crates/perry-runtime/src/object/class_registry/dispatch.rs
+++ b/crates/perry-runtime/src/object/class_registry/dispatch.rs
@@ -59,9 +59,11 @@ const EMPTY_VTABLE_IC_ENTRY: VTableICEntry = VTableICEntry {
 };
 
 thread_local! {
-    static VTABLE_IC: UnsafeCell<[VTableICEntry; VTABLE_IC_SIZE]> = const {
-        UnsafeCell::new([EMPTY_VTABLE_IC_ENTRY; VTABLE_IC_SIZE])
-    };
+    // arm64_32 fix: HEAP-allocate (Box) this ~160KB cache instead of inline TLS.
+    // Oversized `#[thread_local]` storage overflows the ILP32 TLS layout and its
+    // writes corrupt adjacent thread-locals. Boxing keeps only a pointer in TLS.
+    static VTABLE_IC: UnsafeCell<Box<[VTableICEntry]>> =
+        UnsafeCell::new(vec![EMPTY_VTABLE_IC_ENTRY; VTABLE_IC_SIZE].into_boxed_slice());
 }
 
 #[inline(always)]
@@ -87,7 +89,7 @@ pub(crate) unsafe fn vtable_ic_lookup(
     let cur_gen = VTABLE_GEN.load(Ordering::Relaxed);
     let slot = vtable_ic_slot(class_id, method_name_ptr);
     VTABLE_IC.with(|cell| {
-        let cache = &*cell.get();
+        let cache = &**cell.get();
         let entry = &cache[slot];
         if entry.gen == cur_gen
             && entry.class_id == class_id
@@ -120,7 +122,7 @@ pub(crate) unsafe fn vtable_ic_insert(
     let cur_gen = VTABLE_GEN.load(Ordering::Relaxed);
     let slot = vtable_ic_slot(class_id, method_name_ptr);
     VTABLE_IC.with(|cell| {
-        let cache = &mut *cell.get();
+        let cache = &mut **cell.get();
         cache[slot] = VTableICEntry {
             gen: cur_gen,
             class_id,

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -717,21 +717,35 @@ const TRANSITION_CACHE_MASK: usize = TRANSITION_CACHE_SIZE - 1;
 /// but a grep across crates/perry-codegen confirms no codegen path ever
 /// resolved against it, so the export was dead.
 thread_local! {
-    static TRANSITION_CACHE_GLOBAL: std::cell::UnsafeCell<[TransitionEntry; TRANSITION_CACHE_SIZE]> =
-        const { std::cell::UnsafeCell::new([TransitionEntry {
-            prev_keys: 0,
-            key_ptr: 0,
-            next_keys: 0,
-            slot_idx: 0,
-            target_len: 0,
-        }; TRANSITION_CACHE_SIZE]) };
+    // arm64_32 fix: HEAP-allocate the 320KB cache (Box) instead of storing it
+    // inline in TLS. Oversized `#[thread_local]` storage overflows the ILP32
+    // TLS layout and its writes corrupt adjacent thread-locals (confirmed on a
+    // real Series 7: shrinking OR boxing removes the corruption). `vec!` builds
+    // directly on the heap (no 320KB stack temporary).
+    static TRANSITION_CACHE_GLOBAL: std::cell::UnsafeCell<Box<[TransitionEntry]>> =
+        std::cell::UnsafeCell::new(
+            vec![
+                TransitionEntry {
+                    prev_keys: 0,
+                    key_ptr: 0,
+                    next_keys: 0,
+                    slot_idx: 0,
+                    target_len: 0,
+                };
+                TRANSITION_CACHE_SIZE
+            ]
+            .into_boxed_slice(),
+        );
 }
 
 #[inline]
 fn with_transition_cache<R>(
     f: impl FnOnce(*mut [TransitionEntry; TRANSITION_CACHE_SIZE]) -> R,
 ) -> R {
-    TRANSITION_CACHE_GLOBAL.with(|c| f(c.get()))
+    TRANSITION_CACHE_GLOBAL.with(|c| unsafe {
+        let boxed = &mut *c.get();
+        f(boxed.as_mut_ptr() as *mut [TransitionEntry; TRANSITION_CACHE_SIZE])
+    })
 }
 
 /// FNV-1a content hash for a property-name string.

--- a/crates/perry-runtime/src/string/intern.rs
+++ b/crates/perry-runtime/src/string/intern.rs
@@ -26,15 +26,23 @@ pub(crate) const INTERN_MAX_BYTE_LEN: u32 = 64;
 /// `static mut`, which both raced under concurrent allocation and risked
 /// handing back foreign-arena pointers.
 thread_local! {
-    pub(crate) static INTERN_TABLE: std::cell::UnsafeCell<[InternEntry; INTERN_TABLE_SIZE]> =
-        const { std::cell::UnsafeCell::new([InternEntry { hash: 0, string_ptr: 0 }; INTERN_TABLE_SIZE]) };
+    // arm64_32 fix: HEAP-allocate (Box) this ~128KB table instead of inline TLS.
+    // Oversized `#[thread_local]` storage overflows the ILP32 TLS layout and its
+    // writes corrupt adjacent thread-locals. Boxing keeps only a pointer in TLS.
+    pub(crate) static INTERN_TABLE: std::cell::UnsafeCell<Box<[InternEntry]>> =
+        std::cell::UnsafeCell::new(
+            vec![InternEntry { hash: 0, string_ptr: 0 }; INTERN_TABLE_SIZE].into_boxed_slice(),
+        );
 }
 
 #[inline]
 pub(crate) fn with_intern_table<R>(
     f: impl FnOnce(*mut [InternEntry; INTERN_TABLE_SIZE]) -> R,
 ) -> R {
-    INTERN_TABLE.with(|c| f(c.get()))
+    INTERN_TABLE.with(|c| unsafe {
+        let boxed = &mut *c.get();
+        f(boxed.as_mut_ptr() as *mut [InternEntry; INTERN_TABLE_SIZE])
+    })
 }
 
 /// Intern a property-name string. Returns the canonical pointer for


### PR DESCRIPTION
## What

The final runtime piece for building a **watchOS arm64_32** app on `main`. Follows #6107 (target-aware object-header size), #6108 (boxed exception TLS), and #6109 (AVFAudio/mic linking) — all merged. Without this, the next arm64_32 app links but corrupts memory at runtime.

## Why

On **arm64_32** (ILP32: 64-bit registers, 32-bit pointers — Apple Watch Series 4–8 / SE), oversized `#[thread_local]` statics overflow the ILP32 TLS layout, and their writes **silently corrupt adjacent thread-locals**. Three large per-thread caches trip this:

| static | size | file |
|---|---|---|
| `INTERN_TABLE` | ~128 KB | `string/intern.rs` |
| `TRANSITION_CACHE_GLOBAL` | ~320 KB | `object/mod.rs` |
| `VTABLE_IC` | ~160 KB | `object/class_registry/dispatch.rs` |

**Fix:** heap-allocate each via `Box<[T]>` so only a pointer lives in TLS. Confirmed on a real Series 7 — shrinking *or* boxing each table removes the corruption; boxing keeps full cache capacity.

## Also (ILP32-only, `cfg`-gated)

- **`gc/barrier.rs`** — reject heap-word candidates whose tagged payload exceeds 32 bits, so a mistagged/immediate value can't truncate to a garbage 32-bit address the GC then marks or dereferences.
- **`lib.rs`** — use the system allocator (`libsystem_malloc`, solid on watchOS) on 32-bit targets; mimalloc on ILP32 is unproven and a corruption suspect. 64-bit keeps mimalloc.

## Impact on 64-bit

None. Every new branch is gated to `not(target_pointer_width = "64")`, except the `Box` indirection, which is target-agnostic and free in the hot path (`.with()` still hands back a `*mut [T; N]`). `cargo check -p perry-runtime` is clean on host.

## Provenance

Extracted from the dbmeter watch app's device-test branch — the *clean* runtime fixes only. App-specific debugging scaffolding (a game-thread runner, a data-container trace logger) was deliberately left out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved 32-bit compatibility by preventing invalid pointer/address decoding and truncation of non-pointer payload bits.
  * Reduced instability on 32-bit targets by moving large per-thread caches (vtable, transition, string interning) from fixed TLS arrays to safer heap-backed storage.
  * Updated global allocator selection to use mimalloc only on 64-bit targets, with a System fallback on 32-bit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->