### PR TITLE
fix(runtime): stringify/JSON of a fetch/Blob handle SIGSEGV (fixes #6240, #6241)

### DIFF
--- a/crates/perry-runtime/src/json/stringify_api.rs
+++ b/crates/perry-runtime/src/json/stringify_api.rs
@@ -26,7 +26,11 @@ pub(crate) unsafe fn redirect_lazy_to_materialized(value: f64) -> f64 {
     } else {
         return value;
     };
-    if ptr.is_null() || (ptr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
+    // A synthetic handle-band id (fetch/Blob/socket/… < HANDLE_BAND_MAX) is not
+    // a real heap object; `gc_header = ptr - 8` would deref unmapped memory →
+    // SIGSEGV on e.g. `JSON.stringify(new Blob())` (#6240/#6241). It's never a
+    // LazyArrayHeader, so bail before the header read.
+    if ptr.is_null() || crate::value::addr_class::is_handle_band(ptr as usize) {
         return value;
     }
     let gc_header = ptr.sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
@@ -76,7 +80,9 @@ pub(crate) unsafe fn try_stringify_lazy_array(value: f64) -> Option<*mut StringH
     } else {
         return None;
     };
-    if maybe_ptr.is_null() || (maybe_ptr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
+    // Handle-band synthetic ids are never lazy arrays and must not be deref'd
+    // one word below the id (#6240/#6241).
+    if maybe_ptr.is_null() || crate::value::addr_class::is_handle_band(maybe_ptr as usize) {
         return None;
     }
     let gc_header = maybe_ptr.sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -812,7 +812,13 @@ pub extern "C" fn js_jsvalue_to_string(value: f64) -> *mut crate::string::String
             }
             return crate::string::js_string_from_bytes(b"[object Object]".as_ptr(), 15);
         }
-        if !ptr.is_null() && (ptr as usize) >= 0x10000 {
+        // Only a *real heap pointer* (above the whole synthetic handle band)
+        // may enter the object-deref block below. The prior `>= 0x10000` floor
+        // let fetch/Blob/socket/stream handle ids (0x40000+) through, so
+        // `String(new Blob())` reached the ToPrimitive/GC-header derefs and
+        // segfaulted (#6240/#6241). Proxies (a handle-band id) are already
+        // resolved above; any other handle falls through to "[object Object]".
+        if !ptr.is_null() && crate::value::addr_class::is_above_handle_band(ptr as usize) {
             // A Proxy is a small registered id, not a heap object — the GC-header
             // probes / ToPrimitive dispatch below would deref the fake pointer
             // and segfault (e.g. `String(proxy)`). Default `ToString` has no


### PR DESCRIPTION
## What

`String(new Blob())`, `"" + blob`, `JSON.stringify(new Request())` — any string/JSON coercion of a fetch/Blob/Request/Response handle — SIGSEGV'd. These handles are synthetic band ids (`[0x40000, HANDLE_BAND_MAX)`), not real `ObjectHeader`s, but the coercion paths treated the id as a heap pointer and read a GC header one word below it (`id - 8`).

Two sites:
1. **`js_jsvalue_to_string`** — the object-deref gate was `ptr >= 0x10000`, which let fetch handles (`0x40000+`) into the block where the ToPrimitive / GC-header probes deref the fake pointer. Gate on `is_above_handle_band` (real heap pointers only). Proxies (also band ids) are already resolved before the gate; any other handle now falls through to `"[object Object]"`.
2. **JSON `redirect_lazy_to_materialized` / `try_stringify_lazy_array`** — the `< 0x1000` floor missed the whole handle band, so a Blob id reached the `LazyArrayHeader` read. Guard with `is_handle_band`.

## Test

`String(new Blob())` → `"[object Object]"`, `JSON.stringify(new Blob())` → `"null"` (no crash), and the same for Request/Response — none crash. Regressions verified: `String({})`, `String([1,2,3])`, `String(new URL(...))`, `String(new Uint8Array(...))`, `JSON.stringify({...})` all unchanged. Found via Bun's `bun/jsc/native-constructor-identity` and `node/buffer-resolveObjectURL` tests — both went from SIGSEGV to running; the full portable suite now has **zero crash files**.

Fixes #6240, #6241.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes that could occur when converting certain special values to strings.
  * Improved handling of lazy and materialized values during JSON serialization.
  * Added safeguards so handle-like values are recognized correctly without unsafe memory access.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->