### PR TITLE
perf(gc): delta-maintained old-gen bytes, releasable-block evacuation metric + hard-RSS bypass, smaller per-thread floors

### DIFF
--- a/crates/perry-runtime/src/arena/block.rs
+++ b/crates/perry-runtime/src/arena/block.rs
@@ -197,6 +197,62 @@ impl Arena {
         }
     }
 
+    /// Lazy variant of `new`: starts with a single tombstone block
+    /// (`data = null, size = 0`) instead of an eagerly-mapped 1 MB
+    /// block, so JS-touching threads that never allocate in this
+    /// region (spawn workers, tokio callers) don't pay the block.
+    /// The tombstone shape is exactly the one C4b-δ dealloc leaves
+    /// behind, so every walker/reset/alloc path already handles it:
+    /// the first `alloc` misses the tombstone, and the slow path's
+    /// `install_fresh_block` replaces the tombstone slot in place.
+    /// Only used for the non-Eden regions — Eden must stay eager
+    /// because `js_inline_arena_state` hands its current block to
+    /// codegen's inline bump allocator at thread start.
+    fn new_lazy(generation: HeapGeneration, space: HeapSpace) -> Self {
+        Arena {
+            blocks: vec![ArenaBlock {
+                data: std::ptr::null_mut(),
+                size: 0,
+                offset: 0,
+                dead_cycles: 0,
+            }],
+            current: 0,
+            generation,
+            space,
+        }
+    }
+
+    /// Bump-allocate in `blocks[idx]`, delta-maintaining the cached
+    /// old-gen in-use counter (see `OLD_GEN_IN_USE_BYTES`). Every
+    /// successful offset advance of an old-arena block MUST go through
+    /// here — a bypassed site silently skews the OldReclaim trigger.
+    #[inline]
+    fn try_block_alloc(&mut self, idx: usize, size: usize, align: usize) -> Option<*mut u8> {
+        let before = self.blocks[idx].offset;
+        let ptr = self.blocks[idx].alloc(size, align)?;
+        if self.generation == HeapGeneration::Old {
+            old_gen_in_use_bytes_add(self.blocks[idx].offset - before);
+        }
+        Some(ptr)
+    }
+
+    /// `try_block_alloc` twin for the page-excluding path.
+    #[inline]
+    fn try_block_alloc_excluding_pages(
+        &mut self,
+        idx: usize,
+        size: usize,
+        align: usize,
+        excluded_pages: &crate::fast_hash::PtrHashSet<usize>,
+    ) -> Option<*mut u8> {
+        let before = self.blocks[idx].offset;
+        let ptr = self.blocks[idx].alloc_excluding_pages(size, align, excluded_pages)?;
+        if self.generation == HeapGeneration::Old {
+            old_gen_in_use_bytes_add(self.blocks[idx].offset - before);
+        }
+        Some(ptr)
+    }
+
     #[inline]
     fn resync_inline_to_current(&self) {
         // `INLINE_STATE` mirrors ONLY the general nursery-Eden arena — the
@@ -254,8 +310,7 @@ impl Arena {
 
     fn alloc_fresh_block(&mut self, size: usize, align: usize) -> *mut u8 {
         self.install_fresh_block(size);
-        self.blocks[self.current]
-            .alloc(size, align)
+        self.try_block_alloc(self.current, size, align)
             .expect("Fresh block should have space")
     }
 
@@ -268,7 +323,7 @@ impl Arena {
         loop {
             self.install_fresh_block(size);
             if let Some(ptr) =
-                self.blocks[self.current].alloc_excluding_pages(size, align, excluded_pages)
+                self.try_block_alloc_excluding_pages(self.current, size, align, excluded_pages)
             {
                 return ptr;
             }
@@ -278,7 +333,7 @@ impl Arena {
     #[inline]
     pub(crate) fn alloc(&mut self, size: usize, align: usize) -> *mut u8 {
         // Try current block first
-        if let Some(ptr) = self.blocks[self.current].alloc(size, align) {
+        if let Some(ptr) = self.try_block_alloc(self.current, size, align) {
             return ptr;
         }
 
@@ -296,7 +351,7 @@ impl Arena {
         // Retry the (possibly newly-reset) current block. arena.current
         // may have been changed by arena_reset_empty_blocks to point
         // at the lowest reset block.
-        if let Some(ptr) = self.blocks[self.current].alloc(size, align) {
+        if let Some(ptr) = self.try_block_alloc(self.current, size, align) {
             return ptr;
         }
 
@@ -308,7 +363,7 @@ impl Arena {
             if i == self.current {
                 continue;
             }
-            if let Some(ptr) = self.blocks[i].alloc(size, align) {
+            if let Some(ptr) = self.try_block_alloc(i, size, align) {
                 self.current = i;
                 // Resync inline state to the new current block.
                 self.resync_inline_to_current();
@@ -335,7 +390,7 @@ impl Arena {
             return self.alloc(size, align);
         }
         if let Some(ptr) =
-            self.blocks[self.current].alloc_excluding_pages(size, align, excluded_pages)
+            self.try_block_alloc_excluding_pages(self.current, size, align, excluded_pages)
         {
             return ptr;
         }
@@ -343,7 +398,8 @@ impl Arena {
             if i == self.current {
                 continue;
             }
-            if let Some(ptr) = self.blocks[i].alloc_excluding_pages(size, align, excluded_pages) {
+            if let Some(ptr) = self.try_block_alloc_excluding_pages(i, size, align, excluded_pages)
+            {
                 self.current = i;
                 self.resync_inline_to_current();
                 return ptr;
@@ -366,6 +422,31 @@ thread_local! {
     /// `arena_reset_empty_blocks`).
     pub(crate) static ARENA_TOTAL_BYTES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 
+    /// Cached running sum of `block.offset` across the old-gen arena —
+    /// the delta-maintained twin of `ARENA_TOTAL_BYTES` above, same
+    /// rationale: `gc_budgeted_due_trigger()` reads the old-gen in-use
+    /// total on every `gc_check_trigger` (i.e. every `gc_malloc` and
+    /// every nursery block fill), and recomputing it walked every
+    /// old-arena block each time — a linear-in-old-gen tax on every
+    /// malloc-class allocation once the old gen holds real data.
+    /// Mutation sites (each MUST maintain the delta):
+    ///   - `Arena::try_block_alloc` / `try_block_alloc_excluding_pages`
+    ///     (the only offset-advance funnel for `Arena::alloc`,
+    ///     `alloc_excluding_pages`, and the fresh-block paths),
+    ///   - `reset_region_to_zero` (generation-aware, reset.rs),
+    ///   - the old-arena reclaim family in reset.rs
+    ///     (`old_arena_reclaim_dead_blocks`,
+    ///     `old_arena_reclaim_selected_dead_blocks`,
+    ///     `OldArenaReclaimDeadBlocksState::process_block`) which zero
+    ///     old block offsets on sweep/defrag.
+    /// Block install/dealloc paths don't touch it: fresh blocks start
+    /// at offset 0 and blocks are only deallocated after their offset
+    /// was already zeroed. `old_gen_in_use_bytes()` (stats.rs)
+    /// debug-asserts this cache against the O(blocks) recompute so a
+    /// missed mutation site fails tests instead of silently skewing
+    /// the OldReclaim trigger.
+    pub(crate) static OLD_GEN_IN_USE_BYTES: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+
     pub(crate) static ARENA: UnsafeCell<Arena> =
         UnsafeCell::new(Arena::new(HeapGeneration::Nursery, HeapSpace::NurseryEden));
 
@@ -387,15 +468,15 @@ thread_local! {
     /// scanners (`scan_parse_roots`, `scan_shape_cache_roots`,
     /// `scan_transition_cache_roots`) keep them marked.
     pub(crate) static LONGLIVED_ARENA: UnsafeCell<Arena> =
-        UnsafeCell::new(Arena::new(HeapGeneration::Longlived, HeapSpace::Longlived));
+        UnsafeCell::new(Arena::new_lazy(HeapGeneration::Longlived, HeapSpace::Longlived));
 
     /// Copying nursery survivor semispaces. At most one is the active
     /// from-space at the start of a copying minor GC; the other is reset
     /// and used as to-space for fresh Eden survivors.
     pub(crate) static SURVIVOR_ARENA_0: UnsafeCell<Arena> =
-        UnsafeCell::new(Arena::new(HeapGeneration::Nursery, HeapSpace::Survivor0));
+        UnsafeCell::new(Arena::new_lazy(HeapGeneration::Nursery, HeapSpace::Survivor0));
     pub(crate) static SURVIVOR_ARENA_1: UnsafeCell<Arena> =
-        UnsafeCell::new(Arena::new(HeapGeneration::Nursery, HeapSpace::Survivor1));
+        UnsafeCell::new(Arena::new_lazy(HeapGeneration::Nursery, HeapSpace::Survivor1));
     pub(crate) static ACTIVE_SURVIVOR: Cell<usize> = const { Cell::new(0) };
 
     /// Generational-GC old-generation arena (gen-GC Phase B per
@@ -413,7 +494,7 @@ thread_local! {
     /// mark-sweep can reclaim completely dead old blocks through the
     /// dedicated old-arena reset/deallocation path.
     pub(crate) static OLD_ARENA: UnsafeCell<Arena> =
-        UnsafeCell::new(Arena::new(HeapGeneration::Old, HeapSpace::Old));
+        UnsafeCell::new(Arena::new_lazy(HeapGeneration::Old, HeapSpace::Old));
 
     /// Inline allocator state — a cache of the current arena block's
     /// `(data, offset, size)` triple, exposed via a stable pointer so
@@ -429,4 +510,22 @@ thread_local! {
         offset: 0,
         size: 0,
     }) };
+}
+
+/// Delta-maintenance for `OLD_GEN_IN_USE_BYTES` — see the thread-local's
+/// doc comment for the full mutation-site inventory.
+#[inline]
+pub(crate) fn old_gen_in_use_bytes_add(delta: usize) {
+    if delta == 0 {
+        return;
+    }
+    OLD_GEN_IN_USE_BYTES.with(|c| c.set(c.get().saturating_add(delta)));
+}
+
+#[inline]
+pub(crate) fn old_gen_in_use_bytes_sub(delta: usize) {
+    if delta == 0 {
+        return;
+    }
+    OLD_GEN_IN_USE_BYTES.with(|c| c.set(c.get().saturating_sub(delta)));
 }

--- a/crates/perry-runtime/src/arena/mod.rs
+++ b/crates/perry-runtime/src/arena/mod.rs
@@ -79,12 +79,12 @@ pub use reset::{arena_reset_all_blocks_to_zero, arena_reset_empty_blocks};
 
 // stats.rs
 pub(crate) use stats::{active_survivor_space, inactive_survivor_space};
-#[cfg(test)]
-pub(crate) use stats::{old_gen_in_use_bytes_recomputed, old_gen_in_use_bytes_resync};
 pub use stats::{
     js_arena_stats, longlived_in_use_bytes, old_gen_in_use_bytes, pointer_in_nursery,
     pointer_in_old_gen,
 };
+#[cfg(test)]
+pub(crate) use stats::{old_gen_in_use_bytes_recomputed, old_gen_in_use_bytes_resync};
 
 // page_meta.rs (public + pub(crate) classification/page-meta API)
 pub(crate) use page_meta::{

--- a/crates/perry-runtime/src/arena/mod.rs
+++ b/crates/perry-runtime/src/arena/mod.rs
@@ -27,9 +27,9 @@ pub(crate) use allocators::{
     inactive_survivor_index, with_survivor_arena, with_survivor_arena_mut,
 };
 pub(crate) use block::{
-    Arena, ArenaBlock, ACTIVE_SURVIVOR, ARENA, ARENA_TOTAL_BYTES, BLOCK_SIZE,
-    FRESH_GENERAL_BLOCK_MIN_USED_BYTES, INLINE_STATE, LONGLIVED_ARENA, OLD_ARENA, SURVIVOR_ARENA_0,
-    SURVIVOR_ARENA_1,
+    old_gen_in_use_bytes_sub, Arena, ArenaBlock, ACTIVE_SURVIVOR, ARENA, ARENA_TOTAL_BYTES,
+    BLOCK_SIZE, FRESH_GENERAL_BLOCK_MIN_USED_BYTES, INLINE_STATE, LONGLIVED_ARENA, OLD_ARENA,
+    OLD_GEN_IN_USE_BYTES, SURVIVOR_ARENA_0, SURVIVOR_ARENA_1,
 };
 pub(crate) use page_meta::{
     address_span_overlaps_pages, register_block_space, register_old_object_pages,
@@ -63,8 +63,8 @@ pub use walk::{
 };
 pub(crate) use walk::{
     arena_block_snapshots, arena_telemetry_snapshot, general_block_in_recent_window,
-    ArenaBlockSnapshot, ArenaObjectCursor, ArenaObjectCursorBuilder, ArenaTelemetrySnapshot,
-    ArenaWalkOrder,
+    general_block_sizes, ArenaBlockSnapshot, ArenaObjectCursor, ArenaObjectCursorBuilder,
+    ArenaTelemetrySnapshot, ArenaWalkOrder,
 };
 
 // reset.rs
@@ -79,6 +79,8 @@ pub use reset::{arena_reset_all_blocks_to_zero, arena_reset_empty_blocks};
 
 // stats.rs
 pub(crate) use stats::{active_survivor_space, inactive_survivor_space};
+#[cfg(test)]
+pub(crate) use stats::{old_gen_in_use_bytes_recomputed, old_gen_in_use_bytes_resync};
 pub use stats::{
     js_arena_stats, longlived_in_use_bytes, old_gen_in_use_bytes, pointer_in_nursery,
     pointer_in_old_gen,

--- a/crates/perry-runtime/src/arena/reset.rs
+++ b/crates/perry-runtime/src/arena/reset.rs
@@ -49,6 +49,13 @@ fn reset_region_to_zero(arena: &mut Arena) -> (usize, usize) {
         block.offset = 0;
         block.dead_cycles = 0;
     }
+    // Delta-maintain the cached old-gen in-use counter. Only Eden and
+    // the survivor semispaces are reset through here today, but this
+    // takes any `&mut Arena` — keep the counter honest if an old-gen
+    // caller ever appears.
+    if arena.generation == HeapGeneration::Old {
+        old_gen_in_use_bytes_sub(reusable_bytes);
+    }
     arena.current = 0;
     (reset_blocks, reusable_bytes)
 }
@@ -1014,6 +1021,7 @@ impl OldArenaReclaimDeadBlocksState {
             }
             block.offset = 0;
             block.dead_cycles = 0;
+            old_gen_in_use_bytes_sub(used);
             self.changed = true;
 
             if local_idx == original_current {
@@ -1103,6 +1111,7 @@ pub(crate) fn old_arena_reclaim_dead_blocks(block_has_live: &[bool]) -> ArenaRes
             }
             block.offset = 0;
             block.dead_cycles = 0;
+            old_gen_in_use_bytes_sub(used);
             changed = true;
 
             // Keep the current old allocation target mapped and reusable.
@@ -1204,6 +1213,7 @@ pub(crate) fn old_arena_reclaim_selected_dead_blocks(
             }
             block.offset = 0;
             block.dead_cycles = 0;
+            old_gen_in_use_bytes_sub(used);
             changed = true;
 
             if i == original_current {

--- a/crates/perry-runtime/src/arena/stats.rs
+++ b/crates/perry-runtime/src/arena/stats.rs
@@ -67,14 +67,41 @@ pub fn longlived_in_use_bytes() -> usize {
     })
 }
 
-/// Bytes currently allocated in the old-gen arena (gen-GC Phase B).
-/// Diagnostic-only — empty in Phase B; populated by Phase C's
-/// nursery→old promotion path.
+/// Bytes currently allocated in the old-gen arena (gen-GC Phase C).
+/// Read by `gc_budgeted_due_trigger()` on every `gc_check_trigger` —
+/// i.e. on every `gc_malloc` and every nursery block fill — so this
+/// returns the delta-maintained cache (`OLD_GEN_IN_USE_BYTES`) instead
+/// of recomputing an O(old-blocks) sum each time. Debug builds
+/// cross-check the cache against the recompute so a missed mutation
+/// site fails tests instead of silently skewing the OldReclaim trigger.
 pub fn old_gen_in_use_bytes() -> usize {
+    let cached = OLD_GEN_IN_USE_BYTES.with(|c| c.get());
+    debug_assert_eq!(
+        cached,
+        old_gen_in_use_bytes_recomputed(),
+        "OLD_GEN_IN_USE_BYTES cache drifted from the per-block recompute — \
+         an old-arena offset mutation site is missing its delta update \
+         (see the mutation-site inventory on OLD_GEN_IN_USE_BYTES in arena/block.rs)"
+    );
+    cached
+}
+
+/// O(blocks) recompute of the old-gen in-use total — the cross-check /
+/// resync source of truth for the delta-maintained cache. Not for hot
+/// paths.
+pub(crate) fn old_gen_in_use_bytes_recomputed() -> usize {
     OLD_ARENA.with(|arena| {
         let arena = unsafe { &*arena.get() };
         arena.blocks.iter().map(|b| b.offset).sum()
     })
+}
+
+/// Test-only: force the cache back in sync after a test hand-mutates
+/// old-arena block offsets without going through the tracked paths.
+#[cfg(test)]
+pub(crate) fn old_gen_in_use_bytes_resync() {
+    let recomputed = old_gen_in_use_bytes_recomputed();
+    OLD_GEN_IN_USE_BYTES.with(|c| c.set(recomputed));
 }
 
 #[inline]

--- a/crates/perry-runtime/src/arena/tests.rs
+++ b/crates/perry-runtime/src/arena/tests.rs
@@ -168,6 +168,10 @@ fn synthetic_old_block_range() -> (usize, usize) {
 #[test]
 fn old_page_metadata_registers_old_block_pages() {
     run_with_fresh_arenas(|| {
+        // Old-arena blocks are lazily materialized: force the first
+        // block with a raw (non-GC-header) old alloc, which registers
+        // the block's pages without registering any object bytes.
+        let _ = arena_alloc_old(8, 8);
         OLD_ARENA.with(|a| unsafe {
             let arena = &*a.get();
             let block = &arena.blocks[arena.current];
@@ -931,16 +935,28 @@ fn old_arena_block_reuse_does_not_repoint_eden_inline_state() {
         );
 
         // Drive the OLD_ARENA into a forward-scan-reuse state: a reusable
-        // earlier block (offset 0) plus a full current block.
+        // earlier block (offset 0) plus a full current block. The old
+        // arena starts with a lazy tombstone, so materialize block 0
+        // with a real allocation first.
         OLD_ARENA.with(|a| unsafe {
             let arena = &mut *a.get();
+            let _ = arena.alloc(64, 8); // materialize block 0
+            assert_eq!(arena.current, 0, "first old alloc should fill slot 0");
             arena.install_fresh_block(BLOCK_SIZE); // >=2 blocks, current = newest
             let cur = arena.current;
             assert!(cur > 0, "fresh block should advance current past block 0");
             arena.blocks[cur].offset = arena.blocks[cur].size; // current is full
             arena.blocks[0].offset = 0; // block 0 reusable
-                                        // Current full → forward-scan reuses block 0 → current = 0 →
-                                        // resync_inline_to_current(OLD_ARENA).
+        });
+        // The hand-mutated offsets above bypassed the tracked alloc
+        // paths — resync the delta-maintained old-gen in-use cache so
+        // the debug cross-check in `old_gen_in_use_bytes()` (reached
+        // via the next alloc's gc_check_trigger) sees a consistent pair.
+        old_gen_in_use_bytes_resync();
+        OLD_ARENA.with(|a| unsafe {
+            let arena = &mut *a.get();
+            // Current full → forward-scan reuses block 0 → current = 0 →
+            // resync_inline_to_current(OLD_ARENA).
             let _ = arena.alloc(64, 8);
             assert_eq!(arena.current, 0, "forward-scan should have reused block 0");
         });

--- a/crates/perry-runtime/src/arena/tests.rs
+++ b/crates/perry-runtime/src/arena/tests.rs
@@ -976,3 +976,45 @@ fn old_arena_block_reuse_does_not_repoint_eden_inline_state() {
         );
     });
 }
+
+/// The survivor/longlived/old arenas start with a lazy tombstone block:
+/// a fresh JS-touching thread pays only Eden's eager 1 MB, and each
+/// lazy region materializes its first real block on first allocation.
+#[test]
+fn lazy_regions_defer_initial_block_allocation() {
+    run_with_fresh_arenas(|| {
+        let before = arena_telemetry_snapshot();
+        assert!(
+            before.arena.reserved_bytes >= BLOCK_SIZE,
+            "Eden must stay eagerly materialized for the inline allocator"
+        );
+        assert_eq!(before.survivor0.reserved_bytes, 0);
+        assert_eq!(before.survivor1.reserved_bytes, 0);
+        assert_eq!(before.longlived.reserved_bytes, 0);
+        assert_eq!(before.old.reserved_bytes, 0);
+        assert_eq!(old_gen_in_use_bytes(), 0);
+
+        // First allocation in each lazy region materializes its block.
+        let old_ptr = arena_alloc_gc_old(40, 8, GC_TYPE_STRING);
+        assert!(!old_ptr.is_null());
+        let ll_ptr = arena_alloc_gc_longlived(40, 8, GC_TYPE_STRING);
+        assert!(!ll_ptr.is_null());
+        let survivor_ptr = arena_alloc_gc_survivor(40, 8, GC_TYPE_STRING);
+        assert!(!survivor_ptr.is_null());
+
+        let after = arena_telemetry_snapshot();
+        assert!(after.old.reserved_bytes >= BLOCK_SIZE);
+        assert!(after.longlived.reserved_bytes >= BLOCK_SIZE);
+        assert!(
+            after.survivor0.reserved_bytes >= BLOCK_SIZE
+                || after.survivor1.reserved_bytes >= BLOCK_SIZE,
+            "the inactive survivor semispace should have materialized"
+        );
+        assert!(after.old.in_use_bytes > 0);
+        assert_eq!(
+            old_gen_in_use_bytes(),
+            old_gen_in_use_bytes_recomputed(),
+            "cached old-gen in-use bytes must match the recompute after lazy materialization"
+        );
+    });
+}

--- a/crates/perry-runtime/src/arena/walk.rs
+++ b/crates/perry-runtime/src/arena/walk.rs
@@ -799,6 +799,21 @@ pub fn general_block_count() -> usize {
     ARENA.with(|arena| unsafe { (*arena.get()).blocks.len() })
 }
 
+/// Per-block `size` for the general (nursery-Eden) arena, indexed by
+/// general block index (`0..general_block_count()`, tombstones report
+/// size 0). Used by the evacuation policy to translate "this block's
+/// reset is blocked only by movable candidates" into the block-granule
+/// bytes a defrag would actually hand back.
+pub(crate) fn general_block_sizes() -> Vec<usize> {
+    ARENA.with(|arena| unsafe {
+        (*arena.get())
+            .blocks
+            .iter()
+            .map(|block| if block.data.is_null() { 0 } else { block.size })
+            .collect()
+    })
+}
+
 /// Whether a general-arena block is in the caller-saved-register safety
 /// window used by `arena_reset_empty_blocks`.
 #[inline]

--- a/crates/perry-runtime/src/gc/malloc.rs
+++ b/crates/perry-runtime/src/gc/malloc.rs
@@ -84,6 +84,11 @@ pub(crate) struct MallocState {
     /// already-active exact registry, but must never rebuild it on the fast
     /// path because that would scale with total malloc churn.
     pub(super) registry_state: MallocRegistryState,
+    /// One-shot latch for the small-start → heavy-capacity growth (see
+    /// `MALLOC_STATE_INITIAL_CAPACITY`). Stays latched even if a sweep
+    /// later drops `objects.len()` back under the threshold — a thread
+    /// that was malloc-heavy once keeps the reserved capacity.
+    pub(super) heavy_capacity_reserved: bool,
     pub(super) kind_telemetry: [MallocKindTelemetry; MALLOC_KIND_BUCKET_COUNT],
 }
 
@@ -95,19 +100,28 @@ pub(super) enum MallocRegistryState {
 
 /// Pre-allocated capacity for `MallocState.objects` and `.set`.
 ///
-/// On promise-heavy kernels (`promise_all_chains` allocates ~200 k
-/// strings/closures/promises before the first GC) the set grows from
-/// 0 → 128 → … → 256 k buckets across the allocation history. Each
-/// hashbrown doubling re-inserts every existing key, and at the
-/// ~100 k mark those rehashes were the single hottest leaf in the
-/// profile (15.6 % self-time on `gc_malloc`'s caller chain). Starting
-/// at 256 k buckets covers the kernel's full pre-GC working set
-/// (200 k entries at hashbrown's 7/8 load factor) in one allocation —
-/// subsequent kernel iterations re-use the slots that sweep re-emptied,
-/// so we never pay the rehash tax. Cost: one upfront ~4 MB allocation
-/// per thread (vs ~2 MB at 128 k); pays for itself on the first 100
-/// allocations.
-pub(super) const MALLOC_STATE_INITIAL_CAPACITY: usize = 256 * 1024;
+/// History: this used to be a flat 256 k (`MALLOC_STATE_HEAVY_CAPACITY`
+/// below), sized for promise-heavy kernels (`promise_all_chains`
+/// allocates ~200 k strings/closures/promises before the first GC)
+/// where hashbrown's doubling rehashes at the ~100 k mark were the
+/// single hottest leaf in the profile (15.6 % self-time on
+/// `gc_malloc`'s caller chain). But that pre-sized a ~2 MB Vec plus a
+/// ~4 MB PtrHashSet on EVERY JS-touching thread — spawn workers and
+/// tokio callers that allocate a few hundred malloc objects paid a
+/// ~6 MB floor for a benchmark they never run. Now: start small, and
+/// the first time a thread's tracked-object count crosses
+/// `MALLOC_STATE_HEAVY_LEN_THRESHOLD` (a genuinely malloc-heavy
+/// thread), reserve straight to the heavy capacity in one step —
+/// preserving the rehash-amortization rationale exactly where it
+/// mattered while cutting the per-thread floor everywhere else.
+pub(super) const MALLOC_STATE_INITIAL_CAPACITY: usize = 4096;
+/// One-time growth trigger: a thread whose live tracked-object count
+/// reaches this is on the promise-heavy profile — reserve the rest.
+pub(super) const MALLOC_STATE_HEAVY_LEN_THRESHOLD: usize = 64 * 1024;
+/// Capacity reserved once the heavy threshold trips (the old flat
+/// pre-size; covers the 200 k-entry pre-GC working set at hashbrown's
+/// 7/8 load factor without further rehashes).
+pub(super) const MALLOC_STATE_HEAVY_CAPACITY: usize = 256 * 1024;
 
 thread_local! {
     pub(crate) static MALLOC_STATE: RefCell<MallocState> = RefCell::new(MallocState {
@@ -119,6 +133,7 @@ thread_local! {
         realloc_forwarding: crate::fast_hash::new_ptr_hash_map(),
         realloc_snapshot_headers: crate::fast_hash::new_ptr_hash_set(),
         registry_state: MallocRegistryState::Inactive,
+        heavy_capacity_reserved: false,
         kind_telemetry: [MallocKindTelemetry::zero(); MALLOC_KIND_BUCKET_COUNT],
     });
 
@@ -167,6 +182,7 @@ pub fn gc_malloc(size: usize, obj_type: u8) -> *mut u8 {
             if s.malloc_registry_available() {
                 s.set.insert(header as usize);
             }
+            s.maybe_reserve_heavy_capacity();
         });
         GC_FLAGS.with(|f| f.set(f.get() & !GC_FLAG_IN_ALLOC));
 
@@ -215,6 +231,7 @@ pub fn gc_malloc_batch(sizes: &[usize], obj_type: u8) -> Vec<*mut u8> {
             if s.malloc_registry_available() {
                 s.set.extend(headers.iter().map(|&h| h as usize));
             }
+            s.maybe_reserve_heavy_capacity();
         });
 
         GC_FLAGS.with(|f| f.set(f.get() & !GC_FLAG_IN_ALLOC));
@@ -227,6 +244,23 @@ impl MallocState {
     #[inline]
     pub(super) fn malloc_registry_available(&self) -> bool {
         self.registry_state == MallocRegistryState::ActiveConsistent
+    }
+
+    /// One-time jump from the small per-thread start to the heavy
+    /// pre-size once this thread proves malloc-heavy. Called after the
+    /// tracked-object push on the allocation paths; `>=` (rather than
+    /// an exact-crossing check) keeps `gc_malloc_batch`'s multi-entry
+    /// extends from skipping over the threshold.
+    #[inline]
+    pub(super) fn maybe_reserve_heavy_capacity(&mut self) {
+        if self.heavy_capacity_reserved || self.objects.len() < MALLOC_STATE_HEAVY_LEN_THRESHOLD {
+            return;
+        }
+        self.heavy_capacity_reserved = true;
+        self.objects
+            .reserve(MALLOC_STATE_HEAVY_CAPACITY.saturating_sub(self.objects.len()));
+        self.set
+            .reserve(MALLOC_STATE_HEAVY_CAPACITY.saturating_sub(self.set.len()));
     }
 
     #[inline]

--- a/crates/perry-runtime/src/gc/oldgen.rs
+++ b/crates/perry-runtime/src/gc/oldgen.rs
@@ -21,6 +21,16 @@ pub(super) struct EvacuationPolicySnapshot {
     pub(super) old_page_selected_live_bytes: usize,
     pub(super) old_page_reclaimable_bytes: usize,
     pub(super) old_page_skipped_pinned_pages: usize,
+    /// Block/page-granule bytes a defrag would actually release: the
+    /// full size of every nursery block whose reset is blocked ONLY by
+    /// movable candidates, plus the page granule of every selected old
+    /// page. `reclaimable_candidate_bytes` counts the candidate
+    /// OBJECTS' own bytes — but memory returns to the OS in whole
+    /// blocks/pages, so 500 blocks each pinned by a few hundred bytes
+    /// of scattered tenured survivors are ~500 MB of releasable RSS
+    /// that the object-bytes metric reports as <1 MB. The policy gate
+    /// passes when EITHER metric clears `MIN_CANDIDATE_BYTES`.
+    pub(super) releasable_block_bytes: usize,
     pub(super) retained_forwarded_stub_bytes: usize,
     pub(super) retained_forwarded_stub_objects: usize,
     pub(super) conservative_pinned_bytes: usize,
@@ -80,6 +90,10 @@ pub(super) struct OldPageDefragSelection {
     pub(super) selected_pages: usize,
     pub(super) selected_live_bytes: usize,
     pub(super) selected_reclaimable_bytes: usize,
+    /// Page-granule bytes the selected pages would hand back once their
+    /// movable live objects are evacuated: page size minus pinned bytes
+    /// (selection skips pinned pages, so in practice the full granule).
+    pub(super) selected_releasable_block_bytes: usize,
     pub(super) skipped_pinned_pages: usize,
 }
 
@@ -172,6 +186,12 @@ pub(super) fn select_old_page_defrag_pages_from_snapshot(
             selection.selected_reclaimable_bytes = selection
                 .selected_reclaimable_bytes
                 .saturating_add(meta.dead_bytes);
+            selection.selected_releasable_block_bytes = selection
+                .selected_releasable_block_bytes
+                .saturating_add(
+                    (meta.page_end.saturating_sub(meta.page_base))
+                        .saturating_sub(meta.pinned_bytes),
+                );
         }
     }
 
@@ -295,6 +315,7 @@ pub(super) fn evacuation_policy_snapshot_after_mark(
     snapshot.old_page_selected_live_bytes = old_page_selection.selected_live_bytes;
     snapshot.old_page_reclaimable_bytes = old_page_selection.selected_reclaimable_bytes;
     snapshot.old_page_skipped_pinned_pages = old_page_selection.skipped_pinned_pages;
+    snapshot.releasable_block_bytes = old_page_selection.selected_releasable_block_bytes;
 
     let n_blocks = crate::arena::arena_block_count();
     let general_n = crate::arena::general_block_count();
@@ -359,10 +380,21 @@ pub(super) fn evacuation_policy_snapshot_after_mark(
         }
     });
 
-    for block in blocks.iter().take(general_n) {
+    let general_block_sizes = crate::arena::general_block_sizes();
+    for (block_idx, block) in blocks.iter().enumerate().take(general_n) {
         if block.candidate_bytes > 0 && !block.retained_live {
             snapshot.reclaimable_candidate_objects += block.candidate_objects;
             snapshot.reclaimable_candidate_bytes += block.candidate_bytes;
+            // This block's reset is blocked ONLY by movable candidates:
+            // evacuating them frees the whole block granule. Exclude the
+            // caller-saved-register safety window — those blocks are not
+            // reset even when empty, so their granule can't be released
+            // this cycle regardless of what evacuation moves.
+            if !crate::arena::general_block_in_recent_window(block_idx) {
+                snapshot.releasable_block_bytes = snapshot.releasable_block_bytes.saturating_add(
+                    general_block_sizes.get(block_idx).copied().unwrap_or(0),
+                );
+            }
         }
     }
     snapshot
@@ -393,28 +425,51 @@ pub(super) fn evacuation_policy_final_decision(
         decision.reason = "force";
         return decision;
     }
-    if snapshot.effective_reclaimable_candidate_bytes() == 0 {
+    // Hard RSS pressure bypasses every candidate-volume/ratio/pause gate:
+    // at 256 MB+ of RSS with ANY movable candidate (checked above), refusing
+    // to compact because the candidates look small is exactly backwards —
+    // the small scattered candidates are what's pinning the blocks.
+    // Previously these gates `return`ed before the RSS checks, so a heap of
+    // sparsely-pinned blocks could sit above the hard threshold forever with
+    // reason `reclaimable_candidate_bytes_below_threshold`.
+    let hard_rss_pressure = snapshot.rss_bytes >= RSS_HARD_PRESSURE_BYTES;
+    if hard_rss_pressure {
+        decision.enabled = true;
+        decision.reason = "rss_hard_pressure";
+        return decision;
+    }
+    if snapshot.effective_reclaimable_candidate_bytes() == 0
+        && snapshot.releasable_block_bytes == 0
+    {
         decision.reason = "zero_reclaimable_candidates";
         return decision;
     }
-    if snapshot.effective_reclaimable_candidate_bytes() < MIN_CANDIDATE_BYTES {
+    // Volume gate: pass when EITHER the candidate objects' own bytes OR the
+    // block/page granule bytes their evacuation releases clear the bar. The
+    // ratio gate stays object-bytes-scoped — the granule metric is an
+    // absolute-RSS argument, not a proportion of the tenured working set.
+    let object_bytes_pass = snapshot.effective_reclaimable_candidate_bytes() >= MIN_CANDIDATE_BYTES;
+    let block_bytes_pass = snapshot.releasable_block_bytes >= MIN_CANDIDATE_BYTES;
+    if !object_bytes_pass && !block_bytes_pass {
         decision.reason = "reclaimable_candidate_bytes_below_threshold";
         return decision;
     }
-    if snapshot.effective_reclaimable_candidate_ratio_pct() < MIN_CANDIDATE_RATIO_PCT {
+    if !block_bytes_pass
+        && snapshot.effective_reclaimable_candidate_ratio_pct() < MIN_CANDIDATE_RATIO_PCT
+    {
         decision.reason = "reclaimable_candidate_ratio_below_threshold";
         return decision;
     }
-    let hard_rss_pressure = snapshot.rss_bytes >= RSS_HARD_PRESSURE_BYTES;
     let pause_budget_exceeded = snapshot.previous_pause_us > MAX_PREVIOUS_PAUSE_US
         || snapshot.pre_evac_pause_us > MAX_PREVIOUS_PAUSE_US;
-    if pause_budget_exceeded && !hard_rss_pressure {
+    if pause_budget_exceeded {
         decision.reason = "pause_budget_exceeded";
         return decision;
     }
     decision.enabled = true;
-    decision.reason = if hard_rss_pressure {
-        "rss_hard_pressure"
+    decision.reason = if !object_bytes_pass && block_bytes_pass {
+        // Only the granule metric cleared the bar — the new W3 path.
+        "releasable_block_bytes"
     } else if snapshot.rss_bytes >= RSS_PRESSURE_BYTES {
         "rss_pressure"
     } else if snapshot.old_page_selected_pages > 0
@@ -439,7 +494,7 @@ pub(super) fn maybe_print_evacuation_policy_diag(
     }
     let snapshot = decision.snapshot;
     eprintln!(
-        "[gc-evac-policy] enabled={} reason={} tenured={} candidate_bytes={} candidate_objects={} candidate_ratio_pct={} reclaimable_candidate_bytes={} reclaimable_candidate_objects={} reclaimable_candidate_ratio_pct={} old_page_candidate_pages={} old_page_selected_pages={} old_page_selected_live_bytes={} old_page_reclaimable_bytes={} old_page_skipped_pinned_pages={} policy_retained_forwarded_stub_bytes={} policy_retained_forwarded_stub_objects={} cons_pinned={} rss={} prev_pause_us={} pre_evac_pause_us={} moved_bytes={} moved_objects={} old_page_moved_bytes={} old_page_moved_objects={} released_original_bytes={} released_original_objects={} sweep_retained_forwarded_stub_bytes={} sweep_retained_forwarded_stub_objects={}",
+        "[gc-evac-policy] enabled={} reason={} tenured={} candidate_bytes={} candidate_objects={} candidate_ratio_pct={} reclaimable_candidate_bytes={} reclaimable_candidate_objects={} reclaimable_candidate_ratio_pct={} releasable_block_bytes={} old_page_candidate_pages={} old_page_selected_pages={} old_page_selected_live_bytes={} old_page_reclaimable_bytes={} old_page_skipped_pinned_pages={} policy_retained_forwarded_stub_bytes={} policy_retained_forwarded_stub_objects={} cons_pinned={} rss={} prev_pause_us={} pre_evac_pause_us={} moved_bytes={} moved_objects={} old_page_moved_bytes={} old_page_moved_objects={} released_original_bytes={} released_original_objects={} sweep_retained_forwarded_stub_bytes={} sweep_retained_forwarded_stub_objects={}",
         decision.enabled,
         decision.reason,
         snapshot.tenured_still_in_nursery_bytes,
@@ -449,6 +504,7 @@ pub(super) fn maybe_print_evacuation_policy_diag(
         snapshot.reclaimable_candidate_bytes,
         snapshot.reclaimable_candidate_objects,
         snapshot.reclaimable_candidate_ratio_pct(),
+        snapshot.releasable_block_bytes,
         snapshot.old_page_candidate_pages,
         snapshot.old_page_selected_pages,
         snapshot.old_page_selected_live_bytes,

--- a/crates/perry-runtime/src/gc/oldgen.rs
+++ b/crates/perry-runtime/src/gc/oldgen.rs
@@ -186,9 +186,8 @@ pub(super) fn select_old_page_defrag_pages_from_snapshot(
             selection.selected_reclaimable_bytes = selection
                 .selected_reclaimable_bytes
                 .saturating_add(meta.dead_bytes);
-            selection.selected_releasable_block_bytes = selection
-                .selected_releasable_block_bytes
-                .saturating_add(
+            selection.selected_releasable_block_bytes =
+                selection.selected_releasable_block_bytes.saturating_add(
                     (meta.page_end.saturating_sub(meta.page_base))
                         .saturating_sub(meta.pinned_bytes),
                 );
@@ -391,9 +390,9 @@ pub(super) fn evacuation_policy_snapshot_after_mark(
             // reset even when empty, so their granule can't be released
             // this cycle regardless of what evacuation moves.
             if !crate::arena::general_block_in_recent_window(block_idx) {
-                snapshot.releasable_block_bytes = snapshot.releasable_block_bytes.saturating_add(
-                    general_block_sizes.get(block_idx).copied().unwrap_or(0),
-                );
+                snapshot.releasable_block_bytes = snapshot
+                    .releasable_block_bytes
+                    .saturating_add(general_block_sizes.get(block_idx).copied().unwrap_or(0));
             }
         }
     }
@@ -438,8 +437,7 @@ pub(super) fn evacuation_policy_final_decision(
         decision.reason = "rss_hard_pressure";
         return decision;
     }
-    if snapshot.effective_reclaimable_candidate_bytes() == 0
-        && snapshot.releasable_block_bytes == 0
+    if snapshot.effective_reclaimable_candidate_bytes() == 0 && snapshot.releasable_block_bytes == 0
     {
         decision.reason = "zero_reclaimable_candidates";
         return decision;

--- a/crates/perry-runtime/src/gc/telemetry.rs
+++ b/crates/perry-runtime/src/gc/telemetry.rs
@@ -859,6 +859,7 @@ impl GcCycleTrace {
             "reclaimable_candidate_bytes": self.evacuation_policy.snapshot.reclaimable_candidate_bytes,
             "reclaimable_candidate_objects": self.evacuation_policy.snapshot.reclaimable_candidate_objects,
             "reclaimable_candidate_ratio_pct": self.evacuation_policy.snapshot.reclaimable_candidate_ratio_pct(),
+            "releasable_block_bytes": self.evacuation_policy.snapshot.releasable_block_bytes,
             "old_page_candidate_pages": self.evacuation_policy.snapshot.old_page_candidate_pages,
             "old_page_selected_pages": self.evacuation_policy.snapshot.old_page_selected_pages,
             "old_page_selected_live_bytes": self.evacuation_policy.snapshot.old_page_selected_live_bytes,

--- a/crates/perry-runtime/src/gc/tests/alloc.rs
+++ b/crates/perry-runtime/src/gc/tests/alloc.rs
@@ -1158,7 +1158,10 @@ fn malloc_state_capacity_grows_once_for_heavy_threads() {
         }
         MALLOC_STATE.with(|s| {
             let s = s.borrow();
-            assert!(s.heavy_capacity_reserved, "heavy latch must trip at the threshold");
+            assert!(
+                s.heavy_capacity_reserved,
+                "heavy latch must trip at the threshold"
+            );
             assert!(
                 s.objects.capacity() >= MALLOC_STATE_HEAVY_CAPACITY,
                 "objects Vec must reserve the heavy capacity (got {})",

--- a/crates/perry-runtime/src/gc/tests/alloc.rs
+++ b/crates/perry-runtime/src/gc/tests/alloc.rs
@@ -1127,3 +1127,45 @@ fn test_malloc_kind_telemetry_trace_json() {
         .expect("unknown row should be present");
     assert_eq!(unknown_row["kind"].as_str(), Some("unknown"));
 }
+
+/// `MALLOC_STATE` starts small (4096-entry pre-size) and jumps to the
+/// heavy 256 k pre-size exactly once, the first time a thread's tracked
+/// object count crosses `MALLOC_STATE_HEAVY_LEN_THRESHOLD` — spawn
+/// workers keep the small floor, promise-heavy threads keep the
+/// rehash-amortization the old flat pre-size existed for.
+#[test]
+fn malloc_state_capacity_grows_once_for_heavy_threads() {
+    std::thread::spawn(|| {
+        let _triggers = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+
+        // Fresh thread → pristine MALLOC_STATE at the small pre-size.
+        let (initial_objects_cap, initial_set_cap) = MALLOC_STATE.with(|s| {
+            let s = s.borrow();
+            (s.objects.capacity(), s.set.capacity())
+        });
+        assert!(
+            initial_objects_cap < MALLOC_STATE_HEAVY_CAPACITY,
+            "objects Vec must not start at the heavy pre-size (got {initial_objects_cap})"
+        );
+        assert!(
+            initial_set_cap < MALLOC_STATE_HEAVY_CAPACITY,
+            "pointer set must not start at the heavy pre-size (got {initial_set_cap})"
+        );
+
+        // Cross the heavy threshold; the one-shot reserve must trip.
+        while MALLOC_STATE.with(|s| s.borrow().objects.len()) < MALLOC_STATE_HEAVY_LEN_THRESHOLD {
+            let _ = gc_malloc(16, GC_TYPE_STRING);
+        }
+        MALLOC_STATE.with(|s| {
+            let s = s.borrow();
+            assert!(s.heavy_capacity_reserved, "heavy latch must trip at the threshold");
+            assert!(
+                s.objects.capacity() >= MALLOC_STATE_HEAVY_CAPACITY,
+                "objects Vec must reserve the heavy capacity (got {})",
+                s.objects.capacity()
+            );
+        });
+    })
+    .join()
+    .expect("malloc capacity growth test panicked");
+}

--- a/crates/perry-runtime/src/gc/tests/evacuation.rs
+++ b/crates/perry-runtime/src/gc/tests/evacuation.rs
@@ -339,6 +339,175 @@ fn test_evacuation_policy() {
     assert_eq!(disabled.reason, "disabled");
 }
 
+/// 2026-07-09 GC audit W3: the volume gate must pass on the block-granule
+/// metric (`releasable_block_bytes`) even when the candidate OBJECTS' own
+/// bytes are far below `MIN_CANDIDATE_BYTES` — the "500 blocks pinned by a
+/// few hundred bytes of scattered tenured survivors each" shape — and hard
+/// RSS pressure must bypass the candidate-volume/ratio/pause gates
+/// entirely whenever any movable candidate exists.
+#[test]
+fn test_evacuation_policy_releasable_block_bytes_gate_and_hard_rss_bypass() {
+    fn decide(snapshot: EvacuationPolicySnapshot) -> EvacuationPolicyDecision {
+        evacuation_policy_final_decision(
+            EvacuationPolicyDecision {
+                allowed: true,
+                considered: true,
+                force: false,
+                enabled: false,
+                reason: "test",
+                snapshot,
+            },
+            snapshot,
+        )
+    }
+
+    // Scattered-survivor shape: ~500 blocks each pinned by ~1 KB of
+    // movable tenured candidates. Object-bytes metric (~512 KB) is far
+    // below the 8 MB bar, but evacuating the candidates releases
+    // ~500 MB of block granules.
+    let scattered = EvacuationPolicySnapshot {
+        tenured_still_in_nursery_bytes: 512 * 1024,
+        candidate_bytes: 512 * 1024,
+        candidate_objects: 500,
+        reclaimable_candidate_bytes: 512 * 1024,
+        reclaimable_candidate_objects: 500,
+        releasable_block_bytes: 500 * 1024 * 1024,
+        ..EvacuationPolicySnapshot::default()
+    };
+    let scattered_decision = decide(scattered);
+    assert!(
+        scattered_decision.enabled,
+        "block-granule metric must clear the volume gate on its own"
+    );
+    assert_eq!(scattered_decision.reason, "releasable_block_bytes");
+
+    // The granule metric also skips the object-bytes ratio gate: same
+    // shape with a huge tenured denominator would fail the 25% ratio.
+    let low_ratio = EvacuationPolicySnapshot {
+        tenured_still_in_nursery_bytes: MIN_TENURED_NURSERY_BYTES * 8,
+        ..scattered
+    };
+    let low_ratio_decision = decide(low_ratio);
+    assert!(
+        low_ratio_decision.enabled,
+        "ratio gate must not veto a block-granule pass"
+    );
+    assert_eq!(low_ratio_decision.reason, "releasable_block_bytes");
+
+    // Both metrics below the bar still refuses, preserving the existing
+    // telemetry reason.
+    let both_small = EvacuationPolicySnapshot {
+        tenured_still_in_nursery_bytes: MIN_TENURED_NURSERY_BYTES,
+        candidate_bytes: 64 * 1024,
+        candidate_objects: 8,
+        reclaimable_candidate_bytes: 64 * 1024,
+        reclaimable_candidate_objects: 8,
+        releasable_block_bytes: MIN_CANDIDATE_BYTES - 1,
+        ..EvacuationPolicySnapshot::default()
+    };
+    let both_small_decision = decide(both_small);
+    assert!(!both_small_decision.enabled);
+    assert_eq!(
+        both_small_decision.reason,
+        "reclaimable_candidate_bytes_below_threshold"
+    );
+
+    // Hard RSS pressure bypasses the volume/ratio/pause gates: candidate
+    // volume below every bar, zero reclaimable/releasable bytes, pause
+    // budget blown — still evacuates, because movable candidates exist
+    // and RSS is past the hard threshold.
+    let hard_rss_bypass = EvacuationPolicySnapshot {
+        tenured_still_in_nursery_bytes: 64 * 1024,
+        candidate_bytes: 4096,
+        candidate_objects: 4,
+        reclaimable_candidate_bytes: 0,
+        reclaimable_candidate_objects: 0,
+        releasable_block_bytes: 0,
+        rss_bytes: RSS_HARD_PRESSURE_BYTES,
+        previous_pause_us: MAX_PREVIOUS_PAUSE_US + 1,
+        ..EvacuationPolicySnapshot::default()
+    };
+    let bypass_decision = decide(hard_rss_bypass);
+    assert!(
+        bypass_decision.enabled,
+        "hard RSS pressure must bypass the candidate-volume gates"
+    );
+    assert_eq!(bypass_decision.reason, "rss_hard_pressure");
+
+    // ...but zero movable candidates still refuses even under hard RSS:
+    // there is nothing evacuation could move.
+    let no_candidates = EvacuationPolicySnapshot {
+        tenured_still_in_nursery_bytes: 64 * 1024,
+        candidate_bytes: 0,
+        candidate_objects: 0,
+        rss_bytes: RSS_HARD_PRESSURE_BYTES,
+        ..EvacuationPolicySnapshot::default()
+    };
+    let no_candidates_decision = decide(no_candidates);
+    assert!(!no_candidates_decision.enabled);
+    assert_eq!(no_candidates_decision.reason, "zero_candidates");
+
+    // Object-bytes pass with below-bar granule metric keeps the legacy
+    // pressure-based reason strings.
+    let object_pass = EvacuationPolicySnapshot {
+        tenured_still_in_nursery_bytes: MIN_TENURED_NURSERY_BYTES * 2,
+        candidate_bytes: MIN_CANDIDATE_BYTES * 2,
+        candidate_objects: 16,
+        reclaimable_candidate_bytes: MIN_CANDIDATE_BYTES * 2,
+        reclaimable_candidate_objects: 16,
+        releasable_block_bytes: 0,
+        ..EvacuationPolicySnapshot::default()
+    };
+    let object_pass_decision = decide(object_pass);
+    assert!(object_pass_decision.enabled);
+    assert_eq!(object_pass_decision.reason, "nursery_pressure");
+}
+
+/// The old-page defrag selection must report the page-granule bytes its
+/// selected pages would release (page size minus pinned bytes) so the
+/// policy's `releasable_block_bytes` metric sees whole granules, not
+/// just the dead object bytes.
+#[test]
+fn test_old_page_defrag_selection_reports_releasable_granule_bytes() {
+    fn meta(
+        page_base: usize,
+        allocated_bytes: usize,
+        live_bytes: usize,
+        dead_bytes: usize,
+        pinned_bytes: usize,
+    ) -> crate::arena::OldPageMeta {
+        crate::arena::OldPageMeta {
+            page_base,
+            page_end: page_base + 4096,
+            allocated_bytes,
+            live_bytes,
+            dead_bytes,
+            object_count: 1,
+            live_object_count: usize::from(live_bytes > 0),
+            dead_object_count: usize::from(dead_bytes > 0),
+            pinned_bytes,
+            pinned_object_count: usize::from(pinned_bytes > 0),
+            dirty_slots: 0,
+            dirty: false,
+            evacuation_eligible: false,
+        }
+    }
+
+    let selected_a = meta(0x2000_0000, 100, 10, 90, 0);
+    let selected_b = meta(0x2000_1000, 100, 20, 80, 0);
+    let unselected_low_dead = meta(0x2000_2000, 100, 80, 20, 0);
+    let pinned = meta(0x2000_3000, 100, 10, 90, 8);
+    let snapshot = [selected_a, selected_b, unselected_low_dead, pinned];
+
+    let selection = select_old_page_defrag_pages_from_snapshot(&snapshot, false);
+    assert_eq!(selection.selected_pages, 2);
+    assert_eq!(
+        selection.selected_releasable_block_bytes,
+        2 * 4096,
+        "each selected (unpinned) page contributes its full page granule"
+    );
+}
+
 #[test]
 fn test_evacuation_policy_snapshot_excludes_retained_forwarded_stub_blocks() {
     clear_marks();

--- a/crates/perry-runtime/src/gc/tests/oldgen.rs
+++ b/crates/perry-runtime/src/gc/tests/oldgen.rs
@@ -940,3 +940,80 @@ fn test_old_page_defrag_trace_json_distinguishes_moved_from_reclaimable() {
     assert_eq!(event["sweep"]["returned_bytes"].as_u64(), Some(32));
     assert_eq!(event["sweep"]["deallocated_bytes"].as_u64(), Some(32));
 }
+
+/// The delta-maintained `OLD_GEN_IN_USE_BYTES` cache must agree with the
+/// O(blocks) recompute across every old-arena mutation class: small bump
+/// allocations, oversized-block allocation, sweep-driven block reset,
+/// block deallocation back to the OS, post-reset block reuse, and a full
+/// explicit collection. (`old_gen_in_use_bytes()` additionally
+/// debug-asserts the same invariant on every read, so every other GC
+/// test — including the old-page defrag suite — cross-checks it too.)
+#[test]
+fn test_old_gen_in_use_bytes_delta_matches_recompute_across_alloc_and_reclaim() {
+    let _isolation = copying_nursery_isolation_lock();
+    // Keep alloc-point triggers quiet so the mid-test totals compare
+    // deterministically; the explicit sweep/collect calls below still run.
+    let _triggers = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    reset_remembered_set();
+    clear_marks();
+    clear_mark_seeds();
+    crate::arena::old_pages_begin_gc_cycle();
+
+    fn assert_consistent(label: &str) {
+        assert_eq!(
+            crate::arena::old_gen_in_use_bytes(),
+            crate::arena::old_gen_in_use_bytes_recomputed(),
+            "{label}: cached old-gen in-use bytes drifted from the per-block recompute"
+        );
+    }
+
+    assert_consistent("baseline");
+
+    // Small old-arena bump allocations (also materializes the lazy
+    // initial block on a fresh test thread).
+    let live = crate::arena::arena_alloc_gc_old(40, 8, GC_TYPE_STRING) as usize;
+    for _ in 0..32 {
+        let _ = unsafe { alloc_old_test_object(4) };
+    }
+    assert_consistent("after small old allocs");
+    let before_oversized = crate::arena::old_gen_in_use_bytes();
+
+    // Oversized allocation: forces a custom-sized fresh-block install +
+    // bump through the fresh-block alloc path.
+    let dead_big = crate::arena::arena_alloc_gc_old(2 * 1024 * 1024, 8, GC_TYPE_STRING) as usize;
+    let (_, dead_total) = old_test_header_and_size(dead_big);
+    assert_consistent("after oversized old alloc");
+    assert!(
+        crate::arena::old_gen_in_use_bytes() >= before_oversized + dead_total,
+        "oversized alloc must raise the cached in-use total"
+    );
+
+    // Sweep + old-block reclaim: the oversized block dies (reset and/or
+    // deallocated), the block holding `live` survives.
+    let (live_header, _) = old_test_header_and_size(live);
+    unsafe {
+        (*live_header).gc_flags |= GC_FLAG_MARKED;
+    }
+    let old_before_sweep = crate::arena::old_gen_in_use_bytes();
+    let _ = sweep_with_age_bump_and_old_reclaim(false, true);
+    assert_consistent("after sweep + old block reclaim");
+    assert!(
+        crate::arena::old_gen_in_use_bytes() < old_before_sweep,
+        "dead old block reclaim must lower the cached in-use total"
+    );
+
+    // Re-allocate after the reclaim so the reset-block reuse path
+    // (forward scan into an offset-0 block) is delta-tracked too.
+    for _ in 0..8 {
+        let _ = unsafe { alloc_old_test_object(2) };
+    }
+    assert_consistent("after post-reclaim reuse allocs");
+
+    // Full explicit collection end-to-end (mark, sweep, reclaim,
+    // possible evacuation-policy pass).
+    js_gc_collect();
+    assert_consistent("after full explicit collection");
+
+    clear_marks();
+    remembered_set_clear();
+}


### PR DESCRIPTION
Wave 2/3 of the 2026-07-09 GC audit (fable-audit-perry-gc.md); companions #6178 #6188 #6189 #6190.

Three scoped performance/policy fixes in `perry-runtime`'s GC/arena layer.

## 1. Delta-maintained `old_gen_in_use_bytes` (P2)

`gc_budgeted_due_trigger()` called `old_gen_in_use_bytes()` — a fresh `blocks.iter().map(|b| b.offset).sum()` over every old-arena block — on every `gc_check_trigger`, i.e. on every `gc_malloc` and every nursery block fill. A multi-GB old gen made each malloc-class allocation pay a linear walk (audit T8, "still unfixed from audit-2").

Now the total is a delta-maintained thread-local (`OLD_GEN_IN_USE_BYTES`), mirroring the existing `ARENA_TOTAL_BYTES` pattern. Mutation-site inventory (documented on the thread-local):

- **Offset advance**: all `Arena::alloc` / `alloc_excluding_pages` / fresh-block paths now funnel through `Arena::try_block_alloc[_excluding_pages]`, which records the post-alloc offset delta when `generation == Old`.
- **Offset zeroing**: the old-arena reclaim family in `arena/reset.rs` (`old_arena_reclaim_dead_blocks`, `old_arena_reclaim_selected_dead_blocks`, budgeted `OldArenaReclaimDeadBlocksState::process_block`) subtracts the zeroed block's `used` bytes; `reset_region_to_zero` is generation-aware for future-proofing (no old-gen caller today).
- Block install/dealloc paths need no update: fresh blocks start at offset 0, and blocks are only deallocated after their offset was already zeroed.

`old_gen_in_use_bytes()` `debug_assert_eq!`s the cache against the O(blocks) recompute on **every read** in debug/test builds, so a missed mutation site fails the test suite instead of silently skewing the OldReclaim trigger. A dedicated test drives allocs (small, oversized-block), sweep + block reclaim/dealloc, post-reset block reuse, and a full explicit collection, asserting cache == recompute at each step.

## 2. Evacuation policy: releasable BLOCK bytes + hard-RSS bypass (P1)

`evacuation_policy_final_decision` gated on `effective_reclaimable_candidate_bytes() >= 8 MB` plus a >=25% ratio, where the metric sums the candidate **objects'** own bytes — but a defrag releases whole block/page granules. 500 nursery blocks each pinned by a few hundred bytes of scattered tenured survivors are ~500 MB of releasable RSS that the policy saw as <1 MB → `reclaimable_candidate_bytes_below_threshold` forever. Worse, those gates `return`ed before the RSS checks, so even 256 MB+ hard RSS pressure could not override.

- **(a) New `releasable_block_bytes` metric** on `EvacuationPolicySnapshot`: the full block size of every nursery block whose reset is blocked *only* by movable candidates (recent-window blocks excluded — they aren't reset even when empty), plus the page granule (page size minus pinned bytes, via the existing `OldPageMeta`) of every selected old page (`OldPageDefragSelection::selected_releasable_block_bytes`). The volume gate passes when **either** the object-bytes metric or the granule metric clears `MIN_CANDIDATE_BYTES`; the 25%-ratio gate stays object-bytes-scoped (the granule metric is an absolute-RSS argument, not a proportion).
- **(b) Hard-RSS bypass**: the `rss_bytes >= RSS_HARD_PRESSURE_BYTES` check now runs **before** the candidate-volume/ratio/pause early-returns. With any movable candidate present (`zero_candidates` still precedes it), hard pressure enables evacuation directly with the existing `rss_hard_pressure` reason.

Telemetry: all existing reason strings preserved (`zero_candidates`, `zero_reclaimable_candidates`, `reclaimable_candidate_bytes_below_threshold`, `reclaimable_candidate_ratio_below_threshold`, `pause_budget_exceeded`, `rss_hard_pressure`, `rss_pressure`, `old_page_fragmentation`, `nursery_pressure`, `force`); one new enabled-reason `releasable_block_bytes` for the granule-only pass; the metric is added to the `PERRY_GC_DIAG` policy line and the trace JSON.

## 3. Smaller fixed per-thread floors (P2/P3)

- **`MALLOC_STATE`**: the flat 256 k pre-size (~2 MB Vec + ~4 MB PtrHashSet on every JS-touching thread, sized for a promise-heavy benchmark) becomes a 4096-entry start with a one-shot `reserve` to 256 k the first time a thread's tracked-object count crosses 64 k (`maybe_reserve_heavy_capacity`, latched so sweeps can't re-trip it). Heavy threads keep the rehash-amortization the pre-size existed for; spawn workers drop the ~6 MB floor.
- **Lazy arena initial blocks**: `SURVIVOR_ARENA_0/1`, `OLD_ARENA`, and `LONGLIVED_ARENA` now start with a `data = null, size = 0` tombstone block (`Arena::new_lazy`) instead of an eager 1 MB block each — the exact shape the C4b-δ dealloc path already leaves behind, so every walker/reset/alloc path handles it without new `is_empty` guards; the first allocation materializes the block via the existing tombstone-reuse slow path. **Eden (`ARENA`) intentionally stays eager**: `js_inline_arena_state` hands its current block to codegen's inline bump allocator at thread start, and threads allocate in Eden immediately anyway — making it lazy would touch the codegen-facing hot path for no realistic saving. Net: ~4 MB less eager mapping per thread (plus the malloc-state floor above).

## Verification

- New tests: `gc::tests::oldgen::test_old_gen_in_use_bytes_delta_matches_recompute_across_alloc_and_reclaim`, `gc::tests::evacuation::test_evacuation_policy_releasable_block_bytes_gate_and_hard_rss_bypass`, `gc::tests::evacuation::test_old_page_defrag_selection_reports_releasable_granule_bytes`, `gc::tests::alloc::malloc_state_capacity_grows_once_for_heavy_threads`, `arena::tests::lazy_regions_defer_initial_block_allocation`. The debug cross-check in `old_gen_in_use_bytes()` additionally makes every existing GC test (including the old-page defrag suite) a consistency check.
- `PERRY_NO_AUTO_OPTIMIZE=1 cargo test -p perry-runtime --lib`: full suite `1169 passed; 0 failed` (three consecutive clean runs post-fmt). Note: under heavy machine load the suite shows pre-existing nondeterministic failures **on the base commit too** (`url::node_compat`, `telemetry_verifier::allocation_heavy_arena_debt...`, `object::tests::builtin_prototype_methods_reject_dynamic_new` — verified flaky at origin/main@62349a149 with 0-3 failures per run at load ~75); failure rate and identities are unchanged by this branch.
- `cargo fmt --all -- --check` clean.
- Two arena tests were updated for the lazy initial block (`old_page_metadata_registers_old_block_pages` materializes the first old block; `old_arena_block_reuse_does_not_repoint_eden_inline_state` materializes block 0 before installing a second block and resyncs the counter after its deliberate hand-mutation of offsets).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved GC telemetry with a new evacuation metric for releasable block bytes.
  * Added support for lazy initialization of certain memory regions, reducing upfront allocation.

* **Bug Fixes**
  * Made old-generation memory usage tracking more accurate during allocation, reset, and reclamation.
  * Improved evacuation decisions under memory pressure and when reclaimable block space is available.
  * Optimized thread-local malloc tracking so heavy allocation patterns reserve capacity more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->