### PR TITLE
fix(codegen): register v8 dispatch when constructing v8.GCProfiler (#3142)

### DIFF
--- a/crates/perry-codegen/src/expr/new_dynamic.rs
+++ b/crates/perry-codegen/src/expr/new_dynamic.rs
@@ -430,6 +430,19 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                             for a in args {
                                 let _ = lower_expr(ctx, a)?;
                             }
+                            // #3142: the profiler's `start()`/`stop()` instance
+                            // methods dispatch through the generic native-module
+                            // registry (`dispatch_native_module_method` →
+                            // `("v8.GCProfiler", …)`), which only resolves once
+                            // `js_nm_install_v8()` has populated the V8 dispatch
+                            // slot. A program whose other `v8.*` calls are all
+                            // direct-lowered never emits that install, so without
+                            // this `p.start()`/`p.stop()` fall through to
+                            // `undefined`. Emit it here (mirrors the sibling
+                            // `crypto.Certificate` new-branch).
+                            if let Some(s) = crate::nm_install::nm_install_symbol("v8.GCProfiler") {
+                                ctx.block().call_void(s, &[]);
+                            }
                             return Ok(ctx.block().call(DOUBLE, "js_v8_gc_profiler_new", &[]));
                         }
                     }


### PR DESCRIPTION
## Summary

Fixes `test-files/test_gap_node_v8_3137plus.ts`, which was failing `conformance-smoke` (`Object.keys(profiler.stop())` threw *"Cannot convert undefined or null to object"*).

`new v8.GCProfiler()` is special-cased in `new_dynamic.rs` to call `js_v8_gc_profiler_new()` directly — but, unlike the sibling `crypto.Certificate` new-branch, it never emitted `js_nm_install_v8()`.

The profiler's `start()`/`stop()` **instance** methods dispatch through the generic native-module registry (`dispatch_native_module_method` → `("v8.GCProfiler", …)` in `dispatch_v_z.rs`), which resolves only once `js_nm_install_v8()` has populated the V8 dispatch slot. In a program whose other `v8.*` calls are all direct-lowered (so no v8 install is otherwise emitted), `nm_dispatch_lookup("v8.GCProfiler")` returned `None`, so `p.start()`/`p.stop()` fell through to `undefined`.

I traced this with runtime `eprintln` diagnostics: `p.start()` reached `dispatch_native_module_method` with the correct `module="v8.GCProfiler" method="start"` key, but `lookup_some=false` — the registry slot was null.

## Fix

Emit `js_nm_install_v8()` in the GCProfiler new-branch (mirrors the `crypto.Certificate` branch at `new_dynamic.rs:363`). Additive — it only populates a dispatch slot.

## Verification

```
const p = new v8.GCProfiler();
p.start();
p.stop();   // before: undefined   after: { version, startTime, statistics, endTime } ✓
```
- `test_gap_node_v8_3137plus` now **passes parity** with `node --experimental-strip-types`.
- Regression sanity: a v8-namespace-only program (`getHeapStatistics`, `serialize`/`deserialize` round-trip) still matches Node.

## Note

This clears one of the currently-untriaged `conformance-smoke` failures on `main`. The others (`zlib_4917_level` — createGzip/createDeflate `{level}` streaming; `string_locale_2781` / `dyn_index_get_denormal_safe` — which pass locally on macOS but fail on CI Linux, i.e. environment-specific) are separate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where V8 GC profiler instances could have unavailable `start()` and `stop()` methods.
  * GC profiler functionality now initializes correctly before use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->