### PR TITLE
fix(hir): erase a type-only name in a mixed named import from a node builtin (#6361)

### DIFF
--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -75,6 +75,7 @@ impl LoweringContext {
             param_native_hints: HashMap::new(),
             current_strict: false,
             ui_widget_type_aliases: HashMap::new(),
+            deferred_unknown_native_imports: HashMap::new(),
             current_class: None,
             current_class_inner_name: None,
             pending_class_inner_name: None,

--- a/crates/perry-hir/src/lower/lower_expr/arm_ident.rs
+++ b/crates/perry-hir/src/lower/lower_expr/arm_ident.rs
@@ -15,6 +15,26 @@ pub(crate) fn lower_ident_expr(ctx: &mut LoweringContext, ident: &ast::Ident) ->
     let expr_ident = ast::Expr::Ident(ident.clone());
     let expr = &expr_ident;
     let name = ident.sym.to_string();
+    // A named import from a node-core module that is not a value export of that
+    // module was deferred (neither bound nor rejected) at import lowering — see
+    // `LoweringContext::deferred_unknown_native_imports`. Type annotations are
+    // erased before expression lowering, so reaching this arm means the local is
+    // genuinely used as a VALUE (`import { nope } from "crypto"; nope()`), not a
+    // TS type in a mixed import (`import { createCipheriv, BinaryLike }`). Raise
+    // the original diagnostic now, at the real point of use. A same-named local
+    // that shadows the specifier resolves normally and is untouched.
+    if ctx.lookup_local(&name).is_none() {
+        if let Some((imported, raw_source, span)) =
+            ctx.deferred_unknown_native_imports.get(&name).cloned()
+        {
+            crate::lower_bail!(
+                span,
+                "The requested module '{}' does not provide an export named '{}'",
+                raw_source,
+                imported
+            );
+        }
+    }
     let with_envs = ctx.active_with_envs_for_ident(&name);
     if !with_envs.is_empty() {
         let saved_with_envs = std::mem::take(&mut ctx.with_env_stack);

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -222,6 +222,24 @@ pub struct LoweringContext {
     /// exactly like a `canvas: Canvas` param or a `const canvas = Canvas(...)`
     /// local. Type-only native specifiers are otherwise dropped at import.
     pub(crate) ui_widget_type_aliases: HashMap<String, String>,
+    /// A named import from a node-core module whose name is not a *value* export
+    /// of that module — `local -> (imported, raw_source, span)`.
+    ///
+    /// The overwhelmingly common cause is a TYPE name in a mixed import:
+    /// `import { createCipheriv, BinaryLike } from "crypto"` — `BinaryLike` is a
+    /// TS type, not a runtime export. tsc, esbuild, and Bun all erase such a
+    /// specifier (it is never referenced in a value position); only Node's
+    /// non-type-directed `--experimental-strip-types` rejects it, and it demands
+    /// an explicit `import type`. Rejecting it at import time made every such
+    /// file fail to compile.
+    ///
+    /// So the specifier is neither bound nor rejected here — it is recorded, and
+    /// the error is raised from `lower_ident_expr` if (and only if) the local is
+    /// actually referenced as a VALUE. Type annotations are erased before
+    /// expression lowering, so reaching that point proves a genuine bad import
+    /// (`import { nope } from "crypto"; nope()`), which still gets the original
+    /// `U006` diagnostic and still diverges-from-Node-safely.
+    pub(crate) deferred_unknown_native_imports: HashMap<String, (String, String, swc_common::Span)>,
     /// Current class being lowered (for arrow function `this` capture)
     pub(crate) current_class: Option<String>,
     /// Source-level inner name of the class currently being lowered — the

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -195,12 +195,18 @@ pub(crate) fn lower_module_decl(
                                     &source, &imported,
                                 )
                             {
-                                crate::lower_bail!(
-                                    named.span,
-                                    "The requested module '{}' does not provide an export named '{}'",
-                                    raw_source,
-                                    imported
+                                // Almost always a TS TYPE in a mixed import —
+                                // `import { createCipheriv, BinaryLike } from "crypto"`.
+                                // tsc/esbuild/Bun all erase such a specifier; bailing here
+                                // failed the whole file. Defer: record it, bind nothing, and
+                                // let `lower_ident_expr` raise this same error if the local is
+                                // ever referenced as a VALUE (type positions are erased before
+                                // expression lowering, so a genuine bad import still errors).
+                                ctx.deferred_unknown_native_imports.insert(
+                                    local.clone(),
+                                    (imported.clone(), raw_source.clone(), named.span),
                                 );
+                                continue;
                             }
                             // Register as native module function with the original method name
                             // e.g., import { v4 as uuid } from 'uuid' -> uuid maps to uuid.v4.

--- a/crates/perry-hir/tests/node_named_export_hygiene.rs
+++ b/crates/perry-hir/tests/node_named_export_hygiene.rs
@@ -274,3 +274,66 @@ fn imported_worker_messaging_constructors_keep_worker_threads_routing() {
         "imported messaging constructors should route through worker_threads native constructors: {debug}"
     );
 }
+
+/// A TS **type** name in a mixed import from a node-core module
+/// (`import { createCipheriv, BinaryLike } from "crypto"` — `BinaryLike` is a
+/// type, not a runtime export) must be ERASED, not rejected. tsc, esbuild, and
+/// Bun all drop such a specifier; only Node's non-type-directed
+/// `--experimental-strip-types` rejects it, and it demands an explicit
+/// `import type`. Rejecting it failed the whole file to compile.
+#[test]
+fn type_only_names_in_a_mixed_import_are_erased_not_rejected() {
+    let cases = [
+        (
+            "crypto",
+            r#"
+            import { createCipheriv, BinaryLike, CipherGCM } from "crypto";
+            const key: BinaryLike = "0123456789abcdef";
+            function f(c: CipherGCM) { return c; }
+            console.log(typeof createCipheriv, key, typeof f);
+        "#,
+        ),
+        (
+            "stream",
+            r#"
+            import { Readable, WritableOptions } from "stream";
+            function logCall(fn: WritableOptions["write"], id: number) { return id; }
+            console.log(typeof Readable, logCall(undefined as any, 1));
+        "#,
+        ),
+        (
+            "type name never referenced at all",
+            r#"
+            import { readFileSync, PathLike } from "node:fs";
+            console.log(typeof readFileSync);
+        "#,
+        ),
+    ];
+
+    for (label, src) in cases {
+        assert!(
+            lower_result(src).is_ok(),
+            "{label}: a type-only name in a mixed import must be erased, not rejected"
+        );
+    }
+}
+
+/// The erasure above must NOT weaken the #3922 gate: a name that is not a value
+/// export and IS referenced in a value position is a genuine bad import and must
+/// still be rejected (Node throws a SyntaxError at module instantiation; binding
+/// `undefined` would silently diverge).
+#[test]
+fn unknown_named_import_used_as_a_value_is_still_rejected() {
+    let err = lower_result(
+        r#"
+        import { createCipheriv, definitelyNotAnExport } from "crypto";
+        console.log(typeof createCipheriv);
+        definitelyNotAnExport();
+    "#,
+    )
+    .expect_err("a non-export used as a value must be rejected");
+    assert!(
+        err.contains("does not provide an export named 'definitelyNotAnExport'"),
+        "expected the U006 export diagnostic, got: {err}"
+    );
+}


### PR DESCRIPTION
Closes #6361.

## Problem

The most common TypeScript import shape — values and types together from a node builtin — failed to compile:

```ts
import { createCipheriv, BinaryLike } from "crypto";   // BinaryLike is a TYPE
import { Readable, WritableOptions } from "stream";     // WritableOptions is a TYPE
```
```
error[U006]: The requested module 'crypto' does not provide an export named 'BinaryLike'
```

`lower_module_decl` validated every named specifier against `perry-api-manifest` and hard-bailed when the name wasn't a value export, killing the whole file.

`tsc`, `esbuild`, and `Bun` all **erase** a specifier never referenced in a value position — all three emit exactly `import { createCipheriv } from "crypto"`. Only Node's `--experimental-strip-types` rejects it, because it does no type-directed erasure and demands an explicit `import type`. Perry is a TypeScript compiler, so this made a large class of ordinary TS source uncompilable.

## Fix

Key off **value-position usage**, not the presence of a `type` keyword — that's what the erasure actually depends on, and it's what keeps the #3919–#3922 gate intact.

- **`module_decl.rs`** — a node-core named specifier that isn't a value export is now neither bound nor rejected; it's recorded in `LoweringContext::deferred_unknown_native_imports` (`local -> (imported, source, span)`).
- **`arm_ident.rs`** — `lower_ident_expr` is the single choke point every VALUE reference passes through, and type annotations are erased before expression lowering. So arriving there with a deferred name *proves* it is genuinely used as a value → raise the original `U006` there, at the real point of use. A same-named local that shadows the specifier resolves normally and is untouched.

Net: a type-only name is erased (file compiles); a genuine bad import still errors, so Node's SyntaxError-at-instantiation behavior is preserved and nothing silently binds `undefined`.

```ts
import { createCipheriv, definitelyNotAnExport } from "crypto";
definitelyNotAnExport();   // still U006 ✅
```

## Found by

Running Bun's own test suite through perry. Two files failed at the `compile` tier (total failure) on this alone — `bun/crypto/cipheriv-decipheriv.test.ts` and `node/stream/node-stream-uint8array.test.ts`. Both now compile and run (the latter goes 0 → 3 passing cases).

## Testing

- Two new cases in `crates/perry-hir/tests/node_named_export_hygiene.rs`: type-only names in a mixed import are erased (crypto / stream / never-referenced), and an unknown name **used as a value** is still rejected with the U006 diagnostic.
- `tests/test_issue_3922_http2_named_imports.sh` still passes (its bad imports are used as values, so they still error).
- `node_named_export_hygiene` 9/9, `unimplemented_api_check` 14/14.
- **Full parity suite A/B'd against a pristine `main` build in the same worktree — identical results, zero regressions.** (The residual local failures are pre-existing: 3 are already in `known_failures.json`; 2 are a local prebuilt-`libperry_ext_zlib.a`-vs-rustc `__rust_drop_panic` link error affecting any `node:zlib` import; 2 are Node-version output drift. All reproduce identically without this change.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with mixed TypeScript imports from Node.js modules by allowing type-only imports to compile correctly.
  * Added clear errors when a non-value import is used as a runtime value.

* **Tests**
  * Expanded coverage for Node.js named-import handling, including erased type-only imports and invalid value usage diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->