### PR TITLE
fix(fetch): honor a runtime init object's status/statusText/headers in Response.json and super(body, init)

### DIFF
--- a/crates/perry-codegen/src/lower_call/options/fetch.rs
+++ b/crates/perry-codegen/src/lower_call/options/fetch.rs
@@ -86,9 +86,14 @@ pub(in crate::lower_call) fn lower_fetch_native_method(
                         // `NextResponse.json`, so every authenticated route's 401 became
                         // a 200. Mirror the `new Response(body, init)` runtime path and
                         // read the fields at runtime.
+                        // `init` is a runtime value that need not be an object:
+                        // `Response.json(x, 3.14)` is legal TS. Unboxing it to a
+                        // raw pointer and dereferencing would SIGSEGV (a
+                        // non-integer double's bits land in the heap-pointer
+                        // magnitude window). Read each field through the boxed
+                        // helper, which validates the receiver and returns
+                        // `undefined` for a non-object instead of derefing.
                         let opts_val = lower_expr(ctx, &args[1])?;
-                        let blk = ctx.block();
-                        let opts_handle = crate::expr::unbox_to_i64(blk, &opts_val);
                         let get_field = |ctx_inner: &mut FnCtx<'_>, key: &str| -> Result<String> {
                             let key_idx = ctx_inner.strings.intern(key);
                             let key_global =
@@ -97,11 +102,11 @@ pub(in crate::lower_call) fn lower_fetch_native_method(
                             let key_box = blk.load(DOUBLE, &key_global);
                             let key_bits = blk.bitcast_double_to_i64(&key_box);
                             let key_raw = blk.and(I64, &key_bits, crate::nanbox::POINTER_MASK_I64);
-                            let opts_handle_local = opts_handle.clone();
+                            let opts_val_local = opts_val.clone();
                             Ok(blk.call(
                                 DOUBLE,
-                                "js_object_get_field_by_name_f64",
-                                &[(I64, &opts_handle_local), (I64, &key_raw)],
+                                "js_object_get_field_by_name_boxed",
+                                &[(DOUBLE, &opts_val_local), (I64, &key_raw)],
                             ))
                         };
                         status_val = get_field(ctx, "status")?;

--- a/crates/perry-codegen/src/lower_call/options/fetch.rs
+++ b/crates/perry-codegen/src/lower_call/options/fetch.rs
@@ -75,6 +75,41 @@ pub(in crate::lower_call) fn lower_fetch_native_method(
                                 }
                             }
                         }
+                    } else {
+                        // The init arg is a RUNTIME object, not a literal — a bound
+                        // variable (`Response.json(data, init)` where `init` is a param
+                        // or local, or another `Response`). `extract_options_fields`
+                        // only sees object literals, so the whole init was dropped and
+                        // the status defaulted to 200: `Response.json(x, {status:401})`
+                        // returned 401 at module scope (literal) but 200 the moment the
+                        // init was passed through a variable — e.g. inside
+                        // `NextResponse.json`, so every authenticated route's 401 became
+                        // a 200. Mirror the `new Response(body, init)` runtime path and
+                        // read the fields at runtime.
+                        let opts_val = lower_expr(ctx, &args[1])?;
+                        let blk = ctx.block();
+                        let opts_handle = crate::expr::unbox_to_i64(blk, &opts_val);
+                        let get_field = |ctx_inner: &mut FnCtx<'_>, key: &str| -> Result<String> {
+                            let key_idx = ctx_inner.strings.intern(key);
+                            let key_global =
+                                format!("@{}", ctx_inner.strings.entry(key_idx).handle_global);
+                            let blk = ctx_inner.block();
+                            let key_box = blk.load(DOUBLE, &key_global);
+                            let key_bits = blk.bitcast_double_to_i64(&key_box);
+                            let key_raw = blk.and(I64, &key_bits, crate::nanbox::POINTER_MASK_I64);
+                            let opts_handle_local = opts_handle.clone();
+                            Ok(blk.call(
+                                DOUBLE,
+                                "js_object_get_field_by_name_f64",
+                                &[(I64, &opts_handle_local), (I64, &key_raw)],
+                            ))
+                        };
+                        status_val = get_field(ctx, "status")?;
+                        let st_box = get_field(ctx, "statusText")?;
+                        let blk = ctx.block();
+                        status_text_ptr =
+                            blk.call(I64, "js_get_string_pointer_unified", &[(DOUBLE, &st_box)]);
+                        headers_handle = get_field(ctx, "headers")?;
                     }
                 }
                 let handle = ctx.block().call(

--- a/crates/perry-codegen/src/runtime_decls/objects.rs
+++ b/crates/perry-codegen/src/runtime_decls/objects.rs
@@ -216,6 +216,9 @@ pub fn declare_phase_b_objects(module: &mut LlModule) {
     );
     module.declare_function("js_object_get_index_polymorphic", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_object_get_field_by_name_f64", DOUBLE, &[I64, I64]);
+    // Boxed receiver: validates it is an object and returns undefined for a
+    // non-object instead of dereferencing (Response.json(x, <non-object>)).
+    module.declare_function("js_object_get_field_by_name_boxed", DOUBLE, &[DOUBLE, I64]);
     module.declare_function(
         "js_object_get_field_by_property_id_f64",
         DOUBLE,

--- a/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
+++ b/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
@@ -46,6 +46,46 @@ pub extern "C" fn js_object_get_field_by_name_f64(
     f64::from_bits(value.bits())
 }
 
+/// Read a field by name from a *boxed* receiver, returning `undefined` when the
+/// receiver is not an object.
+///
+/// `js_object_get_field_by_name_f64` takes an already-unboxed `*const
+/// ObjectHeader` and dereferences it on faith. That is fine when codegen has
+/// proven the receiver is an object, but `Response.json(data, init)` reads its
+/// fields off a *runtime* `init` value that can be anything — a number, a
+/// string, a symbol. A non-integer double like `3.14` unboxes to a bit pattern
+/// squarely inside the heap-pointer magnitude window, so the raw read SIGSEGVs
+/// (observed on `Response.json(x, 3.14)`).
+///
+/// This wrapper applies the same handle-band / `is_valid_obj_ptr` guard the
+/// runtime fetch-option reader uses, so a non-object `init` yields `undefined`
+/// fields instead of dereferencing a forged pointer. Codegen calls this with
+/// the boxed value rather than re-implementing the pointer checks in IR.
+#[no_mangle]
+pub extern "C" fn js_object_get_field_by_name_boxed(
+    receiver: f64,
+    key: *const crate::StringHeader,
+) -> f64 {
+    let value = crate::value::JSValue::from_bits(receiver.to_bits());
+    if !value.is_pointer() {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    let raw = crate::value::js_nanbox_get_pointer(receiver);
+    if raw == 0 {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    // A handle-band id (a `Response`/`Request` forwarded as init) is not a heap
+    // ObjectHeader; `js_object_get_field_by_name_f64` routes it through the
+    // handle property dispatch, so hand it over directly.
+    if crate::value::addr_class::is_handle_band(raw as usize) {
+        return js_object_get_field_by_name_f64(raw as *const ObjectHeader, key);
+    }
+    if raw < 0x10000 || !crate::value::addr_class::is_valid_obj_ptr(raw as *const u8) {
+        return f64::from_bits(crate::value::TAG_UNDEFINED);
+    }
+    js_object_get_field_by_name_f64(raw as *const ObjectHeader, key)
+}
+
 /// #2058: the universal `Object.prototype` methods inherited by every value,
 /// including primitive numbers. Read as a property *value* (e.g.
 /// `const f = n.toString`, `typeof n.isPrototypeOf`), these resolve to real

--- a/crates/perry-runtime/src/object/global_this/fetch_globals.rs
+++ b/crates/perry-runtime/src/object/global_this/fetch_globals.rs
@@ -156,6 +156,22 @@ fn global_this_fetch_option(init: f64, name: &[u8]) -> f64 {
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     }
     let raw = crate::value::js_nanbox_get_pointer(init);
+    // A handle-backed init object — `new Response(body, otherResponse)`, which is
+    // how `NextResponse.json(data, {status})` forwards its init through
+    // `super(body, response)` — is a fetch-band handle id, not a heap
+    // `ObjectHeader`. `is_valid_obj_ptr` rejects it, so `status` / `statusText` /
+    // `headers` all read `undefined` and the new Response silently defaulted to
+    // 200: every `NextResponse.json(x, {status:401})` route returned 200.
+    // `js_object_get_field_by_name_f64` routes a handle through the handle
+    // property dispatch (where Response `.status` etc. resolve), so hand it the
+    // handle directly instead of bailing.
+    if crate::value::addr_class::is_handle_band(raw as usize) {
+        if raw == 0 {
+            return f64::from_bits(crate::value::TAG_UNDEFINED);
+        }
+        let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+        return js_object_get_field_by_name_f64(raw as *const ObjectHeader, key);
+    }
     if raw < 0x10000 || !is_valid_obj_ptr(raw as *const u8) {
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     }

--- a/test-files/test_gap_response_json_runtime_init.ts
+++ b/test-files/test_gap_response_json_runtime_init.ts
@@ -1,0 +1,62 @@
+// `Response.json(data, init)` and `new Response(body, init)` extracted the init's
+// `status` / `statusText` / `headers` ONLY when `init` was an object LITERAL the
+// codegen could read at compile time. A runtime init — a bound variable, a
+// function parameter, or another `Response` used as init — was dropped, so the
+// response silently defaulted to status 200.
+//
+// `Response.json(x, {status: 401})` therefore returned 401 at module scope
+// (literal init) but 200 the instant the init flowed through a variable — e.g.
+// inside `NextResponse.json`, which is `class NextResponse extends Response {}`
+// doing `new NextResponse(Response.json(body, init).body, thatResponse)`. Under
+// Next.js every authenticated route's intended 401 became a 200.
+
+// literal init — always worked
+console.log("literal    :", Response.json({ e: 1 }, { status: 401 }).status);
+
+// runtime init variable at module scope — worked
+const init = { status: 402, statusText: "custom" };
+console.log("module var :", Response.json({ e: 1 }, init).status);
+
+// runtime init inside a function — this is what regressed to 200
+function inFn(i: any): number {
+  return Response.json({ e: 1 }, i).status;
+}
+console.log("in function:", inFn({ status: 403 }));
+
+class C {
+  static inStatic(i: any): number {
+    return Response.json({ e: 1 }, i).status;
+  }
+  inMethod(i: any): number {
+    return Response.json({ e: 1 }, i).status;
+  }
+}
+console.log("in static  :", C.inStatic({ status: 404 }));
+console.log("in method  :", new C().inMethod({ status: 405 }));
+
+// a Response used AS the init, forwarded through a subclass `super(body, init)`
+// — the exact `NextResponse.json` shape
+class NR extends Response {
+  constructor(body: any, i: any = {}) {
+    super(body, i);
+  }
+  static json(body: any, i?: any): NR {
+    const r = Response.json(body, i);
+    return new NR(r.body, r);
+  }
+}
+const a = NR.json({ error: "Unauthorized" }, { status: 401 });
+console.log("subclass   :", a.status, a.headers.get("content-type"));
+
+// statusText and a runtime-object headers init must also survive
+const withText = Response.json({ e: 1 }, { status: 406, statusText: "Not Acceptable" });
+console.log("statusText :", withText.status, withText.statusText);
+
+// default (no init) is unchanged
+console.log("default    :", Response.json({ ok: 1 }).status);
+
+// plain new Response with a runtime init
+function makeResp(i: any): Response {
+  return new Response("body", i);
+}
+console.log("new+runtime:", makeResp({ status: 418 }).status);


### PR DESCRIPTION
## The bug

`Response.json(data, init)` and `new Response(body, init)` extracted the init's `status` / `statusText` / `headers` **only when `init` was an object literal** the codegen could read at compile time. A runtime init — a bound variable, a function parameter, or another `Response` used as init — was dropped, so the response silently defaulted to status 200.

```js
Response.json({ e: 1 }, { status: 401 }).status;   // 401  (literal init)
const init = { status: 401 };
function f(i) { return Response.json({ e: 1 }, i).status; }
f(init);                                            // node: 401   perry: 200  (runtime init)
```

## Why it matters

`NextResponse.json` is exactly this shape — a subclass of the native `Response` that forwards its init through `super()`:

```js
class NextResponse extends Response { /* ... */ }
NextResponse.json = (body, init) => {
  const r = Response.json(body, init);   // init is a runtime var here
  return new NextResponse(r.body, r);    // r (a Response) used AS init, through super(body, init)
};
```

So under Next.js **every authenticated route's intended 401 became a 200** — the body was correct, only the status was lost.

## The fix

Two paths, both mirroring machinery that already existed for the literal case:

1. **`Response.json`'s codegen** — `extract_options_fields` returns `None` for a non-literal init and skipped the whole init. It now falls back to reading the fields at runtime via `js_object_get_field_by_name_f64`, the same runtime path `new Response(body, init)` already used.

2. **`super(body, init)` to the native `Response` base** — routes through `global_this_fetch_option`, which bailed to `undefined` for a handle-backed init (a fetch-band handle fails `is_valid_obj_ptr`). A Response used as init is such a handle, so it now hands the handle to `js_object_get_field_by_name_f64`, which resolves `.status` through the handle property dispatch.

## How it was found

Compiling a real Next.js 16 + Auth.js v5 app: `/api/sites` and `/api/dimensions` went from **200 to their correct 401**.

## Test

`test_gap_response_json_runtime_init` — literal init, a module-scope variable, a function parameter, static and instance methods, a Response-as-init forwarded through a subclass `super(body, init)` (NextResponse.json's shape), `statusText`, the default (no init), and `new Response(body, runtimeInit)`. Byte-identical to node.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `Response.json(data, init)` and `new Response(body, init)` so `init` provided via non-literal runtime values no longer drops `status`, `statusText`, and `headers`.
  * Improved forwarding scenarios where a `Response`-derived value is used as `init`, ensuring response fields resolve correctly instead of falling back to defaults.

* **Tests**
  * Added regression coverage for compile-time literals, variable/parameter cases, subclass forwarding, and constructor/runtime `init` scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->