### PR TITLE
Fix updater rollback lifecycle transitions

### DIFF
--- a/crates/perry-updater/src/desktop.rs
+++ b/crates/perry-updater/src/desktop.rs
@@ -229,25 +229,41 @@ pub extern "C" fn perry_updater_perform_rollback(target_path_val: i64) -> i64 {
         Some(s) => s,
         None => return 0,
     };
+
+    let mut rename = rename_path;
+    if perform_rollback_with(&target, &mut rename) {
+        1
+    } else {
+        0
+    }
+}
+
+/// Rollback implementation factored for deterministic failure-path tests.
+/// The native ABI above supplies `rename_path`; tests can inject a failed
+/// second rename and verify that the broken executable is restored.
+fn perform_rollback_with<F>(target: &str, rename: &mut F) -> bool
+where
+    F: FnMut(&str, &str) -> std::io::Result<()>,
+{
     let prev = format!("{}.prev", target);
 
     if !std::path::Path::new(&prev).exists() {
-        return 0;
+        return false;
     }
 
     // Move current (likely-broken) target out of the way.
     let broken = format!("{}.broken", target);
     let _ = remove_path(&broken);
-    let _ = rename_path(&target, &broken);
+    let _ = rename(target, &broken);
 
-    if rename_path(&prev, &target).is_err() {
+    if rename(&prev, target).is_err() {
         // Try to put broken back so the system isn't left without an exe.
-        let _ = rename_path(&broken, &target);
-        return 0;
+        let _ = rename(&broken, target);
+        return false;
     }
 
     let _ = remove_path(&broken);
-    1
+    true
 }
 
 fn rename_path(from: &str, to: &str) -> std::io::Result<()> {
@@ -356,6 +372,42 @@ mod tests {
 
         let s = target.to_string_lossy().to_string();
         assert_eq!(perry_updater_perform_rollback(make_str(&s)), 0);
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn rollback_rename_failure_restores_broken_target() {
+        let dir = std::env::temp_dir().join(format!(
+            "perry-updater-rb-rename-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let target = dir.join("app.bin");
+        let prev = format!("{}.prev", target.display());
+        std::fs::write(&target, b"broken-v2").unwrap();
+        std::fs::write(&prev, b"backup-v1").unwrap();
+
+        let target_s = target.to_string_lossy().to_string();
+        let prev_for_failure = prev.clone();
+        let mut rename = move |from: &str, to: &str| {
+            if from == prev_for_failure {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "injected rollback rename failure",
+                ));
+            }
+            std::fs::rename(from, to)
+        };
+
+        assert!(!perform_rollback_with(&target_s, &mut rename));
+        assert_eq!(std::fs::read(&target).unwrap(), b"broken-v2");
+        assert_eq!(std::fs::read(&prev).unwrap(), b"backup-v1");
+        assert!(!std::path::Path::new(&format!("{}.broken", target.display())).exists());
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/packages/perry-updater/src/index.ts
+++ b/packages/perry-updater/src/index.ts
@@ -221,9 +221,9 @@ export async function checkForUpdate(opts: UpdaterOptions): Promise<Update | nul
  *                       hook so a quick close-and-reopen pattern doesn't
  *                       look like a crash loop.
  *  - Sentinel armed and `restartCount >= crashLoopThreshold`:
- *                       crash loop detected → `performRollback()` and
- *                       `process.exit(0)` so the launcher restarts us at
- *                       the rolled-back binary.
+ *                       crash loop detected → roll back, clear the captured
+ *                       sentinel, and exit only if both operations succeed.
+ *                       A failed rollback leaves the sentinel for recovery.
  *
  * The graceful-exit hook is the difference between "user closed the app
  * within 60s" (legitimate, shouldn't bump the count) and "the new version
@@ -236,6 +236,11 @@ export async function initUpdater(options: InitOptions = {}): Promise<void> {
   const healthCheckMs = options.healthCheckMs ?? 60_000;
   const threshold = options.crashLoopThreshold ?? 2;
 
+  // A second initialization (or a disabled re-initialization) supersedes any
+  // callbacks registered by the previous generation. Exit hooks cannot be
+  // reliably removed on every target, so they also carry this validity bit.
+  invalidateActiveLifecycle();
+
   if (!autoRollback) return;
 
   const sentinelPath = getSentinelPath();
@@ -247,7 +252,7 @@ export async function initUpdater(options: InitOptions = {}): Promise<void> {
     state = JSON.parse(raw) as SentinelPayload;
   } catch {
     // Malformed sentinel — clear it so we don't retry forever.
-    clearSentinel(sentinelPath);
+    clearSentinelOrThrow(sentinelPath, "malformed sentinel");
     return;
   }
 
@@ -257,8 +262,13 @@ export async function initUpdater(options: InitOptions = {}): Promise<void> {
 
   if (state.restartCount >= threshold) {
     // Crash loop — roll back and bail.
-    nativePerformRollback(getExePath());
-    clearSentinel(sentinelPath);
+    // Do not clear or exit when rollback fails: the armed sentinel is the
+    // recoverable evidence needed for a later/manual retry. Exiting here
+    // would merely recreate the crash loop without restoring the old binary.
+    if (nativePerformRollback(getExePath()) !== 1) {
+      throw new Error("updater: rollback failed; sentinel retained for recovery");
+    }
+    clearSentinelIfCurrentOrThrow(sentinelPath, raw, "after rollback");
     (globalThis as any).process?.exit?.(0);
     return;
   }
@@ -270,8 +280,26 @@ export async function initUpdater(options: InitOptions = {}): Promise<void> {
   //  2. The user gracefully exits before the timer fires — close-and-reopen
   //     is a normal pattern for CLIs and quick-launch GUIs and shouldn't
   //     count toward crash-loop detection.
-  writeSentinel(sentinelPath, JSON.stringify(state));
-  setTimeout(() => clearSentinel(sentinelPath), healthCheckMs);
+  // Older sentinels did not include a generation. Upgrade them while writing
+  // the bumped restart count so their callbacks get the same protection.
+  state.generation = validGeneration(state.generation)
+    ? state.generation
+    : nextGeneration();
+  const capturedSentinel = JSON.stringify(state);
+  if (writeSentinel(sentinelPath, capturedSentinel) !== 1) {
+    throw new Error("updater: failed to persist crash-loop sentinel");
+  }
+
+  const lifecycle: ActiveLifecycle = {
+    sentinelPath,
+    capturedSentinel,
+    active: true,
+    timer: undefined,
+  };
+  activeLifecycle = lifecycle;
+  lifecycle.timer = setTimeout(() => {
+    clearLifecycleQuietly(lifecycle, "health check");
+  }, healthCheckMs);
 
   // Register a graceful-exit hook if `process.on` is wired in this build.
   // The check keeps initUpdater portable across UI / CLI / minimal targets
@@ -279,12 +307,13 @@ export async function initUpdater(options: InitOptions = {}): Promise<void> {
   // path and the user can call `markHealthy()` explicitly instead.
   const proc = (globalThis as any).process;
   if (proc && typeof proc.on === "function") {
-    proc.on("exit", () => clearSentinel(sentinelPath));
+    proc.on("exit", () => clearLifecycleQuietly(lifecycle, "graceful exit"));
   }
 }
 
 /**
- * Explicitly mark the running version as healthy and clear the sentinel.
+ * Explicitly mark the running version as healthy and clear its owned
+ * sentinel. Calling this after the sentinel was already cleared is a no-op.
  *
  * `initUpdater` already arms a timer + a graceful-exit hook, so most apps
  * never need to call this. Reach for it when:
@@ -297,7 +326,13 @@ export async function initUpdater(options: InitOptions = {}): Promise<void> {
  *    rather than relying on the generic exit hook.
  */
 export function markHealthy(): void {
-  clearSentinel(getSentinelPath());
+  const lifecycle = activeLifecycle;
+  if (lifecycle?.active) {
+    clearLifecycleOrThrow(lifecycle, "markHealthy");
+  }
+  // No owned lifecycle is also a successful no-op. In particular, an old
+  // process must not guess that a sentinel created by a newer install is its
+  // own merely because markHealthy was invoked late.
 }
 
 // ---------------------------------------------------------------------------
@@ -311,6 +346,80 @@ interface SentinelPayload {
   targetVersion: string;
   restartCount: number;
   state: "installing" | "armed";
+  /** Opaque install nonce used to reject stale timer and exit callbacks. */
+  generation?: string;
+}
+
+interface ActiveLifecycle {
+  sentinelPath: string;
+  /** Exact on-disk payload this process is allowed to clear. */
+  capturedSentinel: string;
+  active: boolean;
+  timer: ReturnType<typeof setTimeout> | undefined;
+}
+
+let activeLifecycle: ActiveLifecycle | undefined;
+let generationCounter = 0;
+
+function nextGeneration(): string {
+  generationCounter += 1;
+  return `${Date.now().toString(36)}-${generationCounter.toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+function validGeneration(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function invalidateActiveLifecycle(): void {
+  const lifecycle = activeLifecycle;
+  if (!lifecycle) return;
+  lifecycle.active = false;
+  if (lifecycle.timer !== undefined) clearTimeout(lifecycle.timer);
+  activeLifecycle = undefined;
+}
+
+/**
+ * Compare-and-clear the exact sentinel captured by this lifecycle. This
+ * prevents an old timer/exit hook from deleting a newer install's sentinel.
+ */
+function clearSentinelIfCurrentOrThrow(
+  sentinelPath: string,
+  expected: string,
+  context: string,
+): boolean {
+  if (readSentinel(sentinelPath) !== expected) return false;
+  clearSentinelOrThrow(sentinelPath, context);
+  return true;
+}
+
+function clearSentinelOrThrow(sentinelPath: string, context: string): void {
+  if (clearSentinel(sentinelPath) !== 1) {
+    throw new Error(`updater: failed to clear sentinel ${context}`);
+  }
+}
+
+function clearLifecycleOrThrow(lifecycle: ActiveLifecycle, context: string): void {
+  if (!lifecycle.active || activeLifecycle !== lifecycle) return;
+  clearSentinelIfCurrentOrThrow(
+    lifecycle.sentinelPath,
+    lifecycle.capturedSentinel,
+    context,
+  );
+  // A different generation owns the file now, so this lifecycle must never
+  // attempt to clear it again. A clear failure intentionally stays active so
+  // markHealthy can retry and the sentinel remains recoverable.
+  invalidateActiveLifecycle();
+}
+
+function clearLifecycleQuietly(lifecycle: ActiveLifecycle, context: string): void {
+  try {
+    clearLifecycleOrThrow(lifecycle, context);
+  } catch (error) {
+    // Throwing from a timer or exit hook can turn a healthy process into the
+    // very crash loop this sentinel is meant to diagnose. Keep the sentinel
+    // for recovery and report the failed cleanup instead.
+    (globalThis as any).console?.error?.("updater:", error);
+  }
 }
 
 async function downloadAndVerify(
@@ -374,6 +483,10 @@ async function applyAndRelaunch(
   currentVersion: string,
   targetVersion: string,
 ): Promise<void> {
+  // This process may have booted the previous installation and armed timer or
+  // exit callbacks. Invalidate them before publishing the new generation.
+  invalidateActiveLifecycle();
+
   const sentinelPath = getSentinelPath();
   const prevPath = `${targetPath}.prev`;
 
@@ -387,13 +500,15 @@ async function applyAndRelaunch(
     targetVersion,
     restartCount: 0,
     state: "armed",
+    generation: nextGeneration(),
   };
-  if (writeSentinel(sentinelPath, JSON.stringify(sentinel)) !== 1) {
+  const serializedSentinel = JSON.stringify(sentinel);
+  if (writeSentinel(sentinelPath, serializedSentinel) !== 1) {
     throw new Error("updater: failed to write sentinel");
   }
 
   if (nativeInstallUpdate(stagedPath, targetPath) !== 1) {
-    clearSentinel(sentinelPath);
+    clearSentinelIfCurrentOrThrow(sentinelPath, serializedSentinel, "after install failure");
     throw new Error("updater: install failed");
   }
 

--- a/packages/perry-updater/test/lifecycle.test.mjs
+++ b/packages/perry-updater/test/lifecycle.test.mjs
@@ -1,0 +1,210 @@
+import assert from "node:assert/strict";
+import { readFile, rm, writeFile } from "node:fs/promises";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import test from "node:test";
+
+const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
+const sourcePath = new URL("../src/index.ts", import.meta.url);
+const nativeImport = /import \{([\s\S]*?)\} from "perry\/updater";/;
+
+function armed(generation, restartCount = 0) {
+  return JSON.stringify({
+    prevExePath: "/app.prev",
+    stagedAt: "2026-01-01T00:00:00.000Z",
+    currentVersion: "1.0.0",
+    targetVersion: "1.0.1",
+    restartCount,
+    state: "armed",
+    generation,
+  });
+}
+
+async function loadUpdater(overrides = {}) {
+  let sentinel = overrides.sentinel ?? "";
+  const timers = [];
+  const clearedTimers = [];
+  const exits = [];
+  const exitHandlers = [];
+  const clears = [];
+  const writes = [];
+  const native = {
+    compareVersions: () => -1,
+    verifyHash: () => 1,
+    verifySignature: () => 1,
+    verifySignatureV2: () => 1,
+    computeFileSha256: () => "",
+    writeSentinel: (_path, payload) => {
+      writes.push(payload);
+      sentinel = payload;
+      return overrides.writeResult ?? 1;
+    },
+    readSentinel: () => sentinel,
+    clearSentinel: () => {
+      clears.push(sentinel);
+      if ((overrides.clearResult ?? 1) === 1) sentinel = "";
+      return overrides.clearResult ?? 1;
+    },
+    getExePath: () => "/app",
+    getSentinelPath: () => "/sentinel",
+    installUpdate: () => overrides.installResult ?? 1,
+    performRollback: () => overrides.rollbackResult ?? 1,
+    relaunch: () => overrides.relaunchResult ?? 123,
+    ...overrides.native,
+  };
+
+  const previous = {
+    native: globalThis.__perryUpdaterNative,
+    process: globalThis.process,
+    setTimeout: globalThis.setTimeout,
+    clearTimeout: globalThis.clearTimeout,
+    fetch: globalThis.fetch,
+  };
+  globalThis.__perryUpdaterNative = native;
+  Object.defineProperty(globalThis, "process", {
+    configurable: true,
+    value: {
+      platform: "darwin",
+      arch: "arm64",
+      exit: (code) => exits.push(code),
+      on: (event, callback) => {
+        if (event === "exit") exitHandlers.push(callback);
+      },
+    },
+  });
+  globalThis.setTimeout = (callback, ms) => {
+    const timer = { callback, ms };
+    timers.push(timer);
+    return timer;
+  };
+  globalThis.clearTimeout = (timer) => clearedTimers.push(timer);
+
+  const source = await readFile(sourcePath, "utf8");
+  const transformed = source.replace(nativeImport, (_match, bindings) => {
+    const destructuring = bindings.replace(
+      /(\w+)\s+as\s+(\w+)/g,
+      "$1: $2",
+    );
+    return `const {${destructuring}} = globalThis.__perryUpdaterNative;`;
+  });
+  const modulePath = `${repoRoot}.updater-test-${Date.now()}-${Math.random()}.ts`;
+  await writeFile(modulePath, transformed);
+  const updater = await import(pathToFileURL(modulePath).href);
+
+  return {
+    updater,
+    timers,
+    clearedTimers,
+    exits,
+    exitHandlers,
+    clears,
+    writes,
+    native,
+    get sentinel() {
+      return sentinel;
+    },
+    set sentinel(value) {
+      sentinel = value;
+    },
+    async restore() {
+      await rm(modulePath, { force: true });
+      globalThis.__perryUpdaterNative = previous.native;
+      Object.defineProperty(globalThis, "process", { configurable: true, value: previous.process });
+      globalThis.setTimeout = previous.setTimeout;
+      globalThis.clearTimeout = previous.clearTimeout;
+      globalThis.fetch = previous.fetch;
+    },
+  };
+}
+
+test("rollback failure preserves the sentinel and does not exit", async () => {
+  const ctx = await loadUpdater({ sentinel: armed("generation-1", 1), rollbackResult: 0 });
+  try {
+    await assert.rejects(ctx.updater.initUpdater({ crashLoopThreshold: 2 }), /rollback failed/);
+    assert.equal(ctx.sentinel, armed("generation-1", 1));
+    assert.deepEqual(ctx.exits, []);
+  } finally {
+    await ctx.restore();
+  }
+});
+
+test("a clear failure after rollback is reported and does not exit", async () => {
+  const ctx = await loadUpdater({ sentinel: armed("generation-1", 1), clearResult: 0 });
+  try {
+    await assert.rejects(ctx.updater.initUpdater({ crashLoopThreshold: 2 }), /failed to clear sentinel/);
+    assert.equal(ctx.sentinel, armed("generation-1", 1));
+    assert.deepEqual(ctx.exits, []);
+  } finally {
+    await ctx.restore();
+  }
+});
+
+test("a stale health timer cannot clear a newer generation", async () => {
+  const ctx = await loadUpdater({ sentinel: armed("generation-1") });
+  try {
+    await ctx.updater.initUpdater({ crashLoopThreshold: 3, healthCheckMs: 10 });
+    const oldTimer = ctx.timers.at(-1);
+    ctx.sentinel = armed("generation-2");
+    oldTimer.callback();
+    assert.equal(ctx.sentinel, armed("generation-2"));
+  } finally {
+    await ctx.restore();
+  }
+});
+
+test("a stale exit hook cannot clear a newer generation", async () => {
+  const ctx = await loadUpdater({ sentinel: armed("generation-1") });
+  try {
+    await ctx.updater.initUpdater({ crashLoopThreshold: 3 });
+    const oldExitHook = ctx.exitHandlers.at(-1);
+    ctx.sentinel = armed("generation-2");
+    oldExitHook();
+    assert.equal(ctx.sentinel, armed("generation-2"));
+  } finally {
+    await ctx.restore();
+  }
+});
+
+test("a new install invalidates callbacks from the previous generation", async () => {
+  const ctx = await loadUpdater({ sentinel: armed("generation-1"), relaunchResult: -1 });
+  try {
+    await ctx.updater.initUpdater({ crashLoopThreshold: 3 });
+    const oldTimer = ctx.timers.at(-1);
+    globalThis.fetch = async () => ({
+      ok: true,
+      json: async () => ({
+        schemaVersion: 1,
+        version: "1.0.1",
+        notes: "",
+        platforms: {
+          "darwin-aarch64": { url: "https://example.test/app", sha256: "x", signature: "x", size: 1 },
+        },
+      }),
+    });
+    const update = await ctx.updater.checkForUpdate({
+      manifestUrl: "https://example.test/manifest.json",
+      publicKey: "key",
+      currentVersion: "1.0.0",
+    });
+    await assert.rejects(update.installAndRelaunch(), /relaunch failed/);
+    const installedSentinel = ctx.sentinel;
+    oldTimer.callback();
+    assert.equal(ctx.sentinel, installedSentinel);
+    assert.ok(ctx.clearedTimers.includes(oldTimer));
+  } finally {
+    await ctx.restore();
+  }
+});
+
+test("markHealthy is idempotent and cancels its active timer", async () => {
+  const ctx = await loadUpdater({ sentinel: armed("generation-1") });
+  try {
+    await ctx.updater.initUpdater({ crashLoopThreshold: 3 });
+    const timer = ctx.timers.at(-1);
+    ctx.updater.markHealthy();
+    ctx.updater.markHealthy();
+    assert.equal(ctx.sentinel, "");
+    assert.ok(ctx.clearedTimers.includes(timer));
+  } finally {
+    await ctx.restore();
+  }
+});


### PR DESCRIPTION
## Summary
- add generation-owned sentinel cleanup for updater timers and exit hooks
- preserve rollback evidence and report rollback or cleanup failures instead of exiting successfully
- add lifecycle and native rollback failure coverage

## Root cause
Older callbacks cleared the sentinel unconditionally, so they could erase a newer installation's recovery state. Rollback failures were also ignored, which made the updater exit without restoring the prior binary.

## Validation
- `cargo test -p perry-updater`
- `node --test packages/perry-updater/test/lifecycle.test.mjs`
- `cargo fmt --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crash-loop detection and update rollback reliability.
  * Prevented stale lifecycle callbacks from clearing newer update state.
  * Preserved recovery information when rollback fails.
  * Ensured failed cleanup and installation operations report errors safely.
  * Fixed rollback behavior when restoring a previous installation encounters an error.

* **Tests**
  * Added coverage for rollback failures, stale lifecycle state, installation transitions, and repeated health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->