### PR TITLE
fix(runtime): ptr_derefable overflows on arm64_32 (ptr >> 48 on 32-bit usize)

### DIFF
--- a/crates/perry-runtime/src/json/replacer.rs
+++ b/crates/perry-runtime/src/json/replacer.rs
@@ -78,7 +78,15 @@ unsafe fn root_holder(value_f64: f64) -> f64 {
 /// dereferenceable `GcHeader` — feeding it to `gc_obj_type` SIGBUSes.
 #[inline]
 fn ptr_derefable(ptr: usize) -> bool {
-    (ptr >> 48) <= 1 && ptr >= 0x10000 && (ptr & 0x7) == 0
+    // Top-16-bits check: a real heap pointer sits in the low canonical VA
+    // range (bits 48-63 are 0 or 1). On 32-bit targets (arm64_32/watchOS)
+    // `usize` has no bits above 31, so this is vacuously true — and emitting
+    // `ptr >> 48` there is a compile-time overflow. Gate it by pointer width.
+    #[cfg(target_pointer_width = "64")]
+    let high_bits_ok = (ptr >> 48) <= 1;
+    #[cfg(not(target_pointer_width = "64"))]
+    let high_bits_ok = true;
+    high_bits_ok && ptr >= 0x10000 && (ptr & 0x7) == 0
 }
 
 unsafe fn apply_to_json(value: f64) -> f64 {


### PR DESCRIPTION
## What

`crates/perry-runtime/src/json/replacer.rs` fails to compile for `arm64_32-apple-watchos`:

```
error: this arithmetic operation will overflow
  --> crates/perry-runtime/src/json/replacer.rs:81
   |
81 |     (ptr >> 48) <= 1 && ptr >= 0x10000 && (ptr & 0x7) == 0
   |     ^^^^^^^^^^^ attempt to shift right by `48_i32`, which would overflow
```

`ptr_derefable(ptr: usize)` checks that a heap pointer sits in the low canonical VA range (top 16 bits 0 or 1) via `ptr >> 48`. On **32-bit targets** — `arm64_32`, i.e. watchOS on Apple Watch Series 4–8 and SE — `usize` is 32-bit, so `>> 48` exceeds the type width and trips the `arithmetic_overflow` deny. That makes `perry-runtime` (and thus `perry-ui-watchos`) unbuildable for `arm64_32-apple-watchos`, which **blocks every standalone watch app targeting those devices** — the majority of Apple Watches in use.

## Fix

32-bit pointers have no bits above 31, so the high-bits check is vacuously true there. Gate it on `target_pointer_width`; 64-bit codegen is byte-for-byte unchanged.

## How it came up

Building a real times-table app for a physical **Apple Watch Series 7** (which reports `supportedCPUTypes: arm64_32` even on watchOS 26.5). The arm64 slice built fine; the arm64_32 slice — the one a Series 7 actually runs — hit this. With the fix, the arm64_32 lib builds and the app installs and runs on the device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a compilation issue on non-64-bit platforms.
  * Preserved existing pointer safety checks across supported architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->