### PR TITLE
fix(hir): per-evaluation captures for class declarations in function bodies (#6465)

### DIFF
--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -309,16 +309,40 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                 // class VALUE (`exports.C = C; new mod.C()`) can fill the
                 // synthesized `__perry_cap_<id>` ctor params. Static `new C()`
                 // sites still pass captures as trailing args directly.
-                if let Some(captured) = ctx.lookup_class_captures(&class.name) {
-                    if !captured.is_empty() {
-                        let captures: Vec<Expr> =
-                            captured.iter().map(|id| Expr::LocalGet(*id)).collect();
-                        result.push(Stmt::Expr(Expr::RegisterClassCaptures {
-                            class_name: class.name.clone(),
-                            captures,
-                        }));
-                    }
+                let captured_exprs: Vec<Expr> = ctx
+                    .lookup_class_captures(&class.name)
+                    .map(|ids| ids.iter().map(|id| Expr::LocalGet(*id)).collect())
+                    .unwrap_or_default();
+                if !captured_exprs.is_empty() {
+                    result.push(Stmt::Expr(Expr::RegisterClassCaptures {
+                        class_name: class.name.clone(),
+                        captures: captured_exprs.clone(),
+                    }));
                 }
+                // #6465: a capturing class DECLARATION in a factory needs
+                // per-evaluation semantics, same as a class expression.
+                // `RegisterClassCaptures` above is a class-id-keyed,
+                // last-wins registry — when the enclosing function runs more
+                // than once (effect's `makeException`, called once per
+                // exception kind), every escaped class value replayed the
+                // LAST call's captures: all of effect's core error classes
+                // reported `_tag` "TimeoutException", masking the real error
+                // in any `Cause.pretty` output and breaking every
+                // `catchTag`-style dispatch. Bind the declared name to a
+                // `ClassExprFresh` value (the #1772/#1787 machinery class
+                // EXPRESSIONS already use) so each evaluation carries its own
+                // captured environment on its own heap class object. Scoped
+                // to capture-only classes: one with static state keeps the
+                // shared-template path, whose interleaved static-init
+                // statements below target the template by name. Prototype
+                // identity is still shared per template — the remaining gap
+                // tracked on #6465.
+                let has_static_state = !class.static_fields.is_empty()
+                    || class
+                        .static_methods
+                        .iter()
+                        .any(|m| m.name.starts_with("__perry_static_init_"));
+                let fresh_binding = !captured_exprs.is_empty() && !has_static_state;
                 // Static field initializers + static blocks for a
                 // function-nested class. The module-level path
                 // (`lower/stmt.rs`) emits these into `module.init`; here they
@@ -335,7 +359,31 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                     &class.static_fields,
                     &class.static_methods,
                 ));
+                let template_name = class.name.clone();
                 ctx.pending_classes.push(class);
+                // #6465 (see `fresh_binding` above): bind the declared name to
+                // a per-evaluation heap class object. The local shadows the
+                // class-registry fallback for every in-scope read — including
+                // the factory's `return C` — so the escaped value carries THIS
+                // evaluation's captures instead of the registry's last-wins
+                // snapshot. `new C()` sites that statically resolve the
+                // template still pass the live captures as trailing args, so
+                // in-factory construction is per-evaluation on both paths.
+                if fresh_binding {
+                    let class_local = ctx.define_local(class_name.clone(), Type::Any);
+                    result.push(Stmt::Let {
+                        id: class_local,
+                        name: class_name.clone(),
+                        ty: Type::Any,
+                        init: Some(Expr::ClassExprFresh {
+                            template: template_name,
+                            named_statics: Vec::new(),
+                            symbol_statics: Vec::new(),
+                            captured_args: captured_exprs,
+                        }),
+                        mutable: false,
+                    });
+                }
                 // #5251 follow-up — a function-nested `class X { … }` whose
                 // name collides with an OUTER same-named local must SHADOW
                 // that local within this scope, exactly as a nested
@@ -354,7 +402,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                 // `local_class_aliases`) so the in-scope read resolves to the
                 // class. Gated on a pre-existing outer binding so working
                 // packages (no collision) are byte-for-byte unaffected.
-                if ctx.lookup_local(&class_name).is_some() {
+                if !fresh_binding && ctx.lookup_local(&class_name).is_some() {
                     let class_local = ctx.define_local(class_name.clone(), Type::Any);
                     result.push(Stmt::Let {
                         id: class_local,


### PR DESCRIPTION
## Problem

Every error class effect creates through its `makeException` factory reported `_tag: "TimeoutException"` under perry — whichever kind actually failed. Every failure in an effect app printed as `TimeoutException`, and every `catchTag`-style dispatch matched the wrong arm. In the effect-compiled-experiment `web.ts`, the real startup failure (a `RuntimeException`) was completely masked.

```ts
const makeException = (proto, tag) => {
  class Base extends YieldableError {
    readonly _tag = tag          // captured field init
  }
  Object.assign(Base.prototype, proto)
  return Base
}
export const RuntimeException     = makeException({...}, "RuntimeException")
export const InterruptedException = makeException({...}, "InterruptedException")
...
export const TimeoutException     = makeException({...}, "TimeoutException")
```

## Root cause

A function-body class **declaration** lowers once into a shared compile-time class; its captured environment is snapshotted via `RegisterClassCaptures` — a class-id-keyed, **last-wins** registry. When the enclosing factory runs N times, every escaped class value replays the LAST call's captures: all six exception kinds share one class whose captured `tag` is `"TimeoutException"`.

Class **expressions** already have per-evaluation semantics (#1772/#1787 `ClassExprFresh`, extended to heritage by #6438/#6449). The declaration form has the same disease (#6465).

## Fix

`class X {}` in a function body is semantically `let X = class X {}` — block-scoped, TDZ, not hoisted. Route the declaration through the existing `ClassExprFresh` machinery: bind the declared name to a fresh heap class object whose `captured_args` are evaluated at the declaration site. The local shadows the class-registry fallback for every in-scope read — including the factory's `return Base` — so the escaped value carries THIS evaluation's captures.

Scoped to capture-only classes (no static fields / static blocks); static-state classes keep the shared-template path whose interleaved static-init statements target the template by name. `RegisterClassCaptures` is still emitted for ClassRef-based paths.

## Validation

Minimal repro (probe38 on #6465), node vs perry after fix:

| check | before | after |
|---|---|---|
| `new RuntimeException()._tag` | `TimeoutException` | `RuntimeException` ✓ |
| `new InterruptedException()._tag` | `TimeoutException` | `InterruptedException` ✓ |
| `new TimeoutException()._tag` | `TimeoutException` | `TimeoutException` ✓ |

Effect `web.ts`'s masked startup error is unmasked (a `RuntimeException`; its message being empty is a separate defect — implicit default ctors of nested Error-descendants drop `super(...args)`, filed as #6469). `logger.ts` / `forking.ts` / `api.ts` remain byte-identical to node.

Remaining #6465 gaps (documented, out of scope here): per-evaluation prototype identity (`Object.assign(C.prototype, ...)` still hits the shared template proto; cross-`instanceof` still true) and the `__perry_cap_N` own-key leak on instances.

Part of #6465.

https://claude.ai/code/session_01R4phoN4f7eFbSQTkuB2oQP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nested classes so they correctly capture local values from their surrounding scope.
  * Ensured classes without static state receive a fresh, isolated binding each time they are evaluated.
  * Prevented class-name shadowing and binding conflicts in nested class declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->