### PR TITLE
fix(runtime): bound the TIMER_REF_STATES registry to stop a permanent leak (#6084)

### DIFF
--- a/crates/perry-runtime/src/timer.rs
+++ b/crates/perry-runtime/src/timer.rs
@@ -9,7 +9,6 @@
 
 use crate::promise::{js_promise_new, js_promise_resolve, Promise};
 use std::any::Any;
-use std::collections::HashMap;
 use std::os::raw::c_int;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
@@ -110,7 +109,7 @@ fn timer_has_ref_state(id: i64) -> bool {
         .lock()
         .unwrap()
         .as_ref()
-        .and_then(|map| map.get(&id).copied())
+        .and_then(|s| s.states.get(&id).copied())
         .unwrap_or(true)
 }
 
@@ -328,7 +327,13 @@ static CALLBACK_TIMERS: Mutex<Vec<CallbackTimer>> = Mutex::new(Vec::new());
 // id collisions across queues could cause `clearTimeout(intId)` to also
 // clobber an unrelated Timeout with the same numeric id.
 static NEXT_TIMER_ID: Mutex<i64> = Mutex::new(1);
-static TIMER_REF_STATES: Mutex<Option<HashMap<i64, bool>>> = Mutex::new(None);
+
+// #6084: the bounded ref-state registry lives in a submodule to keep this file
+// under the 2000-line lint cap.
+mod ref_states;
+use ref_states::{TimerRefStates, TIMER_REF_STATES_CAP};
+
+static TIMER_REF_STATES: Mutex<Option<TimerRefStates>> = Mutex::new(None);
 static WARNED_NEGATIVE_TIMER_DELAY: AtomicBool = AtomicBool::new(false);
 static WARNED_NAN_TIMER_DELAY: AtomicBool = AtomicBool::new(false);
 
@@ -503,8 +508,8 @@ fn normalize_timer_delay(delay_value: f64) -> u64 {
 
 fn set_timer_ref_state(id: i64, has_ref: bool) {
     let mut slot = TIMER_REF_STATES.lock().unwrap();
-    let map = slot.get_or_insert_with(HashMap::new);
-    map.insert(id, has_ref);
+    slot.get_or_insert_with(TimerRefStates::default)
+        .insert_bounded(id, has_ref, TIMER_REF_STATES_CAP);
 }
 
 /// Whether `id` corresponds to a timer that was scheduled by this runtime
@@ -527,7 +532,7 @@ pub fn is_known_timer_id(id: i64) -> bool {
         .lock()
         .unwrap()
         .as_ref()
-        .map(|map| map.contains_key(&id))
+        .map(|s| s.states.contains_key(&id))
         .unwrap_or(false)
 }
 
@@ -790,7 +795,7 @@ pub extern "C" fn js_timer_has_ref(timer_id: i64) -> i32 {
         .lock()
         .unwrap()
         .as_ref()
-        .and_then(|map| map.get(&timer_id).copied())
+        .and_then(|s| s.states.get(&timer_id).copied())
         .unwrap_or(true) as i32
 }
 

--- a/crates/perry-runtime/src/timer/ref_states.rs
+++ b/crates/perry-runtime/src/timer/ref_states.rs
@@ -1,0 +1,75 @@
+//! #6084: bounded id→ref-state registry for scheduled timers, extracted from
+//! `timer.rs` to keep that file under the 2000-line lint cap.
+
+use std::collections::{HashMap, VecDeque};
+
+/// id → ref-state registry for scheduled timers. Entries are kept after
+/// `clearTimeout`/`clearInterval` so post-clear `.hasRef()`/`.unref()`/`+timer`
+/// still route through timer dispatch (Node keeps the Timeout object alive).
+/// They used to be inserted and *never* removed — a permanent per-id leak for a
+/// process that creates unboundedly many timers (e.g. a `setTimeout` per
+/// request). The insertion-ordered eviction queue bounds the map: the cap is
+/// large enough that a realistic "hold the handle, call `.hasRef()` after
+/// clear" pattern never sees eviction, but a long-running process no longer
+/// grows it without limit. Timer ids are monotonic (never reused), so an
+/// evicted id is never re-queried in practice.
+#[derive(Default)]
+pub(super) struct TimerRefStates {
+    pub(super) states: HashMap<i64, bool>,
+    order: VecDeque<i64>,
+}
+
+pub(super) const TIMER_REF_STATES_CAP: usize = 65_536;
+
+impl TimerRefStates {
+    /// Insert/overwrite `id`'s ref state, bounding the registry to `cap` entries
+    /// by evicting the oldest ids. Only a new id extends the eviction queue; a
+    /// ref/unref change on an existing id just overwrites its value.
+    pub(super) fn insert_bounded(&mut self, id: i64, has_ref: bool, cap: usize) {
+        if self.states.insert(id, has_ref).is_none() {
+            self.order.push_back(id);
+            while self.order.len() > cap {
+                if let Some(old) = self.order.pop_front() {
+                    self.states.remove(&old);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TimerRefStates;
+
+    /// #6084: the ref-state registry must stay bounded, evicting the oldest ids
+    /// while retaining recent ones (so post-clear `.hasRef()` keeps working for
+    /// a handle held for any realistic duration).
+    #[test]
+    fn insert_bounded_evicts_oldest_and_caps_size() {
+        let mut s = TimerRefStates::default();
+        let cap = 4;
+        for id in 1..=10i64 {
+            s.insert_bounded(id, id % 2 == 0, cap);
+        }
+        assert_eq!(s.states.len(), cap);
+        assert_eq!(s.order.len(), cap);
+        for id in 1..=6i64 {
+            assert!(!s.states.contains_key(&id), "id {id} should be evicted");
+        }
+        for id in 7..=10i64 {
+            assert_eq!(s.states.get(&id).copied(), Some(id % 2 == 0));
+        }
+    }
+
+    #[test]
+    fn ref_unref_of_existing_id_does_not_grow_queue() {
+        let mut s = TimerRefStates::default();
+        let cap = 100;
+        s.insert_bounded(42, true, cap);
+        s.insert_bounded(42, false, cap);
+        s.insert_bounded(42, true, cap);
+        assert_eq!(s.order.len(), 1);
+        assert_eq!(s.states.len(), 1);
+        assert_eq!(s.states.get(&42).copied(), Some(true));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the **permanent TIMER leak** sub-item of #6084.

`TIMER_REF_STATES` mapped every timer id ever scheduled → its ref state and **never removed** entries. Keeping ids post-`clearTimeout` is intentional (Node keeps the `Timeout` alive, so `.hasRef()`/`.unref()`/`+timer` must still route through timer dispatch), but since ids are never reused and nothing ever evicts, a process that creates unboundedly many timers (e.g. a `setTimeout` per request) leaked one `HashMap` entry per id for the life of the process.

## Fix

Bound the registry with an insertion-ordered eviction queue (cap 65 536): a genuinely new id appends and evicts the oldest once over cap; a ref/unref change on an existing id overwrites its value without re-queuing. The cap is generous enough that a realistic "hold the `Timeout` handle and call `.hasRef()` after clear" pattern never sees eviction, and ids are monotonic so an evicted id is never re-queried.

Deliberately **not** a naive delete-on-clear, which would regress `hasRef()` after `clearTimeout` (the trap called out in the triage).

## Verification

- Unit tests: eviction evicts oldest / caps size / an existing-id ref-unref doesn't grow the queue.
- E2E vs Node: `hasRef()` before clear (`true`), after `clearTimeout` (still `true`), after `unref()` (`false`), plus the `setInterval` equivalents — all match.

## Scope / follow-ups (separate, independently-mergeable)

The other perf items named in #6084 are left for follow-up PRs (disjoint files):
- object-keyed `Map` O(n) lookup → mirror `Set`'s `rebuild_*_index_for_gc` evacuation hook (`map.rs` + 4 GC sites);
- `Promise.all` / settle-listener / overflow-reaction O(n) full-table scans on every settle → `HashMap<usize, _>` keyed by promise (`combinators.rs` + `reactions.rs`);
- timer batch drain's `Vec::remove(i)` O(n²) → single-pass partition (`timer.rs`);
- (the `process.nextTick` `Vec::remove(0)` O(n²) is already fixed by #6126.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timer `.hasRef()` tracking for long-running processes by limiting how many timer ref states are retained.
  * Added bounded, insertion-ordered eviction so the oldest timer entries are automatically removed when the cap is reached.
  * Ensured updating an existing timer’s ref status overwrites without creating duplicate tracking records.
* **Tests**
  * Added unit tests covering cap/eviction behavior and overwrite semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->