### PR TITLE
docs: show latest release dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Perry is a native TypeScript compiler written in Rust. It takes your TypeScript and compiles it straight to native executables — no Node.js, no Electron, no browser engine. Just fast, small binaries that run anywhere.
 
-**Current Version:** 0.5.1164 | [Website](https://perryts.com) | [Documentation](https://perryts.github.io/perry/) | [Showcase](https://perryts.com/showcase)
+[![Latest release](https://img.shields.io/github/v/release/PerryTS/perry?display_name=tag)](https://github.com/PerryTS/perry/releases/latest) | [Website](https://perryts.com) | [Documentation](https://perryts.github.io/perry/) | [Showcase](https://perryts.com/showcase)
 
 **Community:** [Join the Perry Discord](https://discord.gg/chEmpGdTtZ)
 


### PR DESCRIPTION
## Summary
- replace the stale hard-coded README version with a latest-release badge
- link the badge to the latest GitHub Release

The badge resolves its value when the README is rendered, so publishing a GitHub Release updates the displayed version without a follow-up commit.

## Validation
- confirmed the badge endpoint returns an SVG response
- confirmed the latest-release link resolves
- verified README contains no static `Current Version` semver field
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README status area with a “Latest release” badge linking to Releases.
  * Added links to the Website, Documentation, and Showcase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->