### PR TITLE
perf(gc): use the filtered arena walk for the minor promotable-survivor census (#6181)

### DIFF
--- a/crates/perry-runtime/src/gc/policy.rs
+++ b/crates/perry-runtime/src/gc/policy.rs
@@ -763,25 +763,31 @@ pub(super) fn copied_minor_promotion_handoff_pressure_due(
 }
 
 pub(super) fn copied_minor_promotable_active_survivor_bytes() -> usize {
+    // Pure measurement pass over the active survivor semispace only. Use the
+    // block-filtered walk so blocks outside the active range are skipped in
+    // O(n_blocks) instead of iterating every object in Eden/longlived/old-gen
+    // just to discard it (#6181) — both walkers visit the regions in the same
+    // order with the same global block-index bases, so the filter is exactly
+    // equivalent to the previous in-callback range check.
     let active_range = crate::arena::active_survivor_block_index_range();
     let mut promotable = 0usize;
-    crate::arena::arena_walk_objects_with_block_index(|header_ptr, block_idx| {
-        if !active_range.contains(&block_idx) {
-            return;
-        }
-        let header = header_ptr as *mut GcHeader;
-        unsafe {
-            let flags = (*header).gc_flags;
-            if flags & GC_FLAG_FORWARDED != 0 {
-                return;
+    crate::arena::arena_walk_objects_filtered(
+        |block_idx| active_range.contains(&block_idx),
+        |header_ptr, _block_idx| {
+            let header = header_ptr as *mut GcHeader;
+            unsafe {
+                let flags = (*header).gc_flags;
+                if flags & GC_FLAG_FORWARDED != 0 {
+                    return;
+                }
+                let prior_age = copied_survival_age((*header)._reserved, flags);
+                let next_age = prior_age.saturating_add(1);
+                if flags & GC_FLAG_TENURED != 0 || next_age >= GC_COPY_PROMOTION_SURVIVALS {
+                    promotable = promotable.saturating_add((*header).size as usize);
+                }
             }
-            let prior_age = copied_survival_age((*header)._reserved, flags);
-            let next_age = prior_age.saturating_add(1);
-            if flags & GC_FLAG_TENURED != 0 || next_age >= GC_COPY_PROMOTION_SURVIVALS {
-                promotable = promotable.saturating_add((*header).size as usize);
-            }
-        }
-    });
+        },
+    );
     promotable
 }
 

--- a/crates/perry-runtime/src/gc/tests/copying/survival_and_malloc.rs
+++ b/crates/perry-runtime/src/gc/tests/copying/survival_and_malloc.rs
@@ -778,3 +778,67 @@ fn test_movable_date_evacuation_migrates_expando_and_preserves_ts() {
         "expando must not remain at the stale old address"
     );
 }
+
+// #6181: the promotion-handoff census switched from the unfiltered
+// `arena_walk_objects_with_block_index` (visits every object in every region,
+// discards out-of-range ones in the callback) to the block-filtered walk that
+// skips non-active blocks in O(n_blocks). Both walkers must assign the same
+// global block indices, so the filtered census must equal the old in-callback
+// range check byte-for-byte — including ignoring Eden garbage and old-gen
+// objects that sit outside the active survivor range.
+#[test]
+fn test_copied_minor_promotable_census_filtered_walk_matches_unfiltered() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    let child = young_leaf();
+    js_shadow_slot_set(0, ptr_bits(child));
+
+    // Age the rooted object to the promotion boundary: after 3 copied minors
+    // its survival age is 3, so next_age (4) >= GC_COPY_PROMOTION_SURVIVALS
+    // and the census must count it.
+    for _ in 0..3 {
+        let _ = gc_collect_minor();
+    }
+    let survivor = (js_shadow_slot_get(0) & POINTER_MASK) as usize;
+    assert!(crate::arena::pointer_in_nursery(survivor));
+    let survivor_total = unsafe { (*header_from_user_ptr(survivor as *const u8)).size as usize };
+
+    // Populate regions OUTSIDE the active survivor range: Eden garbage and an
+    // old-gen object. The census must ignore all of them.
+    for _ in 0..64 {
+        let _ = young_leaf();
+    }
+    let _old = unsafe { alloc_old_test_symbol() };
+
+    // Reference value: the pre-#6181 implementation — the unfiltered walk
+    // with the active-range check inside the callback.
+    let active_range = crate::arena::active_survivor_block_index_range();
+    let mut expected = 0usize;
+    crate::arena::arena_walk_objects_with_block_index(|header_ptr, block_idx| {
+        if !active_range.contains(&block_idx) {
+            return;
+        }
+        let header = header_ptr as *mut GcHeader;
+        unsafe {
+            let flags = (*header).gc_flags;
+            if flags & GC_FLAG_FORWARDED != 0 {
+                return;
+            }
+            let prior_age = copied_survival_age((*header)._reserved, flags);
+            let next_age = prior_age.saturating_add(1);
+            if flags & GC_FLAG_TENURED != 0 || next_age >= GC_COPY_PROMOTION_SURVIVALS {
+                expected = expected.saturating_add((*header).size as usize);
+            }
+        }
+    });
+
+    let actual = copied_minor_promotable_active_survivor_bytes();
+    assert_eq!(
+        actual, expected,
+        "filtered census must match the unfiltered-walk reference"
+    );
+    assert!(
+        actual >= survivor_total,
+        "census must count the aged survivor ({survivor_total} bytes), got {actual} — \
+         the equivalence assert above must not be vacuously 0 == 0"
+    );
+}


### PR DESCRIPTION
Part of #6181.

## What / why

`copied_minor_promotable_active_survivor_bytes` (`crates/perry-runtime/src/gc/policy.rs`) is a pure measurement pass: it sums the bytes of active-survivor-semispace objects that are at the promotion boundary, feeding `copied_minor_promotion_handoff_due` (the "escalate this minor to a full old-gen reclaim" pressure check at `gc/mod.rs:120`).

It previously ran the **unfiltered** `arena_walk_objects_with_block_index`, which decodes the header of every object in Eden + both survivor semispaces + longlived + old-gen, and discarded out-of-range objects one callback at a time. On heaps with a large old-gen or a full Eden that is O(n_objects) of wasted header walking on every promotion-handoff check.

This switches it to the existing `arena_walk_objects_filtered` (`arena/walk.rs`), which skips whole blocks outside the active survivor range in O(n_blocks).

## Before / after cost shape

- Before: O(all arena objects) per census — every object in every region has its header decoded, then most are discarded by the range check.
- After: O(objects in the active survivor semispace) + O(total blocks) for the skip test. Blocks outside the active range are never entered.

## Why the value is unchanged

Both walkers visit the same regions in the same order with the same global block-index bases (general at 0, survivor0 at `general_n`, survivor1 at `general_n + survivor0_n`, then longlived, then old-gen), and both call `sync_inline_arena_state()` up front. `active_survivor_block_index_range()` computes its range in exactly that global index space, so filtering by `active_range.contains(block_idx)` up front admits precisely the objects the old in-callback range check kept. The per-object callback body (FORWARDED skip, survival-age / TENURED promotability test, byte accumulation) is unchanged.

## Verification

- New unit test `gc::tests::copying::survival_and_malloc::test_copied_minor_promotable_census_filtered_walk_matches_unfiltered`: drives a rooted object through three real copied minors (`gc_collect_minor` under `CopyingNurseryTestGuard`) so it sits in the active survivor space at the promotion boundary, seeds Eden garbage and an old-gen object outside the active range, then asserts the filtered census equals the old unfiltered-walk reference byte-for-byte and is non-zero (counts the aged survivor).
- `cargo test -p perry-runtime`: 1233 passed, 0 failed. (One unrelated flake on the first run, `url::node_compat::tests::path_to_file_url_posix_preserves_relative_trailing_slash` — a pre-existing CWD race between parallel tests; it passes in isolation and the full suite is green on rerun.)
- End-to-end smoke (perry-dev build): a 3M-allocation churn loop with a 20k rotating survivor set, plus an async variant with microtask yields, both compiled and run against `node --experimental-strip-types` — byte-identical output in all configurations tried: default, `PERRY_GC_DIAG=1` (6+ full GC cycles observed), `PERRY_GC_FORCE_EVACUATE=1`, and `PERRY_GC_HEAP_LIMIT=48`.
- Note on end-to-end coverage: in these compiled compute-loop workloads the nursery-pressure triggers were serviced by the budgeted/full collector, so `gc_collect_minor` (and therefore this census) did not light up in the smoke's diag stream; the census's exact-value equivalence is covered by the unit test above, which exercises the real copied-minor machinery in-process.
- `cargo fmt --all -- --check` passes.

## Scope

Only the promotion-handoff census walk. The other #6181 sub-item — the minor sweep's full old-gen walk — is design-gated (mark-bit coupling) and deliberately **not** touched here; #6181 stays open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy and consistency when measuring promotable survivors during minor garbage collection.
  * Ensured inactive memory regions and non-promotable objects are excluded from survivor measurements.

* **Tests**
  * Added regression coverage validating survivor measurements across multiple copying cycles and promotion boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->