### PR TITLE
fix(runtime): TextDecoder/TextEncoder handle methods on type-erased receivers

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -443,6 +443,13 @@ pub extern "C" fn js_object_get_field_by_name(
                         let result = super::super::js_class_method_bind(this_f64, key_ptr, key_len);
                         return JSValue::from_bits(result.to_bits());
                     }
+                    // TextDecoder/TextEncoder registry handles — see
+                    // `text_handle_property` (text.rs).
+                    if let Some(v) =
+                        crate::text::text_handle_property(raw, key_bytes, key_ptr, key_len)
+                    {
+                        return v;
+                    }
                     if key_bytes == b"constructor" {
                         let null_obj_ptr = &NULL_OBJECT_BYTES as *const NullObjectBytes as *mut u8;
                         return JSValue::from_bits(JSValue::pointer(null_obj_ptr).bits());

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
@@ -48,6 +48,14 @@ pub(crate) fn get_field_by_name_object_tail(
                                 super::super::js_class_method_bind(this_f64, key_ptr, key_len);
                             return JSValue::from_bits(result.to_bits());
                         }
+                        if let Some(v) = crate::text::text_handle_property(
+                            raw as usize,
+                            key_bytes,
+                            key_ptr,
+                            key_len,
+                        ) {
+                            return v;
+                        }
                     }
                     // Drizzle-sqlite blocker: synth `data.constructor` for
                     // small-handle native instances so drizzle's
@@ -112,6 +120,11 @@ pub(crate) fn get_field_by_name_object_tail(
                         f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
                     let result = super::super::js_class_method_bind(this_f64, key_ptr, key_len);
                     return JSValue::from_bits(result.to_bits());
+                }
+                if let Some(v) =
+                    crate::text::text_handle_property(obj as usize, key_bytes, key_ptr, key_len)
+                {
+                    return v;
                 }
             }
             if let Some(dispatch) = handle_property_dispatch() {

--- a/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
+++ b/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
@@ -280,6 +280,15 @@ pub extern "C" fn js_object_get_field_ic_miss(
                     f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
                 return super::super::js_class_method_bind(this_f64, key_ptr, key_len);
             }
+            // TextDecoder/TextEncoder registry handles — IC-miss mirror of
+            // the arms in `js_object_get_field_by_name` /
+            // `get_field_by_name_object_tail`; static-name reads (`td.decode`,
+            // `td.encoding`) funnel here. See `text_handle_property`.
+            if let Some(v) =
+                crate::text::text_handle_property(obj as usize, key_bytes, key_ptr, key_len)
+            {
+                return f64::from_bits(v.bits());
+            }
         }
         // Drizzle-sqlite blocker: synth `data.constructor` for small-handle
         // receivers — IC-miss path mirror of the constructor intercept in

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -717,6 +717,46 @@ pub unsafe extern "C" fn js_native_call_method(
             args_len > 0 && !args_ptr.is_null() && { crate::value::js_is_truthy(*args_ptr) != 0 };
         return js_using_check_disposable(object, want_async);
     }
+    // TextDecoder / TextEncoder registry handles on a type-erased receiver —
+    // same wall class as the URLSearchParams / AbortSignal blocks below: the
+    // statically-typed `td.decode(buf)` lowers straight to
+    // `js_text_decoder_decode_llvm`, but a fused dynamic call (through an
+    // untyped local, or via the bound method the VALUE read in
+    // `get_field_by_name_tail.rs` reifies for `K.decode.bind(K)` — the shape
+    // a minified SDK's cached decodeText helper takes) lands here, and the
+    // generic field-scan would miss and throw "is not a function".
+    if matches!(method_name, "decode" | "encode" | "encodeInto") && jsval.is_pointer() {
+        let raw = (object.to_bits() & 0x0000_FFFF_FFFF_FFFF) as usize;
+        if crate::value::addr_class::is_small_handle(raw) {
+            let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+            let arg0 = if args_len > 0 && !args_ptr.is_null() {
+                *args_ptr
+            } else {
+                undef
+            };
+            if method_name == "decode" && crate::text::is_known_text_decoder_id(raw as i64) {
+                let sp = crate::text::js_text_decoder_decode_llvm(object, arg0);
+                return f64::from_bits(
+                    JSValue::string_ptr(sp as *mut crate::string::StringHeader).bits(),
+                );
+            }
+            if raw as i64 == crate::text::TEXT_ENCODER_SENTINEL_ID {
+                if method_name == "encode" {
+                    let bp = crate::text::js_text_encoder_encode_llvm(arg0);
+                    return crate::value::js_nanbox_pointer(bp);
+                }
+                if method_name == "encodeInto" {
+                    let arg1 = if args_len > 1 && !args_ptr.is_null() {
+                        *args_ptr.add(1)
+                    } else {
+                        undef
+                    };
+                    let rp = crate::text::js_text_encoder_encode_into_llvm(arg0, arg1);
+                    return crate::value::js_nanbox_pointer(rp);
+                }
+            }
+        }
+    }
     // #5961: native URLSearchParams is an ordinary object (class_id == 0,
     // leading `_entries` slot) whose method surface normally resolves via
     // static type-directed lowering. A fused dynamic call on a type-erased

--- a/crates/perry-runtime/src/text.rs
+++ b/crates/perry-runtime/src/text.rs
@@ -93,7 +93,19 @@ pub(crate) fn text_encoder_string_ptr(value: f64) -> *const StringHeader {
 /// decoder sentinel purely for debuggability.
 #[no_mangle]
 pub extern "C" fn js_text_encoder_new() -> i64 {
-    1
+    TEXT_ENCODER_SENTINEL_ID
+}
+
+/// The stateless `TextEncoder` sentinel handle returned by
+/// `js_text_encoder_new` — see its doc comment.
+pub const TEXT_ENCODER_SENTINEL_ID: i64 = 1;
+
+/// Whether `id` is a live `TextDecoder` registry handle. Used by the
+/// dynamic method-call / property-GET handle arms
+/// (`native_call_method.rs` / `get_field_by_name_tail.rs`) to route
+/// `decode`/`encoding`/… on a type-erased receiver to the text natives.
+pub fn is_known_text_decoder_id(id: i64) -> bool {
+    DECODER_REGISTRY.lock().unwrap().contains_key(&id)
 }
 
 /// `new TextDecoder(label?, { fatal?, ignoreBOM? })` — validates the
@@ -570,3 +582,46 @@ static KEEP_TEXT_DECODER_ENCODING: extern "C" fn(f64) -> *mut StringHeader =
 static KEEP_TEXT_DECODER_FATAL: extern "C" fn(f64) -> f64 = js_text_decoder_fatal;
 #[used]
 static KEEP_TEXT_DECODER_IGNORE_BOM: extern "C" fn(f64) -> f64 = js_text_decoder_ignore_bom;
+
+/// TextDecoder / TextEncoder registry-handle property surface for VALUE
+/// reads (`K.decode.bind(K)` — the shape a minified SDK's cached decodeText
+/// helper takes; pre-fix the read returned undefined and `.bind` threw
+/// "Bind must be called on a function"). Methods reify as bound methods —
+/// the dynamic-call arm in `native_call_method.rs` executes them on call —
+/// and accessors return their values directly.
+pub(crate) unsafe fn text_handle_property(
+    raw: usize,
+    key_bytes: &[u8],
+    key_ptr: *const u8,
+    key_len: usize,
+) -> Option<crate::value::JSValue> {
+    let this_f64 = f64::from_bits(crate::value::js_nanbox_pointer(raw as i64).to_bits());
+    if is_known_text_decoder_id(raw as i64) {
+        match key_bytes {
+            b"decode" => {
+                let result = crate::object::js_class_method_bind(this_f64, key_ptr, key_len);
+                return Some(crate::value::JSValue::from_bits(result.to_bits()));
+            }
+            b"encoding" => {
+                let s = js_text_decoder_encoding(this_f64);
+                return Some(crate::value::JSValue::string_ptr(s));
+            }
+            b"fatal" => {
+                return Some(crate::value::JSValue::from_bits(
+                    js_text_decoder_fatal(this_f64).to_bits(),
+                ));
+            }
+            b"ignoreBOM" => {
+                return Some(crate::value::JSValue::from_bits(
+                    js_text_decoder_ignore_bom(this_f64).to_bits(),
+                ));
+            }
+            _ => {}
+        }
+    }
+    if raw as i64 == TEXT_ENCODER_SENTINEL_ID && matches!(key_bytes, b"encode" | b"encodeInto") {
+        let result = crate::object::js_class_method_bind(this_f64, key_ptr, key_len);
+        return Some(crate::value::JSValue::from_bits(result.to_bits()));
+    }
+    None
+}

--- a/crates/perry/tests/text_decoder_dynamic_surface.rs
+++ b/crates/perry/tests/text_decoder_dynamic_surface.rs
@@ -1,0 +1,130 @@
+//! Regression tests: TextDecoder / TextEncoder registry handles on
+//! type-erased receivers.
+//!
+//! `new TextDecoder()` reached through a dynamic constructor value (e.g.
+//! `new globalThis.TextDecoder` — the dynamic-construct path in
+//! `class_registry/construct.rs`) returns a small registry-handle id. The
+//! statically-typed `td.decode(buf)` call lowers straight to
+//! `js_text_decoder_decode_llvm`, but every *dynamic* surface was missing:
+//!
+//! - property VALUE reads (`td.decode`, `td.encoding`) returned `undefined`
+//!   through all three field-get funnels (`js_object_get_field_by_name`,
+//!   its object tail, and the IC-miss handler);
+//! - fused dynamic method calls (`td.decode(buf)` on an untyped local)
+//!   fell through `js_native_call_method`'s field-scan and misbehaved.
+//!
+//! Canonical failure: a minified SDK's cached decodeText helper,
+//!   `(PW7 ?? (K = new globalThis.TextDecoder, PW7 = K.decode.bind(K)))(q)`
+//! — the `K.decode` read yielded a non-callable, so `.bind` threw
+//! `TypeError: Bind must be called on a function`, killing every streamed
+//! (SSE) API response in a large esbuild-bundled CLI app.
+//!
+//! Fix: `text_handle_property` (get_field_by_name_tail.rs) reifies the
+//! method/accessor surface for VALUE reads at all three funnels, and a
+//! dispatch arm in `native_call_method.rs` routes `decode` / `encode` /
+//! `encodeInto` on text registry handles to the text natives.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+/// The SDK decodeText shape: `K.decode.bind(K)` must yield a callable that
+/// decodes (pre-fix: the read was `undefined` and `.bind` threw
+/// "Bind must be called on a function").
+#[test]
+fn text_decoder_decode_bind_and_reads() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const td: any = new (globalThis as any).TextDecoder();
+console.log(typeof td.decode);
+console.log(typeof td["decode"]);
+const key = "dec" + "ode";
+console.log(typeof td[key]);
+const bound = td.decode.bind(td);
+console.log(bound(new Uint8Array([104, 105])));
+console.log(td.decode(new Uint8Array([104, 105])));
+console.log(td.encoding, td.fatal, td.ignoreBOM);
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "function\nfunction\nfunction\nhi\nhi\nutf-8 false false\n"
+    );
+}
+
+/// TextEncoder's dynamic surface: `enc.encode` read as a value + bound +
+/// dynamic call, and `encodeInto`'s `{ read, written }` result.
+#[test]
+fn text_encoder_encode_bind_and_calls() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const enc: any = new (globalThis as any).TextEncoder();
+console.log(typeof enc.encode);
+const bound = enc.encode.bind(enc);
+const u8 = bound("hi");
+console.log(u8 instanceof Uint8Array, u8[0], u8[1]);
+const dest = new Uint8Array(8);
+const r = enc.encodeInto("hi", dest);
+console.log(r.read, r.written, dest[0], dest[1]);
+"#,
+    );
+    assert_eq!(stdout, "function\ntrue 104 105\n2 2 104 105\n");
+}
+
+/// Decoder state must be honored through the dynamic surface: a latin1
+/// decoder obtained dynamically decodes high bytes per its label.
+#[test]
+fn text_decoder_dynamic_label_state() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const td: any = new (globalThis as any).TextDecoder("latin1");
+console.log(td.encoding);
+const bound = td.decode.bind(td);
+console.log(bound(new Uint8Array([0xe9])));
+"#,
+    );
+    assert_eq!(stdout, "windows-1252\né\n");
+}


### PR DESCRIPTION
## Problem

`new TextDecoder()` reached through a **dynamic constructor value** (e.g. `new globalThis.TextDecoder`, via the dynamic-construct path in `class_registry/construct.rs`) returns a small registry-handle id. The statically-typed `td.decode(buf)` call lowers straight to `js_text_decoder_decode_llvm` and works — but every **dynamic** surface was missing:

- property **value reads** (`td.decode`, `td.encoding`, `td.fatal`, `td.ignoreBOM`) returned `undefined` through all three field-get funnels (`js_object_get_field_by_name`, its object tail, and the IC-miss handler);
- **fused dynamic method calls** (`td.decode(buf)` on an untyped local) fell through `js_native_call_method`'s generic field-scan.

Canonical real-world failure — a minified SDK's cached decodeText helper:

```js
(PW7 ?? (K = new globalThis.TextDecoder, PW7 = K.decode.bind(K)))(q)
```

The `K.decode` read yielded a non-callable, so `.bind` threw `TypeError: Bind must be called on a function`, killing every streamed (SSE) API response in a large esbuild-bundled CLI app.

## Fix

- **`text_handle_property`** (new, `get_field_by_name_tail.rs`): reifies the method/accessor surface for value reads — `decode`/`encode`/`encodeInto` come back as bound methods (same mechanism as the #1213 timer-handle methods), `encoding`/`fatal`/`ignoreBOM` return their values. Wired at all three field-get funnels (the head arm in `get_field_by_name.rs`, the object tail, and the IC-miss mirror — the existing comments there already note these blocks must be mirrored).
- **`native_call_method.rs`**: dispatch arm routing `decode` on a known decoder handle (and `encode`/`encodeInto` on the encoder sentinel) to the text natives — same wall class as the #5961 URLSearchParams / #5964 AbortSignal type-erased-receiver arms. This is also what executes the reified bound methods on call.
- **`text.rs`**: expose `is_known_text_decoder_id` (registry membership — decoder ids share the common small-handle band, so membership is the discriminator) and name the encoder sentinel (`TEXT_ENCODER_SENTINEL_ID`).

## Tests

New `crates/perry/tests/text_decoder_dynamic_surface.rs` (3 tests, node-oracle-verified):
- decode reads in static, literal-index, and computed-key form; `K.decode.bind(K)` round-trip; dynamic calls; accessor values
- TextEncoder `encode` bind + call and `encodeInto` `{read, written}`
- per-instance decoder state (latin1 label) honored through the dynamic surface

`perry-runtime --lib` passes (1164 tests, single-threaded).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved dynamic `TextDecoder`/`TextEncoder` behavior when accessed through indirect or type-erased paths, including more consistent method/property discovery.
* **Bug Fixes**
  * Fixed dynamic property access and method binding for `decode`, `encode`, `encodeInto`, `encoding`, `fatal`, and `ignoreBOM`, and ensured dynamic construction (e.g., `new TextDecoder("latin1")`) behaves correctly.
* **Tests**
  * Added end-to-end regression coverage for the `TextDecoder`/`TextEncoder` dynamic surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->