### PR TITLE
fix(hir): flatten spread args into native-instance NA_VARARGS methods

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/static_and_instance.rs
+++ b/crates/perry-hir/src/lower/expr_call/static_and_instance.rs
@@ -273,6 +273,22 @@ pub(super) fn try_static_method_and_instance(
                         // Fall through — let the regular method-call
                         // dispatch further down handle the user-class
                         // method.
+                    } else if static_call_has_spread {
+                        // A spread argument (`recv.method(...arr)`) cannot be
+                        // represented in `NativeMethodCall`'s positional `args`:
+                        // the pre-lowered `args` already collapsed the spread
+                        // SOURCE into a single element, and the codegen
+                        // `NA_VARARGS` packer then pushes that array as ONE
+                        // argument instead of flattening it. The static-method
+                        // arms above already guard on `static_call_has_spread`
+                        // for the same reason; the instance arm was missing it.
+                        // Concretely, `AsyncLocalStorage.run(store, cb, ...args)`
+                        // handed the callback a single array instead of its
+                        // forwarded arguments. Fall through to the generic
+                        // `CallSpread` path (function tail `Ok(Err(args))`),
+                        // which materialises + flattens the spread via
+                        // `js_array_concat` before dispatching the native method
+                        // by name.
                     } else {
                         // Get the object expression (the instance variable)
                         let object_expr = lower_expr(ctx, &member.obj)?;

--- a/test-files/test_gap_als_run_spread_args.ts
+++ b/test-files/test_gap_als_run_spread_args.ts
@@ -1,0 +1,47 @@
+// A spread argument forwarded into a native-instance method with a
+// `NA_VARARGS` tail (`AsyncLocalStorage.prototype.run(store, cb, ...args)`)
+// must be FLATTENED into individual arguments, not passed as a single array.
+//
+// The HIR instance-method arm produced a `NativeMethodCall` for the spread
+// call using pre-lowered positional args (which collapse the spread source
+// into one element); the `NA_VARARGS` packer then pushed that array as ONE
+// argument. So `als.run(store, cb, ...[1, 2, 3])` handed `cb` a single
+// `[1,2,3]` array instead of `1, 2, 3`. The static-method arms already
+// guarded on `static_call_has_spread`; the instance arm was missing it, so
+// spread instance calls now fall through to the flattening `CallSpread` path.
+//
+// Next.js wraps the whole app render in
+// `workUnitAsyncStorage.run(store, renderFn, ...args)`, so a collapsed spread
+// silently corrupted the forwarded arguments.
+//
+// Validated byte-for-byte against `node --experimental-strip-types`.
+
+import { AsyncLocalStorage } from "async_hooks";
+
+const als = new AsyncLocalStorage<{ s: number }>();
+const arr = [1, 2, 3];
+
+// spread of an array literal
+console.log(als.run({ s: 1 }, (...a: number[]) => a.length, ...[1, 2, 3]));
+
+// spread of a variable
+console.log(als.run({ s: 1 }, (...a: number[]) => a.length, ...arr));
+
+// mixed literal + spread + literal
+console.log(als.run({ s: 1 }, (...a: number[]) => a.length, 0, ...arr, 9));
+
+// forwarded args reach the callback in order and with correct values
+console.log(als.run({ s: 1 }, (x: number, y: number, z: number) => x + y + z, ...arr));
+
+// nested run(store, fn, ...restParam): the classic Next render shape
+const outer = new AsyncLocalStorage<{ o: number }>();
+const inner = new AsyncLocalStorage<{ i: number }>();
+const nested = outer.run(
+  { o: 1 },
+  (fn: (a: number, b: number) => number, ...args: number[]) =>
+    inner.run({ i: 2 }, fn, ...args),
+  (a: number, b: number) => a + b,
+  100,
+  200,
+);
+console.log(nested);


### PR DESCRIPTION
## Problem

A spread argument forwarded into a **native-instance method** whose signature ends in `NA_VARARGS` was passed to the callee as a **single array** instead of being flattened.

The clearest case is `AsyncLocalStorage.prototype.run(store, cb, ...args)`:

```ts
import { AsyncLocalStorage } from "async_hooks";
const als = new AsyncLocalStorage();
als.run({}, (...a) => a.length, ...[1, 2, 3]);   // Node: 3 — Perry (before): 1
als.run({}, (...a) => a.length, 0, ...[1,2,3], 9); // Node: 5 — Perry (before): 3
```

The callback received a single `[1,2,3]` array as one argument. Plain `fn(...arr)`, `Math.max(...arr)`, and `arr.push(...arr)` were already correct — only native-instance `NA_VARARGS` methods were affected.

## Root cause

`crates/perry-hir/src/lower/expr_call/static_and_instance.rs` — the generic native-**instance**-method arm produced a `NativeMethodCall` using the pre-lowered positional `args`. A spread `...arr` collapses to a bare `arr` `Expr` there (the spread flag lives on the AST `CallArg`, not the lowered `Expr`), and the codegen `NA_VARARGS` packer (`native_module_dispatch.rs`) then `js_array_push_f64`'d that array as **one** element.

The static-method arms in the same function already guard on `static_call_has_spread` and fall through for spread calls; the instance arm was missing the same guard.

## Fix

One arm: add `else if static_call_has_spread { /* fall through */ }` before the `NativeMethodCall` production. A spread instance call now falls through to the generic `CallSpread` path, which materialises + flattens the spread (`js_array_concat`) before dispatching the native method by name (the runtime handler already unpacks the flattened args correctly).

## Validation

`test_gap_als_run_spread_args.ts` (added) covers spread-of-literal, spread-of-var, mixed, argument-order/values, and the nested `run(store, fn, ...restParam)` shape — all byte-identical to `node --experimental-strip-types`. Found while investigating the Next.js force-dynamic render hang (#5989); Next wraps its render in `workUnitAsyncStorage.run(store, renderFn, ...args)`, so a collapsed spread silently corrupts forwarded render arguments. (This is a general fix, not #5989-specific; the specific #5989 render hang has a separate remaining cause.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed native instance method calls so spread arguments are now forwarded correctly instead of being grouped into a single array-like argument.
  * Improved argument handling for callbacks and nested method calls, preserving the correct order and values when using spread syntax.
* **Tests**
  * Added coverage for spread-argument scenarios to prevent regressions in instance method invocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->