### PR TITLE
fix(hir): abstract class fields are type-only, emit no runtime slot

### DIFF
--- a/crates/perry-hir/src/lower_decl/class_decl.rs
+++ b/crates/perry-hir/src/lower_decl/class_decl.rs
@@ -863,7 +863,13 @@ pub fn lower_class_decl(
                 }
             }
             ast::ClassMember::ClassProp(prop) => {
-                if prop.declare {
+                // `declare` and `abstract` fields are type-only: TypeScript
+                // erases them entirely (`node --experimental-strip-types`
+                // emits no runtime slot). Materializing an abstract base-class
+                // field creates a phantom slot that shadows the concrete
+                // subclass initializer of the same name — a base/union-typed
+                // read then resolves to the (undefined) base slot. Skip both.
+                if prop.declare || prop.is_abstract {
                     continue;
                 }
                 // Computed-key fields (`[Symbol.for("k")] = init`) flow through
@@ -1684,7 +1690,13 @@ pub fn lower_class_from_ast(
                 }
             }
             ast::ClassMember::ClassProp(prop) => {
-                if prop.declare {
+                // `declare` and `abstract` fields are type-only: TypeScript
+                // erases them entirely (`node --experimental-strip-types`
+                // emits no runtime slot). Materializing an abstract base-class
+                // field creates a phantom slot that shadows the concrete
+                // subclass initializer of the same name — a base/union-typed
+                // read then resolves to the (undefined) base slot. Skip both.
+                if prop.declare || prop.is_abstract {
                     continue;
                 }
                 // Computed-key fields (`[Symbol.for("k")] = init`) flow through

--- a/test-files/test_gap_abstract_field_shadow_union_read.ts
+++ b/test-files/test_gap_abstract_field_shadow_union_read.ts
@@ -1,0 +1,76 @@
+// Abstract class fields are type-only in TypeScript: `node --experimental-strip-types`
+// erases them and emits NO runtime slot. Perry previously lowered
+// `abstract readonly _tag: string;` into a real field, so a base-class abstract
+// field plus a concrete same-named subclass initializer produced TWO physical
+// slots (`Object.keys` => `_tag|_tag`). Reading the property through a
+// base/union-typed local variable then resolved to the phantom base slot
+// (undefined) instead of the concrete subclass value — the switch below would
+// fall through. This is the exact shape of @effect/platform's HttpBody
+// (`BodyBase` abstract `_tag` + `Uint8ArrayImpl`/`EmptyImpl` concrete `_tag`),
+// which made an Effect HTTP server return "Not a valid effect: undefined".
+//
+// Validated byte-for-byte against `node --experimental-strip-types`.
+
+const TypeId = Symbol.for("BodyTypeId");
+
+abstract class BodyBase {
+  readonly [TypeId]: symbol;
+  abstract readonly _tag: string;
+  constructor() {
+    (this as any)[TypeId] = TypeId;
+  }
+  abstract toJSON(): unknown;
+}
+
+class Uint8ArrayImpl extends BodyBase {
+  readonly _tag = "Uint8Array";
+  readonly body: string;
+  readonly contentType: string;
+  constructor(body: string, contentType: string) {
+    super();
+    this.body = body;
+    this.contentType = contentType;
+  }
+  toJSON(): unknown {
+    return { _tag: this._tag };
+  }
+}
+
+class EmptyImpl extends BodyBase {
+  readonly _tag = "Empty";
+  toJSON(): unknown {
+    return { _tag: this._tag };
+  }
+}
+
+type Body = Uint8ArrayImpl | EmptyImpl;
+
+const x = new Uint8ArrayImpl("hi", "text/html");
+
+// No phantom duplicate slot: abstract `_tag` must not be a runtime field.
+console.log("keys:", Object.keys(x).join("|"));
+
+// Every access path must read the concrete subclass value.
+console.log("any:", (x as any)._tag);
+console.log("base param:", ((b: BodyBase) => b._tag)(x));
+console.log("union param:", ((b: Body) => b._tag)(x));
+
+// The failing case: a union-typed local variable.
+const b2: Body = x;
+console.log("union local:", b2._tag);
+
+// The exact effect discriminated-union dispatch.
+switch (b2._tag) {
+  case "Uint8Array":
+    console.log("switch: matched Uint8Array");
+    break;
+  case "Empty":
+    console.log("switch: matched Empty");
+    break;
+  default:
+    console.log("switch: fell through");
+}
+
+// Second subclass through the union, to be sure both discriminants resolve.
+const e: Body = new EmptyImpl();
+console.log("empty union local:", e._tag);


### PR DESCRIPTION
## Problem

Perry lowered an `abstract` class field (`abstract readonly _tag: string;`) into a real runtime property slot. TypeScript treats abstract members as type-only and erases them — `node --experimental-strip-types` emits no runtime slot. When a subclass declared the same field with an initializer, the instance ended up with **two** physical `_tag` slots (`Object.keys` → `_tag|_tag`): the phantom base slot (undefined) and the concrete subclass slot. A read through a base- or union-typed local variable resolved to the phantom base slot and returned `undefined`.

## Impact

This is the exact shape of `@effect/platform`'s `HttpBody`: `abstract class BodyBase { abstract readonly _tag: string }` with concrete `Uint8ArrayImpl` / `EmptyImpl` / `RawImpl`. The Node HTTP response writer does `switch (body._tag)` with no default; with `_tag` reading `undefined` the switch fell through, the thunk returned `undefined`, and the fiber runtime reported `Not a valid effect: undefined`. An Effect HTTP server (`HttpLayerRouter` / `HttpApi`) returned `500` on every request. Since `HttpBody.text` / `.html` / `.json` / `.uint8Array` all produce `Uint8Array`-tagged bodies, this affected all response bodies.

## Fix

Skip abstract instance fields during class lowering, exactly as `declare` fields are already skipped — `crates/perry-hir/src/lower_decl/class_decl.rs`, both lowering entry points. Abstract fields cannot carry initializers and are always overridden by a concrete subclass, so removing the phantom slot is semantically safe and matches the Node oracle. `is_abstract` was previously unused across the compiler.

## Test

`test-files/test_gap_abstract_field_shadow_union_read.ts` — byte-identical to `node --experimental-strip-types`. Covers the no-duplicate-slot check (`Object.keys`), every read path (any / base param / union param / union local), and the discriminated-union `switch` that mirrors the effect `HttpBody` dispatch.

Closes #6498


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed runtime handling of abstract class fields so they no longer create phantom properties or shadow concrete subclass values.
  * Corrected property access and discriminated-union behavior for classes with abstract fields.

* **Tests**
  * Added coverage for object keys, direct and typed property reads, and union-based type narrowing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->