### PR TITLE
fix(runtime): string `<`/sort compare by UTF-16 code unit, not code point

### DIFF
--- a/crates/perry-runtime/src/array/sort.rs
+++ b/crates/perry-runtime/src/array/sort.rs
@@ -159,7 +159,7 @@ fn sort_defined_values(defined: &mut [f64], scratch: *mut f64, cmp: Option<Compa
             for &v in defined.iter() {
                 pairs.push((sort_key_string(v), v));
             }
-            pairs.sort_by(|a, b| a.0.cmp(&b.0));
+            pairs.sort_by(|a, b| crate::string::utf16_cmp_bytes(a.0.as_bytes(), b.0.as_bytes()));
             for (i, (_, v)) in pairs.into_iter().enumerate() {
                 defined[i] = v;
             }
@@ -626,7 +626,7 @@ unsafe fn sort_array_receiver(
             let val = *elements_ptr.add(i);
             pairs.push((sort_key_string(val), val));
         }
-        pairs.sort_by(|a, b| a.0.cmp(&b.0));
+        pairs.sort_by(|a, b| crate::string::utf16_cmp_bytes(a.0.as_bytes(), b.0.as_bytes()));
         mark_array_layout_unknown(arr);
         for (i, (_, val)) in pairs.into_iter().enumerate() {
             // GC_STORE_AUDIT(BARRIERED): default sort writes are followed by layout/barrier rebuild.

--- a/crates/perry-runtime/src/string/compare.rs
+++ b/crates/perry-runtime/src/string/compare.rs
@@ -3,6 +3,22 @@
 
 use super::*;
 
+/// Lexicographic comparison of two UTF-8 byte slices by **UTF-16 code unit**,
+/// matching ECMAScript string relational comparison (`<`/`>` and the default
+/// `Array.prototype.sort` order), which compares UTF-16 code units — NOT Unicode
+/// code points. The two orders agree for BMP-only strings but diverge once an
+/// astral character (code point > U+FFFF) is involved: its UTF-16 surrogate pair
+/// leads with 0xD800–0xDBFF, sorting it *before* BMP characters in 0xE000–0xFFFF,
+/// whereas raw UTF-8 byte order (= code-point order) sorts it after. Falls back
+/// to raw byte order if either side is not valid UTF-8 (WTF-8 lone surrogates —
+/// a known categorical gap).
+pub(crate) fn utf16_cmp_bytes(a: &[u8], b: &[u8]) -> std::cmp::Ordering {
+    match (std::str::from_utf8(a), std::str::from_utf8(b)) {
+        (Ok(a_str), Ok(b_str)) => a_str.encode_utf16().cmp(b_str.encode_utf16()),
+        _ => a.cmp(b),
+    }
+}
+
 /// Compare two strings lexicographically.
 /// Returns -1 if a < b, 0 if a == b, 1 if a > b.
 #[no_mangle]
@@ -26,7 +42,7 @@ pub extern "C" fn js_string_compare(a: *const StringHeader, b: *const StringHead
         let data_b = string_data(b);
         let a_bytes = std::slice::from_raw_parts(data_a, len_a);
         let b_bytes = std::slice::from_raw_parts(data_b, len_b);
-        match a_bytes.cmp(b_bytes) {
+        match utf16_cmp_bytes(a_bytes, b_bytes) {
             std::cmp::Ordering::Less => -1,
             std::cmp::Ordering::Equal => 0,
             std::cmp::Ordering::Greater => 1,

--- a/crates/perry-runtime/src/string/mod.rs
+++ b/crates/perry-runtime/src/string/mod.rs
@@ -64,7 +64,9 @@ pub use compare::{
 // #1781: SSO-aware key lookup helpers, used to retire the
 // `is_string() && js_string_equals(key, key_val.as_string_ptr())` shape
 // across object/.
-pub(crate) use compare::{js_string_key_bytes, js_string_key_matches, js_string_key_matches_bytes};
+pub(crate) use compare::{
+    js_string_key_bytes, js_string_key_matches, js_string_key_matches_bytes, utf16_cmp_bytes,
+};
 pub use concat::{
     js_string_concat, js_string_concat_box, js_string_concat_chain, js_string_concat_value,
     js_value_concat_string,

--- a/crates/perry-runtime/src/value/equality.rs
+++ b/crates/perry-runtime/src/value/equality.rs
@@ -412,7 +412,9 @@ pub extern "C" fn js_jsvalue_compare(a: f64, b: f64) -> i32 {
                 unsafe {
                     let a_bytes = std::slice::from_raw_parts(a_ptr, a_len as usize);
                     let b_bytes = std::slice::from_raw_parts(b_ptr, b_len as usize);
-                    return match a_bytes.cmp(b_bytes) {
+                    // ECMAScript compares strings by UTF-16 code unit, not raw
+                    // UTF-8 byte / code-point order (differs for astral chars).
+                    return match crate::string::utf16_cmp_bytes(a_bytes, b_bytes) {
                         std::cmp::Ordering::Less => -1,
                         std::cmp::Ordering::Equal => 0,
                         std::cmp::Ordering::Greater => 1,


### PR DESCRIPTION
Fixes #6151.

## Summary

ECMAScript compares strings by **UTF-16 code unit** — for `<` `>` `<=` `>=` and
the default `Array.prototype.sort` order. Perry compared raw UTF-8 bytes
(= code-point order), which diverges once an astral character (code point
> U+FFFF) is involved:

```ts
"\u{1F600}" < "｡"              // U+1F600 vs U+FF61 — was false, now true
["｡", "\u{1F600}", "b"].sort() // was [b,😀,｡], now [b,｡,😀]
```

An astral char's UTF-16 encoding is a surrogate pair leading with 0xD800–0xDBFF,
which sorts *before* BMP characters in 0xE000–0xFFFF; code-point order sorts it
after.

## What it does

- Adds `string::utf16_cmp_bytes(a, b)` — decodes UTF-8 and compares via
  `encode_utf16().cmp()`, falling back to raw byte order if either side is not
  valid UTF-8 (WTF-8 lone surrogates, a known categorical gap).
- Routes the three lexicographic string-order sites through it:
  - `<`/`>`/`<=`/`>=` operator (`value/equality.rs`)
  - `js_string_compare` (`string/compare.rs`)
  - default `sort` comparator, both key-comparison sites (`array/sort.rs`)

BMP-only strings (ASCII, Latin accents, etc.) are unchanged — byte order and
UTF-16 order agree there. `localeCompare` (locale-sensitive collation) is a
different operation and is untouched.

## Validation

Byte-for-byte vs `node --experimental-strip-types`: astral `<`/`>`/`<=`/`>=`,
two-astral, mixed BMP+astral, surrogate-vs-high-BMP; default sort of
astral/emoji/accents/ASCII words/numbers/mixed types/empty+dupes; comparator
sort and `localeCompare` unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved string sorting and comparison to follow JavaScript UTF-16 ordering more closely.
  * Fixed edge cases involving non-BMP characters, so lists and comparisons now behave more consistently.
  * Kept existing behavior for invalid text data while updating how valid strings are ordered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->