### PR TITLE
fix(runtime): reject handle-band payloads in the generic object ops (44 Linux segfaults)

### DIFF
--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -54,7 +54,13 @@ pub extern "C" fn js_object_delete_field(
             }
         }
     }
-    if (obj as usize) < 0x10000 {
+    // The hand-typed 0x10000 floor here was an order of magnitude below the real
+    // boundary (HANDLE_BAND_MAX = 0x100000), so the fetch (0x40000..0xE0000) and
+    // zlib (0xE0000..0xF0000) handle bands fell through to the heap path below
+    // and got dereferenced -> SIGSEGV on Linux. Use the centralized predicate.
+    // A handle simply misses `class_name_for_id` and returns 1, which is the
+    // correct result for `delete request.foo` (Node: true).
+    if crate::value::addr_class::is_handle_band(obj as usize) {
         unsafe {
             if let Some(name) = super::has_own_helpers::str_from_string_header(key) {
                 let class_id = obj as usize as u32;

--- a/crates/perry-runtime/src/object/field_get_set/enumeration.rs
+++ b/crates/perry-runtime/src/object/field_get_set/enumeration.rs
@@ -162,6 +162,13 @@ pub extern "C" fn js_object_keys_value(value: f64) -> *mut ArrayHeader {
     }
     if jv.is_pointer() {
         let ptr = jv.as_pointer::<u8>() as usize;
+        // A POINTER_TAG registry handle (zlib stream, fetch Request/Response/
+        // Headers/Blob, …) is not an address. It exposes no own enumerable
+        // properties — its surface lives on the prototype as accessors — so
+        // return empty instead of dereferencing unmapped low memory.
+        if crate::value::addr_class::is_handle_band(ptr) {
+            return crate::array::js_array_alloc(0);
+        }
         if crate::value::addr_class::is_small_handle(ptr) {
             if let Some(dispatch) =
                 super::super::class_registry::handle_own_property_names_dispatch()
@@ -438,12 +445,42 @@ fn for_each_string_char<F: FnMut(u32, f64)>(value: f64, mut emit: F) -> Option<u
     Some(i)
 }
 
+/// `Object.values` / `Object.entries` over a revocable Proxy: enumerate the
+/// own keys through the `ownKeys` trap (same source `Object.keys` uses), then
+/// read each value back through the `get` trap. Without this the proxy id — a
+/// handle-band payload, not an address — either got dereferenced (SIGSEGV) or,
+/// once the handle-band guard rejected it, silently reported no properties.
+unsafe fn proxy_values_or_entries(value: f64, want_pairs: bool) -> *mut ArrayHeader {
+    let keys_boxed = crate::proxy::proxy_enum_own_keys(value);
+    let keys_arr = (keys_boxed.to_bits() & crate::value::POINTER_MASK) as *mut ArrayHeader;
+    let len = crate::array::js_array_length(keys_arr);
+    let mut out = crate::array::js_array_alloc(len.max(1) as u32);
+    for i in 0..len {
+        let key = crate::array::js_array_get(keys_arr, i);
+        let val = crate::proxy::js_proxy_get(value, f64::from_bits(key.bits()));
+        if want_pairs {
+            let pair = crate::array::js_array_alloc(2);
+            let pair = crate::array::js_array_push(pair, key);
+            let pair = crate::array::js_array_push_f64(pair, val);
+            out = crate::array::js_array_push(out, JSValue::array_ptr(pair));
+        } else {
+            out = crate::array::js_array_push_f64(out, val);
+        }
+    }
+    out
+}
+
 /// Tag-dispatching `Object.values(value)` — see [`js_object_keys_value`].
 /// A string yields its characters (`Object.values("hi") === ["h","i"]`);
 /// objects/arrays delegate to `js_object_values`; primitives yield `[]`.
 #[no_mangle]
 pub extern "C" fn js_object_values_value(value: f64) -> *mut ArrayHeader {
     let jv = JSValue::from_bits(value.to_bits());
+    if crate::proxy::js_proxy_is_proxy(value) != 0 {
+        return unsafe {
+            proxy_values_or_entries(value, /*want_pairs=*/ false)
+        };
+    }
     // #2818: ToObject(null/undefined) throws TypeError, matching Node.
     if jv.is_null() || jv.is_undefined() {
         super::super::has_own_helpers::throw_to_object_nullish_type_error();
@@ -469,6 +506,13 @@ pub extern "C" fn js_object_values_value(value: f64) -> *mut ArrayHeader {
     }
     if jv.is_pointer() {
         let ptr = jv.as_pointer::<u8>() as usize;
+        // A POINTER_TAG registry handle (zlib stream, fetch Request/Response/
+        // Headers/Blob, …) is not an address. It exposes no own enumerable
+        // properties — its surface lives on the prototype as accessors — so
+        // return empty instead of dereferencing unmapped low memory.
+        if crate::value::addr_class::is_handle_band(ptr) {
+            return crate::array::js_array_alloc(0);
+        }
         if crate::typedarray::lookup_typed_array_kind(ptr).is_some() {
             return unsafe {
                 crate::typedarray_props::typed_array_own_enumerable_values(
@@ -491,6 +535,11 @@ pub extern "C" fn js_object_values_value(value: f64) -> *mut ArrayHeader {
 #[no_mangle]
 pub extern "C" fn js_object_entries_value(value: f64) -> *mut ArrayHeader {
     let jv = JSValue::from_bits(value.to_bits());
+    if crate::proxy::js_proxy_is_proxy(value) != 0 {
+        return unsafe {
+            proxy_values_or_entries(value, /*want_pairs=*/ true)
+        };
+    }
     // #2818: ToObject(null/undefined) throws TypeError, matching Node.
     if jv.is_null() || jv.is_undefined() {
         super::super::has_own_helpers::throw_to_object_nullish_type_error();
@@ -521,6 +570,13 @@ pub extern "C" fn js_object_entries_value(value: f64) -> *mut ArrayHeader {
     }
     if jv.is_pointer() {
         let ptr = jv.as_pointer::<u8>() as usize;
+        // A POINTER_TAG registry handle (zlib stream, fetch Request/Response/
+        // Headers/Blob, …) is not an address. It exposes no own enumerable
+        // properties — its surface lives on the prototype as accessors — so
+        // return empty instead of dereferencing unmapped low memory.
+        if crate::value::addr_class::is_handle_band(ptr) {
+            return crate::array::js_array_alloc(0);
+        }
         if crate::typedarray::lookup_typed_array_kind(ptr).is_some() {
             return unsafe {
                 crate::typedarray_props::typed_array_own_enumerable_entries(

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -51,7 +51,24 @@ pub(crate) use keys_array::{ensure_key_in_keys_array, install_builtin_getter, ow
 pub(crate) unsafe fn extract_obj_ptr(value: f64) -> *mut ObjectHeader {
     let jsval = crate::JSValue::from_bits(value.to_bits());
     if jsval.is_pointer() {
-        jsval.as_pointer::<ObjectHeader>() as *mut ObjectHeader
+        let ptr = jsval.as_pointer::<ObjectHeader>() as *mut ObjectHeader;
+        // A POINTER_TAG payload is not always an address. zlib streams, fetch
+        // Request/Response/Headers/Blob, net.Socket, crypto hashes and revocable
+        // Proxies all smuggle small registry *handles* under the same tag (see
+        // `value::addr_class` for the band map). A handle must never be
+        // dereferenced. Return null so every caller takes the `is_null()` path
+        // it already has, instead of reading unmapped low memory.
+        //
+        // This is the central fix for the #6271 crash class: `is_valid_obj_ptr`
+        // does NOT reject the handle band on Linux/Windows/Android/iOS (heap
+        // floor 0x1000, far below HANDLE_BAND_MAX), so callers that guard with
+        // it alone deref the handle and segfault there — while macOS silently
+        // takes the null path behind its 2 TB heap floor. Rejecting here makes
+        // every platform agree on the already-correct macOS behaviour.
+        if !crate::value::addr_class::is_above_handle_band(ptr as usize) {
+            return ptr::null_mut();
+        }
+        ptr
     } else {
         let bits = value.to_bits();
         // Raw-I64-pointer fallback (module-level array/object vars store the
@@ -62,7 +79,11 @@ pub(crate) unsafe fn extract_obj_ptr(value: f64) -> *mut ObjectHeader {
         // sentinel (`require('buffer')`) reaching a generic object op like
         // `hasOwnProperty`. Without it, callers deref `[ptr-8]` for the
         // GcHeader on a misaligned garbage address → SIGBUS (#3527).
-        if bits != 0 && bits <= 0x0000_FFFF_FFFF_FFFF && bits > 0x10000 && bits & 0x7 == 0 {
+        if bits != 0
+            && bits <= 0x0000_FFFF_FFFF_FFFF
+            && crate::value::addr_class::is_above_handle_band(bits as usize)
+            && bits & 0x7 == 0
+        {
             bits as *mut ObjectHeader
         } else {
             ptr::null_mut()

--- a/crates/perry-runtime/src/object/object_ops/has_own.rs
+++ b/crates/perry-runtime/src/object/object_ops/has_own.rs
@@ -73,6 +73,20 @@ pub extern "C" fn js_object_has_own(obj_value: f64, key_value: f64) -> f64 {
             super::super::has_own_helpers::throw_to_object_nullish_type_error();
         }
 
+        // A POINTER_TAG registry handle (zlib stream, fetch Request/Response/
+        // Headers/Blob, …) is not an address and must never be dereferenced. It
+        // carries no own properties, so report false. Proxies also live in the
+        // handle band but are served by the trap branch below (which runs before
+        // any deref), so leave their sub-band alone.
+        if obj_js.is_pointer() {
+            let addr = obj_js.as_pointer::<u8>() as usize;
+            if crate::value::addr_class::is_handle_band(addr)
+                && !crate::value::addr_class::is_proxy_id_band(addr)
+            {
+                return f64::from_bits(TAG_FALSE);
+            }
+        }
+
         // ToPropertyKey(V): fold an object argument (e.g. one whose `toString`
         // returns a Symbol) into its canonical key before the symbol/string
         // split. A no-op for keys that are already primitives.

--- a/test-files/test_gap_handle_band_object_ops.ts
+++ b/test-files/test_gap_handle_band_object_ops.ts
@@ -1,0 +1,67 @@
+// #6271 follow-up — generic object ops on POINTER_TAG *registry handles*.
+//
+// zlib streams, fetch Request/Response/Headers/Blob, crypto hashes and revocable
+// Proxies are small integer handles NaN-boxed under POINTER_TAG, not heap
+// addresses (see perry-runtime/src/value/addr_class.rs). Runtime paths that
+// dereference the payload without a handle-band check read unmapped low memory
+// and SIGSEGV — on Linux only; macOS masks the class behind its 2 TB heap floor.
+// 44 of these (receiver, op) pairs crashed before the fix.
+//
+// This asserts the ops COMPLETE and agree with Node. It deliberately does not
+// assert own-key *counts* for the native handles: Node's Gzip/Hash/Headers are
+// ordinary JS objects carrying internal own fields (_readableState, …) while
+// Perry models them as opaque native handles with none. That difference is
+// long-standing and by design; the crash is the bug.
+import * as zlib from "node:zlib";
+import * as crypto from "node:crypto";
+
+const makers: Array<[string, () => any]> = [
+  ["gzipStream", () => zlib.createGzip({ level: 1 })],
+  ["headers", () => new Headers({ "x-a": "1" })],
+  ["request", () => new Request("https://example.com")],
+  ["response", () => new Response("hi")],
+  ["blob", () => new Blob(["hi"])],
+  ["hash", () => crypto.createHash("sha256")],
+];
+
+// Ops whose result is representation-independent: they must not crash, and
+// must return the same answer Node gives for an absent property.
+const ops: Array<[string, (x: any) => unknown]> = [
+  ["delete absent", (x) => delete x.__nope],
+  ["hasOwnProperty absent", (x) => Object.prototype.hasOwnProperty.call(x, "__nope")],
+  ["propertyIsEnumerable absent", (x) => Object.prototype.propertyIsEnumerable.call(x, "__nope")],
+  ["getOwnPropertyDescriptor absent", (x) => Object.getOwnPropertyDescriptor(x, "__nope") === undefined],
+  ["in absent", (x) => "__nope" in x],
+  ["keys is array", (x) => Array.isArray(Object.keys(x))],
+  ["values is array", (x) => Array.isArray(Object.values(x))],
+  ["entries is array", (x) => Array.isArray(Object.entries(x))],
+  ["getOwnPropertyNames is array", (x) => Array.isArray(Object.getOwnPropertyNames(x))],
+  ["spread is object", (x) => typeof { ...x } === "object"],
+  ["for-in completes", (x) => { let n = 0; for (const _k in x) n++; return typeof n === "number"; }],
+  ["defineProperty completes", (x) => { Object.defineProperty(x, "__d", { value: 1 }); return true; }],
+  ["freeze returns receiver", (x) => Object.freeze(x) === x],
+];
+
+for (const [name, make] of makers) {
+  for (const [opName, op] of ops) {
+    const x = make();
+    try {
+      console.log(`${name}.${opName}: ${op(x)}`);
+    } catch (e: any) {
+      console.log(`${name}.${opName}: throw ${e && e.constructor && e.constructor.name}`);
+    }
+  }
+}
+
+// A revocable Proxy is ALSO a handle-band id, but unlike the native handles it
+// must still reflect its target's own properties through the ownKeys/get traps.
+// Guarding the band without routing proxies to those traps would silently
+// report an empty object — so pin the actual values here.
+const p: any = new Proxy({ a: 1, b: 2 }, {});
+console.log(`proxy.keys: ${JSON.stringify(Object.keys(p))}`);
+console.log(`proxy.values: ${JSON.stringify(Object.values(p))}`);
+console.log(`proxy.entries: ${JSON.stringify(Object.entries(p))}`);
+console.log(`proxy.hasOwnProperty a: ${Object.prototype.hasOwnProperty.call(p, "a")}`);
+console.log(`proxy.delete a: ${delete p.a}`);
+console.log(`proxy.keys after delete: ${JSON.stringify(Object.keys(p))}`);
+console.log("done");


### PR DESCRIPTION
The audit follow-up to #6271, and the second half of that PR's "follow-up" list. (The first half — the harness that reported the crash as an "output mismatch" — is #6274.)

## What the audit found

#6271 fixed one handle-band deref. The obvious question was whether it was alone. It was not.

I ran every POINTER_TAG **registry handle** — zlib stream, fetch `Headers`/`Request`/`Response`/`Blob`, `crypto.createHash`, revocable `Proxy` — through the generic object operations, one (receiver, op) pair per process so a crash couldn't mask the rest, **on Linux**:

> **44 of 240 pairs died with SIGSEGV.**

Every one dereferenced the handle payload as an address. The crashing ops clustered on own-property operations: `delete`, `Object.keys`/`values`/`entries`, `hasOwnProperty`, `propertyIsEnumerable`, `getOwnPropertyDescriptor`, `defineProperty`, `freeze`.

## The central fix

`object_ops.rs::extract_obj_ptr` — **52 callers** — is the chokepoint. Its `is_pointer()` path returned the payload as an `ObjectHeader*` with **no band check at all**, and its raw-i64 fallback used a hand-typed `0x10000` floor, an order of magnitude below `HANDLE_BAND_MAX` (`0x100000`), so the fetch and zlib bands sailed through.

Both now route through `addr_class::is_above_handle_band`. A handle yields null, and every caller takes the `is_null()` path **it already had**. macOS was accidentally safe here because its callers' `is_valid_obj_ptr` floor is 2 TB — this simply makes Linux agree with the already-correct macOS behaviour.

Three sites extract the receiver themselves and needed the guard directly: `js_object_delete_field` (same wrong `0x10000` floor), `js_object_{keys,values,entries}_value`, and `js_object_has_own`.

## Proxy needed real support, not a guard

This is the part worth reviewing closely. **Proxy ids share the handle band**, so band-guarding alone would have silently turned `Object.values(proxy)` and `Object.entries(proxy)` into `[]` — trading a loud segfault for quiet data loss.

`js_object_keys_value` already routed proxies through the `ownKeys` trap; `values` and `entries` did not (`entries` crashed outright). Both now enumerate via `ownKeys` and read each value back through the `get` trap, so they match Node instead of returning empty.

I only caught this because the regression test pins the actual Proxy values rather than just asserting "didn't crash". An earlier iteration of this PR shipped the silent-empty bug and the full gap suite was still green — no existing test covers `Object.values` on a Proxy.

## Verification (Linux x86_64)

| check | result |
|---|---|
| the 240 (receiver, op) pairs | **44 crashes → 0**, and **0/240** node-parity diffs |
| full gap suite vs a **pristine-main baseline built on the same host** | **identical failure set — zero regressions**; pass count 245 → 246 |
| `test_gap_handle_band_object_ops.ts` (new) | byte-identical to `node --experimental-strip-types` (85 lines) |

The baseline diff matters: the only delta that appeared mid-audit was `test_gap_fs_fd_2749`, which I confirmed is the pre-existing flake (8/8 clean runs in isolation), not a regression.

## One deliberate non-assertion

The new test does **not** assert own-key *counts* for the native handles. Node's `Gzip`/`Hash`/`Headers` are ordinary JS objects carrying internal own fields (`_readableState`, …) — `Object.keys(gzip)` is 21 in Node, 0 in Perry, which models them as opaque native handles. That difference is long-standing and by design; the crash was the bug. Asserting the counts would just bake in a permanent failure.

## Not in this PR

`scripts/addr_class_inventory.py` — the gate that exists to catch exactly this class — missed it, twice over: it only recognises *correct* band literals (so a wrong `0x10000` floor is invisible) and does not flag a lone `is_valid_obj_ptr` guard. Closing those blind spots means triaging ~85 + ~320 sites, so I filed it as **#6279** rather than shipping a rule that would red CI on day one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved object operations for special runtime values to prevent invalid memory access and crashes.
  * Corrected handling of property deletion and ownership checks for non-object handles.
  * Updated `Object.keys`, `Object.values`, and `Object.entries` behavior for special values and revocable proxies.
  * Ensured proxy enumeration retrieves keys and corresponding values through proxy behavior.

* **Tests**
  * Added coverage for object operations across multiple runtime-generated values and revocable proxies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->