### PR TITLE
fix(lower): compound/logical member assignment evaluates base + key once (#6071)

### DIFF
--- a/crates/perry-hir/src/lower/expr_assign.rs
+++ b/crates/perry-hir/src/lower/expr_assign.rs
@@ -7,11 +7,11 @@
 //! sequence expression of individual assignments).
 
 use anyhow::{anyhow, Result};
-use perry_types::Type;
+use perry_types::{LocalId, Type};
 use swc_ecma_ast as ast;
 
 use crate::destructuring::lower_destructuring_assignment;
-use crate::ir::{BinaryOp, Expr, LogicalOp};
+use crate::ir::{BinaryOp, Expr, LogicalOp, Stmt};
 use crate::lower_patterns::lower_assign_target_to_expr;
 
 use super::{
@@ -1159,4 +1159,147 @@ fn wrap_assign_object_prelude(prelude: Option<Expr>, e: Expr) -> Expr {
         Some(p) => Expr::Sequence(vec![p, e]),
         None => e,
     }
+}
+
+/// The `BinaryOp` a plain compound assignment (`+=`, `*=`, `<<=`, …) reads-and-
+/// writes with. Returns `None` for `=` and the logical assignments
+/// (`&&=`/`||=`/`??=`), which are not simple read-op-write.
+fn compound_binary_op(op: ast::AssignOp) -> Option<BinaryOp> {
+    use ast::AssignOp::*;
+    Some(match op {
+        AddAssign => BinaryOp::Add,
+        SubAssign => BinaryOp::Sub,
+        MulAssign => BinaryOp::Mul,
+        DivAssign => BinaryOp::Div,
+        ModAssign => BinaryOp::Mod,
+        BitAndAssign => BinaryOp::BitAnd,
+        BitOrAssign => BinaryOp::BitOr,
+        BitXorAssign => BinaryOp::BitXor,
+        LShiftAssign => BinaryOp::Shl,
+        RShiftAssign => BinaryOp::Shr,
+        ZeroFillRShiftAssign => BinaryOp::UShr,
+        ExpAssign => BinaryOp::Pow,
+        Assign | AndAssign | OrAssign | NullishAssign => return None,
+    })
+}
+
+/// #6071: statement-level compound assignment to a member/index target
+/// (`a.b op= v;`, `a[k] op= v;`). Spill the base and (computed) key into
+/// `Stmt::Let` temps so each is evaluated EXACTLY ONCE, then build the read and
+/// the write from those temps. Without this, `lower_assign` lowers the target
+/// twice (once as the read operand, once as the write target), double-evaluating
+/// the base and a side-effecting computed key (`arr[i++] += 1` was wrong).
+///
+/// Returns `None` — so the caller falls back to the ordinary expression
+/// lowering — for anything that isn't a plain member/index compound assign, or
+/// that routes through the proxy / `with` / private-brand paths (those have
+/// their own semantics and are left unchanged).
+pub(crate) fn hoist_compound_member_assign(
+    ctx: &mut LoweringContext,
+    assign: &ast::AssignExpr,
+) -> Result<Option<Vec<Stmt>>> {
+    // A plain compound (`+=`, …) or a logical (`&&=`/`||=`/`??=`) assignment;
+    // `=` is not one of these and keeps the ordinary path.
+    let bin_op = compound_binary_op(assign.op);
+    let logical_op = logical_assignment_op(assign.op);
+    if bin_op.is_none() && logical_op.is_none() {
+        return Ok(None);
+    }
+    let ast::AssignTarget::Simple(ast::SimpleAssignTarget::Member(member)) = &assign.left else {
+        return Ok(None);
+    };
+    // Private fields and proxy / `with`-scoped receivers keep the existing path.
+    if matches!(member.prop, ast::MemberProp::PrivateName(_)) {
+        return Ok(None);
+    }
+    if let ast::Expr::Ident(obj_ident) = member.obj.as_ref() {
+        let n = obj_ident.sym.as_ref();
+        if ctx.proxy_locals.contains(n) || !ctx.active_with_envs_for_ident(n).is_empty() {
+            return Ok(None);
+        }
+    }
+
+    let mut stmts: Vec<Stmt> = Vec::new();
+    let spill =
+        |ctx: &mut LoweringContext, stmts: &mut Vec<Stmt>, tag: &str, init: Expr| -> LocalId {
+            let id = ctx.fresh_local();
+            stmts.push(Stmt::Let {
+                id,
+                name: format!("__cmpd_{}_{}", tag, id),
+                ty: Type::Any,
+                mutable: false,
+                init: Some(init),
+            });
+            id
+        };
+
+    // Base — always spilled (evaluated once).
+    let base = lower_expr(ctx, &member.obj)?;
+    let base_id = spill(ctx, &mut stmts, "base", base);
+
+    // Property name (static) or computed key spilled to its own temp.
+    let prop: Option<String>;
+    let key_id: Option<LocalId>;
+    match &member.prop {
+        ast::MemberProp::Ident(i) => {
+            prop = Some(i.sym.to_string());
+            key_id = None;
+        }
+        ast::MemberProp::Computed(c) => {
+            let key = lower_expr(ctx, &c.expr)?;
+            key_id = Some(spill(ctx, &mut stmts, "key", key));
+            prop = None;
+        }
+        ast::MemberProp::PrivateName(_) => unreachable!("guarded above"),
+    }
+
+    let read = match (&prop, key_id) {
+        (Some(p), _) => Expr::PropertyGet {
+            object: Box::new(Expr::LocalGet(base_id)),
+            property: p.clone(),
+        },
+        (None, Some(k)) => Expr::IndexGet {
+            object: Box::new(Expr::LocalGet(base_id)),
+            index: Box::new(Expr::LocalGet(k)),
+        },
+        _ => unreachable!(),
+    };
+
+    // A write of `value` back to the (spilled) target.
+    let write_of = |value: Expr| -> Expr {
+        match (&prop, key_id) {
+            (Some(p), _) => Expr::PropertySet {
+                object: Box::new(Expr::LocalGet(base_id)),
+                property: p.clone(),
+                value: Box::new(value),
+            },
+            (None, Some(k)) => Expr::IndexSet {
+                object: Box::new(Expr::LocalGet(base_id)),
+                index: Box::new(Expr::LocalGet(k)),
+                value: Box::new(value),
+            },
+            _ => unreachable!(),
+        }
+    };
+
+    // RHS is evaluated once. Compound: unconditionally, after the read (spec
+    // order). Logical: only on the branch that writes, so short-circuit
+    // semantics are preserved (`a[k] ||= v` doesn't write when `a[k]` is truthy).
+    let rhs = lower_expr(ctx, &assign.right)?;
+    let final_expr = if let Some(op) = bin_op {
+        write_of(Expr::Binary {
+            op,
+            left: Box::new(read),
+            right: Box::new(rhs),
+        })
+    } else {
+        // `read OP (target = rhs)` — mirrors `lower_logical_assignment`.
+        Expr::Logical {
+            op: logical_op.unwrap(),
+            left: Box::new(read),
+            right: Box::new(write_of(rhs)),
+        }
+    };
+    stmts.push(Stmt::Expr(final_expr));
+    Ok(Some(stmts))
 }

--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -1243,6 +1243,15 @@ pub(crate) fn lower_stmt(
                     module.init.extend(stmts);
                     return Ok(());
                 }
+                // #6071: a compound member/index assignment at statement level —
+                // spill the base + computed key into Let temps so each is
+                // evaluated once (the expression path lowers them twice).
+                if let Some(stmts) =
+                    crate::lower::expr_assign::hoist_compound_member_assign(ctx, assign)?
+                {
+                    module.init.extend(stmts);
+                    return Ok(());
+                }
             }
             let expr = lower_expr(ctx, &expr_stmt.expr)?;
             module.init.push(Stmt::Expr(expr));

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -144,6 +144,14 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                     result.extend(stmts);
                     return Ok(result);
                 }
+                // #6071: compound member/index assignment — spill base + computed
+                // key into Let temps so each is evaluated exactly once.
+                if let Some(stmts) =
+                    crate::lower::expr_assign::hoist_compound_member_assign(ctx, assign)?
+                {
+                    result.extend(stmts);
+                    return Ok(result);
+                }
             }
             let expr = lower_expr(ctx, &expr_stmt.expr)?;
             if matches!(


### PR DESCRIPTION
Fixes #6071 (statement form).

## Summary

`a[k] op= v` — and `a.b op= v`, `a[k] ||= v` / `&&=` / `??=` — lowered the target
**twice**: once as the read operand and once as the write target. So the base
and a computed key were evaluated twice. Usually the value was still correct, but
a side-effecting key or base broke:

```ts
const a = [10, 20, 30]; let i = 0;
a[i++] += 100;      // was: i incremented twice, wrong slot written → [110? no] → 120,20,30
                    // now: 110,20,30, i === 1
o[f()] += 1;        // f() was called twice → now once
f()[0].x += 1;      // f() was called twice → now once
```

## Fix

At statement level (the common case), spill the base and computed key into
`Stmt::Let` temps — evaluated exactly once — then build the read and the write
from those temps. `hoist_compound_member_assign` is wired into the module-level
(`stmt.rs`) and function-body (`body_stmt.rs`) `ExprStmt` arms, right next to the
existing destructuring-assignment hoist.

- **Compound** (`+=`, `*=`, `<<=`, …): `write(read op rhs)`.
- **Logical** (`||=`, `&&=`, `??=`): `read OP (write = rhs)` — preserves
  short-circuit, so the write is skipped (and `rhs` unevaluated) when it should
  be.

## Scope

Statement context reuses the working `Stmt::Let` slot machinery. Perry has no
expression-context reference-spill, so a **value-used** compound assignment
(`x = (a[k()] += 1)`) still double-evaluates in the rarer expression form — the
value is correct there, only a side-effecting key/base is observed twice. Proxy
/ `with` / private-field targets keep their existing paths.

## Validation

Byte-for-byte vs Node: computed-key/base eval-once, `arr[i++] += v`, nested
member bases (`a.b.c *=`), every compound operator, `this.field +=` in a method,
`||=`/`&&=`/`??=` short-circuit + eval-once; plus a broad assignment regression
(plain `=`, `++`/`--`, loops, Redux-style accumulation, string `+=`, method-call
bases) and a 25-file gap-test sample (23/25; the 2 failures are pre-existing
async/`process` gaps with no compound assignment).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compound assignments on object properties and indexed values are now lowered more efficiently and predictably, with intermediate values evaluated only once.
  * Short-circuit assignment forms now preserve expected behavior when used with member or index targets.

* **Bug Fixes**
  * Fixed cases where repeated evaluation could occur for complex assignment targets.
  * Improved handling of compound assignments in expression statements, reducing unexpected lowering fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->