### PR TITLE
fix(timer): fire an expired batch in event-loop order, not creation order (#6287)

### DIFF
--- a/crates/perry-runtime/src/timer.rs
+++ b/crates/perry-runtime/src/timer.rs
@@ -169,6 +169,37 @@ fn drain_expired_timers<T>(
     expired
 }
 
+/// Order an expired callback batch the way Node's event loop does (#6287).
+///
+/// The queue is in creation order, but firing it in creation order is wrong on
+/// two counts once several timers come due in the same turn:
+///
+/// 1. **Deadline order.** Node's timers phase walks lists by expiry, so a 5 ms
+///    timer created *after* a 10 ms one still fires first. Perry fired them in
+///    creation order (`setTimeout(f,10); setTimeout(g,5)` ran `f` then `g`).
+/// 2. **Timers before immediates.** `setImmediate` runs in the *check* phase,
+///    which comes after the timers phase — so an expired `setTimeout` fires
+///    ahead of an immediate that was scheduled earlier. Perry interleaved both
+///    kinds in one creation-ordered queue.
+///
+/// Both are fixed by ordering the batch as (timeouts by deadline) then
+/// (immediates in FIFO order). The sort is **stable**, which is what preserves
+/// the two orderings Perry already got right: same-deadline timers keep firing
+/// in creation order, and immediates keep firing in scheduling order.
+fn order_expired_callback_batch(expired: &mut [CallbackTimer]) {
+    use std::cmp::Ordering as CmpOrdering;
+    expired.sort_by(|a, b| match (a.kind, b.kind) {
+        // Timers phase before check phase.
+        (CallbackTimerKind::Timeout, CallbackTimerKind::Immediate) => CmpOrdering::Less,
+        (CallbackTimerKind::Immediate, CallbackTimerKind::Timeout) => CmpOrdering::Greater,
+        // Within the timers phase: earliest deadline first. Equal deadlines
+        // compare Equal, and a stable sort leaves them in creation order.
+        (CallbackTimerKind::Timeout, CallbackTimerKind::Timeout) => a.deadline.cmp(&b.deadline),
+        // Within the check phase: FIFO — stable sort keeps insertion order.
+        (CallbackTimerKind::Immediate, CallbackTimerKind::Immediate) => CmpOrdering::Equal,
+    });
+}
+
 /// Process any expired timers, resolving their promises
 /// Returns the number of timers that fired
 #[no_mangle]
@@ -179,7 +210,7 @@ pub extern "C" fn js_timer_tick() -> i32 {
 
     // Collect expired timers (single-pass stable partition, see
     // `drain_expired_timers`).
-    let expired: Vec<Timer> = {
+    let mut expired: Vec<Timer> = {
         let mut queue = TIMER_QUEUE.lock().unwrap();
         drain_expired_timers(
             &mut queue,
@@ -187,6 +218,10 @@ pub extern "C" fn js_timer_tick() -> i32 {
             |timer| timer.deadline <= now && (timer.has_ref || allow_unref),
         )
     };
+    // #6287: fire the batch in deadline order, not creation order — a 5 ms
+    // timer created after a 10 ms one must still fire first. The sort is
+    // stable, so same-deadline timers keep firing in creation order.
+    expired.sort_by_key(|timer| timer.deadline);
 
     // Resolve the expired timers' promises
     for timer in expired {
@@ -1084,7 +1119,7 @@ pub extern "C" fn js_callback_timer_tick() -> i32 {
 
     // Collect expired, non-cleared timers (single-pass stable partition,
     // see `drain_expired_timers`; cleared timers are discarded).
-    let expired: Vec<CallbackTimer> = {
+    let mut expired: Vec<CallbackTimer> = {
         let mut queue = CALLBACK_TIMERS.lock().unwrap();
         drain_expired_timers(
             &mut queue,
@@ -1092,6 +1127,8 @@ pub extern "C" fn js_callback_timer_tick() -> i32 {
             |timer| timer.deadline <= now && (timer_has_ref_state(timer.id) || allow_unref),
         )
     };
+    // #6287: timers phase (by deadline) before check phase (FIFO immediates).
+    order_expired_callback_batch(&mut expired);
 
     let mut fired = 0;
     // Call the callbacks, forwarding any trailing args captured at

--- a/crates/perry-runtime/src/timer.rs
+++ b/crates/perry-runtime/src/timer.rs
@@ -2086,3 +2086,78 @@ mod drain_expired_tests {
         assert!(queue.is_empty());
     }
 }
+
+#[cfg(test)]
+mod expired_batch_order_tests {
+    use super::{order_expired_callback_batch, CallbackTimer, CallbackTimerKind};
+    use std::time::{Duration, Instant};
+
+    fn timer(id: i64, kind: CallbackTimerKind, base: Instant, delay_ms: u64) -> CallbackTimer {
+        CallbackTimer {
+            id,
+            kind,
+            deadline: base + Duration::from_millis(delay_ms),
+            delay_ms,
+            callback: 0,
+            args: Vec::new(),
+            context: crate::async_context::AsyncContextSnapshot::default(),
+            async_id: 0,
+            trigger_async_id: 0,
+            cleared: false,
+        }
+    }
+
+    /// #6287 case 1: the batch fires in DEADLINE order, not creation order —
+    /// a 5 ms timer created after a 10 ms one still fires first. Ground truth
+    /// from node: `setTimeout(f,10); setTimeout(g,5)` runs g then f.
+    #[test]
+    fn expired_timeouts_fire_in_deadline_order() {
+        let base = Instant::now();
+        let mut batch = vec![
+            timer(1, CallbackTimerKind::Timeout, base, 10),
+            timer(2, CallbackTimerKind::Timeout, base, 5),
+            timer(3, CallbackTimerKind::Timeout, base, 1),
+        ];
+        order_expired_callback_batch(&mut batch);
+        let ids: Vec<i64> = batch.iter().map(|t| t.id).collect();
+        assert_eq!(ids, vec![3, 2, 1], "earliest deadline first");
+    }
+
+    /// Same-deadline timers must STILL fire in creation order — the ordering
+    /// Perry already got right, preserved by the sort being stable.
+    #[test]
+    fn same_deadline_timeouts_keep_creation_order() {
+        let base = Instant::now();
+        let mut batch = vec![
+            timer(1, CallbackTimerKind::Timeout, base, 3),
+            timer(2, CallbackTimerKind::Timeout, base, 3),
+            timer(3, CallbackTimerKind::Timeout, base, 3),
+        ];
+        order_expired_callback_batch(&mut batch);
+        let ids: Vec<i64> = batch.iter().map(|t| t.id).collect();
+        assert_eq!(ids, vec![1, 2, 3], "stable sort keeps creation order");
+    }
+
+    /// #6287 case 2: setImmediate runs in the CHECK phase, so an expired
+    /// setTimeout fires ahead of an immediate scheduled earlier — and this is
+    /// exactly why a naive sort by deadline alone is wrong (an immediate's
+    /// deadline is ~now, so it would sort ahead of the timeout). Immediates
+    /// keep FIFO order among themselves.
+    #[test]
+    fn expired_timeouts_precede_immediates_which_stay_fifo() {
+        let base = Instant::now();
+        let mut batch = vec![
+            timer(1, CallbackTimerKind::Immediate, base, 0),
+            timer(2, CallbackTimerKind::Timeout, base, 5),
+            timer(3, CallbackTimerKind::Immediate, base, 0),
+            timer(4, CallbackTimerKind::Timeout, base, 1),
+        ];
+        order_expired_callback_batch(&mut batch);
+        let ids: Vec<i64> = batch.iter().map(|t| t.id).collect();
+        assert_eq!(
+            ids,
+            vec![4, 2, 1, 3],
+            "timeouts by deadline (4 then 2), then immediates FIFO (1 then 3)"
+        );
+    }
+}

--- a/test-files/test_gap_6287_timer_batch_order.ts
+++ b/test-files/test_gap_6287_timer_batch_order.ts
@@ -1,0 +1,42 @@
+// #6287: when several timers come due in the same event-loop turn, the batch
+// must fire in event-loop order, not queue (creation) order:
+//   1. expired timeouts by DEADLINE (a 5 ms timer created after a 10 ms one
+//      still fires first), with same-deadline ties in creation order;
+//   2. timeouts (timers phase) before setImmediate (check phase), with
+//      immediates FIFO among themselves.
+// Each block blocks the loop first, so every timer below is already expired
+// when the loop next ticks — that is what makes batch ordering observable.
+
+const log: string[] = [];
+
+// --- deadline ordering, created in reverse-deadline order ---
+setTimeout(() => log.push("t10"), 10);
+setTimeout(() => log.push("t5"), 5);
+setTimeout(() => log.push("t1"), 1);
+
+// --- same deadline => creation order (must not regress) ---
+setTimeout(() => log.push("same-a"), 3);
+setTimeout(() => log.push("same-b"), 3);
+setTimeout(() => log.push("same-c"), 3);
+
+// --- cleared timers never fire, and don't disturb the survivors ---
+const cancelled = setTimeout(() => log.push("CANCELLED"), 2);
+clearTimeout(cancelled);
+
+// --- immediates: scheduled before/after a timeout, must run after it ---
+setImmediate(() => log.push("imm1"));
+setTimeout(() => log.push("t7"), 7);
+setImmediate(() => log.push("imm2"));
+
+// Block past every deadline above so they all land in one expired batch.
+const start = Date.now();
+while (Date.now() - start < 30) {
+  /* spin */
+}
+
+setTimeout(() => {
+  console.log("order:", log.join(","));
+  console.log("count:", log.length);
+  console.log("no-cancelled:", !log.includes("CANCELLED"));
+  console.log("done");
+}, 50);


### PR DESCRIPTION
## Summary

Fixes #6287. When several timers come due in the same event-loop turn, Perry fired the batch in **queue (creation) order**. That diverged from Node on two counts, and the second one is why a naive "just sort by deadline" would have been wrong.

### 1. Deadline order

Node's timers phase walks lists by expiry, so a 5 ms timer created *after* a 10 ms one still fires first:

```ts
setTimeout(() => log("late10"), 10);
setTimeout(() => log("reffed"), 5);
```
| | |
|---|---|
| node | `reffed, late10` |
| perry (before) | `late10, reffed` |

### 2. Timers before immediates

`setImmediate` runs in the **check** phase, which comes *after* the timers phase — so an expired `setTimeout` fires ahead of an immediate that was scheduled earlier. Perry interleaved both kinds in one creation-ordered queue:

```ts
setImmediate(() => log("IMM1"));
setTimeout(() => log("T5"), 5);   // loop blocked past 5 ms
```
| | |
|---|---|
| node | `T5, IMM1` |
| perry (before) | `IMM1, T5` |

This case is the reason the fix is **kind-aware** rather than a plain deadline sort: an immediate carries a `~now` deadline, so sorting the batch by deadline alone would place it *ahead* of the expired timeout and make this case worse.

## Fix

Order the expired callback batch as **(timeouts by deadline) then (immediates in FIFO)**, and the expired promise-timer batch by deadline. Both sorts are **stable**, which is what preserves the two orderings Perry already got right:

- same-deadline timers keep firing in creation order (Node semantics), and
- immediates keep firing in scheduling order.

`order_expired_callback_batch` is a single `sort_by` over the drained batch — O(k log k) in the number of timers actually due, on a path that only runs when something expired.

## Verification

Node's ordering was **captured as ground truth** from `node --experimental-strip-types` (deterministic across repeated runs) rather than inferred from the docs — including the immediate-vs-timeout case that rules out the naive sort.

- **Unit tests** (3): deadline order for expired timeouts; same-deadline ties keep creation order (the stable-sort guarantee); timeouts-before-immediates with immediates staying FIFO.
- **Gap test** `test_gap_6287_timer_batch_order.ts`: blocks the loop past every deadline so the whole batch comes due in one turn (this is what makes batch ordering observable at all — and it makes the test deterministic rather than timing-dependent). Covers reverse-deadline creation, same-deadline ties, a `clearTimeout` mid-burst, and immediates scheduled either side of a timeout. **Byte-identical to node**, repeatedly, before and after:

  | | order |
  |---|---|
  | node | `t1,same-a,same-b,same-c,t5,t7,t10,imm1,imm2` |
  | perry (before) | `t10,t5,t1,same-a,same-b,same-c,imm1,t7,imm2` |
  | perry (after) | `t1,same-a,same-b,same-c,t5,t7,t10,imm1,imm2` |

- `cargo test -p perry-runtime`: **1239 passed, 0 failed**. `cargo fmt --all -- --check` clean.
- Full gap suite: no new failures vs base.

## Stacking

Branched off `perf/6084-promise-map-timer-scans` (**#6285**), which refactored the same drain path — the two would otherwise conflict in `js_timer_tick`/`js_callback_timer_tick`. **Review the last two commits only**; merge #6285 first and this retargets cleanly to `main`.

## Note on an unrelated pre-existing flake

While gating this I found that `cargo test -p perry-runtime` is **already flaky under parallel execution on `main`** — pristine `main` failed 2 of 5 runs (`closure::dynamic_props::tests_1802::*`). Root cause is test hermeticity, not product code: `dyn_prop_scanner_visits_values_without_holding_props_lock` asserts `get_closure_props().try_lock().is_ok()`, which fails spuriously whenever any parallel test happens to hold the process-global `CLOSURE_PROPS` at that instant. Unrelated to this change (it reproduces with all my edits reverted) and left alone here, but worth a separate fix — it will keep producing random red CI.
