### PR TITLE
fix(runtime): dynamic index of a subnormal number is undefined on Linux too (#321)

### DIFF
--- a/crates/perry-runtime/src/value/dyn_index.rs
+++ b/crates/perry-runtime/src/value/dyn_index.rs
@@ -105,15 +105,22 @@ pub extern "C" fn js_dyn_index_get(value: f64, index: f64) -> f64 {
             key_ptr,
         );
     }
+    // A non-NaN-boxed f64 reaching here is a plain `number` (its `[idx]` is
+    // `undefined` per JS). The old code kept a "raw I64 pointer passed as
+    // DOUBLE" heuristic — `bits < 2^48 && (bits & 3) == 0 && bits >= 0x10000` —
+    // that treated such a number's bits as a heap pointer, a relic of the
+    // now-removed module-var raw-I64 representation (module vars are uniform
+    // NaN-boxed doubles today, so a real object always takes the `is_pointer()`
+    // branch above). The heuristic only ever MISfired on numbers whose f64 bits
+    // land in that band — e.g. a subnormal `~1.7e-314` (bits `0x8_0000_0000`).
+    // On the macOS host the resulting address was below the heap range so
+    // `is_valid_obj_ptr` rejected it and this returned `undefined`; on Linux
+    // (`HEAP_MIN = 0x1000`, needed for Android/Scudo low allocations) the same
+    // address is *in range*, so it was dereferenced as an `ObjectHeader` →
+    // garbage/crash. Drop the heuristic: a non-pointer receiver is a number and
+    // its indexed read is `undefined` on every platform (#63/#321 denormal-safe).
     let raw_ptr = if jsval.is_pointer() {
         (bits & POINTER_MASK) as usize
-    } else if !value.is_nan()
-        && bits != 0
-        && bits < 0x0001_0000_0000_0000
-        && (bits & 0x3) == 0
-        && bits >= 0x10000
-    {
-        bits as usize
     } else {
         return f64::from_bits(TAG_UNDEFINED);
     };


### PR DESCRIPTION
## Summary

Fixes the Linux-only failure of `test-files/test_gap_dyn_index_get_denormal_safe.ts` (a `conformance-smoke` blocker that passes on macOS but fails on CI Linux).

`js_dyn_index_get` kept a "raw-I64-pointer-passed-as-double" heuristic that treated a **non**-NaN-boxed `f64` whose bits land in `[0x10000, 2^48)` (low two bits clear) as a heap pointer. That representation is gone — module vars are uniform NaN-boxed doubles now, so a real object always takes the `is_pointer()` branch — leaving the heuristic to only ever **misfire** on plain numbers whose bit pattern matches, e.g. a subnormal `~1.7e-314` (bits `0x8_0000_0000`).

The divergence is purely the platform heap range in `is_valid_obj_ptr`:
- **macOS**: `HEAP_MIN = 0x200_0000_0000` — `0x8_0000_0000` (34 GB) is **below** it → rejected → `undefined` ✓
- **Linux/Android/iOS**: `HEAP_MIN = 0x1000` (deliberately low for Bionic/Scudo) — `0x8_0000_0000` **is in range** → dereferenced as an `ObjectHeader` → garbage/crash ✗

## Fix

Drop the heuristic: a non-pointer receiver is a `number`, and `number[idx]` is `undefined` on every platform. This kills the platform-dependent divergence at the root, rather than narrowing the Android-constrained Linux heap range.

## Verification

- **Full macOS gap suite: byte-identical pass/fail vs `origin/main`** — I ran the whole `test_gap_*` suite with and without this change; both produce the exact same 27 no-auto-mode failures, so removing the heuristic causes **zero regressions**. The affected fallback is only reached for non-pointer/non-string/non-classref receivers.
- Correct-by-construction for Linux: the subnormal no longer reaches any dereference, so `number[idx]` returns `undefined` on Linux exactly as on macOS.
- `test_gap_dyn_index_get_denormal_safe` is the regression guard (was Linux-only failing).

## Note

I don't have a Linux host to run the binary on directly; verification is (a) zero-regression across the entire macOS gap suite and (b) the fix removing the exact code path that the platform heap-range difference made unsafe on Linux. The other two Linux-only conformance failures (`zlib_4917_level`, `string_locale_2781`) are tracked separately — they pass on macOS (incl. auto-optimize) so they need Linux ground truth to diagnose.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed indexed access on numeric values to safely return `undefined`.
  * Prevented certain numeric bit patterns from being misinterpreted as object references, avoiding invalid memory access and potential crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->