### PR TITLE
chore: fix stale post-V8-removal comments + broken CI-template action

### DIFF
--- a/crates/perry-runtime/src/closure/v8_stubs.rs
+++ b/crates/perry-runtime/src/closure/v8_stubs.rs
@@ -1,32 +1,40 @@
-//! V8-interop weak/Rust stubs and AOT no-op stubs for unconditionally-declared
+//! V8-interop no-op stubs and AOT no-op stubs for unconditionally-declared
 //! FFI symbols (lodash, axios, argon2, sharp, ratelimit).
 
-// V8 interop no-op stubs. Real implementations are in perry-jsruntime/src/interop.rs.
-// These stubs ensure symbols are always available even when perry-jsruntime is not linked
-// (iOS, Android, standalone builds). When perry-jsruntime IS linked, its strong symbols
-// override these stubs via linker symbol resolution order.
+// V8 interop no-op stubs. Perry no longer ships a runtime JS engine: the
+// `perry-jsruntime` crate (V8 via `deno_core`) that used to provide the real
+// implementations of these symbols was deleted in #1696 ("remove
+// perry-jsruntime; ship V8-free binaries"). These stubs are now the *only*
+// definitions of `js_load_module`/`js_call_function`/etc. — every build links
+// them, and `js_*` calls always return the "no JS runtime" sentinel below.
+// (`enforce_js_runtime_gate` in
+// `crates/perry/src/commands/compile/bootstrap.rs` hard-errors any build
+// that would actually need one of these to do real work, so in practice a
+// compiled binary never calls through to them for a live JS module — they
+// exist only to satisfy the codegen-side `js_*` FFI declarations that are
+// still unconditionally emitted.)
 //
 // Signatures must match `crates/perry-codegen/src/runtime_decls.rs` exactly — the codegen
 // declarations determine which register the caller reads the result from (rax/x0 for I64,
 // xmm0/d0 for DOUBLE). A signature mismatch reads garbage and silently miscompiles.
 //
-// Stubs return NaN-boxed `TAG_UNDEFINED` (not 0.0) so when V8 isn't linked, downstream
-// `typeof` correctly observes `undefined` instead of `"number"` — making the missing-V8
-// case diagnostically distinct from a successful 0-returning JS call.
+// Stubs return NaN-boxed `TAG_UNDEFINED` (not 0.0) so downstream `typeof`
+// correctly observes `undefined` instead of `"number"` — making the
+// no-JS-runtime case diagnostically distinct from a successful
+// 0-returning JS call, in case any of these symbols is ever reached.
 //
-// On macOS (Mach-O) the stubs are emitted as **weak** symbols via `global_asm!` so
-// perry-jsruntime's strong impls always win, regardless of linker archive scan order.
-// Pre-fix, when user code only referenced FFIs that have stubs (e.g. `js_load_module` +
-// `js_call_function`, but NOT `js_call_method`), the linker resolved those symbols against
-// closure.o and never pulled `interop.o` from libperry_jsruntime.a — yielding a runtime
-// that links V8 nowhere and silently returns undefined for every JS call. The weak
-// attribute forces the linker to keep looking past closure.o's defs and pull in interop.o
-// when jsruntime.a is on the command line. (Issue #257.)
+// On macOS (Mach-O) the stubs are still emitted as **weak** symbols via
+// `global_asm!` (`.weak_definition`) — a holdover from when a strong
+// definition in `libperry_jsruntime.a` needed to be able to override them
+// regardless of linker archive scan order (Issue #257). With
+// `perry-jsruntime` gone there is no strong definition left to win that
+// race, so the weak attribute is currently a no-op; it's left in place
+// rather than downgraded to a plain global so re-adding a real JS runtime
+// wouldn't require rediscovering this mechanism.
 //
-// On other platforms (Linux, iOS, Android, Windows), Rust functions remain — Linux's
-// linker handles duplicate-defs via link order (jsruntime is listed first in link.rs);
-// iOS/Android/Windows don't link jsruntime at all (see compile.rs:2877), so the stubs
-// are the only defs and behave as runtime-only no-ops.
+// On other platforms (Linux, iOS, Android, Windows), the plain Rust
+// functions below are the only definitions and behave the same way —
+// unconditional no-ops.
 
 const _UNDEF_BITS: u64 = crate::value::TAG_UNDEFINED;
 

--- a/crates/perry-runtime/src/tui/cell.rs
+++ b/crates/perry-runtime/src/tui/cell.rs
@@ -1,6 +1,7 @@
-//! Packed cell grid. Each cell is 8 bytes (char=4, fg=1, bg=1, style=1,
-//! pad=1) so an 80x24 terminal fits in 15 KB and an 200x80 in 128 KB
-//! — well within L2.
+//! Packed cell grid. Each cell is 16 bytes (char=4, fg=4, bg=4, style=1,
+//! plus padding) now that `Color` carries truecolor RGB (see color.rs;
+//! grew from 1 byte/color to 4 bytes/color), so an 80x24 terminal fits
+//! in ~30 KB and a 200x80 one in ~250 KB — still well within L2.
 
 use super::color::Color;
 

--- a/crates/perry/src/commands/compile/targets.rs
+++ b/crates/perry/src/commands/compile/targets.rs
@@ -23,6 +23,14 @@ use crate::OutputFormat;
 
 use super::{CompilationContext, CompileArgs, CompileResult, NativeBackend};
 
+/// Historical leftover from the pre-#1696 V8/`deno_core` fallback runtime
+/// (`perry-jsruntime`, removed). `ctx.js_modules` is only ever populated
+/// alongside `ctx.js_runtime_importers` (see `collect_modules.rs`), and
+/// `enforce_js_runtime_gate` (`bootstrap.rs`) hard-errors the build as soon
+/// as `js_runtime_importers` is non-empty — well before this function's
+/// caller runs. In current builds `ctx.js_modules` is therefore always
+/// empty here, so this function is effectively dead code kept around
+/// for the (currently unreachable) day a JS engine ships again.
 pub(super) fn generate_js_bundle(ctx: &CompilationContext, output_dir: &Path) -> Result<PathBuf> {
     let bundle_path = output_dir.join("__perry_js_bundle.js");
 
@@ -50,17 +58,21 @@ pub(super) fn generate_js_bundle(ctx: &CompilationContext, output_dir: &Path) ->
     Ok(bundle_path)
 }
 
-/// Issue #818 follow-up: emit a generated C file whose constructor
-/// registers every bundled JS module (and bare-specifier alias) into
-/// `perry-jsruntime`'s embedded-module map at startup. Returns the path
-/// to the compiled `.o`, ready to be appended to `obj_paths` ahead of
-/// the final link. The result is a self-contained binary: the V8
-/// fallback `ModuleLoader` consults the in-memory map before touching
-/// disk, so `node_modules/` is no longer required at runtime.
+/// Issue #818 follow-up, now historical: this generated a C constructor
+/// that registered every bundled JS module (and bare-specifier alias)
+/// into `perry-jsruntime`'s embedded-module map at startup, so the V8
+/// fallback `ModuleLoader` could consult the in-memory map before
+/// touching disk. `perry-jsruntime` (V8 via `deno_core`) was removed in
+/// #1696 — Perry ships no JS engine and compiles TypeScript ahead-of-time
+/// only, so `js_register_embedded_module`/`js_register_embedded_alias`
+/// (declared as `extern` below) no longer have any implementation to
+/// link against.
 ///
-/// Constructor priority `101` lands before any normal user constructors
-/// and before `main`'s call to `js_runtime_init`, so by the time the
-/// runtime asks for a module the map is fully populated.
+/// Like `generate_js_bundle` above, this function is effectively dead
+/// code today: `ctx.js_modules` can't be non-empty by the time its
+/// caller runs, because `enforce_js_runtime_gate` hard-errors the build
+/// as soon as any entry lands in `ctx.js_modules` (see that function's
+/// doc comment). Kept for reference / in case a JS engine returns.
 pub(super) fn generate_embedded_js_object(
     ctx: &CompilationContext,
     output_dir: &Path,

--- a/crates/perry/well_known_bindings.toml
+++ b/crates/perry/well_known_bindings.toml
@@ -8,7 +8,11 @@
 #
 # Resolution precedence (see docs/src/native-libraries/manifest-v1.md):
 #   1. node_modules/<name>/  with  perry.nativeLibrary  →  use it
-#   2. node_modules/<name>/  without manifest           →  V8 fallback
+#   2. node_modules/<name>/  without manifest           →  hard compile
+#      error naming the package and pointing at
+#      `perry.compilePackages` (Perry ships no JS runtime — see
+#      `enforce_js_runtime_gate` in
+#      crates/perry/src/commands/compile/bootstrap.rs)
 #   3. well_known_bindings.toml (this file)             →  bundled crate
 #   4. nothing matches                                  →  resolution error
 #

--- a/templates/github-actions/ci.yml
+++ b/templates/github-actions/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
 
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Cache cargo registry
         uses: actions/cache@v4

--- a/templates/github-actions/release.yml
+++ b/templates/github-actions/release.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
 


### PR DESCRIPTION
## Summary

Fixes five small, unrelated defects found in a docs audit: stale references
to the V8/QuickJS fallback runtime (`perry-jsruntime`, deleted in #1696) and
a broken CI-template action name. Comment/template-only — no runtime
behavior changes, no cargo build needed.

- **`templates/github-actions/{ci,release}.yml`**: `uses: dtolnay/rust-action@stable`
  references an action that doesn't exist. Every real workflow in
  `.github/workflows/` uses `dtolnay/rust-toolchain@stable`; fixed all 4
  occurrences (3 in `ci.yml`, 1 in `release.yml`).
- **`crates/perry/well_known_bindings.toml`**: the resolution-precedence
  comment said `node_modules/<name>/` without a manifest falls back to
  "V8". That path now hard-errors via `enforce_js_runtime_gate`
  (`crates/perry/src/commands/compile/bootstrap.rs`), pointing users at
  `perry.compilePackages`. Updated the text; step ordering unchanged
  (cross-checked against `docs/src/native-libraries/manifest-v1.md`,
  which still needs the same fix — see "Not changed" below).
- **`crates/perry/src/commands/compile/targets.rs`**: `generate_js_bundle`
  and `generate_embedded_js_object` doc comments described feeding a "V8
  fallback `ModuleLoader`" (#818). Rewrote both to present-day reality.
  Also noted (not fixed) that both functions are now unreachable dead
  code — see "Dead-code note" below.
- **`crates/perry-runtime/src/closure/v8_stubs.rs`**: header said real
  implementations live in `perry-jsruntime/src/interop.rs` and that its
  strong symbols override these stubs when linked. That crate no longer
  exists — these stubs are the only definitions on every platform now.
  Rewrote the header accordingly, keeping the ABI/signature-mismatch
  warning intact.
- **`crates/perry-runtime/src/tui/cell.rs`**: header comment said `Cell`
  is 8 bytes (15 KB for an 80x24 grid, 128 KB for 200x80), left over from
  before truecolor `Color` (4 bytes/color, `color.rs`). Verified with
  `std::mem::size_of` that `Cell` is actually 16 bytes; grids are ~30 KB
  and ~250 KB respectively. Comment-only fix, no static asserts added.

## Dead-code note (not fixed, flagging for follow-up)

While updating the `targets.rs` doc comments I traced who populates
`ctx.js_modules`: every insertion in `collect_modules.rs` happens in the
same code block as a push to `ctx.js_runtime_importers`, and
`enforce_js_runtime_gate` (called from `run_post_collect_preflight`, which
runs early in `run_pipeline.rs`) hard-errors the build as soon as
`js_runtime_importers` is non-empty. `generate_js_bundle` and
`generate_embedded_js_object` are only called later in `run_pipeline.rs`
behind `if !ctx.js_modules.is_empty()`, which — given the above — can never
be true by the time execution gets there. Both functions appear to be
unreachable dead code today. Documented this in their doc comments but
left the functions in place rather than deleting them, since that's a
bigger, separate change than a docs audit should make.

## Not changed

- `docs/src/native-libraries/manifest-v1.md:455-457` has the identical
  stale "falls through to V8" claim that `well_known_bindings.toml`
  pointed at. Left it alone since it wasn't in the audited list, but it's
  the same bug and worth a follow-up.
- `crates/perry-runtime/src/closure/v8_stubs.rs`'s inline comments further
  down the file (the generated-C-file string literal, and the alias-loop
  comments in `targets.rs`) still mention "V8" in describing what the
  (now largely dead) code was built to do; left as historical
  implementation detail rather than rewriting every mention, since the
  file/function-level doc comments now make the current state clear.

## Test plan

- [x] `cargo fmt --all -- --check` passes (comment/template-only changes,
      untouched by rustfmt)
- [x] Manually traced `ctx.js_modules` / `ctx.js_runtime_importers` /
      `enforce_js_runtime_gate` call graph to confirm the dead-code claim
      in the `targets.rs` comments
- [x] Verified `Cell` is 16 bytes with a standalone `rustc` compile of the
      struct (`std::mem::size_of::<Cell>() == 16`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified JavaScript runtime support, build gating, and fallback behavior.
  - Updated terminal UI memory estimates to reflect truecolor support.
  - Documented clearer errors when packages lack required manifests.
  - Clarified legacy JavaScript bundling behavior for future runtime support.

- **Chores**
  - Updated automated workflows to use the current stable Rust toolchain setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->