### PR TITLE
fix(runtime): Map/BigInt bare-address branches must reject the handle bands (unblocks main)

### DIFF
--- a/crates/perry-runtime/src/map.rs
+++ b/crates/perry-runtime/src/map.rs
@@ -105,7 +105,11 @@ pub fn map_ptr_from_receiver_bits(bits: u64) -> Option<*mut MapHeader> {
     let jsv = crate::value::JSValue::from_bits(bits);
     let addr = if jsv.is_pointer() {
         (bits & 0x0000_FFFF_FFFF_FFFF) as usize
-    } else if bits >> 48 == 0 && bits > 0x10000 {
+    } else if bits >> 48 == 0 && crate::value::addr_class::is_above_handle_band(bits as usize) {
+        // #6271 class: the bare-address branch must reject the handle bands, not
+        // just small integers. A hand-rolled `> 0x10000` floor sits an order of
+        // magnitude BELOW `HANDLE_BAND_MAX` (0x100000), so every fetch / zlib /
+        // proxy handle passed it and was treated as a candidate heap address.
         bits as usize
     } else {
         return None;
@@ -258,7 +262,9 @@ fn bigint_ptr_from_bits(bits: u64) -> *const crate::bigint::BigIntHeader {
     let upper = bits >> 48;
     let addr = if upper == (crate::value::BIGINT_TAG >> 48) || upper == 0x7FFD {
         (bits & crate::value::POINTER_MASK) as usize
-    } else if upper == 0 && bits > 0x10000 {
+    } else if upper == 0 && crate::value::addr_class::is_above_handle_band(bits as usize) {
+        // #6271 class — see `map_ptr_from_receiver_bits`: `> 0x10000` lets the
+        // whole handle band through; `is_above_handle_band` is the real floor.
         bits as usize
     } else {
         return std::ptr::null();


### PR DESCRIPTION
## main is currently red — this unblocks it

The addr-class ratchet fails on a **clean `origin/main` checkout**:

```
[handle-floor] crates/perry-runtime/src/map.rs: 4 site(s), baseline allows 3
```

so the `lint` gate blocks every PR against main. #6285 added two hand-rolled address floors to `map.rs` without updating the ratchet baseline. (Found while rebasing #6294; my branch doesn't touch `map.rs` at all.)

## The floors are also wrong — which is what the ratchet exists to catch

Both bare-address branches gate on `bits > 0x10000`:

```rust
} else if bits >> 48 == 0 && bits > 0x10000 {   // map_ptr_from_receiver_bits
} else if upper == 0 && bits > 0x10000 {        // bigint_ptr_from_bits
```

But `HANDLE_BAND_MAX` is **`0x100000`** — an order of magnitude higher. So every fetch handle (`0x40000..0xE0000`), zlib stream handle and proxy id clears that floor and is accepted as a candidate heap address.

Both call sites happen to survive *today* because each re-checks before dereferencing — `is_registered_map` is an exact registry lookup, and `try_read_gc_header` is the guarded reader — so this is a **latent hazard, not a live segfault**. But it's exactly the shape that segfaults on Linux the moment a caller trusts the returned address: the #1843 / #4004 / #4665 / #4800 / #6271 family, which macOS's 2 TB heap floor reliably hides.

## Fix

Use the sanctioned predicate, `value::addr_class::is_above_handle_band`, as the floor — which is what the ratchet's own failure message tells you to do.

It is strictly narrower than the old check: the only addresses it newly rejects are `[0x10001, 0x100000)` — precisely the handle bands, which must never be read as a `Map` or `BigInt` header. Real arena allocations are already above `HANDLE_BAND_MAX`, so no valid pointer changes behavior.

## Result

- `map.rs` drops from 4 handle-floor sites to 2 (baseline allows 3) → **ratchet passes, main goes green**.
- `perry-runtime` lib suite: **1264/1264**.
- `cargo fmt` clean; `gc_store_site_inventory` gate passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of encoded map and bigint references.
  * Correctly distinguishes valid addresses from values in the reserved handle range, reducing the risk of invalid reference interpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->