### PR TITLE
fix(runtime): per-evaluation inherited static wins over last-wins registry props (#6552)

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -1033,33 +1033,58 @@ pub extern "C" fn js_object_get_field_by_name(
                     // chain walk so the #2059 own-name synthesis below answers
                     // with THIS class's registered name instead of an ancestor's.
                     if name != "name" {
-                        let mut cid = class_id;
+                        // Walk the class-object proto chain for an inherited static
+                        // DATA field. At EACH level the class's pinned
+                        // per-evaluation parent OBJECT is consulted BEFORE the
+                        // parent's registry props (`CLASS_DYNAMIC_PROPS`).
+                        //
+                        // #6552: a subclass of a class-EXPRESSION value evaluated
+                        // more than once (`function make(a){return class{static
+                        // ast=a}}`, then `class Number$ extends make(x) {}` /
+                        // `class Widget$ extends make(y) {}`) records THIS
+                        // evaluation's parent object as its static prototype
+                        // (`class_prototype_object`, #1788), but the parent's
+                        // `CLASS_DYNAMIC_PROPS` are keyed by the class-expression
+                        // TEMPLATE id — shared, last-wins across every evaluation.
+                        // Reading the registry entry for such a parent collapses
+                        // sibling subclasses to the LAST `make(...)` (effect Schema:
+                        // `Number$.ast`/`Widget$.ast` both read the last parent's
+                        // `ast`). The pinned object carries this evaluation's own
+                        // edge, so it is authoritative; the registry read remains
+                        // the fallback for a plain declaration parent (#6443:
+                        // Auth.js `SignInError.kind`), which has no pinned object.
+                        let mut child = class_id;
                         let mut depth = 0usize;
                         while depth < 32 {
-                            match get_parent_class_id(cid) {
-                                Some(p) if p != 0 && p != cid => {
-                                    cid = p;
-                                    depth += 1;
+                            let proto =
+                                super::super::class_registry::class_prototype_object(child);
+                            if !proto.is_null() {
+                                let v = js_object_get_field_by_name(proto as *const _, key);
+                                if !v.is_undefined() && !v.is_null() {
+                                    return v;
                                 }
+                            }
+                            let p = match get_parent_class_id(child) {
+                                Some(p) if p != 0 && p != child => p,
                                 _ => break,
+                            };
+                            // A key deleted on THIS ancestor is not provided by it,
+                            // but a higher ancestor may still define it — `delete
+                            // Mid.foo` must let `Sub.foo` inherit `Base.foo`, not
+                            // resolve to undefined. Skip the registry read for the
+                            // deleted level and keep walking up.
+                            if !super::super::class_registry::class_is_key_deleted(p, name) {
+                                let inherited = CLASS_DYNAMIC_PROPS.with(|m| {
+                                    m.borrow()
+                                        .get(&p)
+                                        .and_then(|props| props.get(name).copied())
+                                });
+                                if let Some(v) = inherited {
+                                    return JSValue::from_bits(v.to_bits());
+                                }
                             }
-                            if super::super::class_registry::class_is_key_deleted(cid, name) {
-                                // A key deleted on THIS ancestor is not provided by
-                                // it, but a higher ancestor may still define it —
-                                // `delete Mid.foo` must let `Sub.foo` inherit
-                                // `Base.foo`, not resolve to undefined. Skip this
-                                // level and keep walking up (safe: `cid`/`depth`
-                                // advance at the top of every iteration).
-                                continue;
-                            }
-                            let inherited = CLASS_DYNAMIC_PROPS.with(|m| {
-                                m.borrow()
-                                    .get(&cid)
-                                    .and_then(|props| props.get(name).copied())
-                            });
-                            if let Some(v) = inherited {
-                                return JSValue::from_bits(v.to_bits());
-                            }
+                            child = p;
+                            depth += 1;
                         }
                     }
                     if super::super::class_registry::lookup_static_method_in_chain(class_id, name)

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -1060,7 +1060,15 @@ pub extern "C" fn js_object_get_field_by_name(
                                 super::super::class_registry::class_prototype_object(child);
                             if !proto.is_null() {
                                 let v = js_object_get_field_by_name(proto as *const _, key);
-                                if !v.is_undefined() && !v.is_null() {
+                                // Return a value present on the pinned object even
+                                // when it is `null` — a static explicitly set to
+                                // `null` on THIS evaluation is authoritative and
+                                // must not fall through to the last-wins registry
+                                // entry (a sibling evaluation's value). Only
+                                // `undefined` means "absent here", which continues
+                                // the walk to the parent's registry props / a higher
+                                // ancestor.
+                                if !v.is_undefined() {
                                     return v;
                                 }
                             }

--- a/test-files/_helpers/renamed_class_export.ts
+++ b/test-files/_helpers/renamed_class_export.ts
@@ -12,8 +12,13 @@ export function make(a: any) {
 
 class Number$ extends make({ _tag: "NumberKeyword" }) {}
 class Widget$ extends make({ _tag: "WidgetKeyword" }) {}
+// A per-evaluation static explicitly set to `null` — its own value must win
+// over any sibling's (last-wins) registry `ast`. Declared before `DirectCls`
+// so the last `make(...)` to register is a NON-null value, making `null` a real
+// discriminator (regression guard for the #6552 fix's proto-vs-registry order).
+class NullAst$ extends make(null) {}
 export class DirectCls extends make({ _tag: "DirectKeyword" }) {}
 
 // Renamed exports. `Number` deliberately collides with the JS global
 // `Number` — pre-fix, `M.Number` resolved to the global constructor.
-export { Number$ as Number, Widget$ as Widget };
+export { Number$ as Number, Widget$ as Widget, NullAst$ as NullAst };

--- a/test-files/test_gap_renamed_class_export_namespace.ts
+++ b/test-files/test_gap_renamed_class_export_namespace.ts
@@ -29,3 +29,8 @@ console.log("(3) M.DirectCls.ast._tag:", (M as any).DirectCls.ast?._tag);
 
 // (4) the global `Number` is still itself (not shadowed by the import).
 console.log("(4) global Number(42):", Number("42"));
+
+// (5) a renamed export whose per-evaluation static is explicitly `null` reads
+// back `null` — it must not fall through to a sibling evaluation's (last-wins)
+// `ast`. Guards the proto-object-before-registry ordering of the #6552 fix.
+console.log("(5) M.NullAst.ast:", (M as any).NullAst.ast);


### PR DESCRIPTION
Fixes #6552.

## Symptom

`test_gap_renamed_class_export_namespace.ts` (the #1758/#1812 regression guard) fails on current main: every renamed class export read via `import * as M` resolves to the **same** inherited static — the direct export's `DirectKeyword` — instead of each alias's own origin class.

```
expected (node):                          got (perry, before):
(1) M.Number.ast._tag: NumberKeyword     (1) M.Number.ast._tag: DirectKeyword
(2) M.Widget.ast._tag: WidgetKeyword     (2) M.Widget.ast._tag: DirectKeyword
```

This re-breaks effect Schema decode (the #1785 shape: `S.Number = class Number$ extends make(numberKeyword) {}` re-exported as `Number`, then `decodeUnknownSync(S.Number)` reads `S.Number.ast`).

## Root cause

Not the namespace/alias resolution the test header points at — that still resolves `M.Number` to the correct `Number$` class-ref. The collapse is in the **inherited-static read**.

The three subclasses (`Number$`, `Widget$`, `DirectCls`) all `extend make(...)`, where `make` returns the **same** class-expression template `SchemaClass` — one shared compile-time class-id. Each `make()` call's `static ast` overwrites `CLASS_DYNAMIC_PROPS[template_id]["ast"]`, so the registry entry is **last-wins** (`DirectKeyword`).

`fb04be0f` — *"fix(runtime): inherit static data fields from a parent class (#6443)"* — added a parent-**class-id**-chain walk over `CLASS_DYNAMIC_PROPS` in `get_field_by_name.rs`, and placed it **before** the older #1788 per-evaluation prototype-object walk (`resolve_proto_chain_field`). For a subclass of a multiply-evaluated class expression, that registry read fires first and returns the last-wins value, preempting each subclass's pinned per-evaluation parent object.

(The issue guessed the #6537/#6529 window; the actual regressor is #6443, which lands in the #6504-era the issue verified as already-broken.)

## Fix

`crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs`: **interleave** the two walks. At each level of the class-object proto chain, consult the class's pinned per-evaluation parent object (`class_prototype_object`) **before** the parent's `CLASS_DYNAMIC_PROPS`. The pinned object carries *this* evaluation's own edge, so it is authoritative; the registry read stays the fallback for a plain declaration parent (#6443: Auth.js `SignInError.kind`), which has no pinned object. Depth order is preserved, so a closer registry static still shadows a deeper per-evaluation one.

The proto-object read is not new to this path — the #1788 arm right below already reads `class_prototype_object(class_id)` the same way; this only reorders it relative to the registry read, level by level.

## Testing

Byte-compared against `node --experimental-strip-types` (Node 26.5):

- `test_gap_renamed_class_export_namespace` — now identical (renamed global-colliding + non-colliding + direct exports).
- Class-expr/static regression sweep — **18/18 identical**, including `test_gap_static_field_inheritance` (#6443's own test, incl. `delete Mid.foo` fallthrough), `test_gap_class_expr_perf_eval_statics` (#6438), and `test_issue_effect_factory_static_dispatch`.
- Edge cases confirmed vs node: multi-level grandchild of a per-eval parent; a **closer** runtime/registry static correctly shadowing a **deeper** per-eval static (the case a naive reorder would miscompile); plain-declaration static inheritance.

Per contributor convention, no version bump / CHANGELOG entry — leaving the metadata for the maintainer to fold in at merge.

Out of scope: `test_gap_zlib_3285_params`, noted in the issue as a likely separate regression from the same window — not touched here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inherited static property resolution for dynamically evaluated classes to use the current per-evaluation prototype precedence before falling back to registered dynamic values.
  * Corrected repeated class-expression evaluation behavior, including handling of explicitly overridden or deleted static fields.
  * Ensured renamed class exports with `ast = null` return `null` reliably.
* **Tests**
  * Added regression coverage for renamed class exports where static `ast` is explicitly `null`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->