### PR TITLE
fix(lower): #6143 — unresolvable object shorthand throws ReferenceError (was silently dropped)

### DIFF
--- a/crates/perry-hir/src/lower/expr_object.rs
+++ b/crates/perry-hir/src/lower/expr_object.rs
@@ -928,7 +928,10 @@ pub(super) fn lower_object(ctx: &mut LoweringContext, obj: &ast::ObjectLit) -> R
                         } else if let Some(value) = builtin_global_value_expr(ctx, &name) {
                             value
                         } else {
-                            continue;
+                            // #6143: an unresolvable shorthand is a ReferenceError,
+                            // not a silently-dropped property (see the non-spread
+                            // path above). Lower a normal identifier read.
+                            lower_expr(ctx, &ast::Expr::Ident(ident.clone()))?
                         };
                         ops.push(SpreadOp::Set {
                             key: Expr::String(name),
@@ -1223,7 +1226,11 @@ pub(super) fn lower_object(ctx: &mut LoweringContext, obj: &ast::ObjectLit) -> R
                     } else if let Some(value) = builtin_global_value_expr(ctx, &name) {
                         value
                     } else {
-                        continue;
+                        // #6143: an unresolvable shorthand (`{ undeclaredName }`) is
+                        // a ReferenceError, not a silently-dropped property. Lower a
+                        // normal identifier read, which throws for a truly-undeclared
+                        // name (and reads a sloppy implicit global if one exists).
+                        lower_expr(ctx, &ast::Expr::Ident(ident.clone()))?
                     };
                     props.push((name, value));
                 }


### PR DESCRIPTION
## Summary
Fixes #6143. `const o = { undeclaredName }` must throw `ReferenceError: undeclaredName is not defined` (a shorthand reads its binding). Perry's object-literal lowering instead did `continue`, silently dropping the property, in both legacy handlers (non-spread + spread). The closed-shape fast path bails to those on an unresolvable shorthand, so `{ undeclaredName }` produced an empty object.

## Fix
Lower the unresolvable shorthand as a normal identifier read (`lower_expr(Ident)`) — which throws for a truly-undeclared name and reads a sloppy implicit global if one exists.

## Validation (vs Node)
Now throw ReferenceError: `{ a, undeclaredZZZ, b }`, `{ ...{x:1}, undeclaredYYY }`, `{ undeclaredXYZ }`.
Unchanged: `{a,b}` → `{"a":1,"b":2}`, `{a, fn: fn()}`, spread `{...{a}, b}`, sloppy implicit global `g=5; {g}` → `{"g":5}`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Object literal shorthand properties that can’t be resolved now behave like normal identifier reads instead of being skipped.
  * In cases with spreads, computed keys, methods, accessors, or prototype setters, undeclared shorthand names now surface a runtime `ReferenceError` rather than disappearing.
  * The same fix applies to computed-key handling after object initialization, making shorthand behavior more consistent and predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->