### PR TITLE
fix(runtime): honour an own toString override on the ToString coercion path (#6370)

### DIFF
--- a/crates/perry-runtime/src/value/dynamic_arith.rs
+++ b/crates/perry-runtime/src/value/dynamic_arith.rs
@@ -175,8 +175,44 @@ unsafe fn to_primitive_default_for_add(value: f64) -> f64 {
         return crate::value::function_to_primitive_for_add(value);
     }
 
+    // A `RegExpHeader` is NOT an `ObjectHeader` either, and — unlike Buffer /
+    // TypedArray / Date above — it had no guard here at all: `"" + re` fell
+    // through to `ordinary_to_primitive_number_for_add`, which bit-casts `ptr`
+    // to an `ObjectHeader` and reads `valueOf`/`toString` out of garbage field
+    // slots. It came back `undefined`, so `"" + /c/gi` printed "undefined"
+    // instead of "/c/gi" (release builds; the read is UB, and a lower opt level
+    // happened to mask it). Route the regex through the same ToPrimitive steps
+    // the spec prescribes (#6370):
+    //
+    //   OrdinaryToPrimitive(re, "default") = valueOf, then toString.
+    //
+    // `RegExp.prototype` has no `valueOf`, so only an OWN `valueOf` can win the
+    // first step (`re.valueOf = () => "V"; re + ""` → "V"); otherwise the
+    // `toString` step runs, and `js_jsvalue_to_string` performs it — own
+    // override first (data or accessor), else the `/source/flags` literal.
+    // `Symbol.toPrimitive` was already consulted by `js_to_primitive` above.
+    if crate::regex::is_regex_pointer(ptr as *const u8) {
+        if let Some(primitive) = crate::value::to_string::exotic_own_value_of_primitive(
+            ptr,
+            crate::object::exotic_expando::ExoticKind::RegExp,
+            value,
+        ) {
+            return primitive;
+        }
+        let s = crate::value::js_jsvalue_to_string(value);
+        return crate::value::js_nanbox_string(s as i64);
+    }
+
     if crate::date::is_date_cell_addr(ptr) {
-        let s = crate::date::js_date_to_string(value);
+        // `Date.prototype[@@toPrimitive]` maps the "default" hint to "string",
+        // so `"" + date` is OrdinaryToPrimitive(date, "string") — an own
+        // `toString` (data or accessor) shadows `Date.prototype.toString` here
+        // exactly as it does for `String(date)` (#6370). Route through
+        // `js_jsvalue_to_string`, whose date arm now performs that own-property
+        // lookup and otherwise still yields `js_date_to_string`. (An own
+        // `valueOf` correctly does NOT win: the string hint tries `toString`
+        // first and the built-in one already returns a primitive.)
+        let s = crate::value::js_jsvalue_to_string(value);
         return crate::value::js_nanbox_string(s as i64);
     }
 

--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -334,6 +334,151 @@ fn is_primitive_value(value: f64) -> bool {
             && crate::symbol::is_registered_symbol((value.to_bits() & POINTER_MASK) as usize))
 }
 
+/// Result of consulting an exotic instance's OWN `toString` (#6370).
+pub(crate) enum ExoticOwnToString {
+    /// No own `toString` — the caller runs the built-in prototype conversion
+    /// (`RegExp.prototype.toString` → `/source/flags`,
+    /// `Date.prototype.toString` → the full local date string).
+    UseBuiltin,
+    /// An own override produced a primitive; ToString *that* instead.
+    Primitive(f64),
+}
+
+/// `OrdinaryToPrimitive(O, "string")` step 1 for an exotic instance whose own
+/// properties live in the `exotic_expando` side table.
+///
+/// A `RegExpHeader` / `DateCell` is NOT an `ObjectHeader`, so the generic
+/// `ordinary_to_primitive_string` (which resolves `toString` with
+/// `js_object_get_field_by_name`) cannot see their own properties — the regex
+/// and date arms of [`js_jsvalue_to_string`] therefore jumped straight to the
+/// built-in conversion and an own `toString` was silently ignored. That made
+/// the SAME regex stringify two different ways depending on how you asked:
+/// `re.toString()` honoured the override (the method fold, #6358) while
+/// `String(re)` / `` `${re}` `` / `[re].join("")` printed `/source/flags`.
+/// Ordinary `[[Get]]` consults own properties before the prototype chain, so
+/// the override must win on EVERY ToString site (#6370).
+///
+/// Hot-path note: `js_jsvalue_to_string` runs on every string concat, so this
+/// is only ever reached behind the existing `is_date_cell_addr` /
+/// `is_regex_pointer` gates, and `exotic_get_own_property` itself early-outs
+/// before any map lookup while no expando/descriptor has been installed on the
+/// thread. A value that is not a Date/RegExp pays nothing.
+pub(crate) unsafe fn exotic_own_to_string(
+    addr: usize,
+    kind: crate::object::exotic_expando::ExoticKind,
+    receiver: f64,
+) -> ExoticOwnToString {
+    // Bound the recursion exactly as `ordinary_to_primitive_string` does. An
+    // override whose body string-coerces `this`
+    // (`re.toString = function () { return "" + this; }`) re-enters this
+    // helper through `js_jsvalue_to_string` and would recurse until the Rust
+    // stack overflows and SIGSEGVs the process. Node raises
+    // `RangeError: Maximum call stack size exceeded`; Perry's convention in
+    // this file is to cap the depth and fall back to the built-in conversion.
+    let depth = TO_PRIMITIVE_DEPTH.with(|c| c.get());
+    if depth >= 200 {
+        return ExoticOwnToString::UseBuiltin;
+    }
+    TO_PRIMITIVE_DEPTH.with(|c| c.set(depth + 1));
+    let outcome = exotic_own_to_string_inner(addr, kind, receiver);
+    TO_PRIMITIVE_DEPTH.with(|c| c.set(depth));
+    match outcome {
+        ExoticOwnOutcome::UseBuiltin => ExoticOwnToString::UseBuiltin,
+        ExoticOwnOutcome::Primitive(primitive) => ExoticOwnToString::Primitive(primitive),
+        // Thrown out here, AFTER the depth counter is restored.
+        ExoticOwnOutcome::NoPrimitive => throw_cannot_convert_to_primitive(),
+    }
+}
+
+/// Non-throwing core of [`exotic_own_to_string`], so the depth counter can be
+/// restored before the `TypeError` leaves the helper.
+enum ExoticOwnOutcome {
+    UseBuiltin,
+    Primitive(f64),
+    NoPrimitive,
+}
+
+unsafe fn exotic_own_to_string_inner(
+    addr: usize,
+    kind: crate::object::exotic_expando::ExoticKind,
+    receiver: f64,
+) -> ExoticOwnOutcome {
+    // Accessor-aware: the override may be installed as
+    // `Object.defineProperty(re, "toString", { get() {…} })`, which a
+    // data-only expando read cannot see. `exotic_get_own_property` checks
+    // accessor descriptors first (invoking the getter with `receiver` as the
+    // receiver) and falls back to the expando data lookup.
+    let Some(own) =
+        crate::object::exotic_expando::exotic_get_own_property(addr, kind, "toString", receiver)
+    else {
+        return ExoticOwnOutcome::UseBuiltin;
+    };
+    if let Some(primitive) = call_own_method_for_primitive(own, receiver) {
+        return ExoticOwnOutcome::Primitive(primitive);
+    }
+    // An own `toString` that is NOT callable (`re.toString = 5`) or that
+    // returns an object still SHADOWS the built-in — it is never a licence to
+    // fall back to `RegExp.prototype.toString`. OrdinaryToPrimitive continues
+    // with `valueOf`, and only an OWN `valueOf` can yield a primitive here:
+    // the inherited `Object.prototype.valueOf` returns `this`, an object. When
+    // neither yields, ToPrimitive throws — Node agrees
+    // (`re.toString = 5; String(re)` → "TypeError: Cannot convert object to
+    // primitive value").
+    if let Some(own_value_of) =
+        crate::object::exotic_expando::exotic_get_own_property(addr, kind, "valueOf", receiver)
+    {
+        if let Some(primitive) = call_own_method_for_primitive(own_value_of, receiver) {
+            return ExoticOwnOutcome::Primitive(primitive);
+        }
+    }
+    ExoticOwnOutcome::NoPrimitive
+}
+
+/// Invoke `method` with `this = receiver` when it is a callable closure.
+/// `None` means "not callable" — the value is an own property that shadows the
+/// builtin but cannot be called (`re.toString = 5`).
+pub(crate) unsafe fn call_own_method(method: f64, receiver: f64) -> Option<f64> {
+    let bits = method.to_bits();
+    if (bits & TAG_MASK) != POINTER_TAG
+        || !crate::closure::is_closure_ptr((bits & POINTER_MASK) as usize)
+    {
+        return None;
+    }
+    // Rebind `this` to the receiver — an assigned closure may have baked a
+    // different value into its reserved `this` slot (an inherited or bound
+    // method), exactly as the method-dispatch tower does (#1982).
+    let bound = crate::closure::clone_closure_rebind_this(bits, receiver);
+    let prev_this = crate::object::js_implicit_this_set(receiver);
+    let ret = crate::closure::js_native_call_value(f64::from_bits(bound), std::ptr::null(), 0);
+    crate::object::js_implicit_this_set(prev_this);
+    Some(ret)
+}
+
+/// [`call_own_method`], but the result counts only when it is a primitive —
+/// a non-callable value or an object result makes OrdinaryToPrimitive move on
+/// to the next method name.
+unsafe fn call_own_method_for_primitive(method: f64, receiver: f64) -> Option<f64> {
+    call_own_method(method, receiver).filter(|ret| is_primitive_value(*ret))
+}
+
+/// `OrdinaryToPrimitive(O, "default"|"number")` step 1 for an exotic instance:
+/// the `valueOf` step, restricted to the receiver's OWN property.
+///
+/// The "default" hint (`"" + re`) tries `valueOf` BEFORE `toString`, unlike the
+/// "string" hint. `RegExp.prototype` has no `valueOf`, so only an OWN one can
+/// yield a primitive here — the inherited `Object.prototype.valueOf` returns
+/// `this`, an object, and OrdinaryToPrimitive then moves on to `toString`.
+/// `None` therefore means "caller continues with the toString step".
+pub(crate) unsafe fn exotic_own_value_of_primitive(
+    addr: usize,
+    kind: crate::object::exotic_expando::ExoticKind,
+    receiver: f64,
+) -> Option<f64> {
+    let own =
+        crate::object::exotic_expando::exotic_get_own_property(addr, kind, "valueOf", receiver)?;
+    call_own_method_for_primitive(own, receiver)
+}
+
 /// `ToPrimitive(O, "number"|"default")`: consult a user
 /// `[Symbol.toPrimitive]("number")` method first, then fall back to the
 /// ordinary `valueOf`/`toString` order.
@@ -900,6 +1045,21 @@ pub extern "C" fn js_jsvalue_to_string(value: f64) -> *mut crate::string::String
             // before GC-header object dispatch (the 8-byte cell is smaller
             // than an ObjectHeader), after non-GC native buffer handles.
             if crate::date::is_date_cell_addr(ptr as usize) {
+                // #6370: an own `toString` (data or accessor) shadows
+                // `Date.prototype.toString` on every coercion site, exactly as
+                // it already does for the explicit `date.toString()` call.
+                match unsafe {
+                    exotic_own_to_string(
+                        ptr as usize,
+                        crate::object::exotic_expando::ExoticKind::Date,
+                        value,
+                    )
+                } {
+                    ExoticOwnToString::Primitive(primitive) => {
+                        return js_jsvalue_to_string(primitive)
+                    }
+                    ExoticOwnToString::UseBuiltin => {}
+                }
                 return crate::date::js_date_to_string(value);
             }
             // Temporal (#4686): `String(temporal)`, `` `${temporal}` ``, and
@@ -915,6 +1075,24 @@ pub extern "C" fn js_jsvalue_to_string(value: f64) -> *mut crate::string::String
             // A RegExp stringifies to `/source/flags` (RegExp.prototype.toString),
             // not "[object Object]" — covers `String(re)` and `` `${re}` ``.
             if crate::regex::is_regex_pointer(ptr) {
+                // …unless an own `toString` shadows the prototype method
+                // (#6370). This is the SAME lookup the `re.toString()` method
+                // fold performs (#6358); doing it here too is what makes the
+                // two agree, and it reaches every implicit ToString —
+                // `String(re)`, `` `${re}` ``, `[re].join("")`,
+                // `"".concat(re)`, `[re].toString()`.
+                match unsafe {
+                    exotic_own_to_string(
+                        ptr as usize,
+                        crate::object::exotic_expando::ExoticKind::RegExp,
+                        value,
+                    )
+                } {
+                    ExoticOwnToString::Primitive(primitive) => {
+                        return js_jsvalue_to_string(primitive)
+                    }
+                    ExoticOwnToString::UseBuiltin => {}
+                }
                 return crate::regex::js_regexp_to_string(ptr as *const crate::regex::RegExpHeader);
             }
             unsafe {
@@ -1164,16 +1342,21 @@ pub extern "C" fn js_jsvalue_to_string_method(value: f64) -> *mut crate::string:
     // live in the `exotic_expando` side table — a `RegExpHeader` is not an
     // `ObjectHeader` — and the `is_regex_pointer` gate keeps every other
     // receiver on the existing fast path.
+    //
+    // Accessor-aware: the override may be installed via
+    // `Object.defineProperty(re, "toString", { get() {…} })`, which a data-only
+    // `value_lookup` cannot see (it would silently fall back to the
+    // `/source/flags` literal). `exotic_get_own_property` checks accessor
+    // descriptors first, invoking the getter with `value` as the receiver, then
+    // falls back to the same expando data lookup.
+    //
+    // A non-callable own `toString` (`re.toString = 5`) declines here and lands
+    // in `js_jsvalue_to_string` below, whose own-property arm (#6370) reports
+    // the same TypeError the coercion path does.
     #[cfg(feature = "regex-engine")]
     if jsval.is_pointer() {
         let p = jsval.as_pointer::<u8>();
         if crate::regex::is_regex_pointer(p) {
-            // Accessor-aware: the override may be installed via
-            // `Object.defineProperty(re, "toString", { get() {…} })`, which a
-            // data-only `value_lookup` cannot see (it would silently fall back
-            // to the `/source/flags` literal). `exotic_get_own_property` checks
-            // accessor descriptors first, invoking the getter with `value` as
-            // the receiver, then falls back to the same expando data lookup.
             let own = unsafe {
                 crate::object::exotic_expando::exotic_get_own_property(
                     p as usize,
@@ -1181,26 +1364,9 @@ pub extern "C" fn js_jsvalue_to_string_method(value: f64) -> *mut crate::string:
                     "toString",
                     value,
                 )
-            }
-            .map(|v| v.to_bits());
-            if let Some(own_bits) = own {
-                let raw = (own_bits & crate::value::POINTER_MASK) as usize;
-                if (own_bits & crate::value::TAG_MASK) == crate::value::POINTER_TAG
-                    && crate::closure::is_closure_ptr(raw)
-                {
-                    let bound = crate::closure::clone_closure_rebind_this(own_bits, value);
-                    let prev_this =
-                        crate::object::IMPLICIT_THIS.with(|c| c.replace(value.to_bits()));
-                    let result = unsafe {
-                        crate::closure::js_native_call_value(
-                            f64::from_bits(bound),
-                            std::ptr::null(),
-                            0,
-                        )
-                    };
-                    crate::object::IMPLICIT_THIS.with(|c| c.set(prev_this));
-                    return js_jsvalue_to_string(result);
-                }
+            };
+            if let Some(result) = own.and_then(|own| unsafe { call_own_method(own, value) }) {
+                return js_jsvalue_to_string(result);
             }
         }
     }

--- a/test-files/test_gap_6370_tostring_coercion_own_override.ts
+++ b/test-files/test_gap_6370_tostring_coercion_own_override.ts
@@ -1,0 +1,101 @@
+// #6370 — an own `toString` on an exotic instance (RegExp / Date) must win on
+// EVERY ToString site, not just the explicit `x.toString()` call.
+//
+// Ordinary [[Get]] consults the receiver's own properties before the prototype
+// chain, so `String(re)`, `` `${re}` ``, `[re].join("")`, `"".concat(re)` … all
+// have to see an assigned/defined `toString` — data property OR accessor.
+// Before the fix, `re.toString()` honoured the override (#6358) while the
+// ToString coercion path mapped the regex straight back to its `/source/flags`
+// literal, so the same regex stringified two different ways depending on how
+// you asked. Date had the identical split.
+
+function attempt(fn: () => string): string {
+  try {
+    return fn();
+  } catch (e: any) {
+    return "THROW: " + e.message;
+  }
+}
+
+// ── RegExp, own toString as a DATA property ───────────────────────────────
+const r1: any = /a/;
+r1.toString = () => "DATA-toString";
+console.log("re data .toString() :", r1.toString());
+console.log("re data String()    :", String(r1));
+console.log("re data template    :", `${r1}`);
+console.log('re data "" + re     :', "" + r1);
+console.log('re data re + ""     :', r1 + "");
+console.log("re data join        :", [r1].join(""));
+console.log("re data join sep    :", ["x", r1].join("-"));
+console.log("re data arr toString:", [r1].toString());
+console.log("re data concat      :", "".concat(r1));
+
+// ── RegExp, own toString as an ACCESSOR ───────────────────────────────────
+const r2: any = /b/;
+Object.defineProperty(r2, "toString", {
+  get() {
+    return () => "ACC-toString";
+  },
+  configurable: true,
+});
+console.log("re acc  .toString() :", r2.toString());
+console.log("re acc  String()    :", String(r2));
+console.log("re acc  template    :", `${r2}`);
+console.log('re acc  "" + re     :', "" + r2);
+
+// ── RegExp with NO override still renders /source/flags everywhere ────────
+const r3 = /c/gi;
+console.log("re none String()    :", String(r3));
+console.log("re none template    :", `${r3}`);
+console.log('re none "" + re     :', "" + r3);
+console.log("re none .toString() :", r3.toString());
+console.log("re none join        :", [r3].join(""));
+
+// ── A non-callable own toString SHADOWS the builtin: ToPrimitive throws ───
+const r4: any = /d/;
+r4.toString = 5;
+console.log("re bad  String()    :", attempt(() => String(r4)));
+
+// ── Hint matters: an own valueOf wins for "default", toString for "string" ─
+const r5: any = /e/;
+r5.valueOf = () => "VALUEOF";
+console.log("re vOf  String()    :", String(r5));
+console.log("re vOf  template    :", `${r5}`);
+console.log('re vOf  re + ""     :', r5 + "");
+
+// ── Symbol.toPrimitive takes precedence over toString on the coercion path ─
+const r6: any = /f/;
+r6[Symbol.toPrimitive] = (hint: string) => "SYMPRIM-" + hint;
+console.log("re sym  String()    :", String(r6));
+console.log("re sym  template    :", `${r6}`);
+
+// ── Date: same own-property shadowing on the coercion path ────────────────
+const d1: any = new Date(0);
+d1.toString = () => "DATE-DATA";
+console.log("date data .toString():", d1.toString());
+console.log("date data String()   :", String(d1));
+console.log("date data template   :", `${d1}`);
+console.log('date data "" + d     :', "" + d1);
+
+const d2: any = new Date(0);
+Object.defineProperty(d2, "toString", {
+  get() {
+    return () => "DATE-ACC";
+  },
+  configurable: true,
+});
+console.log("date acc  String()   :", String(d2));
+console.log("date acc  template   :", `${d2}`);
+
+// A Date with no override still renders the built-in date string (kept
+// timezone-independent so the fixture is stable everywhere).
+const d3 = new Date(0);
+console.log("date none builtin    :", String(d3) === d3.toString(), String(d3).includes("1970"));
+
+// ── Error already honoured own overrides on both paths — regression guard ──
+const e1: any = new Error("boom");
+e1.toString = () => "ERR-DATA";
+console.log("err data String()    :", String(e1));
+console.log("err data template    :", `${e1}`);
+const e2 = new TypeError("bad");
+console.log("err none String()    :", String(e2));


### PR DESCRIPTION
Fixes #6370.

## The bug

`String(re)` and `` `${re}` `` ignored an own `toString` override on a RegExp — both the data and the accessor form. Only the explicit `re.toString()` call honoured it, so the same regex stringified two different ways depending on how you asked:

```ts
const r: any = /a/;
r.toString = () => "DATA-toString";
r.toString()   // DATA-toString   (correct)
String(r)      // /a/             <-- was wrong
`${r}`         // /a/             <-- was wrong
[r].join("")   // /a/             <-- was wrong
```

## Root cause

Two distinct paths, and only one of them consulted own properties.

* **The `.toString()` fold** — `js_jsvalue_to_string_method`. Codegen rewrites every `x.toString()` straight into it, bypassing method dispatch. #6358 taught it to consult the receiver's own `toString` via `exotic_expando::exotic_get_own_property` (accessor-aware).
* **The ToString coercion path** — `js_jsvalue_to_string`, reached from `String(x)`, template literals, `Array.prototype.join`, `String.prototype.concat`, ToPropertyKey, the default sort comparator, and every other implicit ToString. Its RegExp arm mapped the receiver straight back to its `/source/flags` literal and **never consulted own properties at all**.

A `RegExpHeader` is not an `ObjectHeader`, so the generic `ordinary_to_primitive_string` (which resolves `toString` through `js_object_get_field_by_name`) cannot see a regex's own props — and the regex arm returned long before reaching it anyway. **Date had the identical split**: `date.toString()` honoured an override, `String(date)` did not.

## The fix

`exotic_own_to_string()` (`crates/perry-runtime/src/value/to_string.rs`) implements `OrdinaryToPrimitive(O, "string")` restricted to the receiver's own `toString`/`valueOf`, for the exotics whose own properties live in the `exotic_expando` side table. The RegExp and Date arms of `js_jsvalue_to_string` consult it before falling back to the built-in conversion.

It reuses `exotic_get_own_property`, so an **accessor** override (`Object.defineProperty(re, "toString", { get() {…} })`) is honoured as well as a data one. A non-callable own `toString` (`re.toString = 5`) still *shadows* the builtin: OrdinaryToPrimitive continues with an own `valueOf` and otherwise throws `TypeError: Cannot convert object to primitive value` — matching Node, where Perry previously printed `/d/`.

The method fold's own-property block now shares the same invoke helper instead of open-coding a second copy of the lookup — the divergence between the two copies *was* the bug.

Two things surfaced while validating, both fixed here because the issue lists the sites explicitly:

* **`"" + re` / `re + ""` were broken on `main` independently of any override** — they printed `"undefined"`, *including for a plain `/c/gi` with no own properties at all*. `to_primitive_default_for_add` (`dynamic_arith.rs`) guards Proxy / Buffer / TypedArray / closures / Date / URL before falling through to `ordinary_to_primitive_number_for_add`, which does `ptr as *mut ObjectHeader` and reads `valueOf`/`toString` out of field slots — but it had **no RegExp guard**, so a `RegExpHeader` got bit-cast and the garbage read yielded `undefined`. The read is UB, hence optimization-sensitive: a `perry-dev` runtime returns the right answer and only `--release` shows it, which is why it hid for so long. This PR adds the missing guard, implementing the *default* hint properly (`valueOf` then `toString`, so `re.valueOf = () => "V"; re + ""` → `"V"`, while `String(re)` still uses the string hint). Verified on a pristine `origin/main` release build first — see "Not introduced here" below.
* **A self-coercing override SIGSEGV'd.** `re.toString = function () { return "" + this; }` recursed through the new own-property call until the Rust stack overflowed. `ordinary_to_primitive_string` already guards this with `TO_PRIMITIVE_DEPTH`; `exotic_own_to_string` now shares that cap (and restores the counter before the TypeError leaves the helper).

### Coercion sites verified byte-for-byte against `node --experimental-strip-types`

`String(x)`, `` `${x}` ``, `"" + x`, `x + ""`, `s += x`, `[x].join("")`, `["a", x].join("-")`, `[x].toString()`, `"".concat(x)`, `"".padEnd(3, x)`, `o[x] = 1` / `{ [x]: 1 }` (ToPropertyKey), `[x, "a"].sort()` — for RegExp **and** Date, with data overrides, accessor overrides, and no override.

`console.log(re)` is deliberately left alone: node's inspect prints `/g/ { toString: [Function (anonymous)] }`, which is not ToString.

## Other exotics + `Symbol.toPrimitive` (asked in the issue)

* **Error** — already correct on every path (own data override, accessor override, `Symbol.toPrimitive`). An `ErrorHeader` reaches the generic `ordinary_to_primitive_string`, whose `js_object_get_field_by_name` already consults the exotic side table. Kept as a regression guard in the fixture.
* **Map / Set / Promise** — own `toString` overrides already honoured on all paths. They do expose an unrelated gap: `String(new Map())` → `"[object Object]"` where node says `"[object Map]"` (the ToString fallback ignores `Symbol.toStringTag`). Filed as **#6374**.
* **`Symbol.toPrimitive`** — already honoured on the coercion path, and it correctly takes precedence over an own `toString`. But it *also* wrongly hijacks an explicit `re.toString()` call (node: `/y/`; perry: the `@@toPrimitive` result), because the codegen fold falls through into the coercion helper and inherits its ToPrimitive pre-step. Pre-existing, orthogonal mechanism — filed as **#6373**.
* **The `+` guard gap is wider than RegExp**: `"" + err` → `"undefined"` and `"" + [1,2,3]` → `"undefined"` on release, same missing-guard/bit-cast root cause (`ArrayHeader` / `ErrorHeader`). Filed as **#6381** with the fix shape; left out of this PR to keep the diff scoped. (`test_gap_string_coercion_tostring`'s triaged `array: undefined` failure is that bug.)

## Not introduced here

`"" + re` → `"undefined"` was verified on a **pristine `origin/main` release toolchain** before the guard was added — with no override in play, so no code in this PR can reach it:

```
A module+typed  : undefined      # node: /c/gi
B module+any    : undefined
C fn+typed      : undefined
D fn+any        : undefined
```

## Performance

`js_jsvalue_to_string` is on the string-concat hot path, so the new lookup sits *inside* the pre-existing `is_regex_pointer` / `is_date_cell_addr` gates — a string, number, or plain-object concat reaches no new code. `exotic_get_own_property` additionally early-outs before any map lookup while no expando/descriptor has been installed on the thread.

String-concat microbench (800k `"x" + i + "-" + bool` concats + 200k template literals over object/array operands), release builds, run **interleaved** A/B ×10 to cancel machine-load drift:

| | min | mean |
|---|---|---|
| pristine `main` | 4404 ms | 4666 ms |
| this PR | 4482 ms | 4639 ms |
| delta | +1.8% | **−0.6%** |

Run-to-run spread (±10%) is larger than the delta in both directions — no measurable regression.

## Validation

* **Full gap suite A/B against a pristine `origin/main` toolchain (release, same host, same config): zero regressions.** Baseline 22 parity failures → 21 with this PR; the set difference is exactly `test_gap_6370_*` flipping FAIL → PASS. Parity rate 92.6% → 93.0%. (Baseline also showed one compile failure, `test_gap_zlib_fs_assert_*`, which was a disk-full artifact of that run and does not reproduce.)
* **The fixture fails without the fix** — `test_gap_6370_tostring_coercion_own_override` is in the pristine-main failure list and passes here.
* `test_issue_5897_regexp_own_props_and_utf16.ts` (the #6358 fixture) still matches node — the `.toString()` fold is not regressed.
* `cargo fmt --all -- --check` and `scripts/check_file_size.sh` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Date and RegExp values now consistently honor own `toString` overrides during string conversion.
  - Accessor-based and non-callable overrides now follow expected coercion and error behavior.
  - Improved handling of `Date` and `RegExp` in concatenation, templates, arrays, and `String()` conversion.
  - Preserved correct precedence for custom primitive conversion and `valueOf`.
  - Improved compatibility with standard JavaScript and Node.js coercion behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->