### PR TITLE
feat(runtime): ArrayBuffer.prototype.transfer (ES2024) + perry/gc explicit GC control

### DIFF
--- a/crates/perry-api-manifest/src/entries.rs
+++ b/crates/perry-api-manifest/src/entries.rs
@@ -127,6 +127,10 @@ pub const NATIVE_MODULES: &[&str] = &[
     "perry/i18n",
     "worker_threads",
     "perry/thread",
+    // `perry/gc` — explicit GC control (collect / minor / idleHint).
+    // Served entirely by perry-runtime; a no-op-style Perry-native
+    // surface like `perry/thread` (doesn't resolve under Node/Bun).
+    "perry/gc",
     "perry/updater",
     "perry/container",
     "perry/container-compose",
@@ -217,6 +221,7 @@ pub const RUNTIME_ONLY_MODULES: &[&str] = &[
     "perry/widget",
     "perry/i18n",
     "perry/thread",
+    "perry/gc",
     "perry/media",
     "perry/audio",
     "perry/tui",

--- a/crates/perry-api-manifest/src/entries/part_1.rs
+++ b/crates/perry-api-manifest/src/entries/part_1.rs
@@ -1388,6 +1388,14 @@ pub(crate) const API_MANIFEST_PART_1: &[ApiEntry] = &[
         &[p_any("p0")],
         TypeSpec::Promise,
     ),
+    // `perry/gc` — explicit GC control. `collect()` runs a full collection
+    // (same as the global `gc()`), `minor()` runs a nursery-only collection
+    // and returns the freed byte count, `idleHint()` runs a threshold-due
+    // collection at a caller-declared idle point (frame boundary) and
+    // returns whether one ran.
+    method_sig("perry/gc", "collect", false, None, &[], TypeSpec::Void),
+    method_sig("perry/gc", "minor", false, None, &[], TypeSpec::Number),
+    method_sig("perry/gc", "idleHint", false, None, &[], TypeSpec::Bool),
     method_sig(
         "lodash",
         "chunk",

--- a/crates/perry-codegen/src/lower_call/builtin.rs
+++ b/crates/perry-codegen/src/lower_call/builtin.rs
@@ -137,19 +137,27 @@ pub(super) fn lower_builtin_new(
             Ok(Some(nanbox_pointer_inline(blk, &handle)))
         }
         "Uint8Array" if args.len() >= 2 => {
+            // Pass the raw NaN-boxed offset/length (undefined when absent),
+            // same as the non-Uint8Array view kinds below: the runtime runs
+            // ToIndex — which can execute user `valueOf` code — and applies
+            // the spec's post-coercion detached/bounds checks. The old
+            // `fptosi` cast silently turned object arguments into garbage
+            // without ever running their coercion.
             let source = lower_expr(ctx, &args[0])?;
-            let offset = lower_expr(ctx, &args[1])?;
-            let offset_i32 = ctx.block().fptosi(DOUBLE, &offset, I32);
-            let length_i32 = if args.len() >= 3 {
-                let length = lower_expr(ctx, &args[2])?;
-                ctx.block().fptosi(DOUBLE, &length, I32)
+            let offset_box = lower_expr(ctx, &args[1])?;
+            let length_box = if args.len() >= 3 {
+                lower_expr(ctx, &args[2])?
             } else {
-                "-1".to_string()
+                double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))
             };
             let handle = ctx.block().call(
                 I64,
                 "js_uint8array_view",
-                &[(DOUBLE, &source), (I32, &offset_i32), (I32, &length_i32)],
+                &[
+                    (DOUBLE, &source),
+                    (DOUBLE, &offset_box),
+                    (DOUBLE, &length_box),
+                ],
             );
             Ok(Some(nanbox_pointer_inline(ctx.block(), &handle)))
         }

--- a/crates/perry-codegen/src/lower_call/native_table/thread_lodash.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/thread_lodash.rs
@@ -56,6 +56,38 @@ pub(super) const THREAD_LODASH_ROWS: &[NativeModSig] = &[
         args: &[NA_F64],
         ret: NR_F64,
     },
+    // ========== perry/gc (explicit GC control: collect, minor, idleHint) ==========
+    // Zero-arg runtime calls. The runtime side returns already-NaN-boxed
+    // JSValues (undefined / a byte count / a boolean), so NR_F64 passes them
+    // through unchanged. Under Node/Bun these imports don't resolve — the
+    // module is a Perry-native pacing surface, same story as perry/thread.
+    NativeModSig {
+        module: "perry/gc",
+        has_receiver: false,
+        method: "collect",
+        class_filter: None,
+        runtime: "js_gc_module_collect",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "perry/gc",
+        has_receiver: false,
+        method: "minor",
+        class_filter: None,
+        runtime: "js_gc_module_minor",
+        args: &[],
+        ret: NR_F64,
+    },
+    NativeModSig {
+        module: "perry/gc",
+        has_receiver: false,
+        method: "idleHint",
+        class_filter: None,
+        runtime: "js_gc_module_idle_hint",
+        args: &[],
+        ret: NR_F64,
+    },
     // ========== lodash (named-import form: import { chunk } from 'lodash') ==========
     // Default-import form (import _ from 'lodash'; _.chunk(...)) needs has_receiver:true
     // but would pass the module object as first arg, breaking the C signature.

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -88,7 +88,9 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
     // `new Uint8Array(x)` runtime dispatch — handles the non-literal case
     // where `x` could be a number (length) or an array (source data).
     module.declare_function("js_uint8array_new", I64, &[DOUBLE]);
-    module.declare_function("js_uint8array_view", I64, &[DOUBLE, I32, I32]);
+    // Raw NaN-boxed byteOffset/length (undefined when absent) — the runtime
+    // runs ToIndex and the spec's post-coercion detached/bounds checks.
+    module.declare_function("js_uint8array_view", I64, &[DOUBLE, DOUBLE, DOUBLE]);
     // Generic typed array runtime (Int8/16/32, Uint16/32, Float32/64, Uint8Clamped).
     // Uint8Array piggybacks on the BufferHeader path.
     module.declare_function("js_typed_array_new_empty", I64, &[I32, I32]);

--- a/crates/perry-runtime/src/buffer/detach.rs
+++ b/crates/perry-runtime/src/buffer/detach.rs
@@ -130,17 +130,22 @@ fn throw_type_error(message: &str) -> ! {
 /// the current byteLength), copy `min(oldLength, newLength)` bytes, detach the
 /// source, and return the new buffer.
 pub(crate) fn array_buffer_transfer(addr: usize, args: &[f64]) -> f64 {
+    // ES2024 ArrayBufferCopyAndDetach ordering: ToIndex(newLength) runs FIRST
+    // — it can execute user code (`valueOf`) that detaches this very buffer —
+    // and IsDetachedBuffer is checked after, so a mid-coercion detach is
+    // caught before any stale header read.
+    let requested_len = match args.first().copied() {
+        Some(v) if !crate::value::JSValue::from_bits(v.to_bits()).is_undefined() => {
+            Some(super::from::array_buffer_to_index(v))
+        }
+        _ => None,
+    };
     if is_detached_buffer(addr) {
         throw_type_error("Cannot perform ArrayBuffer.prototype.transfer on a detached ArrayBuffer");
     }
     let src = addr as *mut BufferHeader;
     let old_len = unsafe { (*src).length } as i32;
-    let new_len = match args.first().copied() {
-        Some(v) if !crate::value::JSValue::from_bits(v.to_bits()).is_undefined() => {
-            super::from::array_buffer_to_index(v)
-        }
-        _ => old_len,
-    };
+    let new_len = requested_len.unwrap_or(old_len);
     let dst = super::from::zeroed_array_buffer_storage(new_len);
     mark_as_array_buffer(dst as usize);
     let copy_len = old_len.min(new_len);

--- a/crates/perry-runtime/src/buffer/detach.rs
+++ b/crates/perry-runtime/src/buffer/detach.rs
@@ -1,0 +1,135 @@
+//! ArrayBuffer detach state and `ArrayBuffer.prototype.transfer` /
+//! `transferToFixedLength` / `detached` (ES2024).
+//!
+//! Buffer bytes live INLINE after the `BufferHeader` in a GC old-arena
+//! allocation, so a detached buffer's storage cannot be individually freed
+//! while the JS object is alive. Detach therefore (1) zeroes the header —
+//! the pre-existing structuredClone-transfer convention, which makes
+//! `byteLength` read 0 — (2) zeroes every registered view's length so views
+//! over the detached buffer report length 0 like Node, and (3) hands the
+//! page-aligned interior of the payload back to the OS with `madvise`, so a
+//! large detached buffer stops costing RSS immediately even while the
+//! ArrayBuffer object itself is still reachable. The GcHeader `size` field
+//! is left untouched: the arena sweep still steps over the full allocation,
+//! and the decommitted pages stay mapped (later reads are legal and return
+//! zeros), so the only observable effect is RSS dropping.
+
+use super::*;
+use crate::fast_hash::{new_ptr_hash_set, PtrHashSet};
+use std::cell::RefCell;
+
+thread_local! {
+    /// Buffers detached via `transfer`/`transferToFixedLength`/structuredClone
+    /// transfer. A detached buffer also has `length == capacity == 0`, but that
+    /// alone cannot be the probe: `new ArrayBuffer(0)` is empty yet NOT
+    /// detached.
+    static DETACHED_BUFFER_REGISTRY: RefCell<PtrHashSet<usize>> =
+        RefCell::new(new_ptr_hash_set());
+}
+
+/// `ArrayBuffer.prototype.detached` — true after a successful transfer.
+pub fn is_detached_buffer(addr: usize) -> bool {
+    DETACHED_BUFFER_REGISTRY.with(|r| r.borrow().contains(&addr))
+}
+
+/// Drop the detached mark when the buffer dies — a recycled address would
+/// otherwise inherit detached-ness (the #6080 ABA class).
+pub(crate) fn remove_detached_entry_for_dead_buffer(addr: usize) {
+    DETACHED_BUFFER_REGISTRY.with(|r| {
+        r.borrow_mut().remove(&addr);
+    });
+}
+
+/// DetachArrayBuffer(buffer): idempotent.
+pub fn detach_array_buffer(addr: usize) {
+    if is_detached_buffer(addr) {
+        return;
+    }
+    let buf = addr as *mut BufferHeader;
+    let capacity = unsafe { (*buf).capacity };
+    unsafe {
+        (*buf).length = 0;
+        (*buf).capacity = 0;
+    }
+    DETACHED_BUFFER_REGISTRY.with(|r| {
+        r.borrow_mut().insert(addr);
+    });
+    // Buffer-shaped views (`new Uint8Array(ab)`, DataView slices): zero their
+    // own header lengths so `.length`/`.byteLength` report 0 and every indexed
+    // access is out-of-bounds, matching Node's view-over-detached semantics.
+    super::view::for_each_view(addr, |view_ptr, _info| unsafe {
+        let view = view_ptr as *mut BufferHeader;
+        (*view).length = 0;
+    });
+    // Typed-array views (`new Float32Array(ab, ...)`) record their backing in
+    // a separate side table; zero those lengths too.
+    crate::typedarray_view::zero_views_of_detached_backing(addr);
+    decommit_payload_pages(buffer_data_mut(buf), capacity as usize);
+}
+
+/// Release the page-aligned interior of a detached payload back to the OS.
+/// Rounds INWARD (start up, end down), so only pages lying entirely inside
+/// `[data, data + capacity)` are touched — the BufferHeader, the GcHeader in
+/// front of it, and any neighbor allocations on the boundary pages are never
+/// affected. Failure is harmless (the advice is best-effort), so the return
+/// value is ignored.
+#[cfg(unix)]
+fn decommit_payload_pages(data: *mut u8, capacity: usize) {
+    let page = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    if page <= 0 {
+        return;
+    }
+    let page = page as usize;
+    let start = (data as usize).wrapping_add(page - 1) & !(page - 1);
+    let end = (data as usize + capacity) & !(page - 1);
+    if end <= start {
+        return;
+    }
+    // MADV_FREE keeps the mapping valid on macOS and lets the kernel reclaim
+    // lazily; MADV_DONTNEED on Linux drops the pages (and RSS) immediately.
+    #[cfg(target_os = "macos")]
+    let advice = libc::MADV_FREE;
+    #[cfg(not(target_os = "macos"))]
+    let advice = libc::MADV_DONTNEED;
+    unsafe {
+        libc::madvise(start as *mut libc::c_void, end - start, advice);
+    }
+}
+
+#[cfg(not(unix))]
+fn decommit_payload_pages(_data: *mut u8, _capacity: usize) {}
+
+fn throw_type_error(message: &str) -> ! {
+    let msg = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_error_new_with_name_message(b"TypeError", msg);
+    crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64))
+}
+
+/// `ArrayBuffer.prototype.transfer(newLength?)` and `transferToFixedLength`.
+/// Perry has no resizable ArrayBuffers, so both produce a fixed-length result
+/// and are identical: allocate a zero-filled buffer of `newLength` (default:
+/// the current byteLength), copy `min(oldLength, newLength)` bytes, detach the
+/// source, and return the new buffer.
+pub(crate) fn array_buffer_transfer(addr: usize, args: &[f64]) -> f64 {
+    if is_detached_buffer(addr) {
+        throw_type_error("Cannot perform ArrayBuffer.prototype.transfer on a detached ArrayBuffer");
+    }
+    let src = addr as *mut BufferHeader;
+    let old_len = unsafe { (*src).length } as i32;
+    let new_len = match args.first().copied() {
+        Some(v) if !crate::value::JSValue::from_bits(v.to_bits()).is_undefined() => {
+            super::from::array_buffer_to_index(v)
+        }
+        _ => old_len,
+    };
+    let dst = super::from::zeroed_array_buffer_storage(new_len);
+    mark_as_array_buffer(dst as usize);
+    let copy_len = old_len.min(new_len);
+    if copy_len > 0 {
+        unsafe {
+            std::ptr::copy_nonoverlapping(buffer_data(src), buffer_data_mut(dst), copy_len as usize);
+        }
+    }
+    detach_array_buffer(addr);
+    f64::from_bits(crate::value::JSValue::pointer(dst as *mut u8).bits())
+}

--- a/crates/perry-runtime/src/buffer/detach.rs
+++ b/crates/perry-runtime/src/buffer/detach.rs
@@ -137,7 +137,11 @@ pub(crate) fn array_buffer_transfer(addr: usize, args: &[f64]) -> f64 {
     let copy_len = old_len.min(new_len);
     if copy_len > 0 {
         unsafe {
-            std::ptr::copy_nonoverlapping(buffer_data(src), buffer_data_mut(dst), copy_len as usize);
+            std::ptr::copy_nonoverlapping(
+                buffer_data(src),
+                buffer_data_mut(dst),
+                copy_len as usize,
+            );
         }
     }
     detach_array_buffer(addr);

--- a/crates/perry-runtime/src/buffer/detach.rs
+++ b/crates/perry-runtime/src/buffer/detach.rs
@@ -85,14 +85,24 @@ fn decommit_payload_pages(data: *mut u8, capacity: usize) {
     if end <= start {
         return;
     }
-    // MADV_FREE keeps the mapping valid on macOS and lets the kernel reclaim
-    // lazily; MADV_DONTNEED on Linux drops the pages (and RSS) immediately.
-    #[cfg(target_os = "macos")]
-    let advice = libc::MADV_FREE;
-    #[cfg(not(target_os = "macos"))]
-    let advice = libc::MADV_DONTNEED;
     unsafe {
-        libc::madvise(start as *mut libc::c_void, end - start, advice);
+        // macOS: MADV_FREE_REUSABLE drops the pages from the process
+        // footprint immediately (plain MADV_FREE only reclaims under
+        // memory pressure, so RSS wouldn't visibly shrink). It can fail
+        // on some region types — fall back to MADV_FREE then.
+        #[cfg(target_os = "macos")]
+        {
+            let len = end - start;
+            if libc::madvise(start as *mut libc::c_void, len, libc::MADV_FREE_REUSABLE) != 0 {
+                libc::madvise(start as *mut libc::c_void, len, libc::MADV_FREE);
+            }
+        }
+        // Linux (and other unix): MADV_DONTNEED drops the pages (and RSS)
+        // immediately; later reads legally return zeros.
+        #[cfg(not(target_os = "macos"))]
+        {
+            libc::madvise(start as *mut libc::c_void, end - start, libc::MADV_DONTNEED);
+        }
     }
 }
 

--- a/crates/perry-runtime/src/buffer/detach.rs
+++ b/crates/perry-runtime/src/buffer/detach.rs
@@ -57,9 +57,18 @@ pub fn detach_array_buffer(addr: usize) {
     // Buffer-shaped views (`new Uint8Array(ab)`, DataView slices): zero their
     // own header lengths so `.length`/`.byteLength` report 0 and every indexed
     // access is out-of-bounds, matching Node's view-over-detached semantics.
-    super::view::for_each_view(addr, |view_ptr, _info| unsafe {
-        let view = view_ptr as *mut BufferHeader;
-        (*view).length = 0;
+    // `ArrayBuffer.prototype.slice` results also land in the view table (the
+    // Buffer.slice aliasing mechanism registers them), but they are
+    // independent COPIES per spec and must survive the source's detach —
+    // they're the only view-table entries marked as ArrayBuffers, so skip
+    // those.
+    super::view::for_each_view(addr, |view_ptr, _info| {
+        if is_array_buffer(view_ptr) {
+            return;
+        }
+        unsafe {
+            (*(view_ptr as *mut BufferHeader)).length = 0;
+        }
     });
     // Typed-array views (`new Float32Array(ab, ...)`) record their backing in
     // a separate side table; zero those lengths too.

--- a/crates/perry-runtime/src/buffer/from.rs
+++ b/crates/perry-runtime/src/buffer/from.rs
@@ -531,6 +531,11 @@ pub extern "C" fn js_uint8array_new(val: f64) -> *mut BufferHeader {
             // Issue #227 (the prior memcpy branch) was about avoiding
             // f64-misinterpretation; aliasing also avoids it.
             if is_any_array_buffer(raw) {
+                if super::detach::is_detached_buffer(raw) {
+                    crate::collection_iter::throw_type_error(
+                        "Cannot perform Construct on a detached ArrayBuffer",
+                    );
+                }
                 let src = raw as *const BufferHeader;
                 unsafe {
                     let len = (*src).length as i32;
@@ -636,7 +641,7 @@ pub extern "C" fn js_uint8array_view(
     }
 }
 
-fn zeroed_array_buffer_storage(size: i32) -> *mut BufferHeader {
+pub(super) fn zeroed_array_buffer_storage(size: i32) -> *mut BufferHeader {
     let size = size.max(0) as u32;
     let buf = buffer_alloc(size);
     unsafe {
@@ -657,7 +662,7 @@ fn throw_array_buffer_range_error() -> ! {
     crate::fs::validate::throw_range_error_with_code("Invalid array buffer length")
 }
 
-fn array_buffer_to_index(value: f64) -> i32 {
+pub(super) fn array_buffer_to_index(value: f64) -> i32 {
     let jv = crate::value::JSValue::from_bits(value.to_bits());
     if jv.is_undefined() {
         return 0;
@@ -803,6 +808,11 @@ pub extern "C" fn js_data_view_new(value: f64, offset_value: f64, length_value: 
     let addr = v.as_pointer::<u8>() as usize;
     if addr == 0 || !is_registered_buffer(addr) {
         throw_dataview_buffer_not_object();
+    }
+    if super::detach::is_detached_buffer(addr) {
+        crate::collection_iter::throw_type_error(
+            "Cannot perform Construct on a detached ArrayBuffer",
+        );
     }
 
     // Steps 4-6: offset = ToIndex(byteOffset) (RangeError if negative).

--- a/crates/perry-runtime/src/buffer/from.rs
+++ b/crates/perry-runtime/src/buffer/from.rs
@@ -809,14 +809,15 @@ pub extern "C" fn js_data_view_new(value: f64, offset_value: f64, length_value: 
     if addr == 0 || !is_registered_buffer(addr) {
         throw_dataview_buffer_not_object();
     }
+    // Steps 4-6: offset = ToIndex(byteOffset) (RangeError if negative). Runs
+    // BEFORE the detached check — ToIndex can execute user code (`valueOf`)
+    // that detaches the buffer, and the spec checks IsDetachedBuffer after.
+    let offset = dataview_to_index(offset_value, "byteOffset");
     if super::detach::is_detached_buffer(addr) {
         crate::collection_iter::throw_type_error(
             "Cannot perform Construct on a detached ArrayBuffer",
         );
     }
-
-    // Steps 4-6: offset = ToIndex(byteOffset) (RangeError if negative).
-    let offset = dataview_to_index(offset_value, "byteOffset");
 
     let src = addr as *const BufferHeader;
     let total_len = unsafe { (*src).length as i64 };
@@ -838,6 +839,15 @@ pub extern "C" fn js_data_view_new(value: f64, offset_value: f64, length_value: 
         }
         requested
     };
+
+    // Spec step 12's second IsDetachedBuffer check: ToIndex(byteLength) above
+    // can also run user code that detaches the buffer; re-check before
+    // touching its bytes.
+    if super::detach::is_detached_buffer(addr) {
+        crate::collection_iter::throw_type_error(
+            "Cannot perform Construct on a detached ArrayBuffer",
+        );
+    }
 
     // Build a registered view so the numeric accessors index
     // relative to the view start and `.byteOffset`/`.byteLength`/`.buffer`

--- a/crates/perry-runtime/src/buffer/from.rs
+++ b/crates/perry-runtime/src/buffer/from.rs
@@ -597,11 +597,17 @@ pub extern "C" fn js_uint8array_new(val: f64) -> *mut BufferHeader {
 /// `new Uint8Array(buffer, byteOffset, length)` — create a Uint8Array view
 /// over ArrayBuffer-like storage. Perry's BufferHeader model represents the
 /// view with a sliced buffer registered against the original backing store.
+///
+/// `offset_value` / `length_value` are the raw NaN-boxed arguments
+/// (`undefined` when absent), matching the other typed-array view kinds:
+/// ToIndex runs here — it can execute user code (`valueOf`) that detaches
+/// the source — and per spec the IsDetachedBuffer check and all bounds
+/// validation happen after both coercions.
 #[no_mangle]
 pub extern "C" fn js_uint8array_view(
     source: f64,
-    byte_offset: i32,
-    requested_length: i32,
+    offset_value: f64,
+    length_value: f64,
 ) -> *mut BufferHeader {
     let bits = source.to_bits();
     if (bits >> 48) != 0x7FFD {
@@ -611,29 +617,44 @@ pub extern "C" fn js_uint8array_view(
     if !is_registered_buffer(raw) || !is_any_array_buffer(raw) {
         return js_uint8array_new(source);
     }
+    let byte_offset = crate::typedarray_view::typed_array_view_to_index(offset_value);
+    let length_jv = crate::value::JSValue::from_bits(length_value.to_bits());
+    let requested = if length_jv.is_undefined() {
+        None
+    } else {
+        Some(crate::typedarray_view::typed_array_view_to_index(
+            length_value,
+        ))
+    };
+    if super::detach::is_detached_buffer(raw) {
+        crate::collection_iter::throw_type_error(
+            "Cannot perform Construct on a detached ArrayBuffer",
+        );
+    }
     let src = raw as *const BufferHeader;
     unsafe {
-        let total_len = (*src).length as i32;
+        let total_len = (*src).length as i64;
         // #4103: spec `RangeError` for an out-of-range view. `BYTES_PER_ELEMENT`
         // is 1 for `Uint8Array`, so there is no alignment constraint — only the
         // offset and (offset + length) bounds against the backing buffer.
-        if byte_offset < 0 || byte_offset > total_len {
+        if byte_offset > total_len {
             crate::fs::validate::throw_range_error_with_code(&format!(
                 "Start offset {byte_offset} is outside the bounds of the buffer"
             ));
         }
-        if requested_length >= 0 && byte_offset.saturating_add(requested_length) > total_len {
-            crate::fs::validate::throw_range_error_with_code(&format!(
-                "Invalid typed array length: {requested_length}"
-            ));
+        if let Some(requested) = requested {
+            if byte_offset.saturating_add(requested) > total_len {
+                crate::fs::validate::throw_range_error_with_code(&format!(
+                    "Invalid typed array length: {requested}"
+                ));
+            }
         }
-        let start = byte_offset.clamp(0, total_len);
-        let len = if requested_length < 0 {
-            total_len.saturating_sub(start)
-        } else {
-            requested_length.max(0)
+        let start = byte_offset.clamp(0, total_len) as i32;
+        let len = match requested {
+            None => (total_len - byte_offset).max(0) as i32,
+            Some(requested) => requested.max(0) as i32,
         };
-        let end = start.saturating_add(len).min(total_len);
+        let end = start.saturating_add(len).min(total_len as i32);
         let view = js_buffer_slice(src, start, end);
         mark_as_uint8array(view as usize);
         set_buffer_ab_alias(view as usize, resolve_buffer_ab_alias(raw));

--- a/crates/perry-runtime/src/buffer/header.rs
+++ b/crates/perry-runtime/src/buffer/header.rs
@@ -490,6 +490,7 @@ pub(crate) fn finalize_collected_dead_buffer(addr: usize) {
     BUFFER_AB_ALIAS.with(|r| {
         r.borrow_mut().remove(&addr);
     });
+    super::detach::remove_detached_entry_for_dead_buffer(addr);
     super::view::remove_entries_for_dead_buffer(addr);
 }
 

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -45,8 +45,11 @@ pub(crate) use header::{
 };
 
 // ---- Re-exports: ArrayBuffer detach / transfer (ES2024) ----
-pub(crate) use detach::array_buffer_transfer;
-pub use detach::{detach_array_buffer, is_detached_buffer};
+// `detach_array_buffer` dereferences the raw address it is given, so it stays
+// crate-internal; only the side-effect-free `is_detached_buffer` probe is
+// part of the public surface.
+pub use detach::is_detached_buffer;
+pub(crate) use detach::{array_buffer_transfer, detach_array_buffer};
 
 // ---- Re-exports: Buffer.from / alloc / concat (FFI) ----
 pub use from::{

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -14,6 +14,7 @@ mod coding;
 mod copy_bytes;
 mod copy_write;
 mod dataview;
+mod detach;
 mod encode;
 mod from;
 mod header;
@@ -42,6 +43,10 @@ pub use header::{
 pub(crate) use header::{
     collect_dead_registered_buffers_post_trace, finalize_collected_dead_buffer,
 };
+
+// ---- Re-exports: ArrayBuffer detach / transfer (ES2024) ----
+pub(crate) use detach::array_buffer_transfer;
+pub use detach::{detach_array_buffer, is_detached_buffer};
 
 // ---- Re-exports: Buffer.from / alloc / concat (FFI) ----
 pub use from::{

--- a/crates/perry-runtime/src/builtins/globals.rs
+++ b/crates/perry-runtime/src/builtins/globals.rs
@@ -507,13 +507,14 @@ fn record_transfer_clone(src: usize, cloned: usize) {
     });
 }
 
-fn detach_unseen_transferables() {
+/// Detach every transfer-list buffer. Runs only AFTER the whole clone
+/// succeeded (HTML structured-clone semantics): a `DataCloneError` thrown
+/// mid-walk must leave all source buffers attached, so no detachment happens
+/// during cloning itself. Idempotent per buffer.
+fn detach_transferables_after_success() {
     STRUCTURED_CLONE_TRANSFER_STATE.with(|state| {
         if let Some(state) = state.borrow().as_ref() {
             for addr in &state.transferables {
-                if state.clones.contains_key(addr) {
-                    continue;
-                }
                 crate::buffer::detach_array_buffer(*addr);
             }
         }
@@ -521,6 +522,12 @@ fn detach_unseen_transferables() {
 }
 
 fn clone_buffer_header(addr: usize, detach_source: bool) -> f64 {
+    // An already-detached ArrayBuffer cannot be serialized — transferring it
+    // is rejected earlier by `collect_transfer_list`, and plain cloning must
+    // throw rather than produce a fresh empty buffer.
+    if crate::buffer::is_detached_buffer(addr) {
+        throw_data_clone_error("An ArrayBuffer is detached and could not be cloned");
+    }
     if detach_source {
         if let Some(existing) = transfer_existing_clone(addr) {
             return crate::value::js_nanbox_pointer(existing as i64);
@@ -557,8 +564,10 @@ fn clone_buffer_header(addr: usize, detach_source: bool) -> f64 {
     }
 
     if detach_source {
+        // Record only — detachment is deferred to
+        // `detach_transferables_after_success` so a clone that fails later in
+        // the walk leaves the source attached.
         record_transfer_clone(addr, dst_addr);
-        crate::buffer::detach_array_buffer(addr);
     }
 
     crate::value::js_nanbox_pointer(dst_addr as i64)
@@ -628,7 +637,7 @@ pub extern "C" fn js_structured_clone_with_options(value: f64, options: f64) -> 
     });
     let _guard = CloneTransferStateGuard(previous);
     let cloned = js_structured_clone_inner(value);
-    detach_unseen_transferables();
+    detach_transferables_after_success();
     cloned
 }
 

--- a/crates/perry-runtime/src/builtins/globals.rs
+++ b/crates/perry-runtime/src/builtins/globals.rs
@@ -514,11 +514,7 @@ fn detach_unseen_transferables() {
                 if state.clones.contains_key(addr) {
                     continue;
                 }
-                unsafe {
-                    let src = *addr as *mut crate::buffer::BufferHeader;
-                    (*src).length = 0;
-                    (*src).capacity = 0;
-                }
+                crate::buffer::detach_array_buffer(*addr);
             }
         }
     });
@@ -562,10 +558,7 @@ fn clone_buffer_header(addr: usize, detach_source: bool) -> f64 {
 
     if detach_source {
         record_transfer_clone(addr, dst_addr);
-        unsafe {
-            (*src).length = 0;
-            (*src).capacity = 0;
-        }
+        crate::buffer::detach_array_buffer(addr);
     }
 
     crate::value::js_nanbox_pointer(dst_addr as i64)
@@ -605,6 +598,9 @@ fn collect_transfer_list(options: f64) -> std::collections::HashSet<usize> {
             || crate::buffer::is_shared_array_buffer(item_addr)
         {
             throw_data_clone_error("Found invalid value in transferList");
+        }
+        if crate::buffer::is_detached_buffer(item_addr) {
+            throw_data_clone_error("ArrayBuffer is already detached");
         }
         if !out.insert(item_addr) {
             throw_data_clone_error("Transfer list contains duplicate ArrayBuffer");

--- a/crates/perry-runtime/src/gc/policy.rs
+++ b/crates/perry-runtime/src/gc/policy.rs
@@ -1885,6 +1885,40 @@ fn manual_gc_collect_now() {
     crate::weakref::queue_pending_finalization_callbacks_after_gc();
 }
 
+/// `perry/gc` `collect()` — explicit full collection, same semantics as the
+/// global `gc()`. Returns `undefined` so the JS surface has a stable shape.
+#[no_mangle]
+pub extern "C" fn js_gc_module_collect() -> f64 {
+    js_gc_collect();
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+/// `perry/gc` `minor()` — synchronous nursery-only collection; returns the
+/// freed byte count (0 when skipped: unsafe zone or deferred). Like `gc()`,
+/// the callsite may hold live locals only on the native stack, so force the
+/// conservative scan (#4977).
+#[no_mangle]
+pub extern "C" fn js_gc_module_minor() -> f64 {
+    if manual_gc_blocked_by_unsafe_zone() {
+        return 0.0;
+    }
+    let _scan = super::roots::ManualGcScanGuard::force_full_scan();
+    super::gc_collect_minor() as f64
+}
+
+/// `perry/gc` `idleHint()` — frame-boundary pacing hint for latency-sensitive
+/// programs (games, interactive UIs). If a threshold-driven collection is
+/// already due, run it NOW — at a point the caller declared idle — instead of
+/// letting it land mid-frame at an arbitrary allocation site. O(1) when
+/// nothing is due. Returns whether a collection ran.
+#[no_mangle]
+pub extern "C" fn js_gc_module_idle_hint() -> f64 {
+    let before = gc_total_collection_count();
+    gc_check_trigger();
+    let ran = gc_total_collection_count() != before;
+    f64::from_bits(crate::value::JSValue::bool(ran).bits())
+}
+
 pub(super) fn gc_blocked_by_unsafe_zone() -> bool {
     GC_UNSAFE_ZONES.load(std::sync::atomic::Ordering::Acquire) > 0
 }

--- a/crates/perry-runtime/src/gc/telemetry.rs
+++ b/crates/perry-runtime/src/gc/telemetry.rs
@@ -1197,6 +1197,12 @@ pub(super) fn gc_last_pause_us() -> u64 {
     GC_STATS.with(|stats| stats.borrow().last_pause_us)
 }
 
+/// Total collections so far on this thread. `js_gc_module_idle_hint` compares
+/// this before/after a trigger check to report whether a collection ran.
+pub(super) fn gc_total_collection_count() -> u64 {
+    GC_STATS.with(|stats| stats.borrow().collection_count)
+}
+
 impl GcCollectOutcome {
     #[inline]
     pub(super) fn emit_after_current(self) -> u64 {

--- a/crates/perry-runtime/src/object/buffer_dispatch.rs
+++ b/crates/perry-runtime/src/object/buffer_dispatch.rs
@@ -466,11 +466,32 @@ pub unsafe fn dispatch_buffer_method(
         "inspect" => {
             crate::builtins::js_util_inspect(buf_f64, f64::from_bits(crate::value::TAG_UNDEFINED))
         }
+        // ES2024 `ArrayBuffer.prototype.transfer` / `transferToFixedLength`.
+        // Scoped to plain ArrayBuffers: SharedArrayBuffer and Uint8Array/Buffer
+        // receivers don't have these methods in Node, so they keep falling
+        // through to the catch-all like any other unknown method.
+        "transfer" | "transferToFixedLength"
+            if crate::buffer::is_array_buffer(addr)
+                && !crate::buffer::is_shared_array_buffer(addr)
+                && !crate::buffer::is_data_view(addr) =>
+        {
+            crate::buffer::array_buffer_transfer(addr, args)
+        }
         "slice" | "subarray" => {
             let len = (*buf_ptr).length as i32;
             let (start, end) = if crate::buffer::is_array_buffer(addr)
                 || crate::buffer::is_shared_array_buffer(addr)
             {
+                // A detached ArrayBuffer refuses slice with a TypeError
+                // (ES2024 DetachArrayBuffer; `transfer` is the only detach
+                // source in Perry).
+                if crate::buffer::is_detached_buffer(addr)
+                    && !crate::buffer::is_shared_array_buffer(addr)
+                {
+                    crate::collection_iter::throw_type_error(
+                        "Cannot perform ArrayBuffer.prototype.slice on a detached ArrayBuffer",
+                    );
+                }
                 // ArrayBuffer / SharedArrayBuffer.prototype.slice: ToIntegerOrInfinity
                 // on `start` (always) and `end` (defaults to len when undefined),
                 // running an object arg's `valueOf` in left-to-right order. Plain

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
@@ -261,13 +261,21 @@ pub(crate) fn get_field_by_name_object_tail(
                 // on ArrayBuffer (not DataView/SharedArrayBuffer/typed arrays),
                 // which return `undefined` for them in Node — so scope to a
                 // plain registered ArrayBuffer.
-                if (key_bytes == b"resizable" || key_bytes == b"maxByteLength")
+                if (key_bytes == b"resizable"
+                    || key_bytes == b"maxByteLength"
+                    || key_bytes == b"detached")
                     && crate::buffer::is_array_buffer(obj as usize)
                     && !crate::buffer::is_data_view(obj as usize)
                     && !crate::buffer::is_shared_array_buffer(obj as usize)
                 {
                     if key_bytes == b"resizable" {
                         return JSValue::bool(false);
+                    }
+                    // `detached` (ES2024) — true after a successful
+                    // `transfer`/`transferToFixedLength`/structuredClone
+                    // transfer.
+                    if key_bytes == b"detached" {
+                        return JSValue::bool(crate::buffer::is_detached_buffer(obj as usize));
                     }
                     let b = obj as *const crate::buffer::BufferHeader;
                     return JSValue::number(crate::buffer::js_buffer_length(b) as f64);

--- a/crates/perry-runtime/src/typedarray_view.rs
+++ b/crates/perry-runtime/src/typedarray_view.rs
@@ -72,6 +72,9 @@ pub extern "C" fn js_typed_array_view(
     if !crate::buffer::is_registered_buffer(addr) || !crate::buffer::is_any_array_buffer(addr) {
         return js_typed_array_new(kind as i32, source);
     }
+    if crate::buffer::is_detached_buffer(addr) {
+        crate::typedarray::throw_type_error(b"Cannot perform Construct on a detached ArrayBuffer");
+    }
     let bpe = elem_size_for_kind(kind) as i64;
     let src = addr as *const crate::buffer::BufferHeader;
     let total_len = unsafe { (*src).length as i64 };
@@ -182,6 +185,25 @@ static VIEW_META_COUNT: AtomicUsize = AtomicUsize::new(0);
 #[inline]
 pub(crate) fn any_view_meta() -> bool {
     VIEW_META_COUNT.load(Ordering::Relaxed) != 0
+}
+
+/// DetachArrayBuffer support (ES2024 `ArrayBuffer.prototype.transfer`): zero
+/// the length of every typed array aliasing `backing` so views over a
+/// detached buffer report length 0 and every indexed read is out-of-bounds
+/// (`undefined`), matching Node.
+pub(crate) fn zero_views_of_detached_backing(backing: usize) {
+    if !any_view_meta() {
+        return;
+    }
+    TYPED_ARRAY_VIEW_META.with(|r| {
+        for (&ta, meta) in r.borrow().iter() {
+            if meta.backing == backing {
+                unsafe {
+                    (*(ta as *mut TypedArrayHeader)).length = 0;
+                }
+            }
+        }
+    });
 }
 
 /// Record `ta` as aliasing `backing` at `byte_offset`. After this call

--- a/crates/perry-runtime/src/typedarray_view.rs
+++ b/crates/perry-runtime/src/typedarray_view.rs
@@ -72,13 +72,12 @@ pub extern "C" fn js_typed_array_view(
     if !crate::buffer::is_registered_buffer(addr) || !crate::buffer::is_any_array_buffer(addr) {
         return js_typed_array_new(kind as i32, source);
     }
-    if crate::buffer::is_detached_buffer(addr) {
-        crate::typedarray::throw_type_error(b"Cannot perform Construct on a detached ArrayBuffer");
-    }
     let bpe = elem_size_for_kind(kind) as i64;
-    let src = addr as *const crate::buffer::BufferHeader;
-    let total_len = unsafe { (*src).length as i64 };
 
+    // ES ordering (InitializeTypedArrayFromArrayBuffer): ToIndex(byteOffset)
+    // and ToIndex(length) run BEFORE the IsDetachedBuffer check — either can
+    // execute user code (`valueOf`) that detaches the buffer — so all buffer
+    // reads and bounds checks happen after, against post-coercion state.
     let offset = typed_array_view_to_index(offset_value);
     if bpe > 1 && offset % bpe != 0 {
         throw_range_error(
@@ -90,32 +89,44 @@ pub extern "C" fn js_typed_array_view(
             .as_bytes(),
         );
     }
+    let length_jv = crate::value::JSValue::from_bits(length_value.to_bits());
+    let requested = if length_jv.is_undefined() {
+        None
+    } else {
+        Some(typed_array_view_to_index(length_value))
+    };
+    if crate::buffer::is_detached_buffer(addr) {
+        crate::typedarray::throw_type_error(b"Cannot perform Construct on a detached ArrayBuffer");
+    }
+    let src = addr as *const crate::buffer::BufferHeader;
+    let total_len = unsafe { (*src).length as i64 };
     if offset > total_len {
         throw_range_error(
             format!("Start offset {offset} is outside the bounds of the buffer").as_bytes(),
         );
     }
 
-    let length_jv = crate::value::JSValue::from_bits(length_value.to_bits());
-    let elem_count = if length_jv.is_undefined() {
-        let remaining = total_len - offset;
-        if bpe > 1 && remaining % bpe != 0 {
-            throw_range_error(
-                format!(
-                    "byte length of {} should be a multiple of {}",
-                    name_for_kind(kind),
-                    bpe
-                )
-                .as_bytes(),
-            );
+    let elem_count = match requested {
+        None => {
+            let remaining = total_len - offset;
+            if bpe > 1 && remaining % bpe != 0 {
+                throw_range_error(
+                    format!(
+                        "byte length of {} should be a multiple of {}",
+                        name_for_kind(kind),
+                        bpe
+                    )
+                    .as_bytes(),
+                );
+            }
+            remaining / bpe
         }
-        remaining / bpe
-    } else {
-        let requested = typed_array_view_to_index(length_value);
-        if offset + requested * bpe > total_len {
-            throw_range_error(format!("Invalid typed array length: {requested}").as_bytes());
+        Some(requested) => {
+            if offset + requested * bpe > total_len {
+                throw_range_error(format!("Invalid typed array length: {requested}").as_bytes());
+            }
+            requested
         }
-        requested
     };
 
     let count = elem_count.max(0) as u32;

--- a/crates/perry-runtime/src/typedarray_view.rs
+++ b/crates/perry-runtime/src/typedarray_view.rs
@@ -21,7 +21,7 @@ use crate::typedarray::{
 /// arguments (#4103): `undefined` / `NaN` → 0, otherwise `ToIntegerOrInfinity`
 /// truncated toward zero, with a `RangeError` for a negative or
 /// out-of-`[[0, 2^53-1]]` result.
-fn typed_array_view_to_index(value: f64) -> i64 {
+pub(crate) fn typed_array_view_to_index(value: f64) -> i64 {
     let jv = crate::value::JSValue::from_bits(value.to_bits());
     if jv.is_undefined() {
         return 0;

--- a/crates/perry/src/commands/types.rs
+++ b/crates/perry/src/commands/types.rs
@@ -21,6 +21,7 @@ pub struct TypesArgs {
 // Canonical `.d.ts` sources, embedded at compile time from `types/perry/`.
 const PERRY_UI_DTS: &str = include_str!("../../../../types/perry/ui/index.d.ts");
 const PERRY_THREAD_DTS: &str = include_str!("../../../../types/perry/thread/index.d.ts");
+const PERRY_GC_DTS: &str = include_str!("../../../../types/perry/gc/index.d.ts");
 const PERRY_I18N_DTS: &str = include_str!("../../../../types/perry/i18n/index.d.ts");
 const PERRY_SYSTEM_DTS: &str = include_str!("../../../../types/perry/system/index.d.ts");
 const PERRY_MEDIA_DTS: &str = include_str!("../../../../types/perry/media/index.d.ts");
@@ -45,6 +46,7 @@ pub fn write_perry_type_stubs(project_path: &Path, quiet: bool) -> Result<()> {
     let modules: &[(&str, &str)] = &[
         ("ui", PERRY_UI_DTS),
         ("thread", PERRY_THREAD_DTS),
+        ("gc", PERRY_GC_DTS),
         ("i18n", PERRY_I18N_DTS),
         ("system", PERRY_SYSTEM_DTS),
         ("media", PERRY_MEDIA_DTS),

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1952 entries across 114 modules
+// Coverage: 1955 entries across 115 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -2495,6 +2495,15 @@ declare module "perry/container-compose" {
   export function stop(...args: any[]): any;
   /** stdlib */
   export function up(...args: any[]): any;
+}
+
+declare module "perry/gc" {
+  /** stdlib */
+  export function collect(): void;
+  /** stdlib */
+  export function idleHint(): boolean;
+  /** stdlib */
+  export function minor(): number;
 }
 
 declare module "perry/i18n" {

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -169,6 +169,7 @@
 # Internals
 
 - [Memory Model](internals/memory-model.md)
+- [Explicit Memory Control](internals/explicit-memory.md)
 
 # Contributing
 

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2826 entries across 116 modules.
+Total: 2829 entries across 117 modules.
 
 ## Modules
 
@@ -73,6 +73,7 @@ Total: 2826 entries across 116 modules.
 - [`perry/compose`](#perry-compose)
 - [`perry/container`](#perry-container)
 - [`perry/container-compose`](#perry-container-compose)
+- [`perry/gc`](#perry-gc)
 - [`perry/i18n`](#perry-i18n)
 - [`perry/media`](#perry-media)
 - [`perry/plugin`](#perry-plugin)
@@ -2351,6 +2352,14 @@ Total: 2826 entries across 116 modules.
 - `start` — module
 - `stop` — module
 - `up` — module
+
+## `perry/gc`
+
+### Methods
+
+- `collect` — module
+- `idleHint` — module
+- `minor` — module
 
 ## `perry/i18n`
 

--- a/docs/src/internals/explicit-memory.md
+++ b/docs/src/internals/explicit-memory.md
@@ -1,0 +1,69 @@
+# Explicit Memory Control
+
+JavaScript has no `free()`. For most programs that's the right default — Perry's
+generational GC (see [Memory Model](memory-model.md)) decides when to collect.
+But latency-sensitive programs (games, interactive UIs) and programs that churn
+large binary buffers sometimes need to *choose the moment*: run the collection
+between frames, not in the middle of one; release a 100 MB texture now, not at
+the next full cycle. Perry gives you two standard-shaped tools for that.
+
+## `ArrayBuffer.prototype.transfer()` (ES2024)
+
+`transfer(newLength?)` moves an ArrayBuffer's contents into a new buffer and
+**detaches** the source: its `byteLength` becomes 0, `detached` reports `true`,
+views over it report length 0, and any further `transfer`/`slice`/view
+construction on it throws a `TypeError`. This is standard ECMAScript — the same
+code runs under Node and Bun unchanged.
+
+```ts
+let scratch = new ArrayBuffer(64 * 1024 * 1024);
+// ... use it ...
+scratch = scratch.transfer(0); // detach: the 64 MB backing is released
+```
+
+Perry gives detach real teeth: buffer bytes live inline in the GC heap, so the
+runtime hands the page-aligned interior of a detached payload back to the OS
+immediately (`madvise`). A large detached buffer stops costing RSS the moment
+you transfer it, even while the (now empty) ArrayBuffer object is still
+reachable. `transferToFixedLength()` behaves identically (Perry has no
+resizable ArrayBuffers), and `structuredClone(v, { transfer: [...] })` detaches
+through the same path.
+
+## `perry/gc` — collection pacing
+
+A Perry-native module in the spirit of `perry/thread`: it compiles to direct
+runtime calls and does not resolve under Node/Bun, so guard the import if the
+source must also run there.
+
+```ts
+import { collect, minor, idleHint } from "perry/gc";
+
+collect();  // full collection now — same as the global gc()
+minor();    // nursery-only collection now; returns freed bytes
+idleHint(); // "this is a good moment": runs a collection only if one
+            // is already due by the normal thresholds; returns whether
+            // one ran. O(1) when nothing is due.
+```
+
+`idleHint()` is the one to reach for in a frame loop: call it once per frame
+after presenting. When allocation pressure has made a collection imminent, it
+runs at your chosen boundary instead of landing mid-frame at whatever
+allocation happens to trip the threshold:
+
+```ts
+function frame() {
+  update();
+  render();
+  idleHint(); // GC pause (if any) happens here, not inside update()
+  requestFrame(frame);
+}
+```
+
+## What Perry deliberately does NOT provide
+
+A `free(value)` / `forget(value)` API. With a tracing GC, "free this object
+now" is either equivalent to dropping the reference (which the compiler already
+tracks) or it dangles every other reference to the object — a use-after-free
+factory. The two mechanisms above cover the real use cases — bulk binary data
+(`transfer`) and pause timing (`perry/gc`) — without making any correct program
+crash.

--- a/test-files/test_gap_arraybuffer_transfer.ts
+++ b/test-files/test_gap_arraybuffer_transfer.ts
@@ -1,0 +1,75 @@
+// ArrayBuffer.prototype.transfer / transferToFixedLength / detached (ES2024).
+// Compared byte-for-byte against `node --experimental-strip-types`.
+
+// Basic transfer: contents move, source detaches.
+const ab = new ArrayBuffer(8);
+const u8 = new Uint8Array(ab);
+u8[0] = 42;
+u8[7] = 7;
+console.log(ab.byteLength, ab.detached);
+
+const moved = ab.transfer();
+console.log(moved.byteLength, moved.detached);
+const mv = new Uint8Array(moved);
+console.log(mv[0], mv[7]);
+console.log(ab.byteLength, ab.detached);
+console.log(u8.length);
+
+// Growing transfer zero-fills the tail.
+const grown = moved.transfer(16);
+const gv = new Uint8Array(grown);
+console.log(grown.byteLength, gv[0], gv[7], gv[8], gv[15]);
+
+// Shrinking transfer truncates.
+const shrunk = grown.transfer(4);
+const sv = new Uint8Array(shrunk);
+console.log(shrunk.byteLength, sv.length, sv[0]);
+
+// transferToFixedLength behaves like transfer (no resizable buffers here).
+const fixed = shrunk.transferToFixedLength(6);
+console.log(fixed.byteLength, fixed.detached, shrunk.detached);
+
+// slice() copies survive a later detach of their source.
+const src = new ArrayBuffer(4);
+new Uint8Array(src)[0] = 9;
+const copy = src.slice(0);
+src.transfer();
+console.log(copy.byteLength, new Uint8Array(copy)[0]);
+
+// Error cases.
+try {
+  shrunk.transfer();
+} catch (e) {
+  console.log("re-transfer:", (e as Error).name);
+}
+try {
+  fixed.transfer(-1);
+} catch (e) {
+  console.log("negative-length:", (e as Error).name);
+}
+try {
+  shrunk.slice(0);
+} catch (e) {
+  console.log("slice-detached:", (e as Error).name);
+}
+try {
+  new Uint8Array(shrunk);
+} catch (e) {
+  console.log("view-detached:", (e as Error).name);
+}
+try {
+  new DataView(shrunk);
+} catch (e) {
+  console.log("dataview-detached:", (e as Error).name);
+}
+
+// structuredClone transfer detaches the source the same way.
+const big = new ArrayBuffer(32);
+new Uint8Array(big)[0] = 5;
+const cloned = structuredClone(big, { transfer: [big] });
+console.log(cloned.byteLength, new Uint8Array(cloned)[0], big.detached, big.byteLength);
+try {
+  structuredClone(big, { transfer: [big] });
+} catch (e) {
+  console.log("re-clone:", (e as Error).name);
+}

--- a/test-files/test_gap_arraybuffer_transfer.ts
+++ b/test-files/test_gap_arraybuffer_transfer.ts
@@ -73,3 +73,56 @@ try {
 } catch (e) {
   console.log("re-clone:", (e as Error).name);
 }
+
+// Coercion ordering: ToIndex(newLength/byteOffset) runs BEFORE the detached
+// check and can itself detach the buffer via valueOf (spec ordering).
+const vb = new ArrayBuffer(8);
+try {
+  vb.transfer({
+    valueOf() {
+      vb.transfer();
+      return 4;
+    },
+  } as any);
+} catch (e) {
+  console.log("transfer-valueof-detach:", (e as Error).name);
+}
+const dvb = new ArrayBuffer(8);
+try {
+  new DataView(dvb, {
+    valueOf() {
+      dvb.transfer();
+      return 0;
+    },
+  } as any);
+} catch (e) {
+  console.log("dataview-valueof-detach:", (e as Error).name);
+}
+const tvb = new ArrayBuffer(8);
+try {
+  new Uint8Array(tvb, {
+    valueOf() {
+      tvb.transfer();
+      return 0;
+    },
+  } as any);
+} catch (e) {
+  console.log("typedarray-valueof-detach:", (e as Error).name);
+}
+
+// Cloning an already-detached buffer (no transfer list) throws.
+const det = new ArrayBuffer(4);
+det.transfer();
+try {
+  structuredClone(det);
+} catch (e) {
+  console.log("clone-detached:", (e as Error).name);
+}
+
+// A clone that FAILS must leave transfer-list buffers attached.
+const keep = new ArrayBuffer(4);
+try {
+  structuredClone({ b: keep, f: () => 1 }, { transfer: [keep] });
+} catch (e) {
+  console.log("failed-clone-keeps:", (e as Error).name, keep.detached, keep.byteLength);
+}

--- a/test-files/test_perry_gc_module.ts
+++ b/test-files/test_perry_gc_module.ts
@@ -1,0 +1,25 @@
+// perry/gc — explicit GC control (Perry-native module; does not run under
+// Node, so the parity harness records NODE_FAIL and skips it).
+import { collect, idleHint, minor } from "perry/gc";
+
+// Churn some garbage so the collections below have work to do.
+let sum = 0;
+for (let i = 0; i < 200000; i++) {
+  const arr = new Array(16).fill(i);
+  sum += arr[0] as number;
+}
+console.log("churned:", sum > 0);
+
+const freed = minor();
+console.log("minor returns number:", typeof freed === "number", freed >= 0);
+
+const hinted = idleHint();
+console.log("idleHint returns boolean:", typeof hinted === "boolean");
+
+const r = collect();
+console.log("collect returns undefined:", r === undefined);
+
+// Still alive and allocating after explicit collections.
+const arr = [1, 2, 3].map((x) => x * 2);
+console.log("post-gc allocation:", arr.join(","));
+console.log("done");

--- a/types/perry/gc/index.d.ts
+++ b/types/perry/gc/index.d.ts
@@ -1,0 +1,29 @@
+// Type declarations for perry/gc — explicit garbage-collection control.
+// These types are auto-written by `perry init` / `perry types` so IDEs
+// and tsc can resolve `import { ... } from "perry/gc"`.
+//
+// This module is a Perry-native pacing surface (like `perry/thread`): it
+// does not resolve under Node/Bun. Guard imports if the same source must
+// also run there.
+
+/**
+ * Run a full garbage collection now. Same semantics as the global `gc()`:
+ * a complete mark-sweep that also reclaims dead large/tenured objects and
+ * returns freed memory to the OS.
+ */
+export function collect(): void;
+
+/**
+ * Run a minor (nursery-only) collection now and return the number of freed
+ * bytes. Cheaper than `collect()`; useful for explicit pacing in
+ * latency-sensitive loops.
+ */
+export function minor(): number;
+
+/**
+ * Declare an idle point (e.g. a frame boundary). If a threshold-driven
+ * collection is already due, it runs here — at a moment you chose — instead
+ * of landing mid-frame at an arbitrary allocation site. O(1) when nothing
+ * is due. Returns whether a collection ran.
+ */
+export function idleHint(): boolean;

--- a/types/perry/gc/package.json
+++ b/types/perry/gc/package.json
@@ -1,0 +1,3 @@
+{
+  "types": "./index.d.ts"
+}


### PR DESCRIPTION
## What

Two standard-shaped tools for explicit memory control, aimed at latency-sensitive programs (games, interactive UIs) and large-binary-buffer churn:

**1. `ArrayBuffer.prototype.transfer(newLength?)` / `transferToFixedLength(newLength?)` / `detached` (ES2024)**

- `transfer` copies the contents into a fresh zero-filled buffer (`min(old, new)` bytes; growing zero-fills the tail) and detaches the source.
- Detach zeroes the source header (so `byteLength` reads 0), zeroes the length of every registered view over it (`new Uint8Array(ab)` reports length 0 after, matching Node), records the buffer in a detached side-registry (`.detached` getter; `new ArrayBuffer(0)` is empty but NOT detached, so length alone can't be the probe), and — the Perry-specific part — **hands the page-aligned interior of the payload back to the OS** (`MADV_FREE_REUSABLE`→`MADV_FREE` on macOS, `MADV_DONTNEED` on Linux). Buffer bytes live inline in a GC old-arena allocation, so this is what makes "detach = release" true immediately, even while the detached ArrayBuffer object is still reachable. The GcHeader `size` is untouched — the arena sweep still walks the full allocation; only pages entirely inside the payload are decommitted (rounded inward), so neighbors and headers are never affected.
- Detached guards added where the spec demands a `TypeError`: re-`transfer`, `ArrayBuffer.prototype.slice`, `new Uint8Array(detached)` (both the `js_uint8array_new` alias branch and `js_typed_array_view`), `new DataView(detached)`.
- `structuredClone(v, { transfer: [...] })` now detaches through the same shared path (previously it hand-zeroed length/capacity), so transferred sources report `.detached === true`, and re-transferring a detached buffer throws `DataCloneError`.
- Registry hygiene: the detached mark is dropped in `finalize_collected_dead_buffer` so a recycled address can't inherit detached-ness (the #6080 ABA class).

**2. `perry/gc` built-in module** (runtime-only, same pattern as `perry/thread`; does not resolve under Node/Bun)

- `collect()` — full collection, same semantics as the global `gc()`.
- `minor()` — synchronous nursery-only collection with the manual-gc guards (unsafe-zone skip, forced conservative scan per #4977); returns freed bytes.
- `idleHint()` — frame-boundary pacing: runs `gc_check_trigger()` and reports whether a collection ran. If allocation pressure has made a collection due, it lands at the caller-declared idle point instead of mid-frame at an arbitrary allocation site. O(1) when nothing is due. No new GC invariants — it reuses the existing trigger machinery verbatim and detects "ran" via the collection counter.

Wired end-to-end: NATIVE_MODULES + RUNTIME_ONLY_MODULES + manifest signatures (api docs regenerated), codegen native-table rows, `types/perry/gc/index.d.ts` written by `perry init`/`perry types`, docs page under Internals.

## Why not `free(x)`?

Deliberately out of scope: with a tracing GC, a user-facing `free(value)` is either equivalent to dropping the reference or it dangles every other reference to the object. `transfer` (bulk data) + `perry/gc` (pause timing) cover the real use cases without making any correct program crash. The docs page spells this out.

## Validation

- `test-files/test_gap_arraybuffer_transfer.ts` — byte-for-byte parity vs `node --experimental-strip-types` (v26): basic move, grow zero-fill, shrink, `transferToFixedLength`, slice-copy independence, `TypeError` on re-transfer / slice / typed-array / DataView construction over detached, `RangeError` on negative length, structuredClone transfer + `DataCloneError` on re-transfer. PASSES.
- `test-files/test_perry_gc_module.ts` — perry-only functional test (node records NODE_FAIL → auto-skip in the parity harness, same as the perry/thread tests): return shapes + program alive after explicit collections. PASSES.
- Footprint demo (256 MB `new ArrayBuffer` → hold → `transfer(0)` → hold, `vmmap` sampled externally in each window): **291.1 MB → 32.3 MB physical footprint immediately after `transfer(0)`**, while the detached ArrayBuffer object is still alive. Note macOS accounting: `MADV_FREE_REUSABLE` drops `phys_footprint` (Activity Monitor) instantly but `task_info` `resident_size` (what `process.memoryUsage().rss` reads) lags until reuse/pressure — verified with a standalone C probe (REUSABLE returns 0, fp 257 MB → 1 MB, rss unchanged). On Linux `MADV_DONTNEED` drops RSS directly.
- `cargo test -p perry-api-manifest` green; API docs regenerated (`api-docs-drift` gate).
- Full gap suite (isolated worktree target, `PERRY_NO_AUTO_OPTIMIZE=1`): 253/272 pass including the new test. All 19 mismatches reproduce **identically on unmodified `origin/main`** — 16 are triaged in `known_failures.json`; the remaining 3 (`disposablestack_2875`, `events_import_4995`, `http_overloads_3226plus`) were A/B-verified pre-existing by reverting this branch's sources to main in-place, rebuilding, and re-running. Zero regressions from this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `perry/gc` with `collect()`, `minor()`, and `idleHint()` for explicit garbage-collection control.
  * Added `ArrayBuffer.prototype.transfer()` and `transferToFixedLength()` with proper detachment behavior.
  * Implemented detached-buffer status (`detached`) and consistent errors for invalid operations.
* **Bug Fixes**
  * Updated `structuredClone(..., { transfer })` to detach transferred buffers only after a successful clone; detached `ArrayBuffer` cloning/viewing now reliably throws.
* **Documentation**
  * Added API reference entries and explicit memory-control documentation.
* **Tests**
  * Added standalone tests for `ArrayBuffer` transfer/detachment and the `perry/gc` module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->