### PR TITLE
fix(gc): Map 16M walk bound, old→malloc remembered edges, step-scanner parity, barriers-off soundness

### DIFF
--- a/crates/perry-runtime/src/gc/barrier.rs
+++ b/crates/perry-runtime/src/gc/barrier.rs
@@ -1061,13 +1061,17 @@ pub(super) fn remembered_child_needs_tracking(child_addr: usize) -> bool {
         crate::arena::HeapGeneration::Unknown => {
             // Non-arena child: candidate malloc-GC object (RegExp, Symbol,
             // hook-mode Promise, grown string, large-capture closure).
-            // Band-guard before the header sniff — handle-band ids below
-            // HANDLE_BAND_MAX are small integers, not dereferenceable
-            // addresses. A false positive here only dirties a page
-            // (correctness-safe rescan); the exact membership checks run
-            // at scan time against the valid-pointer set.
-            child_addr >= crate::value::addr_class::HANDLE_BAND_MAX
-                && malloc_gc_parent_addr(child_addr)
+            // EXACT malloc-registry membership — deliberately not a header
+            // sniff: barrier child values can be uninitialized slot
+            // contents (array-growth barrier replay passes raw slot bits),
+            // and a plausibility sniff on garbage dirtied pages whose
+            // dirty-scan then treated neighboring garbage slots as movable
+            // young pointers. Band ids and foreign pointers are never in
+            // the registry, so this also needs no pre-deref band guard.
+            child_addr > GC_HEADER_SIZE
+                && super::malloc::gc_malloc_header_is_tracked(
+                    (child_addr - GC_HEADER_SIZE) as *const GcHeader,
+                )
         }
     }
 }

--- a/crates/perry-runtime/src/gc/barrier.rs
+++ b/crates/perry-runtime/src/gc/barrier.rs
@@ -1027,10 +1027,7 @@ pub(super) fn write_barrier_slot_inner(
         bump_write_barrier_trace_counter(BarrierTraceCounter::ParentNotOldSkips);
         return;
     }
-    if !matches!(
-        crate::arena::classify_heap_generation(child_addr),
-        crate::arena::HeapGeneration::Nursery
-    ) {
+    if !remembered_child_needs_tracking(child_addr) {
         bump_write_barrier_trace_counter(BarrierTraceCounter::ChildNotYoungSkips);
         return;
     }
@@ -1044,6 +1041,34 @@ pub(super) fn write_barrier_slot_inner(
     };
     if inserted {
         bump_write_barrier_trace_counter(BarrierTraceCounter::NewInserts);
+    }
+}
+
+/// Which stored children must an old parent's slot be remembered for?
+/// Minor GCs sweep BOTH the nursery and the malloc registry, and old
+/// parents are black leaves in minors — so an unremembered old→nursery OR
+/// old→malloc edge leaves the child unmarked: the nursery sweep or the
+/// malloc sweep frees it while live (and a malloc child's own nursery
+/// children die with it, since marked malloc objects are the only path
+/// that traces them). Longlived and old children need no remembering:
+/// longlived is never swept individually and old is reclaimed only by
+/// full cycles that trace everything.
+#[inline]
+pub(super) fn remembered_child_needs_tracking(child_addr: usize) -> bool {
+    match crate::arena::classify_heap_generation(child_addr) {
+        crate::arena::HeapGeneration::Nursery => true,
+        crate::arena::HeapGeneration::Old | crate::arena::HeapGeneration::Longlived => false,
+        crate::arena::HeapGeneration::Unknown => {
+            // Non-arena child: candidate malloc-GC object (RegExp, Symbol,
+            // hook-mode Promise, grown string, large-capture closure).
+            // Band-guard before the header sniff — handle-band ids below
+            // HANDLE_BAND_MAX are small integers, not dereferenceable
+            // addresses. A false positive here only dirties a page
+            // (correctness-safe rescan); the exact membership checks run
+            // at scan time against the valid-pointer set.
+            child_addr >= crate::value::addr_class::HANDLE_BAND_MAX
+                && malloc_gc_parent_addr(child_addr)
+        }
     }
 }
 

--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -613,7 +613,11 @@ impl CopyingNurseryCollector {
             let parent_user = (parent_header as *mut u8).add(GC_HEADER_SIZE) as usize;
             if barrier_parent_needs_remembering(parent_user, external) {
                 if let Some((child_addr, _, _)) = self.ptrs.decode_bits(*slot) {
-                    if crate::arena::pointer_in_nursery(child_addr) {
+                    // Keep old→malloc pages dirty alongside old→nursery:
+                    // the malloc child is spared by this cycle's mark
+                    // (mark_addr handles CopyingPointerKind::Malloc) but
+                    // the NEXT minor's malloc sweep needs the edge again.
+                    if crate::gc::barrier::remembered_child_needs_tracking(child_addr) {
                         self.sticky.remember_slot(parent_header, slot, external);
                     }
                 }

--- a/crates/perry-runtime/src/gc/layout.rs
+++ b/crates/perry-runtime/src/gc/layout.rs
@@ -1315,7 +1315,13 @@ pub(super) unsafe fn visit_gc_rewrite_slot_descriptors(
             let map = user_ptr as *mut crate::map::MapHeader;
             let size = (*map).size;
             let capacity = (*map).capacity;
-            if size > capacity || size > 100_000 || (*map).entries.is_null() {
+            // Corruption guard only: mirror Set's 16M bound (set.rs
+            // gc_element_slot_range). Every GC walk (mark, copy, rewrite,
+            // dirty-scan, verify) funnels through this descriptor, so a
+            // lower cap makes larger maps invisible to the collector —
+            // entries reachable only through a >cap map would be swept
+            // while live and never rewritten after a move.
+            if size > capacity || size > 16_000_000 || (*map).entries.is_null() {
                 return;
             }
             visit(GcMutableSlotDescriptor::Range {

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -72,6 +72,13 @@ pub fn gc_collect_minor() -> u64 {
 }
 
 pub(super) fn gc_collect_minor_with_trigger(trigger: GcTriggerSnapshot) -> GcCollectOutcome {
+    // Barriers-off ⇒ the remembered set is not being maintained, and a
+    // minor's black-leafed old parents would hide live children. Route
+    // every caller (direct arm, moving-safepoint arm, public FFI) to the
+    // full collection instead of trusting an empty RS.
+    if !gen_gc_enabled() {
+        return gc_collect_full_mark_sweep_with_trigger(trigger);
+    }
     // Phase C4b-γ-3: re-entrancy guard. Without this, the evacuation
     // pass's `arena_alloc_gc_old` can trigger `gc_check_trigger` (via
     // `arena.alloc`'s slow-path block-fill) DURING the outer collection
@@ -167,6 +174,17 @@ pub fn gen_gc_enabled() -> bool {
     use std::sync::OnceLock;
     static CACHED: OnceLock<bool> = OnceLock::new();
     *CACHED.get_or_init(|| {
+        // Generational minors are only sound with runtime write barriers:
+        // minors black-leaf old parents and trust the remembered set for
+        // every old→young/old→malloc edge. `PERRY_WRITE_BARRIERS=0` used
+        // to disable only evacuation gating while minors kept running —
+        // the remembered set stayed empty, so a born-old (>16 KB) parent's
+        // nursery children were swept on the first minor and the
+        // "bisection" mode crashed for reasons unrelated to what was being
+        // bisected. Barriers off now means full mark-sweep only.
+        if !write_barriers_enabled() {
+            return false;
+        }
         !matches!(
             std::env::var("PERRY_GEN_GC").as_deref(),
             Ok("0") | Ok("off") | Ok("false")

--- a/crates/perry-runtime/src/gc/tests/barrier.rs
+++ b/crates/perry-runtime/src/gc/tests/barrier.rs
@@ -1786,3 +1786,45 @@ fn test_minor_gc_promotes_after_two_survivals() {
         );
     }
 }
+
+// Regression (2026-07 GC audit, old→malloc hole): the fallback minor's
+// remembered-set scan used to seed only NURSERY children; a malloc-GC child
+// on a dirty old page stayed unmarked and the minor malloc sweep freed it.
+// Exercises both halves of the fix: the barrier recording the old→malloc
+// edge and `try_mark_young_user_ptr_as_seed` accepting malloc children.
+#[test]
+fn test_remembered_set_scan_marks_malloc_child_of_old_parent() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    reset_remembered_set();
+    clear_marks();
+    activate_malloc_registry_for_tests();
+
+    let malloc_child = gc_malloc(
+        std::mem::size_of::<crate::closure::ClosureHeader>(),
+        GC_TYPE_CLOSURE,
+    );
+    unsafe {
+        init_test_closure(malloc_child);
+    }
+    let (old_arr, elements) = unsafe { alloc_old_test_array(1) };
+    unsafe {
+        *elements = ptr_bits(malloc_child as usize);
+    }
+    js_write_barrier_slot(
+        ptr_bits(old_arr as usize),
+        elements as u64,
+        ptr_bits(malloc_child as usize),
+    );
+    assert!(
+        remembered_set_size() > 0,
+        "old→malloc store must dirty the remembered page"
+    );
+
+    let valid_ptrs = build_valid_pointer_set();
+    mark_remembered_set_roots(&valid_ptrs);
+    assert_heap_child_marked(malloc_child as *const u8, "malloc child of old parent");
+
+    reset_remembered_set();
+    clear_marks();
+}

--- a/crates/perry-runtime/src/gc/tests/barrier.rs
+++ b/crates/perry-runtime/src/gc/tests/barrier.rs
@@ -1144,7 +1144,7 @@ fn test_dirty_page_promise_value_slot_marks_child() {
     remembered_set_clear();
 }
 
-fn assert_heap_child_marked(ptr: *const u8, label: &str) {
+pub(super) fn assert_heap_child_marked(ptr: *const u8, label: &str) {
     assert!(!ptr.is_null(), "{label} should not be null");
     unsafe {
         let header = header_from_user_ptr(ptr);

--- a/crates/perry-runtime/src/gc/tests/copying.rs
+++ b/crates/perry-runtime/src/gc/tests/copying.rs
@@ -1358,12 +1358,17 @@ fn malloc_backed_large_closure_capture_in_old_container_survives_copied_minor() 
     assert!(crate::arena::pointer_in_nursery(captured_after));
     assert_eq!(trace.copying_nursery.copied_objects, 1);
     assert_eq!(trace.copying_nursery.copied_bytes, child_total);
-    assert_eq!(trace.remembered_set.dirty_pages_before, 1);
-    assert_eq!(trace.remembered_set.dirty_pages_scanned, 1);
-    assert_eq!(trace.remembered_set.dirty_objects_scanned, 1);
+    // Two remembered entries since the old→malloc fix: the external
+    // capture-page entry (closure→young child) AND the old array's element
+    // page (old→malloc edge). The latter is what keeps this malloc-backed
+    // closure alive across minor malloc sweeps when the old container is
+    // its only referrer.
+    assert_eq!(trace.remembered_set.dirty_pages_before, 2);
+    assert_eq!(trace.remembered_set.dirty_pages_scanned, 2);
+    assert_eq!(trace.remembered_set.dirty_objects_scanned, 2);
     assert!(
-        (1..=512).contains(&trace.remembered_set.dirty_slots_scanned),
-        "one dirty closure-capture page should bound copied-minor scanning"
+        (1..=1024).contains(&trace.remembered_set.dirty_slots_scanned),
+        "two dirty pages (capture page + old element page) should bound copied-minor scanning"
     );
     assert!(
         remembered_set_size() > 0,
@@ -1375,10 +1380,18 @@ fn malloc_backed_large_closure_capture_in_old_container_survives_copied_minor() 
     }
     let promoted = unsafe { (*capture_slot & POINTER_MASK) as usize };
     assert!(crate::arena::pointer_in_old_gen(promoted));
+    // The capture's external entry clears once the capture points old, but
+    // the old array's element page stays remembered: its old→malloc edge
+    // must keep protecting the closure from minor malloc sweeps.
+    assert!(
+        malloc_user_ptr_tracked(closure as *mut u8),
+        "malloc-backed closure must remain tracked while its old container lives"
+    );
     assert_eq!(
         remembered_set_size(),
-        0,
-        "external dirty tracking should clear once the capture no longer points to young gen"
+        1,
+        "only the old→malloc element page should remain remembered once the \
+         capture no longer points to young gen"
     );
 }
 

--- a/crates/perry-runtime/src/gc/tests/copying/survival_and_malloc.rs
+++ b/crates/perry-runtime/src/gc/tests/copying/survival_and_malloc.rs
@@ -629,3 +629,95 @@ fn test_copying_minor_falls_back_for_transitive_pinned_young_child() {
         (*child_header).gc_flags &= !GC_FLAG_PINNED;
     }
 }
+
+// Regression (2026-07 GC audit, old→malloc hole): minors sweep the malloc
+// registry, old parents are black leaves, and the barrier used to remember
+// only old→NURSERY children — a malloc-GC child (RegExp, hook-mode Promise,
+// Symbol, large-capture closure) whose sole referrer was a clean old parent
+// was freed while live on the next MallocCount/ArenaBytes minor.
+#[test]
+fn test_copying_minor_old_to_malloc_child_survives_sweep() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    activate_malloc_registry_for_tests();
+
+    let malloc_child = gc_malloc(
+        std::mem::size_of::<crate::closure::ClosureHeader>(),
+        GC_TYPE_CLOSURE,
+    );
+    unsafe {
+        init_test_closure(malloc_child);
+    }
+    let (old_arr, elements) = unsafe { alloc_old_test_array(1) };
+    unsafe {
+        *elements = ptr_bits(malloc_child as usize);
+    }
+    js_write_barrier_slot(
+        ptr_bits(old_arr as usize),
+        elements as u64,
+        ptr_bits(malloc_child as usize),
+    );
+    assert!(
+        remembered_set_size() > 0,
+        "old→malloc store must dirty the remembered page"
+    );
+
+    trigger_guard.make_malloc_sweep_due();
+    let _ = gc_collect_minor_with_trigger(GcTriggerSnapshot {
+        kind: GcTriggerKind::ArenaBytes,
+        steps_before: Some(GcStepSnapshot::current()),
+    });
+
+    assert!(
+        malloc_user_ptr_tracked(malloc_child),
+        "malloc child referenced only by a clean old parent must survive \
+         the minor malloc sweep via the remembered old→malloc edge"
+    );
+}
+
+// Same hole, scenario B: the nursery GRANDCHILD behind an unmarked malloc
+// parent needs no malloc sweep to die — the malloc parent was never marked
+// in a minor, so its nursery child was unmarked and the nursery reset freed
+// it on the very next minor.
+#[test]
+fn test_copying_minor_old_to_malloc_nursery_grandchild_survives() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    activate_malloc_registry_for_tests();
+
+    let grandchild = young_leaf();
+    let malloc_child = gc_malloc(
+        std::mem::size_of::<crate::closure::ClosureHeader>() + 8,
+        GC_TYPE_CLOSURE,
+    );
+    let capture_slot = unsafe {
+        init_test_closure_with_one_capture(malloc_child, ptr_bits(grandchild))
+    };
+    let (old_arr, elements) = unsafe { alloc_old_test_array(1) };
+    unsafe {
+        *elements = ptr_bits(malloc_child as usize);
+    }
+    js_write_barrier_slot(
+        ptr_bits(old_arr as usize),
+        elements as u64,
+        ptr_bits(malloc_child as usize),
+    );
+
+    trigger_guard.make_malloc_sweep_due();
+    let _ = gc_collect_minor_with_trigger(GcTriggerSnapshot {
+        kind: GcTriggerKind::ArenaBytes,
+        steps_before: Some(GcStepSnapshot::current()),
+    });
+
+    assert!(
+        malloc_user_ptr_tracked(malloc_child),
+        "malloc parent must survive the minor via the remembered edge"
+    );
+    let grandchild_after = unsafe { (*capture_slot & POINTER_MASK) as usize };
+    assert!(
+        crate::arena::pointer_in_nursery(grandchild_after)
+            || crate::arena::pointer_in_old_gen(grandchild_after),
+        "nursery grandchild behind a malloc parent must be evacuated/kept, \
+         not left dangling in reset from-space"
+    );
+}

--- a/crates/perry-runtime/src/gc/tests/copying/survival_and_malloc.rs
+++ b/crates/perry-runtime/src/gc/tests/copying/survival_and_malloc.rs
@@ -690,9 +690,8 @@ fn test_copying_minor_old_to_malloc_nursery_grandchild_survives() {
         std::mem::size_of::<crate::closure::ClosureHeader>() + 8,
         GC_TYPE_CLOSURE,
     );
-    let capture_slot = unsafe {
-        init_test_closure_with_one_capture(malloc_child, ptr_bits(grandchild))
-    };
+    let capture_slot =
+        unsafe { init_test_closure_with_one_capture(malloc_child, ptr_bits(grandchild)) };
     let (old_arr, elements) = unsafe { alloc_old_test_array(1) };
     unsafe {
         *elements = ptr_bits(malloc_child as usize);

--- a/crates/perry-runtime/src/gc/tests/cycle_state.rs
+++ b/crates/perry-runtime/src/gc/tests/cycle_state.rs
@@ -1,4 +1,5 @@
 use super::super::*;
+use super::barrier::assert_heap_child_marked;
 use super::support::*;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;

--- a/crates/perry-runtime/src/gc/tests/cycle_state.rs
+++ b/crates/perry-runtime/src/gc/tests/cycle_state.rs
@@ -1354,3 +1354,47 @@ fn full_cycle_console_singleton_store_after_root_scan_preserves_new_value() {
     );
     crate::builtins::test_set_console_log_singleton(0);
 }
+
+// Regression (2026-07 GC audit, sync/step scanner divergence): cycle-based
+// collections run ONLY the budgeted STEP scanner when one is registered, and
+// the promise step machine lacked the PROMISE_OVERFLOW_REACTIONS phase its
+// sync twin visits — the 2nd+ `.then()` on a still-pending promise parks its
+// reaction closure and chained `next` promise ONLY in that table, so every
+// full/fallback collection swept them while the promise was pending.
+#[test]
+fn full_cycle_step_scanner_covers_promise_overflow_reactions() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    gc_register_budgeted_mutable_root_scanner_with_source(
+        promise_mutable_root_scanner,
+        crate::promise::scan_promise_roots_mut_step,
+        crate::promise::new_promise_root_scan_state,
+        MutableRootScannerSource::RuntimeMutableScanner,
+    );
+
+    let promise = unsafe { alloc_old_test_promise() };
+    js_shadow_slot_set(0, ptr_bits(promise as usize));
+    let cb1 = crate::closure::js_closure_alloc(test_captured_singleton_func as *const u8, 0);
+    let cb2 = crate::closure::js_closure_alloc(test_captured_singleton_func as *const u8, 0);
+    // First reaction lands inline in the promise's own fields; the second
+    // goes to PROMISE_OVERFLOW_REACTIONS — the table under test.
+    let _next1 = crate::promise::js_promise_then(promise, cb1, std::ptr::null());
+    let next2 = crate::promise::js_promise_then(promise, cb2, std::ptr::null());
+
+    let mut state = GcCycleState::new_full(trace_snapshot(GcTriggerKind::Manual));
+    run_cycle_until_phase(&mut state, GcCyclePhase::RootScan);
+    let mut root_steps = 0usize;
+    while state.phase() == GcCyclePhase::RootScan {
+        state.step(GcWorkBudget::bounded(1));
+        root_steps += 1;
+        assert!(root_steps < 100_000, "root scan did not finish");
+    }
+
+    // Marked during RootScan by the step scanner itself (not via promise
+    // field propagation — cb2/next2 are reachable ONLY through the table).
+    assert_heap_child_marked(cb2 as *const u8, "overflow on_fulfilled closure");
+    assert_heap_child_marked(next2 as *const u8, "overflow next promise");
+
+    run_cycle_in_single_unit_steps(&mut state);
+    let _ = state.take_outcome().expect("cycle should complete");
+}

--- a/crates/perry-runtime/src/gc/trace.rs
+++ b/crates/perry-runtime/src/gc/trace.rs
@@ -509,11 +509,18 @@ pub(super) fn try_mark_young_user_ptr_as_seed(
     if ptr_val == 0 || !valid_ptrs.contains(&ptr_val) {
         return false;
     }
-    if !matches!(
-        crate::arena::classify_heap_generation(ptr_val),
-        crate::arena::HeapGeneration::Nursery
-    ) {
-        return false;
+    match crate::arena::classify_heap_generation(ptr_val) {
+        crate::arena::HeapGeneration::Nursery => {}
+        // Non-arena member of the valid-pointer set = malloc-GC object.
+        // Minors sweep the malloc registry, and malloc objects are NOT
+        // black-leafed in minor traces (they can hold nursery children),
+        // so an RS-reachable malloc child must be seeded and traced
+        // exactly like a nursery one — otherwise the malloc sweep frees
+        // it while its only referrer is a clean old parent.
+        crate::arena::HeapGeneration::Unknown => {}
+        crate::arena::HeapGeneration::Old | crate::arena::HeapGeneration::Longlived => {
+            return false;
+        }
     }
     unsafe {
         let header = header_from_user_ptr(ptr_val as *const u8);

--- a/crates/perry-runtime/src/gc/verify.rs
+++ b/crates/perry-runtime/src/gc/verify.rs
@@ -128,7 +128,11 @@ pub(super) unsafe fn remember_evacuated_old_to_young_slot(
         return;
     }
     let child_addr = decode_heap_addr(*slot);
-    if child_addr == 0 || !crate::arena::pointer_in_nursery(child_addr) {
+    // Nursery AND malloc-GC children both need their pages kept dirty:
+    // minors sweep the malloc registry too, and old parents are black
+    // leaves — dropping an old→malloc page here would free the malloc
+    // child on the next minor (see remembered_child_needs_tracking).
+    if child_addr == 0 || !crate::gc::barrier::remembered_child_needs_tracking(child_addr) {
         return;
     }
     let external = !matches!(
@@ -449,7 +453,7 @@ pub(super) unsafe fn verify_old_young_slot_covered(
         return;
     }
     let child_addr = decode_heap_addr(*slot);
-    if child_addr == 0 || !crate::arena::pointer_in_nursery(child_addr) {
+    if child_addr == 0 || !crate::gc::barrier::remembered_child_needs_tracking(child_addr) {
         return;
     }
     stats.checked_old_to_young_edges = stats.checked_old_to_young_edges.saturating_add(1);

--- a/crates/perry-runtime/src/object/class_registry/gc_roots.rs
+++ b/crates/perry-runtime/src/object/class_registry/gc_roots.rs
@@ -26,6 +26,9 @@ enum ClassSideTableRootSlot {
     ParentClosure {
         class_id: u32,
     },
+    DynamicParentValue {
+        class_id: u32,
+    },
     ClassSymbolMethod {
         class_id: u32,
         sym_key: usize,
@@ -226,6 +229,19 @@ fn class_side_table_root_snapshot() -> Vec<ClassSideTableRootSlot> {
         }
     }
 
+    // Step twin of the CLASS_DYNAMIC_PARENT_VALUE block in
+    // `scan_class_side_table_roots_mut`. Cycle-based collections run only
+    // this snapshot machine, so omitting the stash meant a heap parent
+    // (`class X extends someRuntimeValue()`) reachable only through it was
+    // swept/left stale — `super()` then dereferenced freed/moved memory.
+    if let Ok(guard) = CLASS_DYNAMIC_PARENT_VALUE.read() {
+        if let Some(map) = guard.as_ref() {
+            for &class_id in map.keys() {
+                slots.push(ClassSideTableRootSlot::DynamicParentValue { class_id });
+            }
+        }
+    }
+
     if let Ok(guard) = CLASS_SYMBOL_METHODS.read() {
         if let Some(map) = guard.as_ref() {
             for &(class_id, sym_key, is_static) in map.keys() {
@@ -306,6 +322,13 @@ fn scan_class_side_table_root_slot(
             if let Ok(mut guard) = CLASS_PARENT_CLOSURES.write() {
                 if let Some(closure_addr) = guard.as_mut().and_then(|map| map.get_mut(class_id)) {
                     visitor.visit_usize_slot(closure_addr);
+                }
+            }
+        }
+        ClassSideTableRootSlot::DynamicParentValue { class_id } => {
+            if let Ok(mut guard) = CLASS_DYNAMIC_PARENT_VALUE.write() {
+                if let Some(value_bits) = guard.as_mut().and_then(|map| map.get_mut(class_id)) {
+                    visitor.visit_nanbox_u64_slot(value_bits);
                 }
             }
         }

--- a/crates/perry-runtime/src/promise/scanners.rs
+++ b/crates/perry-runtime/src/promise/scanners.rs
@@ -140,9 +140,10 @@ const PROMISE_SCAN_ASYNC_STEP_GUARD: u8 = 6;
 const PROMISE_SCAN_CONTEXTS: u8 = 7;
 const PROMISE_SCAN_ALL_STATES: u8 = 8;
 const PROMISE_SCAN_SETTLE_LISTENERS: u8 = 9;
-const PROMISE_SCAN_PREV_CONTEXTS: u8 = 10;
-const PROMISE_SCAN_SCHEDULED_RESOLVES: u8 = 11;
-const PROMISE_SCAN_DONE: u8 = 12;
+const PROMISE_SCAN_OVERFLOW_REACTIONS: u8 = 10;
+const PROMISE_SCAN_PREV_CONTEXTS: u8 = 11;
+const PROMISE_SCAN_SCHEDULED_RESOLVES: u8 = 12;
+const PROMISE_SCAN_DONE: u8 = 13;
 
 #[derive(Default)]
 pub(crate) struct PromiseRootScanState {
@@ -202,6 +203,9 @@ pub(crate) fn scan_promise_roots_mut_step(
             PROMISE_SCAN_ALL_STATES => scan_promise_all_states_step(visitor, state, remaining),
             PROMISE_SCAN_SETTLE_LISTENERS => {
                 scan_promise_settle_listeners_step(visitor, state, remaining)
+            }
+            PROMISE_SCAN_OVERFLOW_REACTIONS => {
+                scan_promise_overflow_reactions_step(visitor, state, remaining)
             }
             PROMISE_SCAN_PREV_CONTEXTS => scan_prev_contexts_step(visitor, state, remaining),
             PROMISE_SCAN_SCHEDULED_RESOLVES => {
@@ -606,6 +610,50 @@ fn scan_promise_settle_listeners_step(
     })
 }
 
+// Step twin of `scan_promise_overflow_reactions_mut` (then.rs). The 2nd+
+// `.then()`/`.catch()`/`.finally()` on a still-pending promise parks its
+// reaction ONLY in PROMISE_OVERFLOW_REACTIONS — cycle-based collections run
+// exclusively the step scanner, so a missing phase here meant those reaction
+// closures and their chained `next` promises were swept while the promise
+// was pending, and never rewritten on a moving cycle.
+fn scan_promise_overflow_reactions_step(
+    visitor: &mut crate::gc::RuntimeRootVisitor<'_>,
+    state: &mut PromiseRootScanState,
+    remaining: &mut usize,
+) -> bool {
+    super::then::PROMISE_OVERFLOW_REACTIONS.with(|reactions| {
+        let mut reactions = reactions.borrow_mut();
+        while state.index < reactions.len() {
+            while state.slot < 4 {
+                if !consume_root_work(remaining) {
+                    return false;
+                }
+                let (key, reaction) = &mut reactions[state.index];
+                match state.slot {
+                    0 => visitor.visit_metadata_usize_slot(key),
+                    1 => visitor.visit_raw_const_ptr_slot(&mut reaction.on_fulfilled),
+                    2 => visitor.visit_raw_const_ptr_slot(&mut reaction.on_rejected),
+                    3 => visitor.visit_raw_mut_ptr_slot(&mut reaction.next),
+                    _ => false,
+                };
+                state.slot += 1;
+            }
+            if !crate::async_context::scan_snapshot_roots_mut_step(
+                &mut reactions[state.index].1.context,
+                visitor,
+                &mut state.context_entry,
+                &mut state.context_store,
+                remaining,
+            ) {
+                return false;
+            }
+            state.index += 1;
+            state.finish_context_item();
+        }
+        true
+    })
+}
+
 fn scan_prev_contexts_step(
     visitor: &mut crate::gc::RuntimeRootVisitor<'_>,
     state: &mut PromiseRootScanState,
@@ -866,6 +914,7 @@ pub(crate) fn test_clear_promise_scanner_roots() {
     });
     super::combinators::SCHEDULED_RESOLVES.with(|q| q.borrow_mut().clear());
     super::then::PROMISE_SETTLE_LISTENERS.with(|listeners| listeners.borrow_mut().clear());
+    super::then::PROMISE_OVERFLOW_REACTIONS.with(|reactions| reactions.borrow_mut().clear());
 }
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/symbol/accessors.rs
+++ b/crates/perry-runtime/src/symbol/accessors.rs
@@ -136,6 +136,49 @@ pub(super) fn scan_symbol_accessor_roots_mut(visitor: &mut crate::gc::RuntimeRoo
     }
 }
 
+/// Snapshot of the accessor table's keys for the budgeted step scanner.
+pub(super) fn accessor_property_keys() -> Vec<(usize, usize)> {
+    let guard = crate::gc::lock_gc_root_registry(&SYMBOL_ACCESSOR_PROPERTIES);
+    guard
+        .as_ref()
+        .map(|m| m.keys().copied().collect())
+        .unwrap_or_default()
+}
+
+/// Step twin of `scan_symbol_accessor_roots_mut` for one snapshot key:
+/// strong-visits the get/set closures and rekeys owner/sym on a move.
+/// Cycle-based collections run ONLY the step scanner, so before this
+/// existed, symbol-keyed getter/setter closures reachable solely through
+/// this table were swept by every full/fallback collection.
+pub(super) fn scan_symbol_accessor_root_slot(
+    visitor: &mut crate::gc::RuntimeRootVisitor<'_>,
+    owner: usize,
+    sym_key: usize,
+) {
+    let mut guard = crate::gc::lock_gc_root_registry(&SYMBOL_ACCESSOR_PROPERTIES);
+    let Some(map) = guard.as_mut() else {
+        return;
+    };
+    let Some(acc) = map.get_mut(&(owner, sym_key)) else {
+        return;
+    };
+    let mut new_owner = owner;
+    let mut new_sym_key = sym_key;
+    let owner_changed = visitor.visit_metadata_usize_slot(&mut new_owner) && new_owner != owner;
+    let sym_changed = visitor.visit_usize_slot(&mut new_sym_key) && new_sym_key != sym_key;
+    if acc.get != 0 {
+        visitor.visit_nanbox_u64_slot(&mut acc.get);
+    }
+    if acc.set != 0 {
+        visitor.visit_nanbox_u64_slot(&mut acc.set);
+    }
+    if owner_changed || sym_changed {
+        if let Some(acc) = map.remove(&(owner, sym_key)) {
+            map.insert((new_owner, new_sym_key), acc);
+        }
+    }
+}
+
 pub(super) fn has_own_symbol_accessor(obj_key: usize, sym_key: usize) -> bool {
     let guard = crate::gc::lock_gc_root_registry(&SYMBOL_ACCESSOR_PROPERTIES);
     guard

--- a/crates/perry-runtime/src/symbol/gc_roots.rs
+++ b/crates/perry-runtime/src/symbol/gc_roots.rs
@@ -139,6 +139,7 @@ enum SymbolSideTableRootSlot {
     SymbolPropertyOwner { owner: usize },
     SymbolPropertyEntry { owner: usize, sym_key: usize },
     SymbolPropertyAttrs { owner: usize, sym_key: usize },
+    SymbolAccessorProperty { owner: usize, sym_key: usize },
     ClassStaticSymbol { class_id: u32, sym_key: usize },
     SymbolPointer { ptr: usize },
 }
@@ -195,6 +196,10 @@ fn symbol_side_table_root_snapshot() -> Vec<SymbolSideTableRootSlot> {
         }
     }
 
+    for (owner, sym_key) in accessors::accessor_property_keys() {
+        slots.push(SymbolSideTableRootSlot::SymbolAccessorProperty { owner, sym_key });
+    }
+
     {
         let guard = crate::gc::lock_gc_root_registry(&CLASS_STATIC_SYMBOLS);
         if let Some(map) = guard.as_ref() {
@@ -235,6 +240,9 @@ fn scan_symbol_side_table_root_slot(
             };
             visitor.visit_usize_slot(entry_sym);
             visitor.visit_nanbox_u64_slot(value_bits);
+        }
+        SymbolSideTableRootSlot::SymbolAccessorProperty { owner, sym_key } => {
+            accessors::scan_symbol_accessor_root_slot(visitor, owner, sym_key);
         }
         SymbolSideTableRootSlot::SymbolPropertyAttrs { owner, sym_key } => {
             rewrite_symbol_property_attrs_if_forwarded(visitor, owner, sym_key);

--- a/crates/perry-runtime/src/timer.rs
+++ b/crates/perry-runtime/src/timer.rs
@@ -1597,7 +1597,9 @@ pub fn scan_timer_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
 const TIMER_SCAN_TIMEOUTS: u8 = 0;
 const TIMER_SCAN_CALLBACKS: u8 = 1;
 const TIMER_SCAN_INTERVALS: u8 = 2;
-const TIMER_SCAN_DONE: u8 = 3;
+const TIMER_SCAN_MOCK_CALLBACKS: u8 = 3;
+const TIMER_SCAN_MOCK_INTERVALS: u8 = 4;
+const TIMER_SCAN_DONE: u8 = 5;
 
 #[derive(Default)]
 pub(crate) struct TimerRootScanState {
@@ -1644,6 +1646,8 @@ pub(crate) fn scan_timer_roots_mut_step(
             TIMER_SCAN_TIMEOUTS => scan_timeout_timers_step(visitor, state, remaining),
             TIMER_SCAN_CALLBACKS => scan_callback_timers_step(visitor, state, remaining),
             TIMER_SCAN_INTERVALS => scan_interval_timers_step(visitor, state, remaining),
+            TIMER_SCAN_MOCK_CALLBACKS => scan_mock_timers_step(visitor, state, remaining, false),
+            TIMER_SCAN_MOCK_INTERVALS => scan_mock_timers_step(visitor, state, remaining, true),
             TIMER_SCAN_DONE => true,
             _ => true,
         };
@@ -1779,6 +1783,67 @@ fn scan_interval_timers_step(
         }
         state.index += 1;
         state.finish_timer();
+    }
+    true
+}
+
+// Step twin of the MOCK_TIMERS block in `scan_timer_roots_mut`. Cycle-based
+// collections run only the step scanner, so before these phases existed,
+// `node:test` mocked-timer callbacks/args/contexts reachable only through
+// MOCK_TIMERS were swept while scheduled — `.tick()` then invoked a freed
+// closure. One function serves both lists (distinct structs, same fields).
+fn scan_mock_timers_step(
+    visitor: &mut crate::gc::RuntimeRootVisitor<'_>,
+    state: &mut TimerRootScanState,
+    remaining: &mut usize,
+    intervals: bool,
+) -> bool {
+    let mut guard = MOCK_TIMERS.lock().unwrap();
+    macro_rules! scan_mock_list {
+        ($list:expr) => {{
+            while state.index < $list.len() {
+                let timer = &mut $list[state.index];
+                if state.slot == 0 {
+                    if !consume_timer_root_work(remaining) {
+                        return false;
+                    }
+                    if !timer.cleared && timer.callback != 0 {
+                        visitor.visit_i64_slot(&mut timer.callback);
+                    }
+                    state.slot = 1;
+                }
+                if state.slot == 1 {
+                    while state.arg_index < timer.args.len() {
+                        if !consume_timer_root_work(remaining) {
+                            return false;
+                        }
+                        visitor.visit_nanbox_f64_slot(&mut timer.args[state.arg_index]);
+                        state.arg_index += 1;
+                    }
+                    state.slot = 2;
+                    state.arg_index = 0;
+                }
+                if state.slot == 2 {
+                    if !crate::async_context::scan_snapshot_roots_mut_step(
+                        &mut timer.context,
+                        visitor,
+                        &mut state.context_entry,
+                        &mut state.context_store,
+                        remaining,
+                    ) {
+                        return false;
+                    }
+                    state.slot = 3;
+                }
+                state.index += 1;
+                state.finish_timer();
+            }
+        }};
+    }
+    if intervals {
+        scan_mock_list!(guard.intervals)
+    } else {
+        scan_mock_list!(guard.callbacks)
     }
     true
 }


### PR DESCRIPTION
Wave 1 of the 2026-07-09 GC audit fixes (`fable-audit-perry-gc.md`): four GC-internal correctness holes, all code-only.

## 1. Maps >100k entries were invisible to every GC walk (P0)

`gc/layout.rs`'s Map rewrite-descriptor arm bailed at `size > 100_000` — a stale sanity bound (Set's equivalent is 16M). Every walk funnels through this descriptor (mark, copied-minor scan/rewrite, evacuation rewrite, RS dirty-scan, and the evacuation verifier itself), so entries reachable only through a larger map were swept while live and never rewritten after moves. Now mirrors Set's 16M corruption guard.

## 2. Old→malloc edges were never remembered — minors freed live malloc objects (P0)

Minors sweep the malloc registry and black-leaf old parents, but the write barrier recorded only old→**nursery** children (`ChildNotYoungSkips` for malloc children). A RegExp/hook-mode-Promise/Symbol/large-capture-closure whose only referrer was a clean old parent was freed by the next MallocCount/ArenaBytes minor; a nursery grandchild behind an unmarked malloc parent died on the very next minor without any malloc sweep.

Fix (shared predicate `remembered_child_needs_tracking`):
- barrier: remember old→malloc stores — membership check is the **exact** lazy malloc registry (`gc_malloc_header_is_tracked`), deliberately not a header sniff (barrier child values can be raw uninitialized slot bits replayed by array-growth barriers; a plausibility sniff on garbage dirtied pages whose rescan then moved neighboring garbage as "young pointers")
- fallback-minor RS scan: `try_mark_young_user_ptr_as_seed` now seeds malloc children (they are traced through — not black-leafed — so nursery grandchildren get marked)
- rebuild/repair/sticky filters (`remember_evacuated_old_to_young_slot`, copied-minor `visit_slot_with_parent`, verifier predicate) keep old→malloc pages dirty across cycles
- copied-minor needed no mark-side change: `mark_addr` already handles `CopyingPointerKind::Malloc` once the page is dirty

`malloc_backed_large_closure_capture_in_old_container_survives_copied_minor`'s remembered-set expectations updated for the new (correct) accounting: the old container's element page now stays remembered, which is exactly what protects the malloc-backed closure from minor malloc sweeps.

## 3. Sync/step scanner divergence: 4 tables invisible to cycle-based collections (P0/P1)

Cycle-based collections (all fulls, every fallback minor) run only the budgeted **step** scanners; four had silently diverged from their sync twins:
- `PROMISE_OVERFLOW_REACTIONS` (2nd+ `.then()`/`.catch()` on a pending promise) — reaction closures + chained `next` promises were swept while pending
- `SYMBOL_ACCESSOR_PROPERTIES` — symbol-keyed getter/setter closures swept; owner keys never rekeyed on moves
- `CLASS_DYNAMIC_PARENT_VALUE` — `class X extends someRuntimeValue()` parents swept/stale → `super()` deref of freed memory (the Effect `Context.Tag` shape)
- `MOCK_TIMERS` — `node:test` mocked-timer callbacks swept while scheduled

Each gained its step phase mirroring the sync visit.

## 4. `PERRY_WRITE_BARRIERS=0` was itself unsound (P1)

It disabled evacuation gating but minors kept running against an empty remembered set — born-old (>16 KB) parents' nursery children were swept on the first minor, so the documented bisection switch crashed for reasons unrelated to what was being bisected. Barriers-off now forces full mark-sweep mode (`gen_gc_enabled()` requires `write_barriers_enabled()`, and `gc_collect_minor_with_trigger` routes to the full collection for every caller).

## Tests

- `test_copying_minor_old_to_malloc_child_survives_sweep` / `..._nursery_grandchild_survives` (copied-minor e2e)
- `test_remembered_set_scan_marks_malloc_child_of_old_parent` (barrier + seed unit)
- `full_cycle_step_scanner_covers_promise_overflow_reactions` (step-scanner coverage; marks asserted during RootScan)
- Full `perry-runtime` lib suite: 1168 passed / 0 failed. (`gc::tests::copying::large_object_old_born_array_slot_write_keeps_young_child_alive` fails when run under a `gc::`-filtered subset on this machine — it also fails identically on pristine `origin/main`, i.e. pre-existing and filter-order-dependent, passes in the full suite.)

Part of the Wave-1 series from the GC audit; raw-pointer-window rooting and threading quick fixes follow in separate PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GC root scanning now includes additional runtime sources, including promise overflow reactions, timer callbacks/intervals, symbol accessor properties, and class dynamic parent values.
  * Incremental GC now tracks more heap edges, helping keep reachable objects alive during collection.

* **Bug Fixes**
  * Improved minor collection fallback behavior when generational GC isn’t available.
  * Fixed cases where old-to-malloc and old-to-young references could be missed, preventing premature freeing or dangling pointers.
  * Expanded map slot coverage so larger maps remain visible to GC and rewrite operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->