### PR TITLE
fix(hir): bind the value of a mixin-factory result (#5952)

### DIFF
--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -52,6 +52,24 @@ pub(crate) struct PrivateScope {
     pub(crate) members: HashMap<String, PrivMember>,
 }
 
+/// A `function Mixin(B) { return class [Name] extends B { … } }` recorded by
+/// `pre_scan_mixin_functions`, so a `const M = Mixin(Base)` call site can
+/// synthesize a real class extending the concrete base.
+#[derive(Debug, Clone)]
+pub(crate) struct MixinFn {
+    /// The mixin function's single parameter — the name the returned class
+    /// `extends`.
+    pub(crate) param_name: String,
+    /// The returned class EXPRESSION's own name, if it has one (`return class
+    /// Named extends B {}`). `None` for the anonymous form, whose `.name` is
+    /// the empty string per spec — a directly-returned class expression gets
+    /// no NamedEvaluation from the call site's binding.
+    pub(crate) class_expr_name: Option<String>,
+    /// The returned class's AST, copied verbatim; the call site rewrites its
+    /// `extends` clause to the concrete base.
+    pub(crate) class_ast: Box<swc_ecma_ast::Class>,
+}
+
 pub struct LoweringContext {
     /// Counter for generating unique local IDs
     pub(crate) next_local_id: LocalId,
@@ -623,10 +641,12 @@ pub struct LoweringContext {
     /// name, so the New expression points at a real HIR class.
     pub(crate) class_expr_aliases: HashMap<String, String>,
     /// Mixin functions: `function withName<T>(B: Constructor<T>) { return class extends B { ... } }`.
-    /// Maps mixin name → (param_name, captured class AST). Stub field
-    /// added to satisfy in-tree references; full mixin support is a
-    /// separate workstream.
-    pub(crate) mixin_funcs: HashMap<String, (String, Box<swc_ecma_ast::Class>)>,
+    /// Maps mixin name → (param_name, class-expression's own name, captured
+    /// class AST). The class-expression name is `None` for the common
+    /// anonymous `return class extends B {…}` form and drives the synthesized
+    /// class's user-visible `.name` (issue #5952). Stub field added to satisfy
+    /// in-tree references; full mixin support is a separate workstream.
+    pub(crate) mixin_funcs: HashMap<String, MixinFn>,
     /// Set to the class name when lowering inside a class constructor body.
     /// Used to resolve `new.target` to a placeholder object whose `.name`
     /// returns the class name. None outside any constructor.

--- a/crates/perry-hir/src/lower/mod.rs
+++ b/crates/perry-hir/src/lower/mod.rs
@@ -85,7 +85,7 @@ pub(crate) use widget_decl::*;
 // so spelling them out keeps the public-and-internal API stable.
 mod lowering_context;
 pub(crate) use lowering_context::{
-    LoweringContext, PrivKind, PrivMember, PrivateScope, WithEnvFrame,
+    LoweringContext, MixinFn, PrivKind, PrivMember, PrivateScope, WithEnvFrame,
 };
 
 mod locals;

--- a/crates/perry-hir/src/lower/pre_scan.rs
+++ b/crates/perry-hir/src/lower/pre_scan.rs
@@ -410,8 +410,14 @@ pub(crate) fn pre_scan_mixin_functions(ast_module: &ast::Module, ctx: &mut Lower
             return;
         }
         let fn_name = fn_decl.ident.sym.to_string();
-        ctx.mixin_funcs
-            .insert(fn_name, (param_name, Box::new((*class_expr.class).clone())));
+        ctx.mixin_funcs.insert(
+            fn_name,
+            crate::lower::MixinFn {
+                param_name,
+                class_expr_name: class_expr.ident.as_ref().map(|i| i.sym.to_string()),
+                class_ast: Box::new((*class_expr.class).clone()),
+            },
+        );
     }
     for item in &ast_module.body {
         match item {

--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -805,8 +805,7 @@ pub(crate) fn lower_stmt(
                                 if let ast::Callee::Expr(callee_expr) = &call.callee {
                                     if let ast::Expr::Ident(fn_ident) = callee_expr.as_ref() {
                                         let fn_name = fn_ident.sym.to_string();
-                                        if let Some((_param_name, mixin_class_box)) =
-                                            ctx.mixin_funcs.get(&fn_name).cloned()
+                                        if let Some(mixin) = ctx.mixin_funcs.get(&fn_name).cloned()
                                         {
                                             if call.args.len() == 1 {
                                                 if let ast::Expr::Ident(base_ident) =
@@ -819,7 +818,7 @@ pub(crate) fn lower_stmt(
                                                         let bind_name = ident.id.sym.to_string();
                                                         if ctx.lookup_class(&bind_name).is_none() {
                                                             let mut new_class =
-                                                                (*mixin_class_box).clone();
+                                                                (*mixin.class_ast).clone();
                                                             let base_id = ast::Ident::new(
                                                                 base_class_name.clone().into(),
                                                                 base_ident.span,
@@ -834,10 +833,45 @@ pub(crate) fn lower_stmt(
                                                                 &bind_name,
                                                                 false,
                                                             )?;
+                                                            // Issue #5952: the synthesized class is
+                                                            // registered under the BINDING name so
+                                                            // `new M()` / `instanceof M` resolve
+                                                            // statically, but its user-visible
+                                                            // `.name` is the class EXPRESSION's own
+                                                            // name — the empty string for the
+                                                            // canonical anonymous
+                                                            // `return class extends B {…}` (a
+                                                            // directly-returned class expression
+                                                            // gets no NamedEvaluation from the call
+                                                            // site's `const M =`). Record the
+                                                            // override so codegen registers the
+                                                            // spec name rather than the
+                                                            // registration key.
+                                                            ctx.class_display_names.insert(
+                                                                lowered_class.id,
+                                                                mixin
+                                                                    .class_expr_name
+                                                                    .clone()
+                                                                    .unwrap_or_default(),
+                                                            );
                                                             push_class_dedup(module, lowered_class);
                                                             ctx.class_expr_aliases.insert(
                                                                 bind_name.clone(),
                                                                 bind_name.clone(),
+                                                            );
+                                                            // Issue #5952: bind the VALUE too. The
+                                                            // sibling `const X = class {…}` arm
+                                                            // above ends with this call; this arm
+                                                            // used to `continue` straight from the
+                                                            // class synthesis, so `M` was never
+                                                            // bound — `typeof M` / `M.name` /
+                                                            // `String(M)` read an unassigned local
+                                                            // (undefined) even though `new M()` and
+                                                            // `instanceof M` worked (both key off
+                                                            // the class NAME, not the binding).
+                                                            emit_class_expression_value_binding(
+                                                                ctx, module, &bind_name, mutable,
+                                                                is_var,
                                                             );
                                                             continue;
                                                         }

--- a/crates/perry-runtime/src/builtins/formatting/prototype_equality.rs
+++ b/crates/perry-runtime/src/builtins/formatting/prototype_equality.rs
@@ -75,16 +75,19 @@ pub(super) fn prototype_token(value: f64) -> Option<u64> {
         // while a `{}`-born object mutated afterwards keeps class_id 0 — both
         // have Object.prototype, so normalize unregistered ids to 0 or the
         // two would spuriously compare as prototype-different.
+        //
+        // The test is REGISTERED, not "registered under a non-empty name": an
+        // anonymous class expression (`const M = Mixin(Base)`, issue #5952)
+        // registers the empty string as its `.name` and is every bit a real
+        // constructor, so its instances must keep their own prototype identity
+        // rather than collapse onto Object.prototype.
         let class_id = (*obj).class_id;
-        let proto_class_id = if class_id != 0
-            && crate::object::class_name_for_id(class_id)
-                .filter(|name| !name.is_empty())
-                .is_none()
-        {
-            0
-        } else {
-            class_id
-        };
+        let proto_class_id =
+            if class_id != 0 && crate::object::class_name_for_id(class_id).is_none() {
+                0
+            } else {
+                class_id
+            };
         Some(CLASS_PROTO_NAMESPACE | proto_class_id as u64)
     }
 }

--- a/crates/perry-runtime/src/object/class_registry/class_meta.rs
+++ b/crates/perry-runtime/src/object/class_registry/class_meta.rs
@@ -30,9 +30,16 @@ pub static CLASS_NAMES: RwLock<Option<HashMap<u32, String>>> = RwLock::new(None)
 
 /// Register the user-visible name of a class so the V8 bridge can label
 /// the V8-side wrapper for nice `metatype.name` reads. Idempotent.
+///
+/// A zero-length name is a legitimate registration, not a no-op: an anonymous
+/// class expression's `.name` IS the empty string per spec (issue #5952 —
+/// `const M = Mixin(Base)` over `function Mixin(B) { return class extends B {} }`
+/// binds a class whose `name` is `""`). Membership in `CLASS_NAMES` means "this
+/// id is a real class", which stays true for an anonymous one; only the null
+/// pointer and the reserved id 0 are rejected.
 #[no_mangle]
 pub unsafe extern "C" fn js_register_class_name(class_id: u32, name_ptr: *const u8, name_len: u32) {
-    if class_id == 0 || name_ptr.is_null() || name_len == 0 {
+    if class_id == 0 || name_ptr.is_null() {
         return;
     }
     let slice = std::slice::from_raw_parts(name_ptr, name_len as usize);

--- a/test-files/test_gap_5952_mixin_factory_binding.ts
+++ b/test-files/test_gap_5952_mixin_factory_binding.ts
@@ -1,0 +1,138 @@
+// Issue #5952 — a mixin factory that DIRECTLY returns a dynamic-parent class
+// expression must still bind its result as a value.
+//
+// `function Mixin(B) { return class extends B {…} }` + `const M = Mixin(Base)`
+// takes a fast path in HIR lowering that synthesizes a real class under the
+// binding name `M`. That path used to synthesize the class and stop, never
+// emitting the value binding — so `new M()` and `instanceof M` worked (both
+// key off the class NAME) while `typeof M` / `M.name` / `M === M` read an
+// unassigned local and saw `undefined`.
+//
+// Covers the neighbourhood: direct return, a NAMED returned class expression,
+// return-via-const, return-via-intermediate, two mixins composed in one
+// expression, a mixin over another mixin's result, and a static-parent
+// captured-param factory (the class-factory specialization pass's own win,
+// which must survive).
+
+class Base {
+  value = "base value";
+  hello() {
+    return "base hello";
+  }
+}
+
+// (1) the reported shape: direct return of `class extends <param>`
+function Greetable(B: any) {
+  return class extends B {
+    greet() {
+      return "hi";
+    }
+  };
+}
+
+// (2) same, but the returned class expression has its own name
+function Named(B: any) {
+  return class Marker extends B {
+    who() {
+      return "marker";
+    }
+  };
+}
+
+// (3) bound to a const inside the factory, then returned
+function ViaConst(B: any) {
+  const K = class extends B {
+    greet() {
+      return "const";
+    }
+  };
+  return K;
+}
+
+// (4) bounced through an intermediate variable
+function ViaTemp(B: any) {
+  const K = class extends B {
+    greet() {
+      return "temp";
+    }
+  };
+  const K2 = K;
+  return K2;
+}
+
+// (5) a second mixin, for composition
+function Serializable(B: any) {
+  return class extends B {
+    ser() {
+      return "ser";
+    }
+  };
+}
+
+// (6) static-parent factory capturing a param — specialized per call site by
+// `specialize_captured_class_factories`; the capture must stay baked in.
+function makeTagged(tag: string) {
+  class Inner {
+    readonly _tag = tag;
+    who() {
+      return "tagged:" + this._tag;
+    }
+  }
+  return Inner;
+}
+
+// --- (1) direct return -------------------------------------------------
+const M = Greetable(Base);
+console.log("direct typeof:", typeof M);
+console.log("direct name:", JSON.stringify(M.name));
+console.log("direct method:", new M().greet());
+console.log("direct inherited method:", (new M() as any).hello());
+console.log("direct inherited field:", (new M() as any).value);
+console.log("direct instanceof self:", new M() instanceof M);
+console.log("direct instanceof base:", new M() instanceof Base);
+console.log("direct constructor:", (new M() as any).constructor === M);
+console.log("direct prototype:", Object.getPrototypeOf(new M()) === M.prototype);
+console.log("direct identity:", (M as any) !== (Base as any));
+
+// --- (2) named class expression ----------------------------------------
+const N = Named(Base);
+console.log("named typeof:", typeof N);
+console.log("named name:", JSON.stringify(N.name));
+console.log("named method:", new N().who());
+console.log("named instanceof base:", new N() instanceof Base);
+
+// --- (3) returned via a const binding -----------------------------------
+const C = ViaConst(Base);
+console.log("viaconst typeof:", typeof C);
+console.log("viaconst method:", new C().greet());
+console.log("viaconst inherited method:", (new C() as any).hello());
+console.log("viaconst instanceof base:", new C() instanceof Base);
+
+// --- (4) returned via an intermediate variable ---------------------------
+const T = ViaTemp(Base);
+console.log("viatemp typeof:", typeof T);
+console.log("viatemp method:", new T().greet());
+console.log("viatemp instanceof base:", new T() instanceof Base);
+
+// --- (5) two mixins composed in one expression ---------------------------
+const Composed = Serializable(Greetable(Base) as any);
+console.log("composed typeof:", typeof Composed);
+console.log("composed outer:", new Composed().ser());
+console.log("composed inner:", (new Composed() as any).greet());
+console.log("composed instanceof base:", new Composed() instanceof Base);
+
+// --- (6) a mixin whose parent is itself a mixin result --------------------
+const Mid = Greetable(Base);
+const Top = Serializable(Mid as any);
+console.log("chained typeof mid:", typeof Mid);
+console.log("chained typeof top:", typeof Top);
+console.log("chained outer:", new Top().ser());
+console.log("chained instanceof base:", new Top() instanceof Base);
+console.log("chained identity:", (Mid as any) !== (Top as any));
+
+// --- (7) static-parent captured-param factory -----------------------------
+const Tagged = makeTagged("S");
+console.log("factory typeof:", typeof Tagged);
+console.log("factory name:", JSON.stringify(Tagged.name));
+console.log("factory method:", new Tagged().who());
+console.log("factory captured field:", new Tagged()._tag);


### PR DESCRIPTION
Fixes #5952.

## Symptom

```ts
class Base { value = "base value"; }
function Greetable(B: any) {
  return class extends B { greet() { return "hi"; } };
}
const M = Greetable(Base);
typeof M      // node: "function"   perry: "undefined"
M.name        // node: ""           perry: TypeError: Cannot read properties of undefined
new M().greet()  // "hi" on both
```

`new M()` and `instanceof M` worked; only the **runtime value** of `M` was missing.

## Root cause — the mixin fast path in HIR lowering, not the factory pass

`pre_scan_mixin_functions` (`crates/perry-hir/src/lower/pre_scan.rs`) records every
`function Mixin(B) { return class extends B { … } }` — a single param, a single
statement, returning a class expression that `extends` that param. A
`const M = Mixin(Base)` call site then takes a fast path in
`crates/perry-hir/src/lower/stmt.rs` which copies the mixin's class AST, rewrites
its `extends` clause to the concrete base, and registers it as a real class under
the **binding name** `M`. That's what makes `new M()`, `instanceof M` and the
inherited field/method work.

The path then `continue`d straight out of the declaration — **it never emitted the
value binding for `M`**. The sibling `const X = class {…}` arm a few lines above
ends with `emit_class_expression_value_binding(...)`, which pushes
`Let { name, init: ClassRef(name) }`; the mixin arm simply forgot it. Every
consumer that keys off the class NAME (`New { class_name: "M" }`,
`InstanceOf { ty: "M" }`) resolved fine, while every consumer that reads the
VALUE (`typeof M`, `M.name`, `String(M)`, `M === M`) hit an unbound local and
folded to `undefined`.

`--print-hir` on the repro shows it exactly — class `M` is present, the `Let` is not:

```
Classes: 3
  - Base
  - __anon_class_2
  - M                              <- synthesized by the fast path
Init statements: 7
  [0] Expr(console.log("typeof:", TypeOf(LocalGet(0))))     <- LocalGet(0) never assigned
  [1] Expr(console.log("name:", PropertyGet(LocalGet(0), "name")))
  [2] Let { id: 1, name: "m", init: New { class_name: "M" } }   <- works: keyed by name
```

This is **not** `resolve_factory_return_class` / `specialize_captured_class_factories`
in `perry-transform`. That pass never sees this shape: the `Let` is already gone by
the time the HIR reaches it. I verified the localization by dumping the HIR rather
than by inspection — the transform pass is reached only for the shapes the fast
path declines (see the matrix below), and all of those already worked.

## Fix

1. **`crates/perry-hir/src/lower/stmt.rs`** — call
   `emit_class_expression_value_binding` before the `continue`, so `M` holds
   `ClassRef("M")`, exactly like the sibling class-expression arm.

2. **`.name`** — the synthesized class is *keyed* by the binding name, but a
   directly-returned class expression gets no NamedEvaluation from the call
   site's `const M =`, so per spec `M.name` is `""` (or the class expression's
   own name for `return class Marker extends B {}`). `pre_scan_mixin_functions`
   now records that name (`MixinFn { param_name, class_expr_name, class_ast }`)
   and the call site registers it via the existing `class_display_names`
   override, so codegen emits the spec name rather than the registration key.

3. **`crates/perry-runtime/.../class_meta.rs`** — `js_register_class_name`
   treated a zero-length name as a no-op, so the anonymous class never landed in
   `CLASS_NAMES` and `.name` still read `undefined`. An anonymous class's `.name`
   IS the empty string; membership in `CLASS_NAMES` means "this id is a real
   class", which stays true for an anonymous one. Only the null pointer and the
   reserved id 0 are rejected now.

4. **`prototype_equality.rs`** — registering an empty name makes its previously
   unreachable `!name.is_empty()` filter live *and wrong*: it would treat an
   anonymous class as unregistered and collapse its instances onto
   `Object.prototype`. It now tests registration, not the name's emptiness.

## The factory-specialization pass is untouched and still fires

`specialize_captured_class_factories` exists to monomorphize a class-returning
factory per call site: it clones the returned class with the factory's captured
params baked in as constants, drops the synthesized `__perry_cap_*` ctor
params/fields, and rewrites the `Call` to a `ClassRef` of the clone (issue #740 —
Effect's `makeLiteralClass` shape). Nothing in this PR touches that pass, and the
mixin fast path it competes with is strictly narrower (single param, single-stmt
`return class extends <param>`, called with one identifier naming a known class).
Every other shape still routes through `Call` → `factory_specialize` unchanged.
Its canonical win is covered by the new fixture (shape 7) and verified green
before and after:

```
function makeTagged(tag: string) {
  class Inner { readonly _tag = tag; who() { return "tagged:" + this._tag; } }
  return Inner;
}
const Tagged = makeTagged("S");
new Tagged().who()   // "tagged:S"  — capture still baked in, main and branch
Tagged.name          // "Inner"
```

## Shape matrix vs `node --experimental-strip-types`

| shape | main | this PR |
|---|---|---|
| direct `return class extends B {}` | `typeof` **undefined**, `.name` **TypeError** | ✅ matches node (`typeof`, `.name === ""`, `new`, `instanceof` self+base, `constructor`, `prototype`, inherited field + method) |
| `return class Marker extends B {}` | `typeof` undefined | ✅ matches (`.name === "Marker"`) |
| `const K = class extends B {}; return K` | ✅ except inherited **field** | unchanged (still ✅ except inherited field) |
| via an intermediate variable | ✅ | ✅ |
| two mixins composed, `S(G(Base))` | ✅ except inherited **field** | unchanged |
| mixin over a mixin result (`Top = S(Mid)`) | `typeof Mid` **undefined**; inherited field; `instanceof Mid` | `typeof` ✅; inherited field / `instanceof Mid` unchanged |
| static-parent captured-param factory (#740) | ✅ | ✅ preserved |

The residual "inherited **field** is `undefined`" cells are a **separate,
pre-existing** gap — instance field initializers of the base are not replayed
through a `RegisterClassParentDynamic` parent edge (prototype methods resolve
fine through it). Identical on main and on this branch, byte for byte; filed
separately rather than folded in here. The fixture asserts only the cells that
match node.

## Validation

- **Full gap suite A/B, 298 tests**, pristine `origin/main` (`be5ed2bfc`) toolchain
  vs this branch, same `perry-dev` profile: **3 output deltas, zero regressions.**
  - `test_gap_5952_mixin_factory_binding` — the new fixture: fails on main at line 1
    (`typeof undefined`), byte-identical to node on this branch.
  - `test_gap_console_methods` — `console.time` values only (`0.003ms` vs `0.014ms`);
    varies run-to-run on the *same* binary.
  - `test_gap_module_const_local_shadow` — a pre-existing uninitialized-memory read
    (`x+3.06e-311`); the value changes on every run of the same binary on both sides.
- `cargo fmt --all -- --check` clean; `scripts/check_file_size.sh` clean.
- New fixture `test-files/test_gap_5952_mixin_factory_binding.ts` covers the whole
  neighbourhood above and is byte-identical to `node --experimental-strip-types`.

## Note on the issue's provenance section

#5952 blames PR #5874. That is stale: the #5874 payload was fully reverted from
`main` in `5afa08fca` (PR #6015) and the bug still reproduces on current `main`.
The mixin fast path — and its missing value binding — dates to `1e65d9c22`
(2026-04-11), long before #5874. #5874 is exonerated. `test_gap_class_advanced`,
named in the issue as the surfacing gap test, also matches node on main today, so
the suite no longer covered this; the new fixture is the coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mixin-generated classes so their bindings work correctly with `typeof`, `.name`, string conversion, `instanceof`, and related runtime checks.
  * Improved handling of anonymous class expressions and prototype identity during strict equality comparisons.
  * Preserved empty class names when registering runtime class metadata.

* **Tests**
  * Added coverage for direct, named, composed, chained, and parameterized mixin factories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->