### PR TITLE
fix(hir,runtime): per-evaluation class bindings must carry the capture BOX, and expose .name

### DIFF
--- a/crates/perry-hir/src/lower/shared_mutable_capture.rs
+++ b/crates/perry-hir/src/lower/shared_mutable_capture.rs
@@ -873,6 +873,35 @@ fn rewrite_expr(expr: &mut Expr, shared: &HashSet<LocalId>, index_uses: &HashSet
         // Capture sites snapshot the WHOLE handle (the array). Leave the bare
         // `LocalGet(id)` capture args alone; still rewrite non-capture children.
         Expr::RegisterClassCaptures { .. } => return,
+        // #6497: the per-evaluation fresh-binding path (#6470) carries the
+        // same capture-param-ordered `LocalGet` args as RegisterClassCaptures
+        // — they too must snapshot the WHOLE box handle. Rewriting them to
+        // `id[0]` stored the cell's current VALUE on the heap class object,
+        // so methods of a class that captures AND mutates a local indexed
+        // into a number: reads came back `undefined` and writes were lost
+        // (gap tests anon_shape_boxed_capture / 5952_mixin_factory_binding).
+        // Statics' initializer values are ordinary reads and still rewrite.
+        Expr::ClassExprFresh {
+            named_statics,
+            symbol_statics,
+            captured_args,
+            ..
+        } => {
+            for (_, v) in named_statics.iter_mut() {
+                rewrite_expr(v, shared, index_uses);
+            }
+            for (k, v) in symbol_statics.iter_mut() {
+                rewrite_expr(k, shared, index_uses);
+                rewrite_expr(v, shared, index_uses);
+            }
+            for a in captured_args.iter_mut() {
+                if matches!(a, Expr::LocalGet(id) if index_uses.contains(id)) {
+                    continue; // capture argument — keep the array handle
+                }
+                rewrite_expr(a, shared, index_uses);
+            }
+            return;
+        }
         Expr::New {
             class_name, args, ..
         } => {

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -111,6 +111,7 @@ pub(crate) fn is_fetch_subclass_body_method(name: &[u8]) -> bool {
 // ── Topical sub-modules (issue #1103: keep every file < 2000 lines) ──
 mod accessors;
 mod buffer_own_prop;
+mod class_object_props;
 mod crypto_key;
 mod enumeration;
 mod field_ops;

--- a/crates/perry-runtime/src/object/field_get_set/class_object_props.rs
+++ b/crates/perry-runtime/src/object/field_get_set/class_object_props.rs
@@ -1,0 +1,41 @@
+//! #6497: `.name` on a heap class-expression value (`ClassExprFresh` — #6470
+//! also routes capturing function-body class DECLARATIONS through it) must
+//! expose the template's registry name, matching the INT32 class-ref path's
+//! #2059 arm. Split from `get_field_by_name_tail.rs` for the file-size cap.
+
+use super::*;
+
+/// #4949: heap class-expression values (`ClassExprFresh`) are real
+/// OBJECT_TYPE_CLASS objects, not INT32 class refs. Their `.prototype`
+/// read must still expose the live declared-class prototype object so
+/// tsc/tslib decorator code can inspect and mutate method descriptors.
+pub(super) unsafe fn class_object_prototype_value(obj: *const ObjectHeader) -> JSValue {
+    let class_id = (*obj).class_id;
+    let value = super::super::class_registry::class_decl_prototype_value(class_id);
+    if value.to_bits() == crate::value::TAG_UNDEFINED {
+        let value = super::super::class_prototype_ref_value(class_id);
+        return JSValue::from_bits(value.to_bits());
+    }
+    JSValue::from_bits(value.to_bits())
+}
+
+/// Resolve `.name` for an `OBJECT_TYPE_CLASS` heap object. An explicit
+/// `static name` member (an own field on the class object) wins; a deleted
+/// key still reads `undefined` (returns `None`).
+pub(super) unsafe fn class_object_name_value(
+    obj: *const ObjectHeader,
+    key: *const crate::StringHeader,
+) -> Option<JSValue> {
+    if let Some(v) = own_data_field_by_name(obj, key) {
+        return Some(v);
+    }
+    let class_id = (*obj).class_id;
+    if super::super::class_registry::class_is_key_deleted(class_id, "name") {
+        return None;
+    }
+    let cname = super::super::class_registry::class_name_for_id(class_id)?;
+    let s = crate::string::js_string_from_bytes(cname.as_ptr(), cname.len() as u32);
+    Some(JSValue::from_bits(
+        crate::js_nanbox_string(s as i64).to_bits(),
+    ))
+}

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
@@ -1328,6 +1328,27 @@ pub(crate) fn get_field_by_name_object_tail(
                 }
                 return JSValue::from_bits(value.to_bits());
             }
+            // #6497: `.name` on a heap class-expression value (ClassExprFresh —
+            // #6470 also routes capturing function-body class DECLARATIONS
+            // through it) must expose the template's class name, same as the
+            // INT32 class-ref path's #2059 arm. An explicit `static name`
+            // member (an own field on the class object) still wins.
+            if key_bytes == b"name"
+                && (*obj).object_type == crate::error::OBJECT_TYPE_CLASS
+                && (*obj).class_id != 0
+            {
+                if let Some(v) = own_data_field_by_name(obj, key) {
+                    return v;
+                }
+                let class_id = (*obj).class_id;
+                if !super::super::class_registry::class_is_key_deleted(class_id, "name") {
+                    if let Some(cname) = super::super::class_registry::class_name_for_id(class_id) {
+                        let s =
+                            crate::string::js_string_from_bytes(cname.as_ptr(), cname.len() as u32);
+                        return JSValue::from_bits(crate::js_nanbox_string(s as i64).to_bits());
+                    }
+                }
+            }
             if (*obj).class_id == CLASS_ID_BOXED_STRING {
                 if let Some((_, payload)) = crate::builtins::boxed_primitive_payload(
                     f64::from_bits(crate::value::js_nanbox_pointer(obj as i64).to_bits()),

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
@@ -1312,40 +1312,15 @@ pub(crate) fn get_field_by_name_object_tail(
             let key_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
             let key_len = (*key).byte_len as usize;
             let key_bytes = std::slice::from_raw_parts(key_ptr, key_len);
-            // #4949: heap class-expression values (`ClassExprFresh`) are real
-            // OBJECT_TYPE_CLASS objects, not INT32 class refs. Their `.prototype`
-            // read must still expose the live declared-class prototype object so
-            // tsc/tslib decorator code can inspect and mutate method descriptors.
-            if key_bytes == b"prototype"
-                && (*obj).object_type == crate::error::OBJECT_TYPE_CLASS
-                && (*obj).class_id != 0
-            {
-                let class_id = (*obj).class_id;
-                let value = super::super::class_registry::class_decl_prototype_value(class_id);
-                if value.to_bits() == crate::value::TAG_UNDEFINED {
-                    let value = super::super::class_prototype_ref_value(class_id);
-                    return JSValue::from_bits(value.to_bits());
+            // #4949 `.prototype` / #6497 `.name` on heap class-expression
+            // values — see `class_object_props`.
+            if (*obj).object_type == crate::error::OBJECT_TYPE_CLASS && (*obj).class_id != 0 {
+                if key_bytes == b"prototype" {
+                    return super::class_object_props::class_object_prototype_value(obj);
                 }
-                return JSValue::from_bits(value.to_bits());
-            }
-            // #6497: `.name` on a heap class-expression value (ClassExprFresh —
-            // #6470 also routes capturing function-body class DECLARATIONS
-            // through it) must expose the template's class name, same as the
-            // INT32 class-ref path's #2059 arm. An explicit `static name`
-            // member (an own field on the class object) still wins.
-            if key_bytes == b"name"
-                && (*obj).object_type == crate::error::OBJECT_TYPE_CLASS
-                && (*obj).class_id != 0
-            {
-                if let Some(v) = own_data_field_by_name(obj, key) {
-                    return v;
-                }
-                let class_id = (*obj).class_id;
-                if !super::super::class_registry::class_is_key_deleted(class_id, "name") {
-                    if let Some(cname) = super::super::class_registry::class_name_for_id(class_id) {
-                        let s =
-                            crate::string::js_string_from_bytes(cname.as_ptr(), cname.len() as u32);
-                        return JSValue::from_bits(crate::js_nanbox_string(s as i64).to_bits());
+                if key_bytes == b"name" {
+                    if let Some(v) = super::class_object_props::class_object_name_value(obj, key) {
+                        return v;
                     }
                 }
             }


### PR DESCRIPTION
Fixes #6497 — the main-tip regression from be2e23f86 (#6470) that currently reds conformance-smoke shards 5/7 on every PR.

## What broke

#6470 routes capturing function-body class declarations through `ClassExprFresh` (per-evaluation captures). Two interactions:

1. **Boxed (mutated) captures lost their cell.** The #5951 shared-mutable-capture pass rewrites every value read of a boxed capture into `cell[0]`, and exempts `RegisterClassCaptures` args — capture sites must snapshot the whole box handle. The new `ClassExprFresh.captured_args` had no exemption, so the fresh class object snapshotted the cell's current **value**. A class that captures AND mutates a local then read `undefined` and dropped writes:

   ```ts
   function sharedCell() {
     let count = 0;
     class Counter { bump() { count++; } read() { return count; } }
     const c = new Counter(); c.bump(); c.bump(); count += 10;
     return c.read() + "," + count;   // node: "12,12" — main: "undefined,10"
   }
   ```

2. **`.name` read `undefined`** on the fresh class value (`makeTagged("S").name`): nothing routed the read to the template's registry name. Added a `name` arm next to the #4949 `prototype` arm in the `OBJECT_TYPE_CLASS` property tail; explicit `static name` members still win.

## Fix

- `shared_mutable_capture.rs`: exempt `ClassExprFresh.captured_args` from the `cell[0]` rewrite exactly like `RegisterClassCaptures`; statics' initializer values are ordinary reads and still rewrite.
- `get_field_by_name_tail.rs`: `.name` on heap class objects resolves via `class_name_for_id`, after own-field lookup, honoring key deletion.

## Validation

- `test_gap_anon_shape_boxed_capture` and `test_gap_5952_mixin_factory_binding`: byte-identical to node (both fail on clean `origin/main`).
- #6470's own repro (effect `makeException`, per-evaluation `_tag`s) still passes, plus a boxed-counter variant through the same factory shape.
- `perry-runtime` 1321/0 single-threaded; `perry-hir` unchanged (the c262_parity failure `logical_property_assignment_short_circuits_the_store_4586` is pre-existing — fails identically on clean origin/main).

https://claude.ai/code/session_01M44HoYS3CAYZyagm3ZzYDG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Class expression objects now expose their class name via the `.name` property.
  * Heap-backed class objects now resolve `.prototype` and `.name` through consistent runtime logic.

* **Bug Fixes**
  * Improved handling of captured arguments in fresh class expressions, preserving the correct snapshot array reference when required.
  * More accurate fallback behavior for `.name` when no own data field is present (returns `undefined` when marked deleted).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->