### PR TITLE
fix(gc): release side-table locks before visiting prototype slots (collector self-deadlock)

### DIFF
--- a/crates/perry-runtime/src/closure/dynamic_props.rs
+++ b/crates/perry-runtime/src/closure/dynamic_props.rs
@@ -205,10 +205,27 @@ pub(crate) fn visit_closure_static_prototype_slot_mut(
     if owner == 0 {
         return;
     }
+    // Take the entry OUT and run the visit with the lock RELEASED: a
+    // copying-minor rewrite visitor can move the prototype closure, and
+    // move fixup re-enters `closure_dynamic_props_owner_moved`, which
+    // takes this same lock — visiting under it self-deadlocks the
+    // collector (the geisterhand+reviver GC test wedged CI's cargo-test
+    // at the 3h job timeout). Same remove → visit → merge-back pattern
+    // as `visit_closure_dynamic_prop_values_mut` above and the roots
+    // scanner below.
+    let Some(mut proto_bits) = get_closure_prototypes()
+        .lock()
+        .ok()
+        .and_then(|mut prototypes| prototypes.remove(&owner))
+    else {
+        return;
+    };
+    visit(&mut proto_bits as *mut u64);
+    // The visit can forward the owner itself (self-referential
+    // prototype); re-key like the roots scanner does.
+    let new_owner = forwarded_heap_owner(owner).unwrap_or(owner);
     if let Ok(mut prototypes) = get_closure_prototypes().lock() {
-        if let Some(proto_bits) = prototypes.get_mut(&owner) {
-            visit(proto_bits as *mut u64);
-        }
+        prototypes.insert(new_owner, proto_bits);
     }
 }
 

--- a/crates/perry-runtime/src/object/prototype_chain.rs
+++ b/crates/perry-runtime/src/object/prototype_chain.rs
@@ -162,10 +162,30 @@ pub(crate) fn visit_object_static_prototype_slot_mut(
     if owner == 0 {
         return;
     }
+    // Take the entry OUT and run the visit with the lock RELEASED: a
+    // copying-minor rewrite visitor can move the prototype object, and
+    // move fixup re-enters `object_static_prototype_owner_moved`, which
+    // takes this same lock — visiting under it self-deadlocks the
+    // collector. Same hazard and fix as the closure static-prototype
+    // visitor in `closure::dynamic_props`.
+    let Some(mut proto_bits) = get_object_prototypes()
+        .lock()
+        .ok()
+        .and_then(|mut map| map.remove(&owner))
+    else {
+        return;
+    };
+    visit(&mut proto_bits as *mut u64);
+    // The visit can forward the owner itself (self-referential
+    // prototype); re-key the entry to the forwarded address.
+    let new_owner = unsafe {
+        crate::value::addr_class::try_read_gc_header(owner)
+            .filter(|h| h.gc_flags & crate::gc::GC_FLAG_FORWARDED != 0)
+            .map(|h| crate::gc::forwarding_address(h as *const _) as usize)
+            .unwrap_or(owner)
+    };
     if let Ok(mut map) = get_object_prototypes().lock() {
-        if let Some(proto_bits) = map.get_mut(&owner) {
-            visit(proto_bits as *mut u64);
-        }
+        map.insert(new_owner, proto_bits);
     }
 }
 


### PR DESCRIPTION
Unblocks every open PR: all runtime-scoped `cargo-test` runs since this morning's merge train (#6079, #6083, #6130, and the post-merge nextTick branch run) wedged at the 3-hour job timeout. This was misattributed to each PR in turn — the deadlock is on main.

## Root cause

lldb on the parked test binary shows a **single-thread self-deadlock in the copying minor collector**:

```
visit_closure_static_prototype_slot_mut      ← holds closure-prototypes Mutex (dynamic_props.rs)
  → visit → CopyingNurseryCollector::move_young   (the prototype closure is young → moved)
    → gc_type_after_payload_move
      → closure_dynamic_props_owner_moved    ← locks the SAME Mutex → parks forever
```

`std::sync::Mutex` is non-reentrant, so the collector parks at 0% CPU inside `test_geisterhand_callback_then_json_reviver_copied_minor_gc` (a forced minor GC from within a JSON reviver), every other `callback_scanners` test queues behind the copying-nursery isolation lock, and libtest sits silent until the job timeout.

`visit_object_static_prototype_slot_mut` (#2820 `Object.setPrototypeOf` side table) has the identical bug — an ordinary-object move re-enters `object_static_prototype_owner_moved` on the same lock.

The hazardous shape dates to #2345 (May); one of this morning's runtime merges made the young-movable-prototype case fire deterministically. The fix is correct regardless of trigger.

## Fix

The pattern the two sibling visitors in the same file already use (`visit_closure_dynamic_prop_values_mut`, `scan_closure_dynamic_props_roots_mut`): **remove the entry → drop the lock → visit → re-insert**, re-keying to the forwarded owner address in case the visit moved the owner itself (self-referential prototype).

Audited the remaining `gc_type_after_payload_move` hooks (overflow fields, Map/Set, exotic expando, error side tables): their visitors either collect slots before visiting (RefCell pattern) or use remove/merge — no other instance of visit-under-Mutex.

## Verification

- `cargo test -p perry-runtime --lib gc::tests::runtime_roots::callback_scanners` — 26/26, 0.4s, twice (was: wedged indefinitely, reproduced locally at 0% CPU with the exact CI stack)
- Full `cargo test -p perry-runtime --lib` — **1162/1162 in 3.6s**
- Deadlock reproduced and re-verified across runtime states at 04b8170b9, 042c4a95b, and c78c20be2 — pre-dates today's runtime commits; not attributable to #6123/#6126

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prototype handling during garbage collection so prototype data is updated without holding internal locks during callbacks.
  * Fixed cases where moved or forwarded prototype entries could be re-associated incorrectly, helping prevent stale or inconsistent prototype state.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->