### PR TITLE
fix(regex,hir): UTF-16 indices, own-property method shadowing, RegExp static inheritance (#5897)

### DIFF
--- a/crates/perry-hir/src/lower/expr_member/member_tail.rs
+++ b/crates/perry-hir/src/lower/expr_member/member_tail.rs
@@ -333,8 +333,33 @@ pub(crate) fn lower_member_tail(
                     );
                     let outer_is_inherited_function_proto_method =
                         matches!(outer_static_member, Some("bind" | "call" | "apply"));
+                    // #5897: `RegExp` has NO intrinsic static-member fast path in
+                    // Perry — nothing downstream keys on the collapsed
+                    // `GlobalGet(0).<prop>` shape for it (no reified statics are
+                    // installed for `RegExp`, and its `.prototype` / `.length` /
+                    // `.name` reads are folded by the dedicated arms above and
+                    // below, off the AST receiver rather than `object_expr`).
+                    // Collapsing can therefore only LOSE the receiver: an
+                    // unrecognized static read resolved against `globalThis`
+                    // instead of the constructor, so after
+                    // `Function.prototype.indicator = 1` the spec-mandated
+                    // `RegExp.indicator` (inherited from `Function.prototype`,
+                    // which is `RegExp`'s [[Prototype]]) came back `undefined`
+                    // rather than `1` (test262 built-ins/RegExp/S15.10.5_A2_T2).
+                    // Keeping the receiver lets the runtime walk the constructor's
+                    // prototype chain, which already resolves inherited props.
+                    //
+                    // The same receiver-drop affects the OTHER built-in
+                    // constructors (`Array.indicator`, `Object.indicator`, …), but
+                    // there the collapsed shape IS load-bearing — the intrinsic
+                    // call/constant-fold paths for `Array.isArray`, `Object.keys`,
+                    // `Math.PI`, … depend on it — so lifting it for those needs a
+                    // complete per-builtin intrinsic-member table and is tracked
+                    // separately.
+                    let receiver_is_regexp_ctor = property == "RegExp";
                     if !outer_is_prototype_or_proto
                         && !receiver_is_namespace_value
+                        && !receiver_is_regexp_ctor
                         && !outer_is_websocket_static
                         && !outer_is_reified_object_static_value
                         && !outer_is_reified_builtin_static_value

--- a/crates/perry-runtime/src/object/native_call_method/primitive_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/primitive_methods.rs
@@ -479,22 +479,58 @@ pub(super) unsafe fn dispatch_primitive(
         // (which returns the `/source/flags` literal). The same holds for
         // `re.exec` / `re.test` overrides, which libraries use to instrument a
         // regex. Expando writes on a RegExp land in the `exotic_expando` side
-        // table (a `RegExpHeader` is not an `ObjectHeader`), so consult it here
-        // and fall through to generic dispatch — which invokes the own value,
-        // or throws `is not a function` for a non-callable — whenever the key
-        // is present (test262 built-ins/RegExp/S15.10.4.1_A6_T1, #5897).
-        let shadowed_by_own = crate::regex::is_regex_pointer(p)
-            && crate::object::exotic_expando::value_lookup(
+        // table, because a `RegExpHeader` is not an `ObjectHeader`.
+        //
+        // The own value is invoked HERE rather than by declining the regex
+        // dispatch and letting the generic path pick it up: `toString` has a
+        // downstream catch-all arm that stringifies any pointer receiver via
+        // `js_jsvalue_to_string`, which maps a regex straight back to
+        // `/source/flags` — so a bare fall-through would still miss the
+        // override (test262 built-ins/RegExp/S15.10.4.1_A6_T1, #5897).
+        let own_override = if crate::regex::is_regex_pointer(p) {
+            crate::object::exotic_expando::value_lookup(
                 crate::object::exotic_expando::ExoticKind::RegExp,
                 p as usize,
                 method_name,
             )
-            .is_some();
-        if !shadowed_by_own {
-            let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
-            let arg0 = refreshed_args().first().copied().unwrap_or(undef);
-            if let Some(r) = crate::regex::dispatch_regex_receiver_method(p, method_name, arg0) {
-                return Some(r);
+        } else {
+            None
+        };
+        match own_override {
+            Some(own_bits) => {
+                let raw = (own_bits & crate::value::POINTER_MASK) as usize;
+                if (own_bits & crate::value::TAG_MASK) == crate::value::POINTER_TAG
+                    && crate::closure::is_closure_ptr(raw)
+                {
+                    // Bind `this` to the regex, exactly as the class-static and
+                    // prototype method-dispatch arms above do.
+                    let bound = crate::closure::clone_closure_rebind_this(
+                        own_bits,
+                        object_handle.get_nanbox_f64(),
+                    );
+                    let prop_handle = root_scope.root_nanbox_f64(f64::from_bits(bound));
+                    let args = refreshed_args();
+                    let prev_this =
+                        IMPLICIT_THIS.with(|c| c.replace(object_handle.get_nanbox_f64().to_bits()));
+                    let result = crate::closure::js_native_call_value(
+                        prop_handle.get_nanbox_f64(),
+                        args.as_ptr(),
+                        args.len(),
+                    );
+                    IMPLICIT_THIS.with(|c| c.set(prev_this));
+                    return Some(result);
+                }
+                // Own key present but NOT callable (`re.exec = 5; re.exec()`).
+                // Fall through to generic dispatch, which raises the
+                // `is not a function` TypeError — never run the builtin.
+            }
+            None => {
+                let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+                let arg0 = refreshed_args().first().copied().unwrap_or(undef);
+                if let Some(r) = crate::regex::dispatch_regex_receiver_method(p, method_name, arg0)
+                {
+                    return Some(r);
+                }
             }
         }
     }

--- a/crates/perry-runtime/src/object/native_call_method/primitive_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/primitive_methods.rs
@@ -470,11 +470,32 @@ pub(super) unsafe fn dispatch_primitive(
     // (#1731). The helper returns None for non-regex so generic dispatch resumes.
     #[cfg(feature = "regex-engine")]
     if matches!(method_name, "test" | "exec" | "toString") && jsval.is_pointer() {
-        let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
-        let arg0 = refreshed_args().first().copied().unwrap_or(undef);
         let p = jsval.as_pointer::<u8>();
-        if let Some(r) = crate::regex::dispatch_regex_receiver_method(p, method_name, arg0) {
-            return Some(r);
+        // An OWN property SHADOWS the `RegExp.prototype` method — ordinary
+        // `[[Get]]` consults the receiver's own properties before walking the
+        // prototype chain. `__re.toString = Object.prototype.toString;
+        // __re.toString()` must therefore call the *assigned* function (giving
+        // `[object RegExp]`), not the builtin `RegExp.prototype.toString`
+        // (which returns the `/source/flags` literal). The same holds for
+        // `re.exec` / `re.test` overrides, which libraries use to instrument a
+        // regex. Expando writes on a RegExp land in the `exotic_expando` side
+        // table (a `RegExpHeader` is not an `ObjectHeader`), so consult it here
+        // and fall through to generic dispatch — which invokes the own value,
+        // or throws `is not a function` for a non-callable — whenever the key
+        // is present (test262 built-ins/RegExp/S15.10.4.1_A6_T1, #5897).
+        let shadowed_by_own = crate::regex::is_regex_pointer(p)
+            && crate::object::exotic_expando::value_lookup(
+                crate::object::exotic_expando::ExoticKind::RegExp,
+                p as usize,
+                method_name,
+            )
+            .is_some();
+        if !shadowed_by_own {
+            let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+            let arg0 = refreshed_args().first().copied().unwrap_or(undef);
+            if let Some(r) = crate::regex::dispatch_regex_receiver_method(p, method_name, arg0) {
+                return Some(r);
+            }
         }
     }
 

--- a/crates/perry-runtime/src/object/native_call_method/primitive_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/primitive_methods.rs
@@ -487,12 +487,20 @@ pub(super) unsafe fn dispatch_primitive(
         // `js_jsvalue_to_string`, which maps a regex straight back to
         // `/source/flags` — so a bare fall-through would still miss the
         // override (test262 built-ins/RegExp/S15.10.4.1_A6_T1, #5897).
+        // `exotic_get_own_property` rather than `value_lookup`: the override
+        // may be an ACCESSOR (`Object.defineProperty(re, "test", { get() {…} })`),
+        // which `value_lookup` — a data-property-only side-table read — cannot
+        // see, so the builtin would run instead. It checks accessor descriptors
+        // first (invoking the getter with `object` as the receiver) and falls
+        // back to the same expando data lookup.
         let own_override = if crate::regex::is_regex_pointer(p) {
-            crate::object::exotic_expando::value_lookup(
-                crate::object::exotic_expando::ExoticKind::RegExp,
+            crate::object::exotic_expando::exotic_get_own_property(
                 p as usize,
+                crate::object::exotic_expando::ExoticKind::RegExp,
                 method_name,
+                object,
             )
+            .map(|v| v.to_bits())
         } else {
             None
         };

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -53,8 +53,9 @@ pub use compile::js_regexp_compile_value;
 pub use escape::js_regexp_escape;
 #[cfg(feature = "regex-engine")]
 use exec_array::{
-    byte_index_to_char_index, char_index_to_byte, set_exec_array_groups, set_exec_array_indices,
+    byte_index_to_utf16_index, set_exec_array_groups, set_exec_array_indices,
     set_exec_array_indices_fancy, set_exec_array_metadata, set_exec_array_metadata_value,
+    utf16_index_to_byte,
 };
 #[cfg(feature = "regex-engine")]
 use grammar::{
@@ -1335,7 +1336,7 @@ pub extern "C" fn js_string_search_regex(s: *const StringHeader, re: *const RegE
         // placeholder in `regex_ptr` would always report -1 otherwise.
         if let Some(fre) = lookup_fancy_regex(re) {
             return match fre.find(str_data) {
-                Ok(Some(m)) => str_data[..m.start()].chars().count() as i32,
+                Ok(Some(m)) => byte_index_to_utf16_index(str_data, m.start()) as i32,
                 _ => -1,
             };
         }
@@ -1343,11 +1344,9 @@ pub extern "C" fn js_string_search_regex(s: *const StringHeader, re: *const RegE
         let regex = &*(*re).regex_ptr;
         match regex.find(str_data) {
             Some(m) => {
-                // Convert byte offset to char offset (JS indices are UTF-16 code units,
-                // but for ASCII/BMP this matches char offset)
-                let byte_offset = m.start();
-                let char_offset = str_data[..byte_offset].chars().count();
-                char_offset as i32
+                // `String.prototype.search` returns a JS string index — UTF-16
+                // code units, matching `.index` / `lastIndex` / `str.length`.
+                byte_index_to_utf16_index(str_data, m.start()) as i32
             }
             None => -1,
         }

--- a/crates/perry-runtime/src/regex.rs
+++ b/crates/perry-runtime/src/regex.rs
@@ -46,6 +46,7 @@ mod replace_fn;
 mod unicode17;
 #[cfg(feature = "regex-engine")]
 mod unicode17_data;
+mod utf16;
 #[cfg(feature = "regex-engine")]
 use class_range_validate::has_out_of_order_double_dash_class_range;
 #[cfg(feature = "regex-engine")]

--- a/crates/perry-runtime/src/regex/exec.rs
+++ b/crates/perry-runtime/src/regex/exec.rs
@@ -61,17 +61,12 @@ pub extern "C" fn js_regexp_exec(
         // read above only drives the search start for a stateful regex.
         let last_index = if use_last_index { last_index_read } else { 0 };
 
+        // `lastIndex` is a JS string index — UTF-16 code units, like
+        // `str.length` — so map it back through the UTF-16 ↔ byte conversion
+        // rather than counting `chars()` (which walks one step per astral
+        // scalar instead of two, over-shooting the intended start).
         let search_start_byte = if use_last_index && last_index > 0 {
-            let mut byte_off = 0;
-            let mut char_count = 0;
-            for ch in str_data.chars() {
-                if char_count >= last_index {
-                    break;
-                }
-                byte_off += ch.len_utf8();
-                char_count += 1;
-            }
-            byte_off
+            super::exec_array::utf16_index_to_byte(str_data, last_index)
         } else {
             0
         };
@@ -103,7 +98,8 @@ pub extern "C" fn js_regexp_exec(
                         return Some(ptr::null_mut());
                     }
                     let match_byte_offset = full.start() + search_start_byte;
-                    let match_char_offset = str_data[..match_byte_offset].chars().count();
+                    let match_char_offset =
+                        super::exec_array::byte_index_to_utf16_index(str_data, match_byte_offset);
                     let arr = crate::array::js_array_alloc(caps.len() as u32);
                     let scope = crate::gc::RuntimeHandleScope::new();
                     let arr_handle = scope.root_raw_mut_ptr(arr);
@@ -122,8 +118,11 @@ pub extern "C" fn js_regexp_exec(
                         }
                     }
                     if use_last_index {
-                        let match_str = full.as_str();
-                        set_last_index_throwing(re, match_char_offset + match_str.chars().count());
+                        let match_end_byte = full.end() + search_start_byte;
+                        set_last_index_throwing(
+                            re,
+                            super::exec_array::byte_index_to_utf16_index(str_data, match_end_byte),
+                        );
                     }
                     set_exec_array_metadata(
                         arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
@@ -173,11 +172,13 @@ pub extern "C" fn js_regexp_exec(
         match standard_caps {
             Some(caps) => {
                 let match_byte_offset = caps.get(0).unwrap().start() + search_start_byte;
-                let match_char_offset = str_data[..match_byte_offset].chars().count();
+                let match_char_offset =
+                    super::exec_array::byte_index_to_utf16_index(str_data, match_byte_offset);
 
                 if use_last_index {
                     let match_end_byte = caps.get(0).unwrap().end() + search_start_byte;
-                    let match_end_char = str_data[..match_end_byte].chars().count();
+                    let match_end_char =
+                        super::exec_array::byte_index_to_utf16_index(str_data, match_end_byte);
                     set_last_index_throwing(re, match_end_char);
                 }
 

--- a/crates/perry-runtime/src/regex/exec_array.rs
+++ b/crates/perry-runtime/src/regex/exec_array.rs
@@ -103,12 +103,12 @@ pub(super) fn set_exec_array_indices(
     for (i, cap) in caps.iter().enumerate() {
         let indices_arr_ptr = indices_handle.get_raw_mut_ptr::<ArrayHeader>();
         if let Some(m) = cap {
-            // Convert byte offsets to char indices (JS spec uses UTF-16 code units,
-            // but we use char indices for simplicity — matches existing .index behavior)
+            // Convert byte offsets to JS string indices (UTF-16 code units),
+            // consistent with `.index` / `lastIndex` / `str.length`.
             let start_byte = m.start() + search_start_byte;
             let end_byte = m.end() + search_start_byte;
-            let start_char = str_data[..start_byte].chars().count() as f64;
-            let end_char = str_data[..end_byte].chars().count() as f64;
+            let start_char = byte_index_to_utf16_index(str_data, start_byte) as f64;
+            let end_char = byte_index_to_utf16_index(str_data, end_byte) as f64;
 
             // Create [start, end] pair
             let pair = crate::array::js_array_alloc(2);
@@ -155,8 +155,8 @@ pub(super) fn set_exec_array_indices(
             let val = if let Some(m) = m {
                 let start_byte = m.start() + search_start_byte;
                 let end_byte = m.end() + search_start_byte;
-                let start_char = str_data[..start_byte].chars().count() as f64;
-                let end_char = str_data[..end_byte].chars().count() as f64;
+                let start_char = byte_index_to_utf16_index(str_data, start_byte) as f64;
+                let end_char = byte_index_to_utf16_index(str_data, end_byte) as f64;
 
                 // Create [start, end] pair for named group
                 let pair = crate::array::js_array_alloc(2);
@@ -206,20 +206,43 @@ pub(super) fn set_exec_array_indices(
     );
 }
 
-pub(super) fn char_index_to_byte(s: &str, char_index: usize) -> usize {
-    if char_index == 0 {
+/// A JS string index (UTF-16 code units) → the byte offset of that position in
+/// the UTF-8 buffer. Inverse of [`byte_index_to_utf16_index`].
+///
+/// An index that lands *inside* a surrogate pair (i.e. addresses the low
+/// surrogate of an astral scalar, which has no UTF-8 boundary of its own)
+/// resolves to the byte offset just past that scalar; an index at or beyond the
+/// end resolves to `s.len()`.
+pub(super) fn utf16_index_to_byte(s: &str, utf16_index: usize) -> usize {
+    if utf16_index == 0 {
         return 0;
     }
-    for (idx, (byte, _)) in s.char_indices().enumerate() {
-        if idx == char_index {
+    let mut units = 0usize;
+    for (byte, ch) in s.char_indices() {
+        if units >= utf16_index {
             return byte;
         }
+        units += ch.len_utf16();
     }
     s.len()
 }
 
-pub(super) fn byte_index_to_char_index(s: &str, byte_index: usize) -> f64 {
-    s[..byte_index.min(s.len())].chars().count() as f64
+/// A byte offset in the UTF-8 buffer → the JS string index (UTF-16 code units).
+///
+/// Every JS-observable string index — `match.index`, `lastIndex`, the offset
+/// passed to a `String.prototype.replace` callback — is counted in UTF-16 code
+/// units, which is exactly what Perry's own `StringHeader::utf16_len`
+/// (`js_string_length`, i.e. `str.length`) reports. A non-BMP scalar such as
+/// U+1D306 is ONE `char` but TWO UTF-16 code units, so the previous
+/// `chars().count()` under-reported every index at or past an astral character
+/// and left the regex module inconsistent with `str.length` / `charAt`:
+/// `/./ug.exec('𝌆')` parked `lastIndex` at 1 where the spec (and Node) require 2
+/// (test262 built-ins/RegExp/prototype/exec/u-lastindex-value, #5897).
+pub(super) fn byte_index_to_utf16_index(s: &str, byte_index: usize) -> usize {
+    s[..byte_index.min(s.len())]
+        .chars()
+        .map(char::len_utf16)
+        .sum()
 }
 
 /// Build and attach the `indices` property for fancy-regex captures (lookbehind/backreference fallback).
@@ -246,8 +269,8 @@ pub(super) unsafe fn set_exec_array_indices_fancy(
         if let Some(m) = caps.get(i) {
             let start_byte = m.start() + search_start_byte;
             let end_byte = m.end() + search_start_byte;
-            let start_char = str_data[..start_byte].chars().count() as f64;
-            let end_char = str_data[..end_byte].chars().count() as f64;
+            let start_char = byte_index_to_utf16_index(str_data, start_byte) as f64;
+            let end_char = byte_index_to_utf16_index(str_data, end_byte) as f64;
 
             // Create [start, end] pair
             let pair = crate::array::js_array_alloc(2);
@@ -288,8 +311,8 @@ pub(super) unsafe fn set_exec_array_indices_fancy(
             let val = if let Some(m) = m {
                 let start_byte = m.start() + search_start_byte;
                 let end_byte = m.end() + search_start_byte;
-                let start_char = str_data[..start_byte].chars().count() as f64;
-                let end_char = str_data[..end_byte].chars().count() as f64;
+                let start_char = byte_index_to_utf16_index(str_data, start_byte) as f64;
+                let end_char = byte_index_to_utf16_index(str_data, end_byte) as f64;
 
                 // Create [start, end] pair for named group
                 let pair = crate::array::js_array_alloc(2);

--- a/crates/perry-runtime/src/regex/exec_array.rs
+++ b/crates/perry-runtime/src/regex/exec_array.rs
@@ -6,6 +6,7 @@
 //!
 //! Split out of `regex.rs` under the 2000-line CI cap.
 
+pub(super) use super::utf16::{byte_index_to_utf16_index, utf16_index_to_byte};
 use crate::array::ArrayHeader;
 use crate::object::ObjectHeader;
 use crate::value::js_nanbox_string;
@@ -204,45 +205,6 @@ pub(super) fn set_exec_array_indices(
         indices_key,
         f64::from_bits(indices_nanboxed.to_bits()),
     );
-}
-
-/// A JS string index (UTF-16 code units) → the byte offset of that position in
-/// the UTF-8 buffer. Inverse of [`byte_index_to_utf16_index`].
-///
-/// An index that lands *inside* a surrogate pair (i.e. addresses the low
-/// surrogate of an astral scalar, which has no UTF-8 boundary of its own)
-/// resolves to the byte offset just past that scalar; an index at or beyond the
-/// end resolves to `s.len()`.
-pub(super) fn utf16_index_to_byte(s: &str, utf16_index: usize) -> usize {
-    if utf16_index == 0 {
-        return 0;
-    }
-    let mut units = 0usize;
-    for (byte, ch) in s.char_indices() {
-        if units >= utf16_index {
-            return byte;
-        }
-        units += ch.len_utf16();
-    }
-    s.len()
-}
-
-/// A byte offset in the UTF-8 buffer → the JS string index (UTF-16 code units).
-///
-/// Every JS-observable string index — `match.index`, `lastIndex`, the offset
-/// passed to a `String.prototype.replace` callback — is counted in UTF-16 code
-/// units, which is exactly what Perry's own `StringHeader::utf16_len`
-/// (`js_string_length`, i.e. `str.length`) reports. A non-BMP scalar such as
-/// U+1D306 is ONE `char` but TWO UTF-16 code units, so the previous
-/// `chars().count()` under-reported every index at or past an astral character
-/// and left the regex module inconsistent with `str.length` / `charAt`:
-/// `/./ug.exec('𝌆')` parked `lastIndex` at 1 where the spec (and Node) require 2
-/// (test262 built-ins/RegExp/prototype/exec/u-lastindex-value, #5897).
-pub(super) fn byte_index_to_utf16_index(s: &str, byte_index: usize) -> usize {
-    s[..byte_index.min(s.len())]
-        .chars()
-        .map(char::len_utf16)
-        .sum()
 }
 
 /// Build and attach the `indices` property for fancy-regex captures (lookbehind/backreference fallback).

--- a/crates/perry-runtime/src/regex/match_all.rs
+++ b/crates/perry-runtime/src/regex/match_all.rs
@@ -1,7 +1,7 @@
 use super::{
-    byte_index_to_char_index, char_index_to_byte, is_valid_ptr, is_valid_regex_ptr, js_regexp_new,
-    js_string_from_str, set_exec_array_metadata_value, string_as_str,
-    throw_match_all_non_global_regex, RegExpHeader,
+    byte_index_to_utf16_index, is_valid_ptr, is_valid_regex_ptr, js_regexp_new, js_string_from_str,
+    set_exec_array_metadata_value, string_as_str, throw_match_all_non_global_regex,
+    utf16_index_to_byte, RegExpHeader,
 };
 use crate::array::ArrayHeader;
 use crate::object::ObjectHeader;
@@ -90,7 +90,7 @@ unsafe fn materialize_match_all_results(
     // needed because the never-match placeholder in `regex_ptr` would yield
     // an empty iterator otherwise.
     let str_data = string_as_str(s);
-    let search_start = char_index_to_byte(str_data, start_char_index);
+    let search_start = utf16_index_to_byte(str_data, start_char_index);
     let search_str = &str_data[search_start..];
 
     let mut owned: Vec<OwnedMatchAllData> = Vec::new();
@@ -112,7 +112,7 @@ unsafe fn materialize_match_all_results(
                     .collect(),
                 match_index: caps
                     .get(0)
-                    .map(|m| byte_index_to_char_index(str_data, search_start + m.start()))
+                    .map(|m| byte_index_to_utf16_index(str_data, search_start + m.start()) as f64)
                     .unwrap_or(start_char_index as f64),
             });
         }
@@ -134,7 +134,7 @@ unsafe fn materialize_match_all_results(
                     .collect(),
                 match_index: caps
                     .get(0)
-                    .map(|m| byte_index_to_char_index(str_data, search_start + m.start()))
+                    .map(|m| byte_index_to_utf16_index(str_data, search_start + m.start()) as f64)
                     .unwrap_or(start_char_index as f64),
             });
         }

--- a/crates/perry-runtime/src/regex/match_string.rs
+++ b/crates/perry-runtime/src/regex/match_string.rs
@@ -148,7 +148,9 @@ pub extern "C" fn js_string_match(
                         // Attach .index / .input as real own properties.
                         let match_char_offset = caps
                             .get(0)
-                            .map(|m| str_data[..m.start()].chars().count())
+                            .map(|m| {
+                                super::exec_array::byte_index_to_utf16_index(str_data, m.start())
+                            })
                             .unwrap_or(0);
                         set_exec_array_metadata(
                             arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
@@ -241,7 +243,7 @@ pub extern "C" fn js_string_match(
                     // on another regex, instead of a most-recent-match thread-local.
                     let match_char_offset = caps
                         .get(0)
-                        .map(|m| str_data[..m.start()].chars().count())
+                        .map(|m| super::exec_array::byte_index_to_utf16_index(str_data, m.start()))
                         .unwrap_or(0);
                     set_exec_array_metadata(
                         arr_handle.get_raw_mut_ptr::<ArrayHeader>(),

--- a/crates/perry-runtime/src/regex/match_string.rs
+++ b/crates/perry-runtime/src/regex/match_string.rs
@@ -148,9 +148,7 @@ pub extern "C" fn js_string_match(
                         // Attach .index / .input as real own properties.
                         let match_char_offset = caps
                             .get(0)
-                            .map(|m| {
-                                super::exec_array::byte_index_to_utf16_index(str_data, m.start())
-                            })
+                            .map(|m| super::utf16::byte_index_to_utf16_index(str_data, m.start()))
                             .unwrap_or(0);
                         set_exec_array_metadata(
                             arr_handle.get_raw_mut_ptr::<ArrayHeader>(),
@@ -243,7 +241,7 @@ pub extern "C" fn js_string_match(
                     // on another regex, instead of a most-recent-match thread-local.
                     let match_char_offset = caps
                         .get(0)
-                        .map(|m| super::exec_array::byte_index_to_utf16_index(str_data, m.start()))
+                        .map(|m| super::utf16::byte_index_to_utf16_index(str_data, m.start()))
                         .unwrap_or(0);
                     set_exec_array_metadata(
                         arr_handle.get_raw_mut_ptr::<ArrayHeader>(),

--- a/crates/perry-runtime/src/regex/replace_expand.rs
+++ b/crates/perry-runtime/src/regex/replace_expand.rs
@@ -247,7 +247,7 @@ pub(super) unsafe fn replace_regex_fn_fancy(
         matches.push(OwnedMatchData {
             start: full_match.start(),
             end: full_match.end(),
-            char_offset: str_data[..full_match.start()].chars().count(),
+            char_offset: super::exec_array::byte_index_to_utf16_index(str_data, full_match.start()),
             groups: (0..caps.len())
                 .map(|gi| caps.get(gi).map(|m| m.as_str().to_string()))
                 .collect(),
@@ -337,7 +337,10 @@ pub extern "C" fn js_string_replace_regex_fn(
             matches.push(OwnedMatchData {
                 start: full_match.start(),
                 end: full_match.end(),
-                char_offset: str_data[..full_match.start()].chars().count(),
+                char_offset: super::exec_array::byte_index_to_utf16_index(
+                    str_data,
+                    full_match.start(),
+                ),
                 groups: (0..caps.len())
                     .map(|gi| caps.get(gi).map(|m| m.as_str().to_string()))
                     .collect(),

--- a/crates/perry-runtime/src/regex/replace_fn.rs
+++ b/crates/perry-runtime/src/regex/replace_fn.rs
@@ -85,7 +85,7 @@ pub extern "C" fn js_string_replace_string_fn(
         let Some(byte_idx) = str_data.find(pattern_str.as_str()) else {
             return js_string_from_str(str_data);
         };
-        let char_offset = super::exec_array::byte_index_to_utf16_index(str_data, byte_idx);
+        let char_offset = super::utf16::byte_index_to_utf16_index(str_data, byte_idx);
         let replacement = call_string_replace_callback(
             callback_handle.get_nanbox_f64(),
             &pattern_str,

--- a/crates/perry-runtime/src/regex/replace_fn.rs
+++ b/crates/perry-runtime/src/regex/replace_fn.rs
@@ -85,7 +85,7 @@ pub extern "C" fn js_string_replace_string_fn(
         let Some(byte_idx) = str_data.find(pattern_str.as_str()) else {
             return js_string_from_str(str_data);
         };
-        let char_offset = str_data[..byte_idx].chars().count();
+        let char_offset = super::exec_array::byte_index_to_utf16_index(str_data, byte_idx);
         let replacement = call_string_replace_callback(
             callback_handle.get_nanbox_f64(),
             &pattern_str,
@@ -167,7 +167,12 @@ pub extern "C" fn js_string_replace_all_string_fn(
             str_data
                 .match_indices(pattern_str.as_str())
                 .map(|(byte_idx, _)| {
-                    char_pos += str_data[last_byte..byte_idx].chars().count();
+                    // Advance in UTF-16 code units — the offset handed to a
+                    // `String.prototype.replace` callback is a JS string index.
+                    char_pos += str_data[last_byte..byte_idx]
+                        .chars()
+                        .map(char::len_utf16)
+                        .sum::<usize>();
                     last_byte = byte_idx;
                     (byte_idx, char_pos)
                 })

--- a/crates/perry-runtime/src/regex/tests.rs
+++ b/crates/perry-runtime/src/regex/tests.rs
@@ -520,3 +520,107 @@ fn regex_cache_capped_and_prior_headers_survive_eviction() {
         "fancy-fallback header must keep rejecting after cache eviction"
     );
 }
+
+// ---------------------------------------------------------------------------
+// UTF-16 code-unit indices (#5897)
+//
+// Every JS-observable string index is counted in UTF-16 code units — the same
+// unit `str.length` (`StringHeader::utf16_len`) reports. The regex module used
+// to count `chars()` (Unicode scalars) instead, which is only equivalent for
+// BMP text: a non-BMP scalar is one `char` but TWO code units.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn byte_index_to_utf16_index_counts_surrogate_pairs_as_two() {
+    // U+1D306 TETRAGRAM FOR CENTRE ("𝌆") is 4 UTF-8 bytes / 1 char / 2 UTF-16 units.
+    let s = "𝌆a";
+    assert_eq!(byte_index_to_utf16_index(s, 0), 0);
+    // Past the astral scalar: 2 code units, NOT 1 (the old `chars().count()`).
+    assert_eq!(byte_index_to_utf16_index(s, 4), 2);
+    // Past the trailing ASCII 'a'.
+    assert_eq!(byte_index_to_utf16_index(s, 5), 3);
+    // Matches what `str.length` reports for the same string.
+    assert_eq!(
+        byte_index_to_utf16_index(s, s.len()),
+        s.encode_utf16().count()
+    );
+
+    // Pure-BMP text is unchanged (code points == code units).
+    let bmp = "héllo";
+    assert_eq!(
+        byte_index_to_utf16_index(bmp, bmp.len()),
+        bmp.encode_utf16().count()
+    );
+
+    // Out-of-range byte index clamps to the end rather than panicking.
+    assert_eq!(byte_index_to_utf16_index(s, 999), 3);
+}
+
+#[test]
+fn utf16_index_to_byte_inverts_byte_index_to_utf16_index() {
+    let s = "a𝌆b𝌆";
+    // Walk every code-unit boundary and confirm the round trip.
+    for (byte, ch) in s.char_indices() {
+        let u16_idx = byte_index_to_utf16_index(s, byte);
+        assert_eq!(
+            utf16_index_to_byte(s, u16_idx),
+            byte,
+            "round trip at {byte}"
+        );
+        let _ = ch;
+    }
+    assert_eq!(utf16_index_to_byte(s, 0), 0);
+    // Index 1 addresses the LOW surrogate of the first "𝌆" — no UTF-8 boundary
+    // of its own, so it resolves just past that scalar.
+    assert_eq!(utf16_index_to_byte(s, 2), 1 + 4);
+    // At/beyond the end clamps to the buffer length.
+    assert_eq!(utf16_index_to_byte(s, 99), s.len());
+}
+
+#[test]
+fn exec_last_index_advances_by_utf16_code_units() {
+    // test262 built-ins/RegExp/prototype/exec/u-lastindex-value:
+    //   var r = /./ug; r.exec('𝌆'); assert.sameValue(r.lastIndex, 2);
+    // A single astral match must leave `lastIndex` at 2 (the string's `.length`),
+    // not 1 (its scalar count).
+    let re = js_regexp_new(make_string("."), make_string("ug"));
+    let arr = js_regexp_exec(re, make_string("𝌆"));
+    assert!(!arr.is_null(), "/./ug must match the astral scalar");
+    assert_eq!(
+        regex_last_index_offset(re),
+        2,
+        "lastIndex must be in UTF-16 code units"
+    );
+
+    // A second exec finds nothing more and resets lastIndex — proving the
+    // UTF-16 lastIndex maps back to a valid byte offset (the end of input).
+    let arr2 = js_regexp_exec(re, make_string("𝌆"));
+    assert!(
+        arr2.is_null(),
+        "second exec must not re-match past the input"
+    );
+    assert_eq!(regex_last_index_offset(re), 0, "no-match resets lastIndex");
+}
+
+#[test]
+fn global_exec_walks_astral_string_by_code_units() {
+    // Two astral scalars: `.` with `u` matches each whole scalar, so lastIndex
+    // must land on 2 then 4 — the same indices `str.length` / `charAt` use.
+    let re = js_regexp_new(make_string("."), make_string("ug"));
+    let subject = "𝌆𝌆";
+    assert!(!js_regexp_exec(re, make_string(subject)).is_null());
+    assert_eq!(regex_last_index_offset(re), 2);
+    assert!(!js_regexp_exec(re, make_string(subject)).is_null());
+    assert_eq!(regex_last_index_offset(re), 4);
+    // Exhausted → null, lastIndex reset.
+    assert!(js_regexp_exec(re, make_string(subject)).is_null());
+    assert_eq!(regex_last_index_offset(re), 0);
+}
+
+#[test]
+fn search_returns_utf16_index() {
+    // `"𝌆x".search(/x/)` is 2 (the astral scalar occupies indices 0 and 1),
+    // matching `"𝌆x".indexOf("x")`.
+    let re = js_regexp_new(make_string("x"), make_string(""));
+    assert_eq!(js_string_search_regex(make_string("𝌆x"), re), 2);
+}

--- a/crates/perry-runtime/src/regex/utf16.rs
+++ b/crates/perry-runtime/src/regex/utf16.rs
@@ -1,0 +1,36 @@
+//! UTF-16 <-> byte index conversion.
+//!
+//! JS string indices are UTF-16 code units, and `StringHeader::utf16_len`
+//! (`str.length`) reports them — but Rust byte offsets are what the match
+//! engines hand back. Converting with `chars().count()` yields *Unicode
+//! scalars*, which disagrees with `str.length` / `charAt` on the same string
+//! at and past any astral character.
+//!
+//! These live outside `exec_array` deliberately: that module is behind
+//! `#[cfg(feature = "regex-engine")]`, but `replace_fn` and `match_string`
+//! are not, and they need these too. Keeping the helpers here means a
+//! `regex-engine`-off build still compiles. (Same class of cross-gate
+//! dependency as #6303.)
+
+/// UTF-16 code-unit index -> byte offset.
+pub(super) fn utf16_index_to_byte(s: &str, utf16_index: usize) -> usize {
+    if utf16_index == 0 {
+        return 0;
+    }
+    let mut units = 0usize;
+    for (byte, ch) in s.char_indices() {
+        if units >= utf16_index {
+            return byte;
+        }
+        units += ch.len_utf16();
+    }
+    s.len()
+}
+
+/// Byte offset -> UTF-16 code-unit index.
+pub(super) fn byte_index_to_utf16_index(s: &str, byte_index: usize) -> usize {
+    s[..byte_index.min(s.len())]
+        .chars()
+        .map(char::len_utf16)
+        .sum()
+}

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -1148,6 +1148,52 @@ pub extern "C" fn js_jsvalue_to_string_method(value: f64) -> *mut crate::string:
             }
         }
     }
+    // An OWN `toString` shadows the built-in conversion. Codegen's "universal
+    // `.toString()`" fold (lower_call/property_get/number_string.rs) rewrites
+    // EVERY `x.toString()` into a direct call to this function whenever the
+    // receiver isn't a user class that declares `toString` — bypassing the
+    // runtime method-dispatch arms entirely. So the own-property check that
+    // `dispatch_primitive` applies to `re.exec` / `re.test` has to be repeated
+    // at this fold target, or an assigned `re.toString` is silently ignored and
+    // the regex renders as its `/source/flags` literal instead:
+    //
+    //     __re.toString = Object.prototype.toString;
+    //     __re.toString()   // must be "[object RegExp]", was "/(?:)/"
+    //
+    // (test262 built-ins/RegExp/S15.10.4.1_A6_T1, #5897.) Expandos on a RegExp
+    // live in the `exotic_expando` side table — a `RegExpHeader` is not an
+    // `ObjectHeader` — and the `is_regex_pointer` gate keeps every other
+    // receiver on the existing fast path.
+    #[cfg(feature = "regex-engine")]
+    if jsval.is_pointer() {
+        let p = jsval.as_pointer::<u8>();
+        if crate::regex::is_regex_pointer(p) {
+            let own = crate::object::exotic_expando::value_lookup(
+                crate::object::exotic_expando::ExoticKind::RegExp,
+                p as usize,
+                "toString",
+            );
+            if let Some(own_bits) = own {
+                let raw = (own_bits & crate::value::POINTER_MASK) as usize;
+                if (own_bits & crate::value::TAG_MASK) == crate::value::POINTER_TAG
+                    && crate::closure::is_closure_ptr(raw)
+                {
+                    let bound = crate::closure::clone_closure_rebind_this(own_bits, value);
+                    let prev_this =
+                        crate::object::IMPLICIT_THIS.with(|c| c.replace(value.to_bits()));
+                    let result = unsafe {
+                        crate::closure::js_native_call_value(
+                            f64::from_bits(bound),
+                            std::ptr::null(),
+                            0,
+                        )
+                    };
+                    crate::object::IMPLICIT_THIS.with(|c| c.set(prev_this));
+                    return js_jsvalue_to_string(result);
+                }
+            }
+        }
+    }
     js_jsvalue_to_string(value)
 }
 

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -1168,11 +1168,21 @@ pub extern "C" fn js_jsvalue_to_string_method(value: f64) -> *mut crate::string:
     if jsval.is_pointer() {
         let p = jsval.as_pointer::<u8>();
         if crate::regex::is_regex_pointer(p) {
-            let own = crate::object::exotic_expando::value_lookup(
-                crate::object::exotic_expando::ExoticKind::RegExp,
-                p as usize,
-                "toString",
-            );
+            // Accessor-aware: the override may be installed via
+            // `Object.defineProperty(re, "toString", { get() {…} })`, which a
+            // data-only `value_lookup` cannot see (it would silently fall back
+            // to the `/source/flags` literal). `exotic_get_own_property` checks
+            // accessor descriptors first, invoking the getter with `value` as
+            // the receiver, then falls back to the same expando data lookup.
+            let own = unsafe {
+                crate::object::exotic_expando::exotic_get_own_property(
+                    p as usize,
+                    crate::object::exotic_expando::ExoticKind::RegExp,
+                    "toString",
+                    value,
+                )
+            }
+            .map(|v| v.to_bits());
             if let Some(own_bits) = own {
                 let raw = (own_bits & crate::value::POINTER_MASK) as usize;
                 if (own_bits & crate::value::TAG_MASK) == crate::value::POINTER_TAG

--- a/test-files/test_issue_5897_regexp_own_props_and_utf16.ts
+++ b/test-files/test_issue_5897_regexp_own_props_and_utf16.ts
@@ -1,0 +1,96 @@
+// #5897 (test262 built-ins/RegExp worklist): three RegExp-surface gaps.
+//
+// 1. An OWN property must SHADOW the `RegExp.prototype` method. Ordinary
+//    `[[Get]]` consults the receiver's own properties before walking the
+//    prototype chain, so an assigned `toString` / `exec` / `test` wins over the
+//    builtin. Perry ignored the override: `exec`/`test` because the regex
+//    method-dispatch arm ran before any own-property check, and `toString`
+//    additionally because codegen folds every `x.toString()` straight into
+//    `js_jsvalue_to_string_method` (test262 S15.10.4.1_A6_T1).
+//
+// 2. `RegExp`'s [[Prototype]] is `Function.prototype`, so a property added
+//    there is readable off the constructor. The HIR member-lowering collapsed
+//    `RegExp.<unknown>` to `globalThis.<unknown>`, dropping the receiver
+//    (test262 S15.10.5_A2_T2).
+//
+// 3. JS string indices are UTF-16 code units, not Unicode scalars. The regex
+//    module counted `chars()`, so every index at or past an astral character
+//    was under-reported and disagreed with `str.length` / `charAt` on the same
+//    string (test262 prototype/exec/u-lastindex-value).
+//
+// Validated byte-for-byte against `node --experimental-strip-types`.
+
+// --- 1. own-property shadowing -------------------------------------------
+const re: any = /a/g;
+re.toString = Object.prototype.toString;
+console.log("own toString  :", re.toString());
+
+const re2: any = /a/g;
+re2.toString = function () {
+  return "OWN-TS";
+};
+console.log("own toString2 :", re2.toString());
+
+const re3: any = /a/g;
+re3.exec = function () {
+  return "OWN-EXEC";
+};
+re3.test = function () {
+  return "OWN-TEST";
+};
+console.log("own exec      :", re3.exec("a"));
+console.log("own test      :", re3.test("a"));
+
+// A regex WITHOUT an override still gets the builtin methods.
+const plain = /a+/;
+console.log("builtin toStr :", plain.toString());
+console.log("builtin exec  :", JSON.stringify(plain.exec("caaat")));
+console.log("builtin test  :", plain.test("caaat"));
+
+// The brand is unaffected by an own toString.
+console.log("brand         :", Object.prototype.toString.call(re2));
+
+// --- 2. RegExp inherits from Function.prototype ---------------------------
+(Function.prototype as any).indicator = 1;
+console.log("RegExp.indic  :", (RegExp as any).indicator);
+console.log("proto is FnP  :", Object.getPrototypeOf(RegExp) === Function.prototype);
+// The intrinsic RegExp surfaces still resolve.
+console.log("RegExp.proto  :", typeof RegExp.prototype);
+console.log("RegExp.length :", RegExp.length);
+console.log("RegExp.name   :", RegExp.name);
+
+// --- 3. UTF-16 code-unit indices -----------------------------------------
+// U+1D306 is ONE scalar but TWO UTF-16 code units.
+const astral = "\u{1D306}";
+console.log("length        :", astral.length);
+
+const u = /./gu;
+u.exec(astral);
+console.log("lastIndex     :", u.lastIndex);
+
+// Walking two astral scalars lands on 2 then 4.
+const u2 = /./gu;
+const two = "\u{1D306}\u{1D306}";
+u2.exec(two);
+console.log("walk 1        :", u2.lastIndex);
+u2.exec(two);
+console.log("walk 2        :", u2.lastIndex);
+console.log("walk 3 (null) :", u2.exec(two));
+console.log("reset         :", u2.lastIndex);
+
+// `.index` and `search` agree with `indexOf` past an astral char.
+const m = /x/.exec(astral + "x");
+console.log("match index   :", m ? m.index : -1);
+console.log("search        :", (astral + "x").search(/x/));
+console.log("indexOf       :", (astral + "x").indexOf("x"));
+
+// The offset handed to a replace callback is a JS string index too.
+(astral + "x").replace(/x/, (match: string, offset: number) => {
+  console.log("replace offset:", offset);
+  return match;
+});
+
+// BMP text is unchanged.
+const bmp = /o/g;
+bmp.exec("foo");
+console.log("bmp lastIndex :", bmp.lastIndex);


### PR DESCRIPTION
Closes out the tractable remainder of the test262 `built-ins/RegExp` worklist (#5897).

## test262 `built-ins/RegExp` — measured, pinned SHA `4249661`, node v26.3.0

| | before | after |
|---|---|---|
| pass | 1162 | **1167** |
| runtime-fail | 9 | **6** |
| compile-fail | 2 | **0** |
| parity | 99.1% | **99.5%** |

**11 → 6 failures. Zero regressions** (before/after failure lists diffed; no case that passed before fails now).

The 2 `compile-fail`s were **not real failures** — `property-escapes/generated/{Alphabetic,Assigned}.js` are the two largest generated files and were tripping the runner's 20s per-test timeout under `--jobs 8`. Standalone they compile in ~6s and run clean; they did not recur on the re-measure.

## What was broken

### 1. JS string indices are UTF-16 code units, not Unicode scalars

Every JS-observable string index — `match.index`, `lastIndex`, the offset handed to a `String.prototype.replace` callback, the `d`-flag `indices` pairs, `String.prototype.search` — is counted in UTF-16 code units. That is also the unit Perry's own `StringHeader::utf16_len` (`js_string_length`, i.e. `str.length`) reports.

The regex module instead counted `chars()` (Unicode scalars) at ~20 sites. The two agree only for BMP text: a non-BMP scalar is ONE `char` but TWO UTF-16 code units, so **every index at or past an astral character was under-reported**, leaving the regex module inconsistent with `str.length` / `charAt` on the very same string:

```js
const r = /./ug;
r.exec('𝌆');
r.lastIndex   // was 1, must be 2 ('𝌆'.length === 2)
```

Replaced the `char_index_to_byte` / `byte_index_to_char_index` pair with `utf16_index_to_byte` / `byte_index_to_utf16_index` and routed every byte↔index conversion in exec / match / matchAll / replace / search through them. The reverse map (`lastIndex` → byte offset) had to move in lockstep: counting `chars()` there walked one step per astral scalar instead of two, overshooting the resume point.

Because the old and new code differ **only** when the subject contains a non-BMP character, and only ever move toward Node's semantics, no previously-passing case can regress — a test that agreed with Node on an astral string under code-point indices is impossible, since Node is UTF-16.

### 2. An own property must shadow the `RegExp.prototype` method

```js
__re.toString = Object.prototype.toString;
__re.toString()   // was "/(?:)/", must be "[object RegExp]"
```

Ordinary `[[Get]]` consults own properties before walking the prototype chain. Two independent layers dropped the override:

- **Runtime dispatch** ran the regex `test`/`exec`/`toString` arm before any own-property check. Expandos on a RegExp live in the `exotic_expando` side table (a `RegExpHeader` is not an `ObjectHeader`), so the dispatch now consults it and invokes the own value with `this` bound to the regex. This also fixes `re.exec` / `re.test` overrides, which were broken the same way.
- **Codegen** has a *universal `.toString()` fold* (`lower_call/property_get/number_string.rs`): whenever the receiver isn't a user class declaring `toString`, `x.toString()` is rewritten into a direct `js_jsvalue_to_string_method(x)` call, bypassing method dispatch entirely. It only ever checked user *classes* for an override, never runtime own properties — so the fix above never ran for `toString`. The check is repeated at that fold target, gated on `is_regex_pointer` so all other receivers stay on the existing fast path.

### 3. `RegExp.<unknown-prop>` dropped its receiver

```js
Function.prototype.indicator = 1;
RegExp.indicator   // was undefined, must be 1
```

`Function.prototype` **is** `RegExp`'s `[[Prototype]]`, so the property is inherited. But HIR member-lowering (`expr_member/member_tail.rs`) collapses `<Builtin>.<prop>` to the intrinsic `GlobalGet(0).<prop>` shape unless the property is on a per-builtin carve-out list — so an *unrecognized* property resolved against `globalThis` instead of the constructor.

`RegExp` has no intrinsic static-member fast path in Perry (no reified statics are installed for it; `.prototype` / `.length` / `.name` are folded by dedicated arms off the AST receiver), so collapsing can only *lose* the receiver. It is now skipped for `RegExp`, letting the runtime walk the constructor's prototype chain.

The same receiver-drop affects the other built-in constructors (`Array.indicator`, `Object.indicator`, …), but there the collapsed shape **is** load-bearing — the intrinsic call/constant-fold paths for `Array.isArray`, `Object.keys`, `Math.PI`, … depend on it. Lifting it for those needs a complete per-builtin intrinsic-member table, so it is deliberately left out of scope here and called out in the issue.

## Cases closed

- `S15.10.4.1_A6_T1` — `Object.prototype.toString` assigned onto a regex
- `S15.10.5_A2_T2` — `RegExp` inherits from `Function.prototype`
- `prototype/exec/u-lastindex-value` — `lastIndex` in UTF-16 code units

## What remains (6) — and why

**4 cases are one root cause: ECMA-262 `RepeatMatcher` semantics.**

`S15.10.2.5_A1_T4`, `prototype/exec/S15.10.6.2_A1_T6`, `nullable-quantifier`, `lookahead-quantifier-match-groups`.

They need two behaviours a finite-automata engine cannot express: **captures inside a quantified group are reset on each iteration** (so `/(z)((a+)?(b+)?(c))*/.exec("zaacbbbcac")` yields `undefined`, not `"bbb"`, for the `(b+)?` group), and **an optional iteration that matches the empty string is discarded and retried** (so `/(a?b??)*/` matches all of `"ab"`, not just `"a"`). Perry compiles with the Rust `regex` crate, and the `fancy-regex` fallback delegates non-fancy patterns straight back to it — so neither path implements JS backtracking capture semantics. Closing these means writing a spec-compliant backtracking matcher: real, coherent, and much larger than this PR.

**2 cases are the documented lone-surrogate / WTF-8 categorical gap** (listed as a standing limitation in CLAUDE.md).

`S15.10.2.8_A2_T1`, `character-class-escape-non-whitespace` — both hinge on a lone surrogate (`\uD800`) surviving as a string value, which Perry's UTF-8 string representation cannot represent.

Excluding that documented categorical gap, the worklist is down to the single `RepeatMatcher` cluster.

## Validation

- `built-ins/RegExp` before/after diffed — 5 cases flipped to pass, **zero new failures**.
- 5 new unit tests in `crates/perry-runtime/src/regex/tests.rs` (UTF-16 helpers, round-trip, `lastIndex` advance, astral walk, `search`); all 41 regex tests pass.
- `test-files/test_issue_5897_regexp_own_props_and_utf16.ts` — new parity test covering all three fixes, **byte-identical to `node --experimental-strip-types`**.
- `cargo test -p perry-runtime --lib`: 1298 passed. The one failure, `promise::keyed_table::tests::settling_many_keys_is_not_quadratic`, is a **pre-existing flaky wall-clock scaling assertion** (`large < small * 8.0 + 0.05`) introduced by the base commit — it passes 3/5 and fails 2/5 on identical code, lives in `promise/keyed_table.rs`, and is untouched by this diff.
- `cargo fmt --all -- --check` clean; `scripts/check_file_size.sh` clean.

Refs #5897.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `RegExp`/string match indexing to follow JavaScript UTF-16 code-unit semantics across `lastIndex`, `exec` iteration, `search`, match `.index`, `String.prototype.replace` callback offsets, and `indices`.
  * Improved `RegExp` method dispatch to respect instance own-property overrides for `exec`, `test`, and `toString`.
  * Adjusted handling of `RegExp` static member reads to preserve the correct constructor receiver.
* **Tests**
  * Added unit and TypeScript coverage for UTF-16 indexing and RegExp own-property shadowing behavior (issue `#5897`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->