### PR TITLE
fix(windows): unbreak Windows-host cross-links and the Android default output (#5740, #6333)

### DIFF
--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -38,6 +38,7 @@ mod lock_scan;
 mod lowering_report;
 mod object_cache;
 mod optimized_libs;
+mod output_path;
 mod parse_cache;
 mod post_link;
 mod precompile_capture;

--- a/crates/perry/src/commands/compile/build_cache.rs
+++ b/crates/perry/src/commands/compile/build_cache.rs
@@ -519,15 +519,16 @@ fn default_output_path(args: &CompileArgs) -> PathBuf {
         .and_then(|s| s.to_str())
         .unwrap_or("output");
     let stem = crate::commands::sanitize::sanitize_for_linker_argv(raw_stem);
-    if matches!(
+    // Same helper the compile pipeline links with (#5740) — the cache
+    // fingerprints the output file, so a divergence here means it stats a path
+    // the build never wrote (Android used to land on the bare stem `app` while
+    // the link produced `libapp.so`).
+    super::output_path::default_output_path(
+        args.output_type == "dylib",
+        args.output_type == "staticlib",
         args.target.as_deref(),
-        Some("windows") | Some("windows-winui")
-    ) || (args.target.is_none() && cfg!(target_os = "windows"))
-    {
-        PathBuf::from(format!("{stem}.exe"))
-    } else {
-        PathBuf::from(stem)
-    }
+        &stem,
+    )
 }
 
 fn current_env() -> Vec<EnvFingerprint> {

--- a/crates/perry/src/commands/compile/link/build_and_run.rs
+++ b/crates/perry/src/commands/compile/link/build_and_run.rs
@@ -861,24 +861,11 @@ pub(crate) fn build_and_run_link(
         )
         .ok();
         let ndk_home = std::env::var("ANDROID_NDK_HOME").unwrap_or_default();
-        // #1508: see platform_cmd.rs — same host-tag bug.
-        let host_tag = if cfg!(target_os = "macos") {
-            "darwin-x86_64"
-        } else if cfg!(target_os = "windows") {
-            "windows-x86_64"
-        } else {
-            "linux-x86_64"
-        };
-        let ndk_clang = format!(
-            "{}/toolchains/llvm/prebuilt/{}/bin/aarch64-linux-android24-clang{}",
-            ndk_home,
-            host_tag,
-            if cfg!(target_os = "windows") {
-                ".cmd"
-            } else {
-                ""
-            }
-        );
+        // #1508 (host toolchain tag) + #5740 (no `.cmd` wrapper on Windows —
+        // this stub compile hit the same defect as the link driver, and a failed
+        // spawn here is silent: `stub_ok` goes false and the link then dies on an
+        // undefined `JNI_GetCreatedJavaVMs`). `-target` is passed below.
+        let ndk_clang = ndk_clang_path(&ndk_home);
         let stub_ok = Command::new(&ndk_clang)
             .args(["-c", "-fPIC", "-target", "aarch64-linux-android24"])
             .arg("-o")

--- a/crates/perry/src/commands/compile/link/mod.rs
+++ b/crates/perry/src/commands/compile/link/mod.rs
@@ -392,15 +392,34 @@ fn resolve_optional_framework_dir(env_name: &str, args_input: &Path) -> Option<P
 /// Quote one linker argument for a response file. `msvc` selects `link.exe` /
 /// `lld-link` rules (a `"` toggles a quoted run; backslashes are literal Windows
 /// path separators, so they are NOT escaped — only an embedded `"` is escaped as
-/// `\"`); otherwise GNU/clang rules (inside double quotes `\` and `"` escape, so
-/// both are backslash-escaped). An argument with no whitespace/quote needs no
-/// quoting in either dialect — the common case (long object/lib paths).
+/// `\"`); otherwise GNU/clang rules (`\` and `"` escape the next character, both
+/// inside and outside double quotes, so both are backslash-escaped). An argument
+/// with no whitespace/quote and no backslash needs no quoting in either dialect —
+/// the common case (long object/lib paths).
 pub(super) fn quote_response_arg(arg: &str, msvc: bool) -> String {
     let needs_quote = arg.is_empty()
         || arg
             .bytes()
             .any(|b| matches!(b, b' ' | b'\t' | b'\n' | b'\r' | b'"'));
     if !needs_quote {
+        // #5740 / #6333 — GNU-style tokenizers (clang, gcc, ld: everything
+        // reached through a non-MSVC driver) treat `\` as an escape character
+        // *outside* quotes too, not just inside them. A plain Windows object
+        // path has no spaces, so it took this early return verbatim and the
+        // driver ate every separator: `C:\Users\me\AppData\...\app_ts.o` came
+        // back out of the tokenizer as `C:UsersmeAppData...app_ts.o` ("it seems
+        // the dir replace the \ split"). This bites the Windows-host →
+        // Android/HarmonyOS/Linux cross-links, which use the NDK/SDK clang
+        // driver (GNU rules) while the response-file path itself is taken on
+        // every Windows host.
+        //
+        // Escape rather than rewrite to `/`: doubling the backslash round-trips
+        // the argument byte-for-byte through the tokenizer on *any* host, so a
+        // POSIX file whose name legitimately contains a backslash still links
+        // (a blanket `\` → `/` substitution would corrupt it).
+        if !msvc && arg.contains('\\') {
+            return arg.replace('\\', "\\\\");
+        }
         return arg.to_string();
     }
     let mut out = String::with_capacity(arg.len() + 2);
@@ -428,6 +447,59 @@ pub(super) fn response_file_contents(args: &[String], msvc: bool) -> String {
     s
 }
 
+/// Path to the Android NDK's `clang` driver for the current build host.
+///
+/// #1508 — the host tag names the *build* machine's prebuilt toolchain, not the
+/// target; a Windows host used to fall through to `linux-x86_64` and point at a
+/// path the NDK doesn't ship.
+///
+/// #5740 — this drives `clang` itself rather than the NDK's per-target wrapper
+/// (`aarch64-linux-android24-clang`), which is a two-line shim that execs
+/// `clang --target=aarch64-linux-android24 "$@"`. Every caller here already
+/// passes `-target aarch64-linux-android24` explicitly, so the two are
+/// equivalent — except on Windows, where the wrapper is a `.cmd` batch file:
+/// Rust's `Command` can only spawn a batch file through `cmd.exe`, which layers
+/// a second round of command-line quoting (plus the batch-escaping restrictions
+/// from the CVE-2024-24576 fix) over an already-long link line.
+pub(super) fn ndk_clang_path(ndk_home: &str) -> String {
+    let host_tag = if cfg!(target_os = "macos") {
+        "darwin-x86_64"
+    } else if cfg!(target_os = "windows") {
+        "windows-x86_64"
+    } else {
+        "linux-x86_64"
+    };
+    format!(
+        "{}/toolchains/llvm/prebuilt/{}/bin/clang{}",
+        ndk_home,
+        host_tag,
+        if cfg!(target_os = "windows") {
+            ".exe"
+        } else {
+            ""
+        }
+    )
+}
+
+/// Render the `@<file>` argument that points the linker at the response file.
+///
+/// This one is passed on the *command line*, so it is not subject to the
+/// response-file tokenizer — but on a Windows host it may still travel through
+/// a `cmd.exe`-mediated driver wrapper (the NDK ships `.cmd` shims, and Rust
+/// spawns those via `cmd.exe`). Every non-MSVC driver we hand it to (clang,
+/// gcc, ld) accepts `/` as a path separator on Windows, so normalizing the
+/// separators there sidesteps that whole layer of quoting (#5740).
+///
+/// `windows_host` gates the rewrite: on POSIX a backslash is a legal filename
+/// character, so the path is passed through untouched.
+pub(super) fn response_file_arg(rsp_display: &str, msvc: bool, windows_host: bool) -> String {
+    if !msvc && windows_host {
+        format!("@{}", rsp_display.replace('\\', "/"))
+    } else {
+        format!("@{}", rsp_display)
+    }
+}
+
 /// Rewrite a linker invocation to pass its arguments via a response file
 /// (`<linker> @<file>`) instead of inline, dodging the Windows `CreateProcess`
 /// command-line length cap (os error 206) on links with many object files.
@@ -449,7 +521,11 @@ fn rewrite_link_with_response_file(cmd: &Command, msvc: bool) -> Option<(Command
     fs::write(&rsp, contents).ok()?;
 
     let mut new_cmd = Command::new(cmd.get_program());
-    new_cmd.arg(format!("@{}", rsp.display()));
+    new_cmd.arg(response_file_arg(
+        &rsp.display().to_string(),
+        msvc,
+        cfg!(target_os = "windows"),
+    ));
     // Preserve env overrides (e.g. MSVC LIB/PATH set by select_linker_command)
     // and the working directory the original command was configured with.
     for (key, val) in cmd.get_envs() {
@@ -473,7 +549,7 @@ mod optional_framework_dir_tests;
 
 #[cfg(test)]
 mod response_file_tests {
-    use super::{quote_response_arg, response_file_contents};
+    use super::{quote_response_arg, response_file_arg, response_file_contents};
 
     #[test]
     fn plain_paths_are_unquoted_in_both_dialects() {
@@ -484,6 +560,60 @@ mod response_file_tests {
         );
         // /OPT:REF etc. — no whitespace, untouched.
         assert_eq!(quote_response_arg("/OPT:REF", true), "/OPT:REF");
+    }
+
+    /// #5740 / #6333 — the regression this PR fixes. A Windows object path has
+    /// no spaces, so it used to take the "no quoting needed" early return
+    /// verbatim; the GNU tokenizer in clang/gcc/ld then consumed each `\` as an
+    /// escape and the path collapsed to `C:Usersme...`. Every separator must
+    /// come out the other side, so each one is doubled.
+    #[test]
+    fn gnu_escapes_backslashes_in_unquoted_windows_paths() {
+        assert_eq!(
+            quote_response_arg(r"C:\Users\me\AppData\Local\Temp\app_ts.o", false),
+            r"C:\\Users\\me\\AppData\\Local\\Temp\\app_ts.o"
+        );
+        // Same for flags that embed a path (`-Wl,-rpath,C:\lib`).
+        assert_eq!(
+            quote_response_arg(r"-Wl,--out-implib,C:\build\app.lib", false),
+            r"-Wl,--out-implib,C:\\build\\app.lib"
+        );
+        // MSVC keeps backslashes literal — link.exe/lld-link do not escape.
+        assert_eq!(
+            quote_response_arg(r"C:\Users\me\app_ts.o", true),
+            r"C:\Users\me\app_ts.o"
+        );
+        // Unix paths have no backslash to escape: byte-identical passthrough.
+        assert_eq!(
+            quote_response_arg("/tmp/perry/app_ts.o", false),
+            "/tmp/perry/app_ts.o"
+        );
+    }
+
+    /// The `@<file>` arg rides the command line, not the response file. On a
+    /// Windows host with a non-MSVC driver it is normalized to `/` separators
+    /// (clang/gcc accept them, and it survives any `cmd.exe` wrapper); on POSIX
+    /// a backslash is a legal filename character and must survive untouched.
+    #[test]
+    fn response_file_arg_normalizes_only_on_windows_host_gnu_driver() {
+        assert_eq!(
+            response_file_arg(r"C:\Temp\perry-link-1.rsp", false, true),
+            "@C:/Temp/perry-link-1.rsp"
+        );
+        // MSVC driver on Windows: backslashes are the native separator.
+        assert_eq!(
+            response_file_arg(r"C:\Temp\perry-link-1.rsp", true, true),
+            r"@C:\Temp\perry-link-1.rsp"
+        );
+        // POSIX host: never rewrite (a `\` here is part of the filename).
+        assert_eq!(
+            response_file_arg(r"/tmp/we\ird/perry-link-1.rsp", false, false),
+            r"@/tmp/we\ird/perry-link-1.rsp"
+        );
+        assert_eq!(
+            response_file_arg("/tmp/perry-link-1.rsp", false, false),
+            "@/tmp/perry-link-1.rsp"
+        );
     }
 
     #[test]
@@ -508,6 +638,28 @@ mod response_file_tests {
     fn embedded_quote_is_escaped() {
         assert_eq!(quote_response_arg("a\"b", true), "\"a\\\"b\"");
         assert_eq!(quote_response_arg("a\"b", false), "\"a\\\"b\"");
+    }
+
+    /// #5740 — the Android link and the JNI-stub compile must both drive the
+    /// NDK's `clang` driver, never the per-target wrapper: on Windows that
+    /// wrapper is a `.cmd` batch file, which Rust can only spawn through
+    /// `cmd.exe`. (The `--target` the wrapper would have added is passed
+    /// explicitly by both call sites.)
+    #[test]
+    fn ndk_clang_path_bypasses_the_per_target_wrapper() {
+        let p = super::ndk_clang_path("/ndk");
+        assert!(!p.contains("aarch64-linux-android24-clang"), "{p}");
+        assert!(!p.ends_with(".cmd"), "{p}");
+        assert!(p.starts_with("/ndk/toolchains/llvm/prebuilt/"), "{p}");
+        #[cfg(target_os = "macos")]
+        assert_eq!(p, "/ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang");
+        #[cfg(target_os = "windows")]
+        assert_eq!(
+            p,
+            "/ndk/toolchains/llvm/prebuilt/windows-x86_64/bin/clang.exe"
+        );
+        #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+        assert_eq!(p, "/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/clang");
     }
 
     #[test]

--- a/crates/perry/src/commands/compile/link/platform_cmd.rs
+++ b/crates/perry/src/commands/compile/link/platform_cmd.rs
@@ -588,27 +588,11 @@ pub fn select_linker_command(
                  %LOCALAPPDATA%\\Android\\Sdk\\ndk\\28.0.12433566 (Windows)"
             )
         })?;
-        // #1508: Windows host falls through to "linux-x86_64" and points at
-        // a path that doesn't exist on the NDK. The NDK ships per-host
-        // prebuilt toolchains under `toolchains/llvm/prebuilt/<host>/`;
-        // the host tag must match the build machine, not the target.
-        let host_tag = if cfg!(target_os = "macos") {
-            "darwin-x86_64"
-        } else if cfg!(target_os = "windows") {
-            "windows-x86_64"
-        } else {
-            "linux-x86_64"
-        };
-        let clang = format!(
-            "{}/toolchains/llvm/prebuilt/{}/bin/aarch64-linux-android24-clang{}",
-            ndk_home,
-            host_tag,
-            if cfg!(target_os = "windows") {
-                ".cmd"
-            } else {
-                ""
-            }
-        );
+        // #1508 (per-host toolchain tag) + #5740 (drive `clang` directly rather
+        // than the NDK's `.cmd`/shell wrapper) — see `ndk_clang_path`. The
+        // `-target aarch64-linux-android24` below is what the wrapper would have
+        // added, so nothing else changes.
+        let clang = ndk_clang_path(&ndk_home);
         if !PathBuf::from(&clang).exists() {
             return Err(anyhow!("Android NDK clang not found at: {}", clang));
         }

--- a/crates/perry/src/commands/compile/output_path.rs
+++ b/crates/perry/src/commands/compile/output_path.rs
@@ -1,0 +1,142 @@
+//! The default output path for a compile — the file `perry app.ts` writes when
+//! the user gave no `-o`.
+//!
+//! One source of truth, shared by the compile pipeline (`run_pipeline`, which
+//! links to this path) and the build cache (`build_cache`, which fingerprints
+//! it to decide whether a rebuild is needed). These used to be two independent
+//! `default_output_path` functions that had already drifted apart; keeping them
+//! in one place is what makes the Android arm below correct in both.
+
+use std::path::PathBuf;
+
+/// The output file a compile targets when no `-o` was given.
+///
+/// `stem` is the already-sanitized entry-file stem (`app.ts` → `app`).
+pub(super) fn default_output_path(
+    is_dylib: bool,
+    is_staticlib: bool,
+    target: Option<&str>,
+    stem: &str,
+) -> PathBuf {
+    if is_dylib {
+        #[cfg(target_os = "macos")]
+        {
+            PathBuf::from(format!("{}.dylib", stem))
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            PathBuf::from(format!("{}.so", stem))
+        }
+    } else if is_staticlib {
+        // #1088 — Windows hosts expect `.lib`; everywhere else uses
+        // the Unix `lib<stem>.a` convention so the archive is reachable
+        // from `-l<stem>` at the host's link step.
+        if is_windows_target(target) {
+            PathBuf::from(format!("{}.lib", stem))
+        } else {
+            PathBuf::from(format!("lib{}.a", stem))
+        }
+    } else if matches!(
+        target,
+        Some("harmonyos")
+            | Some("harmonyos-simulator")
+            // #5740 — Android (and Wear OS, which links identically: same NDK,
+            // same triple, same cdylib shape) links with `-shared` and ships as
+            // a `.so` that `PerryActivity` dlopens; there is no standalone
+            // executable shipping shape. Without this arm the default output was
+            // the bare stem (`app`), which fails the link outright in a stock
+            // Android project — `app/` is already a directory there, so lld
+            // reports `cannot open output file app: Is a directory`.
+            | Some("android")
+            | Some("wearos")
+    ) {
+        // HarmonyOS apps ship as .so loaded by the ArkTS runtime via
+        // napi_module_register — there is no standalone executable
+        // shipping shape. `lib` prefix matches the dlopen name used by
+        // the generated ArkTS shim (`import entry from 'libapp.so'`),
+        // and the Android/Wear OS jniLibs copy expects a `.so` too.
+        PathBuf::from(format!("lib{}.so", stem))
+    } else if is_windows_target(target) {
+        PathBuf::from(format!("{}.exe", stem))
+    } else {
+        PathBuf::from(stem)
+    }
+}
+
+/// `--target windows*`, or a native build on a Windows host.
+fn is_windows_target(target: Option<&str>) -> bool {
+    matches!(target, Some("windows") | Some("windows-winui"))
+        || (target.is_none() && cfg!(target_os = "windows"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::default_output_path;
+    use std::path::PathBuf;
+
+    fn exe(target: Option<&str>, stem: &str) -> PathBuf {
+        default_output_path(false, false, target, stem)
+    }
+
+    /// #5740 bug 4 — `--target android` used to fall through to the bare stem,
+    /// so the link ran with `-o app` inside an Android project where `app/` is
+    /// a directory: `ld.lld: cannot open output file app: Is a directory`.
+    #[test]
+    fn android_defaults_to_shared_library() {
+        assert_eq!(exe(Some("android"), "app"), PathBuf::from("libapp.so"));
+        assert_eq!(exe(Some("android"), "hello"), PathBuf::from("libhello.so"));
+    }
+
+    /// Wear OS links exactly like Android (same NDK, triple, cdylib + TLS
+    /// model — see `link::build_and_run`'s `is_android`), so it needs the
+    /// same default.
+    #[test]
+    fn wearos_defaults_to_shared_library() {
+        assert_eq!(exe(Some("wearos"), "app"), PathBuf::from("libapp.so"));
+    }
+
+    #[test]
+    fn harmonyos_still_defaults_to_shared_library() {
+        assert_eq!(exe(Some("harmonyos"), "app"), PathBuf::from("libapp.so"));
+        assert_eq!(
+            exe(Some("harmonyos-simulator"), "app"),
+            PathBuf::from("libapp.so")
+        );
+    }
+
+    #[test]
+    fn windows_target_defaults_to_exe() {
+        assert_eq!(exe(Some("windows"), "app"), PathBuf::from("app.exe"));
+        assert_eq!(exe(Some("windows-winui"), "app"), PathBuf::from("app.exe"));
+    }
+
+    /// The unix/native executable shape must stay a bare, extension-less name.
+    #[test]
+    fn unix_targets_default_to_bare_stem() {
+        assert_eq!(exe(Some("linux"), "app"), PathBuf::from("app"));
+        assert_eq!(exe(Some("macos"), "app"), PathBuf::from("app"));
+        #[cfg(not(target_os = "windows"))]
+        assert_eq!(exe(None, "app"), PathBuf::from("app"));
+    }
+
+    #[test]
+    fn staticlib_keeps_its_conventions() {
+        assert_eq!(
+            default_output_path(false, true, Some("linux"), "app"),
+            PathBuf::from("libapp.a")
+        );
+        assert_eq!(
+            default_output_path(false, true, Some("windows"), "app"),
+            PathBuf::from("app.lib")
+        );
+    }
+
+    #[test]
+    fn dylib_uses_the_host_shared_library_extension() {
+        let out = default_output_path(true, false, None, "app");
+        #[cfg(target_os = "macos")]
+        assert_eq!(out, PathBuf::from("app.dylib"));
+        #[cfg(not(target_os = "macos"))]
+        assert_eq!(out, PathBuf::from("app.so"));
+    }
+}

--- a/crates/perry/src/commands/compile/run_pipeline.rs
+++ b/crates/perry/src/commands/compile/run_pipeline.rs
@@ -4722,51 +4722,11 @@ pub fn run_with_parse_cache(
                 p
             }
         }
-        None => default_output_path(is_dylib, is_staticlib, target.as_deref(), stem),
+        // The default output path when no `-o` is given. Lives in
+        // `compile/output_path.rs` so the build cache fingerprints the same
+        // file this link is about to write (#5740).
+        None => output_path::default_output_path(is_dylib, is_staticlib, target.as_deref(), stem),
     };
-
-    // The default output path when no `-o` is given. Extracted to a free fn so
-    // the `-o`-provided extension-defaulting above stays readable.
-    fn default_output_path(
-        is_dylib: bool,
-        is_staticlib: bool,
-        target: Option<&str>,
-        stem: &str,
-    ) -> PathBuf {
-        if is_dylib {
-            #[cfg(target_os = "macos")]
-            {
-                PathBuf::from(format!("{}.dylib", stem))
-            }
-            #[cfg(not(target_os = "macos"))]
-            {
-                PathBuf::from(format!("{}.so", stem))
-            }
-        } else if is_staticlib {
-            // #1088 — Windows hosts expect `.lib`; everywhere else uses
-            // the Unix `lib<stem>.a` convention so the archive is reachable
-            // from `-l<stem>` at the host's link step.
-            if matches!(target, Some("windows") | Some("windows-winui"))
-                || (target.is_none() && cfg!(target_os = "windows"))
-            {
-                PathBuf::from(format!("{}.lib", stem))
-            } else {
-                PathBuf::from(format!("lib{}.a", stem))
-            }
-        } else if matches!(target, Some("harmonyos") | Some("harmonyos-simulator")) {
-            // HarmonyOS apps ship as .so loaded by the ArkTS runtime via
-            // napi_module_register — there is no standalone executable
-            // shipping shape. `lib` prefix matches the dlopen name used by
-            // the generated ArkTS shim (`import entry from 'libapp.so'`).
-            PathBuf::from(format!("lib{}.so", stem))
-        } else if matches!(target, Some("windows") | Some("windows-winui"))
-            || (target.is_none() && cfg!(target_os = "windows"))
-        {
-            PathBuf::from(format!("{}.exe", stem))
-        } else {
-            PathBuf::from(stem)
-        }
-    }
 
     if !failed_modules.is_empty() {
         // The loud failure summary + abort already ran earlier (right

--- a/crates/perry/src/commands/run/android.rs
+++ b/crates/perry/src/commands/run/android.rs
@@ -96,8 +96,10 @@ fn build_and_run_android_impl(
         for entry in entries.flatten() {
             let path = entry.path();
             // Only sibling `.so` files; the main output was already copied as
-            // libperry_app.so above (and it carries no `.so` extension itself,
-            // so it can't match here and won't be double-copied).
+            // libperry_app.so above, and the `path == *so_path` guard below
+            // keeps it from being copied a second time under its own name
+            // (#5740 made the default output `lib<stem>.so`, so it now does
+            // carry a `.so` extension and would otherwise match here).
             let is_so = path
                 .extension()
                 .and_then(|e| e.to_str())


### PR DESCRIPTION
Fixes #5740 (bugs 2–4). Fixes #6333.

**Credit: @YC-CLT.** They diagnosed all four bugs in #5740, fixed them on their own machine, and pasted the patches into the issue rather than opening a PR ("feel free to cherry-pick"). This is that PR. I re-derived each fix against current `main` (the code had moved since their line numbers) and added regression tests so the behaviour can't drift back; the diagnosis and the fix design are theirs. Bug 1 of their report (the `replace_expr!` comma, rustc 1.96) already landed in #5741.

## #6333 is the same bug as #5740 bug 2

@startewho reports "On Windows can not build android example" and reads their own error as *"it seems the dir replace the `\` split"*. That reading is correct, and I reproduced the mechanism on macOS with the same clang tokenizer that runs on their box:

```
$ printf 'C:\\Users\\me\\AppData\\Local\\Temp\\app_ts.o\n' > old.rsp   # what perry writes today
$ clang @old.rsp
clang: error: no such file or directory: 'C:UsersmeAppDataLocalTempapp_ts.o'   # ← "the dir replace the \ split"

$ printf 'C:\\\\Users\\\\me\\\\...\\\\app_ts.o\n' > new.rsp             # what this PR writes
$ clang @new.rsp
clang: error: no such file or directory: 'C:\Users\me\AppData\Local\Temp\app_ts.o'   # path intact
```

So one PR closes both issues.

## The three fixes

### Bug 2 — backslashes in GNU-style response files (#5740, #6333)

Every link on a Windows host is routed through a linker response file (`@file`), added to dodge the ~32 KiB `CreateProcess` command-line cap. `quote_response_arg` escaped `\` only inside its *quoted* branch — but a plain object path has no spaces, so it took the "no quoting needed" early return and kept its backslashes verbatim. GNU-style tokenizers (clang, gcc, ld — i.e. every non-MSVC driver, which is exactly what a Windows-host cross-link to Android/HarmonyOS/Linux uses) treat `\` as an escape character *outside* quotes too, so every separator was eaten before the linker ever saw the path.

I escaped the backslashes rather than rewriting them to `/` as the original patch did. Doubling round-trips the argument byte-for-byte through the tokenizer on *any* host, so this needs no host gate and cannot corrupt a POSIX filename that legitimately contains a backslash — a blanket `\` → `/` substitution would. (`lld-link`/`link.exe` take Windows tokenization, where `\` is already literal; that branch is untouched.)

The `@<file>` argument itself rides the command line, not the response file, so it *is* gated: normalized to `/` separators only on a Windows host with a non-MSVC driver (clang/gcc accept them, and it survives any `cmd.exe` wrapper).

### Bug 3 — the NDK `.cmd` wrapper

The Android link drove `aarch64-linux-android24-clang`. That wrapper is two lines:

```sh
"$bin_dir/clang" --target=aarch64-linux-android24 "$@"
```

…which is precisely the `-target aarch64-linux-android24` perry already passes. On Windows the wrapper is a `.cmd` batch file, so Rust's `Command` can only spawn it through `cmd.exe` — a second round of command-line quoting (plus the batch-escaping restrictions from the CVE-2024-24576 fix) layered onto an already-long link line. Now both call sites go straight to `clang` through one `ndk_clang_path` helper.

The second call site is the JNI-stub compile in `link/build_and_run.rs`, which had the identical wrapper and wasn't in the original report. It matters: a failed spawn there is **silent** (`stub_ok` goes false, no diagnostic) and the link dies later on an undefined `JNI_GetCreatedJavaVMs`.

### Bug 4 — Android `default_output_path`

`--target android` had no arm and fell through to the bare stem, so `perry app.ts --target android` linked with `-o app` — and in a stock Android project `app/` is already a directory:

```
ld.lld: error: cannot open output file app: Is a directory
```

Now returns `lib<stem>.so`, mirroring the HarmonyOS arm directly above it (same reason: the artifact is a dlopen'd `.so`, not an executable), and covering Wear OS, which links identically. I used the plain `lib<stem>.so` rather than the `<stem>/lib<stem>.so` subdirectory from the original patch — @YC-CLT flagged that the subdir was working around their own project's `app` name collision, and `perry run --target android` copies the `.so` into `jniLibs/` itself.

While here: the compile pipeline and the build cache had **two independent copies** of `default_output_path` that had already drifted (the cache one knew nothing about dylib/staticlib/harmonyos). They now share one in `compile/output_path.rs` — otherwise the cache fingerprints a path the link never wrote, and an android rebuild silently never caches.

## What I verified locally, and what I couldn't

Verified on macOS (arm64):

- **The root cause of #6333, reproduced and fixed** — the `clang @rsp` transcript above. Same tokenizer, same failure, without a Windows box.
- **Bug 3's equivalence claim, empirically** — compiling the same C source with the NDK wrapper and with `clang -target aarch64-linux-android24` and the exact flags perry passes produces a **byte-identical** `.so` (`cmp` clean).
- **Non-Windows linking is unaffected** — compiled and ran a normal TS program before/after, *and* forced the GNU response-file path on macOS (`PERRY_FORCE_LINK_RESPONSE_FILE=1`, which is the code this PR changes, with `msvc=false`): identical output both ways. macOS/Linux link args contain no backslashes, so the new branch is inert there; the default output path for every non-Android target is asserted unchanged.
- `cargo test -p perry`: 705 unit tests green. `cargo fmt --all -- --check` + `scripts/check_file_size.sh` clean.
- **The new tests fail without the source fix** — I reverted each hunk and confirmed the failures reproduce the bug exactly: `left: "app"` vs `right: "libapp.so"`, and `C:\Users\...` vs `C:\\Users\\...`.

(One pre-existing integration failure on my machine, `addr_class_handle_bands` — a stale prebuilt runtime archive, `js_promise_run_microtasks_event_loop` landed in #6323 after it was built. Reproduces identically on the base commit; unrelated to this PR.)

**Cannot verify locally:** the actual Windows-host → Android link, end to end. Nobody here has a Windows box with an NDK — which is precisely why these patches sat in the issue for weeks. The unit tests pin the pure logic (feeding Windows-shaped inputs cross-platform), and the `clang @rsp` transcript pins the mechanism, but the real end-to-end proof has to come from a machine that has the failure.

**@YC-CLT, @startewho — could you pull this branch (`fix/5740-windows-android-crosscompile`) and confirm your builds go through?** That's the only real end-to-end validation available, and it would let us close both issues with confidence.

## Not in scope — #5742 (`android-x86_64`)

Bug 3's fix removes one arm64 hardcode as a side effect: the NDK driver is no longer named per-target (`aarch64-linux-android24-clang` → `clang`), so `ndk_clang_path` is arch-agnostic. Everything else in that chain still hardcodes arm64, and I deliberately did not expand scope:

- `link/platform_cmd.rs` and `link/build_and_run.rs` still pass a literal `-target aarch64-linux-android24` (both would need the triple mapping that `library_search::android_cross_env` already has).
- `android-x86_64` is not in the `is_android` matches in `link/build_and_run.rs:63`, `run_pipeline.rs` (×2), `post_link.rs:44`, `lock_scan.rs:163`, `app_metadata.rs:175`, `library_search.rs` (×3), `optimized_libs/driver.rs:1062`, `resolve/native_library.rs` (×2) — so it doesn't even reach the Android link branch today. My new `output_path.rs` arm matches the same `android | wearos` set on purpose, for consistency with those.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Windows linker response files so paths containing backslashes are preserved correctly.
  - Improved Android builds by selecting the correct NDK compiler path across host platforms.
  - Corrected default output naming and build-cache tracking for Windows, Android, Wear OS, HarmonyOS, static libraries, and dynamic libraries.

- **Documentation**
  - Clarified Android shared-library bundling behavior to prevent duplicate copies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->