### PR TITLE
fix(hir): hoist top-level `var` entry slot in function-expression bodies

### DIFF
--- a/crates/perry-hir/src/lower/expr_function.rs
+++ b/crates/perry-hir/src/lower/expr_function.rs
@@ -787,7 +787,7 @@ fn lower_fn_expr_anon(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) -> Resul
                                 .lookup_index_in_scope(&name, outer_locals_len)
                                 .is_some();
                             if !already_in_scope {
-                                let id = ctx.define_local(name, Type::Any);
+                                let id = ctx.define_local(name.clone(), Type::Any);
                                 // Mark as hoisted so closures created
                                 // before the var's init expression see
                                 // it through a box (mutable capture),
@@ -814,6 +814,32 @@ fn lower_fn_expr_anon(ctx: &mut LoweringContext, fn_expr: &ast::FnExpr) -> Resul
                                 // sibling-capture symptom, extended to
                                 // forward-var captures).
                                 hoisted_id_set.insert(id);
+                                // Emit an undefined-initialised entry slot,
+                                // exactly like the nested-`var` pre-pass
+                                // below (and `predefine_var_bindings_in_
+                                // function_body` on the fn-decl/arrow path).
+                                // The `hoisted_id_set` box above only covers
+                                // the forward-CAPTURE case (a closure created
+                                // before the decl reads the box). A `var`
+                                // merely READ/WRITTEN before its own textual
+                                // declaration but NOT captured by any closure
+                                // gets no prealloc box, so without this Let
+                                // its slot first materialises at the late
+                                // `var <name> = …` and every earlier read/
+                                // write folds to `undefined`. React's
+                                // cloneElement/createElement do exactly this:
+                                //   for (propName in o) …;  var propName = …;
+                                // one hoisted `propName` used by the for-in
+                                // loop, then redeclared as a number — so the
+                                // loop body's `hasOwnProperty.call(o, propName)`
+                                // saw `undefined` and dropped every prop.
+                                nested_var_prologue.push(Stmt::Let {
+                                    id,
+                                    name,
+                                    ty: Type::Any,
+                                    mutable: true,
+                                    init: Some(Expr::Undefined),
+                                });
                             }
                         }
                     }

--- a/test-files/test_gap_var_hoist_forin_fn_expr.ts
+++ b/test-files/test_gap_var_hoist_forin_fn_expr.ts
@@ -1,0 +1,79 @@
+// A `var` is function-scoped and hoisted: a declaration that appears textually
+// AFTER a statement that reads/writes it is still bound (as `undefined`) from
+// function entry. Perry honored this for function *declarations* (and arrows)
+// but NOT for function *expressions*: the fn-expr lowering pre-registered the
+// hoisted local but never emitted the undefined-initialised entry slot, so a
+// read/write compiled BEFORE the late `var x = …` fell to a folded `undefined`.
+//
+// React 19's `cloneElement`/`createElement` are exactly this shape — one
+// hoisted `propName` used by a `for (propName in config)` loop, then redeclared
+// as `var propName = arguments.length - 2`. The loop body's
+// `hasOwnProperty.call(config, propName)` saw `undefined`, so it dropped every
+// prop and `<Button asChild>` (Radix Slot → cloneElement) rendered a bare `<a>`.
+
+const hop = Object.prototype.hasOwnProperty;
+
+// The minimal trigger: a function EXPRESSION with a `for-in` loop variable that
+// is a `var` declared after the loop.
+const clone = function (element: any, config: any, children?: any): any {
+  const props: any = Object.assign({}, element.props);
+  let key = element.key;
+  if (null != config)
+    for (propName in (void 0 !== config.key && (key = "" + config.key), config))
+      !hop.call(config, propName) ||
+        "key" === propName ||
+        "__self" === propName ||
+        "__source" === propName ||
+        (props[propName] = config[propName]);
+  var propName = arguments.length - 2; // hoisted; declared AFTER the loop, reused as a number
+  if (1 === propName) props.children = children;
+  return props;
+};
+
+const el = { props: { href: "/signup", children: "Get Started" }, key: null };
+const config = { "data-slot": "button", "data-variant": "default", className: "px-6", href: "/signup", children: "Get Started" };
+const out = clone(el, config);
+console.log("clone keys:", Object.keys(out).join(","));
+console.log("clone data-slot:", out["data-slot"]);
+console.log("clone className:", out.className);
+
+// A plain forward read of a hoisted `var` in a function expression: reads
+// before the declaration are `undefined`, after are the assigned value.
+const fwd = function (): string {
+  const before = String(later);
+  var later = 42;
+  const after = String(later);
+  return before + "/" + after;
+};
+console.log("forward var:", fwd());
+
+// Arrow expressions must keep behaving identically (they already worked).
+const arrowFwd = (): string => {
+  const before = String(v);
+  var v = 7;
+  return before + "/" + String(v);
+};
+console.log("arrow var:", arrowFwd());
+
+// A method (object-literal function expression) with the same hoist shape.
+const obj = {
+  run(o: any): string {
+    const seen: string[] = [];
+    for (k in o) seen.push(k + "=" + o[k]);
+    var k: string;
+    return seen.join(",");
+  },
+};
+console.log("method for-in:", obj.run({ a: 1, b: 2, c: 3 }));
+
+// Nested `var` inside an if-branch of a function expression, used by a sibling
+// branch before its textual position (already worked; guards against regression).
+const branchy = function (cond: boolean): number {
+  if (cond) {
+    var acc = 10;
+  } else {
+    acc = 20;
+  }
+  return acc;
+};
+console.log("branchy true:", branchy(true), "false:", branchy(false));


### PR DESCRIPTION
## Summary

A `var` is function-scoped and hoisted: a declaration textually **after** a statement that reads/writes it is still bound (as `undefined`) from function entry. Perry honored this for function **declarations** and arrows, but not for function **expressions** — so a `var` used before its own late declaration folded to a constant `undefined` at every earlier read.

## Root cause

The fn-expr lowering has a top-level `var` pre-pass (issue #838) that pre-registers the hoisted local and adds it to `hoisted_id_set`. That only fixes the forward-**capture** case (a closure created before the declaration reads the var through a prealloc box). A `var` merely **read/written** before its declaration but **not captured by any closure** got no box and — crucially — no undefined-initialised entry slot, so its storage first materialised at the late `var x = …` statement. The fn-decl/arrow path (`predefine_var_bindings_in_function_body`) always emits that entry slot; the fn-expr path did not.

HIR was already correct (one shared `LocalId` for both the loop use and the late redeclaration); only the entry `Let` was missing, so codegen resolved earlier `LocalGet`s to a folded `undefined`.

## Real-world impact: React `cloneElement` drops all props

React 19's `cloneElement`/`createElement` are exactly this shape:

```js
exports.cloneElement = function (element, config, children) {
  var props = assign({}, element.props), key = element.key;
  if (null != config)
    for (propName in (void 0 !== config.key && (key = "" + config.key), config))
      !hasOwnProperty.call(config, propName) || "key" === propName || … ||
        (props[propName] = config[propName]);
  var propName = arguments.length - 2;   // hoisted; declared AFTER the loop
  …
};
```

Compiled as a function expression, the loop body's `hasOwnProperty.call(config, propName)` saw `propName === undefined`, so the `!hasOwn(...) || …` chain short-circuited and `props[propName] = config[propName]` never ran — **cloneElement returned the element's original props with none of `config` merged in**. Radix `Slot` (shadcn `<Button asChild>`) merges its props onto its child via cloneElement, so `<Button asChild><Link/></Button>` rendered a bare `<a href>` with no `data-slot`/`data-variant`/`className`.

## Fix

The top-level `var` pre-pass now also pushes the undefined-initialised entry `Let` into `nested_var_prologue`, exactly like the nested-`var` pre-pass a few lines below (and the fn-decl/arrow path).

## Testing

Reproduces at `-O0`, confirming a lowering bug rather than an LLVM-optimisation artifact. Added `test-files/test_gap_var_hoist_forin_fn_expr.ts` (byte-identical to `node --experimental-strip-types`) covering the cloneElement shape plus forward-`var` reads in function expressions, object methods, arrows, and if-branch `var`s. Verified end-to-end: a real Next.js 16 app's shadcn `<Button asChild>` buttons now render with their full class list, matching Node byte-for-byte in the visible DOM.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `var` hoisting in function expressions so variables are available with `undefined` values before their declarations.
  * Corrected hoisting behavior in `for-in` loops, arrow functions, object methods, and conditional branches.

* **Tests**
  * Added regression coverage for forward `var` references and related function-expression scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->