### PR TITLE
fix(codegen): bound the pointer-typed-local inference fixed point (compile hang on large bundles)

### DIFF
--- a/crates/perry-codegen/src/collectors/pointer_locals.rs
+++ b/crates/perry-codegen/src/collectors/pointer_locals.rs
@@ -579,8 +579,25 @@ pub fn collect_pointer_typed_locals(
         })
         .collect();
 
+    // The `local_value_types` refinement below is NOT monotonic — a local's
+    // inferred type can flip between rounds (insert a different type at the
+    // `!= Some(&ty)` check), each flip re-arming `changed`. On a closure body
+    // with a data-flow cycle (mutually-referential locals whose inferred types
+    // oscillate) this fixed point never settles and the codegen hangs forever
+    // — reproduced as a wedged `perry compile` on a large esbuild-bundled CLI
+    // app: ~4GB of IR built, then one pathological closure spins here. Bound
+    // the iteration count; `non_pointer_locals` (the only fact `out` actually
+    // consumes) grows monotonically, so a genuine fixed point converges in at
+    // most ~one round per local. Anything past that generous cap is
+    // oscillation — stop and keep the current state, which is conservatively
+    // SAFE: an unresolved local stays pointer-typed and gets a shadow slot
+    // (over-rooting a non-pointer is harmless; under-rooting a pointer is the
+    // GC bug this analysis exists to prevent).
+    let max_rounds = writes.len().saturating_mul(2).saturating_add(32);
     let mut changed = true;
-    while changed {
+    let mut rounds = 0usize;
+    while changed && rounds < max_rounds {
+        rounds += 1;
         changed = false;
         for (id, local_writes) in &writes {
             let mut inferred_ty: Option<Type> = None;


### PR DESCRIPTION
## Problem

`collect_pointer_typed_locals` (perry-codegen) runs a `while changed { … }`
fixed point that refines each local's inferred value type. **The refinement is
not monotonic:** a local's entry in `local_value_types` can be *replaced* with a
different type between rounds (the `!= Some(&ty)` insert), and each replacement
re-arms `changed`. On a closure body with a data-flow cycle — mutually-
referential locals whose inferred types depend on each other and oscillate — the
loop never settles and **codegen spins forever at 100% CPU.**

This stayed latent while the collector only ran for top-level functions. Once
closures/arrows/methods started getting shadow-frame GC roots, it began running
for *every* closure — and a large esbuild-bundled CLI app then wedged
`perry compile`: ~4 GB of IR built, then one pathological minified closure spins
here indefinitely (0 objects emitted, compile log frozen).

## Fix

Cap the iteration count at `writes.len() * 2 + 32`.

`non_pointer_locals` — the only fact the returned slot map actually consumes —
grows **monotonically**, so a genuine fixed point converges in at most ~one round
per local. Anything past the (generous) cap is oscillation: stop and keep the
current state.

Hitting the cap is **conservatively safe**. An unresolved local simply stays
pointer-typed and gets a shadow-frame slot. Over-rooting a non-pointer is
harmless; the failure this analysis exists to prevent is the opposite —
*under*-rooting a live pointer across a moving GC.

## Validation

- The previously-wedging bundle now **compiles and runs `-p` end-to-end (rc=0)**
  on the default GC policy.
- Small programs still compile **byte-identical** to
  `node --experimental-strip-types` across a 12-case differential suite.
- Confirmed the hang reproduced on a base compiler without the shadow-frame
  change, and that this cap clears it.

A minimal standalone `.ts` trigger wasn't isolated — the oscillation needs a
specific inferred-type cycle the minifier emits — but the bundle reproduces it
deterministically. The cap is a pure termination guarantee, so it's safe to land
without waiting on a reduced repro.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented pointer analysis from hanging indefinitely in cases involving cyclical data-flow patterns.
  * Added a safeguard to ensure analysis completes within a bounded number of refinement rounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->