### PR TITLE
fix(http): read POST request body — for-await-of req + new Request(body: nodeIM) (#6432)

### DIFF
--- a/crates/perry-ext-http-server/src/dispatch_ext.rs
+++ b/crates/perry-ext-http-server/src/dispatch_ext.rs
@@ -125,6 +125,7 @@ fn is_incoming_message_member(name: &str) -> bool {
             | "_addHeaderLine"
             | "__set_socket"
             | "__set_connection"
+            | "@@asyncIterator"
     ) || matches!(
         name,
         "method"

--- a/crates/perry-ext-http-server/src/handle_dispatch.rs
+++ b/crates/perry-ext-http-server/src/handle_dispatch.rs
@@ -117,6 +117,8 @@ extern "C" {
     fn js_node_http_im_remote_address(handle: i64) -> *mut StringHeader;
     fn js_node_http_im_remote_port(handle: i64) -> f64;
     fn js_node_http_im_raw_body(handle: i64) -> f64;
+    // #6432: perry-runtime helper — an async iterator that yields `value` once.
+    fn js_make_single_value_async_iterator(value: f64) -> f64;
     fn js_node_http_im_pause(handle: i64);
     fn js_node_http_im_resume(handle: i64);
     fn js_node_http_im_destroy(handle: i64);
@@ -548,6 +550,12 @@ pub unsafe extern "C" fn js_ext_http_incoming_message_dispatch_method(
             js_node_http_im_on(handle, event_ptr, closure_arg(Some(args[1])));
             self_ref
         }
+        // #6432: `for await (const chunk of req)` — reads the buffered request
+        // body. Perry delivers the whole body as one buffer (its `.on('data')`
+        // emits `body_bytes` in a single shot), so a one-shot async iterator over
+        // `req.rawBody` reproduces Node's observable result (same total bytes)
+        // for Next.js's `requestToBodyStream` / any `for await` body reader.
+        "@@asyncIterator" => js_make_single_value_async_iterator(js_node_http_im_raw_body(handle)),
         "setEncoding" if !args.is_empty() => {
             let encoding_ptr = string_value_arg(args[0]);
             if !encoding_ptr.is_null() {
@@ -1154,6 +1162,9 @@ fn incoming_method_bytes(name: &str) -> Option<&'static [u8]> {
         // #4904: internal-by-convention header-merge API, exercised
         // directly by Node's own tests on standalone IncomingMessages.
         "_addHeaderLine" => Some(b"_addHeaderLine"),
+        // #6432: `req[Symbol.asyncIterator]()` — makes `for await…of req` read
+        // the buffered request body (Next.js `requestToBodyStream`).
+        "@@asyncIterator" => Some(b"@@asyncIterator"),
         _ => None,
     }
 }

--- a/crates/perry-runtime/src/node_stream/async_iterator.rs
+++ b/crates/perry-runtime/src/node_stream/async_iterator.rs
@@ -24,6 +24,10 @@ const FOREIGN_READABLE_KEY: &[u8] = b"__perryForeignReadable";
 const READABLE_ITERATOR_DATA_CB_KEY: &[u8] = b"__perryReadableIteratorDataCb";
 const READABLE_ITERATOR_END_CB_KEY: &[u8] = b"__perryReadableIteratorEndCb";
 const READABLE_ITERATOR_ERROR_CB_KEY: &[u8] = b"__perryReadableIteratorErrorCb";
+// One-shot async iterator (`js_make_single_value_async_iterator`) — the value it
+// yields on its single pull.
+const SINGLE_VALUE_ITERATOR_SHAPE_ID: u32 = 0x7FFF_FF64;
+const SINGLE_VALUE_ITERATOR_VALUE_KEY: &[u8] = b"__perrySingleValueIteratorValue";
 
 fn iterator_result(value: f64, done: bool) -> f64 {
     let obj = crate::object::js_object_alloc(0, 2);
@@ -574,6 +578,59 @@ fn build_readable_async_iterator(stream: f64, destroy_on_return: bool) -> f64 {
     );
     install_async_iterator_symbol(iterator, ns_readable_iterator_self);
     iterator
+}
+
+/// Build an async iterator that yields `value` exactly once, then completes.
+/// If `value` is `undefined`/`null`, the iterator completes immediately (yields
+/// nothing).
+///
+/// Used for handle-backed readables whose entire payload is already buffered by
+/// the time they are iterated: perry's http `IncomingMessage` delivers the whole
+/// request body as a single buffer (its `.on('data')` emits `body_bytes` in one
+/// shot), so a one-shot iterator reproduces the observable `for await (const c of
+/// req)` result — the same total bytes — without wiring the handle into
+/// node:stream's event registry (which keys on a JS-object identity the handle
+/// does not have). Closes #6432: `for await…of req` used to throw
+/// `is not iterable` and yield nothing, so Next.js's `requestToBodyStream` read
+/// an empty POST body and Auth.js rejected every credentials login with
+/// `MissingCSRF`.
+#[no_mangle]
+pub extern "C" fn js_make_single_value_async_iterator(value: f64) -> f64 {
+    let methods = [
+        ("next", cast0(single_value_iterator_next)),
+        ("return", cast0(single_value_iterator_return)),
+    ];
+    let obj = build_object(
+        &methods,
+        SINGLE_VALUE_ITERATOR_SHAPE_ID + methods.len() as u32,
+    );
+    let iterator = box_pointer(obj as *const u8);
+    let v = crate::value::JSValue::from_bits(value.to_bits());
+    let empty = v.is_undefined() || v.is_null();
+    set_hidden_value(iterator, hidden_key(SINGLE_VALUE_ITERATOR_VALUE_KEY), value);
+    set_hidden_value(
+        iterator,
+        hidden_key(READABLE_ITERATOR_DONE_KEY),
+        f64::from_bits(if empty { TAG_TRUE } else { TAG_FALSE }),
+    );
+    install_async_iterator_symbol(iterator, ns_readable_iterator_self);
+    iterator
+}
+
+extern "C" fn single_value_iterator_next(closure: *const ClosureHeader) -> f64 {
+    let iterator = this_value(closure);
+    if iterator_is_done(iterator) {
+        return readable_iterator_done();
+    }
+    iterator_mark_done(iterator);
+    let value = get_hidden_value(iterator, hidden_key(SINGLE_VALUE_ITERATOR_VALUE_KEY))
+        .unwrap_or_else(|| f64::from_bits(TAG_UNDEFINED));
+    resolved_promise(iterator_result(value, false))
+}
+
+extern "C" fn single_value_iterator_return(closure: *const ClosureHeader) -> f64 {
+    iterator_mark_done(this_value(closure));
+    readable_iterator_done()
 }
 
 /// Install node:stream's async iterator on a readable that is *not* a node:stream

--- a/crates/perry-runtime/src/symbol/get.rs
+++ b/crates/perry-runtime/src/symbol/get.rs
@@ -420,6 +420,33 @@ pub unsafe extern "C" fn js_object_get_symbol_property(obj_f64: f64, sym_f64: f6
             }
         }
     }
+    // Generic small-handle `Symbol.asyncIterator` support — lets a handle-backed
+    // readable drive `for await (const chunk of x)`. Mirrors the
+    // `Symbol.asyncDispose` block above: resolve the bound `@@asyncIterator`
+    // method through the handle property dispatcher, so a subsystem that owns the
+    // method (perry's http `IncomingMessage`) can expose it without a
+    // runtime-specific special case. #6432 — `for await…of req` used to throw
+    // `is not iterable`, so Next.js read an empty POST body → Auth.js MissingCSRF.
+    if (bits >> 48) == 0x7FFD {
+        let id = (bits & 0x0000_FFFF_FFFF_FFFF) as i64;
+        if crate::value::addr_class::is_small_handle(id as usize) {
+            let async_iterator = well_known_symbol("asyncIterator");
+            if !async_iterator.is_null() {
+                let async_iterator_f64 = f64::from_bits(
+                    crate::value::JSValue::pointer(async_iterator as *const u8).bits(),
+                );
+                if sym_key_from_f64(sym_f64) == sym_key_from_f64(async_iterator_f64) {
+                    if let Some(dispatch) = crate::object::handle_property_dispatch() {
+                        let method = b"@@asyncIterator";
+                        let v = dispatch(id, method.as_ptr(), method.len());
+                        if v.to_bits() != TAG_UNDEFINED {
+                            return v;
+                        }
+                    }
+                }
+            }
+        }
+    }
     // Web Fetch and other stdlib handle-backed values are small ids
     // NaN-boxed as POINTER. A computed `handle[Symbol.iterator]` reaches the
     // symbol resolver directly, bypassing the normal string-key handle

--- a/crates/perry-stdlib/src/fetch/dispatch.rs
+++ b/crates/perry-stdlib/src/fetch/dispatch.rs
@@ -72,30 +72,15 @@ pub extern "C" fn js_response_body_init_ptr(value: f64) -> i64 {
         }
     }
     // #5437: a Node `IncomingMessage` body — the request-body bridge Next.js's
-    // `NextRequestAdapter.fromNodeNextRequest` relies on. It sets the web
-    // `Request` body to the `NodeNextRequest`'s `.body`, which is the underlying
-    // `IncomingMessage` (a native handle: `POINTER_TAG | small id`, not bytes).
-    // Stringifying it below yielded `"[object Object]"`, so `req.json()` /
-    // `req.text()` saw garbage and POST bodies were silently lost. Read the
-    // request's buffered bytes through the handle-property dispatch — the node
-    // http impl exposes them as a Buffer under `rawBody` (`js_node_http_im_raw_body`)
-    // — and materialize a lossless StringHeader from them. Only a small-handle
-    // POINTER value is probed, so string / heap-object / buffer bodies above are
-    // untouched. A handle without a buffered `rawBody` falls through to ToString.
+    // `NextRequestAdapter.fromNodeNextRequest` relies on (it sets the web
+    // `Request`/`Response` body to the underlying `IncomingMessage`).
     {
         let jsval = JSValue::from_bits(value.to_bits());
         if jsval.is_pointer() {
-            let raw = jsval.as_pointer::<u8>() as usize;
-            if raw != 0 && raw < 0x10000 {
-                let key = unsafe { js_string_from_bytes(b"rawBody".as_ptr(), 7) };
-                let raw_body = perry_runtime::object::js_object_get_field_by_name_f64(
-                    raw as *const perry_runtime::object::ObjectHeader,
-                    key,
-                );
-                if let Some(bytes) = unsafe { body_value_buffer_bytes(raw_body) } {
-                    return unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32) }
-                        as i64;
-                }
+            if let Some(bytes) =
+                unsafe { incoming_message_raw_body_bytes(jsval.as_pointer::<u8>() as usize) }
+            {
+                return unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32) } as i64;
             }
         }
     }
@@ -123,6 +108,34 @@ pub extern "C" fn js_response_body_init_ptr(value: f64) -> i64 {
         }
     }
     js_get_string_pointer_unified(value)
+}
+
+/// A Node `IncomingMessage` used as a fetch body: Next.js's
+/// `NextRequestAdapter.fromNodeNextRequest` hands the raw `req` to
+/// `new Request(url, { body: req })` (and the `Response` twin). It is a small
+/// native handle (`POINTER_TAG | small id`, `addr < 0x10000`), not bytes;
+/// stringifying it yields `"[object Object]"` and the POST body is silently
+/// lost. It exposes its buffered request body as a Buffer under `rawBody`
+/// (`js_node_http_im_raw_body`, surfaced through the handle-property dispatch),
+/// so read that. Returns `None` when `addr` is not a small handle or has no
+/// buffered `rawBody`, leaving string / buffer / heap-object bodies untouched.
+/// Shared by `js_response_body_init_ptr` (#5437) and the `Request` constructor
+/// (#6432 — the Request path never got this reader, so `new Request(url,
+/// { body: req })` dropped the body and Auth.js rejected logins with
+/// `MissingCSRF`).
+///
+/// # Safety
+/// FFI-adjacent: reads a runtime object field through a raw address.
+pub(crate) unsafe fn incoming_message_raw_body_bytes(addr: usize) -> Option<Vec<u8>> {
+    if !perry_runtime::value::addr_class::is_small_handle(addr) {
+        return None;
+    }
+    let key = js_string_from_bytes(b"rawBody".as_ptr(), 7);
+    let raw_body = perry_runtime::object::js_object_get_field_by_name_f64(
+        addr as *const perry_runtime::object::ObjectHeader,
+        key,
+    );
+    body_value_buffer_bytes(raw_body)
 }
 
 /// Read a body `*const StringHeader` losslessly as raw bytes (no UTF-8

--- a/crates/perry-stdlib/src/fetch/request_ctor.rs
+++ b/crates/perry-stdlib/src/fetch/request_ctor.rs
@@ -51,11 +51,25 @@ pub unsafe extern "C" fn js_request_new(
     // StringHeader/Buffer pointer, so it must be resolved via the blob registry
     // first: reading it through `body_bytes_from_header` would dereference the
     // synthetic id → SIGSEGV (#6231, the Request-constructor twin).
+    // #6432: a Node `IncomingMessage` body (Next.js's `fromNodeNextRequest` hands
+    // the raw `req` to `new Request(url, { body: req })`) is a small native handle
+    // (`body_ptr` in the handle band, e.g. `0x3`) exposing its buffered bytes under
+    // `rawBody`. It must be probed in BOTH the handle-band and the pointer arm —
+    // `is_handle_band` is true for it, so a plain `if handle_band { blob } else`
+    // routed it to the Blob reader (→ `None`) and dropped the body. The
+    // `incoming_message_raw_body_bytes` probe self-gates on `addr < 0x10000`, so a
+    // real Blob / buffer / string body is untouched. Mirrors the #5437 fix already
+    // in `js_response_body_init_ptr` (the Response twin), which falls through via
+    // `or_else` rather than if/else.
     let body: Option<Vec<u8>> =
         if perry_runtime::value::addr_class::is_handle_band(body_ptr as usize) {
             crate::fetch::blob_bytes_clone(body_ptr as usize)
+                .or_else(|| dispatch::incoming_message_raw_body_bytes(body_ptr as usize))
         } else {
             dispatch::body_addr_buffer_bytes(body_ptr as usize)
+                // Probe the IM before the StringHeader read below, which would
+                // misread the handle id as a string pointer.
+                .or_else(|| dispatch::incoming_message_raw_body_bytes(body_ptr as usize))
                 .or_else(|| dispatch::body_bytes_from_header(body_ptr))
         };
     // GET/HEAD requests may not carry a body (WHATWG fetch). Refs #2643.

--- a/test-files/test_gap_fetch_request_from_node_incoming_message.ts
+++ b/test-files/test_gap_fetch_request_from_node_incoming_message.ts
@@ -1,0 +1,51 @@
+// Regression: `new Request(url, { body: req })` where `req` is a Node
+// `http.IncomingMessage` must read the request's buffered body.
+//
+// Next.js's App Router bridges a Node request into the Web platform via
+// `NextRequestAdapter.fromNodeNextRequest`, which hands the raw `IncomingMessage`
+// straight to `new Request(url, { body: req, duplex: 'half' })` and then reads it
+// back with `request.text()` / `request.formData()`. Perry's Request constructor
+// only extracted bytes from Buffer / typed-array / Blob / string bodies, so a
+// Node `IncomingMessage` body (a small native handle) was dropped and the Web
+// Request came back empty — which made Auth.js reject every credentials login
+// with `MissingCSRF`. The Response constructor already had this reader (#5437);
+// the Request path never did. #6432.
+//
+// The observable is the body length read back through `request.text()`,
+// byte-for-byte identical to `node --experimental-strip-types`.
+
+import { createServer, request } from "node:http";
+
+const PORT = 18994;
+const BODY = "csrfToken=abc123&email=user@example.com&password=secret";
+
+const server = createServer(async (req: any, res: any) => {
+  let out = "";
+  try {
+    const webReq = new Request("http://x/", {
+      method: "POST",
+      body: req,
+      duplex: "half",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+    } as any);
+    const txt = await webReq.text();
+    out = `len=${txt.length} match=${txt === BODY}`;
+  } catch (e: any) {
+    out = `threw=${String((e && e.message) || e)}`;
+  }
+  res.statusCode = 200;
+  res.end(out);
+});
+
+server.listen(PORT, () => {
+  const r = request(
+    { host: "localhost", port: PORT, path: "/", method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded", "Content-Length": Buffer.byteLength(BODY) } },
+    (res: any) => {
+      let o = ""; res.setEncoding("utf8");
+      res.on("data", (c: string) => (o += c));
+      res.on("end", () => { console.log(o); console.log(`expected len=${Buffer.byteLength(BODY)}`); server.close(); });
+    }
+  );
+  r.write(BODY); r.end();
+});

--- a/test-files/test_gap_http_req_async_iterator.ts
+++ b/test-files/test_gap_http_req_async_iterator.ts
@@ -1,0 +1,59 @@
+// Regression: an http `IncomingMessage` (the request) must be async-iterable, so
+// `for await (const chunk of req)` reads the request body.
+//
+// Node's `http.IncomingMessage` is a Readable stream with `[Symbol.asyncIterator]`.
+// Perry represents the request as a native handle; it used to expose no async
+// iterator, so `for await…of req` threw `is not iterable` and yielded 0 bytes.
+// That broke every framework that reads the POST body via async iteration — e.g.
+// Next.js's `requestToBodyStream` does exactly `for await (const chunk of stream)`,
+// so an App Router POST (and Auth.js's CSRF check) saw an empty body. #6432.
+//
+// The observable here is the byte count read back through `for await…of req`,
+// byte-for-byte identical to `node --experimental-strip-types`.
+
+import { createServer, request } from "node:http";
+
+const PORT = 18992;
+const BODY = "csrfToken=abc123&email=user@example.com&password=secret&remember=1";
+
+const server = createServer(async (req: any, res: any) => {
+  let bytes = 0;
+  let threw = "";
+  try {
+    for await (const chunk of req) {
+      bytes += chunk.length;
+    }
+  } catch (e: any) {
+    threw = String((e && e.message) || e);
+  }
+  res.statusCode = 200;
+  res.setHeader("Content-Type", "text/plain");
+  res.end(`bytes=${bytes} threw=${threw}`);
+});
+
+server.listen(PORT, () => {
+  const req = request(
+    {
+      host: "localhost",
+      port: PORT,
+      path: "/",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Content-Length": Buffer.byteLength(BODY),
+      },
+    },
+    (res: any) => {
+      let out = "";
+      res.setEncoding("utf8");
+      res.on("data", (c: string) => (out += c));
+      res.on("end", () => {
+        console.log(out);
+        console.log(`expected bytes=${Buffer.byteLength(BODY)}`);
+        server.close();
+      });
+    }
+  );
+  req.write(BODY);
+  req.end();
+});


### PR DESCRIPTION
Closes #6432.

Two related gaps in reading a Node http request's body on the Web-platform side, both hit by frameworks that bridge a Node `IncomingMessage` into `fetch` primitives (Next.js's App Router, Auth.js).

### 1. `http.IncomingMessage` was not async-iterable (#6432)
`for await (const chunk of req)` threw `is not iterable` and yielded 0 bytes (Node yields the body). Perry represents the request as a native handle that never exposed `[Symbol.asyncIterator]`. Next.js's `requestToBodyStream` reads the body with exactly `for await (const chunk of stream)`, so any `for await` body reader saw nothing.

Fixed by:
- **`js_make_single_value_async_iterator`** (perry-runtime) — a one-shot async iterator. Perry buffers the whole request body before the handler runs (its `.on('data')` emits `body_bytes` in a single shot), so yielding `req.rawBody` once reproduces Node's observable `for await` result without wiring the handle into node:stream's event registry (which keys on a JS-object identity the handle lacks).
- A generic small-handle `Symbol.asyncIterator` resolver in `js_object_get_symbol_property` that delegates to the handle property dispatch — mirrors the existing `Symbol.dispose` / `Symbol.asyncDispose` handling — plus the `@@asyncIterator` method + vocabulary entries on the `IncomingMessage` dispatch.

### 2. `new Request(url, { body: req })` dropped a Node `IncomingMessage` body
The `Response` constructor already reads such a body via `rawBody` (#5437), but the `Request` constructor only handled Buffer / typed-array / Blob / string bodies. Factored the `IncomingMessage` reader out of `js_response_body_init_ptr` into a shared `incoming_message_raw_body_bytes` and used it in the `Request` constructor. It is probed in **both** the handle-band and pointer arms — the IM handle is in the handle band (`body_ptr` e.g. `0x3`), so a plain `if handle_band { blob } else` routed it to the Blob reader (→ `None`) and lost the body.

### Coverage
- `test_gap_http_req_async_iterator.ts` — `for await (const chunk of req)` byte count.
- `test_gap_fetch_request_from_node_incoming_message.ts` — `new Request(url, { body: req }).text()`.

Both byte-identical to `node --experimental-strip-types`, and verified end-to-end against a Next.js 16 standalone app (a raw-`IncomingMessage` request body now round-trips through `new Request(...).text()` / `.formData()`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `http.IncomingMessage` request objects now support `Symbol.asyncIterator`, enabling `for await...of` iteration.
  * The iterator returns the buffered request body once and then completes.
  * Incoming request bodies can be passed directly to the Web `Request` constructor and read correctly.

* **Bug Fixes**
  * Fixed missing/incorrect async-iteration support on incoming HTTP request objects.
  * Improved preservation and decoding of buffered `rawBody` content when constructing Web requests.

* **Tests**
  * Added regression coverage for async iteration and request-body preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->