### PR TITLE
fix(runtime): string scanners must not read past exact-sized slice allocations (#6085)

### DIFF
--- a/crates/perry-runtime/src/string/char_ops.rs
+++ b/crates/perry-runtime/src/string/char_ops.rs
@@ -78,22 +78,44 @@ pub extern "C" fn js_string_char_code_at(s: *const StringHeader, index: i32) -> 
         }
     }
 
-    // Non-ASCII: walk codepoints counting UTF-16 units. Allocation-free.
-    let str_data = string_as_str(s);
-    let mut utf16_pos = 0usize;
-    for ch in str_data.chars() {
-        let clen = ch.len_utf16();
-        if utf16_pos + clen > idx {
-            if clen == 1 {
-                return ch as u32 as f64;
-            }
-            let mut buf = [0u16; 2];
-            ch.encode_utf16(&mut buf);
-            return buf[idx - utf16_pos] as f64;
-        }
-        utf16_pos += clen;
+    // Non-ASCII: bounded WTF-8 walk counting UTF-16 units (#6085). The
+    // previous `str_data.chars()` loop decoded through the UTF-8-validity
+    // assumption, which over-reads an exact-sized payload ending in a
+    // truncated multi-byte lead. Allocation-free, never reads past byte_len.
+    match utf16_unit_at(s, idx) {
+        Some(unit) => unit as f64,
+        None => f64::NAN,
     }
-    f64::NAN
+}
+
+/// Bounded lookup of the UTF-16 code unit at `idx` (UTF-16 index) in a
+/// non-ASCII string's WTF-8 payload. Never reads past `byte_len` (#6085);
+/// truncated tail bytes decode from what is present (missing bytes read as 0),
+/// matching `wtf8_step`. Returns `None` when `idx` is past the last decodable
+/// unit (an invalid payload's header `utf16_len` can overcount).
+fn utf16_unit_at(s: *const StringHeader, idx: usize) -> Option<u16> {
+    let bytes = unsafe { slice::from_raw_parts(string_data(s), (*s).byte_len as usize) };
+    let mut utf16_pos = 0usize;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let (advance, units, cp) = crate::string::wtf8_step(bytes, i);
+        if units > 0 && utf16_pos + units > idx {
+            return Some(if units == 2 {
+                // Astral code point → the requested surrogate half.
+                let v = cp.wrapping_sub(0x10000);
+                if idx == utf16_pos {
+                    0xD800 + ((v >> 10) & 0x3FF) as u16
+                } else {
+                    0xDC00 + (v & 0x3FF) as u16
+                }
+            } else {
+                cp as u16
+            });
+        }
+        utf16_pos += units;
+        i += advance;
+    }
+    None
 }
 
 /// `s[key]` indexed read with ECMAScript CanonicalNumericIndexString semantics
@@ -191,58 +213,12 @@ pub extern "C" fn js_string_char_at(s: *const StringHeader, index: i32) -> *mut 
     // their surrogate halves, so `"😀"[0]` is the lone high surrogate (length
     // 1) — matching JS UTF-16 indexing (#4793). Walking bytes directly (rather
     // than `str::chars()`) keeps this sound on inputs that already hold lone
-    // surrogates.
-    let target = index as usize;
-    let bytes = unsafe { slice::from_raw_parts(string_data(s), (*s).byte_len as usize) };
-    let mut u16_pos = 0usize;
-    let mut i = 0usize;
-    while i < bytes.len() {
-        let b = bytes[i];
-        // Decode one WTF-8 sequence into its code point and UTF-16 width.
-        let (seq_len, units, cp) = if b < 0x80 {
-            (1usize, 1usize, b as u32)
-        } else if b < 0xE0 {
-            let b1 = bytes.get(i + 1).copied().unwrap_or(0);
-            (2, 1, ((b as u32 & 0x1F) << 6) | (b1 as u32 & 0x3F))
-        } else if b < 0xF0 {
-            let b1 = bytes.get(i + 1).copied().unwrap_or(0);
-            let b2 = bytes.get(i + 2).copied().unwrap_or(0);
-            (
-                3,
-                1,
-                ((b as u32 & 0x0F) << 12) | ((b1 as u32 & 0x3F) << 6) | (b2 as u32 & 0x3F),
-            )
-        } else {
-            let b1 = bytes.get(i + 1).copied().unwrap_or(0);
-            let b2 = bytes.get(i + 2).copied().unwrap_or(0);
-            let b3 = bytes.get(i + 3).copied().unwrap_or(0);
-            (
-                4,
-                2,
-                ((b as u32 & 0x07) << 18)
-                    | ((b1 as u32 & 0x3F) << 12)
-                    | ((b2 as u32 & 0x3F) << 6)
-                    | (b3 as u32 & 0x3F),
-            )
-        };
-        if target < u16_pos + units {
-            let unit = if units == 2 {
-                // Astral: emit the requested surrogate half.
-                let v = cp - 0x10000;
-                if target == u16_pos {
-                    0xD800 + (v >> 10) as u16
-                } else {
-                    0xDC00 + (v & 0x3FF) as u16
-                }
-            } else {
-                cp as u16
-            };
-            return string_from_code_unit(unit);
-        }
-        u16_pos += units;
-        i += seq_len;
+    // surrogates, and `wtf8_step` bounds every continuation-byte read so a
+    // truncated multi-byte tail can't read past the exact-sized payload (#6085).
+    match utf16_unit_at(s, index as usize) {
+        Some(unit) => string_from_code_unit(unit),
+        None => js_string_from_bytes(std::ptr::null(), 0),
     }
-    js_string_from_bytes(std::ptr::null(), 0)
 }
 
 /// Split a string into an array of single-character strings.
@@ -255,14 +231,27 @@ pub extern "C" fn js_string_to_char_array(s: i64) -> i64 {
     if str_ptr.is_null() || !is_valid_string_ptr(str_ptr) {
         return crate::array::js_array_alloc(0) as i64;
     }
-    let str_data = string_as_str(str_ptr);
-    let char_count = str_data.chars().count();
-    let arr = crate::array::js_array_alloc_with_length(char_count as u32);
+    // Bounded WTF-8 walk (#6085): `string_as_str(..).chars()` decodes through
+    // std's UTF-8-validity assumption, so a payload whose last sequence is a
+    // truncated multi-byte lead (WTF-8 / Buffer / FFI-sourced bytes are not
+    // guaranteed well-formed) reads up to 3 bytes past the exact-sized
+    // allocation. `wtf8_step` bounds every continuation read; well-formed input
+    // yields byte-identical elements.
+    let bytes =
+        unsafe { slice::from_raw_parts(string_data(str_ptr), (*str_ptr).byte_len as usize) };
+    let mut spans: Vec<(usize, usize)> = Vec::new();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let (advance, _, _) = crate::string::wtf8_step(bytes, i);
+        let end = (i + advance).min(bytes.len());
+        spans.push((i, end));
+        i = end;
+    }
+    let arr = crate::array::js_array_alloc_with_length(spans.len() as u32);
     let elements = unsafe { (arr as *mut u8).add(8) as *mut f64 };
-    for (i, ch) in str_data.chars().enumerate() {
-        let mut buf = [0u8; 4];
-        let encoded = ch.encode_utf8(&mut buf);
-        let ch_ptr = js_string_from_bytes(encoded.as_ptr(), encoded.len() as u32);
+    for (i, &(start, end)) in spans.iter().enumerate() {
+        let seq = &bytes[start..end];
+        let ch_ptr = js_string_from_bytes(seq.as_ptr(), seq.len() as u32);
         let nanboxed =
             f64::from_bits(crate::value::STRING_TAG | (ch_ptr as u64 & crate::value::POINTER_MASK));
         unsafe {
@@ -515,9 +504,13 @@ pub extern "C" fn js_string_at(s: *const StringHeader, index: i32) -> f64 {
     if !is_valid_string_ptr(s) {
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
-    let str_data = string_as_str(s);
-    let utf16: Vec<u16> = str_data.encode_utf16().collect();
-    let len = utf16.len() as i32;
+    // #6085: the old `string_as_str(s).encode_utf16().collect()` materialized
+    // every code unit through std's UTF-8-validity assumption, reading past an
+    // exact-sized payload whose last sequence is a truncated multi-byte lead.
+    // The header's `utf16_len` already IS the code-unit count (it is computed
+    // by the WTF-8-aware `compute_utf16_len` at construction), so resolve the
+    // negative index against it and fetch the single unit with the bounded walk.
+    let len = unsafe { (*s).utf16_len } as i32;
     let resolved = if index < 0 { len + index } else { index };
     if resolved < 0 || resolved >= len {
         return f64::from_bits(crate::value::TAG_UNDEFINED);
@@ -526,7 +519,14 @@ pub extern "C" fn js_string_at(s: *const StringHeader, index: i32) -> f64 {
     // NOT code-point based like `codePointAt`. For an astral char stored as a
     // surrogate pair, each index returns the lone surrogate code unit (Node:
     // `"😀".at(0).charCodeAt(0) === 0xd83d`), it does NOT decode the pair.
-    let unit = utf16[resolved as usize];
+    let unit = if is_ascii_string(s) {
+        unsafe { *string_data(s).add(resolved as usize) as u16 }
+    } else {
+        match utf16_unit_at(s, resolved as usize) {
+            Some(u) => u,
+            None => return f64::from_bits(crate::value::TAG_UNDEFINED),
+        }
+    };
     // Encode the single code unit. A lone surrogate (0xD800..=0xDFFF) is not a
     // valid Rust `char`, so it materializes as U+FFFD — the documented WTF-8 /
     // lone-surrogate categorical gap (same shim as `fromCharCode`). BMP units
@@ -558,23 +558,26 @@ pub extern "C" fn js_string_code_point_at(s: *const StringHeader, index: i32) ->
         }
     }
 
-    // Non-ASCII: walk codepoints without allocating a Vec<u16>.
-    let str_data = string_as_str(s);
+    // Non-ASCII: bounded WTF-8 walk (#6085) — the old `str_data.chars()` loop
+    // read continuation bytes past an exact-sized payload ending in a truncated
+    // multi-byte lead. Allocation-free either way.
+    let bytes = unsafe { slice::from_raw_parts(string_data(s), (*s).byte_len as usize) };
     let mut utf16_pos = 0usize;
-    for ch in str_data.chars() {
-        let clen = ch.len_utf16();
-        if utf16_pos + clen > idx {
-            if clen == 1 || utf16_pos == idx {
-                // Either a BMP char, or the start of a surrogate pair
-                // (which is the whole codepoint per the spec).
-                return ch as u32 as f64;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let (advance, units, cp) = crate::string::wtf8_step(bytes, i);
+        if units > 0 && utf16_pos + units > idx {
+            if units == 1 || utf16_pos == idx {
+                // Either a BMP code point, or the START of a surrogate pair —
+                // which per spec is the whole code point.
+                return cp as f64;
             }
-            // Index lands on the low surrogate — return the bare unit.
-            let mut buf = [0u16; 2];
-            ch.encode_utf16(&mut buf);
-            return buf[idx - utf16_pos] as f64;
+            // Index lands on the low surrogate half — return the bare unit.
+            let v = cp.wrapping_sub(0x10000);
+            return (0xDC00 + (v & 0x3FF)) as f64;
         }
-        utf16_pos += clen;
+        utf16_pos += units;
+        i += advance;
     }
     f64::from_bits(crate::value::TAG_UNDEFINED)
 }

--- a/crates/perry-runtime/src/string/mod.rs
+++ b/crates/perry-runtime/src/string/mod.rs
@@ -40,6 +40,11 @@ pub(crate) use split::spec_regex_split;
 #[cfg(test)]
 mod tests;
 
+/// #6085 guard-page regression tests: prove no string scanner reads past the
+/// end of an exact-sized payload. Unix-only (needs `mmap` + `mprotect`).
+#[cfg(all(test, unix))]
+mod tests_guard_page;
+
 // Explicit named re-exports — preserve the original `crate::string::*`
 // surface 1:1. NO glob re-exports.
 pub use alloc::{
@@ -264,32 +269,115 @@ pub(crate) fn compute_utf16_len(data: *const u8, byte_len: u32) -> u32 {
     }
 }
 
+/// One bounded WTF-8 decode step at `bytes[i]` (caller guarantees `i < bytes.len()`).
+/// Returns `(advance, utf16_units, code_point)`.
+///
+/// Issue #6085: Perry heap-string payloads are EXACT-SIZED allocations
+/// (`string_storage_alloc` reserves `byte_len` bytes, no NUL terminator, no
+/// tail padding) and may legally hold non-UTF-8 bytes (WTF-8 lone surrogates,
+/// `Buffer.toString('utf8')` of arbitrary bytes, FFI blobs). Scanning such a
+/// payload through `str::from_utf8_unchecked(...)` + `chars()`/`encode_utf16()`
+/// is undefined behavior: the std decoders assume UTF-8 validity, so a
+/// multi-byte lead in the last 1–3 bytes licenses the optimizer to read the
+/// "guaranteed" continuation bytes past the end of the allocation. When the
+/// payload ends flush against an unmapped page that read is an access
+/// violation (`0x...FFF8`-style faulting addresses on Windows x64).
+///
+/// This helper is the bounds-driven replacement: it classifies the sequence
+/// from the lead byte exactly like [`compute_utf16_len_wtf8`] (so cursor walks
+/// agree with the `utf16_len` recorded in the header) and reads continuation
+/// bytes only via bounds-checked `get()`, substituting 0 for bytes that don't
+/// exist. Valid UTF-8/WTF-8 input decodes byte-for-byte identically to the
+/// std decoders.
+///
+/// - ASCII byte → `(1, 1, b)`
+/// - stray continuation byte in lead position → `(1, 0, 0xFFFD)` (skipped by
+///   unit counting, mirroring `compute_utf16_len_wtf8`)
+/// - 2/3-byte lead → `(2/3, 1, cp)`
+/// - 4-byte lead → `(4, 2, cp)` (astral → surrogate pair)
+///
+/// `advance` may point past `bytes.len()` for a truncated tail; loop
+/// conditions (`i < bytes.len()`) or an explicit `min(len)` clamp keep the
+/// cursor sound — exactly the convention `compute_utf16_len_wtf8` uses.
+#[inline]
+pub(crate) fn wtf8_step(bytes: &[u8], i: usize) -> (usize, usize, u32) {
+    let b = bytes[i];
+    if b < 0x80 {
+        return (1, 1, b as u32);
+    }
+    if b < 0xC0 {
+        // Continuation byte in lead position — invalid; skip one byte.
+        return (1, 0, 0xFFFD);
+    }
+    let b1 = bytes.get(i + 1).copied().unwrap_or(0) as u32;
+    if b < 0xE0 {
+        return (2, 1, ((b as u32 & 0x1F) << 6) | (b1 & 0x3F));
+    }
+    let b2 = bytes.get(i + 2).copied().unwrap_or(0) as u32;
+    if b < 0xF0 {
+        return (
+            3,
+            1,
+            ((b as u32 & 0x0F) << 12) | ((b1 & 0x3F) << 6) | (b2 & 0x3F),
+        );
+    }
+    let b3 = bytes.get(i + 3).copied().unwrap_or(0) as u32;
+    (
+        4,
+        2,
+        ((b as u32 & 0x07) << 18) | ((b1 & 0x3F) << 12) | ((b2 & 0x3F) << 6) | (b3 & 0x3F),
+    )
+}
+
 /// Convert a UTF-16 code unit index to a UTF-8 byte offset.
 /// Returns `s.len()` if `utf16_idx` is past the end.
+///
+/// Bounds-driven byte walk (#6085): the previous `s.chars()` loop decoded
+/// through the UTF-8-validity assumption, which over-reads an exact-sized
+/// payload ending in a truncated multi-byte lead. `wtf8_step` reads only
+/// bounds-checked bytes; valid input maps identically.
 #[inline]
 pub(crate) fn utf16_offset_to_byte_offset(s: &str, utf16_idx: usize) -> usize {
     if utf16_idx == 0 {
         return 0;
     }
-    let mut byte_off = 0;
-    let mut u16_count = 0;
-    for ch in s.chars() {
+    let bytes = s.as_bytes();
+    let mut byte_off = 0usize;
+    let mut u16_count = 0usize;
+    while byte_off < bytes.len() {
         if u16_count >= utf16_idx {
             return byte_off;
         }
-        byte_off += ch.len_utf8();
-        u16_count += ch.len_utf16();
+        let (advance, units, _) = wtf8_step(bytes, byte_off);
+        byte_off = (byte_off + advance).min(bytes.len());
+        u16_count += units;
     }
     byte_off // past the end → return full byte length
 }
 
 /// Convert a UTF-8 byte offset to a UTF-16 code unit index.
+///
+/// Bounds-driven (#6085): counts code units over the raw byte prefix instead
+/// of `s[..byte_off].encode_utf16()`, which both assumed UTF-8 validity and
+/// could panic on a non-char-boundary offset in an invalid payload.
 #[inline]
 pub(crate) fn byte_offset_to_utf16_index(s: &str, byte_off: usize) -> usize {
     if byte_off == 0 {
         return 0;
     }
-    s[..byte_off].encode_utf16().count()
+    let bytes = &s.as_bytes()[..byte_off.min(s.len())];
+    // ASCII fast path mirrors compute_utf16_len.
+    if bytes.iter().all(|&b| b < 0x80) {
+        return bytes.len();
+    }
+    let mut u16_count = 0usize;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let (advance, units, _) = wtf8_step(bytes, i);
+        i += advance;
+        u16_count += units;
+    }
+    u16_count
 }
 
 /// Heap storage policy for `StringHeader` strings.

--- a/crates/perry-runtime/src/string/slice_ops.rs
+++ b/crates/perry-runtime/src/string/slice_ops.rs
@@ -212,60 +212,153 @@ pub(crate) fn is_js_whitespace(c: char) -> bool {
     )
 }
 
-/// Trim whitespace from both ends of a string
-#[no_mangle]
-pub extern "C" fn js_string_trim(s: *const StringHeader) -> *mut StringHeader {
+/// Byte range `[start, end)` of `bytes` after trimming JS whitespace from the
+/// requested ends. Bounds-driven (#6085): decodes with `wtf8_step` instead of
+/// `str::trim_matches`, whose `chars()` walk reads continuation bytes past an
+/// exact-sized payload that ends in a truncated multi-byte lead.
+///
+/// Every JS whitespace code point is well-formed (ASCII, U+00A0, U+2028, …), so
+/// a truncated/invalid tail sequence is never whitespace and simply terminates
+/// the scan — trimming behavior on valid input is unchanged.
+fn js_whitespace_trim_range(bytes: &[u8], trim_start: bool, trim_end: bool) -> (usize, usize) {
+    let mut start = 0usize;
+    if trim_start {
+        while start < bytes.len() {
+            let (advance, units, cp) = crate::string::wtf8_step(bytes, start);
+            let is_ws = units > 0 && char::from_u32(cp).map(is_js_whitespace).unwrap_or(false);
+            if !is_ws {
+                break;
+            }
+            start = (start + advance).min(bytes.len());
+        }
+    }
+
+    let mut end = bytes.len();
+    if trim_end {
+        // Forward-walk from `start`, remembering the end of the last
+        // non-whitespace sequence. A reverse WTF-8 walk would have to guess
+        // sequence boundaries; this stays O(n) and never reads out of range.
+        let mut i = start;
+        let mut last_non_ws_end = start;
+        while i < bytes.len() {
+            let (advance, units, cp) = crate::string::wtf8_step(bytes, i);
+            let next = (i + advance).min(bytes.len());
+            let is_ws = units > 0 && char::from_u32(cp).map(is_js_whitespace).unwrap_or(false);
+            if !is_ws {
+                last_non_ws_end = next;
+            }
+            i = next;
+        }
+        end = last_non_ws_end;
+    }
+
+    (start, end.max(start))
+}
+
+/// Shared trim entry point over the raw payload bytes.
+fn trim_impl(s: *const StringHeader, trim_start: bool, trim_end: bool) -> *mut StringHeader {
     if !is_valid_string_ptr(s) {
         return js_string_from_bytes(ptr::null(), 0);
     }
+    let bytes = unsafe { slice::from_raw_parts(string_data(s), (*s).byte_len as usize) };
+    let (start, end) = js_whitespace_trim_range(bytes, trim_start, trim_end);
+    let out = &bytes[start..end];
+    // Preserve the WTF-8 flag: trimming only removes well-formed whitespace, so
+    // any lone surrogate in the source survives into the result.
+    let flags = unsafe { (*s).flags };
+    if flags & STRING_FLAG_HAS_LONE_SURROGATES != 0 {
+        return js_string_from_wtf8_bytes(out.as_ptr(), out.len() as u32);
+    }
+    js_string_from_bytes(out.as_ptr(), out.len() as u32)
+}
 
-    let str_data = string_as_str(s);
-    let trimmed = str_data.trim_matches(is_js_whitespace);
-    js_string_from_str(trimmed)
+/// Trim whitespace from both ends of a string
+#[no_mangle]
+pub extern "C" fn js_string_trim(s: *const StringHeader) -> *mut StringHeader {
+    trim_impl(s, true, true)
 }
 
 /// Trim whitespace from start of a string (trimStart/trimLeft)
 #[no_mangle]
 pub extern "C" fn js_string_trim_start(s: *const StringHeader) -> *mut StringHeader {
-    if !is_valid_string_ptr(s) {
-        return js_string_from_bytes(ptr::null(), 0);
-    }
-    let str_data = string_as_str(s);
-    js_string_from_str(str_data.trim_start_matches(is_js_whitespace))
+    trim_impl(s, true, false)
 }
 
 /// Trim whitespace from end of a string (trimEnd/trimRight)
 #[no_mangle]
 pub extern "C" fn js_string_trim_end(s: *const StringHeader) -> *mut StringHeader {
+    trim_impl(s, false, true)
+}
+
+/// Unicode case conversion over the raw payload (#6085).
+///
+/// `str::to_lowercase`/`to_uppercase` iterate `chars()`, which reads
+/// continuation bytes past an exact-sized payload ending in a truncated
+/// multi-byte lead. Decode with the bounded `wtf8_step` instead: sequences that
+/// form a real Unicode scalar get the full `char` case mapping (identical
+/// output for well-formed input, including multi-char expansions like `ß`→`SS`),
+/// while a lone surrogate or a truncated/invalid sequence is copied through
+/// VERBATIM — which also preserves the WTF-8 round-trip (#4793) that the old
+/// `from_utf8_unchecked` path only got by accident.
+fn case_convert(s: *const StringHeader, upper: bool) -> *mut StringHeader {
     if !is_valid_string_ptr(s) {
         return js_string_from_bytes(ptr::null(), 0);
     }
-    let str_data = string_as_str(s);
-    js_string_from_str(str_data.trim_end_matches(is_js_whitespace))
+    let bytes = unsafe { slice::from_raw_parts(string_data(s), (*s).byte_len as usize) };
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut has_lone_surrogate = false;
+    let mut buf = [0u8; 4];
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let (advance, units, cp) = crate::string::wtf8_step(bytes, i);
+        let end = (i + advance).min(bytes.len());
+        // A sequence is only case-mapped when it decodes to a real scalar value
+        // AND the encoder round-trips it (a truncated tail must not be
+        // "repaired" into a different character).
+        let mapped = if units > 0 && advance == end - i {
+            char::from_u32(cp)
+        } else {
+            None
+        };
+        match mapped {
+            Some(ch) => {
+                if upper {
+                    for c in ch.to_uppercase() {
+                        out.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+                    }
+                } else {
+                    for c in ch.to_lowercase() {
+                        out.extend_from_slice(c.encode_utf8(&mut buf).as_bytes());
+                    }
+                }
+            }
+            None => {
+                // Lone surrogate / truncated / stray continuation byte: copy the
+                // raw bytes so the payload round-trips unchanged.
+                if (0xD800..=0xDFFF).contains(&cp) {
+                    has_lone_surrogate = true;
+                }
+                out.extend_from_slice(&bytes[i..end]);
+            }
+        }
+        i = end;
+    }
+    if has_lone_surrogate || unsafe { (*s).flags } & STRING_FLAG_HAS_LONE_SURROGATES != 0 {
+        return js_string_from_wtf8_bytes(out.as_ptr(), out.len() as u32);
+    }
+    js_string_from_bytes(out.as_ptr(), out.len() as u32)
 }
 
 /// Convert string to lowercase
 #[no_mangle]
 pub extern "C" fn js_string_to_lower_case(s: *const StringHeader) -> *mut StringHeader {
-    if !is_valid_string_ptr(s) {
-        return js_string_from_bytes(ptr::null(), 0);
-    }
-
-    let str_data = string_as_str(s);
-    let lower = str_data.to_lowercase();
-    js_string_from_str(&lower)
+    case_convert(s, false)
 }
 
 /// Convert string to uppercase
 #[no_mangle]
 pub extern "C" fn js_string_to_upper_case(s: *const StringHeader) -> *mut StringHeader {
-    if !is_valid_string_ptr(s) {
-        return js_string_from_bytes(ptr::null(), 0);
-    }
-
-    let str_data = string_as_str(s);
-    let upper = str_data.to_uppercase();
-    js_string_from_str(&upper)
+    case_convert(s, true)
 }
 
 /// Find index of substring (-1 if not found)

--- a/crates/perry-runtime/src/string/slice_ops.rs
+++ b/crates/perry-runtime/src/string/slice_ops.rs
@@ -212,20 +212,35 @@ pub(crate) fn is_js_whitespace(c: char) -> bool {
     )
 }
 
+/// Is the WTF-8 sequence starting at `i` a JS whitespace code point?
+/// Returns `(is_whitespace, advance)`.
+///
+/// The sequence must be COMPLETE — fully contained in `bytes` — to count as
+/// whitespace. `wtf8_step` zero-fills continuation bytes that don't exist, so a
+/// truncated tail like `E2 80` would otherwise decode as U+2000 (EN QUAD, which
+/// IS JS whitespace) and `trim`/`trimEnd` would silently eat those bytes. A
+/// truncated tail is therefore treated as non-whitespace and preserved verbatim
+/// — consistent with `case_convert`, which also only maps complete sequences.
+#[inline]
+fn js_whitespace_seq_at(bytes: &[u8], i: usize) -> (bool, usize) {
+    let (advance, units, cp) = crate::string::wtf8_step(bytes, i);
+    let complete = i + advance <= bytes.len();
+    let is_ws = complete && units > 0 && char::from_u32(cp).map(is_js_whitespace).unwrap_or(false);
+    (is_ws, advance)
+}
+
 /// Byte range `[start, end)` of `bytes` after trimming JS whitespace from the
 /// requested ends. Bounds-driven (#6085): decodes with `wtf8_step` instead of
 /// `str::trim_matches`, whose `chars()` walk reads continuation bytes past an
 /// exact-sized payload that ends in a truncated multi-byte lead.
 ///
-/// Every JS whitespace code point is well-formed (ASCII, U+00A0, U+2028, …), so
-/// a truncated/invalid tail sequence is never whitespace and simply terminates
-/// the scan — trimming behavior on valid input is unchanged.
+/// Trimming behavior on valid input is unchanged; a truncated/invalid tail is
+/// never treated as whitespace, so it survives the trim byte-for-byte.
 fn js_whitespace_trim_range(bytes: &[u8], trim_start: bool, trim_end: bool) -> (usize, usize) {
     let mut start = 0usize;
     if trim_start {
         while start < bytes.len() {
-            let (advance, units, cp) = crate::string::wtf8_step(bytes, start);
-            let is_ws = units > 0 && char::from_u32(cp).map(is_js_whitespace).unwrap_or(false);
+            let (is_ws, advance) = js_whitespace_seq_at(bytes, start);
             if !is_ws {
                 break;
             }
@@ -241,9 +256,8 @@ fn js_whitespace_trim_range(bytes: &[u8], trim_start: bool, trim_end: bool) -> (
         let mut i = start;
         let mut last_non_ws_end = start;
         while i < bytes.len() {
-            let (advance, units, cp) = crate::string::wtf8_step(bytes, i);
+            let (is_ws, advance) = js_whitespace_seq_at(bytes, i);
             let next = (i + advance).min(bytes.len());
-            let is_ws = units > 0 && char::from_u32(cp).map(is_js_whitespace).unwrap_or(false);
             if !is_ws {
                 last_non_ws_end = next;
             }

--- a/crates/perry-runtime/src/string/split.rs
+++ b/crates/perry-runtime/src/string/split.rs
@@ -139,67 +139,129 @@ pub extern "C" fn js_string_split_n(
         // up to 3 bytes past the end of the allocation. Step the raw bytes with
         // the bounded WTF-8 decoder instead and emit each sequence verbatim;
         // well-formed input yields byte-identical parts.
-        let src = unsafe { slice::from_raw_parts(string_data(s), (*s).byte_len as usize) };
-        let mut parts: Vec<*mut StringHeader> = Vec::new();
-        let mut i = 0usize;
-        while i < src.len() {
-            let (advance, _, _) = crate::string::wtf8_step(src, i);
-            let end = (i + advance).min(src.len());
-            let seq = &src[i..end];
-            parts.push(js_string_from_bytes(seq.as_ptr(), seq.len() as u32));
-            i = end;
-        }
-        if limit > 0 && (parts.len() as i64) > (limit as i64) {
-            parts.truncate(limit as usize);
-        }
-
-        let arr = crate::array::js_array_alloc(parts.len() as u32);
+        // Pass 1: count the sequences. No allocation happens here, so the
+        // source payload cannot move under us.
+        let mut n = 0usize;
         unsafe {
-            (*arr).length = parts.len() as u32;
-            let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
-            for (i, p) in parts.iter().enumerate() {
-                let nanboxed = STRING_TAG | (*p as u64 & POINTER_MASK);
-                // GC_STORE_AUDIT(BARRIERED): split char slot is immediately recorded via note_array_slot.
-                std::ptr::write(elements_ptr.add(i), f64::from_bits(nanboxed));
-                crate::array::note_array_slot(arr, i, nanboxed);
+            let src = slice::from_raw_parts(string_data(s), (*s).byte_len as usize);
+            let mut i = 0usize;
+            while i < src.len() {
+                let (advance, _, _) = crate::string::wtf8_step(src, i);
+                i = (i + advance).min(src.len());
+                n += 1;
+                if limit > 0 && n as i64 >= limit as i64 {
+                    break;
+                }
             }
         }
-        return arr;
+
+        // Pass 2: allocate the result array, then fill it slot by slot.
+        //
+        // GC safety: `js_string_from_bytes` allocates, and a collection can
+        // both RECLAIM and (under C4b evacuation) MOVE the source string and
+        // the result array. A raw `*mut StringHeader` parked in a plain `Vec`
+        // is neither a root nor rewritten, so accumulating the parts there and
+        // writing them into the array afterwards is unsound. Root the source
+        // and the array in a `RuntimeHandleScope`, re-read both after every
+        // allocation, and store each part into the (rooted) array immediately —
+        // from then on the array keeps it alive.
+        let arr = crate::array::js_array_alloc(n as u32);
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let s_handle = scope.root_string_ptr(s);
+        let arr_handle = scope.root_raw_mut_ptr(arr);
+
+        let mut i = 0usize;
+        for idx in 0..n {
+            // Copy the sequence into a stack buffer BEFORE allocating:
+            // `js_string_from_bytes` allocates first and copies second, so
+            // handing it a pointer into the GC heap is the #5062 dangling-source
+            // class. A WTF-8 sequence is at most 4 bytes.
+            let mut buf = [0u8; 4];
+            let seq_len;
+            unsafe {
+                let s_now = s_handle.get_raw_const_ptr::<StringHeader>();
+                let src = slice::from_raw_parts(string_data(s_now), (*s_now).byte_len as usize);
+                if i >= src.len() {
+                    break;
+                }
+                let (advance, _, _) = crate::string::wtf8_step(src, i);
+                let end = (i + advance).min(src.len());
+                seq_len = end - i;
+                buf[..seq_len].copy_from_slice(&src[i..end]);
+                i = end;
+            }
+            let sh = js_string_from_bytes(buf.as_ptr(), seq_len as u32);
+            unsafe {
+                let arr_now = arr_handle.get_raw_mut_ptr::<ArrayHeader>();
+                let elements_ptr =
+                    (arr_now as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
+                let nanboxed = STRING_TAG | (sh as u64 & POINTER_MASK);
+                // GC_STORE_AUDIT(BARRIERED): split char slot is immediately recorded via note_array_slot.
+                std::ptr::write(elements_ptr.add(idx), f64::from_bits(nanboxed));
+                crate::array::note_array_slot(arr_now, idx, nanboxed);
+                // Publish the slot only once it holds a real value: `js_array_alloc`
+                // does NOT zero its storage, so a GC that scanned `length = n` up
+                // front would read uninitialized slots as JSValues.
+                (*arr_now).length = (idx + 1) as u32;
+            }
+        }
+        return arr_handle.get_raw_mut_ptr::<ArrayHeader>();
     }
 
-    // Non-empty delimiter: arena-allocate parts (bump-pointer, no tracking overhead)
-    let mut part_slices: Vec<&str> = str_data.split(delim).collect();
-    if limit > 0 && (part_slices.len() as i64) > (limit as i64) {
-        part_slices.truncate(limit as usize);
+    // Non-empty delimiter: record the parts as BYTE RANGES into the source
+    // payload, not as `&str` slices. `string_storage_alloc` below allocates, and
+    // a collection can move the source string — borrowed slices (and the raw
+    // pointers inside them) would dangle, and `ptr::copy_nonoverlapping` from a
+    // stale address is the #5062 class. Offsets stay valid across a move; the
+    // source address is re-read from a rooted handle on every iteration.
+    let src_base = str_data.as_ptr() as usize;
+    let mut part_ranges: Vec<(usize, usize)> = str_data
+        .split(delim)
+        .map(|part| (part.as_ptr() as usize - src_base, part.len()))
+        .collect();
+    if limit > 0 && (part_ranges.len() as i64) > (limit as i64) {
+        part_ranges.truncate(limit as usize);
     }
-    let n = part_slices.len();
+    let n = part_ranges.len();
 
     let src_is_ascii = is_ascii_string(s);
 
     let arr = crate::array::js_array_alloc(n as u32);
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let s_handle = scope.root_string_ptr(s);
+    let arr_handle = scope.root_raw_mut_ptr(arr);
+
     unsafe {
-        (*arr).length = n as u32;
-        let elements_ptr = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
-        for (i, part) in part_slices.iter().enumerate() {
-            let byte_len = part.len() as u32;
+        for (i, &(offset, byte_len_usize)) in part_ranges.iter().enumerate() {
+            let byte_len = byte_len_usize as u32;
+            // Allocate the destination FIRST (it may move the source), then
+            // re-read the source address before touching its bytes.
             let (sh, data_ptr) = string_storage_alloc(byte_len);
+            let s_now = s_handle.get_raw_const_ptr::<StringHeader>();
+            let part_ptr = string_data(s_now).add(offset);
             let utf16_len = if src_is_ascii {
                 byte_len
             } else {
-                compute_utf16_len(part.as_ptr(), byte_len)
+                compute_utf16_len(part_ptr, byte_len)
             };
             init_string_header(sh, utf16_len, byte_len, byte_len, 0, 0);
             if byte_len > 0 {
-                ptr::copy_nonoverlapping(part.as_ptr(), data_ptr, byte_len as usize);
+                ptr::copy_nonoverlapping(part_ptr, data_ptr, byte_len as usize);
             }
+            let arr_now = arr_handle.get_raw_mut_ptr::<ArrayHeader>();
+            let elements_ptr =
+                (arr_now as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
             let nanboxed = STRING_TAG | (sh as u64 & POINTER_MASK);
             // GC_STORE_AUDIT(BARRIERED): split part slot is immediately recorded via note_array_slot.
             std::ptr::write(elements_ptr.add(i), f64::from_bits(nanboxed));
-            crate::array::note_array_slot(arr, i, nanboxed);
+            crate::array::note_array_slot(arr_now, i, nanboxed);
+            // Publish incrementally — `js_array_alloc` leaves the storage
+            // uninitialized, so `length` must never cover an unwritten slot.
+            (*arr_now).length = (i + 1) as u32;
         }
     }
 
-    arr
+    arr_handle.get_raw_mut_ptr::<ArrayHeader>()
 }
 
 /// `ToUint32(ToNumber(value))` (ECMA-262 §7.1.7). Runs the full `ToNumber`

--- a/crates/perry-runtime/src/string/split.rs
+++ b/crates/perry-runtime/src/string/split.rs
@@ -129,15 +129,26 @@ pub extern "C" fn js_string_split_n(
     const STRING_TAG: u64 = 0x7FFF_0000_0000_0000;
     const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
     if delim.is_empty() {
-        // Empty delimiter: split into individual characters (single pass)
-        let mut parts: Vec<*mut StringHeader> = str_data
-            .chars()
-            .map(|c| {
-                let mut buf = [0u8; 4];
-                let char_str = c.encode_utf8(&mut buf);
-                js_string_from_bytes(char_str.as_ptr(), char_str.len() as u32)
-            })
-            .collect();
+        // Empty delimiter: split into individual characters (single pass).
+        //
+        // #6085: `str_data.chars()` decodes through std's UTF-8-validity
+        // assumption (`next_code_point` reads continuation bytes with
+        // `unwrap_unchecked`). Perry payloads are EXACT-SIZED and not
+        // guaranteed valid UTF-8 — a `Buffer`/FFI blob sliced at a byte
+        // delimiter can end in a truncated multi-byte lead — so that walk read
+        // up to 3 bytes past the end of the allocation. Step the raw bytes with
+        // the bounded WTF-8 decoder instead and emit each sequence verbatim;
+        // well-formed input yields byte-identical parts.
+        let src = unsafe { slice::from_raw_parts(string_data(s), (*s).byte_len as usize) };
+        let mut parts: Vec<*mut StringHeader> = Vec::new();
+        let mut i = 0usize;
+        while i < src.len() {
+            let (advance, _, _) = crate::string::wtf8_step(src, i);
+            let end = (i + advance).min(src.len());
+            let seq = &src[i..end];
+            parts.push(js_string_from_bytes(seq.as_ptr(), seq.len() as u32));
+            i = end;
+        }
         if limit > 0 && (parts.len() as i64) > (limit as i64) {
             parts.truncate(limit as usize);
         }

--- a/crates/perry-runtime/src/string/tests_guard_page.rs
+++ b/crates/perry-runtime/src/string/tests_guard_page.rs
@@ -1,0 +1,251 @@
+//! Guard-page regression tests for #6085.
+//!
+//! Perry heap-string payloads are EXACT-SIZED: `string_storage_alloc` reserves
+//! `size_of::<StringHeader>() + byte_len` bytes — no NUL terminator, no tail
+//! padding — and the bytes are NOT guaranteed to be valid UTF-8 (`Buffer`
+//! `toString`, FFI blobs, and WTF-8 lone-surrogate strings all reach
+//! `js_string_from_bytes` with raw bytes). Any scanner that decodes such a
+//! payload through std's UTF-8-validity-assuming iterators (`str::chars()`,
+//! `str::encode_utf16()` over a `from_utf8_unchecked` view) reads the
+//! continuation bytes of a multi-byte lead WITHOUT a bounds check
+//! (`core::str::validations::next_code_point` uses `unwrap_unchecked`). A
+//! payload whose last sequence is a truncated multi-byte lead therefore reads
+//! 1–3 bytes PAST the end of its own allocation.
+//!
+//! In production that read usually lands in mapped heap and is invisible; when
+//! the allocation happens to sit flush against an unmapped page it faults
+//! (`0x...FFF8`-style access violations on Windows x64 — the #6085 report).
+//!
+//! These tests make the fault DETERMINISTIC on any Unix host: map two pages,
+//! `mprotect(PROT_NONE)` the second, and place the string so its last payload
+//! byte is the last byte of the first page. Any read past `byte_len` hits the
+//! guard page and raises SIGSEGV instead of silently succeeding.
+
+use super::*;
+use std::ptr;
+
+/// A `StringHeader` + payload placed flush against a `PROT_NONE` guard page:
+/// `data[byte_len - 1]` is the last readable byte before the guard.
+struct GuardedString {
+    base: *mut u8,
+    total: usize,
+    hdr: *mut StringHeader,
+}
+
+impl GuardedString {
+    /// Map the string so the payload ends exactly at the page boundary.
+    /// `payload.len()` must keep the header 8-byte aligned (len ≡ 4 mod 8,
+    /// since `size_of::<StringHeader>() == 20`).
+    fn new(payload: &[u8]) -> Self {
+        unsafe {
+            let page = libc::sysconf(libc::_SC_PAGESIZE) as usize;
+            let total = page * 2;
+            let base = libc::mmap(
+                ptr::null_mut(),
+                total,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANON,
+                -1,
+                0,
+            ) as *mut u8;
+            assert!(base as isize != -1, "mmap failed");
+            // Second page unreadable: any over-read past the payload faults.
+            assert_eq!(
+                libc::mprotect(base.add(page) as *mut libc::c_void, page, libc::PROT_NONE),
+                0,
+                "mprotect(PROT_NONE) failed"
+            );
+
+            let hdr_size = std::mem::size_of::<StringHeader>();
+            let need = hdr_size + payload.len();
+            assert!(need <= page);
+            let hdr = base.add(page - need) as *mut StringHeader;
+            assert_eq!(
+                hdr as usize % 8,
+                0,
+                "test payload length must keep the header 8-byte aligned"
+            );
+
+            let data = (hdr as *mut u8).add(hdr_size);
+            ptr::copy_nonoverlapping(payload.as_ptr(), data, payload.len());
+            // Sanity: the payload really is flush against the guard page.
+            assert_eq!(data.add(payload.len()) as usize, base.add(page) as usize);
+
+            let byte_len = payload.len() as u32;
+            let u16len = compute_utf16_len(payload.as_ptr(), byte_len);
+            init_string_header(hdr, u16len, byte_len, byte_len, 0, 0);
+            GuardedString { base, total, hdr }
+        }
+    }
+
+    fn ptr(&self) -> *const StringHeader {
+        self.hdr as *const StringHeader
+    }
+}
+
+impl Drop for GuardedString {
+    fn drop(&mut self) {
+        unsafe {
+            libc::munmap(self.base as *mut libc::c_void, self.total);
+        }
+    }
+}
+
+/// Payload ending in a TRUNCATED 2-byte lead (`0xC3` with no continuation
+/// byte): "é" + "A" + a dangling lead. This is what a byte-delimited blob from
+/// an FFI / `Buffer` produces when a `split()` boundary lands mid-sequence, and
+/// it is the shape that makes `chars()` read past the end.
+///
+/// Length 4 keeps the 20-byte header 8-byte aligned.
+/// `utf16_len` (3) != `byte_len` (4), so scanners take their non-ASCII path.
+const TRUNCATED_TAIL: [u8; 4] = [0xC3, 0xA9, 0x41, 0xC3];
+
+/// Well-formed multi-byte payload (also length 4): "é" + "é".
+const WELL_FORMED: [u8; 4] = [0xC3, 0xA9, 0xC3, 0xA9];
+
+#[test]
+fn truncated_tail_is_non_ascii_and_flush_against_guard_page() {
+    let g = GuardedString::new(&TRUNCATED_TAIL);
+    unsafe {
+        assert_eq!((*g.ptr()).byte_len, 4);
+        // Must NOT take the ASCII fast path, or the scanners never decode.
+        assert_ne!(
+            (*g.ptr()).utf16_len,
+            (*g.ptr()).byte_len,
+            "payload must exercise the non-ASCII decode path"
+        );
+    }
+}
+
+#[test]
+fn char_code_at_does_not_read_past_payload() {
+    let g = GuardedString::new(&TRUNCATED_TAIL);
+    let s = g.ptr();
+    assert_eq!(js_string_char_code_at(s, 0), 233.0); // é
+    assert_eq!(js_string_char_code_at(s, 1), 65.0); // A
+                                                    // Truncated lead: decoded from the bytes that EXIST (missing continuation
+                                                    // bytes read as 0) — the point is that it does not touch the guard page.
+    assert_eq!(js_string_char_code_at(s, 2), 192.0);
+    assert!(js_string_char_code_at(s, 3).is_nan());
+}
+
+#[test]
+fn code_point_at_does_not_read_past_payload() {
+    let g = GuardedString::new(&TRUNCATED_TAIL);
+    let s = g.ptr();
+    assert_eq!(js_string_code_point_at(s, 0), 233.0);
+    assert_eq!(js_string_code_point_at(s, 1), 65.0);
+    assert_eq!(js_string_code_point_at(s, 2), 192.0);
+}
+
+#[test]
+fn char_at_does_not_read_past_payload() {
+    let g = GuardedString::new(&TRUNCATED_TAIL);
+    let s = g.ptr();
+    let c0 = js_string_char_at(s, 0);
+    assert_eq!(string_as_str(c0), "é");
+    let c1 = js_string_char_at(s, 1);
+    assert_eq!(string_as_str(c1), "A");
+    // Index 2 decodes the dangling lead — must not fault.
+    let _ = js_string_char_at(s, 2);
+}
+
+#[test]
+fn string_at_does_not_read_past_payload() {
+    let g = GuardedString::new(&TRUNCATED_TAIL);
+    let s = g.ptr();
+    // `String.prototype.at` collected the whole string via `encode_utf16()`.
+    let _ = js_string_at(s, 0);
+    let _ = js_string_at(s, 2);
+    let _ = js_string_at(s, -1);
+}
+
+#[test]
+fn to_char_array_does_not_read_past_payload() {
+    let g = GuardedString::new(&TRUNCATED_TAIL);
+    let boxed = crate::value::js_nanbox_string(g.ptr() as i64);
+    let _ = js_string_to_char_array(boxed.to_bits() as i64);
+}
+
+#[test]
+fn slice_and_substring_do_not_read_past_payload() {
+    let g = GuardedString::new(&TRUNCATED_TAIL);
+    let s = g.ptr();
+    // Non-ASCII slice routes through `utf16_offset_to_byte_offset`, which
+    // walked `chars()` before #6085.
+    let sliced = js_string_slice(s, 0, 2);
+    assert_eq!(string_as_str(sliced), "éA");
+    let _ = js_string_slice(s, 1, 3);
+    let _ = js_string_substring(s, 0, 3);
+}
+
+#[test]
+fn index_of_does_not_read_past_payload() {
+    let g = GuardedString::new(&TRUNCATED_TAIL);
+    let s = g.ptr();
+    let needle = js_string_from_bytes(b"A".as_ptr(), 1);
+    assert_eq!(js_string_index_of(s, needle), 1);
+    let missing = js_string_from_bytes(b"zz".as_ptr(), 2);
+    assert_eq!(js_string_index_of(s, missing), -1);
+}
+
+#[test]
+fn split_by_empty_delimiter_does_not_read_past_payload() {
+    let g = GuardedString::new(&TRUNCATED_TAIL);
+    // `"…".split("")` walked `str_data.chars()` over the raw payload.
+    let empty = js_string_from_bytes(b"".as_ptr(), 0);
+    let arr = js_string_split_n(g.ptr(), empty, -1);
+    assert!(!arr.is_null());
+}
+
+#[test]
+fn trim_and_case_conversion_do_not_read_past_payload() {
+    let g = GuardedString::new(&TRUNCATED_TAIL);
+    let s = g.ptr();
+    let _ = js_string_trim(s);
+    let _ = js_string_trim_start(s);
+    let _ = js_string_trim_end(s);
+    let _ = js_string_to_lower_case(s);
+    let _ = js_string_to_upper_case(s);
+}
+
+/// Well-formed multi-byte input must decode EXACTLY as before the #6085 fix
+/// (the bounded decoder is byte-for-byte equivalent on valid input).
+#[test]
+fn well_formed_multibyte_decodes_identically() {
+    let g = GuardedString::new(&WELL_FORMED);
+    let s = g.ptr();
+    unsafe {
+        assert_eq!((*s).byte_len, 4);
+        assert_eq!((*s).utf16_len, 2);
+    }
+    assert_eq!(js_string_char_code_at(s, 0), 233.0);
+    assert_eq!(js_string_char_code_at(s, 1), 233.0);
+    assert!(js_string_char_code_at(s, 2).is_nan());
+    assert_eq!(string_as_str(js_string_char_at(s, 1)), "é");
+    assert_eq!(string_as_str(js_string_slice(s, 0, 1)), "é");
+    assert_eq!(string_as_str(js_string_to_upper_case(s)), "ÉÉ");
+}
+
+/// An astral (4-byte) code point split into surrogate halves — the
+/// `utf16_len != byte_len` path with `units == 2`, plus a truncated astral
+/// lead flush against the guard page.
+#[test]
+fn astral_and_truncated_astral_lead() {
+    // "😀" = F0 9F 98 80 (2 UTF-16 units, 4 bytes).
+    let g = GuardedString::new(&[0xF0, 0x9F, 0x98, 0x80]);
+    let s = g.ptr();
+    unsafe {
+        assert_eq!((*s).utf16_len, 2);
+        assert_eq!((*s).byte_len, 4);
+    }
+    assert_eq!(js_string_char_code_at(s, 0), 55357.0); // high surrogate
+    assert_eq!(js_string_char_code_at(s, 1), 56832.0); // low surrogate
+    assert_eq!(js_string_code_point_at(s, 0), 128512.0);
+
+    // Truncated astral lead: "é" + a dangling 0xF0 (len 4 keeps alignment).
+    let t = GuardedString::new(&[0xC3, 0xA9, 0x41, 0xF0]);
+    let ts = t.ptr();
+    let _ = js_string_char_code_at(ts, 2);
+    let _ = js_string_to_char_array(crate::value::js_nanbox_string(ts as i64).to_bits() as i64);
+}

--- a/crates/perry-runtime/src/string/tests_guard_page.rs
+++ b/crates/perry-runtime/src/string/tests_guard_page.rs
@@ -196,6 +196,37 @@ fn split_by_empty_delimiter_does_not_read_past_payload() {
     let empty = js_string_from_bytes(b"".as_ptr(), 0);
     let arr = js_string_split_n(g.ptr(), empty, -1);
     assert!(!arr.is_null());
+    // "é", "A", dangling lead → 3 parts, each holding its raw bytes.
+    assert_eq!(unsafe { (*arr).length }, 3);
+}
+
+/// A truncated multi-byte tail must NOT be mistaken for whitespace.
+///
+/// `wtf8_step` zero-fills continuation bytes that don't exist, so a dangling
+/// `E2 80` decodes as U+2000 (EN QUAD) — which IS JS whitespace. Without an
+/// explicit "sequence is complete" gate, `trim`/`trimEnd` would silently DELETE
+/// those bytes. Trimming must only consume complete whitespace sequences.
+#[test]
+fn trim_preserves_truncated_multibyte_tail() {
+    // "A" + truncated E2 80 (would decode as U+2000 if zero-filled), length 4
+    // keeps the header 8-byte aligned.
+    let g = GuardedString::new(&[0x41, 0x41, 0xE2, 0x80]);
+    let s = g.ptr();
+    for out in [js_string_trim(s), js_string_trim_end(s)] {
+        let bytes =
+            unsafe { std::slice::from_raw_parts(string_data(out), (*out).byte_len as usize) };
+        assert_eq!(
+            bytes,
+            &[0x41, 0x41, 0xE2, 0x80],
+            "truncated tail must survive trimming byte-for-byte"
+        );
+    }
+    // A COMPLETE U+2000 really is whitespace and must still be trimmed.
+    let ws = GuardedString::new(&[0x41, 0xE2, 0x80, 0x80]); // "A" + U+2000
+    let trimmed = js_string_trim_end(ws.ptr());
+    let bytes =
+        unsafe { std::slice::from_raw_parts(string_data(trimmed), (*trimmed).byte_len as usize) };
+    assert_eq!(bytes, &[0x41], "complete U+2000 must still be trimmed");
 }
 
 #[test]


### PR DESCRIPTION
## Root cause

Perry heap-string payloads are **exact-sized**: `string_storage_alloc` reserves `size_of::<StringHeader>() + byte_len` bytes — no NUL terminator, no tail padding — and the bytes are **not guaranteed to be valid UTF-8**. `Buffer.toString()`, FFI blobs, and WTF-8 lone-surrogate strings all reach `js_string_from_bytes` with raw bytes, and `string_as_str` hands those bytes to `str::from_utf8_unchecked`.

Several scanners then decoded that view with std's **UTF-8-validity-assuming** iterators (`str::chars()`, `str::encode_utf16()`). `core::str::validations::next_code_point` reads the continuation bytes of a multi-byte lead with `unwrap_unchecked` — no bounds check. So a payload whose **last sequence is a truncated multi-byte lead** reads 1–3 bytes **past the end of its own allocation**.

That is exactly the reported shape: reads just past the end of a heap page, layout-sensitive (a relink hides or resurfaces it), fatal only when an allocation happens to land flush against an unmapped page (`0x...FFF8`-style faulting addresses).

**How the repro reaches it.** A native FFI / `Buffer` blob is not required to be well-formed UTF-8. Splitting such a blob on an ASCII delimiter (`\n`, `|`) can cut *inside* a multi-byte sequence, and each `split()` part is a fresh **exact-sized** allocation ending in a dangling lead byte. Any subsequent scan of that part over-reads. This matches the reporter's "6/6 crashes within 7–29 seconds" on a per-frame `split()` + parse hot path, where the churn of fresh exact-sized allocations eventually places one against a guard page.

### OOB sites fixed (each proven to fault, see below)

| Site | Read class |
|---|---|
| `string/mod.rs` `utf16_offset_to_byte_offset` / `byte_offset_to_utf16_index` — reached by `slice` / `substring` / `substr` / `startsWith(pos)` / `endsWith(pos)` | `chars()` / `encode_utf16()` continuation-byte read past `byte_len` |
| `string/char_ops.rs` `js_string_char_code_at`, `js_string_code_point_at` | `chars()` walk past `byte_len` |
| `string/char_ops.rs` `js_string_at` | `encode_utf16().collect()` over the whole payload |
| `string/char_ops.rs` `js_string_to_char_array` (spread `[...s]`) | `chars()` walk past `byte_len` |
| `string/slice_ops.rs` `trim` / `trimStart` / `trimEnd` | `str::trim_matches` → `chars()` |
| `string/slice_ops.rs` `toLowerCase` / `toUpperCase` | `str::to_lowercase/to_uppercase` → `chars()` |
| `string/split.rs` empty-delimiter `split("")` | `chars()` walk past `byte_len` |

### Explicitly NOT a fix I am claiming

- **`parseFloat` is already bounds-safe.** `parse_float_bytes` / `float_prefix_end` / `trim_leading_js_whitespace` guard every index with `i < n` and operate on the exact byte slice. I audited it and changed nothing there. The fault is on the **scan** side, not the parse side.
- **`split()`'s non-empty-delimiter path is already bounds-safe** (byte search + exact-length copies). Only its `split("")` character walk over-read.
- `js_string_char_at` and `js_string_index_of` were already bounds-driven; they get guard-page tests as regression cover, not fixes.
- #6255 previously bounded `decode_wtf8_units` (`padStart`/`padEnd`). This PR closes the remaining sites in the same class.

## Convention enforced: bounds-driven scanning

Perry strings carry an explicit `byte_len` and **no terminator**, and the payload is not guaranteed well-formed. Adding a NUL terminator would mean touching every allocation site, growing every string by a byte, and would still not make `chars()` safe (it stops at a *lead* byte, not a NUL). So the invariant enforced is: **never read past `byte_len`; never assume UTF-8 validity.**

All the walks above now go through one shared helper, `string::wtf8_step`, which classifies a sequence from its lead byte exactly as `compute_utf16_len_wtf8` already does (so cursor walks agree with the `utf16_len` in the header) and reads continuation bytes **only** via bounds-checked `get()`, substituting 0 for bytes that do not exist. Well-formed input decodes byte-for-byte identically.

Case conversion additionally now round-trips lone surrogates and truncated sequences **verbatim** instead of depending on `from_utf8_unchecked`.

## Verification

### 1. Guard-page tests (deterministic, red → green)

New `crates/perry-runtime/src/string/tests_guard_page.rs` (`#[cfg(all(test, unix))]`): `mmap` two pages, `mprotect(PROT_NONE)` the second, and place the `StringHeader` so the **last payload byte is the last byte of the first page**. Any read past `byte_len` hits the guard page. Payload is `C3 A9 41 C3` ("é", "A", dangling 2-byte lead) with `utf16_len (3) != byte_len (4)` so the non-ASCII decode path is actually taken.

Against the **pre-fix** scanners, release build:

```
char_code_at_does_not_read_past_payload              (signal: 10, SIGBUS)
code_point_at_does_not_read_past_payload             (signal: 10, SIGBUS)
string_at_does_not_read_past_payload                 (signal: 10, SIGBUS)
to_char_array_does_not_read_past_payload             (signal: 10, SIGBUS)
trim_and_case_conversion_do_not_read_past_payload    (signal: 10, SIGBUS)
split_by_empty_delimiter_does_not_read_past_payload  (signal: 10, SIGBUS)
slice_and_substring_do_not_read_past_payload         (signal: 10, SIGBUS)
```

(macOS maps the guard-page read to SIGBUS; it is the same access violation Windows reports as `c0000005`. In a debug build the same reads instead panic inside `core/src/str/validations.rs:48` — literally `next_code_point`'s `unwrap_unchecked` — which pinpoints the over-read.)

After the fix, all 12 pass:

```
test result: ok. 12 passed; 0 failed
```

### 2. Behavior parity

`cargo test -p perry-runtime -- --test-threads=1`: **1244 passed, 0 failed.** (The suite has pre-existing order-dependent flakes when run in parallel — a different unrelated test fails on each parallel run, on main as well as here.)

TS repro compiled with this build — per-frame `blob.split('\n')` → `line.split('|')` → `parseFloat`, 500 frames, plus edge cases (`""`, `"1.23e5"`, `"  1.5"`, `"abc"`, `"Infinity"`, `"-Infinity"`, `"-0"` (incl. `1/x` sign check), `"3."`, `".5"`, `"1e"`, `"+2.5"`, `"0x10"`, `"5px"`, empty parts, trailing newline) and every scanner this PR touches over multi-byte text (`split`, spread, `charCodeAt`, `codePointAt`, `at`, `charAt`, `slice`, `substring`, `indexOf`, `trim*`, case conversion, `.length`):

- **vs a stock `main` build: output byte-identical** → this fix changes no observable behavior.
- **vs `node --experimental-strip-types`: identical**, except one line — `"😀x".at(0) === "\ud83d"` — which is the pre-existing, documented lone-surrogate/WTF-8 categorical gap (`at()` substitutes U+FFFD). Verified it prints the same wrong value on unmodified `main`, so it is untouched by this PR and out of scope.

`cargo fmt --all -- --check` clean.

Fixes #6085


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JavaScript string character/index/code point access for non-ASCII, truncated multi-byte, and lone-surrogate data.
  * Updated splitting, trimming, and case conversion to avoid out-of-bounds reads on malformed or truncated UTF-8-like payloads.
  * Preserved correct UTF-16/astral and surrogate-pair behavior for valid Unicode inputs.
* **Tests**
  * Added guarded-memory regression tests to verify safe decoding and correct results for both valid and truncated sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->