### PR TITLE
fix(publish/compile): controllable CPU baseline — stop baking build-box AVX-512 into published binaries

### DIFF
--- a/crates/perry-codegen/src/linker.rs
+++ b/crates/perry-codegen/src/linker.rs
@@ -50,6 +50,52 @@ fn native_tuning_arg_for_host() -> &'static str {
     }
 }
 
+/// Resolve the CPU-tuning clang flag for one `.ll` → `.o` compile (#6125).
+///
+/// `requested` is the value of `PERRY_TARGET_CPU` — set directly, or promoted
+/// by the compile driver from `--march` / perry.toml `[build] march` /
+/// `[build] native_tuning`:
+///
+///   - `None` (unset) — historical default: a host build (no explicit target
+///     triple) tunes to the build machine via `-march=native`/`-mcpu=native`;
+///     an explicit-triple build gets no tuning flag (the target's portable
+///     baseline).
+///   - `"native"` — force build-machine tuning.
+///   - `"generic"` / `"off"` / `"none"` / `"0"` / `"false"` — no tuning flag:
+///     the target architecture's portable baseline, even for host builds.
+///   - anything else — an explicit LLVM CPU name (`x86-64-v2`, `x86-64-v3`,
+///     `znver2`, `apple-m1`, …) the emitted code must not exceed.
+///
+/// The flag spelling follows the EFFECTIVE target, not the host: x86 targets
+/// take `-march=<cpu>`, everything else (aarch64/arm, riscv) `-mcpu=<cpu>`.
+/// This knob exists because binaries built on one machine and run on another
+/// (the `perry publish` hub, shared CI caches) must not bake the build box's
+/// full instruction set — e.g. AVX-512 — into the shipped objects, which
+/// SIGILLs on any CPU missing those extensions.
+fn cpu_tuning_arg_for(
+    requested: Option<&str>,
+    target_triple: Option<&str>,
+    effective_target: &str,
+) -> Option<String> {
+    let arch_flag = |cpu: &str| {
+        let is_x86 = effective_target.starts_with("x86_64")
+            || effective_target.starts_with("i686")
+            || effective_target.starts_with("i586");
+        if is_x86 {
+            format!("-march={cpu}")
+        } else {
+            format!("-mcpu={cpu}")
+        }
+    };
+    match requested.map(str::trim).filter(|s| !s.is_empty()) {
+        None => target_triple
+            .is_none()
+            .then(|| native_tuning_arg_for_host().to_string()),
+        Some("generic") | Some("off") | Some("none") | Some("0") | Some("false") => None,
+        Some(cpu) => Some(arch_flag(cpu)),
+    }
+}
+
 /// Default IR-size cutoff above which a module is compiled at `-O0` instead
 /// of `-O3` (#4880). A module dominated by a huge generated literal
 /// (config / lookup table) lowers to one enormous function whose
@@ -135,9 +181,9 @@ fn build_clang_compile_plan(
     let effective_target = target_triple
         .map(|s| s.to_string())
         .unwrap_or_else(crate::codegen::default_target_triple);
-    let native_tuning_arg = target_triple
-        .is_none()
-        .then(|| native_tuning_arg_for_host().to_string());
+    let requested_cpu = std::env::var("PERRY_TARGET_CPU").ok();
+    let native_tuning_arg =
+        cpu_tuning_arg_for(requested_cpu.as_deref(), target_triple, &effective_target);
     let stderr_remarks_path = PathBuf::from(format!("{}.clang-stderr", obj_path.display()));
 
     // #4880: oversized modules don't get the speed-tuned -O3 pipeline (it goes
@@ -280,8 +326,10 @@ pub fn compile_ll_to_object(ll_text: &str, target_triple: Option<&str>) -> Resul
     // host default when target is None) makes clang trust the IR and
     // skips the override path.
     //
-    // Native CPU tuning remains part of the same plan when no explicit target
-    // is supplied: only host builds receive `-mcpu=native` / `-march=native`.
+    // CPU tuning rides the same plan: by default only host builds receive
+    // `-mcpu=native` / `-march=native`; `PERRY_TARGET_CPU` (from `--march` /
+    // perry.toml `[build]`) overrides that with an explicit baseline or
+    // disables tuning entirely. See `cpu_tuning_arg_for` (#6125).
 
     log::debug!("perry-codegen: {:?}", cmd);
     let output = cmd
@@ -1055,6 +1103,75 @@ mod tests {
             .clang_args
             .iter()
             .any(|arg| arg == "-march=native" || arg == "-mcpu=native"));
+    }
+
+    #[test]
+    fn cpu_tuning_unset_keeps_historical_defaults() {
+        // Host build (no triple) → native tuning; explicit triple → none.
+        assert_eq!(
+            cpu_tuning_arg_for(None, None, "x86_64-apple-darwin").as_deref(),
+            Some(native_tuning_arg_for_host())
+        );
+        assert_eq!(
+            cpu_tuning_arg_for(
+                None,
+                Some("x86_64-unknown-linux-gnu"),
+                "x86_64-unknown-linux-gnu"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn cpu_tuning_explicit_cpu_spells_march_or_mcpu_by_target_arch() {
+        // #6125: an explicit baseline applies to host AND cross builds, and
+        // the flag spelling follows the effective target's architecture.
+        assert_eq!(
+            cpu_tuning_arg_for(Some("x86-64-v2"), None, "x86_64-unknown-linux-gnu").as_deref(),
+            Some("-march=x86-64-v2")
+        );
+        assert_eq!(
+            cpu_tuning_arg_for(
+                Some("x86-64-v3"),
+                Some("x86_64-unknown-linux-musl"),
+                "x86_64-unknown-linux-musl"
+            )
+            .as_deref(),
+            Some("-march=x86-64-v3")
+        );
+        assert_eq!(
+            cpu_tuning_arg_for(Some("apple-m1"), None, "arm64-apple-macosx15.0.0").as_deref(),
+            Some("-mcpu=apple-m1")
+        );
+    }
+
+    #[test]
+    fn cpu_tuning_generic_disables_native_tuning_on_host_builds() {
+        for off in ["generic", "off", "none", "0", "false"] {
+            assert_eq!(
+                cpu_tuning_arg_for(Some(off), None, "x86_64-apple-darwin"),
+                None,
+                "'{off}' should disable tuning"
+            );
+        }
+        // Whitespace / empty values fall back to the default.
+        assert_eq!(
+            cpu_tuning_arg_for(Some("  "), None, "x86_64-apple-darwin").as_deref(),
+            Some(native_tuning_arg_for_host())
+        );
+    }
+
+    #[test]
+    fn cpu_tuning_native_can_be_forced_for_explicit_triples() {
+        assert_eq!(
+            cpu_tuning_arg_for(
+                Some("native"),
+                Some("x86_64-unknown-linux-gnu"),
+                "x86_64-unknown-linux-gnu"
+            )
+            .as_deref(),
+            Some("-march=native")
+        );
     }
 
     #[test]

--- a/crates/perry/src/commands/compile/bootstrap.rs
+++ b/crates/perry/src/commands/compile/bootstrap.rs
@@ -902,6 +902,53 @@ pub(super) fn validate_windows_subsystem(
     Ok(())
 }
 
+/// #6125: resolve the CPU-baseline knob into the canonical `PERRY_TARGET_CPU`
+/// env var, which codegen (`clang -march`/`-mcpu`), the object/build cache
+/// keys, and the auto-optimize runtime/stdlib rebuild (`-C target-cpu`) all
+/// honor uniformly.
+///
+/// Precedence: `--march` → `PERRY_TARGET_CPU` already in the environment →
+/// perry.toml `[build] march` → `[build] native_tuning` (`false` is shorthand
+/// for `generic`, `true` for `native`). The toml sources are what survive the
+/// `perry publish` worker round-trip, like `[windows] subsystem` above.
+/// Mirrors the `--debug-symbols` → `PERRY_DEBUG_SYMBOLS` promotion: must run
+/// single-threaded, before module codegen spawns rayon workers, so every
+/// layer observes one value.
+pub(super) fn promote_cpu_baseline_env(args: &CompileArgs) {
+    if let Some(march) = args
+        .march
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        std::env::set_var("PERRY_TARGET_CPU", march);
+        return;
+    }
+    if std::env::var_os("PERRY_TARGET_CPU").is_some() {
+        return;
+    }
+    let project_root = find_project_root_for_resources(&args.input, true);
+    let Ok(content) = std::fs::read_to_string(project_root.join("perry.toml")) else {
+        return;
+    };
+    let Ok(doc) = content.parse::<toml::Table>() else {
+        return;
+    };
+    let march = super::app_metadata::toml_string(&doc, "build", "march")
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            let tuning = doc
+                .get("build")
+                .and_then(|b| b.get("native_tuning"))
+                .and_then(|v| v.as_bool())?;
+            Some(if tuning { "native" } else { "generic" }.to_string())
+        });
+    if let Some(march) = march {
+        std::env::set_var("PERRY_TARGET_CPU", march);
+    }
+}
+
 /// Run the full post-collect preflight chain (capability / egress /
 /// lockdown / SBOM / geisterhand / windows-version / project_root
 /// recompute / module-count print). All gates collected here so the

--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -38,6 +38,11 @@ const BUILD_CACHE_ENV_VARS: &[&str] = &[
     "PERRY_DISABLE_BUFFER_FAST_PATH",
     "PERRY_VERIFY_NATIVE_REGIONS",
     "PERRY_UNBOXED_OBJECT_FIELDS",
+    // #6125: the resolved CPU baseline (promoted from --march / perry.toml
+    // [build] by promote_cpu_baseline_env before this probe runs). Flipping
+    // it must invalidate the build-level no-op check, not just per-object
+    // cache entries.
+    "PERRY_TARGET_CPU",
     "PERRY_NO_AUTO_OPTIMIZE",
     "PERRY_DISABLE_WELL_KNOWN",
     "PERRY_FORCE_WELL_KNOWN",

--- a/crates/perry/src/commands/compile/object_cache.rs
+++ b/crates/perry/src/commands/compile/object_cache.rs
@@ -230,17 +230,21 @@ fn stable_type_key(ty: &perry_types::Type) -> String {
 /// at compile time but that aren't part of `CompileOptions`:
 /// `PERRY_DEBUG_INIT`, `PERRY_DEBUG_SYMBOLS`, `PERRY_LLVM_CLANG`,
 /// `PERRY_WRITE_BARRIERS`, `PERRY_SHADOW_STACK`,
-/// `PERRY_DISABLE_BUFFER_FAST_PATH`, `PERRY_VERIFY_NATIVE_REGIONS`, and
-/// `PERRY_UNBOXED_OBJECT_FIELDS`. See the env-var block at the bottom of
-/// this function for the rationale.
+/// `PERRY_DISABLE_BUFFER_FAST_PATH`, `PERRY_VERIFY_NATIVE_REGIONS`,
+/// `PERRY_UNBOXED_OBJECT_FIELDS`, and `PERRY_TARGET_CPU`. See the env-var
+/// block at the bottom of this function for the rationale.
 ///
-/// NOT captured in the key: the host CPU. `compile_ll_to_object` passes
-/// `-mcpu=native`/`-march=native` to clang, so the emitted `.o` bakes in
-/// whatever instruction set the build machine supports. The cache is
-/// consequently **machine-local** — the default `node_modules/.cache/perry`
+/// NOT captured in the key: the host CPU. By default (`PERRY_TARGET_CPU`
+/// unset) `compile_ll_to_object` passes `-mcpu=native`/`-march=native` to
+/// clang for host builds, so the emitted `.o` bakes in whatever instruction
+/// set the build machine supports. The cache is consequently
+/// **machine-local** — the default `node_modules/.cache/perry`
 /// is inside the already-gitignored `node_modules/` for this reason.
 /// Sharing across machines with different CPUs (rsync,
-/// NFS, Docker bind-mount) can produce SIGILL at runtime.
+/// NFS, Docker bind-mount) can produce SIGILL at runtime. Pinning an
+/// explicit baseline (`--march x86-64-v2` / `[build] march`, #6125) removes
+/// the machine dependence — the chosen baseline IS keyed, via the
+/// `PERRY_TARGET_CPU` env field.
 ///
 /// Cross-platform non-determinism (Mach-O LC_UUID, PE TimeDateStamp,
 /// codesigning) affects the *linked binary*, not the object file — so
@@ -765,6 +769,11 @@ fn compute_object_cache_key_with_env(
     //     not be bypassed by a stale cache hit.
     //   - PERRY_UNBOXED_OBJECT_FIELDS=1 changes object-literal layout
     //     lowering for exact typed object shapes.
+    //   - PERRY_TARGET_CPU (#6125, set directly or promoted from `--march` /
+    //     perry.toml `[build] march`/`native_tuning`) changes the clang
+    //     `-march`/`-mcpu` tuning flag, i.e. which instruction-set baseline
+    //     the .o bytes assume. Serving a host-native-tuned object to a
+    //     pinned-baseline build would silently ship AVX-512 again.
     // Hashing the values (not just presence) means a persistent override
     // like PERRY_LLVM_CLANG=/opt/homebrew/opt/llvm/bin/clang in a shell rc
     // still gets cache reuse across runs, while flipping a debug flag on
@@ -806,6 +815,10 @@ fn compute_object_cache_key_with_env(
         env_var("PERRY_UNBOXED_OBJECT_FIELDS")
             .as_deref()
             .unwrap_or(""),
+    );
+    h.field(
+        "env_target_cpu",
+        env_var("PERRY_TARGET_CPU").as_deref().unwrap_or(""),
     );
 
     h.finish()
@@ -1609,6 +1622,7 @@ mod object_cache_tests {
             "PERRY_DISABLE_BUFFER_FAST_PATH",
             "PERRY_VERIFY_NATIVE_REGIONS",
             "PERRY_UNBOXED_OBJECT_FIELDS",
+            "PERRY_TARGET_CPU",
         ] {
             // Sample state without the var, with the var, and with a different
             // value — all three keys must be distinct.

--- a/crates/perry/src/commands/compile/optimized_libs/driver.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/driver.rs
@@ -770,11 +770,29 @@ pub(crate) fn build_optimized_libs(
     // and cargo correctly reuses incremental artifacts that were built with
     // the same RUSTFLAGS. The hash-keyed CARGO_TARGET_DIR keeps builds with
     // distinct flag sets from clobbering each other's cache.
-    let mut rustflags: Vec<&str> = Vec::new();
+    let mut rustflags: Vec<String> = Vec::new();
     if panic_abort_safe {
         // Override the workspace profile's `panic = "unwind"` for the
         // duration of this invocation.
-        rustflags.push("-C panic=abort");
+        rustflags.push("-C panic=abort".to_string());
+    }
+    // #6125: pin the Rust-side CPU baseline to the same PERRY_TARGET_CPU
+    // knob codegen's clang invocation honors, so the rebuilt runtime/stdlib
+    // (which is what runs before the app's first print — exactly where the
+    // reported SIGILLs landed) obeys the requested portable baseline too.
+    // A `generic`-family value adds no flag but still forces RUSTFLAGS to be
+    // set explicitly below, so an ambient `-C target-cpu=native` (shell rc,
+    // CI image, build-server environment) can't leak the build box's ISA
+    // into libraries that ship to other machines.
+    let requested_cpu = std::env::var("PERRY_TARGET_CPU")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    if let Some(cpu) = &requested_cpu {
+        match cpu.as_str() {
+            "generic" | "off" | "none" | "0" | "false" => {}
+            cpu => rustflags.push(format!("-C target-cpu={cpu}")),
+        }
     }
     // #1529 — Android loads `libperry_app.so` via `dlopen` at runtime
     // (PerryActivity's System.loadLibrary), but Rust's default TLS model for
@@ -789,9 +807,14 @@ pub(crate) fn build_optimized_libs(
         target,
         Some("android") | Some("android-x86_64") | Some("wearos")
     ) {
-        rustflags.push(android_global_dynamic_tls_rustflag(&mut cargo_cmd));
+        rustflags.push(android_global_dynamic_tls_rustflag(&mut cargo_cmd).to_string());
     }
-    if !rustflags.is_empty() {
+    // Set RUSTFLAGS whenever we have flags to pass, and also whenever a CPU
+    // baseline was requested at all (#6125): explicitly setting the env var —
+    // even to a flag list without a `-C target-cpu` — overrides any inherited
+    // RUSTFLAGS from the parent environment, which is exactly the isolation a
+    // pinned-baseline build needs.
+    if !rustflags.is_empty() || requested_cpu.is_some() {
         cargo_cmd.env("RUSTFLAGS", rustflags.join(" "));
     }
 
@@ -920,6 +943,17 @@ pub(crate) fn build_optimized_libs(
             bc_rustflags.push_str("-C panic=abort ");
         }
         bc_rustflags.push_str("-C codegen-units=1");
+        // #6125: the bitcode-LTO path must obey the same CPU baseline as the
+        // staticlib build above, or the LTO'd binary re-imports the build
+        // box's ISA through the runtime bitcode.
+        if let Some(cpu) = &requested_cpu {
+            match cpu.as_str() {
+                "generic" | "off" | "none" | "0" | "false" => {}
+                cpu => {
+                    bc_rustflags.push_str(&format!(" -C target-cpu={cpu}"));
+                }
+            }
+        }
 
         let emit_bc = |crate_name: &str| -> Option<PathBuf> {
             let mut cmd = Command::new("cargo");

--- a/crates/perry/src/commands/compile/run_pipeline.rs
+++ b/crates/perry/src/commands/compile/run_pipeline.rs
@@ -55,6 +55,16 @@ pub fn run_with_parse_cache(
         std::env::set_var("PERRY_DEBUG_SYMBOLS", "1");
     }
 
+    // #6125: resolve the CPU-baseline knob (`--march` / env / perry.toml
+    // `[build] march` / `[build] native_tuning`) into the canonical
+    // PERRY_TARGET_CPU env var, exactly like `--debug-symbols` above.
+    // Codegen's clang invocation, the object/build cache keys, and the
+    // auto-optimize runtime rebuild all read that one var, so a build meant
+    // to run on other machines (publish workers, CI) can pin a portable
+    // baseline (e.g. x86-64-v2) instead of baking the build box's full ISA
+    // (AVX-512) into the shipped binary.
+    bootstrap::promote_cpu_baseline_env(&args);
+
     // `--trace <stages>` consolidates the scattered debug-dump knobs into one
     // flag. Parse it up-front (single-threaded, before codegen spawns rayon
     // workers) so the `llvm` stage can promote itself to the env vars the

--- a/crates/perry/src/commands/compile/types.rs
+++ b/crates/perry/src/commands/compile/types.rs
@@ -121,6 +121,20 @@ pub struct CompileArgs {
     #[arg(long)]
     pub libc: Option<String>,
 
+    /// CPU baseline for the generated machine code (#6125). Accepts an LLVM
+    /// CPU name (`x86-64-v2`, `x86-64-v3`, `znver2`, `apple-m1`, …), `native`
+    /// (tune to this machine's full instruction set — the default for host
+    /// builds), or `generic`/`off` (the target architecture's portable
+    /// baseline — the default for cross builds). Pin this when the binary
+    /// will run on other machines: a build box with AVX-512 otherwise bakes
+    /// AVX-512 into a host-native build, which SIGILLs on older x86-64 CPUs.
+    /// Also settable via the `PERRY_TARGET_CPU` env var or perry.toml
+    /// `[build] march`; `[build] native_tuning = false` is shorthand for
+    /// `generic`. Applies to app code, and to the auto-optimized
+    /// runtime/stdlib rebuild via `-C target-cpu`.
+    #[arg(long)]
+    pub march: Option<String>,
+
     /// App bundle identifier (required for widget targets)
     #[arg(long)]
     pub app_bundle_id: Option<String>,

--- a/crates/perry/src/commands/dev.rs
+++ b/crates/perry/src/commands/dev.rs
@@ -290,6 +290,7 @@ fn build_once(
         enable_wasm_runtime: false,
         target: None,
         libc: None,
+        march: None,
         app_bundle_id: None,
         output_type: "executable".to_string(),
         bundle_extensions: None,

--- a/crates/perry/src/commands/publish/args.rs
+++ b/crates/perry/src/commands/publish/args.rs
@@ -15,6 +15,18 @@ pub struct PublishArgs {
     #[arg(long)]
     pub libc: Option<String>,
 
+    /// CPU baseline for the produced binaries (#6125): an LLVM CPU name
+    /// (`x86-64-v2`, `x86-64-v3`, …), `native` (tune to the build worker's
+    /// machine — fastest, but the binary only runs on CPUs at least as new),
+    /// or `generic` (the target architecture's portable baseline). Overrides
+    /// the `[build] march` / `[build] native_tuning` perry.toml settings.
+    /// Linux defaults to `x86-64-v2` so published services run on any
+    /// x86-64 CPU from the last ~15 years instead of inheriting the build
+    /// server's instruction set (AVX-512 → SIGILL on Zen2/EPYC and other
+    /// non-AVX-512 hosts).
+    #[arg(long)]
+    pub march: Option<String>,
+
     /// Build server URL
     #[arg(long, default_value = "https://hub.perryts.com")]
     pub server: Option<String>,

--- a/crates/perry/src/commands/publish/config_types.rs
+++ b/crates/perry/src/commands/publish/config_types.rs
@@ -239,6 +239,32 @@ pub(super) struct BuildConfig {
     pub(super) native_tuning: Option<bool>,
 }
 
+/// Resolve the CPU baseline forwarded to the build worker (#6125).
+///
+/// `--march` wins over `[build] march`, which wins over the
+/// `[build] native_tuning` boolean shorthand (`true` → `native`, `false` →
+/// `generic`). Linux defaults to the portable `x86-64-v2`: the hub worker
+/// compiles linux-on-linux natively, and an unpinned baseline bakes the
+/// build box's full ISA (AVX-512) into the binary, which SIGILLs on
+/// non-AVX-512 hosts (Zen2/EPYC-Rome, pre-Skylake Xeons). Forwarded to the
+/// worker as `BuildManifest.build_march` → `perry compile --march`.
+pub(super) fn resolve_build_march(
+    march_flag: Option<&str>,
+    build: Option<&BuildConfig>,
+    is_linux: bool,
+) -> Option<String> {
+    march_flag
+        .or_else(|| build.and_then(|b| b.march.as_deref()))
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            build
+                .and_then(|b| b.native_tuning)
+                .map(|tuning| if tuning { "native" } else { "generic" }.to_string())
+        })
+        .or_else(|| is_linux.then(|| "x86-64-v2".to_string()))
+}
+
 #[derive(Debug, Deserialize)]
 pub(super) struct PublishConfig {
     pub(super) server: Option<String>,

--- a/crates/perry/src/commands/publish/config_types.rs
+++ b/crates/perry/src/commands/publish/config_types.rs
@@ -228,6 +228,15 @@ pub(super) struct WindowsConfig {
 #[derive(Debug, Deserialize)]
 pub(super) struct BuildConfig {
     pub(super) out_dir: Option<String>,
+    /// CPU baseline for the produced binaries (#6125): an LLVM CPU name
+    /// (`x86-64-v2`, `x86-64-v3`, `znver2`, …), `native`, or `generic`.
+    /// Forwarded to the build worker as `build_march`, which drives
+    /// `perry compile --march`. Wins over `native_tuning`.
+    pub(super) march: Option<String>,
+    /// Boolean shorthand: `true` → tune to the build worker's CPU
+    /// (`native`), `false` → the target's portable baseline (`generic`).
+    /// Ignored when `march` is set.
+    pub(super) native_tuning: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/perry/src/commands/publish/mod.rs
+++ b/crates/perry/src/commands/publish/mod.rs
@@ -41,7 +41,7 @@ pub(crate) use saved_config::{
 pub(crate) use tarball::{create_project_tarball, create_project_tarball_with_excludes};
 
 // Sibling-only items used by run_async and tests.
-use config_types::PerryToml;
+use config_types::{resolve_build_march, PerryToml};
 use credentials::{
     auto_export_p12_from_keychain, prompt_target, resolve_credential, resolve_path_credential,
     validate_credentials_for_distribute,
@@ -206,28 +206,8 @@ async fn run_async(args: PublishArgs, format: OutputFormat, _use_color: bool) ->
         None
     };
 
-    // --- Resolve CPU baseline (#6125) ---
-    // `--march` wins over `[build] march`, which wins over the
-    // `[build] native_tuning` boolean shorthand (true → `native`, false →
-    // `generic`). Linux defaults to the portable `x86-64-v2`: the hub worker
-    // compiles linux-on-linux natively, and an unpinned baseline bakes the
-    // build box's full ISA (AVX-512) into the binary, which SIGILLs on
-    // non-AVX-512 hosts (Zen2/EPYC-Rome, pre-Skylake Xeons). Forwarded to
-    // the worker as `build_march` → `perry compile --march`.
-    let build_march: Option<String> = args
-        .march
-        .as_deref()
-        .or_else(|| config.build.as_ref().and_then(|b| b.march.as_deref()))
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .or_else(|| {
-            config
-                .build
-                .as_ref()
-                .and_then(|b| b.native_tuning)
-                .map(|tuning| if tuning { "native" } else { "generic" }.to_string())
-        })
-        .or_else(|| is_linux.then(|| "x86-64-v2".to_string()));
+    // --- Resolve CPU baseline (#6125) — see resolve_build_march ---
+    let build_march = resolve_build_march(args.march.as_deref(), config.build.as_ref(), is_linux);
     if is_linux {
         if let (OutputFormat::Text, Some(march)) = (&format, &build_march) {
             println!("  CPU:       {} baseline", style(march).bold());

--- a/crates/perry/src/commands/publish/mod.rs
+++ b/crates/perry/src/commands/publish/mod.rs
@@ -206,6 +206,34 @@ async fn run_async(args: PublishArgs, format: OutputFormat, _use_color: bool) ->
         None
     };
 
+    // --- Resolve CPU baseline (#6125) ---
+    // `--march` wins over `[build] march`, which wins over the
+    // `[build] native_tuning` boolean shorthand (true → `native`, false →
+    // `generic`). Linux defaults to the portable `x86-64-v2`: the hub worker
+    // compiles linux-on-linux natively, and an unpinned baseline bakes the
+    // build box's full ISA (AVX-512) into the binary, which SIGILLs on
+    // non-AVX-512 hosts (Zen2/EPYC-Rome, pre-Skylake Xeons). Forwarded to
+    // the worker as `build_march` → `perry compile --march`.
+    let build_march: Option<String> = args
+        .march
+        .as_deref()
+        .or_else(|| config.build.as_ref().and_then(|b| b.march.as_deref()))
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            config
+                .build
+                .as_ref()
+                .and_then(|b| b.native_tuning)
+                .map(|tuning| if tuning { "native" } else { "generic" }.to_string())
+        })
+        .or_else(|| is_linux.then(|| "x86-64-v2".to_string()));
+    if is_linux {
+        if let (OutputFormat::Text, Some(march)) = (&format, &build_march) {
+            println!("  CPU:       {} baseline", style(march).bold());
+        }
+    }
+
     // --- Resolve server URL ---
     let server_url = args
         .server
@@ -1333,6 +1361,7 @@ async fn run_async(args: PublishArgs, format: OutputFormat, _use_color: bool) ->
             None
         },
         linux_libc: linux_libc.clone(),
+        build_march: build_march.clone(),
         release_notes: config.release_notes.clone(),
         features: config.project.as_ref().and_then(|p| p.features.clone()),
     };

--- a/crates/perry/src/commands/publish/server_api.rs
+++ b/crates/perry/src/commands/publish/server_api.rs
@@ -157,6 +157,16 @@ pub(super) struct BuildManifest {
     /// `perry compile --target linux[-musl]` selection. #4826.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) linux_libc: Option<String>,
+    /// CPU baseline for the produced binaries (#6125): an LLVM CPU name
+    /// (`x86-64-v2`, …), `native`, or `generic`. Drives the worker's
+    /// `perry compile --march <value>`. The client defaults linux builds to
+    /// `x86-64-v2` — the hub worker compiles linux-on-linux natively, and
+    /// without a pinned baseline the binary inherits the build box's full
+    /// ISA (AVX-512) and SIGILLs on older x86-64 CPUs (Zen2/EPYC-Rome,
+    /// pre-Skylake Xeons). `[build] native_tuning = true` /
+    /// `--march native` opts back into build-machine tuning.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) build_march: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) release_notes: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/perry/src/commands/publish/tests.rs
+++ b/crates/perry/src/commands/publish/tests.rs
@@ -608,3 +608,49 @@ fn test_server_is_local() {
     assert!(!server_is_local("http://10.0.0.5:3000"));
     assert!(!server_is_local("not a url"));
 }
+
+#[test]
+fn test_resolve_build_march_precedence_and_linux_default() {
+    // #6125 — CLI --march > [build] march > [build] native_tuning shorthand
+    // > linux portable default > nothing.
+    fn bc(march: Option<&str>, native_tuning: Option<bool>) -> config_types::BuildConfig {
+        config_types::BuildConfig {
+            out_dir: None,
+            march: march.map(str::to_string),
+            native_tuning,
+        }
+    }
+
+    // CLI flag wins over everything.
+    let cfg = bc(Some("x86-64-v3"), Some(false));
+    assert_eq!(
+        resolve_build_march(Some("znver2"), Some(&cfg), true).as_deref(),
+        Some("znver2")
+    );
+    // [build] march wins over native_tuning.
+    assert_eq!(
+        resolve_build_march(None, Some(&cfg), true).as_deref(),
+        Some("x86-64-v3")
+    );
+    // native_tuning shorthand: false → generic, true → native.
+    assert_eq!(
+        resolve_build_march(None, Some(&bc(None, Some(false))), true).as_deref(),
+        Some("generic")
+    );
+    assert_eq!(
+        resolve_build_march(None, Some(&bc(None, Some(true))), true).as_deref(),
+        Some("native")
+    );
+    // Unset on linux → portable x86-64-v2 default (whitespace-only march
+    // counts as unset).
+    assert_eq!(
+        resolve_build_march(None, None, true).as_deref(),
+        Some("x86-64-v2")
+    );
+    assert_eq!(
+        resolve_build_march(Some("  "), Some(&bc(Some(" "), None)), true).as_deref(),
+        Some("x86-64-v2")
+    );
+    // Unset on a non-linux target → nothing is sent.
+    assert_eq!(resolve_build_march(None, None, false), None);
+}

--- a/crates/perry/src/commands/run/mod.rs
+++ b/crates/perry/src/commands/run/mod.rs
@@ -202,6 +202,7 @@ pub fn run(args: RunArgs, format: OutputFormat, use_color: bool, verbose: u8) ->
         enable_wasm_runtime: args.enable_wasm_runtime,
         target: target.clone(),
         libc: args.libc.clone(),
+        march: None,
         app_bundle_id: Some(bundle_id),
         output_type: "executable".to_string(),
         bundle_extensions: None,

--- a/docs/src/cli/flags.md
+++ b/docs/src/cli/flags.md
@@ -114,6 +114,7 @@ unchanged modules, leaving the trace dir empty).
 | Flag | Description |
 |------|-------------|
 | `--minify` | Minify and obfuscate output (auto-enabled for `--target web`) |
+| `--march <CPU>` | CPU baseline for the generated machine code: an LLVM CPU name (`x86-64-v2`, `x86-64-v3`, `znver2`, `apple-m1`, …), `native` (tune to the build machine — the default for host builds), or `generic` (the target architecture's portable baseline — the default for cross builds). Pin this when the binary runs on other machines: a host-native build on an AVX-512 box otherwise SIGILLs on older x86-64 CPUs. Also settable via `PERRY_TARGET_CPU` or perry.toml `[build] march`; `[build] native_tuning = false` is shorthand for `generic`. Applies to app code and the auto-optimized runtime/stdlib rebuild. |
 
 Minification strips comments, collapses whitespace, and mangles local variable/parameter/non-exported function names for smaller output.
 
@@ -140,6 +141,7 @@ Minification strips comments, collapses whitespace, and mangles local variable/p
 |----------|-------------|
 | `PERRY_LICENSE_KEY` | Perry Hub license key for `perry publish` |
 | `PERRY_APPLE_CERTIFICATE_PASSWORD` | Password for .p12 certificate |
+| `PERRY_TARGET_CPU` | CPU baseline for generated machine code (same values as `--march`; the flag and perry.toml `[build] march` win over the env var) |
 | `PERRY_NO_UPDATE_CHECK=1` | Disable automatic update checks |
 | `PERRY_UPDATE_SERVER` | Custom update server URL |
 | `CI=true` | Auto-skip update checks (set by most CI systems) |

--- a/docs/src/cli/perry-toml.md
+++ b/docs/src/cli/perry-toml.md
@@ -153,6 +153,10 @@ Build output settings.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `out_dir` | string | `"dist"` | Directory for build artifacts |
+| `march` | string | `native` for host builds, `generic` for cross builds, `x86-64-v2` for `perry publish linux` | CPU baseline for the generated machine code: an LLVM CPU name (`"x86-64-v2"`, `"x86-64-v3"`, `"znver2"`, `"apple-m1"`, …), `"native"` (tune to the build machine's full instruction set), or `"generic"` (the target architecture's portable baseline). Pin this when the binary runs on machines other than the build box — an unpinned host-native build on an AVX-512 machine crashes with SIGILL on older x86-64 CPUs. Equivalent to `--march` / `PERRY_TARGET_CPU`. |
+| `native_tuning` | bool | — | Boolean shorthand for `march`: `true` → `"native"`, `false` → `"generic"`. Ignored when `march` is set. |
+
+`perry publish` forwards the resolved baseline to the build worker, and defaults Linux builds to `x86-64-v2` so published services run on any x86-64 CPU from roughly the last 15 years instead of inheriting the build server's instruction set.
 
 ---
 


### PR DESCRIPTION
Fixes #6125 (primary ask). 

## Root cause

`perry publish` is a thin client — the hub worker runs the same `perry compile` pipeline server-side, **natively (linux-on-linux, no cross triple)**. For host builds, `compile_ll_to_object` unconditionally passed `-march=native` to clang (`crates/perry-codegen/src/linker.rs`), so every app object bakes in the build box's full ISA — AVX-512 on the hub — and the binary SIGILLs at startup on Zen2/EPYC-Rome and other non-AVX-512 hosts. `object_cache.rs` even documented this hazard for cache sharing.

The knobs the reporter tried couldn't work: `[build] native_tuning` / `[build] march` were parsed by nothing (publish's `BuildConfig` only declared `out_dir`, serde silently drops unknown keys), and the `BuildManifest` had no CPU-baseline field, so the client had no way to tell the worker anything about ISA.

## Fix

One canonical knob, `PERRY_TARGET_CPU`, honored by every layer that emits machine code:

- **`perry-codegen`**: `cpu_tuning_arg_for()` resolves it to the clang tuning flag — `native`, `generic`/`off` (no flag → the target's portable baseline), or an explicit LLVM CPU name (`x86-64-v2`, `x86-64-v3`, `znver2`, …). `-march=` vs `-mcpu=` is spelled by the **effective target** arch. Defaults unchanged: host builds stay `native`, cross builds stay generic.
- **`perry compile`**: new `--march` flag; precedence `--march` → `PERRY_TARGET_CPU` → perry.toml `[build] march` → `[build] native_tuning` (`false` ⇒ `generic`, `true` ⇒ `native`), promoted to the env var single-threaded before codegen (same pattern as `--debug-symbols` → `PERRY_DEBUG_SYMBOLS`).
- **Auto-optimize rebuild**: the runtime/stdlib/ext staticlib cargo build (and the bitcode-LTO path) gets `-C target-cpu=<cpu>`; whenever a baseline is requested RUSTFLAGS is set explicitly, so an ambient `-C target-cpu=native` on the build machine can't leak into shipped libs. (The reported crash was in runtime init — this covers that vector too.)
- **Caches**: `PERRY_TARGET_CPU` joins the object-cache key env set and `BUILD_CACHE_ENV_VARS`, so flipping the baseline can't serve stale differently-tuned objects.
- **`perry publish`**: parses `[build] march` / `[build] native_tuning`, adds `--march`, sends `build_march` in the `BuildManifest`, and **defaults `linux` to `x86-64-v2`** (portable across ~15 years of x86-64). `native_tuning = true` / `--march native` opts back into worker-CPU tuning.

## Server-side follow-up (out of this repo)

The hub worker must forward `build_march` as `perry compile --march <value>` (or export `PERRY_TARGET_CPU`) once it runs a perry with this change — analogous to how `linux_libc` drives `--target linux[-musl]`. Until then, a worker running this perry version still emits AVX-512 for unpinned native builds (defaults unchanged by design). The two related repro findings — `--libc musl` failing to link `js_fastify_*` (no prebuilt musl ext archive; `release-packages.yml` builds ext libs best-effort) and `PERRY_NO_AUTO_OPTIMIZE=1` yielding a non-ELF artifact (worker packages on after a failed compile: fastify + NO_AUTO_OPTIMIZE is a hard `exit(1)`) — are separate issues worth their own tracking.

## Validation

- `cargo test -p perry-codegen --lib` (156 ✓, incl. 4 new resolver tests), `cargo test -p perry --bin perry` (678 ✓, incl. extended cache-key env test), `cargo fmt --check` ✓.
- End-to-end on the built compiler via `PERRY_LLVM_KEEP_IR` compile-plan metadata: default host build keeps `-mcpu=native`; `--march generic` drops the flag; `--march apple-m1` lands in the real clang args; `[build] march`/`native_tuning` and `PERRY_TARGET_CPU` resolve with the documented precedence (`march` wins over `native_tuning`); changing the baseline misses the object cache (an invalid CPU reaches clang and errors instead of being served the previous object); all produced binaries run correctly.

Per the external-contribution convention, no version bump / changelog — fold in at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--march` option to builds and publishes to select the CPU baseline (`native`, `generic`, or specific LLVM CPU names).
  * Linux publish builds now default to `x86-64-v2` for improved runtime compatibility.
* **Bug Fixes**
  * Build, object caching, and build-cache fingerprinting now consistently account for the selected CPU baseline to avoid stale/mismatched artifacts.
* **Documentation**
  * Updated CLI and `perry.toml` docs, including precedence and `PERRY_TARGET_CPU` environment-variable behavior.
* **Tests**
  * Added coverage for CPU baseline resolution and tuning flag generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->