### PR TITLE
fix(gc): minor sweep reclaimed array-growth forwarding stubs still referenced from old-gen parents

### DIFF
--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -1124,6 +1124,14 @@ pub(super) fn gc_collect_minor_copying_fast_path_with_eligibility(
         trace_phase_record(trace, "evacuation_verify", phase_start);
     }
 
+    // Diagnostic (PERRY_GC_VERIFY_MARK): before from-space reset frees the dead
+    // young objects, check that no MARKED (survived) object references an
+    // UNMARKED (about-to-be-freed) child — i.e. a live parent whose child is
+    // being swept. Non-fatal; logs parent/child obj_types.
+    if std::env::var_os("PERRY_GC_VERIFY_MARK").is_some() {
+        super::verify::verify_marked_heap_report_nonfatal("copying-minor");
+    }
+
     crate::promise::cleanup_copied_minor_promise_contexts_for_gc();
     finalize_dead_copied_minor_from_space_side_allocations();
     let reset = crate::arena::copying_reset_from_spaces_and_flip();

--- a/crates/perry-runtime/src/gc/cycle.rs
+++ b/crates/perry-runtime/src/gc/cycle.rs
@@ -1492,6 +1492,12 @@ impl GcCycleState {
                 trace.old_young_edge_verifier = old_young_edge_verifier;
             }
         }
+        // Diagnostic (PERRY_GC_VERIFY_MARK): marks are final for this minor and
+        // sweep has not yet run — report any OLD parent whose young/malloc child
+        // is UNMARKED (about to be swept live = dropped remembered-set edge).
+        if std::env::var_os("PERRY_GC_VERIFY_MARK").is_some() {
+            super::verify::verify_minor_unmarked_young_children_report("minor-prelude");
+        }
 
         let active_elapsed_us = self.active_elapsed_us();
         let progress_kind = self.progress_kind;
@@ -1607,6 +1613,10 @@ impl GcCycleState {
                     reclaim_dead_old_blocks,
                     targeted_old_blocks,
                     sweep_malloc,
+                    // Minor sweeps must retain every forwarding stub: old-gen
+                    // parents are black leaves, so an unmarked stub can still
+                    // be referenced (see ArenaSweepObjectsState docs).
+                    !full_trace,
                 )
                 // #6010: dead Maps'/Sets' external side buffers are freed as
                 // the first sweep subphase, budget-chunked — no ordinary

--- a/crates/perry-runtime/src/gc/oldgen.rs
+++ b/crates/perry-runtime/src/gc/oldgen.rs
@@ -827,11 +827,15 @@ fn sweep_with_age_bump_and_old_reclaim_targets(
     targeted_old_blocks: Option<&crate::fast_hash::PtrHashSet<usize>>,
     sweep_malloc: bool,
 ) -> SweepTraceStats {
+    // These synchronous wrappers age-bump exactly when sweeping a MINOR
+    // trace, so `do_age_bump` doubles as the minor-ness signal for the
+    // forwarded-stub retention rule (see `retain_all_forwarded_stubs`).
     let mut state = IncrementalSweepState::new(
         do_age_bump,
         reclaim_dead_old_blocks,
         targeted_old_blocks.cloned(),
         sweep_malloc,
+        do_age_bump,
     );
     state.finish_unbounded()
 }
@@ -985,7 +989,10 @@ fn legacy_sweep_with_age_bump_and_old_reclaim_targets(
             // them pins one object in nearly every JSON-churn block and prevents
             // RSS from falling after sweep.
             if flags & GC_FLAG_FORWARDED != 0 {
-                let retain_stub = flags & GC_FLAG_MARKED != 0
+                // Parity with ArenaSweepObjectsState::process_forwarded_object:
+                // a minor sweep (do_age_bump) cannot prove a stub unreferenced.
+                let retain_stub = do_age_bump
+                    || flags & GC_FLAG_MARKED != 0
                     || (block_idx < resettable_general_n
                         && crate::arena::general_block_in_recent_window(block_idx));
                 if retain_stub {
@@ -1191,6 +1198,7 @@ impl IncrementalSweepState {
         reclaim_dead_old_blocks: bool,
         targeted_old_blocks: Option<crate::fast_hash::PtrHashSet<usize>>,
         sweep_malloc: bool,
+        retain_all_forwarded_stubs: bool,
     ) -> Self {
         Self {
             subphase: SweepCycleSubphase::Malloc,
@@ -1199,7 +1207,11 @@ impl IncrementalSweepState {
             dead_buffers: Vec::new(),
             dead_typed_arrays: Vec::new(),
             malloc: MallocSweepCycleState::new(sweep_malloc),
-            arena: ArenaSweepObjectsState::new(do_age_bump, reclaim_dead_old_blocks),
+            arena: ArenaSweepObjectsState::new(
+                do_age_bump,
+                reclaim_dead_old_blocks,
+                retain_all_forwarded_stubs,
+            ),
             cleanup: None,
             reclaim_dead_old_blocks,
             targeted_old_blocks,
@@ -1329,13 +1341,28 @@ struct ArenaSweepObjectsState {
     overflow_active: bool,
     do_age_bump: bool,
     reclaim_dead_old_blocks: bool,
+    /// Minor sweeps must retain EVERY forwarding stub: array growth installs
+    /// PERMANENT stubs (#6228 — stale pre-growth pointers keep resolving for
+    /// reads, references are never rewritten), and a minor treats old-gen
+    /// parents as black leaves whose slots are only visited via dirty pages.
+    /// An old parent (e.g. a long-lived Map's entries buffer) whose page is
+    /// no longer dirty never marks the stub its slot points at, so
+    /// "unmarked stub" does NOT imply "unreferenced" in a minor — reclaiming
+    /// it is a use-after-free (reads through the stale pointer return
+    /// reused-memory garbage). Full traces DO visit every live parent, so
+    /// mark-based stub reclaim stays sound (and bounds the accumulation).
+    retain_all_forwarded_stubs: bool,
     freed_bytes: u64,
     retained_forwarded_stub_objects: usize,
     retained_forwarded_stub_bytes: usize,
 }
 
 impl ArenaSweepObjectsState {
-    fn new(do_age_bump: bool, reclaim_dead_old_blocks: bool) -> Self {
+    fn new(
+        do_age_bump: bool,
+        reclaim_dead_old_blocks: bool,
+        retain_all_forwarded_stubs: bool,
+    ) -> Self {
         let n_blocks = crate::arena::arena_block_count();
         let block_snapshots = crate::arena::arena_block_snapshots();
         crate::arena::old_pages_reset_sweep_accounting();
@@ -1351,6 +1378,7 @@ impl ArenaSweepObjectsState {
                 || crate::closure::closure_dynamic_side_tables_nonempty(),
             do_age_bump,
             reclaim_dead_old_blocks,
+            retain_all_forwarded_stubs,
             freed_bytes: 0,
             retained_forwarded_stub_objects: 0,
             retained_forwarded_stub_bytes: 0,
@@ -1462,7 +1490,11 @@ impl ArenaSweepObjectsState {
         block_idx: usize,
         flags: u8,
     ) {
-        let retain_stub = flags & GC_FLAG_MARKED != 0
+        // See `retain_all_forwarded_stubs`: a minor cannot prove a stub
+        // unreferenced (old-gen parents are black leaves), so it must keep
+        // them all; a full trace reclaims the genuinely unreferenced ones.
+        let retain_stub = self.retain_all_forwarded_stubs
+            || flags & GC_FLAG_MARKED != 0
             || (block_idx < self.resettable_general_n
                 && crate::arena::general_block_in_recent_window(block_idx));
         if retain_stub {

--- a/crates/perry-runtime/src/gc/tests/debt_pacer.rs
+++ b/crates/perry-runtime/src/gc/tests/debt_pacer.rs
@@ -633,3 +633,94 @@ fn forwarded_array_stub_propagates_liveness_to_grown_array() {
     assert_eq!(crate::array::js_array_length(live), 64);
     assert_eq!(crate::array::js_array_get_f64_unchecked(live, 63), 63.0);
 }
+
+/// A minor sweep must retain EVERY array-growth forwarding stub, marked or
+/// not. Growth stubs are PERMANENT (#6228 above: stale pre-growth pointers
+/// keep resolving for reads; references to them are never rewritten), and a
+/// minor treats old-gen parents as black leaves — their slots are visited
+/// only via remembered-set dirty pages. A stale pre-growth pointer held in an
+/// old parent whose page is not dirty (a long-lived Map's entries buffer that
+/// hasn't been written since) therefore never marks the stub, so "unmarked"
+/// does NOT imply "unreferenced". The pre-fix sweep freed such stubs once
+/// their block left the recent-allocation window; reads through the stale
+/// pointer then returned reused-memory garbage (observed in a large
+/// esbuild-bundled TUI app: a render cell-cache Map value's `.length` read
+/// back as a heap pointer, aborting every frame). Only a full trace — which
+/// visits every live parent — may reclaim stubs by mark.
+///
+/// Drives `IncrementalSweepState` directly, exactly as `cycle.rs::step_sweep`
+/// constructs it for a minor (`retain_all_forwarded_stubs = true`), with the
+/// stub deliberately UNMARKED and aged out of the recent-allocation window —
+/// the precise pre-fix reclaim conditions.
+#[test]
+fn minor_sweep_retains_window_expired_growth_stub() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    let trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+    let _ = &trigger_guard;
+    reset_old_reclaim_pressure();
+    clear_marks();
+    clear_mark_seeds();
+
+    let arr = crate::array::js_array_alloc(4);
+    let pre_growth = arr as usize;
+    // Push past capacity: js_array_grow reallocates and installs the
+    // forwarding stub at `pre_growth`.
+    for i in 0..64 {
+        crate::array::js_array_push(
+            pre_growth as *mut crate::array::ArrayHeader,
+            crate::JSValue::number(i as f64),
+        );
+    }
+    let stub_header = unsafe { header_from_user_ptr(pre_growth as *const u8) };
+    assert!(
+        unsafe { (*stub_header).gc_flags } & GC_FLAG_FORWARDED != 0,
+        "growth past capacity must leave a forwarding stub at the old address"
+    );
+    // Mark the grown TARGET (a live survivor); leave the STUB unmarked, as a
+    // minor does when the only reference sits in an old black-leaf parent
+    // slot on a non-dirty page.
+    let target = unsafe { forwarding_address(stub_header) as usize };
+    unsafe {
+        (*header_from_user_ptr(target as *const u8)).gc_flags |= GC_FLAG_MARKED;
+    }
+    js_shadow_slot_set(0, ptr_bits(target));
+
+    // Age the stub's block out of the recent-allocation window
+    // (`general_block_in_recent_window` keeps `current - 4 ..= current`):
+    // raw arena churn marches the current block index forward.
+    // Small allocations advance the GENERAL bump blocks (large ones are
+    // routed to dedicated blocks and would leave `current` untouched).
+    let general_before = crate::arena::general_block_count();
+    for _ in 0..3_000 {
+        let filler = crate::arena::arena_alloc_gc(4 * 1024, 8, GC_TYPE_STRING);
+        std::hint::black_box(filler);
+    }
+    assert!(
+        crate::arena::general_block_count() >= general_before + 6,
+        "filler churn must advance the general allocation window past the stub's block"
+    );
+
+    // Minor-shaped sweep, exactly as cycle.rs builds it (age-bump minor,
+    // no old-block reclaim, retain_all_forwarded_stubs = true).
+    let mut sweep = IncrementalSweepState::new(true, false, None, false, true);
+    for _ in 0..5_000_000 {
+        if sweep.step(1024) {
+            break;
+        }
+    }
+    let stats = sweep.stats();
+    assert!(
+        stats.retained_forwarded_stub_objects >= 1,
+        "minor sweep must report the retained stub"
+    );
+
+    // The stub must have survived: the header still forwards, and reads
+    // through the stale pre-growth pointer still see the grown array.
+    assert!(
+        unsafe { (*stub_header).gc_flags } & GC_FLAG_FORWARDED != 0,
+        "minor sweep reclaimed a window-expired growth stub it cannot prove unreferenced"
+    );
+    let live = pre_growth as *const crate::array::ArrayHeader;
+    assert_eq!(crate::array::js_array_length(live), 64);
+    assert_eq!(crate::array::js_array_get_f64_unchecked(live, 63), 63.0);
+}

--- a/crates/perry-runtime/src/gc/tests/incremental_sweep_reclaim.rs
+++ b/crates/perry-runtime/src/gc/tests/incremental_sweep_reclaim.rs
@@ -137,7 +137,7 @@ fn malloc_sweep_pauses_mid_list_and_eventually_frees_dead_malloc() {
     }
     let dead_headers = allocate_dead_malloc_churn_headers(32);
 
-    let mut sweep = IncrementalSweepState::new(false, false, None, true);
+    let mut sweep = IncrementalSweepState::new(false, false, None, true, false);
     assert!(!sweep.step(1));
     assert!(
         tracked_malloc_headers_matching(&dead_headers) > 0,
@@ -238,7 +238,7 @@ fn arena_sweep_pauses_before_block_cleanup_and_preserves_live_objects() {
     }
     let in_use_after_alloc = crate::arena::arena_in_use_bytes();
 
-    let mut sweep = IncrementalSweepState::new(true, false, None, false);
+    let mut sweep = IncrementalSweepState::new(true, false, None, false, true);
     assert!(
         !sweep.step(1),
         "first tiny step should only enter arena sweep"
@@ -295,6 +295,7 @@ fn old_generation_targeted_and_full_reclaim_are_bounded_and_publish_telemetry() 
         false,
         Some(targeted_blocks.block_indices.clone()),
         false,
+        false,
     );
     assert!(
         !targeted_sweep.step(1),
@@ -315,7 +316,7 @@ fn old_generation_targeted_and_full_reclaim_are_bounded_and_publish_telemetry() 
     let _full_dead_a = crate::arena::arena_alloc_gc_old(900 * 1024, 8, GC_TYPE_STRING) as usize;
     let _full_dead_b = crate::arena::arena_alloc_gc_old(900 * 1024, 8, GC_TYPE_STRING) as usize;
     crate::arena::old_pages_begin_gc_cycle();
-    let mut full_sweep = IncrementalSweepState::new(false, true, None, false);
+    let mut full_sweep = IncrementalSweepState::new(false, true, None, false, false);
     assert!(
         !full_sweep.step(1),
         "full old reclaim should not complete in one work unit"

--- a/crates/perry-runtime/src/gc/verify.rs
+++ b/crates/perry-runtime/src/gc/verify.rs
@@ -684,6 +684,126 @@ pub(super) fn verify_marked_heap_no_unmarked_children() -> MarkInvariantVerifySt
     stats
 }
 
+/// Non-fatal mark-invariant probe (`PERRY_GC_VERIFY_MARK`): walks the marked
+/// heap and, instead of panicking, logs the first marked→UNMARKED-child edge
+/// with parent/child obj_types. Lets the bundle be driven to reproduce a
+/// swept-live-child (freed Map value) without aborting. Diagnostic only.
+pub(super) fn verify_marked_heap_report_nonfatal(phase: &str) {
+    let mut stats = MarkInvariantVerifyStats::default();
+    crate::arena::arena_walk_objects(|hp| unsafe {
+        verify_marked_object_child_marks(&mut stats, hp as *mut GcHeader);
+    });
+    MALLOC_STATE.with(|s| {
+        let s = s.borrow();
+        for &header in s.objects.iter() {
+            unsafe {
+                verify_marked_object_child_marks(&mut stats, header);
+            }
+        }
+    });
+    let tn = |t: u8| gc_type_info(t).map_or("?", |i| i.name);
+    if let Some(m) = stats.first_missing {
+        let (ptype, ctype) = unsafe {
+            let ph = (m.parent as *const u8).sub(GC_HEADER_SIZE) as *const GcHeader;
+            let ch = (m.child as *const u8).sub(GC_HEADER_SIZE) as *const GcHeader;
+            ((*ph).obj_type, (*ch).obj_type)
+        };
+        eprintln!(
+            "[gc-mark-verify:{}] marked->UNMARKED edges={} checked_marked={} checked_edges={} | first parent=0x{:x} ptype={}({}) slot=0x{:x} child=0x{:x} ctype={}({})",
+            phase,
+            stats.missing_edges,
+            stats.checked_marked_objects,
+            stats.checked_edges,
+            m.parent,
+            tn(ptype),
+            ptype,
+            m.slot,
+            m.child,
+            tn(ctype),
+            ctype,
+        );
+    } else {
+        eprintln!(
+            "[gc-mark-verify:{}] OK (no marked->unmarked) checked_marked={} checked_edges={}",
+            phase, stats.checked_marked_objects, stats.checked_edges,
+        );
+    }
+}
+
+/// Non-fatal minor-sweep probe (`PERRY_GC_VERIFY_MARK`): at the minor's
+/// AtomicFinalize→Sweep boundary (marks final, nothing freed yet), walk every
+/// OLD-gen parent (implicitly live in a minor) and report any child slot that
+/// points at a sweep-eligible (young/malloc) object which is UNMARKED — i.e.
+/// about to be freed while its parent survives. This is the direct signature
+/// of a dropped remembered-set edge. Logs a per-(parent,child)-type histogram
+/// plus the first edge; diagnostic only.
+pub(super) fn verify_minor_unmarked_young_children_report(phase: &str) {
+    let mut missing = 0usize;
+    let mut checked_parents = 0usize;
+    let mut checked_edges = 0usize;
+    let mut first: Option<(usize, usize, usize, u8, u8)> = None;
+    let mut hist: std::collections::HashMap<(u8, u8), usize> = std::collections::HashMap::new();
+    let mut visit_parent = |header: *mut GcHeader| unsafe {
+        if header.is_null() || (*header).gc_flags & GC_FLAG_FORWARDED != 0 {
+            return;
+        }
+        let user = (header as *mut u8).add(GC_HEADER_SIZE) as usize;
+        if !matches!(
+            crate::arena::classify_heap_generation(user),
+            crate::arena::HeapGeneration::Old
+        ) {
+            return;
+        }
+        checked_parents += 1;
+        visit_gc_rewrite_slots(header, |slot| unsafe {
+            if crate::weakref::is_weak_target_trace_slot(header, slot.slot) {
+                return;
+            }
+            slot.record_layout_read();
+            let child_addr = decode_heap_addr(*slot.slot);
+            if child_addr == 0 || !crate::gc::barrier::remembered_child_needs_tracking(child_addr) {
+                return;
+            }
+            checked_edges += 1;
+            let ch = (child_addr as *const u8).sub(GC_HEADER_SIZE) as *const GcHeader;
+            if (*ch).gc_flags & (GC_FLAG_MARKED | GC_FLAG_PINNED) == 0 {
+                missing += 1;
+                *hist
+                    .entry(((*header).obj_type, (*ch).obj_type))
+                    .or_insert(0) += 1;
+                if first.is_none() {
+                    first = Some((
+                        header as usize,
+                        slot.slot as usize,
+                        child_addr,
+                        (*header).obj_type,
+                        (*ch).obj_type,
+                    ));
+                }
+            }
+        });
+    };
+    crate::arena::old_arena_walk_objects(|hp| {
+        visit_parent(hp as *mut GcHeader);
+    });
+    let tn = |t: u8| gc_type_info(t).map_or("?", |i| i.name);
+    if let Some((p, s, c, pt, ct)) = first {
+        let mut hist_str = String::new();
+        for ((pt, ct), n) in &hist {
+            hist_str.push_str(&format!(" {}({})->{}({})={}", tn(*pt), pt, tn(*ct), ct, n));
+        }
+        eprintln!(
+            "[gc-mark-verify:{}] SWEEP-LIVE-CHILD edges={} parents={} young_edges={} | first parent=0x{:x} ptype={}({}) slot=0x{:x} child=0x{:x} ctype={}({}) | hist:{}",
+            phase, missing, checked_parents, checked_edges, p, tn(pt), pt, s, c, tn(ct), ct, hist_str,
+        );
+    } else {
+        eprintln!(
+            "[gc-mark-verify:{}] OK parents={} young_edges={}",
+            phase, checked_parents, checked_edges,
+        );
+    }
+}
+
 pub(super) unsafe fn verify_heap_object_fields(
     header: *mut GcHeader,
     valid_ptrs: &ValidPointerSet,


### PR DESCRIPTION
Array growth installs a **PERMANENT forwarding stub** at the pre-growth address (#6228): stale pre-growth pointers keep resolving for reads, and references to stubs are never rewritten. But the minor sweep reclaimed any `FORWARDED` stub that was neither marked this cycle nor inside the recent-allocation block window, assuming unmarked stubs are "stale array-growth remnants".

That assumption is unsound in a minor: **old-gen parents are black leaves** — their slots are visited only via remembered-set dirty pages — so a stale pre-growth pointer held in an old parent whose page is not dirty (a long-lived Map's entries buffer that hasn't been written since) never marks the stub. "Unmarked" does NOT imply "unreferenced". Once the stub's block aged out of the recent window, the sweep freed it; reads through the still-live stale pointer then returned reused-memory garbage.

**Observed in a large esbuild-bundled TUI app**: a render cell-cache Map value (a grown cells array reached via its pre-growth pointer) read `.length` back as a heap pointer after a few minors — pointer-shaped, varying per run, elements at higher offsets still intact — blowing up every subsequent frame, so typed input never appeared on screen. The failure needs an old parent + non-dirty page + window expiry to line up, which is why smaller reproductions kept passing.

## Fix
Thread `retain_all_forwarded_stubs` from `step_sweep` into the arena sweep:
- **Minor sweeps retain EVERY forwarding stub** — a minor cannot prove one unreferenced.
- **Full traces** visit every live parent, so their mark-based stub reclaim stays as-is and bounds the accumulation.
- The synchronous sweep wrappers use `do_age_bump` (true exactly for minor sweeps) as the same signal.

## Diagnostics
Adds two env-gated, non-fatal reporters (`PERRY_GC_VERIFY_MARK`) used to isolate this: a marked-heap mark-invariant reporter on the copied-minor path, and a pre-sweep old-parent → unmarked-young-child reporter at the budgeted minor's AtomicFinalize boundary.

## Test
`minor_sweep_retains_window_expired_growth_stub` drives `IncrementalSweepState` exactly as a minor builds it, with a genuinely unmarked, window-expired growth stub (small-allocation churn to advance the general window past the stub's block; the test-build full-conservative-scan default and large-allocation routing both mask the scenario otherwise — validated failing-then-passing: pre-fix the sweep strips `FORWARDED` and reclaims the stub; post-fix it is retained, `retained_forwarded_stub_objects` reports it, and reads through the stale pointer still resolve).

Full `perry-runtime` suite: 1315 passed / 0 failed (single-threaded).

https://claude.ai/code/session_01XRHKpxgDnVB3GJdsV9ud7g

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved minor garbage-collection handling to retain forwarding information when it may still be needed, preserving access to expanded objects.
  - Added safeguards to reduce the risk of invalid references during minor collection and sweeping.

- **Diagnostics**
  - Added optional, non-fatal heap verification when `PERRY_GC_VERIFY_MARK` is enabled.
  - Diagnostic reports identify potential marking and young-generation reference issues without interrupting collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->