### PR TITLE
fix(container): wire ContainerSpec security opts, ComposeSpec.name, down --remove-orphans

### DIFF
--- a/crates/perry-container-compose/src/backend.rs
+++ b/crates/perry-container-compose/src/backend.rs
@@ -125,6 +125,17 @@ pub trait ContainerBackend: Send + Sync {
         spec: &ContainerSpec,
         profile: &SecurityProfile,
     ) -> Result<ContainerHandle>;
+    /// Security-aware variant of [`create`](Self::create): same
+    /// contract as [`run_with_security`](Self::run_with_security)
+    /// (capability normalization + `security_args` splicing) but the
+    /// container is created without being started. Exists so the
+    /// public `create()` API can honor spec-level `seccomp` /
+    /// `no_new_privileges` instead of silently dropping them.
+    async fn create_with_security(
+        &self,
+        spec: &ContainerSpec,
+        profile: &SecurityProfile,
+    ) -> Result<ContainerHandle>;
     /// Wait for a container to exit and return its exit code.
     async fn wait(&self, id: &str) -> Result<i32>;
 }
@@ -245,9 +256,10 @@ mod tests {
         let proto = DockerProtocol;
         let spec = ContainerSpec {
             image: "alpine".into(),
-            // seccomp lives on SecurityProfile, not ContainerSpec, so
-            // run_with_security applies it via security_args. Test the
-            // security_args output directly:
+            // seccomp is spec-level since the run()/create() security
+            // fix, but it still reaches the CLI via security_args
+            // (spliced in by run_with_security/create_with_security),
+            // NOT via run_args. Test the security_args output directly:
             ..Default::default()
         };
         let _ = proto.run_args(&spec); // smoke — no panic on minimal spec
@@ -261,6 +273,176 @@ mod tests {
             "expected seccomp in security args; got {:?}",
             security_args
         );
+    }
+
+    #[test]
+    fn test_container_spec_json_parses_security_fields() {
+        // Pins the FFI boundary: the TS object literal passed to
+        // `run()`/`create()` arrives as JSON and is serde-parsed into
+        // `ContainerSpec`. Pre-fix, `seccomp` / `no_new_privileges`
+        // were not fields on the struct, so serde silently dropped
+        // them and the documented hardening never reached the runtime.
+        let spec: ContainerSpec = serde_json::from_str(
+            r#"{
+                "image": "alpine:3.19",
+                "read_only": true,
+                "user": "nobody",
+                "cap_drop": ["ALL"],
+                "seccomp": "default",
+                "no_new_privileges": true
+            }"#,
+        )
+        .expect("security fields must parse");
+        assert_eq!(spec.seccomp.as_deref(), Some("default"));
+        assert_eq!(spec.no_new_privileges, Some(true));
+        assert!(spec.has_security_opts());
+
+        let profile = spec.security_profile();
+        assert!(profile.read_only_root);
+        assert_eq!(profile.seccomp.as_deref(), Some("default"));
+        assert!(profile.no_new_privileges);
+    }
+
+    #[test]
+    fn test_container_spec_without_security_fields_uses_plain_path() {
+        // `read_only` / `cap_drop` / `user` are emitted directly by
+        // run_args/create_args, so a spec using only those must NOT
+        // trigger the security-aware path (routing invariant for
+        // `js_container_run` / `js_container_create`).
+        let spec: ContainerSpec = serde_json::from_str(
+            r#"{ "image": "alpine", "read_only": true, "cap_drop": ["ALL"], "user": "nobody" }"#,
+        )
+        .expect("parse");
+        assert!(!spec.has_security_opts());
+    }
+
+    #[test]
+    fn test_docker_run_with_security_argv_from_spec() {
+        // End-to-end argv shape for the fixed `run()` path: spec-level
+        // security fields → SecurityProfile → security_args spliced
+        // before the image reference. Mirrors what
+        // `CliBackend::run_with_security` executes (minus the process
+        // spawn).
+        let proto = DockerProtocol;
+        let spec = ContainerSpec {
+            image: "alpine:3.19".into(),
+            cmd: Some(vec!["echo".into(), "hi".into()]),
+            read_only: Some(true),
+            user: Some("nobody".into()),
+            cap_drop: Some(vec!["ALL".into()]),
+            seccomp: Some("default".into()),
+            no_new_privileges: Some(true),
+            ..Default::default()
+        };
+        let args = cli_backend::splice_security_args(
+            proto.run_args(&spec),
+            &spec.image,
+            proto.security_args(&spec.security_profile()),
+        );
+
+        assert!(
+            args.windows(2)
+                .any(|w| w[0] == "--security-opt" && w[1] == "seccomp=default"),
+            "expected --security-opt seccomp=default; got {:?}",
+            args
+        );
+        assert!(
+            args.windows(2)
+                .any(|w| w[0] == "--security-opt" && w[1] == "no-new-privileges:true"),
+            "expected --security-opt no-new-privileges:true; got {:?}",
+            args
+        );
+        assert!(args.contains(&"--read-only".to_string()));
+        assert!(args
+            .windows(2)
+            .any(|w| w[0] == "--user" && w[1] == "nobody"));
+        assert!(args
+            .windows(2)
+            .any(|w| w[0] == "--cap-drop" && w[1] == "ALL"));
+
+        // Every flag must precede the image; the container command
+        // (`echo hi`) must stay after it.
+        let image_pos = args.iter().position(|a| a == "alpine:3.19").unwrap();
+        let seccomp_pos = args.iter().position(|a| a == "seccomp=default").unwrap();
+        let echo_pos = args.iter().position(|a| a == "echo").unwrap();
+        assert!(
+            seccomp_pos < image_pos && image_pos < echo_pos,
+            "flag/image/cmd ordering broken: {:?}",
+            args
+        );
+    }
+
+    #[test]
+    fn test_docker_create_with_security_argv_from_spec() {
+        // Same shape for the fixed `create()` path — `create` has no
+        // security-arg splice pre-fix (there was no
+        // `create_with_security` at all), so pin the argv here.
+        let proto = DockerProtocol;
+        let spec = ContainerSpec {
+            image: "nginx".into(),
+            seccomp: Some("/etc/seccomp/app.json".into()),
+            ..Default::default()
+        };
+        let args = cli_backend::splice_security_args(
+            proto.create_args(&spec),
+            &spec.image,
+            proto.security_args(&spec.security_profile()),
+        );
+        assert_eq!(args[0], "create");
+        let sec_pos = args
+            .iter()
+            .position(|a| a == "seccomp=/etc/seccomp/app.json")
+            .expect("expected seccomp security-opt in create argv");
+        let image_pos = args.iter().position(|a| a == "nginx").unwrap();
+        assert!(
+            sec_pos < image_pos,
+            "security args must precede the image; got {:?}",
+            args
+        );
+    }
+
+    #[test]
+    fn test_apple_security_argv_from_spec_drops_seccomp_keeps_read_only() {
+        // apple/container has no seccomp equivalent: the normalization
+        // layer drops the field with a warning AND the protocol's
+        // security_args ignores it (defense in depth). A spec-driven
+        // launch on apple must still emit `--read-only` but never a
+        // seccomp flag.
+        let proto = AppleContainerProtocol;
+        let spec = ContainerSpec {
+            image: "alpine".into(),
+            read_only: Some(true),
+            seccomp: Some("default".into()),
+            ..Default::default()
+        };
+        let args = cli_backend::splice_security_args(
+            proto.run_args(&spec),
+            &spec.image,
+            proto.security_args(&spec.security_profile()),
+        );
+        assert!(args.contains(&"--read-only".to_string()));
+        assert!(
+            !args.iter().any(|s| s.contains("seccomp")),
+            "apple argv must not contain seccomp; got {:?}",
+            args
+        );
+    }
+
+    #[test]
+    fn test_compose_service_security_opt_flows_into_container_spec() {
+        // `ComposeService::to_container_spec` must parse
+        // `security_opt: [...]` into the spec-level fields so
+        // `run_command` routes through the security-aware path instead
+        // of dropping the entries on the plain-`run` floor.
+        let svc = crate::types::ComposeService {
+            image: Some("redis:7".into()),
+            security_opt: Some(vec!["seccomp=default".into(), "no-new-privileges".into()]),
+            ..Default::default()
+        };
+        let spec = svc.to_container_spec("cache", "cache-ctr");
+        assert_eq!(spec.seccomp.as_deref(), Some("default"));
+        assert_eq!(spec.no_new_privileges, Some(true));
+        assert!(spec.has_security_opts());
     }
 
     #[test]

--- a/crates/perry-container-compose/src/backend.rs
+++ b/crates/perry-container-compose/src/backend.rs
@@ -373,6 +373,68 @@ mod tests {
     }
 
     #[test]
+    fn test_docker_run_with_security_argv_when_option_value_equals_image() {
+        // Regression: the image slot used to be located by string value,
+        // so a container name equal to the image reference matched the
+        // `--name` VALUE first and the security flags were spliced
+        // between `--name` and its value:
+        //   run --name --security-opt seccomp=default alpine alpine
+        // which corrupts both the name and the command. The image is now
+        // located by construction, so duplicate values are harmless.
+        let proto = DockerProtocol;
+        let spec = ContainerSpec {
+            image: "alpine".into(),
+            name: Some("alpine".into()),
+            cmd: Some(vec!["alpine".into()]),
+            seccomp: Some("default".into()),
+            ..Default::default()
+        };
+        let args = cli_backend::build_secured_args(
+            &proto,
+            &spec,
+            &spec.security_profile(),
+            /* create_only */ false,
+        );
+
+        // `--name` keeps its value, and no flag separates the two.
+        let name_pos = args.iter().position(|a| a == "--name").unwrap();
+        assert_eq!(
+            args[name_pos + 1],
+            "alpine",
+            "--name lost its value: {:?}",
+            args
+        );
+
+        // Ordering: security flag → image → command, with exactly three
+        // `alpine` tokens (name value, image, command).
+        let seccomp_pos = args.iter().position(|a| a == "seccomp=default").unwrap();
+        assert!(
+            seccomp_pos > name_pos + 1,
+            "security flags spliced into the --name pair: {:?}",
+            args
+        );
+        assert_eq!(
+            args.iter().filter(|a| *a == "alpine").count(),
+            3,
+            "expected name value + image + cmd: {:?}",
+            args
+        );
+        // The image is the token right after the last security flag.
+        assert_eq!(
+            args[seccomp_pos + 1],
+            "alpine",
+            "image must directly follow the security flags: {:?}",
+            args
+        );
+        // No sentinel may leak into the executed argv.
+        assert!(
+            !args.iter().any(|a| a.contains('\u{1}')),
+            "image sentinel leaked: {:?}",
+            args
+        );
+    }
+
+    #[test]
     fn test_docker_create_with_security_argv_from_spec() {
         // Same shape for the fixed `create()` path — `create` has no
         // security-arg splice pre-fix (there was no

--- a/crates/perry-container-compose/src/backend/cli_backend.rs
+++ b/crates/perry-container-compose/src/backend/cli_backend.rs
@@ -114,13 +114,12 @@ impl CliBackend {
             );
         }
 
-        let base_args = if create_only {
-            self.protocol.create_args(&normalised_spec)
-        } else {
-            self.protocol.run_args(&normalised_spec)
-        };
-        let sec_args = self.protocol.security_args(&normalised_profile);
-        let args = splice_security_args(base_args, &normalised_spec.image, sec_args);
+        let args = build_secured_args(
+            self.protocol.as_ref(),
+            &normalised_spec,
+            &normalised_profile,
+            create_only,
+        );
 
         let (stdout, _) = self.exec_raw(&args).await?;
         let id = self.protocol.parse_container_id(&stdout)?;
@@ -132,11 +131,63 @@ impl CliBackend {
 }
 
 /// Insert the protocol's `security_args` immediately before the image
-/// reference in a `run`/`create` argument vector. The image is the
-/// first positional argument; everything after it is the container
-/// command, so flags must land before it. Pure function so the final
-/// argv shape is unit-testable without spawning a CLI process (see
-/// the arg-construction tests in `crate::backend::tests`).
+/// Unique stand-in for the image reference while the argv is built, so
+/// the image slot is found by construction rather than by matching a
+/// value that an option (e.g. `--name`) may legitimately repeat. The
+/// control characters keep it distinct from any real image reference.
+pub(crate) const IMAGE_SENTINEL: &str = "\u{1}perry-image-sentinel\u{1}";
+
+/// Build the final `run`/`create` argv with the protocol's security
+/// flags spliced immediately before the image reference.
+///
+/// The image slot is located by *construction* rather than by value:
+/// the argv is built from a probe spec carrying [`IMAGE_SENTINEL`], so
+/// an option value that happens to equal the real image reference
+/// (`run --name alpine alpine`) cannot be mistaken for the image and
+/// have the flags spliced between a flag and its value. The protocols
+/// only ever emit `spec.image` at the image position, so substituting
+/// the sentinel back afterwards is exact.
+///
+/// Pure (the protocol's arg builders are sync), so the whole secured
+/// argv shape is unit-testable without spawning a CLI process.
+pub(crate) fn build_secured_args(
+    protocol: &dyn CliProtocol,
+    spec: &ContainerSpec,
+    profile: &SecurityProfile,
+    create_only: bool,
+) -> Vec<String> {
+    let mut probe_spec = spec.clone();
+    probe_spec.image = IMAGE_SENTINEL.to_string();
+    let base_args = if create_only {
+        protocol.create_args(&probe_spec)
+    } else {
+        protocol.run_args(&probe_spec)
+    };
+    let sec_args = protocol.security_args(profile);
+    splice_security_args(base_args, IMAGE_SENTINEL, sec_args)
+        .into_iter()
+        .map(|a| {
+            if a == IMAGE_SENTINEL {
+                spec.image.clone()
+            } else {
+                a
+            }
+        })
+        .collect()
+}
+
+/// Insert the protocol's `security_args` immediately before `image` in a
+/// `run`/`create` argument vector. The image is the first positional
+/// argument; everything after it is the container command, so flags must
+/// land before it. Pure function so the final argv shape is
+/// unit-testable without spawning a CLI process (see the
+/// arg-construction tests in `crate::backend::tests`).
+///
+/// `image` must occur exactly once, at the image position — production
+/// callers pass [`IMAGE_SENTINEL`] and substitute the real reference
+/// afterwards, because matching the real reference can hit an earlier
+/// option value first (`run --name alpine alpine` would splice between
+/// `--name` and its value).
 ///
 /// If the image can't be located (defensive — `run_args` always pushes
 /// it) the args are returned unchanged rather than emitting flags into

--- a/crates/perry-container-compose/src/backend/cli_backend.rs
+++ b/crates/perry-container-compose/src/backend/cli_backend.rs
@@ -75,6 +75,83 @@ impl CliBackend {
             })
         }
     }
+
+    /// Shared implementation behind `run_with_security` /
+    /// `create_with_security`.
+    ///
+    /// Cross-backend determinism pass (see `crate::capabilities`):
+    /// normalise the spec and security profile against the backend's
+    /// declared capabilities BEFORE emitting CLI args. Drops fields
+    /// the backend can't honor + emits structured warnings via
+    /// tracing so the user can grep for them. This is the layer
+    /// that prevents an apple/container `run` from receiving a
+    /// `--privileged` flag the CLI rejects.
+    async fn launch_with_security(
+        &self,
+        spec: &ContainerSpec,
+        profile: &SecurityProfile,
+        create_only: bool,
+    ) -> Result<ContainerHandle> {
+        let caps = self.protocol.capabilities();
+        let svc_name = spec.name.as_deref().unwrap_or("<unnamed>");
+        let mut normalised_spec = spec.clone();
+        let mut normalised_profile = profile.clone();
+        let mut warnings =
+            crate::capabilities::normalise_spec_for(caps, svc_name, &mut normalised_spec);
+        warnings.extend(crate::capabilities::normalise_security_profile(
+            caps,
+            svc_name,
+            &mut normalised_profile,
+        ));
+        for w in &warnings {
+            tracing::warn!(
+                target: "perry::container::normalise",
+                backend = w.backend,
+                service = %w.service,
+                field = w.field,
+                reason = %w.reason,
+                "spec field dropped/translated for backend"
+            );
+        }
+
+        let base_args = if create_only {
+            self.protocol.create_args(&normalised_spec)
+        } else {
+            self.protocol.run_args(&normalised_spec)
+        };
+        let sec_args = self.protocol.security_args(&normalised_profile);
+        let args = splice_security_args(base_args, &normalised_spec.image, sec_args);
+
+        let (stdout, _) = self.exec_raw(&args).await?;
+        let id = self.protocol.parse_container_id(&stdout)?;
+        Ok(ContainerHandle {
+            id,
+            name: normalised_spec.name,
+        })
+    }
+}
+
+/// Insert the protocol's `security_args` immediately before the image
+/// reference in a `run`/`create` argument vector. The image is the
+/// first positional argument; everything after it is the container
+/// command, so flags must land before it. Pure function so the final
+/// argv shape is unit-testable without spawning a CLI process (see
+/// the arg-construction tests in `crate::backend::tests`).
+///
+/// If the image can't be located (defensive — `run_args` always pushes
+/// it) the args are returned unchanged rather than emitting flags into
+/// the container command position.
+pub(crate) fn splice_security_args(
+    mut args: Vec<String>,
+    image: &str,
+    sec_args: Vec<String>,
+) -> Vec<String> {
+    if let Some(pos) = args.iter().position(|a| a == image) {
+        for (i, arg) in sec_args.into_iter().enumerate() {
+            args.insert(pos + i, arg);
+        }
+    }
+    args
 }
 
 #[async_trait]
@@ -234,52 +311,15 @@ impl ContainerBackend for CliBackend {
         spec: &ContainerSpec,
         profile: &SecurityProfile,
     ) -> Result<ContainerHandle> {
-        // Cross-backend determinism pass (see `crate::capabilities`):
-        // normalise the spec and security profile against the backend's
-        // declared capabilities BEFORE emitting CLI args. Drops fields
-        // the backend can't honor + emits structured warnings via
-        // tracing so the user can grep for them. This is the layer
-        // that prevents an apple/container `run` from receiving a
-        // `--privileged` flag the CLI rejects.
-        let caps = self.protocol.capabilities();
-        let svc_name = spec.name.as_deref().unwrap_or("<unnamed>");
-        let mut normalised_spec = spec.clone();
-        let mut normalised_profile = profile.clone();
-        let mut warnings =
-            crate::capabilities::normalise_spec_for(caps, svc_name, &mut normalised_spec);
-        warnings.extend(crate::capabilities::normalise_security_profile(
-            caps,
-            svc_name,
-            &mut normalised_profile,
-        ));
-        for w in &warnings {
-            tracing::warn!(
-                target: "perry::container::normalise",
-                backend = w.backend,
-                service = %w.service,
-                field = w.field,
-                reason = %w.reason,
-                "spec field dropped/translated for backend"
-            );
-        }
+        self.launch_with_security(spec, profile, false).await
+    }
 
-        let mut args = self.protocol.run_args(&normalised_spec);
-        // Find the image name to insert security args before it
-        if let Some(pos) = args.iter().position(|a| a == &normalised_spec.image) {
-            let sec_args = self.protocol.security_args(&normalised_profile);
-            // If it's lima, we need to be careful with where we insert.
-            // But let's assume we can just insert before the image.
-            for (i, arg) in sec_args.into_iter().enumerate() {
-                args.insert(pos + i, arg);
-            }
-        }
-
-        let (stdout, _) = self.exec_raw(&args).await?;
-        let id = self.protocol.parse_container_id(&stdout)?;
-        Ok(ContainerHandle {
-            id,
-            name: normalised_spec.name,
-        })
+    async fn create_with_security(
+        &self,
+        spec: &ContainerSpec,
+        profile: &SecurityProfile,
+    ) -> Result<ContainerHandle> {
+        self.launch_with_security(spec, profile, true).await
     }
 
     async fn wait(&self, id: &str) -> Result<i32> {

--- a/crates/perry-container-compose/src/compose.rs
+++ b/crates/perry-container-compose/src/compose.rs
@@ -776,7 +776,7 @@ impl ComposeEngine {
     pub async fn down(
         &self,
         services: &[String],
-        _remove_orphans: bool,
+        remove_orphans: bool,
         remove_volumes: bool,
     ) -> Result<()> {
         // `rollback()` removes `session_volumes` unconditionally — that's
@@ -831,6 +831,55 @@ impl ComposeEngine {
             let container_name = self.resolve_container_name(svc_name);
             let _ = self.backend.stop(&container_name, Some(10)).await;
             let _ = self.backend.remove(&container_name, true).await;
+        }
+
+        // Orphan removal (`down --remove-orphans` semantics): containers
+        // that still carry THIS project's `perry.compose.project` label
+        // but whose `perry.compose.service` key is no longer in the
+        // current spec — typically left behind when a service was
+        // renamed or deleted between deploys. Every container the
+        // engine creates is stamped with both labels in `up()`, so the
+        // label pair is the ownership test; unlabelled containers (or
+        // ones without a service label) were never ours and are left
+        // alone, as are other projects' containers. Runs BEFORE network
+        // removal so an orphan attached to a project network doesn't
+        // keep the network alive. Pre-fix this flag was parsed at the
+        // FFI boundary and then discarded (`_remove_orphans`).
+        if remove_orphans {
+            match self.backend.list(true).await {
+                Ok(all) => {
+                    for c in all {
+                        let ours = c
+                            .labels
+                            .get("perry.compose.project")
+                            .map(|v| v == &self.project_name)
+                            .unwrap_or(false);
+                        if !ours {
+                            continue;
+                        }
+                        let orphan = c
+                            .labels
+                            .get("perry.compose.service")
+                            .map(|svc| !self.spec.services.contains_key(svc))
+                            .unwrap_or(false);
+                        if orphan {
+                            let _ = self.backend.stop(&c.id, Some(10)).await;
+                            let _ = self.backend.remove(&c.id, true).await;
+                        }
+                    }
+                }
+                Err(e) => {
+                    // Best-effort like the rest of down(): a backend
+                    // that can't list containers shouldn't abort the
+                    // network/volume teardown below.
+                    tracing::warn!(
+                        target: "perry::compose::down",
+                        project = %self.project_name,
+                        error = %e,
+                        "remove_orphans: could not list containers; skipping orphan sweep"
+                    );
+                }
+            }
         }
 
         if let Some(networks) = &self.spec.networks {

--- a/crates/perry-container-compose/src/compose.rs
+++ b/crates/perry-container-compose/src/compose.rs
@@ -540,6 +540,14 @@ impl ComposeEngine {
                 workdir: svc.working_dir.clone(),
                 cap_add: svc.cap_add.clone(),
                 cap_drop: svc.cap_drop.clone(),
+                // Left unset here: the compose engine expresses seccomp
+                // / no-new-privileges through the `SecurityProfile`
+                // built from `security_opt` below, and
+                // `run_with_security` emits them from the profile.
+                // Setting them on the spec too would double-emit the
+                // `--security-opt` flags.
+                seccomp: None,
+                no_new_privileges: None,
                 // Register the service KEY as a DNS alias on the
                 // attached network. This makes `db:5432` / `api:8080`
                 // etc. resolve from sibling containers without the

--- a/crates/perry-container-compose/src/testing/mock_backend.rs
+++ b/crates/perry-container-compose/src/testing/mock_backend.rs
@@ -381,4 +381,12 @@ impl ContainerBackend for MockBackend {
         }
         self.run(spec).await
     }
+
+    async fn create_with_security(
+        &self,
+        spec: &ContainerSpec,
+        _profile: &SecurityProfile,
+    ) -> Result<ContainerHandle> {
+        self.create(spec).await
+    }
 }

--- a/crates/perry-container-compose/src/types.rs
+++ b/crates/perry-container-compose/src/types.rs
@@ -614,6 +614,14 @@ impl ComposeService {
             None => None,
         };
         let labels = self.labels.as_ref().map(|l| l.to_map());
+        // Parse `security_opt: [...]` into the spec-level seccomp /
+        // no-new-privileges fields so `run_command` can route through
+        // the security-aware backend path (mirrors the SecurityProfile
+        // `ComposeEngine::up` builds from the same entries).
+        let mut sec = crate::backend::SecurityProfile::default();
+        if let Some(opts) = &self.security_opt {
+            sec.merge_security_opt(opts);
+        }
         ContainerSpec {
             image: self.image_ref(service_name),
             name: Some(container_name.to_string()),
@@ -631,6 +639,12 @@ impl ComposeService {
             workdir: self.working_dir.clone(),
             cap_add: self.cap_add.clone(),
             cap_drop: self.cap_drop.clone(),
+            seccomp: sec.seccomp,
+            no_new_privileges: if sec.no_new_privileges {
+                Some(true)
+            } else {
+                None
+            },
             // network_aliases is populated separately by ComposeEngine::up
             // (using the service KEY + any long-form `aliases` from the
             // compose-spec) — this single-service `to_container_spec`
@@ -700,7 +714,12 @@ impl ComposeService {
     ) -> crate::error::Result<ContainerHandle> {
         let container_name = crate::service::service_container_name(self, service_name);
         let spec = self.to_container_spec(service_name, &container_name);
-        backend.run(&spec).await
+        if spec.has_security_opts() {
+            let profile = spec.security_profile();
+            backend.run_with_security(&spec, &profile).await
+        } else {
+            backend.run(&spec).await
+        }
     }
 
     /// Start an already-created (stopped) container.
@@ -840,6 +859,23 @@ pub struct ContainerSpec {
     pub workdir: Option<String>,
     pub cap_add: Option<Vec<String>>,
     pub cap_drop: Option<Vec<String>>,
+    /// Seccomp profile: a path to a JSON profile file, or the literal
+    /// string `"default"` for the runtime's default profile. Emitted
+    /// as `--security-opt seccomp=<value>` via the security-aware
+    /// launch path ([`crate::backend::ContainerBackend::run_with_security`] /
+    /// [`crate::backend::ContainerBackend::create_with_security`]).
+    /// Backends without seccomp support (apple/container) drop the
+    /// field with a normalization warning instead of emitting a flag
+    /// their CLI rejects. Pre-fix this field didn't exist on the spec,
+    /// so a `seccomp:` key sent through the public `run()`/`create()`
+    /// FFI was silently discarded by serde.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seccomp: Option<String>,
+    /// `--security-opt no-new-privileges` — SUID/SGID binaries inside
+    /// the container can't gain privileges via execve. Routed through
+    /// the same security-aware launch path as `seccomp`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub no_new_privileges: Option<bool>,
     /// Additional DNS-resolvable names this container should answer to
     /// on its attached network (`--network-alias <name>` per entry).
     /// Populated by `ComposeEngine::up()` from the service key plus any
@@ -849,6 +885,32 @@ pub struct ContainerSpec {
     /// matching docker-compose semantics.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub network_aliases: Option<Vec<String>>,
+}
+
+impl ContainerSpec {
+    /// Whether any spec field that can only reach the CLI through
+    /// [`crate::backend::SecurityProfile`] is set. `read_only`,
+    /// `cap_drop`, `user`, … are emitted directly by the protocols'
+    /// `run_args`/`create_args`; `seccomp` and `no_new_privileges`
+    /// only exist on `security_args`, so callers must route through
+    /// `run_with_security`/`create_with_security` when this returns
+    /// true — plain `run()`/`create()` would silently drop them.
+    pub fn has_security_opts(&self) -> bool {
+        self.seccomp.is_some() || self.no_new_privileges.unwrap_or(false)
+    }
+
+    /// Build the [`crate::backend::SecurityProfile`] equivalent of this
+    /// spec's security fields. Mirrors the profile `ComposeEngine::up`
+    /// derives from a service's `read_only` + `security_opt` entries,
+    /// so the single-container API and the compose engine hand the
+    /// backend identical profiles for identical knobs.
+    pub fn security_profile(&self) -> crate::backend::SecurityProfile {
+        crate::backend::SecurityProfile {
+            read_only_root: self.read_only.unwrap_or(false),
+            seccomp: self.seccomp.clone(),
+            no_new_privileges: self.no_new_privileges.unwrap_or(false),
+        }
+    }
 }
 
 /// Handle returned after creating/running a container.

--- a/crates/perry-container-compose/tests/common/mod.rs
+++ b/crates/perry-container-compose/tests/common/mod.rs
@@ -208,6 +208,14 @@ impl ContainerBackend for MockBackend {
         self.run(spec).await
     }
 
+    async fn create_with_security(
+        &self,
+        spec: &ContainerSpec,
+        _profile: &SecurityProfile,
+    ) -> Result<ContainerHandle> {
+        self.create(spec).await
+    }
+
     async fn inspect_network(&self, _name: &str) -> Result<()> {
         let state = self.state.lock().unwrap();
         if state.networks.contains(&_name.to_string()) {

--- a/crates/perry-container-compose/tests/orchestration.rs
+++ b/crates/perry-container-compose/tests/orchestration.rs
@@ -192,3 +192,161 @@ async fn test_compose_project_name_scopes_volumes_networks_and_labels() {
         "container must carry the project label"
     );
 }
+
+/// Seed the mock backend with a container that looks like a leftover
+/// from an earlier deploy of `project`: it carries Perry's compose
+/// labels but its service key is not in the current spec.
+fn seed_orphan(backend: &MockBackend, id: &str, project: &str, service: &str) {
+    use perry_container_compose::types::ContainerInfo;
+    let mut labels = std::collections::HashMap::new();
+    labels.insert("perry.compose.project".to_string(), project.to_string());
+    labels.insert("perry.compose.service".to_string(), service.to_string());
+    backend.state.lock().unwrap().containers.insert(
+        id.to_string(),
+        ContainerInfo {
+            id: id.to_string(),
+            name: id.to_string(),
+            image: "busybox".to_string(),
+            status: "running".to_string(),
+            ports: vec![],
+            labels,
+            created: "2025-01-01T00:00:00Z".to_string(),
+            ip_address: String::new(),
+        },
+    );
+}
+
+#[tokio::test]
+async fn test_compose_down_remove_orphans_removes_stale_service_containers() {
+    // A container from a previous deploy whose service key
+    // ("old-worker") was deleted from the spec must be stopped +
+    // removed when down() runs with remove_orphans = true. Pre-fix the
+    // flag was parsed at the FFI and discarded (`_remove_orphans`).
+    let mut spec = ComposeSpec::default();
+    spec.services.insert(
+        "web".into(),
+        ComposeService {
+            image: Some("nginx".into()),
+            ..Default::default()
+        },
+    );
+
+    let backend = Arc::new(MockBackend::default());
+    seed_orphan(&backend, "orphan-ctr", "orphan-proj", "old-worker");
+
+    let engine = Arc::new(ComposeEngine::new(
+        spec,
+        "orphan-proj".into(),
+        backend.clone(),
+    ));
+    let _ = Arc::clone(&engine)
+        .up(&[], true, false, false)
+        .await
+        .expect("up failed");
+
+    engine.down(&[], true, false).await.expect("down failed");
+
+    let state = backend.state.lock().unwrap();
+    assert!(
+        !state.containers.contains_key("orphan-ctr"),
+        "orphan must be removed by down(remove_orphans: true); got {:?}",
+        state.containers.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        state.actions.iter().any(|a| a == "remove:orphan-ctr"),
+        "expected an explicit remove of the orphan; actions: {:?}",
+        state.actions
+    );
+}
+
+#[tokio::test]
+async fn test_compose_down_without_remove_orphans_keeps_orphans() {
+    // Default behavior is unchanged: remove_orphans = false leaves the
+    // stale container alone (only current-spec services are removed).
+    let mut spec = ComposeSpec::default();
+    spec.services.insert(
+        "web".into(),
+        ComposeService {
+            image: Some("nginx".into()),
+            ..Default::default()
+        },
+    );
+
+    let backend = Arc::new(MockBackend::default());
+    seed_orphan(&backend, "orphan-ctr", "orphan-proj", "old-worker");
+
+    let engine = Arc::new(ComposeEngine::new(
+        spec,
+        "orphan-proj".into(),
+        backend.clone(),
+    ));
+    let _ = Arc::clone(&engine)
+        .up(&[], true, false, false)
+        .await
+        .expect("up failed");
+
+    engine.down(&[], false, false).await.expect("down failed");
+
+    let state = backend.state.lock().unwrap();
+    assert!(
+        state.containers.contains_key("orphan-ctr"),
+        "down without remove_orphans must NOT touch the orphan"
+    );
+}
+
+#[tokio::test]
+async fn test_compose_down_remove_orphans_scoped_to_project_and_labels() {
+    // The orphan sweep must be strictly label-scoped: containers from
+    // OTHER projects and containers without Perry's compose labels are
+    // never candidates, even with remove_orphans = true.
+    use perry_container_compose::types::ContainerInfo;
+
+    let mut spec = ComposeSpec::default();
+    spec.services.insert(
+        "web".into(),
+        ComposeService {
+            image: Some("nginx".into()),
+            ..Default::default()
+        },
+    );
+
+    let backend = Arc::new(MockBackend::default());
+    // Same-key orphan in a DIFFERENT project.
+    seed_orphan(&backend, "other-proj-ctr", "some-other-proj", "old-worker");
+    // Unlabelled container (not created by Perry at all).
+    backend.state.lock().unwrap().containers.insert(
+        "unlabelled-ctr".to_string(),
+        ContainerInfo {
+            id: "unlabelled-ctr".to_string(),
+            name: "unlabelled-ctr".to_string(),
+            image: "busybox".to_string(),
+            status: "running".to_string(),
+            ports: vec![],
+            labels: std::collections::HashMap::new(),
+            created: "2025-01-01T00:00:00Z".to_string(),
+            ip_address: String::new(),
+        },
+    );
+
+    let engine = Arc::new(ComposeEngine::new(
+        spec,
+        "orphan-proj".into(),
+        backend.clone(),
+    ));
+    let _ = Arc::clone(&engine)
+        .up(&[], true, false, false)
+        .await
+        .expect("up failed");
+
+    engine.down(&[], true, false).await.expect("down failed");
+
+    let state = backend.state.lock().unwrap();
+    assert!(
+        state.containers.contains_key("other-proj-ctr"),
+        "other project's container must survive the orphan sweep"
+    );
+    assert!(
+        state.containers.contains_key("unlabelled-ctr"),
+        "unlabelled container must survive the orphan sweep"
+    );
+}

--- a/crates/perry-container-compose/tests/orchestration.rs
+++ b/crates/perry-container-compose/tests/orchestration.rs
@@ -131,3 +131,64 @@ async fn test_compose_down_cleans_resources() {
         state.containers
     );
 }
+
+#[tokio::test]
+async fn test_compose_project_name_scopes_volumes_networks_and_labels() {
+    // The project name (ComposeSpec.name via the FFI; the second
+    // ComposeEngine::new arg here) must namespace non-external volumes
+    // and networks as `<project>_<declared-name>` and stamp the
+    // `perry.compose.project` label on every container. Typed TS
+    // callers couldn't set it before ComposeSpec.name landed in the
+    // d.ts — every stack silently collided under "perry-stack".
+    use perry_container_compose::types::ServiceNetworks;
+
+    let mut spec = ComposeSpec::default();
+    spec.services.insert(
+        "web".into(),
+        ComposeService {
+            image: Some("nginx".into()),
+            volumes: Some(vec![serde_yaml::Value::String("data:/var/www".into())]),
+            networks: Some(ServiceNetworks::List(vec!["appnet".into()])),
+            ..Default::default()
+        },
+    );
+    spec.volumes = Some({
+        let mut m = indexmap::IndexMap::new();
+        m.insert("data".to_string(), None);
+        m
+    });
+    spec.networks = Some({
+        let mut m = indexmap::IndexMap::new();
+        m.insert("appnet".to_string(), None);
+        m
+    });
+
+    let backend = Arc::new(MockBackend::default());
+    let engine = Arc::new(ComposeEngine::new(spec, "myproj".into(), backend.clone()));
+    Arc::clone(&engine)
+        .up(&[], true, false, false)
+        .await
+        .expect("up failed");
+
+    let state = backend.state.lock().unwrap();
+    assert!(
+        state.volumes.contains(&"myproj_data".to_string()),
+        "volume must be project-scoped as myproj_data; got {:?}",
+        state.volumes
+    );
+    assert!(
+        state.networks.contains(&"myproj_appnet".to_string()),
+        "network must be project-scoped as myproj_appnet; got {:?}",
+        state.networks
+    );
+    let web = state
+        .containers
+        .values()
+        .next()
+        .expect("one container expected");
+    assert_eq!(
+        web.labels.get("perry.compose.project"),
+        Some(&"myproj".to_string()),
+        "container must carry the project label"
+    );
+}

--- a/crates/perry-container-compose/tests/types_tests.rs
+++ b/crates/perry-container-compose/tests/types_tests.rs
@@ -98,3 +98,18 @@ proptest! {
 // |-------------|-----------|-------|
 // | 10.11       | test_list_or_dict_to_map | unit |
 // | 12.6        | prop_compose_spec_json_round_trip | property |
+
+// The compose FFI JSON-parses the TS object literal straight into
+// `ComposeSpec`; `name` drives project scoping (labels + `<name>_`
+// volume/network namespacing) and defaults to "perry-stack" at the
+// stdlib layer when absent. Pin that the field round-trips from JSON,
+// matching the `name?: string` now exposed in the perry/compose d.ts.
+#[test]
+fn test_compose_spec_json_parses_project_name() {
+    let spec: ComposeSpec =
+        serde_json::from_str(r#"{ "name": "myproj", "services": {} }"#).expect("parse");
+    assert_eq!(spec.name.as_deref(), Some("myproj"));
+
+    let unnamed: ComposeSpec = serde_json::from_str(r#"{ "services": {} }"#).expect("parse");
+    assert_eq!(unnamed.name, None);
+}

--- a/crates/perry-stdlib/src/container/compose.rs
+++ b/crates/perry-stdlib/src/container/compose.rs
@@ -33,8 +33,8 @@ impl ComposeWrapper {
         self.engine.clone().up(&[], true, false, false).await
     }
 
-    pub async fn down(&self, volumes: bool) -> Result<(), ContainerError> {
-        self.engine.down(&[], false, volumes).await
+    pub async fn down(&self, volumes: bool, remove_orphans: bool) -> Result<(), ContainerError> {
+        self.engine.down(&[], remove_orphans, volumes).await
     }
 
     pub async fn ps(&self) -> Result<Vec<ContainerInfo>, ContainerError> {

--- a/crates/perry-stdlib/src/container/compose_ffi.rs
+++ b/crates/perry-stdlib/src/container/compose_ffi.rs
@@ -287,7 +287,7 @@ pub unsafe extern "C" fn js_container_compose_down(
     let handle_id = handle_id_from_f64(handle);
 
     let opts_json = unsafe { string_from_header(opts_ptr) };
-    let (remove_volumes, _remove_orphans) = match opts_json.as_deref() {
+    let (remove_volumes, remove_orphans) = match opts_json.as_deref() {
         Some(s) if !s.is_empty() && s != "undefined" && s != "null" => {
             let v: serde_json::Value = serde_json::from_str(s).unwrap_or(serde_json::Value::Null);
             (
@@ -316,7 +316,7 @@ pub unsafe extern "C" fn js_container_compose_down(
             Err(e) => return Err::<u64, String>(e.to_string()),
         };
         let wrapper = compose::ComposeWrapper::new_from_engine(engine);
-        match wrapper.down(remove_volumes).await {
+        match wrapper.down(remove_volumes, remove_orphans).await {
             Ok(()) => Ok(PROMISE_VOID_BITS),
             Err(e) => Err::<u64, String>(e.to_string()),
         }

--- a/crates/perry-stdlib/src/container/lifecycle.rs
+++ b/crates/perry-stdlib/src/container/lifecycle.rs
@@ -38,7 +38,19 @@ pub unsafe extern "C" fn js_container_run(spec_ptr: *const StringHeader) -> *mut
             Ok(b) => Arc::clone(b),
             Err(e) => return Err::<u64, String>(e.to_string()),
         };
-        match backend.run(&spec).await {
+        // Route through the security-aware path when the spec carries
+        // fields (`seccomp`, `no_new_privileges`) that only exist on
+        // the protocol's `security_args`. Pre-fix `run()` always
+        // called `backend.run()`, so those knobs were unreachable via
+        // the public API — serde dropped them from the JSON and the
+        // documented hardening silently never reached the runtime.
+        let result = if spec.has_security_opts() {
+            let profile = spec.security_profile();
+            backend.run_with_security(&spec, &profile).await
+        } else {
+            backend.run(&spec).await
+        };
+        match result {
             Ok(handle) => {
                 let handle_id = types::register_container_handle(handle);
                 Ok(handle_to_promise_bits(handle_id as u64))
@@ -75,7 +87,15 @@ pub unsafe extern "C" fn js_container_create(spec_ptr: *const StringHeader) -> *
             Ok(b) => Arc::clone(b),
             Err(e) => return Err::<u64, String>(e.to_string()),
         };
-        match backend.create(&spec).await {
+        // Same security routing as `run()` above — `create()` must not
+        // silently drop `seccomp` / `no_new_privileges` either.
+        let result = if spec.has_security_opts() {
+            let profile = spec.security_profile();
+            backend.create_with_security(&spec, &profile).await
+        } else {
+            backend.create(&spec).await
+        };
+        match result {
             Ok(handle) => {
                 let handle_id = types::register_container_handle(handle);
                 Ok(handle_to_promise_bits(handle_id as u64))

--- a/crates/perry-stdlib/src/container/mod.rs
+++ b/crates/perry-stdlib/src/container/mod.rs
@@ -347,7 +347,7 @@ async fn drain_compose_handles() {
     for id in ids {
         if let Some(engine) = types::take_compose_handle(id) {
             let wrapper = compose::ComposeWrapper::new_from_engine(engine);
-            let _ = wrapper.down(false).await;
+            let _ = wrapper.down(false, false).await;
         }
     }
 }

--- a/docs/src/container/compose.md
+++ b/docs/src/container/compose.md
@@ -41,6 +41,14 @@ The full `ComposeSpec` shape is exported from `perry/compose` as
 `ComposeSpec`, with sub-types `Service`, `ComposeNetwork`,
 `ComposeVolume`, `Build`, and `Healthcheck`.
 
+The root-level `name:` field sets the **compose project name** — it
+labels every container (`perry.compose.project=<name>`) and namespaces
+non-external volumes and networks as `<name>_<declared-name>`, exactly
+like docker-compose's project prefix. It defaults to `"perry-stack"`
+when omitted, so set it whenever more than one stack can run on the
+same host (see [Volumes → Volume naming and
+ownership](./volumes.md#volume-naming-and-ownership)).
+
 ### Recognised Service fields
 
 The full set Perry's engine understands (matches compose-spec § services):

--- a/docs/src/container/compose.md
+++ b/docs/src/container/compose.md
@@ -141,12 +141,14 @@ still works but is now optional.
 `down(handle)` removes containers and networks, and **preserves named
 volumes by default**. Pass `{ volumes: true }` to also drop the volumes
 (destroys committed data — use only for "rip and replace" redeploy or
-test cleanup).
+test cleanup). Pass `{ removeOrphans: true }` to also sweep out
+containers left behind by earlier deploys of the same project whose
+service key no longer exists in the spec.
 
 | `down` option | Type | Default | Effect |
 |---|---|---|---|
 | `volumes` | `boolean` | `false` | Also remove named volumes after containers + networks. |
-| `removeOrphans` | `boolean` | `false` | Remove containers labelled with this stack's project but not in the current spec. |
+| `removeOrphans` | `boolean` | `false` | Remove **orphaned containers**: ones still carrying this stack's `perry.compose.project` label whose `perry.compose.service` key is no longer in the spec (service renamed/deleted between deploys). Strictly label-scoped — other projects' containers and anything not created by Perry are never touched. |
 
 ## Status / logs / exec
 

--- a/docs/src/container/containers.md
+++ b/docs/src/container/containers.md
@@ -40,9 +40,16 @@ The full `ContainerSpec` accepts:
 | `workdir` | `string` | Working directory inside the container. |
 | `cap_add` | `string[]` | Linux capabilities to add (e.g. `["NET_BIND_SERVICE"]`). |
 | `cap_drop` | `string[]` | Linux capabilities to drop (e.g. `["ALL"]`). |
-| `seccomp` | `string` | Seccomp profile path or `"default"`. |
+| `seccomp` | `string` | Seccomp profile path or `"default"` (the runtime's default profile). |
+| `no_new_privileges` | `boolean` | Sets `--security-opt no-new-privileges` — SUID/SGID binaries inside the container can't gain privileges via execve. |
 
-See [Security](./security.md) for the security knobs in depth.
+When `seccomp` or `no_new_privileges` is set, `run()`/`create()`
+automatically route through the engine's security-aware launch path
+(the same one `perry/compose` uses), which also normalizes the spec
+against the detected backend's capabilities — on apple/container the
+two flags have no equivalent and are dropped with a warning instead of
+crashing the CLI. See [Security](./security.md) for the security knobs
+in depth.
 
 ### Hardened single-container run
 

--- a/docs/src/container/security.md
+++ b/docs/src/container/security.md
@@ -20,6 +20,13 @@ compose `up()`:
 | `cap_add` | `string[]` | Linux capabilities to add. Specific (e.g. `["NET_BIND_SERVICE"]`), not blanket. | All backends |
 | `cap_drop` | `string[]` | Capabilities to drop. `["ALL"]` is the canonical "drop everything" starting point. | All backends |
 | `seccomp` | `string` | Seccomp profile path or `"default"` (uses the runtime's default profile). | Docker / Podman / Lima only — apple/container has no equivalent and **drops the field** with a warning |
+| `no_new_privileges` | `boolean` | Sets `--security-opt no-new-privileges` — SUID/SGID binaries inside the container can't gain privileges via execve. | Docker / Podman / Lima only — dropped on apple/container |
+
+On a compose service the last two are spelled in compose-spec form
+instead: `security_opt: ["seccomp=<path-or-default>",
+"no-new-privileges"]`. The engine parses those entries into the same
+internal `SecurityProfile` that `run()`/`create()` build from the
+spec-level fields, so both APIs hand the backend identical flags.
 
 > ⚠️ **Cross-backend security caveat.** `privileged`, `seccomp`,
 > `--security-opt no-new-privileges`, IPC/PID namespace sharing, and

--- a/docs/src/container/volumes.md
+++ b/docs/src/container/volumes.md
@@ -125,19 +125,23 @@ remove it explicitly with `docker volume rm team-shared-cache`.
 
 ## Volume naming and ownership
 
-Perry doesn't currently namespace volume names by project — the name
-you write in the spec is the literal docker volume name. So
-`forgejo-pgdata` is created as the docker volume `forgejo-pgdata`, and
-two stacks both declaring `forgejo-pgdata` would share it.
-
-For multi-stack isolation, prefix the volume name with the project /
-stack identifier:
+Perry project-scopes volume (and network) names as `<project>_<name>`
+unless the volume is `external: true` or carries an explicit `name:`
+override — so `forgejo-pgdata` under project `forgejo` becomes the
+docker volume `forgejo_forgejo-pgdata`. The project identifier comes
+from `ComposeSpec.name` and defaults to `"perry-stack"` when omitted —
+so two stacks that *both* leave `name` unset and declare the same
+volume key still collide. Give each stack a distinct project name for
+multi-stack isolation:
 
 ```typescript,no-test
-volumes: {
-  "myapp-staging-pgdata":   { driver: "local" },
-  "myapp-production-pgdata": { driver: "local" },
-},
+await up({
+  name: "myapp-staging",              // → volume myapp-staging_pgdata
+  services: { /* … */ },
+  volumes: {
+    pgdata: { driver: "local" },
+  },
+});
 ```
 
 ## Inspecting volume state

--- a/types/perry/compose/index.d.ts
+++ b/types/perry/compose/index.d.ts
@@ -89,6 +89,11 @@ export interface Service {
   cap_add?: string[];
   /** Linux capabilities to drop (e.g. `["ALL"]`) */
   cap_drop?: string[];
+  /** Security options (compose-spec § service.security_opt), e.g.
+   *  `["seccomp=default", "no-new-privileges"]`. Parsed into the
+   *  engine's `SecurityProfile`; entries a backend can't honor are
+   *  dropped with a warning. */
+  security_opt?: string[];
 }
 
 /**

--- a/types/perry/compose/index.d.ts
+++ b/types/perry/compose/index.d.ts
@@ -129,6 +129,16 @@ export interface ComposeVolume {
  * Root Compose file structure (docker-compose.yaml / compose.yaml).
  */
 export interface ComposeSpec {
+  /**
+   * Compose project name. Scopes everything the engine creates:
+   * containers get the `perry.compose.project=<name>` label (used by
+   * `down()` and `perry/container.downByProject()`), and non-external
+   * volumes / networks are namespaced `<name>_<declared-name>` so two
+   * stacks declaring the same volume key don't collide and corrupt
+   * each other's data. Defaults to `"perry-stack"` when omitted — set
+   * it whenever more than one stack can run on the same host.
+   */
+  name?: string;
   version?: string;
   services: Record<string, Service>;
   networks?: Record<string, ComposeNetwork>;

--- a/types/perry/compose/index.d.ts
+++ b/types/perry/compose/index.d.ts
@@ -166,6 +166,15 @@ export interface UpOptions {
 export interface DownOptions {
   /** Remove named volumes */
   volumes?: boolean;
+  /**
+   * Remove orphaned containers: containers that still carry this
+   * stack's project label (`perry.compose.project`) but whose service
+   * key is no longer present in the spec — typically left behind when
+   * a service was renamed or deleted between deploys. Containers
+   * belonging to other projects (or without Perry's compose labels)
+   * are never touched. Default false.
+   */
+  removeOrphans?: boolean;
 }
 
 export interface LogsOptions {

--- a/types/perry/container/index.d.ts
+++ b/types/perry/container/index.d.ts
@@ -246,6 +246,11 @@ export function removeImage(reference: string, force?: boolean): Promise<void>;
  * Multi-container application specification.
  */
 export interface ComposeSpec {
+  /** Compose project name — labels every container
+   *  (`perry.compose.project=<name>`) and namespaces non-external
+   *  volumes / networks as `<name>_<declared-name>`. Defaults to
+   *  `"perry-stack"` when omitted. */
+  name?: string;
   /** Compose file version */
   version?: string;
   /** Service definitions */

--- a/types/perry/container/index.d.ts
+++ b/types/perry/container/index.d.ts
@@ -28,6 +28,30 @@ export interface ContainerSpec {
   network?: string;
   /** Remove container on exit */
   rm?: boolean;
+  /** Container labels */
+  labels?: Record<string, string>;
+  /** Mount the root filesystem read-only */
+  read_only?: boolean;
+  /** Privileged mode — use sparingly (dropped with a warning on
+   *  apple/container, which has no privileged concept) */
+  privileged?: boolean;
+  /** UID, username, or `"UID:GID"` the container's processes run as */
+  user?: string;
+  /** Working directory inside the container */
+  workdir?: string;
+  /** Linux capabilities to add (e.g. `["NET_BIND_SERVICE"]`) */
+  cap_add?: string[];
+  /** Linux capabilities to drop (e.g. `["ALL"]`) */
+  cap_drop?: string[];
+  /** Seccomp profile: a path to a JSON profile file, or `"default"`
+   *  for the runtime's default profile. Emitted as
+   *  `--security-opt seccomp=<value>`. Dropped with a warning on
+   *  backends without seccomp support (apple/container). */
+  seccomp?: string;
+  /** Set `--security-opt no-new-privileges` so SUID/SGID binaries
+   *  inside the container can't gain privileges via execve. Dropped
+   *  with a warning on apple/container. */
+  no_new_privileges?: boolean;
 }
 
 /**
@@ -294,6 +318,11 @@ export interface ComposeService {
   cap_add?: string[];
   /** Linux capabilities to drop (e.g. `["ALL"]`) */
   cap_drop?: string[];
+  /** Security options (compose-spec § service.security_opt), e.g.
+   *  `["seccomp=default", "no-new-privileges"]`. Parsed into the
+   *  engine's `SecurityProfile`; entries a backend can't honor are
+   *  dropped with a warning. */
+  security_opt?: string[];
 }
 
 /**


### PR DESCRIPTION
Fixes three real gaps in `perry/container` / `perry/compose` found by the 2026-07-16 docs audit. One commit per bug; code-only (no version/CHANGELOG churn — maintainer folds metadata at merge).

## 1. ContainerSpec security opts were silently dropped on `run()`/`create()`

`ContainerSpec` had no `seccomp`/`no_new_privileges` fields, so those keys in the object passed to the public `run()`/`create()` FFI were discarded by serde, and `lifecycle.rs` always called plain `backend.run()`/`create()` — `run_with_security()` was unreachable from the single-container API. Users who wrote the documented hardening got the looser default with no signal.

- Spec-level `seccomp: Option<String>` + `no_new_privileges: Option<bool>` (serde `default` + `skip_serializing_if`, so existing serialized shapes are byte-identical), with `has_security_opts()` / `security_profile()` helpers that build the exact `SecurityProfile` shape `ComposeEngine::up` derives from `read_only` + `security_opt`.
- `js_container_run` / `js_container_create` route through `run_with_security()` / new `create_with_security()` when either field is set; the plain path is untouched otherwise (`read_only`/`cap_drop`/`user`/… are already emitted directly by `run_args`/`create_args`).
- New `ContainerBackend::create_with_security` (there was no security-aware create at all). `CliBackend` shares the capability-normalization + security-arg splicing with `run_with_security` via one `launch_with_security` helper; the splice is now a pure function (`splice_security_args`) so argv shapes are unit-testable.
- `ComposeService::to_container_spec` parses `security_opt` into the new fields and `run_command` routes through the security path, matching what `up()` already did.
- d.ts: `ContainerSpec` gains the security fields plus the already-wired fields the interface was missing (`labels`, `read_only`, `privileged`, `user`, `workdir`, `cap_add`, `cap_drop`); the compose `Service` / `ComposeService` interfaces gain `security_opt` so the engine's existing seccomp path is reachable from typed compose specs too. (These d.ts files are handwritten, not generated — `crates/perry/src/commands/types.rs` doesn't embed container/compose.)
- `docs/examples/stdlib/container/snippets.ts`'s `run-secure` anchor (`seccomp: "default"`) now matches a real field and actually reaches the runtime.

## 2. `ComposeSpec.name` missing from the typed API

The engine always read `spec.name` for project scoping — the `perry.compose.project` label and `<project>_<name>` namespacing of non-external volumes/networks (`project_scoped_name`) — but neither d.ts declared the field, so typed callers silently defaulted to project `"perry-stack"` and same-key volumes collided across stacks. Added `name?: string` to both `ComposeSpec` interfaces with the scoping semantics documented, plus tests pinning the JSON boundary and the `myproj_data` / `myproj_appnet` / label scoping.

## 3. `down()` `removeOrphans` was dead end to end

`ComposeEngine::down()` took `_remove_orphans: bool` and ignored it; the FFI parsed `removeOrphans` from the options JSON and discarded it; `DownOptions` in the d.ts didn't declare it. Now `down(remove_orphans: true)` sweeps containers that carry **this project's** `perry.compose.project` label but whose `perry.compose.service` key is no longer in the spec (service renamed/deleted between deploys), before network removal so orphans can't keep project networks alive. Strictly label-scoped: other projects' containers and unlabelled (non-Perry) containers are never candidates. Wired through `ComposeWrapper::down` and `js_container_compose_down`; the CLI's existing `--remove-orphans` flag takes effect for free.

**Stated limitation:** orphan identification relies on the `perry.compose.{project,service}` labels the engine stamps in `up()`. Containers created by pre-label Perry versions (or with hand-edited labels) are invisible to the sweep — `perry/container.downByProject()` remains the broader project-wide hammer. This matches how every other engine query (idempotency, `down_by_project`) identifies ownership, so it's the most faithful version the current scheme supports.

## Tests

`cargo test -p perry-container-compose`: **169 passed, 0 failed** across all 19 suites, including the new ones:

- JSON-boundary parse of security fields + routing invariant (`read_only`-only spec stays on the plain path)
- Docker run/create argv splicing (`--security-opt seccomp=…`, `no-new-privileges:true` before the image, cmd after), Apple drops seccomp but keeps `--read-only`
- `security_opt` → `to_container_spec` flow
- project name scopes volumes/networks/labels; `ComposeSpec.name` JSON round-trip
- orphan removed with the flag / preserved without it / other-project + unlabelled containers survive

`cargo check -p perry-stdlib --features container` clean (warnings pre-existing). `cargo fmt --all -- --check` clean; file-size gate clean.

**Not verified live:** no docker daemon was driven (arg-construction level only, per the crate's existing test strategy). The stdlib FFI end (`js_container_run` with a seccomp spec against a real backend) and `perry compose down --remove-orphans` against a live runtime remain to be smoke-tested by hand.

## Docs

`docs/src/container/{containers,security,compose,volumes}.md` updated to describe the now-working behavior (containers.md/security.md security-knob tables + routing note, compose.md `name:` + `removeOrphans` rows, volumes.md "Volume naming and ownership" rewritten — it previously claimed no project namespacing existed at all). Note for coordination: the 2026-07-16 docs-audit working tree carries uncommitted "not wired" corrections for these same passages; those three corrections are superseded by this PR (its other corrections — JSON return shapes, naming, `detectBackend`, workloads alpha notice — are untouched here and still apply).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-container security options for `seccomp` and `no_new_privileges`, including compose `security_opt` support.
  * Compose services can now use `name` to control project identity, labels, and namespacing.
  * `down(removeOrphans)` now supports removing stale containers for the active project.
  * Updated public type definitions for the new security, project, and cleanup options.

* **Bug Fixes**
  * Security settings are now applied consistently during container creation and startup.

* **Documentation**
  * Clarified security options, compose project naming/namespacing, and orphan cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->