### PR TITLE
fix(lower): object-rest assignment-expression form binds + excludes computed keys (#6153)

### DIFF
--- a/crates/perry-hir/src/destructuring/assignment_expr.rs
+++ b/crates/perry-hir/src/destructuring/assignment_expr.rs
@@ -148,22 +148,42 @@ pub(crate) fn lower_destructuring_assignment(
             //   expr (result)
 
             let mut exprs = Vec::new();
+            // Computed keys destructured here (`{ [k]: t }`), lowered once for the
+            // rest exclusion below. This is the value-used assignment-expression
+            // form (`y = ({ [k]: t, ...rest } = o)`); it builds a pure-expression
+            // Sequence with no statement slots, so a computed key can't be spilled
+            // to a shared temp and is re-lowered for the exclusion — a
+            // side-effecting computed key evaluates twice in this rare form.
+            let mut computed_excl_keys: Vec<Expr> = Vec::new();
 
             // Now assign each property
             for prop in &obj_pat.props {
                 match prop {
                     ast::ObjectPatProp::KeyValue(kv) => {
                         // { key: target } - extract obj.key into target
-                        let key = match &kv.key {
-                            ast::PropName::Ident(ident) => ident.sym.to_string(),
-                            ast::PropName::Str(s) => s.value.as_str().unwrap_or("").to_string(),
-                            ast::PropName::Num(n) => n.value.to_string(),
-                            _ => continue, // Skip computed keys
-                        };
-
-                        let prop_expr = Expr::PropertyGet {
-                            object: value.clone(),
-                            property: key,
+                        let prop_expr = match &kv.key {
+                            ast::PropName::Ident(ident) => Expr::PropertyGet {
+                                object: value.clone(),
+                                property: ident.sym.to_string(),
+                            },
+                            ast::PropName::Str(s) => Expr::PropertyGet {
+                                object: value.clone(),
+                                property: s.value.as_str().unwrap_or("").to_string(),
+                            },
+                            ast::PropName::Num(n) => Expr::PropertyGet {
+                                object: value.clone(),
+                                property: n.value.to_string(),
+                            },
+                            ast::PropName::Computed(computed) => {
+                                // `{ [k]: target }` → target = obj[k]; also record
+                                // the key so `...rest` can exclude it below.
+                                computed_excl_keys.push(lower_expr(ctx, &computed.expr)?);
+                                Expr::IndexGet {
+                                    object: value.clone(),
+                                    index: Box::new(lower_expr(ctx, &computed.expr)?),
+                                }
+                            }
+                            _ => continue, // BigInt property names, etc.
                         };
 
                         match &*kv.value {
@@ -238,6 +258,16 @@ pub(crate) fn lower_destructuring_assignment(
                                 let name = ident.id.sym.to_string();
                                 if let Some(id) = ctx.lookup_local(&name) {
                                     exprs.push(Expr::LocalSet(id, Box::new(rest_expr)));
+                                    // ObjectRest only excludes statically-named
+                                    // keys; delete the computed ones from the fresh
+                                    // rest object (a private copy, so the source is
+                                    // untouched).
+                                    for key in computed_excl_keys.drain(..) {
+                                        exprs.push(Expr::Delete(Box::new(Expr::IndexGet {
+                                            object: Box::new(Expr::LocalGet(id)),
+                                            index: Box::new(key),
+                                        })));
+                                    }
                                 } else {
                                     return Err(anyhow!(
                                         "Assignment to undeclared variable in destructuring rest: {}",


### PR DESCRIPTION
Closes #6153 — the final object-rest computed-key form.

## Summary

The value-used assignment form `y = ({ [k]: t, ...rest } = obj)` routes through
`destructuring/assignment_expr.rs`, which skipped computed `KeyValue` props
entirely (`_ => continue`) — so the computed target was never bound **and** the
key leaked into `...rest`:

```ts
let t, rest;
const y = ({ [key]: t, ...rest } = { a: 1, b: 2, c: 3 });
// before: t undefined, rest {a,b,c}
// now:    t = 2,       rest {a, c}
```

## Approach

A computed key now lowers to `target = obj[k]` (identifier or nested
array/object target), and the rest handler `delete`s each computed key from the
freshly-cloned rest object — the same delete-after approach as the declaration
(#6155) and statement-assignment (#6157) forms.

This is a pure-expression `Sequence` with no statement slots, so a computed key
can't be spilled to a shared temp and is re-lowered for the exclusion. A
**side-effecting** computed key therefore evaluates twice in this rare
value-used form; the far more common statement form (`({…} = obj);`) keeps
eval-once via #6157. Documented inline.

## #6153 now complete

| Form | PR |
|---|---|
| `const { [k]: x, ...rest } = o` (declaration) | #6155 ✅ merged |
| `({ [k]: x, ...rest } = o);` (statement) | #6157 ✅ merged |
| `y = ({ [k]: x, ...rest } = o)` (value-used) | this PR |

## Validation

Byte-for-byte vs `node --experimental-strip-types`: value-used binding + rest
exclusion, named+computed, multiple computed keys, computed-key binding without
rest (previously dropped entirely), static-only; declaration / statement /
general-destructuring regressions unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved object destructuring assignments to support computed property keys.
  * Fixed rest destructuring so computed keys are correctly excluded from the remaining object, matching expected behavior for both named and computed properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->