### PR TITLE
fix(transform): specialized mixin clones keep parent edge + a unique id (#6356)

### DIFF
--- a/crates/perry-transform/src/inline/factory_specialize.rs
+++ b/crates/perry-transform/src/inline/factory_specialize.rs
@@ -823,6 +823,15 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
         *next_class_counter += 1;
         let mut cloned = class.clone();
         cloned.name = cloned_name.clone();
+        // When the parent arg specializes to a runtime value rather than a
+        // static class (`Serializable(Mid)` where `Mid` is a local binding, not
+        // a `ClassRef`), we can't wire a static `extends_name`. The factory
+        // Call — including the `RegisterClassParentDynamic` its lowered Sequence
+        // carried — is about to be replaced by a bare `ClassRef` below, which
+        // would drop the parent edge entirely: `new Top()` would then inherit
+        // nothing from `Mid` (no fields, no methods, `instanceof Mid` false).
+        // Re-emit the dynamic registration at the call site instead (#6356).
+        let mut dynamic_parent_expr: Option<Expr> = None;
         if let Some(extends_expr) = cloned.extends_expr.as_mut() {
             substitute_locals(extends_expr, &param_subst, &mut next_id_seed);
             if let Expr::ClassRef(parent_name) = extends_expr.as_ref() {
@@ -837,6 +846,8 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                             .find(|c| &c.name == parent_name)
                             .map(|c| c.id)
                     });
+            } else {
+                dynamic_parent_expr = Some((**extends_expr).clone());
             }
         }
         // Filter out the capture ctor params + matching synthetic fields +
@@ -914,13 +925,42 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                 cloned.constructor = None;
             }
         }
+        // Assign a FRESH, unique class id. `class.clone()` above copied the
+        // template's id, and codegen keys the runtime class registry (methods,
+        // constructor, parent edges) by `c.id` (`codegen/mod.rs` builds
+        // `class_ids` from each class's `id`). Leaving the copy in place makes a
+        // clone collide with its template AND with sibling clones of the same
+        // template (`Serializable(Greetable(Base))` and `Serializable(Mid)` both
+        // clone `__anon_class_N`) — the distinct classes then share one registry
+        // slot, last-writer-wins on the constructor/parent edge, and a two-level
+        // dynamic mixin chain loses its intermediate parent (#6356). Ids past
+        // the current max are free: codegen derives its imported-class fallback
+        // range from the post-specialization max, and static parent edges are
+        // resolved by NAME, so only the numeric id has to be unique here. Later
+        // clones referencing this one as a static parent (see the `extends`
+        // lookup above) read the id assigned here, so assign before pushing.
+        let base_class_id = classes.iter().map(|c| c.id).max().unwrap_or(0) + 1;
+        cloned.id = base_class_id + new_classes.len() as u32;
         new_classes.push(cloned);
         // Replace the Call with `ClassRef(cloned_name)`. The Let's init is
         // now a plain ClassRef — the regular inliner won't touch it and
         // subsequent `new <X>()` sites will see it as an alias for the
         // specialized class via the existing `local_class_aliases`
-        // mechanism in codegen.
-        *expr = Expr::ClassRef(cloned_name);
+        // mechanism in codegen. When the parent is a runtime value, sequence
+        // the dynamic parent registration ahead of the ClassRef (the Sequence
+        // still yields the ClassRef as its value) so the parent edge is wired
+        // when this init runs — mirroring the class-expression lowering in
+        // `perry-hir`'s `arm_class.rs`.
+        *expr = match dynamic_parent_expr {
+            Some(parent_expr) => Expr::Sequence(vec![
+                Expr::RegisterClassParentDynamic {
+                    class_name: cloned_name.clone(),
+                    parent_expr: Box::new(parent_expr),
+                },
+                Expr::ClassRef(cloned_name),
+            ]),
+            None => Expr::ClassRef(cloned_name),
+        };
         true
     }
 

--- a/crates/perry-transform/src/inline/factory_specialize.rs
+++ b/crates/perry-transform/src/inline/factory_specialize.rs
@@ -982,13 +982,21 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
     // lets `lower_new` walk through the specialized class for inherited
     // constructors and field initializers instead of the unspecialized
     // anonymous original.
+    //
+    // `parent_expr` may be an `Expr::Sequence([RegisterClassParentDynamic, …,
+    // ClassRef(<inline>)])` when a class DECLARATION extends a factory call
+    // with a runtime-value arg (`class Child extends Factory(runtimeVar) {}`):
+    // `rewrite_call_init` rewrote the inner factory Call to that Sequence
+    // (see `rewrite_to_specialized_class`). Resolve through `classref_name`,
+    // which unwraps a Sequence to its trailing `ClassRef`, so the child's
+    // static parent still hoists rather than falling back to the runtime edge.
     for stmt in &module.init {
         if let Stmt::Expr(Expr::RegisterClassParentDynamic {
             class_name,
             parent_expr,
         }) = stmt
         {
-            if let Expr::ClassRef(parent_name) = parent_expr.as_ref() {
+            if let Some(ref parent_name) = classref_name(parent_expr.as_ref()) {
                 if let Some(child) = module.classes.iter_mut().find(|c| &c.name == class_name) {
                     child.extends_name = Some(parent_name.clone());
                     if let Some(parent_cls) = new_classes

--- a/test-files/test_gap_6356_dynamic_parent_mixin_chain.ts
+++ b/test-files/test_gap_6356_dynamic_parent_mixin_chain.ts
@@ -1,0 +1,96 @@
+// Issue #6356 — a class whose parent is wired at runtime (via
+// `RegisterClassParentDynamic`, i.e. any mixin/factory class that declines the
+// HIR mixin fast path) must inherit the base's instance FIELD initializers and,
+// through a TWO-LEVEL dynamic chain, the grandparent's methods + `instanceof`.
+//
+// These shapes route through `specialize_captured_class_factories`
+// (`perry-transform`), which monomorphizes the returned class per call site.
+// Two defects made the two-level chain fail:
+//
+//   1. The specialized clone reused the template class's `id` (`class.clone()`
+//      copies it). Codegen keys the runtime class registry by that id, so a
+//      clone collided with its template AND with sibling clones of the same
+//      template — the distinct classes shared one registry slot (last-writer-
+//      wins on the constructor / parent edge).
+//   2. When the parent arg specialized to a runtime value (`Serializable(Mid)`
+//      where `Mid` is a local binding, not a static `ClassRef`), the factory
+//      Call — including the `RegisterClassParentDynamic` its Sequence carried —
+//      was replaced by a bare `ClassRef`, dropping the parent edge entirely.
+//
+// Net symptom before the fix: `new Serializable(Greetable(Base))()` / the
+// `Top = Serializable(Mid)` chain lost `.value`, `greet()`, and
+// `instanceof Mid`. See the matrix in #6355 (which deliberately left these
+// cells out because they matched neither node nor a clean gap).
+
+class Base {
+  value = "base value";
+  hello() {
+    return "base hello";
+  }
+}
+
+// A canonical single-statement mixin (takes the HIR fast path when bound
+// directly, e.g. `const Mid = Greetable(Base)`).
+function Greetable(B: any) {
+  return class extends B {
+    greet() {
+      return "hi";
+    }
+  };
+}
+
+function Serializable(B: any) {
+  return class extends B {
+    ser() {
+      return "ser";
+    }
+  };
+}
+
+// A factory whose body is NOT the fast-path shape (`const K = …; return K`),
+// so it declines the fast path and is factory-specialized instead.
+function ViaConst(B: any) {
+  const K = class extends B {
+    greet() {
+      return "const";
+    }
+  };
+  return K;
+}
+
+// --- (1) return-via-const: inherited field through a dynamic parent ---------
+const C = ViaConst(Base);
+console.log("viaconst method:", new C().hello());
+console.log("viaconst field:", (new C() as any).value);
+console.log("viaconst instanceof base:", new C() instanceof Base);
+
+// --- (2) two mixins composed in one expression (arg is a Call) -------------
+const Comp = Serializable(Greetable(Base) as any);
+console.log("composed field:", (new Comp() as any).value);
+console.log("composed outer:", new Comp().ser());
+console.log("composed inner:", (new Comp() as any).greet());
+console.log("composed instanceof base:", new Comp() instanceof Base);
+
+// --- (3) mixin over a mixin RESULT (the core two-level dynamic chain) -------
+const Mid = Greetable(Base);
+const Top = Serializable(Mid as any);
+console.log("mid field:", (new Mid() as any).value);
+console.log("mid greet:", (new Mid() as any).greet());
+console.log("mid instanceof base:", new Mid() instanceof Base);
+console.log("chained field:", (new Top() as any).value);
+console.log("chained greet:", (new Top() as any).greet());
+console.log("chained ser:", new Top().ser());
+console.log("chained inherited method:", (new Top() as any).hello());
+console.log("chained instanceof base:", new Top() instanceof Base);
+console.log("chained instanceof mid:", new Top() instanceof Mid);
+
+// --- (4) sibling specializations of one template must not collide ----------
+// `Comp` and `Top` are both clones of Serializable's returned class; with the
+// id-collision bug they shared a class id and their parent edges clobbered each
+// other. Re-read both after constructing the other to confirm independence.
+const compAgain = new Comp() as any;
+const topAgain = new Top() as any;
+console.log("sibling comp instanceof base:", compAgain instanceof Base);
+console.log("sibling top instanceof mid:", topAgain instanceof Mid);
+console.log("sibling comp value:", compAgain.value);
+console.log("sibling top value:", topAgain.value);

--- a/test-files/test_gap_6356_dynamic_parent_mixin_chain.ts
+++ b/test-files/test_gap_6356_dynamic_parent_mixin_chain.ts
@@ -94,3 +94,21 @@ console.log("sibling comp instanceof base:", compAgain instanceof Base);
 console.log("sibling top instanceof mid:", topAgain instanceof Mid);
 console.log("sibling comp value:", compAgain.value);
 console.log("sibling top value:", topAgain.value);
+
+// --- (5) class DECLARATION extending a factory call with a runtime-value arg
+// `class Child extends Serializable(V)` rewrites the factory Call into a
+// `Sequence([RegisterClassParentDynamic, ClassRef(clone)])`. The decl-time
+// `RegisterClassParentDynamic { class_name: "Child", parent_expr: <that
+// Sequence> }` must still hoist the clone as `Child`'s static parent (the hoist
+// resolves through the Sequence's trailing `ClassRef`), so `Child` inherits the
+// base's field/method through the specialized clone.
+const V: any = Base;
+class Child extends Serializable(V) {
+  child() {
+    return "child";
+  }
+}
+console.log("decl field:", (new Child() as any).value);
+console.log("decl inherited method:", (new Child() as any).hello());
+console.log("decl own method:", new Child().child());
+console.log("decl instanceof base:", new Child() instanceof Base);


### PR DESCRIPTION
Fixes #6356.

## Symptom

A class whose parent is wired at runtime (a mixin/factory class that declines the HIR mixin fast path) loses the base's inheritance through a **two-level dynamic chain**:

```ts
class Base { value = "base value"; hello() { return "base hello"; } }
function Greetable(B: any)    { return class extends B { greet() { return "hi"; } }; }
function Serializable(B: any) { return class extends B { ser()   { return "ser"; } }; }

const Mid = Greetable(Base);
const Top = Serializable(Mid as any);

(new Top() as any).value       // node: "base value"   perry: undefined      ❌
(new Top() as any).greet()     // node: "hi"           perry: TypeError      ❌
new Top() instanceof Mid       // node: true           perry: false          ❌
```

On current `main` most of the #6356 matrix already passes (field-init through a single dynamic parent was fixed by later work); the residual failure is the two-level `Serializable(Mid)` chain, where `Top` inherits **nothing** from `Mid`.

## Root cause

These shapes route through `specialize_captured_class_factories` (`crates/perry-transform/src/inline/factory_specialize.rs`), which monomorphizes the returned class per call site. Two defects there broke the chain:

1. **Colliding class id.** `class.clone()` copied the template's `id`, and the pass renamed the clone but never reassigned it. Codegen keys the runtime class registry (methods, constructor, parent edges) by `c.id`, so a clone collided with its template **and** with sibling clones of the same template (`Serializable(Greetable(Base))` and `Serializable(Mid)` both clone `__anon_class_N`) — the distinct classes shared one registry slot, last-writer-wins on the constructor/parent edge.

2. **Dropped parent edge for a runtime-value parent.** When the parent arg specialized to a runtime value (`Serializable(Mid)`, where `Mid` is a local binding) rather than a static `ClassRef`, no static `extends_name` could be set, and the factory `Call` — including the `RegisterClassParentDynamic` its lowered `Sequence` carried — was replaced by a bare `ClassRef`, dropping the parent edge entirely.

Confirmed via `--trace llvm`: the clone registered under the template's id (`js_register_class_method`/`js_register_class_constructor` emitted twice for the same cid), and no parent edge (`js_register_class_parent[_dynamic]`) was emitted for it.

## Fix

- **Assign each specialized clone a fresh, unique class id** (past the current max). Codegen resolves static parent edges by *name* and derives its imported-class fallback id range from the post-specialization max, so only numeric uniqueness matters here. Later clones that reference this one as a static parent read the id assigned here (so it's assigned before pushing).
- **When the specialized parent is a runtime value, sequence a `RegisterClassParentDynamic` ahead of the `ClassRef`** so the parent edge is wired when the init runs — mirroring the class-expression lowering in `perry-hir`'s `arm_class.rs`. The `Sequence` still yields the `ClassRef` as its value.

## Validation

- New fixture `test-files/test_gap_6356_dynamic_parent_mixin_chain.ts` (return-via-const, composed mixins, the two-level `Serializable(Mid)` chain, and sibling-clone independence) is **byte-identical to `node --experimental-strip-types`**.
- After the fix, the clone gets a distinct cid with a `(Top → Mid)` dynamic edge, so `Top → Mid → Base` resolves: `instanceof Mid`, inherited `greet`, and the `value` field all match node.
- No regressions across the class/mixin/factory gap tests, incl. `test_gap_5952_mixin_factory_binding`, `test_gap_class_expr_*`, `test_gap_class_ref_new_dynamic`, `test_gap_class_extends_function_static`. The two pre-existing triaged failures in that neighbourhood (`test_gap_2159_defineproperty_class_prototype`, `test_gap_class_expr_extends_static_call_this`) produce **identical** output with and without this change (A/B'd against a stashed baseline).
- `cargo test -p perry-transform` green (48 tests); `cargo fmt --all --check` and the 2000-line file-size gate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved class mixin and factory behavior when the parent is resolved dynamically at runtime.
  * Preserved dynamic parent wiring so `extends` relationships and inherited fields/methods remain correct through multi-level chains.
  * Prevented ID collisions between specialized class variants created from the same template.
  * Updated module initialization so dynamic parent expressions are correctly hoisted and applied to child classes.
* **Tests**
  * Added a regression test covering dynamic parent chains, composed mixins, `instanceof` correctness, and runtime-value `extends` scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->