### PR TITLE
fix(runtime): instanceof walks real [[Prototype]] chain for reassigned prototypes

### DIFF
--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -343,7 +343,21 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
         }
         let class_id = global_builtin_constructor_class_id(name);
         if class_id != 0 {
-            return js_instanceof(value, class_id);
+            let r = js_instanceof(value, class_id);
+            if r.to_bits() == crate::value::TAG_TRUE {
+                return r;
+            }
+            // #5989: an object that inherits a builtin's prototype via
+            // `Fn.prototype = Object.create(Builtin.prototype)` is `instanceof
+            // Builtin` per the spec even though it carries no builtin class id —
+            // react-server-dom's flight Chunk inherits `Promise.prototype` this
+            // way, so `chunk instanceof Promise` must be true. Walk the real
+            // [[Prototype]] chain against `Builtin.prototype` before answering
+            // false.
+            if ordinary_has_instance_prototype_walk(value, type_ref) {
+                return f64::from_bits(crate::value::TAG_TRUE);
+            }
+            return f64::from_bits(TAG_FALSE);
         }
     }
     if crate::node_submodules::is_diagnostics_channel_constructor_value(type_ref) {
@@ -450,7 +464,22 @@ fn js_instanceof_dynamic_tail(value: f64, type_ref: f64) -> f64 {
     // inside a `new`-invoked body instead of recursing forever (#838 followup).
     let synthetic_cid = synthetic_class_id_for_function(type_ref);
     if synthetic_cid != 0 {
-        return js_instanceof(value, synthetic_cid);
+        let r = js_instanceof(value, synthetic_cid);
+        if r.to_bits() == crate::value::TAG_TRUE {
+            return r;
+        }
+        // #5989: the synthetic class-id chain is stamped at construction and does
+        // NOT reflect a prototype installed later via
+        // `Fn.prototype = Object.create(Base.prototype)` — the classic ES5
+        // inheritance idiom react-server-dom's flight Chunk uses to inherit
+        // `Promise.prototype` (so `chunk instanceof Promise` wrongly returned
+        // false). Fall back to the spec `OrdinaryHasInstance` prototype-chain
+        // walk: Perry already walks the real chain for method lookup and
+        // `getPrototypeOf`, so only this id-based shortcut missed it.
+        if ordinary_has_instance_prototype_walk(value, type_ref) {
+            return f64::from_bits(crate::value::TAG_TRUE);
+        }
+        return f64::from_bits(TAG_FALSE);
     }
     // #2909: nothing recognized the RHS as a constructor/class. Per the
     // ECMAScript `InstanceofOperator`, the right operand must be an object
@@ -471,6 +500,62 @@ fn js_instanceof_dynamic_tail(value: f64, type_ref: f64) -> f64 {
         return f64::from_bits(TAG_FALSE);
     }
     throw_invalid_instanceof_rhs(type_ref)
+}
+
+/// Spec `OrdinaryHasInstance(C, O)` prototype-chain walk (ECMA-262 7.3.20 steps
+/// 4-7): `P = Get(C, "prototype")`; walk `O`'s `[[Prototype]]` chain and return
+/// `true` iff some link is identical to `P`. Used as a fallback for the
+/// synthetic class-id shortcut, which is stamped at construction and misses a
+/// prototype installed via `Fn.prototype = Object.create(Base.prototype)`.
+fn ordinary_has_instance_prototype_walk(value: f64, type_ref: f64) -> bool {
+    extern "C" {
+        fn js_object_get_prototype_of(obj_value: f64) -> f64;
+    }
+    // P = type_ref.prototype (the constructor's `.prototype` data property).
+    let proto = unsafe {
+        crate::value::js_dynamic_object_get_property(
+            type_ref,
+            b"prototype".as_ptr() as *const i8,
+            9,
+        )
+    };
+    let target = proto_identity_addr(proto);
+    if target == 0 {
+        return false; // non-object `.prototype` can never be on the chain
+    }
+    // Walk `value`'s real [[Prototype]] chain looking for identity with P.
+    let mut cur = unsafe { js_object_get_prototype_of(value) };
+    let mut depth = 0usize;
+    while depth < 100_000 {
+        if crate::value::JSValue::from_bits(cur.to_bits()).is_null() {
+            return false;
+        }
+        let cur_addr = proto_identity_addr(cur);
+        if cur_addr == 0 {
+            return false;
+        }
+        if cur_addr == target {
+            return true;
+        }
+        cur = unsafe { js_object_get_prototype_of(cur) };
+        depth += 1;
+    }
+    false
+}
+
+/// Normalize a value to its heap-pointer address for prototype identity
+/// comparison — a NaN-boxed `POINTER_TAG` value or a raw heap pointer both
+/// resolve to their address; any non-pointer yields 0.
+fn proto_identity_addr(v: f64) -> usize {
+    let bits = v.to_bits();
+    let top16 = bits >> 48;
+    if top16 == 0x7FFD {
+        (bits & crate::value::POINTER_MASK) as usize
+    } else if top16 == 0 && bits >= 0x1000 {
+        bits as usize
+    } else {
+        0
+    }
 }
 
 #[cold]

--- a/test-files/test_gap_instanceof_reassigned_prototype.ts
+++ b/test-files/test_gap_instanceof_reassigned_prototype.ts
@@ -1,0 +1,49 @@
+// `instanceof` must walk the REAL [[Prototype]] chain, not a synthetic class-id
+// chain stamped at construction. The ES5 inheritance idiom
+// `Derived.prototype = Object.create(Base.prototype)` installs the chain AFTER
+// the constructor is defined, so the class-id shortcut never learned the
+// `Derived -> Base` edge and `new Derived() instanceof Base` wrongly returned
+// false. react-server-dom's flight Chunk inherits `Promise.prototype` exactly
+// this way (`Chunk.prototype = Object.create(Promise.prototype)`), so this
+// pattern shows up in real Next.js SSR.
+//
+// Perry already walks the real chain for method lookup + `getPrototypeOf`; only
+// the `instanceof` operator took the id-based shortcut. The fix adds a spec
+// `OrdinaryHasInstance` prototype-walk fallback.
+//
+// Validated byte-for-byte against `node --experimental-strip-types`.
+
+function Base(this: any) {}
+(Base as any).prototype.hi = function () { return "hi"; };
+
+// (1) two-level chain with the common `constructor` fix-up idiom
+function Derived(this: any) {}
+(Derived as any).prototype = Object.create((Base as any).prototype);
+(Derived as any).prototype.constructor = Derived;
+const d: any = new (Derived as any)();
+console.log(d instanceof Derived, d instanceof Base, d.hi());
+
+// (2) two-level chain WITHOUT the constructor fix-up (the flight Chunk shape)
+function D2(this: any) {}
+(D2 as any).prototype = Object.create((Base as any).prototype);
+const d2: any = new (D2 as any)();
+console.log(d2 instanceof D2, d2 instanceof Base);
+console.log(Object.getPrototypeOf(d2) === (D2 as any).prototype);
+console.log(Object.getPrototypeOf((D2 as any).prototype) === (Base as any).prototype);
+console.log(d2.hi());
+
+// (3) three-level chain: Grand -> Mid -> Leaf, all via reassigned prototypes
+function Grand(this: any) {}
+(Grand as any).prototype.g = function () { return "g"; };
+function Mid(this: any) {}
+(Mid as any).prototype = Object.create((Grand as any).prototype);
+function Leaf(this: any) {}
+(Leaf as any).prototype = Object.create((Mid as any).prototype);
+const leaf: any = new (Leaf as any)();
+console.log(leaf instanceof Leaf, leaf instanceof Mid, leaf instanceof Grand);
+console.log(leaf.g());
+
+// (4) unrelated types must still be false (no over-matching from the fallback)
+function Other(this: any) {}
+const o: any = new (Other as any)();
+console.log(o instanceof Base, d instanceof Other, leaf instanceof Other);


### PR DESCRIPTION
## Problem

`x instanceof C` returned `false` when `C`'s prototype was installed via the
classic ES5 idiom `C.prototype = Object.create(Base.prototype)` and the check was
against a grandparent (`x instanceof Base`). Perry resolved a plain-function or
built-in RHS to a **synthetic class-id chain** that is stamped at *construction* —
it never learned the `C → Base` edge added by the later `.prototype` reassignment.

The real prototype chain was correct all along: `Object.getPrototypeOf`, method
inheritance, and `x.prop` lookups all walk it. Only the `instanceof` operator took
the stale id-based shortcut, so e.g.:

```js
function D(){}
D.prototype = Object.create(Base.prototype);
new D() instanceof Base   // false in Perry, true in Node
```

This shows up in real Next.js App Router SSR: react-server-dom's flight `Chunk`
inherits `Promise.prototype` via `Chunk.prototype = Object.create(Promise.prototype)`,
so `chunk instanceof Promise` was wrongly `false`.

## Fix

Add a spec `OrdinaryHasInstance` (ECMA-262 7.3.20 steps 4–7) prototype-chain-walk
fallback in `js_instanceof_dynamic`: when the synthetic class-id shortcut returns
`false` for a function / identified-builtin RHS, walk the value's real
`[[Prototype]]` chain and return `true` iff some link is identical to
`C.prototype`. The walk only runs on the otherwise-`false` path, so `true`
answers stay on the existing fast path.

## Validation

- New gap test `test_gap_instanceof_reassigned_prototype.ts` — byte-for-byte
  against `node --experimental-strip-types` (two-level chains with and without the
  `constructor` fix-up, a three-level chain, and negative/unrelated cases).
- Regression sweep of 19 `instanceof` checks across user classes, ES5 function
  constructors, and built-ins (`Array`/`Map`/`Set`/`Promise`/`Error`/`Object`) —
  no false positives.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `instanceof` behavior for objects whose constructors use reassigned or inherited prototypes.
  * Fixed cases where `instanceof` could incorrectly return `false` for valid prototype-chain relationships.
  * Preserved correct `false` results for unrelated constructors.
* **Tests**
  * Added coverage for multi-level prototype chains and runtime prototype reassignment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->