### PR TITLE
fix(thread): loud cross-heap transfer errors, worker MallocState cleanup, owner-tagged timer dispatch (#6185)

### DIFF
--- a/crates/perry-runtime/src/gc/malloc.rs
+++ b/crates/perry-runtime/src/gc/malloc.rs
@@ -98,6 +98,79 @@ pub(super) enum MallocRegistryState {
     ActiveConsistent,
 }
 
+impl MallocState {
+    /// Reclaim every malloc-tracked object block this state still owns.
+    ///
+    /// Runs at thread exit via `Drop`. Returns the number of bytes freed
+    /// (surfaced for tests). Empties `objects` and `set` so the drop is
+    /// idempotent.
+    ///
+    /// # Why this is sound at thread exit (2026-07-09 GC audit §6 / #6185)
+    /// `MALLOC_STATE` is `thread_local!`, so this only runs while the owning
+    /// thread is being torn down:
+    /// - **Worker threads** (`spawn` / `parallelMap` / `parallelFilter`): by
+    ///   the time TLS is destroyed the worker's result has already crossed the
+    ///   boundary as an owned `SerializedValue` deep-copy — no other thread
+    ///   holds a raw pointer into this heap — so freeing these blocks cannot
+    ///   create a dangling reference elsewhere. Without this, every
+    ///   promise/map/error/large-closure a worker allocated leaked at exit (the
+    ///   first malloc-count GC needs 100k objects, so per-request workers never
+    ///   collected once).
+    /// - **The main thread**: its `MALLOC_STATE` is not dropped until process
+    ///   teardown, never mid-program, so this cannot yank live objects out from
+    ///   under running code.
+    ///
+    /// # Why finalizers are deliberately NOT run here
+    /// The sweep path pairs `dealloc` with `gc_type_finalize_unmarked_payload` /
+    /// `layout_clear_for_ptr`, which reach into *other* thread-locals
+    /// (`MAP_REGISTRY`, `MAP_INDEX`, `PROMISE_CONTEXTS`, the async-hooks queues,
+    /// …). Thread-local destruction order is unspecified, so touching one of
+    /// those during this Drop could hit an already-destroyed TLS and panic
+    /// ("cannot access a Thread Local Storage value during or after
+    /// destruction"), aborting the thread. We therefore reclaim only the object
+    /// blocks themselves — the audit's primary worker-exit leak. Any external
+    /// side-allocations those objects own (a Map's entry table, an error's side
+    /// tables) are out of scope for this mechanical fix. This also avoids the
+    /// re-entrant `MALLOC_STATE.with(...)` the sweep bookkeeping performs.
+    ///
+    /// Pinned objects are skipped, mirroring `process_sweep_header`, so a
+    /// cross-thread promise pinned for an in-flight result is never yanked.
+    fn free_all_tracked_objects(&mut self) -> u64 {
+        let mut freed_bytes: u64 = 0;
+        for header in self.objects.drain(..) {
+            if header.is_null() {
+                continue;
+            }
+            // SAFETY: every entry in `objects` is a live `gc_malloc` header
+            // (GcHeader-prefixed block) until freed here; this loop frees each
+            // exactly once and the thread is exiting, so no concurrent access.
+            unsafe {
+                if (*header).gc_flags & GC_FLAG_PINNED != 0 {
+                    continue;
+                }
+                let total_size = (*header).size as usize;
+                if total_size == 0 {
+                    continue;
+                }
+                let layout = Layout::from_size_align(total_size, 8).unwrap();
+                dealloc(header as *mut u8, layout);
+                freed_bytes = freed_bytes.saturating_add(total_size as u64);
+            }
+        }
+        self.set.clear();
+        freed_bytes
+    }
+}
+
+impl Drop for MallocState {
+    fn drop(&mut self) {
+        // Free the worker thread's malloc objects instead of leaking them at
+        // exit (audit §6 / #6185). See `free_all_tracked_objects` for the
+        // thread-exit soundness and TLS-destruction-order argument.
+        self.free_all_tracked_objects();
+    }
+}
+
 /// Pre-allocated capacity for `MallocState.objects` and `.set`.
 ///
 /// History: this used to be a flat 256 k (`MALLOC_STATE_HEAVY_CAPACITY`
@@ -543,5 +616,108 @@ pub fn gc_realloc(old_user_ptr: *mut u8, new_payload_size: usize) -> *mut u8 {
         });
 
         new_raw.add(GC_HEADER_SIZE)
+    }
+}
+
+#[cfg(test)]
+impl MallocState {
+    /// Build an empty, TLS-independent `MallocState` for unit tests.
+    fn new_empty_for_test() -> Self {
+        MallocState {
+            objects: Vec::new(),
+            set: crate::fast_hash::PtrHashSet::with_capacity_and_hasher(
+                0,
+                crate::fast_hash::PtrHasher,
+            ),
+            realloc_forwarding: crate::fast_hash::new_ptr_hash_map(),
+            realloc_snapshot_headers: crate::fast_hash::new_ptr_hash_set(),
+            registry_state: MallocRegistryState::Inactive,
+            heavy_capacity_reserved: false,
+            kind_telemetry: [MallocKindTelemetry::zero(); MALLOC_KIND_BUCKET_COUNT],
+        }
+    }
+
+    /// Allocate a raw GcHeader-prefixed block (as `gc_malloc` would) and push
+    /// it into this state's tracking, WITHOUT touching the thread-local
+    /// `MALLOC_STATE`. Returns the header so a test can assert on / manually
+    /// reclaim it. `flags` seeds `gc_flags` (e.g. `GC_FLAG_PINNED`).
+    unsafe fn push_test_object(&mut self, payload: usize, flags: u8) -> *mut GcHeader {
+        let total = GC_HEADER_SIZE + payload;
+        let layout = Layout::from_size_align(total, 8).unwrap();
+        let raw = alloc(layout);
+        assert!(!raw.is_null(), "test allocation failed");
+        let header = raw as *mut GcHeader;
+        (*header).obj_type = GC_TYPE_STRING;
+        (*header).gc_flags = flags;
+        (*header)._reserved = 0;
+        (*header).size = total as u32;
+        self.objects.push(header);
+        self.set.insert(header as usize);
+        header
+    }
+}
+
+#[cfg(test)]
+mod drop_tests {
+    use super::*;
+
+    /// `free_all_tracked_objects` (the body of `Drop for MallocState`) reclaims
+    /// every tracked block and reports the exact byte total — the worker-exit
+    /// leak fix (#6185 / GC audit §6). TLS-Drop itself can't be exercised
+    /// directly from a unit test (it fires only at real thread teardown), so we
+    /// drive the shared free path on a TLS-independent `MallocState`.
+    #[test]
+    fn free_all_tracked_objects_reclaims_every_block() {
+        let mut state = MallocState::new_empty_for_test();
+        let payloads = [8usize, 24, 100, 4096];
+        let expected: u64 = payloads.iter().map(|&p| (GC_HEADER_SIZE + p) as u64).sum();
+
+        unsafe {
+            for &p in &payloads {
+                state.push_test_object(p, 0);
+            }
+        }
+        assert_eq!(state.objects.len(), payloads.len());
+
+        let freed = state.free_all_tracked_objects();
+        assert_eq!(
+            freed, expected,
+            "must free the exact total size of every tracked block"
+        );
+        assert!(
+            state.objects.is_empty(),
+            "tracked-object list must be drained after free"
+        );
+
+        // Idempotent: the subsequent real Drop must be a no-op (no double free).
+        let freed_again = state.free_all_tracked_objects();
+        assert_eq!(freed_again, 0);
+    }
+
+    /// Pinned objects are skipped (mirrors `process_sweep_header`) so a
+    /// cross-thread promise pinned for an in-flight result is never yanked.
+    #[test]
+    fn free_all_tracked_objects_skips_pinned() {
+        let mut state = MallocState::new_empty_for_test();
+        let (pinned, unpinned_size);
+        unsafe {
+            pinned = state.push_test_object(64, GC_FLAG_PINNED);
+            state.push_test_object(32, 0);
+        }
+        unpinned_size = (GC_HEADER_SIZE + 32) as u64;
+
+        let freed = state.free_all_tracked_objects();
+        assert_eq!(
+            freed, unpinned_size,
+            "only the unpinned block's bytes are reclaimed"
+        );
+
+        // The pinned block was skipped, not freed — reclaim it manually so the
+        // test itself doesn't leak.
+        unsafe {
+            let total = (*pinned).size as usize;
+            let layout = Layout::from_size_align(total, 8).unwrap();
+            dealloc(pinned as *mut u8, layout);
+        }
     }
 }

--- a/crates/perry-runtime/src/thread.rs
+++ b/crates/perry-runtime/src/thread.rs
@@ -267,6 +267,20 @@ pub enum SerializedValue {
     /// backing is never freed (see `crate::shared_sab`), so the raw address
     /// stays valid for the life of the process.
     SharedArrayBuffer { addr: usize },
+
+    /// A value whose runtime type cannot cross a `perry/thread` boundary
+    /// (Map, Set, Promise, Error, TypedArray, Buffer, Symbol, Temporal,
+    /// native handles, unmaterialized lazy JSON arrays, …).
+    ///
+    /// The serializer used to lower every one of these to `Inline(TAG_UNDEFINED)`,
+    /// so a capture/return of such a value crossed silently as `undefined`
+    /// with no diagnostic (2026-07-09 GC audit §6 / #6185). Instead we now
+    /// carry the human-readable type name here and raise a catchable
+    /// `TypeError` at the transfer boundary **on the main thread** — the
+    /// capture path throws synchronously from `spawn`/`parallelMap`, and the
+    /// `spawn` return path rejects the returned promise. This value is never
+    /// deserialized; its presence anywhere in a serialized tree is a hard error.
+    Unsupported(&'static str),
 }
 
 // Safety: SerializedValue contains no raw pointers to arena memory.
@@ -367,15 +381,102 @@ pub unsafe fn serialize_nanbox_for_thread(bits: u64) -> SerializedValue {
                 // a fresh cell (deep-copy, like every other crossed value).
                 return SerializedValue::Date((*(raw_ptr as *const crate::date::DateCell)).ts);
             }
-            _ => {
-                // Unknown pointer type — treat as undefined
-                return SerializedValue::Inline(TAG_UNDEFINED);
+            // Everything below is a genuinely non-transferable runtime type.
+            // Previously all of these silently became `undefined` on the far
+            // side (#6185); now they surface a named TypeError at the boundary.
+            other => {
+                return SerializedValue::Unsupported(unsupported_transfer_type_name(other));
             }
         }
     }
 
     // Regular f64 number (no tag in the NaN-boxing range we use)
     SerializedValue::Inline(bits)
+}
+
+/// Human-readable name for a GC object type that cannot cross a thread
+/// boundary. Used only to build the TypeError message (#6185).
+///
+/// Note: a Symbol is POINTER_TAG'd but allocated with `GC_TYPE_STRING`
+/// (real strings arrive under `STRING_TAG` and never reach this match), so
+/// `GC_TYPE_STRING` here means "Symbol".
+fn unsupported_transfer_type_name(obj_type: u8) -> &'static str {
+    match obj_type {
+        gc::GC_TYPE_STRING => "Symbol",
+        gc::GC_TYPE_PROMISE => "Promise",
+        gc::GC_TYPE_BIGINT => "BigInt",
+        gc::GC_TYPE_ERROR => "Error",
+        gc::GC_TYPE_MAP => "Map",
+        gc::GC_TYPE_LAZY_ARRAY => "lazy (unmaterialized) JSON array",
+        gc::GC_TYPE_BUFFER => "Buffer",
+        gc::GC_TYPE_TYPED_ARRAY => "TypedArray",
+        gc::GC_TYPE_SET => "Set",
+        gc::GC_TYPE_NATIVE_ARENA_OWNER
+        | gc::GC_TYPE_NATIVE_TYPED_VIEW
+        | gc::GC_TYPE_NATIVE_HANDLE
+        | gc::GC_TYPE_NATIVE_POD_VIEW => "native handle",
+        gc::GC_TYPE_TEMPORAL => "Temporal value",
+        _ => "value of an unsupported type",
+    }
+}
+
+/// Depth-first search for the first non-transferable value anywhere in a
+/// serialized tree (a captured/returned Map, an object field holding a Set,
+/// an array element that is a Promise, …). Returns its type name, or `None`
+/// if the whole tree is transferable.
+pub(crate) fn first_unsupported_transfer_type(sv: &SerializedValue) -> Option<&'static str> {
+    match sv {
+        SerializedValue::Unsupported(name) => Some(name),
+        SerializedValue::Array(elements) => {
+            elements.iter().find_map(first_unsupported_transfer_type)
+        }
+        SerializedValue::Object { fields, .. } => {
+            fields.iter().find_map(first_unsupported_transfer_type)
+        }
+        SerializedValue::Closure { captures, .. } => {
+            captures.iter().find_map(first_unsupported_transfer_type)
+        }
+        _ => None,
+    }
+}
+
+/// Build (but do not throw) a `TypeError` value naming an unsupported
+/// cross-thread transfer. Used by the `spawn` return path, which *rejects*
+/// the returned promise rather than throwing.
+///
+/// # Safety
+/// Must run on the thread whose arena should own the error object (the main
+/// thread, at the drain boundary).
+unsafe fn make_unsupported_transfer_error(type_name: &str) -> f64 {
+    let msg =
+        format!("Cannot transfer a {type_name} across a perry/thread boundary (unsupported type)");
+    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(s);
+    crate::value::js_nanbox_pointer(err as i64)
+}
+
+/// Throw a catchable `TypeError` naming an unsupported cross-thread transfer.
+///
+/// # Safety
+/// Must be called on the **main / calling thread** (never a worker): it
+/// `longjmp`s to the nearest active `setjmp` frame, which only the calling
+/// JS thread has established. Worker threads have no such frame, so a throw
+/// there would be undefined behavior — worker-side failures are surfaced by
+/// rejecting the returned promise on the main thread instead.
+unsafe fn throw_unsupported_transfer(type_name: &str) -> ! {
+    crate::exception::js_throw(make_unsupported_transfer_error(type_name));
+}
+
+/// Main-thread guard: if any value in `values` is non-transferable, throw a
+/// named `TypeError`. Call this at a `spawn`/`parallelMap`/`parallelFilter`
+/// serialization boundary, on the calling thread, before spawning any worker.
+///
+/// # Safety
+/// Same as [`throw_unsupported_transfer`] — main/calling thread only.
+unsafe fn guard_transferable(values: &[SerializedValue]) {
+    if let Some(name) = values.iter().find_map(first_unsupported_transfer_type) {
+        throw_unsupported_transfer(name);
+    }
 }
 
 /// Serialize an ArrayHeader into a SerializedValue::Array.
@@ -646,6 +747,12 @@ pub unsafe fn deserialize_nanbox_on_current_thread(sv: &SerializedValue) -> u64 
             crate::buffer::mark_as_shared_array_buffer(*addr);
             JSValue::pointer(*addr as *const u8).bits()
         }
+
+        // Non-transferable values are rejected at the boundary before we ever
+        // reach deserialization (main-thread throw for captures, promise
+        // rejection for `spawn` returns), so this arm should be unreachable.
+        // Defensive fallback to `undefined` rather than a panic.
+        SerializedValue::Unsupported(_) => TAG_UNDEFINED,
     }
 }
 
@@ -745,6 +852,9 @@ unsafe fn parallel_map_impl(array_val: f64, closure_val: f64) -> i64 {
         let bits = (*elements_ptr.add(i)).to_bits();
         serialized_elements.push(serialize_nanbox_for_thread(bits));
     }
+    // #6185: a non-transferable element (e.g. a Map in the input array) would
+    // otherwise cross as `undefined`. Fail loudly on the calling thread.
+    guard_transferable(&serialized_elements);
 
     // ── 5. Serialize closure captures (shared across all threads) ────
     let serialized_captures: Option<(usize, u32, Vec<SerializedValue>)> = {
@@ -758,6 +868,7 @@ unsafe fn parallel_map_impl(array_val: f64, closure_val: f64) -> i64 {
             for i in 0..actual {
                 caps.push(serialize_nanbox_for_thread((*base.add(i)).to_bits()));
             }
+            guard_transferable(&caps); // #6185: named throw for a captured Map/Set/…
             Some((fp, cc, caps))
         } else {
             None
@@ -856,6 +967,12 @@ unsafe fn parallel_map_impl(array_val: f64, closure_val: f64) -> i64 {
     });
 
     // ── 7. Deserialize results into main thread's arena ──────────────
+    // #6185: a mapper that returns a non-transferable value (e.g. a Map) is a
+    // loud TypeError on the calling thread, not a silent `undefined`. The
+    // worker never throws (no setjmp frame there); the marker rode back here.
+    for chunk_results in &all_results {
+        guard_transferable(chunk_results);
+    }
     let total_results: usize = all_results.iter().map(|r| r.len()).sum();
     let result_arr = crate::array::js_array_alloc(total_results as u32);
     let scope = crate::gc::RuntimeHandleScope::new();
@@ -972,6 +1089,8 @@ unsafe fn parallel_filter_impl(array_val: f64, closure_val: f64) -> i64 {
         let bits = (*elements_ptr.add(i)).to_bits();
         serialized_elements.push(serialize_nanbox_for_thread(bits));
     }
+    // #6185: fail loudly on a non-transferable input element.
+    guard_transferable(&serialized_elements);
 
     // Serialize closure captures
     let serialized_captures: Option<(usize, u32, Vec<SerializedValue>)> = {
@@ -983,6 +1102,7 @@ unsafe fn parallel_filter_impl(array_val: f64, closure_val: f64) -> i64 {
         for i in 0..actual {
             caps.push(serialize_nanbox_for_thread((*base.add(i)).to_bits()));
         }
+        guard_transferable(&caps); // #6185: named throw for a captured Map/Set/…
         Some((fp, cc, caps))
     };
 
@@ -1163,7 +1283,29 @@ unsafe fn spawn_impl(closure_val: f64) -> *mut crate::promise::Promise {
         return promise;
     };
 
-    // ── 1. Allocate Promise on main thread ───────────────────────────
+    // ── 1. Serialize closure captures (before allocating the promise) ─
+    // #6185: a captured non-transferable value (Map/Set/Promise/…) must throw
+    // a named TypeError here on the calling thread. Serializing *before* the
+    // promise is allocated keeps the throw clean — `js_throw` longjmps and does
+    // not run Rust destructors, so a pinned promise allocated first would leak.
+    let serialized_captures: Option<(u32, Vec<SerializedValue>)> = {
+        let cc = (*closure).capture_count;
+        let actual = real_capture_count(cc) as usize;
+        if actual > 0 {
+            let base =
+                (closure as *const u8).add(std::mem::size_of::<ClosureHeader>()) as *const f64;
+            let mut caps = Vec::with_capacity(actual);
+            for i in 0..actual {
+                caps.push(serialize_nanbox_for_thread((*base.add(i)).to_bits()));
+            }
+            guard_transferable(&caps);
+            Some((cc, caps))
+        } else {
+            None
+        }
+    };
+
+    // ── 2. Allocate Promise on main thread ───────────────────────────
     // Cross-thread variant: this promise is referenced only by a raw usize
     // in PENDING_THREAD_RESULTS (no scanner) until drain — a nursery
     // resident would be destroyed by the copied-minor from-space flip even
@@ -1175,23 +1317,6 @@ unsafe fn spawn_impl(closure_val: f64) -> *mut crate::promise::Promise {
     (*promise_header).gc_flags |= gc::GC_FLAG_PINNED;
 
     let promise_usize = promise as usize;
-
-    // ── 2. Serialize closure captures ────────────────────────────────
-    let serialized_captures: Option<(u32, Vec<SerializedValue>)> = {
-        let cc = (*closure).capture_count;
-        let actual = real_capture_count(cc) as usize;
-        if actual > 0 {
-            let base =
-                (closure as *const u8).add(std::mem::size_of::<ClosureHeader>()) as *const f64;
-            let mut caps = Vec::with_capacity(actual);
-            for i in 0..actual {
-                caps.push(serialize_nanbox_for_thread((*base.add(i)).to_bits()));
-            }
-            Some((cc, caps))
-        } else {
-            None
-        }
-    };
 
     // ── 3. Spawn background thread ───────────────────────────────────
     ACTIVE_THREAD_JOBS.fetch_add(1, Ordering::SeqCst);
@@ -1337,14 +1462,23 @@ pub extern "C" fn js_thread_process_pending() -> i32 {
         unsafe {
             let promise = item.promise_ptr as *mut crate::promise::Promise;
 
-            // Deserialize the result into the main thread's arena
-            let result_bits = deserialize_nanbox_on_current_thread(&item.result);
-
-            // Unpin the promise now that we're resolving it
+            // Unpin the promise now that we're settling it.
             let promise_header = (promise as *mut u8).sub(gc::GC_HEADER_SIZE) as *mut gc::GcHeader;
             (*promise_header).gc_flags &= !gc::GC_FLAG_PINNED;
 
-            // Resolve the promise
+            // #6185: a worker that returned a non-transferable value (e.g.
+            // `spawn(() => new Map())`) can't throw on its own thread (no
+            // setjmp frame). The marker rode back in the serialized result;
+            // reject the returned promise here on the main thread with a named
+            // TypeError so `await`/`.catch` observes it instead of `undefined`.
+            if let Some(name) = first_unsupported_transfer_type(&item.result) {
+                let reason = make_unsupported_transfer_error(name);
+                crate::promise::js_promise_reject(promise, reason);
+                continue;
+            }
+
+            // Deserialize the result into the main thread's arena and resolve.
+            let result_bits = deserialize_nanbox_on_current_thread(&item.result);
             crate::promise::js_promise_resolve(promise, f64::from_bits(result_bits));
         }
     }
@@ -1364,5 +1498,163 @@ pub extern "C" fn js_thread_has_pending() -> i32 {
         0
     } else {
         1
+    }
+}
+
+#[cfg(test)]
+mod transfer_guard_tests {
+    //! #6185 (2026-07-09 GC audit §6): a non-transferable value crossing a
+    //! `perry/thread` boundary must surface a named `TypeError`, not silently
+    //! become `undefined`. These tests exercise the serialization-boundary
+    //! detection directly. The main-thread `js_throw` and promise-reject wiring
+    //! rides on top of this detection and needs the full JS runtime (setjmp
+    //! frame) to observe, so it is covered by the parity suite rather than here.
+    use super::*;
+
+    #[test]
+    fn unsupported_type_names_are_human_readable() {
+        assert_eq!(unsupported_transfer_type_name(gc::GC_TYPE_MAP), "Map");
+        assert_eq!(unsupported_transfer_type_name(gc::GC_TYPE_SET), "Set");
+        assert_eq!(
+            unsupported_transfer_type_name(gc::GC_TYPE_PROMISE),
+            "Promise"
+        );
+        assert_eq!(unsupported_transfer_type_name(gc::GC_TYPE_ERROR), "Error");
+        assert_eq!(
+            unsupported_transfer_type_name(gc::GC_TYPE_TYPED_ARRAY),
+            "TypedArray"
+        );
+        assert_eq!(unsupported_transfer_type_name(gc::GC_TYPE_BUFFER), "Buffer");
+        assert_eq!(
+            unsupported_transfer_type_name(gc::GC_TYPE_TEMPORAL),
+            "Temporal value"
+        );
+        // A Symbol is POINTER_TAG'd but allocated with GC_TYPE_STRING.
+        assert_eq!(unsupported_transfer_type_name(gc::GC_TYPE_STRING), "Symbol");
+        // Any unrecognized type still yields a message, never a panic.
+        assert_eq!(
+            unsupported_transfer_type_name(250),
+            "value of an unsupported type"
+        );
+    }
+
+    #[test]
+    fn first_unsupported_transfer_type_finds_nested_markers() {
+        // Top-level.
+        assert_eq!(
+            first_unsupported_transfer_type(&SerializedValue::Unsupported("Map")),
+            Some("Map")
+        );
+        // Inside an array element.
+        let arr = SerializedValue::Array(vec![
+            SerializedValue::Inline(TAG_NULL),
+            SerializedValue::Unsupported("Set"),
+        ]);
+        assert_eq!(first_unsupported_transfer_type(&arr), Some("Set"));
+        // Inside an object field, nested in an array.
+        let obj = SerializedValue::Object {
+            class_id: 0,
+            parent_class_id: 0,
+            fields: vec![
+                SerializedValue::Inline(TAG_TRUE),
+                SerializedValue::Array(vec![SerializedValue::Unsupported("Promise")]),
+            ],
+            keys: None,
+        };
+        assert_eq!(first_unsupported_transfer_type(&obj), Some("Promise"));
+        // Inside a closure capture.
+        let clo = SerializedValue::Closure {
+            func_ptr: 0,
+            capture_count: 1,
+            captures: vec![SerializedValue::Unsupported("Error")],
+        };
+        assert_eq!(first_unsupported_transfer_type(&clo), Some("Error"));
+    }
+
+    #[test]
+    fn transferable_trees_report_no_unsupported() {
+        let tree = SerializedValue::Array(vec![
+            SerializedValue::Inline(0x4045_0000_0000_0000), // a plain f64
+            SerializedValue::String(b"ok".to_vec()),
+            SerializedValue::Object {
+                class_id: 3,
+                parent_class_id: 0,
+                fields: vec![
+                    SerializedValue::Inline(TAG_FALSE),
+                    SerializedValue::Date(1.0),
+                ],
+                keys: None,
+            },
+            SerializedValue::BigInt([0u64; BIGINT_LIMBS]),
+        ]);
+        assert_eq!(first_unsupported_transfer_type(&tree), None);
+    }
+
+    #[test]
+    fn serialize_map_yields_unsupported_marker() {
+        // The concrete audit case: a real Map value serializes to a named
+        // Unsupported marker instead of Inline(undefined).
+        unsafe {
+            let map = crate::map::js_map_alloc(4);
+            let map_bits = POINTER_TAG | (map as u64 & POINTER_MASK);
+            let sv = serialize_nanbox_for_thread(map_bits);
+            assert!(
+                matches!(sv, SerializedValue::Unsupported("Map")),
+                "a Map must serialize to Unsupported(\"Map\"), got {sv:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn serialize_supported_values_still_transfer() {
+        unsafe {
+            // Inline scalars round-trip their exact bits.
+            for bits in [TAG_UNDEFINED, TAG_NULL, TAG_TRUE, TAG_FALSE] {
+                assert!(matches!(
+                    serialize_nanbox_for_thread(bits),
+                    SerializedValue::Inline(b) if b == bits
+                ));
+            }
+            let int_bits = INT32_TAG | 42u64;
+            assert!(matches!(
+                serialize_nanbox_for_thread(int_bits),
+                SerializedValue::Inline(b) if b == int_bits
+            ));
+            let num_bits = 3.5f64.to_bits();
+            assert!(matches!(
+                serialize_nanbox_for_thread(num_bits),
+                SerializedValue::Inline(b) if b == num_bits
+            ));
+
+            // A real string transfers as its UTF-8 bytes.
+            let s = crate::string::js_string_from_bytes(b"hello".as_ptr(), 5);
+            let s_bits = JSValue::string_ptr(s).bits();
+            match serialize_nanbox_for_thread(s_bits) {
+                SerializedValue::String(bytes) => assert_eq!(bytes, b"hello"),
+                other => panic!("string must serialize to String, got {other:?}"),
+            }
+
+            // A real array of numbers transfers and round-trips.
+            let arr = crate::array::js_array_alloc(3);
+            for (i, v) in [10.0f64, 20.0, 30.0].iter().enumerate() {
+                store_thread_array_slot(arr, i, v.to_bits());
+            }
+            let arr_bits = JSValue::pointer(arr as *const u8).bits();
+            let sv = serialize_nanbox_for_thread(arr_bits);
+            assert_eq!(first_unsupported_transfer_type(&sv), None);
+            match &sv {
+                SerializedValue::Array(elems) => {
+                    assert_eq!(elems.len(), 3);
+                    assert!(
+                        matches!(elems[0], SerializedValue::Inline(b) if b == 10.0f64.to_bits())
+                    );
+                }
+                other => panic!("array must serialize to Array, got {other:?}"),
+            }
+            // Round-trip back into this thread's arena.
+            let back = deserialize_nanbox_on_current_thread(&sv);
+            let back_arr = (back & POINTER_MASK) as *const crate::array::ArrayHeader;
+            assert_eq!((*back_arr).length, 3);
+        }
     }
 }


### PR DESCRIPTION
Three mechanical cross-thread GC-safety wins identified by the 2026-07-09 GC audit (§6, threading; #6185). These reduce silent corruption to loud failure / eliminate a leak **without** committing to the larger single-JS-thread-vs-multi-heap threading-model decision (still open — see "What remains").

Perry is single-JS-thread by default; `perry/thread` gives `spawn()` / `parallelMap` / `parallelFilter` per-thread arenas + GC, values cross by `SerializedValue` deep-copy, and results return via the global `PENDING_THREAD_RESULTS` drained in the microtask pump.

## Shipped

### 1. Loud `SerializedValue` failures (audit P2 → not-silent)
`serialize_nanbox_for_thread` silently lowered every non-transferable runtime type — Map, Set, Promise, Error, TypedArray, Buffer, **Symbol** (POINTER_TAG'd but `GC_TYPE_STRING`), Temporal, native handles, unmaterialized lazy JSON arrays — to `Inline(TAG_UNDEFINED)`. A captured or returned value of one of these crossed a `perry/thread` boundary as `undefined` with **no diagnostic**, contradicting the documented deep-copy contract.

Now the serializer emits a named `SerializedValue::Unsupported(&'static str)` marker, and the transfer **boundary** raises a catchable `TypeError` ("Cannot transfer a Map across a perry/thread boundary (unsupported type)"):

- **Capture / input-element paths** (`spawn`, `parallelMap`, `parallelFilter`): `guard_transferable` throws synchronously **on the calling/main thread**, right after serialization.
- **`spawn` RETURN path**: the worker cannot throw (it has no `setjmp` frame), so the marker rides back in the serialized result and `js_thread_process_pending` **rejects the returned promise** on the main thread — observable via `await`/`.catch`.

The recursive `first_unsupported_transfer_type` walks arrays / object fields / closure captures, so a Map nested inside a returned object is caught too.

**Preserved transfers:** every arm that previously worked is untouched — arrays, plain objects, closures, strings, numbers, int32, BigInt, Date, `SharedArrayBuffer`, and all inline tags. Only the arms that previously became silent `undefined` now throw, so no working transfer regresses.

**Safety argument (throw placement + leak avoidance):** `js_throw` `longjmp`s and does **not** run Rust destructors. In `spawn_impl` the captures are therefore serialized and guarded **before** the cross-thread promise is allocated + pinned, so a throw cannot leak a pinned promise. Throwing only ever happens on the calling/main thread (which has an active `setjmp` frame from compiled JS); worker-side failures are surfaced by promise rejection instead of a throw with no target.

### 2. `Drop for MallocState` — free worker malloc objects at thread exit (audit P1 leak)
`thread_local! MALLOC_STATE` tracked a worker's malloc-heap objects (promises / maps / errors / large closures / tracked buffers) in `objects: Vec<*mut GcHeader>` with **no `Drop`**. A `spawn`/`parallelMap` worker leaked **all** of them at exit — and because the first malloc-count GC needs 100k objects, per-request workers effectively never collected once. Added a `Drop` that reclaims every tracked block via the same `dealloc(Layout)` path `process_sweep_header`/`sweep_malloc_objects` use for one object.

**Drop-ordering safety argument:**
- `MALLOC_STATE` is `thread_local!`, so `Drop` runs **only at thread teardown**, never mid-program.
- **Worker threads:** at TLS destruction the worker's result has already crossed the boundary as an **owned** `SerializedValue` deep-copy — no other thread holds a raw pointer into this heap — so reclaiming these blocks cannot dangle a reference anywhere else.
- **Main thread:** its `MALLOC_STATE` is not dropped until process teardown, so this never yanks live objects from running code.
- **Finalizers are deliberately NOT run.** The sweep pairs `dealloc` with `gc_type_finalize_unmarked_payload`/`layout_clear_for_ptr`, which touch **other** thread-locals (`MAP_REGISTRY`, `MAP_INDEX`, `PROMISE_CONTEXTS`, async-hooks queues). TLS destruction order is unspecified, so reaching an already-destroyed TLS during this `Drop` would panic ("cannot access a Thread Local Storage value during or after destruction") and abort the thread — worse than the leak. We reclaim only the object blocks (the audit's primary worker-exit leak); external side-allocations (a Map's entry table, an error's side tables) are left to the fuller rework, and the re-entrant `MALLOC_STATE.with(...)` the sweep bookkeeping performs is avoided. **Pinned objects are skipped**, mirroring the sweep, so a cross-thread promise pinned for an in-flight result is never yanked.

Scoped to `MALLOC_STATE` per the task's "only if clearly safe" guidance; the small-buffer slab / buffer registry are **not** touched here (their finalizer-free freeing safety wasn't clear).

## Deferred

### 3. Owner-ThreadId-tagged timer dispatch (audit P0 mitigation) — BLOCKED
The naive slice (tag each queued timer with `std::thread::current().id()` at schedule time; have the tick/fire functions skip entries whose owner `!=` current thread) **would break all Android timer delivery**, and this is a real, active configuration — exactly the "timers legitimately fire on a different thread than created" case flagged in the task:

- `crates/perry-ui-android/src/app.rs` `nativePumpTick` (JNI, ~8ms) calls `js_callback_timer_tick` / `js_interval_timer_tick` **on the UI thread**, while TypeScript (and thus `setTimeout`/`setInterval` scheduling) runs on the **perry-native thread**. The in-file comment states this explicitly: *"Timer state is global (Mutex-protected), so this works from the UI thread even though timers were registered on the perry-native thread."*
- `timer.rs`'s own module doc documents the same design: *"Uses global Mutex-protected state (not thread_local) so that timers registered on one thread can be pumped from another. This is critical on Android…"*

A blanket owner-skip would make the UI-thread pump skip every perry-native-registered timer → `setTimeout`/`setInterval` never fire on Android. A safe variant (quarantine only known `spawn`/`parallelMap` worker-origin timers) is no longer the "narrow mechanical slice" this PR targets — it needs a worker-thread registry and answers to "should a quarantined timer ever fire". Per the audit this P0 belongs to the **per-thread-queue rework** (Wave 4 threading-model decision), not this slice. No timer code changed.

## Tests
`PERRY_NO_AUTO_OPTIMIZE=1 cargo test -p perry-runtime --lib -- --test-threads=1` → **1219 passed, 0 failed**. New unit tests:

- **#1** — `serialize_nanbox_for_thread` on a **real Map** yields `Unsupported("Map")` (the concrete audit case, not silent undefined); the boundary check recurses through array/object/closure trees; supported values (undefined/null/bool/int32/f64/string/array + round-trip) still transfer with no `Unsupported`; type-name mapping is human-readable.
- **#2** — TLS `Drop` can't be exercised directly from a unit test (fires only at real thread teardown), so a `#[cfg(test)]` helper drives the shared free path on a TLS-independent `MallocState`: asserts the exact freed-byte total, that `objects` is drained (idempotent second call frees 0), and that **pinned** objects are skipped.

## What remains for the full threading-model decision
The audit's Wave 4: either enforce single-JS-thread discipline mechanically (owner-tagged **per-thread** queues + compiler rejection of module-global access in thread closures) or commit to real multi-heap isolation. Beyond deferred #3, still open from §6: module globals aliasing the main heap into workers, per-thread GCs scanning shared global tables without coordination, the `await`-loop draining process-global completion queues cross-heap, and `ws.rs`'s deferred-resolution tag bug.

Ref **#6185**; 2026-07-09 GC audit §6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-thread operations so unsupported values now fail with a clear error instead of silently becoming `undefined`.
  * `parallelMap`, `parallelFilter`, and background task results now surface transfer issues more reliably.
  * Fixed a leak when a background task fails early, preventing pinned work from being left behind.
  * Reduced memory waste by releasing tracked allocations when runtime state shuts down.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->