### PR TITLE
feat(ui): bounded GC idle budget at the macOS pump boundary

### DIFF
--- a/crates/perry-ui-macos/src/app.rs
+++ b/crates/perry-ui-macos/src/app.rs
@@ -1281,7 +1281,14 @@ define_class!(
         #[unsafe(method(pump:))]
         fn pump(&self, _sender: &AnyObject) {
             crate::catch_callback_panic("pump", std::panic::AssertUnwindSafe(|| {
-                extern "C" { fn js_run_stdlib_pump(); }
+                extern "C" {
+                    fn js_run_stdlib_pump();
+                    // perry-runtime's embedder GC stepper: spends up to
+                    // `budget_us` advancing an ACTIVE budgeted collection
+                    // in bounded work units; a cheap status probe when no
+                    // cycle is active (out=null is allowed).
+                    fn js_gc_step_us(budget_us: u64, out: *mut u8) -> u32;
+                }
                 unsafe {
                     js_callback_timer_tick();
                     js_interval_timer_tick();
@@ -1293,6 +1300,14 @@ define_class!(
                     // Process deferred promise resolutions from perry-stdlib tokio workers.
                     // No-op if perry-stdlib is not linked (function pointer not registered).
                     js_run_stdlib_pump();
+                    // #6183 (2026-07-09 GC audit): spend a bounded idle
+                    // budget on any active budgeted GC cycle at the pump
+                    // boundary — the JS stack is fully unwound here, so
+                    // this is a precise-root safepoint. 2 ms of the ~8 ms
+                    // tick drains collection debt in slices instead of
+                    // letting an alloc-point collection land unbounded on
+                    // this (main/UI) thread mid-gesture.
+                    js_gc_step_us(2_000, std::ptr::null_mut());
                     #[cfg(feature = "geisterhand")]
                     {
                         extern "C" { fn perry_geisterhand_pump(); }


### PR DESCRIPTION
First slice of #6183 (Wave 3 of the 2026-07-09 GC audit, `fable-audit-perry-gc.md`).

The macOS UI host drives JS via an ~8 ms main-thread NSTimer pump — the outermost precise-root safepoint — but nothing advanced budgeted GC cycles there, so collection debt eventually landed as a single unbounded alloc-point pause mid-gesture (hundreds of ms on large heaps).

The pump tail now spends up to 2 ms per tick in `js_gc_step_us` (perry-runtime's existing embedder stepper: bounded work units while a budgeted cycle is ACTIVE, a cheap status probe otherwise, null out-param supported). Combined with #6197's `js_gc_pause_stats`, an embedder can observe whether the budget is keeping up.

Remaining #6183 scope (follow-ups): CADisplayLink-aligned budgets on macOS, and the iOS/tvOS/watchOS host pumps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app responsiveness by spreading garbage collection work across UI pump cycles.
  * Reduced the chance of noticeable pauses during normal operation by limiting GC work to short time slices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->