### PR TITLE
ci: shard the node core subset radar so the nightly completes (#6305)

### DIFF
--- a/.github/workflows/node-core-subset.yml
+++ b/.github/workflows/node-core-subset.yml
@@ -1,5 +1,19 @@
 name: Node Core Subset Radar
 
+# Advisory nightly Node-compat radar (#800). It publishes a parity number and
+# an artifact; it does NOT gate merges or releases, and it deliberately does
+# NOT run on pull_request — it is a heavy, cargo-relinking sweep.
+#
+# #6305: this used to be one serial job that swept all 23 APIs. It never once
+# completed — 38/38 scheduled runs died with exit 143, and the runner's own
+# system log gave the reason: "The runner has received a shutdown signal", i.e.
+# the hosted VM was reclaimed under the job rather than stopped by
+# `timeout-minutes`. When that happens no further step runs — not even an
+# `if: always()` one — so the report was never uploaded and #4975 lost its
+# parity number entirely. The sweep is now split across shards, each shard is
+# bounded by a wall-clock budget it enforces itself, and the report is written
+# incrementally so a partial sweep still publishes a (clearly-flagged) number.
+
 on:
   workflow_dispatch:
     inputs:
@@ -12,8 +26,6 @@ on:
         required: false
         default: "25"
   schedule:
-    # Advisory nightly compatibility radar. It uploads a report but does not
-    # gate merges or releases.
     - cron: "17 3 * * *"
 
 permissions:
@@ -23,13 +35,35 @@ concurrency:
   group: node-core-subset-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  # Number of shards. MUST equal the length of `matrix.shard` below — the merge
+  # job uses it to know which per-shard reports to expect, so that a shard whose
+  # runner died outright is detected as missing rather than silently dropped.
+  NODE_CORE_SHARDS: "6"
+  # Bail out of the sweep with a partial-but-flagged report at this many seconds
+  # rather than running until something else kills us. Sized to sit well inside
+  # the job's `timeout-minutes` even after the release build and a cold ext-crate
+  # prewarm (the budget covers the prewarm too).
+  NODE_CORE_TIME_BUDGET: "2400"
+
 jobs:
-  node-core-subset:
+  radar:
+    name: radar (shard ${{ matrix.shard }})
     runs-on: ubuntu-latest
-    timeout-minutes: 180
+    timeout-minutes: 75
+    strategy:
+      # One shard blowing its budget must not cancel the others: their numbers
+      # are still worth publishing.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6]
     env:
       NODE_CORE_APIS: ${{ github.event_name == 'workflow_dispatch' && inputs.apis || '' }}
       NODE_CORE_MAX_PER_API: ${{ github.event_name == 'workflow_dispatch' && inputs.max_per_api || '25' }}
+      # Without this, Python block-buffers stdout into the Actions pipe and a
+      # killed step shows *zero* output — which is why #6305 was undiagnosable
+      # from the job log for six weeks.
+      PYTHONUNBUFFERED: "1"
     steps:
       - uses: actions/checkout@v7
 
@@ -63,14 +97,66 @@ jobs:
           set -euo pipefail
           args=(
             --root vendor/nodejs
-            --report test-compat/node-core/report.json
+            --report "test-compat/node-core/report-shard-${{ matrix.shard }}.json"
             --max-per-api "$NODE_CORE_MAX_PER_API"
+            --shard "${{ matrix.shard }}/${{ strategy.job-total }}"
+            --time-budget "$NODE_CORE_TIME_BUDGET"
           )
           if [[ -n "$NODE_CORE_APIS" ]]; then
             read -r -a requested_apis <<< "$NODE_CORE_APIS"
             args+=(--api "${requested_apis[@]}")
           fi
           scripts/node_core_subset.py "${args[@]}"
+
+      - name: Runner headroom
+        if: always()
+        run: |
+          # The nightly's terminal symptom was the VM being reclaimed mid-sweep.
+          # If that recurs, this is the evidence we did not have (#6305).
+          df -h / | tail -1
+          free -h | head -2
+
+      - name: Upload shard report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: node-core-subset-report-shard-${{ matrix.shard }}
+          path: test-compat/node-core/report-shard-${{ matrix.shard }}.json
+          if-no-files-found: warn
+
+  report:
+    name: merge + publish
+    needs: radar
+    # Publish whatever the shards managed even if some of them failed: a
+    # clearly-flagged lower bound beats the nothing-at-all that #6305 produced.
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Download shard reports
+        uses: actions/download-artifact@v8
+        with:
+          pattern: node-core-subset-report-shard-*
+          merge-multiple: true
+          path: shard-reports
+
+      - name: Merge shard reports
+        run: |
+          set -euo pipefail
+          # Ask for every shard report BY NAME rather than globbing whatever
+          # turned up: a shard whose runner was reclaimed uploads nothing, and
+          # that has to read as a missing shard, not as a smaller sweep. The
+          # merge exits non-zero if any shard is missing or incomplete — but it
+          # writes the aggregate report first, so the number still lands.
+          reports=()
+          for i in $(seq 1 "$NODE_CORE_SHARDS"); do
+            reports+=("shard-reports/report-shard-${i}.json")
+          done
+          scripts/node_core_subset.py \
+            --merge "${reports[@]}" \
+            --report test-compat/node-core/report.json
 
       - name: Write radar summary
         if: always()
@@ -80,15 +166,24 @@ jobs:
           from pathlib import Path
 
           report_path = Path("test-compat/node-core/report.json")
+          print("## Node Core Subset Radar")
+          print("")
           if not report_path.exists():
-              print("## Node Core Subset Radar")
-              print("")
               print("No report was generated.")
               raise SystemExit(0)
 
           report = json.loads(report_path.read_text())
-          print("## Node Core Subset Radar")
-          print("")
+          if not report.get("complete", False):
+              print("> [!WARNING]")
+              print("> **The sweep did not complete** — the parity below is a "
+                    "LOWER BOUND over the tests that actually ran.")
+              for key, label in (("missing_shard_reports", "Missing shard reports"),
+                                 ("unreached_apis", "Never reached"),
+                                 ("partial_apis", "Cut off mid-API")):
+                  if report.get(key):
+                      print(f"> - {label}: `{', '.join(report[key])}`")
+              print("")
+
           print(f"Node corpus: `{report.get('node_pinned', '')}`")
           print(f"Node runtime: `{report.get('node_runtime', '')}`")
           print(f"Parity: `{report.get('parity_pct', 0)}%` over `{report.get('judged', 0)}` judged tests")

--- a/scripts/node_core_subset.py
+++ b/scripts/node_core_subset.py
@@ -59,6 +59,43 @@ the sweep is incremental, and bumps the per-compile timeout to absorb the
 cold cargo build (see `--compile-timeout`). Restrict with `--api` to keep
 the sweep tractable.
 
+Bounding the sweep (#6305)
+--------------------------
+The nightly radar never once completed: every scheduled run died mid-sweep with
+exit 143, and the runner's own `system.txt` gave the reason —
+
+    ##[error]The runner has received a shutdown signal.
+    ##[error]Process completed with exit code 143.
+
+i.e. the hosted VM was reclaimed out from under the job, not stopped by
+`timeout-minutes`. When that happens *no* later step runs (even `if: always()`
+ones), and since the report was only written after the final API, the run
+uploaded nothing at all — the radar read as "no signal" rather than "broken".
+
+Three things kept the sweep unbounded, and all three are fixed here:
+
+1. **No wall-clock bound.** One serial job swept 23 APIs x <=25 tests, ~125 of
+   which are auto-optimize compiles that each pay a cargo relink of the Perry
+   runtime. `--shard I/N` splits the API list across N jobs (cost-aware: the
+   auto-optimize APIs are round-robined FIRST so no shard draws two — a
+   contiguous split would put http/https/net/zlib, adjacent in
+   `supported-apis.txt`, in one shard), and `--time-budget SECS` stops the sweep
+   at a deadline instead of running until something else kills it. `--merge`
+   reduces the per-shard reports back to one aggregate.
+
+2. **Leaked grandchildren.** `subprocess.run(timeout=...)` kills only the direct
+   child. Node's core tests fork servers, workers and `child_process` helpers,
+   so every timed-out test leaked a live process tree that kept holding CPU,
+   memory and sockets for the rest of the sweep (the runner logs "Cleaning up
+   orphan processes" at kill time). `run()` now puts each child in its own
+   process group and SIGKILLs the whole group on timeout.
+
+3. **Nothing on disk until the end.** The report is now rewritten after every
+   API, so even a hard kill leaves a partial, mergeable report behind.
+
+A sweep that is cut short reports `complete: false` and exits non-zero: an
+incomplete radar must fail loudly, not quietly publish a number that looks whole.
+
 See test-compat/node-core/README.md.
 """
 
@@ -69,6 +106,7 @@ import json
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -91,6 +129,10 @@ SHIM_DIR = NODE_CORE_DIR / "shim"
 _AUTO_OPTIMIZE_APIS: frozenset[str] = frozenset({
     "events", "http", "https", "net", "zlib",
 })
+
+# Report buckets, and the subset of them that carry failing-test samples.
+_BUCKETS = ("pass", "diff", "runtime-fail", "compile-fail", "node-skip")
+_SAMPLE_BUCKETS = ("diff", "runtime-fail", "compile-fail", "node-skip")
 
 
 # Lines that are pure environmental noise from either runtime — stripped
@@ -170,23 +212,56 @@ class Bucket:
             self.samples.append(Sample(api, test, reason[:300]))
 
 
-def run(cmd, env, timeout, cwd=None):
-    """Return (exit_code, combined_stdout_stderr). exit_code 124 == timeout."""
+def _kill_group(proc: subprocess.Popen) -> None:
+    """SIGKILL the child's whole process group, then the child (#6305).
+
+    Called only while `proc` is known to be unreaped, so its pid — and hence
+    the group id it leads — cannot have been recycled onto some other process.
+    """
     try:
-        p = subprocess.run(
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
+    try:
+        proc.kill()
+    except OSError:
+        pass
+
+
+def run(cmd, env, timeout, cwd=None):
+    """Return (exit_code, combined_stdout_stderr). exit_code 124 == timeout.
+
+    The child gets its own process group (`start_new_session`) and on timeout
+    the WHOLE group is killed. `subprocess.run(timeout=...)` kills only the
+    direct child, and Node's core tests routinely fork servers, workers and
+    `child_process` helpers — so every timed-out test used to leak a live
+    process tree that kept burning CPU/memory and holding listening sockets for
+    the remainder of the sweep. On the CI runner that accumulation is what
+    eventually got the VM reclaimed mid-sweep (#6305).
+    """
+    try:
+        p = subprocess.Popen(
             cmd,
             env=env,
             cwd=cwd,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
-            timeout=timeout,
+            start_new_session=True,
         )
-        return p.returncode, p.stdout.decode("utf-8", errors="replace")
-    except subprocess.TimeoutExpired as e:
-        out = e.stdout.decode("utf-8", errors="replace") if e.stdout else ""
-        return 124, out
     except FileNotFoundError as e:
         return 127, str(e)
+    try:
+        out, _ = p.communicate(timeout=timeout)
+        return p.returncode, out.decode("utf-8", errors="replace")
+    except subprocess.TimeoutExpired:
+        _kill_group(p)
+        # The group is gone, so the write ends of the pipe are all closed and
+        # this drain cannot block for long; the bound is pure belt-and-braces.
+        try:
+            out, _ = p.communicate(timeout=30)
+        except subprocess.TimeoutExpired:
+            out = b""
+        return 124, out.decode("utf-8", errors="replace")
 
 
 def first_meaningful_line(text: str) -> str:
@@ -211,6 +286,174 @@ def error_line(text: str) -> str:
     return lines[-1] if lines else "(no output)"
 
 
+def parse_shard(spec: str) -> tuple[int, int]:
+    """`"3/6"` -> (2, 6): a 0-based index and the shard count (#6305)."""
+    m = re.fullmatch(r"\s*(\d+)\s*/\s*(\d+)\s*", spec)
+    if not m:
+        raise argparse.ArgumentTypeError(
+            f"--shard must look like I/N (1-based), got {spec!r}")
+    index, total = int(m.group(1)), int(m.group(2))
+    if total < 1 or not 1 <= index <= total:
+        raise argparse.ArgumentTypeError(
+            f"--shard I/N needs 1 <= I <= N, got {spec!r}")
+    return index - 1, total
+
+
+def shard_apis(apis: list[str], index: int, total: int) -> list[str]:
+    """Cost-aware deterministic split of `apis` across `total` shards (#6305).
+
+    Every compile of an `_AUTO_OPTIMIZE_APIS` test pays a cargo relink of the
+    Perry runtime, so those APIs dominate the sweep's wall clock. Round-robin
+    them FIRST, so with total >= len(_AUTO_OPTIMIZE_APIS) no shard ever draws
+    two — a contiguous split would drop http/https/net/zlib (adjacent in
+    supported-apis.txt) into a single shard and leave it as slow as the
+    unsharded job. Then round-robin the cheap APIs to even out the tail.
+    """
+    heavy = [a for a in apis if a in _AUTO_OPTIMIZE_APIS]
+    light = [a for a in apis if a not in _AUTO_OPTIMIZE_APIS]
+    mine = {a for i, a in enumerate(heavy) if i % total == index}
+    mine |= {a for i, a in enumerate(light) if i % total == index}
+    return [a for a in apis if a in mine]  # preserve supported-apis.txt order
+
+
+def build_report(*, pinned: str, node_runtime: str, args, apis: list[str],
+                 auto_optimize_apis_in_run: list[str],
+                 buckets: dict[str, Bucket], per_api: dict[str, dict[str, int]],
+                 per_api_seconds: dict[str, float], unreached: list[str],
+                 partial: list[str], shard: str | None) -> dict:
+    totals = {k: buckets[k].count for k in _BUCKETS}
+    judged = sum(totals[k] for k in _BUCKETS if k != "node-skip")
+    return {
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "node_pinned": pinned,
+        "node_runtime": node_runtime,
+        "auto_optimize": args.auto_optimize,
+        "auto_optimize_per_api": sorted(auto_optimize_apis_in_run),
+        "shard": shard,
+        # False => the sweep was cut short (time budget, or a hard kill that
+        # left this file behind mid-write-cycle). The numbers below then cover
+        # only `per_api`'s keys, and `partial_apis` only part of their tests,
+        # so parity is a LOWER BOUND, not the sweep's verdict. #6305.
+        "complete": not unreached and not partial,
+        "unreached_apis": unreached,
+        "partial_apis": partial,
+        "apis": apis,
+        "totals": totals,
+        "judged": judged,
+        "parity_pct": round(100 * totals["pass"] / judged, 1) if judged else 0.0,
+        "per_api": per_api,
+        "per_api_seconds": {k: round(v, 1) for k, v in per_api_seconds.items()},
+        "samples": {
+            k: [s.__dict__ for s in buckets[k].samples] for k in _SAMPLE_BUCKETS
+        },
+    }
+
+
+def merge_reports(paths: list[Path], sample_cap: int) -> tuple[dict, list[Path]]:
+    """Reduce per-shard reports to one aggregate (#6305).
+
+    Shards partition the API list, so `per_api` is a plain dict union and the
+    totals just sum. Returns (report, missing_paths); a report is "complete"
+    only if every shard report exists AND every shard ran to the end of its
+    own API list.
+    """
+    totals = {k: 0 for k in _BUCKETS}
+    per_api: dict[str, dict[str, int]] = {}
+    per_api_seconds: dict[str, float] = {}
+    samples: dict[str, list] = {k: [] for k in _SAMPLE_BUCKETS}
+    apis: list[str] = []
+    unreached: list[str] = []
+    partial: list[str] = []
+    shards: list[dict] = []
+    missing: list[Path] = []
+    meta = {"node_pinned": "", "node_runtime": "", "auto_optimize": False,
+            "auto_optimize_per_api": []}
+
+    for path in sorted(paths):
+        if not path.is_file():
+            missing.append(path)
+            continue
+        try:
+            r = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            missing.append(path)
+            continue
+        for k in ("node_pinned", "node_runtime"):
+            meta[k] = meta[k] or r.get(k, "")
+        meta["auto_optimize"] = meta["auto_optimize"] or r.get("auto_optimize", False)
+        meta["auto_optimize_per_api"] = sorted(
+            set(meta["auto_optimize_per_api"]) | set(r.get("auto_optimize_per_api", [])))
+        for k in _BUCKETS:
+            totals[k] += r.get("totals", {}).get(k, 0)
+        per_api.update(r.get("per_api", {}))
+        per_api_seconds.update(r.get("per_api_seconds", {}))
+        for k in _SAMPLE_BUCKETS:
+            samples[k].extend(r.get("samples", {}).get(k, []))
+        apis.extend(a for a in r.get("apis", []) if a not in apis)
+        unreached.extend(r.get("unreached_apis", []))
+        partial.extend(r.get("partial_apis", []))
+        shards.append({
+            "shard": r.get("shard"),
+            "complete": r.get("complete", False),
+            "judged": r.get("judged", 0),
+        })
+
+    judged = sum(totals[k] for k in _BUCKETS if k != "node-skip")
+    report = {
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        **meta,
+        "shards": shards,
+        "missing_shard_reports": [p.name for p in missing],
+        "complete": (not missing and not unreached and not partial
+                     and bool(shards)),
+        "unreached_apis": unreached,
+        "partial_apis": partial,
+        "apis": apis,
+        "totals": totals,
+        "judged": judged,
+        "parity_pct": round(100 * totals["pass"] / judged, 1) if judged else 0.0,
+        "per_api": per_api,
+        "per_api_seconds": per_api_seconds,
+        "samples": {k: v[: sample_cap * 4] for k, v in samples.items()},
+    }
+    return report, missing
+
+
+def run_merge(args) -> int:
+    report, missing = merge_reports(list(args.merge), args.sample_cap)
+    args.report.parent.mkdir(parents=True, exist_ok=True)
+    args.report.write_text(json.dumps(report, indent=2) + "\n")
+
+    print("=" * 60)
+    print("  Node-core subset radar (#800) — merged shard reports")
+    print("=" * 60)
+    print(f"  shards:        {len(report['shards'])} "
+          f"({sum(1 for s in report['shards'] if s['complete'])} complete)")
+    for k in _BUCKETS:
+        print(f"  {k:<14} {report['totals'][k]}")
+    print(f"  {'judged':<14} {report['judged']}   (excludes node-skip)")
+    print(f"  parity:        {report['parity_pct']}%")
+    print(f"  report:        {args.report}")
+
+    # Loud, not silent: an incomplete radar must not read as "no signal", and
+    # must not quietly publish a partial number as if it were the whole sweep.
+    # The report is written either way, so #4975 still gets a figure. #6305.
+    if missing:
+        print(f"\n  ERROR: {len(missing)} shard report(s) missing: "
+              f"{', '.join(p.name for p in missing)}", file=sys.stderr)
+    if report["unreached_apis"]:
+        print(f"  ERROR: never reached: "
+              f"{', '.join(report['unreached_apis'])}", file=sys.stderr)
+    if report["partial_apis"]:
+        print(f"  ERROR: cut off mid-API: "
+              f"{', '.join(report['partial_apis'])}", file=sys.stderr)
+    if not report["complete"]:
+        print("  ERROR: radar did not fully run; the parity above is a LOWER "
+              "BOUND over the tests that did run.", file=sys.stderr)
+        return 1
+    return 0
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="Node core test subset radar (#800)")
     ap.add_argument("--root", type=Path, default=REPO_ROOT / "vendor" / "nodejs",
@@ -228,9 +471,26 @@ def main() -> int:
                          "link artifacts (#1778). Slower: the first compile per "
                          "import-set rebuilds the runtime (cached after).")
     ap.add_argument("--compile-timeout", type=int, default=0,
-                    help="per-compile timeout (s); 0 = use --timeout, or 600 "
-                         "under --auto-optimize to absorb the cold ext-crate "
-                         "rebuild without mis-bucketing it as compile-fail")
+                    help="per-compile timeout (s) for auto-optimize APIs; "
+                         "0 = use --timeout, or 600 under --auto-optimize to "
+                         "absorb the cold ext-crate rebuild without "
+                         "mis-bucketing it as compile-fail")
+    ap.add_argument("--plain-compile-timeout", type=int, default=120,
+                    help="per-compile timeout (s) for the NON-auto-optimize "
+                         "APIs, which link the prebuilt libperry_*.a and so "
+                         "never pay a cargo rebuild (#6305)")
+    ap.add_argument("--shard", type=parse_shard, default=None, metavar="I/N",
+                    help="run only shard I of N (1-based) of the API list; the "
+                         "split is cost-aware, see shard_apis(). Reduce the "
+                         "per-shard reports with --merge (#6305)")
+    ap.add_argument("--time-budget", type=int, default=0, metavar="SECS",
+                    help="stop the sweep after SECS and write a partial report "
+                         "flagged `complete: false` rather than being killed "
+                         "with nothing to show (0 = unbounded) (#6305)")
+    ap.add_argument("--merge", nargs="*", type=Path, default=None,
+                    metavar="REPORT",
+                    help="merge these per-shard reports into --report and exit; "
+                         "exits non-zero if any shard is missing or incomplete")
     ap.add_argument("--perry-bin", type=Path,
                     default=REPO_ROOT / "target" / "release" / "perry")
     ap.add_argument("--report", type=Path, default=NODE_CORE_DIR / "report.json")
@@ -239,9 +499,21 @@ def main() -> int:
     ap.add_argument("--quiet", action="store_true")
     args = ap.parse_args()
 
+    if args.merge is not None:
+        return run_merge(args)
+
     # Resolve early so the prewarm + timeout decisions cover both the
     # explicit `--auto-optimize` flag and the per-API auto-route (#2156).
     apis_pre = args.api or read_api_list(NODE_CORE_DIR / "supported-apis.txt")
+    shard_label = None
+    if args.shard is not None:
+        shard_index, shard_total = args.shard
+        shard_label = f"{shard_index + 1}/{shard_total}"
+        apis_pre = shard_apis(apis_pre, shard_index, shard_total)
+        if not args.quiet:
+            print(f"  shard {shard_label}: "
+                  f"{', '.join(apis_pre) if apis_pre else '(no APIs)'}",
+                  flush=True)
     auto_optimize_apis_in_run = [a for a in apis_pre if a in _AUTO_OPTIMIZE_APIS]
     auto_optimize_needed = args.auto_optimize or bool(auto_optimize_apis_in_run)
 
@@ -249,8 +521,16 @@ def main() -> int:
     # import-set can take minutes; without a longer compile budget it would
     # time out and land in compile-fail — the exact mis-bucketing #1778 is
     # about. Per-test execution still uses the tighter --timeout.
-    compile_timeout = args.compile_timeout or (
+    #
+    # #6305: this budget is PER-API, not global. It used to be one variable, so
+    # the presence of a single auto-optimize API in the run raised the compile
+    # ceiling to 600s for *every* API — including the ~314 tests that link the
+    # prebuilt .a and compile in seconds. One pathological compile among those
+    # could then burn 10 minutes of a budget that was already over-subscribed.
+    ao_compile_timeout = args.compile_timeout or (
         max(args.timeout, 600) if auto_optimize_needed else args.timeout)
+    plain_compile_timeout = args.compile_timeout or max(
+        args.timeout, args.plain_compile_timeout)
 
     root = args.root.resolve()
     if not (root / "test" / "parallel").is_dir():
@@ -273,11 +553,15 @@ def main() -> int:
         if args.auto_optimize:
             print(f"  auto-optimize: ON (#1778) — linking per-program perry-ext-* "
                   f"crates for every API; first compile per import-set rebuilds "
-                  f"the runtime (compile-timeout={compile_timeout}s).")
+                  f"the runtime (compile-timeout={ao_compile_timeout}s).",
+                  flush=True)
         elif auto_optimize_apis_in_run:
             print(f"  auto-optimize: ON per-API (#2156) for "
                   f"{', '.join(auto_optimize_apis_in_run)}; "
-                  f"compile-timeout={compile_timeout}s for those APIs.")
+                  f"compile-timeout={ao_compile_timeout}s for those APIs.",
+                  flush=True)
+        if args.time_budget:
+            print(f"  time budget: {args.time_budget}s (#6305)", flush=True)
 
     base_env = dict(os.environ)
     base_env.update(FORCE_COLOR="0", NO_COLOR="1", NODE_DISABLE_COLORS="1")
@@ -285,9 +569,51 @@ def main() -> int:
     if fixtures.is_dir():
         base_env["PERRY_NODE_CORE_FIXTURES"] = str(fixtures)
 
-    buckets = {k: Bucket() for k in
-               ("pass", "diff", "runtime-fail", "compile-fail", "node-skip")}
+    buckets = {k: Bucket() for k in _BUCKETS}
     per_api: dict[str, dict[str, int]] = {}
+    per_api_seconds: dict[str, float] = {}
+    # "Not finished yet", drained as each API completes — NOT "known to be
+    # skipped". Seeding it with the whole list is what makes every snapshot of
+    # the report honest by construction: a report written before the sweep (or
+    # left behind by a kill mid-sweep) still lists everything outstanding, and
+    # so can never claim `complete: true` over work that never ran. #6305.
+    unreached: list[str] = list(apis)
+    partial: list[str] = []
+    node_runtime = run(["node", "--version"], base_env, 10)[1].strip()
+
+    # The sweep can be cut short — by --time-budget, or by the job being killed
+    # outright, which is what #6305 was: the report only existed after the last
+    # API, so every interrupted run uploaded nothing. Write it after every API
+    # so whatever we got is always on disk and mergeable.
+    def emit_report() -> None:
+        args.report.parent.mkdir(parents=True, exist_ok=True)
+        args.report.write_text(json.dumps(build_report(
+            pinned=pinned, node_runtime=node_runtime, args=args, apis=apis,
+            auto_optimize_apis_in_run=auto_optimize_apis_in_run,
+            buckets=buckets, per_api=per_api, per_api_seconds=per_api_seconds,
+            unreached=unreached, partial=partial, shard=shard_label),
+            indent=2) + "\n")
+
+    # The budget covers the prewarm too — it is a cold cargo build that can run
+    # for minutes, and a budget that only started counting afterwards would not
+    # bound the job's wall clock, which is the whole point (#6305).
+    deadline = time.monotonic() + args.time_budget if args.time_budget else None
+    emit_report()  # a zero-work report beats no report if we die in the prewarm
+
+    def _on_sigterm(_signum, _frame):
+        """Land the report before we die.
+
+        A CI job timeout / cancellation SIGTERMs the step process, and the
+        default disposition would take us out without writing a thing. Whatever
+        is still in `unreached` is exactly what we never finished, so the report
+        this leaves behind is already correctly flagged incomplete.
+        """
+        try:
+            emit_report()
+        finally:
+            os._exit(143)
+
+    signal.signal(signal.SIGTERM, _on_sigterm)
 
     stage = Path(tempfile.mkdtemp(prefix="node-core-"))
     try:
@@ -333,7 +659,8 @@ def main() -> int:
             )
             if not args.quiet:
                 print("  pre-warming ext-crate libs (one cold build; "
-                      "makes per-feature relinks incremental, #1842)...")
+                      "makes per-feature relinks incremental, #1842)...",
+                      flush=True)
             w_env = dict(base_env, PERRY_ALLOW_UNIMPLEMENTED="1")
             # cwd MUST be the perry workspace: auto-optimize locates the
             # Cargo workspace from cwd to (re)build the perry-ext-* crates. From
@@ -343,19 +670,43 @@ def main() -> int:
                          "-o", str(bin_dir / "_prewarm.out")],
                         w_env, max(args.timeout, 1800), cwd=str(REPO_ROOT))
             if not args.quiet:
-                print(f"  pre-warm {'done' if wc == 0 else f'exit {wc} (continuing)'}")
+                print(f"  pre-warm {'done' if wc == 0 else f'exit {wc} (continuing)'}",
+                      flush=True)
             try:
                 warm.unlink()
             except OSError:
                 pass
 
+        budget_hit = False
         for api in apis:
+            # `unreached` already holds exactly the APIs we have not finished,
+            # so there is nothing to recompute here — just stop.
+            if deadline is not None and time.monotonic() >= deadline:
+                print(f"  time budget exhausted — {len(unreached)} API(s) not "
+                      f"reached: {', '.join(unreached)}", flush=True)
+                break
+
             tests = resolve_tests(root, api)
             if args.max_per_api > 0:
                 tests = tests[: args.max_per_api]
             counts = {k: 0 for k in buckets}
+            api_started = time.monotonic()
+            if not args.quiet:
+                print(f"  {api} ({len(tests)} tests)...", flush=True)
 
             for tf in tests:
+                # Check the budget per TEST, not just per API: one API is up to
+                # `--max-per-api` compiles, and an auto-optimize compile may
+                # take minutes, so an API-granular check would let a single API
+                # overshoot the budget by hours. #6305.
+                if deadline is not None and time.monotonic() >= deadline:
+                    partial.append(api)
+                    budget_hit = True
+                    print(f"  time budget exhausted mid-{api} — "
+                          f"{len(unreached) - 1} further API(s) not reached",
+                          flush=True)
+                    break
+
                 test_name = tf.name
                 staged = parallel_stage / test_name
                 shutil.copy(tf, staged)
@@ -399,7 +750,9 @@ def main() -> int:
                 c_exit, c_out = run(
                     [str(args.perry_bin), "compile", str(staged),
                      "-o", str(out_bin)],
-                    c_env, compile_timeout, cwd=compile_cwd)
+                    c_env,
+                    ao_compile_timeout if effective_ao else plain_compile_timeout,
+                    cwd=compile_cwd)
                 if c_exit != 0:
                     buckets["compile-fail"].add(
                         api, test_name, error_line(c_out), args.sample_cap)
@@ -429,6 +782,14 @@ def main() -> int:
                 staged.unlink()
 
             per_api[api] = counts
+            per_api_seconds[api] = time.monotonic() - api_started
+            if api in unreached:  # `in` guard: --api may repeat a name
+                unreached.remove(api)  # done with it — partially or fully
+            # Rewrite the report now, not at the end of the sweep: if the job
+            # is killed (#6305 — the hosted runner was reclaimed every night)
+            # this is the only thing that survives, and it is what the artifact
+            # upload picks up.
+            emit_report()
             if not args.quiet:
                 judged = sum(counts[k] for k in
                              ("pass", "diff", "runtime-fail", "compile-fail"))
@@ -436,42 +797,44 @@ def main() -> int:
                 print(f"  {api:<16} pass={counts['pass']:<4} diff={counts['diff']:<4} "
                       f"rt-fail={counts['runtime-fail']:<4} "
                       f"compile-fail={counts['compile-fail']:<4} "
-                      f"node-skip={counts['node-skip']:<4} parity={rate}")
+                      f"node-skip={counts['node-skip']:<4} parity={rate} "
+                      f"({per_api_seconds[api]:.0f}s)", flush=True)
+            if budget_hit:
+                break
     finally:
         shutil.rmtree(stage, ignore_errors=True)
 
-    totals = {k: buckets[k].count for k in buckets}
-    judged = sum(totals[k] for k in
-                 ("pass", "diff", "runtime-fail", "compile-fail"))
-    parity_pct = round(100 * totals["pass"] / judged, 1) if judged else 0.0
-
-    report = {
-        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        "node_pinned": pinned,
-        "node_runtime": run(["node", "--version"], base_env, 10)[1].strip(),
-        "auto_optimize": args.auto_optimize,
-        "auto_optimize_per_api": sorted(auto_optimize_apis_in_run),
-        "apis": apis,
-        "totals": totals,
-        "judged": judged,
-        "parity_pct": parity_pct,
-        "per_api": per_api,
-        "samples": {
-            k: [s.__dict__ for s in buckets[k].samples]
-            for k in ("diff", "runtime-fail", "compile-fail", "node-skip")
-        },
-    }
-    args.report.write_text(json.dumps(report, indent=2) + "\n")
+    emit_report()
+    report = json.loads(args.report.read_text())
 
     print()
     print("=" * 60)
-    print(f"  Node-core subset radar (#800) — Node {pinned}")
+    print(f"  Node-core subset radar (#800) — Node {pinned}"
+          + (f" — shard {shard_label}" if shard_label else ""))
     print("=" * 60)
-    for k in ("pass", "diff", "runtime-fail", "compile-fail", "node-skip"):
-        print(f"  {k:<14} {totals[k]}")
-    print(f"  {'judged':<14} {judged}   (excludes node-skip)")
-    print(f"  parity:        {parity_pct}%")
+    for k in _BUCKETS:
+        print(f"  {k:<14} {report['totals'][k]}")
+    print(f"  {'judged':<14} {report['judged']}   (excludes node-skip)")
+    print(f"  parity:        {report['parity_pct']}%")
     print(f"  report:        {args.report}")
+
+    # An incomplete sweep exits non-zero. The radar is advisory about *parity*
+    # — compile-fail and runtime-fail never fail the job, that is the gap signal
+    # it exists to publish — but it is NOT advisory about whether it actually
+    # ran. A truncated sweep that exits 0 is how #6305 hid for 38 straight
+    # nightlies. The report is written either way, so the number still lands.
+    if not report["complete"]:
+        print()
+        if partial:
+            print(f"  ERROR: cut off mid-API: {', '.join(partial)}",
+                  file=sys.stderr)
+        if unreached:
+            print(f"  ERROR: never reached: {', '.join(unreached)}",
+                  file=sys.stderr)
+        print("  ERROR: sweep incomplete — parity above is a LOWER BOUND. "
+              "Raise --time-budget / the job timeout, or add shards.",
+              file=sys.stderr)
+        return 1
     return 0
 
 


### PR DESCRIPTION
Fixes #6305.

## What was actually blowing the budget

The issue reports six failed nights. It is worse than that: **the radar has never once completed.** All 38 scheduled runs in retained history — back to 2026-06-05 — failed, every one with exit 143 and no artifact.

The job log is useless: it shows the step's `Run` block, then, 75 minutes later, `##[error]Process completed with exit code 143` and **not one line of script output**. The real message is in the runner's own `system.txt`, which the web log view does not surface:

```
##[error]The runner has received a shutdown signal. This can happen when the
runner service is stopped, or a manually started runner is canceled.
##[error]Process completed with exit code 143.
```

So the hosted VM was being **reclaimed under the job** — not stopped by `timeout-minutes: 180`, which never fired (the runs died at 44–75 min, well inside it). That also explains the missing artifact: when the runner goes down this way, *no* further step runs. On the last run, `Write radar summary`, `Upload radar report` **and every post step** are all reported as `skipped`. The existing `if: always()` on the upload was never going to help — and the report was only written after the final API anyway, so there was nothing on disk to upload regardless.

Three things kept the sweep unbounded:

1. **No wall-clock bound at all.** One serial job swept 23 APIs × ≤25 tests. ~125 of those are auto-optimize compiles that each pay a cargo relink of the Perry runtime (`http`/`https`/`net`/`zlib`/`events`). Nothing in the script or the workflow bounded that; it ran until something killed it.
2. **Leaked grandchildren.** `subprocess.run(timeout=...)` kills only the *direct* child. Node's core tests fork servers, workers and `child_process` helpers, so every timed-out test leaked a live process tree that kept holding CPU, memory and listening sockets **for the rest of the sweep**. The runner logs `Cleaning up orphan processes` at kill time. This is the accumulation that plausibly got the VM reclaimed, and it got worse the longer the sweep ran.
3. **Nothing on disk until the end.** The report was written once, after the last API — so any interruption produced zero output.

## What changed

**`scripts/node_core_subset.py`**

- `--shard I/N` — splits the API list. The split is **cost-aware**: the auto-optimize APIs are round-robined *first*, so no shard draws two of them. A naive contiguous split would have put 4 of the 5 heavy APIs in one shard (they are adjacent in `supported-apis.txt`), leaving that shard as slow as the unsharded job. `--merge` reduces the per-shard reports back to one aggregate.
- `--time-budget SECS` — stops the sweep at a deadline and writes what it has. Checked **per test**, not per API: an API is up to 25 compiles and an auto-optimize compile can take minutes, so an API-granular check could overshoot by hours. The budget covers the cold ext-crate prewarm too.
- `run()` now starts each child in its **own process group** and SIGKILLs the whole group on timeout, so a hung test cannot leak a process tree into the rest of the sweep.
- The report is rewritten **after every API**, and a SIGTERM handler flushes it before dying — so a truncated sweep still leaves a mergeable report behind.
- Separate compile timeouts for auto-optimize vs. plain APIs. Previously a single auto-optimize API in the run raised the compile ceiling to 600s for *every* API, including the ~314 tests that link the prebuilt `.a` and compile in seconds.

**`.github/workflows/node-core-subset.yml`**

- 6 matrix shards, `fail-fast: false`, `timeout-minutes: 75` each, `--time-budget 2400`.
- A `report` job (`needs: radar`, `if: always()`) merges the shard reports and uploads the aggregate under the **same `node-core-subset-report` artifact name** consumers already use.
- `PYTHONUNBUFFERED=1` — Python was block-buffering stdout into the Actions pipe, which is why a killed step showed *zero* output and this went undiagnosed for six weeks.
- A `Runner headroom` step (`df -h` / `free -h`) so that if the VM is reclaimed again we have the evidence we didn't have this time.
- Triggers unchanged: **`schedule` + `workflow_dispatch` only, never `pull_request`.**

## Failure is now loud

Today a timeout reads as "no signal". Now:

- An incomplete sweep **exits non-zero**. The radar stays advisory about *parity* — `compile-fail`/`runtime-fail` never fail the job, that's the gap signal it exists to publish — but it is **not** advisory about whether it actually ran. A truncated sweep exiting 0 is how this hid for 38 nightlies.
- The merge job fails if any shard report is **missing** (a shard whose runner died uploads nothing, and that must not read as "a smaller sweep") or **incomplete**.
- The report is written either way and carries `complete: false`, `unreached_apis` and `partial_apis`, and the step summary gets a warning banner. **#4975 gets a number even from a partial sweep** — clearly marked as a lower bound.

## Expected runtime

Per shard: ~10 min release build + prewarm + one heavy API + ~3 cheap ones, hard-capped at a 40-minute sweep budget inside a 75-minute job. The 6 shards run in parallel, so wall clock should land in the **35–60 min** range instead of running unbounded into a VM reclaim. If a shard still cannot finish inside its budget it now says so loudly and still publishes its numbers, instead of vanishing.

## Validation

No Rust changes, so no build needed.

- `python3 -c "import yaml; yaml.safe_load(...)"` on the workflow, plus asserts that the matrix length matches `NODE_CORE_SHARDS`, that `fail-fast` is off, and that there is no `pull_request`/`push` trigger.
- `python3 -m py_compile scripts/node_core_subset.py`; `--help` exercised.
- Drove `main()` end-to-end against a fake Node corpus and a fake `perry` binary — one test per bucket (pass / diff / node-skip / compile-fail / a hanging test that forks a grandchild):
  - **sharded + merged reproduces the unsharded run exactly** — same `totals`, `judged`, `parity_pct` and `per_api` map;
  - shards partition the API list with no loss or duplication, and no shard draws two auto-optimize APIs;
  - the time-budget path exits 1, prints why, and still writes a report with `complete: false`;
  - `--merge` exits 1 on a missing/incomplete shard while still writing the aggregate, and 0 when every shard is complete;
  - **the grandchild of the hung test is reaped** with the process group — under the old `subprocess.run` path it survives.

I also dispatched this workflow on the branch to confirm it completes end-to-end; result noted in a comment below.

Note: `lint` and `conformance-smoke` are already red on clean `main` (addr-class ratchet on `map.rs`, fixed by #6297) — unrelated to this change, which touches no Rust.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Node compatibility “radar” sweeps now run as a sharded, nightly time-bounded job with separate per-shard reports and a merge step to produce a single aggregated report.

* **Improvements**
  * Reports are written incrementally during the sweep, improving resumability after cancellations.
  * The sweep now enforces cost-aware per-API compile time budgets and caps sampled tests per API.
  * Compatibility summaries provide clearer warnings when the sweep is incomplete, including what’s missing and where cut-off occurred.

* **Bug Fixes**
  * Timeout handling now reliably terminates entire test process groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->