### PR TITLE
fix(runtime): root raw-pointer windows across user callbacks (sort, stringify, replace, BigInt64 sort, matchAll)

### DIFF
--- a/crates/perry-runtime/src/array/generic.rs
+++ b/crates/perry-runtime/src/array/generic.rs
@@ -1541,39 +1541,44 @@ pub(crate) fn object_sort(recv: f64, cmp_validated: *const ClosureHeader) -> f64
     };
     let len = al_length(recv);
     unsafe {
-        // Rooted temp array: keeps accessor-produced values alive across
-        // comparator calls (a Rust Vec would be invisible to the GC scan).
-        let temp = js_array_alloc_with_length(len.clamp(0, u32::MAX as i64) as u32);
-        let temp_elems = (temp as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
+        // Root BOTH the receiver value and the collection temp for the whole
+        // protocol: `al_has`/`al_get`/`al_set` fire user accessors (and the
+        // comparator runs inside `sort_rooted_values`) — any of them can
+        // allocate and sweep or move either object, so every raw pointer is
+        // re-derived from its rooted handle after each such call.
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let recv_handle = scope.root_nanbox_f64(recv);
+        let temp = super::sort::RootedArrayElems::new(
+            &scope,
+            js_array_alloc_with_length(len.clamp(0, u32::MAX as i64) as u32),
+        );
         let mut count = 0usize;
         let mut undef_count = 0usize;
         for j in 0..len {
-            if al_has(recv, j) {
-                let v = al_get(recv, j);
+            if al_has(recv_handle.get_nanbox_f64(), j) {
+                let v = al_get(recv_handle.get_nanbox_f64(), j);
                 if v.to_bits() == TAG_UNDEFINED {
                     undef_count += 1;
                 } else {
-                    // GC_STORE_AUDIT(BARRIERED): temp collection array rebuilt below.
-                    ptr::write(temp_elems.add(count), v);
+                    temp.set(count, v);
                     count += 1;
                 }
             }
         }
-        (*temp).length = count as u32;
-        rebuild_array_layout(temp);
-        super::sort::sort_rooted_values(temp_elems, count, cmp);
-        rebuild_array_layout(temp);
+        (*temp.arr()).length = count as u32;
+        rebuild_array_layout(temp.arr());
+        let _ = super::sort::sort_rooted_values(temp.arr(), count, cmp);
         for j in 0..count {
-            al_set(recv, j as i64, *temp_elems.add(j));
+            al_set(recv_handle.get_nanbox_f64(), j as i64, temp.get(j));
         }
         for j in count..count + undef_count {
-            al_set(recv, j as i64, undef());
+            al_set(recv_handle.get_nanbox_f64(), j as i64, undef());
         }
         for j in (count + undef_count) as i64..len {
-            al_delete(recv, j);
+            al_delete(recv_handle.get_nanbox_f64(), j);
         }
+        recv_handle.get_nanbox_f64()
     }
-    recv
 }
 
 /// `Array.prototype.concat` over a non-real-array receiver: the receiver is

--- a/crates/perry-runtime/src/array/sort.rs
+++ b/crates/perry-runtime/src/array/sort.rs
@@ -2,7 +2,6 @@
 //! receivers (index accessors, sparse storage, inherited prototype elements).
 use super::*;
 use crate::closure::{js_closure_call2, ClosureHeader};
-use std::ptr;
 
 // ---------------------------------------------------------------------------
 // SortCompare helpers shared by the dense fast paths, the exotic spec path,
@@ -25,23 +24,26 @@ impl ComparatorCall {
         }
     }
 
-    /// Raw `Call(comparator, undefined, « a, b »)`.
-    #[inline(always)]
-    fn call_raw(&self, a: f64, b: f64) -> f64 {
-        match self.direct {
-            Some(f) => f(self.comparator, a, b),
-            None => js_closure_call2(self.comparator, a, b),
-        }
-    }
-
     /// ECMA-262 `CompareArrayElements` numeric result: `ToNumber(Call(...))`
     /// with NaN → +0. A plain finite/±inf f64 result skips the coercion; any
     /// NaN-boxed value (boolean, string, object with `valueOf`, undefined)
     /// goes through real ToNumber (firing user `valueOf`, throwing on
     /// BigInt/Symbol per spec).
+    ///
+    /// Takes an explicitly re-derived closure header rather than using the
+    /// one cached in `self`: the sorting engines root the comparator in a
+    /// `RuntimeHandleScope` and pass the CURRENT address here after every
+    /// user-code window — a comparator that allocates can trigger a moving
+    /// minor GC that relocates its own closure header, and the raw pointer
+    /// cached in `self.comparator` then points at from-space. `direct` stays
+    /// valid: it is a static code address resolved from the closure's shape,
+    /// which relocation does not change.
     #[inline(always)]
-    pub(crate) fn compare(&self, a: f64, b: f64) -> f64 {
-        let r = self.call_raw(a, b);
+    pub(crate) fn compare_at(&self, comparator: *const ClosureHeader, a: f64, b: f64) -> f64 {
+        let r = match self.direct {
+            Some(f) => f(comparator, a, b),
+            None => js_closure_call2(comparator, a, b),
+        };
         if r == r {
             return r;
         }
@@ -77,126 +79,220 @@ fn is_undefined_bits(bits: u64) -> bool {
     bits == crate::value::TAG_UNDEFINED
 }
 
-/// Stable bottom-up merge sort over a raw f64 buffer pair using `le(a, b)`
-/// ("a sorts at-or-before b"). Tolerant of an inconsistent user comparator
-/// (never panics, unlike `slice::sort_by` which detects total-order
-/// violations). `src` and `dst` must each hold `n` elements; the sorted run
-/// is guaranteed to end up back in `src`'s buffer.
-///
-/// SAFETY: caller keeps both buffers alive (and GC-visible when the values
-/// are NaN-boxed pointers and `le` can allocate — see the rooted temp-array
-/// usage in the spec path).
-unsafe fn stable_merge_sort_raw(
-    src0: *mut f64,
-    dst0: *mut f64,
+/// TimSort-style hybrid threshold shared by the sorting engines below:
+/// insertion sort for runs of at most this many elements, bottom-up merges
+/// above it.
+const INSERTION_THRESHOLD: usize = 32;
+
+/// GC-rooted view of an array's inline element storage. The header pointer
+/// lives in a `RuntimeHandleScope` slot (marked AND rewritten by a moving
+/// collection), and the element base is re-derived from the CURRENT header
+/// address on every access. A comparator — or an accessor fired by the spec
+/// ops — is user code: it can allocate → trigger a minor GC → the array is
+/// swept (bare Rust locals are invisible without a conservative stack scan,
+/// which production does not run) or moved (alloc-point minors can be moving
+/// under the evacuation policy), and any hoisted `*mut f64` then reads or
+/// writes from-space garbage. Mirrors the PR #5981 `RootedIterArray` pattern
+/// in `iter_methods.rs`.
+pub(crate) struct RootedArrayElems<'s> {
+    handle: crate::gc::RuntimeHandle<'s>,
+}
+
+impl<'s> RootedArrayElems<'s> {
+    pub(crate) fn new(scope: &'s crate::gc::RuntimeHandleScope, arr: *mut ArrayHeader) -> Self {
+        Self {
+            handle: scope.root_raw_mut_ptr(arr),
+        }
+    }
+
+    /// The CURRENT (post-any-GC) header address.
+    #[inline(always)]
+    pub(crate) fn arr(&self) -> *mut ArrayHeader {
+        self.handle.get_raw_mut_ptr::<ArrayHeader>()
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn get(&self, index: usize) -> f64 {
+        let arr = self.arr();
+        *((arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64).add(index)
+    }
+
+    /// Barriered store (`note_array_slot`): keeps the layout side-table and
+    /// the remembered set coherent even when the array is tenured mid-sort.
+    #[inline(always)]
+    pub(crate) unsafe fn set(&self, index: usize, value: f64) {
+        note_array_slot(self.arr(), index, value.to_bits());
+    }
+}
+
+/// In-place insertion sort of `vals[start..end]` under `le(a, b)` ("a sorts
+/// at-or-before b"). Swap-based: the moving key is never parked in a Rust
+/// local across a comparator call, so the authoritative element bits always
+/// live in the rooted array and get rewritten in place by a moving GC.
+unsafe fn insertion_sort_rooted(
+    vals: &RootedArrayElems<'_>,
+    start: usize,
+    end: usize,
+    le: &mut impl FnMut(f64, f64) -> bool,
+) {
+    for i in (start + 1)..end {
+        let mut j = i;
+        while j > start {
+            // `le` is user code — both operands are re-read AFTER it returns
+            // (their slots were rewritten in place if the array moved).
+            if le(vals.get(j - 1), vals.get(j)) {
+                break;
+            }
+            let prev = vals.get(j - 1);
+            let cur = vals.get(j);
+            vals.set(j - 1, cur);
+            vals.set(j, prev);
+            j -= 1;
+        }
+    }
+}
+
+/// Stable bottom-up merge sort over TWO rooted element buffers: `data` holds
+/// the values, `scratch` is the ping-pong buffer, and runs of `start_width`
+/// are assumed already sorted. Tolerant of an inconsistent user comparator
+/// (never panics, unlike `slice::sort_by`). Every element access re-derives
+/// the buffer base from its rooted handle and re-reads the winning element
+/// AFTER each comparator call — the authoritative bits always live in one of
+/// the two GC-visible arrays, never in an unrooted Rust buffer. (The #6076
+/// merge engine ping-ponged through a bare `Vec<f64>`: after the first src/dst
+/// swap the authoritative bits lived in that Vec, and a moving minor during a
+/// comparator call left pre-move addresses in the published result.)
+unsafe fn stable_merge_sort_rooted(
+    data: &RootedArrayElems<'_>,
+    scratch: &RootedArrayElems<'_>,
     n: usize,
+    start_width: usize,
     mut le: impl FnMut(f64, f64) -> bool,
 ) {
     if n <= 1 {
         return;
     }
-    let mut src = src0;
-    let mut dst = dst0;
-    let mut width = 1usize;
+    let mut in_data = true; // which buffer currently holds the runs
+    let mut width = start_width.max(1);
     while width < n {
-        let mut i = 0;
+        let (src, dst) = if in_data {
+            (data, scratch)
+        } else {
+            (scratch, data)
+        };
+        let mut i = 0usize;
         while i < n {
             let left = i;
             let mid = (i + width).min(n);
             let right = (i + 2 * width).min(n);
             let (mut l, mut r, mut k) = (left, mid, left);
-            // GC_STORE_AUDIT(STACK): merge writes target caller-rooted scratch buffers.
             while l < mid && r < right {
-                if le(*src.add(l), *src.add(r)) {
-                    *dst.add(k) = *src.add(l);
+                if le(src.get(l), src.get(r)) {
+                    dst.set(k, src.get(l));
                     l += 1;
                 } else {
-                    *dst.add(k) = *src.add(r);
+                    dst.set(k, src.get(r));
                     r += 1;
                 }
                 k += 1;
             }
-            // GC_STORE_AUDIT(STACK): tail copies target caller-rooted scratch buffers.
             while l < mid {
-                *dst.add(k) = *src.add(l);
+                dst.set(k, src.get(l));
                 l += 1;
                 k += 1;
             }
-            // GC_STORE_AUDIT(STACK): tail copies target caller-rooted scratch buffers.
             while r < right {
-                *dst.add(k) = *src.add(r);
+                dst.set(k, src.get(r));
                 r += 1;
                 k += 1;
             }
             i += 2 * width;
         }
-        std::mem::swap(&mut src, &mut dst);
+        in_data = !in_data;
         width *= 2;
     }
-    if src != src0 {
-        // GC_STORE_AUDIT(STACK): final copy between the two caller-rooted buffers.
-        ptr::copy_nonoverlapping(src, src0, n);
+    if !in_data {
+        // Final runs landed in scratch — copy back (no user code here).
+        for i in 0..n {
+            data.set(i, scratch.get(i));
+        }
     }
 }
 
-/// Sort `defined` (no holes / no undefined) per `SortCompare`: with the user
-/// comparator when present, else the default ToString lexicographic order.
-/// The default path materializes each key once (eager), matching the previous
-/// behavior; `String` keys make the Rust sort total (never panics).
-fn sort_defined_values(defined: &mut [f64], scratch: *mut f64, cmp: Option<ComparatorCall>) {
-    let n = defined.len();
+/// Comparator sort of `data[0..n]` (hybrid insertion + merge) with the
+/// comparator header re-derived from `cmp_handle` before every call.
+unsafe fn sort_comparator_rooted(
+    data: &RootedArrayElems<'_>,
+    scratch: &RootedArrayElems<'_>,
+    n: usize,
+    c: &ComparatorCall,
+    cmp_handle: &crate::gc::RuntimeHandle<'_>,
+) {
+    let mut le = |a: f64, b: f64| -> bool {
+        c.compare_at(cmp_handle.get_raw_const_ptr::<ClosureHeader>(), a, b) <= 0.0
+    };
+    // Phase 1: insertion-sort each small run in place.
+    let mut run_start = 0usize;
+    while run_start < n {
+        let run_end = (run_start + INSERTION_THRESHOLD).min(n);
+        insertion_sort_rooted(data, run_start, run_end, &mut le);
+        run_start = run_end;
+    }
+    // Phase 2: bottom-up merges, ping-ponging between the two rooted buffers.
+    stable_merge_sort_rooted(data, scratch, n, INSERTION_THRESHOLD, le);
+}
+
+/// Default (no-comparator) SortCompare over a rooted buffer: ToString each
+/// element (user `toString`/`valueOf` can run — and can sweep or move the
+/// buffer), sort a rank permutation on the owned `String` keys (GC-inert,
+/// total order — never panics), then apply the permutation. Element bits are
+/// only ever read fresh from the rooted array after the last user code.
+unsafe fn sort_default_rooted(vals: &RootedArrayElems<'_>, n: usize) {
     if n <= 1 {
         return;
     }
-    match cmp {
-        Some(c) => unsafe {
-            stable_merge_sort_raw(defined.as_mut_ptr(), scratch, n, |a, b| {
-                c.compare(a, b) <= 0.0
-            });
-        },
-        None => {
-            let mut pairs: Vec<(String, f64)> = Vec::with_capacity(n);
-            for &v in defined.iter() {
-                pairs.push((sort_key_string(v), v));
-            }
-            pairs.sort_by(|a, b| crate::string::utf16_cmp_bytes(a.0.as_bytes(), b.0.as_bytes()));
-            for (i, (_, v)) in pairs.into_iter().enumerate() {
-                defined[i] = v;
-            }
-        }
+    let mut keys: Vec<String> = Vec::with_capacity(n);
+    for i in 0..n {
+        keys.push(sort_key_string(vals.get(i)));
+    }
+    let mut order: Vec<u32> = (0..n as u32).collect();
+    order.sort_by(|&a, &b| {
+        crate::string::utf16_cmp_bytes(keys[a as usize].as_bytes(), keys[b as usize].as_bytes())
+    });
+    // No user code below — a plain snapshot Vec is safe for the permutation.
+    let snapshot: Vec<f64> = (0..n).map(|i| vals.get(i)).collect();
+    for (i, &src) in order.iter().enumerate() {
+        vals.set(i, snapshot[src as usize]);
     }
 }
 
-/// Sort `count` values held in the element buffer of a GC-rooted array (the
-/// caller keeps the array pointer on its stack). The scratch buffer is a
-/// second rooted array so every value stays GC-visible across comparator
-/// calls. Used by the exotic spec path and the generic array-like engine.
+/// Sort the first `count` element slots of `temp` (a dense collection array
+/// with no holes / no undefined) per `SortCompare`: with the user comparator
+/// when present, else the default ToString lexicographic order. `temp` is
+/// rooted here for the duration — the caller's raw pointer may be STALE on
+/// return whenever a comparator / ToString moved the array, so the current
+/// header is returned; callers must either switch to it or hold their own
+/// rooted handle. Used by the exotic spec path and the generic array-like
+/// engine.
 pub(crate) unsafe fn sort_rooted_values(
-    elems: *mut f64,
+    temp: *mut ArrayHeader,
     count: usize,
     cmp: Option<ComparatorCall>,
-) {
+) -> *mut ArrayHeader {
     if count <= 1 {
-        return;
+        return temp;
     }
-    let scratch = js_array_alloc_with_length(count as u32);
-    let scratch_elems = (scratch as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let data = RootedArrayElems::new(&scope, temp);
     match cmp {
         Some(c) => {
-            stable_merge_sort_raw(elems, scratch_elems, count, |a, b| c.compare(a, b) <= 0.0);
+            let cmp_handle = scope.root_raw_const_ptr(c.comparator);
+            let scratch = RootedArrayElems::new(&scope, js_array_alloc_with_length(count as u32));
+            sort_comparator_rooted(&data, &scratch, count, &c, &cmp_handle);
         }
-        None => {
-            let mut defined: Vec<f64> = Vec::with_capacity(count);
-            for i in 0..count {
-                defined.push(*elems.add(i));
-            }
-            sort_defined_values(&mut defined, scratch_elems, None);
-            for (i, v) in defined.into_iter().enumerate() {
-                // GC_STORE_AUDIT(BARRIERED): caller rebuilds the rooted array's layout.
-                ptr::write(elems.add(i), v);
-            }
-        }
+        None => sort_default_rooted(&data, count),
     }
+    data.arr()
 }
 
 // ---------------------------------------------------------------------------
@@ -242,10 +338,15 @@ fn object_prototype_numeric_keys() -> Vec<u32> {
     }
     let mut keys = Vec::new();
     unsafe {
-        let len = (*arr).length as usize;
-        let elems = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        // Root the freshly-built names array: `sort_key_string` can allocate
+        // (ToString of a non-string key), and a GC at that allocation point
+        // would sweep — or move — the otherwise-unreferenced array while the
+        // loop still reads its elements.
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let names = RootedArrayElems::new(&scope, arr as *mut ArrayHeader);
+        let len = (*names.arr()).length as usize;
         for i in 0..len {
-            let s = sort_key_string(*elems.add(i));
+            let s = sort_key_string(names.get(i));
             if !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit()) {
                 if let Ok(k) = s.parse::<u32>() {
                     keys.push(k);
@@ -298,28 +399,45 @@ pub(crate) fn object_prototype_has_index_prop(index: u32) -> bool {
 /// accessor there, OrdinarySet walks the chain and invokes that SETTER with
 /// the array as receiver (test262 sort/precise-prototype-accessors) — a plain
 /// `js_array_set_f64_extend` would create an own data slot instead.
+///
+/// The receiver travels as a rooted handle (updated in place when
+/// `js_array_set_f64_extend` reallocates it, or when a setter-triggered GC
+/// moves it), and `value` is rooted for the duration: the prototype probe
+/// above the write can allocate, and a moving minor at that point would
+/// otherwise leave `value` holding a pre-move address.
 unsafe fn sort_spec_set(
-    arr: *mut ArrayHeader,
+    arr_handle: &crate::gc::RuntimeHandle<'_>,
     index: u32,
     value: f64,
     objproto_keys: &[u32],
-) -> *mut ArrayHeader {
-    if objproto_keys.contains(&index) && !crate::array::array_has_own_index(arr, index) {
+) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let value_handle = scope.root_nanbox_f64(value);
+    if objproto_keys.contains(&index)
+        && !crate::array::array_has_own_index(arr_handle.get_raw_mut_ptr::<ArrayHeader>(), index)
+    {
         if let Some(proto) = object_prototype_value() {
             let addr = (proto.to_bits() & crate::value::POINTER_MASK) as usize;
             if let Some(acc) = crate::object::get_accessor_descriptor(addr, &index.to_string()) {
                 if acc.set != 0 {
                     crate::object::invoke_accessor_setter(
                         acc.set,
-                        crate::value::js_nanbox_pointer(arr as i64),
-                        value,
+                        crate::value::js_nanbox_pointer(
+                            arr_handle.get_raw_mut_ptr::<ArrayHeader>() as i64,
+                        ),
+                        value_handle.get_nanbox_f64(),
                     );
                 }
-                return arr;
+                return;
             }
         }
     }
-    js_array_set_f64_extend(arr, index, value)
+    let updated = js_array_set_f64_extend(
+        arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
+        index,
+        value_handle.get_nanbox_f64(),
+    );
+    arr_handle.set_raw_mut_ptr(updated);
 }
 
 // ---------------------------------------------------------------------------
@@ -337,58 +455,66 @@ unsafe fn array_sort_spec_path(
 ) -> *mut ArrayHeader {
     let len = (*arr).length;
 
-    // Collect present elements into a GC-rooted temp array (stack-local
-    // pointer keeps it alive under the conservative scan; its element buffer
-    // keeps accessor-produced values alive across comparator calls — a plain
-    // Rust Vec would not be traced).
-    let temp = js_array_alloc_with_length(len);
-    let temp_elems = (temp as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
+    // Root the receiver BEFORE the temp allocation below (which can trigger
+    // GC) and re-derive it after every spec op — [[HasProperty]]/[[Get]]/
+    // [[Set]] fire user accessors that can allocate, sweeping or moving it.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let arr_handle = scope.root_raw_mut_ptr(arr);
+
+    // Collect present elements into a GC-rooted temp array whose element
+    // buffer keeps accessor-produced values alive — and CURRENT — across
+    // comparator calls (a plain Rust Vec is invisible to the collector).
+    let temp = RootedArrayElems::new(&scope, js_array_alloc_with_length(len));
     let mut count = 0usize;
     let mut undef_count = 0usize;
     for j in 0..len {
-        let (present, value) = if crate::array::array_spec_has_index(arr, j) {
-            (true, crate::array::array_spec_get(arr, j))
-        } else if objproto_keys.contains(&j) {
-            (true, object_prototype_index_get(j))
-        } else {
-            (false, 0.0)
-        };
+        let (present, value) =
+            if crate::array::array_spec_has_index(arr_handle.get_raw_mut_ptr::<ArrayHeader>(), j) {
+                (
+                    true,
+                    crate::array::array_spec_get(arr_handle.get_raw_mut_ptr::<ArrayHeader>(), j),
+                )
+            } else if objproto_keys.contains(&j) {
+                (true, object_prototype_index_get(j))
+            } else {
+                (false, 0.0)
+            };
         if present {
             if is_undefined_bits(value.to_bits()) {
                 undef_count += 1;
             } else {
-                // GC_STORE_AUDIT(BARRIERED): temp collection array is rebuilt below.
-                ptr::write(temp_elems.add(count), value);
+                temp.set(count, value);
                 count += 1;
             }
         }
     }
-    (*temp).length = count as u32;
-    rebuild_array_layout(temp);
+    (*temp.arr()).length = count as u32;
+    rebuild_array_layout(temp.arr());
     let item_count = count + undef_count;
 
     // Sort the defined values; the scratch buffer is a second rooted array.
-    sort_rooted_values(temp_elems, count, cmp);
-    rebuild_array_layout(temp);
+    let _ = sort_rooted_values(temp.arr(), count, cmp);
 
     // Write back via [[Set]] (fires index setters / honors attrs), then
     // [[Delete]] the trailing [itemCount, len) range — restoring sparseness.
-    let mut cur = arr;
+    // The receiver handle is updated in place by `sort_spec_set`, and the
+    // sorted value is re-read from the rooted temp AFTER the previous
+    // element's (possibly user-code-running) write.
     for j in 0..count {
-        cur = sort_spec_set(cur, j as u32, *temp_elems.add(j), objproto_keys);
+        sort_spec_set(&arr_handle, j as u32, temp.get(j), objproto_keys);
     }
     for j in count..item_count {
-        cur = sort_spec_set(
-            cur,
+        sort_spec_set(
+            &arr_handle,
             j as u32,
             f64::from_bits(crate::value::TAG_UNDEFINED),
             objproto_keys,
         );
     }
     for j in item_count..len as usize {
-        crate::array::js_array_delete(cur, j as u32);
+        crate::array::js_array_delete(arr_handle.get_raw_mut_ptr::<ArrayHeader>(), j as u32);
     }
-    cur
+    arr_handle.get_raw_mut_ptr::<ArrayHeader>()
 }
 
 /// Whether the dense raw-store sort would diverge from the spec protocol for
@@ -546,7 +672,13 @@ unsafe fn sort_array_receiver(
     arr: *mut ArrayHeader,
     cmp: Option<ComparatorCall>,
 ) -> *mut ArrayHeader {
+    // Root the receiver up front: every branch below can run user code
+    // (comparator, ToString, prototype accessors) or allocate before touching
+    // it again, and a bare Rust local is invisible to the collector.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let arr_handle = scope.root_raw_mut_ptr(arr);
     let objproto_keys = object_prototype_numeric_keys();
+    let arr = arr_handle.get_raw_mut_ptr::<ArrayHeader>();
     if sort_needs_spec_path(arr, &objproto_keys) {
         return array_sort_spec_path(arr, cmp, &objproto_keys);
     }
@@ -571,36 +703,44 @@ unsafe fn sort_array_receiver(
         }
     }
     if has_special {
-        // Gather defined (non-hole, non-undefined) elements; tally the
-        // undefined and hole counts to re-emit as a trailing suffix.
-        let mut defined: Vec<f64> = Vec::with_capacity(length);
+        // Gather defined (non-hole, non-undefined) elements into a rooted
+        // collection array; tally the undefined and hole counts to re-emit as
+        // a trailing suffix. (A Rust Vec held the defined values before — a
+        // moving minor during a comparator / ToString call rewrote the array
+        // storage but left pre-move addresses in the Vec's copies.)
+        let temp = RootedArrayElems::new(&scope, js_array_alloc_with_length(length as u32));
+        let mut count = 0usize;
         let mut undef_count = 0usize;
         let mut hole_count = 0usize;
-        for i in 0..length {
-            let v = *elements_ptr.add(i);
-            let bits = v.to_bits();
-            if bits == crate::value::TAG_HOLE {
-                hole_count += 1;
-            } else if is_undefined_bits(bits) {
-                undef_count += 1;
-            } else {
-                defined.push(v);
+        {
+            // Re-derive after the temp allocation above (which can GC).
+            let arr = arr_handle.get_raw_mut_ptr::<ArrayHeader>();
+            let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
+            for i in 0..length {
+                let v = *elements_ptr.add(i);
+                let bits = v.to_bits();
+                if bits == crate::value::TAG_HOLE {
+                    hole_count += 1;
+                } else if is_undefined_bits(bits) {
+                    undef_count += 1;
+                } else {
+                    temp.set(count, v);
+                    count += 1;
+                }
             }
         }
-        // All defined values remain reachable through the (unmodified) array
-        // storage until the write-back below, so the Vec scratch is safe.
-        let n = defined.len();
-        if n > 1 {
-            let mut buf: Vec<f64> = vec![0.0; n];
-            sort_defined_values(&mut defined, buf.as_mut_ptr(), cmp);
-        }
-        // Write back: sorted defined values, then `undefined` ×N, then
-        // holes ×N — restoring the array's exotic sparseness.
+        (*temp.arr()).length = count as u32;
+        rebuild_array_layout(temp.arr());
+        let _ = sort_rooted_values(temp.arr(), count, cmp);
+        // Write back (no user code below): sorted defined values, then
+        // `undefined` ×N, then holes ×N — restoring the exotic sparseness.
+        let arr = arr_handle.get_raw_mut_ptr::<ArrayHeader>();
+        let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
         mark_array_layout_unknown(arr);
         let mut idx = 0usize;
         // GC_STORE_AUDIT(BARRIERED): write-back is included in the rebuild below.
-        for &v in &defined {
-            *elements_ptr.add(idx) = v;
+        for i in 0..count {
+            *elements_ptr.add(idx) = temp.get(i);
             idx += 1;
         }
         // GC_STORE_AUDIT(POINTER_FREE): undefined/hole suffix has no child pointer;
@@ -619,157 +759,46 @@ unsafe fn sort_array_receiver(
     }
 
     let Some(c) = cmp else {
-        // Dense all-defined default sort: materialize each element's string
-        // key once, sort stably on the keys, write back.
-        let mut pairs: Vec<(String, f64)> = Vec::with_capacity(length);
-        for i in 0..length {
-            let val = *elements_ptr.add(i);
-            pairs.push((sort_key_string(val), val));
-        }
-        pairs.sort_by(|a, b| crate::string::utf16_cmp_bytes(a.0.as_bytes(), b.0.as_bytes()));
-        mark_array_layout_unknown(arr);
-        for (i, (_, val)) in pairs.into_iter().enumerate() {
-            // GC_STORE_AUDIT(BARRIERED): default sort writes are followed by layout/barrier rebuild.
-            *elements_ptr.add(i) = val;
-        }
-        rebuild_array_layout(arr);
-        return arr;
+        // Dense all-defined default sort: rank-permutation on owned string
+        // keys over the rooted receiver — a user `toString` can allocate and
+        // sweep/move the array mid-key-materialization, so element bits are
+        // only ever read fresh from the rooted handle. A throwing `toString`
+        // unwinds during the key pass, leaving the elements untouched.
+        let vals = RootedArrayElems::new(&scope, arr);
+        sort_default_rooted(&vals, length);
+        return vals.arr();
     };
 
     // #6076: sort a GC-rooted COPY of the elements and publish it back only
-    // after the comparator sort SUCCEEDS. A throwing comparator therefore leaves
-    // the receiver's elements intact (an in-place sort corrupts them), and the
-    // rooted temp keeps every value GC-visible across comparator allocations (a
-    // bare Vec would go stale under a moving GC). `elements_ptr` is rebound to
-    // the temp for the in-place sort below; the receiver storage is untouched
-    // until the write-back.
-    let recv_elems = elements_ptr;
-    let temp = js_array_alloc_with_length(length as u32);
-    let elements_ptr = (temp as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
-    for i in 0..length {
-        // GC_STORE_AUDIT(INIT): initializing the freshly-allocated temp from the
-        // receiver before it is published; no allocation (hence no GC) occurs
-        // between js_array_alloc_with_length above and rebuild_array_layout below.
-        ptr::write(elements_ptr.add(i), *recv_elems.add(i));
-    }
-    (*temp).length = length as u32;
-    rebuild_array_layout(temp);
-
-    // TimSort-style hybrid: insertion sort for small runs, merge sort for large arrays.
-    // Stable, O(n log n) worst case. Insertion sort is used for runs <= 32 elements
-    // because it has lower overhead for small inputs.
-    const INSERTION_THRESHOLD: usize = 32;
-
-    if length <= INSERTION_THRESHOLD {
-        // Insertion sort for small arrays
-        for i in 1..length {
-            let key = *elements_ptr.add(i);
-            let mut j = i as isize - 1;
-            while j >= 0 {
-                if c.compare(*elements_ptr.add(j as usize), key) > 0.0 {
-                    // GC_STORE_AUDIT(BARRIERED): insertion-sort shift is included in the rebuild below.
-                    ptr::write(
-                        elements_ptr.add((j + 1) as usize),
-                        *elements_ptr.add(j as usize),
-                    );
-                    j -= 1;
-                } else {
-                    break;
-                }
-            }
-            // GC_STORE_AUDIT(BARRIERED): insertion-sort key write is included in the rebuild below.
-            ptr::write(elements_ptr.add((j + 1) as usize), key);
-        }
-    } else {
-        // Bottom-up merge sort for large arrays — O(n log n) stable sort
-        let mut buf: Vec<f64> = Vec::with_capacity(length);
-        buf.set_len(length);
-
-        // Phase 1: Sort small runs with insertion sort
-        let mut run_start = 0;
-        while run_start < length {
-            let run_end = (run_start + INSERTION_THRESHOLD).min(length);
-            for i in (run_start + 1)..run_end {
-                let key = *elements_ptr.add(i);
-                let mut j = i as isize - 1;
-                while j >= run_start as isize {
-                    if c.compare(*elements_ptr.add(j as usize), key) > 0.0 {
-                        // GC_STORE_AUDIT(BARRIERED): large-sort insertion shift is included in the rebuild below.
-                        ptr::write(
-                            elements_ptr.add((j + 1) as usize),
-                            *elements_ptr.add(j as usize),
-                        );
-                        j -= 1;
-                    } else {
-                        break;
-                    }
-                }
-                // GC_STORE_AUDIT(BARRIERED): large-sort insertion key write is included in the rebuild below.
-                ptr::write(elements_ptr.add((j + 1) as usize), key);
-            }
-            run_start = run_end;
-        }
-
-        // Phase 2: Merge runs, doubling width each pass. Values are always
-        // present in either the array storage or the scratch buffer; the
-        // array itself roots them for the conservative scan.
-        let mut width = INSERTION_THRESHOLD;
-        let mut src = elements_ptr;
-        let mut dst = buf.as_mut_ptr();
-
-        while width < length {
-            let mut i = 0;
-            while i < length {
-                let left = i;
-                let mid = (i + width).min(length);
-                let right = (i + 2 * width).min(length);
-
-                let (mut l, mut r, mut k) = (left, mid, left);
-                // GC_STORE_AUDIT(STACK): merge destination is a function-local Vec buffer, not GC heap.
-                while l < mid && r < right {
-                    if c.compare(*src.add(l), *src.add(r)) <= 0.0 {
-                        *dst.add(k) = *src.add(l);
-                        l += 1;
-                    } else {
-                        *dst.add(k) = *src.add(r);
-                        r += 1;
-                    }
-                    k += 1;
-                }
-                // GC_STORE_AUDIT(STACK): remaining left run copies into the temporary merge buffer.
-                while l < mid {
-                    *dst.add(k) = *src.add(l);
-                    l += 1;
-                    k += 1;
-                }
-                // GC_STORE_AUDIT(STACK): remaining right run copies into the temporary merge buffer.
-                while r < right {
-                    *dst.add(k) = *src.add(r);
-                    r += 1;
-                    k += 1;
-                }
-
-                i += 2 * width;
-            }
-            // Swap src and dst for next pass
-            std::mem::swap(&mut src, &mut dst);
-            width *= 2;
-        }
-
-        // If final result is in buf, copy back to the temp element buffer.
-        if src != elements_ptr {
-            // GC_STORE_AUDIT(BARRIERED): merge buffer copyback is followed by layout/barrier rebuild.
-            ptr::copy_nonoverlapping(src, elements_ptr, length);
+    // after the comparator sort SUCCEEDS. A throwing comparator therefore
+    // leaves the receiver's elements intact (an in-place sort corrupts them).
+    // Both the copy AND the merge scratch are rooted arrays: the merge engine
+    // ping-pongs between two GC-visible buffers, so a moving minor during a
+    // comparator call rewrites whichever buffer holds the authoritative bits
+    // (the previous engine's bare `Vec<f64>` kept pre-move addresses and
+    // published them back into the receiver).
+    let cmp_handle = scope.root_raw_const_ptr(c.comparator);
+    let temp = RootedArrayElems::new(&scope, js_array_alloc_with_length(length as u32));
+    {
+        // Re-derive after the temp allocation above (which can GC).
+        let arr = arr_handle.get_raw_mut_ptr::<ArrayHeader>();
+        let recv_elems = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
+        for i in 0..length {
+            temp.set(i, *recv_elems.add(i));
         }
     }
+    rebuild_array_layout(temp.arr());
+    let scratch = RootedArrayElems::new(&scope, js_array_alloc_with_length(length as u32));
+    sort_comparator_rooted(&temp, &scratch, length, &c, &cmp_handle);
 
     // The comparator sort completed without a throw — publish the sorted temp
-    // back into the receiver. A throwing comparator unwinds before reaching here,
-    // so `arr` keeps its original elements (#6076).
+    // back into the receiver (no user code below; both sides re-derived).
+    let arr = arr_handle.get_raw_mut_ptr::<ArrayHeader>();
+    let recv_elems = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
     mark_array_layout_unknown(arr);
     for i in 0..length {
         // GC_STORE_AUDIT(BARRIERED): dense write-back is followed by the rebuild below.
-        *recv_elems.add(i) = *elements_ptr.add(i);
+        *recv_elems.add(i) = temp.get(i);
     }
     rebuild_array_layout(arr);
 

--- a/crates/perry-runtime/src/gc/tests/runtime_roots/callback_scanners.rs
+++ b/crates/perry-runtime/src/gc/tests/runtime_roots/callback_scanners.rs
@@ -1328,3 +1328,332 @@ fn test_lazy_media_mutable_scanner_rewrites_callback_slots() {
         (fixture.old_bits, fixture.old_bits)
     );
 }
+
+// ---------------------------------------------------------------------------
+// 2026-07-09 GC audit, wave 1: raw-pointer windows across user callbacks.
+// Each test forces a COPIED (moving) minor GC from inside the user callback —
+// with the pre-fix code the helper kept reading through pre-move raw
+// pointers / unrooted Rust buffers, publishing from-space addresses.
+// ---------------------------------------------------------------------------
+
+fn string_value_content(value: f64) -> String {
+    let bits = value.to_bits();
+    assert_eq!(
+        bits & TAG_MASK,
+        STRING_TAG,
+        "expected a live string value, got bits {bits:#x}"
+    );
+    crate::string::string_as_str((bits & POINTER_MASK) as *const crate::StringHeader).to_string()
+}
+
+extern "C" fn test_sort_comparator_force_minor_gc(
+    _closure: *const crate::closure::ClosureHeader,
+    a: f64,
+    b: f64,
+) -> f64 {
+    let scope = RuntimeHandleScope::new();
+    let a_handle = scope.root_nanbox_f64(a);
+    let b_handle = scope.root_nanbox_f64(b);
+    let _ = crate::gc::gc_collect_minor();
+    let a_str = string_value_content(a_handle.get_nanbox_f64());
+    let b_str = string_value_content(b_handle.get_nanbox_f64());
+    match a_str.cmp(&b_str) {
+        std::cmp::Ordering::Less => -1.0,
+        std::cmp::Ordering::Equal => 0.0,
+        std::cmp::Ordering::Greater => 1.0,
+    }
+}
+
+/// `Array.prototype.sort(comparator)` where every comparator call forces a
+/// copied minor GC: the receiver, the #6076 temp copy, the merge scratch, and
+/// the comparator closure itself must all be re-derived from rooted handles.
+/// 40 elements exercises the run + bottom-up-merge engine (threshold 32); the
+/// 8-element pass covers the pure insertion-sort path.
+#[test]
+fn test_array_sort_comparator_rooted_buffers_survive_copied_minor_gc() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    register_runtime_handle_root_scanner_for_tests();
+
+    for count in [8usize, 40usize] {
+        let scope = RuntimeHandleScope::new();
+        let comparator =
+            crate::closure::js_closure_alloc(test_sort_comparator_force_minor_gc as *const u8, 0);
+        let comparator_handle = scope.root_raw_const_ptr(comparator);
+        let arr = crate::array::js_array_alloc(count as u32);
+        let arr_handle = scope.root_raw_mut_ptr(arr);
+        for i in 0..count {
+            // Descending heap strings ("s39", "s38", …) so the sort has real
+            // work and stale pre-move addresses are observable as garbage.
+            let text = format!("s{:02}", count - 1 - i);
+            let sp = crate::string::js_string_from_bytes(text.as_ptr(), text.len() as u32);
+            let sp_handle = scope.root_string_ptr(sp);
+            let arr = crate::array::js_array_push(
+                arr_handle.get_raw_mut_ptr::<crate::array::ArrayHeader>(),
+                crate::JSValue::from_bits(string_bits(
+                    sp_handle.get_raw_const_ptr::<crate::StringHeader>() as usize,
+                )),
+            );
+            arr_handle.set_raw_mut_ptr(arr);
+        }
+
+        let before = gc_collection_count();
+        let sorted = crate::array::js_array_sort_with_comparator(
+            arr_handle.get_raw_mut_ptr::<crate::array::ArrayHeader>(),
+            comparator_handle.get_raw_const_ptr::<crate::closure::ClosureHeader>(),
+        );
+        assert!(
+            gc_collection_count() > before,
+            "comparator should force copied-minor GCs during the sort"
+        );
+        unsafe {
+            assert_eq!((*sorted).length as usize, count);
+            let elems = (sorted as *const u8).add(std::mem::size_of::<crate::array::ArrayHeader>())
+                as *const f64;
+            for i in 0..count {
+                let got = string_value_content(*elems.add(i));
+                assert_eq!(
+                    got,
+                    format!("s{i:02}"),
+                    "element {i} of the {count}-element sort should hold the \
+                     post-move string, not a stale pre-move address"
+                );
+            }
+        }
+    }
+}
+
+extern "C" fn test_tojson_force_minor_gc(_closure: *const crate::closure::ClosureHeader) -> f64 {
+    let _ = crate::gc::gc_collect_minor();
+    test_string_value(b"tojson-out")
+}
+
+fn json_test_object_with_gc_forcing_tojson(scope: &RuntimeHandleScope) -> f64 {
+    let to_json = crate::closure::js_closure_alloc(test_tojson_force_minor_gc as *const u8, 0);
+    let to_json_handle = scope.root_raw_mut_ptr(to_json);
+    let nested = crate::object::js_object_alloc(0, 1);
+    let nested_handle = scope.root_raw_mut_ptr(nested);
+    let key = crate::string::js_string_from_bytes(b"toJSON".as_ptr(), 6);
+    crate::object::js_object_set_field_by_name(
+        nested_handle.get_raw_mut_ptr::<crate::ObjectHeader>(),
+        key,
+        f64::from_bits(ptr_bits(to_json_handle.get_raw_mut_ptr::<u8>() as usize)),
+    );
+    f64::from_bits(ptr_bits(nested_handle.get_raw_mut_ptr::<u8>() as usize))
+}
+
+fn set_string_field(
+    scope: &RuntimeHandleScope,
+    obj_handle: &crate::gc::RuntimeHandle<'_>,
+    key: &[u8],
+    value: &[u8],
+) {
+    let value_handle = scope.root_nanbox_f64(test_string_value(value));
+    let key_ptr = crate::string::js_string_from_bytes(key.as_ptr(), key.len() as u32);
+    crate::object::js_object_set_field_by_name(
+        obj_handle.get_raw_mut_ptr::<crate::ObjectHeader>(),
+        key_ptr,
+        value_handle.get_nanbox_f64(),
+    );
+}
+
+/// `JSON.stringify` of an object whose MIDDLE field is a nested object with a
+/// GC-forcing `toJSON`: after the callback moves the parent, the remaining
+/// fields must be read through the re-derived keys/field buffers (the pre-fix
+/// code hoisted `keys_elements`/`fields_ptr` once, before any user code).
+#[test]
+fn test_json_stringify_object_rederives_fields_after_tojson_minor_gc() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    register_runtime_handle_root_scanner_for_tests();
+
+    let scope = RuntimeHandleScope::new();
+    let obj = crate::object::js_object_alloc(0, 3);
+    let obj_handle = scope.root_raw_mut_ptr(obj);
+    set_string_field(&scope, &obj_handle, b"a", b"first");
+    let nested_value = json_test_object_with_gc_forcing_tojson(&scope);
+    let nested_handle = scope.root_nanbox_f64(nested_value);
+    {
+        let key_ptr = crate::string::js_string_from_bytes(b"b".as_ptr(), 1);
+        crate::object::js_object_set_field_by_name(
+            obj_handle.get_raw_mut_ptr::<crate::ObjectHeader>(),
+            key_ptr,
+            nested_handle.get_nanbox_f64(),
+        );
+    }
+    set_string_field(&scope, &obj_handle, b"c", b"last");
+
+    let before = gc_collection_count();
+    let out = unsafe {
+        crate::json::js_json_stringify(
+            f64::from_bits(ptr_bits(obj_handle.get_raw_mut_ptr::<u8>() as usize)),
+            0,
+        )
+    };
+    assert!(
+        gc_collection_count() > before,
+        "nested toJSON should force a copied-minor GC mid-stringify"
+    );
+    unsafe {
+        assert_string_bytes(out, br#"{"a":"first","b":"tojson-out","c":"last"}"#);
+    }
+}
+
+/// `JSON.stringify` of an array whose MIDDLE element serializes through a
+/// GC-forcing `toJSON`: the elements after it must be read through the
+/// re-derived element base (the pre-fix code hoisted `elements` once).
+#[test]
+fn test_json_stringify_array_rederives_elements_after_tojson_minor_gc() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    register_runtime_handle_root_scanner_for_tests();
+
+    let scope = RuntimeHandleScope::new();
+    let arr = crate::array::js_array_alloc(3);
+    let arr_handle = scope.root_raw_mut_ptr(arr);
+    let first = scope.root_nanbox_f64(test_string_value(b"head"));
+    let nested = scope.root_nanbox_f64(json_test_object_with_gc_forcing_tojson(&scope));
+    let last = scope.root_nanbox_f64(test_string_value(b"tail"));
+    for value in [&first, &nested, &last] {
+        let arr = crate::array::js_array_push(
+            arr_handle.get_raw_mut_ptr::<crate::array::ArrayHeader>(),
+            crate::JSValue::from_bits(value.get_nanbox_f64().to_bits()),
+        );
+        arr_handle.set_raw_mut_ptr(arr);
+    }
+
+    let before = gc_collection_count();
+    let out = unsafe {
+        crate::json::js_json_stringify(
+            f64::from_bits(ptr_bits(arr_handle.get_raw_mut_ptr::<u8>() as usize)),
+            0,
+        )
+    };
+    assert!(
+        gc_collection_count() > before,
+        "element toJSON should force a copied-minor GC mid-stringify"
+    );
+    unsafe {
+        assert_string_bytes(out, br#"["head","tojson-out","tail"]"#);
+    }
+}
+
+extern "C" fn test_replacer_force_minor_gc(
+    _closure: *const crate::closure::ClosureHeader,
+    matched: f64,
+    _offset: f64,
+    _whole: f64,
+) -> f64 {
+    let scope = RuntimeHandleScope::new();
+    let matched_handle = scope.root_nanbox_f64(matched);
+    let _ = crate::gc::gc_collect_minor();
+    // The matched argument must still be a live string after the collection.
+    let _ = string_value_content(matched_handle.get_nanbox_f64());
+    test_string_value(b"<R>")
+}
+
+/// `String.prototype.replaceAll(pattern, fn)` where every replacer call
+/// forces a copied minor GC: the subject's `&str` view must be re-derived
+/// from the rooted handle for the between-match slices (the pre-fix code
+/// cached `str_data` once and kept a live `match_indices` borrow across the
+/// callbacks).
+#[test]
+fn test_string_replace_all_fn_rederives_subject_after_callback_minor_gc() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    register_runtime_handle_root_scanner_for_tests();
+
+    let scope = RuntimeHandleScope::new();
+    let callback = crate::closure::js_closure_alloc(test_replacer_force_minor_gc as *const u8, 0);
+    let callback_handle = scope.root_raw_mut_ptr(callback);
+    let s = crate::string::js_string_from_bytes(b"one--two--three".as_ptr(), 15);
+    let s_handle = scope.root_string_ptr(s);
+    let pattern = crate::string::js_string_from_bytes(b"--".as_ptr(), 2);
+    let pattern_handle = scope.root_string_ptr(pattern);
+
+    let before = gc_collection_count();
+    let out = crate::regex::js_string_replace_all_string_fn(
+        s_handle.get_raw_const_ptr::<crate::StringHeader>(),
+        pattern_handle.get_raw_const_ptr::<crate::StringHeader>(),
+        f64::from_bits(ptr_bits(callback_handle.get_raw_mut_ptr::<u8>() as usize)),
+    );
+    assert!(
+        gc_collection_count() > before,
+        "replacer should force copied-minor GCs during replaceAll"
+    );
+    unsafe {
+        assert_string_bytes(out, b"one<R>two<R>three");
+    }
+}
+
+extern "C" fn test_bigint_comparator_force_minor_gc(
+    _closure: *const crate::closure::ClosureHeader,
+    a: f64,
+    b: f64,
+) -> f64 {
+    let scope = RuntimeHandleScope::new();
+    let a_handle = scope.root_nanbox_f64(a);
+    let b_handle = scope.root_nanbox_f64(b);
+    let _ = crate::gc::gc_collect_minor();
+    let read = |value: f64| -> i64 {
+        let bits = value.to_bits();
+        let ptr = (bits & POINTER_MASK) as *const crate::bigint::BigIntHeader;
+        let cleaned = crate::bigint::clean_bigint_ptr(ptr);
+        assert!(!cleaned.is_null(), "comparator arg should be a live BigInt");
+        unsafe { (*cleaned).limbs[0] as i64 }
+    };
+    let av = read(a_handle.get_nanbox_f64());
+    let bv = read(b_handle.get_nanbox_f64());
+    match av.cmp(&bv) {
+        std::cmp::Ordering::Less => -1.0,
+        std::cmp::Ordering::Equal => 0.0,
+        std::cmp::Ordering::Greater => 1.0,
+    }
+}
+
+/// `BigInt64Array.prototype.sort(comparator)` where every comparator call
+/// forces a copied minor GC: the raw lanes are sorted through an owned Rust
+/// buffer with two per-compare boxed (and rooted) BigInts — the pre-fix code
+/// parked a `Vec<f64>` full of unrooted BigInt boxes across every call.
+#[test]
+fn test_bigint64_sort_comparator_boxes_survive_copied_minor_gc() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    register_runtime_handle_root_scanner_for_tests();
+
+    let scope = RuntimeHandleScope::new();
+    let comparator =
+        crate::closure::js_closure_alloc(test_bigint_comparator_force_minor_gc as *const u8, 0);
+    let comparator_handle = scope.root_raw_const_ptr(comparator);
+
+    let lanes: [i64; 6] = [42, -7, 1_000_000_000_007, 0, -900_000_000_001, 13];
+    let ta = crate::typedarray::typed_array_alloc(crate::typedarray::KIND_BIGINT64, 6);
+    unsafe {
+        let base = crate::typedarray::data_ptr_mut(ta) as *mut i64;
+        for (i, v) in lanes.iter().enumerate() {
+            *base.add(i) = *v;
+        }
+    }
+
+    let before = gc_collection_count();
+    let sorted = crate::typedarray::js_typed_array_sort_with_comparator(
+        ta,
+        comparator_handle.get_raw_const_ptr::<crate::closure::ClosureHeader>(),
+    );
+    assert!(
+        gc_collection_count() > before,
+        "comparator should force copied-minor GCs during the BigInt64 sort"
+    );
+    unsafe {
+        let base = crate::typedarray::data_ptr_mut(sorted) as *const i64;
+        let mut expected = lanes;
+        expected.sort_unstable();
+        for (i, v) in expected.iter().enumerate() {
+            assert_eq!(
+                *base.add(i),
+                *v,
+                "lane {i} should hold the comparator-sorted value"
+            );
+        }
+    }
+}

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -1081,10 +1081,24 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
     }
     let keys_arr = (*obj).keys_array;
     let keys_len = (*keys_arr).length;
-    let keys_elements =
-        (keys_arr as *const u8).add(std::mem::size_of::<crate::ArrayHeader>()) as *const f64;
-    let fields_ptr =
-        (ptr as *const u8).add(std::mem::size_of::<crate::ObjectHeader>()) as *const f64;
+    // Root the object for the enumeration below and re-derive the keys/field
+    // buffers from the CURRENT header on every access: a user getter
+    // (`json_object_getter_value`), a `toJSON` somewhere inside a nested
+    // value, or any allocation in the recursive `stringify_value_depth` call
+    // can trigger a GC that sweeps or moves this object — bare Rust locals
+    // are invisible to the collector (production runs no conservative stack
+    // scan), and alloc-point minors can be MOVING under the evacuation
+    // policy. The keys array is re-derived THROUGH the object header (its
+    // `keys_array` field is rewritten by the collector when it moves).
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let obj_handle = scope.root_raw_const_ptr(obj);
+    let cur_obj = || obj_handle.get_raw_const_ptr::<crate::ObjectHeader>();
+    let key_at = |f: u32| -> f64 {
+        let keys_arr = (*cur_obj()).keys_array;
+        let keys_elements =
+            (keys_arr as *const u8).add(std::mem::size_of::<crate::ArrayHeader>()) as *const f64;
+        *keys_elements.add(f as usize)
+    };
     // Closes #307: iterate up to keys_len, not min(num_fields, keys_len).
     // Parser-built objects with ≥9 fields cap field_count at the inline
     // alloc_limit (max(field_count, 8) physical slots) and store the overflow
@@ -1098,7 +1112,10 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
     // for any parsed object with ≥9 fields.
     let alloc_limit = std::cmp::max(num_fields, 8);
     let read_field_bits = |f: u32| -> u64 {
+        let obj = cur_obj();
         if f < alloc_limit {
+            let fields_ptr =
+                (obj as *const u8).add(std::mem::size_of::<crate::ObjectHeader>()) as *const f64;
             (*fields_ptr.add(f as usize)).to_bits()
         } else {
             crate::object::js_object_get_field(obj, f).bits()
@@ -1216,15 +1233,15 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
         // not serializable own properties. (`has_prototype_chain` == class_id != 0.)
         if has_prototype_chain
             && crate::object::instance_private_key_hidden(
-                obj,
-                JSValue::from_bits((*keys_elements.add(f as usize)).to_bits()),
+                cur_obj(),
+                JSValue::from_bits(key_at(f).to_bits()),
             )
         {
             continue;
         }
         // Skip non-enumerable own keys (e.g. `Object.defineProperty(o, k,
         // { enumerable: false })`) before touching the value.
-        if filter_non_enum && json_key_non_enumerable(obj, *keys_elements.add(f as usize)) {
+        if filter_non_enum && json_key_non_enumerable(cur_obj(), key_at(f)) {
             continue;
         }
         let mut field_bits = read_field_bits(f);
@@ -1232,10 +1249,10 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
         // invokes the getter), not the raw slot — which holds the getter
         // closure (object-literal `get x() {}`) or an empty placeholder
         // (`Object.defineProperty(o, k, { get })`). Gated on the descriptor flag.
+        // The getter is USER CODE: every pointer below is re-derived from the
+        // rooted handle after it returns.
         if filter_non_enum {
-            if let Some(gv) =
-                crate::object::json_object_getter_value(obj, *keys_elements.add(f as usize))
-            {
+            if let Some(gv) = crate::object::json_object_getter_value(cur_obj(), key_at(f)) {
                 field_bits = gv.to_bits();
             }
         }
@@ -1257,7 +1274,7 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
         }
         first = false;
 
-        let key_f64 = *keys_elements.add(f as usize);
+        let key_f64 = key_at(f);
         let key_bits = key_f64.to_bits();
         let key_tag = key_bits & 0xFFFF_0000_0000_0000;
         let key_ptr = if key_tag == STRING_TAG || key_tag == POINTER_TAG {
@@ -1683,7 +1700,18 @@ pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, dep
     }
     STRINGIFY_STACK.with(|s| s.borrow_mut().push(arr as usize));
     let len = (*arr).length;
-    let elements = (arr as *const u8).add(std::mem::size_of::<crate::ArrayHeader>()) as *const f64;
+    // Root the array and re-derive the element base per access: a nested
+    // `toJSON` / getter / any allocation inside the recursive serialization
+    // below can trigger a GC that sweeps or moves this array while a hoisted
+    // `elements` pointer still aims at the old storage (no conservative
+    // stack scan in production; alloc-point minors can be moving under the
+    // evacuation policy).
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let arr_handle = scope.root_raw_const_ptr(arr);
+    let elem_at = |i: usize| -> f64 {
+        let arr = arr_handle.get_raw_const_ptr::<crate::ArrayHeader>();
+        *((arr as *const u8).add(std::mem::size_of::<crate::ArrayHeader>()) as *const f64).add(i)
+    };
 
     // Homogeneous-shape fast path for arrays of objects sharing one
     // `keys_array` (issue #59). The template is built from element 0 and
@@ -1693,7 +1721,7 @@ pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, dep
     // function call entirely for arrays of primitives (issue #64) — common
     // for nested fields like `tags: ["x","y"]` that fired per-element.
     let template = if len >= 2 {
-        let first_bits = (*elements).to_bits();
+        let first_bits = elem_at(0).to_bits();
         let tag = first_bits & 0xFFFF_0000_0000_0000;
         let first_ptr = if tag == POINTER_TAG {
             (first_bits & POINTER_MASK) as *const u8
@@ -1714,7 +1742,7 @@ pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, dep
             // #3857: a boxed primitive wrapper has no own enumerable keys, so an
             // object-shape template would render it (and the whole array) as
             // `{}`. Fall through to per-element handling, which unwraps it.
-            && crate::builtins::boxed_primitive_json_value(*elements).is_none()
+            && crate::builtins::boxed_primitive_json_value(elem_at(0)).is_none()
         {
             build_shape_prefix_template(first_bits)
         } else {
@@ -1730,7 +1758,9 @@ pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, dep
             if i > 0 {
                 buf.push(',');
             }
-            let elem = *elements.add(i as usize);
+            // Re-derived per element: the previous element's serialization can
+            // have run user code / allocated (and moved this array).
+            let elem = elem_at(i as usize);
             let elem_bits = elem.to_bits();
             if !try_emit_shape_element(elem_bits, tmpl, buf, depth) {
                 // Match the slow path: array descent does not bump depth.
@@ -1747,7 +1777,9 @@ pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, dep
         if i > 0 {
             buf.push(',');
         }
-        let elem = *elements.add(i as usize);
+        // Re-derived per element: the previous element's serialization can
+        // have run user code / allocated (and moved this array).
+        let elem = elem_at(i as usize);
         let elem_bits = elem.to_bits();
         let elem_tag = elem_bits & 0xFFFF_0000_0000_0000;
 

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -54,7 +54,7 @@ pub use escape::js_regexp_escape;
 #[cfg(feature = "regex-engine")]
 use exec_array::{
     byte_index_to_char_index, char_index_to_byte, set_exec_array_groups, set_exec_array_indices,
-    set_exec_array_indices_fancy, set_exec_array_metadata,
+    set_exec_array_indices_fancy, set_exec_array_metadata, set_exec_array_metadata_value,
 };
 #[cfg(feature = "regex-engine")]
 use grammar::{

--- a/crates/perry-runtime/src/regex/exec_array.rs
+++ b/crates/perry-runtime/src/regex/exec_array.rs
@@ -25,6 +25,33 @@ pub(super) fn set_exec_array_metadata(arr: *mut ArrayHeader, input: &str, index:
     crate::array::js_array_set_string_key(arr, input_key, input_value);
 }
 
+/// [`set_exec_array_metadata`] variant taking the `input` property as an
+/// already-boxed string VALUE (typically the rooted original subject) instead
+/// of a `&str` to copy. Both the array and the input value are rooted across
+/// the internal key-string allocations, which can trigger a (potentially
+/// moving) minor GC.
+pub(super) fn set_exec_array_metadata_value(arr: *mut ArrayHeader, input_value: f64, index: f64) {
+    if arr.is_null() {
+        return;
+    }
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let arr_handle = scope.root_raw_mut_ptr(arr);
+    let input_handle = scope.root_nanbox_f64(input_value);
+    let index_key = js_string_from_str("index");
+    crate::array::js_array_set_string_key(
+        arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
+        index_key,
+        index,
+    );
+
+    let input_key = js_string_from_str("input");
+    crate::array::js_array_set_string_key(
+        arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
+        input_key,
+        input_handle.get_nanbox_f64(),
+    );
+}
+
 /// Attach the `groups` own property to a regex match-result array.
 ///
 /// Mirrors `set_exec_array_metadata` for `index`/`input`: the result of

--- a/crates/perry-runtime/src/regex/match_all.rs
+++ b/crates/perry-runtime/src/regex/match_all.rs
@@ -1,9 +1,7 @@
-use regex::Regex;
-
 use super::{
     byte_index_to_char_index, char_index_to_byte, is_valid_ptr, is_valid_regex_ptr, js_regexp_new,
-    js_string_from_str, set_exec_array_metadata, string_as_str, throw_match_all_non_global_regex,
-    RegExpHeader,
+    js_string_from_str, set_exec_array_metadata_value, string_as_str,
+    throw_match_all_non_global_regex, RegExpHeader,
 };
 use crate::array::ArrayHeader;
 use crate::object::ObjectHeader;
@@ -17,41 +15,62 @@ use crate::value::{
 /// dispatch can reference it even when this engine module is gated out).
 use super::REGEXP_STRING_ITERATOR_CLASS_ID;
 
-fn build_match_all_groups(
-    regex: &Regex,
-    caps: &regex::Captures<'_>,
+/// Owned, GC-inert snapshot of one matchAll result, copied OUT of the subject
+/// string before the allocating phase below. There is no user callback here —
+/// sweeping isn't the risk (internal allocations only), MOVING is: an
+/// alloc-point minor can be moving under the evacuation policy, and both a
+/// cached `&str` and the `Captures` borrowing it would silently read
+/// from-space after the subject relocates (2026-07-09 audit, wave 1).
+struct OwnedMatchAllData {
+    /// Group 0 (full match) + capture groups (None = non-participating).
+    groups: Vec<Option<String>>,
+    /// Named groups in declaration order: (name, text).
+    named: Vec<(String, Option<String>)>,
+    /// Char index of the match start in the full subject.
+    match_index: f64,
+}
+
+/// Build the named-capture `groups` object from an owned snapshot, or return
+/// `undefined` when the pattern declares no named groups.
+fn build_match_all_groups_owned(
+    named: &[(String, Option<String>)],
     scope: &crate::gc::RuntimeHandleScope,
 ) -> f64 {
-    let group_names: Vec<(&str, Option<regex::Match<'_>>)> = regex
-        .capture_names()
-        .enumerate()
-        .filter_map(|(i, name)| name.map(|n| (n, caps.get(i))))
-        .collect();
-
-    if group_names.is_empty() {
+    if named.is_empty() {
         return f64::from_bits(TAG_UNDEFINED);
     }
-
     let groups_obj = crate::object::js_object_alloc(0, 0);
     let groups_handle = scope.root_raw_mut_ptr(groups_obj);
-    for (name, m) in &group_names {
-        let val = if let Some(m) = m {
-            let str_ptr = js_string_from_str(m.as_str());
-            js_nanbox_string(str_ptr as i64)
-        } else {
-            f64::from_bits(TAG_UNDEFINED)
+    for (name, text) in named {
+        let val = match text {
+            Some(t) => js_nanbox_string(js_string_from_str(t) as i64),
+            None => f64::from_bits(TAG_UNDEFINED),
         };
+        // Root the value across the key allocation below.
+        let val_handle = scope.root_nanbox_f64(val);
         let key_ptr = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
         let groups_obj = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
-        crate::object::js_object_set_field_by_name(groups_obj, key_ptr, val);
+        crate::object::js_object_set_field_by_name(
+            groups_obj,
+            key_ptr,
+            val_handle.get_nanbox_f64(),
+        );
     }
-    let groups_obj = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
-    js_nanbox_pointer(groups_obj as i64)
+    js_nanbox_pointer(groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>() as i64)
 }
 
 fn set_match_all_groups(arr: *mut ArrayHeader, groups_value: f64) {
+    // Root both sides across the key-string allocation (a moving minor at
+    // that point would leave either raw local stale).
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let arr_handle = scope.root_raw_mut_ptr(arr);
+    let groups_handle = scope.root_nanbox_f64(groups_value);
     let groups_key = js_string_from_str("groups");
-    crate::array::js_array_set_string_key(arr, groups_key, groups_value);
+    crate::array::js_array_set_string_key(
+        arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
+        groups_key,
+        groups_handle.get_nanbox_f64(),
+    );
 }
 
 unsafe fn materialize_match_all_results(
@@ -63,95 +82,96 @@ unsafe fn materialize_match_all_results(
         return crate::array::js_array_alloc(0);
     }
 
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let s_handle = scope.root_string_ptr(s);
+
+    // Phase 1 (borrowing, no JS allocation): snapshot every match into owned
+    // Rust data. The fancy-regex fallback (lookbehind/backreferences) is
+    // needed because the never-match placeholder in `regex_ptr` would yield
+    // an empty iterator otherwise.
     let str_data = string_as_str(s);
     let search_start = char_index_to_byte(str_data, start_char_index);
     let search_str = &str_data[search_start..];
 
-    // Fancy-regex fallback (lookbehind/backreferences): the never-match
-    // placeholder in `regex_ptr` would yield an empty iterator otherwise.
-    // Mirrors the standard-engine loop below, including named-group `groups`.
+    let mut owned: Vec<OwnedMatchAllData> = Vec::new();
     if let Some(fre) = super::lookup_fancy_regex(re) {
-        let mut all_caps: Vec<fancy_regex::Captures> = Vec::new();
+        let named_names: Vec<(usize, String)> = fre
+            .capture_names()
+            .enumerate()
+            .filter_map(|(i, name)| name.map(|n| (i, n.to_string())))
+            .collect();
         let mut it = fre.captures_iter(search_str);
-        while let Some(Ok(c)) = it.next() {
-            all_caps.push(c);
+        while let Some(Ok(caps)) = it.next() {
+            owned.push(OwnedMatchAllData {
+                groups: (0..caps.len())
+                    .map(|j| caps.get(j).map(|m| m.as_str().to_string()))
+                    .collect(),
+                named: named_names
+                    .iter()
+                    .map(|(gi, n)| (n.clone(), caps.get(*gi).map(|m| m.as_str().to_string())))
+                    .collect(),
+                match_index: caps
+                    .get(0)
+                    .map(|m| byte_index_to_char_index(str_data, search_start + m.start()))
+                    .unwrap_or(start_char_index as f64),
+            });
         }
-        let outer = crate::array::js_array_alloc(all_caps.len() as u32);
-        let scope = crate::gc::RuntimeHandleScope::new();
-        let outer_handle = scope.root_raw_mut_ptr(outer);
-        (*outer_handle.get_raw_mut_ptr::<ArrayHeader>()).length = all_caps.len() as u32;
-
-        for (i, caps) in all_caps.iter().enumerate() {
-            let inner = crate::array::js_array_alloc(caps.len() as u32);
-            let inner_handle = scope.root_raw_mut_ptr(inner);
-            (*inner_handle.get_raw_mut_ptr::<ArrayHeader>()).length = caps.len() as u32;
-
-            for j in 0..caps.len() {
-                let value = if let Some(m) = caps.get(j) {
-                    let str_ptr = js_string_from_str(m.as_str());
-                    js_nanbox_string(str_ptr as i64)
-                } else {
-                    f64::from_bits(TAG_UNDEFINED)
-                };
-                let inner = inner_handle.get_raw_mut_ptr::<ArrayHeader>();
-                crate::array::store_array_slot(inner, j, value.to_bits());
-            }
-
-            let match_index = caps
-                .get(0)
-                .map(|m| byte_index_to_char_index(str_data, search_start + m.start()))
-                .unwrap_or_else(|| start_char_index as f64);
-            let inner = inner_handle.get_raw_mut_ptr::<ArrayHeader>();
-            set_exec_array_metadata(inner, str_data, match_index);
-            let groups_ptr = super::build_fancy_groups(&fre, caps, &scope);
-            let groups_value = if groups_ptr.is_null() {
-                f64::from_bits(TAG_UNDEFINED)
-            } else {
-                js_nanbox_pointer(groups_ptr as i64)
-            };
-            set_match_all_groups(inner, groups_value);
-
-            let inner_boxed = js_nanbox_pointer(inner as i64);
-            let outer = outer_handle.get_raw_mut_ptr::<ArrayHeader>();
-            crate::array::store_array_slot(outer, i, inner_boxed.to_bits());
+    } else {
+        let regex = &*(*re).regex_ptr;
+        let named_names: Vec<(usize, String)> = regex
+            .capture_names()
+            .enumerate()
+            .filter_map(|(i, name)| name.map(|n| (i, n.to_string())))
+            .collect();
+        for caps in regex.captures_iter(search_str) {
+            owned.push(OwnedMatchAllData {
+                groups: (0..caps.len())
+                    .map(|j| caps.get(j).map(|m| m.as_str().to_string()))
+                    .collect(),
+                named: named_names
+                    .iter()
+                    .map(|(gi, n)| (n.clone(), caps.get(*gi).map(|m| m.as_str().to_string())))
+                    .collect(),
+                match_index: caps
+                    .get(0)
+                    .map(|m| byte_index_to_char_index(str_data, search_start + m.start()))
+                    .unwrap_or(start_char_index as f64),
+            });
         }
-
-        return outer_handle.get_raw_mut_ptr::<ArrayHeader>();
     }
 
-    let regex = &*(*re).regex_ptr;
-    let all_caps: Vec<regex::Captures<'_>> = regex.captures_iter(search_str).collect();
-    let outer = crate::array::js_array_alloc(all_caps.len() as u32);
-    let scope = crate::gc::RuntimeHandleScope::new();
+    // Phase 2 (allocating, no borrows into the subject): build the result
+    // arrays from the owned snapshots. Every heap pointer lives in a rooted
+    // handle and is re-derived after each allocation; the `input` metadata
+    // is the rooted subject itself (same string value, current address).
+    let outer = crate::array::js_array_alloc(owned.len() as u32);
     let outer_handle = scope.root_raw_mut_ptr(outer);
-    (*outer_handle.get_raw_mut_ptr::<ArrayHeader>()).length = all_caps.len() as u32;
+    (*outer_handle.get_raw_mut_ptr::<ArrayHeader>()).length = owned.len() as u32;
 
-    for (i, caps) in all_caps.iter().enumerate() {
-        let inner = crate::array::js_array_alloc(caps.len() as u32);
-        let inner_handle = scope.root_raw_mut_ptr(inner);
-        (*inner_handle.get_raw_mut_ptr::<ArrayHeader>()).length = caps.len() as u32;
+    for (i, m) in owned.iter().enumerate() {
+        let match_scope = crate::gc::RuntimeHandleScope::new();
+        let inner = crate::array::js_array_alloc(m.groups.len() as u32);
+        let inner_handle = match_scope.root_raw_mut_ptr(inner);
+        (*inner_handle.get_raw_mut_ptr::<ArrayHeader>()).length = m.groups.len() as u32;
 
-        for (j, cap) in caps.iter().enumerate() {
-            let value = if let Some(m) = cap {
-                let str_ptr = js_string_from_str(m.as_str());
-                js_nanbox_string(str_ptr as i64)
-            } else {
-                f64::from_bits(TAG_UNDEFINED)
+        for (j, group) in m.groups.iter().enumerate() {
+            let value = match group {
+                Some(text) => js_nanbox_string(js_string_from_str(text) as i64),
+                None => f64::from_bits(TAG_UNDEFINED),
             };
             let inner = inner_handle.get_raw_mut_ptr::<ArrayHeader>();
             crate::array::store_array_slot(inner, j, value.to_bits());
         }
 
-        let match_index = caps
-            .get(0)
-            .map(|m| byte_index_to_char_index(str_data, search_start + m.start()))
-            .unwrap_or_else(|| start_char_index as f64);
-        let inner = inner_handle.get_raw_mut_ptr::<ArrayHeader>();
-        set_exec_array_metadata(inner, str_data, match_index);
-        let groups_value = build_match_all_groups(regex, caps, &scope);
-        set_match_all_groups(inner, groups_value);
+        set_exec_array_metadata_value(
+            inner_handle.get_raw_mut_ptr::<ArrayHeader>(),
+            js_nanbox_string(s_handle.get_raw_const_ptr::<StringHeader>() as i64),
+            m.match_index,
+        );
+        let groups_value = build_match_all_groups_owned(&m.named, &match_scope);
+        set_match_all_groups(inner_handle.get_raw_mut_ptr::<ArrayHeader>(), groups_value);
 
-        let inner_boxed = js_nanbox_pointer(inner as i64);
+        let inner_boxed = js_nanbox_pointer(inner_handle.get_raw_mut_ptr::<ArrayHeader>() as i64);
         let outer = outer_handle.get_raw_mut_ptr::<ArrayHeader>();
         crate::array::store_array_slot(outer, i, inner_boxed.to_bits());
     }
@@ -160,11 +180,16 @@ unsafe fn materialize_match_all_results(
 }
 
 unsafe fn alloc_regexp_string_iterator(matches: *mut ArrayHeader) -> *mut ObjectHeader {
+    // Root the matches array across the iterator-object allocation.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let matches_handle = scope.root_raw_mut_ptr(matches);
     let obj = crate::object::js_object_alloc(REGEXP_STRING_ITERATOR_CLASS_ID, 2);
     crate::object::js_object_set_field(
         obj,
         0,
-        JSValue::from_bits(js_nanbox_pointer(matches as i64).to_bits()),
+        JSValue::from_bits(
+            js_nanbox_pointer(matches_handle.get_raw_mut_ptr::<ArrayHeader>() as i64).to_bits(),
+        ),
     );
     crate::object::js_object_set_field(obj, 1, JSValue::number(0.0));
     crate::object::attach_iterator_prototype(obj, REGEXP_STRING_ITERATOR_CLASS_ID);
@@ -196,6 +221,12 @@ pub extern "C" fn js_string_match_all_value(
         return unsafe { alloc_regexp_string_iterator(empty) };
     }
 
+    // Root the subject across the pattern→RegExp conversion below, which
+    // allocates (ToString of the pattern, the "g" flags string, the RegExp
+    // registration) before `materialize_match_all_results` roots it again.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let s_handle = scope.root_string_ptr(s);
+
     let pattern_jsval = JSValue::from_bits(pattern_value.to_bits());
     let raw = if pattern_jsval.is_pointer() {
         js_nanbox_get_pointer(pattern_value)
@@ -217,7 +248,13 @@ pub extern "C" fn js_string_match_all_value(
         )
     };
 
-    let matches = unsafe { materialize_match_all_results(s, re, start_index) };
+    let matches = unsafe {
+        materialize_match_all_results(
+            s_handle.get_raw_const_ptr::<StringHeader>(),
+            re,
+            start_index,
+        )
+    };
     unsafe { alloc_regexp_string_iterator(matches) }
 }
 

--- a/crates/perry-runtime/src/regex/replace_expand.rs
+++ b/crates/perry-runtime/src/regex/replace_expand.rs
@@ -118,78 +118,88 @@ pub(super) fn expand_js_replacement(
     out
 }
 
-/// Fancy-regex fallback for `js_string_replace_regex_fn`: used when the pattern
-/// needs lookahead/backreferences that the `regex` crate can't compile. Mirrors
-/// the standard-engine loop below (full ECMAScript callback argument list,
-/// char-based offset, named-group `groups` object) but drives the match loop
-/// with `fancy_regex`.
-pub(super) unsafe fn replace_regex_fn_fancy(
-    str_data: &str,
-    fre: &fancy_regex::Regex,
-    global: bool,
+/// Owned, GC-inert snapshot of one match: everything the callback-argument
+/// builder needs, copied OUT of the subject string BEFORE any JS allocation
+/// or callback runs. The old code kept `Captures` (borrows of the heap
+/// subject) alive across the callback loop: from the 2nd match on, every
+/// `.as_str()` read through the ORIGINAL base address, which a moving GC
+/// during an earlier callback had already retired (2026-07-09 audit, wave 1).
+struct OwnedMatchData {
+    /// Full-match byte range in the subject.
+    start: usize,
+    end: usize,
+    /// Char offset of the match start (the callback's `offset` argument).
+    char_offset: usize,
+    /// Group 0 (full match) + capture groups (None = non-participating).
+    groups: Vec<Option<String>>,
+    /// Named groups in declaration order: (name, text).
+    named: Vec<(String, Option<String>)>,
+}
+
+/// Shared callback-replace loop over pre-snapshotted matches. The subject is
+/// rooted (`s_handle`) and re-derived after every callback; the callback
+/// closure is rooted too, so a GC it triggers relocates — not strands — it.
+unsafe fn replace_fn_run_matches(
+    s_handle: &crate::gc::RuntimeHandle<'_>,
+    matches: &[OwnedMatchData],
     closure_ptr: *const crate::closure::ClosureHeader,
+    has_named_groups: bool,
 ) -> *mut StringHeader {
-    const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
-
-    let has_named_groups = fre.capture_names().any(|n| n.is_some());
-
-    // Collect captures up front so a GC during callback dispatch can't disturb
-    // the iterator's borrow of `str_data`.
-    let mut captures_list: Vec<fancy_regex::Captures> = Vec::new();
-    let mut iter = fre.captures_iter(str_data);
-    while let Some(Ok(caps)) = iter.next() {
-        captures_list.push(caps);
-        if !global {
-            break;
-        }
+    let cur_str = || string_as_str(s_handle.get_raw_const_ptr::<StringHeader>());
+    if matches.is_empty() {
+        return js_string_from_str(cur_str());
     }
+    let outer = crate::gc::RuntimeHandleScope::new();
+    let closure_handle = outer.root_raw_const_ptr(closure_ptr);
 
     let mut result = String::new();
     let mut last_end = 0usize;
 
-    for caps in &captures_list {
-        let full_match = caps.get(0).unwrap();
-        result.push_str(&str_data[last_end..full_match.start()]);
+    for m in matches {
+        // Between-match text is re-sliced from the CURRENT subject address
+        // (the previous callback may have moved the string).
+        result.push_str(&cur_str()[last_end..m.start]);
 
-        let char_offset = str_data[..full_match.start()].chars().count();
-
+        // Build the full ECMAScript callback argument list:
+        //   (match, p1, ..., pN, offset, string, groups?)
+        // Every NaN-boxed heap value is rooted as it is created, so the next
+        // allocation can't reclaim (or silently move) an earlier argument.
         let scope = crate::gc::RuntimeHandleScope::new();
         let mut arg_handles: Vec<crate::gc::RuntimeHandle<'_>> = Vec::new();
 
-        let match_nanboxed = js_nanbox_string(js_string_from_str(full_match.as_str()) as i64);
-        arg_handles.push(scope.root_nanbox_f64(match_nanboxed));
-
-        let num_groups = caps.len() - 1; // exclude full match
-        for gi in 1..=num_groups {
-            let group_val = if let Some(m) = caps.get(gi) {
-                js_nanbox_string(js_string_from_str(m.as_str()) as i64)
-            } else {
-                f64::from_bits(TAG_UNDEFINED)
+        for group in &m.groups {
+            let group_val = match group {
+                Some(text) => js_nanbox_string(js_string_from_str(text) as i64),
+                None => f64::from_bits(crate::value::TAG_UNDEFINED),
             };
             arg_handles.push(scope.root_nanbox_f64(group_val));
         }
 
-        arg_handles.push(scope.root_nanbox_f64(char_offset as f64));
-        let string_nanboxed = js_nanbox_string(js_string_from_str(str_data) as i64);
-        arg_handles.push(scope.root_nanbox_f64(string_nanboxed));
+        arg_handles.push(scope.root_nanbox_f64(m.char_offset as f64));
+        // The `string` argument is the subject itself — pass the rooted
+        // original (same string value, current address) instead of
+        // allocating a fresh copy per match.
+        arg_handles.push(scope.root_nanbox_f64(js_nanbox_string(
+            s_handle.get_raw_const_ptr::<StringHeader>() as i64,
+        )));
 
         if has_named_groups {
             let groups_obj = crate::object::js_object_alloc(0, 0);
             let groups_handle = scope.root_raw_mut_ptr(groups_obj);
-            let group_names: Vec<(&str, Option<fancy_regex::Match>)> = fre
-                .capture_names()
-                .enumerate()
-                .filter_map(|(i, name)| name.map(|n| (n, caps.get(i))))
-                .collect();
-            for (name, m) in &group_names {
-                let val = if let Some(m) = m {
-                    js_nanbox_string(js_string_from_str(m.as_str()) as i64)
-                } else {
-                    f64::from_bits(TAG_UNDEFINED)
+            for (name, text) in &m.named {
+                let val = match text {
+                    Some(t) => js_nanbox_string(js_string_from_str(t) as i64),
+                    None => f64::from_bits(crate::value::TAG_UNDEFINED),
                 };
+                // Root the value across the key allocation below.
+                let val_handle = scope.root_nanbox_f64(val);
                 let key_ptr = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
                 let groups_obj = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
-                crate::object::js_object_set_field_by_name(groups_obj, key_ptr, val);
+                crate::object::js_object_set_field_by_name(
+                    groups_obj,
+                    key_ptr,
+                    val_handle.get_nanbox_f64(),
+                );
             }
             let groups_ptr = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
             let groups_value = crate::value::js_nanbox_pointer(groups_ptr as i64);
@@ -197,15 +207,61 @@ pub(super) unsafe fn replace_regex_fn_fancy(
         }
 
         let call_args: Vec<f64> = arg_handles.iter().map(|h| h.get_nanbox_f64()).collect();
-        let callback_value =
-            f64::from_bits(crate::value::JSValue::pointer(closure_ptr as *mut u8).bits());
+        let callback_value = f64::from_bits(
+            crate::value::JSValue::pointer(closure_handle.get_raw_const_ptr::<u8>()).bits(),
+        );
         result.push_str(&call_replace_callback(callback_value, &call_args));
 
-        last_end = full_match.end();
+        last_end = m.end;
     }
 
-    result.push_str(&str_data[last_end..]);
+    result.push_str(&cur_str()[last_end..]);
     js_string_from_str(&result)
+}
+
+/// Fancy-regex fallback for `js_string_replace_regex_fn`: used when the pattern
+/// needs lookahead/backreferences that the `regex` crate can't compile. Mirrors
+/// the standard-engine loop below (full ECMAScript callback argument list,
+/// char-based offset, named-group `groups` object) but drives the match loop
+/// with `fancy_regex`.
+pub(super) unsafe fn replace_regex_fn_fancy(
+    s_handle: &crate::gc::RuntimeHandle<'_>,
+    fre: &fancy_regex::Regex,
+    global: bool,
+    closure_ptr: *const crate::closure::ClosureHeader,
+) -> *mut StringHeader {
+    let has_named_groups = fre.capture_names().any(|n| n.is_some());
+    let named_names: Vec<(usize, String)> = fre
+        .capture_names()
+        .enumerate()
+        .filter_map(|(i, name)| name.map(|n| (i, n.to_string())))
+        .collect();
+
+    // Snapshot every match into owned data BEFORE the first callback (see
+    // `OwnedMatchData`).
+    let str_data = string_as_str(s_handle.get_raw_const_ptr::<StringHeader>());
+    let mut matches: Vec<OwnedMatchData> = Vec::new();
+    let mut iter = fre.captures_iter(str_data);
+    while let Some(Ok(caps)) = iter.next() {
+        let full_match = caps.get(0).unwrap();
+        matches.push(OwnedMatchData {
+            start: full_match.start(),
+            end: full_match.end(),
+            char_offset: str_data[..full_match.start()].chars().count(),
+            groups: (0..caps.len())
+                .map(|gi| caps.get(gi).map(|m| m.as_str().to_string()))
+                .collect(),
+            named: named_names
+                .iter()
+                .map(|(gi, n)| (n.clone(), caps.get(*gi).map(|m| m.as_str().to_string())))
+                .collect(),
+        });
+        if !global {
+            break;
+        }
+    }
+
+    replace_fn_run_matches(s_handle, &matches, closure_ptr, has_named_groups)
 }
 
 /// string.replace(regex, replacerFn) — replace with a callback function.
@@ -226,13 +282,19 @@ pub extern "C" fn js_string_replace_regex_fn(
     if !is_valid_ptr(s) {
         return js_string_from_str("");
     }
-    let str_data = string_as_str(s);
+
+    // Root the subject for the whole replace: the replacer callback is user
+    // code — it can allocate → trigger a minor GC → the subject is swept
+    // (bare Rust locals are invisible without a conservative stack scan) or
+    // moved. Match data is snapshotted into owned Rust strings BEFORE the
+    // first callback, and the `&str` view is re-derived from this handle
+    // after every callback.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let s_handle = scope.root_string_ptr(s);
 
     if !is_valid_regex_ptr(re) {
-        return js_string_from_str(str_data);
+        return js_string_from_str(string_as_str(s));
     }
-
-    const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
 
     unsafe {
         let regex = &*(*re).regex_ptr;
@@ -242,7 +304,7 @@ pub extern "C" fn js_string_replace_regex_fn(
         let closure_ptr =
             crate::value::js_nanbox_get_pointer(callback) as *const crate::closure::ClosureHeader;
         if closure_ptr.is_null() {
-            return js_string_from_str(str_data);
+            return js_string_from_str(string_as_str(s));
         }
 
         // If the `regex` crate couldn't compile this pattern (lookahead,
@@ -253,98 +315,47 @@ pub extern "C" fn js_string_replace_regex_fn(
         // silently match nothing and return the input unchanged. (get-intrinsic's
         // `stringToPath` relies on `String.prototype.replace(/…(?=…)…/g, fn)`.)
         if let Some(fre) = lookup_fancy_regex(re) {
-            return replace_regex_fn_fancy(str_data, &fre, global, closure_ptr);
+            return replace_regex_fn_fancy(&s_handle, &fre, global, closure_ptr);
         }
-
-        let mut result = String::new();
-        let mut last_end = 0usize;
-        let captures_iter: Vec<regex::Captures> = if global {
-            regex.captures_iter(str_data).collect()
-        } else {
-            match regex.captures(str_data) {
-                Some(caps) => vec![caps],
-                None => vec![],
-            }
-        };
 
         // Does the pattern declare any named capture groups? If so we pass a
         // trailing `groups` object to the callback (matching Node). Computed
         // once outside the match loop.
         let has_named_groups = regex.capture_names().any(|n| n.is_some());
+        let named_names: Vec<(usize, String)> = regex
+            .capture_names()
+            .enumerate()
+            .filter_map(|(i, name)| name.map(|n| (i, n.to_string())))
+            .collect();
 
-        for caps in &captures_iter {
+        // Snapshot every match into owned data BEFORE the first callback (see
+        // `OwnedMatchData`).
+        let str_data = string_as_str(s_handle.get_raw_const_ptr::<StringHeader>());
+        let mut matches: Vec<OwnedMatchData> = Vec::new();
+        let mut push_caps = |caps: regex::Captures<'_>| {
             let full_match = caps.get(0).unwrap();
-            result.push_str(&str_data[last_end..full_match.start()]);
-
-            // Calculate char offset for the offset parameter.
-            let char_offset = str_data[..full_match.start()].chars().count();
-
-            // Build the full ECMAScript callback argument list:
-            //   (match, p1, ..., pN, offset, string, groups?)
-            // Root every NaN-boxed value as we go so a GC triggered by a
-            // subsequent string/object/array allocation (or by the callback
-            // dispatch itself) can't reclaim earlier arguments.
-            let scope = crate::gc::RuntimeHandleScope::new();
-            let mut arg_handles: Vec<crate::gc::RuntimeHandle<'_>> = Vec::new();
-
-            let match_nanboxed = js_nanbox_string(js_string_from_str(full_match.as_str()) as i64);
-            arg_handles.push(scope.root_nanbox_f64(match_nanboxed));
-
-            // Capture groups 1..=N (undefined for non-participating groups).
-            let num_groups = caps.len() - 1; // exclude full match
-            for gi in 1..=num_groups {
-                let group_val = if let Some(m) = caps.get(gi) {
-                    js_nanbox_string(js_string_from_str(m.as_str()) as i64)
-                } else {
-                    f64::from_bits(TAG_UNDEFINED)
-                };
-                arg_handles.push(scope.root_nanbox_f64(group_val));
+            matches.push(OwnedMatchData {
+                start: full_match.start(),
+                end: full_match.end(),
+                char_offset: str_data[..full_match.start()].chars().count(),
+                groups: (0..caps.len())
+                    .map(|gi| caps.get(gi).map(|m| m.as_str().to_string()))
+                    .collect(),
+                named: named_names
+                    .iter()
+                    .map(|(gi, n)| (n.clone(), caps.get(*gi).map(|m| m.as_str().to_string())))
+                    .collect(),
+            });
+        };
+        if global {
+            for caps in regex.captures_iter(str_data) {
+                push_caps(caps);
             }
-
-            // offset (number) then the whole input string.
-            arg_handles.push(scope.root_nanbox_f64(char_offset as f64));
-            let string_nanboxed = js_nanbox_string(js_string_from_str(str_data) as i64);
-            arg_handles.push(scope.root_nanbox_f64(string_nanboxed));
-
-            // groups object (only when the pattern has named captures).
-            if has_named_groups {
-                let groups_obj = crate::object::js_object_alloc(0, 0);
-                let groups_handle = scope.root_raw_mut_ptr(groups_obj);
-                let group_names: Vec<(&str, Option<regex::Match>)> = regex
-                    .capture_names()
-                    .enumerate()
-                    .filter_map(|(i, name)| name.map(|n| (n, caps.get(i))))
-                    .collect();
-                for (name, m) in &group_names {
-                    let val = if let Some(m) = m {
-                        js_nanbox_string(js_string_from_str(m.as_str()) as i64)
-                    } else {
-                        f64::from_bits(TAG_UNDEFINED)
-                    };
-                    let key_ptr =
-                        crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-                    let groups_obj = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
-                    crate::object::js_object_set_field_by_name(groups_obj, key_ptr, val);
-                }
-                // Re-root the (possibly-moved) groups object as a NaN-boxed
-                // pointer value so it lands in the uniform `arg_handles` list
-                // alongside the other NaN-boxed callback args.
-                let groups_ptr = groups_handle.get_raw_mut_ptr::<crate::object::ObjectHeader>();
-                let groups_value = crate::value::js_nanbox_pointer(groups_ptr as i64);
-                arg_handles.push(scope.root_nanbox_f64(groups_value));
-            }
-
-            let call_args: Vec<f64> = arg_handles.iter().map(|h| h.get_nanbox_f64()).collect();
-            let callback_value =
-                f64::from_bits(crate::value::JSValue::pointer(closure_ptr as *mut u8).bits());
-            result.push_str(&call_replace_callback(callback_value, &call_args));
-
-            last_end = full_match.end();
+        } else if let Some(caps) = regex.captures(str_data) {
+            push_caps(caps);
         }
 
-        // Append remaining text
-        result.push_str(&str_data[last_end..]);
-        js_string_from_str(&result)
+        replace_fn_run_matches(&s_handle, &matches, closure_ptr, has_named_groups)
     }
 }
 

--- a/crates/perry-runtime/src/regex/replace_fn.rs
+++ b/crates/perry-runtime/src/regex/replace_fn.rs
@@ -16,27 +16,38 @@ pub(super) unsafe fn call_replace_callback(callback: f64, args: &[f64]) -> Strin
     }
 }
 
+/// Invoke a string-pattern replacer callback with `(matched, offset, whole)`.
+///
+/// `matched` must be an OWNED (or static) Rust string — never a slice of a GC
+/// heap string, because boxing it below allocates and an alloc-point minor
+/// can be MOVING under the evacuation policy. The subject travels as a rooted
+/// handle and is NaN-boxed directly (same string value, CURRENT address) —
+/// no per-call copy, and no borrow of the heap string crosses user code.
 unsafe fn call_string_replace_callback(
     callback: f64,
     matched: &str,
     offset: usize,
-    whole: &str,
+    whole_handle: &crate::gc::RuntimeHandle<'_>,
 ) -> String {
     let scope = crate::gc::RuntimeHandleScope::new();
     let matched_value = js_nanbox_string(js_string_from_str(matched) as i64);
     let matched_handle = scope.root_nanbox_f64(matched_value);
-    let offset_handle = scope.root_nanbox_f64(offset as f64);
-    let whole_value = js_nanbox_string(js_string_from_str(whole) as i64);
-    let whole_handle = scope.root_nanbox_f64(whole_value);
     let args = [
         matched_handle.get_nanbox_f64(),
-        offset_handle.get_nanbox_f64(),
-        whole_handle.get_nanbox_f64(),
+        offset as f64,
+        js_nanbox_string(whole_handle.get_raw_const_ptr::<StringHeader>() as i64),
     ];
     call_replace_callback(callback, &args)
 }
 
 /// string.replace(pattern, replacerFn) for a non-regex string pattern.
+///
+/// GC discipline (2026-07-09 audit, wave 1): the replacer callback is user
+/// code — it can allocate and trigger a minor GC that sweeps the subject
+/// (bare Rust locals are invisible without a conservative stack scan) or
+/// moves it. The subject is rooted in a `RuntimeHandleScope` and the `&str`
+/// view is re-derived from the rooted handle after every callback; the
+/// pattern is copied to an owned Rust string up front.
 #[no_mangle]
 pub extern "C" fn js_string_replace_string_fn(
     s: *const StringHeader,
@@ -47,28 +58,42 @@ pub extern "C" fn js_string_replace_string_fn(
         return js_string_from_str("");
     }
 
-    let str_data = string_as_str(s);
-    let pattern_str = if is_valid_ptr(pattern) {
-        string_as_str(pattern)
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let s_handle = scope.root_string_ptr(s);
+    // Root the callback too: a GC it triggers can relocate its own closure
+    // header, and the raw `f64` parameter would keep the pre-move address.
+    let callback_handle = scope.root_nanbox_f64(callback);
+    let cur_str = || string_as_str(s_handle.get_raw_const_ptr::<StringHeader>());
+    let pattern_str: String = if is_valid_ptr(pattern) {
+        string_as_str(pattern).to_string()
     } else {
-        ""
+        String::new()
     };
 
     unsafe {
         if pattern_str.is_empty() {
-            let replacement = call_string_replace_callback(callback, "", 0, str_data);
+            let replacement =
+                call_string_replace_callback(callback_handle.get_nanbox_f64(), "", 0, &s_handle);
+            let str_data = cur_str();
             let mut result = String::with_capacity(replacement.len() + str_data.len());
             result.push_str(&replacement);
             result.push_str(str_data);
             return js_string_from_str(&result);
         }
 
-        let Some(byte_idx) = str_data.find(pattern_str) else {
+        let str_data = cur_str();
+        let Some(byte_idx) = str_data.find(pattern_str.as_str()) else {
             return js_string_from_str(str_data);
         };
         let char_offset = str_data[..byte_idx].chars().count();
-        let replacement =
-            call_string_replace_callback(callback, pattern_str, char_offset, str_data);
+        let replacement = call_string_replace_callback(
+            callback_handle.get_nanbox_f64(),
+            &pattern_str,
+            char_offset,
+            &s_handle,
+        );
+        // Re-derive the subject: the callback may have moved it.
+        let str_data = cur_str();
         let mut result = String::with_capacity(str_data.len() + replacement.len());
         result.push_str(&str_data[..byte_idx]);
         result.push_str(&replacement);
@@ -78,6 +103,11 @@ pub extern "C" fn js_string_replace_string_fn(
 }
 
 /// string.replaceAll(pattern, replacerFn) for a non-regex string pattern.
+///
+/// Same GC discipline as [`js_string_replace_string_fn`], plus: match
+/// positions are computed into an owned Vec BEFORE the first callback — the
+/// old code kept a lazy `match_indices` iterator (a live borrow of the heap
+/// string) running WHILE callbacks executed between its steps.
 #[no_mangle]
 pub extern "C" fn js_string_replace_all_string_fn(
     s: *const StringHeader,
@@ -88,45 +118,79 @@ pub extern "C" fn js_string_replace_all_string_fn(
         return js_string_from_str("");
     }
 
-    let str_data = string_as_str(s);
-    let pattern_str = if is_valid_ptr(pattern) {
-        string_as_str(pattern)
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let s_handle = scope.root_string_ptr(s);
+    // Root the callback too: a GC it triggers can relocate its own closure
+    // header, and the raw `f64` parameter would keep the pre-move address
+    // for every call after the first.
+    let callback_handle = scope.root_nanbox_f64(callback);
+    let cur_str = || string_as_str(s_handle.get_raw_const_ptr::<StringHeader>());
+    let pattern_str: String = if is_valid_ptr(pattern) {
+        string_as_str(pattern).to_string()
     } else {
-        ""
+        String::new()
     };
 
     unsafe {
         if pattern_str.is_empty() {
+            // Owned char snapshot: the old code iterated `str_data.chars()`
+            // while the callback ran between steps — a stale borrow across
+            // user code.
+            let chars: Vec<char> = cur_str().chars().collect();
             let mut result = String::new();
-            result.push_str(&call_string_replace_callback(callback, "", 0, str_data));
+            result.push_str(&call_string_replace_callback(
+                callback_handle.get_nanbox_f64(),
+                "",
+                0,
+                &s_handle,
+            ));
             let mut offset = 0usize;
-            for ch in str_data.chars() {
+            for ch in chars {
                 result.push(ch);
                 offset += 1;
                 result.push_str(&call_string_replace_callback(
-                    callback, "", offset, str_data,
+                    callback_handle.get_nanbox_f64(),
+                    "",
+                    offset,
+                    &s_handle,
                 ));
             }
             return js_string_from_str(&result);
         }
 
+        // Precompute every match position (byte index + char offset) before
+        // the first callback runs.
+        let matches: Vec<(usize, usize)> = {
+            let str_data = cur_str();
+            let mut char_pos = 0usize;
+            let mut last_byte = 0usize;
+            str_data
+                .match_indices(pattern_str.as_str())
+                .map(|(byte_idx, _)| {
+                    char_pos += str_data[last_byte..byte_idx].chars().count();
+                    last_byte = byte_idx;
+                    (byte_idx, char_pos)
+                })
+                .collect()
+        };
+        if matches.is_empty() {
+            return js_string_from_str(cur_str());
+        }
         let mut result = String::new();
         let mut last_end = 0usize;
-        for (byte_idx, matched) in str_data.match_indices(pattern_str) {
-            result.push_str(&str_data[last_end..byte_idx]);
-            let char_offset = str_data[..byte_idx].chars().count();
+        for (byte_idx, char_offset) in matches {
+            // Between-match text is re-sliced from the CURRENT subject
+            // address (the previous callback may have moved it).
+            result.push_str(&cur_str()[last_end..byte_idx]);
             result.push_str(&call_string_replace_callback(
-                callback,
-                matched,
+                callback_handle.get_nanbox_f64(),
+                &pattern_str,
                 char_offset,
-                str_data,
+                &s_handle,
             ));
-            last_end = byte_idx + matched.len();
+            last_end = byte_idx + pattern_str.len();
         }
-        if last_end == 0 {
-            return js_string_from_str(str_data);
-        }
-        result.push_str(&str_data[last_end..]);
+        result.push_str(&cur_str()[last_end..]);
         js_string_from_str(&result)
     }
 }

--- a/crates/perry-runtime/src/typedarray/transform.rs
+++ b/crates/perry-runtime/src/typedarray/transform.rs
@@ -115,6 +115,69 @@ pub extern "C" fn js_typed_array_sort_default(ta: *mut TypedArrayHeader) -> *mut
     }
 }
 
+/// Invoke a typed-array sort comparator on two raw BigInt64/BigUint64 lanes.
+/// Each lane is boxed as a fresh GC BigInt ONLY for the duration of this one
+/// call, and each box is rooted in a scope: the second box's allocation (and
+/// the comparator body itself) can trigger a GC that would otherwise sweep —
+/// or move — the first while its pointer sits in a bare Rust local.
+unsafe fn bigint_lane_compare(
+    comparator: *const ClosureHeader,
+    a_bits: u64,
+    b_bits: u64,
+    signed: bool,
+) -> std::cmp::Ordering {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let box_lane = |bits: u64| -> f64 {
+        if signed {
+            crate::value::js_nanbox_bigint(crate::bigint::js_bigint_from_i64(bits as i64) as i64)
+        } else {
+            crate::value::js_nanbox_bigint(crate::bigint::js_bigint_from_u64(bits) as i64)
+        }
+    };
+    let a_handle = scope.root_nanbox_f64(box_lane(a_bits));
+    let b_handle = scope.root_nanbox_f64(box_lane(b_bits));
+    let r = crate::closure::js_closure_call2(
+        comparator,
+        a_handle.get_nanbox_f64(),
+        b_handle.get_nanbox_f64(),
+    );
+    if r < 0.0 {
+        std::cmp::Ordering::Less
+    } else if r > 0.0 {
+        std::cmp::Ordering::Greater
+    } else {
+        std::cmp::Ordering::Equal
+    }
+}
+
+/// Comparator-sorted copy of a BigInt64/BigUint64 array's raw 64-bit lanes.
+/// The lanes live in an OWNED Rust buffer for the whole sort — no boxed
+/// BigInt pointers (the old code parked a `Vec<f64>` full of unrooted boxes
+/// across every comparator call) and no pointer into the typed-array storage
+/// are held across user code; each compare boxes its two operands lazily,
+/// mirroring the raw-lane special case the default no-comparator sort already
+/// had. The comparator closure itself is re-derived from a rooted handle per
+/// call (a comparator-triggered GC can relocate its own closure header).
+unsafe fn sorted_bigint_lanes(
+    ta: *const TypedArrayHeader,
+    len: usize,
+    signed: bool,
+    comparator: *const ClosureHeader,
+) -> Vec<u64> {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let cmp_handle = scope.root_raw_const_ptr(comparator);
+    let mut lanes: Vec<u64> = std::slice::from_raw_parts(data_ptr(ta) as *const u64, len).to_vec();
+    lanes.sort_by(|&a, &b| {
+        bigint_lane_compare(
+            cmp_handle.get_raw_const_ptr::<ClosureHeader>(),
+            a,
+            b,
+            signed,
+        )
+    });
+    lanes
+}
+
 /// `ta.sort(cmp)` — in-place sort with comparator. Issue #654.
 #[no_mangle]
 pub extern "C" fn js_typed_array_sort_with_comparator(
@@ -134,6 +197,23 @@ pub extern "C" fn js_typed_array_sort_with_comparator(
         if len <= 1 {
             return ta_clean;
         }
+        let kind = (*ta_clean).kind;
+        if kind == KIND_BIGINT64 || kind == KIND_BIGUINT64 {
+            // Sort the raw lanes with lazy per-compare boxing; the receiver is
+            // rooted so the write-back targets its CURRENT address even when a
+            // comparator-triggered GC relocated it.
+            let scope = crate::gc::RuntimeHandleScope::new();
+            let ta_handle = scope.root_raw_mut_ptr(ta_clean);
+            let lanes = sorted_bigint_lanes(ta_clean, len, kind == KIND_BIGINT64, comparator);
+            let ta_cur = ta_handle.get_raw_mut_ptr::<TypedArrayHeader>();
+            let base = data_ptr_mut(ta_cur) as *mut u64;
+            for (i, bits) in lanes.into_iter().enumerate() {
+                *base.add(i) = bits;
+            }
+            return ta_cur;
+        }
+        // Non-BigInt kinds: `load_at` yields plain numeric f64s (no heap
+        // pointers), so the owned buffer is GC-inert by construction.
         let mut buf: Vec<f64> = (0..len).map(|i| load_at(ta_clean, i)).collect();
         buf.sort_by(|a, b| {
             let r = crate::closure::js_closure_call2(comparator, *a, *b);
@@ -191,6 +271,20 @@ pub extern "C" fn js_typed_array_to_sorted_with_comparator(
     unsafe {
         let kind = (*ta).kind;
         let len = (*ta).length as usize;
+        if kind == KIND_BIGINT64 || kind == KIND_BIGUINT64 {
+            // Copy the raw lanes out FIRST (owned buffer), sort with lazy
+            // per-compare boxing (no unrooted BigInt boxes parked across
+            // comparator calls), then allocate the result only after all
+            // user code has run.
+            let lanes = sorted_bigint_lanes(ta, len, kind == KIND_BIGINT64, comparator);
+            let out = typed_array_alloc(kind, len as u32);
+            let base = data_ptr_mut(out) as *mut u64;
+            for (i, bits) in lanes.into_iter().enumerate() {
+                *base.add(i) = bits;
+            }
+            return out;
+        }
+        // Non-BigInt kinds: plain numeric f64s — the owned buffer is GC-inert.
         let mut buf: Vec<f64> = (0..len).map(|i| load_at(ta, i)).collect();
         buf.sort_by(|a, b| {
             let r = crate::closure::js_closure_call2(comparator, *a, *b);


### PR DESCRIPTION
Wave 1 of the 2026-07-09 GC audit (fable-audit-perry-gc.md); companion to PR #6178.

## The bug class

Production runs **no conservative stack scan** (the alloc-point scan resolves to SkipDisabled), so a bare Rust local holding a GC heap pointer across an allocation point is invisible to the collector. Two distinct failure modes:

- **Sweeping**: an object reachable only through a Rust local (a fresh temp array, a boxed BigInt, a names array) is unmarked and reclaimed while the helper is still using it.
- **Moving**: the object survives (it is reachable through some other root) but is *relocated* — alloc-point minors can be MOVING via the evacuation policy, and `PERRY_GC_FORCE_EVACUATE=1` makes every copied minor move. The GC rewrites every registered slot, but a raw `*mut f64` / `&str` / `regex::Captures` hoisted into a Rust local keeps the pre-move address and silently reads or writes from-space.

Any helper that runs a **user callback** (comparator, getter/setter, `toJSON`, replacer) mid-loop is exposed to both; helpers that merely allocate in a loop while holding borrows (matchAll) are exposed to the moving mode only.

The sanctioned pattern (PR #5981 `iter_methods.rs`, `js_map_foreach_impl`): root every heap value in a `RuntimeHandleScope` and re-derive raw pointers from the handle after every user-code call / allocation batch.

## The six windows

### 1. `array/sort.rs` — comparator paths (+ `array/generic.rs` `object_sort`)
The #6076 fix rooted the temp copy for *liveness*, but the large-array merge engine ping-ponged element bits through a bare `Vec<f64>`: after the first src/dst swap the **authoritative bits lived in the Vec**, and a moving minor during a comparator call left pre-move addresses in the published result. Rebuilt the engines on a `RootedArrayElems` helper (handle-rooted header, per-access re-derived element base, `note_array_slot` barriered stores):
- merge scratch is now a **second rooted array**; elements are re-read after every comparator call;
- insertion sort is swap-based, so the moving key is never parked in a Rust local across a compare;
- receiver, temp copy, scratch, and the **comparator closure itself** (its own header moves when a comparator-triggered GC evacuates) are all rooted and re-derived (`ComparatorCall::compare_at` takes the re-derived header; the resolved direct-call target is a static code address and stays cached);
- `array_sort_spec_path` re-derives across every `[[Get]]`/`[[Set]]`-fired accessor, and `sort_spec_set` roots the receiver + value across the prototype-accessor probe;
- the default (ToString) sort keys via an owned rank permutation — a user `toString` can also allocate/move;
- `sort_rooted_values` now takes/returns the array header (it roots internally); `object_sort` (array-like engine) roots the receiver value + collection temp across `al_has`/`al_get`/`al_set`.

### 2. `json/stringify.rs` — `stringify_object_inner` / `stringify_array_depth`
Both hoisted `keys_elements` / `fields_ptr` / `elements` once, then ran user code (own-accessor getters via `json_object_getter_value`, nested `toJSON`, recursive serialization that can allocate) inside the loop. Both now root the owner object/array and re-derive the keys/field/element bases from the CURRENT header per access (`key_at`/`read_field_bits`/`elem_at` closures); the keys array is re-derived *through* the object header, whose `keys_array` field the collector rewrites.

### 3. `regex/replace_fn.rs` — `js_string_replace_string_fn` / `js_string_replace_all_string_fn`
`str_data = string_as_str(s)` was cached once and re-used across replacer callbacks; replaceAll additionally kept a lazy `match_indices` iterator (a live borrow of the heap string) running *while* callbacks executed between its steps. Now: subject + callback rooted; match positions (byte index + char offset) precomputed into an owned Vec before the first callback; every between-match slice re-derived from the rooted handle; the pattern copied to an owned Rust string; the `whole` argument passes the rooted original subject (same string value, current address) instead of allocating a per-call copy.

### 4. `regex/replace_expand.rs` — `js_string_replace_regex_fn` / `replace_regex_fn_fancy`
The eagerly-collected `Vec<Captures>` borrowed `str_data`; the existing per-match `RuntimeHandleScope` rooted only the callback *arguments*, so from the 2nd match on every `.as_str()` read through the stale base. Applied the audit's suggested owned-snapshot fix: each match is copied into an `OwnedMatchData` (full-match range, char offset, group texts, named-group texts) **before** the first callback; a shared `replace_fn_run_matches` loop then runs the callbacks with the subject and closure rooted and re-derived. Both the standard and fancy engines route through it.

### 5. `typedarray/transform.rs` — BigInt64/BigUint64 `.sort(cmp)` / `.toSorted(cmp)`
`load_at` boxes each element as a fresh GC BigInt; the old code parked a `Vec<f64>` full of those unrooted boxes across every comparator call. Per the audit recommendation, the boxes are gone: the raw 64-bit lanes are copied to an owned Rust buffer and sorted with **lazy per-compare boxing** (two fresh BigInts per compare, each rooted while the other allocates and while the comparator runs), mirroring the raw-lane special case the default no-comparator sort already had. The in-place variant roots the receiver for the write-back; `toSorted` allocates the result only after all user code has run.

### 6. `regex/match_all.rs` — `materialize_match_all_results`
No user callback — sweeping isn't the risk here, **moving is**: `str_data` and the collected `Captures` were held across the per-match allocation storm (`js_string_from_str`, array/object allocs). Restructured into a borrowing snapshot phase (owned `OwnedMatchAllData` per match, no JS allocation) followed by an allocating phase that touches only rooted handles. The `index`/`input` metadata is attached via a new `set_exec_array_metadata_value` (exec_array.rs) that roots the array + input value across its key-string allocations and passes the rooted original subject as `input`; `set_match_all_groups`, `alloc_regexp_string_iterator`, and the `js_string_match_all_value` pattern→RegExp conversion window are rooted the same way.

## Regression tests

`gc/tests/runtime_roots/callback_scanners.rs` — each new test forces a **copied (moving) minor GC from inside the user callback** (`CopyingNurseryTestGuard` + `gc_collect_minor()` in the callback) and asserts post-move-correct results:

- `test_array_sort_comparator_rooted_buffers_survive_copied_minor_gc` — 8-element (insertion path) and 40-element (run + merge engine) sorts of heap strings; every compare collects.
- `test_json_stringify_object_rederives_fields_after_tojson_minor_gc` — middle field's nested `toJSON` collects; trailing fields must be read through re-derived buffers.
- `test_json_stringify_array_rederives_elements_after_tojson_minor_gc` — same for the array element walk.
- `test_string_replace_all_fn_rederives_subject_after_callback_minor_gc` — every replacer call collects; also asserts the matched argument stays a live string. (This test caught a further real window during development: the `callback: f64` parameter itself went stale after the first call when the GC moved the closure header — now rooted.)
- `test_bigint64_sort_comparator_boxes_survive_copied_minor_gc` — comparator reads both BigInt operands after collecting.

matchAll has **no regression test**: with no user callback there is no deterministic way to force a *moving* collection inside its allocation window from the current test harness (alloc-point minors only move under evacuation policy/env pressure). The fix is the owned-snapshot restructure; coverage is indirect via the existing matchAll behavior tests.

## Validation

- `PERRY_NO_AUTO_OPTIMIZE=1 cargo test -p perry-runtime --lib -- --test-threads=1` → **1169 passed; 0 failed**.
- Parallel full-suite runs intermittently fail `closure::dynamic_props::tests_1802::*` / `object::tests::closure_name_and_length_ignore_plain_assignment` — a **pre-existing cross-test race** (global closure side-table cleared by concurrently-running `CopyingNurseryTestGuard` users): clean `origin/main` (62349a149) failed 3 of 4 parallel full-suite runs on the same machine with the same tests, without this branch's changes.
- `cargo fmt --all -- --check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of array and typed-array sorting, especially when custom comparators or callbacks are used.
  * Fixed cases where string, JSON, and regex operations could return stale or incorrect results after internal memory moves.
  * BigInt typed-array sorting now handles comparator-based sorting correctly.
  * `matchAll`, `replace`, `replaceAll`, and JSON serialization are now more stable during complex nested operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->