### PR TITLE
perf(codegen): LLVM attributes on verified-pure runtime-helper declarations (#6082)

### DIFF
--- a/crates/perry-codegen/src/module.rs
+++ b/crates/perry-codegen/src/module.rs
@@ -58,6 +58,75 @@ fn promote_global_for_units(line: &str) -> String {
     }
 }
 
+/// Attribute-group suffix for a runtime-helper `declare` line, keyed by
+/// helper name (#6082 tranche 1).
+///
+/// Without attributes, -O3 must treat every `js_*` call as "may read and
+/// write all memory, may not return" — no CSE/LICM/DCE across any helper
+/// call. The two groups below re-enable those optimizations for a small,
+/// individually audited allowlist:
+///
+/// * `#2` (PURE) = `nounwind willreturn memory(none)`. Invariant: the
+///   helper's Rust body (transitively) performs NaN-box BIT manipulation
+///   only — no loads, no stores, no allocation, no GC trigger, no
+///   `js_throw`/longjmp, and it is total over arbitrary input bits (no
+///   panic, no UB), so LLVM may CSE/hoist/sink/delete it freely.
+/// * `#3` (READONLY) = `nounwind willreturn memory(read)`. Invariant: the
+///   helper may READ heap memory (string headers, BigInt limbs) but never
+///   writes, never allocates, never triggers GC, never takes a lock, and
+///   never throws. LLVM may CSE/LICM it across write-free regions and
+///   delete unused calls, but must still order it against any
+///   possibly-writing call — which keeps it correct w.r.t. the moving GC,
+///   because every GC-capable helper stays maximally clobbering.
+///
+/// SOUNDNESS NOTES (read before adding an entry):
+/// * Deliberately `memory(read)`, NOT `memory(argmem: read)`: helper args
+///   are f64 NaN-boxes, not LLVM pointer arguments, so `argmem` would mean
+///   "reads no memory at all" and license CSE/DSE across real heap reads.
+/// * Anything that can allocate or trigger GC gets NO group — the moving
+///   GC's shadow-stack reload discipline depends on those calls staying
+///   maximally clobbering.
+/// * Anything that can reach `js_throw` (setjmp/longjmp) gets NO group —
+///   `willreturn` would let DCE delete a throwing call whose result is
+///   unused, silently dropping the exception.
+///
+/// Audited and rejected (do not re-add without a new audit):
+/// `js_nanbox_string` (allocates an empty string for null input),
+/// `js_get_string_pointer_unified` / `js_typed_string_arg_to_raw`
+/// (materialize SSO strings onto the heap = allocation),
+/// `js_typed_f64_arg_to_raw` (routes through `js_number_coerce`, whose
+/// string/object paths read+parse and reach ToPrimitive),
+/// `js_value_length_f64` (Buffer/TypedArray registry lookups take locks —
+/// a lock acquisition writes memory).
+fn helper_decl_attrs(name: &str) -> &'static str {
+    match name {
+        // PURE — each verified: pure bit tests/masking on the f64/i64 args,
+        // total over arbitrary bits, no memory access anywhere in the body.
+        //   js_nanbox_pointer        value/nanbox.rs — tag ladder, 0 → TAG_NULL
+        //   js_nanbox_get_pointer    value/nanbox.rs — mask ladder, no deref
+        //   js_typed_f64_arg_guard   native_abi.rs — tag-band check
+        //   js_typed_i32_arg_guard   native_abi.rs — tag check + finite/fract/range
+        //   js_typed_i1_arg_guard    native_abi.rs — bits == TAG_TRUE|TAG_FALSE
+        //   js_typed_i1_arg_to_raw   native_abi.rs — bits == TAG_TRUE
+        //   js_typed_i32_arg_to_raw  native_abi.rs — bit extract / saturating cast
+        //   js_typed_string_arg_guard native_abi.rs — STRING/SHORT_STRING tag check
+        "js_nanbox_pointer"
+        | "js_nanbox_get_pointer"
+        | "js_typed_f64_arg_guard"
+        | "js_typed_i32_arg_guard"
+        | "js_typed_i1_arg_guard"
+        | "js_typed_i1_arg_to_raw"
+        | "js_typed_i32_arg_to_raw"
+        | "js_typed_string_arg_guard" => " #2",
+        // READONLY — verified: tag ladder plus reads of StringHeader.utf16_len
+        // (via is_valid_string_ptr, a pure magnitude check) and BigInt limbs
+        // (js_bigint_is_zero via clean_bigint_ptr, pure bit cleanup). No
+        // registry/lock access, no allocation, no throw, no writes.
+        "js_is_truthy" => " #3",
+        _ => "",
+    }
+}
+
 /// Synthesize an external `declare` line matching a locally-defined function's
 /// signature, so a codegen unit that calls it (but does not define it) resolves
 /// the call at link time.
@@ -163,10 +232,15 @@ impl LlModule {
         // the setjmp boundary. Without it, local variables modified
         // between setjmp and longjmp are clobbered when the second
         // return (via longjmp) happens.
+        //
+        // Verified-pure runtime helpers get the #2/#3 optimization groups
+        // (#6082) — see `helper_decl_attrs` for the audit invariants. The
+        // lookup is name-keyed here in the single declaration funnel so
+        // every declaration path agrees on the attributes.
         let attrs = if name == "setjmp" || name == "_setjmp" {
             " #0"
         } else {
-            ""
+            helper_decl_attrs(name)
         };
         self.declarations.push((
             name.to_string(),
@@ -367,6 +441,24 @@ impl LlModule {
             // (else try-body mutations are invisible to catch after longjmp);
             // `noinline` keeps the constraint from being lost via inlining.
             ir.push_str("attributes #1 = { noinline optnone }\n");
+        }
+        // Verified runtime-helper groups (#6082) — emitted only when a
+        // declaration actually references them (mirrors the setjmp gating
+        // above). See `helper_decl_attrs` for the audit invariants.
+        let mut used_pure = false;
+        let mut used_readonly = false;
+        for name in &self.declared_names {
+            match helper_decl_attrs(name) {
+                " #2" => used_pure = true,
+                " #3" => used_readonly = true,
+                _ => {}
+            }
+        }
+        if used_pure {
+            ir.push_str("\nattributes #2 = { nounwind willreturn memory(none) }\n");
+        }
+        if used_readonly {
+            ir.push_str("\nattributes #3 = { nounwind willreturn memory(read) }\n");
         }
         // Issue #52: `!0 = !{}` referenced by `!invariant.load !0`, plus the
         // buffer alias-scope metadata. LICM/GVN hoist invariant loads out of
@@ -619,6 +711,82 @@ mod tests {
         let f = m.define_function("main", I32, vec![]);
         f.create_block("entry").ret(I32, "0");
         assert_eq!(m.render_codegen_units(1), vec![m.to_ir()]);
+    }
+
+    #[test]
+    fn helper_attr_groups_on_verified_declarations_only() {
+        // #6082: allowlisted helpers carry the #2 (pure) / #3 (readonly)
+        // group refs; a non-allowlisted helper (js_nanbox_string ALLOCATES)
+        // must not; each attributes line is emitted exactly once.
+        let mut m = LlModule::new("arm64-apple-macosx15.0.0");
+        m.declare_function("js_nanbox_get_pointer", I64, &[DOUBLE]);
+        m.declare_function("js_is_truthy", I32, &[DOUBLE]);
+        m.declare_function("js_nanbox_string", DOUBLE, &[I64]);
+        let f = m.define_function("main", I32, vec![]);
+        f.create_block("entry").ret(I32, "0");
+
+        let ir = m.to_ir();
+        assert!(
+            ir.contains("declare i64 @js_nanbox_get_pointer(double) #2"),
+            "pure helper must carry the #2 group ref"
+        );
+        assert!(
+            ir.contains("declare i32 @js_is_truthy(double) #3"),
+            "readonly helper must carry the #3 group ref"
+        );
+        assert!(
+            ir.contains("declare double @js_nanbox_string(i64)\n"),
+            "allocating helper must stay attribute-free"
+        );
+        assert!(!ir.contains("js_nanbox_string(i64) #"));
+        assert_eq!(
+            ir.matches("attributes #2 = { nounwind willreturn memory(none) }")
+                .count(),
+            1
+        );
+        assert_eq!(
+            ir.matches("attributes #3 = { nounwind willreturn memory(read) }")
+                .count(),
+            1
+        );
+        // No setjmp declared → the setjmp-only groups stay out.
+        assert!(!ir.contains("attributes #0"));
+        assert!(!ir.contains("attributes #1"));
+    }
+
+    #[test]
+    fn helper_attr_groups_omitted_when_unused() {
+        // A module that declares no allowlisted helper must not emit the
+        // #2/#3 attributes lines (mirrors the setjmp #0/#1 gating).
+        let mut m = LlModule::new("arm64-apple-macosx15.0.0");
+        m.declare_function("js_console_log_number", VOID, &[DOUBLE]);
+        let f = m.define_function("main", I32, vec![]);
+        f.create_block("entry").ret(I32, "0");
+        let ir = m.to_ir();
+        assert!(!ir.contains("attributes #2"));
+        assert!(!ir.contains("attributes #3"));
+    }
+
+    #[test]
+    fn helper_attr_groups_replicated_in_codegen_units() {
+        // Every codegen unit re-emits the declaration (with its group ref)
+        // and the attributes line, so #2/#3 references resolve per-unit.
+        let mut m = LlModule::new("arm64-apple-macosx15.0.0");
+        m.declare_function("js_is_truthy", I32, &[DOUBLE]);
+        for k in 0..2 {
+            let f = m.define_function(format!("perry_fn_m__f{k}"), DOUBLE, vec![]);
+            f.create_block("entry").ret(DOUBLE, "0.0");
+        }
+        let units = m.render_codegen_units(2);
+        assert_eq!(units.len(), 2);
+        for u in &units {
+            assert!(u.contains("declare i32 @js_is_truthy(double) #3"));
+            assert_eq!(
+                u.matches("attributes #3 = { nounwind willreturn memory(read) }")
+                    .count(),
+                1
+            );
+        }
     }
 
     #[test]

--- a/test-files/test_gap_6082_helper_attr_soundness.ts
+++ b/test-files/test_gap_6082_helper_attr_soundness.ts
@@ -1,0 +1,132 @@
+// #6082 negative control: LLVM attribute groups (#2 pure / #3 readonly) on
+// verified runtime-helper declarations must not change observable behavior
+// at -O3. Exercises the user-visible surface of every annotated helper —
+// js_is_truthy, js_nanbox_pointer / js_nanbox_get_pointer, and the
+// js_typed_{f64,i32,i1,string}_arg_guard / _to_raw family — plus a control
+// that a NON-annotated throwing helper (BigInt + Number mix) still throws
+// when its result is unused. Compared byte-for-byte against node.
+
+// --- 1) throwing helper, result UNUSED: DCE must not delete the call. ---
+function throwingUnusedResult(): string {
+  const big: any = 10n;
+  const num: any = 3;
+  try {
+    // js_add (NOT annotated) throws TypeError on BigInt+Number mix; the
+    // result is deliberately unused. willreturn on this call would let
+    // -O3 delete it and swallow the exception.
+    big + num;
+    return "no-throw";
+  } catch (e: any) {
+    return "caught " + (e instanceof TypeError ? "TypeError" : "other");
+  }
+}
+console.log("unused-throw:", throwingUnusedResult());
+
+// Same shape inside a loop (LICM bait): the throw must fire every iteration.
+let throwCount = 0;
+for (let i = 0; i < 3; i++) {
+  try {
+    const b: any = 1n;
+    const n: any = i;
+    b + n;
+  } catch {
+    throwCount++;
+  }
+}
+console.log("loop-throws:", throwCount);
+
+// --- 2) js_is_truthy (readonly): dynamic truthiness across the tag ladder,
+// with allocations interleaved so hoisting/CSE across GC-capable calls
+// would be observable if unsound. ---
+const truthyProbes: any[] = [
+  "", "x", "hello world, a heap string", 0, -0, NaN, 1, 0n, 10n,
+  null, undefined, true, false, {}, [], "😀",
+];
+let truthyBits = "";
+for (const p of truthyProbes) {
+  // Allocation between checks (string concat) — a moving-GC trigger point.
+  truthyBits += p ? "1" : "0";
+}
+console.log("truthy-ladder:", truthyBits);
+
+// Loop-invariant dynamic condition (LICM bait for the readonly group):
+// the string is checked every iteration while the loop body allocates.
+const invariant: any = "steady";
+let hoistSum = 0;
+const junk: string[] = [];
+for (let i = 0; i < 50; i++) {
+  if (invariant) hoistSum += 1;
+  junk.push("alloc" + i);
+  if (junk.length > 10) junk.length = 0;
+}
+console.log("licm-truthy:", hoistSum);
+
+// Truthiness of a value that CHANGES between identical-looking checks —
+// unsound CSE of js_is_truthy(v1)/js_is_truthy(v2) would merge these.
+let mut: any = "";
+const before = mut ? "T" : "F";
+mut = mut + "grew";
+const after = mut ? "T" : "F";
+console.log("cse-guard:", before + after);
+
+// --- 3) js_nanbox_pointer / js_nanbox_get_pointer (pure): objects moving
+// through any-typed unions and back. ---
+const objA: any = { tag: "A", n: 1 };
+const objB: any = { tag: "B", n: 2 };
+let pick: any = objA;
+const t1 = pick.tag;
+pick = objB;
+const t2 = pick.tag;
+console.log("boxing:", t1 + t2, objA.n + objB.n);
+
+// --- 4) typed arg guards + to_raw: call typed functions through any-typed
+// references with both guard-passing and guard-failing argument types. ---
+function addNums(a: number, b: number): number {
+  return a + b;
+}
+function pickFlag(b: boolean): string {
+  return b ? "yes" : "no";
+}
+function shout(s: string): string {
+  return s + "!";
+}
+function countUp(n: number): number {
+  let acc = 0;
+  for (let i = 0; i < n; i++) acc += i;
+  return acc;
+}
+
+const fAdd: any = addNums;
+const fFlag: any = pickFlag;
+const fShout: any = shout;
+const fCount: any = countUp;
+
+try {
+  // Guard-pass paths (typed clones): number/number, boolean, string, int32.
+  console.log("guards-pass:", fAdd(2, 3), fFlag(true), fShout("hi"), fCount(5));
+  // Guard-fail paths (generic fallback). Probes are limited to inputs where
+  // Perry's fallback agrees with node (the fallback's coercion semantics for
+  // e.g. string-into-number-slot are a pre-existing, separately-tracked gap
+  // unrelated to #6082): fractional into the int32 slot, and falsy
+  // non-booleans into the boolean slot.
+  console.log(
+    "guards-fail:",
+    fCount(2.5),
+    fFlag(0 as any),
+    fFlag("" as any),
+  );
+} catch (e: any) {
+  console.log("guard-threw:", e instanceof TypeError ? "TypeError" : "other");
+}
+
+// Guards inside an allocating loop: same function, alternating guard-pass
+// (integral) and guard-fail (fractional) argument classes — CSE/hoist of
+// the guard across iterations would misroute dispatch and skew the sums.
+let mixed = "";
+for (let i = 0; i < 6; i++) {
+  const arg: any = i % 2 === 0 ? i : i + 0.5;
+  mixed += fCount(arg) + "|";
+}
+console.log("guard-alternate:", mixed);
+
+console.log("done");


### PR DESCRIPTION
## Summary

Runtime-helper `declare` lines carried **zero LLVM attributes**, so `-O3` had to treat every `js_*` call as "may read and write all memory, may not return". Since nearly all non-arithmetic JS lowers to helper calls, the optimizer could only work inside pure-numeric islands: no CSE of two `js_nanbox_get_pointer` on the same value, no LICM of a loop-invariant truthiness test, no DCE of a dead guard.

This is **tranche 1** of #6082: the attribute machinery plus a small, individually audited allowlist. It is deliberately conservative — the failure modes here (a dropped `throw`, a stale pointer after evacuation) are *silent*, so the allowlist is short and every entry was checked against its Rust body transitively.

## Mechanism

Declarations funnel through `LlModule::declare_function` (`crates/perry-codegen/src/module.rs`), which already appends `#0` (`returns_twice`) for `setjmp`. A name-keyed `helper_decl_attrs` now returns an attribute-group suffix for allowlisted helpers, and `push_attrs_and_metadata` emits the group definitions only when a declaration actually references them (mirroring the existing `#0`/`#1` gating):

- `#2` **PURE** — `nounwind willreturn memory(none)`
- `#3` **READONLY** — `nounwind willreturn memory(read)`

## Allowlist and audit

Each entry was verified by reading its Rust body and everything it calls.

| Helper | Group | Audit |
|---|---|---|
| `js_nanbox_pointer` | `#2` | tag ladder + mask, no deref |
| `js_nanbox_get_pointer` | `#2` | `is_pointer`/`is_string`/`is_bigint` + mask extraction — **never dereferences** the pointee |
| `js_typed_f64_arg_guard` | `#2` | `is_number \|\| is_int32`, pure bit tests |
| `js_typed_i32_arg_guard` | `#2` | tag test + finite/fract/range on the f64 |
| `js_typed_i1_arg_guard` | `#2` | `bits == TAG_TRUE \| TAG_FALSE` |
| `js_typed_i1_arg_to_raw` | `#2` | `bits == TAG_TRUE` |
| `js_typed_i32_arg_to_raw` | `#2` | bit extract / saturating cast |
| `js_typed_string_arg_guard` | `#2` | `is_string \|\| is_short_string` — tag-band test only, no deref |
| `js_is_truthy` | `#3` | reads `StringHeader.utf16_len` and BigInt limbs; no writes, no allocation, no lock, no throw |

The `js_typed_*` guards are all **non-throwing by contract** (a failed guard routes codegen to the generic JSValue body), which is what makes `willreturn` safe on them.

**Audited and rejected** (do not re-add without a fresh audit): `js_nanbox_string` (allocates an empty string for null input), `js_get_string_pointer_unified` / `js_typed_string_arg_to_raw` (materialize SSO strings onto the heap = allocation), `js_typed_f64_arg_to_raw` (routes through `js_number_coerce`, whose string/object paths parse and reach ToPrimitive), `js_value_length_f64` (Buffer/TypedArray registry lookups take locks — a lock acquisition writes memory).

## Soundness boundary

Three rules govern the allowlist, documented on `helper_decl_attrs`:

1. **`memory(read)`, never `memory(argmem: read)`.** The issue text suggested `argmem`, but that is *wrong for Perry*: helper args are `f64` NaN-boxes, not LLVM pointer arguments, so LLVM would conclude argmem is empty → "reads nothing" → license CSE/DSE across real heap reads. `memory(read)` (reads-any, writes-none) is the correct model.
2. **Anything that can allocate or trigger GC gets no group.** The moving GC's shadow-stack reload discipline depends on those calls staying maximally clobbering; `memory(none)` there would license deleting the post-call pointer reload and reintroduce the #6206 stale-pointer class via the optimizer.
3. **Anything that can reach `js_throw` gets no group.** `try/catch` is setjmp/longjmp, not LLVM unwind, so `willreturn` on a throw-reachable helper would let DCE **delete the call when its result is unused** — silently swallowing the exception.

Because every GC-capable and throw-capable helper stays unannotated (and therefore maximally clobbering), LLVM can neither hoist a `memory(read)` call across a GC point nor reorder one against a write.

## Verification

- **Codegen unit tests** (3 new, `module.rs`): allowlisted decls carry `#2`/`#3`; a non-allowlisted allocating helper (`js_nanbox_string`) stays attribute-free; the `attributes` lines are emitted exactly once, only when referenced, and are replicated into every codegen unit so per-unit references resolve.
- **Negative control** (`test-files/test_gap_6082_helper_attr_soundness.ts`, new gap test) — the point of the PR. Baits the two failure modes directly: a throwing helper (`10n + 3`) whose **result is unused**, both straight-line and inside a loop (DCE/LICM bait); loop-invariant `js_is_truthy` with allocation churn in the body; the full truthiness tag ladder incl. `""`/`0`/`-0`/`NaN`/`0n`/`10n`/`{}`/`[]`; and the typed-guard pass/fail/alternating paths. **Byte-identical to `node --experimental-strip-types`** — the `TypeError` still fires (3/3 loop iterations).
- **GC evacuation stress**: the negative control is byte-identical to Node under `PERRY_GC_FORCE_EVACUATE=1`, `PERRY_GC_VERIFY_EVACUATION=1`, and both together.
- **Gap suite**: no new failures. The run reports three untriaged failures — `test_gap_disposablestack_2875`, `test_gap_events_import_4995`, and `test_gap_http_overloads_3226plus` (a crash) — and all three were **A/B'd against the base commit** (`bc744f39b`) by reverting `module.rs` in place and rebuilding: the first two already differ from Node on base, and the third already crashes on base (exit 134). All pre-existing on `main`, none introduced here.
- `cargo fmt --all -- --check` clean; `cargo test -p perry-codegen` green.

## Scope

Tranche 1 only. Follow-ups (each needing its own audit): the wider read-only family (string/array accessors that provably don't allocate or lock), `memory(inaccessiblemem: readwrite)` for allocation helpers that don't touch user-visible memory, and `nounwind` alone on the many helpers that neither throw nor are pure enough for a memory group.

Part of #6082.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime helper handling during optimized builds, preserving observable behavior for throwing, truthiness, pointer conversion, and typed argument operations.
  * Prevented unsafe optimization of helpers that may allocate or produce side effects.

* **Tests**
  * Added coverage for helper behavior under high optimization, including garbage collection, allocation, repeated exceptions, and invalid typed arguments.
  * Added validation that optimization metadata is applied only to approved helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->