### PR TITLE
fix(runtime): WeakMap/WeakSet method VALUE reads resolve the prototype thunk

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -102,6 +102,46 @@ pub extern "C" fn js_object_get_field_by_name(
             }
         }
     }
+    // WeakMap / WeakSet instance — a VALUE read of the collection methods
+    // (`w.add`, `wm.set`, `typeof w.has`; react-server-dom's chunk-preload
+    // dedup does `u.add.bind(u, a)` — #5989) must resolve the brand-checking
+    // prototype thunk. Method CALLS dispatch via js_native_call_method's weak
+    // arms, but this by-name read path had no equivalent, so the read yielded
+    // `undefined` and the subsequent `.bind` threw. Own keys keep precedence
+    // (fresh instances only carry the `__perry_wk_entries` sentinel).
+    if !key.is_null()
+        && ((obj as u64) >> 48) == 0
+        && crate::value::addr_class::is_above_handle_band(obj as usize)
+    {
+        unsafe {
+            let boxed = f64::from_bits(JSValue::pointer(obj as *const u8).bits());
+            if let Some(cid) = crate::weakref::weak_class_id_from_receiver(boxed) {
+                let name_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+                let name_len = (*key).byte_len as usize;
+                let name = std::slice::from_raw_parts(name_ptr, name_len);
+                let (builtin, known) = if cid == crate::weakref::CLASS_ID_WEAKMAP {
+                    (
+                        "WeakMap",
+                        matches!(name, b"set" | b"get" | b"has" | b"delete"),
+                    )
+                } else {
+                    ("WeakSet", matches!(name, b"add" | b"has" | b"delete"))
+                };
+                if known && !super::super::own_key_present(obj as *mut ObjectHeader, key) {
+                    if let Ok(method_name) = std::str::from_utf8(name) {
+                        if let Some(v) =
+                            super::super::collection_proto_thunks::collection_proto_method_value(
+                                builtin,
+                                method_name,
+                            )
+                        {
+                            return JSValue::from_bits(v.to_bits());
+                        }
+                    }
+                }
+            }
+        }
+    }
     // `class X extends Promise` instance — a value read of `then`/`catch`/
     // `finally` (`p.then` / `typeof p.finally`, and codegen's `p.finally(cb)`
     // which reads the property first) must resolve the reified Promise prototype

--- a/test-files/test_gap_weak_method_value_read.ts
+++ b/test-files/test_gap_weak_method_value_read.ts
@@ -1,0 +1,46 @@
+// A VALUE read of a WeakMap/WeakSet method (`w.add`, `wm.set`, `typeof w.has`)
+// must return the callable prototype method — not `undefined`. Method CALLS
+// (`w.add(k)`) already dispatched via the native weak arms, but a bare property
+// read had no equivalent, so `const f = w.add` / `w.add.bind(w, k)` yielded
+// `undefined` and the subsequent call/bind threw "Bind must be called on a
+// function". react-server-dom's chunk-preload dedup does exactly
+// `u.add.bind(u, chunk)` on a module-level WeakSet, which 500'd every Next.js
+// App Router dynamic route (#5989).
+//
+// Validated byte-for-byte against `node --experimental-strip-types`.
+
+const ws: any = new WeakSet();
+console.log(typeof ws.add, typeof ws.has, typeof ws.delete);
+
+const k1 = {};
+const boundAdd = ws.add.bind(ws, k1);
+boundAdd();
+console.log(ws.has(k1));
+
+// method value stored then invoked
+const addFn = ws.add;
+const k2 = {};
+addFn.call(ws, k2);
+console.log(ws.has(k2));
+
+const wm: any = new WeakMap();
+console.log(typeof wm.set, typeof wm.get, typeof wm.has, typeof wm.delete);
+
+const mk = {};
+const boundSet = wm.set.bind(wm);
+boundSet(mk, 42);
+console.log(wm.get(mk), wm.has(mk));
+
+// the bind value is a real function object (has .name / .call)
+console.log(typeof ws.add.bind, typeof wm.get.call);
+
+// method CALL path still works (regression guard)
+const ws2: any = new WeakSet();
+const k3 = {};
+ws2.add(k3);
+console.log(ws2.has(k3), ws2.delete(k3), ws2.has(k3));
+
+// an OWN property shadowing a method name still wins (own-key precedence)
+const wm2: any = new WeakMap();
+Object.defineProperty(wm2, "get", { value: 123, enumerable: true, configurable: true });
+console.log(wm2.get);


### PR DESCRIPTION
## Problem

A **value read** of a `WeakMap`/`WeakSet` method (`w.add`, `wm.set`,
`typeof w.has`) returned `undefined`. Method *calls* (`w.add(k)`) dispatch
through `js_native_call_method`'s weak arms, but the by-name property-read path
(`js_object_get_field_by_name`) had no equivalent, so a bare read yielded
`undefined` and any subsequent call or `.bind` threw:

```js
const s = new WeakSet();
const f = s.add.bind(s, obj);   // TypeError: Bind must be called on a function
```

react-server-dom's client-chunk preload dedup does exactly
`u.add.bind(u, chunk)` on a module-level `WeakSet`, so every Next.js App Router
dynamic route 500'd during flight resolution (#5989).

## Fix

In `js_object_get_field_by_name`, detect a `WeakMap`/`WeakSet` receiver (via the
existing GC-header-safe `weak_class_id_from_receiver`, already guarded against
the small-handle band) and, for a known method name with no own-key shadow,
return the brand-checking prototype thunk from
`collection_proto_method_value` — the same thunk `Map`/`Set` value reads already
resolve. Own keys keep precedence (a fresh instance only carries the internal
`__perry_wk_entries` sentinel, which is not a method name).

## Validation

New gap test `test_gap_weak_method_value_read.ts`, byte-for-byte against
`node --experimental-strip-types`: `typeof` reads, `.bind(...)` + call,
stored-method `.call(...)`, `WeakMap.set/get` round-trip, the bound value being
a real function (`.bind`/`.call` present), a method-call regression guard, and
own-key precedence over a shadowed method name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed method lookups on `WeakMap` and `WeakSet` instances so methods such as `get`, `set`, `has`, `delete`, and `add` return callable functions as expected.
  - Preserved support for detached and bound method calls.
  - Ensured custom instance properties continue to override prototype methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->