### PR TITLE
fix(runtime): `in` on a class instance walks the declared-class prototype (unblocks nightly)

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set/has_property.rs
+++ b/crates/perry-runtime/src/object/field_get_set/has_property.rs
@@ -876,8 +876,46 @@ unsafe fn ordinary_has_property(
                 // and could spuriously hop. Arrays never model a synthetic
                 // prototype, so skip the lookup for them.
                 if !cur_is_array {
-                    let synth_proto =
-                        crate::object::class_prototype_object(unsafe { (*cur).class_id });
+                    let cur_class_id = unsafe { (*cur).class_id };
+                    // A DECLARED class instance (`class C {}; new C()`) records no
+                    // static `[[Prototype]]`: its prototype is the reflective
+                    // `C.prototype` object in the SEPARATE `CLASS_DECL_PROTOTYPE_OBJECTS`
+                    // table, which the synthetic-proto lookup below cannot see.
+                    // `js_object_get_prototype_of` already resolves it (that is why
+                    // `Object.getPrototypeOf(inst) === C.prototype` holds), so without
+                    // the same hop here `in` and `getPrototypeOf` disagreed about the
+                    // very same chain: `"m" in new C()` was false for any member that
+                    // is not a vtable method — notably a method added by ASSIGNMENT
+                    // (`C.prototype.m = fn`, stored in `CLASS_PROTOTYPE_METHODS` and
+                    // mirrored onto the decl-proto object), which the
+                    // `class_instance_has_member` vtable fallback below does not cover.
+                    // That divergence silently emptied `for…in` over an instance: the
+                    // #6147 for-in desugar re-checks every snapshotted key with
+                    // `key in obj` (so a key deleted mid-iteration is not visited), and
+                    // this `false` filtered the inherited keys back out again.
+                    //
+                    // Resolve through the materializing accessor — the same one
+                    // `js_object_get_prototype_of` uses — so the walk is
+                    // order-independent: a `C.prototype.m = fn` assignment registers the
+                    // method long before any reflective `C.prototype` read materializes
+                    // the decl-proto object.
+                    if let Some(decl_proto) =
+                        crate::object::class_decl_prototype_value_for_instance_class(cur_class_id)
+                    {
+                        let decl_ptr = (decl_proto.to_bits() & crate::value::POINTER_MASK)
+                            as *const ObjectHeader;
+                        // The decl-proto object is allocated WITH the class's own id
+                        // (`js_object_alloc(class_id, 0)`), so re-resolving it from the
+                        // proto itself yields the same pointer — hopping again would
+                        // spin. Stop at the self-edge; the decl-proto records a real
+                        // static `[[Prototype]]` to its parent, which the walk above
+                        // follows on the next turn.
+                        if !decl_ptr.is_null() && decl_ptr != cur {
+                            cur = decl_ptr;
+                            continue;
+                        }
+                    }
+                    let synth_proto = crate::object::class_prototype_object(cur_class_id);
                     if !synth_proto.is_null() && synth_proto as *const ObjectHeader != cur {
                         cur = synth_proto as *const ObjectHeader;
                         continue;


### PR DESCRIPTION
## Unblocks the nightly

The nightly `cargo-test` job has been red since **`d51b057f4`** — *"fix(runtime,lower): in-operator walks Object.create protos; for-in skips deleted keys (#6147)"*, 2026-07-08 — on:

```
cargo test -p perry --test issue_5024_class_prototype_assignment_enumeration
  assignment_registered_prototype_methods_are_enumerable ... FAILED
```

This restores it to green. Both tests in the suite pass, and the compiled program is byte-for-byte identical to `node --experimental-strip-types`.

## The failure

Exactly one of the five asserted lines was wrong — `for…in` over an **instance**:

```
   forin: int,optional      correct
   inst:                    <-- expected "int,optional"
   keys: ["int"]            correct
   in: true                 correct
   hasOwn: true             correct
```

## Bisect

| commit | result |
|---|---|
| `7724c039e` (parent of #6147) | **GOOD** |
| `d51b057f4` (#6147) | **BAD** — same signature as `main` |
| `735e89480` (`main`) | BAD |

Parent good + commit bad ⇒ first bad commit. Both endpoints were built from source (compiler **and** both static archives); the good endpoint was verified good before being trusted.

Note this exonerates `5afa08fca` (the #5874 revert, 2026-07-05), the commit the red date superficially pointed at: the verified-good endpoint `7724c039e` sits *after* it.

## Root cause

The enumeration walk was never at fault. #6147 added `guard_for_in_body` (`perry-hir/src/lower/for_head.rs`), which re-checks every snapshotted key with **`key in obj`** so a key deleted mid-iteration is not visited (EnumerateObjectProperties). `js_for_in_keys_value` collected the inherited keys correctly — and the new guard then filtered them straight back out, because `"m" in inst` was `false`.

So `in` was the bug. In `ordinary_has_property`, a receiver with no recorded static `[[Prototype]]` hops through `CLASS_PROTOTYPE_OBJECTS` — the **synthetic** table used by `Object.create` / plain-function constructors. A **declared**-class instance's prototype lives in the separate `CLASS_DECL_PROTOTYPE_OBJECTS` table, which that hop cannot see, so the walk stopped dead at the instance. The tail fallback (`class_instance_has_member`) only covers **vtable** methods — not a method added by assignment (`C.prototype.m = fn`, which lives in `CLASS_PROTOTYPE_METHODS` and is mirrored onto the decl-proto object).

Meanwhile `js_object_get_prototype_of` **does** resolve the decl-proto — which is why `Object.getPrototypeOf(inst) === C.prototype` held all along. The two prototype-resolution paths disagreed about the very same chain, and #6147 made `for…in` depend on the one that was wrong.

## Fix

One hop, in the `None` (no recorded static prototype) arm of `ordinary_has_property`: resolve the decl-proto too, through the same materializing accessor `js_object_get_prototype_of` uses, so `in` and `getPrototypeOf` agree.

Using the materializing accessor keeps the walk order-independent — `C.prototype.m = fn` runs at module init, long before any reflective `C.prototype` read materializes the object. The decl-proto carries the class's own `class_id`, so re-resolving it from itself returns the same pointer; the code stops at that self-edge and lets the decl-proto's recorded static `[[Prototype]]` carry the walk up to the parent class.

This also fixes, directly, two things that are `true` in Node and were `false` here:

```ts
class C {}
(C as any).prototype.m = function () {};
const c: any = new C();
"m" in c            // was false -> now true
"constructor" in c  // was false -> now true
```

## Validation

- `cargo test -p perry --test issue_5024_class_prototype_assignment_enumeration` — **2 passed, 0 failed**.
- Test program byte-identical to `node --experimental-strip-types`, as are three additional hand-written probes covering instance/prototype `for…in`, `Object.keys`, `getOwnPropertyNames`, `in`, and `hasOwnProperty`.
- Full `test-files/test_gap_*` suite (296 tests) A/B'd against a **pristine `origin/main`** build: **zero regressions**.

The A/B used two fully independent toolchains — each with its own `perry` **and** its own `libperry_runtime.a` / `libperry_stdlib.a`, with `PERRY_RUNTIME_DIR` pinned to its own directory (verified by distinct archive SHA-256s, and by the baseline still reproducing the bug). `perry-runtime` / `perry-stdlib` are `crate-type = ["rlib"]`, so building *them* does not refresh the archives that `perry compile` links — the `.a` files come from the `perry-runtime-static` / `perry-stdlib-static` wrapper crates (#5422). Building only the rlib crates leaves both sides of an A/B linking the same stale archive, which makes the comparison vacuous.

## Why CI missed it for 5 days

`.github/workflows/test.yml` runs `cargo test -p perry` (the `tests/*.rs` integration suite, this one included) only on the **full nightly / tag** path; the per-PR path deliberately skips it for runtime. So #6147 could land without CI ever executing this test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed prototype-chain traversal for declared class instances.
  - Corrected `in` checks and `getPrototypeOf` behavior for members added to class prototypes.
  - Preserved accurate prototype lookup after prototype replacements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->