### PR TITLE
fix(runtime): guard native-module deref against the small-handle band (Linux SIGSEGV in zlib streams)

### DIFF
--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -720,7 +720,15 @@ pub unsafe extern "C" fn js_native_call_method(
         )
     {
         let ns_ptr = jsval.as_pointer::<ObjectHeader>();
-        if !ns_ptr.is_null()
+        // The POINTER_TAG payload reaching here can be a small registry handle
+        // (zlib stream, fetch Request/Response, net.Socket, …) rather than a
+        // heap address. `is_valid_obj_ptr` alone does NOT reject the handle
+        // band on Linux/Windows/Android/iOS — its heap floor is 0x1000, far
+        // below HANDLE_BAND_MAX — so without the band check this dereferences
+        // unmapped low memory. macOS masks it behind a 2 TB heap floor, which
+        // is why `gz.on("data", …)` on a `zlib.createGzip()` handle segfaulted
+        // only on Linux.
+        if crate::value::addr_class::is_above_handle_band(ns_ptr as usize)
             && crate::object::is_valid_obj_ptr(ns_ptr as *const u8)
             && (*ns_ptr).class_id == crate::object::native_module::NATIVE_MODULE_CLASS_ID
         {


### PR DESCRIPTION
## What

`js_native_call_method` dereferenced a `POINTER_TAG` payload as an `ObjectHeader` (to read `class_id`) guarded only by `is_valid_obj_ptr`. That predicate deliberately does **not** reject the small-handle band on Linux/Windows/Android/iOS — its heap floor is `0x1000`, far below `HANDLE_BAND_MAX` (`0x100000`). `value/addr_class.rs` documents this in so many words:

> the platform `HEAP_MIN` floor on Linux/Android/iOS/Windows (`0x1000`) is BELOW the handle band, so this predicate alone does NOT reject small handles there — pair it with `is_handle_band`

Two other sites in this same function already pair it. This one didn't.

`zlib.createGzip()` returns a **stream handle** (handle band), so `gz.on("data", …)` dispatched through here and dereferenced address `0x60000` → **SIGSEGV**. macOS masks the entire class behind its 2 TB heap floor, which is why this only ever crashed on Linux.

## Why this matters beyond zlib

`test_gap_zlib_4917_level` has been failing in CI as a bare `output mismatch`. It was not a formatting nit — **the process was dying with exit 139** (`Segmentation fault (core dumped)`) right after the sync-API lines. The gap harness only diffs stdout, so a hard crash was being reported as a benign parity diff.

That single untriaged gap failure is what has been red-flagging the required `conformance-smoke-complete` check on **~13 open PRs**, none of which had anything to do with zlib.

## Verification (Linux x86_64, clean `main`)

Before:
```
$ ./zlib_gap_test
deflateRawSync level1 >= level9: true
... (5 sync lines) ...
Segmentation fault (core dumped)     # exit 139
```

After:
```
$ diff -u node.txt perry.txt && echo IDENTICAL
IDENTICAL
```

Confirmed the crash is **not** GC-related: it reproduces identically under `PERRY_GEN_GC=0`, `PERRY_GC_INCREMENTAL=0`, `PERRY_WRITE_BARRIERS=0`, and `PERRY_GEN_GC_EVACUATE=0`.

gdb (release + `PERRY_DEBUG_SYMBOLS=1`):
```
Program received signal SIGSEGV
#0  js_native_call_method (method_name_len=2, ...) at object/native_call_method.rs:725
#1  js_typed_feedback_native_call_method_by_id (object=nan(0xd000000060000)) at typed_feedback/guards.rs:832
```
`method_name_len=2` is `on`; the payload `0x60000` is inside the handle band.

## Follow-up (not in this PR)

Two things worth separate issues:

1. **The gap harness silently converts crashes into "output mismatch."** A non-zero/signal exit should be reported distinctly — this crash hid in plain sight for days behind a parity-diff label.
2. **Audit the other `is_valid_obj_ptr` call sites** that can receive handle-band payloads. `scripts/addr_class_inventory.py` exists for this class; this call site slipped through it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime safety when accessing certain global namespace objects.
  * Prevented potential crashes caused by invalid or unmapped pointer values during native method calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->