### PR TITLE
fix(runtime): WeakMap/WeakSet no longer leak `__perry_wk_entries` through enumeration (#6120)

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set/enumeration.rs
+++ b/crates/perry-runtime/src/object/field_get_set/enumeration.rs
@@ -875,18 +875,19 @@ pub(crate) unsafe fn instance_private_key_hidden(
         .unwrap_or(false)
 }
 
-/// True for perry's hidden runtime-internal own keys — currently exactly the
+/// True for perry's hidden runtime-internal own keys — the
 /// `__perry_collection_backing__` field stashed on a `class … extends Map/Set`
-/// instance. This physically lives in the instance keys_array but must NEVER
+/// instance, and the `__perry_wk_entries` field backing a `WeakMap`/`WeakSet`
+/// (#6120). These physically live in the object's keys_array but must NEVER
 /// surface to `Object.keys` / `for…in` / `Object.getOwnPropertyNames` /
 /// `JSON.stringify` / `Object.hasOwn` / `hasOwnProperty` / `propertyIsEnumerable`.
 ///
-/// Matches the backing key EXACTLY (an allowlist), not a broad `__perry_*`
-/// prefix — a prefix test would wrongly hide legitimate user properties whose
-/// name happens to begin with `__perry_` (e.g. `this.__perry_user = 1`).
+/// Matches each key EXACTLY (an allowlist), not a broad `__perry_*` prefix — a
+/// prefix test would wrongly hide legitimate user properties whose name happens
+/// to begin with `__perry_` (e.g. `this.__perry_user = 1`).
 #[inline]
 pub(crate) fn is_internal_runtime_key_bytes(b: &[u8]) -> bool {
-    b == crate::object::map_set_subclass::BACKING_KEY
+    b == crate::object::map_set_subclass::BACKING_KEY || b == crate::weakref::WEAK_ENTRIES_KEY
 }
 
 /// `&str` form of [`is_internal_runtime_key_bytes`].

--- a/crates/perry-runtime/src/weakref.rs
+++ b/crates/perry-runtime/src/weakref.rs
@@ -827,6 +827,17 @@ unsafe fn weak_entry_at(entries: *mut ArrayHeader, i: usize) -> *mut ObjectHeade
 pub const CLASS_ID_WEAKMAP: u32 = 0xFFFF_0027;
 pub const CLASS_ID_WEAKSET: u32 = 0xFFFF_0028;
 
+/// Sentinel name of the internal slot-0 field that backs a `WeakMap`/`WeakSet`
+/// with its `[k, v]`-pair entry array (`js_weakmap_new` / `js_weakset_new`).
+/// `WeakMap`/`WeakSet` are `GC_TYPE_OBJECT`s, so this is an own enumerable
+/// string key — it must NEVER surface through any enumeration surface
+/// (`Object.keys` / `Object.assign` / spread / `JSON.stringify` / `for…in` /
+/// `hasOwnProperty`). Hidden via `is_internal_runtime_key_bytes`, exactly like
+/// the `class … extends Map/Set` backing key. Internal reads go through
+/// `entries_array` by direct name lookup, so hiding it from enumeration is
+/// safe. Refs #6120.
+pub(crate) const WEAK_ENTRIES_KEY: &[u8] = b"__perry_wk_entries";
+
 /// Dynamic-dispatch entry point for WeakMap/WeakSet method calls (issue
 /// #1757/#1758). `js_native_call_method` calls this for any heap object;
 /// it returns `Some(result)` only when `obj` carries the reserved


### PR DESCRIPTION
## Summary

`WeakMap`/`WeakSet` exposed an internal `__perry_wk_entries` key through every enumeration surface; Node exposes none (a `WeakMap`/`WeakSet` has no own enumerable properties).

Fixes #6120.

```js
const wm = new WeakMap();
JSON.stringify(Object.assign({ k: 9 }, wm));  // node: {"k":9}  perry(before): {"k":9,"__perry_wk_entries":[]}
JSON.stringify({ ...wm });                     // node: {}       perry(before): {"__perry_wk_entries":[]}
Object.keys(wm);                               // node: []       perry(before): ["__perry_wk_entries"]
JSON.stringify(wm);                            // node: {}       perry(before): {"__perry_wk_entries":[]}
```

## Root cause

`WeakMap`/`WeakSet` are `GC_TYPE_OBJECT`s whose slot-0 field (`__perry_wk_entries`) holds the `[k, v]`-pair entry array. #1766 renamed it to a sentinel so `wm.entries` reads back `undefined`, but it stayed an own **enumerable** string key.

## Fix

Add the sentinel to `is_internal_runtime_key_bytes` — the existing exact-match allowlist that already hides the `class … extends Map/Set` backing key (`__perry_collection_backing__`) from `Object.keys` / `for…in` / `getOwnPropertyNames` / `JSON.stringify` / `hasOwnProperty` / `Object.hasOwn` / `propertyIsEnumerable`. `WeakMap`/`WeakSet` objects carry `class_id != 0`, so they take the filtering enumeration path where this allowlist is consulted; every surface converges on it, so a one-line allowlist addition covers them all.

- A new `weakref::WEAK_ENTRIES_KEY` constant is the single source of truth for the sentinel (mirroring `map_set_subclass::BACKING_KEY`).
- Internal reads go through `entries_array` by **direct name lookup**, not enumeration, so hiding the key from enumeration does not affect WeakMap/WeakSet operation.
- Descriptor-based non-enumerability was rejected — it would trip the process-wide `GLOBAL_DESCRIPTORS_IN_USE` deopt (#6084).

## Validation

Byte-for-byte vs `node --experimental-strip-types`:
- All surfaces clean for both `WeakMap` **and** `WeakSet`: `Object.assign`, spread, `Object.keys`/`values`/`entries`, `JSON.stringify`, `for…in`, `getOwnPropertyNames`, `Reflect.ownKeys`, `hasOwnProperty`, `Object.hasOwn`, `propertyIsEnumerable`.
- `wm.set`/`get`/`has` still work.
- **No regression** to the shared `extends Map/Set` backing-key hiding (14 collection/enumeration gap tests green).
- `cargo fmt` + GC store-site inventory clean.

Code-only per contributor convention (no version/CHANGELOG bump).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved object enumeration and reflection so hidden backing data for `WeakMap` and `WeakSet` no longer appears in results.
  * Kept internal storage for collection types consistently excluded from user-visible key listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->