### PR TITLE
fix(codegen): x++/x-- disqualifies the i32 fast path (accumulator overflow) (#6072)

### DIFF
--- a/crates/perry-codegen/src/collectors/i32_locals.rs
+++ b/crates/perry-codegen/src/collectors/i32_locals.rs
@@ -530,10 +530,18 @@ pub fn walk_writes_in_expr_for_strict(
             );
         }
         Expr::Update { id, .. } => {
-            // Update (i++/i--) is always strictly i32-bounded — it's a
-            // bitwise mod-2^32 wrap operation in JS semantics. Mark as
-            // a write but don't disqualify.
+            // #6072: `x++`/`x--` is `x = x + 1` with full f64 semantics — NOT a
+            // mod-2^32 wrap (only `| 0` / `>>> 0` are ToInt32/ToUint32). An i32
+            // accumulator incremented past 2^31-1 silently wraps to a negative
+            // value, corrupting every later read (reads prefer the i32 shadow).
+            // So an increment/decrement write is NOT strictly i32-bounded:
+            // record it and disqualify the local, dropping it to the correct
+            // f64 slot. Loop counters still get their i32 slot via the
+            // loop-bound path, and index-used accumulators via
+            // `index_used_locals` — this only removes the unsound path that let
+            // a bare `let big = 2147483640; ...; big++` overflow silently.
             saw_any.insert(*id);
+            disqualified.insert(*id);
         }
         _ => {
             // Recurse via the centralized walker so any future Expr

--- a/test-files/test_gap_6072_i32_update_overflow.ts
+++ b/test-files/test_gap_6072_i32_update_overflow.ts
@@ -1,0 +1,19 @@
+// repro 1: bare accumulator past 2^31
+let big = 2147483640;
+for (let k = 0; k < 10; k++) big++;
+console.log("big:", big);              // node: 2147483650
+
+let dn = -2147483640;
+for (let k = 0; k < 10; k++) dn--;
+console.log("dn:", dn);                // node: -2147483650
+
+// a normal small counter must still be correct (and can stay fast)
+let c = 0;
+for (let k = 0; k < 1000; k++) c++;
+console.log("c:", c);                  // 1000
+
+// index-used counter still works (should keep i32 fast path)
+const arr = new Array(5).fill(0);
+let s = 0;
+for (let i = 0; i < 5; i++) { arr[i] = i * 2; s += arr[i]; }
+console.log("arr sum:", s, "arr:", arr.join(","));


### PR DESCRIPTION
## Summary

Fixes the bare-accumulator case of #6072: an integer local seeded near `INT32_MAX` and incremented past `2^31` silently wrapped to a negative value.

`collect_strictly_i32_bounded_locals` classified an `x++`/`x--` write as "strictly i32-bounded" on a false premise stated in its own comment — that `++`/`--` is *"a bitwise mod-2^32 wrap operation in JS semantics."* It isn't: `x++` is `x = x + 1` with full f64 semantics; only `| 0` / `>>> 0` are ToInt32/ToUint32. So `let big = 2147483640; for (…) big++;` qualified for the i32 shadow slot and wrapped at `2^31`, corrupting every later read (reads prefer the i32 shadow over the f64 slot).

## Fix

Disqualify a local from the strictly-i32-bounded set when it's written via increment/decrement, dropping it to the correct f64 slot. This removes only the unsound path:
- **loop counters** still get their i32 slot via the loop-bound path,
- **index-used accumulators** via `index_used_locals`,
- the FNV-style `| 0`-coerced accumulators #436 recovered write via `LocalSet` (not `Update`), so they're unaffected.

The change can only push a local to the (correct) f64 path — it can never produce a wrong value.

## Verification

```
let big = 2147483640; for (let k=0;k<10;k++) big++;   // before: -2147483646   after: 2147483650 ✓
let dn = -2147483640; for (let k=0;k<10;k++) dn--;    // -2147483650 ✓
```
- New gap test `test_gap_6072_i32_update_overflow` passes parity with Node; ordinary and index-used counters keep correct values.
- Spot-check of integer-heavy gap tests shows no regression (the one diff, `test_gap_2514_settracesigint`, is a pre-existing `known_failures.json` entry about SIGINT arg types, unrelated to i32 codegen).

## Scope / follow-up

Closes repro 1 (bare accumulator). Repro 2 — a `for` counter whose **runtime** bound exceeds i32 range (`for (let i=2147483640; i<lim; i++)`) — is a separate follow-up in `stmt/loops.rs`'s dynamic-bound fast path, which registers the counter into the shared i32-slot map without a static upper-bound proof.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of increment and decrement operations near 32-bit integer limits.
  * Prevented overflow from producing incorrect values in subsequent calculations.
  * Preserved optimized behavior for ordinary counters and array-indexing scenarios.
* **Tests**
  * Added coverage for positive and negative 32-bit overflow cases.
  * Added sanity checks for standard counter arithmetic and indexed array operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->