### PR TITLE
fix(thread): worker gc-init, rooted rebuilt closures, cross-thread promises in malloc space, ws deferred resolution

### DIFF
--- a/crates/perry-runtime/src/atomics.rs
+++ b/crates/perry-runtime/src/atomics.rs
@@ -765,7 +765,10 @@ pub extern "C" fn js_atomics_wait_async(
     };
 
     let deadline = timeout_to_deadline(timeout);
-    let promise = crate::promise::js_promise_new();
+    // Cross-thread variant: referenced only by a raw usize in the pending
+    // results queue until drained — must not live in the copying nursery
+    // (the from-space flip ignores pins that no scanner reaches).
+    let promise = crate::promise::js_promise_new_cross_thread();
     // Pin the promise + keep the event loop alive until the async result lands.
     unsafe {
         crate::thread::pin_promise(promise);

--- a/crates/perry-runtime/src/promise/mod.rs
+++ b/crates/perry-runtime/src/promise/mod.rs
@@ -78,9 +78,9 @@ pub(crate) use then::{
 };
 pub use then::{
     js_promise_bound_method, js_promise_catch, js_promise_finally, js_promise_free,
-    js_promise_mark_internally_handled, js_promise_new, js_promise_reason, js_promise_reject,
-    js_promise_resolve, js_promise_resolve_with_promise, js_promise_result, js_promise_state,
-    js_promise_then, js_promise_value,
+    js_promise_mark_internally_handled, js_promise_new, js_promise_new_cross_thread,
+    js_promise_reason, js_promise_reject, js_promise_resolve, js_promise_resolve_with_promise,
+    js_promise_result, js_promise_state, js_promise_then, js_promise_value,
 };
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/promise/then.rs
+++ b/crates/perry-runtime/src/promise/then.rs
@@ -430,10 +430,27 @@ pub extern "C" fn js_promise_new() -> *mut Promise {
 /// Allocate a new Promise, recording `parent` so `v8.promiseHooks` `init`
 /// callbacks (#3139) receive the parent promise.
 pub(crate) fn js_promise_new_with_parent(parent: *mut Promise) -> *mut Promise {
+    js_promise_new_with_parent_impl(parent, false)
+}
+
+/// Allocate a Promise that will cross a thread boundary as a raw address
+/// (`spawn`, `Atomics.waitAsync`): pinned by the caller and referenced only
+/// by a `usize` in the global PENDING_THREAD_RESULTS queue, which no root
+/// scanner visits. A nursery resident in that situation is destroyed by the
+/// copied-minor from-space flip regardless of its PIN flag (the flip resets
+/// eden/survivor blocks wholesale; only root-reachable pins force the
+/// fallback). Malloc space is non-moving and both sweep paths honor
+/// GC_FLAG_PINNED, so these promises are allocated there unconditionally.
+#[no_mangle]
+pub extern "C" fn js_promise_new_cross_thread() -> *mut Promise {
+    js_promise_new_with_parent_impl(ptr::null_mut(), true)
+}
+
+fn js_promise_new_with_parent_impl(parent: *mut Promise, force_malloc: bool) -> *mut Promise {
     bump(&MT_PROMISE_NEW_COUNT);
     let async_hooks_active = crate::async_hooks::hooks_active();
     let lifecycle_hooks_active = async_hooks_active || crate::v8::promise_hooks_active();
-    let raw = if lifecycle_hooks_active {
+    let raw = if lifecycle_hooks_active || force_malloc {
         crate::gc::gc_malloc(std::mem::size_of::<Promise>(), crate::gc::GC_TYPE_PROMISE)
     } else {
         crate::arena::arena_alloc_gc(

--- a/crates/perry-runtime/src/thread.rs
+++ b/crates/perry-runtime/src/thread.rs
@@ -901,8 +901,7 @@ unsafe fn single_thread_map(
     let call_fn: ClosureCallFn = std::mem::transmute(func as usize);
 
     for i in 0..len {
-        let elements_ptr = (arr_handle.get_raw_mut_ptr::<crate::array::ArrayHeader>()
-            as *const u8)
+        let elements_ptr = (arr_handle.get_raw_mut_ptr::<crate::array::ArrayHeader>() as *const u8)
             .add(std::mem::size_of::<crate::array::ArrayHeader>())
             as *const f64;
         let arg = *elements_ptr.add(i);
@@ -1111,8 +1110,7 @@ unsafe fn single_thread_filter(
     let mut count = 0u32;
 
     for i in 0..len {
-        let elements_ptr = (arr_handle.get_raw_mut_ptr::<crate::array::ArrayHeader>()
-            as *const u8)
+        let elements_ptr = (arr_handle.get_raw_mut_ptr::<crate::array::ArrayHeader>() as *const u8)
             .add(std::mem::size_of::<crate::array::ArrayHeader>())
             as *const f64;
         let arg = *elements_ptr.add(i);

--- a/crates/perry-runtime/src/thread.rs
+++ b/crates/perry-runtime/src/thread.rs
@@ -801,30 +801,43 @@ unsafe fn parallel_map_impl(array_val: f64, closure_val: f64) -> i64 {
             let captures_ref = captures_arc.clone();
 
             let handle = scope.spawn(move || {
-                // Each thread has its own arena (via thread_local!)
+                // Each thread has its own arena (via thread_local!).
+                // Register this thread's root scanners BEFORE any allocation
+                // can cross a GC trigger — a fresh worker otherwise collects
+                // with an empty scanner registry (and an empty shadow stack)
+                // and sweeps everything it just deserialized.
+                crate::gc::ensure_gc_initialized();
                 let mut results = Vec::with_capacity(chunk.len());
 
-                // Reconstruct closure on this thread's arena
-                let local_closure: *const ClosureHeader = if let Some(ref caps) = captures_ref {
+                // Reconstruct closure on this thread's arena, rooted for the
+                // whole loop: per-element deserialization below can allocate
+                // and trigger a worker GC, and a bare local is not a root.
+                let gc_scope = crate::gc::RuntimeHandleScope::new();
+                let closure_handle = if let Some(ref caps) = captures_ref {
                     let (fp, cc, ref cap_vals) = **caps;
                     let c = closure::js_closure_alloc(fp as *const u8, cc);
+                    let h = gc_scope.root_raw_mut_ptr(c);
                     for (i, cap) in cap_vals.iter().enumerate() {
                         let bits = deserialize_nanbox_on_current_thread(cap);
                         crate::closure::js_closure_set_capture_f64(
-                            c,
+                            h.get_raw_mut_ptr::<ClosureHeader>(),
                             i as u32,
                             f64::from_bits(bits),
                         );
                     }
-                    c as *const ClosureHeader
+                    Some(h)
                 } else {
-                    ptr::null()
+                    None
                 };
 
                 let call_fn: ClosureCallFn = std::mem::transmute(func_usize);
 
                 for elem_sv in &chunk {
                     let arg = f64::from_bits(deserialize_nanbox_on_current_thread(elem_sv));
+                    let local_closure = closure_handle
+                        .as_ref()
+                        .map(|h| h.get_raw_mut_ptr::<ClosureHeader>() as *const ClosureHeader)
+                        .unwrap_or(ptr::null());
                     let result = call_fn(local_closure, arg);
                     results.push(serialize_nanbox_for_thread(result.to_bits()));
                 }
@@ -871,10 +884,12 @@ unsafe fn single_thread_map(
     func: *const u8,
     closure_ptr: i64,
 ) -> i64 {
-    let elements_ptr =
-        (arr as *const u8).add(std::mem::size_of::<crate::array::ArrayHeader>()) as *const f64;
-    let result_arr = crate::array::js_array_alloc(len as u32);
+    // Root the input array BEFORE allocating the result (the allocation can
+    // trigger a moving minor), and re-derive the elements pointer from the
+    // rooted handle each iteration — the user callback can allocate too.
     let scope = crate::gc::RuntimeHandleScope::new();
+    let arr_handle = scope.root_raw_mut_ptr(arr as *mut crate::array::ArrayHeader);
+    let result_arr = crate::array::js_array_alloc(len as u32);
     let result_handle = scope.root_raw_mut_ptr(result_arr);
 
     let closure = if closure_ptr != 0 {
@@ -886,6 +901,10 @@ unsafe fn single_thread_map(
     let call_fn: ClosureCallFn = std::mem::transmute(func as usize);
 
     for i in 0..len {
+        let elements_ptr = (arr_handle.get_raw_mut_ptr::<crate::array::ArrayHeader>()
+            as *const u8)
+            .add(std::mem::size_of::<crate::array::ArrayHeader>())
+            as *const f64;
         let arg = *elements_ptr.add(i);
         let result = call_fn(closure, arg);
         let result_arr = result_handle.get_raw_mut_ptr::<crate::array::ArrayHeader>();
@@ -1001,28 +1020,38 @@ unsafe fn parallel_filter_impl(array_val: f64, closure_val: f64) -> i64 {
             let captures_ref = captures_arc.clone();
 
             let handle = scope.spawn(move || {
+                // See parallel_map's worker: scanner registration must precede
+                // any allocation, and the rebuilt closure must be rooted
+                // across the per-element deserialization allocations.
+                crate::gc::ensure_gc_initialized();
                 let mut kept = Vec::new();
 
-                let local_closure: *const ClosureHeader = if let Some(ref caps) = captures_ref {
+                let gc_scope = crate::gc::RuntimeHandleScope::new();
+                let closure_handle = if let Some(ref caps) = captures_ref {
                     let (fp, cc, ref cap_vals) = **caps;
                     let c = closure::js_closure_alloc(fp as *const u8, cc);
+                    let h = gc_scope.root_raw_mut_ptr(c);
                     for (i, cap) in cap_vals.iter().enumerate() {
                         let bits = deserialize_nanbox_on_current_thread(cap);
                         crate::closure::js_closure_set_capture_f64(
-                            c,
+                            h.get_raw_mut_ptr::<ClosureHeader>(),
                             i as u32,
                             f64::from_bits(bits),
                         );
                     }
-                    c as *const ClosureHeader
+                    Some(h)
                 } else {
-                    ptr::null()
+                    None
                 };
 
                 let call_fn: ClosureCallFn = std::mem::transmute(func_usize);
 
                 for elem_sv in &chunk {
                     let arg = f64::from_bits(deserialize_nanbox_on_current_thread(elem_sv));
+                    let local_closure = closure_handle
+                        .as_ref()
+                        .map(|h| h.get_raw_mut_ptr::<ClosureHeader>() as *const ClosureHeader)
+                        .unwrap_or(ptr::null());
                     let result = call_fn(local_closure, arg);
                     let keep = is_truthy_bits(result.to_bits());
                     if keep {
@@ -1071,16 +1100,21 @@ unsafe fn single_thread_filter(
     func: *const u8,
     closure: *const ClosureHeader,
 ) -> i64 {
-    let elements_ptr =
-        (arr as *const u8).add(std::mem::size_of::<crate::array::ArrayHeader>()) as *const f64;
-    let result_arr = crate::array::js_array_alloc(len as u32);
+    // Same rooting discipline as single_thread_map: the result allocation
+    // and every user callback can trigger a moving minor.
     let scope = crate::gc::RuntimeHandleScope::new();
+    let arr_handle = scope.root_raw_mut_ptr(arr as *mut crate::array::ArrayHeader);
+    let result_arr = crate::array::js_array_alloc(len as u32);
     let result_handle = scope.root_raw_mut_ptr(result_arr);
 
     let call_fn: ClosureCallFn = std::mem::transmute(func as usize);
     let mut count = 0u32;
 
     for i in 0..len {
+        let elements_ptr = (arr_handle.get_raw_mut_ptr::<crate::array::ArrayHeader>()
+            as *const u8)
+            .add(std::mem::size_of::<crate::array::ArrayHeader>())
+            as *const f64;
         let arg = *elements_ptr.add(i);
         let result = call_fn(closure, arg);
         let keep = is_truthy_bits(result.to_bits());
@@ -1132,7 +1166,11 @@ unsafe fn spawn_impl(closure_val: f64) -> *mut crate::promise::Promise {
     };
 
     // ── 1. Allocate Promise on main thread ───────────────────────────
-    let promise = crate::promise::js_promise_new();
+    // Cross-thread variant: this promise is referenced only by a raw usize
+    // in PENDING_THREAD_RESULTS (no scanner) until drain — a nursery
+    // resident would be destroyed by the copied-minor from-space flip even
+    // while pinned. Malloc space is non-moving and sweeps honor the pin.
+    let promise = crate::promise::js_promise_new_cross_thread();
 
     // Pin the promise so GC doesn't collect it while the thread is running
     let promise_header = (promise as *mut u8).sub(gc::GC_HEADER_SIZE) as *mut gc::GcHeader;
@@ -1160,26 +1198,36 @@ unsafe fn spawn_impl(closure_val: f64) -> *mut crate::promise::Promise {
     // ── 3. Spawn background thread ───────────────────────────────────
     ACTIVE_THREAD_JOBS.fetch_add(1, Ordering::SeqCst);
     std::thread::spawn(move || {
-        // Reconstruct closure in this thread's arena
-        let local_closure: *const ClosureHeader = if let Some((cc, ref cap_vals)) =
-            serialized_captures
-        {
+        // Register this thread's root scanners before any allocation can
+        // cross a GC trigger (see the parallel_map worker for rationale).
+        crate::gc::ensure_gc_initialized();
+        // Reconstruct closure in this thread's arena, rooted across the
+        // capture-deserialization allocations.
+        let gc_scope = crate::gc::RuntimeHandleScope::new();
+        let closure_handle = if let Some((cc, ref cap_vals)) = serialized_captures {
             let c = closure::js_closure_alloc(func_usize as *const u8, cc);
+            let h = gc_scope.root_raw_mut_ptr(c);
             for (i, cap) in cap_vals.iter().enumerate() {
                 unsafe {
                     let bits = deserialize_nanbox_on_current_thread(cap);
-                    crate::closure::js_closure_set_capture_f64(c, i as u32, f64::from_bits(bits));
+                    crate::closure::js_closure_set_capture_f64(
+                        h.get_raw_mut_ptr::<ClosureHeader>(),
+                        i as u32,
+                        f64::from_bits(bits),
+                    );
                 }
             }
-            c as *const ClosureHeader
+            h
         } else {
             // No captures — create a minimal closure header
-            closure::js_closure_alloc(func_usize as *const u8, 0) as *const ClosureHeader
+            gc_scope.root_raw_mut_ptr(closure::js_closure_alloc(func_usize as *const u8, 0))
         };
 
         // Call the function — catch panics to avoid aborting across FFI boundary
         let call_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let call_fn: ClosureCall0Fn = unsafe { std::mem::transmute(func_usize) };
+            let local_closure =
+                closure_handle.get_raw_mut_ptr::<ClosureHeader>() as *const ClosureHeader;
             unsafe { call_fn(local_closure) }
         }));
 

--- a/crates/perry-stdlib/src/ws.rs
+++ b/crates/perry-stdlib/src/ws.rs
@@ -884,8 +884,7 @@ pub unsafe extern "C" fn js_ws_wait_for_message(
                         // used POINTER_TAG, so the awaited value was a
                         // string-like *object* (`typeof === "object"`).
                         queue_deferred_resolution(promise_ptr, true, move || {
-                            let result_str =
-                                js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+                            let result_str = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
                             JSValue::string_ptr(result_str).bits()
                         });
                         return;

--- a/crates/perry-stdlib/src/ws.rs
+++ b/crates/perry-stdlib/src/ws.rs
@@ -17,7 +17,7 @@ use tokio::sync::mpsc;
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 
 #[cfg(not(target_os = "ios"))]
-use crate::common::async_bridge::{queue_promise_resolution, spawn};
+use crate::common::async_bridge::{queue_deferred_resolution, queue_promise_resolution, spawn};
 use crate::common::{for_each_handle_mut_of, get_handle_mut, register_handle, Handle};
 
 /// #6117 — rustls panics resolving the process-level CryptoProvider on the
@@ -876,9 +876,18 @@ pub unsafe extern "C" fn js_ws_wait_for_message(
                 if let Some(conn) = guard.get_mut(&ws_id) {
                     if !conn.messages.is_empty() {
                         let msg = conn.messages.remove(0);
-                        let result_str = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
-                        let result_bits = JSValue::pointer(result_str as *const u8).bits();
-                        queue_promise_resolution(promise_ptr, true, result_bits);
+                        // #1292 pattern (see bcrypt.rs): build the JS string on
+                        // the MAIN thread via the deferred converter and tag it
+                        // STRING_TAG. The old path allocated the StringHeader on
+                        // this tokio worker's arena (cross-heap pointer — freed
+                        // under the main thread by the worker's GC/exit) and
+                        // used POINTER_TAG, so the awaited value was a
+                        // string-like *object* (`typeof === "object"`).
+                        queue_deferred_resolution(promise_ptr, true, move || {
+                            let result_str =
+                                js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+                            JSValue::string_ptr(result_str).bits()
+                        });
                         return;
                     }
 


### PR DESCRIPTION
Wave 1 of the 2026-07-09 GC audit (`fable-audit-perry-gc.md`), threading dimension — the quick, mechanical subset. The structural cross-heap questions (owner-tagged queues, module globals in thread closures) are tracked in #6185; nothing here changes the threading model.

## 1. Worker threads could collect with zero registered root scanners (P1)

`MUTABLE_ROOT_SCANNERS` is thread-local and `ensure_gc_initialized` was wired only through `js_get_global_this`. A `spawn`/`parallelMap`/`parallelFilter` worker whose closure never reads a global but allocates past a trigger (e.g. deserializing large captures/elements) ran a collection with an empty scanner registry and an empty shadow stack — sweeping everything it had just built (singleton-closure caches, boxes, class side tables all invisible). Every worker entry now calls `ensure_gc_initialized()` before its first allocation. It is idempotent and cheap.

## 2. Rebuilt worker closures were unrooted across deserialization (P1)

The worker-side `local_closure` was a bare Rust local; every `deserialize_nanbox_on_current_thread` between `call_fn` invocations can allocate and trigger a worker GC, sweeping the closure and its captures mid-loop. The rebuilt closure is now rooted in a `RuntimeHandleScope` and re-derived from the handle at each call (spawn body, parallelMap worker, parallelFilter worker).

## 3. Cross-thread promises moved out of the copying nursery (P1)

`spawn()`/`Atomics.waitAsync` pin a promise and hand its raw `usize` to the global `PENDING_THREAD_RESULTS` queue, which no root scanner visits. The copied-minor from-space flip resets eden/survivor blocks wholesale — only *root-reachable* pins force the fallback — so a fire-and-forget `spawn` promise could be recycled while the worker still held its address; `js_thread_process_pending` then resolved through freed memory.

New `js_promise_new_cross_thread()` allocates these promises via `gc_malloc`: malloc space is non-moving, both sweep paths honor `GC_FLAG_PINNED`, and (since #6178) old→malloc edges are remembered. Used by `spawn_impl` and `js_atomics_wait_async`; ordinary promises are untouched.

## 4. `ws.waitForMessage` resolved with a tokio-arena string (P1)

`js_ws_wait_for_message` allocated the result `StringHeader` on the tokio worker's thread-local arena and queued the raw pointer for main-thread resolution — a cross-heap pointer freed under the main thread by the worker's GC — and tagged it `POINTER_TAG`, so the awaited value was a string-like *object* (`typeof === "object"`). Converted to the #1292 `queue_deferred_resolution` pattern (bcrypt.rs): the owned bytes move into the converter closure, the JS string is built on the main thread, tagged `STRING_TAG`. This was the only `spawn_for_promise` discipline violation found in perry-stdlib.

## 5. `single_thread_map`/`single_thread_filter` cached `elements_ptr` across user calls (P3)

The input array's elements pointer was computed once and re-read after each user callback (which can trigger a *moving* minor). The input array is now rooted before the result allocation and the elements pointer re-derived from the handle per iteration, matching the array `iter_methods.rs` discipline.

## Tests

Full `perry-runtime` lib suite: 1164 passed / 0 failed; perry-stdlib compiles clean. `cargo fmt --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved thread-safety during concurrent operations by properly initializing GC state in worker threads.
  * Fixed memory allocation for cross-thread promises to prevent garbage collection scanning issues.

* **Performance**
  * Optimized promise allocation strategy for async operations and parallel tasks.
  * Enhanced WebSocket message resolution handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->