### PR TITLE
fix(runtime): reject small-handle ids in the closure-validation probes (#5976)

### DIFF
--- a/crates/perry-runtime/src/closure/dispatch/validate.rs
+++ b/crates/perry-runtime/src/closure/dispatch/validate.rs
@@ -16,6 +16,11 @@ pub fn clean_closure_ptr(mut closure: *const ClosureHeader) -> *const ClosureHea
         if !(0x1000..0x0001_0000_0000_0000).contains(&addr) {
             return closure;
         }
+        // #5976: never probe `*(addr + 12)` on a small-handle id (see
+        // `get_valid_func_ptr` below and `value::addr_class` for the band map).
+        if crate::value::addr_class::is_handle_band(addr as usize) {
+            return closure;
+        }
         let type_tag = unsafe {
             std::ptr::read_volatile(
                 (closure as *const u8).add(CLOSURE_TYPE_TAG_OFFSET) as *const u32
@@ -63,6 +68,21 @@ pub fn clean_closure_ptr(mut closure: *const ClosureHeader) -> *const ClosureHea
 pub fn get_valid_func_ptr(closure: *const ClosureHeader) -> *const u8 {
     let addr = closure as u64;
     if !(0x1000..0x0001_0000_0000_0000).contains(&addr) {
+        return std::ptr::null();
+    }
+    // #5976: reject the small-handle band BEFORE the `*(addr + 12)`
+    // CLOSURE_MAGIC probe. Revocable-proxy ids, Web-Fetch/zlib/net handles and
+    // the generic stdlib registry ids are all NaN-boxed `POINTER_TAG | <small
+    // id>` values, not heap pointers — a real closure is always a GC allocation
+    // above the band (`value::addr_class`). The 0x1000 floor above let every
+    // one of them through, so this probe dereferenced unmapped low memory:
+    // `new ProxyOfClass(...)` reaching the dynamic construct path passed the
+    // proxy value to `is_bound_function_closure_value` → `get_valid_func_ptr`,
+    // which faulted at `PROXY_ID_BAND_START + id + 12` before
+    // `js_new_function_construct` ever got to its Proxy branch. `is_closure_ptr`
+    // (closure/dynamic_props.rs) has carried this guard since #1843/#4800; the
+    // two validators here were the remaining hole.
+    if crate::value::addr_class::is_handle_band(addr as usize) {
         return std::ptr::null();
     }
     let type_tag = unsafe {

--- a/test-files/test_gap_5976_proxy_class_construct.ts
+++ b/test-files/test_gap_5976_proxy_class_construct.ts
@@ -1,0 +1,83 @@
+// #5976: `new W(...)` where `W` is a `Proxy(<class>)` reached the runtime's
+// dynamic construct path (`js_new_function_construct`), which probed the value
+// as a possible bound-function closure BEFORE its Proxy branch. The probe
+// dereferenced `*(proxy_id + 12)` — a small-handle id, not a heap pointer —
+// and SIGSEGV'd. Every step below must run and the program must exit 0.
+
+function show(label: string, fn: () => unknown) {
+  try {
+    console.log(label, "ok", JSON.stringify(fn()));
+  } catch (e: any) {
+    console.log(label, "throw", e?.constructor?.name);
+  }
+}
+
+// A proxy whose construct trap returns a non-object → TypeError (per spec).
+const badReturn: any = new Proxy(function BadReturn() {}, {
+  construct() {
+    return 1 as any;
+  },
+});
+show("badret", () => Reflect.construct(badReturn, []));
+
+class Thing {
+  value: string;
+  constructor(v: string) {
+    this.value = v;
+  }
+  method() {
+    return "m:" + this.value;
+  }
+}
+
+// The crashing shape: construct through a Proxy(class) with an empty handler,
+// then use the instance (both `instanceof` and a method call).
+show("proxy class empty handler", () => {
+  const W: any = new Proxy(Thing, {});
+  const i: any = new W("x");
+  return [i instanceof Thing, i.method()];
+});
+
+// Same, but with a `construct` trap that delegates via Reflect.construct.
+const delegating: any = new Proxy(Thing, {
+  construct(target: any, args: any[], newTarget: any) {
+    const inst: any = Reflect.construct(target, args, newTarget);
+    inst.value = `${inst.value}:proxy`;
+    return inst;
+  },
+});
+show("proxy class construct trap delegates", () => {
+  const i: any = new delegating("y");
+  return [i instanceof Thing, i.value, i.method()];
+});
+
+// A callable (non-class) proxy target on the same dynamic path.
+function Point(this: any, x: number) {
+  this.x = x;
+}
+const PointProxy: any = new Proxy(Point, {});
+show("proxy function target", () => {
+  const p: any = new PointProxy(3);
+  return [p.x, p instanceof Point];
+});
+
+// A proxy whose target is itself a proxy of the class (nested forwarding).
+const Nested: any = new Proxy(new Proxy(Thing, {}), {});
+show("nested proxy class", () => {
+  const i: any = new Nested("n");
+  return [i instanceof Thing, i.method()];
+});
+
+// Calling (not constructing) a proxy-wrapped function goes through the same
+// closure-validation gate.
+const CallProxy: any = new Proxy(function add(a: number, b: number) {
+  return a + b;
+}, {});
+show("proxy apply", () => CallProxy(2, 3));
+
+// A revoked proxy must throw, not crash.
+const rev = Proxy.revocable(Thing, {});
+rev.revoke();
+show("revoked proxy construct", () => new (rev.proxy as any)("z"));
+
+console.log("END");


### PR DESCRIPTION
Fixes #5976.

## Root cause — not a GC scanner hole

The issue suspected #5937's proxy/descriptor GC scanners. Those are fine: the program never even reaches a collection. The crash is a plain handle-band dereference.

`new W(...)` where `W` is a `Proxy(<class>)` reaches the runtime's dynamic construct path, `js_new_function_construct` (HIR's `ProxyConstruct` fast path only fires for proxy locals the *module-level* pre-scan recorded; a `const W = new Proxy(Thing, {})` inside a nested function body is not one, which is exactly what the runtime fallback exists for — see the `#3656` comment on that branch).

`js_new_function_construct` checks for a `Function.prototype.bind` wrapper **before** it gets to its Proxy branch:

```
js_new_function_construct
  -> is_bound_function_closure_value(func_value)
     -> bound_function_target_ptr(func_value)      // is_pointer() -> true for a proxy
        -> get_valid_func_ptr(proxy_ptr)           // *** faults here ***
  ...
  if crate::proxy::js_proxy_is_proxy(func_value) == 1 { ... }   // three checks too late
```

`get_valid_func_ptr` only floored the candidate address at `0x1000`:

```rust
if !(0x1000..0x0001_0000_0000_0000).contains(&addr) { return null; }
let type_tag = read_volatile(addr + CLOSURE_TYPE_TAG_OFFSET /* 12 */);   // <-- SIGSEGV
```

A Proxy is a NaN-boxed `POINTER_TAG | (PROXY_ID_BAND_START + id)` — a registry id, not a heap pointer. `0x1000` sits far below `HANDLE_BAND_MAX` (`0x100000`), so the id sailed through and the CLOSURE_MAGIC probe read unmapped low memory:

```
EXC_BAD_ACCESS (SIGSEGV) KERN_INVALID_ADDRESS at 0x000f000e
  repro  js_new_function_construct + 164
```

`0xF000E` = `PROXY_ID_BAND_START (0xF0000) + proxy id 2 + 12`. Exactly the `type_tag` probe. Deterministic, and it is the same bug class as #1843 / #4004 / #4800 / #4904 / #6271 — a small-handle id dereferenced as a heap object.

## Fix

Reject the small-handle band before the probe, in the two shared closure validators (`crates/perry-runtime/src/closure/dispatch/validate.rs`):

- `get_valid_func_ptr` — returns null (i.e. "not a closure") for a handle-band address.
- `clean_closure_ptr` — same guard on its GC-forwarding walk, which carries the identical `*(addr + 12)` probe.

Nothing is lost: every small-handle id in `value::addr_class` (generic stdlib registry, Web Fetch, zlib streams, revocable-proxy ids) travels as a pointer-tagged small integer, and a real closure is always a GC allocation above `HANDLE_BAND_MAX`. `is_closure_ptr` (`closure/dynamic_props.rs`) has carried this exact guard since #1843/#4800; these two validators were the remaining hole.

With the probe answering "not a closure", `js_new_function_construct` falls through to its Proxy branch and the construct dispatches correctly.

## Before / after

Repro from the issue:

| | perry (main) | perry (this PR) | node |
|---|---|---|---|
| `badret` | `throw TypeError` | `throw TypeError` | `throw TypeError` |
| `case9` | **SIGSEGV, rc 139** | `ok [true,"m:x"]` | `ok [true,"m:x"]` |
| `END` | never printed | printed | printed |
| exit | 139 | 0 | 0 |

Also byte-identical to node under `PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1`.

`test-parity/node-suite/object/reflect-proxy-construct.ts` — the case the issue reported as regressed (object 24→23) — is byte-identical to node again.

## Validation

- New fixture `test-files/test_gap_5976_proxy_class_construct.ts` (proxy-of-class empty handler, delegating `construct` trap, proxy of a plain function, nested proxy-of-proxy, proxy apply, revoked proxy): byte-identical to `node --experimental-strip-types`, plain and under forced evacuation + evacuation verification.
- **Gap-suite A/B, 258 tests**, same `perry` binary, only the linked runtime archive swapped between a pristine `origin/main` build and this branch. Three outputs differ:
  - `test_gap_5976_proxy_class_construct` — rc 139 → rc 0 (the fix).
  - `test_gap_console_methods` — `console.time` µs jitter (`0.014ms` vs `0.001ms`).
  - `test_gap_module_const_local_shadow` — known failure #5917; it prints an uninitialized subnormal double that differs **on every run of the same binary**, main included.
  
  Zero regressions.
- `cargo test -p perry-runtime`: 1263 pass. The two failures (`object::tests::closure_name_and_length_ignore_plain_assignment`, `url::node_compat::tests::path_to_file_url_posix_preserves_relative_trailing_slash`) reproduce identically with this file reverted to `origin/main` — pre-existing parallel-suite/cwd flakes.
- `cargo fmt --all -- --check` clean. `scripts/addr_class_inventory.py` reports only the pre-existing `map.rs` handle-floor ratchet failure (#6297), untouched by this diff.

## Follow-up

#6320 — three *ad-hoc* CLOSURE_MAGIC probes still carry the `0x1000` floor (`symbol/iterator.rs` `Symbol.toPrimitive`, `symbol/properties.rs` `js_object_set_symbol_method`, `jsx.rs` `is_valid_closure`) and SIGSEGV the same way (`0x000f000d`) when a Proxy is stored where a closure is expected. Unlike the construct path, those sites have no proxy-aware fallback below them, so a band guard alone would stop the crash without dispatching the trap — that needs its own fix, filed separately rather than folded in here.

Note: #5937 is a merged PR, not an open issue, and its scanners are not implicated — nothing to close there.
