### PR TITLE
test(gap): de-flake test_gap_fs_fd_2749 — it raced the libuv threadpool

### DIFF
--- a/test-files/test_gap_fs_fd_2749.ts
+++ b/test-files/test_gap_fs_fd_2749.ts
@@ -33,11 +33,26 @@ function syncCode(label: string, fn: () => void): void {
   }
 }
 
+// The three callback-form calls below are dispatched to the libuv threadpool
+// concurrently, so their callbacks fire in *completion* order, which is not
+// deterministic — node itself emits `fchown closed cb` before `futimes closed
+// cb` on roughly one run in six. Comparing raw interleaving against a freshly
+// run node oracle therefore fails at random on any PR.
+//
+// What this test is actually about is the error surface (`err.code` /
+// `err.syscall`) of each fd mutator, not libuv's scheduling. So buffer the
+// three results and flush them in a fixed order once all three have landed.
+// Every assertion is preserved; only the print order is pinned.
+const CB_ORDER = ["ftruncate closed cb", "futimes closed cb", "fchown closed cb"];
+const cbLines = new Map<string, string>();
+
 function cbCode(label: string, err: any): void {
-  if (err) {
-    console.log(label + ": " + err.code + " " + err.syscall);
-  } else {
-    console.log(label + ": OK");
+  cbLines.set(label, err ? label + ": " + err.code + " " + err.syscall : label + ": OK");
+  if (cbLines.size < CB_ORDER.length) {
+    return;
+  }
+  for (const key of CB_ORDER) {
+    console.log(cbLines.get(key));
   }
 }
 


### PR DESCRIPTION
`test_gap_fs_fd_2749` is flaky, and it has been silently red-lighting unrelated PRs. It took out **#6397, #6398 and #6399** today — each of which had it as their *only* untriaged failure — and it cost a full bisect before the oracle itself became the suspect.

### The test races the libuv threadpool

The three callback-form fd mutators are dispatched concurrently:

```ts
fs.ftruncate(fd, 1, (err) => cbCode("ftruncate closed cb", err));
fs.futimes(fd, 1, 2, (err) => cbCode("futimes closed cb", err));
fs.fchown(fd, 0, 0, (err) => cbCode("fchown closed cb", err));
```

Those land on the libuv threadpool and their callbacks fire in **completion** order, which is not deterministic across three different syscalls.

The gap harness compares perry's output against a freshly run node oracle — and **the oracle itself is unstable**. Measured directly:

| | distinct outputs |
|---|---|
| `node --experimental-strip-types`, 40 runs | **4** |
| perry, 40 runs | 1 |

Node emits `fchown closed cb` *before* `futimes closed cb` on roughly one run in six:

```
   ftruncate closed cb: EBADF ftruncate
-  futimes closed cb: EBADF futime      <- ~84% of runs
-  fchown closed cb: EBADF fchown
+  fchown closed cb: EBADF fchown       <- ~16% of runs
+  futimes closed cb: EBADF futime
```

Perry is deterministic (always submission order), so it disagrees with the oracle whenever the oracle takes the minority path. That is a coin flip on every PR, and it is why the failure looked like a regression: it correlated with nothing.

### The fix

The test is about the **error surface** (`err.code` / `err.syscall`) of each fd mutator, not about libuv's scheduling. Buffer the three callback results and flush them in a fixed order once all three have landed.

Every assertion is preserved, and the emitted 10 lines are byte-for-byte what they were — only the print order is pinned.

### Verification

| | before | after |
|---|---|---|
| node, 60 runs | 4 distinct | **1 distinct** |
| perry, 40 runs | 1 distinct | 1 distinct |
| perry vs node | flaky | **byte-identical** |
| expected output | — | unchanged (same 10 lines) |

### Deliberately left alone

While restructuring I briefly sequenced the promisified forms by calling `main()` from the last callback, and that surfaced a **separate, real perry bug**: awaiting a `promisify(fs.ftruncate)` rejection from inside an fs callback yields `undefined undefined` instead of `EBADF ftruncate`. That is not this PR's business — filing it separately with a repro rather than folding an unrelated runtime bug into a test de-flake. `main()` stays at top level here, exactly as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Stabilized callback error-reporting test output by enforcing a consistent result order.
  * Ensured callback results are collected before being displayed, reducing variability across runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->