### PR TITLE
fix(runtime): dispatch dynamic native-module namespace method calls (fixes #6230)

### DIFF
--- a/crates/perry-runtime/src/object/global_this/populate.rs
+++ b/crates/perry-runtime/src/object/global_this/populate.rs
@@ -504,6 +504,18 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
         let name_key =
             crate::string::js_string_from_bytes(name_bytes.as_ptr(), name_bytes.len() as u32);
         let ns_value = if matches!(name, "console" | "process") {
+            // #6230: install the module's runtime dispatch bucket so dynamic
+            // method calls on the namespace *value* resolve — `const p = process;
+            // p.exit(1)`, `process["exit"](1)`, `p.cwd()`, dynamic `console.log`.
+            // These globals are never `import`ed, so nothing else emits the
+            // `js_nm_install_<module>()` call; `import`ed modules get theirs from
+            // the import. Reached only when the globalThis singleton is
+            // materialized — i.e. exactly when process/console are used as values.
+            match name {
+                "process" => crate::object::native_module_registry::js_nm_install_process(),
+                "console" => crate::object::native_module_registry::js_nm_install_console(),
+                _ => {}
+            }
             js_create_native_module_namespace(name_bytes.as_ptr(), name_bytes.len())
         } else if name == "WebAssembly" {
             super::global_this_webassembly::create_webassembly_namespace()

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -694,6 +694,46 @@ pub unsafe extern "C" fn js_native_call_method(
         }
     };
 
+    // #6230: a native-module namespace object (globalThis.process, console, or an
+    // imported node module) reached as a dynamic value — `const p = process;
+    // p.exit(1)`, `process["exit"](1)`, `p.cwd()`, `p.nextTick(cb)`, dynamic
+    // `console.log` — lands here rather than the codegen intrinsic used for the
+    // bare `process.exit(...)` form. Route the call to the native-module dispatch
+    // with the actual args; previously every such method fell through to
+    // `undefined` (so `exit` dropped its code, `cwd()` returned undefined,
+    // dynamic `nextTick`/`console.log` no-op'd). Exclude the generic
+    // Object.prototype methods and perry-internal (`__perry_*`) hooks so they
+    // keep using the shared object dispatch below; everything else is a genuine
+    // module method whose result (incl. a legitimate `undefined`) is returned
+    // directly — returning unconditionally avoids double-invoking a void method.
+    if jsval.is_pointer()
+        && !method_name.starts_with("__perry_")
+        && !matches!(
+            method_name,
+            "toString"
+                | "toLocaleString"
+                | "valueOf"
+                | "hasOwnProperty"
+                | "isPrototypeOf"
+                | "propertyIsEnumerable"
+                | "constructor"
+        )
+    {
+        let ns_ptr = jsval.as_pointer::<ObjectHeader>();
+        if !ns_ptr.is_null()
+            && crate::object::is_valid_obj_ptr(ns_ptr as *const u8)
+            && (*ns_ptr).class_id == crate::object::native_module::NATIVE_MODULE_CLASS_ID
+        {
+            let ns_args = refreshed_args();
+            return crate::object::dispatch_native_module_method(
+                ns_ptr as *const ObjectHeader,
+                method_name,
+                ns_args.as_ptr(),
+                ns_args.len(),
+            );
+        }
+    }
+
     // #4795: `using` / `await using` desugars disposal to
     // `obj.__perry_dispose__()` / `obj.__perry_async_dispose__()`. Class
     // instances resolve these through the renamed vtable method (handled by


### PR DESCRIPTION
## What

A native-module namespace read as a **value** — `const p = process; p.exit(1)`, `process["exit"](1)`, `p.cwd()`, dynamic `console.log(...)`, `p.nextTick(cb)` — reaches `js_native_call_method` (only the bare `process.exit(...)` keyword form is a codegen intrinsic). That path had no arm for namespace objects, so every such method fell through to `undefined`:

```ts
const p = process; p.exit(1);   // exited 0 (code dropped)
process["exit"](1);             // exited 0
const p = process; p.cwd();     // undefined
const c = console; c.log("x");  // no-op
```

Localization: extracting the function works (`const e = process.exit; e(1)` — via the keyword) but every method **call** through the namespace value was broken; and it wasn't `exit`-specific — all dynamic namespace methods were dead.

## Fix

Route namespace-object method calls to the native-module dispatch (`dispatch_native_module_method`) with the real args. Two parts:

1. **`js_native_call_method`** — add a branch for `NATIVE_MODULE_CLASS_ID` receivers. Excludes generic `Object.prototype` methods (`toString`/`hasOwnProperty`/…) and `__perry_*` hooks so they keep using the shared object dispatch; returns the dispatch result **unconditionally** so a void method (`nextTick`/`console.log`) isn't double-invoked.
2. **`globalThis` populate** — imported modules already emit `js_nm_install_<module>()` (so dynamic `os.platform()` etc. already resolve once routed), but `process`/`console` are globals that are never `import`ed. Install their dispatch bucket when the globalThis namespace object is created — reached only when the singleton is materialized, i.e. exactly when they're used as values, so it stays dead-strip-friendly.

## Test

`p.exit(4)`→exit 4, `process["exit"](2)`→2, `globalThis.process.exit(5)`→5, `p.cwd()`→real cwd, `p.nextTick`/dynamic `console.log` fire exactly once, dynamic `os.platform()`→"darwin". Regressions: direct `process.exit(N)` intrinsic unchanged, `process.hasOwnProperty('pid')`/`toString` still use the generic path, adversarial suite 22/22 run.

Fixes #6230. Found via running Bun's own test suite through perry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic method calls on `process`, `console`, and imported native modules.
  * Calls such as `process["exit"]()` and dynamically accessed `console.log()` now resolve correctly.
  * Preserved standard object methods such as `toString()`, `valueOf()`, and `hasOwnProperty()`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->