### PR TITLE
perf(gc): bound copied-minor weak processing to a live-holder registry (+ classifier liveness) (#6182)

### DIFF
--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -11,12 +11,12 @@ pub(super) enum CopyingPointerKind {
 }
 
 #[derive(Clone, Copy)]
-pub(super) struct CopyingPointer {
-    pub(super) header: *mut GcHeader,
+pub(crate) struct CopyingPointer {
+    pub(crate) header: *mut GcHeader,
     pub(super) kind: CopyingPointerKind,
 }
 
-pub(super) struct CopyingPointerSet {
+pub(crate) struct CopyingPointerSet {
     pub(super) malloc_registry_available: Cell<bool>,
     pub(super) malloc_registry_empty_at_start: bool,
     pub(super) malloc_validation_lookups: Cell<usize>,
@@ -39,7 +39,7 @@ impl CopyingPointerSet {
     }
 
     #[inline]
-    pub(super) fn classify(&self, addr: usize) -> Option<CopyingPointer> {
+    pub(crate) fn classify(&self, addr: usize) -> Option<CopyingPointer> {
         self.classify_arena(addr)
             .or_else(|| self.classify_malloc(addr))
     }
@@ -1085,23 +1085,33 @@ pub(super) fn gc_collect_minor_copying_fast_path_with_eligibility(
     // operative cycle (unbounded retention in long-running servers).
     // Now the scan records weak slots without evacuating; here we repair
     // any whose target was moved via a strong edge after the slot was
-    // visited, then run the shared after-mark tombstone pass. Must run
+    // visited, then run the registry-scoped tombstone pass. Must run
     // BEFORE `copying_reset_from_spaces_and_flip` below: liveness is
     // MARKED|PINNED on pre-flip headers (to-space copies carry MARKED
-    // until `clear_marks`). Gated on the weak-holder latch so programs
-    // that never allocate a weak container skip the full arena walk.
+    // until `clear_marks`), and dead holders' from-space headers are still
+    // intact/classifiable before the flip. Gated on the weak-holder latch
+    // (now "registry non-empty") so programs that never allocate — or that
+    // once did but whose holders have all died — skip the pass entirely.
+    //
+    // 2026-07-09 GC audit (#6182): this used to build a full-heap
+    // `build_valid_pointer_set()` BTreeSet AND `arena_walk_objects` over
+    // EVERY live object to find the 3 weak-holder class_ids — two O(all
+    // objects) passes forfeited forever once any WeakMap/WeakRef/FinReg was
+    // allocated. `process_weak_targets_from_registry` instead walks only the
+    // registered holders and classifies targets with the O(1) page-metadata
+    // classifier the copy already built (`collector.ptrs`) — no BTreeSet, no
+    // arena walk. The full-cycle path (cycle.rs `WeakProcessing`) is
+    // untouched and still uses the valid-pointer set it built for its trace.
     unsafe {
         collector.repair_weak_slots();
     }
     if crate::weakref::weak_target_holders_allocated() {
         let phase_start = trace_phase_start(trace);
-        let valid_ptrs = build_valid_pointer_set();
         // Enqueue FinalizationRegistry cleanup jobs on every trigger kind —
         // see the matching WeakProcessing comment in cycle.rs (2026-07-09 GC
         // audit: delivery was gated on the Manual trigger).
-        crate::weakref::process_weak_targets_after_mark(
-            &valid_ptrs,
-            /* minor_only = */ true,
+        crate::weakref::process_weak_targets_from_registry(
+            &collector.ptrs,
             /* enqueue_callbacks = */ true,
         );
         trace_phase_record(trace, "weak_processing", phase_start);

--- a/crates/perry-runtime/src/gc/dead_owner.rs
+++ b/crates/perry-runtime/src/gc/dead_owner.rs
@@ -184,6 +184,14 @@ pub(super) fn prune_dead_owner_side_tables_post_trace(full_trace: bool) {
         &|addr| probe.owner_is_dead(addr, Some(GC_TYPE_CLOSURE)),
         &|addr| probe.owner_is_dead(addr, Some(GC_TYPE_STRING)),
     );
+    // #6182: drop dead weak-target HOLDERS (WeakRef / FinalizationRegistry /
+    // WeakMap-WeakSet entry — all GC_TYPE_OBJECT) from the registry so the
+    // copied-minor weak-processing latch (`weak_target_holders_allocated` =
+    // registry non-empty) returns to zero once a transient WeakMap and its
+    // entries die. The copied-minor fast path prunes inside
+    // `process_weak_targets_from_registry`; this covers the full/fallback
+    // (non-copying) cycles, which don't run that pass.
+    crate::weakref::prune_dead_weak_holders(&|addr| probe.owner_is_dead(addr, Some(GC_TYPE_OBJECT)));
 }
 
 /// Copied-minor fan-out: prune entries owned by dead from-space objects

--- a/crates/perry-runtime/src/gc/dead_owner.rs
+++ b/crates/perry-runtime/src/gc/dead_owner.rs
@@ -191,7 +191,9 @@ pub(super) fn prune_dead_owner_side_tables_post_trace(full_trace: bool) {
     // entries die. The copied-minor fast path prunes inside
     // `process_weak_targets_from_registry`; this covers the full/fallback
     // (non-copying) cycles, which don't run that pass.
-    crate::weakref::prune_dead_weak_holders(&|addr| probe.owner_is_dead(addr, Some(GC_TYPE_OBJECT)));
+    crate::weakref::prune_dead_weak_holders(&|addr| {
+        probe.owner_is_dead(addr, Some(GC_TYPE_OBJECT))
+    });
 }
 
 /// Copied-minor fan-out: prune entries owned by dead from-space objects

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -56,6 +56,9 @@ mod barrier;
 pub use barrier::*;
 mod copying;
 use copying::*;
+// The copied-minor pointer classifier is consumed by the weak-holder registry
+// pass in `crate::weakref` (#6182), which lives outside the gc module.
+pub(crate) use copying::{CopyingPointer, CopyingPointerSet};
 mod dead_owner;
 mod oldgen;
 use oldgen::*;
@@ -436,6 +439,12 @@ pub fn gc_init() {
     gc_register_mutable_root_scanner(crate::builtins::scan_console_log_singleton_roots_mut);
     gc_register_mutable_root_scanner(crate::builtins::scan_boxed_primitive_payload_roots_mut);
     gc_register_mutable_root_scanner(crate::weakref::scan_pending_finalization_jobs_roots_mut);
+    // #6182: keep the weak-holder registry's stored holder ADDRESSES current
+    // across evacuation. Metadata-only (non-rooting) — it rewrites forwarded
+    // addresses in rewrite phases and emits nothing during mark, so it never
+    // keeps a dead holder alive. Copied-minor liveness/prune is driven by
+    // `process_weak_targets_from_registry`; this covers full-cycle currency.
+    gc_register_mutable_root_scanner(crate::weakref::scan_weak_holders_roots_mut);
     // Issue #841: GC roots for the per-(submodule, export) function
     // singletons + per-submodule namespace stub objects allocated by
     // `node_submodules.rs`. Without this scanner the next GC cycle

--- a/crates/perry-runtime/src/gc/tests/copying.rs
+++ b/crates/perry-runtime/src/gc/tests/copying.rs
@@ -1,5 +1,6 @@
 mod promise_side_tables;
 mod survival_and_malloc;
+mod weak_holder_registry;
 mod weak_semantics;
 use super::super::*;
 use super::support::*;

--- a/crates/perry-runtime/src/gc/tests/copying/weak_holder_registry.rs
+++ b/crates/perry-runtime/src/gc/tests/copying/weak_holder_registry.rs
@@ -318,3 +318,135 @@ fn test_copied_minor_finreg_enqueues_cleanup_via_registry() {
         "a second automatic cycle must NOT re-enqueue the same record"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Promoted-key generational-invariant guards.
+//
+// A copied minor does NOT mark the old generation (old objects are black
+// leaves, not re-traced), so a weak target that survived enough minors to be
+// PROMOTED to old-gen is live-but-unmarked during a copied minor. Judging its
+// deadness by the mark bit would silently drop a live entry / deref / target.
+// Each of these FAILS against a mark-only copied-minor predicate and PASSES
+// with the `pointer_in_nursery` guard (replicating `minor_only`).
+// ---------------------------------------------------------------------------
+
+/// Drive a rooted young object to old-gen via `GC_COPY_PROMOTION_SURVIVALS`
+/// (4) survivals, then return its (promoted) address. Leaves it rooted in
+/// `slot`.
+fn promote_rooted_to_old(slot: u32) -> usize {
+    for _ in 0..4 {
+        let _ = gc_collect_minor();
+    }
+    let addr = (js_shadow_slot_get(slot) & POINTER_MASK) as usize;
+    assert!(
+        crate::arena::pointer_in_old_gen(addr),
+        "test premise: the object must be promoted to old-gen after 4 survivals"
+    );
+    addr
+}
+
+/// A WeakMap key promoted to old-gen (still strongly held) whose entry is a
+/// young object must NOT be tombstoned by a further copied minor. Pre-fix
+/// (`classify → !header_is_live`) the unmarked old key was judged dead and the
+/// entry silently dropped from the map.
+#[test]
+fn test_copied_minor_promoted_weakmap_key_not_tombstoned() {
+    let _guard = CopyingNurseryTestGuard::new(2);
+
+    let key = crate::object::js_object_alloc(0, 0);
+    js_shadow_slot_set(1, obj_bits(key));
+    let key_old = promote_rooted_to_old(1);
+
+    // Fresh (young) WeakMap + entry keyed by the promoted old-gen key.
+    let map = crate::weakref::js_weakmap_new();
+    js_shadow_slot_set(0, obj_bits(map));
+    let map_v = f64::from_bits(js_shadow_slot_get(0));
+    crate::weakref::js_weakmap_set(
+        map_v,
+        f64::from_bits(ptr_bits(key_old)),
+        f64::from_bits(crate::value::TAG_TRUE),
+    );
+
+    let trace = collect_minor_trace(GcTriggerKind::Direct);
+    assert_copied_minor_trace(&trace, true, CopiedMinorFallbackReason::None, false);
+
+    let key_now = (js_shadow_slot_get(1) & POINTER_MASK) as usize;
+    let map_v = f64::from_bits(js_shadow_slot_get(0));
+    assert_eq!(
+        crate::weakref::js_weakmap_has(map_v, f64::from_bits(ptr_bits(key_now))).to_bits(),
+        crate::value::TAG_TRUE,
+        "a live WeakMap key PROMOTED to old-gen must NOT be tombstoned by a copied minor \
+         (a minor does not mark old-gen)"
+    );
+    let map_after = (js_shadow_slot_get(0) & POINTER_MASK) as *const crate::ObjectHeader;
+    assert_eq!(
+        crate::weakref::weak_collection_entries(map_after).len(),
+        1,
+        "the promoted-key entry must survive"
+    );
+}
+
+/// A WeakRef whose target is promoted to old-gen and still live must deref to
+/// the target (not `undefined`) after a copied minor.
+#[test]
+fn test_copied_minor_weakref_promoted_target_survives() {
+    let _guard = CopyingNurseryTestGuard::new(2);
+
+    let target = crate::object::js_object_alloc(0, 0);
+    js_shadow_slot_set(1, obj_bits(target));
+    let target_old = promote_rooted_to_old(1);
+
+    let wr = crate::weakref::js_weakref_new(f64::from_bits(ptr_bits(target_old)));
+    js_shadow_slot_set(0, obj_bits(wr));
+
+    let trace = collect_minor_trace(GcTriggerKind::Direct);
+    assert_copied_minor_trace(&trace, true, CopiedMinorFallbackReason::None, false);
+
+    let wr_after = ptr_bits((js_shadow_slot_get(0) & POINTER_MASK) as usize);
+    let target_now = js_shadow_slot_get(1) & POINTER_MASK;
+    let deref = crate::weakref::js_weakref_deref(f64::from_bits(wr_after)).to_bits();
+    assert_ne!(
+        deref,
+        crate::value::TAG_UNDEFINED,
+        "a live WeakRef target promoted to old-gen must NOT be tombstoned by a copied minor"
+    );
+    assert_eq!(
+        deref & POINTER_MASK,
+        target_now,
+        "deref must return the (old-gen) target"
+    );
+}
+
+/// A FinalizationRegistry target promoted to old-gen and still live must NOT be
+/// reported collected by a copied minor (no cleanup job enqueued). Pre-fix the
+/// unmarked old target was judged collected and its callback prematurely queued.
+#[test]
+fn test_copied_minor_finreg_promoted_live_target_not_collected() {
+    let _guard = CopyingNurseryTestGuard::new(2);
+
+    let target = crate::object::js_object_alloc(0, 0);
+    js_shadow_slot_set(1, obj_bits(target));
+    let target_old = promote_rooted_to_old(1);
+
+    let cb = crate::closure::js_closure_alloc(finreg_registry_test_callback as *const u8, 0);
+    let reg = crate::weakref::js_finreg_new(f64::from_bits(ptr_bits(cb as usize)));
+    js_shadow_slot_set(0, obj_bits(reg));
+    let reg_v = f64::from_bits(js_shadow_slot_get(0));
+    crate::weakref::js_finreg_register(
+        reg_v,
+        f64::from_bits(ptr_bits(target_old)),
+        f64::from_bits(crate::value::TAG_TRUE),
+        f64::from_bits(crate::value::TAG_UNDEFINED),
+    );
+    assert_eq!(crate::weakref::pending_finalization_jobs_count(), 0);
+
+    let trace = collect_minor_trace(GcTriggerKind::Direct);
+    assert_copied_minor_trace(&trace, true, CopiedMinorFallbackReason::None, false);
+
+    assert_eq!(
+        crate::weakref::pending_finalization_jobs_count(),
+        0,
+        "a FinalizationRegistry target promoted to old-gen and still live must NOT be \
+         reported collected by a copied minor"
+    );
+}

--- a/crates/perry-runtime/src/gc/tests/copying/weak_holder_registry.rs
+++ b/crates/perry-runtime/src/gc/tests/copying/weak_holder_registry.rs
@@ -1,0 +1,320 @@
+//! Copied-minor weak processing scoped to the live-holder registry (#6182).
+//!
+//! These exercise `process_weak_targets_from_registry` on a REAL moving
+//! copied-minor (`collect_minor_trace` + `assert_copied_minor_trace(..true..)`):
+//! the pass walks only the registered holders — following each through
+//! evacuation and dropping dead ones — and classifies weak targets with the
+//! copy's O(1) page-metadata classifier instead of a full-heap valid-pointer
+//! set. Correctness parity with the old whole-arena pass, plus the incidental
+//! handle-band fix and the registry-currency guarantees the optimization rests
+//! on.
+//!
+//! Note: the GC test harness clears `MUTABLE_ROOT_SCANNERS`, so the registered
+//! `scan_weak_holders_roots_mut` does NOT run here — these tests prove the
+//! copied-minor pass keeps holder addresses current by ITSELF (follow-forward +
+//! in-place rekey), which is the robust production-and-test path.
+
+use super::*;
+
+fn obj_bits(obj: *mut crate::ObjectHeader) -> u64 {
+    ptr_bits(obj as usize)
+}
+
+/// (1) A WeakMap with a live key and a dead key across a moving minor: the dead
+/// entry is tombstoned (dropped from the enumeration) while the live entry
+/// survives with BOTH its key and its (object) value repaired to their
+/// evacuated addresses.
+#[test]
+fn test_copied_minor_weakmap_dead_key_tombstoned_live_entry_rewritten() {
+    let _guard = CopyingNurseryTestGuard::new(2);
+
+    let map = crate::weakref::js_weakmap_new();
+    let live_key = crate::object::js_object_alloc(0, 0);
+    // Value is an object referenced ONLY through the entry's (strong) value
+    // slot, so observing its rewrite proves the live entry was evacuated.
+    let live_val = crate::object::js_object_alloc(0, 0);
+    js_shadow_slot_set(0, obj_bits(map));
+    js_shadow_slot_set(1, obj_bits(live_key));
+
+    {
+        // Dead key: reachable only from this scope's un-rooted local.
+        let dead_key = crate::object::js_object_alloc(0, 0);
+        let map_v = f64::from_bits(js_shadow_slot_get(0));
+        crate::weakref::js_weakmap_set(
+            map_v,
+            f64::from_bits(obj_bits(dead_key)),
+            f64::from_bits(crate::value::TAG_TRUE),
+        );
+        let live_v = f64::from_bits(js_shadow_slot_get(1));
+        crate::weakref::js_weakmap_set(map_v, live_v, f64::from_bits(obj_bits(live_val)));
+    }
+
+    let trace = collect_minor_trace(GcTriggerKind::Direct);
+    assert_copied_minor_trace(&trace, true, CopiedMinorFallbackReason::None, false);
+
+    let map_after = (js_shadow_slot_get(0) & POINTER_MASK) as *const crate::ObjectHeader;
+    let live_key_after = js_shadow_slot_get(1) & POINTER_MASK;
+
+    let entries = crate::weakref::weak_collection_entries(map_after);
+    assert_eq!(
+        entries.len(),
+        1,
+        "dead-key entry must be tombstoned; the live entry must remain"
+    );
+    let (k, v) = entries[0];
+    assert_eq!(
+        k.to_bits() & POINTER_MASK,
+        live_key_after,
+        "live entry's key must be repaired to the key's evacuated address"
+    );
+    let value_after = (v.to_bits() & POINTER_MASK) as usize;
+    assert_ne!(
+        value_after, live_val as usize,
+        "test premise: the (strongly-held) value object must actually move"
+    );
+    assert!(crate::arena::pointer_in_nursery(value_after));
+
+    // Behavioral: the map still answers `has(liveKey)` after the move.
+    let map_v = f64::from_bits(js_shadow_slot_get(0));
+    let live_v = f64::from_bits(js_shadow_slot_get(1));
+    assert_eq!(
+        crate::weakref::js_weakmap_has(map_v, live_v).to_bits(),
+        crate::value::TAG_TRUE
+    );
+}
+
+/// (2) One WeakRef whose target dies across a moving minor derefs to
+/// `undefined`; another whose target lives derefs to the target's repaired
+/// (evacuated) address.
+#[test]
+fn test_copied_minor_weakref_dead_and_live_via_registry() {
+    let _guard = CopyingNurseryTestGuard::new(3);
+
+    let dead_target = crate::object::js_object_alloc(0, 0);
+    let wr_dead = crate::weakref::js_weakref_new(f64::from_bits(obj_bits(dead_target)));
+    let live_target = crate::object::js_object_alloc(0, 0);
+    let wr_live = crate::weakref::js_weakref_new(f64::from_bits(obj_bits(live_target)));
+
+    js_shadow_slot_set(0, obj_bits(wr_dead));
+    js_shadow_slot_set(1, obj_bits(wr_live));
+    js_shadow_slot_set(2, obj_bits(live_target)); // strong edge keeps it alive
+
+    let trace = collect_minor_trace(GcTriggerKind::Direct);
+    assert_copied_minor_trace(&trace, true, CopiedMinorFallbackReason::None, false);
+
+    let wr_dead_after = ptr_bits((js_shadow_slot_get(0) & POINTER_MASK) as usize);
+    let wr_live_after = ptr_bits((js_shadow_slot_get(1) & POINTER_MASK) as usize);
+    let live_target_after = js_shadow_slot_get(2) & POINTER_MASK;
+
+    assert_eq!(
+        crate::weakref::js_weakref_deref(f64::from_bits(wr_dead_after)).to_bits(),
+        crate::value::TAG_UNDEFINED,
+        "weak-only young target must be collected and its WeakRef tombstoned"
+    );
+    let live_deref = crate::weakref::js_weakref_deref(f64::from_bits(wr_live_after)).to_bits();
+    assert_eq!(
+        live_deref & POINTER_MASK,
+        live_target_after,
+        "live target's WeakRef slot must be repaired to the evacuated address"
+    );
+    assert_ne!(
+        (live_deref & POINTER_MASK) as usize,
+        live_target as usize,
+        "test premise: the live target must actually move"
+    );
+}
+
+/// (3) Band-key correctness — the incidental fix. A WeakMap keyed by a
+/// POINTER_TAG value whose address lands in the handle band
+/// `[0x1000, HANDLE_BAND_MAX)` (here a fabricated 0x40000, not a real heap
+/// object) must NOT be tombstoned by the copied-minor pass. The old
+/// `valid_ptrs`-based predicate false-tombstoned any such key on the first GC
+/// (it read "not in valid_ptrs" as "dead"); the classifier reads a miss as
+/// "not a collectible heap object" and keeps it.
+#[test]
+fn test_copied_minor_handle_band_key_not_false_tombstoned() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+
+    let map = crate::weakref::js_weakmap_new();
+    js_shadow_slot_set(0, obj_bits(map));
+
+    // A fabricated handle-band key: POINTER_TAG over 0x40000 (a Proxy/fetch/http
+    // id band address), which is NOT a heap allocation.
+    let band_key = f64::from_bits(ptr_bits(0x40000));
+    let map_v = f64::from_bits(js_shadow_slot_get(0));
+    crate::weakref::js_weakmap_set(map_v, band_key, f64::from_bits(crate::value::TAG_TRUE));
+    assert_eq!(
+        crate::weakref::js_weakmap_has(map_v, band_key).to_bits(),
+        crate::value::TAG_TRUE
+    );
+
+    let trace = collect_minor_trace(GcTriggerKind::Direct);
+    assert_copied_minor_trace(&trace, true, CopiedMinorFallbackReason::None, false);
+
+    let map_v = f64::from_bits(js_shadow_slot_get(0));
+    assert_eq!(
+        crate::weakref::js_weakmap_has(map_v, band_key).to_bits(),
+        crate::value::TAG_TRUE,
+        "a handle-band weak key (non-heap) must NOT be false-tombstoned"
+    );
+    let map_after = (js_shadow_slot_get(0) & POINTER_MASK) as *const crate::ObjectHeader;
+    assert_eq!(
+        crate::weakref::weak_collection_entries(map_after).len(),
+        1,
+        "the band-key entry must survive the copied-minor pass"
+    );
+}
+
+/// (4) Latch clears: a transient WeakMap whose wrapper AND entries all die is
+/// pruned from the registry by a full collection, so
+/// `weak_target_holders_allocated()` (registry non-empty) returns to false —
+/// the transient-WeakMap copied-minor cost returns to zero (the old bool latch
+/// stayed set forever).
+#[test]
+fn test_weak_holder_latch_clears_after_transient_weakmap_dies() {
+    let _guard = GcTestIsolationGuard::new();
+    assert!(
+        !crate::weakref::weak_target_holders_allocated(),
+        "the registry starts empty for this isolated test"
+    );
+
+    {
+        // Un-rooted WeakMap + one entry: both are dead at the full trace.
+        let map = crate::weakref::js_weakmap_new();
+        let map_v = f64::from_bits(ptr_bits(map as usize));
+        let key = crate::object::js_object_alloc(0, 0);
+        crate::weakref::js_weakmap_set(
+            map_v,
+            f64::from_bits(ptr_bits(key as usize)),
+            f64::from_bits(crate::value::TAG_TRUE),
+        );
+    }
+    assert!(
+        crate::weakref::weak_target_holders_allocated(),
+        "the WeakMap entry must register a holder"
+    );
+
+    // Full (non-moving) mark-sweep → dead holders pruned via
+    // `prune_dead_weak_holders` (dead_owner post-trace hook).
+    gc_collect_full_mark_sweep_with_trigger(GcTriggerSnapshot::capture(GcTriggerKind::Direct));
+
+    assert!(
+        !crate::weakref::weak_target_holders_allocated(),
+        "a transient WeakMap that died must return the weak-processing latch to zero"
+    );
+}
+
+/// (5) Cross-cycle registry currency: a WeakMap entry survives three
+/// consecutive moving minors with its holder evacuated (address changing) each
+/// time; the registry tracks the moved holder so a key that dies on cycle 3 is
+/// still tombstoned while a permanently-live key is retained. If the registry
+/// lost track of the moved entry, the dead key's entry would never be processed
+/// (enumeration would still show it).
+#[test]
+fn test_registry_tracks_holder_across_three_moving_minors() {
+    let _guard = CopyingNurseryTestGuard::new(3);
+
+    let map = crate::weakref::js_weakmap_new();
+    let live_key = crate::object::js_object_alloc(0, 0);
+    let temp_key = crate::object::js_object_alloc(0, 0);
+    js_shadow_slot_set(0, obj_bits(map));
+    js_shadow_slot_set(1, obj_bits(live_key));
+    js_shadow_slot_set(2, obj_bits(temp_key));
+
+    let map_v = f64::from_bits(js_shadow_slot_get(0));
+    crate::weakref::js_weakmap_set(
+        map_v,
+        f64::from_bits(js_shadow_slot_get(1)),
+        f64::from_bits(crate::value::TAG_TRUE),
+    );
+    crate::weakref::js_weakmap_set(
+        map_v,
+        f64::from_bits(js_shadow_slot_get(2)),
+        f64::from_bits(crate::value::TAG_TRUE),
+    );
+
+    let mut prev_map = map as usize;
+    for cycle in 0..3 {
+        if cycle == 2 {
+            // Drop the strong root: temp_key dies going into the third minor.
+            js_shadow_slot_set(2, 0);
+        }
+        let trace = collect_minor_trace(GcTriggerKind::Direct);
+        assert_copied_minor_trace(&trace, true, CopiedMinorFallbackReason::None, false);
+        let map_now = (js_shadow_slot_get(0) & POINTER_MASK) as usize;
+        assert_ne!(
+            map_now, prev_map,
+            "the holder graph must be evacuated (addresses change) on each moving minor"
+        );
+        prev_map = map_now;
+    }
+
+    let map_after = (js_shadow_slot_get(0) & POINTER_MASK) as *const crate::ObjectHeader;
+    let entries = crate::weakref::weak_collection_entries(map_after);
+    assert_eq!(
+        entries.len(),
+        1,
+        "the key that died on cycle 3 must be tombstoned; the live entry retained \
+         (proves the registry tracked the entry through all three evacuations)"
+    );
+    let live_key_after = js_shadow_slot_get(1) & POINTER_MASK;
+    assert_eq!(
+        entries[0].0.to_bits() & POINTER_MASK,
+        live_key_after,
+        "the surviving entry's key must track the live key's final address"
+    );
+    let map_v = f64::from_bits(js_shadow_slot_get(0));
+    assert_eq!(
+        crate::weakref::js_weakmap_has(map_v, f64::from_bits(js_shadow_slot_get(1))).to_bits(),
+        crate::value::TAG_TRUE
+    );
+}
+
+extern "C" fn finreg_registry_test_callback(
+    _closure: *const crate::closure::ClosureHeader,
+    _held: f64,
+) -> f64 {
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+/// (6) FinalizationRegistry: a registered target that dies across a moving minor
+/// enqueues its cleanup job through the registry-based pass (the #6192
+/// automatic-cycle delivery must be preserved — the registry holder is the
+/// FinalizationRegistry itself, which carries the callback), and a second cycle
+/// must not re-enqueue it.
+#[test]
+fn test_copied_minor_finreg_enqueues_cleanup_via_registry() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+
+    let cb = crate::closure::js_closure_alloc(finreg_registry_test_callback as *const u8, 0);
+    let reg = crate::weakref::js_finreg_new(f64::from_bits(ptr_bits(cb as usize)));
+    js_shadow_slot_set(0, obj_bits(reg));
+
+    {
+        // Target reachable only from this scope — dead at the first minor.
+        let target = crate::object::js_object_alloc(0, 0);
+        let reg_v = f64::from_bits(js_shadow_slot_get(0));
+        crate::weakref::js_finreg_register(
+            reg_v,
+            f64::from_bits(obj_bits(target)),
+            f64::from_bits(crate::value::TAG_TRUE),
+            f64::from_bits(crate::value::TAG_UNDEFINED),
+        );
+    }
+    assert_eq!(crate::weakref::pending_finalization_jobs_count(), 0);
+
+    let trace = collect_minor_trace(GcTriggerKind::Direct);
+    assert_copied_minor_trace(&trace, true, CopiedMinorFallbackReason::None, false);
+    assert_eq!(
+        crate::weakref::pending_finalization_jobs_count(),
+        1,
+        "the registry-based copied-minor pass must enqueue the cleanup job for the dead target"
+    );
+
+    let _ = gc_collect_minor();
+    assert_eq!(
+        crate::weakref::pending_finalization_jobs_count(),
+        1,
+        "a second automatic cycle must NOT re-enqueue the same record"
+    );
+}

--- a/crates/perry-runtime/src/weakref.rs
+++ b/crates/perry-runtime/src/weakref.rs
@@ -733,10 +733,7 @@ impl WeakLiveness for CopiedMinorLiveness<'_> {
 /// Web-Stream) or any non-heap pointer — so we KEEP it. The old predicate
 /// treated "not in valid_ptrs" as dead, which FALSE-tombstoned live handle-band
 /// weak keys ≥0x1000 on the first GC (2026-07-09 audit §8); this path fixes it.
-fn weak_target_should_clear_copied(
-    target_bits: u64,
-    ptrs: &crate::gc::CopyingPointerSet,
-) -> bool {
+fn weak_target_should_clear_copied(target_bits: u64, ptrs: &crate::gc::CopyingPointerSet) -> bool {
     if target_bits == TAG_UNDEFINED {
         return false;
     }
@@ -829,7 +826,8 @@ pub(crate) fn process_weak_targets_from_registry(
     // Snapshot addresses so the registry can be mutated (rekey moved holders,
     // drop dead ones) while iterating. Holders don't allocate GC objects in
     // the helpers below, so no re-entrant `WEAK_HOLDERS` borrow occurs.
-    let snapshot: Vec<usize> = WEAK_HOLDERS.with(|holders| holders.borrow().iter().copied().collect());
+    let snapshot: Vec<usize> =
+        WEAK_HOLDERS.with(|holders| holders.borrow().iter().copied().collect());
     for addr in snapshot {
         let Some(current) = (unsafe { resolve_live_holder_copied(ptrs, addr) }) else {
             // Dead or unclassifiable holder → drop and skip.
@@ -961,8 +959,8 @@ unsafe fn process_finreg_after_mark(
     let registry_value = f64::from_bits(JSValue::pointer(registry as *const u8).bits());
     for i in 0..len {
         let record_value = js_array_get_f64(entries, i as u32);
-        let Some(record) =
-            liveness.as_live_object_with_class(record_value.to_bits(), CLASS_ID_FINALIZATION_RECORD)
+        let Some(record) = liveness
+            .as_live_object_with_class(record_value.to_bits(), CLASS_ID_FINALIZATION_RECORD)
         else {
             continue;
         };

--- a/crates/perry-runtime/src/weakref.rs
+++ b/crates/perry-runtime/src/weakref.rs
@@ -711,7 +711,7 @@ impl WeakLiveness for CopiedMinorLiveness<'_> {
         weak_target_should_clear_copied(target_bits, self.ptrs)
     }
     unsafe fn as_live_array(&self, bits: u64) -> Option<*mut ArrayHeader> {
-        classify_live_gc_type(bits, self.ptrs, crate::gc::GC_TYPE_ARRAY)
+        classify_gc_type_child(bits, self.ptrs, crate::gc::GC_TYPE_ARRAY)
             .map(|ptr| ptr as *mut ArrayHeader)
     }
     unsafe fn as_live_object_with_class(
@@ -719,20 +719,31 @@ impl WeakLiveness for CopiedMinorLiveness<'_> {
         bits: u64,
         class_id: u32,
     ) -> Option<*mut ObjectHeader> {
-        let ptr = classify_live_gc_type(bits, self.ptrs, crate::gc::GC_TYPE_OBJECT)?;
+        let ptr = classify_gc_type_child(bits, self.ptrs, crate::gc::GC_TYPE_OBJECT)?;
         let obj = ptr as *mut ObjectHeader;
         ((*obj).class_id == class_id).then_some(obj)
     }
 }
 
 /// Copied-minor twin of `weak_target_should_clear`. A weak target is collected
-/// iff it is a REAL heap object the classifier can attribute and that object is
-/// not live (MARKED|PINNED). The key correctness difference from the
-/// `ValidPointerSet` predicate: a classifier miss (`None`) means "not a
-/// collectible heap object" — a handle-band id (Proxy / node:http / fetch /
-/// Web-Stream) or any non-heap pointer — so we KEEP it. The old predicate
-/// treated "not in valid_ptrs" as dead, which FALSE-tombstoned live handle-band
-/// weak keys ≥0x1000 on the first GC (2026-07-09 audit §8); this path fixes it.
+/// iff it is a REAL, NURSERY heap object the classifier can attribute and that
+/// object is not live (MARKED|PINNED). Two correctness rules, both replicating
+/// the `weak_target_should_clear(.., minor_only = true)` semantics:
+///
+/// * A classifier miss (`None`) means "not a collectible heap object" — a
+///   handle-band id (Proxy / node:http / fetch / Web-Stream) or any non-heap
+///   pointer — so KEEP it. The old `ValidPointerSet` predicate treated "not in
+///   valid_ptrs" as dead, which FALSE-tombstoned live handle-band weak keys
+///   ≥0x1000 on the first GC (2026-07-09 audit §8); this path fixes it.
+/// * A copied minor IS a MINOR, so it does NOT mark the old generation (old
+///   objects are black leaves, not re-traced). An old-gen / longlived / malloc
+///   target is therefore live-but-unmarked here — its mark bit proves nothing —
+///   so it must be conservatively KEPT (a full GC tombstones it properly once it
+///   traces old-gen). This mirrors the original `minor_only && !pointer_in_nursery`
+///   guard: without it a WeakMap key that survived enough minors to be PROMOTED
+///   to old-gen would be silently dropped from the map on the next copied minor.
+///   Only nursery/survivor targets — which this minor DID trace — may be judged
+///   dead by their mark bit.
 fn weak_target_should_clear_copied(target_bits: u64, ptrs: &crate::gc::CopyingPointerSet) -> bool {
     if target_bits == TAG_UNDEFINED {
         return false;
@@ -747,44 +758,92 @@ fn weak_target_should_clear_copied(target_bits: u64, ptrs: &crate::gc::CopyingPo
     match ptrs.classify(ptr) {
         // Band-id handle / non-heap pointer → not collectible → keep.
         None => false,
-        // Real heap object → dead iff not MARKED|PINNED.
-        Some(cp) => unsafe { !header_is_live(cp.header) },
+        Some(cp) => {
+            // Old / longlived / malloc target in a minor: unmarked ≠ dead → keep.
+            if !crate::arena::pointer_in_nursery(ptr) {
+                return false;
+            }
+            // Nursery/survivor target this minor traced: dead iff not MARKED|PINNED.
+            unsafe { !header_is_live(cp.header) }
+        }
     }
 }
 
-/// Resolve `bits` to a live heap object of `obj_type` using the copied-minor
+/// Resolve `bits` to a heap object of `obj_type` using the copied-minor
 /// classifier, without following forwarding (the caller's fields are already
-/// current). Returns the user address, or `None` if dead / wrong type.
-unsafe fn classify_live_gc_type(
+/// current). Returns the user address, or `None` if not a valid heap object of
+/// that type.
+///
+/// This intentionally does NOT gate on the mark bit: it resolves a STRONG child
+/// of a holder whose liveness `resolve_live_holder_copied` already established
+/// (a FinalizationRegistry's entries array and records). Requiring MARKED would
+/// wrongly drop an entries array or record that was PROMOTED to old-gen (a minor
+/// doesn't mark old-gen), delaying finalization — the original
+/// `object_value_to_array` / `object_value_with_class` resolvers only checked
+/// validity + `obj_type`, never MARKED.
+unsafe fn classify_gc_type_child(
     bits: u64,
     ptrs: &crate::gc::CopyingPointerSet,
     obj_type: u8,
 ) -> Option<usize> {
     let ptr = heap_ptr_from_tagged_bits(bits)?;
     let cp = ptrs.classify(ptr)?;
-    if !header_is_live(cp.header) {
-        return None;
-    }
     (unsafe { (*cp.header).obj_type } == obj_type).then_some(ptr)
 }
 
-/// Follow a registered holder address to its current (post-evacuation)
-/// location and confirm the holder is live. Returns the current user address,
-/// or `None` when the holder is dead (unmarked, un-forwarded) or the address
-/// is no longer classifiable (stale / recycled). Copied-minor only: it reads
-/// pre-flip from-space headers, so the FORWARDED bit and the forwarding
-/// address are still valid.
-unsafe fn resolve_live_holder_copied(
+/// What the copied-minor pass should do with a registered holder address.
+enum HolderDisposition {
+    /// Live holder scanned this cycle (its weak slots are repaired): rekey the
+    /// registry to this current address and process it.
+    Process(usize),
+    /// Cannot be proven dead in a minor (an unmarked OLD/longlived holder — a
+    /// minor doesn't mark old-gen) AND its weak slots may be stale/unrepaired:
+    /// leave it registered untouched and let a full GC resolve it. Mirrors the
+    /// original arena walk, which only ever processed MARKED objects.
+    Keep,
+    /// Provably dead (unmarked nursery holder) or unclassifiable (stale /
+    /// recycled address): remove it from the registry.
+    Drop,
+}
+
+/// Decide the disposition of a registered holder in a copied minor. Copied-minor
+/// only: it reads pre-flip from-space headers, so the FORWARDED bit and the
+/// forwarding address are still valid.
+///
+/// A copied minor is a MINOR — it authoritatively traces only the nursery and
+/// does NOT mark or scan the old generation. So:
+/// * a live young holder is EVACUATED (FORWARDED); its to-space copy carries
+///   MARKED and had its weak slots repaired this cycle → `Process`;
+/// * an unmarked NURSERY holder is genuinely dead (an eligible copied minor has
+///   no pinned young survivors) → `Drop`;
+/// * an unmarked OLD/longlived holder is live-but-unmarked and its weak slots
+///   were neither repaired nor remembered, so it can be neither proven dead nor
+///   safely processed here → `Keep` (a full GC handles it).
+unsafe fn resolve_weak_holder_copied(
     ptrs: &crate::gc::CopyingPointerSet,
     addr: usize,
-) -> Option<usize> {
-    let cp = ptrs.classify(addr)?;
-    if (*cp.header).gc_flags & crate::gc::GC_FLAG_FORWARDED != 0 {
+) -> HolderDisposition {
+    let Some(cp) = ptrs.classify(addr) else {
+        return HolderDisposition::Drop;
+    };
+    let (cur_addr, cur_header) = if (*cp.header).gc_flags & crate::gc::GC_FLAG_FORWARDED != 0 {
         let fwd = crate::gc::forwarding_address(cp.header) as usize;
-        let cp2 = ptrs.classify(fwd)?;
-        return header_is_live(cp2.header).then_some(fwd);
+        match ptrs.classify(fwd) {
+            Some(cp2) => (fwd, cp2.header),
+            None => return HolderDisposition::Drop,
+        }
+    } else {
+        (addr, cp.header)
+    };
+    if header_is_live(cur_header) {
+        // MARKED|PINNED ⇒ scanned this cycle ⇒ weak slots repaired ⇒ processable.
+        return HolderDisposition::Process(cur_addr);
     }
-    header_is_live(cp.header).then_some(addr)
+    if crate::arena::pointer_in_nursery(cur_addr) {
+        HolderDisposition::Drop
+    } else {
+        HolderDisposition::Keep
+    }
 }
 
 /// Full / fallback-cycle weak processing. Walks EVERY live object in the arena
@@ -829,22 +888,32 @@ pub(crate) fn process_weak_targets_from_registry(
     let snapshot: Vec<usize> =
         WEAK_HOLDERS.with(|holders| holders.borrow().iter().copied().collect());
     for addr in snapshot {
-        let Some(current) = (unsafe { resolve_live_holder_copied(ptrs, addr) }) else {
-            // Dead or unclassifiable holder → drop and skip.
-            WEAK_HOLDERS.with(|holders| {
-                holders.borrow_mut().remove(&addr);
-            });
-            continue;
-        };
-        if current != addr {
-            WEAK_HOLDERS.with(|holders| {
-                let mut holders = holders.borrow_mut();
-                holders.remove(&addr);
-                holders.insert(current);
-            });
-        }
-        unsafe {
-            dispatch_weak_holder(current as *mut ObjectHeader, &liveness, enqueue_callbacks);
+        match unsafe { resolve_weak_holder_copied(ptrs, addr) } {
+            HolderDisposition::Drop => {
+                WEAK_HOLDERS.with(|holders| {
+                    holders.borrow_mut().remove(&addr);
+                });
+            }
+            // Live old holder: keep tracking it, but do not process it this
+            // minor (a full GC will). Not dropping keeps a promoted holder from
+            // being forgotten by the registry.
+            HolderDisposition::Keep => {}
+            HolderDisposition::Process(current) => {
+                if current != addr {
+                    WEAK_HOLDERS.with(|holders| {
+                        let mut holders = holders.borrow_mut();
+                        holders.remove(&addr);
+                        holders.insert(current);
+                    });
+                }
+                unsafe {
+                    dispatch_weak_holder(
+                        current as *mut ObjectHeader,
+                        &liveness,
+                        enqueue_callbacks,
+                    );
+                }
+            }
         }
     }
 }

--- a/crates/perry-runtime/src/weakref.rs
+++ b/crates/perry-runtime/src/weakref.rs
@@ -58,23 +58,42 @@ struct PendingFinalizationJob {
 thread_local! {
     static PENDING_FINALIZATION_JOBS: RefCell<Vec<PendingFinalizationJob>> =
         const { RefCell::new(Vec::new()) };
-    /// One-way latch: set the first time this thread allocates a weak
-    /// TARGET holder (WeakRef, WeakMap/WeakSet entry, FinalizationRegistry
-    /// record). The copied-minor fast path consults it to decide whether
-    /// `process_weak_targets_after_mark` (a full arena walk) needs to run —
-    /// programs that never touch weak containers keep the fast path
-    /// walk-free. Never cleared: a dead weak holder costs one redundant
-    /// walk per cycle, which is the price of not tracking deallocation.
-    static WEAK_TARGET_HOLDERS_ALLOCATED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    /// Registry of every live weak-target HOLDER object on this thread — a
+    /// WeakRef (`CLASS_ID_WEAKREF`), a FinalizationRegistry
+    /// (`CLASS_ID_FINALIZATION_REGISTRY`), or a WeakMap/WeakSet entry
+    /// (`CLASS_ID_WEAK_ENTRY`) — keyed by the holder's `ObjectHeader` USER
+    /// address (the same address the copied-minor pointer classifier and the
+    /// arena walk observe). Replaces the old one-way `bool` latch (#6182):
+    ///
+    /// * `weak_target_holders_allocated()` = "registry non-empty", so a
+    ///   program whose only WeakMap died stops paying the copied-minor weak
+    ///   cost once its entries are pruned (the bool latched forever).
+    /// * `process_weak_targets_from_registry` iterates ONLY these holders
+    ///   instead of walking every object in the arena, and classifies weak
+    ///   targets with the copy's O(1) page-metadata classifier instead of a
+    ///   full-heap `build_valid_pointer_set()` BTreeSet.
+    ///
+    /// Currency + pruning: `scan_weak_holders_roots_mut` rewrites stored
+    /// addresses through evacuation without rooting them; the copied-minor
+    /// pass follows forwarding and drops dead holders; the full/fallback
+    /// cycles drop dead holders via `prune_dead_weak_holders`.
+    static WEAK_HOLDERS: RefCell<crate::fast_hash::PtrHashSet<usize>> =
+        RefCell::new(crate::fast_hash::new_ptr_hash_set());
 }
 
-/// See `WEAK_TARGET_HOLDERS_ALLOCATED`.
+/// True while at least one live weak-target holder is registered on this
+/// thread. Gates the copied-minor weak-processing pass (see `WEAK_HOLDERS`).
 pub(crate) fn weak_target_holders_allocated() -> bool {
-    WEAK_TARGET_HOLDERS_ALLOCATED.with(|latch| latch.get())
+    WEAK_HOLDERS.with(|holders| !holders.borrow().is_empty())
 }
 
-fn note_weak_target_holder_allocated() {
-    WEAK_TARGET_HOLDERS_ALLOCATED.with(|latch| latch.set(true));
+/// Register a freshly-allocated weak-target holder by its `ObjectHeader` user
+/// address (called at the WeakRef / FinalizationRegistry / WeakMap-WeakSet
+/// entry alloc sites, after the holder's `class_id` is stamped).
+fn weak_holder_register(holder: *const ObjectHeader) {
+    WEAK_HOLDERS.with(|holders| {
+        holders.borrow_mut().insert(holder as usize);
+    });
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -367,7 +386,7 @@ pub extern "C" fn js_weakref_new(target: f64) -> *mut ObjectHeader {
     unsafe {
         (*obj).class_id = CLASS_ID_WEAKREF;
     }
-    note_weak_target_holder_allocated();
+    weak_holder_register(obj);
     obj
 }
 
@@ -416,6 +435,15 @@ pub extern "C" fn js_finreg_new(callback: f64) -> *mut ObjectHeader {
     unsafe {
         (*obj).class_id = CLASS_ID_FINALIZATION_REGISTRY;
     }
+    // #6182: the FinalizationRegistry itself is the registered holder (not its
+    // per-`register()` records). The copied-minor weak pass dispatches on
+    // `CLASS_ID_FINALIZATION_REGISTRY` and walks the registry's entries array
+    // to reach records — the record has no back-reference to its registry or
+    // cleanup callback, so a record-keyed dispatch could not enqueue the
+    // cleanup job (the #6192 automatic-cycle behavior). A registry that is
+    // created but never `.register()`ed processes an empty entries array (a
+    // cheap no-op) and is pruned when it dies.
+    weak_holder_register(obj);
     obj
 }
 
@@ -450,7 +478,6 @@ fn js_finreg_record_new(target: f64, held: f64, token: f64) -> *mut ObjectHeader
     unsafe {
         (*record).class_id = CLASS_ID_FINALIZATION_RECORD;
     }
-    note_weak_target_holder_allocated();
     record
 }
 
@@ -607,40 +634,302 @@ pub(crate) fn scan_pending_finalization_jobs_roots_mut(
     });
 }
 
+// =============================================================================
+// Weak-target liveness abstraction (#6182)
+// =============================================================================
+//
+// The per-holder tombstone helpers (`process_weakref_after_mark` et al.) are
+// shared between two passes that decide "was this weak target collected?"
+// differently:
+//
+// * The FULL / fallback cycle (`process_weak_targets_after_mark`, driven from
+//   cycle.rs `WeakProcessing`) probes the `ValidPointerSet` it already built
+//   for its main trace. UNCHANGED behavior — see `weak_target_should_clear`.
+// * The copied-minor fast path (`process_weak_targets_from_registry`) probes
+//   the copy's O(1) page-metadata classifier (`CopyingPointerSet`), avoiding
+//   both the full-heap BTreeSet build and the whole-arena walk. See
+//   `weak_target_should_clear_copied`.
+//
+// The helpers are parameterized over `&dyn WeakLiveness` so neither pass's
+// liveness logic can drift from the other's tombstone/enqueue/token semantics.
+
+trait WeakLiveness {
+    /// True when the weak target denoted by `target_bits` was collected and
+    /// its slot must be tombstoned to `undefined`.
+    fn target_should_clear(&self, target_bits: u64) -> bool;
+    /// Resolve `bits` to a LIVE `GC_TYPE_ARRAY` header (a FinalizationRegistry
+    /// entries array), or `None` if dead/not-an-array.
+    ///
+    /// # Safety
+    /// `bits` must be a value word read from a live holder's field.
+    unsafe fn as_live_array(&self, bits: u64) -> Option<*mut ArrayHeader>;
+    /// Resolve `bits` to a LIVE `GC_TYPE_OBJECT` of `class_id` (a
+    /// FinalizationRegistry record), or `None`.
+    ///
+    /// # Safety
+    /// `bits` must be a value word read from a live holder's field.
+    unsafe fn as_live_object_with_class(
+        &self,
+        bits: u64,
+        class_id: u32,
+    ) -> Option<*mut ObjectHeader>;
+}
+
+/// Full / fallback-cycle liveness: the existing `ValidPointerSet`-based
+/// predicates, behavior-identical to pre-#6182 code.
+struct FullCycleLiveness<'a> {
+    valid_ptrs: &'a crate::gc::ValidPointerSet,
+    minor_only: bool,
+}
+
+impl WeakLiveness for FullCycleLiveness<'_> {
+    fn target_should_clear(&self, target_bits: u64) -> bool {
+        weak_target_should_clear(target_bits, self.valid_ptrs, self.minor_only)
+    }
+    unsafe fn as_live_array(&self, bits: u64) -> Option<*mut ArrayHeader> {
+        object_value_to_array(bits, self.valid_ptrs)
+    }
+    unsafe fn as_live_object_with_class(
+        &self,
+        bits: u64,
+        class_id: u32,
+    ) -> Option<*mut ObjectHeader> {
+        object_value_with_class(bits, self.valid_ptrs, class_id)
+    }
+}
+
+/// Copied-minor liveness: probe the copy's page-metadata classifier. Callers
+/// pass value words that have ALREADY been made current — weak target slots by
+/// `repair_weak_slots`, holder strong fields (entries array, records) by the
+/// collector's evacuation rewrite — so this does not itself follow forwarding.
+struct CopiedMinorLiveness<'a> {
+    ptrs: &'a crate::gc::CopyingPointerSet,
+}
+
+impl WeakLiveness for CopiedMinorLiveness<'_> {
+    fn target_should_clear(&self, target_bits: u64) -> bool {
+        weak_target_should_clear_copied(target_bits, self.ptrs)
+    }
+    unsafe fn as_live_array(&self, bits: u64) -> Option<*mut ArrayHeader> {
+        classify_live_gc_type(bits, self.ptrs, crate::gc::GC_TYPE_ARRAY)
+            .map(|ptr| ptr as *mut ArrayHeader)
+    }
+    unsafe fn as_live_object_with_class(
+        &self,
+        bits: u64,
+        class_id: u32,
+    ) -> Option<*mut ObjectHeader> {
+        let ptr = classify_live_gc_type(bits, self.ptrs, crate::gc::GC_TYPE_OBJECT)?;
+        let obj = ptr as *mut ObjectHeader;
+        ((*obj).class_id == class_id).then_some(obj)
+    }
+}
+
+/// Copied-minor twin of `weak_target_should_clear`. A weak target is collected
+/// iff it is a REAL heap object the classifier can attribute and that object is
+/// not live (MARKED|PINNED). The key correctness difference from the
+/// `ValidPointerSet` predicate: a classifier miss (`None`) means "not a
+/// collectible heap object" — a handle-band id (Proxy / node:http / fetch /
+/// Web-Stream) or any non-heap pointer — so we KEEP it. The old predicate
+/// treated "not in valid_ptrs" as dead, which FALSE-tombstoned live handle-band
+/// weak keys ≥0x1000 on the first GC (2026-07-09 audit §8); this path fixes it.
+fn weak_target_should_clear_copied(
+    target_bits: u64,
+    ptrs: &crate::gc::CopyingPointerSet,
+) -> bool {
+    if target_bits == TAG_UNDEFINED {
+        return false;
+    }
+    let target = f64::from_bits(target_bits);
+    if crate::value::is_js_handle(target) {
+        return false;
+    }
+    let Some(ptr) = heap_ptr_from_tagged_bits(target_bits) else {
+        return false;
+    };
+    match ptrs.classify(ptr) {
+        // Band-id handle / non-heap pointer → not collectible → keep.
+        None => false,
+        // Real heap object → dead iff not MARKED|PINNED.
+        Some(cp) => unsafe { !header_is_live(cp.header) },
+    }
+}
+
+/// Resolve `bits` to a live heap object of `obj_type` using the copied-minor
+/// classifier, without following forwarding (the caller's fields are already
+/// current). Returns the user address, or `None` if dead / wrong type.
+unsafe fn classify_live_gc_type(
+    bits: u64,
+    ptrs: &crate::gc::CopyingPointerSet,
+    obj_type: u8,
+) -> Option<usize> {
+    let ptr = heap_ptr_from_tagged_bits(bits)?;
+    let cp = ptrs.classify(ptr)?;
+    if !header_is_live(cp.header) {
+        return None;
+    }
+    (unsafe { (*cp.header).obj_type } == obj_type).then_some(ptr)
+}
+
+/// Follow a registered holder address to its current (post-evacuation)
+/// location and confirm the holder is live. Returns the current user address,
+/// or `None` when the holder is dead (unmarked, un-forwarded) or the address
+/// is no longer classifiable (stale / recycled). Copied-minor only: it reads
+/// pre-flip from-space headers, so the FORWARDED bit and the forwarding
+/// address are still valid.
+unsafe fn resolve_live_holder_copied(
+    ptrs: &crate::gc::CopyingPointerSet,
+    addr: usize,
+) -> Option<usize> {
+    let cp = ptrs.classify(addr)?;
+    if (*cp.header).gc_flags & crate::gc::GC_FLAG_FORWARDED != 0 {
+        let fwd = crate::gc::forwarding_address(cp.header) as usize;
+        let cp2 = ptrs.classify(fwd)?;
+        return header_is_live(cp2.header).then_some(fwd);
+    }
+    header_is_live(cp.header).then_some(addr)
+}
+
+/// Full / fallback-cycle weak processing. Walks EVERY live object in the arena
+/// to find the three weak-holder class_ids and tombstones dead weak targets
+/// using the `ValidPointerSet` the caller built for its main trace. UNCHANGED
+/// by #6182 (the registry optimization is copied-minor-only).
 pub(crate) fn process_weak_targets_after_mark(
     valid_ptrs: &crate::gc::ValidPointerSet,
     minor_only: bool,
     enqueue_callbacks: bool,
 ) {
+    let liveness = FullCycleLiveness {
+        valid_ptrs,
+        minor_only,
+    };
     crate::arena::arena_walk_objects(|header_ptr| unsafe {
         let header = header_ptr as *mut crate::gc::GcHeader;
         if (*header).obj_type != crate::gc::GC_TYPE_OBJECT || !header_is_live(header) {
             return;
         }
         let obj = header_ptr.add(crate::gc::GC_HEADER_SIZE) as *mut ObjectHeader;
-        match (*obj).class_id {
-            CLASS_ID_WEAKREF => process_weakref_after_mark(obj, valid_ptrs, minor_only),
-            CLASS_ID_FINALIZATION_REGISTRY => {
-                process_finreg_after_mark(obj, valid_ptrs, minor_only, enqueue_callbacks);
+        dispatch_weak_holder(obj, &liveness, enqueue_callbacks);
+    });
+}
+
+/// Copied-minor weak processing (#6182). Iterates ONLY the registered holders
+/// — following each through evacuation and dropping dead ones — instead of
+/// walking the whole arena, and tombstones dead weak targets with the O(1)
+/// page-metadata classifier instead of a full-heap valid-pointer BTreeSet.
+///
+/// Runs at the copied-minor completion point AFTER `repair_weak_slots` and
+/// BEFORE the from-space flip, so weak target slots and holder strong fields
+/// are already current and dead holders' from-space headers are still intact.
+pub(crate) fn process_weak_targets_from_registry(
+    ptrs: &crate::gc::CopyingPointerSet,
+    enqueue_callbacks: bool,
+) {
+    let liveness = CopiedMinorLiveness { ptrs };
+    // Snapshot addresses so the registry can be mutated (rekey moved holders,
+    // drop dead ones) while iterating. Holders don't allocate GC objects in
+    // the helpers below, so no re-entrant `WEAK_HOLDERS` borrow occurs.
+    let snapshot: Vec<usize> = WEAK_HOLDERS.with(|holders| holders.borrow().iter().copied().collect());
+    for addr in snapshot {
+        let Some(current) = (unsafe { resolve_live_holder_copied(ptrs, addr) }) else {
+            // Dead or unclassifiable holder → drop and skip.
+            WEAK_HOLDERS.with(|holders| {
+                holders.borrow_mut().remove(&addr);
+            });
+            continue;
+        };
+        if current != addr {
+            WEAK_HOLDERS.with(|holders| {
+                let mut holders = holders.borrow_mut();
+                holders.remove(&addr);
+                holders.insert(current);
+            });
+        }
+        unsafe {
+            dispatch_weak_holder(current as *mut ObjectHeader, &liveness, enqueue_callbacks);
+        }
+    }
+}
+
+/// Dispatch a single live weak holder (WeakRef / FinalizationRegistry /
+/// WeakMap-WeakSet entry) to its tombstone helper. Shared by both passes; the
+/// liveness strategy is the only thing that differs.
+#[inline]
+unsafe fn dispatch_weak_holder(
+    obj: *mut ObjectHeader,
+    liveness: &dyn WeakLiveness,
+    enqueue_callbacks: bool,
+) {
+    match (*obj).class_id {
+        CLASS_ID_WEAKREF => process_weakref_after_mark(obj, liveness),
+        CLASS_ID_FINALIZATION_REGISTRY => {
+            process_finreg_after_mark(obj, liveness, enqueue_callbacks)
+        }
+        // Each WeakMap/WeakSet entry is its own GcHeader-backed object; the
+        // weak key slot's address is repaired by the copy/rewrite pass before
+        // this pass reads it.
+        CLASS_ID_WEAK_ENTRY => process_weak_entry_after_mark(obj, liveness),
+        _ => {}
+    }
+}
+
+/// Mutable-root scanner keeping the `WEAK_HOLDERS` addresses current across
+/// evacuation (#6182). Metadata-only: `visit_metadata_usize_slot` rewrites a
+/// forwarded address in rewrite/verify phases and emits NOTHING during mark, so
+/// registering this scanner never keeps a dead holder alive. Copied-minor
+/// currency is handled independently by `process_weak_targets_from_registry`
+/// (the GC test harness clears the scanner registry); this covers full-cycle
+/// evacuation, where the registered scanners ARE the rewrite mechanism.
+pub(crate) fn scan_weak_holders_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    if !visitor.is_metadata_rewrite_phase() {
+        return;
+    }
+    WEAK_HOLDERS.with(|holders| {
+        let mut holders = holders.borrow_mut();
+        if holders.is_empty() {
+            return;
+        }
+        // Rebuild only when an address actually moved — a `HashSet` can't
+        // rewrite keys in place. Mirrors `scan_descriptor_roots_mut`.
+        let needs_rebuild = holders
+            .iter()
+            .any(|&addr| rewritten_holder_addr(visitor, addr) != addr);
+        if needs_rebuild {
+            let old = std::mem::take(&mut *holders);
+            let mut rebuilt = crate::fast_hash::new_ptr_hash_set();
+            for addr in old {
+                rebuilt.insert(rewritten_holder_addr(visitor, addr));
             }
-            // Each WeakMap/WeakSet entry is its own GcHeader-backed object, so
-            // the arena walk reaches it directly — exactly like a WeakRef. This
-            // mirrors the `CLASS_ID_WEAKREF` arm (which is correct under
-            // evacuation): the weak key slot's address is repaired by the
-            // copy/rewrite pass before this pass reads it.
-            CLASS_ID_WEAK_ENTRY => process_weak_entry_after_mark(obj, valid_ptrs, minor_only),
-            _ => {}
+            *holders = rebuilt;
         }
     });
 }
 
-unsafe fn process_weakref_after_mark(
-    obj: *mut ObjectHeader,
-    valid_ptrs: &crate::gc::ValidPointerSet,
-    minor_only: bool,
-) {
+#[inline]
+fn rewritten_holder_addr(visitor: &mut crate::gc::RuntimeRootVisitor<'_>, addr: usize) -> usize {
+    let mut a = addr;
+    visitor.visit_metadata_usize_slot(&mut a);
+    a
+}
+
+/// Drop dead weak holders from the registry (#6182). Used by the full /
+/// fallback (non-copying) cycles via `dead_owner::prune_dead_owner_side_tables_post_trace`;
+/// the copied-minor path prunes inline in `process_weak_targets_from_registry`.
+/// Keeping the registry pruned lets `weak_target_holders_allocated()` return to
+/// zero once a transient WeakMap and its entries die.
+pub(crate) fn prune_dead_weak_holders(is_dead: &dyn Fn(usize) -> bool) {
+    WEAK_HOLDERS.with(|holders| {
+        let mut holders = holders.borrow_mut();
+        if holders.is_empty() {
+            return;
+        }
+        holders.retain(|&addr| !is_dead(addr));
+    });
+}
+
+unsafe fn process_weakref_after_mark(obj: *mut ObjectHeader, liveness: &dyn WeakLiveness) {
     let target_bits = object_field_bits(obj, WEAKREF_TARGET_FIELD);
-    if weak_target_should_clear(target_bits, valid_ptrs, minor_only) {
+    if liveness.target_should_clear(target_bits) {
         write_object_field_bits_raw(obj, WEAKREF_TARGET_FIELD, TAG_UNDEFINED);
     }
 }
@@ -650,13 +939,9 @@ unsafe fn process_weakref_after_mark(
 /// collectible (next cycle) and the lookups skip the slot. The entry object
 /// itself is reclaimed when `delete`/`set` next compacts the entries array (or
 /// when the whole collection dies). Mirrors `process_weakref_after_mark`.
-unsafe fn process_weak_entry_after_mark(
-    entry: *mut ObjectHeader,
-    valid_ptrs: &crate::gc::ValidPointerSet,
-    minor_only: bool,
-) {
+unsafe fn process_weak_entry_after_mark(entry: *mut ObjectHeader, liveness: &dyn WeakLiveness) {
     let key_bits = object_field_bits(entry, WEAK_ENTRY_KEY_FIELD);
-    if weak_target_should_clear(key_bits, valid_ptrs, minor_only) {
+    if liveness.target_should_clear(key_bits) {
         write_object_field_bits_raw(entry, WEAK_ENTRY_KEY_FIELD, TAG_UNDEFINED);
         write_object_field_bits_raw(entry, WEAK_ENTRY_VALUE_FIELD, TAG_UNDEFINED);
     }
@@ -664,32 +949,28 @@ unsafe fn process_weak_entry_after_mark(
 
 unsafe fn process_finreg_after_mark(
     registry: *mut ObjectHeader,
-    valid_ptrs: &crate::gc::ValidPointerSet,
-    minor_only: bool,
+    liveness: &dyn WeakLiveness,
     enqueue_callbacks: bool,
 ) {
     let callback = f64::from_bits(object_field_bits(registry, FINREG_CALLBACK_FIELD));
     let entries_bits = object_field_bits(registry, FINREG_ENTRIES_FIELD);
-    let Some(entries) = object_value_to_array(entries_bits, valid_ptrs) else {
+    let Some(entries) = liveness.as_live_array(entries_bits) else {
         return;
     };
     let len = js_array_length(entries) as usize;
     let registry_value = f64::from_bits(JSValue::pointer(registry as *const u8).bits());
     for i in 0..len {
         let record_value = js_array_get_f64(entries, i as u32);
-        let Some(record) = object_value_with_class(
-            record_value.to_bits(),
-            valid_ptrs,
-            CLASS_ID_FINALIZATION_RECORD,
-        ) else {
+        let Some(record) =
+            liveness.as_live_object_with_class(record_value.to_bits(), CLASS_ID_FINALIZATION_RECORD)
+        else {
             continue;
         };
         process_finreg_record_after_mark(
             registry_value,
             record,
             callback,
-            valid_ptrs,
-            minor_only,
+            liveness,
             enqueue_callbacks,
         );
     }
@@ -699,13 +980,12 @@ unsafe fn process_finreg_record_after_mark(
     registry: f64,
     record: *mut ObjectHeader,
     callback: f64,
-    valid_ptrs: &crate::gc::ValidPointerSet,
-    minor_only: bool,
+    liveness: &dyn WeakLiveness,
     enqueue_callbacks: bool,
 ) {
     let pending_bits = object_field_bits(record, FINREG_RECORD_PENDING_FIELD);
     let target_bits = object_field_bits(record, FINREG_RECORD_TARGET_FIELD);
-    let collected = weak_target_should_clear(target_bits, valid_ptrs, minor_only);
+    let collected = liveness.target_should_clear(target_bits);
     if collected {
         write_object_field_bits_raw(record, FINREG_RECORD_TARGET_FIELD, TAG_UNDEFINED);
         write_object_field_bits_raw(record, FINREG_RECORD_PENDING_FIELD, TAG_TRUE);
@@ -715,7 +995,7 @@ unsafe fn process_finreg_record_after_mark(
     // the record can't resurrect the token graph. Independent of the target —
     // spec: clearing [[UnregisterToken]] does not cancel the registration.
     let token_bits = object_field_bits(record, FINREG_RECORD_TOKEN_FIELD);
-    if weak_target_should_clear(token_bits, valid_ptrs, minor_only) {
+    if liveness.target_should_clear(token_bits) {
         write_object_field_bits_raw(record, FINREG_RECORD_TOKEN_FIELD, TAG_UNDEFINED);
     }
 
@@ -842,7 +1122,7 @@ fn weak_entry_new(key: f64, value: f64) -> *mut ObjectHeader {
     unsafe {
         (*entry).class_id = CLASS_ID_WEAK_ENTRY;
     }
-    note_weak_target_holder_allocated();
+    weak_holder_register(entry);
     entry
 }
 


### PR DESCRIPTION
## Problem (#6182)

Once **any** weak-target holder (a `WeakRef`, a `FinalizationRegistry`, or a
`WeakMap`/`WeakSet` entry) is ever allocated, the old one-way
`WEAK_TARGET_HOLDERS_ALLOCATED` bool latched **forever**, and every subsequent
copied-minor cycle then paid **two O(all-objects) passes**:

1. `build_valid_pointer_set()` — a full-heap `BTreeSet` of every object in every
   arena.
2. `process_weak_targets_after_mark` → `arena_walk_objects(...)` — a walk over
   **every** live object just to find the three weak-holder `class_id`s.

React / Effect / most polyfills allocate one module-lifetime `WeakMap` at init,
so a single weak container permanently forfeited the copied minor's O(survivors)
design goal (2026-07-09 GC audit `fable-audit-perry-gc.md` §7/§8).

## Fix — a live-holder registry + classifier liveness (copied-minor only)

**Registry.** A per-thread `WEAK_HOLDERS: RefCell<PtrHashSet<usize>>` stores the
`ObjectHeader` user address of each live holder, inserted at the three alloc
sites. The latch `weak_target_holders_allocated()` becomes "registry non-empty",
so a program whose only `WeakMap` dies stops paying the cost once its entries are
pruned.

**Eliminated cost #1 — the whole-arena walk.**
`process_weak_targets_from_registry` iterates only the registered holders instead
of `arena_walk_objects`.

**Eliminated cost #2 — the full-heap `BTreeSet`.** Weak-target liveness is
decided with the copy's existing **O(1) page-metadata classifier**
(`CopyingPointerSet::classify`) — `build_valid_pointer_set()` is gone from this
path.

**Incidental correctness fix (this path).** `weak_target_should_clear_copied`
reads a classifier miss as "not a collectible heap object" (a handle-band id —
Proxy / node:http / fetch / Web-Stream — or any non-heap pointer) and **keeps**
the key. The old `valid_ptrs`-based predicate read "not in valid_ptrs" as "dead"
and **false-tombstoned** live handle-band weak keys ≥0x1000 on the first GC
(audit §8).

**Address currency + pruning.**
- `scan_weak_holders_roots_mut` (registered in `gc_init`) rewrites stored holder
  addresses through evacuation **without rooting** them — metadata-only
  (`visit_metadata_usize_slot`), emits nothing during mark — mirroring
  `scan_descriptor_roots_mut`. Covers full-cycle currency.
- The copied-minor pass additionally **follows forwarding itself** and rekeys the
  registry in place, so it is correct even where the scanner does not run (the GC
  test harness clears `MUTABLE_ROOT_SCANNERS`).
- Full/fallback cycles drop dead holders via `prune_dead_weak_holders`, wired
  into `dead_owner::prune_dead_owner_side_tables_post_trace`.

**The full-cycle path is untouched.** cycle.rs `WeakProcessing` still calls
`process_weak_targets_after_mark` with the valid-pointer set it already built for
its main trace. The three tombstone helpers are shared between the two passes via
a `WeakLiveness` trait, so their tombstone / finreg-enqueue / unregister-token
semantics cannot drift. FinalizationRegistry callback enqueue on every automatic
cycle (#6192) and the FIFO/token semantics are preserved.

Note: the FinalizationRegistry holder registered is the registry object itself
(not its per-`register()` records) — the record has no back-reference to its
registry or callback, so a record-keyed dispatch could not enqueue the cleanup
job. This keeps the three dispatch `class_id`s aligned with the shared helpers.

## Tests

New `gc/tests/copying/weak_holder_registry.rs` (6 tests, each forcing a real
moving copied-minor): dead-vs-live WeakMap key, dead-vs-live WeakRef target,
handle-band-key regression guard, latch-clears-after-transient-WeakMap-dies,
cross-cycle registry currency across three moving minors, and FinalizationRegistry
enqueue-once via the registry pass. `cargo test -p perry-runtime --lib
--test-threads=1` → `0 failed` (1209 passed); all existing weakref/weak-semantics
and dead_owner tests unchanged.

Refs #6182; 2026-07-09 GC audit `fable-audit-perry-gc.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed weak-reference and FinalizationRegistry processing during moving minor garbage collections.
  * Prevented incorrect tombstoning and ensured weak-map/weak-ref entries are rewritten to evacuated targets.
  * Improved weak-holder bookkeeping so cleanup jobs enqueue and reset correctly, including after transient weak containers are collected.
  * Added regression coverage for copied-minor weak processing across multiple evacuation cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->