### PR TITLE
fix(runtime): guard flatMap array flattening

### DIFF
--- a/crates/perry-runtime/src/array/flat_clone.rs
+++ b/crates/perry-runtime/src/array/flat_clone.rs
@@ -25,6 +25,59 @@ unsafe fn receiver_gc_type(ptr: *const ArrayHeader) -> u8 {
     (*gc_header).obj_type
 }
 
+/// Return a real `ArrayHeader` only when `value` satisfies ECMAScript's
+/// `IsArray` check. This unwraps proxy targets, rejects every other
+/// `POINTER_TAG` heap object by its GC type, and materializes lazy arrays
+/// through `clean_arr_ptr` before callers read the dense array layout.
+///
+/// The result is suitable for a flattening operation (`flat` / `flatMap`),
+/// where arrays are spread by one level but ordinary objects, closures, and
+/// other pointer-tagged values remain elements.
+#[inline]
+pub(crate) fn flattenable_array_ptr(value: f64) -> *const ArrayHeader {
+    // IsArray recurses through proxies and must throw for a revoked proxy.
+    let mut value = value;
+    while let Some(target) = crate::proxy::is_array_proxy_step(value) {
+        value = target;
+    }
+
+    let bits = value.to_bits();
+    let top16 = bits >> 48;
+    let addr = if top16 == 0x7FFD {
+        (bits & crate::value::POINTER_MASK) as usize
+    } else if top16 == 0 && bits >= 0x10000 && (bits & 0x7) == 0 {
+        bits as usize
+    } else {
+        return ptr::null();
+    };
+
+    // Do not interpret a pointer-tagged handle as a heap address. The GC type
+    // check must happen before reading `ArrayHeader.length`: ObjectHeader and
+    // ClosureHeader have incompatible layouts.
+    let is_array = unsafe {
+        matches!(
+            crate::value::addr_class::try_read_gc_header(addr),
+            Some(header)
+                if header.obj_type == crate::gc::GC_TYPE_ARRAY
+                    || header.obj_type == crate::gc::GC_TYPE_LAZY_ARRAY
+        )
+    };
+    if !is_array {
+        return ptr::null();
+    }
+
+    let array = clean_arr_ptr(addr as *const ArrayHeader);
+    if array.is_null() {
+        return ptr::null();
+    }
+    unsafe {
+        match crate::value::addr_class::try_read_gc_header(array as usize) {
+            Some(header) if header.obj_type == crate::gc::GC_TYPE_ARRAY => array,
+            _ => ptr::null(),
+        }
+    }
+}
+
 /// `Array.prototype.flat(depth)` — flatten up to `depth` levels deep
 /// (ECMA-262 §23.1.3.10).
 #[no_mangle]
@@ -59,49 +112,19 @@ unsafe fn js_array_flat_into(
     let elements = (src as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
     for i in 0..len {
         let element = *elements.add(i);
-        let bits = element.to_bits();
         // Per ECMAScript FlattenIntoArray, holes are absent (HasProperty is
         // false) and are skipped, not copied as `null`/`undefined`.
-        if bits == crate::value::TAG_HOLE {
+        if element.to_bits() == crate::value::TAG_HOLE {
             continue;
         }
-        let top16 = (bits >> 48) as u16;
-        let maybe_arr_ptr = if top16 >= 0x7FF8 {
-            if top16 == 0x7FFD {
-                let ptr = (bits & 0x0000_FFFF_FFFF_FFFF) as *const ArrayHeader;
-                if (ptr as usize) >= 0x1000 {
-                    Some(ptr)
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        } else if top16 == 0 && bits >= 0x10000 && (bits & 0x7) == 0 {
-            Some(bits as *const ArrayHeader)
-        } else {
-            None
-        };
         let mut pushed = false;
         if depth_left > 0 {
-            if let Some(sub_arr) = maybe_arr_ptr {
-                let is_set_or_map = crate::set::is_registered_set(sub_arr as usize)
-                    || crate::map::is_registered_map(sub_arr as usize);
-                if !is_set_or_map {
-                    let obj_type = if (sub_arr as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000 {
-                        let hdr = (sub_arr as *const u8).sub(crate::gc::GC_HEADER_SIZE)
-                            as *const crate::gc::GcHeader;
-                        (*hdr).obj_type
-                    } else {
-                        0
-                    };
-                    if obj_type == crate::gc::GC_TYPE_ARRAY {
-                        let sub_len = (*sub_arr).length as usize;
-                        if sub_len <= 1_000_000 {
-                            result = js_array_flat_into(result, sub_arr, depth_left - 1);
-                            pushed = true;
-                        }
-                    }
+            let sub_arr = flattenable_array_ptr(element);
+            if !sub_arr.is_null() {
+                let sub_len = (*sub_arr).length as usize;
+                if sub_len <= 1_000_000 {
+                    result = js_array_flat_into(result, sub_arr, depth_left - 1);
+                    pushed = true;
                 }
             }
         }
@@ -128,50 +151,12 @@ pub extern "C" fn js_array_flat(arr: *const ArrayHeader) -> *mut ArrayHeader {
 
         for i in 0..len {
             let element = *elements.add(i);
-            let bits = element.to_bits();
             // Per ECMAScript FlattenIntoArray, holes are absent and skipped.
-            if bits == crate::value::TAG_HOLE {
+            if element.to_bits() == crate::value::TAG_HOLE {
                 continue;
             }
-            let top16 = (bits >> 48) as u16;
-
-            // Check if the element is an array pointer (NaN-boxed or raw)
-            let maybe_arr_ptr = if top16 >= 0x7FF8 {
-                // NaN-boxed value - check if it's a pointer-like tag
-                if top16 == 0x7FFD {
-                    // POINTER_TAG — extract raw pointer
-                    let ptr = (bits & 0x0000_FFFF_FFFF_FFFF) as *const ArrayHeader;
-                    if (ptr as usize) >= 0x1000 {
-                        Some(ptr)
-                    } else {
-                        None
-                    }
-                } else {
-                    None // STRING_TAG, BIGINT_TAG, JS_HANDLE_TAG, undefined, NaN
-                }
-            } else if top16 == 0 && bits >= 0x10000 && (bits & 0x7) == 0 {
-                // Raw pointer without NaN-boxing (top 16 bits zero = userspace pointer,
-                // >= 64KB to exclude small integers, 8-byte aligned)
-                Some(bits as *const ArrayHeader)
-            } else {
-                None
-            };
-
-            // Only flatten when the pointer is genuinely an array. A plain
-            // object / Set / Map / string etc. is a non-array element and must
-            // be pushed as-is — `flat` only spreads arrays. Pre-fix this read
-            // an arbitrary heap object's bytes as an `ArrayHeader.length` and
-            // iterated garbage (segfault on `[{…}].flat()`). Mirrors the
-            // `GC_TYPE_ARRAY` gate in the recursive `js_array_flat_into`.
-            let is_array = match maybe_arr_ptr {
-                Some(sub_arr) if (sub_arr as usize) >= crate::gc::GC_HEADER_SIZE + 0x1000 => {
-                    let hdr = (sub_arr as *const u8).sub(crate::gc::GC_HEADER_SIZE)
-                        as *const crate::gc::GcHeader;
-                    (*hdr).obj_type == crate::gc::GC_TYPE_ARRAY
-                }
-                _ => false,
-            };
-            if let (true, Some(sub_arr)) = (is_array, maybe_arr_ptr) {
+            let sub_arr = flattenable_array_ptr(element);
+            if !sub_arr.is_null() {
                 let sub_len = (*sub_arr).length as usize;
                 // Sanity check: if length is unreasonably large, treat as non-array.
                 if sub_len <= 1_000_000 {

--- a/crates/perry-runtime/src/array/iter_methods.rs
+++ b/crates/perry-runtime/src/array/iter_methods.rs
@@ -702,30 +702,29 @@ pub extern "C" fn js_array_flatMap(
                 continue;
             };
             let mapped = js_closure_call3(callback, element, i as f64, rooted.receiver());
-            // Check if the mapped value is an array (pointer-tagged)
-            let bits = mapped.to_bits();
-            let top16 = bits >> 48;
-            if top16 == 0x7FFD {
-                // NaN-boxed pointer — likely an array
-                let sub_arr = (bits & 0x0000_FFFF_FFFF_FFFF) as *const ArrayHeader;
-                if !sub_arr.is_null() {
-                    sub_rooted.set_nanbox_f64(mapped);
-                    let sub_len = (*sub_arr).length;
-                    for j in 0..sub_len as usize {
-                        let sub_arr = (sub_rooted.get_nanbox_u64() & crate::value::POINTER_MASK)
-                            as *const ArrayHeader;
-                        let sub_elements = (sub_arr as *const u8)
-                            .add(std::mem::size_of::<ArrayHeader>())
-                            as *const f64;
-                        let Some(sub_element) = present_array_element(sub_elements, j) else {
-                            continue;
-                        };
-                        push_rooted(sub_element);
-                    }
+            // Root first: detecting a lazy array may materialize it, and a
+            // push in the inner loop can move the callback result's target.
+            sub_rooted.set_nanbox_f64(mapped);
+            let sub_arr = crate::array::flattenable_array_ptr(sub_rooted.get_nanbox_f64());
+            if !sub_arr.is_null() {
+                let sub_len = (*sub_arr).length;
+                for j in 0..sub_len as usize {
+                    // Resolve from the rooted value after each allocation so a
+                    // moved array (or a proxy's moved array target) is never
+                    // read through a stale ArrayHeader pointer.
+                    let sub_arr = crate::array::flattenable_array_ptr(sub_rooted.get_nanbox_f64());
+                    debug_assert!(!sub_arr.is_null());
+                    let sub_elements = (sub_arr as *const u8)
+                        .add(std::mem::size_of::<ArrayHeader>())
+                        as *const f64;
+                    let Some(sub_element) = present_array_element(sub_elements, j) else {
+                        continue;
+                    };
+                    push_rooted(sub_element);
                 }
             } else {
                 // Not an array — push as single element
-                push_rooted(mapped);
+                push_rooted(sub_rooted.get_nanbox_f64());
             }
         }
 

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -140,6 +140,7 @@ pub use self::splice_slice::{
 
 pub(crate) use self::alloc::array_length_from_property_value_or_throw;
 pub(crate) use self::alloc::{js_array_from_arraylike, js_array_from_string_codepoints};
+pub(crate) use self::flat_clone::flattenable_array_ptr;
 pub(crate) use self::header::{
     array_byte_size, array_is_frozen, array_is_sealed_or_no_extend, array_named_property_delete,
     array_named_property_get, array_named_property_get_by_name, array_named_property_has,

--- a/crates/perry-runtime/src/array/tests.rs
+++ b/crates/perry-runtime/src/array/tests.rs
@@ -54,6 +54,26 @@ fn string_value(ptr: *mut crate::StringHeader) -> f64 {
     f64::from_bits(crate::value::JSValue::string_ptr(ptr).bits())
 }
 
+#[test]
+fn flattenable_array_ptr_accepts_only_arrays_and_array_proxies() {
+    let array = js_array_alloc(0);
+    let array_value = boxed_pointer(array as *mut u8);
+    assert_eq!(flattenable_array_ptr(array_value), array);
+
+    let object = crate::object::js_object_alloc(0, 0);
+    assert!(flattenable_array_ptr(boxed_pointer(object as *mut u8)).is_null());
+
+    let closure = crate::closure::js_closure_alloc(ptr::null(), 0);
+    assert!(flattenable_array_ptr(boxed_pointer(closure as *mut u8)).is_null());
+
+    let handler = crate::object::js_object_alloc(0, 0);
+    let proxy = crate::proxy::js_proxy_new(array_value, boxed_pointer(handler as *mut u8));
+    assert_eq!(flattenable_array_ptr(proxy), array);
+
+    let nested_proxy = crate::proxy::js_proxy_new(proxy, boxed_pointer(handler as *mut u8));
+    assert_eq!(flattenable_array_ptr(nested_proxy), array);
+}
+
 fn array_keys_contain(keys: *mut ArrayHeader, name: &[u8]) -> bool {
     let key = string_key(name);
     for i in 0..js_array_length(keys) {

--- a/test-files/test_gap_flatmap_array_type_check.ts
+++ b/test-files/test_gap_flatmap_array_type_check.ts
@@ -1,0 +1,22 @@
+// Regression: flatMap must flatten only Arrays, never arbitrary POINTER_TAG values.
+
+const plainObject = { x: 7 };
+const objectResult = [1].flatMap(() => plainObject as any);
+console.log("object:", objectResult.length, objectResult[0] === plainObject, objectResult[0].x);
+
+const closure = () => 42;
+const functionResult = [1].flatMap(() => closure as any);
+console.log("function:", functionResult.length, functionResult[0] === closure, functionResult[0]());
+
+console.log("array:", [1, 2].flatMap((x) => [x, x * 10]).join(","));
+
+const sparse = [1, , 3] as number[];
+console.log("sparse:", sparse.flatMap((x) => [, x]).join(","));
+
+console.log("nested:", JSON.stringify([1].flatMap((x) => [[x, x + 1]])));
+
+const proxiedArray = new Proxy([8, 9], {});
+console.log("proxy-array:", [1].flatMap(() => proxiedArray).join(","));
+
+const nestedProxiedArray = new Proxy(proxiedArray, {});
+console.log("nested-proxy-array:", [1].flatMap(() => nestedProxiedArray).join(","));


### PR DESCRIPTION
## Summary
- classify flatMap callback results by GC array type before reading ArrayHeader
- preserve ordinary objects and closures while flattening arrays, lazy arrays, and nested array proxies
- add runtime and parity regressions for pointer-tagged callback results

## Root cause
flatMap treated every POINTER_TAG result as an ArrayHeader, so ordinary objects and closures could be read with the wrong layout.

## Validation
- cargo fmt --check
- cargo check -p perry-runtime
- cargo test -p perry-runtime --lib flattenable_array_ptr_accepts_only_arrays_and_array_proxies -- --nocapture
- ./run_parity_tests.sh --filter test_gap_flatmap_array_type_check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `Array.prototype.flat`, `flatMap`, and related operations to recognize only actual arrays and valid array proxies.
  * Prevented objects, functions, closures, and invalid values from being incorrectly flattened.
  * Improved handling of sparse arrays and nested or proxied arrays.

* **Tests**
  * Added regression coverage for flattening behavior across arrays, proxies, sparse arrays, objects, and functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->