### PR TITLE
fix(codegen): `continue` inside switch targets the enclosing loop, not the switch exit

### DIFF
--- a/crates/perry-codegen/src/stmt/mod.rs
+++ b/crates/perry-codegen/src/stmt/mod.rs
@@ -377,9 +377,15 @@ pub(crate) fn lower_stmt(ctx: &mut FnCtx<'_>, stmt: &Stmt) -> Result<()> {
         // (which is the update block for `for`, the cond block for
         // `while`/`do-while`).
         Stmt::Continue => {
+            // Scan outward past switch frames: a switch pushes a loop_targets
+            // entry with an EMPTY cont slot (it is a break target only), so
+            // `continue` inside a switch must resolve to the innermost real
+            // LOOP, not the switch exit (#5989 — see switch_stmt.rs).
             let (cont_label, target_depth) = ctx
                 .loop_targets
-                .last()
+                .iter()
+                .rev()
+                .find(|(c, _b, _d)| !c.is_empty())
                 .map(|(c, _b, d)| (c.clone(), *d))
                 .ok_or_else(|| anyhow!("continue statement outside any loop"))?;
             // Pop try frames escaped by jumping back to the loop header
@@ -472,9 +478,12 @@ pub(crate) fn lower_stmt(ctx: &mut FnCtx<'_>, stmt: &Stmt) -> Result<()> {
                 if let Some((cont, _brk, depth)) = ctx.label_targets.get(label).cloned() {
                     (cont, depth)
                 } else {
-                    // Fallback: use innermost loop.
+                    // Fallback: innermost real LOOP — skip switch frames, whose
+                    // cont slot is the empty break-only sentinel (#5989).
                     ctx.loop_targets
-                        .last()
+                        .iter()
+                        .rev()
+                        .find(|(c, _b, _d)| !c.is_empty())
                         .map(|(c, _b, d)| (c.clone(), *d))
                         .ok_or_else(|| anyhow!("labeled continue '{}' outside any loop", label))?
                 };

--- a/crates/perry-codegen/src/stmt/switch_stmt.rs
+++ b/crates/perry-codegen/src/stmt/switch_stmt.rs
@@ -65,9 +65,16 @@ pub(crate) fn lower_switch(
         }
     }
 
-    // Push break target. Switch has no continue, so we use exit for both.
+    // Push break target. A switch has NO continue target — the cont slot is an
+    // empty sentinel so `Stmt::Continue` skips this entry and resolves to the
+    // innermost enclosing LOOP. (It previously pushed the exit label for both,
+    // so `continue` inside a switch-in-loop branched to the switch EXIT — i.e.
+    // it behaved like `break` and fell into the post-switch tail. react-server-
+    // dom's flight row parser is a for-loop state machine whose case arms end
+    // in `continue`; every row-boundary step executed the row-commit tail with
+    // a stale slice index, mis-framing every RSC row — #5989.)
     ctx.loop_targets
-        .push((exit_label.clone(), exit_label.clone(), ctx.try_depth));
+        .push((String::new(), exit_label.clone(), ctx.try_depth));
 
     // If this switch carries a pending label (from an enclosing
     // `a: switch (...)`), register it so `break a;` resolves to THIS

--- a/test-files/test_gap_switch_continue_loop.ts
+++ b/test-files/test_gap_switch_continue_loop.ts
@@ -1,0 +1,130 @@
+// `continue` inside a `switch` inside a loop must jump to the LOOP's continue
+// target — never fall into the post-switch tail (which only `break` arms
+// reach). The switch lowering pushed its exit label as BOTH the break and
+// continue target, so `continue` compiled exactly like `break`: every case arm
+// ending in `continue` executed the code after the switch with stale locals.
+//
+// react-server-dom's flight row parser is a for-loop state machine whose case
+// arms end in `continue`; each row-boundary step fell into the row-commit tail
+// with a stale slice index, mis-framing every RSC row Next.js streamed (#5989).
+//
+// Validated byte-for-byte against `node --experimental-strip-types`.
+
+// (1) basic: case-0's continue must skip the tail; only case-1's break reaches it
+function t1(): string {
+  let hits = 0;
+  const log: string[] = [];
+  for (let i = 0; i < 4; ) {
+    switch (i) {
+      case 0:
+        i = 1;
+        log.push("c0");
+        continue;
+      case 1:
+        i = 2;
+        log.push("c1");
+        break;
+    }
+    hits++;
+    log.push(`tail(i=${i})`);
+    i = 4;
+  }
+  return `hits=${hits} ${log.join(",")}`;
+}
+console.log(t1());
+
+// (2) a var written before the switch (the parser's `d` pattern): the tail must
+// only ever observe the break arm's value
+function t2(): string {
+  const log: string[] = [];
+  for (let i = 0, guard = 0; i < 10 && guard < 8; guard++) {
+    let d = -1;
+    switch (i % 2) {
+      case 0:
+        d = 100 + i;
+        i++;
+        log.push(`even d${d}`);
+        continue;
+      case 1:
+        d = 7;
+        i++;
+        break;
+    }
+    log.push(`tail d${d} i${i}`);
+  }
+  return log.join(",");
+}
+console.log(t2());
+
+// (3) while-loop + default arm with continue
+function t3(): string {
+  const log: string[] = [];
+  let i = 0;
+  let guard = 0;
+  while (i < 6 && guard++ < 10) {
+    switch (i) {
+      case 0:
+        i = 2;
+        log.push("a");
+        continue;
+      case 2:
+        i = 4;
+        log.push("b");
+        break;
+      default:
+        i = 6;
+        log.push("c");
+        continue;
+    }
+    log.push("tail" + i);
+  }
+  return log.join(",");
+}
+console.log(t3());
+
+// (4) the flight-parser shape: byte state machine over a Uint8Array, rows
+// delimited by ':' and '\n' — every framing step continues; the commit tail
+// runs only via the case-with-break
+function t4(): string {
+  const bytes = new Uint8Array([49, 58, 104, 105, 10, 50, 58, 106, 10]); // "1:hi\n2:j\n"
+  const rows: string[] = [];
+  let iter = 0;
+  for (var n = 0, a = 0, o = 0, c = bytes.length; n < c; ) {
+    if (++iter > 50) return "STUCK";
+    var d = -1;
+    switch (a) {
+      case 0:
+        58 === (d = bytes[n++]) ? (a = 1) : (o = (o << 4) | (d - 48));
+        continue;
+      case 1:
+        d = bytes.indexOf(10, n);
+        break;
+    }
+    if (-1 < d) {
+      rows.push(`${o}:${d - n}`);
+      n = d + 1;
+      o = a = 0;
+    } else break;
+  }
+  return rows.join(",");
+}
+console.log(t4());
+
+// (5) continue inside switch inside a LABELED outer loop via plain continue
+function t5(): string {
+  const log: string[] = [];
+  outer: for (let i = 0; i < 3; i++) {
+    for (let j = 0; j < 3; j++) {
+      switch (j) {
+        case 0:
+          log.push(`i${i}j${j}`);
+          continue; // inner loop
+        case 1:
+          continue outer;
+      }
+      log.push("unreachable-tail");
+    }
+  }
+  return log.join(",");
+}
+console.log(t5());


### PR DESCRIPTION
## Problem

`continue` inside a `switch` inside a loop compiled exactly like `break`: it
branched to the **switch exit** and fell into the post-switch tail instead of
jumping to the loop's continue target.

The switch lowering pushed its exit label onto `loop_targets` as **both** the
break and continue slot (the comment said as much: *"Switch has no continue, so
we use exit for both"*), and `Stmt::Continue` resolves against the innermost
`loop_targets` entry — the switch.

```js
for (let i = 0; i < 4; ) {
  switch (i) {
    case 0: i = 1; continue;   // fell into the tail below (with i = 1)
    case 1: i = 2; break;
  }
  tail();                       // must run only via the break arm
}
```

This mis-framed **every RSC row** in Next.js App Router SSR (#5989):
react-server-dom's flight row parser is a for-loop byte state machine whose
case arms end in `continue` —

```js
case 0: 58 === (d = r[n++]) ? (a = 1) : (o = o << 4 | …); continue;
```

— so every framing step executed the row-commit tail with a stale slice index,
the parser re-entered at byte values (`n = r[n]` chasing), and the flight
consumer saw duplicated/garbled rows (`TypeError: enqueueModel is not a
function`, infinite parse loops).

## Fix

- `switch_stmt.rs`: push the switch's `loop_targets` entry with an **empty
  continue slot** — it is a break target only.
- `stmt/mod.rs` `Stmt::Continue` (and the `LabeledContinue` innermost-loop
  fallback): scan `loop_targets` outward past empty-cont entries to the
  innermost real **loop**. `break` semantics are unchanged (`.last()` — a
  switch exit is the correct innermost break target), and the try-depth
  unwinding uses the resolved loop's recorded depth.

## Validation

New gap test `test_gap_switch_continue_loop.ts` — byte-for-byte against
`node --experimental-strip-types`: the basic tail-skip shape, the stale-var
pattern, `while` + `default: continue`, a miniature flight-style byte state
machine over a `Uint8Array`, and `continue` vs `continue label` in nested
loops. Existing loop/labeled-break/for-of gap tests re-validated unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `continue` statements inside `switch` blocks so they correctly continue the surrounding loop instead of exiting the switch.
  * Corrected labeled `continue` behavior in nested loops and switch statements.

* **Tests**
  * Added coverage for nested loops, labeled loops, and switch-based state-machine scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->