### PR TITLE
perf(link): stop exporting every symbol from native macOS executables

### DIFF
--- a/crates/perry/src/commands/compile/link/build_and_run.rs
+++ b/crates/perry/src/commands/compile/link/build_and_run.rs
@@ -249,6 +249,18 @@ pub(crate) fn build_and_run_link(
         } else {
             // Native macOS/iOS via clang driver
             cmd.arg("-Wl,-dead_strip");
+            // A perry executable exports every external Rust/codegen symbol by
+            // default — a large app binary carries a 300k-entry export trie
+            // with WEAK_DEFINES set, and dyld spends ~0.9s of EVERY launch on
+            // weak-def coalescing + bind resolution against it (profiled:
+            // `--version` was ~80% dyld). Nothing consumes those exports —
+            // plugins dlopen their own dylibs and resolve from their own
+            // handle (never `dlsym(RTLD_DEFAULT/SELF)` into the host) — except
+            // the plugin-host mode, which force-exports its API via `-u` and
+            // must keep the trie.
+            if !ctx.needs_plugins {
+                cmd.arg("-Wl,-no_exported_symbols");
+            }
         }
         // PERRY_LINK_MAP=<path> — emit a linker map (which archive each symbol
         // resolves from) for diagnosing dup-symbol / shadowing bugs. Honor it on


### PR DESCRIPTION
## Problem

A perry-compiled executable exports every external Rust/codegen symbol — **300,281 exports** on a large app binary — with `MH_WEAK_DEFINES`/`MH_BINDS_TO_WEAK` set. dyld pays for that at every launch: weak-def coalescing plus bind-target resolution against a 300k-entry export trie.

Measured on a large compiled TUI app: `--version` takes 1.168s wall, and sampling shows **~80% of it inside dyld** (`trieWalk`, `resolveSymbol`, `hasExportedSymbol`, weak-def map inserts) — ~0.9s of pure dynamic-linker overhead on every single launch, before any app code runs. node runs the same app's `--version` in 328ms.

## Fix

Pass `-Wl,-no_exported_symbols` on the native macOS/iOS clang link when plugins are off.

Safety audit: nothing consumes the exports —
- plugins `dlopen` their own dylibs and `dlsym` from **their own handle** (`plugin.rs` uses `RTLD_NOW | RTLD_LOCAL`, never `dlopen(NULL)` / `RTLD_DEFAULT` / `RTLD_SELF` into the host);
- the plugin-host mode, which genuinely needs exports, force-exports its API via `-u` and is explicitly excluded (`!ctx.needs_plugins`, unchanged behavior).

## Numbers

- Exports: 300,281 → 3; `WEAK_DEFINES`/`BINDS_TO_WEAK` header flags cleared.
- Binary size: 5.1MB → 4.9MB on a small program.
- Full-app launch numbers (hyperfine, before/after) to follow in a comment once the big-binary rebuild completes — the profile attributes ~0.9s/launch to the eliminated dyld work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved application startup performance for builds that do not use plugins by reducing exported symbol metadata.
  * Preserved exported symbols for plugin-enabled builds to maintain compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->