### PR TITLE
perf(runtime): read stdin in chunks instead of one byte at a time

### DIFF
--- a/crates/perry-runtime/src/os_process_streams.rs
+++ b/crates/perry-runtime/src/os_process_streams.rs
@@ -190,12 +190,20 @@ fn ensure_stdin_reader() {
             let _guard = ReaderGuard;
             let stdin = std::io::stdin();
             let mut handle = stdin.lock();
-            let mut byte = [0u8; 1];
+            // Read in chunks, not one byte at a time. A paste or a fast-typed
+            // burst arrives as many bytes; the old `[0u8; 1]` read did one
+            // `read` syscall + one STDIN_BUFFER lock + one main-thread notify
+            // (and thus one event-loop wake + pump) PER BYTE, so an N-byte
+            // burst paid N round trips. `read` still returns as soon as any
+            // bytes are available (it does not wait to fill the buffer), so a
+            // lone keystroke is unaffected — it returns 1 byte immediately —
+            // while a burst collapses into one lock + one notify.
+            let mut buf = [0u8; 4096];
             loop {
                 if stdin_is_detached() {
                     break;
                 }
-                match handle.read(&mut byte) {
+                match handle.read(&mut buf) {
                     Ok(0) => {
                         // EOF: record it so the main-thread pump can fire JS
                         // `'end'`/`'close'` listeners after the buffer drains,
@@ -205,9 +213,9 @@ fn ensure_stdin_reader() {
                         crate::event_pump::js_notify_main_thread();
                         break;
                     }
-                    Ok(_) => {
+                    Ok(n) => {
                         if let Ok(mut q) = STDIN_BUFFER.lock() {
-                            q.push(byte[0]);
+                            q.extend_from_slice(&buf[..n]);
                         }
                         crate::event_pump::js_notify_main_thread();
                     }


### PR DESCRIPTION
The background stdin reader read a single byte per iteration (`[0u8; 1]`), so every byte cost one `read` syscall + one `STDIN_BUFFER` mutex + one `js_notify_main_thread` (one event-loop wake + one stdin pump). A paste or fast-typed burst of N bytes paid N round trips.

Read into a 4 KB buffer and append the slice with one lock + one notify per read. `Read::read` returns as soon as any bytes are available (no blocking to fill), so a lone keystroke is unchanged — one byte, immediate — while a burst collapses into a single append + wake. `STDIN_BUFFER` is a `Vec<u8>` drained identically by every consumer, so behavior is unchanged; the per-burst syscall/lock/wake count drops from O(bytes) to O(reads).

Improves paste / fast-input latency in TUI apps (raw-mode stdin). Behavior-preserving; part of a runtime hot-path optimization series.