### PR TITLE
perf(gc): let mutator assists drive all incremental phases (#6180)

### DIFF
--- a/crates/perry-runtime/src/gc/cycle.rs
+++ b/crates/perry-runtime/src/gc/cycle.rs
@@ -42,17 +42,6 @@ impl GcCyclePhase {
             Self::Complete => 8,
         }
     }
-
-    #[inline]
-    pub(super) const fn mutator_assist_honors_budget(self) -> bool {
-        matches!(
-            self,
-            Self::BuildValidPointerSet
-                | Self::RootScan
-                | Self::MarkPropagation
-                | Self::BlockPersistence
-        )
-    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/perry-runtime/src/gc/policy.rs
+++ b/crates/perry-runtime/src/gc/policy.rs
@@ -1758,17 +1758,12 @@ enum BudgetedStepOutcome {
 }
 
 fn gc_budgeted_step_work_units_inner(work_units: usize) -> JsGcStepResult {
-    gc_budgeted_step_work_units_inner_with_progress(
-        work_units,
-        GcProgressKind::NormalIncremental,
-        false,
-    )
+    gc_budgeted_step_work_units_inner_with_progress(work_units, GcProgressKind::NormalIncremental)
 }
 
 fn gc_budgeted_step_work_units_inner_with_progress(
     work_units: usize,
     start_progress_kind: GcProgressKind,
-    mutator_assist_only: bool,
 ) -> JsGcStepResult {
     if work_units == 0 {
         return gc_budgeted_status_result();
@@ -1804,14 +1799,6 @@ fn gc_budgeted_step_work_units_inner_with_progress(
             return BudgetedStepOutcome::Result(gc_idle_step_result());
         };
 
-        if mutator_assist_only && !cycle.state.phase().mutator_assist_honors_budget() {
-            return BudgetedStepOutcome::Result(gc_cycle_step_result(
-                JS_GC_STEP_STATUS_ACTIVE,
-                cycle,
-                false,
-            ));
-        }
-
         let step = cycle.state.step(GcWorkBudget::bounded(work_units));
         if step.completed {
             BudgetedStepOutcome::Completed(slot.take().expect("active budgeted GC cycle exists"))
@@ -1830,11 +1817,23 @@ fn gc_budgeted_step_work_units_inner_with_progress(
     }
 }
 
+/// Allocation-side mutator assist: a bounded (`GC_MUTATOR_ASSIST_WORK_UNITS`)
+/// slice of GC work performed from the allocator (`gc_check_trigger`) rather
+/// than from a host safepoint. Assists drive **every** resumable phase of the
+/// active budgeted cycle, exactly like a host safepoint — the only difference
+/// is the smaller per-step budget carried in `work_units`. This is what closes
+/// the incremental sweep-parking hole (#6180): a pure compute loop that never
+/// reaches the event pump still finishes the cycle (and disables the mark
+/// barrier / reclaims memory) purely from the allocations it keeps making, so
+/// RSS stays bounded. `AtomicFinalizeSubphase::WeakProcessing` is the one
+/// phase step that is not yet internally sliced, so the assist that lands on it
+/// runs it whole — a single O(live-weak-holders) spike per cycle; slicing it is
+/// a tracked follow-up (pause-quality, not correctness).
 fn gc_mutator_assist_step_work_units_inner_with_progress(
     work_units: usize,
     start_progress_kind: GcProgressKind,
 ) -> JsGcStepResult {
-    gc_budgeted_step_work_units_inner_with_progress(work_units, start_progress_kind, true)
+    gc_budgeted_step_work_units_inner_with_progress(work_units, start_progress_kind)
 }
 
 pub(crate) fn gc_runtime_safepoint() -> JsGcStepResult {
@@ -1842,11 +1841,7 @@ pub(crate) fn gc_runtime_safepoint() -> JsGcStepResult {
     let Some(work_units) = budget.work_units else {
         return gc_budgeted_status_result();
     };
-    gc_budgeted_step_work_units_inner_with_progress(
-        work_units,
-        GcProgressKind::NormalIncremental,
-        false,
-    )
+    gc_budgeted_step_work_units_inner_with_progress(work_units, GcProgressKind::NormalIncremental)
 }
 
 fn write_gc_step_result(out: *mut JsGcStepResult, result: JsGcStepResult) -> u32 {

--- a/crates/perry-runtime/src/gc/tests/debt_pacer.rs
+++ b/crates/perry-runtime/src/gc/tests/debt_pacer.rs
@@ -165,8 +165,22 @@ fn active_cycle_gc_check_trigger_calls_pay_bounded_assist_work() {
     }
 }
 
+/// #6180: allocation-side mutator assists must drive the *entire* budgeted
+/// cycle to completion — through `AtomicFinalize`, `Sweep`, and `Reclaim` —
+/// using only the slice of work performed from `gc_check_trigger` (the
+/// allocator), never a host safepoint (`js_gc_step_work_units`).
+///
+/// Before #6180 the assist path bailed at the first non-mark phase, so a pure
+/// compute loop that never reached the event pump would start a cycle, advance
+/// it to `AtomicFinalize`, and park there forever: the incremental mark barrier
+/// stayed enabled and nothing was ever swept, so resident memory grew without
+/// bound. This proves the parking hole is closed — dead malloc churn is
+/// reclaimed and the live root survives, entirely from allocation-side assists.
+///
+/// Host-driven incremental sweep/reclaim *slicing* (partial-progress pauses) is
+/// covered separately in `incremental_sweep_reclaim.rs`.
 #[test]
-fn allocation_assists_stop_before_unsliced_finalize_and_sweep() {
+fn allocation_assists_complete_finalize_sweep_and_reclaim() {
     let _guard = CopyingNurseryTestGuard::new(1);
     let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
     reset_old_reclaim_pressure();
@@ -193,132 +207,54 @@ fn allocation_assists_stop_before_unsliced_finalize_and_sweep() {
     let before = gc_collection_count();
     gc_check_trigger();
 
-    let mut status = budgeted_step_until_phase(GcCyclePhase::AtomicFinalize);
-    assert_eq!(status.status, JS_GC_STEP_STATUS_ACTIVE);
-    assert_eq!(status.phase, GcCyclePhase::AtomicFinalize.ffi_code());
-
-    for _ in 0..8 {
-        gc_check_trigger();
-        assert_eq!(js_gc_step_status(&mut status), JS_GC_STEP_STATUS_ACTIVE);
-        assert_eq!(
-            status.phase,
-            GcCyclePhase::AtomicFinalize.ffi_code(),
-            "allocation-side assist must not run atomic finalize"
-        );
-        assert_eq!(
-            gc_collection_count(),
-            before,
-            "allocation-side assist must not complete the cycle"
-        );
-        assert_eq!(
-            tracked_malloc_headers_matching(&churn_headers),
-            churn_headers.len(),
-            "allocation-side assist must not reach malloc sweep through finalize"
-        );
-    }
-
-    let mut host_finalize_steps = 0usize;
-    while status.phase == GcCyclePhase::AtomicFinalize.ffi_code() {
-        assert_eq!(
-            js_gc_step_work_units(1, &mut status),
-            JS_GC_STEP_STATUS_ACTIVE
-        );
-        host_finalize_steps += 1;
-        assert!(
-            host_finalize_steps < 100_000,
-            "host-driven atomic finalize did not finish"
-        );
-        assert!(
-            status.phase == GcCyclePhase::AtomicFinalize.ffi_code()
-                || status.phase == GcCyclePhase::Sweep.ffi_code(),
-            "host-driven finalization should stay in atomic finalize or advance to sweep"
-        );
-    }
-    assert!(
-        host_finalize_steps > 0,
-        "host step should advance through atomic finalize"
-    );
-    assert_eq!(status.phase, GcCyclePhase::Sweep.ffi_code());
-
-    for _ in 0..8 {
-        gc_check_trigger();
-        assert_eq!(js_gc_step_status(&mut status), JS_GC_STEP_STATUS_ACTIVE);
-        assert_eq!(
-            status.phase,
-            GcCyclePhase::Sweep.ffi_code(),
-            "allocation-side assist must not run the unsliced sweep"
-        );
-        assert_eq!(
-            gc_collection_count(),
-            before,
-            "allocation-side assist must not complete the cycle"
-        );
-        assert_eq!(
-            tracked_malloc_headers_matching(&churn_headers),
-            churn_headers.len(),
-            "allocation-side assist must not reclaim malloc churn from sweep"
-        );
-    }
-
-    let mut saw_partial_sweep = false;
+    // Drive the active budgeted cycle using ONLY allocation-side assists: every
+    // `gc_check_trigger()` performs one bounded assist step, and we observe the
+    // phase after each. We never call `js_gc_step_work_units` (the host path).
+    let mut status = JsGcStepResult::default();
+    let mut reached_finalize = false;
+    let mut reached_sweep = false;
+    let mut reached_reclaim = false;
+    let mut completed = false;
     for _ in 0..500_000 {
-        assert_eq!(
-            js_gc_step_work_units(1, &mut status),
-            JS_GC_STEP_STATUS_ACTIVE
-        );
-        if status.phase == GcCyclePhase::Reclaim.ffi_code() {
+        gc_check_trigger();
+        js_gc_step_status(&mut status);
+        if status.phase == GcCyclePhase::AtomicFinalize.ffi_code() {
+            reached_finalize = true;
+        } else if status.phase == GcCyclePhase::Sweep.ffi_code() {
+            reached_sweep = true;
+        } else if status.phase == GcCyclePhase::Reclaim.ffi_code() {
+            reached_reclaim = true;
+        }
+        if gc_collection_count() > before {
+            completed = true;
             break;
         }
-        assert_eq!(status.phase, GcCyclePhase::Sweep.ffi_code());
-        let remaining = tracked_malloc_headers_matching(&churn_headers);
-        if remaining < churn_headers.len() {
-            saw_partial_sweep = true;
-        }
-        assert_eq!(
-            gc_collection_count(),
-            before,
-            "host-driven incremental sweep must not complete the cycle"
-        );
     }
+
     assert!(
-        saw_partial_sweep,
-        "host-driven sweep should pause after reclaiming part of malloc churn"
+        completed,
+        "allocation-side assists alone must drive the budgeted cycle to completion (#6180 parking hole)"
     );
-    assert_eq!(status.phase, GcCyclePhase::Reclaim.ffi_code());
+    assert!(
+        reached_finalize && reached_sweep && reached_reclaim,
+        "assists must advance through atomic finalize, sweep, and reclaim \
+         (finalize={reached_finalize} sweep={reached_sweep} reclaim={reached_reclaim})"
+    );
     assert_eq!(
         tracked_malloc_headers_matching(&churn_headers),
         0,
-        "host-driven sweep should reclaim dead malloc churn before reclaim"
+        "assist-driven sweep must reclaim dead malloc churn"
     );
-
-    for _ in 0..8 {
-        gc_check_trigger();
-        assert_eq!(js_gc_step_status(&mut status), JS_GC_STEP_STATUS_ACTIVE);
-        assert_eq!(
-            status.phase,
-            GcCyclePhase::Reclaim.ffi_code(),
-            "allocation-side assist must not run unsliced reclaim"
-        );
-        assert_eq!(
-            gc_collection_count(),
-            before,
-            "allocation-side assist must not complete the cycle from reclaim"
-        );
-    }
-
-    let completed = complete_budgeted_gc_cycle();
-    assert_eq!(completed.status, JS_GC_STEP_STATUS_COMPLETED);
     assert!(
         malloc_user_ptr_tracked(live_malloc),
-        "live malloc root should survive after host drains the cycle"
+        "live malloc root must survive the assist-driven cycle"
     );
+    let live_after = (js_shadow_slot_get(0) & POINTER_MASK) as usize;
     assert_eq!(
-        tracked_malloc_headers_matching(&churn_headers),
-        0,
-        "host-drained sweep should reclaim dead malloc churn"
+        live_after, live_malloc as usize,
+        "live root must remain reachable via the shadow slot after assists drain the cycle"
     );
 }
-
 fn noop_copy_only_root_scanner(_visit: &mut dyn FnMut(f64)) {}
 
 /// Regression: the direct synchronous minor — taken whenever synchronous-only


### PR DESCRIPTION
## Summary

Closes the incremental-GC **sweep-parking hole** (#6180): under `PERRY_GC_INCREMENTAL`, a pure compute loop that never reaches the event pump could start a budgeted collection cycle, advance it to `AtomicFinalize`, and **park there forever** — the incremental mark barrier stayed enabled and nothing was ever swept, so resident memory grew without bound.

## Root cause

Allocation-side **mutator assists** (the slice of GC work `gc_check_trigger` performs from the allocator) were gated by `GcCyclePhase::mutator_assist_honors_budget()`, which only permitted the four *mark* phases:

```
BuildValidPointerSet | RootScan | MarkPropagation | BlockPersistence
```

`AtomicFinalize`, `Sweep`, and `Reclaim` advanced **only** at a host safepoint (`gc_runtime_safepoint`, reached from the event pump / microtask drain). A workload that never pumps therefore drives the cycle up to `AtomicFinalize` via assists and then stalls: `gc_budgeted_cycle_active()` stays true (so no new cycle starts either), the barrier never disables, and no memory is reclaimed.

## Fix

Let mutator assists drive **every** resumable phase, exactly like a host safepoint — the only difference is the smaller per-step budget carried in `work_units`. Concretely:

- Remove the `mutator_assist_only && !phase.mutator_assist_honors_budget()` early-return in the budgeted stepper.
- Delete the now-dead `GcCyclePhase::mutator_assist_honors_budget()` method and the redundant `mutator_assist_only` parameter (the assist-vs-host distinction that actually matters — budget sizing — already rides on `GcProgressKind` + the passed `work_units`).

Reentering the finalize/sweep/reclaim machinery from an allocation context is already an exercised, safe pattern: the existing *direct-fallback* synchronous mark-sweep in `gc_check_trigger` runs the whole collection (root scan + mark + sweep + reclaim) from these exact call sites. `Sweep` and `Reclaim` are already internally budget-sliced (`IncrementalSweepState`, `RememberedSetClearState`, `ConservativePinClearState`), and budgeted cycles are asserted non-moving, so no evacuation runs on the assist path.

Every assist step stays bounded at `GC_MUTATOR_ASSIST_WORK_UNITS`, so this does **not** reintroduce an unbounded pause — with the one caveat below.

## Scope / caveat

`AtomicFinalizeSubphase::WeakProcessing` (`process_weak_targets_after_mark`) is the single phase step that is not yet internally sliced — it does one unbudgeted `arena_walk_objects`. The assist that lands on it runs it whole, i.e. one `O(live-weak-holders)` spike per cycle. That's a **pause-quality** issue, not correctness (RSS is now bounded regardless), and slicing it (snapshot the live weak-holder set, then process in budgeted slices, gated to non-evacuating cycles) is a tracked follow-up that belongs with the separate *default-on graduation* work. `PERRY_GC_INCREMENTAL` remains experimental/default-off; this PR is the Stage-1 correctness fix that makes it viable.

## Test

Rewrote the test that previously asserted the *buggy* behavior (`allocation_assists_stop_before_unsliced_finalize_and_sweep`) into `allocation_assists_complete_finalize_sweep_and_reclaim`, which drives a budgeted cycle to completion using **only** `gc_check_trigger` (never a host `js_gc_step_work_units`) and asserts it advances through atomic-finalize → sweep → reclaim, reclaims dead malloc churn, and preserves the live root. Host-driven incremental sweep/reclaim *slicing* coverage is unchanged in `incremental_sweep_reclaim.rs`.

`cargo test -p perry-runtime --lib gc::` → 427 passed (the one unrelated failure, `large_object_old_born_array_slot_write_keeps_young_child_alive`, is a pre-existing test-order fragility that fails identically on the base without this change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Allocation-side GC assists now continue through finalize, sweep, and reclaim phases more consistently, helping dead memory be reclaimed without requiring extra host-driven stepping.
  * GC cycle progression behavior was simplified so budgeted steps follow a more consistent path during normal collection work.

* **Tests**
  * Updated GC coverage to verify that allocation-triggered assists can complete an entire collection cycle and reclaim dead memory correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->