### PR TITLE
fix(runtime,compiler): Node-style require resolution for bundled servers + AsyncLocalStorage global seed

### DIFF
--- a/crates/perry-codegen/src/codegen/entry.rs
+++ b/crates/perry-codegen/src/codegen/entry.rs
@@ -502,7 +502,17 @@ pub(super) fn compile_module_entry(
             // those snapshots before node-environment-baseline.js's own
             // assignment — leaving a FakeAsyncLocalStorage that throws
             // Next error E504 on the first request.
-            blk.call_void("js_globalthis_seed_async_local_storage", &[]);
+            //
+            // Emitted ONLY for Next.js-shaped programs (the wall-54
+            // `.next/server/**` path-init list is non-empty). Node itself has
+            // NO `globalThis.AsyncLocalStorage` — Next's baseline assigns it
+            // at runtime — so seeding unconditionally diverges from node for
+            // ordinary programs AND installs the async_hooks surface at every
+            // program's entry (the native-ABI proof workload's write-barrier
+            // budget went 8 → 7921 on exactly that).
+            if !nextjs_path_inits.is_empty() {
+                blk.call_void("js_globalthis_seed_async_local_storage", &[]);
+            }
             for prefix in non_entry_module_prefixes {
                 if cross_module.deferred_module_prefixes.contains(prefix) {
                     continue;

--- a/crates/perry-codegen/src/codegen/entry.rs
+++ b/crates/perry-codegen/src/codegen/entry.rs
@@ -496,6 +496,13 @@ pub(super) fn compile_module_entry(
             // the startup cost. The extern declaration at line ~3947
             // still emits for every non-entry prefix so the dispatch
             // site can resolve the symbol at link time.
+            // Seed `globalThis.AsyncLocalStorage` BEFORE any module init:
+            // Next.js modules (dist and the bundled app-page runtime alike)
+            // snapshot it at module scope, and the eager init order can run
+            // those snapshots before node-environment-baseline.js's own
+            // assignment — leaving a FakeAsyncLocalStorage that throws
+            // Next error E504 on the first request.
+            blk.call_void("js_globalthis_seed_async_local_storage", &[]);
             for prefix in non_entry_module_prefixes {
                 if cross_module.deferred_module_prefixes.contains(prefix) {
                     continue;

--- a/crates/perry-codegen/src/lower_call/native/native_runtime_branch.rs
+++ b/crates/perry-codegen/src/lower_call/native/native_runtime_branch.rs
@@ -77,6 +77,22 @@
                     &[(DOUBLE, &specifier)],
                 ));
             }
+            // require.resolve node_modules subpath fallback.
+            "requireResolveNodeModules" => {
+                let from = args.first().map_or_else(
+                    || Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))),
+                    |arg| lower_expr(ctx, arg),
+                )?;
+                let specifier = args.get(1).map_or_else(
+                    || Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED))),
+                    |arg| lower_expr(ctx, arg),
+                )?;
+                return Ok(ctx.block().call(
+                    DOUBLE,
+                    "js_require_resolve_node_modules",
+                    &[(DOUBLE, &from), (DOUBLE, &specifier)],
+                ));
+            }
             // Next.js wall 54: register an AOT-compiled module by absolute path.
             "registerPathModule" => {
                 let path = args.first().map_or_else(

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -291,6 +291,8 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
     module.declare_function("js_require_object_coercible", DOUBLE, &[DOUBLE]);
     // Next.js wall 53: runtime `require(absolutePath.json)` disk fallback.
     module.declare_function("js_require_json_disk", DOUBLE, &[DOUBLE]);
+    module.declare_function("js_require_resolve_node_modules", DOUBLE, &[DOUBLE, DOUBLE]);
+    module.declare_function("js_globalthis_seed_async_local_storage", VOID, &[]);
     // Next.js wall 54: runtime `require(absolutePath.js)` -> AOT-compiled module.
     module.declare_function("js_register_path_module", VOID, &[DOUBLE, DOUBLE]);
     module.declare_function("js_require_path_module", DOUBLE, &[DOUBLE]);

--- a/crates/perry-hir/src/lower/expr_call/globals.rs
+++ b/crates/perry-hir/src/lower/expr_call/globals.rs
@@ -233,6 +233,27 @@ pub(super) fn try_global_builtins(
                     args: vec![specifier],
                 }));
             }
+            // require.resolve fallback: node_modules subpath probing for
+            // specifiers never statically required (styled-jsx/package.json).
+            "__perry_require_resolve_node_modules" => {
+                let from = if !args.is_empty() {
+                    args.remove(0)
+                } else {
+                    Expr::Undefined
+                };
+                let specifier = if !args.is_empty() {
+                    args.remove(0)
+                } else {
+                    Expr::Undefined
+                };
+                return Ok(Ok(Expr::NativeMethodCall {
+                    module: "__perry_runtime".to_string(),
+                    class_name: None,
+                    object: None,
+                    method: "requireResolveNodeModules".to_string(),
+                    args: vec![from, specifier],
+                }));
+            }
             // Wall 54: register an AOT-compiled module's exports under its
             // absolute source path (emitted at the tail of each CJS wrapper).
             "__perry_register_path_module" => {

--- a/crates/perry-runtime/src/module_require.rs
+++ b/crates/perry-runtime/src/module_require.rs
@@ -329,7 +329,124 @@ pub extern "C" fn js_require_path_module(path_value: f64) -> f64 {
             }
         }
     }
+    // Node directory resolution: `require('<abs dir>')` loads the package's
+    // `main` (else `index.js`). Next's require-hook aliases `styled-jsx` to
+    // the RESOLVED PACKAGE DIRECTORY, so the eventual require arrives here
+    // with a directory path. Map it to the registered file module.
+    let dir = std::path::Path::new(&key);
+    if dir.is_dir() {
+        let mut candidates: Vec<String> = Vec::new();
+        if let Ok(manifest) = std::fs::read_to_string(dir.join("package.json")) {
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&manifest) {
+                if let Some(main) = parsed.get("main").and_then(|m| m.as_str()) {
+                    let main_path = dir.join(main);
+                    candidates.push(main_path.to_string_lossy().into_owned());
+                    if main_path.extension().is_none() {
+                        candidates.push(format!("{}.js", main_path.to_string_lossy()));
+                    }
+                }
+            }
+        }
+        candidates.push(dir.join("index.js").to_string_lossy().into_owned());
+        for cand in candidates {
+            let cand_key = canonicalize_module_path(&cand);
+            let resolved = {
+                let guard = MODULE_PATH_REGISTRY.read().unwrap();
+                guard.as_ref().and_then(|m| m.get(&cand_key).copied())
+            };
+            if let Some(bits) = resolved {
+                return f64::from_bits(bits);
+            }
+            // Deferred module: trigger its init, then re-check.
+            let cand_init = {
+                let guard = MODULE_PATH_INIT_REGISTRY.read().unwrap();
+                guard.as_ref().and_then(|m| m.get(&cand_key).copied())
+            };
+            if let Some(addr) = cand_init {
+                // SAFETY: same contract as the direct-path init above.
+                let init_fn: extern "C" fn() = unsafe { std::mem::transmute::<usize, _>(addr) };
+                init_fn();
+                let guard = MODULE_PATH_REGISTRY.read().unwrap();
+                if let Some(bits) = guard.as_ref().and_then(|m| m.get(&cand_key).copied()) {
+                    return f64::from_bits(bits);
+                }
+            }
+        }
+    }
     undefined()
+}
+
+/// Node-style `require.resolve` fallback for package-subpath specifiers that
+/// were never statically required (e.g. Next's require-hook probing
+/// `resolve('styled-jsx/package.json')`, unguarded before Next 16.2). Walks
+/// `node_modules` directories upward from `from_dir`, trying the exact file,
+/// then `.js`, `.json`, and `/index.js` — returning the absolute path string
+/// or `undefined` for the caller's MODULE_NOT_FOUND path.
+#[no_mangle]
+pub extern "C" fn js_require_resolve_node_modules(from_dir: f64, specifier: f64) -> f64 {
+    let from = value_to_string(from_dir, "from");
+    let spec = value_to_string(specifier, "specifier");
+    if spec.is_empty() || spec.starts_with('.') {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    // Absolute specifier: `require.resolve('<abs>')` returns the resolved FILE
+    // (a directory resolves through package.json `main`, then `index.js`) —
+    // Next's require-hook re-resolves its alias map values, which are package
+    // DIRECTORIES by construction.
+    if spec.starts_with('/') {
+        let base = std::path::PathBuf::from(&spec);
+        let mut candidates: Vec<std::path::PathBuf> = Vec::new();
+        if base.is_file() {
+            candidates.push(base.clone());
+        } else if base.is_dir() {
+            if let Ok(manifest) = std::fs::read_to_string(base.join("package.json")) {
+                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&manifest) {
+                    if let Some(main) = parsed.get("main").and_then(|m| m.as_str()) {
+                        let main_path = base.join(main);
+                        candidates.push(main_path.clone());
+                        if main_path.extension().is_none() {
+                            candidates.push(std::path::PathBuf::from(format!(
+                                "{}.js",
+                                main_path.to_string_lossy()
+                            )));
+                        }
+                    }
+                }
+            }
+            candidates.push(base.join("index.js"));
+        } else {
+            candidates.push(std::path::PathBuf::from(format!("{spec}.js")));
+            candidates.push(std::path::PathBuf::from(format!("{spec}.json")));
+        }
+        for cand in candidates {
+            if cand.is_file() {
+                let text = cand.to_string_lossy();
+                let ptr = js_string_from_bytes(text.as_ptr(), text.len() as u32);
+                return crate::value::js_nanbox_string(ptr as i64);
+            }
+        }
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    let mut dir = std::path::Path::new(&from);
+    loop {
+        let base = dir.join("node_modules").join(&spec);
+        for cand in [
+            base.clone(),
+            base.with_extension("js"),
+            base.with_extension("json"),
+            base.join("index.js"),
+        ] {
+            if cand.is_file() {
+                let text = cand.to_string_lossy();
+                let ptr = js_string_from_bytes(text.as_ptr(), text.len() as u32);
+                return crate::value::js_nanbox_string(ptr as i64);
+            }
+        }
+        match dir.parent() {
+            Some(parent) => dir = parent,
+            None => return f64::from_bits(TAG_UNDEFINED),
+        }
+    }
 }
 
 /// Next.js wall 53: runtime `require(absolutePath)` of a `.json` file.

--- a/crates/perry-runtime/src/object/native_module_registry.rs
+++ b/crates/perry-runtime/src/object/native_module_registry.rs
@@ -148,6 +148,33 @@ pub extern "C" fn js_nm_install_assert() {
         Ordering::Relaxed,
     );
 }
+/// Seed `globalThis.AsyncLocalStorage` with the `async_hooks` constructor
+/// BEFORE any module init runs. Next.js's `node-environment-baseline.js` does
+/// exactly this assignment, but only when its own init runs — and several
+/// Next modules (including the bundled app-page runtime) snapshot
+/// `globalThis.AsyncLocalStorage` at *their* module scope. Perry's eager init
+/// order can run those snapshots first, leaving them with `undefined` and a
+/// FakeAsyncLocalStorage that throws `Invariant: AsyncLocalStorage accessed in
+/// runtime where it is not available` (Next E504) on the first request.
+/// Emitted by codegen at the top of the entry `main`, so the value exists
+/// before ANY module-scope code observes it. (Divergence note: Node itself
+/// does not expose AsyncLocalStorage on globalThis; programs feature-detecting
+/// its absence will see it present under Perry.)
+#[no_mangle]
+pub extern "C" fn js_globalthis_seed_async_local_storage() {
+    let global = crate::object::js_get_global_this();
+    let ctor = crate::object::native_module::bound_native_callable_export_value(
+        "async_hooks",
+        "AsyncLocalStorage",
+    );
+    let key = crate::string::js_string_from_bytes(b"AsyncLocalStorage".as_ptr(), 17);
+    crate::object::js_object_set_field_by_name(
+        crate::value::js_nanbox_get_pointer(global) as *mut crate::object::ObjectHeader,
+        key,
+        ctor,
+    );
+}
+
 #[no_mangle]
 pub extern "C" fn js_nm_install_async_hooks() {
     NM_DISPATCH_REGISTRY[NmBucket::AsyncHooks as usize].store(

--- a/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/wrap.rs
@@ -729,6 +729,15 @@ pub(in crate::commands::compile) fn wrap_commonjs_with_body_offset(
     // written for the in-IIFE position; at module scope (flat) it is purely
     // cosmetic. Embedding `{cjs_preamble}` reproduces the historical IIFE text
     // byte-for-byte.
+    // Debug-quoted absolute dir of this module, the starting point for the
+    // require.resolve node_modules subpath fallback.
+    let module_dir_literal = format!(
+        "{:?}",
+        source_path
+            .parent()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default()
+    );
     let cjs_preamble = format!(
         r#"    // #3527: `module`/`exports` are reassignable `var`s (mirroring Node, where
     // they are wrapper-function parameters), so CJS bodies that do
@@ -832,6 +841,8 @@ pub(in crate::commands::compile) fn wrap_commonjs_with_body_offset(
         if (typeof specifier !== 'string') throw __perry_cjs_require_error('type', 'ERR_INVALID_ARG_TYPE', 'The "request" argument must be of type string.');
 {require_resolve_cases}
         if (__perry_cjs_require_is_builtin(specifier)) return specifier;
+        var __perry_nm_resolved = __perry_require_resolve_node_modules({module_dir_literal}, specifier);
+        if (__perry_nm_resolved !== undefined) return __perry_nm_resolved;
         throw __perry_cjs_require_error('error', 'MODULE_NOT_FOUND', 'Cannot find module ' + specifier);
     }};
     require.resolve.paths = function paths(specifier) {{

--- a/crates/perry/src/commands/compile/run_pipeline.rs
+++ b/crates/perry/src/commands/compile/run_pipeline.rs
@@ -2064,6 +2064,16 @@ pub fn run_with_parse_cache(
                     .iter()
                     .filter(|(p, _)| {
                         self::collect_modules::is_nextjs_runtime_module(p)
+                            // A `perry.compilePackages` module may be reachable
+                            // ONLY through a runtime-computed require (Next's
+                            // require-hook aliases `styled-jsx` to its resolved
+                            // package directory); without a path-init anchor the
+                            // linker dead-strips it and the runtime require dies
+                            // with MODULE_NOT_FOUND even though it was compiled.
+                            || ctx
+                                .compile_package_dirs
+                                .values()
+                                .any(|dir| p.starts_with(dir))
                     })
                     .map(|(p, m)| {
                         (p.to_string_lossy().into_owned(), sanitize_name(&m.name))


### PR DESCRIPTION
## Problem

Four resolution/init walls hit while compiling a real Next.js 16.1.4 standalone server (myairank.io, 44 routes) to a native binary:

1. **`require.resolve` of a bare package subpath** (`styled-jsx/package.json`): Next <16.2 calls this **unguarded** from its styled-jsx require-hook; resolution failure killed boot.
2. **`require()` of a package directory**: mysql2/Next internals require directories that must resolve via `package.json` `"main"` → `index.js`.
3. **`require.resolve` of an absolute path/dir**: Next re-resolves alias values through its `toResolveMap`; absolute specifiers need file → `package.json` main(+`.js`) → `index.js` → `spec.js`/`.json` probing.
4. **Next error E504** (`AsyncLocalStorage accessed in runtime where it is not available`): node-environment-baseline assigns `globalThis.AsyncLocalStorage`, but Next's dist *and* the bundled app-page runtime snapshot `globalThis.AsyncLocalStorage` **at module scope**, and Perry's eager module-init order can run those snapshots first.

## Fixes

- `js_require_resolve_node_modules(from_dir, specifier)`: node_modules walk-up probing exact/`.js`/`.json`/`index.js` for bare subpaths; absolute-path branch for file/dir probing. Wired as the `__perry_require_resolve_node_modules` intrinsic and used by the synthesized CJS wrapper's `require.resolve` before `MODULE_NOT_FOUND`.
- `js_require_path_module`: directory resolution via `package.json` `"main"`(+`.js`) → `index.js`, probing `MODULE_PATH_REGISTRY` then the deferred-init registry (triggering deferred init).
- `run_pipeline`: the Next.js path-init anchor now also covers `compile_package_dirs`, so compile-package modules survive dead-strip as deferred inits.
- `js_globalthis_seed_async_local_storage()`: entry `main` seeds `globalThis.AsyncLocalStorage` (bound `async_hooks` export) **before** the eager `<prefix>__init` loop. Emission order is load-bearing: an earlier placement after the init loop was provably invisible to the module-scope snapshots (verified with in-bundle probes).

With these + #6378 + #6379, the myairank server boots to Ready under Perry and serves its request pipeline.

https://claude.ai/code/session_01NjymZygYh31wM9h3wLnUqv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Node-like `require.resolve` fallback for absolute paths and `node_modules` package resolution.
  - Improved `require(<abs dir>)` directory imports using `package.json` `main` with `index.js` fallback.
  - Seed `globalThis.AsyncLocalStorage` earlier during startup initialization.
- **Bug Fixes**
  - Prevented Next.js-runtime reachable modules from being stripped when initialized via runtime-computed `require` indirection.
  - Fixed CommonJS module resolution for directory and package entrypoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->