### PR TITLE
fix(styling): emit borderWidth design token

### DIFF
--- a/packages/perry-styling/package.json
+++ b/packages/perry-styling/package.json
@@ -10,7 +10,8 @@
     "nativeModule": true
   },
   "scripts": {
-    "build:cli": "perry compile src/cli.ts -o dist/cli"
+    "build:cli": "perry compile src/cli.ts -o dist/cli",
+    "test": "mkdir -p dist && perry compile src/tokens.test.ts -o dist/tokens-test && ./dist/tokens-test"
   },
   "keywords": ["perry", "ui", "design-tokens", "theming"],
   "license": "MIT"

--- a/packages/perry-styling/src/cli.ts
+++ b/packages/perry-styling/src/cli.ts
@@ -113,7 +113,8 @@ if (args.length < 3 || args[2] === "--help" || args[2] === "-h") {
         const spacingCount = Object.keys(tokens.spacing).length;
         const radiusCount = Object.keys(tokens.radius).length;
         const fontSizeCount = Object.keys(tokens.fontSize).length;
-        console.log("  " + String(colorCount) + " color(s), " + String(spacingCount) + " spacing token(s), " + String(radiusCount) + " radius token(s), " + String(fontSizeCount) + " fontSize token(s)");
+        const borderWidthCount = Object.keys(tokens.borderWidth).length;
+        console.log("  " + String(colorCount) + " color(s), " + String(spacingCount) + " spacing token(s), " + String(radiusCount) + " radius token(s), " + String(fontSizeCount) + " fontSize token(s), " + String(borderWidthCount) + " borderWidth token(s)");
       } catch (e) {
         console.log("Error: Could not write output file: " + outPath);
       }

--- a/packages/perry-styling/src/generator.ts
+++ b/packages/perry-styling/src/generator.ts
@@ -112,6 +112,17 @@ export function generateTheme(tokens: TokenSet, originalColorValues: { [key: str
     lines.push("  fontSize: " + fsType + ";");
   }
 
+  const borderWidthKeys = Object.keys(tokens.borderWidth);
+  if (borderWidthKeys.length > 0) {
+    let bwType = "{ ";
+    for (let i = 0; i < borderWidthKeys.length; i = i + 1) {
+      bwType = bwType + formatKey(borderWidthKeys[i]) + ": number;";
+      if (i < borderWidthKeys.length - 1) { bwType = bwType + " "; }
+    }
+    bwType = bwType + " }";
+    lines.push("  borderWidth: " + bwType + ";");
+  }
+
   lines.push("}");
   lines.push("");
 
@@ -174,6 +185,18 @@ export function generateTheme(tokens: TokenSet, originalColorValues: { [key: str
     }
     fsLine = fsLine + " },";
     lines.push(fsLine);
+  }
+
+  // BorderWidth
+  if (borderWidthKeys.length > 0) {
+    let bwLine = "  borderWidth: { ";
+    for (let i = 0; i < borderWidthKeys.length; i = i + 1) {
+      const k = borderWidthKeys[i];
+      bwLine = bwLine + formatKey(k) + ": " + String(tokens.borderWidth[k]);
+      if (i < borderWidthKeys.length - 1) { bwLine = bwLine + ", "; }
+    }
+    bwLine = bwLine + " },";
+    lines.push(bwLine);
   }
 
   lines.push("};");

--- a/packages/perry-styling/src/tokens.test.ts
+++ b/packages/perry-styling/src/tokens.test.ts
@@ -1,0 +1,55 @@
+// tokens.test.ts — regression test for the `borderWidth` design token.
+//
+// Perry's compiler doesn't (yet) ship a test runner for this package, so this
+// follows the same pattern used across the repo's test-files/*.ts gap tests:
+// a plain .ts program that throws (non-zero exit) on failure and prints a
+// PASS line + exits 0 on success.
+//
+// Run:
+//   perry compile src/tokens.test.ts -o dist/tokens-test && ./dist/tokens-test
+// or:
+//   npm test   (see package.json)
+
+import { parseTokens } from "./tokens";
+import { generateTheme } from "./generator";
+
+function assertEqual(actual: number, expected: number, label: string): void {
+  if (actual !== expected) {
+    throw new Error(label + ": expected " + String(expected) + ", got " + String(actual));
+  }
+}
+
+function assertContains(haystack: string, needle: string, label: string): void {
+  if (haystack.indexOf(needle) === -1) {
+    throw new Error(label + ": expected output to contain " + JSON.stringify(needle) + "\n---\n" + haystack);
+  }
+}
+
+const tokensJson = JSON.stringify({
+  colors: {
+    primary: "#3B82F6",
+  },
+  spacing: { md: 16 },
+  radius: { md: 8 },
+  fontSize: { md: 16 },
+  borderWidth: { none: 0, thin: 0.5, md: 2, lg: 4 },
+});
+
+// 1. parseTokens() must read the borderWidth section into TokenSet.borderWidth.
+const tokens = parseTokens(tokensJson);
+
+assertEqual(Object.keys(tokens.borderWidth).length, 4, "borderWidth key count");
+assertEqual(tokens.borderWidth["none"], 0, "borderWidth.none");
+assertEqual(tokens.borderWidth["thin"], 0.5, "borderWidth.thin");
+assertEqual(tokens.borderWidth["md"], 2, "borderWidth.md");
+assertEqual(tokens.borderWidth["lg"], 4, "borderWidth.lg");
+
+// 2. generateTheme() must emit borderWidth in both the PerryTheme interface
+//    and the emitted `theme` object literal — matching the documented
+//    PerryTheme/ResolvedTheme shape in docs/src/ui/theming.md.
+const output = generateTheme(tokens, {}, {});
+
+assertContains(output, "borderWidth: { none: number; thin: number; md: number; lg: number; };", "PerryTheme.borderWidth field type");
+assertContains(output, "borderWidth: { none: 0, thin: 0.5, md: 2, lg: 4 },", "theme.borderWidth value");
+
+console.log("PASS: borderWidth flows through parseTokens() -> generateTheme()");

--- a/packages/perry-styling/src/tokens.ts
+++ b/packages/perry-styling/src/tokens.ts
@@ -20,6 +20,7 @@ export interface TokenSet {
   spacing: NumberMap;
   radius: NumberMap;
   fontSize: NumberMap;
+  borderWidth: NumberMap;
 }
 
 // Parse a flat JSON token object into a TokenSet.
@@ -34,6 +35,7 @@ export function parseTokens(json: string): TokenSet {
   const spacing: NumberMap = {};
   const radius: NumberMap = {};
   const fontSize: NumberMap = {};
+  const borderWidth: NumberMap = {};
 
   // Process colors section
   if (raw !== null && typeof raw === "object") {
@@ -115,7 +117,20 @@ export function parseTokens(json: string): TokenSet {
         }
       }
     }
+
+    // Process borderWidth section
+    const borderWidthRaw = raw["borderWidth"];
+    if (borderWidthRaw !== null && typeof borderWidthRaw === "object") {
+      const keys = Object.keys(borderWidthRaw);
+      for (let i = 0; i < keys.length; i = i + 1) {
+        const k = keys[i];
+        const v = borderWidthRaw[k];
+        if (typeof v === "number") {
+          borderWidth[k] = v;
+        }
+      }
+    }
   }
 
-  return { lightColors, darkColors, colorKeys, spacing, radius, fontSize };
+  return { lightColors, darkColors, colorKeys, spacing, radius, fontSize, borderWidth };
 }


### PR DESCRIPTION
## Root cause

`perry-styling`'s theme generator (`packages/perry-styling/src/tokens.ts` +
`src/generator.ts`) never read or emitted the `borderWidth` design token,
even though every other part of the package already assumed it existed:

- `src/index.ts` declares `PerryTheme`/`ResolvedTheme` with a required
  `borderWidth: { [key: string]: number }` field and threads it through
  `getTheme()`.
- `examples/tokens.json` has a `"borderWidth"` section.
- `examples/theme.ts` (the checked-in "generated" example) has a
  `borderWidth` field on `PerryTheme` and in the `theme` object literal.
- `examples/showcase.ts` calls `applyBorderWidth(borderCard, t.borderWidth.md)`.
- `docs/src/ui/theming.md` documents `borderWidth` in the token-format JSON
  example and in both the `PerryTheme`/`ResolvedTheme` interface listings.

Only `tokens.ts::parseTokens()` and `generator.ts::generateTheme()` — the
actual codegen — silently dropped it. Anyone who ran
`perry-styling generate --tokens tokens.json --out theme.ts` on a
`tokens.json` with a `borderWidth` section got a `theme.ts` missing the
field entirely, silently diverging from the documented/hand-authored API
surface.

### Evidence (before the fix, on `origin/main`)

```
$ perry compile src/cli.ts -o /tmp/cli-before
$ /tmp/cli-before generate --tokens examples/tokens.json --out /tmp/theme-before.ts
Generated /tmp/theme-before.ts
  7 color(s), 4 spacing token(s), 4 radius token(s), 5 fontSize token(s)
```

`/tmp/theme-before.ts` has no `borderWidth` field in `PerryTheme` and no
`borderWidth` line in the emitted `theme` object, despite
`examples/tokens.json` containing a 5-key `"borderWidth"` section.

## Fix

Added `borderWidth` support to `tokens.ts`/`generator.ts` following the
exact pattern already used for `radius`/`fontSize`:

- `tokens.ts`: `TokenSet` gains a `borderWidth: NumberMap` field;
  `parseTokens()` parses a `"borderWidth"` JSON section the same way it
  parses `"radius"`/`"fontSize"` (numeric values only, arbitrary keys).
- `generator.ts`: `generateTheme()` emits `borderWidth: { ... }` in both
  the `PerryTheme` interface and the `theme` object literal, mirroring the
  `fontSize` block byte-for-byte in structure.
- `cli.ts`: the `generate` summary line now also reports the borderWidth
  token count (matching the existing color/spacing/radius/fontSize counts).

No changes were needed in `src/index.ts`, `examples/*`, or
`docs/src/ui/theming.md` — those already documented/consumed `borderWidth`
correctly; the generator was the only place out of sync.

## Verification

Compiled and ran the CLI (via the already-built `perry` release binary,
no cargo rebuild) against `examples/tokens.json`:

```
$ perry compile src/cli.ts -o /tmp/cli-after
$ /tmp/cli-after generate --tokens examples/tokens.json --out /tmp/theme-after.ts
Generated /tmp/theme-after.ts
  7 color(s), 4 spacing token(s), 4 radius token(s), 5 fontSize token(s), 5 borderWidth token(s)
```

`/tmp/theme-after.ts` now contains:

```ts
export interface PerryTheme {
  ...
  borderWidth: { none: number; thin: number; sm: number; md: number; lg: number; };
}

export const theme: PerryTheme = {
  ...
  borderWidth: { none: 0, thin: 0.5, sm: 1, md: 2, lg: 4 },
};
```

matching `examples/tokens.json`'s `borderWidth` section and the values
already hand-authored in `examples/theme.ts`.

Added `src/tokens.test.ts`, a small perry-compiled regression test
(`npm test` → `perry compile src/tokens.test.ts -o dist/tokens-test &&
./dist/tokens-test`) asserting that a token file with a `borderWidth`
section round-trips through `parseTokens()` into `TokenSet.borderWidth`
and through `generateTheme()` into both the emitted interface and the
`theme` object literal.

```
$ npm test
...
Wrote executable: dist/tokens-test
PASS: borderWidth flows through parseTokens() -> generateTheme()
```

Confirmed the test is a genuine regression guard by running it against
the pre-fix `tokens.ts`/`generator.ts` (via `git show HEAD~1:...`):

```
$ ./dist/tokens-test
TypeError: Cannot convert undefined or null to object
    at <anonymous>
exit: 1
```

Note: while reproducing this, found a separate, unrelated pre-existing
formatting bug in `generator.ts::colorProp()` — the trailing comma is
appended after the inline `// #HEXVALUE` comment, so it lands inside the
comment and is dropped, making the raw CLI-generated `theme.ts` for the
color sections unparseable. That's independent of `borderWidth` (present
in both light/dark palettes with or without this change) and out of scope
here; flagging it in case it's worth its own follow-up issue.

## Unverified / out of scope

- Did not touch `docs/src/ui/theming.md` — it already documents
  `borderWidth` correctly on `origin/main` (verified byte-identical via
  `git show origin/main:docs/src/ui/theming.md`).
- Did not fix the unrelated `colorProp()` comment/comma formatting bug
  noted above.
- No cargo build was run (not needed — this only touches TypeScript under
  `packages/perry-styling/`); verification used the existing `perry`
  release binary to compile and run the package's own CLI and new test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for parsing and generating `borderWidth` design tokens in themes.
  - Generated themes now include border width values and type definitions.
  - Generation results now display the number of border width tokens processed.

- **Tests**
  - Added coverage validating border width token parsing and theme generation.
  - Added a test command for running styling package tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->