### PR TITLE
fix(runtime): delete blanked the surviving values of an object that grew past 8 properties

### DIFF
--- a/crates/perry-runtime/src/object/delete_rest.rs
+++ b/crates/perry-runtime/src/object/delete_rest.rs
@@ -319,6 +319,11 @@ pub extern "C" fn js_object_delete_field(
         //    into slot j. Inline reads/writes for j < alloc_limit;
         //    overflow_get/set otherwise.
         for j in i..new_count {
+            // Read through the index path, which resolves inline-vs-overflow with the
+            // CURRENT (pre-decrement) `field_count` — the same boundary the value was
+            // written under. Reading by NAME here would invoke a getter and store its
+            // result as a data property, silently collapsing accessors (Next's module
+            // exports are `Object.defineProperty(..., {get})`).
             let next = js_object_get_field(obj, (j + 1) as u32);
             // Inline write if target slot < alloc_limit, else overflow.
             if j < alloc_limit {
@@ -349,11 +354,23 @@ pub extern "C" fn js_object_delete_field(
         //    we built the new keys directly with the deleted entry
         //    omitted, so no in-place shift is needed.)
 
-        // 3) Adjust field_count: keep within bounds. If the original
-        //    field_count counted this slot, drop by one.
-        if (i as u32) < field_count {
-            (*obj).field_count = field_count - 1;
-        }
+        // 3) `field_count` is the number of properties resident in the INLINE
+        //    slots — every reader treats `field_index >= field_count` as living in
+        //    the overflow map. It is NOT the property count: an object with 9
+        //    properties and 8 inline slots carries `field_count == 8`, with the 9th
+        //    spilled to overflow.
+        //
+        //    Decrementing it by one was therefore wrong. Deleting one property from
+        //    that 9-property object leaves 8 survivors — all of which now FIT
+        //    inline, so `field_count` must become 8. The old `field_count - 1 = 7`
+        //    pushed the last survivor's index (7) at or past the boundary, so
+        //    reading it went to the overflow map, found nothing, and returned
+        //    `undefined`: the key stayed enumerable while its value vanished.
+        //
+        //    After the rebuild above, the survivors occupy slots `0..new_count`,
+        //    inline up to the allocation's capacity. That is exactly
+        //    `min(new_count, alloc_limit)`.
+        (*obj).field_count = std::cmp::min(new_count, alloc_limit) as u32;
 
         // 4) Invalidate the keys-index sidecar for this object — the
         //    slot map is now stale (entries past `i` have shifted).

--- a/test-files/test_gap_delete_field_count_boundary.ts
+++ b/test-files/test_gap_delete_field_count_boundary.ts
@@ -1,0 +1,94 @@
+// `field_count` is the number of properties resident in an object's INLINE slots
+// — every reader treats `field_index >= field_count` as living in the overflow
+// map. It is NOT the property count: an object with 9 properties and 8 inline
+// slots carries `field_count == 8`, with the 9th spilled to overflow.
+//
+// `delete` decremented it by one regardless. Deleting one property from that
+// 9-property object leaves 8 survivors — all of which now FIT inline — but
+// `field_count` became 7, so the last survivor's slot (index 7) sat at the
+// boundary and was read from the overflow map, which held nothing. Its key stayed
+// enumerable while its value vanished:
+//
+//   Object.keys(o)      -> still lists it
+//   o.keep              -> undefined
+//   JSON.stringify(o)   -> drops it entirely
+//
+// It bites any object that ever grew past 8 properties. Next.js deletes a batch of
+// `x-middleware-request-*` keys from the middleware's header object; the surviving
+// `x-middleware-rewrite` came back `undefined`, so Next stopped rewriting to the
+// page and served an empty body.
+
+const o: any = {};
+for (let i = 0; i < 8; i++) o["k" + i] = "v" + i;
+o["keep"] = "KEEP";
+
+console.log("before      :", o["keep"], Object.keys(o).length);
+delete o["k0"];
+console.log("after       :", o["keep"]);
+console.log("keys        :", Object.keys(o).join(","));
+console.log("json        :", JSON.stringify(o));
+
+// exhaustive: build n properties, delete an arbitrary subset, compare with a Map
+function check(n: number, deleteIdxs: number[]): boolean {
+  const obj: any = {};
+  const model = new Map<string, string>();
+  for (let i = 0; i < n; i++) {
+    obj["k" + i] = "v" + i;
+    model.set("k" + i, "v" + i);
+  }
+  for (const i of deleteIdxs) {
+    delete obj["k" + i];
+    model.delete("k" + i);
+  }
+  if (Object.keys(obj).join(",") !== [...model.keys()].join(",")) return false;
+  for (const [k, v] of model) if (obj[k] !== v) return false;
+  if (JSON.stringify(obj) !== JSON.stringify(Object.fromEntries(model))) return false;
+  if (JSON.stringify(Object.entries(obj)) !== JSON.stringify([...model])) return false;
+  return true;
+}
+
+let failures = 0;
+let cases = 0;
+for (let n = 1; n <= 16; n++) {
+  const bits = Math.min(n, 6);
+  for (let mask = 0; mask < 1 << bits; mask++) {
+    const del: number[] = [];
+    for (let b = 0; b < bits; b++) if (mask & (1 << b)) del.push(b);
+    cases++;
+    if (!check(n, del)) failures++;
+  }
+}
+console.log("exhaustive  :", cases, "cases,", failures, "failures");
+
+// re-adding after a delete, and every enumeration path agreeing
+const r: any = {};
+for (let i = 0; i < 10; i++) r["k" + i] = i;
+delete r["k3"];
+delete r["k7"];
+r["k3"] = "re-added";
+r["fresh"] = "F";
+console.log("re-add      :", r["k3"], r["k7"], r["fresh"], r["k9"]);
+const seen: string[] = [];
+for (const k in r) seen.push(k);
+console.log("for-in      :", seen.join(","));
+console.log("spread      :", JSON.stringify({ ...r }));
+
+// an accessor must survive a delete on the same object — it must NOT be
+// collapsed into a data property (Next's module exports are defineProperty
+// getters, and flattening them breaks every route)
+const a: any = {};
+Object.defineProperty(a, "lazy", {
+  get() {
+    return "COMPUTED:" + (a.n || 0);
+  },
+  enumerable: true,
+  configurable: true,
+});
+for (let i = 0; i < 9; i++) a["k" + i] = i;
+a.n = 7;
+console.log("accessor    :", a.lazy);
+delete a["k0"];
+a.n = 8;
+console.log("after delete:", a.lazy);
+const d = Object.getOwnPropertyDescriptor(a, "lazy")!;
+console.log("still getter:", typeof d.get === "function", d.value === undefined);


### PR DESCRIPTION
## The bug

`field_count` is the number of properties resident in an object's **inline** slots — every reader treats `field_index >= field_count` as living in the overflow map. It is **not** the property count: an object with 9 properties and 8 inline slots carries `field_count == 8`, with the 9th spilled to overflow.

`js_object_delete_field` decremented it by one regardless. Deleting one property from that 9-property object leaves 8 survivors — all of which now *fit* inline — but `field_count` became 7, so the last survivor's slot (index 7) sat at the boundary and was read from the overflow map, which held nothing:

```js
const o = {};
for (let i = 0; i < 8; i++) o["k" + i] = "v" + i;
o.keep = "KEEP";
delete o.k0;

o.keep              // node: "KEEP"   perry: undefined
Object.keys(o)      // still lists "keep"   <-- the key survives
JSON.stringify(o)   // drops it entirely    <-- the value is gone
```

The key stays enumerable while its value vanishes, so the failure surfaces far from the `delete`. It bites **any object that ever grew past 8 properties** — the corruption appears exactly when the property count drops from above 8 back to ≤ 8.

## The fix

After the shift, the survivors occupy slots `0..new_count`, inline up to the allocation's capacity. The correct count is therefore `min(new_count, alloc_limit)`.

One subtlety worth flagging for review: **the shift must keep reading by slot index.** My first attempt moved the values by reading them *by name*, which invokes a getter and stores its result as a data property — silently collapsing accessors. Next's module exports are `Object.defineProperty(…, {get})`, so that flattened them and every route 404'd. The test pins this down.

## How it was found

Compiling a real Next.js 16 app. Next deletes a batch of `x-middleware-request-*` keys from the middleware's header object; the surviving `x-middleware-rewrite` then read back `undefined`, so Next concluded there was no rewrite, treated the middleware response as final, and served `NextResponse.next()`'s **null body** — a 200 with the correct headers and zero bytes, on every page.

## Test

`test_gap_delete_field_count_boundary`:

* the 9-property case above,
* **766 exhaustive** build/delete/compare cases against a `Map` model — keys, values, `JSON.stringify` and `Object.entries` must all agree,
* re-adding a key after deleting it, with `for-in` and spread agreeing,
* an accessor surviving a delete on the same object (still a getter, still recomputing).

Byte-identical to node.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed object property deletion near storage boundaries, preventing remaining properties from becoming inaccessible or appearing as `undefined`.
  * Preserved correct property enumeration, value access, serialization, object spreading, and `for...in` behavior after deletions.
  * Ensured accessor properties remain getters when other properties are deleted.

* **Tests**
  * Added comprehensive coverage for deletion, re-adding properties, enumeration, serialization, and accessor preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->