### PR TITLE
fix: static/namespace resolution for effect Tag & Schema — web.ts server starts (#6475)

### DIFF
--- a/crates/perry-codegen/src/expr/call_spread.rs
+++ b/crates/perry-codegen/src/expr/call_spread.rs
@@ -359,6 +359,82 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 }
             }
 
+            // #6475: `ns.fn(...spread)` where `ns` is a namespace import and
+            // `fn` is a REST function export (effect's
+            // `Schema.Union(...Array.from(...))`). The regular-call path routes
+            // through `try_lower_namespace_member_call`, which resolves the
+            // export's `perry_fn_<src>__fn` symbol directly. The spread path
+            // instead fell to `lower_expr(callee)` below, which resolves
+            // `ns.fn` as a VALUE — and `property_get`'s bare-name `class_ids`
+            // lookup returns a same-named CLASS ref for the collision
+            // `Schema.Union` (a Union CLASS exists in an unrelated module),
+            // baking it as the spread callee → "value is not a function". A
+            // rest function's `perry_fn` symbol takes its trailing args as a
+            // single bundled array, so bundle the whole spread into that rest
+            // slot and call the symbol directly, exactly as the regular path
+            // does for `fixed_count == 0`. Gated on a known rest-function
+            // export, so class members and non-rest shapes are untouched.
+            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+                if let Expr::ExternFuncRef { name: ns_name, .. } = object.as_ref() {
+                    if ctx.namespace_imports.contains(ns_name)
+                        && ctx.imported_func_has_rest.contains(property)
+                        && ctx
+                            .imported_func_param_counts
+                            .get(property)
+                            .copied()
+                            .unwrap_or(1)
+                            == 1
+                    {
+                        let source_prefix_opt = ctx
+                            .namespace_member_prefixes
+                            .get(&(ns_name.clone(), property.clone()))
+                            .cloned()
+                            .or_else(|| ctx.import_function_prefixes.get(property).cloned());
+                        if let Some(source_prefix) = source_prefix_opt {
+                            let origin_suffix = crate::expr::import_origin_suffix_ns(
+                                ctx.import_function_origin_names,
+                                ctx.namespace_member_origin_names,
+                                ns_name,
+                                property,
+                            );
+                            let symbol = format!("perry_fn_{}__{}", source_prefix, origin_suffix);
+                            // Bundle every arg (regular + spread) into the single
+                            // rest array, in source order.
+                            let mut acc = ctx.block().call(I64, "js_array_alloc", &[(I32, "0")]);
+                            for a in args {
+                                match a {
+                                    CallArg::Expr(e) => {
+                                        let v = lower_expr(ctx, e)?;
+                                        acc = ctx.block().call(
+                                            I64,
+                                            "js_array_push_f64",
+                                            &[(I64, &acc), (DOUBLE, &v)],
+                                        );
+                                    }
+                                    CallArg::Spread(e) => {
+                                        let part_box = lower_expr(ctx, e)?;
+                                        let part = ctx.block().call(
+                                            I64,
+                                            "js_array_like_to_array",
+                                            &[(DOUBLE, &part_box)],
+                                        );
+                                        acc = ctx.block().call(
+                                            I64,
+                                            "js_array_concat",
+                                            &[(I64, &acc), (I64, &part)],
+                                        );
+                                    }
+                                }
+                            }
+                            let rest_box = nanbox_pointer_inline(ctx.block(), &acc);
+                            ctx.pending_declares
+                                .push((symbol.clone(), DOUBLE, vec![DOUBLE]));
+                            return Ok(ctx.block().call(DOUBLE, &symbol, &[(DOUBLE, &rest_box)]));
+                        }
+                    }
+                }
+            }
+
             // Closure callee path: `cb(reg0, reg1, ..., ...spread)` where
             // `cb` is a closure value (not a known FuncRef). We lower the
             // callee to its NaN-boxed value, marshal regular args into a

--- a/crates/perry-codegen/src/lower_call/console_promise.rs
+++ b/crates/perry-codegen/src/lower_call/console_promise.rs
@@ -1220,11 +1220,29 @@ pub fn try_lower_closure_call_fallthrough(
         // `js_closure_callN` as a wild `*const ClosureHeader` and SIGSEGV on
         // the header read. The checked unbox throws `TypeError: value is not
         // a function` for any non-`POINTER_TAG` value.
-        let closure_handle = blk.call(
-            I64,
-            "js_closure_unbox_callee_checked",
-            &[(DOUBLE, &recv_box)],
-        );
+        // #6475: a member-shaped call (`o.m(args)`) must rebind an
+        // object-literal method's baked `this` capture slot to the receiver —
+        // the slot wins over the IMPLICIT_THIS cell set above, so a method
+        // inherited via `Object.setPrototypeOf(obj, proto)` otherwise runs
+        // with `this` bound to the proto literal (effect's Pipeable
+        // `TagClass.pipe(...)` composed against the wrong `this` and
+        // HttpApiBuilder.group returned a curried function instead of a
+        // Layer). The rebind variant is a no-op for closures that don't
+        // capture `this`, so plain functions and arrows are untouched;
+        // receiverless calls keep the plain checked unbox.
+        let closure_handle = if let Some(ref this_val) = method_recv {
+            blk.call(
+                I64,
+                "js_closure_unbox_callee_checked_rebind",
+                &[(DOUBLE, &recv_box), (DOUBLE, this_val)],
+            )
+        } else {
+            blk.call(
+                I64,
+                "js_closure_unbox_callee_checked",
+                &[(DOUBLE, &recv_box)],
+            )
+        };
         let runtime_fn = format!("js_closure_call{}", lowered_args.len());
         let mut call_args: Vec<(crate::types::LlvmType, &str)> = vec![(I64, &closure_handle)];
         for v in &lowered_args {
@@ -1250,11 +1268,29 @@ pub fn try_lower_closure_call_fallthrough(
         // `js_closure_callN` as a wild `*const ClosureHeader` and SIGSEGV on
         // the header read. The checked unbox throws `TypeError: value is not
         // a function` for any non-`POINTER_TAG` value.
-        let closure_handle = blk.call(
-            I64,
-            "js_closure_unbox_callee_checked",
-            &[(DOUBLE, &recv_box)],
-        );
+        // #6475: a member-shaped call (`o.m(args)`) must rebind an
+        // object-literal method's baked `this` capture slot to the receiver —
+        // the slot wins over the IMPLICIT_THIS cell set above, so a method
+        // inherited via `Object.setPrototypeOf(obj, proto)` otherwise runs
+        // with `this` bound to the proto literal (effect's Pipeable
+        // `TagClass.pipe(...)` composed against the wrong `this` and
+        // HttpApiBuilder.group returned a curried function instead of a
+        // Layer). The rebind variant is a no-op for closures that don't
+        // capture `this`, so plain functions and arrows are untouched;
+        // receiverless calls keep the plain checked unbox.
+        let closure_handle = if let Some(ref this_val) = method_recv {
+            blk.call(
+                I64,
+                "js_closure_unbox_callee_checked_rebind",
+                &[(DOUBLE, &recv_box), (DOUBLE, this_val)],
+            )
+        } else {
+            blk.call(
+                I64,
+                "js_closure_unbox_callee_checked",
+                &[(DOUBLE, &recv_box)],
+            )
+        };
         let argc = n.to_string();
         blk.call(
             DOUBLE,

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -209,6 +209,13 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // `TypeError: value is not a function` instead of masking a
     // non-pointer value's low 48 bits into a wild closure pointer.
     module.declare_function("js_closure_unbox_callee_checked", I64, &[DOUBLE]);
+    // #6475: receiver-aware variant for member-shaped fused calls — rebinds an
+    // object-literal method's baked `this` slot to the receiver before unboxing.
+    module.declare_function(
+        "js_closure_unbox_callee_checked_rebind",
+        I64,
+        &[DOUBLE, DOUBLE],
+    );
     module.declare_function("js_closure_call0", DOUBLE, &[I64]);
     module.declare_function("js_closure_call1", DOUBLE, &[I64, DOUBLE]);
     module.declare_function("js_closure_call2", DOUBLE, &[I64, DOUBLE, DOUBLE]);

--- a/crates/perry-runtime/src/closure/dynamic_props.rs
+++ b/crates/perry-runtime/src/closure/dynamic_props.rs
@@ -994,8 +994,46 @@ pub(crate) fn clone_closure_rebind_this(closure_bits: u64, recv_box: f64) -> u64
     if !is_closure_ptr(ptr) {
         return closure_bits;
     }
+    // #6475: a CANONICAL bound class method — a BOUND_METHOD closure whose
+    // receiver slot holds the class PROTOTYPE-REF marker (the shape
+    // `class_prototype_method_value_for_name` caches per `(class_id, name)`)
+    // rather than a real instance. It reaches a rebind site whenever a method
+    // resolved through a prototype WALK is invoked method-shaped — effect's
+    // `TagClass.pipe(...)`, where `pipe` is a class instance method reached
+    // via `Object.setPrototypeOf(TagClass, Object.getPrototypeOf(tagInstance))`.
+    // The CAPTURES_THIS machinery below can't touch it (a bound method carries
+    // its receiver in capture slot 0, not a `this` slot), so the canonical
+    // proto-ref leaked through as the callee's `this` — an INT32 the method
+    // body then read fields off (`typeof this === "number"`), losing the
+    // receiver entirely. Rebuild the binding onto the caller's receiver.
+    // An explicit `.bind(x)` product carries a real value in slot 0 (not a
+    // proto-ref) and is left untouched, matching spec bound-function
+    // semantics. Symbol-keyed bound methods carry the sentinel name and their
+    // dispatch data in extra slots — skip them here (their builder binds the
+    // true receiver at materialization).
     unsafe {
         let header = ptr as *const ClosureHeader;
+        if (*header).func_ptr == crate::closure::BOUND_METHOD_FUNC_PTR {
+            let recv0 = crate::closure::js_closure_get_capture_f64(header, 0);
+            if crate::object::class_prototype_ref_id(recv0).is_some() {
+                let name_ptr = crate::closure::js_closure_get_capture_ptr(header, 1) as *const u8;
+                let name_len = crate::closure::js_closure_get_capture_ptr(header, 2) as usize;
+                let is_symbol_sentinel = name_ptr
+                    == crate::object::SYMBOL_BOUND_METHOD_NAME.as_ptr()
+                    && name_len == crate::object::SYMBOL_BOUND_METHOD_NAME.len();
+                if !name_ptr.is_null() && name_len > 0 && !is_symbol_sentinel {
+                    let scope = crate::gc::RuntimeHandleScope::new();
+                    let recv_handle = scope.root_nanbox_f64(recv_box);
+                    let rebuilt = crate::object::build_bound_method_closure(
+                        recv_handle.get_nanbox_f64(),
+                        name_ptr,
+                        name_len,
+                    );
+                    return rebuilt.to_bits();
+                }
+            }
+            return closure_bits;
+        }
         // Arrow functions bind `this` lexically: their `this` capture slot holds
         // the enclosing instance and must NEVER be overwritten with a call-time
         // receiver (proxy handler, getter receiver, method-call object, …).

--- a/crates/perry-runtime/src/closure/dynamic_props.rs
+++ b/crates/perry-runtime/src/closure/dynamic_props.rs
@@ -994,46 +994,8 @@ pub(crate) fn clone_closure_rebind_this(closure_bits: u64, recv_box: f64) -> u64
     if !is_closure_ptr(ptr) {
         return closure_bits;
     }
-    // #6475: a CANONICAL bound class method — a BOUND_METHOD closure whose
-    // receiver slot holds the class PROTOTYPE-REF marker (the shape
-    // `class_prototype_method_value_for_name` caches per `(class_id, name)`)
-    // rather than a real instance. It reaches a rebind site whenever a method
-    // resolved through a prototype WALK is invoked method-shaped — effect's
-    // `TagClass.pipe(...)`, where `pipe` is a class instance method reached
-    // via `Object.setPrototypeOf(TagClass, Object.getPrototypeOf(tagInstance))`.
-    // The CAPTURES_THIS machinery below can't touch it (a bound method carries
-    // its receiver in capture slot 0, not a `this` slot), so the canonical
-    // proto-ref leaked through as the callee's `this` — an INT32 the method
-    // body then read fields off (`typeof this === "number"`), losing the
-    // receiver entirely. Rebuild the binding onto the caller's receiver.
-    // An explicit `.bind(x)` product carries a real value in slot 0 (not a
-    // proto-ref) and is left untouched, matching spec bound-function
-    // semantics. Symbol-keyed bound methods carry the sentinel name and their
-    // dispatch data in extra slots — skip them here (their builder binds the
-    // true receiver at materialization).
     unsafe {
         let header = ptr as *const ClosureHeader;
-        if (*header).func_ptr == crate::closure::BOUND_METHOD_FUNC_PTR {
-            let recv0 = crate::closure::js_closure_get_capture_f64(header, 0);
-            if crate::object::class_prototype_ref_id(recv0).is_some() {
-                let name_ptr = crate::closure::js_closure_get_capture_ptr(header, 1) as *const u8;
-                let name_len = crate::closure::js_closure_get_capture_ptr(header, 2) as usize;
-                let is_symbol_sentinel = name_ptr
-                    == crate::object::SYMBOL_BOUND_METHOD_NAME.as_ptr()
-                    && name_len == crate::object::SYMBOL_BOUND_METHOD_NAME.len();
-                if !name_ptr.is_null() && name_len > 0 && !is_symbol_sentinel {
-                    let scope = crate::gc::RuntimeHandleScope::new();
-                    let recv_handle = scope.root_nanbox_f64(recv_box);
-                    let rebuilt = crate::object::build_bound_method_closure(
-                        recv_handle.get_nanbox_f64(),
-                        name_ptr,
-                        name_len,
-                    );
-                    return rebuilt.to_bits();
-                }
-            }
-            return closure_bits;
-        }
         // Arrow functions bind `this` lexically: their `this` capture slot holds
         // the enclosing instance and must NEVER be overwritten with a call-time
         // receiver (proxy handler, getter receiver, method-call object, …).

--- a/crates/perry-runtime/src/closure/registry.rs
+++ b/crates/perry-runtime/src/closure/registry.rs
@@ -200,6 +200,32 @@ fn resolve_strategy_slow(func_ptr: *const u8) -> DispatchStrategy {
 /// `fixed_arity` (i.e., the closure has `fixed_arity` fixed params before the
 /// rest param, and its declared LLVM arity is `fixed_arity + 1` — the +1 is
 /// the rest array). Called once per closure literal at module init time.
+
+/// #6475: purge a func_ptr's cached dispatch strategy. The strategy caches
+/// (`DISPATCH_CACHE` + the single-slot `DISPATCH_LAST`) memoize the FIRST
+/// resolution per func_ptr — but effect's module-init graph calls `.pipe`
+/// (an `arguments`-object method) during init, and inside an import cycle
+/// such a call can precede the module's own `js_register_closure_*` batch.
+/// The pre-registration miss resolved to `Arity`/`Direct` and was cached
+/// FOREVER: every later `obj.pipe(a, b, c)` transmuted three positional args
+/// onto the 1-slot `arguments` ABI, so `arguments.length` read 1 and effect's
+/// `pipeArguments` applied only the first stage (`HttpApiBuilder.group`
+/// returned the wrong pipe stage; web.ts died with "Not a valid effect:
+/// undefined"). Registration is init-time-rare, so invalidating here keeps
+/// the hot-path caches lock-free and unchanged. Also covers the late arity
+/// registration for plain closures.
+fn invalidate_dispatch_strategy(func_ptr: *const u8) {
+    let key = func_ptr as usize;
+    DISPATCH_CACHE.with(|c| {
+        c.borrow_mut().remove(&key);
+    });
+    DISPATCH_LAST.with(|c| {
+        if c.get().0 == key {
+            c.set((0, DispatchStrategy::Direct));
+        }
+    });
+}
+
 #[no_mangle]
 pub extern "C" fn js_register_closure_rest(func_ptr: *const u8, fixed_arity: u32) {
     if func_ptr.is_null() {
@@ -209,6 +235,7 @@ pub extern "C" fn js_register_closure_rest(func_ptr: *const u8, fixed_arity: u32
         r.borrow_mut()
             .insert(func_ptr as usize, (fixed_arity, RestDispatchKind::UserRest));
     });
+    invalidate_dispatch_strategy(func_ptr);
 }
 
 /// Like `js_register_closure_rest`, but flags the rest param as the
@@ -231,6 +258,7 @@ pub extern "C" fn js_register_closure_synthetic_arguments(func_ptr: *const u8, f
             (fixed_arity, RestDispatchKind::SyntheticArguments),
         );
     });
+    invalidate_dispatch_strategy(func_ptr);
 }
 
 /// Register a function with both a user-declared rest parameter and a hidden
@@ -248,6 +276,7 @@ pub extern "C" fn js_register_closure_rest_and_arguments(func_ptr: *const u8, fi
             (fixed_arity, RestDispatchKind::UserRestAndArguments),
         );
     });
+    invalidate_dispatch_strategy(func_ptr);
 }
 
 #[no_mangle]
@@ -293,6 +322,9 @@ pub extern "C" fn js_register_closure_arity(func_ptr: *const u8, arity: u32) {
     CLOSURE_ARITY_REGISTRY.with(|r| {
         r.borrow_mut().insert(func_ptr as usize, arity);
     });
+    // #6475: same pre-registration cache-poisoning hazard as the rest-family
+    // registrations above — a call before this registration caches `Direct`.
+    invalidate_dispatch_strategy(func_ptr);
 }
 
 #[inline(always)]

--- a/crates/perry-runtime/src/closure/unbox.rs
+++ b/crates/perry-runtime/src/closure/unbox.rs
@@ -29,3 +29,35 @@ pub extern "C" fn js_closure_unbox_callee_checked(callee: f64) -> i64 {
     }
     (bits & crate::value::POINTER_MASK) as i64
 }
+
+/// #6475: receiver-aware variant of [`js_closure_unbox_callee_checked`] for
+/// the fused member-call lowering (`o.m(args)` compiled as property-get +
+/// `js_closure_callN`). An object-literal method carries its `this` baked
+/// into a reserved capture slot at construction time, and that slot WINS over
+/// the `IMPLICIT_THIS` cell codegen sets around the call — so a method
+/// inherited through `Object.setPrototypeOf(obj, proto)` ran with `this`
+/// bound to the PROTO literal instead of the receiver. `js_native_call_method`
+/// (the by-name dispatcher) already rebinds via `clone_closure_rebind_this`;
+/// this brings the fused path to parity. effect's Pipeable
+/// (`TagClass.pipe(...)` in `HttpRouter.Tag`) resolved `pipe` off the Tag
+/// prototype chain and composed against the wrong `this`, so
+/// `HttpApiBuilder.group(...)` returned a curried function instead of a
+/// Layer ("Not a valid effect: undefined" at web.ts startup).
+///
+/// `clone_closure_rebind_this` is a no-op for closures that don't capture
+/// `this` (plain functions, arrows), so receiverless shapes and the common
+/// own-method call (baked `this` == receiver) keep their exact behavior.
+#[no_mangle]
+pub extern "C" fn js_closure_unbox_callee_checked_rebind(callee: f64, receiver: f64) -> i64 {
+    let bits = callee.to_bits();
+    if bits & crate::value::TAG_MASK != crate::value::POINTER_TAG {
+        throw_not_callable();
+    }
+    let rebound = crate::closure::clone_closure_rebind_this(bits, receiver);
+    (rebound & crate::value::POINTER_MASK) as i64
+}
+
+/// Keepalive: generated code is the only caller (#6475).
+#[used]
+static KEEP_JS_CLOSURE_UNBOX_CALLEE_CHECKED_REBIND: extern "C" fn(f64, f64) -> i64 =
+    js_closure_unbox_callee_checked_rebind;

--- a/crates/perry-runtime/src/object/class_registry/parent_static.rs
+++ b/crates/perry-runtime/src/object/class_registry/parent_static.rs
@@ -1442,6 +1442,41 @@ pub unsafe extern "C" fn js_class_static_method_call(
             return result;
         }
     }
+    // #6475: `class X extends <function value>() {}` — a static member
+    // INHERITED from the parent FUNCTION's own properties, invoked as a call
+    // (`X.use(f)`, effect's `HttpRouter.Tag(id)().use`/`unwrap`/`serve`). The
+    // field-GET path already walks the parent closure
+    // (`get_field_by_name.rs` #36/#321: `closure_get_dynamic_prop(parent,
+    // name)`), so `typeof X.use === "function"` — but the fused static-CALL
+    // lowering routes here, and this helper only consulted CLASS_DYNAMIC_PROPS
+    // (which holds statics of a CLASS parent, not the own props of a runtime
+    // FUNCTION parent stored in the closure-props table). So the call missed,
+    // fell to the receiver fallback below, and effect's `X.use(f)` returned the
+    // class ref (`1`) instead of running the inherited arrow — every Tag-based
+    // Layer built through `.use`/`.serve` silently became the class itself.
+    // Walk the parent-closure chain and invoke the resolved callable with `this`
+    // bound to the receiver, mirroring the GET path.
+    if let Some(closure_ptr) = parent_closure_in_chain(class_id) {
+        let closure_val = f64::from_bits(
+            crate::value::POINTER_TAG | (closure_ptr as u64 & crate::value::POINTER_MASK),
+        );
+        let member = crate::closure::closure_get_dynamic_prop(closure_ptr, name);
+        let mv = crate::value::JSValue::from_bits(member.to_bits());
+        if !mv.is_undefined()
+            && !mv.is_null()
+            && crate::collection_iter::is_callable(member)
+            // Guard against the closure_get_dynamic_prop fallback returning the
+            // closure itself for an unknown key (it never should for a miss,
+            // but be defensive): a member equal to the parent closure value is
+            // not a real inherited member.
+            && member.to_bits() != closure_val.to_bits()
+        {
+            let prev_this = crate::object::js_implicit_this_set(receiver);
+            let result = crate::closure::js_native_call_value(member, args_ptr, args_len);
+            crate::object::js_implicit_this_set(prev_this);
+            return result;
+        }
+    }
     // True miss: no static method and no callable static field resolved on the
     // class chain. We hand back the receiver (load-bearing for effect's
     // `.pipe()`-during-init chains, #687) — but that silent class-ref is exactly

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -54,6 +54,9 @@ mod native_module;
 pub(crate) use native_module::class_instance_has_member;
 pub(crate) use native_module::class_ref_id;
 pub(crate) use native_module::install_native_module_vtable;
+pub(crate) use native_module::{
+    build_bound_method_closure, class_prototype_ref_id, SYMBOL_BOUND_METHOD_NAME,
+};
 mod native_module_crypto_key_object;
 mod native_module_crypto_random;
 mod native_module_dispatch;

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1189,6 +1189,28 @@ pub(crate) fn canonical_bound_method_receiver(captured: f64) -> f64 {
         if class_id_from_method_receiver(call_this).is_some() {
             return call_this;
         }
+        // #6475: a FUNCTION-object call-site `this` — effect's `TagClass`, a
+        // plain function given the Tag class prototype via
+        // `Object.setPrototypeOf(TagClass, Object.getPrototypeOf(tagInstance))` —
+        // is a legitimate spec receiver for an inherited class method
+        // (`TagClass.pipe(...)`: `pipe` lives on the Tag class prototype and
+        // must run with `this === TagClass`). `class_id_from_method_receiver`
+        // deliberately rejects closures (reading `class_id` off a
+        // `ClosureHeader` is type confusion), but that guard protects
+        // RESOLUTION — and `dispatch_bound_method` resolves the method from
+        // the CAPTURED owner proto-ref, never from this substituted receiver.
+        // Passing the closure through only changes the `this` the body
+        // observes, which previously leaked the INT32 proto-ref marker
+        // (`typeof this === "number"`): effect's Pipeable composed against
+        // it, `HttpApiBuilder.group(...)` returned a curried function instead
+        // of a Layer, and web.ts died with "Not a valid effect: undefined".
+        let jv = JSValue::from_bits(call_this.to_bits());
+        if jv.is_pointer() {
+            let raw = (call_this.to_bits() & crate::value::POINTER_MASK) as usize;
+            if crate::closure::is_closure_ptr(raw) {
+                return call_this;
+            }
+        }
     }
     captured
 }


### PR DESCRIPTION
## Summary

Fixes a chain of codegen/runtime bugs that blocked effect (`effect` + `@effect/platform`) apps whose services are built on `Context.Tag` / `HttpRouter.Tag` and `Schema`. With these, the effect-compiled-experiment `web.ts` HTTP server **starts and logs `Listening on http://127.0.0.1:PORT` byte-identical to node**, and routes incoming requests (previously it died at `Layer.launch`). `logger.ts` / `forking.ts` / `api.ts` from the same repo remain byte-identical to node.

Part of #6475.

## The bugs (each has a no-effect minimal repro)

1. **`this` on methods inherited via `Object.setPrototypeOf`** — the fused member-call path (`o.m(args)` → property-get + `js_closure_callN`) set `IMPLICIT_THIS` but never rebound an object-literal method's baked `this` capture slot, so a method inherited through `setPrototypeOf(obj, proto)` ran with `this` = the proto. New `js_closure_unbox_callee_checked_rebind` for member-shaped calls; no-op for non-`this`-capturing closures.

2. **Function-object receiver for canonical bound class methods** — `canonical_bound_method_receiver` refused a FUNCTION-object call-site `this` (effect's `TagClass`), leaking the INT32 prototype-ref marker as the method body's `this` (`typeof this === "number"`). Dispatch resolves the method from the captured owner proto-ref, so admitting a closure receiver only changes `this`, never resolution.

3. **Dispatch-strategy cache invalidation** — `DISPATCH_CACHE`/`DISPATCH_LAST` memoize the first resolution per func_ptr; a call before the module's `js_register_closure_*` batch cached `Direct` forever, so a later `arguments`-method call transmuted args onto the 1-slot ABI. Invalidate both caches on all four registration entry points (init-time-rare; hot paths untouched).

4. **Static-member CALL walks the parent-closure chain** — `class X extends <function value>() {}` (effect's `Tag`) inherits static members (`use`/`unwrap`/`serve`) from the parent FUNCTION's own props. The field-GET path already walked the parent closure (#36/#321), so `typeof X.use === "function"`, but the fused static-CALL (`js_class_static_method_call`) only consulted `CLASS_DYNAMIC_PROPS` and returned the class ref instead of running the inherited arrow (the stray `1` its own fallback comment warned about). Walk the parent-closure chain and invoke the callable with `this` bound to the receiver.

5. **Namespace-member SPREAD call resolves the function, not a same-named class** — `Schema.Union(...Array.from(...))` threw "value is not a function": the spread path lowered the callee as a VALUE, and `property_get`'s class-ref shortcut matched `ctx.class_ids` by BARE name — picking an unrelated `Union` CLASS from another module. Fixed at the spread-call site (not the shared value-resolution path, which genuine namespace class members depend on): when the callee is a known REST function export, bundle the spread into the rest array and call `perry_fn_<src>__fn` directly, mirroring the regular-call path.

## Validation

- effect `web.ts`: server starts, `Listening on ...` byte-identical to node; requests routed.
- `logger.ts` / `forking.ts` / `api.ts`: byte-identical to node (unchanged).
- Minimal probes for each bug (function-object receivers, `class X extends <fnValue>()` static inheritance, namespace-member spread call with a same-named local class) match node.
- No regressions across the effect app suite.

## Known remaining (tracked, out of scope here)

`web.ts` per-request handlers still hit a `ToObject(undefined)` deep in effect's fiber runtime (a captured value that is undefined in perry but a valid Effect in node), and `Object.getPrototypeOf` on a `class X extends <fnValue>()` returns an object rather than the parent function. Both are separate follow-ups.

https://claude.ai/code/session_01R4phoN4f7eFbSQTkuB2oQP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed spread calls to namespace-imported rest functions, including mixed regular and spread arguments.
  - Corrected `this` binding for object-literal and member method calls.
  - Improved closure dispatch during module initialization and import cycles.
  - Fixed inherited static method calls on classes extending dynamically evaluated functions.
  - Corrected bound-method receiver handling in function-object calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->