### PR TITLE
fix(codegen): an integer literal past 2^31 must not seed the i32 fast path (#6319)

### DIFF
--- a/crates/perry-codegen/src/collectors/i32_locals.rs
+++ b/crates/perry-codegen/src/collectors/i32_locals.rs
@@ -2,6 +2,30 @@ use std::collections::HashSet;
 
 use super::*;
 
+/// An integer literal only proves an int32 value when it *is* one (#6319).
+///
+/// `Expr::Integer` carries an `i64`, so it happily holds `3000000000` or
+/// `9007199254740991` — values that are integral but do NOT fit in i32. Every
+/// judgment in the i32 fast-path chain used to accept `Expr::Integer(_)`
+/// unconditionally, which is how a literal past 2^31 reached an i32 shadow
+/// slot and got silently `ToInt32`-wrapped (`3000000000` → `-1294967296`).
+///
+/// This is the one predicate all four of those judgments now share:
+/// `is_strictly_i32_bounded_expr` (the write-is-i32-bounded proof),
+/// `collect_integer_let_ids` (the syntactic seed), `is_int32_producing_expr`
+/// (the forward-closure admission) and `int32_producing_deps` (the
+/// disqualification judgment). Narrowing only the seed would not have held:
+/// the forward closure re-admits from the init, and the judgment re-admits
+/// from every `LocalSet` rhs.
+///
+/// Deliberately *not* widened to "any value ToInt32 can wrap". `| 0`, `>>> 0`,
+/// bitwise ops and `Math.imul` all wrap by spec, so their results are genuinely
+/// int32 and keep their own arms below; a bare literal does not wrap — `let x =
+/// 3000000000` is the Number 3000000000 and must stay a double.
+pub(crate) fn integer_literal_fits_i32(n: i64) -> bool {
+    i32::try_from(n).is_ok()
+}
+
 pub fn is_strictly_i32_bounded_expr(
     e: &perry_hir::Expr,
     known_int_locals: &HashSet<u32>,
@@ -11,7 +35,11 @@ pub fn is_strictly_i32_bounded_expr(
 ) -> bool {
     use perry_hir::{BinaryOp, Expr};
     match e {
-        Expr::Integer(_) => true,
+        // #6319: an out-of-i32-range literal is NOT i32-bounded. Without the
+        // magnitude check, `let y = 0; y = 3000000000;` counted every write to
+        // `y` as strict, `y` got an i32 shadow at its `Let` site, and the store
+        // truncated to -1294967296.
+        Expr::Integer(n) => integer_literal_fits_i32(*n),
         // `x++`/`x--` is i32-bounded ONLY when the updated local is itself a
         // known integer (a loop counter). The previous unconditional `true`
         // truncated `var y = x++` to an i32 slot even when `x` held a
@@ -627,7 +655,7 @@ pub fn collect_integer_let_ids(
                 init: Some(init),
                 mutable,
                 ..
-            } if matches!(init, Expr::Integer(_))
+            } if matches!(init, Expr::Integer(n) if integer_literal_fits_i32(*n))
                     || is_flat_const_indexget(init, flat_const_ids, flat_row_alias_ids)
                     || is_clamp_call(init, clamp_fn_ids)
                     // Seed immutable (const) Lets whose init is a bitwise expression

--- a/crates/perry-codegen/src/collectors/integer_locals.rs
+++ b/crates/perry-codegen/src/collectors/integer_locals.rs
@@ -347,7 +347,10 @@ fn int32_producing_deps(
         )
     };
     match e {
-        Expr::Integer(_) => true,
+        // #6319: only a literal that actually fits in i32 proves an int32
+        // value. `let x = 3000000000` is integral but not int32, and admitting
+        // it here let every copy of `x` inherit an unearned i32 shadow.
+        Expr::Integer(n) => super::i32_locals::integer_literal_fits_i32(*n),
         Expr::Update { id, .. } if candidates.contains(id) => {
             deps.insert(*id);
             true
@@ -623,7 +626,11 @@ pub fn collect_flat_row_aliases(
 /// `int32_producing_deps` during disqualification — see the module comment.
 ///
 /// Accepted shapes:
-///   - `Expr::Integer(_)`: trivially integer.
+///   - `Expr::Integer(n)` **when `n` fits in i32** (#6319). `Expr::Integer`
+///     carries an `i64`, so `let x = 3000000000` and `let x =
+///     Number.MAX_SAFE_INTEGER` parse into it too — integral, but not int32.
+///     Admitting them let a plain copy (`let y = 0; y = x`) be judged
+///     i32-bounded and take a wrapping i32 shadow.
 ///   - `(expr) | 0` and `(expr) >>> 0`: the JS ToInt32 / ToUint32 idiom —
 ///     always yields a 32-bit integer regardless of the inner expression.
 ///   - Pure bitwise ops (`&`, `|`, `^`, `<<`, `>>`, `>>>`): per JS spec
@@ -653,7 +660,10 @@ pub fn is_int32_producing_expr(
 ) -> bool {
     use perry_hir::{BinaryOp, Expr};
     match e {
-        Expr::Integer(_) => true,
+        // #6319: an `Expr::Integer` holds an i64. Only accept it when it really
+        // is an int32 — otherwise the forward-closure pass re-admits the very
+        // `let x = 3000000000` that the syntactic seed now rejects.
+        Expr::Integer(n) => super::i32_locals::integer_literal_fits_i32(*n),
         Expr::Update { .. } => true,
         Expr::Binary { op, right, .. }
             if matches!(op, BinaryOp::BitOr | BinaryOp::UShr)

--- a/test-files/test_gap_6319_i32_literal_magnitude.ts
+++ b/test-files/test_gap_6319_i32_literal_magnitude.ts
@@ -1,0 +1,95 @@
+// #6319 (third face of #6072): an integer literal past 2^31 still seeded the
+// i32 fast path, so *copying* such a local wrapped it.
+//
+// `let x = 3000000000` kept the correct double in its own slot (the `Let`-site
+// gate checks the literal's magnitude), but it was still admitted to
+// `integer_locals`. `let y = 0; y = x;` then counted as a "strictly i32-bounded"
+// write, `y` got an i32 shadow, and the store truncated it — `y` read back as
+// -1294967296. Same for a direct out-of-range store, a copy chain, and a
+// counter seeded past 2^31 under an `arr.length` / `i < n` loop.
+
+// ---- the issue's repro ----
+let x = 3000000000;
+let y = 0;
+y = x;
+console.log("copy:", y);
+
+let z = 0;
+z = x + 4;
+console.log("add:", z);
+
+// ---- direct out-of-range store into an otherwise-i32 local ----
+let d = 0;
+d = 3000000000;
+console.log("direct store:", d);
+
+// ---- boundary neighbourhood, each copied through a fresh local ----
+function copyOf(v: number): number {
+  let out = 0;
+  out = v;
+  return out;
+}
+const a = 2147483647; // 2^31 - 1  — fits, stays on the i32 path
+const b = 2147483648; // 2^31
+const c = 2147483649; // 2^31 + 1
+const e = 4294967296; // 2^32
+const f = -2147483648; // -2^31    — fits
+const g = -2147483649; // -2^31 - 1
+const h = 9007199254740991; // Number.MAX_SAFE_INTEGER
+console.log("2^31-1:", copyOf(a));
+console.log("2^31:", copyOf(b));
+console.log("2^31+1:", copyOf(c));
+console.log("2^32:", copyOf(e));
+console.log("-2^31:", copyOf(f));
+console.log("-2^31-1:", copyOf(g));
+console.log("MAX_SAFE:", copyOf(h));
+
+// ---- copy chain ----
+const c1 = 5000000000;
+const c2 = c1;
+const c3 = c2;
+console.log("chain:", c3);
+
+let m1 = 0;
+let m2 = 0;
+let m3 = 0;
+m1 = 6000000000;
+m2 = m1;
+m3 = m2;
+console.log("mut chain:", m3);
+
+// ---- a counter seeded past 2^31 under an `arr.length` bound ----
+// The length-hoist path used to install the counter's i32 shadow from
+// `integer_locals` membership alone, seeding it with a poison `fptosi`.
+const arr = [11, 22, 33];
+let big = 3000000000;
+const hits: number[] = [];
+for (let i = 0; i < arr.length; i++) {
+  hits.push(big + arr[i]);
+}
+console.log("length-hoist:", hits.join(","), "big:", big);
+
+// ---- the i32 chain that must stay exact: FNV-1a over bytes ----
+function imul32(p: number, q: number): number {
+  return Math.imul(p, q);
+}
+let fnv = 0x811c9dc5 | 0;
+const bytes = [1, 2, 3, 4, 5, 250, 251, 252];
+for (let i = 0; i < bytes.length; i++) {
+  fnv = (fnv ^ bytes[i]) | 0;
+  fnv = imul32(fnv, 0x01000193);
+}
+const hash = fnv >>> 0;
+console.log("fnv:", hash.toString(16).padStart(8, "0"));
+
+// A `>>> 0` seed above INT32_MAX stays unsigned and must not be truncated.
+const SEED = 0x9e3779b9 >>> 0;
+console.log("seed:", SEED, (SEED | 0) === -1640531527);
+
+// ---- the array-index fast path must survive ----
+const nums = [10, 20, 30, 40, 50];
+let acc = 0;
+for (let i = 0; i < nums.length; i++) {
+  acc = acc + nums[i];
+}
+console.log("arrsum:", acc, "nums[2]:", nums[2]);


### PR DESCRIPTION
Closes #6319 — the third face of #6072 (`i32 fast-path locals silently wrap at 2^31`), after #6258 (bare `x++` accumulator) and #6318 (dynamic-bound loop counter).

```ts
let x = 3000000000;
let y = 0;
y = x;
console.log(y);   // node: 3000000000   perry (before): -1294967296
```

## Root cause

`Expr::Integer` carries an `i64` — every integral literal that fits in i64 lowers into it, including `3000000000`, `4294967296` and `Number.MAX_SAFE_INTEGER` (`perry-hir/src/lower_patterns.rs:143`). But every judgment in the i32 fast-path chain accepted `Expr::Integer(_)` *regardless of magnitude*.

`x` itself stayed correct — its own `Let`-site slot is gated on `init_in_i32_range` — yet it was still admitted to `integer_locals`. `is_strictly_i32_bounded_expr`'s `LocalGet` arm then answers `known_int_locals.contains(id)`, so `y = x` counted as a strictly-i32-bounded write, `y` got an i32 shadow at its `Let` site, and the store truncated the 3e9 double. Reads prefer the shadow (issue #48), so the wrapped value is what `console.log` sees.

**Denying the shadow is the only cure.** The f64 fallback in `LocalSet` mirrors into the i32 slot with `fptosi`+`trunc` anyway (`literals_vars.rs:634`), so rejecting the value in `can_lower_expr_as_i32` would not have helped — the truncation happens on both paths.

## The fix

One shared predicate, `integer_literal_fits_i32`, applied at all four judgments that make up the seeding chain:

| site | role |
|---|---|
| `collect_integer_let_ids` | the syntactic seed |
| `is_int32_producing_expr` | the forward-closure admission |
| `int32_producing_deps` | the disqualification judgment |
| `is_strictly_i32_bounded_expr` | the write-is-i32-bounded proof |

All four are load-bearing. Narrowing only the seed (the issue's sketch) does **not** hold: the forward-closure pass re-admits from the `Let` init, and the disqualification judgment re-admits from every `LocalSet` rhs. And `is_strictly_i32_bounded_expr` is an independent hole — `let y = 0; y = 3000000000;` wrapped with no copy at all.

Two latent poison `fptosi`s go with it: the `arr.length`-hoist (`loops.rs:2454`) and the static `i < n` bound (`loops.rs:2516`) both install a counter's i32 shadow from `integer_locals` membership *alone*, seeding it with a bare `fptosi` of the counter's double — poison in LLVM for a counter past 2^31.

## Why the imul32 / FNV chain is safe

The `compiler-output-regression` gate watches image_convolution's i32 chain, whose two out-of-i32-range constants are written

```ts
const SEED = 0x9E3779B9 >>> 0;   // Binary{UShr, .., Integer(0)}
let h = 0x811c9dc5 | 0;          // Binary{BitOr, .., Integer(0)}
```

— they reach `integer_locals` through the `>>> 0` / `| 0` arms, **not** the bare `Expr::Integer` arm this PR narrows. `| 0`, `>>> 0`, bitwise ops and `Math.imul` genuinely produce int32 by spec; a bare literal does not. A sweep of every `source` in `benchmarks/compiler_output/workloads.toml` found no other >i32 literal.

## Magnitude matrix (vs `node --experimental-strip-types`)

Each value is copied through a fresh local whose own `Let` init is in range, so the `init_in_i32_range` gate cannot mask the bug.

| case | node | before | after |
|---|---|---|---|
| `2^31 - 1` | 2147483647 | 2147483647 | 2147483647 |
| `2^31` | 2147483648 | 2147483648 | 2147483648 |
| `2^31 + 1` | 2147483649 | 2147483649 | 2147483649 |
| `2^32` | 4294967296 | 4294967296 | 4294967296 |
| `-2^31` | -2147483648 | -2147483648 | -2147483648 |
| `-2^31 - 1` | -2147483649 | -2147483649 | -2147483649 |
| `MAX_SAFE_INTEGER` | 9007199254740991 | 9007199254740991 | 9007199254740991 |
| **copy** (`y = x`) | 3000000000 | **-1294967296** | 3000000000 |
| **direct store** (`d = 3000000000`) | 3000000000 | **-1294967296** | 3000000000 |
| **copy chain** (`a → b → c`) | 5000000000 | **705032704** | 5000000000 |
| **mutable chain** | 6000000000 | **1705032704** | 6000000000 |
| **compare** (`n = lim; n > 2^31-1`) | true | **false** | true |
| FNV-1a checksum | de92f531 | de92f531 | de92f531 |
| array sum | 150 | 150 | 150 |

The `compare` row is worth calling out: `const lim = 3000000000; let n = 0; n = lim; n > 2147483647` evaluated to **`false`** on `main`.

## Fast paths preserved (IR evidence)

`--trace llvm` on the new fixture, before vs after:

| | before | after |
|---|---|---|
| `js_typed_feedback_numeric_array_index_get_guard` (array fast path, #6299/#6312) | 5 | **5** |
| `mul i32` (FNV / imul32 chain) | 1 | **1** |
| `alloca i32` (i32 shadows) | 13 | **6** |
| `store i32 2147483647` (2^31-1 keeps its shadow) | 1 | **1** |
| `store i32 -2147483648` (-2^31 keeps its shadow) | 1 | **1** |

Exactly the intended precision: the boundary literals that *do* fit keep the i32 fast path; only the ones that don't drop off it.

## Validation

- `compiler-output-regression`: all five CI gate steps green locally (harness unit tests, `native-region-proof` ×11 workloads, `native-abi-proof` ×12, `vectorized_buffer_transform`, `hir_fact_rewrite`, `fma_contract`) — `failed_workloads: []`.
- `test_gap_6072_i32_update_overflow` and `test_gap_6072_dynamic_bound_counter` stay byte-identical to node.
- Gap suite A/B (297 tests) against a pristine `origin/main` build: zero regressions. The only output changes are the new fixture and `test_gap_console_methods` (`console.time` jitter, e.g. `0.001ms` → `0.003ms`).
- New fixture `test-files/test_gap_6319_i32_literal_magnitude.ts`, byte-identical to node.
- `cargo fmt --all -- --check` and `scripts/check_file_size.sh` clean.

## Known adjacent face — not this PR

Copying a local whose value came from an *arithmetic chain* past 2^31 still wraps (`let big2 = big1 + big1; let t = 0; t = big2;` → `-294967296`). That is a different root cause: `is_strictly_i32_bounded_expr`'s `LocalGet` arm reads `integer_locals`, which by design admits overflowing `Add`/`Sub`/`Mul` — it is not a literal-magnitude problem, and closing it means turning the strict set into a greatest fixpoint. Filed separately as #6339 with the repro and a fix sketch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected handling of integer literals outside the signed 32-bit range.
  * Prevented certain optimization paths from incorrectly treating large values as 32-bit integers.
  * Preserved accurate results for large-number assignments, mutation chains, counters, hashing, unsigned values, and array indexing.

* **Tests**
  * Added coverage for 32-bit boundary values and out-of-range integer scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->