### PR TITLE
fix(fetch): new Request(urlObject) must ToString the input to its href

### DIFF
--- a/crates/perry-codegen/src/lower_call/builtin.rs
+++ b/crates/perry-codegen/src/lower_call/builtin.rs
@@ -1077,8 +1077,22 @@ pub(super) fn lower_builtin_new(
 
         "Request" => {
             // new Request(url, init?) — init = Fetch RequestInit subset.
+            // The spec runs ToString on `input` when it isn't already a Request,
+            // so a URL object must stringify to its href. `get_raw_string_ptr`
+            // (js_get_string_pointer_unified) only unwraps an actual string value
+            // — handed a URL object (a heap ObjectHeader) it read the object
+            // pointer as a string and produced "", so `new Request(new URL(u)).url`
+            // was empty. Auth.js v5 builds its session request as `new
+            // Request(fu("session", …))` where `fu` returns a URL object, so the
+            // session lookup got an empty URL, returned 400 "Bad request.", and
+            // `auth()` yielded that string instead of null — the authenticated-page
+            // guard then never redirected and fell through to a DB-pool init that
+            // threw. Route through `js_jsvalue_to_string`, which invokes `toString`
+            // on an object (URL → href) and passes a real string straight through.
             let url_ptr = if !args.is_empty() {
-                get_raw_string_ptr(ctx, &args[0])?
+                let v = lower_expr(ctx, &args[0])?;
+                ctx.block()
+                    .call(I64, "js_request_input_to_url", &[(DOUBLE, &v)])
             } else {
                 "0".to_string()
             };

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -977,6 +977,7 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
     // object at runtime instead of silently dropping them.
     module.declare_function("js_request_new_from_init", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_request_get_url", I64, &[DOUBLE]);
+    module.declare_function("js_request_input_to_url", I64, &[DOUBLE]);
     module.declare_function("js_request_get_method", I64, &[DOUBLE]);
     module.declare_function("js_request_get_body", DOUBLE, &[DOUBLE]);
     module.declare_function("js_request_body_used", DOUBLE, &[DOUBLE]);

--- a/crates/perry-stdlib/src/fetch/mod.rs
+++ b/crates/perry-stdlib/src/fetch/mod.rs
@@ -1767,6 +1767,23 @@ pub extern "C" fn js_request_get_url(handle: f64) -> *mut StringHeader {
     }
 }
 
+/// Coerce the first argument of `new Request(input, init)` to its URL string.
+/// The spec runs `ToString(input)` unless `input` is already a `Request`, in
+/// which case the constructor clones it and keeps its url. A `Request` handle
+/// has no custom `toString` (`String(request)` is `"[object Request]"`), so
+/// running ToString on it would store that literal as the url — this returns the
+/// cloned request's real url instead. Any other value (a URL object, a string)
+/// falls through to `js_jsvalue_to_string`, which invokes `toString` (URL → href)
+/// or passes a string straight through.
+#[no_mangle]
+pub extern "C" fn js_request_input_to_url(value: f64) -> *mut StringHeader {
+    let id = handle_id(value);
+    if let Some(req) = REQUEST_REGISTRY.lock().unwrap().get(&id) {
+        return js_string_from_bytes(req.url.as_ptr(), req.url.len() as u32);
+    }
+    perry_runtime::value::js_jsvalue_to_string(value) as *mut StringHeader
+}
+
 #[no_mangle]
 pub extern "C" fn js_request_get_method(handle: f64) -> *mut StringHeader {
     let id = handle_id(handle);

--- a/test-files/test_gap_request_url_object.ts
+++ b/test-files/test_gap_request_url_object.ts
@@ -1,0 +1,35 @@
+// `new Request(input, init)` runs ToString on `input` when it isn't already a
+// Request. A URL object must stringify to its href. Perry's codegen extracted a
+// raw string pointer from the first arg (`js_get_string_pointer_unified`), which
+// only unwraps an actual string — handed a URL object it read the object pointer
+// as a string and produced "". So `new Request(new URL(u)).url` was empty.
+//
+// Auth.js v5 builds its session request as `new Request(makeSessionUrl(...))`
+// where the helper returns a URL object, so the session lookup got an empty URL,
+// returned 400, and `auth()` yielded the wrong value — every authenticated page
+// then mis-decided its redirect.
+
+const href = "http://localhost:3000/api/auth/session";
+
+// a string first arg — always worked
+console.log("string      :", new Request(href).url);
+
+// a URL object first arg — the regression
+const u = new URL(href);
+console.log("URL object  :", new Request(u).url);
+
+// URL object + init
+console.log("URL + init  :", new Request(u, { method: "GET", headers: { cookie: "" } }).url);
+
+// URL object with a path and query
+const u2 = new URL("https://example.com/a/b?x=1&y=2");
+const r2 = new Request(u2);
+console.log("URL w/ query:", r2.url);
+
+// method/headers from a runtime init still apply (regression guard for #5458)
+const init = { method: "POST", headers: { "content-type": "application/json" } };
+const r4 = new Request(u, init);
+console.log("method kept :", r4.method, r4.url);
+
+// String()/toString of the URL match what Request stored
+console.log("consistency :", new Request(u).url === u.toString());


### PR DESCRIPTION
## The bug

The `Request` constructor runs `ToString(input)` when `input` isn't already a `Request`, so a `URL` object must stringify to its href. The codegen extracted a raw string pointer from the first arg (`js_get_string_pointer_unified`), which only unwraps an actual string value — handed a URL object (a heap `ObjectHeader`) it read the object pointer as a string and produced `""`:

```js
const u = new URL("http://localhost/api/auth/session");
new Request(u).url;   // node: "http://localhost/api/auth/session"   perry: ""
```

## Why it matters

Auth.js v5 (next-auth) builds its session request as `new Request(makeSessionUrl(...))`, where the helper returns a **URL object**. With an empty url the internal session lookup returned `400 "Bad request."`, so `auth()` yielded that string instead of `null` — and the authenticated-page guard `if (!session?.user?.id) redirect(...)` mis-decided, falling through to code that then threw a 500. With this fix `auth()` correctly returns `null` for an unauthenticated request and the guard redirects.

## The fix

New `js_request_input_to_url` coerces the constructor input:

- a `Request` handle → its cloned url (a Request has no custom `toString` — `String(request)` is `"[object Request]"` — so ToString would store that literal as the url);
- anything else → `js_jsvalue_to_string`, which invokes `toString` on an object (URL → href) and passes a real string straight through.

## How it was found

Compiling a real Next.js 16 + Auth.js v5 app.

## Test

`test_gap_request_url_object` — a string input, a URL object, a URL object plus init, a URL with a path and query, a runtime init still applying its method (#5458 guard), and `String()`/url consistency. Byte-identical to node.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `Request` construction with `URL` objects and other URL-like inputs.
  * URL objects now correctly preserve their full URL, including paths and query parameters.
  * Request initialization now consistently retains methods and headers when a URL object is provided.

* **Tests**
  * Added coverage for string URLs, URL objects, URL conversion, and request initialization options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->