### PR TITLE
fix(gc): allocate-black births were never traced — children reachable only through them were swept live

### DIFF
--- a/crates/perry-runtime/src/arena/allocators.rs
+++ b/crates/perry-runtime/src/arena/allocators.rs
@@ -273,7 +273,7 @@ pub fn arena_alloc_gc(size: usize, align: usize, obj_type: u8) -> *mut u8 {
             let header = user_ptr.sub(GC_HEADER_SIZE) as *mut GcHeader;
             (*header).obj_type = obj_type;
             (*header).gc_flags = GC_FLAG_ARENA | crate::gc::gc_birth_extra_flags();
-        crate::gc::gc_note_black_birth(header);
+            crate::gc::gc_note_black_birth(header);
             (*header)._reserved = 0;
             // size field already set from original allocation
         }

--- a/crates/perry-runtime/src/arena/allocators.rs
+++ b/crates/perry-runtime/src/arena/allocators.rs
@@ -71,6 +71,7 @@ pub fn arena_alloc_gc_longlived(size: usize, align: usize, obj_type: u8) -> *mut
         let header = raw as *mut GcHeader;
         (*header).obj_type = obj_type;
         (*header).gc_flags = GC_FLAG_ARENA | crate::gc::gc_birth_extra_flags();
+        crate::gc::gc_note_black_birth(header);
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }
@@ -121,6 +122,7 @@ pub fn arena_alloc_gc_old(size: usize, align: usize, obj_type: u8) -> *mut u8 {
         let header = raw as *mut GcHeader;
         (*header).obj_type = obj_type;
         (*header).gc_flags = GC_FLAG_ARENA | crate::gc::gc_birth_extra_flags();
+        crate::gc::gc_note_black_birth(header);
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }
@@ -145,6 +147,7 @@ pub(crate) fn arena_alloc_gc_old_excluding_pages(
         let header = raw as *mut GcHeader;
         (*header).obj_type = obj_type;
         (*header).gc_flags = GC_FLAG_ARENA | crate::gc::gc_birth_extra_flags();
+        crate::gc::gc_note_black_birth(header);
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }
@@ -192,6 +195,7 @@ pub(crate) fn arena_alloc_gc_survivor(size: usize, align: usize, obj_type: u8) -
         let header = raw as *mut GcHeader;
         (*header).obj_type = obj_type;
         (*header).gc_flags = GC_FLAG_ARENA | crate::gc::gc_birth_extra_flags();
+        crate::gc::gc_note_black_birth(header);
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }
@@ -269,6 +273,7 @@ pub fn arena_alloc_gc(size: usize, align: usize, obj_type: u8) -> *mut u8 {
             let header = user_ptr.sub(GC_HEADER_SIZE) as *mut GcHeader;
             (*header).obj_type = obj_type;
             (*header).gc_flags = GC_FLAG_ARENA | crate::gc::gc_birth_extra_flags();
+        crate::gc::gc_note_black_birth(header);
             (*header)._reserved = 0;
             // size field already set from original allocation
         }
@@ -300,6 +305,7 @@ pub fn arena_alloc_gc(size: usize, align: usize, obj_type: u8) -> *mut u8 {
         let header = raw as *mut GcHeader;
         (*header).obj_type = obj_type;
         (*header).gc_flags = GC_FLAG_ARENA | crate::gc::gc_birth_extra_flags();
+        crate::gc::gc_note_black_birth(header);
         (*header)._reserved = 0;
         (*header).size = total as u32;
     }

--- a/crates/perry-runtime/src/gc/barrier.rs
+++ b/crates/perry-runtime/src/gc/barrier.rs
@@ -807,9 +807,17 @@ pub fn gc_birth_extra_flags() -> u8 {
 /// visit per mid-cycle runtime allocation.
 #[inline]
 pub(crate) fn gc_note_black_birth(header: *mut GcHeader) {
-    if GC_BIRTH_EXTRA_FLAGS.with(|cell| cell.get()) & GC_FLAG_MARKED != 0 {
-        push_mark_seed(header);
+    if GC_BIRTH_EXTRA_FLAGS.with(|cell| cell.get()) & GC_FLAG_MARKED == 0 {
+        return;
     }
+    // Leaf types (strings, pointer-free payloads) carry no child edges — the
+    // birth mark alone protects them, and seeding them would turn a lazy
+    // init burst (e.g. the globalThis builtins table populating mid-cycle:
+    // thousands of interned strings) into pure drain traffic.
+    if unsafe { gc_type_is_pointer_free((*header).obj_type) } {
+        return;
+    }
+    push_mark_seed(header);
 }
 
 #[inline]

--- a/crates/perry-runtime/src/gc/barrier.rs
+++ b/crates/perry-runtime/src/gc/barrier.rs
@@ -778,6 +778,13 @@ pub(super) fn incremental_mark_barrier_disable() {
         cell.set(std::ptr::null());
     });
     INCREMENTAL_MARK_BARRIER_MINOR_ONLY.with(|cell| cell.set(false));
+    // Keep allocate-black aligned with the barrier (see enable). Sweep-phase
+    // births need no mark either: both the arena cursor and the malloc sweep
+    // are snapshot-bounded at sweep-state construction, so the in-flight
+    // sweep can never visit them — while a birth mark they carry would leak
+    // into the next cycle as "already traced" (post-snapshot objects are
+    // exactly the ones this sweep never visits and never unmarks).
+    GC_BIRTH_EXTRA_FLAGS.with(|cell| cell.set(0));
 }
 
 /// Allocate-black birth flags for runtime-path allocations — see
@@ -785,6 +792,24 @@ pub(super) fn incremental_mark_barrier_disable() {
 #[inline(always)]
 pub fn gc_birth_extra_flags() -> u8 {
     GC_BIRTH_EXTRA_FLAGS.with(|cell| cell.get())
+}
+
+/// A born-black object must also be TRACED: marking treats MARKED as
+/// "already visited", so without a seed the object's children are reachable
+/// through it only via the store-time shade — and the insertion barrier is
+/// not active during the budgeted BuildValidPointerSet phase's mutator
+/// windows. A child linked into a build-window birth before barrier-enable
+/// and reachable through nothing else was never marked and got swept live
+/// (the compiled-TUI lost-fiber-field bug: a React WIP fiber born in a
+/// build window, its `alternate` back-edge holding the only path to the
+/// old fiber tree). Seeding every black birth closes this for all phases;
+/// the trace drains absorb seeds continuously, so the cost is one worklist
+/// visit per mid-cycle runtime allocation.
+#[inline]
+pub(crate) fn gc_note_black_birth(header: *mut GcHeader) {
+    if GC_BIRTH_EXTRA_FLAGS.with(|cell| cell.get()) & GC_FLAG_MARKED != 0 {
+        push_mark_seed(header);
+    }
 }
 
 #[inline]

--- a/crates/perry-runtime/src/gc/cycle.rs
+++ b/crates/perry-runtime/src/gc/cycle.rs
@@ -892,8 +892,11 @@ impl GcCycleState {
         // (the longest phase), so an object born during a build slice and
         // installed via a runtime-internal raw store would be swept live
         // (measured: identical 2,890-node loss with barrier-window-only
-        // birth flags). Cleared in the outcome finalizer / Drop, NOT at
-        // barrier disable — sweeping runs after the barrier is off.
+        // birth flags). Cleared when the barrier disables at sweep entry
+        // (post-snapshot births cannot be reached by the in-flight sweep,
+        // and a mark they carried would leak into the next cycle as
+        // "already traced"). Every black birth is also pushed as a mark
+        // seed — see `gc_note_black_birth`.
         super::barrier::GC_BIRTH_EXTRA_FLAGS.with(|cell| cell.set(GC_FLAG_MARKED));
         Self {
             collection_kind: GcCollectionKind::Full,
@@ -941,8 +944,11 @@ impl GcCycleState {
         // (the longest phase), so an object born during a build slice and
         // installed via a runtime-internal raw store would be swept live
         // (measured: identical 2,890-node loss with barrier-window-only
-        // birth flags). Cleared in the outcome finalizer / Drop, NOT at
-        // barrier disable — sweeping runs after the barrier is off.
+        // birth flags). Cleared when the barrier disables at sweep entry
+        // (post-snapshot births cannot be reached by the in-flight sweep,
+        // and a mark they carried would leak into the next cycle as
+        // "already traced"). Every black birth is also pushed as a mark
+        // seed — see `gc_note_black_birth`.
         super::barrier::GC_BIRTH_EXTRA_FLAGS.with(|cell| cell.set(GC_FLAG_MARKED));
         Self {
             collection_kind: GcCollectionKind::Minor,
@@ -1415,14 +1421,26 @@ impl GcCycleState {
                 // leave `live_old_to_young_sticky` None; reclaim then restores
                 // only `evacuation_sticky` + the pre-clear dirty snapshot.
                 if self.minor.is_some() {
-                    // Barrier off for the minor: first drain any seeds the
-                    // barrier pushed since BarrierSeedDrain completed (late
-                    // stores mark the child but its children still need the
-                    // trace), then disable. Bounded by late-store volume.
+                    // Drain any seeds the barrier pushed since
+                    // BarrierSeedDrain completed (late stores mark the child
+                    // but its children still need the trace). Bounded by
+                    // late-store volume.
+                    //
+                    // The barrier deliberately STAYS ENABLED here: the sweep
+                    // state (and its per-block fill snapshot) is only built
+                    // on the next step_sweep slice, and the mutator runs in
+                    // between. With the barrier (and its allocate-black birth
+                    // flags) off in that window, an object allocated and
+                    // linked there is WHITE yet INSIDE the sweep snapshot —
+                    // it gets freed live (observed: React fibers created
+                    // during a render burst between finalize and sweep lost
+                    // their side-table fields; the compiled TUI's
+                    // pendingProps/lanes/slice crashes). step_sweep drains
+                    // the gap's seeds and disables the barrier in the same
+                    // slice that takes the snapshot.
                     let valid_ptrs = self.valid_ptrs.as_ref().expect("valid pointer set built");
                     let mut final_drain = TraceWorklistCycleState::new(true);
                     while !final_drain.step(valid_ptrs, usize::MAX) {}
-                    incremental_mark_barrier_disable();
                     self.atomic_finalize = None;
                     self.phase = GcCyclePhase::Sweep;
                     return;
@@ -1462,13 +1480,13 @@ impl GcCycleState {
                 // Same late-seed closure as the minor path: trace anything
                 // the barrier shaded after BarrierSeedDrain completed, so no
                 // marked-but-untraced object reaches Sweep with unmarked
-                // children.
+                // children. The barrier stays enabled until step_sweep takes
+                // the block snapshot (see the minor arm's gap comment).
                 {
                     let valid_ptrs = self.valid_ptrs.as_ref().expect("valid pointer set built");
                     let mut final_drain = TraceWorklistCycleState::new(false);
                     while !final_drain.step(valid_ptrs, usize::MAX) {}
                 }
-                incremental_mark_barrier_disable();
                 if let Some(state) = self.atomic_finalize.as_mut() {
                     state.subphase = AtomicFinalizeSubphase::Done;
                 }
@@ -1588,6 +1606,19 @@ impl GcCycleState {
         let phase_start = trace_phase_start(&self.trace);
         if self.sweep_state.is_none() {
             let full_trace = self.minor.is_none();
+            // Close the finalize->sweep gap: the barrier stayed enabled across
+            // the mutator windows since AtomicFinalize ended. Trace whatever
+            // it shaded there (so gap-born objects' children are live too),
+            // then disable it — in the SAME slice that builds the sweep
+            // state's block/fill snapshot below, so no mutator window exists
+            // between barrier-off and snapshot.
+            if incremental_mark_barrier_active() {
+                let valid_ptrs = self.valid_ptrs.as_ref().expect("valid pointer set built");
+                let mut gap_drain = TraceWorklistCycleState::new(!full_trace);
+                while !gap_drain.step(valid_ptrs, usize::MAX) {}
+                incremental_mark_barrier_disable();
+            }
+
             let (do_age_bump, reclaim_dead_old_blocks, targeted_old_blocks, sweep_malloc) =
                 if let Some(minor) = self.minor.as_ref() {
                     let targeted_old_blocks = (minor.evacuation.old_page_moved_bytes > 0)

--- a/crates/perry-runtime/src/gc/malloc.rs
+++ b/crates/perry-runtime/src/gc/malloc.rs
@@ -248,6 +248,7 @@ pub fn gc_malloc(size: usize, obj_type: u8) -> *mut u8 {
         let header = raw as *mut GcHeader;
         (*header).obj_type = obj_type;
         (*header).gc_flags = super::barrier::gc_birth_extra_flags(); // not arena; allocate-black while a budgeted cycle marks
+        super::barrier::gc_note_black_birth(header);
         (*header)._reserved = 0;
         (*header).size = total as u32;
 
@@ -301,6 +302,7 @@ pub fn gc_malloc_batch(sizes: &[usize], obj_type: u8) -> Vec<*mut u8> {
             let header = raw as *mut GcHeader;
             (*header).obj_type = obj_type;
             (*header).gc_flags = super::barrier::gc_birth_extra_flags();
+            super::barrier::gc_note_black_birth(header);
             (*header)._reserved = 0;
             (*header).size = total as u32;
 

--- a/crates/perry-runtime/src/gc/tests/cycle_state.rs
+++ b/crates/perry-runtime/src/gc/tests/cycle_state.rs
@@ -26,7 +26,14 @@ fn run_cycle_in_single_unit_steps(state: &mut GcCycleState) -> Vec<GcCyclePhase>
         let result = state.step(GcWorkBudget::bounded(1));
         phases.push(result.phase);
     }
-    panic!("GC cycle did not complete within step limit");
+    let mut hist = std::collections::HashMap::new();
+    for ph in &phases {
+        *hist.entry(format!("{ph:?}")).or_insert(0usize) += 1;
+    }
+    panic!(
+        "GC cycle did not complete within step limit; histogram: {hist:?}; tail: {:?}",
+        &phases[phases.len().saturating_sub(12)..]
+    );
 }
 
 fn run_cycle_until_phase(state: &mut GcCycleState, target: GcCyclePhase) {
@@ -760,7 +767,12 @@ fn born_black_build_phase_object_is_traced() {
     }
     crate::object::test_seed_overflow_fields_root(child as usize, 7f64.to_bits());
     unsafe {
-        runtime_store_jsvalue_slot(parent as usize, fields as usize, 0, ptr_bits(child as usize));
+        runtime_store_jsvalue_slot(
+            parent as usize,
+            fields as usize,
+            0,
+            ptr_bits(child as usize),
+        );
     }
 
     // Age the parent/child block out of the block-persistence window
@@ -785,6 +797,13 @@ fn born_black_build_phase_object_is_traced() {
          black births must be seeded into the trace"
     );
     crate::object::test_clear_overflow_fields_root();
+
+    // The filler blocks above were born black (and seeded) inside the active
+    // cycle, so they survived it as floating garbage. Reclaim them so later
+    // tests' bounded cycles don't walk seven extra blocks of dead strings.
+    let mut cleanup = GcCycleState::new_full(trace_snapshot(GcTriggerKind::Manual));
+    run_cycle_in_single_unit_steps(&mut cleanup);
+    let _ = cleanup.take_outcome();
 }
 
 /// Regression: an object born in a mutator window BETWEEN AtomicFinalize
@@ -825,7 +844,12 @@ fn gap_born_child_stored_between_finalize_and_sweep_survives() {
     // OVERFLOW_FIELDS entry cleared by the dead-payload sweep arm).
     crate::object::test_seed_overflow_fields_root(child as usize, 42f64.to_bits());
     unsafe {
-        runtime_store_jsvalue_slot(parent as usize, fields as usize, 0, ptr_bits(child as usize));
+        runtime_store_jsvalue_slot(
+            parent as usize,
+            fields as usize,
+            0,
+            ptr_bits(child as usize),
+        );
     }
 
     run_cycle_in_single_unit_steps(&mut state);

--- a/crates/perry-runtime/src/gc/tests/cycle_state.rs
+++ b/crates/perry-runtime/src/gc/tests/cycle_state.rs
@@ -715,6 +715,137 @@ fn root_scan_slices_remembered_set_dirty_old_pages_with_tiny_budget() {
     }
 }
 
+/// Regression: a born-black (allocate-black) object must also be TRACED.
+/// The budgeted BuildValidPointerSet phase runs mutator windows BEFORE the
+/// insertion barrier enables; an object born there is MARKED at birth, so
+/// the later trace treats it as already-visited. Pre-fix its children —
+/// linked before barrier-enable, hence never shaded — were unreachable to
+/// the whole mark and swept live (the compiled TUI's React fiber tree,
+/// reachable only through a build-window fiber's `alternate` back-edge,
+/// lost its side-table fields this way). `gc_note_black_birth` seeds every
+/// black birth so the trace descends into it.
+#[test]
+fn born_black_build_phase_object_is_traced() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+
+    let mut state = GcCycleState::new_full(trace_snapshot(GcTriggerKind::Manual));
+    // Budgeted kind: production build-phase mutator windows only exist in
+    // budgeted cycles, whose valid-pointer set is the live page classifier
+    // (mid-cycle births classify as valid). A census-mode cycle with mutator
+    // windows would be an artificial hybrid production never runs.
+    state.set_progress_kind(GcProgressKind::NormalIncremental);
+    // One bounded step: parked inside BuildValidPointerSet, barrier not yet
+    // enabled, allocate-black active since cycle construction.
+    state.step(GcWorkBudget::bounded(1));
+    assert_eq!(state.phase(), GcCyclePhase::BuildValidPointerSet);
+
+    // Mutator window: a runtime-path allocation is born black...
+    let (parent, fields) = unsafe { alloc_nursery_test_object(1) };
+    unsafe {
+        let header = header_from_user_ptr(parent as *const u8);
+        assert_ne!(
+            (*header).gc_flags & GC_FLAG_MARKED,
+            0,
+            "runtime allocation during an active budgeted cycle is born marked"
+        );
+    }
+    // ...and links a white child with the barrier still off. The child is
+    // reachable ONLY through the born-black parent; the parent is not
+    // rooted anywhere (its birth mark alone keeps it alive this cycle).
+    let (child, _child_fields) = unsafe { alloc_nursery_test_object(1) };
+    unsafe {
+        let ch = header_from_user_ptr(child as *const u8);
+        (*ch).gc_flags &= !GC_FLAG_MARKED;
+    }
+    crate::object::test_seed_overflow_fields_root(child as usize, 7f64.to_bits());
+    unsafe {
+        runtime_store_jsvalue_slot(parent as usize, fields as usize, 0, ptr_bits(child as usize));
+    }
+
+    // Age the parent/child block out of the block-persistence window
+    // (BLOCK_PERSIST_WINDOW = 5 recent general blocks get their objects
+    // force-marked as register-holding candidates — that pass would
+    // otherwise resurrect the child and mask the missing trace).
+    let aged_from = crate::arena::general_block_count();
+    let mut filler_blocks = 0usize;
+    while filler_blocks < 7 {
+        for _ in 0..64 {
+            let _ = unsafe { crate::arena::arena_alloc_gc(4096, 8, GC_TYPE_STRING) };
+        }
+        filler_blocks = crate::arena::general_block_count().saturating_sub(aged_from);
+    }
+
+    run_cycle_in_single_unit_steps(&mut state);
+    let _ = state.take_outcome().expect("cycle should complete");
+
+    assert!(
+        crate::object::debug_overflow_entry_len(child as usize).is_some(),
+        "child reachable only through a born-black object was swept live: \
+         black births must be seeded into the trace"
+    );
+    crate::object::test_clear_overflow_fields_root();
+}
+
+/// Regression: an object born in a mutator window BETWEEN AtomicFinalize
+/// completion and the first sweep slice ("the finalize->sweep gap"), then
+/// linked from a live parent, must survive the sweep. Pre-fix the barrier
+/// was disabled at finalize-end while the sweep's block/fill snapshot was
+/// only taken one or more mutator windows later: a gap-born object (codegen
+/// bump allocations carry no allocate-black birth flag) was WHITE yet inside
+/// the snapshot and freed live — observed as React fibers losing their
+/// overflow side-table fields in the compiled TUI. The fix keeps the barrier
+/// active across the gap and disables it in the same slice that takes the
+/// snapshot.
+#[test]
+fn gap_born_child_stored_between_finalize_and_sweep_survives() {
+    let _guard = CopyingNurseryTestGuard::new(1);
+    let _trigger_guard = GcTriggerThresholdTestGuard::suppress_automatic_triggers();
+
+    let (parent, fields) = unsafe { alloc_old_test_object(1) };
+    js_shadow_slot_set(0, ptr_bits(parent as usize));
+
+    let mut state = GcCycleState::new_full(trace_snapshot(GcTriggerKind::Manual));
+    // Stop exactly in the gap: AtomicFinalize is done (marks final), but the
+    // first step_sweep slice (which builds the sweep state's block snapshot)
+    // has not run.
+    run_cycle_until_phase(&mut state, GcCyclePhase::Sweep);
+
+    // Mutator window in the gap: birth a young object and link it from the
+    // live parent. Codegen's inline bump allocator does not stamp the
+    // allocate-black birth flag, so emulate a codegen birth by clearing the
+    // runtime-path birth mark before the store.
+    let (child, _child_fields) = unsafe { alloc_nursery_test_object(1) };
+    unsafe {
+        let ch = header_from_user_ptr(child as *const u8);
+        (*ch).gc_flags &= !GC_FLAG_MARKED;
+    }
+    // Give the child a side-table entry: its survival is then observable the
+    // same way the production failure was (a swept child has its
+    // OVERFLOW_FIELDS entry cleared by the dead-payload sweep arm).
+    crate::object::test_seed_overflow_fields_root(child as usize, 42f64.to_bits());
+    unsafe {
+        runtime_store_jsvalue_slot(parent as usize, fields as usize, 0, ptr_bits(child as usize));
+    }
+
+    run_cycle_in_single_unit_steps(&mut state);
+    let _ = state.take_outcome().expect("cycle should complete");
+
+    assert!(
+        crate::object::debug_overflow_entry_len(child as usize).is_some(),
+        "gap-born child was swept live: its overflow side-table entry was cleared"
+    );
+    unsafe {
+        let obj = child as *mut crate::object::ObjectHeader;
+        assert_eq!(
+            (*obj).object_type,
+            1,
+            "gap-born child payload clobbered after sweep"
+        );
+    }
+    crate::object::test_clear_overflow_fields_root();
+}
+
 #[test]
 fn full_atomic_finalize_slices_barrier_seed_drain_with_tiny_budget() {
     let _guard = CopyingNurseryTestGuard::new(1);
@@ -753,9 +884,20 @@ fn full_atomic_finalize_slices_barrier_seed_drain_with_tiny_budget() {
         atomic_steps > SEEDS,
         "barrier seed drain and remembered rebuild should keep tiny steps in atomic_finalize"
     );
+    // The barrier must survive the AtomicFinalize->Sweep boundary: the sweep
+    // state's per-block fill snapshot is only taken on the first step_sweep
+    // slice, and mutator windows in between would otherwise birth WHITE
+    // objects that sit inside the snapshot and get freed live (the compiled
+    // TUI's lost-fiber-field bug). The first sweep slice drains the gap's
+    // shaded seeds, disables the barrier, and takes the snapshot atomically.
+    assert!(
+        incremental_mark_barrier_active(),
+        "barrier must stay active across the finalize->sweep gap"
+    );
+    state.step(GcWorkBudget::bounded(1));
     assert!(
         !incremental_mark_barrier_active(),
-        "full cycle should disable incremental barriers before sweep"
+        "first sweep slice must disable the barrier when it takes the block snapshot"
     );
 
     run_cycle_in_single_unit_steps(&mut state);

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1277,6 +1277,11 @@ pub(crate) fn test_seed_overflow_fields_root(owner: usize, value_bits: u64) {
 }
 
 #[cfg(test)]
+pub(crate) fn debug_overflow_entry_len(owner: usize) -> Option<usize> {
+    OVERFLOW_FIELDS.with(|m| m.borrow().get(&owner).map(|v| v.len()))
+}
+
+#[cfg(test)]
 pub(crate) fn test_clear_overflow_fields_root() {
     OVERFLOW_FIELDS.with(|m| m.borrow_mut().clear());
     OVERFLOW_LAST.with(|c| unsafe {


### PR DESCRIPTION
## Symptom

A large esbuild-bundled TUI app (React-based) intermittently loses constructor-initialized object fields at runtime: reads of `alternate` / `lanes` / `dependencies` on live React fibers return `undefined`, and a cached `Set`'s iteration yields `undefined` (`Cannot read properties of undefined (reading 'slice')`). ~50% repro on a scripted PTY run, GC-mode-insensitive (default / `PERRY_GC_FORCE_EVACUATE=1` / `PERRY_GEN_GC_EVACUATE=0` identical).

Diagnosed with an env-gated side-table tracer: a **live** object's overflow entry was cleared by the sweep (`clear_overflow_for_ptr`) and then read moments later through a still-held reference — the object was swept while alive. Its payload stayed readable (inline fields fine, `tag` intact), which is why the failure surfaced as "some fields are undefined" rather than a crash.

## Root cause

Budgeted cycles set the allocate-black birth flag (`GC_BIRTH_EXTRA_FLAGS = MARKED`) at **cycle construction**, but the insertion barrier only engages at the **end of BuildValidPointerSet**. An object born in a build-phase mutator window is:

- **born MARKED** → marking treats it as already-visited → **never traced**;
- **storing children with the barrier off** → nothing shades them.

A child linked into such an object before barrier-enable — and reachable through nothing else — stays white for the entire cycle and is swept live.

React hits this shape deterministically: work-in-progress fibers are created in bursts (runtime construct path → born black) and immediately cross-linked (`wip.alternate = current`). After a commit swap, the **old fiber tree is reachable only via those `alternate` back-edges**, so a whole live tree was freed one phase later (reverse-reference scan confirmed: victims' only marked referrer held them via an overflow slot, and that referrer had zero trace events — born-black, never traced).

Two adjacent windows had the same consequence and are fixed together:

- **finalize→sweep gap**: the barrier was disabled at AtomicFinalize-end, but the sweep state's block-fill snapshot is only built on the first `step_sweep` slice — one or more mutator windows later. Gap-born objects sat white *inside* the snapshot.
- **stale birth marks**: birth flags stayed set through the sweep's mutator windows, but sweep-phase births are beyond the block-fill snapshot, so that sweep never visits them and never clears their mark — they entered the *next* cycle pre-marked ("already traced"), re-creating the untraced-black-birth hole.

## Fix

1. **`gc_note_black_birth`** — every born-black runtime allocation (6 arena allocator sites + 2 malloc sites) is also pushed as a mark seed; the trace drains (which already absorb seeds every step) descend into it and mark its children. Preserves the #6224 born-marked contract for raw-installed runtime buffers.
2. **Barrier lifetime** — stays enabled across the AtomicFinalize→Sweep boundary; the first `step_sweep` slice drains the gap's shaded seeds, disables the barrier, and builds the block snapshot atomically (no mutator window between barrier-off and snapshot).
3. **Allocate-black lifetime** — ends when the barrier disables (sweep entry) instead of at outcome finalization. Sweep-phase births are snapshot-safe by construction (arena cursor and malloc sweep are both snapshot-bounded at sweep-state creation) and no longer carry a stale mark into the next cycle.

## Tests

Three regression tests, each validated failing-then-passing by temporarily reverting the corresponding change:

- `born_black_build_phase_object_is_traced` — an unrooted born-black build-phase object's only-child must survive the cycle (fails without the mark seed; block-persistence window aged out to unmask the sweep).
- `gap_born_child_stored_between_finalize_and_sweep_survives` — a white child linked from a live parent in the finalize→sweep gap must survive (fails with the early barrier disable).
- `full_atomic_finalize_slices_barrier_seed_drain_with_tiny_budget` — contract updated: barrier active across the finalize→sweep boundary, off after the first sweep slice.

`perry-runtime` suite: **1323 passed / 0 failed** (`--test-threads=1`).

End-to-end on the TUI reproducer: **6/6 scripted PTY runs with zero visible errors and zero sweep-then-read incidents** (previously 5–6/6 failing, 16–20 live fibers freed per incident, deterministic at the same sweep).

## Cost

One `Vec` push per runtime allocation while a budgeted cycle is active (seeds are deduplicated by the born-marked bit and drained incrementally); born-black floating garbage now also gets traced, keeping its children one extra cycle — same retention class as allocate-black itself.

https://claude.ai/code/session_01M44HoYS3CAYZyagm3ZzYDG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved “born-black” barrier handling by recording newly allocated objects for correct incremental marking.
  - Fixed edge cases where objects could be missed during transitions between atomic finalization and sweeping.
  - Corrected barrier shutdown behavior to avoid birth-state leaking across sweeps.
- **Tests**
  - Enhanced cycle failure diagnostics with phase histograms.
  - Added incremental-marking regression tests covering born-black and gap-born survival across finalize→sweep.
  - Updated existing barrier coverage to verify barrier activity timing across the gap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->