### PR TITLE
docs: centralize release metadata guidance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+      - name: Release metadata contract
+        run: python3 scripts/check_release_metadata.py
+
       # File-size gate (v0.5.1019): fails the PR if any tracked source
       # file exceeds the LOC threshold (5000 initially; eventual target
       # is 2000). Big single-file modules are hard to read, slow IDE +

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1256
-
-
 ## TypeScript Parity Status
 
 Tracked via the gap test suite (`test-files/test_gap_*.ts`, 258 tests). Compared byte-for-byte against `node --experimental-strip-types`. Run via `./scripts/run_gap_tests.sh` (a thin wrapper over `run_parity_tests.sh --filter test_gap_` that builds the compiler itself and gates on no new untriaged failures).
@@ -33,17 +30,21 @@ Tracked via the gap test suite (`test-files/test_gap_*.ts`, 258 tests). Compared
 2. Wait for required checks to go green.
 3. Squash- or rebase-merge. The PR branch auto-deletes on merge.
 
-**For every change that lands on `main`** (whether via PR or admin bypass):
-
-1. **Bump version**: Increment patch in `[workspace.package].version` in `Cargo.toml` and the `**Current Version:**` line above. That is the ONLY metadata edit CLAUDE.md needs.
-2. **Add changelog entry**: Prepend a new `## v0.5.x — <one-line summary>` block at the top of `CHANGELOG.md`. Detail can go below in the same block — long-form root-cause writeups, file paths, validation notes, etc. all belong here, NOT in CLAUDE.md.
-3. **Commit changes**: Include code, `Cargo.toml`/`Cargo.lock`, `CLAUDE.md` (version bump only), and `CHANGELOG.md` updates together.
-
-**Do not write changelog entries into CLAUDE.md.** This file is for orientation (architecture, common pitfalls, build commands). Per-version history lives in `CHANGELOG.md` so CLAUDE.md stays small and stable across context loads.
+For release metadata and the publication sequence, follow the single checklist
+in [`README.md` → Releasing Perry](README.md#releasing-perry). The authoritative
+version is `[workspace.package].version` in `Cargo.toml`; `CHANGELOG.md` begins
+with the matching release heading, and
+`python3 scripts/check_release_metadata.py` validates both plus the workflow
+trigger. Do not copy the version or changelog entries into this file.
 
 ### External contributor PRs
 
-PRs from outside contributors should **not** touch `[workspace.package] version` in `Cargo.toml`, the `**Current Version:**` line in `CLAUDE.md`, or `CHANGELOG.md`. The maintainer bumps the version and writes the changelog entry at merge time — usually by rebasing the PR branch and amending. This avoids the patch-version collisions that happen when Perry's `main` ships several commits while a PR is in review (each on-main commit bumps the version; a PR that bumped to the same patch on day 1 is already behind by merge day). Contributors just write code; let the maintainer fold in the metadata last.
+PRs from outside contributors should **not** touch `[workspace.package] version`
+in `Cargo.toml` or `CHANGELOG.md`. The maintainer bumps the version and writes
+the changelog entry at merge time — usually by rebasing the PR branch and
+amending. This avoids the patch-version collisions that happen when Perry's
+`main` ships several commits while a PR is in review. Contributors just write
+code; let the maintainer fold in the metadata last.
 
 ## Build Commands
 
@@ -173,9 +174,3 @@ First-resolved directory cached in `compile_package_dirs`; subsequent imports re
 ### objc2 v0.6 API
 - `define_class!` with `#[unsafe(super(NSObject))]`, `msg_send!` returns `Retained` directly
 - All AppKit constructors require `MainThreadMarker`
-
-## Recent Changes
-
-Per-version entries live in CHANGELOG.md.
-
-**Do not add changelog entries to this file.** Bump only the `**Current Version:**` line above when you ship a release; everything else goes in CHANGELOG.md as a new `## v0.5.x — ...` block at the top.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Perry is a native TypeScript compiler written in Rust. It takes your TypeScript and compiles it straight to native executables — no Node.js, no Electron, no browser engine. Just fast, small binaries that run anywhere.
 
-**Current Version:** 0.5.1164 | [Website](https://perryts.com) | [Documentation](https://perryts.github.io/perry/) | [Showcase](https://perryts.com/showcase)
+[Website](https://perryts.com) | [Documentation](https://perryts.github.io/perry/) | [Showcase](https://perryts.com/showcase)
 
 **Community:** [Join the Perry Discord](https://discord.gg/chEmpGdTtZ)
 
@@ -909,6 +909,22 @@ macOS CI gate. **Major releases** — any bump of the major or minor number
 supported platform** before the tag is pushed. Patch releases only require the
 default CI gate.
 
+### Release metadata contract
+
+This section is the release checklist. The version is defined **only** by
+`[workspace.package].version` in [`Cargo.toml`](Cargo.toml); do not copy it to
+README or `CLAUDE.md`. `CHANGELOG.md` must begin with the matching
+`## vX.Y.Z` entry. The actual publication trigger is the
+[`release-packages.yml`](.github/workflows/release-packages.yml) workflow:
+publishing a GitHub Release starts it; a tag push does not. The workflow also
+allows `workflow_dispatch` for manual recovery.
+
+Validate those structured fields before tagging:
+
+```bash
+python3 scripts/check_release_metadata.py
+```
+
 ### 1. Pre-release checklist (every release)
 
 Run on macOS (the canonical dev host):
@@ -928,14 +944,19 @@ cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos \
 Then bump and tag:
 
 ```bash
-# Edit Cargo.toml workspace.package.version + CLAUDE.md "Current Version".
-# Add a "Recent Changes" entry in CLAUDE.md.
+# Update [workspace.package].version in Cargo.toml.
+# Prepend the matching ## vX.Y.Z entry to CHANGELOG.md.
+python3 scripts/check_release_metadata.py
 git commit -am "release: v0.x.y"
-git tag v0.x.y && git push --tags
+VERSION="$(python3 scripts/check_release_metadata.py --print-version)"
+git tag "v${VERSION}"
+git push origin "v${VERSION}"
+# After the tag-triggered tests are green, publish the GitHub Release.
+gh release create "v${VERSION}" --generate-notes
 ```
 
-The `release-packages.yml` workflow fires on the pushed tag and builds the
-cross-platform matrix (see §3).
+The tag starts the tag-triggered test and documentation workflows. Publishing
+the GitHub Release starts `release-packages.yml` (see §3).
 
 ### 2. Major-release verification (all platforms)
 
@@ -988,7 +1009,7 @@ Same recipe works for `tvos-simulator` + `"Apple TV"` device. On watchOS the
 Rust Tier-3 toolchain requires `+nightly -Zbuild-std` — see the
 `watchos-simulator` row in the matrix above.
 
-### 3. What CI does on the tag
+### 3. What CI does after GitHub Release publication
 
 The `Release Packages` workflow (`.github/workflows/release-packages.yml`)
 triggers on a published GitHub Release or manual `workflow_dispatch`. Matrix
@@ -1008,7 +1029,7 @@ Artifacts are published to:
 4. **winget** — manifest auto-update
 5. **hub.perryts.com** — worker notification so cloud build workers refresh
 
-A tag push with a failing platform build aborts the publish step for that
+A failing platform build aborts the publish step for that
 platform only; fix-forward with a new patch tag (e.g. `v0.6.1`) rather than
 amending the existing one.
 

--- a/scripts/check_release_metadata.py
+++ b/scripts/check_release_metadata.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Validate the release metadata contract without interpreting prose docs."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CARGO_TOML = REPO_ROOT / "Cargo.toml"
+CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+RELEASE_WORKFLOW = REPO_ROOT / ".github/workflows/release-packages.yml"
+
+
+def workspace_version() -> str:
+    """Read version from the structured [workspace.package] TOML section."""
+    in_workspace_package = False
+    for line in CARGO_TOML.read_text(encoding="utf-8").splitlines():
+        if line.startswith("["):
+            in_workspace_package = line == "[workspace.package]"
+            continue
+        if in_workspace_package:
+            match = re.fullmatch(r'\s*version\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"\s*(?:#.*)?', line)
+            if match:
+                return match.group(1)
+    raise ValueError("Cargo.toml has no [workspace.package].version")
+
+
+def first_release_heading() -> str:
+    for line in CHANGELOG.read_text(encoding="utf-8").splitlines():
+        match = re.match(r"^## v([0-9]+\.[0-9]+\.[0-9]+)(?:\s|$)", line)
+        if match:
+            return match.group(1)
+    raise ValueError("CHANGELOG.md has no release heading of the form '## vX.Y.Z'")
+
+
+def trigger_block(workflow: str) -> list[str]:
+    """Return the top-level YAML `on` block, using indentation rather than prose."""
+    lines = workflow.splitlines()
+    for index, line in enumerate(lines):
+        if line == "on:":
+            block: list[str] = []
+            for candidate in lines[index + 1 :]:
+                if candidate and not candidate.startswith((" ", "\t", "#")):
+                    break
+                block.append(candidate)
+            return block
+    raise ValueError("release workflow has no top-level 'on' block")
+
+
+def has_published_release_trigger(block: list[str]) -> bool:
+    for index, line in enumerate(block):
+        if line == "  release:":
+            child_lines: list[str] = []
+            for candidate in block[index + 1 :]:
+                if candidate.startswith("  ") and not candidate.startswith("    "):
+                    break
+                child_lines.append(candidate)
+            return any(re.fullmatch(r"\s*types:\s*\[\s*published\s*\]\s*", line) for line in child_lines)
+    return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--print-version", action="store_true", help="print the validated workspace version")
+    args = parser.parse_args()
+
+    try:
+        version = workspace_version()
+        changelog_version = first_release_heading()
+        triggers = trigger_block(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
+    except ValueError as error:
+        print(f"release metadata check failed: {error}", file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+    if changelog_version != version:
+        errors.append(
+            f"CHANGELOG.md starts with v{changelog_version}, but Cargo.toml declares v{version}"
+        )
+    if not has_published_release_trigger(triggers):
+        errors.append("release-packages.yml must trigger on release publication (types: [published])")
+    if "  workflow_dispatch:" not in triggers:
+        errors.append("release-packages.yml must retain workflow_dispatch for manual recovery")
+
+    if errors:
+        for error in errors:
+            print(f"release metadata check failed: {error}", file=sys.stderr)
+        return 1
+
+    if args.print_version:
+        print(version)
+    else:
+        print(
+            f"Release metadata is valid: Cargo.toml and CHANGELOG.md agree on v{version}; "
+            "release-packages.yml publishes on GitHub Release publication."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pre-tag-check.sh
+++ b/scripts/pre-tag-check.sh
@@ -68,11 +68,14 @@ run_check() {
 # 1. cargo fmt --all -- --check (Tests `lint` job)
 run_check "cargo fmt --all --check" cargo fmt --all -- --check
 
-# 2. docs/src linter (Tests `doc-tests` matrix --lint pass)
+# 2. Release metadata contract (Cargo.toml, CHANGELOG.md, and publish trigger)
+run_check "release metadata contract" python3 scripts/check_release_metadata.py
+
+# 3. docs/src linter (Tests `doc-tests` matrix --lint pass)
 run_check "perry-doc-tests --lint docs/src" \
     cargo run --release --quiet -p perry-doc-tests -- --lint docs/src
 
-# 3. cargo check (catches type errors fast; Tests `cargo-test` builds
+# 4. cargo check (catches type errors fast; Tests `cargo-test` builds
 #    everything anyway). Skipped under --quick.
 if [[ "$mode" != "quick" ]]; then
     run_check "cargo check --release --workspace" \
@@ -87,7 +90,7 @@ fi
 # regressions and runtime Perry behavior that fmt + cargo check can't
 # see (HIR rewrites, codegen routing, api-manifest gating).
 if [[ "$mode" == "thorough" ]]; then
-    # 4. Run the macOS doc-test suite end-to-end with the same
+    # 5. Run the macOS doc-test suite end-to-end with the same
     #    --filter-exclude shape the Tests workflow uses. Catches
     #    real Perry bugs (state desugar, WebView 1-arg routing,
     #    api-manifest class lookup, etc.).
@@ -95,7 +98,7 @@ if [[ "$mode" == "thorough" ]]; then
         cargo run --release --quiet -p perry-doc-tests -- \
             --skip-xcompile --filter-exclude ui/gallery.ts
 
-    # 5. cargo check against musl. Catches `cfg(target_os = "linux")`
+    # 6. cargo check against musl. Catches `cfg(target_os = "linux")`
     #    gates that should be `cfg(all(target_os = "linux", target_env = "gnu"))`
     #    (e.g. RTLD_DEEPBIND, glibc-only libc constants). Only runs
     #    if the musl target is installed — `rustup target add


### PR DESCRIPTION
## Summary
- make `Cargo.toml` the sole version source and remove duplicated current-version fields
- document the GitHub Release publication trigger in the primary release checklist
- add a lightweight metadata checker to CI and the pre-tag checks

## Validation
- `python3 scripts/check_release_metadata.py`
- checker parser assertions and relative README link checks
- YAML parsing for the affected workflows
- English mdBook build

`./scripts/pre-tag-check.sh --quick` reached the documentation linter, but its Rust link step could not complete because the local disk ran out of space.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated validation for release version, changelog, and publishing workflow metadata.
  * Added release metadata checks to pre-tag and continuous integration workflows.

* **Documentation**
  * Updated release instructions with a consolidated checklist and clearer version, changelog, tagging, and publishing guidance.
  * Clarified workflow behavior following GitHub Release publication and platform build failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->