### PR TITLE
fix(hir,codegen): instanceof RHS (ty_expr) was invisible to analysis passes

### DIFF
--- a/crates/perry-codegen/src/collectors/escape_check.rs
+++ b/crates/perry-codegen/src/collectors/escape_check.rs
@@ -776,8 +776,11 @@ pub fn check_escapes_in_expr(
             check_escapes_in_expr(property, candidates, classes, escaped);
             check_escapes_in_expr(object, candidates, classes, escaped);
         }
-        Expr::InstanceOf { expr, .. } => {
+        Expr::InstanceOf { expr, ty_expr, .. } => {
             check_escapes_in_expr(expr, candidates, classes, escaped);
+            if let Some(t) = ty_expr {
+                check_escapes_in_expr(t, candidates, classes, escaped);
+            }
         }
         Expr::ObjectRest { object, .. } => {
             check_escapes_in_expr(object, candidates, classes, escaped);

--- a/crates/perry-codegen/src/collectors/escape_news.rs
+++ b/crates/perry-codegen/src/collectors/escape_news.rs
@@ -550,8 +550,11 @@ fn collect_used_new_fields_in_expr(
             collect_used_new_fields_in_expr(property, non_escaping_news, used);
             collect_used_new_fields_in_expr(object, non_escaping_news, used);
         }
-        Expr::InstanceOf { expr, .. } => {
+        Expr::InstanceOf { expr, ty_expr, .. } => {
             collect_used_new_fields_in_expr(expr, non_escaping_news, used);
+            if let Some(t) = ty_expr {
+                collect_used_new_fields_in_expr(t, non_escaping_news, used);
+            }
         }
         Expr::ProcessOn { event, handler } => {
             collect_used_new_fields_in_expr(event, non_escaping_news, used);

--- a/crates/perry-codegen/src/collectors/i32_locals.rs
+++ b/crates/perry-codegen/src/collectors/i32_locals.rs
@@ -1378,7 +1378,12 @@ pub fn collect_localset_ids_in_expr_filtered(
                 walk(e, out);
             }
         }
-        Expr::InstanceOf { expr, .. } => walk(expr, out),
+        Expr::InstanceOf { expr, ty_expr, .. } => {
+            walk(expr, out);
+            if let Some(t) = ty_expr {
+                walk(t, out);
+            }
+        }
         Expr::In { property, object } => {
             walk(property, out);
             walk(object, out);

--- a/crates/perry-codegen/src/collectors/refs.rs
+++ b/crates/perry-codegen/src/collectors/refs.rs
@@ -623,7 +623,12 @@ pub fn collect_ref_ids_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
                 walk(e, out);
             }
         }
-        Expr::InstanceOf { expr, .. } => walk(expr, out),
+        Expr::InstanceOf { expr, ty_expr, .. } => {
+            walk(expr, out);
+            if let Some(t) = ty_expr {
+                walk(t, out);
+            }
+        }
         Expr::In { property, object } => {
             walk(property, out);
             walk(object, out);

--- a/crates/perry-codegen/src/collectors/this_as_value.rs
+++ b/crates/perry-codegen/src/collectors/this_as_value.rs
@@ -369,7 +369,13 @@ pub fn expr_uses_this_as_value(e: &perry_hir::Expr, fields: &HashSet<String>) ->
         Expr::Yield { value, .. } => value
             .as_ref()
             .is_some_and(|v| expr_uses_this_as_value(v, fields)),
-        Expr::InstanceOf { expr, .. } => expr_uses_this_as_value(expr, fields),
+        Expr::InstanceOf { expr, ty_expr, .. } => {
+            expr_uses_this_as_value(expr, fields)
+                || ty_expr
+                    .as_ref()
+                    .map(|t| expr_uses_this_as_value(t, fields))
+                    .unwrap_or(false)
+        }
         Expr::In { property, object } => {
             expr_uses_this_as_value(property, fields) || expr_uses_this_as_value(object, fields)
         }

--- a/crates/perry-hir/src/analysis.rs
+++ b/crates/perry-hir/src/analysis.rs
@@ -1061,7 +1061,16 @@ fn replace_this_in_expr(expr: &mut Expr, this_id: LocalId) {
             }
         }
         Expr::TypeOf(o) | Expr::Void(o) => replace_this_in_expr(o, this_id),
-        Expr::InstanceOf { expr: inner, .. } => replace_this_in_expr(inner, this_id),
+        Expr::InstanceOf {
+            expr: inner,
+            ty_expr,
+            ..
+        } => {
+            replace_this_in_expr(inner, this_id);
+            if let Some(t) = ty_expr {
+                replace_this_in_expr(t, this_id);
+            }
+        }
         Expr::In { property, object } => {
             replace_this_in_expr(property, this_id);
             replace_this_in_expr(object, this_id);

--- a/crates/perry-hir/src/js_transform/imports.rs
+++ b/crates/perry-hir/src/js_transform/imports.rs
@@ -842,8 +842,15 @@ pub fn transform_expr(
         Expr::TypeOf(inner) => {
             transform_expr(inner, js_imports, extern_func_to_js, local_name_to_js, tracker);
         }
-        Expr::InstanceOf { expr: inner, .. } => {
+        Expr::InstanceOf {
+            expr: inner,
+            ty_expr,
+            ..
+        } => {
             transform_expr(inner, js_imports, extern_func_to_js, local_name_to_js, tracker);
+            if let Some(t) = ty_expr {
+                transform_expr(t, js_imports, extern_func_to_js, local_name_to_js, tracker);
+            }
         }
         Expr::Await(inner) => {
             transform_expr(inner, js_imports, extern_func_to_js, local_name_to_js, tracker);

--- a/crates/perry-hir/src/lower/closure_analysis.rs
+++ b/crates/perry-hir/src/lower/closure_analysis.rs
@@ -258,7 +258,12 @@ fn widen_mutable_captures_expr(
         Expr::Await(inner) | Expr::TypeOf(inner) | Expr::Void(inner) | Expr::Delete(inner) => {
             widen_mutable_captures_expr(inner, scope_mutable);
         }
-        Expr::InstanceOf { expr, .. } => widen_mutable_captures_expr(expr, scope_mutable),
+        Expr::InstanceOf { expr, ty_expr, .. } => {
+            widen_mutable_captures_expr(expr, scope_mutable);
+            if let Some(t) = ty_expr {
+                widen_mutable_captures_expr(t, scope_mutable);
+            }
+        }
         Expr::In { property, object } => {
             widen_mutable_captures_expr(property, scope_mutable);
             widen_mutable_captures_expr(object, scope_mutable);
@@ -566,7 +571,12 @@ fn collect_closure_assigned_expr(expr: &Expr, out: &mut std::collections::HashSe
         Expr::Await(inner) | Expr::TypeOf(inner) | Expr::Void(inner) | Expr::Delete(inner) => {
             collect_closure_assigned_expr(inner, out);
         }
-        Expr::InstanceOf { expr, .. } => collect_closure_assigned_expr(expr, out),
+        Expr::InstanceOf { expr, ty_expr, .. } => {
+            collect_closure_assigned_expr(expr, out);
+            if let Some(t) = ty_expr {
+                collect_closure_assigned_expr(t, out);
+            }
+        }
         Expr::In { property, object } => {
             collect_closure_assigned_expr(property, out);
             collect_closure_assigned_expr(object, out);
@@ -953,6 +963,12 @@ fn collect_closure_captures_expr(expr: &Expr, out: &mut std::collections::HashSe
                 collect_closure_captures_expr(arg, out);
             }
         }
+        Expr::InstanceOf { expr, ty_expr, .. } => {
+            collect_closure_captures_expr(expr, out);
+            if let Some(t) = ty_expr {
+                collect_closure_captures_expr(t, out);
+            }
+        }
         Expr::JsCreateCallback { closure, .. } => collect_closure_captures_expr(closure, out),
         Expr::Sequence(exprs) => {
             for e in exprs {
@@ -1291,7 +1307,12 @@ fn collect_closure_assigned_in_body_expr(
         Expr::Await(inner) | Expr::TypeOf(inner) | Expr::Void(inner) | Expr::Delete(inner) => {
             collect_closure_assigned_in_body_expr(inner, out);
         }
-        Expr::InstanceOf { expr, .. } => collect_closure_assigned_in_body_expr(expr, out),
+        Expr::InstanceOf { expr, ty_expr, .. } => {
+            collect_closure_assigned_in_body_expr(expr, out);
+            if let Some(t) = ty_expr {
+                collect_closure_assigned_in_body_expr(t, out);
+            }
+        }
         Expr::In { property, object } => {
             collect_closure_assigned_in_body_expr(property, out);
             collect_closure_assigned_in_body_expr(object, out);

--- a/crates/perry-hir/src/monomorph/defaults.rs
+++ b/crates/perry-hir/src/monomorph/defaults.rs
@@ -303,8 +303,11 @@ fn fill_defaults_in_expr(expr: &mut Expr, cx: &DefaultFill) {
                 fill_defaults_in_expr(v, cx);
             }
         }
-        Expr::InstanceOf { expr, .. } => {
+        Expr::InstanceOf { expr, ty_expr, .. } => {
             fill_defaults_in_expr(expr, cx);
+            if let Some(t) = ty_expr {
+                fill_defaults_in_expr(t, cx);
+            }
         }
         Expr::Closure { body, .. } => {
             fill_defaults_in_stmts(body, cx);

--- a/crates/perry-hir/src/monomorph/driver.rs
+++ b/crates/perry-hir/src/monomorph/driver.rs
@@ -378,7 +378,12 @@ fn collect_instantiations_in_expr(
                 collect_instantiations_in_expr(v, ctx, module, idx);
             }
         }
-        Expr::InstanceOf { expr, .. } => collect_instantiations_in_expr(expr, ctx, module, idx),
+        Expr::InstanceOf { expr, ty_expr, .. } => {
+            collect_instantiations_in_expr(expr, ctx, module, idx);
+            if let Some(t) = ty_expr {
+                collect_instantiations_in_expr(t, ctx, module, idx);
+            }
+        }
         Expr::Await(inner) => collect_instantiations_in_expr(inner, ctx, module, idx),
         Expr::SuperCall(args) => {
             for arg in args {

--- a/crates/perry-hir/src/monomorph/update_call_sites.rs
+++ b/crates/perry-hir/src/monomorph/update_call_sites.rs
@@ -283,7 +283,12 @@ fn update_call_sites_in_expr(
                 update_call_sites_in_expr(v, ctx, lookup);
             }
         }
-        Expr::InstanceOf { expr, .. } => update_call_sites_in_expr(expr, ctx, lookup),
+        Expr::InstanceOf { expr, ty_expr, .. } => {
+            update_call_sites_in_expr(expr, ctx, lookup);
+            if let Some(t) = ty_expr {
+                update_call_sites_in_expr(t, ctx, lookup);
+            }
+        }
         Expr::Await(inner) => update_call_sites_in_expr(inner, ctx, lookup),
         Expr::SuperCall(args) => {
             for arg in args.iter_mut() {

--- a/crates/perry/tests/instanceof_classexpr_rhs_captured.rs
+++ b/crates/perry/tests/instanceof_classexpr_rhs_captured.rs
@@ -1,0 +1,121 @@
+//! Regression: a class-expression binding used *only* as the RHS of
+//! `instanceof` inside a function evaluated to `undefined`.
+//!
+//! `const C = class {}` is a module-level local. When the sole use of `C` is
+//! as an `instanceof` right-hand side inside a nested function
+//! (`x instanceof C`), the codegen "referenced locals" collector
+//! (collectors/refs.rs, and its siblings — i32-locals, escape, closure
+//! capture, monomorph) walked only the InstanceOf `expr` (LHS) and skipped
+//! `ty_expr` (the RHS class value). So `C` looked unreferenced, its
+//! initializing store was eliminated, and `LocalGet` read an uninitialized
+//! slot → the runtime received `undefined` as the RHS and threw
+//! `TypeError: Right-hand side of 'instanceof' is not an object`.
+//!
+//! Node evaluates the RHS normally, so `x instanceof C` returns a boolean.
+//! Any *other* use of `C` (`const x = C; x instanceof …`, `f(C)`) masked the
+//! bug by making the collector see `C`. Fix: every InstanceOf analysis pass
+//! visits `ty_expr`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed (pre-fix: 'Right-hand side of instanceof is not an object')\n\
+         status: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+/// The minimal case: a plain class-expression const used only as an
+/// instanceof RHS inside a plain function.
+#[test]
+fn classexpr_instanceof_rhs_in_function() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const C: any = class {};
+function fn() { console.log(({}) instanceof C, (new C()) instanceof C); }
+fn();
+"#,
+    );
+    assert_eq!(stdout, "false true\n");
+}
+
+/// Multiple class-expression consts, one with `static [Symbol.hasInstance]`,
+/// each used only as an instanceof RHS inside a function (the shape that
+/// first surfaced this: a class-expression `H` whose `hasInstance` brand
+/// check ran inside an async body).
+#[test]
+fn classexpr_instanceof_rhs_multiple_and_hasinstance() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const H: any = class { static [Symbol.hasInstance](v: any) { return v === 7; } };
+const P1: any = class {};
+const P2: any = class {};
+function sync() {
+  console.log("H", 7 instanceof H, 8 instanceof H);
+  console.log("P1", ({}) instanceof P1, "P2", ({}) instanceof P2);
+}
+sync();
+(async () => {
+  console.log("async-H", 7 instanceof H);
+  console.log("async-P1", ({}) instanceof P1);
+})();
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "H true false\nP1 false P2 false\nasync-H true\nasync-P1 false\n"
+    );
+}
+
+/// The RHS class expression captured into an actual closure (arrow), not just
+/// a top-level function — exercises the closure-capture collector arm.
+#[test]
+fn classexpr_instanceof_rhs_in_closure() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+const Klass: any = class {};
+const check = (v: any) => v instanceof Klass;
+console.log(check({}), check(new Klass()));
+[1, 2].forEach(() => { if (({}) instanceof Klass) console.log("unreachable"); });
+console.log("done");
+"#,
+    );
+    assert_eq!(stdout, "false true\ndone\n");
+}


### PR DESCRIPTION
## Problem

A class-expression binding used **only** as the right-hand side of `instanceof` inside a function evaluated to `undefined`, so it threw where Node returns a boolean:

```ts
const C = class {};
function f() { return ({}) instanceof C; }
f();   // perry: TypeError: Right-hand side of 'instanceof' is not an object
       // node:  false
```

Found by a Node-vs-perry differential harness while chasing "run identically to Node."

## Root cause

`Expr::InstanceOf` carries two operands: `expr` (LHS) and `ty_expr` (the lowered RHS *value*, e.g. `LocalGet(C)` for a captured class-expression binding). Every hand-written analysis pass matched `InstanceOf { expr, .. }` and recursed into `expr` **only**, dropping `ty_expr`.

The load-bearing one is codegen's referenced-locals collector (`collectors/refs.rs`). With the sole use of `C` hidden inside `ty_expr`, `C` looked unreferenced → its initializing store was dead-code-eliminated → the `LocalGet` slot read `undefined` → the runtime got `undefined` as the RHS and threw.

This only bit **class expressions referenced exclusively through `instanceof`**:
- Any other use of `C` (`const x = C`, `f(C)`) makes `C` visible to the collector, masking it (that's why `const x = C; x instanceof …` worked but `x instanceof C` didn't).
- Class **declarations** take the static by-name path (`ty = "C"` → class id) and never build a `ty_expr`, so they were unaffected.

## Fix

Every InstanceOf arm now also visits `ty_expr`:
- **codegen**: `refs`, `i32_locals`, `escape_check`, `escape_news`, `this_as_value`
- **hir**: `closure_analysis` (mutable-capture widen, the two assigned collectors, and the read-capture collector — which had *no* InstanceOf arm at all, so a class-expr RHS captured into a closure was dropped), `monomorph` (`driver`/`update_call_sites`/`defaults`), `js_transform/imports`, and `analysis.rs::replace_this` (so `x instanceof this` rewrites the RHS too).

The AST walkers (`walker/expr_ref.rs`, `walker/expr_mut.rs`) already visited `ty_expr` — these hand-written collectors had diverged from them.

## Tests

New `crates/perry/tests/instanceof_classexpr_rhs_captured.rs` (3 tests, node-oracle-verified):
- class-expr const used only via `instanceof` in a plain function
- multiple consts incl. `static [Symbol.hasInstance]`, sync + async bodies
- RHS class expression captured into an arrow closure

Existing `issue_5667_instanceof_define_property_hasinstance`, `class_expr_well_known_symbol_methods`, `issue_5437_class_expr_heritage_capture`, and `perry-hir` unit suites pass. (The unrelated `c262_parity::logical_property_assignment_short_circuits_the_store_4586` fails identically on pristine main.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `instanceof` handling when the right-hand side is a class expression, preventing incorrect undefined or unreferenced values.
  - Ensured expressions within `instanceof` type operands are fully processed, including closures, captures, references, and generic behavior.
  - Improved support for synchronous, asynchronous, and custom `Symbol.hasInstance` scenarios.

- **Tests**
  - Added regression coverage for class expressions used as `instanceof` operands, including closure-captured cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->