### PR TITLE
fix: sloppy-mode write to a frozen object no-ops instead of throwing (#6542)

### DIFF
--- a/crates/perry-codegen/src/expr/proxy_reflect.rs
+++ b/crates/perry-codegen/src/expr/proxy_reflect.rs
@@ -177,10 +177,23 @@ fn put_value_static_property_fast_path(
     target: &Expr,
     key: &Expr,
     receiver: &Expr,
+    strict: bool,
 ) -> Option<String> {
     let Expr::String(property) = key else {
         return None;
     };
+    // #6542: this fast path lowers to `js_object_set_field_by_name`, which has
+    // no `strict` parameter and throws unconditionally when the field is
+    // non-writable (frozen/sealed object, `writable: false` descriptor). That
+    // matches spec `[[Set]]`+`PutValue` only in STRICT mode; a SLOPPY store to
+    // a non-writable property must be a silent no-op (`OrdinarySet` returns
+    // `false`, sloppy `PutValue` ignores it). So a heap object instance in
+    // sloppy code must stay on the strict-aware `js_put_value_set` path (which
+    // honors `strict = 0`). This gate only affects the class-instance arms
+    // below: a POD-layout / scalar-replaced object never escapes, so it can
+    // never have been passed to `Object.freeze` and can never be frozen —
+    // those keep the fast path in both modes (and diverting them to the
+    // pointer-taking `js_put_value_set` would break their fieldless storage).
     match (target, receiver) {
         (Expr::LocalGet(id), Expr::LocalGet(receiver_id)) if id == receiver_id => {
             let pod_field = ctx.pod_records.get(id).is_some_and(|local| {
@@ -197,6 +210,9 @@ fn put_value_static_property_fast_path(
             if pod_field || scalar_field {
                 return Some(property.clone());
             }
+            if !strict {
+                return None;
+            }
             receiver_class_name(ctx, target)
                 .and_then(|class_name| {
                     crate::type_analysis::class_field_global_index(ctx, &class_name, property)
@@ -212,6 +228,9 @@ fn put_value_static_property_fast_path(
             {
                 return Some(property.clone());
             }
+            if !strict {
+                return None;
+            }
             receiver_class_name(ctx, target)
                 .and_then(|class_name| {
                     crate::type_analysis::class_field_global_index(ctx, &class_name, property)
@@ -219,6 +238,9 @@ fn put_value_static_property_fast_path(
                 .map(|_| property.clone())
         }
         _ if same_side_effect_free_receiver(target, receiver) => {
+            if !strict {
+                return None;
+            }
             let class_name = receiver_class_name(ctx, target)?;
             crate::type_analysis::class_field_global_index(ctx, &class_name, property)
                 .map(|_| property.clone())
@@ -613,7 +635,8 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     );
                 }
             }
-            if let Some(property) = put_value_static_property_fast_path(ctx, target, key, receiver)
+            if let Some(property) =
+                put_value_static_property_fast_path(ctx, target, key, receiver, *strict)
             {
                 return super::property_set::lower(
                     ctx,

--- a/crates/perry-hir/src/lower/lower_module_fn.rs
+++ b/crates/perry-hir/src/lower/lower_module_fn.rs
@@ -15,18 +15,40 @@ use swc_ecma_ast as ast;
 use super::*;
 use crate::ir::*;
 
-fn module_has_strict_mode(ast_module: &ast::Module) -> bool {
+fn module_has_strict_mode(ast_module: &ast::Module, source_file_path: &str) -> bool {
+    // A file is strict-mode code exactly when Node runs it as an ES module. Three
+    // independent signals make it one (#6542); any is sufficient:
+    //
+    // 1. The module FORMAT — an ESM extension (`.mjs`/`.mts`) or an ESM package
+    //    context (`"type":"module"`). This holds even with NO in-file import/
+    //    export syntax: e.g. Perry's own test-suite `.ts` files carry no module
+    //    syntax yet run strict because the repo's `package.json` sets
+    //    `"type":"module"`, so `Object.freeze(o); o.x = 1` must throw there.
+    if perry_parser::file_is_es_module_by_format(source_file_path) {
+        return true;
+    }
+    // 2. An ES `import`/`export` ANYWHERE in the body makes the source a Module
+    //    (Source Text Module Record) even outside any package context — the
+    //    declaration need not precede other statements, so a trailing
+    //    `export {}` or a `const x = 1; export function f() {}` both count.
+    if ast_module
+        .body
+        .iter()
+        .any(|item| matches!(item, ast::ModuleItem::ModuleDecl(_)))
+    {
+        return true;
+    }
+    // 3. Otherwise this is CommonJS script text; it is strict only if the
+    //    directive prologue opens with a `"use strict"` directive.
     for item in &ast_module.body {
-        match item {
-            ast::ModuleItem::ModuleDecl(_) => return true,
-            ast::ModuleItem::Stmt(stmt) => {
-                let Some(directive) = string_directive_stmt_lit(stmt) else {
-                    break;
-                };
-                if is_raw_use_strict_directive(directive) {
-                    return true;
-                }
-            }
+        let ast::ModuleItem::Stmt(stmt) = item else {
+            break;
+        };
+        let Some(directive) = string_directive_stmt_lit(stmt) else {
+            break;
+        };
+        if is_raw_use_strict_directive(directive) {
+            return true;
         }
     }
     false
@@ -393,7 +415,7 @@ pub fn lower_module_full(
     ctx.resolved_types = resolved_types;
     ctx.is_entry_module = is_entry_module;
     ctx.is_external_module = is_external_module;
-    ctx.module_strict = module_has_strict_mode(ast_module);
+    ctx.module_strict = module_has_strict_mode(ast_module, source_file_path);
     ctx.current_strict = ctx.module_strict;
     if let Some(seed) = imported_class_fields {
         ctx.seed_imported_class_fields(seed);

--- a/crates/perry-parser/src/lib.rs
+++ b/crates/perry-parser/src/lib.rs
@@ -329,6 +329,31 @@ fn should_parse_as_script(filename: &str, source: &str) -> bool {
     !looks_like_es_module(source)
 }
 
+/// Whether `filename` is an ES module purely by its module FORMAT — i.e.
+/// independent of in-file `import`/`export` syntax or a `"use strict"`
+/// directive, which the caller weighs separately. An explicit ESM extension
+/// (`.mjs`/`.mts`) is always a module; a CommonJS extension (`.cjs`/`.cts`) is
+/// never a module by format (Node treats it as CommonJS even under
+/// `"type":"module"`); an ambiguous extension (`.js`/`.ts`/`.jsx`/`.tsx`) is a
+/// module when it sits in an ESM package context (`"type":"module"` /
+/// conditional-export map). Mirrors the format half of Node's CJS-vs-ESM
+/// detection and of `should_parse_as_script`'s package-context guard.
+///
+/// Module code is strict-mode code, so lowering consults this to decide the
+/// runtime strictness of a file that carries no in-file module syntax (#6542):
+/// a frozen-object write is a silent no-op in a sloppy CommonJS script but a
+/// TypeError in an ESM/strict module.
+pub fn file_is_es_module_by_format(filename: &str) -> bool {
+    let path = path_for_extension_check(filename);
+    if path.ends_with(".mjs") || path.ends_with(".mts") {
+        return true;
+    }
+    if path.ends_with(".cjs") || path.ends_with(".cts") {
+        return false;
+    }
+    file_is_in_esm_package_context(path)
+}
+
 fn looks_like_es_module(source: &str) -> bool {
     #[derive(Clone, Copy, PartialEq, Eq)]
     enum State {
@@ -899,6 +924,27 @@ mod tests {
         assert_eq!(path_for_extension_check("./mod.ts?inline"), "./mod.ts");
         assert_eq!(path_for_extension_check("mod.wasm#section"), "mod.wasm");
         assert_eq!(path_for_extension_check("/home/u/mod.ts"), "/home/u/mod.ts");
+    }
+
+    #[test]
+    fn file_is_es_module_by_format_honors_extension() {
+        // #6542: an explicit ESM extension is a module by format regardless of
+        // any package context, so its code is strict.
+        assert!(file_is_es_module_by_format("/no/such/pkg/mod.mjs"));
+        assert!(file_is_es_module_by_format("/no/such/pkg/mod.mts"));
+        assert!(file_is_es_module_by_format("./mod.mjs?v=2"));
+        // A CommonJS extension is never a module by format — Node treats `.cjs`/
+        // `.cts` as CommonJS even under `"type":"module"`, so an ancestor
+        // package context must not flip these to strict.
+        assert!(!file_is_es_module_by_format("/no/such/pkg/mod.cjs"));
+        assert!(!file_is_es_module_by_format("/no/such/pkg/mod.cts"));
+        // An ambiguous extension with no package.json anywhere up the tree is a
+        // CommonJS script (sloppy) — the format signal alone does not make it a
+        // module (in-file import/export or a "use strict" directive still can,
+        // but those are weighed by the caller, not here).
+        assert!(!file_is_es_module_by_format(
+            "/nonexistent-perry-6542-root/deep/mod.ts"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #6542.

## Summary

A write to a non-writable property (a frozen/sealed object, or a `writable: false` descriptor) must be a **silent no-op in sloppy mode** (`OrdinarySet` returns `false`; a sloppy `PutValue` ignores it) and throw a `TypeError` **only in strict mode**. Perry threw in both, so the issue's repro printed a `TypeError` where Node (running the file as a sloppy CommonJS script) prints `q=1`:

```ts
class D { q = 1; }
const d = new D();
Object.freeze(d);
d.q = 999;              // sloppy: should be a silent no-op
console.log("q=" + d.q); // node: q=1   perry (before): TypeError
```

## Root cause — two parts

**1. Codegen fast path dropped the `strict` flag.** For a class-instance field write, `put_value_static_property_fast_path` lowered `d.q = v` to `js_object_set_field_by_name`, which takes no `strict` parameter and throws unconditionally on a non-writable field — bypassing the strict-aware `js_put_value_set` the issue points at. The fast path is now gated on `strict`; a heap class instance in sloppy code stays on `js_put_value_set(strict=0)`, which correctly no-ops. The POD-layout / scalar-replaced arms keep the fast path in **both** modes — those objects never escape, so they can never have been passed to `Object.freeze` (and routing them through the pointer-taking `js_put_value_set` would break their fieldless storage).

**2. Strict-mode classification ignored the module format.** A file is strict-mode code exactly when Node runs it as an ES module, but `module_has_strict_mode` only looked at a *leading* in-file module declaration / `"use strict"` directive. It ignored:
- the module **format** — an `.mjs`/`.mts` extension or a `"type":"module"` package context, and
- `import`/`export` that appears **after** other statements.

So a `.ts` file with no in-file module syntax was classed *sloppy* even under `"type":"module"` — including Perry's own `test-files/` suite (the repo root `package.json` sets `"type":"module"`). Once part 1 removes the "throw anyway" compensation, that misclassification would wrongly no-op frozen writes in a strict module. The classifier now consults all three signals: module format (new `perry_parser::file_is_es_module_by_format`), any in-file `import`/`export`, then a leading `"use strict"`.

The net behavior change is confined to genuinely-sloppy (CommonJS-context) programs. Every ESM/strict module still throws, matching Node.

## Validation

- **Issue repro + variants** (run in a CommonJS context) match Node exactly: sloppy frozen write / computed-key frozen write / plain-object frozen / `defineProperty` non-writable all no-op; sealed (still writable) updates; a nested `"use strict"` frozen write throws; `export {}`/`use strict`/module variants throw; undeclared-assignment-in-module throws `ReferenceError`.
- **No gap-suite impact.** Every `test_gap_*.ts` is `.ts` under the repo's `"type":"module"`, i.e. strict — the branch my change touches (sloppy) never runs for them. A baseline-vs-fixed byte comparison of the frozen/non-writable gap tests is identical, including `test_gap_5654_class_field_inline_descriptor` (`ro-threw:true`, unchanged) and the one test whose strict classification flips via a different signal (identical output).
- Added a `perry-parser` unit test for `file_is_es_module_by_format` (extension handling).

No version bump / changelog entry (left for the maintainer per repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved strict-mode handling for ES modules and files using module-specific extensions.
  * Corrected property assignment behavior in strict and non-strict code.
  * More reliably recognizes module syntax and package context when determining execution mode.

* **Tests**
  * Added coverage for distinguishing ES module and CommonJS file extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->