### PR TITLE
fix(ws): #6117 — install rustls CryptoProvider before wss:// connects + real ws.readyState

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5902,6 +5902,7 @@ dependencies = [
  "lazy_static",
  "perry-ffi",
  "perry-runtime",
+ "rustls",
  "tokio",
  "tokio-tungstenite",
 ]

--- a/crates/perry-codegen/src/lower_call/native_table/net_events.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/net_events.rs
@@ -47,6 +47,18 @@ pub(super) const NET_EVENTS_ROWS: &[NativeModSig] = &[
         args: &[],
         ret: NR_VOID,
     },
+    // #6117 — `ws.readyState` data getter (CONNECTING=0 / OPEN=1 /
+    // CLOSING=2 / CLOSED=3). Reached as a 0-arg NativeMethodCall via the
+    // bare-member-read reroute in perry-hir's `is_native_dispatch_member`.
+    NativeModSig {
+        module: "ws",
+        has_receiver: true,
+        method: "readyState",
+        class_filter: None,
+        runtime: "js_ws_ready_state",
+        args: &[],
+        ret: NR_F64,
+    },
     // Issue #577 Phase 4 — `("ws", "Client")` instance methods.
     // The wsId delivered to `Server.on('upgrade', (req, wsId, head) => …)`
     // is NaN-boxed POINTER_TAG so unbox_to_i64 (called by the dispatch

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi/web.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi/web.rs
@@ -102,6 +102,7 @@ pub(crate) fn declare_web(module: &mut LlModule) {
     module.declare_function("js_ws_handle_to_i64", I64, &[DOUBLE]);
     module.declare_function("js_ws_is_open", DOUBLE, &[I64]);
     module.declare_function("js_ws_message_count", DOUBLE, &[I64]);
+    module.declare_function("js_ws_ready_state", DOUBLE, &[I64]);
     module.declare_function("js_ws_on", I64, &[I64, I64, I64]);
     module.declare_function("js_ws_receive", I64, &[I64]);
     module.declare_function("js_ws_send", VOID, &[I64, I64]);

--- a/crates/perry-ext-ws/Cargo.toml
+++ b/crates/perry-ext-ws/Cargo.toml
@@ -16,6 +16,12 @@ tokio = { workspace = true }
 # handoff; mismatched versions split type identity and the
 # `register_external_ws_stream` re-export silently fails to compile.
 tokio-tungstenite = { workspace = true }
+# #6117: already in the graph via tokio-tungstenite's rustls-tls, so this
+# pulls nothing new — declared so the connect path can install a process-level
+# CryptoProvider (feature unification enables both `ring` and `aws-lc-rs` in
+# the final link, and rustls panics on the first wss:// handshake unless one
+# is installed). Same pattern as perry-ext-net.
+rustls = "0.23"
 futures-util = "0.3"
 lazy_static = "1.5"
 

--- a/crates/perry-ext-ws/src/lib.rs
+++ b/crates/perry-ext-ws/src/lib.rs
@@ -51,6 +51,16 @@ const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
 const TAG_MASK: u64 = 0xFFFF_0000_0000_0000;
 const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
 
+/// #6117 — rustls panics resolving the process-level CryptoProvider on the
+/// first `wss://` handshake when both `ring` and `aws-lc-rs` end up
+/// feature-unified into the final link (perry-ext-http-server brings ring;
+/// perry-ext-net brings aws-lc-rs). Install one explicitly before
+/// connecting. Idempotent — `install_default` errors (ignored) if a
+/// provider is already set. Same pattern as perry-ext-net's tls module.
+fn ensure_tls_crypto_provider() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+}
+
 unsafe fn read_str(ptr: *const StringHeader) -> Option<String> {
     if ptr.is_null() {
         return None;
@@ -65,6 +75,13 @@ struct WsConnection {
     sender: mpsc::UnboundedSender<WsCommand>,
     messages: Vec<String>,
     is_open: bool,
+    /// #6117 — `close()` was called but the close handshake hasn't finished:
+    /// `readyState` reports CLOSING (2).
+    is_closing: bool,
+    /// #6117 — the connection terminated (close event, IO error, or connect
+    /// failure): `readyState` reports CLOSED (3). Distinguishes a dead entry
+    /// from a pre-open one (CONNECTING, 0) — both have `is_open == false`.
+    is_closed: bool,
 }
 
 enum WsCommand {
@@ -150,6 +167,7 @@ fn push_ws_event(ev: PendingWsEvent) {
 #[no_mangle]
 pub unsafe extern "C" fn js_ws_connect(url_ptr: *const StringHeader) -> *mut perry_ffi::Promise {
     ensure_gc_scanner_registered();
+    ensure_tls_crypto_provider();
     let promise = perry_ffi::JsPromise::new();
     let raw = promise.as_raw();
     let Some(url) = read_str(url_ptr) else {
@@ -179,6 +197,7 @@ pub unsafe extern "C" fn js_ws_connect(url_ptr: *const StringHeader) -> *mut per
 #[no_mangle]
 pub extern "C" fn js_ws_connect_start(url_nanboxed: f64) -> f64 {
     ensure_gc_scanner_registered();
+    ensure_tls_crypto_provider();
     let bits = url_nanboxed.to_bits();
     let mask = TAG_MASK;
     let string_tag = 0x7FFF_0000_0000_0000u64;
@@ -203,6 +222,8 @@ pub extern "C" fn js_ws_connect_start(url_nanboxed: f64) -> f64 {
             sender: tx,
             messages: Vec::new(),
             is_open: false,
+            is_closing: false,
+            is_closed: false,
         },
     );
     WS_CLIENT_LISTENERS.lock().unwrap().insert(
@@ -225,6 +246,11 @@ pub extern "C" fn js_ws_connect_start(url_nanboxed: f64) -> f64 {
                     drive_client_io(ws_id, ws_stream, rx);
                 }
                 Err(e) => {
+                    // #6117 — readyState must report CLOSED (3), not
+                    // CONNECTING (0), once the connect has failed.
+                    if let Some(c) = WS_CONNECTIONS.lock().unwrap().get_mut(&ws_id) {
+                        c.is_closed = true;
+                    }
                     push_ws_event(PendingWsEvent::Error(
                         ws_id,
                         format!("WebSocket connect error: {}", e),
@@ -252,6 +278,8 @@ fn setup_client_io(
             sender: tx,
             messages: Vec::new(),
             is_open: true,
+            is_closing: false,
+            is_closed: false,
         },
     );
     WS_CLIENT_LISTENERS.lock().unwrap().insert(
@@ -304,6 +332,7 @@ fn drive_client_io<S>(
                                     .unwrap_or((1000u16, String::new()));
                                 if let Some(c) = WS_CONNECTIONS.lock().unwrap().get_mut(&ws_id) {
                                     c.is_open = false;
+                                    c.is_closed = true;
                                 }
                                 push_ws_event(PendingWsEvent::Close(ws_id, code, reason));
                                 break;
@@ -334,6 +363,7 @@ fn drive_client_io<S>(
             }
             if let Some(c) = WS_CONNECTIONS.lock().unwrap().get_mut(&ws_id) {
                 c.is_open = false;
+                c.is_closed = true;
             }
         });
     });
@@ -360,6 +390,9 @@ pub extern "C" fn js_ws_close(handle: i64) {
     if let Some(c) = WS_CONNECTIONS.lock().unwrap().get_mut(&id) {
         let _ = c.sender.send(WsCommand::Close);
         c.is_open = false;
+        // #6117 — readyState reports CLOSING (2) until the IO loop
+        // finishes the close handshake and marks is_closed.
+        c.is_closing = true;
     }
 }
 
@@ -395,6 +428,7 @@ pub extern "C" fn js_ws_close_client_i64(handle: i64) {
     if let Some(c) = WS_CONNECTIONS.lock().unwrap().get_mut(&id) {
         let _ = c.sender.send(WsCommand::Close);
         c.is_open = false;
+        c.is_closing = true;
     }
 }
 
@@ -465,6 +499,7 @@ pub extern "C" fn js_ws_close_client(handle_f64: f64) {
     if let Some(c) = WS_CONNECTIONS.lock().unwrap().get_mut(&id) {
         let _ = c.sender.send(WsCommand::Close);
         c.is_open = false;
+        c.is_closing = true;
     }
 }
 
@@ -479,6 +514,22 @@ pub extern "C" fn js_ws_is_open(handle: i64) -> f64 {
         .get(&id)
         .map(|c| if c.is_open { 1.0 } else { 0.0 })
         .unwrap_or(0.0)
+}
+
+/// #6117 — `ws.readyState` per npm-ws semantics: CONNECTING=0, OPEN=1,
+/// CLOSING=2, CLOSED=3. An id with no map entry is CLOSED — either the
+/// entry was cleaned up after close, or the promise-path connect failed
+/// before an entry was ever created.
+#[no_mangle]
+pub extern "C" fn js_ws_ready_state(handle: i64) -> f64 {
+    let id = handle as usize;
+    match WS_CONNECTIONS.lock().unwrap().get(&id) {
+        Some(c) if c.is_closed => 3.0,
+        Some(c) if c.is_closing => 2.0,
+        Some(c) if c.is_open => 1.0,
+        Some(_) => 0.0,
+        None => 3.0,
+    }
 }
 
 #[no_mangle]
@@ -703,6 +754,8 @@ pub extern "C" fn js_ws_server_new(opts_f64: f64) -> Handle {
                                             sender: tx,
                                             messages: Vec::new(),
                                             is_open: true,
+                                            is_closing: false,
+                                            is_closed: false,
                                         });
                                         WS_CLIENT_LISTENERS.lock().unwrap().insert(ws_id, WsClientListeners {
                                             listeners: HashMap::new(),
@@ -924,6 +977,7 @@ fn drive_server_client_io<S>(
         }
         if let Some(c) = WS_CONNECTIONS.lock().unwrap().get_mut(&ws_id) {
             c.is_open = false;
+            c.is_closed = true;
         }
     });
 }
@@ -964,6 +1018,8 @@ where
             sender: tx,
             messages: Vec::new(),
             is_open: true,
+            is_closing: false,
+            is_closed: false,
         },
     );
     WS_CLIENT_LISTENERS.lock().unwrap().insert(
@@ -1342,5 +1398,43 @@ mod tests {
         assert_eq!(extract_port(8080.0), 8080);
         assert_eq!(extract_port(0.0), 0);
         assert_eq!(extract_port(-5.0), 0);
+    }
+
+    /// #6117 — `readyState` walks the npm-ws lifecycle: CONNECTING (0)
+    /// pre-open, OPEN (1), CLOSING (2) after `close()` is requested,
+    /// CLOSED (3) once the IO loop marks the connection dead, and CLOSED
+    /// for ids with no entry (cleaned up, or promise-path connect failed).
+    /// Uses an id far outside anything other tests insert, so no lock.
+    #[test]
+    fn ready_state_reports_npm_ws_lifecycle() {
+        let ws_id = 990_077usize;
+        let (tx, _rx) = mpsc::unbounded_channel::<WsCommand>();
+        WS_CONNECTIONS.lock().unwrap().insert(
+            ws_id,
+            WsConnection {
+                sender: tx,
+                messages: Vec::new(),
+                is_open: false,
+                is_closing: false,
+                is_closed: false,
+            },
+        );
+
+        assert_eq!(js_ws_ready_state(ws_id as i64), 0.0);
+        WS_CONNECTIONS
+            .lock()
+            .unwrap()
+            .get_mut(&ws_id)
+            .unwrap()
+            .is_open = true;
+        assert_eq!(js_ws_ready_state(ws_id as i64), 1.0);
+        js_ws_close(ws_id as i64);
+        assert_eq!(js_ws_ready_state(ws_id as i64), 2.0);
+        if let Some(c) = WS_CONNECTIONS.lock().unwrap().get_mut(&ws_id) {
+            c.is_closed = true;
+        }
+        assert_eq!(js_ws_ready_state(ws_id as i64), 3.0);
+        WS_CONNECTIONS.lock().unwrap().remove(&ws_id);
+        assert_eq!(js_ws_ready_state(ws_id as i64), 3.0);
     }
 }

--- a/crates/perry-hir/src/lower/expr_member/native_dispatch.rs
+++ b/crates/perry-hir/src/lower/expr_member/native_dispatch.rs
@@ -115,6 +115,13 @@ pub(crate) fn is_native_dispatch_member(module: &str, class: &str, prop: &str) -
             "Agent" => matches!(prop, "createConnection" | "createSocket"),
             _ => true,
         },
+        // #6117 — ws client instances: `readyState` is a native data getter
+        // (npm ws: CONNECTING=0 / OPEN=1 / CLOSING=2 / CLOSED=3) dispatched
+        // to `js_ws_ready_state`. Server instances expose no readyState, and
+        // every other bare member read stays a plain PropertyGet (method
+        // CALLS like `ws.send(..)` arrive via the call-expression path, not
+        // this bare-read block).
+        "ws" => prop == "readyState" && !matches!(class, "WebSocketServer" | "Server"),
         // events / net instances dispatch their EventEmitter / socket methods
         // and getters through the class_filter table. These modules expose no
         // user own-property surface in the bundle walls, so keep dispatching

--- a/crates/perry-hir/tests/ws_ready_state_constants.rs
+++ b/crates/perry-hir/tests/ws_ready_state_constants.rs
@@ -53,3 +53,42 @@ fn ws_ready_state_constants_lower_on_default_namespace_and_class_shapes() {
     assert_eq!(let_number(&module, "fromNamespaceClass"), 3.0);
     assert_eq!(let_number(&module, "fromNamedClass"), 0.0);
 }
+
+/// #6117 — the plain named-import shape used inside a function body:
+/// `import { WebSocket } from 'ws'` then `ws.readyState !== WebSocket.OPEN`
+/// in an async loop. The static read must fold to the numeric constant; a
+/// surviving `PropertyGet { .. "OPEN" }` becomes a runtime "Cannot read
+/// properties of undefined (reading 'OPEN')".
+#[test]
+fn ws_ready_state_constants_fold_in_function_bodies_with_named_import() {
+    let module = lower(
+        r#"
+        import { WebSocket } from "ws";
+
+        const ws = new WebSocket("ws://127.0.0.1:9");
+
+        async function main() {
+            while (ws.readyState !== WebSocket.OPEN) {
+                if (ws.readyState === WebSocket.CONNECTING) {
+                    console.log("connecting");
+                }
+            }
+        }
+        "#,
+    );
+
+    let main = module
+        .functions
+        .iter()
+        .find(|f| f.name.contains("main"))
+        .expect("lowered main function");
+    let debug = format!("{:?}", main.body);
+    assert!(
+        !debug.contains("\"OPEN\"") && !debug.contains("\"CONNECTING\""),
+        "WebSocket ready-state statics must fold to numbers, found property reads in: {debug}"
+    );
+    assert!(
+        debug.contains("Number(1.0)"),
+        "expected folded WebSocket.OPEN constant in: {debug}"
+    );
+}

--- a/crates/perry-stdlib/Cargo.toml
+++ b/crates/perry-stdlib/Cargo.toml
@@ -116,7 +116,11 @@ bundled-streams = ["dep:flate2", "dep:brotli"]
 # `import 'ws'` can route to perry-ext-ws without duplicate
 # `_js_ws_*` symbols at link time.
 websocket = ["bundled-ws"]
-bundled-ws = ["dep:tokio-tungstenite", "dep:futures-util", "async-runtime"]
+# #6117: `dep:rustls` so the client-connect path can install a process-level
+# CryptoProvider before the first `wss://` handshake — feature unification
+# enables BOTH `ring` and `aws-lc-rs` in the final link, so rustls panics
+# unless one is installed explicitly (same as the `tls` feature's paths).
+bundled-ws = ["dep:tokio-tungstenite", "dep:futures-util", "dep:rustls", "async-runtime"]
 
 # Activated by `optimized_libs::build_optimized_libs` when the
 # well-known flip strips `bundled-ws` and routes `import 'ws'` to

--- a/crates/perry-stdlib/src/ws.rs
+++ b/crates/perry-stdlib/src/ws.rs
@@ -20,6 +20,17 @@ use tokio_tungstenite::{connect_async, tungstenite::Message};
 use crate::common::async_bridge::{queue_promise_resolution, spawn};
 use crate::common::{for_each_handle_mut_of, get_handle_mut, register_handle, Handle};
 
+/// #6117 — rustls panics resolving the process-level CryptoProvider on the
+/// first `wss://` handshake when both `ring` and `aws-lc-rs` end up
+/// feature-unified into the final link (perry-ext-http-server brings ring;
+/// net/tls bring aws-lc-rs). Install one explicitly before connecting.
+/// Idempotent — `install_default` errors (ignored) if a provider is already
+/// set. Mirrors `net::mod` / `tls` (#4971) and `perry-ext-net`.
+#[cfg(not(target_os = "ios"))]
+fn ensure_tls_crypto_provider() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+}
+
 fn ws_file_log(msg: &str) {
     use std::io::Write;
     if let Ok(mut f) = std::fs::OpenOptions::new()
@@ -116,6 +127,13 @@ struct WsConnection {
     sender: mpsc::UnboundedSender<WsCommand>,
     messages: Vec<String>,
     is_open: bool,
+    /// #6117 — `close()` was called but the close handshake hasn't finished:
+    /// `readyState` reports CLOSING (2).
+    is_closing: bool,
+    /// #6117 — the connection terminated (close event, IO error, or connect
+    /// failure): `readyState` reports CLOSED (3). Distinguishes a dead entry
+    /// from a pre-open one (CONNECTING, 0) — both have `is_open == false`.
+    is_closed: bool,
 }
 
 #[cfg(not(target_os = "ios"))]
@@ -180,6 +198,7 @@ fn mark_ws_connection_closed(ws_id: usize) -> bool {
         .map(|conn| {
             let was_open = conn.is_open;
             conn.is_open = false;
+            conn.is_closed = true;
             was_open
         })
         .unwrap_or(false)
@@ -217,6 +236,7 @@ pub unsafe extern "C" fn js_ws_connect(
     url_ptr: *const StringHeader,
 ) -> *mut perry_runtime::Promise {
     ensure_gc_scanner_registered();
+    ensure_tls_crypto_provider();
     #[cfg(target_os = "android")]
     {
         extern "C" {
@@ -301,6 +321,8 @@ pub unsafe extern "C" fn js_ws_connect(
                         sender: tx,
                         messages: Vec::new(),
                         is_open: true,
+                        is_closing: false,
+                        is_closed: false,
                     },
                 );
 
@@ -457,6 +479,7 @@ pub unsafe extern "C" fn js_ws_connect(
 #[no_mangle]
 pub unsafe extern "C" fn js_ws_connect_start(url_nanboxed: f64) -> f64 {
     ensure_gc_scanner_registered();
+    ensure_tls_crypto_provider();
     #[cfg(target_os = "android")]
     {
         extern "C" {
@@ -491,6 +514,8 @@ pub unsafe extern "C" fn js_ws_connect_start(url_nanboxed: f64) -> f64 {
             sender: tx,
             messages: Vec::new(),
             is_open: false,
+            is_closing: false,
+            is_closed: false,
         },
     );
 
@@ -606,6 +631,9 @@ pub unsafe extern "C" fn js_ws_connect_start(url_nanboxed: f64) -> f64 {
                 });
             }
             Err(e) => {
+                // #6117 — readyState must report CLOSED (3), not
+                // CONNECTING (0), once the connect has failed.
+                mark_ws_connection_closed(ws_id);
                 push_ws_event(PendingWsEvent::Error(
                     ws_id,
                     format!("WebSocket connection error: {}", e),
@@ -688,8 +716,10 @@ pub unsafe extern "C" fn js_ws_close(handle: i64) {
 
     // Otherwise close client connection
     let ws_id = handle as usize;
-    let guard = WS_CONNECTIONS.lock().unwrap();
-    if let Some(conn) = guard.get(&ws_id) {
+    let mut guard = WS_CONNECTIONS.lock().unwrap();
+    if let Some(conn) = guard.get_mut(&ws_id) {
+        // #6117 — readyState reports CLOSING (2) until the close completes.
+        conn.is_closing = true;
         let _ = conn.sender.send(WsCommand::Close);
     }
 }
@@ -741,6 +771,35 @@ pub extern "C" fn js_ws_is_open(handle: i64) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_ws_is_open(handle: i64) -> f64 {
     unsafe { perry_native_ws_is_open(handle as f64) }
+}
+
+/// #6117 — `ws.readyState` per npm-ws semantics: CONNECTING=0, OPEN=1,
+/// CLOSING=2, CLOSED=3. An id with no map entry is CLOSED — either the
+/// entry was cleaned up after close, or the promise-path connect failed
+/// before an entry was ever created.
+#[cfg(not(target_os = "ios"))]
+#[no_mangle]
+pub extern "C" fn js_ws_ready_state(handle: i64) -> f64 {
+    let ws_id = handle as usize;
+    match WS_CONNECTIONS.lock().unwrap().get(&ws_id) {
+        Some(conn) if conn.is_closed => 3.0,
+        Some(conn) if conn.is_closing => 2.0,
+        Some(conn) if conn.is_open => 1.0,
+        Some(_) => 0.0,
+        None => 3.0,
+    }
+}
+
+/// iOS: NSURLSessionWebSocketTask exposes no CONNECTING/CLOSING signal
+/// through the existing native bridge — approximate with open/closed.
+#[cfg(target_os = "ios")]
+#[no_mangle]
+pub extern "C" fn js_ws_ready_state(handle: i64) -> f64 {
+    if unsafe { perry_native_ws_is_open(handle as f64) } == 1.0 {
+        1.0
+    } else {
+        3.0
+    }
 }
 
 /// Get the number of pending messages
@@ -1020,6 +1079,8 @@ pub unsafe extern "C" fn js_ws_server_new(opts_f64: f64) -> Handle {
                                         sender: tx,
                                         messages: Vec::new(),
                                         is_open: true,
+                                        is_closing: false,
+                                        is_closed: false,
                                     });
 
                                     // Initialize client listeners
@@ -1496,6 +1557,8 @@ mod tests {
                 sender: tx,
                 messages: Vec::new(),
                 is_open: false,
+                is_closing: false,
+                is_closed: false,
             },
         );
         WS_CLIENT_LISTENERS.lock().unwrap().insert(
@@ -1530,6 +1593,46 @@ mod tests {
         assert_eq!(js_ws_has_active_handles(), 0);
 
         crate::common::drop_handle(server_handle);
+        clear_test_state();
+    }
+
+    /// #6117 — `readyState` walks the npm-ws lifecycle: CONNECTING (0)
+    /// pre-open, OPEN (1), CLOSING (2) after `close()` is requested,
+    /// CLOSED (3) once the IO loop marks the connection dead, and CLOSED
+    /// for ids with no entry (cleaned up, or promise-path connect failed).
+    #[test]
+    fn ready_state_reports_npm_ws_lifecycle() {
+        let _guard = TEST_LOCK.lock().unwrap();
+        clear_test_state();
+
+        let ws_id = 91usize;
+        let (tx, _rx) = mpsc::unbounded_channel::<WsCommand>();
+        WS_CONNECTIONS.lock().unwrap().insert(
+            ws_id,
+            WsConnection {
+                sender: tx,
+                messages: Vec::new(),
+                is_open: false,
+                is_closing: false,
+                is_closed: false,
+            },
+        );
+
+        assert_eq!(js_ws_ready_state(ws_id as i64), 0.0);
+        WS_CONNECTIONS
+            .lock()
+            .unwrap()
+            .get_mut(&ws_id)
+            .unwrap()
+            .is_open = true;
+        assert_eq!(js_ws_ready_state(ws_id as i64), 1.0);
+        unsafe { js_ws_close(ws_id as i64) };
+        assert_eq!(js_ws_ready_state(ws_id as i64), 2.0);
+        mark_ws_connection_closed(ws_id);
+        assert_eq!(js_ws_ready_state(ws_id as i64), 3.0);
+        cleanup_ws_client(ws_id);
+        assert_eq!(js_ws_ready_state(ws_id as i64), 3.0);
+
         clear_test_state();
     }
 }

--- a/test-files/test_ws_static_constants_6117.ts
+++ b/test-files/test_ws_static_constants_6117.ts
@@ -1,0 +1,32 @@
+// Issue #6117 repro (bug 2): WebSocket static readyState constants from 'ws'
+// must be readable as values — `WebSocket.OPEN` etc. crashed with
+// "TypeError: Cannot read properties of undefined (reading 'OPEN')".
+import { WebSocket } from 'ws'
+
+console.log('CONNECTING =', WebSocket.CONNECTING)
+console.log('OPEN =', WebSocket.OPEN)
+console.log('CLOSING =', WebSocket.CLOSING)
+console.log('CLOSED =', WebSocket.CLOSED)
+
+// The exact comparison shape from the issue: instance readyState vs static.
+const ws = new WebSocket('ws://127.0.0.1:9')
+
+let waits = 0
+async function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function main() {
+  while (ws.readyState !== WebSocket.OPEN && waits < 3) {
+    console.log('Waiting for connection...', ws.readyState === WebSocket.CONNECTING ? 'still connecting' : 'not connecting')
+    waits++
+    await sleep(50)
+  }
+  console.log('done waiting, readyState is number:', typeof ws.readyState === 'number')
+  // Connection to a closed port must end CLOSED (3), not stuck CONNECTING.
+  await sleep(200)
+  console.log('refused connect ends CLOSED:', ws.readyState === WebSocket.CLOSED)
+  ws.close()
+}
+
+await main()

--- a/test-files/test_ws_wss_tls_6117.ts
+++ b/test-files/test_ws_wss_tls_6117.ts
@@ -1,0 +1,48 @@
+// Issue #6117 repro (bug 1): connecting via wss:// panicked the tokio worker
+// with "Could not automatically determine the process-level CryptoProvider"
+// because no rustls provider was installed before the TLS handshake.
+import { WebSocket } from 'ws'
+
+async function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function main() {
+  const ws = new WebSocket('wss://echo.websocket.org')
+
+  let opened = false
+  let gotMessage = false
+
+  ws.on('open', () => {
+    opened = true
+    console.log('Connected to WebSocket')
+  })
+
+  ws.on('message', (data) => {
+    gotMessage = true
+  })
+
+  ws.on('error', (error) => {
+    console.error('WebSocket error:', error)
+  })
+
+  let waits = 0
+  while (ws.readyState !== 1 && waits < 100) {
+    waits++
+    await sleep(100)
+  }
+
+  if (ws.readyState === 1) {
+    console.log('readyState reached OPEN')
+    ws.send('Hello again!')
+    await sleep(1500)
+    console.log('received message after send:', gotMessage)
+    ws.close()
+    await sleep(500)
+    console.log('readyState after close is CLOSING/CLOSED:', ws.readyState === 2 || ws.readyState === 3)
+  } else {
+    console.log('FAILED: never reached OPEN after', waits, 'waits')
+  }
+}
+
+await main()


### PR DESCRIPTION
Fixes #6117 — three distinct defects were behind "ws doesn't seem to work".

## 1. `wss://` connects panicked the tokio worker

```
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
```

Root cause: the final link feature-unifies rustls with **both** `ring` (via perry-ext-http-server) and `aws-lc-rs` (via net/tls/mongodb), so rustls 0.23 refuses to auto-pick a provider — every TLS entry point must install one explicitly. The `net` / `tls` / `http-server` paths already do (#4971 pattern); both ws client-connect paths did not.

Fix — the same idempotent install the sibling modules use, at the top of `js_ws_connect` / `js_ws_connect_start`:
- `perry-stdlib/src/ws.rs` (`bundled-ws` now enables `dep:rustls`)
- `perry-ext-ws/src/lib.rs` (direct `rustls = "0.23"` dep — already in the graph via tokio-tungstenite, pulls nothing new; same as perry-ext-net's declaration)

## 2. Instance `ws.readyState` was always `undefined`

The issue's wait loop `while (ws.readyState !== 1)` never exits — even after `open` fires — because `readyState` lowered to a plain dynamic PropertyGet against the NaN-boxed ws id. So fixing the panic alone would NOT have made the reporter's program work.

Now wired end-to-end as a native data getter:
- HIR: `is_native_dispatch_member` gets a `"ws"` arm rerouting the bare `readyState` read on client instances (not servers) to a 0-arg NativeMethodCall
- codegen: new NATIVE_MODULE_TABLE row + `js_ws_ready_state` declaration
- both runtimes track the full npm-ws state machine via new `is_closing` / `is_closed` flags on `WsConnection`: CONNECTING=0 (pre-open), OPEN=1, CLOSING=2 (`close()` requested), CLOSED=3 (close event / IO error / connect failure / cleaned-up id)

## 3. `WebSocket.OPEN` reading as undefined — already fixed, regression-pinned

The reporter was on v0.5.1022; the ready-state constant fold landed in v0.5.1102 (#4070). Added a regression test for the exact reported shape (plain named import compared inside an async function body).

## Testing

- **Live e2e against `wss://echo.websocket.org`** (`test-files/test_ws_wss_tls_6117.ts`): no panic, `open` fires, `readyState` reaches OPEN, echo round-trip received, post-close readyState is CLOSING/CLOSED. Output:
  ```
  Connected to WebSocket
  readyState reached OPEN
  received message after send: true
  readyState after close is CLOSING/CLOSED: true
  ```
- **Statics + lifecycle e2e** (`test-files/test_ws_static_constants_6117.ts`): constants print 0/1/2/3, `typeof ws.readyState === 'number'`, first poll reports CONNECTING, refused connect ends CLOSED.
- `cargo test -p perry-hir` — full suite, 20/20 test binaries green (incl. new #6117 lowering shape)
- New `ready_state_reports_npm_ws_lifecycle` unit tests in both `perry-stdlib::ws` and `perry-ext-ws` — pass
- `test-files/test_node_http_ws_upgrade.ts` canary — server-side upgrade path unaffected
- `cargo fmt --all -- --check` — clean

Note: the local e2e compiles route `import 'ws'` through perry-ext-ws (optimized-libs flip), so that path is live-verified; the identical perry-stdlib `bundled-ws` change is covered by its unit test and `cargo check --features bundled-ws`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebSocket connections now expose a reliable `readyState` value, including `CONNECTING`, `OPEN`, `CLOSING`, and `CLOSED`.
  * TLS-enabled WebSocket connections are more robust during the first secure handshake.

* **Bug Fixes**
  * Fixed incorrect WebSocket state reporting after close requests, connection failures, and cleanup.
  * Static WebSocket state constants now read correctly instead of causing crashes in some cases.

* **Tests**
  * Added regression coverage for WebSocket state transitions and secure connection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->