### PR TITLE
fix(codegen): run the inherited constructor for a no-own-ctor class with a purely dynamic parent

### DIFF
--- a/crates/perry-codegen/src/codegen/artifacts.rs
+++ b/crates/perry-codegen/src/codegen/artifacts.rs
@@ -561,7 +561,16 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
         {
             let ctor_body = if let Some(c) = class.constructor.as_ref() {
                 (c.params.clone(), c.body.clone(), c.captures.clone())
-            } else if class.extends_name.is_some() {
+            } else if class.extends_name.is_some() || class.extends_expr.is_some() {
+                // `extends_expr.is_some()` (with NO extends_name): a PURELY
+                // dynamic parent — `class extends <local var> {}`, the shape a
+                // bundled mysql2 promise-mixin takes (`module.exports = class
+                // extends Pool { promise() {…} }`). It needs the same
+                // forwarding signature; `synthesized_ctor_param_count` already
+                // resolves it to the unresolved-parent fixed band. Previously
+                // this fell to the empty-ctor branch, so the standalone ctor
+                // dropped every construction arg AND never called super — the
+                // instance silently lost all inherited ctor state (wall 7).
                 // No own ctor + heritage → JS spec default ctor
                 // `constructor(...args) { super(...args) }`. Synthesize forwarding
                 // params matching the closest ancestor ctor's arity (incl.

--- a/crates/perry-codegen/src/codegen/method.rs
+++ b/crates/perry-codegen/src/codegen/method.rs
@@ -565,7 +565,14 @@ pub(super) fn compile_method(
         //     later (after super() in own-body case, after explicit parent
         //     ctor call in no-own-body case).
         //   - no extends: apply all (= just self) here.
-        let init_mode = if class.extends_name.is_some() {
+        // A no-own-ctor class with a PURELY dynamic parent (`extends_expr`,
+        // no `extends_name`) now emits a synthesized dynamic super below —
+        // stage its self fields AFTER that call (tail SelfOnly), like any
+        // other heritage class, instead of applying them twice.
+        let no_ctor_dynamic_parent = class.constructor.is_none()
+            && class.extends_name.is_none()
+            && class.extends_expr.is_some();
+        let init_mode = if class.extends_name.is_some() || no_ctor_dynamic_parent {
             crate::lower_call::FieldInitMode::AncestorsOnly
         } else {
             crate::lower_call::FieldInitMode::All
@@ -586,7 +593,9 @@ pub(super) fn compile_method(
         // call to the parent's standalone ctor symbol here, forwarding all
         // args. The walk skips empty-bodied parents (matching the JS spec
         // chain semantics).
-        if class.constructor.is_none() && class.extends_name.is_some() {
+        if class.constructor.is_none()
+            && (class.extends_name.is_some() || class.extends_expr.is_some())
+        {
             let builtin_parent_runtime = match class.extends_name.as_deref() {
                 Some("Writable") => Some("js_node_stream_writable_subclass_init"),
                 Some("Duplex") => Some("js_node_stream_duplex_subclass_init"),

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -89,6 +89,7 @@ impl LoweringContext {
             class_display_names: HashMap::new(),
             gen_param_prologue_len: HashMap::new(),
             assignment_inferred_name: None,
+            inferred_class_bindings: std::collections::HashSet::new(),
             closure_source_text: HashMap::new(),
             func_return_native_instances: Vec::new(),
             pending_classes: Vec::new(),

--- a/crates/perry-hir/src/lower/expr_assign.rs
+++ b/crates/perry-hir/src/lower/expr_assign.rs
@@ -698,6 +698,29 @@ fn lower_assignment_target(
                                     && ctx.lookup_func(&cls_name).is_none()
                                 {
                                     None
+                                } else if ctx.lookup_local(&cls_name).is_some()
+                                    && !ctx.inferred_class_bindings.contains(cls_name.as_str())
+                                {
+                                    // A lexical local shadows any same-named
+                                    // module-scope class for this write too
+                                    // (wall 7's disease, 4th surface): the
+                                    // vendored eventemitter3 `function s(){}`
+                                    // + `s.prototype.emit = fn` inside a
+                                    // turbopack chunk that ALSO has minified
+                                    // `class s {…}` declarations registered
+                                    // emit onto the unrelated class — the ES5
+                                    // constructor's prototype stayed EMPTY and
+                                    // every subclass (p-queue's PQueue) lost
+                                    // the inherited surface. A function-valued
+                                    // local keys the registration by the
+                                    // closure VALUE; any other local falls to
+                                    // the ordinary property-set path.
+                                    let local_id = ctx.lookup_local(&cls_name).unwrap();
+                                    if ctx.function_valued_locals.contains(&local_id) {
+                                        Some(ProtoOwner::Func(Expr::LocalGet(local_id)))
+                                    } else {
+                                        None
+                                    }
                                 } else if ctx.lookup_class(&cls_name).is_some()
                                     && class_has_accessor(ctx, &cls_name, &method_name)
                                 {

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -178,14 +178,20 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
             //      param shadows it — and the `resolve_class_alias().is_none()`
             //      guard on the reroute block below would then skip it.
             //
-            // Capturing the binding here (when no real class of this name is in
-            // scope) keeps the reroute stable against both.
-            let callee_local_at_entry: Option<LocalId> = if ctx.lookup_class(&class_name).is_none()
-            {
-                ctx.lookup_local(&class_name)
-            } else {
-                None
-            };
+            // Capturing the binding here keeps the reroute stable against both.
+            //
+            // Snapshotted UNCONDITIONALLY (previously only when no class of
+            // this name existed): a lexical local shadows a same-named
+            // module-scope class for every reference in scope, `new`
+            // included. Minified bundles hit this constantly — mysql2's
+            // chunk has `class e{...}` (PacketParser) at module scope AND
+            // factory-local `let e = E.r(76464)` (PoolConfig); `new e(o)`
+            // must construct the LOCAL's value, not the name-keyed class
+            // (myairank wall 7: the wrong class's ctor ran, silently). A
+            // class-decl name only carries a local slot when the module
+            // reassigns it (#5833), and for a reassigned binding reading the
+            // slot is the spec-correct behavior for `new` too.
+            let callee_local_at_entry: Option<LocalId> = ctx.lookup_local(&class_name);
             // #6233: a user-declared binding — `class Symbol extends Base {}`,
             // a local/param, a `function` declaration, or an imported binding —
             // lexically shadows the same-named global for every reference in
@@ -1141,24 +1147,21 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 }
             }
             // A local/param binding lexically shadows any same-named outer
-            // `let`/`const` class alias. When `callee_local_at_entry` is set
-            // (a non-class local was in scope at the top of this arm, before
-            // arg lowering could disturb the scope), route the construct
-            // through that VALUE — even if `resolve_class_alias` would
-            // otherwise resolve `class_name` to a stale enclosing-scope alias
-            // (its map is name-keyed, not scope-aware). Without this, the
-            // `resolve_class_alias().is_none()` guard on the local-reroute
-            // block below is false and the construct falls through to an
-            // empty-object `Expr::New { class_name }` placeholder whose
-            // constructor body never runs.
-            if ctx.lookup_class(&class_name).is_none() {
-                if let Some(local_id) = callee_local_at_entry {
-                    return Ok(Expr::NewDynamic {
-                        callee: Box::new(Expr::LocalGet(local_id)),
-                        args,
-                        byte_offset: new_byte_offset,
-                    });
-                }
+            // `let`/`const` class alias AND any same-named module-scope class
+            // declaration. When `callee_local_at_entry` is set (a local was
+            // in scope at the top of this arm, before arg lowering could
+            // disturb the scope), route the construct through that VALUE —
+            // even if `resolve_class_alias` would otherwise resolve
+            // `class_name` to a stale enclosing-scope alias (its map is
+            // name-keyed, not scope-aware), and even if a class of this name
+            // exists (the local shadows it; constructing the class instead
+            // ran the WRONG constructor for mysql2's bundled factories).
+            if let Some(local_id) = callee_local_at_entry {
+                return Ok(Expr::NewDynamic {
+                    callee: Box::new(Expr::LocalGet(local_id)),
+                    args,
+                    byte_offset: new_byte_offset,
+                });
             }
             // Issue #838 followup (b): when `<Ident>` is NOT a real
             // class but resolves to a local binding, route through

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -1157,11 +1157,23 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
             // exists (the local shadows it; constructing the class instead
             // ran the WRONG constructor for mysql2's bundled factories).
             if let Some(local_id) = callee_local_at_entry {
-                return Ok(Expr::NewDynamic {
-                    callee: Box::new(Expr::LocalGet(local_id)),
-                    args,
-                    byte_offset: new_byte_offset,
-                });
+                // …but NOT when the local IS the class's own alias binding
+                // (`const E2 = class extends Event {}` — `let_class_aliases`
+                // maps E2 to its class): the static path carries the exact
+                // builtin-parent construction (#6336's Event/Map native
+                // attach), which the generic dynamic construct does not.
+                // A shadowing local over an UNRELATED same-named class
+                // declaration has no alias entry, so wall 7's reroute keeps
+                // firing.
+                let local_is_class_alias =
+                    ctx.inferred_class_bindings.contains(class_name.as_str());
+                if !local_is_class_alias {
+                    return Ok(Expr::NewDynamic {
+                        callee: Box::new(Expr::LocalGet(local_id)),
+                        args,
+                        byte_offset: new_byte_offset,
+                    });
+                }
             }
             // Issue #838 followup (b): when `<Ident>` is NOT a real
             // class but resolves to a local binding, route through

--- a/crates/perry-hir/src/lower/lower_expr/arm_class.rs
+++ b/crates/perry-hir/src/lower/lower_expr/arm_class.rs
@@ -68,7 +68,13 @@ pub(crate) fn lower_class_expr(
             match inferred {
                 // First class expression to claim this inferred binding name —
                 // reuse it directly as the registration key (and thus `.name`).
-                Some(name) if ctx.lookup_class(&name).is_none() => name,
+                Some(name) if ctx.lookup_class(&name).is_none() => {
+                    // Record that this binding's local holds ITS OWN class, so
+                    // `new <name>()` keeps the exact static construct path
+                    // (see `inferred_class_bindings`).
+                    ctx.inferred_class_bindings.insert(name.clone());
+                    name
+                }
                 // #5592: a second anonymous class expression assigned to the
                 // SAME binding (`C = class {…}; C = class {…}`) infers the same
                 // name. Reusing the key would alias both onto one ClassId
@@ -77,6 +83,12 @@ pub(crate) fn lower_class_expr(
                 // registration key but keep its user-visible `.name` as the
                 // binding name.
                 Some(name) => {
+                    // The binding's local still holds ITS OWN class even when
+                    // the registration key is disambiguated (#5592) — or when
+                    // the Phase-1.5 pre-scan already claimed the inferred name
+                    // for this same expression. Record the BINDING name so
+                    // `new <name>()` keeps the static construct path.
+                    ctx.inferred_class_bindings.insert(name.clone());
                     display_override = Some(name.clone());
                     format!("{}__anon_dup_{}", name, ctx.fresh_class())
                 }

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -300,6 +300,15 @@ pub struct LoweringContext {
     /// identifier lhs can provide the `NamedEvaluation` name for an anonymous
     /// function/class rhs. This slot is set only while lowering that rhs.
     pub(crate) assignment_inferred_name: Option<String>,
+    /// Binding names whose class registration was created BY the binding's
+    /// own class-expression init (`const E2 = class extends Event {}` — the
+    /// anonymous expression claimed the inferred binding name as its
+    /// registration key, and `var K = class Inner {}` registers under the
+    /// bind name too). At a `new <name>()` site, such a name's local provably
+    /// holds that same class, so the static construct path (with its exact
+    /// builtin-parent handling) is correct; any OTHER in-scope local shadows
+    /// whatever same-named class exists and must construct dynamically.
+    pub(crate) inferred_class_bindings: std::collections::HashSet<String>,
     /// #4101: original source text keyed by FuncId, captured by slicing the
     /// module source against each function's AST span at lowering time.
     /// Flushed into `Module.closure_source_text` alongside `pending_functions`.

--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -61,6 +61,9 @@ fn emit_class_expression_value_binding(
         ctx.mark_local_immutable(id);
     }
     ctx.register_let_class_alias(bind_name.to_string(), bind_name.to_string());
+    // The binding's local holds ITS OWN class — `new <bind_name>()` must keep
+    // the static construct path (see `inferred_class_bindings`).
+    ctx.inferred_class_bindings.insert(bind_name.to_string());
     module.init.push(Stmt::Let {
         id,
         name: bind_name.to_string(),
@@ -688,6 +691,9 @@ pub(crate) fn lower_stmt(
                                         let class_id = ctx.fresh_class();
                                         ctx.register_class(bind_name.clone(), class_id);
                                         ctx.register_class(inner_name.clone(), class_id);
+                                        // The bind-name local holds ITS OWN
+                                        // class (see inferred_class_bindings).
+                                        ctx.inferred_class_bindings.insert(bind_name.clone());
                                         ctx.class_expr_aliases
                                             .insert(inner_name.clone(), bind_name.clone());
                                     }

--- a/crates/perry-runtime/src/object/class_constructors.rs
+++ b/crates/perry-runtime/src/object/class_constructors.rs
@@ -950,17 +950,48 @@ pub(crate) unsafe fn replay_class_object_constructor(
     args_ptr: *const f64,
     args_len: usize,
 ) {
-    let Some((ctor_ptr, total_params, sig_caps)) = lookup_class_constructor(class_cid) else {
+    // Spec: a derived class with no own `constructor` gets the implicit
+    // `constructor(...args) { super(...args) }` — the nearest ancestor's ctor
+    // must run with the same argument list. `lookup_class_constructor` holds
+    // OWN ctors only, so walk the parent chain (static edges and the
+    // dynamically-registered `class X extends <runtime value>` edges both
+    // live in CLASS_REGISTRY). Bailing out here instead constructed a
+    // FIELD-LESS instance silently — mysql2's promise mixin
+    // (`module.exports = class extends Pool { promise() {…} }`) produced a
+    // Pool whose ctor never ran, so `pool.config` was undefined and Next.js
+    // requests died far from the fault (myairank wall 7).
+    let mut ctor_cid = class_cid;
+    let mut depth = 0usize;
+    let found = loop {
+        if let Some(found) = lookup_class_constructor(ctor_cid) {
+            break Some(found);
+        }
+        match super::class_registry::get_parent_class_id(ctor_cid) {
+            Some(p) if p != 0 && p != ctor_cid && depth < 32 => {
+                ctor_cid = p;
+                depth += 1;
+            }
+            _ => break None,
+        }
+    };
+    let Some((ctor_ptr, total_params, sig_caps)) = found else {
         return;
     };
 
     // Read the snapshotted captures (an own array, in capture-param order).
-    // Absent → no captures.
-    let caps_val = crate::object::js_object_get_own_field_or_undef(
-        classobj_value,
-        b"__perry_ctor_caps".as_ptr(),
-        17,
-    );
+    // Absent → no captures. The `__perry_ctor_caps` snapshot on this class
+    // object belongs to ITS OWN ctor — when the walk above resolved an
+    // ANCESTOR's ctor, that snapshot doesn't apply; use the ancestor's
+    // decl-site snapshot (CLASS_CAPTURE_VALUES) via the fallback below.
+    let caps_val = if ctor_cid == class_cid {
+        crate::object::js_object_get_own_field_or_undef(
+            classobj_value,
+            b"__perry_ctor_caps".as_ptr(),
+            17,
+        )
+    } else {
+        f64::from_bits(crate::value::TAG_UNDEFINED)
+    };
     let caps_jv = crate::value::JSValue::from_bits(caps_val.to_bits());
     let (caps_arr, n_caps): (*const crate::array::ArrayHeader, u32) = if caps_jv.is_pointer() {
         let arr = caps_jv.as_pointer::<crate::array::ArrayHeader>();
@@ -981,7 +1012,9 @@ pub(crate) unsafe fn replay_class_object_constructor(
     // (p-queue's `new PQueue({...})` left `i.default` undefined and
     // `new e.queueClass` threw "undefined is not a constructor").
     let snapshot_caps: Vec<u64> = if n_caps == 0 {
-        class_capture_values(class_cid).unwrap_or_default()
+        // Keyed by the ctor's OWNING class (`ctor_cid` — differs from
+        // `class_cid` when the parent walk resolved an ancestor's ctor).
+        class_capture_values(ctor_cid).unwrap_or_default()
     } else {
         Vec::new()
     };
@@ -1065,7 +1098,31 @@ pub(crate) unsafe fn replay_registered_class_constructor(
     args_ptr: *const f64,
     args_len: usize,
 ) {
-    let Some((ctor_ptr, total_params, sig_caps)) = lookup_class_constructor(class_cid) else {
+    // Spec: a derived class with no own `constructor` gets the implicit
+    // `constructor(...args) { super(...args) }` — the nearest ancestor's ctor
+    // runs with the same argument list. `lookup_class_constructor` holds OWN
+    // ctors only, so walk the parent chain (static edges and the
+    // dynamically-registered `class X extends <runtime value>` edges both
+    // live in CLASS_REGISTRY). Bailing out here instead constructed a
+    // FIELD-LESS instance silently — mysql2's promise mixin
+    // (`module.exports = class extends Pool { promise() {…} }`) produced a
+    // Pool whose ctor never ran, and the first `.config` read blew up far
+    // from the fault.
+    let mut ctor_cid = class_cid;
+    let mut depth = 0usize;
+    let found = loop {
+        if let Some(found) = lookup_class_constructor(ctor_cid) {
+            break Some(found);
+        }
+        match super::class_registry::get_parent_class_id(ctor_cid) {
+            Some(p) if p != 0 && p != ctor_cid && depth < 32 => {
+                ctor_cid = p;
+                depth += 1;
+            }
+            _ => break None,
+        }
+    };
+    let Some((ctor_ptr, total_params, sig_caps)) = found else {
         return;
     };
 
@@ -1073,7 +1130,9 @@ pub(crate) unsafe fn replay_registered_class_constructor(
     // snapshot (see CLASS_CAPTURE_VALUES). The ctor's trailing
     // `__perry_cap_<id>` params are filled from it; user args fill the rest.
     // #5957: the split is the SIGNATURE cap count, not the snapshot length.
-    let caps = class_capture_values(class_cid).unwrap_or_default();
+    // Keyed by the ctor's OWNING class (`ctor_cid`), which differs from
+    // `class_cid` when the walk above resolved an ancestor's ctor.
+    let caps = class_capture_values(ctor_cid).unwrap_or_default();
     let user_params = (total_params as usize).saturating_sub(sig_caps as usize);
 
     let undef = f64::from_bits(crate::value::TAG_UNDEFINED);

--- a/test-files/test_gap_class_expr_dynamic_parent_ctor.ts
+++ b/test-files/test_gap_class_expr_dynamic_parent_ctor.ts
@@ -1,0 +1,83 @@
+// A derived class EXPRESSION with no own constructor must run the inherited
+// constructor (implicit `constructor(...args) { super(...args) }`) — including
+// when the parent is a runtime VALUE (dynamic parent edge), the shape bundlers
+// emit for mysql2's promise mixin: `module.exports = class extends Pool {...}`.
+import { EventEmitter } from 'events';
+
+// [A] named base decl + named derived decl, no own ctor
+class BaseA extends EventEmitter {
+  config: any;
+  constructor(o: any) { super(); this.config = o.config; }
+}
+class DerA extends BaseA { promise() { return 1; } }
+const a = new DerA({ config: { x: 1 } });
+console.log('[A]', typeof a.config, a.config && a.config.x);
+
+// [B] anonymous base expr + anonymous derived expr, no own ctor
+const BaseB: any = class extends EventEmitter {
+  config: any;
+  constructor(o: any) { super(); this.config = o.config; }
+};
+const DerB: any = class extends BaseB { promise() { return 1; } };
+const b = new DerB({ config: { x: 2 } });
+console.log('[B]', typeof b.config, b.config && b.config.x);
+
+// [C] same but base extends a plain class
+class P0 {}
+const BaseC: any = class extends P0 {
+  config: any;
+  constructor(o: any) { super(); this.config = o.config; }
+};
+const DerC: any = class extends BaseC { promise() { return 1; } };
+const c = new DerC({ config: { x: 3 } });
+console.log('[C]', typeof c.config, c.config && c.config.x);
+
+// [D] derived-no-ctor constructed via a type-erased variable
+const mk = () => DerB;
+const DerD = mk();
+const d = new DerD({ config: { x: 4 } });
+console.log('[D]', typeof d.config, d.config && d.config.x);
+
+// [E] registry shape (turbopack factories): class values obtained via a
+// lazily-run module table, mysql2 createPool chain end-to-end
+const factories = new Map<number, any>();
+const cache = new Map<number, any>();
+const R = {
+  r(id: number) {
+    if (cache.has(id)) return cache.get(id).exports;
+    const mod = { exports: {} as any };
+    cache.set(id, mod);
+    factories.get(id)!(R, mod, mod.exports);
+    return mod.exports;
+  },
+};
+factories.set(1, (E: any, _: any) => {
+  _.exports = class {
+    cc: any;
+    constructor(o: any) { this.cc = { v: o.x }; }
+  };
+});
+factories.set(2, (E: any, _: any) => {
+  const t = EventEmitter;
+  _.exports = class extends t {
+    config: any;
+    constructor(o: any) { super(); this.config = o.config; this.config.cc.pool = this; }
+  };
+});
+factories.set(3, (E: any, _: any) => {
+  const P = E.r(2);
+  _.exports = class extends P { promise() { return 'promised'; } };
+});
+factories.set(4, (E: any, _: any) => {
+  const Pool = E.r(3), Cfg = E.r(1);
+  _.exports = function (o: any) { return new Pool({ config: new Cfg(o) }); };
+});
+const createPool = R.r(4);
+const pool = createPool({ x: 42 });
+console.log('[E]', typeof pool.config, pool.config.cc.v, typeof pool.config.cc.pool, pool.promise());
+
+// [F] three-level chain: derived-no-ctor over derived-no-ctor over base
+const Mid: any = class extends BaseB { };
+const Leaf: any = class extends Mid { tag() { return 'leaf'; } };
+const f = new Leaf({ config: { x: 6 } });
+console.log('[F]', typeof f.config, f.config && f.config.x, f.tag());

--- a/test-files/test_gap_new_local_shadows_class.ts
+++ b/test-files/test_gap_new_local_shadows_class.ts
@@ -1,0 +1,35 @@
+// `new <ident>` where a lexical local shadows a same-named module-scope
+// class: the LOCAL's value must be constructed, not the name-keyed class.
+// Minified bundles hit this constantly — mysql2's chunk has a module-scope
+// `class e {…}` (PacketParser) AND factory-local `let e = require(...)`
+// (PoolConfig); `new e(opts)` constructed the wrong class silently.
+class e {
+  buffer: any[];
+  packetHeaderLength: number;
+  constructor(E: any, _?: number) { this.buffer = []; this.packetHeaderLength = _ || 4; }
+}
+class PoolConfigLike {
+  connectionConfig: any;
+  constructor(o: any) { this.connectionConfig = { host: o.host || 'x' }; }
+}
+// plain function-local shadow
+function factory() {
+  let e = PoolConfigLike;
+  return new e({ host: 'db' });
+}
+const cfg = factory();
+console.log('[s1]', typeof cfg.connectionConfig, cfg.connectionConfig && cfg.connectionConfig.host, 'buffer:', typeof (cfg as any).buffer);
+// the module class itself still constructs correctly
+const p = new e('x', 9);
+console.log('[s2]', Array.isArray(p.buffer), p.packetHeaderLength);
+// closure-captured shadow (the exact bundled-factory shape)
+const mk = (function () {
+  let e = PoolConfigLike;
+  return function (o: any) { return new e(o); };
+})();
+const cfg2 = mk({ host: 'h2' });
+console.log('[s3]', typeof cfg2.connectionConfig, cfg2.connectionConfig && cfg2.connectionConfig.host);
+// param shadow
+function build(e: any) { return new e({ host: 'h3' }); }
+const cfg3 = build(PoolConfigLike);
+console.log('[s4]', cfg3.connectionConfig && cfg3.connectionConfig.host);

--- a/test-files/test_gap_proto_write_local_shadows_class.ts
+++ b/test-files/test_gap_proto_write_local_shadows_class.ts
@@ -1,0 +1,37 @@
+// `<ident>.prototype.<m> = fn` where the ident is a lexical LOCAL (an ES5
+// constructor function) that shadows a same-named module-scope class: the
+// write must land on the local function's prototype, not register onto the
+// unrelated class. Vendored eventemitter3 (`function s(){}` +
+// `s.prototype.emit = fn`) inside a turbopack chunk that also has minified
+// `class s {…}` declarations lost its whole prototype surface — every
+// subclass (p-queue's PQueue) inherited nothing and Next page renders died
+// on `this.emit(...)`.
+class s {
+  tracer(): string { return "tracer"; }
+}
+function makeEE(): any {
+  function s(this: any) { this._events = {}; }
+  (s as any).prototype.on = function (this: any, n: string, f: any) {
+    (this._events[n] = this._events[n] || []).push(f);
+    return this;
+  };
+  (s as any).prototype.emit = function (this: any, n: string) {
+    (this._events[n] || []).forEach((f: any) => f());
+    return true;
+  };
+  return s;
+}
+const EE = makeEE();
+console.log("[1] proto surface:", typeof EE.prototype.on, typeof EE.prototype.emit);
+// subclass over the ES5 function through a dynamic parent
+const Q: any = class extends EE {
+  constructor() { super(); this.ok = 1; }
+  kick() { return this.emit("x"); }
+};
+const q = new Q();
+let hits = 0;
+q.on("x", () => { hits++; });
+console.log("[2] inherited:", typeof q.on, typeof q.emit, q.kick(), hits);
+// the module class is untouched
+const t = new s();
+console.log("[3] class s intact:", t.tracer(), typeof (s.prototype as any).emit);


### PR DESCRIPTION
## Problem

A derived class **expression** with no own constructor whose parent is a **runtime value** (`class extends <local var> {}` — `extends_expr` set, `extends_name` `None`) silently skipped the entire constructor chain: the instance allocated field-less, with no throw.

Bundlers emit exactly this shape for mysql2's promise mixin — turbopack module `_.exports = class extends Pool { promise() {…} }` — so every pool constructed under a bundled Next.js server lost its constructor state, and requests died far from the fault with `TypeError: Cannot set properties of undefined (setting 'pool')` (myairank.io wall 7).

Repro matrix (all silently wrong before, all byte-identical with node now): anonymous derived over anonymous base, over plain base, via type-erased variable, a turbopack-style lazy factory registry end-to-end, and a three-level no-ctor chain.

## Root cause

Two codegen gates keyed on `extends_name` only:

- **artifacts.rs**: the synthesized standalone ctor fell to the *empty* branch for `extends_expr`-only classes — no forwarding params, no super call — while `synthesized_ctor_param_count` already registered the unresolved-parent forwarding arity (8) for the same class, so registration and emission disagreed.
- **method.rs**: the no-own-ctor super-forwarding block (which already contains the wall-51 dynamic-parent dispatch via `js_fetch_or_value_super`) was never entered without `extends_name`.

## Fixes

- Both gates now include `extends_expr.is_some()`.
- Field-init staging for the no-ctor + dynamic-parent case: `AncestorsOnly` up front + tail `SelfOnly`, so self fields land **after** the synthesized super instead of being applied twice.
- Runtime belt-and-braces: both dynamic-construct ctor replays (`replay_registered_class_constructor`, `replay_class_object_constructor`) walk the parent chain instead of silently returning when the class has no own registered ctor; capture snapshots key off the ctor's **owning** class.

## Testing

`test-files/test_gap_class_expr_dynamic_parent_ctor.ts` — byte-identical with `node --experimental-strip-types`.

https://claude.ai/code/session_01NjymZygYh31wM9h3wLnUqv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed derived-class implicit constructor forwarding so synthesized `super(...)` works correctly for purely dynamic parents (`extends` via runtime values), including no-own-constructor inheritance.
  * Corrected constructor replay to run the nearest ancestor with an owned registered constructor and aligned captured constructor parameters accordingly.
  * Improved `new` resolution to respect local shadowing and refined prototype assignment resolution when names are inferred/static.
* **Tests**
  * Added TypeScript coverage for dynamic-parent ctor inheritance across multi-level hierarchies.
  * Added TypeScript coverage for `new` picking locally shadowed bindings and for prototype writes not polluting unrelated classes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->