### PR TITLE
feat(gc): always-on pause ring (max + 32-sample window) via js_gc_pause_stats

### DIFF
--- a/crates/perry-runtime/src/gc/cycle.rs
+++ b/crates/perry-runtime/src/gc/cycle.rs
@@ -1570,10 +1570,9 @@ impl GcCycleState {
     fn publish_reclaim_outcome(&mut self) {
         let elapsed_us = self.active_elapsed_us();
         GC_STATS.with(|stats| {
-            let mut stats = stats.borrow_mut();
-            stats.collection_count += 1;
-            stats.total_freed_bytes = stats.total_freed_bytes.saturating_add(self.freed_bytes);
-            stats.last_pause_us = elapsed_us;
+            stats
+                .borrow_mut()
+                .record_collection(self.freed_bytes, elapsed_us);
         });
 
         if let Some(minor) = self.minor.as_ref() {

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -134,10 +134,9 @@ pub(super) fn gc_collect_minor_with_trigger(trigger: GcTriggerSnapshot) -> GcCol
         let freed_bytes = fast_path.freed_bytes;
         let elapsed_us = start.elapsed().as_micros() as u64;
         GC_STATS.with(|stats| {
-            let mut stats = stats.borrow_mut();
-            stats.collection_count += 1;
-            stats.total_freed_bytes += freed_bytes;
-            stats.last_pause_us = elapsed_us;
+            stats
+                .borrow_mut()
+                .record_collection(freed_bytes, elapsed_us);
         });
         restore_minor_in_alloc(prev_in_alloc);
         if let Some(trace) = trace.as_mut() {
@@ -523,6 +522,44 @@ pub extern "C" fn js_gc_stats(
             }
             if !out_pause_us.is_null() {
                 *out_pause_us = stats.last_pause_us;
+            }
+        }
+    });
+}
+
+/// FFI: always-on pause observability (#6187, 2026-07-09 audit). Fills the
+/// max pause since thread start, the max and mean over the recent-pause
+/// ring (`GC_RECENT_PAUSE_WINDOW` samples), and how many samples the ring
+/// currently holds. Cheap enough for a UI frame scheduler to poll per tick.
+#[no_mangle]
+pub extern "C" fn js_gc_pause_stats(
+    out_max_us: *mut u64,
+    out_recent_max_us: *mut u64,
+    out_recent_avg_us: *mut u64,
+    out_recent_count: *mut u64,
+) {
+    GC_STATS.with(|stats| {
+        let stats = stats.borrow();
+        let n = stats.recent_len as usize;
+        let window = &stats.recent_pauses_us[..n.min(GC_RECENT_PAUSE_WINDOW)];
+        let recent_max = window.iter().copied().max().unwrap_or(0);
+        let recent_avg = if window.is_empty() {
+            0
+        } else {
+            window.iter().copied().sum::<u64>() / window.len() as u64
+        };
+        unsafe {
+            if !out_max_us.is_null() {
+                *out_max_us = stats.max_pause_us;
+            }
+            if !out_recent_max_us.is_null() {
+                *out_recent_max_us = recent_max;
+            }
+            if !out_recent_avg_us.is_null() {
+                *out_recent_avg_us = recent_avg;
+            }
+            if !out_recent_count.is_null() {
+                *out_recent_count = n as u64;
             }
         }
     });

--- a/crates/perry-runtime/src/gc/telemetry.rs
+++ b/crates/perry-runtime/src/gc/telemetry.rs
@@ -1,9 +1,40 @@
 use super::*;
 
+/// Number of most-recent pause samples retained per thread (#6187).
+pub const GC_RECENT_PAUSE_WINDOW: usize = 32;
+
 pub struct GcStats {
     pub collection_count: u64,
     pub total_freed_bytes: u64,
     pub last_pause_us: u64,
+    /// 2026-07-09 audit (#6187): always-on pause observability. A frame
+    /// scheduler or an ops dashboard needs more than the last sample; the
+    /// max-since-start plus a small ring of recent pauses costs a few
+    /// stores per collection and a few hundred bytes of TLS. The rich
+    /// per-phase traces stay behind PERRY_GC_TRACE.
+    pub max_pause_us: u64,
+    pub recent_pauses_us: [u64; GC_RECENT_PAUSE_WINDOW],
+    pub recent_cursor: u8,
+    pub recent_len: u8,
+}
+
+impl GcStats {
+    /// Single funnel for per-collection accounting: last/max pause and the
+    /// recent-pause ring advance together with the counters, so no future
+    /// collection path can update one without the others.
+    pub(super) fn record_collection(&mut self, freed_bytes: u64, elapsed_us: u64) {
+        self.collection_count += 1;
+        self.total_freed_bytes = self.total_freed_bytes.saturating_add(freed_bytes);
+        self.last_pause_us = elapsed_us;
+        if elapsed_us > self.max_pause_us {
+            self.max_pause_us = elapsed_us;
+        }
+        self.recent_pauses_us[self.recent_cursor as usize] = elapsed_us;
+        self.recent_cursor = ((self.recent_cursor as usize + 1) % GC_RECENT_PAUSE_WINDOW) as u8;
+        if (self.recent_len as usize) < GC_RECENT_PAUSE_WINDOW {
+            self.recent_len += 1;
+        }
+    }
 }
 
 thread_local! {
@@ -11,6 +42,10 @@ thread_local! {
         collection_count: 0,
         total_freed_bytes: 0,
         last_pause_us: 0,
+        max_pause_us: 0,
+        recent_pauses_us: [0; GC_RECENT_PAUSE_WINDOW],
+        recent_cursor: 0,
+        recent_len: 0,
     }) };
 }
 

--- a/crates/perry-runtime/src/gc/tests/telemetry_verifier.rs
+++ b/crates/perry-runtime/src/gc/tests/telemetry_verifier.rs
@@ -331,3 +331,38 @@ fn verifier_rejects_over_budget_ordinary_step() {
         "synthetic over-budget ordinary step should fail verifier"
     );
 }
+
+// #6187: the always-on pause ring must track last/max/window coherently.
+#[test]
+fn test_pause_ring_records_max_and_window() {
+    GC_STATS.with(|stats| {
+        let mut stats = stats.borrow_mut();
+        let baseline_count = stats.collection_count;
+        stats.record_collection(10, 100);
+        stats.record_collection(0, 900);
+        stats.record_collection(5, 300);
+        assert_eq!(stats.collection_count, baseline_count + 3);
+        assert_eq!(stats.last_pause_us, 300);
+        assert!(stats.max_pause_us >= 900);
+        assert!(stats.recent_len >= 3);
+    });
+    // Overflow the ring: cursor wraps, len saturates at the window size.
+    GC_STATS.with(|stats| {
+        let mut stats = stats.borrow_mut();
+        for i in 0..(GC_RECENT_PAUSE_WINDOW as u64 + 5) {
+            stats.record_collection(0, i + 1);
+        }
+        assert_eq!(stats.recent_len as usize, GC_RECENT_PAUSE_WINDOW);
+        assert!((stats.recent_cursor as usize) < GC_RECENT_PAUSE_WINDOW);
+        assert_eq!(stats.last_pause_us, GC_RECENT_PAUSE_WINDOW as u64 + 5);
+    });
+    let mut max_us = 0u64;
+    let mut recent_max = 0u64;
+    let mut recent_avg = 0u64;
+    let mut count = 0u64;
+    js_gc_pause_stats(&mut max_us, &mut recent_max, &mut recent_avg, &mut count);
+    assert_eq!(count as usize, GC_RECENT_PAUSE_WINDOW);
+    assert!(max_us >= 900);
+    assert!(recent_max >= GC_RECENT_PAUSE_WINDOW as u64);
+    assert!(recent_avg > 0 && recent_avg <= recent_max);
+}


### PR DESCRIPTION
Implements #6187 (Wave 3 of the 2026-07-09 GC audit, `fable-audit-perry-gc.md`).

The only always-on pause signal was a single `last_pause_us` — no max, no window, nothing a frame scheduler or ops dashboard could consume, and pause regressions were invisible in production (the rich per-phase traces exist only under `PERRY_GC_TRACE`).

`GcStats` now funnels per-collection accounting through one `record_collection` method (count/freed/last/max/ring advance together, so no future collection path can update one without the others), keeping a 32-sample recent-pause ring plus max-since-start per thread — a few stores per collection and a few hundred bytes of TLS. New FFI `js_gc_pause_stats(out_max, out_recent_max, out_recent_avg, out_recent_count)` next to `js_gc_stats`, cheap enough for a UI pump to poll per tick (the #6183 wiring consumes it).

Both write sites converted (copying fast path in `gc/mod.rs`, cycle completion in `gc/cycle.rs`). Ring/overflow/FFI unit test added. Full suite serial: 1174 passed / 0 failed; fmt clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GC pause-time statistics, including maximum pause, recent-window max/average, and sample count.
  * Exposed a new API to retrieve these pause metrics for observability.

* **Bug Fixes**
  * Improved GC telemetry tracking so collection and pause stats are updated consistently.
  * Added coverage for pause-history behavior when the recent window fills and wraps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->