### PR TITLE
fix(runtime): path.* builtins rejected malloc-backed strings

### DIFF
--- a/crates/perry-runtime/src/path.rs
+++ b/crates/perry-runtime/src/path.rs
@@ -22,15 +22,25 @@ fn is_string_header_ptr(ptr: *const StringHeader) -> bool {
     if ptr == crate::string::js_get_empty_string() {
         return true;
     }
+    let gc_header =
+        (ptr as *const u8).wrapping_sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+    // A string outside the managed arenas (generation `Unknown`) is still a
+    // real string when the GC malloc registry tracks its header — e.g. a
+    // string grown through the append realloc path (`gc_malloc_realloc` →
+    // `gc_malloc(_, GC_TYPE_STRING)`) or a Symbol description. Rejecting those
+    // made every `path.*` builtin throw `The "path" argument must be of type
+    // string.` on a perfectly valid argument. The registry lookup is
+    // dereference-free, so forged pointers are still rejected before the
+    // header reads below (mirrors the empty-string singleton special case
+    // above and `current_heap_header_for_user_ptr`'s Unknown→malloc rule).
     if matches!(
         crate::arena::classify_heap_generation(ptr as usize),
         crate::arena::HeapGeneration::Unknown
-    ) {
+    ) && !crate::gc::gc_malloc_header_is_tracked(gc_header)
+    {
         return false;
     }
     unsafe {
-        let gc_header =
-            (ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
         if (*gc_header).obj_type != crate::gc::GC_TYPE_STRING {
             return false;
         }
@@ -1818,5 +1828,63 @@ mod win32_normalize_tests {
             win32_to_namespaced_path("\\\\?\\C:\\already"),
             "\\\\?\\C:\\already"
         );
+    }
+}
+
+#[cfg(test)]
+mod malloc_backed_string_arg_tests {
+    use super::*;
+
+    /// Build a REAL string whose backing allocation is malloc-tracked (not
+    /// arena) — the shape produced by the string-append realloc path
+    /// (`gc_malloc_realloc` → `gc_malloc(_, GC_TYPE_STRING)`) and by Symbol
+    /// descriptions. Its user address classifies as `HeapGeneration::Unknown`.
+    fn malloc_backed_string(bytes: &[u8]) -> *mut StringHeader {
+        let payload = std::mem::size_of::<StringHeader>() + bytes.len();
+        let user = crate::gc::gc_malloc(payload, crate::gc::GC_TYPE_STRING) as *mut StringHeader;
+        assert!(!user.is_null());
+        unsafe {
+            crate::string::init_string_header(
+                user,
+                bytes.len() as u32,
+                bytes.len() as u32,
+                bytes.len() as u32,
+                0,
+                0,
+            );
+            std::ptr::copy_nonoverlapping(
+                bytes.as_ptr(),
+                (user as *mut u8).add(std::mem::size_of::<StringHeader>()),
+                bytes.len(),
+            );
+        }
+        user
+    }
+
+    /// A malloc-backed (generation-Unknown) string is a valid `path` argument.
+    /// `is_string_header_ptr` used to reject every generation-Unknown pointer,
+    /// so `path.dirname()` (and every other `path.*` builtin) threw
+    /// `TypeError: The "path" argument must be of type string.` whenever a
+    /// program passed a string that had grown through the append realloc path.
+    #[test]
+    fn path_builtins_accept_malloc_backed_strings() {
+        let path = malloc_backed_string(b"/a/b/c.txt");
+        assert!(is_string_header_ptr(path));
+
+        let dir = js_path_dirname(path);
+        let dir_str = unsafe { string_from_header(dir) }.expect("dirname returns a string");
+        assert_eq!(dir_str, "/a/b");
+
+        let base = js_path_basename(path);
+        let base_str = unsafe { string_from_header(base) }.expect("basename returns a string");
+        assert_eq!(base_str, "c.txt");
+    }
+
+    /// Forged pointers (not in the malloc registry, not in an arena) must
+    /// still be rejected without dereferencing the candidate header.
+    #[test]
+    fn forged_unknown_pointer_is_still_rejected() {
+        let bogus = 0x0000_7777_0000_1000usize as *const StringHeader;
+        assert!(!is_string_header_ptr(bogus));
     }
 }


### PR DESCRIPTION
**Problem.** `is_string_header_ptr` (crates/perry-runtime/src/path.rs) treats every pointer whose `classify_heap_generation` is `Unknown` as a non-string. But strings grown through the append realloc path (`gc_malloc_realloc` → `gc_malloc(_, GC_TYPE_STRING)`) and Symbol description strings are malloc-tracked GC allocations that legitimately live outside the managed arenas and classify as `Unknown`. Any such string passed to any `path.*` builtin threw `TypeError: The "path" argument must be of type string.` — observed in a large minified program that assembled a path via string append and passed it to `path.dirname()`.

**Fix.** Accept an `Unknown`-generation candidate when `gc_malloc_header_is_tracked(header)` — a dereference-free registry lookup, so forged pointer-tagged values are still rejected before any header field is read. This mirrors `current_heap_header_for_user_ptr`'s Unknown→malloc-registry rule and sits next to the existing empty-string singleton special case in the same function.

**Tests.** `path::malloc_backed_string_arg_tests`:
- `path_builtins_accept_malloc_backed_strings` — a malloc-backed `/a/b/c.txt` passes validation; `dirname` → `/a/b`, `basename` → `c.txt` (fails before the fix: the validator rejects the pointer and the builtin throws).
- `forged_unknown_pointer_is_still_rejected` — an arbitrary non-registered address is still rejected without dereferencing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved string-path validation so valid malloc-backed strings are accepted in path operations.
  * Path functions now work with certain GC-tracked strings that were previously rejected.
  * Added protection to continue rejecting forged or untracked pointers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->