### PR TITLE
fix(codegen): arithmetic on a scalar-replaced array element produced NaN

### DIFF
--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -984,6 +984,23 @@ pub(crate) fn lower_numeric_index_get_for_number_context(
         return Ok(None);
     }
 
+    // A scalar-replaced array has no heap allocation at all: its elements live
+    // in stack slots and the local never holds an array. Lowering `arr[i]`
+    // through the guarded element path would take that empty slot as the
+    // receiver — the guard sees a null array and declines, and the boxed
+    // fallback coerces the resulting `undefined` to NaN. So
+    // `const a = [1, 2, 3]; a[0] + 1` produced NaN while a bare `a[0]` (which
+    // `lower` serves from the scalar slot) was correct. Leave these locals to
+    // `lower`, exactly as the inline-TA path already does.
+    if let Expr::LocalGet(id) = object.as_ref() {
+        if ctx.scalar_replaced_arrays.contains_key(id)
+            || ctx.array_row_aliases.contains_key(id)
+            || ctx.scalar_replaced.contains_key(id)
+        {
+            return Ok(None);
+        }
+    }
+
     if let Expr::LocalGet(arr_id) = object.as_ref() {
         if let Some((fact, idx_id, offset)) =
             packed_f64_loop_fact_for_index(ctx, *arr_id, index.as_ref())

--- a/tests/issue_scalar_array_number_context.js
+++ b/tests/issue_scalar_array_number_context.js
@@ -1,0 +1,45 @@
+// An array that never escapes is scalar-replaced: its elements live in stack
+// slots and the local never holds a heap array. `lower_numeric_index_get_for_
+// number_context` — the path taken when an element read feeds arithmetic — did
+// not check for that, so it lowered `a[i]` through the guarded element path with
+// the empty local as the receiver. The runtime guard saw a null array and
+// declined, and the boxed fallback coerced the resulting `undefined` to NaN.
+//
+// `a[0]` on its own was correct (`lower` serves it from the scalar slot), so
+// only the arithmetic form was wrong:
+//
+//     const a = [1, 2, 3];
+//     a[0];        // 1   ✓
+//     a[0] + 1;    // NaN ✗   (expected 2)
+
+const m = [1, 2, 3];
+if (m[0] + 1 !== 2) throw new Error(`module-level a[0] + 1 = ${m[0] + 1}, expected 2`);
+if (m[1] * 2 !== 4) throw new Error(`module-level a[1] * 2 = ${m[1] * 2}, expected 4`);
+if (m[0] !== 1) throw new Error(`module-level a[0] = ${m[0]}, expected 1`);
+
+function local() {
+  const a = [10, 20, 30];
+  return a[2] - a[0];
+}
+if (local() !== 20) throw new Error(`function-local a[2] - a[0] = ${local()}, expected 20`);
+
+let mutable = [1.5, 2.5];
+if (mutable[0] * 2 !== 3) throw new Error(`float array a[0] * 2 = ${mutable[0] * 2}, expected 3`);
+
+// An array that DOES escape keeps its heap allocation — this path already worked
+// and must keep working.
+const escaping = [1, 2, 3];
+function readsEscaping() {
+  return escaping[0] + 1;
+}
+if (readsEscaping() !== 2) throw new Error(`escaping a[0] + 1 = ${readsEscaping()}, expected 2`);
+
+// Elements feeding arithmetic inside a loop.
+const nums = [1, 2, 3, 4];
+let total = 0;
+for (let i = 0; i < nums.length; i++) {
+  total += nums[i] * 2;
+}
+if (total !== 20) throw new Error(`sum of nums[i] * 2 = ${total}, expected 20`);
+
+console.log("scalar-array number context ok");

--- a/tests/test_scalar_array_number_context.sh
+++ b/tests/test_scalar_array_number_context.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PERRY="${PERRY_BIN:-${PERRY:-$ROOT/target/release/perry}}"
+RUNTIME_DIR="${PERRY_RUNTIME_DIR:-$ROOT/target/release}"
+FIXTURE="$ROOT/tests/issue_scalar_array_number_context.js"
+WORKDIR="${TMPDIR:-/tmp}/perry-scalar-array-number-$$"
+BIN="$WORKDIR/perry-scalar-array-number"
+COMPILE_LOG="$WORKDIR/compile.log"
+OUT_LOG="$WORKDIR/out.log"
+
+mkdir -p "$WORKDIR"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+if [[ ! -x "$PERRY" ]]; then
+  PERRY="$ROOT/target/debug/perry"
+fi
+if [[ ! -x "$PERRY" ]]; then
+  echo "SKIP: perry binary not found (build with cargo build --release -p perry)"
+  exit 0
+fi
+
+env PERRY_ALLOW_UNIMPLEMENTED=1 PERRY_RUNTIME_DIR="$RUNTIME_DIR" "$PERRY" compile --no-cache --no-auto-optimize "$FIXTURE" -o "$BIN" \
+  >"$COMPILE_LOG" 2>&1 || {
+    cat "$COMPILE_LOG" >&2
+    exit 1
+  }
+
+set +e
+"$BIN" >"$OUT_LOG" 2>&1
+rc=$?
+set -e
+
+if [[ "$rc" -ne 0 ]]; then
+  echo "scalar-array number-context fixture failed (exit $rc):" >&2
+  cat "$OUT_LOG" >&2
+  exit 1
+fi
+
+grep -qx "scalar-array number context ok" "$OUT_LOG" || {
+  echo "unexpected output:" >&2
+  cat "$OUT_LOG" >&2
+  exit 1
+}


### PR DESCRIPTION
## The bug

```js
const a = [1, 2, 3];
console.log(a[0]);       // 1    ✓
console.log(a[0] + 1);   // NaN  ✗   (Node: 2)
```

Reproduces on `main` at module scope, in a function, with `const` or `let`, and
for float arrays. Any arithmetic on the element is affected (`+`, `*`, `-`, …);
a bare `a[0]` is fine.

## Why

An array that never escapes is **scalar-replaced**: its elements live in stack
slots and the local never holds a heap array at all.

`lower_numeric_index_get_for_number_context` — the path taken when an element
read feeds arithmetic — checks the array's *type* but never checks whether the
local was scalar-replaced. So it lowers `a[i]` through the guarded element path
using that empty local as the receiver:

```llvm
%r14 = call i32 @js_typed_feedback_numeric_array_index_get_guard(i64 <site>, double %r13, i32 0, i32 1)
br i1 %r15, label %arr.fast, label %arr.fallback
```

At runtime the guard is handed a **null** array:

```
[arr-diag] arr=0x0 idx=0 plain_guard=false raw_f64_layout=0 -> guard=false
```

It correctly declines, and the boxed fallback then coerces the resulting
`undefined` through `js_number_coerce` → **NaN**.

Two things kept this hidden:

* a bare `a[0]` is correct, because `lower` serves it from the scalar slot
  (only the *number context* goes through the guarded path), and
* an array that **escapes** keeps its heap allocation, so `a[0] + 1` read from
  another function works. It only bites the array you declared and used in the
  same scope.

## The fix

Bail out of the number-context path for a scalar-replaced local (plus the
row-alias / scalar-replaced-object cases) and let `lower` serve the element from
its slot — mirroring the guard the inline-TA path in this same file already
carries.

## Test

`tests/issue_scalar_array_number_context.js` + `tests/test_scalar_array_number_context.sh`
cover module scope, function scope, `let`, floats, an escaping array (the path
that already worked), and elements feeding arithmetic in a loop.

Without the fix the fixture fails immediately:

```
Error: function-local a[2] - a[0] = NaN, expected 20
```

`cargo test -p perry-runtime --release -- --test-threads=1`: 1314 passed, 0 failed.
`perry-hir`: 229 passed. (The two `perry-codegen` test binaries that fail to
compile — `CompileOptions has no field named namespace_reexport_named_imports` —
are broken on `main` already, unrelated to this change.)

## How it was found

Compiling a large esbuild-bundled CLI app. While reducing an unrelated failure I
noticed `a[0] + 1` evaluating to NaN in a two-line script, which turned out to be
this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed arithmetic involving elements from optimized numeric arrays, preventing incorrect `NaN` results.
  * Preserved correct behavior for local, mutable, and escaping arrays.

* **Tests**
  * Added coverage for array element reads in numeric and arithmetic expressions, including end-to-end runtime validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->