### PR TITLE
fix(runtime): Proxy get-trap must fire during Promise resolution's then read

### DIFF
--- a/crates/perry-runtime/src/value/dynamic_object.rs
+++ b/crates/perry-runtime/src/value/dynamic_object.rs
@@ -234,6 +234,41 @@ pub unsafe extern "C" fn js_dynamic_object_get_property(
     property_name_ptr: *const i8,
     property_name_len: usize,
 ) -> f64 {
+    // A revocable Proxy value reaching this generic dynamic getter must go
+    // through the Proxy's `get` trap. Proxy ids live at the TOP of the handle
+    // band ([PROXY_ID_BAND_START, HANDLE_BAND_MAX)), so without this branch the
+    // `is_handle_band` dispatch further down routes the read to the stdlib
+    // handle dispatcher and the trap never fires. The Promise resolution
+    // procedure's `Get(resolution, "then")` runs through here, so
+    // `Promise.resolve(proxy)` / `await proxy` on a thenable Proxy (React's RSC
+    // client-module reference, whose `.then` trap lazily marks the module as an
+    // async ESM export) silently skipped the trap — #5989: the Flight stream
+    // dropped the `,1` async flag on client references. Mirror the proxy branch
+    // in `js_object_get_field_by_name`. `js_proxy_is_proxy` confirms a
+    // *registered* proxy so a real heap object with a small address isn't
+    // misrouted.
+    if !property_name_ptr.is_null() {
+        let addr = js_nanbox_get_pointer(obj_value);
+        if addr != 0 && crate::value::addr_class::is_proxy_id_band(addr as usize) {
+            const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
+            let boxed = f64::from_bits(POINTER_TAG | (addr as u64 & POINTER_MASK));
+            if crate::proxy::js_proxy_is_proxy(boxed) != 0 {
+                let name_slice = if property_name_len > 0 {
+                    std::slice::from_raw_parts(property_name_ptr as *const u8, property_name_len)
+                } else {
+                    std::ffi::CStr::from_ptr(property_name_ptr as *const std::ffi::c_char)
+                        .to_bytes()
+                };
+                let key = crate::string::js_string_from_bytes(
+                    name_slice.as_ptr(),
+                    name_slice.len() as u32,
+                );
+                let key_f64 = crate::value::js_nanbox_string(key as i64);
+                return crate::proxy::js_proxy_get(boxed, key_f64);
+            }
+        }
+    }
+
     // Check if this is a JS handle
     if is_js_handle(obj_value) {
         // Try to use the JS runtime function if it's been registered

--- a/test-files/test_gap_promise_resolve_proxy_then_trap.ts
+++ b/test-files/test_gap_promise_resolve_proxy_then_trap.ts
@@ -1,0 +1,64 @@
+// #5989: the Promise resolution procedure must read `then` via `Get(resolution,
+// "then")`, which for a Proxy resolution value invokes the Proxy's `get` trap.
+//
+// Perry's `js_dynamic_object_get_property` (the thenable check behind
+// `Promise.resolve`/`await`) lacked a Proxy branch, so a Proxy in the proxy id
+// band fell into the generic handle dispatch and its `get` trap never fired —
+// only direct `proxy.then` / `typeof proxy.then` (which route through the
+// codegen property-get) triggered it. React's RSC client-module references are
+// exactly such trap-bearing Proxies: their `then` trap lazily marks the module
+// as an async ESM export, and the Flight serializer awaits/resolves them, so
+// the async flag (the trailing `,1` in `I[id,chunks,name,1]`) was dropped.
+
+function trapProxy(log: string[]) {
+  return new Proxy(
+    { v: 42 },
+    {
+      get(t: any, key) {
+        if (typeof key === "string") log.push("get:" + key);
+        return t[key];
+      },
+    },
+  );
+}
+
+async function main() {
+  // Promise.resolve must Get(resolution, "then").
+  const l1: string[] = [];
+  Promise.resolve(trapProxy(l1));
+  await Promise.resolve();
+  console.log("Promise.resolve reads then:", l1.includes("get:then"));
+
+  // await must Get(value, "then").
+  const l2: string[] = [];
+  await trapProxy(l2);
+  console.log("await reads then:", l2.includes("get:then"));
+
+  // A resolve() inside a new Promise must Get(resolution, "then").
+  const l3: string[] = [];
+  await new Promise<void>((res) => res(trapProxy(l3) as any));
+  console.log("resolve() reads then:", l3.includes("get:then"));
+
+  // Promise.all element resolution reads then on each.
+  const l4: string[] = [];
+  await Promise.all([trapProxy(l4)]);
+  console.log("Promise.all reads then:", l4.includes("get:then"));
+
+  // A thenable Proxy actually assimilates: its `then` is invoked and the
+  // resolved value flows through.
+  const thenable = new Proxy(
+    {},
+    {
+      get(_t, key) {
+        if (key === "then") {
+          return (resolve: (v: string) => void) => resolve("assimilated");
+        }
+        return undefined;
+      },
+    },
+  );
+  const result = await (thenable as any);
+  console.log("thenable Proxy resolves to:", result);
+}
+
+main();


### PR DESCRIPTION
## Summary

`js_dynamic_object_get_property` — the type-erased getter behind the Promise resolution procedure's `Get(resolution, "then")` thenable check — had **no Proxy branch**. Revocable Proxy ids sit at the top of the handle band (`[PROXY_ID_BAND_START, HANDLE_BAND_MAX)`), so a Proxy fell into the generic `is_handle_band` dispatch and its `get` trap never ran.

Only direct `proxy.then` / `typeof proxy.then` fired the trap (those route through the codegen property-get, which already has the proxy branch). `Promise.resolve(p)` and `await p` did **not**:

```js
const p = new Proxy(t, { get(_, k){ if (k==="then") { /* mark async */ } } });
typeof p.then          // ✅ trap fires
Promise.resolve(p)     // ❌ trap skipped
await p                // ❌ trap skipped
```

## Fix

Add the proxy-id-band → `js_proxy_get` branch at the top of `js_dynamic_object_get_property`, mirroring `js_object_get_field_by_name`. `js_proxy_is_proxy` confirms a *registered* proxy so a real heap object with a small address isn't misrouted; every non-proxy value falls through unchanged.

## Impact — the last byte of #5989 Next.js `/plain`

React's RSC client-module references are Proxies whose `then` trap lazily marks the module as an **async ESM export**. The Flight serializer resolves/awaits them; node reads `.then` through the trap, so the reference serializes with its async flag — the trailing `,1` in `I[id, chunks, name, 1]`. Perry skipped the trap, dropped the `,1`, and `/plain` differed from node by exactly those **2 bytes** (4878 vs 4880). With this fix `Promise.resolve(proxy)` / `await proxy` observe the trap and the flag is emitted.

## Validation

- New gap test `test_gap_promise_resolve_proxy_then_trap.ts` — a trap-logging Proxy resolved via `Promise.resolve`, `await`, `resolve()` inside a `new Promise`, and `Promise.all` all read `then` through the trap, plus a thenable Proxy that actually assimilates — **byte-identical to node**.
- Regression: `test_gap_5588_object_assign_proxy_source`, `test_gap_5592_extends_proxy_superclass`, `test_gap_object_proto_proxy_2820_2846`, `test_gap_proxy_reflect`, `test_gap_2823_2825_2822_promise_semantics` all pass.
- `cargo fmt` clean; builds on `main`.

Code-only; no version/changelog bump (maintainer folds metadata at merge).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed property access on revocable Proxy values so their `get` traps are correctly invoked.
  - Ensured Promise resolution and async operations consistently access a Proxy’s `then` property through its `get` trap.
  - Improved handling of Proxy thenables across `Promise.resolve`, `await`, and `Promise.all`.
- **Tests**
  - Added coverage for Proxy-based `then` lookups and thenable resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->