### PR TITLE
test(packages): run effect-basic smoke by default (#5890)

### DIFF
--- a/tests/release/packages/effect-basic/fixture.sh
+++ b/tests/release/packages/effect-basic/fixture.sh
@@ -9,9 +9,12 @@ if [[ "${1:-}" == "--__did-skip-marker" ]]; then
     exit 1
 fi
 
-if [[ "${PERRY_EFFECT_BASIC_ADVISORY:-0}" != "1" ]]; then
-    fixture_skip "$NAME" "advisory #802 signal; set PERRY_EFFECT_BASIC_ADVISORY=1 to compile/run"
-fi
+# #5890: this fixture now compiles and runs clean on `main`, so it runs by
+# default like the other tier-3 package smokes (drizzle-mysql, ink-link)
+# instead of skipping behind an opt-in flag. The CI job stays advisory
+# (`continue-on-error: true`) per the tier-3 convention. The historical
+# `PERRY_EFFECT_BASIC_ADVISORY=1` gate (added in #4391 when Effect reliably
+# failed) is gone; the env var is now a harmless no-op.
 
 fixture_setup "$NAME" || exit 1
 fixture_compile_run_diff "$NAME"


### PR DESCRIPTION
## Summary

`#5890` reported the `effect-basic` tier-3 smoke failing at runtime with
`TypeError: undefined is not iterable` (empty stdout), based on CI runs from
**2026-07-03**.

Rebuilding the compiler from current `main` (`a7dd328ff`, v0.5.1263) and running
the fixture shows it now **compiles and runs clean** — the bug was fixed by an
intervening commit in the ~600 patch versions since. Because the fixture is
gated behind an opt-in `PERRY_EFFECT_BASIC_ADVISORY` skip (it reliably failed
when added in #4391), nobody noticed it recovered.

This PR removes that opt-in skip gate so the fixture **runs by default** — like
the other tier-3 package smokes (`drizzle-mysql`, `ink-link`) — turning a silent
skip into a live regression guard for the Effect compile/run path (#802 / #321).

## Change

- `tests/release/packages/effect-basic/fixture.sh`: drop the
  `PERRY_EFFECT_BASIC_ADVISORY` skip gate.

Deliberately **not** changed:
- The `effect-basic-smoke` CI job stays advisory (`continue-on-error: true`),
  matching the intentional tier-3 convention shared by `drizzle-mysql`,
  `ink-link`, and `compile-smoke` — a flake here must never block the release
  gate.
- The `PERRY_EFFECT_BASIC_ADVISORY=1` the CI job exports is left in place as a
  harmless no-op (minimal diff; can be dropped separately if desired).
- The `--__did-skip-marker` fast-exit is kept so the harness's skip probe
  doesn't trigger a second (expensive) Effect compile.

## Verification

Fresh compiler built from `origin/main`; Effect 3.21.2 compiled natively via
`compilePackages`. Against the Node 26.5.0 oracle:

- `entry.ts` output matches `expected.txt` **byte-for-byte**:
  ```
  runPromise=effect:42
  runSync=sync:ok
  ```
- Deterministic across 5 runs.
- `bash fixture.sh` (no env var) → `PASS effect-basic`, exit 0.
- CI-style invocation (`PERRY_EFFECT_BASIC_ADVISORY=1 … bash fixture.sh`) → `PASS`, exit 0.
- `bash fixture.sh --__did-skip-marker` → exit 1 (probe stays cheap, no compile).
- No `.last-skip` sentinel written (fixture no longer reports SKIP).

## Notes

- No version bump / CHANGELOG entry included — per the "External contributor
  PRs" convention in CLAUDE.md, the maintainer folds those in at merge time to
  avoid patch-version collisions.
- Closes #5890.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled the effect-basic package smoke test to run by default.
  * Clarified that the test executes successfully while the associated CI job remains advisory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->