### PR TITLE
fix(wasm-host): build against wasmi 1.x — F32/F64 moved to the crate root

### DIFF
--- a/crates/perry-wasm-host/src/lib.rs
+++ b/crates/perry-wasm-host/src/lib.rs
@@ -41,8 +41,10 @@ impl WasmVal {
         match self {
             WasmVal::I32(x) => Val::I32(x),
             WasmVal::I64(x) => Val::I64(x),
-            WasmVal::F32(x) => Val::F32(wasmi::core::F32::from_bits(x.to_bits())),
-            WasmVal::F64(x) => Val::F64(wasmi::core::F64::from_bits(x.to_bits())),
+            // wasmi 1.x re-exports F32/F64 at the crate root; `wasmi::core`
+            // is private there (0.x accepted `wasmi::core::F32/F64`).
+            WasmVal::F32(x) => Val::F32(wasmi::F32::from_bits(x.to_bits())),
+            WasmVal::F64(x) => Val::F64(wasmi::F64::from_bits(x.to_bits())),
         }
     }
 }


### PR DESCRIPTION
**Problem.** `crates/perry-wasm-host/Cargo.toml` requests `wasmi = "1.1"`, but the code still constructs floats via `wasmi::core::F32/F64` — a 0.x path that wasmi 1.x makes private (the types are re-exported at the crate root instead). Because `perry-wasm-host` is deliberately excluded from default builds, a fresh checkout only notices when compiling a program that uses `WebAssembly.*`: cargo fails with `E0433`/`E0603` and the compile aborts with `Error: WebAssembly.* used but libperry_wasm_host.a not found`.

**Fix.** Use the crate-root re-exports `wasmi::F32` / `wasmi::F64` (`pub use wasmi_core::{…, F32, F64, …}` in wasmi 1.1). Two lines; `cargo build --release -p perry-wasm-host` goes from 4 errors to green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with newer runtime versions for WebAssembly floating-point values.
  * Fixed value conversion handling so `f32` and `f64` data are passed through more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->