### PR TITLE
fix(android): implement notification bridge methods in template app

### DIFF
--- a/crates/perry-ui-android/src/system.rs
+++ b/crates/perry-ui-android/src/system.rs
@@ -564,11 +564,15 @@ pub fn notification_on_tap(callback: f64) {
     NOTIFICATION_TAP_KEY.store(key, std::sync::atomic::Ordering::Relaxed);
 }
 
-/// JNI entry point — fired from `PerryNotificationReceiver.onReceive` when
-/// the user taps a notification. Looks up the registered tap callback and
-/// invokes it with `(id, undefined)`. The `action` parameter (from the TS
-/// surface) is always `undefined` for #97 because action-button registration
-/// isn't wired yet — same shape as the Apple side.
+/// JNI entry point — fired via `PerryBridge.handleNotificationTapIntent`
+/// when the user taps a notification (the tap PendingIntent launches
+/// `PerryActivity` directly: apps targeting API 31+ may not start an
+/// activity from a receiver reached through a notification tap, so the
+/// receiver only handles scheduled fires). Looks up the registered tap
+/// callback and invokes it with `(id, undefined)`. The `action` parameter
+/// (from the TS surface) is always `undefined` for #97 because
+/// action-button registration isn't wired yet — same shape as the Apple
+/// side.
 #[no_mangle]
 pub extern "C" fn Java_com_perry_app_PerryBridge_nativeNotificationTap(
     mut env: jni::JNIEnv,
@@ -595,9 +599,13 @@ pub extern "C" fn Java_com_perry_app_PerryBridge_nativeNotificationTap(
 
 /// Register the JS closure that fires when FCM hands us a device token
 /// (#95). Stores the closure in the global callback table, saves the key in
-/// `NOTIFICATION_REMOTE_TOKEN_KEY` for the JNI side to look up, and asks
-/// `PerryBridge.registerForRemoteNotifications` to kick off the initial
-/// `FirebaseMessaging.getInstance().token` fetch.
+/// `NOTIFICATION_REMOTE_TOKEN_KEY` for the JNI side to look up, and calls
+/// `PerryBridge.registerForRemoteNotifications`. The scaffolded template
+/// ships without Firebase (no `google-services.json`), so that method logs
+/// a warning describing the required app-side Firebase Messaging setup and
+/// returns; once the app adds Firebase and forwards `onNewToken` to
+/// `PerryBridge.nativeNotificationToken`, the closure registered here fires
+/// with the token.
 pub fn notification_register_remote(callback: f64) {
     let key = crate::callback::register(callback);
     NOTIFICATION_REMOTE_TOKEN_KEY.store(key, std::sync::atomic::Ordering::Relaxed);

--- a/crates/perry-ui-android/template/app/src/main/AndroidManifest.xml
+++ b/crates/perry-ui-android/template/app/src/main/AndroidManifest.xml
@@ -27,6 +27,13 @@
     <!-- perry/system hapticPlay — Vibrator / VibrationEffect. Normal
          permission (granted at install, no runtime prompt). -->
     <uses-permission android:name="android.permission.VIBRATE" />
+    <!-- perry/system notifications (#96/#97): Android 13+ requires an
+         explicit runtime grant before an app may post notifications.
+         PerryActivity requests every ungranted dangerous permission
+         declared here at launch, so this line is what surfaces the
+         prompt; if the user denies it, notificationSend / schedules log
+         a warning and drop the banner instead of crashing. -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
@@ -58,5 +65,14 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- perry/system scheduled notifications (#96): AlarmManager fires
+             into this receiver, which posts the notification (waking the
+             process if it died in the meantime). Not exported — the only
+             sender is our own PendingIntent. Fully qualified for the same
+             reason as PerryActivity above (#1528). -->
+        <receiver
+            android:name="com.perry.app.PerryNotificationReceiver"
+            android:exported="false" />
     </application>
 </manifest>

--- a/crates/perry-ui-android/template/app/src/main/java/com/perry/app/PerryActivity.kt
+++ b/crates/perry-ui-android/template/app/src/main/java/com/perry/app/PerryActivity.kt
@@ -105,6 +105,12 @@ class PerryActivity : Activity() {
         // URL until the JS module's `appOnOpenUrl` registers its handler.
         intent?.data?.toString()?.let { PerryBridge.onDeepLinkColdStart(it) }
 
+        // Notification tap (#97): a banner tap launches us with the
+        // notification id as an Intent extra. On a cold start the native
+        // library isn't loaded yet, so the bridge logs and skips (no JS
+        // callback can be registered before the app has run).
+        PerryBridge.handleNotificationTapIntent(intent)
+
         // Request any dangerous runtime permissions declared in the manifest
         // before starting native code, so they're available when needed.
         val needed = getDangerousPermissionsToRequest()
@@ -172,6 +178,10 @@ class PerryActivity : Activity() {
         super.onNewIntent(intent)
         setIntent(intent)
         intent.data?.toString()?.let { PerryBridge.onDeepLinkForeground(it) }
+        // Notification tap while the app is alive (#97): the tap
+        // PendingIntent uses FLAG_ACTIVITY_SINGLE_TOP, so it lands here
+        // rather than in a fresh onCreate.
+        PerryBridge.handleNotificationTapIntent(intent)
     }
 
     @Deprecated("Required to wire pre-existing file dialog and the issue #552 image picker")

--- a/crates/perry-ui-android/template/app/src/main/java/com/perry/app/PerryBridge.kt
+++ b/crates/perry-ui-android/template/app/src/main/java/com/perry/app/PerryBridge.kt
@@ -2323,4 +2323,285 @@ object PerryBridge {
 
     @JvmStatic
     external fun nativeMenuItemSelected(menuHandle: Long, index: Int)
+
+    // =====================================================================
+    // Notifications (issues #95/#96/#97) — local + scheduled notifications.
+    //
+    // These static methods are invoked over JNI from
+    // perry-ui-android/src/system.rs; the Kotlin signatures must keep
+    // matching the JNI descriptors used there exactly:
+    //   sendNotification                (Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)V
+    //   cancelNotification              (Landroid/app/Activity;Ljava/lang/String;)V
+    //   registerForRemoteNotifications  (Landroid/app/Activity;)V
+    //   scheduleInterval                (Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;DZ)V
+    //   scheduleCalendar                (Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;D)V
+    // =====================================================================
+
+    private const val NOTIFICATION_TAG = "PerryNotification"
+
+    /** Channel every Perry notification posts to (required since API 26). */
+    private const val NOTIFICATION_CHANNEL_ID = "perry_default"
+
+    /**
+     * Identifier used by `notificationSend` (the TS surface passes no id for
+     * plain sends). Matches the fixed "perry_notification" request identifier
+     * the Apple implementations use, so
+     * `notificationCancel("perry_notification")` behaves the same on both
+     * platforms.
+     */
+    private const val DEFAULT_NOTIFICATION_ID = "perry_notification"
+
+    private fun ensureNotificationChannel(context: Context) {
+        if (android.os.Build.VERSION.SDK_INT < 26) return
+        val mgr = context.getSystemService(Context.NOTIFICATION_SERVICE)
+            as android.app.NotificationManager
+        if (mgr.getNotificationChannel(NOTIFICATION_CHANNEL_ID) == null) {
+            mgr.createNotificationChannel(
+                android.app.NotificationChannel(
+                    NOTIFICATION_CHANNEL_ID,
+                    "Notifications",
+                    android.app.NotificationManager.IMPORTANCE_DEFAULT
+                )
+            )
+        }
+    }
+
+    /**
+     * The template ships no launcher icon of its own (the manifest has no
+     * `android:icon`), so fall back to a system drawable when
+     * `applicationInfo.icon` is unset — the system rejects notifications
+     * without a valid small icon.
+     */
+    private fun notificationSmallIcon(context: Context): Int {
+        val appIcon = context.applicationInfo.icon
+        return if (appIcon != 0) appIcon else android.R.drawable.ic_dialog_info
+    }
+
+    /** True when we may post notifications (POST_NOTIFICATIONS on API 33+). */
+    private fun canPostNotifications(context: Context): Boolean {
+        if (android.os.Build.VERSION.SDK_INT < 33) return true
+        return ContextCompat.checkSelfPermission(
+            context, Manifest.permission.POST_NOTIFICATIONS
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    /**
+     * Build + post one notification. Shared by `sendNotification` (immediate)
+     * and `PerryNotificationReceiver` (AlarmManager-scheduled fire, so this
+     * must work from a receiver context with `PerryBridge.init` never run).
+     * `id` becomes the notification *tag*, which is what lets
+     * `cancelNotification` key the shade entry by the same string id.
+     */
+    fun postNotification(context: Context, id: String, title: String, body: String) {
+        if (!canPostNotifications(context)) {
+            Log.w(
+                NOTIFICATION_TAG,
+                "notification '$id' dropped: POST_NOTIFICATIONS not granted (Android 13+). " +
+                    "PerryActivity requests it at launch; the user denied it."
+            )
+            return
+        }
+        ensureNotificationChannel(context)
+
+        // Tapping the banner must launch the Activity directly — apps
+        // targeting API 31+ may not start an activity from a
+        // receiver/service reached via a notification tap ("trampoline"
+        // block), so the tap PendingIntent points straight at
+        // PerryActivity, which forwards the id extra to
+        // nativeNotificationTap (issue #97). No data URI here: PerryActivity
+        // forwards `intent.data` to the deep-link callbacks (#583), and a
+        // synthetic URI would fire those spuriously. Distinct ids get
+        // distinct PendingIntents via the request code instead (extras
+        // don't participate in PendingIntent matching).
+        val tapIntent = Intent(context, PerryActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            putExtra(PerryNotificationReceiver.EXTRA_ID, id)
+        }
+        val tapPending = android.app.PendingIntent.getActivity(
+            context,
+            id.hashCode(),
+            tapIntent,
+            android.app.PendingIntent.FLAG_UPDATE_CURRENT or
+                android.app.PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification =
+            androidx.core.app.NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID)
+                .setSmallIcon(notificationSmallIcon(context))
+                .setContentTitle(title)
+                .setContentText(body)
+                .setStyle(androidx.core.app.NotificationCompat.BigTextStyle().bigText(body))
+                .setAutoCancel(true)
+                .setContentIntent(tapPending)
+                .build()
+        try {
+            androidx.core.app.NotificationManagerCompat.from(context).notify(id, 0, notification)
+        } catch (e: SecurityException) {
+            // Permission revoked between the check above and the call.
+            Log.w(NOTIFICATION_TAG, "notify('$id') failed: ${e.message}")
+        }
+    }
+
+    /** JNI: `notificationSend(title, body)` — post immediately. */
+    @JvmStatic
+    fun sendNotification(activity: Activity, title: String, body: String) {
+        postNotification(activity, DEFAULT_NOTIFICATION_ID, title, body)
+    }
+
+    /**
+     * Build the AlarmManager PendingIntent for a scheduled notification id.
+     * The `perry-notification://fire/<id>` data URI is what makes each id
+     * its own PendingIntent (extras are ignored by `Intent.filterEquals`),
+     * so schedule/cancel pairs resolve to the same alarm.
+     */
+    private fun scheduledFirePendingIntent(
+        context: Context,
+        id: String,
+        title: String?,
+        body: String?,
+        flags: Int,
+    ): android.app.PendingIntent? {
+        val intent = Intent(context, PerryNotificationReceiver::class.java).apply {
+            action = PerryNotificationReceiver.ACTION_FIRE
+            data = Uri.parse("perry-notification://fire/" + Uri.encode(id))
+            putExtra(PerryNotificationReceiver.EXTRA_ID, id)
+            if (title != null) putExtra(PerryNotificationReceiver.EXTRA_TITLE, title)
+            if (body != null) putExtra(PerryNotificationReceiver.EXTRA_BODY, body)
+        }
+        return android.app.PendingIntent.getBroadcast(
+            context, 0, intent, flags or android.app.PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+
+    /**
+     * JNI: schedule a fire-after-N-seconds notification (issue #96).
+     * Inexact timing: exact alarms need the SCHEDULE_EXACT_ALARM special
+     * permission on API 31+, which a notification banner doesn't justify.
+     * Repeating intervals under a minute are clamped to 60s by the OS.
+     */
+    @JvmStatic
+    fun scheduleInterval(
+        activity: Activity,
+        id: String,
+        title: String,
+        body: String,
+        seconds: Double,
+        repeats: Boolean,
+    ) {
+        val alarm = activity.getSystemService(Context.ALARM_SERVICE) as android.app.AlarmManager
+        val delayMs = (seconds * 1000.0).toLong().coerceAtLeast(0L)
+        val triggerAt = System.currentTimeMillis() + delayMs
+        val pending = scheduledFirePendingIntent(
+            activity, id, title, body, android.app.PendingIntent.FLAG_UPDATE_CURRENT
+        ) ?: return
+        if (repeats) {
+            alarm.setRepeating(android.app.AlarmManager.RTC_WAKEUP, triggerAt, delayMs, pending)
+        } else {
+            alarm.setAndAllowWhileIdle(android.app.AlarmManager.RTC_WAKEUP, triggerAt, pending)
+        }
+    }
+
+    /** JNI: schedule a fire-at-wallclock-ms notification (issue #96). */
+    @JvmStatic
+    fun scheduleCalendar(
+        activity: Activity,
+        id: String,
+        title: String,
+        body: String,
+        timestampMs: Double,
+    ) {
+        val alarm = activity.getSystemService(Context.ALARM_SERVICE) as android.app.AlarmManager
+        val pending = scheduledFirePendingIntent(
+            activity, id, title, body, android.app.PendingIntent.FLAG_UPDATE_CURRENT
+        ) ?: return
+        alarm.setAndAllowWhileIdle(
+            android.app.AlarmManager.RTC_WAKEUP, timestampMs.toLong(), pending
+        )
+    }
+
+    /** JNI: cancel a scheduled and/or already-delivered notification by id. */
+    @JvmStatic
+    fun cancelNotification(activity: Activity, id: String) {
+        // Cancel the pending AlarmManager schedule, if one exists.
+        val alarm = activity.getSystemService(Context.ALARM_SERVICE) as android.app.AlarmManager
+        val pending = scheduledFirePendingIntent(
+            activity, id, null, null, android.app.PendingIntent.FLAG_NO_CREATE
+        )
+        if (pending != null) {
+            alarm.cancel(pending)
+            pending.cancel()
+        }
+        // Remove the delivered notification (tag = id) from the shade.
+        androidx.core.app.NotificationManagerCompat.from(activity).cancel(id, 0)
+    }
+
+    /**
+     * JNI: `notificationRegisterRemote` (issue #95). Real FCM registration
+     * needs app-level Firebase wiring the scaffold intentionally does not
+     * ship: a `google-services.json`, the `com.google.gms.google-services`
+     * Gradle plugin, the `com.google.firebase:firebase-messaging`
+     * dependency, and a `FirebaseMessagingService` subclass. Until the app
+     * adds those, this logs exactly what's missing instead of failing the
+     * JNI lookup silently.
+     *
+     * When you do add Firebase to the generated project, forward the token
+     * and payloads to the native side from your service:
+     *   onNewToken(token)      → PerryBridge.nativeNotificationToken(token)
+     *   onMessageReceived(msg) → PerryBridge.nativeNotificationReceive(json)
+     *                            and/or nativeNotificationBackgroundReceive(json)
+     */
+    @JvmStatic
+    fun registerForRemoteNotifications(activity: Activity) {
+        Log.w(
+            NOTIFICATION_TAG,
+            "registerForRemoteNotifications: this app has no Firebase Messaging. Add " +
+                "google-services.json, the google-services Gradle plugin and " +
+                "com.google.firebase:firebase-messaging, then forward onNewToken / " +
+                "onMessageReceived to PerryBridge.nativeNotificationToken / " +
+                "nativeNotificationReceive. See https://github.com/PerryTS/perry/issues/95"
+        )
+    }
+
+    /**
+     * Forward a notification-tap Intent (built by `postNotification`) to the
+     * native tap callback. Called from PerryActivity.onCreate/onNewIntent.
+     * Returns true when a tap id was present and dispatched.
+     */
+    @JvmStatic
+    fun handleNotificationTapIntent(intent: Intent?): Boolean {
+        val id = intent?.getStringExtra(PerryNotificationReceiver.EXTRA_ID) ?: return false
+        return try {
+            nativeNotificationTap(id)
+            true
+        } catch (_: UnsatisfiedLinkError) {
+            // Cold start: the tap arrived before the native library loaded,
+            // so no JS callback can be registered yet. Same v1 limitation as
+            // FCM cold delivery (#98).
+            Log.w(
+                NOTIFICATION_TAG,
+                "notification tap for '$id' before native lib load; onTap callback skipped"
+            )
+            false
+        }
+    }
+
+    // Notification native callbacks (issues #95/#97/#98) — exported by
+    // perry-ui-android/src/system.rs as
+    // Java_com_perry_app_PerryBridge_nativeNotification{Tap,Token,Receive,BackgroundReceive}.
+
+    /** User tapped a delivered notification; `id` is the notification id. */
+    @JvmStatic
+    external fun nativeNotificationTap(id: String)
+
+    /** FCM registration token (initial fetch + rotations). */
+    @JvmStatic
+    external fun nativeNotificationToken(token: String)
+
+    /** Foreground push payload as a JSON string. */
+    @JvmStatic
+    external fun nativeNotificationReceive(payloadJson: String)
+
+    /** Background push payload as a JSON string. */
+    @JvmStatic
+    external fun nativeNotificationBackgroundReceive(payloadJson: String)
 }

--- a/crates/perry-ui-android/template/app/src/main/java/com/perry/app/PerryNotificationReceiver.kt
+++ b/crates/perry-ui-android/template/app/src/main/java/com/perry/app/PerryNotificationReceiver.kt
@@ -1,0 +1,38 @@
+package com.perry.app
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+
+/**
+ * BroadcastReceiver behind Perry's scheduled local notifications (#96).
+ *
+ * `PerryBridge.scheduleInterval` / `scheduleCalendar` arm an AlarmManager
+ * alarm whose PendingIntent targets this receiver with ACTION_FIRE; when the
+ * alarm comes due (the process may have been dead — manifest receivers wake
+ * it), the notification is built and posted here.
+ *
+ * Taps are NOT routed through this receiver: apps targeting API 31+ may not
+ * start an activity from a receiver reached via a notification tap (the
+ * "notification trampoline" block), so the tap PendingIntent goes directly
+ * to PerryActivity, which calls `PerryBridge.handleNotificationTapIntent`.
+ *
+ * Registered in AndroidManifest.xml with `exported="false"` — the fire
+ * intent is an app-internal PendingIntent.
+ */
+class PerryNotificationReceiver : BroadcastReceiver() {
+    companion object {
+        const val ACTION_FIRE = "com.perry.app.NOTIFICATION_FIRE"
+        const val EXTRA_ID = "perry_notification_id"
+        const val EXTRA_TITLE = "perry_notification_title"
+        const val EXTRA_BODY = "perry_notification_body"
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ACTION_FIRE) return
+        val id = intent.getStringExtra(EXTRA_ID) ?: return
+        val title = intent.getStringExtra(EXTRA_TITLE) ?: ""
+        val body = intent.getStringExtra(EXTRA_BODY) ?: ""
+        PerryBridge.postNotification(context, id, title, body)
+    }
+}

--- a/docs/src/system/notifications.md
+++ b/docs/src/system/notifications.md
@@ -41,9 +41,19 @@ expects. `notificationOnReceive(cb)` runs whenever a remote payload arrives
 while the app is foregrounded; the payload is the APNs `aps` userInfo
 dictionary (or equivalent platform shape) converted to a plain object.
 
-Requires the relevant platform capability (APNs entitlement on iOS/macOS,
-Firebase Messaging on Android — wired via JNI through
-`PerryFirebaseMessagingService`, see [#98](https://github.com/PerryTS/perry/issues/98)).
+Requires the relevant platform capability. On iOS/macOS that's the APNs
+entitlement (below). On Android the scaffolded app ships **without**
+Firebase — there is no `google-services.json` — so
+`notificationRegisterRemote` logs a warning describing the setup it needs
+and returns without doing anything. To enable it, add Firebase Messaging to
+the generated Android project (the `com.google.gms.google-services` Gradle
+plugin, the `com.google.firebase:firebase-messaging` dependency, and your
+`google-services.json`), then forward your `FirebaseMessagingService`'s
+`onNewToken` / `onMessageReceived` to `PerryBridge.nativeNotificationToken`
+/ `nativeNotificationReceive` (and/or
+`nativeNotificationBackgroundReceive`) — the native side of those callbacks
+is already wired ([#95](https://github.com/PerryTS/perry/issues/95),
+[#98](https://github.com/PerryTS/perry/issues/98)).
 No-op on platforms without a push pipeline (tvOS, visionOS, watchOS, GTK4,
 Windows, Web).
 
@@ -66,19 +76,48 @@ Push Notifications capability on the App ID when minting the development
 provisioning profile. For App Store / Ad Hoc distribution set
 `push_environment = "production"`.
 
+## Local notifications on Android
+
+Local and scheduled notifications work out of the box on a freshly
+scaffolded Android app:
+
+- `notificationSend(title, body)` posts immediately to the `perry_default`
+  notification channel (created on demand, API 26+). Like the Apple
+  implementations it uses the fixed id `"perry_notification"`, so
+  `notificationCancel("perry_notification")` removes it.
+- `notificationSchedule(...)` interval/calendar triggers arm an
+  `AlarmManager` alarm that fires a broadcast receiver, so the banner is
+  delivered even if the process has since exited. Timing is *inexact*
+  (exact alarms need the `SCHEDULE_EXACT_ALARM` special permission on
+  Android 12+), and repeating intervals under 60 seconds are clamped to 60
+  seconds by the OS. Location triggers are not wired
+  ([#96](https://github.com/PerryTS/perry/issues/96) follow-up).
+- `notificationCancel(id)` cancels the pending alarm *and* removes an
+  already-delivered banner with that id from the shade.
+- `notificationOnTap(cb)` fires while the app process is alive (the tap
+  intent routes through `PerryActivity`). A tap that cold-starts the
+  process is logged and skipped — no JS callback can be registered before
+  the app has run.
+- **Permission**: Android 13+ requires the `POST_NOTIFICATIONS` runtime
+  grant. The template declares it and `PerryActivity` requests it (with the
+  other dangerous permissions) at first launch; if the user denies it,
+  notification calls log a warning to logcat and drop the banner instead of
+  crashing.
+
 ## Platform Implementation
 
 | Platform | Backend |
 |----------|---------|
 | macOS | UNUserNotificationCenter |
 | iOS | UNUserNotificationCenter |
-| Android | NotificationManager |
+| Android | NotificationManager + AlarmManager (local/scheduled); FCM push requires app-side Firebase setup |
 | Windows | Toast notifications |
 | Linux | GNotification |
 | Web | Web Notification API |
 
-> **Permissions**: On macOS, iOS, and Web, the user may need to grant
-> notification permissions. On first use, the system will prompt automatically.
+> **Permissions**: On macOS, iOS, Android 13+, and Web, the user may need to
+> grant notification permissions. On first use (app launch on Android), the
+> system will prompt automatically.
 
 ## Next Steps
 

--- a/docs/src/system/overview.md
+++ b/docs/src/system/overview.md
@@ -24,9 +24,9 @@ links the file on every PR.
 | `keychainGet(key)` | Secure storage read | All |
 | `keychainDelete(key)` | Secure storage remove | All |
 | `notificationSend(title, body)` | Local notification | All |
-| `notificationCancel(id)` | Cancel a scheduled notification | Apple |
-| `notificationOnTap(cb)` | Handle banner taps | Apple |
-| `notificationRegisterRemote(cb)` / `notificationOnReceive(cb)` | Push (APNs) | iOS, macOS |
+| `notificationCancel(id)` | Cancel a scheduled notification | Apple, Android |
+| `notificationOnTap(cb)` | Handle banner taps | Apple, Android |
+| `notificationRegisterRemote(cb)` / `notificationOnReceive(cb)` | Push (APNs / FCM) | iOS, macOS; Android needs app-side Firebase setup — see [Notifications](notifications.md) |
 | `audioStart()` / `audioStop()` | Microphone capture | All |
 | `audioGetLevel()` / `audioGetPeak()` | RMS / peak amplitude (`0..1`) | All |
 | `audioGetWaveform(n)` | Recent waveform samples for visualization | All |


### PR DESCRIPTION
## Problem

2026-07-16 docs-audit finding: Perry's Android notification FFI calls Kotlin methods that don't exist in the scaffolded app. `perry-ui-android/src/system.rs` invokes `PerryBridge.sendNotification` / `cancelNotification` / `registerForRemoteNotifications` / `scheduleInterval` / `scheduleCalendar` via JNI, but the template's `PerryBridge.kt` contained zero matches for any of them, and no receiver/service classes existed. Every notification API (`notificationSend`, `notificationCancel`, `notificationSchedule`, `notificationOnTap`, `notificationRegisterRemote`) was a silent no-op on a freshly scaffolded Android app — the JNI static-method lookup fails and the `Err` is swallowed by `let _ =`.

## Fix

Template-side implementation (no Rust behavior change; the two `system.rs` edits are doc-comment corrections only):

- **`PerryBridge.kt`** — implements all five bridge methods with Kotlin signatures matching the Rust JNI descriptors byte-for-byte (table below):
  - `sendNotification`: `perry_default` `NotificationChannel` created on demand (API 26+), `NotificationCompat.Builder` with BigTextStyle, small-icon fallback to a system drawable (the template ships no launcher icon — `applicationInfo.icon` is 0), auto-cancel, tap content-intent. Uses the fixed id `"perry_notification"` — same identifier the iOS/macOS implementations use for plain sends, so `notificationCancel("perry_notification")` is cross-platform.
  - `scheduleInterval` / `scheduleCalendar` (#96): `AlarmManager` (`setAndAllowWhileIdle`, `setRepeating` for repeats) firing into the new **`PerryNotificationReceiver`**, so scheduled banners deliver even if the process died. Id-keyed via a `perry-notification://fire/<id>` data URI so schedule/cancel resolve to the same `PendingIntent` (extras don't participate in `Intent.filterEquals`). Deliberately inexact: exact alarms require the `SCHEDULE_EXACT_ALARM` special permission on API 31+.
  - `cancelNotification`: cancels the pending alarm (`FLAG_NO_CREATE` lookup) *and* removes the delivered banner (notification tag = string id).
  - `registerForRemoteNotifications` (#95): honest no-op that logs exactly what app-side Firebase Messaging setup is required (google-services plugin + `firebase-messaging` + `google-services.json` + a `FirebaseMessagingService` forwarding to the now-declared `nativeNotificationToken` / `nativeNotificationReceive` externals). The template gains **no** Firebase dependency; the Rust side of all four callbacks was already exported and is now reachable from app-added services.
- **Tap dispatch (#97)**: the tap `PendingIntent` launches `PerryActivity` directly — Android 12+ blocks notification "trampolines" (activity starts from receivers) for targetSdk 31+ (template targets 35), so routing taps through the receiver would be silently dropped. `onCreate`/`onNewIntent` (tap intent uses `FLAG_ACTIVITY_SINGLE_TOP`) forward the id extra to `nativeNotificationTap`, guarded against cold-start `UnsatisfiedLinkError`. The tap intent carries no data URI because `PerryActivity` forwards `intent.data` to the deep-link callbacks (#583).
- **`AndroidManifest.xml`**: `POST_NOTIFICATIONS` `<uses-permission>` (Android 13+ runtime grant — `PerryActivity` already requests every ungranted dangerous manifest permission at launch, so the prompt comes for free) + the `PerryNotificationReceiver` registration (`exported="false"`). Denied grants degrade to a logcat warning, never a `SecurityException` crash.
- **Docs**: `docs/src/system/notifications.md` — new "Local notifications on Android" section (channel, permission flow, inexact-alarm + 60s-repeat-clamp caveats, cold-start tap limitation) and an honest rewrite of the Android push paragraph (previously claimed FCM was "wired via `PerryFirebaseMessagingService`", which does not exist); `docs/src/system/overview.md` — `notificationCancel`/`notificationOnTap` rows now `Apple, Android`; push row states Android needs app-side Firebase setup.

## JNI signature cross-check

Rust caller (`perry-ui-android/src/system.rs`) → Kotlin (`PerryBridge.kt`, all `@JvmStatic`):

| Rust call site | JNI descriptor used by Rust | Kotlin signature |
|---|---|---|
| `notification_send` | `sendNotification` `(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)V` | `fun sendNotification(activity: Activity, title: String, body: String)` |
| `notification_cancel` | `cancelNotification` `(Landroid/app/Activity;Ljava/lang/String;)V` | `fun cancelNotification(activity: Activity, id: String)` |
| `notification_register_remote` | `registerForRemoteNotifications` `(Landroid/app/Activity;)V` | `fun registerForRemoteNotifications(activity: Activity)` |
| `notification_schedule_interval` | `scheduleInterval` `(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;DZ)V` | `fun scheduleInterval(activity: Activity, id: String, title: String, body: String, seconds: Double, repeats: Boolean)` |
| `notification_schedule_calendar` | `scheduleCalendar` `(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;D)V` | `fun scheduleCalendar(activity: Activity, id: String, title: String, body: String, timestampMs: Double)` |

Kotlin `external fun` → Rust `#[no_mangle]` export (now declared so Kotlin/app code can call them):

| Kotlin declaration | Rust symbol (`system.rs`) |
|---|---|
| `external fun nativeNotificationTap(id: String)` | `Java_com_perry_app_PerryBridge_nativeNotificationTap` |
| `external fun nativeNotificationToken(token: String)` | `Java_com_perry_app_PerryBridge_nativeNotificationToken` |
| `external fun nativeNotificationReceive(payloadJson: String)` | `Java_com_perry_app_PerryBridge_nativeNotificationReceive` |
| `external fun nativeNotificationBackgroundReceive(payloadJson: String)` | `Java_com_perry_app_PerryBridge_nativeNotificationBackgroundReceive` |

## Verification

- `gradle :app:compileDebugKotlin` on a copy of the template (AGP 8.8.2 / Kotlin 2.0.21 / compileSdk 35, JDK 21): **BUILD SUCCESSFUL**, including `:app:processDebugManifest` (manifest edits valid).
- `javap -s` on the compiled `PerryBridge.class` confirms every descriptor above byte-for-byte (`public static final void sendNotification … (Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)V`, etc.), and the four `nativeNotification*` declarations compile to `public static final native … (Ljava/lang/String;)V` — i.e. the `Java_com_perry_app_PerryBridge_*` static-form symbols the Rust exports use.
- `cargo fmt --all -- --check`: clean (only doc comments changed in `.rs`).
- Not verified on-device: actual banner delivery / tap round-trip on an emulator (no APK built — that needs a compiled Perry `.so`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Android support for local and scheduled notifications, including notification channels, cancellation, repeating schedules, and calendar-based scheduling.
  * Added notification tap handling when the app is launched or already running.
  * Added Android 13+ notification permission support.
  * Added internal handling for scheduled notification delivery.

* **Documentation**
  * Updated notification API documentation with Android support details, scheduling behavior, permissions, and Firebase setup requirements.
  * Clarified that remote notifications require app-side Firebase configuration on Android.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->