### PR TITLE
Expand granular child_process parity coverage

### DIFF
--- a/test-parity/node-suite/child_process/README.md
+++ b/test-parity/node-suite/child_process/README.md
@@ -6,16 +6,16 @@ Focused compatibility cases for `node:child_process` process execution APIs.
 
 Reviewed on 2026-07-16 against primary repository snapshots:
 
-- Node.js [`34c28d5`](https://github.com/nodejs/node/tree/34c28d5a69f4f00cd599adcbe57834435d3a683b/test): the 126 `test/parallel` and `test/sequential` files whose names contain `child-process`, with particular attention to validation, cwd/env, spawn events, stdio flushing, sync result shapes, timeouts, AbortSignal, and advanced serialization.
+- Node.js [`608112a`](https://github.com/nodejs/node/tree/608112affae2cf44d2f8a0a6bfe7967193b459c8/test): the 126 `test/parallel` and `test/sequential` files whose names contain `child-process`, with particular attention to validation, cwd/env, spawn events, stdio flushing, sync result shapes, timeouts, AbortSignal, and advanced serialization.
 - Deno [`f8a17c8`](https://github.com/denoland/deno/blob/f8a17c8171569fa2870d740030aaa59c91fdf9ee/tests/unit_node/child_process_test.ts): its selected spawn/error/event, cwd/env, stdio, sync, and IPC compatibility coverage.
-- Bun [`5d350cc`](https://github.com/oven-sh/bun/tree/5d350cc17525a493fcb55b0a014f75af7c414580/test/js/node/test): its selected Node child-process parallel/sequential tests, including validation, lifecycle, buffering, serialization, and platform-specific cases.
+- Bun [`c4fad46`](https://github.com/oven-sh/bun/tree/c4fad462e7dc20e5e9780f848db42e1e2f52186d/test/js/node/test): its selected Node child-process parallel/sequential tests, including validation, lifecycle, buffering, serialization, and platform-specific cases.
 
-The granular suite now has 49 fixtures. The 23 expansion fixtures add:
+The granular suite now has 53 fixtures. The 27 expansion fixtures and focused follow-up assertions add:
 
-- deterministic embedded-null, option, fork overload, stdio layout, IPC placement, and kill-signal validation;
-- sync cwd/default-env/value coercion, missing-cwd errors, optional args, binary input views, encoding aliases, argument preservation, option immutability, `windowsHide`, shell execution, and infinite maxBuffer behavior;
-- async spawn metadata/default-env/optional-args behavior, option immutability, exit-code matrices, `exec`/`execFile` success shapes, callback and stream lifecycle ordering, text/binary stdin, stream piping, fd3, and bounded stdio flushing;
-- portable JSON IPC plus advanced Buffer, Map, Set, Date, RegExp, Uint16Array, BigInt, and Error serialization.
+- deterministic embedded-null, option, direct `ChildProcess` constructor, missing-command, fork overload/URL, stdio layout, IPC placement, and kill-signal validation;
+- sync cwd/default-env/value coercion, missing-cwd errors, optional args, binary input views, encoding aliases, literal metacharacter arguments, argument preservation, option immutability, `windowsHide`, shell execution, Unicode byte-boundary/infinite maxBuffer behavior, and multi-chunk/streamed output above 64 KiB;
+- async spawn metadata/default-env/optional-args behavior, option immutability, missing-command completion, exit-code/kill lifecycle matrices, `exec`/`execFile` success and promisified shapes, callback and stream lifecycle ordering, non-expiring timeouts, text/binary stdin, stream piping, fd3, and bounded multi-chunk stdio flushing;
+- portable JSON IPC plus advanced Buffer, empty/non-empty typed arrays, Map, Set, Date, RegExp, BigInt, and Error serialization.
 
 All new subprocesses invoke a controlled `node -e` program or a temporary local helper. Temporary files/directories are PID-scoped and removed in `finally` blocks.
 
@@ -25,34 +25,35 @@ With the repository-pinned Node 26.5.0 oracle:
 
 ```text
 ./run_parity_tests.sh --suite node-suite --module child_process
-39 pass, 9 output mismatches, 0 compile failures, 0 crashes, 1 host Node failure, 49 fixtures
+42 pass, 10 output mismatches, 0 compile failures, 0 crashes, 1 host Node failure, 53 fixtures
 
 NODE_BIN="$(command -v node)" python3 scripts/node_suite_run.py \
   "$PWD/target/release/perry" "$PWD" child_process
-40 pass, 9 output mismatches, 49 total
+43 pass, 10 output mismatches, 53 total
 ```
 
-Eight expansion fixtures intentionally expose stable Perry differences:
+Nine expansion fixtures intentionally expose stable Perry differences:
 
 - `validation/null-bytes`: Perry accepts command, file, argument, and fork paths containing `\0` instead of throwing `ERR_INVALID_ARG_VALUE`.
-- `validation/options`: Perry accepts invalid option/fork/stdio/IPC/signal inputs that Node rejects with `ERR_INVALID_ARG_TYPE`, `ERR_INVALID_ARG_VALUE`, `ERR_INVALID_SYNC_FORK_INPUT`, `ERR_IPC_ONE_PIPE`, `ERR_IPC_SYNC_FORK`, `ERR_OUT_OF_RANGE`, or `ERR_UNKNOWN_SIGNAL`.
-- `async/callback-ordering`: Perry invokes the `execFile` callback but returns no `ChildProcess` handle, so stream and lifecycle listeners cannot be attached.
+- `validation/options`: Perry accepts invalid option/fork/stdio/IPC/signal inputs that Node rejects with `ERR_INVALID_ARG_TYPE`, `ERR_INVALID_ARG_VALUE`, `ERR_INVALID_SYNC_FORK_INPUT`, `ERR_IPC_ONE_PIPE`, `ERR_IPC_SYNC_FORK`, `ERR_OUT_OF_RANGE`, or `ERR_UNKNOWN_SIGNAL`; its direct `ChildProcess` instance also lacks Node's prototype identity, initial state, and coded validation errors.
+- `async/callback-ordering`: Perry invokes the `execFile` callback but returns no `ChildProcess` handle, so stream and lifecycle listeners cannot be attached; promisified `exec`/`execFile` similarly omit the `.child` handle while their resolved/rejected output shapes match.
 - `async/cwd-env`: the child exits successfully but Perry captures no stdout when custom cwd/env options are used.
-- `async/spawn-behavior`: process metadata/status match, but async stdout is empty for direct, inherited-env, optional-args, and immutable-options probes.
+- `async/fork-url`: Perry accepts the WHATWG file URL but never receives the helper's IPC message and exits with unsettled top-level await.
+- `async/spawn-behavior`: process metadata/status match, but async stdout is empty for direct, inherited-env, optional-args, and immutable-options probes; missing-command errors fire without Node's subsequent `close` completion.
 - `async/stdio-dataflow`: writable calls and exit statuses match, but Perry does not expose readable state/end transitions, return stdout for text/binary/pipe flows, or create fd3.
-- `sync/error-shell`: missing-cwd error objects lack Node's constructor/code shape and basic shell execution is treated as ENOENT.
+- `sync/error-shell`: missing-cwd error objects lack Node's constructor/code shape, basic shell execution is treated as ENOENT, and Unicode sync maxBuffer errors report completed status/no signal while `maxBuffer: 0` is enforced instead of treated as unlimited.
 - `serialization/basic`: JSON plus advanced Buffer, Date, Uint16Array, and BigInt round trips match; Map, Set, RegExp, and Error brands/content are lost.
 
-The pre-existing `async/abort-signal` fixture remains the ninth mismatch. The focused harness's single host Node failure is the pre-existing detached-process-group fixture intermittently ending with Node's unsettled top-level-await exit 13; the baseline runner measures it cleanly.
+The pre-existing `async/abort-signal` fixture remains the tenth mismatch and now also shows that Perry returns `true` from `kill()` after close, where Node returns `false`. The focused harness's single host Node failure is the pre-existing detached-process-group fixture intermittently ending with Node's unsettled top-level-await exit 13; the baseline runner measures it cleanly.
 
 ## Stopping judgment and exclusions
 
 Further direct ports in the upstream corpus are redundant with current fixtures or belong in separate platform/slow feature assessments:
 
-- fork/IPC races, disconnect/ref timing, fd/handle and socket/server transfer, diagnostics-channel integration, and cluster/dgram interaction;
+- fork/IPC races, disconnect/ref timing, fd/handle and socket/server transfer, diagnostics-channel integration, and cluster/dgram interaction beyond the deterministic URL/serialization probes;
 - exhaustive signal-number matrices, kill races, UID/GID privilege behavior, detached process groups, and POSIX scheduler-sensitive cleanup;
 - Windows batch files, command quoting, overlapped stdio, and `windowsVerbatimArguments`;
 - custom-shell discovery/quoting and arbitrary external-command behavior;
-- EMFILE/resource exhaustion, large-buffer IPC framing, host-object/circular serialization, and multi-megabyte maxBuffer stress.
+- EMFILE/resource exhaustion, large-buffer IPC framing, host-object/circular serialization, and multi-megabyte maxBuffer stress beyond the bounded byte-boundary and 64 KiB flushing regressions.
 
 The suite stops here because those cases require platform gates, elevated privileges, network handles, shell assumptions, or longer stress windows. They should not be mixed into the deterministic portable floor.

--- a/test-parity/node-suite/child_process/README.md
+++ b/test-parity/node-suite/child_process/README.md
@@ -10,13 +10,12 @@ Reviewed on 2026-07-16 against primary repository snapshots:
 - Deno [`f8a17c8`](https://github.com/denoland/deno/blob/f8a17c8171569fa2870d740030aaa59c91fdf9ee/tests/unit_node/child_process_test.ts): its selected spawn/error/event, cwd/env, stdio, sync, and IPC compatibility coverage.
 - Bun [`5d350cc`](https://github.com/oven-sh/bun/tree/5d350cc17525a493fcb55b0a014f75af7c414580/test/js/node/test): its selected Node child-process parallel/sequential tests, including validation, lifecycle, buffering, serialization, and platform-specific cases.
 
-The granular suite now has 34 fixtures. The eight expansion fixtures add:
+The granular suite now has 49 fixtures. The 23 expansion fixtures add:
 
-- deterministic option and embedded-null validation;
-- sync cwd, environment coercion/omission, binary input, and result output;
-- async cwd/env propagation, spawn/stream/exit/close ordering, and `execFile` callback ordering;
-- 128 KiB stdout/stderr draining and 192 KiB stdin flushing;
-- portable JSON IPC plus basic advanced Buffer, Map, and BigInt serialization.
+- deterministic embedded-null, option, fork overload, stdio layout, IPC placement, and kill-signal validation;
+- sync cwd/default-env/value coercion, missing-cwd errors, optional args, binary input views, encoding aliases, argument preservation, option immutability, `windowsHide`, shell execution, and infinite maxBuffer behavior;
+- async spawn metadata/default-env/optional-args behavior, option immutability, exit-code matrices, `exec`/`execFile` success shapes, callback and stream lifecycle ordering, text/binary stdin, stream piping, fd3, and bounded stdio flushing;
+- portable JSON IPC plus advanced Buffer, Map, Set, Date, RegExp, Uint16Array, BigInt, and Error serialization.
 
 All new subprocesses invoke a controlled `node -e` program or a temporary local helper. Temporary files/directories are PID-scoped and removed in `finally` blocks.
 
@@ -26,27 +25,34 @@ With the repository-pinned Node 26.5.0 oracle:
 
 ```text
 ./run_parity_tests.sh --suite node-suite --module child_process
-28 pass, 6 output mismatches, 0 compile failures, 0 crashes, 34 total
+39 pass, 9 output mismatches, 0 compile failures, 0 crashes, 1 host Node failure, 49 fixtures
+
+NODE_BIN="$(command -v node)" python3 scripts/node_suite_run.py \
+  "$PWD/target/release/perry" "$PWD" child_process
+40 pass, 9 output mismatches, 49 total
 ```
 
-Five new fixtures intentionally expose stable Perry differences:
+Eight expansion fixtures intentionally expose stable Perry differences:
 
 - `validation/null-bytes`: Perry accepts command, file, argument, and fork paths containing `\0` instead of throwing `ERR_INVALID_ARG_VALUE`.
-- `validation/options`: Perry accepts invalid options that Node rejects with `ERR_INVALID_ARG_TYPE`, `ERR_INVALID_ARG_VALUE`, `ERR_OUT_OF_RANGE`, or `ERR_UNKNOWN_SIGNAL`.
+- `validation/options`: Perry accepts invalid option/fork/stdio/IPC/signal inputs that Node rejects with `ERR_INVALID_ARG_TYPE`, `ERR_INVALID_ARG_VALUE`, `ERR_INVALID_SYNC_FORK_INPUT`, `ERR_IPC_ONE_PIPE`, `ERR_IPC_SYNC_FORK`, `ERR_OUT_OF_RANGE`, or `ERR_UNKNOWN_SIGNAL`.
 - `async/callback-ordering`: Perry invokes the `execFile` callback but returns no `ChildProcess` handle, so stream and lifecycle listeners cannot be attached.
 - `async/cwd-env`: the child exits successfully but Perry captures no stdout when custom cwd/env options are used.
-- `serialization/basic`: JSON, Buffer, and BigInt round trips match; advanced serialization loses Map identity/content.
+- `async/spawn-behavior`: process metadata/status match, but async stdout is empty for direct, inherited-env, optional-args, and immutable-options probes.
+- `async/stdio-dataflow`: writable calls and exit statuses match, but Perry does not expose readable state/end transitions, return stdout for text/binary/pipe flows, or create fd3.
+- `sync/error-shell`: missing-cwd error objects lack Node's constructor/code shape and basic shell execution is treated as ENOENT.
+- `serialization/basic`: JSON plus advanced Buffer, Date, Uint16Array, and BigInt round trips match; Map, Set, RegExp, and Error brands/content are lost.
 
-The pre-existing `async/abort-signal` fixture remains the sixth mismatch.
+The pre-existing `async/abort-signal` fixture remains the ninth mismatch. The focused harness's single host Node failure is the pre-existing detached-process-group fixture intermittently ending with Node's unsettled top-level-await exit 13; the baseline runner measures it cleanly.
 
 ## Stopping judgment and exclusions
 
 Further direct ports in the upstream corpus are redundant with current fixtures or belong in separate platform/slow feature assessments:
 
 - fork/IPC races, disconnect/ref timing, fd/handle and socket/server transfer, diagnostics-channel integration, and cluster/dgram interaction;
-- signal-number matrices, kill races, UID/GID privilege behavior, detached process groups, and POSIX scheduler-sensitive cleanup;
-- Windows batch files, command quoting, overlapped stdio, `windowsHide`, and `windowsVerbatimArguments`;
-- shell discovery/quoting and arbitrary external-command behavior;
+- exhaustive signal-number matrices, kill races, UID/GID privilege behavior, detached process groups, and POSIX scheduler-sensitive cleanup;
+- Windows batch files, command quoting, overlapped stdio, and `windowsVerbatimArguments`;
+- custom-shell discovery/quoting and arbitrary external-command behavior;
 - EMFILE/resource exhaustion, large-buffer IPC framing, host-object/circular serialization, and multi-megabyte maxBuffer stress.
 
 The suite stops here because those cases require platform gates, elevated privileges, network handles, shell assumptions, or longer stress windows. They should not be mixed into the deterministic portable floor.

--- a/test-parity/node-suite/child_process/README.md
+++ b/test-parity/node-suite/child_process/README.md
@@ -1,3 +1,52 @@
 # node:child_process parity cases
 
 Focused compatibility cases for `node:child_process` process execution APIs.
+
+## Upstream comparison
+
+Reviewed on 2026-07-16 against primary repository snapshots:
+
+- Node.js [`34c28d5`](https://github.com/nodejs/node/tree/34c28d5a69f4f00cd599adcbe57834435d3a683b/test): the 126 `test/parallel` and `test/sequential` files whose names contain `child-process`, with particular attention to validation, cwd/env, spawn events, stdio flushing, sync result shapes, timeouts, AbortSignal, and advanced serialization.
+- Deno [`f8a17c8`](https://github.com/denoland/deno/blob/f8a17c8171569fa2870d740030aaa59c91fdf9ee/tests/unit_node/child_process_test.ts): its selected spawn/error/event, cwd/env, stdio, sync, and IPC compatibility coverage.
+- Bun [`5d350cc`](https://github.com/oven-sh/bun/tree/5d350cc17525a493fcb55b0a014f75af7c414580/test/js/node/test): its selected Node child-process parallel/sequential tests, including validation, lifecycle, buffering, serialization, and platform-specific cases.
+
+The granular suite now has 34 fixtures. The eight expansion fixtures add:
+
+- deterministic option and embedded-null validation;
+- sync cwd, environment coercion/omission, binary input, and result output;
+- async cwd/env propagation, spawn/stream/exit/close ordering, and `execFile` callback ordering;
+- 128 KiB stdout/stderr draining and 192 KiB stdin flushing;
+- portable JSON IPC plus basic advanced Buffer, Map, and BigInt serialization.
+
+All new subprocesses invoke a controlled `node -e` program or a temporary local helper. Temporary files/directories are PID-scoped and removed in `finally` blocks.
+
+## Measured status
+
+With the repository-pinned Node 26.5.0 oracle:
+
+```text
+./run_parity_tests.sh --suite node-suite --module child_process
+28 pass, 6 output mismatches, 0 compile failures, 0 crashes, 34 total
+```
+
+Five new fixtures intentionally expose stable Perry differences:
+
+- `validation/null-bytes`: Perry accepts command, file, argument, and fork paths containing `\0` instead of throwing `ERR_INVALID_ARG_VALUE`.
+- `validation/options`: Perry accepts invalid options that Node rejects with `ERR_INVALID_ARG_TYPE`, `ERR_INVALID_ARG_VALUE`, `ERR_OUT_OF_RANGE`, or `ERR_UNKNOWN_SIGNAL`.
+- `async/callback-ordering`: Perry invokes the `execFile` callback but returns no `ChildProcess` handle, so stream and lifecycle listeners cannot be attached.
+- `async/cwd-env`: the child exits successfully but Perry captures no stdout when custom cwd/env options are used.
+- `serialization/basic`: JSON, Buffer, and BigInt round trips match; advanced serialization loses Map identity/content.
+
+The pre-existing `async/abort-signal` fixture remains the sixth mismatch.
+
+## Stopping judgment and exclusions
+
+Further direct ports in the upstream corpus are redundant with current fixtures or belong in separate platform/slow feature assessments:
+
+- fork/IPC races, disconnect/ref timing, fd/handle and socket/server transfer, diagnostics-channel integration, and cluster/dgram interaction;
+- signal-number matrices, kill races, UID/GID privilege behavior, detached process groups, and POSIX scheduler-sensitive cleanup;
+- Windows batch files, command quoting, overlapped stdio, `windowsHide`, and `windowsVerbatimArguments`;
+- shell discovery/quoting and arbitrary external-command behavior;
+- EMFILE/resource exhaustion, large-buffer IPC framing, host-object/circular serialization, and multi-megabyte maxBuffer stress.
+
+The suite stops here because those cases require platform gates, elevated privileges, network handles, shell assumptions, or longer stress windows. They should not be mixed into the deterministic portable floor.

--- a/test-parity/node-suite/child_process/async/abort-signal.ts
+++ b/test-parity/node-suite/child_process/async/abort-signal.ts
@@ -4,7 +4,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 function valueText(value) {
-  return value === null ? "null" : value === undefined ? "undefined" : String(value);
+  return value === null
+    ? "null"
+    : value === undefined
+      ? "undefined"
+      : String(value);
 }
 
 function errSummary(err) {
@@ -18,7 +22,9 @@ function errSummary(err) {
 }
 
 function close(child) {
-  return new Promise((resolve) => child.on("close", (code, signal) => resolve([code, signal])));
+  return new Promise((resolve) =>
+    child.on("close", (code, signal) => resolve([code, signal])),
+  );
 }
 
 function invalidSignal(label, start) {
@@ -47,28 +53,43 @@ function execWithAbort(label, run) {
 async function liveAbort(label, child) {
   const events = [];
   child.on("spawn", () => {
-    events.push(`spawn:${valueText(child.killed)}:${valueText(child.signalCode)}`);
+    events.push(
+      `spawn:${valueText(child.killed)}:${valueText(child.signalCode)}`,
+    );
   });
   child.on("error", (err) => {
-    events.push(`error:${errSummary(err)}:${valueText(child.killed)}:${valueText(child.signalCode)}`);
+    events.push(
+      `error:${errSummary(err)}:${valueText(child.killed)}:${valueText(child.signalCode)}`,
+    );
   });
   child.on("exit", (code, signal) => {
-    events.push(`exit:${valueText(code)}:${valueText(signal)}:${valueText(child.killed)}:${valueText(child.signalCode)}`);
+    events.push(
+      `exit:${valueText(code)}:${valueText(signal)}:${valueText(child.killed)}:${valueText(child.signalCode)}`,
+    );
   });
   const [code, signal] = await close(child);
-  events.push(`close:${valueText(code)}:${valueText(signal)}:${valueText(child.killed)}:${valueText(child.signalCode)}`);
+  events.push(
+    `close:${valueText(code)}:${valueText(signal)}:${valueText(child.killed)}:${valueText(child.signalCode)}`,
+  );
   console.log(`${label}:`, events.join(">"));
 }
 
 invalidSignal("spawn", () => spawn("node", ["-e", ""], { signal: {} }));
-invalidSignal("exec", () => exec("node -e \"\"", { signal: {} }, () => {}));
-invalidSignal("execFile", () => execFile("node", ["-e", ""], { signal: {} }, () => {}));
+invalidSignal("exec", () => exec('node -e ""', { signal: {} }, () => {}));
+invalidSignal("execFile", () =>
+  execFile("node", ["-e", ""], { signal: {} }, () => {}),
+);
 
 await execWithAbort("exec aborted", (signal, cb) =>
-  exec("sleep 1; printf exec-after", { signal, encoding: "utf8" }, cb)
+  exec("sleep 1; printf exec-after", { signal, encoding: "utf8" }, cb),
 );
 await execWithAbort("execFile aborted", (signal, cb) =>
-  execFile("sh", ["-c", "sleep 1; printf execfile-after"], { signal, encoding: "utf8" }, cb)
+  execFile(
+    "sh",
+    ["-c", "sleep 1; printf execfile-after"],
+    { signal, encoding: "utf8" },
+    cb,
+  ),
 );
 
 const spawnController = new AbortController();
@@ -92,3 +113,39 @@ await liveAbort("fork aborted", forked);
 try {
   unlinkSync(childFile);
 } catch {}
+
+const lifecycle = spawn("node", ["-e", "setInterval(() => {}, 1000)"]);
+try {
+  await new Promise((resolve, reject) => {
+    lifecycle.once("spawn", resolve);
+    lifecycle.once("error", reject);
+  });
+  console.log(
+    "kill initial:",
+    lifecycle.killed,
+    valueText(lifecycle.exitCode),
+    valueText(lifecycle.signalCode),
+  );
+  console.log("kill probe:", lifecycle.kill(0), lifecycle.killed);
+  console.log("kill terminate:", lifecycle.kill("SIGTERM"), lifecycle.killed);
+  const lifecycleEvents = [];
+  lifecycle.on("exit", (code, signal) =>
+    lifecycleEvents.push(`exit:${valueText(code)}:${valueText(signal)}`),
+  );
+  await new Promise((resolve) =>
+    lifecycle.on("close", (code, signal) => {
+      lifecycleEvents.push(`close:${valueText(code)}:${valueText(signal)}`);
+      resolve();
+    }),
+  );
+  console.log("kill events:", lifecycleEvents.join(">"));
+  console.log(
+    "kill final:",
+    valueText(lifecycle.exitCode),
+    valueText(lifecycle.signalCode),
+  );
+  console.log("kill after close:", lifecycle.kill(), lifecycle.killed);
+} finally {
+  if (lifecycle.exitCode === null && lifecycle.signalCode === null)
+    lifecycle.kill("SIGKILL");
+}

--- a/test-parity/node-suite/child_process/async/callback-ordering.ts
+++ b/test-parity/node-suite/child_process/async/callback-ordering.ts
@@ -1,4 +1,5 @@
-import { execFile } from "node:child_process";
+import { exec, execFile } from "node:child_process";
+import { promisify } from "node:util";
 
 const events: string[] = [];
 let finishCallback!: () => void;
@@ -43,4 +44,50 @@ if (child) {
 } else {
   await callbackDone;
   console.log("order:", events.join(">"));
+}
+
+const execPromise = promisify(exec);
+const execFilePromise = promisify(execFile);
+const execResult = execPromise(
+  "node -e \"process.stdout.write('exec-out'); process.stderr.write('exec-err')\"",
+  { encoding: "utf8" },
+);
+console.log(
+  "promise exec child:",
+  typeof execResult.child?.pid,
+  execResult.child?.spawnfile,
+);
+console.log("promise exec result:", JSON.stringify(await execResult));
+
+const fileResult = execFilePromise(
+  "node",
+  ["-e", "process.stdout.write(process.argv[1])", "file-out"],
+  { encoding: "utf8" },
+);
+console.log(
+  "promise file child:",
+  typeof fileResult.child?.pid,
+  fileResult.child?.spawnfile,
+);
+console.log("promise file result:", JSON.stringify(await fileResult));
+
+try {
+  await execFilePromise(
+    "node",
+    [
+      "-e",
+      "process.stdout.write('partial'); process.stderr.write('problem'); process.exit(7)",
+    ],
+    { encoding: "utf8" },
+  );
+  console.log("promise failure: no rejection");
+} catch (error: any) {
+  console.log(
+    "promise failure:",
+    error.name,
+    error.code,
+    error.killed,
+    error.signal,
+  );
+  console.log("promise failure output:", error.stdout, error.stderr);
 }

--- a/test-parity/node-suite/child_process/async/callback-ordering.ts
+++ b/test-parity/node-suite/child_process/async/callback-ordering.ts
@@ -1,0 +1,46 @@
+import { execFile } from "node:child_process";
+
+const events: string[] = [];
+let finishCallback!: () => void;
+const callbackDone = new Promise<void>((resolve) => {
+  finishCallback = resolve;
+});
+const child = execFile(
+  "node",
+  ["-e", "process.stdout.write('out'); process.stderr.write('err');"],
+  { encoding: "utf8" },
+  (error, stdout, stderr) => {
+    events.push("callback");
+    console.log("callback error:", error === null ? "null" : error?.name);
+    console.log("callback output:", stdout, stderr);
+    finishCallback();
+  },
+);
+
+console.log("child present:", child !== undefined);
+console.log(
+  "stdio present:",
+  child?.stdout !== undefined,
+  child?.stderr !== undefined,
+);
+child?.on("spawn", () => events.push("spawn"));
+child?.stdout?.on("end", () => events.push("stdout-end"));
+child?.stderr?.on("end", () => events.push("stderr-end"));
+child?.on("exit", () => events.push("exit"));
+
+if (child) {
+  await new Promise<void>((resolve) => {
+    child.on("close", () => {
+      events.push("close");
+      console.log("order:", events.join(">"));
+      console.log(
+        "callback before listener close:",
+        events.indexOf("callback") < events.indexOf("close"),
+      );
+      resolve();
+    });
+  });
+} else {
+  await callbackDone;
+  console.log("order:", events.join(">"));
+}

--- a/test-parity/node-suite/child_process/async/cwd-env.ts
+++ b/test-parity/node-suite/child_process/async/cwd-env.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { type ChildProcess, spawn } from "node:child_process";
 import { mkdirSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -7,7 +7,7 @@ const cwd = join(tmpdir(), `perry-child-process-async-${process.pid}`);
 mkdirSync(cwd);
 const expectedCwd = realpathSync(cwd);
 
-function close(child: any): Promise<number | null> {
+function close(child: ChildProcess): Promise<number | null> {
   return new Promise((resolve) => child.on("close", resolve));
 }
 

--- a/test-parity/node-suite/child_process/async/cwd-env.ts
+++ b/test-parity/node-suite/child_process/async/cwd-env.ts
@@ -1,0 +1,51 @@
+import { spawn } from "node:child_process";
+import { mkdirSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const cwd = join(tmpdir(), `perry-child-process-async-${process.pid}`);
+mkdirSync(cwd);
+const expectedCwd = realpathSync(cwd);
+
+function close(child: any): Promise<number | null> {
+  return new Promise((resolve) => child.on("close", resolve));
+}
+
+try {
+  const child = spawn(
+    "node",
+    [
+      "-e",
+      "process.stdout.write(JSON.stringify({ cwd: process.cwd(), value: process.env.PERRY_VALUE, empty: process.env.PERRY_EMPTY, missing: Object.hasOwn(process.env, 'PERRY_MISSING') }))",
+    ],
+    {
+      cwd,
+      env: {
+        ...process.env,
+        PERRY_VALUE: false as any,
+        PERRY_EMPTY: "",
+        PERRY_MISSING: undefined,
+      },
+    },
+  );
+  let stdout = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => {
+    stdout += chunk;
+  });
+  const status = await close(child);
+  console.log("status:", status);
+  console.log("stdout present:", stdout.length > 0);
+  if (stdout.length > 0) {
+    const value = JSON.parse(stdout);
+    console.log("cwd:", value.cwd === expectedCwd);
+    console.log(
+      "env:",
+      value.value,
+      JSON.stringify(value.empty),
+      value.missing,
+    );
+  }
+} finally {
+  rmSync(cwd, { recursive: true, force: true });
+}

--- a/test-parity/node-suite/child_process/async/event-ordering.ts
+++ b/test-parity/node-suite/child_process/async/event-ordering.ts
@@ -1,0 +1,43 @@
+import { spawn } from "node:child_process";
+
+const child = spawn("node", [
+  "-e",
+  "process.stdout.write('ready'); process.stderr.write('warn');",
+]);
+const events: string[] = [];
+let stdout = "";
+let stderr = "";
+
+child.on("spawn", () => events.push("spawn"));
+child.stdout.on("data", (chunk: Buffer) => {
+  events.push("stdout-data");
+  stdout += chunk.toString("utf8");
+});
+child.stderr.on("data", (chunk: Buffer) => {
+  events.push("stderr-data");
+  stderr += chunk.toString("utf8");
+});
+child.stdout.on("end", () => events.push("stdout-end"));
+child.stderr.on("end", () => events.push("stderr-end"));
+child.on("exit", (code, signal) => events.push(`exit:${code}:${signal}`));
+
+await new Promise<void>((resolve) => {
+  child.on("close", (code, signal) => {
+    events.push(`close:${code}:${signal}`);
+    console.log("spawn first:", events[0] === "spawn");
+    console.log(
+      "exit before close:",
+      events.indexOf("exit:0:null") < events.indexOf("close:0:null"),
+    );
+    console.log(
+      "stdout end before close:",
+      events.indexOf("stdout-end") < events.indexOf("close:0:null"),
+    );
+    console.log(
+      "stderr end before close:",
+      events.indexOf("stderr-end") < events.indexOf("close:0:null"),
+    );
+    console.log("output:", stdout, stderr);
+    resolve();
+  });
+});

--- a/test-parity/node-suite/child_process/async/exec-success.ts
+++ b/test-parity/node-suite/child_process/async/exec-success.ts
@@ -1,0 +1,16 @@
+import { exec } from "node:child_process";
+
+await new Promise<void>((resolve) => {
+  exec(
+    `node -e "process.stdout.write('exec-out');process.stderr.write('exec-err')"`,
+    { encoding: "utf8" },
+    (error, stdout, stderr) => {
+      console.log("error:", error === null ? "null" : error?.name);
+      console.log("stdout:", stdout);
+      console.log("stderr:", stderr);
+      console.log("stdout type:", typeof stdout);
+      console.log("stderr type:", typeof stderr);
+      resolve();
+    },
+  );
+});

--- a/test-parity/node-suite/child_process/async/execfile-args.ts
+++ b/test-parity/node-suite/child_process/async/execfile-args.ts
@@ -1,0 +1,20 @@
+import { execFile } from "node:child_process";
+
+const args = ["space value", 'quote"value', "unicode-中文", "", "--flag=value"];
+await new Promise<void>((resolve) => {
+  execFile(
+    "node",
+    [
+      "-e",
+      "process.stdout.write(JSON.stringify(process.argv.slice(1)))",
+      ...args,
+    ],
+    { encoding: "utf8" },
+    (error, stdout, stderr) => {
+      console.log("error:", error === null ? "null" : error?.name);
+      console.log("args:", stdout);
+      console.log("stderr:", JSON.stringify(stderr));
+      resolve();
+    },
+  );
+});

--- a/test-parity/node-suite/child_process/async/exit-codes.ts
+++ b/test-parity/node-suite/child_process/async/exit-codes.ts
@@ -1,0 +1,16 @@
+import { spawn } from "node:child_process";
+
+for (const expected of [0, 3, 23]) {
+  const child = spawn("node", ["-e", `process.exit(${expected})`]);
+  const events: string[] = [];
+  child.on("exit", (code, signal) => events.push(`exit:${code}:${signal}`));
+  await new Promise<void>((resolve) => {
+    child.on("close", (code, signal) => {
+      events.push(`close:${code}:${signal}`);
+      console.log(`${expected} events:`, events.join(">"));
+      console.log(`${expected} exitCode:`, child.exitCode);
+      console.log(`${expected} signalCode:`, child.signalCode);
+      resolve();
+    });
+  });
+}

--- a/test-parity/node-suite/child_process/async/fork-url.ts
+++ b/test-parity/node-suite/child_process/async/fork-url.ts
@@ -1,0 +1,33 @@
+import { fork } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+const helper = new URL("../fixtures/fork-url-child.cjs", import.meta.url);
+
+const child = fork(helper, ["first", "space value"], {
+  cwd: tmpdir(),
+  execArgv: [],
+  execPath: "node",
+  stdio: ["ignore", "ignore", "ignore", "ipc"],
+});
+
+try {
+  const message = await new Promise<any>((resolve, reject) => {
+    child.once("error", reject);
+    child.once("message", resolve);
+  });
+  console.log("message argv:", message.argv.join("|"));
+  console.log("message cwd matches:", message.cwd === realpathSync(tmpdir()));
+  console.log("spawnfile:", child.spawnfile);
+  console.log(
+    "spawnargs has helper:",
+    child.spawnargs.some((arg) => arg.endsWith("fork-url-child.cjs")),
+  );
+  console.log(
+    "close:",
+    await new Promise((resolve) => child.once("close", resolve)),
+  );
+} finally {
+  if (child.connected) child.disconnect();
+  if (child.exitCode === null) child.kill();
+}

--- a/test-parity/node-suite/child_process/async/spawn-behavior.ts
+++ b/test-parity/node-suite/child_process/async/spawn-behavior.ts
@@ -1,0 +1,95 @@
+import { type ChildProcess, spawn } from "node:child_process";
+
+function close(child: ChildProcess): Promise<number | null> {
+  return new Promise((resolve) => child.on("close", resolve));
+}
+
+{
+  const child = spawn("node", [
+    "-e",
+    "process.stdout.write(process.argv[1])",
+    "child-arg",
+  ]);
+  let stdout = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => (stdout += chunk));
+  console.log("metadata pid type:", typeof child.pid);
+  console.log("metadata spawnfile:", child.spawnfile);
+  console.log("metadata spawnargs length:", child.spawnargs.length);
+  console.log("metadata spawnargs command:", child.spawnargs[0]);
+  console.log("metadata spawnargs flag:", child.spawnargs[1]);
+  const code = await close(child);
+  console.log("metadata close:", code, child.signalCode);
+  console.log("metadata stdout:", stdout);
+  console.log("metadata exitCode:", child.exitCode);
+}
+
+{
+  const key = "PERRY_CHILD_DEFAULT_ENV";
+  const previous = process.env[key];
+  process.env[key] = "inherited-value";
+  try {
+    const child = spawn("node", [
+      "-e",
+      `process.stdout.write(process.env.${key} || 'missing')`,
+    ]);
+    let stdout = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => (stdout += chunk));
+    console.log("default env status:", await close(child));
+    console.log("default env value:", stdout);
+  } finally {
+    if (previous === undefined) delete process.env[key];
+    else process.env[key] = previous;
+  }
+}
+
+for (const [label, args] of [
+  ["undefined", undefined],
+  ["null", null],
+  ["empty", []],
+] as const) {
+  const child = spawn(
+    "node",
+    args as any,
+    { env: { ...process.env, PERRY_OPTIONAL_ARGS: label } } as any,
+  );
+  let stdout = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => (stdout += chunk));
+  child.stdin.end("process.stdout.write(process.env.PERRY_OPTIONAL_ARGS)\n");
+  console.log(`optional ${label} status:`, await close(child));
+  console.log(`optional ${label} output:`, stdout);
+}
+
+{
+  const options = {
+    cwd: process.cwd(),
+    env: { ...process.env, PERRY_IMMUTABLE: "yes" },
+    stdio: ["ignore", "pipe", "pipe"] as any,
+    windowsHide: true,
+  };
+  const before = {
+    cwd: options.cwd,
+    env: options.env.PERRY_IMMUTABLE,
+    stdio: options.stdio.join(","),
+    windowsHide: options.windowsHide,
+  };
+  const child = spawn(
+    "node",
+    ["-e", "process.stdout.write(process.env.PERRY_IMMUTABLE)"],
+    options,
+  );
+  let stdout = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => (stdout += chunk));
+  console.log("immutable status:", await close(child));
+  console.log("immutable stdout:", stdout);
+  console.log("immutable cwd:", options.cwd === before.cwd);
+  console.log("immutable env:", options.env.PERRY_IMMUTABLE === before.env);
+  console.log("immutable stdio:", options.stdio.join(",") === before.stdio);
+  console.log(
+    "immutable windowsHide:",
+    options.windowsHide === before.windowsHide,
+  );
+}

--- a/test-parity/node-suite/child_process/async/spawn-behavior.ts
+++ b/test-parity/node-suite/child_process/async/spawn-behavior.ts
@@ -93,3 +93,59 @@ for (const [label, args] of [
     options.windowsHide === before.windowsHide,
   );
 }
+
+{
+  const events: string[] = [];
+  let errorErrno: unknown;
+  const child = spawn("__perry_missing_child_process_command__", [
+    "first",
+    "second",
+  ]);
+
+  console.log(
+    "missing pid:",
+    child.pid === undefined ? "undefined" : String(child.pid),
+  );
+  console.log("missing spawnfile:", child.spawnfile);
+  console.log("missing spawnargs:", child.spawnargs.join("|"));
+  console.log(
+    "missing stdio:",
+    child.stdin !== null,
+    child.stdout !== null,
+    child.stderr !== null,
+  );
+
+  child.on("spawn", () => events.push("spawn"));
+  child.on("error", (error: any) => {
+    events.push("error");
+    errorErrno = error.errno;
+    console.log("missing error name:", error.name);
+    console.log("missing error code:", error.code);
+    console.log("missing error errno type:", typeof error.errno);
+    console.log("missing error syscall:", error.syscall);
+    console.log("missing error path:", error.path);
+    console.log("missing error spawnargs:", error.spawnargs.join("|"));
+  });
+  child.on("exit", () => events.push("exit"));
+
+  await new Promise<void>((resolve) => {
+    child.on("close", (code, signal) => {
+      events.push("close");
+      console.log(
+        "missing close matches errno:",
+        code === errorErrno,
+        signal === null ? "null" : signal,
+      );
+      console.log(
+        "missing exitCode matches errno:",
+        child.exitCode === errorErrno,
+      );
+      console.log(
+        "missing signalCode:",
+        child.signalCode === null ? "null" : child.signalCode,
+      );
+      console.log("missing events:", events.join(">"));
+      resolve();
+    });
+  });
+}

--- a/test-parity/node-suite/child_process/async/stdio-dataflow.ts
+++ b/test-parity/node-suite/child_process/async/stdio-dataflow.ts
@@ -1,0 +1,76 @@
+import { type ChildProcess, spawn } from "node:child_process";
+
+function close(child: ChildProcess): Promise<number | null> {
+  return new Promise((resolve) => child.on("close", resolve));
+}
+
+{
+  const child = spawn("node", [
+    "-e",
+    "let text='';process.stdin.setEncoding('utf8');process.stdin.on('data',c=>text+=c);process.stdin.on('end',()=>process.stdout.write(text));",
+  ]);
+  let stdout = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => (stdout += chunk));
+  console.log("text stdin writable before:", child.stdin.writable);
+  console.log("text stdin readable:", child.stdin.readable);
+  console.log("text write one:", child.stdin.write("hello"));
+  console.log("text write two:", child.stdin.write(" world", "utf8"));
+  child.stdin.end("!");
+  console.log("text status:", await close(child));
+  console.log("text stdout:", stdout);
+  console.log("text stdin writable after:", child.stdin.writable);
+}
+
+{
+  const child = spawn("node", [
+    "-e",
+    "const b=[];process.stdin.on('data',c=>b.push(c));process.stdin.on('end',()=>process.stdout.write(Buffer.concat(b).toString('hex')));",
+  ]);
+  let stdout = "";
+  child.stdout.setEncoding("utf8");
+  child.stdout.on("data", (chunk: string) => (stdout += chunk));
+  child.stdin.write(new Uint8Array([0, 1, 127, 128]));
+  child.stdin.end(Buffer.from([254, 255]));
+  console.log("binary status:", await close(child));
+  console.log("binary hex:", stdout);
+}
+
+{
+  const producer = spawn("node", ["-e", "process.stdout.write('pipe-data')"]);
+  const producerClosed = close(producer);
+  const consumer = spawn("node", [
+    "-e",
+    "let s='';process.stdin.on('data',c=>s+=c);process.stdin.on('end',()=>process.stdout.write(s.toUpperCase()));",
+  ]);
+  producer.stdout.pipe(consumer.stdin);
+  let stdout = "";
+  let stderr = "";
+  consumer.stdout.setEncoding("utf8");
+  consumer.stderr.setEncoding("utf8");
+  consumer.stdout.on("data", (chunk: string) => (stdout += chunk));
+  consumer.stderr.on("data", (chunk: string) => (stderr += chunk));
+  const [producerCode, consumerCode] = await Promise.all([
+    producerClosed,
+    close(consumer),
+  ]);
+  console.log("pipe statuses:", producerCode, consumerCode);
+  console.log("pipe stdout:", stdout);
+  console.log("pipe stderr:", JSON.stringify(stderr));
+}
+
+{
+  const child = spawn(
+    "node",
+    ["-e", "require('node:fs').writeSync(3, Buffer.from('fd3-data'))"],
+    { stdio: ["ignore", "ignore", "ignore", "pipe"] },
+  );
+  let output = "";
+  const fd3: any = child.stdio[3];
+  fd3?.setEncoding?.("utf8");
+  fd3?.on?.("data", (chunk: string) => (output += chunk));
+  console.log("fd3 stdio length:", child.stdio.length);
+  console.log("fd3 present:", fd3 !== null && fd3 !== undefined);
+  console.log("fd3 status:", await close(child));
+  console.log("fd3 output:", output);
+}

--- a/test-parity/node-suite/child_process/async/stdio-flush.ts
+++ b/test-parity/node-suite/child_process/async/stdio-flush.ts
@@ -44,3 +44,21 @@ const result = await consumed;
 console.log("consumer status:", result.code);
 console.log("consumer received:", result.stdout);
 console.log("consumer stderr:", JSON.stringify(result.stderr));
+
+const chunks = 6;
+const chunkSize = 50 * 1024;
+const multiChunk = spawn("node", [
+  "-e",
+  `for (let i = 0; i < ${chunks}; i++) process.stdout.write(String(i).repeat(${chunkSize}));`,
+]);
+const chunked = await collect(multiChunk);
+console.log("multi status:", chunked.code);
+console.log("multi length:", chunked.stdout.length);
+console.log(
+  "multi boundaries:",
+  Array.from(
+    { length: chunks },
+    (_, index) => chunked.stdout[index * chunkSize],
+  ).join(""),
+);
+console.log("multi stderr:", JSON.stringify(chunked.stderr));

--- a/test-parity/node-suite/child_process/async/stdio-flush.ts
+++ b/test-parity/node-suite/child_process/async/stdio-flush.ts
@@ -1,0 +1,46 @@
+import { spawn } from "node:child_process";
+
+function collect(
+  child: any,
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+    child.on("close", (code: number | null) => {
+      resolve({
+        code,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+      });
+    });
+  });
+}
+
+const outputSize = 128 * 1024;
+const producer = spawn("node", [
+  "-e",
+  `process.stdout.write('o'.repeat(${outputSize})); process.stderr.write('e'.repeat(${outputSize}));`,
+]);
+const produced = await collect(producer);
+console.log("producer status:", produced.code);
+console.log("producer stdout length:", produced.stdout.length);
+console.log("producer stderr length:", produced.stderr.length);
+console.log(
+  "producer boundaries:",
+  produced.stdout[0] + produced.stdout.at(-1),
+  produced.stderr[0] + produced.stderr.at(-1),
+);
+
+const consumer = spawn("node", [
+  "-e",
+  "let size = 0; process.stdin.on('data', chunk => size += chunk.length); process.stdin.on('end', () => process.stdout.write(String(size)));",
+]);
+const inputSize = 192 * 1024;
+const consumed = collect(consumer);
+consumer.stdin.end(Buffer.alloc(inputSize, 120));
+const result = await consumed;
+console.log("consumer status:", result.code);
+console.log("consumer received:", result.stdout);
+console.log("consumer stderr:", JSON.stringify(result.stderr));

--- a/test-parity/node-suite/child_process/async/stdio-flush.ts
+++ b/test-parity/node-suite/child_process/async/stdio-flush.ts
@@ -1,7 +1,7 @@
-import { spawn } from "node:child_process";
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 
 function collect(
-  child: any,
+  child: ChildProcessWithoutNullStreams,
 ): Promise<{ code: number | null; stdout: string; stderr: string }> {
   return new Promise((resolve) => {
     const stdout: Buffer[] = [];

--- a/test-parity/node-suite/child_process/async/timeout-nonexpired.ts
+++ b/test-parity/node-suite/child_process/async/timeout-nonexpired.ts
@@ -1,0 +1,43 @@
+import { exec, execFile } from "node:child_process";
+
+function run(
+  label: string,
+  start: (
+    callback: (error: Error | null, stdout: unknown, stderr: unknown) => void,
+  ) => void,
+) {
+  return new Promise<void>((resolve) => {
+    start((error, stdout, stderr) => {
+      console.log(`${label} error:`, error === null ? "null" : error.name);
+      console.log(`${label} stdout:`, JSON.stringify(String(stdout)));
+      console.log(`${label} stderr:`, JSON.stringify(String(stderr)));
+      resolve();
+    });
+  });
+}
+
+await run("exec undefined", (callback) =>
+  exec(
+    "node -e \"process.stdout.write('undefined-timeout')\"",
+    { timeout: undefined, encoding: "utf8" },
+    callback,
+  ),
+);
+
+await run("execFile zero", (callback) =>
+  execFile(
+    "node",
+    ["-e", "process.stdout.write('zero-timeout')"],
+    { timeout: 0, encoding: "utf8" },
+    callback,
+  ),
+);
+
+await run("execFile large", (callback) =>
+  execFile(
+    "node",
+    ["-e", "process.stdout.write('large-timeout')"],
+    { timeout: 2 ** 31 - 1, encoding: "utf8" },
+    callback,
+  ),
+);

--- a/test-parity/node-suite/child_process/fixtures/fork-url-child.cjs
+++ b/test-parity/node-suite/child_process/fixtures/fork-url-child.cjs
@@ -1,0 +1,4 @@
+process.send(
+  { argv: process.argv.slice(2), cwd: process.cwd() },
+  () => process.disconnect(),
+);

--- a/test-parity/node-suite/child_process/serialization/basic.ts
+++ b/test-parity/node-suite/child_process/serialization/basic.ts
@@ -1,0 +1,60 @@
+import { fork } from "node:child_process";
+import { rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const helper = join(
+  tmpdir(),
+  `perry-child-process-serialization-${process.pid}.js`,
+);
+writeFileSync(
+  helper,
+  [
+    "process.once('message', (message) => {",
+    "const summary = {",
+    "keys: Object.keys(message).join(','),",
+    "nested: message.nested && message.nested.value,",
+    "array: Array.isArray(message.items) ? message.items.join('|') : '',",
+    "buffer: Buffer.isBuffer(message.buffer) ? message.buffer.toString('hex') : '',",
+    "map: message.map instanceof Map ? Array.from(message.map.entries()).join('|') : '',",
+    "bigint: typeof message.bigint === 'bigint' ? String(message.bigint) : '',",
+    "};",
+    "process.send(summary, () => process.disconnect());",
+    "});",
+  ].join(""),
+);
+
+async function roundTrip(serialization: "json" | "advanced", message: any) {
+  const child = fork(helper, [], {
+    execArgv: [],
+    execPath: "node",
+    serialization,
+    stdio: ["ignore", "ignore", "ignore", "ipc"],
+  });
+  try {
+    const response = await new Promise<any>((resolve, reject) => {
+      child.once("error", reject);
+      child.once("message", resolve);
+      child.send(message);
+    });
+    const code = await new Promise((resolve) => child.once("close", resolve));
+    console.log(`${serialization} response:`, JSON.stringify(response));
+    console.log(`${serialization} close:`, code);
+  } finally {
+    if (child.connected) child.disconnect();
+    if (child.exitCode === null) child.kill();
+  }
+}
+
+try {
+  await roundTrip("json", { nested: { value: 7 }, items: ["a", 2, true] });
+  await roundTrip("advanced", {
+    nested: { value: 8 },
+    items: ["b", 3, false],
+    buffer: Buffer.from([0, 127, 255]),
+    map: new Map([["key", "value"]]),
+    bigint: 9007199254740993n,
+  });
+} finally {
+  rmSync(helper, { force: true });
+}

--- a/test-parity/node-suite/child_process/serialization/basic.ts
+++ b/test-parity/node-suite/child_process/serialization/basic.ts
@@ -21,6 +21,8 @@ writeFileSync(
     "date: message.date instanceof Date ? message.date.toISOString() : '',",
     "regexp: message.regexp instanceof RegExp ? message.regexp.toString() : '',",
     "uint16: message.uint16 instanceof Uint16Array ? Array.from(message.uint16).join('|') : '',",
+    "emptyBuffer: Buffer.isBuffer(message.emptyBuffer) ? String(message.emptyBuffer.length) : '',",
+    "emptyUint8: message.emptyUint8 instanceof Uint8Array ? String(message.emptyUint8.length) : '',",
     "bigint: typeof message.bigint === 'bigint' ? String(message.bigint) : '',",
     "error: message.error instanceof TypeError ? message.error.message : '',",
     "};",
@@ -62,6 +64,8 @@ try {
     date: new Date("2020-01-02T03:04:05.000Z"),
     regexp: /child-process/gi,
     uint16: new Uint16Array([1, 256, 65535]),
+    emptyBuffer: Buffer.alloc(0),
+    emptyUint8: new Uint8Array(0),
     bigint: 9007199254740993n,
     error: new TypeError("advanced-error"),
   });

--- a/test-parity/node-suite/child_process/serialization/basic.ts
+++ b/test-parity/node-suite/child_process/serialization/basic.ts
@@ -17,7 +17,12 @@ writeFileSync(
     "array: Array.isArray(message.items) ? message.items.join('|') : '',",
     "buffer: Buffer.isBuffer(message.buffer) ? message.buffer.toString('hex') : '',",
     "map: message.map instanceof Map ? Array.from(message.map.entries()).join('|') : '',",
+    "set: message.set instanceof Set ? Array.from(message.set.values()).join('|') : '',",
+    "date: message.date instanceof Date ? message.date.toISOString() : '',",
+    "regexp: message.regexp instanceof RegExp ? message.regexp.toString() : '',",
+    "uint16: message.uint16 instanceof Uint16Array ? Array.from(message.uint16).join('|') : '',",
     "bigint: typeof message.bigint === 'bigint' ? String(message.bigint) : '',",
+    "error: message.error instanceof TypeError ? message.error.message : '',",
     "};",
     "process.send(summary, () => process.disconnect());",
     "});",
@@ -53,7 +58,12 @@ try {
     items: ["b", 3, false],
     buffer: Buffer.from([0, 127, 255]),
     map: new Map([["key", "value"]]),
+    set: new Set(["first", "second"]),
+    date: new Date("2020-01-02T03:04:05.000Z"),
+    regexp: /child-process/gi,
+    uint16: new Uint16Array([1, 256, 65535]),
     bigint: 9007199254740993n,
+    error: new TypeError("advanced-error"),
   });
 } finally {
   rmSync(helper, { force: true });

--- a/test-parity/node-suite/child_process/sync/cwd-env-input.ts
+++ b/test-parity/node-suite/child_process/sync/cwd-env-input.ts
@@ -1,0 +1,64 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const cwd = join(tmpdir(), `perry-child-process-sync-${process.pid}`);
+mkdirSync(cwd);
+const expectedCwd = realpathSync(cwd);
+
+try {
+  const code = [
+    "const fs = require('node:fs');",
+    "const input = fs.readFileSync(0);",
+    "process.stdout.write(JSON.stringify({",
+    "cwd: process.cwd(),",
+    "text: input.toString('utf8'),",
+    "hex: input.toString('hex'),",
+    "value: process.env.PERRY_VALUE,",
+    "empty: process.env.PERRY_EMPTY,",
+    "missing: Object.hasOwn(process.env, 'PERRY_MISSING')",
+    "}));",
+  ].join("");
+  const env = {
+    ...process.env,
+    PERRY_VALUE: 42 as any,
+    PERRY_EMPTY: "",
+    PERRY_MISSING: undefined,
+  };
+
+  const spawned = spawnSync("node", ["-e", code], {
+    cwd,
+    env,
+    input: new Uint8Array([65, 0, 66]),
+    encoding: "utf8",
+  });
+  const spawnValue = JSON.parse(spawned.stdout);
+  console.log("spawnSync status:", spawned.status);
+  console.log("spawnSync cwd:", spawnValue.cwd === expectedCwd);
+  console.log("spawnSync input text:", JSON.stringify(spawnValue.text));
+  console.log("spawnSync input hex:", spawnValue.hex);
+  console.log(
+    "spawnSync env:",
+    spawnValue.value,
+    JSON.stringify(spawnValue.empty),
+    spawnValue.missing,
+  );
+  console.log("spawnSync stderr:", JSON.stringify(spawned.stderr));
+
+  const fileText = execFileSync(
+    "node",
+    [
+      "-e",
+      "process.stdout.write(process.cwd() + '|' + process.env.PERRY_VALUE)",
+    ],
+    {
+      cwd,
+      env,
+      encoding: "utf8",
+    },
+  );
+  console.log("execFileSync cwd/env:", fileText === `${expectedCwd}|42`);
+} finally {
+  rmSync(cwd, { recursive: true, force: true });
+}

--- a/test-parity/node-suite/child_process/sync/default-env.ts
+++ b/test-parity/node-suite/child_process/sync/default-env.ts
@@ -1,0 +1,20 @@
+import { spawnSync } from "node:child_process";
+
+const key = "PERRY_CHILD_SYNC_DEFAULT_ENV";
+const previous = process.env[key];
+process.env[key] = "sync-inherited";
+try {
+  const result = spawnSync(
+    "node",
+    ["-e", `process.stdout.write(process.env.${key} || 'missing')`],
+    {
+      encoding: "utf8",
+    },
+  );
+  console.log("status:", result.status);
+  console.log("stdout:", result.stdout);
+  console.log("stderr:", JSON.stringify(result.stderr));
+} finally {
+  if (previous === undefined) delete process.env[key];
+  else process.env[key] = previous;
+}

--- a/test-parity/node-suite/child_process/sync/encoding-aliases.ts
+++ b/test-parity/node-suite/child_process/sync/encoding-aliases.ts
@@ -1,0 +1,23 @@
+import { execFileSync, spawnSync } from "node:child_process";
+
+for (const encoding of ["utf8", "utf-8", "ascii", "latin1"] as const) {
+  const result = spawnSync(
+    "node",
+    ["-e", "process.stdout.write('plain-ascii')"],
+    {
+      encoding,
+    },
+  );
+  console.log(`spawnSync ${encoding}:`, result.status, result.stdout);
+}
+
+for (const encoding of ["utf8", "utf-8", "ascii", "latin1"] as const) {
+  const output = execFileSync(
+    "node",
+    ["-e", "process.stdout.write('file-ascii')"],
+    {
+      encoding,
+    },
+  );
+  console.log(`execFileSync ${encoding}:`, output);
+}

--- a/test-parity/node-suite/child_process/sync/env-values.ts
+++ b/test-parity/node-suite/child_process/sync/env-values.ts
@@ -1,0 +1,23 @@
+import { spawnSync } from "node:child_process";
+
+const result = spawnSync(
+  "node",
+  [
+    "-e",
+    "process.stdout.write(JSON.stringify({number:process.env.PERRY_NUMBER,boolean:process.env.PERRY_BOOLEAN,nullValue:process.env.PERRY_NULL,empty:process.env.PERRY_EMPTY,missing:Object.hasOwn(process.env,'PERRY_UNDEFINED')}))",
+  ],
+  {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PERRY_NUMBER: 42 as any,
+      PERRY_BOOLEAN: false as any,
+      PERRY_NULL: null as any,
+      PERRY_EMPTY: "",
+      PERRY_UNDEFINED: undefined,
+    },
+  },
+);
+console.log("status:", result.status);
+console.log("stdout:", result.stdout);
+console.log("stderr:", JSON.stringify(result.stderr));

--- a/test-parity/node-suite/child_process/sync/error-shell.ts
+++ b/test-parity/node-suite/child_process/sync/error-shell.ts
@@ -41,3 +41,25 @@ reportShell(
   "shell failure",
   `node -e "process.stderr.write('shell-err');process.exit(7)"`,
 );
+
+function reportUnicodeMaxBuffer(label: string, maxBuffer: number) {
+  try {
+    const stdout = execFileSync(
+      "node",
+      ["-e", "process.stdout.write('中文测试')"],
+      { encoding: "utf8", maxBuffer },
+    );
+    console.log(`${label} result:`, JSON.stringify(stdout));
+  } catch (error: any) {
+    console.log(`${label} error:`, error.name, error.code);
+    console.log(`${label} status:`, error.status);
+    console.log(`${label} signal:`, error.signal);
+    console.log(`${label} stdout:`, JSON.stringify(String(error.stdout)));
+    console.log(`${label} stderr:`, JSON.stringify(String(error.stderr)));
+  }
+}
+
+reportUnicodeMaxBuffer("unicode exact bytes", 12);
+reportUnicodeMaxBuffer("unicode one byte short", 11);
+reportUnicodeMaxBuffer("unicode one character", 3);
+reportUnicodeMaxBuffer("unicode zero", 0);

--- a/test-parity/node-suite/child_process/sync/error-shell.ts
+++ b/test-parity/node-suite/child_process/sync/error-shell.ts
@@ -1,0 +1,43 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const missing = join(tmpdir(), `perry-missing-cwd-${process.pid}`);
+const missingCwd = spawnSync("node", ["-e", ""], { cwd: missing });
+console.log("missing cwd status:", missingCwd.status);
+console.log("missing cwd signal:", missingCwd.signal);
+console.log("missing cwd pid type:", typeof missingCwd.pid);
+console.log(
+  "missing cwd error:",
+  missingCwd.error?.constructor?.name,
+  missingCwd.error?.code,
+);
+console.log("missing cwd error path:", missingCwd.error?.path);
+
+try {
+  execFileSync("node", ["-e", ""], { cwd: missing });
+  console.log("execFileSync missing cwd: no throw");
+} catch (error: any) {
+  console.log(
+    "execFileSync missing cwd:",
+    error?.constructor?.name,
+    error?.code,
+  );
+  console.log("execFileSync missing status:", error?.status);
+  console.log("execFileSync missing signal:", error?.signal);
+}
+
+function reportShell(label: string, command: string) {
+  const result = spawnSync(command, { shell: true, encoding: "utf8" });
+  console.log(`${label} status:`, result.status);
+  console.log(`${label} signal:`, result.signal);
+  console.log(`${label} error:`, result.error?.code ?? "none");
+  console.log(`${label} stdout:`, JSON.stringify(result.stdout));
+  console.log(`${label} stderr empty:`, result.stderr?.length === 0);
+}
+
+reportShell("shell success", `node -e "process.stdout.write('shell-ok')"`);
+reportShell(
+  "shell failure",
+  `node -e "process.stderr.write('shell-err');process.exit(7)"`,
+);

--- a/test-parity/node-suite/child_process/sync/execfile-args.ts
+++ b/test-parity/node-suite/child_process/sync/execfile-args.ts
@@ -1,0 +1,13 @@
+import { execFileSync } from "node:child_process";
+
+const args = ["space value", 'quote"value', "unicode-中文", "", "--flag=value"];
+const stdout = execFileSync(
+  "node",
+  [
+    "-e",
+    "process.stdout.write(JSON.stringify(process.argv.slice(1)))",
+    ...args,
+  ],
+  { encoding: "utf8" },
+);
+console.log("args:", stdout);

--- a/test-parity/node-suite/child_process/sync/input-views.ts
+++ b/test-parity/node-suite/child_process/sync/input-views.ts
@@ -1,0 +1,19 @@
+import { spawnSync } from "node:child_process";
+
+const code =
+  "const fs=require('node:fs');const b=fs.readFileSync(0);process.stdout.write(b.toString('hex'))";
+
+for (const [label, input] of [
+  ["buffer", Buffer.from([0, 1, 254, 255])],
+  ["uint8", new Uint8Array([2, 3, 252, 253])],
+  ["data-view", new DataView(new Uint8Array([4, 5, 250, 251]).buffer)],
+] as const) {
+  try {
+    const result = spawnSync("node", ["-e", code], { input, encoding: "utf8" });
+    console.log(`${label} status:`, result.status);
+    console.log(`${label} stdout:`, result.stdout);
+    console.log(`${label} error:`, result.error?.code ?? "none");
+  } catch (error: any) {
+    console.log(`${label} throw:`, error?.constructor?.name, error?.code);
+  }
+}

--- a/test-parity/node-suite/child_process/sync/large-output-chunks.ts
+++ b/test-parity/node-suite/child_process/sync/large-output-chunks.ts
@@ -1,0 +1,52 @@
+import { execFileSync } from "node:child_process";
+import { createReadStream, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const chunkSize = 50_000;
+const direct = execFileSync(
+  "node",
+  [
+    "-e",
+    `process.stdout.write('A'.repeat(${chunkSize})); process.stdout.write('B'.repeat(${chunkSize}));`,
+  ],
+  { encoding: "utf8", maxBuffer: 1024 * 1024 },
+);
+console.log("direct length:", direct.length);
+console.log(
+  "direct boundary:",
+  direct[0] + direct[chunkSize - 1] + direct[chunkSize] + direct.at(-1),
+);
+
+const dataFile = join(
+  tmpdir(),
+  `perry-child-process-large-output-${process.pid}.txt`,
+);
+const helperFile = join(
+  tmpdir(),
+  `perry-child-process-large-output-${process.pid}.js`,
+);
+const fileContent = `${"x".repeat(40_000)}\n${"y".repeat(40_000)}\n`;
+
+try {
+  writeFileSync(dataFile, fileContent);
+  writeFileSync(
+    helperFile,
+    "require('node:fs').createReadStream(process.argv[2]).pipe(process.stdout);",
+  );
+  const streamed = execFileSync("node", [helperFile, dataFile], {
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024,
+  });
+  console.log("stream length:", streamed.length);
+  console.log("stream exact:", streamed === fileContent);
+  console.log(
+    "stream boundary:",
+    JSON.stringify(
+      streamed[0] + streamed[40_000] + streamed[40_001] + streamed.at(-2),
+    ),
+  );
+} finally {
+  rmSync(dataFile, { force: true });
+  rmSync(helperFile, { force: true });
+}

--- a/test-parity/node-suite/child_process/sync/maxbuffer-infinity.ts
+++ b/test-parity/node-suite/child_process/sync/maxbuffer-infinity.ts
@@ -1,0 +1,22 @@
+import { execFileSync, spawnSync } from "node:child_process";
+
+const size = 256 * 1024;
+const code = `process.stdout.write('x'.repeat(${size}));process.stderr.write('y'.repeat(${size}))`;
+const spawned = spawnSync("node", ["-e", code], {
+  encoding: "utf8",
+  maxBuffer: Infinity,
+});
+console.log("spawnSync status:", spawned.status);
+console.log("spawnSync stdout length:", spawned.stdout.length);
+console.log("spawnSync stderr length:", spawned.stderr.length);
+console.log("spawnSync error:", spawned.error?.code ?? "none");
+
+const output = execFileSync(
+  "node",
+  ["-e", `process.stdout.write('z'.repeat(${size}))`],
+  {
+    encoding: "utf8",
+    maxBuffer: Infinity,
+  },
+);
+console.log("execFileSync length:", output.length);

--- a/test-parity/node-suite/child_process/sync/metacharacter-args.ts
+++ b/test-parity/node-suite/child_process/sync/metacharacter-args.ts
@@ -1,0 +1,20 @@
+import { spawnSync } from "node:child_process";
+
+const argument = "a&b|c<d>e;$HOME`value`*?";
+const program = "process.stdout.write(JSON.stringify(process.argv.slice(1)))";
+
+for (const [label, options] of [
+  ["default", { encoding: "utf8" }],
+  ["shell false", { encoding: "utf8", shell: false }],
+] as const) {
+  const result = spawnSync(
+    "node",
+    ["-e", program, argument, "space value"],
+    options,
+  );
+  console.log(`${label} status:`, result.status);
+  console.log(`${label} signal:`, result.signal);
+  console.log(`${label} error:`, result.error?.code ?? "none");
+  console.log(`${label} stdout:`, result.stdout);
+  console.log(`${label} stderr:`, JSON.stringify(result.stderr));
+}

--- a/test-parity/node-suite/child_process/sync/optional-args-metadata.ts
+++ b/test-parity/node-suite/child_process/sync/optional-args-metadata.ts
@@ -1,0 +1,32 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const cwd = join(tmpdir(), `perry-child-process-optional-${process.pid}`);
+mkdirSync(cwd);
+const expected = realpathSync(cwd);
+
+try {
+  for (const [label, args] of [
+    ["undefined", undefined],
+    ["null", null],
+    ["empty", []],
+  ] as const) {
+    const result = spawnSync(
+      "node",
+      args as any,
+      {
+        cwd,
+        encoding: "utf8",
+        env: { ...process.env, NODE_REPL_EXTERNAL_MODULE: "" },
+        input: "process.stdout.write(process.cwd())\n",
+      } as any,
+    );
+    console.log(`${label} status:`, result.status);
+    console.log(`${label} cwd:`, result.stdout === expected);
+    console.log(`${label} stderr empty:`, result.stderr === "");
+  }
+} finally {
+  rmSync(cwd, { recursive: true, force: true });
+}

--- a/test-parity/node-suite/child_process/sync/options-immutable.ts
+++ b/test-parity/node-suite/child_process/sync/options-immutable.ts
@@ -1,0 +1,33 @@
+import { spawnSync } from "node:child_process";
+
+const options = {
+  cwd: process.cwd(),
+  encoding: "utf8" as const,
+  env: { ...process.env, PERRY_SYNC_IMMUTABLE: "yes" },
+  input: "input",
+  windowsHide: true,
+};
+const before = JSON.stringify({
+  cwd: options.cwd,
+  encoding: options.encoding,
+  value: options.env.PERRY_SYNC_IMMUTABLE,
+  input: options.input,
+  windowsHide: options.windowsHide,
+});
+const result = spawnSync(
+  "node",
+  ["-e", "process.stdin.pipe(process.stdout)"],
+  options,
+);
+console.log("status:", result.status);
+console.log("stdout:", result.stdout);
+console.log(
+  "unchanged:",
+  JSON.stringify({
+    cwd: options.cwd,
+    encoding: options.encoding,
+    value: options.env.PERRY_SYNC_IMMUTABLE,
+    input: options.input,
+    windowsHide: options.windowsHide,
+  }) === before,
+);

--- a/test-parity/node-suite/child_process/sync/spawn-sync-stdio.ts
+++ b/test-parity/node-suite/child_process/sync/spawn-sync-stdio.ts
@@ -55,3 +55,15 @@ report(
     stdio: ["ignore", "ignore", "pipe"],
   }),
 );
+
+report(
+  "null entries",
+  spawnSync(
+    "node",
+    [
+      "-e",
+      "process.stdout.write('null-out'); process.stderr.write('null-err')",
+    ],
+    { encoding: "utf8", stdio: [null, null, null] },
+  ),
+);

--- a/test-parity/node-suite/child_process/sync/windows-hide.ts
+++ b/test-parity/node-suite/child_process/sync/windows-hide.ts
@@ -1,0 +1,17 @@
+import { execFileSync, spawnSync } from "node:child_process";
+
+for (const value of [undefined, null, false, true] as const) {
+  const result = spawnSync("node", ["-e", "process.stdout.write('ok')"], {
+    windowsHide: value,
+    encoding: "utf8",
+  });
+  console.log(`spawnSync ${String(value)}:`, result.status, result.stdout);
+}
+
+console.log(
+  "execFileSync true:",
+  execFileSync("node", ["-e", "process.stdout.write('file-ok')"], {
+    windowsHide: true,
+    encoding: "utf8",
+  }),
+);

--- a/test-parity/node-suite/child_process/validation/null-bytes.ts
+++ b/test-parity/node-suite/child_process/validation/null-bytes.ts
@@ -1,0 +1,35 @@
+import {
+  exec,
+  execFile,
+  execFileSync,
+  execSync,
+  fork,
+  spawn,
+  spawnSync,
+} from "node:child_process";
+
+function report(label: string, action: () => unknown) {
+  try {
+    const child: any = action();
+    if (child && typeof child === "object") {
+      child.on?.("error", () => {});
+      if (child.connected) child.disconnect();
+      child.kill?.();
+    }
+    console.log(`${label}: no throw`);
+  } catch (error: any) {
+    console.log(`${label}:`, error?.constructor?.name, error?.code);
+  }
+}
+
+report("exec command", () => exec("node\0 --version"));
+report("execSync command", () => execSync("node\0 --version"));
+report("execFile file", () => execFile("node\0", []));
+report("execFile arg", () => execFile("node", ["bad\0arg"]));
+report("execFileSync file", () => execFileSync("node\0", []));
+report("execFileSync arg", () => execFileSync("node", ["bad\0arg"]));
+report("spawn file", () => spawn("node\0", []));
+report("spawn arg", () => spawn("node", ["bad\0arg"]));
+report("spawnSync file", () => spawnSync("node\0", []));
+report("spawnSync arg", () => spawnSync("node", ["bad\0arg"]));
+report("fork module", () => fork("bad\0module.js"));

--- a/test-parity/node-suite/child_process/validation/options.ts
+++ b/test-parity/node-suite/child_process/validation/options.ts
@@ -1,4 +1,4 @@
-import { fork, spawn, spawnSync } from "node:child_process";
+import { ChildProcess, fork, spawn, spawnSync } from "node:child_process";
 
 function report(label: string, action: () => unknown) {
   try {
@@ -15,6 +15,46 @@ function report(label: string, action: () => unknown) {
 }
 
 report("spawn options number", () => spawn("node", [], 1 as any));
+
+console.log("constructor type:", typeof ChildProcess);
+const directChild = new ChildProcess();
+console.log("constructor instance:", directChild instanceof ChildProcess);
+console.log(
+  "constructor initial:",
+  directChild.pid === undefined,
+  directChild.connected,
+  directChild.killed,
+  directChild.exitCode,
+  directChild.signalCode,
+);
+for (const [label, options] of [
+  ["undefined options", undefined],
+  ["null options", null],
+  ["string options", "options"],
+  ["number options", 1],
+] as const) {
+  report(`constructor ${label}`, () => directChild.spawn(options as any));
+}
+for (const [label, file] of [
+  ["undefined file", undefined],
+  ["null file", null],
+  ["number file", 1],
+  ["object file", {}],
+] as const) {
+  report(`constructor ${label}`, () =>
+    new ChildProcess().spawn({ file } as any),
+  );
+}
+for (const [label, args] of [
+  ["null args", null],
+  ["number args", 1],
+  ["string args", "args"],
+  ["object args", {}],
+] as const) {
+  report(`constructor ${label}`, () =>
+    new ChildProcess().spawn({ file: "node", args } as any),
+  );
+}
 report("spawn cwd number", () => spawn("node", [], { cwd: 1 as any }));
 report("spawn timeout negative", () => spawn("node", [], { timeout: -1 }));
 report("spawn killSignal unknown", () =>

--- a/test-parity/node-suite/child_process/validation/options.ts
+++ b/test-parity/node-suite/child_process/validation/options.ts
@@ -1,0 +1,48 @@
+import { fork, spawn, spawnSync } from "node:child_process";
+
+function report(label: string, action: () => unknown) {
+  try {
+    const child: any = action();
+    if (child && typeof child === "object") {
+      child.on?.("error", () => {});
+      if (child.connected) child.disconnect();
+      child.kill?.();
+    }
+    console.log(`${label}: no throw`);
+  } catch (error: any) {
+    console.log(`${label}:`, error?.constructor?.name, error?.code);
+  }
+}
+
+report("spawn options number", () => spawn("node", [], 1 as any));
+report("spawn cwd number", () => spawn("node", [], { cwd: 1 as any }));
+report("spawn timeout negative", () => spawn("node", [], { timeout: -1 }));
+report("spawn killSignal unknown", () =>
+  spawn("node", [], { killSignal: "NOT_A_SIGNAL" }),
+);
+report("spawn serialization invalid", () =>
+  spawn("node", [], { serialization: "other" as any }),
+);
+report("spawn detached number", () =>
+  spawn("node", [], { detached: 1 as any }),
+);
+report("spawn shell number", () => spawn("node", [], { shell: 1 as any }));
+report("spawn argv0 number", () => spawn("node", [], { argv0: 1 as any }));
+report("spawnSync timeout string", () =>
+  spawnSync("node", [], { timeout: "1" as any }),
+);
+report("spawnSync maxBuffer negative", () =>
+  spawnSync("node", [], { maxBuffer: -1 }),
+);
+report("spawnSync detached number", () =>
+  spawnSync("missing-perry-command", [], { detached: 1 as any }),
+);
+report("spawnSync shell number", () =>
+  spawnSync("missing-perry-command", [], { shell: 1 as any }),
+);
+report("spawnSync argv0 number", () =>
+  spawnSync("missing-perry-command", [], { argv0: 1 as any }),
+);
+report("fork serialization invalid", () =>
+  fork("unused.js", [], { serialization: "other" as any }),
+);

--- a/test-parity/node-suite/child_process/validation/options.ts
+++ b/test-parity/node-suite/child_process/validation/options.ts
@@ -46,3 +46,48 @@ report("spawnSync argv0 number", () =>
 report("fork serialization invalid", () =>
   fork("unused.js", [], { serialization: "other" as any }),
 );
+
+for (const value of [0, true, "arg", {}]) {
+  report(`fork args ${String(value)}`, () => fork("unused.js", value as any));
+}
+for (const value of [0, true, "options", []]) {
+  report(`fork options ${String(value)}`, () =>
+    fork("unused.js", [], value as any),
+  );
+}
+
+report("spawn stdio string", () =>
+  spawn("node", [], { stdio: "other" as any }),
+);
+report("spawn stdio number", () => spawn("node", [], { stdio: 600 as any }));
+report("spawn stdio entry", () =>
+  spawn("node", [], { stdio: ["other"] as any }),
+);
+report("spawn stdio object", () => spawn("node", [], { stdio: [{}] as any }));
+report("spawn two ipc", () =>
+  spawn("node", [], {
+    stdio: ["ignore", "ignore", "ignore", "ipc", "ipc"],
+  }),
+);
+report("spawnSync ipc", () =>
+  spawnSync("node", [], {
+    stdio: ["ignore", "ignore", "ignore", "ipc"],
+  }),
+);
+
+const killChild = spawn("node", ["-e", "setInterval(() => {}, 1000)"], {
+  stdio: "ignore",
+});
+function reportKill(label: string, signal: any) {
+  try {
+    console.log(`${label}:`, killChild.kill(signal));
+  } catch (error: any) {
+    console.log(`${label}:`, error?.constructor?.name, error?.code);
+  }
+}
+reportKill("kill unknown name", "NOT_A_SIGNAL");
+reportKill("kill zero", 0);
+reportKill("kill fraction", 3.14);
+reportKill("kill object", {});
+console.log("kill cleanup:", killChild.kill());
+await new Promise((resolve) => killChild.on("close", resolve));

--- a/test-parity/node_suite_baseline.json
+++ b/test-parity/node_suite_baseline.json
@@ -1,12 +1,12 @@
 {
   "_schema": {
     "description": "Floor baseline for scripts/node_suite_regression_check.py. Each module's run must produce pass >= floor.pass; dropping below is a regression (exit 1). Improvements are always accepted and reported as ratchet candidates. Captured in the node-26 environment with scripts/node_suite_run.py (pre-warm + fast/slow lanes).",
-    "oracle": "node v26.3.0 on Linux (the box)",
-    "note": "Deterministic modules are floored at full pass. Timing/racy modules (http2, net, stream, diagnostics_channel, fs-promises) carry a small margin below observed pass so ordinary flake does not false-alarm; the guard still catches real regressions, which are large (e.g. dns 6->0, http 19->9). node_suite_run.normalize() scrubs environment-variant tokens (console.time hrtime durations, stack-trace frame lines) symmetrically before the stdout compare, so console is floored at full pass (119) on its deterministic content. http is verified 19/19 in isolation but the full-suite harness flakes to 17 under port contention, so it is floored at 17 (flake margin, not a regression); a real http break is a much larger drop. Floors were refreshed from a clean node-26 run at 2810/2863 (98.1%), then the deterministic child_process floor was measured independently at 28/34 on Node 26.5.0."
+    "oracle": "node v26.5.0 (pinned by .node-version)",
+    "note": "Deterministic modules are floored at full pass. Timing/racy modules (http2, net, stream, diagnostics_channel, fs-promises) carry a small margin below observed pass so ordinary flake does not false-alarm; the guard still catches real regressions, which are large (e.g. dns 6->0, http 19->9). node_suite_run.normalize() scrubs environment-variant tokens (console.time hrtime durations, stack-trace frame lines) symmetrically before the stdout compare, so console is floored at full pass (119) on its deterministic content. http is verified 19/19 in isolation but the full-suite harness flakes to 17 under port contention, so it is floored at 17 (flake margin, not a regression); a real http break is a much larger drop. Floors were refreshed from a clean node-26 run at 2810/2863 (98.1%), then the deterministic child_process floor was measured independently at 40/49 on Node 26.5.0."
   },
   "overall": {
-    "pass": 2812,
-    "total": 2871,
+    "pass": 2824,
+    "total": 2886,
     "pct": 97.9
   },
   "modules": {
@@ -27,8 +27,8 @@
       "total": 134
     },
     "child_process": {
-      "pass": 28,
-      "total": 34
+      "pass": 40,
+      "total": 49
     },
     "cluster": {
       "pass": 1,

--- a/test-parity/node_suite_baseline.json
+++ b/test-parity/node_suite_baseline.json
@@ -2,11 +2,11 @@
   "_schema": {
     "description": "Floor baseline for scripts/node_suite_regression_check.py. Each module's run must produce pass >= floor.pass; dropping below is a regression (exit 1). Improvements are always accepted and reported as ratchet candidates. Captured in the node-26 environment with scripts/node_suite_run.py (pre-warm + fast/slow lanes).",
     "oracle": "node v26.5.0 (pinned by .node-version)",
-    "note": "Deterministic modules are floored at full pass. Timing/racy modules (http2, net, stream, diagnostics_channel, fs-promises) carry a small margin below observed pass so ordinary flake does not false-alarm; the guard still catches real regressions, which are large (e.g. dns 6->0, http 19->9). node_suite_run.normalize() scrubs environment-variant tokens (console.time hrtime durations, stack-trace frame lines) symmetrically before the stdout compare, so console is floored at full pass (119) on its deterministic content. http is verified 19/19 in isolation but the full-suite harness flakes to 17 under port contention, so it is floored at 17 (flake margin, not a regression); a real http break is a much larger drop. Floors were refreshed from a clean node-26 run at 2810/2863 (98.1%), then the deterministic child_process floor was measured independently at 40/49 on Node 26.5.0. The overall summary is the sum of the committed per-module floors."
+    "note": "Deterministic modules are floored at full pass. Timing/racy modules (http2, net, stream, diagnostics_channel, fs-promises) carry a small margin below observed pass so ordinary flake does not false-alarm; the guard still catches real regressions, which are large (e.g. dns 6->0, http 19->9). node_suite_run.normalize() scrubs environment-variant tokens (console.time hrtime durations, stack-trace frame lines) symmetrically before the stdout compare, so console is floored at full pass (119) on its deterministic content. http is verified 19/19 in isolation but the full-suite harness flakes to 17 under port contention, so it is floored at 17 (flake margin, not a regression); a real http break is a much larger drop. Floors were refreshed from a clean node-26 run at 2810/2863 (98.1%), then the deterministic child_process floor was measured independently at 43/53 on Node 26.5.0. The overall summary is the sum of the committed per-module floors."
   },
   "overall": {
-    "pass": 2815,
-    "total": 2886,
+    "pass": 2818,
+    "total": 2890,
     "pct": 97.5
   },
   "modules": {
@@ -27,8 +27,8 @@
       "total": 134
     },
     "child_process": {
-      "pass": 40,
-      "total": 49
+      "pass": 43,
+      "total": 53
     },
     "cluster": {
       "pass": 1,

--- a/test-parity/node_suite_baseline.json
+++ b/test-parity/node_suite_baseline.json
@@ -2,12 +2,12 @@
   "_schema": {
     "description": "Floor baseline for scripts/node_suite_regression_check.py. Each module's run must produce pass >= floor.pass; dropping below is a regression (exit 1). Improvements are always accepted and reported as ratchet candidates. Captured in the node-26 environment with scripts/node_suite_run.py (pre-warm + fast/slow lanes).",
     "oracle": "node v26.3.0 on Linux (the box)",
-    "note": "Deterministic modules are floored at full pass. Timing/racy modules (http2, net, stream, diagnostics_channel, fs-promises) carry a small margin below observed pass so ordinary flake does not false-alarm; the guard still catches real regressions, which are large (e.g. dns 6->0, http 19->9). node_suite_run.normalize() scrubs environment-variant tokens (console.time hrtime durations, stack-trace frame lines) symmetrically before the stdout compare, so console is floored at full pass (119) on its deterministic content. http is verified 19/19 in isolation but the full-suite harness flakes to 17 under port contention, so it is floored at 17 (flake margin, not a regression); a real http break is a much larger drop. Floors refreshed from a clean node-26 run at 2810/2863 (98.1%)."
+    "note": "Deterministic modules are floored at full pass. Timing/racy modules (http2, net, stream, diagnostics_channel, fs-promises) carry a small margin below observed pass so ordinary flake does not false-alarm; the guard still catches real regressions, which are large (e.g. dns 6->0, http 19->9). node_suite_run.normalize() scrubs environment-variant tokens (console.time hrtime durations, stack-trace frame lines) symmetrically before the stdout compare, so console is floored at full pass (119) on its deterministic content. http is verified 19/19 in isolation but the full-suite harness flakes to 17 under port contention, so it is floored at 17 (flake margin, not a regression); a real http break is a much larger drop. Floors were refreshed from a clean node-26 run at 2810/2863 (98.1%), then the deterministic child_process floor was measured independently at 28/34 on Node 26.5.0."
   },
   "overall": {
-    "pass": 2810,
-    "total": 2863,
-    "pct": 98.1
+    "pass": 2812,
+    "total": 2871,
+    "pct": 97.9
   },
   "modules": {
     "assert": {
@@ -27,8 +27,8 @@
       "total": 134
     },
     "child_process": {
-      "pass": 26,
-      "total": 26
+      "pass": 28,
+      "total": 34
     },
     "cluster": {
       "pass": 1,

--- a/test-parity/node_suite_baseline.json
+++ b/test-parity/node_suite_baseline.json
@@ -2,12 +2,12 @@
   "_schema": {
     "description": "Floor baseline for scripts/node_suite_regression_check.py. Each module's run must produce pass >= floor.pass; dropping below is a regression (exit 1). Improvements are always accepted and reported as ratchet candidates. Captured in the node-26 environment with scripts/node_suite_run.py (pre-warm + fast/slow lanes).",
     "oracle": "node v26.5.0 (pinned by .node-version)",
-    "note": "Deterministic modules are floored at full pass. Timing/racy modules (http2, net, stream, diagnostics_channel, fs-promises) carry a small margin below observed pass so ordinary flake does not false-alarm; the guard still catches real regressions, which are large (e.g. dns 6->0, http 19->9). node_suite_run.normalize() scrubs environment-variant tokens (console.time hrtime durations, stack-trace frame lines) symmetrically before the stdout compare, so console is floored at full pass (119) on its deterministic content. http is verified 19/19 in isolation but the full-suite harness flakes to 17 under port contention, so it is floored at 17 (flake margin, not a regression); a real http break is a much larger drop. Floors were refreshed from a clean node-26 run at 2810/2863 (98.1%), then the deterministic child_process floor was measured independently at 40/49 on Node 26.5.0."
+    "note": "Deterministic modules are floored at full pass. Timing/racy modules (http2, net, stream, diagnostics_channel, fs-promises) carry a small margin below observed pass so ordinary flake does not false-alarm; the guard still catches real regressions, which are large (e.g. dns 6->0, http 19->9). node_suite_run.normalize() scrubs environment-variant tokens (console.time hrtime durations, stack-trace frame lines) symmetrically before the stdout compare, so console is floored at full pass (119) on its deterministic content. http is verified 19/19 in isolation but the full-suite harness flakes to 17 under port contention, so it is floored at 17 (flake margin, not a regression); a real http break is a much larger drop. Floors were refreshed from a clean node-26 run at 2810/2863 (98.1%), then the deterministic child_process floor was measured independently at 40/49 on Node 26.5.0. The overall summary is the sum of the committed per-module floors."
   },
   "overall": {
-    "pass": 2824,
+    "pass": 2815,
     "total": 2886,
-    "pct": 97.9
+    "pct": 97.5
   },
   "modules": {
     "assert": {


### PR DESCRIPTION
## Summary

- add 27 granular `node:child_process` fixtures, expanding the suite from 26 to 53 cases
- cover validation, cwd/env behavior, sync input/result shapes, lifecycle and callback ordering, stdio dataflow/flushing, timeout behavior, URL forks, shell/error behavior, and JSON/advanced serialization
- use controlled Node helper programs and deterministic cleanup
- document the current Node, Deno, and Bun primary-source comparison, stable Perry mismatches, stopping judgment, and platform/slow exclusions
- ratchet the measured child-process floor from 26/26 to 43/53 and align oracle metadata with pinned Node 26.5.0

## Coverage added

- validation: embedded nulls; direct `ChildProcess` constructor; option types/ranges; fork overloads; stdio layouts; duplicate/sync IPC; kill signals
- sync: cwd/default env/env coercion; missing cwd; optional args; Buffer/Uint8Array/DataView input; encoding aliases; literal metacharacter arguments; argument preservation; option immutability; `windowsHide`; basic shell execution; Unicode and infinite maxBuffer; multi-chunk/streamed output above 64 KiB
- async: spawn metadata/default env/optional args; missing-command completion; option immutability; exit/kill lifecycle; `exec`/`execFile` success and promisified shapes; callback/stream lifecycle ordering; non-expiring timeout options; text/binary stdin; stream piping; fd3; bounded multi-chunk stdio flushing; WHATWG URL fork
- serialization: JSON plus advanced Buffer, empty/non-empty typed arrays, Map, Set, Date, RegExp, BigInt, and Error values

## Verification

- `NPM_CONFIG_CACHE=/tmp/perry-npm-cache npx -y prettier@3.6.2 --write <changed files>` — passed
- `git diff --check` — passed
- baseline aggregate validation — 2818/2890 equals the sum of all committed module floors
- `./run_parity_tests.sh --suite node-suite --module child_process` with Node 26.5.0 — 42 pass, 10 output mismatches, 0 compile failures, 0 crashes, 1 pre-existing host Node failure, 53 fixtures (80.7% of executed cases)
- `NODE_BIN="$(command -v node)" python3 scripts/node_suite_run.py "$PWD/target/release/perry" "$PWD" child_process` with Node 26.5.0 — 43/53 (81.1%), `diff=10`

## Diagnostic mismatches

Nine expanded fixtures expose stable differences:

- embedded-null commands/files/arguments are accepted rather than rejected
- invalid options, fork overloads, stdio/IPC layouts, and signals are accepted rather than rejected; direct `ChildProcess` instances lack Node's prototype identity, initial state, and coded validation errors
- async `execFile` invokes its callback but returns no `ChildProcess` handle; promisified `exec`/`execFile` results also omit `.child`
- async spawn metadata/status match but stdout is empty for direct, inherited-env, optional-args, and immutable-options probes; missing-command errors do not reach `close`
- async stdin writes/statuses match but readable/end state, output dataflow, stream piping, and fd3 differ
- custom async cwd/env exits with status 0 but captures no stdout
- WHATWG URL fork never receives the helper IPC message and ends with unsettled top-level await
- missing-cwd sync errors lack Node's error shape, basic shell execution is treated as ENOENT, and Unicode maxBuffer termination/zero semantics differ
- advanced IPC preserves Buffer, Date, typed arrays, and BigInt but loses Map, Set, RegExp, and Error brands/content

The existing AbortSignal fixture remains the tenth mismatch and now also demonstrates Perry returning `true` from `kill()` after close where Node returns `false`.

## Upstream scope and exclusions

Compared against Node.js `608112affae2cf44d2f8a0a6bfe7967193b459c8`, Deno `f8a17c8171569fa2870d740030aaa59c91fdf9ee`, and Bun `c4fad462e7dc20e5e9780f848db42e1e2f52186d`.

Deferred to separate platform/slow assessments: fork/IPC races and handle transfer beyond deterministic URL/serialization probes; socket/server and cluster/dgram integration; exhaustive signal, UID/GID, detached and scheduler-sensitive behavior; Windows quoting/batch/overlapped stdio; custom-shell discovery; EMFILE/resource exhaustion; large IPC framing; host-object/circular serialization; and multi-megabyte stress.
