### PR TITLE
fix(runtime): make fs and child_process readables async-iterable

### DIFF
--- a/crates/perry-runtime/src/child_process/builder.rs
+++ b/crates/perry-runtime/src/child_process/builder.rs
@@ -148,6 +148,20 @@ pub(crate) fn cp_build_readable() -> f64 {
     let val = cp_box_ptr(obj as *const u8);
     cp_set_field(val, b"readable", TAG_TRUE_F64);
     cp_set_field(val, b"destroyed", TAG_FALSE_F64);
+    // A child's `stdout`/`stderr` must be async-iterable, like Node's: both
+    // `for await (const chunk of child.stdout)` and the `isAsyncIterable` probe
+    // every stream-consuming library runs —
+    // `typeof stream[Symbol.asyncIterator] === "function"` — depend on it.
+    // Without the symbol, `get-stream` (used by execa) rejects the stream with
+    // "The first argument must be a Readable, a ReadableStream, or an async
+    // iterable", which silently aborted the background downloads of a large
+    // esbuild-bundled CLI app.
+    //
+    // Reuse node:stream's iterator: it is event-driven (it attaches persistent
+    // `data`/`end`/`error` listeners and settles a promise per pull), so it
+    // drives this emitter-backed object as-is — `cp_emit` forwards to node:stream's
+    // listener registry so those listeners fire.
+    crate::node_stream::async_iterator::install_foreign_readable_async_iterator_symbol(val);
     val
 }
 

--- a/crates/perry-runtime/src/child_process/emitter.rs
+++ b/crates/perry-runtime/src/child_process/emitter.rs
@@ -80,6 +80,13 @@ pub(crate) fn cp_emit(target: f64, event: &str, args: &[f64]) -> bool {
         fired = true;
         i += 1;
     }
+
+    // `cp_build_readable` installs node:stream's async iterator on stdout/stderr,
+    // and that iterator registers its `data`/`end`/`error` listeners in node:stream's
+    // registry rather than the one above. Forward there too, so a `for await` over a
+    // child's output sees the chunks the reactor delivers.
+    crate::node_stream::emit_to_stream_listeners(target, event.as_bytes(), args);
+
     fired
 }
 

--- a/crates/perry-runtime/src/fs/stream.rs
+++ b/crates/perry-runtime/src/fs/stream.rs
@@ -582,6 +582,26 @@ fn callbacks_for_event(id: usize, event: &str) -> Vec<f64> {
     })
 }
 
+/// Forward `event` to node:stream's listener registry for this stream's object.
+///
+/// A read stream carries node:stream's async iterator (installed in
+/// `js_fs_create_read_stream`), and that iterator's `data`/`end`/`error`
+/// listeners register in node:stream's registry — not the per-id one above. Without
+/// this, `for await (const chunk of fs.createReadStream(p))` would hang forever.
+fn bridge_to_stream_listeners(id: usize, event: &str, args: &[f64]) {
+    let object_value = STREAM_REGISTRY.with(|registry| {
+        registry
+            .borrow()
+            .get(&id)
+            .map(|state| state.object_value)
+            .unwrap_or(f64::from_bits(crate::value::TAG_UNDEFINED))
+    });
+    if object_value.to_bits() == crate::value::TAG_UNDEFINED {
+        return;
+    }
+    crate::node_stream::emit_to_stream_listeners(object_value, event.as_bytes(), args);
+}
+
 fn emit_event0(id: usize, event: &str) {
     use crate::closure::js_closure_call0;
     let callbacks = callbacks_for_event(id, event);
@@ -591,6 +611,7 @@ fn emit_event0(id: usize, event: &str) {
             js_closure_call0(cb_ptr);
         }
     }
+    bridge_to_stream_listeners(id, event, &[]);
 }
 
 fn emit_event1(id: usize, event: &str, arg: f64) {
@@ -602,6 +623,7 @@ fn emit_event1(id: usize, event: &str, arg: f64) {
             js_closure_call1(cb_ptr, arg);
         }
     }
+    bridge_to_stream_listeners(id, event, &[arg]);
 }
 
 fn call_js_method0(receiver: f64, name: &[u8]) -> f64 {
@@ -1649,6 +1671,12 @@ fn create_read_stream_with_state(state: StreamState) -> f64 {
             update_common_props(state);
         }
     });
+    // Like Node's, a read stream must be async-iterable: `for await (const chunk of
+    // fs.createReadStream(p))`, and the `typeof stream[Symbol.asyncIterator] ===
+    // "function"` probe that stream-consuming libraries run before accepting a
+    // stream at all. `emit_event0`/`emit_event1` forward to node:stream's listener
+    // registry so the iterator this installs actually receives the chunks.
+    crate::node_stream::async_iterator::install_foreign_readable_async_iterator_symbol(value);
     value
 }
 

--- a/crates/perry-runtime/src/node_stream.rs
+++ b/crates/perry-runtime/src/node_stream.rs
@@ -29,7 +29,7 @@ use crate::object::js_object_set_field_by_name;
 use crate::object::{js_object_get_field_by_name_f64, ObjectHeader};
 use crate::value::JSValue;
 
-mod async_iterator;
+pub(crate) mod async_iterator;
 mod readable_from_promises;
 
 #[path = "node_stream_event_emitter.rs"]
@@ -42,6 +42,19 @@ use event_emitter::{
     ns_remove_listener2, ns_set_max_listeners, remove_stream_listener_for_event,
     stream_listener_count_for_event,
 };
+
+/// Dispatch `event` to the listeners registered on `stream` through node:stream's
+/// own emitter registry.
+///
+/// Exposed for `child_process`: a child's `stdout`/`stderr` is an emitter-backed
+/// object with its *own* listener registry, but it carries node:stream's async
+/// iterator (see `async_iterator::install_readable_async_iterator_symbol`), whose
+/// `data`/`end`/`error` listeners land *here*. Without this bridge the reactor's
+/// emit would never reach them and `for await (const chunk of child.stdout)` would
+/// hang forever.
+pub(crate) fn emit_to_stream_listeners(stream: f64, event: &[u8], args: &[f64]) {
+    let _ = emit_stream_event(stream, string_value(event), args);
+}
 // #3049 — `process.setMaxListeners` reuses the EventEmitter setter
 // validation (TypeError/RangeError + fractional/Infinity storage).
 pub(crate) use event_emitter::validate_max_listeners;

--- a/crates/perry-runtime/src/node_stream/async_iterator.rs
+++ b/crates/perry-runtime/src/node_stream/async_iterator.rs
@@ -16,6 +16,11 @@ const READABLE_ITERATOR_PENDING_KEY: &[u8] = b"__perryReadableIteratorPending";
 const READABLE_ITERATOR_ENDED_KEY: &[u8] = b"__perryReadableIteratorEnded";
 const READABLE_ITERATOR_ERROR_KEY: &[u8] = b"__perryReadableIteratorError";
 const READABLE_ITERATOR_ATTACHED_KEY: &[u8] = b"__perryReadableIteratorAttached";
+/// Marks a readable that is NOT a node:stream Readable — an `fs` read stream or a
+/// child's `stdout`/`stderr`. Those keep their own listener registry and stay
+/// paused until `resume()` is called on the object itself, so the iterator has to
+/// start their flow through the public method rather than node:stream's internal one.
+const FOREIGN_READABLE_KEY: &[u8] = b"__perryForeignReadable";
 const READABLE_ITERATOR_DATA_CB_KEY: &[u8] = b"__perryReadableIteratorDataCb";
 const READABLE_ITERATOR_END_CB_KEY: &[u8] = b"__perryReadableIteratorEndCb";
 const READABLE_ITERATOR_ERROR_CB_KEY: &[u8] = b"__perryReadableIteratorErrorCb";
@@ -387,6 +392,21 @@ fn iterator_ensure_attached(iterator: f64, stream: f64) {
     // Start flow: delivers any already-buffered chunks via `data` (on the
     // resume/drain microtask) and schedules `end` if the source is finite.
     resume_readable_stream(stream);
+
+    // A foreign readable has no node:stream state for the call above to act on;
+    // it starts reading only when its own `resume()` runs.
+    if has_truthy_hidden(stream, hidden_key(FOREIGN_READABLE_KEY)) {
+        let name = b"resume";
+        unsafe {
+            crate::object::js_native_call_method(
+                stream,
+                name.as_ptr() as *const i8,
+                name.len(),
+                std::ptr::null(),
+                0,
+            );
+        }
+    }
 }
 
 fn remove_iterator_listener(iterator: f64, stream: f64, event: &[u8], store_key: &[u8]) {
@@ -556,7 +576,22 @@ fn build_readable_async_iterator(stream: f64, destroy_on_return: bool) -> f64 {
     iterator
 }
 
-pub(super) fn install_readable_async_iterator_symbol(stream: f64) {
+/// Install node:stream's async iterator on a readable that is *not* a node:stream
+/// Readable (an `fs` read stream, a child's `stdout`/`stderr`). The iterator is
+/// event-driven — it attaches persistent `data`/`end`/`error` listeners and settles
+/// one promise per pull — so it drives any emitter-backed readable, provided the
+/// source forwards its events into node:stream's registry (see
+/// `node_stream::emit_to_stream_listeners`) and can be resumed via `resume()`.
+pub(crate) fn install_foreign_readable_async_iterator_symbol(stream: f64) {
+    set_hidden_value(
+        stream,
+        hidden_key(FOREIGN_READABLE_KEY),
+        f64::from_bits(TAG_TRUE),
+    );
+    install_readable_async_iterator_symbol(stream);
+}
+
+pub(crate) fn install_readable_async_iterator_symbol(stream: f64) {
     install_async_iterator_symbol(stream, ns_async_iterator);
 }
 


### PR DESCRIPTION
`fs.createReadStream(...)` and a child's `stdout`/`stderr` were not async-iterable: they carried no `Symbol.asyncIterator`, so `for await (const chunk of stream)` threw `"value is not iterable"`, and the probe that stream-consuming libraries run before they will accept a stream at all —

```js
typeof stream[Symbol.asyncIterator] === "function"
```

— was false. Libraries that wrap a spawned process (the `execa` / `get-stream` shape) reject the stream outright with *"The first argument must be a Readable, a ReadableStream, or an async iterable"*, so the whole operation fails rather than degrading. Only `node:stream`'s own Readables (`Readable.from`, `PassThrough`, …) had the symbol; Node has it on all three.

## Cause

Each of the three readables keeps its *own* listener registry: `node:stream` has its hidden-key registry, `child_process` has `cp_emit`'s per-object arrays, and `fs` has a per-stream-id map. Only the first ever had the iterator installed.

## The fix

Rather than duplicate the iterator, reuse `node:stream`'s: it is event-driven — it attaches persistent `data`/`end`/`error` listeners and settles one promise per pull — so it drives any emitter-backed readable given two things, which this adds:

- `node_stream::emit_to_stream_listeners`, so `cp_emit` and the `fs` stream's `emit_event0`/`emit_event1` also forward their events into `node:stream`'s registry, where the iterator's listeners live. Without this the iterator would attach and then hang forever.
- `install_foreign_readable_async_iterator_symbol`, which marks the readable as foreign so that on first pull the iterator starts flow through the object's own public `resume()`. `fs` read streams stay paused until then; `node:stream`'s internal resume has no state to act on for them.

The `node:stream` path itself is untouched.

## Validation

A node-vs-perry differential over 10 stream scenarios is byte-identical, where 4 previously diverged — `for await` and `.on("data")` on each of `Readable.from` / `fs.createReadStream` / child `stdout`+`stderr`, `pipe` into a `PassThrough` and into a file, the `isAsyncIterable` probe on all four readable kinds, and an early `break` out of a `for await` (the iterator-return path). The pre-existing `.on("data")` and `.pipe()` paths are covered there and are unchanged.

`perry-runtime`: 1264 passed / 0 failed (also verified with `--test-threads=1`).

On a large esbuild-bundled CLI app that shells out through this path, the *"must be a Readable"* throw goes from 36 occurrences to 0, and an uncaught `TypeError: is not iterable` that was aborting the run disappears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compatibility with async iteration for child-process output streams.
  * Improved support for consuming file and process streams with stream utilities such as `get-stream`.
  * Ensured streamed data, completion, and error events are delivered correctly to async iterators.
  * Improved handling of non-native readable streams by automatically starting them when iterated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->