### PR TITLE
fix(http): server req.on('end') fires every listener, not just the first

### DIFF
--- a/crates/perry-ext-http-server/src/request.rs
+++ b/crates/perry-ext-http-server/src/request.rs
@@ -635,7 +635,20 @@ pub unsafe extern "C" fn js_node_http_im_on(
                 encoding_to_emit = im.encoding.clone();
                 should_emit_end = false;
             }
-            "end" if !im.paused && !im.end_emitted => {
+            // Node fires `'end'` at every registered listener; the one-shot
+            // `!im.end_emitted` guard fired only the FIRST `req.on('end', …)`
+            // and silently dropped every later one (stored but never invoked).
+            // A single request stream routinely carries multiple `'end'`
+            // listeners — e.g. Next.js `getCloneableBody` (body-streams.js)
+            // attaches its body-drain `endPromise` resolver as a *second*
+            // `'end'` listener, so on routes that clone the request body that
+            // promise never resolved and the request hung. Fire the
+            // just-registered callback on every non-paused registration; the
+            // buffered request body is already complete when the handler runs,
+            // so each late listener observes `'end'` exactly once. `end_emitted`
+            // still latches so the bulk `resume()`/reaper emit paths (which gate
+            // on it) never double-fire an already-invoked listener.
+            "end" if !im.paused => {
                 im.end_emitted = true;
                 im.complete = true;
                 body_to_emit = None;


### PR DESCRIPTION
## Problem

On the native HTTP server, `req.on('end', cb)` fired **only the first** `'end'`
listener. `js_node_http_im_on`'s `"end"` arm was guarded by
`!im.paused && !im.end_emitted` and emitted just the newly-registered callback
while latching the one-shot `end_emitted` flag — so every subsequent
`req.on('end', …)` was stored but never invoked. Node delivers `'end'` to **all**
registered listeners.

This surfaced under Next.js. `getCloneableBody`
(`next/dist/server/body-streams.js`) builds:

```js
const endPromise = new Promise((resolve, reject) => {
  readable.on('end', resolve);   // <- a *second* 'end' listener on the request
  readable.on('error', reject);
});
```

Because `resolve` was not the first `'end'` listener, it never fired, so
`endPromise` never resolved and `finalize()` awaited it forever — hanging requests
on routes that clone the request body.

## Fix

Drop the `!im.end_emitted` guard so every non-paused `.on('end')` fires its own
callback. The buffered request body is already complete when the handler runs, so
each listener observes `'end'` exactly once. `end_emitted` still latches, so the
bulk `resume()` / reaper emit paths (which gate on it) never double-fire an
already-invoked listener. This makes multi-listener behavior consistent with the
existing single-listener path (which already emitted synchronously on
registration).

## Repro

```ts
import * as http from "http";
http.createServer((req, res) => {
  req.on("end", () => { console.log("L1"); res.end("ok"); });
  req.on("end", () => console.log("L2"));
  req.on("end", () => console.log("L3"));
}).listen(0, "127.0.0.1", function () {
  console.log((this.address()).port);
});
```

- Before: prints only `L1`.
- After: prints `L1`, `L2`, `L3` (matches Node).

## Scope / risk

One-line guard change in `crates/perry-ext-http-server/src/request.rs` (+ comment).
The passing static routes and API routes in the Next.js compatibility matrix are
unaffected; POST body handling verified unchanged. Found while investigating the
Next.js force-dynamic render hang (#5989) — this removes one of that issue's
blockers (the request-body-clone hang); the dynamic-render suspend has a separate
remaining blocker tracked under #5989.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where newly added “end” listeners on incoming requests could fail to run immediately.
  * Request processing now completes more reliably, improving behavior for streaming or buffered request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->