### PR TITLE
fix(runtime): bound WTF-8 decode against truncated trailing lead bytes (#6085)

### DIFF
--- a/crates/perry-runtime/src/string/pad.rs
+++ b/crates/perry-runtime/src/string/pad.rs
@@ -75,14 +75,25 @@ fn to_length(target_length: f64) -> usize {
 /// just wrong output.
 fn decode_wtf8_units(bytes: &[u8]) -> Vec<u16> {
     let mut units = Vec::with_capacity(bytes.len());
+    let len = bytes.len();
     let mut i = 0;
-    while i < bytes.len() {
+    while i < len {
         let b0 = bytes[i];
         if b0 < 0x80 {
             units.push(b0 as u16);
             i += 1;
         } else if b0 < 0xE0 {
             // 2-byte sequence: U+0080..U+07FF, always one code unit.
+            // #6085: a multi-byte lead truncated at the end of the buffer
+            // has no continuation byte; emit the lead as a lone byte instead
+            // of reading `bytes[i + 1]` one past the slice. Strings are
+            // normally well-formed WTF-8 so this is a defensive bound, but an
+            // unchecked read here is a real out-of-slice access.
+            if i + 1 >= len {
+                units.push(b0 as u16);
+                i += 1;
+                continue;
+            }
             let b1 = bytes[i + 1];
             let cp = ((b0 as u32 & 0x1F) << 6) | (b1 as u32 & 0x3F);
             units.push(cp as u16);
@@ -90,6 +101,11 @@ fn decode_wtf8_units(bytes: &[u8]) -> Vec<u16> {
         } else if b0 < 0xF0 {
             // 3-byte sequence: U+0800..U+FFFF, including a WTF-8 lone
             // surrogate (U+D800..U+DFFF) — always one code unit either way.
+            if i + 2 >= len {
+                units.push(b0 as u16);
+                i += 1;
+                continue;
+            }
             let b1 = bytes[i + 1];
             let b2 = bytes[i + 2];
             let cp = ((b0 as u32 & 0x0F) << 12) | ((b1 as u32 & 0x3F) << 6) | (b2 as u32 & 0x3F);
@@ -97,6 +113,11 @@ fn decode_wtf8_units(bytes: &[u8]) -> Vec<u16> {
             i += 3;
         } else {
             // 4-byte sequence: an astral code point, encoded as a surrogate pair.
+            if i + 3 >= len {
+                units.push(b0 as u16);
+                i += 1;
+                continue;
+            }
             let b1 = bytes[i + 1];
             let b2 = bytes[i + 2];
             let b3 = bytes[i + 3];
@@ -345,5 +366,48 @@ mod pad_length_tests {
         assert_eq!(to_length(MAX_STRING_LENGTH as f64), MAX_STRING_LENGTH);
         assert!(to_length((MAX_STRING_LENGTH + 1) as f64) > MAX_STRING_LENGTH);
         assert!(to_length(4_294_967_296.0) > MAX_STRING_LENGTH); // 2^32
+    }
+}
+
+#[cfg(test)]
+mod decode_wtf8_tests {
+    use super::decode_wtf8_units;
+
+    #[test]
+    fn decodes_well_formed_sequences() {
+        // ASCII
+        assert_eq!(decode_wtf8_units(b"AB"), vec![0x41, 0x42]);
+        // 2-byte: U+00E9 (é) = 0xC3 0xA9
+        assert_eq!(decode_wtf8_units(&[0xC3, 0xA9]), vec![0x00E9]);
+        // 3-byte: U+20AC (€) = 0xE2 0x82 0xAC
+        assert_eq!(decode_wtf8_units(&[0xE2, 0x82, 0xAC]), vec![0x20AC]);
+        // 3-byte WTF-8 lone surrogate: U+D800 = 0xED 0xA0 0x80
+        assert_eq!(decode_wtf8_units(&[0xED, 0xA0, 0x80]), vec![0xD800]);
+        // 4-byte astral: U+1F600 (😀) = 0xF0 0x9F 0x98 0x80 -> surrogate pair
+        assert_eq!(
+            decode_wtf8_units(&[0xF0, 0x9F, 0x98, 0x80]),
+            vec![0xD83D, 0xDE00]
+        );
+    }
+
+    /// #6085: a multi-byte lead byte truncated at the end of the slice must not
+    /// read past the buffer. Each case ends mid-sequence; the decoder must
+    /// return without an out-of-bounds read (emitting the lead as a lone byte).
+    #[test]
+    fn truncated_trailing_lead_does_not_over_read() {
+        // 2-byte lead with no continuation byte.
+        assert_eq!(decode_wtf8_units(&[0xC3]), vec![0x00C3]);
+        // 3-byte lead missing 1 and 2 continuation bytes.
+        assert_eq!(decode_wtf8_units(&[0xE2]), vec![0x00E2]);
+        assert_eq!(decode_wtf8_units(&[0xE2, 0x82]), vec![0x00E2, 0x0082]);
+        // 4-byte lead with no continuation byte.
+        assert_eq!(decode_wtf8_units(&[0xF0]), vec![0x00F0]);
+        // Valid prefix followed by a truncated lead: prefix decodes, tail is safe.
+        assert_eq!(decode_wtf8_units(&[0x41, 0xF0]), vec![0x0041, 0x00F0]);
+        // Longer malformed tails must also complete without an out-of-slice
+        // read (exact re-interpreted units are unspecified — only safety
+        // matters), so just assert the call returns a bounded result.
+        assert!(decode_wtf8_units(&[0xF0, 0x9F, 0x98]).len() <= 3);
+        assert!(decode_wtf8_units(&[0xE2, 0x82]).len() <= 2);
     }
 }


### PR DESCRIPTION
## Summary

Fixes an out-of-slice read of the same class as #6085 in `decode_wtf8_units` (the WTF-8 → UTF-16 decoder behind `String.prototype.padStart` / `padEnd`).

For a 2/3/4-byte lead byte the decoder read `bytes[i+1]`, `bytes[i+2]`, `bytes[i+3]` **without** checking those continuation bytes were within the slice. A payload ending on a truncated multi-byte lead read 1–3 bytes past the exact-sized allocation.

## Fix

Guard each multi-byte branch: if the required continuation bytes aren't present before the end of the slice, emit the lead byte as a lone unit and advance by one, instead of indexing past the buffer. Well-formed WTF-8 decodes identically (the guards only fire on a truncated tail, which a well-formed string never has); the previous unchecked reads were a genuine OOB access.

Mirrors the already-correct guard pattern in `js_string_to_well_formed` (`compare.rs`) and `compute_utf16_len_wtf8` (`string/mod.rs`).

## Verification

- New Rust unit tests (`cargo test -p perry-runtime decode_wtf8`, both pass): well-formed ASCII / 2-byte / 3-byte / 4-byte-astral / lone-surrogate sequences decode correctly; truncated tails complete without an over-read.
- E2E: `padStart`/`padEnd` (incl. multi-byte and astral fills) match `node --experimental-strip-types` byte-for-byte with the rebuilt runtime.

## Note on the originally-reported functions

A read-only audit of the exact functions named in #6085 — `String.prototype.split()` and `parseFloat()` — found them **already bounds-safe on current `main`** (both index-guarded; `parseFloat` since #4843). I could not reproduce an over-read there statically. This PR fixes the real, live instance of the same bug class that the audit did surface. If the original split/parseFloat crash still reproduces, a Windows minidump fault address / backtrace would pinpoint the exact site — happy to chase it with that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text decoding for incomplete multi-byte character sequences.
  * Prevented errors when processing truncated input at the end of a string.
  * Preserved incomplete leading bytes as standalone characters where appropriate.
* **Tests**
  * Added coverage for valid Unicode, surrogate pairs, lone surrogates, and truncated sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->