### PR TITLE
fix(runtime): export js_array_length as a #[no_mangle] C symbol

### DIFF
--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -417,6 +417,14 @@ pub(crate) unsafe fn keys_array_len_capped_to_capacity(arr: *const ArrayHeader) 
     }
 }
 
+/// Auto-opt dead-strip anchor: codegen emits a bare `js_array_length` symbol in
+/// native-region wrappers (`__perry_wrap_*`) and elsewhere, so it must be a
+/// `#[no_mangle]` C export AND survive dead-stripping even when no Rust caller
+/// keeps it referenced — mirroring the neighbouring `js_array_push`.
+#[used]
+static KEEP_ARRAY_LENGTH: extern "C" fn(*const ArrayHeader) -> u32 = js_array_length;
+
+#[no_mangle]
 pub extern "C" fn js_array_length(arr: *const ArrayHeader) -> u32 {
     // #5135: a Proxy typed (statically) as an array (immer drafts) reaches here
     // with the masked proxy id. Read `length` through the proxy `get` trap


### PR DESCRIPTION
### Problem
`js_array_length` (`crates/perry-runtime/src/array/indexing.rs`) is `pub extern "C"` but was **missing `#[no_mangle]`**, so `libperry_runtime.a` carried it only under its mangled Rust name (`_ZN…js_array_length…E`). Codegen declares and emits a bare `js_array_length` symbol in native-region wrappers (`__perry_wrap_*`) and other array paths, so any program that reaches that path fails to link:

```
Undefined symbols for architecture arm64:
  "_js_array_length", referenced from:
      ___perry_wrap_perry_fn_numeric_arrays_ts__numericArraysChecksum in numeric_arrays_ts.o
```

The neighbouring `js_array_push` has `#[no_mangle]`; this one was simply missed. (The linker message lists the *callers*, not the missing symbol — the actual undefined symbol is `_js_array_length`.)

This is what fails the `native-region-proof` / `native-ABI-proof` compiler-output gates (workloads `loop_data_dependent`, `numeric_arrays`, `packed_f64_loop_versioning_negative`), and it blocks any local/CI build that hits the native-region path.

### Fix
Add `#[no_mangle]` and a `#[used] static KEEP_ARRAY_LENGTH` anchor (matching the existing `KEEP_*` anchors in this file) so the C export exists **and** survives auto-opt dead-stripping.

### Verification
- `nm libperry_runtime.a` now shows `T _js_array_length` (was absent).
- `native-region-proof` gate: **3 failed workloads → 0** (`failed_workloads: []`, exit 0).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a runtime array-length capability from being removed during builds, improving reliability in configurations where it might otherwise be stripped out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->