### PR TITLE
fix(hir): cross-module Fastify factory — `app.listen()` compiles, resolves, and silently binds nothing

### DIFF
--- a/crates/perry-hir/src/js_transform/cross_module_natives.rs
+++ b/crates/perry-hir/src/js_transform/cross_module_natives.rs
@@ -315,7 +315,22 @@ pub fn scan_for_native_func_returns(
                 }
             }
         }
-        Stmt::While { body, .. } | Stmt::For { body, .. } => {
+        // `Labeled`/`DoWhile` are how async/generator lowering builds its state
+        // machine (`Try { Labeled { __step_done: DoWhile { switch on __gen_state } } }`),
+        // so without these arms the scan stops at the first `await` boundary and
+        // every native instance inside an async function stays untagged — while
+        // `fix_native_instance_stmt` below *does* walk both. Keep the two
+        // traversals in sync: a shape the fixer rewrites but the scan never
+        // reaches produces no diagnostic, just a silently untyped receiver.
+        Stmt::Labeled { body, .. } => {
+            scan_for_native_func_returns(
+                body,
+                func_return_instances,
+                local_native_instances,
+                local_id_native_instances,
+            );
+        }
+        Stmt::While { body, .. } | Stmt::For { body, .. } | Stmt::DoWhile { body, .. } => {
             for s in body {
                 scan_for_native_func_returns(
                     s,
@@ -605,6 +620,34 @@ pub fn scan_expr_for_closure_returns(
             local_native_instances,
             local_id_native_instances,
         ),
+        // `app = buildServer()` as an *assignment* rather than a `let` with an
+        // initializer. Async/generator lowering rewrites
+        //   const app = buildServer();  await app.listen(...)
+        // into a hoisted box plus `Expr(LocalSet(0, Call(buildServer)))` inside
+        // the step closure, so the `Stmt::Let { init: Some(call) }` arm above
+        // never sees it and `app` stays untagged — `app.listen(...)` then lowers
+        // to a generic property call, hits codegen's unknown-native-method arm,
+        // and silently no-ops. Tag by LocalId here (the name is gone by this
+        // point; LocalId is what `LocalGet`-based dispatch resolves against).
+        Expr::LocalSet(id, value) => {
+            let call_expr = match value.as_ref() {
+                Expr::Await(inner) => inner.as_ref(),
+                other => other,
+            };
+            if let Expr::Call { callee, .. } = call_expr {
+                if let Expr::ExternFuncRef { name, .. } = callee.as_ref() {
+                    if let Some((module, class)) = func_return_instances.get(name.as_str()) {
+                        local_id_native_instances.insert(*id, (module.clone(), class.clone()));
+                    }
+                }
+            }
+            scan_expr_for_closure_returns(
+                value,
+                func_return_instances,
+                local_native_instances,
+                local_id_native_instances,
+            );
+        }
         _ => {}
     }
 }

--- a/crates/perry-hir/src/lower/misc.rs
+++ b/crates/perry-hir/src/lower/misc.rs
@@ -95,6 +95,21 @@ pub(crate) fn native_instance_from_return_type(ty: &Type) -> Option<(&'static st
             "PoolConnection" => Some(("mysql2/promise", "PoolConnection")),
             "WebSocket" => Some(("ws", "WebSocket")),
             "WebSocketServer" => Some(("ws", "WebSocketServer")),
+            // Fastify: the same (module, class) pairs the *parameter* paths
+            // already register (`lower_decl/fn_decl.rs`, `lower/expr_function.rs`).
+            // Without these, the extremely common server-factory shape
+            //   // server.ts
+            //   export function buildServer(): FastifyInstance { return Fastify(); }
+            //   // main.ts
+            //   const app = buildServer();
+            //   await app.listen({ port });   // <- receiver not known to be native
+            // loses the native handle across the module boundary: `listen` falls
+            // back to `dynamic_boundary:runtime_api` and codegen's unknown-native-
+            // method arm SILENTLY returns 0.0, so the process starts, awaits a
+            // resolved promise, binds nothing, and exits 0 with no diagnostic.
+            "FastifyInstance" => Some(("fastify", "App")),
+            "FastifyRequest" => Some(("fastify", "Request")),
+            "FastifyReply" => Some(("fastify", "Reply")),
             _ => None,
         };
     }

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -1102,43 +1102,22 @@ pub(crate) fn lower_module_decl(
                                         other => other,
                                     };
                                     if let Type::Named(type_name) = check_type {
-                                        let module_info = match type_name.as_str() {
-                                            "Redis" => Some(("ioredis", "Redis")),
-                                            "EventEmitter" => Some(("events", "EventEmitter")),
-                                            "EventEmitterAsyncResource" => {
-                                                Some(("events", "EventEmitterAsyncResource"))
-                                            }
-                                            "Pool" => Some(("mysql2/promise", "Pool")),
-                                            "PoolConnection" => {
-                                                Some(("mysql2/promise", "PoolConnection"))
-                                            }
-                                            "WebSocket" | "WebSocketServer" => {
-                                                Some(("ws", type_name.as_str()))
-                                            }
-                                            // perry-stdlib net.Socket: lets library wrappers like
-                                            //   export function openSocket(host, port): Socket { ... }
-                                            // propagate native-instance tagging to callers, so
-                                            //   const sock = openSocket(...);
-                                            //   sock.on(...);   // dispatches to js_net_socket_on
-                                            // works without ceremony.
-                                            "Socket" => Some(("net", "Socket")),
-                                            _ => {
-                                                // Also check dotted names (e.g., mysql.Pool)
-                                                if let Some(dot_pos) = type_name.find('.') {
-                                                    let module_alias = &type_name[..dot_pos];
-                                                    let class_name = &type_name[dot_pos + 1..];
-                                                    if let Some((module_name, _)) =
-                                                        ctx.lookup_native_module(module_alias)
-                                                    {
-                                                        Some((module_name, class_name))
-                                                    } else {
-                                                        None
-                                                    }
-                                                } else {
-                                                    None
-                                                }
-                                            }
-                                        };
+                                        // Bare names (Redis, Socket, FastifyInstance, …) come from
+                                        // the shared table in `misc.rs` — keeping a second copy here
+                                        // is what let the Fastify types reach the parameter paths
+                                        // but never the return paths (silent no-op `listen`).
+                                        let module_info = native_instance_from_return_type(
+                                            &return_type,
+                                        )
+                                        .or_else(|| {
+                                            // Also check dotted names (e.g., mysql.Pool)
+                                            let dot_pos = type_name.find('.')?;
+                                            let module_alias = &type_name[..dot_pos];
+                                            let class_name = &type_name[dot_pos + 1..];
+                                            let (module_name, _) =
+                                                ctx.lookup_native_module(module_alias)?;
+                                            Some((module_name, class_name))
+                                        });
                                         if let Some((module, class)) = module_info {
                                             ctx.push_func_return_native_instance((
                                                 name.clone(),

--- a/crates/perry-hir/src/lower_decl/fn_decl.rs
+++ b/crates/perry-hir/src/lower_decl/fn_decl.rs
@@ -3,7 +3,7 @@ use perry_types::{LocalId, Type};
 use swc_ecma_ast as ast;
 
 use crate::ir::*;
-use crate::lower::{capture_function_source, LoweringContext};
+use crate::lower::{capture_function_source, native_instance_from_return_type, LoweringContext};
 use crate::lower_patterns::*;
 use crate::lower_types::*;
 
@@ -276,17 +276,14 @@ pub fn lower_fn_decl(ctx: &mut LoweringContext, fn_decl: &ast::FnDecl) -> Result
                 ));
             }
         } else {
-            // Bare type name check (e.g., `Redis` instead of `ioredis.Redis`)
-            let module_info = match type_name.as_str() {
-                "Redis" => Some(("ioredis", "Redis")),
-                "EventEmitter" => Some(("events", "EventEmitter")),
-                "EventEmitterAsyncResource" => Some(("events", "EventEmitterAsyncResource")),
-                "Pool" => Some(("mysql2/promise", "Pool")),
-                "PoolConnection" => Some(("mysql2/promise", "PoolConnection")),
-                "WebSocket" | "WebSocketServer" => Some(("ws", type_name.as_str())),
-                _ => None,
-            };
-            if let Some((module, class)) = module_info {
+            // Bare type name check (e.g., `Redis` instead of `ioredis.Redis`).
+            // Delegates to the shared table in `lower/misc.rs` rather than a
+            // local copy: this list had drifted behind the parameter paths and
+            // the local-`const`/factory paths (which already knew Socket and the
+            // Fastify types), so an exported `function buildServer():
+            // FastifyInstance` was never recorded as returning a native
+            // instance. Keep new native return types in that one table.
+            if let Some((module, class)) = native_instance_from_return_type(&return_type) {
                 ctx.push_func_return_native_instance((
                     name.clone(),
                     module.to_string(),

--- a/tests/test_cross_module_fastify_factory.sh
+++ b/tests/test_cross_module_fastify_factory.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Regression: a Fastify instance returned by a factory in ANOTHER module lost
+# its native-handle tag, so `app.listen(...)` silently bound nothing.
+#
+# Bug history:
+#   The idiomatic server layout
+#       // server.ts
+#       export function buildServer(): FastifyInstance { return Fastify(); }
+#       // main.ts
+#       async function main() {
+#         const app = buildServer();
+#         await app.listen({ port });   // <- resolved, but never bound
+#       }
+#   compiled and ran with exit code 0, printed nothing, and served nothing.
+#   `listen` lowered to `dynamic_boundary:runtime_api` and hit codegen's
+#   unknown-native-method arm, which returns 0.0 — so the await resolved on a
+#   no-op and the process exited as if the server had started. No diagnostic
+#   at any stage; `perry check` and `--type-check` were both clean.
+#
+#   Two independent gaps had to line up to produce it:
+#     1. `lower_decl/fn_decl.rs` matched the return-type annotation against a
+#        hand-rolled allowlist that had drifted behind the parameter paths and
+#        the shared `native_instance_from_return_type` table — it knew Redis,
+#        Pool and WebSocket but not the Fastify types, so `buildServer` was
+#        never recorded in `exported_func_return_native_instances`.
+#     2. `js_transform/cross_module_natives.rs` only recognised the consumer
+#        shape `Stmt::Let { init: Some(Call) }`, and never traversed
+#        `Labeled`/`DoWhile`. Async lowering turns `const app = buildServer()`
+#        inside `async function main()` into a hoisted box plus
+#        `Expr(LocalSet(0, Call(buildServer)))` nested in the generator state
+#        machine (`Try > Labeled > DoWhile > If`), so the scan both failed to
+#        reach the statement and failed to match its shape — even though
+#        `fix_native_instance_stmt` already walked both statement kinds.
+#
+#   Fix (1) routes fn_decl through the shared table (+ Fastify entries);
+#   fix (2) adds the Labeled/DoWhile arms and a LocalSet-from-call arm.
+#
+# Because gap 2 is about the *async* shape, this test MUST keep `await
+# app.listen(...)` inside an async function — a non-async main passes even with
+# the bug present.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PERRY="$SCRIPT_DIR/../target/release/perry"
+[ ! -f "$PERRY" ] && PERRY="$SCRIPT_DIR/../target/debug/perry"
+if [ ! -f "$PERRY" ]; then
+  echo "SKIP: perry binary not found (build with cargo build --release)"
+  exit 0
+fi
+if ! command -v curl >/dev/null 2>&1; then
+  echo "SKIP: curl not available"
+  exit 0
+fi
+
+PORT=18094
+TMPDIR=$(mktemp -d)
+cleanup() {
+  [ -n "${APP_PID:-}" ] && kill -9 "$APP_PID" 2>/dev/null
+  rm -rf "$TMPDIR"
+}
+trap cleanup EXIT
+
+cat > "$TMPDIR/server.ts" << 'EOF'
+import Fastify, { type FastifyInstance } from 'fastify';
+
+export function buildServer(): FastifyInstance {
+  const app = Fastify({ logger: false });
+  app.get('/health', async () => ({ ok: true }));
+  return app;
+}
+EOF
+
+cat > "$TMPDIR/main.ts" << EOF
+import { buildServer } from './server';
+
+async function main() {
+  const app = buildServer();
+  await app.listen({ port: $PORT });
+  console.log('listen-resolved');
+}
+main().catch((e) => { console.error(e); process.exit(1); });
+EOF
+
+cd "$TMPDIR"
+if ! "$PERRY" compile main.ts --output test_bin >compile.log 2>&1; then
+  echo "FAIL: compile error"
+  cat compile.log
+  exit 1
+fi
+
+./test_bin >run.log 2>&1 &
+APP_PID=$!
+
+RUN_OUTPUT=""
+for _ in $(seq 1 40); do
+  sleep 0.25
+  if RUN_OUTPUT=$(curl -sf -m 2 "http://127.0.0.1:$PORT/health" 2>/dev/null); then
+    break
+  fi
+done
+
+if [ "$RUN_OUTPUT" = '{"ok":true}' ]; then
+  echo "PASS"
+  exit 0
+fi
+
+echo "FAIL: cross-module factory server did not serve on port $PORT"
+if kill -0 "$APP_PID" 2>/dev/null; then
+  echo "  (process alive — bound to a different address, or route missing)"
+else
+  echo "  (process exited — listen() no-opped, the original bug)"
+fi
+echo "Expected: {\"ok\":true}"
+echo "Got: ${RUN_OUTPUT:-<no response>}"
+echo "--- program output ---"
+cat run.log
+exit 1


### PR DESCRIPTION
## The bug

This idiomatic server layout compiles clean, runs, exits 0 — and serves nothing:

```ts
// server.ts
import Fastify, { type FastifyInstance } from 'fastify';
export function buildServer(): FastifyInstance {
  const app = Fastify({ logger: false });
  app.get('/health', async () => ({ ok: true }));
  return app;
}

// main.ts
import { buildServer } from './server';
async function main() {
  const app = buildServer();
  await app.listen({ port: 8094 });   // resolves; nothing is listening
  console.log('listen() resolved');   // prints
}
main().catch((e) => { console.error(e); process.exit(1); });
```

`listen` lowers to `dynamic_boundary:runtime_api`, hits codegen's unknown-native-method arm, and **returns 0.0**. The `await` resolves on a no-op, so the process looks like a server that started and simply finished. There is no diagnostic at any stage — `perry check` and `--type-check` are both clean, and the same code inside a single module works — which makes it expensive to localize. Reproduced on `main` @ 889f39eda (0.5.1258).

## Root cause — two gaps that had to line up

**1. The return-type → native-module detection had drifted.** `lower_decl/fn_decl.rs` matched the return annotation against its own hand-rolled allowlist. There were **five** copies of that "bare type name → (module, class)" mapping in `perry-hir`, and the Fastify types had been added to the *parameter* copies (`fn_decl.rs`, `expr_function.rs`) but never to the *return* copies — so `buildServer` was never recorded in `exported_func_return_native_instances` and the cross-module machinery (which already exists and works) had nothing to act on.

This PR routes `fn_decl.rs` and the exported-arrow path in `module_decl.rs` through the shared `lower/misc.rs::native_instance_from_return_type` table (already the source of truth for four other call sites) and adds the Fastify entries there — one list to teach instead of five. Both call sites keep their dotted-name (`mysql.Pool`) branch. This is a strict superset of what each local copy matched, so no previously-detected type stops being detected.

**2. The cross-module scan didn't understand async lowering.** `js_transform/cross_module_natives.rs::scan_for_native_func_returns` only recognised the consumer shape `Stmt::Let { init: Some(Call) }`, and never traversed `Labeled` / `DoWhile`. Async lowering rewrites

```
const app = buildServer();   →   Expr(LocalSet(0, Call(ExternFuncRef("buildServer"))))
```

hoisting `app` into a prealloc'd box and burying the assignment inside the generator state machine (`Try > Labeled > DoWhile > If`). So the scan both failed to *reach* the statement and failed to *match* its shape.

Notably `fix_native_instance_stmt` — the rewriter in the same file — already walks `Labeled` and `DoWhile`. Only the scan lagged, and that asymmetry is precisely why **only async consumers** were affected: a non-async `main` keeps the `Let{init:Call}` shape and works today.

This PR adds the `Labeled`/`DoWhile` arms to the scan and a `LocalSet`-from-call arm (tagging by `LocalId`, which is what `LocalGet`-based dispatch resolves against).

## Test

`tests/test_cross_module_fastify_factory.sh` compiles the two-module factory, runs the binary, and curls the port:

- pre-fix: `FAIL … (process exited — listen() no-opped, the original bug)`
- post-fix: `PASS`

It deliberately keeps `await app.listen(...)` inside an `async function` — a non-async main passes even with the bug present, so an async-free test would not catch it.

I used a `.sh` test rather than a `test-files/*.ts` case because the assertion is "a socket is actually bound and serving", which the byte-for-byte parity harness can't express; this follows the existing `tests/test_cross_module_getter.sh` precedent for cross-module compiler behavior. Happy to add a `test-files/` case too if you'd prefer.

## Verification

- Repro binds and serves; `{"ok":true}` over HTTP.
- `cargo test --release -p perry-hir -p perry-codegen -p perry-types` → **889 passed, 0 failed** (×3 runs).
- `tests/test_cross_module_getter.sh`, `test_chained_cross_module_getter.sh`, `test_namespace_const_cross_module.sh` still pass.
- `cargo fmt --check` clean; no new clippy warnings.
- Also validated against a real ~17 MB fastify + mysql + drizzle service (the reason I found this): full e2e suite green on the native binary, where it previously never bound.

Note for anyone reproducing the test runs: `perry-codegen`'s `native_proof_regressions` suite shares `ARTIFACT_ENV_LOCK` around env-var mutation, so running two `cargo test` invocations concurrently poisons the mutex and cascades into dozens of `PoisonError` failures with varying counts. Serialized or run alone, it's green.

## Wider point (not fixed here)

The reason this cost days rather than minutes is codegen's unresolved-native-method arm returning `0.0` silently. Any native receiver the compiler fails to tag degrades to "the call did nothing, successfully". A warning (or an opt-in hard error) when a known native module's method falls back to `dynamic_boundary:runtime_api` would turn this whole class into a compile-time message. Related in spirit to #4919 (stub elimination — "every registered API is real or fails loud"). Happy to open a separate issue/PR for that if it's wanted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for Fastify applications, including Fastify server, request, and reply types.
  * Enhanced native type recognition for typed function and arrow-function exports, including dotted module type names.
  * Improved reliability for native values returned across asynchronous and generator-based workflows.

* **Bug Fixes**
  * Fixed cases where native instances could be lost when crossing module boundaries after asynchronous operations.

* **Tests**
  * Added coverage for compiling and running a two-module Fastify application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->