### PR TITLE
fix(ui): restore App() frameless/level/transparent/vibrancy/activationPolicy wiring

### DIFF
--- a/crates/perry-codegen/src/lower_call/native/native_ui_appshell_branch.rs
+++ b/crates/perry-codegen/src/lower_call/native/native_ui_appshell_branch.rs
@@ -239,6 +239,11 @@
         let mut body_handle: String = "0".to_string();
         let mut icon_ptr: Option<String> = None;
         let mut window_state_ptr: Option<String> = None;
+        let mut frameless_val: Option<String> = None;
+        let mut level_ptr: Option<String> = None;
+        let mut transparent_val: Option<String> = None;
+        let mut vibrancy_ptr: Option<String> = None;
+        let mut activation_policy_ptr: Option<String> = None;
         for (key, val) in &props {
             match key.as_str() {
                 "title" => {
@@ -270,6 +275,37 @@
                     let blk = ctx.block();
                     window_state_ptr = Some(unbox_to_i64(blk, &v));
                 }
+                // v0.4.11 launcher-style window options, lost in the Phase K
+                // Cranelift→LLVM cutover (2026-07-16 docs audit). `frameless`
+                // and `transparent` are forwarded as the raw NaN-boxed value —
+                // every platform backend only acts when the bits equal
+                // TAG_TRUE, exactly like the original Cranelift wiring.
+                "frameless" => {
+                    frameless_val = Some(lower_expr(ctx, val)?);
+                }
+                "transparent" => {
+                    transparent_val = Some(lower_expr(ctx, val)?);
+                }
+                // `level` / `vibrancy` / `activationPolicy` are strings. Route
+                // through the SSO-safe unbox (js_get_string_pointer_unified)
+                // rather than the raw pointer mask: short literals like
+                // "modal" or "menu" can arrive as inline SSO values whose low
+                // 48 bits are not a StringHeader pointer.
+                "level" => {
+                    let v = lower_expr(ctx, val)?;
+                    let blk = ctx.block();
+                    level_ptr = Some(crate::expr::unbox_str_handle(blk, &v));
+                }
+                "vibrancy" => {
+                    let v = lower_expr(ctx, val)?;
+                    let blk = ctx.block();
+                    vibrancy_ptr = Some(crate::expr::unbox_str_handle(blk, &v));
+                }
+                "activationPolicy" => {
+                    let v = lower_expr(ctx, val)?;
+                    let blk = ctx.block();
+                    activation_policy_ptr = Some(crate::expr::unbox_str_handle(blk, &v));
+                }
                 _ => {
                     let _ = lower_expr(ctx, val)?;
                 }
@@ -287,6 +323,31 @@
         ));
         ctx.pending_declares.push((
             "perry_ui_app_set_window_state".to_string(),
+            crate::types::VOID,
+            vec![I64, I64],
+        ));
+        ctx.pending_declares.push((
+            "perry_ui_app_set_frameless".to_string(),
+            crate::types::VOID,
+            vec![I64, DOUBLE],
+        ));
+        ctx.pending_declares.push((
+            "perry_ui_app_set_level".to_string(),
+            crate::types::VOID,
+            vec![I64, I64],
+        ));
+        ctx.pending_declares.push((
+            "perry_ui_app_set_transparent".to_string(),
+            crate::types::VOID,
+            vec![I64, DOUBLE],
+        ));
+        ctx.pending_declares.push((
+            "perry_ui_app_set_vibrancy".to_string(),
+            crate::types::VOID,
+            vec![I64, I64],
+        ));
+        ctx.pending_declares.push((
+            "perry_ui_app_set_activation_policy".to_string(),
             crate::types::VOID,
             vec![I64, I64],
         ));
@@ -313,6 +374,34 @@
             blk.call_void(
                 "perry_ui_app_set_window_state",
                 &[(I64, &app_handle), (I64, &state_ptr)],
+            );
+        }
+        // Window properties are applied BEFORE the body so vibrancy /
+        // frameless can reconfigure the window (content view swap, style
+        // mask) before Auto Layout constraints are installed — same call
+        // order the Cranelift backend used (v0.4.11).
+        if let Some(v) = &frameless_val {
+            blk.call_void(
+                "perry_ui_app_set_frameless",
+                &[(I64, &app_handle), (DOUBLE, v)],
+            );
+        }
+        if let Some(p) = &level_ptr {
+            blk.call_void("perry_ui_app_set_level", &[(I64, &app_handle), (I64, p)]);
+        }
+        if let Some(v) = &transparent_val {
+            blk.call_void(
+                "perry_ui_app_set_transparent",
+                &[(I64, &app_handle), (DOUBLE, v)],
+            );
+        }
+        if let Some(p) = &vibrancy_ptr {
+            blk.call_void("perry_ui_app_set_vibrancy", &[(I64, &app_handle), (I64, p)]);
+        }
+        if let Some(p) = &activation_policy_ptr {
+            blk.call_void(
+                "perry_ui_app_set_activation_policy",
+                &[(I64, &app_handle), (I64, p)],
             );
         }
         blk.call_void(

--- a/crates/perry-codegen/tests/app_window_config_options.rs
+++ b/crates/perry-codegen/tests/app_window_config_options.rs
@@ -1,0 +1,195 @@
+//! Regression test: `App({...})` launcher-style window config keys.
+//!
+//! `frameless`, `level`, `transparent`, `vibrancy`, and `activationPolicy`
+//! were wired under the Cranelift backend (v0.4.11) but silently dropped in
+//! the Phase K Cranelift→LLVM cutover — the appshell branch only forwarded
+//! title/width/height/body/icon/windowState and lowered everything else for
+//! side effects only (2026-07-16 docs audit finding). These tests pin the
+//! restored wiring at the IR level: each present key must emit a call to its
+//! `perry_ui_app_set_*` FFI setter, and omitted keys must emit nothing.
+
+use perry_codegen::{compile_module, AppMetadata, CompileOptions};
+use perry_hir::{Expr, Function, Module, ModuleInitKind, Stmt};
+use perry_types::Type;
+
+fn empty_opts() -> CompileOptions {
+    CompileOptions {
+        target: None,
+        is_entry_module: false,
+        non_entry_module_prefixes: Vec::new(),
+        import_function_prefixes: std::collections::HashMap::new(),
+        import_function_ffi_aliases: std::collections::HashMap::new(),
+        import_function_origin_names: std::collections::HashMap::new(),
+        import_function_v8_specifiers: std::collections::HashMap::new(),
+        import_function_node_submodule: std::collections::HashMap::new(),
+        namespace_node_submodules: std::collections::HashMap::new(),
+        namespace_v8_specifiers: std::collections::HashMap::new(),
+        namespace_member_prefixes: std::collections::HashMap::new(),
+        namespace_member_origin_names: std::collections::HashMap::new(),
+        emit_ir_only: true,
+        verify_native_regions: false,
+        disable_buffer_fast_path: false,
+        namespace_imports: Vec::new(),
+        imported_classes: Vec::new(),
+        imported_enums: Vec::new(),
+        imported_async_funcs: std::collections::HashSet::new(),
+        type_aliases: std::collections::HashMap::new(),
+        imported_func_param_counts: std::collections::HashMap::new(),
+        imported_func_has_rest: std::collections::HashSet::new(),
+        imported_func_synthetic_arguments: std::collections::HashSet::new(),
+        imported_func_return_types: std::collections::HashMap::new(),
+        imported_vars: std::collections::HashSet::new(),
+        output_type: "executable".to_string(),
+        needs_stdlib: false,
+        needs_ui: false,
+        needs_geisterhand: false,
+        geisterhand_port: 7676,
+        enabled_features: Vec::new(),
+        native_module_init_names: Vec::new(),
+        js_module_specifiers: Vec::new(),
+        bundled_extensions: Vec::new(),
+        native_library_functions: Vec::new(),
+        i18n_table: None,
+        fast_math: false,
+        fp_contract_mode: perry_codegen::FpContractMode::Off,
+        app_metadata: AppMetadata::default(),
+        namespace_entries: Vec::new(),
+        dynamic_import_path_to_prefix: std::collections::HashMap::new(),
+        nextjs_path_init_modules: Vec::new(),
+        deferred_module_prefixes: std::collections::HashSet::new(),
+        module_init_deps: Vec::new(),
+        is_dynamic_import_target: false,
+        debug_locations: false,
+        module_source: None,
+        debug_source_line_offset: 0,
+    }
+}
+
+fn module(name: &str, body: Vec<Stmt>) -> Module {
+    Module {
+        name: name.to_string(),
+        imports: Vec::new(),
+        exports: Vec::new(),
+        classes: Vec::new(),
+        interfaces: Vec::new(),
+        type_aliases: Vec::new(),
+        enums: Vec::new(),
+        globals: Vec::new(),
+        functions: vec![Function {
+            id: 1,
+            name: "probe".to_string(),
+            type_params: Vec::new(),
+            params: Vec::new(),
+            return_type: Type::Number,
+            body,
+            is_async: false,
+            is_generator: false,
+            is_strict: false,
+            is_exported: false,
+            captures: Vec::new(),
+            decorators: Vec::new(),
+            was_plain_async: false,
+            was_unrolled: false,
+        }],
+        init: Vec::new(),
+        exported_native_instances: Vec::new(),
+        exported_func_return_native_instances: Vec::new(),
+        exported_objects: Vec::new(),
+        exported_functions: Vec::new(),
+        script_global_functions: Vec::new(),
+        references_global_this: false,
+        annexb_global_undefined_names: Vec::new(),
+        widgets: Vec::new(),
+        uses_fetch: false,
+        uses_webassembly: false,
+        extern_funcs: Vec::new(),
+        init_was_unrolled: false,
+        has_top_level_await: false,
+        init_kind: ModuleInitKind::Eager,
+        async_step_closures: std::collections::HashSet::new(),
+        closure_display_names: std::collections::HashMap::new(),
+        class_display_names: std::collections::HashMap::new(),
+        closure_source_text: std::collections::HashMap::new(),
+        async_generator_funcs: std::collections::HashSet::new(),
+        gen_param_prologue_len: std::collections::HashMap::new(),
+    }
+}
+
+fn app_call(config: Vec<(&str, Expr)>) -> Stmt {
+    Stmt::Expr(Expr::NativeMethodCall {
+        module: "perry/ui".to_string(),
+        class_name: None,
+        object: None,
+        method: "App".to_string(),
+        args: vec![Expr::Object(
+            config
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v))
+                .collect(),
+        )],
+    })
+}
+
+fn compile_ir(name: &str, body: Vec<Stmt>) -> String {
+    String::from_utf8(compile_module(&module(name, body), empty_opts()).unwrap()).unwrap()
+}
+
+const WINDOW_OPTION_SETTERS: [&str; 5] = [
+    "call void @perry_ui_app_set_frameless",
+    "call void @perry_ui_app_set_level",
+    "call void @perry_ui_app_set_transparent",
+    "call void @perry_ui_app_set_vibrancy",
+    "call void @perry_ui_app_set_activation_policy",
+];
+
+#[test]
+fn app_config_window_options_emit_ffi_calls() {
+    let ir = compile_ir(
+        "app_window_opts_all",
+        vec![app_call(vec![
+            ("title", Expr::String("Launcher".to_string())),
+            ("width", Expr::Number(600.0)),
+            ("height", Expr::Number(80.0)),
+            ("body", Expr::Number(0.0)),
+            ("frameless", Expr::Bool(true)),
+            ("level", Expr::String("floating".to_string())),
+            ("transparent", Expr::Bool(true)),
+            ("vibrancy", Expr::String("sidebar".to_string())),
+            ("activationPolicy", Expr::String("accessory".to_string())),
+        ])],
+    );
+    for setter in WINDOW_OPTION_SETTERS {
+        assert!(
+            ir.contains(setter),
+            "App() config key must lower to `{setter}` — the key was silently \
+             dropped (Cranelift→LLVM migration regression). IR:\n{ir}"
+        );
+    }
+    // Window options must be applied before the body is attached so
+    // vibrancy/frameless reconfigure the window ahead of Auto Layout.
+    let vibrancy_at = ir.find("call void @perry_ui_app_set_vibrancy").unwrap();
+    let body_at = ir.find("call void @perry_ui_app_set_body").unwrap();
+    assert!(
+        vibrancy_at < body_at,
+        "perry_ui_app_set_vibrancy must be emitted before perry_ui_app_set_body"
+    );
+}
+
+#[test]
+fn app_config_without_window_options_emits_no_setter_calls() {
+    let ir = compile_ir(
+        "app_window_opts_none",
+        vec![app_call(vec![
+            ("title", Expr::String("Plain".to_string())),
+            ("width", Expr::Number(1024.0)),
+            ("height", Expr::Number(768.0)),
+            ("body", Expr::Number(0.0)),
+        ])],
+    );
+    for setter in WINDOW_OPTION_SETTERS {
+        assert!(
+            !ir.contains(setter),
+            "omitted App() config key must not emit `{setter}`. IR:\n{ir}"
+        );
+    }
+}

--- a/docs/examples/ui/multi_window/snippets.ts
+++ b/docs/examples/ui/multi_window/snippets.ts
@@ -35,6 +35,11 @@ App({
     title: "QuickLaunch",
     width: 600,
     height: 80,
+    frameless: true,             // borderless window, movable by background
+    level: "floating",           // stays above normal windows
+    transparent: true,           // desktop shows through non-opaque regions
+    vibrancy: "sidebar",         // native translucent background material
+    activationPolicy: "accessory", // no dock icon — launcher-style app
     body: VStack(8, [
         Text("Search..."),
         Button("Open Settings", () => settings.show()),

--- a/docs/src/ui/multi-window.md
+++ b/docs/src/ui/multi-window.md
@@ -39,7 +39,11 @@ building launcher-style, overlay, or utility apps:
 ```
 
 `App` additionally accepts the optional fields `frameless`, `level`,
-`transparent`, `vibrancy`, `activationPolicy`, and `icon`. They map to the
+`transparent`, `vibrancy`, `activationPolicy`, and `icon`. Each present
+field is applied to the window right after creation — before the body
+widget is attached, so vibrancy and frameless reconfigure the window ahead
+of layout. (`activationPolicy` is also settable at runtime via the
+standalone `appSetActivationPolicy(policy)` function.) They map to the
 following native primitives:
 
 ### `frameless: true`

--- a/docs/src/ui/overview.md
+++ b/docs/src/ui/overview.md
@@ -38,13 +38,16 @@ Every Perry UI app starts with `App()`:
 | `height` | number | Initial window height |
 | `body` | widget | Root widget |
 | `icon` | string | App icon file path (optional) |
+| `windowState` | string | Initial state: `"normal"`, `"maximized"`, `"fullscreen"` (optional) |
 | `frameless` | boolean | Remove title bar (optional) |
 | `level` | string | Window z-order: `"floating"`, `"statusBar"`, `"modal"` (optional) |
 | `transparent` | boolean | Transparent background (optional) |
 | `vibrancy` | string | Native blur material, e.g. `"sidebar"` (optional) |
 | `activationPolicy` | string | `"regular"`, `"accessory"` (no dock icon), `"background"` (optional) |
 
-See [Multi-Window](multi-window.md) for full documentation on window properties.
+See [Multi-Window](multi-window.md#app-window-properties) for full
+documentation on window properties, including the native primitive each
+field maps to per platform.
 
 ### Lifecycle Hooks
 

--- a/types/perry/ui/index.d.ts
+++ b/types/perry/ui/index.d.ts
@@ -231,6 +231,35 @@ export function App(config: {
      * Issue #1280.
      */
     windowState?: "normal" | "maximized" | "fullscreen";
+    /**
+     * Remove the window title bar and frame (borderless window, movable
+     * by background). v0.4.11 launcher-style option.
+     */
+    frameless?: boolean;
+    /**
+     * Window z-order level: `"floating"` stays above normal windows,
+     * `"statusBar"` above floating ones, `"modal"` is the modal-panel
+     * level, `"normal"` (default) is the ordinary level.
+     */
+    level?: "normal" | "floating" | "statusBar" | "modal";
+    /** Transparent window background (desktop shows through). */
+    transparent?: boolean;
+    /**
+     * Native translucent background material (NSVisualEffectView on
+     * macOS, Mica/Acrylic on Windows 11, best-effort CSS alpha on GTK4).
+     * macOS materials: "sidebar" (default fallback), "titlebar",
+     * "selection", "menu", "popover", "headerView", "sheet",
+     * "windowBackground", "hudWindow", "fullScreenUI", "tooltip",
+     * "contentBackground", "underWindowBackground", "underPageBackground".
+     */
+    vibrancy?: string;
+    /**
+     * Dock/taskbar presence: `"regular"` (default) shows a dock icon,
+     * `"accessory"` hides the dock icon (launcher/utility apps),
+     * `"background"` hides the app from dock and app switcher entirely.
+     * Also available at runtime via `appSetActivationPolicy(policy)`.
+     */
+    activationPolicy?: "regular" | "accessory" | "background";
 }): void;
 
 /** Vertical stack layout. */


### PR DESCRIPTION
## Summary

`App({...})` documented config keys `frameless`, `level`, `transparent`, `vibrancy`, and `activationPolicy` were silently discarded. They were wired under the old Cranelift backend (CHANGELOG v0.4.9, extended v0.4.11/v0.4.12) and lost in the Phase K Cranelift → LLVM cutover: the LLVM appshell branch (`crates/perry-codegen/src/lower_call/native/native_ui_appshell_branch.rs`) only forwarded `title`/`width`/`height`/`body`/`icon`/`windowState` and lowered every other key for side effects only. Found in the 2026-07-16 docs audit, confirmed empirically via `--trace llvm` (zero FFI refs emitted).

All five `perry_ui_app_set_*` FFI setters still exist in every backend with unchanged signatures — macOS real implementations (`crates/perry-ui-macos/src/app.rs`), GTK4/Windows real, iOS/tvOS/watchOS/visionOS/Android no-op stubs (same graceful degradation as `windowState`) — so this is codegen-only wiring plus type-surface/docs/test updates.

## What changed

- **`crates/perry-codegen/src/lower_call/native/native_ui_appshell_branch.rs`** — destructure the five keys from the `App({...})` config object, declare the five externs, and emit the calls after `perry_ui_app_set_window_state` and **before** `perry_ui_app_set_body` (the v0.4.11 Cranelift order: vibrancy/frameless must reconfigure the window before Auto Layout constraints are installed).
  - `frameless` / `transparent` (**boolean**): forwarded as the raw NaN-boxed value; every backend setter acts only when the bits equal `TAG_TRUE` — identical to the original Cranelift semantics.
  - `level` (**string**: `"normal" | "floating" | "statusBar" | "modal"`), `vibrancy` (**string**: NSVisualEffectView material name, e.g. `"sidebar"`), `activationPolicy` (**string**: `"regular" | "accessory" | "background"`): routed through the SSO-safe unbox (`js_get_string_pointer_unified`) rather than the raw pointer mask, so short literals like `"modal"` can't hand the FFI inline-SSO garbage bits. Numeric `level` is not supported by the FFI (it takes a string pointer and maps names to `NSWindowLevel` values); the string forms above are what shipped in v0.4.x and what this restores.
- **`types/perry/ui/index.d.ts`** — the five keys were documented in `docs/src/ui/multi-window.md` but absent from the `App()` config type; they are now declared with the exact accepted value unions.
- **`crates/perry-codegen/tests/app_window_config_options.rs`** — IR-level regression test: an `App({...})` with all five keys must emit all five `call void @perry_ui_app_set_*` instructions (and vibrancy before `app_set_body`); an `App({...})` without them must emit none.
- **`docs/src/ui/overview.md` / `docs/src/ui/multi-window.md`** — documented apply-order semantics, the `appSetActivationPolicy(policy)` runtime alternative, added the missing `windowState` row to the overview table.
- **`docs/examples/ui/multi_window/snippets.ts`** — the CI-compiled `app-config` snippet now exercises all five keys, so the doc-example harness covers the wiring on every PR.

## Verification (macOS arm64)

### (a) `--trace llvm` — the audit's absence proof, inverted

```
$ perry app_window_opts.ts --trace llvm -o probe
$ grep -n "perry_ui_app" .perry-trace/llvm/app_window_opts_ts.ll | grep call
3722:  %r27 = call i64 @perry_ui_app_create(i64 %r3, double 420.0, double 160.0)
3723:  call void @perry_ui_app_set_frameless(i64 %r27, double %r5)
3724:  call void @perry_ui_app_set_level(i64 %r27, i64 %r7)
3725:  call void @perry_ui_app_set_transparent(i64 %r27, double %r9)
3726:  call void @perry_ui_app_set_vibrancy(i64 %r27, i64 %r11)
3727:  call void @perry_ui_app_set_activation_policy(i64 %r27, i64 %r13)
3728:  call void @perry_ui_app_set_body(i64 %r27, i64 %r26)
3729:  call void @perry_ui_app_run(i64 %r27)
```

### (b) IR regression test

```
$ cargo test -p perry-codegen --test app_window_config_options
test app_config_without_window_options_emits_no_setter_calls ... ok
test app_config_window_options_emit_ffi_calls ... ok
```

### (c) Runtime evidence

Temporary `eprintln!` probes in the five macOS FFI setters (local only, not committed), app compiled through the real `perry compile` flow (fresh binary, mtime checked) and run with `PERRY_UI_TEST_MODE=1 PERRY_UI_TEST_EXIT_AFTER_MS=500` — renders one frame (borderless, floating, vibrant) and exits 0:

```
[TEMP-VERIFY] perry_ui_app_set_frameless(handle=1, bits=0x7ffc000000000004)
[TEMP-VERIFY] perry_ui_app_set_level(handle=1)
[TEMP-VERIFY] perry_ui_app_set_transparent(handle=1, bits=0x7ffc000000000004)
[TEMP-VERIFY] perry_ui_app_set_vibrancy(handle=1)
[TEMP-VERIFY] perry_ui_app_set_activation_policy(handle=1)
```

`frameless`/`transparent` arrive as NaN-boxed `TAG_TRUE` (`0x7ffc000000000004`). Negative control: a plain `App({title,width,height,body})` binary fires zero probes and exits 0 — omitted keys emit and execute nothing.

### Caveat

The runtime runs used `PERRY_NO_AUTO_OPTIMIZE=1` (the same flow as CI doc-tests). The default auto-optimize flow could not be exercised in a `perry-dev`-profile dev tree at all — it fails to link **any** UI app (verified with a keys-free control app) because strip-dedup dedups `libperry_ui_macos.a` against the exe-adjacent perry-dev `libperry_{stdlib,runtime}.a` while the link then uses the freshly built `target/perry-auto-<hash>/release` pair, leaving std-internal symbols (`miniz_oxide`/`rustc_demangle`/`addr2line`) unresolved. Pre-existing, profile-mixing, unrelated to this change. (Also hit a second pre-existing local-only trap: incremental-profile rlibs name CGU members without `-cgu.`, so strip-dedup's `is_alloc_shim` heuristic skips every rlib object; workaround `CARGO_INCREMENTAL=0`.)
