### PR TITLE
fix(test): report a crashed Perry process as a CRASH, not an output mismatch

### DIFF
--- a/run_parity_tests.sh
+++ b/run_parity_tests.sh
@@ -96,6 +96,25 @@ else
 fi
 
 # Function to run with optional timeout
+# Describe an abnormal Perry exit, or print nothing when the exit is normal.
+# Bash reports a signal death as 128+signo; `timeout` reports 124.
+perry_abnormal_exit() {
+    local code=$1
+    case "$code" in
+        124) echo "TIMEOUT (killed after ${PERRY_RUN_TIMEOUT:-10}s)" ;;
+        132) echo "SIGILL (exit 132)" ;;
+        134) echo "SIGABRT (exit 134)" ;;
+        136) echo "SIGFPE (exit 136)" ;;
+        138) echo "SIGBUS (exit 138)" ;;
+        139) echo "SIGSEGV (exit 139)" ;;
+        *)
+            if [[ "$code" -gt 128 ]]; then
+                echo "signal $((code - 128)) (exit $code)"
+            fi
+            ;;
+    esac
+}
+
 run_with_timeout() {
     local seconds=$1
     shift
@@ -195,10 +214,17 @@ PARITY_FAIL=0
 COMPILE_FAIL=0
 NODE_FAIL=0
 SKIPPED=0
+# Perry died from a signal (SIGSEGV/SIGABRT/…) or hit the run timeout. Tracked
+# separately from PARITY_FAIL: a crash is a *hard* defect, not a formatting
+# nit, and reporting it as a plain "output mismatch" is how the #6271 zlib
+# SIGSEGV sat in main for days — the harness only diffed stdout, so a process
+# dying with exit 139 after printing half its output looked like a benign diff.
+CRASH_FAIL=0
 
 # Arrays for tracking
 declare -a PARITY_FAILURES=()
 declare -a COMPILE_FAILURES=()
+declare -a CRASH_FAILURES=()
 
 # Create output directories
 mkdir -p "$OUTPUT_DIR/node" "$OUTPUT_DIR/perry" "$REPORT_DIR"
@@ -733,6 +759,29 @@ for test_file in "${TEST_FILES[@]}"; do
     # Save Perry output
     echo "$perry_output" > "$perry_output_file"
 
+    # A signal death / timeout is a CRASH, not a parity mismatch. Check it
+    # before either comparison below: a crashed process usually printed a
+    # correct *prefix* of its output and then died, which diffs as a plain
+    # "output mismatch" and reads as a cosmetic gap. That is exactly how the
+    # #6271 zlib SIGSEGV hid behind a green-looking label. Node already exited
+    # 0 to reach this point (non-zero Node => node_fail + skip above), so an
+    # abnormal exit here is unambiguously Perry's.
+    #
+    # Exception: a test carrying its own expected-output file may legitimately
+    # assert a non-zero exit; only *signals*/timeouts are treated as crashes,
+    # never an ordinary non-zero exit like an uncaught throw (exit 1).
+    perry_crash=$(perry_abnormal_exit "$perry_exit")
+    if [[ -n "$perry_crash" ]]; then
+        echo -e "${RED}CRASH${NC} $test_id (${perry_crash})"
+        echo "       Perry died after printing $(printf '%s' "$perry_output" | grep -c '' || true) line(s); Node exited 0."
+        echo "       Last Perry line: $(printf '%s' "$perry_output" | tail -1)"
+        ((CRASH_FAIL++))
+        CRASH_FAILURES+=("$test_id")
+        record_result "$test_id" "crash"
+        [[ -n "$local_server_pid" ]] && stop_tls_upgrade_server
+        continue
+    fi
+
     # For tests that have a stored expected-output file (Perry-specific APIs
     # that don't map 1:1 to Node.js), compare Perry output against the file
     # instead of against Node.js.  This lets us verify Perry's behaviour
@@ -787,7 +836,7 @@ for test_file in "${TEST_FILES[@]}"; do
 done
 
 # Calculate parity percentage
-TOTAL_RUN=$((PARITY_PASS + PARITY_FAIL))
+TOTAL_RUN=$((PARITY_PASS + PARITY_FAIL + CRASH_FAIL))
 if [[ $TOTAL_RUN -gt 0 ]]; then
     PARITY_PCT=$(echo "scale=1; $PARITY_PASS * 100 / $TOTAL_RUN" | bc)
 else
@@ -802,10 +851,21 @@ echo "========================================"
 echo -e "${GREEN}Parity Pass:${NC}   $PARITY_PASS"
 echo -e "${RED}Parity Fail:${NC}   $PARITY_FAIL"
 echo -e "${RED}Compile Fail:${NC}  $COMPILE_FAIL"
+echo -e "${RED}Crashed:${NC}       $CRASH_FAIL"
 echo -e "${YELLOW}Skipped:${NC}       $SKIPPED"
 echo ""
 echo -e "${CYAN}Parity Rate:${NC}   ${PARITY_PCT}%"
 echo ""
+
+# List crashes first — these are hard defects (signal death / timeout), not
+# output nits, and must never be skimmed past as if they were.
+if [[ ${#CRASH_FAILURES[@]} -gt 0 ]]; then
+    echo -e "${RED}CRASHED (signal death / timeout — NOT an output nit):${NC}"
+    for crashed in "${CRASH_FAILURES[@]}"; do
+        echo "  - $crashed"
+    done
+    echo ""
+fi
 
 # List failures
 if [[ ${#PARITY_FAILURES[@]} -gt 0 ]]; then
@@ -834,6 +894,7 @@ cat > "$REPORT_FILE" << EOF
     "parity_pass": $PARITY_PASS,
     "parity_fail": $PARITY_FAIL,
     "compile_fail": $COMPILE_FAIL,
+    "crash_fail": $CRASH_FAIL,
     "node_fail": $NODE_FAIL,
     "skipped": $SKIPPED,
     "total_run": $TOTAL_RUN,
@@ -843,6 +904,8 @@ cat > "$REPORT_FILE" << EOF
     "parity": [$(printf '"%s",' "${PARITY_FAILURES[@]}" | sed 's/,$//')]
 ,
     "compile": [$(printf '"%s",' "${COMPILE_FAILURES[@]}" | sed 's/,$//')]
+,
+    "crash": [$(printf '"%s",' "${CRASH_FAILURES[@]}" | sed 's/,$//')]
 
   },
   "results": [${RESULTS_JSON}]

--- a/scripts/run_gap_tests.sh
+++ b/scripts/run_gap_tests.sh
@@ -54,8 +54,25 @@ fi
 # Every failure in this report is a gap test (we filtered on test_gap_), so the
 # whole failure set is the gap failure set. Drop empty entries (run_parity_tests.sh
 # emits compile: [""] when there are zero compile failures).
-jq -r '(.failures.parity // []) + (.failures.compile // []) | .[] | select(. != "")' \
+jq -r '(.failures.parity // []) + (.failures.compile // []) + (.failures.crash // []) | .[] | select(. != "")' \
   "$REPORT" | sort -u > "$WORK/all_fails.txt"
+
+# Crashes (SIGSEGV/SIGABRT/timeout) are hard defects, never cosmetic gaps.
+# Surface them ALWAYS — including when they are triaged in known_failures.json
+# — so a segfault can never again be filed away as a routine "output mismatch"
+# (that is precisely how the #6271 zlib SIGSEGV stayed invisible while it
+# red-flagged the required conformance gate on ~13 open PRs).
+jq -r '(.failures.crash // []) | .[] | select(. != "")' "$REPORT" | sort -u > "$WORK/crashes.txt"
+if [[ -s "$WORK/crashes.txt" ]]; then
+  echo "" >&2
+  echo "*** CRASHES — Perry died from a signal or timed out (NOT an output nit): ***" >&2
+  sed 's/^/  - /' "$WORK/crashes.txt" >&2
+  echo "" >&2
+  echo "A crash is a hard defect. Even if it is triaged in known_failures.json," >&2
+  echo "it is reported here every run. Reproduce on LINUX — several crash classes" >&2
+  echo "(e.g. handle-band derefs, #6271) are masked on macOS by its 2 TB heap floor." >&2
+  echo "" >&2
+fi
 
 if [[ -f "$KNOWN" ]]; then
   # known_failures.json is keyed by test name; skip the audit-metadata _schema key.


### PR DESCRIPTION
Follow-up to #6271.

## The problem

The gap/parity harness **only diffs stdout**. A Perry process that printed a correct *prefix* of its output and then died from a signal produced a plain `output mismatch` — the exact same label a cosmetic formatting gap gets.

That is how the #6271 zlib **SIGSEGV** stayed invisible. `test_gap_zlib_4917_level` was reported as:

```
FAIL  test_gap_zlib_4917_level (output mismatch)
       Node.js:    deflateRawSync level1 >= level9: true
       Perry:      deflateRawSync level1 >= level9: true
```

Identical first lines, a "mismatch" label, nothing alarming. The process was in fact dying with **exit 139, core dumped**. It sat in `main` for days red-flagging the required `conformance-smoke-complete` check on ~13 open PRs, and the label actively invited everyone to treat it as a parity nit.

## The change

Signal deaths and timeouts are intercepted **before** either output comparison:

```
CRASH test_gap_zlib_4917_level (SIGSEGV (exit 139))
       Perry died after printing 5 line(s); Node exited 0.
       Last Perry line: deflateRawSync level 99 throws: RangeError
```

- New `crash` result status, `CRASH_FAIL` counter, and a dedicated `failures.crash` array in the JSON report. Crashes are counted in `total_run`, so `parity_percentage` cannot quietly ignore them.
- `run_gap_tests.sh` gates on crashes like any other failure — **and additionally prints them every run even when triaged in `known_failures.json`**. A segfault is never an acceptable "known gap", so it must not be silenceable.
- The crash banner points at Linux: the handle-band deref class (#6271) is masked on macOS by its 2 TB heap floor, so "it passes on my Mac" proves nothing for this class.

## Safety of the classification

Only **signals** (`128+N`) and **timeouts** (`124`) count as crashes. An ordinary non-zero exit — an uncaught throw exiting 1, say — is still compared normally, so expected-output tests that deliberately assert a non-zero exit are unaffected.

Node has already been proven to exit 0 to reach this point (a non-zero Node exit becomes `node_fail` + skip earlier), so an abnormal exit here is unambiguously Perry's, not a property of the fixture.

## Verification

Exercised against the real harness, not just eyeballed:

| case | result |
|---|---|
| pass path | unchanged — `PASS`, `crash_fail: 0` |
| simulated signal death | labelled `CRASH`, `failures.crash` populated, status `crash`, **gate trips** |
| *triaged* crash | gate passes (no CI surprise) but the `*** CRASHES ***` block still prints |

## Deliberately not done

Crashes are still triage-able, so this cannot break CI on an existing triaged crash. Making a crash an *unconditional* gate failure regardless of triage is the stricter (and arguably correct) semantic — worth doing as a follow-up once we've confirmed no currently-triaged gap test is actually crashing on Linux.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reporting to distinguish crashes and timeouts from output mismatches.
  * Crashed tests are now skipped from parity comparisons and clearly identified in summaries and reports.
  * Crash details are surfaced prominently during gap-test runs and cannot be silently treated as known mismatches.
  * JSON reports now include dedicated crash counts and failure lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->