### PR TITLE
fix(runtime): node:assert.equal/notEqual use == abstract equality (BigInt/ToPrimitive), not drifted loose-eq

### DIFF
--- a/crates/perry-runtime/src/object/assert.rs
+++ b/crates/perry-runtime/src/object/assert.rs
@@ -858,9 +858,24 @@ pub extern "C" fn js_assert_not_strict_equal(actual: f64, expected: f64, message
     )
 }
 
+/// Audit #18: `node:assert` loose equality (`assert.equal` / `assert.notEqual`)
+/// must use the SAME abstract equality as the `==` operator — `js_loose_eq`,
+/// which performs full ToPrimitive coercion and BigInt==Number comparison. The
+/// previously-used `js_jsvalue_loose_equals` is a drifted variant lacking both,
+/// so `assert.equal(1n, 1)` wrongly threw (`1n == 1` is true) and
+/// `assert.equal(new Number(1), 1)` etc. disagreed with `==`. (`assert.deepEqual`
+/// leaf coercion is a separate, deeper path — not changed here.)
+fn assert_loose_eq(actual: f64, expected: f64) -> bool {
+    crate::builtins::js_loose_eq(
+        crate::value::JSValue::from_bits(actual.to_bits()),
+        crate::value::JSValue::from_bits(expected.to_bits()),
+    )
+    .as_bool()
+}
+
 #[no_mangle]
 pub extern "C" fn js_assert_equal(actual: f64, expected: f64, message: f64) -> f64 {
-    if crate::value::js_jsvalue_loose_equals(actual, expected) != 0 {
+    if assert_loose_eq(actual, expected) {
         return undefined_f64();
     }
     throw_assertion(
@@ -874,7 +889,7 @@ pub extern "C" fn js_assert_equal(actual: f64, expected: f64, message: f64) -> f
 
 #[no_mangle]
 pub extern "C" fn js_assert_not_equal(actual: f64, expected: f64, message: f64) -> f64 {
-    if crate::value::js_jsvalue_loose_equals(actual, expected) == 0 {
+    if !assert_loose_eq(actual, expected) {
         return undefined_f64();
     }
     throw_assertion(


### PR DESCRIPTION
## Summary
Fixes #6140 (audit fable-audit-perry-2.md #18). `node:assert.equal` / `assert.notEqual` compared values with `js_jsvalue_loose_equals`, a **drifted** loose-equality helper that lacks ToPrimitive coercion and BigInt==Number handling — so they disagreed with the `==` operator:

```ts
import assert from "node:assert";
assert.equal(1n, 1);   // was: THROWS. `1n == 1` is true → must pass.
```

## Fix
Route both assertions through `js_loose_eq` — the exact abstract-equality the `==` operator uses (full ToPrimitive + BigInt==Number) — via a small `assert_loose_eq(f64, f64) -> bool` helper. `assert.deepEqual`'s leaf coercion is a separate, deeper path and is left unchanged here.

## Validation (vs Node)
Pass: `equal(1n,1)`, `equal("1",1)`, `equal(true,1)`, `equal(0,false)`, `equal(null,undefined)`, `notEqual(1n,2)`, `notEqual(1,"2")`. Still throw (correct): `equal(1,2)`, `notEqual(1n,1)` (since `1n==1`), `equal({},{})` (distinct refs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `assert.equal` and `assert.notEqual` to follow JavaScript’s loose equality behavior more closely.
  * Comparison results now better match `==` coercion rules, while existing error messages and failure behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->