### PR TITLE
fix(i18n): wire runtime locale detection, per-locale tables, plurals, currency config

### DIFF
--- a/crates/perry-codegen/src/codegen/entry.rs
+++ b/crates/perry-codegen/src/codegen/entry.rs
@@ -375,6 +375,68 @@ pub(super) fn compile_module_entry(
                 .filter(|s| !s.is_empty())
                 .map(|suite| llmod.add_string_constant(suite))
         };
+        // i18n startup init: when the project configures `[i18n]`, bake the
+        // configured locale-code list (and the optional `[i18n.currencies]`
+        // map) into `main`'s prelude as a single `perry_i18n_init` call —
+        // this registers the locale registry the plural rules and format
+        // wrappers read, and eagerly resolves the runtime locale index at
+        // startup instead of leaving it pinned to the default row. Non-i18n
+        // projects (`cross_module.i18n` is `None`) emit nothing. Constants
+        // and raw ptr/len arrays are allocated up-front while `llmod` is
+        // still mutable — `main` claims the borrow below.
+        //
+        // (ptrs_global, lens_global, count, default_idx, currencies_const)
+        let i18n_startup: Option<(String, String, usize, usize, Option<(String, usize)>)> =
+            if is_dylib {
+                None
+            } else {
+                cross_module
+                    .i18n
+                    .as_ref()
+                    .filter(|i| !i.locale_codes.is_empty())
+                    .map(|i18n| {
+                        let mut ptr_elems: Vec<String> = Vec::new();
+                        let mut len_elems: Vec<String> = Vec::new();
+                        for code in &i18n.locale_codes {
+                            let (name, len) = llmod.add_string_constant(code);
+                            ptr_elems.push(format!("ptr @{}", name));
+                            len_elems.push(format!("i32 {}", len));
+                        }
+                        let count = i18n.locale_codes.len();
+                        let ptrs_global = "__perry_i18n_locale_ptrs".to_string();
+                        let lens_global = "__perry_i18n_locale_lens".to_string();
+                        llmod.add_raw_global(format!(
+                            "@{} = private unnamed_addr constant [{} x ptr] [{}]",
+                            ptrs_global,
+                            count,
+                            ptr_elems.join(", ")
+                        ));
+                        llmod.add_raw_global(format!(
+                            "@{} = private unnamed_addr constant [{} x i32] [{}]",
+                            lens_global,
+                            count,
+                            len_elems.join(", ")
+                        ));
+                        let currencies = if i18n.currencies.is_empty() {
+                            None
+                        } else {
+                            let joined = i18n
+                                .currencies
+                                .iter()
+                                .map(|(l, c)| format!("{}={}", l, c))
+                                .collect::<Vec<_>>()
+                                .join(",");
+                            Some(llmod.add_string_constant(&joined))
+                        };
+                        (
+                            ptrs_global,
+                            lens_global,
+                            count,
+                            i18n.default_locale_idx,
+                            currencies,
+                        )
+                    })
+            };
         // Next.js wall 54 (part 2): emit a string constant for every Deferred
         // `.next/server/**` module path now (before `main` borrows `llmod`); the
         // registration calls go in the block below. `(string_const_name,
@@ -431,6 +493,34 @@ pub(super) fn compile_module_entry(
                     "perry_app_group_init",
                     &[(PTR, suite_ptr.as_str()), (I32, len_str.as_str())],
                 );
+            }
+            // i18n: register the configured locale list + resolve the runtime
+            // locale BEFORE any module init runs, so module-top-level `t()`
+            // calls and format wrappers already see the detected locale.
+            if let Some((ptrs_global, lens_global, count, default_idx, currencies)) =
+                i18n_startup.as_ref()
+            {
+                let ptrs_ref = format!("@{}", ptrs_global);
+                let lens_ref = format!("@{}", lens_global);
+                let count_str = count.to_string();
+                let default_str = default_idx.to_string();
+                blk.call_void(
+                    "perry_i18n_init",
+                    &[
+                        (PTR, ptrs_ref.as_str()),
+                        (PTR, lens_ref.as_str()),
+                        (I32, count_str.as_str()),
+                        (I32, default_str.as_str()),
+                    ],
+                );
+                if let Some((const_name, byte_len)) = currencies {
+                    let pairs_ptr = format!("@{}", const_name);
+                    let pairs_len = byte_len.to_string();
+                    blk.call_void(
+                        "perry_i18n_set_currencies",
+                        &[(PTR, pairs_ptr.as_str()), (I32, pairs_len.as_str())],
+                    );
+                }
             }
             // Wire up stdlib HANDLE_METHOD_DISPATCH eagerly when stdlib is
             // linked. Previously this was only called from

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -1518,13 +1518,20 @@ pub fn compile_module(hir: &HirModule, opts: CompileOptions) -> Result<Vec<u8>> 
             // per-module Vec clone — wrapping the I18nLowerCtx field
             // in Arc too would eliminate it, but is a wider refactor
             // tracked as a follow-up.
-            let (translations, key_count, _locale_count, locale_codes, default_locale_idx) =
-                arc.as_ref();
+            let (
+                translations,
+                key_count,
+                _locale_count,
+                locale_codes,
+                default_locale_idx,
+                currencies,
+            ) = arc.as_ref();
             crate::expr::I18nLowerCtx {
                 translations: translations.clone(),
                 key_count: *key_count,
                 default_locale_idx: *default_locale_idx,
                 locale_codes: locale_codes.clone(),
+                currencies: currencies.clone(),
             }
         }),
         imported_vars: opts.imported_vars,

--- a/crates/perry-codegen/src/codegen/opts.rs
+++ b/crates/perry-codegen/src/codegen/opts.rs
@@ -286,17 +286,28 @@ pub struct CompileOptions {
         perry_api_manifest::NativeAbiType,
     )>,
     /// i18n translation table snapshot — `(translations, key_count,
-    /// locale_count, locale_codes, default_locale_idx)`. The
+    /// locale_count, locale_codes, default_locale_idx, currencies)`. The
     /// `default_locale_idx` is the row index used at compile time to
     /// resolve `Expr::I18nString` to the right translation — without
     /// it, the lowering would have to either pick locale 0 blindly or
-    /// fall back to the verbatim key.
+    /// fall back to the verbatim key. `currencies` is the sorted
+    /// `[i18n.currencies]` map (`locale → ISO 4217 code`) baked into the
+    /// entry `main` prelude's `perry_i18n_set_currencies` call.
     /// Tier 4.6 (v0.5.336): wrapped in `Arc` so the per-module clone
     /// in the `compile_module` rayon worker is a cheap reference bump
     /// instead of duplicating the (potentially large) `Vec<String>` of
-    /// every translated string. The tuple shape is unchanged for the
-    /// downstream destructure at `compile_module` line 597.
-    pub i18n_table: Option<std::sync::Arc<(Vec<String>, usize, usize, Vec<String>, usize)>>,
+    /// every translated string.
+    #[allow(clippy::type_complexity)]
+    pub i18n_table: Option<
+        std::sync::Arc<(
+            Vec<String>,
+            usize,
+            usize,
+            Vec<String>,
+            usize,
+            Vec<(String, String)>,
+        )>,
+    >,
 
     /// When true, emit LLVM `reassoc` per-instruction fast-math flags on
     /// every f64 op. Off by default — Perry produces bit-exact output

--- a/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
+++ b/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
@@ -333,6 +333,117 @@ fn emit_i18n_template(
     Ok(nanbox_string_inline(ctx.block(), &final_handle))
 }
 
+/// Resolve every locale's template for one i18n string-table row. An empty
+/// translation cell means the locale file is missing this key — fall back to
+/// `fallback_text` (the base key's source text; for plural-form rows this is
+/// the base key WITHOUT the `.one`/`.other` suffix, so an untranslated form
+/// never leaks the suffixed registry key to the user).
+///
+/// Returns `(templates, default_idx, locale_codes)`; a `(vec![fallback],
+/// 0, vec![])` triple when i18n isn't configured for this build.
+fn resolve_i18n_templates(
+    i18n: &Option<I18nLowerCtx>,
+    fallback_text: &str,
+    string_idx: u32,
+) -> (Vec<String>, usize, Vec<String>) {
+    let (mut templates, default_idx, locale_codes): (Vec<String>, usize, Vec<String>) =
+        match i18n.as_ref() {
+            Some(t) if t.key_count > 0 => {
+                let locale_count = t.translations.len() / t.key_count;
+                let rows = (0..locale_count)
+                    .map(
+                        |li| match t.translations.get(li * t.key_count + string_idx as usize) {
+                            Some(s) if !s.is_empty() => s.clone(),
+                            _ => fallback_text.to_string(),
+                        },
+                    )
+                    .collect();
+                (rows, t.default_locale_idx, t.locale_codes.clone())
+            }
+            _ => (Vec::new(), 0, Vec::new()),
+        };
+    if templates.is_empty() {
+        templates.push(fallback_text.to_string());
+    }
+    let default_idx = default_idx.min(templates.len() - 1);
+    (templates, default_idx, locale_codes)
+}
+
+/// Emit the runtime locale-row index for this site as an i32 SSA value.
+/// `perry_i18n_locale_index_for` lazily detects the system locale on first
+/// call (the entry `main` prelude's `perry_i18n_init` normally resolved it
+/// already — then this is a cached atomic load), matches it against the
+/// configured locale list (one interned "en,de,fr" literal), and returns the
+/// row index; an explicit `perry_i18n_set_locale_index` always wins.
+fn emit_locale_index(ctx: &mut FnCtx<'_>, locale_codes: &[String], default_idx: usize) -> String {
+    let locales_joined = locale_codes.join(",");
+    let locales_key_idx = ctx.strings.intern(&locales_joined);
+    let locales_handle_global = format!("@{}", ctx.strings.entry(locales_key_idx).handle_global);
+    let blk = ctx.block();
+    let locales_box = blk.load(DOUBLE, &locales_handle_global);
+    let locales_handle = unbox_to_i64(blk, &locales_box);
+    blk.call(
+        I32,
+        "perry_i18n_locale_index_for",
+        &[(I64, &locales_handle), (I32, &default_idx.to_string())],
+    )
+}
+
+/// Emit the value for one resolved i18n row (a `templates` vector in locale
+/// order): the compile-time fast path when every locale's template is
+/// identical (or the build is single-locale / lacks a runtime locale index),
+/// otherwise a branch chain on `locale_idx_val` with the default locale's row
+/// as the fallthrough.
+fn emit_i18n_row_value(
+    ctx: &mut FnCtx<'_>,
+    templates: &[String],
+    default_idx: usize,
+    locale_idx_val: Option<&str>,
+    lowered_params: &std::collections::HashMap<String, String>,
+) -> Result<String> {
+    let all_same = templates.iter().all(|t| t == &templates[default_idx]);
+    let locale_idx = match locale_idx_val {
+        Some(v) if !all_same => v,
+        _ => return emit_i18n_template(ctx, &templates[default_idx], lowered_params),
+    };
+
+    let result_slot = ctx.block().alloca(DOUBLE);
+    let join_block_idx = ctx.new_block("i18n_locale_join");
+
+    for (li, template) in templates.iter().enumerate() {
+        if li == default_idx {
+            continue; // default row is the fallthrough below
+        }
+        let blk = ctx.block();
+        let cond = blk.icmp_eq(I32, locale_idx, &li.to_string());
+        let match_block_idx = ctx.new_block(&format!("i18n_locale_{}", li));
+        let next_block_idx = ctx.new_block(&format!("i18n_locale_next_{}", li));
+        let match_label = ctx.block_label(match_block_idx);
+        let next_label = ctx.block_label(next_block_idx);
+        ctx.block().cond_br(&cond, &match_label, &next_label);
+
+        ctx.current_block = match_block_idx;
+        let val = emit_i18n_template(ctx, template, lowered_params)?;
+        let join_label = ctx.block_label(join_block_idx);
+        let blk = ctx.block();
+        blk.store(DOUBLE, &val, &result_slot);
+        blk.br(&join_label);
+
+        ctx.current_block = next_block_idx;
+    }
+
+    // Fallthrough: the default locale's row (also covers a stale
+    // out-of-range index from perry_i18n_set_locale_index).
+    let val = emit_i18n_template(ctx, &templates[default_idx], lowered_params)?;
+    let join_label = ctx.block_label(join_block_idx);
+    let blk = ctx.block();
+    blk.store(DOUBLE, &val, &result_slot);
+    blk.br(&join_label);
+
+    ctx.current_block = join_block_idx;
+    Ok(ctx.block().load(DOUBLE, &result_slot))
+}
+
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {
         Expr::WorkerNew {
@@ -990,47 +1101,31 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         //        runtime. Fragments are interned via the StringPool so
         //        identical templates share storage.
         //
-        // Plurals: `plural_forms` and `plural_param` are deliberately
-        // ignored in this first cut. The lowering uses the canonical
-        // `string_idx` (which is what the singular/non-plural form
-        // points at). CLDR plural rule selection at runtime is a
-        // followup; in the meantime plural-tagged keys still produce a
-        // working translation, just not the count-aware variant.
+        // Plurals: when the key carries `.zero`/`.one`/…/`.other` variants
+        // in the locale files (registered by the perry-transform pass as
+        // `plural_forms: (category, string_idx)` rows) AND the call site
+        // passes the detected plural parameter, the lowering selects the
+        // CLDR plural category at runtime via `perry_i18n_plural_category`
+        // and branches to the matching form's row — each form then runs the
+        // same per-locale selection as a non-plural key. Sites without a
+        // count param (or keys without plural variants) use the canonical
+        // `string_idx` row directly.
         Expr::I18nString {
             key,
             string_idx,
             params,
-            ..
+            plural_forms,
+            plural_param,
         } => {
-            // Resolve every locale's template for this key from the flat
-            // 2D table. An empty translation cell means the locale file
-            // is missing this key — fall back to the source key so the
-            // user at least sees the English text instead of `""`.
-            let (mut templates, default_idx, locale_codes): (Vec<String>, usize, Vec<String>) =
-                match ctx.i18n.as_ref() {
-                    Some(t) if t.key_count > 0 => {
-                        let locale_count = t.translations.len() / t.key_count;
-                        let rows = (0..locale_count)
-                            .map(|li| {
-                                match t.translations.get(li * t.key_count + *string_idx as usize) {
-                                    Some(s) if !s.is_empty() => s.clone(),
-                                    _ => key.clone(),
-                                }
-                            })
-                            .collect();
-                        (rows, t.default_locale_idx, t.locale_codes.clone())
-                    }
-                    _ => (Vec::new(), 0, Vec::new()),
-                };
-            if templates.is_empty() {
-                templates.push(key.clone());
-            }
-            let default_idx = default_idx.min(templates.len() - 1);
+            // Resolve every locale's template for the base row (and later,
+            // each plural form's row) from the flat 2D table.
+            let (templates, default_idx, locale_codes) =
+                resolve_i18n_templates(ctx.i18n, key, *string_idx);
 
             // Lower each param exactly once, up front, so closures and
             // side effects in arg expressions fire in source order — no
-            // matter which locale branch runs (or whether the template
-            // references the param at all).
+            // matter which locale/plural branch runs (or whether the
+            // template references the param at all).
             let mut lowered_params: std::collections::HashMap<String, String> =
                 std::collections::HashMap::with_capacity(params.len());
             for (name, v) in params {
@@ -1038,53 +1133,79 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 lowered_params.insert(name.clone(), v_box);
             }
 
-            // Compile-time fast path: single-locale build, or a key whose
-            // resolved template is identical in every locale (incl. the
-            // untranslated-key fallback) — no runtime selection needed.
-            let all_same = templates.iter().all(|t| t == &templates[default_idx]);
-            if all_same || locale_codes.len() != templates.len() {
-                return emit_i18n_template(ctx, &templates[default_idx], &lowered_params);
-            }
+            // A runtime locale index is only meaningful when the table
+            // metadata is consistent and there is more than one locale.
+            let multi_locale = locale_codes.len() == templates.len() && templates.len() > 1;
 
-            // Multi-locale: select the translation row at RUNTIME.
-            // `perry_i18n_locale_index_for` lazily detects the system
-            // locale on first call (NSBundle/CFLocale on Apple, Win32 /
-            // Android props / env vars elsewhere), matches it against the
-            // configured locale list (one interned "en,de,fr" literal),
-            // and caches the row index — an explicit
-            // `perry_i18n_set_locale_index` beats it. Then branch per
-            // locale and emit that row's template plan; the default
-            // locale's row is the fallthrough.
-            let locales_joined = locale_codes.join(",");
-            let locales_key_idx = ctx.strings.intern(&locales_joined);
-            let locales_handle_global =
-                format!("@{}", ctx.strings.entry(locales_key_idx).handle_global);
-            let blk = ctx.block();
-            let locales_box = blk.load(DOUBLE, &locales_handle_global);
-            let locales_handle = unbox_to_i64(blk, &locales_box);
-            let locale_idx = blk.call(
+            // Plural selection applies when the key has plural variants and
+            // this site actually passes the plural parameter.
+            let count_val = plural_param
+                .as_ref()
+                .and_then(|p| lowered_params.get(p))
+                .cloned()
+                .filter(|_| !plural_forms.is_empty());
+
+            let Some(count_val) = count_val else {
+                // Non-plural path: base row only.
+                let locale_idx = if multi_locale {
+                    Some(emit_locale_index(ctx, &locale_codes, default_idx))
+                } else {
+                    None
+                };
+                return emit_i18n_row_value(
+                    ctx,
+                    &templates,
+                    default_idx,
+                    locale_idx.as_deref(),
+                    &lowered_params,
+                );
+            };
+
+            // Plural path. The locale index feeds both the CLDR category
+            // lookup and each form's per-locale template selection.
+            let locale_idx = if multi_locale {
+                emit_locale_index(ctx, &locale_codes, default_idx)
+            } else {
+                // Single-locale build: row 0 is the only (= default) row.
+                default_idx.to_string()
+            };
+            let category = ctx.block().call(
                 I32,
-                "perry_i18n_locale_index_for",
-                &[(I64, &locales_handle), (I32, &default_idx.to_string())],
+                "perry_i18n_plural_category",
+                &[(I32, &locale_idx), (DOUBLE, &count_val)],
             );
 
-            let result_slot = ctx.block().alloca(DOUBLE);
-            let join_block_idx = ctx.new_block("i18n_locale_join");
+            // `other` (category 5) is the fallthrough when present; a key
+            // with no `.other` variant falls back to the base row.
+            let fallback_row: u32 = plural_forms
+                .iter()
+                .find(|(cat, _)| *cat == 5)
+                .map(|(_, idx)| *idx)
+                .unwrap_or(*string_idx);
 
-            for li in 0..templates.len() {
-                if li == default_idx {
-                    continue; // default row is the fallthrough below
-                }
+            let result_slot = ctx.block().alloca(DOUBLE);
+            let join_block_idx = ctx.new_block("i18n_plural_join");
+
+            for (cat, form_idx) in plural_forms.iter().filter(|(cat, _)| *cat != 5) {
                 let blk = ctx.block();
-                let cond = blk.icmp_eq(I32, &locale_idx, &li.to_string());
-                let match_block_idx = ctx.new_block(&format!("i18n_locale_{}", li));
-                let next_block_idx = ctx.new_block(&format!("i18n_locale_next_{}", li));
+                let cond = blk.icmp_eq(I32, &category, &cat.to_string());
+                let match_block_idx = ctx.new_block(&format!("i18n_plural_{}", cat));
+                let next_block_idx = ctx.new_block(&format!("i18n_plural_next_{}", cat));
                 let match_label = ctx.block_label(match_block_idx);
                 let next_label = ctx.block_label(next_block_idx);
                 ctx.block().cond_br(&cond, &match_label, &next_label);
 
                 ctx.current_block = match_block_idx;
-                let val = emit_i18n_template(ctx, &templates[li], &lowered_params)?;
+                let (form_templates, form_default_idx, _) =
+                    resolve_i18n_templates(ctx.i18n, key, *form_idx);
+                let locale_idx_ref = multi_locale.then_some(locale_idx.as_str());
+                let val = emit_i18n_row_value(
+                    ctx,
+                    &form_templates,
+                    form_default_idx,
+                    locale_idx_ref,
+                    &lowered_params,
+                )?;
                 let join_label = ctx.block_label(join_block_idx);
                 let blk = ctx.block();
                 blk.store(DOUBLE, &val, &result_slot);
@@ -1093,9 +1214,17 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 ctx.current_block = next_block_idx;
             }
 
-            // Fallthrough: the default locale's row (also covers a stale
-            // out-of-range index from perry_i18n_set_locale_index).
-            let val = emit_i18n_template(ctx, &templates[default_idx], &lowered_params)?;
+            // Fallthrough: the `other` form (or the base row).
+            let (fb_templates, fb_default_idx, _) =
+                resolve_i18n_templates(ctx.i18n, key, fallback_row);
+            let locale_idx_ref = multi_locale.then_some(locale_idx.as_str());
+            let val = emit_i18n_row_value(
+                ctx,
+                &fb_templates,
+                fb_default_idx,
+                locale_idx_ref,
+                &lowered_params,
+            )?;
             let join_label = ctx.block_label(join_block_idx);
             let blk = ctx.block();
             blk.store(DOUBLE, &val, &result_slot);

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -1060,8 +1060,14 @@ pub struct I18nLowerCtx {
     /// Configured locale codes in string-table row order (e.g.
     /// `["en", "de", "fr"]`). Used by the `Expr::I18nString` lowering to
     /// emit the runtime locale-index lookup for keys whose translations
-    /// differ between locales.
+    /// differ between locales, and by the entry `main` prelude to bake
+    /// the `perry_i18n_init` locale registration.
     pub locale_codes: Vec<String>,
+    /// `[i18n.currencies]` overrides from perry.toml as sorted
+    /// `(locale, ISO 4217 code)` pairs. Baked into the entry `main`
+    /// prelude's `perry_i18n_set_currencies` call; empty when the project
+    /// doesn't configure the table.
+    pub currencies: Vec<(String, String)>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/perry-codegen/src/runtime_decls/mod.rs
+++ b/crates/perry-codegen/src/runtime_decls/mod.rs
@@ -60,6 +60,20 @@ pub fn declare_phase1(module: &mut LlModule) {
     // StringHeader handle, default row index) -> resolved row index. Lazily
     // detects + matches the system locale on first call, cached after.
     module.declare_function("perry_i18n_locale_index_for", I32, &[I64, I32]);
+    // i18n startup init, emitted once in the entry `main` prelude when the
+    // project configures `[i18n]`: (locale-code ptr array, locale-code len
+    // array, count, default row index). Registers the locale-code list for
+    // the plural rules + format wrappers and eagerly resolves LOCALE_INDEX
+    // from the system locale.
+    module.declare_function("perry_i18n_init", VOID, &[PTR, PTR, I32, I32]);
+    // `[i18n.currencies]` registration: comma-separated `locale=CODE`
+    // pairs baked as a byte constant, passed as (ptr, len).
+    module.declare_function("perry_i18n_set_currencies", VOID, &[PTR, I32]);
+    // CLDR plural category selection for `t('key', { count })` sites whose
+    // key carries `.one`/`.other`/… plural variants: (locale row index,
+    // NaN-boxed count value) -> category (0=zero 1=one 2=two 3=few 4=many
+    // 5=other).
+    module.declare_function("perry_i18n_plural_category", I32, &[I32, DOUBLE]);
     // Function-name registry — populated by `main()` once per top-level
     // named function so `console.log(named)` prints `[Function: named]`
     // instead of `[Function (anonymous)]`. See #1202.

--- a/crates/perry-runtime/src/i18n.rs
+++ b/crates/perry-runtime/src/i18n.rs
@@ -69,20 +69,29 @@ pub extern "C" fn perry_i18n_locale_index_for(
     LOCALE_INDEX.load(Ordering::Relaxed)
 }
 
-/// Initialize the i18n system. Detects the system locale and matches it against
-/// the configured locale list to set LOCALE_INDEX.
+/// Initialize the i18n system. Registers the configured locale-code list
+/// (used by the plural rules and the locale-aware format wrappers), detects
+/// the system locale, and matches it against the list to set LOCALE_INDEX.
 ///
 /// # Arguments
 /// * `locale_codes` - Array of locale code C-string pointers (e.g., "en\0", "de\0")
 /// * `locale_lens` - Array of locale code lengths (without null terminator)
 /// * `count` - Number of locales
+/// * `default_idx` - Row index of the configured `default_locale` (used when
+///   no configured locale matches the detected system locale — the default
+///   is not necessarily row 0)
 ///
-/// Called once from the entry module's init function.
+/// Called once from the entry module's `main` prelude when the project
+/// configures `[i18n]` in perry.toml. Diagnostics: set `PERRY_I18N_DEBUG=1`
+/// to write the detection log to `$HOME/Documents/i18n-debug.log` (always
+/// written on the embedded Apple targets, where the file is retrieved via
+/// devicectl and env vars don't exist).
 #[no_mangle]
 pub extern "C" fn perry_i18n_init(
     locale_codes: *const *const u8,
     locale_lens: *const u32,
     count: u32,
+    default_idx: i32,
 ) {
     if count == 0 || locale_codes.is_null() || locale_lens.is_null() {
         return;
@@ -105,21 +114,42 @@ pub extern "C" fn perry_i18n_init(
         return;
     }
 
+    // Register the locale-code list so `perry_i18n_plural_category` and the
+    // `get_locale_code`-backed format wrappers can map LOCALE_INDEX back to
+    // a locale code. (`perry_i18n_set_plural_locales` remains available as a
+    // standalone setter, but a single init call covers both jobs.)
+    set_locale_codes(locales.iter().map(|s| s.to_string()).collect());
+
     // Detect system locale
     let system_locale = detect_system_locale();
 
     let mut log = format!("[i18n] configured locales: {:?}\n", locales);
     log += &format!("[i18n] detected system locale: {:?}\n", system_locale);
 
-    if let Some(locale_str) = system_locale {
-        if let Some(idx) = match_locale(&locale_str, &locales) {
-            log += &format!("[i18n] matched locale index: {} ({})\n", idx, locales[idx]);
-            LOCALE_INDEX.store(idx as i32, Ordering::Relaxed);
-        } else {
-            log += "[i18n] no match found, using default (index 0)\n";
-        }
+    let default_idx = if default_idx >= 0 && (default_idx as usize) < locales.len() {
+        default_idx
     } else {
-        log += "[i18n] no system locale detected, using default (index 0)\n";
+        0
+    };
+    let resolved = system_locale
+        .as_deref()
+        .and_then(|locale_str| match_locale(locale_str, &locales))
+        .map(|idx| idx as i32);
+    match resolved {
+        Some(idx) => {
+            log += &format!(
+                "[i18n] matched locale index: {} ({})\n",
+                idx, locales[idx as usize]
+            );
+            LOCALE_INDEX.store(idx, Ordering::Relaxed);
+        }
+        None => {
+            log += &format!(
+                "[i18n] no match found, using default (index {})\n",
+                default_idx
+            );
+            LOCALE_INDEX.store(default_idx, Ordering::Relaxed);
+        }
     }
     LOCALE_RESOLVED.store(true, Ordering::Release);
     log += &format!(
@@ -127,15 +157,48 @@ pub extern "C" fn perry_i18n_init(
         LOCALE_INDEX.load(Ordering::Relaxed)
     );
 
-    // Write to Documents for retrieval via devicectl
-    if let Ok(home) = std::env::var("HOME") {
-        let _ = std::fs::write(format!("{}/Documents/i18n-debug.log", home), log.as_bytes());
+    // Write to Documents for retrieval via devicectl on the embedded Apple
+    // targets; everywhere else only on explicit request. The unconditional
+    // write polluted `~/Documents` on every desktop i18n binary startup.
+    let force_log = cfg!(any(
+        target_os = "ios",
+        target_os = "watchos",
+        target_os = "tvos",
+        target_os = "visionos"
+    ));
+    if force_log || std::env::var_os("PERRY_I18N_DEBUG").is_some() {
+        if let Ok(home) = std::env::var("HOME") {
+            let _ = std::fs::write(format!("{}/Documents/i18n-debug.log", home), log.as_bytes());
+        }
     }
 }
 
 /// Detect the system locale from environment or platform APIs.
 fn detect_system_locale() -> Option<String> {
-    // 1. Platform-native APIs first (most reliable on GUI apps)
+    // 1. Explicit POSIX env overrides first: LANGUAGE (GNU extension,
+    //    colon-separated list), then LC_ALL > LC_MESSAGES > LANG. A user who
+    //    runs `LANG=de_DE.UTF-8 ./app` has stated a preference; platform
+    //    APIs like CFLocaleCopyCurrent would otherwise mask it on macOS,
+    //    which pinned every console binary to the Mac's system language no
+    //    matter what the environment said. GUI launches (Finder,
+    //    SpringBoard, …) don't set these vars, so apps still fall through
+    //    to the platform-native detection below.
+    if let Ok(lang) = std::env::var("LANGUAGE") {
+        if let Some(first) = lang.split(':').next() {
+            if !first.is_empty() && first != "C" && first != "POSIX" {
+                return Some(first.to_string());
+            }
+        }
+    }
+    for var in &["LC_ALL", "LC_MESSAGES", "LANG"] {
+        if let Ok(val) = std::env::var(var) {
+            if !val.is_empty() && val != "C" && val != "POSIX" {
+                return Some(val);
+            }
+        }
+    }
+
+    // 2. Platform-native APIs (GUI apps and env-less environments).
     #[cfg(any(
         target_os = "macos",
         target_os = "ios",
@@ -160,25 +223,6 @@ fn detect_system_locale() -> Option<String> {
     {
         if let Some(locale) = detect_android_locale() {
             return Some(locale);
-        }
-    }
-
-    // 2. Environment variables (Linux, or fallback on other platforms)
-    // Try LANGUAGE first (GNU extension, colon-separated list)
-    if let Ok(lang) = std::env::var("LANGUAGE") {
-        if let Some(first) = lang.split(':').next() {
-            if !first.is_empty() {
-                return Some(first.to_string());
-            }
-        }
-    }
-
-    // Try LC_ALL, then LC_MESSAGES, then LANG
-    for var in &["LC_ALL", "LC_MESSAGES", "LANG"] {
-        if let Ok(val) = std::env::var(var) {
-            if !val.is_empty() && val != "C" && val != "POSIX" {
-                return Some(val);
-            }
         }
     }
 
@@ -467,24 +511,21 @@ pub extern "C" fn perry_i18n_interpolate(
 /// Returns the CLDR plural category for a given count in a given locale.
 /// Categories: 0=zero, 1=one, 2=two, 3=few, 4=many, 5=other
 ///
+/// `count` accepts either a plain f64 or a NaN-boxed JSValue (string/int32/
+/// bool boxes coerce through the standard ToNumber ladder), so codegen can
+/// pass the lowered `{count}` parameter value directly.
+///
 /// Based on CLDR plural rules v44.
 #[no_mangle]
 pub extern "C" fn perry_i18n_plural_category(locale_idx: i32, count: f64) -> i32 {
-    // The locale_idx maps to the locale code set during init.
-    // We use a thread-local to store the locale codes for lookup.
-    let category = PLURAL_LOCALE_CODES.with(|codes| {
-        let codes = codes.borrow();
-        let locale = codes
-            .get(locale_idx as usize)
-            .map(|s| s.as_str())
-            .unwrap_or("en");
-        cldr_plural_category(locale, count)
-    });
-    category as i32
+    let n = crate::builtins::js_number_coerce(count);
+    let locale = get_locale_code(locale_idx);
+    cldr_plural_category(&locale, n) as i32
 }
 
 /// Initialize the plural rule locale code list.
-/// Called from codegen init alongside perry_i18n_init.
+/// `perry_i18n_init` registers the same list itself; this standalone setter
+/// remains for callers that manage the locale registry separately.
 #[no_mangle]
 pub extern "C" fn perry_i18n_set_plural_locales(
     locale_codes: *const *const u8,
@@ -502,14 +543,55 @@ pub extern "C" fn perry_i18n_set_plural_locales(
             std::str::from_utf8(bytes).ok().map(|s| s.to_string())
         })
         .collect();
-    PLURAL_LOCALE_CODES.with(|codes| {
-        *codes.borrow_mut() = locales;
-    });
+    set_locale_codes(locales);
 }
 
-use std::cell::RefCell;
-thread_local! {
-    static PLURAL_LOCALE_CODES: RefCell<Vec<String>> = const { RefCell::new(Vec::new()) };
+use std::sync::RwLock;
+
+/// Configured locale codes in string-table row order. Process-global (not
+/// thread-local): it is written once at startup by `perry_i18n_init` /
+/// `perry_i18n_set_plural_locales` on the main thread, and `perry/thread`
+/// workers must see the same registry — a thread-local left every spawned
+/// thread with an empty list, silently pinning plurals and format wrappers
+/// to "en" off the main thread.
+static LOCALE_CODES: RwLock<Vec<String>> = RwLock::new(Vec::new());
+
+/// `[i18n.currencies]` overrides from perry.toml: `(locale, ISO 4217 code)`
+/// pairs, written once at startup by `perry_i18n_set_currencies`.
+static CURRENCY_OVERRIDES: RwLock<Vec<(String, String)>> = RwLock::new(Vec::new());
+
+fn set_locale_codes(locales: Vec<String>) {
+    if let Ok(mut codes) = LOCALE_CODES.write() {
+        *codes = locales;
+    }
+}
+
+/// Register the `[i18n.currencies]` map. `pairs` is a comma-separated
+/// `locale=CODE` list (e.g. `"en=USD,de=EUR"`), baked into the binary by
+/// codegen from perry.toml and passed here from the entry `main` prelude.
+#[no_mangle]
+pub extern "C" fn perry_i18n_set_currencies(pairs_ptr: *const u8, pairs_len: u32) {
+    if pairs_ptr.is_null() || pairs_len == 0 {
+        return;
+    }
+    let bytes = unsafe { std::slice::from_raw_parts(pairs_ptr, pairs_len as usize) };
+    let Ok(s) = std::str::from_utf8(bytes) else {
+        return;
+    };
+    let parsed: Vec<(String, String)> = s
+        .split(',')
+        .filter_map(|pair| {
+            let (locale, code) = pair.split_once('=')?;
+            let (locale, code) = (locale.trim(), code.trim());
+            if locale.is_empty() || code.is_empty() {
+                return None;
+            }
+            Some((locale.to_string(), code.to_string()))
+        })
+        .collect();
+    if let Ok(mut overrides) = CURRENCY_OVERRIDES.write() {
+        *overrides = parsed;
+    }
 }
 
 /// CLDR plural category constants
@@ -819,13 +901,72 @@ fn locale_format(locale: &str) -> LocaleFormat {
 }
 
 fn get_locale_code(locale_idx: i32) -> String {
-    PLURAL_LOCALE_CODES.with(|codes| {
-        let codes = codes.borrow();
-        codes
-            .get(locale_idx as usize)
-            .cloned()
-            .unwrap_or_else(|| "en".to_string())
-    })
+    LOCALE_CODES
+        .read()
+        .ok()
+        .and_then(|codes| codes.get(locale_idx as usize).cloned())
+        .unwrap_or_else(|| "en".to_string())
+}
+
+/// Map an ISO 4217 currency code to its conventional symbol. Codes without
+/// a well-known single symbol render as the code itself (CLDR does the
+/// same for e.g. CHF).
+fn iso_currency_symbol(code: &str) -> &str {
+    match code.to_ascii_uppercase().as_str() {
+        "USD" => "$",
+        "EUR" => "€",
+        "GBP" => "£",
+        "JPY" | "CNY" => "¥",
+        "KRW" => "₩",
+        "INR" => "₹",
+        "RUB" => "₽",
+        "PLN" => "zł",
+        "CZK" => "Kč",
+        "TRY" => "₺",
+        "UAH" => "₴",
+        "ILS" => "₪",
+        "THB" => "฿",
+        "VND" => "₫",
+        "PHP" => "₱",
+        "NGN" => "₦",
+        "BRL" => "R$",
+        "CAD" => "CA$",
+        "AUD" => "A$",
+        "HKD" => "HK$",
+        "NZD" => "NZ$",
+        "MXN" => "MX$",
+        "SEK" | "NOK" | "DKK" | "ISK" => "kr",
+        _ => code,
+    }
+}
+
+/// Resolve the currency symbol for the active locale: an `[i18n.currencies]`
+/// override (exact locale match first, then base-language match) wins over
+/// the locale's built-in default symbol.
+fn currency_symbol_for(locale: &str, fmt: &LocaleFormat) -> String {
+    let lang = locale
+        .split(&['-', '_'][..])
+        .next()
+        .unwrap_or(locale)
+        .to_lowercase();
+    let overridden = CURRENCY_OVERRIDES.read().ok().and_then(|overrides| {
+        overrides
+            .iter()
+            .find(|(l, _)| l.eq_ignore_ascii_case(locale))
+            .or_else(|| {
+                overrides.iter().find(|(l, _)| {
+                    l.split(&['-', '_'][..])
+                        .next()
+                        .map(|base| base.eq_ignore_ascii_case(&lang))
+                        .unwrap_or(false)
+                })
+            })
+            .map(|(_, code)| code.clone())
+    });
+    match overridden {
+        Some(code) => iso_currency_symbol(&code).to_string(),
+        None => fmt.currency_symbol.to_string(),
+    }
 }
 
 /// Format a number with locale-appropriate grouping and decimal separator.
@@ -890,6 +1031,7 @@ pub extern "C" fn perry_i18n_format_currency(
 ) -> *mut crate::StringHeader {
     let locale = get_locale_code(locale_idx);
     let fmt = locale_format(&locale);
+    let currency_symbol = currency_symbol_for(&locale, &fmt);
 
     let is_negative = value < 0.0;
     let abs = value.abs();
@@ -915,13 +1057,13 @@ pub extern "C" fn perry_i18n_format_currency(
             "{}{}\u{00a0}{}",
             if is_negative { "-" } else { "" },
             number_str,
-            fmt.currency_symbol
+            currency_symbol
         )
     } else {
         format!(
             "{}{}{}",
             if is_negative { "-" } else { "" },
-            fmt.currency_symbol,
+            currency_symbol,
             number_str
         )
     };

--- a/crates/perry/src/commands/compile/object_cache.rs
+++ b/crates/perry/src/commands/compile/object_cache.rs
@@ -700,7 +700,8 @@ fn compute_object_cache_key_with_env(
     // a mis-flagged non-entry module can't collide with an entry one.
     if let Some(arc) = &opts.i18n_table {
         // Tier 4.6: deref the Arc<Tuple> to read the inner fields.
-        let (translations, key_count, locale_count, locale_codes, default_idx) = arc.as_ref();
+        let (translations, key_count, locale_count, locale_codes, default_idx, currencies) =
+            arc.as_ref();
         h.field("i18n_kc", &key_count.to_string());
         h.field("i18n_lc", &locale_count.to_string());
         h.field("i18n_def", &default_idx.to_string());
@@ -708,6 +709,15 @@ fn compute_object_cache_key_with_env(
         // Translations are a single long Vec — join with a NUL to avoid
         // substring ambiguity across entries.
         h.field("i18n_tr", &translations.join("\0"));
+        // `[i18n.currencies]` is baked into the entry `main` prelude —
+        // a change must invalidate the cached entry object. Pre-sorted
+        // at snapshot construction, so the key is deterministic.
+        let currencies_s = currencies
+            .iter()
+            .map(|(l, c)| format!("{}={}", l, c))
+            .collect::<Vec<_>>()
+            .join(",");
+        h.field("i18n_currencies", &currencies_s);
     } else {
         h.field("i18n", "none");
     }

--- a/crates/perry/src/commands/compile/run_pipeline.rs
+++ b/crates/perry/src/commands/compile/run_pipeline.rs
@@ -1627,16 +1627,39 @@ pub fn run_with_parse_cache(
     // duplicating the (potentially large) `Vec<String>` of every
     // translated string. Pre-fix, a project with N modules cloned the
     // full translations Vec N times during codegen.
-    let i18n_snapshot: Option<std::sync::Arc<(Vec<String>, usize, usize, Vec<String>, usize)>> =
-        i18n_table.as_ref().map(|table| {
-            std::sync::Arc::new((
-                table.translations.clone(),
-                table.keys.len(),
-                table.locale_count,
-                table.locale_codes.clone(),
-                table.default_locale_idx,
-            ))
-        });
+    #[allow(clippy::type_complexity)]
+    let i18n_snapshot: Option<
+        std::sync::Arc<(
+            Vec<String>,
+            usize,
+            usize,
+            Vec<String>,
+            usize,
+            Vec<(String, String)>,
+        )>,
+    > = i18n_table.as_ref().map(|table| {
+        // `[i18n.currencies]` rides along so the entry module's `main`
+        // prelude can bake the `perry_i18n_set_currencies` call. Sorted
+        // for a deterministic object-cache key (the config is a HashMap).
+        let mut currencies: Vec<(String, String)> = i18n_config
+            .as_ref()
+            .map(|c| {
+                c.currencies
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.clone()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        currencies.sort();
+        std::sync::Arc::new((
+            table.translations.clone(),
+            table.keys.len(),
+            table.locale_count,
+            table.locale_codes.clone(),
+            table.default_locale_idx,
+            currencies,
+        ))
+    });
 
     // Phase J: detect bitcode-link mode. The actual .bc paths aren't known
     // yet (build_optimized_libs runs after compilation), but we decide the

--- a/docs/src/i18n/formatting.md
+++ b/docs/src/i18n/formatting.md
@@ -51,7 +51,7 @@ de: "Population: 1.234.567,89"
 fr: "Population: 1 234 567,89"
 ```
 
-### ShortDate / LongDate / FormatDate
+### ShortDate / LongDate
 
 Formats a timestamp (milliseconds since epoch) as a date:
 
@@ -68,7 +68,7 @@ ShortDate
 LongDate
   en: "Event: March 22, 2026"
   de: "Event: 22. März 2026"
-  fr: "Event: 22 mars 2026"
+  fr: "Event: 22. mars 2026"
 ```
 
 ### FormatTime
@@ -130,4 +130,4 @@ de = "EUR"
 fr = "EUR"
 ```
 
-When `Currency(value)` is called, the locale's configured currency code determines the symbol and formatting rules.
+When `Currency(value)` is called, the active locale's configured ISO 4217 code determines the **symbol** (`USD` → `$`, `EUR` → `€`, `GBP` → `£`, …; codes without a well-known symbol render as the code itself), while the locale keeps controlling the **layout** — separators and symbol placement. With `en = "GBP"`, English output becomes `£1,234.50`; with `de = "USD"`, German output becomes `1.234,50 $`. Locales without an entry (exact locale first, then base language) use their built-in default symbol.

--- a/docs/src/i18n/interpolation.md
+++ b/docs/src/i18n/interpolation.md
@@ -26,15 +26,17 @@ Translation files use the same `{param}` syntax:
 
 Parameters are substituted at runtime after the locale-appropriate template is selected. The substitution handles any value type (numbers, strings, dates) by converting to string.
 
-### Compile-Time Validation
+### Diagnostics & Fallbacks
 
-Perry validates parameters across all locales during compilation:
+Perry reports translation-table problems as build warnings and falls back safely at runtime:
 
-| Condition | Severity |
+| Condition | Behavior |
 |-----------|----------|
-| `{param}` in translation but not provided in code | Error |
-| Param in code but `{param}` not in translation | Error |
-| Parameter set differs between locales for same key | Error |
+| Key missing from a locale file | Build **warning**; that locale renders the default locale's text |
+| Key present in a locale file but never used in code | Build **warning** ("unused i18n key") |
+| Translation cell left empty (`""`, the "needs translation" marker) | Renders the source key's text |
+| `{param}` in the template but not passed at the call site | Renders the literal `{param}` text so the mismatch is visible |
+| Param passed at the call site but not referenced by the template | Value is evaluated (side effects run in source order) and ignored |
 
 ## Plural Rules
 
@@ -72,7 +74,7 @@ Reference the base key without any suffix. Perry detects the plural variants aut
 {{#include ../../examples/i18n/snippets.ts:interp-plural}}
 ```
 
-Perry determines which plural form to use based on the `count` parameter value and the current locale's CLDR rules.
+Perry detects the plural parameter from the first `{param}` placeholder in the key (here `{count}`). At runtime, each call site evaluates the current locale's CLDR rules against the passed value and selects the matching form's translation — a compiled binary run with `LANG=de_DE.UTF-8` picks the German `.one` form for `count: 1` and the German `.other` form for `count: 3`. A call site that doesn't pass the plural parameter renders the base (non-plural) key.
 
 ### Supported Locales
 
@@ -89,13 +91,16 @@ Perry includes hand-rolled CLDR plural rules for 30+ locales:
 | one/few/other | Romanian, Lithuanian |
 | zero/one/other | Latvian |
 
-### Compile-Time Validation
+### Fallback Order
 
-| Condition | Severity |
+When the selected CLDR category has no corresponding form:
+
+| Situation | Behavior |
 |-----------|----------|
-| `.other` form missing for any locale | Error |
-| Required CLDR category missing (e.g., `.few` for Polish) | Error |
-| Extra category locale doesn't use (e.g., `.few` for English) | Warning |
+| Category matches a defined form (e.g. `.one`) | That form's translation, in the active locale |
+| Category has no defined form, `.other` exists | The `.other` form |
+| Category has no defined form, no `.other` | The base key's translation |
+| A locale file is missing a form key | Build **warning**; that locale renders the default locale's form |
 
 ## Explicit API for Non-UI Strings
 
@@ -105,4 +110,4 @@ For strings outside UI components (API responses, notifications, etc.), use `t()
 {{#include ../../examples/i18n/snippets.ts:interp-explicit-t}}
 ```
 
-This uses the same key lookup, validation, and interpolation as UI strings.
+This uses the same key lookup, locale selection, and interpolation as UI strings.

--- a/docs/src/i18n/overview.md
+++ b/docs/src/i18n/overview.md
@@ -15,9 +15,9 @@ The same key-resolution and interpolation runs through the explicit `t()` API fo
 ## Design Principles
 
 - **Zero ceremony**: String literals in UI components are automatically localizable keys
-- **Compile-time validation**: Missing translations, parameter mismatches, and plural form errors caught during build
+- **Compile-time diagnostics**: Missing and unused translation keys are reported as warnings during build (missing keys fall back to the default locale's text)
 - **Embedded string table**: All translations baked into the binary as a flat 2D table. Near-zero runtime lookup cost
-- **Platform-native locale detection**: Uses OS APIs on every platform (no env vars needed on mobile)
+- **Native locale detection**: POSIX locale environment variables first (`LANGUAGE`, `LC_ALL`, `LC_MESSAGES`, `LANG`), then platform OS APIs — so CLI binaries respect the environment and GUI apps (which carry no locale env vars) use the OS setting
 
 ## Quick Start
 
@@ -68,26 +68,27 @@ Fill in `locales/de.json`:
 perry compile src/main.ts -o myapp
 ```
 
-Perry validates all translations at compile time and bakes them into the binary. At runtime, the app detects the user's system locale and shows the right language.
+Perry warns about missing or unused translations at compile time and bakes every configured locale's strings into the binary. At runtime, the app detects the user's locale and shows the right language.
 
 ## How It Works
 
 1. **Detection**: String literals in UI component calls (`Button`, `Text`, `Label`, etc.) are automatically treated as i18n keys
 2. **Transform**: The compiler replaces `Expr::String("Next")` with `Expr::I18nString { key: "Next", string_idx: 0 }` in the HIR
-3. **Codegen**: For each `I18nString`, the compiler emits a locale branch that selects the correct translation at runtime
-4. **Locale detection**: At startup, `perry_i18n_init()` detects the system locale via native APIs and sets the global locale index
+3. **Codegen**: For each `I18nString`, the compiler emits a locale branch that selects the correct translation at runtime (keys whose translation is identical in every locale skip the branch entirely)
+4. **Locale detection**: At startup, the entry point calls `perry_i18n_init()`, which detects the system locale and sets the global locale index all `t()` calls, plural rules, and format wrappers read
 
 ## Locale Detection
 
+Locale environment variables are checked first on **every** platform, in POSIX order: `LANGUAGE`, then `LC_ALL`, `LC_MESSAGES`, `LANG` (values `C` and `POSIX` are ignored). This makes `LANG=de_DE.UTF-8 ./myapp` work the way Unix CLI tools are expected to. When none are set — the normal case for GUI launches via Finder, SpringBoard, etc. — detection falls through to the platform API:
+
 | Platform | Method |
 |----------|--------|
-| macOS | `CFLocaleCopyCurrent()` (CoreFoundation) |
-| iOS | `CFLocaleCopyCurrent()` (CoreFoundation) |
-| Android | `__system_property_get("persist.sys.locale")` |
+| macOS / iOS / watchOS / tvOS / visionOS | `NSBundle.preferredLocalizations` (respects per-app language settings), falling back to `CFLocaleCopyCurrent()` |
+| Android | `__system_property_get("persist.sys.locale")` (then `ro.product.locale`, `persist.sys.language`) |
 | Windows | `GetUserDefaultLocaleName()` (Win32) |
-| Linux | `LANG` / `LC_ALL` / `LC_MESSAGES` env vars |
+| Linux | env vars only (above) |
 
-The detected locale is fuzzy-matched against your configured locales: `de_DE.UTF-8` matches `de`, `en-US` matches `en`, etc.
+The detected locale is fuzzy-matched against your configured locales: `de_DE.UTF-8` matches `de`, `en-US` matches `en`, etc. No match selects the configured `default_locale`. Set `PERRY_I18N_DEBUG=1` to write a detection log to `~/Documents/i18n-debug.log`.
 
 ## Platform Output
 


### PR DESCRIPTION
## Summary

The perry/i18n runtime was dead code (2026-07-16 docs audit): `perry_i18n_init()` — with its full per-platform locale detection — had **zero call sites**, so compiled binaries produced byte-identical output under `LANG=de_DE.UTF-8`, `fr_FR.UTF-8`, and unset. This PR wires the runtime up end-to-end and makes the i18n docs describe what actually ships.

### Root causes found

1. **`perry_i18n_init` / `perry_i18n_set_plural_locales` never called.** `LOCALE_INDEX` stayed 0 and the locale-code registry stayed empty, so every format wrapper (`Currency`/`ShortDate`/`LongDate`/…) fell back to `"en"` forever.
2. **Platform APIs preempted the environment.** `detect_system_locale()` consulted `CFLocaleCopyCurrent` *before* env vars; on macOS that always succeeds, so even the lazy per-site locale selection that #6201 added for `t()` could never observe `LANG`/`LC_ALL` — console binaries were pinned to the Mac's system language.
3. **Plurals deliberately ignored in codegen** (`plural_forms`/`plural_param` collected by the transform, dropped by the `Expr::I18nString` lowering — the "first cut" comment).
4. **`[i18n.currencies]` parsed but read by nothing**; `dynamic` likewise.

### What shipped (goals 1–5)

1. **Startup init (shipped).** When the project configures `[i18n]`, the entry `main` prelude now bakes the locale-code list as ptr/len constant arrays and calls `perry_i18n_init(ptrs, lens, count, default_idx)` before any module init, plus `perry_i18n_set_currencies(pairs, len)` when `[i18n.currencies]` is set. `perry_i18n_init` (which had zero callers, so its contract was safe to extend) gained a `default_idx` param — the configured `default_locale` is not necessarily row 0 — and now registers the locale-code registry itself. Non-i18n projects emit **nothing** (verified: zero `perry_i18n_*` calls in a hello-world's `--trace llvm` IR; binary runs identically).
2. **Runtime-locale `t()` (shipped).** The per-locale table + runtime branch (`perry_i18n_locale_index_for`) already existed on main since #6201 but was unobservable on macOS console binaries due to root cause 2. Detection is now env-first on every platform (`LANGUAGE` → `LC_ALL` → `LC_MESSAGES` → `LANG`, ignoring `C`/`POSIX`), then platform APIs (NSBundle preferredLocalizations → CFLocaleCopyCurrent, Win32, Android props). GUI launches carry no locale env vars and keep using the OS APIs.
3. **Plural selection (shipped).** `t('key', { count })` now branches on `perry_i18n_plural_category(locale_idx, count)` (CLDR rules, count coerced through `js_number_coerce` so any NaN-boxed value works) and selects the matching `.zero/.one/.two/.few/.many/.other` form's row, which then goes through the same per-locale selection as a non-plural key. `.other` (or the base row) is the fallthrough; untranslated form cells fall back to the base key text, never the suffixed registry key.
4. **Locale-aware formatters (shipped).** With init running, `Currency`/`Percent`/`FormatNumber`/`ShortDate`/`LongDate`/`FormatTime` follow the runtime locale. The locale-code registry also moved from a `thread_local` to a process-global `RwLock` so `perry/thread` workers don't silently see an empty registry.
5. **Config fields.** `[i18n.currencies]` is now threaded through `CompileOptions::i18n_table` into the entry prelude; `Currency()` resolves the active locale's ISO 4217 code (exact locale, then base language) to its symbol while the locale keeps controlling layout. The map is part of the object-cache key (verified: editing it invalidates the cached entry object). **`dynamic` remains reserved**: it gates nothing real — the multi-locale table is now always embedded and runtime-selected, and runtime switching would need a new TS API surface (`setLocale`) that doesn't exist in `types/perry/i18n/index.d.ts`. Parsing left intact.

Also: the `~/Documents/i18n-debug.log` write in `perry_i18n_init` is now gated behind `PERRY_I18N_DEBUG=1` (still unconditional on iOS/watchOS/tvOS/visionOS where it exists for devicectl retrieval) instead of polluting every desktop user's Documents folder on startup.

## Verification (same binary, three environments)

Scratch project: `locales = ["en", "de", "fr"]`, `default_locale = "en"`, `[i18n.currencies] en = "USD", de = "EUR", fr = "EUR"`, plural variants `.one`/`.other` for `"You have {count} items"`.

**Before** (main @ 2e105caad): all three runs byte-identical —

```
Hello, World! / You have 1 items / You have 3 items / $1,234.50 / 1,234,567.89 / 42% / 3/22/2026 / March 22, 2026 / 12:00 AM
```

**After** — `LANG=de_DE.UTF-8`:

```
Hallo, World!
Sie haben einen Artikel
Sie haben 3 Artikel
1.234,50 €
1.234.567,89
42 %
22.03.2026
22. März 2026
00:00
```

`LANG=fr_FR.UTF-8`:

```
Bonjour, World !
Vous avez un article
Vous avez 3 articles
1 234,50 €
1 234 567,89
42 %
22.03.2026
22. mars 2026
00:00
```

`LANG` unset (default en):

```
Hello, World!
You have one item
You have 3 items
$1,234.50
1,234,567.89
42%
3/22/2026
March 22, 2026
12:00 AM
```

Additional checks:

- CLDR details: German `count: 0` → other ("0 Artikel"), French `count: 0` → one ("un article", French one covers 0–1); variable (non-literal) counts through a function boundary work; `LANG=ja_JP.UTF-8` (unconfigured) falls back to default `en`.
- Env precedence: `LC_ALL=fr` beats `LANG=de`; `LANGUAGE=de` beats `LANG=fr`.
- `[i18n.currencies]` `en = "GBP"` → `£1,234.50` (symbol from code, layout from locale), and the edit invalidated the object cache without `--no-cache`.
- Non-i18n hello-world: compiles + runs identically; `--trace llvm` shows zero i18n calls emitted.
- `docs/examples/i18n/snippets.ts` + `format_wrappers.ts` compile and run with unchanged output (the no-`[i18n]`-config path is untouched).
- Tests: `cargo test -p perry --test i18n_interpolation_params` 2/2 pass (includes the #6201 multi-locale runtime-selection test), `perry-codegen --lib` 188/188, object-cache key tests 46/46. `cargo fmt --all -- --check` clean.

Not verified on this host: Windows/Android/watchOS detection paths (code motion only — the platform probes themselves are unchanged, just reordered after the env check) and the iOS `.lproj`/Android `strings.xml` bundle emission (untouched).

## Docs

`docs/src/i18n/{overview,interpolation,formatting}.md` updated so every claim matches shipped behavior: the aspirational "compile-time validation" Error tables are replaced with the real missing/unused-key warnings + runtime fallback semantics, the nonexistent `FormatDate` is gone, the French `LongDate` example now shows the `22. mars 2026` the code produces, the locale-detection table documents env-first order + `NSBundle.preferredLocalizations`, and `[i18n.currencies]` is described as implemented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic locale detection with environment-variable overrides and platform fallbacks.
  * Added runtime plural selection using CLDR rules.
  * Added locale-specific currency symbol overrides.
  * Added startup initialization for configured locales and currencies.
  * Improved translation fallback behavior for missing plural forms and parameters.

* **Documentation**
  * Expanded guidance on locale detection, formatting, currency configuration, diagnostics, and fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->