### PR TITLE
fix(intl): resolve and apply the host time zone in DateTimeFormat

### DIFF
--- a/crates/perry-runtime/src/date.rs
+++ b/crates/perry-runtime/src/date.rs
@@ -244,6 +244,100 @@ fn timestamp_to_local_components(secs: i64) -> (i32, u32, u32, u32, u32, u32, i6
     }
 }
 
+/// The host IANA time-zone identifier (e.g. `"Europe/Berlin"`), matching what
+/// Node returns from `Intl.DateTimeFormat().resolvedOptions().timeZone`. Honors
+/// the `TZ` environment variable first (like libc / Node), then the OS default
+/// via the `/etc/localtime` symlink; falls back to `"UTC"`. Cached for the
+/// process lifetime (the host zone doesn't change under us).
+pub fn host_time_zone_name() -> &'static str {
+    use std::sync::OnceLock;
+    static TZ: OnceLock<String> = OnceLock::new();
+    TZ.get_or_init(|| {
+        if let Some(raw) = std::env::var_os("TZ") {
+            if let Some(s) = raw.to_str() {
+                // A `TZ` of `:Europe/Berlin` / `:/path/zoneinfo/Europe/Berlin`
+                // (leading colon) or a bare IANA id. Empty `TZ` means UTC.
+                let s = s.trim().strip_prefix(':').unwrap_or_else(|| s.trim());
+                if s.is_empty() {
+                    return "UTC".to_string();
+                }
+                if let Some(name) = iana_id_from_zoneinfo_path(s) {
+                    return name;
+                }
+                return s.to_string();
+            }
+        }
+        #[cfg(unix)]
+        {
+            if let Ok(target) = std::fs::read_link("/etc/localtime") {
+                if let Some(name) = iana_id_from_zoneinfo_path(&target.to_string_lossy()) {
+                    return name;
+                }
+            }
+        }
+        "UTC".to_string()
+    })
+    .as_str()
+}
+
+/// Extract the IANA id (`Europe/Berlin`) after a `.../zoneinfo/` path segment.
+/// Returns `None` when the path has no `zoneinfo/` component (e.g. a bare id).
+fn iana_id_from_zoneinfo_path(p: &str) -> Option<String> {
+    const MARKER: &str = "zoneinfo/";
+    p.rfind(MARKER).map(|i| p[i + MARKER.len()..].to_string())
+}
+
+/// Parse a fixed UTC offset like `"+02:00"`, `"-0500"`, `"+03"` into seconds
+/// east of UTC. Returns `None` for named zones / non-offset strings.
+fn parse_fixed_offset(tz: &str) -> Option<i64> {
+    let bytes = tz.as_bytes();
+    let sign = match bytes.first()? {
+        b'+' => 1,
+        b'-' => -1,
+        _ => return None,
+    };
+    let digits: String = tz[1..].chars().filter(|c| c.is_ascii_digit()).collect();
+    let (h, m) = match digits.len() {
+        1 | 2 => (digits.parse::<i64>().ok()?, 0),
+        3 => (digits[..1].parse().ok()?, digits[1..].parse().ok()?),
+        4 => (digits[..2].parse().ok()?, digits[2..].parse().ok()?),
+        _ => return None,
+    };
+    if h > 23 || m > 59 {
+        return None;
+    }
+    Some(sign * (h * 3600 + m * 60))
+}
+
+/// UTC offset (seconds east of UTC) for time-zone `tz` at instant `secs`,
+/// DST-aware, matching the OS tz database — the amount to add to a UTC timestamp
+/// to get the wall-clock time in `tz`. `UTC`/`GMT`/empty are 0; a fixed numeric
+/// offset is parsed directly; the process's own host zone is read straight from
+/// libc (thread-safe — it uses the process `TZ`). A named zone that is NOT the
+/// host zone can't be resolved without mutating the global libc `TZ` state
+/// (unsafe in a threaded runtime), so it falls back to 0 (UTC) — callers that
+/// need arbitrary named zones should gate a tzdb path. The common cases —
+/// default (host) zone, explicit host zone, UTC, and numeric offsets — are exact.
+pub fn zone_offset_seconds(tz: &str, secs: i64) -> i64 {
+    if tz.is_empty()
+        || tz.eq_ignore_ascii_case("UTC")
+        || tz.eq_ignore_ascii_case("GMT")
+        || tz == "Etc/UTC"
+        || tz == "Etc/GMT"
+    {
+        return 0;
+    }
+    if let Some(off) = parse_fixed_offset(tz) {
+        return off;
+    }
+    if tz == host_time_zone_name() {
+        // The process is already running in this zone; libc localtime applies
+        // the correct (DST-aware) offset for `secs`.
+        return timestamp_to_local_components(secs).6;
+    }
+    0
+}
+
 /// Get current timestamp in milliseconds (Date.now())
 #[no_mangle]
 pub extern "C" fn js_date_now() -> f64 {

--- a/crates/perry-runtime/src/intl.rs
+++ b/crates/perry-runtime/src/intl.rs
@@ -25,6 +25,9 @@ mod locale;
 mod locales;
 use locales::{get_canonical_locales_thunk, supported_values_of_thunk};
 mod date_collator;
+mod date_names;
+mod time_zone;
+pub(crate) use time_zone::{canonicalize_named_time_zone, resolved_date_time_zone};
 mod install;
 use install::install_constructor;
 mod subclass;
@@ -313,26 +316,6 @@ fn coerce_option_string(value: f64) -> Option<String> {
 
 fn get_option_string(options: f64, key: &str) -> Option<String> {
     coerce_option_string(get_option_value(options, key))
-}
-
-/// Resolve the effective time zone for a `toLocaleString`-style call: the
-/// `timeZone` option if present, otherwise the host zone (ECMA-402
-/// DefaultTimeZone). Canonicalized the same way the `Intl.DateTimeFormat`
-/// constructor does. Used to shift a `Date`'s UTC instant into wall-clock time
-/// before formatting (a `Date` is an instant, so `toLocaleString` renders it in
-/// the resolved zone — unlike a zone-agnostic `Temporal.PlainDateTime`).
-pub(crate) fn resolved_date_time_zone(options: f64) -> String {
-    let tz = get_option_string(options, "timeZone")
-        .unwrap_or_else(|| crate::date::host_time_zone_name().to_string());
-    if matches!(tz.as_bytes().first(), Some(b'+') | Some(b'-')) {
-        if is_valid_offset_time_zone(&tz) {
-            canonicalize_offset_time_zone(&tz)
-        } else {
-            tz
-        }
-    } else {
-        canonicalize_named_time_zone(&tz).unwrap_or(tz)
-    }
 }
 
 /// As `get_option_string`, but for the Unicode locale-extension keys (`calendar`,
@@ -960,71 +943,6 @@ fn dt_component_option(
 /// IANA zone identifiers pass; the malformed names ECMA-402 rejects
 /// (`"MEZ"`, `"invalid"`, `"Europe/İstanbul"`, …) do not. Returns the (best
 /// effort, un-recased) canonical identifier, or `None` to signal `RangeError`.
-fn canonicalize_named_time_zone(tz: &str) -> Option<String> {
-    if tz.eq_ignore_ascii_case("UTC") || tz.eq_ignore_ascii_case("Etc/UTC") {
-        return Some("UTC".to_string());
-    }
-    if !tz.is_ascii() {
-        return None;
-    }
-    // Legacy single-component IANA zones / links that carry no '/'.
-    const SINGLE_WORD_ZONES: &[&str] = &[
-        "GMT",
-        "GMT0",
-        "Zulu",
-        "Universal",
-        "UCT",
-        "Greenwich",
-        "Navajo",
-        "Eire",
-        "Iceland",
-        "Cuba",
-        "Egypt",
-        "Hongkong",
-        "Iran",
-        "Israel",
-        "Japan",
-        "Jamaica",
-        "Libya",
-        "Poland",
-        "Portugal",
-        "PRC",
-        "Singapore",
-        "Turkey",
-        "ROC",
-        "ROK",
-        "W-SU",
-        "Factory",
-        "EST",
-        "MST",
-        "HST",
-        "EST5EDT",
-        "CST6CDT",
-        "MST7MDT",
-        "PST8PDT",
-    ];
-    if SINGLE_WORD_ZONES.iter().any(|z| z.eq_ignore_ascii_case(tz)) {
-        return Some(tz.to_string());
-    }
-    let segments: Vec<&str> = tz.split('/').collect();
-    if segments.len() < 2 {
-        return None;
-    }
-    let mut has_alpha = false;
-    for seg in &segments {
-        if seg.is_empty() {
-            return None;
-        }
-        for b in seg.bytes() {
-            if b.is_ascii_alphabetic() {
-                has_alpha = true;
-            } else if !(b.is_ascii_alphanumeric() || b == b'_' || b == b'+' || b == b'-') {
-                return None;
-            }
-        }
-    }
-    has_alpha.then(|| tz.to_string())
-}
 fn make_instance(closure: *const ClosureHeader, kind: &str, locales: f64, options: f64) -> f64 {
     let locale = locale_or_default(locales);
     let obj = js_object_alloc(0, 8);
@@ -1154,25 +1072,13 @@ fn make_instance(closure: *const ClosureHeader, kind: &str, locales: f64, option
                 set_internal_field(obj, KEY_HOUR_CYCLE, string_value(&hc));
             }
             // ECMA-402 DefaultTimeZone(): when no `timeZone` option is given, use
-            // the HOST time zone (Node returns e.g. "Europe/Berlin"), not UTC.
-            let mut time_zone = get_option_string(options, "timeZone")
-                .unwrap_or_else(|| crate::date::host_time_zone_name().to_string());
-            // A timeZone that begins with a sign is an offset identifier: it must
-            // be syntactically valid (ECMA-402 rejects malformed offsets with a
-            // RangeError), and is then canonicalized to `±HH:mm` so
-            // `resolvedOptions().timeZone` matches FormatOffsetTimeZoneIdentifier.
-            // Named zones are validated structurally (Perry has no tz database).
-            if matches!(time_zone.as_bytes().first(), Some(b'+') | Some(b'-')) {
-                if !is_valid_offset_time_zone(&time_zone) {
-                    throw_range_error(&format!("Invalid time zone specified: {time_zone}"));
-                }
-                time_zone = canonicalize_offset_time_zone(&time_zone);
-            } else {
-                match canonicalize_named_time_zone(&time_zone) {
-                    Some(canonical) => time_zone = canonical,
-                    None => throw_range_error(&format!("Invalid time zone specified: {time_zone}")),
-                }
-            }
+            // the HOST time zone (Node returns e.g. "Europe/Berlin"), not UTC —
+            // and an explicit invalid zone is a RangeError while an unrecognized
+            // host default falls back to UTC. `resolved_date_time_zone` is the
+            // single source of that logic (it canonicalizes offsets to `±HH:mm`
+            // for FormatOffsetTimeZoneIdentifier and validates named zones
+            // structurally, Perry having no tz database).
+            let time_zone = resolved_date_time_zone(options);
             set_internal_field(obj, KEY_TIME_ZONE, string_value(&time_zone));
             // Date/time component options (ECMA-402 Table 7), read in order. Each
             // out-of-range value is a RangeError.

--- a/crates/perry-runtime/src/intl.rs
+++ b/crates/perry-runtime/src/intl.rs
@@ -315,6 +315,26 @@ fn get_option_string(options: f64, key: &str) -> Option<String> {
     coerce_option_string(get_option_value(options, key))
 }
 
+/// Resolve the effective time zone for a `toLocaleString`-style call: the
+/// `timeZone` option if present, otherwise the host zone (ECMA-402
+/// DefaultTimeZone). Canonicalized the same way the `Intl.DateTimeFormat`
+/// constructor does. Used to shift a `Date`'s UTC instant into wall-clock time
+/// before formatting (a `Date` is an instant, so `toLocaleString` renders it in
+/// the resolved zone — unlike a zone-agnostic `Temporal.PlainDateTime`).
+pub(crate) fn resolved_date_time_zone(options: f64) -> String {
+    let tz = get_option_string(options, "timeZone")
+        .unwrap_or_else(|| crate::date::host_time_zone_name().to_string());
+    if matches!(tz.as_bytes().first(), Some(b'+') | Some(b'-')) {
+        if is_valid_offset_time_zone(&tz) {
+            canonicalize_offset_time_zone(&tz)
+        } else {
+            tz
+        }
+    } else {
+        canonicalize_named_time_zone(&tz).unwrap_or(tz)
+    }
+}
+
 /// As `get_option_string`, but for the Unicode locale-extension keys (`calendar`,
 /// `numberingSystem`) whose value is validated for *well-formedness* rather than
 /// against a closed enum. ECMA-402 coerces `null` to the string `"null"` — a
@@ -1133,8 +1153,10 @@ fn make_instance(closure: *const ClosureHeader, kind: &str, locales: f64, option
                 }
                 set_internal_field(obj, KEY_HOUR_CYCLE, string_value(&hc));
             }
-            let mut time_zone =
-                get_option_string(options, "timeZone").unwrap_or_else(|| "UTC".to_string());
+            // ECMA-402 DefaultTimeZone(): when no `timeZone` option is given, use
+            // the HOST time zone (Node returns e.g. "Europe/Berlin"), not UTC.
+            let mut time_zone = get_option_string(options, "timeZone")
+                .unwrap_or_else(|| crate::date::host_time_zone_name().to_string());
             // A timeZone that begins with a sign is an offset identifier: it must
             // be syntactically valid (ECMA-402 rejects malformed offsets with a
             // RangeError), and is then canonicalized to `±HH:mm` so

--- a/crates/perry-runtime/src/intl/date_collator.rs
+++ b/crates/perry-runtime/src/intl/date_collator.rs
@@ -136,13 +136,31 @@ fn date_time_format_to_parts_value(obj: *const ObjectHeader, value: f64) -> f64 
 }
 
 /// Decompose the formatted output into typed parts matching `format_ms_with_dtf_obj`.
+/// Shift a UTC epoch-second count into the DTF instance's configured time zone,
+/// so `timestamp_to_components` yields the zone-local wall-clock fields. Only
+/// applied to plain `Date`/timestamp values — Temporal values carry their own
+/// zone/date semantics — so callers pass `temporal_kind` and get `secs`
+/// unchanged for any Temporal input.
+fn dtf_zone_local_secs(
+    obj: *const ObjectHeader,
+    secs: i64,
+    temporal_kind: Option<crate::temporal::TemporalKind>,
+) -> i64 {
+    if temporal_kind.is_some() {
+        return secs;
+    }
+    let tz = get_string_field(obj, KEY_TIME_ZONE)
+        .unwrap_or_else(|| crate::date::host_time_zone_name().to_string());
+    secs + crate::date::zone_offset_seconds(&tz, secs)
+}
+
 fn format_parts_with_dtf_obj(
     obj: *const ObjectHeader,
     ms: f64,
     temporal_kind: Option<crate::temporal::TemporalKind>,
 ) -> Vec<(&'static str, String)> {
     use crate::temporal::TemporalKind::*;
-    let secs = (ms as i64).div_euclid(1000);
+    let secs = dtf_zone_local_secs(obj, (ms as i64).div_euclid(1000), temporal_kind);
     let (year, month, day, hour, minute, second) = crate::date::timestamp_to_components(secs);
     let mi = month.saturating_sub(1).min(11) as usize;
 
@@ -1172,7 +1190,7 @@ fn format_ms_with_dtf_obj(
     temporal_kind: Option<crate::temporal::TemporalKind>,
 ) -> String {
     use crate::temporal::TemporalKind::*;
-    let secs = (ms as i64).div_euclid(1000);
+    let secs = dtf_zone_local_secs(obj, (ms as i64).div_euclid(1000), temporal_kind);
     let (year, month, day, hour, minute, second) = crate::date::timestamp_to_components(secs);
 
     let date_style = get_string_field(obj, KEY_DATE_STYLE);
@@ -1773,7 +1791,10 @@ pub(crate) fn date_time_format_resolved_options_object(obj: *const ObjectHeader)
     set_field(
         out,
         "timeZone",
-        string_value(&get_string_field(obj, KEY_TIME_ZONE).unwrap_or_else(|| "UTC".to_string())),
+        string_value(
+            &get_string_field(obj, KEY_TIME_ZONE)
+                .unwrap_or_else(|| crate::date::host_time_zone_name().to_string()),
+        ),
     );
     // hourCycle / hour12 surface only when an hour field is present. With no tz
     // /CLDR data, the default cycle is the 12-hour clock (`h11` for `ja`, else

--- a/crates/perry-runtime/src/intl/date_collator.rs
+++ b/crates/perry-runtime/src/intl/date_collator.rs
@@ -811,42 +811,13 @@ fn validate_temporal_dtf_overlap(kind: crate::temporal::TemporalKind, obj: *cons
 }
 
 // ---- Locale-aware date/time formatting (DTF and Temporal.toLocaleString) ---
-
-const MONTH_FULL: &[&str] = &[
-    "January",
-    "February",
-    "March",
-    "April",
-    "May",
-    "June",
-    "July",
-    "August",
-    "September",
-    "October",
-    "November",
-    "December",
-];
-const MONTH_ABBR: &[&str] = &[
-    "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
-];
-const WEEKDAY_FULL: &[&str] = &[
-    "Sunday",
-    "Monday",
-    "Tuesday",
-    "Wednesday",
-    "Thursday",
-    "Friday",
-    "Saturday",
-];
+use super::date_names::{MONTH_ABBR, MONTH_FULL, WEEKDAY_ABBR, WEEKDAY_FULL, WEEKDAY_NARROW};
 
 /// Weekday index (0=Sunday…6=Saturday) from a UTC epoch-seconds value.
 /// 1970-01-01 was Thursday = index 4.
 fn weekday_index(secs: i64) -> usize {
     ((secs.div_euclid(86400) + 4).rem_euclid(7)) as usize
 }
-
-const WEEKDAY_ABBR: &[&str] = &["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-const WEEKDAY_NARROW: &[&str] = &["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
 
 fn weekday_name(secs: i64, style: &str) -> String {
     let wi = weekday_index(secs);

--- a/crates/perry-runtime/src/intl/date_names.rs
+++ b/crates/perry-runtime/src/intl/date_names.rs
@@ -1,0 +1,31 @@
+//! English month / weekday name tables for date formatting. Split out of
+//! `date_collator.rs` to keep it under the 2000-line cap. Pure data, no deps.
+
+pub(crate) const MONTH_FULL: &[&str] = &[
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+];
+pub(crate) const MONTH_ABBR: &[&str] = &[
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+pub(crate) const WEEKDAY_FULL: &[&str] = &[
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+];
+pub(crate) const WEEKDAY_ABBR: &[&str] = &["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+pub(crate) const WEEKDAY_NARROW: &[&str] = &["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];

--- a/crates/perry-runtime/src/intl/time_zone.rs
+++ b/crates/perry-runtime/src/intl/time_zone.rs
@@ -1,0 +1,103 @@
+//! ECMA-402 time-zone resolution for `Intl.DateTimeFormat` and the
+//! `toLocaleString` family. Split out of `intl.rs` to keep it under the
+//! 2000-line cap. `use super::*` preserves access to the parent's helpers
+//! (`get_option_string`, `throw_range_error`, the offset-zone validators).
+
+use super::*;
+
+/// Resolve the effective time zone for a `toLocaleString`-style call and for the
+/// `Intl.DateTimeFormat` constructor: the `timeZone` option if present,
+/// otherwise the host zone (ECMA-402 DefaultTimeZone), canonicalized.
+///
+/// An explicit `timeZone` option that names no recognized zone is a RangeError
+/// (ECMA-402 CreateDateTimeFormat / ToLocaleString). But DefaultTimeZone — no
+/// option given — must ALWAYS yield a valid zone: an unrecognized host zone (a
+/// broken `TZ`) falls back to `"UTC"`, never throws.
+pub(crate) fn resolved_date_time_zone(options: f64) -> String {
+    let explicit = get_option_string(options, "timeZone");
+    let tz = explicit
+        .clone()
+        .unwrap_or_else(|| crate::date::host_time_zone_name().to_string());
+    let canonical = if matches!(tz.as_bytes().first(), Some(b'+') | Some(b'-')) {
+        is_valid_offset_time_zone(&tz).then(|| canonicalize_offset_time_zone(&tz))
+    } else {
+        canonicalize_named_time_zone(&tz)
+    };
+    match canonical {
+        Some(c) => c,
+        None if explicit.is_some() => {
+            throw_range_error(&format!("Invalid time zone specified: {tz}"))
+        }
+        None => "UTC".to_string(),
+    }
+}
+
+/// Structurally validate + canonicalize a named IANA time zone. Perry has no
+/// tz database, so this checks the identifier shape (and a table of legacy
+/// single-component zones) rather than membership. Returns `None` for a
+/// malformed / unrecognized identifier.
+pub(crate) fn canonicalize_named_time_zone(tz: &str) -> Option<String> {
+    if tz.eq_ignore_ascii_case("UTC") || tz.eq_ignore_ascii_case("Etc/UTC") {
+        return Some("UTC".to_string());
+    }
+    if !tz.is_ascii() {
+        return None;
+    }
+    // Legacy single-component IANA zones / links that carry no '/'.
+    const SINGLE_WORD_ZONES: &[&str] = &[
+        "GMT",
+        "GMT0",
+        "Zulu",
+        "Universal",
+        "UCT",
+        "Greenwich",
+        "Navajo",
+        "Eire",
+        "Iceland",
+        "Cuba",
+        "Egypt",
+        "Hongkong",
+        "Iran",
+        "Israel",
+        "Japan",
+        "Jamaica",
+        "Libya",
+        "Poland",
+        "Portugal",
+        "PRC",
+        "Singapore",
+        "Turkey",
+        "ROC",
+        "ROK",
+        "W-SU",
+        "Factory",
+        "EST",
+        "MST",
+        "HST",
+        "EST5EDT",
+        "CST6CDT",
+        "MST7MDT",
+        "PST8PDT",
+    ];
+    if SINGLE_WORD_ZONES.iter().any(|z| z.eq_ignore_ascii_case(tz)) {
+        return Some(tz.to_string());
+    }
+    let segments: Vec<&str> = tz.split('/').collect();
+    if segments.len() < 2 {
+        return None;
+    }
+    let mut has_alpha = false;
+    for seg in &segments {
+        if seg.is_empty() {
+            return None;
+        }
+        for b in seg.bytes() {
+            if b.is_ascii_alphabetic() {
+                has_alpha = true;
+            } else if !(b.is_ascii_alphanumeric() || b == b'_' || b == b'+' || b == b'-') {
+                return None;
+            }
+        }
+    }
+    has_alpha.then(|| tz.to_string())
+}

--- a/crates/perry-runtime/src/object/date_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/date_proto_thunks.rs
@@ -507,8 +507,17 @@ extern "C" fn date_to_locale_string_opts(
     let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
     let locale = args.get(0).copied().unwrap_or(undef);
     let opts = args.get(1).copied().unwrap_or(undef);
+    // A `Date` is a specific INSTANT; `toLocaleString` renders it in the resolved
+    // time zone (the `timeZone` option, else the host zone) — not UTC. Shift the
+    // epoch into that zone's wall clock, then format it as the zone-agnostic
+    // date-time it now represents. (Perry formatted it in UTC before, so
+    // `new Date().toLocaleString()` was off by the host offset.)
+    let tz = crate::intl::resolved_date_time_zone(opts);
+    let secs = (epoch_ms as i64).div_euclid(1000);
+    let frac_ms = epoch_ms - (secs as f64) * 1000.0;
+    let shifted_ms = (secs + crate::date::zone_offset_seconds(&tz, secs)) as f64 * 1000.0 + frac_ms;
     crate::intl::temporal_locale_string(
-        epoch_ms,
+        shifted_ms,
         locale,
         opts,
         crate::intl::TemporalLocaleCtx::PlainDateTime,

--- a/test-files/test_gap_intl_host_timezone.ts
+++ b/test-files/test_gap_intl_host_timezone.ts
@@ -1,0 +1,19 @@
+// Intl.DateTimeFormat resolves the HOST time zone (like Node), applies its
+// UTC offset when formatting a Date, honors an explicit UTC / numeric-offset
+// zone, and Date.prototype.toLocaleString renders the instant in the resolved
+// zone. Uses en-US + numeric hour/minute so the comparison isolates the time
+// ZONE (offset) rather than any locale date-pattern differences, and avoids
+// non-host named zones (whose offset needs the OS tz db). Byte-compared to
+// `node --experimental-strip-types` on the same host, so both read the same
+// host zone regardless of CI's timezone.
+const d = new Date(Date.UTC(2026, 0, 15, 12, 30, 0));
+const num = { hour: "2-digit", minute: "2-digit", hour12: false } as const;
+console.log("resolvedIsString=" + (typeof new Intl.DateTimeFormat().resolvedOptions().timeZone === "string"));
+console.log("resolvedMatchesGlobal=" +
+  (new Intl.DateTimeFormat("en-US").resolvedOptions().timeZone ===
+   new Intl.DateTimeFormat().resolvedOptions().timeZone));
+console.log("utc=" + new Intl.DateTimeFormat("en-US", { timeZone: "UTC", ...num }).format(d));
+console.log("host=" + new Intl.DateTimeFormat("en-US", num).format(d));
+console.log("plus5=" + new Intl.DateTimeFormat("en-US", { timeZone: "+05:00", ...num }).format(d));
+console.log("minus0330=" + new Intl.DateTimeFormat("en-US", { timeZone: "-03:30", ...num }).format(d));
+console.log("toLocaleUtc=" + d.toLocaleString("en-US", { timeZone: "UTC", ...num }));


### PR DESCRIPTION
## Summary

`Intl.DateTimeFormat().resolvedOptions().timeZone` returned `"UTC"` regardless of the host machine, and all `DateTimeFormat` / `Date.prototype.toLocaleString` formatting was done in UTC. On any non-UTC host every result was off by the host offset, and Node's host zone (e.g. `Europe/Berlin`) never appeared.

This surfaced in a bundled Next.js app: `next-intl` reads `resolvedOptions().timeZone`, so the server-rendered hydration payload carried `timeZone:"UTC"` where Node produced `timeZone:"Europe/Berlin"`.

## How

- **`date.rs`** — `host_time_zone_name()` resolves the IANA id from `TZ` (honored like libc/Node) then the `/etc/localtime` symlink, falling back to `"UTC"`; `zone_offset_seconds()` returns a DST-aware offset: `0` for UTC/GMT, a parsed fixed offset for `±HH:mm`, and the process zone via `libc::localtime` for the host zone.
- **`intl.rs` / `date_collator.rs`** — the `DateTimeFormat` constructor defaults `timeZone` to the host zone (was UTC), `resolvedOptions()` reports it, and the two instance format paths shift the epoch into the configured zone before extracting Y/M/D H:M:S.
- **`date_proto_thunks.rs`** — `Date.prototype.toLocaleString` renders the instant in the resolved zone (the `timeZone` option, else host) instead of UTC.

## Testing

`test_gap_intl_host_timezone.ts` (byte-compared to Node on the same host): resolved-zone-is-a-string, resolved matches the global default, UTC formatting, host-zone formatting (host offset applied), fixed `+05:00` / `-03:30` offsets, and `toLocaleString({timeZone:'UTC'})`. Under `TZ=UTC` (typical CI) the host zone is UTC so this is a no-op; the full perry-runtime suite passes on both a UTC and a Europe/Berlin host.

## Scope / follow-up

A named zone that is **not** the host zone (e.g. `America/New_York` on a Europe/Berlin host) still needs the OS tz database to resolve, and mutating libc's global `TZ` is unsafe in a threaded runtime, so it currently falls back to UTC. The exact cases — default/host zone, explicit UTC, fixed numeric offsets — cover the common usage; a follow-up can wire the already-vendored `jiff-tzdb` (currently gated on `Temporal`) for arbitrary named zones. The German date *pattern* (`15.01.` vs `1/15/`) is a separate locale-localization gap, not timezone.

https://claude.ai/code/session_01NjymZygYh31wM9h3wLnUqv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Default `Intl.DateTimeFormat` now resolves to the host system time zone (not hardcoded UTC).
  - Added time-zone resolution helpers, including canonicalization and numeric offset handling.
  - `resolvedOptions().timeZone` reflects the effective host zone.

- **Bug Fixes**
  - Corrected `Intl.DateTimeFormat`/`Date.prototype.toLocaleString` formatting so non-Temporal inputs apply the selected time zone correctly.

- **Tests**
  - Added host time-zone resolution tests covering default formatting, UTC, and numeric offsets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->