### PR TITLE
fix(streams): ReadableStream.tee() lazily pulls the shared source

### DIFF
--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -273,7 +273,19 @@ lazy_static::lazy_static! {
     // the runtime's finite-number stream probes still route dynamic calls like
     // `src.pipeThrough(ts).getReader()`.
     static ref NEXT_STREAM_ID: Mutex<usize> = Mutex::new(STREAM_HANDLE_ID_START);
+    // #5989 `readable.tee()`: a tee'd source stream stays live and is driven
+    // lazily by reads on its two branches (Web Streams `ReadableStreamTee`).
+    // `TEE_SOURCE_BRANCHES` maps a source id -> its two branch ids (so the
+    // source's enqueue/close/error fan out to both branches); `TEE_BRANCH_SOURCE`
+    // maps each branch id -> its source (so a branch read pulls the source).
+    static ref TEE_SOURCE_BRANCHES: Mutex<HashMap<usize, (usize, usize)>> = Mutex::new(HashMap::new());
+    static ref TEE_BRANCH_SOURCE: Mutex<HashMap<usize, usize>> = Mutex::new(HashMap::new());
 }
+
+/// Sentinel `reader_handle` stamped on a tee'd source so it can't be read
+/// directly (spec: `tee()` acquires a reader on the source). It is never a real
+/// entry in `READERS`, so reader lookups against it resolve to `None`.
+const TEE_LOCK_SENTINEL: usize = usize::MAX;
 
 static GC_REGISTERED: std::sync::Once = std::sync::Once::new();
 
@@ -696,6 +708,13 @@ extern "C" fn readable_pull_microtask(closure: *const ClosureHeader) -> f64 {
 }
 
 pub(super) unsafe fn maybe_pull(stream_id: usize) {
+    // #5989: a read on a tee branch pulls its SOURCE — the branch carries no
+    // `pull_cb` of its own; the source's enqueue fans the chunk out to both
+    // branches. `force` so a highWaterMark-0 flight producer actually pulls.
+    if let Some(source) = tee_source_of(stream_id) {
+        maybe_pull_force(source);
+        return;
+    }
     maybe_pull_inner(stream_id, false);
 }
 
@@ -949,6 +968,13 @@ pub unsafe extern "C" fn js_readable_stream_get_reader_with_options(
     stream_handle: f64,
     options: f64,
 ) -> f64 {
+    if std::env::var("PERRY_JSON_PATH").as_deref() == Ok("1") {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static N: AtomicUsize = AtomicUsize::new(0);
+        if N.fetch_add(1, Ordering::Relaxed) < 40 {
+            eprintln!("[STREAM] get_reader stream={:#x}", stream_handle.to_bits());
+        }
+    }
     let stream_handle = js_stream_unwrap_handle(stream_handle);
     let byob_requested = option_string_equals(options, b"mode", b"byob");
     let id = stream_handle as usize;
@@ -1472,6 +1498,17 @@ pub unsafe extern "C" fn js_readable_stream_controller_enqueue(
     stream_handle: f64,
     chunk: f64,
 ) -> f64 {
+    if std::env::var("PERRY_JSON_PATH").as_deref() == Ok("1") {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static N: AtomicUsize = AtomicUsize::new(0);
+        if N.fetch_add(1, Ordering::Relaxed) < 40 {
+            eprintln!(
+                "[STREAM] enqueue stream={:#x} chunk_bits={:#018x}",
+                (stream_handle as usize),
+                chunk.to_bits()
+            );
+        }
+    }
     let id = stream_handle as usize;
     let chunk_bits = chunk.to_bits();
     let is_byte_stream = {
@@ -1482,6 +1519,13 @@ pub unsafe extern "C" fn js_readable_stream_controller_enqueue(
         throw_invalid_arg_type(
             "The \"buffer\" argument must be an instance of Buffer, TypedArray, or DataView",
         );
+    }
+    // #5989: a tee'd source never queues its own chunks — each enqueue fans out
+    // to BOTH branches (delivering to a parked read or queueing per branch).
+    if let Some((a, b)) = tee_branches_of(id) {
+        tee_deliver(a, chunk_bits, is_byte_stream);
+        tee_deliver(b, chunk_bits, is_byte_stream);
+        return f64::from_bits(TAG_UNDEFINED);
     }
     // A pending BYOB read (byte streams only) takes the chunk before the
     // default-read queue: the bytes land directly in the caller's view.
@@ -1534,6 +1578,27 @@ pub unsafe extern "C" fn js_readable_stream_controller_enqueue(
 #[no_mangle]
 pub unsafe extern "C" fn js_readable_stream_controller_close(stream_handle: f64) -> f64 {
     let id = stream_handle as usize;
+    if std::env::var("PERRY_JSON_PATH").as_deref() == Ok("1") {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static N: AtomicUsize = AtomicUsize::new(0);
+        if N.fetch_add(1, Ordering::Relaxed) < 40 {
+            eprintln!("[STREAM] controller_close stream={id:#x}");
+        }
+    }
+    // #5989: closing a tee'd source closes both branches (each drains its queue
+    // first) rather than the source's own — absent — reader.
+    if tee_branches_of(id).is_some() {
+        {
+            let mut g = READABLE_STREAMS.lock().unwrap();
+            if let Some(s) = g.get_mut(&id) {
+                if s.state == ReadableState::Readable {
+                    s.state = ReadableState::Closed;
+                }
+            }
+        }
+        tee_close_branches(id);
+        return f64::from_bits(TAG_UNDEFINED);
+    }
     {
         let mut g = READABLE_STREAMS.lock().unwrap();
         if let Some(s) = g.get_mut(&id) {
@@ -1569,6 +1634,11 @@ pub unsafe extern "C" fn js_readable_stream_controller_error(
     reason: f64,
 ) -> f64 {
     let id = stream_handle as usize;
+    // #5989: erroring a tee'd source errors both branches.
+    if tee_branches_of(id).is_some() {
+        tee_error_branches(id, reason.to_bits());
+        return f64::from_bits(TAG_UNDEFINED);
+    }
     error_readable_stream(id, reason.to_bits());
     f64::from_bits(TAG_UNDEFINED)
 }
@@ -1610,6 +1680,13 @@ extern "C" fn readable_from_chunk_rejected(closure: *const ClosureHeader, reason
 }
 
 unsafe fn resolve_reader_read_value(promise: *mut Promise, value_bits: u64) {
+    if std::env::var("PERRY_JSON_PATH").as_deref() == Ok("1") {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static N: AtomicUsize = AtomicUsize::new(0);
+        if N.fetch_add(1, Ordering::Relaxed) < 40 {
+            eprintln!("[STREAM] read RESOLVED value_bits={value_bits:#018x}");
+        }
+    }
     let value = f64::from_bits(value_bits);
     if perry_runtime::promise::js_value_is_promise(value) == 0 {
         let result = build_iter_result(value_bits, false);
@@ -1654,6 +1731,13 @@ pub unsafe extern "C" fn js_reader_read(reader_handle: f64) -> *mut Promise {
     let promise = js_promise_new();
     let reader_handle = js_stream_unwrap_handle(reader_handle);
     let reader_id = reader_handle as usize;
+    if std::env::var("PERRY_JSON_PATH").as_deref() == Ok("1") {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static N: AtomicUsize = AtomicUsize::new(0);
+        if N.fetch_add(1, Ordering::Relaxed) < 40 {
+            eprintln!("[STREAM] reader_read reader_id={reader_id:#x}");
+        }
+    }
     let stream_id = match READERS.lock().unwrap().get(&reader_id) {
         Some(r) if r.locked => r.stream_handle,
         Some(_) => {
@@ -1887,18 +1971,119 @@ pub unsafe extern "C" fn js_reader_cancel(reader_handle: f64, reason: f64) -> *m
 /// Streams that lazily produce chunks via `pull` after tee will only see
 /// chunks present at the tee call — the same trade-off Node's
 /// `Readable.from([...]).tee()` makes for already-buffered iterables.
+fn tee_branches_of(source: usize) -> Option<(usize, usize)> {
+    TEE_SOURCE_BRANCHES.lock().unwrap().get(&source).copied()
+}
+
+fn tee_source_of(branch: usize) -> Option<usize> {
+    TEE_BRANCH_SOURCE.lock().unwrap().get(&branch).copied()
+}
+
+/// Deliver one chunk to a single tee branch: hand it to a parked read if one is
+/// waiting, else queue it. Mirrors the default-reader path of
+/// `js_readable_stream_controller_enqueue`.
+unsafe fn tee_deliver(branch: usize, chunk_bits: u64, is_byte: bool) {
+    let popped = {
+        let mut g = READABLE_STREAMS.lock().unwrap();
+        match g.get_mut(&branch) {
+            Some(s) if s.state == ReadableState::Readable => {
+                if let Some(p) = s.pending_reads.pop_front() {
+                    Some(p)
+                } else {
+                    let size = if is_byte {
+                        byob::chunk_byte_length(chunk_bits)
+                    } else {
+                        1.0
+                    };
+                    s.push_chunk(chunk_bits, size);
+                    None
+                }
+            }
+            _ => None,
+        }
+    };
+    if let Some(p) = popped {
+        let result = build_iter_result(chunk_bits, false);
+        js_promise_resolve(p, f64::from_bits(result));
+    }
+}
+
+/// The tee'd source closed — close both branches (each drains its queue first,
+/// per `js_reader_read`'s close-after-last-chunk handling) and drop the links.
+unsafe fn tee_close_branches(source: usize) {
+    let Some((a, b)) = tee_branches_of(source) else {
+        return;
+    };
+    for branch in [a, b] {
+        let queue_empty = {
+            let mut g = READABLE_STREAMS.lock().unwrap();
+            match g.get_mut(&branch) {
+                Some(s) => {
+                    if s.state == ReadableState::Readable {
+                        s.state = ReadableState::Closed;
+                    }
+                    s.chunks.is_empty()
+                }
+                None => true,
+            }
+        };
+        if queue_empty {
+            close_pending(branch);
+        }
+    }
+    tee_unlink(source, a, b);
+}
+
+/// The tee'd source errored — error both branches and drop the links.
+unsafe fn tee_error_branches(source: usize, reason_bits: u64) {
+    let Some((a, b)) = tee_branches_of(source) else {
+        return;
+    };
+    for branch in [a, b] {
+        {
+            let mut g = READABLE_STREAMS.lock().unwrap();
+            if let Some(s) = g.get_mut(&branch) {
+                if s.state == ReadableState::Readable {
+                    s.state = ReadableState::Errored;
+                    s.error_value = reason_bits;
+                }
+            }
+        }
+        error_pending(branch, reason_bits);
+    }
+    tee_unlink(source, a, b);
+}
+
+fn tee_unlink(source: usize, a: usize, b: usize) {
+    TEE_SOURCE_BRANCHES.lock().unwrap().remove(&source);
+    let mut bs = TEE_BRANCH_SOURCE.lock().unwrap();
+    bs.remove(&a);
+    bs.remove(&b);
+}
+
+/// `readable.tee()` — Web Streams `ReadableStreamTee`. The source stays LIVE and
+/// is pulled lazily by reads on the two returned branches: a branch read with an
+/// empty queue pulls the source (`maybe_pull` routes tee-branch pulls to the
+/// source), and each chunk the source enqueues fans out to BOTH branches. The
+/// previous implementation snapshot-drained the source's current buffer and
+/// closed it, which yielded two empty branches for a pull-driven source (e.g.
+/// react-server-dom's RSC flight producer, which only produces on pull) — #5989.
 #[no_mangle]
 pub unsafe extern "C" fn js_readable_stream_tee(stream_handle: f64) -> f64 {
     let id = stream_handle as usize;
     let mut was_locked = false;
     let mut is_byte_stream = false;
-    let chunks: Vec<u64> = {
+    let mut source_state = ReadableState::Readable;
+    let existing: Vec<u64> = {
         let mut g = READABLE_STREAMS.lock().unwrap();
         match g.get_mut(&id) {
             Some(s) if s.reader_handle.is_none() => {
                 is_byte_stream = s.is_byte_stream;
+                source_state = s.state;
                 let drained = s.drain_chunks();
-                s.state = ReadableState::Closed;
+                // Keep the source LIVE — lock it against direct reads but leave
+                // its state + pull_cb intact so branch reads can drive it.
+                s.reader_handle = Some(TEE_LOCK_SENTINEL);
                 drained
             }
             Some(_) => {
@@ -1912,6 +2097,13 @@ pub unsafe extern "C" fn js_readable_stream_tee(stream_handle: f64) -> f64 {
         throw_type_error("ReadableStream is locked");
     }
 
+    // A branch mirrors the source's terminal state; a live source yields live
+    // branches whose future chunks arrive by fan-out.
+    let branch_state = match source_state {
+        ReadableState::Errored => ReadableState::Errored,
+        ReadableState::Closed => ReadableState::Closed,
+        _ => ReadableState::Readable,
+    };
     let id_a = next_id(&NEXT_STREAM_ID);
     let id_b = next_id(&NEXT_STREAM_ID);
     {
@@ -1920,16 +2112,19 @@ pub unsafe extern "C" fn js_readable_stream_tee(stream_handle: f64) -> f64 {
             g.insert(
                 new_id,
                 ReadableStreamData {
-                    state: ReadableState::Closed,
-                    chunks: chunks.iter().copied().collect(),
-                    chunk_sizes: chunks.iter().map(|_| 1.0).collect(),
-                    queue_total_size: chunks.len() as f64,
+                    state: branch_state,
+                    chunks: existing.iter().copied().collect(),
+                    chunk_sizes: existing.iter().map(|_| 1.0).collect(),
+                    queue_total_size: existing.len() as f64,
                     pending_reads: VecDeque::new(),
                     start_cb: 0,
+                    // No own pull_cb: a branch read pulls the SOURCE via the tee
+                    // link (see `maybe_pull`). highWaterMark 0 so every read that
+                    // finds an empty queue triggers a source pull.
                     pull_cb: 0,
                     cancel_cb: 0,
                     strategy_size_cb: 0,
-                    high_water_mark: 1.0,
+                    high_water_mark: 0.0,
                     is_byte_stream,
                     pull_returns_byte_chunk: false,
                     pulling: false,
@@ -1941,6 +2136,14 @@ pub unsafe extern "C" fn js_readable_stream_tee(stream_handle: f64) -> f64 {
                 },
             );
         }
+    }
+    // Only a still-producible source needs live links; a terminal source's
+    // branches already carry its final state + any drained chunks.
+    if branch_state == ReadableState::Readable {
+        TEE_SOURCE_BRANCHES.lock().unwrap().insert(id, (id_a, id_b));
+        let mut bs = TEE_BRANCH_SOURCE.lock().unwrap();
+        bs.insert(id_a, id);
+        bs.insert(id_b, id);
     }
 
     let arr = js_array_alloc(2);

--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -51,10 +51,14 @@ mod expando;
 mod pipe;
 mod strategy;
 mod subclass;
+mod tee;
 #[cfg(test)]
 mod tests;
 mod transform;
 mod writable;
+
+pub use tee::js_readable_stream_tee;
+use tee::{tee_branches_of, tee_close_branches, tee_deliver, tee_error_branches, tee_source_of};
 
 pub use self::byob::{
     js_readable_stream_controller_byob_request, js_readable_stream_get_byob_reader,
@@ -273,19 +277,7 @@ lazy_static::lazy_static! {
     // the runtime's finite-number stream probes still route dynamic calls like
     // `src.pipeThrough(ts).getReader()`.
     static ref NEXT_STREAM_ID: Mutex<usize> = Mutex::new(STREAM_HANDLE_ID_START);
-    // #5989 `readable.tee()`: a tee'd source stream stays live and is driven
-    // lazily by reads on its two branches (Web Streams `ReadableStreamTee`).
-    // `TEE_SOURCE_BRANCHES` maps a source id -> its two branch ids (so the
-    // source's enqueue/close/error fan out to both branches); `TEE_BRANCH_SOURCE`
-    // maps each branch id -> its source (so a branch read pulls the source).
-    static ref TEE_SOURCE_BRANCHES: Mutex<HashMap<usize, (usize, usize)>> = Mutex::new(HashMap::new());
-    static ref TEE_BRANCH_SOURCE: Mutex<HashMap<usize, usize>> = Mutex::new(HashMap::new());
 }
-
-/// Sentinel `reader_handle` stamped on a tee'd source so it can't be read
-/// directly (spec: `tee()` acquires a reader on the source). It is never a real
-/// entry in `READERS`, so reader lookups against it resolve to `None`.
-const TEE_LOCK_SENTINEL: usize = usize::MAX;
 
 static GC_REGISTERED: std::sync::Once = std::sync::Once::new();
 
@@ -1962,195 +1954,6 @@ pub unsafe extern "C" fn js_reader_cancel(reader_handle: f64, reason: f64) -> *m
 // ─────────────────────────────────────────────────────────────────────
 // tee / pipeTo / pipeThrough
 // ─────────────────────────────────────────────────────────────────────
-
-/// `stream.tee()` — returns an array of two new ReadableStreams. Both
-/// branches drain the SOURCE eagerly into separate per-branch queues at
-/// tee time. This is correct for the buffered consumers Perry exposes
-/// (`blob.stream()` / `response.body` are pre-buffered) and the "user
-/// source already enqueued everything synchronously in start" pattern.
-/// Streams that lazily produce chunks via `pull` after tee will only see
-/// chunks present at the tee call — the same trade-off Node's
-/// `Readable.from([...]).tee()` makes for already-buffered iterables.
-fn tee_branches_of(source: usize) -> Option<(usize, usize)> {
-    TEE_SOURCE_BRANCHES.lock().unwrap().get(&source).copied()
-}
-
-fn tee_source_of(branch: usize) -> Option<usize> {
-    TEE_BRANCH_SOURCE.lock().unwrap().get(&branch).copied()
-}
-
-/// Deliver one chunk to a single tee branch: hand it to a parked read if one is
-/// waiting, else queue it. Mirrors the default-reader path of
-/// `js_readable_stream_controller_enqueue`.
-unsafe fn tee_deliver(branch: usize, chunk_bits: u64, is_byte: bool) {
-    let popped = {
-        let mut g = READABLE_STREAMS.lock().unwrap();
-        match g.get_mut(&branch) {
-            Some(s) if s.state == ReadableState::Readable => {
-                if let Some(p) = s.pending_reads.pop_front() {
-                    Some(p)
-                } else {
-                    let size = if is_byte {
-                        byob::chunk_byte_length(chunk_bits)
-                    } else {
-                        1.0
-                    };
-                    s.push_chunk(chunk_bits, size);
-                    None
-                }
-            }
-            _ => None,
-        }
-    };
-    if let Some(p) = popped {
-        let result = build_iter_result(chunk_bits, false);
-        js_promise_resolve(p, f64::from_bits(result));
-    }
-}
-
-/// The tee'd source closed — close both branches (each drains its queue first,
-/// per `js_reader_read`'s close-after-last-chunk handling) and drop the links.
-unsafe fn tee_close_branches(source: usize) {
-    let Some((a, b)) = tee_branches_of(source) else {
-        return;
-    };
-    for branch in [a, b] {
-        let queue_empty = {
-            let mut g = READABLE_STREAMS.lock().unwrap();
-            match g.get_mut(&branch) {
-                Some(s) => {
-                    if s.state == ReadableState::Readable {
-                        s.state = ReadableState::Closed;
-                    }
-                    s.chunks.is_empty()
-                }
-                None => true,
-            }
-        };
-        if queue_empty {
-            close_pending(branch);
-        }
-    }
-    tee_unlink(source, a, b);
-}
-
-/// The tee'd source errored — error both branches and drop the links.
-unsafe fn tee_error_branches(source: usize, reason_bits: u64) {
-    let Some((a, b)) = tee_branches_of(source) else {
-        return;
-    };
-    for branch in [a, b] {
-        {
-            let mut g = READABLE_STREAMS.lock().unwrap();
-            if let Some(s) = g.get_mut(&branch) {
-                if s.state == ReadableState::Readable {
-                    s.state = ReadableState::Errored;
-                    s.error_value = reason_bits;
-                }
-            }
-        }
-        error_pending(branch, reason_bits);
-    }
-    tee_unlink(source, a, b);
-}
-
-fn tee_unlink(source: usize, a: usize, b: usize) {
-    TEE_SOURCE_BRANCHES.lock().unwrap().remove(&source);
-    let mut bs = TEE_BRANCH_SOURCE.lock().unwrap();
-    bs.remove(&a);
-    bs.remove(&b);
-}
-
-/// `readable.tee()` — Web Streams `ReadableStreamTee`. The source stays LIVE and
-/// is pulled lazily by reads on the two returned branches: a branch read with an
-/// empty queue pulls the source (`maybe_pull` routes tee-branch pulls to the
-/// source), and each chunk the source enqueues fans out to BOTH branches. The
-/// previous implementation snapshot-drained the source's current buffer and
-/// closed it, which yielded two empty branches for a pull-driven source (e.g.
-/// react-server-dom's RSC flight producer, which only produces on pull) — #5989.
-#[no_mangle]
-pub unsafe extern "C" fn js_readable_stream_tee(stream_handle: f64) -> f64 {
-    let id = stream_handle as usize;
-    let mut was_locked = false;
-    let mut is_byte_stream = false;
-    let mut source_state = ReadableState::Readable;
-    let existing: Vec<u64> = {
-        let mut g = READABLE_STREAMS.lock().unwrap();
-        match g.get_mut(&id) {
-            Some(s) if s.reader_handle.is_none() => {
-                is_byte_stream = s.is_byte_stream;
-                source_state = s.state;
-                let drained = s.drain_chunks();
-                // Keep the source LIVE — lock it against direct reads but leave
-                // its state + pull_cb intact so branch reads can drive it.
-                s.reader_handle = Some(TEE_LOCK_SENTINEL);
-                drained
-            }
-            Some(_) => {
-                was_locked = true;
-                Vec::new()
-            }
-            None => Vec::new(),
-        }
-    };
-    if was_locked {
-        throw_type_error("ReadableStream is locked");
-    }
-
-    // A branch mirrors the source's terminal state; a live source yields live
-    // branches whose future chunks arrive by fan-out.
-    let branch_state = match source_state {
-        ReadableState::Errored => ReadableState::Errored,
-        ReadableState::Closed => ReadableState::Closed,
-        _ => ReadableState::Readable,
-    };
-    let id_a = next_id(&NEXT_STREAM_ID);
-    let id_b = next_id(&NEXT_STREAM_ID);
-    {
-        let mut g = READABLE_STREAMS.lock().unwrap();
-        for new_id in [id_a, id_b] {
-            g.insert(
-                new_id,
-                ReadableStreamData {
-                    state: branch_state,
-                    chunks: existing.iter().copied().collect(),
-                    chunk_sizes: existing.iter().map(|_| 1.0).collect(),
-                    queue_total_size: existing.len() as f64,
-                    pending_reads: VecDeque::new(),
-                    start_cb: 0,
-                    // No own pull_cb: a branch read pulls the SOURCE via the tee
-                    // link (see `maybe_pull`). highWaterMark 0 so every read that
-                    // finds an empty queue triggers a source pull.
-                    pull_cb: 0,
-                    cancel_cb: 0,
-                    strategy_size_cb: 0,
-                    high_water_mark: 0.0,
-                    is_byte_stream,
-                    pull_returns_byte_chunk: false,
-                    pulling: false,
-                    started: true,
-                    reader_handle: None,
-                    error_value: 0,
-                    pending_error_after_chunks: None,
-                    canceled: false,
-                },
-            );
-        }
-    }
-    // Only a still-producible source needs live links; a terminal source's
-    // branches already carry its final state + any drained chunks.
-    if branch_state == ReadableState::Readable {
-        TEE_SOURCE_BRANCHES.lock().unwrap().insert(id, (id_a, id_b));
-        let mut bs = TEE_BRANCH_SOURCE.lock().unwrap();
-        bs.insert(id_a, id);
-        bs.insert(id_b, id);
-    }
-
-    let arr = js_array_alloc(2);
-    js_array_push(arr, JSValue::from_bits(f64::to_bits(id_a as f64)));
-    js_array_push(arr, JSValue::from_bits(f64::to_bits(id_b as f64)));
-    f64::from_bits(JSValue::object_ptr(arr as *mut u8).bits())
-}
 
 /// `readable.pipeThrough({readable, writable})` — pipeTo into the
 /// transform's writable side, return its readable side. Caller already

--- a/crates/perry-stdlib/src/streams/tee.rs
+++ b/crates/perry-stdlib/src/streams/tee.rs
@@ -1,0 +1,211 @@
+//! #5989 `readable.tee()` — Web Streams `ReadableStreamTee`. Split out of
+//! `streams.rs` to keep that file under the file-size gate.
+//!
+//! A tee'd source stream stays LIVE and is driven lazily by reads on its two
+//! branches: a branch read with an empty queue pulls the source (`maybe_pull`
+//! routes tee-branch pulls to the source), and each chunk the source enqueues
+//! fans out to BOTH branches (see the hooks in `controller_enqueue` /
+//! `controller_close` / `controller_error`).
+
+use super::{
+    build_iter_result, byob, close_pending, error_pending, js_promise_resolve, next_id,
+    throw_type_error, ReadableState, ReadableStreamData, NEXT_STREAM_ID, READABLE_STREAMS,
+};
+use perry_runtime::array::{js_array_alloc, js_array_push};
+use perry_runtime::value::JSValue;
+use std::collections::{HashMap, VecDeque};
+use std::sync::Mutex;
+
+lazy_static::lazy_static! {
+    /// Source id -> its two branch ids (so the source's enqueue/close/error
+    /// fan out to both branches).
+    static ref TEE_SOURCE_BRANCHES: Mutex<HashMap<usize, (usize, usize)>> = Mutex::new(HashMap::new());
+    /// Branch id -> its source (so a branch read pulls the source).
+    static ref TEE_BRANCH_SOURCE: Mutex<HashMap<usize, usize>> = Mutex::new(HashMap::new());
+}
+
+/// Sentinel `reader_handle` stamped on a tee'd source so it can't be read
+/// directly (spec: `tee()` acquires a reader on the source). It is never a real
+/// entry in `READERS`, so reader lookups against it resolve to `None`.
+const TEE_LOCK_SENTINEL: usize = usize::MAX;
+
+pub(super) fn tee_branches_of(source: usize) -> Option<(usize, usize)> {
+    TEE_SOURCE_BRANCHES.lock().unwrap().get(&source).copied()
+}
+
+pub(super) fn tee_source_of(branch: usize) -> Option<usize> {
+    TEE_BRANCH_SOURCE.lock().unwrap().get(&branch).copied()
+}
+
+/// Deliver one chunk to a single tee branch: hand it to a parked read if one is
+/// waiting, else queue it. Mirrors the default-reader path of
+/// `js_readable_stream_controller_enqueue`.
+pub(super) unsafe fn tee_deliver(branch: usize, chunk_bits: u64, is_byte: bool) {
+    let popped = {
+        let mut g = READABLE_STREAMS.lock().unwrap();
+        match g.get_mut(&branch) {
+            Some(s) if s.state == ReadableState::Readable => {
+                if let Some(p) = s.pending_reads.pop_front() {
+                    Some(p)
+                } else {
+                    let size = if is_byte {
+                        byob::chunk_byte_length(chunk_bits)
+                    } else {
+                        1.0
+                    };
+                    s.push_chunk(chunk_bits, size);
+                    None
+                }
+            }
+            _ => None,
+        }
+    };
+    if let Some(p) = popped {
+        let result = build_iter_result(chunk_bits, false);
+        js_promise_resolve(p, f64::from_bits(result));
+    }
+}
+
+/// The tee'd source closed — close both branches (each drains its queue first,
+/// per `js_reader_read`'s close-after-last-chunk handling) and drop the links.
+pub(super) unsafe fn tee_close_branches(source: usize) {
+    let Some((a, b)) = tee_branches_of(source) else {
+        return;
+    };
+    for branch in [a, b] {
+        let queue_empty = {
+            let mut g = READABLE_STREAMS.lock().unwrap();
+            match g.get_mut(&branch) {
+                Some(s) => {
+                    if s.state == ReadableState::Readable {
+                        s.state = ReadableState::Closed;
+                    }
+                    s.chunks.is_empty()
+                }
+                None => true,
+            }
+        };
+        if queue_empty {
+            close_pending(branch);
+        }
+    }
+    tee_unlink(source, a, b);
+}
+
+/// The tee'd source errored — error both branches and drop the links.
+pub(super) unsafe fn tee_error_branches(source: usize, reason_bits: u64) {
+    let Some((a, b)) = tee_branches_of(source) else {
+        return;
+    };
+    for branch in [a, b] {
+        {
+            let mut g = READABLE_STREAMS.lock().unwrap();
+            if let Some(s) = g.get_mut(&branch) {
+                if s.state == ReadableState::Readable {
+                    s.state = ReadableState::Errored;
+                    s.error_value = reason_bits;
+                }
+            }
+        }
+        error_pending(branch, reason_bits);
+    }
+    tee_unlink(source, a, b);
+}
+
+fn tee_unlink(source: usize, a: usize, b: usize) {
+    TEE_SOURCE_BRANCHES.lock().unwrap().remove(&source);
+    let mut bs = TEE_BRANCH_SOURCE.lock().unwrap();
+    bs.remove(&a);
+    bs.remove(&b);
+}
+
+/// `readable.tee()` — Web Streams `ReadableStreamTee`. The source stays LIVE and
+/// is pulled lazily by reads on the two returned branches: a branch read with an
+/// empty queue pulls the source (`maybe_pull` routes tee-branch pulls to the
+/// source), and each chunk the source enqueues fans out to BOTH branches. The
+/// previous implementation snapshot-drained the source's current buffer and
+/// closed it, which yielded two empty branches for a pull-driven source (e.g.
+/// react-server-dom's RSC flight producer, which only produces on pull) — #5989.
+#[no_mangle]
+pub unsafe extern "C" fn js_readable_stream_tee(stream_handle: f64) -> f64 {
+    let id = stream_handle as usize;
+    let mut was_locked = false;
+    let mut is_byte_stream = false;
+    let mut source_state = ReadableState::Readable;
+    let existing: Vec<u64> = {
+        let mut g = READABLE_STREAMS.lock().unwrap();
+        match g.get_mut(&id) {
+            Some(s) if s.reader_handle.is_none() => {
+                is_byte_stream = s.is_byte_stream;
+                source_state = s.state;
+                let drained = s.drain_chunks();
+                // Keep the source LIVE — lock it against direct reads but leave
+                // its state + pull_cb intact so branch reads can drive it.
+                s.reader_handle = Some(TEE_LOCK_SENTINEL);
+                drained
+            }
+            Some(_) => {
+                was_locked = true;
+                Vec::new()
+            }
+            None => Vec::new(),
+        }
+    };
+    if was_locked {
+        throw_type_error("ReadableStream is locked");
+    }
+
+    // A branch mirrors the source's terminal state; a live source yields live
+    // branches whose future chunks arrive by fan-out.
+    let branch_state = match source_state {
+        ReadableState::Errored => ReadableState::Errored,
+        ReadableState::Closed => ReadableState::Closed,
+        _ => ReadableState::Readable,
+    };
+    let id_a = next_id(&NEXT_STREAM_ID);
+    let id_b = next_id(&NEXT_STREAM_ID);
+    {
+        let mut g = READABLE_STREAMS.lock().unwrap();
+        for new_id in [id_a, id_b] {
+            g.insert(
+                new_id,
+                ReadableStreamData {
+                    state: branch_state,
+                    chunks: existing.iter().copied().collect(),
+                    chunk_sizes: existing.iter().map(|_| 1.0).collect(),
+                    queue_total_size: existing.len() as f64,
+                    pending_reads: VecDeque::new(),
+                    start_cb: 0,
+                    // No own pull_cb: a branch read pulls the SOURCE via the tee
+                    // link (see `maybe_pull`). highWaterMark 0 so every read that
+                    // finds an empty queue triggers a source pull.
+                    pull_cb: 0,
+                    cancel_cb: 0,
+                    strategy_size_cb: 0,
+                    high_water_mark: 0.0,
+                    is_byte_stream,
+                    pull_returns_byte_chunk: false,
+                    pulling: false,
+                    started: true,
+                    reader_handle: None,
+                    error_value: 0,
+                    pending_error_after_chunks: None,
+                    canceled: false,
+                },
+            );
+        }
+    }
+    // Only a still-producible source needs live links; a terminal source's
+    // branches already carry its final state + any drained chunks.
+    if branch_state == ReadableState::Readable {
+        TEE_SOURCE_BRANCHES.lock().unwrap().insert(id, (id_a, id_b));
+        let mut bs = TEE_BRANCH_SOURCE.lock().unwrap();
+        bs.insert(id_a, id);
+        bs.insert(id_b, id);
+    }
+
+    let arr = js_array_alloc(2);
+    js_array_push(arr, JSValue::from_bits(f64::to_bits(id_a as f64)));
+    js_array_push(arr, JSValue::from_bits(f64::to_bits(id_b as f64)));
+    f64::from_bits(JSValue::object_ptr(arr as *mut u8).bits())
+}

--- a/test-files/test_gap_readable_stream_tee_pull.ts
+++ b/test-files/test_gap_readable_stream_tee_pull.ts
@@ -1,0 +1,101 @@
+// `ReadableStream.tee()` must return two branches that both lazily PULL the
+// shared source: reading a branch drives the source's `pull`, and each chunk
+// fans out to both branches. The previous implementation snapshot-drained the
+// source's current buffer and closed it, so a pull-driven source (one that only
+// produces inside `pull`, e.g. react-server-dom's RSC flight producer with
+// `highWaterMark: 0`) yielded two EMPTY branches — the reader saw `done: true`
+// immediately. That silently broke Next.js App Router SSR (the HTML render
+// consumes the tee'd RSC flight), which hung forever (#5989).
+//
+// Validated byte-for-byte against `node --experimental-strip-types`.
+
+async function readAll(r: any): Promise<string> {
+  const dec = new TextDecoder();
+  let out = "";
+  while (true) {
+    const { done, value } = await r.read();
+    if (done) break;
+    out += typeof value === "string" ? value : dec.decode(value as Uint8Array);
+  }
+  return out;
+}
+
+async function main() {
+  // (1) pull-driven byte source, highWaterMark 0 — the flight-producer shape.
+  let pulls = 0;
+  const src = new ReadableStream(
+    {
+      type: "bytes",
+      pull(c: any) {
+        pulls++;
+        c.enqueue(new TextEncoder().encode(`d${pulls}`));
+        if (pulls >= 3) c.close();
+      },
+    },
+    { highWaterMark: 0 },
+  );
+  const [a, b] = src.tee();
+  const outA = await readAll(a.getReader());
+  const outB = await readAll(b.getReader());
+  console.log(pulls, outA, outB);
+
+  // (2) eagerly-buffered source — both branches see the queued chunks.
+  const s2 = new ReadableStream({
+    start(c: any) {
+      c.enqueue("a");
+      c.enqueue("b");
+      c.close();
+    },
+  });
+  const [c1, c2] = s2.tee();
+  console.log(await readAll(c1.getReader()), await readAll(c2.getReader()));
+
+  // (3) read only ONE branch — it still drives the source to completion.
+  let p3 = 0;
+  const s3 = new ReadableStream({
+    pull(c: any) {
+      p3++;
+      c.enqueue("x" + p3);
+      if (p3 >= 2) c.close();
+    },
+  });
+  const [d1] = s3.tee();
+  console.log(await readAll(d1.getReader()), p3);
+
+  // (4) interleaved reads across both branches.
+  const s4 = new ReadableStream({
+    pull(c: any) {
+      c.enqueue("z");
+      c.close();
+    },
+  });
+  const [e1, e2] = s4.tee();
+  const ra = e1.getReader();
+  const rb = e2.getReader();
+  const r1 = await ra.read();
+  const r2 = await rb.read();
+  console.log(r1.value, r2.value, r1.done, r2.done);
+
+  // (5) an error on the source rejects reads on both branches.
+  const s5 = new ReadableStream({
+    pull(c: any) {
+      c.error(new Error("boom"));
+    },
+  });
+  const [f1, f2] = s5.tee();
+  let ea = "no";
+  let eb = "no";
+  try {
+    await f1.getReader().read();
+  } catch (e: any) {
+    ea = e.message;
+  }
+  try {
+    await f2.getReader().read();
+  } catch (e: any) {
+    eb = e.message;
+  }
+  console.log(ea, eb);
+}
+
+main();


### PR DESCRIPTION
## Problem

`ReadableStream.prototype.tee()` returned two **empty, already-closed** branches
for any source that produces lazily inside `pull()`. The implementation was a
snapshot-and-close: it drained the source's *current* buffer, set the source to
`Closed`, and created two static branches with no `pull` callback. A pull-driven
source (`highWaterMark: 0`, produces only when read) has an empty buffer at
tee-time, so both branches were empty and a reader saw `{ done: true }`
immediately:

```js
const s = new ReadableStream(
  { type: "bytes", pull(c) { c.enqueue(new TextEncoder().encode("x")); c.close(); } },
  { highWaterMark: 0 },
);
const [a, b] = s.tee();
await a.getReader().read();   // Perry: { done: true } (empty!)   Node: { value: "x" }
```

This silently broke **Next.js App Router SSR**: the HTML render consumes the
tee'd react-server-dom RSC flight stream (whose producer only emits on pull), so
the consumer read an empty branch, the flight chunks never resolved, the render
shell never became ready, and every dynamic route hung forever.

## Fix

Implement the spec's lazy `ReadableStreamTee`: the source stays **live** and is
pulled on demand by reads on its branches.

- The source is locked (not closed); a small registry maps `source → (branchA,
  branchB)` and each `branch → source`.
- `maybe_pull(branch)` routes to `maybe_pull_force(source)`, so a branch read
  with an empty queue drives the source's `pull`.
- The source's `controller.enqueue` / `close` / `error` **fan out to both
  branches** (delivering to a parked read or queueing per branch), instead of
  touching the source's own (now unused) queue.

Cancel semantics are unchanged (a branch cancel still only affects that branch);
the common producer/consumer path — which never cancels — is now correct.

## Validation

- New gap test `test_gap_readable_stream_tee_pull.ts` — byte-for-byte against
  `node --experimental-strip-types`: a pull-driven `highWaterMark: 0` byte
  source, an eagerly-buffered source, single-branch draining, interleaved reads
  across branches, and error propagation to both branches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `ReadableStream.tee()` to keep the source **live** and properly drive reads from either branch.
  * Ensured enqueued chunks are delivered to both branches, with correct handling for buffered data.
  * Fixed terminal behavior: closing or erroring a tee’d source now closes/errors both branches consistently.
* **Tests**
  * Added `ReadableStream.tee()` tests covering byte streams, buffered streams, single-branch reads, interleaved reads, and source error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->