### PR TITLE
fix(scripts): gen_parity_gaps reads split api-manifest entries

### DIFF
--- a/docs/runtime-parity-gaps.md
+++ b/docs/runtime-parity-gaps.md
@@ -1,13 +1,17 @@
 # Perry Runtime Parity Gap List
 
 > **Generated** by `scripts/gen_parity_gaps.py` from `docs/runtime-parity.md`
-> (the API inventory) reconciled against Perry's coverage sources. Do not
-> edit by hand — re-run the script to refresh.
+> (the API inventory) reconciled against Perry's coverage sources. Normally
+> do not edit by hand — re-run the script to refresh. **As of 2026-07-17 the
+> script's worst bug (a stale single-file manifest path) is fixed** — see the
+> audit note under Summary — but a dry run still undercounts by a handful of
+> rows relative to this file, so it still carries a small set of
+> hand-corrections instead of being freshly emitted.
 
 This is a structured gap analysis comparing the public Node.js API surface
 against the APIs Perry can dispatch. Coverage is derived from four sources:
-the unimplemented-API gate manifest (`crates/perry-api-manifest/src/entries.rs`,
-`method`/`property` rows), compound `Expr::*` HIR variants
+the unimplemented-API gate manifest (`crates/perry-api-manifest/src/entries.rs`
+and `entries/*.rs`, `method`/`property` rows), compound `Expr::*` HIR variants
 (`crates/perry-hir/src/ir/`), `js_*` FFI exports across `perry-runtime` /
 `perry-stdlib` / `perry-ext-*`, and module-gated method-dispatch literals.
 
@@ -21,7 +25,40 @@ the unimplemented-API gate manifest (`crates/perry-api-manifest/src/entries.rs`,
 
 ## Summary
 
-Across 49 `node:*` modules: **2222 covered / 296 gap** of 2518 catalogued APIs.
+Across 49 `node:*` modules: **2238 covered / 280 gap** of 2518 catalogued APIs.
+
+> **Audit note (2026-07-16, updated 2026-07-17):** spot-checking ~10 "gap"
+> entries against the current source turned up 16 false positives (below)
+> that the generator missed. Two distinct root causes:
+>
+> 1. `crates/perry-api-manifest/src/entries.rs` was split into
+>    `entries/part_1.rs`..`part_4.rs` (2026-07-03) after this file's last
+>    regeneration (2026-06-15); `scripts/gen_parity_gaps.py`'s `MANIFEST`
+>    constant still pointed at the now-mostly-empty `entries.rs`, so a
+>    dry run showed 1750 covered / 768 gap (e.g. `node:os` swinging from 0
+>    gaps to 143) — most of the manifest was invisible to the script. **This
+>    is now fixed**: the script globs `entries.rs` + `entries/*.rs` and fails
+>    loudly if the parsed entry count looks implausibly low (guards against a
+>    future re-split doing this again silently).
+> 2. The remaining 13 of the 16 false positives are still invisible to a
+>    fresh run even with the manifest path fixed — a dry run with the fixed
+>    script lands at **2232 covered / 286 gap**, close to but not identical
+>    to the 2238/280 below. Root cause: those 13 rows (the four
+>    `new URLSearchParams(...)` overloads, `Buffer.allocUnsafeSlow`, the six
+>    `stats.*` numeric fields, `new Worker(filename)`, `new AsyncLocalStorage()`)
+>    are declared via the manifest's `class(...)`/`internal_method(...)`
+>    macros or dispatched through code paths outside the script's four
+>    recognized coverage sources (a dynamic-callee constructor path in
+>    `class_registry/construct.rs`, and packed-key-array object shapes like
+>    `fs`'s `STATS_KEYS_REGULAR`) — `MANIFEST_RE` only matches bare
+>    `method(`/`property(` calls, not `class(`/`internal_method(`/
+>    `internal_property(`/`internal_class(`. That's a separate, pre-existing
+>    matcher gap, not the file-split bug, and is out of scope for the
+>    manifest-path fix; the other 3 false positives (`params.entries()`/
+>    `.keys()`/`.values()` on `node:url`) *are* recovered by the path fix.
+>    The counts below stay hand-corrected for all 16 until the matcher gap
+>    has its own fix; the rest of the list has not been re-audited and may
+>    contain further stale entries.
 
 > Web / global APIs and Bun-only APIs are tracked separately in
 > `runtime-parity.md`; their coverage is curated, not recomputed here.
@@ -39,11 +76,11 @@ Across 49 `node:*` modules: **2222 covered / 296 gap** of 2518 catalogued APIs.
 | `node:inspector` | 10 | 9 | 19 |
 | `node:module` | 41 | 9 | 50 |
 | `node:timers` | 8 | 9 | 17 |
-| `node:url` | 40 | 9 | 49 |
-| `node:fs` | 174 | 8 | 182 |
+| `node:url` | 47 | 2 | 49 |
+| `node:fs` | 180 | 2 | 182 |
 | `node:readline/promises` | 0 | 7 | 7 |
 | `node:assert` | 21 | 6 | 27 |
-| `node:buffer` | 102 | 6 | 108 |
+| `node:buffer` | 103 | 5 | 108 |
 | `node:cluster` | 29 | 6 | 35 |
 | `node:events` | 35 | 6 | 41 |
 | `node:trace_events` | 0 | 6 | 6 |
@@ -54,8 +91,8 @@ Across 49 `node:*` modules: **2222 covered / 296 gap** of 2518 catalogued APIs.
 | `node:readline` | 27 | 2 | 29 |
 | `node:sqlite` | 50 | 2 | 52 |
 | `node:timers/promises` | 3 | 2 | 5 |
-| `node:worker_threads` | 62 | 2 | 64 |
-| `node:async_hooks` | 28 | 1 | 29 |
+| `node:worker_threads` | 63 | 1 | 64 |
+| `node:async_hooks` | 29 | 0 | 29 |
 | `node:console` | 22 | 1 | 23 |
 | `node:dgram` | 27 | 1 | 28 |
 | `node:fs/promises` | 60 | 1 | 61 |
@@ -77,7 +114,7 @@ Across 49 `node:*` modules: **2222 covered / 296 gap** of 2518 catalogued APIs.
 | `node:string_decoder` | 6 | 0 | 6 |
 | `node:vm` | 32 | 0 | 32 |
 | `node:wasi` | 6 | 0 | 6 |
-| **Total** | **2222** | **296** | **2518** |
+| **Total** | **2238** | **280** | **2518** |
 
 ## Per-module gaps
 
@@ -353,30 +390,32 @@ gap-size order. Modules omitted here have **zero** catalogued gaps.
 
 ### node:url
 
-**Covered: 40 · Gap: 9**
+**Covered: 47 · Gap: 2**
 
 - `url.toJSON()`
-- `new URLSearchParams()`
-- `new URLSearchParams(string)`
-- `new URLSearchParams(obj)`
-- `new URLSearchParams(iterable)`
-- `params.entries()`
-- `params.keys()`
-- `params.values()`
 - `params[Symbol.iterator]()`
+
+> `new URLSearchParams()` (all four init-shape overloads) and
+> `params.entries()`/`.keys()`/`.values()` are implemented
+> (`crates/perry-runtime/src/url/search_params.rs`: `js_url_search_params_new_any`/
+> `_new_empty`, dispatched from `object/class_registry/construct.rs`;
+> `js_url_search_params_entries_arr`/`_keys_arr`/`_values_arr`) — removed
+> from this list 2026-07-16. `params[Symbol.iterator]()` specifically
+> wasn't found wired to a distinct dispatch path in a quick check, so it's
+> left as an unverified gap.
 
 ### node:fs
 
-**Covered: 174 · Gap: 8**
+**Covered: 180 · Gap: 2**
 
 - `fs.realpath.native(path[, options], callback)`
 - `fs.realpathSync.native(path[, options])`
-- `stats.dev`
-- `stats.ino`
-- `stats.nlink`
-- `stats.rdev`
-- `stats.size`
-- `stats.blksize`
+
+> `stats.dev`/`.ino`/`.nlink`/`.rdev`/`.size`/`.blksize` are all populated
+> fields on the `Stats` object (`crates/perry-runtime/src/fs/stats.rs`
+> `STATS_KEYS_REGULAR`/`STATS_KEYS_BIGINT` include all six) — removed from
+> this list 2026-07-16. The `fs.realpath.native`/`realpathSync.native`
+> entries are unverified; left as-is.
 
 ### node:readline/promises
 
@@ -403,14 +442,19 @@ gap-size order. Modules omitted here have **zero** catalogued gaps.
 
 ### node:buffer
 
-**Covered: 102 · Gap: 6**
+**Covered: 103 · Gap: 5**
 
-- `Buffer.allocUnsafeSlow(size)`
 - `Buffer.poolSize`
 - `buf[index]`
 - `buf.parent`
 - `new buffer.Blob([sources[, options]])`
 - `new buffer.File(sources, fileName[, options])`
+
+> `Buffer.allocUnsafeSlow(size)` is implemented
+> (`crates/perry-runtime/src/object/native_module_dispatch/dispatch_a_c.rs`
+> `("buffer.Buffer", "allocUnsafeSlow")`, backed by
+> `crates/perry-runtime/src/buffer/validate.rs`) — removed from this list
+> 2026-07-16.
 
 ### node:cluster
 
@@ -502,16 +546,14 @@ gap-size order. Modules omitted here have **zero** catalogued gaps.
 
 ### node:worker_threads
 
-**Covered: 62 · Gap: 2**
+**Covered: 63 · Gap: 1**
 
-- `new Worker(filename[, options])`
 - `worker[Symbol.asyncDispose]()`
 
-### node:async_hooks
-
-**Covered: 28 · Gap: 1**
-
-- `new AsyncLocalStorage()`
+> `new Worker(filename[, options])` is implemented — dedicated
+> `Expr::WorkerNew` HIR variant (`crates/perry-hir/src/lower/expr_new.rs`),
+> `js_worker_threads_worker_new` runtime function — removed from this list
+> 2026-07-16.
 
 ### node:console
 

--- a/scripts/gen_parity_gaps.py
+++ b/scripts/gen_parity_gaps.py
@@ -6,7 +6,11 @@ over-reported gaps (e.g. claimed node:crypto had 124 missing APIs when the
 manifest already declares createCipheriv/createSign/timingSafeEqual/...).
 
 Coverage sources, in priority order:
-  1. Manifest entries  -- crates/perry-api-manifest/src/entries.rs
+  1. Manifest entries  -- crates/perry-api-manifest/src/entries.rs plus any
+     crates/perry-api-manifest/src/entries/*.rs split files (the entry data
+     was split across entries/part_{1..4}.rs on 2026-07-03 to keep files
+     under the 2000-line CI gate; entries.rs now just declares the `mod`s and
+     concatenates them -- see MANIFEST_FILES below):
         method("mod","member",..)  /  property("mod","member",..)
      A CI test asserts every NATIVE_MODULE_TABLE entry has a row here, so this
      is the authoritative set of compile-time-dispatched top-level methods.
@@ -32,7 +36,20 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 INVENTORY = ROOT / "docs" / "runtime-parity.md"
-MANIFEST = ROOT / "crates" / "perry-api-manifest" / "src" / "entries.rs"
+MANIFEST_DIR = ROOT / "crates" / "perry-api-manifest" / "src"
+# The manifest entry table lives in entries.rs and/or split files under
+# entries/ (split out 2026-07-03 to stay under the 2000-line CI gate; see
+# entries.rs's own `mod part_N;` declarations). Glob both shapes rather than
+# hardcoding a single path so a future re-split can't silently zero out most
+# of the manifest again -- a stale single-file path here once undercounted
+# coverage by ~480 entries and swung node:os from 0 gaps to 143.
+MANIFEST_FILES = sorted(MANIFEST_DIR.glob("entries*.rs")) + sorted(
+    MANIFEST_DIR.glob("entries/*.rs")
+)
+# Below this, something is almost certainly wrong with MANIFEST_FILES (a
+# missed split, a moved directory, ...) rather than a genuine drop in
+# manifest size -- fail loudly instead of silently emitting bogus gap counts.
+MIN_PLAUSIBLE_MANIFEST_ENTRIES = 1500
 IR_DIR = ROOT / "crates" / "perry-hir" / "src" / "ir"
 SRC_DIRS = [
     ROOT / "crates" / "perry-runtime" / "src",
@@ -120,9 +137,24 @@ def extract_member(sig: str) -> str | None:
 
 
 def parse_manifest():
+    if not MANIFEST_FILES:
+        sys.exit(
+            f"gen_parity_gaps: no manifest source files matched under {MANIFEST_DIR} "
+            "(expected entries.rs and/or entries/*.rs) -- has the manifest crate moved?"
+        )
     by_module: dict[str, set] = {}
-    for mod, member in MANIFEST_RE.findall(MANIFEST.read_text()):
-        by_module.setdefault(mod, set()).add(member)
+    total = 0
+    for path in MANIFEST_FILES:
+        for mod, member in MANIFEST_RE.findall(path.read_text()):
+            by_module.setdefault(mod, set()).add(member)
+            total += 1
+    if total < MIN_PLAUSIBLE_MANIFEST_ENTRIES:
+        sys.exit(
+            f"gen_parity_gaps: only parsed {total} manifest entries across "
+            f"{len(MANIFEST_FILES)} file(s) ({', '.join(str(p.relative_to(ROOT)) for p in MANIFEST_FILES)}); "
+            f"expected at least {MIN_PLAUSIBLE_MANIFEST_ENTRIES}. The manifest was likely split/moved again "
+            "and MANIFEST_FILES no longer covers it -- refusing to emit misleadingly-bad gap counts."
+        )
     return by_module
 
 
@@ -251,8 +283,8 @@ def emit_doc(rows) -> str:
     w("> edit by hand — re-run the script to refresh.\n")
     w("This is a structured gap analysis comparing the public Node.js API surface")
     w("against the APIs Perry can dispatch. Coverage is derived from four sources:")
-    w("the unimplemented-API gate manifest (`crates/perry-api-manifest/src/entries.rs`,")
-    w("`method`/`property` rows), compound `Expr::*` HIR variants")
+    w("the unimplemented-API gate manifest (`crates/perry-api-manifest/src/entries.rs`")
+    w("and `entries/*.rs`, `method`/`property` rows), compound `Expr::*` HIR variants")
     w("(`crates/perry-hir/src/ir/`), `js_*` FFI exports across `perry-runtime` /")
     w("`perry-stdlib` / `perry-ext-*`, and module-gated method-dispatch literals.\n")
     w(BEHAVIORAL_NOTE)

--- a/scripts/gen_parity_gaps.py
+++ b/scripts/gen_parity_gaps.py
@@ -89,7 +89,7 @@ def parse_inventory():
     modules: dict[str, list] = {}
     cur = None
     in_inventory = False
-    for line in INVENTORY.read_text().splitlines():
+    for line in INVENTORY.read_text(encoding="utf-8").splitlines():
         m = SECTION_RE.match(line)
         if m:
             title = m.group(1)
@@ -145,7 +145,7 @@ def parse_manifest():
     by_module: dict[str, set] = {}
     total = 0
     for path in MANIFEST_FILES:
-        for mod, member in MANIFEST_RE.findall(path.read_text()):
+        for mod, member in MANIFEST_RE.findall(path.read_text(encoding="utf-8")):
             by_module.setdefault(mod, set()).add(member)
             total += 1
     if total < MIN_PLAUSIBLE_MANIFEST_ENTRIES:
@@ -159,7 +159,7 @@ def parse_manifest():
 
 
 def parse_expr_variants() -> set:
-    txt = "\n".join(f.read_text(errors="ignore") for f in IR_DIR.rglob("*.rs"))
+    txt = "\n".join(f.read_text(encoding="utf-8", errors="ignore") for f in IR_DIR.rglob("*.rs"))
     # crude: collect PascalCase enum variant idents inside the Expr enum
     return set(re.findall(r"\b([A-Z][A-Za-z0-9]+)\s*[\({,]", txt))
 
@@ -173,7 +173,7 @@ def scan_ffi_and_dispatch():
         if not d.exists():
             continue
         for f in d.rglob("*.rs"):
-            t = f.read_text(errors="ignore")
+            t = f.read_text(encoding="utf-8", errors="ignore")
             files[str(f)] = t
             for fn in re.findall(r"\bfn (js_[a-z0-9_]+)", t):
                 ffi.add(fn)


### PR DESCRIPTION
## Root cause

`scripts/gen_parity_gaps.py:35` hardcoded the manifest path to a single
file:

```python
MANIFEST = ROOT / "crates" / "perry-api-manifest" / "src" / "entries.rs"
```

`crates/perry-api-manifest/src/entries.rs` was split into
`entries/part_1.rs`..`part_4.rs` on 2026-07-03 (5212 lines total, to stay
under the 2000-line CI gate). `entries.rs` (`crates/perry-api-manifest/src/entries.rs:459-467`)
now just declares `mod part_1;`..`mod part_4;` and concatenates them into
`API_MANIFEST` at compile time — the actual `method(...)`/`property(...)`
rows all moved into the split files. The script never picked up the split,
so `parse_manifest()` (`scripts/gen_parity_gaps.py:122-126`, old) parsed
`entries.rs` alone and found ~0 manifest rows, making almost every module
look unimplemented.

Before this fix, a dry run landed at **1753 covered / 765 gap** (vs. the
true ballpark of ~2238/280) — e.g. `node:os` swung from 0 gaps to 143.

## Fix

- `scripts/gen_parity_gaps.py`: replaced the single `MANIFEST` path with
  `MANIFEST_FILES = glob("entries*.rs") + glob("entries/*.rs")`, and
  `parse_manifest()` now reads every matched file. Added a loud failure if
  zero manifest files are found, and a second loud failure if the total
  parsed entry count is implausibly low (`< 1500`), so a future re-split
  can't silently zero out most of the manifest again — the script exits
  with a clear message instead of quietly emitting bogus, worse-than-useless
  gap counts.
- `docs/runtime-parity-gaps.md`: landed the 2026-07-16 hand-audited counts
  (2238 covered / 280 gap) that a prior audit session had already worked
  out but left uncommitted, and rewrote the banner + audit note to reflect
  the fixed script's actual dry-run output rather than the pre-fix
  catastrophic numbers.

## Dry-run before / after

| State | Covered | Gap | node:os gap |
|---|---:|---:|---:|
| Broken (single-file `entries.rs` path) | 1753 | 765 | 143 |
| Fixed (globs `entries.rs` + `entries/*.rs`) | 2232 | 286 | 0 |
| Hand-audited doc (2026-07-16) | 2238 | 280 | 0 |

## Spot-check of the 5 named items

Checked with `python3 scripts/gen_parity_gaps.py --module <mod>` after the
fix:

- `new AsyncLocalStorage()` (`node:async_hooks`) — **still listed as a gap**
- `new URLSearchParams(...)` overloads (`node:url`) — **still listed as a
  gap**; `params.entries()`/`.keys()`/`.values()` on the same module *are*
  now recovered as covered
- `Buffer.allocUnsafeSlow` (`node:buffer`) — **still listed as a gap**
- `stats.dev`/`.ino`/`.nlink`/`.rdev`/`.size`/`.blksize` (`node:fs`) —
  **still listed as a gap**
- `new Worker(filename)` (`node:worker_threads`) — **still listed as a gap**

So per the task's own fallback criterion, I did **not** run `--emit` /
regenerate the doc from scratch — the fixed script's manifest data still
wrongly lists 13 of the 16 hand-confirmed 2026-07-16 false positives as
missing, so a fresh `--emit` today would still be worse than the existing
hand-corrected file (2232/286 vs. 2238/280) and would silently drop the
hand-corrections. I only fixed the manifest-file-discovery bug, hand-landed
the already-audited doc content (previously sitting uncommitted in another
session's working tree), and rewrote the banner/audit note to describe the
current, more accurate state.

## Why those 13 rows are still invisible (separate, pre-existing bug — not fixed here)

All 13 are declared via manifest macros `MANIFEST_RE` never matched, even
with the file-glob fix:

```python
MANIFEST_RE = re.compile(r'\b(?:method|property)\(\s*"([^"]+)"\s*,\s*"([^"]+)"')
```

- `new AsyncLocalStorage()`, `new URLSearchParams()`, `new Worker(...)` are
  declared via `class("async_hooks", "AsyncLocalStorage")` /
  `class("url", "URLSearchParams")` / `class("worker_threads", "Worker")` —
  `class(` is never matched by `MANIFEST_RE` (only `method(`/`property(`
  are).
- `Buffer.allocUnsafeSlow` is declared via
  `internal_method("buffer", "allocUnsafeSlow", false, None)`
  (`crates/perry-api-manifest/src/entries/part_4.rs:111`) — the `\b`
  word-boundary in `MANIFEST_RE` doesn't fire between `_` and `method`, so
  `internal_method(`/`internal_property(`/`internal_class(` calls are
  invisible to the regex too.
- `stats.dev`/`.ino`/etc. aren't manifest rows at all — they're populated
  via a packed key array (`STATS_KEYS_REGULAR` in
  `crates/perry-runtime/src/fs/stats.rs`), a fifth coverage shape the
  script's four recognized sources don't model.

Fixing `MANIFEST_RE`/adding a fifth coverage source is a separate, larger
change (would need care not to swing other modules the wrong way) and is
out of scope for this manifest-path fix. Left as a documented gap in the
updated audit note for a follow-up.

## Test plan

- [x] `python3 scripts/gen_parity_gaps.py` (dry run, no `--emit`) —
      2232 covered / 286 gap, monotonically better than the broken
      1753/765 baseline across every module (no regressions)
- [x] Confirmed the fail-loud guards trip correctly (simulated zero
      matched files, and simulated only-`entries.rs`-matched with 0
      entries)
- [x] Did not run `--emit`; `docs/runtime-parity-gaps.md`'s table/summary
      numbers are the hand-audited 2238/280, only the banner prose changed
- [x] No Rust files touched, so no `cargo fmt`/build needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refreshed the Node.js runtime parity audit with updated coverage and gap totals.
  * Corrected multiple module gap listings (including URL, filesystem, buffer, worker threads, and async hooks) and retained/updated audit notes on verification status and potential staleness.

* **Bug Fixes**
  * Improved parity report generation to reliably include all split manifest sources.
  * Added stronger validation to prevent incomplete manifest input from producing misleading results.
  * Adjusted text parsing/reading to use consistent encoding during regeneration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->