### PR TITLE
Fix array side-table GC lifecycles

### DIFF
--- a/crates/perry-runtime/src/array/header.rs
+++ b/crates/perry-runtime/src/array/header.rs
@@ -271,6 +271,24 @@ pub(crate) fn scan_array_named_property_roots_mut(visitor: &mut crate::gc::Runti
     });
 }
 
+/// Remove named-property entries whose array owners are provably dead under
+/// the centralized collection-specific liveness policy.
+pub(crate) fn prune_dead_array_named_property_owners(is_dead_owner: &dyn Fn(usize) -> bool) {
+    ARRAY_NAMED_PROPS.with(|m| {
+        m.borrow_mut().retain(|owner, _| !is_dead_owner(*owner));
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn test_array_named_property_owner_exists(owner: usize) -> bool {
+    ARRAY_NAMED_PROPS.with(|m| m.borrow().contains_key(&owner))
+}
+
+#[cfg(test)]
+pub(crate) fn test_clear_array_named_property_roots() {
+    ARRAY_NAMED_PROPS.with(|m| m.borrow_mut().clear());
+}
+
 unsafe fn string_header_as_str<'a>(key: *const crate::StringHeader) -> Option<&'a str> {
     if key.is_null() {
         return None;

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -60,13 +60,17 @@ pub use self::generic_mutators::{
 };
 pub(crate) use self::header::{
     array_has_arguments_object_flag, mark_array_as_arguments_object,
-    rebuild_array_numeric_raw_f64_allow_holes,
+    prune_dead_array_named_property_owners, rebuild_array_numeric_raw_f64_allow_holes,
 };
 pub use self::header::{
     js_array_clear_numeric_layout, js_array_is_numeric_f64_layout, js_array_mark_arguments_object,
     js_array_mark_numeric_f64_layout, js_array_note_numeric_write, js_tagged_template_get_or_init,
     js_tagged_template_register_raw, js_template_raw, scan_template_raw_roots,
     scan_template_raw_roots_mut, ArrayHeader,
+};
+#[cfg(test)]
+pub(crate) use self::header::{
+    test_array_named_property_owner_exists, test_clear_array_named_property_roots,
 };
 pub use self::immutable::{
     js_array_copy_within, js_array_copy_within_value, js_array_to_reversed,

--- a/crates/perry-runtime/src/gc/dead_owner.rs
+++ b/crates/perry-runtime/src/gc/dead_owner.rs
@@ -4,7 +4,8 @@
 //! Around a dozen runtime side tables are keyed by the raw address of an
 //! owning heap object (descriptor tables, symbol-keyed properties, closure
 //! dynamic props, arguments metadata, recorded prototypes, exotic expandos,
-//! `node:vm` metadata, fs FileHandle fds). The owning GC types mostly have no
+//! array expandos and iterator brands, `node:vm` metadata, fs FileHandle fds).
+//! The owning GC types mostly have no
 //! finalize hook, so nothing told those tables when the owner died: entries —
 //! and any strongly-rooted values inside them (accessor closures, symbol
 //! property values, expando values) — leaked forever, and a NEW object
@@ -212,6 +213,9 @@ fn fan_out(
     is_dead_closure: &dyn Fn(usize) -> bool,
     is_dead_symbol: &dyn Fn(usize) -> bool,
 ) {
+    crate::array::prune_dead_array_named_property_owners(is_dead_owner);
+    crate::map::prune_dead_map_iterator_array_owners(is_dead_owner);
+    crate::set::prune_dead_set_iterator_array_owners(is_dead_owner);
     crate::object::prune_dead_descriptor_owner_entries(is_dead_owner);
     crate::object::prune_dead_arguments_object_entries(is_dead_owner);
     crate::object::prototype_chain::prune_dead_object_prototype_owners(is_dead_owner);

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -394,6 +394,8 @@ pub fn gc_init() {
     gc_register_mutable_root_scanner(crate::regex::scan_last_exec_groups_root_mut);
     gc_register_mutable_root_scanner(crate::object::scan_exotic_expando_roots_mut);
     gc_register_mutable_root_scanner(crate::array::scan_template_raw_roots_mut);
+    gc_register_mutable_root_scanner(crate::map::scan_map_iterator_array_roots_mut);
+    gc_register_mutable_root_scanner(crate::set::scan_set_iterator_array_roots_mut);
     gc_register_mutable_root_scanner(crate::perf_hooks::scan_perf_entries_roots_mut);
     gc_register_mutable_root_scanner(crate::v8::scan_v8_promise_hook_roots_mut);
     gc_register_mutable_root_scanner(crate::typed_feedback::scan_typed_feedback_roots_mut);

--- a/crates/perry-runtime/src/gc/tests/dead_owner_side_tables.rs
+++ b/crates/perry-runtime/src/gc/tests/dead_owner_side_tables.rs
@@ -15,6 +15,247 @@ fn full_gc() {
         gc_collect_full_mark_sweep_with_trigger(GcTriggerSnapshot::capture(GcTriggerKind::Direct));
 }
 
+struct ArraySideTableTestGuard;
+
+impl ArraySideTableTestGuard {
+    fn new() -> Self {
+        crate::array::test_clear_array_named_property_roots();
+        crate::map::test_clear_map_iterator_arrays();
+        crate::set::test_clear_set_iterator_arrays();
+        Self
+    }
+}
+
+impl Drop for ArraySideTableTestGuard {
+    fn drop(&mut self) {
+        crate::array::test_clear_array_named_property_roots();
+        crate::map::test_clear_map_iterator_arrays();
+        crate::set::test_clear_set_iterator_arrays();
+    }
+}
+
+fn register_array_side_table_scanners() {
+    gc_register_mutable_root_scanner(crate::array::scan_template_raw_roots_mut);
+    gc_register_mutable_root_scanner(crate::map::scan_map_iterator_array_roots_mut);
+    gc_register_mutable_root_scanner(crate::set::scan_set_iterator_array_roots_mut);
+}
+
+unsafe fn set_array_named_property(arr: *mut crate::array::ArrayHeader, name: &str, value: f64) {
+    let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+    crate::array::array_named_property_set(arr, key, value);
+}
+
+unsafe fn alloc_nursery_test_array() -> *mut crate::array::ArrayHeader {
+    let arr = crate::arena::arena_alloc_gc(
+        std::mem::size_of::<crate::array::ArrayHeader>(),
+        std::mem::align_of::<crate::array::ArrayHeader>(),
+        GC_TYPE_ARRAY,
+    ) as *mut crate::array::ArrayHeader;
+    (*arr).length = 0;
+    (*arr).capacity = 0;
+    arr
+}
+
+unsafe fn alloc_malloc_test_object() -> *mut crate::object::ObjectHeader {
+    let obj = gc_malloc(
+        std::mem::size_of::<crate::object::ObjectHeader>(),
+        GC_TYPE_OBJECT,
+    ) as *mut crate::object::ObjectHeader;
+    (*obj).object_type = 1;
+    (*obj).class_id = 0;
+    (*obj).parent_class_id = 0;
+    (*obj).field_count = 0;
+    (*obj).keys_array = std::ptr::null_mut();
+    obj
+}
+
+fn util_types_is_map_iterator(addr: usize) -> bool {
+    crate::object::js_util_types_is_map_iterator(f64::from_bits(ptr_bits(addr))).to_bits()
+        == crate::value::TAG_TRUE
+}
+
+fn util_types_is_set_iterator(addr: usize) -> bool {
+    crate::object::js_util_types_is_set_iterator(f64::from_bits(ptr_bits(addr))).to_bits()
+        == crate::value::TAG_TRUE
+}
+
+#[test]
+fn test_array_named_dead_owner_stops_rooting_value_after_full_gc() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _side_tables = ArraySideTableTestGuard::new();
+    register_array_side_table_scanners();
+    crate::arena::arena_reset_all_blocks_to_zero();
+
+    let value = unsafe { alloc_malloc_test_object() };
+    let owner = unsafe { alloc_nursery_test_array() };
+    unsafe {
+        set_array_named_property(owner, "payload", f64::from_bits(ptr_bits(value as usize)));
+    }
+
+    full_gc();
+    assert!(
+        !crate::array::test_array_named_property_owner_exists(owner as usize),
+        "the first full collection must prune the dead owner"
+    );
+    assert!(
+        malloc_user_ptr_tracked(value as *mut u8),
+        "the value was scanned before post-trace pruning and survives that cycle"
+    );
+
+    full_gc();
+    assert!(
+        !malloc_user_ptr_tracked(value as *mut u8),
+        "without the dead owner entry, the next full collection must reclaim the value"
+    );
+}
+
+#[test]
+fn test_array_named_dead_owner_cannot_leak_property_across_exact_eden_reuse() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _side_tables = ArraySideTableTestGuard::new();
+    register_array_side_table_scanners();
+    crate::arena::arena_reset_all_blocks_to_zero();
+
+    let dead = unsafe { alloc_nursery_test_array() };
+    unsafe {
+        set_array_named_property(dead, "inherited", f64::from_bits(crate::value::TAG_TRUE));
+    }
+    let dead_addr = dead as usize;
+
+    let _ = gc_collect_minor();
+    let replacement = unsafe { alloc_nursery_test_array() };
+    assert_eq!(
+        replacement as usize, dead_addr,
+        "test premise: the copied-minor Eden reset must reuse the exact owner address"
+    );
+    assert!(
+        unsafe { crate::array::array_named_property_get_by_name(replacement, "inherited") }
+            .is_none(),
+        "an ordinary replacement array must not inherit the dead array's expando"
+    );
+}
+
+#[test]
+fn test_array_named_live_move_rekeys_owner_and_rewrites_object_value() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    let _side_tables = ArraySideTableTestGuard::new();
+    register_array_side_table_scanners();
+    crate::arena::arena_reset_all_blocks_to_zero();
+
+    let arr = unsafe { alloc_nursery_test_array() };
+    let old_owner = arr as usize;
+    let (value, _) = unsafe { alloc_nursery_test_object(0) };
+    let old_value = value as usize;
+    unsafe {
+        set_array_named_property(arr, "kept", f64::from_bits(ptr_bits(old_value)));
+    }
+    js_shadow_slot_set(0, ptr_bits(old_owner));
+
+    let _ = gc_collect_minor();
+
+    let new_owner = (js_shadow_slot_get(0) & POINTER_MASK) as usize;
+    assert_ne!(new_owner, old_owner, "test premise: the owner must move");
+    let new_value_bits = unsafe {
+        crate::array::array_named_property_get_by_name(
+            new_owner as *const crate::array::ArrayHeader,
+            "kept",
+        )
+    }
+    .expect("the moved owner must retain its expando")
+    .to_bits();
+    let new_value = (new_value_bits & POINTER_MASK) as usize;
+    assert_ne!(new_value, old_value, "the object value must be rewritten");
+    assert!(crate::arena::pointer_in_nursery(new_value));
+    assert!(crate::array::test_array_named_property_owner_exists(
+        new_owner
+    ));
+    assert!(!crate::array::test_array_named_property_owner_exists(
+        old_owner
+    ));
+}
+
+#[test]
+fn test_array_named_materialized_iterator_brands_follow_live_moves() {
+    let _guard = CopyingNurseryTestGuard::new(2);
+    let _side_tables = ArraySideTableTestGuard::new();
+    register_array_side_table_scanners();
+
+    let map = crate::map::js_map_alloc(0);
+    let set = crate::set::js_set_alloc(0);
+    let map_iter = crate::map::js_map_entries(map) as usize;
+    let set_iter = crate::set::js_set_to_array(set) as usize;
+    assert!(util_types_is_map_iterator(map_iter));
+    assert!(util_types_is_set_iterator(set_iter));
+    js_shadow_slot_set(0, ptr_bits(map_iter));
+    js_shadow_slot_set(1, ptr_bits(set_iter));
+
+    let _ = gc_collect_minor();
+
+    let moved_map_iter = (js_shadow_slot_get(0) & POINTER_MASK) as usize;
+    let moved_set_iter = (js_shadow_slot_get(1) & POINTER_MASK) as usize;
+    assert_ne!(moved_map_iter, map_iter);
+    assert_ne!(moved_set_iter, set_iter);
+    assert!(util_types_is_map_iterator(moved_map_iter));
+    assert!(util_types_is_set_iterator(moved_set_iter));
+    assert!(!util_types_is_map_iterator(map_iter));
+    assert!(!util_types_is_set_iterator(set_iter));
+
+    js_shadow_slot_set(0, 0);
+    js_shadow_slot_set(1, 0);
+    full_gc();
+    assert!(!util_types_is_map_iterator(moved_map_iter));
+    assert!(!util_types_is_set_iterator(moved_set_iter));
+}
+
+#[test]
+fn test_array_named_dead_map_iterator_marker_does_not_brand_exact_eden_reuse() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _side_tables = ArraySideTableTestGuard::new();
+    register_array_side_table_scanners();
+    crate::arena::arena_reset_all_blocks_to_zero();
+
+    let dead_map = crate::map::js_map_alloc(0);
+    let dead_map_iter = crate::map::js_map_entries(dead_map) as usize;
+    assert!(util_types_is_map_iterator(dead_map_iter));
+
+    let _ = gc_collect_minor();
+    let _replacement_map = crate::map::js_map_alloc(0);
+    let replacement_map_array = unsafe { alloc_nursery_test_array() };
+    assert_eq!(
+        replacement_map_array as usize, dead_map_iter,
+        "test premise: the copied-minor Eden reset must reuse the exact Map iterator address"
+    );
+    assert!(!util_types_is_map_iterator(replacement_map_array as usize));
+
+    // Finalize the replacement Map while its header is still intact; a raw
+    // arena reset would otherwise strand its external entries allocation.
+    full_gc();
+}
+
+#[test]
+fn test_array_named_dead_set_iterator_marker_does_not_brand_exact_eden_reuse() {
+    let _guard = CopyingNurseryTestGuard::new(0);
+    let _side_tables = ArraySideTableTestGuard::new();
+    register_array_side_table_scanners();
+    crate::arena::arena_reset_all_blocks_to_zero();
+
+    let dead_set = crate::set::js_set_alloc(0);
+    let dead_set_iter = crate::set::js_set_to_array(dead_set) as usize;
+    assert!(util_types_is_set_iterator(dead_set_iter));
+
+    let _ = gc_collect_minor();
+    let _replacement_set = crate::set::js_set_alloc(0);
+    let replacement_set_array = unsafe { alloc_nursery_test_array() };
+    assert_eq!(
+        replacement_set_array as usize, dead_set_iter,
+        "test premise: the copied-minor Eden reset must reuse the exact Set iterator address"
+    );
+    assert!(!util_types_is_set_iterator(replacement_set_array as usize));
+
+    // Finalize the replacement Set before the test guard tears down state.
+    full_gc();
+}
+
 #[test]
 fn test_dead_owner_descriptor_entries_pruned_on_full_gc() {
     let _guard = GcTestIsolationGuard::new();

--- a/crates/perry-runtime/src/map.rs
+++ b/crates/perry-runtime/src/map.rs
@@ -30,6 +30,38 @@ pub fn is_registered_map_iterator(addr: usize) -> bool {
     MAP_ITERATOR_ARRAYS.with(|r| r.borrow().contains(&addr))
 }
 
+/// Rekey legacy materialized-iterator brands after array evacuation without
+/// treating the metadata key as a root.
+pub(crate) fn scan_map_iterator_array_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    MAP_ITERATOR_ARRAYS.with(|r| {
+        let mut arrays = r.borrow_mut();
+        let mut moved = Vec::new();
+        for old_addr in arrays.iter().copied() {
+            let mut new_addr = old_addr;
+            if visitor.visit_metadata_usize_slot(&mut new_addr) {
+                moved.push((old_addr, new_addr));
+            }
+        }
+        for (old_addr, new_addr) in moved {
+            arrays.remove(&old_addr);
+            arrays.insert(new_addr);
+        }
+    });
+}
+
+/// Remove legacy Map iterator brands whose array owners are provably dead
+/// under the centralized collection-specific liveness policy.
+pub(crate) fn prune_dead_map_iterator_array_owners(is_dead_owner: &dyn Fn(usize) -> bool) {
+    MAP_ITERATOR_ARRAYS.with(|r| {
+        r.borrow_mut().retain(|owner| !is_dead_owner(*owner));
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn test_clear_map_iterator_arrays() {
+    MAP_ITERATOR_ARRAYS.with(|r| r.borrow_mut().clear());
+}
+
 #[cfg(test)]
 thread_local! {
     static TEST_FORCE_HELPER_GC: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };

--- a/crates/perry-runtime/src/set.rs
+++ b/crates/perry-runtime/src/set.rs
@@ -27,6 +27,38 @@ pub fn is_registered_set_iterator(addr: usize) -> bool {
     SET_ITERATOR_ARRAYS.with(|r| r.borrow().contains(&addr))
 }
 
+/// Rekey legacy materialized-iterator brands after array evacuation without
+/// treating the metadata key as a root.
+pub(crate) fn scan_set_iterator_array_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    SET_ITERATOR_ARRAYS.with(|r| {
+        let mut arrays = r.borrow_mut();
+        let mut moved = Vec::new();
+        for old_addr in arrays.iter().copied() {
+            let mut new_addr = old_addr;
+            if visitor.visit_metadata_usize_slot(&mut new_addr) {
+                moved.push((old_addr, new_addr));
+            }
+        }
+        for (old_addr, new_addr) in moved {
+            arrays.remove(&old_addr);
+            arrays.insert(new_addr);
+        }
+    });
+}
+
+/// Remove legacy Set iterator brands whose array owners are provably dead
+/// under the centralized collection-specific liveness policy.
+pub(crate) fn prune_dead_set_iterator_array_owners(is_dead_owner: &dyn Fn(usize) -> bool) {
+    SET_ITERATOR_ARRAYS.with(|r| {
+        r.borrow_mut().retain(|owner| !is_dead_owner(*owner));
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn test_clear_set_iterator_arrays() {
+    SET_ITERATOR_ARRAYS.with(|r| r.borrow_mut().clear());
+}
+
 #[cfg(test)]
 thread_local! {
     static TEST_FORCE_HELPER_GC: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };


### PR DESCRIPTION
## Summary

Fix raw-address array side tables so live metadata follows GC movement and dead metadata is removed before allocator address reuse. This prevents leaked expando values and stale Map/Set iterator brands.

## Changes

- prune dead array named-property owners during full/fallback and copied-minor collections
- rekey Map/Set iterator-array brands after evacuation without keeping dead arrays alive
- remove stale iterator brands before address reuse
- add deterministic full-GC, movement, and exact-address reuse regressions

## Related issue

n/a

## Test plan

- [ ] `cargo build --release` clean — not run; no build-system changes
- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes — not run; focused runtime and root-contract suites used instead
- [x] Added `#[test]` regressions in the affected runtime crate
- [x] Documentation update not applicable; this changes internal GC bookkeeping only
- [x] Platform UI backend build not applicable

Validation performed:

- `RUST_TEST_THREADS=1 cargo test --lib -p perry-runtime array_named` — 6 passed
- `RUST_TEST_THREADS=1 cargo test --lib -p perry-runtime dead_owner_side_tables` — 18 passed
- `RUST_TEST_THREADS=1 cargo test --lib -p perry-runtime` — 1270 passed, 1 ignored
- `python3 scripts/gc_store_site_inventory.py --self-test` — passed
- `python3 scripts/gc_store_site_inventory.py` — passed
- `cargo fmt --all -- --check` — passed
- `cargo test -p perry-codegen --test shadow_slot_hygiene` — 9 passed

## Screenshots / output

Not applicable; there are no user-interface changes.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commit follows the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention
- [x] I've read `CONTRIBUTING.md` and agree to the Code of Conduct


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved garbage collection handling for array named properties and Map/Set iterator state.
  * Dead-owner cleanup now prevents stale expando/iterator metadata from incorrectly rooting or affecting re-used addresses.
  * Ensured side tables and iterator brands remain consistent after object relocation during garbage collection.
* **Tests**
  * Expanded coverage for dead-owner pruning, address reuse, relocation rekeying, and correct iterator branding for both Map and Set across full and minor GC cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->