### PR TITLE
fix(runtime): `<key> in <ClassRef>` resolves static members (#6149)

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -51,7 +51,7 @@ mod state;
 pub(crate) use state::{
     class_decl_prototype_object, class_decl_prototype_object_root_store,
     class_decl_prototype_value, class_decl_prototype_value_for_instance_class,
-    class_delete_own_dynamic_prop, class_dynamic_prop_root_store,
+    class_delete_own_dynamic_prop, class_dynamic_prop_root_store, class_has_own_dynamic_prop,
     class_id_for_decl_prototype_object, class_is_key_deleted, class_mark_key_deleted,
     class_own_enumerable_field_names, class_own_static_field_value, class_parent_closure,
     class_parent_closure_root_store, class_prototype_method_is_enumerable,

--- a/crates/perry-runtime/src/object/class_registry/state.rs
+++ b/crates/perry-runtime/src/object/class_registry/state.rs
@@ -108,6 +108,19 @@ pub(crate) fn class_own_enumerable_field_names(class_id: u32) -> Vec<String> {
     })
 }
 
+/// True when `name` is an own static data property (a static field, or a
+/// runtime `C.x = …` assignment) recorded in `CLASS_DYNAMIC_PROPS`. Presence
+/// only — does not read the value, so it never invokes a static getter. Used by
+/// the `in` operator on a class ref (#6149).
+pub(crate) fn class_has_own_dynamic_prop(class_id: u32, name: &str) -> bool {
+    CLASS_DYNAMIC_PROPS.with(|m| {
+        m.borrow()
+            .get(&class_id)
+            .map(|props| props.contains_key(name))
+            .unwrap_or(false)
+    })
+}
+
 pub(crate) fn class_delete_own_dynamic_prop(class_id: u32, name: &str) {
     CLASS_DYNAMIC_PROPS.with(|m| {
         if let Some(props) = m.borrow_mut().get_mut(&class_id) {

--- a/crates/perry-runtime/src/object/field_get_set/has_property.rs
+++ b/crates/perry-runtime/src/object/field_get_set/has_property.rs
@@ -182,10 +182,34 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
             if crate::symbol::class_static_symbol_lookup(class_id, key).is_some() {
                 return nanbox_true;
             }
-            // String key path: check CLASS_DYNAMIC_PROPS via the get-by-name fn.
-            if !key_val.is_pointer() && key_val.is_string() {
-                // is_string covers heap StringHeader. Route through the
-                // CLASS_DYNAMIC_PROPS-aware get fn.
+            // #6149: string key on a class ref (`"prototype" in C`,
+            // `"staticField" in C`, `"staticMethod" in C`). Check the
+            // constructor's own static members WITHOUT reading them, so a static
+            // getter is never invoked (`in` is [[HasProperty]], not [[Get]]).
+            // Inherited `Function.prototype` methods (`"call" in C`) and
+            // inherited static *data* fields are not covered — the latter mirror
+            // the get-by-name gap for the same shape.
+            if key_val.is_any_string() {
+                let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+                if let Some(name) = unsafe { crate::string::js_string_key_bytes(key_val, &mut sso) }
+                    .and_then(|b| std::str::from_utf8(b).ok())
+                {
+                    let present = matches!(name, "prototype" | "name" | "length")
+                        || (!super::super::class_registry::class_is_key_deleted(class_id, name)
+                            && (super::super::class_registry::class_has_own_dynamic_prop(
+                                class_id, name,
+                            ) || super::super::class_registry::lookup_static_method_in_chain(
+                                class_id, name,
+                            )
+                            .is_some()
+                                || super::super::class_registry::class_own_static_accessor_ptrs(
+                                    class_id, name,
+                                )
+                                .is_some()));
+                    if present {
+                        return nanbox_true;
+                    }
+                }
             }
             // Fallback: emit false for class refs that aren't in either table.
             return nanbox_false;


### PR DESCRIPTION
Fixes #6149.

## Summary

`<key> in <ClassRef>` for a string key returned `false` for everything —
`"prototype" in C`, `"name" in C`, `"length" in C`, own static fields, static
methods. The class-ref arm of `js_object_has_property` had a no-op string-key
branch that fell straight through to `false`.

```ts
class Base { static bs = 10; static bm() {} }
class C extends Base { static s = 1; static sm() {} m() {} static get g() { return 5; } }
"prototype" in C  // was false → true
"s" in C          // was false → true   (own static field)
"sm" in C         // was false → true   (own static method)
"bm" in C         // was false → true   (inherited static method)
"g" in C          // was false → true   (static accessor)
"name" in C       // was false → true
"m" in C          // false (instance member, correctly excluded)
```

## Approach

Resolve the constructor's **own static members** with a **presence-only** check
— it never reads the value, so a `static get` accessor is not invoked (`in` is
[[HasProperty]], not [[Get]]):

- built-in non-enumerable slots: `prototype` / `name` / `length`
- own static data fields + runtime `C.x = …` (`CLASS_DYNAMIC_PROPS`, respecting
  deletes) — via the new `class_has_own_dynamic_prop`
- static methods, own + inherited through `extends`
  (`lookup_static_method_in_chain`)
- static accessors (`class_own_static_accessor_ptrs`)

Instance members remain excluded. Symbol keys are unchanged (handled earlier by
the symbol path).

## Not covered (separate, pre-existing)

Inherited `Function.prototype` methods (`"call" in C`), inherited static **data**
fields (mirrors the same-shape get-by-name gap), and symbol keys on a class ref
(`Symbol.hasInstance in C` — the untouched symbol path). Noted for follow-up.

## Validation

Byte-for-byte vs `node --experimental-strip-types`: own/inherited static method,
own static field, static getter, `prototype`/`name`/`length`, runtime `C.x=…`,
instance-member exclusion, absent key; plus an `in` regression sweep (plain
object, array, class instance, `Object.create`, primitive-throw) unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `in` checks for class references with string keys so they now return the expected presence result for properties like `prototype`, `name`, and `length`, as well as other class members.
  * Fixed cases where property checks could behave inconsistently by avoiding value lookup during presence detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->