### PR TITLE
fix(runtime): dynamic index access — buffer-backed views + handle-band receivers

### DIFF
--- a/crates/perry-runtime/src/typedarray_props.rs
+++ b/crates/perry-runtime/src/typedarray_props.rs
@@ -640,6 +640,20 @@ pub(crate) unsafe fn typed_array_get_numeric_index(owner: usize, index: f64) -> 
 
 pub(crate) unsafe fn typed_array_index_get_dynamic(owner_bits: usize, key: f64) -> f64 {
     let Some(owner) = typed_array_addr_from_value(f64::from_bits(owner_bits as u64)) else {
+        // #5989: a `u8.subarray(...)` / `u8.slice(...)` of a BufferHeader-backed
+        // Uint8Array returns another (uint8array-marked) BUFFER, which the
+        // typed-array registry gate above doesn't know — a statically-typed
+        // `r[i]` on such a value silently read `undefined` (react-server-dom's
+        // flight row parser walks exactly these chunk views). Route buffer
+        // receivers through the generic dynamic index path, which handles
+        // BufferHeader indexing (numeric, string, and symbol keys) correctly.
+        let addr = owner_bits & crate::value::POINTER_MASK as usize;
+        if addr != 0 && crate::buffer::is_registered_buffer(addr) {
+            return crate::value::js_dyn_index_get(
+                crate::value::js_nanbox_pointer(addr as i64),
+                key,
+            );
+        }
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     };
     // A Symbol key is never an integer-indexed element — read it from the symbol
@@ -689,6 +703,17 @@ pub extern "C" fn js_typed_array_index_set_dynamic(
 ) -> f64 {
     unsafe {
         let Some(owner) = typed_array_addr_from_value(f64::from_bits(ta as u64)) else {
+            // #5989: BufferHeader-backed receivers (subarray/slice results) —
+            // mirror the get-side fallback so statically-typed `r[i] = v`
+            // stores aren't silently dropped.
+            let addr = (ta as usize) & crate::value::POINTER_MASK as usize;
+            if addr != 0 && crate::buffer::is_registered_buffer(addr) {
+                return crate::value::js_dyn_index_set(
+                    crate::value::js_nanbox_pointer(addr as i64),
+                    key,
+                    value,
+                );
+            }
             return value;
         };
         // A Symbol key is never an integer-indexed element — store it in the

--- a/crates/perry-runtime/src/value/dyn_index.rs
+++ b/crates/perry-runtime/src/value/dyn_index.rs
@@ -117,8 +117,28 @@ pub extern "C" fn js_dyn_index_get(value: f64, index: f64) -> f64 {
     } else {
         return f64::from_bits(TAG_UNDEFINED);
     };
-    if raw_ptr < 0x10000 {
-        return f64::from_bits(TAG_UNDEFINED);
+    if crate::value::addr_class::is_small_handle(raw_ptr) {
+        // #5989: registry HANDLES (fetch/native ids) live below HANDLE_BAND_MAX
+        // (0x100000). The old guard only excluded the first 64KB, so a handle
+        // in [0x10000, 0x100000) indexed as `h[key]` fell through to the raw
+        // ObjectHeader walk below and dereferenced the id as a pointer —
+        // react-server-dom's flight wake path indexes a handle-valued object
+        // and segfaulted at the handle address. Route through the by-name read,
+        // which triages small handles (HANDLE_PROPERTY_DISPATCH, recorded
+        // prototypes) without ever dereferencing the id.
+        let idx_top16 = index.to_bits() >> 48;
+        let key_ptr = if idx_top16 == 0x7FFF || idx_top16 == 0x7FF9 {
+            js_get_string_pointer_unified(index) as *const crate::StringHeader
+        } else {
+            crate::builtins::js_string_coerce(index) as *const crate::StringHeader
+        };
+        if key_ptr.is_null() {
+            return f64::from_bits(TAG_UNDEFINED);
+        }
+        return crate::object::js_object_get_field_by_name_f64(
+            raw_ptr as *const crate::object::ObjectHeader,
+            key_ptr,
+        );
     }
     // TypedArrays carry element-typed storage, not boxed ArrayHeader slots.
     // Probe the registry before any GC-header or raw ArrayHeader fallback so

--- a/test-files/test_gap_typed_view_index_reads.ts
+++ b/test-files/test_gap_typed_view_index_reads.ts
@@ -1,0 +1,49 @@
+// Indexed element access on the result of `u8.subarray(...)` / `u8.slice(...)`
+// must read/write real elements when the receiver is statically typed.
+//
+// Perry's `subarray`/`slice` on a BufferHeader-backed Uint8Array returns
+// another buffer, which the typed-array registry doesn't know — so the
+// statically-typed dynamic-index helpers (`r[i]` where `r: Uint8Array` and the
+// index isn't provably in-bounds) silently read `undefined` and dropped
+// writes. react-server-dom's flight row parser walks exactly these chunk
+// views: every RSC row Next.js streamed parsed as garbage (#5989).
+//
+// Validated byte-for-byte against `node --experimental-strip-types`.
+
+function sum(r: Uint8Array): number {
+  let s = 0;
+  for (var n = 0, c = r.length; n < c; ) {
+    s += r[n++];
+  }
+  return s;
+}
+
+const base = new Uint8Array([1, 2, 3, 4]);
+console.log(sum(base), sum(base.subarray(0, 4)), sum(base.subarray(1, 3)));
+
+// slice() results go through the same buffer-backed path
+console.log(sum(base.slice(0, 3)));
+
+// writes through the typed path must land
+function bump(r: Uint8Array): number {
+  let i: any = 0;
+  r[i] = 9;
+  return r[0];
+}
+const sub = base.subarray(2);
+console.log(bump(sub), sub[0]);
+
+// sequential scan over subarray chunks (the flight-parser read shape — the
+// full state-machine regression lives in test_gap_switch_continue_loop.ts)
+function scan(r: Uint8Array): string {
+  const out: number[] = [];
+  for (var n = 0, c = r.length; n < c; ) {
+    const d = r[n++];
+    if (d === 58) out.push(n);
+  }
+  return out.join(",");
+}
+const payload = new TextEncoder().encode("1:hi\n2:jkl\n10:x\n");
+console.log(scan(payload));
+console.log(scan(payload.subarray(0, payload.length)));
+console.log(scan(payload.subarray(5)));


### PR DESCRIPTION
## Problem

Two dynamic-index defects on non-heap-object receivers, both hit by
react-server-dom during Next.js App Router SSR (#5989):

1. **Typed element access on `subarray()`/`slice()` results read `undefined`
   (and dropped writes).** Perry's `u8.subarray(...)` / `u8.slice(...)` on a
   BufferHeader-backed `Uint8Array` returns another buffer, which the
   typed-array registry doesn't know. The statically-typed dynamic-index
   helpers (`r[i]` where `r: Uint8Array` and the index isn't provably
   in-bounds) gate on that registry, so they silently returned `undefined` /
   dropped the store:

   ```ts
   function sum(r: Uint8Array) { let s = 0; for (let n = 0; n < r.length; ) s += r[n++]; return s; }
   sum(new Uint8Array([1,2,3,4]).subarray(0, 4));   // was undefined; Node: 10
   ```

   react-server-dom's flight row parser walks exactly these chunk views — every
   RSC row Next.js streamed parsed as garbage.

2. **Handle-band ids dereferenced as pointers.** `js_dyn_index_get`'s raw-value
   guard only excluded the first 64KB, but registry handles (fetch/native ids)
   live anywhere below `HANDLE_BAND_MAX` (0x100000). A handle in
   `[0x10000, 0x100000)` indexed as `h[key]` fell through to the raw
   `ObjectHeader` walk and dereferenced the id as a pointer — react-server-dom's
   flight wake path indexes a handle-valued object and segfaulted at the handle
   address (`KERN_INVALID_ADDRESS at 0xf001b`).

## Fix

- `typedarray_props.rs`: when the typed-array registry gate misses, probe
  `is_registered_buffer` and delegate to the generic `js_dyn_index_get` /
  `js_dyn_index_set`, which already handle BufferHeader indexing (numeric,
  string, and symbol keys) — get and set sides.
- `value/dyn_index.rs`: replace the 64KB raw guard with an
  `is_small_handle` check that routes handle-band receivers through the by-name
  read (`js_object_get_field_by_name_f64`), which triages small handles
  (HANDLE_PROPERTY_DISPATCH, recorded prototypes) without dereferencing the id.

## Validation

New gap test `test_gap_typed_view_index_reads.ts` — byte-for-byte against
`node --experimental-strip-types`: typed loop sums over base/subarray/slice
receivers, writes through the typed path landing in the shared backing, and a
sequential scan over subarray chunks (the flight read shape; the full parser
state machine regression lives in `test_gap_switch_continue_loop.ts` / #6218).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed indexed reads and writes for `Uint8Array` values created through `subarray()` and `slice()`.
  * Corrected dynamic property access for native-backed values, preventing invalid memory access and crashes.
  * Ensured updates through sliced typed-array views persist correctly.

* **Tests**
  * Added regression coverage for typed-array reads, writes, and sequential indexed scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->