### PR TITLE
fix(streams): await TransformStream flush() before closing the readable

### DIFF
--- a/crates/perry-stdlib/src/streams/transform.rs
+++ b/crates/perry-stdlib/src/streams/transform.rs
@@ -290,9 +290,100 @@ pub(super) unsafe fn transform_close(writable_id: usize) -> *mut Promise {
         js_promise_reject(promise, f64::from_bits(error_bits));
         return promise;
     }
-    if !handled_native && flush_cb != 0 && readable_id != 0 {
-        js_closure_call1(flush_cb as *const ClosureHeader, readable_id as f64);
+    // Invoke the user `flush(controller)`. It may return a promise: e.g.
+    // Next.js' `createBufferedTransformStream` buffers chunks in `transform()`
+    // and enqueues the coalesced chunk from a `setImmediate`, with `flush()`
+    // returning a promise that resolves only once that deferred enqueue runs.
+    // Per the WHATWG spec the transformer's flush completion is awaited before
+    // the readable side is closed; closing early drops the not-yet-enqueued
+    // chunk (the #5989 Next.js `bytes=0` empty-body bug — the buffered HTML
+    // never reached `res.write`). So when flush returns a still-pending
+    // promise, defer the readable close until it settles.
+    let flush_result = if !handled_native && flush_cb != 0 && readable_id != 0 {
+        Some(js_closure_call1(
+            flush_cb as *const ClosureHeader,
+            readable_id as f64,
+        ))
+    } else {
+        None
+    };
+
+    if let Some(fv) = flush_result {
+        if perry_runtime::promise::js_value_is_promise(fv) != 0 {
+            let inner = js_nanbox_get_pointer(fv) as *mut Promise;
+            if !inner.is_null() {
+                match perry_runtime::promise::js_promise_state(inner) {
+                    // Already fulfilled — nothing deferred; close synchronously.
+                    1 => {}
+                    // Rejected — error the readable and reject the close request.
+                    2 => {
+                        let reason = perry_runtime::promise::js_promise_reason(inner);
+                        error_transform_close(writable_id, readable_id, promise, reason.to_bits());
+                        return promise;
+                    }
+                    // Pending — chain the close onto flush's settlement so the
+                    // deferred enqueue lands on the still-open readable first.
+                    _ => {
+                        let fulfill = perry_runtime::closure::js_closure_alloc(
+                            transform_flush_fulfilled as *const u8,
+                            3,
+                        );
+                        let reject = perry_runtime::closure::js_closure_alloc(
+                            transform_flush_rejected as *const u8,
+                            3,
+                        );
+                        perry_runtime::closure::js_closure_set_capture_ptr(
+                            fulfill,
+                            0,
+                            writable_id as i64,
+                        );
+                        perry_runtime::closure::js_closure_set_capture_ptr(
+                            fulfill,
+                            1,
+                            readable_id as i64,
+                        );
+                        perry_runtime::closure::js_closure_set_capture_ptr(
+                            fulfill,
+                            2,
+                            promise as i64,
+                        );
+                        perry_runtime::closure::js_closure_set_capture_ptr(
+                            reject,
+                            0,
+                            writable_id as i64,
+                        );
+                        perry_runtime::closure::js_closure_set_capture_ptr(
+                            reject,
+                            1,
+                            readable_id as i64,
+                        );
+                        perry_runtime::closure::js_closure_set_capture_ptr(
+                            reject,
+                            2,
+                            promise as i64,
+                        );
+                        let _ = perry_runtime::promise::js_promise_then(inner, fulfill, reject);
+                        return promise;
+                    }
+                }
+            }
+        }
     }
+
+    finish_transform_close(writable_id, readable_id, promise);
+    promise
+}
+
+/// Close a TransformStream's writable side once `flush()` has settled: close
+/// the readable (delivering any chunk flush enqueued, possibly from a deferred
+/// `setImmediate`), mark the writable closed, and resolve both its closed
+/// promise and the close-request promise the caller (pipeTo/writer.close) is
+/// awaiting.
+unsafe fn finish_transform_close(
+    writable_id: usize,
+    readable_id: usize,
+    close_promise: *mut Promise,
+) {
     if readable_id != 0 {
         js_readable_stream_controller_close(readable_id as f64);
     }
@@ -301,8 +392,56 @@ pub(super) unsafe fn transform_close(writable_id: usize) -> *mut Promise {
         let cp = s.closed_promise;
         js_promise_resolve(cp, f64::from_bits(TAG_UNDEFINED));
     }
-    js_promise_resolve(promise, f64::from_bits(TAG_UNDEFINED));
-    promise
+    js_promise_resolve(close_promise, f64::from_bits(TAG_UNDEFINED));
+}
+
+/// Error a TransformStream's writable side when `flush()` rejected: error the
+/// readable, mark the writable errored, and reject both the closed promise and
+/// the close-request promise.
+unsafe fn error_transform_close(
+    writable_id: usize,
+    readable_id: usize,
+    close_promise: *mut Promise,
+    reason_bits: u64,
+) {
+    if readable_id != 0 {
+        js_readable_stream_controller_error(readable_id as f64, f64::from_bits(reason_bits));
+    }
+    if let Some(s) = WRITABLE_STREAMS.lock().unwrap().get_mut(&writable_id) {
+        s.state = WritableState::Errored;
+        s.error_value = reason_bits;
+        let cp = s.closed_promise;
+        js_promise_reject(cp, f64::from_bits(reason_bits));
+    }
+    js_promise_reject(close_promise, f64::from_bits(reason_bits));
+}
+
+extern "C" fn transform_flush_fulfilled(closure: *const ClosureHeader, _value: f64) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    unsafe {
+        let writable_id = perry_runtime::closure::js_closure_get_capture_ptr(closure, 0) as usize;
+        let readable_id = perry_runtime::closure::js_closure_get_capture_ptr(closure, 1) as usize;
+        let close_promise =
+            perry_runtime::closure::js_closure_get_capture_ptr(closure, 2) as *mut Promise;
+        finish_transform_close(writable_id, readable_id, close_promise);
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+extern "C" fn transform_flush_rejected(closure: *const ClosureHeader, reason: f64) -> f64 {
+    if closure.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    unsafe {
+        let writable_id = perry_runtime::closure::js_closure_get_capture_ptr(closure, 0) as usize;
+        let readable_id = perry_runtime::closure::js_closure_get_capture_ptr(closure, 1) as usize;
+        let close_promise =
+            perry_runtime::closure::js_closure_get_capture_ptr(closure, 2) as *mut Promise;
+        error_transform_close(writable_id, readable_id, close_promise, reason.to_bits());
+    }
+    f64::from_bits(TAG_UNDEFINED)
 }
 
 pub(super) fn split_utf8_prefix(bytes: &[u8]) -> Result<(usize, bool), ()> {

--- a/test-files/test_gap_transform_stream_deferred_flush.ts
+++ b/test-files/test_gap_transform_stream_deferred_flush.ts
@@ -1,0 +1,107 @@
+// #5989: a TransformStream whose flush() completes asynchronously must have its
+// deferred enqueue delivered before the readable side closes.
+//
+// Next.js' `createBufferedTransformStream` (the first transform in React's
+// Fizz → HTTP-response pipeline) buffers every chunk in transform() and emits
+// the coalesced chunk from a `setImmediate`; its flush() returns a promise that
+// resolves only once that deferred enqueue has run. Per the WHATWG spec the
+// transformer's flush completion is awaited before TransformStreamDefaultSink
+// closes the readable. Perry closed the readable synchronously right after
+// invoking flush(), so the not-yet-enqueued buffered chunk was dropped — every
+// force-dynamic Next.js route streamed a 200 with an empty body (content-length
+// 0). This test reproduces that exact buffered-transform shape.
+
+function createBufferedTransform() {
+  let chunks: Uint8Array[] = [];
+  let byteLen = 0;
+  let pending: { promise: Promise<void>; resolve: () => void } | undefined;
+
+  const scheduleFlush = (ctrl: TransformStreamDefaultController<Uint8Array>) => {
+    if (pending) return;
+    let resolve!: () => void;
+    const promise = new Promise<void>((r) => (resolve = r));
+    pending = { promise, resolve };
+    setImmediate(() => {
+      try {
+        const out = new Uint8Array(byteLen);
+        let off = 0;
+        for (const c of chunks) {
+          out.set(c, off);
+          off += c.byteLength;
+        }
+        chunks = [];
+        byteLen = 0;
+        ctrl.enqueue(out);
+      } finally {
+        const p = pending!;
+        pending = undefined;
+        p.resolve();
+      }
+    });
+  };
+
+  return new TransformStream<Uint8Array, Uint8Array>({
+    transform(chunk, ctrl) {
+      chunks.push(chunk);
+      byteLen += chunk.byteLength;
+      scheduleFlush(ctrl);
+    },
+    flush() {
+      if (pending) return pending.promise;
+    },
+  });
+}
+
+async function run() {
+  const enc = new TextEncoder();
+  const src = new ReadableStream<Uint8Array>({
+    start(c) {
+      c.enqueue(enc.encode("<html>"));
+      c.enqueue(enc.encode("<body>hi</body>"));
+      c.enqueue(enc.encode("</html>"));
+      c.close();
+    },
+  });
+
+  const out: number[] = [];
+  let total = 0;
+  await src.pipeThrough(createBufferedTransform()).pipeTo(
+    new WritableStream<Uint8Array>({
+      write(chunk) {
+        out.push(chunk.byteLength);
+        total += chunk.byteLength;
+      },
+    }),
+  );
+
+  console.log("chunks:", JSON.stringify(out));
+  console.log("total bytes:", total);
+}
+
+// Two chained buffered transforms — the deferred flush of the first must land
+// before it closes so the second still receives the payload.
+async function chained() {
+  const enc = new TextEncoder();
+  const dec = new TextDecoder();
+  const src = new ReadableStream<Uint8Array>({
+    start(c) {
+      c.enqueue(enc.encode("alpha"));
+      c.enqueue(enc.encode("beta"));
+      c.close();
+    },
+  });
+  let seen = "";
+  await src
+    .pipeThrough(createBufferedTransform())
+    .pipeThrough(createBufferedTransform())
+    .pipeTo(
+      new WritableStream<Uint8Array>({
+        write(chunk) {
+          seen += dec.decode(chunk, { stream: true });
+        },
+      }),
+    );
+  console.log("chained:", seen);
+}
+
+run().then(chained);


### PR DESCRIPTION
## Summary

A `TransformStream` whose `flush(controller)` completes **asynchronously** dropped whatever that flush enqueued. `transform_close` invoked the user flush callback and then closed the readable side synchronously on the very next line, ignoring the promise `flush()` returned. Any `controller.enqueue()` the transformer deferred — e.g. from a `setImmediate` scheduled in `transform()`, with `flush()` handing back the promise that resolves once it runs — landed on an already-closed readable and was silently lost.

Per the WHATWG Streams spec, `TransformStreamDefaultSink`'s close **awaits the transformer's flush completion** before closing the readable controller.

## Impact — #5989 Next.js force-dynamic `bytes=0`

React's Fizz → HTTP-response pipeline begins with `createBufferedTransformStream`, which buffers every chunk in `transform()` and emits the coalesced chunk from a `setImmediate`; its `flush()` returns the promise that resolves once that deferred enqueue runs. Perry closed the readable before the `setImmediate` fired, so the buffered HTML never reached `res.write` and **every force-dynamic route streamed an HTTP 200 with `content-length: 0`.**

With this fix the Next.js standalone `/plain` route streams its body: **`bytes=0` → `bytes=4490`**, with the rendered `<main><h1>Plain</h1>…</main>` and the RSC flight data delivered.

## Fix

Capture `flush()`'s return value. When it is a still-pending promise, defer the readable close by chaining onto its settlement via `js_promise_then` (mirroring the existing `resolve_reader_read_value` native-continuation pattern):

- **fulfilled** → close the readable (delivering the deferred chunk) and resolve the close-request promise;
- **rejected** → error the readable and reject;
- **non-promise / already-fulfilled** → the previous synchronous close, unchanged.

The write path is untouched (the buffered transform returns `undefined` from `transform()` — no promise — so writes still resolve synchronously, matching node).

## Validation

- New gap test `test_gap_transform_stream_deferred_flush.ts` — a buffered transform (deferred `setImmediate` enqueue + promise-returning `flush()`) piped to a sink, plus two such transforms chained — **byte-identical to node**.
- Stream regression: `test_gap_readable_stream_tee_pull` + `test_gap_2823_2825_2822_promise_semantics` pass; identity / pipeThrough / immediate-flush isolations pass.
- Next.js standalone min-app: `/plain` HTTP 200 with a streamed body (was empty).
- `cargo fmt` clean; builds on `main`.

Code-only; no version/changelog bump (maintainer folds metadata at merge).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transform streams now wait for asynchronous `flush()` operations to complete before closing.
  * Rejected flush operations correctly propagate errors instead of closing prematurely.
  * Buffered data is preserved and delivered in both single and chained transform pipelines.

* **Tests**
  * Added coverage for deferred flush behavior, including buffered output and chained transforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->