### PR TITLE
fix(codegen): don't scalar-replace an instance whose class chain reaches an unmodeled base (#6343)

### DIFF
--- a/crates/perry-codegen/src/collectors/escape_news.rs
+++ b/crates/perry-codegen/src/collectors/escape_news.rs
@@ -49,6 +49,22 @@ pub fn collect_non_escaping_news(
             else if class_chain_extends_builtin_error(class, classes) {
                 escaped.insert(*id);
             }
+            // Issue #6343: the class chain reaches a base whose construction
+            // codegen cannot see — a NATIVE base that stamps its method
+            // surface onto the instance as own properties (`extends
+            // EventEmitter`, `extends Readable`, …), a dynamic `extends
+            // <expr>` parent, or a parent name that resolves to no visible
+            // class. Scalar replacement promotes only the DECLARED fields of
+            // the chain, so a runtime-installed own property has no slot in
+            // the promoted set: `class X extends EventEmitter { a = 1 }` read
+            // `x.a` correctly but `typeof x.emit` as `undefined`. The heap
+            // path runs the real subclass-init and looks the property up on
+            // the object. Same family as the #573 check above and the #5872
+            // dispatch-stability pass below — a chain of ordinary user classes
+            // is fully modeled and stays scalar-replaced.
+            else if class_chain_has_unmodeled_base(class, classes) {
+                escaped.insert(*id);
+            }
         }
     }
 

--- a/crates/perry-codegen/src/collectors/mod.rs
+++ b/crates/perry-codegen/src/collectors/mod.rs
@@ -83,4 +83,6 @@ pub(crate) use scalar_methods::simple_scalar_method_summary;
 pub(crate) use shadow_slots::{
     collect_declared_shadow_slots_in_stmts, collect_shadow_slot_clear_points,
 };
-pub(crate) use this_as_value::{class_chain_extends_builtin_error, class_uses_this_as_value};
+pub(crate) use this_as_value::{
+    class_chain_extends_builtin_error, class_chain_has_unmodeled_base, class_uses_this_as_value,
+};

--- a/crates/perry-codegen/src/collectors/this_as_value.rs
+++ b/crates/perry-codegen/src/collectors/this_as_value.rs
@@ -128,6 +128,79 @@ pub fn class_chain_extends_builtin_error(
     false
 }
 
+/// Issue #6343: walk the class's `extends` chain and report whether it reaches
+/// a base whose *construction* codegen cannot see.
+///
+/// Scalar replacement models an instance as exactly the set of DECLARED fields
+/// on its chain — one alloca per field name — and inlines the constructor
+/// bodies that fill them. That is only faithful when the whole chain is
+/// visible. A base that isn't contributes instance state the promoted set does
+/// not model, and every way that happens is silent:
+///
+///   * a **native** base — `class X extends EventEmitter`, `extends Readable`,
+///     … — installs its method surface as OWN PROPERTIES on the instance at
+///     subclass-init time (`js_object_set_field_by_name(obj, "emit", <native
+///     closure>)`) rather than on a prototype. `emit` has no declared slot, so
+///     the promoted set has no slot for it and `x.emit` reads back
+///     `undefined` (#6343: `class X extends EventEmitter { a = 1 }` printed
+///     `typeof x.emit === "undefined"` while `x.a` was correct).
+///   * a **dynamic** base — `extends <expr>`, including a lexically shadowed
+///     heritage name — runs an arbitrary constructor that can install
+///     anything.
+///   * a parent NAME that resolves to no visible class: a builtin (`Error`,
+///     `Map`, `Set`, `Event`, …) or a base whose declaration never reached
+///     this module. Its construction happens in the runtime, not in code
+///     codegen can inline.
+///
+/// The only sound answer for all three is to keep the instance on the heap,
+/// where the real init runs and property lookup goes through the object.
+///
+/// This is deliberately a chain property, not a name test: it must hop user
+/// classes (`class Leaf extends Mid`, `class Mid extends EventEmitter`) and it
+/// must NOT fire for a chain that bottoms out in an ordinary user class — that
+/// instance is fully modeled and keeping it scalar-replaced is a real win
+/// (guarded by `scripts/run_issue_945_scalar_method_ir_guard.sh`).
+///
+/// Generalizes [`class_chain_extends_builtin_error`] (#573), which stays as-is
+/// because it is name-keyed and therefore also fires for a *locally shadowed*
+/// `Error` — this walk resolves such a shadow to the user class and would let
+/// it through.
+pub fn class_chain_has_unmodeled_base(
+    class: &perry_hir::Class,
+    classes: &std::collections::HashMap<String, &perry_hir::Class>,
+) -> bool {
+    let mut current = class;
+    let mut seen: HashSet<String> = HashSet::new();
+    loop {
+        // A cycle (or a chain deep enough to look like one) means the walk
+        // can't prove anything. Fail closed: keep the instance on the heap.
+        if !seen.insert(current.name.clone()) || seen.len() > 64 {
+            return true;
+        }
+        // `native_extends` is the (module, class) tag for a base whose
+        // subclass-init shim stamps a surface onto `this` at construction —
+        // events, node:stream, the Web Streams bases, async_hooks, ws.
+        if current.native_extends.is_some() {
+            return true;
+        }
+        // `class X extends <expr>` — the parent is a runtime value; its
+        // constructor is opaque to this analysis.
+        if current.extends_expr.is_some() || current.heritage_lexically_shadowed {
+            return true;
+        }
+        let Some(parent_name) = current.extends_name.as_deref() else {
+            // Chain bottoms out in a root user class: fully modeled.
+            return false;
+        };
+        match classes.get(parent_name) {
+            Some(parent) => current = parent,
+            // A parent name with no visible class behind it — a builtin, or an
+            // import whose stub never landed. Unmodeled either way.
+            None => return true,
+        }
+    }
+}
+
 pub fn stmts_use_this_as_value(stmts: &[perry_hir::Stmt], fields: &HashSet<String>) -> bool {
     use perry_hir::Stmt;
     for s in stmts {
@@ -497,5 +570,93 @@ mod tests {
         classes.insert(parent.name.clone(), &parent);
 
         assert!(!class_chain_extends_builtin_error(&child, &classes));
+    }
+
+    // ── #6343: unmodeled-base chain walk ──
+
+    /// A root user class with no heritage is fully modeled — scalar
+    /// replacement must stay available (this is the #945 fast path).
+    #[test]
+    fn unmodeled_base_allows_plain_class() {
+        let plain = class("Plain", None);
+        let mut classes = HashMap::new();
+        classes.insert(plain.name.clone(), &plain);
+
+        assert!(!class_chain_has_unmodeled_base(&plain, &classes));
+    }
+
+    /// A chain of ordinary user classes is fully modeled too.
+    #[test]
+    fn unmodeled_base_allows_user_class_chain() {
+        let base = class("Base", None);
+        let mid = class("Mid", Some("Base"));
+        let leaf = class("Leaf", Some("Mid"));
+        let mut classes = HashMap::new();
+        classes.insert(base.name.clone(), &base);
+        classes.insert(mid.name.clone(), &mid);
+        classes.insert(leaf.name.clone(), &leaf);
+
+        assert!(!class_chain_has_unmodeled_base(&leaf, &classes));
+    }
+
+    /// `class X extends EventEmitter` — the native base installs its surface as
+    /// own properties on the instance, so the instance must stay on the heap.
+    #[test]
+    fn unmodeled_base_rejects_direct_native_parent() {
+        let mut child = class("X", Some("EventEmitter"));
+        child.native_extends = Some(("events".to_string(), "EventEmitter".to_string()));
+        let mut classes = HashMap::new();
+        classes.insert(child.name.clone(), &child);
+
+        assert!(class_chain_has_unmodeled_base(&child, &classes));
+    }
+
+    /// The native base is found by walking the CHAIN, not by matching the
+    /// leaf's own `extends` name: `class Leaf extends Mid`, `class Mid extends
+    /// EventEmitter`.
+    #[test]
+    fn unmodeled_base_rejects_indirect_native_parent() {
+        let mut mid = class("Mid", Some("EventEmitter"));
+        mid.native_extends = Some(("events".to_string(), "EventEmitter".to_string()));
+        let leaf = class("Leaf", Some("Mid"));
+        let mut classes = HashMap::new();
+        classes.insert(mid.name.clone(), &mid);
+        classes.insert(leaf.name.clone(), &leaf);
+
+        assert!(class_chain_has_unmodeled_base(&leaf, &classes));
+    }
+
+    /// A parent name with no class behind it (a builtin such as `Error` /
+    /// `Map`, or an import whose stub never landed) is unmodeled.
+    #[test]
+    fn unmodeled_base_rejects_unresolvable_parent_name() {
+        let child = class("MyError", Some("Error"));
+        let mut classes = HashMap::new();
+        classes.insert(child.name.clone(), &child);
+
+        assert!(class_chain_has_unmodeled_base(&child, &classes));
+    }
+
+    /// `class X extends <expr>` — an arbitrary runtime parent value.
+    #[test]
+    fn unmodeled_base_rejects_dynamic_parent_expr() {
+        let mut child = class("X", None);
+        child.extends_expr = Some(Box::new(Expr::LocalGet(0)));
+        let mut classes = HashMap::new();
+        classes.insert(child.name.clone(), &child);
+
+        assert!(class_chain_has_unmodeled_base(&child, &classes));
+    }
+
+    /// A cyclic chain proves nothing, so it must fail closed (escape).
+    #[test]
+    fn unmodeled_base_fails_closed_on_cyclic_parent_chain() {
+        let child = class("A", Some("B"));
+        let parent = class("B", Some("A"));
+        let mut classes = HashMap::new();
+        classes.insert(child.name.clone(), &child);
+        classes.insert(parent.name.clone(), &parent);
+
+        assert!(class_chain_has_unmodeled_base(&child, &classes));
     }
 }

--- a/test-files/test_gap_6343_scalar_native_base_surface.ts
+++ b/test-files/test_gap_6343_scalar_native_base_surface.ts
@@ -1,0 +1,171 @@
+// #6343: escape analysis must not scalar-replace an instance whose class chain
+// reaches a base that codegen cannot fully model.
+//
+// perry's native bases (`EventEmitter`, the `node:stream` classes, …) install
+// their method surface as OWN PROPERTIES on the instance at subclass-init time
+// — `js_object_set_field_by_name(obj, "emit", <native closure>)` — not on a
+// prototype. Scalar replacement promotes a non-escaping instance to one alloca
+// per DECLARED field, so a runtime-installed own property has no slot in the
+// promoted set and reads back `undefined`.
+//
+// The trigger is that the instance never ESCAPES: a method call (`x.on(…)`)
+// forces the heap path and hides the bug, so every probe below deliberately
+// only *reads* properties off its receiver. A declared field alongside the
+// read is what makes the instance look worth promoting.
+//
+// The controls are the other half: a class with no unmodeled base must STILL
+// scalar-replace — that is a real perf win (see
+// scripts/run_issue_945_scalar_method_ir_guard.sh), so the disqualifier has to
+// be precise rather than a blanket disable.
+
+import { EventEmitter } from "node:events";
+import { Readable, Writable } from "node:stream";
+
+// ── the issue's exact repro: declared field + bare reads, no method call ──
+class X extends EventEmitter {
+  a = 1;
+}
+function probeX(): string {
+  const x = new X();
+  x.a = 2;
+  return `${x.a} ${typeof x.emit} ${typeof x.on}`;
+}
+console.log("X:", probeX());
+
+// same shape at module scope (the local is not referenced from any function,
+// so it stays a plain init-time local — still a promotion candidate)
+const moduleX = new X();
+console.log("moduleX:", moduleX.a, typeof moduleX.emit, typeof moduleX.on);
+
+// ── no declared field at all: the promoted set is simply empty ──
+class NoField extends EventEmitter {}
+function probeNoField(): string {
+  const n = new NoField();
+  return `${typeof n.emit} ${typeof n.on} ${typeof n.once}`;
+}
+console.log("NoField:", probeNoField());
+
+// ── several fields, a post-construction write, and more of the surface ──
+class Multi extends EventEmitter {
+  count = 0;
+  label = "start";
+  flag = true;
+}
+function probeMulti(): string {
+  const m = new Multi();
+  m.count = 5;
+  m.label = "changed";
+  return `${m.count} ${m.label} ${m.flag} ${typeof m.once} ${typeof m.removeAllListeners} ${typeof m.listenerCount}`;
+}
+console.log("Multi:", probeMulti());
+
+// ── node:stream bases install the same way ──
+class R extends Readable {
+  pushes = 0;
+}
+function probeR(): string {
+  const r = new R();
+  r.pushes = 3;
+  return `${r.pushes} ${typeof r.on} ${typeof r.push} ${typeof r.pipe}`;
+}
+console.log("R:", probeR());
+
+class W extends Writable {
+  written = 0;
+}
+function probeW(): string {
+  const w = new W();
+  w.written = 4;
+  return `${w.written} ${typeof w.on} ${typeof w.write} ${typeof w.end}`;
+}
+console.log("W:", probeW());
+
+// ── the surface must be LIVE, not merely present ──
+class Bus extends EventEmitter {
+  seen = 0;
+}
+const bus = new Bus();
+bus.on("ping", (v: number) => {
+  bus.seen += v;
+  console.log("bus listener got:", v);
+});
+console.log("bus emit:", bus.emit("ping", 42), "seen:", bus.seen);
+
+// ── explicit constructor + super(): already escaped via `super`, keep working ──
+class Ctor extends EventEmitter {
+  seen = 0;
+  constructor(start: number) {
+    super();
+    this.seen = start;
+  }
+}
+function probeCtor(): string {
+  const c = new Ctor(3);
+  c.seen = 9;
+  return `${c.seen} ${typeof c.emit}`;
+}
+console.log("Ctor:", probeCtor());
+
+// ── an Error subclass (#573's sibling disqualifier) still works ──
+class MyError extends Error {
+  code = 42;
+}
+function probeErr(): string {
+  const e = new MyError("boom");
+  return `${e.message} ${e.code}`;
+}
+console.log("MyError:", probeErr());
+
+// ── an INDIRECT native base: declared fields on both hops must survive ──
+// (the emitter SURFACE on an indirect chain is a separate open gap — #6326 —
+// so this probes fields only, which is what this issue is about.)
+class Mid extends EventEmitter {
+  mid = 7;
+}
+class Leaf extends Mid {
+  leaf = 8;
+}
+function probeLeaf(): string {
+  const l = new Leaf();
+  l.leaf = 9;
+  return `${l.mid} ${l.leaf}`;
+}
+console.log("Leaf:", probeLeaf());
+
+// ── CONTROL: a plain class with no unmodeled base MUST still scalar-replace ──
+class Point {
+  x: number;
+  y: number;
+  constructor(x: number, y: number) {
+    this.x = x;
+    this.y = y;
+  }
+  getX(): number {
+    return this.x;
+  }
+}
+function hot(n: number): number {
+  let sum = 0;
+  for (let i = 0; i < n; i++) {
+    const p = new Point(i, i * 2);
+    sum += p.getX() + p.y;
+  }
+  return sum;
+}
+console.log("plain class (scalar-replaced):", hot(5));
+
+// ── CONTROL: a user-class chain is fully modeled — still scalar-replaced ──
+class Base {
+  base = 10;
+}
+class Derived extends Base {
+  own = 20;
+  total(): number {
+    return this.base + this.own;
+  }
+}
+function probeDerived(): string {
+  const d = new Derived();
+  return `${d.base} ${d.own} ${d.total()}`;
+}
+console.log("user chain:", probeDerived());


### PR DESCRIPTION
## Summary

Escape analysis promotes a non-escaping `new C()` to **one alloca per DECLARED field** and inlines the constructor stores into them. That model is faithful only when codegen can see the *whole* construction — and a native base cannot be seen.

`EventEmitter` and the `node:stream` classes install their method surface as **own properties on the instance** at subclass-init time (`js_object_set_field_by_name(obj, "emit", <native closure>)`), not on a prototype. A runtime-installed own property has no declared slot, so it was simply absent from the promoted set:

```ts
import { EventEmitter } from "node:events";
class X extends EventEmitter {
  a = 1;                       // a declared field is what makes it look promotable
}
const x = new X();
console.log("field:", x.a, "typeof emit:", typeof x.emit, "typeof on:", typeof x.on);
```

| | output |
|---|---|
| node 26 | `field: 1 typeof emit: function typeof on: function` |
| `main` | `field: 1 typeof emit: undefined typeof on: undefined` |
| this PR | `field: 1 typeof emit: function typeof on: function` |

Silent wrong answer, no error, no diagnostic. Closes #6343.

**The trigger is that the instance never escapes.** A *method call* on the receiver (`x.on(…)`) forces the heap path and hides the bug entirely — which is why this survived so long. The shape that bites is a bare property **read** sitting next to a field read, i.e. exactly `typeof x.emit`.

While writing the fixture I found the issue's "drop the field and the methods reappear" note is a red herring: `class X extends EventEmitter {}` with *no* field is equally broken when its only use is a bare read (the promoted set is then simply empty). What made the methods reappear in the original snippet was the method call, not the missing field.

## The fix

`class_chain_has_unmodeled_base` (`perry-codegen/src/collectors/this_as_value.rs`) walks the `extends` chain and disqualifies a scalar-replacement candidate when the chain reaches a base whose construction is opaque to codegen:

* **`native_extends`** — events / node:stream / Web Streams / async_hooks / ws. Resolved by walking the **chain**, so `class Leaf extends Mid`, `class Mid extends EventEmitter` is caught too, not just a literal `extends EventEmitter`.
* **`extends <expr>`** (including a lexically shadowed heritage name) — an arbitrary runtime parent whose constructor can install anything.
* **a parent name that resolves to no visible class** — a builtin (`Error`, `Map`, `Set`, `Event`, …) or an import whose stub never landed. Imported classes *do* land in `class_table` as stubs, so an ordinary cross-module `class Local extends ImportedBase` still resolves and stays on the fast path.

A cyclic chain fails closed. It is wired into `collect_non_escaping_news` as one more Pass-3 disqualifier, next to #313 (`this`-as-value) and #573 (builtin `Error`) — the same family, and the same shape as #5872/#6324's Pass-4 dispatch-stability guard.

This **generalizes** the #573 `class_chain_extends_builtin_error` check, which stays as-is: it is name-keyed and therefore also fires for a *locally shadowed* `Error`, which the chain walk would resolve to the user class and let through. Keeping both means the analysis only ever gets more conservative.

### It did not need #6342's helper

#6342 adds `native_instance_base_in_chain` in `lower_call/new_helpers.rs`, which enumerates *named* native bases (`EventEmitter`, `Map`, `Set`, `Event`, `CustomEvent`) because it has to decide **which** init to emit. This pass only has to decide **whether the base is opaque**, which is a strictly weaker question with a name-free answer — "does the chain leave the set of classes codegen can see". So there's no dependency and no duplicated list: the two land independently and can merge in either order. (#6342's own writeup calls this bug out as pre-existing and orthogonal, which matches.)

## The fast path is preserved — IR evidence

The point of a precise disqualifier is that the real perf win survives. Same two source files compiled by a **pristine `origin/main` `perry`** and by this branch's `perry` (identical `libperry_runtime.a` — this is a codegen-only change, verified by md5, so the archive cannot be a confound):

```
##### PLAIN CLASS  hot()  — must stay scalar-replaced #####
  baseline  heap-alloc: 0   method-dispatch: 0   body lines: 128
  fixed     heap-alloc: 0   method-dispatch: 0   body lines: 128
  -> hot() IR byte-identical across arms? YES

##### EventEmitter SUBCLASS  probe()  — must flip to the heap path #####
  baseline  heap-alloc: 0   body lines: 44     js_event_emitter_subclass_init: absent
  fixed     heap-alloc: 1   body lines: 284    js_event_emitter_subclass_init: present
```

The plain non-escaping class emits **byte-identical IR** on both sides — zero allocations, zero dispatch. The regression is localized exactly to the class that was miscompiled: on `main` its `probe()` never even called `js_event_emitter_subclass_init`, which is the bug in one line of IR.

`scripts/run_issue_945_scalar_method_ir_guard.sh` → **PASS** (both halves: the scalar fast path *and* the #5872 must-dispatch mirror). `test-files/test_issue_945_scalar_method_guards.ts` stays byte-identical to Node.

## Validation

**Fixture** — `test-files/test_gap_6343_scalar_native_base_surface.ts`, byte-identical to `node --experimental-strip-types`. It fails on pristine `main` on four independent probes (`X`, `Multi`, `R`, `W`) and passes here. It covers `EventEmitter`, `node:stream` `Readable` + `Writable`, an indirect `Leaf → Mid → EventEmitter` chain, and an `Error` subclass, plus controls: a plain class and a pure user-class chain that must *stay* scalar-replaced, an explicit-`super()` subclass, and a live emitter (listener actually fires).

**Unit tests** — 7 new cases in `collectors::this_as_value` pin the chain walk: plain class and user-class chain accepted; direct native parent, indirect native parent, unresolvable parent name, dynamic `extends <expr>`, and a cyclic chain all rejected. `cargo test -p perry-codegen --lib`: 176 passed, 0 failed.

**Gap-suite A/B, 298 tests, two genuinely distinct compilers.** Baseline = a `perry` built from a worktree pinned at `origin/main` (`be5ed2bfc`) and snapshotted *before* the fix commit (`be5ed2bfc`; the branch has since been rebased onto current `main`, which added only an unrelated docs commit and #6340); both arms run against the same (unchanged, md5-identical) runtime archives, so the compiler is the only variable. `md5(baseline perry) != md5(fixed perry)`, and the baseline binary demonstrably reproduces the bug while the fixed one does not — so the A/B is not vacuous.

**295 identical / 3 changed → zero regressions.**

| test | baseline | this PR | |
|---|---|---|---|
| `test_gap_6343_scalar_native_base_surface` | FAIL | **PASS** | the new fixture |
| `test_gap_console_methods` | FAIL | FAIL | run-to-run noise |
| `test_gap_module_const_local_shadow` | FAIL | FAIL | run-to-run noise |

The two unchanged-verdict tests are proven noise rather than build differences — re-running the **baseline** binary *alone* reproduces each:

* `test_gap_console_methods` diverges only on a `console.time` wall-clock line (`timer1: 0.010ms` vs `0.009ms`); three consecutive runs of the baseline binary print `0.001ms` / `0.002ms` / `0.002ms`.
* `test_gap_module_const_local_shadow` is already in `test-parity/known_failures.json` — it prints uninitialized memory, and three consecutive runs of the baseline binary yield `x+1.116756386944e-311`, `x+2.613644130718e-311`, `x+2.771571180747e-311`.

`cargo fmt --all -- --check` clean; `scripts/check_file_size.sh` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for classes extending native, dynamic, unresolved, or otherwise complex base classes.
  - Prevented inherited properties and methods from becoming unavailable in certain optimized object-handling scenarios.
  - Preserved expected behavior for event-driven classes, stream subclasses, error subclasses, and explicit constructor patterns.

- **Tests**
  - Added coverage for native inheritance chains, dynamic inheritance, unresolved parents, cyclic chains, and fully modeled user-defined classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->