### PR TITLE
fix(runtime): #6070 — Object.assign with a Map/Set/exotic source no longer type-confuses its header

### DIFF
--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -648,10 +648,21 @@ pub unsafe extern "C" fn js_object_clone_with_extra(
 
     let header_size = std::mem::size_of::<ObjectHeader>();
 
-    // If source is invalid, create an empty object with enough capacity for the static props.
-    // Physical slot count = max(extra_count, 8) to match js_object_set_field_by_name's
-    // alloc_limit = max(field_count, 8) expectation.
-    if src_raw < 0x10000 {
+    // If source is invalid OR not a genuine heap object, create an empty object
+    // with capacity for the static props. Physical slot count = max(extra_count,
+    // 8) to match js_object_set_field_by_name's alloc_limit = max(field_count, 8).
+    // The `top16 >= 0x7FF8` extraction above admits SSO/BigInt/INT32/negative-
+    // double payloads and exotic headers (Map/Set/Promise/…) whose bytes are not
+    // an ObjectHeader; deref'ing `field_count`/`keys_array` off them is type
+    // confusion (#6070). The sole production caller (`js_structured_clone`)
+    // already gates on GC_TYPE_OBJECT, so this only hardens against a future one.
+    let src_is_object = src_raw >= 0x10000
+        && !crate::value::addr_class::is_handle_band(src_raw)
+        && matches!(
+            crate::value::addr_class::try_read_gc_header(src_raw),
+            Some(h) if h.obj_type == crate::gc::GC_TYPE_OBJECT
+        );
+    if !src_is_object {
         let phys_slots = std::cmp::max(extra_count, 8);
         let total_size = header_size + phys_slots as usize * 8;
         let new_ptr = arena_alloc_gc(total_size, 8, crate::gc::GC_TYPE_OBJECT) as *mut ObjectHeader;
@@ -1199,11 +1210,23 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
     // keys_array read below would deref a garbage pointer and crash (the prior
     // behavior — a hard SIGSEGV on a common operation). Enumerate the dense
     // index range directly through the array API instead. (#5347 Object/assign)
-    let source_is_array = {
-        let gc_header =
-            (src_raw as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
-        (*gc_header).obj_type == crate::gc::GC_TYPE_ARRAY
+    // Classify the source's GC type once. A genuine plain/class object keeps
+    // its own string-keyed props in `ObjectHeader.keys_array`; an array keeps
+    // indexed elements in its `ArrayHeader` buffer (handled below). Anything
+    // else (Map/Set/Promise/Date/WeakMap/…) has its OWN header layout — reading
+    // its bytes as `ObjectHeader.keys_array` yields a garbage pointer that the
+    // key-copy loop then walks as an array (a memory-layout-dependent SIGBUS on
+    // `Object.assign({}, new Map())`, #6070). Per CopyDataProperties such
+    // exotics expose no own enumerable string keys through this path, so they
+    // contribute nothing — skip them (mirrors `js_object_copy_own_fields`).
+    // Probe the GcHeader without deref-faulting — a handle-band id that passed
+    // the guards above would otherwise deref a non-heap address; mirrors the
+    // sibling `js_object_copy_own_fields`.
+    let source_obj_type = match crate::value::addr_class::try_read_gc_header(src_raw) {
+        Some(h) => h.obj_type,
+        None => return target_f64,
     };
+    let source_is_array = source_obj_type == crate::gc::GC_TYPE_ARRAY;
 
     // 1) Copy own string-keyed enumerable properties from source to target,
     //    in source insertion order. Mirrors `js_object_copy_own_fields`.
@@ -1242,7 +1265,7 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
             let key_ptr = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
             object_assign_set_string_key(target, target_is_array, key_ptr, value);
         }
-    } else {
+    } else if source_obj_type == crate::gc::GC_TYPE_OBJECT {
         let src_keys = (*src).keys_array;
         if !src_keys.is_null() && (src_keys as usize) >= 0x10000 {
             // Cap the key count at the keys array's capacity: a malformed keys

--- a/test-files/test_gap_object_assign_collection.ts
+++ b/test-files/test_gap_object_assign_collection.ts
@@ -1,0 +1,20 @@
+// Object.assign / object-spread with an exotic source (Map/Set/Date/RegExp)
+// must not crash: such objects expose no own enumerable string keys, so they
+// contribute nothing (CopyDataProperties). Regression test for #6070, where a
+// Map/Set source deref'd its header bytes as an ObjectHeader.keys_array — the
+// bogus keys pointer was then walked as an array (a memory-layout-dependent
+// SIGBUS, made deterministic here by sourcing through `any`-typed bindings).
+const m: any = new Map([["a", 1]]);
+const s: any = new Set([1, 2, 3]);
+console.log(JSON.stringify(Object.assign({ z: 0 }, m)));
+console.log(JSON.stringify(Object.assign({ z: 0 }, s)));
+console.log(JSON.stringify({ z: 0, ...m }));
+console.log(JSON.stringify(Object.assign({}, new Date(0))));
+console.log(JSON.stringify(Object.assign({}, /x/g)));
+// The any-typed loop is what made the crash reliably reproduce.
+const cases: any[] = [new Map([["a", 1]]), new Set([1]), new Date(0), /y/];
+let out = "";
+for (const src of cases) out += JSON.stringify(Object.assign({ z: 0 }, src)) + ";";
+console.log(out);
+// Genuine object and array sources still copy their own enumerable props.
+console.log(JSON.stringify(Object.assign({ a: 1 }, { b: 2 }, [10, 20])));


### PR DESCRIPTION
Fixes #6070.

### Problem
`js_object_assign_one` dispatches string / proxy / closure / array sources explicitly, but any *other* pointer source (Map, Set, Date, RegExp, …) fell through to `let src = src_raw as *const ObjectHeader; … (*src).keys_array`. A `MapHeader` etc. has its own layout, so `keys_array` at the `ObjectHeader` offset reads a garbage pointer *past* the exotic header — which the key-copy loop then walks as an array (reading its GC header → SIGBUS).

Whether it faults depends on the bytes sitting past the exotic header, so the simplest form (`Object.assign({}, new Map([["a",1]]))`) currently happens to survive on `main`, but the same call through an `any`-typed binding reliably crashes:
```ts
const src: any = new Map([["a", 1]]);
Object.assign({ z: 0 }, src);   // SIGBUS  (node: { z: 0 })
```
Per CopyDataProperties a Map/Set/Date/RegExp exposes no own enumerable **string** keys, so the result is just the target.

(The object-**spread** half of #6070 was already fixed by the 2026-07-02 band-safety sweep — `{...map}` routes through the hardened `js_object_copy_own_fields`. This completes the `Object.assign` path and hardens the `js_object_clone_with_extra` footgun the issue also flagged.)

### Fix
- `js_object_assign_one`: classify the source's GC type once and gate the `keys_array` walk on `GC_TYPE_OBJECT`. Arrays keep their existing dedicated path; anything else contributes nothing. Exact mirror of `js_object_copy_own_fields`.
- `js_object_clone_with_extra`: its sole production caller (`js_structured_clone`) already gates on `GC_TYPE_OBJECT`, but the function still used the pre-audit `top16 >= 0x7FF8` extraction and deref'd `field_count` unchecked. Added the same `try_read_gc_header → GC_TYPE_OBJECT` guard, falling back to the existing empty-object path for a non-object source (never taken by the current caller; hardens against a future one).

### Test
`test-files/test_gap_object_assign_collection.ts` — Map/Set/Date/RegExp sources (including an `any`-typed loop, the form that reliably crashed) yield the target unchanged, and genuine object + array sources still copy their own enumerable props. Byte-for-byte match vs `node --experimental-strip-types`; normal object/spread/class/getter/symbol behavior separately regression-checked.

### Out of scope (filed separately)
`WeakMap`/`WeakSet` are implemented as plain objects carrying an enumerable `__perry_wk_entries` field, so `Object.assign({}, new WeakMap())` leaks that internal key (node: `{}`). That's a pre-existing enumeration bug independent of this crash (setting the field non-enumerable would trip the process-wide `GLOBAL_DESCRIPTORS_IN_USE` deopt), tracked in a follow-up issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved object copying so non-plain sources like Maps, Sets, Dates, and RegExps are handled safely.
  * Prevented invalid source values from being treated like regular objects during property assignment and spread operations.
  * Added coverage to confirm normal object and array property copying still works as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->