### PR TITLE
fix(runtime): root promises tracked for unhandled rejection (UAF) (#6077)

### DIFF
--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -474,6 +474,9 @@ pub fn gc_init() {
     gc_register_mutable_root_scanner(crate::process::scan_process_finalization_roots_mut);
     gc_register_mutable_root_scanner(crate::process::scan_process_module_loader_roots_mut);
     gc_register_mutable_root_scanner(crate::os::scan_process_event_listener_roots_mut);
+    // #6077: keep promises tracked for an unhandled rejection alive + address-
+    // stable until reported, so the program-end report is not a stale/UAF read.
+    gc_register_mutable_root_scanner(crate::promise::scan_unhandled_rejection_roots_mut);
     gc_register_mutable_root_scanner(crate::os::scan_process_stream_singleton_roots_mut);
     gc_register_mutable_root_scanner(crate::fs::scan_fs_handle_roots_mut);
     gc_register_mutable_root_scanner(crate::fs::scan_fs_stream_roots_mut);

--- a/crates/perry-runtime/src/promise/mod.rs
+++ b/crates/perry-runtime/src/promise/mod.rs
@@ -82,6 +82,7 @@ pub use then::{
     js_promise_mark_internally_handled, js_promise_new, js_promise_new_cross_thread,
     js_promise_reason, js_promise_reject, js_promise_resolve, js_promise_resolve_with_promise,
     js_promise_result, js_promise_state, js_promise_then, js_promise_value,
+    scan_unhandled_rejection_roots_mut,
 };
 
 #[cfg(test)]

--- a/crates/perry-runtime/src/promise/then.rs
+++ b/crates/perry-runtime/src/promise/then.rs
@@ -117,6 +117,25 @@ pub(crate) fn mark_rejection_handled(promise: *mut Promise) {
     });
 }
 
+/// GC root scanner for `UNHANDLED_REJECTIONS` (#6077). The set stores raw
+/// promise addresses. A regular promise is allocated in the MOVABLE arena
+/// (`js_promise_new_with_parent_impl`), so without this scanner a tracked
+/// promise could be swept or evacuated before the program-end report — making
+/// `js_promise_report_unhandled_rejections`'s `(*pr).state` / `(*pr).reason`
+/// deref a stale/use-after-free read (arena pages stay mapped, so a silent
+/// misreport is likelier than a hard fault). Visiting each address marks the
+/// promise live AND rewrites the stored pointer on evacuation, so the report
+/// always sees a valid promise. Entries are removed (and thus unrooted) as soon
+/// as a reaction is wired (`mark_rejection_handled`) or the promise settles
+/// handled, so this never keeps a genuinely-dead promise alive past its report.
+pub fn scan_unhandled_rejection_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    UNHANDLED_REJECTIONS.with(|m| {
+        for slot in m.borrow_mut().iter_mut() {
+            visitor.visit_usize_slot(slot);
+        }
+    });
+}
+
 /// Program-end hook (emitted by codegen's event-loop exit block, after the
 /// final microtask/timer drain). If any rejection went unhandled, mirror Node:
 /// print to stderr and exit with a non-zero code.


### PR DESCRIPTION
## Summary

The unhandled-rejection tracking set (`UNHANDLED_REJECTIONS`, `promise/then.rs`) stores raw promise addresses but had **no GC root scanner**. A regular promise is allocated in the **movable arena**, so a tracked promise could be swept or evacuated before the program-end report — at which point `js_promise_report_unhandled_rejections` dereferences `(*pr).state` / `(*pr).reason` through a **stale/forwarded pointer** (a use-after-free). Arena pages stay mapped, so it reads a recycled promise (silent misreport / wrong reason) more often than it hard-faults.

Addresses the memory-safety half of #6077 (the "latent UAF" the issue flags).

## Fix

Register `scan_unhandled_rejection_roots_mut` as a mutable GC root scanner (mirroring the ~55 existing side-table scanners). It visits each tracked address with `visit_usize_slot`, which **marks the promise live** and **rewrites the stored pointer on evacuation**. Entries are already removed the moment a reaction is wired (`mark_rejection_handled`) or the promise settles handled, so this never keeps a dead promise alive past its own report.

## Validation

- Under `PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1` (panics if a live slot still points at a forwarded object): a distinctive unhandled rejection driven through heavy allocation reports its **exact** reason, no panic, no corruption. Multi-rejection stress likewise clean.
- 25 promise/async gap tests green; normal `resolve`/`reject`/`await` behavior unchanged.
- `cargo fmt` + GC store-site inventory clean.

## Scope note

This is the **memory-safety** half. The other two parts of #6077 — end-of-turn reporting timing (so a late `.catch` no longer suppresses) and the `process.on('unhandledRejection'/'rejectionHandled')` emitter — are a **behavior change** with real blast radius on rejection semantics (default-crash-on-unhandled), so they're left as a documented follow-up rather than bundled into this UAF fix.

Code-only per contributor convention (no version/CHANGELOG bump).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unhandled promise rejections so tracked promise data stays valid until final reporting.
  * Reduced the risk of missing or stale rejection details at program end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->