### PR TITLE
fix(runtime): defer void fs callback delivery to a later tick (#6401)

### DIFF
--- a/crates/perry-runtime/src/fs/callbacks.rs
+++ b/crates/perry-runtime/src/fs/callbacks.rs
@@ -131,10 +131,54 @@ fn catch_callback_throw(call: impl FnOnce() -> f64) -> Result<f64, f64> {
     }
 }
 
-pub(crate) fn call_cb0(callback: *const ClosureHeader) {
-    if !callback.is_null() {
-        crate::closure::js_closure_call1(callback, f64::from_bits(0x7FFC_0000_0000_0002));
+/// Trampoline body for a deferred single-arg fs completion callback. Invoked
+/// with no JS args from the microtask drain (`js_closure_call0`); the real
+/// callback and its single argument travel as tag-aware capture slots so the
+/// GC keeps them live — and rewrites their addresses — across any collection
+/// that lands between the enqueue and the drain. Slot 0 is the callback
+/// NaN-boxed as a POINTER value, slot 1 the argument (an error value or `null`).
+extern "C" fn deferred_fs_cb1_impl(closure: *const ClosureHeader) -> f64 {
+    const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+    let cb = extract_closure_ptr(crate::closure::js_closure_get_capture_f64(closure, 0));
+    let arg0 = crate::closure::js_closure_get_capture_f64(closure, 1);
+    if !cb.is_null() {
+        crate::closure::js_closure_call1(cb, arg0);
     }
+    f64::from_bits(TAG_UNDEFINED)
+}
+
+/// Deliver a void fs op's completion callback on a LATER tick instead of
+/// synchronously (#6401). Node's async `fs.*` functions dispatch to the libuv
+/// threadpool and never invoke the callback in the same turn they were called;
+/// firing it inline reorders execution — code that runs `main()` from an fs
+/// callback would then observe module-top-level `const`s that Node has already
+/// initialized as still-uninitialized. We still run the syscall eagerly (as
+/// before) and only defer the `(err)` / `(null)` delivery, mirroring the
+/// already-deferred `fs.opendir`/`Dir.read` path (`dir_schedule_read_callback`).
+fn defer_fs_cb1(callback: *const ClosureHeader, arg0: f64) {
+    if callback.is_null() {
+        return;
+    }
+    // Register the trampoline's arity (0 JS params) before it can first be
+    // dispatched, so `resolve_strategy` doesn't cache a stale strategy (#6475).
+    thread_local! {
+        static ARITY_REGISTERED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    }
+    ARITY_REGISTERED.with(|r| {
+        if !r.get() {
+            crate::closure::js_register_closure_arity(deferred_fs_cb1_impl as *const u8, 0);
+            r.set(true);
+        }
+    });
+    let cb_boxed = crate::value::js_nanbox_pointer(callback as i64);
+    let closure = crate::closure::js_closure_alloc(deferred_fs_cb1_impl as *const u8, 2);
+    crate::closure::js_closure_set_capture_f64(closure, 0, cb_boxed);
+    crate::closure::js_closure_set_capture_f64(closure, 1, arg0);
+    crate::builtins::js_queue_microtask(closure as i64);
+}
+
+pub(crate) fn call_cb0(callback: *const ClosureHeader) {
+    defer_fs_cb1(callback, f64::from_bits(0x7FFC_0000_0000_0002));
 }
 
 /// Invoke a 2-arg callback with (err, undefined). Used by read-style ops
@@ -149,9 +193,7 @@ pub(crate) unsafe fn call_cb_err2(callback: *const ClosureHeader, err_val: f64) 
 /// Invoke a 1-arg callback with (err). Used by void ops (mkdir/unlink/rm/…)
 /// when the pre-flight probe detected an io::Error.
 pub(crate) unsafe fn call_cb_err1(callback: *const ClosureHeader, err_val: f64) {
-    if !callback.is_null() {
-        crate::closure::js_closure_call1(callback, err_val);
-    }
+    defer_fs_cb1(callback, err_val);
 }
 
 /// `fs.writeFile(path, data, callback)` — sync write + immediate callback.


### PR DESCRIPTION
## Summary

Fixes #6401.

Perry's callback-form `fs.*` void ops (`ftruncate`/`futimes`/`fchown`/`fsync`/`fdatasync`/`fchmod`/`mkdir`/`unlink`/`rm`/`writeFile`/`appendFile`/`access`/`link`/`symlink`/`utimes`/`lutimes`) invoked their completion callback **synchronously**, in the same turn the op was called. Node's async `fs.*` functions dispatch to the libuv threadpool and **never** call the callback in the calling turn. This reorders execution relative to Node.

The issue #6401 exposed this via a promisified fd rejection: when `main()` is invoked from inside an `fs` callback (which, under Perry, fires synchronously during the `fs.fchown(...)` call), `main()` runs *before* the module-top-level `const ftruncateP = promisify(fs.ftruncate)` line has executed. Its first `await` then evaluates `ftruncateP(fd, 1)` while `ftruncateP` is still uninitialized, so the promise rejects with `TypeError: value is not a function` — whose `.code`/`.syscall` are naturally `undefined`. The *second* and *third* awaits run as microtasks after top-level completes and the consts are assigned, so they resolve correctly. That is why only the **first** promisified rejection looked broken.

The reporter's diagnosis (a lost `err.code`/`err.syscall` on a real `EBADF` error) was a red herring — the first rejection is not an fs error at all; it's a `TypeError` from calling an uninitialized `const`.

### Root cause, precisely

`js_closure_call0`/`call1` were invoked inline from the `js_fs_*_callback` entry points. With `main()` reached synchronously from the third callback:

```
CB fired: ftruncate closed cb (typeof ftruncateP=undefined)   ← callbacks fire synchronously
CB fired: futimes closed cb (typeof ftruncateP=undefined)
CB fired: fchown closed cb (typeof ftruncateP=undefined)
ftruncate closed promise: undefined undefined (msg=value is not a function)
TOP: about to assign promisified consts                       ← consts assigned AFTER main's 1st await
```

Node fires the callbacks in a later tick, after top-level (and the consts) are done.

## Fix

Defer the void fs op callback delivery to a microtask instead of firing it inline, mirroring the already-deferred `fs.opendir`/`Dir.read` path (`dir_schedule_read_callback`). The syscall still runs eagerly; only the `(err)` / `(null)` delivery is deferred. Implemented at the two shared helpers `call_cb0`/`call_cb_err1` (used by every void fs callback op), via a small trampoline that captures the callback (NaN-boxed as a POINTER value) and its single argument in tag-aware closure capture slots — so the GC keeps them live and rewrites their addresses across any collection between enqueue and drain (the `TASK_QUEUE` roots the queued trampoline).

Value-returning ops (`stat`/`read`/`readdir`/`fstat`) still deliver synchronously and are left unchanged here (their success path is a direct `js_closure_call2`); making them consistent is a natural follow-up.

## Validation

Compiled + run against `node --experimental-strip-types` (Node 26.3 local):

- The #6401 repro now matches Node byte-for-byte, deterministically (40/40 → all `EBADF <syscall>`).
- `test_gap_fs_fd_2749` (the shipped test) still passes.
- No regressions across fs + ordering-sensitive gap tests: `fs_errprop`/`fs_errprop2`/`fs_write_error_propagation`/`node_fs`/`zlib_fs`, `promise_tick_parity`/`promise_tick_parity2`/`promise_resolve_proxy_then_trap`, `timer_batch_order`, `unhandled_rejection_event`, stream tee/transform tick-parity, `async_advanced`, `asynchooks`, `readline`, `encoding_timers`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Filesystem operation callbacks are now delivered asynchronously, after the current task completes.
  - Void-style filesystem operations consistently defer both successful completion and error notifications.
  - Prevents callbacks from running synchronously in certain filesystem error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->