### PR TITLE
fix(runtime): `in` on typed array/Buffer resolves prototype members, order-independent (#6164)

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set/has_property.rs
+++ b/crates/perry-runtime/src/object/field_get_set/has_property.rs
@@ -419,19 +419,38 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
                 return if present { nanbox_true } else { nanbox_false };
             }
             if key_val.is_any_string() {
-                // Own view slots, always present. Inherited prototype MEMBERS
-                // (`subarray`, `map`, `toString`, …) via `in` on a buffer are a
-                // separate follow-up — the same string-key gap the registered
-                // typed-array arm above has, tied to lazy `%TypedArray%`
-                // prototype population.
                 let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
                 if let Some(name) = unsafe { crate::string::js_string_key_bytes(key_val, &mut sso) }
                     .and_then(|b| std::str::from_utf8(b).ok())
                 {
+                    // Own view slots, always present.
                     if matches!(
                         name,
                         "length" | "byteLength" | "byteOffset" | "BYTES_PER_ELEMENT" | "buffer"
                     ) {
+                        return nanbox_true;
+                    }
+                    // A canonical numeric-index string (`"0"`, `"2"`, …) is an own
+                    // in-bounds index. The round-trip check rejects non-canonical
+                    // forms (`"00"`, `"1.5"`, `"-1"`, `"0x1"`), which stay ordinary
+                    // string keys.
+                    if let Ok(idx) = name.parse::<u32>() {
+                        if idx.to_string() == name && idx < len as u32 {
+                            return nanbox_true;
+                        }
+                    }
+                    // A Buffer / `Uint8Array` is a `%TypedArray%`, so inherited
+                    // prototype members (`subarray`, `map`, `join`, `toString`, …)
+                    // count. `typed_array_prototype_chain_has` builds the shared
+                    // prototype intrinsic on demand, so this is order-independent
+                    // (#6164). Buffer-specific `Buffer.prototype` methods
+                    // (`readUInt8`, …) are not covered here.
+                    if unsafe {
+                        crate::typedarray_props::typed_array_prototype_chain_has(
+                            obj_addr as usize,
+                            name,
+                        )
+                    } {
                         return nanbox_true;
                     }
                 }

--- a/crates/perry-runtime/src/object/field_get_set/has_property.rs
+++ b/crates/perry-runtime/src/object/field_get_set/has_property.rs
@@ -54,6 +54,23 @@ unsafe fn class_ref_has_symbol_member(class_id: u32, sym_f64: f64) -> bool {
     false
 }
 
+/// Is `name` a CanonicalNumericIndexString (ECMA-262 §7.1.21)? True for `"-0"`
+/// and any string that round-trips through `ToString(ToNumber(s))` — `"0"`,
+/// `"100"`, `"-1"`, `"1.5"`, `"NaN"`, `"Infinity"` — but NOT `"00"`, `"1e3"`,
+/// `"0x1"`, `"+1"`, or whitespace-padded forms (`ToNumber` of those does not
+/// stringify back to the original). The typed-array/Buffer `in` path uses this
+/// to short-circuit a canonical numeric index to the IntegerIndexed
+/// [[HasProperty]] result without ever consulting the prototype chain.
+fn is_canonical_numeric_index_string(name: &str) -> bool {
+    if name == "-0" {
+        return true;
+    }
+    match name.parse::<f64>() {
+        Ok(n) => crate::string::js_format_f64(n) == name,
+        Err(_) => false,
+    }
+}
+
 /// Render a value the way V8 does inside the `in`-operator TypeError message.
 /// Only the primitive RHS shapes that reach `throw_in_operator_non_object` need
 /// handling: `null`/`undefined` render literally, a Symbol as `Symbol(desc)`,
@@ -430,14 +447,22 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
                     ) {
                         return nanbox_true;
                     }
-                    // A canonical numeric-index string (`"0"`, `"2"`, …) is an own
-                    // in-bounds index. The round-trip check rejects non-canonical
-                    // forms (`"00"`, `"1.5"`, `"-1"`, `"0x1"`), which stay ordinary
-                    // string keys.
-                    if let Ok(idx) = name.parse::<u32>() {
-                        if idx.to_string() == name && idx < len as u32 {
-                            return nanbox_true;
+                    // A CanonicalNumericIndexString (`"0"`, `"100"`, `"-1"`,
+                    // `"1.5"`, `"-0"`, `"NaN"`) is resolved ENTIRELY by the
+                    // IntegerIndexed [[HasProperty]] (ECMA-262 §10.4.9.2): present
+                    // iff it is a valid in-bounds integer index, absent otherwise,
+                    // and it NEVER consults the prototype. So an out-of-bounds
+                    // (`"100"` on a length-5 view), negative, or fractional
+                    // canonical index short-circuits to false here rather than
+                    // falling through to the prototype scan below. Non-canonical
+                    // forms (`"00"`, `"1e3"`, `"0x1"`) stay ordinary string keys.
+                    if is_canonical_numeric_index_string(name) {
+                        if let Ok(idx) = name.parse::<u32>() {
+                            if idx.to_string() == name && idx < len as u32 {
+                                return nanbox_true;
+                            }
                         }
+                        return nanbox_false;
                     }
                     // A Buffer / `Uint8Array` is a `%TypedArray%`, so inherited
                     // prototype members (`subarray`, `map`, `join`, `toString`, …)

--- a/crates/perry-runtime/src/typedarray_props.rs
+++ b/crates/perry-runtime/src/typedarray_props.rs
@@ -778,7 +778,12 @@ pub(crate) unsafe fn typed_array_has_property(
 /// object (spec methods + the reflectable accessors), the per-kind prototype
 /// object (`Float64Array.prototype` — `constructor` and any user patches),
 /// and finally `Object.prototype` (its universal methods + user expandos).
-unsafe fn typed_array_prototype_chain_has(owner: usize, name: &str) -> bool {
+pub(crate) unsafe fn typed_array_prototype_chain_has(owner: usize, name: &str) -> bool {
+    // Build the shared `%TypedArray%.prototype` intrinsic if it hasn't been yet,
+    // so the membership check doesn't depend on a registered typed array having
+    // been created first (#6164 — otherwise the result was creation-order
+    // dependent, and buffer-backed `Uint8Array` never populated it).
+    let _ = crate::object::ensure_typed_array_intrinsic();
     let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
     // %TypedArray%.prototype intrinsic.
     let intrinsic = crate::object::typed_array_intrinsic_proto_ptr();


### PR DESCRIPTION
Fixes #6164; supersedes #6168 (folds in its canonical-index handling).

`"subarray" in ta`/`"map" in ta`/`"toString" in ta` returned false or gave **creation-order-dependent** results — the string-key walk consulted the shared `%TypedArray%.prototype` intrinsic only if it had already been built (first registered typed-array creation), and the buffer-backed `Uint8Array` branch never populated it (only matched the five named view slots).

- `typed_array_prototype_chain_has` now builds the intrinsic on demand (`ensure_typed_array_intrinsic`, idempotent) → order-independent.
- The buffer branch routes non-slot string keys through the same walk (a `Uint8Array`/`Buffer` is a `%TypedArray%`), and reports a canonical numeric-index string (`"0" in u8`) as an own index (folds in #6168).

Buffer-specific `Buffer.prototype` methods (`readUInt8`) are not covered.

Validated vs Node across methods / `Object.prototype` members / `Symbol.iterator` / numeric+canonical-index strings / view slots, for registered TAs **and** buffer-backed `Uint8Array` (both creation orders), plus an `in` regression sweep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `in` operator handling for typed arrays and array-buffer views: canonical numeric index keys (e.g., `"0"`, `"2"`) are treated as present only when they map exactly to valid element indices.
  * Ensured view-specific properties (`length`, `byteLength`, `byteOffset`, `BYTES_PER_ELEMENT`, `buffer`) are consistently reported as present.
  * Fixed detection of inherited `%TypedArray%.prototype` members, improving reliability even during early startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->