### PR TITLE
fix(runtime): URLSearchParams default iterator + full dynamic method surface

### DIFF
--- a/crates/perry-runtime/src/array/iter_object.rs
+++ b/crates/perry-runtime/src/array/iter_object.rs
@@ -292,6 +292,26 @@ unsafe fn collection_iter_obj_for_receiver(arr: *const ArrayHeader, kind: u8) ->
             _ => crate::collection_iter_object::js_set_values_iter_obj(s),
         });
     }
+    // Native URLSearchParams (ordinary heap object, `_entries`-leading shape —
+    // NOT a fetch-band handle): the #597 any-typed fold lands here too, e.g.
+    // `const sp = new URL(u).searchParams; sp.entries()` where `sp`'s static
+    // type erased to Any. Reading the params object as an `ArrayHeader`
+    // yielded an EMPTY iterator. Materialize the requested view as an eager
+    // array and drive it with the standard array iterator object.
+    {
+        let obj = raw as *mut crate::object::ObjectHeader;
+        if crate::url::search_params::shape_is_url_search_params(obj) {
+            let boxed = match kind {
+                1 => crate::url::js_url_search_params_keys_arr(obj),
+                2 => crate::url::js_url_search_params_entries_arr(obj),
+                _ => crate::url::js_url_search_params_values_arr(obj),
+            };
+            let ptr = (boxed.to_bits() & 0x0000_FFFF_FFFF_FFFF) as *const ArrayHeader;
+            if !ptr.is_null() {
+                return Some(array_iter_obj_raw(ptr, KIND_VALUES));
+            }
+        }
+    }
     // `class X extends Map|Set` instance — probe the hidden backing field via
     // the reconstructed NaN-boxed pointer value.
     let boxed = f64::from_bits(JSValue::pointer(arr as *const u8).bits());

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -862,7 +862,18 @@ pub unsafe extern "C" fn js_native_call_method(
     // before the generic field-scan misses and throws "is not a function".
     if matches!(
         method_name,
-        "append" | "set" | "get" | "has" | "delete" | "toString"
+        "append"
+            | "set"
+            | "get"
+            | "has"
+            | "delete"
+            | "toString"
+            | "entries"
+            | "keys"
+            | "values"
+            | "getAll"
+            | "sort"
+            | "forEach"
     ) {
         let recv_ptr = (object.to_bits() & 0x0000_FFFF_FFFF_FFFF) as *mut ObjectHeader;
         if crate::url::search_params::shape_is_url_search_params(recv_ptr) {

--- a/crates/perry-runtime/src/symbol/iterator.rs
+++ b/crates/perry-runtime/src/symbol/iterator.rs
@@ -256,6 +256,26 @@ pub extern "C" fn js_get_iterator(val_f64: f64) -> f64 {
     // drive `.next()`. Matches the builtins' default iterator. Skipped when the
     // subclass overrides `[Symbol.iterator]`, so we fall through to the generic
     // symbol lookup below (which resolves the user's `@@iterator` method).
+    //
+    // A URLSearchParams object (shape-detected: `_entries` + `_owner` fields)
+    // has no symbol-table `[Symbol.iterator]` entry — its default iterator
+    // yields `[key, value]` pairs (`%URLSearchParamsIteratorPrototype%`).
+    // Without this branch the generic lookup below finds nothing and returns
+    // the params object as its own "iterator"; the lazy for-of then calls
+    // `.next()` on it → "next is not a function" (mysql2's `parseUrl` does
+    // `for (const [key, value] of url.searchParams)`, so `createPool` with a
+    // `uri:` option died on this).
+    {
+        let jsv = crate::value::JSValue::from_bits(val_f64.to_bits());
+        if jsv.is_pointer() {
+            let obj =
+                jsv.as_pointer::<crate::object::ObjectHeader>() as *mut crate::object::ObjectHeader;
+            if crate::url::search_params::shape_is_url_search_params(obj) {
+                let entries = crate::url::js_url_search_params_entries_arr(obj);
+                return crate::array::array_values_iter(entries);
+            }
+        }
+    }
     match crate::object::map_set_subclass::subclass_backing_for_default_iteration(val_f64) {
         Some(crate::object::map_set_subclass::CollectionBacking::Map(m)) => {
             return crate::value::js_nanbox_pointer(

--- a/crates/perry-runtime/src/url/search_params.rs
+++ b/crates/perry-runtime/src/url/search_params.rs
@@ -948,14 +948,25 @@ pub(crate) fn url_search_params_dynamic_call(
             }
         }
         "has" => {
-            if js_url_search_params_has(params, arg(0)) != 0.0 {
+            // Node 19+: `has(name, value)` matches on BOTH when a second
+            // argument is present.
+            let hit = if args_len >= 2 && arg(1).to_bits() != crate::value::TAG_UNDEFINED {
+                js_url_search_params_has2(params, arg(0), arg(1)) != 0.0
+            } else {
+                js_url_search_params_has(params, arg(0)) != 0.0
+            };
+            if hit {
                 f64::from_bits(crate::value::TAG_TRUE)
             } else {
                 f64::from_bits(crate::value::TAG_FALSE)
             }
         }
         "delete" => {
-            js_url_search_params_delete(params, arg(0));
+            if args_len >= 2 && arg(1).to_bits() != crate::value::TAG_UNDEFINED {
+                js_url_search_params_delete2(params, arg(0), arg(1));
+            } else {
+                js_url_search_params_delete(params, arg(0));
+            }
             undefined
         }
         "toString" => {
@@ -966,6 +977,28 @@ pub(crate) fn url_search_params_dynamic_call(
                 .collect::<Vec<_>>()
                 .join("&");
             create_string_f64(&joined)
+        }
+        // Iteration helpers surface as eager arrays, matching the convention
+        // the static lowering uses (`js_get_iterator` wraps an eager array in
+        // the runtime array iterator when driven through for-of). mysql2's
+        // `parseUrl` iterates `url.searchParams` and Node code commonly calls
+        // `.entries()` / `.getAll()` on dynamic receivers.
+        "entries" => js_url_search_params_entries_arr(params),
+        "keys" => js_url_search_params_keys_arr(params),
+        "values" => js_url_search_params_values_arr(params),
+        "getAll" => {
+            // The FFI helper returns RAW pointer bits (the static lowering
+            // boxes them); re-box for the dynamic call path.
+            let raw = js_url_search_params_get_all(params, arg(0));
+            crate::value::js_nanbox_pointer(f64::to_bits(raw).cast_signed())
+        }
+        "sort" => {
+            js_url_search_params_sort(params);
+            undefined
+        }
+        "forEach" => {
+            js_url_search_params_for_each(params, arg(0), arg(1));
+            undefined
         }
         _ => return None,
     })

--- a/test-files/test_gap_url_searchparams_iter.ts
+++ b/test-files/test_gap_url_searchparams_iter.ts
@@ -1,0 +1,42 @@
+// URLSearchParams iteration parity (mysql2 parseUrl pattern + dynamic surface).
+// 1. for-of over a URL-adopted searchParams (default @@iterator → [key, value] pairs)
+const u = new URL('mysql://user:pw@dbhost:3306/mydb?connectionLimit=5&x=1');
+for (const [k, v] of u.searchParams) console.log('adopted', k, v);
+
+// 2. for-of over an EMPTY adopted searchParams (mysql2 hits this for query-less URIs)
+const bare = new URL('mysql://user:pw@dbhost:3306/mydb');
+let empty = 0;
+for (const _pair of bare.searchParams) empty++;
+console.log('empty count', empty);
+
+// 3. builtin held in a variable (minified-bundle shape)
+const R = URL;
+const u2 = new R('https://h/p?a=1&b=2');
+for (const [k, v] of u2.searchParams) console.log('via-var', k, v);
+
+// 4. free-standing URLSearchParams
+const sp = new URLSearchParams('q=1&w=2&q=3');
+for (const [k, v] of sp) console.log('free', k, v);
+
+// 5. type-erased receiver: methods must dispatch dynamically
+const erased: any = u2.searchParams;
+console.log('get', erased.get('a'));
+console.log('getAll', sp.getAll('q'));
+for (const p of erased.entries()) console.log('entries', p[0], p[1]);
+for (const k of erased.keys()) console.log('key', k);
+for (const v of erased.values()) console.log('value', v);
+erased.forEach((v: any, k: any) => console.log('fe', k, v));
+
+// 6. has/delete with the Node 19+ two-arg forms through a dynamic receiver
+const dsp: any = new URLSearchParams('m=1&m=2&n=3');
+console.log('has2', dsp.has('m', '2'), dsp.has('m', '9'));
+dsp.delete('m', '1');
+console.log('after delete2', dsp.toString());
+
+// 7. sort through a dynamic receiver
+const ssp: any = new URLSearchParams('z=26&a=1&k=11');
+ssp.sort();
+console.log('sorted', ssp.toString());
+
+// 8. spread still works (regression guard for the #1668 path)
+console.log('spread', JSON.stringify([...sp]));


### PR DESCRIPTION
## Problem

`for...of` over a `URLSearchParams` threw `TypeError: next is not a function`: `js_get_iterator` had no branch for the native params shape, returned the params object as its own "iterator", and the lazy for-of protocol called `.next()` on it.

Real-world impact: mysql2's `ConnectionConfig.parseUrl` does `for (const [key, value] of url.searchParams)`, so `createPool({ uri })` died on this — **even for query-less connection strings** (acquiring the iterator itself throws). Found compiling a real Next.js 16 standalone app (myairank.io) whose DB layer passes `uri: process.env.DATABASE_URL`.

Also: `entries()` / `keys()` / `values()` / `getAll()` / `sort()` / `forEach()` were unreachable on a **type-erased receiver** — `url_search_params_dynamic_call` had no arms for them, and the `js_native_call_method` dispatch gate lists method names explicitly, so bundled/minified code (which calls everything dynamically) silently got the generic own-key scan (internal keys hidden → empty results).

## Fixes

- `js_get_iterator`: a shape-detected URLSearchParams yields its `[key, value]` entries via the standard array iterator.
- `url_search_params_dynamic_call`: add `entries`/`keys`/`values`/`getAll`/`sort`/`forEach` arms, plus the Node 19+ two-arg `has(name, value)` / `delete(name, value)` forms.
- `native_call_method` gate: extend the explicit method-name list so the new arms are reachable.
- `js_array_{values,keys,entries}_iter_obj` (the #597 any-typed `.entries()` fold): route a URLSearchParams receiver to the matching params view instead of reading the params object as an `ArrayHeader` (which produced a silently empty iterator).

## Testing

`test-files/test_gap_url_searchparams_iter.ts` — adopted/free-standing/via-variable iteration, empty params, type-erased method surface, two-arg has/delete, sort, spread — byte-identical with `node --experimental-strip-types`.

Known residual (pre-existing, unchanged): `sp.entries()` as a *value* returns an eager array under Perry (node returns an iterator object), consistent with the existing eager-array convention for host collections.

https://claude.ai/code/session_01NjymZygYh31wM9h3wLnUqv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded `URLSearchParams` support with `entries`, `keys`, `values`, `getAll`, `sort`, and `forEach`.
  * Added support for value-aware `has` and `delete` operations.
  * Improved iteration and spread behavior for `URLSearchParams`, including parameters associated with URLs.

* **Bug Fixes**
  * Fixed iteration failures when using `for...of` with `URLSearchParams`.
  * Improved behavior for dynamically typed `URLSearchParams` operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->