### PR TITLE
fix(hir): `continue` in for-await drivers skipped the iterator advance (spin)

### DIFF
--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -358,6 +358,40 @@ pub(crate) fn iterator_next_call(iter_id: LocalId) -> Expr {
     })
 }
 
+/// Iterator-driver loop with the ADVANCE AT THE TOP of the body:
+///   while (true) { __result = <next_call>; if (__result.done) break; <bind + body> }
+/// `continue` in the user body falls to the `while` condition and re-runs the
+/// advance. The previous shape — `while (!__result.done) { <body>;
+/// __result = next() }` — put the advance at the body TAIL, so a `continue`
+/// skipped it and re-processed the SAME result forever (the footgun
+/// `lazy_iter_for_stmt` documents; it can use `Stmt::For`'s update clause,
+/// but the await-capable drivers here cannot carry an `await` there, so they
+/// use this shape). Canonical spin: an SSE consumer's
+/// `for await (...) { if (ev === "ping") continue; ... }` hung a large
+/// esbuild-bundled CLI app on the first real server ping.
+///
+/// The synthetic `if done break` is appended AFTER
+/// `insert_iterator_return_before_abrupts` runs over the user body, so the
+/// normal-completion exit never triggers a spurious IteratorClose.
+fn iter_driver_while_stmt(result_id: LocalId, next_call: Expr, rest: Vec<Stmt>) -> Stmt {
+    let mut body = vec![
+        Stmt::Expr(Expr::LocalSet(result_id, Box::new(next_call))),
+        Stmt::If {
+            condition: Expr::PropertyGet {
+                object: Box::new(Expr::LocalGet(result_id)),
+                property: "done".to_string(),
+            },
+            then_branch: vec![Stmt::Break],
+            else_branch: None,
+        },
+    ];
+    body.extend(rest);
+    Stmt::While {
+        condition: Expr::Bool(true),
+        body,
+    }
+}
+
 /// The lazy `for...of` driver loop, modeled as a `for` so `continue` re-pulls
 /// the iterator via the update clause (a `while` with the advance at the body
 /// tail would skip it on `continue` and spin):
@@ -683,7 +717,7 @@ fn lower_runtime_for_await_iterator(
         name: format!("__result_{}", result_id),
         ty: Type::Any,
         mutable: true,
-        init: Some(next_call.clone()),
+        init: Some(Expr::Undefined),
     });
 
     let binding_pat = match &for_of_stmt.left {
@@ -725,18 +759,9 @@ fn lower_runtime_for_await_iterator(
     let mut user_body: Vec<Stmt> = module.init.drain(init_before..).collect();
     insert_iterator_return_before_abrupts(&mut user_body, iter_id, true);
     body_stmts.append(&mut user_body);
-    body_stmts.push(Stmt::Expr(Expr::LocalSet(result_id, Box::new(next_call))));
-
-    module.init.push(Stmt::While {
-        condition: Expr::Unary {
-            op: UnaryOp::Not,
-            operand: Box::new(Expr::PropertyGet {
-                object: Box::new(Expr::LocalGet(result_id)),
-                property: "done".to_string(),
-            }),
-        },
-        body: body_stmts,
-    });
+    module
+        .init
+        .push(iter_driver_while_stmt(result_id, next_call, body_stmts));
 
     ctx.pop_block_scope(for_scope_mark);
     Ok(())
@@ -934,7 +959,7 @@ pub(crate) fn lower_stmt_for_of(
             name: format!("__result_{}", result_id),
             ty: Type::Any,
             mutable: true,
-            init: Some(next_call.clone()),
+            init: Some(Expr::Undefined),
         });
 
         // Extract the loop variable binding pattern.
@@ -1016,20 +1041,10 @@ pub(crate) fn lower_stmt_for_of(
             insert_iterator_return_before_abrupts(&mut user_body, iter_id, needs_await);
         }
         body_stmts.append(&mut user_body);
-        // __result = __iter.next()
-        body_stmts.push(Stmt::Expr(Expr::LocalSet(result_id, Box::new(next_call))));
-
-        // while (!__result.done) { body }
-        module.init.push(Stmt::While {
-            condition: Expr::Unary {
-                op: UnaryOp::Not,
-                operand: Box::new(Expr::PropertyGet {
-                    object: Box::new(Expr::LocalGet(result_id)),
-                    property: "done".to_string(),
-                }),
-            },
-            body: body_stmts,
-        });
+        // while (true) { __result = __iter.next(); if (__result.done) break; body }
+        module
+            .init
+            .push(iter_driver_while_stmt(result_id, next_call, body_stmts));
 
         ctx.pop_block_scope(for_scope_mark);
         return Ok(());
@@ -1136,7 +1151,7 @@ pub(crate) fn lower_stmt_for_of(
                 name: format!("__res_{}", res_id),
                 ty: Type::Any,
                 mutable: true,
-                init: Some(read_call(reader_id)),
+                init: Some(Expr::Undefined),
             });
 
             // Loop variable: const <name> = __res.value;
@@ -1176,23 +1191,12 @@ pub(crate) fn lower_stmt_for_of(
             }
             let mut user_body: Vec<Stmt> = module.init.drain(init_before..).collect();
             body_stmts.append(&mut user_body);
-            // __res = await __reader.read();
-            body_stmts.push(Stmt::Expr(Expr::LocalSet(
+            // while (true) { __res = await read(); if (__res.done) break; body }
+            module.init.push(iter_driver_while_stmt(
                 res_id,
-                Box::new(read_call(reader_id)),
-            )));
-
-            // while (!__res.done) { body }
-            module.init.push(Stmt::While {
-                condition: Expr::Unary {
-                    op: UnaryOp::Not,
-                    operand: Box::new(Expr::PropertyGet {
-                        object: Box::new(Expr::LocalGet(res_id)),
-                        property: "done".to_string(),
-                    }),
-                },
-                body: body_stmts,
-            });
+                read_call(reader_id),
+                body_stmts,
+            ));
 
             // reader.releaseLock(); — best-effort cleanup.
             module.init.push(Stmt::Expr(Expr::NativeMethodCall {

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -942,7 +942,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                         name: format!("__res_{}", res_id),
                         ty: Type::Any,
                         mutable: true,
-                        init: Some(read_call()),
+                        init: Some(Expr::Undefined),
                     });
 
                     let item_name = if let ast::ForHead::VarDecl(var_decl) = &for_of_stmt.left {
@@ -973,17 +973,24 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                     });
                     let user_body = lower_body_stmt(ctx, &for_of_stmt.body)?;
                     body_stmts.extend(user_body);
-                    body_stmts.push(Stmt::Expr(Expr::LocalSet(res_id, Box::new(read_call()))));
 
-                    result.push(Stmt::While {
-                        condition: Expr::Unary {
-                            op: UnaryOp::Not,
-                            operand: Box::new(Expr::PropertyGet {
+                    // Advance-at-top driver (see lower_decl/body_stmt/for_await.rs):
+                    // `continue` must re-run the read, not re-process the same chunk.
+                    let mut loop_body = vec![
+                        Stmt::Expr(Expr::LocalSet(res_id, Box::new(read_call()))),
+                        Stmt::If {
+                            condition: Expr::PropertyGet {
                                 object: Box::new(Expr::LocalGet(res_id)),
                                 property: "done".to_string(),
-                            }),
+                            },
+                            then_branch: vec![Stmt::Break],
+                            else_branch: None,
                         },
-                        body: body_stmts,
+                    ];
+                    loop_body.extend(body_stmts);
+                    result.push(Stmt::While {
+                        condition: Expr::Bool(true),
+                        body: loop_body,
                     });
 
                     // reader.releaseLock(); — best-effort cleanup so the
@@ -1162,7 +1169,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                     name: format!("__result_{}", result_id),
                     ty: Type::Any,
                     mutable: true,
-                    init: Some(next_call.clone()),
+                    init: Some(Expr::Undefined),
                 });
 
                 let binding_pat: Option<&ast::Pat> =
@@ -1222,17 +1229,24 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                     insert_iterator_return_before_abrupts(&mut user_body, iter_id, needs_await);
                 }
                 body_stmts.extend(user_body);
-                body_stmts.push(Stmt::Expr(Expr::LocalSet(result_id, Box::new(next_call))));
 
-                result.push(Stmt::While {
-                    condition: Expr::Unary {
-                        op: UnaryOp::Not,
-                        operand: Box::new(Expr::PropertyGet {
+                // Advance-at-top driver (see lower_decl/body_stmt/for_await.rs):
+                // `continue` must re-run `next()`, not re-process the same result.
+                let mut loop_body = vec![
+                    Stmt::Expr(Expr::LocalSet(result_id, Box::new(next_call))),
+                    Stmt::If {
+                        condition: Expr::PropertyGet {
                             object: Box::new(Expr::LocalGet(result_id)),
                             property: "done".to_string(),
-                        }),
+                        },
+                        then_branch: vec![Stmt::Break],
+                        else_branch: None,
                     },
-                    body: body_stmts,
+                ];
+                loop_body.extend(body_stmts);
+                result.push(Stmt::While {
+                    condition: Expr::Bool(true),
+                    body: loop_body,
                 });
 
                 ctx.pop_block_scope(scope_mark);

--- a/crates/perry-hir/src/lower_decl/body_stmt/for_await.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt/for_await.rs
@@ -37,7 +37,7 @@ pub(super) fn lower_runtime_for_await_iterator_body(
         name: format!("__result_{}", result_id),
         ty: Type::Any,
         mutable: true,
-        init: Some(next_call.clone()),
+        init: Some(Expr::Undefined),
     });
 
     let binding_pat = match &for_of_stmt.left {
@@ -71,17 +71,31 @@ pub(super) fn lower_runtime_for_await_iterator_body(
     let mut user_body = lower_body_stmt(ctx, &for_of_stmt.body)?;
     insert_iterator_return_before_abrupts(&mut user_body, iter_id, true);
     body_stmts.extend(user_body);
-    body_stmts.push(Stmt::Expr(Expr::LocalSet(result_id, Box::new(next_call))));
 
-    result.push(Stmt::While {
-        condition: Expr::Unary {
-            op: UnaryOp::Not,
-            operand: Box::new(Expr::PropertyGet {
+    // Advance-at-top driver: `while (true) { __result = await next();
+    // if (__result.done) break; <bind + body> }`. The previous shape put the
+    // advance at the body TAIL (`while (!done) { body; result = next() }`),
+    // so a `continue` in the user body skipped it and re-processed the SAME
+    // result forever — an SSE consumer's `if (ev === "ping") continue;` hung
+    // a large esbuild-bundled CLI app on the first real server ping. Mirrors
+    // `iter_driver_while_stmt` (lower/stmt_loops.rs); the synthetic
+    // `if done break` is appended after the abrupt-close rewrite over the
+    // user body, so normal completion never runs a spurious IteratorClose.
+    let mut loop_body = vec![
+        Stmt::Expr(Expr::LocalSet(result_id, Box::new(next_call))),
+        Stmt::If {
+            condition: Expr::PropertyGet {
                 object: Box::new(Expr::LocalGet(result_id)),
                 property: "done".to_string(),
-            }),
+            },
+            then_branch: vec![Stmt::Break],
+            else_branch: None,
         },
-        body: body_stmts,
+    ];
+    loop_body.extend(body_stmts);
+    result.push(Stmt::While {
+        condition: Expr::Bool(true),
+        body: loop_body,
     });
 
     ctx.pop_block_scope(scope_mark);

--- a/crates/perry/tests/for_await_continue.rs
+++ b/crates/perry/tests/for_await_continue.rs
@@ -1,0 +1,208 @@
+//! Regression tests: `continue` inside `for await (… of …)` loops.
+//!
+//! Every iterator-driver desugar that modeled the loop as
+//! `while (!__result.done) { <body>; __result = await next() }` put the
+//! advance at the body TAIL, so a `continue` in the user body jumped to the
+//! `while` condition, skipped the advance, and re-processed the SAME result
+//! forever — an infinite spin observed as a hang. Six copies of the shape
+//! existed (`lower/stmt_loops.rs` ×3, `lower_decl/body_stmt.rs` ×2,
+//! `lower_decl/body_stmt/for_await.rs`); all now advance at the TOP:
+//! `while (true) { __result = await next(); if (__result.done) break; … }`.
+//! (The array/lazy sync path already used `Stmt::For`'s update clause and
+//! documented this exact footgun.)
+//!
+//! Canonical real-world failure: an SSE consumer's
+//! `for await (const ev of stream) { if (ev.event === "ping") continue; … }`
+//! — a large esbuild-bundled CLI app hung on the first real server ping
+//! event (local mocks that never sent pings masked it).
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::Duration;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+/// Compile + run with a hang guard: pre-fix these programs spun forever, so
+/// enforce a wall-clock bound rather than letting the test suite wedge.
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let mut child = Command::new(&output)
+        .current_dir(dir)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn compiled binary");
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        match child.try_wait().expect("try_wait") {
+            Some(status) => {
+                let out = child.wait_with_output().expect("collect output");
+                assert!(
+                    status.success(),
+                    "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+                    status,
+                    String::from_utf8_lossy(&out.stdout),
+                    String::from_utf8_lossy(&out.stderr)
+                );
+                return String::from_utf8_lossy(&out.stdout).into_owned();
+            }
+            None if std::time::Instant::now() > deadline => {
+                let _ = child.kill();
+                panic!(
+                    "compiled binary hung (pre-fix: `continue` spun on the same iterator result)"
+                );
+            }
+            None => std::thread::sleep(Duration::from_millis(50)),
+        }
+    }
+}
+
+/// The SSE-ping shape: `continue` inside `for await` inside an async
+/// generator must re-pull the source iterator.
+#[test]
+fn continue_in_for_await_inside_async_generator() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+async function* events(): any {
+  yield { event: "message_start", data: '{"a":1}' };
+  yield { event: "ping", data: "{}" };
+  yield { event: "content_block_delta", data: '{"b":2}' };
+  yield { event: "ping", data: "{}" };
+}
+async function* filtered(): any {
+  for await (const w of events()) {
+    if (w.event === "ping") continue;
+    yield JSON.parse(w.data);
+  }
+}
+(async () => {
+  for await (const x of filtered()) console.log("got", JSON.stringify(x));
+  console.log("done");
+})();
+"#,
+    );
+    assert_eq!(stdout, "got {\"a\":1}\ngot {\"b\":2}\ndone\n");
+}
+
+/// `continue` inside `for await` in a plain async function.
+#[test]
+fn continue_in_for_await_inside_async_fn() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+async function* nums(): any { yield 1; yield 2; yield 3; yield 4; }
+(async () => {
+  const out: number[] = [];
+  for await (const n of nums()) {
+    if (n % 2 === 0) continue;
+    out.push(n);
+  }
+  console.log(JSON.stringify(out));
+})();
+"#,
+    );
+    assert_eq!(stdout, "[1,3]\n");
+}
+
+/// `continue` over a custom `[Symbol.asyncIterator]` object (the runtime
+/// GetAsyncIterator driver path, not the recognized-generator-call path).
+#[test]
+fn continue_in_for_await_over_custom_async_iterable() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+async function* mk(): any { yield "a"; yield "skip"; yield "b"; }
+const src: any = { [Symbol.asyncIterator]() { return mk(); } };
+(async () => {
+  const out: string[] = [];
+  for await (const s of src) {
+    if (s === "skip") continue;
+    out.push(s);
+  }
+  console.log(JSON.stringify(out));
+})();
+"#,
+    );
+    assert_eq!(stdout, "[\"a\",\"b\"]\n");
+}
+
+/// `continue` over a Web ReadableStream (the getReader()/read() driver).
+#[test]
+fn continue_in_for_await_over_readable_stream() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const rs = new ReadableStream({
+  start(c: any) {
+    c.enqueue("x");
+    c.enqueue("skip");
+    c.enqueue("y");
+    c.close();
+  },
+});
+(async () => {
+  const out: string[] = [];
+  for await (const chunk of rs as any) {
+    if (chunk === "skip") continue;
+    out.push(chunk);
+  }
+  console.log(JSON.stringify(out));
+})();
+"#,
+    );
+    assert_eq!(stdout, "[\"x\",\"y\"]\n");
+}
+
+/// Loop-exit semantics stay intact after the restructure: `break` exits the
+/// driver, and a NESTED loop's own `continue` doesn't touch the outer
+/// driver's advance. (Whether `break` also runs IteratorClose — the source
+/// generator's `finally` — is a separate, pre-existing gap on the
+/// recognized-generator-call path: the abrupt-close rewrite is only applied
+/// for node-stream-like sources. Unchanged by this fix, so not asserted.)
+#[test]
+fn break_and_nested_continue_still_behave() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+async function* src(): any { yield 1; yield 2; yield 3; yield 4; }
+(async () => {
+  const out: number[] = [];
+  for await (const n of src()) {
+    for (const k of [10, 20]) {
+      if (k === 10) continue; // inner continue must not touch the outer driver
+      out.push(n * k);
+    }
+    if (n === 3) break;
+  }
+  console.log(JSON.stringify(out));
+})();
+"#,
+    );
+    assert_eq!(stdout, "[20,40,60]\n");
+}


### PR DESCRIPTION
## Problem

Every iterator-driver desugar that modeled `for await (x of src)` as

```
let __result = await __iter.next();
while (!__result.done) {
    <bind x>; <user body>;
    __result = await __iter.next();   // advance at the body TAIL
}
```

broke `continue`: it jumps to the `while` condition, **skips the tail advance**, and re-processes the same result forever — an infinite spin observed as a hang. Six copies of the shape existed (`lower/stmt_loops.rs` ×3: generic for-await, recognized-generator-call, Web-ReadableStream reader; `lower_decl/body_stmt.rs` ×2; `lower_decl/body_stmt/for_await.rs` ×1).

The array/lazy sync path (`lazy_iter_for_stmt`) already **documents this exact footgun** — *"a `while` with the advance at the body tail would skip it on `continue` and spin"* — and dodges it with `Stmt::For`'s update clause, which the await-capable drivers can't use (no `await` in a `for` update).

Ten-line repro (hangs pre-fix, node prints both values + done):

```ts
async function* events() { yield "a"; yield "ping"; yield "b"; }
async function* filtered() {
  for await (const w of events()) {
    if (w === "ping") continue;   // ← spins forever on the same result
    yield w;
  }
}
for await (const x of filtered()) console.log(x);
```

Canonical real-world failure: an SSE consumer's `for await (const ev of stream) { if (ev.event === "ping") continue; … }` — a large esbuild-bundled CLI app hung on the **first real server ping event**. Local mocks that never sent pings masked it completely; `ping` is the only SSE event the client skips via `continue`.

## Fix

All six drivers now advance at the TOP:

```
let __result = undefined;
while (true) {
    __result = await __iter.next();
    if (__result.done) break;
    <bind x>; <user body>;
}
```

`continue` falls to the `while (true)` condition and re-runs the advance. `break`/`return`/`throw` behavior is unchanged — the synthetic `if done break` is appended after the abrupt-close rewrite over the user body, so normal completion never runs a spurious IteratorClose. The three `stmt_loops.rs` sites share a new `iter_driver_while_stmt` helper; the `body_stmt` copies mirror it.

## Tests

New `crates/perry/tests/for_await_continue.rs` (5 tests, node-oracle-verified, 30s hang guard since pre-fix they spin forever):
- `continue` inside for-await in an async generator (the SSE shape)
- in a plain async fn
- over a custom `[Symbol.asyncIterator]` iterable (runtime GetAsyncIterator driver)
- over a Web ReadableStream (getReader()/read() driver)
- break + nested-loop-continue behavior guard

(The pre-existing `c262_parity::logical_property_assignment_short_circuits_the_store_4586` failure reproduces identically on pristine main — unrelated.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `for await` and iterator-based loop handling so `continue` now advances to the next item correctly instead of reusing the same completed result.
  * Fixed async loops over generators, custom async iterators, and readable streams to avoid hangs and infinite spinning.
  * Preserved correct behavior for `break` and nested-loop `continue` cases.

* **Tests**
  * Added regression coverage for `for await` loops to verify correct output and prevent future loop-control regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->