### PR TITLE
fix(codegen): prove the dynamic-bound loop counter stays in i32 (#6072)

### DIFF
--- a/crates/perry-codegen/src/stmt/loops.rs
+++ b/crates/perry-codegen/src/stmt/loops.rs
@@ -100,14 +100,19 @@ struct LengthHoistRejection {
 /// only on a guard-passing block so NaN, infinities, fractional values, and
 /// out-of-i32-range values keep JS comparison semantics.
 struct DynamicI32Bound {
-    counter_id: u32,
     op: perry_hir::CompareOp,
-    /// `i1` slot: true when `n` was a finite integral i32 at loop entry.
+    /// `i1` slot: true when the guard proved, at loop entry, that the whole
+    /// `icmp` loop stays inside i32 — see [`emit_guarded_i32_bound`].
     flag_slot: String,
     /// `i32` slot holding `fptosi(n)` (valid only when `flag_slot` is true).
     bound_i32_slot: String,
-    /// Whether we allocated the counter's i32 slot (so we remove it at exit).
-    counter_i32_was_fresh: bool,
+    /// `i32` slot the fast cond block compares against `bound_i32_slot`.
+    counter_i32_slot: String,
+    /// True when `counter_i32_slot` is loop-private: allocated here and
+    /// deliberately NOT published in `ctx.i32_counter_slots`, so the loop body
+    /// and the slow cond keep reading the counter's f64 slot (#6072). The
+    /// update block bumps it by hand in that case.
+    counter_is_private: bool,
 }
 
 #[derive(Clone)]
@@ -2057,20 +2062,76 @@ fn is_packed_f64_loop_index(
     )
 }
 
+/// Emit the one-time loop-entry guard behind the dynamic-bound `icmp` fast
+/// loop, and pick the i32 counter it compares.
+///
+/// The counter comes from one of two places:
+///
+/// * It already owns a **shared** i32 shadow (`ctx.i32_counter_slots`, put
+///   there at its `Let` site because it is index-used / strictly-i32-bounded).
+///   Every read of the local in this loop already comes from that shadow, so
+///   reusing it for the `icmp` introduces no new representation and no new
+///   hazard — the array-index fast path keeps working exactly as before.
+/// * It has no shadow. #6072: the old code installed one **into the shared
+///   map** right here, with nothing proving that the counter stays inside i32.
+///   A runtime bound above `INT32_MAX` — `for (let i = 2147483640; i < lim;
+///   i++)` with `lim = 2147483653` — wrapped the shadow to `INT32_MIN`, and
+///   because every `LocalGet` prefers the shadow over the f64 slot (issue #48),
+///   the counter went negative and the loop spun forever. Even the *slow*
+///   (guard-failed) cond read the wrapped shadow, so the runtime guard could
+///   not save it. Now we allocate a **loop-private** i32 counter that never
+///   enters the map: only the fast cond block reads it, the update block bumps
+///   it, and the body / slow cond keep reading the f64 slot, which `Update`
+///   maintains with exact JS semantics.
+///
+/// The guard proves, once, that the fast loop cannot leave i32 range:
+///
+/// * `n` is a number, integral, and `>= INT32_MIN`;
+/// * `n <= INT32_MAX` for `i < n` — the counter is only bumped after a taken
+///   `i < n`, so it tops out at `n`;
+/// * `n <= INT32_MAX - 1` for `i <= n` — there the counter tops out at `n + 1`;
+/// * (private counter only) the counter's entry value is itself an integral
+///   number in i32 range, so the initial `fptosi` is well-defined and the
+///   counter starts no higher than `INT32_MAX`.
+///
+/// Anything else (NaN, infinities, fractional or out-of-i32-range bounds,
+/// non-numbers, a counter seeded past 2^31) leaves the flag false and runs the
+/// generic per-iteration comparison with full JS semantics.
 fn emit_guarded_i32_bound(
     ctx: &mut FnCtx<'_>,
     counter_id: u32,
     bound_id: u32,
     op: perry_hir::CompareOp,
+    update: Option<&perry_hir::Expr>,
+    body: &[perry_hir::Stmt],
     label_prefix: &str,
 ) -> Option<DynamicI32Bound> {
     let bound_slot = ctx.locals.get(&bound_id).cloned()?;
-    let counter_i32_was_fresh = ensure_loop_counter_i32_slot(ctx, counter_id)?;
+    let counter_slot = ctx.locals.get(&counter_id).cloned()?;
+    let shared_counter_i32 = ctx.i32_counter_slots.get(&counter_id).cloned();
+    let counter_is_private = shared_counter_i32.is_none();
+    if counter_is_private && !dynamic_bound_private_counter_is_safe(ctx, counter_id, update, body) {
+        return None;
+    }
+    let counter_i32_slot = match shared_counter_i32 {
+        Some(slot) => slot,
+        None => ctx.func.alloca_entry(I32),
+    };
+
+    // `i <= n` bumps the counter one past the bound on the last iteration, so
+    // the largest bound it can carry without overflowing is `INT32_MAX - 1`.
+    let max_bound = match op {
+        perry_hir::CompareOp::Le => "2147483646.0",
+        _ => "2147483647.0",
+    };
 
     let flag_slot = ctx.func.alloca_entry(I1);
     let bound_i32_slot = ctx.func.alloca_entry(I32);
     ctx.block().store(I1, "false", &flag_slot);
     ctx.block().store(I32, "0", &bound_i32_slot);
+    if counter_is_private {
+        ctx.block().store(I32, "0", &counter_i32_slot);
+    }
 
     let n_dbl = ctx.block().load(DOUBLE, &bound_slot);
     let is_number = emit_js_value_is_number(ctx, &n_dbl);
@@ -2085,7 +2146,7 @@ fn emit_guarded_i32_bound(
 
     ctx.current_block = number_idx;
     let ge_min = ctx.block().fcmp("oge", &n_dbl, "-2147483648.0");
-    let le_max = ctx.block().fcmp("ole", &n_dbl, "2147483647.0");
+    let le_max = ctx.block().fcmp("ole", &n_dbl, max_bound);
     let in_i32_range = ctx.block().and(I1, &ge_min, &le_max);
     ctx.block()
         .cond_br(&in_i32_range, &convert_label, &merge_label);
@@ -2094,31 +2155,91 @@ fn emit_guarded_i32_bound(
     let bound_i32 = ctx.block().fptosi(DOUBLE, &n_dbl, I32);
     let roundtrip = ctx.block().sitofp(I32, &bound_i32, DOUBLE);
     let is_integral = ctx.block().fcmp("oeq", &roundtrip, &n_dbl);
-    ctx.block().store(I1, &is_integral, &flag_slot);
     ctx.block().store(I32, &bound_i32, &bound_i32_slot);
+    if !counter_is_private {
+        // The shared shadow was already seeded (and range-checked) at the
+        // counter's `Let` site; only the bound needs proving here.
+        ctx.block().store(I1, &is_integral, &flag_slot);
+        ctx.block().br(&merge_label);
+        ctx.current_block = merge_idx;
+        return Some(DynamicI32Bound {
+            op,
+            flag_slot,
+            bound_i32_slot,
+            counter_i32_slot,
+            counter_is_private,
+        });
+    }
+
+    // Private counter: seed it from the f64 slot, but only on a block the
+    // range check dominates — `fptosi` of an out-of-range double is poison.
+    // A non-number counter (every NaN-boxed tag is a NaN double) fails the
+    // ordered compares below and takes the generic path.
+    let counter_idx = ctx.new_block(&format!("{label_prefix}.counter_i32.range"));
+    let counter_conv_idx = ctx.new_block(&format!("{label_prefix}.counter_i32.convert"));
+    let counter_label = ctx.block_label(counter_idx);
+    let counter_conv_label = ctx.block_label(counter_conv_idx);
+    ctx.block()
+        .cond_br(&is_integral, &counter_label, &merge_label);
+
+    ctx.current_block = counter_idx;
+    let c_dbl = ctx.block().load(DOUBLE, &counter_slot);
+    let c_ge_min = ctx.block().fcmp("oge", &c_dbl, "-2147483648.0");
+    let c_le_max = ctx.block().fcmp("ole", &c_dbl, "2147483647.0");
+    let c_in_range = ctx.block().and(I1, &c_ge_min, &c_le_max);
+    ctx.block()
+        .cond_br(&c_in_range, &counter_conv_label, &merge_label);
+
+    ctx.current_block = counter_conv_idx;
+    let c_i32 = ctx.block().fptosi(DOUBLE, &c_dbl, I32);
+    let c_roundtrip = ctx.block().sitofp(I32, &c_i32, DOUBLE);
+    let c_is_integral = ctx.block().fcmp("oeq", &c_roundtrip, &c_dbl);
+    ctx.block().store(I32, &c_i32, &counter_i32_slot);
+    ctx.block().store(I1, &c_is_integral, &flag_slot);
     ctx.block().br(&merge_label);
 
     ctx.current_block = merge_idx;
     Some(DynamicI32Bound {
-        counter_id,
         op,
         flag_slot,
         bound_i32_slot,
-        counter_i32_was_fresh,
+        counter_i32_slot,
+        counter_is_private,
     })
 }
 
-fn ensure_loop_counter_i32_slot(ctx: &mut FnCtx<'_>, counter_id: u32) -> Option<bool> {
-    if ctx.i32_counter_slots.contains_key(&counter_id) {
-        return Some(false);
+/// Static preconditions for handing a dynamic-bound loop a *loop-private* i32
+/// counter (#6072).
+///
+/// The private shadow is maintained by this loop alone — the update block bumps
+/// it by hand, because the counter is not in `ctx.i32_counter_slots` and so the
+/// generic `Update` / `LocalSet` lowerings never see it. That is only correct
+/// when the loop's own `i++` is the *only* thing that ever advances the
+/// counter, and when the counter lives in a plain f64 alloca (a boxed/captured
+/// or module-global counter is read through a box/root helper, which a stack
+/// shadow could not track).
+fn dynamic_bound_private_counter_is_safe(
+    ctx: &crate::expr::FnCtx<'_>,
+    counter_id: u32,
+    update: Option<&perry_hir::Expr>,
+    body: &[perry_hir::Stmt],
+) -> bool {
+    use perry_hir::{Expr, UpdateOp};
+    if !ctx.locals.contains_key(&counter_id)
+        || ctx.boxed_vars.contains(&counter_id)
+        || ctx.module_globals.contains_key(&counter_id)
+    {
+        return false;
     }
-    let counter_slot = ctx.locals.get(&counter_id).cloned()?;
-    let i32_slot = ctx.func.alloca_entry(I32);
-    let cur_dbl = ctx.block().load(DOUBLE, &counter_slot);
-    let cur_i32 = ctx.block().fptosi(DOUBLE, &cur_dbl, I32);
-    ctx.block().store(I32, &cur_i32, &i32_slot);
-    ctx.i32_counter_slots.insert(counter_id, i32_slot);
-    Some(true)
+    let advanced_by_increment = matches!(
+        update,
+        Some(Expr::Update {
+            id,
+            op: UpdateOp::Increment,
+            ..
+        }) if *id == counter_id
+    );
+    advanced_by_increment && !stmts_mutate_local(body, counter_id)
 }
 
 fn emit_js_value_is_number(ctx: &mut FnCtx<'_>, value: &str) -> String {
@@ -2428,16 +2549,17 @@ fn lower_for_after_init_with_i32_bound(
     // finite-integral-i32 guard and `fptosi(n)` once here, in the pre-loop
     // block, so the cond block can pick an `icmp slt/sle i32` fast loop when
     // safe and fall back to the generic comparison otherwise.
-    let dynamic_i32_bound: Option<DynamicI32Bound> =
-        if hoist_classification.is_none() && local_bound_classification.is_none() {
-            condition
-                .and_then(|cond| classify_for_local_bound_dynamic(cond, update, body, ctx))
-                .and_then(|(counter_id, bound_id, op)| {
-                    emit_guarded_i32_bound(ctx, counter_id, bound_id, op, label_prefix)
-                })
-        } else {
-            None
-        };
+    let dynamic_i32_bound: Option<DynamicI32Bound> = if hoist_classification.is_none()
+        && local_bound_classification.is_none()
+    {
+        condition
+            .and_then(|cond| classify_for_local_bound_dynamic(cond, update, body, ctx))
+            .and_then(|(counter_id, bound_id, op)| {
+                emit_guarded_i32_bound(ctx, counter_id, bound_id, op, update, body, label_prefix)
+            })
+    } else {
+        None
+    };
     let local_bound_index_bounds_are_safe =
         local_bound_classification.is_some_and(|(counter_id, _, op)| {
             matches!(op, perry_hir::CompareOp::Lt)
@@ -2561,43 +2683,46 @@ fn lower_for_after_init_with_i32_bound(
         }
     } else if let Some(ref dyn_bound) = dynamic_i32_bound {
         // Issue #168 follow-up: `i < n` / `i <= n` with a runtime-guarded
-        // local bound. Branch on the one-time finite-integral-i32 flag
-        // hoisted above: the fast loop uses `icmp`, and the slow loop keeps
-        // full JS comparison semantics. The branch is loop-invariant, so
-        // LLVM's LoopUnswitch peels it into two loops at -O2+; even
-        // unswitched, the hot path executes pure integer compares with no
-        // per-iteration `sitofp` / call.
-        if let Some(ctr_i32_slot) = ctx.i32_counter_slots.get(&dyn_bound.counter_id).cloned() {
-            let fast_idx = ctx.new_block(&format!("{label_prefix}.cond.fast"));
-            let slow_idx = ctx.new_block(&format!("{label_prefix}.cond.slow"));
-            let fast_label = ctx.block_label(fast_idx);
-            let slow_label = ctx.block_label(slow_idx);
-            let flag = ctx.block().load(I1, &dyn_bound.flag_slot);
-            ctx.block().cond_br(&flag, &fast_label, &slow_label);
+        // local bound. Branch on the one-time guard flag hoisted above: the
+        // fast loop uses `icmp`, and the slow loop keeps full JS comparison
+        // semantics. The branch is loop-invariant, so LLVM's LoopUnswitch peels
+        // it into two loops at -O2+; even unswitched, the hot path executes
+        // pure integer compares with no per-iteration `sitofp` / call.
+        //
+        // #6072: when the counter's i32 slot is loop-private, the slow cond
+        // below re-lowers the condition with the counter absent from
+        // `ctx.i32_counter_slots`, so it reads the f64 slot — the one the
+        // `Update` lowering keeps at exact JS semantics. That is what makes a
+        // guard failure (e.g. a bound past `INT32_MAX`) merely slow instead of
+        // an infinite loop over a wrapped counter.
+        let ctr_i32_slot = dyn_bound.counter_i32_slot.clone();
+        let fast_idx = ctx.new_block(&format!("{label_prefix}.cond.fast"));
+        let slow_idx = ctx.new_block(&format!("{label_prefix}.cond.slow"));
+        let fast_label = ctx.block_label(fast_idx);
+        let slow_label = ctx.block_label(slow_idx);
+        let flag = ctx.block().load(I1, &dyn_bound.flag_slot);
+        ctx.block().cond_br(&flag, &fast_label, &slow_label);
 
-            // Fast path: integer induction variable + `icmp`.
-            ctx.current_block = fast_idx;
-            let ctr = ctx.block().load(I32, &ctr_i32_slot);
-            let bound = ctx.block().load(I32, &dyn_bound.bound_i32_slot);
-            let cmp = match dyn_bound.op {
-                perry_hir::CompareOp::Le => ctx.block().icmp_sle(I32, &ctr, &bound),
-                _ => ctx.block().icmp_slt(I32, &ctr, &bound),
-            };
-            ctx.block().cond_br(&cmp, &body_label, &exit_label);
+        // Fast path: integer induction variable + `icmp`.
+        ctx.current_block = fast_idx;
+        let ctr = ctx.block().load(I32, &ctr_i32_slot);
+        let bound = ctx.block().load(I32, &dyn_bound.bound_i32_slot);
+        let cmp = match dyn_bound.op {
+            perry_hir::CompareOp::Le => ctx.block().icmp_sle(I32, &ctr, &bound),
+            _ => ctx.block().icmp_slt(I32, &ctr, &bound),
+        };
+        ctx.block().cond_br(&cmp, &body_label, &exit_label);
 
-            // Slow path: generic per-iteration comparison (full coercion).
-            ctx.current_block = slow_idx;
-            if let Some(cond_expr) = condition {
-                let cv = lower_expr(ctx, cond_expr)?;
-                let i1 = lower_truthy(ctx, &cv, cond_expr);
-                ctx.block().cond_br(&i1, &body_label, &exit_label);
-            } else {
-                ctx.block().br(&body_label);
-            }
-            true
+        // Slow path: generic per-iteration comparison (full coercion).
+        ctx.current_block = slow_idx;
+        if let Some(cond_expr) = condition {
+            let cv = lower_expr(ctx, cond_expr)?;
+            let i1 = lower_truthy(ctx, &cv, cond_expr);
+            ctx.block().cond_br(&i1, &body_label, &exit_label);
         } else {
-            false
+            ctx.block().br(&body_label);
         }
+        true
     } else {
         false
     };
@@ -2663,6 +2788,22 @@ fn lower_for_after_init_with_i32_bound(
     if let Some(update_expr) = update {
         let _ = lower_expr(ctx, update_expr)?;
     }
+    // #6072: a loop-private i32 counter is invisible to the `Update` lowering
+    // (it is not in `ctx.i32_counter_slots`), so advance it here. The classifier
+    // proved the update is exactly `counter++` and that nothing else writes the
+    // counter, so this stays in lockstep with the f64 slot. The `add` wraps
+    // (LLVM `add` without `nsw`) if the guard failed, but nothing reads this
+    // slot then — only the fast cond block does, and it is unreachable with a
+    // false flag.
+    if let Some(ref dyn_bound) = dynamic_i32_bound {
+        if dyn_bound.counter_is_private && !ctx.block().is_terminated() {
+            let slot = dyn_bound.counter_i32_slot.clone();
+            let blk = ctx.block();
+            let cur = blk.load(I32, &slot);
+            let next = blk.add(I32, &cur, "1");
+            blk.store(I32, &next, &slot);
+        }
+    }
     if !ctx.block().is_terminated() {
         ctx.block().br(&cond_label);
     }
@@ -2688,12 +2829,10 @@ fn lower_for_after_init_with_i32_bound(
         }
     }
     let _ = i32_local_bound_slot;
-    // Same cleanup for the runtime-guarded `any`-bound path.
-    if let Some(dyn_bound) = dynamic_i32_bound {
-        if dyn_bound.counter_i32_was_fresh {
-            ctx.i32_counter_slots.remove(&dyn_bound.counter_id);
-        }
-    }
+    // The runtime-guarded `any`-bound path needs no cleanup: it either reuses
+    // the counter's existing (Let-site) i32 slot or keeps its own private one
+    // out of `ctx.i32_counter_slots` entirely (#6072).
+    let _ = dynamic_i32_bound;
     ctx.bounded_index_pairs
         .retain(|fact| fact.scope_id != loop_proof_scope_id);
     ctx.bounded_buffer_index_pairs

--- a/test-files/test_gap_6072_dynamic_bound_counter.ts
+++ b/test-files/test_gap_6072_dynamic_bound_counter.ts
@@ -1,0 +1,83 @@
+// #6072 repro 2: a `for` counter whose loop bound is a runtime value (not a
+// constant) must not be put on a wrapping i32 shadow. Before the fix the
+// counter wrapped to INT32_MIN at 2^31 and the loop never terminated.
+//
+// Every loop below carries a hard iteration cap so a regression fails the
+// parity diff instead of hanging the suite.
+
+// `parseInt` keeps the bound opaque to constant folding.
+const lim = parseInt("2147483653", 10);
+
+let iters = 0;
+const seen: number[] = [];
+for (let i = 2147483640; i < lim; i++) {
+  iters++;
+  if (iters > 50) {
+    console.log("BUG: dynamic-bound loop did not terminate");
+    break;
+  }
+  seen.push(i);
+}
+console.log("cross-2^31 iters:", iters);
+console.log("cross-2^31 first/last:", seen[0], seen[seen.length - 1]);
+
+// `i <= n` tops out one past the bound — INT32_MAX itself must not be a fast
+// bound, or the last increment overflows.
+const atMax = parseInt("2147483647", 10);
+let leIters = 0;
+let leLast = 0;
+for (let i = 2147483645; i <= atMax; i++) {
+  leIters++;
+  if (leIters > 50) {
+    console.log("BUG: <= loop did not terminate");
+    break;
+  }
+  leLast = i;
+}
+console.log("le iters:", leIters, "last:", leLast);
+
+// A counter seeded past 2^31 with a runtime bound: the entry value itself does
+// not fit in an i32, so the guard must reject the fast loop outright.
+const hiLim = parseInt("3000000005", 10);
+let hiIters = 0;
+const hiSeen: number[] = [];
+for (let i = 3000000000; i < hiLim; i++) {
+  hiIters++;
+  if (hiIters > 50) {
+    console.log("BUG: high-seed loop did not terminate");
+    break;
+  }
+  hiSeen.push(i);
+}
+console.log("high-seed iters:", hiIters, "seen:", hiSeen.join(","));
+
+// Ordinary runtime-bounded counters must stay correct (and stay fast).
+const n = parseInt("1000", 10);
+let sum = 0;
+for (let i = 0; i < n; i++) sum += i;
+console.log("sum:", sum);
+
+// Runtime-bounded array-index loop: keeps the guarded numeric fast path.
+const arr: number[] = new Array(n).fill(0);
+for (let i = 0; i < n; i++) arr[i] = i * 2;
+let asum = 0;
+for (let i = 0; i < n; i++) asum += arr[i];
+console.log("asum:", asum, "arr[999]:", arr[999]);
+
+// A constant bound crossing 2^31 was already correct — keep it that way.
+let constIters = 0;
+for (let i = 2147483640; i < 2147483650; i++) constIters++;
+console.log("const-bound iters:", constIters);
+
+// ...and so was `while`.
+let w = 2147483640;
+let wIters = 0;
+while (w < lim) {
+  w++;
+  wIters++;
+  if (wIters > 50) {
+    console.log("BUG: while loop did not terminate");
+    break;
+  }
+}
+console.log("while iters:", wIters, "w:", w);


### PR DESCRIPTION
Closes the **second half of #6072** (repro 2). Repro 1 — the bare `big++` accumulator — landed in #6258; this is the dynamic-runtime-bound loop counter that #6258's commit message explicitly deferred to a follow-up in `stmt/loops.rs`.

## The bug

A `for` counter whose loop bound is a **runtime** value crossing 2^31 wrapped to `INT32_MIN` and the loop spun forever:

```ts
const lim = parseInt("2147483653", 10);
for (let i = 2147483640; i < lim; i++) console.log(i);
// node:  13 iterations, i = 2147483640 .. 2147483652
// perry: i = 2147483646, 2147483647, -2147483648, -2147483647, ... forever
```

A **constant**-bound loop crossing 2^31 was fine, and `while` was fine. It is specifically the dynamic-bound `for` fast path.

## Root cause

`emit_guarded_i32_bound` (`crates/perry-codegen/src/stmt/loops.rs`) handed the counter an i32 shadow slot in the **shared** `ctx.i32_counter_slots` map, with nothing proving the counter stays below 2^31. Since issue #48, *every* `LocalGet` of a local with a shadow reads the i32 slot and `sitofp`s it (`expr/literals_vars.rs:459`), so the wrapped value became the counter's value everywhere.

The one-time bound guard could not rescue it. The guard picks the comparison strategy, not the representation: when it failed (bound above `INT32_MAX`), the "slow" cond re-lowered `i < lim` generically — and that generic lowering read the very same wrapped i32 shadow. Both loop versions were poisoned by one unsound representation decision.

## The fix

Keep the fast loop; drop the unsound representation.

* **Counter already owns a shared i32 shadow** (installed at its `Let` site because it is index-used or strictly-i32-bounded): reuse it for the `icmp`. The body already reads that shadow, so this adds no representation and no new hazard — **the array-index fast path is untouched**.
* **Counter has no shadow**: allocate a **loop-private** i32 counter that never enters `i32_counter_slots`. Only the fast cond block reads it; the update block bumps it by hand. The body and the slow cond keep reading the f64 slot, which the `Update` lowering maintains with exact JS semantics. A guard failure is now merely *slow* instead of an infinite loop over a wrapped counter.

The loop-entry guard now proves the fast loop cannot leave i32 range:

* the bound is a number, integral, `>= INT32_MIN`, and `<= INT32_MAX` for `i < n` (the counter is bumped only after a taken `i < n`, so it tops out at `n`);
* `<= INT32_MAX - 1` for `i <= n`, where the counter tops out at `n + 1`;
* for a private counter, the counter's **entry value** is itself an integral number in i32 range, so the seeding `fptosi` is well defined and the counter starts no higher than `INT32_MAX`.

A private counter additionally requires (statically) that the loop's own `i++` is the only write to it — it is invisible to the generic `Update`/`LocalSet` lowerings — and that it is not boxed/captured or a module global.

Two latent bugs in the same path fall out of the guard: `i <= n` with `n == INT32_MAX` overflowed the counter on its last increment, and a counter seeded past 2^31 (`for (let i = 3000000000; ...)`) fed an out-of-range — i.e. poison — `fptosi` into the shadow.

## Fast paths preserved (IR evidence)

`--trace llvm`, `for (let i = 0; i < n; i++) s += arr[i]` with a runtime bound `n` and `arr: number[]` — the counter is index-used, so it gets its i32 slot at the `Let` site, takes the shared branch, and keeps `js_typed_feedback_numeric_array_index_get_guard` plus `icmp slt i32`: identical counts to main. The `arr.length`-hoist path and the statically-i32-bounded `i < n` path are untouched.

The *private* counter keeps the guarded `icmp` loop too. `for (let i = 0; i < n; i++) s += i * 3 - 1;` (counter not index-used, runtime bound) still emits the `cond.fast` / `cond.slow` unswitch pair, and the split representation is visible:

```llvm
for.cond.6:                              ; branch on the one-time guard flag
  br i1 %r26, label %for.cond.fast.10, label %for.cond.slow.11
for.body.7:
  %r37 = load double, ptr %r3            ; counter read: f64 slot, never the shadow
for.update.8:
  %r42 = fadd double %r41, 1.0           ; f64 counter — exact JS semantics
  %r44 = add i32 %r43, 1                 ; private i32 shadow, fast cond only
for.cond.fast.10:
  %r29 = icmp slt i32 %r27, %r28         ; integer induction variable preserved
for.cond.slow.11:
  %r30 = load double, ptr %r3            ; guard failed -> generic compare on f64
```

### Cost

| shape (runtime bound `n`) | main | this PR |
|---|---|---|
| `for (let i = 0; i < n; i++) s += arr[i];` (index-used counter) | 100–101 ms | 100–102 ms |
| `for (let i = 0; i < n; i++) s += i * 3 - 1;` (counter not index-used) | 100–103 ms | 107–109 ms |

Best of 5, `--profile perry-dev` compiler, 100M iterations. Array loops are unchanged. A counter that feeds only integer *arithmetic* pays ~7%: its body reads now come from the f64 slot, so the arithmetic chain stays in doubles instead of i32. That is the price of not spinning forever on a bound above `INT32_MAX`; the guarded `icmp` loop and the integer induction variable are still there.

### Interaction with #6312 / #6299 — please merge #6312 first

There is one shape where the counter's *only* route to an i32 slot was the unsound insert this PR removes: a **write-only** array loop with a runtime bound whose store lowers to `PutValueSet` rather than `IndexSet` (`function fillArr(arr: number[], n: number) { for (let i = 0; i < n; i++) arr[i] = i * 2; }`). That is exactly the `collect_index_used_locals` blind spot **#6299**, fixed by **#6312**. On today's `main` such a loop loses `js_typed_feedback_numeric_array_index_set_guard` under this PR.

Verified directly: with #6312's collector patch applied on top of this branch, `fillArr` regains its set guard and the emitted guard counts match pristine main exactly (2 × get, 2 × set). The two PRs are complementary — #6312 gives those counters a *legitimate*, `Let`-site i32 slot, and this PR then takes the shared branch for them. If #6312 lands first, this PR is perf-neutral; the correctness fix stands either way (those same counters were the ones silently wrapping).

## Verification

* Repro 2 terminates and matches `node --experimental-strip-types` (13 iterations, values 2147483640..2147483652).
* New gap fixture `test-files/test_gap_6072_dynamic_bound_counter.ts` — byte-identical to node. Every loop carries a hard iteration cap so a regression fails the parity diff instead of hanging the suite. It covers: a dynamic bound crossing 2^31, `i <= INT32_MAX`, a counter seeded past 2^31, an ordinary runtime-bounded counter, a runtime-bounded array-index loop, the constant-bound loop, and the `while` form. Built by pristine main, that same fixture trips all three "did not terminate" guards and prints wrapped negative counters.
* `test_gap_6072_i32_update_overflow` (#6258 / repro 1) still byte-identical.
* Whole gap suite (287 files) A/B'd file-by-file against a pristine `origin/main` build — same flags, same env, compile status + stdout/stderr + exit code compared. Four files differ, none of them a regression:
  * `test_gap_6072_dynamic_bound_counter` — the new fixture; main hangs on the caps, this branch matches node.
  * `test_gap_console_methods` — `console.time` jitter (`timer1: 0.011ms` vs `0.013ms`).
  * `test_gap_http_overloads_3226plus` — both binaries abort identically (a port collision between my 4-way parallel sweep jobs); only thread ids and stack addresses differ.
  * `test_gap_module_const_local_shadow` — pre-existing nondeterminism on main: the *same pristine-main binary* prints a different uninitialized denormal (`x+1.96e-311`, `x+1.59e-311`, `x+2.23e-311`) on every run, where node prints `x+y`.
* `cargo test -p perry-codegen --test native_proof_regressions -- --test-threads=1`: 234 passed, 1 failed — `pod_field_read_after_dynamic_materialization_uses_number_coerce`, which fails identically with main's `loops.rs` restored (pre-existing; it has no loop in it). `manifest_consistency`'s `ws::readyState` drift is likewise pre-existing on a `-p perry-codegen` run.
* `cargo fmt --all -- --check` clean.

## Known remaining gap (not this PR) — filed as #6319

While writing the fixture I hit a **third**, distinct face of #6072's title that also reproduces on pristine main, unchanged by this diff (now tracked in #6319):

```ts
let x = 3000000000;   // integer literal past 2^31 still seeds `integer_locals`
let y = 0;
y = x;                // `is_strictly_i32_bounded_expr(LocalGet(x))` says "i32-bounded"
console.log(y);       // node: 3000000000   perry: -1294967296
```

`collect_integer_let_ids` seeds any `Expr::Integer` literal regardless of magnitude, so a plain copy of such a local is judged strictly-i32-bounded and gets a wrapping shadow. Narrowing that seed to i32-range literals looks right but reaches into the `imul32`/FNV i32-chain lowering that the `compiler_output_regression` image-convolution gate watches, so it deserves its own PR + benchmark rather than a drive-by here.
