### PR TITLE
fix(runtime): numeric-key computed calls must read the element, not dispatch by name (#6328)

### DIFF
--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -226,6 +226,23 @@ pub unsafe extern "C" fn js_native_call_method_apply_by_id(
     )
 }
 
+/// The numeric property key of an `obj[key](...)` call, as the raw `f64` index
+/// `js_object_get_index_polymorphic` consumes, or `None` when `key` is not a
+/// number. Both representations a numeric key can arrive in are accepted: a
+/// plain IEEE double (what a boxed `Any` capture reads back as — the #6328
+/// async-loop shape) and a NaN-boxed INT32 (the i32 loop-counter lowering).
+#[inline]
+fn numeric_index_key(key: JSValue) -> Option<f64> {
+    if key.is_int32() {
+        return Some(key.as_int32() as f64);
+    }
+    // `is_number` accepts every non-Perry-tagged bit pattern, NaN included; a
+    // NaN key is not an index and would only make the polymorphic read return
+    // `undefined`, so screen it out here rather than paying for the probe.
+    let raw = f64::from_bits(key.bits());
+    (key.is_number() && !raw.is_nan()).then_some(raw)
+}
+
 /// Dispatch `obj[key](args)` where `key` is a *runtime value* whose static type
 /// is not provably a string (`cur._op`, `arr[i]`, a `let`-rebound key, etc.).
 ///
@@ -335,6 +352,39 @@ pub unsafe extern "C" fn js_native_call_method_value(
                         }
                     }
                 }
+            }
+        }
+    }
+
+    // #6328: NUMERIC key — `fns[i](x)`, `resolvers[i](i)`. `js_to_property_key`
+    // canonicalizes the index to the string `"i"`, and the string branch below
+    // hands that to `js_native_call_method`, which dispatches by *method name*:
+    // own-field scan + prototype/class-id chain. An Array's ELEMENT storage is
+    // none of those, so the lookup misses, the tower returns `undefined`, and
+    // the call SILENTLY EVAPORATES — no throw, no diagnostic, exit code 0.
+    //
+    // Codegen only routes an `arr[i](...)` call here when it cannot prove `i`
+    // numeric (`try_lower_index_get_call` bails to the array element-call
+    // lowering when `is_numeric_expr` holds). Inside an async function it never
+    // can: the async-to-generator transform turns every body local into a
+    // boxed mutable capture typed `Any`, so `i` reads back as an untyped value
+    // and the call lands here. That is why `await Promise.all(ps)` evaporated —
+    // the `for (…) resolvers[i](i)` loop resolved nothing (#6328).
+    //
+    // Per spec `obj[k](...)` is Get(obj, k) then Call — the property READ wins.
+    // Resolve the element/own value first and invoke it when the key names
+    // something; only fall through to the name tower when it names nothing, so
+    // a numerically-named vtable method (`class C { 3() {} }`) keeps working.
+    if !is_symbol_key {
+        if let Some(index) = numeric_index_key(key_jsval) {
+            let field =
+                crate::object::js_object_get_index_polymorphic(object.to_bits() as i64, index);
+            let fv = JSValue::from_bits(field.to_bits());
+            if !fv.is_undefined() && !fv.is_null() {
+                let prev_this = IMPLICIT_THIS.with(|c| c.replace(object.to_bits()));
+                let result = crate::closure::js_native_call_value(field, args_ptr, args_len);
+                IMPLICIT_THIS.with(|c| c.set(prev_this));
+                return result;
             }
         }
     }

--- a/test-files/test_gap_6328_async_index_call.ts
+++ b/test-files/test_gap_6328_async_index_call.ts
@@ -1,0 +1,102 @@
+// #6328: `await Promise.all([...])` silently evaporated (exit 0, no output) when
+// the input promises were settled through executor-captured resolvers invoked
+// from a loop.
+//
+// Root cause was not in the promise machinery at all: `arr[i](x)` — a call whose
+// callee is a computed member with a *numeric* key — is routed to
+// `js_native_call_method_value` whenever codegen cannot statically prove the key
+// numeric. Inside an `async` function it never can (the async-to-generator
+// transform turns body locals into boxed `Any` captures), and that runtime helper
+// stringified the index and dispatched by METHOD NAME — which can never see an
+// Array's element storage. The lookup missed, `undefined` came back, and the call
+// was a silent no-op. The loop resolved nothing, so `await all` never resumed.
+//
+// The `for` loops below matter: at a low trip count the loop is unrolled to
+// constant indices, which codegen *can* prove numeric — the bug only shows up
+// once the index stays a runtime value.
+
+async function combinator() {
+  const resolvers: ((v: number) => void)[] = [];
+  const ps = Array.from(
+    { length: 100 },
+    () => new Promise<number>((res) => { resolvers.push(res); }),
+  );
+  const all = Promise.all(ps);
+  for (let i = 0; i < 100; i++) resolvers[i](i);
+  const r = await all;
+  console.log("all", r.length, r[0], r[99]);
+
+  const settled = await Promise.allSettled(ps);
+  console.log("allSettled", settled.length, settled[7].status);
+  console.log("race", await Promise.race(ps));
+  console.log("any", await Promise.any(ps));
+}
+
+// The underlying defect, with no promise anywhere: calling closures out of an
+// array by runtime index, inside an async function.
+async function indexCall() {
+  const fns: ((v: number) => string)[] = [];
+  for (let i = 0; i < 9; i++) fns.push((v) => "fn:" + v);
+  const out: string[] = [];
+  for (let i = 0; i < 9; i++) out.push(fns[i](i));
+  await 0;
+  console.log("indexCall", out.join(","));
+}
+
+// `this` must still be bound by the dynamic-key dispatch (#321): a numerically
+// keyed own method on a plain object reads `this` through the same helper.
+async function thisBinding() {
+  const obj: any = { tag: "obj", 3: function () { return this.tag; } };
+  let k = 3;
+  console.log("thisBinding", obj[k]());
+  await 0;
+}
+
+// A numerically named class method still resolves through the vtable — the
+// element-read fast path must fall through when the key names no own value.
+class Numbered {
+  3() {
+    return "vtable-3";
+  }
+}
+
+async function vtable() {
+  const c: any = new Numbered();
+  let k = 3;
+  console.log("vtable", c[k]());
+  await 0;
+}
+
+// A rejecting member must still reject, and `await` must still see it.
+async function rejects() {
+  const resolvers: ((v: number) => void)[] = [];
+  const rejecters: ((e: unknown) => void)[] = [];
+  const ps = Array.from(
+    { length: 10 },
+    () =>
+      new Promise<number>((res, rej) => {
+        resolvers.push(res);
+        rejecters.push(rej);
+      }),
+  );
+  const all = Promise.all(ps);
+  for (let i = 0; i < 9; i++) resolvers[i](i);
+  rejecters[9](new Error("boom"));
+  try {
+    await all;
+    console.log("rejects UNREACHABLE");
+  } catch (e) {
+    console.log("rejects", (e as Error).message);
+  }
+}
+
+async function main() {
+  await combinator();
+  await indexCall();
+  await thisBinding();
+  await vtable();
+  await rejects();
+  console.log("done");
+}
+
+main();


### PR DESCRIPTION
Fixes #6328.

## TL;DR

The promise machinery was never at fault, and `Promise.all` is not needed to reproduce. The real defect is that **`arr[i](x)` — a call whose callee is a computed member with a *numeric* key — was a silent no-op inside an `async` function.** The reported `await Promise.all([...])` hang is a downstream symptom: the `for (…) resolvers[i](i)` loop resolved *nothing*.

## Root cause

`try_lower_index_get_call` (`perry-codegen/src/lower_call/early_branches.rs`) bails out to the array element-call lowering only when it can prove the index numeric:

```rust
if crate::type_analysis::is_numeric_expr(ctx, index) && !object_is_class_ref {
    return Ok(None);   // → real element-call lowering
}
```

Otherwise the call goes to `js_native_call_method_value`, the dynamic-key `this`-binding path added for #321 (effect's `this[(cur)._op](cur)`).

Inside an `async` function that proof is never available: the async-to-generator transform turns every body local into a **boxed mutable capture typed `Any`**, so the loop counter reads back untyped. Confirmed in the HIR — the step closure carries `captures: [0, 1, 3, …]`, `mutable_captures: [0, 1, 3, …]`, and the call lowers as `Call { callee: IndexGet { object: LocalGet(0), index: LocalGet(3) } }`.

`js_native_call_method_value` then ran the key through `js_to_property_key`, which canonicalizes the index to the **string** `"3"`, and handed that to `js_native_call_method` — the dispatch tower, which resolves by **method name** (own-field scan + prototype/class-id chain). An Array's **element storage is none of those**. The lookup missed, `undefined` came back, and the call evaporated. No throw, no diagnostic.

So the loop resolved nothing, `await all` waited on a promise nobody would ever settle, the event loop drained, and the process exited **0** having printed nothing.

This also explains every discriminator in the issue:

| observation | why |
|---|---|
| `.then()` form works | `main` has no `await` → not transformed → locals stay typed → codegen proves the index numeric → correct lowering |
| `setTimeout` form works | same — the resolve loop moves out of the async body |
| **N=8 works, N=9 fails** | the loop unroller: at a low trip count the indices const-fold to literals, which codegen *can* prove numeric |

The 8-vs-9 threshold was the tell — it is an unroll boundary, not an array-capacity or promise-count boundary.

## Fix

One runtime change, in `js_native_call_method_value`. Per spec `obj[k](...)` is `Get(obj, k)` then `Call` — **the property read wins**. For a numeric key, resolve the element/own value through `js_object_get_index_polymorphic` first and invoke it when the key names something; fall through to the name tower when it names nothing, so a numerically-named vtable method (`class C { 3() {} }`) keeps its dispatch. `this` stays bound on both paths.

Deliberately *not* fixed in codegen: the type information genuinely is not recoverable there (both the array and the index are untyped boxed captures), so the runtime is the only place this can be made correct. The sync fast path is untouched.

## Shape matrix vs node 26 (all byte-identical, exit codes match)

| shape | before | after |
|---|---|---|
| N=1 / N=2 / N=8 | pass | pass |
| N=9 / N=100 (`Promise.all`) | **silent, exit 0** | pass |
| `Promise.allSettled` / `race` / `any`, N=100 | **silent, exit 0** | pass |
| `.then()` form, N=100 | pass | pass |
| resolvers fired from `setTimeout` | pass | pass |
| `await` already-resolved plain promise | pass | pass |
| promise settling synchronously inside its executor | pass | pass |
| **rejecting member** → `await` throws, `catch` sees it | pass | pass |
| unhandled combinator rejection → exit 1 + report (#6077) | pass | pass |
| `arr[i](x)` with no promise anywhere (the real bug) | **silent no-op** | pass |
| `this`-binding via numeric key on a plain object (#321) | pass | pass |
| `class C { 3() {} }` vtable dispatch | pass | pass |

## Validation

- **Cross-controlled archive A/B** (runtime-only change, so the `libperry_runtime.a` staleness trap is real — `perry-runtime` is rlib-only; the archive comes from `perry-runtime-static`): base compiler + **my** archive → **fixed**; my compiler + **base** archive → **bug returns**. The archive is decisively the causal factor.
- **Gap suite A/B, 297 tests, against a pristine `origin/main` build (735e89480)**: **zero regressions.** All 296 shared tests produce identical output. The single sha delta, `test_gap_module_const_local_shadow`, is already triaged in `known_failures.json` and reads uninitialised memory — its garbage float drifts on every run of the *same* binary, on base and on this branch alike.
- `cargo test -p perry-runtime`: **1285/1285** green (`--test-threads=1`). The parallel suite flakes on `test_array_exotic_descriptors_and_global_prototype_identity`, `stream_constructors_expose_static_method_values` and two `gc::telemetry_verifier` tests — pre-existing shared-realm races that reproduce at the same rate on pristine `main`.
- `cargo fmt --all -- --check` clean; `scripts/check_file_size.sh` clean.

## Regression fixture

`test-files/test_gap_6328_async_index_call.ts` — asserts **exit code** as well as stdout, since the failure mode is a silent exit 0. Covers the combinator shapes, the underlying `arr[i](x)` defect with no promise involved, `this`-binding, vtable fall-through, and the rejecting-member path.

## Found while here — separate bug, NOT fixed in this PR

Per-iteration `let`/`const` binding **collapses for closures created in a loop body inside an `async` function**: every closure sees the *last* iteration's value.

```ts
async function main() {
  const fns: (() => void)[] = [];
  for (let i = 0; i < 9; i++) { const j = i; fns.push(() => console.log(j)); }
  fns.forEach(f => f());   // node: 0..8   perry: 8,8,8,8,8,8,8,8,8
  await 0;
}
```

Same root family (the async transform boxes body locals into one shared cell) but a distinct fix in the transform, not the runtime. It is **pre-existing and independent** — it reproduces on unpatched `main` through a call shape that already worked (`const f = fns[i]; f(i)`), so this PR neither causes nor masks it. Filing separately.

## Overlap with #6327

**None.** #6327 (`fix/6084-promise-all-and-freeze-fastpath`) rewrites the promise side tables (`PROMISE_SETTLE_LISTENERS`, `PROMISE_OVERFLOW_REACTIONS`, `PROMISE_ALL_STATES`) with an O(1) index — a perf change in `promise/{combinators,reactions,scanners}.rs` + a new `keyed_table.rs`. This PR touches only `object/native_call_method.rs`. No file overlap, no semantic overlap, and #6327 would not have fixed this (the bug is upstream of the promise tables — the promises were never settled at all). Based on `origin/main`; merges cleanly in either order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calls to functions and methods accessed through runtime numeric keys.
  * Preserved correct `this` binding and class-method dispatch for numeric-key access.
  * Improved reliability for asynchronous operations involving indexed callbacks and promises.
  * Ensured rejecting promises continue to propagate errors correctly.

* **Tests**
  * Added coverage for indexed function calls, method binding, class dispatch, and promise combinators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->