### PR TITLE
fix(fetch): Headers.get returns null (not a "string") for an absent header

### DIFF
--- a/crates/perry-codegen/src/lower_call/options/fetch.rs
+++ b/crates/perry-codegen/src/lower_call/options/fetch.rs
@@ -12,7 +12,7 @@ use perry_hir::Expr;
 use super::get_raw_string_ptr;
 use crate::expr::{lower_expr, nanbox_pointer_inline, nanbox_string_inline, unbox_to_i64, FnCtx};
 use crate::nanbox::double_literal;
-use crate::types::{DOUBLE, I64};
+use crate::types::{DOUBLE, I1, I64};
 
 /// Dispatch for the Web Fetch API family: Response/Headers/Request
 /// methods and property getters. Called before the generic
@@ -221,8 +221,22 @@ pub(in crate::lower_call) fn lower_fetch_native_method(
                     "js_headers_get",
                     &[(DOUBLE, &h_handle), (I64, &key_ptr)],
                 );
+                // `js_headers_get` returns a NULL string pointer for an absent
+                // header. Per WHATWG `Headers.get` must yield `null` — NaN-boxing
+                // the null pointer as a STRING made `typeof h.get(x) === "string"`
+                // and `h.get(x) !== null`, so `h.get("x-forwarded-host") ??
+                // h.get("host")` never fell through (Auth.js v5's trustHost URL
+                // builder then did `new URL("://")` → "Invalid URL", 500 on every
+                // authenticated page). Mirror `UrlSearchParamsGet`: box null as
+                // TAG_NULL. (Same pattern as searchParams.get.)
                 let blk = ctx.block();
-                return Ok(Some(nanbox_string_inline(blk, &str_ptr)));
+                let is_null = blk.icmp_eq(I64, &str_ptr, "0");
+                let as_string = nanbox_string_inline(blk, &str_ptr);
+                let str_bits = ctx.block().bitcast_double_to_i64(&as_string);
+                let selected =
+                    ctx.block()
+                        .select(I1, &is_null, I64, crate::nanbox::TAG_NULL_I64, &str_bits);
+                return Ok(Some(ctx.block().bitcast_i64_to_double(&selected)));
             }
             "getSetCookie" => {
                 let arr =

--- a/test-files/test_gap_headers_get_null_missing.ts
+++ b/test-files/test_gap_headers_get_null_missing.ts
@@ -1,0 +1,38 @@
+// `Headers.get(name)` must return `null` for an absent header (WHATWG). Perry
+// returned a NULL string pointer NaN-boxed AS a string, so `typeof h.get(x)`
+// was "string" and `h.get(x) !== null` — which broke nullish-coalescing:
+// `h.get("x-forwarded-host") ?? h.get("host")` never fell through because the
+// left operand wasn't nullish. Auth.js v5's trustHost URL builder then did
+// `new URL("://" )` and threw "Invalid URL" on every authenticated page.
+
+const h = new Headers();
+h.set("host", "localhost:3000");
+h.set("content-type", "application/json");
+
+// present header — a real string
+console.log("present typeof :", typeof h.get("host"));
+console.log("present value  :", h.get("host"));
+
+// absent header — must be null, not a "string"
+const missing = h.get("x-forwarded-host");
+console.log("missing typeof :", typeof missing);
+console.log("missing ===null:", missing === null);
+console.log("missing ==null :", missing == null);
+
+// nullish coalescing must fall through
+console.log("?? fallback    :", h.get("x-forwarded-host") ?? "FB");
+console.log("?? chain       :", h.get("x-forwarded-host") ?? h.get("host"));
+console.log("|| chain       :", h.get("nope") || "OR-FB");
+
+// the exact Auth.js trustHost URL-builder pattern
+const host = h.get("x-forwarded-host") ?? h.get("host");
+const proto = h.get("x-forwarded-proto") ?? "https";
+const scheme = proto.endsWith(":") ? proto : proto + ":";
+const url = new URL(`${scheme}//${host}`);
+console.log("built URL      :", url.href);
+
+// String() of a missing header must be "null"
+console.log("String(missing):", String(missing));
+
+// after reading a missing one, present reads still work
+console.log("present after  :", h.get("content-type"));


### PR DESCRIPTION
## The bug

`Headers.get(name)` returns a NULL `*mut StringHeader` when the header is absent, but the codegen unconditionally NaN-boxed that pointer as a **string**. So a missing header read back as a value whose `typeof` was `"string"` and which was not `=== null`:

```js
const h = new Headers();
typeof h.get("x-forwarded-host");         // node: "object"    perry: "string"
h.get("x-forwarded-host") === null;       // node: true        perry: false
h.get("x-forwarded-host") ?? "fallback";  // node: "fallback"  perry: the boxed null
```

The `??` and `||` fallbacks that WHATWG code relies on therefore never fired.

## Why it matters

Auth.js v5 (next-auth) builds its base URL under `trustHost` with `h.get("x-forwarded-host") ?? h.get("host")`. With the left operand a non-nullish boxed-null, the `??` kept it, so the builder did `new URL("://")` and threw `TypeError: Invalid URL` — a **500 on every authenticated page render**.

## The fix

Mirror `UrlSearchParamsGet` (which already handles this): when `js_headers_get` returns a null pointer, box `TAG_NULL` instead of a string.

## How it was found

Compiling a real Next.js 16 + Auth.js v5 app.

## Test

`test_gap_headers_get_null_missing` — a present header (a real string), an absent header (`typeof` object, `=== null`, `String()` gives `"null"`), `??` / `||` fallthrough, the exact Auth.js trustHost URL-builder pattern producing a valid URL, and present reads still working after a missing one. Byte-identical to node.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `Headers.get()` to return `null` when a requested header is absent, matching standard Fetch behavior.
  * Preserved correct retrieval of existing headers and compatibility with nullish coalescing and string conversion.

* **Tests**
  * Added coverage for missing-header behavior, fallback values, URL construction, and subsequent access to existing headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->