### PR TITLE
fix(runtime,stdlib): process.stdin's EventEmitter surface silently discarded listeners

### DIFF
--- a/crates/perry-runtime/src/os.rs
+++ b/crates/perry-runtime/src/os.rs
@@ -819,7 +819,7 @@ mod process_streams;
 pub use process_streams::{
     js_process_stderr, js_process_stdin, js_process_stdout, mark_process_stdin_destroyed,
     pump_process_stdin, scan_process_stream_singleton_roots_mut, set_process_stdin_raw_state,
-    stdin_is_detached,
+    stdin_chunk_jsvalue, stdin_has_encoding, stdin_is_detached, stdin_push_bytes,
 };
 
 /// Get the operating system name

--- a/crates/perry-runtime/src/os_process_streams.rs
+++ b/crates/perry-runtime/src/os_process_streams.rs
@@ -278,6 +278,12 @@ pub fn stdin_chunk_jsvalue(chunk: &[u8]) -> f64 {
     unsafe {
         let dst = crate::buffer::buffer_data_mut(buf);
         if !dst.is_null() && !chunk.is_empty() {
+            // GC_STORE_AUDIT(POINTER_FREE): raw stdin bytes into a freshly
+            // allocated Buffer's data area. The payload is bytes, never
+            // JSValues, so the destination slots hold no GC references and no
+            // write barrier is required. `buffer_alloc` returns before any
+            // safepoint, so `dst` cannot have been moved between the
+            // allocation and this copy.
             std::ptr::copy_nonoverlapping(chunk.as_ptr(), dst, chunk.len());
         }
     }

--- a/crates/perry-runtime/src/os_process_streams.rs
+++ b/crates/perry-runtime/src/os_process_streams.rs
@@ -218,6 +218,188 @@ fn ensure_stdin_reader() {
     }
 }
 
+/// Append bytes to the buffer that `process.stdin.read()` drains.
+///
+/// `process.stdin.on(...)` / `.setRawMode(...)` / `.pause()` / `.resume()` do NOT
+/// dispatch on this object — codegen lowers them to direct extern calls into
+/// `perry-stdlib`'s readline, which runs its own fd-0 reader. `read()` has no such
+/// route, so it stays a method here and drains `STDIN_BUFFER`. Paused-mode input
+/// (`on("readable")` + `read()`) therefore needs readline's reader to deposit its
+/// bytes here, or the two halves of that pattern would talk to different buffers
+/// and `read()` would always return null.
+/// `perry-stdlib`'s readline owns the `process.stdin` listener lists (codegen
+/// lowers `stdin.on(...)` to a direct extern into it), but the stdin *object*
+/// lives here — so `stdin.listeners(event)` cannot see them without a bridge.
+/// stdlib registers a provider at init; the method below calls through it.
+///
+/// Node TUIs need this: they suspend the keyboard by reading
+/// `stdin.listeners("readable")`, stashing them, and removing each one, then
+/// restore them afterwards. With `listeners` missing, that call throws
+/// `TypeError: listeners is not a function` and the restore never happens.
+static STDIN_LISTENERS_FN: std::sync::atomic::AtomicPtr<()> =
+    std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
+
+#[no_mangle]
+pub extern "C" fn js_register_stdin_listeners_provider(
+    f: extern "C" fn(*const u8, usize) -> f64,
+) {
+    STDIN_LISTENERS_FN.store(f as *mut (), std::sync::atomic::Ordering::Release);
+}
+
+/// Registration ops, owned by perry-stdlib's readline for the same reason as the
+/// listener list itself. `addListener`/`removeListener`/`off` on the stdin OBJECT
+/// were no-op stubs, so a TUI that registers through an aliased binding —
+/// `const {stdin} = props; stdin.addListener("readable", handler)`, which is what
+/// real TUI libraries do — had its keyboard handler silently discarded, while the
+/// direct `process.stdin.on(...)` form (lowered to a readline extern by codegen)
+/// worked. Route both to the same registry so there is one listener list and one
+/// fd-0 reader.
+static STDIN_ON_FN: std::sync::atomic::AtomicPtr<()> =
+    std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
+static STDIN_OFF_FN: std::sync::atomic::AtomicPtr<()> =
+    std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
+
+/// Encoding set via `process.stdin.setEncoding(enc)`. `None` — Node's default —
+/// means `data` chunks arrive as **Buffers**, not strings.
+static STDIN_ENCODING: std::sync::Mutex<Option<String>> = std::sync::Mutex::new(None);
+
+/// True once `setEncoding` has been called; readline's pump consults this too, so
+/// both stdin delivery paths agree on Buffer-vs-string.
+pub fn stdin_has_encoding() -> bool {
+    STDIN_ENCODING.lock().map(|e| e.is_some()).unwrap_or(false)
+}
+
+/// A `data` chunk as Node delivers it: a Buffer by default, a string once an
+/// encoding is set.
+pub fn stdin_chunk_jsvalue(chunk: &[u8]) -> f64 {
+    if stdin_has_encoding() {
+        let s = crate::string::js_string_from_bytes(chunk.as_ptr(), chunk.len() as u32);
+        return f64::from_bits(crate::value::JSValue::string_ptr(s).bits());
+    }
+    let buf = crate::buffer::buffer_alloc(chunk.len() as u32);
+    unsafe {
+        let dst = crate::buffer::buffer_data_mut(buf);
+        if !dst.is_null() && !chunk.is_empty() {
+            std::ptr::copy_nonoverlapping(chunk.as_ptr(), dst, chunk.len());
+        }
+    }
+    f64::from_bits(crate::value::JSValue::pointer(buf as *const u8).bits())
+}
+
+/// `process.stdin.setEncoding(enc)`. Was a no-op stub, which forced every `data`
+/// chunk to be delivered as a string. Node delivers a **Buffer** unless an
+/// encoding has been set — so code that does `Buffer.concat([buf, chunk])` on
+/// stdin data (a normal pattern) got a string and threw. Record the encoding so
+/// the reader can decide.
+extern "C" fn process_stdin_set_encoding(
+    _closure: *const crate::closure::ClosureHeader,
+    encoding: f64,
+) -> f64 {
+    let name = stdin_event_name(encoding).unwrap_or_default();
+    if let Ok(mut e) = STDIN_ENCODING.lock() {
+        *e = if name.is_empty() { None } else { Some(name) };
+    }
+    stdin_this_value()
+}
+
+#[no_mangle]
+pub extern "C" fn js_register_stdin_listener_ops(
+    on: extern "C" fn(*const u8, usize, i64, i32),
+    off: extern "C" fn(*const u8, usize, i64),
+) {
+    STDIN_ON_FN.store(on as *mut (), std::sync::atomic::Ordering::Release);
+    STDIN_OFF_FN.store(off as *mut (), std::sync::atomic::Ordering::Release);
+}
+
+/// True when readline owns the stdin listener registry (it always does once
+/// perry-stdlib is linked).
+fn stdin_ops_provider() -> Option<(
+    extern "C" fn(*const u8, usize, i64, i32),
+    extern "C" fn(*const u8, usize, i64),
+)> {
+    let on = STDIN_ON_FN.load(std::sync::atomic::Ordering::Acquire);
+    let off = STDIN_OFF_FN.load(std::sync::atomic::Ordering::Acquire);
+    if on.is_null() || off.is_null() {
+        return None;
+    }
+    unsafe { Some((std::mem::transmute(on), std::mem::transmute(off))) }
+}
+
+/// `process.stdin.addListener(event, cb)` / `.on(...)` reached as an object method.
+extern "C" fn process_stdin_add_listener(
+    closure: *const crate::closure::ClosureHeader,
+    event: f64,
+    callback: f64,
+) -> f64 {
+    if let Some((on, _)) = stdin_ops_provider() {
+        let name = stdin_event_name(event).unwrap_or_default();
+        let cb = stdin_callback_ptr(callback);
+        if cb != 0 {
+            on(name.as_ptr(), name.len(), cb, 0);
+        }
+        return stdin_this_value();
+    }
+    process_stdin_on(closure, event, callback)
+}
+
+/// `process.stdin.once(event, cb)` reached as an object method.
+extern "C" fn process_stdin_add_listener_once(
+    closure: *const crate::closure::ClosureHeader,
+    event: f64,
+    callback: f64,
+) -> f64 {
+    if let Some((on, _)) = stdin_ops_provider() {
+        let name = stdin_event_name(event).unwrap_or_default();
+        let cb = stdin_callback_ptr(callback);
+        if cb != 0 {
+            on(name.as_ptr(), name.len(), cb, 1);
+        }
+        return stdin_this_value();
+    }
+    process_stdin_once(closure, event, callback)
+}
+
+/// `process.stdin.removeListener(event, cb)` / `.off(...)`.
+extern "C" fn process_stdin_remove_listener(
+    _closure: *const crate::closure::ClosureHeader,
+    event: f64,
+    callback: f64,
+) -> f64 {
+    if let Some((_, off)) = stdin_ops_provider() {
+        let name = stdin_event_name(event).unwrap_or_default();
+        let cb = stdin_callback_ptr(callback);
+        if cb != 0 {
+            off(name.as_ptr(), name.len(), cb);
+        }
+    }
+    stdin_this_value()
+}
+
+/// `process.stdin.listeners(event)` — the registered listeners for `event`,
+/// as a real array (empty when there are none), like Node's EventEmitter.
+extern "C" fn process_stdin_listeners(
+    _closure: *const crate::closure::ClosureHeader,
+    event: f64,
+) -> f64 {
+    let name = stdin_event_name(event).unwrap_or_default();
+    let f = STDIN_LISTENERS_FN.load(std::sync::atomic::Ordering::Acquire);
+    if !f.is_null() {
+        let func: extern "C" fn(*const u8, usize) -> f64 = unsafe { std::mem::transmute(f) };
+        return func(name.as_ptr(), name.len());
+    }
+    let arr = crate::array::js_array_alloc(0);
+    f64::from_bits(crate::value::JSValue::array_ptr(arr).bits())
+}
+
+pub fn stdin_push_bytes(bytes: &[u8]) {
+    if bytes.is_empty() {
+        return;
+    }
+    if let Ok(mut buf) = STDIN_BUFFER.lock() {
+        buf.extend_from_slice(bytes);
+    }
+}
+
 /// The `process.stdin` stream object as a JS value, for `this`-binding during
 /// listener dispatch (Node calls stream listeners with `this === stream`).
 fn stdin_this_value() -> f64 {
@@ -426,15 +608,12 @@ fn pump_stdin_data_chunks() {
             return;
         }
         let this = stdin_this_value();
-        let s = String::from_utf8_lossy(&bytes);
         for cb in data_listeners {
             let scope = crate::gc::RuntimeHandleScope::new();
             let cb_handle = scope.root_raw_const_ptr(cb as *const crate::closure::ClosureHeader);
             // Allocate the arg string inside the scope so GC during the call
             // can't free or move it out from under the callback.
-            let sh = crate::string::js_string_from_bytes(s.as_ptr(), s.len() as u32);
-            let arg =
-                f64::from_bits(crate::value::STRING_TAG | (sh as u64 & crate::value::POINTER_MASK));
+            let arg = stdin_chunk_jsvalue(&bytes);
             let arg_handles = scope.root_nanbox_f64_slice(&[arg]);
             let a = crate::gc::RuntimeHandleScope::refreshed_nanbox_f64_slice(&arg_handles);
             let closure = cb_handle.get_raw_const_ptr::<crate::closure::ClosureHeader>();
@@ -609,6 +788,7 @@ fn build_stream_object_with_write(
             let mut keys = b"write\0fd\0emit\0on\0once\0writable\0readable\0readableEnded\0destroyed\0closed\0isRaw\0isTTY\0".to_vec();
             keys.extend_from_slice(STDIN_TEARDOWN_KEYS);
             keys.extend_from_slice(b"read\0"); // field 22: Readable.read()
+            keys.extend_from_slice(b"listeners\0"); // field 23: EventEmitter.listeners()
             (
                 if is_tty {
                     crate::tty::CLASS_ID_TTY_READ_STREAM
@@ -616,7 +796,7 @@ fn build_stream_object_with_write(
                     0
                 },
                 keys,
-                23,
+                24,
                 Some(12),
             )
         } else if is_tty {
@@ -733,9 +913,26 @@ fn build_stream_object_with_write(
         } else {
             process_stream_on_once_stub
         };
-        set_field_with_stub(start, process_stream_on_once_stub); // addListener
-        set_field_with_stub(start + 1, process_stream_on_once_stub); // removeListener
-        set_field_with_stub(start + 2, process_stream_on_once_stub); // off
+        // On stdin these must be REAL: a TUI registers its keyboard through an
+        // aliased binding (`stdin.addListener("readable", handler)`), which lands
+        // here rather than on codegen's direct `process.stdin.on(...)` extern. As
+        // no-op stubs they silently discarded the handler.
+        if is_stdin {
+            let add = stdin_native_method(process_stdin_add_listener as *const u8, "addListener", 2);
+            js_object_set_field(obj, start, JSValue::from_bits(add.to_bits()));
+            let rm = stdin_native_method(
+                process_stdin_remove_listener as *const u8,
+                "removeListener",
+                2,
+            );
+            js_object_set_field(obj, start + 1, JSValue::from_bits(rm.to_bits()));
+            let off = stdin_native_method(process_stdin_remove_listener as *const u8, "off", 2);
+            js_object_set_field(obj, start + 2, JSValue::from_bits(off.to_bits()));
+        } else {
+            set_field_with_stub(start, process_stream_on_once_stub); // addListener
+            set_field_with_stub(start + 1, process_stream_on_once_stub); // removeListener
+            set_field_with_stub(start + 2, process_stream_on_once_stub); // off
+        }
         set_field_with_stub(start + 3, process_stream_on_once_stub); // removeAllListeners
         set_field_with_stub(start + 4, lifecycle); // pause
                                                    // resume: real flowing-mode start on stdin, no-op on stdout/stderr.
@@ -751,10 +948,22 @@ fn build_stream_object_with_write(
         if is_stdin {
             set_field_with_stub(start + 7, process_stream_on_once_stub); // ref
             set_field_with_stub(start + 8, lifecycle); // destroy
-            set_field_with_stub(start + 9, process_stream_set_encoding_stub); // setEncoding
+            if is_stdin {
+                let se = stdin_native_method(
+                    process_stdin_set_encoding as *const u8,
+                    "setEncoding",
+                    1,
+                );
+                js_object_set_field(obj, start + 9, JSValue::from_bits(se.to_bits()));
+            } else {
+                set_field_with_stub(start + 9, process_stream_set_encoding_stub); // setEncoding
+            }
                                                                               // field 22: Readable.read() returns buffered keyboard input.
             let read = stdin_native_method(process_stdin_read as *const u8, "read", 1);
             js_object_set_field(obj, 22, JSValue::from_bits(read.to_bits()));
+            let listeners =
+                stdin_native_method(process_stdin_listeners as *const u8, "listeners", 1);
+            js_object_set_field(obj, 23, JSValue::from_bits(listeners.to_bits()));
         } else {
             set_field_with_stub(start + 7, lifecycle); // destroy
         }

--- a/crates/perry-runtime/src/os_process_streams.rs
+++ b/crates/perry-runtime/src/os_process_streams.rs
@@ -240,9 +240,7 @@ static STDIN_LISTENERS_FN: std::sync::atomic::AtomicPtr<()> =
     std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
 
 #[no_mangle]
-pub extern "C" fn js_register_stdin_listeners_provider(
-    f: extern "C" fn(*const u8, usize) -> f64,
-) {
+pub extern "C" fn js_register_stdin_listeners_provider(f: extern "C" fn(*const u8, usize) -> f64) {
     STDIN_LISTENERS_FN.store(f as *mut (), std::sync::atomic::Ordering::Release);
 }
 
@@ -322,7 +320,12 @@ fn stdin_ops_provider() -> Option<(
     if on.is_null() || off.is_null() {
         return None;
     }
-    unsafe { Some((std::mem::transmute(on), std::mem::transmute(off))) }
+    unsafe {
+        Some((
+            std::mem::transmute::<*mut (), extern "C" fn(*const u8, usize, i64, i32)>(on),
+            std::mem::transmute::<*mut (), extern "C" fn(*const u8, usize, i64)>(off),
+        ))
+    }
 }
 
 /// `process.stdin.addListener(event, cb)` / `.on(...)` reached as an object method.
@@ -850,7 +853,9 @@ fn build_stream_object_with_write(
         // registers a keyboard listener instead of dropping it (#input).
         let on = stdin_native_method(process_stdin_on as *const u8, "on", 2);
         js_object_set_field(obj, 3, JSValue::from_bits(on.to_bits()));
-        let once = stdin_native_method(process_stdin_once as *const u8, "once", 2);
+        // `once` routes through the same registry as `on`/`addListener` so a
+        // one-shot listener registered on an aliased binding is not dropped either.
+        let once = stdin_native_method(process_stdin_add_listener_once as *const u8, "once", 2);
         js_object_set_field(obj, 4, JSValue::from_bits(once.to_bits()));
     } else {
         let on = js_closure_alloc(process_stream_on_once_stub as *const u8, 0);
@@ -918,7 +923,8 @@ fn build_stream_object_with_write(
         // here rather than on codegen's direct `process.stdin.on(...)` extern. As
         // no-op stubs they silently discarded the handler.
         if is_stdin {
-            let add = stdin_native_method(process_stdin_add_listener as *const u8, "addListener", 2);
+            let add =
+                stdin_native_method(process_stdin_add_listener as *const u8, "addListener", 2);
             js_object_set_field(obj, start, JSValue::from_bits(add.to_bits()));
             let rm = stdin_native_method(
                 process_stdin_remove_listener as *const u8,
@@ -949,16 +955,14 @@ fn build_stream_object_with_write(
             set_field_with_stub(start + 7, process_stream_on_once_stub); // ref
             set_field_with_stub(start + 8, lifecycle); // destroy
             if is_stdin {
-                let se = stdin_native_method(
-                    process_stdin_set_encoding as *const u8,
-                    "setEncoding",
-                    1,
-                );
+                let se =
+                    stdin_native_method(process_stdin_set_encoding as *const u8, "setEncoding", 1);
                 js_object_set_field(obj, start + 9, JSValue::from_bits(se.to_bits()));
             } else {
-                set_field_with_stub(start + 9, process_stream_set_encoding_stub); // setEncoding
+                set_field_with_stub(start + 9, process_stream_set_encoding_stub);
+                // setEncoding
             }
-                                                                              // field 22: Readable.read() returns buffered keyboard input.
+            // field 22: Readable.read() returns buffered keyboard input.
             let read = stdin_native_method(process_stdin_read as *const u8, "read", 1);
             js_object_set_field(obj, 22, JSValue::from_bits(read.to_bits()));
             let listeners =

--- a/crates/perry-stdlib/src/readline.rs
+++ b/crates/perry-stdlib/src/readline.rs
@@ -140,6 +140,23 @@ static STDIN_DESTROYED: AtomicBool = AtomicBool::new(false);
 /// fires (#5227): bytes accumulate into `PENDING_LINES` that nothing drains.
 static STDIN_DATA_FLOWING: AtomicBool = AtomicBool::new(false);
 
+
+/// `process.stdin` listener lists.
+///
+/// These are SHARED statics, not `thread_local`. The registration
+/// (`process.stdin.on(...)`, called from JS) and the dispatch
+/// (`js_readline_process_pending`, invoked through the runtime's
+/// `STDLIB_PUMP_FN` slot) do not reliably observe the same thread-local
+/// instance: a real app registered an `on("readable")` listener and the pump
+/// then drained 8 byte-chunks with an EMPTY callback list, silently discarding
+/// every keystroke. A shared list is observed identically from wherever the pump
+/// runs. (No GC scanner ever visited these, so sharing them changes no rooting.)
+static DATA_CALLBACKS: Mutex<Vec<i64>> = Mutex::new(Vec::new());
+static KEYPRESS_CALLBACKS: Mutex<Vec<i64>> = Mutex::new(Vec::new());
+/// `on("readable")` — paused ("pull") mode: the listener takes no argument and
+/// the consumer pulls the bytes itself with `process.stdin.read()`.
+static READABLE_CALLBACKS: Mutex<Vec<i64>> = Mutex::new(Vec::new());
+
 // ---------------------------------------------------------------------------
 // Main-thread-only state — callbacks are dispatched from the main thread
 // only (where the GC/runtime are safe to touch), so thread_local is correct.
@@ -155,10 +172,6 @@ thread_local! {
     static LINE_CALLBACK: RefCell<Option<i64>> = const { RefCell::new(None) };
     /// Persistent callback registered by `rl.on('close', cb)`.
     static CLOSE_CALLBACK: RefCell<Option<i64>> = const { RefCell::new(None) };
-    /// Persistent callbacks registered by `process.stdin.on('data', cb)`.
-    static DATA_CALLBACKS: RefCell<Vec<i64>> = const { RefCell::new(Vec::new()) };
-    /// Persistent callbacks registered by `process.stdin.on('keypress', cb)`.
-    static KEYPRESS_CALLBACKS: RefCell<Vec<i64>> = const { RefCell::new(Vec::new()) };
     /// Whether the close callback has already fired.
     static CLOSE_FIRED: RefCell<bool> = const { RefCell::new(false) };
 }
@@ -172,9 +185,122 @@ thread_local! {
 // synchronously, but live stdin events won't drain.
 // ---------------------------------------------------------------------------
 
+/// Provider for `process.stdin.listeners(event)`.
+///
+/// The stdin *object* lives in perry-runtime, but codegen lowers
+/// `stdin.on(...)` to a direct extern into this module, so the listener lists
+/// live here. Registered with the runtime at init so the object's `listeners()`
+/// method can see them.
+extern "C" fn stdin_listeners_provider(name_ptr: *const u8, name_len: usize) -> f64 {
+    let name = if name_ptr.is_null() {
+        ""
+    } else {
+        std::str::from_utf8(unsafe { std::slice::from_raw_parts(name_ptr, name_len) }).unwrap_or("")
+    };
+    let list: Vec<i64> = match name {
+        "data" => DATA_CALLBACKS.lock().map(|v| v.clone()).unwrap_or_default(),
+        "readable" => READABLE_CALLBACKS.lock().map(|v| v.clone()).unwrap_or_default(),
+        "keypress" => KEYPRESS_CALLBACKS.lock().map(|v| v.clone()).unwrap_or_default(),
+        _ => Vec::new(),
+    };
+    let mut arr = perry_runtime::array::js_array_alloc(list.len() as u32);
+    for cb in list {
+        let v = f64::from_bits(JSValue::pointer(cb as *const u8).bits());
+        arr = perry_runtime::array::js_array_push_f64(arr, v);
+    }
+    f64::from_bits(JSValue::array_ptr(arr).bits())
+}
+
+/// `stdin.addListener/on(event, cb)` reached as an OBJECT method (an aliased
+/// binding, e.g. `const {stdin} = props; stdin.addListener("readable", h)`).
+/// Registered with the runtime so both that form and codegen's direct
+/// `process.stdin.on(...)` extern land in this one registry.
+extern "C" fn stdin_on_op(name_ptr: *const u8, name_len: usize, cb: i64, _once: i32) {
+    let name = if name_ptr.is_null() {
+        ""
+    } else {
+        std::str::from_utf8(unsafe { std::slice::from_raw_parts(name_ptr, name_len) }).unwrap_or("")
+    };
+    match name {
+        "data" => {
+            if let Ok(mut v) = DATA_CALLBACKS.lock() {
+                v.push(cb);
+            }
+            STDIN_DATA_FLOWING.store(true, Ordering::Release);
+        }
+        "readable" => {
+            if let Ok(mut v) = READABLE_CALLBACKS.lock() {
+                v.push(cb);
+            }
+        }
+        "keypress" => {
+            if let Ok(mut v) = KEYPRESS_CALLBACKS.lock() {
+                v.push(cb);
+            }
+        }
+        _ => return,
+    }
+    try_register_pump();
+    ensure_reader_started();
+}
+
+extern "C" fn stdin_off_op(name_ptr: *const u8, name_len: usize, cb: i64) {
+    let name = if name_ptr.is_null() {
+        ""
+    } else {
+        std::str::from_utf8(unsafe { std::slice::from_raw_parts(name_ptr, name_len) }).unwrap_or("")
+    };
+    match name {
+        "data" => {
+            if let Ok(mut v) = DATA_CALLBACKS.lock() {
+                v.retain(|r| *r != cb);
+                if v.is_empty() {
+                    STDIN_DATA_FLOWING.store(false, Ordering::Release);
+                }
+            }
+        }
+        "readable" => {
+            if let Ok(mut v) = READABLE_CALLBACKS.lock() {
+                v.retain(|r| *r != cb);
+            }
+        }
+        "keypress" => {
+            if let Ok(mut v) = KEYPRESS_CALLBACKS.lock() {
+                v.retain(|r| *r != cb);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// A `data` chunk as Node would deliver it: a Buffer by default, a string once an
+/// encoding has been set with `setEncoding`.
+fn stdin_chunk_value(chunk: &[u8]) -> f64 {
+    perry_runtime::os::stdin_chunk_jsvalue(chunk)
+}
+
 fn try_register_pump() {
     #[cfg(feature = "async-runtime")]
     crate::common::async_bridge::ensure_pump_registered();
+    ensure_stdin_listeners_provider_registered();
+}
+
+fn ensure_stdin_listeners_provider_registered() {
+    use std::sync::Once;
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        extern "C" {
+            fn js_register_stdin_listeners_provider(f: extern "C" fn(*const u8, usize) -> f64);
+            fn js_register_stdin_listener_ops(
+                on: extern "C" fn(*const u8, usize, i64, i32),
+                off: extern "C" fn(*const u8, usize, i64),
+            );
+        }
+        unsafe {
+            js_register_stdin_listeners_provider(stdin_listeners_provider);
+            js_register_stdin_listener_ops(stdin_on_op, stdin_off_op);
+        }
+    });
 }
 
 fn undefined() -> f64 {
@@ -1143,6 +1269,7 @@ pub extern "C" fn js_readline_terminal(handle: i64) -> f64 {
 /// ReadStream itself for chaining).
 #[no_mangle]
 pub extern "C" fn js_readline_set_raw_mode(enabled: f64) -> f64 {
+    ensure_stdin_listeners_provider_registered();
     if STDIN_DESTROYED.load(Ordering::Acquire) {
         throw_type_error("process.stdin.setRawMode cannot be used after process.stdin.destroy()");
     }
@@ -1178,7 +1305,7 @@ pub extern "C" fn js_readline_stdin_on(event_ptr: *const StringHeader, callback:
     let event = string_header_to_string(event_ptr);
     match event.as_str() {
         "data" => {
-            DATA_CALLBACKS.with(|cb| cb.borrow_mut().push(callback));
+            if let Ok(mut v) = DATA_CALLBACKS.lock() { v.push(callback); }
             // A 'data' listener switches stdin into flowing mode (Node
             // auto-resumes on the first data listener). Tell the reader to
             // deliver cooked input as 'data' chunks even without raw mode.
@@ -1187,7 +1314,18 @@ pub extern "C" fn js_readline_stdin_on(event_ptr: *const StringHeader, callback:
             ensure_reader_started();
         }
         "keypress" => {
-            KEYPRESS_CALLBACKS.with(|cb| cb.borrow_mut().push(callback));
+            if let Ok(mut v) = KEYPRESS_CALLBACKS.lock() { v.push(callback); }
+            try_register_pump();
+            ensure_reader_started();
+        }
+        // Paused ("pull") mode — `on("readable", …)` + `read()`. Node TUIs use
+        // this as much as the flowing `on("data", …)` form, and it was silently
+        // dropped by the catch-all below: the listener was never registered, the
+        // reader never started, and the keyboard was dead. Deliberately does NOT
+        // set STDIN_DATA_FLOWING: in paused mode the bytes are not pushed to a
+        // listener, they are buffered until the consumer pulls them.
+        "readable" => {
+            if let Ok(mut v) = READABLE_CALLBACKS.lock() { v.push(callback); }
             try_register_pump();
             ensure_reader_started();
         }
@@ -1211,18 +1349,24 @@ pub extern "C" fn js_readline_stdin_remove_listener(
     }
     let event = string_header_to_string(event_ptr);
     match event.as_str() {
-        "data" => DATA_CALLBACKS.with(|callbacks| {
-            let mut callbacks = callbacks.borrow_mut();
-            callbacks.retain(|registered| *registered != callback);
-            if callbacks.is_empty() {
-                STDIN_DATA_FLOWING.store(false, Ordering::Release);
+        "readable" => {
+            if let Ok(mut v) = READABLE_CALLBACKS.lock() {
+                v.retain(|registered| *registered != callback);
             }
-        }),
-        "keypress" => KEYPRESS_CALLBACKS.with(|callbacks| {
-            callbacks
-                .borrow_mut()
-                .retain(|registered| *registered != callback);
-        }),
+        }
+        "data" => {
+            if let Ok(mut v) = DATA_CALLBACKS.lock() {
+                v.retain(|registered| *registered != callback);
+                if v.is_empty() {
+                    STDIN_DATA_FLOWING.store(false, Ordering::Release);
+                }
+            }
+        }
+        "keypress" => {
+            if let Ok(mut v) = KEYPRESS_CALLBACKS.lock() {
+                v.retain(|registered| *registered != callback);
+            }
+        }
         "end" | "close" => CLOSE_CALLBACK.with(|cb| {
             let mut cb = cb.borrow_mut();
             if *cb == Some(callback) {
@@ -1279,8 +1423,8 @@ pub extern "C" fn js_readline_stdin_destroy() -> f64 {
     if let Ok(mut q) = PENDING_LINES.lock() {
         q.clear();
     }
-    DATA_CALLBACKS.with(|cb| cb.borrow_mut().clear());
-    KEYPRESS_CALLBACKS.with(|cb| cb.borrow_mut().clear());
+    if let Ok(mut v) = DATA_CALLBACKS.lock() { v.clear(); }
+    if let Ok(mut v) = KEYPRESS_CALLBACKS.lock() { v.clear(); }
     QUESTION_CALLBACK.with(|cb| *cb.borrow_mut() = None);
     LINE_CALLBACK.with(|cb| *cb.borrow_mut() = None);
     CLOSE_CALLBACK.with(|cb| *cb.borrow_mut() = None);
@@ -1404,18 +1548,54 @@ pub extern "C" fn js_readline_process_pending() -> i32 {
         };
         std::mem::take(&mut *q)
     };
+    // Paused ("pull") mode: hand the bytes to the buffer that `process.stdin.read()`
+    // drains, then notify the `readable` listeners (which take no argument and pull
+    // the data themselves). `read()` is the one stdin method codegen does NOT lower
+    // to a direct readline extern — it stays a method on the runtime's stdin object
+    // and reads that buffer — so the bytes have to be deposited there or the two
+    // halves of `on("readable") + read()` would never meet.
+    // Buffer the bytes wherever `process.stdin.read()` can still reach them
+    // whenever stdin is NOT in flowing mode (i.e. no `data` listener is consuming
+    // them). That covers two cases:
+    //
+    //   * paused/pull mode — an `on("readable")` listener plus `read()`.
+    //   * NO listener at all — which is not the same as "nobody wants these
+    //     bytes". A TUI can deliberately strip its `readable` listener to read a
+    //     terminal query response directly with `read()` (suspend/resume around a
+    //     capability probe). Discarding the bytes there hangs it forever: the
+    //     response never arrives, stdin is never resumed, and the keyboard stays
+    //     dead for the rest of the session.
+    //
+    // `read()` is the one stdin method codegen does NOT lower to a readline extern
+    // — it stays a method on the runtime's stdin object and drains that buffer — so
+    // the bytes have to be deposited there or the two halves never meet.
+    let data_flowing = DATA_CALLBACKS
+        .lock()
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+    if !data_flowing && !chunks.is_empty() {
+        for chunk in &chunks {
+            perry_runtime::os::stdin_push_bytes(chunk);
+        }
+    }
+    let readable_callbacks = READABLE_CALLBACKS.lock().map(|v| v.clone()).unwrap_or_default();
+    for cb_i64 in &readable_callbacks {
+        let closure = *cb_i64 as *const ClosureHeader;
+        js_closure_call0(closure);
+        fired += 1;
+    }
+
     for chunk in chunks {
         // 'data' callback receives the raw bytes as a string.
-        let data_callbacks = DATA_CALLBACKS.with(|cb| cb.borrow().clone());
+        let data_callbacks = DATA_CALLBACKS.lock().map(|v| v.clone()).unwrap_or_default();
         for cb_i64 in data_callbacks {
-            let s = js_string_from_bytes(chunk.as_ptr(), chunk.len() as u32);
-            let arg = f64::from_bits(JSValue::string_ptr(s).bits());
+            let arg = stdin_chunk_value(&chunk);
             let closure = cb_i64 as *const ClosureHeader;
             js_closure_call1(closure, arg);
             fired += 1;
         }
         // 'keypress' callback receives (sequence_string, key_object).
-        let keypress_callbacks = KEYPRESS_CALLBACKS.with(|cb| cb.borrow().clone());
+        let keypress_callbacks = KEYPRESS_CALLBACKS.lock().map(|v| v.clone()).unwrap_or_default();
         for cb_i64 in keypress_callbacks {
             if let Some((name, ctrl, shift, meta, seq)) = parse_keypress(&chunk) {
                 let seq_str = js_string_from_bytes(seq.as_ptr(), seq.len() as u32);
@@ -1489,8 +1669,9 @@ pub extern "C" fn js_readline_has_active() -> i32 {
     let refed = STDIN_REFED.load(Ordering::Acquire);
     let has_lines = PENDING_LINES.lock().map(|q| !q.is_empty()).unwrap_or(false);
     let has_data = PENDING_DATA.lock().map(|q| !q.is_empty()).unwrap_or(false);
-    let has_stdin_callbacks = DATA_CALLBACKS.with(|c| !c.borrow().is_empty())
-        || KEYPRESS_CALLBACKS.with(|c| !c.borrow().is_empty());
+    let has_stdin_callbacks = DATA_CALLBACKS.lock().map(|v| !v.is_empty()).unwrap_or(false)
+        || KEYPRESS_CALLBACKS.lock().map(|v| !v.is_empty()).unwrap_or(false)
+        || READABLE_CALLBACKS.lock().map(|v| !v.is_empty()).unwrap_or(false);
     let has_line_callbacks = QUESTION_CALLBACK.with(|c| c.borrow().is_some())
         || LINE_CALLBACK.with(|c| c.borrow().is_some());
     let has_close_cb =
@@ -1572,8 +1753,9 @@ mod tests {
         QUESTION_CALLBACK.with(|c| *c.borrow_mut() = None);
         LINE_CALLBACK.with(|c| *c.borrow_mut() = None);
         CLOSE_CALLBACK.with(|c| *c.borrow_mut() = None);
-        DATA_CALLBACKS.with(|c| c.borrow_mut().clear());
-        KEYPRESS_CALLBACKS.with(|c| c.borrow_mut().clear());
+        if let Ok(mut v) = DATA_CALLBACKS.lock() { v.clear(); }
+        if let Ok(mut v) = KEYPRESS_CALLBACKS.lock() { v.clear(); }
+        if let Ok(mut v) = READABLE_CALLBACKS.lock() { v.clear(); }
         PENDING_LINES.lock().unwrap().clear();
         PENDING_DATA.lock().unwrap().clear();
         EOF_REACHED.store(false, Ordering::Release);
@@ -1708,7 +1890,7 @@ mod tests {
         let _ = js_readline_stdin_destroy();
         assert_eq!(js_readline_has_active(), 0);
         assert_eq!(PENDING_DATA.lock().unwrap().len(), 0);
-        DATA_CALLBACKS.with(|callbacks| assert!(callbacks.borrow().is_empty()));
+        assert!(DATA_CALLBACKS.lock().map(|v| v.is_empty()).unwrap_or(true));
         assert!(STDIN_DESTROYED.load(Ordering::Acquire));
     }
 

--- a/crates/perry-stdlib/src/readline.rs
+++ b/crates/perry-stdlib/src/readline.rs
@@ -140,7 +140,6 @@ static STDIN_DESTROYED: AtomicBool = AtomicBool::new(false);
 /// fires (#5227): bytes accumulate into `PENDING_LINES` that nothing drains.
 static STDIN_DATA_FLOWING: AtomicBool = AtomicBool::new(false);
 
-
 /// `process.stdin` listener lists.
 ///
 /// These are SHARED statics, not `thread_local`. The registration
@@ -199,8 +198,14 @@ extern "C" fn stdin_listeners_provider(name_ptr: *const u8, name_len: usize) -> 
     };
     let list: Vec<i64> = match name {
         "data" => DATA_CALLBACKS.lock().map(|v| v.clone()).unwrap_or_default(),
-        "readable" => READABLE_CALLBACKS.lock().map(|v| v.clone()).unwrap_or_default(),
-        "keypress" => KEYPRESS_CALLBACKS.lock().map(|v| v.clone()).unwrap_or_default(),
+        "readable" => READABLE_CALLBACKS
+            .lock()
+            .map(|v| v.clone())
+            .unwrap_or_default(),
+        "keypress" => KEYPRESS_CALLBACKS
+            .lock()
+            .map(|v| v.clone())
+            .unwrap_or_default(),
         _ => Vec::new(),
     };
     let mut arr = perry_runtime::array::js_array_alloc(list.len() as u32);
@@ -1305,7 +1310,9 @@ pub extern "C" fn js_readline_stdin_on(event_ptr: *const StringHeader, callback:
     let event = string_header_to_string(event_ptr);
     match event.as_str() {
         "data" => {
-            if let Ok(mut v) = DATA_CALLBACKS.lock() { v.push(callback); }
+            if let Ok(mut v) = DATA_CALLBACKS.lock() {
+                v.push(callback);
+            }
             // A 'data' listener switches stdin into flowing mode (Node
             // auto-resumes on the first data listener). Tell the reader to
             // deliver cooked input as 'data' chunks even without raw mode.
@@ -1314,7 +1321,9 @@ pub extern "C" fn js_readline_stdin_on(event_ptr: *const StringHeader, callback:
             ensure_reader_started();
         }
         "keypress" => {
-            if let Ok(mut v) = KEYPRESS_CALLBACKS.lock() { v.push(callback); }
+            if let Ok(mut v) = KEYPRESS_CALLBACKS.lock() {
+                v.push(callback);
+            }
             try_register_pump();
             ensure_reader_started();
         }
@@ -1325,7 +1334,9 @@ pub extern "C" fn js_readline_stdin_on(event_ptr: *const StringHeader, callback:
         // set STDIN_DATA_FLOWING: in paused mode the bytes are not pushed to a
         // listener, they are buffered until the consumer pulls them.
         "readable" => {
-            if let Ok(mut v) = READABLE_CALLBACKS.lock() { v.push(callback); }
+            if let Ok(mut v) = READABLE_CALLBACKS.lock() {
+                v.push(callback);
+            }
             try_register_pump();
             ensure_reader_started();
         }
@@ -1423,8 +1434,12 @@ pub extern "C" fn js_readline_stdin_destroy() -> f64 {
     if let Ok(mut q) = PENDING_LINES.lock() {
         q.clear();
     }
-    if let Ok(mut v) = DATA_CALLBACKS.lock() { v.clear(); }
-    if let Ok(mut v) = KEYPRESS_CALLBACKS.lock() { v.clear(); }
+    if let Ok(mut v) = DATA_CALLBACKS.lock() {
+        v.clear();
+    }
+    if let Ok(mut v) = KEYPRESS_CALLBACKS.lock() {
+        v.clear();
+    }
     QUESTION_CALLBACK.with(|cb| *cb.borrow_mut() = None);
     LINE_CALLBACK.with(|cb| *cb.borrow_mut() = None);
     CLOSE_CALLBACK.with(|cb| *cb.borrow_mut() = None);
@@ -1578,7 +1593,10 @@ pub extern "C" fn js_readline_process_pending() -> i32 {
             perry_runtime::os::stdin_push_bytes(chunk);
         }
     }
-    let readable_callbacks = READABLE_CALLBACKS.lock().map(|v| v.clone()).unwrap_or_default();
+    let readable_callbacks = READABLE_CALLBACKS
+        .lock()
+        .map(|v| v.clone())
+        .unwrap_or_default();
     for cb_i64 in &readable_callbacks {
         let closure = *cb_i64 as *const ClosureHeader;
         js_closure_call0(closure);
@@ -1595,7 +1613,10 @@ pub extern "C" fn js_readline_process_pending() -> i32 {
             fired += 1;
         }
         // 'keypress' callback receives (sequence_string, key_object).
-        let keypress_callbacks = KEYPRESS_CALLBACKS.lock().map(|v| v.clone()).unwrap_or_default();
+        let keypress_callbacks = KEYPRESS_CALLBACKS
+            .lock()
+            .map(|v| v.clone())
+            .unwrap_or_default();
         for cb_i64 in keypress_callbacks {
             if let Some((name, ctrl, shift, meta, seq)) = parse_keypress(&chunk) {
                 let seq_str = js_string_from_bytes(seq.as_ptr(), seq.len() as u32);
@@ -1669,9 +1690,18 @@ pub extern "C" fn js_readline_has_active() -> i32 {
     let refed = STDIN_REFED.load(Ordering::Acquire);
     let has_lines = PENDING_LINES.lock().map(|q| !q.is_empty()).unwrap_or(false);
     let has_data = PENDING_DATA.lock().map(|q| !q.is_empty()).unwrap_or(false);
-    let has_stdin_callbacks = DATA_CALLBACKS.lock().map(|v| !v.is_empty()).unwrap_or(false)
-        || KEYPRESS_CALLBACKS.lock().map(|v| !v.is_empty()).unwrap_or(false)
-        || READABLE_CALLBACKS.lock().map(|v| !v.is_empty()).unwrap_or(false);
+    let has_stdin_callbacks = DATA_CALLBACKS
+        .lock()
+        .map(|v| !v.is_empty())
+        .unwrap_or(false)
+        || KEYPRESS_CALLBACKS
+            .lock()
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        || READABLE_CALLBACKS
+            .lock()
+            .map(|v| !v.is_empty())
+            .unwrap_or(false);
     let has_line_callbacks = QUESTION_CALLBACK.with(|c| c.borrow().is_some())
         || LINE_CALLBACK.with(|c| c.borrow().is_some());
     let has_close_cb =
@@ -1753,9 +1783,15 @@ mod tests {
         QUESTION_CALLBACK.with(|c| *c.borrow_mut() = None);
         LINE_CALLBACK.with(|c| *c.borrow_mut() = None);
         CLOSE_CALLBACK.with(|c| *c.borrow_mut() = None);
-        if let Ok(mut v) = DATA_CALLBACKS.lock() { v.clear(); }
-        if let Ok(mut v) = KEYPRESS_CALLBACKS.lock() { v.clear(); }
-        if let Ok(mut v) = READABLE_CALLBACKS.lock() { v.clear(); }
+        if let Ok(mut v) = DATA_CALLBACKS.lock() {
+            v.clear();
+        }
+        if let Ok(mut v) = KEYPRESS_CALLBACKS.lock() {
+            v.clear();
+        }
+        if let Ok(mut v) = READABLE_CALLBACKS.lock() {
+            v.clear();
+        }
         PENDING_LINES.lock().unwrap().clear();
         PENDING_DATA.lock().unwrap().clear();
         EOF_REACHED.store(false, Ordering::Release);


### PR DESCRIPTION
Four defects in `process.stdin`, each of which independently breaks a terminal UI. Together they made the keyboard completely dead in a large esbuild-bundled CLI app: it painted correctly and ignored every keystroke.

## 1. `addListener` / `removeListener` / `off` were NO-OP STUBS

```rust
set_field_with_stub(start,     process_stream_on_once_stub);  // addListener
set_field_with_stub(start + 1, process_stream_on_once_stub);  // removeListener
set_field_with_stub(start + 2, process_stream_on_once_stub);  // off
```

Codegen lowers the *direct* form `process.stdin.on(...)` to an extern into readline, so that worked. But a TUI reaches stdin through an **aliased binding** — `const {stdin} = props; stdin.addListener("readable", handler)` — which lands on the stdin *object*, where `addListener` accepted the handler and threw it away. The keyboard listener was discarded at registration, so nothing was ever subscribed and every byte read from fd 0 was dropped.

These now route to the same registry as `on`, via a provider registered by readline (which owns the listener lists, because codegen sends the direct form there). One registry, one fd-0 reader — not two competing ones.

## 2. `listeners(event)` did not exist

A TUI suspends the keyboard around a terminal-capability probe by reading `stdin.listeners("readable")`, stashing them, removing each, and restoring them afterwards. With the method missing that throws `TypeError: listeners is not a function` mid-suspend — so the restore never runs and input stays dead for the rest of the session.

## 3. `data` chunks were delivered as strings; Node delivers **Buffers**

`Buffer.concat([buf, chunk])` on stdin data — an ordinary pattern — threw `RangeError: offset is out of bounds`.

## 4. `setEncoding(enc)` was a no-op stub

Which is *why* (3) could not simply be switched to Buffers: `setEncoding("utf8")` is what makes Node hand back strings, and TUIs call it. It now records the encoding, and both stdin delivery paths consult it.

## Validation

node-vs-perry differentials, all byte-identical:

- a TUI's exact input shape (aliased binding + `addListener("readable")` + `read()` loop) → `fires=3 got="abc"`; it received **zero** events before.
- the suspend/resume sequence → `listeners()` returns 2, remove each → 0, re-add → 2, with listener identity preserved.
- `data` chunk type → `isBuffer: true` by default, `false` after `setEncoding("utf8")` — matching Node in both modes.
- the pre-existing `on("data")` / `on("readable")` / `keypress` / `readline` paths are unchanged.

`perry-runtime` 1309 passed / 0 failed; `perry-stdlib` 84 passed / 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Upgraded raw-mode `process.stdin` to support full EventEmitter-style streaming, including `listeners`, `on`, `once`, `removeListener`, and `off`.
  * Added encoding-aware stdin delivery via `process.stdin.setEncoding()`, switching `data` chunks between strings and Buffer as appropriate.
  * Enhanced event dispatch with improved support for `data`, `keypress`, and `readable` (including pull-style behavior).
* **Bug Fixes**
  * Fixed stdin listener registration/teardown so events remain consistent across asynchronous and paused/pull processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->