### PR TITLE
fix(runtime): derive each split part's metadata from its own bytes (#6085 follow-up)

### DIFF
--- a/crates/perry-runtime/src/string/mod.rs
+++ b/crates/perry-runtime/src/string/mod.rs
@@ -545,6 +545,28 @@ pub(crate) fn string_copy_range(
     ptr
 }
 
+/// Does `bytes` contain a WTF-8 lone-surrogate sequence
+/// (`0xED 0xA0..=0xBF 0x80..=0xBF`)?
+///
+/// Used to derive `STRING_FLAG_HAS_LONE_SURROGATES` for a substring carved out
+/// of a WTF-8 source: the flag is a property of the BYTES, so a slice of a
+/// flagged string only carries it if the surrogate actually landed in that
+/// slice. Bounds-driven — never reads past the slice.
+#[inline]
+pub(crate) fn bytes_have_lone_surrogate(bytes: &[u8]) -> bool {
+    let mut i = 0usize;
+    while i + 3 <= bytes.len() {
+        if bytes[i] == 0xED
+            && (0xA0..=0xBF).contains(&bytes[i + 1])
+            && (0x80..=0xBF).contains(&bytes[i + 2])
+        {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
 /// Count UTF-16 code units for a WTF-8 byte slice without using from_utf8.
 /// Lone surrogate sequences (0xED 0xA0..0xBF 0x80..0xBF) each count as 1 unit,
 /// same as any other BMP codepoint. Astral sequences (4-byte) count as 2.

--- a/crates/perry-runtime/src/string/split.rs
+++ b/crates/perry-runtime/src/string/split.rs
@@ -128,6 +128,27 @@ pub extern "C" fn js_string_split_n(
 
     const STRING_TAG: u64 = 0x7FFF_0000_0000_0000;
     const POINTER_MASK: u64 = 0x0000_FFFF_FFFF_FFFF;
+
+    // Per-part metadata inputs, derived ONCE from the source payload.
+    //
+    // NOT `is_ascii_string(s)`: that compares `byte_len == utf16_len` over the
+    // WHOLE source, which malformed bytes can satisfy while the individual
+    // parts do not. For `[0x80, b'|', 0xF0]` the source is 3 == 3 (so the old
+    // check said "ASCII"), but the parts need utf16_len 0 and 2 — the fast path
+    // stamped 1 and 1 onto them, corrupting `.length` and every downstream
+    // index operation. Scan the bytes instead: a genuinely all-ASCII source has
+    // all-ASCII parts, which IS sound per-part.
+    //
+    // Both of these are plain `bool`s, so they stay valid even if a later
+    // allocation moves the source string.
+    let (src_all_ascii, src_has_lone_surrogates) = unsafe {
+        let bytes = slice::from_raw_parts(string_data(s), (*s).byte_len as usize);
+        (
+            bytes.iter().all(|&b| b < 0x80),
+            (*s).flags & STRING_FLAG_HAS_LONE_SURROGATES != 0,
+        )
+    };
+
     if delim.is_empty() {
         // Empty delimiter: split into individual characters (single pass).
         //
@@ -190,7 +211,16 @@ pub extern "C" fn js_string_split_n(
                 buf[..seq_len].copy_from_slice(&src[i..end]);
                 i = end;
             }
-            let sh = js_string_from_bytes(buf.as_ptr(), seq_len as u32);
+            // `js_string_from_bytes` derives utf16_len from the bytes (correct
+            // even for a malformed sequence) but hardcodes flags = 0. A lone
+            // surrogate carved out of a WTF-8 source must keep its flag, or
+            // `isWellFormed()` on the part wrongly reports true.
+            let seq = &buf[..seq_len];
+            let sh = if src_has_lone_surrogates && crate::string::bytes_have_lone_surrogate(seq) {
+                js_string_from_wtf8_bytes(seq.as_ptr(), seq_len as u32)
+            } else {
+                js_string_from_bytes(seq.as_ptr(), seq_len as u32)
+            };
             unsafe {
                 let arr_now = arr_handle.get_raw_mut_ptr::<ArrayHeader>();
                 let elements_ptr =
@@ -224,8 +254,6 @@ pub extern "C" fn js_string_split_n(
     }
     let n = part_ranges.len();
 
-    let src_is_ascii = is_ascii_string(s);
-
     let arr = crate::array::js_array_alloc(n as u32);
     let scope = crate::gc::RuntimeHandleScope::new();
     let s_handle = scope.root_string_ptr(s);
@@ -239,12 +267,23 @@ pub extern "C" fn js_string_split_n(
             let (sh, data_ptr) = string_storage_alloc(byte_len);
             let s_now = s_handle.get_raw_const_ptr::<StringHeader>();
             let part_ptr = string_data(s_now).add(offset);
-            let utf16_len = if src_is_ascii {
-                byte_len
+            // Derive metadata from THIS PART's own bytes. The only shortcut
+            // taken is the all-ASCII one, which was verified by scanning the
+            // source payload (so it holds for every part).
+            let (utf16_len, flags) = if src_all_ascii {
+                (byte_len, 0)
             } else {
-                compute_utf16_len(part_ptr, byte_len)
+                let part_bytes = slice::from_raw_parts(part_ptr, byte_len as usize);
+                let flags = if src_has_lone_surrogates
+                    && crate::string::bytes_have_lone_surrogate(part_bytes)
+                {
+                    STRING_FLAG_HAS_LONE_SURROGATES
+                } else {
+                    0
+                };
+                (compute_utf16_len(part_ptr, byte_len), flags)
             };
-            init_string_header(sh, utf16_len, byte_len, byte_len, 0, 0);
+            init_string_header(sh, utf16_len, byte_len, byte_len, 0, flags);
             if byte_len > 0 {
                 ptr::copy_nonoverlapping(part_ptr, data_ptr, byte_len as usize);
             }

--- a/crates/perry-runtime/src/string/tests_guard_page.rs
+++ b/crates/perry-runtime/src/string/tests_guard_page.rs
@@ -200,6 +200,95 @@ fn split_by_empty_delimiter_does_not_read_past_payload() {
     assert_eq!(unsafe { (*arr).length }, 3);
 }
 
+/// Read back a split part's `(bytes, utf16_len, flags)`.
+fn split_part_meta(arr: *mut crate::array::ArrayHeader, i: u32) -> (Vec<u8>, u32, u32) {
+    unsafe {
+        let v = crate::array::js_array_get_f64(arr, i);
+        let p = crate::value::js_nanbox_get_pointer(v) as *const StringHeader;
+        let bytes = std::slice::from_raw_parts(string_data(p), (*p).byte_len as usize).to_vec();
+        (bytes, (*p).utf16_len, (*p).flags)
+    }
+}
+
+/// Each split part's metadata must come from THAT PART's own bytes.
+///
+/// `is_ascii_string(s)` only compares `byte_len == utf16_len` over the whole
+/// source, and malformed bytes can satisfy that aggregate while the individual
+/// parts cannot. For `[0x80, '|', 0xF0]` the source is 3 == 3, so the old ASCII
+/// fast path stamped `utf16_len = byte_len = 1` onto BOTH parts — but a stray
+/// continuation byte is 0 code units and a 4-byte lead is 2. Wrong `.length`
+/// then propagates into every downstream index/length operation.
+#[test]
+fn split_parts_get_metadata_from_their_own_bytes() {
+    let src = [0x80u8, b'|', 0xF0];
+    let s = js_string_from_bytes(src.as_ptr(), 3);
+    // The aggregate check really does lie here — that is the whole bug.
+    assert!(
+        is_ascii_string(s),
+        "precondition: the aggregate byte_len == utf16_len check misfires"
+    );
+
+    let delim = js_string_from_bytes(b"|".as_ptr(), 1);
+    let arr = js_string_split_n(s, delim, -1);
+    assert_eq!(unsafe { (*arr).length }, 2);
+
+    // [0x80] — a stray continuation byte contributes ZERO UTF-16 units.
+    let (b0, u0, f0) = split_part_meta(arr, 0);
+    assert_eq!(b0, vec![0x80]);
+    assert_eq!(u0, 0, "stray continuation byte is 0 UTF-16 units, not 1");
+    assert_eq!(f0, 0);
+
+    // [0xF0] — a 4-byte lead counts as an astral code point: TWO units.
+    let (b1, u1, f1) = split_part_meta(arr, 1);
+    assert_eq!(b1, vec![0xF0]);
+    assert_eq!(u1, 2, "4-byte lead is 2 UTF-16 units, not 1");
+    assert_eq!(f1, 0);
+}
+
+/// A lone surrogate carved out of a WTF-8 source must keep its
+/// `HAS_LONE_SURROGATES` flag, or `isWellFormed()` on the part wrongly says
+/// true. (`js_string_from_bytes` hardcodes `flags = 0`, so the flag has to be
+/// derived from the part's own bytes.)
+#[test]
+fn split_parts_preserve_lone_surrogate_flag() {
+    // "\uD800" (ED A0 80) + '|' + 'B'
+    let src = [0xEDu8, 0xA0, 0x80, b'|', b'B'];
+    let s = js_string_from_wtf8_bytes(src.as_ptr(), 5);
+    let delim = js_string_from_bytes(b"|".as_ptr(), 1);
+
+    let arr = js_string_split_n(s, delim, -1);
+    assert_eq!(unsafe { (*arr).length }, 2);
+
+    let (b0, u0, f0) = split_part_meta(arr, 0);
+    assert_eq!(b0, vec![0xED, 0xA0, 0x80]);
+    assert_eq!(u0, 1);
+    assert_eq!(
+        f0, STRING_FLAG_HAS_LONE_SURROGATES,
+        "the part holding the lone surrogate must stay flagged"
+    );
+    let part0 = unsafe {
+        let v = crate::array::js_array_get_f64(arr, 0);
+        crate::value::js_nanbox_get_pointer(v) as *const StringHeader
+    };
+    assert_eq!(
+        js_string_is_well_formed(part0).to_bits(),
+        crate::value::TAG_FALSE,
+        "isWellFormed() must be false for a lone-surrogate part"
+    );
+
+    // The clean part must NOT inherit the flag.
+    let (b1, _, f1) = split_part_meta(arr, 1);
+    assert_eq!(b1, vec![b'B']);
+    assert_eq!(f1, 0, "a part with no surrogate must not carry the flag");
+
+    // Same for the empty-delimiter path.
+    let empty = js_string_from_bytes(b"".as_ptr(), 0);
+    let chars = js_string_split_n(s, empty, -1);
+    let (cb0, _, cf0) = split_part_meta(chars, 0);
+    assert_eq!(cb0, vec![0xED, 0xA0, 0x80]);
+    assert_eq!(cf0, STRING_FLAG_HAS_LONE_SURROGATES);
+}
+
 /// A truncated multi-byte tail must NOT be mistaken for whitespace.
 ///
 /// `wtf8_step` zero-fills continuation bytes that don't exist, so a dangling


### PR DESCRIPTION
Follow-up to #6286 (#6085). That PR was merged at `3525a31dd`, one commit before this fix landed on the branch, so this review finding is **not** on `main`. It is a real correctness bug and is filed here on its own.

## Root cause

`js_string_split_n`'s ASCII fast path gated on `is_ascii_string(s)`, which only compares `byte_len == utf16_len` over the **whole source**. Malformed bytes can satisfy that aggregate while the individual parts cannot — so the fast path stamped wrong `utf16_len` (and hardcoded `flags = 0`) onto every part.

This lands squarely in #6085's own threat model: a payload that is *not* well-formed UTF-8 is the entire reason that issue exists (FFI / `Buffer` blobs split on an ASCII delimiter).

### Verified, not inferred

Instrumented `js_string_split_n` with `[0x80, '|', 0xF0]`:

```
SOURCE byte_len=3 utf16_len=3 is_ascii_string=true    <- the aggregate lies
  part[0] bytes=[80] byte_len=1 utf16_len(RECORDED)=1 utf16_len(CORRECT)=0
  part[1] bytes=[F0] byte_len=1 utf16_len(RECORDED)=1 utf16_len(CORRECT)=2
```

A stray continuation byte is **0** UTF-16 units; a 4-byte lead is **2**. Both were recorded as **1**. That wrong `.length` propagates into every downstream index/length operation.

Lone-surrogate metadata was dropped too. With `"\uD800|B"` (`ED A0 80 | B`):

```
SRC flags=1 utf16_len=3 byte_len=5
  PART[0] bytes=[ED, A0, 80] flags=0  (isWellFormed=true)   <- wrong
```

Note `js_string_from_bytes` **also** hardcodes `flags = 0` (it only derives `utf16_len`), so the flag has to be derived from each part's **own bytes**, not mirrored from that constructor.

## Fix

- Replace the aggregate `is_ascii_string(s)` gate with an actual **byte scan of the source payload**. A genuinely all-ASCII source provably has all-ASCII parts, so that shortcut *is* sound per-part — it is kept (common case, hot path), but now gated on something true.
- Otherwise derive `utf16_len` per part with the bounded `compute_utf16_len` over that part's own bytes.
- Derive `STRING_FLAG_HAS_LONE_SURROGATES` per part via a new bounds-driven `bytes_have_lone_surrogate()` helper, on **both** the non-empty and empty-delimiter paths. A part carries the flag only if the surrogate actually landed in it.

## Tests

- `split_parts_get_metadata_from_their_own_bytes` — asserts `utf16_len` 0 and 2 for the two parts, and asserts the precondition that `is_ascii_string` really does misfire, so a regression back to the aggregate check fails the test.
- `split_parts_preserve_lone_surrogate_flag` — flagged part → `isWellFormed() == false`; the clean `"B"` part stays unflagged; covers the `split("")` path too.

`cargo test -p perry-runtime -- --test-threads=1`: **1257 passed, 0 failed**. `cargo fmt --all -- --check` clean. Node parity repro (per-frame `split('\n')` → `split('|')` → `parseFloat`, plus every scanner touched): byte-identical to a stock `main` build and identical to `node --experimental-strip-types`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved string splitting for malformed UTF-8 and lone-surrogate content.
  * Split results now retain accurate character lengths and encoding metadata.
  * Corrected handling for both delimiter-based and character-by-character splitting.
  * Prevented incorrect metadata from being copied from the original string to each result.

* **Tests**
  * Added regression coverage for split-result metadata and lone-surrogate preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->