### PR TITLE
fix(runtime): write-barrier RegExp header pattern/flags string fields

### DIFF
--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -694,6 +694,35 @@ pub extern "C" fn js_regexp_new(
         (*ptr).regex_ptr = regex_ptr;
         (*ptr).pattern_ptr = pattern;
         (*ptr).flags_ptr = canonical_flags_ptr;
+        // `pattern_ptr` / `flags_ptr` are GC-managed StringHeaders — the GC scans
+        // this 2-slot payload range via the magic-tagged RegExp layout, and
+        // `canonical_flags_ptr` (js_string_from_str above) is a freshly-allocated
+        // YOUNG string. They are stored into this malloc'd (old-generation) header
+        // by raw writes; without a write barrier the old→young edge is never
+        // remembered, so a copying minor GC sweeps the string while the retained
+        // RegExp still points at it. The evacuation verifier reports this as an
+        // uncovered object→string edge, and it crashes for real when the freed
+        // slot is later scanned/read (a heavy regex workload — e.g. ANSI/emoji
+        // parsing in a terminal UI — hits it within seconds). Remember both edges,
+        // mirroring every other native-header pointer store (closure captures,
+        // object prototype slots, array headers). `runtime_write_barrier_gc_slot`
+        // detects the malloc parent and only remembers genuinely-young children,
+        // so an already-old/interned `pattern` is a harmless no-op.
+        let regexp_parent_addr = ptr as usize;
+        if !pattern.is_null() {
+            crate::gc::runtime_write_barrier_gc_slot(
+                regexp_parent_addr,
+                std::ptr::addr_of!((*ptr).pattern_ptr) as usize,
+                js_nanbox_string(pattern as i64).to_bits(),
+            );
+        }
+        if !canonical_flags_ptr.is_null() {
+            crate::gc::runtime_write_barrier_gc_slot(
+                regexp_parent_addr,
+                std::ptr::addr_of!((*ptr).flags_ptr) as usize,
+                js_nanbox_string(canonical_flags_ptr as i64).to_bits(),
+            );
+        }
         (*ptr).case_insensitive = case_insensitive;
         (*ptr).global = global;
         (*ptr).multiline = multiline;


### PR DESCRIPTION
## Problem

`js_regexp_new` allocates the `RegExpHeader` via `gc_malloc` (the only
`GC_TYPE_OBJECT` malloc site) and then stores its `pattern_ptr` and
`flags_ptr` — both GC-managed `StringHeader`s — with **plain raw field writes**:

```rust
(*ptr).pattern_ptr = pattern;
(*ptr).flags_ptr = canonical_flags_ptr;   // js_string_from_str -> YOUNG string
```

The header is malloc-backed, so the GC treats it as **old-generation**, and
`canonical_flags_ptr` is a freshly-allocated **nursery** string — an old→young
edge. The raw writes fire **no write barrier**, so that edge is never recorded
in the remembered set. A copying minor GC (the common collection under the
default generational policy) doesn't re-trace old objects, so the young
flags/pattern string is **swept while the retained RegExp still points at it**.
The next minor's scan of the header — or any read of the field — then
dereferences freed memory.

`PERRY_GC_VERIFY_EVACUATION=1` reports it precisely: ~2000 uncovered
`object → string` edges at the `flags_ptr` slot. Without the verifier it's an
intermittent `SIGSEGV`/`SIGBUS` whose faulting pointer is a reused nursery
slot. A regex-heavy workload (e.g. ANSI/emoji scanning in a terminal UI)
reproduces it within seconds. The compiled-regex program is cached, so the leak
is per RegExp **object**, not per distinct pattern.

The GC already scans these two slots correctly for a **full mark** (the magic-
tagged RegExp layout in `gc/layout.rs`), so this is purely the missing
remembered-set edge on the copied-minor path.

## Fix

After the stores, remember both edges with `runtime_write_barrier_gc_slot`,
mirroring every other native-header pointer store (closure captures, object
prototype slots, array headers). It detects the malloc parent and only
remembers genuinely-young children, so an already-old or interned string is a
harmless no-op.

## Validation

- On a large esbuild-bundled CLI app that reproduced the crash,
  `PERRY_GC_VERIFY_EVACUATION` goes from **~2000 missing edges + abort** to
  **zero missing edges + no abort**.
- `perry-runtime` regex tests: **37 passed / 0 failed**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regular expression memory management to ensure pattern and flag values remain available during garbage collection.
  * Prevented potential issues where regular expressions could lose associated string data after memory cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->