### PR TITLE
fix: complete DisposableStack `.disposed` getter and `instanceof SuppressedError` (#6364)

### DIFF
--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -63,6 +63,10 @@ pub(crate) fn builtin_parent_reserved_class_id(name: &str) -> Option<u32> {
         "AggregateError" => 0xFFFF0014,
         "EvalError" => 0xFFFF0015,
         "URIError" => 0xFFFF0016,
+        // #6364 — keep in sync with the `lower_instanceof` match above and
+        // `CLASS_ID_SUPPRESSED_ERROR` so `class X extends SuppressedError {}`
+        // walks the parent edge and `new X() instanceof SuppressedError` holds.
+        "SuppressedError" => 0xFFFF003E,
         "Date" => 0xFFFF0020,
         "RegExp" => 0xFFFF0021,
         "Map" => 0xFFFF0022,
@@ -377,6 +381,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 "AggregateError" => 0xFFFF0014u32,
                 "EvalError" | "globalThis.EvalError" => 0xFFFF0015u32,
                 "URIError" | "globalThis.URIError" => 0xFFFF0016u32,
+                // #6364 — SuppressedError (TC39 explicit-resource-management).
+                // Must match `CLASS_ID_SUPPRESSED_ERROR` in
+                // perry-runtime/src/disposable.rs. The instance is a
+                // GC_TYPE_OBJECT carrying this class id, so the runtime
+                // class-id chain fast-path matches it (see instanceof.rs).
+                "SuppressedError" => 0xFFFF003Eu32,
                 // Uint8Array / Buffer — runtime detects these via a
                 // thread-local buffer registry (see buffer.rs). The
                 // TextEncoder path registers its ArrayHeader result

--- a/crates/perry-hir/src/lower/expr_member/native_dispatch.rs
+++ b/crates/perry-hir/src/lower/expr_member/native_dispatch.rs
@@ -127,6 +127,15 @@ pub(crate) fn is_native_dispatch_member(module: &str, class: &str, prop: &str) -
         // user own-property surface in the bundle walls, so keep dispatching
         // for any member to preserve existing behaviour.
         "events" | "net" => true,
+        // #6364 — DisposableStack / AsyncDisposableStack: `disposed` is the
+        // only native data getter (its value comes from the FFI helper
+        // `js_disposable_stack_disposed`), so a bare read must dispatch as a
+        // 0-arg `NativeMethodCall` through the `__disposable__` NativeModSig
+        // row. Every other member (`use`/`adopt`/`defer`/`dispose`/
+        // `disposeAsync`/`move`) is a method: a method CALL arrives via the
+        // call-expression path, and a bare method-VALUE read must stay a plain
+        // PropertyGet (a bound-method read), never a 0-arg invoking dispatch.
+        "__disposable__" => prop == "disposed",
         // Other native modules historically routed every uncovered member to
         // the dispatching fallback. They have no observed user-own-property
         // surface, so preserve that: dispatch any member not handled by the

--- a/crates/perry-runtime/src/disposable.rs
+++ b/crates/perry-runtime/src/disposable.rs
@@ -129,7 +129,14 @@ pub const CLASS_ID_DISPOSABLE_STACK: u32 = 0xFFFF_003C;
 pub const CLASS_ID_ASYNC_DISPOSABLE_STACK: u32 = 0xFFFF_003D;
 /// Reserved class id for a `SuppressedError` instance. Registered as an
 /// Error subclass at first construction so `instanceof Error` holds.
-pub const CLASS_ID_SUPPRESSED_ERROR: u32 = 0xFFFF_003B;
+///
+/// #6364 — must stay OUT of the typed-array reserved range
+/// (`0xFFFF0030..=0xFFFF003B`, Int8Array..Float16Array). This previously read
+/// `0xFFFF_003B`, colliding with `CLASS_ID_FLOAT16_ARRAY`, which made
+/// `err instanceof Float16Array` (and the reverse) true once `SuppressedError`
+/// was wired into the codegen `instanceof` table. `0xFFFF_003E` is the first
+/// free id after the DisposableStack/AsyncDisposableStack block below.
+pub const CLASS_ID_SUPPRESSED_ERROR: u32 = 0xFFFF_003E;
 
 const FIELD_DISPOSERS: u32 = 0;
 const FIELD_DISPOSED: u32 = 1;


### PR DESCRIPTION
## Summary

Closes #6364. `test_gap_disposablestack_2875.ts` was an untriaged gap-suite failure with **two** distinct defects. The issue flagged `.disposed`; running the test against the pinned Node 26 oracle surfaced a second one, `instanceof SuppressedError`. Both were structurally invisible to CI because `DisposableStack` / `SuppressedError` are Node 24+ and were dropped by the old node-22 pin (`node_fail`).

## Changes

**`stack.disposed` returned `undefined`** — `crates/perry-hir/src/lower/expr_member/native_dispatch.rs`
- A bare native-instance member read on a `__disposable__`-tagged instance had no arm in `is_native_dispatch_member`, so it fell through to a plain `PropertyGet` and never reached the existing `js_disposable_stack_disposed` FFI getter.
- Added a `"__disposable__" => prop == "disposed"` arm so `disposed` dispatches as a 0-arg `NativeMethodCall` (the runtime helper and the codegen `NativeModSig` row already existed). Every other member (`use`/`adopt`/`defer`/`dispose`/`disposeAsync`/`move`) stays a bound-method `PropertyGet` read.

**`err instanceof SuppressedError` returned `false`** (while `instanceof Error` was `true`) — `crates/perry-runtime/src/disposable.rs`, `crates/perry-codegen/src/expr/instance_misc1.rs`
- **Class-id collision:** `CLASS_ID_SUPPRESSED_ERROR` was `0xFFFF_003B`, the same reserved id as `CLASS_ID_FLOAT16_ARRAY`. Moved it to the free `0xFFFF_003E`, out of the `0xFFFF0030..=0xFFFF003B` typed-array reserved range.
- **Missing codegen registration:** `SuppressedError` was absent from the codegen name→class-id tables, so the static-RHS `instanceof` lowered to id `0` and `js_instanceof(v, 0)` short-circuits to `false`. Registered it in both the `lower_instanceof` match and `builtin_parent_reserved_class_id`, kept in sync with the runtime constant.

## Related issue

Closes #6364.

## Test plan

Built the compiler (`cargo build --profile perry-dev -p perry`) and let `perry compile` rebuild the release runtime static libs (confirmed `libperry_runtime.a` mtime moved *past* the source edit — not a stale-archive false pass). Then compared output to `node --experimental-strip-types` (Node 26):

- `test-files/test_gap_disposablestack_2875.ts` — now **byte-for-byte identical** to node (all 14 lines, incl. `.disposed` → `false`/`true` and `instanceof SuppressedError` → `true`). Was `undefined`/`undefined`/`false` on `main`.
- `test-files/test_gap_float16array_2902.ts` — **identical** (guards the class-id move: `Float16Array instanceof` still works; `0x003B` stays Float16Array's).
- `test-files/test_issue_154_using_dispose.ts` — **identical** (`using` / `Symbol.dispose` end-to-end).

Notes: the class-id move also closes a latent `err instanceof Float16Array` false-positive. `DisposableStack`/`AsyncDisposableStack` `instanceof` (ids `003C`/`003D`) remain unregistered in the codegen table — not exercised by this test, left as a follow-up rather than adding untested paths here.

- [ ] `cargo build --release` clean — *not run to completion locally; compiler (`perry-dev`) + release runtime static libs built clean, full-workspace release build left to CI.*
- [ ] `cargo test --workspace ...` — *left to CI (`cargo-test`).*
- [x] Coverage: the existing gap test `test-files/test_gap_disposablestack_2875.ts` was failing untriaged and now passes byte-for-byte; it is the acceptance test for this fix.
- [ ] No CLI/stdlib/runtime-API surface changed → no `docs/src/` update needed.
- [ ] No platform UI backend touched.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention
- [x] Changes are scoped to the reported regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)
