### PR TITLE
fix(hir): JSON.stringify(url.toString()) inlined argument returned undefined

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -388,20 +388,22 @@ pub(super) fn try_module_static_methods(
                                 // string. Perry's runtime JSON stringifier doesn't
                                 // honor `toJSON` on opaque runtime objects, so
                                 // intercept the URL case at HIR time. Recognize URL
-                                // both via the original AST (typed local / direct
-                                // `new URL`) and via the HIR variants (`UrlNew`,
-                                // `UrlInstanceToJSON`, …) that earlier passes may
-                                // already have produced.
+                                // via the original AST (typed local / direct
+                                // `new URL`) and via `Expr::UrlNew` when the arg
+                                // was already lowered. `UrlInstanceToJSON` /
+                                // `UrlInstanceToString` must NOT match here: those
+                                // are the href STRING produced by `u.toJSON()` /
+                                // `u.toString()`, and wrapping them in another
+                                // `UrlInstanceToJSON` reads a `StringHeader` as a
+                                // URL `ObjectHeader` → undefined (#6488). The
+                                // AST-side check can't misfire on those either:
+                                // `static_receiver_class` of a call expression is
+                                // `None`, not the callee receiver's class.
                                 let original_arg = call.args.first().map(|a| a.expr.as_ref());
                                 let arg_is_url = original_arg
                                     .map(|e| static_receiver_class(ctx, e) == Some("URL"))
                                     .unwrap_or(false)
-                                    || matches!(
-                                        &value,
-                                        Expr::UrlNew { .. }
-                                            | Expr::UrlInstanceToJSON(_)
-                                            | Expr::UrlInstanceToString(_)
-                                    );
+                                    || matches!(&value, Expr::UrlNew { .. });
                                 if arg_is_url {
                                     let href = Expr::UrlInstanceToJSON(Box::new(value));
                                     return Ok(Ok(Expr::JsonStringifyFull(

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -371,18 +371,7 @@ pub(super) fn try_module_static_methods(
                             }
                         }
                         "stringify" => {
-                            if args.len() >= 2 {
-                                let mut it = args.into_iter();
-                                let value = it.next().unwrap();
-                                let replacer = it.next().unwrap();
-                                let spacer = it.next().unwrap_or(Expr::Null);
-                                return Ok(Ok(Expr::JsonStringifyFull(
-                                    Box::new(value),
-                                    Box::new(replacer),
-                                    Box::new(spacer),
-                                )));
-                            } else if args.len() == 1 {
-                                let value = args.into_iter().next().unwrap();
+                            if !args.is_empty() {
                                 // `JSON.stringify(url)` should invoke `url.toJSON()`
                                 // (which returns href) and stringify the resulting
                                 // string. Perry's runtime JSON stringifier doesn't
@@ -399,25 +388,32 @@ pub(super) fn try_module_static_methods(
                                 // AST-side check can't misfire on those either:
                                 // `static_receiver_class` of a call expression is
                                 // `None`, not the callee receiver's class.
+                                //
+                                // The wrap applies to the replacer/spacer forms
+                                // too: per SerializeJSONProperty, `toJSON` runs
+                                // BEFORE the replacer, so the replacer observing
+                                // the href string matches Node. Without it,
+                                // `JSON.stringify(u, null, 2)` walked the opaque
+                                // URL object and threw a circular-structure
+                                // TypeError on its searchParams back-reference.
                                 let original_arg = call.args.first().map(|a| a.expr.as_ref());
                                 let arg_is_url = original_arg
                                     .map(|e| static_receiver_class(ctx, e) == Some("URL"))
                                     .unwrap_or(false)
-                                    || matches!(&value, Expr::UrlNew { .. });
+                                    || matches!(args.first(), Some(Expr::UrlNew { .. }));
+                                let mut it = args.into_iter();
+                                let mut value = it.next().unwrap();
+                                let replacer = it.next().unwrap_or(Expr::Null);
+                                let spacer = it.next().unwrap_or(Expr::Null);
                                 if arg_is_url {
-                                    let href = Expr::UrlInstanceToJSON(Box::new(value));
-                                    return Ok(Ok(Expr::JsonStringifyFull(
-                                        Box::new(href),
-                                        Box::new(Expr::Null),
-                                        Box::new(Expr::Null),
-                                    )));
+                                    value = Expr::UrlInstanceToJSON(Box::new(value));
                                 }
-                                // Route ALL single-arg stringify through JsonStringifyFull
+                                // Route ALL stringify calls through JsonStringifyFull
                                 // so the runtime can return TAG_UNDEFINED for undefined input
                                 return Ok(Ok(Expr::JsonStringifyFull(
                                     Box::new(value),
-                                    Box::new(Expr::Null),
-                                    Box::new(Expr::Null),
+                                    Box::new(replacer),
+                                    Box::new(spacer),
                                 )));
                             }
                         }

--- a/test-files/test_gap_6488_json_stringify_url_tostring_inline.ts
+++ b/test-files/test_gap_6488_json_stringify_url_tostring_inline.ts
@@ -1,0 +1,25 @@
+// #6488: JSON.stringify(u.toString()) returned undefined when the
+// URL.prototype.toString()/toJSON() call was inlined directly as the
+// argument. The single-arg JSON.stringify HIR lowering pattern-matched
+// the UrlInstanceToString/UrlInstanceToJSON variants as "the argument
+// is a URL object" and wrapped the href STRING in another
+// UrlInstanceToJSON, so js_url_get_href read a StringHeader as an
+// ObjectHeader and produced undefined. Only Expr::UrlNew proves the
+// lowered argument is a URL object.
+const u = new URL("http://x/en", "http://x/");
+
+// The bug: inline string-producing URL method calls.
+console.log(JSON.stringify(u.toString()));
+console.log(JSON.stringify(u.toJSON()));
+
+// Stored form (always worked) — must stay identical to the inline form.
+const r = u.toString();
+console.log(JSON.stringify(r));
+
+// URL-object arguments — the toJSON interception must still fire so
+// these stringify as the quoted href, not a field dump.
+console.log(JSON.stringify(u));
+console.log(JSON.stringify(new URL("http://y/fr", "http://y/")));
+
+// Property read producing the href string.
+console.log(JSON.stringify(u.href));

--- a/test-files/test_gap_6488_json_stringify_url_tostring_inline.ts
+++ b/test-files/test_gap_6488_json_stringify_url_tostring_inline.ts
@@ -21,5 +21,12 @@ console.log(JSON.stringify(r));
 console.log(JSON.stringify(u));
 console.log(JSON.stringify(new URL("http://y/fr", "http://y/")));
 
+// Replacer/spacer forms: toJSON runs BEFORE the replacer per
+// SerializeJSONProperty, so these also print the quoted href (perry
+// used to walk the opaque URL object and throw a circular-structure
+// TypeError on its searchParams back-reference).
+console.log(JSON.stringify(u, null, 2));
+console.log(JSON.stringify(u, (_k: string, v: unknown) => v, 2));
+
 // Property read producing the href string.
 console.log(JSON.stringify(u.href));


### PR DESCRIPTION
Fixes #6488.

## Root cause

`JSON.stringify(u.toString())` with a URL receiver lowers the argument to `Expr::UrlInstanceToString(u)` (the href **string**). The single-arg `JSON.stringify` special-case in `crates/perry-hir/src/lower/expr_call/module_static.rs` then pattern-matched that HIR variant (and `UrlInstanceToJSON`) as "the argument is a URL object" and wrapped it in another `UrlInstanceToJSON`:

```
JsonStringifyFull(UrlInstanceToJSON(UrlInstanceToString(u)), Null, Null)
```

`UrlInstanceToJSON` codegens to `js_url_get_href`, so the second call received the href string and `js_object_get_field_f64` read the `StringHeader` as a URL `ObjectHeader` field table — yielding `undefined`, which `JSON.stringify` then reported as top-level `undefined`.

This is why the trigger was so narrow: only URL receivers produce `UrlInstance*` HIR variants, and only the single-arg `JSON.stringify` lowering has this interception (`String(u.toString())`, user functions, `console.log`, the 3-arg stringify form, and a stored `const r = u.toString()` were all unaffected).

## Fix

`UrlInstanceToJSON` / `UrlInstanceToString` produce strings by construction and can never be a URL object, so drop them from the `matches!`. Only `Expr::UrlNew` proves the lowered argument is a URL object. The AST-side `static_receiver_class` check is unaffected (it returns `None` for call expressions, so it never misfires on these shapes) and continues to handle URL-typed locals (`JSON.stringify(u)`).

`JSON.stringify(u.toJSON())` was broken the same way and is fixed by the same change.

## Validation

New gap test `test-files/test_gap_6488_json_stringify_url_tostring_inline.ts` is byte-identical to node and covers: inline `u.toString()` / `u.toJSON()`, the stored-variable form, `JSON.stringify(u)` and `JSON.stringify(new URL(...))` (the interception must still fire for real URL objects), and `u.href`.

Ran the 13 existing URL/JSON gap/issue tests against the fixed build — all match node (the only diffs were node's DEP0169 stderr deprecation warnings, present on pristine main as well). `cargo test -p perry-hir` has one failure, `logical_property_assignment_short_circuits_the_store_4586`, which fails identically on pristine main (`137cfefca`) — pre-existing, unrelated.

Per contributor convention this PR is code-only: no version bump, no CHANGELOG entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `JSON.stringify` output for values derived from `URL.toString()` and `URL.toJSON()`, ensuring they serialize consistently.
  * Improved URL handling so `JSON.stringify` correctly applies URL serialization before `replacer`/`space` processing.
  * Preserved expected JSON serialization for `URL` objects and `href` properties.

* **Tests**
  * Added regression coverage for inline URL stringification and direct URL serialization, including `JSON.stringify(url, replacer, space)` cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->