### PR TITLE
fix(npm): run on glibc older than the builder's — route Ubuntu 22.04 / Debian 12 / RHEL 9 to the static build (#6298)

### DIFF
--- a/.github/workflows/npm-launcher.yml
+++ b/.github/workflows/npm-launcher.yml
@@ -88,7 +88,17 @@ jobs:
           cp "$GITHUB_WORKSPACE/npm/perry/bin/detect.cjs" node_modules/@perryts/perry/bin/detect.cjs
           node node_modules/@perryts/perry/bin/perry.js --version
 
+      # Perry's LLVM backend emits opaque-pointer IR (`ptr`) and shells out to
+      # `clang -c`. Jammy's default clang is 14, which predates opaque pointers
+      # and rejects the IR with "expected type" — nothing to do with libc, and it
+      # bites the glibc binary just as hard. Ubuntu 22.04 users need clang >= 15
+      # (in the jammy archive) on PATH or in PERRY_LLVM_CLANG.
+      - name: Install clang 15 (jammy default clang is too old for opaque-pointer IR)
+        run: sudo apt-get update && sudo apt-get install -y clang-15
+
       - name: Compile and run a TypeScript program with the fallback binary
+        env:
+          PERRY_LLVM_CLANG: /usr/bin/clang-15
         run: |
           cd /tmp/e2e
           cat > hello.ts <<'TS'

--- a/.github/workflows/npm-launcher.yml
+++ b/.github/workflows/npm-launcher.yml
@@ -75,7 +75,7 @@ jobs:
             echo "$out" | grep -qi "GLIBC" || { echo "failed for some other reason than glibc"; exit 1; }
           fi
 
-      - name: Install the static build (npm skips it here — libc: musl)
+      - name: "Install the static build (npm skips it here: libc is musl)"
         run: |
           cd /tmp/e2e
           version=$(node -p "require('@perryts/perry/package.json').version")

--- a/.github/workflows/npm-launcher.yml
+++ b/.github/workflows/npm-launcher.yml
@@ -15,6 +15,12 @@ on:
       - ".github/workflows/npm-launcher.yml"
   workflow_dispatch:
 
+# This workflow installs and executes published registry content (the platform
+# packages) — so it must not carry a writable token, and checkout must not leave
+# a git credential on disk for that content to find.
+permissions:
+  contents: read
+
 jobs:
   # Hermetic: no network, no platform packages — just the resolution rules.
   detect-self-test:
@@ -23,6 +29,8 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v6
         with:
           node-version: "22.23.1"
@@ -40,6 +48,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v6
         with:
           node-version: "22.23.1"

--- a/.github/workflows/npm-launcher.yml
+++ b/.github/workflows/npm-launcher.yml
@@ -1,0 +1,106 @@
+name: npm launcher
+
+# The @perryts/perry launcher decides which prebuilt binary a machine gets. That
+# decision is invisible to every other job in CI — the compiler is never built or
+# run through it — so install breakage on a whole distro family can (and did,
+# #6298) ship unnoticed. This workflow exercises the launcher itself.
+#
+# Path-filtered: it only runs when the launcher or the install script changes.
+
+on:
+  pull_request:
+    paths:
+      - "npm/**"
+      - "packaging/install.sh"
+      - ".github/workflows/npm-launcher.yml"
+  push:
+    branches:
+      - "fix/6298-glibc-235-fallback"
+  workflow_dispatch:
+
+jobs:
+  # Hermetic: no network, no platform packages — just the resolution rules.
+  detect-self-test:
+    name: Platform resolution self-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22.23.1"
+      - run: node npm/perry/test/detect.test.cjs
+      - name: install.sh is valid POSIX sh
+        run: sh -n packaging/install.sh
+
+  # End-to-end on the platform from #6298: Ubuntu 22.04 = glibc 2.35, older than
+  # the glibc 2.39 the release matrix builds the linux-gnu binaries against.
+  # Installs the *published* platform packages and runs this repo's launcher
+  # against them.
+  ubuntu-2204:
+    name: Ubuntu 22.04 (glibc 2.35) end-to-end
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22.23.1"
+
+      - name: Host glibc
+        run: |
+          ldd --version | head -1
+          node -p "'node reports glibcVersionRuntime: ' + process.report.getReport().header.glibcVersionRuntime"
+
+      - name: Install @perryts/perry the way a user would
+        run: |
+          mkdir -p /tmp/e2e && cd /tmp/e2e
+          npm init -y >/dev/null 2>&1
+          npm install @perryts/perry@latest --no-audit --no-fund
+          echo "installed platform packages:"
+          ls node_modules/@perryts/
+
+      - name: Show the bug — the glibc binary npm picked cannot load here
+        run: |
+          cd /tmp/e2e
+          set +e
+          out=$(./node_modules/@perryts/perry-linux-x64/bin/perry --version 2>&1)
+          code=$?
+          set -e
+          echo "exit=$code"
+          echo "$out"
+          if [ "$code" -eq 0 ]; then
+            echo "::warning::the prebuilt glibc binary loaded on glibc 2.35 — the floor in bin/detect.cjs may be too high"
+          else
+            echo "$out" | grep -qi "GLIBC" || { echo "failed for some other reason than glibc"; exit 1; }
+          fi
+
+      - name: Install the static build (npm skips it here — libc: musl)
+        run: |
+          cd /tmp/e2e
+          version=$(node -p "require('@perryts/perry/package.json').version")
+          npm install --force "@perryts/perry-linux-x64-musl@$version" --no-audit --no-fund
+
+      - name: Launcher under test routes to the static build
+        run: |
+          cd /tmp/e2e
+          cp "$GITHUB_WORKSPACE/npm/perry/bin/perry.js" node_modules/@perryts/perry/bin/perry.js
+          cp "$GITHUB_WORKSPACE/npm/perry/bin/detect.cjs" node_modules/@perryts/perry/bin/detect.cjs
+          node node_modules/@perryts/perry/bin/perry.js --version
+
+      - name: Compile and run a TypeScript program with the fallback binary
+        run: |
+          cd /tmp/e2e
+          cat > hello.ts <<'TS'
+          class Greeter {
+            constructor(private who: string) {}
+            greet(): string { return `hello ${this.who}`; }
+          }
+          const doubled = [1, 2, 3].map((x) => x * 2);
+          console.log(new Greeter("22.04").greet(), doubled.join(","));
+          TS
+          node node_modules/@perryts/perry/bin/perry.js hello.ts -o hello
+          ./hello
+          test "$(./hello)" = "hello 22.04 2,4,6"
+          echo "compiled binary links against:"
+          ldd ./hello || true

--- a/.github/workflows/npm-launcher.yml
+++ b/.github/workflows/npm-launcher.yml
@@ -13,9 +13,6 @@ on:
       - "npm/**"
       - "packaging/install.sh"
       - ".github/workflows/npm-launcher.yml"
-  push:
-    branches:
-      - "fix/6298-glibc-235-fallback"
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -995,8 +995,10 @@ triggers on a published GitHub Release or manual `workflow_dispatch`. Matrix
 runners build:
 
 - `macos-14` / `macos-15` — arm64 + x86_64 Darwin binaries
-- `ubuntu-22.04` / `ubuntu-24.04-arm` — glibc x86_64 + aarch64
-- `ubuntu-22.04` / `ubuntu-24.04-arm` — musl x86_64 + aarch64
+- `ubuntu-24.04` / `ubuntu-24.04-arm` — glibc x86_64 + aarch64 (glibc 2.39 floor:
+  the npm launcher and `install.sh` route older-glibc hosts to the musl build — if
+  you move these runners, update `GLIBC_BUILD_FLOOR` in `npm/perry/bin/detect.cjs`)
+- `ubuntu-24.04` / `ubuntu-24.04-arm` — musl x86_64 + aarch64 (fully static)
 - `windows-latest` — x86_64 MSVC
 
 Artifacts are published to:

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -63,6 +63,21 @@ npx -y @perryts/perry compile src/main.ts -o myapp
 | Linux arm64 (musl / Alpine) | `@perryts/perry-linux-arm64-musl` |
 | Windows x64 | `@perryts/perry-win32-x64` |
 
+#### Linux glibc requirement
+
+The Linux **glibc** binaries are built on Ubuntu 24.04, so they require **glibc ≥ 2.39**. Older distributions — Ubuntu 22.04 (glibc 2.35), Debian 12 (2.36), RHEL 9 / Amazon Linux 2023 (2.34) — cannot load them; the dynamic loader fails with `GLIBC_2.39 not found` before Perry starts.
+
+On those hosts Perry uses the **fully-static musl build** instead, which has no libc dependency and runs on any Linux:
+
+- **`install.sh`** detects the glibc version and downloads `perry-linux-<arch>-musl.tar.gz` automatically.
+- **npm** — the launcher routes to `@perryts/perry-linux-x64-musl` (or `-arm64-musl`) and prints a one-time notice. npm does not install that package on a glibc machine by itself (its `libc` selector says `musl`), so install it once:
+
+  ```bash
+  npm install --force @perryts/perry-linux-x64-musl
+  ```
+
+The static build is the same compiler and produces the same binaries. The only feature it does not support is `perry/ui` (GTK4 desktop apps), which needs glibc. Tracking issue: [#6298](https://github.com/PerryTS/perry/issues/6298).
+
 ### Homebrew (macOS)
 
 ```bash

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -5,8 +5,10 @@
 Perry compiles TypeScript to native binaries by linking with your system's C toolchain, so every install path needs a linker:
 
 - **macOS**: Xcode Command Line Tools (`xcode-select --install`)
-- **Linux**: `gcc` or `clang` — see your distro below
+- **Linux**: `gcc` or `clang` for linking, plus **clang ≥ 15** for codegen — see your distro below
 - **Windows**: LLVM (`winget install LLVM.LLVM`) + `perry setup windows` (lightweight, ~1.5 GB, no Visual Studio needed), or MSVC Build Tools with the "Desktop development with C++" workload — see the [Windows platform guide](../platforms/windows.md) for both options
+
+> **clang ≥ 15 on Linux.** Perry's LLVM backend emits opaque-pointer IR (`ptr`) and compiles it with `clang -c`. clang 14 and older reject it with `error: expected type`. Ubuntu 22.04's default `clang` is 14 — install a newer one (`sudo apt install clang-15`) and point Perry at it if it isn't the default: `export PERRY_LLVM_CLANG=/usr/bin/clang-15`. Ubuntu 24.04, Debian 13, Fedora 39+ and Arch all ship a new enough clang.
 
 Linux C toolchain by distribution:
 

--- a/npm/perry/README.md
+++ b/npm/perry/README.md
@@ -41,7 +41,7 @@ The launcher tells you this (with the exact command) instead of letting the bina
 Perry produces native binaries by linking its runtime and stdlib (shipped as static archives in the platform package) into your code. That link step uses your system C toolchain, so you need:
 
 - **macOS** — Xcode Command Line Tools (`xcode-select --install`)
-- **Linux** — `gcc` or `clang` (e.g. `apt install build-essential` on Debian/Ubuntu, `apk add build-base` on Alpine)
+- **Linux** — `gcc` or `clang` (e.g. `apt install build-essential` on Debian/Ubuntu, `apk add build-base` on Alpine), plus **clang ≥ 15**: codegen emits opaque-pointer LLVM IR, which clang 14 and older reject with `error: expected type`. Ubuntu 22.04 defaults to clang 14 — `apt install clang-15` and `export PERRY_LLVM_CLANG=/usr/bin/clang-15`.
 - **Windows** — MSVC / Visual Studio Build Tools with the C++ workload
 
 Node.js 16 or later is required for the wrapper itself.

--- a/npm/perry/README.md
+++ b/npm/perry/README.md
@@ -24,6 +24,18 @@ Installing picks the right prebuilt binary for your platform automatically — `
 | Linux arm64 (musl / Alpine) | `@perryts/perry-linux-arm64-musl` |
 | Windows x64 | `@perryts/perry-win32-x64` |
 
+### Linux: glibc version
+
+The glibc packages are built on Ubuntu 24.04 (glibc 2.39), so they need **glibc ≥ 2.39**. On an older glibc — Ubuntu 22.04 (2.35), Debian 12 (2.36), RHEL 9 / Amazon Linux 2023 (2.34) — the launcher automatically runs the fully-static musl build instead, which has no libc dependency at all and works everywhere ([#6298](https://github.com/PerryTS/perry/issues/6298)). It prints a one-time notice when it does; set `PERRY_NO_FALLBACK_NOTICE=1` to silence it.
+
+npm only installs the musl package when it thinks the machine is musl-based, so on an old-glibc host you have to ask for it once:
+
+```bash
+npm install --force @perryts/perry-linux-x64-musl   # or -arm64-musl
+```
+
+The launcher tells you this (with the exact command) instead of letting the binary die with `GLIBC_2.39 not found`. The static build is the same compiler; the one thing it cannot do is build `perry/ui` GTK4 desktop apps.
+
 ## Host requirements
 
 Perry produces native binaries by linking its runtime and stdlib (shipped as static archives in the platform package) into your code. That link step uses your system C toolchain, so you need:

--- a/npm/perry/bin/detect.cjs
+++ b/npm/perry/bin/detect.cjs
@@ -1,0 +1,138 @@
+"use strict";
+// Platform detection for the @perryts/perry launcher.
+//
+// Split out of bin/perry.js so the resolution rules can be exercised directly
+// (see ../test/detect.test.js) with a synthetic host description instead of
+// whatever machine happens to run the tests.
+
+const PLATFORM_PACKAGES = {
+  "darwin-arm64": "@perryts/perry-darwin-arm64",
+  "darwin-x64": "@perryts/perry-darwin-x64",
+  "linux-arm64": "@perryts/perry-linux-arm64",
+  "linux-arm64-musl": "@perryts/perry-linux-arm64-musl",
+  "linux-x64": "@perryts/perry-linux-x64",
+  "linux-x64-musl": "@perryts/perry-linux-x64-musl",
+  "win32-x64": "@perryts/perry-win32-x64",
+};
+
+// Minimum glibc the prebuilt *glibc* Linux binaries can run on.
+//
+// KEEP IN SYNC WITH THE BUILDER IMAGE. `.github/workflows/release-packages.yml`
+// builds `x86_64-unknown-linux-gnu` on `ubuntu-24.04` and
+// `aarch64-unknown-linux-gnu` on `ubuntu-24.04-arm`. Both images ship glibc
+// 2.39, so the emitted ELF carries GLIBC_2.39 symbol-version references and the
+// dynamic loader refuses to start it on anything older — the process dies with
+// `GLIBC_2.39 not found` before Perry's own code runs (#6298).
+//
+// A binary only requires the glibc version whose symbols it actually pulls in,
+// so this is an upper bound: it is the version of the builder image, and the
+// safe assumption is that the binary needs all of it. If the release matrix
+// moves to a different base image, update this constant in the same commit —
+// otherwise hosts that *could* run the glibc build get silently pushed onto the
+// static build (too high a value), or hosts that can't get the loader error back
+// (too low a value).
+const GLIBC_BUILD_FLOOR = "2.39";
+
+// Compare two dotted numeric versions ("2.35", "2.39.1"). Returns <0, 0, >0.
+// Non-numeric components sort as 0 — glibc versions are always numeric, and a
+// garbage value should not be read as "newer than the floor".
+function compareVersions(a, b) {
+  const pa = String(a).split(".");
+  const pb = String(b).split(".");
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const na = parseInt(pa[i], 10) || 0;
+    const nb = parseInt(pb[i], 10) || 0;
+    if (na !== nb) return na - nb;
+  }
+  return 0;
+}
+
+// Read the host description this module reasons about. `glibcVersionRuntime` is
+// what Node itself uses for the `libc` field of optional deps: a version string
+// on glibc, and empty/absent on musl.
+function readHost() {
+  const host = {
+    platform: process.platform,
+    arch: process.arch,
+    hasGlibcField: false,
+    glibcVersionRuntime: undefined,
+    osRelease: null,
+  };
+  try {
+    const header = process.report && process.report.getReport().header;
+    if (header && "glibcVersionRuntime" in header) {
+      host.hasGlibcField = true;
+      host.glibcVersionRuntime = header.glibcVersionRuntime;
+    }
+  } catch (_) {
+    /* process.report unavailable — fall back to /etc/os-release below. */
+  }
+  try {
+    host.osRelease = require("fs").readFileSync("/etc/os-release", "utf8");
+  } catch (_) {
+    /* not Linux, or no os-release — leave null. */
+  }
+  return host;
+}
+
+function isMusl(host) {
+  if (host.platform !== "linux") return false;
+  // Node reports an empty glibc version on musl. This is the same signal npm
+  // uses for the `libc` selector, so it agrees with what npm installed.
+  if (host.hasGlibcField) return !host.glibcVersionRuntime;
+  // No report header (very old Node, or a hardened runtime): sniff os-release.
+  if (host.osRelease) return /\bID=alpine\b|\bmusl\b/i.test(host.osRelease);
+  return false;
+}
+
+function glibcVersion(host) {
+  if (host.platform !== "linux") return null;
+  if (!host.hasGlibcField) return null;
+  const v = host.glibcVersionRuntime;
+  return typeof v === "string" && /^\d+(\.\d+)*$/.test(v) ? v : null;
+}
+
+// Resolve a host to the ordered list of platform packages that could serve it.
+//
+// `candidates[0]` is the preferred package; later entries are tried only if the
+// preferred one is not installed. `reason` explains the choice:
+//
+//   "native"        — the plain os-arch build is the right one
+//   "musl"          — musl libc host (Alpine/distroless): the static build
+//   "glibc-too-old" — glibc host whose glibc predates the builder image, so the
+//                     glibc build's loader would reject it (#6298). The musl
+//                     build is fully static, so it runs here.
+function detectPlatform(host) {
+  const base = `${host.platform}-${host.arch}`;
+
+  if (host.platform !== "linux") {
+    return { candidates: [base], reason: "native", glibc: null };
+  }
+
+  if (isMusl(host)) {
+    // Fall back to the glibc package: some glibc systems (custom kernels, odd
+    // container images) report an empty glibcVersionRuntime and land here by
+    // mistake — see #116 / v0.5.118. If the musl package really isn't there,
+    // the glibc one is the better guess than a hard failure.
+    return { candidates: [`${base}-musl`, base], reason: "musl", glibc: null };
+  }
+
+  const glibc = glibcVersion(host);
+  if (glibc && compareVersions(glibc, GLIBC_BUILD_FLOOR) < 0) {
+    // Deliberately no glibc fallback: that binary physically cannot load here.
+    return { candidates: [`${base}-musl`], reason: "glibc-too-old", glibc };
+  }
+
+  return { candidates: [base], reason: "native", glibc };
+}
+
+module.exports = {
+  PLATFORM_PACKAGES,
+  GLIBC_BUILD_FLOOR,
+  compareVersions,
+  detectPlatform,
+  glibcVersion,
+  isMusl,
+  readHost,
+};

--- a/npm/perry/bin/perry.js
+++ b/npm/perry/bin/perry.js
@@ -5,62 +5,51 @@
 // optional-dependency packages that npm picks by os/cpu/libc.
 
 const { spawn } = require("child_process");
+const {
+  PLATFORM_PACKAGES,
+  GLIBC_BUILD_FLOOR,
+  detectPlatform,
+  readHost,
+} = require("./detect.cjs");
 
-const PLATFORM_PACKAGES = {
-  "darwin-arm64": "@perryts/perry-darwin-arm64",
-  "darwin-x64": "@perryts/perry-darwin-x64",
-  "linux-arm64": "@perryts/perry-linux-arm64",
-  "linux-arm64-musl": "@perryts/perry-linux-arm64-musl",
-  "linux-x64": "@perryts/perry-linux-x64",
-  "linux-x64-musl": "@perryts/perry-linux-x64-musl",
-  "win32-x64": "@perryts/perry-win32-x64",
-};
-
-function isMusl() {
-  if (process.platform !== "linux") return false;
-  try {
-    const header = process.report && process.report.getReport().header;
-    if (header && "glibcVersionRuntime" in header) {
-      return !header.glibcVersionRuntime;
-    }
-  } catch (_) {}
-  try {
-    const release = require("fs").readFileSync("/etc/os-release", "utf8");
-    return /\bID=alpine\b|\bmusl\b/i.test(release);
-  } catch (_) {}
-  return false;
-}
-
-function detectKey() {
-  let key = `${process.platform}-${process.arch}`;
-  if (process.platform === "linux" && isMusl()) key += "-musl";
-  return key;
-}
-
-const key = detectKey();
-const pkg = PLATFORM_PACKAGES[key];
-if (!pkg) {
-  console.error(
-    `[perry] No prebuilt binary for ${key}.\n` +
-      `Supported: ${Object.keys(PLATFORM_PACKAGES).join(", ")}\n` +
-      `File an issue: https://github.com/PerryTS/perry/issues`
-  );
-  process.exit(1);
-}
-
+const host = readHost();
+const detected = detectPlatform(host);
 const binName = process.platform === "win32" ? "perry.exe" : "perry";
-let binPath;
-try {
-  binPath = require.resolve(`${pkg}/bin/${binName}`);
-} catch (err) {
-  console.error(
-    `[perry] The ${pkg} package is not installed.\n` +
-      `This usually means npm skipped the optional dependency for ${key}.\n` +
-      `Try: npm install --force ${pkg}\n` +
-      `Or reinstall @perryts/perry with a matching npm (\u22658.12) so os/cpu/libc selectors apply.\n` +
-      `Underlying error: ${err.message}`
-  );
+
+// Walk the candidate packages in preference order. On Linux the first entry may
+// be the fully-static musl build (musl host, or a glibc host older than the one
+// the glibc binaries were built on — #6298); everywhere else there is exactly
+// one candidate and this loop is the old single require.resolve.
+let binPath = null;
+let usedKey = null;
+const resolveErrors = [];
+for (const key of detected.candidates) {
+  const pkg = PLATFORM_PACKAGES[key];
+  if (!pkg) continue;
+  try {
+    binPath = require.resolve(`${pkg}/bin/${binName}`);
+    usedKey = key;
+    break;
+  } catch (err) {
+    resolveErrors.push(`${pkg}: ${err.message}`);
+  }
+}
+
+if (!binPath) {
+  reportResolutionFailure();
   process.exit(1);
+}
+
+// Tell the user once — not on every invocation — when they are not running the
+// binary their platform string implies.
+if (detected.reason === "glibc-too-old" && usedKey.endsWith("-musl")) {
+  noticeOnce(
+    `[perry] glibc ${detected.glibc} is older than the prebuilt glibc binary requires ` +
+      `(>= ${GLIBC_BUILD_FLOOR}), so Perry is running its fully-static Linux build ` +
+      `(${PLATFORM_PACKAGES[usedKey]}).\n` +
+      `[perry] Same compiler; the static build cannot produce perry/ui (GTK4) apps. ` +
+      `Set PERRY_NO_FALLBACK_NOTICE=1 to silence this. Details: https://github.com/PerryTS/perry/issues/6298`
+  );
 }
 
 const child = spawn(binPath, process.argv.slice(2), { stdio: "inherit" });
@@ -87,3 +76,83 @@ child.on("error", (err) => {
   console.error(`[perry] Failed to spawn ${binPath}: ${err.message}`);
   process.exit(1);
 });
+
+// --- helpers ---------------------------------------------------------------
+
+// Print `msg` at most once per (version, platform key) on this machine. The
+// stamp lives in the temp dir, so it comes back after a reboot/cleanup — that's
+// deliberate: the message is worth seeing again occasionally, just not on every
+// single `perry` invocation in a build loop.
+function noticeOnce(msg) {
+  if (process.env.PERRY_NO_FALLBACK_NOTICE) return;
+  const fs = require("fs");
+  const path = require("path");
+  const os = require("os");
+  let version = "unknown";
+  try {
+    version = require("../package.json").version;
+  } catch (_) {}
+  const stamp = path.join(
+    os.tmpdir(),
+    `perry-static-fallback-${version}-${usedKey}.stamp`
+  );
+  try {
+    // "wx" fails with EEXIST if we already printed this.
+    fs.closeSync(fs.openSync(stamp, "wx"));
+  } catch (err) {
+    if (err && err.code === "EEXIST") return;
+    // Any other stamp problem (read-only tmp, etc.) — print, don't crash.
+  }
+  console.error(msg);
+}
+
+function reportResolutionFailure() {
+  const key = detected.candidates[0];
+  const pkg = PLATFORM_PACKAGES[key];
+
+  if (!pkg) {
+    console.error(
+      `[perry] No prebuilt binary for ${key}.\n` +
+        `Supported: ${Object.keys(PLATFORM_PACKAGES).join(", ")}\n` +
+        `File an issue: https://github.com/PerryTS/perry/issues`
+    );
+    return;
+  }
+
+  let version = "";
+  try {
+    version = `@${require("../package.json").version}`;
+  } catch (_) {}
+
+  if (detected.reason === "glibc-too-old") {
+    // npm skipped the musl package because this host is glibc — its `libc`
+    // selector says "musl". Without --force npm refuses to install it here, so
+    // spell the command out rather than leaving the user with a loader error.
+    console.error(
+      `[perry] This system has glibc ${detected.glibc}, but Perry's prebuilt Linux binary\n` +
+        `        needs glibc >= ${GLIBC_BUILD_FLOOR} (it is built on ubuntu-24.04). Running it would fail\n` +
+        `        in the dynamic loader with "GLIBC_${GLIBC_BUILD_FLOOR} not found".\n` +
+        `\n` +
+        `        Perry also ships a fully-static Linux build that needs no glibc at all, but\n` +
+        `        npm skipped it here because that package is tagged libc: ["musl"]. Install it:\n` +
+        `\n` +
+        `            npm install --force ${pkg}${version}\n` +
+        `\n` +
+        `        ...then re-run perry — this launcher picks it up automatically.\n` +
+        `\n` +
+        `        Or install outside npm (this picks the static build for you):\n` +
+        `            curl -fsSL https://perryts.com/install.sh | sh\n` +
+        `\n` +
+        `        Tracking: https://github.com/PerryTS/perry/issues/6298`
+    );
+    return;
+  }
+
+  console.error(
+    `[perry] The ${pkg} package is not installed.\n` +
+      `This usually means npm skipped the optional dependency for ${key}.\n` +
+      `Try: npm install --force ${pkg}${version}\n` +
+      `Or reinstall @perryts/perry with a matching npm (≥8.12) so os/cpu/libc selectors apply.\n` +
+      `Underlying error: ${resolveErrors.join("; ")}`
+  );
+}

--- a/npm/perry/bin/perry.js
+++ b/npm/perry/bin/perry.js
@@ -134,8 +134,13 @@ function reportResolutionFailure() {
         `        in the dynamic loader with "GLIBC_${GLIBC_BUILD_FLOOR} not found".\n` +
         `\n` +
         `        Perry also ships a fully-static Linux build that needs no glibc at all, but\n` +
-        `        npm skipped it here because that package is tagged libc: ["musl"]. Install it:\n` +
+        `        npm skipped it here because that package is tagged libc: ["musl"]. Install it\n` +
+        `        the same way you installed perry:\n` +
         `\n` +
+        `          if perry is GLOBAL (npm i -g @perryts/perry):\n` +
+        `            npm install -g --force ${pkg}${version}\n` +
+        `\n` +
+        `          if perry is a PROJECT dependency:\n` +
         `            npm install --force ${pkg}${version}\n` +
         `\n` +
         `        ...then re-run perry — this launcher picks it up automatically.\n` +
@@ -151,7 +156,9 @@ function reportResolutionFailure() {
   console.error(
     `[perry] The ${pkg} package is not installed.\n` +
       `This usually means npm skipped the optional dependency for ${key}.\n` +
-      `Try: npm install --force ${pkg}${version}\n` +
+      `Install it the same way you installed perry:\n` +
+      `  global:  npm install -g --force ${pkg}${version}\n` +
+      `  project: npm install --force ${pkg}${version}\n` +
       `Or reinstall @perryts/perry with a matching npm (≥8.12) so os/cpu/libc selectors apply.\n` +
       `Underlying error: ${resolveErrors.join("; ")}`
   );

--- a/npm/perry/test/detect.test.cjs
+++ b/npm/perry/test/detect.test.cjs
@@ -1,0 +1,227 @@
+"use strict";
+// Self-test for the @perryts/perry launcher's platform resolution.
+//
+//   node npm/perry/test/detect.test.js
+//
+// No dependencies, no network, no installed platform packages — it feeds
+// synthetic host descriptions (the shape of `process.report.getReport().header`
+// on each platform) through detectPlatform() and checks where they land.
+//
+// It also cross-checks the launcher against the things it has to agree with:
+//   * every package it can name is a real optionalDependency of @perryts/perry
+//   * the release matrix really does build the musl targets it falls back to
+//   * the glibc targets are still built on the image GLIBC_BUILD_FLOOR assumes
+
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+const {
+  PLATFORM_PACKAGES,
+  GLIBC_BUILD_FLOOR,
+  compareVersions,
+  detectPlatform,
+} = require("../bin/detect.cjs");
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+let failures = 0;
+
+function check(name, fn) {
+  try {
+    fn();
+    console.log(`  ok   ${name}`);
+  } catch (err) {
+    failures++;
+    console.log(`  FAIL ${name}\n       ${err.message}`);
+  }
+}
+
+// A glibc host: Node reports the runtime glibc version in the report header.
+const glibcHost = (arch, version) => ({
+  platform: "linux",
+  arch,
+  hasGlibcField: true,
+  glibcVersionRuntime: version,
+  osRelease: "ID=ubuntu\n",
+});
+
+// A musl host: the field is present but empty. This is exactly what npm keys
+// its `libc` selector off.
+const muslHost = (arch) => ({
+  platform: "linux",
+  arch,
+  hasGlibcField: true,
+  glibcVersionRuntime: "",
+  osRelease: "ID=alpine\n",
+});
+
+console.log("\nglibc / musl routing (linux-x64, floor = " + GLIBC_BUILD_FLOOR + ")");
+console.log("  glibc            → package                          reason");
+console.log("  ---------------------------------------------------------------");
+const table = [
+  ["2.31 (Ubuntu 20.04)", glibcHost("x64", "2.31"), "linux-x64-musl", "glibc-too-old"],
+  ["2.34 (RHEL 9 / AL2023)", glibcHost("x64", "2.34"), "linux-x64-musl", "glibc-too-old"],
+  ["2.35 (Ubuntu 22.04)", glibcHost("x64", "2.35"), "linux-x64-musl", "glibc-too-old"],
+  ["2.36 (Debian 12)", glibcHost("x64", "2.36"), "linux-x64-musl", "glibc-too-old"],
+  ["2.39 (Ubuntu 24.04)", glibcHost("x64", "2.39"), "linux-x64", "native"],
+  ["2.41 (newer)", glibcHost("x64", "2.41"), "linux-x64", "native"],
+  ["(musl / Alpine)", muslHost("x64"), "linux-x64-musl", "musl"],
+];
+for (const [label, host, wantKey, wantReason] of table) {
+  const got = detectPlatform(host);
+  console.log(
+    `  ${label.padEnd(24)} ${got.candidates[0].padEnd(20)} ${got.reason}`
+  );
+  check(`${label} → ${wantKey} (${wantReason})`, () => {
+    assert.strictEqual(got.candidates[0], wantKey);
+    assert.strictEqual(got.reason, wantReason);
+  });
+}
+
+console.log("\nother platforms");
+check("linux-arm64 glibc 2.35 → linux-arm64-musl", () => {
+  const got = detectPlatform(glibcHost("arm64", "2.35"));
+  assert.strictEqual(got.candidates[0], "linux-arm64-musl");
+  assert.strictEqual(got.reason, "glibc-too-old");
+});
+check("linux-arm64 glibc 2.39 → linux-arm64", () => {
+  assert.strictEqual(detectPlatform(glibcHost("arm64", "2.39")).candidates[0], "linux-arm64");
+});
+check("linux-arm64 musl → linux-arm64-musl", () => {
+  assert.strictEqual(detectPlatform(muslHost("arm64")).candidates[0], "linux-arm64-musl");
+});
+check("darwin-arm64 unaffected", () => {
+  const got = detectPlatform({ platform: "darwin", arch: "arm64", hasGlibcField: false });
+  assert.deepStrictEqual(got.candidates, ["darwin-arm64"]);
+  assert.strictEqual(got.reason, "native");
+});
+check("win32-x64 unaffected", () => {
+  const got = detectPlatform({ platform: "win32", arch: "x64", hasGlibcField: false });
+  assert.deepStrictEqual(got.candidates, ["win32-x64"]);
+});
+
+console.log("\nhosts that don't report a glibc version");
+check("no report header + alpine os-release → musl", () => {
+  const got = detectPlatform({
+    platform: "linux",
+    arch: "x64",
+    hasGlibcField: false,
+    osRelease: 'ID=alpine\nNAME="Alpine Linux"\n',
+  });
+  assert.strictEqual(got.candidates[0], "linux-x64-musl");
+  assert.strictEqual(got.reason, "musl");
+});
+check("no report header + glibc os-release → linux-x64 (old behaviour kept)", () => {
+  const got = detectPlatform({
+    platform: "linux",
+    arch: "x64",
+    hasGlibcField: false,
+    osRelease: 'ID=ubuntu\nVERSION_ID="22.04"\n',
+  });
+  // Without a version we cannot know the binary won't load; guessing musl here
+  // would push every unknown host onto the static build. Stay on the default.
+  assert.deepStrictEqual(got.candidates, ["linux-x64"]);
+  assert.strictEqual(got.reason, "native");
+});
+check("empty glibcVersionRuntime (musl) falls back to the glibc pkg — #116", () => {
+  // Some glibc systems report an empty version (custom kernels / odd images).
+  // They get the musl package first, but must still be able to land on the
+  // glibc one if that's what npm actually installed.
+  const got = detectPlatform(muslHost("x64"));
+  assert.deepStrictEqual(got.candidates, ["linux-x64-musl", "linux-x64"]);
+});
+check("glibc-too-old does NOT fall back to the glibc pkg", () => {
+  // That binary physically cannot load — a fallback would just resurrect the
+  // "GLIBC_2.39 not found" error the user reported.
+  const got = detectPlatform(glibcHost("x64", "2.35"));
+  assert.deepStrictEqual(got.candidates, ["linux-x64-musl"]);
+});
+
+console.log("\nversion comparison");
+check("compareVersions is numeric, not lexical", () => {
+  assert.ok(compareVersions("2.35", "2.39") < 0);
+  assert.ok(compareVersions("2.39", "2.39") === 0);
+  assert.ok(compareVersions("2.40", "2.39") > 0);
+  assert.ok(compareVersions("2.9", "2.39") < 0, "2.9 must sort below 2.39");
+  assert.ok(compareVersions("3.0", "2.39") > 0);
+  assert.ok(compareVersions("2.39.1", "2.39") > 0);
+});
+check("a garbage glibc string is not treated as 'newer than the floor'", () => {
+  const got = detectPlatform({
+    platform: "linux",
+    arch: "x64",
+    hasGlibcField: true,
+    glibcVersionRuntime: "not-a-version",
+    osRelease: "ID=ubuntu\n",
+  });
+  // Unparseable → we don't know → keep the default package (status quo), never
+  // silently claim it satisfies the floor by string comparison.
+  assert.deepStrictEqual(got.candidates, ["linux-x64"]);
+});
+
+console.log("\nagreement with what actually ships");
+check("every platform package is an optionalDependency of @perryts/perry", () => {
+  const tmpl = fs.readFileSync(
+    path.join(REPO_ROOT, "npm", "perry", "package.json.tmpl"),
+    "utf8"
+  );
+  const manifest = JSON.parse(tmpl.replace(/__VERSION__/g, "0.0.0"));
+  const optional = Object.keys(manifest.optionalDependencies || {});
+  for (const pkg of Object.values(PLATFORM_PACKAGES)) {
+    assert.ok(optional.includes(pkg), `${pkg} missing from optionalDependencies`);
+  }
+});
+check("the musl packages the fallback targets have publishable manifests", () => {
+  for (const key of ["linux-x64-musl", "linux-arm64-musl"]) {
+    const dir = path.join(REPO_ROOT, "npm", "perry-" + key);
+    const tmpl = JSON.parse(
+      fs.readFileSync(path.join(dir, "package.json.tmpl"), "utf8").replace(/__VERSION__/g, "0.0.0")
+    );
+    assert.strictEqual(tmpl.name, PLATFORM_PACKAGES[key]);
+  }
+});
+check("release matrix builds the musl targets the fallback relies on", () => {
+  const wf = fs.readFileSync(
+    path.join(REPO_ROOT, ".github", "workflows", "release-packages.yml"),
+    "utf8"
+  );
+  assert.ok(wf.includes("x86_64-unknown-linux-musl"), "x86_64 musl target missing");
+  assert.ok(wf.includes("aarch64-unknown-linux-musl"), "aarch64 musl target missing");
+});
+check(`glibc legs still build on the image GLIBC_BUILD_FLOOR=${GLIBC_BUILD_FLOOR} assumes`, () => {
+  // The floor is a property of the *builder image*, not of Perry. If the glibc
+  // legs move to another runner, this fails and whoever moved them has to
+  // revisit GLIBC_BUILD_FLOOR in bin/detect.js instead of silently shipping a
+  // binary that the launcher's routing no longer describes.
+  //   ubuntu-24.04 / ubuntu-24.04-arm → glibc 2.39
+  const wf = fs.readFileSync(
+    path.join(REPO_ROOT, ".github", "workflows", "release-packages.yml"),
+    "utf8"
+  );
+  const entries = [
+    ...wf.matchAll(/-\s+os:\s*(\S+)\s*\n\s+target:\s*(\S+)/g),
+  ].map((m) => ({ os: m[1], target: m[2] }));
+  const gnu = entries.filter((e) => e.target.endsWith("-unknown-linux-gnu"));
+  assert.ok(gnu.length >= 2, `expected the linux-gnu legs in the matrix, saw ${gnu.length}`);
+  const IMAGE_GLIBC = { "ubuntu-24.04": "2.39", "ubuntu-24.04-arm": "2.39" };
+  for (const leg of gnu) {
+    const glibc = IMAGE_GLIBC[leg.os];
+    assert.ok(
+      glibc,
+      `${leg.target} now builds on '${leg.os}', an image this test doesn't know the ` +
+        `glibc of. Add it to IMAGE_GLIBC and re-check GLIBC_BUILD_FLOOR in bin/detect.js.`
+    );
+    assert.strictEqual(
+      glibc,
+      GLIBC_BUILD_FLOOR,
+      `${leg.target} builds on ${leg.os} (glibc ${glibc}) but GLIBC_BUILD_FLOOR is ` +
+        `${GLIBC_BUILD_FLOOR} — update bin/detect.js.`
+    );
+  }
+});
+
+console.log("");
+if (failures) {
+  console.log(`${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log("all checks passed");

--- a/npm/perry/test/detect.test.cjs
+++ b/npm/perry/test/detect.test.cjs
@@ -190,7 +190,7 @@ check("release matrix builds the musl targets the fallback relies on", () => {
 check(`glibc legs still build on the image GLIBC_BUILD_FLOOR=${GLIBC_BUILD_FLOOR} assumes`, () => {
   // The floor is a property of the *builder image*, not of Perry. If the glibc
   // legs move to another runner, this fails and whoever moved them has to
-  // revisit GLIBC_BUILD_FLOOR in bin/detect.js instead of silently shipping a
+  // revisit GLIBC_BUILD_FLOOR in bin/detect.cjs instead of silently shipping a
   // binary that the launcher's routing no longer describes.
   //   ubuntu-24.04 / ubuntu-24.04-arm → glibc 2.39
   const wf = fs.readFileSync(
@@ -208,13 +208,13 @@ check(`glibc legs still build on the image GLIBC_BUILD_FLOOR=${GLIBC_BUILD_FLOOR
     assert.ok(
       glibc,
       `${leg.target} now builds on '${leg.os}', an image this test doesn't know the ` +
-        `glibc of. Add it to IMAGE_GLIBC and re-check GLIBC_BUILD_FLOOR in bin/detect.js.`
+        `glibc of. Add it to IMAGE_GLIBC and re-check GLIBC_BUILD_FLOOR in bin/detect.cjs.`
     );
     assert.strictEqual(
       glibc,
       GLIBC_BUILD_FLOOR,
       `${leg.target} builds on ${leg.os} (glibc ${glibc}) but GLIBC_BUILD_FLOOR is ` +
-        `${GLIBC_BUILD_FLOOR} — update bin/detect.js.`
+        `${GLIBC_BUILD_FLOOR} — update bin/detect.cjs.`
     );
   }
 });

--- a/npm/perry/test/detect.test.cjs
+++ b/npm/perry/test/detect.test.cjs
@@ -1,7 +1,7 @@
 "use strict";
 // Self-test for the @perryts/perry launcher's platform resolution.
 //
-//   node npm/perry/test/detect.test.js
+//   node npm/perry/test/detect.test.cjs
 //
 // No dependencies, no network, no installed platform packages — it feeds
 // synthetic host descriptions (the shape of `process.report.getReport().header`

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -63,6 +63,7 @@ if [ "$OS" = "linux" ]; then
   if [ -f /etc/alpine-release ] || (ldd --version 2>&1 | head -1 | grep -qi musl); then
     LIBC="musl"
     echo "Detected musl libc — using the fully-static build."
+    echo "(Note: the static build cannot build perry/ui GTK4 apps.)"
   else
     # getconf: "glibc 2.35". ldd: "ldd (Ubuntu GLIBC 2.35-0ubuntu3) 2.35".
     GLIBC_VER=$(getconf GNU_LIBC_VERSION 2>/dev/null | awk '{print $2}')

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -43,9 +43,56 @@ case "$ARCH" in
     ;;
 esac
 
-ARTIFACT="perry-${OS}-${ARCH}.tar.gz"
+# Pick the glibc or the fully-static (musl) Linux build.
+#
+# The Linux glibc tarballs are built by .github/workflows/release-packages.yml
+# on ubuntu-24.04 / ubuntu-24.04-arm, whose glibc is 2.39. Their ELF carries
+# GLIBC_2.39 symbol-version references, so the dynamic loader refuses to start
+# them on anything older — Ubuntu 22.04 (2.35), Debian 12 (2.36), RHEL 9 and
+# Amazon Linux 2023 (2.34) all die with "GLIBC_2.39 not found" before Perry runs
+# (#6298). The musl tarball is a fully-static binary with no interpreter and no
+# libc dependency at all, so it runs on every one of them.
+#
+# KEEP IN SYNC with the builder image and with GLIBC_BUILD_FLOOR in
+# npm/perry/bin/detect.cjs.
+GLIBC_FLOOR_MAJOR=2
+GLIBC_FLOOR_MINOR=39
 
-echo "Detecting platform: ${OS}/${ARCH}"
+LIBC="glibc"
+if [ "$OS" = "linux" ]; then
+  if [ -f /etc/alpine-release ] || (ldd --version 2>&1 | head -1 | grep -qi musl); then
+    LIBC="musl"
+    echo "Detected musl libc — using the fully-static build."
+  else
+    # getconf: "glibc 2.35". ldd: "ldd (Ubuntu GLIBC 2.35-0ubuntu3) 2.35".
+    GLIBC_VER=$(getconf GNU_LIBC_VERSION 2>/dev/null | awk '{print $2}')
+    if [ -z "$GLIBC_VER" ]; then
+      GLIBC_VER=$(ldd --version 2>/dev/null | head -1 | awk '{print $NF}')
+    fi
+    GLIBC_MAJOR=$(printf '%s' "$GLIBC_VER" | cut -d. -f1 | tr -cd '0-9')
+    GLIBC_MINOR=$(printf '%s' "$GLIBC_VER" | cut -d. -f2 | tr -cd '0-9')
+    # Unparseable (empty / non-numeric) → keep the glibc build. Guessing "too
+    # old" for every host we can't read would push everyone onto the static
+    # build, which cannot build perry/ui (GTK4) apps.
+    if [ -n "$GLIBC_MAJOR" ] && [ -n "$GLIBC_MINOR" ]; then
+      if [ "$GLIBC_MAJOR" -lt "$GLIBC_FLOOR_MAJOR" ] ||
+        { [ "$GLIBC_MAJOR" -eq "$GLIBC_FLOOR_MAJOR" ] && [ "$GLIBC_MINOR" -lt "$GLIBC_FLOOR_MINOR" ]; }; then
+        LIBC="musl"
+        echo "Detected glibc ${GLIBC_VER} — older than the ${GLIBC_FLOOR_MAJOR}.${GLIBC_FLOOR_MINOR} the"
+        echo "prebuilt glibc binary needs. Using the fully-static Linux build instead."
+        echo "(Same compiler; it cannot build perry/ui GTK4 apps. See issue #6298.)"
+      fi
+    fi
+  fi
+fi
+
+if [ "$LIBC" = "musl" ]; then
+  ARTIFACT="perry-${OS}-${ARCH}-musl.tar.gz"
+else
+  ARTIFACT="perry-${OS}-${ARCH}.tar.gz"
+fi
+
+echo "Detecting platform: ${OS}/${ARCH} (${LIBC})"
 
 # Find the most recent release that actually has our platform asset.
 #


### PR DESCRIPTION
Closes #6298.

## The hole

`release-packages.yml` builds every glibc Linux target on `ubuntu-24.04` / `ubuntu-24.04-arm` — **glibc 2.39**. The npm launcher (`npm/perry/bin/perry.js`) only ever appended `-musl` when it detected a *musl* host; there was no glibc **version** check anywhere in `npm/`, and `packaging/install.sh` had no libc detection at all.

So every glibc distro below 2.39 gets a binary its dynamic loader refuses:

| Distro | glibc | before |
|---|---|---|
| Ubuntu 22.04 LTS | 2.35 | `GLIBC_2.39 not found` |
| Debian 12 (bookworm) | 2.36 | `GLIBC_2.39 not found` |
| RHEL 9 / Rocky 9 / Alma 9 | 2.34 | `GLIBC_2.39 not found` |
| Amazon Linux 2023 | 2.34 | `GLIBC_2.39 not found` |
| Alpine (via `install.sh`) | musl | downloaded the glibc tarball |

Perry already publishes exactly the artifact these hosts need: `perry-linux-{x86_64,aarch64}-musl` is a **fully-static PIE** — I checked the shipped ELF, it has no `PT_INTERP` and no libc dependency at all.

## What this PR does

Routes old-glibc hosts to that static build.

- **`npm/perry/bin/detect.cjs`** (new) — resolution rules, split out so they can be tested without the machine under them. `GLIBC_BUILD_FLOOR = "2.39"` is a named constant documented against the builder image; below it, Linux hosts resolve to `@perryts/perry-linux-{x64,arm64}-musl`.
- **`npm/perry/bin/perry.js`** — walks candidate packages in preference order, prints a **one-time** notice when it lands on the static build (stamped in tmpdir; `PERRY_NO_FALLBACK_NOTICE=1` silences), and when the musl package isn't installed replaces the loader error with the exact command to fix it.
- **`packaging/install.sh`** — detects musl *and* old glibc, downloads `perry-linux-<arch>-musl.tar.gz`. This path needs no user action at all.
- **`.github/workflows/npm-launcher.yml`** (new) — path-filtered CI: the hermetic self-test, plus an end-to-end job on a real `ubuntu-22.04` runner.
- **Docs** — glibc floor + fallback in `installation.md` and the npm README. Also corrects the README release-matrix section, which still claimed the Linux legs build on `ubuntu-22.04` (they moved to `ubuntu-24.04` in v0.5.860 — that move is what raised the floor).

Bonus robustness: a musl-detected host now falls back to the glibc package if the musl one is missing, which un-breaks the empty-`glibcVersionRuntime` case from #116.

## Verification

Self-test (`node npm/perry/test/detect.test.cjs`) — 2.31 / 2.34 / 2.35 / 2.36 / 2.39 / 2.41 / musl / no-report hosts, both arches, plus a check that the packages it names really are optionalDependencies built by the release matrix:

```
glibc / musl routing (linux-x64, floor = 2.39)
  2.31 (Ubuntu 20.04)      linux-x64-musl       glibc-too-old
  2.34 (RHEL 9 / AL2023)   linux-x64-musl       glibc-too-old
  2.35 (Ubuntu 22.04)      linux-x64-musl       glibc-too-old
  2.36 (Debian 12)         linux-x64-musl       glibc-too-old
  2.39 (Ubuntu 24.04)      linux-x64            native
  2.41 (newer)             linux-x64            native
  (musl / Alpine)          linux-x64-musl       musl
```

The floor is pinned to reality: the self-test parses the release matrix and **fails** if the `-unknown-linux-gnu` legs move off `ubuntu-24.04` without `GLIBC_BUILD_FLOOR` being revisited. Bumping the builder can't silently re-break this.

**End-to-end on a real Ubuntu 22.04 runner** (`npm-launcher` workflow, this PR): installs the published packages the way a user does, reproduces the bug, then runs the patched launcher against them.

**Run: https://github.com/PerryTS/perry/actions/runs/29233234338** — `Ubuntu 22.04 (glibc 2.35) end-to-end`, green. Verbatim:

```
ldd (Ubuntu GLIBC 2.35-0ubuntu3.13) 2.35
node reports glibcVersionRuntime: 2.35

# 1. the bug — the binary npm actually picks today
$ ./node_modules/@perryts/perry-linux-x64/bin/perry --version
.../perry-linux-x64/bin/perry: /lib/x86_64-linux-gnu/libc.so.6:
    version `GLIBC_2.39' not found (required by .../perry-linux-x64/bin/perry)
exit=1

# 2. the launcher from this PR, same machine
$ node node_modules/@perryts/perry/bin/perry.js --version
[perry] glibc 2.35 is older than the prebuilt glibc binary requires (>= 2.39), so Perry is
        running its fully-static Linux build (@perryts/perry-linux-x64-musl).
[perry] Same compiler; the static build cannot produce perry/ui (GTK4) apps. Set
        PERRY_NO_FALLBACK_NOTICE=1 to silence this. Details: .../issues/6298
perry 0.5.1220

# 3. it is a working compiler, not just a binary that loads
$ node node_modules/@perryts/perry/bin/perry.js hello.ts -o hello && ./hello
hello 22.04 2,4,6            # assertion in the job: test "$(./hello)" = "hello 22.04 2,4,6"

$ ldd ./hello
        linux-vdso.so.1
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6      # ordinary glibc-dynamic output
```

Two things worth calling out from that run:

- **The notice is genuinely one-time.** It appears on the `--version` invocation and not on the subsequent `compile` invocation.
- **The static compiler emits ordinary glibc binaries.** The musl-built `libperry_runtime.a` / `libperry_stdlib.a` link cleanly under the host's glibc `cc`, and the output is a normal dynamic glibc executable — the static-ness is confined to the *compiler*, it does not leak into what users ship. I checked why before trusting it: those archives bundle no musl libc objects (only Rust CGUs + compiler-builtins), and all 380 of their libc-facing undefined symbols are plain POSIX/ISO-C names (`__errno_location`, `__xpg_strerror_r`, `__cxa_thread_atexit_impl`, `__tls_get_addr`, `accept4`, …) that glibc exports. Nothing musl-internal to resolve.

Local verification of the launcher itself (`perry.js`, with fake platform packages and a stubbed `process.report`) covers the paths CI doesn't: notice-once + suppression, the `--force` instruction when the musl package is absent (exit 1, no loader error), and the #116 rescue.


## What the fallback costs the user

- **`perry/ui` (GTK4) desktop apps.** The musl package doesn't ship `libperry_ui_gtk4.a` (GTK4 is glibc-only), and the musl target hard-errors on `perry/ui` by design. Everything else — server, CLI, native compile, stdlib — is the same compiler.
- **One manual step on npm.** npm won't install a package tagged `libc: ["musl"]` on a glibc machine, so the launcher can't silently pull it in. It now prints `npm install --force @perryts/perry-linux-x64-musl@<version>` instead of a loader error. If you'd rather it be zero-touch, dropping the `libc` field from the two musl `package.json.tmpl`s makes npm install the static build alongside the glibc one on every Linux host — that costs every Linux user ~67 MB of unpacked package they may not need, which is why I didn't do it unilaterally. Say the word and it's a two-line change.
- **No perf cliff in compiled output**: the runtime archive bundles mimalloc, so musl's slower `malloc` isn't in the hot path of the programs you build.

## Separate blocker found on 22.04 (not a libc issue)

Once the binary loads, jammy's **default clang is 14**, which rejects Perry's opaque-pointer IR:

```
/tmp/perry_llvm_...ll:28:36: error: expected type
```

Perry's LLVM backend emits `ptr` and shells out to `clang -c`, so Linux needs **clang ≥ 15**. `perry doctor` reports clang as OK without ever checking its version, so this surfaces as a mysterious codegen error. Documented here (`apt install clang-15` + `PERRY_LLVM_CLANG`); the doctor gate is filed separately.

## Is a native glibc-2.35 build leg worth adding? Not in this PR — and it wouldn't remove the launcher logic

I looked at it properly; it is not a clean matrix addition:

1. **Moving the glibc legs back to `ubuntu-22.04`** is blocked by `perry-ui-gtk4`. Jammy has neither `libwebkitgtk-6.0-dev` (WebView, #658) nor `libshumate-dev` (MapView, #517) — that is *precisely* why v0.5.860 moved the runners 22.04 → 24.04. Going back means feature-gating both widgets out of the Linux desktop build, and it still leaves RHEL 9 / AL2023 (2.34) broken.
2. **Adding a third Linux glibc leg + npm package** doesn't fix distribution: npm has no glibc-*version* selector, so the new package could only ever be selected by the launcher — i.e. by the exact logic in this PR — and would still need `--force` or an unconditional ~110 MB optional dep. It doubles the slowest part of the release matrix (dist-profile LTO Linux builds) and buys nothing over the musl fallback.
3. **An old-sysroot / manylinux-style container** (glibc 2.28, would cover RHEL 9 and AL2023 too) is the best end state — and the compiler side is genuinely feasible, since Perry has no system-LLVM build dependency (it shells to `clang` at runtime rather than linking `llvm-sys`). The blocker is `perry-ui-gtk4` again.

So the proper fix is a **`perry-ui-gtk4` feature-gating project plus a release-matrix change**, not a packaging tweak — filed as a follow-up. Whatever we do there, a launcher that understands glibc versions is still required, because npm's selector cannot express one.

## Still open (not fixable from the launcher)

The **apt `.deb`** is built from the `perry-linux-x86_64` glibc artifact, so `apt install perry` stays broken below glibc 2.39 — a deb can't fall back at runtime. It should either declare `Depends: libc6 (>= 2.39)` so it fails cleanly at install time, or ship the static binary. Folded into the follow-up issue.

## Notes

- No Rust code touched — nothing to rebuild.
- `conformance-smoke` shards are known-flaky and unrelated to anything here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Linux installation and the npm launcher now detect whether you’re on glibc or musl and select the appropriate prebuilt artifact.
  - Systems with glibc older than 2.39 automatically fall back to the fully-static musl build.
  - Enhanced launcher selection with clearer errors and a one-time fallback notice (can be disabled with `PERRY_NO_FALLBACK_NOTICE=1`).
- **Documentation**
  - Updated Linux prerequisites to require `clang ≥ 15`.
  - Added clear glibc ≥ 2.39 requirements and musl fallback guidance/limitations.
- **Tests**
  - Added platform-detection self-tests covering glibc/musl routing and version threshold edge cases.
- **Chores**
  - Added release CI coverage to verify correct platform resolution and musl/glibc behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->