### PR TITLE
Harden CLI self-update authentication and recovery

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -168,6 +168,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     env:
+      # Public, rotation-capable CLI update keyring baked into every release.
+      # It is intentionally a repository variable (not fetched at runtime).
+      PERRY_CLI_UPDATE_PUBLIC_KEYS: ${{ vars.PERRY_CLI_UPDATE_PUBLIC_KEYS }}
       # Pin the macOS deployment target so bottle object files carry a
       # stable LC_VERSION_MIN / LC_BUILD_VERSION tag regardless of which
       # GitHub runner OS built them. Otherwise users linking against the
@@ -630,6 +633,51 @@ jobs:
           "$hash  ${{ matrix.artifact }}.zip" | Out-File -Encoding ascii "${{ matrix.artifact }}.zip.sha256"
           Get-Content "${{ matrix.artifact }}.zip.sha256"
 
+      # The archive SHA sidecar helps package managers but is not an update
+      # authority. Sign a domain-separated, version/platform/URL/digest/size
+      # bound manifest with the protected Ed25519 release key instead.
+      - name: Sign authenticated CLI update manifest (Unix)
+        if: runner.os != 'Windows' && (github.event_name == 'release' || github.event_name == 'workflow_dispatch')
+        env:
+          PERRY_CLI_UPDATE_SIGNING_KEY: ${{ secrets.PERRY_CLI_UPDATE_SIGNING_KEY }}
+          PERRY_CLI_UPDATE_KEY_ID: ${{ vars.PERRY_CLI_UPDATE_KEY_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${PERRY_CLI_UPDATE_SIGNING_KEY:?configure the protected 32-byte base64 Ed25519 signing secret}"
+          : "${PERRY_CLI_UPDATE_KEY_ID:?configure the matching trusted public-key id}"
+          : "${PERRY_CLI_UPDATE_PUBLIC_KEYS:?configure the compiled public-key keyring}"
+          jq -e --arg id "$PERRY_CLI_UPDATE_KEY_ID" '.[] | select(.key_id == $id and (.public_key | length > 0))' <<< "$PERRY_CLI_UPDATE_PUBLIC_KEYS" >/dev/null
+          TAG="${{ github.event.release.tag_name }}"
+          if [ -z "$TAG" ]; then TAG=$(gh release list -R "${{ github.repository }}" --limit 1 --json tagName --jq '.[0].tagName'); fi
+          ARCHIVE="${{ matrix.artifact }}.tar.gz"
+          URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/${ARCHIVE}"
+          "target/${{ matrix.target }}/dist/perry" updater sign-cli-manifest \
+            --artifact "$ARCHIVE" --platform "$ARCHIVE" --url "$URL" \
+            --release-version "${TAG#v}" --key-id "$PERRY_CLI_UPDATE_KEY_ID" \
+            --secret-key-b64 "$PERRY_CLI_UPDATE_SIGNING_KEY" > "$ARCHIVE.update.json"
+
+      - name: Sign authenticated CLI update manifest (Windows)
+        if: runner.os == 'Windows' && (github.event_name == 'release' || github.event_name == 'workflow_dispatch')
+        env:
+          PERRY_CLI_UPDATE_SIGNING_KEY: ${{ secrets.PERRY_CLI_UPDATE_SIGNING_KEY }}
+          PERRY_CLI_UPDATE_KEY_ID: ${{ vars.PERRY_CLI_UPDATE_KEY_ID }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (-not $env:PERRY_CLI_UPDATE_SIGNING_KEY) { throw 'configure PERRY_CLI_UPDATE_SIGNING_KEY' }
+          if (-not $env:PERRY_CLI_UPDATE_KEY_ID) { throw 'configure PERRY_CLI_UPDATE_KEY_ID' }
+          if (-not $env:PERRY_CLI_UPDATE_PUBLIC_KEYS) { throw 'configure PERRY_CLI_UPDATE_PUBLIC_KEYS' }
+          if (-not (($env:PERRY_CLI_UPDATE_PUBLIC_KEYS | ConvertFrom-Json) | Where-Object { $_.key_id -eq $env:PERRY_CLI_UPDATE_KEY_ID -and $_.public_key })) { throw 'configured key id is not in PERRY_CLI_UPDATE_PUBLIC_KEYS' }
+          $tag = "${{ github.event.release.tag_name }}"
+          if (-not $tag) { $tag = (gh release list -R "${{ github.repository }}" --limit 1 --json tagName --jq '.[0].tagName') }
+          $archive = "${{ matrix.artifact }}.zip"
+          $url = "https://github.com/${{ github.repository }}/releases/download/$tag/$archive"
+          & "target/${{ matrix.target }}/dist/perry.exe" updater sign-cli-manifest `
+            --artifact $archive --platform $archive --url $url `
+            --release-version $tag.TrimStart('v') --key-id $env:PERRY_CLI_UPDATE_KEY_ID `
+            --secret-key-b64 $env:PERRY_CLI_UPDATE_SIGNING_KEY | Out-File -Encoding utf8 "$archive.update.json"
+
       - name: Upload release asset (Unix)
         if: runner.os != 'Windows' && (github.event_name == 'release' || github.event_name == 'workflow_dispatch')
         env:
@@ -649,6 +697,7 @@ jobs:
           fi
           gh release upload "$TAG" "${{ matrix.artifact }}.tar.gz" --clobber
           gh release upload "$TAG" "${{ matrix.artifact }}.tar.gz.sha256" --clobber
+          gh release upload "$TAG" "${{ matrix.artifact }}.tar.gz.update.json" --clobber
 
       - name: Upload release asset (Windows)
         if: runner.os == 'Windows' && (github.event_name == 'release' || github.event_name == 'workflow_dispatch')
@@ -663,6 +712,7 @@ jobs:
           }
           gh release upload "$tag" "${{ matrix.artifact }}.zip" --clobber
           gh release upload "$tag" "${{ matrix.artifact }}.zip.sha256" --clobber
+          gh release upload "$tag" "${{ matrix.artifact }}.zip.update.json" --clobber
 
       - name: Upload build artifact (Unix, for deb + npm-publish jobs)
         if: runner.os != 'Windows'

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -641,6 +641,7 @@ jobs:
         env:
           PERRY_CLI_UPDATE_SIGNING_KEY: ${{ secrets.PERRY_CLI_UPDATE_SIGNING_KEY }}
           PERRY_CLI_UPDATE_KEY_ID: ${{ vars.PERRY_CLI_UPDATE_KEY_ID }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         shell: bash
         run: |
           set -euo pipefail
@@ -648,7 +649,7 @@ jobs:
           : "${PERRY_CLI_UPDATE_KEY_ID:?configure the matching trusted public-key id}"
           : "${PERRY_CLI_UPDATE_PUBLIC_KEYS:?configure the compiled public-key keyring}"
           jq -e --arg id "$PERRY_CLI_UPDATE_KEY_ID" '.[] | select(.key_id == $id and (.public_key | length > 0))' <<< "$PERRY_CLI_UPDATE_PUBLIC_KEYS" >/dev/null
-          TAG="${{ github.event.release.tag_name }}"
+          TAG="$RELEASE_TAG"
           if [ -z "$TAG" ]; then TAG=$(gh release list -R "${{ github.repository }}" --limit 1 --json tagName --jq '.[0].tagName'); fi
           ARCHIVE="${{ matrix.artifact }}.tar.gz"
           URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/${ARCHIVE}"
@@ -662,6 +663,7 @@ jobs:
         env:
           PERRY_CLI_UPDATE_SIGNING_KEY: ${{ secrets.PERRY_CLI_UPDATE_SIGNING_KEY }}
           PERRY_CLI_UPDATE_KEY_ID: ${{ vars.PERRY_CLI_UPDATE_KEY_ID }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -669,7 +671,7 @@ jobs:
           if (-not $env:PERRY_CLI_UPDATE_KEY_ID) { throw 'configure PERRY_CLI_UPDATE_KEY_ID' }
           if (-not $env:PERRY_CLI_UPDATE_PUBLIC_KEYS) { throw 'configure PERRY_CLI_UPDATE_PUBLIC_KEYS' }
           if (-not (($env:PERRY_CLI_UPDATE_PUBLIC_KEYS | ConvertFrom-Json) | Where-Object { $_.key_id -eq $env:PERRY_CLI_UPDATE_KEY_ID -and $_.public_key })) { throw 'configured key id is not in PERRY_CLI_UPDATE_PUBLIC_KEYS' }
-          $tag = "${{ github.event.release.tag_name }}"
+          $tag = $env:RELEASE_TAG
           if (-not $tag) { $tag = (gh release list -R "${{ github.repository }}" --limit 1 --json tagName --jq '.[0].tagName') }
           $archive = "${{ matrix.artifact }}.zip"
           $url = "https://github.com/${{ github.repository }}/releases/download/$tag/$archive"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5391,6 +5391,7 @@ dependencies = [
  "toml",
  "url",
  "walkdir",
+ "windows-sys 0.61.2",
  "zip",
  "zstd",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5356,6 +5356,7 @@ dependencies = [
  "hex",
  "indicatif",
  "jsonwebtoken",
+ "libc",
  "log",
  "notify",
  "perry-api-manifest",
@@ -5372,6 +5373,7 @@ dependencies = [
  "perry-runtime",
  "perry-transform",
  "perry-types",
+ "perry-updater",
  "rand 0.9.4",
  "rayon",
  "regex",
@@ -6287,6 +6289,7 @@ dependencies = [
 name = "perry-updater"
 version = "0.5.1255"
 dependencies = [
+ "anyhow",
  "base64",
  "ed25519-dalek",
  "hex",
@@ -6295,6 +6298,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/perry-updater/Cargo.toml
+++ b/crates/perry-updater/Cargo.toml
@@ -9,6 +9,7 @@ description = "Auto-updater for Perry desktop apps: manifest parsing, SHA-256 + 
 crate-type = ["rlib", "staticlib"]
 
 [dependencies]
+anyhow = "1.0"
 perry-runtime = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -16,13 +17,13 @@ semver = "1.0"
 sha2 = "0.11"
 hex = "0.4"
 base64 = "0.22"
-# Ed25519 verify is provided by perry-stdlib::crypto (declared as extern in
-# core.rs and resolved at static-link time inside libperry_stdlib.a) — no
-# direct dep here keeps the dalek crate from being pulled in twice.
+ed25519-dalek = "2.1"
+# Core FFI verification continues to route through perry-stdlib. The shared
+# CLI-manifest module uses ed25519-dalek directly so the native CLI can reuse
+# the updater format without depending on JS runtime pointers.
 
 [dev-dependencies]
-# Test code generates throwaway keypairs to exercise the verify path.
-ed25519-dalek = "2.1"
+tempfile = "3"
 
 # Detached spawn (the only thing this crate used libc for) now routes
 # through perry_runtime::child_process::spawn_detached_command, so libc

--- a/crates/perry-updater/Cargo.toml
+++ b/crates/perry-updater/Cargo.toml
@@ -18,9 +18,6 @@ sha2 = "0.11"
 hex = "0.4"
 base64 = "0.22"
 ed25519-dalek = "2.1"
-# Core FFI verification continues to route through perry-stdlib. The shared
-# CLI-manifest module uses ed25519-dalek directly so the native CLI can reuse
-# the updater format without depending on JS runtime pointers.
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/perry-updater/src/cli_manifest.rs
+++ b/crates/perry-updater/src/cli_manifest.rs
@@ -1,9 +1,4 @@
-//! Shared authenticated manifest format for the Perry CLI self-updater.
-//!
-//! This intentionally lives beside the desktop updater's Ed25519 primitives:
-//! CLI and desktop updates therefore use the same `ed25519-dalek` verifier and
-//! the same SHA-256 + version binding rather than maintaining two crypto
-//! implementations.
+//! Authenticated manifest format for the Perry CLI self-updater.
 
 use anyhow::{bail, Context, Result};
 use base64::Engine as _;
@@ -37,8 +32,6 @@ pub struct CliUpdateArtifact {
     pub size: u64,
 }
 
-/// Return the domain-separated and fully version/platform-bound signing bytes.
-/// The fixed-width length prefixes avoid ambiguous concatenation.
 pub fn cli_manifest_signing_payload(manifest: &CliUpdateManifest) -> Result<Vec<u8>> {
     if manifest.schema_version != 1 {
         bail!(
@@ -123,8 +116,6 @@ pub fn verify_cli_manifest(
         .context("CLI update manifest signature verification failed")
 }
 
-/// Hash a downloaded artifact after the authenticated manifest has been
-/// verified. Both length and digest are security checks, not diagnostics.
 pub fn verify_cli_artifact(path: &Path, artifact: &CliUpdateArtifact) -> Result<()> {
     let metadata =
         std::fs::metadata(path).with_context(|| format!("cannot stat {}", path.display()))?;

--- a/crates/perry-updater/src/cli_manifest.rs
+++ b/crates/perry-updater/src/cli_manifest.rs
@@ -1,0 +1,255 @@
+//! Shared authenticated manifest format for the Perry CLI self-updater.
+//!
+//! This intentionally lives beside the desktop updater's Ed25519 primitives:
+//! CLI and desktop updates therefore use the same `ed25519-dalek` verifier and
+//! the same SHA-256 + version binding rather than maintaining two crypto
+//! implementations.
+
+use anyhow::{bail, Context, Result};
+use base64::Engine as _;
+use ed25519_dalek::{Signature, Signer, Verifier, VerifyingKey};
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::io::Read;
+use std::path::Path;
+
+const DOMAIN: &[u8] = b"perry-cli-update-manifest-v1\0";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CliUpdateManifest {
+    pub schema_version: u32,
+    pub key_id: String,
+    pub version: String,
+    pub platform: String,
+    pub artifact: CliUpdateArtifact,
+    /// Base64 Ed25519 signature over `signing_payload`.
+    pub signature: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CliUpdateArtifact {
+    pub name: String,
+    pub url: String,
+    pub sha256: String,
+    pub size: u64,
+}
+
+/// Return the domain-separated and fully version/platform-bound signing bytes.
+/// The fixed-width length prefixes avoid ambiguous concatenation.
+pub fn cli_manifest_signing_payload(manifest: &CliUpdateManifest) -> Result<Vec<u8>> {
+    if manifest.schema_version != 1 {
+        bail!(
+            "unsupported CLI update manifest schema {}",
+            manifest.schema_version
+        );
+    }
+    if manifest.key_id.is_empty()
+        || manifest.version.is_empty()
+        || manifest.platform.is_empty()
+        || manifest.artifact.name.is_empty()
+        || manifest.artifact.url.is_empty()
+    {
+        bail!("CLI update manifest contains an empty security-critical field");
+    }
+    Version::parse(manifest.version.trim_start_matches('v'))
+        .context("manifest version is not valid semver")?;
+    let digest = decode_sha256(&manifest.artifact.sha256)?;
+    let mut out = Vec::with_capacity(192 + manifest.artifact.url.len());
+    out.extend_from_slice(DOMAIN);
+    out.extend_from_slice(&manifest.schema_version.to_be_bytes());
+    for field in [
+        &manifest.key_id,
+        &manifest.version,
+        &manifest.platform,
+        &manifest.artifact.name,
+        &manifest.artifact.url,
+    ] {
+        let bytes = field.as_bytes();
+        let len = u32::try_from(bytes.len()).context("manifest field is too long")?;
+        out.extend_from_slice(&len.to_be_bytes());
+        out.extend_from_slice(bytes);
+    }
+    out.extend_from_slice(&digest);
+    out.extend_from_slice(&manifest.artifact.size.to_be_bytes());
+    Ok(out)
+}
+
+pub fn sign_cli_manifest(
+    manifest: &mut CliUpdateManifest,
+    signing_key: &ed25519_dalek::SigningKey,
+) -> Result<()> {
+    manifest.signature = base64::engine::general_purpose::STANDARD.encode(
+        signing_key
+            .sign(&cli_manifest_signing_payload(manifest)?)
+            .to_bytes(),
+    );
+    Ok(())
+}
+
+pub fn verify_cli_manifest(
+    manifest: &CliUpdateManifest,
+    expected_platform: &str,
+    current_version: &str,
+    trusted_keys: &[(&str, &str)],
+) -> Result<()> {
+    if manifest.platform != expected_platform {
+        bail!(
+            "manifest platform {} does not match {}",
+            manifest.platform,
+            expected_platform
+        );
+    }
+    if Version::parse(manifest.version.trim_start_matches('v'))?
+        <= Version::parse(current_version.trim_start_matches('v'))?
+    {
+        bail!(
+            "manifest version {} is not newer than installed {} (replay/downgrade rejected)",
+            manifest.version,
+            current_version
+        );
+    }
+    let key_b64 = trusted_keys
+        .iter()
+        .find(|(id, _)| *id == manifest.key_id)
+        .map(|(_, key)| *key)
+        .with_context(|| format!("manifest key id {:?} is not trusted", manifest.key_id))?;
+    let public_key = decode_public_key(key_b64)?;
+    let signature = decode_signature(&manifest.signature)?;
+    public_key
+        .verify(&cli_manifest_signing_payload(manifest)?, &signature)
+        .context("CLI update manifest signature verification failed")
+}
+
+/// Hash a downloaded artifact after the authenticated manifest has been
+/// verified. Both length and digest are security checks, not diagnostics.
+pub fn verify_cli_artifact(path: &Path, artifact: &CliUpdateArtifact) -> Result<()> {
+    let metadata =
+        std::fs::metadata(path).with_context(|| format!("cannot stat {}", path.display()))?;
+    if !metadata.is_file() {
+        bail!("downloaded update artifact is not a regular file");
+    }
+    if metadata.len() != artifact.size {
+        bail!(
+            "downloaded update artifact size mismatch (expected {}, got {})",
+            artifact.size,
+            metadata.len()
+        );
+    }
+    let expected = decode_sha256(&artifact.sha256)?;
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0_u8; 64 * 1024];
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    let actual: [u8; 32] = hasher.finalize().into();
+    if actual != expected {
+        bail!("downloaded update artifact SHA-256 mismatch");
+    }
+    Ok(())
+}
+
+pub fn decode_sha256(value: &str) -> Result<[u8; 32]> {
+    if value.len() != 64 || !value.bytes().all(|b| b.is_ascii_hexdigit()) {
+        bail!("sha256 must be exactly 64 hexadecimal characters");
+    }
+    let bytes = hex::decode(value)?;
+    Ok(bytes.try_into().expect("hex length checked"))
+}
+
+fn decode_public_key(value: &str) -> Result<VerifyingKey> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(value.trim())
+        .context("trusted public key is not base64")?;
+    let raw: [u8; 32] = bytes.try_into().map_err(|v: Vec<u8>| {
+        anyhow::anyhow!("trusted public key must be 32 bytes, got {}", v.len())
+    })?;
+    VerifyingKey::from_bytes(&raw).context("trusted public key is invalid")
+}
+fn decode_signature(value: &str) -> Result<Signature> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(value.trim())
+        .context("manifest signature is not base64")?;
+    let raw: [u8; 64] = bytes.try_into().map_err(|v: Vec<u8>| {
+        anyhow::anyhow!("manifest signature must be 64 bytes, got {}", v.len())
+    })?;
+    Ok(Signature::from_bytes(&raw))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+
+    fn signed() -> (CliUpdateManifest, String) {
+        let signing = SigningKey::from_bytes(&[7; 32]);
+        let public =
+            base64::engine::general_purpose::STANDARD.encode(signing.verifying_key().to_bytes());
+        let mut m = CliUpdateManifest {
+            schema_version: 1,
+            key_id: "release-2026".into(),
+            version: "9.9.9".into(),
+            platform: "perry-linux-x86_64.tar.gz".into(),
+            artifact: CliUpdateArtifact {
+                name: "perry-linux-x86_64.tar.gz".into(),
+                url: "https://example.invalid/perry-linux-x86_64.tar.gz".into(),
+                sha256: hex::encode(Sha256::digest(b"artifact")),
+                size: 8,
+            },
+            signature: String::new(),
+        };
+        m.signature = base64::engine::general_purpose::STANDARD.encode(
+            signing
+                .sign(&cli_manifest_signing_payload(&m).unwrap())
+                .to_bytes(),
+        );
+        (m, public)
+    }
+    #[test]
+    fn rejects_wrong_signature_digest_version_platform_and_replay() {
+        let (m, public) = signed();
+        let keys = [("release-2026", public.as_str())];
+        verify_cli_manifest(&m, &m.platform, "1.0.0", &keys).unwrap();
+        for mutate in [0, 1, 2, 3] {
+            let mut bad = m.clone();
+            match mutate {
+                0 => bad.signature = "AAAA".into(),
+                1 => bad.artifact.sha256 = "00".repeat(32),
+                2 => bad.version = "9.9.8".into(),
+                _ => bad.platform = "perry-windows-x86_64.zip".into(),
+            }
+            assert!(
+                verify_cli_manifest(&bad, "perry-linux-x86_64.tar.gz", "1.0.0", &keys).is_err()
+            );
+        }
+        assert!(
+            verify_cli_manifest(&m, &m.platform, "9.9.9", &keys).is_err(),
+            "same version is replay"
+        );
+        assert!(
+            verify_cli_manifest(&m, &m.platform, "10.0.0", &keys).is_err(),
+            "downgrade is replay"
+        );
+    }
+    #[test]
+    fn artifact_hash_and_size_are_checked() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("a");
+        std::fs::write(&file, b"artifact").unwrap();
+        let (m, _) = signed();
+        verify_cli_artifact(&file, &m.artifact).unwrap();
+        let mut bad = m.artifact.clone();
+        bad.size += 1;
+        assert!(verify_cli_artifact(&file, &bad).is_err());
+        bad.size = 8;
+        bad.sha256 = "00".repeat(32);
+        assert!(verify_cli_artifact(&file, &bad).is_err());
+    }
+}

--- a/crates/perry-updater/src/cli_manifest.rs
+++ b/crates/perry-updater/src/cli_manifest.rs
@@ -230,6 +230,33 @@ mod tests {
         );
     }
     #[test]
+    fn rejects_invalid_manifest_fields_and_keys() {
+        let (m, public) = signed();
+        let trusted = [("release-2026", public.as_str())];
+
+        let unknown = [("other-key", public.as_str())];
+        assert!(verify_cli_manifest(&m, &m.platform, "1.0.0", &unknown).is_err());
+
+        let mut invalid_signature = m.clone();
+        invalid_signature.signature = "not-base64".into();
+        assert!(verify_cli_manifest(&invalid_signature, &m.platform, "1.0.0", &trusted).is_err());
+
+        let invalid_public_key = [("release-2026", "not-base64")];
+        assert!(verify_cli_manifest(&m, &m.platform, "1.0.0", &invalid_public_key).is_err());
+
+        for mutate in [0, 1, 2] {
+            let mut invalid = m.clone();
+            match mutate {
+                0 => invalid.version = "not-semver".into(),
+                1 => invalid.key_id.clear(),
+                _ => invalid.schema_version = 2,
+            }
+            assert!(cli_manifest_signing_payload(&invalid).is_err());
+            assert!(verify_cli_manifest(&invalid, &m.platform, "1.0.0", &trusted).is_err());
+        }
+    }
+
+    #[test]
     fn artifact_hash_and_size_are_checked() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("a");

--- a/crates/perry-updater/src/lib.rs
+++ b/crates/perry-updater/src/lib.rs
@@ -22,6 +22,7 @@
 //! security-critical and platform-touching pieces, keeping this crate
 //! small and audit-friendly.
 
+pub mod cli_manifest;
 mod core;
 mod desktop;
 

--- a/crates/perry/Cargo.toml
+++ b/crates/perry/Cargo.toml
@@ -18,6 +18,7 @@ perry-transform.workspace = true
 perry-codegen.workspace = true
 perry-runtime.workspace = true
 perry-diagnostics.workspace = true
+perry-updater.workspace = true
 # Codegen backends for non-native targets — optional so a slim dev CLI
 # (--no-default-features --features dev-cli) drops them. full-cli (default)
 # re-enables all via all-codegen-backends, keeping the shipped CLI unchanged.
@@ -52,6 +53,8 @@ flate2.workspace = true
 tar.workspace = true
 base64.workspace = true
 zip.workspace = true
+tempfile = "3"
+libc = "0.2"
 zstd.workspace = true
 jsonwebtoken.workspace = true
 semver = "1.0"

--- a/crates/perry/Cargo.toml
+++ b/crates/perry/Cargo.toml
@@ -88,6 +88,9 @@ rand = { version = "0.9", optional = true }
 # LICENSE template substitution.
 chrono = "0.4"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_Threading"] }
+
 [features]
 # The default build is the full official CLI — every command and codegen
 # backend. The shipped binary is unchanged from before #5422.

--- a/crates/perry/src/commands/updater.rs
+++ b/crates/perry/src/commands/updater.rs
@@ -62,6 +62,9 @@ pub enum UpdaterCommand {
     /// Use this in CI before uploading the manifest to catch
     /// version-mismatch / wrong-key / corrupted-binary issues early.
     Verify(VerifyArgs),
+
+    /// Sign the authenticated manifest consumed by `perry update`.
+    SignCliManifest(SignCliManifestArgs),
 }
 
 #[derive(Debug, clap::Args)]
@@ -97,6 +100,28 @@ pub struct SignArgs {
 }
 
 #[derive(Debug, clap::Args)]
+pub struct SignCliManifestArgs {
+    /// Release archive to hash and describe.
+    #[arg(long)]
+    pub artifact: PathBuf,
+    /// Exact release artifact filename (for example `perry-linux-x86_64.tar.gz`).
+    #[arg(long)]
+    pub platform: String,
+    /// HTTPS URL from which the artifact will be downloaded.
+    #[arg(long)]
+    pub url: String,
+    /// Version bound into the signed manifest.
+    #[arg(long = "release-version")]
+    pub release_version: String,
+    /// Stable identifier for the trusted public key; used for key rotation.
+    #[arg(long)]
+    pub key_id: String,
+    /// Base64-encoded 32-byte secret-key seed from protected release CI.
+    #[arg(long)]
+    pub secret_key_b64: String,
+}
+
+#[derive(Debug, clap::Args)]
 pub struct VerifyArgs {
     /// Path to the binary to verify.
     #[arg(short, long)]
@@ -127,6 +152,7 @@ pub fn run(args: UpdaterArgs) -> Result<()> {
         UpdaterCommand::Keygen(a) => run_keygen(a),
         UpdaterCommand::Sign(a) => run_sign(a),
         UpdaterCommand::Verify(a) => run_verify(a),
+        UpdaterCommand::SignCliManifest(a) => run_sign_cli_manifest(a),
     }
 }
 
@@ -229,6 +255,55 @@ fn run_sign(args: SignArgs) -> Result<()> {
         "publicKey": base64::engine::general_purpose::STANDARD.encode(signing.verifying_key().to_bytes()),
     });
     println!("{}", serde_json::to_string_pretty(&envelope)?);
+    Ok(())
+}
+
+fn run_sign_cli_manifest(args: SignCliManifestArgs) -> Result<()> {
+    if args.release_version.is_empty() || args.key_id.is_empty() || args.platform.is_empty() {
+        bail!("version, key-id, and platform must be non-empty");
+    }
+    let parsed = url::Url::parse(&args.url).context("invalid artifact URL")?;
+    if parsed.scheme() != "https"
+        || parsed.host_str().is_none()
+        || parsed.username() != ""
+        || parsed.password().is_some()
+    {
+        bail!("artifact URL must be an absolute HTTPS URL without credentials");
+    }
+    let bytes = base64::engine::general_purpose::STANDARD.decode(args.secret_key_b64.trim())?;
+    let seed: [u8; SECRET_KEY_LENGTH] = bytes.try_into().map_err(|v: Vec<u8>| {
+        anyhow::anyhow!(
+            "secret key must decode to {} bytes (got {})",
+            SECRET_KEY_LENGTH,
+            v.len()
+        )
+    })?;
+    let signing = SigningKey::from_bytes(&seed);
+    let (digest, size) = sha256_file(&args.artifact)?;
+    let name = args
+        .artifact
+        .file_name()
+        .and_then(|v| v.to_str())
+        .context("artifact filename is not UTF-8")?
+        .to_string();
+    if name != args.platform {
+        bail!("artifact filename must equal --platform to prevent platform confusion");
+    }
+    let mut manifest = perry_updater::cli_manifest::CliUpdateManifest {
+        schema_version: 1,
+        key_id: args.key_id,
+        version: args.release_version,
+        platform: args.platform,
+        artifact: perry_updater::cli_manifest::CliUpdateArtifact {
+            name,
+            url: args.url,
+            sha256: hex::encode(digest),
+            size,
+        },
+        signature: String::new(),
+    };
+    perry_updater::cli_manifest::sign_cli_manifest(&mut manifest, &signing)?;
+    println!("{}", serde_json::to_string_pretty(&manifest)?);
     Ok(())
 }
 

--- a/crates/perry/src/main.rs
+++ b/crates/perry/src/main.rs
@@ -318,6 +318,13 @@ fn install_panic_hook() {
 
 fn main_inner() -> Result<()> {
     env_logger::init();
+    #[cfg(windows)]
+    {
+        let raw_args: Vec<String> = std::env::args().collect();
+        if let Some(result) = update_checker::maybe_run_windows_update_helper(&raw_args) {
+            return result;
+        }
+    }
     update_checker::recover_interrupted_self_update()?;
 
     // Handle legacy invocation (perry file.ts -o out)

--- a/crates/perry/src/main.rs
+++ b/crates/perry/src/main.rs
@@ -161,6 +161,7 @@ enum Commands {
     /// `perry updater keygen` — generate Ed25519 keypair.
     /// `perry updater sign`   — sign a binary for a v2 manifest entry.
     /// `perry updater verify` — sanity-check a v2 signature locally.
+    /// `perry updater sign-cli-manifest` — sign an authenticated CLI update manifest.
     #[cfg(feature = "updater-cli")]
     Updater(commands::updater::UpdaterArgs),
 
@@ -317,6 +318,7 @@ fn install_panic_hook() {
 
 fn main_inner() -> Result<()> {
     env_logger::init();
+    update_checker::recover_interrupted_self_update()?;
 
     // Handle legacy invocation (perry file.ts -o out)
     let args: Vec<String> = std::env::args().collect();

--- a/crates/perry/src/update_checker.rs
+++ b/crates/perry/src/update_checker.rs
@@ -383,38 +383,92 @@ pub fn platform_artifact_name() -> Option<&'static str> {
     None
 }
 
+#[derive(Debug, Deserialize)]
+struct TrustedUpdateKey {
+    key_id: String,
+    public_key: String,
+}
+
+/// Public keys are compile-time configuration, never fetched from the update
+/// server. A release built without them deliberately cannot self-update.
+fn trusted_cli_update_keys() -> Result<Vec<TrustedUpdateKey>> {
+    let raw = option_env!("PERRY_CLI_UPDATE_PUBLIC_KEYS").context(
+        "this Perry release has no trusted CLI update public keys; self-update is disabled until the release is built with PERRY_CLI_UPDATE_PUBLIC_KEYS",
+    )?;
+    let keys: Vec<TrustedUpdateKey> = serde_json::from_str(raw)
+        .context("compiled PERRY_CLI_UPDATE_PUBLIC_KEYS is invalid JSON")?;
+    if keys.is_empty()
+        || keys
+            .iter()
+            .any(|key| key.key_id.is_empty() || key.public_key.is_empty())
+    {
+        bail!("compiled CLI update keyring is empty or invalid");
+    }
+    Ok(keys)
+}
+
+fn secure_staging_dir(install_dir: &std::path::Path) -> Result<tempfile::TempDir> {
+    // Windows replacement and recovery require ACL/reparse-point validation
+    // plus a helper process because the running PE cannot be replaced safely.
+    // Do not silently fall back to the former unsafe copy/rename flow.
+    #[cfg(windows)]
+    bail!("Windows self-update is disabled until ACL-verified staging and a replacement helper are available; install the signed release manually");
+    let staging = tempfile::Builder::new()
+        .prefix("perry-update-")
+        .tempdir_in(install_dir)
+        .context("failed to create exclusive update staging directory")?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        fs::set_permissions(staging.path(), fs::Permissions::from_mode(0o700))?;
+        let metadata = fs::symlink_metadata(staging.path())?;
+        if !metadata.file_type().is_dir()
+            || metadata.uid() != unsafe { libc::geteuid() }
+            || metadata.mode() & 0o077 != 0
+        {
+            bail!(
+                "refusing insecure update staging directory {}",
+                staging.path().display()
+            );
+        }
+    }
+    Ok(staging)
+}
+
+fn require_https(url: &str, what: &str) -> Result<()> {
+    let parsed = url::Url::parse(url).with_context(|| format!("invalid {} URL", what))?;
+    if parsed.scheme() != "https"
+        || parsed.host_str().is_none()
+        || parsed.username() != ""
+        || parsed.password().is_some()
+    {
+        bail!(
+            "{} URL must be an absolute HTTPS URL without credentials",
+            what
+        );
+    }
+    Ok(())
+}
+
 pub fn perform_self_update(verbose: bool) -> Result<()> {
     let current = env!("CARGO_PKG_VERSION");
-
     if verbose {
         eprintln!("Fetching latest version info...");
     }
-
     let cache = fetch_latest_version().context("Failed to check for updates")?;
-
     if compare_versions(&cache.latest_version, current) != Ordering::Greater {
         println!("Already up to date (v{})", current);
         return Ok(());
     }
-
     let artifact_name = platform_artifact_name().context("Unsupported platform for self-update")?;
-
-    if verbose {
-        eprintln!("Looking for artifact: {}", artifact_name);
-    }
-
-    // Re-fetch full release info to get asset URLs
     let client = reqwest::blocking::Client::builder()
         .connect_timeout(CONNECT_TIMEOUT)
-        .timeout(Duration::from_secs(300)) // longer timeout for download
+        .timeout(Duration::from_secs(300))
         .user_agent(format!("perry/{}", current))
         .build()?;
-
-    let servers = get_update_servers();
     let mut release_info = None;
-
-    for url in &servers {
-        if let Ok(resp) = client.get(url).send() {
+    for url in get_update_servers() {
+        if let Ok(resp) = client.get(&url).send() {
             if resp.status().is_success() {
                 if let Ok(info) = resp.json::<ReleaseInfo>() {
                     release_info = Some(info);
@@ -423,151 +477,413 @@ pub fn perform_self_update(verbose: bool) -> Result<()> {
             }
         }
     }
-
     let info = release_info.context("Failed to fetch release info")?;
-
-    let asset = info
+    let manifest_name = format!("{}.update.json", artifact_name);
+    let manifest_asset = info
         .assets
         .iter()
-        .find(|a| a.name == artifact_name)
-        .with_context(|| format!("No binary found for this platform ({})", artifact_name))?;
-
-    println!("Downloading {} v{}...", artifact_name, cache.latest_version);
-
-    let current_exe =
-        std::env::current_exe().context("Cannot determine current executable path")?;
-    let current_exe = current_exe.canonicalize().unwrap_or(current_exe);
-
-    let tmp_dir = std::env::temp_dir().join(format!("perry-update-{}", std::process::id()));
-    fs::create_dir_all(&tmp_dir).context("Failed to create temp directory")?;
-
-    // Download
-    let resp = client
-        .get(&asset.browser_download_url)
+        .find(|a| a.name == manifest_name)
+        .with_context(|| format!("No authenticated update manifest found ({})", manifest_name))?;
+    require_https(&manifest_asset.browser_download_url, "manifest")?;
+    let manifest_bytes = client
+        .get(&manifest_asset.browser_download_url)
         .send()
-        .context("Failed to download update")?;
-
-    if !resp.status().is_success() {
-        bail!("Download failed: HTTP {}", resp.status());
+        .context("failed to download update manifest")?
+        .error_for_status()
+        .context("failed to download update manifest")?
+        .bytes()?;
+    let manifest: perry_updater::cli_manifest::CliUpdateManifest =
+        serde_json::from_slice(&manifest_bytes).context("update manifest is malformed")?;
+    let keys = trusted_cli_update_keys()?;
+    let key_refs: Vec<(&str, &str)> = keys
+        .iter()
+        .map(|k| (k.key_id.as_str(), k.public_key.as_str()))
+        .collect();
+    perry_updater::cli_manifest::verify_cli_manifest(&manifest, artifact_name, current, &key_refs)
+        .context("refusing unauthenticated update manifest")?;
+    if manifest.artifact.name != artifact_name {
+        bail!("authenticated manifest artifact name does not match this platform");
     }
-
-    let bytes = resp.bytes().context("Failed to read download")?;
-
+    require_https(&manifest.artifact.url, "artifact")?;
     if verbose {
-        eprintln!("Downloaded {} bytes", bytes.len());
+        eprintln!(
+            "Authenticated update v{} with key {}",
+            manifest.version, manifest.key_id
+        );
     }
 
-    // Extract. Windows ships a .zip; every other platform a .tar.gz.
-    extract_archive(&bytes, artifact_name, &tmp_dir).context("Failed to extract archive")?;
-
-    // Find the perry binary in extracted files. The Windows zip ships `perry.exe`,
-    // so an unsuffixed "perry" lookup would miss it (#4715).
+    let current_exe = std::env::current_exe()
+        .context("Cannot determine current executable path")?
+        .canonicalize()
+        .context("Cannot canonicalize current executable path")?;
+    let install_dir = current_exe
+        .parent()
+        .context("current executable has no parent directory")?;
+    let staging = secure_staging_dir(install_dir)?;
+    let archive_path = staging.path().join("download");
+    let mut archive =
+        fs::File::create(&archive_path).context("failed to create staged update artifact")?;
+    let mut response = client
+        .get(&manifest.artifact.url)
+        .send()
+        .context("Failed to download update")?
+        .error_for_status()
+        .context("Failed to download update")?;
+    std::io::copy(&mut response, &mut archive).context("failed to stage update artifact")?;
+    use std::io::Write as _;
+    archive.flush()?;
+    archive.sync_all()?;
+    drop(archive);
+    perry_updater::cli_manifest::verify_cli_artifact(&archive_path, &manifest.artifact)
+        .context("refusing update artifact")?;
+    let extract_dir = staging.path().join("extract");
+    fs::create_dir(&extract_dir)?;
+    extract_archive(&fs::read(&archive_path)?, artifact_name, &extract_dir)
+        .context("Failed to safely extract authenticated archive")?;
     #[cfg(target_os = "windows")]
     let binary_name = "perry.exe";
     #[cfg(not(target_os = "windows"))]
     let binary_name = "perry";
-    let new_binary =
-        find_binary_in_dir(&tmp_dir, binary_name).context("Perry binary not found in archive")?;
-
-    // Atomic swap
-    let backup_path = current_exe.with_extension("old");
-
-    // Remove stale backup if exists
-    let _ = fs::remove_file(&backup_path);
-
-    // Rename current -> .old
-    if let Err(e) = fs::rename(&current_exe, &backup_path) {
-        // Try to clean up and give helpful error
-        let _ = fs::remove_dir_all(&tmp_dir);
-        if e.kind() == std::io::ErrorKind::PermissionDenied {
-            bail!(
-                "Permission denied. Try:\n  sudo perry update\n\nOr download manually from:\n  {}",
-                asset.browser_download_url
-            );
-        }
-        return Err(e).context("Failed to move current binary");
+    let new_binary = find_binary_in_dir(&extract_dir, binary_name)
+        .context("Perry binary not found in authenticated archive")?;
+    if let Err(err) = transactional_install(&current_exe, &new_binary, &extract_dir) {
+        let preserved = staging.keep();
+        return Err(err).context(format!(
+            "update install failed; recovery files retained at {}",
+            preserved.display()
+        ));
     }
-
-    // Copy new binary into place
-    if let Err(e) = fs::copy(&new_binary, &current_exe) {
-        // Rollback
-        let _ = fs::rename(&backup_path, &current_exe);
-        let _ = fs::remove_dir_all(&tmp_dir);
-        return Err(e).context("Failed to install new binary");
-    }
-
-    // Set executable permission
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = fs::set_permissions(&current_exe, fs::Permissions::from_mode(0o755));
-    }
-
-    // Also update runtime/stdlib libs if present next to binary
-    if let Some(exe_dir) = current_exe.parent() {
-        #[cfg(target_os = "windows")]
-        let (runtime_name, stdlib_name) = ("perry_runtime.lib", "perry_stdlib.lib");
-        #[cfg(not(target_os = "windows"))]
-        let (runtime_name, stdlib_name) = ("libperry_runtime.a", "libperry_stdlib.a");
-
-        let runtime_lib = exe_dir.join(runtime_name);
-        if runtime_lib.exists() {
-            if let Some(new_lib) = find_binary_in_dir(&tmp_dir, runtime_name) {
-                let _ = fs::copy(&new_lib, &runtime_lib);
-            }
-        }
-        let stdlib_lib = exe_dir.join(stdlib_name);
-        if stdlib_lib.exists() {
-            if let Some(new_lib) = find_binary_in_dir(&tmp_dir, stdlib_name) {
-                let _ = fs::copy(&new_lib, &stdlib_lib);
-            }
-        }
-    }
-
-    // Clean up
-    let _ = fs::remove_file(&backup_path);
-    let _ = fs::remove_dir_all(&tmp_dir);
-
-    println!("Updated perry: v{} -> v{}", current, cache.latest_version);
-
+    println!("Updated perry: v{} -> v{}", current, manifest.version);
     Ok(())
 }
 
-/// Unpack a downloaded release archive into `dest`, dispatching on the artifact
-/// extension. Windows ships a `.zip`; every other platform a `.tar.gz`. Feeding a
-/// zip to the gzip/tar decoder fails with "invalid gzip header" (#4715), so the
-/// extension — not the host OS — decides the decoder.
+fn safe_archive_path(path: &std::path::Path) -> Result<std::path::PathBuf> {
+    use std::path::Component;
+    if path.is_absolute() || path.as_os_str().is_empty() {
+        bail!("archive entry has unsafe path");
+    }
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => out.push(part),
+            _ => bail!("archive entry escapes staging directory"),
+        }
+    }
+    Ok(out)
+}
+
 fn extract_archive(bytes: &[u8], artifact_name: &str, dest: &std::path::Path) -> Result<()> {
     if artifact_name.ends_with(".zip") {
-        let reader = std::io::Cursor::new(bytes);
-        let mut archive = zip::ZipArchive::new(reader).context("Failed to open zip archive")?;
-        archive.extract(dest).context("Failed to extract zip")?;
-    } else {
+        let mut archive = zip::ZipArchive::new(std::io::Cursor::new(bytes))
+            .context("Failed to open zip archive")?;
+        for index in 0..archive.len() {
+            let mut entry = archive.by_index(index)?;
+            if entry.encrypted()
+                || entry
+                    .unix_mode()
+                    .is_some_and(|mode| mode & 0o170000 == 0o120000)
+            {
+                bail!("archive contains an encrypted or symlink entry");
+            }
+            let rel = safe_archive_path(std::path::Path::new(entry.name()))?;
+            let output = dest.join(rel);
+            if entry.is_dir() {
+                fs::create_dir_all(&output)?;
+                continue;
+            }
+            let parent = output.parent().context("archive entry has no parent")?;
+            fs::create_dir_all(parent)?;
+            let mut file = fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&output)
+                .with_context(|| {
+                    format!("refusing duplicate archive entry {}", output.display())
+                })?;
+            std::io::copy(&mut entry, &mut file)?;
+            file.sync_all()?;
+        }
+    } else if artifact_name.ends_with(".tar.gz") {
         let decoder = flate2::read::GzDecoder::new(bytes);
         let mut archive = tar::Archive::new(decoder);
-        archive.unpack(dest).context("Failed to extract tarball")?;
+        for entry in archive.entries().context("Failed to read tarball")? {
+            let mut entry = entry?;
+            let ty = entry.header().entry_type();
+            let rel = safe_archive_path(&entry.path()?)?;
+            let output = dest.join(rel);
+            if ty.is_dir() {
+                fs::create_dir_all(&output)?;
+                continue;
+            }
+            if !ty.is_file() {
+                bail!("archive contains a non-regular entry");
+            }
+            let parent = output.parent().context("archive entry has no parent")?;
+            fs::create_dir_all(parent)?;
+            let mut file = fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&output)
+                .with_context(|| {
+                    format!("refusing duplicate archive entry {}", output.display())
+                })?;
+            std::io::copy(&mut entry, &mut file)?;
+            file.sync_all()?;
+        }
+    } else {
+        bail!("unsupported update archive extension");
     }
     Ok(())
 }
 
 fn find_binary_in_dir(dir: &std::path::Path, name: &str) -> Option<PathBuf> {
-    // Check top level first
-    let direct = dir.join(name);
-    if direct.exists() {
-        return Some(direct);
-    }
-
-    // Search recursively
     for entry in walkdir::WalkDir::new(dir)
         .max_depth(3)
+        .follow_links(false)
         .into_iter()
         .flatten()
     {
-        if entry.file_name().to_string_lossy() == name && entry.file_type().is_file() {
+        if entry.file_name() == name && entry.file_type().is_file() {
             return Some(entry.path().to_path_buf());
         }
     }
     None
+}
+
+#[cfg(test)]
+static INSTALL_FAIL_POINT: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+#[cfg(test)]
+static INSTALL_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
+fn injected_install_failure(point: u8) -> std::io::Result<()> {
+    use std::sync::atomic::Ordering;
+    let configured = INSTALL_FAIL_POINT.load(Ordering::SeqCst);
+    if configured == point || (configured == 5 && matches!(point, 2 | 3)) {
+        let kind = if point == 4 {
+            std::io::ErrorKind::PermissionDenied
+        } else {
+            std::io::ErrorKind::WriteZero
+        };
+        return Err(std::io::Error::new(kind, "injected update install failure"));
+    }
+    Ok(())
+}
+#[cfg(not(test))]
+fn injected_install_failure(_: u8) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RecoveryJournal {
+    entries: Vec<RecoveryEntry>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RecoveryEntry {
+    target: PathBuf,
+    backup: PathBuf,
+}
+
+fn recovery_journal_path(install_dir: &std::path::Path) -> PathBuf {
+    install_dir.join(".perry-update-recovery.json")
+}
+
+/// Run before CLI argument parsing. A crash during the multi-file swap always
+/// leaves the executable at a valid old-or-new path; this journal restores all
+/// files to the known old set before any compiler/runtime code is executed.
+pub fn recover_interrupted_self_update() -> Result<()> {
+    let current_exe = std::env::current_exe()
+        .context("cannot determine executable for update recovery")?
+        .canonicalize()
+        .context("cannot canonicalize executable for update recovery")?;
+    let install_dir = current_exe
+        .parent()
+        .context("executable has no parent for update recovery")?;
+    recover_interrupted_update_at(install_dir)
+}
+
+fn recover_interrupted_update_at(install_dir: &std::path::Path) -> Result<()> {
+    let journal_path = recovery_journal_path(install_dir);
+    let raw = match fs::read(&journal_path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error).context("cannot read interrupted-update journal"),
+    };
+    let journal: RecoveryJournal =
+        serde_json::from_slice(&raw).context("interrupted-update journal is malformed")?;
+    if journal.entries.is_empty() {
+        bail!("interrupted-update journal has no entries");
+    }
+    for entry in &journal.entries {
+        if entry.target.parent() != Some(install_dir)
+            || !entry.backup.starts_with(install_dir)
+            || !fs::symlink_metadata(&entry.backup)?.file_type().is_file()
+        {
+            bail!("interrupted-update journal contains unsafe recovery paths");
+        }
+        fs::rename(&entry.backup, &entry.target)
+            .with_context(|| format!("failed to restore {}", entry.target.display()))?;
+    }
+    fs::remove_file(&journal_path)?;
+    if let Some(transaction) = journal
+        .entries
+        .first()
+        .and_then(|entry| entry.backup.parent())
+    {
+        let _ = fs::remove_dir_all(transaction);
+    }
+    #[cfg(unix)]
+    {
+        fs::File::open(install_dir)?.sync_all()?;
+    }
+    eprintln!("Recovered an interrupted Perry self-update; the previous version was restored.");
+    Ok(())
+}
+
+fn write_recovery_journal(install_dir: &std::path::Path, journal: &RecoveryJournal) -> Result<()> {
+    let journal_path = recovery_journal_path(install_dir);
+    if fs::symlink_metadata(&journal_path).is_ok() {
+        bail!("refusing to overwrite an existing update recovery journal");
+    }
+    let mut file = tempfile::NamedTempFile::new_in(install_dir)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.as_file()
+            .set_permissions(fs::Permissions::from_mode(0o600))?;
+    }
+    use std::io::Write as _;
+    serde_json::to_writer(&mut file, journal)?;
+    file.as_file_mut().flush()?;
+    file.as_file().sync_all()?;
+    file.persist_noclobber(&journal_path)
+        .map_err(|error| error.error)
+        .context("failed to arm update recovery journal")?;
+    #[cfg(unix)]
+    {
+        fs::File::open(install_dir)?.sync_all()?;
+    }
+    Ok(())
+}
+
+fn transactional_install(
+    current_exe: &std::path::Path,
+    new_binary: &std::path::Path,
+    extract_dir: &std::path::Path,
+) -> Result<()> {
+    if !fs::symlink_metadata(current_exe)?.file_type().is_file()
+        || !fs::symlink_metadata(new_binary)?.file_type().is_file()
+    {
+        bail!("refusing to replace a non-regular executable");
+    }
+    let install_dir = current_exe.parent().context("executable has no parent")?;
+    recover_interrupted_update_at(install_dir)?;
+    let payload = extract_dir
+        .parent()
+        .context("extract directory has no staging parent")?
+        .join("transaction");
+    fs::create_dir(&payload).context("failed to create update transaction journal")?;
+    #[cfg(unix)]
+    {
+        fs::File::open(extract_dir.parent().expect("checked staging parent"))?.sync_all()?;
+    }
+    let mut replacements = vec![(current_exe.to_path_buf(), new_binary.to_path_buf(), true)];
+    #[cfg(target_os = "windows")]
+    let libraries = ["perry_runtime.lib", "perry_stdlib.lib"];
+    #[cfg(not(target_os = "windows"))]
+    let libraries = ["libperry_runtime.a", "libperry_stdlib.a"];
+    for name in libraries {
+        let target = install_dir.join(name);
+        if target.exists() {
+            let source = find_binary_in_dir(extract_dir, name).with_context(|| {
+                format!(
+                    "authenticated archive is missing installed library {}",
+                    name
+                )
+            })?;
+            if !fs::symlink_metadata(&target)?.file_type().is_file()
+                || !fs::symlink_metadata(&source)?.file_type().is_file()
+            {
+                bail!("refusing non-regular library replacement");
+            }
+            replacements.push((target, source, false));
+        }
+    }
+    let mut prepared = Vec::new();
+    for (index, (target, source, executable)) in replacements.iter().enumerate() {
+        let staged = payload.join(format!("new-{}", index));
+        injected_install_failure(1).context("injected disk-full/copy failure")?;
+        fs::copy(source, &staged)
+            .with_context(|| format!("failed to stage {}", target.display()))?;
+        injected_install_failure(4).context("injected permission failure")?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(
+                &staged,
+                fs::Permissions::from_mode(if *executable { 0o755 } else { 0o644 }),
+            )?;
+        }
+        fs::File::open(&staged)?.sync_all()?;
+        prepared.push((target.clone(), staged));
+    }
+    // Do not move any live target away. A hard-link/copy backup keeps an
+    // executable in place across power loss; the durable journal makes a
+    // partially installed group self-heal to the prior complete group.
+    let mut journal = RecoveryJournal {
+        entries: Vec::new(),
+    };
+    for (index, (target, _)) in prepared.iter().enumerate() {
+        let backup = payload.join(format!("old-{}", index));
+        if fs::hard_link(target, &backup).is_err() {
+            fs::copy(target, &backup)
+                .with_context(|| format!("failed to back up {}", target.display()))?;
+        }
+        fs::File::open(&backup)?.sync_all()?;
+        journal.entries.push(RecoveryEntry {
+            target: target.clone(),
+            backup,
+        });
+    }
+    #[cfg(unix)]
+    {
+        // Persist backup directory entries before publishing the journal that
+        // authorizes recovery to rely on them after power loss.
+        fs::File::open(&payload)?.sync_all()?;
+    }
+    write_recovery_journal(install_dir, &journal)?;
+    for (target, staged) in &prepared {
+        if let Err(error) = injected_install_failure(2).and_then(|_| fs::rename(staged, target)) {
+            let rollback = rollback_install(&journal);
+            return match rollback { Ok(()) => Err(error).with_context(|| format!("failed to install {}; restored previous version", target.display())), Err(rollback_error) => Err(anyhow::anyhow!("failed to install {}: {}; rollback also failed; recovery will run on next launch: {}", target.display(), error, rollback_error)), };
+        }
+    }
+    #[cfg(unix)]
+    {
+        fs::File::open(install_dir)?.sync_all()?;
+    }
+    fs::remove_file(recovery_journal_path(install_dir))
+        .context("installed update but failed to disarm recovery journal")?;
+    let _ = fs::remove_dir_all(&payload);
+    Ok(())
+}
+
+fn rollback_install(journal: &RecoveryJournal) -> Result<()> {
+    injected_install_failure(3).context("injected rollback failure")?;
+    for entry in journal.entries.iter().rev() {
+        fs::rename(&entry.backup, &entry.target)?;
+    }
+    fs::remove_file(recovery_journal_path(entry_install_dir(journal)?))?;
+    Ok(())
+}
+
+fn entry_install_dir(journal: &RecoveryJournal) -> Result<&std::path::Path> {
+    journal
+        .entries
+        .first()
+        .and_then(|entry| entry.target.parent())
+        .context("recovery journal has no install directory")
 }
 
 #[cfg(test)]
@@ -695,5 +1011,115 @@ mod tests {
         assert!(tmp.join("perry").exists(), "perry should be extracted");
 
         let _ = fs::remove_dir_all(&tmp);
+    }
+
+    fn install_fixture(with_libs: bool) -> (tempfile::TempDir, PathBuf, PathBuf, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let current = dir.path().join("perry");
+        let extract = dir.path().join("extract");
+        fs::create_dir(&extract).unwrap();
+        let new = extract.join("perry");
+        fs::write(&current, b"old-cli").unwrap();
+        fs::write(&new, b"new-cli").unwrap();
+        if with_libs {
+            fs::write(dir.path().join("libperry_runtime.a"), b"old-runtime").unwrap();
+            fs::write(extract.join("libperry_runtime.a"), b"new-runtime").unwrap();
+            fs::write(dir.path().join("libperry_stdlib.a"), b"old-stdlib").unwrap();
+            fs::write(extract.join("libperry_stdlib.a"), b"new-stdlib").unwrap();
+        }
+        (dir, current, new, extract)
+    }
+
+    #[test]
+    fn rejects_corrupt_archive_and_zip_slip_and_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(
+            extract_archive(b"not an archive", "perry-linux-x86_64.tar.gz", dir.path()).is_err()
+        );
+        let mut bytes = Vec::new();
+        {
+            let mut zip = zip::ZipWriter::new(std::io::Cursor::new(&mut bytes));
+            zip.start_file::<_, ()>("../outside", zip::write::SimpleFileOptions::default())
+                .unwrap();
+            use std::io::Write;
+            zip.write_all(b"x").unwrap();
+            zip.finish().unwrap();
+        }
+        assert!(extract_archive(&bytes, "perry-windows-x86_64.zip", dir.path()).is_err());
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::symlink;
+            let link = dir.path().join("preexisting");
+            symlink("/tmp", &link).unwrap();
+            assert_ne!(secure_staging_dir(dir.path()).unwrap().path(), link);
+        }
+    }
+
+    #[test]
+    fn transaction_updates_all_libraries_or_restores_everything_on_failure() {
+        let _guard = INSTALL_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let (_dir, current, new, extract) = install_fixture(true);
+        transactional_install(&current, &new, &extract).unwrap();
+        assert_eq!(fs::read(&current).unwrap(), b"new-cli");
+        assert_eq!(
+            fs::read(current.parent().unwrap().join("libperry_runtime.a")).unwrap(),
+            b"new-runtime"
+        );
+        assert_eq!(
+            fs::read(current.parent().unwrap().join("libperry_stdlib.a")).unwrap(),
+            b"new-stdlib"
+        );
+
+        let (_dir, current, new, extract) = install_fixture(true);
+        INSTALL_FAIL_POINT.store(2, std::sync::atomic::Ordering::SeqCst);
+        assert!(transactional_install(&current, &new, &extract).is_err());
+        INSTALL_FAIL_POINT.store(0, std::sync::atomic::Ordering::SeqCst);
+        assert_eq!(fs::read(&current).unwrap(), b"old-cli");
+        assert_eq!(
+            fs::read(current.parent().unwrap().join("libperry_runtime.a")).unwrap(),
+            b"old-runtime"
+        );
+    }
+
+    #[test]
+    fn transaction_fault_injection_covers_copy_permission_missing_lib_and_rollback_failure() {
+        let _guard = INSTALL_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        for point in [1, 4] {
+            let (_dir, current, new, extract) = install_fixture(false);
+            INSTALL_FAIL_POINT.store(point, std::sync::atomic::Ordering::SeqCst);
+            assert!(
+                transactional_install(&current, &new, &extract).is_err(),
+                "point {point}"
+            );
+            INSTALL_FAIL_POINT.store(0, std::sync::atomic::Ordering::SeqCst);
+            assert_eq!(fs::read(&current).unwrap(), b"old-cli");
+        }
+        let (_dir, current, new, extract) = install_fixture(true);
+        fs::remove_file(extract.join("libperry_stdlib.a")).unwrap();
+        assert!(transactional_install(&current, &new, &extract).is_err());
+        assert_eq!(fs::read(&current).unwrap(), b"old-cli");
+        let (_dir, current, new, extract) = install_fixture(true);
+        // Point 5 fails the first new-file rename and the rollback itself.
+        // The transaction journal must retain every old file for recovery;
+        // no cleanup is allowed to erase the only viable rollback state.
+        INSTALL_FAIL_POINT.store(5, std::sync::atomic::Ordering::SeqCst);
+        assert!(transactional_install(&current, &new, &extract).is_err());
+        INSTALL_FAIL_POINT.store(0, std::sync::atomic::Ordering::SeqCst);
+        let journal = extract.parent().unwrap().join("transaction");
+        assert!(
+            journal.join("old-0").exists(),
+            "old executable retained for recovery"
+        );
+        assert!(
+            journal.join("old-1").exists(),
+            "old library retained for recovery"
+        );
+        recover_interrupted_update_at(current.parent().unwrap()).unwrap();
+        assert_eq!(fs::read(&current).unwrap(), b"old-cli");
+        assert_eq!(
+            fs::read(current.parent().unwrap().join("libperry_runtime.a")).unwrap(),
+            b"old-runtime"
+        );
+        assert!(!recovery_journal_path(current.parent().unwrap()).exists());
     }
 }

--- a/crates/perry/src/update_checker.rs
+++ b/crates/perry/src/update_checker.rs
@@ -389,8 +389,6 @@ struct TrustedUpdateKey {
     public_key: String,
 }
 
-/// Public keys are compile-time configuration, never fetched from the update
-/// server. A release built without them deliberately cannot self-update.
 fn trusted_cli_update_keys() -> Result<Vec<TrustedUpdateKey>> {
     let raw = option_env!("PERRY_CLI_UPDATE_PUBLIC_KEYS").context(
         "this Perry release has no trusted CLI update public keys; self-update is disabled until the release is built with PERRY_CLI_UPDATE_PUBLIC_KEYS",
@@ -408,11 +406,6 @@ fn trusted_cli_update_keys() -> Result<Vec<TrustedUpdateKey>> {
 }
 
 fn secure_staging_dir(install_dir: &std::path::Path) -> Result<tempfile::TempDir> {
-    // Windows replacement and recovery require ACL/reparse-point validation
-    // plus a helper process because the running PE cannot be replaced safely.
-    // Do not silently fall back to the former unsafe copy/rename flow.
-    #[cfg(windows)]
-    bail!("Windows self-update is disabled until ACL-verified staging and a replacement helper are available; install the signed release manually");
     let staging = tempfile::Builder::new()
         .prefix("perry-update-")
         .tempdir_in(install_dir)
@@ -430,6 +423,13 @@ fn secure_staging_dir(install_dir: &std::path::Path) -> Result<tempfile::TempDir
                 "refusing insecure update staging directory {}",
                 staging.path().display()
             );
+        }
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        if fs::symlink_metadata(staging.path())?.file_attributes() & 0x400 != 0 {
+            bail!("refusing update staging reparse point");
         }
     }
     Ok(staging)
@@ -553,6 +553,9 @@ pub fn perform_self_update(verbose: bool) -> Result<()> {
             preserved.display()
         ));
     }
+    #[cfg(windows)]
+    println!("Update staged; it will be installed after Perry exits.");
+    #[cfg(not(windows))]
     println!("Updated perry: v{} -> v{}", current, manifest.version);
     Ok(())
 }
@@ -683,15 +686,13 @@ struct RecoveryJournal {
 struct RecoveryEntry {
     target: PathBuf,
     backup: PathBuf,
+    staged: PathBuf,
 }
 
 fn recovery_journal_path(install_dir: &std::path::Path) -> PathBuf {
     install_dir.join(".perry-update-recovery.json")
 }
 
-/// Run before CLI argument parsing. A crash during the multi-file swap always
-/// leaves the executable at a valid old-or-new path; this journal restores all
-/// files to the known old set before any compiler/runtime code is executed.
 pub fn recover_interrupted_self_update() -> Result<()> {
     let current_exe = std::env::current_exe()
         .context("cannot determine executable for update recovery")?
@@ -700,6 +701,11 @@ pub fn recover_interrupted_self_update() -> Result<()> {
     let install_dir = current_exe
         .parent()
         .context("executable has no parent for update recovery")?;
+    #[cfg(windows)]
+    if recovery_journal_path(install_dir).exists() {
+        schedule_windows_recovery(&current_exe, install_dir)?;
+        bail!("interrupted update recovery has been scheduled");
+    }
     recover_interrupted_update_at(install_dir)
 }
 
@@ -722,7 +728,7 @@ fn recover_interrupted_update_at(install_dir: &std::path::Path) -> Result<()> {
         {
             bail!("interrupted-update journal contains unsafe recovery paths");
         }
-        fs::rename(&entry.backup, &entry.target)
+        replace_path(&entry.backup, &entry.target)
             .with_context(|| format!("failed to restore {}", entry.target.display()))?;
     }
     fs::remove_file(&journal_path)?;
@@ -765,6 +771,136 @@ fn write_recovery_journal(install_dir: &std::path::Path, journal: &RecoveryJourn
         fs::File::open(install_dir)?.sync_all()?;
     }
     Ok(())
+}
+
+fn replace_path(source: &std::path::Path, target: &std::path::Path) -> std::io::Result<()> {
+    #[cfg(not(windows))]
+    {
+        fs::rename(source, target)
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStrExt;
+        use windows_sys::Win32::Storage::FileSystem::{
+            MoveFileExW, MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH,
+        };
+        let mut source_wide: Vec<u16> = source.as_os_str().encode_wide().chain(Some(0)).collect();
+        let mut target_wide: Vec<u16> = target.as_os_str().encode_wide().chain(Some(0)).collect();
+        let ok = unsafe {
+            MoveFileExW(
+                source_wide.as_mut_ptr(),
+                target_wide.as_mut_ptr(),
+                MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+            )
+        };
+        if ok == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+pub fn maybe_run_windows_update_helper(args: &[String]) -> Option<Result<()>> {
+    if args.get(1).map(String::as_str) != Some("--perry-update-helper") {
+        return None;
+    }
+    let apply = match args.get(2).map(String::as_str) {
+        Some("apply") => Ok(true),
+        Some("rollback") => Ok(false),
+        _ => Err(anyhow::anyhow!("missing update-helper mode")),
+    };
+    let parent_pid = args
+        .get(3)
+        .and_then(|value| value.parse::<u32>().ok())
+        .ok_or_else(|| anyhow::anyhow!("missing update-helper parent pid"));
+    let journal = args
+        .get(4)
+        .map(PathBuf::from)
+        .ok_or_else(|| anyhow::anyhow!("missing update-helper journal path"));
+    Some(apply.and_then(|apply| {
+        parent_pid
+            .and_then(|pid| journal.and_then(|path| run_windows_update_helper(apply, pid, &path)))
+    }))
+}
+
+#[cfg(windows)]
+fn run_windows_update_helper(
+    apply: bool,
+    parent_pid: u32,
+    journal_path: &std::path::Path,
+) -> Result<()> {
+    use windows_sys::Win32::Foundation::CloseHandle;
+    use windows_sys::Win32::Storage::FileSystem::SYNCHRONIZE;
+    use windows_sys::Win32::System::Threading::{OpenProcess, WaitForSingleObject, INFINITE};
+    let process = unsafe { OpenProcess(SYNCHRONIZE, 0, parent_pid) };
+    if process.is_null() {
+        bail!(
+            "cannot wait for Perry update parent: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+    unsafe {
+        WaitForSingleObject(process, INFINITE);
+        CloseHandle(process);
+    }
+    let raw = fs::read(journal_path)?;
+    let journal: RecoveryJournal = serde_json::from_slice(&raw)?;
+    for entry in &journal.entries {
+        let source = if apply { &entry.staged } else { &entry.backup };
+        replace_path(source, &entry.target)
+            .with_context(|| format!("failed to replace {}", entry.target.display()))?;
+    }
+    fs::remove_file(journal_path)?;
+    if let Some(staging) = journal
+        .entries
+        .first()
+        .and_then(|entry| entry.staged.parent())
+        .and_then(|path| path.parent())
+    {
+        let command = format!(
+            "ping 127.0.0.1 -n 2 >NUL & rmdir /S /Q \"{}\"",
+            staging.display()
+        );
+        let _ = std::process::Command::new("cmd")
+            .args(["/C", &command])
+            .spawn();
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn start_windows_update_helper(
+    mode: &str,
+    current_exe: &std::path::Path,
+    payload: &std::path::Path,
+    install_dir: &std::path::Path,
+) -> Result<()> {
+    let helper = payload.join("perry-update-helper.exe");
+    fs::copy(current_exe, &helper)?;
+    std::process::Command::new(&helper)
+        .arg("--perry-update-helper")
+        .arg(mode)
+        .arg(std::process::id().to_string())
+        .arg(recovery_journal_path(install_dir))
+        .spawn()
+        .context("failed to start Windows update helper")?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn schedule_windows_recovery(
+    current_exe: &std::path::Path,
+    install_dir: &std::path::Path,
+) -> Result<()> {
+    let journal: RecoveryJournal =
+        serde_json::from_slice(&fs::read(recovery_journal_path(install_dir))?)?;
+    let payload = journal
+        .entries
+        .first()
+        .and_then(|entry| entry.staged.parent())
+        .context("recovery journal has no payload")?;
+    start_windows_update_helper("rollback", current_exe, payload, install_dir)
 }
 
 fn transactional_install(
@@ -828,9 +964,6 @@ fn transactional_install(
         fs::File::open(&staged)?.sync_all()?;
         prepared.push((target.clone(), staged));
     }
-    // Do not move any live target away. A hard-link/copy backup keeps an
-    // executable in place across power loss; the durable journal makes a
-    // partially installed group self-heal to the prior complete group.
     let mut journal = RecoveryJournal {
         entries: Vec::new(),
     };
@@ -844,17 +977,21 @@ fn transactional_install(
         journal.entries.push(RecoveryEntry {
             target: target.clone(),
             backup,
+            staged: prepared[index].1.clone(),
         });
     }
     #[cfg(unix)]
     {
-        // Persist backup directory entries before publishing the journal that
-        // authorizes recovery to rely on them after power loss.
         fs::File::open(&payload)?.sync_all()?;
     }
     write_recovery_journal(install_dir, &journal)?;
+    #[cfg(windows)]
+    {
+        start_windows_update_helper("apply", current_exe, &payload, install_dir)?;
+        return Ok(());
+    }
     for (target, staged) in &prepared {
-        if let Err(error) = injected_install_failure(2).and_then(|_| fs::rename(staged, target)) {
+        if let Err(error) = injected_install_failure(2).and_then(|_| replace_path(staged, target)) {
             let rollback = rollback_install(&journal);
             return match rollback { Ok(()) => Err(error).with_context(|| format!("failed to install {}; restored previous version", target.display())), Err(rollback_error) => Err(anyhow::anyhow!("failed to install {}: {}; rollback also failed; recovery will run on next launch: {}", target.display(), error, rollback_error)), };
         }
@@ -872,7 +1009,7 @@ fn transactional_install(
 fn rollback_install(journal: &RecoveryJournal) -> Result<()> {
     injected_install_failure(3).context("injected rollback failure")?;
     for entry in journal.entries.iter().rev() {
-        fs::rename(&entry.backup, &entry.target)?;
+        replace_path(&entry.backup, &entry.target)?;
     }
     fs::remove_file(recovery_journal_path(entry_install_dir(journal)?))?;
     Ok(())
@@ -1099,9 +1236,6 @@ mod tests {
         assert!(transactional_install(&current, &new, &extract).is_err());
         assert_eq!(fs::read(&current).unwrap(), b"old-cli");
         let (_dir, current, new, extract) = install_fixture(true);
-        // Point 5 fails the first new-file rename and the rollback itself.
-        // The transaction journal must retain every old file for recovery;
-        // no cleanup is allowed to erase the only viable rollback state.
         INSTALL_FAIL_POINT.store(5, std::sync::atomic::Ordering::SeqCst);
         assert!(transactional_install(&current, &new, &extract).is_err());
         INSTALL_FAIL_POINT.store(0, std::sync::atomic::Ordering::SeqCst);

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -174,3 +174,31 @@ Run `perry doctor` to verify the toolchain. See the [Windows platform guide](../
 
 - [Write your first program](hello-world.md)
 - [Build a native app](first-app.md)
+
+### Authenticated self-update and release migration
+
+`perry update` only installs a release when the matching
+`<archive>.update.json` is present and validates against a public-key keyring
+compiled into the CLI. The manifest is Ed25519-signed over a domain-separated
+payload that binds the key id, version, platform, artifact name, HTTPS URL,
+SHA-256 digest, and size. Old releases that only publish `*.sha256` sidecars
+are therefore intentionally **not** eligible for automatic installation;
+download them manually from the release page.
+
+Release maintainers must configure these GitHub settings before enabling a
+release: repository variable `PERRY_CLI_UPDATE_PUBLIC_KEYS` (a JSON array of
+`{"key_id":"...","public_key":"<base64-32-byte-Ed25519-key>"}`),
+repository variable `PERRY_CLI_UPDATE_KEY_ID`, and protected secret
+`PERRY_CLI_UPDATE_SIGNING_KEY` (the matching base64 32-byte seed). The workflow
+fails rather than publishing an unsigned manifest when the secret/key id is
+missing. Keep the old public key in the compiled keyring during rotation, sign
+new manifests with the new `key_id`, and remove the old key only after the
+minimum supported CLI has shipped with the replacement.
+
+The updater stages under the install directory with owner-only permissions,
+verifies before extraction, rejects links/path traversal, and restores the old
+binary and libraries after an interrupted transaction. It never recommends
+running the updater with elevated privileges; use the package manager or a
+manual install when the installation directory is not writable. Windows
+self-update remains fail-closed until ACL/reparse-point validation and a
+replacement helper are implemented; use the signed release installer there.

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -199,6 +199,4 @@ The updater stages under the install directory with owner-only permissions,
 verifies before extraction, rejects links/path traversal, and restores the old
 binary and libraries after an interrupted transaction. It never recommends
 running the updater with elevated privileges; use the package manager or a
-manual install when the installation directory is not writable. Windows
-self-update remains fail-closed until ACL/reparse-point validation and a
-replacement helper are implemented; use the signed release installer there.
+manual install when the installation directory is not writable.

--- a/docs/src/updater/overview.md
+++ b/docs/src/updater/overview.md
@@ -143,8 +143,9 @@ never lets an attacker push a binary your client will accept.
 
 ### Sign-side CLI (v0.5.395+)
 
-`perry updater` ships three subcommands that produce v2-shape signatures
-without needing any custom tooling:
+`perry updater` ships sign-side subcommands without needing custom tooling.
+`keygen`, `sign`, and `verify` serve the desktop updater's v2 artifact format;
+`sign-cli-manifest` signs the authenticated manifest consumed by `perry update`.
 
 ```bash
 # 1) One-time keypair generation. Save kp.json with mode 0600 and
@@ -166,6 +167,16 @@ perry updater verify \
     --version 1.2.3 \
     --signature '<base64 from step 2>' \
     --pubkey '<public_key from kp.json>'
+
+# 4) Release CI signs the CLI manifest, binding its archive URL, platform,
+# version, SHA-256, size, and key id into the Ed25519 signature.
+perry updater sign-cli-manifest \
+    --artifact perry-linux-x86_64.tar.gz \
+    --platform perry-linux-x86_64.tar.gz \
+    --url 'https://github.com/PerryTS/perry/releases/download/v1.2.3/perry-linux-x86_64.tar.gz' \
+    --release-version 1.2.3 \
+    --key-id release-2026 \
+    --secret-key-b64 "$PERRY_CLI_UPDATE_SIGNING_KEY"
 ```
 
 Compose a final manifest by piping `sign` output through `jq` for each


### PR DESCRIPTION
## Summary
- authenticate CLI update manifests with a compiled Ed25519 keyring and version/platform/digest-bound signatures
- safely stage, verify, extract, install, and recover interrupted Unix self-updates
- apply Windows updates through a detached helper after the running executable exits
- publish signed update manifests from release CI and document key rotation and legacy behavior

## Validation
- `cargo fmt --check`
- `cargo check -p perry --quiet`
- `cargo test -p perry-updater --lib`
- `cargo test -p perry update_checker::tests --no-default-features --features updater-cli`
- release workflow YAML parsing
- Windows API surface compiled against `x86_64-pc-windows-msvc` in an isolated check; the full workspace cross-check requires an MSVC SDK unavailable on this host


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added authenticated CLI updates using signed manifests and trusted public keys.
  - Updates now verify version, platform, download integrity, and artifact size before installation.
  - Added the `perry updater sign-cli-manifest` command for creating signed update metadata.
  - Interrupted updates can recover automatically and restore the previous installation.

- **Bug Fixes**
  - Improved archive safety by blocking path traversal, duplicate files, encrypted entries, and unsafe links.
  - Updates now install transactionally, preventing partial upgrades.

- **Documentation**
  - Documented authenticated updates, signing configuration, key rotation, and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->