### PR TITLE
fix(runtime,lower): Map/Set for-of doesn't skip on delete-during-iteration (#6075)

### DIFF
--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1041,6 +1041,10 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // would do. (Map ptr, entry idx) → key / value.
     module.declare_function("js_map_entry_key_at", DOUBLE, &[I64, I32]);
     module.declare_function("js_map_entry_value_at", DOUBLE, &[I64, I32]);
+    // #6075: current index of a key/value (or -1) for the delete-safe for-of
+    // fast path. Takes the NaN-boxed collection + key; strips internally.
+    module.declare_function("js_map_find_key_index", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_set_find_value_index", DOUBLE, &[DOUBLE, DOUBLE]);
     // Map/Set forEach: (collection_ptr, callback_nanboxed_f64, thisArg_f64) -> void (#2830)
     module.declare_function("js_map_foreach", VOID, &[I64, DOUBLE, DOUBLE]);
     module.declare_function("js_set_foreach", VOID, &[I64, DOUBLE, DOUBLE]);

--- a/crates/perry-hir/src/lower/for_head.rs
+++ b/crates/perry-hir/src/lower/for_head.rs
@@ -251,3 +251,152 @@ pub(crate) fn guard_for_in_body(
         else_branch: None,
     }]
 }
+
+/// Build the delete-safe control for the Map/Set `for-of` fast path (#6075).
+///
+/// The fast path iterates the backing entries array by index (`arr_id` holds the
+/// collection, `idx_id` the cursor). But `delete` compacts that array (entries
+/// after the hole shift down), so deleting an entry at index ≤ the cursor moves
+/// an unvisited entry below the cursor and skips it. This re-derives the read
+/// index each iteration from the last-returned key, so a shift can't skip.
+///
+/// Returns `(init_lets, condition, body_prefix)`:
+/// - `init_lets` — declare the state temps; push BEFORE the `for`.
+/// - `condition` — replaces `idx < size`. Overwrites `idx_id` with the corrected
+///   read index (fast cursor path when no delete shrank the collection; else
+///   locate the last key — `+1` after it, or into its vacated slot if it was
+///   itself deleted) and yields whether that index is in range.
+/// - `body_prefix` — prepend to the loop body (runs after the in-range check):
+///   records the visited key + the size just observed for the next iteration.
+///
+/// `find` is O(1) for numeric/string keys and only called when the collection
+/// shrank, so normal / append-only iteration keeps the plain cursor path.
+pub(crate) fn map_set_delete_safe_for_of(
+    ctx: &mut LoweringContext,
+    arr_id: LocalId,
+    idx_id: LocalId,
+    is_set: bool,
+) -> (Vec<Stmt>, Expr, Vec<Stmt>) {
+    let ls_id = ctx.fresh_local(); // size observed at the previous iteration (-1 = not started)
+    let lk_id = ctx.fresh_local(); // last-returned key
+    let sz_id = ctx.fresh_local(); // current size (spilled once per iteration)
+    let fk_id = ctx.fresh_local(); // find() result
+
+    // `.size` on a Map/Set-typed receiver is codegen-recognized and lowered to
+    // js_map_size / js_set_size (the raw `MapSize`/`SetSize` nodes are not
+    // codegen expressions), matching the original loop bound.
+    let size_of = |a: Expr| -> Expr {
+        Expr::PropertyGet {
+            object: Box::new(a),
+            property: "size".to_string(),
+        }
+    };
+    let key_at = |a: Expr, i: Expr| -> Expr {
+        if is_set {
+            Expr::SetValueAt {
+                set: Box::new(a),
+                idx: Box::new(i),
+            }
+        } else {
+            Expr::MapEntryKeyAt {
+                map: Box::new(a),
+                idx: Box::new(i),
+            }
+        }
+    };
+    let find_fn = if is_set {
+        "js_set_find_value_index"
+    } else {
+        "js_map_find_key_index"
+    };
+    let find_call = |args: Vec<Expr>| -> Expr {
+        Expr::Call {
+            callee: Box::new(Expr::ExternFuncRef {
+                name: find_fn.to_string(),
+                param_types: Vec::new(),
+                return_type: Type::Number,
+            }),
+            args,
+            type_args: Vec::new(),
+            byte_offset: 0,
+        }
+    };
+    let cmp = |op: CompareOp, l: Expr, r: Expr| -> Expr {
+        Expr::Compare {
+            op,
+            left: Box::new(l),
+            right: Box::new(r),
+        }
+    };
+
+    // read_idx = (not started || size >= last_seen) ? cursor
+    //            : (j = find(coll, last_key)) >= 0 ? j + 1 : cursor - 1
+    let rederive = Expr::Conditional {
+        condition: Box::new(cmp(CompareOp::Lt, Expr::LocalGet(ls_id), Expr::Number(0.0))),
+        then_expr: Box::new(Expr::LocalGet(idx_id)),
+        else_expr: Box::new(Expr::Conditional {
+            condition: Box::new(cmp(
+                CompareOp::Ge,
+                Expr::LocalGet(sz_id),
+                Expr::LocalGet(ls_id),
+            )),
+            then_expr: Box::new(Expr::LocalGet(idx_id)),
+            else_expr: Box::new(Expr::Sequence(vec![
+                Expr::LocalSet(
+                    fk_id,
+                    Box::new(find_call(vec![
+                        Expr::LocalGet(arr_id),
+                        Expr::LocalGet(lk_id),
+                    ])),
+                ),
+                Expr::Conditional {
+                    condition: Box::new(cmp(
+                        CompareOp::Ge,
+                        Expr::LocalGet(fk_id),
+                        Expr::Number(0.0),
+                    )),
+                    then_expr: Box::new(Expr::Binary {
+                        op: BinaryOp::Add,
+                        left: Box::new(Expr::LocalGet(fk_id)),
+                        right: Box::new(Expr::Number(1.0)),
+                    }),
+                    else_expr: Box::new(Expr::Binary {
+                        op: BinaryOp::Sub,
+                        left: Box::new(Expr::LocalGet(idx_id)),
+                        right: Box::new(Expr::Number(1.0)),
+                    }),
+                },
+            ])),
+        }),
+    };
+
+    let condition = Expr::Sequence(vec![
+        Expr::LocalSet(sz_id, Box::new(size_of(Expr::LocalGet(arr_id)))),
+        Expr::LocalSet(idx_id, Box::new(rederive)),
+        cmp(CompareOp::Lt, Expr::LocalGet(idx_id), Expr::LocalGet(sz_id)),
+    ]);
+
+    let body_prefix = vec![
+        Stmt::Expr(Expr::LocalSet(
+            lk_id,
+            Box::new(key_at(Expr::LocalGet(arr_id), Expr::LocalGet(idx_id))),
+        )),
+        Stmt::Expr(Expr::LocalSet(ls_id, Box::new(Expr::LocalGet(sz_id)))),
+    ];
+
+    let mk_let = |id: LocalId, tag: &str, ty: Type, init: Expr| Stmt::Let {
+        id,
+        name: format!("__miter_{}_{}", tag, id),
+        ty,
+        mutable: true,
+        init: Some(init),
+    };
+    let init_lets = vec![
+        mk_let(ls_id, "ls", Type::Number, Expr::Number(-1.0)),
+        mk_let(lk_id, "lk", Type::Any, Expr::Undefined),
+        mk_let(sz_id, "sz", Type::Number, Expr::Number(0.0)),
+        mk_let(fk_id, "fk", Type::Number, Expr::Number(0.0)),
+    ];
+
+    (init_lets, condition, body_prefix)
+}

--- a/crates/perry-hir/src/lower/mod.rs
+++ b/crates/perry-hir/src/lower/mod.rs
@@ -49,7 +49,9 @@ mod stmt;
 mod unimpl_hints;
 pub(crate) use stmt::*;
 mod for_head;
-pub(crate) use for_head::{for_head_binding_stmts, guard_for_in_body, predefine_for_head};
+pub(crate) use for_head::{
+    for_head_binding_stmts, guard_for_in_body, map_set_delete_safe_for_of, predefine_for_head,
+};
 mod stmt_loops;
 pub(crate) use stmt_loops::{
     insert_iterator_close_on_abrupt, lazy_iter_for_stmt, lazy_or_index_elem, lower_stmt_for_in,

--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -1840,15 +1840,27 @@ pub(crate) fn lower_stmt_for_of(
     // Loop bound. Map/Set fast paths read `.size` (lowered by
     // codegen to `js_map_size` / `js_set_size`); regular path uses
     // `__arr.length` against the materialized iterable.
-    let bound_expr = if map_kv_fastpath || set_fastpath {
-        Expr::PropertyGet {
-            object: Box::new(Expr::LocalGet(arr_id)),
-            property: "size".to_string(),
+    // Map/Set fast path re-derives the cursor each iteration so a mid-loop
+    // `delete` (which compacts the entries array) can't skip an entry (#6075).
+    // Array/String/iterator paths keep the plain `idx < length` bound.
+    let condition = if map_kv_fastpath || set_fastpath {
+        let (init_lets, cond, prefix) =
+            map_set_delete_safe_for_of(ctx, arr_id, idx_id, set_fastpath);
+        for s in init_lets {
+            module.init.push(s);
         }
+        let mut body = prefix;
+        body.append(&mut loop_body);
+        loop_body = body;
+        cond
     } else {
-        Expr::PropertyGet {
-            object: Box::new(Expr::LocalGet(arr_id)),
-            property: "length".to_string(),
+        Expr::Compare {
+            op: CompareOp::Lt,
+            left: Box::new(Expr::LocalGet(idx_id)),
+            right: Box::new(Expr::PropertyGet {
+                object: Box::new(Expr::LocalGet(arr_id)),
+                property: "length".to_string(),
+            }),
         }
     };
     // Create the for loop:
@@ -1861,11 +1873,7 @@ pub(crate) fn lower_stmt_for_of(
             mutable: true,
             init: Some(Expr::Number(0.0)),
         })),
-        condition: Some(Expr::Compare {
-            op: CompareOp::Lt,
-            left: Box::new(Expr::LocalGet(idx_id)),
-            right: Box::new(bound_expr),
-        }),
+        condition: Some(condition),
         update: Some(Expr::Update {
             id: idx_id,
             op: UpdateOp::Increment,

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -1766,17 +1766,25 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                 loop_body.insert(i, stmt);
             }
 
-            // Loop bound: Map/Set fast paths use `.size` (codegen-recognized,
-            // lowered to js_map_size / js_set_size), regular path uses .length.
-            let bound_expr = if map_kv_fastpath || set_fastpath {
-                Expr::PropertyGet {
-                    object: Box::new(Expr::LocalGet(arr_id)),
-                    property: "size".to_string(),
-                }
+            // Map/Set fast path re-derives the cursor each iteration so a mid-loop
+            // `delete` (which compacts the entries array) can't skip an entry
+            // (#6075). Array/String/iterator paths keep `idx < length`.
+            let condition = if map_kv_fastpath || set_fastpath {
+                let (init_lets, cond, prefix) =
+                    crate::lower::map_set_delete_safe_for_of(ctx, arr_id, idx_id, set_fastpath);
+                result.extend(init_lets);
+                let mut body = prefix;
+                body.append(&mut loop_body);
+                loop_body = body;
+                cond
             } else {
-                Expr::PropertyGet {
-                    object: Box::new(Expr::LocalGet(arr_id)),
-                    property: "length".to_string(),
+                Expr::Compare {
+                    op: CompareOp::Lt,
+                    left: Box::new(Expr::LocalGet(idx_id)),
+                    right: Box::new(Expr::PropertyGet {
+                        object: Box::new(Expr::LocalGet(arr_id)),
+                        property: "length".to_string(),
+                    }),
                 }
             };
             // Create the for loop
@@ -1788,11 +1796,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                     mutable: true,
                     init: Some(Expr::Number(0.0)),
                 })),
-                condition: Some(Expr::Compare {
-                    op: CompareOp::Lt,
-                    left: Box::new(Expr::LocalGet(idx_id)),
-                    right: Box::new(bound_expr),
-                }),
+                condition: Some(condition),
                 update: Some(Expr::Update {
                     id: idx_id,
                     op: UpdateOp::Increment,

--- a/crates/perry-runtime/src/collection_iter_object.rs
+++ b/crates/perry-runtime/src/collection_iter_object.rs
@@ -58,13 +58,21 @@ fn iterator_class_id(addr: usize) -> Option<u32> {
 }
 
 unsafe fn alloc_iterator(class_id: u32, coll_nanboxed: f64, kind: i32) -> f64 {
-    let obj = js_object_alloc(class_id, 3);
+    let obj = js_object_alloc(class_id, 5);
     // Field 0: backing collection (NaN-boxed pointer so the GC scanner keeps it).
     js_object_set_field(obj, 0, JSValue::from_bits(coll_nanboxed.to_bits()));
-    // Field 1: cursor index, starts at 0.
+    // Field 1: cursor index (index just past the last-returned entry), starts at 0.
     js_object_set_field(obj, 1, JSValue::number(0.0));
     // Field 2: iterator kind.
     js_object_set_field(obj, 2, JSValue::number(kind as f64));
+    // Field 3: collection size observed at the last `next()`. `-1` sentinel means
+    // "not started" (no entry returned yet). Used to detect a mid-iteration
+    // delete (which compacts the entries array, shifting live entries below the
+    // cursor) so the cursor can be re-derived from the last key (#6075).
+    js_object_set_field(obj, 3, JSValue::number(-1.0));
+    // Field 4: the KEY of the last-returned entry (a Map key / Set value), used
+    // to re-derive the cursor after a delete-shift. Undefined until started.
+    js_object_set_field(obj, 4, JSValue::undefined());
     // Link `[[Prototype]]` to the shared `%MapIteratorPrototype%` /
     // `%SetIteratorPrototype%` singleton so `Object.getPrototypeOf(it)` and the
     // inherited `.next` read resolve.
@@ -171,33 +179,68 @@ unsafe fn make_pair_array(a: f64, b: f64) -> f64 {
     js_nanbox_pointer(pair as i64)
 }
 
+/// Compute the entries-array index to read next, self-correcting for a
+/// mid-iteration delete. `cursor` = index just past the last-returned entry;
+/// `last_seen` = collection size at the previous `next()` (`< 0` ⇒ not started);
+/// `size` = current size; `find_last` locates the last-returned key's current
+/// index (or `< 0` if it was deleted).
+///
+/// Deleting an entry compacts the backing array (entries after the hole shift
+/// down one slot, #2831), so a delete at index ≤ cursor would move an unvisited
+/// entry below the cursor and skip it. Normal / append-only iteration keeps the
+/// fast cursor path (no lookup); only a size DROP re-derives from the last key —
+/// so object-keyed maps (whose key lookup is a linear scan) pay nothing unless a
+/// delete actually happened. If the last key itself was deleted, the entry that
+/// followed it now sits in the vacated slot (`cursor - 1`). (#6075)
+fn next_read_index(cursor: u32, last_seen: f64, size: u32, find_last: impl FnOnce() -> i32) -> u32 {
+    if last_seen < 0.0 || (size as f64) >= last_seen {
+        return cursor;
+    }
+    let j = find_last();
+    if j >= 0 {
+        (j as u32) + 1
+    } else {
+        cursor.saturating_sub(1)
+    }
+}
+
 /// Dispatch `.next()` / `[Symbol.iterator]()` on a Map iterator object.
 pub unsafe fn dispatch_map_iterator_method(iter_obj: *mut ObjectHeader, method_name: &str) -> f64 {
     match method_name {
         "next" => {
             let backing = f64::from_bits(js_object_get_field(iter_obj, 0).bits());
             let map = js_nanbox_get_pointer(backing) as *const MapHeader;
-            let idx = f64::from_bits(js_object_get_field(iter_obj, 1).bits()) as u32;
             let kind = f64::from_bits(js_object_get_field(iter_obj, 2).bits()) as i32;
-
-            let size = crate::map::js_map_size(map);
-            if map.is_null() || idx >= size {
+            if map.is_null() {
                 return make_iter_result(JSValue::undefined(), true);
             }
-            // Advance the cursor before computing the value.
+            let cursor = f64::from_bits(js_object_get_field(iter_obj, 1).bits()) as u32;
+            let last_seen = f64::from_bits(js_object_get_field(iter_obj, 3).bits());
+            let last_key = js_object_get_field(iter_obj, 4);
+            let size = crate::map::js_map_size(map);
+            let idx = next_read_index(cursor, last_seen, size, || {
+                crate::map::find_key_index(map, f64::from_bits(last_key.bits()))
+            });
+            if idx >= size {
+                js_object_set_field(iter_obj, 1, JSValue::number(size as f64));
+                js_object_set_field(iter_obj, 3, JSValue::number(size as f64));
+                return make_iter_result(JSValue::undefined(), true);
+            }
+
+            let entry_key = crate::map::js_map_entry_key_at(map, idx);
+            // Record state for the next re-derive BEFORE any allocation below.
             js_object_set_field(iter_obj, 1, JSValue::number((idx + 1) as f64));
+            js_object_set_field(iter_obj, 3, JSValue::number(size as f64));
+            js_object_set_field(iter_obj, 4, JSValue::from_bits(entry_key.to_bits()));
 
             let value = match kind {
-                KIND_KEYS => {
-                    JSValue::from_bits(crate::map::js_map_entry_key_at(map, idx).to_bits())
-                }
+                KIND_KEYS => JSValue::from_bits(entry_key.to_bits()),
                 KIND_VALUES => {
                     JSValue::from_bits(crate::map::js_map_entry_value_at(map, idx).to_bits())
                 }
                 _ => {
-                    let key = crate::map::js_map_entry_key_at(map, idx);
                     let val = crate::map::js_map_entry_value_at(map, idx);
-                    JSValue::from_bits(make_pair_array(key, val).to_bits())
+                    JSValue::from_bits(make_pair_array(entry_key, val).to_bits())
                 }
             };
             make_iter_result(value, false)
@@ -214,16 +257,28 @@ pub unsafe fn dispatch_set_iterator_method(iter_obj: *mut ObjectHeader, method_n
         "next" => {
             let backing = f64::from_bits(js_object_get_field(iter_obj, 0).bits());
             let set = js_nanbox_get_pointer(backing) as *const SetHeader;
-            let idx = f64::from_bits(js_object_get_field(iter_obj, 1).bits()) as u32;
             let kind = f64::from_bits(js_object_get_field(iter_obj, 2).bits()) as i32;
-
-            let size = crate::set::js_set_size(set);
-            if set.is_null() || idx >= size {
+            if set.is_null() {
                 return make_iter_result(JSValue::undefined(), true);
             }
-            js_object_set_field(iter_obj, 1, JSValue::number((idx + 1) as f64));
+            let cursor = f64::from_bits(js_object_get_field(iter_obj, 1).bits()) as u32;
+            let last_seen = f64::from_bits(js_object_get_field(iter_obj, 3).bits());
+            let last_val = js_object_get_field(iter_obj, 4);
+            let size = crate::set::js_set_size(set);
+            let idx = next_read_index(cursor, last_seen, size, || {
+                crate::set::find_value_index(set, f64::from_bits(last_val.bits()))
+            });
+            if idx >= size {
+                js_object_set_field(iter_obj, 1, JSValue::number(size as f64));
+                js_object_set_field(iter_obj, 3, JSValue::number(size as f64));
+                return make_iter_result(JSValue::undefined(), true);
+            }
 
             let elem = crate::set::js_set_value_at(set, idx);
+            js_object_set_field(iter_obj, 1, JSValue::number((idx + 1) as f64));
+            js_object_set_field(iter_obj, 3, JSValue::number(size as f64));
+            js_object_set_field(iter_obj, 4, JSValue::from_bits(elem.to_bits()));
+
             let value = match kind {
                 // For Sets, keys === values; entries yields [v, v] pairs.
                 KIND_ENTRIES => JSValue::from_bits(make_pair_array(elem, elem).to_bits()),

--- a/crates/perry-runtime/src/map.rs
+++ b/crates/perry-runtime/src/map.rs
@@ -747,7 +747,22 @@ pub extern "C" fn js_map_size(map: *const MapHeader) -> u32 {
 /// the perf-comprehensive sync-heavy benchmarks.
 const SIDE_TABLE_THRESHOLD: u32 = 8;
 
-unsafe fn find_key_index(map: *const MapHeader, key: f64) -> i32 {
+/// C-ABI: current entries-array index of `key` (SameValueZero), or `-1.0` if
+/// absent. Used by the delete-safe `for-of` fast path (#6075) to re-derive the
+/// cursor after a mid-iteration delete compacts the entries array. Only invoked
+/// from generated IR, so `#[used]` keeps it linked on the default compile path.
+#[no_mangle]
+pub extern "C" fn js_map_find_key_index(map_boxed: f64, key: f64) -> f64 {
+    let map = clean_map_ptr(crate::value::js_nanbox_get_pointer(map_boxed) as *const MapHeader);
+    if map.is_null() {
+        return -1.0;
+    }
+    unsafe { find_key_index(map, normalize_zero(key)) as f64 }
+}
+#[used]
+static KEEP_MAP_FIND_KEY_INDEX: extern "C" fn(f64, f64) -> f64 = js_map_find_key_index;
+
+pub(crate) unsafe fn find_key_index(map: *const MapHeader, key: f64) -> i32 {
     let size = (*map).size;
     let key_bits = key.to_bits();
 

--- a/crates/perry-runtime/src/set.rs
+++ b/crates/perry-runtime/src/set.rs
@@ -580,7 +580,21 @@ fn jsvalue_eq(a: f64, b: f64) -> bool {
 
 /// Find the index of a value in the set, or -1 if not found.
 /// Uses the O(1) hash index side-table.
-unsafe fn find_value_index(set: *const SetHeader, value: f64) -> i32 {
+/// C-ABI: current elements-array index of `value` (SameValueZero), or `-1.0` if
+/// absent. Companion to `js_map_find_key_index` for the delete-safe Set `for-of`
+/// fast path (#6075). Only invoked from generated IR, so `#[used]` keeps it.
+#[no_mangle]
+pub extern "C" fn js_set_find_value_index(set_boxed: f64, value: f64) -> f64 {
+    let set = clean_set_ptr(crate::value::js_nanbox_get_pointer(set_boxed) as *const SetHeader);
+    if set.is_null() {
+        return -1.0;
+    }
+    unsafe { find_value_index(set, normalize_zero(value)) as f64 }
+}
+#[used]
+static KEEP_SET_FIND_VALUE_INDEX: extern "C" fn(f64, f64) -> f64 = js_set_find_value_index;
+
+pub(crate) unsafe fn find_value_index(set: *const SetHeader, value: f64) -> i32 {
     SET_INDEX.with(|idx| {
         let idx = idx.borrow();
         if let Some(map) = idx.get(&(set as usize)) {


### PR DESCRIPTION
Fixes #6075.

## Summary

Deleting the entry currently being visited during Map/Set iteration skipped the
next entry:

```ts
const m = new Map([["a",1],["b",2],["c",3]]);
for (const [k] of m) { console.log(k); m.delete(k); }
// was: a c   →  now: a b c   (matches Node)
```

`delete` compacts the backing entries array (entries after the hole shift down
one slot, #2831). So a delete at index ≤ the iterator cursor moves an unvisited
entry *below* the cursor and skips it. Deleting a **later** key already worked
(the shift stays above the cursor) — only delete-current / delete-earlier broke.

## Fix

Re-derive the read index from the **last returned key** each iteration, gated on
a size decrease so normal / append-only iteration keeps the plain cursor path
(object-keyed maps, whose key lookup is a linear scan, pay nothing unless a
delete actually happened). If the last key is still present, continue after it
(`find+1`); if it was itself deleted, the entry that followed it now sits in the
vacated slot (`cursor-1`).

Both iteration paths are covered:

- **Inlined `for-of` fast path** (`for (const [k,v] of map)`): shared lowering
  `for_head::map_set_delete_safe_for_of`, wired into the module-level
  (`stmt_loops.rs`) and function-body (`body_stmt.rs`) for-of desugars, rewrites
  the loop condition to overwrite the cursor. Uses new `js_map_find_key_index` /
  `js_set_find_value_index` runtime helpers (via an `extern` call — no new IR
  node).
- **Explicit iterator objects** (`map.entries()/.keys()/.values()`,
  `set.values()` + `.next()`): `dispatch_map_iterator_method` /
  `dispatch_set_iterator_method` do the same re-derive, tracking last-seen size +
  last key in two added iterator-object fields.

## Validation

Byte-for-byte vs `node --experimental-strip-types`:

- delete-current / delete-later / add-during — Map **and** Set
- `[k]` / `[,v]` / `[k,v]` destructure shapes
- object-keyed maps (linear-scan `find` path)
- break / continue / empty / function-body path
- for-of regression sweep (arrays, strings, typed+untyped Map/Set, `.entries()`,
  `.keys()`/`.values()`, nested, `forEach`, spread, generators) — unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved `Map` and `Set` iteration to handle deletions safely during `for-of` loops.
  * Added internal runtime support for locating the current item index during iteration, enabling more reliable cursor tracking.
  * Expanded iterator state to remember the last seen collection size and last returned item for better continuation after changes.
* **Bug Fixes**
  * Fixed iteration behavior so shrinking collections no longer cause skipped or repeated items during fast-path traversal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->