### PR TITLE
fix(runtime): a throwing sort comparator no longer corrupts the array (#6076)

### DIFF
--- a/crates/perry-runtime/src/array/sort.rs
+++ b/crates/perry-runtime/src/array/sort.rs
@@ -636,7 +636,24 @@ unsafe fn sort_array_receiver(
         return arr;
     };
 
-    mark_array_layout_unknown(arr);
+    // #6076: sort a GC-rooted COPY of the elements and publish it back only
+    // after the comparator sort SUCCEEDS. A throwing comparator therefore leaves
+    // the receiver's elements intact (an in-place sort corrupts them), and the
+    // rooted temp keeps every value GC-visible across comparator allocations (a
+    // bare Vec would go stale under a moving GC). `elements_ptr` is rebound to
+    // the temp for the in-place sort below; the receiver storage is untouched
+    // until the write-back.
+    let recv_elems = elements_ptr;
+    let temp = js_array_alloc_with_length(length as u32);
+    let elements_ptr = (temp as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
+    for i in 0..length {
+        // GC_STORE_AUDIT(INIT): initializing the freshly-allocated temp from the
+        // receiver before it is published; no allocation (hence no GC) occurs
+        // between js_array_alloc_with_length above and rebuild_array_layout below.
+        ptr::write(elements_ptr.add(i), *recv_elems.add(i));
+    }
+    (*temp).length = length as u32;
+    rebuild_array_layout(temp);
 
     // TimSort-style hybrid: insertion sort for small runs, merge sort for large arrays.
     // Stable, O(n log n) worst case. Insertion sort is used for runs <= 32 elements
@@ -739,11 +756,20 @@ unsafe fn sort_array_receiver(
             width *= 2;
         }
 
-        // If final result is in buf, copy back to elements
+        // If final result is in buf, copy back to the temp element buffer.
         if src != elements_ptr {
             // GC_STORE_AUDIT(BARRIERED): merge buffer copyback is followed by layout/barrier rebuild.
             ptr::copy_nonoverlapping(src, elements_ptr, length);
         }
+    }
+
+    // The comparator sort completed without a throw — publish the sorted temp
+    // back into the receiver. A throwing comparator unwinds before reaching here,
+    // so `arr` keeps its original elements (#6076).
+    mark_array_layout_unknown(arr);
+    for i in 0..length {
+        // GC_STORE_AUDIT(BARRIERED): dense write-back is followed by the rebuild below.
+        *recv_elems.add(i) = *elements_ptr.add(i);
     }
     rebuild_array_layout(arr);
 


### PR DESCRIPTION
Fixes #6076.

## Summary

`Array.prototype.sort(cmp)` on a dense, all-defined array sorted the receiver's
element buffer **in place** (insertion sort ≤32 elements, bottom-up merge
above). A comparator that threw partway through left the array half-sorted with
**duplicated / dropped elements** — silent data corruption:

```ts
const a = [3, 1, 4, 1, 5, 9, 2, 6];
try { a.sort((x, y) => { if (++n > 3) throw new Error(); return x - y; }); } catch {}
// was: multiset {1,2,3,4,4,5,6,9}  (a 1 lost, a 4 duplicated)
// now: {1,1,2,3,4,5,6,9}           (original elements preserved)
```

Per spec, a throwing comparator must leave the elements intact.

## Fix

Sort a **GC-rooted copy** (a temp array) and publish it back to the receiver
only after the comparator sort completes. A throw unwinds before the write-back,
so the receiver keeps its original elements. The rooted temp also keeps every
value GC-visible across comparator allocations — addressing the issue's "scratch
buffer also GC-unsafe" note for this path (a bare `Vec<f64>` copy would go stale
under a moving GC; the receiver's own storage is untouched until the end). The
already-copy-based has-special / default / exotic-receiver paths are unchanged.

## Validation

Byte-for-byte vs Node: throwing comparator on **small (insertion)** and **large
(merge)** arrays preserves the element multiset; plus a sort regression sweep —
small/large arrays, descending, strings, objects, **stability**, a
**GC-allocating comparator** (rooted-temp safety), `toSorted`, return-value
identity, and empty/single/duplicate edges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved array sorting when using custom comparators, so a failing or throwing comparison no longer leaves the original array partially modified.
  * Sorting now keeps the original values intact while the comparison-based sort runs, and only applies the final sorted order after the operation completes successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->