### PR TITLE
fix(runtime): String(new Map()) reports [object Map], not [object Object] (#6374)

### DIFF
--- a/crates/perry-runtime/src/value/to_string.rs
+++ b/crates/perry-runtime/src/value/to_string.rs
@@ -1207,7 +1207,15 @@ pub extern "C" fn js_jsvalue_to_string(value: f64) -> *mut crate::string::String
                 }
             }
         }
-        crate::string::js_string_from_bytes(b"[object Object]".as_ptr(), 15)
+        // An object with no `toString` override inherits
+        // `Object.prototype.toString`, which brands Map / Set / WeakMap /
+        // WeakSet / Promise (and any `Symbol.toStringTag`) as "[object Map]"
+        // etc. — not the bare "[object Object]". `String(new Map())` reached
+        // here after finding no override, so reuse that brand detection instead
+        // of hardcoding the generic tag. Ordinary objects still come back
+        // "[object Object]".
+        let branded = unsafe { crate::object::js_object_to_string(value) };
+        (branded.to_bits() & 0x0000_FFFF_FFFF_FFFF) as *mut crate::StringHeader
     } else {
         // Regular number - use js_number_to_string
         crate::string::js_number_to_string(value)

--- a/test-files/test_gap_string_builtin_brand_tostring.ts
+++ b/test-files/test_gap_string_builtin_brand_tostring.ts
@@ -1,0 +1,22 @@
+// String()/template/inherited-toString on a built-in collection reports its
+// brand, not the bare "[object Object]": an override-less Map/Set/WeakMap/
+// WeakSet/Promise (and any Symbol.toStringTag object) inherits
+// Object.prototype.toString, which brands it.
+console.log(String(new Map()));
+console.log(String(new Set()));
+console.log(String(new WeakMap()));
+console.log(String(new WeakSet()));
+console.log(String(Promise.resolve(1)));
+console.log(`${new Set([1, 2])}`);
+console.log(Object.prototype.toString.call(new Map()));
+// Plain objects are unchanged.
+console.log(String({}));
+console.log(String({ a: 1 }));
+// Symbol.toStringTag wins.
+const tagged: any = {};
+tagged[Symbol.toStringTag] = "Widget";
+console.log(String(tagged));
+// An own/inherited toString override wins over the brand.
+const m: any = new Map();
+m.toString = () => "custom-map";
+console.log(String(m));


### PR DESCRIPTION
Closes #6374.

The stringify fallback for an override-less heap object hardcoded `"[object Object]"`. But such an object inherits `Object.prototype.toString`, which brands Map/Set/WeakMap/WeakSet/Promise (and any `Symbol.toStringTag`). `js_object_to_string` already does that detection — call it at the fallback instead of the hardcoded tag.

| input | before | after / node |
|---|---|---|
| `String(new Map())` | `[object Object]` | `[object Map]` |
| `String(new Set())` | `[object Object]` | `[object Set]` |
| `String(new WeakMap())` | `[object Object]` | `[object WeakMap]` |
| `String(Promise.resolve())` | `[object Object]` | `[object Promise]` |
| `String({})` | `[object Object]` | `[object Object]` (unchanged) |
| `{[Symbol.toStringTag]:'X'}` | `[object Object]` | `[object X]` |
| own `toString` override | (override) | (override, unchanged) |

Verified byte-identical to node; 20 string/object/coercion gap tests still pass. Added `test_gap_string_builtin_brand_tostring`.

Note: `"" + new Map()` still yields `"undefined"` — that's the separate `+`-operator coercion bug (#6381), a different code path, not addressed here.