### PR TITLE
feat(gc): incremental collection by default — bounded pauses, RSS parity, STW as escape hatch (#6180)

### DIFF
--- a/crates/perry-runtime/src/gc/policy.rs
+++ b/crates/perry-runtime/src/gc/policy.rs
@@ -302,9 +302,17 @@ pub(crate) fn gc_moving_safepoint_enabled() -> bool {
 pub(crate) fn gc_incremental_enabled() -> bool {
     static CACHED: OnceLock<bool> = OnceLock::new();
     *CACHED.get_or_init(|| {
-        matches!(
+        // DEFAULT ON (#6180 flip): ordinary allocation pressure is collected
+        // by the budgeted incremental stepper — debt-paced assists, sound
+        // across mutator windows (mark barrier + allocate-black + final
+        // remark + drain-before-synchronous), census-free, RSS-parity on
+        // realistic workloads with ~5x lower worst pause. Bounded pauses by
+        // default; the synchronous collector remains for manual gc(),
+        // emergency reclaim, and as the PERRY_GC_INCREMENTAL=0 escape hatch
+        // (bisection / max-throughput batch workloads).
+        !matches!(
             std::env::var("PERRY_GC_INCREMENTAL").as_deref(),
-            Ok("1") | Ok("on") | Ok("true")
+            Ok("0") | Ok("off") | Ok("false")
         )
     })
 }

--- a/crates/perry-runtime/src/gc/tests/budgeted_step_api.rs
+++ b/crates/perry-runtime/src/gc/tests/budgeted_step_api.rs
@@ -71,7 +71,12 @@ fn arena_pressure_budgeted_step_starts_bounded_minor_cycle() {
 }
 
 #[test]
-fn synchronous_only_registered_scanner_blocks_budgeted_step_start() {
+fn synchronous_only_registered_scanner_runs_inline_under_default_incremental() {
+    // #6180 flip: incremental is the DEFAULT. Unbudgeted mutable scanners no
+    // longer block the budgeted stepper — they run synchronously inside the
+    // initial root-scan step (a bounded initial-mark pause). The meaningful
+    // contract is that the cycle starts, completes, and roots the scanner
+    // sees survive.
     let _guard = CopyingNurseryTestGuard::new(1);
     let trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
     reset_old_reclaim_pressure();
@@ -84,11 +89,12 @@ fn synchronous_only_registered_scanner_blocks_budgeted_step_start() {
     let mut result = JsGcStepResult::default();
     assert_eq!(
         js_gc_step_work_units(1, &mut result),
-        JS_GC_STEP_STATUS_SKIPPED
+        JS_GC_STEP_STATUS_ACTIVE,
+        "budgeted stepper must start despite unbudgeted mutable scanners"
     );
-    assert_eq!(result.active, 0);
-    assert_eq!(result.completed, 0);
-    assert_eq!(js_gc_step_status(&mut result), JS_GC_STEP_STATUS_IDLE);
+    let completed = complete_budgeted_gc_cycle();
+    assert_eq!(completed.status, JS_GC_STEP_STATUS_COMPLETED);
+    assert_eq!(js_shadow_slot_get(0) & POINTER_MASK, live as u64);
 }
 
 #[test]

--- a/crates/perry-runtime/src/gc/tests/cycle_state.rs
+++ b/crates/perry-runtime/src/gc/tests/cycle_state.rs
@@ -592,7 +592,10 @@ fn root_scan_slices_many_registered_tui_state_roots_with_tiny_budget() {
 }
 
 #[test]
-fn normal_incremental_root_scan_pauses_before_synchronous_only_registered_scanner() {
+fn normal_incremental_root_scan_runs_synchronous_only_scanner_inline() {
+    // #6180 flip: with incremental as the default, unbudgeted mutable
+    // scanners run synchronously inside the initial root-scan step instead
+    // of pausing the cycle before them.
     let _guard = CopyingNurseryTestGuard::new(0);
     let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
     SYNC_ONLY_SCANNER_CALLS.store(0, Ordering::Relaxed);
@@ -602,15 +605,15 @@ fn normal_incremental_root_scan_pauses_before_synchronous_only_registered_scanne
     state.set_progress_kind(GcProgressKind::NormalIncremental);
     run_cycle_until_phase(&mut state, GcCyclePhase::RootScan);
 
-    for _ in 0..8 {
+    let mut steps = 0usize;
+    while state.phase() == GcCyclePhase::RootScan && steps < 500_000 {
         state.step(GcWorkBudget::bounded(1));
+        steps += 1;
     }
 
-    assert_eq!(state.phase(), GcCyclePhase::RootScan);
-    assert_eq!(
-        SYNC_ONLY_SCANNER_CALLS.load(Ordering::Relaxed),
-        0,
-        "ordinary budgeted root scan must not invoke synchronous-only scanners"
+    assert!(
+        SYNC_ONLY_SCANNER_CALLS.load(Ordering::Relaxed) >= 1,
+        "default-incremental root scan must run synchronous-only scanners inline"
     );
     incremental_mark_barrier_disable();
     clear_mark_seeds();

--- a/crates/perry-runtime/src/gc/tests/debt_pacer.rs
+++ b/crates/perry-runtime/src/gc/tests/debt_pacer.rs
@@ -592,3 +592,44 @@ fn atomic_finalize_remark_rescues_pointer_hidden_in_shadow_slot_after_root_scan(
         "remark must keep the shadow-slot-only pointer off the sweep free list"
     );
 }
+
+/// #6228: array growth installs a PERMANENT forwarding stub at the old
+/// address; a stale pre-growth pointer held as the ONLY reference (the
+/// deforestation pass manufactures exactly this for direct calls) must keep
+/// the live post-growth array alive — the tracer hops the forwarding edge
+/// and MARKS the target instead of treating the stub as zero-children.
+#[test]
+fn forwarded_array_stub_propagates_liveness_to_grown_array() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    let trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    reset_old_reclaim_pressure();
+
+    let arr = crate::array::js_array_alloc(4);
+    let pre_growth = arr as usize;
+    // Push past capacity: js_array_grow reallocates and installs the
+    // forwarding stub at `pre_growth`.
+    for i in 0..64 {
+        crate::array::js_array_push(
+            pre_growth as *mut crate::array::ArrayHeader,
+            crate::JSValue::number(i as f64),
+        );
+    }
+    let header = unsafe { header_from_user_ptr(pre_growth as *const u8) };
+    assert!(
+        unsafe { (*header).gc_flags } & GC_FLAG_FORWARDED != 0,
+        "growth past capacity must leave a forwarding stub at the old address"
+    );
+
+    // The stale pre-growth pointer is the ONLY root.
+    js_shadow_slot_set(0, ptr_bits(pre_growth));
+
+    trigger_guard.make_arena_trigger_due();
+    gc_check_trigger();
+    let completed = complete_budgeted_gc_cycle();
+    assert_eq!(completed.status, JS_GC_STEP_STATUS_COMPLETED);
+
+    // Reads through the stale pointer must still see the full array.
+    let live = pre_growth as *const crate::array::ArrayHeader;
+    assert_eq!(crate::array::js_array_length(live), 64);
+    assert_eq!(crate::array::js_array_get_f64_unchecked(live, 63), 63.0);
+}

--- a/crates/perry-runtime/src/gc/trace.rs
+++ b/crates/perry-runtime/src/gc/trace.rs
@@ -705,6 +705,27 @@ pub(super) fn trace_one_worklist_header(
 ) {
     unsafe {
         let user_ptr = (header as *mut u8).add(GC_HEADER_SIZE);
+        // #6228: a FORWARDED header (array growth installs PERMANENT
+        // forwarding stubs — types.rs set_forwarding_address — so stale
+        // pre-growth pointers keep resolving for reads) must propagate
+        // liveness to its target instead of tracing as zero-children. The
+        // deforestation pass manufactures exactly such a stale pointer as
+        // the ONLY reference (direct-call `var b = build(n)`), and without
+        // this hop the live post-growth array was swept: length 0 / NaN
+        // reads past 32 MiB. Mirrors the (previously dead-code) trace_array
+        // path, plus MARKING the target — worklist membership alone does
+        // not protect it from the sweep.
+        if (*header).gc_flags & GC_FLAG_FORWARDED != 0 {
+            let new_user = forwarding_address(header) as usize;
+            if new_user >= 0x1000 && valid_ptrs.contains(&new_user) {
+                let new_header = header_from_user_ptr(new_user as *const u8);
+                if (*new_header).gc_flags & GC_FLAG_MARKED == 0 {
+                    (*new_header).gc_flags |= GC_FLAG_MARKED;
+                    worklist.push(new_header);
+                }
+            }
+            return;
+        }
         // C3b/C4 generational skip: in minor mode, an object
         // is treated as a black leaf when it lives in OLD_ARENA
         // (Phase B physical region) OR carries GC_FLAG_TENURED

--- a/crates/perry-runtime/src/gc/types.rs
+++ b/crates/perry-runtime/src/gc/types.rs
@@ -499,18 +499,25 @@ pub(super) static GC_TYPE_INFO_BY_ID: [Option<GcTypeInfo>; MALLOC_KIND_BUCKET_CO
         true,
         GcRewriteDescriptorKind::Leaf,
         GcLayoutSlotKind::None,
-        // Non-movable: like Date, a Temporal value is referenced by a NaN-boxed
-        // pointer kept in a plain f64/DOUBLE local that codegen does NOT
-        // shadow-root. The conservative stack scan keeps it alive; a stable
-        // address means that un-rooted pointer never goes stale across a GC.
-        false,
+        // Movable (#6186, completing the Date change from #6214 — the
+        // non-movable rationale above it was disproven there): `movable`
+        // only gates OLD-PAGE DEFRAG, which runs solely inside moving
+        // collections at stack-unwound safepoints; the nursery copied-minor
+        // already relocates Temporal cells. The embedded `temporal_rs` value
+        // survives memcpy (its owned allocations live on the Rust heap and
+        // move by value); from-space bulk resets skip per-object finalizers,
+        // so a moved cell is never double-dropped — `TemporalCleanup` fires
+        // once, wherever the cell finally dies.
+        true,
         GcExternalBytePolicy::None,
         GcLargeObjectPolicy::NotApplicable,
         // pointer_free: the embedded `temporal_rs` value is plain integers +
         // `'static` calendar data, never a JSValue. Any Rust-heap it owns is
         // released by the TemporalCleanup finalize hook, not GC tracing.
         true,
-        GcMoveHookKind::None,
+        // Expando rekey on relocation, mirroring Date: no-op when the cell
+        // has no expando entry.
+        GcMoveHookKind::ExoticExpandoOwner,
         GcRewriteHookKind::None,
         GcFinalizeHookKind::TemporalCleanup,
     )),


### PR DESCRIPTION
Closes #6180. Also completes #6186 (Temporal) and fixes #6228.

# Incremental collection is the default

Ordinary allocation pressure is now collected by the budgeted incremental stepper. `PERRY_GC_INCREMENTAL=0` is the escape hatch (bisection, max-throughput batch); manual `gc()` and emergency reclaim keep their synchronous full collections.

## Why it's ready — the evidence chain (all merged prerequisites)

- **Soundness** (#6226, #6235, #6239): debt-paced assists drive every phase; minor+full incremental mark barrier (nursery-scoped shading); whole-cycle allocate-black; final-root remark (atomic finalize); synchronous collections drain parked cycles; census-free budgeted cycles differentially verified (`PERRY_GC_VERIFY_CLASSIFIER=1`, 1227/0).
- **Numbers** (N=3 medians, `/usr/bin/time -l`): realistic workload at **RSS parity** (521 MB vs 521 MB STW) with **max frame 132 ms vs 636 ms** (~5×); throughput parity; extreme-churn peak attributed by vmmap to the transient mid-cycle high-water (steady-state 572 MB), the structural trade of slicing vs a pause wall.
- **Differential battery**: 15k-round graph stress ± manual gc ± force-evacuate ± `GEN_GC=0`, exact checksums; `VERIFY_EVACUATION` sweeps clean.
- **Gap suite A/B on the same binary**: incremental 243/269 = STW 243/269, **zero flip-only failures — and 4 tests fail under STW that pass under incremental** (failure set strictly ⊆ STW's).
- Full `perry-runtime` suite: 1227/0 as default.

## Also in this PR

- **#6228 fix** (measured, dlee's repro now prints `4194305 0`, Node-equal, both modes): the shared tracer treated FORWARDED array-growth stubs as zero-children — a stale pre-growth pointer as the only reference (deforestation manufactures exactly this for direct calls) let the live array be swept. The tracer now hops the forwarding edge and marks the target. Regression test included.
- **#6186 completion**: Temporal cells movable (same enumeration as Date/#6214; embedded `temporal_rs` survives memcpy, bulk resets skip finalizers → no double-drop, expando rekey mirrors Date).
- Two tests updated from the old default's scanner-gating contract (mutable sync-only scanners now run inline in the initial mark, by design).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Incremental garbage collection is now enabled by default.
  * Synchronous-only scanners run inline during initial garbage-collection scanning.
  * Forwarded pointers from grown arrays remain traceable, preserving access to live data.
  * Temporal objects can now move safely during garbage collection.

* **Bug Fixes**
  * Improved liveness tracking for forwarded array pointers.
  * Updated relocation handling for Temporal objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->