### PR TITLE
fix(async): don't report caught throw-after-await as unhandled rejection

### DIFF
--- a/crates/perry-runtime/src/promise/assimilate.rs
+++ b/crates/perry-runtime/src/promise/assimilate.rs
@@ -200,6 +200,19 @@ pub(crate) fn promise_resolve_assimilating(promise: *mut Promise, value: f64) {
 pub(super) fn enqueue_native_adoption_job(outer: *mut Promise, inner: *mut Promise) {
     use crate::closure::{js_closure_alloc, js_closure_set_capture_ptr};
 
+    // `outer` is adopting `inner`'s eventual state — `inner`'s rejection (now or
+    // later) is consumed by `outer`, so `inner` is no longer an unhandled
+    // rejection. The synchronous adoption path (`js_promise_resolve_with_promise`)
+    // marks this at then.rs's Pending arm; this deferred native-job path
+    // (V8-hop-parity adoption used by `async fn` return AND by an async fn that
+    // THROWS after an `await` — its step-catch `Promise.reject(e)` wrapper is
+    // assimilated here) must mark it too. Without it the already-rejected wrapper
+    // had no reaction of its own and was spuriously reported "Uncaught (in
+    // promise)" — once PER caught throw-after-await, which floods a server's
+    // `process.on('unhandledRejection')` (Next.js's RSC renders catch such
+    // rejections internally) and can crash it.
+    crate::promise::mark_rejection_handled(inner);
+
     let callback = js_closure_alloc(native_promise_adoption_job as *const u8, 2);
     js_closure_set_capture_ptr(callback, 0, outer as i64);
     js_closure_set_capture_ptr(callback, 1, inner as i64);

--- a/test-files/test_gap_async_throw_after_await_not_unhandled.ts
+++ b/test-files/test_gap_async_throw_after_await_not_unhandled.ts
@@ -1,0 +1,47 @@
+// Regression: an async function that `throw`s AFTER an `await`, whose rejection
+// is CAUGHT by the caller's `try/catch`, must NOT fire `unhandledRejection`.
+//
+// The async-to-generator transform lowers `await x; throw e` so the throwing
+// step returns `Promise.reject(e)` (a wrapper), which is assimilated into the
+// activation's result promise via the deferred native-adoption job
+// (V8-hop-parity path). That job forgot to mark the wrapper's rejection as
+// handled — unlike the synchronous `js_promise_resolve_with_promise` adoption,
+// which does — so the already-rejected wrapper, having no reaction of its own,
+// was spuriously reported "Uncaught (in promise)" EVEN THOUGH the caller caught
+// it. Fired once per caught throw-after-await, it floods a server's
+// `process.on('unhandledRejection')` (Next.js's RSC renders catch such
+// rejections internally) and can crash it.
+//
+// The observable is byte-for-byte identical to `node --experimental-strip-types`:
+// the caught throws produce NO `unhandledRejection`, while a genuinely-unawaited
+// rejection still DOES — so the fix suppresses only the spurious reports.
+
+const events: string[] = [];
+process.on("unhandledRejection", (reason: any) => {
+  events.push(`unhandled:${reason && reason.message}`);
+});
+
+async function throwsAfterAwait(tag: string): Promise<void> {
+  await Promise.resolve();
+  throw new Error(tag);
+}
+
+async function caughtInLoop(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    try {
+      await throwsAfterAwait(`caught-${i}`);
+    } catch {
+      // swallowed — must NOT surface as an unhandled rejection
+    }
+  }
+  console.log("caught all 5");
+}
+
+caughtInLoop().then(() => {
+  // A genuinely-unhandled rejection (not awaited, not caught) MUST still fire.
+  void throwsAfterAwait("really-unhandled");
+  // Give the rejection checkpoint a turn, then report what fired.
+  setTimeout(() => {
+    console.log("events:", JSON.stringify(events));
+  }, 20);
+});


### PR DESCRIPTION
## Problem

An `async` function that `throw`s **after** an `await`, whose rejection is **caught** by the caller's `try/catch`, was spuriously reported `Uncaught (in promise)` — **once per caught throw**.

```js
async function f() { await Promise.resolve(); throw new Error("boom"); }
(async () => {
  for (let i = 0; i < 5; i++) {
    try { await f(); } catch {}   // caught!
  }
})();
// node: silent   perry (before): "Uncaught (in promise) Error: boom"
```

The `await`-before-`throw` is required to trigger it (a synchronous `throw` in an async fn is fine).

## Root cause

The async-to-generator transform lowers `await x; throw e` so the throwing step returns `Promise.reject(e)` — a wrapper promise. That wrapper is assimilated into the activation's result promise through the **deferred native-adoption job** (`enqueue_native_adoption_job`, the V8-hop-parity path also used by an `async fn` that returns a promise).

The **synchronous** adoption path (`js_promise_resolve_with_promise`) marks the adopted inner's rejection as handled — *"inner's rejection is consumed by outer, so inner is no longer an unhandled rejection"* — but the **deferred native-job** path forgot to. So the already-rejected wrapper, which has no reaction of its own, was tracked and reported unhandled even though the caller caught it.

## Fix

Mark the inner rejection handled in `enqueue_native_adoption_job`, matching the synchronous path (a one-line `mark_rejection_handled(inner)`).

Genuinely-unhandled rejections still report correctly — an async throw that is never awaited/caught surfaces through the *activation's own result promise*, not the internal wrapper, so this only suppresses the spurious duplicate.

## Impact

A long-running server that registers `process.on('unhandledRejection')` (e.g. Next.js) was flooded with spurious events — every RSC render that catches a rejection internally fired one — which could crash the process after a handful of requests.

## Test

`test-files/test_gap_async_throw_after_await_not_unhandled.ts`: 5 caught throw-after-await produce **no** `unhandledRejection`; a genuinely-unawaited rejection still does. Byte-identical to `node --experimental-strip-types`. The existing `#6077` unhandled-rejection gap tests still pass unchanged.

https://claude.ai/code/session_01KD4GTmiwZjRrxShzQydJpF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented handled promise rejections that occur after `await` from being incorrectly reported as unhandled.
  * Preserved reporting for genuinely unhandled promise rejections.

* **Tests**
  * Added coverage for async errors caught after an `await`, including within loops.
  * Added verification that truly unhandled rejections continue to trigger notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->