### PR TITLE
fix(codegen): i64 specialization emitted empty body for ternary self-recursion (#6221)

### DIFF
--- a/crates/perry-codegen/src/collectors/clamp_detect.rs
+++ b/crates/perry-codegen/src/collectors/clamp_detect.rs
@@ -271,7 +271,11 @@ pub fn i64s_stmts(ss: &[Stmt], sid: u32) -> bool {
 }
 pub fn i64s_expr(e: &Expr, sid: u32) -> bool {
     match e {
-        Expr::Integer(_) | Expr::Number(_) | Expr::LocalGet(_) => true,
+        Expr::Integer(_) | Expr::LocalGet(_) => true,
+        // The i64 emitter lowers Number literals with `as i64`, so only admit
+        // values that round-trip exactly — a fractional constant (`? 0.5 :`)
+        // would silently truncate in the specialized body.
+        Expr::Number(n) => *n as i64 as f64 == *n,
         Expr::Binary { op, left, right } => {
             matches!(op, BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul)
                 && i64s_expr(left, sid)

--- a/crates/perry-codegen/src/collectors/i64_emit.rs
+++ b/crates/perry-codegen/src/collectors/i64_emit.rs
@@ -172,6 +172,39 @@ pub fn i64_val(cx: &mut I64Cx<'_>, e: &Expr) -> String {
             }
             "0".to_string()
         }
+        Expr::Conditional {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            // Must be real control flow, not `select`: a branch can hold the
+            // self-recursive call, and evaluating both sides unconditionally
+            // would recurse past the base case.
+            let slot = cx.f.block_mut(cx.cur).unwrap().alloca(I64);
+            let cond = i64_cond(cx, condition);
+            let _ = cx.f.create_block("i64.cond.then");
+            let ti = cx.f.num_blocks() - 1;
+            let tl = cx.f.blocks()[ti].label.clone();
+            let _ = cx.f.create_block("i64.cond.else");
+            let ei = cx.f.num_blocks() - 1;
+            let el = cx.f.blocks()[ei].label.clone();
+            let _ = cx.f.create_block("i64.cond.merge");
+            let mi = cx.f.num_blocks() - 1;
+            let ml = cx.f.blocks()[mi].label.clone();
+            cx.f.block_mut(cx.cur).unwrap().cond_br(&cond, &tl, &el);
+            cx.cur = ti;
+            let tv = i64_val(cx, then_expr);
+            let blk = cx.f.block_mut(cx.cur).unwrap();
+            blk.store(I64, &tv, &slot);
+            blk.br(&ml);
+            cx.cur = ei;
+            let ev = i64_val(cx, else_expr);
+            let blk = cx.f.block_mut(cx.cur).unwrap();
+            blk.store(I64, &ev, &slot);
+            blk.br(&ml);
+            cx.cur = mi;
+            cx.f.block_mut(cx.cur).unwrap().load(I64, &slot)
+        }
         _ => "0".to_string(),
     }
 }

--- a/crates/perry-codegen/tests/i64_spec_ternary_recursion.rs
+++ b/crates/perry-codegen/tests/i64_spec_ternary_recursion.rs
@@ -1,0 +1,200 @@
+//! #6221: a self-recursive function whose recursive call sits inside a
+//! ternary was admitted by the i64-specialization gate (`i64s_expr` accepts
+//! `Expr::Conditional`) but the i64 body emitter had no `Conditional` arm and
+//! fell into its `_ => "0"` catch-all — producing an empty specialized body
+//! (`ret i64 0`) that shadowed the real function. Also covers the sibling
+//! gate bug: fractional `Number` literals were admitted and then truncated
+//! by the emitter's `as i64` lowering.
+
+use perry_codegen::{compile_module, AppMetadata, CompileOptions};
+use perry_hir::{BinaryOp, CompareOp, Expr, Function, Module, ModuleInitKind, Param, Stmt};
+use perry_types::Type;
+
+fn empty_opts() -> CompileOptions {
+    CompileOptions {
+        target: None,
+        is_entry_module: false,
+        non_entry_module_prefixes: Vec::new(),
+        import_function_prefixes: std::collections::HashMap::new(),
+        import_function_ffi_aliases: std::collections::HashMap::new(),
+        import_function_origin_names: std::collections::HashMap::new(),
+        import_function_v8_specifiers: std::collections::HashMap::new(),
+        import_function_node_submodule: std::collections::HashMap::new(),
+        namespace_node_submodules: std::collections::HashMap::new(),
+        namespace_v8_specifiers: std::collections::HashMap::new(),
+        namespace_member_prefixes: std::collections::HashMap::new(),
+        namespace_member_origin_names: std::collections::HashMap::new(),
+        emit_ir_only: true,
+        verify_native_regions: false,
+        disable_buffer_fast_path: false,
+        namespace_imports: Vec::new(),
+        namespace_reexport_named_imports: std::collections::HashSet::new(),
+        imported_classes: Vec::new(),
+        imported_enums: Vec::new(),
+        imported_async_funcs: std::collections::HashSet::new(),
+        type_aliases: std::collections::HashMap::new(),
+        imported_func_param_counts: std::collections::HashMap::new(),
+        imported_func_has_rest: std::collections::HashSet::new(),
+        imported_func_synthetic_arguments: std::collections::HashSet::new(),
+        imported_func_return_types: std::collections::HashMap::new(),
+        imported_vars: std::collections::HashSet::new(),
+        output_type: "executable".to_string(),
+        needs_stdlib: false,
+        needs_ui: false,
+        needs_geisterhand: false,
+        geisterhand_port: 7676,
+        enabled_features: Vec::new(),
+        native_module_init_names: Vec::new(),
+        js_module_specifiers: Vec::new(),
+        bundled_extensions: Vec::new(),
+        native_library_functions: Vec::new(),
+        i18n_table: None,
+        fast_math: false,
+        fp_contract_mode: perry_codegen::FpContractMode::Off,
+        app_metadata: AppMetadata::default(),
+        namespace_entries: Vec::new(),
+        dynamic_import_path_to_prefix: std::collections::HashMap::new(),
+        nextjs_path_init_modules: Vec::new(),
+        deferred_module_prefixes: std::collections::HashSet::new(),
+        module_init_deps: Vec::new(),
+        is_dynamic_import_target: false,
+        debug_locations: false,
+        module_source: None,
+        debug_source_line_offset: 0,
+    }
+}
+
+fn number_param(id: u32, name: &str) -> Param {
+    Param {
+        id,
+        name: name.to_string(),
+        ty: Type::Number,
+        default: None,
+        decorators: Vec::new(),
+        is_rest: false,
+        arguments_object: None,
+    }
+}
+
+/// `function <name>(n: number): number { return n <= 0 ? <base> : <name>(n - 1); }`
+fn ternary_recursive_fn(id: u32, name: &str, base: Expr) -> Function {
+    Function {
+        id,
+        name: name.to_string(),
+        type_params: Vec::new(),
+        params: vec![number_param(10, "n")],
+        return_type: Type::Number,
+        body: vec![Stmt::Return(Some(Expr::Conditional {
+            condition: Box::new(Expr::Compare {
+                op: CompareOp::Le,
+                left: Box::new(Expr::LocalGet(10)),
+                right: Box::new(Expr::Integer(0)),
+            }),
+            then_expr: Box::new(base),
+            else_expr: Box::new(Expr::Call {
+                callee: Box::new(Expr::FuncRef(id)),
+                args: vec![Expr::Binary {
+                    op: BinaryOp::Sub,
+                    left: Box::new(Expr::LocalGet(10)),
+                    right: Box::new(Expr::Integer(1)),
+                }],
+                type_args: Vec::new(),
+                byte_offset: 0,
+            }),
+        }))],
+        is_async: false,
+        is_generator: false,
+        is_strict: true,
+        was_plain_async: false,
+        was_unrolled: false,
+        is_exported: false,
+        captures: Vec::new(),
+        decorators: Vec::new(),
+    }
+}
+
+fn module_with(functions: Vec<Function>) -> Module {
+    Module {
+        name: "i64_spec_ternary.ts".to_string(),
+        imports: Vec::new(),
+        exports: Vec::new(),
+        classes: Vec::new(),
+        interfaces: Vec::new(),
+        type_aliases: Vec::new(),
+        enums: Vec::new(),
+        globals: Vec::new(),
+        functions,
+        script_global_functions: Vec::new(),
+        references_global_this: false,
+        annexb_global_undefined_names: Vec::new(),
+        init: Vec::new(),
+        exported_native_instances: Vec::new(),
+        exported_func_return_native_instances: Vec::new(),
+        exported_objects: Vec::new(),
+        exported_functions: Vec::new(),
+        widgets: Vec::new(),
+        uses_fetch: false,
+        uses_webassembly: false,
+        extern_funcs: Vec::new(),
+        init_was_unrolled: false,
+        has_top_level_await: false,
+        init_kind: ModuleInitKind::Eager,
+        async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
+        class_display_names: std::collections::HashMap::new(),
+        closure_source_text: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
+    }
+}
+
+/// Slice out the body of the `define`d function whose name contains `marker`.
+fn function_body<'a>(ir: &'a str, marker: &str) -> Option<&'a str> {
+    let start = ir
+        .match_indices("define ")
+        .find(|(i, _)| {
+            ir[*i..ir[*i..].find('\n').map(|n| i + n).unwrap_or(ir.len())].contains(marker)
+        })
+        .map(|(i, _)| i)?;
+    let end = ir[start..].find("\n}")? + start;
+    Some(&ir[start..end])
+}
+
+#[test]
+fn ternary_self_recursion_gets_real_i64_body() {
+    let f = ternary_recursive_fn(1, "idDown", Expr::Number(100.0));
+    let ir =
+        String::from_utf8(compile_module(&module_with(vec![f]), empty_opts()).unwrap()).unwrap();
+
+    let body =
+        function_body(&ir, "idDown_i64").expect("i64 specialization for idDown should be emitted");
+    // The specialized body must branch on the ternary condition and make the
+    // self-recursive call — not collapse to the empty `ret i64 0` stub.
+    assert!(
+        body.contains("br i1"),
+        "ternary must lower to a conditional branch, got:\n{body}"
+    );
+    assert!(
+        body.contains("call i64"),
+        "recursive call must survive in the i64 body, got:\n{body}"
+    );
+    assert!(
+        !body.trim_end().ends_with("ret i64 0") || body.contains("br i1"),
+        "i64 body is the empty stub:\n{body}"
+    );
+}
+
+#[test]
+fn fractional_literal_blocks_i64_specialization() {
+    // `return n <= 0 ? 0.5 : halfDown(n - 1);` — the i64 emitter would
+    // truncate 0.5 to 0, so the gate must reject the function entirely and
+    // leave the exact f64 body in place.
+    let f = ternary_recursive_fn(1, "halfDown", Expr::Number(0.5));
+    let ir =
+        String::from_utf8(compile_module(&module_with(vec![f]), empty_opts()).unwrap()).unwrap();
+
+    assert!(
+        !ir.contains("halfDown_i64"),
+        "function with a fractional literal must not be i64-specialized"
+    );
+}


### PR DESCRIPTION
Fixes #6221.

## Root cause

The i64-specialization pass has two halves that disagreed about `Expr::Conditional`:

- The admission gate `i64s_expr` (`collectors/clamp_detect.rs`) **accepts** conditionals, so `function idDown(n: number): number { return n <= 0 ? 100 : idDown(n - 1); }` is admitted for specialization.
- The body emitter `i64_val` (`collectors/i64_emit.rs`) had **no `Conditional` arm** and fell into its `_ => "0"` catch-all, so the specialized body collapsed to `ret i64 0` — exactly the empty stub in the issue's `--trace llvm` dump. The f64 wrapper then shadowed the real function, and every call returned 0.

This matches all the shapes in the report: either branch, the condition, or via a const — anything that keeps the body a single `return <ternary>` — while `if`/`else` worked (the emitter does handle `Stmt::If`) and arrow/mutual recursion never enters the pass.

## Fix

1. **`i64_emit.rs`**: lower `Expr::Conditional` as real control flow (`cond_br` + then/else blocks + merge slot). It must not be a `select`: a branch can hold the self-recursive call, and evaluating both sides unconditionally would recurse past the base case.
2. **`clamp_detect.rs`** — sibling bug in the same gate/emitter-mismatch class: `Expr::Number` literals were admitted unconditionally but the emitter lowers them with `as i64`, so a fractional constant (`return n <= 0 ? 0.5 : f(n - 1)`) silently truncated to `0`. The gate now only admits Number literals that round-trip exactly through i64.

## Validation

New integration test `crates/perry-codegen/tests/i64_spec_ternary_recursion.rs`:
- ternary self-recursion emits an i64 body with a conditional branch and the recursive call (not the empty stub);
- a fractional literal blocks specialization entirely (exact f64 body retained).

End-to-end, this program (covering issue repro + branch/const/nested/fib/fractional variants):

```typescript
function idDown(n: number): number { return n <= 0 ? 100 : idDown(n - 1); }
function upTo(n: number): number { return n >= 10 ? n : upTo(n + 1); }
function viaConst(n: number): number { const next = n - 1; return n <= 0 ? 42 : viaConst(next); }
function fib(n: number): number { return n <= 1 ? n : fib(n - 1) + fib(n - 2); }
function halfDown(n: number): number { return n <= 0 ? 0.5 : halfDown(n - 1); }
```

printed `0 0 0 0 0` before this change and now prints `100 10 42 55 0.5`, byte-identical to `node --experimental-strip-types`.

`cargo test -p perry-codegen` passes except the pre-existing `manifest_consistency::every_dispatch_entry_has_manifest_counterpart` failure (`ws::readyState` missing from `API_MANIFEST`, introduced on main by #6130 — unrelated to this diff).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed recursive conditional expressions in integer-specialized functions so they correctly evaluate branches and preserve recursive calls.
  * Prevented fractional numeric values from being incorrectly truncated in integer-specialized calculations.

* **Tests**
  * Added coverage for recursive ternary expressions and rejection of fractional values in integer-specialized functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->