### PR TITLE
fix(system): macOS getDeviceIdiom/getDeviceModel — real values, correct NaN-boxed ABI

### DIFF
--- a/crates/perry-codegen-js/src/emit/calls.rs
+++ b/crates/perry-codegen-js/src/emit/calls.rs
@@ -69,6 +69,9 @@ impl JsEmitter {
                 }
                 self.output.push(')');
             }
+            "getDeviceIdiom" | "get_device_idiom" => {
+                self.output.push_str("perry_get_device_idiom()");
+            }
             "getDeviceModel" | "get_device_model" => {
                 self.output.push_str("perry_system_get_device_model()");
             }

--- a/crates/perry-codegen-js/src/web_runtime.js
+++ b/crates/perry-codegen-js/src/web_runtime.js
@@ -3153,7 +3153,19 @@ function perry_get_scale_factor()  { return window.devicePixelRatio || 1; }
 function perry_has_hardware_keyboard() { return true; }
 function perry_get_platform() { return "web"; }
 function perry_get_orientation() { return window.innerWidth > window.innerHeight ? "landscape" : "portrait"; }
-function perry_get_device_idiom() { return 0; } // 0 = not a tablet/phone on web
+// Broad form factor per the perry/system contract: "phone" | "pad" |
+// "mac" | "tv" | "watch" | "vision" | "desktop" (was the numeric 0).
+function perry_get_device_idiom() {
+    const ua = (typeof navigator !== "undefined" && navigator.userAgent) || "";
+    // iPadOS 13+ Safari reports "Macintosh" in its desktop-mode UA; the
+    // touch-point count is the standard tell.
+    const touchPoints = (typeof navigator !== "undefined" && navigator.maxTouchPoints) || 0;
+    if (/iPad/i.test(ua) || (/Macintosh/i.test(ua) && touchPoints > 1)) return "pad";
+    if (/Android/i.test(ua) && !/Mobile/i.test(ua)) return "pad";
+    if (/iPhone|Android|Mobile/i.test(ua)) return "phone";
+    if (/Macintosh/i.test(ua)) return "mac";
+    return "desktop";
+}
 function perry_on_layout_change(callback) {
     if (typeof callback === "function") {
         window.addEventListener("resize", function() { callback(); });

--- a/crates/perry-dispatch/src/system_table.rs
+++ b/crates/perry-dispatch/src/system_table.rs
@@ -9,11 +9,20 @@ pub static PERRY_SYSTEM_TABLE: &[MethodRow] = &[
         args: &[],
         ret: ReturnKind::F64,
     },
+    // Returns the broad device form factor as a JS string: "phone",
+    // "pad", "mac", "tv", "watch", "vision", or "desktop" — the contract
+    // documented in types/perry/system/index.d.ts and docs/src/system/.
+    // The platform FFIs return a raw `*mut StringHeader` (i64) via
+    // `js_string_from_bytes`, so the return kind MUST be `Str` (NaN-box
+    // with STRING_TAG) — same shape as `getDeviceModel` below. This row
+    // was `F64` while the impls returned numeric codes (0 = phone,
+    // 1 = pad, 4 = watch) that nothing ever mapped to the documented
+    // strings, so `getDeviceIdiom() === "mac"` could never be true.
     MethodRow {
         method: "getDeviceIdiom",
         runtime: "perry_get_device_idiom",
         args: &[],
-        ret: ReturnKind::F64,
+        ret: ReturnKind::Str,
     },
     // #1475 — safe-area insets. Returns `{ top, right, bottom, left }` (points)
     // read from `UIWindow.safeAreaInsets` (iOS) / `WindowInsets.systemBars()`

--- a/crates/perry-ui-android/src/ffi/embed_misc.rs
+++ b/crates/perry-ui-android/src/ffi/embed_misc.rs
@@ -137,10 +137,17 @@ pub extern "C" fn perry_get_scale_factor() -> f64 {
     query_display_metrics().2
 }
 
+/// perry_get_device_idiom() → "phone" (raw `*mut StringHeader`, NaN-boxed
+/// by the `ReturnKind::Str` dispatch row). Android tablets are not yet
+/// discriminated (needs a JNI smallest-width check); report the phone
+/// form factor, matching the previous numeric code 0.
 #[no_mangle]
 pub extern "C" fn perry_get_device_idiom() -> i64 {
-    0
-} // 0 = phone
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    unsafe { js_string_from_bytes(b"phone".as_ptr(), 5) }
+}
 
 // Audio capture (AudioRecord via JNI)
 #[no_mangle]

--- a/crates/perry-ui-gtk4/src/ffi/platform_audio_camera_toast.rs
+++ b/crates/perry-ui-gtk4/src/ffi/platform_audio_camera_toast.rs
@@ -87,12 +87,14 @@ pub extern "C" fn perry_ui_poll_open_file() -> i64 {
     unsafe { js_string_from_bytes(std::ptr::null(), 0) as i64 }
 }
 
-/// perry_get_device_idiom() → 0 — Linux is always a desktop (not phone or pad).
-/// Called by iOS-specific branches in platform.ts that are dead code on Linux;
-/// the symbol must exist for the linker even though it is never called at runtime.
+/// perry_get_device_idiom() → "desktop" — Linux is always a desktop (not
+/// phone or pad). Returns a raw `*mut StringHeader` (i64); the
+/// `ReturnKind::Str` dispatch row NaN-boxes it with STRING_TAG. (The
+/// dispatch row declares no arguments — the previous `_closure_ptr`
+/// parameter was a copy-paste leftover.)
 #[no_mangle]
-pub extern "C" fn perry_get_device_idiom(_closure_ptr: i64) -> f64 {
-    0.0 // 0 = phone-like; value is irrelevant on Linux (dead code branch)
+pub extern "C" fn perry_get_device_idiom() -> i64 {
+    unsafe { js_string_from_bytes(b"desktop".as_ptr(), 7) as i64 }
 }
 
 // Audio capture (PulseAudio simple API)

--- a/crates/perry-ui-ios/src/ffi/dialogs_lifecycle.rs
+++ b/crates/perry-ui-ios/src/ffi/dialogs_lifecycle.rs
@@ -189,11 +189,16 @@ pub extern "C" fn perry_get_orientation() -> f64 {
     }
 }
 
-/// perry_get_device_idiom() → 0 = phone, 1 = pad
+/// perry_get_device_idiom() → "phone" | "pad" — the device form-factor
+/// string per the perry/system contract. Returns a raw `*mut StringHeader`
+/// (i64); the `ReturnKind::Str` dispatch row NaN-boxes it with STRING_TAG.
 /// Uses UIDevice.model string comparison (more reliable than userInterfaceIdiom
 /// which can return 0 before full UIApplication init on iOS 26 simulator).
 #[no_mangle]
-pub extern "C" fn perry_get_device_idiom() -> f64 {
+pub extern "C" fn perry_get_device_idiom() -> i64 {
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
     unsafe {
         let device_cls = objc2::runtime::AnyClass::get(c"UIDevice").unwrap();
         let current: *mut objc2::runtime::AnyObject = objc2::msg_send![device_cls, currentDevice];
@@ -202,17 +207,13 @@ pub extern "C" fn perry_get_device_idiom() -> f64 {
         let model: *mut objc2::runtime::AnyObject = objc2::msg_send![current, model];
         let utf8: *const u8 = objc2::msg_send![model, UTF8String];
         if !utf8.is_null() {
-            // "iPad" starts with 'i' (0x69) then 'P' (0x50)
-            // "iPhone" starts with 'i' (0x69) then 'P' (0x50) too...
-            // Actually: "iPad" has 4 chars, "iPhone" has 6 chars
-            // Check 3rd char: 'a' (0x61) for iPad vs 'h' (0x68) for iPhone
+            // "iPad" vs "iPhone": check 3rd char, 'a' (iPad) vs 'h' (iPhone).
             let third = *utf8.add(2);
             if third == b'a' {
-                // "iPad"
-                return 1.0;
+                return js_string_from_bytes(b"pad".as_ptr(), 3);
             }
         }
-        0.0
+        js_string_from_bytes(b"phone".as_ptr(), 5)
     }
 }
 

--- a/crates/perry-ui-macos/src/audio.rs
+++ b/crates/perry-ui-macos/src/audio.rs
@@ -298,8 +298,11 @@ pub fn get_waveform(count: f64) -> f64 {
     }
 }
 
-/// Get the device model identifier string (e.g., "MacBookPro18,3").
-/// Returns a NaN-boxed string pointer.
+/// Get the device model identifier string (e.g., "MacBookPro18,3"),
+/// read from sysctl `hw.model`. Returns a raw `*mut StringHeader` (i64)
+/// via `js_string_from_bytes`; the `ReturnKind::Str` dispatch row
+/// NaN-boxes it with STRING_TAG (#5972 — declaring it `F64` passed the
+/// pointer bits through as a double and callers read `NaN`).
 pub fn get_device_model() -> i64 {
     let model = get_sysctl_model();
     unsafe { js_string_from_bytes(model.as_ptr(), model.len() as i32) }

--- a/crates/perry-ui-macos/src/lib_ffi/window_misc.rs
+++ b/crates/perry-ui-macos/src/lib_ffi/window_misc.rs
@@ -206,9 +206,19 @@ pub extern "C" fn perry_get_orientation() -> i64 {
 #[no_mangle]
 pub extern "C" fn perry_on_layout_change(_callback: f64) {}
 
+/// perry_get_device_idiom() → "mac" — the device form-factor string for
+/// macOS per the perry/system contract ("phone" / "pad" / "mac" / "tv" /
+/// "watch" / "vision" / "desktop"). Returns a raw `*mut StringHeader`
+/// (i64); the dispatch row is `ReturnKind::Str`, so codegen NaN-boxes it
+/// with STRING_TAG. Not a screen-detection stub: this used to return the
+/// numeric phone code (0.0) here, which both violated the string contract
+/// and misreported a Mac as a phone.
 #[no_mangle]
-pub extern "C" fn perry_get_device_idiom() -> f64 {
-    0.0
+pub extern "C" fn perry_get_device_idiom() -> i64 {
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    unsafe { js_string_from_bytes(b"mac".as_ptr(), 3) }
 }
 
 // --- TabBar stubs (not yet implemented for macOS) ---

--- a/crates/perry-ui-tvos/src/ffi/dialogs_screen.rs
+++ b/crates/perry-ui-tvos/src/ffi/dialogs_screen.rs
@@ -186,29 +186,15 @@ pub extern "C" fn perry_get_orientation() -> f64 {
     }
 }
 
-/// perry_get_device_idiom() → 0 = phone, 1 = pad
-/// Uses UIDevice.model string comparison (more reliable than userInterfaceIdiom
-/// which can return 0 before full UIApplication init on iOS 26 simulator).
+/// perry_get_device_idiom() → "tv" — this crate only ever runs on tvOS,
+/// so the form factor is static. Returns a raw `*mut StringHeader` (i64);
+/// the `ReturnKind::Str` dispatch row NaN-boxes it with STRING_TAG. (The
+/// previous body was an iOS copy-paste that probed UIDevice.model for
+/// iPad/iPhone and reported an Apple TV as the numeric phone code.)
 #[no_mangle]
-pub extern "C" fn perry_get_device_idiom() -> f64 {
-    unsafe {
-        let device_cls = objc2::runtime::AnyClass::get(c"UIDevice").unwrap();
-        let current: *mut objc2::runtime::AnyObject = objc2::msg_send![device_cls, currentDevice];
-
-        // Check UIDevice.model — returns @"iPad" on iPad, @"iPhone" on iPhone
-        let model: *mut objc2::runtime::AnyObject = objc2::msg_send![current, model];
-        let utf8: *const u8 = objc2::msg_send![model, UTF8String];
-        if !utf8.is_null() {
-            // "iPad" starts with 'i' (0x69) then 'P' (0x50)
-            // "iPhone" starts with 'i' (0x69) then 'P' (0x50) too...
-            // Actually: "iPad" has 4 chars, "iPhone" has 6 chars
-            // Check 3rd char: 'a' (0x61) for iPad vs 'h' (0x68) for iPhone
-            let third = *utf8.add(2);
-            if third == b'a' {
-                // "iPad"
-                return 1.0;
-            }
-        }
-        0.0
+pub extern "C" fn perry_get_device_idiom() -> i64 {
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
     }
+    unsafe { js_string_from_bytes(b"tv".as_ptr(), 2) }
 }

--- a/crates/perry-ui-visionos/src/ffi_system.rs
+++ b/crates/perry-ui-visionos/src/ffi_system.rs
@@ -686,31 +686,19 @@ pub extern "C" fn perry_get_orientation() -> f64 {
     }
 }
 
-/// perry_get_device_idiom() → 0 = phone, 1 = pad
-/// Uses UIDevice.model string comparison (more reliable than userInterfaceIdiom
-/// which can return 0 before full UIApplication init on iOS 26 simulator).
+/// perry_get_device_idiom() → "vision" — this crate only ever runs on
+/// visionOS, so the form factor is static (mirrors Apple's
+/// `UIUserInterfaceIdiom.vision`). Returns a raw `*mut StringHeader`
+/// (i64); the `ReturnKind::Str` dispatch row NaN-boxes it with
+/// STRING_TAG. (The previous body was an iOS copy-paste that probed
+/// UIDevice.model for iPad/iPhone and reported a Vision Pro as the
+/// numeric phone code.)
 #[no_mangle]
-pub extern "C" fn perry_get_device_idiom() -> f64 {
-    unsafe {
-        let device_cls = objc2::runtime::AnyClass::get(c"UIDevice").unwrap();
-        let current: *mut objc2::runtime::AnyObject = objc2::msg_send![device_cls, currentDevice];
-
-        // Check UIDevice.model — returns @"iPad" on iPad, @"iPhone" on iPhone
-        let model: *mut objc2::runtime::AnyObject = objc2::msg_send![current, model];
-        let utf8: *const u8 = objc2::msg_send![model, UTF8String];
-        if !utf8.is_null() {
-            // "iPad" starts with 'i' (0x69) then 'P' (0x50)
-            // "iPhone" starts with 'i' (0x69) then 'P' (0x50) too...
-            // Actually: "iPad" has 4 chars, "iPhone" has 6 chars
-            // Check 3rd char: 'a' (0x61) for iPad vs 'h' (0x68) for iPhone
-            let third = *utf8.add(2);
-            if third == b'a' {
-                // "iPad"
-                return 1.0;
-            }
-        }
-        0.0
+pub extern "C" fn perry_get_device_idiom() -> i64 {
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
     }
+    unsafe { js_string_from_bytes(b"vision".as_ptr(), 6) }
 }
 
 // =============================================================================

--- a/crates/perry-ui-watchos/src/lib.rs
+++ b/crates/perry-ui-watchos/src/lib.rs
@@ -1533,10 +1533,15 @@ pub extern "C" fn perry_get_scale_factor() -> f64 {
 pub extern "C" fn perry_get_orientation() -> f64 {
     0.0
 }
+/// perry_get_device_idiom() → "watch" (raw `*mut StringHeader`, NaN-boxed
+/// by the `ReturnKind::Str` dispatch row). Was the bare numeric code 4.0.
 #[no_mangle]
-pub extern "C" fn perry_get_device_idiom() -> f64 {
-    4.0
-} // 4 = watch
+pub extern "C" fn perry_get_device_idiom() -> i64 {
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    unsafe { js_string_from_bytes(b"watch".as_ptr(), 5) }
+}
 #[no_mangle]
 pub extern "C" fn perry_ui_camera_create() -> i64 {
     0

--- a/crates/perry-ui-windows/src/ffi/screen_audio.rs
+++ b/crates/perry-ui-windows/src/ffi/screen_audio.rs
@@ -32,9 +32,15 @@ pub extern "C" fn perry_get_orientation() -> i64 {
     0
 }
 
+/// perry_get_device_idiom() → "desktop" (raw `*mut StringHeader`,
+/// NaN-boxed by the `ReturnKind::Str` dispatch row). Was the bare
+/// numeric phone code 0.0.
 #[no_mangle]
-pub extern "C" fn perry_get_device_idiom() -> f64 {
-    0.0
+pub extern "C" fn perry_get_device_idiom() -> i64 {
+    extern "C" {
+        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
+    }
+    unsafe { js_string_from_bytes(b"desktop".as_ptr(), 7) }
 }
 
 // Audio capture (WASAPI)

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -1233,6 +1233,17 @@ fn collect_module_one(
                             // UIFeedbackGenerator / VibrationEffect /
                             // NSHapticFeedbackManager), not perry-stdlib.
                             | "hapticPlay"
+                            // Device identity: perry_get_device_idiom and
+                            // perry_system_get_device_model also live only
+                            // in the platform UI crates (UIDevice /
+                            // sysctl hw.model / JNI Build.MODEL). Without
+                            // this trigger, a console program importing
+                            // only these fails to link ("undefined symbol:
+                            // perry_get_device_idiom") — the #5972
+                            // regression test had to import a perry/ui
+                            // widget just to make the link succeed.
+                            | "getDeviceIdiom"
+                            | "getDeviceModel"
                     ),
                     // Namespace imports — opt in conservatively (covers
                     // `import * as system from "perry/system"; system.audioStartRecording()`).

--- a/docs/src/system/other.md
+++ b/docs/src/system/other.md
@@ -53,9 +53,12 @@ Clipboard helpers live in `perry/ui` (not `perry/system`):
 {{#include ../../examples/system/snippets.ts:device}}
 ```
 
-`getDeviceIdiom()` returns the broad form factor (`"phone"`, `"pad"`, `"mac"`,
-`"tv"`, …); `getDeviceModel()` returns the platform-specific model identifier
-(`"iPhone15,2"`, `"MacBookPro18,3"`, etc.).
+`getDeviceIdiom()` returns the broad form factor as a string: `"phone"` or
+`"pad"` on iOS (and `"phone"` on Android), `"mac"` on macOS, `"tv"` on tvOS,
+`"watch"` on watchOS, `"vision"` on visionOS, and `"desktop"` on Windows and
+Linux. `getDeviceModel()` returns the platform-specific model identifier
+(`"iPhone15,2"`, `"MacBookPro18,3"`, etc. — on macOS this is sysctl
+`hw.model`).
 
 ## Next Steps
 

--- a/docs/src/system/overview.md
+++ b/docs/src/system/overview.md
@@ -16,7 +16,7 @@ links the file on every PR.
 |----------|------------|-----------|
 | `openURL(url)` | Open URL in default browser/app | All |
 | `isDarkMode()` | Check system dark mode | All |
-| `getDeviceIdiom()` | `"phone"`, `"pad"`, `"mac"`, `"tv"`, … | All |
+| `getDeviceIdiom()` | `"phone"`, `"pad"`, `"mac"`, `"tv"`, `"watch"`, `"vision"`, `"desktop"` | All |
 | `getDeviceModel()` | Device model identifier (e.g. `"iPhone13,4"`) | All |
 | `preferencesSet(key, value)` | Store a preference (string or number) | All |
 | `preferencesGet(key)` | Read a preference (returns `string | number | undefined`) | All |

--- a/types/perry/system/index.d.ts
+++ b/types/perry/system/index.d.ts
@@ -9,7 +9,10 @@
 /** Returns true if the system is in dark mode. */
 export function isDarkMode(): boolean;
 
-/** Returns the device idiom (e.g. "phone", "pad", "mac", "tv"). */
+/**
+ * Returns the device form factor: "phone" | "pad" | "mac" | "tv" |
+ * "watch" | "vision" | "desktop" ("desktop" on Windows/Linux).
+ */
 export function getDeviceIdiom(): string;
 
 /** The device's safe-area insets in points (status bar / Dynamic Island,


### PR DESCRIPTION
Fixes two related `perry/system` device-identity bugs on macOS found in the 2026-07-16 docs audit, and brings every platform in line with the documented contract.

## Bug 1 — `getDeviceIdiom()` violated its own contract on every platform (worst on macOS)

The public contract — `types/perry/system/index.d.ts`, `docs/src/system/other.md`, `overview.md`, and the `background.md` example that literally does `idiom === "phone" || idiom === "pad" || idiom === "watch"` — says `getDeviceIdiom(): string` returning `"phone" | "pad" | "mac" | "tv" | "watch" | ...`.

What the code actually did:

- dispatch row (`crates/perry-dispatch/src/system_table.rs`): `ReturnKind::F64`
- every platform FFI returned an **undocumented numeric code** (0 = phone, 1 = pad, 4 = watch) that nothing anywhere mapped to the documented strings — so `idiom === "mac"` could never be true on any platform
- **macOS** hardcoded `0.0`: a Mac reported itself as a *phone*
- **tvOS/visionOS** carried an iOS copy-paste probing `UIDevice.model` for iPad/iPhone → an Apple TV / Vision Pro also reported the phone code
- **Android** returned `i64` from an `F64`-declared row — the same silent wrong-register ABI-mismatch class as #5972
- **web** backend had no `getDeviceIdiom` arm at all (emitted `console.warn`), and `web_runtime.js` returned numeric `0`

### Fix

End-to-end, same shape as `getDeviceModel`/`getLocale` (#5972): the dispatch row becomes `ReturnKind::Str` (impl returns a raw `*mut StringHeader` i64 via `js_string_from_bytes`; codegen NaN-boxes it with STRING_TAG), and every platform returns its documented string:

| Platform | Returns |
|---|---|
| macOS | `"mac"` |
| iOS | `"phone"` / `"pad"` (UIDevice.model check kept) |
| tvOS | `"tv"` |
| visionOS | `"vision"` (mirrors `UIUserInterfaceIdiom.vision`) |
| watchOS | `"watch"` |
| Android | `"phone"` (tablet discrimination still TODO, matches previous behavior) |
| GTK4 / Windows | `"desktop"` |
| web | UA-based `"phone"` / `"pad"` / `"mac"` / `"desktop"` |

GTK4 also loses a bogus `_closure_ptr` parameter (the row declares no args). The HarmonyOS build.rs-generated stub auto-follows the row kind (null-string stub, same as the existing `Str` rows).

## Bug 2 — `getDeviceModel()` on macOS: boxing already fixed, but still broken end-to-end

The `F64`-vs-raw-pointer half of the audit finding was already fixed by #5972/#6016 (row is `Str`; the macOS impl reads sysctl `hw.model` and returns a raw StringHeader — no platform still has the ABI mismatch; verified all 8).

What still failed end-to-end on desktop hosts: `perry_get_device_idiom` / `perry_system_get_device_model` live **only** in `libperry_ui_*.a`, and a console program importing just these functions never triggered UI-lib linking:

```
Undefined symbols for architecture arm64:
  "_perry_get_device_idiom", referenced from: _main
  "_perry_system_get_device_model", referenced from: _main
```

The #5972 regression test works around exactly this by importing a `perry/ui` widget ("pull in the UI backend that defines perry_system_*"). Fixed by adding both names to the `perry/system` `triggers_ui` list in `collect_modules.rs`, per the `hapticPlay` (#5283) precedent.

## Docs

`docs/src/system/other.md`, `overview.md`, and `types/perry/system/index.d.ts` now enumerate the full idiom value set and note that macOS `getDeviceModel()` is sysctl `hw.model`. (The `background.md` string-comparison example needed no change — it now actually works.)

## Verification (macOS arm64, MacBookPro18,2)

Test program:

```ts
import { getDeviceIdiom, getDeviceModel } from "perry/system";
const idiom = getDeviceIdiom();
console.log("idiom typeof:", typeof idiom);
console.log("idiom value:", idiom);
console.log("is mac:", idiom === "mac");
const model = getDeviceModel();
console.log("model typeof:", typeof model);
console.log("model value:", model);
```

**Before** (origin/main build):
- console-only program: **link failure** (undefined `_perry_get_device_idiom`, `_perry_system_get_device_model`)
- with a `perry/ui` import forced:

```
idiom typeof: number
idiom value: 0
is mac: false
model typeof: string
model value: MacBookPro18,2
```

**After** (this branch, console-only program, no perry/ui import):

```
idiom typeof: string
idiom value: mac
is mac: true
model typeof: string
model value: MacBookPro18,2
```

**After, default flow with auto-optimize on** (feature-specialized runtime rebuilt from this branch, `target/perry-auto-<hash>/release`, 6.0MB binary) — identical output:

```
idiom typeof: string
idiom value: mac
is mac: true
model typeof: string
model value: MacBookPro18,2
```

`cargo fmt --all -- --check` clean; `perry-dispatch` / `perry-codegen-js` / `perry-api-manifest` test suites pass; `perry-ui-ios` cross-checks clean (`aarch64-apple-ios-sim`). GTK4/Windows/Android crates can't be checked on this host (NDK/system-lib build scripts); their edits mirror string-returning neighbors in the same files.

## Not fixed here (pre-existing, noted while verifying)

- Most other `perry/system` names (`isDarkMode`, `getLocale`, `getOSVersion`, …) have the same console-program link failure on desktop hosts — the `collect_modules.rs` comment claims they "live in stdlib" but no `perry_system_*` symbol exists outside the UI crates. This PR only adds the two audited functions to the trigger list.
- `strip_dedup.rs`'s rlib "alloc shim" heuristic (`.cgu.`/`-cgu.` in the member name) skips **every** rlib member under incremental profiles (incremental CGU names are `<crate>-<hash>.<session>.<x>.rcgu.o`), while still counting the rlib's symbols as "provided elsewhere" — the trimmed `libperry_ui_macos.a` then loses any symbol whose other provider was the rlib, and links fail with dev profiles when the `.rlib` sits next to the `.a`. Release-profile names contain `-cgu.` so shipped builds are unaffected.
