### PR TITLE
fix(codegen): nested class static blocks must not re-run at module init

### DIFF
--- a/crates/perry-codegen/src/codegen/helpers.rs
+++ b/crates/perry-codegen/src/codegen/helpers.rs
@@ -963,17 +963,32 @@ pub(super) fn init_static_fields_late(
                 c.name.clone(),
                 crate::codegen::static_method_registry_key(&sm.name),
             );
-            // Skip if the init stream already invokes this block. The
-            // typical class-decl path emits a `StaticMethodCall` for
-            // each block; if we find one referencing this (class,
-            // method) pair, the user-init lowering above has already
-            // run it and a duplicate call here would double-fire any
-            // observable side effects.
-            if hir
+            // Skip if the block is already invoked inline. The typical class-decl
+            // path emits a `StaticMethodCall` for each block at its evaluation
+            // point; a duplicate call here would double-fire side effects.
+            //
+            // #5989: check both `hir.init` (a MODULE-level class decl) AND every
+            // function body (a function-NESTED class decl — `lower_decl::body_stmt`
+            // emits the block's `StaticMethodCall` into the enclosing factory
+            // body, which lives in `hir.functions`, not `hir.init`). Without the
+            // function-body scan, a nested class's block was ALSO run here at
+            // module init — before its factory ran — so a block that reads a
+            // captured factory-local (a turbopack module factory
+            // `a=>{ var g=a.i(N); class m { static { this.contextType =
+            // g.AppRouterContext } } }`) threw "Cannot read properties of
+            // undefined (reading 'AppRouterContext')" in `<module>__init` (the
+            // Next.js /plain App Router ErrorBoundaryHandler chunk). Class
+            // EXPRESSIONS (no inline invocation) still fall through to run here.
+            let invoked_inline = hir
                 .init
                 .iter()
                 .any(|s| init_calls_static_block(s, &c.name, &sm.name))
-            {
+                || hir.functions.iter().any(|f| {
+                    f.body
+                        .iter()
+                        .any(|s| init_calls_static_block(s, &c.name, &sm.name))
+                });
+            if invoked_inline {
                 continue;
             }
             if let Some(llvm_name) = ctx.methods.get(&key).cloned() {


### PR DESCRIPTION
## Summary

A function-nested `class` declaration's `static { … }` block is emitted **inline** into its enclosing function body (`lower_decl::body_stmt`), so it runs when that function evaluates the class. But the module-init fallback in `init_static_fields_late` (`codegen/helpers.rs`) **also** ran it — because its "already invoked inline?" guard only scanned `hir.init` (the module top-level init stream), **not** the function bodies where a nested class's block invocation actually lives.

So a nested class's static block ran a **second time at module init, before its enclosing factory ran**. When the block reads a captured factory-local, that local is still `undefined` at module init and the block throws.

## Impact — Next.js / turbopack

Turbopack bundles every module as a factory `id, a => { … }`, so this is common:

```js
2420, a => {
  var b, c, d = a.i(87924), /*…*/ g = a.i(9270);        // lazy imports
  class m extends i.default.Component {
    static { this.contextType = g.AppRouterContext }    // reads g
  }
  /* … */
}
```

`g` is a factory-local. At module init (before factory 2420 runs) it is `undefined`, so `g.AppRouterContext` threw

```
TypeError: Cannot read properties of undefined (reading 'AppRouterContext')
```

inside `<module>__init` — surfacing as an **App Router chunk-load failure and a hard 500 on every dynamic route** (part of #5989, e.g. Next.js `/plain`).

## Fix

Extend the inline-invocation guard to scan every function body in `hir.functions` in addition to `hir.init`:

```rust
let invoked_inline = hir.init.iter().any(|s| init_calls_static_block(s, &c.name, &sm.name))
    || hir.functions.iter().any(|f| f.body.iter().any(|s| init_calls_static_block(s, &c.name, &sm.name)));
if invoked_inline { continue; }
```

A block invoked inline **anywhere** — module top level *or* a factory body — is skipped by the late module-init fallback. The fallback is left to run only class-**expression** blocks that genuinely have no inline invocation (unchanged behaviour). This mirrors the `is_nested` / out-of-scope-ref skips the sibling static-field passes already apply (`init_static_fields_early`, and the `init_static_fields_late` field loop).

## Validation

- **Next.js `/plain`**: the App Router chunk (`ErrorBoundaryHandler`) now loads cleanly — the `AppRouterContext` throw is gone, and the dynamic render advances past chunk load.
- **11/13** class-static / class-expression gap tests pass. The 2 diffs (`class_expr_static_this`, `class_expr_extends_static_call_this`) are **pre-existing** — they use static *fields* with factory-local initializers (no static block, so this change cannot touch them) and **fail identically on the pre-fix binary** (the separate #685 static-field gap).
- `cargo fmt` clean.

Code-only; no version/changelog bump (maintainer folds metadata at merge).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate execution of static initialization blocks in classes nested within functions.
  * Ensured initialization blocks already invoked inline are not executed again during late initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->