### PR TITLE
fix(cache): key the object cache on all codegen-affecting env vars (#6394)

### DIFF
--- a/crates/perry/src/commands/compile/object_cache.rs
+++ b/crates/perry/src/commands/compile/object_cache.rs
@@ -806,6 +806,92 @@ fn compute_object_cache_key_with_env(
         "env_target_cpu",
         env_var("PERRY_TARGET_CPU").as_deref().unwrap_or(""),
     );
+    // Codegen tuning/emission toggles (#6394). Each is read by perry-codegen
+    // at compile time and changes the emitted IR / .o bytes, so a warm cache
+    // must not serve an object built under a different setting. These are
+    // process-env reads (`std::env::var`), NOT runtime globals: the class-field
+    // inline guard, typed-array view guard, and TA kind cache are emitted as
+    // loads of `@PERRY_*` globals resolved at run time — codegen emits them
+    // identically regardless of the compile-time environment, so they are
+    // deliberately absent here.
+    h.field(
+        "env_typed_feedback",
+        env_var("PERRY_TYPED_FEEDBACK").as_deref().unwrap_or(""),
+    );
+    h.field(
+        "env_typed_feedback_trace",
+        env_var("PERRY_TYPED_FEEDBACK_TRACE")
+            .as_deref()
+            .unwrap_or(""),
+    );
+    h.field(
+        "env_full_outline_ic",
+        env_var("PERRY_FULL_OUTLINE_IC").as_deref().unwrap_or(""),
+    );
+    h.field(
+        "env_full_outline_ic_min_funcs",
+        env_var("PERRY_FULL_OUTLINE_IC_MIN_FUNCS")
+            .as_deref()
+            .unwrap_or(""),
+    );
+    h.field(
+        "env_outline_method_dispatch",
+        env_var("PERRY_OUTLINE_METHOD_DISPATCH")
+            .as_deref()
+            .unwrap_or(""),
+    );
+    h.field(
+        "env_inline_new",
+        env_var("PERRY_INLINE_NEW").as_deref().unwrap_or(""),
+    );
+    h.field(
+        "env_inline_ctor",
+        env_var("PERRY_INLINE_CTOR").as_deref().unwrap_or(""),
+    );
+    h.field(
+        "env_string_init_chunk_size",
+        env_var("PERRY_STRING_INIT_CHUNK_SIZE")
+            .as_deref()
+            .unwrap_or(""),
+    );
+    h.field(
+        "env_ll_o0_threshold_bytes",
+        env_var("PERRY_LL_O0_THRESHOLD_BYTES")
+            .as_deref()
+            .unwrap_or(""),
+    );
+    h.field(
+        "env_ll_size_opt",
+        env_var("PERRY_LL_SIZE_OPT").as_deref().unwrap_or(""),
+    );
+    h.field(
+        "env_ll_size_opt_max_fn_bytes",
+        env_var("PERRY_LL_SIZE_OPT_MAX_FN_BYTES")
+            .as_deref()
+            .unwrap_or(""),
+    );
+    h.field(
+        "env_entry_symbol",
+        env_var("PERRY_ENTRY_SYMBOL").as_deref().unwrap_or(""),
+    );
+    h.field(
+        "env_codegen_units",
+        env_var("PERRY_CODEGEN_UNITS").as_deref().unwrap_or(""),
+    );
+    h.field(
+        "env_codegen_unit_size",
+        env_var("PERRY_CODEGEN_UNIT_SIZE").as_deref().unwrap_or(""),
+    );
+    h.field(
+        "env_setjmp_volatile",
+        env_var("PERRY_SETJMP_VOLATILE").as_deref().unwrap_or(""),
+    );
+    h.field(
+        "env_gc_moving_loop_polls",
+        env_var("PERRY_GC_MOVING_LOOP_POLLS")
+            .as_deref()
+            .unwrap_or(""),
+    );
 
     h.finish()
 }

--- a/crates/perry/src/commands/compile/object_cache/object_cache_tests.rs
+++ b/crates/perry/src/commands/compile/object_cache/object_cache_tests.rs
@@ -587,6 +587,23 @@ fn key_changes_with_codegen_env_vars() {
         "PERRY_VERIFY_NATIVE_REGIONS",
         "PERRY_UNBOXED_OBJECT_FIELDS",
         "PERRY_TARGET_CPU",
+        // Codegen tuning/emission toggles (#6394).
+        "PERRY_TYPED_FEEDBACK",
+        "PERRY_TYPED_FEEDBACK_TRACE",
+        "PERRY_FULL_OUTLINE_IC",
+        "PERRY_FULL_OUTLINE_IC_MIN_FUNCS",
+        "PERRY_OUTLINE_METHOD_DISPATCH",
+        "PERRY_INLINE_NEW",
+        "PERRY_INLINE_CTOR",
+        "PERRY_STRING_INIT_CHUNK_SIZE",
+        "PERRY_LL_O0_THRESHOLD_BYTES",
+        "PERRY_LL_SIZE_OPT",
+        "PERRY_LL_SIZE_OPT_MAX_FN_BYTES",
+        "PERRY_ENTRY_SYMBOL",
+        "PERRY_CODEGEN_UNITS",
+        "PERRY_CODEGEN_UNIT_SIZE",
+        "PERRY_SETJMP_VOLATILE",
+        "PERRY_GC_MOVING_LOOP_POLLS",
     ] {
         // Sample state without the var, with the var, and with a different
         // value — all three keys must be distinct.


### PR DESCRIPTION
## Problem

The object cache (`node_modules/.cache/perry`) keys on source + compiler identity + a curated set of codegen-affecting environment variables — but that set was **incomplete**. Nine vars were keyed (`PERRY_WRITE_BARRIERS`, `PERRY_SHADOW_STACK`, `PERRY_TARGET_CPU`, …), while ~16 other `PERRY_*` vars that `perry-codegen` reads at compile time — and that change the emitted `.o` — were not. Setting any of those against a warm cache silently reused an object built *without* it: the switch appears to do nothing, and any A/B or bisection built on it is vacuous.

(Contrary to the issue title, `PERRY_WRITE_BARRIERS` itself is already keyed — the env block exists. This PR closes the remaining gap so that *no* codegen env var can silently no-op with a warm cache.)

## Fix

Add the missing compile-time codegen env vars to `compute_object_cache_key_with_env`
(`crates/perry/src/commands/compile/object_cache.rs`):

`PERRY_TYPED_FEEDBACK`, `PERRY_TYPED_FEEDBACK_TRACE`, `PERRY_FULL_OUTLINE_IC`,
`PERRY_FULL_OUTLINE_IC_MIN_FUNCS`, `PERRY_OUTLINE_METHOD_DISPATCH`, `PERRY_INLINE_NEW`,
`PERRY_INLINE_CTOR`, `PERRY_STRING_INIT_CHUNK_SIZE`, `PERRY_LL_O0_THRESHOLD_BYTES`,
`PERRY_LL_SIZE_OPT`, `PERRY_LL_SIZE_OPT_MAX_FN_BYTES`, `PERRY_ENTRY_SYMBOL`,
`PERRY_CODEGEN_UNITS`, `PERRY_CODEGEN_UNIT_SIZE`, `PERRY_SETJMP_VOLATILE`,
`PERRY_GC_MOVING_LOOP_POLLS`.

Each is a `std::env::var` read in `perry-codegen` that changes emitted IR or the
`.ll`→`.o` compile decision (typed-feedback site emission, IC inline/outline, method-dispatch
outlining, inline `new`/ctor, string-init chunking, per-unit `-O0`/`-Os` selection, entry-symbol
rename, codegen-unit partitioning, volatile-setjmp promotion, and loop GC-poll emission).

### Deliberately excluded

- **Runtime globals, not compile-time env:** `PERRY_CLASS_FIELD_INLINE_GUARD_DISABLED`,
  `PERRY_TA_VIEW_GUARD`, `PERRY_TA_KIND_CACHE` — codegen emits loads of `@PERRY_*` globals
  resolved at run time, so the emitted bytes are identical regardless of the compile-time
  environment.
- **Diagnostics / side files only:** `PERRY_LLVM_KEEP_IR`, `PERRY_SAVE_LL`, `PERRY_NATIVE_REPS*`,
  `PERRY_NO_CLANG_PROBE`.
- **Final-link step, not per-module `.o`:** `PERRY_LD`.
- **Already captured indirectly:** `PERRY_WATCHOS_ARM64_32` (folds into the resolved target
  triple, already hashed as `tgt`); `PERRY_GLOBAL_SCRIPT_THIS` / `PERRY_EVAL_CSP` /
  `PERRY_ALLOW_UNIMPLEMENTED` (affect AST→HIR lowering, captured by the `hir` fingerprint).

Over-inclusion only costs an unnecessary cache miss when a rarely-set var is present;
under-inclusion is the silent-wrong-result bug — so the classification errs toward inclusion
for anything that changes emitted bytes.

The auto-optimize archive cache (`target/perry-auto-*`, keyed by
`auto_optimized_cache_key`) is a separate mechanism that keys the Rust build of the
runtime/stdlib static archives, not the per-module TS `.o`; it does not share this blind spot
and is out of scope.

## Test

Extends `key_changes_with_codegen_env_vars` to assert every newly-keyed var (unset vs set vs a
different value) produces a distinct key, via the existing `compute_object_cache_key_with_env`
seam (no process-environment mutation).

Closes #6394


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build cache accuracy by including additional code-generation and tracing-related environment settings in the object-cache key.
  * Prevented reuse of previously cached object files when compile-time tuning options differ between builds.
* **Tests**
  * Expanded cache invalidation tests to cover more code-generation configuration environment variables, verifying distinct cache keys for different unset/set combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->