### PR TITLE
fix(codegen): restore the numeric array-index fast path for call-returned arrays (#6299)

### DIFF
--- a/crates/perry-codegen/src/collectors/index_uses.rs
+++ b/crates/perry-codegen/src/collectors/index_uses.rs
@@ -496,17 +496,51 @@ pub fn walk_index_uses_in_expr(e: &perry_hir::Expr, out: &mut HashSet<u32>) {
                 walk_index_uses_in_expr(a, out);
             }
         }
+        // (#6299) `arr[i] = v` does NOT always lower to `IndexSet`: when the
+        // receiver isn't a statically-known local array — e.g. it arrived as a
+        // function's return value — the lowerer emits the spec-compliant
+        // `PutValue` form instead. Its `key` IS the array index, so it must be
+        // seeded exactly like `IndexSet`'s `index`; the stored `value` subtree
+        // also holds the matching `arr[i]` read.
+        //
+        // Missing this arm kept the loop counter out of `index_used_locals`, so
+        // it lost its i32 shadow slot at the Let site, which in turn dropped the
+        // guarded numeric array-index fast path for every `arr[i]` in the loop
+        // (6.8x). It was masked until #6258 (`x++`/`x--` no longer counts as
+        // strictly-i32-bounded, correctly — that was an unsound overflow path),
+        // which removed the crutch that had been covering this blind spot.
+        Expr::PutValueSet {
+            target,
+            key,
+            value,
+            receiver,
+            ..
+        } => {
+            collect_index_refs(key, out);
+            walk_index_uses_in_expr(target, out);
+            walk_index_uses_in_expr(key, out);
+            walk_index_uses_in_expr(value, out);
+            walk_index_uses_in_expr(receiver, out);
+        }
         // Closure bodies are intentionally NOT walked: a captured local can't
         // use the i32 slot anyway (boxed captures route through
         // `js_box_get`/`js_box_set` and non-boxed ones through
         // `js_closure_get_capture_bits`), so marking them as index-used would
-        // have no effect at the Let-site emission gate.
+        // have no effect at the Let-site emission gate. This arm precedes the
+        // catch-all below, so the generic walker never descends into a closure.
         Expr::Closure { .. } => {}
-        // Everything else: conservatively skipped. Missing a variant means we
-        // don't recurse further into that subtree — a local used as an index
-        // deeper inside may not be marked, in which case its i32 shadow is
-        // not emitted and the per-iteration `fptosi` cost returns. That's a
-        // missed optimization, not a correctness bug.
-        _ => {}
+        // Everything else: recurse structurally via the centralized walker
+        // (same contract as `collect_ref_ids_in_expr`). Only the explicit
+        // index-using arms above ever *mark* a local, so a total walk cannot
+        // widen the set beyond "locals that flow into an array index" — it just
+        // stops a variant that merely *wraps* an index use (as `PutValueSet`
+        // did) from silently hiding the whole subtree. The old `_ => {}` made
+        // every unlisted variant an opaque wall, which is what let #6299 hide
+        // in plain sight.
+        _ => {
+            perry_hir::walker::walk_expr_children(e, &mut |sub| {
+                walk_index_uses_in_expr(sub, out);
+            });
+        }
     }
 }

--- a/crates/perry-codegen/tests/native_proof_regressions.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions.rs
@@ -13277,5 +13277,106 @@ fn raw_numeric_class_field_rejects_unknown_or_dynamic_shape_receiver() {
     }
 }
 
+/// #6299: a numeric array that arrives as a call's return value must still get
+/// the guarded numeric array-index fast path.
+///
+/// `arr[i] = arr[i] + 1` only lowers to `Expr::IndexSet` when the receiver is a
+/// statically-known local array; for a call-returned array the lowerer emits the
+/// spec-compliant `Expr::PutValueSet` instead. `collect_index_used_locals` had no
+/// arm for that variant (it fell into a `_ => {}` catch-all), so the loop counter
+/// never joined `index_used_locals`, lost its i32 shadow slot, and every `arr[i]`
+/// in the loop fell back from `js_typed_feedback_numeric_array_index_{get,set}_guard`
+/// to the generic `js_array_get_index_or_string` path — a 6.8x cliff.
+///
+/// Asserting on the emitted helper (rather than wall-clock time) pins the actual
+/// codegen decision and stays meaningful under any optimization level.
+#[test]
+fn put_value_set_index_keeps_the_numeric_array_fast_path() {
+    // for (let i = 0; i < arr.length; i++) arr[i] = arr[i] + 1;
+    // with `arr: number[]` written through the generic PutValue form.
+    let arr = 1u32;
+    let i = 2u32;
+    let read_arr_i = Expr::IndexGet {
+        object: Box::new(Expr::LocalGet(arr)),
+        index: Box::new(Expr::LocalGet(i)),
+    };
+    let body = vec![
+        Stmt::Let {
+            id: arr,
+            name: "arr".to_string(),
+            ty: Type::Array(Box::new(Type::Number)),
+            mutable: false,
+            init: Some(Expr::Array(vec![])),
+        },
+        // The array escapes into a call — this is what `const arr = build()`
+        // lowers to (the callee fills the array through a return slot). It is
+        // load-bearing for the repro: an array that stays local is still
+        // hoistable, so `stmt/loops.rs` hands the counter an i32 slot from the
+        // length-hoist path and the fast path survives even with the collector
+        // blind spot. Once the array escapes, that path bails and the counter's
+        // only route to an i32 slot is `index_used_locals` — the set this fix
+        // repairs.
+        Stmt::Expr(Expr::Call {
+            callee: Box::new(Expr::FuncRef(1)),
+            args: vec![Expr::LocalGet(arr)],
+            type_args: Vec::new(),
+            byte_offset: 0,
+        }),
+        Stmt::For {
+            init: Some(Box::new(Stmt::Let {
+                id: i,
+                name: "i".to_string(),
+                ty: Type::Any,
+                mutable: true,
+                init: Some(Expr::Integer(0)),
+            })),
+            condition: Some(Expr::Compare {
+                op: CompareOp::Lt,
+                left: Box::new(Expr::LocalGet(i)),
+                right: Box::new(Expr::PropertyGet {
+                    object: Box::new(Expr::LocalGet(arr)),
+                    property: "length".to_string(),
+                }),
+            }),
+            update: Some(Expr::Update {
+                id: i,
+                op: UpdateOp::Increment,
+                prefix: false,
+            }),
+            body: vec![Stmt::Expr(Expr::PutValueSet {
+                target: Box::new(Expr::LocalGet(arr)),
+                key: Box::new(Expr::LocalGet(i)),
+                value: Box::new(Expr::Binary {
+                    op: BinaryOp::Add,
+                    left: Box::new(read_arr_i),
+                    right: Box::new(Expr::Integer(1)),
+                }),
+                receiver: Box::new(Expr::LocalGet(arr)),
+                strict: false,
+            })],
+        },
+    ];
+
+    let ir = compile_ir("put_value_set_fast_path", body);
+
+    // The loop counter must keep its i32 shadow slot: that is what lets the
+    // guarded helpers take a native i32 index.
+    assert!(
+        ir.contains("alloca i32"),
+        "the `arr[i]` loop counter lost its i32 shadow slot — `index_used_locals` \
+         no longer sees the PutValueSet key (#6299):\n{ir}"
+    );
+    assert!(
+        ir.contains("@js_typed_feedback_numeric_array_index_get_guard"),
+        "`arr[i]` read through PutValueSet's value subtree must keep the guarded \
+         numeric fast path, not fall back to js_array_get_index_or_string (#6299):\n{ir}"
+    );
+    assert!(
+        ir.contains("@js_typed_feedback_numeric_array_index_set_guard"),
+        "`arr[i] = ...` through PutValueSet must keep the guarded numeric store \
+         fast path (#6299):\n{ir}"
+    );
+}
+
 #[path = "native_proof_regressions/invalidation.rs"]
 mod invalidation;


### PR DESCRIPTION
Fixes #6299.

## Root cause

`arr[i] = arr[i] + 1` does **not** always lower to `Expr::IndexSet`. When the receiver isn't a statically-known local array — e.g. it arrived as a function's return value — the lowerer emits the spec-compliant `Expr::PutValueSet { target, key, value, receiver }` form instead.

`collect_index_used_locals` (`crates/perry-codegen/src/collectors/index_uses.rs`) had **no arm for `PutValueSet`**. It fell into the walker's `_ => {}` catch-all, which made the entire subtree opaque — so neither the `key` (which *is* the array index) nor the `arr[i]` read nested in `value` was ever seen.

Consequence, for `for (let i = 0; i < arr.length; i++) arr[i] = arr[i] + 1`:

1. `i` never joins `index_used_locals`;
2. so `needs_i32_slot` fails at the Let site (`stmt/let_stmt.rs`) and `i` loses its i32 shadow slot;
3. so every `arr[i]` read/write falls back from the guarded `js_typed_feedback_numeric_array_index_{get,set}_guard` helpers to the generic `js_array_get_index_or_string` / `js_typed_feedback_array_set_index_or_string` path.

**Why it surfaced now.** The blind spot is old, but it was masked: `collect_strictly_i32_bounded_locals` used to treat an `x++` write as strictly-i32-bounded, which handed the counter an i32 slot regardless. #6258 removed that — correctly, it was an unsound overflow path (#6072: `let big = 2147483640; big++` silently wrapped negative). Removing the crutch exposed the latent `PutValueSet` gap as a 6.8x cliff.

This also explains the issue's "narrow trigger": an array built inline stays hoistable, so `stmt/loops.rs` still hands the counter an i32 slot via the length-hoist path and the fast path survives. Once the array escapes into a call, that path bails and `index_used_locals` is the counter's only remaining route to an i32 slot.

**Note on the reported window.** The bisect in the issue (`83f4fcba5..main`, prime suspect #6253) doesn't hold up: `83f4fcba5` is *already* bad, and reverting `pointer_locals.rs` to its pre-#6253 content changes nothing. The actual first bad commit is `95775b645` (#6258), one commit earlier than the assumed-good base. #6253 is innocent.

## Fix

- Add an explicit `Expr::PutValueSet` arm that seeds `key` as an index (exactly as `IndexSet` seeds `index`) and recurses into `target` / `key` / `value` / `receiver`.
- Replace the dead `_ => {}` catch-all with a structural recursion through `perry_hir::walker::walk_expr_children` — the same contract `collect_ref_ids_in_expr` already uses. Only the explicit index-using arms ever *mark* a local, so a total walk cannot widen the set beyond "locals that flow into an array index"; it just stops a variant that merely *wraps* an index use from hiding the whole subtree.

## Results

Same v0.5.1255 runtime archive on both sides, release compilers, 250k-element array from a call, 25 passes:

| compiler | time | `..._index_get_guard` | `..._index_set_guard` | `js_array_get_index_or_string` |
|---|---|---|---|---|
| `main` @ 0960415ad | **1149 ms** | 1 | 0 | 2 |
| this PR | **166 ms** | 2 | 1 | 1 |
| node 26 | 19 ms | — | — | — |

## Not reintroducing #6072 / #6219

- **#6072 (the overflow #6258 fixed) stays fixed.** A bare accumulator (`big++`, `dn--`) never flows into an array index, so it stays out of `index_used_locals` and off the i32 shadow. `test_gap_6072_i32_update_overflow` is byte-identical to node.
- **#6219 (super-linear codegen on deeply-nested closures) is not reintroduced.** The deliberate `Expr::Closure => {}` arm still *precedes* the catch-all, so the generic walker never descends into closure bodies; the walk stays linear per frame. Measured on a 60-deep nested-closure stress input: 2.93 s (main) vs 2.94 s (this PR). A 400-function array-loop input: 5.93 s vs 4.94 s. This PR touches a different collector than #6253 anyway.

## Testing

- New IR-level regression test `put_value_set_index_keeps_the_numeric_array_fast_path` in `crates/perry-codegen/tests/native_proof_regressions.rs`, asserting the guarded helpers are emitted (not a wall-clock assertion). Verified it **fails** without the source fix and passes with it.
- `cargo test -p perry-codegen`: all green except `manifest_consistency::every_dispatch_entry_has_manifest_counterpart`, which fails identically on unmodified `origin/main` (`ws::readyState` manifest drift — pre-existing, unrelated).
- 45 array/loop/index-heavy gap tests vs node: 39 pass, 6 fail — and all 6 fail identically on `origin/main` (pre-existing). Zero regressions.
- `cargo fmt --all -- --check` clean.

Note: `lint` and `conformance-smoke` are already red on clean `main` (addr-class ratchet on `map.rs`; #6297 fixes it) — unrelated to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed index-use analysis for array assignments where the array receiver isn’t a statically known local, ensuring loop-related locals are correctly recognized.
  * Improved recursive traversal of expression trees so index-relevant locals aren’t missed in previously unhandled expression forms.
* **Performance**
  * Preserved the optimized numeric-array guarded fast path for updates like `arr[i] = arr[i] + 1`, keeping faster guarded index set/get behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->