### PR TITLE
fix(runtime): resolve Uint8Array-view data pointer to backing for native buffer+len params (#6515)

### DIFF
--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -28,6 +28,11 @@ mod u8_codec;
 pub mod validate;
 pub(crate) mod view;
 
+// Canonical view-resolving span accessor. Every path that hands a raw data
+// pointer to native code routes through this so a Uint8Array view over an
+// ArrayBuffer exposes its backing bytes, not its stale local copy (#6515).
+pub(crate) use view::resolve_data_ptr as resolve_span_data_ptr;
+
 // ---- Re-exports: types & constants ----
 pub use header::{BufferHeader, BUFFER_TYPE_ID, SMALL_BUF_THRESHOLD};
 

--- a/crates/perry-runtime/src/buffer/query.rs
+++ b/crates/perry-runtime/src/buffer/query.rs
@@ -37,7 +37,9 @@ pub unsafe extern "C" fn js_value_buffer_or_typedarray_data(
             if !out_len.is_null() {
                 *out_len = (*buf).length;
             }
-            return buffer_data(buf);
+            // #6515: resolve a registered view to its backing window so native
+            // consumers see the bytes JS reads/writes, not the stale local copy.
+            return resolve_span_data_ptr(buf);
         }
     }
     // TypedArray? (Uint8Array etc. backing bytes)
@@ -144,8 +146,10 @@ fn native_buffer_from_value(value: f64) -> Option<*const BufferHeader> {
 
 #[no_mangle]
 pub extern "C" fn js_native_buffer_data_ptr(value: f64) -> *const u8 {
+    // #6515: a Uint8Array view over an ArrayBuffer must expose its backing
+    // window here, not its stale local copy (see `view::resolve_data_ptr`).
     native_buffer_from_value(value)
-        .map(buffer_data)
+        .map(|buf| unsafe { resolve_span_data_ptr(buf) })
         .unwrap_or(std::ptr::null())
 }
 

--- a/crates/perry-runtime/src/buffer/view.rs
+++ b/crates/perry-runtime/src/buffer/view.rs
@@ -92,9 +92,16 @@ pub(crate) fn byte_offset_of(buf_ptr: usize) -> u32 {
 /// copy while JS reads come from the backing (or vice-versa), a silent
 /// corruption with no null and no error (#6515).
 ///
-/// Falls back to the buffer's own inline storage for a plain (non-view) buffer
-/// or a view whose recorded offset is out of the backing's bounds — matching
-/// `read_buffer_byte`'s per-byte guard so the two never drift.
+/// Falls back to the buffer's own inline storage for a plain (non-view) buffer,
+/// or for a view whose recorded window no longer fits inside the backing (a
+/// backing that was detached or shrunk since the view was registered). The
+/// native callee consumes `(*buf_ptr).length` bytes — the byte-length half of
+/// the ABI — so the whole `[offset, offset + length)` span must fit in the
+/// current backing before we hand back a backing pointer; otherwise it could
+/// read/write past the backing's end. The view's own storage is always sized
+/// to its own length, so the fallback stays in bounds. The `<=` boundary lets a
+/// zero-length view sitting exactly at `backing.length` still resolve to the
+/// backing edge rather than falling back.
 ///
 /// SAFETY: `buf_ptr` must be a live `BufferHeader`; a registered view's backing
 /// is kept in the registry only while it is live (see
@@ -103,7 +110,9 @@ pub(crate) fn byte_offset_of(buf_ptr: usize) -> u32 {
 pub(crate) unsafe fn resolve_data_ptr(buf_ptr: *const BufferHeader) -> *const u8 {
     if let Some(info) = lookup(buf_ptr as usize) {
         let backing_ptr = info.backing as *const BufferHeader;
-        if !backing_ptr.is_null() && info.offset < (*backing_ptr).length {
+        if !backing_ptr.is_null()
+            && info.offset.saturating_add((*buf_ptr).length) <= (*backing_ptr).length
+        {
             return buffer_data(backing_ptr).add(info.offset as usize);
         }
     }

--- a/crates/perry-runtime/src/buffer/view.rs
+++ b/crates/perry-runtime/src/buffer/view.rs
@@ -79,6 +79,37 @@ pub(crate) fn byte_offset_of(buf_ptr: usize) -> u32 {
     lookup(buf_ptr).map(|v| v.offset).unwrap_or(0)
 }
 
+/// Resolve `buf_ptr` to the canonical data pointer for its bytes.
+///
+/// A registered view (`Buffer.prototype.slice`/`subarray`,
+/// `new Uint8Array(arrayBuffer)`, `new Uint8Array(ab, off, len)`) keeps its
+/// own *copy* of the bytes so the codegen fast path can `gep+load` against the
+/// view pointer, but the ultimate backing buffer is the source of truth:
+/// `read_buffer_byte` reads and `js_buffer_set` writes `backing_data + offset`,
+/// and a direct fast-path store to the backing never refreshes the view's
+/// local copy. Any code that hands a raw span to a native callee must resolve
+/// through here too — otherwise a native write lands in the view's stale local
+/// copy while JS reads come from the backing (or vice-versa), a silent
+/// corruption with no null and no error (#6515).
+///
+/// Falls back to the buffer's own inline storage for a plain (non-view) buffer
+/// or a view whose recorded offset is out of the backing's bounds — matching
+/// `read_buffer_byte`'s per-byte guard so the two never drift.
+///
+/// SAFETY: `buf_ptr` must be a live `BufferHeader`; a registered view's backing
+/// is kept in the registry only while it is live (see
+/// `remove_entries_for_dead_buffer`), the same invariant `read_buffer_byte`
+/// and `js_buffer_set` already rely on.
+pub(crate) unsafe fn resolve_data_ptr(buf_ptr: *const BufferHeader) -> *const u8 {
+    if let Some(info) = lookup(buf_ptr as usize) {
+        let backing_ptr = info.backing as *const BufferHeader;
+        if !backing_ptr.is_null() && info.offset < (*backing_ptr).length {
+            return buffer_data(backing_ptr).add(info.offset as usize);
+        }
+    }
+    buffer_data(buf_ptr)
+}
+
 #[inline]
 pub(crate) fn for_each_view<F: FnMut(usize, ViewInfo)>(backing_ptr: usize, mut f: F) {
     BACKING_TO_VIEWS.with(|m| {

--- a/crates/perry-runtime/src/native_abi.rs
+++ b/crates/perry-runtime/src/native_abi.rs
@@ -541,6 +541,18 @@ mod tests {
             js_native_abi_check_buffer_data_ptr(boxed_ptr(standalone)),
             crate::buffer::buffer_data(standalone)
         );
+
+        // Hardening: if the backing shrinks after the view is registered so the
+        // recorded window no longer fits, resolution falls back to the view's
+        // own (correctly-sized) storage rather than hand back a backing pointer
+        // that a `len`-byte native write would overrun.
+        unsafe {
+            (*ab).length = 8;
+        }
+        assert_eq!(
+            js_native_abi_check_buffer_data_ptr(boxed_ptr(view)),
+            crate::buffer::buffer_data(view)
+        );
     }
 
     #[test]

--- a/crates/perry-runtime/src/native_abi.rs
+++ b/crates/perry-runtime/src/native_abi.rs
@@ -4,7 +4,7 @@
 //! used by the rest of the runtime. Manifest lowering calls them before handing
 //! raw scalars, pointers, buffer spans, strings, or promises to native code.
 
-use crate::buffer::{buffer_data, is_registered_buffer, BufferHeader};
+use crate::buffer::{is_registered_buffer, resolve_span_data_ptr, BufferHeader};
 use crate::object::ObjectHeader;
 use crate::promise::Promise;
 use crate::value::{JSValue, POINTER_MASK, TAG_FALSE, TAG_TRUE};
@@ -284,9 +284,14 @@ pub extern "C" fn js_native_abi_check_ptr(value: f64) -> i64 {
 }
 
 /// Validate and lower the data pointer half of a manifest `buffer+len` span.
+///
+/// Resolves a registered view (`new Uint8Array(arrayBuffer)`, `slice`,
+/// `subarray`) to `backing_data + byteOffset` — the same storage JS reads and
+/// writes go through — so a native callee that writes `len` bytes touches the
+/// bytes the script observes, not the view's stale local copy (#6515).
 #[no_mangle]
 pub extern "C" fn js_native_abi_check_buffer_data_ptr(value: f64) -> *const u8 {
-    buffer_data(strict_buffer_from_value(value))
+    unsafe { resolve_span_data_ptr(strict_buffer_from_value(value)) }
 }
 
 /// Validate and lower the byte-length half of a manifest `buffer+len` span.
@@ -475,6 +480,67 @@ mod tests {
         assert!(catch_runtime_throw(|| {
             js_native_abi_check_buffer_byte_len(42.0);
         }));
+    }
+
+    // #6515: a `Uint8Array` view over an `ArrayBuffer` is a registered view
+    // whose own storage is a copy; the backing ArrayBuffer is what JS reads
+    // and writes go through. The `buffer+len` data pointer must resolve to the
+    // backing window, otherwise a native write lands in the view's stale copy
+    // and the script never observes it (silent corruption).
+    #[test]
+    fn buffer_data_ptr_resolves_view_over_arraybuffer_to_backing() {
+        let ab = crate::buffer::js_array_buffer_new(64);
+        let view = crate::buffer::js_uint8array_new(boxed_ptr(ab));
+        assert_ne!(view as usize, ab as usize, "view must be a distinct header");
+
+        // Resolves to the backing's storage — NOT the view's own local copy.
+        let resolved = js_native_abi_check_buffer_data_ptr(boxed_ptr(view));
+        assert_eq!(resolved, crate::buffer::buffer_data(ab));
+        assert_ne!(resolved, crate::buffer::buffer_data(view));
+        assert_eq!(js_native_abi_check_buffer_byte_len(boxed_ptr(view)), 64);
+
+        // End-to-end: a native write through the resolved pointer is observed
+        // by a JS-value index read of the view. Before the fix this read 0 —
+        // the byte landed in the view's copy while the read came from `ab`.
+        unsafe {
+            *(resolved as *mut u8) = 0xAB;
+        }
+        assert_eq!(
+            crate::buffer::js_buffer_index_get_value(view, 0),
+            0xAB as f64
+        );
+
+        // Offset views (`new Uint8Array(ab, 16, 8)`) resolve to
+        // `backing_data + byteOffset`, and the write is visible at the
+        // absolute backing offset too.
+        let with_offset = crate::buffer::js_uint8array_view(boxed_ptr(ab), 16.0, 8.0);
+        let resolved_off = js_native_abi_check_buffer_data_ptr(boxed_ptr(with_offset));
+        assert_eq!(resolved_off, unsafe {
+            crate::buffer::buffer_data(ab).add(16)
+        });
+        assert_eq!(
+            js_native_abi_check_buffer_byte_len(boxed_ptr(with_offset)),
+            8
+        );
+        unsafe {
+            *(resolved_off as *mut u8) = 0xCD;
+        }
+        assert_eq!(
+            crate::buffer::js_buffer_index_get_value(with_offset, 0),
+            0xCD as f64
+        );
+        assert_eq!(
+            crate::buffer::js_buffer_index_get_value(ab, 16),
+            0xCD as f64
+        );
+
+        // A standalone `new Uint8Array(64)` is not a view: it keeps resolving
+        // to its own storage (the working case in the report).
+        let standalone = crate::buffer::js_uint8array_alloc(64);
+        assert_eq!(
+            js_native_abi_check_buffer_data_ptr(boxed_ptr(standalone)),
+            crate::buffer::buffer_data(standalone)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Fixes #6515. When a `buffer+len` native-library param received a **`Uint8Array` view over an existing `ArrayBuffer`**, the lowered `data_ptr` pointed at the wrong memory. The length resolved correctly, so the callee read/wrote `len` bytes — of the wrong buffer. No error, no null: **silent data corruption**. A standalone `new Uint8Array(64)` worked.

## Root cause

Perry models a view (`new Uint8Array(ab)`, `.slice()`, `.subarray()`, `new Uint8Array(ab, off, len)`) as a **freshly-allocated `BufferHeader` with its own copy** of the bytes, plus a view-registry entry recording the ultimate backing buffer and byte offset. The backing is the source of truth: `read_buffer_byte` reads and `js_buffer_set` writes `backing_data + offset`, and a direct fast-path store to the backing never refreshes the view's local copy.

`js_native_abi_check_buffer_data_ptr` handed the callee `buffer_data(view)` — the view's **own stale copy** — instead of `backing_data + byteOffset`. So a native write landed in the copy while JS reads came from the backing (and vice-versa). Standalone Uint8Arrays aren't registered views, so they resolved to their own storage and worked.

## Fix

Add `view::resolve_data_ptr`, mirroring `read_buffer_byte`'s view resolution (`backing_data + byteOffset`, with the same out-of-bounds fallback to the buffer's own storage), and route every native raw-span accessor through it so read/write/native never drift:

- `js_native_abi_check_buffer_data_ptr` — the manifest `buffer+len` path this issue reports (`@perryts/webgpu`'s `js_webgpu_queue_write_buffer` etc.).
- `js_native_buffer_data_ptr` — the sibling native data-pointer accessor (v8 serialization, stream introspection, child_process serde).
- `js_value_buffer_or_typedarray_data` — the FFI span accessor used by `perry-ext-http-server`.

The issue suggested returning null when a view can't be resolved; instead the resolver falls back to the buffer's own storage exactly as `read_buffer_byte` does, so standalone buffers keep working and the native span always agrees with what JS reads.

## Test

`buffer_data_ptr_resolves_view_over_arraybuffer_to_backing` (a crate unit test, so it runs in per-PR `cargo-test`) drives the exact failure end-to-end: a native write through the resolved pointer of a `new Uint8Array(ab)` view — and an offset `new Uint8Array(ab, 16, 8)` view — is now observed by a subsequent JS index read of the view and at the absolute backing offset; the standalone `new Uint8Array(64)` case still resolves to its own storage.

`cargo test -p perry-runtime --lib native_abi:: buffer::` green (31 tests); `cargo fmt --check` clean.

_No version bump / changelog entry — leaving those for the maintainer to fold in at merge time._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed native buffer pointer resolution so `Uint8Array` views operate on the same bytes as their underlying `ArrayBuffer` (including `byteOffset`/offset views).
  * Prevented view-vs-backing pointer mismatches and ensured correct behavior when the backing `ArrayBuffer` shrinks.

* **Tests**
  * Added/extended regression coverage to verify pointer resolution for view vs backing, offset handling, write visibility from both sides, and fallback behavior for non-view `Uint8Array`.

* **Documentation**
  * Clarified the expected semantics for native-code data pointer resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->