### PR TITLE
fix(mysql2): route bundled mysql2 createPool/createConnection to native ext

### DIFF
--- a/crates/perry-codegen/src/ext_registry.rs
+++ b/crates/perry-codegen/src/ext_registry.rs
@@ -505,6 +505,34 @@ const FFI_REGISTRY: &[(&str, OwnerKind)] = &[
     ("js_event_emitter_set_max_listeners",          OwnerKind::WellKnown("events")),
     ("js_event_emitter_get_max_listeners",          OwnerKind::WellKnown("events")),
     ("js_event_emitter_domain_value",               OwnerKind::WellKnown("events")),
+
+    // ── mysql2 (perry-ext-mysql2) ────────────────────────────────────
+    // Normally `import "mysql2"` flips the `[bindings.mysql2]` well-known
+    // and links perry-ext-mysql2. But a bundler (webpack/turbopack) inlines
+    // mysql2 under a NUMERIC module id, so there is no bare import for perry
+    // to see — and JS mysql2 JIT-compiles its row parsers with `new Function`
+    // (via `generate-function`), which an AOT binary cannot execute. The HIR
+    // pass in `perry-hir`'s native-module lowering recognizes a bundled
+    // `createPool`/`createConnection` by its mysql2 config-object signature
+    // and emits these FFIs directly, WITHOUT adding "mysql2" to the import
+    // set. Tag them here so the well-known flip fires off codegen provenance
+    // — same mechanism as the http/net/events rows above — and the staticlib
+    // joins the link line instead of leaving `_js_mysql2_*` undefined.
+    ("js_mysql2_create_pool",                       OwnerKind::WellKnown("mysql2")),
+    ("js_mysql2_create_connection",                 OwnerKind::WellKnown("mysql2")),
+    ("js_mysql2_pool_query",                        OwnerKind::WellKnown("mysql2")),
+    ("js_mysql2_pool_execute",                      OwnerKind::WellKnown("mysql2")),
+    ("js_mysql2_pool_get_connection",               OwnerKind::WellKnown("mysql2")),
+    ("js_mysql2_pool_end",                          OwnerKind::WellKnown("mysql2")),
+    ("js_mysql2_pool_connection_query",             OwnerKind::WellKnown("mysql2")),
+    ("js_mysql2_pool_connection_execute",           OwnerKind::WellKnown("mysql2")),
+    ("js_mysql2_pool_connection_release",           OwnerKind::WellKnown("mysql2")),
+    ("js_mysql2_connection_query",                  OwnerKind::WellKnown("mysql2")),
+    ("js_mysql2_connection_execute",                OwnerKind::WellKnown("mysql2")),
+    ("js_mysql2_connection_begin_transaction",      OwnerKind::WellKnown("mysql2")),
+    ("js_mysql2_connection_commit",                 OwnerKind::WellKnown("mysql2")),
+    ("js_mysql2_connection_rollback",               OwnerKind::WellKnown("mysql2")),
+    ("js_mysql2_connection_end",                    OwnerKind::WellKnown("mysql2")),
 ];
 
 /// Process-wide collector of provider keys observed during codegen.

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -160,6 +160,7 @@ impl LoweringContext {
             current_class_super_ident: None,
             mixin_funcs: HashMap::new(),
             anon_shape_classes: HashMap::new(),
+            anon_shape_fields: HashMap::new(),
             forward_class_names: std::collections::HashSet::new(),
             forward_class_decl_depth: std::collections::HashMap::new(),
             class_renames: std::collections::HashMap::new(),
@@ -946,7 +947,14 @@ impl LoweringContext {
             shape_key.push(',');
         }
 
+        // Field names in source order, so a call-site can recover a config
+        // object's keys after the literal is lowered to `New { class_name }`.
+        let field_names: Vec<String> = field_shapes.iter().map(|(name, _)| name.clone()).collect();
+
         if let Some(existing) = self.anon_shape_classes.get(&shape_key) {
+            self.anon_shape_fields
+                .entry(existing.clone())
+                .or_insert(field_names);
             return existing.clone();
         }
 
@@ -1065,6 +1073,8 @@ impl LoweringContext {
 
         self.anon_shape_classes
             .insert(shape_key, class_name.clone());
+        self.anon_shape_fields
+            .insert(class_name.clone(), field_names);
         class_name
     }
 

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -153,6 +153,72 @@ fn lower_os_module_method_call(
     }
 }
 
+/// Recognize a bundled-mysql2 `createPool` / `createConnection` call by the
+/// shape of its config object, so it can be routed to perry-ext-mysql2 even
+/// when a bundler inlined mysql2 under a numeric module id (the import-keyed
+/// native lowering can't see through that — see the call site).
+///
+/// The signature is deliberately tight so it cannot hijack an unrelated
+/// `createPool`/`createConnection`: the sole config argument must be an object
+/// LITERAL that carries BOTH a mysql connection key (`uri`/`host`/`socketPath`)
+/// AND at least one mysql2-specific driver/pool option (`connectionLimit`,
+/// `waitForConnections`, `queueLimit`, `namedPlaceholders`, …). generic-pool's
+/// `createPool(factory, opts)` passes a factory object with `create`/`destroy`
+/// (no connection key); pg uses `new Pool()`, not `.createPool({...})`. The
+/// older `mysql` package shares mysql2's exact API and wire protocol, so
+/// routing it to perry-ext-mysql2 is correct too. A non-literal config
+/// (variable / spread) returns `None` and falls through to normal lowering.
+///
+/// Returns the canonical method name (`"createPool"` / `"createConnection"`).
+///
+/// Pure signature check over a config object's field names.
+fn mysql2_config_signature(method_name: &str, keys: &[&str]) -> Option<&'static str> {
+    let canonical = match method_name {
+        "createPool" => "createPool",
+        "createConnection" => "createConnection",
+        _ => return None,
+    };
+    let mut has_conn_key = false;
+    let mut has_mysql2_opt = false;
+    for key in keys {
+        match *key {
+            "uri" | "host" | "socketPath" => has_conn_key = true,
+            "connectionLimit" | "waitForConnections" | "queueLimit" | "maxIdle" | "idleTimeout"
+            | "namedPlaceholders" | "rowsAsArray" | "enableKeepAlive" | "multipleStatements"
+            | "typeCast" => has_mysql2_opt = true,
+            _ => {}
+        }
+    }
+    if has_conn_key && has_mysql2_opt {
+        Some(canonical)
+    } else {
+        None
+    }
+}
+
+/// Recover the config object's keys and run the mysql2 signature check. A closed
+/// object literal is lowered to `New { class_name: "__AnonShape_*" }` with the
+/// keys stripped into the shape class, so recover them from the lowering
+/// context's `anon_shape_fields` map; a literal that stayed `Expr::Object`
+/// (small / open shape) is inspected directly.
+fn detect_bundled_mysql2_create(
+    ctx: &LoweringContext,
+    method_name: &str,
+    args: &[Expr],
+) -> Option<&'static str> {
+    let keys: Vec<&str> = match args.first()? {
+        Expr::Object(pairs) => pairs.iter().map(|(k, _)| k.as_str()).collect(),
+        Expr::New { class_name, .. } => ctx
+            .anon_shape_fields
+            .get(class_name)?
+            .iter()
+            .map(|s| s.as_str())
+            .collect(),
+        _ => return None,
+    };
+    mysql2_config_signature(method_name, &keys)
+}
+
 pub(super) fn try_native_module_methods(
     ctx: &mut LoweringContext,
     call: &ast::CallExpr,
@@ -161,6 +227,36 @@ pub(super) fn try_native_module_methods(
 ) -> Result<Result<Expr, Vec<Expr>>> {
     // Check for native module method calls (e.g., mysql.createConnection())
     if let ast::Expr::Member(member) = expr {
+        // Bundled mysql2 (webpack/turbopack): when a bundler inlines mysql2
+        // under a numeric module id, the `createPool(...)` receiver is an
+        // opaque `E.i(87205).default`, not a tracked native import — so the
+        // identifier-keyed lowering below never fires and the call runs the
+        // inlined JS mysql2, which JIT-compiles its row parsers with
+        // `new Function` (via `generate-function`). An AOT binary cannot
+        // execute a function built from a runtime string, so every query
+        // throws. Recognize the call by its mysql2 config-object SIGNATURE
+        // (tight enough to be mysql/mysql2-exclusive) and route it to
+        // perry-ext-mysql2 regardless of how mysql2 was imported/bundled.
+        // The receiver is intentionally dropped: we don't want the JS module
+        // loaded at all. Downstream typing (`detect_native_instance_creation`)
+        // sees `NativeMethodCall{module:"mysql2/promise", method:"createPool"}`
+        // and tags the result `Pool`, so `pool.execute`/`pool.query` dispatch
+        // natively too; the emitted `js_mysql2_*` FFIs flip the "mysql2"
+        // well-known (see perry-codegen `ext_registry`) to link the staticlib.
+        if let ast::MemberProp::Ident(method_ident) = &member.prop {
+            if let Some(canonical) =
+                detect_bundled_mysql2_create(ctx, method_ident.sym.as_ref(), &args)
+            {
+                return Ok(Ok(Expr::NativeMethodCall {
+                    module: "mysql2/promise".to_string(),
+                    class_name: None,
+                    object: None,
+                    method: canonical.to_string(),
+                    args,
+                }));
+            }
+        }
+
         // Inline `require("node:os").platform()` reaches this outer member
         // call before the inner bare `require(...)` lowering can produce a
         // NativeModuleRef. Recognize the same literal-native namespace shape
@@ -1757,4 +1853,73 @@ pub(super) fn try_native_module_methods(
     }
 
     Ok(Err(args))
+}
+
+#[cfg(test)]
+mod bundled_mysql2_tests {
+    use super::mysql2_config_signature;
+
+    #[test]
+    fn matches_pool_with_uri_and_pool_option() {
+        // gscmaster's exact config: uri + mysql2 pool options.
+        let keys = [
+            "uri",
+            "waitForConnections",
+            "connectionLimit",
+            "maxIdle",
+            "idleTimeout",
+            "queueLimit",
+        ];
+        assert_eq!(
+            mysql2_config_signature("createPool", &keys),
+            Some("createPool")
+        );
+    }
+
+    #[test]
+    fn matches_host_credentials_with_pool_option() {
+        let keys = ["host", "user", "password", "database", "connectionLimit"];
+        assert_eq!(
+            mysql2_config_signature("createPool", &keys),
+            Some("createPool")
+        );
+    }
+
+    #[test]
+    fn matches_create_connection_with_mysql2_option() {
+        let keys = ["host", "user", "password", "namedPlaceholders"];
+        assert_eq!(
+            mysql2_config_signature("createConnection", &keys),
+            Some("createConnection")
+        );
+    }
+
+    #[test]
+    fn rejects_without_connection_key() {
+        // Pool options but no connection key — not enough to be sure it's mysql2.
+        let keys = ["connectionLimit", "waitForConnections"];
+        assert_eq!(mysql2_config_signature("createPool", &keys), None);
+    }
+
+    #[test]
+    fn rejects_without_mysql2_option() {
+        // A bare connection config could be any driver; require a mysql2 option.
+        let keys = ["host", "user", "password", "database"];
+        assert_eq!(mysql2_config_signature("createPool", &keys), None);
+    }
+
+    #[test]
+    fn rejects_generic_pool_factory() {
+        // generic-pool's `createPool(factory, opts)` — first arg is a factory
+        // object with create/destroy, no connection or mysql2 keys.
+        let keys = ["create", "destroy", "validate"];
+        assert_eq!(mysql2_config_signature("createPool", &keys), None);
+    }
+
+    #[test]
+    fn rejects_unrelated_method() {
+        let keys = ["uri", "connectionLimit"];
+        assert_eq!(mysql2_config_signature("connect", &keys), None);
+        assert_eq!(mysql2_config_signature("createServer", &keys), None);
+    }
 }

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -705,6 +705,13 @@ pub struct LoweringContext {
     /// field layout. Dedup is per-module only; cross-module dedup would need
     /// a stable hash and is deferred.
     pub(crate) anon_shape_classes: HashMap<String, String>,
+    /// Reverse of `anon_shape_classes`: synthetic `__AnonShape_*` class name ->
+    /// its field names in source-declared order. A closed-shape object literal
+    /// lowers to `New { class_name, args }` with the KEYS stripped into the
+    /// shape class, so a call-site that needs to inspect a config object's keys
+    /// (e.g. recognizing a bundled mysql2 `createPool(config)` by its option
+    /// names) recovers them here.
+    pub(crate) anon_shape_fields: HashMap<String, Vec<String>>,
     /// Class DECLARATION names at the top level of the function body
     /// currently being lowered. JS resolves a method-body reference to a
     /// sibling class declared LATER in the same function at call time


### PR DESCRIPTION
## Summary

A Next.js / webpack / turbopack production build **inlines `mysql2` into the server bundle** under a numeric module id (`E.i(87205).default.createPool(...)`), so Perry never sees a bare `import "mysql2"` and the import-keyed native-extension redirect (`perry-ext-mysql2`) never fires. The inlined **JS** mysql2 then runs, and its row-parser JIT — `generate-function` → `Function.apply(null, [...params, bodyString])` — builds a function from a **runtime string**, which an ahead-of-time-compiled binary cannot execute. Every query throws.

On a real app (gscmaster: Auth.js v5 credentials login) this surfaced as a `CallbackRouteError`; the underlying error is a misleading `Function.prototype.apply was called on a value that is not a function` (perry's `Function` constructor class-ref isn't callable via `.apply`, and even if it were, the dynamic body is unsupported AOT).

This routes the bundled call to the native extension by recognizing it at HIR lowering, so no source or bundler config change is needed.

## How

**`perry-hir` — `expr_call/native_module.rs`:** a `createPool`/`createConnection` whose sole config argument is an object carrying **both** a mysql connection key (`uri`/`host`/`socketPath`) **and** a mysql2-specific driver/pool option (`connectionLimit`, `waitForConnections`, `queueLimit`, `namedPlaceholders`, `rowsAsArray`, …) lowers to `NativeMethodCall{module:"mysql2/promise", …}`, dropping the opaque JS receiver. Downstream typing tags the result `Pool`, so `pool.execute`/`pool.query` dispatch natively too. The signature is tight enough to be mysql/mysql2-exclusive — generic-pool passes a `create`/`destroy` factory (no connection key); pg uses `new Pool()`, not `.createPool({...})`. A non-object-literal config falls through unchanged, and a bare `{host,user,password,database}` config (no pool option) is left to the existing import path — so the existing `test_issue_414` import test is unaffected.

**`perry-hir` — `context.rs` / `lowering_context.rs`:** a closed object literal lowers to `New{class_name:"__AnonShape_*"}` with the KEYS stripped into the synthesized shape class, so a reverse map `anon_shape_fields` (shape class name → field names, in source order) is added to the lowering context to recover the config keys.

**`perry-codegen` — `ext_registry.rs`:** tag the `js_mysql2_*` FFIs `WellKnown("mysql2")` so emitting them off codegen provenance (no import in the entry) flips the `[bindings.mysql2]` well-known and links the staticlib — the same mechanism the http / net / events rows already use.

## Testing

- New unit tests for the signature matcher (`mysql2_config_signature`): matches the gscmaster config and a host/credentials + `connectionLimit` config; rejects a connection-only config, a pool-option-only config, a generic-pool factory, and unrelated methods.
- Verified end-to-end against a live MySQL 8 server: an opaque `bundle.i(id).default.createPool({uri, waitForConnections, connectionLimit, …})` — both at top level and inside a factory arrow that captures the pool in nested `query`/`execute` functions (the turbopack shape) — now links and runs on native mysql2 (`queryOne(nonexistent)` → `null`, a real row round-trips) instead of throwing on the JS `generate-function` path.

https://claude.ai/code/session_01NjymZygYh31wM9h3wLnUqv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for bundled `mysql2` usage, including `createPool` and `createConnection` calls.
  * Automatically includes the required MySQL integration when these APIs are detected, even when imports are optimized or inlined.

* **Bug Fixes**
  * Improved recognition of MySQL connection configurations across supported object shapes.
  * Added safeguards to prevent unrelated pool factories from being incorrectly treated as `mysql2` connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->