### PR TITLE
Harden publish archive boundaries

### DIFF
--- a/crates/perry/src/commands/publish/config_types.rs
+++ b/crates/perry/src/commands/publish/config_types.rs
@@ -270,6 +270,8 @@ pub(super) struct PublishConfig {
     pub(super) server: Option<String>,
     /// Extra directories to exclude from the upload tarball (e.g. ["screenshots", "docs"])
     pub(super) exclude: Option<Vec<String>>,
+    /// Project-root paths to deliberately upload despite automatic safety filters.
+    pub(super) include: Option<Vec<String>>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/perry/src/commands/publish/mod.rs
+++ b/crates/perry/src/commands/publish/mod.rs
@@ -38,7 +38,7 @@ pub(crate) use saved_config::{
     check_beta_consent, config_path, is_interactive, load_config, prompt_input, report_beta_error,
     save_config, AndroidSavedConfig, AppleSavedConfig, HarmonyosSavedConfig, PerryConfig,
 };
-pub(crate) use tarball::{create_project_tarball, create_project_tarball_with_excludes};
+pub(crate) use tarball::create_project_tarball_with_filters;
 
 // Sibling-only items used by run_async and tests.
 use config_types::{resolve_build_march, PerryToml};
@@ -1424,6 +1424,11 @@ async fn run_async(args: PublishArgs, format: OutputFormat, _use_color: bool) ->
         .as_ref()
         .and_then(|p| p.exclude.clone())
         .unwrap_or_default();
+    let publish_includes = config
+        .publish
+        .as_ref()
+        .and_then(|p| p.include.clone())
+        .unwrap_or_default();
 
     // #1303 — force the vendored optional-framework dir
     // (`[google_auth].framework_dir`, project-relative) into the upload set
@@ -1438,8 +1443,13 @@ async fn run_async(args: PublishArgs, format: OutputFormat, _use_color: bool) ->
         .filter(|p| p.is_dir())
         .into_iter()
         .collect();
-    let tarball = create_project_tarball(&project_dir, &publish_excludes, &force_include_dirs)
-        .context("Failed to create project tarball")?;
+    let tarball = tarball::create_project_tarball_with_includes(
+        &project_dir,
+        &publish_excludes,
+        &force_include_dirs,
+        &publish_includes,
+    )
+    .context("Failed to create project tarball")?;
 
     let tarball_size = tarball.len();
     if let OutputFormat::Text = format {

--- a/crates/perry/src/commands/publish/tarball.rs
+++ b/crates/perry/src/commands/publish/tarball.rs
@@ -176,6 +176,21 @@ fn append_dir_beneath(
     Ok(true)
 }
 
+/// TAR headers always use `/` as the path separator. Keep the accompanying
+/// manifest in the same form on Windows without rewriting literal backslashes
+/// in valid Unix filenames.
+fn inventory_path(path: &Path) -> String {
+    let path = path.to_string_lossy();
+    #[cfg(windows)]
+    {
+        path.replace('\\', "/")
+    }
+    #[cfg(not(windows))]
+    {
+        path.into_owned()
+    }
+}
+
 /// Resolve `file:` dependencies from package.json and return (package_name, resolved_path) pairs.
 pub(super) fn resolve_file_deps(project_dir: &Path) -> Vec<(String, PathBuf)> {
     let pkg_path = project_dir.join("package.json");
@@ -324,7 +339,7 @@ pub(super) fn create_project_tarball_with_includes(
                 continue;
             }
             if append_file_beneath(&mut ar, &project_root, path, relative)? {
-                inventory.push(relative.to_string_lossy().into_owned());
+                inventory.push(inventory_path(relative));
             }
         } else if entry.file_type().is_dir() {
             append_dir_beneath(&mut ar, &project_root, path, relative)?;
@@ -372,7 +387,7 @@ pub(super) fn create_project_tarball_with_includes(
                     continue;
                 }
                 if append_file_beneath(&mut ar, dep_dir, path, &tar_path)? {
-                    inventory.push(tar_path.to_string_lossy().into_owned());
+                    inventory.push(inventory_path(&tar_path));
                 }
             } else if entry.file_type().is_dir() {
                 append_dir_beneath(&mut ar, dep_dir, path, &tar_path)?;
@@ -433,6 +448,15 @@ mod force_include_tests {
             }
         }
         panic!("publish manifest missing from archive");
+    }
+
+    #[test]
+    fn inventory_paths_use_tar_separators_without_rewriting_unix_names() {
+        let path = Path::new(r"directory\file.ts");
+        #[cfg(windows)]
+        assert_eq!(inventory_path(path), "directory/file.ts");
+        #[cfg(not(windows))]
+        assert_eq!(inventory_path(path), r"directory\file.ts");
     }
 
     #[test]

--- a/crates/perry/src/commands/publish/tarball.rs
+++ b/crates/perry/src/commands/publish/tarball.rs
@@ -34,6 +34,29 @@ pub(super) fn should_exclude_file(path: &Path) -> bool {
     false
 }
 
+/// Returns true for credentials and local configuration that must never leave a
+/// project accidentally. `publish.include` can opt in an individual project
+/// file after the caller has made that intent explicit.
+fn is_sensitive_file(path: &Path) -> bool {
+    let name = path.file_name().unwrap_or_default().to_string_lossy();
+    let name = name.to_ascii_lowercase();
+    let extension = path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+
+    name == ".npmrc"
+        || name == ".env"
+        || name.starts_with(".env.")
+        || matches!(
+            extension.as_str(),
+            "pem" | "key" | "p12" | "pfx" | "crt" | "cer" | "der" | "jks" | "keystore"
+        )
+        || ((name.contains("service-account") || name.contains("service_account"))
+            && extension == "json")
+}
+
 /// Does a user `publish.exclude` pattern match `path` (within `project_dir`)?
 ///
 /// Matching is anchored to the project root, NOT gitignore-style "match at any
@@ -62,6 +85,95 @@ pub(super) fn exclude_matches(pattern: &str, path: &Path, project_dir: &Path) ->
         // Bare name: a single project-root entry (file or dir), root-anchored.
         rel == Path::new(pattern)
     }
+}
+
+fn include_matches(pattern: &str, path: &Path, project_dir: &Path) -> bool {
+    exclude_matches(pattern, path, project_dir)
+}
+
+fn is_same_open_file(opened: &fs::Metadata, current: &fs::Metadata) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        opened.dev() == current.dev() && opened.ino() == current.ino()
+    }
+    #[cfg(not(unix))]
+    {
+        opened.is_file()
+            && current.is_file()
+            && opened.len() == current.len()
+            && opened.modified().ok() == current.modified().ok()
+    }
+}
+
+/// Opens a regular file only after proving that its resolved location remains
+/// under `root`. The handle, rather than the path, is then handed to `tar` so a
+/// replacement after this check cannot change the archived content.
+fn open_file_beneath(root: &Path, path: &Path) -> Option<fs::File> {
+    let before = fs::symlink_metadata(path).ok()?;
+    if !before.file_type().is_file() {
+        return None;
+    }
+    let canonical_before = path.canonicalize().ok()?;
+    if !canonical_before.starts_with(root) {
+        return None;
+    }
+
+    let file = fs::File::open(path).ok()?;
+    let opened = file.metadata().ok()?;
+    if !opened.is_file() {
+        return None;
+    }
+
+    // Detect a path replacement between `symlink_metadata`, canonicalization,
+    // and opening. If the path changes after this point, the already-opened
+    // descriptor remains the verified file.
+    let canonical_after = path.canonicalize().ok()?;
+    let current = fs::metadata(path).ok()?;
+    if canonical_after != canonical_before
+        || !canonical_after.starts_with(root)
+        || !is_same_open_file(&opened, &current)
+    {
+        return None;
+    }
+    Some(file)
+}
+
+fn append_file_beneath(
+    ar: &mut tar::Builder<GzEncoder<Vec<u8>>>,
+    root: &Path,
+    path: &Path,
+    tar_path: &Path,
+) -> Result<bool> {
+    let Some(mut file) = open_file_beneath(root, path) else {
+        return Ok(false);
+    };
+    ar.append_file(tar_path, &mut file)?;
+    Ok(true)
+}
+
+fn append_dir_beneath(
+    ar: &mut tar::Builder<GzEncoder<Vec<u8>>>,
+    root: &Path,
+    path: &Path,
+    tar_path: &Path,
+) -> Result<bool> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(_) => return Ok(false),
+    };
+    if !metadata.file_type().is_dir() {
+        return Ok(false);
+    }
+    let canonical = match path.canonicalize() {
+        Ok(path) if path.starts_with(root) => path,
+        _ => return Ok(false),
+    };
+    // `canonical` is used solely to prove containment; append_dir records
+    // metadata for the directory and never reads a symlink target.
+    let _ = canonical;
+    ar.append_dir(tar_path, path)?;
+    Ok(true)
 }
 
 /// Resolve `file:` dependencies from package.json and return (package_name, resolved_path) pairs.
@@ -93,25 +205,44 @@ pub(super) fn resolve_file_deps(project_dir: &Path) -> Vec<(String, PathBuf)> {
     deps
 }
 
-pub(crate) fn create_project_tarball_with_excludes(
+pub(crate) fn create_project_tarball_with_filters(
     project_dir: &Path,
     extra_excludes: &[String],
+    explicit_includes: &[String],
 ) -> Result<Vec<u8>> {
-    create_project_tarball(project_dir, extra_excludes, &[])
+    create_project_tarball_with_includes(project_dir, extra_excludes, &[], explicit_includes)
 }
 
-/// As [`create_project_tarball_with_excludes`], but `force_include_dirs`
-/// (absolute paths) are packed verbatim — files under them bypass
-/// [`should_exclude_file`]. Issue #1303: a vendored optional-framework dir
+/// Test helper for the optional-framework force-include behavior.
+///
+/// `force_include_dirs` lets files beneath those absolute paths bypass
+/// [`should_exclude_file`], while the regular root and symlink checks still
+/// apply. Issue #1303: a vendored optional-framework dir
 /// (e.g. the GoogleSignIn SDK declared via `perry.toml [google_auth]
 /// framework_dir`) contains the static archive binary (extension-less, often
 /// >1 MB) and would otherwise be dropped, leaving the worker to link the
 /// > no-SDK stub.
-pub(crate) fn create_project_tarball(
+#[cfg(test)]
+fn create_project_tarball(
     project_dir: &Path,
     extra_excludes: &[String],
     force_include_dirs: &[PathBuf],
 ) -> Result<Vec<u8>> {
+    create_project_tarball_with_includes(project_dir, extra_excludes, force_include_dirs, &[])
+}
+
+/// Creates the publish archive. `explicit_includes` may restore automatic
+/// exclusions (including sensitive files), but never follows symlinks and
+/// never overrides a `publish.exclude` rule.
+pub(super) fn create_project_tarball_with_includes(
+    project_dir: &Path,
+    extra_excludes: &[String],
+    force_include_dirs: &[PathBuf],
+    explicit_includes: &[String],
+) -> Result<Vec<u8>> {
+    let project_root = project_dir
+        .canonicalize()
+        .context("Failed to canonicalize project directory")?;
     // Force-include dirs are matched by absolute-path prefix; canonicalize
     // so a relative/`./`-prefixed input still matches the walked paths.
     let force_roots: Vec<PathBuf> = force_include_dirs
@@ -128,6 +259,8 @@ pub(crate) fn create_project_tarball(
     let buf = Vec::new();
     let encoder = GzEncoder::new(buf, Compression::default());
     let mut ar = tar::Builder::new(encoder);
+    ar.follow_symlinks(false);
+    let mut inventory = Vec::new();
 
     let builtin_exclude_dirs: Vec<&str> = vec![
         "node_modules",
@@ -140,47 +273,61 @@ pub(crate) fn create_project_tarball(
     ];
 
     // Walk the project directory
-    for entry in WalkDir::new(project_dir).into_iter().filter_entry(|e| {
-        // The walk root is always kept — exclusion rules below apply to
-        // children only. Without this guard, a user whose project root
-        // basename happens to match a bare-name entry in
-        // `publish.exclude` (typical when excluding a built binary that
-        // shares a name with the project dir) would have the entire
-        // tree pruned at depth 0, producing an empty tarball with no
-        // CLI-side error. Tracked in #416.
-        if e.depth() == 0 {
-            return true;
-        }
-        let name = e.file_name().to_string_lossy();
-        if builtin_exclude_dirs.iter().any(|ex| name == *ex) {
-            return false;
-        }
-        if extra_excludes
-            .iter()
-            .any(|ex| exclude_matches(ex, e.path(), project_dir))
-        {
-            return false;
-        }
-        if name.ends_with(".app") {
-            return false;
-        }
-        true
-    }) {
+    for entry in WalkDir::new(&project_root)
+        .follow_links(false)
+        .into_iter()
+        .filter_entry(|e| {
+            // The walk root is always kept — exclusion rules below apply to
+            // children only. Without this guard, a user whose project root
+            // basename happens to match a bare-name entry in
+            // `publish.exclude` (typical when excluding a built binary that
+            // shares a name with the project dir) would have the entire
+            // tree pruned at depth 0, producing an empty tarball with no
+            // CLI-side error. Tracked in #416.
+            if e.depth() == 0 {
+                return true;
+            }
+            let name = e.file_name().to_string_lossy();
+            if builtin_exclude_dirs.iter().any(|ex| name == *ex) {
+                return false;
+            }
+            if extra_excludes
+                .iter()
+                .any(|ex| exclude_matches(ex, e.path(), &project_root))
+            {
+                return false;
+            }
+            if name.ends_with(".app") {
+                return false;
+            }
+            true
+        })
+    {
         let entry = entry?;
         let path = entry.path();
-        let relative = path.strip_prefix(project_dir)?;
+        let relative = path.strip_prefix(&project_root)?;
 
         if relative.as_os_str().is_empty() {
             continue;
         }
 
-        if path.is_file() {
-            if should_exclude_file(path) && !is_force_included(path) {
+        if entry.file_type().is_file() {
+            let explicitly_included = explicit_includes
+                .iter()
+                .any(|include| include_matches(include, path, &project_root));
+            // Force-included framework roots are only for their binary
+            // artifacts; they must not silently bypass credential filtering.
+            if is_sensitive_file(path) && !explicitly_included {
                 continue;
             }
-            ar.append_path_with_name(path, relative)?;
-        } else if path.is_dir() {
-            ar.append_dir(relative, path)?;
+            if should_exclude_file(path) && !is_force_included(path) && !explicitly_included {
+                continue;
+            }
+            if append_file_beneath(&mut ar, &project_root, path, relative)? {
+                inventory.push(relative.to_string_lossy().into_owned());
+            }
+        } else if entry.file_type().is_dir() {
+            append_dir_beneath(&mut ar, &project_root, path, relative)?;
         }
     }
 
@@ -191,7 +338,7 @@ pub(crate) fn create_project_tarball(
         // Walk the dependency directory (exclude .git, target, dist, build artifacts)
         let dep_exclude_dirs = [".git", "target", "dist", "build", "xcode", "node_modules"];
         for entry in WalkDir::new(dep_dir)
-            .follow_links(true)
+            .follow_links(false)
             .into_iter()
             .filter_entry(|e| {
                 let name = e.file_name().to_string_lossy();
@@ -220,16 +367,33 @@ pub(crate) fn create_project_tarball(
 
             let tar_path = nm_prefix.join(relative);
 
-            if path.is_file() {
-                if should_exclude_file(path) {
+            if entry.file_type().is_file() {
+                if is_sensitive_file(path) || should_exclude_file(path) {
                     continue;
                 }
-                ar.append_path_with_name(path, &tar_path)?;
-            } else if path.is_dir() {
-                ar.append_dir(&tar_path, path)?;
+                if append_file_beneath(&mut ar, dep_dir, path, &tar_path)? {
+                    inventory.push(tar_path.to_string_lossy().into_owned());
+                }
+            } else if entry.file_type().is_dir() {
+                append_dir_beneath(&mut ar, dep_dir, path, &tar_path)?;
             }
         }
     }
+
+    inventory.sort();
+    let inventory = serde_json::to_vec(&serde_json::json!({
+        "version": 1,
+        "files": inventory,
+    }))?;
+    let mut header = tar::Header::new_gnu();
+    header.set_size(inventory.len() as u64);
+    header.set_mode(0o644);
+    header.set_cksum();
+    ar.append_data(
+        &mut header,
+        Path::new(".perry/publish-manifest.json"),
+        inventory.as_slice(),
+    )?;
 
     ar.finish()?;
     let encoder = ar.into_inner()?;
@@ -239,6 +403,7 @@ pub(crate) fn create_project_tarball(
 #[cfg(test)]
 mod force_include_tests {
     use super::*;
+    use std::io::Read;
 
     /// Collect the relative paths packed into a gzipped tarball.
     fn tar_entries(bytes: &[u8]) -> Vec<String> {
@@ -249,6 +414,25 @@ mod force_include_tests {
             .filter_map(|e| e.ok())
             .map(|e| e.path().unwrap().to_string_lossy().into_owned())
             .collect()
+    }
+
+    fn tar_manifest_files(bytes: &[u8]) -> Vec<String> {
+        let dec = flate2::read::GzDecoder::new(bytes);
+        let mut ar = tar::Archive::new(dec);
+        for entry in ar.entries().unwrap().flatten() {
+            if entry.path().unwrap() == Path::new(".perry/publish-manifest.json") {
+                let mut contents = String::new();
+                let mut entry = entry;
+                entry.read_to_string(&mut contents).unwrap();
+                return serde_json::from_str::<serde_json::Value>(&contents).unwrap()["files"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .filter_map(|file| file.as_str().map(String::from))
+                    .collect();
+            }
+        }
+        panic!("publish manifest missing from archive");
     }
 
     #[test]
@@ -355,5 +539,142 @@ mod force_include_tests {
                 .any(|p| p.ends_with("com/bloomengine/jump/BloomActivity.kt")),
             "deep jump/ package must be kept, got {entries:?}"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn skips_symlinks_without_reading_their_targets() {
+        use std::os::unix::fs::symlink;
+
+        let proj = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        fs::write(proj.path().join("index.ts"), "export {}\n").unwrap();
+        fs::write(proj.path().join("inside.txt"), "inside").unwrap();
+        fs::write(outside.path().join("secret.txt"), "outside secret").unwrap();
+        fs::create_dir_all(outside.path().join("external-dir")).unwrap();
+        fs::write(
+            outside.path().join("external-dir/nested.txt"),
+            "outside nested secret",
+        )
+        .unwrap();
+        symlink(
+            outside.path().join("secret.txt"),
+            proj.path().join("external-file"),
+        )
+        .unwrap();
+        symlink(
+            outside.path().join("external-dir"),
+            proj.path().join("external-dir"),
+        )
+        .unwrap();
+        symlink("inside.txt", proj.path().join("internal-file")).unwrap();
+        symlink("chain-b", proj.path().join("chain-a")).unwrap();
+        symlink("chain-a", proj.path().join("chain-b")).unwrap();
+
+        let entries = tar_entries(&create_project_tarball(proj.path(), &[], &[]).unwrap());
+        assert!(entries.iter().any(|p| p == "inside.txt"));
+        for omitted in [
+            "external-file",
+            "external-dir",
+            "external-dir/nested.txt",
+            "internal-file",
+            "chain-a",
+            "chain-b",
+        ] {
+            assert!(
+                !entries.iter().any(|p| p == omitted),
+                "symlink entry {omitted} must be omitted, got {entries:?}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn skips_symlink_escapes_from_file_dependencies() {
+        use std::os::unix::fs::symlink;
+
+        let proj = tempfile::tempdir().unwrap();
+        let dep = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        fs::write(proj.path().join("index.ts"), "export {}\n").unwrap();
+        fs::write(
+            proj.path().join("package.json"),
+            format!(
+                r#"{{"dependencies":{{"local-dep":"file:{}"}}}}"#,
+                dep.path().display()
+            ),
+        )
+        .unwrap();
+        fs::write(dep.path().join("index.ts"), "export const dep = true\n").unwrap();
+        fs::write(
+            outside.path().join("secret.ts"),
+            "export const secret = true\n",
+        )
+        .unwrap();
+        symlink(
+            outside.path().join("secret.ts"),
+            dep.path().join("escaped.ts"),
+        )
+        .unwrap();
+
+        let entries = tar_entries(&create_project_tarball(proj.path(), &[], &[]).unwrap());
+        assert!(entries
+            .iter()
+            .any(|p| p == "node_modules/local-dep/index.ts"));
+        assert!(!entries
+            .iter()
+            .any(|p| p == "node_modules/local-dep/escaped.ts"));
+    }
+
+    #[test]
+    fn excludes_sensitive_files_unless_explicitly_included() {
+        let proj = tempfile::tempdir().unwrap();
+        fs::write(proj.path().join("index.ts"), "export {}\n").unwrap();
+        for name in [
+            ".env",
+            ".env.production",
+            ".npmrc",
+            "tls-cert.pem",
+            "signing.key",
+            "service-account.json",
+            "service_account.production.json",
+        ] {
+            fs::write(proj.path().join(name), "sensitive").unwrap();
+        }
+
+        let default_tarball = create_project_tarball(proj.path(), &[], &[]).unwrap();
+        let default_entries = tar_entries(&default_tarball);
+        assert!(default_entries.iter().any(|p| p == "index.ts"));
+        assert!(default_entries
+            .iter()
+            .any(|p| p == ".perry/publish-manifest.json"));
+        let manifest_files = tar_manifest_files(&default_tarball);
+        assert!(manifest_files.iter().any(|p| p == "index.ts"));
+        for name in [
+            ".env",
+            ".env.production",
+            ".npmrc",
+            "tls-cert.pem",
+            "signing.key",
+            "service-account.json",
+            "service_account.production.json",
+        ] {
+            assert!(
+                !default_entries.iter().any(|p| p == name),
+                "sensitive file {name} must be excluded by default"
+            );
+        }
+
+        let included = create_project_tarball_with_includes(
+            proj.path(),
+            &[],
+            &[],
+            &[".env.production".to_string()],
+        )
+        .unwrap();
+        let included_entries = tar_entries(&included);
+        assert!(included_entries.iter().any(|p| p == ".env.production"));
+        assert!(!included_entries.iter().any(|p| p == ".env"));
+        assert!(!included_entries.iter().any(|p| p == ".npmrc"));
     }
 }

--- a/crates/perry/src/commands/run/remote.rs
+++ b/crates/perry/src/commands/run/remote.rs
@@ -13,7 +13,7 @@ pub async fn remote_build_and_launch(
     format: OutputFormat,
 ) -> Result<()> {
     use super::super::publish::{
-        auto_register_license, create_project_tarball_with_excludes, load_config, save_config,
+        auto_register_license, create_project_tarball_with_filters, load_config, save_config,
     };
     use base64::Engine;
     use futures_util::{SinkExt, StreamExt};
@@ -87,19 +87,30 @@ pub async fn remote_build_and_launch(
         std::io::stdout().flush().ok();
     }
 
-    // Read [publish].exclude from perry.toml so `run` excludes the same dirs as `publish`
-    let publish_excludes = std::fs::read_to_string(project_root.join("perry.toml"))
-        .ok()
-        .and_then(|s| toml::from_str::<toml::Value>(&s).ok())
-        .and_then(|v| v.get("publish")?.get("exclude")?.as_array().cloned())
-        .map(|arr| {
-            arr.into_iter()
-                .filter_map(|v| v.as_str().map(String::from))
-                .collect::<Vec<_>>()
-        })
-        .unwrap_or_default();
-    let tarball = create_project_tarball_with_excludes(&project_root, &publish_excludes)
-        .context("Failed to create project tarball")?;
+    // Read [publish] filters so remote runs use the same archive policy as publish.
+    let (publish_excludes, publish_includes) =
+        std::fs::read_to_string(project_root.join("perry.toml"))
+            .ok()
+            .and_then(|s| toml::from_str::<toml::Value>(&s).ok())
+            .and_then(|v| v.get("publish").cloned())
+            .map(|publish| {
+                let strings = |key: &str| {
+                    publish
+                        .get(key)
+                        .and_then(|value| value.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|value| value.as_str().map(String::from))
+                                .collect::<Vec<_>>()
+                        })
+                        .unwrap_or_default()
+                };
+                (strings("exclude"), strings("include"))
+            })
+            .unwrap_or_default();
+    let tarball =
+        create_project_tarball_with_filters(&project_root, &publish_excludes, &publish_includes)
+            .context("Failed to create project tarball")?;
 
     if let OutputFormat::Text = format {
         println!(

--- a/docs/src/cli/perry-toml.md
+++ b/docs/src/cli/perry-toml.md
@@ -93,6 +93,9 @@ fr = "EUR"
 
 [publish]
 server = "https://hub.perryts.com"
+exclude = ["screenshots", "docs"]
+# Deliberately send this input; see the archive safety policy below.
+include = [".env.publish"]
 
 [audit]
 fail_on = "B"
@@ -382,6 +385,25 @@ Publishing configuration.
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `server` | string | `https://hub.perryts.com` | Custom Perry Hub build server URL. Useful for self-hosted or enterprise deployments |
+| `exclude` | string[] | — | Project-root paths to omit from the upload. A bare name matches only a root entry; a path containing `/` matches that root-relative subtree. |
+| `include` | string[] | — | Project-root paths deliberately restored after automatic file filtering. It cannot override `exclude` or make Perry follow a symlink. |
+
+#### Upload archive safety
+
+`perry publish` and remote `perry run` package only regular files contained in
+their declared roots. Symlinks are never followed or included, whether they
+point inside the project, outside it, form a chain/cycle, or appear inside a
+`file:` dependency. A declared `file:` dependency is its own canonical root,
+so legitimate sibling packages remain supported, but links *inside* that
+dependency cannot escape it.
+
+The archive excludes `.env`, `.env.*`, `.npmrc`, certificate/key containers
+(`.pem`, `.key`, `.p12`, `.pfx`, `.crt`, `.cer`, `.der`, `.jks`, `.keystore`),
+and `service-account*.json` / `service_account*.json` by default. If a remote
+build genuinely needs one of these files, list its exact project-root path in
+`publish.include`; treat that as an intentional credential disclosure. An
+explicit `publish.exclude` always wins. The packed archive also contains a
+machine-readable `.perry/publish-manifest.json` inventory of included files.
 
 ---
 


### PR DESCRIPTION
## Summary
- reject and do not follow project or `file:` dependency symlinks
- exclude common credential files by default, with explicit `publish.include` opt-in
- add an archive inventory manifest and document the safety policy

## Validation
- `cargo fmt --check`
- `cargo check -p perry`
- `cargo test -p perry --bin perry force_include_tests -- --nocapture`

## Compatibility
- preserves vendored framework force-includes for regular files
- preserves declared `file:` dependencies as independent canonical roots

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional `publish.include` patterns to deliberately include otherwise-excluded files in publish upload archives.
  - Publish archives now contain a `.perry/publish-manifest.json` listing the packaged inventory.
  - Remote runs apply both `publish.include` and `publish.exclude`.
- **Bug Fixes**
  - Hardened archive building to avoid symlink following/escape and enforce root-contained paths.
  - Sensitive credential/config/cert/key files are excluded by default, unless explicitly included; `publish.exclude` still overrides.
- **Documentation**
  - Updated `perry.toml` examples and archive safety/precedence guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->