### PR TITLE
fix(json): stringify replacer walks — sparse holes as undefined + overflow (>8) properties

### DIFF
--- a/crates/perry-runtime/src/json/replacer.rs
+++ b/crates/perry-runtime/src/json/replacer.rs
@@ -358,8 +358,14 @@ pub(crate) unsafe fn stringify_object_with_replacer_pretty(
     let fields_ptr =
         (ptr as *const u8).add(std::mem::size_of::<crate::ObjectHeader>()) as *const f64;
 
-    // Use keys_len as the iteration count since field_count may include pre-allocated slots.
-    let actual_fields = std::cmp::min(num_fields, keys_len);
+    // #5989 (mirrors the plain-stringify #307 fix): iterate up to keys_len, not
+    // min(num_fields, keys_len). Objects with ≥9 fields cap field_count at the
+    // inline alloc limit and store the overflow values in OVERFLOW_FIELDS, so
+    // num_fields can be smaller than keys_len — the min() silently DROPPED
+    // every overflow property from replacer serialization (react-server-dom's
+    // flight props objects routinely exceed 8 keys).
+    let alloc_limit = std::cmp::max(num_fields, 8);
+    let actual_fields = keys_len;
     let use_pretty = !indent.is_empty();
     let inner_depth = depth + 1;
     // A function replacer only sees own ENUMERABLE keys (EnumerableOwnProperty
@@ -400,8 +406,14 @@ pub(crate) unsafe fn stringify_object_with_replacer_pretty(
         };
 
         // Get the field value (invoking an own getter, as spec [[Get]] does),
-        // resolve toJSON, then apply the replacer.
-        let mut field_val = *fields_ptr.add(f as usize);
+        // resolve toJSON, then apply the replacer. Overflow slots (f >=
+        // alloc_limit) route through js_object_get_field's OVERFLOW_FIELDS
+        // lookup.
+        let mut field_val = if f < alloc_limit {
+            *fields_ptr.add(f as usize)
+        } else {
+            f64::from_bits(crate::object::js_object_get_field(obj, f).bits())
+        };
         if filter_non_enum && f < keys_len {
             if let Some(gv) =
                 crate::object::json_object_getter_value(obj, *keys_elements.add(f as usize))
@@ -822,7 +834,10 @@ pub(crate) unsafe fn stringify_object_pretty(
         (keys_arr as *const u8).add(std::mem::size_of::<crate::ArrayHeader>()) as *const f64;
     let fields_ptr =
         (ptr as *const u8).add(std::mem::size_of::<crate::ObjectHeader>()) as *const f64;
-    let actual_fields = std::cmp::min(num_fields, keys_len);
+    // Iterate keys_len, not min(...): ≥9-field objects keep overflow values in
+    // OVERFLOW_FIELDS (see the function-replacer walk above / plain #307 fix).
+    let alloc_limit = std::cmp::max(num_fields, 8);
+    let actual_fields = keys_len;
     // Only own ENUMERABLE keys are serialized (gated for the common case).
     let filter_non_enum = crate::object::descriptors_in_use();
 
@@ -837,7 +852,11 @@ pub(crate) unsafe fn stringify_object_pretty(
         {
             continue;
         }
-        let mut field_val = *fields_ptr.add(f as usize);
+        let mut field_val = if f < alloc_limit {
+            *fields_ptr.add(f as usize)
+        } else {
+            f64::from_bits(crate::object::js_object_get_field(obj, f).bits())
+        };
         // Own accessor properties: serialize the getter's return value.
         if filter_non_enum && f < keys_len {
             if let Some(gv) =
@@ -968,7 +987,10 @@ pub(crate) unsafe fn stringify_object_with_array_replacer(
         (keys_arr as *const u8).add(std::mem::size_of::<crate::ArrayHeader>()) as *const f64;
     let fields_ptr =
         (ptr as *const u8).add(std::mem::size_of::<crate::ObjectHeader>()) as *const f64;
-    let actual_fields = std::cmp::min(num_fields, keys_len);
+    // Iterate keys_len, not min(...): ≥9-field objects keep overflow values in
+    // OVERFLOW_FIELDS (see the function-replacer walk above / plain #307 fix).
+    let alloc_limit = std::cmp::max(num_fields, 8);
+    let actual_fields = keys_len;
 
     // Build a map of key_name -> field_value for the object. An own accessor
     // (`get key()`) holds no value in its raw slot, so resolve it through the
@@ -977,7 +999,11 @@ pub(crate) unsafe fn stringify_object_with_array_replacer(
     let filter_non_enum = crate::object::descriptors_in_use();
     let mut field_map: Vec<(String, f64)> = Vec::new();
     for f in 0..actual_fields {
-        let mut field_val = *fields_ptr.add(f as usize);
+        let mut field_val = if f < alloc_limit {
+            *fields_ptr.add(f as usize)
+        } else {
+            f64::from_bits(crate::object::js_object_get_field(obj, f).bits())
+        };
         if filter_non_enum && f < keys_len {
             if let Some(gv) =
                 crate::object::json_object_getter_value(obj, *keys_elements.add(f as usize))

--- a/crates/perry-runtime/src/json/replacer.rs
+++ b/crates/perry-runtime/src/json/replacer.rs
@@ -505,6 +505,18 @@ pub(crate) unsafe fn stringify_array_with_replacer_pretty(
             }
         }
         let elem = *elements.add(i as usize);
+        // #5989: a sparse-array HOLE slot must surface to toJSON / the replacer
+        // as `undefined` (spec: Get() on a missing index yields undefined),
+        // never as the raw TAG_HOLE sentinel — the sentinel is an unrecognized
+        // quiet-NaN bit pattern, so user code saw a number-NaN and e.g.
+        // react-server-dom's flight encoder serialized "$NaN" where node emits
+        // "$undefined" (Next.js sparse flightRouterState tuples:
+        // `seg[4] = flags` on a length-2 array).
+        let elem = if elem.to_bits() == crate::value::TAG_HOLE {
+            f64::from_bits(TAG_UNDEFINED)
+        } else {
+            elem
+        };
 
         // Index key as a string for toJSON / replacer.
         let idx_str = i.to_string();
@@ -908,7 +920,8 @@ pub(crate) unsafe fn stringify_array_pretty(
         }
         let elem = *elements.add(i as usize);
         let elem_bits = elem.to_bits();
-        if elem_bits == TAG_UNDEFINED {
+        // TAG_HOLE: sparse-array holes serialize as null, same as undefined.
+        if elem_bits == TAG_UNDEFINED || elem_bits == crate::value::TAG_HOLE {
             buf.push_str("null");
         } else {
             stringify_value_pretty(elem, TYPE_UNKNOWN, buf, indent, inner_indent_count);
@@ -1147,7 +1160,11 @@ pub(crate) unsafe fn stringify_array_with_array_replacer(
         }
         let elem = *elements.add(i as usize);
         let elem_bits = elem.to_bits();
-        if elem_bits == TAG_UNDEFINED || is_closure_value(elem_bits) {
+        // TAG_HOLE: sparse-array holes serialize as null, same as undefined.
+        if elem_bits == TAG_UNDEFINED
+            || elem_bits == crate::value::TAG_HOLE
+            || is_closure_value(elem_bits)
+        {
             buf.push_str("null");
         } else {
             stringify_value_with_array_replacer(

--- a/test-files/test_gap_json_replacer_sparse_hole.ts
+++ b/test-files/test_gap_json_replacer_sparse_hole.ts
@@ -1,0 +1,50 @@
+// JSON.stringify with a replacer must surface sparse-array HOLES to the
+// replacer (and toJSON) as `undefined` — per spec, SerializeJSONArray does
+// Get(holder, index), and a missing index yields undefined. Perry's replacer
+// walk read the raw element slot, so a hole leaked its internal sentinel — an
+// unrecognized quiet-NaN bit pattern that user code observed as a NaN number.
+//
+// react-server-dom's flight encoder branches `typeof v === "number"` (with the
+// isFinite/NaN chain) BEFORE its undefined check, so Next.js sparse
+// flightRouterState tuples (`seg[4] = flags` on a length-2 array → holes at
+// 2,3) serialized as "$NaN" instead of "$undefined" — corrupting the RSC
+// payload of every App Router dynamic route (#5989).
+//
+// Validated byte-for-byte against `node --experimental-strip-types`.
+
+// The flight-encoder shape: typeof-number branch first, then undefined.
+function flightReplacer(this: any, k: string, v: any): any {
+  if (k === "") return v;
+  if (typeof v === "number") return Number.isFinite(v) ? v : "$NaN";
+  if (v === undefined) return "$undefined";
+  return v;
+}
+
+// (1) literal holes
+console.log(JSON.stringify([1, , 3], flightReplacer));
+
+// (2) the Next.js sparse-tuple shape: length-2 array extended by index-4 write
+const seg: any[] = ["", {}];
+seg[1] = { children: ["plain", {}] };
+let flags = 0;
+flags |= 16;
+if (flags !== 0) seg[4] = flags;
+console.log(JSON.stringify(seg, flightReplacer));
+
+// (3) replacer receives undefined (not a NaN number) for the hole value param
+JSON.stringify([, 7], (k, v) => {
+  if (k === "0") console.log(typeof v, v === undefined, typeof v === "number" && Number.isNaN(v));
+  return v;
+});
+
+// (4) holes + replacer that returns the value unchanged → null in output
+console.log(JSON.stringify([, 7], (_k, v) => v));
+
+// (5) pretty-print variant walks the same path
+console.log(JSON.stringify([1, , 3], flightReplacer, 1));
+
+// (6) array-of-allowed-keys replacer form over an array with holes
+console.log(JSON.stringify({ a: [1, , 3] }, ["a"] as any));
+
+// (7) real NaN still round-trips as "$NaN" through the same replacer
+console.log(JSON.stringify([NaN, , 2], flightReplacer));

--- a/test-files/test_gap_json_replacer_sparse_hole.ts
+++ b/test-files/test_gap_json_replacer_sparse_hole.ts
@@ -48,3 +48,22 @@ console.log(JSON.stringify({ a: [1, , 3] }, ["a"] as any));
 
 // (7) real NaN still round-trips as "$NaN" through the same replacer
 console.log(JSON.stringify([NaN, , 2], flightReplacer));
+
+// (8) objects with >8 properties: overflow fields must reach the replacer
+// (field_count caps at the inline slot limit; overflow values live in a side
+// table — the walk previously dropped every property past the 8th).
+const big: any = {
+  p1: 1, p2: 2, p3: 3, p4: 4, p5: 5, p6: 6, p7: 7, p8: 8, p9: 9, p10: 10,
+  p11: 11, p12: 12, p13: 13, notFound: undefined, forbidden: undefined, unauthorized: undefined,
+};
+console.log(JSON.stringify(big, flightReplacer));
+
+// (9) exactly 9 props (first overflow slot), last one undefined-valued
+const nine: any = { a1: 1, a2: 2, a3: 3, a4: 4, a5: 5, a6: 6, a7: 7, a8: 8, a9: undefined };
+console.log(JSON.stringify(nine, flightReplacer));
+
+// (10) overflow props through the sorted/pretty walk
+console.log(JSON.stringify(big, flightReplacer, 1).split("\n").length);
+
+// (11) overflow props through the allowed-keys form
+console.log(JSON.stringify(big, ["p9", "p13", "forbidden"] as any));


### PR DESCRIPTION
## Problem

`JSON.stringify` with a replacer leaked the internal sparse-array HOLE sentinel
into user code. The replacer walk read the raw element slot, so for a hole the
replacer (and `toJSON`) received the sentinel — an unrecognized quiet-NaN bit
pattern that user code observes as a NaN *number* — instead of `undefined`
(spec: `SerializeJSONArray` does `Get(holder, index)`; a missing index yields
`undefined`).

react-server-dom's flight encoder branches on `typeof v === "number"` (with the
isFinite/NaN chain) *before* its undefined check, so it serialized `"$NaN"`
where Node emits `"$undefined"`. Next.js builds sparse `FlightRouterState`
tuples exactly this way —

```js
const segmentTree = [segment, {}];
if (prefetchHints !== 0) segmentTree[4] = prefetchHints;   // holes at 2, 3
```

— which corrupted the RSC payload of every App Router dynamic route: the
client-side flight parser then rejected the rows and the render 500'd (#5989).

```js
JSON.stringify([, 7], (k, v) => (k === "0" ? String(v === undefined) : v));
// Node: "true"   Perry (before): the hole arrived as a NaN number
```

## Fix

In the replacer array walk (`json/replacer.rs`), normalize a `TAG_HOLE` element
to `undefined` before `toJSON` / the replacer see it. The two array variants
that stringify elements directly (pretty printer, array-of-allowed-keys form)
now treat `TAG_HOLE` like `undefined` (→ `null`), matching the spec and the
existing plain-stringify behavior.

## Validation

New gap test `test_gap_json_replacer_sparse_hole.ts`, byte-for-byte against
`node --experimental-strip-types`: literal holes, the Next.js sparse-tuple
shape (`seg[4] = flags` on a length-2 array with the flight-encoder replacer),
the hole value param arriving as real `undefined`, identity replacer (→ null),
pretty-print variant, allowed-keys form, and a real-NaN control that still
serializes as `"$NaN"`.


## Second fix in this PR: overflow (>8) properties dropped from replacer walks

The replacer object walks iterated `min(field_count, keys_len)` — but objects
with ≥9 fields cap `field_count` at the inline slot limit and keep overflow
values in a side table, so **every property past the 8th was silently dropped**
from replacer serialization (plain stringify already fixed this truncation for
#307; the replacer walks never got the fix).

```js
const o = { p1:1, …, p13:13, forbidden: undefined };
JSON.stringify(o, replacer);   // before: only p1…p8 emitted
```

react-server-dom's flight props objects routinely exceed 8 keys, so Next.js RSC
payloads lost the `notFound` / `forbidden` / `unauthorized` slots of
layout-router elements. All three walks (function replacer, sorted/pretty,
allowed-keys) now iterate `keys_len` and route overflow slots through
`js_object_get_field`. Gap test extended with >8-field objects through each
walk.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `JSON.stringify` handling for sparse array holes to behave consistently with `undefined` across replacer and pretty-print modes.
  * Replacer callbacks and `toJSON` now receive holes as `undefined` (no internal placeholder).
  * Sparse holes are serialized consistently (including `null` behavior where appropriate) and now work correctly for whitelist-style array replacers.
  * Prevented object serialization from skipping overflowed properties when internal field limits are reached.
* **Tests**
  * Added regression tests covering sparse holes, non-finite number handling, pretty output, and overflow-property traversal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->