### PR TITLE
fix(runtime): resolve array forwarding stubs in thread crossing and spread calls (#6518)

### DIFF
--- a/crates/perry-runtime/src/closure/dispatch/value_call.rs
+++ b/crates/perry-runtime/src/closure/dispatch/value_call.rs
@@ -682,13 +682,19 @@ pub unsafe extern "C" fn js_closure_call_apply_with_spread(
         regular_count as usize
     };
 
-    let arr = spread_arr_handle as *const ArrayHeader;
-    let (spread_n, spread_data): (usize, *const f64) = if arr.is_null() {
-        (0, std::ptr::null())
+    // #6518: resolve a push-grown array's forwarding stub (#233, the #6486
+    // family) before reading length. In-tree codegen callsites pre-resolve
+    // the spread source through `js_array_like_to_array` (whose real-Array
+    // arm runs `clean_arr_ptr`), but this helper is `#[no_mangle]` and
+    // declared to stdlib FFI — a caller passing a raw handle to a grown
+    // array would read the forwarding pointer's bytes as the spread length.
+    // Don't lean on upstream cleaning for memory safety here; the re-clean
+    // on an already-resolved pointer is cheap.
+    let arr = crate::array::clean_arr_ptr(spread_arr_handle as *const ArrayHeader);
+    let spread_n: usize = if arr.is_null() {
+        0
     } else {
-        let len = (*arr).length as usize;
-        let data = (arr as *const u8).add(std::mem::size_of::<ArrayHeader>()) as *const f64;
-        (len, data)
+        (*arr).length as usize
     };
 
     let total = reg_n + spread_n;
@@ -696,14 +702,20 @@ pub unsafe extern "C" fn js_closure_call_apply_with_spread(
     // Small fast path: stack buffer for up to 16 args (matches js_closure_call16).
     let mut stack_buf: [f64; 16] = [0.0; 16];
     let mut heap_buf: Vec<f64>;
+    // Spread slots are read per element via `js_array_get_f64`, not a raw
+    // memcpy: a sparse array (length > capacity, far slots in
+    // ARRAY_NAMED_PROPS) legally passes `clean_arr_ptr`, so copying `length`
+    // raw slots reads out of bounds (same rule as #6517's from-array
+    // constructors). The accessor resolves far-index slots and reads holes
+    // as undefined.
     let buf_ptr: *const f64 = if total <= 16 {
         if !regular_args.is_null() && reg_n > 0 {
             // GC_STORE_AUDIT(STACK): spread-call regular args copy into a temporary stack buffer.
             std::ptr::copy_nonoverlapping(regular_args, stack_buf.as_mut_ptr(), reg_n);
         }
-        if !spread_data.is_null() && spread_n > 0 {
+        for i in 0..spread_n {
             // GC_STORE_AUDIT(STACK): spread args copy into a temporary stack buffer.
-            std::ptr::copy_nonoverlapping(spread_data, stack_buf.as_mut_ptr().add(reg_n), spread_n);
+            stack_buf[reg_n + i] = crate::array::js_array_get_f64(arr, i as u32);
         }
         stack_buf.as_ptr()
     } else {
@@ -712,9 +724,9 @@ pub unsafe extern "C" fn js_closure_call_apply_with_spread(
             // GC_STORE_AUDIT(STACK): regular args copy into a temporary native Vec buffer.
             std::ptr::copy_nonoverlapping(regular_args, heap_buf.as_mut_ptr(), reg_n);
         }
-        if !spread_data.is_null() && spread_n > 0 {
+        for i in 0..spread_n {
             // GC_STORE_AUDIT(STACK): spread args copy into a temporary native Vec buffer.
-            std::ptr::copy_nonoverlapping(spread_data, heap_buf.as_mut_ptr().add(reg_n), spread_n);
+            heap_buf[reg_n + i] = crate::array::js_array_get_f64(arr, i as u32);
         }
         heap_buf.as_ptr()
     };

--- a/crates/perry-runtime/src/thread.rs
+++ b/crates/perry-runtime/src/thread.rs
@@ -821,7 +821,22 @@ pub extern "C" fn js_thread_parallel_map(array_val: f64, closure_val: f64) -> f6
 }
 
 unsafe fn parallel_map_impl(array_val: f64, closure_val: f64) -> i64 {
-    // ── 1. Extract array pointer from NaN-boxed value ────────────────
+    // ── 1. Extract closure pointer and func_ptr, and root the closure ─
+    // The closure is validated and rooted BEFORE `clean_arr_ptr`: resolving
+    // the array can force-materialize a lazy array — a GC point — and a
+    // moving minor there would strand a raw closure pointer held in an
+    // unrooted local (#6521 review follow-up).
+    let closure_bits = closure_val.to_bits();
+    let closure = (closure_bits & POINTER_MASK) as *const ClosureHeader;
+    if closure.is_null() || (closure as usize) < 0x1000 {
+        // No valid closure — can't call anything
+        return crate::array::js_array_alloc(0) as i64;
+    }
+    let func = (*closure).func_ptr;
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let closure_handle = scope.root_raw_mut_ptr(closure as *mut ClosureHeader);
+
+    // ── 1b. Extract array pointer from NaN-boxed value ───────────────
     let array_bits = array_val.to_bits();
     let arr = (array_bits & POINTER_MASK) as *const crate::array::ArrayHeader;
     // #6518: follow a push-grown array's forwarding stub (#233, the #6486
@@ -839,15 +854,9 @@ unsafe fn parallel_map_impl(array_val: f64, closure_val: f64) -> i64 {
         return crate::array::js_array_alloc(0) as i64;
     }
 
-    // ── 1b. Extract closure pointer and func_ptr ─────────────────────
-    let closure_bits = closure_val.to_bits();
-    let closure = (closure_bits & POINTER_MASK) as *const ClosureHeader;
-    let func = if !closure.is_null() && (closure as usize) >= 0x1000 {
-        (*closure).func_ptr
-    } else {
-        // No valid closure — can't call anything
-        return crate::array::js_array_alloc(0) as i64;
-    };
+    // Re-derive the (possibly moved) closure now that the GC points above
+    // are behind us; no further GC points before the derefs below.
+    let closure = closure_handle.get_raw_const_ptr::<ClosureHeader>();
     let closure_ptr_raw = closure as i64;
 
     // ── 2. Determine thread count ────────────────────────────────────
@@ -1029,19 +1038,20 @@ unsafe fn single_thread_map(
     func: *const u8,
     closure_ptr: i64,
 ) -> i64 {
-    // Root the input array BEFORE allocating the result (the allocation can
-    // trigger a moving minor), and re-derive the elements pointer from the
-    // rooted handle each iteration — the user callback can allocate too.
+    // Root the input array AND the closure BEFORE allocating the result (the
+    // allocation can trigger a moving minor), and re-derive both from their
+    // rooted handles each iteration — the user callback can allocate too, and
+    // a moved closure would leave later iterations calling through a dangling
+    // capture block (#6521 review).
     let scope = crate::gc::RuntimeHandleScope::new();
     let arr_handle = scope.root_raw_mut_ptr(arr as *mut crate::array::ArrayHeader);
+    let closure_handle = if closure_ptr != 0 {
+        Some(scope.root_raw_mut_ptr(closure_ptr as *mut ClosureHeader))
+    } else {
+        None
+    };
     let result_arr = crate::array::js_array_alloc(len as u32);
     let result_handle = scope.root_raw_mut_ptr(result_arr);
-
-    let closure = if closure_ptr != 0 {
-        closure_ptr as *const ClosureHeader
-    } else {
-        ptr::null()
-    };
 
     let call_fn: ClosureCallFn = std::mem::transmute(func as usize);
 
@@ -1052,6 +1062,9 @@ unsafe fn single_thread_map(
             arr_handle.get_raw_mut_ptr::<crate::array::ArrayHeader>(),
             i as u32,
         );
+        let closure = closure_handle
+            .as_ref()
+            .map_or(ptr::null(), |h| h.get_raw_const_ptr::<ClosureHeader>());
         let result = call_fn(closure, arg);
         let result_arr = result_handle.get_raw_mut_ptr::<crate::array::ArrayHeader>();
         // GC_STORE_AUDIT(BARRIERED): single-thread map result slot uses the shared array slot-store helper.
@@ -1082,6 +1095,17 @@ pub extern "C" fn js_thread_parallel_filter(array_val: f64, closure_val: f64) ->
 }
 
 unsafe fn parallel_filter_impl(array_val: f64, closure_val: f64) -> i64 {
+    // Closure validated and rooted BEFORE `clean_arr_ptr` — same GC-point
+    // ordering as `parallel_map_impl` above (#6521 review follow-up).
+    let closure_bits = closure_val.to_bits();
+    let closure = (closure_bits & POINTER_MASK) as *const ClosureHeader;
+    if closure.is_null() || (closure as usize) < 0x1000 {
+        return crate::array::js_array_alloc(0) as i64;
+    }
+    let func = (*closure).func_ptr;
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let closure_handle = scope.root_raw_mut_ptr(closure as *mut ClosureHeader);
+
     let array_bits = array_val.to_bits();
     let arr = (array_bits & POINTER_MASK) as *const crate::array::ArrayHeader;
     // #6518: same forwarding-stub resolution as `parallel_map_impl` above.
@@ -1095,13 +1119,9 @@ unsafe fn parallel_filter_impl(array_val: f64, closure_val: f64) -> i64 {
         return crate::array::js_array_alloc(0) as i64;
     }
 
-    let closure_bits = closure_val.to_bits();
-    let closure = (closure_bits & POINTER_MASK) as *const ClosureHeader;
-    let func = if !closure.is_null() && (closure as usize) >= 0x1000 {
-        (*closure).func_ptr
-    } else {
-        return crate::array::js_array_alloc(0) as i64;
-    };
+    // Re-derive the (possibly moved) closure now that the GC points above
+    // are behind us; no further GC points before the derefs below.
+    let closure = closure_handle.get_raw_const_ptr::<ClosureHeader>();
 
     let num_threads = std::thread::available_parallelism()
         .map(|n| n.get())
@@ -1257,9 +1277,16 @@ unsafe fn single_thread_filter(
     closure: *const ClosureHeader,
 ) -> i64 {
     // Same rooting discipline as single_thread_map: the result allocation
-    // and every user callback can trigger a moving minor.
+    // and every user callback can trigger a moving minor, so the array AND
+    // the closure are re-derived from rooted handles each iteration
+    // (#6521 review).
     let scope = crate::gc::RuntimeHandleScope::new();
     let arr_handle = scope.root_raw_mut_ptr(arr as *mut crate::array::ArrayHeader);
+    let closure_handle = if closure.is_null() {
+        None
+    } else {
+        Some(scope.root_raw_mut_ptr(closure as *mut ClosureHeader))
+    };
     let result_arr = crate::array::js_array_alloc(len as u32);
     let result_handle = scope.root_raw_mut_ptr(result_arr);
 
@@ -1273,6 +1300,9 @@ unsafe fn single_thread_filter(
             arr_handle.get_raw_mut_ptr::<crate::array::ArrayHeader>(),
             i as u32,
         );
+        let closure = closure_handle
+            .as_ref()
+            .map_or(ptr::null(), |h| h.get_raw_const_ptr::<ClosureHeader>());
         let result = call_fn(closure, arg);
         let keep = is_truthy_bits(result.to_bits());
         if keep {

--- a/crates/perry-runtime/src/thread.rs
+++ b/crates/perry-runtime/src/thread.rs
@@ -481,16 +481,28 @@ unsafe fn guard_transferable(values: &[SerializedValue]) {
 
 /// Serialize an ArrayHeader into a SerializedValue::Array.
 unsafe fn serialize_array(arr: *const crate::array::ArrayHeader) -> SerializedValue {
-    if arr.is_null() || (arr as usize) < 0x1000 {
+    // #6518 (forwarding-chain family of #6486): the caller may hold a stale
+    // pre-grow pointer — `js_array_grow` moves the array and leaves a
+    // GC_FLAG_FORWARDED stub at the old address (#233) whose first 8 bytes
+    // (length+capacity) are the forwarding pointer. Raw-dereferencing
+    // `(*arr).length` here read those bytes as the element count and
+    // serialized a garbage-length array across the thread boundary.
+    // `clean_arr_ptr` follows the chain, validates the header, and
+    // materializes lazy arrays.
+    let arr = crate::array::clean_arr_ptr(arr);
+    if arr.is_null() {
         return SerializedValue::Array(Vec::new());
     }
     let len = (*arr).length as usize;
-    let elements_ptr =
-        (arr as *const u8).add(std::mem::size_of::<crate::array::ArrayHeader>()) as *const f64;
 
+    // Element reads go through `js_array_get_f64`, not a raw pointer walk:
+    // a sparse array (length > capacity, far slots in ARRAY_NAMED_PROPS)
+    // legally passes `clean_arr_ptr`, so walking `length` raw slots reads
+    // out of bounds (same rule as #6517's from-array constructors). The
+    // accessor resolves far-index slots and reads holes as undefined.
     let mut elements = Vec::with_capacity(len);
     for i in 0..len {
-        let elem_bits = (*elements_ptr.add(i)).to_bits();
+        let elem_bits = crate::array::js_array_get_f64(arr, i as u32).to_bits();
         elements.push(serialize_nanbox_for_thread(elem_bits));
     }
     SerializedValue::Array(elements)
@@ -812,7 +824,13 @@ unsafe fn parallel_map_impl(array_val: f64, closure_val: f64) -> i64 {
     // ── 1. Extract array pointer from NaN-boxed value ────────────────
     let array_bits = array_val.to_bits();
     let arr = (array_bits & POINTER_MASK) as *const crate::array::ArrayHeader;
-    if arr.is_null() || (arr as usize) < 0x1000 {
+    // #6518: follow a push-grown array's forwarding stub (#233, the #6486
+    // family) before reading length — `parallelMap` on a caller's stale
+    // pre-grow pointer read the forwarding pointer's bytes as the element
+    // count. `clean_arr_ptr` also validates the header and materializes
+    // lazy arrays.
+    let arr = crate::array::clean_arr_ptr(arr);
+    if arr.is_null() {
         return crate::array::js_array_alloc(0) as i64;
     }
 
@@ -845,11 +863,12 @@ unsafe fn parallel_map_impl(array_val: f64, closure_val: f64) -> i64 {
     }
 
     // ── 4. Serialize all input elements ──────────────────────────────
-    let elements_ptr =
-        (arr as *const u8).add(std::mem::size_of::<crate::array::ArrayHeader>()) as *const f64;
+    // Per-element via `js_array_get_f64`: a sparse array (length > capacity)
+    // legally passes `clean_arr_ptr`, so a raw walk over `length` slots
+    // reads out of bounds (same rule as in `serialize_array`).
     let mut serialized_elements = Vec::with_capacity(len);
     for i in 0..len {
-        let bits = (*elements_ptr.add(i)).to_bits();
+        let bits = crate::array::js_array_get_f64(arr, i as u32).to_bits();
         serialized_elements.push(serialize_nanbox_for_thread(bits));
     }
     // #6185: a non-transferable element (e.g. a Map in the input array) would
@@ -1027,10 +1046,12 @@ unsafe fn single_thread_map(
     let call_fn: ClosureCallFn = std::mem::transmute(func as usize);
 
     for i in 0..len {
-        let elements_ptr = (arr_handle.get_raw_mut_ptr::<crate::array::ArrayHeader>() as *const u8)
-            .add(std::mem::size_of::<crate::array::ArrayHeader>())
-            as *const f64;
-        let arg = *elements_ptr.add(i);
+        // Sparse-safe element read (see `parallel_map_impl`); re-derived from
+        // the rooted handle each iteration because the callback can move it.
+        let arg = crate::array::js_array_get_f64(
+            arr_handle.get_raw_mut_ptr::<crate::array::ArrayHeader>(),
+            i as u32,
+        );
         let result = call_fn(closure, arg);
         let result_arr = result_handle.get_raw_mut_ptr::<crate::array::ArrayHeader>();
         // GC_STORE_AUDIT(BARRIERED): single-thread map result slot uses the shared array slot-store helper.
@@ -1063,7 +1084,9 @@ pub extern "C" fn js_thread_parallel_filter(array_val: f64, closure_val: f64) ->
 unsafe fn parallel_filter_impl(array_val: f64, closure_val: f64) -> i64 {
     let array_bits = array_val.to_bits();
     let arr = (array_bits & POINTER_MASK) as *const crate::array::ArrayHeader;
-    if arr.is_null() || (arr as usize) < 0x1000 {
+    // #6518: same forwarding-stub resolution as `parallel_map_impl` above.
+    let arr = crate::array::clean_arr_ptr(arr);
+    if arr.is_null() {
         return crate::array::js_array_alloc(0) as i64;
     }
 
@@ -1090,12 +1113,11 @@ unsafe fn parallel_filter_impl(array_val: f64, closure_val: f64) -> i64 {
         return single_thread_filter(arr, len, func, closure);
     }
 
-    // Serialize input elements
-    let elements_ptr =
-        (arr as *const u8).add(std::mem::size_of::<crate::array::ArrayHeader>()) as *const f64;
+    // Serialize input elements (per-element accessor: sparse-safe, see
+    // `parallel_map_impl`).
     let mut serialized_elements = Vec::with_capacity(len);
     for i in 0..len {
-        let bits = (*elements_ptr.add(i)).to_bits();
+        let bits = crate::array::js_array_get_f64(arr, i as u32).to_bits();
         serialized_elements.push(serialize_nanbox_for_thread(bits));
     }
     // #6185: fail loudly on a non-transferable input element.
@@ -1245,10 +1267,12 @@ unsafe fn single_thread_filter(
     let mut count = 0u32;
 
     for i in 0..len {
-        let elements_ptr = (arr_handle.get_raw_mut_ptr::<crate::array::ArrayHeader>() as *const u8)
-            .add(std::mem::size_of::<crate::array::ArrayHeader>())
-            as *const f64;
-        let arg = *elements_ptr.add(i);
+        // Sparse-safe element read (see `parallel_map_impl`); re-derived from
+        // the rooted handle each iteration because the callback can move it.
+        let arg = crate::array::js_array_get_f64(
+            arr_handle.get_raw_mut_ptr::<crate::array::ArrayHeader>(),
+            i as u32,
+        );
         let result = call_fn(closure, arg);
         let keep = is_truthy_bits(result.to_bits());
         if keep {

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -1101,6 +1101,14 @@ fn plain_array_index_guard(arr: *const ArrayHeader, index: u32, require_in_bound
         return false;
     };
     unsafe {
+        // #6518 audit note: the GC_FLAG_FORWARDED arm below is load-bearing
+        // for the stale-grown-pointer family (#6486). A caller-held pre-grow
+        // pointer left by `js_array_grow` (#233) is rejected HERE, before
+        // the raw length/capacity read below — the `len > cap` sanity check
+        // alone is not a reliable defense against forwarding-pointer bit
+        // patterns. Same applies to the sibling check in
+        // `numeric_array_push_guard`. Do not remove either arm without
+        // routing the guard through `clean_arr_ptr`.
         if (*header).obj_type != crate::gc::GC_TYPE_ARRAY
             || (*header).gc_flags & crate::gc::GC_FLAG_FORWARDED != 0
         {

--- a/scripts/run_thread_tests.sh
+++ b/scripts/run_thread_tests.sh
@@ -121,6 +121,75 @@ else
     fail=$((fail+1))
 fi
 
+# Case 5 (#6518, family of #6486): an array push-grown past its inline
+# capacity (16) inside a helper leaves the caller's slot holding a stale
+# pre-grow pointer (js_array_grow forwarding stub, #233). parallelMap /
+# parallelFilter read raw `(*arr).length` on the input, and serialize_array
+# raw-read it on any array crossing the thread boundary (as an element on the
+# way in, or as a worker's return value on the way out) — in every case
+# reading the forwarding pointer's bytes as the element count. Must compile,
+# run, and produce exact output.
+cat >"$TMP_DIR/grown_array_crossing.ts" <<'EOF'
+import { parallelFilter, parallelMap, spawn } from "perry/thread";
+
+function fill(out: number[], a: number[]): void {
+  const vs = [a, a, a, a, a, a];
+  for (const v of vs) out.push(v[0], v[1], v[2]);
+}
+
+const verts: number[] = [];
+fill(verts, [1, 2, 3]);
+
+// parallel_map_impl / parallel_filter_impl: raw length read on the input.
+const doubled = parallelMap(verts, (x: number) => x * 2);
+console.log(doubled.length, doubled[0], doubled[17]);
+
+const twos = parallelFilter(verts, (x: number) => x === 2);
+console.log(twos.length, twos[0]);
+
+// serialize_array, main-thread side: grown rows as crossing elements.
+const matrix = [verts, verts, verts, verts];
+const lens = parallelMap(matrix, (r: number[]) => r.length);
+console.log(lens.length, lens[0], lens[3]);
+
+// Holes cross as undefined: element serialization reads through the
+// canonical accessor, which normalizes the hole sentinel.
+const holey: number[] = [];
+holey[20] = 5;
+const marks = parallelMap(holey, (x: number | undefined) => (x === undefined ? 1 : 2));
+console.log(marks.length, marks[0], marks[20]);
+
+// serialize_array, worker side: the worker's own slot goes stale the same
+// way (fill grows `out` past 16), then the return value crosses back.
+async function main(): Promise<void> {
+  const back: number[] = await spawn(() => {
+    const out: number[] = [];
+    fill(out, [4, 5, 6]);
+    return out;
+  });
+  console.log(back.length, back[0], back[17]);
+}
+await main();
+EOF
+expected_grown_output=$'18 2 6\n6 2\n4 18 18\n21 1 2\n18 4 6'
+if ! "$PERRY_BIN" "$TMP_DIR/grown_array_crossing.ts" -o "$TMP_DIR/grown_array_crossing.out" \
+        >/dev/null 2>"$TMP_DIR/grown_array_crossing.stderr"; then
+    echo "FAIL grown_array_crossing: compile error"
+    sed 's/^/    /' "$TMP_DIR/grown_array_crossing.stderr"
+    fail=$((fail+1))
+elif actual_grown_output="$("$TMP_DIR/grown_array_crossing.out" 2>&1)" \
+        && [[ "$actual_grown_output" == "$expected_grown_output" ]]; then
+    echo "PASS grown_array_crossing"
+    pass=$((pass+1))
+else
+    echo "FAIL grown_array_crossing: wrong runtime output"
+    echo "  expected:"
+    sed 's/^/    /' <<<"$expected_grown_output"
+    echo "  actual:"
+    sed 's/^/    /' <<<"$actual_grown_output"
+    fail=$((fail+1))
+fi
+
 echo
 echo "thread-tests: $pass passed, $fail failed"
 

--- a/test-files/test_gap_6518_spread_call_grown_array.ts
+++ b/test-files/test_gap_6518_spread_call_grown_array.ts
@@ -1,0 +1,55 @@
+// #6518 (forwarding-chain family of #6486): an array grown by `push` past its
+// inline capacity (16) inside a helper moves via `js_array_grow`, leaving a
+// GC_FLAG_FORWARDED stub at the old address (#233) while the caller's
+// variable keeps the stale pre-grow pointer. Spreading that array into a call
+// is only safe because SOMETHING on the path follows the forwarding chain —
+// today `js_array_like_to_array`'s real-Array arm (clean_arr_ptr), plus the
+// #6518 re-clean inside `js_closure_call_apply_with_spread` itself. This test
+// pins the end-to-end behavior so neither resolution point can silently
+// regress: `f(...arr)` reading the stub's bytes as the spread length crashes
+// or garbles every line below.
+
+// The #6486 trigger shape: fn + for-of + 3-arg push × 6 iterations grows the
+// caller's array past 16 while the caller's slot keeps the pre-grow pointer.
+function fill(out: number[], a: number[]): void {
+  const vs = [a, a, a, a, a, a];
+  for (const v of vs) out.push(v[0], v[1], v[2]);
+}
+const verts: number[] = [];
+fill(verts, [1, 2, 3]);
+console.log(verts.length);
+
+// Closure spread call — the CallSpread arm that lowers to
+// js_closure_call_apply_with_spread.
+const collect = (...xs: number[]): number => xs.length;
+console.log(collect(...verts));
+
+// Regular args mixed with spread.
+console.log(collect(0, 0, ...verts));
+
+// Spread into declared params + rest: the values (not just the count) must
+// come from the grown array's real elements.
+const sum3 = (a: number, b: number, c: number, ...rest: number[]): number =>
+  a + b + c + rest.length;
+console.log(sum3(...verts));
+
+// Builtin spread callees over the same grown array.
+console.log(Math.max(...verts), Math.min(...verts));
+
+// Below-capacity control: must keep working (never corrupted before either).
+function fillSmall(out: number[], a: number[]): void {
+  const vs = [a, a, a];
+  for (const v of vs) out.push(v[0], v[1], v[2]);
+}
+const small: number[] = [];
+fillSmall(small, [4, 5, 6]);
+console.log(collect(...small), sum3(...small));
+
+// Holes must spread as `undefined`: the spread slots are read through the
+// canonical element accessor, which normalizes the hole sentinel — a raw
+// slot copy would leak the sentinel bits into the argument buffer.
+const holey: number[] = [];
+holey[20] = 9;
+const pick = (...xs: (number | undefined)[]): string => `${xs.length} ${xs[0]} ${xs[20]}`;
+console.log(pick(...holey));
+console.log(pick(7, ...holey));


### PR DESCRIPTION
Closes #6518 (the forwarding-chain family of #6486, sibling of #6517).

## Problem

`js_array_grow` moves a push-grown array and leaves a `GC_FLAG_FORWARDED` stub at the old address (#233); the old header's first 8 bytes (length+capacity) become the forwarding pointer. Any consumer that raw-dereferences `(*arr).length` on a caller-supplied pointer — instead of resolving through `clean_arr_ptr` — reads the forwarding pointer's bytes as the element count. #6517 fixed the from-array construction paths; this PR closes out the remaining readers from the #6518 audit, each verified individually.

## Confirmed bugs, fixed (verified by negative control)

- **`thread.rs` `parallel_map_impl` / `parallel_filter_impl`** — `parallelMap(arr, fn)` / `parallelFilter(arr, fn)` on a grown array read raw `(*arr).length` right after the NaN-box strip.
- **`thread.rs` `serialize_array`** — a stale array pointer crossing the thread boundary (as an element of a crossed array on the way in, or as a worker's return value on the way out) serialized with a garbage length. The old GcHeader still reads `GC_TYPE_ARRAY`, so `serialize_nanbox_for_thread` dispatched straight into the raw length read.

All three now resolve through `clean_arr_ptr` (chain-follow + header validation + lazy-array materialization) before reading `length`. Negative control: with these two files reverted to origin/main (everything else identical), the new `grown_array_crossing` case crashes with no output; with the fix, byte-exact expected output.

## Hardened (raw deref real, stale caller not currently reachable in-tree)

- **`value_call.rs` `js_closure_call_apply_with_spread`** — raw-read `(*arr).length` on the spread handle. In-tree codegen callsites pre-resolve the spread source through `js_array_like_to_array`, whose real-Array arm already runs `clean_arr_ptr` — so `f(...grownArr)` does not currently reach this deref stale (confirmed: the new gap test passes even on the unfixed runtime). But the helper is `#[no_mangle]` and declared to stdlib FFI, so its contract accepts a raw handle; it now re-cleans instead of leaning on upstream cleaning for memory safety. The gap test pins the end-to-end spread behavior so neither resolution point can silently regress.

## Sparse-safe element reads (same rule as #6517's review follow-up)

Element reads at every touched site (`serialize_array`, the map/filter serialize loops, `single_thread_map`/`single_thread_filter`, the spread arg copy) now go through `js_array_get_f64` instead of raw pointer walks: a sparse array (length > capacity, far slots in `ARRAY_NAMED_PROPS`) legally passes `clean_arr_ptr`, so walking `length` raw slots reads out of bounds — the same hazard the #6517 review fixed in the from-array constructors. The accessor also normalizes the `TAG_HOLE` sentinel to `undefined`, which the raw copies leaked into arg buffers and cross-thread payloads (`f(...holey)` / `parallelMap(holey, fn)` legs in the tests pin this).

## Audited, no behavior change needed

- **`typed_feedback.rs`** (`plain_array_index_guard`, `numeric_array_push_guard`): the issue flagged their raw length/capacity reads, but both guards already reject `GC_FLAG_FORWARDED` headers **before** those reads (present since the typed-feedback foundation, #1752) — a stale grown pointer deterministically falls back to the slow path, which follows the chain. Added an audit note marking the arm load-bearing; the `len > cap` sanity check alone would not be a reliable defense.

Out of scope, per the issue: writers to freshly-allocated arrays (plugin.rs, regex.rs, json_tape materialization) — those pointers can't be stale. Also surveyed the remaining `.length` reads in thread.rs: all are writers to freshly-allocated result/deserialize arrays, or the runtime-managed `keys_array` object field.

## Tests

- `test-files/test_gap_6518_spread_call_grown_array.ts` — node-parity gap test (byte-identical vs `node --experimental-strip-types`): closure spread, mixed regular+spread, declared params + rest, `Math.max/min` spread, below-capacity control.
- `scripts/run_thread_tests.sh` — new runtime case `grown_array_crossing`: `parallelMap`/`parallelFilter` on a grown array, grown rows as crossing elements (main-thread `serialize_array`), and a worker returning an array grown via a helper (worker-side `serialize_array`). Fails (crash) on the unfixed runtime, passes with this PR. Perry-specific `perry/thread` API, so it can't live in the node-parity suite.

While writing these repros I found an unrelated pre-existing bug — a `spawn` closure capturing an async-fn local array sees it as empty — filed separately as #6520 (reproduces identically with and without this PR, including for never-grown arrays).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect spread, rest/closure calls, and built-in spread behavior when arrays grow past inline capacity.
  * Improved array serialization and element access during thread-bound execution to correctly follow forwarded headers and avoid out-of-bounds/sparse issues.
  * Updated map/filter execution paths to use safe per-index reads and correct forwarding resolution.
* **Tests**
  * Added regression tests for grown-array spread (`#6518`) and cross-thread `parallelMap`, `parallelFilter`, and `spawn` scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->