### PR TITLE
ci: raise conformance-smoke shard timeout 55->75 min (#6456)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -896,11 +896,18 @@ jobs:
         shard: [1, 2, 3, 4, 5, 6, 7, 8]
     if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    # Observed 19-37 min/shard on the first real sharded PR run. 40 left only
-    # ~3 min headroom over the slowest shard, so a slow-runner day could trip
-    # the timeout and (once this gate is a required context) flaky-red-block
-    # every PR. 55 gives comfortable headroom without hiding a genuine hang.
-    timeout-minutes: 55
+    # Per-shard wall time has crept up as the gap suite grew: the original
+    # sharded run was 19-37 min/shard, but 2026-07-16 measured 33-44 min for
+    # shards 2-8 and shard 1 (its slice is the heaviest) hit 55:18 — the exact
+    # 55-min cap — and CANCELLED on every run, incl. `gh run rerun --failed`.
+    # On slow-runner days a second shard (observed: shard 3) also grazed 55.
+    # Because `conformance-smoke-complete` is a required context, that
+    # deterministic timeout flaky-red-blocked every PR (#6456). Bump to 75 for
+    # comfortable headroom (~35 min over the normal-day slowest, ~20 over the
+    # heavy shard) while still bounding a genuine hang. Durable fix — raising
+    # the shard count 8->12 so no single slice approaches the cap — tracked as
+    # a follow-up on #6456.
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
## Summary

Fixes #6456 (interim). Raises the `conformance-smoke` per-shard
`timeout-minutes` from **55 → 75**.

## Why

The gap suite has grown past the point where the 55-min per-shard cap holds.
Measured 2026-07-16 across this session's PR batch:

- shards 2–8: **33–44 min**
- **shard 1** (its `--shard 1/8` slice is the heaviest): **55:18 — the exact cap — CANCELLED on every run**, including `gh run rerun --failed`
- on slow-runner days a second shard (observed: shard 3) also grazed 55

Because `conformance-smoke-complete` (the fan-in over all 8 shards) is a
**required** branch-protection context, that deterministic timeout red-blocked
every open PR — the eight PRs that landed this session each needed an admin
bypass. 75 min gives ~20 min headroom over the heavy shard and ~35 over the
normal-day slowest, while still bounding a genuine hang.

## Scope

Single value + rationale comment in `.github/workflows/test.yml`. YAML validated
locally (`yaml.safe_load` + `actionlint` parse). The durable follow-up — raising
the shard count 8→12 so no single slice approaches the cap — stays tracked on
#6456.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the conformance smoke test timeout to reduce premature cancellations.
  * Updated workflow guidance with recent shard timing observations and follow-up recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->