### PR TITLE
fix(fs): fs operations on stdin/stdout/stderr threw EBADF

### DIFF
--- a/crates/perry-runtime/src/fs/mod.rs
+++ b/crates/perry-runtime/src/fs/mod.rs
@@ -57,8 +57,37 @@ pub(crate) const CLASS_ID_FS_STATS_EXPORT: u32 = 0xFFFF_008A;
 pub(crate) const CLASS_ID_FS_UTF8_STREAM: u32 = 0xFFFF_008B;
 pub(crate) const CLASS_ID_FS_FILEHANDLE: u32 = 0xFFFF_008C;
 
+/// Seed the registry with the process-standard descriptors.
+///
+/// `allocate_synthetic_fd` hands out ids from 100 up, so 0/1/2 were never
+/// inserted by anything and every fs op on stdin/stdout/stderr failed the
+/// `fd_is_registered` gate with EBADF — `fs.writeSync(1, …)` threw where Node
+/// writes to the terminal.
+///
+/// Each entry is backed by a `dup` of the real descriptor: the registry owns
+/// `fs::File`s and closes them when an entry is dropped (`closeSync`, thread
+/// teardown), and that must never take the process's actual stdout with it.
+/// The duplicate shares the open file description, so reads and writes land on
+/// the same terminal/pipe.
+fn std_fd_registry() -> StdHashMap<i32, fs::File> {
+    let mut map = StdHashMap::new();
+    #[cfg(unix)]
+    {
+        use std::os::fd::FromRawFd;
+        for fd in 0..=2 {
+            // SAFETY: `dup` returns a fresh descriptor we exclusively own, so
+            // handing it to `File` (which closes on drop) cannot double-close.
+            let duped = unsafe { libc::dup(fd) };
+            if duped >= 0 {
+                map.insert(fd, unsafe { fs::File::from_raw_fd(duped) });
+            }
+        }
+    }
+    map
+}
+
 thread_local! {
-    static FD_REGISTRY: RefCell<StdHashMap<i32, fs::File>> = RefCell::new(StdHashMap::new());
+    static FD_REGISTRY: RefCell<StdHashMap<i32, fs::File>> = RefCell::new(std_fd_registry());
     static FD_PATHS: RefCell<StdHashMap<i32, String>> = RefCell::new(StdHashMap::new());
     static FD_APPEND_MODE: RefCell<StdHashMap<i32, bool>> = RefCell::new(StdHashMap::new());
     static FILEHANDLE_OBJECT_FDS: RefCell<StdHashMap<usize, i32>> = RefCell::new(StdHashMap::new());

--- a/tests/issue_fs_std_fd_ops.js
+++ b/tests/issue_fs_std_fd_ops.js
@@ -1,0 +1,40 @@
+// fs operations addressing the process-standard descriptors (0/1/2) must work.
+//
+// Perry hands out its own fd ids from 100 up, and every fs entry point gates on
+// membership in that registry. Nothing ever registered stdin/stdout/stderr, so
+// `writeSync(1, ...)` — which Node writes straight to the terminal — threw
+// "EBADF: bad file descriptor, write".
+
+import { writeSync, readSync, fstatSync } from "fs";
+
+const wrote = writeSync(1, "stdout-fd-write\n");
+if (wrote !== 16) {
+  throw new Error(`writeSync(1, string) returned ${wrote}, expected 16`);
+}
+
+const wroteErr = writeSync(2, "stderr-fd-write\n");
+if (wroteErr !== 16) {
+  throw new Error(`writeSync(2, string) returned ${wroteErr}, expected 16`);
+}
+
+const buf = Buffer.from("stdout-fd-buffer\n");
+const wroteBuf = writeSync(1, buf);
+if (wroteBuf !== buf.length) {
+  throw new Error(`writeSync(1, buffer) returned ${wroteBuf}, expected ${buf.length}`);
+}
+
+// stdin is redirected from /dev/null by the harness: the read must reach EOF
+// rather than fail the fd gate.
+const sink = Buffer.alloc(8);
+const read = readSync(0, sink, 0, 8, null);
+if (read !== 0) {
+  throw new Error(`readSync(0) returned ${read}, expected 0 at EOF`);
+}
+
+// fstat on a standard fd goes through the same gate.
+const stats = fstatSync(1);
+if (typeof stats.isFile !== "function") {
+  throw new Error("fstatSync(1) did not return a Stats object");
+}
+
+process.stdout.write("done\n");

--- a/tests/test_fs_std_fd_ops.sh
+++ b/tests/test_fs_std_fd_ops.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$ROOT/target/release/perry}}"
+RUNTIME_DIR="${PERRY_RUNTIME_DIR:-$ROOT/target/release}"
+FIXTURE="$ROOT/tests/issue_fs_std_fd_ops.js"
+WORKDIR="${TMPDIR:-/tmp}/perry-fs-std-fd-ops-$$"
+BIN="$WORKDIR/perry-fs-std-fd-ops"
+COMPILE_LOG="$WORKDIR/compile.log"
+STDOUT_LOG="$WORKDIR/stdout.log"
+STDERR_LOG="$WORKDIR/stderr.log"
+EXPECTED_STDOUT="$WORKDIR/expected.stdout"
+EXPECTED_STDERR="$WORKDIR/expected.stderr"
+
+mkdir -p "$WORKDIR"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+if [[ ! -x "$PERRY" ]]; then
+  PERRY="$ROOT/target/debug/perry"
+fi
+if [[ ! -x "$PERRY" ]]; then
+  echo "SKIP: perry binary not found (build with cargo build --release -p perry)"
+  exit 0
+fi
+
+env PERRY_ALLOW_UNIMPLEMENTED=1 PERRY_RUNTIME_DIR="$RUNTIME_DIR" "$PERRY" compile --no-cache --no-auto-optimize "$FIXTURE" -o "$BIN" \
+  >"$COMPILE_LOG" 2>&1 || {
+    cat "$COMPILE_LOG" >&2
+    exit 1
+  }
+
+set +e
+"$BIN" >"$STDOUT_LOG" 2>"$STDERR_LOG" </dev/null
+run_rc=$?
+set -e
+if [[ "$run_rc" -ne 0 ]]; then
+  echo "Perry fs std-fd fixture failed with exit code $run_rc" >&2
+  echo "--- stdout ---" >&2
+  cat "$STDOUT_LOG" >&2
+  echo "--- stderr ---" >&2
+  cat "$STDERR_LOG" >&2
+  exit 1
+fi
+
+printf 'stdout-fd-write\nstdout-fd-buffer\ndone\n' >"$EXPECTED_STDOUT"
+printf 'stderr-fd-write\n' >"$EXPECTED_STDERR"
+
+diff -u "$EXPECTED_STDOUT" "$STDOUT_LOG"
+diff -u "$EXPECTED_STDERR" "$STDERR_LOG"


### PR DESCRIPTION
## The bug

```js
const fs = require("fs");
fs.writeSync(1, "hello\n");   // Node: writes to the terminal
                              // Perry: throws "EBADF: bad file descriptor, write"
fs.readSync(0, buf, 0, 8, null);   // Perry: "EBADF: bad file descriptor, read"
fs.fstatSync(1);                   // Perry: EBADF
```

Perry allocates its own descriptor ids from 100 up (`allocate_synthetic_fd`), and
every fs entry point gates on membership in the thread's `FD_REGISTRY`. The
registry is only ever populated by `openSync`/`open`, so the three
process-standard descriptors were never in it — `fd_is_registered(0/1/2)` was
false and every fs operation on stdin/stdout/stderr threw EBADF, where Node
treats them as ordinary open descriptors.

## The fix

Seed the registry with 0/1/2.

The registry owns `fs::File`s and closes them when an entry goes away (an
explicit `closeSync`, or thread teardown), so the entries must not hold the real
descriptors — closing the process's actual stdout as a side effect would be far
worse than the bug. Each seeded entry is therefore backed by a `dup`: it shares
the open file description (reads and writes land on the same terminal/pipe) while
owning a descriptor that is safe to close. If `dup` fails (stdio closed, e.g. a
daemonised process) the entry is simply absent and the previous EBADF behaviour
stands.

One deliberate divergence: `fs.closeSync(1)` closes Perry's duplicate rather than
the process's real stdout. Node would close the real one.

## Test

`tests/issue_fs_std_fd_ops.js` + `tests/test_fs_std_fd_ops.sh` — writeSync to fd
1 and 2 (string and Buffer), readSync from fd 0 at EOF, and fstatSync(1), with
stdout/stderr diffed against the expected bytes.

## How it was found

Compiling a large esbuild-bundled CLI app. Its terminal UI renders a frame and
then reaches an fs write on a standard descriptor; the EBADF was raised once per
frame inside the renderer's `try/catch`, so the app drew its first screen and
then silently ignored every keystroke — no error, no output, nothing to grep for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file-system operations involving standard input, output, and error descriptors.
  * Writing to standard output and error now works reliably, including string and buffer data.
  * Reading from standard input correctly reports end-of-file when no input is available.
  * File status checks for standard descriptors now return valid results instead of failing with a bad-file-descriptor error.

* **Tests**
  * Added integration coverage for standard descriptor reads, writes, and status checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->