### PR TITLE
fix(watchos): notifications should play the arrival haptic (attach default sound)

### DIFF
--- a/crates/perry-ui-watchos/src/notifications.rs
+++ b/crates/perry-ui-watchos/src/notifications.rs
@@ -150,6 +150,14 @@ unsafe fn build_content(title: &str, body: &str) -> Option<Retained<AnyObject>> 
     let _: () = msg_send![&*content, setTitle: &*ns_title];
     let ns_body = NSString::from_str(body);
     let _: () = msg_send![&*content, setBody: &*ns_body];
+    // Attach the default notification sound. On watchOS the arrival *haptic*
+    // is gated on the notification carrying a sound — without this the alert
+    // shows silently and never taps the wrist, defeating the point of a
+    // reminder. (Honored subject to the watch's Silent Mode / Haptic Strength.)
+    if let Some(sound_cls) = AnyClass::get(c"UNNotificationSound") {
+        let sound: Retained<AnyObject> = msg_send![sound_cls, defaultSound];
+        let _: () = msg_send![&*content, setSound: &*sound];
+    }
     Some(content)
 }
 


### PR DESCRIPTION
## What

watchOS local notifications showed the alert but never played the **arrival haptic**. `build_content` set only `title`/`body` on the `UNMutableNotificationContent`; on watchOS the haptic is gated on the notification carrying a sound. A reminder that doesn't tap the wrist defeats its purpose.

Attach `UNNotificationSound.defaultSound` (honored subject to the watch's Silent Mode / Haptic Strength).

## Verification

On a physical **Apple Watch Series 7**: the same scheduled reminder produced a silent visual alert before this change, and a buzzing alert after. Builds clean for `aarch64-apple-watchos` and `arm64_32-apple-watchos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Local notifications on watchOS now include the default notification sound when supported by the device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->