### PR TITLE
perf(gc): debt-proportional assist pacing + budgeted-cycle soundness (#6224)

### DIFF
--- a/crates/perry-runtime/src/arena/allocators.rs
+++ b/crates/perry-runtime/src/arena/allocators.rs
@@ -70,7 +70,7 @@ pub fn arena_alloc_gc_longlived(size: usize, align: usize, obj_type: u8) -> *mut
     unsafe {
         let header = raw as *mut GcHeader;
         (*header).obj_type = obj_type;
-        (*header).gc_flags = GC_FLAG_ARENA;
+        (*header).gc_flags = GC_FLAG_ARENA | crate::gc::gc_birth_extra_flags();
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }
@@ -120,7 +120,7 @@ pub fn arena_alloc_gc_old(size: usize, align: usize, obj_type: u8) -> *mut u8 {
     unsafe {
         let header = raw as *mut GcHeader;
         (*header).obj_type = obj_type;
-        (*header).gc_flags = GC_FLAG_ARENA;
+        (*header).gc_flags = GC_FLAG_ARENA | crate::gc::gc_birth_extra_flags();
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }
@@ -144,7 +144,7 @@ pub(crate) fn arena_alloc_gc_old_excluding_pages(
     unsafe {
         let header = raw as *mut GcHeader;
         (*header).obj_type = obj_type;
-        (*header).gc_flags = GC_FLAG_ARENA;
+        (*header).gc_flags = GC_FLAG_ARENA | crate::gc::gc_birth_extra_flags();
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }
@@ -191,7 +191,7 @@ pub(crate) fn arena_alloc_gc_survivor(size: usize, align: usize, obj_type: u8) -
     unsafe {
         let header = raw as *mut GcHeader;
         (*header).obj_type = obj_type;
-        (*header).gc_flags = GC_FLAG_ARENA;
+        (*header).gc_flags = GC_FLAG_ARENA | crate::gc::gc_birth_extra_flags();
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }
@@ -268,7 +268,7 @@ pub fn arena_alloc_gc(size: usize, align: usize, obj_type: u8) -> *mut u8 {
         unsafe {
             let header = user_ptr.sub(GC_HEADER_SIZE) as *mut GcHeader;
             (*header).obj_type = obj_type;
-            (*header).gc_flags = GC_FLAG_ARENA;
+            (*header).gc_flags = GC_FLAG_ARENA | crate::gc::gc_birth_extra_flags();
             (*header)._reserved = 0;
             // size field already set from original allocation
         }
@@ -299,7 +299,7 @@ pub fn arena_alloc_gc(size: usize, align: usize, obj_type: u8) -> *mut u8 {
     unsafe {
         let header = raw as *mut GcHeader;
         (*header).obj_type = obj_type;
-        (*header).gc_flags = GC_FLAG_ARENA;
+        (*header).gc_flags = GC_FLAG_ARENA | crate::gc::gc_birth_extra_flags();
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }

--- a/crates/perry-runtime/src/gc/barrier.rs
+++ b/crates/perry-runtime/src/gc/barrier.rs
@@ -689,13 +689,45 @@ pub(super) unsafe fn scan_dirty_object_slots(
 // HashSet behavior.
 
 thread_local! {
-    /// Active full-incremental mark barrier state.
+    /// Active incremental mark barrier state (Full AND budgeted Minor
+    /// cycles — a Minor cycle sliced across mutator turns has exactly the
+    /// same lost-store hazard as a Full one; see the #6224 pacing fix, which
+    /// made budgeted minors actually complete and thereby exposed it).
     ///
     /// The valid pointer set is owned by the current `GcCycleState`. This raw
     /// pointer is installed only after that set has been built and is cleared
     /// before sweep/reclaim or if the cycle is dropped.
     pub(super) static INCREMENTAL_MARK_BARRIER_VALID_PTRS: Cell<*const ValidPointerSet> =
         const { Cell::new(std::ptr::null()) };
+
+    /// Extra GcHeader flags stamped on RUNTIME-path allocations at birth:
+    /// `GC_FLAG_MARKED` while an incremental mark barrier is active, 0
+    /// otherwise (allocate-black). A budgeted cycle's sweep may only collect
+    /// what its own trace could have seen; an object born mid-cycle and
+    /// installed via a runtime-internal RAW store (a grown array's elements
+    /// buffer, a map entry node, a string builder's data — none of which pass
+    /// through the nanboxed value-barrier path) would otherwise sit unmarked
+    /// and be freed live. Measured: 2,890 of 32,000 live graph nodes silently
+    /// lost (checksum mismatch) the moment #6224's pacing made budgeted
+    /// cycles complete; escalates to a swept-live-key SIGSEGV with manual
+    /// `gc()` mixed in. Born-marked objects survive to the NEXT cycle —
+    /// bounded floating garbage, already priced by the debt pacer.
+    ///
+    /// Codegen's inline bump allocator (lower_call.rs IR) does NOT read this
+    /// flag; codegen-born objects are ordinary JS values whose installs all
+    /// go through codegen store barriers → `incremental_mark_barrier_value`.
+    /// The runtime choke points below cover every raw-install allocation.
+    pub(crate) static GC_BIRTH_EXTRA_FLAGS: Cell<u8> = const { Cell::new(0) };
+
+    /// True while the active barrier belongs to a MINOR cycle: the barrier
+    /// must then shade only NURSERY children. Marking an old-gen child during
+    /// a minor would leave a stray mark bit that the minor's sweep never
+    /// clears (minors don't walk the old gen), and the next full cycle would
+    /// read that stale MARKED as "already traced" and skip the object's
+    /// children — unmarking-by-omission, i.e. a live-object sweep one cycle
+    /// later. Old children need no shading in a minor anyway: minors never
+    /// collect live old-gen objects.
+    pub(super) static INCREMENTAL_MARK_BARRIER_MINOR_ONLY: Cell<bool> = const { Cell::new(false) };
 
     /// Dirty old-generation pages that have received a YOUNG-gen
     /// pointer since the last collection. This is Perry's compact
@@ -739,7 +771,8 @@ thread_local! {
 
 pub(super) static GENERATED_WRITE_BARRIERS_EMITTED: AtomicUsize = AtomicUsize::new(0);
 
-pub(super) fn incremental_mark_barrier_enable(valid_ptrs: &ValidPointerSet) {
+pub(super) fn incremental_mark_barrier_enable(valid_ptrs: &ValidPointerSet, minor_only: bool) {
+    INCREMENTAL_MARK_BARRIER_MINOR_ONLY.with(|cell| cell.set(minor_only));
     INCREMENTAL_MARK_BARRIER_VALID_PTRS.with(|cell| {
         cell.set(valid_ptrs as *const ValidPointerSet);
     });
@@ -749,6 +782,14 @@ pub(super) fn incremental_mark_barrier_disable() {
     INCREMENTAL_MARK_BARRIER_VALID_PTRS.with(|cell| {
         cell.set(std::ptr::null());
     });
+    INCREMENTAL_MARK_BARRIER_MINOR_ONLY.with(|cell| cell.set(false));
+}
+
+/// Allocate-black birth flags for runtime-path allocations — see
+/// `GC_BIRTH_EXTRA_FLAGS`.
+#[inline(always)]
+pub fn gc_birth_extra_flags() -> u8 {
+    GC_BIRTH_EXTRA_FLAGS.with(|cell| cell.get())
 }
 
 #[inline]
@@ -847,10 +888,18 @@ fn incremental_mark_barrier_value_with_valid_ptrs(
     value_bits: u64,
     valid_ptrs: &ValidPointerSet,
 ) -> bool {
-    let Some((_addr, header)) = current_heap_header_for_heap_word(value_bits, Some(valid_ptrs))
+    let Some((addr, header)) = current_heap_header_for_heap_word(value_bits, Some(valid_ptrs))
     else {
         return false;
     };
+    // Minor cycles shade only nursery children (see the
+    // INCREMENTAL_MARK_BARRIER_MINOR_ONLY doc: stray old-gen marks survive a
+    // minor's sweep and poison the next full cycle's trace).
+    if INCREMENTAL_MARK_BARRIER_MINOR_ONLY.with(|cell| cell.get())
+        && !crate::arena::pointer_in_nursery(addr)
+    {
+        return false;
+    }
     unsafe {
         let flags = (*header).gc_flags;
         if flags & (GC_FLAG_MARKED | GC_FLAG_PINNED | GC_FLAG_FORWARDED) != 0 {

--- a/crates/perry-runtime/src/gc/cycle.rs
+++ b/crates/perry-runtime/src/gc/cycle.rs
@@ -791,13 +791,16 @@ struct AtomicFinalizeCycleState {
 }
 
 impl AtomicFinalizeCycleState {
-    fn new(collection_kind: GcCollectionKind) -> Self {
-        let subphase = match collection_kind {
-            GcCollectionKind::Minor => AtomicFinalizeSubphase::WeakProcessing,
-            GcCollectionKind::Full => AtomicFinalizeSubphase::BarrierSeedDrain,
-        };
+    fn new(_collection_kind: GcCollectionKind) -> Self {
+        // Both kinds start by draining the incremental-mark-barrier seeds:
+        // minors run the barrier too now (see step_build_valid_pointer_set),
+        // and the drain must precede WeakProcessing so weak/finalization
+        // decisions read the final marks. The post-drain order stays
+        // kind-specific: Minor → WeakProcessing → MinorPrelude →
+        // RememberedSetRebuild(→Sweep); Full → RememberedSetRebuild →
+        // WeakProcessing → DisableBarrier(→Sweep).
         Self {
-            subphase,
+            subphase: AtomicFinalizeSubphase::BarrierSeedDrain,
             barrier_drain: None,
             remembered_rebuild: None,
         }
@@ -837,6 +840,14 @@ impl GcCycleState {
         let start = Instant::now();
         crate::arena::old_pages_begin_gc_cycle();
         clear_mark_seeds();
+        // Allocate-black for the WHOLE cycle, from the first build slice on:
+        // the mark barrier only engages at the END of BuildValidPointerSet
+        // (the longest phase), so an object born during a build slice and
+        // installed via a runtime-internal raw store would be swept live
+        // (measured: identical 2,890-node loss with barrier-window-only
+        // birth flags). Cleared in the outcome finalizer / Drop, NOT at
+        // barrier disable — sweeping runs after the barrier is off.
+        super::barrier::GC_BIRTH_EXTRA_FLAGS.with(|cell| cell.set(GC_FLAG_MARKED));
         Self {
             collection_kind: GcCollectionKind::Full,
             trigger_kind,
@@ -878,6 +889,14 @@ impl GcCycleState {
     ) -> Self {
         let malloc_sweep_due = copied_minor_malloc_sweep_due(trigger.kind);
         let trigger_kind = trigger.kind;
+        // Allocate-black for the WHOLE cycle, from the first build slice on:
+        // the mark barrier only engages at the END of BuildValidPointerSet
+        // (the longest phase), so an object born during a build slice and
+        // installed via a runtime-internal raw store would be swept live
+        // (measured: identical 2,890-node loss with barrier-window-only
+        // birth flags). Cleared in the outcome finalizer / Drop, NOT at
+        // barrier disable — sweeping runs after the barrier is off.
+        super::barrier::GC_BIRTH_EXTRA_FLAGS.with(|cell| cell.set(GC_FLAG_MARKED));
         Self {
             collection_kind: GcCollectionKind::Minor,
             trigger_kind,
@@ -1027,9 +1046,17 @@ impl GcCycleState {
             .expect("valid-pointer builder exists");
         self.valid_ptrs = Some(builder.finish());
         trace_phase_record(&mut self.trace, "build_valid_pointer_set", phase_start);
-        if matches!(self.collection_kind, GcCollectionKind::Full) {
+        // Enable the incremental mark barrier for BOTH kinds. A budgeted
+        // MINOR cycle sliced across mutator turns has the same lost-store
+        // hazard as a Full one: a store into an already-traced object after
+        // its slot was scanned would leave the stored child unmarked, and
+        // the minor sweep frees it live (measured as a property-key UAF the
+        // moment #6224's pacing made budgeted minors actually complete).
+        // Minor barriers shade nursery children only — see
+        // INCREMENTAL_MARK_BARRIER_MINOR_ONLY.
+        {
             let valid_ptrs = self.valid_ptrs.as_ref().expect("valid pointer set built");
-            incremental_mark_barrier_enable(valid_ptrs);
+            incremental_mark_barrier_enable(valid_ptrs, self.minor.is_some());
         }
 
         let active_elapsed_us = self.active_elapsed_us();
@@ -1213,6 +1240,7 @@ impl GcCycleState {
                     .subphase = AtomicFinalizeSubphase::RememberedSetRebuild;
             }
             AtomicFinalizeSubphase::BarrierSeedDrain => {
+                let minor_only = self.minor.is_some();
                 let valid_ptrs = self.valid_ptrs.as_ref().expect("valid pointer set built");
                 let done = {
                     let state = self
@@ -1221,7 +1249,7 @@ impl GcCycleState {
                         .expect("atomic finalize state exists");
                     let drain = state
                         .barrier_drain
-                        .get_or_insert_with(|| TraceWorklistCycleState::new(false));
+                        .get_or_insert_with(|| TraceWorklistCycleState::new(minor_only));
                     drain.step(valid_ptrs, budget)
                 };
                 if done {
@@ -1230,7 +1258,12 @@ impl GcCycleState {
                         .as_mut()
                         .expect("atomic finalize state exists");
                     state.barrier_drain = None;
-                    state.subphase = AtomicFinalizeSubphase::RememberedSetRebuild;
+                    // Kind-specific continuation (see AtomicFinalizeCycleState::new).
+                    state.subphase = if minor_only {
+                        AtomicFinalizeSubphase::WeakProcessing
+                    } else {
+                        AtomicFinalizeSubphase::RememberedSetRebuild
+                    };
                 }
             }
             AtomicFinalizeSubphase::RememberedSetRebuild => {
@@ -1246,6 +1279,14 @@ impl GcCycleState {
                 // leave `live_old_to_young_sticky` None; reclaim then restores
                 // only `evacuation_sticky` + the pre-clear dirty snapshot.
                 if self.minor.is_some() {
+                    // Barrier off for the minor: first drain any seeds the
+                    // barrier pushed since BarrierSeedDrain completed (late
+                    // stores mark the child but its children still need the
+                    // trace), then disable. Bounded by late-store volume.
+                    let valid_ptrs = self.valid_ptrs.as_ref().expect("valid pointer set built");
+                    let mut final_drain = TraceWorklistCycleState::new(true);
+                    while !final_drain.step(valid_ptrs, usize::MAX) {}
+                    incremental_mark_barrier_disable();
                     self.atomic_finalize = None;
                     self.phase = GcCyclePhase::Sweep;
                     return;
@@ -1281,6 +1322,15 @@ impl GcCycleState {
             AtomicFinalizeSubphase::DisableBarrier => {
                 if budget == 0 {
                     return;
+                }
+                // Same late-seed closure as the minor path: trace anything
+                // the barrier shaded after BarrierSeedDrain completed, so no
+                // marked-but-untraced object reaches Sweep with unmarked
+                // children.
+                {
+                    let valid_ptrs = self.valid_ptrs.as_ref().expect("valid pointer set built");
+                    let mut final_drain = TraceWorklistCycleState::new(false);
+                    while !final_drain.step(valid_ptrs, usize::MAX) {}
                 }
                 incremental_mark_barrier_disable();
                 if let Some(state) = self.atomic_finalize.as_mut() {
@@ -1597,6 +1647,7 @@ impl GcCycleState {
             .map(|minor| minor.malloc_sweep_due)
             .unwrap_or(true);
 
+        super::barrier::GC_BIRTH_EXTRA_FLAGS.with(|cell| cell.set(0));
         self.outcome = Some(GcCollectOutcome {
             freed_bytes: self.freed_bytes,
             malloc_swept,
@@ -1607,10 +1658,11 @@ impl GcCycleState {
 
 impl Drop for GcCycleState {
     fn drop(&mut self) {
-        if matches!(self.collection_kind, GcCollectionKind::Full)
-            && self.phase != GcCyclePhase::Complete
-        {
+        // Both kinds enable the barrier now (minor cycles too); never let the
+        // raw valid-ptrs pointer dangle past the cycle that owns the set.
+        if self.phase != GcCyclePhase::Complete {
             incremental_mark_barrier_disable();
+            super::barrier::GC_BIRTH_EXTRA_FLAGS.with(|cell| cell.set(0));
             clear_mark_seeds();
         }
     }

--- a/crates/perry-runtime/src/gc/malloc.rs
+++ b/crates/perry-runtime/src/gc/malloc.rs
@@ -247,7 +247,7 @@ pub fn gc_malloc(size: usize, obj_type: u8) -> *mut u8 {
 
         let header = raw as *mut GcHeader;
         (*header).obj_type = obj_type;
-        (*header).gc_flags = 0; // not arena
+        (*header).gc_flags = super::barrier::gc_birth_extra_flags(); // not arena; allocate-black while a budgeted cycle marks
         (*header)._reserved = 0;
         (*header).size = total as u32;
 
@@ -300,7 +300,7 @@ pub fn gc_malloc_batch(sizes: &[usize], obj_type: u8) -> Vec<*mut u8> {
             }
             let header = raw as *mut GcHeader;
             (*header).obj_type = obj_type;
-            (*header).gc_flags = 0;
+            (*header).gc_flags = super::barrier::gc_birth_extra_flags();
             (*header)._reserved = 0;
             (*header).size = total as u32;
 

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -38,6 +38,8 @@ pub use types::*;
 mod policy;
 pub(crate) use policy::gc_runtime_safepoint;
 pub use policy::*;
+mod progress;
+pub use progress::*;
 mod heap_budget;
 pub use heap_budget::*;
 mod pressure;
@@ -80,6 +82,7 @@ pub fn gc_collect_minor() -> u64 {
 }
 
 pub(super) fn gc_collect_minor_with_trigger(trigger: GcTriggerSnapshot) -> GcCollectOutcome {
+    gc_drain_active_budgeted_cycle();
     // Barriers-off ⇒ the remembered set is not being maintained, and a
     // minor's black-leafed old parents would hide live children. Route
     // every caller (direct arm, moving-safepoint arm, public FFI) to the
@@ -251,6 +254,7 @@ fn gc_collect_inner_with_trigger(trigger: GcTriggerSnapshot) -> GcCollectOutcome
 }
 
 fn gc_collect_full_mark_sweep_with_trigger(trigger: GcTriggerSnapshot) -> GcCollectOutcome {
+    gc_drain_active_budgeted_cycle();
     GC_TRIGGER_BUMPED.with(|c| c.set(false));
     GcCycleState::new_full(trigger).run_to_completion()
 }

--- a/crates/perry-runtime/src/gc/policy.rs
+++ b/crates/perry-runtime/src/gc/policy.rs
@@ -6,10 +6,23 @@ use super::*;
 pub const GC_NORMAL_INCREMENTAL_WORK_UNITS: usize = 2_048;
 /// Soft telemetry target for ordinary automatic GC steps.
 pub const GC_NORMAL_INCREMENTAL_SOFT_PAUSE_US: u64 = 2_000;
-/// Hard work budget for allocation-side mutator assist steps.
+/// BASE work budget for allocation-side mutator assist steps. The actual
+/// per-assist budget is debt-scaled (`gc_mutator_assist_scaled_work_units`):
+/// this constant alone is only enough when the collector is keeping up.
 pub const GC_MUTATOR_ASSIST_WORK_UNITS: usize = 256;
 /// Soft telemetry target for allocation-side mutator assist steps.
 pub const GC_MUTATOR_ASSIST_SOFT_PAUSE_US: u64 = 500;
+/// Debt-proportional assist pacing: one extra work unit per this many bytes
+/// of arena debt (allocation past the armed trigger). This is the gain of a
+/// proportional controller whose equilibrium debt scales as
+/// sqrt(cycle_work × gain⁻¹): measured on a 10M-allocation churn loop, a
+/// 1024-bytes-per-unit gain left cycles spanning ~300 MB of allocation
+/// (pct_freed 156-190% in the re-arm DIAG) and RSS at 3.5× the synchronous
+/// collector's. At 64 bytes per unit the same loop completes cycles within
+/// ~its trigger step and RSS lands near parity. When the collector is
+/// keeping up (debt ≈ 0) the budget stays at the base, so low-latency
+/// workloads never see the scaled assists.
+pub const GC_ASSIST_DEBT_BYTES_PER_WORK_UNIT: u64 = 64;
 
 /// Runtime-visible classification for GC progress.
 ///
@@ -1324,9 +1337,43 @@ pub fn gc_check_trigger() {
     }
 
     let _ = gc_mutator_assist_step_work_units_inner_with_progress(
-        GC_MUTATOR_ASSIST_WORK_UNITS,
+        gc_mutator_assist_scaled_work_units(),
         GcProgressKind::MutatorAssist,
     );
+}
+
+/// Debt-proportional assist pacing (#6180 Stage 2, measured 2026-07-10).
+///
+/// A FIXED per-assist budget lets a tight allocation loop outrun the
+/// collector: on a 10M-allocation ring benchmark the budgeted cycle NEVER
+/// completed (0 collections vs the synchronous default's 7) and RSS grew
+/// unbounded (6-22× the synchronous collector's) — the cycle crawled at 256
+/// units per arena-block allocation against a heap growing by ~16k objects
+/// per block. `GcDebtSnapshot` already measured exactly this shortfall but
+/// fed telemetry only.
+///
+/// Scale the budget linearly with the measured debt instead. Debt is how far
+/// allocation has run past the armed triggers, so between two block-alloc
+/// assists it grows by ~one block while the budget grows with total debt —
+/// the controller self-stabilizes at the equilibrium where collection keeps
+/// pace with allocation, instead of falling behind forever.
+///
+/// No explicit cap is needed: the budget is a CEILING on work, not a pause
+/// floor — `GcCycleState::step` stops the moment the cycle completes, and a
+/// cycle's remaining work is bounded by the heap. The worst case is therefore
+/// finishing the whole cycle in one assist: exactly the pause the synchronous
+/// collector takes on every collection today. Under extreme allocation
+/// pressure incremental degrades gracefully toward synchronous behavior
+/// rather than toward unbounded memory.
+pub(super) fn gc_mutator_assist_scaled_work_units() -> usize {
+    let debt = GcDebtSnapshot::current();
+    let arena_units = (debt.arena_debt_bytes / GC_ASSIST_DEBT_BYTES_PER_WORK_UNIT) as usize;
+    // Malloc-registry work is per-object (mark/sweep touches each header
+    // once), so malloc debt converts 1:1.
+    let malloc_units = debt.malloc_debt_objects as usize;
+    GC_MUTATOR_ASSIST_WORK_UNITS
+        .saturating_add(arena_units)
+        .saturating_add(malloc_units)
 }
 
 pub const JS_GC_STEP_STATUS_IDLE: u32 = 0;

--- a/crates/perry-runtime/src/gc/policy.rs
+++ b/crates/perry-runtime/src/gc/policy.rs
@@ -1,155 +1,6 @@
 use super::heap_budget::*;
 use super::*;
 
-/// Hard work budget for ordinary automatic GC steps once the collector is
-/// split into resumable phases.
-pub const GC_NORMAL_INCREMENTAL_WORK_UNITS: usize = 2_048;
-/// Soft telemetry target for ordinary automatic GC steps.
-pub const GC_NORMAL_INCREMENTAL_SOFT_PAUSE_US: u64 = 2_000;
-/// BASE work budget for allocation-side mutator assist steps. The actual
-/// per-assist budget is debt-scaled (`gc_mutator_assist_scaled_work_units`):
-/// this constant alone is only enough when the collector is keeping up.
-pub const GC_MUTATOR_ASSIST_WORK_UNITS: usize = 256;
-/// Soft telemetry target for allocation-side mutator assist steps.
-pub const GC_MUTATOR_ASSIST_SOFT_PAUSE_US: u64 = 500;
-/// Debt-proportional assist pacing: one extra work unit per this many bytes
-/// of arena debt (allocation past the armed trigger). This is the gain of a
-/// proportional controller whose equilibrium debt scales as
-/// sqrt(cycle_work × gain⁻¹): measured on a 10M-allocation churn loop, a
-/// 1024-bytes-per-unit gain left cycles spanning ~300 MB of allocation
-/// (pct_freed 156-190% in the re-arm DIAG) and RSS at 3.5× the synchronous
-/// collector's. At 64 bytes per unit the same loop completes cycles within
-/// ~its trigger step and RSS lands near parity. When the collector is
-/// keeping up (debt ≈ 0) the budget stays at the base, so low-latency
-/// workloads never see the scaled assists.
-pub const GC_ASSIST_DEBT_BYTES_PER_WORK_UNIT: u64 = 64;
-
-/// Runtime-visible classification for GC progress.
-///
-/// Only `NormalIncremental` and `MutatorAssist` satisfy the low-pause
-/// invariant today defined by this contract: bounded by work units, not heap
-/// size. Explicit synchronous work and emergency full collections are allowed
-/// to be unbounded only because they are separately requested or separately
-/// reported.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum GcProgressKind {
-    NormalIncremental,
-    MutatorAssist,
-    ExplicitSynchronous,
-    ExplicitFull,
-    EmergencyFull,
-    LegacySynchronous,
-}
-
-impl GcProgressKind {
-    #[inline]
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::NormalIncremental => "normal_incremental",
-            Self::MutatorAssist => "mutator_assist",
-            Self::ExplicitSynchronous => "explicit_synchronous",
-            Self::ExplicitFull => "explicit_full",
-            Self::EmergencyFull => "emergency_full",
-            Self::LegacySynchronous => "legacy_synchronous",
-        }
-    }
-
-    #[inline]
-    pub const fn is_budgeted(self) -> bool {
-        matches!(self, Self::NormalIncremental | Self::MutatorAssist)
-    }
-
-    #[inline]
-    pub const fn report_class(self) -> &'static str {
-        match self {
-            Self::NormalIncremental | Self::MutatorAssist => "ordinary_budgeted",
-            Self::ExplicitSynchronous | Self::ExplicitFull => "explicit",
-            Self::EmergencyFull => "emergency",
-            Self::LegacySynchronous => "legacy",
-        }
-    }
-}
-
-/// Hard work-unit limit plus a soft pause target for telemetry.
-///
-/// `None` means the path is intentionally unbounded and must be labeled by its
-/// `GcProgressKind`.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct GcPauseBudget {
-    pub work_units: Option<usize>,
-    pub pause_us: Option<u64>,
-}
-
-impl GcPauseBudget {
-    #[inline]
-    pub const fn bounded(work_units: usize, pause_us: u64) -> Self {
-        Self {
-            work_units: Some(work_units),
-            pause_us: Some(pause_us),
-        }
-    }
-
-    #[inline]
-    pub const fn unbounded() -> Self {
-        Self {
-            work_units: None,
-            pause_us: None,
-        }
-    }
-
-    #[inline]
-    pub const fn is_bounded(self) -> bool {
-        self.work_units.is_some()
-    }
-}
-
-/// GC progress policy exposed to runtime and trace consumers.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct GcProgressContract {
-    pub normal_step_budget: GcPauseBudget,
-    pub assist_budget: GcPauseBudget,
-    pub explicit_synchronous_policy: GcPauseBudget,
-    pub explicit_full_policy: GcPauseBudget,
-    pub emergency_policy: GcPauseBudget,
-}
-
-impl GcProgressContract {
-    #[inline]
-    pub const fn budget_for(self, kind: GcProgressKind) -> GcPauseBudget {
-        match kind {
-            GcProgressKind::NormalIncremental => self.normal_step_budget,
-            GcProgressKind::MutatorAssist => self.assist_budget,
-            GcProgressKind::ExplicitSynchronous => self.explicit_synchronous_policy,
-            GcProgressKind::ExplicitFull => self.explicit_full_policy,
-            GcProgressKind::EmergencyFull => self.emergency_policy,
-            GcProgressKind::LegacySynchronous => GcPauseBudget::unbounded(),
-        }
-    }
-}
-
-impl Default for GcProgressContract {
-    fn default() -> Self {
-        Self {
-            normal_step_budget: GcPauseBudget::bounded(
-                GC_NORMAL_INCREMENTAL_WORK_UNITS,
-                GC_NORMAL_INCREMENTAL_SOFT_PAUSE_US,
-            ),
-            assist_budget: GcPauseBudget::bounded(
-                GC_MUTATOR_ASSIST_WORK_UNITS,
-                GC_MUTATOR_ASSIST_SOFT_PAUSE_US,
-            ),
-            explicit_synchronous_policy: GcPauseBudget::unbounded(),
-            explicit_full_policy: GcPauseBudget::unbounded(),
-            emergency_policy: GcPauseBudget::unbounded(),
-        }
-    }
-}
-
-/// Return Perry's process-wide GC progress contract.
-pub fn gc_progress_contract() -> GcProgressContract {
-    GcProgressContract::default()
-}
-
 pub(super) const GC_FLAG_IN_ALLOC: u8 = 0b01;
 /// Bit 1 of GC_FLAGS — suppression flag (JSON.parse).
 pub(super) const GC_FLAG_SUPPRESSED: u8 = 0b10;
@@ -1802,6 +1653,39 @@ fn gc_finish_budgeted_cycle(mut cycle: BudgetedGcCycle) -> JsGcStepResult {
 enum BudgetedStepOutcome {
     Result(JsGcStepResult),
     Completed(BudgetedGcCycle),
+}
+
+/// Finish any parked budgeted cycle through its own machinery before a
+/// synchronous (direct/manual/emergency) collection constructs a fresh
+/// `GcCycleState`. Two cycles must never be alive at once: they share
+/// `GC_FLAG_MARKED`, the mark-seed queue, the incremental-barrier TLS, and
+/// the allocate-black birth-flag lifecycle — a synchronous full mark-sweep
+/// landing mid-budgeted-cycle erases the parked cycle's marks, so its
+/// eventual sweep frees whatever the interloper didn't re-mark (measured as
+/// the manual-`gc()` SIGSEGV escalation of the #6224 stress). One unbounded
+/// step drives the parked cycle to completion via the normal finisher.
+pub(super) fn gc_drain_active_budgeted_cycle() {
+    if !gc_budgeted_cycle_active() {
+        return;
+    }
+    // One `step()` call advances only the CURRENT phase (even with an
+    // unbounded budget) — completing the whole cycle takes one call per
+    // remaining phase, exactly like `run_to_completion`'s loop. Bound the
+    // loop defensively: 8 phases, and a blocked stepper (suppression /
+    // unsafe zone / reentrancy guard) returns without progress — bail then
+    // rather than spin.
+    for _ in 0..64 {
+        let result = gc_budgeted_step_work_units_inner(usize::MAX);
+        if !gc_budgeted_cycle_active() {
+            return;
+        }
+        if result.status == JS_GC_STEP_STATUS_SKIPPED {
+            break;
+        }
+    }
+    if std::env::var_os("PERRY_GC_DIAG").is_some() {
+        eprintln!("[gc-drain] WARNING: parked budgeted cycle could not be drained before synchronous collection");
+    }
 }
 
 fn gc_budgeted_step_work_units_inner(work_units: usize) -> JsGcStepResult {

--- a/crates/perry-runtime/src/gc/progress.rs
+++ b/crates/perry-runtime/src/gc/progress.rs
@@ -1,0 +1,153 @@
+//! GC progress contract: pause budgets per progress kind (split from
+//! policy.rs for the per-file size gate). Work-unit budgets and soft pause
+//! targets for the budgeted stepper, plus the debt-pacing gain constant used
+//! by `gc_mutator_assist_scaled_work_units` (policy.rs).
+
+/// Hard work budget for ordinary automatic GC steps once the collector is
+/// split into resumable phases.
+pub const GC_NORMAL_INCREMENTAL_WORK_UNITS: usize = 2_048;
+/// Soft telemetry target for ordinary automatic GC steps.
+pub const GC_NORMAL_INCREMENTAL_SOFT_PAUSE_US: u64 = 2_000;
+/// BASE work budget for allocation-side mutator assist steps. The actual
+/// per-assist budget is debt-scaled (`gc_mutator_assist_scaled_work_units`):
+/// this constant alone is only enough when the collector is keeping up.
+pub const GC_MUTATOR_ASSIST_WORK_UNITS: usize = 256;
+/// Soft telemetry target for allocation-side mutator assist steps.
+pub const GC_MUTATOR_ASSIST_SOFT_PAUSE_US: u64 = 500;
+/// Debt-proportional assist pacing: one extra work unit per this many bytes
+/// of arena debt (allocation past the armed trigger). This is the gain of a
+/// proportional controller whose equilibrium debt scales as
+/// sqrt(cycle_work × gain⁻¹): measured on a 10M-allocation churn loop, a
+/// 1024-bytes-per-unit gain left cycles spanning ~300 MB of allocation
+/// (pct_freed 156-190% in the re-arm DIAG) and RSS at 3.5× the synchronous
+/// collector's. At 64 bytes per unit the same loop completes cycles within
+/// ~its trigger step and RSS lands near parity. When the collector is
+/// keeping up (debt ≈ 0) the budget stays at the base, so low-latency
+/// workloads never see the scaled assists.
+pub const GC_ASSIST_DEBT_BYTES_PER_WORK_UNIT: u64 = 64;
+
+/// Runtime-visible classification for GC progress.
+///
+/// Only `NormalIncremental` and `MutatorAssist` satisfy the low-pause
+/// invariant today defined by this contract: bounded by work units, not heap
+/// size. Explicit synchronous work and emergency full collections are allowed
+/// to be unbounded only because they are separately requested or separately
+/// reported.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GcProgressKind {
+    NormalIncremental,
+    MutatorAssist,
+    ExplicitSynchronous,
+    ExplicitFull,
+    EmergencyFull,
+    LegacySynchronous,
+}
+
+impl GcProgressKind {
+    #[inline]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::NormalIncremental => "normal_incremental",
+            Self::MutatorAssist => "mutator_assist",
+            Self::ExplicitSynchronous => "explicit_synchronous",
+            Self::ExplicitFull => "explicit_full",
+            Self::EmergencyFull => "emergency_full",
+            Self::LegacySynchronous => "legacy_synchronous",
+        }
+    }
+
+    #[inline]
+    pub const fn is_budgeted(self) -> bool {
+        matches!(self, Self::NormalIncremental | Self::MutatorAssist)
+    }
+
+    #[inline]
+    pub const fn report_class(self) -> &'static str {
+        match self {
+            Self::NormalIncremental | Self::MutatorAssist => "ordinary_budgeted",
+            Self::ExplicitSynchronous | Self::ExplicitFull => "explicit",
+            Self::EmergencyFull => "emergency",
+            Self::LegacySynchronous => "legacy",
+        }
+    }
+}
+
+/// Hard work-unit limit plus a soft pause target for telemetry.
+///
+/// `None` means the path is intentionally unbounded and must be labeled by its
+/// `GcProgressKind`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GcPauseBudget {
+    pub work_units: Option<usize>,
+    pub pause_us: Option<u64>,
+}
+
+impl GcPauseBudget {
+    #[inline]
+    pub const fn bounded(work_units: usize, pause_us: u64) -> Self {
+        Self {
+            work_units: Some(work_units),
+            pause_us: Some(pause_us),
+        }
+    }
+
+    #[inline]
+    pub const fn unbounded() -> Self {
+        Self {
+            work_units: None,
+            pause_us: None,
+        }
+    }
+
+    #[inline]
+    pub const fn is_bounded(self) -> bool {
+        self.work_units.is_some()
+    }
+}
+
+/// GC progress policy exposed to runtime and trace consumers.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GcProgressContract {
+    pub normal_step_budget: GcPauseBudget,
+    pub assist_budget: GcPauseBudget,
+    pub explicit_synchronous_policy: GcPauseBudget,
+    pub explicit_full_policy: GcPauseBudget,
+    pub emergency_policy: GcPauseBudget,
+}
+
+impl GcProgressContract {
+    #[inline]
+    pub const fn budget_for(self, kind: GcProgressKind) -> GcPauseBudget {
+        match kind {
+            GcProgressKind::NormalIncremental => self.normal_step_budget,
+            GcProgressKind::MutatorAssist => self.assist_budget,
+            GcProgressKind::ExplicitSynchronous => self.explicit_synchronous_policy,
+            GcProgressKind::ExplicitFull => self.explicit_full_policy,
+            GcProgressKind::EmergencyFull => self.emergency_policy,
+            GcProgressKind::LegacySynchronous => GcPauseBudget::unbounded(),
+        }
+    }
+}
+
+impl Default for GcProgressContract {
+    fn default() -> Self {
+        Self {
+            normal_step_budget: GcPauseBudget::bounded(
+                GC_NORMAL_INCREMENTAL_WORK_UNITS,
+                GC_NORMAL_INCREMENTAL_SOFT_PAUSE_US,
+            ),
+            assist_budget: GcPauseBudget::bounded(
+                GC_MUTATOR_ASSIST_WORK_UNITS,
+                GC_MUTATOR_ASSIST_SOFT_PAUSE_US,
+            ),
+            explicit_synchronous_policy: GcPauseBudget::unbounded(),
+            explicit_full_policy: GcPauseBudget::unbounded(),
+            emergency_policy: GcPauseBudget::unbounded(),
+        }
+    }
+}
+
+/// Return Perry's process-wide GC progress contract.
+pub fn gc_progress_contract() -> GcProgressContract {
+    GcProgressContract::default()
+}

--- a/crates/perry-runtime/src/gc/tests/debt_pacer.rs
+++ b/crates/perry-runtime/src/gc/tests/debt_pacer.rs
@@ -451,3 +451,87 @@ fn debt_scaled_assists_cannot_be_outrun_by_allocation() {
         assert_string_bytes(live_after, b"debt_pacing_live");
     }
 }
+
+/// Allocate-black lifecycle: runtime-path allocations made while a budgeted
+/// cycle is in flight are born MARKED (from the FIRST build slice, not just
+/// the barrier window), and birth flags reset once the cycle completes.
+#[test]
+fn budgeted_cycle_allocations_are_born_marked_for_the_whole_cycle() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    let trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    reset_old_reclaim_pressure();
+
+    let live = live_test_string(b"birth_flags_live");
+    js_shadow_slot_set(0, string_bits(live));
+    for _ in 0..(GC_MUTATOR_ASSIST_WORK_UNITS * 4) {
+        let _ = young_leaf();
+    }
+    trigger_guard.make_arena_trigger_due();
+
+    // Start the budgeted cycle; it parks in BuildValidPointerSet after one
+    // bounded assist — BEFORE the mark barrier enables.
+    gc_check_trigger();
+    let mut status = JsGcStepResult::default();
+    assert_eq!(js_gc_step_status(&mut status), JS_GC_STEP_STATUS_ACTIVE);
+
+    let mid_cycle = young_leaf();
+    let header = unsafe { header_from_user_ptr(mid_cycle as *const u8) };
+    assert!(
+        unsafe { (*header).gc_flags } & GC_FLAG_MARKED != 0,
+        "allocation during an active budgeted cycle must be born marked \
+         (raw-installed runtime buffers would otherwise be swept live)"
+    );
+
+    let completed = complete_budgeted_gc_cycle();
+    assert_eq!(completed.status, JS_GC_STEP_STATUS_COMPLETED);
+    let post_cycle = young_leaf();
+    let post_header = unsafe { header_from_user_ptr(post_cycle as *const u8) };
+    assert_eq!(
+        unsafe { (*post_header).gc_flags } & GC_FLAG_MARKED,
+        0,
+        "birth flags must reset once the cycle completes"
+    );
+}
+
+/// Manual `gc()` landing while a budgeted cycle is parked mid-phase must
+/// drain that cycle to completion FIRST: two cycles share GC_FLAG_MARKED,
+/// the mark-seed queue, and the barrier TLS, so the synchronous full's sweep
+/// would erase the parked cycle's marks and its later sweep would free live
+/// objects (measured as the #6224 stress SIGSEGV).
+#[test]
+fn manual_gc_drains_parked_budgeted_cycle_first() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    let trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    reset_old_reclaim_pressure();
+
+    let live = live_test_string(b"drain_first_live");
+    js_shadow_slot_set(0, string_bits(live));
+    for _ in 0..(GC_MUTATOR_ASSIST_WORK_UNITS * 4) {
+        let _ = young_leaf();
+    }
+    trigger_guard.make_arena_trigger_due();
+
+    gc_check_trigger();
+    let mut status = JsGcStepResult::default();
+    assert_eq!(
+        js_gc_step_status(&mut status),
+        JS_GC_STEP_STATUS_ACTIVE,
+        "budgeted cycle should be parked mid-phase before the manual gc"
+    );
+
+    let before = gc_collection_count();
+    js_gc_collect();
+
+    assert!(
+        !gc_budgeted_cycle_active(),
+        "manual gc must leave no parked budgeted cycle behind"
+    );
+    assert!(
+        gc_collection_count() >= before + 2,
+        "both the drained budgeted cycle and the manual full must complete"
+    );
+    let live_after = (js_shadow_slot_get(0) & POINTER_MASK) as *const crate::StringHeader;
+    unsafe {
+        assert_string_bytes(live_after, b"drain_first_live");
+    }
+}

--- a/crates/perry-runtime/src/gc/tests/debt_pacer.rs
+++ b/crates/perry-runtime/src/gc/tests/debt_pacer.rs
@@ -367,3 +367,87 @@ fn direct_malloc_minor_rebaselines_trigger_above_survivors() {
     );
     assert!(next_malloc_trigger > survivors_after);
 }
+
+/// Debt-proportional assist pacing: the per-assist work budget must grow
+/// linearly with measured debt (and be exactly the base when no debt).
+#[test]
+fn mutator_assist_work_units_scale_with_debt() {
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+
+    // Suppressed triggers (usize::MAX) → both debts read zero → base budget.
+    assert_eq!(
+        gc_mutator_assist_scaled_work_units(),
+        GC_MUTATOR_ASSIST_WORK_UNITS
+    );
+
+    // Arena debt scales at GC_ASSIST_DEBT_BYTES_PER_WORK_UNIT bytes per unit.
+    let total = crate::arena::arena_total_bytes();
+    let arena_debt = (2 * 1024 * 1024).min(total);
+    GC_NEXT_TRIGGER_BYTES.with(|trigger| trigger.set(total - arena_debt));
+    let expected = GC_MUTATOR_ASSIST_WORK_UNITS
+        + (arena_debt as u64 / GC_ASSIST_DEBT_BYTES_PER_WORK_UNIT) as usize;
+    assert_eq!(gc_mutator_assist_scaled_work_units(), expected);
+
+    // Malloc debt converts 1:1 (one mark/sweep unit per outstanding object).
+    let malloc_count = malloc_object_count();
+    GC_NEXT_MALLOC_TRIGGER.with(|trigger| trigger.set(malloc_count.saturating_sub(7)));
+    let malloc_debt = malloc_count - malloc_count.saturating_sub(7);
+    assert_eq!(
+        gc_mutator_assist_scaled_work_units(),
+        expected + malloc_debt
+    );
+}
+
+/// The measured #6180 Stage-2 failure mode: with a FIXED 256-unit assist
+/// budget, a large-debt cycle crawls — a 10M-allocation benchmark completed
+/// ZERO collections while the synchronous default completed 7, and RSS grew
+/// 6-22× unbounded. With debt-scaled assists the same shape must finish in a
+/// bounded number of allocation-side calls: the heap below needs hundreds of
+/// thousands of work units, which 300 fixed-256 assists (76.8k units) cannot
+/// supply but 300 debt-scaled assists comfortably can.
+#[test]
+fn debt_scaled_assists_cannot_be_outrun_by_allocation() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    reset_old_reclaim_pressure();
+
+    let live = live_test_string(b"debt_pacing_live");
+    js_shadow_slot_set(0, string_bits(live));
+
+    // A heap big enough that fixed-256 assists could not finish the cycle
+    // within this test's call budget (see doc comment).
+    for _ in 0..150_000 {
+        let _ = young_leaf();
+    }
+
+    // Simulate the collector having fallen far behind: several MB of debt.
+    let total = crate::arena::arena_total_bytes();
+    let debt = (total / 2).max(1);
+    GC_NEXT_TRIGGER_BYTES.with(|trigger| trigger.set(total - debt));
+    assert!(
+        gc_mutator_assist_scaled_work_units() > GC_MUTATOR_ASSIST_WORK_UNITS * 10,
+        "large debt must scale the assist budget well past the base"
+    );
+
+    // Drive the cycle with allocation-side assists ONLY (never a host step),
+    // while the mutator keeps allocating between calls.
+    let before = gc_collection_count();
+    let mut calls = 0usize;
+    while gc_collection_count() == before {
+        for _ in 0..8 {
+            let _ = young_leaf();
+        }
+        gc_check_trigger();
+        calls += 1;
+        assert!(
+            calls <= 300,
+            "debt-scaled assists must complete the cycle before allocation \
+             outruns collection (still incomplete after {calls} calls)"
+        );
+    }
+
+    let live_after = (js_shadow_slot_get(0) & POINTER_MASK) as *const crate::StringHeader;
+    unsafe {
+        assert_string_bytes(live_after, b"debt_pacing_live");
+    }
+}

--- a/crates/perry-runtime/src/gc/tests/support.rs
+++ b/crates/perry-runtime/src/gc/tests/support.rs
@@ -166,7 +166,7 @@ pub(super) struct IncrementalMarkBarrierTestGuard<'a> {
 
 impl<'a> IncrementalMarkBarrierTestGuard<'a> {
     pub(super) fn new(valid_ptrs: &'a ValidPointerSet) -> Self {
-        incremental_mark_barrier_enable(valid_ptrs);
+        incremental_mark_barrier_enable(valid_ptrs, /* minor_only = */ false);
         Self {
             _valid_ptrs: valid_ptrs,
         }

--- a/crates/perry-runtime/src/gc/tests/support.rs
+++ b/crates/perry-runtime/src/gc/tests/support.rs
@@ -409,7 +409,13 @@ impl GcTriggerThresholdTestGuard {
     }
 
     pub(super) fn make_arena_trigger_due(&self) {
-        GC_NEXT_TRIGGER_BYTES.with(|trigger| trigger.set(0));
+        // Just-due, not zero: with debt-proportional assist pacing
+        // (`gc_mutator_assist_scaled_work_units`), trigger=0 would read the
+        // ENTIRE arena as debt and scale the first assist into a monolithic
+        // collection — these tests want "trigger due, collector keeping up"
+        // (debt ≈ 1 byte). Pacing-specific tests inflate debt explicitly.
+        let just_due = crate::arena::arena_total_bytes().saturating_sub(1);
+        GC_NEXT_TRIGGER_BYTES.with(|trigger| trigger.set(just_due));
     }
 }
 


### PR DESCRIPTION
Fixes #6224.

The measured incremental-GC pacing failure, plus the **four** latent budgeted-cycle soundness holes that working pacing immediately exposed (each found by re-running a differential stress after the previous layer, each verified fail-before/pass-after). Neither half is shippable alone — pacing without the soundness fixes crashes or silently drops live objects, and the soundness fixes without pacing are untestable dead weight (cycles never complete to sweep at all).

## 1. Debt-proportional mutator-assist pacing (#6224)

**Bug (measured):** allocation-side assists did a fixed `GC_MUTATOR_ASSIST_WORK_UNITS = 256` units of GC work per trigger regardless of how far behind the collector had fallen. A tight allocation loop outruns that: on a 10M-allocation ring benchmark the budgeted cycle **never completed** (0 collections vs the synchronous default's 7) and RSS grew **6–22× unbounded** (3.1 GB at 10M, 11 GB at 40M, vs STW's 501 MB). `GcDebtSnapshot` already measured exactly this shortfall — allocation past the armed triggers — but fed telemetry only.

**Fix:** scale each assist's budget linearly with measured debt (`gc_mutator_assist_scaled_work_units`): base 256 + 1 unit per `GC_ASSIST_DEBT_BYTES_PER_WORK_UNIT = 64` bytes of arena debt + 1 unit per outstanding malloc-registry object. Between two block-alloc assists the mutator allocates ~one arena block while the budget grows with total debt, so the controller self-stabilizes at a bounded equilibrium. The gain was chosen empirically: at 1024 bytes/unit, cycles still spanned ~300 MB of allocation (`pct_freed` 156–190% in the re-arm DIAG) and RSS sat at 3.5× STW; at 64 bytes/unit cycles complete within ~their trigger step.

**No cap, by design:** the budget is a *ceiling* on work, not a pause floor — `GcCycleState::step` stops the moment the cycle completes, and remaining cycle work is bounded by the heap. Worst case under extreme allocation pressure is finishing the cycle in one assist, i.e. exactly the pause the synchronous collector takes on every collection today: incremental degrades gracefully toward STW behavior rather than toward unbounded memory.

`make_arena_trigger_due` (test helper) now arms *just-due* (debt ≈ 1 byte) instead of `trigger = 0` (debt = entire arena), preserving the existing bounded-assist tests' "collector keeping up" semantics under debt scaling.

## 2. Incremental mark barrier for budgeted MINOR cycles

**Bug (exposed by fix 1, previously masked by it):** `incremental_mark_barrier_enable` was gated to `GcCollectionKind::Full` — but the default budgeted path for ordinary allocation pressure is **Minor**. A minor cycle sliced across mutator turns therefore marked with no store protection: a store into an already-scanned object left the stored child unmarked, and the sweep freed it live. Unreachable while pacing was broken (cycles never completed → never swept → the hole never fired; the earlier differential stress "passed" for exactly this reason). With pacing fixed it reproduced **7/7** as a SIGSEGV — a swept-live property-key string hashed through a wild pointer (`key_content_hash_impl`, `object/mod.rs:771`).

**Fix:**
- Enable the barrier for both kinds. For minors the barrier shades **nursery children only**: marking an old-gen child would leave a stray mark bit that a minor's sweep never clears (minors don't walk the old gen), which the *next full cycle* would misread as "already traced" and skip the object's children — trading one UAF for another a cycle later.
- Minors now run `AtomicFinalizeSubphase::BarrierSeedDrain` (first, so weak/finalization processing reads final marks), with kind-correct trace scoping (`minor_only`).
- Both barrier-off points (the minor jump-to-Sweep and Full's `DisableBarrier`) now do a final synchronous seed drain before disabling, closing the late-store window where a child was marked but its own children never traced. This half of the hole existed for **Full** cycles already.
- The `GcCycleState` Drop safety net (disable + clear seeds on an incomplete cycle) now covers both kinds, so the barrier's raw `valid_ptrs` pointer can never dangle.

## 3. Allocate-black for the whole cycle

Fixes 1–2 still left a deterministic **2,890/32,000 silent live-node loss** (no crash — a checksum-mismatch data corruption), reproducing identically under `PERRY_GEN_GC=0` (so not minor/RS-specific). Mechanism: objects born mid-cycle and installed via runtime-internal **raw** stores (a grown array's elements buffer, map entry nodes) never cross the nanboxed value-barrier path; and the victims were born during `BuildValidPointerSet` slices — **before** the barrier even enables (which is why barrier-window-only birth flags reproduced the loss bit-for-bit). Fix: `GC_BIRTH_EXTRA_FLAGS` — runtime-path allocations are born `MARKED` from cycle **construction** to outcome/Drop. Bounded floating garbage, priced by the pacer. Codegen inline-alloc objects don't need it: their installs all cross codegen store barriers.

## 4. Synchronous collections drain a parked budgeted cycle first

Manual `gc()` (and any direct/emergency collection) landing while a budgeted cycle was parked mid-phase constructed a second `GcCycleState` sharing `GC_FLAG_MARKED`, the mark-seed queue, the barrier TLS, and the birth-flag lifecycle — the interloper's sweep erased the parked cycle's marks, and the parked cycle's eventual sweep freed live objects (the SIGSEGV escalation: a swept-live property-key string hashed through a wild pointer). `gc_drain_active_budgeted_cycle` at both direct-collect entries finishes the parked cycle through its own machinery first — looping `step()` (one call advances only the current phase; instrumentation caught the single-step version leaving the cycle `still_active=true`) and bailing if the stepper reports blocked.

**Known remaining gap (documented, out of scope):** a pointer held *only* in a stack local with no heap store during the cycle window still needs a final root re-scan (remark phase) to be strictly sound — tracked as the remaining #6180 Stage-2 blocker. Every store-visible pattern is covered by the barrier + drains above.

## Measured (N=3 medians unless noted, `/usr/bin/time -l`)

| benchmark | metric | STW | inc BEFORE (fixed 256) | inc AFTER |
|---|---|---|---|---|
| B2 ring churn 10M | collections | 7 | **0** | 5 |
| | peak RSS | 501 MB | **3113 MB** | **921 MB** |
| | wall-clock | 31.9 s | 30.6 s* | 32.0 s |
| B1 large-live-heap latency | peak RSS | 497 MB | **1948 MB** | **974 MB** |
| | max frame | 648 ms | 75 ms* | **118 ms** |
| | p99 frame | 6.3 ms | 12.9 ms* | 53 ms |
| diff-stress (UAF repro) | result | pass | **SIGSEGV 7/7** | **pass 7/7** (exact checksum) |

\* the "before" latency/wall numbers were artifacts of under-collection — the collector wasn't doing its job (RSS column).

Full `perry-runtime` lib suite: 1225/1226 (the 1 failure is the known CWD-race flake `url::node_compat::path_to_file_url_posix`, failing identically on pristine main). New regression tests: `mutator_assist_work_units_scale_with_debt`, `debt_scaled_assists_cannot_be_outrun_by_allocation` (a heap needing ~hundreds of thousands of work units must complete within 300 assist calls — fixed-256 could supply at most 76.8k units), `budgeted_cycle_allocations_are_born_marked_for_the_whole_cycle`, `manual_gc_drains_parked_budgeted_cycle_first`.

`PERRY_GC_INCREMENTAL` remains default-off; this PR makes the mode viable (bounded RSS + no store-visible UAF) so the Stage-2 default-on decision can rest on the remaining remark-phase work plus these measurements.


## Final trade-off (all protections active)

Worst observed pause **5.4× better** (636 → 118 ms; p999 488 → 111 ms), throughput at **parity** (B2 32.3 → 32.0 s), RSS **1.8–2× STW** (down from 6–22× unbounded) — the remaining gap is the exact valid-pointer BTreeSet held across the sliced cycle plus allocate-black floating garbage, both of which #6179 (page-metadata classification) targets. p99 rises 7 → 53 ms: that is the debt pacer honestly doing collection work the broken version skipped. The remaining known soundness gap for default-on (#6180 Stage 2) is the stack-local remark phase; every store-visible pattern is covered here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improve GC correctness for objects allocated during incremental/minor cycles via enhanced “birth” flag handling and stricter incremental mark barrier finalization.
  * Ensure minor/full GC entry drains any active budgeted incremental work before continuing.
  * Refine incremental mark barrier seeding in minor-only mode to avoid marking outside the nursery.
* **New Features**
  * Introduce a public GC progress contract API to centralize pacing/progress budgets and reporting.
* **Tests**
  * Add regression coverage for debt-proportional mutator-assist pacing and correct behavior when combining budgeted and manual garbage collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->