### PR TITLE
fix(codegen): set new.target for a cross-module imported constructor

### DIFF
--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -1762,7 +1762,24 @@ fn lower_new_impl(
                 // to match the symbol's real signature (see codegen/mod.rs).
                 ctx.pending_declares
                     .push((ctor.symbol.clone(), DOUBLE, ctor_param_types));
+                // new.target cross-module: the imported ctor symbol is compiled
+                // in its SOURCE module and reads `new.target` from the runtime
+                // cell, NOT this module's codegen `new_target_stack` slot. Bind
+                // the cell to the LEAF class ref around the call so an ancestor
+                // ctor (e.g. Auth.js `AuthError`'s `this.type = new.target.type`)
+                // sees the class being constructed instead of a stale/undefined
+                // value. Without this, `new CredentialsSignin()` from another
+                // chunk threw `Cannot read properties of undefined (reading
+                // 'type')`, or silently set `type = undefined` → the auth error
+                // was mis-categorized and the login redirect fell back to
+                // `?error=Configuration`.
+                let nt_prev = ctx.block().call(DOUBLE, "js_new_target_get", &[]);
+                let nt_ref = double_literal(f64::from_bits(new_target_bits));
+                ctx.block()
+                    .call(DOUBLE, "js_new_target_set", &[(DOUBLE, &nt_ref)]);
                 let _ = ctx.block().call(DOUBLE, &ctor.symbol, &ctor_args);
+                ctx.block()
+                    .call(DOUBLE, "js_new_target_set", &[(DOUBLE, &nt_prev)]);
             } else if let Some(ctor) = ctx.imported_class_ctors.get(class_name).cloned() {
                 // Pad missing optional args with TAG_UNDEFINED so the constructor
                 // doesn't read garbage from stale registers, and pack the rest
@@ -1788,7 +1805,16 @@ fn lower_new_impl(
                 // ("value is not a function" on `new Chalk(...).red(...)`).
                 ctx.pending_declares
                     .push((ctor.symbol.clone(), DOUBLE, ctor_param_types));
+                // new.target cross-module: bind the runtime cell to the leaf
+                // class ref around the imported ctor call (see the ANCESTOR arm
+                // above for why). This is the direct `new ImportedClass()` case.
+                let nt_prev = ctx.block().call(DOUBLE, "js_new_target_get", &[]);
+                let nt_ref = double_literal(f64::from_bits(new_target_bits));
+                ctx.block()
+                    .call(DOUBLE, "js_new_target_set", &[(DOUBLE, &nt_ref)]);
                 let ctor_ret = ctx.block().call(DOUBLE, &ctor.symbol, &ctor_args);
+                ctx.block()
+                    .call(DOUBLE, "js_new_target_set", &[(DOUBLE, &nt_prev)]);
                 ctx.block().store(DOUBLE, &ctor_ret, &ctor_result_slot);
                 found_inherited_ctor = true;
             }


### PR DESCRIPTION
## Summary

`new C()` where `C`'s constructor lives in another module dispatches to the imported `<C>_constructor` symbol. That symbol is compiled in its **source** module, so its only `new.target` source is the runtime cell — not this module's codegen `new_target_stack` slot. The imported-constructor call sites never set that cell, so an ancestor constructor that reads `new.target` (e.g. `this.type = new.target.type`) saw a stale/undefined value; with an unguarded read it threw `Cannot read properties of undefined (reading 'type')`.

Bind the runtime `new.target` cell to the leaf class ref around the imported-constructor call and restore it after — mirroring the local standalone-symbol path (`ctor_chain_uses_new_target`), but unconditional for imported ctors since their body (and thus their `new.target` usage) isn't visible to analyze in the importing module.

## Context

Found while making a bundled Auth.js v5 login work end-to-end: its `AuthError` base constructor reads `new.target.type`, and constructing a subclass across the (bundled) module boundary hit this.

https://claude.ai/code/session_01NjymZygYh31wM9h3wLnUqv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cross-module class construction so `new.target` correctly refers to the leaf class during imported constructor calls.
  * Ensured the previous `new.target` value is restored after constructor execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->