### PR TITLE
fix(runtime,lower): in-operator walks Object.create protos; for-in skips deleted keys

### DIFF
--- a/crates/perry-hir/src/lower/for_head.rs
+++ b/crates/perry-hir/src/lower/for_head.rs
@@ -208,3 +208,46 @@ pub(crate) fn for_head_binding_stmts(
         }
     }
 }
+
+/// Wrap a desugared for-in loop body so a key that is deleted from the
+/// receiver *before it is visited* is skipped, per ECMAScript for-in deletion
+/// semantics (EnumerateObjectProperties: "If a property that has not yet been
+/// visited during enumeration is deleted, then it will not be visited").
+///
+/// The keys are snapshotted once (`ForInKeys`), so without this guard a key
+/// deleted mid-iteration would still be visited. `obj_id` holds the receiver
+/// (spilled to a temp by the caller so it can be re-read each iteration),
+/// `keys_id`/`idx_id` the snapshot array and cursor.
+///
+/// A primitive string is the only primitive whose for-in snapshot is non-empty
+/// (its indices); its keys cannot be deleted, and the `in` operator *throws* on
+/// a primitive receiver — so strings bypass the recheck and are always visited.
+/// Objects/functions go through `key in obj`, which is `false` for a deleted
+/// key and skips it. Nullish receivers never reach here (empty snapshot).
+pub(crate) fn guard_for_in_body(
+    obj_id: LocalId,
+    keys_id: LocalId,
+    idx_id: LocalId,
+    body: Vec<Stmt>,
+) -> Vec<Stmt> {
+    let guard = Expr::Conditional {
+        condition: Box::new(Expr::Compare {
+            op: CompareOp::Eq,
+            left: Box::new(Expr::TypeOf(Box::new(Expr::LocalGet(obj_id)))),
+            right: Box::new(Expr::String("string".to_string())),
+        }),
+        then_expr: Box::new(Expr::Bool(true)),
+        else_expr: Box::new(Expr::In {
+            property: Box::new(Expr::IndexGet {
+                object: Box::new(Expr::LocalGet(keys_id)),
+                index: Box::new(Expr::LocalGet(idx_id)),
+            }),
+            object: Box::new(Expr::LocalGet(obj_id)),
+        }),
+    };
+    vec![Stmt::If {
+        condition: guard,
+        then_branch: body,
+        else_branch: None,
+    }]
+}

--- a/crates/perry-hir/src/lower/mod.rs
+++ b/crates/perry-hir/src/lower/mod.rs
@@ -49,7 +49,7 @@ mod stmt;
 mod unimpl_hints;
 pub(crate) use stmt::*;
 mod for_head;
-pub(crate) use for_head::{for_head_binding_stmts, predefine_for_head};
+pub(crate) use for_head::{for_head_binding_stmts, guard_for_in_body, predefine_for_head};
 mod stmt_loops;
 pub(crate) use stmt_loops::{
     insert_iterator_close_on_abrupt, lazy_iter_for_stmt, lazy_or_index_elem, lower_stmt_for_in,

--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -1893,15 +1893,25 @@ pub(crate) fn lower_stmt_for_in(
     // lowered below can reference them).
     let head_binding = predefine_for_head(ctx, &for_in_stmt.left, Type::String)?;
 
-    // Lower the object expression
+    // Lower the object expression once, spilling it into a temp so each
+    // iteration can re-check that the current key still exists on the
+    // receiver (for-in deletion semantics — see `guard_for_in_body`).
     let obj_expr = lower_expr(ctx, &for_in_stmt.right)?;
+    let obj_id = ctx.fresh_local();
+    module.init.push(Stmt::Let {
+        id: obj_id,
+        name: format!("__forin_obj_{}", obj_id),
+        ty: Type::Any,
+        mutable: false,
+        init: Some(obj_expr),
+    });
 
     // for-in enumerates the receiver's own AND inherited enumerable string
     // keys (deduplicated), and is a no-op — not a throw — on null/undefined.
     // `ForInKeys` carries those semantics; `ObjectKeys` (Object.keys) would
     // throw on nullish and miss inherited keys. Refs language/statements/for-in
     // S12.6.4_A1/A2 (nullish) and A6/A6.1 (prototype chain).
-    let keys_expr = Expr::ForInKeys(Box::new(obj_expr));
+    let keys_expr = Expr::ForInKeys(Box::new(Expr::LocalGet(obj_id)));
 
     // Create internal variables for the keys array and index
     let keys_id = ctx.fresh_local();
@@ -1928,6 +1938,9 @@ pub(crate) fn lower_stmt_for_in(
     for (i, stmt) in binding_stmts.into_iter().enumerate() {
         loop_body.insert(i, stmt);
     }
+
+    // Skip keys deleted from the receiver before they are visited.
+    let loop_body = guard_for_in_body(obj_id, keys_id, idx_id, loop_body);
 
     // Create the for loop:
     // for (let __i = 0; __i < __keys.length; __i++) { ... }

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -1809,10 +1809,20 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
             let head_binding =
                 crate::lower::predefine_for_head(ctx, &for_in_stmt.left, Type::String)?;
 
+            // Spill the receiver into a temp so each iteration can re-check
+            // that the current key still exists (for-in deletion semantics).
             let obj_expr = lower_expr(ctx, &for_in_stmt.right)?;
+            let obj_id = ctx.fresh_local();
+            result.push(Stmt::Let {
+                id: obj_id,
+                name: format!("__forin_obj_{}", obj_id),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(obj_expr),
+            });
             // for-in: own + inherited enumerable keys, nullish-safe (no throw).
             // See lower/stmt_loops.rs::lower_stmt_for_in for the rationale.
-            let keys_expr = Expr::ForInKeys(Box::new(obj_expr));
+            let keys_expr = Expr::ForInKeys(Box::new(Expr::LocalGet(obj_id)));
             let keys_id = ctx.fresh_local();
             let idx_id = ctx.fresh_local();
 
@@ -1836,6 +1846,9 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
             for (i, stmt) in binding_stmts.into_iter().enumerate() {
                 loop_body.insert(i, stmt);
             }
+
+            // Skip keys deleted from the receiver before they are visited.
+            let loop_body = crate::lower::guard_for_in_body(obj_id, keys_id, idx_id, loop_body);
 
             // Create the for loop
             result.push(Stmt::For {

--- a/crates/perry-runtime/src/object/field_get_set/has_property.rs
+++ b/crates/perry-runtime/src/object/field_get_set/has_property.rs
@@ -685,10 +685,18 @@ unsafe fn ordinary_has_property(
             // absent. Hop through that synthetic prototype object and continue; the
             // field-GET path resolves the same chain via `resolve_proto_chain_field`.
             None => {
-                let synth_proto = crate::object::class_prototype_object(unsafe { (*cur).class_id });
-                if !synth_proto.is_null() && synth_proto as *const ObjectHeader != cur {
-                    cur = synth_proto as *const ObjectHeader;
-                    continue;
+                // A prototype hop can land on a real `ArrayHeader` (`Foo.prototype
+                // = [1,2,3]`), whose layout has no `class_id` field — reading one
+                // would misinterpret the array's `length`/`capacity` as a class id
+                // and could spuriously hop. Arrays never model a synthetic
+                // prototype, so skip the lookup for them.
+                if !cur_is_array {
+                    let synth_proto =
+                        crate::object::class_prototype_object(unsafe { (*cur).class_id });
+                    if !synth_proto.is_null() && synth_proto as *const ObjectHeader != cur {
+                        cur = synth_proto as *const ObjectHeader;
+                        continue;
+                    }
                 }
                 break;
             }

--- a/crates/perry-runtime/src/object/field_get_set/has_property.rs
+++ b/crates/perry-runtime/src/object/field_get_set/has_property.rs
@@ -675,9 +675,23 @@ unsafe fn ordinary_has_property(
                 }
                 cur = p as *const ObjectHeader;
             }
-            // No explicit prototype recorded — the default `Object.prototype`
-            // applies (handled below), so stop the explicit walk here.
-            None => break,
+            // No explicit static `[[Prototype]]` recorded. But `Object.create(proto)`
+            // and `Function.prototype = obj` model the prototype link via a synthetic
+            // class_id → prototype object (`CLASS_PROTOTYPE_OBJECTS`), which the
+            // recorded-static-prototype walk above can't see. Without hopping it,
+            // `key in Object.create({ key: … })` — and even inherited
+            // `Object.prototype` members on such a receiver (its synthetic class_id
+            // makes the `Object.prototype` tail below bail) — were wrongly reported
+            // absent. Hop through that synthetic prototype object and continue; the
+            // field-GET path resolves the same chain via `resolve_proto_chain_field`.
+            None => {
+                let synth_proto = crate::object::class_prototype_object(unsafe { (*cur).class_id });
+                if !synth_proto.is_null() && synth_proto as *const ObjectHeader != cur {
+                    cur = synth_proto as *const ObjectHeader;
+                    continue;
+                }
+                break;
+            }
         }
     }
     // Wall 10 — a class instance's prototype METHODS / GETTERS / SETTERS live in


### PR DESCRIPTION
Fixes #6145, #6146.

## Summary

Two related prototype-chain correctness fixes.

### 1. `in` operator walks the `Object.create` prototype chain (runtime)

`key in Object.create(proto)` wrongly returned `false` for every inherited
property — the custom proto's own keys **and** `Object.prototype` members:

```ts
const o = Object.create({ mid: 1 });
"mid" in o        // was false → now true
"toString" in o   // was false → now true
```

`Object.create(proto)` models `[[Prototype]]` via a *synthetic class_id →
prototype object* (`CLASS_PROTOTYPE_OBJECTS`), the same mechanism the field-GET
path already walks (`resolve_proto_chain_field`). But the `in` operator's walk
(`ordinary_has_property`) only followed *recorded static* prototypes
(`object_static_prototype`), which `Object.create` does not populate — so it
stopped at the receiver's own keys. Worse, the `Object.prototype` fallback
(`ordinary_object_prototype_property_value`) bails when `class_id != 0`, and an
`Object.create` result carries the synthetic class_id, so even `"toString" in o`
was `false`.

Fix: when the static-prototype walk finds no recorded `[[Prototype]]`, hop
through the synthetic prototype object (`class_prototype_object(class_id)`) and
continue — reaching the custom proto's keys and, past it, `Object.prototype`.
`class`/`setPrototypeOf`/`__proto__` were already correct and are unchanged.

### 2. for-in skips keys deleted before they are visited (HIR)

Per `EnumerateObjectProperties`, a property deleted during enumeration but not
yet visited must not be visited. Perry snapshots the key list up front
(`ForInKeys`), so a mid-iteration `delete` still visited the stale key:

```ts
const o = { a: 1, b: 2, c: 3 };
for (const k in o) { if (k === "a") delete o.b; console.log(k); }
// was: a b c   →  now: a c
```

Fix: the for-in desugar now spills the receiver to a temp and wraps the loop
body in `if (typeof obj === "string" ? true : (key in obj)) { … }`, skipping a
key no longer present. A primitive string (the only primitive whose for-in
snapshot is non-empty) can't have keys deleted and the `in` operator throws on
primitives, so strings bypass the recheck. This is why fix (1) is a
prerequisite — the recheck relies on a correct `in` for `Object.create`
receivers. Applied at both desugar sites (`lower/stmt_loops.rs`,
`lower_decl/body_stmt.rs`); shared helper `guard_for_in_body` in `for_head.rs`.

## Validation

Byte-for-byte vs `node --experimental-strip-types` across: `in` on
own/custom-proto/`Object.prototype`/absent/2-level-`Object.create`/`create(null)`;
`in` regression on class/`setPrototypeOf`/`__proto__`/plain; for-in
delete-before-visit / delete-current / delete-past / delete-inherited,
for-in over string & number primitives, for-in over `Object.create` (inherited
enumerated), and the same deletion inside a function body.

## Out of scope (pre-existing, unchanged by this PR)

While testing I confirmed two *separate* pre-existing `in` gaps that this PR
does not touch (both already `false` on origin/main): `<idx> in <small typed
array>` and static data props via `<key> in <ClassRef>` (e.g. `"s" in K`).
These use early-return paths in `js_object_has_property`, not the generic
prototype walk fixed here; filed separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved `for...in` iteration to better match JavaScript behavior when the receiver changes during looping.
  * Loop enumeration is now stable and key visits are skipped if properties are deleted before they’re reached.
* **Bug Fixes**
  * Fixed cases where deleted properties could still be visited during `for...in` iteration.
  * Improved inherited property lookup during prototype walks, including more reliable traversal when prototype-like relationships are involved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->