### PR TITLE
fix(bench): version-invariant Cargo.toml fingerprint in the public-baseline gate

### DIFF
--- a/benchmarks/public_baseline.py
+++ b/benchmarks/public_baseline.py
@@ -7,6 +7,7 @@ import argparse
 import hashlib
 import json
 import math
+import re
 import shutil
 import statistics
 import subprocess
@@ -82,13 +83,29 @@ def _git(*args: str) -> str:
     ).stdout.strip()
 
 
+# The workspace package version is bumped on every release and does not
+# affect benchmark behaviour, but `Cargo.toml` is a fingerprinted source
+# input. Hashing its raw bytes made every version bump invalidate the
+# recorded baseline, reddening the freshness gate on every subsequent PR.
+# Normalize the version line so only benchmark-relevant Cargo.toml changes
+# (dependencies, profiles) move the fingerprint.
+_CARGO_VERSION_RE = re.compile(rb'(?m)^version = "[^"]*"')
+
+
+def _fingerprint_bytes(name: str) -> bytes:
+    data = (ROOT / name).read_bytes()
+    if name == "Cargo.toml":
+        data = _CARGO_VERSION_RE.sub(b'version = "0.0.0"', data)
+    return data
+
+
 def tracked_fingerprint(paths: Iterable[str]) -> str:
     names = _git("ls-files", "-z", "--", *paths).split("\0")
     digest = hashlib.sha256()
     for name in sorted(filter(None, names)):
         digest.update(name.encode())
         digest.update(b"\0")
-        digest.update((ROOT / name).read_bytes())
+        digest.update(_fingerprint_bytes(name))
         digest.update(b"\0")
     return digest.hexdigest()
 

--- a/benchmarks/results/public-node-bun-v1.json
+++ b/benchmarks/results/public-node-bun-v1.json
@@ -5,8 +5,8 @@
   "perry_version": "perry 0.5.1258",
   "generated_at": "2026-07-13T14:10:04Z",
   "freshness": {
-    "source_fingerprint": "6015afdb3a8ef4fb1410bf570e4b6b05d7314837d728121a87e3305ec347758f",
-    "harness_fingerprint": "e3d9291d775d9f5fc9f9e5a70b5eaed1cead9059bc1a0de754189809bf4b274f"
+    "source_fingerprint": "4ff76a2ff69d1cde787770e9ae81f615be56c74e9a1bcb208890810fd079799d",
+    "harness_fingerprint": "437f64a8020aebd4d677405b4e5c8d915b2c76b10977df397ed324eef7b3ae23"
   },
   "host": {
     "os_version": "26.5.1",

--- a/tests/test_public_baseline.py
+++ b/tests/test_public_baseline.py
@@ -5,6 +5,7 @@ from benchmarks.public_baseline import (
     EXPECTED_SUITE_BENCHMARKS,
     README_END,
     README_START,
+    _CARGO_VERSION_RE,
     _replace_block,
     _validate_suite,
     distribution,
@@ -120,6 +121,23 @@ class PublicBaselineTests(unittest.TestCase):
         self.assertIn("loss vs both", block)
         self.assertIn("win vs both", block)
         self.assertIn("`abcdef123456`", block)
+
+    def test_cargo_version_bump_does_not_change_fingerprint_input(self):
+        # A workspace version bump must not move the source fingerprint: the
+        # volatile version line is normalized out before hashing. Regression
+        # guard — before this, the freshness gate reddened on every PR that
+        # followed a version bump (Cargo.toml is a fingerprinted source path).
+        def normalize(data):
+            return _CARGO_VERSION_RE.sub(b'version = "0.0.0"', data)
+
+        base = b'[workspace.package]\nversion = "0.5.1258"\nedition = "2021"\n'
+        bumped = b'[workspace.package]\nversion = "0.5.1300"\nedition = "2021"\n'
+        self.assertEqual(normalize(base), normalize(bumped))
+
+        # A benchmark-relevant change (e.g. edition/profile/deps) must still
+        # move the fingerprint input.
+        edition_change = b'[workspace.package]\nversion = "0.5.1258"\nedition = "2024"\n'
+        self.assertNotEqual(normalize(base), normalize(edition_change))
 
     def test_generated_marker_replacement_is_deterministic(self):
         original = f"before\n{README_START}\nold\n{README_END}\nafter\n"


### PR DESCRIPTION
## Problem

The `lint` job's **"Public benchmark evidence freshness"** step runs
`benchmarks/public_baseline.py check`, which validates that
`freshness.source_fingerprint` still matches `tracked_fingerprint(SOURCE_PATHS)`.
`SOURCE_PATHS` includes `Cargo.toml`, hashed over its whole bytes — so **every
workspace version bump changed the fingerprint** and reddened the gate on every
subsequent PR until the baseline was regenerated (a full, environment-gated
benchmark run). The most recent bump (`v0.5.1260`) left `lint` failing across all
open PRs (#6526, #6514, #6512, #6510, #6509, …) with:

```
public artifact benchmark inputs changed; regenerate it with ./benchmarks/run_public_baseline.sh
```

## Fix

Normalize the volatile `[workspace.package] version` line out of the `Cargo.toml`
contribution to the source fingerprint before hashing (`_fingerprint_bytes`), and
refresh the recorded `source_fingerprint` + `harness_fingerprint` in
`benchmarks/results/public-node-bun-v1.json`.

- Benchmark measurements are **unchanged** — a version bump doesn't affect
  performance, so re-measuring is unnecessary; only the fingerprint bookkeeping is
  corrected. The artifact diff is two lines.
- Dependency / profile / edition changes to `Cargo.toml` still move the fingerprint
  (they can affect benchmark behaviour), so the freshness signal is preserved for
  the changes that matter.
- The `harness_fingerprint` is recomputed because `public_baseline.py` itself
  changed (it's in `HARNESS_PATHS`).

## Test

Adds `test_cargo_version_bump_does_not_change_fingerprint_input`: a version bump
leaves the normalized fingerprint input unchanged, while a benchmark-relevant edit
(edition/profile) still moves it. Verified end-to-end locally: bumping the version
to a fresh value keeps `python3 benchmarks/public_baseline.py check` green
(exit 0), and `PYTHONPATH=. python3 tests/test_public_baseline.py` passes (7/7).

## Notes

This unblocks the repo-wide `lint` failure. PR #6526 (object-cache key) will go
green once rebased onto this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Benchmark freshness tracking no longer invalidates baselines when only the project version changes.
  * Changes to benchmark-relevant configuration still correctly trigger freshness updates.

* **Tests**
  * Added regression coverage to verify version-only changes are ignored while meaningful configuration changes are detected.
  * Updated benchmark freshness metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->