### PR TITLE
perf(runtime): fast non-crypto hasher for property-descriptor side tables

### DIFF
--- a/crates/perry-runtime/src/fast_hash.rs
+++ b/crates/perry-runtime/src/fast_hash.rs
@@ -99,6 +99,66 @@ pub fn new_ptr_hash_map<K: std::hash::Hash + Eq, V>() -> PtrHashMap<K, V> {
     HashMap::with_hasher(PtrHasher)
 }
 
+/// FNV-1a constants (64-bit): offset basis and prime (standard values).
+const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+/// Fast, non-cryptographic hasher for composite keys that mix a `usize` and a
+/// byte string — specifically the property/accessor descriptor side tables'
+/// `(usize, String)` key. [`PtrHasher`] is tuned for a *bare* `usize` pointer
+/// key (a single multiply, no per-byte work) and its generic byte `write` is
+/// only a weak fallback, so it is the wrong tool for a key whose second half is
+/// a program-supplied property name. This hasher folds every byte of the key
+/// with FNV-1a — one xor plus one multiply per byte — which is far cheaper than
+/// SipHash and needs no keyed (random-seed) initialization.
+///
+/// DoS-resistance is unnecessary for the same reason it is for [`PtrHasher`]:
+/// no external / attacker-controlled input ever reaches these keys (the first
+/// half is a runtime heap address, the second a property name baked into the
+/// compiled program), so hash-flooding is not a concern.
+#[derive(Default, Clone, Copy)]
+pub struct FastKeyHasher;
+
+impl BuildHasher for FastKeyHasher {
+    type Hasher = FastKeyHasherImpl;
+    #[inline]
+    fn build_hasher(&self) -> FastKeyHasherImpl {
+        FastKeyHasherImpl(FNV_OFFSET_BASIS)
+    }
+}
+
+pub struct FastKeyHasherImpl(u64);
+
+impl Hasher for FastKeyHasherImpl {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+    /// FNV-1a byte fold. A `(usize, String)` key hashes its `usize` half via the
+    /// default `write_usize` (which forwards to `write(&n.to_ne_bytes())`) and
+    /// its `String` half via `str`'s `Hash` (`write(bytes)` + a `write_u8(0xff)`
+    /// terminator, both routed here), so this one method covers every byte of
+    /// the composite key deterministically.
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        let mut h = self.0;
+        for &b in bytes {
+            h ^= b as u64;
+            h = h.wrapping_mul(FNV_PRIME);
+        }
+        self.0 = h;
+    }
+}
+
+/// `HashMap` keyed by a byte-hashable composite key (e.g. `(usize, String)`)
+/// using the non-cryptographic [`FastKeyHasher`] instead of SipHash.
+pub type FastKeyHashMap<K, V> = HashMap<K, V, FastKeyHasher>;
+
+#[inline]
+pub fn new_fast_key_hash_map<K: std::hash::Hash + Eq, V>() -> FastKeyHashMap<K, V> {
+    HashMap::with_hasher(FastKeyHasher)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -139,5 +199,30 @@ mod tests {
             assert!(s.contains(&(base + i * 8)));
         }
         assert!(!s.contains(&(base + 1000 * 8)));
+    }
+
+    /// The descriptor side tables key on `(usize, String)`. Verify the FNV-1a
+    /// composite-key hasher round-trips: distinct owner addresses and distinct
+    /// key strings must not alias, and lookups by borrowed `&str`/`&(…)` keys
+    /// must find the same slot the owned key inserted.
+    #[test]
+    fn fast_key_map_composite_round_trip() {
+        let mut m = new_fast_key_hash_map::<(usize, String), u8>();
+        let base = 0x100_0000_0000usize;
+        for i in 0..500 {
+            m.insert((base + i * 8, format!("key{i}")), i as u8);
+            // Same address, different key must be a distinct slot.
+            m.insert((base + i * 8, "length".to_string()), 0x07);
+        }
+        for i in 0..500 {
+            assert_eq!(m.get(&(base + i * 8, format!("key{i}"))), Some(&(i as u8)));
+            assert_eq!(m.get(&(base + i * 8, "length".to_string())), Some(&0x07));
+            // Distinct address, same key name must miss.
+            assert_eq!(m.get(&(base + i * 8 + 4, format!("key{i}"))), None);
+        }
+        assert_eq!(m.len(), 500 + 500);
+        m.remove(&(base, "key0".to_string()));
+        assert_eq!(m.get(&(base, "key0".to_string())), None);
+        assert_eq!(m.get(&(base, "length".to_string())), Some(&0x07));
     }
 }

--- a/crates/perry-runtime/src/object/descriptor_state.rs
+++ b/crates/perry-runtime/src/object/descriptor_state.rs
@@ -4,6 +4,7 @@
 use super::*;
 
 use crate::arena::arena_alloc_gc;
+use crate::fast_hash::{new_fast_key_hash_map, FastKeyHashMap};
 use crate::ArrayHeader;
 use crate::JSValue;
 use std::cell::{Cell, RefCell, UnsafeCell};
@@ -52,7 +53,11 @@ impl PropertyAttrs {
 }
 
 thread_local! {
-    pub(crate) static PROPERTY_DESCRIPTORS: RefCell<HashMap<(usize, String), PropertyAttrs>> = RefCell::new(HashMap::new());
+    // Hasher: `FastKeyHasher` (FNV-1a) rather than std's SipHash `RandomState`.
+    // The key is `(owner_addr, key_string)` — a runtime heap pointer plus a
+    // program-supplied property name, so no external input reaches it and
+    // DoS-resistant hashing buys nothing on this hot property-access path.
+    pub(crate) static PROPERTY_DESCRIPTORS: RefCell<FastKeyHashMap<(usize, String), PropertyAttrs>> = RefCell::new(new_fast_key_hash_map());
 }
 
 /// Accessor descriptor storage: maps (obj_ptr, key) -> (get_closure_bits, set_closure_bits).
@@ -67,7 +72,9 @@ pub(crate) struct AccessorDescriptor {
 }
 
 thread_local! {
-    pub(crate) static ACCESSOR_DESCRIPTORS: RefCell<HashMap<(usize, String), AccessorDescriptor>> = RefCell::new(HashMap::new());
+    // Hasher: `FastKeyHasher` (FNV-1a); see `PROPERTY_DESCRIPTORS` above for the
+    // same-shape `(owner_addr, key_string)` key and rationale.
+    pub(crate) static ACCESSOR_DESCRIPTORS: RefCell<FastKeyHashMap<(usize, String), AccessorDescriptor>> = RefCell::new(new_fast_key_hash_map());
     /// Fast-path gate: `false` when no accessor descriptors have ever been installed
     /// on this thread, so hot `js_object_get_field_by_name` / `set_field_by_name`
     /// can skip the `ACCESSOR_DESCRIPTORS` HashMap lookup entirely.


### PR DESCRIPTION
## Problem

`get_property_attrs` / `get_accessor_descriptor` (descriptor_state.rs) look up `PROPERTY_DESCRIPTORS` / `ACCESSOR_DESCRIPTORS` on the property-access path with a `(usize, String)` key hashed by std's default **SipHash `RandomState`**. Profiling a compiled TUI app shows this at **7–14% of hot on-CPU samples** — the `String` compare + cryptographic hash per lookup. The buffer/set/map registries already avoid this via `PtrHasher`, but the descriptor tables were missed.

## Fix

Add `FastKeyHasher` (FNV-1a — one xor + one multiply per byte, no random seed) in `fast_hash.rs` and key both descriptor tables through it. **Hasher-only change**: the `(usize, String)` key type is unchanged, so `Object.getOwnPropertyDescriptor` / `defineProperty` / `freeze` / `seal` semantics are identical.

DoS-resistance is unnecessary for the same reason it is for the existing `PtrHasher`: no external / attacker-controlled input reaches these keys — the `usize` is a runtime heap address and the `String` a property name baked into the compiled program.

## Verification

- perry-runtime suite passes (1295/0 on the verification base); behavior-preserving hasher swap.
- New composite-key round-trip test (`fast_key_map_composite_round_trip`): distinct addresses / distinct key names don't alias, borrowed-key lookups hit the owned-key slot, removal works.
- `cargo fmt --check`, address-classification ratchet, and file-size cap all green.

Independent of the other in-flight perf/GC work; part of a runtime hot-path optimization series.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved internal property and accessor descriptor lookups for faster runtime metadata access.

* **Reliability**
  * Added optimized key-map handling for composite keys, preserving correct lookup, iteration, and removal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->