### PR TITLE
fix(widgets): wire reloadPolicy through lowering into all three widget backends

### DIFF
--- a/crates/perry-codegen-glance/src/emit.rs
+++ b/crates/perry-codegen-glance/src/emit.rs
@@ -5,6 +5,36 @@
 use perry_hir::ir::*;
 use std::fmt::Write;
 
+/// Default `android:updatePeriodMillis` when the widget declares no
+/// compile-time `reloadPolicy`: 30 minutes.
+const DEFAULT_UPDATE_PERIOD_MS: u64 = 1_800_000;
+
+/// Android hard floor for `updatePeriodMillis`: the framework does not
+/// deliver periodic updates more often than every 30 minutes.
+const MIN_UPDATE_PERIOD_MS: u64 = 1_800_000;
+
+/// Resolve the widget's effective `android:updatePeriodMillis`: the parsed
+/// `reloadPolicy` if present, clamped to the Android 30-minute floor (with a
+/// compile-time warning), or the 30-minute default.
+fn effective_update_period_millis(widget: &WidgetDecl) -> u64 {
+    match widget.reload_after_seconds {
+        None => DEFAULT_UPDATE_PERIOD_MS,
+        Some(s) => {
+            let ms = s as u64 * 1000;
+            if ms < MIN_UPDATE_PERIOD_MS {
+                eprintln!(
+                    "[perry] warning: widget '{}': reloadPolicy requests a refresh every {}ms, \
+below the Android `updatePeriodMillis` minimum of {}ms (30 minutes); clamping to {}ms",
+                    widget.kind, ms, MIN_UPDATE_PERIOD_MS, MIN_UPDATE_PERIOD_MS
+                );
+                MIN_UPDATE_PERIOD_MS
+            } else {
+                ms
+            }
+        }
+    }
+}
+
 /// Emit the main GlanceAppWidget Kotlin class
 pub fn emit_widget(widget: &WidgetDecl, name: &str, package: &str) -> String {
     let mut out = String::new();
@@ -259,7 +289,12 @@ pub fn emit_widget_info_xml(widget: &WidgetDecl, name: &str) -> String {
     writeln!(out).unwrap();
     writeln!(out, "    android:minWidth=\"{}dp\"", min_width).unwrap();
     writeln!(out, "    android:minHeight=\"{}dp\"", min_height).unwrap();
-    writeln!(out, "    android:updatePeriodMillis=\"1800000\"").unwrap();
+    writeln!(
+        out,
+        "    android:updatePeriodMillis=\"{}\"",
+        effective_update_period_millis(widget)
+    )
+    .unwrap();
     writeln!(
         out,
         "    android:initialLayout=\"@layout/glance_default_loading_layout\""
@@ -767,5 +802,44 @@ mod tests {
         let xml = emit_widget_info_xml(&widget, "Hello");
         assert!(xml.contains("android:minWidth=\"250dp\""));
         assert!(xml.contains("android:minHeight=\"110dp\""));
+    }
+
+    fn make_reload_widget(reload_after_seconds: Option<u32>) -> WidgetDecl {
+        WidgetDecl {
+            kind: "com.test.Reload".to_string(),
+            display_name: "Reload".to_string(),
+            description: String::new(),
+            supported_families: vec!["systemMedium".to_string()],
+            entry_fields: vec![],
+            render_body: vec![],
+            entry_param_name: "entry".to_string(),
+            config_params: vec![],
+            provider_func_name: None,
+            placeholder: None,
+            family_param_name: None,
+            app_group: None,
+            reload_after_seconds,
+        }
+    }
+
+    #[test]
+    fn test_widget_info_xml_custom_reload_policy() {
+        // 60 minutes → 3600000 ms in the appwidget-provider XML.
+        let xml = emit_widget_info_xml(&make_reload_widget(Some(3600)), "Reload");
+        assert!(xml.contains("android:updatePeriodMillis=\"3600000\""));
+    }
+
+    #[test]
+    fn test_widget_info_xml_default_reload_policy() {
+        let xml = emit_widget_info_xml(&make_reload_widget(None), "Reload");
+        assert!(xml.contains("android:updatePeriodMillis=\"1800000\""));
+    }
+
+    #[test]
+    fn test_widget_info_xml_reload_policy_clamped_to_android_floor() {
+        // 10 minutes — below Android's 30-minute updatePeriodMillis floor.
+        let xml = emit_widget_info_xml(&make_reload_widget(Some(600)), "Reload");
+        assert!(xml.contains("android:updatePeriodMillis=\"1800000\""));
+        assert!(!xml.contains("android:updatePeriodMillis=\"600000\""));
     }
 }

--- a/crates/perry-codegen-swiftui/src/emit.rs
+++ b/crates/perry-codegen-swiftui/src/emit.rs
@@ -6,6 +6,32 @@
 use perry_hir::ir::*;
 use std::fmt::Write;
 
+/// Default WidgetKit refresh interval (seconds) when the widget declares no
+/// compile-time `reloadPolicy`: 30 minutes.
+const DEFAULT_RELOAD_SECONDS: u32 = 1800;
+
+/// WidgetKit floor (seconds): the system's refresh budget does not honor
+/// reload requests below ~15 minutes, so anything shorter is clamped.
+const MIN_RELOAD_SECONDS: u32 = 900;
+
+/// Resolve the widget's effective timeline reload interval in seconds:
+/// the parsed `reloadPolicy` if present, clamped to the WidgetKit floor
+/// (with a compile-time warning), or the 30-minute default.
+fn effective_reload_seconds(widget: &WidgetDecl) -> u32 {
+    match widget.reload_after_seconds {
+        None => DEFAULT_RELOAD_SECONDS,
+        Some(s) if s < MIN_RELOAD_SECONDS => {
+            eprintln!(
+                "[perry] warning: widget '{}': reloadPolicy requests a refresh every {}s, \
+below the WidgetKit minimum of {}s (15 minutes); clamping to {}s",
+                widget.kind, s, MIN_RELOAD_SECONDS, MIN_RELOAD_SECONDS
+            );
+            MIN_RELOAD_SECONDS
+        }
+        Some(s) => s,
+    }
+}
+
 /// Emit the TimelineEntry struct (and any nested Codable structs for complex types)
 pub fn emit_entry_struct(widget: &WidgetDecl, name: &str) -> String {
     let mut out = String::new();
@@ -296,7 +322,7 @@ fn emit_static_timeline_provider(widget: &WidgetDecl, name: &str) -> String {
 fn emit_native_timeline_provider(widget: &WidgetDecl, name: &str) -> String {
     let mut out = String::new();
     let func_name = widget.provider_func_name.as_deref().unwrap();
-    let reload_seconds = widget.reload_after_seconds.unwrap_or(1800);
+    let reload_seconds = effective_reload_seconds(widget);
 
     writeln!(out, "struct {}Provider: TimelineProvider {{", name).unwrap();
     writeln!(
@@ -388,7 +414,7 @@ fn emit_app_intent_timeline_provider(
     has_provider: bool,
 ) -> String {
     let mut out = String::new();
-    let reload_seconds = widget.reload_after_seconds.unwrap_or(1800);
+    let reload_seconds = effective_reload_seconds(widget);
 
     writeln!(out, "struct {}Provider: AppIntentTimelineProvider {{", name).unwrap();
     writeln!(
@@ -1269,6 +1295,74 @@ mod tests {
             app_group: None,
             reload_after_seconds: None,
         }
+    }
+
+    #[test]
+    fn test_native_provider_custom_reload_policy() {
+        let mut widget = make_widget(
+            "com.test.Reload",
+            vec![("value".to_string(), WidgetFieldType::Number)],
+            vec![],
+        );
+        widget.provider_func_name = Some("__widget_provider_Reload".to_string());
+        widget.reload_after_seconds = Some(3600);
+
+        let swift = emit_timeline_provider(&widget, "Reload");
+        assert!(swift.contains("Date().addingTimeInterval(3600)"));
+        assert!(swift.contains("policy: .after(reloadDate)"));
+        assert!(!swift.contains("addingTimeInterval(1800)"));
+    }
+
+    #[test]
+    fn test_native_provider_default_reload_policy() {
+        let mut widget = make_widget(
+            "com.test.Reload",
+            vec![("value".to_string(), WidgetFieldType::Number)],
+            vec![],
+        );
+        widget.provider_func_name = Some("__widget_provider_Reload".to_string());
+        // reload_after_seconds stays None → 30-minute default.
+
+        let swift = emit_timeline_provider(&widget, "Reload");
+        assert!(swift.contains("Date().addingTimeInterval(1800)"));
+    }
+
+    #[test]
+    fn test_native_provider_reload_policy_clamped_to_widgetkit_floor() {
+        let mut widget = make_widget(
+            "com.test.Reload",
+            vec![("value".to_string(), WidgetFieldType::Number)],
+            vec![],
+        );
+        widget.provider_func_name = Some("__widget_provider_Reload".to_string());
+        // 5 minutes — below the 15-minute WidgetKit floor, must clamp to 900s.
+        widget.reload_after_seconds = Some(300);
+
+        let swift = emit_timeline_provider(&widget, "Reload");
+        assert!(swift.contains("Date().addingTimeInterval(900)"));
+        assert!(!swift.contains("addingTimeInterval(300)\n"));
+    }
+
+    #[test]
+    fn test_app_intent_provider_custom_reload_policy() {
+        let mut widget = make_widget(
+            "com.test.Reload",
+            vec![("value".to_string(), WidgetFieldType::Number)],
+            vec![],
+        );
+        widget.provider_func_name = Some("__widget_provider_Reload".to_string());
+        widget.config_params = vec![WidgetConfigParam {
+            name: "site".to_string(),
+            title: "Site".to_string(),
+            param_type: WidgetConfigParamType::String {
+                default: String::new(),
+            },
+        }];
+        widget.reload_after_seconds = Some(2700);
+
+        let swift = emit_timeline_provider(&widget, "Reload");
+        assert!(swift.contains("AppIntentTimelineProvider"));
+        assert!(swift.contains("Date().addingTimeInterval(2700)"));
     }
 
     #[test]

--- a/crates/perry-codegen-wear-tiles/src/emit.rs
+++ b/crates/perry-codegen-wear-tiles/src/emit.rs
@@ -5,6 +5,37 @@
 use perry_hir::ir::*;
 use std::fmt::Write;
 
+/// Default tile freshness interval when the widget declares no compile-time
+/// `reloadPolicy`: 60 minutes.
+const DEFAULT_FRESHNESS_MS: u64 = 3_600_000;
+
+/// Wear OS floor for `setFreshnessIntervalMillis`: tile refreshes are
+/// scheduled through WorkManager-style periodic work, which does not run
+/// more often than every 15 minutes.
+const MIN_FRESHNESS_MS: u64 = 900_000;
+
+/// Resolve the widget's effective `setFreshnessIntervalMillis` value: the
+/// parsed `reloadPolicy` if present, clamped to the 15-minute Wear OS floor
+/// (with a compile-time warning), or the 60-minute default.
+fn effective_freshness_millis(widget: &WidgetDecl) -> u64 {
+    match widget.reload_after_seconds {
+        None => DEFAULT_FRESHNESS_MS,
+        Some(s) => {
+            let ms = s as u64 * 1000;
+            if ms < MIN_FRESHNESS_MS {
+                eprintln!(
+                    "[perry] warning: widget '{}': reloadPolicy requests a refresh every {}ms, \
+below the Wear OS tile freshness minimum of {}ms (15 minutes); clamping to {}ms",
+                    widget.kind, ms, MIN_FRESHNESS_MS, MIN_FRESHNESS_MS
+                );
+                MIN_FRESHNESS_MS
+            } else {
+                ms
+            }
+        }
+    }
+}
+
 /// Emit the TileService Kotlin class
 pub fn emit_tile_service(widget: &WidgetDecl, name: &str, package: &str) -> String {
     let mut out = String::new();
@@ -79,10 +110,7 @@ pub fn emit_tile_service(widget: &WidgetDecl, name: &str, package: &str) -> Stri
     }
     writeln!(out).unwrap();
 
-    let reload_ms = widget
-        .reload_after_seconds
-        .map(|s| s as u64 * 1000)
-        .unwrap_or(3600000);
+    let reload_ms = effective_freshness_millis(widget);
 
     writeln!(
         out,
@@ -502,5 +530,44 @@ mod tests {
         let manifest = emit_manifest_snippet("Stats", "com.test");
         assert!(manifest.contains("StatsTileService"));
         assert!(manifest.contains("BIND_TILE_PROVIDER"));
+    }
+
+    fn make_reload_widget(reload_after_seconds: Option<u32>) -> WidgetDecl {
+        WidgetDecl {
+            kind: "com.test.Reload".to_string(),
+            display_name: "Reload".to_string(),
+            description: String::new(),
+            supported_families: vec!["accessoryCircular".to_string()],
+            entry_fields: vec![("value".to_string(), WidgetFieldType::Number)],
+            render_body: vec![],
+            entry_param_name: "entry".to_string(),
+            config_params: vec![],
+            provider_func_name: None,
+            placeholder: None,
+            family_param_name: None,
+            app_group: None,
+            reload_after_seconds,
+        }
+    }
+
+    #[test]
+    fn test_tile_custom_reload_policy() {
+        // 120 minutes → 7200000 ms freshness interval.
+        let kt = emit_tile_service(&make_reload_widget(Some(7200)), "Reload", "com.test");
+        assert!(kt.contains(".setFreshnessIntervalMillis(7200000)"));
+    }
+
+    #[test]
+    fn test_tile_default_reload_policy() {
+        let kt = emit_tile_service(&make_reload_widget(None), "Reload", "com.test");
+        assert!(kt.contains(".setFreshnessIntervalMillis(3600000)"));
+    }
+
+    #[test]
+    fn test_tile_reload_policy_clamped_to_wear_floor() {
+        // 1 minute — below the 15-minute Wear OS floor, must clamp to 900000 ms.
+        let kt = emit_tile_service(&make_reload_widget(Some(60)), "Reload", "com.test");
+        assert!(kt.contains(".setFreshnessIntervalMillis(900000)"));
+        assert!(!kt.contains(".setFreshnessIntervalMillis(60000)"));
     }
 }

--- a/crates/perry-hir/src/lower/widget_decl.rs
+++ b/crates/perry-hir/src/lower/widget_decl.rs
@@ -325,7 +325,11 @@ pub(crate) fn try_lower_widget_decl(
     let mut placeholder: Option<Vec<(String, WidgetPlaceholderValue)>> = None;
     let mut family_param_name: Option<String> = None;
     let mut app_group: Option<String> = None;
-    let reload_after_seconds: Option<u32> = None;
+    // Compile-time `reloadPolicy: { after: { minutes: N } }` literals found in
+    // the provider's return statements (converted to seconds), plus a flag for
+    // `reloadPolicy` values that exist but aren't statically parseable.
+    let mut reload_policy_seconds: Vec<u32> = Vec::new();
+    let mut reload_policy_unparsed = false;
 
     for prop in &config_obj.props {
         let kv = match prop {
@@ -361,6 +365,13 @@ pub(crate) fn try_lower_widget_decl(
                         // Provider as method: provider(config) { ... }
                         let func_name = format!("__widget_provider_{}", kind);
                         provider_func_name = Some(func_name);
+                        if let Some(body) = &method.function.body {
+                            scan_provider_stmts_for_reload_policy(
+                                &body.stmts,
+                                &mut reload_policy_seconds,
+                                &mut reload_policy_unparsed,
+                            );
+                        }
                     }
                     continue;
                 }
@@ -419,7 +430,7 @@ pub(crate) fn try_lower_widget_decl(
             }
             "provider" => {
                 // Arrow function provider: provider: async (config) => { ... }
-                if let ast::Expr::Arrow(_arrow) = kv.value.as_ref() {
+                if let ast::Expr::Arrow(arrow) = kv.value.as_ref() {
                     let func_name = if kind.is_empty() {
                         "__widget_provider_widget".to_string()
                     } else {
@@ -427,6 +438,22 @@ pub(crate) fn try_lower_widget_decl(
                         format!("__widget_provider_{}", safe)
                     };
                     provider_func_name = Some(func_name);
+                    match arrow.body.as_ref() {
+                        ast::BlockStmtOrExpr::BlockStmt(block) => {
+                            scan_provider_stmts_for_reload_policy(
+                                &block.stmts,
+                                &mut reload_policy_seconds,
+                                &mut reload_policy_unparsed,
+                            );
+                        }
+                        ast::BlockStmtOrExpr::Expr(expr) => {
+                            scan_provider_return_expr_for_reload_policy(
+                                expr,
+                                &mut reload_policy_seconds,
+                                &mut reload_policy_unparsed,
+                            );
+                        }
+                    }
                 }
             }
             "placeholder" => {
@@ -515,6 +542,38 @@ pub(crate) fn try_lower_widget_decl(
             *pfn = format!("__widget_provider_{}", safe);
         }
     }
+
+    // Resolve the compile-time reload policy. The refresh interval is a single
+    // compile-time constant per widget: if the provider returns several
+    // distinct literal policies (e.g. a short error-retry interval and a
+    // longer happy-path one), use the smallest so the most urgent request
+    // wins, and tell the user.
+    if reload_policy_unparsed {
+        eprintln!(
+            "[perry] warning: widget '{}': `reloadPolicy` must be a literal \
+`{{ after: {{ minutes: N }} }}` for the compiler to read it; a non-literal \
+value was ignored and the platform default refresh interval applies \
+(see docs/src/widgets/data-fetching.md)",
+            kind
+        );
+    }
+    reload_policy_seconds.sort_unstable();
+    reload_policy_seconds.dedup();
+    let reload_after_seconds: Option<u32> = match reload_policy_seconds.as_slice() {
+        [] => None,
+        [only] => Some(*only),
+        many => {
+            eprintln!(
+                "[perry] warning: widget '{}': provider returns {} distinct \
+compile-time `reloadPolicy` values; the refresh interval is a single \
+compile-time constant per widget — using the smallest ({} seconds)",
+                kind,
+                many.len(),
+                many[0]
+            );
+            Some(many[0])
+        }
+    };
 
     Some(WidgetDecl {
         kind,
@@ -1666,6 +1725,163 @@ fn parse_widget_config_param(name: &str, value: &ast::Expr) -> Option<WidgetConf
     }
 }
 
+/// Strip semantically transparent wrappers (parens, TS casts) so return-value
+/// scanning sees the underlying object literal in shapes like
+/// `return ({ ... } as ProviderResult)`.
+fn strip_expr_wrappers(expr: &ast::Expr) -> &ast::Expr {
+    match expr {
+        ast::Expr::Paren(p) => strip_expr_wrappers(&p.expr),
+        ast::Expr::TsAs(a) => strip_expr_wrappers(&a.expr),
+        ast::Expr::TsNonNull(n) => strip_expr_wrappers(&n.expr),
+        ast::Expr::TsTypeAssertion(a) => strip_expr_wrappers(&a.expr),
+        ast::Expr::TsConstAssertion(a) => strip_expr_wrappers(&a.expr),
+        ast::Expr::TsSatisfies(s) => strip_expr_wrappers(&s.expr),
+        _ => expr,
+    }
+}
+
+/// Parse a `reloadPolicy` value literal into whole seconds. The single
+/// documented form is `{ after: { minutes: N } }` with a numeric literal `N`
+/// (`N` may be fractional; the result is rounded to the nearest second).
+/// Returns `None` for anything else — non-literal shapes can't be read at
+/// compile time.
+fn parse_reload_policy_seconds(expr: &ast::Expr) -> Option<u32> {
+    let obj = match strip_expr_wrappers(expr) {
+        ast::Expr::Object(obj) => obj,
+        _ => return None,
+    };
+    for prop in &obj.props {
+        let ast::PropOrSpread::Prop(p) = prop else {
+            continue;
+        };
+        let ast::Prop::KeyValue(kv) = p.as_ref() else {
+            continue;
+        };
+        if prop_name_to_string(&kv.key) != "after" {
+            continue;
+        }
+        let after_obj = match strip_expr_wrappers(kv.value.as_ref()) {
+            ast::Expr::Object(o) => o,
+            _ => return None,
+        };
+        for after_prop in &after_obj.props {
+            let ast::PropOrSpread::Prop(ap) = after_prop else {
+                continue;
+            };
+            let ast::Prop::KeyValue(akv) = ap.as_ref() else {
+                continue;
+            };
+            if prop_name_to_string(&akv.key) != "minutes" {
+                continue;
+            }
+            let ast::Expr::Lit(ast::Lit::Num(n)) = strip_expr_wrappers(akv.value.as_ref()) else {
+                return None;
+            };
+            let minutes = n.value;
+            if !minutes.is_finite() || minutes <= 0.0 {
+                return None;
+            }
+            let seconds = (minutes * 60.0).round();
+            if seconds < 1.0 {
+                return Some(1);
+            }
+            if seconds >= u32::MAX as f64 {
+                return Some(u32::MAX);
+            }
+            return Some(seconds as u32);
+        }
+        return None;
+    }
+    None
+}
+
+/// Inspect one provider return-value expression for a `reloadPolicy`
+/// property. Literal policies are appended to `found` (in seconds); a
+/// `reloadPolicy` that exists but isn't a readable literal sets `unparsed`.
+fn scan_provider_return_expr_for_reload_policy(
+    expr: &ast::Expr,
+    found: &mut Vec<u32>,
+    unparsed: &mut bool,
+) {
+    let obj = match strip_expr_wrappers(expr) {
+        ast::Expr::Object(obj) => obj,
+        _ => return,
+    };
+    for prop in &obj.props {
+        let ast::PropOrSpread::Prop(p) = prop else {
+            continue;
+        };
+        let ast::Prop::KeyValue(kv) = p.as_ref() else {
+            continue;
+        };
+        if prop_name_to_string(&kv.key) != "reloadPolicy" {
+            continue;
+        }
+        match parse_reload_policy_seconds(kv.value.as_ref()) {
+            Some(seconds) => found.push(seconds),
+            None => *unparsed = true,
+        }
+    }
+}
+
+/// Walk a provider function body and collect every compile-time
+/// `reloadPolicy` from its `return` statements, recursing through the
+/// statement shapes a provider realistically uses (blocks, if/else, loops,
+/// try/catch, switch, labels).
+fn scan_provider_stmts_for_reload_policy(
+    stmts: &[ast::Stmt],
+    found: &mut Vec<u32>,
+    unparsed: &mut bool,
+) {
+    for stmt in stmts {
+        scan_provider_stmt_for_reload_policy(stmt, found, unparsed);
+    }
+}
+
+fn scan_provider_stmt_for_reload_policy(
+    stmt: &ast::Stmt,
+    found: &mut Vec<u32>,
+    unparsed: &mut bool,
+) {
+    match stmt {
+        ast::Stmt::Return(ret) => {
+            if let Some(arg) = &ret.arg {
+                scan_provider_return_expr_for_reload_policy(arg, found, unparsed);
+            }
+        }
+        ast::Stmt::Block(block) => {
+            scan_provider_stmts_for_reload_policy(&block.stmts, found, unparsed);
+        }
+        ast::Stmt::If(if_stmt) => {
+            scan_provider_stmt_for_reload_policy(&if_stmt.cons, found, unparsed);
+            if let Some(alt) = &if_stmt.alt {
+                scan_provider_stmt_for_reload_policy(alt, found, unparsed);
+            }
+        }
+        ast::Stmt::While(w) => scan_provider_stmt_for_reload_policy(&w.body, found, unparsed),
+        ast::Stmt::DoWhile(d) => scan_provider_stmt_for_reload_policy(&d.body, found, unparsed),
+        ast::Stmt::For(f) => scan_provider_stmt_for_reload_policy(&f.body, found, unparsed),
+        ast::Stmt::ForIn(f) => scan_provider_stmt_for_reload_policy(&f.body, found, unparsed),
+        ast::Stmt::ForOf(f) => scan_provider_stmt_for_reload_policy(&f.body, found, unparsed),
+        ast::Stmt::Try(t) => {
+            scan_provider_stmts_for_reload_policy(&t.block.stmts, found, unparsed);
+            if let Some(handler) = &t.handler {
+                scan_provider_stmts_for_reload_policy(&handler.body.stmts, found, unparsed);
+            }
+            if let Some(finalizer) = &t.finalizer {
+                scan_provider_stmts_for_reload_policy(&finalizer.stmts, found, unparsed);
+            }
+        }
+        ast::Stmt::Switch(s) => {
+            for case in &s.cases {
+                scan_provider_stmts_for_reload_policy(&case.cons, found, unparsed);
+            }
+        }
+        ast::Stmt::Labeled(l) => scan_provider_stmt_for_reload_policy(&l.body, found, unparsed),
+        _ => {}
+    }
+}
+
 /// Parse a placeholder value from an expression
 fn parse_placeholder_value(expr: &ast::Expr) -> WidgetPlaceholderValue {
     match expr {
@@ -1979,6 +2195,157 @@ mod tests {
             }
             other => panic!("expected Formatted, got {:?}", other),
         }
+    }
+
+    /// Parse `source`, extract the body statements of the first function
+    /// declaration, and run the reload-policy scanner over them.
+    fn scan_first_fn_body(source: &str) -> (Vec<u32>, bool) {
+        let module = perry_parser::parse_typescript(source, "widget_reload_test.ts")
+            .expect("test source parses");
+        for item in &module.body {
+            if let ast::ModuleItem::Stmt(ast::Stmt::Decl(ast::Decl::Fn(fn_decl))) = item {
+                let body = fn_decl.function.body.as_ref().expect("fn has body");
+                let mut found = Vec::new();
+                let mut unparsed = false;
+                scan_provider_stmts_for_reload_policy(&body.stmts, &mut found, &mut unparsed);
+                return (found, unparsed);
+            }
+        }
+        panic!("no function declaration in test source");
+    }
+
+    #[test]
+    fn reload_policy_literal_minutes_becomes_seconds() {
+        let (found, unparsed) = scan_first_fn_body(
+            r#"
+            async function provider() {
+                return {
+                    entries: [{ temperature: 20 }],
+                    reloadPolicy: { after: { minutes: 30 } },
+                };
+            }
+            "#,
+        );
+        assert_eq!(found, vec![1800]);
+        assert!(!unparsed);
+    }
+
+    #[test]
+    fn reload_policy_found_inside_if_and_try() {
+        // The docs' error-handling shape: a short retry interval on the
+        // failure path, a longer one on the happy path.
+        let (found, unparsed) = scan_first_fn_body(
+            r#"
+            async function provider() {
+                try {
+                    const res = await fetch("https://api.example.com/weather");
+                    if (!res.ok) {
+                        return {
+                            entries: [{ temperature: 0 }],
+                            reloadPolicy: { after: { minutes: 5 } },
+                        };
+                    }
+                    return {
+                        entries: [{ temperature: 21 }],
+                        reloadPolicy: { after: { minutes: 15 } },
+                    };
+                } catch (e) {
+                    return {
+                        entries: [{ temperature: 0 }],
+                        reloadPolicy: { after: { minutes: 1 } },
+                    };
+                }
+            }
+            "#,
+        );
+        assert_eq!(found, vec![300, 900, 60]);
+        assert!(!unparsed);
+    }
+
+    #[test]
+    fn reload_policy_non_literal_flags_unparsed() {
+        let (found, unparsed) = scan_first_fn_body(
+            r#"
+            async function provider() {
+                const policy = { after: { minutes: 10 } };
+                return { entries: [], reloadPolicy: policy };
+            }
+            "#,
+        );
+        assert!(found.is_empty());
+        assert!(unparsed);
+    }
+
+    #[test]
+    fn reload_policy_missing_is_neither_found_nor_unparsed() {
+        let (found, unparsed) = scan_first_fn_body(
+            r#"
+            async function provider() {
+                return { entries: [{ temperature: 20 }] };
+            }
+            "#,
+        );
+        assert!(found.is_empty());
+        assert!(!unparsed);
+    }
+
+    #[test]
+    fn reload_policy_arrow_expression_body_scanned() {
+        // `provider: async () => ({ entries: [], reloadPolicy: ... })` —
+        // exercise the expression-body scanner directly.
+        let module = perry_parser::parse_typescript(
+            r#"const p = async () => ({ entries: [], reloadPolicy: { after: { minutes: 45 } } });"#,
+            "widget_reload_arrow_test.ts",
+        )
+        .expect("test source parses");
+        let mut found = Vec::new();
+        let mut unparsed = false;
+        for item in &module.body {
+            if let ast::ModuleItem::Stmt(ast::Stmt::Decl(ast::Decl::Var(var))) = item {
+                let init = var.decls[0].init.as_ref().expect("var has init");
+                let ast::Expr::Arrow(arrow) = init.as_ref() else {
+                    panic!("expected arrow init");
+                };
+                let ast::BlockStmtOrExpr::Expr(expr) = arrow.body.as_ref() else {
+                    panic!("expected expression body");
+                };
+                scan_provider_return_expr_for_reload_policy(expr, &mut found, &mut unparsed);
+            }
+        }
+        assert_eq!(found, vec![2700]);
+        assert!(!unparsed);
+    }
+
+    #[test]
+    fn reload_policy_seconds_parser_edge_cases() {
+        // Fractional minutes round to the nearest second.
+        let half_minute = object_lit(vec![key_value(
+            "after",
+            object_lit(vec![key_value("minutes", num_lit(0.5))]),
+        )]);
+        assert_eq!(parse_reload_policy_seconds(&half_minute), Some(30));
+
+        // Zero and negative intervals are rejected.
+        let zero = object_lit(vec![key_value(
+            "after",
+            object_lit(vec![key_value("minutes", num_lit(0.0))]),
+        )]);
+        assert_eq!(parse_reload_policy_seconds(&zero), None);
+        let negative = object_lit(vec![key_value(
+            "after",
+            object_lit(vec![key_value("minutes", num_lit(-5.0))]),
+        )]);
+        assert_eq!(parse_reload_policy_seconds(&negative), None);
+
+        // Missing `minutes`, wrong key, or non-object shapes are rejected.
+        let empty_after = object_lit(vec![key_value("after", object_lit(vec![]))]);
+        assert_eq!(parse_reload_policy_seconds(&empty_after), None);
+        let wrong_key = object_lit(vec![key_value(
+            "every",
+            object_lit(vec![key_value("minutes", num_lit(10.0))]),
+        )]);
+        assert_eq!(parse_reload_policy_seconds(&wrong_key), None);
+        assert_eq!(parse_reload_policy_seconds(&str_lit("hourly")), None);
     }
 
     #[test]

--- a/crates/perry-hir/src/lower/widget_decl.rs
+++ b/crates/perry-hir/src/lower/widget_decl.rs
@@ -548,7 +548,12 @@ pub(crate) fn try_lower_widget_decl(
     // distinct literal policies (e.g. a short error-retry interval and a
     // longer happy-path one), use the smallest so the most urgent request
     // wins, and tell the user.
-    if reload_policy_unparsed {
+    let reload_after_seconds: Option<u32> = if reload_policy_unparsed {
+        // A policy the compiler can't read makes the whole widget's
+        // interval indeterminate: honoring some *other* return path's
+        // literal would silently apply that branch's interval to every
+        // branch, including the unreadable one. Fall back to the platform
+        // default for the widget, which is what this warning promises.
         eprintln!(
             "[perry] warning: widget '{}': `reloadPolicy` must be a literal \
 `{{ after: {{ minutes: N }} }}` for the compiler to read it; a non-literal \
@@ -556,22 +561,24 @@ value was ignored and the platform default refresh interval applies \
 (see docs/src/widgets/data-fetching.md)",
             kind
         );
-    }
-    reload_policy_seconds.sort_unstable();
-    reload_policy_seconds.dedup();
-    let reload_after_seconds: Option<u32> = match reload_policy_seconds.as_slice() {
-        [] => None,
-        [only] => Some(*only),
-        many => {
-            eprintln!(
-                "[perry] warning: widget '{}': provider returns {} distinct \
+        None
+    } else {
+        reload_policy_seconds.sort_unstable();
+        reload_policy_seconds.dedup();
+        match reload_policy_seconds.as_slice() {
+            [] => None,
+            [only] => Some(*only),
+            many => {
+                eprintln!(
+                    "[perry] warning: widget '{}': provider returns {} distinct \
 compile-time `reloadPolicy` values; the refresh interval is a single \
 compile-time constant per widget — using the smallest ({} seconds)",
-                kind,
-                many.len(),
-                many[0]
-            );
-            Some(many[0])
+                    kind,
+                    many.len(),
+                    many[0]
+                );
+                Some(many[0])
+            }
         }
     };
 

--- a/crates/perry-hir/tests/widget_reload_policy.rs
+++ b/crates/perry-hir/tests/widget_reload_policy.rs
@@ -114,3 +114,46 @@ fn multiple_distinct_policies_use_smallest() {
         "smallest literal policy (5 minutes) must win"
     );
 }
+
+#[test]
+fn literal_plus_non_literal_policy_falls_back_to_platform_default() {
+    // A provider mixing a readable literal with a policy the compiler
+    // can't evaluate: the literal must NOT be adopted for the whole
+    // widget. Honoring it would silently apply the error path's interval
+    // to the branch whose policy is unknown — and would contradict the
+    // warning, which says the platform default applies. `None` is what
+    // makes every backend fall back to its own default.
+    let module = lower(
+        r#"
+        import { Widget, VStack, Text } from "perry/widget";
+
+        const dynamicPolicy = { after: { minutes: 5 } };
+
+        const w = Widget({
+            kind: "com.test.Mixed",
+            displayName: "Mixed",
+            description: "One literal policy, one dynamic",
+            entryFields: { temperature: "number" },
+            provider: async (ctx) => {
+                if (ctx.failed) {
+                    return {
+                        entries: [{ temperature: 0 }],
+                        reloadPolicy: dynamicPolicy,
+                    };
+                }
+                return {
+                    entries: [{ temperature: 21 }],
+                    reloadPolicy: { after: { minutes: 45 } },
+                };
+            },
+            render: (entry) => VStack([Text("hi")]),
+        });
+    "#,
+    );
+    assert_eq!(module.widgets.len(), 1, "expected one widget decl");
+    assert_eq!(
+        module.widgets[0].reload_after_seconds, None,
+        "an unreadable reloadPolicy must fall back to the platform default, \
+not silently adopt the other return path's literal"
+    );
+}

--- a/crates/perry-hir/tests/widget_reload_policy.rs
+++ b/crates/perry-hir/tests/widget_reload_policy.rs
@@ -1,0 +1,116 @@
+/// End-to-end lowering tests for the widget `reloadPolicy` field: a literal
+/// `reloadPolicy: { after: { minutes: N } }` in the provider's return value
+/// must land in `WidgetDecl::reload_after_seconds` (in seconds), and a
+/// widget without one must leave the field `None` so each backend applies
+/// its platform default.
+use perry_diagnostics::SourceCache;
+use perry_hir::lower_module;
+use perry_parser::parse_typescript_with_cache;
+
+fn lower(src: &str) -> perry_hir::Module {
+    let src = src.to_string();
+    std::thread::Builder::new()
+        .stack_size(32 * 1024 * 1024)
+        .spawn(move || {
+            let mut cache = SourceCache::new();
+            let parsed = parse_typescript_with_cache(&src, "test.ts", &mut cache)
+                .expect("parse should succeed");
+            lower_module(&parsed.module, "test", "test.ts").expect("lowering should succeed")
+        })
+        .expect("spawn lower thread")
+        .join()
+        .expect("lower thread panicked")
+}
+
+#[test]
+fn provider_reload_policy_lands_in_widget_decl() {
+    let module = lower(
+        r#"
+        import { Widget, VStack, Text } from "perry/widget";
+
+        const w = Widget({
+            kind: "com.test.Weather",
+            displayName: "Weather",
+            description: "Current conditions",
+            entryFields: { temperature: "number" },
+            provider: async () => {
+                return {
+                    entries: [{ temperature: 21 }],
+                    reloadPolicy: { after: { minutes: 45 } },
+                };
+            },
+            render: (entry) => VStack([Text("hi")]),
+        });
+    "#,
+    );
+    assert_eq!(module.widgets.len(), 1, "expected one widget decl");
+    assert_eq!(
+        module.widgets[0].reload_after_seconds,
+        Some(2700),
+        "45 minutes must lower to 2700 seconds"
+    );
+}
+
+#[test]
+fn provider_without_reload_policy_leaves_none() {
+    let module = lower(
+        r#"
+        import { Widget, VStack, Text } from "perry/widget";
+
+        const w = Widget({
+            kind: "com.test.Plain",
+            displayName: "Plain",
+            description: "No policy",
+            entryFields: { temperature: "number" },
+            provider: async () => {
+                return { entries: [{ temperature: 21 }] };
+            },
+            render: (entry) => VStack([Text("hi")]),
+        });
+    "#,
+    );
+    assert_eq!(module.widgets.len(), 1, "expected one widget decl");
+    assert_eq!(
+        module.widgets[0].reload_after_seconds, None,
+        "no reloadPolicy must leave reload_after_seconds unset"
+    );
+}
+
+#[test]
+fn multiple_distinct_policies_use_smallest() {
+    // Error-retry shape from the docs: 5 minutes on the failure path,
+    // 15 minutes on the happy path — the smallest literal wins because
+    // the refresh interval is a single compile-time constant.
+    let module = lower(
+        r#"
+        import { Widget, VStack, Text } from "perry/widget";
+
+        const w = Widget({
+            kind: "com.test.Retry",
+            displayName: "Retry",
+            description: "Retry policy",
+            entryFields: { temperature: "number" },
+            provider: async () => {
+                const ok = false;
+                if (!ok) {
+                    return {
+                        entries: [{ temperature: 0 }],
+                        reloadPolicy: { after: { minutes: 5 } },
+                    };
+                }
+                return {
+                    entries: [{ temperature: 21 }],
+                    reloadPolicy: { after: { minutes: 15 } },
+                };
+            },
+            render: (entry) => VStack([Text("hi")]),
+        });
+    "#,
+    );
+    assert_eq!(module.widgets.len(), 1, "expected one widget decl");
+    assert_eq!(
+        module.widgets[0].reload_after_seconds,
+        Some(300),
+        "smallest literal policy (5 minutes) must win"
+    );
+}

--- a/docs/src/widgets/data-fetching.md
+++ b/docs/src/widgets/data-fetching.md
@@ -95,10 +95,32 @@ return {
 };
 ```
 
+The refresh interval is read **at compile time**: the compiler scans the
+provider's `return` statements for a literal
+`reloadPolicy: { after: { minutes: N } }` (where `N` is a numeric literal;
+fractional values round to the nearest second) and bakes the interval into
+the generated platform code. A `reloadPolicy` computed at runtime (a
+variable, a function call, …) cannot be read — the compiler warns and the
+platform default applies.
+
 | Policy | Behavior |
 |--------|----------|
-| `{ after: { minutes: N } }` | Re-fetch after N minutes. Compiles to `.after(Date().addingTimeInterval(N*60))` on iOS and `setFreshnessIntervalMillis(N*60000)` on Wear OS. |
-| *(omitted)* | Defaults to 30 minutes on iOS, 30 minutes on Android/Wear OS. |
+| `{ after: { minutes: N } }` | Re-fetch after N minutes. Compiles to `.after(Date().addingTimeInterval(N*60))` on iOS/watchOS, `android:updatePeriodMillis="N*60000"` on Android, and `setFreshnessIntervalMillis(N*60000)` on Wear OS. |
+| *(omitted)* | Platform default: 30 minutes on iOS/watchOS, 30 minutes on Android, 60 minutes on Wear OS. |
+
+**Platform floors:** each platform ignores refresh requests below a minimum
+interval, so the compiler clamps and warns:
+
+| Platform | Default | Minimum (clamped) |
+|----------|---------|-------------------|
+| iOS / watchOS (WidgetKit) | 30 minutes | 15 minutes (refresh budget) |
+| Android (Glance, `updatePeriodMillis`) | 30 minutes | 30 minutes (hard framework floor) |
+| Wear OS (Tiles freshness) | 60 minutes | 15 minutes |
+
+If different `return` statements carry different literal policies (e.g. a
+short error-retry interval and a longer happy-path one), the smallest one
+wins — the interval is a single compile-time constant per widget — and the
+compiler emits a warning naming the value it chose.
 
 **Budget limits:** iOS restricts widget refreshes. Typical budget is 40--70 refreshes per day. watchOS is stricter (see [watchOS Complications](watchos.md)). Request only what you need.
 
@@ -152,6 +174,11 @@ Widget({
 ```
 
 The `placeholder` field provides data shown in the widget gallery and during loading. If the provider throws an unhandled exception, the generated Swift/Kotlin code catches it and renders the placeholder instead.
+
+Note that with two distinct literal policies (5 and 15 minutes above), the
+compiled widget uses the smaller one — 5 minutes, which the platform floor
+then raises to its minimum (15 minutes on iOS) — and the compiler warns
+about the choice. See [Reload Policies](#reload-policies).
 
 ## Multiple Timeline Entries
 

--- a/docs/src/widgets/watchos.md
+++ b/docs/src/widgets/watchos.md
@@ -38,7 +38,7 @@ The `Gauge` component is designed for watchOS circular complications:
 ## Refresh Budgets
 
 watchOS has stricter refresh budgets than iOS:
-- Recommended: refresh every 60 minutes (`reloadPolicy: { after: { minutes: 60 } }`)
+- Recommended: refresh every 60 minutes (`reloadPolicy: { after: { minutes: 60 } }`); requests below 15 minutes are clamped at compile time
 - Maximum: system may throttle more aggressively than iOS
 - Background refresh uses `BackgroundTask` framework
 

--- a/docs/src/widgets/wearos.md
+++ b/docs/src/widgets/wearos.md
@@ -84,4 +84,4 @@ Same as Android phone widgets — Wear OS is Android:
 
 ## Refresh
 
-Wear Tiles use `freshnessIntervalMillis` on the `Tile` builder. Set via `reloadPolicy: { after: { minutes: N } }` in the provider return value. Default: 60 minutes.
+Wear Tiles use `freshnessIntervalMillis` on the `Tile` builder. Set via a literal `reloadPolicy: { after: { minutes: N } }` in the provider return value — the interval is read at compile time. Default: 60 minutes. Minimum: 15 minutes (shorter requests are clamped with a compile-time warning). See [Reload Policies](data-fetching.md#reload-policies).


### PR DESCRIPTION
## Problem

The documented home-screen-widget `reloadPolicy` was completely inert (2026-07-16 docs audit). `docs/src/widgets/data-fetching.md` promises that a provider returning

```ts
return {
  entries: [{ ... }],
  reloadPolicy: { after: { minutes: 30 } },
};
```

controls the refresh interval, but `try_lower_widget_decl` initialized `reload_after_seconds: Option<u32> = None` and nothing ever assigned it — no code parsed `reloadPolicy` from anywhere. All three backends silently used hardcoded defaults regardless of what the user wrote:

- `perry-codegen-swiftui/src/emit.rs` — `unwrap_or(1800)` (30 min) in both provider emitters
- `perry-codegen-glance/src/emit.rs` — literal `android:updatePeriodMillis="1800000"` in the widget-info XML
- `perry-codegen-wear-tiles/src/emit.rs` — `unwrap_or(3600000)` (60 min) freshness

## Fix

**Lowering** (`perry-hir/src/lower/widget_decl.rs`): statically scan the provider function body — arrow with block body, arrow with expression body, and method form — for return-value object literals carrying `reloadPolicy: { after: { minutes: N } }` (the single documented form; `N` numeric literal, fractional rounds to whole seconds) and store the interval in `WidgetDecl::reload_after_seconds`. The scanner recurses through blocks, if/else, loops, try/catch/finally, switch, and labeled statements, covering the docs' error-retry example.

Policy resolution:

- one literal → used as-is;
- several distinct literals (e.g. short error-retry + longer happy path) → smallest wins, with a `[perry] warning` naming the chosen value (the interval is a single compile-time constant per widget);
- a `reloadPolicy` that exists but is not a readable literal → `[perry] warning`, platform default applies.

**Backends** — each resolves default + floor in one helper and warns at compile time when clamping:

| Backend | Default (unset) | Floor | Rationale |
|---|---|---|---|
| SwiftUI (WidgetKit) | 1800 s | 900 s | refresh budget ignores <15 min reloads |
| Glance (`updatePeriodMillis`) | 1 800 000 ms | 1 800 000 ms | Android hard framework floor: no periodic updates more often than 30 min |
| Wear Tiles (`setFreshnessIntervalMillis`) | 3 600 000 ms | 900 000 ms | 15-min periodic-work floor |

Defaults when `reloadPolicy` is omitted are unchanged from the previously hardcoded values.

**Docs**: `data-fetching.md` now documents the compile-time-literal requirement, per-platform defaults and floors, and the smallest-literal-wins rule; `wearos.md`/`watchos.md` reload mentions updated to match.

## Tests

- `perry-hir` lib tests: policy parser edge cases (fractional/zero/negative minutes, missing `minutes`, wrong key, non-object), scanner through if/try/catch, arrow expression body, non-literal flags.
- `perry-hir/tests/widget_reload_policy.rs` (new): end-to-end lowering of a full `Widget({...})` declaration — literal policy lands as seconds, omitted stays `None`, multiple distinct literals resolve to the smallest.
- Per-backend emit tests: custom interval appears in the generated Swift (`Date().addingTimeInterval(3600)` + `.after(reloadDate)`, both TimelineProvider and AppIntentTimelineProvider), Glance XML (`android:updatePeriodMillis="3600000"`), and Wear Tiles Kotlin (`.setFreshnessIntervalMillis(7200000)`); default-when-unset stays 1800 s / 1 800 000 ms / 3 600 000 ms; below-floor values clamp (300 s → 900 s, 600 s → 1 800 000 ms, 60 s → 900 000 ms).

All of `cargo test -p perry-codegen-swiftui -p perry-codegen-glance -p perry-codegen-wear-tiles` and the new/existing `perry-hir` widget tests pass; `cargo fmt --all -- --check` clean.

## End-to-end evidence (real driver, this branch)

A scratch widget whose provider returns `reloadPolicy: { after: { minutes: 45 } }`, compiled with the freshly built compiler:

- `--target ios-widget`: generated `ReloadDemo.swift` contains
  `let reloadDate = Date().addingTimeInterval(2700)` / `policy: .after(reloadDate)`
- `--target android-widget`: generated `xml/widget_info_reloaddemo.xml` contains
  `android:updatePeriodMillis="2700000"`
- `--target wearos-tile`: generated `ReloadDemoTileService.kt` contains
  `.setFreshnessIntervalMillis(2700000)`

A below-floor variant (`{ after: { minutes: 5 } }`, ios-widget) prints at compile time:

```
[perry] warning: widget 'com.test.ReloadShort': reloadPolicy requests a refresh every 300s, below the WidgetKit minimum of 900s (15 minutes); clamping to 900s
```

and emits `addingTimeInterval(900)`.

Note: the final `.appex` swiftc link on the ios-widget run fails in this environment for pre-existing reasons unrelated to this change (the iOS-target `libperry_runtime` staticlib isn't built on this host, so `_js_nanbox_string`/`___widget_provider_*` are undefined at link time); the Swift/Kotlin/XML sources above are the codegen output this PR changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Widget refresh intervals now respect literal `reloadPolicy` values across Android, iOS, watchOS, and Wear OS.
  * When multiple policies are detected, the shortest interval is selected.
  * Unspecified policies use a 30-minute default.

* **Bug Fixes**
  * Refresh intervals below platform minimums are clamped automatically, with a warning during compilation.

* **Documentation**
  * Updated widget refresh policy guidance, platform limits, compile-time behavior, and warning conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->