### PR TITLE
fix(runtime): serialize a nested URL via toJSON in JSON.stringify (#6519)

### DIFF
--- a/crates/perry-runtime/src/json/replacer.rs
+++ b/crates/perry-runtime/src/json/replacer.rs
@@ -267,6 +267,15 @@ unsafe fn dispatch_pointer_with_replacer(
         }
         return;
     }
+    // #6519: a nested WHATWG `URL` (the value the replacer passed through)
+    // serializes as its `href` string. Its `searchParams` field points back at
+    // the URL, so the generic object walk below would trip the circular-
+    // structure detector. The href is a plain string, so the emit is identical
+    // for compact and pretty walks. See `write_url_href_json`.
+    if crate::url::is_url_object_shape(ptr as *mut crate::ObjectHeader) {
+        super::stringify::write_url_href_json(ptr as *mut crate::ObjectHeader, buf);
+        return;
+    }
     match gc_obj_type(ptr) {
         crate::gc::GC_TYPE_ARRAY => {
             // #5989: an array grown past its capacity leaves a GC_FLAG_FORWARDED
@@ -776,6 +785,14 @@ pub(crate) unsafe fn stringify_value_pretty(
         // `{"field0":null}`. Detected by the header magic (never a raw deref).
         if crate::regex::regex_header_has_magic(ptr as *const crate::regex::RegExpHeader) {
             buf.push_str("{}");
+            return;
+        }
+        // #6519: a nested WHATWG `URL` must serialize as its `href` string, not
+        // be walked as a plain object (its `searchParams` back-reference trips
+        // the circular-structure detector). Mirrors the compact-path branch in
+        // `stringify_object_inner`; see `write_url_href_json`.
+        if crate::url::is_url_object_shape(ptr as *mut crate::ObjectHeader) {
+            super::stringify::write_url_href_json(ptr as *mut crate::ObjectHeader, buf);
             return;
         }
         if matches!(

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -825,7 +825,38 @@ pub(crate) unsafe fn stringify_object(ptr: *const u8, buf: &mut String) {
     stringify_object_inner(ptr, buf, 0)
 }
 
+/// #6519: emit a WHATWG `URL` instance as its `href` string — Node serializes a
+/// URL through `URL.prototype.toJSON()`. A URL is a plain `GC_TYPE_OBJECT` whose
+/// `searchParams` field points back at the URL, so the generic object walk trips
+/// the circular-structure detector; every stringify walker (compact, pretty, and
+/// replacer, in both `stringify.rs` and `replacer.rs`) short-circuits URL objects
+/// through here. Callers must have confirmed `crate::url::is_url_object_shape`.
+/// `href` is a string by construction, so this never recurses into an object and
+/// is depth-independent (emitting it just escapes + quotes the string).
+#[inline]
+pub(crate) unsafe fn write_url_href_json(url: *mut crate::ObjectHeader, buf: &mut String) {
+    let href = crate::url::url_class::js_url_get_href(url);
+    stringify_value(href, TYPE_UNKNOWN, buf);
+}
+
 pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, depth: u32) {
+    // #6519: a WHATWG `URL` instance is a plain `GC_TYPE_OBJECT` (class_id 0)
+    // whose `searchParams` field points back at the URL — walking its fields
+    // trips the circular-structure detector. Node serializes a URL via
+    // `URL.prototype.toJSON()`, i.e. its `href` string. Top-level
+    // `JSON.stringify(url)` is intercepted at HIR-lowering time
+    // (`UrlInstanceToJSON`, module_static.rs), but a URL *nested* inside another
+    // object/array is invisible to that interception and only reaches this
+    // runtime walker — so detect the URL shape here and emit its href. This is
+    // the single chokepoint every object walk funnels through (the direct
+    // dispatch arms, the array slow loop, and per-field descent all land here);
+    // `is_url_object_shape` validates the GC header before reading any field, so
+    // it is safe to call on the non-object pointers that reach the `TYPE_OBJECT`
+    // hint / catch-all callers.
+    if crate::url::is_url_object_shape(ptr as *mut crate::ObjectHeader) {
+        write_url_href_json(ptr as *mut crate::ObjectHeader, buf);
+        return;
+    }
     // #1704: an object with a null `keys_array` has no own enumerable
     // properties — empty objects come out of `js_object_alloc` with
     // `keys_array == null` and only get one once a field is set. This is the
@@ -1289,6 +1320,14 @@ pub(crate) unsafe fn build_shape_prefix_template(first_elem_bits: u64) -> Option
     // array of `class { toJSON() {…} }` instances must honour the prototype
     // `toJSON`.)
     if (*obj).class_id != 0 {
+        return None;
+    }
+    // #6519: a URL instance is a class_id-0 object but must serialize as its
+    // `href` string (handled by `stringify_object_inner`'s URL branch), never
+    // as a templated dump of its 12 internal fields (which would also walk the
+    // `searchParams` back-reference and throw). Bail so an array whose first
+    // element is a URL routes every element through the per-element slow path.
+    if crate::url::is_url_object_shape(obj as *mut crate::ObjectHeader) {
         return None;
     }
     let keys_arr = (*obj).keys_array;

--- a/test-files/test_gap_6519_json_stringify_nested_url_tojson.ts
+++ b/test-files/test_gap_6519_json_stringify_nested_url_tojson.ts
@@ -1,0 +1,42 @@
+// #6519: JSON.stringify of an object/array *containing* a URL instance threw
+// `TypeError: Converting circular structure to JSON`. The top-level form is
+// intercepted at HIR-lowering time (UrlInstanceToJSON), but a nested URL only
+// reaches the runtime tree-walk stringifier, which walked the URL's internal
+// ObjectHeader fields and hit the `searchParams` → owner back-reference.
+// Node serializes a URL via URL.prototype.toJSON() (its href string), so every
+// line below must be byte-identical to node.
+const u = new URL("http://x/en", "http://x/");
+
+// URL nested directly in an object / array.
+console.log(JSON.stringify({ u }));
+console.log(JSON.stringify([u]));
+
+// Pretty-printed (replacer/spacer) forms.
+console.log(JSON.stringify({ u }, null, 2));
+console.log(JSON.stringify([u], null, 2));
+
+// Two URLs in one array — element 0 is a URL, so the array-of-objects shape
+// template must bail and route every element through href serialization.
+const v = new URL("http://y/fr?q=1", "http://y/");
+console.log(JSON.stringify([u, v]));
+console.log(JSON.stringify({ u, v }));
+
+// Deeper nesting.
+console.log(JSON.stringify({ list: [{ u }], v }));
+
+// URL carrying populated searchParams — this is the exact back-reference that
+// tripped the circular-structure detector.
+const w = new URL("http://z/?a=1&b=2");
+console.log(JSON.stringify({ w }));
+console.log(JSON.stringify([w]));
+
+// Mixed arrays: a plain object builds the shape template first, then a URL
+// element (and vice-versa) must fall back to per-element href serialization.
+console.log(JSON.stringify([{ a: 1 }, u]));
+console.log(JSON.stringify([u, { a: 1 }, v]));
+
+// A replacer that passes values through — toJSON still runs first.
+console.log(JSON.stringify({ u }, (_k: string, val: unknown) => val, 2));
+
+// Regression guard: the top-level HIR interception path must still work.
+console.log(JSON.stringify(u));


### PR DESCRIPTION
Fixes #6519.

## Root cause

`JSON.stringify` of an object/array **containing** a URL instance threw `TypeError: Converting circular structure to JSON`. Node serializes a URL via its `toJSON()` (the `href` string).

Top-level URL arguments are intercepted at HIR-lowering time (`UrlInstanceToJSON` in `crates/perry-hir/src/lower/expr_call/module_static.rs`, extended to the replacer/spacer forms in #6516). That interception can only see the call's **direct** argument — a URL nested inside another value only reaches the runtime tree-walk stringifier (`crates/perry-runtime/src/json/`), which walked the URL's internal `ObjectHeader` fields and hit the `searchParams` → owner back-reference, tripping the circular-structure detector.

## Fix

Detect the URL shape in the runtime walkers and emit its `href` (Node's `URL.prototype.toJSON`) instead of walking the fields, via a shared `write_url_href_json` helper. Detection reuses the existing, false-positive-safe `is_url_object_shape` probe (`class_id == 0` + `field_count >= 12` + a valid absolute `href` + the `searchParams` owner back-reference), the same predicate `js_url_href_if_url` already uses for `http.request`.

Added at every walker chokepoint so all shapes are covered:

- **`stringify_object_inner`** (compact path) — the single point the direct dispatch arms, the array slow loop, and per-field descent all funnel through.
- **`stringify_value_pretty`** (indented / no-replacer path).
- **`dispatch_pointer_with_replacer`** (replacer path, compact + pretty).
- **`build_shape_prefix_template`** bails when an array's first element is a URL, so the array-of-objects fast path never dumps a URL's 12 internal fields (and mixed arrays fall back per-element).

A plain object is never mistaken for a URL: `is_url_object_shape` requires the `searchParams` field to be an object whose owner points back at the URL, which no ordinary object satisfies (verified with a `{ href: "http://x/", …12 fields }` decoy).

## Validation

New gap test `test-files/test_gap_6519_json_stringify_nested_url_tojson.ts` — byte-identical to node — covers: URL nested in an object / array, pretty-printed (`null, 2`) object and array, multi-URL arrays (exercising the template bail), deep nesting, a URL with populated `searchParams` (the exact back-reference that tripped the detector), mixed arrays (plain-object-first and URL-first), the function-replacer form, and the top-level regression guard.

- New `test_gap_6519_*` and the existing `test_gap_6488_*` (URL `toString`/`toJSON`) both match node.
- `cargo test -p perry-runtime --lib json::` — 17 passed, 0 failed.
- A/B sweep of 22 URL/JSON gap tests vs node: 18 byte-match; the other 4 differ only by node's `DEP0169` `url.parse()` stderr deprecation warning or local-timezone date math — pre-existing artifacts unrelated to this change (CI normalizes the stderr warnings).
- `cargo fmt --all -- --check` clean; file-size gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `JSON.stringify` for nested `URL` objects, preventing incorrect circular-structure errors.
  * Ensured URLs serialize as their full URL strings, including when nested in objects or arrays.
  * Improved behavior with replacers, pretty-printing, nested structures, and populated query parameters.
  * Preserved correct serialization for standalone `URL` values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->