### PR TITLE
Expand node trace events parity coverage

### DIFF
--- a/scripts/node_suite_run.py
+++ b/scripts/node_suite_run.py
@@ -82,6 +82,7 @@ SLOW_MODULES = {
     "http", "http2", "https", "net", "dgram", "tls", "cluster", "dns", "async_hooks",
     "stream", "child_process", "worker_threads", "inspector",
     "inspector-promises", "repl", "diagnostics_channel", "timers", "perf_hooks", "fetch",
+    "trace_events",
 }
 
 tests = []

--- a/test-parity/node-suite/trace_events/README.md
+++ b/test-parity/node-suite/trace_events/README.md
@@ -1,0 +1,78 @@
+# `node:trace_events` granular parity suite
+
+This directory covers deterministic public `node:trace_events` contracts. Node
+26.5.0 is the behavioral oracle. Cases print normalized semantic facts rather
+than volatile trace payloads, paths, process/thread identifiers, timestamps, or
+scheduler-dependent event order.
+
+## Source audit
+
+- Node.js `v26.5.0` (`bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb`):
+  `lib/trace_events.js`, `doc/api/tracing.md`, and the 29
+  `test/parallel/test-trace-events-*.js` selections.
+- Deno `main` (`803a3c933e1e23e0972445293ec0b34b8da96ccc`):
+  `ext/node/polyfills/trace_events.ts` and `trace_events_esm.ts`. Deno keeps the
+  source categories array by reference and preserves insertion order in its
+  JavaScript category registry. Deno 2.9.2 executed all 24 TypeScript fixtures,
+  matching Node stdout in 13; its Node-style CLI flags did not feed the public
+  category registry or produce native trace files in the controlled lane.
+- Bun `main` (`aca54d5c2b874ac304a3bbe1d67630e4daf17b43`):
+  `src/js/node/trace_events.ts` plus Bun's selected Node fixtures. Current
+  source copies the categories array and delegates category/file behavior to
+  `internal/trace_events`. The locally available Bun 1.2.18 predates that
+  implementation: 14 of 24 fixtures executed and the stateful tests exposed its
+  older stub behavior. It is recorded as support evidence, not used as the
+  oracle.
+
+## Covered contracts
+
+- Module exports and descriptors; `Tracing` prototype, constructor, accessors,
+  and method surface.
+- Options/category validation, inherited/accessor options, duplicate and empty
+  category entries, and the distinct property-vs-native-handle mutation rules.
+- Read-only accessors, incompatible receivers, idempotent repeated cycles,
+  global normalization, overlap/reference counts, tracer isolation, and the
+  enabled-object warning threshold.
+- Categories inherited from `--trace-event-categories` in a controlled child.
+- Native flags, exit flushing, semantic JSON shape, metadata, category filtering
+  across `disable()`, and normalized `${pid}`/`${rotation}` file-pattern
+  expansion.
+
+Every subprocess file-output case uses a fresh temporary directory and removes
+it in `finally`. In-process cases that enable tracing also redirect Node's trace
+file into a temporary directory before the first enable.
+
+## Measured Perry boundary
+
+Repeated focused runs produce 14/24 parity matches with no compile failures,
+timeouts, harness errors, leaked subprocesses, or temporary artifacts. The ten
+stable differences diagnose:
+
+- module function names/configurability, the exposed `Tracing` constructor's
+  arity/constructibility, and Perry's own `__perryTraceEventsId`/`constructor`
+  instance properties;
+- Node's live `categories` property view of the source array (including later
+  join coercion) versus Perry's property snapshot;
+- the warning emitted after more than ten enabled controllers;
+- categories inherited from process flags; and
+- four native-output contracts: JSON/file creation, metadata/category filtering,
+  disable filtering, and file-pattern placeholder expansion.
+
+## Deliberate stopping boundaries
+
+- Inspector/Perfetto/Chrome tooling and dynamic inspector collection require a
+  separate inspector integration lane.
+- Worker aggregation, worker metadata, and cross-thread async-hooks topology
+  introduce process/thread ordering and aggregation races.
+- Console, fs, net, HTTP, promise, VM, V8, thread-pool, and async-hooks provider
+  payload tests belong to those provider suites; the single console marker here
+  diagnoses the public `disable()` filter without snapshotting its payload.
+- Signals, crashes, permissions/kernel faults, rotation/buffer overflow, huge
+  traces, profiling/coverage, and stress tests are platform- or timing-sensitive
+  native tracing work.
+- Forced-GC retention of an otherwise unreachable enabled controller depends on
+  the separate `--expose-gc`/collector lane; the enabled-controller warning is
+  covered without forcing a collection.
+- Perry's implementation explicitly provides category control without Chrome
+  trace-event emission. Native-file cases intentionally diagnose that boundary;
+  this parity-only suite does not change runtime behavior.

--- a/test-parity/node-suite/trace_events/controller-shape.ts
+++ b/test-parity/node-suite/trace_events/controller-shape.ts
@@ -1,21 +1,34 @@
 import { createTracing } from "node:trace_events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { chdir, cwd } from "node:process";
 
-const tracing = createTracing({ categories: ["node", "v8"] });
+const parent = cwd();
+const temporary = mkdtempSync(join(tmpdir(), "perry-trace-controller-"));
 
-console.log("constructor:", tracing.constructor.name);
-console.log("keys:", Object.keys(tracing).join(","));
-console.log(
-  "own props:",
-  String(Object.prototype.hasOwnProperty.call(tracing, "categories")),
-  String(Object.prototype.hasOwnProperty.call(tracing, "enabled")),
-  String(Object.prototype.hasOwnProperty.call(tracing, "enable")),
-  String(Object.prototype.hasOwnProperty.call(tracing, "disable")),
-);
-console.log("categories:", tracing.categories);
-console.log("enabled:", String(tracing.enabled));
-console.log("methods:", typeof tracing.enable, typeof tracing.disable);
-console.log("method lengths:", tracing.enable.length, tracing.disable.length);
-console.log("enable return:", String(tracing.enable()));
-console.log("enabled after enable:", String(tracing.enabled));
-console.log("disable return:", String(tracing.disable()));
-console.log("enabled after disable:", String(tracing.enabled));
+try {
+  chdir(temporary);
+  const tracing = createTracing({ categories: ["node", "v8"] });
+
+  console.log("constructor:", tracing.constructor.name);
+  console.log("keys:", Object.keys(tracing).join(","));
+  console.log(
+    "own props:",
+    String(Object.prototype.hasOwnProperty.call(tracing, "categories")),
+    String(Object.prototype.hasOwnProperty.call(tracing, "enabled")),
+    String(Object.prototype.hasOwnProperty.call(tracing, "enable")),
+    String(Object.prototype.hasOwnProperty.call(tracing, "disable")),
+  );
+  console.log("categories:", tracing.categories);
+  console.log("enabled:", String(tracing.enabled));
+  console.log("methods:", typeof tracing.enable, typeof tracing.disable);
+  console.log("method lengths:", tracing.enable.length, tracing.disable.length);
+  console.log("enable return:", String(tracing.enable()));
+  console.log("enabled after enable:", String(tracing.enabled));
+  console.log("disable return:", String(tracing.disable()));
+  console.log("enabled after disable:", String(tracing.enabled));
+} finally {
+  chdir(parent);
+  rmSync(temporary, { recursive: true, force: true });
+}

--- a/test-parity/node-suite/trace_events/enabled-categories.ts
+++ b/test-parity/node-suite/trace_events/enabled-categories.ts
@@ -1,34 +1,50 @@
 import * as traceEvents from "node:trace_events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { chdir, cwd } from "node:process";
 
-const a = traceEvents.createTracing({ categories: ["z", "a", "z", "m"] });
-const b = traceEvents.createTracing({ categories: ["b", "a"] });
+const parent = cwd();
+const temporary = mkdtempSync(join(tmpdir(), "perry-trace-enabled-"));
+try {
+  chdir(temporary);
+  const a = traceEvents.createTracing({ categories: ["z", "a", "z", "m"] });
+  const b = traceEvents.createTracing({ categories: ["b", "a"] });
 
-function enabled(label: string) {
-  const value = traceEvents.getEnabledCategories();
-  console.log(label + ":", String(value), typeof value);
+  function enabled(label: string) {
+    const value = traceEvents.getEnabledCategories();
+    console.log(label + ":", String(value), typeof value);
+  }
+
+  console.log(
+    "exports:",
+    typeof traceEvents.createTracing,
+    typeof traceEvents.getEnabledCategories,
+  );
+  console.log(
+    "export lengths:",
+    traceEvents.createTracing.length,
+    traceEvents.getEnabledCategories.length,
+  );
+  console.log("initial enabled:", String(a.enabled), String(b.enabled));
+  enabled("global initial");
+
+  console.log("enable a:", String(a.enable()));
+  console.log("after enable a:", String(a.enabled), String(b.enabled));
+  enabled("global after a");
+
+  console.log("enable a again:", String(a.enable()));
+  console.log("enable b:", String(b.enable()));
+  enabled("global after b");
+
+  console.log("disable a:", String(a.disable()));
+  console.log("after disable a:", String(a.enabled), String(b.enabled));
+  enabled("global after disable a");
+
+  console.log("disable a again:", String(a.disable()));
+  console.log("disable b:", String(b.disable()));
+  enabled("global after disable b");
+} finally {
+  chdir(parent);
+  rmSync(temporary, { recursive: true, force: true });
 }
-
-console.log("exports:", typeof traceEvents.createTracing, typeof traceEvents.getEnabledCategories);
-console.log(
-  "export lengths:",
-  traceEvents.createTracing.length,
-  traceEvents.getEnabledCategories.length,
-);
-console.log("initial enabled:", String(a.enabled), String(b.enabled));
-enabled("global initial");
-
-console.log("enable a:", String(a.enable()));
-console.log("after enable a:", String(a.enabled), String(b.enabled));
-enabled("global after a");
-
-console.log("enable a again:", String(a.enable()));
-console.log("enable b:", String(b.enable()));
-enabled("global after b");
-
-console.log("disable a:", String(a.disable()));
-console.log("after disable a:", String(a.enabled), String(b.enabled));
-enabled("global after disable a");
-
-console.log("disable a again:", String(a.disable()));
-console.log("disable b:", String(b.disable()));
-enabled("global after disable b");

--- a/test-parity/node-suite/trace_events/native-output/category-filtering.ts
+++ b/test-parity/node-suite/trace_events/native-output/category-filtering.ts
@@ -1,0 +1,55 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const marker = "__trace_events_filter_child__";
+
+if (!process.argv.includes(marker)) {
+  for (const category of ["node.bootstrap", '""']) {
+    const temporary = mkdtempSync(join(tmpdir(), "perry-trace-filter-"));
+    try {
+      const script = process.argv[1];
+      const args = ["--trace-event-categories", category];
+      if (typeof script === "string" && script.endsWith(".ts")) {
+        args.push(script);
+      }
+      args.push(marker);
+      const result = spawnSync(process.execPath, args, {
+        cwd: temporary,
+        encoding: "utf8",
+      });
+      const files = readdirSync(temporary).filter((name) =>
+        name.endsWith(".log")
+      );
+      console.log(
+        "case:",
+        category,
+        "status/files:",
+        result.status,
+        files.length,
+      );
+      if (files.length === 1) {
+        const events =
+          JSON.parse(readFileSync(join(temporary, files[0]), "utf8"))
+            .traceEvents;
+        const application = events.filter((event: any) =>
+          event.cat !== "__metadata"
+        );
+        console.log(
+          "metadata present:",
+          events.some((event: any) => event.cat === "__metadata"),
+        );
+        console.log("application count positive:", application.length > 0);
+        console.log(
+          "filter respected:",
+          application.every((event: any) =>
+            event.cat === "node,node.bootstrap"
+          ),
+        );
+      }
+    } finally {
+      rmSync(temporary, { recursive: true, force: true });
+    }
+  }
+}

--- a/test-parity/node-suite/trace_events/native-output/disable-filter.ts
+++ b/test-parity/node-suite/trace_events/native-output/disable-filter.ts
@@ -1,0 +1,45 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createTracing } from "node:trace_events";
+
+const marker = "__trace_events_disable_child__";
+
+if (process.argv.includes(marker)) {
+  const tracing = createTracing({ categories: ["node.console"] });
+  tracing.enable();
+  console.time("included-marker");
+  console.timeEnd("included-marker");
+  tracing.disable();
+  console.time("excluded-marker");
+  console.timeEnd("excluded-marker");
+} else {
+  const temporary = mkdtempSync(join(tmpdir(), "perry-trace-disable-"));
+  try {
+    const script = process.argv[1];
+    const args: string[] = [];
+    if (typeof script === "string" && script.endsWith(".ts")) args.push(script);
+    args.push(marker);
+    const result = spawnSync(process.execPath, args, {
+      cwd: temporary,
+      encoding: "utf8",
+    });
+    const files = readdirSync(temporary).filter((name) =>
+      name.endsWith(".log")
+    );
+    console.log("status/files:", result.status, files.length);
+    if (files.length === 1) {
+      const events = JSON.parse(
+        readFileSync(join(temporary, files[0]), "utf8"),
+      ).traceEvents;
+      console.log(
+        "included/excluded:",
+        events.some((event: any) => event.name?.endsWith("included-marker")),
+        events.some((event: any) => event.name?.endsWith("excluded-marker")),
+      );
+    }
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}

--- a/test-parity/node-suite/trace_events/native-output/file-pattern.ts
+++ b/test-parity/node-suite/trace_events/native-output/file-pattern.ts
@@ -1,0 +1,43 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const marker = "__trace_events_pattern_child__";
+
+if (!process.argv.includes(marker)) {
+  const temporary = mkdtempSync(join(tmpdir(), "perry-trace-pattern-"));
+  try {
+    const script = process.argv[1];
+    const pattern = "trace-${pid}-${rotation}-${pid}-${rotation}.json";
+    const args = [
+      "--trace-events-enabled",
+      "--trace-event-file-pattern",
+      pattern,
+    ];
+    if (typeof script === "string" && script.endsWith(".ts")) args.push(script);
+    args.push(marker);
+    const result = spawnSync(process.execPath, args, {
+      cwd: temporary,
+      encoding: "utf8",
+    });
+    const files = readdirSync(temporary);
+    const expected = `trace-${result.pid}-1-${result.pid}-1.json`;
+    console.log("status/files:", result.status, files.length);
+    console.log(
+      "placeholder match:",
+      files.length === 1 && files[0] === expected,
+    );
+    if (files.length === 1) {
+      console.log(
+        "valid trace:",
+        Array.isArray(
+          JSON.parse(readFileSync(join(temporary, files[0]), "utf8"))
+            .traceEvents,
+        ),
+      );
+    }
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}

--- a/test-parity/node-suite/trace_events/native-output/file-shape-exit.ts
+++ b/test-parity/node-suite/trace_events/native-output/file-shape-exit.ts
@@ -1,0 +1,39 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const marker = "__trace_events_file_child__";
+
+if (process.argv.includes(marker)) {
+  process.exit(0);
+} else {
+  const temporary = mkdtempSync(join(tmpdir(), "perry-trace-file-"));
+  try {
+    const script = process.argv[1];
+    const args = ["--trace-events-enabled"];
+    if (typeof script === "string" && script.endsWith(".ts")) args.push(script);
+    args.push(marker);
+    const result = spawnSync(process.execPath, args, {
+      cwd: temporary,
+      encoding: "utf8",
+    });
+    const files = readdirSync(temporary).filter((name) =>
+      name.endsWith(".log")
+    );
+    console.log("status/files:", result.status, files.length);
+    if (files.length === 1) {
+      const document = JSON.parse(
+        readFileSync(join(temporary, files[0]), "utf8"),
+      );
+      const events = document.traceEvents;
+      console.log("shape:", Array.isArray(events), events.length > 0);
+      console.log(
+        "metadata:",
+        events.some((event: any) => event.cat === "__metadata"),
+      );
+    }
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}

--- a/test-parity/node-suite/trace_events/state.ts
+++ b/test-parity/node-suite/trace_events/state.ts
@@ -1,31 +1,43 @@
 import * as traceEvents from "node:trace_events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { chdir, cwd } from "node:process";
 
-function enabled() {
-  return String(traceEvents.getEnabledCategories());
+const parent = cwd();
+const temporary = mkdtempSync(join(tmpdir(), "perry-trace-state-"));
+try {
+  chdir(temporary);
+  function enabled() {
+    return String(traceEvents.getEnabledCategories());
+  }
+
+  const a = traceEvents.createTracing({ categories: ["b", "a"] });
+  const b = traceEvents.createTracing({ categories: ["c", "a"] });
+  const c = traceEvents.createTracing({ categories: ["d", "b"] });
+
+  console.log("initial:", a.enabled, b.enabled, enabled());
+  console.log("enable return:", a.enable());
+  console.log("after a:", a.enabled, b.enabled, enabled());
+  a.enable();
+  console.log("after a again:", a.enabled, enabled());
+  b.enable();
+  console.log("after b:", a.enabled, b.enabled, enabled());
+  c.enable();
+  console.log("after c:", enabled());
+  a.disable();
+  console.log("after a disable:", a.enabled, b.enabled, enabled());
+  b.disable();
+  console.log("after b disable:", b.enabled, enabled());
+  c.disable();
+  console.log("after c disable:", c.enabled, enabled());
+
+  const dup = traceEvents.createTracing({ categories: ["x", "x", "y"] });
+  dup.enable();
+  console.log("duplicates:", dup.categories, enabled());
+  dup.disable();
+  console.log("duplicates disabled:", enabled());
+} finally {
+  chdir(parent);
+  rmSync(temporary, { recursive: true, force: true });
 }
-
-const a = traceEvents.createTracing({ categories: ["b", "a"] });
-const b = traceEvents.createTracing({ categories: ["c", "a"] });
-const c = traceEvents.createTracing({ categories: ["d", "b"] });
-
-console.log("initial:", a.enabled, b.enabled, enabled());
-console.log("enable return:", a.enable());
-console.log("after a:", a.enabled, b.enabled, enabled());
-a.enable();
-console.log("after a again:", a.enabled, enabled());
-b.enable();
-console.log("after b:", a.enabled, b.enabled, enabled());
-c.enable();
-console.log("after c:", enabled());
-a.disable();
-console.log("after a disable:", a.enabled, b.enabled, enabled());
-b.disable();
-console.log("after b disable:", b.enabled, enabled());
-c.disable();
-console.log("after c disable:", c.enabled, enabled());
-
-const dup = traceEvents.createTracing({ categories: ["x", "x", "y"] });
-dup.enable();
-console.log("duplicates:", dup.categories, enabled());
-dup.disable();
-console.log("duplicates disabled:", enabled());

--- a/test-parity/node-suite/trace_events/state/category-normalization.ts
+++ b/test-parity/node-suite/trace_events/state/category-normalization.ts
@@ -1,0 +1,35 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { chdir, cwd } from "node:process";
+import { createTracing, getEnabledCategories } from "node:trace_events";
+
+const parent = cwd();
+const temporary = mkdtempSync(join(tmpdir(), "perry-trace-categories-"));
+const cases = [
+  [""],
+  ["z", "a", "m"],
+  ["z", "z", "a"],
+  ["a,b"],
+  [" spaced "],
+  ["*"],
+];
+
+try {
+  chdir(temporary);
+  for (const categories of cases) {
+    const tracing = createTracing({ categories });
+    tracing.enable();
+    console.log(
+      JSON.stringify(categories),
+      "property:",
+      JSON.stringify(tracing.categories),
+      "global:",
+      JSON.stringify(getEnabledCategories()),
+    );
+    tracing.disable();
+  }
+} finally {
+  chdir(parent);
+  rmSync(temporary, { recursive: true, force: true });
+}

--- a/test-parity/node-suite/trace_events/state/enabled-object-warning.ts
+++ b/test-parity/node-suite/trace_events/state/enabled-object-warning.ts
@@ -1,0 +1,35 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { chdir, cwd } from "node:process";
+import { createTracing } from "node:trace_events";
+
+const parent = cwd();
+const temporary = mkdtempSync(join(tmpdir(), "perry-trace-warning-"));
+const originalEmitWarning = process.emitWarning;
+const tracers: ReturnType<typeof createTracing>[] = [];
+let warnings = 0;
+let expectedMessage = false;
+
+try {
+  chdir(temporary);
+  process.emitWarning = ((warning: string | Error) => {
+    warnings++;
+    const message = warning instanceof Error
+      ? warning.message
+      : String(warning);
+    expectedMessage = message.includes("more than 10 enabled Tracing objects");
+  }) as typeof process.emitWarning;
+
+  for (let index = 0; index < 11; index++) {
+    const tracing = createTracing({ categories: [`warning-${index}`] });
+    tracing.enable();
+    tracers.push(tracing);
+  }
+  console.log("warnings/message:", warnings, expectedMessage);
+} finally {
+  for (const tracing of tracers) tracing.disable();
+  process.emitWarning = originalEmitWarning;
+  chdir(parent);
+  rmSync(temporary, { recursive: true, force: true });
+}

--- a/test-parity/node-suite/trace_events/state/get-enabled-call-semantics.ts
+++ b/test-parity/node-suite/trace_events/state/get-enabled-call-semantics.ts
@@ -1,0 +1,8 @@
+import { getEnabledCategories } from "node:trace_events";
+
+console.log("plain:", String(getEnabledCategories()));
+console.log("with argument:", String((getEnabledCategories as any)("ignored")));
+console.log(
+  "with receiver:",
+  String(getEnabledCategories.call({ ignored: true })),
+);

--- a/test-parity/node-suite/trace_events/state/property-assignment.ts
+++ b/test-parity/node-suite/trace_events/state/property-assignment.ts
@@ -1,0 +1,16 @@
+import { createTracing } from "node:trace_events";
+
+const tracing = createTracing({ categories: ["readonly"] });
+
+function assign(label: string, name: "categories" | "enabled", value: any) {
+  try {
+    (tracing as any)[name] = value;
+    console.log(label, "OK");
+  } catch (error: any) {
+    console.log(label, "THROW", error.name, String(error.code));
+  }
+}
+
+assign("categories", "categories", "changed");
+assign("enabled", "enabled", true);
+console.log("values:", tracing.categories, tracing.enabled);

--- a/test-parity/node-suite/trace_events/state/receiver-validation.ts
+++ b/test-parity/node-suite/trace_events/state/receiver-validation.ts
@@ -1,0 +1,22 @@
+import { createTracing } from "node:trace_events";
+
+const tracing = createTracing({ categories: ["receiver"] });
+const prototype = Object.getPrototypeOf(tracing);
+const categories = Object.getOwnPropertyDescriptor(prototype, "categories")!
+  .get!;
+const enabled = Object.getOwnPropertyDescriptor(prototype, "enabled")!.get!;
+
+function probe(label: string, fn: () => unknown) {
+  try {
+    fn();
+    console.log(label, "OK");
+  } catch (error: any) {
+    console.log(label, "THROW", error.name, String(error.code));
+  }
+}
+
+probe("enable null", () => tracing.enable.call(null));
+probe("enable object", () => tracing.enable.call({}));
+probe("disable prototype", () => tracing.disable.call(prototype));
+probe("categories object", () => categories.call({}));
+probe("enabled null", () => enabled.call(null));

--- a/test-parity/node-suite/trace_events/state/repeated-cycles.ts
+++ b/test-parity/node-suite/trace_events/state/repeated-cycles.ts
@@ -1,0 +1,29 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { chdir, cwd } from "node:process";
+import { createTracing, getEnabledCategories } from "node:trace_events";
+
+const parent = cwd();
+const temporary = mkdtempSync(join(tmpdir(), "perry-trace-cycles-"));
+
+try {
+  chdir(temporary);
+  const left = createTracing({ categories: ["shared", "left"] });
+  const right = createTracing({ categories: ["right", "shared"] });
+
+  for (let cycle = 1; cycle <= 3; cycle++) {
+    right.enable();
+    left.enable();
+    left.enable();
+    console.log("cycle", cycle, "enabled:", String(getEnabledCategories()));
+    right.disable();
+    console.log("cycle", cycle, "left only:", String(getEnabledCategories()));
+    left.disable();
+    left.disable();
+    console.log("cycle", cycle, "disabled:", String(getEnabledCategories()));
+  }
+} finally {
+  chdir(parent);
+  rmSync(temporary, { recursive: true, force: true });
+}

--- a/test-parity/node-suite/trace_events/subprocess/pre-enabled-categories.ts
+++ b/test-parity/node-suite/trace_events/subprocess/pre-enabled-categories.ts
@@ -1,0 +1,33 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createTracing, getEnabledCategories } from "node:trace_events";
+
+const marker = "__trace_events_flag_child__";
+
+if (process.argv.includes(marker)) {
+  console.log("initial:", String(getEnabledCategories()));
+  const tracing = createTracing({ categories: ["dynamic", "flag.alpha"] });
+  tracing.enable();
+  console.log("with dynamic:", String(getEnabledCategories()));
+  tracing.disable();
+  console.log("after disable:", String(getEnabledCategories()));
+} else {
+  const temporary = mkdtempSync(join(tmpdir(), "perry-trace-flags-"));
+  try {
+    const script = process.argv[1];
+    const args = ["--trace-event-categories", "flag.beta,flag.alpha"];
+    if (typeof script === "string" && script.endsWith(".ts")) args.push(script);
+    args.push(marker);
+
+    const result = spawnSync(process.execPath, args, {
+      cwd: temporary,
+      encoding: "utf8",
+    });
+    console.log("status:", result.status);
+    console.log((result.stdout || "").trim());
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+}

--- a/test-parity/node-suite/trace_events/surface/constructor-behavior.ts
+++ b/test-parity/node-suite/trace_events/surface/constructor-behavior.ts
@@ -1,0 +1,31 @@
+import { createTracing } from "node:trace_events";
+
+const first = createTracing({ categories: ["first"] });
+const second = createTracing({ categories: ["second"] });
+const Constructor = first.constructor as any;
+
+console.log("identity:", Constructor === second.constructor);
+console.log("name/length:", Constructor.name, Constructor.length);
+console.log(
+  "prototype identity:",
+  Constructor.prototype === Object.getPrototypeOf(first),
+);
+
+try {
+  Constructor(["direct"]);
+  console.log("call without new: OK");
+} catch (error: any) {
+  console.log("call without new:", error.name, String(error.code));
+}
+
+try {
+  const direct = new Constructor(["direct"]);
+  console.log(
+    "new instance: OK",
+    direct instanceof Constructor,
+    direct.categories,
+    direct.enabled,
+  );
+} catch (error: any) {
+  console.log("new instance: THROW", error.name, String(error.code));
+}

--- a/test-parity/node-suite/trace_events/surface/module-descriptors.ts
+++ b/test-parity/node-suite/trace_events/surface/module-descriptors.ts
@@ -1,0 +1,22 @@
+import * as traceEvents from "node:trace_events";
+
+function descriptor(name: "createTracing" | "getEnabledCategories") {
+  const value = Object.getOwnPropertyDescriptor(traceEvents, name)!;
+  console.log(
+    name,
+    typeof value.value,
+    value.value.name,
+    value.value.length,
+    value.enumerable,
+    value.configurable,
+    value.writable,
+  );
+}
+
+console.log(
+  "own names:",
+  Object.getOwnPropertyNames(traceEvents).sort().join(","),
+);
+descriptor("createTracing");
+descriptor("getEnabledCategories");
+console.log("frozen:", Object.isFrozen(traceEvents));

--- a/test-parity/node-suite/trace_events/surface/tracing-prototype.ts
+++ b/test-parity/node-suite/trace_events/surface/tracing-prototype.ts
@@ -1,0 +1,38 @@
+import { createTracing } from "node:trace_events";
+
+const tracing = createTracing({ categories: ["surface"] });
+const prototype = Object.getPrototypeOf(tracing);
+
+for (
+  const name of ["constructor", "categories", "enabled", "enable", "disable"]
+) {
+  const descriptor = Object.getOwnPropertyDescriptor(prototype, name)!;
+  console.log(
+    name,
+    "data:",
+    "value" in descriptor,
+    "get:",
+    descriptor.get?.name ?? "none",
+    "set:",
+    descriptor.set?.name ?? "none",
+    "writable:",
+    String(descriptor.writable),
+    "enumerable:",
+    descriptor.enumerable,
+    "configurable:",
+    descriptor.configurable,
+  );
+}
+
+console.log(
+  "prototype parent:",
+  Object.getPrototypeOf(prototype) === Object.prototype,
+);
+console.log(
+  "instance own names:",
+  Object.getOwnPropertyNames(tracing).join(","),
+);
+console.log(
+  "instance owns constructor:",
+  Object.hasOwn(tracing, "constructor"),
+);

--- a/test-parity/node-suite/trace_events/validation/categories-property-resolution.ts
+++ b/test-parity/node-suite/trace_events/validation/categories-property-resolution.ts
@@ -1,0 +1,20 @@
+import { createTracing } from "node:trace_events";
+
+const inherited = createTracing(Object.create({ categories: ["inherited"] }));
+console.log("inherited:", inherited.categories);
+
+let reads = 0;
+const accessorOptions = {
+  get categories() {
+    reads++;
+    return ["accessor"];
+  },
+};
+const accessor = createTracing(accessorOptions);
+console.log("accessor:", accessor.categories, "read:", reads > 0);
+
+const original = ["original"];
+const options = { categories: original };
+const tracing = createTracing(options);
+options.categories = ["replacement"];
+console.log("options replacement:", tracing.categories);

--- a/test-parity/node-suite/trace_events/validation/category-array-mutation.ts
+++ b/test-parity/node-suite/trace_events/validation/category-array-mutation.ts
@@ -1,0 +1,45 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { chdir, cwd } from "node:process";
+import { createTracing, getEnabledCategories } from "node:trace_events";
+
+const parent = cwd();
+const temporary = mkdtempSync(join(tmpdir(), "perry-trace-mutation-"));
+
+try {
+  chdir(temporary);
+  const categories = ["beta", "alpha", "beta"];
+  const tracing = createTracing({ categories });
+
+  categories[0] = "changed-before-enable";
+  categories.push("appended-before-enable");
+  console.log("property before enable:", tracing.categories);
+
+  tracing.enable();
+  console.log("enabled categories:", String(getEnabledCategories()));
+
+  categories[1] = "changed-after-enable";
+  categories.length = 1;
+  console.log("property after mutation:", tracing.categories);
+  console.log("enabled after mutation:", String(getEnabledCategories()));
+
+  tracing.disable();
+  console.log("after disable:", String(getEnabledCategories()));
+
+  categories[0] = 123 as any;
+  console.log("post-construction number coercion:", tracing.categories);
+  categories[0] = Symbol("category") as any;
+  try {
+    console.log("post-construction symbol coercion:", tracing.categories);
+  } catch (error: any) {
+    console.log(
+      "post-construction symbol coercion: THROW",
+      error.name,
+      String(error.code),
+    );
+  }
+} finally {
+  chdir(parent);
+  rmSync(temporary, { recursive: true, force: true });
+}

--- a/test-parity/node-suite/trace_events/validation/category-entry-boundaries.ts
+++ b/test-parity/node-suite/trace_events/validation/category-entry-boundaries.ts
@@ -1,0 +1,21 @@
+import { createTracing } from "node:trace_events";
+
+function probe(label: string, value: any) {
+  try {
+    createTracing({ categories: ["valid", value] });
+    console.log(label, "OK");
+  } catch (error: any) {
+    console.log(label, "THROW", error.name, error.code);
+  }
+}
+
+probe("undefined", undefined);
+probe("null", null);
+probe("boolean", true);
+probe("number", 1);
+probe("object", {});
+probe("array", []);
+probe("function", () => "category");
+
+const sparse = new Array(1);
+probe("sparse", sparse[0]);

--- a/test-parity/node-suite/trace_events/validation/options-boundaries.ts
+++ b/test-parity/node-suite/trace_events/validation/options-boundaries.ts
@@ -1,0 +1,21 @@
+import { createTracing } from "node:trace_events";
+
+function probe(label: string, options: any) {
+  try {
+    const tracing = createTracing(options);
+    console.log(label, "OK", tracing.categories);
+  } catch (error: any) {
+    console.log(label, "THROW", error.name, error.code);
+  }
+}
+
+probe("undefined", undefined);
+probe("null", null);
+probe("false", false);
+probe("zero", 0);
+probe("string", "category");
+probe("function", () => {});
+probe("array", []);
+probe("date", new Date(0));
+probe("null prototype", Object.create(null));
+probe("extra property", { categories: ["ok"], extra: true });

--- a/test-parity/node_suite_baseline.json
+++ b/test-parity/node_suite_baseline.json
@@ -182,8 +182,8 @@
       "total": 100
     },
     "trace_events": {
-      "pass": 6,
-      "total": 6
+      "pass": 14,
+      "total": 24
     },
     "tty": {
       "pass": 32,


### PR DESCRIPTION
## Summary

- expand the granular `node:trace_events` suite from 6 to 24 deterministic fixtures
- cover module/prototype/constructor descriptors, validation, category mutation and normalization, receiver checks, repeated overlap cycles, warning thresholds, and process-flag inheritance
- add isolated native-output diagnostics for trace JSON shape, metadata/category filtering, disable filtering, and `${pid}`/`${rotation}` file patterns
- move `trace_events` to the sequential node-suite lane and ratchet the measured baseline to 14/24
- document the Node 26.5.0, Deno main/2.9.2, and Bun main/1.2.18 source and runtime evidence plus stopping exclusions

## Measured compatibility

Node 26.5.0 is the oracle. Perry repeatedly reports 14/24 matches with 10 stable behavioral differences and no compile failures, timeouts, or harness errors.

The differences cover:
- module function descriptors, constructor arity/constructibility, and Perry-only instance properties
- live source-array category property semantics
- the enabled-controller warning threshold
- categories inherited from process flags
- native trace-file creation/JSON, filtering, and file-pattern behavior

Deno 2.9.2 executes 24/24 fixtures and matches Node stdout in 13/24. Bun 1.2.18 executes 14/24; current Bun main contains a newer implementation than that local runtime.

## Verification

- `cargo build --profile perry-dev -p perry -p perry-runtime-static -p perry-stdlib-static`
- `NODE_BIN=~/.nvm/versions/node/v26.5.0/bin/node PERRY_RUNTIME_DIR=$PWD/target/perry-dev python3 scripts/node_suite_run.py $PWD/target/perry-dev/perry $PWD trace_events` — repeated: 14/24, 10 expected diffs
- Node 26.5.0 direct execution of all 24 fixtures, three rounds — 24/24 each round
- Deno 2.9.2 — 24/24 executable, 13/24 exact Node stdout
- Bun 1.2.18 — 14/24 executable
- `deno fmt --check` on changed trace-events files
- `python3 -m py_compile scripts/node_suite_run.py scripts/node_suite_regression_check.py`
- `python3 -m json.tool test-parity/node_suite_baseline.json`
- `cargo fmt --all -- --check`
- `./scripts/check_file_size.sh`
- `git diff --check`
- cleanup audit: no trace logs or temporary directories leaked

## Exclusions

Inspector tooling, worker aggregation races, provider-specific payload matrices, forced-GC retention, signals/crashes, file-permission and kernel faults, rotation/overflow, huge traces, profiling/coverage, and stress remain separate native or nondeterministic lanes. This change documents Perry's native-emission boundary without changing runtime behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Coverage**
  * Added comprehensive parity checks for trace-event APIs, including validation, state transitions, warnings, category handling, and native trace output.
  * Added coverage for subprocess behavior, file naming, filtering, JSON structure, and repeated enable/disable cycles.

* **Documentation**
  * Documented supported trace-event contracts, parity expectations, and testing boundaries.

* **Tests**
  * Updated suite baselines to reflect expanded trace-event coverage and revised measured results.
  * Improved test isolation and deterministic execution for trace-event checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->