### PR TITLE
fix(runtime): zero-fill new Uint8Array(n) — buffer_alloc returns reclaimed dirty memory

### DIFF
--- a/crates/perry-runtime/src/buffer/from.rs
+++ b/crates/perry-runtime/src/buffer/from.rs
@@ -525,6 +525,19 @@ pub extern "C" fn js_uint8array_alloc(length: i32) -> *mut BufferHeader {
     let buf = buffer_alloc(length);
     unsafe {
         (*buf).length = length;
+        // `buffer_alloc` hands back old-arena memory that is NOT guaranteed
+        // zeroed: the old generation reclaims and re-hands dirty blocks, and
+        // only pristine mmap pages read as zero. `new Uint8Array(n)` (and the
+        // bool / string / numeric-length sources that funnel here) is
+        // spec-mandated zero-filled, so clear the payload explicitly instead of
+        // relying on incidental zeroing. The sibling `js_buffer_alloc`
+        // (Buffer.alloc) already does this; this path was the lone gap. Latent
+        // on macOS (fresh pages read zero); leaked stale bytes on Linux once an
+        // unrelated codegen change shifted these allocations onto reclaimed
+        // blocks.
+        if length > 0 {
+            ptr::write_bytes(buffer_data_mut(buf), 0, length as usize);
+        }
     }
     mark_as_uint8array(buf as usize);
     buf


### PR DESCRIPTION
`new Uint8Array(n)` can observe **uninitialized memory** — a spec violation (a length-constructed typed array must be zero-filled), and a genuine memory-disclosure hazard.

### Root cause

`js_uint8array_alloc` set the header and relied on the backing block already being zero. It isn't. `buffer_alloc` allocates through `arena_alloc_gc_old`, and the old generation **reclaims and re-hands dirty blocks** — only pristine `mmap` pages read as zero.

The sibling paths already know this:

- `js_buffer_alloc` (Buffer.alloc) does `ptr::write_bytes(data, fill, size)`.
- `zeroed_array_buffer_storage` carries the exact comment: *"`buffer_alloc` does not zero, but ArrayBuffer per ECMAScript spec must observe zero-initialized bytes."*

`js_uint8array_alloc` was the one sibling that forgot. The fix adds the same explicit zero-fill:

```rust
let buf = buffer_alloc(length);
unsafe {
    (*buf).length = length;
+   if length > 0 {
+       ptr::write_bytes(buffer_data_mut(buf), 0, length as usize);
+   }
}
```

### Why nobody hit it, and how it surfaced

Latent on macOS (length-constructed arrays land on fresh, zero `mmap` pages), and latent on current `main` even on Linux (they happen to land on clean blocks). It surfaced under **#6407** — an unrelated net-dispatch PR that also expands `BUFFER_PROTOTYPE_METHODS` from 11 to ~93 entries, perturbing `-O3`/thin-LTO code+data layout and moving these allocations onto reclaimed *dirty* blocks. `test_gap_uint8array_source_dispatch` then printed garbage, **non-deterministic** bytes for the `boolean` (`new Uint8Array(true)`) and `string` (`new Uint8Array("2")`) length cases:

```
run 1: boolean 5   string 56,21
run 2: boolean 4   string 16,12
run 3: boolean 5   string 0,14
       (node: boolean 0   string 0,0)
```

Reproduced on a Linux box: **20/20 runs correct** with this fix, byte-identical to Node; reverting it fails. This is why #6407's CI was red on `conformance-smoke (8)` — landing this on `main` unblocks it on rebase.

### On the missing test

I deliberately did **not** add a gap test. The defect requires the arena to re-hand a specific dirtied block, which neither macOS nor `main`-on-Linux reproduces on demand — I verified a GC-reuse stress test (`fill 0xFF → drop → gc() → realloc → assert zero`) passes with *and* without the fix on macOS. A test that can't fail without the fix isn't a regression guard, it's noise. The fix stands on its own correctness: zero-filling a spec-zero-initialized buffer can never regress a caller, and three sibling allocators already do exactly this.
