### PR TITLE
fix(runtime): Object enumeration + expandos on Map/Set receivers (SIGSEGV)

### DIFF
--- a/crates/perry-runtime/src/object/descriptors.rs
+++ b/crates/perry-runtime/src/object/descriptors.rs
@@ -1008,7 +1008,11 @@ pub extern "C" fn js_object_get_own_property_names(obj_value: f64) -> f64 {
             let mut names = match kind {
                 ExoticKind::RegExp => vec!["lastIndex".to_string()],
                 ExoticKind::Error => vec!["message".to_string(), "stack".to_string()],
-                ExoticKind::Date | ExoticKind::Temporal | ExoticKind::Promise => Vec::new(),
+                ExoticKind::Date
+                | ExoticKind::Temporal
+                | ExoticKind::Promise
+                | ExoticKind::Map
+                | ExoticKind::Set => Vec::new(),
             };
             for key in super::exotic_expando::exotic_own_keys(kind, addr, false) {
                 if !names.contains(&key) {

--- a/crates/perry-runtime/src/object/exotic_expando.rs
+++ b/crates/perry-runtime/src/object/exotic_expando.rs
@@ -51,6 +51,17 @@ pub(crate) enum ExoticKind {
     /// Temporal, a promise is movable, so its expando entry is rekeyed on GC
     /// move via `exotic_expando_owner_moved`.
     Promise,
+    /// A `Map` is a `MapHeader` cell, NOT an `ObjectHeader` — a plain expando
+    /// write (`memoized.cache.custom = x` on a lodash-memoize Map cache) must
+    /// land in the side table rather than being bit-cast through the
+    /// `ObjectHeader` field path, which overwrote collection-internal fields
+    /// (and enumeration then read those bytes back as a garbage `keys_array`
+    /// pointer → SIGSEGV). Collection DATA stays in the map natives; only
+    /// true expando keys land here. Movable — rekeyed on GC move like
+    /// Promise.
+    Map,
+    /// `Set` analogue of `Map` (a `SetHeader` cell).
+    Set,
 }
 
 /// Classify `addr` as a Date cell, RegExp header, or Error header. Returns
@@ -63,6 +74,8 @@ pub(crate) fn exotic_expando_kind(addr: usize) -> Option<ExoticKind> {
         crate::gc::GC_TYPE_ERROR => Some(ExoticKind::Error),
         crate::gc::GC_TYPE_TEMPORAL => Some(ExoticKind::Temporal),
         crate::gc::GC_TYPE_PROMISE => Some(ExoticKind::Promise),
+        crate::gc::GC_TYPE_MAP => Some(ExoticKind::Map),
+        crate::gc::GC_TYPE_SET => Some(ExoticKind::Set),
         crate::gc::GC_TYPE_OBJECT if crate::regex::is_regex_pointer(addr as *const u8) => {
             Some(ExoticKind::RegExp)
         }
@@ -278,6 +291,10 @@ pub(crate) unsafe fn exotic_set_property(
             // generic accessors in the side table, so there is no
             // prototype-accessor setter to consult; store the own expando.
             ExoticKind::Promise => "",
+            // Map/Set prototype members are methods + the `size` accessor,
+            // all served by their native dispatch paths — store the own
+            // expando directly.
+            ExoticKind::Map | ExoticKind::Set => "",
         };
         let proto = if proto_name.is_empty() {
             f64::from_bits(crate::value::TAG_UNDEFINED)

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -117,6 +117,7 @@ mod get_field_by_name;
 mod get_field_by_name_tail;
 mod has_property;
 mod ic_miss;
+mod map_set_receiver;
 
 // Explicit named re-exports so existing `crate::object::…` / `super::…`
 // paths keep resolving (a glob re-export does not reliably propagate through

--- a/crates/perry-runtime/src/object/field_get_set/enumeration.rs
+++ b/crates/perry-runtime/src/object/field_get_set/enumeration.rs
@@ -3,6 +3,55 @@
 
 use super::*;
 
+/// Map/Set receivers: the collection's DATA lives in internal slots (never
+/// own enumerable properties — Node: `Object.keys(new Map([...])) === []`),
+/// but user EXPANDOS (`cache.custom = x`) live in the exotic side table
+/// (`ExoticKind::Map`/`Set`). Shared by the keys/values/entries guards.
+enum MapSetEnum {
+    Keys,
+    Values,
+    Entries,
+}
+
+fn map_set_exotic_enum(stripped: *const ObjectHeader, what: MapSetEnum) -> *mut ArrayHeader {
+    let addr = stripped as usize;
+    let kind = if crate::map::is_registered_map(addr) {
+        super::super::exotic_expando::ExoticKind::Map
+    } else {
+        super::super::exotic_expando::ExoticKind::Set
+    };
+    let keys = super::super::exotic_expando::exotic_own_keys(kind, addr, true);
+    let arr = crate::array::js_array_alloc(keys.len().max(1) as u32);
+    let mut out = arr;
+    let receiver = f64::from_bits(JSValue::pointer(addr as *const u8).bits());
+    for name in keys {
+        let value = || unsafe {
+            super::super::exotic_expando::exotic_get_own_property(addr, kind, &name, receiver)
+                .unwrap_or(f64::from_bits(crate::value::TAG_UNDEFINED))
+        };
+        match what {
+            MapSetEnum::Keys => {
+                let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+                out = crate::array::js_array_push(out, JSValue::string_ptr(key));
+            }
+            MapSetEnum::Values => {
+                out = crate::array::js_array_push_f64(out, value());
+            }
+            MapSetEnum::Entries => {
+                let pair = crate::array::js_array_alloc(2);
+                let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+                crate::array::js_array_push(pair, JSValue::string_ptr(key));
+                crate::array::js_array_push_f64(pair, value());
+                out = crate::array::js_array_push(
+                    out,
+                    JSValue::from_bits(JSValue::pointer(pair as *const u8).bits()),
+                );
+            }
+        }
+    }
+    out
+}
+
 /// `Object.keys(value)` entry point that inspects the NaN-boxed *value* (not a
 /// raw pointer) so it handles primitives safely. A string yields its index
 /// keys `"0".."length-1"` (`Object.keys("abc") === ["0","1","2"]`); objects and
@@ -638,6 +687,19 @@ pub extern "C" fn js_object_keys(obj: *const ObjectHeader) -> *mut ArrayHeader {
             obj
         }
     };
+    // A Map/Set receiver is a MapHeader/SetHeader, NOT an ObjectHeader — the
+    // generic object walk below reads collection-internal bytes as a
+    // `keys_array` pointer and SIGSEGVs downstream (js_array_length's GC-kind
+    // probe on the garbage pointer). Per spec a collection's entries live in
+    // internal slots, not own enumerable properties: Node returns [] for
+    // `Object.keys(new Map([...]))` — and likewise for values/entries/for-in.
+    // A telemetry path in a large esbuild-bundled CLI app hit this via
+    // `Object.keys(cache)` on a lodash-memoize Map cache.
+    if crate::map::is_registered_map(stripped as usize)
+        || crate::set::is_registered_set(stripped as usize)
+    {
+        return map_set_exotic_enum(stripped, MapSetEnum::Keys);
+    }
     if let Some(addr) =
         crate::typedarray_props::typed_array_addr_from_value(f64::from_bits(obj as u64))
     {
@@ -931,6 +993,13 @@ pub extern "C" fn js_object_values(obj: *const ObjectHeader) -> *mut ArrayHeader
             obj
         }
     };
+    // Map/Set receiver → no own enumerable properties; see the matching
+    // guard in `js_object_keys` for the rationale.
+    if crate::map::is_registered_map(stripped as usize)
+        || crate::set::is_registered_set(stripped as usize)
+    {
+        return map_set_exotic_enum(stripped, MapSetEnum::Values);
+    }
     if let Some(addr) =
         crate::typedarray_props::typed_array_addr_from_value(f64::from_bits(obj as u64))
     {
@@ -1073,6 +1142,13 @@ pub extern "C" fn js_object_entries(obj: *const ObjectHeader) -> *mut ArrayHeade
             obj
         }
     };
+    // Map/Set receiver → no own enumerable properties; see the matching
+    // guard in `js_object_keys` for the rationale.
+    if crate::map::is_registered_map(stripped as usize)
+        || crate::set::is_registered_set(stripped as usize)
+    {
+        return map_set_exotic_enum(stripped, MapSetEnum::Entries);
+    }
     if let Some(addr) =
         crate::typedarray_props::typed_array_addr_from_value(f64::from_bits(obj as u64))
     {

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
@@ -474,6 +474,20 @@ pub(crate) fn get_field_by_name_object_tail(
                     let result = js_class_method_bind(this_f64, name.as_ptr(), name.len());
                     return JSValue::from_bits(result.to_bits());
                 }
+                // User expando keys (`s.tag = x`) live in the exotic side
+                // table (`ExoticKind::Set`); see the Map/Set arm below.
+                if let Ok(name) = std::str::from_utf8(key_bytes) {
+                    let receiver =
+                        f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
+                    if let Some(v) = crate::object::exotic_expando::exotic_get_own_property(
+                        obj as usize,
+                        crate::object::exotic_expando::ExoticKind::Set,
+                        name,
+                        receiver,
+                    ) {
+                        return JSValue::from_bits(v.to_bits());
+                    }
+                }
             }
             return JSValue::undefined();
         }
@@ -1043,33 +1057,14 @@ pub(crate) fn get_field_by_name_object_tail(
             }
             return JSValue::undefined();
         }
-        // Maps: handle `.size` for `obj.m.size` style access where m is
-        // a Map field stored in a plain object literal. Without this
-        // the dynamic property dispatch returns undefined.
-        if gc_type == crate::gc::GC_TYPE_MAP {
-            if !key.is_null() {
-                let key_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
-                let key_len = (*key).byte_len as usize;
-                let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
-                if key_bytes == b"size" {
-                    let m = obj as *const crate::map::MapHeader;
-                    return JSValue::number(crate::map::js_map_size(m) as f64);
-                }
-                // Inherited `Map.prototype` members read off a Map *instance*
-                // (`m.set`, `m.get`, `m.constructor`, …) resolve through the
-                // prototype chain. The MapHeader isn't a plain object, so walk
-                // to `%Map.prototype%` and return its own data field — this is
-                // what makes `m.set.call(m, k, v)` (reflective dispatch) and
-                // `(new Map()).constructor === Map` work.
-                let proto = crate::object::builtin_prototype_value("Map");
-                let proto_ptr = crate::value::js_nanbox_get_pointer(proto) as *const ObjectHeader;
-                if !proto_ptr.is_null() {
-                    if let Some(v) = own_data_field_by_name(proto_ptr, key) {
-                        return v;
-                    }
-                }
-            }
-            return JSValue::undefined();
+        // Maps/Sets: `.size`, expando keys, and prototype member values —
+        // see `map_set_receiver.rs` (extracted for the file-size gate).
+        if gc_type == crate::gc::GC_TYPE_MAP || gc_type == crate::gc::GC_TYPE_SET {
+            return super::map_set_receiver::map_set_instance_property(
+                obj,
+                key,
+                gc_type == crate::gc::GC_TYPE_MAP,
+            );
         }
         // RegExp: RegExpHeader is allocated via GC_TYPE_OBJECT but tracked
         // in REGEX_POINTERS. Detect and route `.source`, `.flags`,

--- a/crates/perry-runtime/src/object/field_get_set/has_property.rs
+++ b/crates/perry-runtime/src/object/field_get_set/has_property.rs
@@ -271,7 +271,13 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
             // Temporal built-in fields (year/month/calendar/…) are prototype
             // getters, not own data properties (like Date). Promise's
             // then/catch/finally are prototype methods, not own props.
-            ExoticKind::Date | ExoticKind::Temporal | ExoticKind::Promise => false,
+            // Map/Set entries are internal slots; `size` and methods are
+            // prototype members, not own props.
+            ExoticKind::Date
+            | ExoticKind::Temporal
+            | ExoticKind::Promise
+            | ExoticKind::Map
+            | ExoticKind::Set => false,
         };
         if builtin_own {
             return nanbox_true;

--- a/crates/perry-runtime/src/object/field_get_set/map_set_receiver.rs
+++ b/crates/perry-runtime/src/object/field_get_set/map_set_receiver.rs
@@ -1,0 +1,58 @@
+//! Map/Set instance receivers for dynamic property reads: `.size`, user
+//! expando keys (exotic side table), and inherited `Map.prototype` /
+//! `Set.prototype` member values. Extracted from `get_field_by_name_tail.rs`
+//! (its GC-type Map/Set arm) to stay under the file-size gate.
+
+use super::*;
+
+/// Resolve a named property read on a Map/Set *instance* (`MapHeader` /
+/// `SetHeader` — NOT an `ObjectHeader`, so the generic object walk must never
+/// see it).
+///
+/// Order: built-in `size` → own expando keys (`cache.custom = x`, stored in
+/// the exotic side table under `ExoticKind::Map`/`Set` — own props win over
+/// inherited members) → builtin-prototype data fields (`m.set`,
+/// `m.constructor`, … — what makes `m.set.call(m, k, v)` reflective dispatch
+/// and `(new Map()).constructor === Map` work) → undefined.
+pub(crate) unsafe fn map_set_instance_property(
+    obj: *const ObjectHeader,
+    key: *const crate::StringHeader,
+    is_map: bool,
+) -> JSValue {
+    if !key.is_null() {
+        let key_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        let key_len = (*key).byte_len as usize;
+        let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
+        if key_bytes == b"size" {
+            return if is_map {
+                JSValue::number(crate::map::js_map_size(obj as *const crate::map::MapHeader) as f64)
+            } else {
+                JSValue::number(crate::set::js_set_size(obj as *const crate::set::SetHeader) as f64)
+            };
+        }
+        if let Ok(name) = std::str::from_utf8(key_bytes) {
+            let kind = if is_map {
+                crate::object::exotic_expando::ExoticKind::Map
+            } else {
+                crate::object::exotic_expando::ExoticKind::Set
+            };
+            let receiver = f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits());
+            if let Some(v) = crate::object::exotic_expando::exotic_get_own_property(
+                obj as usize,
+                kind,
+                name,
+                receiver,
+            ) {
+                return JSValue::from_bits(v.to_bits());
+            }
+        }
+        let proto = crate::object::builtin_prototype_value(if is_map { "Map" } else { "Set" });
+        let proto_ptr = crate::value::js_nanbox_get_pointer(proto) as *const ObjectHeader;
+        if !proto_ptr.is_null() {
+            if let Some(v) = own_data_field_by_name(proto_ptr, key) {
+                return v;
+            }
+        }
+    }
+    JSValue::undefined()
+}

--- a/crates/perry-runtime/src/object/native_call_method/common_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/common_methods.rs
@@ -155,7 +155,9 @@ pub(super) unsafe fn dispatch_common(
                                     ),
                                     ExoticKind::Date
                                     | ExoticKind::Temporal
-                                    | ExoticKind::Promise => false,
+                                    | ExoticKind::Promise
+                                    | ExoticKind::Map
+                                    | ExoticKind::Set => false,
                                 }
                         })
                         .unwrap_or(false);

--- a/crates/perry-runtime/src/object/object_ops/has_own.rs
+++ b/crates/perry-runtime/src/object/object_ops/has_own.rs
@@ -189,9 +189,11 @@ pub extern "C" fn js_object_has_own(obj_value: f64, key_value: f64) -> f64 {
                                     ptr as *mut crate::error::ErrorHeader,
                                     key,
                                 ),
-                                ExoticKind::Date | ExoticKind::Temporal | ExoticKind::Promise => {
-                                    false
-                                }
+                                ExoticKind::Date
+                                | ExoticKind::Temporal
+                                | ExoticKind::Promise
+                                | ExoticKind::Map
+                                | ExoticKind::Set => false,
                             }
                     })
                     .unwrap_or(false);

--- a/crates/perry/tests/map_set_object_enumeration.rs
+++ b/crates/perry/tests/map_set_object_enumeration.rs
@@ -1,0 +1,142 @@
+//! Regression tests: Object enumeration + expando properties on Map/Set
+//! receivers.
+//!
+//! A `Map`/`Set` is a `MapHeader`/`SetHeader` cell, NOT an `ObjectHeader`.
+//! Pre-fix:
+//!
+//! - `Object.keys` / `Object.values` / `Object.entries` / `for…in` on a Map
+//!   or Set read collection-internal bytes as a `keys_array` pointer and
+//!   SIGSEGV'd in `js_array_length`'s GC-kind probe (a deterministic crash:
+//!   `Object.keys(new Map())` alone reproduced it). A telemetry path in a
+//!   large esbuild-bundled CLI app hit this via `Object.keys(cache)` on a
+//!   lodash-memoize Map cache and took the whole process down mid-turn.
+//! - a plain expando write (`m.foo = 42`) bit-cast the MapHeader as an
+//!   ObjectHeader and overwrote collection-internal fields (silent memory
+//!   corruption), then crashed on the next enumeration.
+//!
+//! Fix: `ExoticKind::Map`/`Set` route expando get/set/has/delete through the
+//! exotic side table (the same mechanism as Date/RegExp/Error/Promise), and
+//! the keys/values/entries entry points enumerate exactly the side-table
+//! expandos (collection DATA lives in internal slots — Node returns `[]`
+//! for `Object.keys(new Map([...]))`).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed (pre-fix: SIGSEGV in js_array_length's \
+         GC-kind probe)\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+/// The bare crash cases: every Object enumeration entry point over Map/Set
+/// receivers (pre-fix: SIGSEGV on all four).
+#[test]
+fn object_enumeration_over_map_set_does_not_crash() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const m: any = new Map([["a", 1], ["b", 2]]);
+console.log(JSON.stringify(Object.keys(m)));
+console.log(JSON.stringify(Object.values(m)));
+console.log(JSON.stringify(Object.entries(m)));
+const ks: string[] = []; for (const k in m) ks.push(k);
+console.log(JSON.stringify(ks));
+const s: any = new Set([1, 2]);
+console.log(JSON.stringify(Object.keys(s)));
+console.log(JSON.stringify(Object.keys(new Map())));
+"#,
+    );
+    assert_eq!(stdout, "[]\n[]\n[]\n[]\n[]\n[]\n");
+}
+
+/// Expando writes must land in the side table (not corrupt the collection),
+/// read back, enumerate, and leave the collection's own data intact.
+#[test]
+fn map_set_expando_properties_round_trip() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const m: any = new Map([["a", 1]]);
+m.foo = 42;
+console.log("get:", m.foo);
+console.log("keys:", JSON.stringify(Object.keys(m)));
+console.log("hasOwn:", m.hasOwnProperty("foo"), Object.hasOwn(m, "foo"));
+console.log("data intact:", m.get("a"), m.size);
+const ks: string[] = []; for (const k in m) ks.push(k);
+console.log("forin:", JSON.stringify(ks));
+const s: any = new Set([7]);
+s.tag = "x";
+console.log("set expando:", s.tag, s.size, s.has(7), JSON.stringify(Object.keys(s)));
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "get: 42\nkeys: [\"foo\"]\nhasOwn: true true\ndata intact: 1 1\n\
+         forin: [\"foo\"]\nset expando: x 1 true [\"tag\"]\n"
+    );
+}
+
+/// The exact shape that took down the CLI app: a lodash-memoize-style cache
+/// (`fn.cache = new Map()`) enumerated by a telemetry helper.
+#[test]
+fn memoize_cache_map_object_keys() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+function memoize(fn: any) {
+  const memoized: any = (...args: any[]) => {
+    const key = args[0];
+    if (memoized.cache.has(key)) return memoized.cache.get(key);
+    const v = fn(...args);
+    memoized.cache.set(key, v);
+    return v;
+  };
+  memoized.cache = new Map();
+  return memoized;
+}
+const f = memoize((x: number) => x * 2);
+f(1); f(2); f(1);
+const K: any = f.cache;
+console.log(typeof K === "object" ? JSON.stringify(Object.keys(K)) : "-");
+console.log("cache works:", f.cache.get(1), f.cache.size);
+"#,
+    );
+    assert_eq!(stdout, "[]\ncache works: 2 2\n");
+}


### PR DESCRIPTION
## Problem

A `Map`/`Set` is a `MapHeader`/`SetHeader` cell, **not** an `ObjectHeader`. Two consequences:

1. **Deterministic SIGSEGV on enumeration** — `Object.keys(new Map())` (also `Object.values`, `Object.entries`, `for…in`) read collection-internal bytes as a `keys_array` pointer and crashed in `js_array_length`'s GC-kind probe:

```ts
Object.keys(new Map());   // SIGSEGV (Node: [])
```

A telemetry path in a large esbuild-bundled CLI app hit this via `Object.keys(cache)` on a lodash-memoize Map cache and took the process down mid-turn. Because the faulting read was a *constant* fabricated pointer (MapHeader offset-16 bytes, landing in reserved VA space), it masqueraded as GC heap corruption for a long time.

2. **Silent memory corruption on expando writes** — `m.foo = 42` bit-cast the MapHeader as an ObjectHeader and overwrote collection-internal fields, then crashed on the next enumeration.

## Fix

- **`ExoticKind::{Map, Set}`** (`exotic_expando.rs`): expando get/set/has/delete route through the exotic side table — the same mechanism as Date/RegExp/Error/Temporal/Promise (whose Promise doc comment already describes this exact bug shape: *"plain property write must land in the side table rather than being bit-cast through the ObjectHeader field path"*). Movable, rekeyed on GC move like Promise (the move hook is address-keyed and kind-agnostic). All `ExoticKind` matches extended.
- **`js_object_keys` / `js_object_values` / `js_object_entries`**: early registered-Map/Set guards enumerate exactly the side-table expandos — collection DATA lives in internal slots, so Node returns `[]` for `Object.keys(new Map([...]))`. `for…in` flows through keys.
- **Value-read arms** (`get_field_by_name_tail.rs`): the registry-detected Set arm and the GC-type Map arm consult the expando table after `size`/method-value resolution; the Map arm now also covers `GC_TYPE_SET` receivers symmetrically.

Audited the other `exotic_expando_kind` consumers (proxy fast-path exclusion, `array/generic.rs` PtrKind, frozen ops, delete-rest, hasOwn): for Map/Set they either keep identical behavior on an empty side table or become expando-correct.

## Tests

New `crates/perry/tests/map_set_object_enumeration.rs` (3 tests, node-oracle-verified):
- all four bare crash cases (keys/values/entries/for-in over Map + Set)
- expando round-trip: write → read → `Object.keys` → `hasOwnProperty`/`Object.hasOwn` → `for…in`, with collection data (`get`/`size`/`has`) intact
- the lodash-memoize cache shape (`fn.cache = new Map()` enumerated by a helper)

`perry-runtime --lib` (1164 tests, single-threaded), weak-collections and shared-promise-adoption suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved `Map` and `Set` support for property access and presence checks, including correct handling of expando properties.
  * `Object.keys`, `Object.values`, `Object.entries`, and `for...in` now enumerate `Map`/`Set` consistently (with expected empty results by default, while expando fields are still readable and enumerable).

* **Bug Fixes**
  * Fixed crashes and incorrect enumeration behavior for `Map`/`Set`.
  * Corrected `hasOwnProperty`/`Object.hasOwn` behavior for `Map`/`Set` when checking built-in vs expando keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->