### PR TITLE
fix(runtime): Reflect.* on a handle-backed native object threw "called on non-object"

### DIFF
--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -493,6 +493,18 @@ fn reflect_value_is_object(value: f64) -> bool {
     let top16 = bits >> 48;
     if top16 == (POINTER_TAG >> 48) {
         let lower48 = bits & POINTER_MASK;
+        // A handle-backed native object — Request / Response / Headers, sockets,
+        // streams — is a POINTER_TAG'd small id, not a heap `ObjectHeader`. It is
+        // still an OBJECT to JS, so `Reflect.get(request, k)` must not be refused:
+        // the sub-4GB cutoff below classified every one of them as a non-object and
+        // threw `TypeError: Reflect.get called on non-object`. Next's app-route
+        // runtime wraps the request in a Proxy whose `get` trap forwards through
+        // `Reflect.get(target, …)`, so every authenticated route 500'd.
+        if crate::value::addr_class::is_handle_band(lower48 as usize)
+            || crate::value::addr_class::is_stream_id_band(lower48 as usize)
+        {
+            return lower48 != 0;
+        }
         if lower48 < 0x1_0000_0000 {
             return false;
         }

--- a/test-files/test_gap_reflect_handle_band_objects.ts
+++ b/test-files/test_gap_reflect_handle_band_objects.ts
@@ -1,0 +1,48 @@
+// Perry represents native web objects — Headers, Request, Response, sockets,
+// streams — as handle ids (a POINTER_TAG'd small integer), not heap ObjectHeaders.
+// `reflect_value_is_object` classified every address below 4 GB as a NON-object, so
+// the whole `Reflect.*` family refused them:
+//
+//   Reflect.get(headers, "get")   ->  TypeError: Reflect.get called on non-object
+//
+// They are objects to JS, and Next's app-route runtime wraps the request in a Proxy
+// whose `get` trap forwards through `Reflect.get(target, …)` — so every route that
+// touched the request 500'd.
+
+const h = new Headers();
+h.set("x-test", "v1");
+h.set("content-type", "application/json");
+
+console.log("get is fn    :", typeof Reflect.get(h, "get"));
+console.log("has          :", Reflect.has(h, "get"), Reflect.has(h, "nope"));
+
+// the method read through Reflect, invoked against its real receiver
+const getter = Reflect.get(h, "get") as (n: string) => string | null;
+console.log("read header  :", getter.call(h, "x-test"));
+console.log("read header2 :", getter.call(h, "content-type"));
+
+// a Proxy whose get trap forwards to Reflect.get — Next's app-route shape
+const proxied: any = new Proxy(h, {
+  get(target, prop) {
+    return Reflect.get(target, prop);
+  },
+});
+console.log("via proxy    :", typeof proxied.get, typeof proxied.set, typeof proxied.has);
+
+// Reflect on a Response handle
+const res = new Response("body", { status: 401 });
+console.log("response     :", Reflect.get(res, "status"), Reflect.has(res, "headers"));
+
+// Reflect on a Request handle
+const req = new Request("http://localhost/api/sites");
+console.log("request      :", Reflect.get(req, "method"), Reflect.get(req, "url"));
+
+// a plain heap object must still work, and a primitive must still be refused
+const plain = { a: 1, b: 2 };
+console.log("plain object :", Reflect.get(plain, "a"), Reflect.has(plain, "b"));
+try {
+  Reflect.get(42 as any, "x");
+  console.log("primitive    : NO THROW");
+} catch (e: any) {
+  console.log("primitive    : threw", e instanceof TypeError);
+}


### PR DESCRIPTION
## The bug

Perry represents native web objects — `Headers`, `Request`, `Response`, sockets, streams — as **handle ids**: a `POINTER_TAG`'d small integer, not a heap `ObjectHeader`. `reflect_value_is_object` rejected every `POINTER_TAG` value whose address was below 4 GB (`lower48 < 0x1_0000_0000`), which is exactly the handle band, so the entire `Reflect.*` family refused them:

```js
const h = new Headers();
Reflect.get(h, "get");   // node: [Function]   perry: TypeError: Reflect.get called on non-object
```

## Why it matters

Next.js's app-route runtime wraps the incoming request in a `Proxy` whose `get` trap forwards through `Reflect.get(target, prop, receiver)`. So every route that read the request — i.e. **every authenticated API route** — 500'd with this TypeError instead of running. The backtrace was unambiguous:

```
js_proxy_get → <next app-route runtime> → js_native_call_method
             → js_class_static_method_call → js_reflect_get → THROW
```

## The fix

A handle-backed object is an object to JS. `reflect_value_is_object` now admits a value whose masked address is in the handle band or the stream-id band (non-zero), before the sub-4 GB cutoff that legitimately screens out tagged non-pointers.

## How it was found

Compiling a real Next.js 16 + Auth.js v5 app. `/api/sites` and `/api/dimensions` went from 500 to their correct JSON bodies.

## Test

`test_gap_reflect_handle_band_objects` — `Reflect.get`/`has` on `Headers` / `Request` / `Response`, a method read through `Reflect` and invoked against its receiver, a `Proxy` `get` trap forwarding to `Reflect.get` (Next's shape), a plain heap object still working, and a primitive still being refused. Byte-identical to node.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `Reflect.get` and related proxy operations for web objects such as `Request`, `Response`, and `Headers`.
  * Prevented valid runtime-managed objects from being incorrectly treated as non-objects.
  * Preserved the expected `TypeError` behavior when reflection is used on primitive values.

* **Tests**
  * Added coverage for reflection, proxy forwarding, property access, and primitive handling across multiple object types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->