### PR TITLE
fix(transform): run an inlined finally once per closure, not once per nesting level

### DIFF
--- a/crates/perry-transform/src/finally_inline.rs
+++ b/crates/perry-transform/src/finally_inline.rs
@@ -582,33 +582,31 @@ fn walk_stmt_exprs<F: FnMut(&mut Expr)>(stmt: &mut Stmt, f: &mut F) {
     match stmt {
         Stmt::Let { init: Some(e), .. } => f(e),
         Stmt::Expr(e) | Stmt::Throw(e) | Stmt::Return(Some(e)) => f(e),
-        Stmt::If {
-            condition,
-            then_branch,
-            else_branch,
-        } => {
-            f(condition);
-            for s in then_branch {
-                walk_stmt_exprs(s, f);
-            }
-            if let Some(eb) = else_branch {
-                for s in eb {
-                    walk_stmt_exprs(s, f);
-                }
-            }
-        }
-        Stmt::While { condition, body } | Stmt::DoWhile { body, condition } => {
-            f(condition);
-            for s in body {
-                walk_stmt_exprs(s, f);
-            }
-        }
+        // Only the statement's OWN operand expressions. Descending into a nested
+        // statement list here would visit its closures a SECOND time, because
+        // `process_stmts` recurses into every one of these bodies itself and calls
+        // `walk_stmt_exprs` on each statement it finds. A closure nested N blocks
+        // deep therefore had `process_expr_closure_bodies` run on it N+1 times, and
+        // each run inlined another copy of its `finally` before the `return` — so
+        // an `async () => { try { return await f() } finally { g() } }` sitting
+        // inside an `if` ran `g()` twice (three times at two levels deep):
+        //
+        //   let __ret1 = await f(); g(); let __ret2 = __ret1; g(); return __ret2;
+        //
+        // The chained `__finally_ret_*` temps are the tell. Next.js closes a
+        // per-request CloseController in exactly such a finally, so every page
+        // render threw "Cannot close a CloseController multiple times" and streamed
+        // an empty body.
+        Stmt::If { condition, .. } => f(condition),
+        Stmt::While { condition, .. } | Stmt::DoWhile { condition, .. } => f(condition),
         Stmt::For {
             init,
             condition,
             update,
-            body,
+            ..
         } => {
+            // `init` is a leaf `Let`/`Expr` statement, not a nested list, and
+            // `process_stmts` does not visit it — take its operand here.
             if let Some(i) = init {
                 walk_stmt_exprs(i, f);
             }
@@ -618,29 +616,12 @@ fn walk_stmt_exprs<F: FnMut(&mut Expr)>(stmt: &mut Stmt, f: &mut F) {
             if let Some(u) = update {
                 f(u);
             }
-            for s in body {
-                walk_stmt_exprs(s, f);
-            }
         }
-        Stmt::Try {
-            body,
-            catch,
-            finally,
-        } => {
-            for s in body {
-                walk_stmt_exprs(s, f);
-            }
-            if let Some(c) = catch {
-                for s in &mut c.body {
-                    walk_stmt_exprs(s, f);
-                }
-            }
-            if let Some(fin) = finally {
-                for s in fin {
-                    walk_stmt_exprs(s, f);
-                }
-            }
-        }
+        // `try` / `catch` / `finally` bodies, `switch` case bodies and a labeled
+        // statement's body are all statement lists that `process_stmts` recurses
+        // into — leave them to it. Only the `switch` discriminant and case tests
+        // are operands.
+        Stmt::Try { .. } => {}
         Stmt::Switch {
             discriminant,
             cases,
@@ -650,12 +631,9 @@ fn walk_stmt_exprs<F: FnMut(&mut Expr)>(stmt: &mut Stmt, f: &mut F) {
                 if let Some(t) = &mut c.test {
                     f(t);
                 }
-                for s in &mut c.body {
-                    walk_stmt_exprs(s, f);
-                }
             }
         }
-        Stmt::Labeled { body, .. } => walk_stmt_exprs(body, f),
+        Stmt::Labeled { .. } => {}
         _ => {}
     }
 }

--- a/test-files/test_gap_finally_inline_nested_closure.ts
+++ b/test-files/test_gap_finally_inline_nested_closure.ts
@@ -1,0 +1,134 @@
+// `inline_finally_into_returns` clones the `finally` body before each `return`
+// that escapes a try. It found closures by walking a statement's expressions —
+// but that walk ALSO descended into nested statement lists, which `process_stmts`
+// recurses into itself. A closure nested N blocks deep was therefore processed
+// N+1 times, and each pass inlined another copy of its `finally`:
+//
+//   let __ret1 = await f(); g(); let __ret2 = __ret1; g(); return __ret2;
+//
+// So `async () => { try { return await f() } finally { g() } }` sitting inside an
+// `if` ran `g()` TWICE. Next.js closes a per-request CloseController in exactly
+// such a finally, so every page render threw "Cannot close a CloseController
+// multiple times" and streamed an empty body.
+
+let runs = 0;
+async function body(): Promise<string> {
+  return "BODY";
+}
+
+// control: a top-level async function (never nested) — always ran once
+async function topLevel(): Promise<string> {
+  try {
+    return await body();
+  } finally {
+    runs++;
+  }
+}
+
+// the closure lives inside an `if` block
+function inIf(flag: boolean): Promise<string> | null {
+  if (flag) {
+    const f = async () => {
+      try {
+        return await body();
+      } finally {
+        runs++;
+      }
+    };
+    return f();
+  }
+  return null;
+}
+
+// two levels of nesting
+function inIfInIf(flag: boolean): Promise<string> | null {
+  if (flag) {
+    if (flag) {
+      const g = async () => {
+        try {
+          return await body();
+        } finally {
+          runs++;
+        }
+      };
+      return g();
+    }
+  }
+  return null;
+}
+
+// nested inside a loop and a try
+function inLoopInTry(): string {
+  let out = "";
+  try {
+    for (let i = 0; i < 2; i++) {
+      const h = () => {
+        try {
+          return "v" + i;
+        } finally {
+          runs++;
+        }
+      };
+      out += h();
+    }
+  } finally {
+    out += "|outer";
+  }
+  return out;
+}
+
+(async () => {
+  runs = 0;
+  await topLevel();
+  console.log("top-level    :", runs);
+
+  runs = 0;
+  await inIf(true);
+  console.log("in if        :", runs);
+
+  runs = 0;
+  await inIfInIf(true);
+  console.log("in if x2     :", runs);
+
+  runs = 0;
+  const loop = inLoopInTry();
+  console.log("in loop/try  :", runs, loop);
+
+  // the pass must still do its job: finally runs on every abrupt completion,
+  // and the return operand is evaluated BEFORE the finally body (#536).
+  const order: string[] = [];
+  const withOperand = () => {
+    try {
+      return (order.push("operand"), "ret");
+    } finally {
+      order.push("finally");
+    }
+  };
+  console.log("ordering     :", withOperand(), order.join(","));
+
+  const log: string[] = [];
+  for (let i = 0; i < 3; i++) {
+    try {
+      if (i === 1) break;
+    } finally {
+      log.push("b" + i);
+    }
+  }
+  for (let i = 0; i < 2; i++) {
+    try {
+      continue;
+    } finally {
+      log.push("c" + i);
+    }
+  }
+  const caught = (() => {
+    try {
+      throw new Error("x");
+    } catch {
+      return "caught";
+    } finally {
+      log.push("t");
+    }
+  })();
+  console.log("abrupt paths :", caught, log.join(","));
+})();


### PR DESCRIPTION
## The bug

`inline_finally_into_returns` clones the `finally` body before each `return` that escapes a try (#536). To find closures it called `walk_stmt_exprs` on every statement — but that walk **also descended into nested statement lists**, which `process_stmts` recurses into itself, calling `walk_stmt_exprs` again on each statement it finds there.

A closure nested N blocks deep was therefore handed to `process_expr_closure_bodies` **N+1 times**, and every pass inlined another copy of its finally around the already-rewritten return, chaining the temps:

```
let __finally_ret_1 = await f();  g();
let __finally_ret_2 = __finally_ret_1;  g();     // <-- second copy
return __finally_ret_2;
```

So the finally ran twice — three times at two levels deep:

```js
function outer(flag) {
  if (flag) {
    const f = async () => { try { return await body(); } finally { g(); } };
    return f();   // g() runs TWICE
  }
}
```

## The fix

`walk_stmt_exprs` now visits only a statement's **own** operand expressions (`if`/`while` conditions, `for` init/condition/update, the `switch` discriminant and case tests) and leaves every nested statement list to `process_stmts` — which already recurses into exactly the same set of statement kinds (`If`, `While`, `DoWhile`, `For`, `Try`, `Switch`, `Labeled`). Each closure body is visited exactly once, and nothing is missed.

The pass still does its job: `finally` runs on every abrupt completion (return with and without a value, `break`, `continue`, `throw`), and the return operand is still evaluated **before** the finally body — #536's `return await foo()` shape.

## How it was found

Compiling a real Next.js 16 app. Next closes a per-request `CloseController` inside exactly such a finally:

```js
try { return await workAsyncStorage.run(h, () => workUnitAsyncStorage.run(p, handler, v, x)) }
finally { setTimeout(() => { r.dispatchClose() }, 0) }
```

nested inside an `if`. The duplicate close threw `Cannot close a CloseController multiple times` (E229) on **every page render**, and the response streamed an empty body.

The tell in the HIR is the chained `__finally_ret_*` temps — the finally body appears twice back-to-back on one linear path. Worth noting no *source-level* guess reproduced it (awaits, nested try, `return await`, ALS nesting, auto-opt all behaved); it only shows up once you look at what the pass emits.

## Test

`test_gap_finally_inline_nested_closure` — a closure in an `if`, in an `if` twice over, and inside a loop within a try; plus the abrupt-completion paths (`return`, bare `return`, `break`, `continue`, `throw`) and the operand-before-finally ordering the pass exists to guarantee. Byte-identical to node.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect execution of `finally` blocks in scenarios involving nested closures and complex control flow.
  * Prevented `finally` logic from running multiple times unexpectedly.

* **Tests**
  * Added coverage for nested closures, loops, conditionals, exceptions, and abrupt control-flow statements to verify correct execution order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->