### PR TITLE
fix(runtime): coerce a numeric key to a string in the `in` operator

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set/has_property.rs
+++ b/crates/perry-runtime/src/object/field_get_set/has_property.rs
@@ -190,6 +190,27 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
     let nanbox_true = f64::from_bits(0x7FFC_0000_0000_0004u64); // TAG_TRUE
 
     let obj_val = JSValue::from_bits(obj.to_bits());
+
+    // `in` runs ToPropertyKey on the key. Object property names are strings, so a
+    // NUMBER key must be coerced to its string form before the lookup — `307 in
+    // {307: …}` is `"307" in {…}` and must be true. Without this the string-only
+    // lookup below never matched a numeric key against a numeric-string property,
+    // so `307 in obj` was false while `"307" in obj` was true. Next.js's
+    // `isRedirectError` does `Number(digest.at(-2)) in RedirectStatusCode` (a
+    // `{307: …, 308: …}` map), so a `redirect()` thrown from a Server Component
+    // was not recognized as a redirect — Next treated it as a real error and a
+    // concurrently-rendered sibling's `session.user` read (guarded by that same
+    // redirect on the happy path) surfaced as a fatal 500 instead of a 307.
+    // (Symbols and strings pass through unchanged; a proxy/handle receiver is
+    // handled below with the coerced key.)
+    let key = {
+        let kv = JSValue::from_bits(key.to_bits());
+        if kv.is_number() {
+            unsafe { crate::object::js_to_property_key(key) }
+        } else {
+            key
+        }
+    };
     let key_val = JSValue::from_bits(key.to_bits());
 
     // A Proxy is a small registered id (POINTER_TAG with a tiny pointer), not a

--- a/test-files/test_gap_in_operator_numeric_key.ts
+++ b/test-files/test_gap_in_operator_numeric_key.ts
@@ -1,0 +1,59 @@
+// The `in` operator runs ToPropertyKey on its left operand. Object property
+// names are strings, so a NUMBER key must be coerced to its string form:
+// `307 in {307: …}` is `"307" in {…}` and must be true. Perry only matched the
+// key when it was already a string, so `307 in obj` was false while `"307" in
+// obj` was true.
+//
+// Next.js's `isRedirectError` does `Number(digest.at(-2)) in RedirectStatusCode`
+// (a `{307: …, 308: …}` map), so a `redirect()` thrown from a Server Component
+// was never recognized — Next treated it as a real error and every authenticated
+// page 500'd instead of redirecting.
+
+const obj: any = { 307: "TemporaryRedirect", 308: "PermanentRedirect", 200: "OK" };
+
+console.log("keys          :", Object.keys(obj).join(","));
+console.log("307 in obj    :", 307 in obj);
+console.log("'307' in obj  :", "307" in obj);
+console.log("200 in obj    :", 200 in obj);
+console.log("999 in obj    :", 999 in obj);
+console.log("Number() in   :", Number("307") in obj);
+
+// a computed numeric key
+const k = 308;
+console.log("computed k in :", k in obj);
+
+// a float that names an integer key
+console.log("307.0 in obj  :", 307.0 in obj);
+
+// a non-integer number is not a key here
+console.log("3.5 in obj    :", 3.5 in obj);
+
+// arrays: numeric index membership
+const arr = ["a", "b", "c"];
+console.log("0 in arr      :", 0 in arr);
+console.log("2 in arr      :", 2 in arr);
+console.log("3 in arr      :", 3 in arr);
+console.log("'1' in arr    :", "1" in arr);
+
+// string keys still work, and a missing string key is still false
+const s: any = { foo: 1, bar: 2 };
+console.log("string key    :", "foo" in s, "baz" in s);
+
+// the exact isRedirectError shape from Next.js
+const RedirectStatusCode: any = { 307: "TemporaryRedirect", 308: "PermanentRedirect", 303: "SeeOther" };
+function isRedirectError(e: any): boolean {
+  if ("object" != typeof e || null === e || !("digest" in e) || "string" != typeof e.digest) return false;
+  const t = e.digest.split(";");
+  const [r, n] = t;
+  const a = t.slice(2, -2).join(";");
+  const o = Number(t.at(-2));
+  return r === "NEXT_REDIRECT" && ("replace" === n || "push" === n) && "string" == typeof a && !isNaN(o) && o in RedirectStatusCode;
+}
+const err: any = new Error("NEXT_REDIRECT");
+err.digest = "NEXT_REDIRECT;replace;/;307;";
+console.log("isRedirectError:", isRedirectError(err));
+
+// a symbol key still round-trips through `in`
+const sym = Symbol("s");
+const withSym: any = { [sym]: 1 };
+console.log("symbol in     :", sym in withSym);


### PR DESCRIPTION
## The bug

The `in` operator runs ToPropertyKey on its left operand. Object property names are strings, so a **number** key must be coerced to its string form before the lookup: `307 in {307: …}` is `"307" in {…}` and must be `true`. `js_object_has_property` only matched a key that was already a string:

```js
const o = { 307: "a" };
307 in o;     // node: true    perry: false
"307" in o;   // node: true    perry: true
```

## Why it matters

Next.js's `isRedirectError` classifies a thrown redirect with `Number(digest.at(-2)) in RedirectStatusCode`, where `RedirectStatusCode` is a `{307: …, 308: …, 303: …}` map. With `307 in map` returning `false`, a `redirect()` thrown from a Server Component was **not recognized as a redirect** — Next treated it as a genuine error. A concurrently-rendered sibling's `session.user` read (guarded by that same redirect on the happy path) then surfaced as a fatal **500 instead of the intended 307**, on every authenticated page.

## The fix

A number key is run through `js_to_property_key` (ToPropertyKey) at the top of the operator, before the proxy / handle / heap-object paths, so every receiver sees the coerced string. Strings and symbols pass through unchanged; arrays were unaffected (they resolve a numeric index through a separate path).

## How it was found

Compiling a real Next.js 16 + Auth.js v5 app: `/dashboard`, `/settings`, and their locale-prefixed forms went from 500 to their correct 307 redirects.

## Test

`test_gap_in_operator_numeric_key` — numeric keys (int and float), `Number()` results, computed keys, a non-integer number, array index membership, string keys (present and absent), a symbol key, and the exact `isRedirectError` shape from Next.js. Byte-identical to node.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the `in` operator so numeric property keys are correctly converted to property-key strings before lookup.
  * Ensured numeric keys work consistently with object properties and proxy-based checks.
  * Preserved support for symbol keys and non-integer numeric behavior.

* **Tests**
  * Added coverage for integer, decimal, symbol, and redirect-status property checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->