### PR TITLE
fix(json): JSON.stringify replacer follows array-growth forwarding stubs (#233)

### DIFF
--- a/crates/perry-runtime/src/json/replacer.rs
+++ b/crates/perry-runtime/src/json/replacer.rs
@@ -261,13 +261,27 @@ unsafe fn dispatch_pointer_with_replacer(
     }
     match gc_obj_type(ptr) {
         crate::gc::GC_TYPE_ARRAY => {
-            // #5989: `gc_obj_type` can mis-read a corrupted / mis-classified
-            // structure as an array — its `length` field then reads as garbage
-            // (e.g. ~2.7e9) and `stringify_array`'s `0..len` walk runs OOB and
-            // SIGBUSes. Sanity-cap the length (mirrors `is_object_pointer`'s 10M
-            // cap): beyond that it is not a real array — emit "null", not a crash.
+            // #5989: an array grown past its capacity leaves a GC_FLAG_FORWARDED
+            // stub at the OLD location (`js_array_grow`, issue #233) — its first
+            // 8 bytes now hold the forwarding pointer to the grown array, so
+            // reading them as length/capacity yields a bogus multi-GB "length".
+            // A stale pre-grow pointer reaches here from the object graph (e.g.
+            // React's RSC flight stores a `[key, value]` pair, then `pair[i] = …`
+            // grows it while the payload still holds the pre-grow reference).
+            // Follow the forwarding chain — as `clean_arr_ptr` does for every hot
+            // accessor and as the plain-JSON path (`json/stringify.rs`) already
+            // does — so the CURRENT grown array is serialized instead of the
+            // defunct stub. Without this, the raw read produced a garbage length
+            // that only the 10M cap below (emit "null") kept from SIGBUS-ing,
+            // silently dropping the real data.
+            let ptr = crate::array::clean_arr_ptr(ptr as *const crate::ArrayHeader) as *const u8;
+            if ptr.is_null() {
+                buf.push_str("null");
+                return;
+            }
             let len = (*(ptr as *const crate::ArrayHeader)).length;
             if len > 10_000_000 {
+                // Defensive backstop for a genuinely mis-classified pointer.
                 buf.push_str("null");
             } else {
                 stringify_array_with_replacer_pretty(ptr, replacer, buf, indent, depth)
@@ -1093,6 +1107,14 @@ pub(crate) unsafe fn stringify_array_with_array_replacer(
     depth: usize,
     use_pretty: bool,
 ) {
+    // #5989: follow GC_FLAG_FORWARDED array-growth stubs (`js_array_grow`, issue
+    // #233) so a stale pre-grow pointer serializes the current grown array —
+    // mirrors the resolution in `dispatch_pointer_with_replacer`'s array arm.
+    let ptr = crate::array::clean_arr_ptr(ptr as *const crate::ArrayHeader) as *const u8;
+    if ptr.is_null() {
+        buf.push_str("null");
+        return;
+    }
     if STRINGIFY_STACK.with(|s| s.borrow().contains(&(ptr as usize))) {
         let msg = "Converting circular structure to JSON";
         let msg_ptr = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);


### PR DESCRIPTION
## Summary

`JSON.stringify(value, replacerFn)` (and the array-allowlist replacer) could
serialize a **garbage multi-GB "length"** for any array that had been grown after
a reference to it was captured — because the replacer paths read the array header
without following array-growth **forwarding stubs**.

## Root cause

When an array outgrows its capacity, `js_array_grow` (issue #233) allocates a
larger copy and installs a `GC_FLAG_FORWARDED` stub at the **old** location: its
first 8 bytes (`length | capacity`) are overwritten with the forwarding pointer
to the grown array. Stale references are meant to resolve through
`clean_arr_ptr`, which follows the `GC_FLAG_FORWARDED` chain.

The hot array accessors and the plain-JSON path (`json/stringify.rs`) already do
this — but the **replacer** paths did not:

- the array arm of `dispatch_pointer_with_replacer`
- `stringify_array_with_array_replacer`

Both read `(*arr).length` straight off the stub, so a stale pre-grow pointer
produces a bogus length (≈ the forwarding pointer's low bits, hundreds of
millions to billions).

A stale pre-grow pointer reaches these paths straight from the object graph. The
motivating case: React's RSC flight stores a `[key, value]` pair, then extends it
with `pair[i] = …` (which grows it), while the serialized payload still holds the
pre-grow reference.

## Fix

Follow the forwarding chain with `clean_arr_ptr` before reading, so the **current
grown array** is serialized instead of the defunct stub. The pre-existing 10M
length cap (which previously kept the garbage read from walking OOB / SIGBUS-ing,
by emitting `"null"` and silently dropping data) stays as a defensive backstop
for genuinely mis-classified pointers.

This is the **shared root cause** of two prior length-cap band-aids:
- #6101 — cap object keys-array length at capacity in property walks
- #6055 — cap array length in `JSON.stringify`

Both caps hid the symptom (no crash) but returned wrong data; following the
forwarding returns the correct data.

## Validation

- Repro: a Next.js App-Router dynamic route whose RSC flight grows a `[k,v]` pair
  after storing it — the corrupt-array read fires during flight serialization.
  With the fix, corrupt-array events drop **1 → 0** and the serialized flight is
  correct.
- 8-route byte-for-byte matrix vs `node` (static + API GET/POST): no regression.
- `cargo fmt --all -- --check` clean.

Single-file change; caps retained as backstops so behavior is strictly safer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of arrays during JSON serialization to avoid incorrect oversized lengths and unexpected output.
  * Serialization now correctly follows updated array references, helping prevent malformed results when arrays have been expanded.
  * Added safer behavior when an array reference can no longer be resolved, returning `null` instead of continuing with invalid data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->