### PR TITLE
style: rustfmt get_field_by_name.rs to unbreak the lint gate

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -1056,8 +1056,7 @@ pub extern "C" fn js_object_get_field_by_name(
                         let mut child = class_id;
                         let mut depth = 0usize;
                         while depth < 32 {
-                            let proto =
-                                super::super::class_registry::class_prototype_object(child);
+                            let proto = super::super::class_registry::class_prototype_object(child);
                             if !proto.is_null() {
                                 let v = js_object_get_field_by_name(proto as *const _, key);
                                 // Return a value present on the pinned object even


### PR DESCRIPTION
## Summary

The required `lint` job (`cargo fmt --all -- --check`) is red on **main** and on the merge ref of **every open PR**. Root cause: #6552 (a7dd328ff) landed `js_object_get_field_by_name` with a wrapped `let proto = ...` at `get_field_by_name.rs:1056` that `cargo fmt` collapses onto one line.

This is the **only** fmt violation on `origin/main` (`cargo fmt --all -- --check` reports exactly this one hunk). Pure formatting change — no behavior.

## Changes

- `crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs` — rustfmt the `let proto = super::super::class_registry::class_prototype_object(child);` line.

## Related issue

Refs #6552 (the PR that introduced the unformatted line). Unblocks lint on all open PRs (e.g. #6567, #6568).

## Test plan

- `cargo fmt --all -- --check` → clean after this change (was: `Diff in .../get_field_by_name.rs:1056`).

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] Formatting-only, no logic change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Cleaned up internal field lookup handling without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->