### PR TITLE
perf(codegen): replace the try/catch optnone contagion with targeted setjmp volatile slots (#6385)

### DIFF
--- a/crates/perry-codegen/src/block.rs
+++ b/crates/perry-codegen/src/block.rs
@@ -9,8 +9,8 @@
 //! sorts out the registers. Explicit `phi` nodes are still emitted for
 //! control-flow merges (if/else value context, short-circuit logical ops).
 
-use std::cell::Cell;
-use std::collections::HashMap;
+use std::cell::{Cell, Ref, RefCell};
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use crate::codegen::FpContractMode;
@@ -62,12 +62,28 @@ impl Default for FpFlags {
 #[derive(Default)]
 pub struct RegCounter {
     value: Cell<u32>,
+    /// Nesting depth of the setjmp-protected regions codegen is currently
+    /// inside (a `try` body, or a `catch` body that a `finally` re-protects).
+    /// Tracked by *emission* depth rather than by block index so it covers
+    /// nested blocks, loops, nested `try`s and duplicated `finally` bodies
+    /// automatically — whatever is lowered while the region is open belongs
+    /// to it, no matter which basic block the instruction lands in.
+    try_region_depth: Cell<u32>,
+    /// Destination pointer of every `store` emitted while
+    /// `try_region_depth > 0`. These are the memory locations this function
+    /// can modify between a `setjmp` and its `longjmp`; the allocas among
+    /// them get `volatile` accesses at IR-render time so LLVM cannot promote
+    /// them into registers that `longjmp` would revert. See
+    /// `crate::volatile_setjmp` for the full argument (#6385).
+    try_region_stores: RefCell<HashSet<String>>,
 }
 
 impl RegCounter {
     pub fn new() -> Self {
         Self {
             value: Cell::new(0),
+            try_region_depth: Cell::new(0),
+            try_region_stores: RefCell::new(HashSet::new()),
         }
     }
 
@@ -75,6 +91,36 @@ impl RegCounter {
         let v = self.value.get() + 1;
         self.value.set(v);
         v
+    }
+
+    /// Open a setjmp-protected region: every `store` emitted from here until
+    /// the matching `exit_try_region` is recorded as "modified between the
+    /// setjmp and a possible longjmp".
+    pub fn enter_try_region(&self) {
+        self.try_region_depth.set(self.try_region_depth.get() + 1);
+    }
+
+    pub fn exit_try_region(&self) {
+        self.try_region_depth
+            .set(self.try_region_depth.get().saturating_sub(1));
+    }
+
+    pub fn try_region_stores(&self) -> Ref<'_, HashSet<String>> {
+        self.try_region_stores.borrow()
+    }
+
+    /// Record `line`'s store destination if we are inside a try region.
+    /// Called from [`LlBlock::emit`], the single choke point every emitter
+    /// (including `emit_raw`) funnels through.
+    fn note_emitted(&self, line: &str) {
+        if self.try_region_depth.get() == 0 {
+            return;
+        }
+        if let Some(ptr) = crate::volatile_setjmp::store_dest_ptr(line) {
+            if ptr.starts_with('%') {
+                self.try_region_stores.borrow_mut().insert(ptr.to_string());
+            }
+        }
     }
 }
 
@@ -160,7 +206,11 @@ impl LlBlock {
         if self.terminated {
             return;
         }
-        self.instructions.push(format!("  {}", line.into()));
+        let line = line.into();
+        // #6385: note stores emitted inside a setjmp-protected region so
+        // `LlFunction::to_ir` can make the backing allocas volatile.
+        self.counter.note_emitted(&line);
+        self.instructions.push(format!("  {}", line));
     }
 
     fn reg(&self) -> String {

--- a/crates/perry-codegen/src/function.rs
+++ b/crates/perry-codegen/src/function.rs
@@ -16,12 +16,22 @@ pub struct LlFunction {
     /// Optional LLVM linkage string, e.g. `"internal"` or `"private"`. Empty
     /// string means external (default) linkage.
     pub linkage: String,
-    /// When true, the function body contains a `try` statement (setjmp/longjmp).
-    /// We must emit `#1` (noinline optnone) on the definition so LLVM doesn't
-    /// promote allocas to SSA registers across the setjmp call — otherwise
-    /// mutations performed in the try body are invisible in the catch block
-    /// after longjmp returns. `returns_twice` alone on the setjmp call is not
-    /// sufficient at -O2 on aarch64.
+    /// When true, the function body contains a `try` statement (setjmp/longjmp),
+    /// so the definition gets `#1` (`noinline`) and `to_ir` runs the volatile
+    /// promotion pass.
+    ///
+    /// The setjmp hazard: `longjmp` restores the callee-saved registers and
+    /// stack pointer that `setjmp` snapshotted, so any local LLVM parked in a
+    /// register across the setjmp call reverts to its setjmp-time value when
+    /// the exception fires — the try body's mutations vanish in the catch.
+    /// `returns_twice` on the setjmp call is not sufficient at -O2 on aarch64.
+    ///
+    /// This used to be handled by stamping `optnone` on the whole function,
+    /// which is correct (at -O0 every value is frame-resident) but cost ~5x on
+    /// the surrounding code even when nothing ever throws (#6385). We now apply
+    /// C's `volatile` rule precisely instead: only the allocas the try body
+    /// actually stores into get volatile accesses, and everything else in the
+    /// function stays optimizable. See [`crate::volatile_setjmp`].
     pub has_try: bool,
     /// When true, emit `alwaysinline` attribute. Forces LLVM to inline this
     /// function at every call site, exposing integer operations to the
@@ -199,6 +209,24 @@ impl LlFunction {
 
     pub fn add_pre_return_void_call(&mut self, func_name: impl Into<String>) {
         self.pre_return_void_calls.push(func_name.into());
+    }
+
+    /// Open a setjmp-protected region (#6385). Every `store` emitted into any
+    /// block of this function until the matching [`exit_try_region`] is
+    /// recorded as "modified between the setjmp and a possible longjmp", and
+    /// the alloca behind it is given volatile accesses by `to_ir`.
+    ///
+    /// Call this around the lowering of a `try` body and of a `catch` body
+    /// that a `finally` re-protects — i.e. exactly the code that a `longjmp`
+    /// can cut short. Regions nest; the depth counter handles that.
+    ///
+    /// [`exit_try_region`]: LlFunction::exit_try_region
+    pub fn enter_try_region(&self) {
+        self.reg_counter.enter_try_region();
+    }
+
+    pub fn exit_try_region(&self) {
+        self.reg_counter.exit_try_region();
     }
 
     /// Allocate a fresh stack slot in the function entry block. Returns
@@ -468,7 +496,7 @@ impl LlFunction {
         // regardless of which lowering path emitted it. Textual rewrite
         // on the full IR catches implicit returns, Stmt::Return, and any
         // hand-emitted `ret`.
-        if self.shadow_frame_slot.is_some() || !self.pre_return_void_calls.is_empty() {
+        let ir = if self.shadow_frame_slot.is_some() || !self.pre_return_void_calls.is_empty() {
             let mut out = String::with_capacity(ir.len() + 512);
             let mut seq: u32 = 0;
             for line in ir.lines() {
@@ -493,7 +521,25 @@ impl LlFunction {
                 out.push_str(line);
                 out.push('\n');
             }
-            return out;
+            out
+        } else {
+            ir
+        };
+
+        // setjmp volatile promotion (#6385).
+        //
+        // Runs LAST so it sees every instruction, including the ones the
+        // return-site rewrite above just spliced in. Any alloca this function
+        // stores into between a `setjmp` and its `longjmp` (recorded by
+        // `LlBlock::emit` while a try region was open) gets `volatile` loads
+        // and stores, which is what stops mem2reg/SROA from promoting it into
+        // a register that `longjmp` would revert. This replaces the old
+        // `optnone`-the-whole-function hammer.
+        if self.has_try {
+            let try_stores = self.reg_counter.try_region_stores();
+            if !try_stores.is_empty() {
+                return crate::volatile_setjmp::apply_setjmp_volatile(&ir, &try_stores);
+            }
         }
 
         ir

--- a/crates/perry-codegen/src/lib.rs
+++ b/crates/perry-codegen/src/lib.rs
@@ -32,6 +32,7 @@ pub(crate) mod type_analysis_facts;
 pub(crate) mod type_analysis_net;
 pub(crate) mod typed_shape;
 pub mod types;
+pub(crate) mod volatile_setjmp;
 
 pub use codegen::{
     compile_module, resolve_target_triple, AppMetadata, CompileOptions, FpContractMode,

--- a/crates/perry-codegen/src/module.rs
+++ b/crates/perry-codegen/src/module.rs
@@ -436,11 +436,27 @@ impl LlModule {
         // `_setjmp` (2-arg ABI), Linux `setjmp` — all need `returns_twice`.
         if self.declared_names.contains("setjmp") || self.declared_names.contains("_setjmp") {
             ir.push_str("\nattributes #0 = { returns_twice }\n");
-            // Functions containing a `try` are marked `#1`. `optnone` skips
-            // mem2reg/SROA so allocas aren't promoted across the setjmp call
-            // (else try-body mutations are invisible to catch after longjmp);
-            // `noinline` keeps the constraint from being lost via inlining.
-            ir.push_str("attributes #1 = { noinline optnone }\n");
+            // Functions containing a `try` are marked `#1`.
+            //
+            // This group used to carry `optnone` as well, to stop mem2reg/SROA
+            // from promoting allocas across the setjmp call (a promoted local
+            // lives in a callee-saved register, which `longjmp` restores to its
+            // setjmp-time value — so try-body mutations were invisible to the
+            // catch). That worked, but it deoptimized the ENTIRE function: just
+            // having a `try` cost ~5x on the surrounding loop even when nothing
+            // ever threw (#6385).
+            //
+            // The promotion is now blocked surgically instead, by emitting
+            // `volatile` loads/stores for exactly the allocas the try body
+            // writes (see `crate::volatile_setjmp`) — LLVM refuses to promote
+            // an alloca with any volatile access. Everything else optimizes.
+            //
+            // `noinline` stays. LLVM's `isInlineViable` already refuses to
+            // inline a function that contains a `returns_twice` call, so this
+            // is belt-and-braces rather than load-bearing — but it keeps the
+            // setjmp frame's identity from depending on an internal inliner
+            // policy, at zero cost.
+            ir.push_str("attributes #1 = { noinline }\n");
         }
         // Verified runtime-helper groups (#6082) — emitted only when a
         // declaration actually references them (mirrors the setjmp gating

--- a/crates/perry-codegen/src/stmt/mod.rs
+++ b/crates/perry-codegen/src/stmt/mod.rs
@@ -112,7 +112,18 @@ fn lower_async_rejecting_stmts_inner(
 
     ctx.current_block = body_idx;
     ctx.try_depth += 1;
+    // The whole async body runs between the setjmp above and a possible
+    // longjmp into `async.catch`. `async.catch` itself only touches runtime
+    // state (get/clear exception, reject the promise) and never reads a
+    // local, so in principle no alloca needs to survive that longjmp — but we
+    // open the region anyway rather than special-case it. The uniform rule
+    // ("every alloca stored inside a setjmp-protected region is volatile") is
+    // the one that is trivially sound, and this is still strictly better than
+    // the `optnone` it replaces: the arithmetic, compares and branches in an
+    // async body now optimize even though its locals stay frame-resident.
+    ctx.func.enter_try_region();
     lower_stmts_inner(ctx, stmts, emit_shadow_clears)?;
+    ctx.func.exit_try_region();
     ctx.try_depth -= 1;
     if !ctx.block().is_terminated() {
         ctx.block().call_void("js_try_end", &[]);

--- a/crates/perry-codegen/src/stmt/try_stmt.rs
+++ b/crates/perry-codegen/src/stmt/try_stmt.rs
@@ -60,12 +60,20 @@ pub(crate) fn lower_try(
     catch: Option<&perry_hir::CatchClause>,
     finally: Option<&[perry_hir::Stmt]>,
 ) -> Result<()> {
-    // Mark the enclosing function so IR emission adds `#1`
-    // (noinline optnone). At -O2 on aarch64, LLVM's mem2reg/SROA will
-    // otherwise promote allocas to SSA registers across the setjmp
-    // call — making mutations performed in the try body invisible in
-    // the catch block after longjmp. `returns_twice` on the setjmp
-    // call site alone is not sufficient.
+    // Mark the enclosing function so IR emission adds `#1` (noinline) and
+    // runs the setjmp volatile-promotion pass.
+    //
+    // At -O2 on aarch64, LLVM's mem2reg/SROA would otherwise promote allocas
+    // to SSA registers across the setjmp call, and `longjmp` — which restores
+    // the callee-saved registers snapshotted by `setjmp` — would revert the
+    // mutations the try body made, so the catch block reads stale values.
+    // `returns_twice` on the setjmp call site alone is not sufficient.
+    //
+    // The fix is C's `volatile` rule, not `optnone`: the
+    // `enter_try_region`/`exit_try_region` brackets below record every store
+    // the try body emits, and `LlFunction::to_ir` gives just those allocas
+    // volatile accesses. Everything else in the function — loop counters,
+    // arithmetic, compares, branches — stays fully optimizable (#6385).
     ctx.func.has_try = true;
 
     // Allocate blocks.
@@ -86,7 +94,12 @@ pub(crate) fn lower_try(
     // pops it via `js_try_end` before falling through to the function's
     // ret. Decremented after the body finishes lowering.
     ctx.try_depth += 1;
+    // Everything lowered from here on runs between the setjmp above and a
+    // possible longjmp into `try.catch`, so its stores must survive that
+    // longjmp (#6385).
+    ctx.func.enter_try_region();
     lower_stmts(ctx, body)?;
+    ctx.func.exit_try_region();
     ctx.try_depth -= 1;
     if !ctx.block().is_terminated() {
         ctx.block().call_void("js_try_end", &[]);
@@ -126,7 +139,13 @@ pub(crate) fn lower_try(
 
             ctx.current_block = cbody_idx;
             ctx.try_depth += 1;
+            // The catch body sits inside its OWN setjmp (the one just emitted):
+            // a throw escaping it longjmps to `try.catch.fail`, which re-runs
+            // the finally and reads locals. So its stores are also
+            // "modified between setjmp and longjmp" (#6385).
+            ctx.func.enter_try_region();
             lower_stmts(ctx, &clause.body)?;
+            ctx.func.exit_try_region();
             ctx.try_depth -= 1;
             if !ctx.block().is_terminated() {
                 ctx.block().call_void("js_try_end", &[]);

--- a/crates/perry-codegen/src/volatile_setjmp.rs
+++ b/crates/perry-codegen/src/volatile_setjmp.rs
@@ -1,0 +1,353 @@
+//! `volatile` promotion for the allocas a `try` body mutates (#6385).
+//!
+//! Perry lowers `try`/`catch` to `setjmp`/`longjmp` (see `stmt/try_stmt.rs`),
+//! not to LLVM unwind edges. `longjmp` restores the callee-saved registers and
+//! the stack pointer that `setjmp` snapshotted — so any value LLVM decided to
+//! keep in a register across the `setjmp` call reverts to its setjmp-time
+//! contents when the exception fires. C spells the consequence out in
+//! 7.13.2.1p3: an automatic object that is *modified between the `setjmp` and
+//! the `longjmp`* and read afterwards has an indeterminate value unless it is
+//! declared `volatile`.
+//!
+//! Perry's locals are alloca-backed, and at `-O2` `mem2reg`/`SROA` promote
+//! those allocas to SSA registers. So the C hazard is exactly our hazard:
+//!
+//! ```text
+//! let acc = 0;
+//! try { acc = 41; throw e; }   // store promoted into a callee-saved reg
+//! catch { acc += 1; }          // longjmp reverted the reg → acc reads 0
+//! ```
+//!
+//! Historically Perry avoided this by stamping `optnone` on the **whole
+//! function** containing the `try`. That is correct (at `-O0` every value is
+//! spilled to the frame, and the frame survives `longjmp`) but it is a
+//! sledgehammer: merely *having* a `try` — even one that never throws — cost a
+//! 5x slowdown on the surrounding code, because the loop counters, the
+//! arithmetic, the compares and the branches all stopped being optimized too.
+//!
+//! This module implements the `volatile` rule instead. `mem2reg` and `SROA`
+//! both refuse to promote an alloca that has any volatile load/store
+//! (`isAllocaPromotable` / SROA's slice analysis bail on `isVolatile()`), and
+//! volatile accesses can be neither elided nor reordered against each other, so
+//! the value provably lives in the frame across the `setjmp`. Everything else
+//! in the function stays fully optimizable.
+//!
+//! # The volatile set — and why it is sound
+//!
+//! `LlBlock::emit` records the destination pointer of **every `store`
+//! instruction emitted while codegen is inside a setjmp-protected region**
+//! (`RegCounter::enter_try_region` / `exit_try_region`, driven from
+//! `lower_try` and the async-boundary lowering). That recorded set is a
+//! superset of "automatic objects this function modifies between a `setjmp` and
+//! its `longjmp`", because:
+//!
+//! * The region is tracked by **emission depth**, not by block index, so it
+//!   automatically covers nested blocks, loops, nested `try`s, and the
+//!   duplicated finally bodies — anything lowered while the region is open,
+//!   regardless of which basic block the instruction lands in.
+//! * We drop the "…and read after the longjmp" half of the C condition. Marking
+//!   an alloca that is written in the try but never read afterwards is merely
+//!   conservative, never wrong.
+//! * Every access to a marked alloca is upgraded, function-wide — not just the
+//!   ones inside the try — because promotion is an all-or-nothing property of
+//!   the alloca.
+//! * Pointers *derived* from an alloca (`getelementptr` into an
+//!   `alloca [N x double]`) are resolved back to their base alloca, so a store
+//!   through a derived pointer marks the whole object.
+//!
+//! Conversely, an alloca this function never stores to inside a try region
+//! cannot have been modified between the `setjmp` and the `longjmp` **by this
+//! frame**, and the only other way to modify it is for its address to escape to
+//! a callee — which by itself already defeats `mem2reg`/`SROA` (an alloca with
+//! a non-load/store user is not promotable), so those stay in memory anyway.
+//!
+//! Values that are *not* memory need no help: an SSA value defined inside the
+//! try body cannot be read from the catch block (it does not dominate it), and
+//! an SSA value defined *before* the `setjmp` and used after it is live across
+//! the call, so the register allocator either spills it to the frame (which
+//! `longjmp` preserves) or parks it in a callee-saved register (which `longjmp`
+//! restores to the same, unmodified value). Module globals are memory, and
+//! every try region is bracketed by opaque runtime calls (`js_try_push`,
+//! `_setjmp`, `js_try_end`, `js_throw`) that LLVM must assume clobber them, so
+//! they are never cached in a register across the boundary either.
+
+use std::borrow::Cow;
+use std::collections::{HashMap, HashSet};
+
+/// Destination pointer operand of a `store` line.
+///
+/// `store double %r4, ptr %r3, align 8` → `%r3`. Uses the LAST `, ptr `
+/// so that `store ptr %v, ptr %slot` (a pointer value stored into a slot)
+/// still yields the destination rather than the value.
+pub(crate) fn store_dest_ptr(line: &str) -> Option<&str> {
+    let t = line.trim_start();
+    if !t.starts_with("store ") {
+        return None;
+    }
+    let at = t.rfind(", ptr ")?;
+    Some(first_operand(&t[at + ", ptr ".len()..]))
+}
+
+/// Source pointer operand of a `load` line.
+/// `%r5 = load double, ptr %r3, align 8` → `%r3`.
+fn load_src_ptr(t: &str) -> Option<&str> {
+    let at = t.find(" = load ")?;
+    let rest = &t[at + " = load ".len()..];
+    let p = rest.rfind(", ptr ")?;
+    Some(first_operand(&rest[p + ", ptr ".len()..]))
+}
+
+/// `%r3 = alloca double` / `%r3 = alloca [8 x double], align 8` → `%r3`.
+fn alloca_result(t: &str) -> Option<&str> {
+    let at = t.find(" = alloca ")?;
+    let res = &t[..at];
+    res.starts_with('%').then_some(res)
+}
+
+/// A pointer-producing instruction whose base is another pointer:
+/// `%r9 = getelementptr inbounds [8 x double], ptr %r3, i64 0, i64 2`
+/// → `(%r9, %r3)`. The base is the FIRST `, ptr ` operand.
+fn derived_ptr(t: &str) -> Option<(&str, &str)> {
+    let at = t.find(" = getelementptr ")?;
+    let res = &t[..at];
+    if !res.starts_with('%') {
+        return None;
+    }
+    let rest = &t[at + " = getelementptr ".len()..];
+    let p = rest.find(", ptr ")?;
+    Some((res, first_operand(&rest[p + ", ptr ".len()..])))
+}
+
+/// First whitespace/comma-delimited token of `s`.
+fn first_operand(s: &str) -> &str {
+    let end = s
+        .find(|c: char| c == ',' || c.is_whitespace())
+        .unwrap_or(s.len());
+    &s[..end]
+}
+
+/// Rewrite `ir` so every load/store touching an alloca that the try region
+/// stores into carries `volatile`.
+///
+/// `try_stores` are the raw pointer operands recorded at emit time
+/// (see [`store_dest_ptr`]); most are alloca registers, but the set may also
+/// contain globals and heap pointers, which are filtered out here.
+pub(crate) fn apply_setjmp_volatile(ir: &str, try_stores: &HashSet<String>) -> String {
+    let lines: Vec<&str> = ir.lines().collect();
+
+    // 1. Every alloca defined in this function is its own base.
+    let mut base: HashMap<&str, &str> = HashMap::new();
+    for l in &lines {
+        let t = l.trim_start();
+        if let Some(r) = alloca_result(t) {
+            base.insert(r, r);
+        }
+    }
+    if base.is_empty() {
+        return ir.to_string();
+    }
+
+    // 2. Resolve derived pointers back to their base alloca. Blocks are
+    //    rendered in creation order, which is not guaranteed to be a
+    //    dominator order, so a single linear pass can miss a `getelementptr`
+    //    whose base is defined further down the text. Iterate to a fixpoint.
+    loop {
+        let mut changed = false;
+        for l in &lines {
+            let t = l.trim_start();
+            if let Some((res, src)) = derived_ptr(t) {
+                if !base.contains_key(res) {
+                    if let Some(&b) = base.get(src) {
+                        base.insert(res, b);
+                        changed = true;
+                    }
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+
+    // 3. Allocas the try region writes — directly or through a derived pointer.
+    let mut volatile_allocas: HashSet<&str> = HashSet::new();
+    for p in try_stores {
+        if let Some(&b) = base.get(p.as_str()) {
+            volatile_allocas.insert(b);
+        }
+    }
+    if volatile_allocas.is_empty() {
+        return ir.to_string();
+    }
+
+    // 4. Upgrade EVERY access to those allocas, function-wide — not just the
+    //    ones inside the try. Suppressing promotion only takes one volatile
+    //    access (mem2reg/SROA bail on any `isVolatile()` user), but the
+    //    *individual* accesses must be volatile too: a plain load in the catch
+    //    block could otherwise be forwarded by GVN from a plain store that
+    //    dominates the setjmp, reintroducing the stale read we are fixing.
+    let mut out = String::with_capacity(ir.len() + 128);
+    for l in &lines {
+        out.push_str(&upgrade(l, &base, &volatile_allocas));
+        out.push('\n');
+    }
+    out
+}
+
+fn is_volatile_target(
+    ptr: &str,
+    base: &HashMap<&str, &str>,
+    volatile_allocas: &HashSet<&str>,
+) -> bool {
+    base.get(ptr).is_some_and(|b| volatile_allocas.contains(*b))
+}
+
+fn upgrade<'a>(
+    line: &'a str,
+    base: &HashMap<&str, &str>,
+    volatile_allocas: &HashSet<&str>,
+) -> Cow<'a, str> {
+    let t = line.trim_start();
+    let indent = &line[..line.len() - t.len()];
+
+    if t.starts_with("store ") {
+        if t.starts_with("store volatile ") {
+            return Cow::Borrowed(line);
+        }
+        if let Some(p) = store_dest_ptr(t) {
+            if is_volatile_target(p, base, volatile_allocas) {
+                return Cow::Owned(format!("{}store volatile {}", indent, &t["store ".len()..]));
+            }
+        }
+        return Cow::Borrowed(line);
+    }
+
+    if let Some(at) = t.find(" = load ") {
+        let rest = &t[at + " = load ".len()..];
+        if rest.starts_with("volatile ") {
+            return Cow::Borrowed(line);
+        }
+        if let Some(p) = load_src_ptr(t) {
+            if is_volatile_target(p, base, volatile_allocas) {
+                // `!invariant.load` promises the memory never changes — the
+                // exact opposite of what a try-mutated slot needs. Drop it.
+                let rest = rest.split(", !invariant.load").next().unwrap_or(rest);
+                return Cow::Owned(format!("{}{} = load volatile {}", indent, &t[..at], rest));
+            }
+        }
+    }
+
+    Cow::Borrowed(line)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stores(regs: &[&str]) -> HashSet<String> {
+        regs.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn parses_store_destination_not_the_stored_pointer() {
+        assert_eq!(store_dest_ptr("  store double %r4, ptr %r3"), Some("%r3"));
+        assert_eq!(
+            store_dest_ptr("  store double %r4, ptr %r3, align 8"),
+            Some("%r3")
+        );
+        // A pointer VALUE stored into a slot: the destination is the 2nd ptr.
+        assert_eq!(store_dest_ptr("  store ptr %r7, ptr %r2"), Some("%r2"));
+        assert_eq!(store_dest_ptr("  %r1 = load double, ptr %r2"), None);
+    }
+
+    #[test]
+    fn upgrades_only_the_try_written_slot() {
+        let ir = "define double @f() #1 {\n\
+                  entry:\n\
+                  \x20 %acc = alloca double\n\
+                  \x20 %i = alloca double\n\
+                  \x20 store double 0.0, ptr %acc\n\
+                  \x20 store double 0.0, ptr %i\n\
+                  \x20 %v = load double, ptr %i\n\
+                  \x20 %a = load double, ptr %acc\n\
+                  \x20 ret double %a\n\
+                  }\n";
+        let out = apply_setjmp_volatile(ir, &stores(&["%acc"]));
+        assert!(out.contains("store volatile double 0.0, ptr %acc"));
+        assert!(out.contains("%a = load volatile double, ptr %acc"));
+        // The loop counter is untouched — that is the whole point of #6385.
+        assert!(out.contains("  store double 0.0, ptr %i\n"));
+        assert!(out.contains("  %v = load double, ptr %i\n"));
+    }
+
+    #[test]
+    fn a_store_through_a_gep_marks_the_whole_alloca() {
+        let ir = "define void @f() #1 {\n\
+                  entry:\n\
+                  \x20 %buf = alloca [4 x double]\n\
+                  \x20 %p0 = getelementptr inbounds [4 x double], ptr %buf, i64 0, i64 0\n\
+                  \x20 %p1 = getelementptr inbounds [4 x double], ptr %buf, i64 0, i64 1\n\
+                  \x20 store double 1.0, ptr %p1\n\
+                  \x20 %x = load double, ptr %p0\n\
+                  \x20 ret void\n\
+                  }\n";
+        let out = apply_setjmp_volatile(ir, &stores(&["%p1"]));
+        assert!(out.contains("store volatile double 1.0, ptr %p1"));
+        // The sibling element of the same alloca is upgraded too: mem2reg/SROA
+        // promotability is a property of the alloca, not of one slice.
+        assert!(out.contains("%x = load volatile double, ptr %p0"));
+    }
+
+    #[test]
+    fn globals_and_heap_pointers_are_not_allocas_and_stay_untouched() {
+        let ir = "define void @f() #1 {\n\
+                  entry:\n\
+                  \x20 %s = alloca double\n\
+                  \x20 store double 1.0, ptr @perry_global_m__3\n\
+                  \x20 %g = load double, ptr @perry_global_m__3\n\
+                  \x20 ret void\n\
+                  }\n";
+        let out = apply_setjmp_volatile(ir, &stores(&["@perry_global_m__3"]));
+        assert!(!out.contains("volatile"));
+    }
+
+    #[test]
+    fn already_volatile_accesses_are_left_alone() {
+        let ir = "define void @f() #1 {\n\
+                  entry:\n\
+                  \x20 %s = alloca double\n\
+                  \x20 store volatile double 1.0, ptr %s\n\
+                  \x20 %v = load volatile double, ptr %s\n\
+                  \x20 ret void\n\
+                  }\n";
+        let out = apply_setjmp_volatile(ir, &stores(&["%s"]));
+        assert!(!out.contains("store volatile volatile"));
+        assert!(!out.contains("load volatile volatile"));
+    }
+
+    #[test]
+    fn invariant_load_metadata_is_dropped_on_upgrade() {
+        let ir = "define void @f() #1 {\n\
+                  entry:\n\
+                  \x20 %s = alloca i64\n\
+                  \x20 store i64 1, ptr %s\n\
+                  \x20 %v = load i64, ptr %s, !invariant.load !0\n\
+                  \x20 ret void\n\
+                  }\n";
+        let out = apply_setjmp_volatile(ir, &stores(&["%s"]));
+        assert!(out.contains("%v = load volatile i64, ptr %s"));
+        assert!(!out.contains("!invariant.load"));
+    }
+
+    #[test]
+    fn no_try_stores_is_a_no_op() {
+        let ir = "define void @f() {\n\
+                  entry:\n\
+                  \x20 %s = alloca double\n\
+                  \x20 store double 1.0, ptr %s\n\
+                  \x20 ret void\n\
+                  }\n";
+        let out = apply_setjmp_volatile(ir, &HashSet::new());
+        assert_eq!(out, ir);
+    }
+}

--- a/crates/perry-codegen/src/volatile_setjmp.rs
+++ b/crates/perry-codegen/src/volatile_setjmp.rs
@@ -73,6 +73,26 @@
 
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
+use std::sync::OnceLock;
+
+/// `PERRY_SETJMP_VOLATILE=0` / `off` / `false` turns the promotion OFF.
+///
+/// **This produces miscompiled code and exists only to bisect/falsify.** With
+/// the promotion disabled, a value written in a `try` body and read in the
+/// `catch` silently reverts to its pre-`setjmp` value at `-O2`. It is here so
+/// the guarantee this module provides is *testable*: build once, run
+/// `test-files/test_gap_try_setjmp_volatile.ts` with and without the flag —
+/// green with, red without. A test that passes both ways proves nothing.
+///
+/// (Same spirit as `PERRY_WRITE_BARRIERS=0` and `PERRY_GEN_GC=0`: a
+/// deliberately-unsound switch, for A/B only.)
+fn promotion_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| match std::env::var("PERRY_SETJMP_VOLATILE") {
+        Ok(v) => !matches!(v.as_str(), "0" | "off" | "false"),
+        Err(_) => true,
+    })
+}
 
 /// Destination pointer operand of a `store` line.
 ///
@@ -133,6 +153,9 @@ fn first_operand(s: &str) -> &str {
 /// (see [`store_dest_ptr`]); most are alloca registers, but the set may also
 /// contain globals and heap pointers, which are filtered out here.
 pub(crate) fn apply_setjmp_volatile(ir: &str, try_stores: &HashSet<String>) -> String {
+    if !promotion_enabled() {
+        return ir.to_string();
+    }
     let lines: Vec<&str> = ir.lines().collect();
 
     // 1. Every alloca defined in this function is its own base.

--- a/test-files/test_gap_try_setjmp_volatile.ts
+++ b/test-files/test_gap_try_setjmp_volatile.ts
@@ -1,0 +1,350 @@
+// Adversarial suite for the setjmp/longjmp volatile-slot contract (#6385).
+//
+// Perry lowers try/catch to setjmp/longjmp. Any automatic (alloca-backed)
+// local that is MODIFIED between the setjmp and the longjmp and then READ on
+// the post-longjmp path must live in memory across the setjmp — otherwise
+// LLVM's mem2reg/SROA promotes it to an SSA register, the register allocator
+// parks it in a callee-saved register, and longjmp restores that register to
+// its setjmp-time value: the try-body mutation silently evaporates.
+//
+// Every case below writes a local inside a `try` body (directly, in a nested
+// block, in a loop, in a nested try, in a closure) and then reads it after the
+// longjmp has fired. A miscompile shows up as a stale value, NOT a crash.
+//
+// MUST be checked at release/-O2 — perry-dev (opt-level=1) can hide it.
+
+let out = "";
+function log(label: string, v: unknown): void {
+  out += label + "=" + String(v) + "\n";
+}
+
+// 1. Plain: written in try, read in catch.
+function c1(): number {
+  let acc = 0;
+  try {
+    acc = 41;
+    throw new Error("x");
+  } catch (e) {
+    acc += 1;
+  }
+  return acc;
+}
+log("c1", c1()); // 42
+
+// 2. Written in try, read in FINALLY.
+function c2(): number {
+  let acc = 0;
+  try {
+    acc = 7;
+    throw new Error("x");
+  } catch (e) {
+    acc *= 2;
+  } finally {
+    acc += 100;
+  }
+  return acc;
+}
+log("c2", c2()); // 114
+
+// 3. Written in try, read AFTER the whole try statement.
+function c3(): number {
+  let acc = 0;
+  try {
+    acc = 5;
+    throw new Error("x");
+  } catch (e) {
+    // does not touch acc
+  }
+  return acc + 1;
+}
+log("c3", c3()); // 6
+
+// 4. `var` (function-scoped) rather than `let`.
+function c4(): number {
+  var acc = 0;
+  var i = 0;
+  for (i = 0; i < 10; i++) {
+    try {
+      acc += 1;
+      if (i === 3) throw i;
+      acc += 10;
+    } catch (e) {
+      acc += 100;
+    }
+  }
+  return acc;
+}
+log("c4", c4()); // 9 iters * 11 + 1 iter * (1 + 100) = 99 + 101 = 200
+
+// 5. Written inside a LOOP inside the try; throw after some iterations.
+function c5(): number {
+  let acc = 0;
+  try {
+    for (let i = 0; i < 100; i++) {
+      acc += i;
+      if (i === 10) throw new Error("stop");
+    }
+  } catch (e) {
+    acc += 1000;
+  }
+  return acc;
+}
+log("c5", c5()); // 0..10 = 55, + 1000 = 1055
+
+// 6. Written in a NESTED try's body; outer catch reads it.
+function c6(): number {
+  let acc = 0;
+  try {
+    try {
+      acc += 1;
+      throw new Error("inner");
+    } catch (e) {
+      acc += 2;
+    }
+    acc += 4;
+    throw new Error("outer");
+  } catch (e) {
+    acc += 8;
+  }
+  return acc;
+}
+log("c6", c6()); // 15
+
+// 7. Written in try AND again in catch; read after.
+function c7(): number {
+  let acc = 1;
+  try {
+    acc = acc * 3; // 3
+    throw new Error("x");
+  } catch (e) {
+    acc = acc * 5; // 15
+  }
+  return acc;
+}
+log("c7", c7()); // 15
+
+// 8. Throw BEFORE the write — catch must see the pre-try value.
+function c8(): number {
+  let acc = 9;
+  try {
+    if (acc === 9) throw new Error("early");
+    acc = 999; // never runs
+  } catch (e) {
+    acc += 1;
+  }
+  return acc;
+}
+log("c8", c8()); // 10
+
+// 9. Written in a closure created inside the try, called inside the try.
+function c9(): number {
+  let acc = 0;
+  try {
+    const bump = () => {
+      acc += 3;
+    };
+    bump();
+    bump();
+    throw new Error("x");
+  } catch (e) {
+    acc += 1;
+  }
+  return acc;
+}
+log("c9", c9()); // 7
+
+// 10. Object / array field mutated in the try (heap — must be unaffected).
+function c10(): string {
+  const o: { n: number } = { n: 0 };
+  const a: number[] = [0];
+  try {
+    o.n = 5;
+    a[0] = 6;
+    a.push(7);
+    throw new Error("x");
+  } catch (e) {
+    o.n += 1;
+  }
+  return o.n + "," + a[0] + "," + a[1] + "," + a.length;
+}
+log("c10", c10()); // 6,6,7,2
+
+// 11. Many locals, only some written in the try (checks we don't lose the
+//     un-written ones either — those are live across the setjmp).
+function c11(): string {
+  let a = 1;
+  let b = 2;
+  let c = 3;
+  let d = 4;
+  try {
+    a = 10;
+    c = 30;
+    throw new Error("x");
+  } catch (e) {
+    a += b; // 12
+    c += d; // 34
+  }
+  return a + "," + b + "," + c + "," + d;
+}
+log("c11", c11()); // 12,2,34,4
+
+// 12. try/finally with NO catch: finally reads a try-body write, then the
+//     throw re-propagates to an outer catch which also reads it.
+function c12(): number {
+  let acc = 0;
+  try {
+    try {
+      acc = 3;
+      throw new Error("x");
+    } finally {
+      acc += 10; // 13
+    }
+  } catch (e) {
+    acc += 100; // 113
+  }
+  return acc;
+}
+log("c12", c12()); // 113
+
+// 13. Write in the CATCH body of a try that HAS a finally (the catch body is
+//     itself setjmp-protected so the finally can re-run on a catch-body throw).
+function c13(): number {
+  let acc = 0;
+  try {
+    try {
+      throw new Error("a");
+    } catch (e) {
+      acc = 1;
+      throw new Error("b"); // escapes the catch → finally must still run
+    } finally {
+      acc += 10; // 11
+    }
+  } catch (e) {
+    acc += 100; // 111
+  }
+  return acc;
+}
+log("c13", c13()); // 111
+
+// 14. String local written in the try (pointer-tagged, GC-tracked).
+function c14(): string {
+  let s = "a";
+  try {
+    s = s + "b";
+    throw new Error("x");
+  } catch (e) {
+    s = s + "c";
+  }
+  return s;
+}
+log("c14", c14()); // abc
+
+// 15. Compound: accumulator + counter, throw on odd — the #6385 shape.
+function c15(): number {
+  let acc = 0;
+  for (let i = 0; i < 1000; i++) {
+    try {
+      if ((i & 1) === 0) throw i;
+      acc += 1;
+    } catch (e) {
+      acc += 2;
+    }
+  }
+  return acc;
+}
+log("c15", c15()); // 500*2 + 500*1 = 1500
+
+// 16. Destructured locals written inside the try.
+function c16(): string {
+  let x = 0;
+  let y = 0;
+  try {
+    [x, y] = [11, 22];
+    throw new Error("x");
+  } catch (e) {
+    x += 1;
+  }
+  return x + "," + y;
+}
+log("c16", c16()); // 12,22
+
+// 17. Catch parameter reassigned inside the catch body, with a finally
+//     (the catch body is setjmp-protected).
+function c17(): string {
+  let r = "";
+  try {
+    try {
+      throw "orig";
+    } catch (e) {
+      e = String(e) + "-mut";
+      r = String(e);
+      throw new Error("again");
+    } finally {
+      r += "|fin";
+    }
+  } catch (e2) {
+    r += "|outer";
+  }
+  return r;
+}
+log("c17", c17()); // orig-mut|fin|outer
+
+// 18. Async: write in try, read in catch after an awaited rejection.
+async function c18(): Promise<number> {
+  let acc = 0;
+  try {
+    acc = 4;
+    await Promise.reject(new Error("x"));
+    acc = 999;
+  } catch (e) {
+    acc += 1;
+  }
+  return acc;
+}
+
+// 19. Generator: write in try, read in catch after a throw across a yield.
+function* gen(): Generator<number, number, unknown> {
+  let acc = 0;
+  try {
+    acc = 2;
+    yield 1;
+    acc = 999;
+  } catch (e) {
+    acc += 3;
+  }
+  return acc;
+}
+function c19(): number {
+  const g = gen();
+  g.next();
+  const r = g.throw(new Error("x")) as IteratorResult<number, number>;
+  return r.value as number;
+}
+log("c19", c19()); // 5
+
+// 20. Deeply-nested try in a loop in a try, all sharing one accumulator.
+function c20(): number {
+  let acc = 0;
+  try {
+    for (let i = 0; i < 5; i++) {
+      try {
+        acc += 1;
+        if (i % 2 === 0) throw i;
+        acc += 10;
+      } catch (e) {
+        acc += 100;
+      }
+    }
+    throw new Error("outer");
+  } catch (e) {
+    acc += 1000;
+  }
+  return acc;
+}
+log("c20", c20()); // i=0,2,4 -> 101 each = 303; i=1,3 -> 11 each = 22; +1000 = 1325
+
+async function main(): Promise<void> {
+  log("c18", await c18()); // 5
+  process.stdout.write(out);
+}
+main();


### PR DESCRIPTION
Fixes the `optnone` contagion behind #6385: **merely having a `try` in a function deoptimized the entire function**, even when nothing ever threw.

## The defect

Perry lowers `try`/`catch` to `setjmp`/`longjmp` (`stmt/try_stmt.rs`), not to LLVM unwind edges. `longjmp` restores the callee-saved registers and stack pointer that `setjmp` snapshotted, so any local LLVM parked in a register across the setjmp reverts to its setjmp-time value when the exception fires — the try body's mutations vanish in the `catch`. This is exactly C's `setjmp` hazard (C11 7.13.2.1p3).

`codegen` defended against it by stamping `optnone` on the **whole function** containing the `try`. That is correct (at `-O0` every value is frame-resident, and the frame survives `longjmp`) but it is a sledgehammer: the loop counters, the arithmetic, the compares and the branches around the `try` all stopped being optimized too. Every `try`-containing function — and every direct `async` function, which gets the same setjmp-based rejection boundary — was compiled unoptimized.

## The fix

Apply C's `volatile` rule precisely instead of disabling optimization wholesale. `mem2reg`/`SROA` refuse to promote an alloca that has any volatile load/store (`isAllocaPromotable` bails on `isVolatile()`), and volatile accesses can be neither elided nor reordered against each other — so a volatile-accessed slot provably lives in the frame across the setjmp, while everything else in the function optimizes normally.

- `RegCounter` (`block.rs`) gains a **try-region depth** counter. `LlBlock::emit` — the single choke point every emitter funnels through, including `emit_raw` — records the destination pointer of every `store` emitted while the depth is non-zero.
- `lower_try` brackets the **try body** and the **finally-protected catch body** with `enter_try_region`/`exit_try_region`; the async rejection boundary brackets the async body.
- `LlFunction::to_ir` then runs `volatile_setjmp::apply_setjmp_volatile`: it resolves those recorded pointers back to their base allocas (through `getelementptr` derivation, to a fixpoint) and rewrites **every** load/store of those allocas — function-wide — to `volatile`.
- `attributes #1` drops `optnone`, keeping only `noinline`.

`noinline` stays: LLVM's `isInlineViable` already refuses to inline a function containing a `returns_twice` call, so it is belt-and-braces rather than load-bearing — but it keeps the setjmp frame's identity from depending on an internal inliner policy, at zero cost.

### The volatile set, and why it is sound

The set is **"every alloca this function stores into while inside a setjmp-protected region"**. One rule, no exceptions — that is what makes it auditable.

* It is a **superset** of the C condition. C says: an automatic object *modified between the `setjmp` and the `longjmp`* and *read afterwards* is indeterminate unless `volatile`. We drop the "and read afterwards" half. Marking a slot that the try writes but nothing reads afterwards is merely conservative, never wrong.
* The region is tracked by **emission depth, not block index**, so it automatically covers nested blocks, loops, nested `try`s, and the duplicated `finally` bodies — whatever is lowered while the region is open belongs to it, regardless of which basic block the instruction lands in. Nesting composes for free.
* Every access to a marked alloca is upgraded, not just the ones inside the try, because promotability is a property of the alloca — and because a plain load in the `catch` could otherwise be GVN-forwarded from a plain store that dominates the setjmp.
* **Conversely**, an alloca this function never stores to inside a try region cannot have been modified between the `setjmp` and the `longjmp` *by this frame*. The only other way to modify it is for its address to escape to a callee — and an alloca with a non-load/store user already defeats `mem2reg`/`SROA`, so those stay in memory anyway.
* **Non-memory needs no help.** An SSA value defined inside the try body cannot be read from the catch (it does not dominate it). An SSA value defined *before* the setjmp and used after is live across the call, so the register allocator either spills it to the frame (which `longjmp` preserves) or parks it in a callee-saved register (which `longjmp` restores to the same, unmodified value).
* **Module globals need no help.** They are memory, and every try region is bracketed by opaque runtime calls (`js_try_push`, `_setjmp`, `js_try_end`, `js_throw`) that LLVM must assume clobber them, so they are never cached in a register across the boundary.
* **Heap needs no help** (objects, arrays, boxed closure captures, generator/async state objects, shadow-stack GC roots — the last go through `js_shadow_slot_set`, a runtime call, not an alloca).

On the #6385 benchmark this yields the intended set exactly. `throughput()` lowers to `%r3` = `acc`, `%r5` = `i`:

```llvm
; before: define double @...throughput() #1 {   ; #1 = { noinline optnone }  ← whole fn dead
; after:  define double @...throughput() #1 {   ; #1 = { noinline }
  store volatile double 0.0, ptr %r3      ; acc  — written in the try body
  store          double 0.0, ptr %r5      ; i    — written only in for.update, OUTSIDE the try
```

`acc` stays frame-resident; the loop counter, the `i & 1`, the compare, the branch — and three redundant reloads of `i` that `optnone` used to preserve — all optimize normally.

## Proving the volatile set is load-bearing

A correctness test that passes both with and without the fix proves nothing. `PERRY_SETJMP_VOLATILE=0` (new, documented bisection-only switch, same spirit as `PERRY_WRITE_BARRIERS=0`) disables the promotion while still dropping `optnone` — i.e. it reproduces the miscompile the promotion exists to prevent.

`test-files/test_gap_try_setjmp_volatile.ts` is a 20-case adversarial suite (written **before** the optimization): written-in-try/read-in-catch, read-in-finally, read-after-the-try, `let` vs `var`, nested `try`, written-in-a-loop-in-the-try, written-in-a-closure, written-in-try-*and*-catch, heap object/array mutation, throw-before-vs-after the write, destructuring, `try/finally` with no catch, catch-param reassignment, async, generator.

Built at **release** (`-O2`/`-O3`; `perry-dev` at opt-level=1 hides the bug entirely):

| | vs `node --experimental-strip-types` |
|---|---|
| promotion **on** (shipped default) | **20/20 identical** |
| `PERRY_SETJMP_VOLATILE=0` | **13/20 silently wrong** |

The failures are exactly the predicted stale-value pattern — the try's write evaporates and the catch reads the pre-`setjmp` value:

```
 c1=42   → c1=1      (try does acc=41; catch reads acc==0, does acc+=1)
 c2=114  → c2=100    c3=6    → c3=1     c4=200  → c4=199
 c5=1055 → c5=1000   c6=15   → c6=8     c7=15   → c7=5
 c11=12,2,34,4 → c11=3,2,7,4            c12=113 → c12=100
 c13=111 → c13=100   c16=12,22 → c16=1,0          c20=1325 → c20=1000
```

Two of those earn their keep specifically: **c12** (`try/finally` with no `catch`, whose finally re-runs on the exception path) and **c13** (a write in the `catch` body of a `try` that has a `finally` — the catch body is itself setjmp-protected so the finally can re-run on a catch-body throw). Both regions are ones this PR deliberately brackets; both go red without them.

## Before / after (release, macOS arm64, min-of-5×5, interleaved A/B)

| shape | node | main | this PR |
|---|--:|--:|--:|
| no `try` at all | 3 ms | 3 ms | **3 ms** |
| `try`/`catch` present, **never throws** | 3 ms | 16 ms | **13 ms** |
| throws 500k times (#6385's benchmark) | 935 ms | 178 ms | **180 ms** |
| JSON parse loop w/ throw bail-out (50k rows) | 35 ms | 38 ms | **39 ms** |
| `try` **around** a 20M-iteration hot loop | 24 ms | 79 ms | **77 ms** |

Correctness is unchanged everywhere; the throwing benchmark does not regress (Perry already beats V8 there — the remaining gap to Hermes is structural, see below).

## Honest reporting: this does NOT close most of the never-throws gap

The issue's framing (and my initial hypothesis) was that the 3 ms → 16 ms penalty for *having* a `try` was mostly `optnone`. **It is not.** Removing `optnone` buys ~3 of the 13 ms. The other ~10 ms is the `js_try_push` + `_setjmp` + `js_try_end` call sequence executed **once per loop iteration** — ~10 ns × 1M. That is structural to setjmp-based EH and is not addressable by this PR; closing it means a zero-cost-until-thrown table-driven scheme, which is a much larger change. I'd rather say so than dress up a 1.25x as a 5x.

What this PR *does* buy is the removal of a silent, general tax: **every** function containing a `try` — and every direct `async` function — was previously compiled with optimization off, whether or not the `try` was hot. That penalty scales with the size of the function, not with how often it throws, and it is now gone.

## One measured regression, and why it is pre-existing

A synthetic "small `try` guard, then a hot loop" shape (`bench_guard`) went **79 ms → 93 ms**. It is not the volatile set — the IR shows only `flag` marked volatile, with the loop counter free. The cause: for that exact function shape, Perry's `-O3` output is *slower than its `-O0` output*, and `optnone` was accidentally protecting it. The proof is that the identical loop with **no `try` at all** — same code path in both compilers, no volatile, no setjmp — runs at **123 ms**, i.e. worse than either. So the `-O3` cliff is pre-existing and reproducible without any `try`; this PR merely stops masking it for `try`-containing functions, and in fact lands *better* than the try-less baseline (93 ms vs 123 ms). Worth a separate issue; not a reason to keep `optnone`.

## Validation

- `cargo test -p perry-codegen --lib` — 183 passed, including 7 new `volatile_setjmp` unit tests (store-destination parsing vs the stored pointer, GEP-derived stores marking the whole alloca, globals/heap left alone, already-volatile left alone, `!invariant.load` dropped on upgrade, no-op when there are no try stores).
  (The 2 pre-existing integration-test compile errors in `perry-codegen` — `CompileOptions has no field named namespace_reexport_named_imports` — are on `main` too and unrelated.)
- Adversarial suite at **release**: 20/20 vs node, and provably red without the promotion.
- Gap suite A/B vs a pristine `origin/main` toolchain: see comment below.
- `cargo fmt --all -- --check` clean; `bash scripts/check_file_size.sh` clean.

## Files

- `crates/perry-codegen/src/volatile_setjmp.rs` (new) — the promotion pass + soundness argument + unit tests
- `crates/perry-codegen/src/block.rs` — `RegCounter` try-region depth + store recording in `emit`
- `crates/perry-codegen/src/function.rs` — `enter/exit_try_region`, `to_ir` runs the pass last
- `crates/perry-codegen/src/stmt/try_stmt.rs` — bracket the try body + finally-protected catch body
- `crates/perry-codegen/src/stmt/mod.rs` — bracket the async rejection boundary
- `crates/perry-codegen/src/module.rs` — `attributes #1 = { noinline }` (was `{ noinline optnone }`)
- `test-files/test_gap_try_setjmp_volatile.ts` (new) — the 20-case adversarial suite


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of `try`/`catch`/`finally` behavior across non-local control flow.
  * Prevented stale local values after exceptions, including nested, async, generator, closure, looping, and destructuring scenarios.
  * Preserved correct behavior when return handling is combined with exception paths.

* **Tests**
  * Added comprehensive coverage for setjmp/longjmp-related control-flow and local-variable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->