### PR TITLE
feat(ui): wire GC pump-step + OS memory-pressure into non-macOS hosts (#6183, #6184)

### DIFF
--- a/crates/perry-ui-android/src/app.rs
+++ b/crates/perry-ui-android/src/app.rs
@@ -162,6 +162,10 @@ extern "C" {
     fn js_interval_timer_tick() -> i32;
     fn js_promise_run_microtasks() -> i32;
     fn js_frame_pump_default() -> i32;
+    // perry-runtime's embedder GC stepper: spends up to `budget_us`
+    // advancing an ACTIVE budgeted collection in bounded work units; a
+    // cheap status probe when no cycle is active (out=null is allowed).
+    fn js_gc_step_us(budget_us: u64, out: *mut u8) -> u32;
 }
 
 /// Start the timer pump that drives setInterval/setTimeout/Promise callbacks.
@@ -228,6 +232,13 @@ pub extern "C" fn Java_com_perry_app_PerryBridge_nativePumpTick(
         // the same 8ms pump drives one-shot frame callbacks.
         js_frame_pump_default();
         js_promise_run_microtasks();
+        // #6183 (2026-07-09 GC audit): spend a bounded idle budget on any
+        // active budgeted GC cycle at the pump boundary — the JS stack is
+        // fully unwound here, so this is a precise-root safepoint. A 2 ms
+        // slice per 8 ms tick drains collection debt incrementally instead of
+        // letting an alloc-point collection land unbounded on this (UI)
+        // thread mid-interaction.
+        js_gc_step_us(2_000, std::ptr::null_mut());
     }
     // perry/media (#351) — drive state polling on the UI thread so the
     // PLAYERS thread_local stays consistent with where create_player

--- a/crates/perry-ui-android/src/lib.rs
+++ b/crates/perry-ui-android/src/lib.rs
@@ -198,6 +198,27 @@ pub extern "C" fn Java_com_perry_app_PerryBridge_nativeShutdown(
     app::signal_shutdown();
 }
 
+/// OS memory-pressure bridge (#6184). PerryActivity.onLowMemory() /
+/// onTrimMemory(level) forward here (see PerryBridge.nativeMemoryPressure):
+/// `onLowMemory` and the severe `onTrimMemory` levels map to `2` (full
+/// collect + trigger clamp), lighter trims to `1` (minor collect). Runs on
+/// the Activity's main thread, which owns the JS arena.
+#[no_mangle]
+pub extern "C" fn Java_com_perry_app_PerryBridge_nativeMemoryPressure(
+    _env: jni::JNIEnv,
+    _class: jni::objects::JClass,
+    level: jni::sys::jint,
+) {
+    extern "C" {
+        // perry-runtime's OS-memory-pressure entry point: level 1 =
+        // collect-if-safe (minor), level 2+ = full collect + clamp trigger.
+        fn js_gc_memory_pressure(level: u32) -> u32;
+    }
+    unsafe {
+        js_gc_memory_pressure(level as u32);
+    }
+}
+
 #[cfg(not(test))]
 extern "C" {
     fn main() -> i32;

--- a/crates/perry-ui-android/template/app/src/main/java/com/perry/app/PerryActivity.kt
+++ b/crates/perry-ui-android/template/app/src/main/java/com/perry/app/PerryActivity.kt
@@ -1,6 +1,7 @@
 package com.perry.app
 
 import android.app.Activity
+import android.content.ComponentCallbacks2
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
@@ -195,6 +196,39 @@ class PerryActivity : Activity() {
     override fun onLowMemory() {
         super.onLowMemory()
         PerryBridge.forwardMapsLifecycle("lowMemory")
+        // #6184: a system low-memory notice is the last warning before the
+        // low-memory killer targets us → force a full collect + trigger clamp.
+        forwardMemoryPressure(2)
+    }
+
+    override fun onTrimMemory(level: Int) {
+        super.onTrimMemory(level)
+        // #6184 (2026-07-09 GC audit): map Android trim levels onto the GC
+        // memory-pressure API. RUNNING_CRITICAL (imminent kill while running)
+        // and COMPLETE / MODERATE (background, high reclaim priority) are the
+        // severe levels → full collect + trigger clamp (2). Every lighter
+        // trim (RUNNING_LOW / RUNNING_MODERATE / BACKGROUND / UI_HIDDEN) is
+        // advisory → minor collect (1). The constants aren't monotonic by
+        // severity, so match the severe set explicitly rather than by range.
+        val pressure = when (level) {
+            ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL,
+            ComponentCallbacks2.TRIM_MEMORY_COMPLETE,
+            ComponentCallbacks2.TRIM_MEMORY_MODERATE -> 2
+            else -> 1
+        }
+        forwardMemoryPressure(pressure)
+    }
+
+    /// Forward an OS memory-pressure signal to the native GC. Guarded against
+    /// UnsatisfiedLinkError because a warning can arrive before the native
+    /// library finishes loading (permission gate / cold start).
+    private fun forwardMemoryPressure(level: Int) {
+        try {
+            PerryBridge.nativeMemoryPressure(level)
+        } catch (_: UnsatisfiedLinkError) {
+            // Native library not loaded yet — the arena isn't live, nothing
+            // to collect.
+        }
     }
 
     override fun onDestroy() {

--- a/crates/perry-ui-android/template/app/src/main/java/com/perry/app/PerryBridge.kt
+++ b/crates/perry-ui-android/template/app/src/main/java/com/perry/app/PerryBridge.kt
@@ -1530,6 +1530,13 @@ object PerryBridge {
     @JvmStatic
     external fun nativePumpTick()
 
+    // #6184 (2026-07-09 GC audit): OS memory-pressure → GC bridge.
+    // PerryActivity.onLowMemory() / onTrimMemory(level) forward here. Level
+    // 1 = minor (collect-if-safe), level 2 = critical (full collect + clamp
+    // the arena trigger).
+    @JvmStatic
+    external fun nativeMemoryPressure(level: Int)
+
     @JvmStatic
     external fun nativeInvokeCallback0(key: Long)
 

--- a/crates/perry-ui-gtk4/src/app.rs
+++ b/crates/perry-ui-gtk4/src/app.rs
@@ -81,6 +81,10 @@ extern "C" {
     fn js_interval_timer_tick() -> i32;
     fn js_run_ext_pump();
     fn js_frame_pump_default() -> i32;
+    // perry-runtime's embedder GC stepper: spends up to `budget_us`
+    // advancing an ACTIVE budgeted collection in bounded work units; a
+    // cheap status probe when no cycle is active (out=null is allowed).
+    fn js_gc_step_us(budget_us: u64, out: *mut u8) -> u32;
 }
 
 /// Extract a &str from a *const StringHeader pointer.
@@ -332,6 +336,13 @@ pub fn app_run(_app_handle: i64) {
                 js_run_ext_pump();
                 js_run_stdlib_pump();
                 js_promise_run_microtasks();
+                // #6183 (2026-07-09 GC audit): spend a bounded idle budget
+                // on any active budgeted GC cycle at the pump boundary — the
+                // JS stack is fully unwound here, so this is a precise-root
+                // safepoint. A 2 ms slice per tick drains collection debt
+                // incrementally instead of letting an alloc-point collection
+                // land unbounded on this (main/UI) thread mid-interaction.
+                js_gc_step_us(2_000, std::ptr::null_mut());
             }
             glib::ControlFlow::Continue
         });

--- a/crates/perry-ui-ios/src/app.rs
+++ b/crates/perry-ui-ios/src/app.rs
@@ -97,6 +97,17 @@ define_class!(
             true
         }
 
+        /// UIKit memory-warning delivery (#6184). This is the last notice
+        /// before jetsam terminates the app, so treat it as critical: force a
+        /// full collect and clamp the GC trigger. Runs on the main thread,
+        /// which owns the JS arena, so calling into the runtime here is safe.
+        #[unsafe(method(applicationDidReceiveMemoryWarning:))]
+        fn application_did_receive_memory_warning(&self, _application: &AnyObject) {
+            unsafe {
+                js_gc_memory_pressure(2);
+            }
+        }
+
         /// APNs handed us a device token (#95). Hex-format it and call the
         /// closure passed to `notificationRegisterRemote`.
         #[unsafe(method(application:didRegisterForRemoteNotificationsWithDeviceToken:))]
@@ -610,6 +621,15 @@ extern "C" {
     fn js_callback_timer_tick() -> i32;
     fn js_interval_timer_tick() -> i32;
     fn js_frame_pump_default() -> i32;
+    // perry-runtime's embedder GC stepper: spends up to `budget_us`
+    // advancing an ACTIVE budgeted collection in bounded work units; a
+    // cheap status probe when no cycle is active (out=null is allowed).
+    fn js_gc_step_us(budget_us: u64, out: *mut u8) -> u32;
+    // perry-runtime's OS-memory-pressure entry point (#6184): level 1 =
+    // collect-if-safe (minor), level 2+ = full collect + clamp trigger.
+    // Always lowers+arms the arena trigger so an unsafe delivery still
+    // collects at the next allocation.
+    fn js_gc_memory_pressure(level: u32) -> u32;
 }
 
 // ============================================
@@ -639,6 +659,14 @@ define_class!(
                     // this, `await fetch(...)` never resolves on iOS — the
                     // macOS pump has always called it; iOS omitted it.
                     js_run_stdlib_pump();
+                    // #6183 (2026-07-09 GC audit): spend a bounded idle
+                    // budget on any active budgeted GC cycle at the pump
+                    // boundary — the JS stack is fully unwound here, so this
+                    // is a precise-root safepoint. A 2 ms slice per tick
+                    // drains collection debt incrementally instead of letting
+                    // an alloc-point collection land unbounded on this
+                    // (main/UI) thread mid-interaction.
+                    js_gc_step_us(2_000, std::ptr::null_mut());
                     #[cfg(feature = "geisterhand")]
                     {
                         extern "C" { fn perry_geisterhand_pump(); }

--- a/crates/perry-ui-macos/src/app.rs
+++ b/crates/perry-ui-macos/src/app.rs
@@ -395,6 +395,11 @@ pub fn app_run(_app_handle: i64) {
     // Install crash reporting hooks before anything else
     crate::crash_log::install_crash_hooks();
 
+    // #6184 (2026-07-09 GC audit): install a libdispatch memory-pressure
+    // source on the main queue so the runtime can collect under OS memory
+    // pressure (WARN → minor, CRITICAL → full collect). See memory_pressure.rs.
+    crate::memory_pressure::install();
+
     // Phase 2 v3.3: register cross-platform showToast / setText handlers.
     // These are no-ops on harmonyos (where the ArkUI drain-queue path
     // owns the dispatch) but on macOS they wire `perry_arkts_show_toast`

--- a/crates/perry-ui-macos/src/lib.rs
+++ b/crates/perry-ui-macos/src/lib.rs
@@ -12,6 +12,7 @@ pub mod image_picker;
 pub mod keychain;
 pub mod location;
 pub mod media_playback;
+pub mod memory_pressure;
 pub mod menu;
 pub mod network;
 pub mod notifications;

--- a/crates/perry-ui-macos/src/memory_pressure.rs
+++ b/crates/perry-ui-macos/src/memory_pressure.rs
@@ -1,0 +1,111 @@
+//! OS memory-pressure → GC bridge for macOS (#6184, 2026-07-09 GC audit).
+//!
+//! AppKit has no `applicationDidReceiveMemoryWarning:` analog; the system-wide
+//! signal is libdispatch's `DISPATCH_SOURCE_TYPE_MEMORYPRESSURE`. We install a
+//! source on the **main** queue (the thread that owns the JS arena and precise
+//! GC roots) at app startup and forward the pressure level to the runtime:
+//!
+//!   - `DISPATCH_MEMORYPRESSURE_WARN`     → `js_gc_memory_pressure(1)` (minor).
+//!   - `DISPATCH_MEMORYPRESSURE_CRITICAL` → `js_gc_memory_pressure(2)` (full
+//!     collect + trigger clamp).
+//!
+//! libdispatch is part of libSystem, so the C symbols below resolve at the
+//! final link of any Perry-produced macOS binary without an extra crate.
+
+use std::ffi::c_void;
+use std::os::raw::c_ulong;
+use std::sync::atomic::{AtomicPtr, Ordering};
+use std::sync::Once;
+
+// Opaque libdispatch handles.
+type DispatchSourceType = *const c_void;
+type DispatchObject = *mut c_void;
+
+/// Placeholder for the opaque `struct dispatch_source_type_s` / queue structs
+/// we only ever take the address of.
+#[repr(C)]
+struct DispatchOpaque {
+    _private: [u8; 0],
+}
+
+extern "C" {
+    /// The memory-pressure source "type" token. The public
+    /// `DISPATCH_SOURCE_TYPE_MEMORYPRESSURE` macro expands to a pointer to
+    /// this symbol.
+    static _dispatch_source_type_memorypressure: DispatchOpaque;
+    /// The process-wide main serial queue; `dispatch_get_main_queue()` expands
+    /// to `&_dispatch_main_q`.
+    static _dispatch_main_q: DispatchOpaque;
+
+    fn dispatch_source_create(
+        type_: DispatchSourceType,
+        handle: usize,
+        mask: c_ulong,
+        queue: DispatchObject,
+    ) -> DispatchObject;
+    fn dispatch_source_set_event_handler_f(
+        source: DispatchObject,
+        handler: extern "C" fn(*mut c_void),
+    );
+    fn dispatch_source_get_data(source: DispatchObject) -> c_ulong;
+    fn dispatch_resume(object: DispatchObject);
+
+    // perry-runtime's OS-memory-pressure entry point: level 1 = collect-if-safe
+    // (minor), level 2+ = full collect + clamp trigger. Always lowers+arms the
+    // arena trigger so an unsafe delivery still collects at the next allocation.
+    fn js_gc_memory_pressure(level: u32) -> u32;
+}
+
+// <dispatch/source.h> DISPATCH_MEMORYPRESSURE_* masks.
+const DISPATCH_MEMORYPRESSURE_WARN: c_ulong = 0x02;
+const DISPATCH_MEMORYPRESSURE_CRITICAL: c_ulong = 0x04;
+
+/// The live source pointer, so the event handler can read its pressure level
+/// via `dispatch_source_get_data`. Set once, never cleared (the source is
+/// intentionally leaked for the app's lifetime).
+static PRESSURE_SOURCE: AtomicPtr<c_void> = AtomicPtr::new(std::ptr::null_mut());
+
+static INSTALL_ONCE: Once = Once::new();
+
+extern "C" fn on_memory_pressure(_context: *mut c_void) {
+    let source = PRESSURE_SOURCE.load(Ordering::Acquire);
+    if source.is_null() {
+        return;
+    }
+    let data = unsafe { dispatch_source_get_data(source) };
+    // CRITICAL is the last notice before the OS starts terminating processes,
+    // so escalate to a full collect; WARN is advisory, so a minor collect.
+    let level: u32 = if data & DISPATCH_MEMORYPRESSURE_CRITICAL != 0 {
+        2
+    } else if data & DISPATCH_MEMORYPRESSURE_WARN != 0 {
+        1
+    } else {
+        0
+    };
+    if level != 0 {
+        unsafe {
+            js_gc_memory_pressure(level);
+        }
+    }
+}
+
+/// Install the main-queue memory-pressure dispatch source. Idempotent; safe to
+/// call once from `app_run`.
+pub fn install() {
+    INSTALL_ONCE.call_once(|| unsafe {
+        let source = dispatch_source_create(
+            &_dispatch_source_type_memorypressure as *const _ as DispatchSourceType,
+            0,
+            DISPATCH_MEMORYPRESSURE_WARN | DISPATCH_MEMORYPRESSURE_CRITICAL,
+            &_dispatch_main_q as *const _ as DispatchObject,
+        );
+        if source.is_null() {
+            return;
+        }
+        PRESSURE_SOURCE.store(source, Ordering::Release);
+        dispatch_source_set_event_handler_f(source, on_memory_pressure);
+        // Dispatch sources start suspended.
+        dispatch_resume(source);
+        // Intentionally never released — the source must outlive `app_run`.
+    });
+}

--- a/crates/perry-ui-tvos/src/app.rs
+++ b/crates/perry-ui-tvos/src/app.rs
@@ -90,6 +90,17 @@ define_class!(
             crate::background::flush_pending_registrations();
             true
         }
+
+        /// UIKit memory-warning delivery (#6184). On tvOS a memory warning is
+        /// the last notice before the app is terminated, so treat it as
+        /// critical: force a full collect and clamp the GC trigger. Runs on
+        /// the main thread, which owns the JS arena.
+        #[unsafe(method(applicationDidReceiveMemoryWarning:))]
+        fn application_did_receive_memory_warning(&self, _application: &AnyObject) {
+            unsafe {
+                js_gc_memory_pressure(2);
+            }
+        }
     }
 );
 
@@ -446,6 +457,13 @@ extern "C" {
     fn js_callback_timer_tick() -> i32;
     fn js_interval_timer_tick() -> i32;
     fn js_frame_pump_default() -> i32;
+    // perry-runtime's embedder GC stepper: spends up to `budget_us`
+    // advancing an ACTIVE budgeted collection in bounded work units; a
+    // cheap status probe when no cycle is active (out=null is allowed).
+    fn js_gc_step_us(budget_us: u64, out: *mut u8) -> u32;
+    // perry-runtime's OS-memory-pressure entry point (#6184): level 1 =
+    // collect-if-safe (minor), level 2+ = full collect + clamp trigger.
+    fn js_gc_memory_pressure(level: u32) -> u32;
 }
 
 // ============================================
@@ -470,6 +488,14 @@ define_class!(
                     // Issue #1865: perry/ui `onFrame` display-link callbacks.
                     js_frame_pump_default();
                     js_promise_run_microtasks();
+                    // #6183 (2026-07-09 GC audit): spend a bounded idle
+                    // budget on any active budgeted GC cycle at the pump
+                    // boundary — the JS stack is fully unwound here, so this
+                    // is a precise-root safepoint. A 2 ms slice per tick
+                    // drains collection debt incrementally instead of letting
+                    // an alloc-point collection land unbounded on this
+                    // (main/UI) thread mid-interaction.
+                    js_gc_step_us(2_000, std::ptr::null_mut());
                     #[cfg(feature = "geisterhand")]
                     {
                         extern "C" { fn perry_geisterhand_pump(); }

--- a/crates/perry-ui-visionos/src/app.rs
+++ b/crates/perry-ui-visionos/src/app.rs
@@ -307,6 +307,10 @@ extern "C" {
     fn js_callback_timer_tick() -> i32;
     fn js_interval_timer_tick() -> i32;
     fn js_frame_pump_default() -> i32;
+    // perry-runtime's embedder GC stepper: spends up to `budget_us`
+    // advancing an ACTIVE budgeted collection in bounded work units; a
+    // cheap status probe when no cycle is active (out=null is allowed).
+    fn js_gc_step_us(budget_us: u64, out: *mut u8) -> u32;
 }
 
 // ============================================
@@ -331,6 +335,14 @@ define_class!(
                     // Issue #1865: perry/ui `onFrame` display-link callbacks.
                     js_frame_pump_default();
                     js_promise_run_microtasks();
+                    // #6183 (2026-07-09 GC audit): spend a bounded idle
+                    // budget on any active budgeted GC cycle at the pump
+                    // boundary — the JS stack is fully unwound here, so this
+                    // is a precise-root safepoint. A 2 ms slice per tick
+                    // drains collection debt incrementally instead of letting
+                    // an alloc-point collection land unbounded on this
+                    // (main/UI) thread mid-interaction.
+                    js_gc_step_us(2_000, std::ptr::null_mut());
                     #[cfg(feature = "geisterhand")]
                     {
                         extern "C" { fn perry_geisterhand_pump(); }

--- a/crates/perry-ui-visionos/swift/PerryVisionApp.swift
+++ b/crates/perry-ui-visionos/swift/PerryVisionApp.swift
@@ -3,6 +3,11 @@ import UIKit
 
 @_silgen_name("perry_main_init") func perry_main_init()
 @_silgen_name("perry_visionos_root_view") func perry_visionos_root_view() -> Int64
+// perry-runtime's OS-memory-pressure entry point (#6184): level 1 =
+// collect-if-safe (minor), level 2+ = full collect + clamp trigger. Always
+// lowers+arms the arena trigger so an unsafe delivery still collects at the
+// next allocation.
+@_silgen_name("js_gc_memory_pressure") func js_gc_memory_pressure(_ level: UInt32) -> UInt32
 
 final class PerryVisionBootstrap {
     static let shared = PerryVisionBootstrap()
@@ -17,6 +22,18 @@ final class PerryVisionBootstrap {
             let label = UILabel()
             label.text = "Perry visionOS root view missing"
             rootView = label
+        }
+        // #6184 (2026-07-09 GC audit): this SwiftUI host has no app-delegate
+        // `applicationDidReceiveMemoryWarning:`, so observe the equivalent
+        // notification. A UIKit memory warning is the last notice before the
+        // app is jettisoned, so treat it as critical (level 2). The observer
+        // fires on the main thread, which owns the JS arena.
+        NotificationCenter.default.addObserver(
+            forName: UIApplication.didReceiveMemoryWarningNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            _ = js_gc_memory_pressure(2)
         }
     }
 }

--- a/crates/perry-ui-watchos/swift/PerryWatchApp.swift
+++ b/crates/perry-ui-watchos/swift/PerryWatchApp.swift
@@ -23,6 +23,11 @@ func perry_watchos_dispatch_background_task(_ id: UnsafePointer<CChar>)
 // callback).
 @_silgen_name("js_callback_timer_tick") func js_callback_timer_tick() -> Int32
 @_silgen_name("js_interval_timer_tick") func js_interval_timer_tick() -> Int32
+// perry-runtime's embedder GC stepper (#6183): spends up to `budgetUs`
+// advancing an ACTIVE budgeted collection in bounded work units; a cheap
+// status probe when no cycle is active (out=nil is allowed).
+@_silgen_name("js_gc_step_us")
+func js_gc_step_us(_ budgetUs: UInt64, _ out: UnsafeMutablePointer<UInt8>?) -> UInt32
 
 // Tree query
 @_silgen_name("perry_watchos_root_node") func perry_watchos_root_node() -> Int64
@@ -114,6 +119,13 @@ class PerryBridge: ObservableObject {
             // Drive JS runtime timers (setInterval, setTimeout) each frame.
             _ = js_callback_timer_tick()
             _ = js_interval_timer_tick()
+            // #6183 (2026-07-09 GC audit): spend a bounded idle budget on any
+            // active budgeted GC cycle at the pump boundary — the JS stack is
+            // fully unwound here, so this is a precise-root safepoint. A 2 ms
+            // slice per frame drains collection debt incrementally instead of
+            // letting an alloc-point collection land unbounded on this (main)
+            // thread mid-interaction.
+            _ = js_gc_step_us(2_000, nil)
             let v = perry_watchos_tree_version()
             if v != self.version {
                 self.version = v

--- a/crates/perry-ui-windows/src/app.rs
+++ b/crates/perry-ui-windows/src/app.rs
@@ -34,6 +34,10 @@ extern "C" {
     fn js_callback_timer_tick() -> i32;
     fn js_interval_timer_tick() -> i32;
     fn js_frame_pump_default() -> i32;
+    // perry-runtime's embedder GC stepper: spends up to `budget_us`
+    // advancing an ACTIVE budgeted collection in bounded work units; a
+    // cheap status probe when no cycle is active (out=null is allowed).
+    fn js_gc_step_us(budget_us: u64, out: *mut u8) -> u32;
 }
 
 /// Timer ID for periodic tick that processes setTimeout/setInterval queues.
@@ -490,6 +494,14 @@ pub fn app_run(app_handle: i64) {
                         // callbacks. Real DwmFlush-aligned vsync driver is
                         // a follow-up.
                         js_frame_pump_default();
+                        // #6183 (2026-07-09 GC audit): spend a bounded idle
+                        // budget on any active budgeted GC cycle at the pump
+                        // boundary — the JS stack is fully unwound here, so
+                        // this is a precise-root safepoint. A 2 ms slice per
+                        // tick drains collection debt incrementally instead of
+                        // letting an alloc-point collection land unbounded on
+                        // this (main/UI) thread mid-interaction.
+                        js_gc_step_us(2_000, std::ptr::null_mut());
                     }
                 }
                 // perry/media (#351) — UI-thread state poll for active


### PR DESCRIPTION
Extends the GC embedder integration already merged for the macOS host to the
remaining UI hosts. Two runtime FFIs land on `main` already; this wires the
host-side calls. Reference: **#6183 #6184; 2026-07-09 GC audit**.

## A. Pump GC-step (#6183)

Mirrors the merged macOS pump call: `js_gc_step_us(2_000, null)` in each host's
run-loop / timer pump tail. That point is a precise-root safepoint (the JS
stack is fully unwound), so an active budgeted GC cycle drains in bounded 2ms
slices instead of an unbounded alloc-point collection landing on the UI thread
mid-interaction. Extern declared per host, matching the macOS style.

| Host | Pump site |
|------|-----------|
| iOS | `PerryPumpTarget::pump:` (`perry-ui-ios/src/app.rs`) |
| tvOS | `PerryPumpTarget::pump:` (`perry-ui-tvos/src/app.rs`) |
| visionOS | `PerryPumpTarget::pump:` (`perry-ui-visionos/src/app.rs`) |
| watchOS | SwiftUI render `Timer` in `PerryWatchApp.swift` (`@_silgen_name` FFI) |
| gtk4 | `glib::timeout_add_local` pump closure (`perry-ui-gtk4/src/app.rs`) |
| Windows | Win32 message-loop `TIMER_TICK_NEEDED` block (`perry-ui-windows/src/app.rs`) |
| Android | `nativePumpTick` JNI callback (`perry-ui-android/src/app.rs`) |

## B. OS memory-pressure (#6184)

Forwards the platform signal to `js_gc_memory_pressure(level)` (1 = minor,
2 = full collect + trigger clamp).

- **iOS / tvOS** — added `applicationDidReceiveMemoryWarning:` to the Rust
  `PerryAppDelegate` (`define_class!`), calling `js_gc_memory_pressure(2)` (a
  UIKit memory warning is the last notice before jetsam → critical).
- **visionOS** — the SwiftUI host has no app-delegate memory callback, so
  `PerryVisionBootstrap` observes `UIApplication.didReceiveMemoryWarningNotification`
  on the main queue → level 2.
- **macOS** — new `memory_pressure.rs` installs a
  `DISPATCH_SOURCE_TYPE_MEMORYPRESSURE` source on the main queue at `app_run`:
  `WARN → 1`, `CRITICAL → 2`. libdispatch symbols bound directly (part of
  libSystem; no new crate). This is the one macOS piece that wasn't done yet.
- **Android** — `PerryActivity.onLowMemory() → 2`; new `onTrimMemory(level)`
  override maps `TRIM_MEMORY_RUNNING_CRITICAL | COMPLETE | MODERATE → 2` and
  lighter trims → 1 (constants aren't monotonic by severity, so the severe set
  is matched explicitly). Wired via a new `nativeMemoryPressure` JNI shim
  (`perry-ui-android/src/lib.rs`) + Kotlin `external fun` (`PerryBridge.kt`),
  guarded against `UnsatisfiedLinkError` for warnings that arrive pre-init. The
  existing Google-Maps `forwardMapsLifecycle("lowMemory")` is preserved.

## Out of scope

- **Linux PSI polling** for gtk4 — a server concern, deliberately not added.
- **Windows / gtk4 OS memory-pressure** — no in-scope UI memory signal was
  wired (only the pump-step). Notable as remaining if desired later
  (`WM_COMPACTING` / `QueryMemoryResourceNotification` on Windows).

## Build verification

Verified with target-specific `cargo check` where the toolchain is present;
inspection-only where a cross native-toolchain is missing on this macOS host
(honest status — no fabricated builds):

| Host | Build-verified? |
|------|-----------------|
| macOS | `cargo check -p perry-ui-macos` — PASS (includes dispatch-source module) |
| iOS | `cargo check --target aarch64-apple-ios` — PASS |
| tvOS | `cargo check --target aarch64-apple-tvos` — PASS |
| visionOS | `cargo check --target aarch64-apple-visionos` — PASS (Rust; Swift template inspection-only) |
| watchOS | Rust crate PASS; the change is Swift-only (`PerryWatchApp.swift`), inspection-only |
| gtk4 | inspection-only — cross-compile blocked (`glib-sys` pkg-config can't cross-compile) |
| Windows | inspection-only — cross-compile blocked (`libmimalloc-sys` needs a Windows C++ toolchain) |
| Android | inspection-only — cross-compile blocked (`aarch64-linux-android-clang` NDK not installed); Kotlin inspection-only |

`cargo fmt --all -- --check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved memory-pressure handling across supported platforms, helping the app respond more quickly to low-memory situations.
  * Added incremental background runtime cleanup during regular UI/update cycles to spread work into small bounded steps.
* **Bug Fixes**
  * Reduced the chance of sudden performance spikes by avoiding larger cleanup bursts during normal app activity.
  * Improved stability when the operating system sends memory warning signals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->