### PR TITLE
feat(gc): js_gc_memory_pressure — OS pressure entry (collect now + clamp trigger)

### DIFF
--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -40,6 +40,8 @@ pub(crate) use policy::gc_runtime_safepoint;
 pub use policy::*;
 mod heap_budget;
 pub use heap_budget::*;
+mod pressure;
+pub use pressure::*;
 mod telemetry;
 pub use telemetry::*;
 mod malloc;

--- a/crates/perry-runtime/src/gc/pressure.rs
+++ b/crates/perry-runtime/src/gc/pressure.rs
@@ -1,0 +1,63 @@
+//! OS memory-pressure entry point (#6184, 2026-07-09 GC audit).
+//!
+//! Platform hosts (UIKit memory warnings, macOS `DISPATCH_SOURCE_TYPE_
+//! MEMORYPRESSURE`, Android `onTrimMemory`, Linux PSI watchers) call
+//! `js_gc_memory_pressure` when the OS signals that this process should
+//! shed memory NOW — typically the last warning before a jetsam/OOM kill.
+//! Before this entry existed, Perry ignored every such signal on every
+//! platform and died holding heaps of collectable garbage.
+//!
+//! Level semantics (loosely mirroring Apple's warn/critical):
+//!   1  = warning : collect if safe; and pull the next arena trigger down
+//!                  so the very next allocation batch collects even when a
+//!                  synchronous collection is not safe right now.
+//!   2+ = critical: same, but the collection is a FULL cycle so old-gen
+//!                  garbage is reclaimed and idle blocks are handed back
+//!                  to the OS (C4b-δ dealloc runs during sweep cleanup).
+//!
+//! The handler typically fires at a run-loop boundary (JS stack unwound),
+//! but the entry defends itself with the same guards the safepoint uses;
+//! when collecting here is unsafe, the lowered trigger still guarantees a
+//! prompt collection at the next allocation-side check.
+
+use super::*;
+
+/// Return codes: 0 = ignored (level 0), 1 = trigger lowered but the
+/// collection was deferred (unsafe point), 2 = collected synchronously.
+#[no_mangle]
+pub extern "C" fn js_gc_memory_pressure(level: u32) -> u32 {
+    if level == 0 {
+        return 0;
+    }
+    // Pull the arena trigger down to "collect at the next check" and arm
+    // it so the un-armed budget ceiling substitution doesn't override the
+    // clamp (see `effective_next_arena_trigger`).
+    let total = crate::arena::arena_total_bytes();
+    GC_NEXT_TRIGGER_BYTES.with(|c| {
+        let clamp = total.saturating_add(1024 * 1024);
+        if c.get() > clamp {
+            c.set(clamp);
+            GC_TRIGGER_ARMED.with(|a| a.set(true));
+        }
+    });
+
+    let blocked = GC_FLAGS.with(|f| f.get()) & (GC_FLAG_IN_ALLOC | GC_FLAG_SUPPRESSED) != 0
+        || gc_blocked_by_unsafe_zone()
+        || GC_ROOT_LOCK_DEPTH.with(|depth| depth.get() != 0)
+        || gc_budgeted_cycle_active();
+    if blocked {
+        return 1;
+    }
+    // Force the conservative scan for the same reason the alloc-point arm
+    // does: a host may deliver the callback with unspilled locals on the
+    // native frames above us.
+    let _scan = roots::ManualGcScanGuard::force_full_scan();
+    if level >= 2 {
+        let _ = gc_collect_full_mark_sweep_with_trigger(GcTriggerSnapshot::capture(
+            GcTriggerKind::Emergency,
+        ));
+    } else {
+        let _ = gc_collect_minor_with_trigger(GcTriggerSnapshot::capture(GcTriggerKind::Direct));
+    }
+    2
+}

--- a/crates/perry-runtime/src/gc/tests/triggers.rs
+++ b/crates/perry-runtime/src/gc/tests/triggers.rs
@@ -274,3 +274,35 @@ fn test_effective_arena_trigger_respects_armed_values() {
     GC_NEXT_TRIGGER_BYTES.with(|c| c.set(prev_trigger));
     GC_TRIGGER_ARMED.with(|c| c.set(prev_armed));
 }
+
+// #6184: the OS memory-pressure entry must run a real collection when the
+// thread is at a safe point, and must lower+arm the arena trigger.
+#[test]
+fn test_memory_pressure_collects_and_clamps_trigger() {
+    let _guard = GcTestIsolationGuard::new();
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    use super::super::policy::{GC_NEXT_TRIGGER_BYTES, GC_TRIGGER_ARMED};
+
+    let prev_trigger = GC_NEXT_TRIGGER_BYTES.with(|c| c.get());
+    let prev_armed = GC_TRIGGER_ARMED.with(|c| c.get());
+    GC_NEXT_TRIGGER_BYTES.with(|c| c.set(usize::MAX / 2));
+    GC_TRIGGER_ARMED.with(|c| c.set(false));
+
+    let count_before = GC_STATS.with(|s| s.borrow().collection_count);
+    let rc = js_gc_memory_pressure(2);
+    assert_eq!(rc, 2, "safe point must collect synchronously");
+    let count_after = GC_STATS.with(|s| s.borrow().collection_count);
+    assert!(count_after > count_before, "critical pressure must collect");
+    assert!(
+        GC_TRIGGER_ARMED.with(|c| c.get()),
+        "pressure must arm the lowered trigger"
+    );
+    assert!(
+        GC_NEXT_TRIGGER_BYTES.with(|c| c.get()) < usize::MAX / 2,
+        "pressure must pull the trigger down"
+    );
+
+    GC_NEXT_TRIGGER_BYTES.with(|c| c.set(prev_trigger));
+    GC_TRIGGER_ARMED.with(|c| c.set(prev_armed));
+    assert_eq!(js_gc_memory_pressure(0), 0);
+}


### PR DESCRIPTION
Runtime half of #6184 (Wave 3 of the 2026-07-09 GC audit, `fable-audit-perry-gc.md`). Builds on #6189's armed-trigger semantics.

Perry ignored every OS memory-pressure signal on every platform — iOS delivers `didReceiveMemoryWarning` before jetsam-killing, Android has `onTrimMemory`, macOS has `DISPATCH_SOURCE_TYPE_MEMORYPRESSURE`, Linux has PSI — and a process holding 100 MB of dead nursery died without ever being asked to collect.

New FFI `js_gc_memory_pressure(level) -> u32`:
- **level 1 (warning):** run a minor collection if the thread is at a safe point (guards mirror the safepoint set; conservative scan forced since host callback frames may hold unspilled locals).
- **level ≥2 (critical):** run a full cycle instead, so old-gen garbage is reclaimed and idle blocks return to the OS via the existing C4b-δ dealloc.
- **Always** (even when delivery lands at an unsafe point): the arena trigger is pulled down to `arena_total + 1 MB` and armed, so a prompt collection is guaranteed at the next allocation-side check. Return code reports ignored/deferred/collected.

Platform wiring (UIKit/AppDelegate templates, macOS dispatch source, Android bridge) remains in #6184 — the macOS piece will stack on #6198's pump changes.

Tests: safe-point critical pressure runs a real collection, arms + lowers the trigger; level 0 is a no-op. Full suite serial: 1181 passed / 0 failed; fmt clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for responding to system memory pressure, with the runtime able to adjust garbage collection behavior and trigger a collection when needed.
  * Exposed a new low-level entry point for memory-pressure signals.

* **Tests**
  * Added coverage to verify memory-pressure handling, including trigger clamping and synchronous collection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->