### PR TITLE
fix(runtime): dispatch Uint8Array object sources safely

### DIFF
--- a/crates/perry-runtime/src/buffer/from.rs
+++ b/crates/perry-runtime/src/buffer/from.rs
@@ -461,6 +461,29 @@ pub extern "C" fn js_uint8array_from_array(arr_ptr: *const ArrayHeader) -> *mut 
     buf
 }
 
+/// Materialize non-Array Uint8Array sources through the shared TypedArray path.
+fn js_uint8array_from_source(source: f64) -> *mut BufferHeader {
+    let raw = unsafe { crate::typedarray::typed_array_from_source_raw_values(source) };
+
+    // Coercion can collect, so retain the snapshot in runtime roots.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let raw_handles = scope.root_nanbox_f64_slice(&raw);
+    let bytes: Vec<u8> = raw_handles
+        .iter()
+        .map(|value| buffer_byte_from_js_value(value.get_nanbox_f64()))
+        .collect();
+
+    unsafe {
+        let buf = buffer_alloc(bytes.len() as u32);
+        (*buf).length = bytes.len() as u32;
+        if !bytes.is_empty() {
+            ptr::copy_nonoverlapping(bytes.as_ptr(), buffer_data_mut(buf), bytes.len());
+        }
+        mark_as_uint8array(buf as usize);
+        buf
+    }
+}
+
 /// Validate a `new Uint8Array(length)` argument with `ToIndex` semantics and
 /// throw the spec `RangeError: Invalid typed array length: <n>` on a negative
 /// or out-of-range length, matching Node (#3662). `Uint8Array` is backed by a
@@ -519,6 +542,13 @@ pub extern "C" fn js_uint8array_alloc(length: i32) -> *mut BufferHeader {
 pub extern "C" fn js_uint8array_new(val: f64) -> *mut BufferHeader {
     let bits = val.to_bits();
     let top16 = (bits >> 48) as u16;
+    // ToIndex rejects BigInt and Symbol.
+    if top16 == 0x7FFA {
+        crate::collection_iter::throw_type_error("Cannot convert a BigInt value to a number");
+    }
+    if top16 == 0x7FFD && unsafe { crate::symbol::js_is_symbol(val) } != 0 {
+        crate::collection_iter::throw_type_error("Cannot convert a Symbol value to a number");
+    }
     // POINTER_TAG (0x7FFD) — an object/array/buffer pointer.
     if top16 == 0x7FFD {
         let raw = (bits & 0x0000_FFFF_FFFF_FFFF) as usize;
@@ -572,8 +602,13 @@ pub extern "C" fn js_uint8array_new(val: f64) -> *mut BufferHeader {
                 return dst;
             }
         }
-        // Otherwise treat as a numeric source array.
-        return js_uint8array_from_array(raw as *const ArrayHeader);
+        // The raw helper requires an actual ArrayHeader layout.
+        if unsafe { crate::value::addr_class::try_read_gc_header(raw) }
+            .is_some_and(|header| header.obj_type == crate::gc::GC_TYPE_ARRAY)
+        {
+            return js_uint8array_from_array(raw as *const ArrayHeader);
+        }
+        return js_uint8array_from_source(val);
     }
     // Plain IEEE double (upper16 < 0x7FFC or > 0x7FFF) — numeric length.
     // Node applies ToIndex (NaN → 0, truncate toward zero) and throws a
@@ -584,9 +619,11 @@ pub extern "C" fn js_uint8array_new(val: f64) -> *mut BufferHeader {
         let len = uint8array_length_or_throw(val);
         return js_uint8array_alloc(len as i32);
     }
-    // Any other tag (undefined/null/bool/string/bigint) → empty buffer,
-    // matching the JS semantics of `new Uint8Array(undefined)` et al.
-    js_uint8array_alloc(0)
+    if bits == crate::value::TAG_UNDEFINED {
+        return js_uint8array_alloc(0);
+    }
+    let len = uint8array_length_or_throw(crate::typedarray::jsvalue_to_f64(val));
+    js_uint8array_alloc(len as i32)
 }
 
 /// `new Uint8Array(buffer, byteOffset, length)` — create a Uint8Array view

--- a/crates/perry-runtime/src/closure/dynamic_props.rs
+++ b/crates/perry-runtime/src/closure/dynamic_props.rs
@@ -470,6 +470,10 @@ pub fn closure_get_dynamic_prop(ptr: usize, prop: &str) -> f64 {
             }
         }
     }
+    // Function length is an own intrinsic property.
+    if prop == "length" && !closure_is_key_deleted(ptr, "length") {
+        return crate::closure::closure_length(ptr as *const ClosureHeader).unwrap_or(0) as f64;
+    }
     // #36 / #321: own prop miss — walk the closure's static prototype chain
     // (`Object.setPrototypeOf(closure, protoObj)`). Reads a string-keyed field
     // off the proto object. Lets effect's `TagClass._op` resolve to "Tag" on

--- a/test-files/test_gap_uint8array_source_dispatch.ts
+++ b/test-files/test_gap_uint8array_source_dispatch.ts
@@ -1,0 +1,52 @@
+// Gap test: Uint8Array constructor source dispatch must distinguish real
+// Arrays from plain object/function array-likes and other iterable sources.
+// Run: ./run_parity_tests.sh --filter uint8array_source_dispatch
+
+function bytes(source: any): string {
+  return Array.from(new Uint8Array(source)).join(",");
+}
+
+const plain = { 0: 5, 1: 6, length: 2 };
+console.log("plain", bytes(plain));
+
+function callableArrayLike(_a: unknown, _b: unknown) {}
+(callableArrayLike as any)[0] = 8;
+(callableArrayLike as any)[1] = 9;
+console.log("function", bytes(callableArrayLike));
+
+const iterable = {
+  *[Symbol.iterator]() {
+    yield 12;
+    yield 13;
+  },
+  length: 99,
+};
+console.log("iterable", bytes(iterable));
+
+const sparse = { 1: 21, length: 3 };
+console.log("sparse", bytes(sparse));
+console.log("array", bytes([31, 32]));
+console.log("buffer", bytes(Buffer.from([41, 42])));
+
+const ab = new ArrayBuffer(2);
+new Uint8Array(ab).set([51, 52]);
+console.log("arraybuffer", bytes(ab));
+console.log("uint8", bytes(new Uint8Array([61, 62])));
+console.log("int16", bytes(new Int16Array([257, -1])));
+
+console.log("undefined", bytes(undefined));
+console.log("null", bytes(null));
+console.log("boolean", bytes(true));
+console.log("string", bytes("2"));
+try {
+  bytes(Symbol("source"));
+  console.log("symbol", "no throw");
+} catch (error) {
+  console.log("symbol", error instanceof TypeError);
+}
+try {
+  bytes(1n);
+  console.log("bigint", "no throw");
+} catch (error) {
+  console.log("bigint", error instanceof TypeError);
+}


### PR DESCRIPTION
## Summary
- Route `Uint8Array` object sources through the shared iterable/array-like materialization unless the source is a verified Perry `Array`.
- Preserve the raw array fast path only after a `GC_TYPE_ARRAY` check, preventing incompatible object and closure layouts from being read as `ArrayHeader` data.
- Root the collected source values while byte coercion can invoke user code, and expose intrinsic function `length` for function array-like sources.

## Root cause
The dynamic Uint8Array constructor passed every unrecognised pointer to the raw array helper. Plain objects and functions do not use `ArrayHeader` layout, so their length and element storage were interpreted incorrectly.

## Validation
- `cargo fmt --check`
- `cargo check -p perry-runtime`
- `cargo test -p perry-runtime buffer --lib`
- Direct Node/Perry parity for `test_gap_uint8array_source_dispatch.ts`, covering object, function, iterable, sparse, Array, Buffer, ArrayBuffer, Uint8Array, another typed array, nullish, scalar, Symbol, and BigInt sources.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded `Uint8Array` construction to support array-like objects, functions, iterables, sparse sources, Node `Buffer`, `ArrayBuffer`, and typed array constructors.
  - Added consistent coercion for `undefined`, `null`, booleans, and strings.
- **Bug Fixes**
  - `Uint8Array` now throws `TypeError` for `Symbol` and `BigInt` inputs.
  - Improved handling for `undefined` inputs (now produces a zero-length `Uint8Array`) and more accurate length determination for other non-array sources.
  - Ensured a function’s intrinsic `length` is returned as its own intrinsic value (while respecting `delete fn.length`).
- **Tests**
  - Added coverage for `Uint8Array` constructor source-type dispatch, including expected `TypeError` cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->