### PR TITLE
fix(runtime): dynamic `new P(executor)` for the Promise constructor value

### DIFF
--- a/crates/perry-runtime/src/object/class_registry/construct.rs
+++ b/crates/perry-runtime/src/object/class_registry/construct.rs
@@ -784,6 +784,28 @@ pub unsafe extern "C" fn js_new_function_construct(
                 let encoder = crate::text::js_text_encoder_new();
                 return crate::value::js_nanbox_pointer(encoder);
             }
+            // `new P(executor)` where `P` holds the global Promise constructor
+            // VALUE (`const P = Promise;` / a polyfill alias). Without this arm
+            // the match fell through to the closure fallback, which CALLED
+            // `promise_constructor_call_thunk` as a plain function — throwing
+            // "Constructor Promise requires 'new'". Route to the same executor
+            // construction as the static literal lowering.
+            "Promise" => {
+                let executor = args
+                    .first()
+                    .copied()
+                    .unwrap_or_else(|| f64::from_bits(crate::value::TAG_UNDEFINED));
+                let bits = executor.to_bits();
+                let exec_ptr = if (bits & crate::value::TAG_MASK) == crate::value::POINTER_TAG {
+                    (bits & crate::value::POINTER_MASK) as *const crate::closure::ClosureHeader
+                } else {
+                    // Non-callable executor: `js_promise_new_with_executor`
+                    // validates and throws the spec TypeError synchronously.
+                    std::ptr::null()
+                };
+                let promise = crate::promise::js_promise_new_with_executor(exec_ptr);
+                return crate::value::js_nanbox_pointer(promise as i64);
+            }
             "TextDecoder" => {
                 let label = args
                     .first()

--- a/test-files/test_gap_dynamic_builtin_construct_dispatch.ts
+++ b/test-files/test_gap_dynamic_builtin_construct_dispatch.ts
@@ -1,0 +1,59 @@
+// Dynamically-constructed builtin instances must behave like their literal
+// counterparts. `new X()` with a LITERAL name is codegen-recognized; obtaining
+// the constructor as a VALUE — `require("util").TextEncoder`, `const P =
+// Promise`, a property read off a namespace — routes through the runtime's
+// dynamic construct + dynamic method dispatch, where three gaps lived:
+//
+//  1. TextEncoder instances are a shared small-handle sentinel with no dynamic
+//     method dispatch — `enc.encode(...)` / `enc.encodeInto(...)` returned
+//     `undefined`. react-server-dom's flight byte-writer does exactly
+//     `var T = new (require("util").TextEncoder)` and then
+//     `T.encodeInto(row, scratch).read`, so the flight flush threw and every
+//     Next.js App Router dynamic route hung (#5989).
+//  2. TextDecoder handles had no dynamic `decode` dispatch.
+//  3. `new P(executor)` where P holds the global Promise constructor value fell
+//     through to the call path and threw "Constructor Promise requires 'new'".
+//
+// Validated byte-for-byte against `node --experimental-strip-types`.
+
+import { TextEncoder as UtilTextEncoder, TextDecoder as UtilTextDecoder } from "util";
+
+// (1) TextEncoder obtained as a value — the flight byte-writer shape.
+const T: any = UtilTextEncoder;
+const enc: any = new T();
+const scratch = new Uint8Array(8);
+const r: any = enc.encodeInto("hi", scratch);
+console.log(r.read, r.written, scratch[0], scratch[1]);
+const encoded: any = enc.encode("xyz");
+console.log(encoded.length, encoded[0], encoded[2]);
+
+// multi-byte + partial destination through the dynamic path
+const small = new Uint8Array(3);
+const rp: any = enc.encodeInto("héllo", small);
+console.log(rp.read <= 3, rp.written <= 3);
+
+// (2) TextDecoder obtained as a value.
+const D: any = UtilTextDecoder;
+const dec: any = new D();
+console.log(dec.decode(new Uint8Array([104, 101, 106])));
+console.log(JSON.stringify(dec.decode()));
+
+// (3) Promise constructor obtained as a value (polyfill alias shape).
+const P: any = Promise;
+const p = new P((resolve: any) => resolve(42));
+p.then((v: any) => console.log("resolved", v));
+
+// executor receives working resolve/reject; rejection path too
+const q = new P((_res: any, rej: any) => rej(new Error("nope")));
+q.catch((e: any) => console.log("rejected", e.message));
+
+// (4) Map/Set/WeakMap constructor values (regression guard for the arms that
+// already worked — construction via value + native method dispatch).
+const M: any = Map;
+const m = new M([["k", 7]]);
+m.set("j", 8);
+console.log(m.get("k"), m.get("j"), m.size);
+const S: any = Set;
+const s = new S([1, 2]);
+s.add(3);
+console.log(s.has(2), s.has(3), s.size);


### PR DESCRIPTION
## Problem

`new P(executor)` where `P` holds the global `Promise` constructor **value** —
`const P = Promise;` or a polyfill/bundler alias — threw
`Constructor Promise requires 'new'`.

The dynamic-construct path (`js_new_function_construct`) identifies global
builtin constructor values and routes them to their native factories, but the
match had no `"Promise"` arm, so the callee fell through to the closure
fallback, which *called* `promise_constructor_call_thunk` as a plain function —
and that thunk (correctly) rejects being invoked without construct semantics.

```js
const P = Promise;
new P((resolve) => resolve(42));   // threw; works in Node
```

## Fix

Add the missing `"Promise"` arm to the identified-builtin construct match in
`class_registry/construct.rs`, routing to `js_promise_new_with_executor` exactly
like the static `new Promise(executor)` lowering. A non-callable executor still
throws the spec TypeError (validation lives in the factory).

## Validation

New gap test `test_gap_dynamic_builtin_construct_dispatch.ts`, byte-for-byte
against `node --experimental-strip-types`:

- `new P(executor)` resolve and reject paths via a Promise constructor value
- dynamic `TextEncoder.encode/encodeInto` + `TextDecoder.decode` through
  `require("util")` constructor values (regression coverage for #6162's
  type-erased dispatch, which this test also exercises)
- Map/Set constructor-value construction + native method dispatch guards

Found while unblocking Next.js App Router SSR (#5989): react-server-dom
constructs builtins through module-namespace values rather than literals, so
every missing dynamic-construct arm surfaces there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for creating built-in objects from constructor values at runtime.
  * Added broader coverage for dynamically obtained constructors, including promises, maps, sets, and text encoding/decoding.

* **Bug Fixes**
  * Fixed `new Promise(...)` when the constructor is passed around as a value before instantiation.
  * Improved behavior for text encoding and decoding methods, including partial buffer handling and multi-byte data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->