### PR TITLE
fix(runtime): reject non-heap / untracked receivers in raw-pointer recovery + deref sites

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -60,6 +60,29 @@ pub extern "C" fn js_object_get_field_by_name(
             }
         }
     }
+    // A receiver that LOOKS like a bare heap pointer (top 16 bits clear) but does
+    // not land in the platform heap range is a MIS-decoded primitive, not an
+    // object. The common case is a `number` whose raw f64 bits alias a sub-heap
+    // address: a dynamic `arr[i]` read (`js_dyn_index_get`) returns the element's
+    // JSValue bits, codegen forwards them straight to the object field-read ABI
+    // on the type-erased path, and a denormal such as `0x0000_0090_8000_0201`
+    // (~620 GB) arrives here as `obj`. It clears the `>> 48 == 0` check and sits
+    // ABOVE the 1 MB handle band, so the `is_above_handle_band`-only guards on the
+    // special-case reads below (and the `own_key_present` / `js_object_get_class_id`
+    // ObjectHeader derefs they call) passed it straight through — and the read
+    // dereferenced it as a GcHeader → KERN_INVALID_ADDRESS (real macOS allocations
+    // sit at ~3–5 TB, never 620 GB). Pair the band check with `is_valid_obj_ptr`
+    // (the canonical heap-range predicate) and treat a non-heap receiver as a
+    // property miss: reading any data property off a primitive is `undefined`, and
+    // the primitive-prototype methods are resolved on the by-name f64 wrapper's own
+    // path, which never reaches this pointer dereference.
+    if !key.is_null()
+        && ((obj as u64) >> 48) == 0
+        && crate::value::addr_class::is_above_handle_band(obj as usize)
+        && !crate::value::addr_class::is_valid_obj_ptr(obj as *const u8)
+    {
+        return JSValue::undefined();
+    }
     // `class X extends Map | Set` instance — `.size` reads the hidden backing
     // collection's size. A subclass CAN still define an own `size` (class field
     // or `Object.defineProperty`), so check own-property precedence first and


### PR DESCRIPTION
## Problem

`js_object_get_field_by_name` gates its special-case reads (the `extends
Map/Set` `.size` backing, the WeakMap/WeakSet method probes, the class-object
probe) — and the `own_key_present` / `js_object_get_class_id` `ObjectHeader`
dereferences they call — on:

```rust
((obj as u64) >> 48) == 0 && is_above_handle_band(obj as usize)
```

`is_above_handle_band` only rejects the sub-1 MB handle/proxy bands, so **any**
value whose top 16 bits are clear and whose low bits exceed 1 MB is treated as a
real heap object and dereferenced.

That admits a **mis-decoded primitive**. On the type-erased dynamic path, a
`arr[i]` read (`js_dyn_index_get`) returns the element's raw JSValue bits and
codegen forwards them straight to the object field-read ABI. When the element is
a `number`, a denormal whose f64 bits alias a low address — e.g.
`0x0000_0090_8000_0201` (~620 GB) — arrives as `obj`. It clears `>> 48 == 0`,
sits above the handle band, and gets dereferenced as a `GcHeader`:
`EXC_BAD_ACCESS` / `KERN_INVALID_ADDRESS` (real macOS allocations live at
~3–5 TB, never 620 GB; the fault reads the type tag at `obj - 8`).

## Fix

Pair the band check with `is_valid_obj_ptr` — the canonical heap-range predicate
the rest of the runtime already uses (`is_plausible_heap_addr`,
`decode_heap_addr`) — and treat a receiver that *looks* like a bare pointer but
is not a plausible heap address as a property miss. Reading any data property off
a primitive is `undefined` per spec, and primitive-prototype methods are resolved
earlier on the by-name f64 wrapper's own path, which never reaches this
dereference.

## Validation

- A focused repro — `arr[i].foo` where `arr[i]` is the exact
  `0x0000_0090_8000_0201` denormal — returns `undefined` for the number/string
  elements and the real field for the object element, instead of SIGSEGV.
- `perry-runtime` suite: **1233 passed / 0 failed**.

Found while diagnosing an intermittent startup `SIGSEGV` in a large
esbuild-bundled CLI app; this dereference was the fault site (a getter reading a
property off a dynamic index result). Note: the macOS heap floor
(`is_valid_obj_ptr` = 2 TB) makes the guard reject the bogus address on that
platform; on Linux/Windows (`HEAP_MIN = 0x1000`) the downstream `obj_type` check
remains the backstop, as elsewhere in the runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved property access safety for invalid or misinterpreted primitive values.
  * Prevented potential crashes caused by treating non-object values as object references.
  * Such property lookups now safely return `undefined` when the receiver is not a valid object.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->