### PR TITLE
lint(gc): audit marker for the scalar concat-arg store in from_concat — main lint gate is red

### DIFF
--- a/crates/perry-runtime/src/array/from_concat.rs
+++ b/crates/perry-runtime/src/array/from_concat.rs
@@ -930,6 +930,9 @@ unsafe fn try_concat_all_dense(
             if arg.to_bits() >> 48 == 0x7FFF {
                 crate::string::js_string_addref_if_heap_string(arg);
             }
+            // GC_STORE_AUDIT(BARRIERED): scalar concat arg into the result;
+            // same single exact layout/barrier rebuild as the bulk copy above
+            // runs after all elements are in place.
             std::ptr::write(dst.add(off), arg);
             off += 1;
         }


### PR DESCRIPTION
## Problem

The `Array.concat` fast path added in #6529 writes each non-array scalar argument into the result with a raw `std::ptr::write`, but only the bulk `copy_array` closure above it carries a `GC_STORE_AUDIT` marker. The GC store-site inventory lint now fails on **main itself** and therefore on every open PR's merge commit:

```
GC store-site inventory failed; add nearby GC_STORE_AUDIT markers:
  crates/perry-runtime/src/array/from_concat.rs:933: raw slot write: std::ptr::write(dst.add(off), arg);
```

(main `Tests` run on 520894f27: lint = failure.)

## Fix

Marker only, no behavior change. Same classification as the sibling bulk copy: **BARRIERED** — nothing in pass 2 allocates or bails, and the single `rebuild_array_layout_exact(result)` after the loop performs the exact layout/barrier rebuild for every stored element, scalar and bulk alike.

`python3 scripts/gc_store_site_inventory.py` → `passed (1134 files scanned, 230 audited sites, 65 allowlisted)`.

Unblocks the lint gate for all open PRs (e.g. #6545, #6547).

https://claude.ai/code/session_01KD4GTmiwZjRrxShzQydJpF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarifying comments explaining how scalar values are handled during array concatenation and when layout updates occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->