### PR TITLE
fix(runtime): unknown method on a Buffer receiver must throw, not return undefined

### DIFF
--- a/crates/perry-runtime/src/object/buffer_dispatch.rs
+++ b/crates/perry-runtime/src/object/buffer_dispatch.rs
@@ -1100,7 +1100,7 @@ pub unsafe fn dispatch_buffer_method(
         // non-callable callback) nor iterating. Delegate any method the Buffer
         // API doesn't claim to the shared uint8 typed-array dispatcher (it
         // validates callbacks and reads the typed store); it returns `None` for
-        // names it doesn't implement, preserving the `undefined` fallback.
+        // names it doesn't implement.
         _ => {
             if super::typed_array_proto_thunks::is_typed_array_buffer(addr) {
                 if let Some(r) = super::typed_array_proto_thunks::dispatch_uint8_buffer_method(
@@ -1111,7 +1111,26 @@ pub unsafe fn dispatch_buffer_method(
                     return r;
                 }
             }
-            f64::from_bits(crate::value::TAG_UNDEFINED)
+            // Internal perry hooks (`using` disposal probes and friends) may
+            // reach any receiver; they are duck-typed and must stay non-throwing.
+            if method_name.starts_with("__perry_") {
+                return f64::from_bits(crate::value::TAG_UNDEFINED);
+            }
+            // A method neither the Buffer API nor %TypedArray%.prototype
+            // implements must throw like Node (`buf.charCodeAt is not a
+            // function`), not silently return undefined. The silent fallback
+            // turned a readFileSync-now-returns-Buffer migration into invisible
+            // data corruption downstream: `content.charCodeAt(i)` yielded
+            // undefined in every comparison, so e.g. a NUL-byte binary-file
+            // scan misclassified every text file while the program kept
+            // running as if the calls had worked. Same shape as the string /
+            // number primitive catch-alls, which already route here.
+            crate::error::js_throw_type_error_not_a_function(
+                b"Buffer".as_ptr(),
+                6,
+                method_name.as_ptr(),
+                method_name.len(),
+            )
         }
     }
 }

--- a/test-files/test_gap_buffer_unknown_method_throws.ts
+++ b/test-files/test_gap_buffer_unknown_method_throws.ts
@@ -1,0 +1,45 @@
+// Calling a method that neither the Buffer API nor %TypedArray%.prototype
+// implements must throw a TypeError like Node — not silently return undefined.
+//
+// Pre-fix, `dispatch_buffer_method`'s catch-all returned undefined for any
+// unknown name. That silence turned the readFileSync Node-parity migration
+// (no encoding → Buffer, not string) into invisible data corruption for
+// callers still treating the result as a string: `content.charCodeAt(i)`
+// yielded undefined in every comparison and the program kept running as if
+// the calls had worked (real case: an editor's NUL-byte binary-file scan
+// misclassified every text file it opened).
+
+const buf = Buffer.from('hello', 'utf8');
+
+// The implemented Buffer API surface keeps working.
+console.log('toString:', buf.toString('utf8'));
+console.log('indexOf:', buf.indexOf('l'));
+
+// Inherited %TypedArray%.prototype methods keep working via delegation.
+console.log('every:', buf.every((b) => b > 0));
+
+// A String.prototype method reached through a Buffer receiver throws.
+try {
+  (buf as any).charCodeAt(0);
+  console.log('charCodeAt: no throw');
+} catch (e) {
+  console.log('charCodeAt throws TypeError:', e instanceof TypeError);
+  const msg = (e as Error).message;
+  console.log('mentions method:', msg.includes('charCodeAt'));
+  console.log('mentions not-a-function:', msg.includes('is not a function'));
+}
+
+// A method that exists nowhere throws too.
+try {
+  (buf as any).definitelyNotAMethod(1, 2);
+  console.log('bogus: no throw');
+} catch (e) {
+  console.log('bogus throws TypeError:', e instanceof TypeError);
+  console.log(
+    'mentions not-a-function:',
+    (e as Error).message.includes('is not a function')
+  );
+}
+
+// The throw is catchable and execution continues normally afterwards.
+console.log('still running:', buf.readUInt8(0));


### PR DESCRIPTION
## Problem

`dispatch_buffer_method`'s catch-all returns `undefined` for any method that neither the Buffer API arms nor the delegated `%TypedArray%.prototype` tower implement. Node throws:

```js
const buf = readFileSync(path);   // Buffer since #1420 (no encoding → Buffer, Node parity)
buf.charCodeAt(0);                // Node: TypeError: buf.charCodeAt is not a function
                                  // Perry: undefined — and execution continues
```

Plain objects, strings, and number receivers already throw through `js_throw_type_error_not_a_function`; Buffer was the one receiver that swallowed the call.

## Why it matters

The silence has real teeth precisely *because* #1420 correctly aligned `readFileSync` with Node: any caller still treating the no-encoding result as a string gets `undefined` from every string-method call and keeps running on garbage instead of failing at the call site. Real-world case (how we found it): a code editor's NUL-byte binary-detection scan — `content.charCodeAt(i) === 0` over the first 8000 chars — misclassified **every** file it opened as binary. No crash, no error message, nothing to grep for; the app just quietly stopped displaying files. A thrown TypeError would have named the exact line on the first file opened.

This also matches the direction of #6453 ("String method on a nullish receiver must throw, not coerce") — loud beats lenient when the alternative is silent corruption.

## Fix

In the catch-all, after Buffer-API arms and typed-array delegation both miss, route through `js_throw_type_error_not_a_function` — the same thrower the string/number primitive catch-alls use, so message shape (`(Buffer).charCodeAt is not a function`) and catchability match those paths. Internal `__perry_*` duck-type probes (`using`-disposal) keep the non-throwing `undefined`.

Caller audit: both dynamic-dispatch entry points (`handle_methods.rs:138`, `collection_methods.rs:313`) return `Some(dispatch_buffer_method(...))` unconditionally — nothing relied on the `undefined` to fall through to another dispatcher; the named-method callers (`set`/`export`/`slice`) never reach the catch-all.

## Validation

- New gap test `test_gap_buffer_unknown_method_throws.ts`: **byte-identical to the Node oracle** locally (assertions avoid raw message text since V8 renders the callee source expression; the test checks `instanceof TypeError` + method-name/`is not a function` substrings, and that execution continues after a caught throw).
- Buffer sweep unchanged: `test_buffer_prototype_methods`, `test_buffer_numeric_read_intrinsic`, `test_buffer_small_alloc`, `test_edge_buffer_from_encoding` all still match Node. `test_compat_buffers_typed` diffs on `toSorted`/`toReversed` (u8 element widening) — pre-existing, byte-identical before/after this change.

No version/CHANGELOG edits — metadata to be folded at merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unknown methods called on Buffer values now raise a clear `TypeError`, matching Node.js behavior.
  * Internal runtime hooks continue to be handled safely without errors.
  * Valid Buffer and typed-array methods remain available, while unsupported methods correctly fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->