### PR TITLE
fix(codegen): perry/system table must not hijack same-named imported functions (#6087)

### DIFF
--- a/crates/perry-codegen/src/lower_call/builtin_table_gate.rs
+++ b/crates/perry-codegen/src/lower_call/builtin_table_gate.rs
@@ -1,0 +1,40 @@
+//! Import-source gate for the `perry/system` | `perry/updater` | `perry/background`
+//! dispatch tables (issue #6087).
+
+use crate::expr::FnCtx;
+
+/// Issue #6087 — may the `perry/system` | `perry/updater` | `perry/background`
+/// dispatch table claim a call to `name`?
+///
+/// Those three tables are keyed by bare TypeScript name (`takeScreenshot`,
+/// `openURL`, `getLocale`, `preferencesGet`, `hapticPlay`, `schedule`, …) and
+/// used to be consulted on the name alone. But a function the user *imported
+/// from their own module* lowers to exactly the same `Expr::ExternFuncRef {
+/// name }` as a `perry/system` import does, so any user function whose name
+/// collided with one of those ~60 rows was hijacked into the native table:
+///
+/// * arity differs from the native row → `lower_perry_ui_table_call` dropped
+///   the call on the floor (silent miscompile — the reported symptom);
+/// * arity happens to match → the program links against an undefined
+///   `perry_system_*` symbol even though it imports nothing native.
+///
+/// `imported_class_sources` maps every named/default import binding in *this*
+/// module to the specifier it was imported from, which answers the question
+/// exactly: a binding that came from anywhere other than `module` can never be
+/// the native builtin, so the table must not claim it. The cross-module inliner
+/// keeps this sound — when it moves a body containing an `ExternFuncRef` into
+/// another module it also adds the matching `Import` to the destination's
+/// `hir.imports` (see `inline::cross_module`), which is the same table this map
+/// is built from.
+///
+/// A name with *no* import binding in this module (ambient `declare`s,
+/// synthesized extern refs) has no import source to contradict the table, so it
+/// keeps the historical name-only behaviour. Note this also means a `perry/*`
+/// import that never reaches `hir.imports` still dispatches as before — the
+/// gate can only ever *reject* a name that demonstrably came from elsewhere.
+pub(super) fn callee_is_from_perry_module(ctx: &FnCtx<'_>, name: &str, module: &str) -> bool {
+    match ctx.imported_class_sources.get(name) {
+        Some(source) => source == module,
+        None => true,
+    }
+}

--- a/crates/perry-codegen/src/lower_call/extern_func.rs
+++ b/crates/perry-codegen/src/lower_call/extern_func.rs
@@ -4,6 +4,7 @@
 //! `lower_perry_ui_table_call` machinery, V8-fallback bridge calls,
 //! and the generic `perry_fn_<src>__<name>` consumer-prefix path.
 
+use super::builtin_table_gate::callee_is_from_perry_module;
 use anyhow::{anyhow, Result};
 use perry_api_manifest::{
     NativeAbiType, NativeHandleAbi, NativeHandleOwnership, NativeHandleThreadAffinity, NativePodAbi,
@@ -1427,21 +1428,30 @@ pub fn try_lower_extern_func_call(
     // keychainSave, etc.) to their perry_system_* / perry_* C symbols.
     // These arrive as ExternFuncRef because perry/system imports aren't
     // lowered to NativeMethodCall in the HIR.
-    if let Some(sig) = perry_system_table_lookup(name) {
-        return Ok(Some(lower_perry_ui_table_call(ctx, sig, args)?));
+    //
+    // Issue #6087: gated on the *import source*, not the bare name — see
+    // `callee_is_from_perry_module`.
+    if callee_is_from_perry_module(ctx, name, "perry/system") {
+        if let Some(sig) = perry_system_table_lookup(name) {
+            return Ok(Some(lower_perry_ui_table_call(ctx, sig, args)?));
+        }
     }
     // perry/updater dispatch: same shape as perry/system. Imports from
     // `perry/updater` arrive as ExternFuncRef; route by name to the
     // perry_updater_* runtime symbols in `perry-updater`.
-    if let Some(sig) = perry_updater_table_lookup(name) {
-        return Ok(Some(lower_perry_ui_table_call(ctx, sig, args)?));
+    if callee_is_from_perry_module(ctx, name, "perry/updater") {
+        if let Some(sig) = perry_updater_table_lookup(name) {
+            return Ok(Some(lower_perry_ui_table_call(ctx, sig, args)?));
+        }
     }
     // perry/background dispatch (issue #538): registerTask / schedule /
     // cancel from `perry/background`. Backed by perry_background_* in
     // libperry_ui_*.a (real impls on iOS + Android, no-op stubs
     // elsewhere). Same calling convention as perry/system.
-    if let Some(sig) = perry_background_table_lookup(name) {
-        return Ok(Some(lower_perry_ui_table_call(ctx, sig, args)?));
+    if callee_is_from_perry_module(ctx, name, "perry/background") {
+        if let Some(sig) = perry_background_table_lookup(name) {
+            return Ok(Some(lower_perry_ui_table_call(ctx, sig, args)?));
+        }
     }
     // Built-in runtime extern functions (`js_weakmap_set`,
     // `js_regexp_exec`, etc.) that start with `js_` are resolved

--- a/crates/perry-codegen/src/lower_call/mod.rs
+++ b/crates/perry-codegen/src/lower_call/mod.rs
@@ -34,6 +34,7 @@ use crate::expr::{variant_name, FnCtx};
 mod atomics;
 mod buffer_intrinsic;
 mod builtin;
+mod builtin_table_gate;
 mod capture_writeback;
 mod closure_analysis;
 mod console_promise;

--- a/crates/perry-codegen/src/lower_call/ui_tables.rs
+++ b/crates/perry-codegen/src/lower_call/ui_tables.rs
@@ -342,11 +342,25 @@ pub fn perry_plugin_instance_method_lookup(method: &str) -> Option<&'static UiSi
 /// lazy-declares the runtime function, emits the call, and boxes the
 /// return value per `sig.ret`.
 ///
-/// Args length mismatch (caller passed wrong number of args) → falls
-/// back to lowering all args for side effects + returning the
-/// zero-sentinel. The catch-all is intentional: TS users may write
-/// `Text()` (no arg) or `Text(s, extra)` and we don't want to bail
-/// the entire compilation.
+/// Arity handling (issue #6087). A row's `args` is the *runtime ABI*, which
+/// is wider than the TypeScript surface whenever the `.d.ts` marks a trailing
+/// param optional (`shareText(text, title?)`, `Image(url, alt?)`,
+/// `stop(handle, fadeOutMs?)`). Three shapes are accepted:
+///
+/// * exactly `sig.args.len()` args — the common case;
+/// * one *extra* trailing arg on a `Widget`-returning constructor — absorbed
+///   as an inline style object (issue #185, see `apply_inline_style`);
+/// * *fewer* args, where every omitted trailing param is a `Str`/`F64` — the
+///   TS-optional case. Those are padded with the empty value (`""` / `0`) and
+///   the call is emitted for real.
+///
+/// Anything else is a hard compile error. This branch used to lower the args
+/// for their side effects and return the `0.0` sentinel — i.e. **silently drop
+/// the call**. That silence is what turned the `perry/system` name-collision
+/// bug (#6087) into a silent miscompile instead of a diagnostic, and it also
+/// meant a legitimate-but-under-supplied `Image(url)` compiled to no widget at
+/// all. A dropped call must never be the answer to an arity we don't
+/// understand.
 pub fn lower_perry_ui_table_call(
     ctx: &mut FnCtx<'_>,
     sig: &UiSig,
@@ -422,6 +436,33 @@ pub fn lower_perry_ui_table_call(
         args
     };
 
+    // Issue #6087: pad TS-optional trailing params so the call is actually
+    // emitted. The dispatch row always spells the full runtime ABI, but the
+    // `.d.ts` lets the caller omit a trailing `title?` / `alt?` / `fadeMs?`.
+    // Pre-fix those calls hit the arity mismatch below and were dropped
+    // wholesale — `shareText("hi")` and `Image(url)` compiled to nothing.
+    // Only value-shaped kinds have a meaningful empty value; a missing
+    // `Widget` handle or `Closure` can't be synthesized, so those fall
+    // through to the hard error.
+    let padded_args: Vec<Expr>;
+    let args: &[Expr] = if args.len() < sig.args.len()
+        && sig.args[args.len()..]
+            .iter()
+            .all(|k| matches!(k, UiArgKind::Str | UiArgKind::F64))
+    {
+        let mut padded: Vec<Expr> = args.to_vec();
+        for kind in &sig.args[args.len()..] {
+            padded.push(match kind {
+                UiArgKind::Str => Expr::String(String::new()),
+                _ => Expr::Integer(0),
+            });
+        }
+        padded_args = padded;
+        &padded_args[..]
+    } else {
+        args
+    };
+
     let inline_style_arg: Option<&Expr> =
         if args.len() == sig.args.len() + 1 && matches!(sig.ret, UiReturnKind::Widget) {
             Some(&args[sig.args.len()])
@@ -431,12 +472,20 @@ pub fn lower_perry_ui_table_call(
     let declared_arg_count = sig.args.len();
 
     if args.len() != declared_arg_count && inline_style_arg.is_none() {
-        // Mismatched arity (and not a trailing-style absorption case)
-        // — fall back to side-effect lowering only.
-        for a in args {
-            let _ = lower_expr(ctx, a)?;
-        }
-        return Ok(double_literal(0.0));
+        // Issue #6087: a `perry/*` builtin called with an arity the runtime
+        // ABI cannot accept. Everything legitimate has been absorbed above
+        // (arg adapters, inline style, optional trailing params), so this is
+        // a genuine mismatch — fail the compile instead of quietly emitting
+        // no call at all, which is what let #6087 hide for so long.
+        anyhow::bail!(
+            "perry/* builtin `{}` takes {} argument(s), but it was called with {}.\n  \
+             note: it lowers to the native runtime symbol `{}`, whose ABI is fixed — \
+             the call cannot be emitted with this arity.",
+            sig.method,
+            declared_arg_count,
+            args.len(),
+            sig.runtime,
+        );
     }
 
     // Lower each arg according to its declared kind. Build two parallel

--- a/crates/perry-codegen/tests/perry_builtin_name_collision.rs
+++ b/crates/perry-codegen/tests/perry_builtin_name_collision.rs
@@ -1,0 +1,281 @@
+//! Issue #6087 — the name-keyed `perry/system` | `perry/updater` |
+//! `perry/background` dispatch tables must not hijack a call to a user
+//! function that merely *shares a name* with one of their rows.
+//!
+//! A function imported from a plain TypeScript module lowers to
+//! `Expr::ExternFuncRef { name }` — the very same shape a `perry/system`
+//! import produces. `lower_call/extern_func.rs` used to consult the three
+//! tables on the bare name, so `import { takeScreenshot } from "./lib.ts"`
+//! was routed into `perry_system_take_screenshot`. Because the user's arity
+//! (1) doesn't match that row's (0), `lower_perry_ui_table_call` then lowered
+//! the args for side effects and returned the 0.0 sentinel — the call
+//! **vanished**, silently, with no error and no warning.
+//!
+//! The lookups are now gated on the callee's import source. These tests pin
+//! both directions: a `./lib.ts` import must reach the cross-module symbol,
+//! and a genuine `perry/system` import must still reach the native one.
+
+use perry_codegen::{compile_module, AppMetadata, CompileOptions};
+use perry_hir::{Expr, Import, ImportSpecifier, Module, ModuleInitKind, ModuleKind, Stmt};
+use perry_types::Type;
+
+fn base_opts() -> CompileOptions {
+    CompileOptions {
+        target: None,
+        is_entry_module: false,
+        non_entry_module_prefixes: Vec::new(),
+        nextjs_path_init_modules: Vec::new(),
+        import_function_prefixes: std::collections::HashMap::new(),
+        import_function_ffi_aliases: std::collections::HashMap::new(),
+        import_function_origin_names: std::collections::HashMap::new(),
+        import_function_v8_specifiers: std::collections::HashMap::new(),
+        import_function_node_submodule: std::collections::HashMap::new(),
+        namespace_node_submodules: std::collections::HashMap::new(),
+        namespace_v8_specifiers: std::collections::HashMap::new(),
+        namespace_member_prefixes: std::collections::HashMap::new(),
+        namespace_member_origin_names: std::collections::HashMap::new(),
+        emit_ir_only: true,
+        verify_native_regions: false,
+        disable_buffer_fast_path: false,
+        namespace_imports: Vec::new(),
+        namespace_reexport_named_imports: std::collections::HashSet::new(),
+        imported_classes: Vec::new(),
+        imported_enums: Vec::new(),
+        imported_async_funcs: std::collections::HashSet::new(),
+        type_aliases: std::collections::HashMap::new(),
+        imported_func_param_counts: std::collections::HashMap::new(),
+        imported_func_has_rest: std::collections::HashSet::new(),
+        imported_func_synthetic_arguments: std::collections::HashSet::new(),
+        imported_func_return_types: std::collections::HashMap::new(),
+        imported_vars: std::collections::HashSet::new(),
+        output_type: "executable".to_string(),
+        needs_stdlib: false,
+        needs_ui: false,
+        needs_geisterhand: false,
+        geisterhand_port: 7676,
+        enabled_features: Vec::new(),
+        native_module_init_names: Vec::new(),
+        js_module_specifiers: Vec::new(),
+        bundled_extensions: Vec::new(),
+        native_library_functions: Vec::new(),
+        i18n_table: None,
+        fast_math: false,
+        fp_contract_mode: perry_codegen::FpContractMode::Off,
+        app_metadata: AppMetadata::default(),
+        namespace_entries: Vec::new(),
+        dynamic_import_path_to_prefix: std::collections::HashMap::new(),
+        deferred_module_prefixes: std::collections::HashSet::new(),
+        module_init_deps: Vec::new(),
+        is_dynamic_import_target: false,
+        debug_locations: false,
+        module_source: None,
+        debug_source_line_offset: 0,
+    }
+}
+
+fn import_from(source: &str, name: &str, kind: ModuleKind) -> Import {
+    Import {
+        source: source.to_string(),
+        specifiers: vec![ImportSpecifier::Named {
+            imported: name.to_string(),
+            local: name.to_string(),
+        }],
+        is_native: !source.starts_with("./"),
+        module_kind: kind,
+        resolved_path: Some(source.to_string()),
+        type_only: false,
+        is_dynamic: false,
+        is_dynamic_target: false,
+        is_deferred_require: false,
+        is_adopted_require: false,
+    }
+}
+
+fn call_extern(name: &str, args: Vec<Expr>) -> Stmt {
+    Stmt::Expr(Expr::Call {
+        callee: Box::new(Expr::ExternFuncRef {
+            name: name.to_string(),
+            param_types: Vec::new(),
+            return_type: Type::Any,
+        }),
+        args,
+        type_args: Vec::new(),
+        byte_offset: 0,
+    })
+}
+
+fn module_with(imports: Vec<Import>, init: Vec<Stmt>) -> Module {
+    Module {
+        name: "app.ts".to_string(),
+        imports,
+        exports: Vec::new(),
+        classes: Vec::new(),
+        interfaces: Vec::new(),
+        type_aliases: Vec::new(),
+        enums: Vec::new(),
+        globals: Vec::new(),
+        functions: Vec::new(),
+        script_global_functions: Vec::new(),
+        references_global_this: false,
+        annexb_global_undefined_names: Vec::new(),
+        init,
+        exported_native_instances: Vec::new(),
+        exported_func_return_native_instances: Vec::new(),
+        exported_objects: Vec::new(),
+        exported_functions: Vec::new(),
+        widgets: Vec::new(),
+        uses_fetch: false,
+        uses_webassembly: false,
+        extern_funcs: Vec::new(),
+        init_was_unrolled: false,
+        has_top_level_await: false,
+        init_kind: ModuleInitKind::Eager,
+        async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
+        class_display_names: std::collections::HashMap::new(),
+        closure_source_text: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
+    }
+}
+
+/// `import { takeScreenshot } from "./lib.ts"; takeScreenshot("a.png")` must
+/// call the user's function, NOT `perry_system_take_screenshot`. Pre-fix the
+/// arity mismatch (1 arg vs the table row's 0) made the call disappear
+/// entirely — the emitted IR contained neither symbol.
+#[test]
+fn user_import_named_like_perry_system_row_is_not_hijacked() {
+    let mut opts = base_opts();
+    opts.import_function_prefixes
+        .insert("takeScreenshot".to_string(), "lib_ts".to_string());
+
+    let module = module_with(
+        vec![import_from(
+            "./lib.ts",
+            "takeScreenshot",
+            ModuleKind::NativeCompiled,
+        )],
+        vec![call_extern(
+            "takeScreenshot",
+            vec![Expr::String("a.png".to_string())],
+        )],
+    );
+
+    let ir = String::from_utf8(compile_module(&module, opts).expect("must compile")).unwrap();
+    assert!(
+        ir.contains("perry_fn_lib_ts__takeScreenshot"),
+        "imported user function must lower to its cross-module symbol; IR:\n{ir}"
+    );
+    assert!(
+        !ir.contains("perry_system_take_screenshot"),
+        "a `./lib.ts` import must never be hijacked by PERRY_SYSTEM_TABLE; IR:\n{ir}"
+    );
+}
+
+/// Same shape for the `perry/background` table: `cancel` is one of its rows,
+/// and it is a wildly plausible user function name. Here the arity even
+/// *matches* the native row, which pre-fix produced a link error against an
+/// undefined `perry_background_cancel` in a program importing nothing native.
+#[test]
+fn user_import_named_like_perry_background_row_is_not_hijacked() {
+    let mut opts = base_opts();
+    opts.import_function_prefixes
+        .insert("cancel".to_string(), "jobs_ts".to_string());
+
+    let module = module_with(
+        vec![import_from(
+            "./jobs.ts",
+            "cancel",
+            ModuleKind::NativeCompiled,
+        )],
+        vec![call_extern(
+            "cancel",
+            vec![Expr::String("job-1".to_string())],
+        )],
+    );
+
+    let ir = String::from_utf8(compile_module(&module, opts).expect("must compile")).unwrap();
+    assert!(
+        ir.contains("perry_fn_jobs_ts__cancel"),
+        "imported user function must lower to its cross-module symbol; IR:\n{ir}"
+    );
+    assert!(
+        !ir.contains("perry_background_cancel"),
+        "a `./jobs.ts` import must never be hijacked by PERRY_BACKGROUND_TABLE; IR:\n{ir}"
+    );
+}
+
+/// The legitimate path is untouched: a real `perry/system` import still
+/// dispatches to the native runtime symbol.
+#[test]
+fn perry_system_import_still_dispatches_to_native_symbol() {
+    let module = module_with(
+        vec![import_from(
+            "perry/system",
+            "takeScreenshot",
+            ModuleKind::NativeRust,
+        )],
+        vec![call_extern("takeScreenshot", vec![])],
+    );
+
+    let ir =
+        String::from_utf8(compile_module(&module, base_opts()).expect("must compile")).unwrap();
+    assert!(
+        ir.contains("perry_system_take_screenshot"),
+        "genuine perry/system import must still reach the native symbol; IR:\n{ir}"
+    );
+}
+
+/// A `perry/system` builtin whose declared runtime ABI can't accept the given
+/// arity is now a hard compile error instead of a call that silently vanishes.
+/// (`isDarkMode` takes 0 args; the surplus arg is not an inline-style object —
+/// its return kind is F64, not Widget.)
+#[test]
+fn perry_system_builtin_arity_mismatch_is_a_compile_error() {
+    let module = module_with(
+        vec![import_from(
+            "perry/system",
+            "isDarkMode",
+            ModuleKind::NativeRust,
+        )],
+        vec![call_extern(
+            "isDarkMode",
+            vec![Expr::String("surplus".to_string())],
+        )],
+    );
+
+    let err = compile_module(&module, base_opts())
+        .expect_err("arity mismatch on a perry/* builtin must not compile to a dropped call");
+    // The bail is wrapped in the lowering context chain, so match the whole
+    // chain (`{:?}` on an anyhow::Error prints the causes too).
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("isDarkMode") && msg.contains("takes 0 argument"),
+        "expected an arity diagnostic naming the builtin, got: {msg}"
+    );
+}
+
+/// TS-optional trailing params stay legal — and now actually emit the call.
+/// `shareText(text, title?)` declares `[Str, Str]` in PERRY_SYSTEM_TABLE; a
+/// one-arg call pads the title with `""` rather than being dropped.
+#[test]
+fn perry_system_optional_trailing_arg_pads_and_emits_the_call() {
+    let module = module_with(
+        vec![import_from(
+            "perry/system",
+            "shareText",
+            ModuleKind::NativeRust,
+        )],
+        vec![call_extern(
+            "shareText",
+            vec![Expr::String("hello".to_string())],
+        )],
+    );
+
+    let ir =
+        String::from_utf8(compile_module(&module, base_opts()).expect("must compile")).unwrap();
+    assert!(
+        ir.contains("perry_system_share_text"),
+        "a one-arg shareText(text) must still emit the native call; IR:\n{ir}"
+    );
+}

--- a/test-files/_helpers/perry_builtin_name_collision_lib.ts
+++ b/test-files/_helpers/perry_builtin_name_collision_lib.ts
@@ -1,0 +1,65 @@
+// Helper for test_issue_6087_builtin_name_collision.ts.
+//
+// Every function here is deliberately named after a row in one of the
+// name-keyed perry/* dispatch tables (PERRY_SYSTEM_TABLE,
+// PERRY_UPDATER_TABLE, PERRY_BACKGROUND_TABLE). None of them import
+// anything native — they are plain user functions that merely happen to
+// share a name with a builtin.
+//
+// Pre-#6087 the codegen hijacked the *call sites* in the importing module
+// purely by callee name:
+//   - arity != the builtin's row  -> the call was silently dropped
+//     (takeScreenshot, getLocale, isDarkMode, schedule below)
+//   - arity == the builtin's row  -> the program linked against an
+//     undefined `perry_system_*` / `perry_background_*` symbol
+//     (hapticPlay, openURL, cancel below)
+
+// PERRY_SYSTEM_TABLE row: `takeScreenshot`, args: [] (arity mismatch)
+export function takeScreenshot(path: string): string {
+  return "takeScreenshot:" + path;
+}
+
+// PERRY_SYSTEM_TABLE row: `hapticPlay`, args: [Str] (arity MATCHES)
+export function hapticPlay(style: string): string {
+  return "hapticPlay:" + style;
+}
+
+// PERRY_SYSTEM_TABLE row: `openURL`, args: [Str] (arity MATCHES)
+export function openURL(url: string): string {
+  return "openURL:" + url;
+}
+
+// PERRY_SYSTEM_TABLE row: `getLocale`, args: [] (arity MATCHES, 0 args)
+export function getLocale(): string {
+  return "getLocale:user";
+}
+
+// PERRY_SYSTEM_TABLE row: `isDarkMode`, args: [] (arity MATCHES, 0 args)
+export function isDarkMode(): boolean {
+  return true;
+}
+
+// PERRY_SYSTEM_TABLE row: `preferencesSet`, args: [Str, Str]
+export function preferencesSet(key: string, value: string, extra: number): string {
+  return "preferencesSet:" + key + "=" + value + "+" + extra;
+}
+
+// PERRY_BACKGROUND_TABLE row: `cancel`
+export function cancel(id: string): string {
+  return "cancel:" + id;
+}
+
+// PERRY_BACKGROUND_TABLE row: `schedule`
+export function schedule(id: string, seconds: number, repeats: boolean): string {
+  return "schedule:" + id + "/" + seconds + "/" + repeats;
+}
+
+// PERRY_UPDATER_TABLE row: `compareVersions`
+export function compareVersions(a: string, b: string): number {
+  return a === b ? 0 : a < b ? -1 : 1;
+}
+
+// PERRY_UPDATER_TABLE row: `relaunch`
+export function relaunch(): string {
+  return "relaunch:user";
+}

--- a/test-files/test_issue_6087_builtin_name_collision.ts
+++ b/test-files/test_issue_6087_builtin_name_collision.ts
@@ -1,0 +1,64 @@
+// Issue #6087 — a user function imported from a plain TypeScript module must
+// never be hijacked by the name-keyed perry/system | perry/updater |
+// perry/background dispatch tables.
+//
+// Pre-fix, `lower_call/extern_func.rs` consulted those tables on the bare
+// callee name with no check of where the name came from. Since an imported
+// function lowers to `Expr::ExternFuncRef { name }` — exactly like a
+// `perry/system` import does — every user function whose name collided with
+// one of the ~60 table rows was routed into the native table:
+//
+//   * arity != the table row  -> `lower_perry_ui_table_call` lowered the args
+//     for side effects and returned the 0.0 sentinel, i.e. THE CALL VANISHED.
+//     `takeScreenshot("a.png")` printed nothing, with no error and no warning.
+//   * arity == the table row  -> the program linked against an undefined
+//     `perry_system_haptic_play` symbol despite importing nothing native.
+//
+// The fix gates all three tables on the callee actually resolving to a
+// `perry/system` / `perry/updater` / `perry/background` import.
+//
+// This file imports NOTHING native. Every call below must reach the user's
+// function in ./_helpers/perry_builtin_name_collision_lib.ts.
+
+import {
+  takeScreenshot,
+  hapticPlay,
+  openURL,
+  getLocale,
+  isDarkMode,
+  preferencesSet,
+  cancel,
+  schedule,
+  compareVersions,
+  relaunch,
+} from "./_helpers/perry_builtin_name_collision_lib.ts";
+
+// perry/system rows
+console.log(takeScreenshot("a.png"));
+console.log(hapticPlay("light"));
+console.log(openURL("https://example.com"));
+console.log(getLocale());
+console.log(isDarkMode());
+console.log(preferencesSet("k", "v", 7));
+
+// perry/background rows
+console.log(cancel("job-1"));
+console.log(schedule("job-2", 30, true));
+
+// perry/updater rows
+console.log(compareVersions("1.2.0", "1.10.0"));
+console.log(relaunch());
+
+// The collision must not survive indirection either: a call through a local
+// alias, and a call from inside another function, both lower to the same
+// ExternFuncRef.
+const aliased = takeScreenshot;
+console.log(aliased("b.png"));
+
+function nested(): void {
+  console.log(takeScreenshot("c.png"));
+  console.log(cancel("job-3"));
+}
+nested();
+
+console.log("done");


### PR DESCRIPTION
Fixes #6087.

## The bug

P1 silent miscompile, reachable from plain TypeScript with **no FFI, no native library, no manifest**:

```ts
// lib.ts
export function takeScreenshot(path: string): void { console.log("takeScreenshot ran:", path); }
export function grabShot(path: string): void { console.log("grabShot ran:", path); }

// app.ts
import { takeScreenshot, grabShot } from "./lib.ts";
grabShot("a.png");
takeScreenshot("a.png");
console.log("after");
```

| perry (before) | node |
|---|---|
| `grabShot ran: a.png`<br>`after` | `grabShot ran: a.png`<br>`takeScreenshot ran: a.png`<br>`after` |

`takeScreenshot` is **silently never invoked**. No error, no warning, links clean.

## Mechanism — a name-keyed builtin hijack of any imported function

Two sites composed.

**1. `lower_call/extern_func.rs`** consulted the `perry/system` / `perry/updater` / `perry/background` dispatch tables purely by callee *name*, with no check of where the name came from:

```rust
if let Some(sig) = perry_system_table_lookup(name) {
    return Ok(Some(lower_perry_ui_table_call(ctx, sig, args)?));
}
```

An imported user function lowers to `Expr::ExternFuncRef { name }` — exactly the shape a `perry/system` import produces — so any user function whose name collided with one of the ~60 table rows was routed into the native table. (Note the contrast ~20 lines below: the `js_*` branch *does* guard itself with `!ctx.ffi_signatures.contains_key(name)`.)

**2. `lower_call/ui_tables.rs`** then dropped the call when the arity didn't line up:

```rust
if args.len() != declared_arg_count && inline_style_arg.is_none() {
    for a in args { let _ = lower_expr(ctx, a)?; }
    return Ok(double_literal(0.0));   // <-- the call is GONE
}
```

So **arity differs → the call silently vanishes**; **arity matches → link failure** on an undefined `perry_system_*` symbol in a program that imports nothing native.

Every one of the 49 `PERRY_SYSTEM_TABLE` names was effectively a reserved word — `getLocale`, `openURL`, `shareText`, `preferencesGet`, `preferencesSet`, `isDarkMode`, `getAppVersion`, `getOSVersion`, `getDeviceModel`, `takeScreenshot`, `hapticPlay`, `networkGetStatus`, … — plus `cancel` / `schedule` / `registerTask` from `perry/background` and `relaunch` / `compareVersions` / `readSentinel` from `perry/updater`.

## The fix

**1. Gate the three table lookups on the callee's import *source*, not its name.**

`imported_class_sources` (already built per-module in `codegen/mod.rs` from `hir.imports`) maps every named/default import binding to the specifier it came from, which answers the question exactly: a binding that came from anywhere other than `perry/system` | `perry/updater` | `perry/background` can never be the builtin.

A name with *no* import binding in the module (ambient `declare`s, synthesized extern refs) keeps the historical behaviour — the gate can only ever **reject** a name that demonstrably came from somewhere else, so it cannot break a `perry/*` call that reaches codegen by some other route. The cross-module inliner stays sound too: when it moves a body containing an `ExternFuncRef` into another module it also adds the matching `Import` to the destination's `hir.imports` (`inline::cross_module`) — the same table this map is built from.

**2. Make the arity-mismatch branch a hard compile error instead of a silent `return 0.0`.**

That silence is what turned a routing bug into a *silent miscompile*, and it would keep hiding future ones. The legitimate shapes are preserved deliberately:

- **inline-style absorption** (#185) — one extra trailing arg on a `Widget`-returning constructor;
- **TS-optional trailing params.** A dispatch row spells the full runtime ABI, but the `.d.ts` lets callers omit the tail: `shareText(text, title?)`, `Image(url, alt?)`, `stop(handle, fadeOutMs?)`, `setMasterVolume(volume, fadeMs?)`. Those previously hit the mismatch and were **dropped too** — a one-arg `shareText("hi")` or `Image(url)` compiled to nothing at all. They are now padded with the per-kind empty value (`""` / `0`, the same convention `native_ui_appshell_branch` already uses for a missing `alt`) and the call is actually emitted. A missing `Widget` handle or `Closure` can't be synthesized, so those still error.

## Verification

**Repro** — now byte-identical to `node --experimental-strip-types`:

```
grabShot ran: a.png
takeScreenshot ran: a.png
after
```

**The legitimate `perry/system` + `perry/ui` path is provably untouched.** Compiled `test-files/test_take_screenshot.ts` (`import { takeScreenshot } from "perry/system"`) and `docs/examples/platforms/macos_system.ts` (`perry/ui` + `openURL` / `isDarkMode` / `preferencesGet` / `preferencesSet`) with a `main`-HEAD build and this build in the same target dir, and diffed the emitted LLVM IR: **byte-identical**, still emitting `perry_system_take_screenshot`, `perry_system_open_url`, `perry_system_is_dark_mode`, `perry_system_preferences_{get,set}`, `perry_ui_app_create`, `perry_ui_text_create`, … `examples/issue_552_demo.ts`, `issue_582_demo.ts`, `issue_583_demo.ts` and `test_issue_673_app_metadata.ts` compile *and link* clean.

**No existing `perry/*` code hits the new hard error.** Swept all 85 files under `test-files/`, `examples/` and `docs/examples/` that import `perry/{ui,system,updater,background,media,i18n,audio,plugin}`: zero arity bails, zero codegen errors.

`cargo test -p perry-codegen -p perry-dispatch` passes. (`manifest_consistency::every_dispatch_entry_has_manifest_counterpart` fails identically on clean `main` — pre-existing `ws::readyState` manifest drift, unrelated: this PR touches no dispatch table.)

The `--target web` / wasm backends never had this bug — they dispatch from a module-qualified `NativeMethodCall`, not a bare name.

## Regression coverage

- `crates/perry-codegen/tests/perry_builtin_name_collision.rs` — a `./lib.ts` import must reach `perry_fn_lib_ts__takeScreenshot` and **never** `perry_system_take_screenshot`; same for `perry/background`'s `cancel`; a genuine `perry/system` import must still reach the native symbol; an impossible arity must now be an error; an optional trailing param must still emit the call.
- `test-files/test_issue_6087_builtin_name_collision.ts` — parity fixture covering ten colliding names (`takeScreenshot`, `hapticPlay`, `openURL`, `getLocale`, `isDarkMode`, `preferencesSet`, `cancel`, `schedule`, `compareVersions`, `relaunch`) plus alias and nested-call forms. It **fails to link on `main`** with six undefined `perry_system_*` / `perry_updater_*` symbols; it now matches node byte-for-byte.

## Note on CI

`lint` and `conformance-smoke` are already red on clean `main` (addr-class ratchet on `map.rs`; #6297 fixes it) — not from this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented misrouting of calls when user-defined functions share names with `perry/system`, `perry/updater`, or `perry/background` dispatch-table rows across modules.
  * Improved optional trailing-parameter handling by padding missing `Str`/`F64` arguments instead of dropping the call.
  * Compilation now fails with a clear arity error for unsupported argument-count mismatches (instead of silently returning a sentinel).

* **Tests**
  * Added Issue `#6087` regression coverage for name collisions, aliasing, nested calls, and optional-parameter padding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->