### PR TITLE
fix(runtime): V8/Node microtask-tick parity for promise resolution and Web Streams

### DIFF
--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -884,6 +884,7 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
     module.declare_function("js_promise_resolve", VOID, &[I64, DOUBLE]);
     module.declare_function("js_promise_reject", VOID, &[I64, DOUBLE]);
     module.declare_function("js_promise_resolved", I64, &[DOUBLE]);
+    module.declare_function("js_async_fn_result", I64, &[DOUBLE]);
     module.declare_function("js_promise_rejected", I64, &[DOUBLE]);
     // Issue #100: build a module-namespace object from parallel key/
     // value arrays. Called from `__perry_init_<prefix>` (populate the

--- a/crates/perry-codegen/src/stmt/mod.rs
+++ b/crates/perry-codegen/src/stmt/mod.rs
@@ -260,13 +260,14 @@ pub(crate) fn lower_stmt(ctx: &mut FnCtx<'_>, stmt: &Stmt) -> Result<()> {
             }
             let v = lower_return_expr(ctx, e)?;
             // Phase E: async functions wrap their return value in
-            // js_promise_resolved so callers can await the result.
-            // If the value is already a promise (e.g. `return
-            // Promise.resolve(x)`), js_promise_resolved is a no-op
-            // wrap that the caller's await loop unwraps anyway.
+            // js_async_fn_result so callers can await the result. Unlike
+            // js_promise_resolved (whose Promise.resolve(p) === p identity
+            // is spec for Promise.resolve only), an async fn returning a
+            // promise must produce a FRESH promise that adopts the inner
+            // via the two-tick thenable job (V8 microtask-hop parity).
             let final_v = if ctx.is_async_fn {
                 let blk = ctx.block();
-                let handle = blk.call(crate::types::I64, "js_promise_resolved", &[(DOUBLE, &v)]);
+                let handle = blk.call(crate::types::I64, "js_async_fn_result", &[(DOUBLE, &v)]);
                 crate::expr::nanbox_pointer_inline_pub(blk, &handle)
             } else {
                 v

--- a/crates/perry-runtime/src/promise/assimilate.rs
+++ b/crates/perry-runtime/src/promise/assimilate.rs
@@ -169,10 +169,12 @@ pub(crate) fn promise_resolve_assimilating(promise: *mut Promise, value: f64) {
                 js_promise_resolve(promise, value);
                 return;
             }
-            // No own `then` → intrinsic `then`; native promise→promise wiring.
+            // No own `then` → intrinsic `then`. Adopt via the native job so
+            // the outer settles exactly two ticks later (V8 hop parity; see
+            // `enqueue_native_adoption_job`).
             OwnThen::None => {
                 let inner = crate::value::js_nanbox_get_pointer(value) as *mut Promise;
-                js_promise_resolve_with_promise(promise, inner);
+                enqueue_native_adoption_job(promise, inner);
                 return;
             }
         }
@@ -183,6 +185,82 @@ pub(crate) fn promise_resolve_assimilating(promise: *mut Promise, value: f64) {
         Ok(None) => js_promise_resolve(promise, value),
         Err(reason) => js_promise_reject(promise, reason),
     }
+}
+
+/// ECMA-262 hop parity for resolving a promise WITH a native promise (no own
+/// `then`): V8 still runs `PromiseResolveThenableJob` (+1 tick) and the
+/// intrinsic `then` it invokes registers a reaction (+1 tick), so adoption of
+/// an already-settled inner is observable exactly two ticks after resolve —
+/// `new Promise(res => res(Promise.resolve(1))).then(X)` fires `X` on tick 3
+/// in Node, and `async fn` returning a promise behaves identically. The old
+/// synchronous `js_promise_resolve_with_promise` wiring settled the outer
+/// ZERO ticks later, which reordered any promise chain racing the adoption
+/// (Next.js cold-start head reorder: the flight client's module-dep chain
+/// lost exactly one such race against the RSC stream read loop).
+pub(super) fn enqueue_native_adoption_job(outer: *mut Promise, inner: *mut Promise) {
+    use crate::closure::{js_closure_alloc, js_closure_set_capture_ptr};
+
+    let callback = js_closure_alloc(native_promise_adoption_job as *const u8, 2);
+    js_closure_set_capture_ptr(callback, 0, outer as i64);
+    js_closure_set_capture_ptr(callback, 1, inner as i64);
+
+    let context = capture_context();
+    let ids = crate::async_hooks::init_resource(
+        "PromiseResolveThenableJob",
+        f64::from_bits(crate::value::TAG_UNDEFINED),
+        false,
+    );
+    TASK_QUEUE.with(|q| {
+        q.borrow_mut().push_back(Task::Microtask {
+            callback,
+            context,
+            async_id: ids.async_id,
+            trigger_async_id: ids.trigger_async_id,
+        });
+    });
+    crate::event_pump::js_notify_main_thread();
+}
+
+/// Job body — the intrinsic-`then` invocation of the adoption job. For a
+/// settled inner the adoption must land as a REACTION (one more tick), never
+/// a synchronous copy, matching V8's reaction-job. A still-pending inner
+/// falls back to the existing chain wiring: its settlement path already
+/// delivers through the microtask runner.
+extern "C" fn native_promise_adoption_job(closure: *const crate::closure::ClosureHeader) -> f64 {
+    use crate::closure::js_closure_get_capture_ptr;
+
+    let outer = js_closure_get_capture_ptr(closure, 0) as *mut Promise;
+    let inner = js_closure_get_capture_ptr(closure, 1) as *mut Promise;
+    if outer.is_null() || inner.is_null() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    let settled = unsafe {
+        match (*inner).state {
+            PromiseState::Fulfilled => Some(((*inner).value, false)),
+            PromiseState::Rejected => Some(((*inner).reason, true)),
+            PromiseState::Pending => None,
+        }
+    };
+    match settled {
+        Some((value, is_error)) => {
+            // Null-closure AsyncStep = a pure propagation task: the runner
+            // resolves/rejects `outer` with `value` on the next tick.
+            TASK_QUEUE.with(|q| {
+                q.borrow_mut().push_back(Task::AsyncStep(
+                    std::ptr::null(),
+                    value,
+                    outer,
+                    is_error,
+                    capture_context(),
+                ));
+            });
+            crate::event_pump::js_notify_main_thread();
+        }
+        None => {
+            super::then::js_promise_resolve_with_promise(outer, inner);
+        }
+    }
+    f64::from_bits(crate::value::TAG_UNDEFINED)
 }
 
 #[inline]

--- a/crates/perry-runtime/src/promise/async_step.rs
+++ b/crates/perry-runtime/src/promise/async_step.rs
@@ -380,6 +380,27 @@ pub extern "C" fn js_async_step_chain(value: f64, step_closure: ClosurePtr) -> *
 /// function) or step_closure doesn't match (nested async-fn call,
 /// where the outer activation's `next` must NOT be settled here).
 /// Fall back to `js_promise_resolved(value)`.
+/// Codegen entry for the return value of an await-less async fn (the
+/// transform leaves those un-converted; `Stmt::Return` wraps the value
+/// directly). Differs from `js_promise_resolved` in one spec-visible way: an
+/// async fn always returns a FRESH promise, and `return <promise>` ADOPTS the
+/// inner via the two-tick job (V8 hop parity; hops.js
+/// `asyncfn-return-resolved-promise` = t0 t1 t2 X in Node) — the #2823
+/// `Promise.resolve(p) === p` identity does not apply to async returns.
+#[no_mangle]
+pub extern "C" fn js_async_fn_result(value: f64) -> *mut Promise {
+    let value = adapt_foreign_promise_value(value);
+    if js_value_is_promise(value) != 0 {
+        let inner = crate::value::js_nanbox_get_pointer(value) as *mut Promise;
+        if !inner.is_null() {
+            let fresh = js_promise_new();
+            super::assimilate::enqueue_native_adoption_job(fresh, inner);
+            return fresh;
+        }
+    }
+    js_promise_resolved(value)
+}
+
 #[no_mangle]
 pub extern "C" fn js_async_step_done(value: f64, step_closure: ClosurePtr) -> *mut Promise {
     // PR #1004 followup (sibling to js_async_step_chain): adapt a
@@ -409,6 +430,19 @@ pub extern "C" fn js_async_step_done(value: f64, step_closure: ClosurePtr) -> *m
         trap.trap_next
     } else {
         bump(&MT_STEP_DONE_REUSE_MISS);
+        // An async fn always returns a FRESH promise — `js_promise_resolved`'s
+        // #2823 identity short-circuit (Promise.resolve(p) === p) must not
+        // apply to `return <promise>` from an async fn, which instead adopts
+        // the inner promise via the two-tick job (V8 hop parity; hops.js
+        // `asyncfn-return-resolved-promise` = t0 t1 t2 X in Node).
+        if js_value_is_promise(value) != 0 {
+            let inner = crate::value::js_nanbox_get_pointer(value) as *mut Promise;
+            if !inner.is_null() {
+                let fresh = js_promise_new();
+                super::assimilate::enqueue_native_adoption_job(fresh, inner);
+                return fresh;
+            }
+        }
         js_promise_resolved(value)
     }
 }
@@ -426,11 +460,13 @@ fn resolve_trap_next_with_adoption(target: *mut Promise, value: f64) {
         js_promise_resolve(target, value);
         return;
     }
-    // Native Promise: chain `target` to follow its eventual state.
+    // Native Promise: adopt via the native job — `return <promise>` from an
+    // async fn is observable two ticks later in V8 (hop parity; see
+    // `enqueue_native_adoption_job`).
     if js_value_is_promise(value) != 0 {
         let inner = crate::value::js_nanbox_get_pointer(value) as *mut Promise;
         if !inner.is_null() && inner != target {
-            js_promise_resolve_with_promise(target, inner);
+            super::assimilate::enqueue_native_adoption_job(target, inner);
             return;
         }
     }
@@ -440,7 +476,7 @@ fn resolve_trap_next_with_adoption(target: *mut Promise, value: f64) {
     if assim.to_bits() != value.to_bits() && js_value_is_promise(assim) != 0 {
         let inner = crate::value::js_nanbox_get_pointer(assim) as *mut Promise;
         if !inner.is_null() && inner != target {
-            js_promise_resolve_with_promise(target, inner);
+            super::assimilate::enqueue_native_adoption_job(target, inner);
             return;
         }
     }

--- a/crates/perry-runtime/src/promise/then.rs
+++ b/crates/perry-runtime/src/promise/then.rs
@@ -1662,7 +1662,22 @@ extern "C" fn finally_passthrough_fulfill(
     let next = js_closure_get_capture_ptr(closure, 0) as *mut Promise;
     let value = js_closure_get_capture_f64(closure, 1);
     if !next.is_null() {
-        js_promise_resolve(next, value);
+        // V8 hop parity: `.finally(cb).then(X)` fires `X` on the FOURTH tick
+        // in Node (hops.js `finally-then`: t0 t1 t2 t3 X) — the spec's
+        // ThenFinally resolves `next` through `promiseResolve(C, cb()).then(
+        // () => value)`, whose then-return propagation costs one more tick
+        // than this passthrough's old direct `js_promise_resolve(next, v)`.
+        // Settle `next` via a propagation task instead.
+        TASK_QUEUE.with(|q| {
+            q.borrow_mut().push_back(Task::AsyncStep(
+                std::ptr::null(),
+                value,
+                next,
+                false,
+                capture_context(),
+            ));
+        });
+        crate::event_pump::js_notify_main_thread();
     }
     f64::from_bits(crate::value::TAG_UNDEFINED)
 }
@@ -1677,7 +1692,17 @@ extern "C" fn finally_passthrough_reject(
     let next = js_closure_get_capture_ptr(closure, 0) as *mut Promise;
     let reason = js_closure_get_capture_f64(closure, 1);
     if !next.is_null() {
-        js_promise_reject(next, reason);
+        // Same extra tick as the fulfilled passthrough (V8 hop parity).
+        TASK_QUEUE.with(|q| {
+            q.borrow_mut().push_back(Task::AsyncStep(
+                std::ptr::null(),
+                reason,
+                next,
+                true,
+                capture_context(),
+            ));
+        });
+        crate::event_pump::js_notify_main_thread();
     }
     f64::from_bits(crate::value::TAG_UNDEFINED)
 }

--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -58,7 +58,7 @@ mod transform;
 mod writable;
 
 pub use tee::js_readable_stream_tee;
-use tee::{tee_branches_of, tee_close_branches, tee_deliver, tee_error_branches, tee_source_of};
+use tee::{tee_branches_of, tee_error_branches, tee_source_of};
 
 pub use self::byob::{
     js_readable_stream_controller_byob_request, js_readable_stream_get_byob_reader,
@@ -704,7 +704,9 @@ pub(super) unsafe fn maybe_pull(stream_id: usize) {
     // `pull_cb` of its own; the source's enqueue fans the chunk out to both
     // branches. `force` so a highWaterMark-0 flight producer actually pulls.
     if let Some(source) = tee_source_of(stream_id) {
-        maybe_pull_force(source);
+        // Tick parity: the pull travels a microtask cycle (buffered chunks +
+        // close discovery included); a live producer is driven from that job.
+        tee::tee_schedule_pull(source);
         return;
     }
     maybe_pull_inner(stream_id, false);
@@ -1512,11 +1514,10 @@ pub unsafe extern "C" fn js_readable_stream_controller_enqueue(
             "The \"buffer\" argument must be an instance of Buffer, TypedArray, or DataView",
         );
     }
-    // #5989: a tee'd source never queues its own chunks — each enqueue fans out
-    // to BOTH branches (delivering to a parked read or queueing per branch).
-    if let Some((a, b)) = tee_branches_of(id) {
-        tee_deliver(a, chunk_bits, is_byte_stream);
-        tee_deliver(b, chunk_bits, is_byte_stream);
+    // #5989 + Node tick parity: a tee'd source's enqueue stays in the SOURCE
+    // queue; branches receive chunks only through the demand-driven pull
+    // cycle (see `tee::tee_source_enqueue`).
+    if tee::tee_source_enqueue(id, chunk, chunk_bits, is_byte_stream) {
         return f64::from_bits(TAG_UNDEFINED);
     }
     // A pending BYOB read (byte streams only) takes the chunk before the
@@ -1577,8 +1578,10 @@ pub unsafe extern "C" fn js_readable_stream_controller_close(stream_handle: f64)
             eprintln!("[STREAM] controller_close stream={id:#x}");
         }
     }
-    // #5989: closing a tee'd source closes both branches (each drains its queue
-    // first) rather than the source's own — absent — reader.
+    // #5989 + Node tick parity: closing a tee'd source marks it Closed; the
+    // branch close is DISCOVERED by the pull cycle draining the source queue
+    // empty (byte tee: prompt; default tee: nextTick-deferred) — never
+    // delivered eagerly ahead of undrained chunks.
     if tee_branches_of(id).is_some() {
         {
             let mut g = READABLE_STREAMS.lock().unwrap();
@@ -1588,7 +1591,7 @@ pub unsafe extern "C" fn js_readable_stream_controller_close(stream_handle: f64)
                 }
             }
         }
-        tee_close_branches(id);
+        tee::tee_schedule_pull(id);
         return f64::from_bits(TAG_UNDEFINED);
     }
     {
@@ -1774,6 +1777,10 @@ pub unsafe extern "C" fn js_reader_read(reader_handle: f64) -> *mut Promise {
             None => Some((TAG_UNDEFINED, true, false)),
         }
     };
+    // Consumer progress: if this readable is a transform's output and its
+    // queue just drained (pop emptied it, or the read parked on an empty
+    // queue), release write promises parked on backpressure.
+    transform::transform_release_writes(stream_id);
     if let Some((reader_id, reason)) = closed_rejection {
         let p = READERS
             .lock()

--- a/crates/perry-stdlib/src/streams/byob.rs
+++ b/crates/perry-stdlib/src/streams/byob.rs
@@ -100,6 +100,16 @@ unsafe fn view_info(view_bits: u64) -> Option<ViewInfo> {
 
 /// `chunk.byteLength` for desiredSize accounting on byte streams; 1.0 for
 /// values whose byte length can't be derived (matches the count fallback).
+/// Clone a byte chunk as a fresh Uint8Array (spec `CloneAsUint8Array`, used by
+/// the byte-stream tee so branches never share a mutable buffer). Non-byte
+/// values pass through unchanged.
+pub(super) unsafe fn clone_byte_chunk(chunk_bits: u64) -> u64 {
+    match read_bytes_from_chunk(chunk_bits) {
+        Some(bytes) => alloc_uint8array_from_bytes(&bytes),
+        None => chunk_bits,
+    }
+}
+
 pub(super) unsafe fn chunk_byte_length(chunk_bits: u64) -> f64 {
     match read_bytes_from_chunk(chunk_bits) {
         Some(bytes) => bytes.len() as f64,
@@ -302,6 +312,10 @@ pub unsafe extern "C" fn js_reader_read_with_view(reader_handle: f64, view: f64)
     }
 
     let filled = fill_view_from_queue(stream_id, &info);
+    // A BYOB drain (or an about-to-park read on an empty queue) is consumer
+    // progress on this readable — release transform writes parked on
+    // backpressure, mirroring the default-reader path in `js_reader_read`.
+    super::transform::transform_release_writes(stream_id);
     if filled > 0 {
         let bytes = std::slice::from_raw_parts(info.data, filled);
         let value = alloc_view_of_kind(info.kind, info.elem_size, bytes);

--- a/crates/perry-stdlib/src/streams/pipe.rs
+++ b/crates/perry-stdlib/src/streams/pipe.rs
@@ -212,7 +212,13 @@ unsafe fn pipe_step(
         return;
     }
     loop {
-        match pipe_next_read(readable_id) {
+        let step = pipe_next_read(readable_id);
+        // Pipe progress on this readable is consumer progress: release
+        // transform writes parked on backpressure (chained
+        // pipeThrough(...).pipeTo(...) drains a transform's readable through
+        // here, never through js_reader_read).
+        super::transform::transform_release_writes(readable_id);
+        match step {
             PipeReadStep::Chunk(chunk) => {
                 pipe_write_then_continue(
                     readable_id,
@@ -296,6 +302,54 @@ unsafe fn reject_pipe(
     js_promise_reject(promise, f64::from_bits(reason));
 }
 
+/// Queue the next pipe cycle directly as a microtask (one tick), mirroring the
+/// pipeTo entry's initial scheduling.
+unsafe fn schedule_pipe_step(
+    readable_id: usize,
+    writable_id: usize,
+    promise: *mut Promise,
+    locks: PipeLockIds,
+    prevent_close: bool,
+) {
+    let closure =
+        perry_runtime::closure::js_closure_alloc(readable_stream_pipe_to_microtask as *const u8, 6);
+    perry_runtime::closure::js_register_closure_arity(
+        readable_stream_pipe_to_microtask as *const u8,
+        0,
+    );
+    perry_runtime::closure::js_closure_set_capture_ptr(
+        closure,
+        0,
+        (readable_id as f64).to_bits() as i64,
+    );
+    perry_runtime::closure::js_closure_set_capture_ptr(
+        closure,
+        1,
+        (writable_id as f64).to_bits() as i64,
+    );
+    perry_runtime::closure::js_closure_set_capture_ptr(
+        closure,
+        2,
+        box_promise(promise).to_bits() as i64,
+    );
+    perry_runtime::closure::js_closure_set_capture_ptr(
+        closure,
+        3,
+        (locks.reader_id as f64).to_bits() as i64,
+    );
+    perry_runtime::closure::js_closure_set_capture_ptr(
+        closure,
+        4,
+        (locks.writer_id as f64).to_bits() as i64,
+    );
+    perry_runtime::closure::js_closure_set_capture_ptr(
+        closure,
+        5,
+        (if prevent_close { 1.0 } else { 0.0f64 }).to_bits() as i64,
+    );
+    perry_runtime::builtins::js_queue_microtask(closure as i64);
+}
+
 unsafe fn pipe_write_then_continue(
     readable_id: usize,
     writable_id: usize,
@@ -305,6 +359,17 @@ unsafe fn pipe_write_then_continue(
     chunk: u64,
 ) {
     let write_promise = writable_stream_write(writable_id, locks.writer_id, f64::from_bits(chunk));
+    // Spec ReadableStreamPipeTo awaits only BACKPRESSURE (writer.ready), not
+    // each write's completion. A sink that accepted the chunk synchronously
+    // (write promise already fulfilled) must not cost an extra reaction tick —
+    // Node's pipe pump runs read→write in lockstep with a racing consumer
+    // (teepipe.js: 1 write/tick; awaiting each write made Perry ~3 ticks/write
+    // and let a tee sibling's reader outrun the pipe — Next.js cold-start
+    // head reorder). Chain on the write promise only while it is pending.
+    if perry_runtime::promise::js_promise_state(write_promise) == 1 {
+        schedule_pipe_step(readable_id, writable_id, promise, locks, prevent_close);
+        return;
+    }
     let fulfilled = pipe_closure(
         readable_stream_pipe_to_write_fulfilled as *const u8,
         readable_id,

--- a/crates/perry-stdlib/src/streams/subclass.rs
+++ b/crates/perry-stdlib/src/streams/subclass.rs
@@ -412,6 +412,8 @@ pub fn drain_readable_into_bytes(stream_id: usize) -> Vec<u8> {
                 None => break,
             }
         };
+        // Consumer progress: release transform writes parked on backpressure.
+        unsafe { super::transform::transform_release_writes(stream_id) };
         let mut got_chunk = false;
         for chunk in chunks {
             unsafe {

--- a/crates/perry-stdlib/src/streams/tee.rs
+++ b/crates/perry-stdlib/src/streams/tee.rs
@@ -12,8 +12,9 @@ use super::{
     throw_type_error, ReadableState, ReadableStreamData, NEXT_STREAM_ID, READABLE_STREAMS,
 };
 use perry_runtime::array::{js_array_alloc, js_array_push};
+use perry_runtime::closure::ClosureHeader;
 use perry_runtime::value::JSValue;
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Mutex;
 
 lazy_static::lazy_static! {
@@ -22,6 +23,8 @@ lazy_static::lazy_static! {
     static ref TEE_SOURCE_BRANCHES: Mutex<HashMap<usize, (usize, usize)>> = Mutex::new(HashMap::new());
     /// Branch id -> its source (so a branch read pulls the source).
     static ref TEE_BRANCH_SOURCE: Mutex<HashMap<usize, usize>> = Mutex::new(HashMap::new());
+    /// Tee sources with a pull job already queued (one job per source at a time).
+    static ref TEE_PULLING: Mutex<HashSet<usize>> = Mutex::new(HashSet::new());
 }
 
 /// Sentinel `reader_handle` stamped on a tee'd source so it can't be read
@@ -41,6 +44,11 @@ pub(super) fn tee_source_of(branch: usize) -> Option<usize> {
 /// waiting, else queue it. Mirrors the default-reader path of
 /// `js_readable_stream_controller_enqueue`.
 pub(super) unsafe fn tee_deliver(branch: usize, chunk_bits: u64, is_byte: bool) {
+    // A parked BYOB read takes the bytes directly (mirrors the
+    // default-reader-vs-BYOB order in `js_readable_stream_controller_enqueue`).
+    if is_byte && byob::service_pending_with_chunk(branch, chunk_bits) {
+        return;
+    }
     let popped = {
         let mut g = READABLE_STREAMS.lock().unwrap();
         match g.get_mut(&branch) {
@@ -64,6 +72,21 @@ pub(super) unsafe fn tee_deliver(branch: usize, chunk_bits: u64, is_byte: bool) 
         let result = build_iter_result(chunk_bits, false);
         js_promise_resolve(p, f64::from_bits(result));
     }
+}
+
+/// A branch has live read demand: a parked default read OR a parked BYOB read.
+unsafe fn tee_branch_demand(a: usize, b: usize) -> bool {
+    {
+        let g = READABLE_STREAMS.lock().unwrap();
+        if [a, b].iter().any(|id| {
+            g.get(id)
+                .map(|s| !s.pending_reads.is_empty())
+                .unwrap_or(false)
+        }) {
+            return true;
+        }
+    }
+    byob::has_pending(a) || byob::has_pending(b)
 }
 
 /// The tee'd source closed — close both branches (each drains its queue first,
@@ -119,6 +142,192 @@ fn tee_unlink(source: usize, a: usize, b: usize) {
     bs.remove(&b);
 }
 
+/// Enqueue on a tee'd SOURCE: the chunk stays in the source queue (spec size
+/// accounting included) and branches receive it only through the demand-driven
+/// pull cycle. The old eager fan-out pre-filled both branch queues at
+/// producer-flush time, so consumer reads resolved at attach with zero pull
+/// ticks — reordering promise chains racing the stream (Next.js cold-start
+/// head reorder). Returns false when the stream is not a tee source.
+pub(super) unsafe fn tee_source_enqueue(
+    id: usize,
+    chunk: f64,
+    chunk_bits: u64,
+    is_byte_stream: bool,
+) -> bool {
+    if tee_branches_of(id).is_none() {
+        return false;
+    }
+    // Per spec the strategy's size(chunk) runs once at enqueue time (same
+    // accounting as the non-tee enqueue path).
+    let size_cb = {
+        let g = READABLE_STREAMS.lock().unwrap();
+        g.get(&id).map(|s| s.strategy_size_cb).unwrap_or(0)
+    };
+    let size = if size_cb != 0 {
+        let size = super::readable_strategy_size_to_number(
+            perry_runtime::closure::js_closure_call1(size_cb as *const ClosureHeader, chunk),
+        );
+        if size.is_nan() || size < 0.0 || size.is_infinite() {
+            super::throw_invalid_readable_strategy_size(id, size);
+        }
+        size
+    } else if is_byte_stream {
+        byob::chunk_byte_length(chunk_bits)
+    } else {
+        1.0
+    };
+    {
+        let mut g = READABLE_STREAMS.lock().unwrap();
+        if let Some(s) = g.get_mut(&id) {
+            if s.state == ReadableState::Readable {
+                s.push_chunk(chunk_bits, size);
+            }
+        }
+    }
+    tee_schedule_pull(id);
+    true
+}
+
+/// Schedule ONE tee pull cycle as a microtask job. Spec/Node tick parity
+/// (streamhops.js): every chunk — including chunks already buffered in the
+/// source at `tee()` time — travels `sourceReader.read().then(fanout)`, a real
+/// promise-reaction cycle, before a branch read resolves. The old shape
+/// (branch queues pre-filled at tee() time / synchronous source pops) resolved
+/// branch reads a tick early and delivered `done` immediately after the last
+/// chunk, which reordered promise chains racing the stream (Next.js cold-start
+/// head reorder: the flight read loop overtook the module-dep unblock chain).
+pub(super) unsafe fn tee_schedule_pull(source: usize) {
+    if !TEE_PULLING.lock().unwrap().insert(source) {
+        return;
+    }
+    let f = tee_pull_microtask as *const u8;
+    perry_runtime::closure::js_register_closure_arity(f, 0);
+    let job = perry_runtime::closure::js_closure_alloc(f, 1);
+    perry_runtime::closure::js_closure_set_capture_ptr(job, 0, source as i64);
+    perry_runtime::builtins::js_queue_microtask(job as i64);
+}
+
+/// The extra tick a byte-stream tee's CHAINED pull pays before the next
+/// cycle (see the chain decision in `tee_pull_microtask`).
+extern "C" fn tee_byte_chain_hop(closure: *const ClosureHeader) -> f64 {
+    unsafe {
+        let source = perry_runtime::closure::js_closure_get_capture_ptr(closure, 0) as usize;
+        tee_schedule_pull(source);
+    }
+    f64::from_bits(0x7FFC_0000_0000_0001) // TAG_UNDEFINED
+}
+
+extern "C" fn tee_close_tick(closure: *const ClosureHeader) -> f64 {
+    unsafe {
+        let source = perry_runtime::closure::js_closure_get_capture_ptr(closure, 0) as usize;
+        tee_close_branches(source);
+    }
+    f64::from_bits(0x7FFC_0000_0000_0001) // TAG_UNDEFINED
+}
+
+extern "C" fn tee_pull_microtask(closure: *const ClosureHeader) -> f64 {
+    let undef = f64::from_bits(0x7FFC_0000_0000_0001); // TAG_UNDEFINED
+    unsafe {
+        let source = perry_runtime::closure::js_closure_get_capture_ptr(closure, 0) as usize;
+        TEE_PULLING.lock().unwrap().remove(&source);
+        let Some((a, b)) = tee_branches_of(source) else {
+            return undef;
+        };
+        // Deliver ONLY when a branch actually has a parked read: a consumer
+        // busy with synchronous work between reads must find its next read
+        // PENDING at attach (paying the pull cycle, like Node) — never a
+        // pre-filled queue. A fast consumer parks before the next cycle runs,
+        // keeping Node's one-chunk-per-tick cadence.
+        if !tee_branch_demand(a, b) {
+            return undef;
+        }
+        // Pop ONE chunk per cycle — per-chunk reaction cadence, like the
+        // spec's per-read pull loop.
+        let (chunk, closed, live_pull, is_byte) = {
+            let mut g = READABLE_STREAMS.lock().unwrap();
+            match g.get_mut(&source) {
+                Some(s) => (
+                    s.pop_chunk(),
+                    s.state == ReadableState::Closed,
+                    s.pull_cb != 0,
+                    s.is_byte_stream,
+                ),
+                None => (None, true, false, false),
+            }
+        };
+        match chunk {
+            Some(bits) => {
+                // Spec order: branch-a sees the chunk before branch-b,
+                // regardless of which branch's read triggered the pull.
+                // Byte tees clone the chunk for branch-b (CloneAsUint8Array)
+                // so the two branches never share a mutable buffer.
+                let b_bits = if is_byte {
+                    byob::clone_byte_chunk(bits)
+                } else {
+                    bits
+                };
+                tee_deliver(a, bits, is_byte);
+                tee_deliver(b, b_bits, is_byte);
+                // Chain the next cycle while the source has backlog or a
+                // pending close; the demand gate at the cycle's entry keeps
+                // pre-fill from ever happening.
+                let more = {
+                    let source_backlog = {
+                        let g = READABLE_STREAMS.lock().unwrap();
+                        g.get(&source)
+                            .map(|s| !s.chunks.is_empty() || s.state == ReadableState::Closed)
+                            .unwrap_or(false)
+                    };
+                    tee_branch_demand(a, b) || source_backlog
+                };
+                if more {
+                    if is_byte {
+                        // Byte-stream tee (bytetee.js): Node's CHAINED pulls
+                        // pay one extra tick per cycle (the byte path's
+                        // clone/view hop); the first demand pull does not.
+                        // Each extra hop cedes a task-generation to racing
+                        // promise cascades (the Next.js module-require chain
+                        // must win that race).
+                        let f = tee_byte_chain_hop as *const u8;
+                        perry_runtime::closure::js_register_closure_arity(f, 0);
+                        let job = perry_runtime::closure::js_closure_alloc(f, 1);
+                        perry_runtime::closure::js_closure_set_capture_ptr(job, 0, source as i64);
+                        perry_runtime::builtins::js_queue_microtask(job as i64);
+                    } else {
+                        tee_schedule_pull(source);
+                    }
+                }
+            }
+            None if closed => {
+                if is_byte {
+                    // Byte-stream tee: Node closes the branches PROMPTLY
+                    // (bytetee.js: done right after the last chunk), unlike
+                    // the default-stream tee below.
+                    tee_close_branches(source);
+                    return undef;
+                }
+                // Node tick parity: the DEFAULT tee branch close lands only
+                // after ALL currently-pending promise microtasks (teedone.js:
+                // DONE scales with metronome length — t5/t11/t19 for
+                // 6/12/20-tick chains), i.e. it travels the nextTick queue,
+                // which runs when the microtask queue exhausts. A plain
+                // (non-tee) stream's close stays prompt. Defer via nextTick.
+                let f = tee_close_tick as *const u8;
+                perry_runtime::closure::js_register_closure_arity(f, 0);
+                let job = perry_runtime::closure::js_closure_alloc(f, 1);
+                perry_runtime::closure::js_closure_set_capture_ptr(job, 0, source as i64);
+                perry_runtime::builtins::js_queue_next_tick(job as i64);
+            }
+            None => {
+                if live_pull {
+                    super::maybe_pull_force(source);
+                }
+            }
+        }
+    }
+    undef
+}
+
 /// `readable.tee()` — Web Streams `ReadableStreamTee`. The source stays LIVE and
 /// is pulled lazily by reads on the two returned branches: a branch read with an
 /// empty queue pulls the source (`maybe_pull` routes tee-branch pulls to the
@@ -132,35 +341,46 @@ pub unsafe extern "C" fn js_readable_stream_tee(stream_handle: f64) -> f64 {
     let mut was_locked = false;
     let mut is_byte_stream = false;
     let mut source_state = ReadableState::Readable;
-    let existing: Vec<u64> = {
+    {
         let mut g = READABLE_STREAMS.lock().unwrap();
         match g.get_mut(&id) {
             Some(s) if s.reader_handle.is_none() => {
                 is_byte_stream = s.is_byte_stream;
                 source_state = s.state;
-                let drained = s.drain_chunks();
                 // Keep the source LIVE — lock it against direct reads but leave
-                // its state + pull_cb intact so branch reads can drive it.
+                // its state + queue + pull_cb intact so branch reads can drive
+                // it. Buffered chunks are NOT copied into the branches: each
+                // travels a tee pull cycle (see `tee_schedule_pull`) so branch
+                // reads resolve with Node's tick cadence.
                 s.reader_handle = Some(TEE_LOCK_SENTINEL);
-                drained
             }
             Some(_) => {
                 was_locked = true;
-                Vec::new()
             }
-            None => Vec::new(),
+            None => {}
         }
     };
     if was_locked {
         throw_type_error("ReadableStream is locked");
     }
 
-    // A branch mirrors the source's terminal state; a live source yields live
-    // branches whose future chunks arrive by fan-out.
+    // Only an errored source yields terminal branches immediately. A CLOSED
+    // source still has its buffered chunks delivered through pull cycles; the
+    // close is discovered by the pull that finds the queue empty.
     let branch_state = match source_state {
         ReadableState::Errored => ReadableState::Errored,
-        ReadableState::Closed => ReadableState::Closed,
         _ => ReadableState::Readable,
+    };
+    // An errored source's branches must carry its rejection reason.
+    let branch_error_value = if branch_state == ReadableState::Errored {
+        READABLE_STREAMS
+            .lock()
+            .unwrap()
+            .get(&id)
+            .map(|s| s.error_value)
+            .unwrap_or(0)
+    } else {
+        0
     };
     let id_a = next_id(&NEXT_STREAM_ID);
     let id_b = next_id(&NEXT_STREAM_ID);
@@ -171,9 +391,9 @@ pub unsafe extern "C" fn js_readable_stream_tee(stream_handle: f64) -> f64 {
                 new_id,
                 ReadableStreamData {
                     state: branch_state,
-                    chunks: existing.iter().copied().collect(),
-                    chunk_sizes: existing.iter().map(|_| 1.0).collect(),
-                    queue_total_size: existing.len() as f64,
+                    chunks: VecDeque::new(),
+                    chunk_sizes: VecDeque::new(),
+                    queue_total_size: 0.0,
                     pending_reads: VecDeque::new(),
                     start_cb: 0,
                     // No own pull_cb: a branch read pulls the SOURCE via the tee
@@ -188,7 +408,7 @@ pub unsafe extern "C" fn js_readable_stream_tee(stream_handle: f64) -> f64 {
                     pulling: false,
                     started: true,
                     reader_handle: None,
-                    error_value: 0,
+                    error_value: branch_error_value,
                     pending_error_after_chunks: None,
                     canceled: false,
                 },

--- a/crates/perry-stdlib/src/streams/transform.rs
+++ b/crates/perry-stdlib/src/streams/transform.rs
@@ -236,18 +236,195 @@ pub(super) unsafe fn transform_write(writable_id: usize, chunk: f64) -> *mut Pro
         js_promise_resolve(promise, f64::from_bits(TAG_UNDEFINED));
         return promise;
     }
-    if transform_cb != 0 && readable_id != 0 {
-        js_closure_call2(
-            transform_cb as *const ClosureHeader,
-            chunk,
-            readable_id as f64,
-        );
-    } else {
-        // Identity transform — pass-through.
-        js_readable_stream_controller_enqueue(readable_id as f64, chunk);
-    }
-    js_promise_resolve(promise, f64::from_bits(TAG_UNDEFINED));
+    // Spec/Node tick parity: the transformer's `transform()` runs as a promise
+    // JOB (TransformStreamDefaultSinkWriteAlgorithm chains PerformTransform),
+    // never synchronously inside `writer.write()`. Running it inline made the
+    // transform side of a piped tee one tick per chunk — faster than Node's
+    // cadence (teepipe2.js) — which let a tee sibling's reader outrun the
+    // pipeline (Next.js cold-start head reorder). Queue the invocation; the
+    // write promise resolves in the job, after the transform enqueues.
+    let job_fn = transform_write_job as *const u8;
+    perry_runtime::closure::js_register_closure_arity(job_fn, 0);
+    let job = perry_runtime::closure::js_closure_alloc(job_fn, 4);
+    perry_runtime::closure::js_closure_set_capture_ptr(job, 0, transform_cb);
+    perry_runtime::closure::js_closure_set_capture_ptr(job, 1, readable_id as i64);
+    perry_runtime::closure::js_closure_set_capture_ptr(job, 2, chunk.to_bits() as i64);
+    perry_runtime::closure::js_closure_set_capture_ptr(job, 3, promise as i64);
+    perry_runtime::builtins::js_queue_microtask(job as i64);
     promise
+}
+
+/// First hop: the sink write algorithm job. Node's write path costs two jobs
+/// before the transformer runs (sink write algorithm → PerformTransform);
+/// teepipe2.js shows the transform output landing one tick later than a
+/// single-job deferral produces. Re-queue once, then run the transform.
+extern "C" fn transform_write_job(closure: *const ClosureHeader) -> f64 {
+    unsafe {
+        let job_fn = transform_write_job2 as *const u8;
+        perry_runtime::closure::js_register_closure_arity(job_fn, 0);
+        let job = perry_runtime::closure::js_closure_alloc(job_fn, 4);
+        for i in 0..4 {
+            perry_runtime::closure::js_closure_set_capture_ptr(
+                job,
+                i,
+                perry_runtime::closure::js_closure_get_capture_ptr(closure, i),
+            );
+        }
+        perry_runtime::builtins::js_queue_microtask(job as i64);
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+extern "C" fn transform_write_job2(closure: *const ClosureHeader) -> f64 {
+    unsafe {
+        let transform_cb = perry_runtime::closure::js_closure_get_capture_ptr(closure, 0);
+        let readable_id = perry_runtime::closure::js_closure_get_capture_ptr(closure, 1) as usize;
+        let chunk_bits = perry_runtime::closure::js_closure_get_capture_ptr(closure, 2) as u64;
+        let promise =
+            perry_runtime::closure::js_closure_get_capture_ptr(closure, 3) as *mut Promise;
+        let chunk = f64::from_bits(chunk_bits);
+        if transform_cb != 0 && readable_id != 0 {
+            let ret = js_closure_call2(
+                transform_cb as *const ClosureHeader,
+                chunk,
+                readable_id as f64,
+            );
+            // Spec PerformTransform: `Promise.resolve(transformer.transform(
+            // chunk, controller))` — an async transform's returned promise
+            // gates the write's settlement. Next's buffered transform returns
+            // a setImmediate-deferred flush promise; ignoring it let Perry's
+            // pipe run a macrotask ahead of Node per write.
+            if perry_runtime::promise::js_value_is_promise(ret) != 0 {
+                let inner = perry_runtime::value::js_nanbox_get_pointer(ret) as *mut Promise;
+                if !inner.is_null() {
+                    let f = transform_write_settle_fulfilled as *const u8;
+                    let r = transform_write_settle_rejected as *const u8;
+                    perry_runtime::closure::js_register_closure_arity(f, 1);
+                    perry_runtime::closure::js_register_closure_arity(r, 1);
+                    let fc = perry_runtime::closure::js_closure_alloc(f, 2);
+                    perry_runtime::closure::js_closure_set_capture_ptr(fc, 0, readable_id as i64);
+                    perry_runtime::closure::js_closure_set_capture_ptr(fc, 1, promise as i64);
+                    let rc = perry_runtime::closure::js_closure_alloc(r, 2);
+                    perry_runtime::closure::js_closure_set_capture_ptr(rc, 0, readable_id as i64);
+                    perry_runtime::closure::js_closure_set_capture_ptr(rc, 1, promise as i64);
+                    let _ = perry_runtime::promise::js_promise_then(inner, fc, rc);
+                    return f64::from_bits(TAG_UNDEFINED);
+                }
+            }
+        } else if readable_id != 0 {
+            // Identity transform — pass-through.
+            js_readable_stream_controller_enqueue(readable_id as f64, chunk);
+        }
+        // Spec backpressure (TransformStreamDefaultSinkWriteAlgorithm): the
+        // readable side's default highWaterMark is 0, so any chunk sitting
+        // undrained in its queue keeps backpressure ON and the write promise
+        // PENDING until the consumer catches up (a read pops the queue empty
+        // or parks on it). Resolving unconditionally let a `pipeTo` upstream
+        // keep pulling at full speed — in a teed pipeline the fast pipe
+        // pre-filled the sibling branch's queue and reordered promise chains
+        // racing the stream (Next.js cold-start head reorder: node's pipe is
+        // stalled here, so the flight branch's read #3 stays pending while
+        // the module-require chain finishes).
+        settle_transform_write(readable_id, promise);
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+/// Settle a transform write with spec semantics: reject when the readable
+/// side has errored (the TransformStream is errored — writes must not report
+/// success), park on backpressure while undrained chunks remain, else resolve.
+unsafe fn settle_transform_write(readable_id: usize, promise: *mut Promise) {
+    enum Settle {
+        Errored(u64),
+        Park,
+        Resolve,
+    }
+    let settle = {
+        let g = super::READABLE_STREAMS.lock().unwrap();
+        match g.get(&readable_id) {
+            Some(s) if s.state == ReadableState::Errored => Settle::Errored(s.error_value),
+            Some(s) if !s.chunks.is_empty() => Settle::Park,
+            _ => Settle::Resolve,
+        }
+    };
+    match settle {
+        Settle::Errored(reason) => js_promise_reject(promise, f64::from_bits(reason)),
+        Settle::Park => {
+            TRANSFORM_WRITE_RELEASES
+                .lock()
+                .unwrap()
+                .entry(readable_id)
+                .or_default()
+                .push(promise as usize);
+        }
+        Settle::Resolve => js_promise_resolve(promise, f64::from_bits(TAG_UNDEFINED)),
+    }
+}
+
+lazy_static::lazy_static! {
+    /// Transform readable id -> write promises parked on backpressure, released
+    /// when the consumer drains the readable (see `transform_release_writes`).
+    pub(super) static ref TRANSFORM_WRITE_RELEASES: Mutex<HashMap<usize, Vec<usize>>> =
+        Mutex::new(HashMap::new());
+}
+
+/// The async transformer's returned promise fulfilled — settle the write with
+/// the same backpressure gate as the synchronous path.
+extern "C" fn transform_write_settle_fulfilled(closure: *const ClosureHeader, _value: f64) -> f64 {
+    unsafe {
+        let readable_id = perry_runtime::closure::js_closure_get_capture_ptr(closure, 0) as usize;
+        let promise =
+            perry_runtime::closure::js_closure_get_capture_ptr(closure, 1) as *mut Promise;
+        settle_transform_write(readable_id, promise);
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+/// The async transformer's returned promise rejected — error the readable side
+/// and reject the write (spec: transformResultPromise rejection errors the
+/// TransformStream).
+extern "C" fn transform_write_settle_rejected(closure: *const ClosureHeader, reason: f64) -> f64 {
+    unsafe {
+        let readable_id = perry_runtime::closure::js_closure_get_capture_ptr(closure, 0) as usize;
+        let promise =
+            perry_runtime::closure::js_closure_get_capture_ptr(closure, 1) as *mut Promise;
+        if readable_id != 0 {
+            js_readable_stream_controller_error(readable_id as f64, reason);
+        }
+        js_promise_reject(promise, reason);
+    }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+/// Consumer progress on a transform's readable side: release parked write
+/// promises once its queue has drained (spec: the source pull algorithm sets
+/// backpressure = false). Called from the reader-read paths in `streams.rs`.
+pub(super) unsafe fn transform_release_writes(readable_id: usize) {
+    let (drained, errored) = {
+        let g = super::READABLE_STREAMS.lock().unwrap();
+        match g.get(&readable_id) {
+            Some(s) => (
+                s.chunks.is_empty(),
+                (s.state == ReadableState::Errored).then_some(s.error_value),
+            ),
+            None => (true, None),
+        }
+    };
+    if !drained && errored.is_none() {
+        return;
+    }
+    let parked = TRANSFORM_WRITE_RELEASES
+        .lock()
+        .unwrap()
+        .remove(&readable_id);
+    if let Some(promises) = parked {
+        for p in promises {
+            match errored {
+                Some(reason) => js_promise_reject(p as *mut Promise, f64::from_bits(reason)),
+                None => js_promise_resolve(p as *mut Promise, f64::from_bits(TAG_UNDEFINED)),
+            }
+        }
+    }
 }
 
 pub(super) unsafe fn transform_close(writable_id: usize) -> *mut Promise {

--- a/crates/perry-stdlib/src/streams/writable.rs
+++ b/crates/perry-stdlib/src/streams/writable.rs
@@ -585,23 +585,15 @@ pub(super) unsafe fn writable_stream_write(
         install_writable_backpressure_ready(stream_id, writer_id);
     }
     if let Some((cb, chunk, write_promise)) = start_write {
-        let start_fn = writable_write_start_microtask as *const u8;
-        perry_runtime::closure::js_register_closure_arity(start_fn, 0);
-        let start = perry_runtime::closure::js_closure_alloc(start_fn, 5);
-        perry_runtime::closure::js_closure_set_capture_ptr(
-            start,
-            0,
-            (stream_id as f64).to_bits() as i64,
-        );
-        perry_runtime::closure::js_closure_set_capture_ptr(
-            start,
-            1,
-            (writer_id as f64).to_bits() as i64,
-        );
-        perry_runtime::closure::js_closure_set_capture_ptr(start, 2, cb);
-        perry_runtime::closure::js_closure_set_capture_ptr(start, 3, chunk.to_bits() as i64);
-        perry_runtime::closure::js_closure_set_capture_ptr(start, 4, write_promise as i64);
-        perry_runtime::builtins::js_queue_microtask(start as i64);
+        // Spec/Node tick parity: with no write in flight, `writer.write(chunk)`
+        // invokes the sink's `write()` SYNCHRONOUSLY in the same job
+        // (WritableStreamDefaultControllerProcessWrite) — deferring it through
+        // a microtask cost one tick per write, which let a tee sibling's
+        // reader outrun a pipeTo pump (teepipe.js; Next.js cold-start head
+        // reorder). All registry locks are released above; `run_writable_write`
+        // re-enters the FFI safely (it is the same body the queued microtask
+        // ran).
+        run_writable_write(stream_id, writer_id, cb, chunk, write_promise);
     }
     promise
 }

--- a/test-files/test_gap_promise_tick_parity.ts
+++ b/test-files/test_gap_promise_tick_parity.ts
@@ -1,0 +1,60 @@
+// Microtask hop-count harness: a metronome chain logs tick0..tickN while each
+// promise shape under test logs its settlement. The tick number that appears
+// immediately before the shape's log = its hop count. Any node-vs-perry
+// difference in ANY shape = an ordering divergence.
+function run(label, arm) {
+  return new Promise((done) => {
+    const order = [];
+    let p = Promise.resolve();
+    for (let i = 0; i < 8; i++) {
+      const n = i;
+      p = p.then(() => { order.push("t" + n); });
+    }
+    const metroDone = p;
+    arm(() => order.push("X"));
+    // Deterministic: the metronome outlives every shape's cascade; snapshot
+    // after it completes + one macrotask backstop.
+    metroDone.then(() => setTimeout(() => { done(label.padEnd(34) + order.join(" ")); }, 0));
+  });
+}
+
+(async () => {
+  const out = [];
+  out.push(await run("then-on-resolved", (X) => {
+    Promise.resolve(1).then(X);
+  }));
+  out.push(await run("asyncfn-return-value", (X) => {
+    (async () => 1)().then(X);
+  }));
+  out.push(await run("asyncfn-return-resolved-promise", (X) => {
+    (async () => Promise.resolve(1))().then(X);
+  }));
+  out.push(await run("executor-resolve-with-promise", (X) => {
+    new Promise((res) => res(Promise.resolve(1))).then(X);
+  }));
+  out.push(await run("promise-all-2-resolved", (X) => {
+    Promise.all([Promise.resolve(1), Promise.resolve(2)]).then(X);
+  }));
+  out.push(await run("promise-all-then-chain", (X) => {
+    Promise.all([Promise.resolve(1), Promise.resolve(2)]).then(() => 1).then(X);
+  }));
+  out.push(await run("finally-then", (X) => {
+    Promise.resolve(1).finally(() => {}).then(X);
+  }));
+  out.push(await run("finally-orig-then", (X) => {
+    const r = Promise.resolve(1);
+    r.finally(() => {});
+    r.then(X);
+  }));
+  out.push(await run("await-then (async wrapper)", (X) => {
+    (async () => { await Promise.resolve(1); })().then(X);
+  }));
+  out.push(await run("thenable-assimilation", (X) => {
+    new Promise((res) => res({ then(r) { r(1); } })).then(X);
+  }));
+  out.push(await run("all-of-asyncfn-results", (X) => {
+    const f = async () => 1;
+    Promise.all([f(), f()]).then(X);
+  }));
+  console.log(out.join("\n"));
+})();

--- a/test-files/test_gap_promise_tick_parity2.ts
+++ b/test-files/test_gap_promise_tick_parity2.ts
@@ -1,0 +1,44 @@
+// Extended hop shapes: the ones the app's module chain actually uses that
+// hops.js round 1 did NOT cover. Any node/perry difference = the third leg.
+function run(label, arm) {
+  return new Promise((done) => {
+    const order = [];
+    let p = Promise.resolve();
+    for (let i = 0; i < 10; i++) { const n = i; p = p.then(() => order.push("t" + n)); }
+    const metroDone = p;
+    arm((tag) => order.push(tag));
+    metroDone.then(() => setTimeout(() => { done(label.padEnd(30) + order.join(" ")); }, 0));
+  });
+}
+const later = () => { let r; const p = new Promise((res) => { r = res; }); Promise.resolve().then(() => r(1)); return p; };
+
+(async () => {
+  const out = [];
+  out.push(await run("all-of-pending", (X) => {
+    Promise.all([later(), later()]).then(() => X("X"));
+  }));
+  out.push(await run("finally-on-pending", (X) => {
+    later().finally(() => {}).then(() => X("X"));
+  }));
+  out.push(await run("finally-orig-pending", (X) => {
+    const r = later(); r.finally(() => {}); r.then(() => X("X"));
+  }));
+  out.push(await run("two-thens-same-promise", (X) => {
+    const p = Promise.resolve(1);
+    p.then(() => X("A")); p.then(() => X("B"));
+  }));
+  out.push(await run("two-thens-pending", (X) => {
+    const p = later();
+    p.then(() => X("A")); p.then(() => X("B"));
+  }));
+  out.push(await run("then-bound", (X) => {
+    const s = new Set(); const p = Promise.resolve(7);
+    p.then(s.add.bind(s, p), () => {}); p.then(() => X("X"));
+  }));
+  out.push(await run("all-then-require-chain", (X) => {
+    // d()'s exact tail: Promise.all(r).then(() => sync()) feeding a dep .then
+    const dep = Promise.all([later(), later()]).then(() => 42);
+    dep.then(() => X("X"));
+  }));
+  console.log(out.join("\n"));
+})();

--- a/test-files/test_gap_stream_async_transform_tick_parity.ts
+++ b/test-files/test_gap_stream_async_transform_tick_parity.ts
@@ -1,0 +1,23 @@
+function metro(order, n) { let p = Promise.resolve(); for (let i = 0; i < n; i++) { const k = i; p = p.then(() => order.push("t" + k)); } }
+(async () => {
+  const order = [];
+  const enc = new TextEncoder();
+  const src = new ReadableStream({ start(c) { c.enqueue(enc.encode("aa")); c.enqueue(enc.encode("bb")); c.close(); } });
+  let buf = [];
+  const ts = new TransformStream({
+    transform(ch, ctrl) {
+      buf.push(ch);
+      return new Promise((res) => setImmediate(() => { for (const b of buf) ctrl.enqueue(b); buf = []; res(); }));
+    },
+  });
+  const out = src.pipeThrough(ts);
+  metro(order, 10);
+  const ro = out.getReader();
+  const aDone = new Promise((fin) => {
+    (function pumpA({ done, value } = {}) { if (done) { order.push("adone"); fin(); return; } if (value) order.push("w" + new TextDecoder().decode(value)); return ro.read().then(pumpA); })();
+  });
+  // Deterministic completion: the pump saw done + one macrotask backstop.
+  await aDone;
+  await new Promise((res) => setTimeout(res, 0));
+  console.log("asynctf  " + order.join(" "));
+})();

--- a/test-files/test_gap_stream_livetee_tick_parity.ts
+++ b/test-files/test_gap_stream_livetee_tick_parity.ts
@@ -1,0 +1,24 @@
+// LIVE tee: producer enqueues AFTER tee() (like the RSC flush) — chunks must
+// travel the demand-pull cycle, never eagerly pre-fill branch queues.
+function metro(order, n) { let p = Promise.resolve(); for (let i = 0; i < n; i++) { const k = i; p = p.then(() => order.push("t" + k)); } }
+(async () => {
+  const order = [];
+  const enc = new TextEncoder();
+  let ctrl;
+  const src = new ReadableStream({ type: "bytes", start(c) { ctrl = c; } });
+  const [a, b] = src.tee();
+  metro(order, 14);
+  setImmediate(() => { ctrl.enqueue(enc.encode("aa")); ctrl.enqueue(enc.encode("bb")); ctrl.close(); order.push("FLUSHED"); });
+  const ra = a.getReader();
+  const aDone = new Promise((fin) => {
+    (function pa({ done, value } = {}) { if (done) { order.push("Adone"); fin(); return; } if (value) order.push("x" + new TextDecoder().decode(value)); return ra.read().then(pa); })();
+  });
+  const rb = b.getReader();
+  const bDone = new Promise((fin) => {
+    (function pb({ done, value } = {}) { if (done) { order.push("Bdone"); fin(); return; } if (value) order.push("r" + new TextDecoder().decode(value)); return rb.read().then(pb); })();
+  });
+  // Deterministic completion: both pumps saw done + one macrotask backstop.
+  await aDone; await bDone;
+  await new Promise((res) => setTimeout(res, 0));
+  console.log("livetee  " + order.join(" "));
+})();

--- a/test-files/test_gap_stream_tee_tick_parity.ts
+++ b/test-files/test_gap_stream_tee_tick_parity.ts
@@ -1,0 +1,50 @@
+// Web Streams hop harness: a source stream with 3 chunks already written and
+// closed (like the completed RSC output), teed; branch-2's chained read loop
+// (like the flight pump) races a metronome chain. The tick at which each read
+// callback fires must match node exactly — any divergence reorders the app.
+function metro(order, n) {
+  let p = Promise.resolve();
+  for (let i = 0; i < n; i++) { const k = i; p = p.then(() => order.push("t" + k)); }
+}
+
+async function scenario(label, useTee) {
+  const order = [];
+  const enc = new TextEncoder();
+  const src = new ReadableStream({
+    start(c) { c.enqueue(enc.encode("aa")); c.enqueue(enc.encode("bb")); c.enqueue(enc.encode("cc")); c.close(); },
+  });
+  let stream = src;
+  let other = null;
+  if (useTee) { const [a, b] = src.tee(); other = a; stream = b; }
+  const metroDone = (function metro2(n) { let p = Promise.resolve(); for (let i = 0; i < n; i++) { const k = i; p = p.then(() => order.push("t" + k)); } return p; })(12);
+  const dones = [];
+  const reader = stream.getReader();
+  dones.push(new Promise((fin) => {
+    (function pump({ done, value } = {}) {
+      if (done) { order.push("DONE"); fin(); return; }
+      if (value) order.push("r" + new TextDecoder().decode(value));
+      return reader.read().then(pump);
+    })({ done: false });
+  }));
+  // drain the other branch too (the app reads both tee branches)
+  if (other) {
+    const r2 = other.getReader();
+    dones.push(new Promise((fin) => {
+      (function pump2({ done, value } = {}) {
+        if (done) { order.push("done2"); fin(); return; }
+        if (value) order.push("x" + new TextDecoder().decode(value));
+        return r2.read().then(pump2);
+      })({ done: false });
+    }));
+  }
+  // Deterministic completion: all pumps finished + metronome drained + one
+  // macrotask so trailing nextTick-deferred events (tee close) land.
+  await Promise.all(dones); await metroDone;
+  await new Promise((res) => setTimeout(res, 0));
+  console.log(label.padEnd(12) + order.join(" "));
+}
+
+(async () => {
+  await scenario("plain", false);
+  await scenario("tee", true);
+})();


### PR DESCRIPTION
## Summary

Perry settled promises and delivered Web-Streams data in **fewer microtask ticks than V8/Node** across several spec shapes, so two promise chains racing each other could interleave differently than under Node. Observable end-to-end symptom: on the **first request** of a compiled Next.js standalone server, React Fizz emitted `<meta name="next-size-adjust">` after `<title>` instead of before (the flight module-require chain lost a one-slot race against the RSC stream read loop that it wins under Node; warm requests were correct). This PR makes the relevant promise-resolution and stream-delivery tick counts Node-exact.

## Promise layer (perry-runtime)

- Resolving a promise **with a native promise** now runs a `PromiseResolveThenableJob`-equivalent adoption job (settled inner ⇒ job + propagation task = 2 ticks, V8-exact) instead of a synchronous copy — in `promise_resolve_assimilating`'s intrinsic-`then` arm and the async-step return paths.
- `async fn` returning a promise returns a **fresh** promise that adopts the inner (2 ticks); the `Promise.resolve(p) === p` identity does not apply to async returns. New `js_async_fn_result` codegen entry covers await-less async fns (they bypass the step machinery entirely).
- `.finally()` passthrough settles its chained promise via a propagation task (+1 tick), matching Node's `ThenFinally` shape.

## Web Streams (perry-stdlib)

- **`tee()`**: branches are never pre-filled — buffered *and* live-enqueued source chunks travel a demand-gated pull job (one chunk per reaction cycle, branch-a before branch-b). The old eager fan-out delivered chunks at producer-flush time, so consumer reads resolved at attach with zero pull ticks. Demand includes parked BYOB reads, and the fanout services them. Default-tee close defers via nextTick (Node's close lands after pending microtasks); byte-stream tee closes promptly and pays one extra tick per *chained* pull (Node cadence).
- **`WritableStream`**: an idle sink's `write` callback runs synchronously inside `writer.write()` (was deferred one microtask).
- **`TransformStream`**: `transform()` runs as a job (Node's sink-write + `PerformTransform` 2-job cadence); its **returned promise gates the write's settlement** (an async transform — e.g. Next's buffered transform returning a `setImmediate`-deferred flush promise — now brakes an upstream pipe like Node); writes **park on backpressure** while the readable side holds undrained chunks, releasing on consumer progress from all four drain paths (default reads, BYOB reads, `pipeTo`'s internal reads, the synchronous body drain).
- **`pipeTo`**: a synchronously-accepted write chains the next cycle directly.

## Verification

- A 25-row tick harness (metronome-raced promise/stream shapes) matches Node **exactly**; 5 of those are added as gap tests (`test_gap_promise_tick_parity{,2}`, `test_gap_stream_{tee,livetee,async_transform}_tick_parity`), all byte-identical vs `node --experimental-strip-types`.
- Next.js 16 standalone sample (turbopack, App Router): every streamed route (`/plain`, `/posts/[id]`, `/fetcher`, `/`) is **byte-identical to node as the first request of a fresh process** (fresh server per route), and the full 8-route matrix is 8/8 byte-identical.
- Gap suite: no new failures vs a pristine merge-base build — the 4 reported (`disposablestack_2875`, `events_import_4995`, `handle_band_object_ops`, `http_overloads_3226plus` timeout) all reproduce on base.
- `cargo fmt --check` and the file-size gate pass.

Fixes the #5989 cold-start residual.

https://claude.ai/code/session_01NjymZygYh31wM9h3wLnUqv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved async function result handling and native Promise adoption timing for closer JavaScript hop parity.
  * Fixed Promise `.finally()` chaining tick order.
  * Reworked `ReadableStream.tee()` to be live and demand/microtask driven, with safer byte handling and corrected close timing.
  * Updated stream transforms/backpressure release and refined piping/write scheduling.

* **Tests**
  * Added/extended deterministic tick-parity and stream ordering tests for Promises and `TransformStream`/`ReadableStream.tee()` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->