### PR TITLE
fix(runtime): `<symbol> in <ClassRef>` resolves static symbol members (#6160)

### DIFF
--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -156,11 +156,11 @@ pub(crate) use dispatch::{
 // ── parent_static.rs ────────────────────────────────────────────────────────
 pub(crate) use parent_static::{
     call_registered_static_method, call_static_method, class_chain_has_instance_accessor,
-    class_has_instance_getter, class_has_own_static_method, class_instance_setter_apply,
-    class_method_bind_length, class_own_symbol_member_keys, class_static_accessor_getter_value,
-    class_static_accessor_setter_apply, class_symbol_getter_value, class_symbol_setter_apply,
-    get_parent_class_id, lookup_class_symbol_method_in_chain, lookup_static_method_in_chain,
-    register_class,
+    class_has_instance_getter, class_has_own_static_method, class_has_symbol_member_in_chain,
+    class_instance_setter_apply, class_method_bind_length, class_own_symbol_member_keys,
+    class_static_accessor_getter_value, class_static_accessor_setter_apply,
+    class_symbol_getter_value, class_symbol_setter_apply, get_parent_class_id,
+    lookup_class_symbol_method_in_chain, lookup_static_method_in_chain, register_class,
 };
 pub use parent_static::{
     is_class_object_ptr, is_class_object_value, is_registered_class_prototype_object,

--- a/crates/perry-runtime/src/object/class_registry/parent_static.rs
+++ b/crates/perry-runtime/src/object/class_registry/parent_static.rs
@@ -623,6 +623,51 @@ pub(crate) fn lookup_class_symbol_method_in_chain(
     None
 }
 
+/// Presence-only check (`[[HasProperty]]`, never `[[Get]]`) for a Symbol-keyed
+/// METHOD or ACCESSOR declared on `class_id` or any ancestor. These computed
+/// members register into `CLASS_SYMBOL_METHODS` / `CLASS_SYMBOL_ACCESSORS`, which
+/// the generic symbol resolver (`js_object_get_symbol_property`) does NOT consult
+/// — so `sym in Class` reported false even though `Class[sym](...)` dispatches
+/// fine through the direct-call path. Walks the parent chain like
+/// `lookup_class_symbol_method_in_chain`, but returns a bool and also covers
+/// accessors so a static/instance `get [sym]()` is detected without invoking the
+/// getter. Refs #6160.
+pub(crate) fn class_has_symbol_member_in_chain(
+    class_id: u32,
+    sym_key: usize,
+    is_static: bool,
+) -> bool {
+    let mut cid = class_id;
+    let mut depth = 0usize;
+    while cid != 0 && depth < 32 {
+        let key = (cid, sym_key, is_static);
+        let in_methods = CLASS_SYMBOL_METHODS
+            .read()
+            .ok()
+            .and_then(|g| g.as_ref().map(|m| m.contains_key(&key)))
+            .unwrap_or(false);
+        if in_methods {
+            return true;
+        }
+        let in_accessors = CLASS_SYMBOL_ACCESSORS
+            .read()
+            .ok()
+            .and_then(|g| g.as_ref().map(|m| m.contains_key(&key)))
+            .unwrap_or(false);
+        if in_accessors {
+            return true;
+        }
+        match get_parent_class_id(cid) {
+            Some(p) if p != 0 && p != cid => {
+                cid = p;
+                depth += 1;
+            }
+            _ => break,
+        }
+    }
+    false
+}
+
 pub(crate) fn class_own_symbol_member_keys(class_id: u32, is_static: bool) -> Vec<usize> {
     let mut keys = Vec::new();
     if let Ok(methods) = CLASS_SYMBOL_METHODS.read() {

--- a/crates/perry-runtime/src/object/field_get_set/has_property.rs
+++ b/crates/perry-runtime/src/object/field_get_set/has_property.rs
@@ -3,6 +3,57 @@
 
 use super::*;
 
+/// Presence of a Symbol-keyed STATIC member on a class ref, for `sym in Class`
+/// (#6160). Covers the registration schemes the generic symbol resolver
+/// (`js_object_get_symbol_property`, which only reads the data-valued
+/// CLASS_STATIC_SYMBOLS table) skips:
+///   * user computed-symbol methods/accessors (`static [S]() {}`,
+///     `static get [S]()`) → CLASS_SYMBOL_METHODS / CLASS_SYMBOL_ACCESSORS;
+///   * `static [Symbol.hasInstance]` → the lifted per-class has-instance hook;
+///   * `static [Symbol.iterator]` / `[Symbol.asyncIterator]` → the synthetic
+///     `@@iterator` / `@@asyncIterator` static-method names the HIR renames them
+///     to.
+/// Presence-only — never invokes a getter or method (`in` is [[HasProperty]]).
+/// `Symbol.toStringTag` is deliberately excluded: its getter lives on the
+/// prototype (instance side), so `Symbol.toStringTag in Class` is false in Node.
+unsafe fn class_ref_has_symbol_member(class_id: u32, sym_f64: f64) -> bool {
+    let sym_key = crate::symbol::sym_key_from_f64(sym_f64);
+    if sym_key == 0 {
+        return false;
+    }
+    if crate::object::class_registry::class_has_symbol_member_in_chain(class_id, sym_key, true) {
+        return true;
+    }
+    let wk_key = |name: &str| -> usize {
+        let s = crate::symbol::well_known_symbol(name);
+        if s.is_null() {
+            0
+        } else {
+            crate::symbol::sym_key_from_f64(f64::from_bits(
+                crate::value::JSValue::pointer(s as *const u8).bits(),
+            ))
+        }
+    };
+    let hi = wk_key("hasInstance");
+    if hi != 0 && sym_key == hi && crate::object::lookup_has_instance_hook(class_id).is_some() {
+        return true;
+    }
+    for (wk, name) in [
+        ("iterator", "@@iterator"),
+        ("asyncIterator", "@@asyncIterator"),
+    ] {
+        let k = wk_key(wk);
+        if k != 0
+            && sym_key == k
+            && crate::object::class_registry::lookup_static_method_in_chain(class_id, name)
+                .is_some()
+        {
+            return true;
+        }
+    }
+    false
+}
+
 /// Render a value the way V8 does inside the `in`-operator TypeError message.
 /// Only the primitive RHS shapes that reach `throw_in_operator_non_object` need
 /// handling: `null`/`undefined` render literally, a Symbol as `Symbol(desc)`,
@@ -152,6 +203,21 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
             && crate::value::addr_class::is_handle_band(addr)
         {
             return nanbox_false;
+        }
+    }
+
+    // #6160: `Symbol in Class` where the member is a Symbol-keyed STATIC member
+    // that registers through a scheme the generic symbol resolver below
+    // (`js_object_get_symbol_property`) does not consult — it only sees the
+    // data-valued CLASS_STATIC_SYMBOLS table. `class_ref_has_symbol_member`
+    // presence-checks the method/accessor and well-known static registrations,
+    // so `sym in Class` matches Node even though those members dispatch through
+    // dedicated call paths. Presence-only: `in` is [[HasProperty]], never [[Get]].
+    if unsafe { crate::symbol::js_is_symbol(key) } != 0 {
+        if let Some(class_id) = crate::object::class_ref_id(obj) {
+            if unsafe { class_ref_has_symbol_member(class_id, key) } {
+                return nanbox_true;
+            }
         }
     }
 

--- a/crates/perry-runtime/src/symbol/properties.rs
+++ b/crates/perry-runtime/src/symbol/properties.rs
@@ -400,6 +400,21 @@ pub unsafe extern "C" fn js_object_set_symbol_property(
     sym_f64: f64,
     value_f64: f64,
 ) -> f64 {
+    // #6160: a runtime symbol assignment onto a class constructor
+    // (`(C as any)[sym] = v`) targets an INT32-tagged class ref, which has no
+    // heap address — `set_symbol_property` keys the own-symbol side table by
+    // `obj_key_from_f64`, which returns 0 for a non-pointer receiver, so the
+    // write was silently dropped and `sym in C` / `C[sym]` came back undefined.
+    // Store it as a static Symbol-keyed member (CLASS_STATIC_SYMBOLS), the same
+    // table `static [sym] = v` uses and that the class-ref arms of
+    // `js_object_get_symbol_property` / `js_object_has_property` already read.
+    if let Some(class_id) = crate::object::class_ref_id(obj_f64) {
+        let sym_key = sym_key_from_f64(sym_f64);
+        if sym_key != 0 {
+            super::store_class_static_symbol_root(class_id, sym_key, value_f64.to_bits());
+            return value_f64;
+        }
+    }
     set_symbol_property(obj_f64, sym_f64, value_f64)
 }
 


### PR DESCRIPTION
## Summary

`<symbol> in <ClassRef>` returned `false` for symbol-keyed **static** members whereas Node returns `true`. Symbol keys are intercepted early in `js_object_has_property` by the generic symbol resolver (`js_object_get_symbol_property`), which only reads the data-valued `CLASS_STATIC_SYMBOLS` table — so every other class-ref symbol registration scheme was missed, and the check short-circuited to `false` before the class-ref arm could see the member.

Fixes #6160.

## What was broken

```ts
class D { static [Symbol.hasInstance]() { return false; } }
Symbol.hasInstance in D;          // node: true   perry (before): false

class K {}
const s = Symbol.for("t");
(K as any)[s] = 1;
s in K;                           // node: true   perry (before): false
```

Root cause spanned **four** distinct registration paths the resolver didn't consult:

| Member shape | Registers into | 
|---|---|
| `static [S]() {}` / `static get [S]()` (user symbol) | `CLASS_SYMBOL_METHODS` / `CLASS_SYMBOL_ACCESSORS` |
| `static [Symbol.hasInstance]` | lifted per-class has-instance hook |
| `static [Symbol.iterator]` / `[Symbol.asyncIterator]` | synthetic `@@iterator` / `@@asyncIterator` static-method names |
| runtime `(C as any)[sym] = v` | *silently dropped* (INT32 class ref has no heap address; `obj_key_from_f64` → 0) |

## Fix

- **`has_property.rs`** — before the generic symbol path, a class-ref receiver consults a new `class_ref_has_symbol_member` presence helper covering user methods/accessors + the well-known static hooks/names. Presence-only (`in` is `[[HasProperty]]`, so no getter/method is invoked). `Symbol.toStringTag` is intentionally excluded — its getter lives on the prototype (instance side), so `Symbol.toStringTag in Class` is `false` in Node.
- **`parent_static.rs`** — new `class_has_symbol_member_in_chain`: walks the parent chain like the existing method lookup, returns a bool, and also covers accessors.
- **`symbol/properties.rs`** — `js_object_set_symbol_property` now routes a registered class-ref target into `CLASS_STATIC_SYMBOLS` (the same table `static [sym] = v` uses and that the class-ref GET/has arms already read), so both `sym in C` and `C[sym]` see a runtime assignment. Previously this write hit `obj_key == 0` and was a silent no-op.

## Validation

Byte-for-byte vs `node --experimental-strip-types`:

- Both issue repros → `true`.
- User symbol method / accessor / inheritance-chain / absent-symbol / overwrite / GET-after-SET — all match.
- **No regression**: `instanceof` dispatch (hasInstance still fires), static-**data**-symbol `in` (`static [sym] = v`), string-key `in` (`"prototype" in C`), and primitive-RHS `TypeError` are unaffected.
- 14 symbol/class/`in`/instanceof gap tests pass; `cargo fmt` clean; GC store-site inventory clean.

Code-only per contributor convention (no version/CHANGELOG bump).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for checking Symbol-keyed static members on classes using the `in` operator.

* **Bug Fixes**
  * Fixed Symbol-keyed static property assignments on class constructors so they are stored correctly.
  * Improved Symbol member lookup across parent classes, including common well-known Symbol-based members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->