### PR TITLE
fix(mysql2): RSA auth, percent-decoded credentials, f64 param ABI

### DIFF
--- a/crates/perry-codegen/src/lower_call/native_table/databases.rs
+++ b/crates/perry-codegen/src/lower_call/native_table/databases.rs
@@ -45,7 +45,7 @@ pub(super) const DATABASES_ROWS: &[NativeModSig] = &[
         method: "query",
         class_filter: Some("Pool"),
         runtime: "js_mysql2_pool_query",
-        args: &[NA_STR, NA_PTR],
+        args: &[NA_STR, NA_F64],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -54,7 +54,7 @@ pub(super) const DATABASES_ROWS: &[NativeModSig] = &[
         method: "execute",
         class_filter: Some("Pool"),
         runtime: "js_mysql2_pool_execute",
-        args: &[NA_STR, NA_PTR],
+        args: &[NA_STR, NA_F64],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -72,7 +72,7 @@ pub(super) const DATABASES_ROWS: &[NativeModSig] = &[
         method: "query",
         class_filter: Some("Pool"),
         runtime: "js_mysql2_pool_query",
-        args: &[NA_STR, NA_PTR],
+        args: &[NA_STR, NA_F64],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -81,7 +81,7 @@ pub(super) const DATABASES_ROWS: &[NativeModSig] = &[
         method: "execute",
         class_filter: Some("Pool"),
         runtime: "js_mysql2_pool_execute",
-        args: &[NA_STR, NA_PTR],
+        args: &[NA_STR, NA_F64],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -100,7 +100,7 @@ pub(super) const DATABASES_ROWS: &[NativeModSig] = &[
         method: "query",
         class_filter: Some("PoolConnection"),
         runtime: "js_mysql2_pool_connection_query",
-        args: &[NA_STR, NA_PTR],
+        args: &[NA_STR, NA_F64],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -109,7 +109,7 @@ pub(super) const DATABASES_ROWS: &[NativeModSig] = &[
         method: "execute",
         class_filter: Some("PoolConnection"),
         runtime: "js_mysql2_pool_connection_execute",
-        args: &[NA_STR, NA_PTR],
+        args: &[NA_STR, NA_F64],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -118,7 +118,7 @@ pub(super) const DATABASES_ROWS: &[NativeModSig] = &[
         method: "query",
         class_filter: Some("PoolConnection"),
         runtime: "js_mysql2_pool_connection_query",
-        args: &[NA_STR, NA_PTR],
+        args: &[NA_STR, NA_F64],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -127,7 +127,7 @@ pub(super) const DATABASES_ROWS: &[NativeModSig] = &[
         method: "execute",
         class_filter: Some("PoolConnection"),
         runtime: "js_mysql2_pool_connection_execute",
-        args: &[NA_STR, NA_PTR],
+        args: &[NA_STR, NA_F64],
         ret: NR_PTR,
     },
     // mysql2 generic instance methods (Connection fallback, class_filter: None)
@@ -137,7 +137,7 @@ pub(super) const DATABASES_ROWS: &[NativeModSig] = &[
         method: "query",
         class_filter: None,
         runtime: "js_mysql2_connection_query",
-        args: &[NA_STR, NA_PTR],
+        args: &[NA_STR, NA_F64],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -146,7 +146,7 @@ pub(super) const DATABASES_ROWS: &[NativeModSig] = &[
         method: "execute",
         class_filter: None,
         runtime: "js_mysql2_connection_execute",
-        args: &[NA_STR, NA_PTR],
+        args: &[NA_STR, NA_F64],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -209,7 +209,7 @@ pub(super) const DATABASES_ROWS: &[NativeModSig] = &[
         method: "query",
         class_filter: None,
         runtime: "js_mysql2_connection_query",
-        args: &[NA_STR, NA_PTR],
+        args: &[NA_STR, NA_F64],
         ret: NR_PTR,
     },
     NativeModSig {
@@ -218,7 +218,7 @@ pub(super) const DATABASES_ROWS: &[NativeModSig] = &[
         method: "execute",
         class_filter: None,
         runtime: "js_mysql2_connection_execute",
-        args: &[NA_STR, NA_PTR],
+        args: &[NA_STR, NA_F64],
         ret: NR_PTR,
     },
     NativeModSig {

--- a/crates/perry-ext-mysql2/Cargo.toml
+++ b/crates/perry-ext-mysql2/Cargo.toml
@@ -10,7 +10,12 @@ crate-type = ["staticlib", "rlib"]
 
 [dependencies]
 perry-ffi.workspace = true
-sqlx = { version = "0.9.0", default-features = false, features = ["runtime-tokio", "mysql", "chrono"] }
+# `mysql-rsa` enables the RSA public-key auth exchange MySQL 8's default
+# `caching_sha2_password` / `sha256_password` need over a NON-TLS connection.
+# Without it every query against such a server fails at connect with
+# "RSA auth backend disabled" — which broke `pool.execute`/`query` (e.g. an
+# Auth.js credentials `authorize` DB lookup, surfaced as a CallbackRouteError).
+sqlx = { version = "0.9.0", default-features = false, features = ["runtime-tokio", "mysql", "mysql-rsa", "chrono"] }
 tokio = { workspace = true }
 chrono = "0.4"
 

--- a/crates/perry-ext-mysql2/src/lib.rs
+++ b/crates/perry-ext-mysql2/src/lib.rs
@@ -87,6 +87,40 @@ unsafe fn jsvalue_to_string(value: JsValue) -> Option<String> {
     None
 }
 
+/// Percent-decode a URI component (`%25` → `%`, `%40` → `@`, …). A lone `%`
+/// not followed by two hex digits is kept verbatim. Node's `mysql2` decodes the
+/// credentials it takes out of a connection URL, so a password written as
+/// `p%25ss` (a literal `%`) authenticates as `p%ss`. Perry used the raw
+/// substring and then RE-encoded it for sqlx, double-encoding every reserved
+/// character — so a `%`/`@`/`:` in the password produced a wrong password and
+/// the server rejected the connection with `1045 Access denied`. Decode here so
+/// the round-trip through `to_url` reproduces the real credential.
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    let hex = |b: u8| -> Option<u8> {
+        match b {
+            b'0'..=b'9' => Some(b - b'0'),
+            b'a'..=b'f' => Some(b - b'a' + 10),
+            b'A'..=b'F' => Some(b - b'A' + 10),
+            _ => None,
+        }
+    };
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 3 <= bytes.len() {
+            if let (Some(h), Some(l)) = (hex(bytes[i + 1]), hex(bytes[i + 2])) {
+                out.push(h * 16 + l);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
 fn parse_mysql_uri(uri: &str) -> Option<MySqlConfig> {
     let uri = uri.strip_prefix("mysql://")?;
     let (credentials, host_part) = if let Some(idx) = uri.rfind('@') {
@@ -96,11 +130,11 @@ fn parse_mysql_uri(uri: &str) -> Option<MySqlConfig> {
     };
     let (user, password) = if let Some(idx) = credentials.find(':') {
         (
-            credentials[..idx].to_string(),
-            credentials[idx + 1..].to_string(),
+            percent_decode(&credentials[..idx]),
+            percent_decode(&credentials[idx + 1..]),
         )
     } else {
-        (credentials.to_string(), String::new())
+        (percent_decode(credentials), String::new())
     };
     let (host_port, database) = if let Some(idx) = host_part.find('/') {
         (&host_part[..idx], Some(host_part[idx + 1..].to_string()))
@@ -1166,6 +1200,28 @@ mod tests {
         assert_eq!(p.user, "root");
         assert_eq!(p.password, "secret");
         assert_eq!(p.database.as_deref(), Some("mydb"));
+    }
+
+    #[test]
+    fn percent_decode_credentials() {
+        // Reserved characters in a percent-encoded password round-trip to the
+        // literal value the server actually expects.
+        assert_eq!(percent_decode("p%40ss"), "p@ss");
+        assert_eq!(percent_decode("a%25b%2Fc%23"), "a%b/c#");
+        assert_eq!(percent_decode("plain"), "plain");
+        // A lone `%` (or one not followed by two hex digits) is kept verbatim.
+        assert_eq!(percent_decode("50%off"), "50%off");
+        assert_eq!(percent_decode("trailing%"), "trailing%");
+        assert_eq!(percent_decode("%zz"), "%zz");
+    }
+
+    #[test]
+    fn parse_uri_percent_encoded_password() {
+        // `@` inside the password is `%40`; the last `@` still splits creds/host.
+        let p = parse_mysql_uri("mysql://user:p%40ss%2Fword@db.example.com/mydb").unwrap();
+        assert_eq!(p.user, "user");
+        assert_eq!(p.password, "p@ss/word");
+        assert_eq!(p.host, "db.example.com");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three independent defects in `perry-ext-mysql2` broke `pool.query` / `pool.execute` against a real MySQL 8 server. Individually each one is enough to fail every query; together they surfaced as an Auth.js credentials `authorize` DB lookup dying with a `CallbackRouteError` on a live app.

### 1. RSA auth disabled (`Cargo.toml`)
MySQL 8 defaults to `caching_sha2_password`. Its full-auth handshake over a **non-TLS** connection requires an RSA public-key exchange, which sqlx gates behind the `mysql-rsa` feature. That feature was not enabled, so every connect failed with *"RSA auth backend disabled"*. `rsa` is already in `Cargo.lock` (pulled transitively), so turning the feature on adds **no new dependencies** and no lock change.

### 2. Double-encoded credentials (`src/lib.rs`)
Node's `mysql2` percent-**decodes** the user/password it extracts from a connection URL. Perry kept the raw substring and then re-encoded it for sqlx via `to_url`, **double-encoding** every reserved character. A `%`, `@`, or `:` in the password produced a wrong password and `1045 Access denied`. Added `percent_decode` and applied it to both credential fields in `parse_mysql_uri`.

### 3. f64 param ABI mismatch (`native_table/databases.rs`)
The `js_mysql2_*_query` / `_execute` runtime entry points take the params array as `params_f: f64` (NaN-boxed, passed in a **float** register on ARM64). The codegen native table declared that argument as `NA_PTR` — an i64 in an **integer** register. `params_f` then read uninitialized float-register bits (`~0x8000000000000000`), so every parameterized query saw garbage instead of the bound array. Changed the 12 mysql2 query/execute rows to `NA_F64` so the argument is passed in the register the callee actually reads.

## Testing
- New unit tests: `percent_decode_credentials`, `parse_uri_percent_encoded_password` (plus the existing 4 pass).
- Verified end-to-end against a live MySQL 8 server: all four of `pool.query`/`pool.execute` × parameterized/non-parameterized now succeed (previously the parameterized variants failed at param binding, and all four failed at connect before the RSA/credential fixes).

https://claude.ai/code/session_01NjymZygYh31wM9h3wLnUqv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MySQL 8 authentication support, including RSA-based authentication over non-TLS connections.
  * Fixed MySQL connection failures caused by percent-encoded usernames and passwords in connection URLs.
  * Preserved special characters such as `@` and `/` when parsing database credentials.
  * Improved compatibility for MySQL query and execute operations across supported connection types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->