### PR TITLE
fix(runtime): `<canonical index string> in <Uint8Array>`/Buffer returns true (#6148 follow-up)

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set/has_property.rs
+++ b/crates/perry-runtime/src/object/field_get_set/has_property.rs
@@ -362,6 +362,15 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
                     ) {
                         return nanbox_true;
                     }
+                    // A canonical numeric-index string (`"0"`, `"2"`, …) is an own
+                    // in-bounds index. The round-trip check rejects non-canonical
+                    // forms (`"00"`, `"1.5"`, `"-1"`, `"0x1"`), which are ordinary
+                    // (absent) string keys.
+                    if let Ok(idx) = name.parse::<u32>() {
+                        if idx.to_string() == name && idx < len as u32 {
+                            return nanbox_true;
+                        }
+                    }
                 }
                 return nanbox_false;
             }


### PR DESCRIPTION
Follow-up to #6163 addressing CodeRabbit's finding: `"0" in new Uint8Array([1,2,3])` returned false. The buffer branch only matched the five named view slots for string keys; a string-encoded **canonical index** (`"0"`, `"2"`, …) is an in-bounds own index and must return true (the registered typed-array arm already handled this).

Parse the string key as a canonical numeric index — the round-trip check (`idx.to_string() == name`) rejects non-canonical forms (`"00"`, `"1.5"`, `"-1"`, `"0x1"`), which remain ordinary absent keys — and report present when `idx < len`.

Validated byte-for-byte vs Node: `"0"/"2" in u8` → true, `"3" in u8` → false, non-canonical → false, named slots unchanged; #6148 index regression clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `in` checks on buffers so canonical numeric string indexes like `"0"` or `"2"` are now reported as present when they are within bounds.
  * Non-canonical numeric strings remain excluded, keeping property checks consistent with expected JavaScript behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->