### PR TITLE
fix(runtime,codegen): bundled-zod capture-class family — statics dispatch, value-super, ctor args, constructor identity (#6530)

### DIFF
--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -243,6 +243,39 @@ fn inline_constructor_param_values_with_class(
     out
 }
 
+/// #6530: true when the trailing args of a bare-identifier `new C(...)` site
+/// are the HIR-appended capture forwards for `class`'s synthesized
+/// `__perry_cap_<id>` constructor params. The HIR `Expr::New` arm appends
+/// `LocalGet(cid)` per captured id, in cap-param order, ONLY where those
+/// locals are in scope (the class's declaring function) — so each trailing
+/// arg must be a `LocalGet` whose id equals the id embedded in the matching
+/// param name. Any mismatch (a sibling-class method's `new ZodEffects({...})`
+/// carries only user args) means the caps are absent and the tail-split must
+/// not steal user args as cap fallbacks.
+fn new_site_args_carry_appended_caps(class: &perry_hir::Class, args: &[Expr]) -> bool {
+    let Some(ctor) = class.constructor.as_ref() else {
+        return false;
+    };
+    let cap_params: Vec<&Param> = ctor
+        .params
+        .iter()
+        .filter(|p| {
+            p.name.starts_with("__perry_cap_") && !p.is_rest && p.arguments_object.is_none()
+        })
+        .collect();
+    if cap_params.is_empty() || args.len() < cap_params.len() {
+        return false;
+    }
+    let tail = &args[args.len() - cap_params.len()..];
+    tail.iter().zip(cap_params.iter()).all(|(arg, p)| {
+        matches!(arg, Expr::LocalGet(id)
+            if p.name
+                .strip_prefix("__perry_cap_")
+                .and_then(|s| s.parse::<u32>().ok())
+                == Some(*id))
+    })
+}
+
 fn pack_lowered_args_array(ctx: &mut FnCtx<'_>, args: &[String]) -> String {
     let cap = (args.len() as u32).to_string();
     let mut current = ctx.block().call(I64, "js_array_alloc", &[(I32, &cap)]);
@@ -676,6 +709,22 @@ fn lower_new_impl(
             return Ok(nanbox_pointer_inline(ctx.block(), &handle));
         }
     };
+
+    // #6530: the HIR bare-identifier `Expr::New` arm appends the class's
+    // captures as trailing `LocalGet(<cap_id>)` args only where the captured
+    // locals are IN SCOPE (the class's declaring function). Inside a SIBLING
+    // class's method nothing is appended — bundled zod's
+    // `ZodType.transform() { return new ZodEffects({...}) }` — but this path
+    // assumed the bare form always carries them, so the tail-split treated
+    // the trailing USER args as cap fallbacks: the synthesized ctor received
+    // an empty rest array, `super(...[])` ran the parent ctor with no `def`,
+    // and every base-ctor field (`_def`, the bound methods) stayed
+    // undefined. The appended form is exactly `LocalGet(id)` paired with the
+    // synthesized trailing param `__perry_cap_<id>` (same id, same order —
+    // `expr_new.rs` pushes `LocalGet(cid)` per captured id), so verify the
+    // tail matches before treating it as appended caps.
+    let caps_absent_from_args =
+        caps_absent_from_args || !new_site_args_carry_appended_caps(class, args);
 
     // Lower the args first (constructor params).
     let mut lowered_args: Vec<String> = Vec::with_capacity(args.len());

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -53,19 +53,20 @@ pub(crate) use state::{
     class_decl_prototype_value, class_decl_prototype_value_for_instance_class,
     class_delete_own_dynamic_prop, class_dynamic_prop_root_store, class_has_own_dynamic_prop,
     class_id_for_decl_prototype_object, class_is_key_deleted, class_mark_key_deleted,
-    class_own_enumerable_field_names, class_own_static_field_value, class_parent_closure,
-    class_parent_closure_root_store, class_prototype_method_is_enumerable,
-    class_prototype_method_set_enumerable, class_prototype_method_value_cache_root_store,
-    class_prototype_object_root_store, global_object_prototype_bits,
-    is_bound_native_method_closure_value, is_non_constructable_builtin_function_value,
-    parent_closure_in_chain, throw_non_constructable_builtin_function,
+    class_object_value_for_cid, class_object_value_root_store, class_own_enumerable_field_names,
+    class_own_static_field_value, class_parent_closure, class_parent_closure_root_store,
+    class_prototype_method_is_enumerable, class_prototype_method_set_enumerable,
+    class_prototype_method_value_cache_root_store, class_prototype_object_root_store,
+    global_object_prototype_bits, is_bound_native_method_closure_value,
+    is_non_constructable_builtin_function_value, parent_closure_in_chain,
+    throw_non_constructable_builtin_function,
 };
 pub use state::{
     ClassVTable, VTableMethodEntry, CLASS_DECL_PROTOTYPE_OBJECTS, CLASS_DYNAMIC_PARENT_VALUE,
-    CLASS_METHOD_BIND_LENGTHS, CLASS_PARENT_CLOSURES, CLASS_PROTOTYPE_METHOD_NONENUM,
-    CLASS_PROTOTYPE_OBJECTS, CLASS_STATIC_ACCESSORS, CLASS_STATIC_METHODS,
-    CLASS_STATIC_METHOD_BIND_LENGTHS, CLASS_SYMBOL_ACCESSORS, CLASS_SYMBOL_METHODS,
-    CLASS_VTABLE_REGISTRY, FUNCTION_CLASS_IDS, REGISTERED_CLASS_IDS,
+    CLASS_METHOD_BIND_LENGTHS, CLASS_OBJECT_VALUES, CLASS_PARENT_CLOSURES,
+    CLASS_PROTOTYPE_METHOD_NONENUM, CLASS_PROTOTYPE_OBJECTS, CLASS_STATIC_ACCESSORS,
+    CLASS_STATIC_METHODS, CLASS_STATIC_METHOD_BIND_LENGTHS, CLASS_SYMBOL_ACCESSORS,
+    CLASS_SYMBOL_METHODS, CLASS_VTABLE_REGISTRY, FUNCTION_CLASS_IDS, REGISTERED_CLASS_IDS,
 };
 
 // ── prototype_objects.rs ────────────────────────────────────────────────────

--- a/crates/perry-runtime/src/object/class_registry/gc_roots.rs
+++ b/crates/perry-runtime/src/object/class_registry/gc_roots.rs
@@ -29,6 +29,9 @@ enum ClassSideTableRootSlot {
     DynamicParentValue {
         class_id: u32,
     },
+    ClassObjectValue {
+        class_id: u32,
+    },
     ClassSymbolMethod {
         class_id: u32,
         sym_key: usize,
@@ -127,6 +130,18 @@ pub fn scan_class_side_table_roots_mut(visitor: &mut crate::gc::RuntimeRootVisit
     // visit + forward — otherwise `js_get_dynamic_parent_value` later hands
     // `super()` a stale pointer.
     if let Ok(mut guard) = CLASS_DYNAMIC_PARENT_VALUE.write() {
+        if let Some(map) = guard.as_mut() {
+            for value_bits in map.values_mut() {
+                visitor.visit_nanbox_u64_slot(value_bits);
+            }
+        }
+    }
+
+    // #6530: cid → per-evaluation class OBJECT (`instance.constructor`
+    // identity for capture-carrying classes). Same liveness/forwarding needs
+    // as the dynamic-parent stash above: the entries are heap objects a
+    // moving GC must visit + forward.
+    if let Ok(mut guard) = CLASS_OBJECT_VALUES.write() {
         if let Some(map) = guard.as_mut() {
             for value_bits in map.values_mut() {
                 visitor.visit_nanbox_u64_slot(value_bits);
@@ -242,6 +257,16 @@ fn class_side_table_root_snapshot() -> Vec<ClassSideTableRootSlot> {
         }
     }
 
+    // Step twin of the CLASS_OBJECT_VALUES block in
+    // `scan_class_side_table_roots_mut` (#6530).
+    if let Ok(guard) = CLASS_OBJECT_VALUES.read() {
+        if let Some(map) = guard.as_ref() {
+            for &class_id in map.keys() {
+                slots.push(ClassSideTableRootSlot::ClassObjectValue { class_id });
+            }
+        }
+    }
+
     if let Ok(guard) = CLASS_SYMBOL_METHODS.read() {
         if let Some(map) = guard.as_ref() {
             for &(class_id, sym_key, is_static) in map.keys() {
@@ -327,6 +352,13 @@ fn scan_class_side_table_root_slot(
         }
         ClassSideTableRootSlot::DynamicParentValue { class_id } => {
             if let Ok(mut guard) = CLASS_DYNAMIC_PARENT_VALUE.write() {
+                if let Some(value_bits) = guard.as_mut().and_then(|map| map.get_mut(class_id)) {
+                    visitor.visit_nanbox_u64_slot(value_bits);
+                }
+            }
+        }
+        ClassSideTableRootSlot::ClassObjectValue { class_id } => {
+            if let Ok(mut guard) = CLASS_OBJECT_VALUES.write() {
                 if let Some(value_bits) = guard.as_mut().and_then(|map| map.get_mut(class_id)) {
                     visitor.visit_nanbox_u64_slot(value_bits);
                 }

--- a/crates/perry-runtime/src/object/class_registry/parent_static.rs
+++ b/crates/perry-runtime/src/object/class_registry/parent_static.rs
@@ -362,6 +362,12 @@ pub extern "C" fn js_object_mark_class(obj: i64) {
     if obj != 0 {
         unsafe {
             (*(obj as *mut ObjectHeader)).object_type = crate::error::OBJECT_TYPE_CLASS;
+            // #6530: record cid → class object so `instance.constructor`
+            // resolves to the SAME value the module scope/exports hold (see
+            // `CLASS_OBJECT_VALUES`). The template cid was stamped by the
+            // `js_object_alloc(cid, …)` call directly preceding this mark.
+            let cid = (*(obj as *const ObjectHeader)).class_id;
+            super::class_object_value_root_store(cid, obj as *mut ObjectHeader);
         }
     }
 }

--- a/crates/perry-runtime/src/object/class_registry/state.rs
+++ b/crates/perry-runtime/src/object/class_registry/state.rs
@@ -315,6 +315,47 @@ pub static CLASS_PARENT_CLOSURES: RwLock<Option<HashMap<u32, usize>>> = RwLock::
 /// (INT32-tagged) and object/closure (POINTER-tagged) parents.
 pub static CLASS_DYNAMIC_PARENT_VALUE: RwLock<Option<HashMap<u32, u64>>> = RwLock::new(None);
 
+/// #6530: maps a template class_id to the raw NaN-boxed POINTER bits of the
+/// per-evaluation CLASS OBJECT the class statement materialized as (marked by
+/// `js_object_mark_class`). A capture-carrying class has no INT32 ClassRef
+/// value at runtime — the class VALUE is this heap object — so
+/// `instance.constructor` must hand back the same object the module scope /
+/// exports hold, or identity checks (`x.constructor === Sub`, bundled zod's
+/// `describe()` re-construction via `this.constructor`) break. Last-wins
+/// across evaluations of the same class statement, matching the template-cid
+/// compromise used by the sibling tables above.
+pub static CLASS_OBJECT_VALUES: RwLock<Option<HashMap<u32, u64>>> = RwLock::new(None);
+
+/// Store the marked class object for its template class id (see
+/// `CLASS_OBJECT_VALUES`).
+pub(crate) fn class_object_value_root_store(class_id: u32, obj_ptr: *mut ObjectHeader) {
+    if class_id == 0 || obj_ptr.is_null() {
+        return;
+    }
+    let bits = crate::value::js_nanbox_pointer(obj_ptr as i64).to_bits();
+    let mut guard = CLASS_OBJECT_VALUES.write().unwrap();
+    if guard.is_none() {
+        *guard = Some(HashMap::new());
+    }
+    guard.as_mut().unwrap().insert(class_id, bits);
+    crate::gc::runtime_write_barrier_root_raw_ptr(obj_ptr);
+}
+
+/// Read back the class object registered for `class_id`, or `None` when the
+/// class never materialized as a per-evaluation object (ordinary
+/// ClassRef-valued classes).
+pub(crate) fn class_object_value_for_cid(class_id: u32) -> Option<f64> {
+    if class_id == 0 {
+        return None;
+    }
+    CLASS_OBJECT_VALUES.read().ok().and_then(|guard| {
+        guard
+            .as_ref()
+            .and_then(|map| map.get(&class_id).copied())
+            .map(f64::from_bits)
+    })
+}
+
 pub(crate) fn class_prototype_object_root_store(class_id: u32, proto_ptr: *mut ObjectHeader) {
     if class_id == 0 || proto_ptr.is_null() {
         return;

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -243,18 +243,28 @@ pub extern "C" fn js_object_get_field_by_name(
                 {
                     return JSValue::from_bits(v.to_bits());
                 }
-                if let Some(parent) = crate::object::class_registry::class_object_pinned_parent(obj)
-                {
-                    let pbits = parent.to_bits();
-                    if (pbits >> 48) == 0x7FFD {
-                        let praw = (pbits & 0x0000_FFFF_FFFF_FFFF) as *mut ObjectHeader;
-                        if praw as usize != obj as usize
-                            && crate::value::addr_class::is_above_handle_band(praw as usize)
-                            && crate::object::is_valid_obj_ptr(praw as *const u8)
-                        {
-                            let v = js_object_get_field_by_name(praw, key);
-                            if !v.is_undefined() {
-                                return v;
+                // #6530: `name` and `prototype` are OWN properties of every
+                // constructor — never inherited through the parent edge. Skip
+                // the pinned-parent recursion for them so the generic tail
+                // below synthesizes both from THIS object's class_id (the
+                // recursion otherwise answered with the BASE class's `.name`
+                // for every capture-carrying subclass — bundled zod's
+                // identity collapse to "ZodType").
+                if want != b"name" && want != b"prototype" {
+                    if let Some(parent) =
+                        crate::object::class_registry::class_object_pinned_parent(obj)
+                    {
+                        let pbits = parent.to_bits();
+                        if (pbits >> 48) == 0x7FFD {
+                            let praw = (pbits & 0x0000_FFFF_FFFF_FFFF) as *mut ObjectHeader;
+                            if praw as usize != obj as usize
+                                && crate::value::addr_class::is_above_handle_band(praw as usize)
+                                && crate::object::is_valid_obj_ptr(praw as *const u8)
+                            {
+                                let v = js_object_get_field_by_name(praw, key);
+                                if !v.is_undefined() {
+                                    return v;
+                                }
                             }
                         }
                     }
@@ -909,7 +919,13 @@ pub extern "C" fn js_object_get_field_by_name(
                     // this covers the data-field case that was returning `undefined`
                     // (Auth.js sets `SignInError.kind = "signIn"` and reads it off a
                     // `CredentialsSignin` subclass to pick the sign-in vs error page).
-                    {
+                    //
+                    // #6530: `name` is an OWN property of every constructor — a
+                    // subclass never inherits its parent's `.name` (spec:
+                    // ClassDefinitionEvaluation installs it per class). Skip the
+                    // chain walk so the #2059 own-name synthesis below answers
+                    // with THIS class's registered name instead of an ancestor's.
+                    if name != "name" {
                         let mut cid = class_id;
                         let mut depth = 0usize;
                         while depth < 32 {
@@ -979,11 +995,18 @@ pub extern "C" fn js_object_get_field_by_name(
                     // parent object was recorded as `class_id`'s static
                     // prototype at `extends` time; walk that chain (also
                     // covering multi-level `class Leaf extends Mid {}`).
-                    if let Some(v) =
-                        super::super::class_registry::resolve_proto_chain_field(class_id, key)
-                    {
-                        if !v.is_undefined() && !v.is_null() {
-                            return v;
+                    // #6530: except `name` — an own property of every
+                    // constructor, never inherited; without the guard a
+                    // subclass of a per-evaluation class object reported its
+                    // BASE's synthesized `.name` (bundled zod:
+                    // `z.string().constructor.name` gave "ZodType").
+                    if name != "name" {
+                        if let Some(v) =
+                            super::super::class_registry::resolve_proto_chain_field(class_id, key)
+                        {
+                            if !v.is_undefined() && !v.is_null() {
+                                return v;
+                            }
                         }
                     }
                     // #36 / #321: the subclass extends a FUNCTION value

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
@@ -1338,6 +1338,20 @@ pub(crate) fn get_field_by_name_object_tail(
                     return v;
                 }
                 let class_id = (*obj).class_id;
+                // #6530: a capture-carrying class has no ClassRef value — the
+                // class VALUE is the per-evaluation class OBJECT registered at
+                // `js_object_mark_class` time. Return that same object so
+                // identity holds (`x.constructor === Sub`, bundled zod's
+                // `describe()` re-construction via `this.constructor`
+                // yielding the SUBCLASS instead of collapsing to the base).
+                // The arms below would otherwise hand back a bound
+                // constructor-method closure (whose underlying func is the
+                // nearest ancestor ctor — reporting the BASE class's name for
+                // every subclass) or the bare INT32 ClassRef.
+                if let Some(v) = super::super::class_registry::class_object_value_for_cid(class_id)
+                {
+                    return JSValue::from_bits(v.to_bits());
+                }
                 // #5834: WeakMap/WeakSet instances carry a reserved class_id
                 // (not a registered declared-class one), so none of the
                 // arms below resolve them and `(new WeakMap()).constructor`

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -799,6 +799,34 @@ pub extern "C" fn js_object_set_field_by_name(
             }
         }
 
+        // #6530: a named write on a per-evaluation CLASS OBJECT (`object_type
+        // == OBJECT_TYPE_CLASS` — what a capture-carrying class statement
+        // materializes as) must ALSO be mirrored into the class_id-keyed
+        // CLASS_DYNAMIC_PROPS side table. Compiled method bodies reference
+        // sibling classes as INT32 ClassRefs (bundled zod's
+        // `ZodOptional.create(this, this._def)` inside `ZodType.optional()`),
+        // and `js_class_static_method_call` resolves statics through that
+        // table only — without the mirror the dispatch missed and handed back
+        // the class ref itself, so `.optional()` returned the ZodOptional
+        // CLASS instead of an instance. The own-field write still proceeds
+        // below, so reads through the class-object binding (module-scope
+        // `ZodOptional.create`, re-exports) are unchanged. Internal
+        // `__perry_*` markers (the pinned-parent edge) stay object-local.
+        // Last-wins across evaluations of the same class statement, matching
+        // the established template-cid compromise.
+        if (*obj).object_type == crate::error::OBJECT_TYPE_CLASS
+            && (*obj).class_id != 0
+            && !key.is_null()
+        {
+            let name_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+            let name_len = (*key).byte_len as usize;
+            if let Ok(name) = std::str::from_utf8(std::slice::from_raw_parts(name_ptr, name_len)) {
+                if !name.is_empty() && !name.starts_with("__perry_") {
+                    class_dynamic_prop_root_store((*obj).class_id, name.to_string(), value);
+                }
+            }
+        }
+
         // Refs #486 (hono): class setter dispatch. JS spec: a `set X(...)`
         // accessor on the prototype intercepts `obj.X = value` writes
         // before they hit the instance's data slots. Hono's `set res(_res)

--- a/crates/perry-runtime/src/object/global_this/fetch_globals.rs
+++ b/crates/perry-runtime/src/object/global_this/fetch_globals.rs
@@ -737,6 +737,34 @@ pub unsafe extern "C" fn js_fetch_or_value_super(
                 // applies to closure/object parents, not a ClassRef.
                 return undef;
             }
+            // #6530: the parent can be a per-evaluation CLASS OBJECT — what a
+            // capture-carrying class statement materializes as (bundled zod's
+            // `class ZodEffects extends ZodType` where ZodType captures module
+            // helpers, registered via `js_register_class_parent_dynamic`).
+            // Dispatching it through `js_native_call_value` below hits that
+            // helper's class-object arm, which CONSTRUCTS a fresh parent
+            // instance — and this super leg drops the result, so the parent
+            // constructor never ran on `this` and every base-ctor field
+            // (zod's `_def`, the bound methods) stayed undefined. Route
+            // through the same flat constructor-on-`this` dispatch as the
+            // ClassRef arm above, using the template class id stamped on the
+            // class object at `js_object_alloc` time.
+            if bits & TAG_MASK == POINTER_TAG {
+                let p = (bits & PTR_MASK) as usize;
+                if super::super::class_registry::is_class_object_ptr(p as *const u8) {
+                    let parent_cid = crate::object::js_object_get_class_id(
+                        p as *const crate::object::ObjectHeader,
+                    );
+                    if parent_cid != 0 {
+                        if let Some(obj) = subclass_this_object_ptr(this_box) {
+                            super::super::class_constructors::run_class_constructor_on_this_flat(
+                                parent_cid, obj as i64, args_ptr, args_len,
+                            );
+                            return undef;
+                        }
+                    }
+                }
+            }
             let usable = if bits & TAG_MASK == POINTER_TAG {
                 let p = (bits & PTR_MASK) as usize;
                 // A real callability test: a closure, or a per-evaluation class

--- a/test-files/test_gap_class_capture_forward_static.ts
+++ b/test-files/test_gap_class_capture_forward_static.ts
@@ -1,0 +1,93 @@
+// #6530: forward class references from methods of a CAPTURE-CARRYING class
+// (classes nested in a function whose methods reference outer locals — the
+// shape of Next.js's bundled zod, where ZodType captures its helper
+// namespaces). Two paths regressed:
+//   1. `Sub.create(this, ...)` from a sibling method — the post-class arrow
+//      static lives on the per-evaluation class object, but the compiled
+//      method dispatches through the INT32 ClassRef static table; the miss
+//      silently returned the class ref itself.
+//   2. `new Eff({...})` from a sibling method — the dynamic-parent value
+//      super leg constructed-and-dropped a fresh parent instead of running
+//      the parent constructor on `this`, so base-ctor fields stayed
+//      undefined.
+
+function makeModule() {
+  function getParsedType(x: any): string {
+    return typeof x;
+  }
+  const OK = (v: any) => ({ ok: true, value: v });
+
+  class Base {
+    _def: any;
+    parse(x: any) {
+      const ctx = { errorMap: this._def.errorMap, data: x, parsedType: getParsedType(x) };
+      return this._parse(ctx);
+    }
+    _parse(ctx: any): any {
+      return "base:" + ctx.data;
+    }
+    constructor(def: any) {
+      this._def = def;
+      this.parse = this.parse.bind(this);
+      this.optional = this.optional.bind(this);
+    }
+    optional() {
+      return (Sub as any).create(this, this._def);
+    }
+    transform(f: any) {
+      return new Eff({ schema: this, effect: f, errorMap: "tm" });
+    }
+    describe(d: string) {
+      const ctor: any = this.constructor;
+      return new ctor({ ...this._def, description: d });
+    }
+  }
+
+  class Eff extends Base {
+    _parse(ctx: any) {
+      return "eff:" + ctx.errorMap + ":" + ctx.data;
+    }
+  }
+
+  class Sub extends Base {
+    _parse(ctx: any) {
+      const pt = getParsedType(ctx.data);
+      if (pt === "undefined") {
+        return OK(undefined).value;
+      }
+      return "sub:" + ctx.errorMap + ":" + ctx.data;
+    }
+    unwrap() {
+      return this._def.innerType;
+    }
+  }
+  (Sub as any).create = (e: any, t: any) => new Sub({ innerType: e, errorMap: "em" });
+
+  return { Base, Sub, Eff };
+}
+
+const m = makeModule();
+
+const b = new m.Base({ errorMap: "bm" });
+console.log("base parse:", b.parse(1));
+
+// path 1: post-class arrow static via forward ClassRef from a sibling method
+const o = b.optional();
+console.log("opt typeof:", typeof o);
+console.log("opt instanceof Sub:", o instanceof m.Sub);
+console.log("opt _def set:", o._def !== undefined);
+console.log("opt parse undef:", o.parse(undefined));
+console.log("opt parse val:", o.parse(7));
+console.log("opt unwrap is base:", o.unwrap() === b);
+
+// path 2: direct `new ForwardClass(...)` from a sibling method
+const v = b.transform((x: any) => x);
+console.log("eff instanceof Eff:", v instanceof m.Eff);
+console.log("eff _def set:", v._def !== undefined);
+console.log("eff parse:", v.parse(3));
+console.log("eff schema is base:", v._def.schema === b);
+
+// direct static call from outside (worked before, must keep working)
+const s2 = (m.Sub as any).create(b, b._def);
+console.log("direct _def set:", s2._def !== undefined);
+console.log("direct parse:", s2.parse(9));


### PR DESCRIPTION
Fixes #6530.

Next.js's bundled zod (`next/dist/compiled/zod/index.cjs`) broke in three ways, all rooted in **capture-carrying classes** — classes nested in a (webpack-wrapper) function whose methods reference outer locals, which Perry materializes as per-evaluation heap class objects instead of INT32 ClassRefs. zod's whole `ZodType` family is this shape (the helper namespaces `o`/`i`/`k` are captured), which is why `z.string().optional().parse(undefined)` threw while trivially-reduced mimics passed.

### Defect 1 — post-class statics on capture classes are invisible to ClassRef static dispatch (repro 1)

`ZodOptional.create = (e, t) => new ZodOptional({...})` lands on the fresh class **object**'s own fields, but a sibling method body (`ZodType.optional()`) compiles the same call as `js_class_static_method_call(ClassRef(cid), "create", …)`, which consults only the cid-keyed `CLASS_DYNAMIC_PROPS` side table. The miss silently returned the receiver — so `.optional()` evaluated to the ZodOptional **class ref**, and `.parse(undefined)` then threw `Cannot read properties of undefined (reading 'errorMap')`.

**Fix** (`field_set_by_name.rs`): mirror named-field writes on a marked class object into `CLASS_DYNAMIC_PROPS` under its template class id (internal `__perry_*` markers excluded; own-field write unchanged; last-wins across evaluations, matching the existing template-cid compromise).

### Defect 2 — value-super with a class-object parent constructs-and-drops (repro 2, part of repro 1's family)

`new ZodEffects({...})` from a sibling method takes the dynamic-parent super leg (`js_fetch_or_value_super`). With a class-object parent it dispatched `js_native_call_value`, whose W2 class-object arm **constructs a fresh discarded parent instance** instead of running the parent constructor on `this` — `ZodType`'s ctor never ran, `_def` and the bound methods stayed undefined (`transform`/`default`/`catch`/`refine`, and the record/object repro's `_getType` crash).

**Fix** (`fetch_globals.rs`): add a class-object arm mirroring the existing INT32-ClassRef arm — resolve the template cid stamped on the class object and run `run_class_constructor_on_this_flat` on `this`.

### Defect 3 — user args swallowed as capture fallbacks at direct-ctor call sites (repro 2)

The bare-identifier `new C(...)` codegen path assumed the HIR always appends the class's captures as trailing `LocalGet` args. The HIR only does that where the captured locals are in scope (the declaring function); inside a sibling class's method nothing is appended — so the tail-split treated the one **user** arg as a capture fallback: the synthesized ctor got an empty rest array, `super(...[])` ran the parent ctor with no `def`.

**Fix** (`lower_call/new.rs`): treat the tail as appended caps only when each trailing arg is `LocalGet(id)` matching the synthesized `__perry_cap_<id>` param it binds to (exact id + order, all-or-nothing — the HIR emitter's invariant).

### Defect 4 — `.constructor` / `.name` identity collapse (repro 3)

Instances of capture classes resolved `.constructor` to a bound constructor-method closure (underlying func = nearest ancestor ctor), so `x.constructor === Sub` was false even for bases and every subclass reported the **base's** name (`z.string().constructor.name === "ZodType"`); zod's `describe()` re-constructs via `this.constructor` and produced base instances. Separately, three static-resolution walks (classref `CLASS_DYNAMIC_PROPS` chain, classref `resolve_proto_chain_field`, class-object pinned-parent recursion) **inherited `name` from the parent edge** — but `name`/`prototype` are own properties of every constructor, never inherited.

**Fix**: new `CLASS_OBJECT_VALUES` registry (cid → marked class object, populated by `js_object_mark_class`, GC-rooted in both the mut scan and the snapshot machine exactly like `CLASS_DYNAMIC_PARENT_VALUE`), consulted first in the instance `.constructor` arm; `name` skipped in the three inheritance walks (`prototype` also skipped in the pinned-parent recursion).

### Validation

All three issue repros now match node byte-for-byte against the bundled zod:

```
z.string().optional().parse(undefined)  → undefined
z.record(z.string(), z.object({p: z.string(), q: z.boolean().optional()}))
  .parse({a:{p:"x"}})                   → { a: { p: "x" } }
z.string().constructor.name             → "ZodString"
z.object({}).constructor.name           → "ZodObject"
```

Every `ZodType` combinator was probed (`optional/nullable/array/promise/or/and/transform/default/brand/catch/describe/pipe/readonly/refine/nullish`) — all now produce real instances with correct `_def.typeName`.

**Boot-time manifestation**: Next 16's real `next/dist/server/config-schema.js` (the gscmaster standalone boot blocker) now initializes under Perry, and `configSchema.safeParse(<valid config>)` matches node. The validation-*failure* path hits a separate pre-existing gap (`new.target` undefined in a CJS-nested `class X extends Error` ctor — bundled zod's `ZodError`), filed as #6535 with a reduced repro; it reproduces identically on a pre-fix main build.

New gap test `test-files/test_gap_class_capture_forward_static.ts` covers the shape without the zod bundle (fails pre-fix, byte-identical post-fix). A full `scripts/run_gap_tests.sh` sweep is running locally; result will be posted as a comment. `perry-codegen`/`perry-runtime` lib tests pass (the two `gc::tests::teardown` parallel-run failures reproduce identically at the base commit — pre-existing parallel-suite flakiness; they pass with `--test-threads=1`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed subclass constructors with captured values so forwarded arguments and `super(...)` calls work correctly.
  * Preserved per-evaluation class identity when accessing `constructor` and invoking inherited static methods.
  * Corrected constructor `name` and `prototype` property resolution for subclasses.
  * Ensured class property updates and garbage collection retain the correct class objects.
  * Fixed dynamic parent construction so base-class fields are initialized correctly.

* **Tests**
  * Added regression coverage for captured class values, forwarded static methods, subclass construction, and parent initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->