### PR TITLE
fix(hir): `typeof` on an uninitialized lexical binding throws ReferenceError (#6062)

### DIFF
--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -117,6 +117,8 @@ impl LoweringContext {
             with_env_stack: Vec::new(),
             var_hoisted_ids: HashSet::new(),
             tdz_forward_ids: HashSet::new(),
+            forward_lexical_names: HashSet::new(),
+            forward_lexical_saves: Vec::new(),
             catch_param_scopes: Vec::new(),
             annexb_block_fn_var_ids: HashMap::new(),
             annexb_block_fn_names_all: HashSet::new(),
@@ -1516,6 +1518,13 @@ impl LoweringContext {
 
     pub(crate) fn enter_scope(&mut self) -> (usize, usize, usize) {
         // Function/closure boundary: new locals are no longer module-level.
+        // #6062: a `typeof <name>` inside a nested closure is runtime-timing-
+        // dependent (the closure may run before OR after the outer lexical is
+        // initialized), so the enclosing block's forward-lexical set must not
+        // statically force a throw inside it. Save and clear across the
+        // boundary; the nested body repopulates its own via `lower_stmts_using_aware`.
+        self.forward_lexical_saves
+            .push(std::mem::take(&mut self.forward_lexical_names));
         let local_mark = self.locals.len();
         self.scope_depth += 1;
         self.scope_local_marks.push(local_mark);
@@ -1532,6 +1541,9 @@ impl LoweringContext {
 
     pub(crate) fn exit_scope(&mut self, mark: (usize, usize, usize)) {
         debug_assert!(self.scope_depth > 0, "exit_scope called at module depth");
+        // #6062: restore the enclosing block's forward-lexical set saved in the
+        // matching `enter_scope`.
+        self.forward_lexical_names = self.forward_lexical_saves.pop().unwrap_or_default();
         self.scope_depth = self.scope_depth.saturating_sub(1);
         // Drop any pre-scan param protections registered in a scope deeper than
         // the one we just returned to — their expected consumer (the callback's

--- a/crates/perry-hir/src/lower/lower_expr/arm_unary.rs
+++ b/crates/perry-hir/src/lower/lower_expr/arm_unary.rs
@@ -133,6 +133,27 @@ pub(crate) fn lower_unary_expr(ctx: &mut LoweringContext, unary: &ast::UnaryExpr
                 && !is_known_global_identifier_name(n)
                 && !matches!(n, "undefined" | "null" | "NaN" | "Infinity")
             {
+                // #6062: a forward-referenced lexical (`let`/`const`/`class`
+                // declared LATER in this or an enclosing same-function block) is
+                // not yet a live local, so it reaches this "unresolvable" arm —
+                // but per ECMA-262 `typeof` only skips GetValue for genuinely
+                // UNRESOLVABLE references (undeclared globals). A declared-but-
+                // uninitialized binding in its TDZ must throw ReferenceError,
+                // exactly like a plain read. Route it to the throwing get. (A
+                // `typeof` AFTER the declarator resolves via `lookup_local` and
+                // never reaches here.)
+                if ctx.forward_lexical_names.contains(n) {
+                    return Ok(Expr::TypeOf(Box::new(Expr::Call {
+                        callee: Box::new(Expr::ExternFuncRef {
+                            name: "js_global_get_or_throw_unresolved".to_string(),
+                            param_types: vec![Type::Any],
+                            return_type: Type::Any,
+                        }),
+                        args: vec![Expr::String(n.to_string())],
+                        type_args: Vec::new(),
+                        byte_offset: id.span.lo.0,
+                    })));
+                }
                 // Not foldable to a compile-time "undefined": sloppy
                 // implicit globals are runtime globalThis properties
                 // (#3575), so `g = 5; typeof g` must observe the live

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -400,6 +400,23 @@ pub struct LoweringContext {
     /// (non-var) bindings. Populated by pre_register_forward_captured_lets
     /// and drained when the body's prealloc set is assembled.
     pub(crate) tdz_forward_ids: HashSet<LocalId>,
+    /// Names of lexical `let`/`const`/`class` bindings declared in the current
+    /// (or an enclosing, same-function) block scope that are still resolvable as
+    /// forward references — i.e. a bare read of the name before its declarator
+    /// lowers to a throwing get. Used ONLY by the `typeof` lowering (#6062): a
+    /// `typeof <name>` whose operand isn't yet a live local suppresses the throw
+    /// (spec `GetValue`-skips for unresolvable refs → `"undefined"`), but a
+    /// declared-but-uninitialized lexical in its TDZ must throw. Presence here
+    /// distinguishes a forward lexical (→ throw) from a genuinely undeclared
+    /// global name (→ `"undefined"`). Populated per block by
+    /// `lower_stmts_using_aware` (pre-scan of the block's direct lexical decls)
+    /// and cleared across function boundaries in `enter_scope`/`exit_scope`,
+    /// since a `typeof` inside a nested closure is runtime-timing-dependent and
+    /// must not statically throw. A post-declaration `typeof` never consults this
+    /// — by then the name is a live local and never reaches the suppressing arm.
+    pub(crate) forward_lexical_names: HashSet<String>,
+    /// Function-boundary save stack for `forward_lexical_names` (see above).
+    pub(crate) forward_lexical_saves: Vec<HashSet<String>>,
     /// Names bound by an enclosing `catch (e)` parameter that is currently in
     /// scope (a stack, innermost last). Annex B B.3.4: a `var e = init;` whose
     /// name collides with a live catch parameter assigns to that *catch

--- a/crates/perry-hir/src/lower_decl/block.rs
+++ b/crates/perry-hir/src/lower_decl/block.rs
@@ -1661,7 +1661,60 @@ pub fn lower_block_stmt_scoped(
 /// body throw (or an earlier dispose throw) is followed by another dispose
 /// throw, the later error is wrapped in a `SuppressedError` whose `.suppressed`
 /// is the accumulated completion (spec `DisposeResources`).
+/// #6062: record a block's DIRECT `let`/`const`/`class` declaration names (not
+/// nested blocks — those own their scope) in `ctx.forward_lexical_names`, so a
+/// `typeof <name>` lowered before the declarator throws a TDZ `ReferenceError`
+/// instead of yielding `"undefined"`. Returns the names this call newly
+/// inserted, for removal on block exit (a name already present belongs to an
+/// enclosing scope and must survive this block).
+fn register_block_forward_lexicals(ctx: &mut LoweringContext, stmts: &[ast::Stmt]) -> Vec<String> {
+    let mut names: Vec<String> = Vec::new();
+    for stmt in stmts {
+        match stmt {
+            ast::Stmt::Decl(ast::Decl::Var(var_decl))
+                if matches!(
+                    var_decl.kind,
+                    ast::VarDeclKind::Let | ast::VarDeclKind::Const
+                ) =>
+            {
+                for decl in &var_decl.decls {
+                    let mut idents: Vec<(String, u32)> = Vec::new();
+                    collect_pat_forward_idents(&decl.name, &mut idents);
+                    names.extend(idents.into_iter().map(|(n, _)| n));
+                }
+            }
+            ast::Stmt::Decl(ast::Decl::Class(class_decl)) => {
+                names.push(class_decl.ident.sym.to_string());
+            }
+            _ => {}
+        }
+    }
+    let mut newly = Vec::new();
+    for name in names {
+        if ctx.forward_lexical_names.insert(name.clone()) {
+            newly.push(name);
+        }
+    }
+    newly
+}
+
 pub fn lower_stmts_using_aware(
+    ctx: &mut LoweringContext,
+    stmts: &[ast::Stmt],
+) -> Result<Vec<Stmt>> {
+    // #6062: register this block's forward lexicals before lowering any
+    // statement (so a `typeof z` preceding `const z` sees `z`), then remove
+    // exactly what we added once the block is lowered — via a wrapper so the
+    // cleanup runs on every early return inside the inner lowering.
+    let newly = register_block_forward_lexicals(ctx, stmts);
+    let r = lower_stmts_using_aware_inner(ctx, stmts);
+    for name in &newly {
+        ctx.forward_lexical_names.remove(name);
+    }
+    r
+}
+
+fn lower_stmts_using_aware_inner(
     ctx: &mut LoweringContext,
     stmts: &[ast::Stmt],
 ) -> Result<Vec<Stmt>> {

--- a/crates/perry-hir/src/lower_decl/block.rs
+++ b/crates/perry-hir/src/lower_decl/block.rs
@@ -1686,6 +1686,16 @@ fn register_block_forward_lexicals(ctx: &mut LoweringContext, stmts: &[ast::Stmt
             ast::Stmt::Decl(ast::Decl::Class(class_decl)) => {
                 names.push(class_decl.ident.sym.to_string());
             }
+            // `using` / `await using` are block-scoped bindings with the same
+            // TDZ semantics as `let`/`const` (a read before the declarator
+            // throws), so `typeof <forward using>` must throw too.
+            ast::Stmt::Decl(ast::Decl::Using(using_decl)) => {
+                for decl in &using_decl.decls {
+                    let mut idents: Vec<(String, u32)> = Vec::new();
+                    collect_pat_forward_idents(&decl.name, &mut idents);
+                    names.extend(idents.into_iter().map(|(n, _)| n));
+                }
+            }
             _ => {}
         }
     }


### PR DESCRIPTION
## Summary

`typeof z` where `z` is a `let`/`const`/`class` still in its Temporal Dead Zone returned `"undefined"` instead of throwing.

```ts
try { typeof z; const z = 3; } catch (e) {}   // node: ReferenceError   perry(before): no throw
```

Fixes #6062.

ECMA-262 lets `typeof` skip `GetValue` only for **unresolvable** references (undeclared globals → `"undefined"`); a declared-but-uninitialized lexical is *resolvable* and must throw, exactly as a plain read does.

## Root cause

The `typeof`-operand lowering resolved a forward-referenced lexical — not yet a live local — to the non-throwing `js_global_get_optional` arm, whereas a plain read of the same name lowers to the throwing `js_global_get_or_throw_unresolved`. `lookup_local` can't distinguish a forward lexical (TDZ) from a genuinely undeclared name (both miss), so the operand was wrongly treated as undeclared.

## Fix

Track `let`/`const`/`class` names declared in the current (or an enclosing, same-function) block in `ctx.forward_lexical_names`:
- **Populated** per block by a pre-scan in `lower_stmts_using_aware` (so `typeof z` *preceding* `const z` sees `z`), and removed on block exit — a name already present belongs to an outer scope and survives.
- **Saved/cleared across function boundaries** (`enter_scope`/`exit_scope`): `typeof` inside a nested closure is runtime-timing-dependent (may run before *or* after the outer binding initializes) and must not statically throw.
- In the `typeof` prologue, a forward-lexical operand routes to the throwing get.

No dead-zone position tracking is needed — a `typeof` **after** the declarator resolves via `lookup_local` and never reaches the suppressing arm, so it stays a normal `typeof`.

## Validation

Byte-for-byte vs `node --experimental-strip-types`:

| Case | Result |
|---|---|
| forward `let`/`const`/`class` in block & function bodies | throws ✓ |
| genuinely undeclared name | `"undefined"` ✓ |
| post-declaration read | normal ✓ |
| `var` (function-scoped, not TDZ) forward | `"undefined"` ✓ |
| param / real globals / `typeof x === "undefined"` guard | unchanged ✓ |
| closed sibling-block binding | `"undefined"` ✓ |
| closure reading outer forward lexical | no static throw ✓ |

24 typeof/scope + 30 broad gap tests green; `cargo fmt` clean. HIR-only change (no runtime touched).

Code-only per contributor convention (no version/CHANGELOG bump).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `typeof` on forward-referenced `let`, `const`, and `class` bindings to follow JavaScript temporal dead zone behavior (now throws `ReferenceError` instead of returning a non-throwing result).
  * Prevented forward-lexical state from leaking into nested closures across function boundaries, avoiding incorrect static behavior.
  * Ensured forward reference handling uses the correct source position when reporting errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->