### PR TITLE
fix(link): ext staticlibs must bundle a full-featured perry-runtime — replace(re, fn) dropped its callback (#6303)

### DIFF
--- a/crates/perry-ext-commander/Cargo.toml
+++ b/crates/perry-ext-commander/Cargo.toml
@@ -13,4 +13,19 @@ perry-ffi.workspace = true
 
 [dev-dependencies]
 perry-ffi = { workspace = true, features = ["runtime-link"] }
-perry-runtime.workspace = true
+# #6303: perry-runtime MUST be built here with the same feature set the shipped
+# `libperry_runtime.a` / `libperry_stdlib.a` carry (i.e. its `default`). This crate
+# is a `staticlib`, so it BUNDLES the perry-runtime rlib objects into
+# `libperry_ext_*.a` — and perry links the ext archives BEFORE stdlib/runtime
+# (`prefer_well_known_before_stdlib`), so those bundled objects WIN the link for
+# every symbol they define. The workspace dep is `default-features = false`, so
+# without `"default"` here a per-crate `cargo build -p perry-ext-<x>` (exactly what
+# release-packages.yml does in its per-crate loop) bundles a runtime with
+# `regex-engine`/`temporal`/... compiled OUT. The dispatchers those features gate
+# are exported UNCONDITIONALLY (`js_string_replace_search_dyn`,
+# `js_native_call_method`, ...) with the feature-gated logic `#[cfg]`-ed out of the
+# BODY — so the degraded copy silently ToString-coerces a RegExp argument and
+# searches for it literally instead of matching it (str.replace(re, fn) never fires
+# its callback). Keep `"default"` in lock-step with perry-runtime's default feature
+# list; `manifest_ext_runtime_features.rs` guards it.
+perry-runtime = { workspace = true, features = ["default"] }

--- a/crates/perry-ext-cron/Cargo.toml
+++ b/crates/perry-ext-cron/Cargo.toml
@@ -15,4 +15,19 @@ chrono = "0.4"
 
 [dev-dependencies]
 perry-ffi = { workspace = true, features = ["runtime-link"] }
-perry-runtime.workspace = true
+# #6303: perry-runtime MUST be built here with the same feature set the shipped
+# `libperry_runtime.a` / `libperry_stdlib.a` carry (i.e. its `default`). This crate
+# is a `staticlib`, so it BUNDLES the perry-runtime rlib objects into
+# `libperry_ext_*.a` — and perry links the ext archives BEFORE stdlib/runtime
+# (`prefer_well_known_before_stdlib`), so those bundled objects WIN the link for
+# every symbol they define. The workspace dep is `default-features = false`, so
+# without `"default"` here a per-crate `cargo build -p perry-ext-<x>` (exactly what
+# release-packages.yml does in its per-crate loop) bundles a runtime with
+# `regex-engine`/`temporal`/... compiled OUT. The dispatchers those features gate
+# are exported UNCONDITIONALLY (`js_string_replace_search_dyn`,
+# `js_native_call_method`, ...) with the feature-gated logic `#[cfg]`-ed out of the
+# BODY — so the degraded copy silently ToString-coerces a RegExp argument and
+# searches for it literally instead of matching it (str.replace(re, fn) never fires
+# its callback). Keep `"default"` in lock-step with perry-runtime's default feature
+# list; `manifest_ext_runtime_features.rs` guards it.
+perry-runtime = { workspace = true, features = ["default"] }

--- a/crates/perry-ext-events/Cargo.toml
+++ b/crates/perry-ext-events/Cargo.toml
@@ -13,4 +13,19 @@ perry-ffi.workspace = true
 
 [dev-dependencies]
 perry-ffi = { workspace = true, features = ["runtime-link"] }
-perry-runtime.workspace = true
+# #6303: perry-runtime MUST be built here with the same feature set the shipped
+# `libperry_runtime.a` / `libperry_stdlib.a` carry (i.e. its `default`). This crate
+# is a `staticlib`, so it BUNDLES the perry-runtime rlib objects into
+# `libperry_ext_*.a` — and perry links the ext archives BEFORE stdlib/runtime
+# (`prefer_well_known_before_stdlib`), so those bundled objects WIN the link for
+# every symbol they define. The workspace dep is `default-features = false`, so
+# without `"default"` here a per-crate `cargo build -p perry-ext-<x>` (exactly what
+# release-packages.yml does in its per-crate loop) bundles a runtime with
+# `regex-engine`/`temporal`/... compiled OUT. The dispatchers those features gate
+# are exported UNCONDITIONALLY (`js_string_replace_search_dyn`,
+# `js_native_call_method`, ...) with the feature-gated logic `#[cfg]`-ed out of the
+# BODY — so the degraded copy silently ToString-coerces a RegExp argument and
+# searches for it literally instead of matching it (str.replace(re, fn) never fires
+# its callback). Keep `"default"` in lock-step with perry-runtime's default feature
+# list; `manifest_ext_runtime_features.rs` guards it.
+perry-runtime = { workspace = true, features = ["default"] }

--- a/crates/perry-ext-fastify/Cargo.toml
+++ b/crates/perry-ext-fastify/Cargo.toml
@@ -36,4 +36,19 @@ socket2 = "0.6"
 
 [dev-dependencies]
 perry-ffi = { workspace = true, features = ["runtime-link"] }
-perry-runtime = { workspace = true, features = ["external-ws-symbols"] }
+# #6303: perry-runtime MUST be built here with the same feature set the shipped
+# `libperry_runtime.a` / `libperry_stdlib.a` carry (i.e. its `default`). This crate
+# is a `staticlib`, so it BUNDLES the perry-runtime rlib objects into
+# `libperry_ext_*.a` — and perry links the ext archives BEFORE stdlib/runtime
+# (`prefer_well_known_before_stdlib`), so those bundled objects WIN the link for
+# every symbol they define. The workspace dep is `default-features = false`, so
+# without `"default"` here a per-crate `cargo build -p perry-ext-<x>` (exactly what
+# release-packages.yml does in its per-crate loop) bundles a runtime with
+# `regex-engine`/`temporal`/... compiled OUT. The dispatchers those features gate
+# are exported UNCONDITIONALLY (`js_string_replace_search_dyn`,
+# `js_native_call_method`, ...) with the feature-gated logic `#[cfg]`-ed out of the
+# BODY — so the degraded copy silently ToString-coerces a RegExp argument and
+# searches for it literally instead of matching it (str.replace(re, fn) never fires
+# its callback). Keep `"default"` in lock-step with perry-runtime's default feature
+# list; `manifest_ext_runtime_features.rs` guards it.
+perry-runtime = { workspace = true, features = ["default", "external-ws-symbols"] }

--- a/crates/perry-ext-fetch/Cargo.toml
+++ b/crates/perry-ext-fetch/Cargo.toml
@@ -18,4 +18,19 @@ lazy_static = "1.5"
 
 [dev-dependencies]
 perry-ffi = { workspace = true, features = ["runtime-link"] }
-perry-runtime = { workspace = true, features = ["external-fetch-symbols"] }
+# #6303: perry-runtime MUST be built here with the same feature set the shipped
+# `libperry_runtime.a` / `libperry_stdlib.a` carry (i.e. its `default`). This crate
+# is a `staticlib`, so it BUNDLES the perry-runtime rlib objects into
+# `libperry_ext_*.a` — and perry links the ext archives BEFORE stdlib/runtime
+# (`prefer_well_known_before_stdlib`), so those bundled objects WIN the link for
+# every symbol they define. The workspace dep is `default-features = false`, so
+# without `"default"` here a per-crate `cargo build -p perry-ext-<x>` (exactly what
+# release-packages.yml does in its per-crate loop) bundles a runtime with
+# `regex-engine`/`temporal`/... compiled OUT. The dispatchers those features gate
+# are exported UNCONDITIONALLY (`js_string_replace_search_dyn`,
+# `js_native_call_method`, ...) with the feature-gated logic `#[cfg]`-ed out of the
+# BODY — so the degraded copy silently ToString-coerces a RegExp argument and
+# searches for it literally instead of matching it (str.replace(re, fn) never fires
+# its callback). Keep `"default"` in lock-step with perry-runtime's default feature
+# list; `manifest_ext_runtime_features.rs` guards it.
+perry-runtime = { workspace = true, features = ["default", "external-fetch-symbols"] }

--- a/crates/perry-ext-http-server/Cargo.toml
+++ b/crates/perry-ext-http-server/Cargo.toml
@@ -40,4 +40,19 @@ socket2 = "0.6"
 
 [dev-dependencies]
 perry-ffi = { workspace = true, features = ["runtime-link"] }
-perry-runtime = { workspace = true, features = ["external-ws-symbols"] }
+# #6303: perry-runtime MUST be built here with the same feature set the shipped
+# `libperry_runtime.a` / `libperry_stdlib.a` carry (i.e. its `default`). This crate
+# is a `staticlib`, so it BUNDLES the perry-runtime rlib objects into
+# `libperry_ext_*.a` — and perry links the ext archives BEFORE stdlib/runtime
+# (`prefer_well_known_before_stdlib`), so those bundled objects WIN the link for
+# every symbol they define. The workspace dep is `default-features = false`, so
+# without `"default"` here a per-crate `cargo build -p perry-ext-<x>` (exactly what
+# release-packages.yml does in its per-crate loop) bundles a runtime with
+# `regex-engine`/`temporal`/... compiled OUT. The dispatchers those features gate
+# are exported UNCONDITIONALLY (`js_string_replace_search_dyn`,
+# `js_native_call_method`, ...) with the feature-gated logic `#[cfg]`-ed out of the
+# BODY — so the degraded copy silently ToString-coerces a RegExp argument and
+# searches for it literally instead of matching it (str.replace(re, fn) never fires
+# its callback). Keep `"default"` in lock-step with perry-runtime's default feature
+# list; `manifest_ext_runtime_features.rs` guards it.
+perry-runtime = { workspace = true, features = ["default", "external-ws-symbols"] }

--- a/crates/perry-ext-http/Cargo.toml
+++ b/crates/perry-ext-http/Cargo.toml
@@ -23,7 +23,22 @@ perry-ext-http-server = { path = "../perry-ext-http-server" }
 # directly. Cargo feature unification keeps the stdlib feature on when
 # both stdlib and this crate link the same perry-runtime — no duplicate
 # symbols, no behaviour change for the default `full` build.
-perry-runtime = { workspace = true, features = ["external-ws-symbols"] }
+# #6303: perry-runtime MUST be built here with the same feature set the shipped
+# `libperry_runtime.a` / `libperry_stdlib.a` carry (i.e. its `default`). This crate
+# is a `staticlib`, so it BUNDLES the perry-runtime rlib objects into
+# `libperry_ext_*.a` — and perry links the ext archives BEFORE stdlib/runtime
+# (`prefer_well_known_before_stdlib`), so those bundled objects WIN the link for
+# every symbol they define. The workspace dep is `default-features = false`, so
+# without `"default"` here a per-crate `cargo build -p perry-ext-<x>` (exactly what
+# release-packages.yml does in its per-crate loop) bundles a runtime with
+# `regex-engine`/`temporal`/... compiled OUT. The dispatchers those features gate
+# are exported UNCONDITIONALLY (`js_string_replace_search_dyn`,
+# `js_native_call_method`, ...) with the feature-gated logic `#[cfg]`-ed out of the
+# BODY — so the degraded copy silently ToString-coerces a RegExp argument and
+# searches for it literally instead of matching it (str.replace(re, fn) never fires
+# its callback). Keep `"default"` in lock-step with perry-runtime's default feature
+# list; `manifest_ext_runtime_features.rs` guards it.
+perry-runtime = { workspace = true, features = ["default", "external-ws-symbols"] }
 reqwest = { version = "0.12", features = ["json", "rustls-tls", "http2"], default-features = false }
 tokio = { workspace = true }
 # Zero-copy body chunks: reqwest::Response::chunk() yields a refcounted

--- a/crates/perry-ext-net/Cargo.toml
+++ b/crates/perry-ext-net/Cargo.toml
@@ -23,4 +23,19 @@ rustls-native-certs = "0.8"
 
 [dev-dependencies]
 perry-ffi = { workspace = true, features = ["runtime-link"] }
-perry-runtime.workspace = true
+# #6303: perry-runtime MUST be built here with the same feature set the shipped
+# `libperry_runtime.a` / `libperry_stdlib.a` carry (i.e. its `default`). This crate
+# is a `staticlib`, so it BUNDLES the perry-runtime rlib objects into
+# `libperry_ext_*.a` — and perry links the ext archives BEFORE stdlib/runtime
+# (`prefer_well_known_before_stdlib`), so those bundled objects WIN the link for
+# every symbol they define. The workspace dep is `default-features = false`, so
+# without `"default"` here a per-crate `cargo build -p perry-ext-<x>` (exactly what
+# release-packages.yml does in its per-crate loop) bundles a runtime with
+# `regex-engine`/`temporal`/... compiled OUT. The dispatchers those features gate
+# are exported UNCONDITIONALLY (`js_string_replace_search_dyn`,
+# `js_native_call_method`, ...) with the feature-gated logic `#[cfg]`-ed out of the
+# BODY — so the degraded copy silently ToString-coerces a RegExp argument and
+# searches for it literally instead of matching it (str.replace(re, fn) never fires
+# its callback). Keep `"default"` in lock-step with perry-runtime's default feature
+# list; `manifest_ext_runtime_features.rs` guards it.
+perry-runtime = { workspace = true, features = ["default"] }

--- a/crates/perry-ext-streams/Cargo.toml
+++ b/crates/perry-ext-streams/Cargo.toml
@@ -14,4 +14,19 @@ lazy_static = "1.5"
 
 [dev-dependencies]
 perry-ffi = { workspace = true, features = ["runtime-link"] }
-perry-runtime.workspace = true
+# #6303: perry-runtime MUST be built here with the same feature set the shipped
+# `libperry_runtime.a` / `libperry_stdlib.a` carry (i.e. its `default`). This crate
+# is a `staticlib`, so it BUNDLES the perry-runtime rlib objects into
+# `libperry_ext_*.a` — and perry links the ext archives BEFORE stdlib/runtime
+# (`prefer_well_known_before_stdlib`), so those bundled objects WIN the link for
+# every symbol they define. The workspace dep is `default-features = false`, so
+# without `"default"` here a per-crate `cargo build -p perry-ext-<x>` (exactly what
+# release-packages.yml does in its per-crate loop) bundles a runtime with
+# `regex-engine`/`temporal`/... compiled OUT. The dispatchers those features gate
+# are exported UNCONDITIONALLY (`js_string_replace_search_dyn`,
+# `js_native_call_method`, ...) with the feature-gated logic `#[cfg]`-ed out of the
+# BODY — so the degraded copy silently ToString-coerces a RegExp argument and
+# searches for it literally instead of matching it (str.replace(re, fn) never fires
+# its callback). Keep `"default"` in lock-step with perry-runtime's default feature
+# list; `manifest_ext_runtime_features.rs` guards it.
+perry-runtime = { workspace = true, features = ["default"] }

--- a/crates/perry-ext-ws/Cargo.toml
+++ b/crates/perry-ext-ws/Cargo.toml
@@ -27,4 +27,19 @@ lazy_static = "1.5"
 
 [dev-dependencies]
 perry-ffi = { workspace = true, features = ["runtime-link"] }
-perry-runtime = { workspace = true, features = ["external-ws-symbols"] }
+# #6303: perry-runtime MUST be built here with the same feature set the shipped
+# `libperry_runtime.a` / `libperry_stdlib.a` carry (i.e. its `default`). This crate
+# is a `staticlib`, so it BUNDLES the perry-runtime rlib objects into
+# `libperry_ext_*.a` — and perry links the ext archives BEFORE stdlib/runtime
+# (`prefer_well_known_before_stdlib`), so those bundled objects WIN the link for
+# every symbol they define. The workspace dep is `default-features = false`, so
+# without `"default"` here a per-crate `cargo build -p perry-ext-<x>` (exactly what
+# release-packages.yml does in its per-crate loop) bundles a runtime with
+# `regex-engine`/`temporal`/... compiled OUT. The dispatchers those features gate
+# are exported UNCONDITIONALLY (`js_string_replace_search_dyn`,
+# `js_native_call_method`, ...) with the feature-gated logic `#[cfg]`-ed out of the
+# BODY — so the degraded copy silently ToString-coerces a RegExp argument and
+# searches for it literally instead of matching it (str.replace(re, fn) never fires
+# its callback). Keep `"default"` in lock-step with perry-runtime's default feature
+# list; `manifest_ext_runtime_features.rs` guards it.
+perry-runtime = { workspace = true, features = ["default", "external-ws-symbols"] }

--- a/crates/perry/tests/manifest_ext_runtime_features.rs
+++ b/crates/perry/tests/manifest_ext_runtime_features.rs
@@ -1,0 +1,110 @@
+//! #6303 — every `perry-ext-*` crate that depends on `perry-runtime` must build
+//! it with perry-runtime's `default` feature set.
+//!
+//! Why this is a *correctness* invariant and not a style rule:
+//!
+//! * The `perry-ext-*` crates are `crate-type = ["staticlib", "rlib"]`. A Rust
+//!   staticlib **bundles its upstream rlib objects**, so `libperry_ext_http.a`
+//!   physically contains a copy of perry-runtime's codegen units.
+//! * `perry compile` links the ext archives *before* stdlib/runtime (see
+//!   `optimized_libs::no_auto::resolve_no_auto_optimized_libs` →
+//!   `prefer_well_known_before_stdlib`). The linker resolves each undefined
+//!   symbol from the first archive that defines it, so the copy bundled inside
+//!   `libperry_ext_*.a` **wins** for every symbol it exports.
+//! * The workspace dependency is declared `default-features = false`
+//!   (root `Cargo.toml`). So a *per-crate* `cargo build -p perry-ext-http` —
+//!   which is exactly what `.github/workflows/release-packages.yml` does in its
+//!   per-crate ext loop — resolves perry-runtime with `regex-engine`,
+//!   `temporal`, `url-engine`, … switched OFF.
+//! * Crucially, the dispatchers those features gate are exported
+//!   **unconditionally** (`js_string_replace_search_dyn`,
+//!   `js_native_call_method`, …): the feature gate sits *inside the function
+//!   body*. A feature-stripped copy therefore still defines the symbol, but with
+//!   the RegExp/Temporal detection `#[cfg]`-ed out — it silently ToString-coerces
+//!   a RegExp argument and searches for `"/re/g"` **literally**.
+//!
+//! Net effect of a violation: `str.replace(re, fn)` where codegen cannot
+//! statically prove `re` is a RegExp (a module-level `var`, an object property,
+//! a function parameter) matches nothing and **never invokes the callback** — a
+//! silent wrong answer, not a crash. That is what stopped Express from booting
+//! (`get-intrinsic`'s `stringToPath` returned `[]` → `%%` → SyntaxError).
+//!
+//! Keeping the bundled copy feature-identical to the shipped one makes the
+//! duplicate harmless whichever archive the linker happens to pick.
+
+use std::path::{Path, PathBuf};
+
+fn workspace_root() -> PathBuf {
+    // CARGO_MANIFEST_DIR = <root>/crates/perry
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root")
+        .to_path_buf()
+}
+
+/// The `perry-runtime = ...` dependency line of a manifest, if there is one.
+/// Only the `[dependencies]`-style `perry-runtime = { ... }` / `perry-runtime.workspace`
+/// forms appear in these crates, so a line-prefix match is sufficient and keeps
+/// this test dependency-free (no toml parser needed).
+fn perry_runtime_dep_line(manifest: &str) -> Option<String> {
+    manifest
+        .lines()
+        .map(str::trim)
+        .find(|l| l.starts_with("perry-runtime.workspace") || l.starts_with("perry-runtime ="))
+        .map(str::to_string)
+}
+
+#[test]
+fn ext_crates_bundle_a_full_featured_perry_runtime() {
+    let root = workspace_root();
+    let crates_dir = root.join("crates");
+    let mut checked = 0usize;
+    let mut violations: Vec<String> = Vec::new();
+
+    let entries = std::fs::read_dir(&crates_dir).expect("read crates/");
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if !name.starts_with("perry-ext-") {
+            continue;
+        }
+        let manifest_path = entry.path().join("Cargo.toml");
+        let Ok(manifest) = std::fs::read_to_string(&manifest_path) else {
+            continue;
+        };
+        let Some(dep_line) = perry_runtime_dep_line(&manifest) else {
+            // Crate doesn't link perry-runtime at all (perry-ffi only) — it
+            // cannot bundle a divergent copy, so it is not in scope.
+            continue;
+        };
+        checked += 1;
+
+        // `perry-runtime.workspace = true` inherits `default-features = false`
+        // from the workspace dep and adds nothing back — always a violation.
+        // Otherwise the explicit `features = [...]` list must contain "default".
+        let ok = dep_line.contains("features") && dep_line.contains("\"default\"");
+        if !ok {
+            violations.push(format!("  {name}: {dep_line}"));
+        }
+    }
+
+    assert!(
+        checked > 0,
+        "found no perry-ext-* crate depending on perry-runtime — did the crate \
+         layout change? This guard would silently pass forever."
+    );
+
+    assert!(
+        violations.is_empty(),
+        "#6303: these perry-ext-* crates bundle a feature-stripped perry-runtime \
+         into their staticlib.\n\
+         They are linked BEFORE stdlib/runtime, so their copy wins the link and \
+         silently degrades every\n\
+         unconditionally-exported dispatcher whose body is feature-gated \
+         (js_string_replace_search_dyn,\n\
+         js_native_call_method, ...) — e.g. `str.replace(re, fn)` stops invoking \
+         its callback.\n\
+         Add \"default\" to the perry-runtime `features` list:\n{}",
+        violations.join("\n")
+    );
+}

--- a/test-files/test_gap_regex_replace_dyn_regex_with_http.ts
+++ b/test-files/test_gap_regex_replace_dyn_regex_with_http.ts
@@ -1,0 +1,59 @@
+// #6303 — `String.prototype.replace(re, fn)` must invoke the replacer callback
+// even when codegen cannot statically prove the search value is a RegExp AND the
+// program links a `perry-ext-*` staticlib (here `http`).
+//
+// The ext archives bundle their own copy of perry-runtime and are linked BEFORE
+// stdlib/runtime, so a copy built without `regex-engine` used to win the link for
+// the unconditionally-exported dispatchers (`js_string_replace_search_dyn`,
+// `js_native_call_method`) — whose RegExp detection is `#[cfg]`-ed out of the
+// function BODY. The RegExp then got ToString-coerced and searched for literally,
+// so the callback fired ZERO times and `replace` returned the subject unchanged.
+//
+// Both halves are required to reproduce:
+//   1. `http` (any perry-ext-* lib that bundles perry-runtime) is linked, and
+//   2. the regex reaches `.replace` through a value codegen can't type as a
+//      RegExp (an object property / a module-level `var`), which routes through
+//      `js_string_replace_search_dyn` instead of the statically-typed
+//      `js_string_replace_regex_fn`.
+//
+// This is get-intrinsic's `stringToPath`, which is what blocked Express boot: it
+// returned `[]`, so `'%' + '' + '%'` threw `SyntaxError: intrinsic %% does not exist!`.
+import * as http from 'http';
+
+// get-intrinsic's rePropName: carries a backreference (\2) and a lookahead, so it
+// also exercises the fancy-regex fallback path.
+const rePropName =
+  /[^%.[\]]+|\[(?:(-?\d+(?:\.\d+)?)|(["'])((?:(?!\2)[^\\]|\\.)*?)\2)\]|(?=(?:\.|\[\])(?:\.|\[\]|%$))/g;
+const reSimple = /[^.]+/g;
+
+// Read through an object property: codegen cannot statically type these as RegExp,
+// so they lower to the runtime `searchValue` dispatcher (#4871).
+const holder: { fancy: RegExp; simple: RegExp } = { fancy: rePropName, simple: reSimple };
+
+function stringToPath(s: string): string[] {
+  const out: string[] = [];
+  s.replace(holder.fancy, function (m: string, num: string): string {
+    out[out.length] = num || m;
+    return '';
+  } as any);
+  return out;
+}
+
+let simpleCalls = 0;
+const simpleOut = 'a.b.c'.replace(holder.simple, function (m: string): string {
+  simpleCalls++;
+  return m.toUpperCase();
+} as any);
+
+console.log('fancy dyn :', JSON.stringify(stringToPath('%String.prototype.indexOf%')));
+console.log('simple dyn:', simpleOut, simpleCalls);
+
+// Force the `perry-ext-http` staticlib — and therefore its bundled perry-runtime
+// copy — into the link. Constructing the server is enough: it pulls
+// `js_node_http_create_server_with_options` out of `libperry_ext_http.a`, which
+// drags in that archive's perry-runtime codegen units. No `listen` needed (this
+// test is about the link, not about serving).
+const server = http.createServer(function (_req: any, res: any): void {
+  res.end('ok');
+});
+console.log('server    :', typeof server.listen === 'function');


### PR DESCRIPTION
Fixes #6303. Unblocks Express boot (the last blocker in #3527 — every bug in that issue's original inventory is now fixed; this is the one that replaced them).

## TL;DR

`String.prototype.replace(re, fn)` invoked its replacer callback **zero times**, silently returning the subject unchanged, whenever the program linked a `perry-ext-*` archive **and** the RegExp reached `.replace` through a value codegen could not statically type as a RegExp.

The issue framed this as *fancy-regex-specific* and *scale-emergent*. **It is neither.** A plain `/[^.]+/g` read from an object property fails identically, and the real discriminator is simply **"does the program link an ext staticlib"** — a 3-module program reproduces it. Module count is a coincidence (Express uses `http`; the 35-module graph did not).

## Root cause: a divergent, feature-stripped duplicate of perry-runtime

1. The `perry-ext-*` crates are `crate-type = ["staticlib", "rlib"]`. A Rust staticlib **bundles its upstream rlib objects**, so `libperry_ext_http.a` physically contains a copy of perry-runtime's codegen units.
2. The workspace dep is `perry-runtime = { ..., default-features = false }`, and the ext crates asked for nothing back. So a **per-crate** `cargo build -p perry-ext-http` — exactly what `release-packages.yml` does in its best-effort per-crate ext loop — bundles a perry-runtime with `regex-engine`, `temporal`, … **compiled out**.
3. `strip_bundled_runtime_from_well_known_lib` is meant to drop those bundled CGUs, but Rule 1 matches members by **name containment** against stdlib's archive. A different feature set ⇒ a different codegen-unit hash ⇒ the containment check misses and the strip **silently no-ops**:

```
libperry_ext_http.a : perry_runtime-9cc0c5804e3dc717.….rcgu.o     (regex-engine OFF)
libperry_stdlib.a   : perry_runtime-f959e593f6355055.….rcgu.o     (regex-engine ON)
```

4. perry links the ext archives **before** stdlib/runtime (`prefer_well_known_before_stdlib`), so the surviving stripped copy **wins the link** for every symbol it defines.
5. The dispatchers those features gate are exported **unconditionally** — `js_string_replace_search_dyn`, `js_native_call_method` — with the `#[cfg]` sitting **inside the function body**. The degraded copy still *defines* the symbol, just with the RegExp detection compiled out:

```rust
pub extern "C" fn js_string_replace_search_dyn(s, needle, replacement) -> *mut StringHeader {
    #[cfg(feature = "regex-engine")]                     // <- GONE in the stripped copy
    if let Some(re) = needle_regex_ptr(needle) { return js_string_replace_regex_dyn(...); }
    js_string_replace_string_dyn(s, js_string_coerce(needle), replacement)   // <- always taken
}
```

So the RegExp was **ToString-coerced and searched for literally** (`"/[^%.[\\]]+|…/g"` as a substring). No match ⇒ callback never fires ⇒ `replace` returns the subject unchanged.

### Why every discriminator in the issue lines up

| observation | explanation |
|---|---|
| `re.exec(s)` works | `js_regexp_exec` is `#[cfg]`-gated, so it **doesn't exist** in the stripped copy — the linker must take it from the real `libperry_runtime.a`. |
| a **literal** regex + callback works | codegen statically types it and emits `js_string_replace_regex_fn`, also `#[cfg]`-gated ⇒ real copy. |
| a regex in a **variable/property** fails | codegen can't type it ⇒ `js_string_replace_search_dyn`, which exists in **both** copies ⇒ poisoned copy wins. |
| "only at graph scale" | not scale — the program just has to link an ext archive. |
| "fancy-regex path" | incidental: `rePropName` is a module-level `var`, so it takes the *dynamic* dispatcher. Fancy has nothing to do with it. |

`get-intrinsic`'s `stringToPath` therefore returned `[]` → `intrinsicBaseName = ''` → `'%' + '' + '%'` → `%%` → `SyntaxError: intrinsic %% does not exist!`, which is what stopped Express from booting.

## The fix

Every `perry-ext-*` crate that depends on perry-runtime now requests its **`default`** feature set, so the bundled copy is feature-identical to the shipped `libperry_runtime.a` and is harmless whichever archive the linker picks.

`regex-engine` alone would **not** be enough: `native_call_method.rs` carries the same in-body gate for `temporal`, so the same class of silent degradation was latent for `Temporal` (and any future gated feature). Matching the shipped feature set kills the whole class.

## Verification

Minimal repro (3 modules — no Express, no fancy regex needed):

```ts
import * as http from 'http';          // links libperry_ext_http.a
const re = /[^.]+/g;                   // plain regex
const holder = { re };                 // read via property -> dynamic dispatcher
'a.b.c'.replace(holder.re, (m) => m.toUpperCase());
```

| | before | after | node |
|---|---|---|---|
| plain `/[^.]+/g` via property | `a.b.c` (cb fired **0**×) | `A.B.C` (cb 3×) | `A.B.C` |
| get-intrinsic `rePropName` (backref + lookahead) | `[]` | `["String","prototype","indexOf"]` | `["String","prototype","indexOf"]` |

**Express 5.2.1 now boots and serves:**

```
$ ./app_bin
listening on 3000
$ curl localhost:3000/
hello from perry          status=200
```

(Both verified against a *per-crate*-built `libperry_ext_http.a`, i.e. the exact build shape the release workflow produces, so the fix is exercised on the path that was actually broken.)

## What's in the diff

- **10 × `crates/perry-ext-*/Cargo.toml`** — add `"default"` to the `perry-runtime` features, with a comment explaining why it is a correctness invariant and not a style choice.
- **`crates/perry/tests/manifest_ext_runtime_features.rs`** — guard test; fails if any `perry-ext-*` crate links perry-runtime without `"default"`. Verified it fails on the pre-fix manifests and passes after.
- **`test-files/test_gap_regex_replace_dyn_regex_with_http.ts`** — regression fixture pinning both the fancy (backreference + lookahead) and the plain regex through the dynamic `searchValue` dispatcher in a program that links `http`. Byte-identical to `node`; verified it reproduces the bug on the pre-fix archives.

## Follow-up (pre-existing, NOT introduced here)

The same duplicate-runtime shape has a second consequence I did **not** fix, because it reproduces identically **without** this change and needs a maintainer call on the build graph:

`perry-runtime/src/stdlib_stubs.rs` defines no-op `#[no_mangle]` stubs (`js_stdlib_init_dispatch`, ws, fetch, readline) on the assumption that *"the linker picks stdlib over runtime since only one is ever linked."* That assumption also breaks when an ext archive bundles perry-runtime and is linked first: `js_stdlib_init_dispatch` resolves to the **no-op stub**, perry-stdlib's real dispatch init never runs, and `spawn_blocking_with_reactor` is never registered — so a `node:http` server panics with *"there is no reactor running"*.

It is masked whenever the archives happen to be built in one cargo invocation (feature unification ⇒ matching CGU hashes ⇒ strip-dedup removes the bundled copy entirely), which is why it doesn't bite in a coherent workspace build. The durable fix is to make the ext archives bundle the *same* perry-runtime unit as stdlib (or to make strip-dedup's Rule 1 hash-insensitive) rather than relying on name containment. Filed as #6314.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved runtime feature consistency across extension modules so bundled runtime behavior matches the shipped defaults when extensions are linked into applications.
  - Fixed a regression where dynamic regular-expression `replace` callbacks might not run correctly in HTTP-enabled scenarios.

- **Tests**
  - Added a workspace check to ensure all extension modules enable the required runtime default feature set.
  - Added a new regression test covering the dynamic regex `replace` behavior when used with the HTTP extension.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->