### PR TITLE
fix(http): serve static files past 64 KB — res.once() + res.socket.writable

### DIFF
--- a/crates/perry-ext-http-server/src/dispatch_ext.rs
+++ b/crates/perry-ext-http-server/src/dispatch_ext.rs
@@ -144,6 +144,7 @@ fn is_incoming_message_member(name: &str) -> bool {
             | "destroyed"
             | "readable"
             | "readableEnded"
+            | "writable"
             | "socket"
             | "connection"
             | "signal"
@@ -200,6 +201,8 @@ fn is_server_response_member(name: &str) -> bool {
             | "detachSocket"
             | "on"
             | "addListener"
+            | "once"
+            | "prependOnceListener"
             | "setStatus"
             | "getStatus"
     ) || matches!(

--- a/crates/perry-ext-http-server/src/handle_dispatch.rs
+++ b/crates/perry-ext-http-server/src/handle_dispatch.rs
@@ -162,6 +162,11 @@ extern "C" {
     fn js_node_http_res_write_continue(handle: i64);
     fn js_node_http_res_write_processing(handle: i64);
     fn js_node_http_res_on(handle: i64, event_name_ptr: *const StringHeader, callback: i64) -> f64;
+    fn js_node_http_res_once(
+        handle: i64,
+        event_name_ptr: *const StringHeader,
+        callback: i64,
+    ) -> f64;
 }
 
 /// Probe: is `handle` a live `HttpServer`?
@@ -796,6 +801,14 @@ pub unsafe extern "C" fn js_ext_http_server_response_dispatch_method(
             js_node_http_res_on(handle, event_ptr, closure_arg(Some(args[1])));
             self_ref
         }
+        "once" | "prependOnceListener" if args.len() >= 2 => {
+            let event_ptr = string_arg(args[0]);
+            if event_ptr.is_null() {
+                return self_ref;
+            }
+            js_node_http_res_once(handle, event_ptr, closure_arg(Some(args[1])));
+            self_ref
+        }
         "setStatus" | "__set_statusCode" if !args.is_empty() => {
             js_node_http_res_set_status(handle, number_arg(Some(args[0]), 200.0));
             undef
@@ -879,6 +892,20 @@ pub unsafe extern "C" fn js_ext_http_incoming_message_dispatch_property(
         // and `@Body()` resolved to `undefined`.
         "readable" => bool_value(js_node_http_im_readable(handle) != 0),
         "readableEnded" => bool_value(js_node_http_im_complete(handle) != 0),
+        // `req.writable` — Node's real `req.socket` is the Duplex TCP socket,
+        // whose `writable` is true while the RESPONSE side of the connection is
+        // still open. `res.socket` aliases the request handle (see
+        // `response_socket_value`), so `on-finished`'s `isFinished(res)` —
+        // `Boolean(res.finished || (socket && !socket.writable))` — reads
+        // `socket.writable` HERE. Without it `writable` was `undefined`, so
+        // `!socket.writable` was true → on-finished reported the response
+        // finished the instant a stream was piped → `send` (Next.js static
+        // serving via `serve-static`) destroyed the read stream after the first
+        // high-water-mark (64 KB) chunk, truncating every static file past that
+        // size. Symmetric with the `readable` accessor above (request-body side).
+        "writable" => bool_value(
+            js_node_http_im_destroyed(handle) == 0 && js_node_http_im_aborted(handle) == 0,
+        ),
         "socket" | "connection" => crate::request::incoming_socket_override(handle)
             .unwrap_or_else(|| handle_to_pointer_f64(handle)),
         "signal" => js_node_http_im_signal(handle),
@@ -1186,6 +1213,8 @@ fn server_response_method_bytes(name: &str) -> Option<&'static [u8]> {
         "pipe" => Some(b"pipe"),
         "on" => Some(b"on"),
         "addListener" => Some(b"addListener"),
+        "once" => Some(b"once"),
+        "prependOnceListener" => Some(b"prependOnceListener"),
         _ => None,
     }
 }

--- a/crates/perry-ext-http-server/src/response.rs
+++ b/crates/perry-ext-http-server/src/response.rs
@@ -233,6 +233,15 @@ pub struct ServerResponse {
     pub needs_drain: bool,
     /// Event-name → list of registered listener closure pointers.
     pub listeners: HashMap<String, Vec<i64>>,
+    /// Event-name → one-shot (`res.once(event, cb)`) listener closure
+    /// pointers. Drained by every event-consumption site after firing so a
+    /// `once` listener fires exactly once — Node's `EventEmitter.once`
+    /// contract. Kept separate from `listeners` so persistent `on` listeners
+    /// survive the drain. The critical caller is Perry's own `createReadStream`
+    /// → `.pipe(res)` pump, which re-arms `res.once('drain')` after each
+    /// backpressure pause; without one-shot semantics the pump stalls after the
+    /// first 64 KB chunk (static files truncate).
+    pub once_listeners: HashMap<String, Vec<i64>>,
     /// #4904: true for `new http.ServerResponse(req)` instances (and any
     /// response wired through `assignSocket`) — `.end()` flushes through
     /// `standalone_socket` instead of the hyper oneshot.
@@ -398,6 +407,7 @@ impl ServerResponse {
             stream_in_flight: None,
             needs_drain: false,
             listeners: HashMap::new(),
+            once_listeners: HashMap::new(),
             standalone: false,
             standalone_socket: f64::from_bits(TAG_UNDEFINED),
             standalone_req_method: None,
@@ -1340,8 +1350,8 @@ fn finalize_buffered_end(handle: i64, chunk: f64) -> Option<(Vec<i64>, Vec<i64>)
         sr.writable_ended = true;
         sr.writable_finished = true;
         sr.needs_drain = false;
-        let finish_listeners = sr.listeners.get("finish").cloned().unwrap_or_default();
-        let close_listeners = sr.listeners.get("close").cloned().unwrap_or_default();
+        let finish_listeners = take_event_listeners(sr, "finish");
+        let close_listeners = take_event_listeners(sr, "close");
         return Some((finish_listeners, close_listeners));
     }
 
@@ -1361,8 +1371,8 @@ fn finalize_buffered_end(handle: i64, chunk: f64) -> Option<(Vec<i64>, Vec<i64>)
         trailers,
         body: ShapeBody::Full(body),
     };
-    let finish_listeners = sr.listeners.get("finish").cloned().unwrap_or_default();
-    let close_listeners = sr.listeners.get("close").cloned().unwrap_or_default();
+    let finish_listeners = take_event_listeners(sr, "finish");
+    let close_listeners = take_event_listeners(sr, "close");
     if let Some(tx) = sr.response_tx.take() {
         let _ = tx.send(shape);
     }
@@ -1461,7 +1471,7 @@ pub(crate) fn take_drain_listeners_if_ready(handle: i64) -> Vec<i64> {
         return Vec::new();
     }
     sr.needs_drain = false;
-    sr.listeners.get("drain").cloned().unwrap_or_default()
+    take_event_listeners(sr, "drain")
 }
 
 /// True when a streaming response's connection died under it (hyper
@@ -1608,6 +1618,58 @@ pub unsafe extern "C" fn js_node_http_res_on(
         }
     }
     handle_to_pointer_f64(handle)
+}
+
+/// `res.once(event, cb)` — register a one-shot listener. Mirrors
+/// `js_node_http_res_on` but stores into `once_listeners`, which every
+/// event-consumption site drains via [`take_event_listeners`] after firing so
+/// the listener runs exactly once (Node's `EventEmitter.once` contract).
+///
+/// Without this the `once` dispatch arm did not exist at all: `res.once(...)`
+/// fell through to a no-op, so Perry's `createReadStream().pipe(res)` pump —
+/// which re-arms `res.once('drain')` after each backpressure pause — never got
+/// its drain callback and stalled after the first 64 KB chunk, truncating every
+/// static file larger than the high-water mark.
+///
+/// # Safety
+/// FFI entry; `event_name_ptr` must be a valid `StringHeader` for its length.
+#[no_mangle]
+pub unsafe extern "C" fn js_node_http_res_once(
+    handle: i64,
+    event_name_ptr: *const StringHeader,
+    callback: i64,
+) -> f64 {
+    let event = read_string_header(event_name_ptr as *mut _).unwrap_or_default();
+    let mut should_fire_now = false;
+    if let Some(sr) = get_handle_mut::<ServerResponse>(handle) {
+        // `finish`/`close` already fired: run immediately without storing,
+        // matching the late-registration behavior of `js_node_http_res_on`.
+        if sr.writable_finished && (event == "finish" || event == "close") {
+            should_fire_now = true;
+        } else {
+            sr.once_listeners.entry(event).or_default().push(callback);
+        }
+    } else {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    if should_fire_now && callback != 0 {
+        let raw = callback as *const RawClosureHeader;
+        let closure = JsClosure::from_raw(raw);
+        if !closure.is_null() {
+            let _ = closure.call0();
+        }
+    }
+    handle_to_pointer_f64(handle)
+}
+
+/// Listeners to fire for `event`: persistent `on` listeners (cloned, retained)
+/// followed by one-shot `once` listeners (removed, so they fire exactly once).
+pub(crate) fn take_event_listeners(sr: &mut ServerResponse, event: &str) -> Vec<i64> {
+    let mut out = sr.listeners.get(event).cloned().unwrap_or_default();
+    if let Some(once) = sr.once_listeners.remove(event) {
+        out.extend(once);
+    }
+    out
 }
 
 // ============================================================================
@@ -1828,8 +1890,8 @@ unsafe fn standalone_end(handle: i64, chunk: f64, callback: i64) {
         payload = bytes;
         socket = sr.standalone_socket;
         write_cbs = std::mem::take(&mut sr.pending_write_callbacks);
-        finish_listeners = sr.listeners.get("finish").cloned().unwrap_or_default();
-        close_listeners = sr.listeners.get("close").cloned().unwrap_or_default();
+        finish_listeners = take_event_listeners(sr, "finish");
+        close_listeners = take_event_listeners(sr, "close");
         sr.writable_finished = true;
     }
     if !JsValue::from_bits(socket.to_bits()).is_undefined() {
@@ -1902,99 +1964,5 @@ pub(crate) fn _force_link_helpers(v: f64) -> bool {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn empty_response() -> ServerResponse {
-        let (tx, _rx) = oneshot::channel::<HyperResponseShape>();
-        ServerResponse::new(tx)
-    }
-
-    #[test]
-    fn write_head_headers_json_merges_and_preserves_case() {
-        // #2132: a `writeHead(status, headers)` object is JSON-serialized and
-        // merged here; the lookup key is lowercase but the original case is
-        // retained for `getHeaderNames()`.
-        let mut sr = empty_response();
-        apply_headers_json(&mut sr, r#"{"Content-Type":"text/plain","X-Custom":"abc"}"#);
-        assert_eq!(
-            sr.headers.get("content-type").map(String::as_str),
-            Some("text/plain")
-        );
-        assert_eq!(sr.headers.get("x-custom").map(String::as_str), Some("abc"));
-        assert_eq!(
-            sr.raw_header_names.get("content-type").map(String::as_str),
-            Some("Content-Type")
-        );
-        assert_eq!(
-            sr.raw_header_names.get("x-custom").map(String::as_str),
-            Some("X-Custom")
-        );
-    }
-
-    #[test]
-    fn write_head_headers_json_stringifies_non_string_values() {
-        let mut sr = empty_response();
-        apply_headers_json(&mut sr, r#"{"Content-Length":42,"X-Flag":true}"#);
-        assert_eq!(
-            sr.headers.get("content-length").map(String::as_str),
-            Some("42")
-        );
-        assert_eq!(sr.headers.get("x-flag").map(String::as_str), Some("true"));
-    }
-
-    #[test]
-    fn write_head_headers_json_ignores_empty_and_sentinels() {
-        let mut sr = empty_response();
-        apply_headers_json(&mut sr, "");
-        apply_headers_json(&mut sr, "null");
-        apply_headers_json(&mut sr, "undefined");
-        assert!(sr.headers.is_empty());
-    }
-
-    // #4965 — `setHeaders` entries normalizer output.
-
-    #[test]
-    fn apply_headers_entries_lowercases_and_preserves_case() {
-        let mut sr = empty_response();
-        apply_headers_entries(&mut sr, r#"[["Foo","1"],["Bar","2"]]"#);
-        assert_eq!(sr.headers.get("foo").map(String::as_str), Some("1"));
-        assert_eq!(sr.headers.get("bar").map(String::as_str), Some("2"));
-        assert_eq!(
-            sr.raw_header_names.get("foo").map(String::as_str),
-            Some("Foo")
-        );
-    }
-
-    #[test]
-    fn apply_headers_entries_set_cookie_array_keeps_per_element_list() {
-        let mut sr = empty_response();
-        apply_headers_entries(&mut sr, r#"[["set-cookie",["a=b","c=d"]]]"#);
-        assert_eq!(
-            sr.header_value_lists.get("set-cookie").map(Vec::as_slice),
-            Some(["a=b".to_string(), "c=d".to_string()].as_slice())
-        );
-        assert_eq!(
-            sr.headers.get("set-cookie").map(String::as_str),
-            Some("a=b, c=d")
-        );
-    }
-
-    #[test]
-    fn apply_headers_entries_ignores_non_array_and_short_pairs() {
-        let mut sr = empty_response();
-        apply_headers_entries(&mut sr, r#"[{"foo":"1"},["only-name"],["k","v"]]"#);
-        assert_eq!(sr.headers.get("k").map(String::as_str), Some("v"));
-        assert_eq!(sr.headers.len(), 1);
-    }
-
-    #[test]
-    fn write_head_flat_array_applies_pairs_and_overrides() {
-        let mut sr = empty_response();
-        sr.headers.insert("foo".into(), "1".into());
-        apply_headers_flat_array(&mut sr, r#"["foo","3","X-New","z"]"#);
-        // even/odd offsets are name/value; `foo` overrides the prior value.
-        assert_eq!(sr.headers.get("foo").map(String::as_str), Some("3"));
-        assert_eq!(sr.headers.get("x-new").map(String::as_str), Some("z"));
-    }
-}
+#[path = "response_tests.rs"]
+mod tests;

--- a/crates/perry-ext-http-server/src/response_tests.rs
+++ b/crates/perry-ext-http-server/src/response_tests.rs
@@ -1,0 +1,136 @@
+//! Unit tests for `response.rs`. Split into a sibling file so `response.rs`
+//! stays under the repository's 2000-line-per-file lint cap; declared as a
+//! `#[path]` child module of `response` so `use super::*` resolves to it.
+
+use super::*;
+
+fn empty_response() -> ServerResponse {
+    let (tx, _rx) = oneshot::channel::<HyperResponseShape>();
+    ServerResponse::new(tx)
+}
+
+#[test]
+fn write_head_headers_json_merges_and_preserves_case() {
+    // #2132: a `writeHead(status, headers)` object is JSON-serialized and
+    // merged here; the lookup key is lowercase but the original case is
+    // retained for `getHeaderNames()`.
+    let mut sr = empty_response();
+    apply_headers_json(&mut sr, r#"{"Content-Type":"text/plain","X-Custom":"abc"}"#);
+    assert_eq!(
+        sr.headers.get("content-type").map(String::as_str),
+        Some("text/plain")
+    );
+    assert_eq!(sr.headers.get("x-custom").map(String::as_str), Some("abc"));
+    assert_eq!(
+        sr.raw_header_names.get("content-type").map(String::as_str),
+        Some("Content-Type")
+    );
+    assert_eq!(
+        sr.raw_header_names.get("x-custom").map(String::as_str),
+        Some("X-Custom")
+    );
+}
+
+#[test]
+fn write_head_headers_json_stringifies_non_string_values() {
+    let mut sr = empty_response();
+    apply_headers_json(&mut sr, r#"{"Content-Length":42,"X-Flag":true}"#);
+    assert_eq!(
+        sr.headers.get("content-length").map(String::as_str),
+        Some("42")
+    );
+    assert_eq!(sr.headers.get("x-flag").map(String::as_str), Some("true"));
+}
+
+#[test]
+fn write_head_headers_json_ignores_empty_and_sentinels() {
+    let mut sr = empty_response();
+    apply_headers_json(&mut sr, "");
+    apply_headers_json(&mut sr, "null");
+    apply_headers_json(&mut sr, "undefined");
+    assert!(sr.headers.is_empty());
+}
+
+// #4965 — `setHeaders` entries normalizer output.
+
+#[test]
+fn apply_headers_entries_lowercases_and_preserves_case() {
+    let mut sr = empty_response();
+    apply_headers_entries(&mut sr, r#"[["Foo","1"],["Bar","2"]]"#);
+    assert_eq!(sr.headers.get("foo").map(String::as_str), Some("1"));
+    assert_eq!(sr.headers.get("bar").map(String::as_str), Some("2"));
+    assert_eq!(
+        sr.raw_header_names.get("foo").map(String::as_str),
+        Some("Foo")
+    );
+}
+
+#[test]
+fn apply_headers_entries_set_cookie_array_keeps_per_element_list() {
+    let mut sr = empty_response();
+    apply_headers_entries(&mut sr, r#"[["set-cookie",["a=b","c=d"]]]"#);
+    assert_eq!(
+        sr.header_value_lists.get("set-cookie").map(Vec::as_slice),
+        Some(["a=b".to_string(), "c=d".to_string()].as_slice())
+    );
+    assert_eq!(
+        sr.headers.get("set-cookie").map(String::as_str),
+        Some("a=b, c=d")
+    );
+}
+
+#[test]
+fn apply_headers_entries_ignores_non_array_and_short_pairs() {
+    let mut sr = empty_response();
+    apply_headers_entries(&mut sr, r#"[{"foo":"1"},["only-name"],["k","v"]]"#);
+    assert_eq!(sr.headers.get("k").map(String::as_str), Some("v"));
+    assert_eq!(sr.headers.len(), 1);
+}
+
+#[test]
+fn write_head_flat_array_applies_pairs_and_overrides() {
+    let mut sr = empty_response();
+    sr.headers.insert("foo".into(), "1".into());
+    apply_headers_flat_array(&mut sr, r#"["foo","3","X-New","z"]"#);
+    // even/odd offsets are name/value; `foo` overrides the prior value.
+    assert_eq!(sr.headers.get("foo").map(String::as_str), Some("3"));
+    assert_eq!(sr.headers.get("x-new").map(String::as_str), Some("z"));
+}
+
+// `res.once(event, cb)` — one-shot listener semantics. Regression guard for
+// the static-file 64 KB truncation: `res.once('drain')` used to be dropped
+// entirely (no `once` dispatch arm), so `createReadStream().pipe(res)`
+// stalled after the first high-water-mark chunk.
+
+#[test]
+fn once_drain_listener_fires_exactly_once() {
+    let mut sr = empty_response();
+    sr.once_listeners.entry("drain".into()).or_default().push(7);
+    // First consumption returns the once listener...
+    assert_eq!(take_event_listeners(&mut sr, "drain"), vec![7]);
+    // ...and drains it, so a second drain edge sees nothing.
+    assert!(take_event_listeners(&mut sr, "drain").is_empty());
+}
+
+#[test]
+fn on_drain_listener_survives_repeated_edges() {
+    let mut sr = empty_response();
+    sr.listeners.entry("drain".into()).or_default().push(9);
+    // A persistent `on` listener fires on every drain edge.
+    assert_eq!(take_event_listeners(&mut sr, "drain"), vec![9]);
+    assert_eq!(take_event_listeners(&mut sr, "drain"), vec![9]);
+}
+
+#[test]
+fn on_and_once_combine_then_once_drops() {
+    let mut sr = empty_response();
+    sr.listeners.entry("finish".into()).or_default().push(1);
+    sr.once_listeners
+        .entry("finish".into())
+        .or_default()
+        .push(2);
+    // `on` listeners first, then `once` listeners.
+    assert_eq!(take_event_listeners(&mut sr, "finish"), vec![1, 2]);
+    // The `once` listener is gone; only the persistent one remains.
+    assert_eq!(take_event_listeners(&mut sr, "finish"), vec![1]);
+}

--- a/test-files/test_gap_http_res_socket_writable_onfinished.ts
+++ b/test-files/test_gap_http_res_socket_writable_onfinished.ts
@@ -1,0 +1,51 @@
+// Regression: an http `ServerResponse`'s `res.socket.writable` must be `true`
+// while the response is still open.
+//
+// Node's `res.socket` is the Duplex TCP socket, whose `writable` is `true`
+// during an active exchange. Perry aliases `res.socket` to the request handle
+// (there is no separate socket object), so a property read of
+// `res.socket.writable` resolves on the IncomingMessage. It used to be
+// `undefined`, which broke the `on-finished` package's readiness probe:
+//
+//     isFinished(res) = Boolean(res.finished || (socket && !socket.writable))
+//
+// With `socket.writable === undefined`, `!socket.writable` was `true`, so
+// `isFinished(res)` returned `true` the instant a stream was piped. The `send`
+// package (Next.js static file serving, via `serve-static`) treats that as
+// "response already finished" and destroys the piped read stream — truncating
+// every static file past the first 64 KB (high-water-mark) chunk.
+//
+// The observable here is the exact `isFinished(res)` computation `on-finished`
+// performs at pipe-setup time: it must be `false`. Also asserts the raw
+// `res.socket.writable` / `res.finished` inputs so a future regression is easy
+// to localize. Byte-for-byte identical to `node --experimental-strip-types`.
+
+import { createServer, get } from "node:http";
+
+const PORT = 18877;
+
+const server = createServer((_req: any, res: any) => {
+  const socket = res.socket;
+  const socketPresent = !!socket;
+  const socketWritable = socket ? socket.writable : "no-socket";
+  const resFinished = res.finished;
+  // The precise readiness check the `on-finished` package runs on a response.
+  const isFinished = Boolean(resFinished || (socket && !socket.writable));
+
+  console.log("socket_present=" + socketPresent);
+  console.log("socket_writable=" + socketWritable);
+  console.log("res_finished=" + resFinished);
+  console.log("isFinished_at_setup=" + isFinished);
+
+  res.end("ok");
+});
+
+server.listen(PORT, () => {
+  get({ host: "localhost", port: PORT, path: "/" }, (res: any) => {
+    res.on("data", () => {});
+    res.on("end", () => {
+      server.close();
+      console.log("done");
+    });
+  });
+});


### PR DESCRIPTION
Large static files served through `fs.createReadStream(path).pipe(res)` on an http `ServerResponse` were truncated at the first 64 KB (high-water-mark) chunk: the server sent a correct `Content-Length` header but only 65536 bytes of body, then hung the connection. In a Next.js standalone app this left every page whose `_next/static/chunks/*.js` exceed 64 KB stuck on its loading fallback, because the chunk `<script>` never finished downloading.

Two independent server-side bugs combine to cause it; both are fixed here.

### 1. `res.once(event, cb)` was silently dropped
The `ServerResponse` handle dispatcher had an `"on" | "addListener"` arm but no `"once"`, and `"once"` was absent from the ServerResponse method vocabulary, so the call fell through to a no-op. Perry's own pipe pump re-arms `res.once('drain')` after every backpressure pause, so the drain callback never fired and the pump stalled after the first chunk.

Fixed with real one-shot listener support: a `once_listeners` map alongside the persistent `listeners` map, `js_node_http_res_once`, and a `take_event_listeners` helper that fires `on` listeners (retained) then `once` listeners (removed, so each runs exactly once) at every event-consumption site (drain / finish / close), plus the `"once"` / `"prependOnceListener"` dispatch arm and vocabulary entries.

### 2. `res.socket.writable` was `undefined`
Node's `res.socket` is the Duplex TCP socket whose `writable` is `true` during an active exchange. Perry aliases `res.socket` to the request handle (there is no separate socket object), so a read of `res.socket.writable` resolves on the `IncomingMessage` and was `undefined`. That broke the `on-finished` package's readiness probe —

```js
isFinished(res) = Boolean(res.finished || (socket && !socket.writable))
```

— which returned `true` the instant a stream was piped. The `send` package (Next.js `serve-static`) treats that as "response already finished" and destroys the piped read stream one tick later, truncating the body.

Fixed by exposing `writable` on the `IncomingMessage` property dispatch, returning `true` while the connection is alive (`!destroyed && !aborted`). This is symmetric to the existing `readable` accessor, which was added for the request-body side of the same `on-finished` / socket-alias interaction (the comment directly above it).

### Coverage
- Unit tests for the one-shot listener semantics (fire-once, persistent-refire, on+once ordering) in `response.rs`.
- Gap test `test_gap_http_res_socket_writable_onfinished.ts` asserting `isFinished(res) === false` at pipe-setup, byte-identical to `node --experimental-strip-types`.
- Verified end-to-end against a Next.js 16 standalone app: 223 KB and 152 KB JS chunks now serve in full, byte-identical to Node, and pages hydrate past their loading fallback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for one-time HTTP response event listeners via `once` and `prependOnceListener`.
  * Added improved event listener lifecycle handling to ensure one-time listeners are removed after firing.
* **Bug Fixes**
  * Fixed `socket.writable` reporting during active streaming/completion to prevent `undefined`-style behavior.
  * Improved response event handling across finish, close, and drain/backpressure scenarios for more consistent runtime semantics.
* **Tests**
  * Added new HTTP response unit tests and an end-to-end regression script for writable/readiness behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->