### PR TITLE
fix(runtime): `<index> in <Uint8Array>` / Buffer resolves numeric indices (#6148)

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set/has_property.rs
+++ b/crates/perry-runtime/src/object/field_get_set/has_property.rs
@@ -298,6 +298,51 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
             }
             return nanbox_false;
         }
+        // #6148: `Uint8Array` / `Buffer` are backed by a header-less registered
+        // buffer (not `TYPED_ARRAY_REGISTRY`), so the typed-array arm above misses
+        // them. A Buffer is a `Uint8Array`, so `in` consults numeric indices
+        // (bounds) and the own/inherited members property-get can resolve.
+        if crate::buffer::is_registered_buffer(obj_addr as usize) {
+            let buf = obj_addr as *const crate::buffer::BufferHeader;
+            let len = unsafe { crate::buffer::js_buffer_length(buf) };
+            if key_val.is_int32() {
+                let idx = key_val.as_int32();
+                return if idx >= 0 && idx < len {
+                    nanbox_true
+                } else {
+                    nanbox_false
+                };
+            }
+            if key_val.is_number() {
+                let f = f64::from_bits(key_val.bits());
+                let present = f.is_finite()
+                    && f >= 0.0
+                    && f.fract() == 0.0
+                    && f <= i32::MAX as f64
+                    && (f as i32) < len;
+                return if present { nanbox_true } else { nanbox_false };
+            }
+            if key_val.is_any_string() {
+                // Own view slots, always present. Inherited prototype MEMBERS
+                // (`subarray`, `map`, `toString`, …) via `in` on a buffer are a
+                // separate follow-up — the same string-key gap the registered
+                // typed-array arm above has, tied to lazy `%TypedArray%`
+                // prototype population.
+                let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+                if let Some(name) = unsafe { crate::string::js_string_key_bytes(key_val, &mut sso) }
+                    .and_then(|b| std::str::from_utf8(b).ok())
+                {
+                    if matches!(
+                        name,
+                        "length" | "byteLength" | "byteOffset" | "BYTES_PER_ELEMENT" | "buffer"
+                    ) {
+                        return nanbox_true;
+                    }
+                }
+                return nanbox_false;
+            }
+            return nanbox_false;
+        }
         let obj_ptr = obj_addr as *mut ObjectHeader;
         unsafe {
             if !obj_ptr.is_null() && (*obj_ptr).class_id == NATIVE_MODULE_CLASS_ID {


### PR DESCRIPTION
Fixes #6148 (the index case).

## Summary

`0 in new Uint8Array([1,2,3])` returned `false` (as did `"length" in u8`),
while every other typed-array kind worked:

```ts
0 in new Uint8Array([1,2,3])   // was false → true
0 in new Int16Array([1,2,3])   // already true
0 in new Float64Array([1,2,3]) // already true
```

`Uint8Array` / `Buffer` are backed by a **header-less registered buffer** (not
`TYPED_ARRAY_REGISTRY`), so the `in` operator's typed-array arm — which gates on
`lookup_typed_array_kind` — never saw them. It was Uint8Array/Buffer-specific,
independent of size.

## Fix

Add a buffer branch to `js_object_has_property`, mirroring the property-get path
(`get_field_by_name_tail.rs`): detect via `is_registered_buffer`, then

- a numeric index is present iff it's in `[0, js_buffer_length)`
- the own view slots (`length` / `byteLength` / `byteOffset` /
  `BYTES_PER_ELEMENT` / `buffer`) are present

## Scope / follow-up

Inherited prototype **members** via `in` on a buffer (`"subarray" in u8`,
`"toString" in u8`) are left as a follow-up: it's the same string-key gap the
*registered* typed-array arm already has, tied to lazy `%TypedArray%.prototype`
population (order-dependent), so it deserves its own fix covering both.

## Validation

Byte-for-byte vs `node --experimental-strip-types`: index `in` for Uint8Array
(small + large), `Buffer.from`, Float64Array, Int16Array; negative and
out-of-bounds indices; the five view slots; plus an `in` regression sweep (plain
object, array, registered typed array, `Object.create`, primitive-throw).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved property-existence checks for buffer values so the `in` operator now returns the expected results for numeric indices and supported buffer-related properties.
  * Fixed cases where certain buffer-backed objects were not recognized correctly during property lookup, preventing incorrect `false` results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->