### PR TITLE
fix(runtime): cross boxed async-fn-local captures into perry/thread workers (#6520)

### DIFF
--- a/crates/perry-runtime/src/box.rs
+++ b/crates/perry-runtime/src/box.rs
@@ -437,6 +437,36 @@ fn is_registered_box_ptr(ptr: *mut Box) -> bool {
     BOX_REGISTRY.with(|r| r.borrow().contains(&(ptr as usize)))
 }
 
+/// If `slot_bits` (the raw contents of a closure capture slot) is a registered
+/// box pointer, return the JSValue bits stored *inside* that box; otherwise
+/// return `None`.
+///
+/// A closure that captures a boxed local — every body local of an `async`
+/// function (the async-to-generator transform boxes them all), plus any
+/// mutable capture — stores the raw box pointer in its capture slot rather
+/// than a NaN-boxed value (see the codegen closure lowering in
+/// `perry-codegen/src/expr/closure.rs`). That pointer addresses a box in the
+/// *current thread's* thread-local, never-freed `BOX_REGISTRY`, so it is
+/// meaningless on any other thread. The `perry/thread` serializer uses this to
+/// unwrap such a slot to the value the box actually holds before deep-copying
+/// it across the boundary (#6520 — without it the worker read the captured
+/// value as `undefined`/empty).
+///
+/// Registry membership is authoritative: any NaN-boxed value or real double
+/// has its high bits set and fails `is_plausible_box_ptr`, so this only ever
+/// matches a genuine live box pointer, never a coincidental capture value.
+#[inline]
+pub fn box_slot_contents_bits(slot_bits: u64) -> Option<u64> {
+    let ptr = slot_bits as usize as *mut Box;
+    if is_registered_box_ptr(ptr) {
+        // Safety: the address is in BOX_REGISTRY, so it was minted by
+        // `js_box_alloc` and points at a live (never-freed) `Box`.
+        Some(unsafe { (*ptr).value })
+    } else {
+        None
+    }
+}
+
 #[inline]
 fn is_registered_i32_box_ptr(ptr: *mut I32Box) -> bool {
     if !is_plausible_box_ptr(ptr.cast::<Box>()) {
@@ -587,5 +617,34 @@ mod tests {
         assert_eq!(js_i32_box_get(ordinary_box.cast::<I32Box>()), 0);
         js_i32_box_set(ordinary_box.cast::<I32Box>(), 99);
         assert_eq!(js_box_get(ordinary_box), 1.0);
+    }
+
+    /// #6520: the thread-boundary serializer unwraps a capture slot that holds
+    /// a box pointer to the value inside. `box_slot_contents_bits` returns the
+    /// contained JSValue bits for a real box and `None` for anything else — a
+    /// plain NaN-boxed value (high tag bits set → not a plausible box address),
+    /// a plausible-but-unregistered pointer, and a null slot.
+    #[test]
+    fn box_slot_contents_unwraps_only_registered_boxes() {
+        test_clear_box_registry();
+
+        // A real box: returns the bits it holds, not the pointer.
+        let inner = crate::value::JSValue::int32(1234).bits();
+        let b = js_box_alloc_bits(inner as i64);
+        let slot_bits = b as usize as u64; // codegen stores the raw box ptr here
+        assert_eq!(box_slot_contents_bits(slot_bits), Some(inner));
+
+        // A NaN-boxed non-box value (its own tag bits are set) is not a box.
+        assert_eq!(box_slot_contents_bits(inner), None);
+        assert_eq!(box_slot_contents_bits(crate::value::TAG_UNDEFINED), None);
+
+        // A plausible pointer that was never minted as a box.
+        static RODATA: [u64; 2] = [0xDEAD_BEEF, 0xFEED_FACE];
+        let fake = (&RODATA[0] as *const u64) as usize as u64;
+        assert!(is_plausible_box_ptr(fake as usize as *mut Box));
+        assert_eq!(box_slot_contents_bits(fake), None);
+
+        // Null / near-null slots.
+        assert_eq!(box_slot_contents_bits(0), None);
     }
 }

--- a/crates/perry-runtime/src/thread.rs
+++ b/crates/perry-runtime/src/thread.rs
@@ -246,6 +246,17 @@ pub enum SerializedValue {
         captures: Vec<SerializedValue>,
     },
 
+    /// A closure capture slot that, on the source thread, held a pointer to a
+    /// mutable `Box` rather than a NaN-boxed value — the shape codegen produces
+    /// for every `async`-fn body local (boxed by the async-to-generator
+    /// transform) and every mutable capture. The box itself is thread-local and
+    /// never crosses; this carries a deep copy of the value it held, and
+    /// deserialization re-boxes it in the receiving thread's registry so the
+    /// reconstructed closure's `js_box_get`/`js_box_set` slot reads work again
+    /// (#6520). Only ever appears in a capture position; the inner value is any
+    /// ordinary transferable `SerializedValue`.
+    BoxedCapture(Box<SerializedValue>),
+
     /// A BigInt: 16 x u64 limbs in little-endian order.
     BigInt([u64; BIGINT_LIMBS]),
 
@@ -394,6 +405,38 @@ pub unsafe fn serialize_nanbox_for_thread(bits: u64) -> SerializedValue {
     SerializedValue::Inline(bits)
 }
 
+/// Serialize a single closure capture slot for a thread boundary.
+///
+/// Capture slots differ from array elements / object fields: a slot for a
+/// *boxed* local holds a raw box pointer, not a NaN-boxed value. Every body
+/// local of an `async` function is boxed by the async-to-generator transform,
+/// and any mutable capture is boxed too; codegen stores the box pointer in the
+/// capture slot so reads/writes inside the closure body go through
+/// `js_box_get`/`js_box_set` — and the reconstructed closure on the receiving
+/// thread reads its slots the same way. That box lives in the *spawning*
+/// thread's thread-local, never-freed registry, so it cannot cross verbatim:
+/// crossing the raw pointer left the worker's `js_box_get` reading an
+/// unregistered address (→ `undefined`), so a captured async-fn local array
+/// looked empty (length 0) and a captured scalar looked `undefined` (#6520).
+///
+/// Cross it as a [`SerializedValue::BoxedCapture`]: deep-copy the value the box
+/// *holds* now, and re-box it on the receiving thread (see
+/// [`deserialize_nanbox_on_current_thread`]) so the slot there again holds a
+/// valid, locally-registered box pointer. Non-boxed slots (plain value
+/// captures, the `this`/`new.target` slots) serialize directly.
+///
+/// # Safety
+/// Same contract as [`serialize_nanbox_for_thread`]: pointer-tagged values
+/// must reference live objects in the current thread's arena/heap.
+unsafe fn serialize_capture_for_thread(slot_bits: u64) -> SerializedValue {
+    match crate::r#box::box_slot_contents_bits(slot_bits) {
+        Some(inner_bits) => {
+            SerializedValue::BoxedCapture(Box::new(serialize_nanbox_for_thread(inner_bits)))
+        }
+        None => serialize_nanbox_for_thread(slot_bits),
+    }
+}
+
 /// Human-readable name for a GC object type that cannot cross a thread
 /// boundary. Used only to build the TypeError message (#6185).
 ///
@@ -436,6 +479,7 @@ pub(crate) fn first_unsupported_transfer_type(sv: &SerializedValue) -> Option<&'
         SerializedValue::Closure { captures, .. } => {
             captures.iter().find_map(first_unsupported_transfer_type)
         }
+        SerializedValue::BoxedCapture(inner) => first_unsupported_transfer_type(inner),
         _ => None,
     }
 }
@@ -585,7 +629,7 @@ unsafe fn serialize_closure(closure: *const ClosureHeader) -> SerializedValue {
     let mut captures = Vec::with_capacity(actual_count);
     for i in 0..actual_count {
         let cap_bits = (*captures_base.add(i)).to_bits();
-        captures.push(serialize_nanbox_for_thread(cap_bits));
+        captures.push(serialize_capture_for_thread(cap_bits));
     }
 
     SerializedValue::Closure {
@@ -733,6 +777,20 @@ pub unsafe fn deserialize_nanbox_on_current_thread(sv: &SerializedValue) -> u64 
                 crate::closure::js_closure_set_capture_f64(closure, i as u32, f64::from_bits(bits));
             }
             JSValue::pointer(closure as *const u8).bits()
+        }
+
+        SerializedValue::BoxedCapture(inner) => {
+            // Re-box on THIS thread: deep-copy the held value into the local
+            // arena, then allocate a fresh box (registered in this thread's
+            // registry) holding it. The returned bits are the raw box POINTER,
+            // exactly what codegen expects a boxed-capture slot to contain, so
+            // `js_box_get`/`js_box_set` in the reconstructed closure body work
+            // (#6520). `js_box_alloc_bits` uses the system allocator (no GC
+            // trigger), so `value_bits` cannot be collected between the two
+            // steps; once stored, the box-registry GC scanner keeps it alive.
+            let value_bits = deserialize_nanbox_on_current_thread(inner);
+            let box_ptr = crate::r#box::js_box_alloc_bits(value_bits as i64);
+            box_ptr as u64
         }
 
         SerializedValue::BigInt(limbs) => {
@@ -894,7 +952,7 @@ unsafe fn parallel_map_impl(array_val: f64, closure_val: f64) -> i64 {
                 (closure as *const u8).add(std::mem::size_of::<ClosureHeader>()) as *const f64;
             let mut caps = Vec::with_capacity(actual);
             for i in 0..actual {
-                caps.push(serialize_nanbox_for_thread((*base.add(i)).to_bits()));
+                caps.push(serialize_capture_for_thread((*base.add(i)).to_bits()));
             }
             guard_transferable(&caps); // #6185: named throw for a captured Map/Set/…
             Some((fp, cc, caps))
@@ -1151,7 +1209,7 @@ unsafe fn parallel_filter_impl(array_val: f64, closure_val: f64) -> i64 {
         let base = (closure as *const u8).add(std::mem::size_of::<ClosureHeader>()) as *const f64;
         let mut caps = Vec::with_capacity(actual);
         for i in 0..actual {
-            caps.push(serialize_nanbox_for_thread((*base.add(i)).to_bits()));
+            caps.push(serialize_capture_for_thread((*base.add(i)).to_bits()));
         }
         guard_transferable(&caps); // #6185: named throw for a captured Map/Set/…
         Some((fp, cc, caps))
@@ -1365,7 +1423,7 @@ unsafe fn spawn_impl(closure_val: f64) -> *mut crate::promise::Promise {
                 (closure as *const u8).add(std::mem::size_of::<ClosureHeader>()) as *const f64;
             let mut caps = Vec::with_capacity(actual);
             for i in 0..actual {
-                caps.push(serialize_nanbox_for_thread((*base.add(i)).to_bits()));
+                caps.push(serialize_capture_for_thread((*base.add(i)).to_bits()));
             }
             guard_transferable(&caps);
             Some((cc, caps))

--- a/scripts/run_thread_tests.sh
+++ b/scripts/run_thread_tests.sh
@@ -190,6 +190,63 @@ else
     fail=$((fail+1))
 fi
 
+# Case 6 (#6520): a `spawn` closure that captures a local of an `async`
+# function. The async-to-generator transform boxes every body local into a
+# shared cell, so codegen stores the raw BOX POINTER in the closure's capture
+# slot (not the value). That pointer lives in the spawning thread's
+# thread-local box registry and is meaningless on the worker — before the fix
+# the serializer crossed it as an opaque number and `js_box_get` on the worker
+# returned `undefined`, so a captured array read as empty (length 0) and a
+# captured scalar/string read as `undefined`. The serializer now unwraps a
+# boxed capture slot to its contained value. A non-async capture (the same
+# local read-only, hence unboxed) was always fine — kept here as a control.
+cat >"$TMP_DIR/async_local_capture.ts" <<'EOF'
+import { spawn } from "perry/thread";
+
+async function main(): Promise<void> {
+  const nums: number[] = [1, 2, 3];
+  const label: string = "sum";
+  const bias: number = 10;
+  // Array + scalar + string, all async-fn locals, captured into the worker.
+  const total: number = await spawn(() => {
+    let s = bias;
+    for (let i = 0; i < nums.length; i++) s += nums[i];
+    return s;
+  });
+  const tag: string = await spawn(() => `${label}=${nums.length}`);
+  console.log(total, tag);
+}
+await main();
+
+// Control: a plain (non-async) function's local is an unboxed value capture.
+function control(): void {
+  const vals: number[] = [4, 5, 6];
+  spawn(() => vals[0] + vals[1] + vals[2]).then((v: number) => {
+    console.log("control", v);
+  });
+}
+control();
+setTimeout(() => {}, 200);
+EOF
+expected_async_output=$'16 sum=3\ncontrol 15'
+if ! "$PERRY_BIN" "$TMP_DIR/async_local_capture.ts" -o "$TMP_DIR/async_local_capture.out" \
+        >/dev/null 2>"$TMP_DIR/async_local_capture.stderr"; then
+    echo "FAIL async_local_capture: compile error"
+    sed 's/^/    /' "$TMP_DIR/async_local_capture.stderr"
+    fail=$((fail+1))
+elif actual_async_output="$("$TMP_DIR/async_local_capture.out" 2>&1)" \
+        && [[ "$actual_async_output" == "$expected_async_output" ]]; then
+    echo "PASS async_local_capture"
+    pass=$((pass+1))
+else
+    echo "FAIL async_local_capture: wrong runtime output"
+    echo "  expected:"
+    sed 's/^/    /' <<<"$expected_async_output"
+    echo "  actual:"
+    sed 's/^/    /' <<<"$actual_async_output"
+    fail=$((fail+1))
+fi
+
 echo
 echo "thread-tests: $pass passed, $fail failed"
 


### PR DESCRIPTION
Fixes #6520.

## Problem

A `spawn` / `parallelMap` / `parallelFilter` closure that captures a local of an **`async`** function saw it as empty on the worker:

```ts
async function main(): Promise<void> {
  const nums: number[] = [1, 2, 3];
  const total: number = await spawn(() => {
    let s = 0;
    for (let i = 0; i < nums.length; i++) s += nums[i];
    return s;
  });
  console.log(total); // printed 0, expected 6
}
await main();
```

A captured scalar in an async fn crossed as `undefined`; the same capture in a **non-async** function was always fine.

## Root cause

The async-to-generator transform boxes every body local into a per-call `js_box_alloc` cell (`PreallocateBoxes`), so codegen stores the raw **box pointer** — not a NaN-boxed value — in the closure's capture slot, and the closure body reads it back through `js_box_get` (`perry-codegen/src/expr/closure.rs`). `serialize_nanbox_for_thread` saw that pointer's bits (high bits zero → matches no NaN tag) and crossed it as an opaque `Inline` number. On the worker, `js_box_get` on that address returned `undefined`, because the box is registered only in the **spawning** thread's thread-local `BOX_REGISTRY`. A non-async read-only local is an unboxed value capture, so its slot already held the real value — hence the async-only symptom.

## Fix (symmetric across the boundary)

- **`box.rs`** — `box_slot_contents_bits(slot_bits)`: if a capture slot holds a registered box pointer, return the JSValue bits it contains. The registry check is authoritative (any NaN-boxed value / real double fails the plausibility gate), so it only ever matches a genuine live box.
- **`thread.rs`** — serialize a boxed capture slot as a new `SerializedValue::BoxedCapture(inner)` carrying a **deep copy** of the box's contents; on deserialization, **re-box** the value in the receiving thread's registry and store the fresh box pointer in the slot, so the reconstructed closure's `js_box_get`/`js_box_set` work again. Routed through the shared serialize/deserialize helpers, so `spawn`, `parallelMap`, `parallelFilter`, and nested-closure captures are all covered. `first_unsupported_transfer_type` recurses into `BoxedCapture`, so a boxed non-transferable (e.g. a captured `Map`) still raises the #6185 named `TypeError`.

## Tests

- `box.rs` unit test `box_slot_contents_unwraps_only_registered_boxes` (runs per-PR via cargo-test): real box unwraps to its contents; NaN-boxed values, plausible-but-unregistered pointers, and null all return `None`.
- `scripts/run_thread_tests.sh` case 6 `async_local_capture`: array + scalar + string async-fn locals crossed into a worker, plus a non-async control. Verified locally alongside the existing 5 thread cases (`6 passed, 0 failed`).

Verified end-to-end: the repro now prints `6`, the scalar case `43`, and the non-async control is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed closure captures from asynchronous functions and mutable local values when used across threads.
  * Preserved boxed captured values during parallel operations and spawned tasks.
  * Improved handling and reporting of unsupported values nested within captured data.

* **Tests**
  * Added coverage for asynchronous local captures, including compilation and runtime output validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->