### PR TITLE
perf(runtime): store-plan cache — skip the per-store interception vet on class instances

### DIFF
--- a/crates/perry-runtime/src/gc/dead_owner.rs
+++ b/crates/perry-runtime/src/gc/dead_owner.rs
@@ -213,6 +213,9 @@ fn fan_out(
     is_dead_closure: &dyn Fn(usize) -> bool,
     is_dead_symbol: &dyn Fn(usize) -> bool,
 ) {
+    // Interned key pointers cached in the store-plan cache may die in this
+    // collection — flush every cached verdict.
+    crate::object::prop_plan::prop_plan_epoch_bump();
     crate::array::prune_dead_array_named_property_owners(is_dead_owner);
     crate::map::prune_dead_map_iterator_array_owners(is_dead_owner);
     crate::set::prune_dead_set_iterator_array_owners(is_dead_owner);

--- a/crates/perry-runtime/src/gc/types.rs
+++ b/crates/perry-runtime/src/gc/types.rs
@@ -907,6 +907,13 @@ pub const OBJ_FLAG_ARRAY_DESCRIPTORS: u16 = 0x400;
 // `GC_TYPE_OBJECT`. Set-only (clearing a descriptor leaves it set; the slow
 // path is always correct).
 pub const OBJ_FLAG_HAS_DESCRIPTORS: u16 = 0x800;
+// This specific object's [[Prototype]] was overridden per-instance
+// (`Object.setPrototypeOf` / `__proto__` recording via
+// `object_set_static_prototype`). Class-keyed interception caches
+// (`object::prop_plan`) must not apply a class-chain verdict to an object
+// whose own chain diverges. Bit 12; only meaningful for `GC_TYPE_OBJECT`.
+// Set-only, travels with the object across evacuation.
+pub const OBJ_FLAG_PROTO_OVERRIDE: u16 = 0x1000;
 // #2145: this object is a per-kind `<TypedArrayCtor>.prototype` whose
 // `[[Prototype]]` is the shared `%TypedArray%.prototype` intrinsic.
 // `Object.getPrototypeOf(Int8Array.prototype)` returns the cached

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -149,8 +149,11 @@ pub use registration::{
 };
 
 // ── dispatch.rs ─────────────────────────────────────────────────────────────
+#[cfg(test)]
+pub(crate) use dispatch::test_bump_vtable_generation;
 pub(crate) use dispatch::{
-    call_vtable_method, fetch_parent_kind_in_chain, vtable_ic_insert, vtable_ic_lookup, VTABLE_GEN,
+    call_vtable_method, fetch_parent_kind_in_chain, vtable_generation, vtable_ic_insert,
+    vtable_ic_lookup, VTABLE_GEN,
 };
 
 // ── parent_static.rs ────────────────────────────────────────────────────────

--- a/crates/perry-runtime/src/object/class_registry/construct.rs
+++ b/crates/perry-runtime/src/object/class_registry/construct.rs
@@ -949,7 +949,7 @@ pub unsafe extern "C" fn js_new_function_construct(
                         )
                     });
                 if has_user_proto {
-                    super::super::prototype_chain::object_set_static_prototype(
+                    super::super::prototype_chain::object_link_class_default_prototype(
                         obj_ptr as usize,
                         dyn_proto.to_bits(),
                     );
@@ -961,7 +961,7 @@ pub unsafe extern "C" fn js_new_function_construct(
     if !linked_user_proto {
         let proto = ensure_function_prototype_object(func_value, cid);
         if !proto.is_null() {
-            super::super::prototype_chain::object_set_static_prototype(
+            super::super::prototype_chain::object_link_class_default_prototype(
                 obj_ptr as usize,
                 crate::value::js_nanbox_pointer(proto as i64).to_bits(),
             );

--- a/crates/perry-runtime/src/object/class_registry/dispatch.rs
+++ b/crates/perry-runtime/src/object/class_registry/dispatch.rs
@@ -31,6 +31,19 @@ use std::sync::RwLock;
 
 pub(crate) static VTABLE_GEN: AtomicU64 = AtomicU64::new(1);
 
+/// Current vtable generation — consumed by caches (method IC below, the
+/// store-plan cache in `object::prop_plan`) that must invalidate on any
+/// class registration/mutation.
+#[inline]
+pub(crate) fn vtable_generation() -> u64 {
+    VTABLE_GEN.load(Ordering::Relaxed)
+}
+
+#[cfg(test)]
+pub(crate) fn test_bump_vtable_generation() {
+    VTABLE_GEN.fetch_add(1, Ordering::Release);
+}
+
 const VTABLE_IC_SIZE: usize = 4096;
 const VTABLE_IC_MASK: usize = VTABLE_IC_SIZE - 1;
 

--- a/crates/perry-runtime/src/object/class_registry/parent_static.rs
+++ b/crates/perry-runtime/src/object/class_registry/parent_static.rs
@@ -8,6 +8,9 @@ use std::sync::RwLock;
 
 /// Register a class with its parent class ID in the global registry
 pub(crate) fn register_class(class_id: u32, parent_class_id: u32) {
+    // Parent linking changes what a class chain can intercept — flush cached
+    // store plans (`object::prop_plan`).
+    crate::object::prop_plan::prop_plan_epoch_bump();
     let mut registry = CLASS_REGISTRY.write().unwrap();
     if registry.is_none() {
         *registry = Some(HashMap::new());

--- a/crates/perry-runtime/src/object/class_registry/prototype_objects.rs
+++ b/crates/perry-runtime/src/object/class_registry/prototype_objects.rs
@@ -142,6 +142,9 @@ pub static NEXT_SYNTHETIC_CLASS_ID: std::sync::atomic::AtomicU32 =
 /// when a class extends `func` via the #711 dynamic-parent path.
 #[no_mangle]
 pub extern "C" fn js_set_function_prototype(func: f64, proto: f64) -> u32 {
+    // `F.prototype = obj` re-shapes the chain of every future instance —
+    // flush cached store plans (`object::prop_plan`).
+    crate::object::prop_plan::prop_plan_epoch_bump();
     let func_bits = func.to_bits();
     let func_tag = func_bits & 0xFFFF_0000_0000_0000;
     let proto_bits = proto.to_bits();

--- a/crates/perry-runtime/src/object/descriptor_state.rs
+++ b/crates/perry-runtime/src/object/descriptor_state.rs
@@ -402,6 +402,7 @@ pub(crate) unsafe fn plain_data_write_may_intercept(addr: usize, class_id: u32, 
 
 /// Store a property descriptor for (obj, key).
 pub(crate) fn set_property_attrs(obj: usize, key: String, attrs: PropertyAttrs) {
+    super::prop_plan::prop_plan_epoch_bump();
     note_descriptor_target(obj);
     PROPERTY_ATTRS_IN_USE.with(|c| c.set(true));
     GLOBAL_DESCRIPTORS_IN_USE.store(true, Ordering::Relaxed);
@@ -414,6 +415,7 @@ pub(crate) fn set_property_attrs(obj: usize, key: String, attrs: PropertyAttrs) 
 /// Remove a customized property descriptor for (obj, key), restoring default
 /// data-property attributes for subsequent writes and reflection.
 pub(crate) fn clear_property_attrs(obj: usize, key: &str) {
+    super::prop_plan::prop_plan_epoch_bump();
     PROPERTY_DESCRIPTORS.with(|m| {
         m.borrow_mut().remove(&(obj, key.to_string()));
     });
@@ -532,6 +534,7 @@ pub(crate) unsafe fn json_object_getter_value(
 
 /// Store an accessor descriptor for (obj, key).
 pub(crate) fn set_accessor_descriptor(obj: usize, key: String, acc: AccessorDescriptor) {
+    super::prop_plan::prop_plan_epoch_bump();
     note_descriptor_target(obj);
     ACCESSORS_IN_USE.with(|c| c.set(true));
     GLOBAL_DESCRIPTORS_IN_USE.store(true, Ordering::Relaxed);
@@ -544,6 +547,7 @@ pub(crate) fn set_accessor_descriptor(obj: usize, key: String, acc: AccessorDesc
 /// Remove an accessor descriptor for (obj, key), letting ordinary data-property
 /// reads and writes use the object's stored field again.
 pub(crate) fn clear_accessor_descriptor(obj: usize, key: &str) {
+    super::prop_plan::prop_plan_epoch_bump();
     ACCESSOR_DESCRIPTORS.with(|m| {
         m.borrow_mut().remove(&(obj, key.to_string()));
     });
@@ -569,6 +573,7 @@ pub(crate) fn set_builtin_accessor_descriptor(
     acc: AccessorDescriptor,
     attrs: PropertyAttrs,
 ) {
+    super::prop_plan::prop_plan_epoch_bump();
     ACCESSOR_DESCRIPTORS.with(|m| {
         m.borrow_mut().insert((obj, key.clone()), acc);
     });
@@ -593,6 +598,7 @@ pub(crate) fn set_builtin_accessor_descriptor(
 /// `PROPERTY_DESCRIPTORS` per-object and unconditionally. The gate stays
 /// down, so the object get/set hot path is unaffected for every program.
 pub(crate) fn set_builtin_property_attrs(obj: usize, key: String, attrs: PropertyAttrs) {
+    super::prop_plan::prop_plan_epoch_bump();
     note_descriptor_target(obj);
     PROPERTY_DESCRIPTORS.with(|m| {
         m.borrow_mut().insert((obj, key), attrs);

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -799,6 +799,51 @@ pub extern "C" fn js_object_set_field_by_name(
             }
         }
 
+        // Resolve the interned key EARLY (hoisted from below the interception
+        // vet): the store-plan cache and the shape-transition cache both key
+        // on interned pointer identity. If the key is already interned
+        // (GC_FLAG_INTERNED set — e.g. from js_string_concat intern hit), skip
+        // the FNV-1a hash entirely. No allocation happens here, so the raw
+        // `obj`/`key` pointers stay valid.
+        let mut interned_key = if !key.is_null() && (key as usize) > 0x10000 {
+            let gc_hdr =
+                (key as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+            if (*gc_hdr).gc_flags & crate::gc::GC_FLAG_INTERNED != 0 {
+                key // already interned
+            } else {
+                let kh = key_content_hash(key);
+                crate::string::js_string_intern(key, kh)
+            }
+        } else {
+            key
+        };
+        let interned_key_handle = scope.root_string_ptr(interned_key);
+        interned_key = interned_key_handle.get_raw_const_ptr::<crate::StringHeader>();
+
+        // Store-plan fast gate (`object::prop_plan`): a recorded verdict means
+        // the full interception vet below (class vtable setter walk, URL-shape
+        // probe, `plain_data_write_may_intercept`) proved a store of this key
+        // to this class cannot be intercepted, and no invalidation (vtable /
+        // descriptor / prototype mutation, GC) happened since. Per-OBJECT
+        // conditions stay outside the verdict: frozen/sealed/own-descriptor
+        // flags are checked below as always, and an instance whose chain
+        // diverges from its class chain (per-instance `setPrototypeOf`
+        // override, null-proto) never records or honors a plan.
+        // Flags that make an object ineligible for class-keyed plans: a
+        // diverging chain (per-instance proto override / null proto) or own
+        // descriptors (an own accessor must dispatch through the short-circuit
+        // below, which a plan hit skips).
+        const PLAN_BLOCKING_FLAGS: u16 = crate::gc::OBJ_FLAG_PROTO_OVERRIDE
+            | crate::gc::OBJ_FLAG_NULL_PROTO
+            | crate::gc::OBJ_FLAG_HAS_DESCRIPTORS;
+        let obj_class_id = (*obj).class_id;
+        let plan_eligible = !key.is_null()
+            && obj_class_id != 0
+            && obj_class_id != NATIVE_MODULE_CLASS_ID
+            && (*gc_header)._reserved & PLAN_BLOCKING_FLAGS == 0;
+        let plan_fast = plan_eligible
+            && super::prop_plan::store_plan_check(obj_class_id, interned_key as usize);
+
         // Refs #486 (hono): class setter dispatch. JS spec: a `set X(...)`
         // accessor on the prototype intercepts `obj.X = value` writes
         // before they hit the instance's data slots. Hono's `set res(_res)
@@ -809,7 +854,7 @@ pub extern "C" fn js_object_set_field_by_name(
         // hono-base's `if (!context.finalized) throw` fired on every
         // request. Walk the class -> parent chain mirroring the getter
         // dispatch in `js_object_get_field_by_name`.
-        if !key.is_null() && (key as usize) > 0x10000 {
+        if !plan_fast && !key.is_null() && (key as usize) > 0x10000 {
             let class_id = (*obj).class_id;
             if class_id != 0 {
                 if let Ok(registry) = CLASS_VTABLE_REGISTRY.read() {
@@ -854,7 +899,11 @@ pub extern "C" fn js_object_set_field_by_name(
             }
         }
 
-        if !key.is_null() && (key as usize) > 0x10000 && crate::url::is_url_object_shape(obj) {
+        if !plan_fast
+            && !key.is_null()
+            && (key as usize) > 0x10000
+            && crate::url::is_url_object_shape(obj)
+        {
             let key_str = key_to_str_for_diag(key);
             let obj = obj_handle.get_raw_mut_ptr::<ObjectHeader>();
             let value = value_handle.get_nanbox_f64();
@@ -917,23 +966,6 @@ pub extern "C" fn js_object_set_field_by_name(
 
         let mut prev_keys_usize = keys as usize;
 
-        // Resolve to interned pointer for transition cache (pointer identity).
-        // If the key is already interned (GC_FLAG_INTERNED set — e.g. from
-        // js_string_concat intern hit), skip the FNV-1a hash entirely.
-        let mut interned_key = if !key.is_null() && (key as usize) > 0x10000 {
-            let gc_hdr =
-                (key as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
-            if (*gc_hdr).gc_flags & crate::gc::GC_FLAG_INTERNED != 0 {
-                key // already interned
-            } else {
-                let kh = key_content_hash(key);
-                crate::string::js_string_intern(key, kh)
-            }
-        } else {
-            key
-        };
-        let interned_key_handle = scope.root_string_ptr(interned_key);
-        interned_key = interned_key_handle.get_raw_const_ptr::<crate::StringHeader>();
         macro_rules! refresh_roots_after_alloc {
             () => {{
                 obj = obj_handle.get_raw_mut_ptr::<ObjectHeader>();
@@ -957,12 +989,26 @@ pub extern "C" fn js_object_set_field_by_name(
             && !is_frozen
             && !is_sealed_or_no_extend
             && !has_own_descriptors
-            && !super::plain_data_write_may_intercept(
-                obj as usize,
-                (*obj).class_id,
-                f64::from_bits(JSValue::string_ptr(key as *mut _).bits()),
-            )
+            && (plan_fast
+                || !super::plain_data_write_may_intercept(
+                    obj as usize,
+                    (*obj).class_id,
+                    f64::from_bits(JSValue::string_ptr(key as *mut _).bits()),
+                ))
         {
+            // The full interception vet just returned negative for this
+            // (class, key) — the vtable setter walk above found nothing, the
+            // URL-shape probe fell through, and `plain_data_write_may_intercept`
+            // cleared the chain. Record the verdict so the next store skips
+            // the vet (`plan_fast` above). Eligibility is re-derived from the
+            // freshly read `obj_flags`, not the pre-vet read.
+            if !plan_fast
+                && obj_class_id != 0
+                && obj_class_id != NATIVE_MODULE_CLASS_ID
+                && obj_flags & PLAN_BLOCKING_FLAGS == 0
+            {
+                super::prop_plan::store_plan_record(obj_class_id, interned_key as usize);
+            }
             if let Some((next_keys, slot_idx)) =
                 transition_cache_lookup(prev_keys_usize, interned_key)
             {
@@ -1058,8 +1104,12 @@ pub extern "C" fn js_object_set_field_by_name(
         // 200k of those allocations per query; with this guard the
         // count drops to zero unless userland actually defined a
         // descriptor.
-        let needs_descriptor_key =
-            ACCESSORS_IN_USE.with(|c| c.get()) || PROPERTY_ATTRS_IN_USE.with(|c| c.get());
+        // On a store-plan hit the object provably has no own descriptors
+        // (OBJ_FLAG_HAS_DESCRIPTORS is clear — vetted below before the plan is
+        // honored), so the descriptor key string can never be consulted: skip
+        // the per-store String allocation entirely.
+        let needs_descriptor_key = !plan_fast
+            && (ACCESSORS_IN_USE.with(|c| c.get()) || PROPERTY_ATTRS_IN_USE.with(|c| c.get()));
         let incoming_key_str: Option<String> = if needs_descriptor_key && !key.is_null() {
             let name_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
             let name_len = (*key).byte_len as usize;
@@ -1086,7 +1136,10 @@ pub extern "C" fn js_object_set_field_by_name(
         // throw "Cannot assign to read only property" on a plain `{}` (Next.js
         // app-page-turbo runtime's `exports.Fragment = …`). A fresh allocation
         // has the flag clear, so it skips the stale lookup entirely.
-        if ACCESSORS_IN_USE.with(|c| c.get()) && super::object_has_descriptors(obj as usize) {
+        if !plan_fast
+            && ACCESSORS_IN_USE.with(|c| c.get())
+            && super::object_has_descriptors(obj as usize)
+        {
             if let Some(ref k) = incoming_key_str {
                 if let Some(acc) = get_accessor_descriptor(obj as usize, k) {
                     if acc.set != 0 {

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -41,6 +41,7 @@ mod field_set_by_name;
 mod global_fetch;
 mod global_this;
 pub mod handle_expando;
+pub(crate) mod prop_plan;
 pub(crate) use global_this::{default_prepare_stack_trace_func_ptr, ERROR_CONSTRUCTOR_PTR};
 mod global_this_tables;
 mod groupby;

--- a/crates/perry-runtime/src/object/prop_plan.rs
+++ b/crates/perry-runtime/src/object/prop_plan.rs
@@ -1,0 +1,198 @@
+//! Per-(class_id, interned-key) property STORE-PLAN cache.
+//!
+//! `js_object_set_field_by_name` pays a long interception vet on every store
+//! to a class instance (`class_id != 0`): the `CLASS_VTABLE_REGISTRY` RwLock +
+//! per-level string-hash setter walk, then
+//! `plain_data_write_may_intercept` → `class_instance_set_may_intercept`,
+//! which allocates a Rust `String` for the key and probes the address-keyed
+//! descriptor tables (each probe re-allocating a `(usize, String)` map key)
+//! for every prototype level. Profiled on a fiber-shaped workload this vet is
+//! the dominant per-store cost — and its verdict is a pure function of
+//! (class chain, key) plus per-object bits the caller checks separately.
+//!
+//! This cache memoizes the FAST verdict only: "a store of `key` to an
+//! instance of `class_id` whose per-object flags are clear cannot be
+//! intercepted" — no vtable setter in the chain, no class-prototype
+//! accessor/non-writable descriptor, no `Object.prototype` own-key trap.
+//! Misses simply take today's slow path; a recorded verdict lets the next
+//! store of the same (class, key) skip straight to the shape-transition
+//! cache.
+//!
+//! ## Invalidation
+//! A verdict goes stale only when one of its inputs changes:
+//!   * vtable mutation (setter/getter/method registration, parent linking) —
+//!     tracked by the existing [`VTABLE_GEN`] generation counter, captured in
+//!     the entry and compared on lookup;
+//!   * descriptor installs/clears anywhere (a class prototype object may be
+//!     the target), `setPrototypeOf` recording, `Object.prototype` index
+//!     notes — these call [`prop_plan_epoch_bump`];
+//!   * GC — interned key pointers can move or die across a collection, so
+//!     the epoch is also bumped from the intern-table root scan and the
+//!     dead-owner prune fan-out (both run in every collection flavor).
+//!     Between collections an interned string cannot be freed or relocated,
+//!     so pointer identity holds for the lifetime of an epoch window.
+//!
+//! Per-OBJECT conditions (frozen/sealed/no-extend, own descriptors,
+//! per-instance `setPrototypeOf` override, null-proto) are NOT part of the
+//! verdict — the caller checks those from header flags before honoring a hit
+//! (see `OBJ_FLAG_PROTO_OVERRIDE` / `OBJ_FLAG_NULL_PROTO` gating at the call
+//! site).
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Monotonic invalidation epoch for cached store plans. Bumped by descriptor
+/// installs/clears, prototype recording, and every GC collection (intern-table
+/// scan + dead-owner prune). Entries recorded under an older epoch never
+/// match.
+static PROP_PLAN_EPOCH: AtomicU64 = AtomicU64::new(1);
+
+/// Invalidate every cached store plan. Cheap (one relaxed add); callers are
+/// rare, cold paths by construction.
+#[inline]
+pub(crate) fn prop_plan_epoch_bump() {
+    PROP_PLAN_EPOCH.fetch_add(1, Ordering::Relaxed);
+}
+
+#[derive(Clone, Copy)]
+struct PlanEntry {
+    /// Interned key pointer (pointer identity within an epoch window).
+    key_ptr: usize,
+    /// [`PROP_PLAN_EPOCH`] at record time.
+    epoch: u64,
+    /// [`super::class_registry::VTABLE_GEN`] at record time.
+    vtable_gen: u64,
+    /// Receiver class id the verdict was computed for.
+    class_id: u32,
+}
+
+const PLAN_CACHE_SIZE: usize = 4096;
+const PLAN_CACHE_MASK: usize = PLAN_CACHE_SIZE - 1;
+
+thread_local! {
+    // Heap-allocate the table (~112KB) — oversized inline TLS overflows the
+    // ILP32 TLS layout on arm64_32 (same fix as string/intern.rs).
+    static STORE_PLAN_CACHE: std::cell::UnsafeCell<Box<[PlanEntry]>> =
+        std::cell::UnsafeCell::new(
+            vec![
+                PlanEntry {
+                    key_ptr: 0,
+                    epoch: 0,
+                    vtable_gen: 0,
+                    class_id: 0,
+                };
+                PLAN_CACHE_SIZE
+            ]
+            .into_boxed_slice(),
+        );
+}
+
+#[inline(always)]
+fn plan_slot(class_id: u32, key_ptr: usize) -> usize {
+    // Fibonacci mix of the two identities; low bits of interned pointers are
+    // alignment zeros, so fold the middle bits down first.
+    let h = ((key_ptr >> 4) as u64 ^ ((class_id as u64) << 17)).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    (h >> 40) as usize & PLAN_CACHE_MASK
+}
+
+fn plan_diag_enabled() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| std::env::var_os("PERRY_PLAN_DIAG").is_some())
+}
+
+/// Does a valid fast-store verdict exist for (class_id, interned key)?
+#[inline]
+pub(crate) fn store_plan_check(class_id: u32, key_ptr: usize) -> bool {
+    if class_id == 0 || key_ptr == 0 {
+        return false;
+    }
+    let slot = plan_slot(class_id, key_ptr);
+    let hit = STORE_PLAN_CACHE.with(|c| unsafe {
+        let e = (*c.get())[slot];
+        e.key_ptr == key_ptr
+            && e.class_id == class_id
+            && e.epoch == PROP_PLAN_EPOCH.load(Ordering::Relaxed)
+            && e.vtable_gen == super::class_registry::vtable_generation()
+    });
+    if plan_diag_enabled() {
+        static CHECKS: AtomicU64 = AtomicU64::new(0);
+        static HITS: AtomicU64 = AtomicU64::new(0);
+        let c = CHECKS.fetch_add(1, Ordering::Relaxed) + 1;
+        let h = HITS.fetch_add(hit as u64, Ordering::Relaxed) + hit as u64;
+        if c % 1_000_000 == 0 {
+            eprintln!(
+                "PLAN-DIAG checks={} hits={} epoch={} vgen={}",
+                c,
+                h,
+                PROP_PLAN_EPOCH.load(Ordering::Relaxed),
+                super::class_registry::vtable_generation()
+            );
+        }
+    }
+    hit
+}
+
+/// Record a fast-store verdict for (class_id, interned key). Caller has just
+/// completed the full interception vet with a negative result.
+#[inline]
+pub(crate) fn store_plan_record(class_id: u32, key_ptr: usize) {
+    if class_id == 0 || key_ptr == 0 {
+        return;
+    }
+    let slot = plan_slot(class_id, key_ptr);
+    STORE_PLAN_CACHE.with(|c| unsafe {
+        (*c.get())[slot] = PlanEntry {
+            key_ptr,
+            epoch: PROP_PLAN_EPOCH.load(Ordering::Relaxed),
+            vtable_gen: super::class_registry::vtable_generation(),
+            class_id,
+        };
+    });
+    if plan_diag_enabled() {
+        static RECORDS: AtomicU64 = AtomicU64::new(0);
+        let r = RECORDS.fetch_add(1, Ordering::Relaxed) + 1;
+        if r <= 8 || r % 1_000_000 == 0 {
+            eprintln!(
+                "PLAN-DIAG record #{} class={} key={:#x} slot={}",
+                r, class_id, key_ptr, slot
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn record_then_check_hits_and_epoch_bump_invalidates() {
+        let key = 0xDEAD_BEE0usize;
+        store_plan_record(7, key);
+        assert!(store_plan_check(7, key));
+        // Different class or key misses.
+        assert!(!store_plan_check(8, key));
+        assert!(!store_plan_check(7, key + 16));
+        // Epoch bump invalidates.
+        prop_plan_epoch_bump();
+        assert!(!store_plan_check(7, key));
+        // Re-record under the new epoch works again.
+        store_plan_record(7, key);
+        assert!(store_plan_check(7, key));
+    }
+
+    #[test]
+    fn vtable_generation_bump_invalidates() {
+        let key = 0xBEEF_00F0usize;
+        store_plan_record(9, key);
+        assert!(store_plan_check(9, key));
+        crate::object::class_registry::test_bump_vtable_generation();
+        assert!(!store_plan_check(9, key));
+    }
+
+    #[test]
+    fn class_zero_and_null_key_never_cache() {
+        store_plan_record(0, 0x1000);
+        assert!(!store_plan_check(0, 0x1000));
+        store_plan_record(3, 0);
+        assert!(!store_plan_check(3, 0));
+    }
+}

--- a/crates/perry-runtime/src/object/prototype_chain.rs
+++ b/crates/perry-runtime/src/object/prototype_chain.rs
@@ -90,13 +90,10 @@ fn object_set_static_prototype_impl(obj_ptr: usize, proto_bits: u64, instance_ov
     if instance_override {
         crate::object::prop_plan::prop_plan_epoch_bump();
         unsafe {
-            if obj_ptr >= crate::gc::GC_HEADER_SIZE + 0x1000
-                && crate::value::addr_class::is_above_handle_band(obj_ptr)
-            {
-                let hdr = (obj_ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE)
-                    as *mut crate::gc::GcHeader;
-                if (*hdr).obj_type == crate::gc::GC_TYPE_OBJECT {
-                    (*hdr)._reserved |= crate::gc::OBJ_FLAG_PROTO_OVERRIDE;
+            if let Some(header) = crate::value::addr_class::try_read_gc_header(obj_ptr) {
+                if header.obj_type == crate::gc::GC_TYPE_OBJECT {
+                    let header = header as *const crate::gc::GcHeader as *mut crate::gc::GcHeader;
+                    (*header)._reserved |= crate::gc::OBJ_FLAG_PROTO_OVERRIDE;
                 }
             }
         }

--- a/crates/perry-runtime/src/object/prototype_chain.rs
+++ b/crates/perry-runtime/src/object/prototype_chain.rs
@@ -50,6 +50,23 @@ fn get_object_prototypes() -> &'static Mutex<HashMap<usize, u64>> {
 /// bits of the prototype object (POINTER-tagged) or `TAG_NULL`. Idempotent
 /// overwrite.
 pub fn object_set_static_prototype(obj_ptr: usize, proto_bits: u64) {
+    object_set_static_prototype_impl(obj_ptr, proto_bits, true)
+}
+
+/// Construct-path variant: link a fresh instance to its class-DEFAULT
+/// prototype (the synthetic-class `F.prototype` object). Unlike a user
+/// `setPrototypeOf`, this chain is identical for every instance of the class,
+/// so it neither flushes class-keyed store plans (`object::prop_plan`) nor
+/// marks the instance as chain-divergent — later mutations that could change
+/// the verdict (`F.prototype = other`, descriptor installs on the proto)
+/// bump the epoch at their own entry points. Calling the loud variant here
+/// flushed the plan cache on EVERY function-ctor construction, which kept it
+/// permanently cold in fiber-heavy workloads.
+pub(crate) fn object_link_class_default_prototype(obj_ptr: usize, proto_bits: u64) {
+    object_set_static_prototype_impl(obj_ptr, proto_bits, false)
+}
+
+fn object_set_static_prototype_impl(obj_ptr: usize, proto_bits: u64, instance_override: bool) {
     if obj_ptr == 0 {
         return;
     }
@@ -65,6 +82,23 @@ pub fn object_set_static_prototype(obj_ptr: usize, proto_bits: u64) {
         };
         if obj_type == crate::gc::GC_TYPE_ARRAY || obj_type == crate::gc::GC_TYPE_LAZY_ARRAY {
             ARRAY_TARGET_PROTO_RECORDED.store(true, Ordering::Relaxed);
+        }
+    }
+    // A per-instance prototype override invalidates class-keyed interception
+    // verdicts (the overridden chain can differ from the class chain), and the
+    // object itself must never satisfy a class-keyed plan again.
+    if instance_override {
+        crate::object::prop_plan::prop_plan_epoch_bump();
+        unsafe {
+            if obj_ptr >= crate::gc::GC_HEADER_SIZE + 0x1000
+                && crate::value::addr_class::is_above_handle_band(obj_ptr)
+            {
+                let hdr = (obj_ptr as *const u8).sub(crate::gc::GC_HEADER_SIZE)
+                    as *mut crate::gc::GcHeader;
+                if (*hdr).obj_type == crate::gc::GC_TYPE_OBJECT {
+                    (*hdr)._reserved |= crate::gc::OBJ_FLAG_PROTO_OVERRIDE;
+                }
+            }
         }
     }
     let mut slot_addr = 0usize;

--- a/crates/perry-runtime/src/string/intern.rs
+++ b/crates/perry-runtime/src/string/intern.rs
@@ -180,6 +180,9 @@ pub fn scan_intern_table_roots(mark: &mut dyn FnMut(f64)) {
 }
 
 pub fn scan_intern_table_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
+    // Interned strings can be relocated by this collection; pointer-identity
+    // verdicts in the store-plan cache would go stale — flush them.
+    crate::object::prop_plan::prop_plan_epoch_bump();
     with_intern_table(|table| unsafe {
         for i in 0..INTERN_TABLE_SIZE {
             let entry = &mut (*table)[i];

--- a/test-files/test_gap_prop_plan_cache_invalidation.ts
+++ b/test-files/test_gap_prop_plan_cache_invalidation.ts
@@ -1,0 +1,44 @@
+// Store-plan cache invalidation semantics — must print identically under node and perry.
+var out = [];
+
+// 1) Per-instance setPrototypeOf AFTER the (class,key) plan is warm:
+//    the overridden instance must dispatch the inherited setter, not store a fast own slot.
+function F() { this.x = 1; }
+var o1 = new F(), o2 = new F();
+for (var i = 0; i < 50000; i++) { o1.y = i; }  // warm (F,"y") as a fast plain store
+var log1 = [];
+Object.setPrototypeOf(o2, { set y(v) { log1.push("setter:" + v); }, get y() { return "got"; } });
+o2.y = 99;
+out.push("t1=" + log1.join(",") + "|" + o2.y + "|" + o1.y);
+
+// 2) Prototype-level accessor installed AFTER warm-up: fresh instances must dispatch it.
+function G() { this.a = 0; }
+var g1 = new G(), g2 = new G();
+for (var i = 0; i < 50000; i++) { g1.w = i; }  // warm (G,"w")
+var log2 = [];
+Object.defineProperty(Object.getPrototypeOf(g2), "w", {
+  set: function (v) { log2.push("ps:" + v); },
+  get: function () { return "pg"; }
+});
+var g3 = new G();
+g3.w = 7;  // no own "w" — must route to the prototype setter
+out.push("t2=" + log2.join(",") + "|" + g3.w + "|" + g1.w);
+
+// 3) Freeze AFTER warm-up: writes must be dropped (sloppy mode) on the frozen instance only.
+function H() { this.q = 1; }
+var h1 = new H(), h2 = new H();
+for (var i = 0; i < 50000; i++) { h1.q = i; }
+Object.freeze(h2);
+h2.q = 123;
+out.push("t3=" + h2.q + "|" + h1.q);
+
+// 4) Non-writable data property on the prototype after warm-up blocks fresh instances' stores.
+function K() {}
+var k1 = new K();
+for (var i = 0; i < 50000; i++) { k1.m = i; }
+Object.defineProperty(Object.getPrototypeOf(k1), "n", { value: 42, writable: false });
+var k2 = new K();
+k2.n = 7;  // inherited non-writable — sloppy-mode silent no-op, no own prop
+out.push("t4=" + k2.n + "|" + Object.prototype.hasOwnProperty.call(k2, "n"));
+
+console.log(out.join(" "));


### PR DESCRIPTION
## Problem

Profiling a large compiled TUI app's typing latency (keystroke→paint p50 111ms vs node 2.2ms) showed the dominant per-store cost on class instances is the interception vet, re-run on EVERY dynamic store:

- the `CLASS_VTABLE_REGISTRY` RwLock + per-prototype-level string-hash setter walk;
- `plain_data_write_may_intercept` → `class_instance_set_may_intercept`, which allocates a Rust `String` for the key and probes the address-keyed descriptor tables — each probe constructing a `(usize, String)` map key and SipHashing it — for every prototype level;
- a per-store descriptor-key `String` allocation when `ACCESSORS_IN_USE`/`PROPERTY_ATTRS_IN_USE` are latched (they are, in any real app).

On a fiber-shaped micro-benchmark (200k 23-field function-ctor objects, hot field loops — the React FiberNode pattern), `get_accessor_descriptor` + SipHash + the may-intercept walk were the top app-side frames. Synthetic-class function-ctor instances (`function F(){this.x=…}` + `new F`) take this path for every field.

## Fix

The vet's verdict is a pure function of (class chain, key) plus per-object header bits — so memoize the FAST verdict ("this (class_id, key) store cannot be intercepted") in a direct-mapped, allocation-free 4096-entry TLS cache keyed by `(class_id, interned key ptr)` (`object/prop_plan.rs`). Entries validate against:

- **`PROP_PLAN_EPOCH`** — bumped by all six descriptor install/clear entry points, `setPrototypeOf` recording, `F.prototype =` reassignment, parent-class linking, and every GC collection (intern-table root scan + dead-owner prune fan-out; interned key pointers can only move/die across a collection, so pointer identity holds within an epoch window);
- the existing **`VTABLE_GEN`** (method/getter/setter registration).

Per-object conditions stay OUTSIDE the verdict, checked from header flags before honoring a hit: frozen/sealed/no-extend, own descriptors (`OBJ_FLAG_HAS_DESCRIPTORS` — own accessors still dispatch through the accessor short-circuit), and the new **`OBJ_FLAG_PROTO_OVERRIDE`** (bit 12) marking instances whose `[[Prototype]]` was overridden per-instance. Null-proto instances are likewise excluded.

One prerequisite fix: the synthetic-construct path recorded its class-DEFAULT prototype via `object_set_static_prototype` **per instance**; that now goes through a quiet `object_link_class_default_prototype` (no epoch bump, no override flag) since the linked chain is identical for every instance of the class — with the loud variant the cache stayed permanently cold in construct-heavy phases (fibers construct constantly).

A hit skips: vtable setter walk, URL-shape probe, `plain_data_write_may_intercept`, accessor short-circuit, and the per-store `String` allocation. Misses take today's path and record on success.

## Numbers

- Hit rate on the fiber workload: **99.998%** (`PERRY_PLAN_DIAG=1` counters).
- Fiber micro-bench (node = 26.3): create **4218→3138ms (−26%)**, overflow-field loop 29784→26602ms (−11%), inline-field loop 12564→10726ms (−15%), alternate-link loop 2602→2362ms (−9%). (The store vet is one of several per-access costs; read-path and call-overhead work are follow-ups.)

## Verification

- `test-files/test_gap_prop_plan_cache_invalidation.ts` — byte-identical to node on the four invalidation scenarios: `setPrototypeOf`-with-accessor after cache warm-up, prototype accessor installed after warm-up, `Object.freeze` after warm-up, inherited non-writable data property after warm-up.
- 3 unit tests in `prop_plan.rs` (epoch bump, vtable-gen bump, class-0/null-key exclusion).
- perry-runtime suite 1327 passed / 0 failed (`--test-threads=1`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved object property writes with a faster “store-plan” path that can skip interception work when it’s safe.

* **Bug Fixes**
  * Fixed cached property-write decisions being reused after prototype changes, descriptor updates, class inheritance updates, and GC/interned-string relocation.
  * Added stricter invalidation when per-instance prototype overrides occur, ensuring correct setter dispatch and correct behavior for frozen and non-writable prototype properties.

* **Tests**
  * Added scenarios validating store-plan cache invalidation across prototype and descriptor changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->