### PR TITLE
fix(lower): #6078 — template literal substitutions use ToString, not the + default hint

### DIFF
--- a/crates/perry-hir/src/lower/expr_misc.rs
+++ b/crates/perry-hir/src/lower/expr_misc.rs
@@ -243,11 +243,17 @@ pub(super) fn lower_tpl(ctx: &mut LoweringContext, tpl: &ast::Tpl) -> Result<Exp
     // Interleave expressions and remaining quasis
     for (i, expr) in tpl.exprs.iter().enumerate() {
         let lowered = lower_expr(ctx, expr)?;
-        // Concatenate: result + toString(expr)
+        // #6078: template substitutions use ToString, NOT the `+` operator's
+        // ToPrimitive(default) hint. `+` with a string operand coerces the other
+        // side valueOf-first, so `` `${obj}` `` (obj with both valueOf+toString)
+        // disagreed with `String(obj)`. Wrap each substitution in `StringCoerce`
+        // (the same `js_string_coerce`/ToString that `String(x)` uses), so it is
+        // toString-first and the concat sees a plain string. No-op for
+        // string/number substitutions; fixes the object case.
         result = Expr::Binary {
             op: BinaryOp::Add,
             left: Box::new(result),
-            right: Box::new(lowered),
+            right: Box::new(Expr::StringCoerce(Box::new(lowered))),
         };
 
         // Add the next quasi (if it's non-empty)


### PR DESCRIPTION
## Summary
Fixes #6078. Template-literal substitutions must be coerced with **ToString**, but Perry desugared `` `${x}` `` to a `+` chain, and `+` with a string operand coerces the other side via **ToPrimitive(default)** — valueOf-first. So for an object with both `valueOf` and `toString`, `` `${obj}` `` took `valueOf` while the spec (and `String(obj)`) use `toString`.

```ts
const obj = { valueOf: () => 42, toString: () => "str" };
`${obj}`      // was "42", spec/Node "str"
String(obj)   // "str"
`${obj}` === String(obj)   // was false, must be true
```

## Fix
Wrap each substitution in `Expr::StringCoerce` — the same `js_string_coerce` / ToString that `String(x)` lowers to — so the substitution is toString-first and the surrounding concat sees a plain string. One-line change in `lower_tpl`.

No-op for `string` / `number` / `boolean` / `null` / `undefined` / `array` / `bigint` substitutions (they already stringify identically); only the object and `Symbol.toPrimitive("string")` cases change (the bug).

## Validation
Byte-for-byte match with Node across: the object case above, `Symbol.toPrimitive` hint (now `"string"`), nested templates, call/array-map substitutions, bigint, `-0`, `Infinity`, `[object Object]`, class `toString`, and multi-substitution templates (`` `${1}${2}${3}` ``). `+` semantics unchanged (`"" + obj` still `"42"`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed template literal interpolation to follow standard string coercion behavior, matching expected JavaScript semantics.
  * Objects with both `valueOf` and `toString` now resolve correctly in template strings, with `toString` taking precedence.
  * String and number substitutions continue to behave as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->