### PR TITLE
fix(hir): parenthesized / cast assignment target must honour const immutability (#6300)

### DIFF
--- a/crates/perry-hir/src/lower/expr_assign.rs
+++ b/crates/perry-hir/src/lower/expr_assign.rs
@@ -70,7 +70,7 @@ fn lower_rhs_with_assignment_name(
     result
 }
 
-fn throw_type_error_const_assignment(name: &str) -> Expr {
+pub(crate) fn throw_type_error_const_assignment(name: &str) -> Expr {
     Expr::Call {
         callee: Box::new(Expr::ExternFuncRef {
             name: "js_throw_type_error_const_assignment".to_string(),
@@ -413,6 +413,97 @@ pub(super) fn lower_assign(ctx: &mut LoweringContext, assign: &ast::AssignExpr) 
     lower_assignment_target(ctx, &assign.left, value)
 }
 
+/// Lower `<name> = value` where `<name>` is an identifier assignment target.
+///
+/// #6300: this is the ONE place identifier stores are resolved, so the
+/// `const`-immutability (and class-inner-name) checks can't be routed around.
+/// It is shared by the bare-`Ident` `AssignTarget` arm below and by
+/// `lower_expr_assignment`'s `Ident` arm, which is what the parenthesized /
+/// TS-cast targets (`(c) = 9`, `(c as any) = 9`, `(c satisfies T) = 9`,
+/// `(c!) = 9`) unwrap into. Before the extraction, only the bare-`Ident` arm
+/// checked immutability, so any wrapper on the LHS silently mutated a `const`.
+pub(crate) fn lower_ident_assignment(
+    ctx: &mut LoweringContext,
+    name: String,
+    value: Box<Expr>,
+) -> Result<Expr> {
+    if let Some(env_id) = ctx.active_with_envs_for_ident(&name).into_iter().next() {
+        let fallback = with_set_fallback_for_ident(ctx, &name);
+        return Ok(Expr::WithSet {
+            object: Box::new(Expr::LocalGet(env_id)),
+            property: name,
+            value,
+            fallback,
+            strict: ctx.current_strict,
+        });
+    }
+    if let Some(id) = ctx.lookup_local(&name) {
+        if ctx.is_local_immutable(id) {
+            // `const c = 1; c = 9` (and every wrapped spelling of the same
+            // target) evaluates the RHS for side effects, then throws
+            // `TypeError: Assignment to constant variable.`
+            return Ok(Expr::Sequence(vec![
+                *value,
+                throw_type_error_const_assignment(&name),
+            ]));
+        }
+        Ok(Expr::LocalSet(id, value))
+    } else if ctx.current_class_inner_name.as_deref() == Some(name.as_str()) {
+        // Assigning to the class own-name binding from inside the class
+        // body targets the immutable inner `const` binding -> TypeError
+        // (test262 language/statements/class/name-binding/const). Evaluate
+        // the RHS for side effects first, then throw. A local/param that
+        // shadows the name was already handled by the `lookup_local` arm
+        // above, so this only fires for the genuine class binding.
+        Ok(Expr::Sequence(vec![
+            *value,
+            throw_type_error_const_assignment(&name),
+        ]))
+    } else if ctx.lookup_class(&name).is_some() || ctx.lookup_func(&name).is_some() {
+        // v0.5.757: don't shadow a class/function binding with an
+        // implicit local for `<Name> = X` patterns. Drizzle's
+        // sql.js uses `((sql2) => { ... })(sql || (sql = {}))`
+        // (and the same for SQL) — since the binding exists
+        // (truthy), the OR short-circuits and the assignment is
+        // dead. Pre-fix the implicit local hid the original
+        // binding from later reads. Just evaluate the RHS for
+        // side effects. Refs #420.
+        Ok(*value)
+    } else {
+        if ctx.current_strict {
+            // #5989: strict-mode assignment to an existing global
+            // builtin is a property write, not a ReferenceError. See
+            // `strict_global_assign_existing_or_throw` for the full
+            // rationale.
+            return Ok(strict_global_assign_existing_or_throw(name, value));
+        }
+        eprintln!(
+            "  Warning: Assignment to undeclared variable '{}', creating sloppy global",
+            name
+        );
+        // Sloppy implicit global: the binding IS a property of globalThis
+        // (spec CreateGlobalVarBinding on the global object), so `foo = 1`
+        // must be visible as `globalThis.foo`, write through to a
+        // pre-existing global property, and observe a later
+        // `delete globalThis.foo`. Reads of the name resolve through the
+        // `js_global_get_or_throw_unresolved` fallback, so no module-local
+        // shadow may be created here (a stale local would keep serving
+        // deleted/overwritten values).
+        // NOTE: `GlobalGet(0)` alone is a by-name routing SENTINEL in
+        // codegen (bare reads lower to 0.0) — the write must target
+        // the VALUE globalThis, which the `PropertyGet { GlobalGet(0),
+        // "globalThis" }` shape resolves to the real global object.
+        Ok(Expr::PropertySet {
+            object: Box::new(Expr::PropertyGet {
+                object: Box::new(Expr::GlobalGet(0)),
+                property: "globalThis".to_string(),
+            }),
+            property: name,
+            value,
+        })
+    }
+}
+
 fn lower_assignment_target(
     ctx: &mut LoweringContext,
     target: &ast::AssignTarget,
@@ -420,74 +511,7 @@ fn lower_assignment_target(
 ) -> Result<Expr> {
     match target {
         ast::AssignTarget::Simple(ast::SimpleAssignTarget::Ident(ident)) => {
-            let name = ident.id.sym.to_string();
-            if let Some(env_id) = ctx.active_with_envs_for_ident(&name).into_iter().next() {
-                let fallback = with_set_fallback_for_ident(ctx, &name);
-                return Ok(Expr::WithSet {
-                    object: Box::new(Expr::LocalGet(env_id)),
-                    property: name,
-                    value,
-                    fallback,
-                    strict: ctx.current_strict,
-                });
-            }
-            if let Some(id) = ctx.lookup_local(&name) {
-                if ctx.is_local_immutable(id) {
-                    return Ok(Expr::Sequence(vec![
-                        *value,
-                        throw_type_error_const_assignment(&name),
-                    ]));
-                }
-                Ok(Expr::LocalSet(id, value))
-            } else if ctx.current_class_inner_name.as_deref() == Some(name.as_str()) {
-                // Assigning to the class own-name binding from inside the class
-                // body targets the immutable inner `const` binding -> TypeError
-                // (test262 language/statements/class/name-binding/const). Evaluate
-                // the RHS for side effects first, then throw. A local/param that
-                // shadows the name was already handled by the `lookup_local` arm
-                // above, so this only fires for the genuine class binding.
-                Ok(Expr::Sequence(vec![
-                    *value,
-                    throw_type_error_const_assignment(&name),
-                ]))
-            } else if ctx.lookup_class(&name).is_some() || ctx.lookup_func(&name).is_some() {
-                // v0.5.757: don't shadow a class/function binding with an
-                // implicit local for `<Name> = X` patterns. Drizzle's
-                // sql.js uses `((sql2) => { ... })(sql || (sql = {}))`
-                // (and the same for SQL) — since the binding exists
-                // (truthy), the OR short-circuits and the assignment is
-                // dead. Pre-fix the implicit local hid the original
-                // binding from later reads. Just evaluate the RHS for
-                // side effects. Refs #420.
-                Ok(*value)
-            } else {
-                if ctx.current_strict {
-                    // #5989: strict-mode assignment to an existing global
-                    // builtin is a property write, not a ReferenceError. See
-                    // `strict_global_assign_existing_or_throw` for the full
-                    // rationale (shared with the sibling arm in
-                    // lower_expr/assignment.rs).
-                    return Ok(strict_global_assign_existing_or_throw(name, value));
-                }
-                eprintln!(
-                    "  Warning: Assignment to undeclared variable '{}', creating sloppy global",
-                    name
-                );
-                // Sloppy implicit global — a real globalThis property, not
-                // a module local (see the sibling arm in lower_expr.rs).
-                // NOTE: `GlobalGet(0)` alone is a by-name routing SENTINEL in
-                // codegen (bare reads lower to 0.0) — the write must target
-                // the VALUE globalThis, which the `PropertyGet { GlobalGet(0),
-                // "globalThis" }` shape resolves to the real global object.
-                Ok(Expr::PropertySet {
-                    object: Box::new(Expr::PropertyGet {
-                        object: Box::new(Expr::GlobalGet(0)),
-                        property: "globalThis".to_string(),
-                    }),
-                    property: name,
-                    value,
-                })
-            }
+            lower_ident_assignment(ctx, ident.id.sym.to_string(), value)
         }
         ast::AssignTarget::Simple(ast::SimpleAssignTarget::Member(member)) => {
             // Proxy set: `proxy.foo = v` / `proxy[k] = v`

--- a/crates/perry-hir/src/lower/expr_misc.rs
+++ b/crates/perry-hir/src/lower/expr_misc.rs
@@ -26,6 +26,7 @@ use anyhow::{anyhow, Result};
 use swc_ecma_ast as ast;
 
 use crate::ir::{BinaryOp, Expr, UpdateOp};
+use crate::lower::expr_assign::throw_type_error_const_assignment;
 use crate::lower_patterns::unescape_template;
 
 use super::{lower_expr, LoweringContext};
@@ -130,13 +131,19 @@ pub(super) fn lower_update(ctx: &mut LoweringContext, update: &ast::UpdateExpr) 
         ast::UpdateOp::MinusMinus => BinaryOp::Sub,
     };
 
-    // Unwrap compile-time-only wrappers: `obj.x!++` (TS non-null assertion) and
-    // `(obj.x)++` (parenthesized) are transparent to update-expression lowering.
+    // Unwrap compile-time-only wrappers: `obj.x!++` (TS non-null assertion),
+    // `(obj.x)++` (parenthesized) and the TS casts (`(x as any)++`,
+    // `(<any>x)++`, `(x satisfies number)++`) are all transparent to
+    // update-expression lowering (#6300 — the cast forms previously fell
+    // through to the "only identifiers and member expressions" error).
     let mut arg = update.arg.as_ref();
     loop {
         match arg {
             ast::Expr::TsNonNull(inner) => arg = inner.expr.as_ref(),
             ast::Expr::Paren(inner) => arg = inner.expr.as_ref(),
+            ast::Expr::TsAs(inner) => arg = inner.expr.as_ref(),
+            ast::Expr::TsTypeAssertion(inner) => arg = inner.expr.as_ref(),
+            ast::Expr::TsSatisfies(inner) => arg = inner.expr.as_ref(),
             _ => break,
         }
     }
@@ -174,6 +181,36 @@ pub(super) fn lower_update(ctx: &mut LoweringContext, update: &ast::UpdateExpr) 
                     byte_offset: 0,
                 });
             };
+            if ctx.is_local_immutable(id) {
+                // #6300: `const c = 1; c++` (and `(c as any)--`, `(c!)++`, …) is
+                // a PutValue on an immutable binding →
+                // `TypeError: Assignment to constant variable.` Emitting
+                // `Expr::Update` here silently mutated the `const` instead.
+                //
+                // The throw is NOT unconditional-first: per ES `++`/`--`
+                // (13.4.2.1 / 13.4.3.1) the operand is run through
+                // `ToNumeric(GetValue(lhs))` *before* `PutValue` rejects the
+                // immutable binding, and that coercion is itself observable —
+                // `const s = Symbol(); s++` throws "Cannot convert a Symbol
+                // value to a number", not the const TypeError (a BigInt, by
+                // contrast, passes ToNumeric cleanly and does get the const
+                // TypeError). Sequence the same `js_to_numeric` the normal
+                // update path uses in front of the throw so both orders match
+                // V8.
+                return Ok(Expr::Sequence(vec![
+                    Expr::Call {
+                        callee: Box::new(Expr::ExternFuncRef {
+                            name: "js_to_numeric".to_string(),
+                            param_types: vec![perry_types::Type::Any],
+                            return_type: perry_types::Type::Any,
+                        }),
+                        args: vec![Expr::LocalGet(id)],
+                        type_args: vec![],
+                        byte_offset: 0,
+                    },
+                    throw_type_error_const_assignment(&name),
+                ]));
+            }
             let op = match update.op {
                 ast::UpdateOp::PlusPlus => UpdateOp::Increment,
                 ast::UpdateOp::MinusMinus => UpdateOp::Decrement,

--- a/crates/perry-hir/src/lower/lower_expr/assignment.rs
+++ b/crates/perry-hir/src/lower/lower_expr/assignment.rs
@@ -17,63 +17,12 @@ pub(crate) fn lower_expr_assignment(
     value: Box<Expr>,
 ) -> Result<Expr> {
     match expr {
+        // #6300: identifier stores — including the ones reached by unwrapping a
+        // parenthesized / TS-cast assignment target below — go through the one
+        // shared helper, so the `const`-immutability check can't be bypassed by
+        // writing `(c as any) = 9` instead of `c = 9`.
         ast::Expr::Ident(ident) => {
-            let name = ident.sym.to_string();
-            if let Some(env_id) = ctx.active_with_envs_for_ident(&name).into_iter().next() {
-                let fallback = with_set_fallback_for_ident(ctx, &name);
-                return Ok(Expr::WithSet {
-                    object: Box::new(Expr::LocalGet(env_id)),
-                    property: name,
-                    value,
-                    fallback,
-                    strict: ctx.current_strict,
-                });
-            }
-            if let Some(id) = ctx.lookup_local(&name) {
-                Ok(Expr::LocalSet(id, value))
-            } else if ctx.lookup_class(&name).is_some() || ctx.lookup_func(&name).is_some() {
-                // v0.5.757: don't shadow a class/function binding with an
-                // implicit local for `<Name> = X` patterns. Drizzle's
-                // sql.js uses `((sql2) => { ... })(sql || (sql = {}))` —
-                // the binding exists (truthy), the OR short-circuits, and
-                // the assignment is dead. Pre-fix the implicit local hid
-                // the original binding from later reads. Just evaluate
-                // the RHS for side effects. Refs #420.
-                Ok(*value)
-            } else {
-                if ctx.current_strict {
-                    // #5989: strict-mode assignment to an existing global
-                    // builtin is a property write, not a ReferenceError. See
-                    // `strict_global_assign_existing_or_throw` for the full
-                    // rationale (shared with the sibling arm in expr_assign.rs).
-                    return Ok(strict_global_assign_existing_or_throw(name, value));
-                }
-                eprintln!(
-                    "  Warning: Assignment to undeclared variable '{}', creating sloppy global",
-                    name
-                );
-                // Sloppy implicit global: the binding IS a property of
-                // globalThis (spec CreateGlobalVarBinding on the global
-                // object), so `foo = 1` must be visible as
-                // `globalThis.foo`, write through to a pre-existing global
-                // property, and observe a later `delete globalThis.foo`.
-                // Reads of the name resolve through the
-                // `js_global_get_or_throw_unresolved` fallback, so no
-                // module-local shadow may be created here (a stale local
-                // would keep serving deleted/overwritten values).
-                // NOTE: `GlobalGet(0)` alone is a by-name routing SENTINEL in
-                // codegen (bare reads lower to 0.0) — the write must target
-                // the VALUE globalThis, which the `PropertyGet { GlobalGet(0),
-                // "globalThis" }` shape resolves to the real global object.
-                Ok(Expr::PropertySet {
-                    object: Box::new(Expr::PropertyGet {
-                        object: Box::new(Expr::GlobalGet(0)),
-                        property: "globalThis".to_string(),
-                    }),
-                    property: name,
-                    value,
-                })
-            }
+            crate::lower::expr_assign::lower_ident_assignment(ctx, ident.sym.to_string(), value)
         }
         ast::Expr::Member(member) => {
             if let ast::Expr::Ident(obj_ident) = member.obj.as_ref() {

--- a/test-files/test_gap_6300_const_cast_assign.ts
+++ b/test-files/test_gap_6300_const_cast_assign.ts
@@ -1,0 +1,197 @@
+// #6300: a parenthesized / TS-cast assignment target must NOT bypass the
+// `const` immutability check. `(c as any) = 9` used to silently mutate the
+// binding with no diagnostic — only the bare-identifier store path checked
+// immutability, and every wrapper spelling (parens, `as`, `satisfies`, `!`,
+// `<T>`) routed around it into a second, unchecked identifier-store arm.
+//
+// Perry appends the binding name to the message (`... variable 'c'.`) where
+// V8 does not, so normalize that away to stay byte-for-byte identical to
+// `node --experimental-strip-types`.
+function norm(e: unknown): string {
+  const err = e as Error;
+  const isTypeError = err instanceof TypeError;
+  const msg = err.message.replace(/ '[^']*'\.$/, ".");
+  return `${isTypeError ? "TypeError" : "Error"}: ${msg}`;
+}
+
+function expectThrow(label: string, fn: () => void): void {
+  try {
+    fn();
+    console.log(`${label}: NO THROW`);
+  } catch (e) {
+    console.log(`${label}: ${norm(e)}`);
+  }
+}
+
+// --- const targets: every wrapper must throw and leave the binding intact ---
+
+const c1 = 1;
+expectThrow("bare", () => {
+  // @ts-expect-error assignment to const
+  c1 = 9;
+});
+console.log("c1 =", c1);
+
+const c2 = 2;
+expectThrow("paren", () => {
+  // @ts-expect-error assignment to const
+  (c2) = 9;
+});
+console.log("c2 =", c2);
+
+const c3 = 3;
+expectThrow("as-cast", () => {
+  (c3 as any) = 9;
+});
+console.log("c3 =", c3);
+
+const c4 = 4;
+expectThrow("satisfies", () => {
+  (c4 satisfies number) = 9;
+});
+console.log("c4 =", c4);
+
+const c5 = 5;
+expectThrow("non-null", () => {
+  // @ts-expect-error assignment to const
+  (c5!) = 9;
+});
+console.log("c5 =", c5);
+
+const c6 = 6;
+expectThrow("nested-wrappers", () => {
+  ((c6 as any)!) = 9;
+});
+console.log("c6 =", c6);
+
+// --- compound / update / logical assignment through a cast ---
+
+const c7 = 7;
+expectThrow("compound-add", () => {
+  (c7 as any) += 1;
+});
+console.log("c7 =", c7);
+
+const c8 = 8;
+expectThrow("compound-shift", () => {
+  (c8 as any) <<= 1;
+});
+console.log("c8 =", c8);
+
+const c9 = 9;
+expectThrow("postfix-incr", () => {
+  (c9 as any)++;
+});
+console.log("c9 =", c9);
+
+const c10 = 10;
+expectThrow("prefix-decr", () => {
+  --(c10 as any);
+});
+console.log("c10 =", c10);
+
+const c11 = 11;
+expectThrow("bare-incr", () => {
+  // @ts-expect-error update of const
+  c11++;
+});
+console.log("c11 =", c11);
+
+// A BigInt const passes ToNumeric cleanly, so `++` still reaches PutValue and
+// reports the const TypeError.
+const c12 = 12n;
+expectThrow("bigint-incr", () => {
+  (c12 as any)++;
+});
+console.log("c12 =", c12);
+
+const c13: number | null = null;
+expectThrow("nullish-assign", () => {
+  (c13 as any) ??= 13;
+});
+console.log("c13 =", c13);
+
+const c14 = 0;
+expectThrow("or-assign", () => {
+  (c14 as any) ||= 14;
+});
+console.log("c14 =", c14);
+
+// The RHS is evaluated before PutValue rejects the binding, so its side
+// effects are observable even though the assignment throws.
+const c15 = 15;
+let rhsRuns = 0;
+expectThrow("rhs-side-effect", () => {
+  (c15 as any) = (rhsRuns++, 99);
+});
+console.log("c15 =", c15, "rhsRuns =", rhsRuns);
+
+// A short-circuiting logical assignment never reaches PutValue, so a truthy
+// const with `||=` must NOT throw.
+const c16 = 16;
+expectThrow("or-assign-shortcircuit", () => {
+  (c16 as any) ||= 99;
+});
+console.log("c16 =", c16);
+
+// A const inside a function body behaves the same.
+function inFunction(): void {
+  const local = 1;
+  expectThrow("fn-local", () => {
+    (local as any) = 9;
+  });
+  console.log("fn-local =", local);
+}
+inFunction();
+
+// `for (const x of ...)` binds a fresh immutable binding per iteration.
+for (const item of [1]) {
+  expectThrow("for-of-const", () => {
+    (item as any) = 9;
+  });
+  console.log("item =", item);
+}
+
+// --- legitimate writes must keep working ---
+
+let d1 = 1;
+(d1 as any) = 9;
+console.log("let as-cast:", d1);
+
+let d2 = 1;
+(d2) = 9;
+console.log("let paren:", d2);
+
+let d3 = 1;
+(d3 as any) += 4;
+console.log("let compound:", d3);
+
+let d4 = 1;
+(d4 as any)++;
+++(d4 as any);
+console.log("let update:", d4);
+
+let d5: number | null = null;
+(d5 as any) ??= 7;
+console.log("let nullish:", d5);
+
+let d6 = 1;
+(d6 satisfies number) = 6;
+(d6!) = d6 + 1;
+console.log("let satisfies/non-null:", d6);
+
+// A cast MEMBER expression target is a property write, not a binding write —
+// it stays legal even when the object itself is `const`.
+const obj: any = { x: 0 };
+(obj as any).x = 1;
+console.log("obj.x =", obj.x);
+(obj as any).x++;
+console.log("obj.x =", obj.x);
+(obj as any)["x"] += 10;
+console.log("obj.x =", obj.x);
+
+// Mutating a `const` object/array is fine — only rebinding is not.
+const arr: number[] = [1];
+arr.push(2);
+(arr as any)[0] = 5;
+console.log("arr =", arr.join(","));


### PR DESCRIPTION
Fixes #6300.

## The bug

```ts
const c = 1;
(c as any) = 9;
console.log("const after cast-assign:", c);   // perry main: 9 — node: TypeError
```

Every wrapper spelling of the same target was affected, not just `as`:
`(c) = 9`, `(c as any) = 9`, `(c satisfies number) = 9`, `(c!) = 9`, `<any>c = 9`,
plus the compound and logical forms (`(c as any) += 1`, `(c as any) ||= 9`).

## Root cause

Two divergent identifier-store arms.

`lower_assignment_target` (`expr_assign.rs`) handled a bare `Ident` target with the
full binding resolution — active `with` env, const-immutability throw,
class-inner-name throw, class/function binding, strict/sloppy global. But its
`Paren` / `TsAs` / `TsNonNull` / `TsTypeAssertion` / `TsSatisfies` arms delegate to
`lower_expr_assignment` (`lower_expr/assignment.rs`), and *that* function's `Ident`
arm was a stripped-down copy that went straight to `Expr::LocalSet` with **no
immutability check**. So any wrapper on the LHS routed around the const check.

The fix extracts the resolution into one shared `lower_ident_assignment` and calls it
from both arms, so the check can't be bypassed. `lower_expr_assignment` has no callers
other than those wrapper arms, so the bare-ident path is byte-identical to before.

## `x++` had the same hole, from the other direction

`lower_update` emitted `Expr::Update` for any local without consulting
`is_local_immutable`, so even the *bare* `const c = 1; c++` mutated silently — and
`(c as any)++` didn't compile at all (`Update expression only supports identifiers and
member expressions`; the unwrap loop only knew `Paren` / `TsNonNull`). This teaches the
loop the three TS cast nodes and throws on an immutable target.

The throw is **sequenced after** the operand's `js_to_numeric`, not before it. Per ES
13.4.2.1, `ToNumeric(GetValue(lhs))` runs ahead of `PutValue`, and that coercion is
observable:

| | node 26 | this PR |
|---|---|---|
| `const s = Symbol(); s++` | `TypeError: Cannot convert a Symbol value to a number` | same |
| `const b = 1n; b++` | `TypeError: Assignment to constant variable.` | same |

A BigInt passes `ToNumeric` cleanly and *does* reach the const `TypeError`; a Symbol
throws in the coercion first. Both now match V8.

## Before / after vs `node --experimental-strip-types`

| case | perry `main` | this PR | node 26 |
|---|---|---|---|
| `(c) = 9` | no throw, `c` → 9 | **TypeError** | TypeError |
| `(c as any) = 9` | no throw, `c` → 9 | **TypeError** | TypeError |
| `(c satisfies number) = 9` | no throw, `c` → 9 | **TypeError** | TypeError |
| `(c!) = 9` | no throw, `c` → 9 | **TypeError** | TypeError |
| `(c as any) += 1` | no throw, `c` → 2 | **TypeError** | TypeError |
| `(c as any)++` | **compile error** | **TypeError** | TypeError |
| `c++` (bare) | no throw, `c` → 2 | **TypeError** | TypeError |
| `(c as any) \|\|= 9`, `c` truthy | no throw, `c` unchanged | no throw, `c` unchanged | no throw (short-circuit) |
| `let d = 1; (d as any) = 9` | `d` → 9 | `d` → 9 | `d` → 9 |
| `(obj as any).x = 1` | `obj.x` → 1 | `obj.x` → 1 | `obj.x` → 1 |

## Blast radius

- The shared helper is only reachable from the wrapper arms — `lower_expr_assignment`
  has no other callers — so bare-identifier assignment lowering is unchanged.
- Every `mark_local_immutable` call site (7 of them) is a genuine `const` binding
  (`kind == Const` / `!mutable`), so the new `lower_update` throw cannot fire on a
  `let` / `var` / param.
- Legal writes are explicitly covered in the fixture and still work: `let` through a
  cast, `(obj as any).x = 1` / `.x++` / `["x"] += 10`, mutating a `const` array.

## Test

`test-files/test_gap_6300_const_cast_assign.ts` — all wrapper spellings,
compound / update / logical forms, RHS-side-effect ordering (`rhsRuns` is incremented
before the `TypeError`), the `||=` short-circuit that must **not** throw, BigInt `++`,
`for (const x of …)` bindings, function-local consts, and the legal writes above.
Byte-for-byte identical to `node --experimental-strip-types`.

### Regression checks

`cargo-test` is green in CI. Locally under `--profile perry-dev`, `cargo test -p
perry-hir` is byte-for-byte unchanged from `main`: same 223 + 2 + 18 passing, and the
same single `logical_property_assignment_short_circuits_the_store_4586` failure, which
reproduces by building main's exact source in the same tree (it asserts on the
*member*-target `??=` shape, untouched here).

A dual sweep of the full 286-test `test_gap_*` corpus — same source compiled and run
with a `main`-baseline binary and with this branch, diffing output — reports 2 changed,
both noise:

- `test_gap_console_methods`: `console.time` jitter (`timer1: 0.014ms` → `0.013ms`).
- `test_gap_module_const_local_shadow`: prints a *different garbage float* from an
  uninitialized read. Already in `test-parity/known_failures.json` under #5917, and the
  value is nondeterministic run-to-run on the **`main` binary** as well
  (`1.678e-311` / `2.538e-311` / `3.021e-311` across three runs).

No real behavioural change outside the new fixture.

Note: `lint` and `conformance-smoke` are already red on clean `main` (addr-class
ratchet on `map.rs`; #6297 fixes it).
