### PR TITLE
fix(hir,runtime): well-known-symbol methods on class expressions

### DIFF
--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -67,18 +67,6 @@ fn computed_member_name(kind: ast::MethodKind, computed: &ast::ComputedPropName)
     format!("{}_{}_{}", base, computed.span.lo.0, computed.span.hi.0)
 }
 
-fn with_static_member_context<T>(
-    ctx: &mut LoweringContext,
-    is_static: bool,
-    f: impl FnOnce(&mut LoweringContext) -> Result<T>,
-) -> Result<T> {
-    let old = ctx.current_class_member_is_static;
-    ctx.current_class_member_is_static = is_static;
-    let result = f(ctx);
-    ctx.current_class_member_is_static = old;
-    result
-}
-
 fn runtime_instance_accessor_names(members: &[ast::ClassMember]) -> crate::ClassAccessorNames {
     let mut accessor_names = crate::ClassAccessorNames::default();
 
@@ -785,123 +773,18 @@ pub fn lower_class_decl(
                             // this name on the object's vtable when there is no
                             // per-instance entry. Refs #1248.
                             ("__perry_inspect_custom__".to_string(), false)
-                        } else if let Some(wk) = symbol_well_known_key(&computed.expr) {
-                            // hasInstance (static method): lift the method
-                            // body to a top-level function named
-                            // `__perry_wk_hasinstance_<class>`. Signature:
-                            // `(value: f64) -> f64` — no `this`.
-                            if wk == "hasInstance"
-                                && method.is_static
-                                && matches!(method.kind, ast::MethodKind::Method)
-                            {
-                                let mut func =
-                                    with_static_member_context(ctx, method.is_static, |ctx| {
-                                        lower_class_method(ctx, method)
-                                    })?;
-                                func.name = format!("__perry_wk_hasinstance_{}", name);
-                                ctx.pending_functions.push(func);
-                                continue;
-                            }
-                            // toStringTag (instance getter): lift the
-                            // getter body to a top-level function named
-                            // `__perry_wk_tostringtag_<class>`. Signature:
-                            // `(this: f64) -> f64` — getter takes `this`
-                            // as an explicit first parameter and returns
-                            // a string.
-                            if wk == "toStringTag"
-                                && !method.is_static
-                                && matches!(method.kind, ast::MethodKind::Getter)
-                            {
-                                let getter =
-                                    with_static_member_context(ctx, method.is_static, |ctx| {
-                                        lower_getter_method(ctx, method)
-                                    })?;
-                                // Inject a `this` parameter at position 0 and rewrite
-                                // any `Expr::This` in the body to `LocalGet(this_id)`.
-                                let this_id = ctx.fresh_local();
-                                let mut new_params = Vec::with_capacity(getter.params.len() + 1);
-                                new_params.push(Param {
-                                    id: this_id,
-                                    name: "this".to_string(),
-                                    ty: Type::Named(name.clone()),
-                                    default: None,
-                                    decorators: Vec::new(),
-                                    is_rest: false,
-                                    arguments_object: None,
-                                });
-                                new_params.extend(getter.params);
-                                let mut body = getter.body;
-                                crate::analysis::replace_this_in_stmts(&mut body, this_id);
-                                let top_fn = Function {
-                                    id: ctx.fresh_func(),
-                                    name: format!("__perry_wk_tostringtag_{}", name),
-                                    type_params: Vec::new(),
-                                    params: new_params,
-                                    return_type: Type::Any,
-                                    body,
-                                    is_async: false,
-                                    is_generator: false,
-                                    is_strict: true,
-                                    was_plain_async: false,
-                                    was_unrolled: false,
-                                    is_exported: false,
-                                    captures: Vec::new(),
-                                    decorators: Vec::new(),
-                                };
-                                ctx.pending_functions.push(top_fn);
-                                continue;
-                            }
-                            // `[Symbol.dispose]()` / `[Symbol.asyncDispose]()`:
-                            // ES2024 explicit-resource-management dispose hooks.
-                            // Rename the method to a stable string-keyed name so
-                            // the using-block desugarer can call it via plain
-                            // method dispatch (`obj.__perry_dispose__()` /
-                            // `obj.__perry_async_dispose__()`). Falls through to
-                            // the regular method-pushing path below with the
-                            // renamed key.
-                            if (wk == "dispose" || wk == "asyncDispose")
-                                && !method.is_static
-                                && matches!(method.kind, ast::MethodKind::Method)
-                            {
-                                if wk == "asyncDispose" {
-                                    ("__perry_async_dispose__".to_string(), false)
-                                } else {
-                                    ("__perry_dispose__".to_string(), false)
-                                }
-                            } else if wk == "asyncIterator"
-                                && !method.is_static
-                                && matches!(method.kind, ast::MethodKind::Method)
-                            {
-                                // #1838 follow-up: `[Symbol.asyncIterator]() {}`
-                                // on a class — register under `@@asyncIterator`
-                                // so the symbol resolver in `runtime/src/symbol.rs`
-                                // (`well_known_symbol_method_key`) binds it as
-                                // `instance[Symbol.asyncIterator]`. Mirrors the
-                                // `@@iterator` path; for-await over a class
-                                // instance picks the same vtable entry.
-                                ("@@asyncIterator".to_string(), false)
-                            } else if wk == "toPrimitive"
-                                && !method.is_static
-                                && matches!(method.kind, ast::MethodKind::Method)
-                            {
-                                // #2374: `[Symbol.toPrimitive](hint) {}` on a
-                                // class — register under `@@toPrimitive` so the
-                                // symbol resolver in `runtime/src/symbol.rs`
-                                // (`well_known_symbol_method_key`) binds it as
-                                // `instance[Symbol.toPrimitive]`. The runtime's
-                                // ToPrimitive (`js_to_primitive`, consulted by
-                                // unary `+` numeric coercion and template/`String()`
-                                // string coercion) then invokes it with the
-                                // appropriate hint before falling back to
-                                // `valueOf`/`toString`. Mirrors the `@@iterator`
-                                // / `@@asyncIterator` path. Pre-fix the method
-                                // was dropped here, so class instances coerced to
-                                // `NaN` / `[object Object]`.
-                                ("@@toPrimitive".to_string(), false)
-                            } else {
-                                // Other well-known on a class: not yet
-                                // implemented, skip.
-                                continue;
+                        } else if let Some(outcome) =
+                            lower_well_known_computed_method(ctx, method, &name)?
+                        {
+                            // Well-known-symbol key (`[Symbol.asyncIterator]`,
+                            // `static [Symbol.hasInstance]`, `[Symbol.dispose]`,
+                            // …) — handling shared with the class-expression
+                            // path (`lower_class_from_ast`); see the helper in
+                            // helpers.rs for the per-symbol details.
+                            match outcome {
+                                WellKnownComputedMethod::Rename(renamed) => (renamed, false),
+                                WellKnownComputedMethod::Lifted
+                                | WellKnownComputedMethod::Unsupported => continue,
                             }
                         } else {
                             continue;
@@ -1722,6 +1605,25 @@ pub fn lower_class_from_ast(
                     {
                         // Refs #1248: see class_decl.rs Method handling above.
                         ("__perry_inspect_custom__".to_string(), false)
+                    }
+                    // Other well-known-symbol keys (`[Symbol.asyncIterator]`,
+                    // `[Symbol.toPrimitive]`, `[Symbol.dispose]` /
+                    // `[Symbol.asyncDispose]`, `static [Symbol.hasInstance]`,
+                    // `get [Symbol.toStringTag]`) on a class *expression* —
+                    // same handling as the declaration path, via the shared
+                    // helper. Pre-fix these fell through `_ => continue` and
+                    // were silently dropped, so e.g. `for await (… of new (C =
+                    // class { [Symbol.asyncIterator]() {…} })())` threw
+                    // `TypeError: value is not iterable`.
+                    ast::PropName::Computed(_) => {
+                        match lower_well_known_computed_method(ctx, method, name)? {
+                            Some(WellKnownComputedMethod::Rename(renamed)) => (renamed, false),
+                            Some(
+                                WellKnownComputedMethod::Lifted
+                                | WellKnownComputedMethod::Unsupported,
+                            )
+                            | None => continue,
+                        }
                     }
                     _ => continue,
                 };

--- a/crates/perry-hir/src/lower_decl/helpers.rs
+++ b/crates/perry-hir/src/lower_decl/helpers.rs
@@ -638,3 +638,157 @@ pub fn append_synthetic_arguments_param(
         }),
     });
 }
+
+/// Scope a member-lowering closure with `ctx.current_class_member_is_static`
+/// set for the member's staticness (restored afterwards).
+pub(crate) fn with_static_member_context<T>(
+    ctx: &mut LoweringContext,
+    is_static: bool,
+    f: impl FnOnce(&mut LoweringContext) -> anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    let old = ctx.current_class_member_is_static;
+    ctx.current_class_member_is_static = is_static;
+    let result = f(ctx);
+    ctx.current_class_member_is_static = old;
+    result
+}
+
+/// Outcome of `lower_well_known_computed_method` for a class method whose
+/// computed key is a well-known symbol (`[Symbol.asyncIterator]() {}`,
+/// `static [Symbol.hasInstance]() {}`, `get [Symbol.toStringTag]() {}`, …).
+pub(crate) enum WellKnownComputedMethod {
+    /// Register the method under this synthetic registration name
+    /// (`@@asyncIterator`, `@@toPrimitive`, `__perry_dispose__`, …) via the
+    /// caller's regular method-pushing path. Never source-order registered.
+    Rename(String),
+    /// Fully handled here — the method body was lifted to a pending
+    /// top-level function (`__perry_wk_hasinstance_<class>` /
+    /// `__perry_wk_tostringtag_<class>`); the caller skips the member.
+    Lifted,
+    /// A recognized well-known symbol in a form perry doesn't implement
+    /// yet (e.g. a static `[Symbol.toPrimitive]`) — the caller drops the
+    /// member, preserving the historical behavior.
+    Unsupported,
+}
+
+/// Shared lowering for class methods keyed by a well-known symbol. Both the
+/// class-declaration path (`lower_class_decl`) and the class-expression path
+/// (`lower_class_from_ast`) call this from their computed-key match arm, so
+/// `const C = class { [Symbol.asyncIterator]() {…} }` registers the same
+/// vtable entries as the equivalent class declaration. Pre-fix the
+/// expression path fell through `_ => continue` and silently dropped every
+/// well-known-symbol method except `@@iterator`, so `for await (… of
+/// new C())` threw `TypeError: value is not iterable` (the SDK-style
+/// `oV = class { [Symbol.asyncIterator]() { return this.iterator() } }`
+/// stream wrapper in a large esbuild-bundled CLI app is the canonical case).
+///
+/// Returns `Ok(None)` when the method's key is not a well-known-symbol
+/// computed key at all.
+pub(crate) fn lower_well_known_computed_method(
+    ctx: &mut LoweringContext,
+    method: &ast::ClassMethod,
+    class_name: &str,
+) -> anyhow::Result<Option<WellKnownComputedMethod>> {
+    let ast::PropName::Computed(computed) = &method.key else {
+        return Ok(None);
+    };
+    let Some(wk) = symbol_well_known_key(&computed.expr) else {
+        return Ok(None);
+    };
+    // hasInstance (static method): lift the method body to a top-level
+    // function named `__perry_wk_hasinstance_<class>`. Signature:
+    // `(value: f64) -> f64` — no `this`.
+    if wk == "hasInstance" && method.is_static && matches!(method.kind, ast::MethodKind::Method) {
+        let mut func = with_static_member_context(ctx, method.is_static, |ctx| {
+            super::lower_class_method(ctx, method)
+        })?;
+        func.name = format!("__perry_wk_hasinstance_{}", class_name);
+        ctx.pending_functions.push(func);
+        return Ok(Some(WellKnownComputedMethod::Lifted));
+    }
+    // toStringTag (instance getter): lift the getter body to a top-level
+    // function named `__perry_wk_tostringtag_<class>`. Signature:
+    // `(this: f64) -> f64` — getter takes `this` as an explicit first
+    // parameter and returns a string.
+    if wk == "toStringTag" && !method.is_static && matches!(method.kind, ast::MethodKind::Getter) {
+        let getter = with_static_member_context(ctx, method.is_static, |ctx| {
+            super::lower_getter_method(ctx, method)
+        })?;
+        // Inject a `this` parameter at position 0 and rewrite any
+        // `Expr::This` in the body to `LocalGet(this_id)`.
+        let this_id = ctx.fresh_local();
+        let mut new_params = Vec::with_capacity(getter.params.len() + 1);
+        new_params.push(Param {
+            id: this_id,
+            name: "this".to_string(),
+            ty: Type::Named(class_name.to_string()),
+            default: None,
+            decorators: Vec::new(),
+            is_rest: false,
+            arguments_object: None,
+        });
+        new_params.extend(getter.params);
+        let mut body = getter.body;
+        crate::analysis::replace_this_in_stmts(&mut body, this_id);
+        let top_fn = Function {
+            id: ctx.fresh_func(),
+            name: format!("__perry_wk_tostringtag_{}", class_name),
+            type_params: Vec::new(),
+            params: new_params,
+            return_type: Type::Any,
+            body,
+            is_async: false,
+            is_generator: false,
+            is_strict: true,
+            was_plain_async: false,
+            was_unrolled: false,
+            is_exported: false,
+            captures: Vec::new(),
+            decorators: Vec::new(),
+        };
+        ctx.pending_functions.push(top_fn);
+        return Ok(Some(WellKnownComputedMethod::Lifted));
+    }
+    // `[Symbol.dispose]()` / `[Symbol.asyncDispose]()`: ES2024
+    // explicit-resource-management dispose hooks. Rename the method to a
+    // stable string-keyed name so the using-block desugarer can call it via
+    // plain method dispatch (`obj.__perry_dispose__()` /
+    // `obj.__perry_async_dispose__()`). Flows through the caller's regular
+    // method-pushing path with the renamed key.
+    if (wk == "dispose" || wk == "asyncDispose")
+        && !method.is_static
+        && matches!(method.kind, ast::MethodKind::Method)
+    {
+        let renamed = if wk == "asyncDispose" {
+            "__perry_async_dispose__".to_string()
+        } else {
+            "__perry_dispose__".to_string()
+        };
+        return Ok(Some(WellKnownComputedMethod::Rename(renamed)));
+    }
+    // #1838 follow-up: `[Symbol.asyncIterator]() {}` on a class — register
+    // under `@@asyncIterator` so the symbol resolver in `runtime/src/symbol.rs`
+    // (`well_known_symbol_method_key`) binds it as
+    // `instance[Symbol.asyncIterator]`. Mirrors the `@@iterator` path;
+    // for-await over a class instance picks the same vtable entry.
+    if wk == "asyncIterator" && !method.is_static && matches!(method.kind, ast::MethodKind::Method)
+    {
+        return Ok(Some(WellKnownComputedMethod::Rename(
+            "@@asyncIterator".to_string(),
+        )));
+    }
+    // #2374: `[Symbol.toPrimitive](hint) {}` on a class — register under
+    // `@@toPrimitive` so the symbol resolver in `runtime/src/symbol.rs`
+    // (`well_known_symbol_method_key`) binds it as
+    // `instance[Symbol.toPrimitive]`. The runtime's ToPrimitive
+    // (`js_to_primitive`, consulted by unary `+` numeric coercion and
+    // template/`String()` string coercion) then invokes it with the
+    // appropriate hint before falling back to `valueOf`/`toString`.
+    if wk == "toPrimitive" && !method.is_static && matches!(method.kind, ast::MethodKind::Method) {
+        return Ok(Some(WellKnownComputedMethod::Rename(
+            "@@toPrimitive".to_string(),
+        )));
+    }
+    // Other well-known on a class: not yet implemented — drop.
+    Ok(Some(WellKnownComputedMethod::Unsupported))
+}

--- a/crates/perry-hir/src/lower_decl/mod.rs
+++ b/crates/perry-hir/src/lower_decl/mod.rs
@@ -54,8 +54,9 @@ pub(crate) use fn_decl::lower_fn_decl;
 pub(crate) use helpers::{
     append_synthetic_arguments_param, body_has_use_strict, body_uses_arguments,
     build_default_param_stmts, collect_let_decls_in_stmt, init_is_webassembly_instantiate,
-    is_inspect_custom_key, is_symbol_iterator_key, mapped_argument_parameter_ids,
-    params_are_simple_arguments_list, params_use_arguments, symbol_well_known_key,
+    is_inspect_custom_key, is_symbol_iterator_key, lower_well_known_computed_method,
+    mapped_argument_parameter_ids, params_are_simple_arguments_list, params_use_arguments,
+    symbol_well_known_key, with_static_member_context, WellKnownComputedMethod,
 };
 pub(crate) use interface_decl::lower_interface_decl;
 pub(crate) use private_members::{

--- a/crates/perry-runtime/src/object/class_registry/parent_static.rs
+++ b/crates/perry-runtime/src/object/class_registry/parent_static.rs
@@ -357,14 +357,73 @@ pub unsafe extern "C" fn js_register_class_computed_method(
         if sym_key == 0 {
             return;
         }
-        let mut guard = CLASS_SYMBOL_METHODS.write().unwrap();
-        if guard.is_none() {
-            *guard = Some(HashMap::new());
+        {
+            let mut guard = CLASS_SYMBOL_METHODS.write().unwrap();
+            if guard.is_none() {
+                *guard = Some(HashMap::new());
+            }
+            guard.as_mut().unwrap().insert(
+                (class_id, sym_key, is_static != 0),
+                (func_ptr as usize, param_count as u32, has_rest != 0),
+            );
         }
-        guard.as_mut().unwrap().insert(
-            (class_id, sym_key, is_static != 0),
-            (func_ptr as usize, param_count as u32, has_rest != 0),
-        );
+        // A computed key that evaluates to a WELL-KNOWN symbol — e.g. the
+        // minified `[(gm = new WeakMap, Symbol.asyncIterator)]() {…}` comma
+        // form, whose key expression the lowering can't see through
+        // statically — must land in the same synthetic vtable slot the
+        // static `[Symbol.asyncIterator]` lowering uses. Every consumer
+        // (GetIterator(async), the #5128 symbol-read binder,
+        // `js_to_primitive`, the using-block desugar) resolves these by the
+        // synthetic NAME on the class; `CLASS_SYMBOL_METHODS` above is not
+        // consulted for instance dispatch. Without the alias,
+        // `for await (… of instance)` threw `TypeError: value is not
+        // iterable` for the comma-keyed form.
+        if is_static == 0 {
+            let alias = [
+                ("iterator", "@@iterator"),
+                ("asyncIterator", "@@asyncIterator"),
+                ("toPrimitive", "@@toPrimitive"),
+                ("dispose", "__perry_dispose__"),
+                ("asyncDispose", "__perry_async_dispose__"),
+            ]
+            .iter()
+            .find_map(|(wk, method_name)| {
+                let s = crate::symbol::well_known_symbol(wk);
+                if s.is_null() {
+                    return None;
+                }
+                let f = f64::from_bits(crate::value::JSValue::pointer(s as *const u8).bits());
+                if sym_key == crate::symbol::sym_key_from_f64(f) {
+                    Some(*method_name)
+                } else {
+                    None
+                }
+            });
+            if let Some(method_name) = alias {
+                let mut registry = CLASS_VTABLE_REGISTRY.write().unwrap();
+                if registry.is_none() {
+                    *registry = Some(HashMap::new());
+                }
+                let vtable = registry
+                    .as_mut()
+                    .unwrap()
+                    .entry(class_id)
+                    .or_insert_with(|| ClassVTable {
+                        methods: HashMap::new(),
+                        getters: HashMap::new(),
+                        setters: HashMap::new(),
+                    });
+                vtable.methods.insert(
+                    method_name.to_string(),
+                    VTableMethodEntry {
+                        func_ptr: func_ptr as usize,
+                        param_count: param_count as u32,
+                        has_synthetic_arguments: false,
+                        has_rest: has_rest != 0,
+                    },
+                );
+            }
+        }
         VTABLE_GEN.fetch_add(1, Ordering::Release);
         return;
     }

--- a/crates/perry/tests/class_expr_well_known_symbol_methods.rs
+++ b/crates/perry/tests/class_expr_well_known_symbol_methods.rs
@@ -1,0 +1,246 @@
+//! Regression tests: well-known-symbol methods on class *expressions*.
+//!
+//! `lower_class_from_ast` (the class-expression path) only special-cased
+//! `[Symbol.iterator]` and `[util.inspect.custom]` computed keys; every other
+//! well-known-symbol method — `[Symbol.asyncIterator]`, `[Symbol.toPrimitive]`,
+//! `[Symbol.dispose]` / `[Symbol.asyncDispose]`, `static [Symbol.hasInstance]`,
+//! `get [Symbol.toStringTag]` — fell through `_ => continue` and was silently
+//! dropped. The same methods on a class *declaration* worked
+//! (`lower_class_decl` handles them all).
+//!
+//! Canonical failure: an SDK-style SSE stream wrapper in a large
+//! esbuild-bundled CLI app,
+//!   `oV = class oV { constructor(it) { this.iterator = it }
+//!                    [Symbol.asyncIterator]() { return this.iterator() } }`
+//! — `for await (const ev of stream)` resolved no `@@asyncIterator`, fell
+//! through to the sync-iterator path, found no `.next`, and threw
+//! `TypeError: value is not iterable`.
+//!
+//! Fix: both lowering paths route computed well-known-symbol keys through the
+//! shared `lower_well_known_computed_method` helper (lower_decl/helpers.rs).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+/// `[Symbol.asyncIterator]() {}` on class expressions: `for await` over an
+/// instance must find `@@asyncIterator` (pre-fix: `TypeError: value is not
+/// iterable`), a dynamic `obj[Symbol.asyncIterator]` read must see a function
+/// (pre-fix: `undefined`), and a manual invoke must drive the iterator.
+#[test]
+fn class_expression_symbol_async_iterator_for_await() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+async function* gen() { yield 1; yield 2; }
+// anonymous class expression
+const A: any = class { [Symbol.asyncIterator]() { return gen(); } };
+// SDK-style named class expression assigned to a same-named outer binding,
+// delegating to a stored iterator factory (the esbuild-bundle shape).
+var oV: any;
+oV = class oV {
+  iterator: any;
+  constructor(it: any) { this.iterator = it; }
+  [Symbol.asyncIterator]() { return this.iterator(); }
+};
+async function* letters() { yield "a"; yield "b"; }
+(async () => {
+  const got: any[] = [];
+  for await (const x of new A()) got.push(x);
+  console.log("A:", got.join(","));
+  console.log("A dyn:", typeof new A()[Symbol.asyncIterator]);
+  const s = new oV(letters);
+  const evs: any[] = [];
+  for await (const ev of s) evs.push(ev);
+  console.log("oV:", evs.join(","));
+  const it = new oV(letters)[Symbol.asyncIterator]();
+  const first = await it.next();
+  console.log("manual:", first.value, first.done);
+})();
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "A: 1,2\nA dyn: function\noV: a,b\nmanual: a false\n"
+    );
+}
+
+/// `[Symbol.toPrimitive](hint) {}` on a class expression: numeric and
+/// default-hint coercions must invoke it (pre-fix: dropped, so instances
+/// coerced to `NaN` / `[object Object]`).
+#[test]
+fn class_expression_symbol_to_primitive() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const P: any = class {
+  [Symbol.toPrimitive](hint: string) { return hint === "number" ? 42 : "str"; }
+};
+console.log(+new P());
+console.log(`${new P()}`);
+"#,
+    );
+    assert_eq!(stdout, "42\nstr\n");
+}
+
+/// `static [Symbol.hasInstance](v) {}` on a class expression: `instanceof`
+/// must consult it (pre-fix: dropped).
+#[test]
+fn class_expression_static_symbol_has_instance() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const H: any = class { static [Symbol.hasInstance](v: any) { return v === 7; } };
+console.log(7 instanceof H);
+console.log(8 instanceof H);
+"#,
+    );
+    assert_eq!(stdout, "true\nfalse\n");
+}
+
+/// `get [Symbol.toStringTag]() {}` on a class expression:
+/// `Object.prototype.toString` must pick up the tag (pre-fix: dropped, so
+/// `[object Object]`).
+#[test]
+fn class_expression_symbol_to_string_tag_getter() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const T: any = class { get [Symbol.toStringTag]() { return "Custom"; } };
+console.log(Object.prototype.toString.call(new T()));
+"#,
+    );
+    assert_eq!(stdout, "[object Custom]\n");
+}
+
+/// `[Symbol.dispose]()` on a class expression: a `using` block must invoke it
+/// at scope exit (pre-fix: dropped, so nothing ran).
+#[test]
+fn class_expression_symbol_dispose_using_block() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const D: any = class {
+  name: string;
+  constructor(name: string) { this.name = name; }
+  [Symbol.dispose]() { console.log("disposed", this.name); }
+};
+{
+  using d = new D("x");
+  console.log("in scope");
+}
+console.log("after");
+"#,
+    );
+    assert_eq!(stdout, "in scope\ndisposed x\nafter\n");
+}
+
+/// A computed key that only EVALUATES to a well-known symbol — the minified
+/// `[(gm = new WeakMap, Symbol.asyncIterator)]() {…}` comma form — can't be
+/// recognized statically and flows through the generic computed-member
+/// runtime registration. `js_register_class_computed_method` must alias the
+/// well-known symbol onto the synthetic vtable slot (`@@asyncIterator` /
+/// `@@iterator`) that GetIterator and the symbol-read binder consult, and the
+/// key expression's side effect must still run.
+#[test]
+fn class_expression_comma_keyed_well_known_symbol_methods() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+var gm1: any, gm2: any;
+var oV: any;
+oV = class oV {
+  iterator: any;
+  constructor(q: any) { this.iterator = q; }
+  [(gm1 = new WeakMap(), Symbol.asyncIterator)]() { return this.iterator(); }
+};
+const S: any = class {
+  [(gm2 = 1, Symbol.iterator)]() {
+    let d = false;
+    return { next: () => d ? { done: true, value: 0 } : (d = true, { done: false, value: 5 }) };
+  }
+};
+async function* mk() { yield "x"; yield "y"; }
+(async () => {
+  const evs: any[] = [];
+  for await (const e of new oV(mk)) evs.push(e);
+  console.log("comma-async:", evs.join(","));
+  console.log("comma-sync:", [...new S()].join(","));
+  console.log("side effects:", gm1 instanceof WeakMap, gm2);
+})();
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "comma-async: x,y\ncomma-sync: 5\nside effects: true 1\n"
+    );
+}
+
+/// The class-declaration forms must keep working identically after the
+/// refactor onto the shared helper (decl-path regression guard).
+#[test]
+fn class_declaration_well_known_methods_still_work() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+async function* gen() { yield "d1"; }
+class DeclAsync { [Symbol.asyncIterator]() { return gen(); } }
+class DeclPrim { [Symbol.toPrimitive](hint: string) { return hint === "number" ? 7 : "p"; } }
+class DeclHas { static [Symbol.hasInstance](v: any) { return v === 1; } }
+class DeclTag { get [Symbol.toStringTag]() { return "DeclTag"; } }
+(async () => {
+  const got: any[] = [];
+  for await (const x of new DeclAsync()) got.push(x);
+  console.log(got.join(","));
+  console.log(+new DeclPrim());
+  console.log(1 instanceof DeclHas, 2 instanceof DeclHas);
+  console.log(Object.prototype.toString.call(new DeclTag()));
+})();
+"#,
+    );
+    assert_eq!(stdout, "d1\n7\ntrue false\n[object DeclTag]\n");
+}


### PR DESCRIPTION
## Problem

`lower_class_from_ast` (the class-**expression** path) special-cases only `[Symbol.iterator]` and `[util.inspect.custom]` computed keys. Every other well-known-symbol method — `[Symbol.asyncIterator]`, `[Symbol.toPrimitive]`, `[Symbol.dispose]` / `[Symbol.asyncDispose]`, `static [Symbol.hasInstance]`, `get [Symbol.toStringTag]` — falls through `_ => continue` and is **silently dropped**. The same members on a class **declaration** work (`lower_class_decl` handles them all).

```ts
const C = class { [Symbol.asyncIterator]() { return gen(); } };
for await (const x of new C()) {}   // TypeError: value is not iterable
typeof new C()[Symbol.asyncIterator] // "undefined"  (declaration form: "function")
```

Canonical real-world failure: an SDK-style SSE stream wrapper in a large esbuild-bundled CLI app —
`oV = class oV { constructor(it){this.iterator=it} [(gm = new WeakMap, Symbol.asyncIterator)]() { return this.iterator() } }` — every streamed API response died with `value is not iterable` in `for await (const event of stream)`.

## Fix

**Part 1 (hir)** — extract the declaration path's well-known computed-key handling into a shared `lower_well_known_computed_method` helper (`lower_decl/helpers.rs`), called from both `lower_class_decl` and `lower_class_from_ast`. Class expressions now register `@@asyncIterator` / `@@toPrimitive` / `__perry_dispose__` / `__perry_async_dispose__` and lift `__perry_wk_hasinstance_*` / `__perry_wk_tostringtag_*` exactly like declarations. (`class_decl.rs` sat at the 2000-line size gate; `with_static_member_context` moves to helpers.rs alongside the new code, shrinking it to 1901.)

**Part 2 (runtime)** — the minified **comma form** `[(gm = new WeakMap, Symbol.asyncIterator)]()` evaluates its key at runtime, so lowering can't recognize it statically; it routes through the generic computed registration `js_register_class_computed_method`, which stored it in `CLASS_SYMBOL_METHODS` — a table **no instance lookup consults** (only GC bookkeeping reads it): registered yet unreachable. Now, when the evaluated key is a well-known symbol, the registration also aliases the function into the class vtable under the synthetic name that `GetIterator` (async/sync), the #5128 symbol-read binder, and the using-block desugar already resolve. Key-expression side effects still run exactly once.

## Tests

New `crates/perry/tests/class_expr_well_known_symbol_methods.rs` (7 tests, all node-oracle-verified):
- `for await` + dynamic read + manual invoke over anonymous **and** named class expressions (incl. the SDK `this.iterator()` delegation shape)
- `[Symbol.toPrimitive]` (number + default hints), `static [Symbol.hasInstance]`, `get [Symbol.toStringTag]`, `[Symbol.dispose]` in a `using` block
- comma-keyed `[(gm = new WeakMap, Symbol.asyncIterator)]` async + `[(x = 1, Symbol.iterator)]` sync, with key-side-effect assertions
- class-declaration regression guard (decl path re-verified after the refactor)

Existing suites pass: `issue_5128_user_symbol_iterator`, `issue_5437_class_expr_heritage_capture`, `issue_5667_instanceof_define_property_hasinstance`, `issue_5703_class_expr_static_dflt_params`, `issue_5735_typed_array_symbol_keys`, `perry-hir` unit tests, `perry-runtime --lib` (1164 tests, single-threaded).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved support for well-known symbol methods on classes, including `Symbol.asyncIterator`, `Symbol.toPrimitive`, `Symbol.hasInstance`, `Symbol.toStringTag`, and disposal-related symbols.
  * Class expressions and class declarations now handle computed symbol-based members more consistently.

* **Bug Fixes**
  * Fixed missing runtime behavior for symbol-keyed class members in common JavaScript patterns like `for await`, `instanceof`, string coercion, and `using` cleanup.
  * Preserved correct behavior when computed keys are produced by expressions with side effects.

* **Tests**
  * Added regression coverage for these well-known symbol behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->