### PR TITLE
test(gap): de-flake test_gap_node_fs — its temp dir was not unique

### DIFF
--- a/test-files/test_gap_node_fs.ts
+++ b/test-files/test_gap_node_fs.ts
@@ -3,9 +3,20 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import * as os from 'os';
 
-const tmpDir = '/tmp/perry_fs_test_' + Date.now();
-fs.mkdirSync(tmpDir, { recursive: true });
+// `'/tmp/perry_fs_test_' + Date.now()` is not a unique path: Date.now() has
+// millisecond resolution, so two executions that start in the same millisecond
+// pick the SAME directory — and this test ends by tearing its directory down
+// with a recursive rmSync. One run then stats a file another run is deleting,
+// which surfaced on Linux CI as
+//   EACCES: Permission denied, stat '/tmp/perry_fs_test_<ms>/test.txt'
+// and red-lit unrelated PRs at random (it failed one #6409 run and passed the
+// next, on the same commit).
+//
+// mkdtempSync is the primitive for this: the kernel picks the suffix and
+// creates the directory atomically, so no two runs can ever collide.
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'perry_fs_test_'));
 
 const testFile = path.join(tmpDir, 'test.txt');
 const testContent = 'hello perry fs';


### PR DESCRIPTION
`test_gap_node_fs` is flaky, and like `test_gap_fs_fd_2749` (#6400) it has been red-lighting unrelated PRs at random. This is the second one from the same family.

### It isn't a parity failure

The CI diff looks alarming but says nothing about parity:

```
FAIL  test_gap_node_fs (output mismatch)
   Node.js:  true
   Perry:    Error: EACCES: Permission denied (os error 13),
             stat '/tmp/perry_fs_test_1784051019891/test.txt'
```

That's a filesystem permission error, not a wrong answer.

### The temp directory is not unique

```ts
const tmpDir = '/tmp/perry_fs_test_' + Date.now();
fs.mkdirSync(tmpDir, { recursive: true });
```

`Date.now()` has millisecond resolution, so two executions starting in the same millisecond pick the **same** directory — and the test ends by tearing its directory down with a recursive `rmSync`. One run then stats a file another run is deleting.

### Evidence it's a race, not a regression

- **#6409** — an HIR capture-box change with nothing to do with `fs` — **failed one run and passed the next on the same commit**.
- **#6403** failed it once, then went green with no change to that code path.
- Locally it is deterministic and passing (30 node runs, 40 perry runs, one output each), so it never reproduces single-threaded.

Running 8 copies of the compiled binary concurrently:

| | failures |
|---|---|
| before (`Date.now()` path) | **2 of 8** — `ENOENT`, another run's `rmSync` removed the shared dir |
| after (`mkdtempSync`) | **0 of 8** |

### The fix

`mkdtempSync` is the primitive for exactly this: the kernel picks the suffix and creates the directory atomically, so no two runs can collide.

Output is byte-for-byte unchanged (all 30 lines); no assertion is touched — only the directory's construction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved temporary directory setup for filesystem parity tests.
  * Tests now use unique system-generated temporary directories, reducing potential conflicts during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->