### PR TITLE
fix(runtime): stream expando reads — a stream-band id is not a primitive number

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -405,6 +405,36 @@ pub extern "C" fn js_object_get_field_by_name(
         let is_primitive_number =
             (top16 != 0 && !(0x7FF9..=0x7FFF).contains(&top16)) || (top16 == 0 && bits == 0);
         if is_primitive_number {
+            // #5989: a live Web Stream handle is itself a finite positive float
+            // (`id as f64`, stream band [0x100000, 0x200000)), so it classifies
+            // as a primitive number HERE and returned `undefined` for every
+            // property — the dedicated stream arm further down never ran.
+            // React's `renderToReadableStream` reads back the `allReady`
+            // expando it attached (`stream.allReady`), got `undefined`, and the
+            // Next.js dynamic render 500'd on `undefined.finally`. Route a
+            // registered stream id to the handle property dispatcher (getter /
+            // bound-method / expando arms) before the primitive-number return.
+            {
+                let f = f64::from_bits(bits);
+                if !key.is_null() && f.is_finite() && f > 0.0 && f.fract() == 0.0 {
+                    let id = f as usize;
+                    if crate::value::addr_class::is_stream_id_band(id) {
+                        if let Some(probe) = crate::object::stream_handle_probe() {
+                            unsafe {
+                                if probe(id) {
+                                    if let Some(dispatch) = handle_property_dispatch() {
+                                        let key_ptr = (key as *const u8)
+                                            .add(std::mem::size_of::<crate::StringHeader>());
+                                        let key_len = (*key).byte_len as usize;
+                                        let v = dispatch(id as i64, key_ptr, key_len);
+                                        return JSValue::from_bits(v.to_bits());
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
             // #2138: auto-box the primitive number for the inherited
             // `.constructor` read so `n.constructor === Number` (and the
             // duck-type `value.constructor.name === "Number"` lodash/date-fns

--- a/test-files/test_gap_stream_expando_property_read.ts
+++ b/test-files/test_gap_stream_expando_property_read.ts
@@ -1,0 +1,45 @@
+// #5989: an expando property attached to a Web ReadableStream must read back.
+//
+// React's `renderToReadableStream` attaches its shell-ready promise to the
+// stream it returns (`stream.allReady = promise`); Next.js destructures it
+// back off the awaited render result and chains `.finally` on it. Perry
+// stored the write (the stream-band arms in `js_put_value_set` /
+// `js_object_set_field_by_name` route to the per-stream expando table), but
+// every READ returned `undefined`: a stream handle is a raw finite f64 id, so
+// `js_object_get_field_by_name`'s primitive-number guard (#2128) classified
+// the receiver as a plain number and returned `undefined` before the
+// dedicated stream arm could run. `undefined.finally` then 500'd every
+// force-dynamic Next.js route.
+
+const rs = new ReadableStream({
+  start(c) {
+    c.enqueue(new Uint8Array([1, 2, 3]));
+    c.close();
+  },
+});
+
+// Plain expando write + the three read shapes the bundles use.
+(rs as any).allReady = Promise.resolve("AR");
+console.log("typeof direct:", typeof (rs as any).allReady);
+
+function readViaParam(s: any) {
+  return s.allReady;
+}
+console.log("typeof via-fn:", typeof readViaParam(rs));
+
+const { allReady } = rs as any;
+console.log("typeof destructured:", typeof allReady);
+
+// The read value is the SAME promise — resolves with the written value.
+(rs as any).allReady.then((v: string) => console.log("value:", v));
+
+// Non-promise expandos too, and unknown keys still miss.
+(rs as any).marker = 42;
+console.log("marker:", (rs as any).marker);
+console.log("missing:", typeof (rs as any).nope);
+
+// Stream still works as a stream after carrying expandos.
+const reader = rs.getReader();
+reader.read().then(({ value, done }) => {
+  console.log("read:", done, value ? value.length : -1);
+});


### PR DESCRIPTION
## Summary

An expando property attached to a Web `ReadableStream` (`stream.allReady = p`) **stored** correctly — the stream-band arms in `js_put_value_set` / `js_object_set_field_by_name` route the write to the stdlib per-stream expando table — but every **read** came back `undefined`.

A live stream handle is a raw finite positive f64 (`id as f64`, stream band `[0x100000, 0x200000)`), so in `js_object_get_field_by_name` the #2128 **primitive-number guard** classified the receiver as a plain number (top16 is an ordinary exponent) and returned `undefined` for unknown keys — *before* the dedicated #1670/#5437 stream arm further down could route the read through the handle property dispatcher. That arm was dead code for exactly the receivers it was written for.

## Impact — #5989 Next.js force-dynamic 500

React's `renderToReadableStream` attaches its shell-ready promise as `stream.allReady`; Next destructures it back off the awaited render result and chains `.finally` on it:

```js
let {stream: l, allReady: u} = await eQ.workUnitAsyncStorage.run(…);
return u.finally(…)
```

The read returned `undefined`, so `undefined.finally` threw `TypeError: Cannot read properties of undefined (reading 'finally')` inside a render timer tick — and every force-dynamic route 500'd. **With this fix the Next.js standalone `/plain` route goes 500 → 200.**

## Fix

Inside the primitive-number arm, before the `undefined` return: check the stream id band + the stdlib stream-handle probe, and route a registered stream id to `handle_property_dispatch()` (the getter / bound-method / expando dispatcher). Non-stream numbers keep the #2128 behavior unchanged; dead/unregistered ids fall through exactly as before. The typed-feedback read wrapper delegates here, so both the plain and feedback paths are covered.

## Validation

- New gap test `test_gap_stream_expando_property_read.ts` — write + the three read shapes the bundles use (direct, via untyped param, destructuring), value round-trip through the promise, non-promise expandos, unknown-key miss, and the stream still functioning as a stream — **byte-identical to node**.
- Stream regression: `test_gap_readable_stream_tee_pull` + `test_gap_2823_2825_2822_promise_semantics` pass.
- Next.js standalone min-app: `/plain` **HTTP 200** (was 500), `/` still 200.
- `cargo fmt` clean.

Code-only; no version/changelog bump (maintainer folds metadata at merge).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed property reads for custom properties attached to readable streams.
  * Stream expandos now work consistently through direct access, function parameters, destructuring, and promise resolution.
  * Preserved standard stream behavior, including reading stream data and returning `undefined` for unknown properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->