### PR TITLE
perf(runtime): learned per-class inline field sizing for dynamic constructors

### DIFF
--- a/crates/perry-runtime/src/object/class_registry/construct.rs
+++ b/crates/perry-runtime/src/object/class_registry/construct.rs
@@ -867,7 +867,10 @@ pub unsafe extern "C" fn js_new_function_construct(
             crate::value::JSValue::from_bits(func_value.to_bits()).as_pointer::<ObjectHeader>();
         let class_cid = js_object_get_class_id(obj);
         if class_cid != 0 {
-            let inst = js_object_alloc(class_cid, 0);
+            let inst = js_object_alloc(
+                class_cid,
+                crate::object::learned_inline_field_count(class_cid),
+            );
             // Replay the class's registered constructor (instance-field
             // initializers + body) on the fresh instance, filling the
             // capture params from the snapshotted `__perry_ctor_caps`. The
@@ -913,7 +916,9 @@ pub unsafe extern "C" fn js_new_function_construct(
     // constructor body fills `this.<field>` writes through
     // PropertySet, and prototype-method dispatch consults the
     // synthetic class id's entry in CLASS_PROTOTYPE_METHODS.
-    let obj_ptr = js_object_alloc(cid, 0);
+    // Learned inline sizing: a class that overflowed once pre-sizes every
+    // later instance so all its fields land inline (object/mod.rs).
+    let obj_ptr = js_object_alloc(cid, crate::object::learned_inline_field_count(cid));
     let nan_boxed = crate::value::js_nanbox_pointer(obj_ptr as i64);
     // A user-assigned `foo.prototype = <obj/array>` lives as the closure's
     // "prototype" dynamic prop; the instance's [[Prototype]] must be THAT
@@ -1308,7 +1313,10 @@ unsafe fn construct_registered_class_ref(
     let inst = if let Some((keys_array, field_count)) = registered_class_keys_array(instance_cid) {
         js_object_alloc_class_inline_keys(instance_cid, 0, field_count, keys_array)
     } else {
-        js_object_alloc(instance_cid, 0)
+        js_object_alloc(
+            instance_cid,
+            crate::object::learned_inline_field_count(instance_cid),
+        )
     };
     // #2768: a registered-class constructor reached through this path — static
     // `new ClassName()`, a first-class ClassRef `new`, or `Reflect.construct`
@@ -1549,7 +1557,9 @@ pub unsafe extern "C" fn js_new_function_construct_with_new_target(
     // the synthetic per-function id applies. (The real `[[Prototype]]` link is
     // still set below from `newTarget.prototype`.)
     let cid = new_target_class_id(nt).unwrap_or_else(|| synthetic_class_id_for_function(nt));
-    let obj_ptr = js_object_alloc(cid, 0);
+    // Learned inline sizing: a class that overflowed once pre-sizes every
+    // later instance so all its fields land inline (object/mod.rs).
+    let obj_ptr = js_object_alloc(cid, crate::object::learned_inline_field_count(cid));
     let nan_boxed = crate::value::js_nanbox_pointer(obj_ptr as i64);
     if let Some(proto_bits) = constructor_prototype_bits(nt) {
         super::super::prototype_chain::object_set_static_prototype(obj_ptr as usize, proto_bits);

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -411,10 +411,77 @@ fn overflow_get(obj_ptr: usize, field_index: usize) -> Option<u64> {
 /// never read).
 ///
 /// Fast path skips the outer HashMap when `obj_ptr` matches the last-
+/// Learned per-class inline sizing: the dynamic-construct path allocates 8
+/// inline slots (it cannot see the constructor body), so a 23-field
+/// ES5-pattern object keeps 15 fields in [`OVERFLOW_FIELDS`] — a `Vec<u64>`
+/// plus map entry per object (~250B, more than the object payload), visited,
+/// rekeyed and finalized by every GC cycle. The FIRST instance that
+/// overflows records its class's high-water field index here; every LATER
+/// `new` of the same (synthetic or registered) class right-sizes its
+/// allocation so all fields land inline. Capped so a pathological dynamic
+/// writer can't inflate every future instance.
+const LEARNED_INLINE_MAX_FIELDS: u32 = 64;
+const LEARNED_INLINE_TABLE_SIZE: usize = 1024;
+
+thread_local! {
+    static LEARNED_INLINE_FIELDS: std::cell::UnsafeCell<[(u32, u32); LEARNED_INLINE_TABLE_SIZE]> =
+        const { std::cell::UnsafeCell::new([(0u32, 0u32); LEARNED_INLINE_TABLE_SIZE]) };
+}
+
+#[inline]
+fn note_learned_inline_fields(class_id: u32, needed_fields: u32) {
+    if class_id == 0 || needed_fields > LEARNED_INLINE_MAX_FIELDS {
+        return;
+    }
+    let slot = (class_id as usize).wrapping_mul(0x9E37_79B1) % LEARNED_INLINE_TABLE_SIZE;
+    LEARNED_INLINE_FIELDS.with(|t| unsafe {
+        let e = &mut (*t.get())[slot];
+        if e.0 != class_id {
+            *e = (class_id, needed_fields);
+        } else if e.1 < needed_fields {
+            e.1 = needed_fields;
+        }
+    });
+}
+
+/// Inline field count to pre-size a dynamic construct of `class_id` with —
+/// the learned high-water mark, or 0 when nothing was learned (caller keeps
+/// its default).
+#[inline]
+pub(crate) fn learned_inline_field_count(class_id: u32) -> u32 {
+    // Bisection kill-switch: PERRY_LEARNED_INLINE=0 disables consumption.
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    if !*ON.get_or_init(|| {
+        !matches!(
+            std::env::var("PERRY_LEARNED_INLINE").as_deref(),
+            Ok("0") | Ok("off") | Ok("false")
+        )
+    }) {
+        return 0;
+    }
+    if class_id == 0 {
+        return 0;
+    }
+    let slot = (class_id as usize).wrapping_mul(0x9E37_79B1) % LEARNED_INLINE_TABLE_SIZE;
+    LEARNED_INLINE_FIELDS.with(|t| unsafe {
+        let e = (*t.get())[slot];
+        if e.0 == class_id {
+            e.1
+        } else {
+            0
+        }
+    })
+}
+
 /// accessed Vec — the common row-build pattern where an object's
 /// overflow slots fill in sequence.
 #[inline]
 fn overflow_set(obj_ptr: usize, field_index: usize, vbits: u64) {
+    // Learn the class's true width so FUTURE instances allocate it inline.
+    unsafe {
+        let hdr = obj_ptr as *const ObjectHeader;
+        note_learned_inline_fields((*hdr).class_id, (field_index as u32).saturating_add(1));
+    }
     let cached_slot = OVERFLOW_LAST.with(|c| unsafe {
         let (cached_obj, cached_vec) = *c.get();
         if cached_obj == obj_ptr && !cached_vec.is_null() {

--- a/test-files/test_gap_learned_inline_sizing.ts
+++ b/test-files/test_gap_learned_inline_sizing.ts
@@ -1,0 +1,29 @@
+// Learned per-class inline sizing: the first instance of a dynamic/function
+// constructor that overflows records its field high-water mark; later `new`
+// pre-sizes so all fields land inline. This must be behavior-transparent —
+// construction, field reads/writes, Object.keys, and JSON.stringify of a wide
+// (>=12-field, so field_count clears internal shape gates) instance must match
+// node exactly, across many instances (instance 1 overflows, 2+ are pre-sized).
+function Wide(this: any, seed: number) {
+  this.a = seed; this.b = 1; this.c = 2; this.d = 3; this.e = 4; this.f = 5;
+  this.g = 6; this.h = 7; this.i = 8; this.j = 9; this.k = 10; this.l = 11;
+  this.m = 12; this.n = 13; this.o = 14; this.p = 15; this.q = 16; this.r = 17;
+  this.child = null;
+}
+const out: string[] = [];
+const kept: any[] = [];
+for (let i = 0; i < 5000; i++) {
+  const w: any = new (Wide as any)(i);
+  w.child = { x: i, url: "https://example.com/" + i + "?q=1" };
+  w.r = w.r + i;                         // overflow-field overwrite
+  if (i % 1000 === 0) kept.push(w);
+}
+const w0 = kept[0];
+out.push("keys=" + Object.keys(w0).length);
+out.push("a=" + w0.a + " r=" + w0.r + " child.x=" + w0.child.x);
+out.push("json=" + JSON.stringify(w0));
+out.push("jsonArr=" + JSON.stringify(kept.map((k) => ({ a: k.a, r: k.r }))));
+let sum = 0;
+for (const k of kept) sum += k.a + k.b + k.r + k.child.x;
+out.push("sum=" + sum);
+console.log(out.join("\n"));


### PR DESCRIPTION
## Problem

A dynamically-constructed object — a plain **function constructor** (`function F(){ this.a=…; … }; new F()`), or any class the codegen can't size at compile time — is allocated with only **8 inline field slots**. A wide instance (e.g. a 23-field React `FiberNode`) keeps its extra 15 fields in the `OVERFLOW_FIELDS` thread-local side map: a `Vec` + hash entry per object (larger than the object payload), visited and re-keyed by every GC cycle, and read through a by-name hash lookup on every hot field access. This is the dominant cost for constructor-heavy / transpiled / library code (idiomatic ES6-`class` TS is already compile-time sized and mostly avoids it).

## Fix

Learn each class's true width and pre-size later instances. The first instance that overflows records its field high-water mark into a direct-mapped per-class table (`note_learned_inline_fields`, called from `overflow_set`, keyed by the owner's `class_id`, capped at 64 fields). Every subsequent `new` of that class allocates that many inline slots (`learned_inline_field_count`, consumed at the two dynamic `js_object_alloc` sites in `construct.rs`) — so all fields land inline: no side-table `Vec`, no hash churn, and reads/writes hit the inline fast path instead of the overflow by-name lookup. `field_count` stays per-instance in the header, so the change is layout- and GC-transparent. A pathological dynamic writer can't inflate future instances past the cap. `PERRY_LEARNED_INLINE=0` disables it.

## Numbers

Fiber micro-benchmark (200k 23-field instances; node 26.3 ≈ same loops at ~25–30ms each):

| loop | before | after |
|---|---|---|
| overflow-field access | 26.3 s | **4.0 s** |
| alternate-link | 2.8 s | **0.27 s** |
| inline-field access | 11.7 s | **2.0 s** |

## Verification

- perry-runtime suite **1330 / 0** single-threaded.
- Compiled-TUI bundle end-to-end: **4/4** launches healthy (reaches interactive prompt, echoes typed input).
- `plan_cache_semantics` / `lane_sem2` / `test_gap_put_value_plan_cache` differentials byte-identical to node.
- New `test-files/test_gap_learned_inline_sizing.ts` (wide-instance construct + overflow-field overwrite + `Object.keys` + `JSON.stringify` across many instances, so `field_count` clears internal shape gates) byte-identical to node.

Independent of the GC-reclaim work; `PERRY_LEARNED_INLINE` kill-switch included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved allocation for dynamically created objects by learning and using per-class inline field requirements during `new`/`Reflect.construct`.
  * Better sizing reduces unnecessary zero-inline allocations and helps limit overflow-related field writes for common “wide” object shapes.

* **Tests**
  * Added a new test covering wide object construction, forced overflow-style updates, and validation of property enumeration and JSON serialization across retained instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->