### PR TITLE
fix(runtime): a bare heap pointer receiver was misdispatched as a number

### DIFF
--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1609,6 +1609,30 @@ pub unsafe extern "C" fn js_native_call_method(
             }
         }
     }
+    // A BARE heap pointer — a real object whose value was never NaN-boxed, so its
+    // top 16 bits are zero and it decodes as a denormal double. Classifying it as a
+    // "number" here throws `<method> is not a function` on a perfectly good object.
+    // Validate deref-free (above the handle band + a genuinely tracked allocation),
+    // rebox as a POINTER_TAG value and dispatch on the object it actually is.
+    // Perry already recovers bare pointers on other dispatch paths; this one threw
+    // before it ever got the chance.
+    if jsval.is_number() && (jsval.bits() >> 48) == 0 {
+        let raw = jsval.bits() as usize;
+        if crate::value::addr_class::is_above_handle_band(raw)
+            && crate::value::addr_class::is_valid_obj_ptr(raw as *const u8)
+        {
+            let reboxed = crate::value::JSValue::pointer(raw as *const u8);
+            if reboxed.bits() != jsval.bits() {
+                return js_native_call_method(
+                    f64::from_bits(reboxed.bits()),
+                    method_name_ptr,
+                    method_name_len,
+                    args_ptr,
+                    args_len,
+                );
+            }
+        }
+    }
     let primitive_kind: Option<&'static str> = if jsval.is_any_string() {
         Some("string")
     } else if jsval.is_int32() || jsval.is_number() {


### PR DESCRIPTION
A method call on a valid object threw `TypeError: <method> is not a function` when the receiver arrived as a **bare heap pointer** — a real object address that was never NaN-boxed. Its top 16 bits are zero, so it decodes as a denormal double; the dispatcher classified the receiver as a primitive `"number"` and threw, on an object that was sitting right there in memory.

Observed receiver:

```
bits = 0x0000028591712e78     as_f64 = 1.37e-312
```

~2.7 TB — a live heap address, well above the heap floor.

## The fix

Perry already recovers bare pointers on other dispatch paths; this one threw before it ever got the chance. The primitive-kind classification now first checks whether a `"number"` receiver is in fact an object pointer: zero high bits, above the handle band, and a genuinely GC-tracked allocation. All three checks are **dereference-free** (magnitude + page-map / registry lookups), so a forged value is rejected without a load. On a match it reboxes as a `POINTER_TAG` value and dispatches on the object it actually is; otherwise the primitive path is unchanged.

## How it showed up

Found in a large esbuild-bundled CLI app whose terminal UI was completely unresponsive to the keyboard. Every keystroke reached the input handler, which called a method on a module-scope object, hit this TypeError, and the framework swallowed it in a `try/catch` — so the app painted correctly and silently ignored all input.

With the recovery the keyboard works (menus open, arrows navigate, selection commits), and a `RangeError: offset is out of bounds` that rode along with it disappears too.

`perry-runtime`: 1309 passed / 0 failed.

## Scope

This is a guard at the dispatch boundary, matching perry's existing bare-pointer recovery elsewhere. Whatever hands out an unboxed pointer upstream is a separate defect worth its own hunt — this stops it from turning a live object into a `"number"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed method calls on certain heap objects that were incorrectly interpreted as numbers.
  * Prevented erroneous “method is not a function” errors in these cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->