### PR TITLE
runtime: spec-shaped WebAssembly global with graceful rejection (#6558 baseline)

### DIFF
--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -4,6 +4,7 @@ use super::*;
 
 #[path = "global_this_webassembly.rs"]
 mod global_this_webassembly;
+pub(crate) use global_this_webassembly::webassembly_error_ctor_instanceof;
 
 // Topical sub-modules split out of the original monolithic `global_this.rs`
 // (pure code move; see the per-module re-exports below for the resolving paths).

--- a/crates/perry-runtime/src/object/global_this_webassembly.rs
+++ b/crates/perry-runtime/src/object/global_this_webassembly.rs
@@ -1,6 +1,282 @@
 //! WebAssembly pieces of the `globalThis` namespace installer.
+//!
+//! ## #6558 baseline: spec-shaped surface, graceful failure
+//!
+//! Perry ships no WebAssembly engine in the default build. This namespace is
+//! nevertheless **spec-shaped**: every standard member exists with the right
+//! type, `.name` and `.length`, so feature-detection code
+//! (`typeof WebAssembly !== "undefined" && WebAssembly.validate(...)`) and
+//! lazy wasm-bindgen loaders (photon-node, @jsquash/webp, undici's llhttp
+//! probe) run their own catch/fallback paths instead of crashing on an
+//! `undefined` read. The failure contract:
+//!
+//! - `compile` / `compileStreaming` / `instantiate` / `instantiateStreaming`
+//!   return a Promise **rejected** with a `WebAssembly.CompileError` whose
+//!   message points at issue #6558 — never a crash, never a hang, never a
+//!   synchronous throw where the spec says reject.
+//! - `validate(bytes)` returns `false` (spec-legal for any module, and the
+//!   honest answer for "can I run this here").
+//! - `new WebAssembly.Module(...)` throws `CompileError` synchronously (the
+//!   spec's shape for an unsupported/invalid module); `Instance` throws
+//!   `LinkError`; `Table` / `Global` throw `RuntimeError`.
+//! - `new WebAssembly.Memory({ initial })` genuinely works: it backs the
+//!   instance with a real zero-filled `ArrayBuffer` (`initial` 64KiB pages)
+//!   and supports `grow(delta)`. Feature probes that allocate one page
+//!   succeed.
+//! - `CompileError` / `LinkError` / `RuntimeError` construct real error
+//!   objects (`instanceof Error` is true) and `instanceof` against the
+//!   namespace constructors brand-checks by error `.name` (see
+//!   `webassembly_error_ctor_instanceof`, consulted from
+//!   `js_instanceof_dynamic`).
+//!
+//! When the runtime is built with the `wasm-host` cargo feature (the opt-in
+//! `--enable-wasm-runtime` wasmi path, issue #76), `validate` / `compile` /
+//! `instantiate` and the `Module` constructor + metadata statics route to the
+//! real host shims in `crate::webassembly` instead. The streaming entry
+//! points still reject (no `Response`-driven compile in the host MVP).
+//!
+//! NOTE: the statically-recognized spellings (`WebAssembly.compile(bytes)`
+//! etc. written literally against the global) lower to dedicated HIR
+//! intrinsics in `perry-hir` and never reach this namespace object — they
+//! auto-link the wasmi host archive. This file is the surface every aliased /
+//! dynamic access hits (`const WA = globalThis.WebAssembly; WA.compile(...)`,
+//! which is also how minified bundles usually spell it).
 
 use super::*;
+
+/// One-line story every graceful-failure message carries. Keep the issue URL
+/// in here — it is the actionable breadcrumb when this surfaces in an app log.
+pub(crate) const WASM_UNSUPPORTED_HINT: &str = "perry does not support WebAssembly yet; \
+     WASM-dependent features degrade gracefully (tracked in \
+     https://github.com/PerryTS/perry/issues/6558)";
+
+const WASM_PAGE_BYTES: u32 = 65536;
+/// Largest page count whose byte size still fits the `i32` ArrayBuffer
+/// allocator (`js_array_buffer_new`): 32767 pages = 2GiB - 64KiB.
+const WASM_MAX_PAGES: u32 = (i32::MAX as u32) / WASM_PAGE_BYTES;
+
+#[inline]
+fn undefined() -> f64 {
+    f64::from_bits(crate::value::TAG_UNDEFINED)
+}
+
+fn named_key(bytes: &[u8]) -> *mut crate::string::StringHeader {
+    crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32)
+}
+
+/// Accept both the NaN-boxed pointer encoding (top16 == 0x7FFD) and the
+/// raw-i64 heap-pointer form module-level object variables are stored as
+/// (mirrors the Temporal-subclass handling in `instanceof.rs`).
+fn value_heap_ptr(value: f64) -> Option<*mut u8> {
+    let bits = value.to_bits();
+    let top16 = bits >> 48;
+    let raw = if top16 == 0x7FFD {
+        (bits & crate::value::POINTER_MASK) as usize
+    } else if top16 == 0 && bits > 0x10000 {
+        bits as usize
+    } else {
+        0
+    };
+    if raw == 0 {
+        return None;
+    }
+    Some(raw as *mut u8)
+}
+
+fn value_gc_type(value: f64) -> Option<u8> {
+    let ptr = value_heap_ptr(value)?;
+    if (ptr as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
+        return None;
+    }
+    unsafe {
+        let gc_header = ptr.sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
+        Some((*gc_header).obj_type)
+    }
+}
+
+fn value_object_ptr(value: f64) -> Option<*mut ObjectHeader> {
+    if value_gc_type(value) == Some(crate::gc::GC_TYPE_OBJECT) {
+        Some(value_heap_ptr(value)? as *mut ObjectHeader)
+    } else {
+        None
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Graceful-failure error factory (#6558)
+// ────────────────────────────────────────────────────────────────────────
+
+/// Build a `WebAssembly.<name>Error`-shaped error object: an ordinary
+/// `ErrorHeader` (so `instanceof Error`, `.message`, `.stack` all work)
+/// whose `.name` is `CompileError` / `LinkError` / `RuntimeError`.
+fn wasm_error_with_message(name: &'static [u8], message: &str) -> f64 {
+    let message_ptr = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let err = crate::error::js_error_new_with_name_message_bytes(name, message_ptr);
+    crate::value::js_nanbox_pointer(err as i64)
+}
+
+/// The user-facing constructor path: coerce an arbitrary message VALUE the
+/// way `new Error(v)` does (`undefined` → empty message).
+fn wasm_error_from_message_value(name: &'static [u8], message: f64) -> f64 {
+    let jv = crate::value::JSValue::from_bits(message.to_bits());
+    let message_ptr = if jv.is_undefined() {
+        crate::string::js_string_from_bytes(b"".as_ptr(), 0)
+    } else {
+        crate::builtins::js_string_coerce(message)
+    };
+    let err = crate::error::js_error_new_with_name_message_bytes(name, message_ptr);
+    crate::value::js_nanbox_pointer(err as i64)
+}
+
+fn wasm_unsupported_error(name: &'static [u8], api: &str) -> f64 {
+    wasm_error_with_message(name, &format!("{api}: {WASM_UNSUPPORTED_HINT}"))
+}
+
+/// A Promise rejected with a `WebAssembly.CompileError` carrying the #6558
+/// unsupported message. This is the graceful-failure result of every async
+/// entry point below.
+fn wasm_unsupported_rejection(api: &str) -> f64 {
+    let error = wasm_unsupported_error(b"CompileError", api);
+    let promise = crate::promise::js_promise_rejected(error);
+    crate::value::js_nanbox_pointer(promise as i64)
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// instanceof support for the namespace error constructors
+// ────────────────────────────────────────────────────────────────────────
+
+/// Resolve a candidate `instanceof` RHS back to the wasm error constructor
+/// it is (if any), identified by the constructor thunk `func_ptr` — stable
+/// across GC moves, and not forgeable by a user function that merely shares
+/// the name. Returns the error `.name` the constructor brands.
+fn webassembly_error_ctor_expected_name(type_ref: f64) -> Option<&'static [u8]> {
+    let jv = crate::value::JSValue::from_bits(type_ref.to_bits());
+    if !jv.is_pointer() {
+        return None;
+    }
+    let ptr = jv.as_pointer::<u8>() as *const crate::closure::ClosureHeader;
+    if ptr.is_null()
+        || !(ptr as usize).is_multiple_of(std::mem::align_of::<crate::closure::ClosureHeader>())
+    {
+        return None;
+    }
+    if !crate::value::addr_class::is_valid_obj_ptr(ptr as *const u8) {
+        return None;
+    }
+    unsafe {
+        if (*ptr).type_tag != crate::closure::CLOSURE_MAGIC {
+            return None;
+        }
+        let func_ptr = (*ptr).func_ptr as usize;
+        if func_ptr == webassembly_compile_error_ctor_thunk as *const u8 as usize {
+            Some(b"CompileError")
+        } else if func_ptr == webassembly_link_error_ctor_thunk as *const u8 as usize {
+            Some(b"LinkError")
+        } else if func_ptr == webassembly_runtime_error_ctor_thunk as *const u8 as usize {
+            Some(b"RuntimeError")
+        } else {
+            None
+        }
+    }
+}
+
+fn error_value_name_matches(value: f64, expected: &[u8]) -> bool {
+    if value_gc_type(value) != Some(crate::gc::GC_TYPE_ERROR) {
+        return false;
+    }
+    let Some(ptr) = value_heap_ptr(value) else {
+        return false;
+    };
+    let err = ptr as *const crate::error::ErrorHeader;
+    unsafe {
+        let name = (*err).name;
+        if name.is_null() {
+            return false;
+        }
+        let len = (*name).byte_len as usize;
+        if len != expected.len() {
+            return false;
+        }
+        let data = (name as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+        std::slice::from_raw_parts(data, len) == expected
+    }
+}
+
+/// `e instanceof WebAssembly.CompileError` (and LinkError / RuntimeError).
+/// The wasm error constructors live on the WebAssembly NAMESPACE — not on
+/// `globalThis` — and their instances are `ErrorHeader`-backed values with
+/// no prototype chain reaching the namespace constructor's `.prototype`, so
+/// neither the builtin-name path nor the ordinary prototype walk in
+/// `js_instanceof_dynamic` can brand them. `Some(matches)` when `type_ref`
+/// IS one of the three constructors; `None` for every other RHS.
+pub(crate) fn webassembly_error_ctor_instanceof(value: f64, type_ref: f64) -> Option<bool> {
+    let expected = webassembly_error_ctor_expected_name(type_ref)?;
+    Some(error_value_name_matches(value, expected))
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Constructor-call plumbing
+// ────────────────────────────────────────────────────────────────────────
+
+/// Whether the current dispatch is a `new <this constructor>` construction.
+/// The dynamic construct path (`js_new_function_construct`) binds
+/// `new.target` to the constructor value around the body call; a plain call
+/// leaves it as whatever enclosing construction (if any) set — never OUR
+/// closure. (A dynamic `class X extends WebAssembly.Memory` construction
+/// passes X as new.target and is reported as a plain call here; subclassing
+/// the wasm builtins is out of the #6558 baseline.)
+fn invoked_as_constructor(closure: *const crate::closure::ClosureHeader) -> bool {
+    if closure.is_null() {
+        return false;
+    }
+    let bits = js_new_target_get().to_bits();
+    if (bits >> 48) != 0x7FFD {
+        return false;
+    }
+    ((bits & crate::value::POINTER_MASK) as usize) == closure as usize
+}
+
+fn throw_requires_new(what: &str) -> ! {
+    super::super::object_ops::throw_object_type_error(
+        format!("Constructor {what} requires 'new'").as_bytes(),
+    )
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Async entry points: compile / instantiate / *Streaming
+// ────────────────────────────────────────────────────────────────────────
+
+#[cfg(feature = "wasm-host")]
+extern "C" fn webassembly_compile_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    bytes: f64,
+) -> f64 {
+    crate::webassembly::js_webassembly_compile(bytes)
+}
+
+#[cfg(not(feature = "wasm-host"))]
+extern "C" fn webassembly_compile_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    _bytes: f64,
+) -> f64 {
+    wasm_unsupported_rejection("WebAssembly.compile")
+}
+
+#[cfg(feature = "wasm-host")]
+extern "C" fn webassembly_instantiate_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    bytes: f64,
+) -> f64 {
+    crate::webassembly::js_webassembly_instantiate(bytes)
+}
+
+#[cfg(not(feature = "wasm-host"))]
+extern "C" fn webassembly_instantiate_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    _bytes: f64,
+) -> f64 {
+    wasm_unsupported_rejection("WebAssembly.instantiate")
+}
 
 #[cfg(feature = "wasm-host")]
 extern "C" fn webassembly_validate_thunk(
@@ -18,101 +294,429 @@ extern "C" fn webassembly_validate_thunk(
     f64::from_bits(crate::value::JSValue::bool(false).bits())
 }
 
-#[cfg(feature = "wasm-host")]
-extern "C" fn webassembly_instantiate_thunk(
+/// Streaming compiles need a `Response`-driven source; the wasmi host MVP
+/// has no streaming path either, so these reject under both cfgs.
+extern "C" fn webassembly_compile_streaming_thunk(
     _closure: *const crate::closure::ClosureHeader,
-    bytes: f64,
+    _source: f64,
 ) -> f64 {
-    crate::webassembly::js_webassembly_instantiate(bytes)
+    wasm_unsupported_rejection("WebAssembly.compileStreaming")
 }
 
-#[cfg(not(feature = "wasm-host"))]
-extern "C" fn webassembly_instantiate_thunk(
+extern "C" fn webassembly_instantiate_streaming_thunk(
     _closure: *const crate::closure::ClosureHeader,
-    _bytes: f64,
+    _source: f64,
 ) -> f64 {
-    f64::from_bits(crate::value::TAG_UNDEFINED)
+    wasm_unsupported_rejection("WebAssembly.instantiateStreaming")
 }
 
+/// `WebAssembly.promising` (JSPI) — kept as an existing-but-inert function.
 extern "C" fn webassembly_unsupported_static_thunk(
     _closure: *const crate::closure::ClosureHeader,
     _arg: f64,
 ) -> f64 {
-    f64::from_bits(crate::value::TAG_UNDEFINED)
+    undefined()
 }
+
+// ────────────────────────────────────────────────────────────────────────
+// Constructors
+// ────────────────────────────────────────────────────────────────────────
+
+extern "C" fn webassembly_module_ctor_thunk(
+    closure: *const crate::closure::ClosureHeader,
+    bytes: f64,
+) -> f64 {
+    if !invoked_as_constructor(closure) {
+        throw_requires_new("WebAssembly.Module");
+    }
+    #[cfg(feature = "wasm-host")]
+    {
+        // Real wasmi compile; throws CompileError itself on invalid bytes.
+        crate::webassembly::js_webassembly_module_new(bytes)
+    }
+    #[cfg(not(feature = "wasm-host"))]
+    {
+        let _ = bytes;
+        crate::exception::js_throw(wasm_unsupported_error(
+            b"CompileError",
+            "WebAssembly.Module",
+        ));
+    }
+}
+
+extern "C" fn webassembly_instance_ctor_thunk(
+    closure: *const crate::closure::ClosureHeader,
+    _module: f64,
+) -> f64 {
+    if !invoked_as_constructor(closure) {
+        throw_requires_new("WebAssembly.Instance");
+    }
+    crate::exception::js_throw(wasm_unsupported_error(b"LinkError", "WebAssembly.Instance"));
+}
+
+extern "C" fn webassembly_table_ctor_thunk(
+    closure: *const crate::closure::ClosureHeader,
+    _descriptor: f64,
+) -> f64 {
+    if !invoked_as_constructor(closure) {
+        throw_requires_new("WebAssembly.Table");
+    }
+    crate::exception::js_throw(wasm_unsupported_error(b"RuntimeError", "WebAssembly.Table"));
+}
+
+extern "C" fn webassembly_global_ctor_thunk(
+    closure: *const crate::closure::ClosureHeader,
+    _descriptor: f64,
+) -> f64 {
+    if !invoked_as_constructor(closure) {
+        throw_requires_new("WebAssembly.Global");
+    }
+    crate::exception::js_throw(wasm_unsupported_error(
+        b"RuntimeError",
+        "WebAssembly.Global",
+    ));
+}
+
+// ── Memory: minimally functional (real ArrayBuffer backing) ─────────────
+
+enum MemoryCtorError {
+    /// Descriptor missing / not an object / `initial` absent or not a
+    /// non-negative number → TypeError per spec.
+    Type(&'static str),
+    /// `initial` (or `maximum`) out of the representable page range →
+    /// RangeError per spec.
+    Range(&'static str),
+}
+
+/// Validate a `MemoryDescriptor` and return the requested `initial` page
+/// count. Split from the thunk so the unit tests can exercise every arm
+/// without triggering the `js_throw` unwind path.
+fn wasm_memory_descriptor_pages(descriptor: f64) -> Result<u32, MemoryCtorError> {
+    let Some(obj) = value_object_ptr(descriptor) else {
+        return Err(MemoryCtorError::Type(
+            "WebAssembly.Memory(): argument must be a memory descriptor object",
+        ));
+    };
+    let initial_raw = js_object_get_field_by_name_f64(obj, named_key(b"initial"));
+    let initial = crate::value::JSValue::from_bits(initial_raw.to_bits()).to_number();
+    if !initial.is_finite() || initial < 0.0 {
+        return Err(MemoryCtorError::Type(
+            "WebAssembly.Memory(): descriptor property 'initial' must be a non-negative number",
+        ));
+    }
+    let pages = initial.trunc();
+    if pages > WASM_MAX_PAGES as f64 {
+        return Err(MemoryCtorError::Range(
+            "WebAssembly.Memory(): could not allocate the requested initial pages",
+        ));
+    }
+    let pages = pages as u32;
+    let maximum_raw = js_object_get_field_by_name_f64(obj, named_key(b"maximum"));
+    let maximum_jv = crate::value::JSValue::from_bits(maximum_raw.to_bits());
+    if !maximum_jv.is_undefined() {
+        let maximum = maximum_jv.to_number();
+        if maximum.is_finite() && maximum.trunc() < pages as f64 {
+            return Err(MemoryCtorError::Range(
+                "WebAssembly.Memory(): 'maximum' must be at least 'initial'",
+            ));
+        }
+    }
+    Ok(pages)
+}
+
+fn wasm_memory_new_buffer(pages: u32) -> f64 {
+    let buf = crate::buffer::js_array_buffer_new((pages * WASM_PAGE_BYTES) as i32);
+    crate::value::js_nanbox_pointer(buf as i64)
+}
+
+extern "C" fn webassembly_memory_ctor_thunk(
+    closure: *const crate::closure::ClosureHeader,
+    descriptor: f64,
+) -> f64 {
+    if !invoked_as_constructor(closure) {
+        throw_requires_new("WebAssembly.Memory");
+    }
+    let pages = match wasm_memory_descriptor_pages(descriptor) {
+        Ok(pages) => pages,
+        Err(MemoryCtorError::Type(msg)) => {
+            super::super::object_ops::throw_object_type_error(msg.as_bytes())
+        }
+        Err(MemoryCtorError::Range(msg)) => {
+            let message_ptr = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+            let err = crate::error::js_rangeerror_new(message_ptr);
+            crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64));
+        }
+    };
+    let buffer = wasm_memory_new_buffer(pages);
+    // The dynamic construct path pre-allocated the receiver with
+    // `Memory.prototype` linked (so `instanceof` works); fill it in place.
+    let this = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    if let Some(this_obj) = value_object_ptr(this) {
+        js_object_set_field_by_name(this_obj, named_key(b"buffer"), buffer);
+        undefined()
+    } else {
+        // Reached only from a non-construct dispatch that faked new.target;
+        // still return a usable standalone instance rather than crashing.
+        let obj = js_object_alloc(0, 1);
+        if obj.is_null() {
+            return undefined();
+        }
+        js_object_set_field_by_name(obj, named_key(b"buffer"), buffer);
+        crate::value::js_nanbox_pointer(obj as i64)
+    }
+}
+
+fn memory_buffer_ptr(value: f64) -> Option<*mut crate::buffer::BufferHeader> {
+    let ptr = value_heap_ptr(value)?;
+    if crate::buffer::is_array_buffer(ptr as usize) {
+        Some(ptr as *mut crate::buffer::BufferHeader)
+    } else {
+        None
+    }
+}
+
+/// Grow logic split from the thunk for unit-testability: returns the OLD
+/// page count on success, replacing the receiver's `buffer` with a larger
+/// copy (the spec detaches the old buffer; perry's baseline leaves the old
+/// buffer intact — stale aliases keep reading the pre-grow bytes).
+fn wasm_memory_grow_on(this: f64, delta: f64) -> Result<u32, MemoryCtorError> {
+    let Some(this_obj) = value_object_ptr(this) else {
+        return Err(MemoryCtorError::Type(
+            "WebAssembly.Memory.prototype.grow called on an incompatible receiver",
+        ));
+    };
+    let buffer_val = js_object_get_field_by_name_f64(this_obj, named_key(b"buffer"));
+    let Some(buf) = memory_buffer_ptr(buffer_val) else {
+        return Err(MemoryCtorError::Type(
+            "WebAssembly.Memory.prototype.grow called on an incompatible receiver",
+        ));
+    };
+    if !delta.is_finite() || delta < 0.0 {
+        return Err(MemoryCtorError::Type(
+            "WebAssembly.Memory.grow(): argument must be a non-negative number",
+        ));
+    }
+    let delta_pages = delta.trunc();
+    let old_bytes = unsafe { (*buf).length } as usize;
+    let old_pages = (old_bytes / WASM_PAGE_BYTES as usize) as u32;
+    if delta_pages > (WASM_MAX_PAGES - old_pages) as f64 {
+        return Err(MemoryCtorError::Range(
+            "WebAssembly.Memory.grow(): could not grow memory",
+        ));
+    }
+    let new_pages = old_pages + delta_pages as u32;
+    let new_buf = crate::buffer::js_array_buffer_new((new_pages * WASM_PAGE_BYTES) as i32);
+    if new_buf.is_null() {
+        return Err(MemoryCtorError::Range(
+            "WebAssembly.Memory.grow(): could not grow memory",
+        ));
+    }
+    if old_bytes > 0 {
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                crate::buffer::buffer_data_mut(buf),
+                crate::buffer::buffer_data_mut(new_buf),
+                old_bytes,
+            );
+        }
+    }
+    js_object_set_field_by_name(
+        this_obj,
+        named_key(b"buffer"),
+        crate::value::js_nanbox_pointer(new_buf as i64),
+    );
+    Ok(old_pages)
+}
+
+extern "C" fn webassembly_memory_grow_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    delta: f64,
+) -> f64 {
+    let this = f64::from_bits(IMPLICIT_THIS.with(|c| c.get()));
+    match wasm_memory_grow_on(this, delta) {
+        Ok(old_pages) => old_pages as f64,
+        Err(MemoryCtorError::Type(msg)) => {
+            super::super::object_ops::throw_object_type_error(msg.as_bytes())
+        }
+        Err(MemoryCtorError::Range(msg)) => {
+            let message_ptr = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+            let err = crate::error::js_rangeerror_new(message_ptr);
+            crate::exception::js_throw(crate::value::js_nanbox_pointer(err as i64));
+        }
+    }
+}
+
+// ── Error constructors ──────────────────────────────────────────────────
+
+extern "C" fn webassembly_compile_error_ctor_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    message: f64,
+) -> f64 {
+    wasm_error_from_message_value(b"CompileError", message)
+}
+
+extern "C" fn webassembly_link_error_ctor_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    message: f64,
+) -> f64 {
+    wasm_error_from_message_value(b"LinkError", message)
+}
+
+extern "C" fn webassembly_runtime_error_ctor_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    message: f64,
+) -> f64 {
+    wasm_error_from_message_value(b"RuntimeError", message)
+}
+
+// ── Module metadata statics ─────────────────────────────────────────────
+
+#[cfg(feature = "wasm-host")]
+extern "C" fn webassembly_module_exports_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    module: f64,
+) -> f64 {
+    crate::webassembly::js_webassembly_module_exports(module)
+}
+
+#[cfg(feature = "wasm-host")]
+extern "C" fn webassembly_module_imports_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    module: f64,
+) -> f64 {
+    crate::webassembly::js_webassembly_module_imports(module)
+}
+
+#[cfg(feature = "wasm-host")]
+extern "C" fn webassembly_module_custom_sections_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    module: f64,
+    name: f64,
+) -> f64 {
+    crate::webassembly::js_webassembly_module_custom_sections(module, name)
+}
+
+/// Without an engine no `WebAssembly.Module` instance can exist, so any
+/// argument fails the spec's brand check → synchronous TypeError.
+#[cfg(not(feature = "wasm-host"))]
+extern "C" fn webassembly_module_exports_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    _module: f64,
+) -> f64 {
+    super::super::object_ops::throw_object_type_error(
+        b"WebAssembly.Module.exports(): argument must be a WebAssembly.Module",
+    )
+}
+
+#[cfg(not(feature = "wasm-host"))]
+extern "C" fn webassembly_module_imports_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    _module: f64,
+) -> f64 {
+    super::super::object_ops::throw_object_type_error(
+        b"WebAssembly.Module.imports(): argument must be a WebAssembly.Module",
+    )
+}
+
+#[cfg(not(feature = "wasm-host"))]
+extern "C" fn webassembly_module_custom_sections_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    _module: f64,
+    _name: f64,
+) -> f64 {
+    super::super::object_ops::throw_object_type_error(
+        b"WebAssembly.Module.customSections(): argument must be a WebAssembly.Module",
+    )
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Namespace assembly
+// ────────────────────────────────────────────────────────────────────────
 
 pub(super) fn create_webassembly_namespace() -> f64 {
     let ns_obj = js_object_alloc(0, 0);
     if ns_obj.is_null() {
-        return f64::from_bits(crate::value::TAG_UNDEFINED);
+        return undefined();
     }
 
-    let module_ctor = install_webassembly_constructor(ns_obj, "Module");
+    let module_ctor = install_webassembly_constructor(
+        ns_obj,
+        "Module",
+        webassembly_module_ctor_thunk as *const u8,
+    );
     if !module_ctor.is_null() {
         install_webassembly_static_fn(
             module_ctor as *mut ObjectHeader,
             "exports",
-            global_this_builtin_noop_thunk as *const u8,
+            webassembly_module_exports_thunk as *const u8,
             1,
             true,
         );
         install_webassembly_static_fn(
             module_ctor as *mut ObjectHeader,
             "imports",
-            global_this_builtin_noop_thunk as *const u8,
+            webassembly_module_imports_thunk as *const u8,
             1,
             true,
         );
         install_webassembly_static_fn(
             module_ctor as *mut ObjectHeader,
             "customSections",
-            global_this_builtin_noop_thunk as *const u8,
+            webassembly_module_custom_sections_thunk as *const u8,
             2,
             true,
         );
     }
 
-    let instance_ctor = install_webassembly_constructor(ns_obj, "Instance");
-    install_webassembly_proto_data(
-        instance_ctor,
-        "exports",
-        f64::from_bits(crate::value::TAG_UNDEFINED),
+    let instance_ctor = install_webassembly_constructor(
+        ns_obj,
+        "Instance",
+        webassembly_instance_ctor_thunk as *const u8,
     );
+    install_webassembly_proto_data(instance_ctor, "exports", undefined());
 
-    let memory_ctor = install_webassembly_constructor(ns_obj, "Memory");
-    install_webassembly_proto_data(
+    let memory_ctor = install_webassembly_constructor(
+        ns_obj,
+        "Memory",
+        webassembly_memory_ctor_thunk as *const u8,
+    );
+    install_webassembly_proto_data(memory_ctor, "buffer", undefined());
+    install_webassembly_proto_fn(
         memory_ctor,
-        "buffer",
-        f64::from_bits(crate::value::TAG_UNDEFINED),
+        "grow",
+        webassembly_memory_grow_thunk as *const u8,
+        1,
     );
-    install_webassembly_proto_method(memory_ctor, "grow", 1);
 
-    let table_ctor = install_webassembly_constructor(ns_obj, "Table");
+    let table_ctor =
+        install_webassembly_constructor(ns_obj, "Table", webassembly_table_ctor_thunk as *const u8);
     install_webassembly_proto_method(table_ctor, "get", 1);
     install_webassembly_proto_method(table_ctor, "grow", 1);
-    install_webassembly_proto_data(
-        table_ctor,
-        "length",
-        f64::from_bits(crate::value::TAG_UNDEFINED),
-    );
+    install_webassembly_proto_data(table_ctor, "length", undefined());
     install_webassembly_proto_method(table_ctor, "set", 2);
 
-    let global_ctor = install_webassembly_constructor(ns_obj, "Global");
-    install_webassembly_proto_data(
-        global_ctor,
-        "value",
-        f64::from_bits(crate::value::TAG_UNDEFINED),
+    let global_ctor = install_webassembly_constructor(
+        ns_obj,
+        "Global",
+        webassembly_global_ctor_thunk as *const u8,
     );
+    install_webassembly_proto_data(global_ctor, "value", undefined());
     install_webassembly_proto_method(global_ctor, "valueOf", 0);
 
-    for name in [
-        "CompileError",
-        "LinkError",
-        "RuntimeError",
-        "Exception",
-        "Tag",
+    for (name, func_ptr) in [
+        (
+            "CompileError",
+            webassembly_compile_error_ctor_thunk as *const u8,
+        ),
+        ("LinkError", webassembly_link_error_ctor_thunk as *const u8),
+        (
+            "RuntimeError",
+            webassembly_runtime_error_ctor_thunk as *const u8,
+        ),
+        ("Exception", global_this_builtin_noop_thunk as *const u8),
+        ("Tag", global_this_builtin_noop_thunk as *const u8),
     ] {
-        let ctor = install_webassembly_constructor(ns_obj, name);
+        let ctor = install_webassembly_constructor(ns_obj, name, func_ptr);
         if matches!(name, "CompileError" | "LinkError" | "RuntimeError") {
             install_webassembly_error_proto_data(ctor, name);
         }
@@ -127,7 +731,7 @@ pub(super) fn create_webassembly_namespace() -> f64 {
     install_webassembly_static_fn(
         ns_obj,
         "compile",
-        webassembly_unsupported_static_thunk as *const u8,
+        webassembly_compile_thunk as *const u8,
         1,
         true,
     );
@@ -148,14 +752,14 @@ pub(super) fn create_webassembly_namespace() -> f64 {
     install_webassembly_static_fn(
         ns_obj,
         "compileStreaming",
-        webassembly_unsupported_static_thunk as *const u8,
+        webassembly_compile_streaming_thunk as *const u8,
         1,
         true,
     );
     install_webassembly_static_fn(
         ns_obj,
         "instantiateStreaming",
-        webassembly_unsupported_static_thunk as *const u8,
+        webassembly_instantiate_streaming_thunk as *const u8,
         1,
         true,
     );
@@ -173,14 +777,16 @@ pub(super) fn create_webassembly_namespace() -> f64 {
 fn install_webassembly_constructor(
     ns_obj: *mut ObjectHeader,
     name: &str,
+    func_ptr: *const u8,
 ) -> *mut crate::closure::ClosureHeader {
     if ns_obj.is_null() {
         return std::ptr::null_mut();
     }
-    let closure = crate::closure::js_closure_alloc(global_this_builtin_noop_thunk as *const u8, 0);
+    let closure = crate::closure::js_closure_alloc(func_ptr, 0);
     if closure.is_null() {
         return std::ptr::null_mut();
     }
+    crate::closure::js_register_closure_arity(func_ptr, 1);
     super::super::native_module::set_bound_native_closure_name(closure, name);
     super::super::native_module::set_builtin_closure_length(closure as usize, 1);
     super::super::set_builtin_property_attrs(
@@ -256,6 +862,11 @@ fn install_webassembly_static_fn(
     let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
     let value = crate::value::js_nanbox_pointer(closure as i64);
     js_object_set_field_by_name(obj, key, value);
+    // Node (v26) descriptor for the namespace FUNCTION members and the
+    // `Module.*` metadata statics: { writable: true, enumerable: true,
+    // configurable: true } — while the CONSTRUCTOR members are installed
+    // non-enumerable (see `install_webassembly_constructor`). Verified
+    // against the webassembly-namespace.ts node-suite fixture.
     super::super::set_builtin_property_attrs(
         obj as usize,
         name.to_string(),
@@ -281,16 +892,25 @@ fn install_webassembly_proto_method(
     name: &str,
     arity: u32,
 ) {
-    let proto = webassembly_constructor_proto(ctor);
-    if proto.is_null() {
-        return;
-    }
-    install_proto_method(
-        proto,
+    install_webassembly_proto_fn(
+        ctor,
         name,
         global_this_builtin_noop_thunk as *const u8,
         arity,
     );
+}
+
+fn install_webassembly_proto_fn(
+    ctor: *mut crate::closure::ClosureHeader,
+    name: &str,
+    func_ptr: *const u8,
+    arity: u32,
+) {
+    let proto = webassembly_constructor_proto(ctor);
+    if proto.is_null() {
+        return;
+    }
+    install_proto_method(proto, name, func_ptr, arity);
 }
 
 fn install_webassembly_proto_data(
@@ -359,4 +979,342 @@ fn install_webassembly_object_property(
     let value = crate::value::js_nanbox_pointer(obj as i64);
     js_object_set_field_by_name(ns_obj, key, value);
     super::super::set_builtin_property_attrs(ns_obj as usize, name.to_string(), attrs);
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Unit tests (#6558). Only the non-throwing arms are exercised here — the
+// `js_throw` paths longjmp and are covered by the e2e/parity fixtures
+// (`test-parity/node-suite/globals/webassembly-*.ts`,
+// `tests/test_webassembly_graceful_fail.sh`).
+// ────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn string_value(text: &str) -> f64 {
+        let ptr = crate::string::js_string_from_bytes(text.as_ptr(), text.len() as u32);
+        crate::value::js_nanbox_string(ptr as i64)
+    }
+
+    fn ns_field(ns: f64, name: &[u8]) -> f64 {
+        let obj = value_heap_ptr(ns).expect("namespace pointer") as *mut ObjectHeader;
+        js_object_get_field_by_name_f64(obj, named_key(name))
+    }
+
+    fn closure_ptr(value: f64) -> *const crate::closure::ClosureHeader {
+        let jv = crate::value::JSValue::from_bits(value.to_bits());
+        assert!(jv.is_pointer(), "expected closure pointer value");
+        jv.as_pointer::<u8>() as *const crate::closure::ClosureHeader
+    }
+
+    fn error_name_bytes(value: f64) -> Vec<u8> {
+        let ptr = value_heap_ptr(value).expect("error pointer");
+        let err = ptr as *const crate::error::ErrorHeader;
+        unsafe {
+            let name = (*err).name;
+            assert!(!name.is_null());
+            let len = (*name).byte_len as usize;
+            let data = (name as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+            std::slice::from_raw_parts(data, len).to_vec()
+        }
+    }
+
+    fn error_message_string(value: f64) -> String {
+        let ptr = value_heap_ptr(value).expect("error pointer");
+        let err = ptr as *const crate::error::ErrorHeader;
+        unsafe {
+            let message = (*err).message;
+            if message.is_null() {
+                return String::new();
+            }
+            let len = (*message).byte_len as usize;
+            let data =
+                (message as *const u8).add(std::mem::size_of::<crate::string::StringHeader>());
+            String::from_utf8_lossy(std::slice::from_raw_parts(data, len)).into_owned()
+        }
+    }
+
+    fn assert_rejected_with_compile_error(promise_value: f64, api_fragment: &str) {
+        let ptr = value_heap_ptr(promise_value).expect("promise pointer");
+        let promise = ptr as *const crate::promise::Promise;
+        let (state, reason) = unsafe { ((*promise).state, (*promise).reason) };
+        assert!(
+            matches!(state, crate::promise::PromiseState::Rejected),
+            "{api_fragment}: expected a rejected promise"
+        );
+        assert_eq!(
+            error_name_bytes(reason),
+            b"CompileError".to_vec(),
+            "{api_fragment}: rejection reason must be a WebAssembly.CompileError"
+        );
+        let message = error_message_string(reason);
+        assert!(
+            message.contains(api_fragment),
+            "rejection message must name the API: {message}"
+        );
+        assert!(
+            message.contains("6558"),
+            "rejection message must reference issue #6558: {message}"
+        );
+        assert!(
+            value_gc_type(reason) == Some(crate::gc::GC_TYPE_ERROR),
+            "rejection reason must be a real error object"
+        );
+    }
+
+    #[test]
+    fn namespace_members_exist_with_expected_shapes() {
+        let ns = create_webassembly_namespace();
+        assert!(value_heap_ptr(ns).is_some(), "namespace must be an object");
+
+        for name in [
+            &b"compile"[..],
+            b"validate",
+            b"instantiate",
+            b"compileStreaming",
+            b"instantiateStreaming",
+            b"promising",
+            b"Module",
+            b"Instance",
+            b"Memory",
+            b"Table",
+            b"Global",
+            b"CompileError",
+            b"LinkError",
+            b"RuntimeError",
+            b"Exception",
+            b"Tag",
+        ] {
+            let member = ns_field(ns, name);
+            let jv = crate::value::JSValue::from_bits(member.to_bits());
+            assert!(
+                jv.is_pointer(),
+                "WebAssembly.{} must exist as a function",
+                String::from_utf8_lossy(name)
+            );
+            let closure = closure_ptr(member);
+            unsafe {
+                assert_eq!(
+                    (*closure).type_tag,
+                    crate::closure::CLOSURE_MAGIC,
+                    "WebAssembly.{} must be a closure",
+                    String::from_utf8_lossy(name)
+                );
+            }
+        }
+
+        // Constructors expose a prototype with a constructor backref.
+        let module_ctor = closure_ptr(ns_field(ns, b"Module"));
+        let proto = webassembly_constructor_proto(module_ctor as *mut _);
+        assert!(!proto.is_null(), "Module.prototype must exist");
+
+        // Memory.prototype carries a callable grow.
+        let memory_ctor = closure_ptr(ns_field(ns, b"Memory"));
+        let memory_proto = webassembly_constructor_proto(memory_ctor as *mut _);
+        assert!(!memory_proto.is_null());
+        let grow = js_object_get_field_by_name_f64(memory_proto, named_key(b"grow"));
+        let grow_jv = crate::value::JSValue::from_bits(grow.to_bits());
+        assert!(grow_jv.is_pointer(), "Memory.prototype.grow must exist");
+    }
+
+    #[cfg(not(feature = "wasm-host"))]
+    #[test]
+    fn async_members_reject_with_compile_error() {
+        let closure = std::ptr::null();
+        assert_rejected_with_compile_error(
+            webassembly_compile_thunk(closure, undefined()),
+            "WebAssembly.compile",
+        );
+        assert_rejected_with_compile_error(
+            webassembly_instantiate_thunk(closure, undefined()),
+            "WebAssembly.instantiate",
+        );
+        assert_rejected_with_compile_error(
+            webassembly_compile_streaming_thunk(closure, undefined()),
+            "WebAssembly.compileStreaming",
+        );
+        assert_rejected_with_compile_error(
+            webassembly_instantiate_streaming_thunk(closure, undefined()),
+            "WebAssembly.instantiateStreaming",
+        );
+    }
+
+    #[cfg(not(feature = "wasm-host"))]
+    #[test]
+    fn validate_reports_false() {
+        let result = webassembly_validate_thunk(std::ptr::null(), undefined());
+        assert_eq!(
+            result.to_bits(),
+            crate::value::JSValue::bool(false).bits(),
+            "validate must answer false without an engine"
+        );
+    }
+
+    #[test]
+    fn error_constructors_build_branded_error_objects() {
+        let message = string_value("boom");
+        let compile_err = webassembly_compile_error_ctor_thunk(std::ptr::null(), message);
+        assert_eq!(error_name_bytes(compile_err), b"CompileError".to_vec());
+        assert_eq!(error_message_string(compile_err), "boom");
+        assert_eq!(value_gc_type(compile_err), Some(crate::gc::GC_TYPE_ERROR));
+
+        // Message coercion mirrors `new Error(v)`.
+        let numbered = webassembly_link_error_ctor_thunk(std::ptr::null(), 42.0);
+        assert_eq!(error_name_bytes(numbered), b"LinkError".to_vec());
+        assert_eq!(error_message_string(numbered), "42");
+
+        let bare = webassembly_runtime_error_ctor_thunk(std::ptr::null(), undefined());
+        assert_eq!(error_name_bytes(bare), b"RuntimeError".to_vec());
+        assert_eq!(error_message_string(bare), "");
+    }
+
+    #[test]
+    fn error_ctor_instanceof_brands_by_ctor_identity_and_error_name() {
+        let ns = create_webassembly_namespace();
+        let compile_ctor = ns_field(ns, b"CompileError");
+        let link_ctor = ns_field(ns, b"LinkError");
+        let runtime_ctor = ns_field(ns, b"RuntimeError");
+
+        let compile_err = webassembly_compile_error_ctor_thunk(std::ptr::null(), string_value("x"));
+        let link_err = webassembly_link_error_ctor_thunk(std::ptr::null(), string_value("x"));
+
+        assert_eq!(
+            webassembly_error_ctor_instanceof(compile_err, compile_ctor),
+            Some(true)
+        );
+        assert_eq!(
+            webassembly_error_ctor_instanceof(link_err, link_ctor),
+            Some(true)
+        );
+        // Cross-brand must not match.
+        assert_eq!(
+            webassembly_error_ctor_instanceof(compile_err, link_ctor),
+            Some(false)
+        );
+        assert_eq!(
+            webassembly_error_ctor_instanceof(link_err, runtime_ctor),
+            Some(false)
+        );
+        // Non-error LHS values never match.
+        assert_eq!(
+            webassembly_error_ctor_instanceof(undefined(), compile_ctor),
+            Some(false)
+        );
+        assert_eq!(
+            webassembly_error_ctor_instanceof(1.5, compile_ctor),
+            Some(false)
+        );
+        // A non-wasm-error RHS is not ours to answer.
+        assert_eq!(
+            webassembly_error_ctor_instanceof(compile_err, ns_field(ns, b"validate")),
+            None
+        );
+        assert_eq!(webassembly_error_ctor_instanceof(compile_err, 2.0), None);
+        // An ordinary Error whose name merely coincides IS accepted by the
+        // name brand (documented looseness of the baseline): verify the
+        // negative case that matters — a plain Error does NOT match.
+        let plain = crate::error::js_error_new_with_message(named_key(b"plain"));
+        let plain_value = crate::value::js_nanbox_pointer(plain as i64);
+        assert_eq!(
+            webassembly_error_ctor_instanceof(plain_value, compile_ctor),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn memory_descriptor_validation_and_buffer_backing() {
+        // Valid: 1 page → 65536-byte zero-filled ArrayBuffer.
+        let descriptor = js_object_alloc(0, 1);
+        js_object_set_field_by_name(descriptor, named_key(b"initial"), 1.0);
+        let pages =
+            wasm_memory_descriptor_pages(crate::value::js_nanbox_pointer(descriptor as i64))
+                .unwrap_or_else(|_| panic!("descriptor {{initial: 1}} must validate"));
+        assert_eq!(pages, 1);
+        let buffer = wasm_memory_new_buffer(pages);
+        let buf = memory_buffer_ptr(buffer).expect("buffer must be a registered ArrayBuffer");
+        unsafe {
+            assert_eq!((*buf).length, WASM_PAGE_BYTES);
+        }
+
+        // Zero pages are legal.
+        let zero_desc = js_object_alloc(0, 1);
+        js_object_set_field_by_name(zero_desc, named_key(b"initial"), 0.0);
+        assert!(matches!(
+            wasm_memory_descriptor_pages(crate::value::js_nanbox_pointer(zero_desc as i64)),
+            Ok(0)
+        ));
+
+        // Missing initial → TypeError arm.
+        let empty_desc = js_object_alloc(0, 0);
+        assert!(matches!(
+            wasm_memory_descriptor_pages(crate::value::js_nanbox_pointer(empty_desc as i64)),
+            Err(MemoryCtorError::Type(_))
+        ));
+
+        // Non-object descriptor → TypeError arm.
+        assert!(matches!(
+            wasm_memory_descriptor_pages(undefined()),
+            Err(MemoryCtorError::Type(_))
+        ));
+
+        // Oversized initial → RangeError arm.
+        let big_desc = js_object_alloc(0, 1);
+        js_object_set_field_by_name(big_desc, named_key(b"initial"), 1e9);
+        assert!(matches!(
+            wasm_memory_descriptor_pages(crate::value::js_nanbox_pointer(big_desc as i64)),
+            Err(MemoryCtorError::Range(_))
+        ));
+
+        // maximum < initial → RangeError arm.
+        let shrunk_desc = js_object_alloc(0, 2);
+        js_object_set_field_by_name(shrunk_desc, named_key(b"initial"), 2.0);
+        js_object_set_field_by_name(shrunk_desc, named_key(b"maximum"), 1.0);
+        assert!(matches!(
+            wasm_memory_descriptor_pages(crate::value::js_nanbox_pointer(shrunk_desc as i64)),
+            Err(MemoryCtorError::Range(_))
+        ));
+    }
+
+    #[test]
+    fn memory_grow_replaces_buffer_and_returns_old_page_count() {
+        let instance = js_object_alloc(0, 1);
+        js_object_set_field_by_name(instance, named_key(b"buffer"), wasm_memory_new_buffer(1));
+        let instance_value = crate::value::js_nanbox_pointer(instance as i64);
+
+        // Write a marker byte and confirm grow copies it over.
+        let before = js_object_get_field_by_name_f64(instance, named_key(b"buffer"));
+        let before_buf = memory_buffer_ptr(before).unwrap();
+        unsafe {
+            *crate::buffer::buffer_data_mut(before_buf) = 0xAB;
+        }
+
+        let old_pages = match wasm_memory_grow_on(instance_value, 2.0) {
+            Ok(pages) => pages,
+            Err(_) => panic!("grow(2) on a 1-page memory must succeed"),
+        };
+        assert_eq!(old_pages, 1);
+
+        let after = js_object_get_field_by_name_f64(instance, named_key(b"buffer"));
+        let after_buf = memory_buffer_ptr(after).unwrap();
+        unsafe {
+            assert_eq!((*after_buf).length, 3 * WASM_PAGE_BYTES);
+            assert_eq!(*crate::buffer::buffer_data_mut(after_buf), 0xAB);
+        }
+
+        // Negative delta → TypeError arm; absurd delta → RangeError arm.
+        assert!(matches!(
+            wasm_memory_grow_on(instance_value, -1.0),
+            Err(MemoryCtorError::Type(_))
+        ));
+        assert!(matches!(
+            wasm_memory_grow_on(instance_value, 1e9),
+            Err(MemoryCtorError::Range(_))
+        ));
+        // Non-memory receiver → TypeError arm.
+        assert!(matches!(
+            wasm_memory_grow_on(undefined(), 1.0),
+            Err(MemoryCtorError::Type(_))
+        ));
+    }
 }

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -275,6 +275,21 @@ pub extern "C" fn js_instanceof_dynamic(value: f64, type_ref: f64) -> f64 {
     if let Some(class_id) = builtin_ctor_class_id_from_value(type_ref) {
         return js_instanceof(value, class_id);
     }
+    // #6558: `e instanceof WebAssembly.CompileError` (and LinkError /
+    // RuntimeError). These constructors live on the WebAssembly NAMESPACE —
+    // not on `globalThis`, so the builtin-name path above never resolves
+    // them — and their instances are ErrorHeader-backed values with no
+    // prototype chain reaching the namespace ctor's `.prototype`, so the
+    // ordinary prototype walk below can't brand them either. Identify the
+    // ctor by its dedicated thunk func_ptr (GC-move-safe) and brand-check
+    // the instance by its error `.name`.
+    if let Some(matches) = super::global_this::webassembly_error_ctor_instanceof(value, type_ref) {
+        return f64::from_bits(if matches {
+            crate::value::TAG_TRUE
+        } else {
+            crate::value::TAG_FALSE
+        });
+    }
     if let Some((module, method)) = unsafe { bound_native_callable_module_and_method(type_ref) } {
         if module == "stream"
             && matches!(

--- a/crates/perry-runtime/src/webassembly.rs
+++ b/crates/perry-runtime/src/webassembly.rs
@@ -206,6 +206,59 @@ fn emit_error_to_stderr(prefix: &str, err: *mut c_char) {
     }
 }
 
+/// Consume (and free) a host error C-string into a `WebAssembly.<name>`-
+/// shaped error value: an ordinary `ErrorHeader` whose `.name` is
+/// `CompileError` / `LinkError` — the same shape the graceful-fail
+/// namespace produces (#6558), so `err instanceof WebAssembly.CompileError`
+/// and `.catch` handlers see one consistent brand in both modes.
+fn wasm_error_value_from_host(name: &'static [u8], err: *mut c_char, fallback: &str) -> f64 {
+    let message = if err.is_null() {
+        fallback.to_string()
+    } else {
+        let cs = unsafe { std::ffi::CStr::from_ptr(err) };
+        let text = cs.to_string_lossy().into_owned();
+        unsafe { perry_wasm_host_string_free(err) };
+        text
+    };
+    let message_ptr = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let error = crate::error::js_error_new_with_name_message_bytes(name, message_ptr);
+    crate::value::js_nanbox_pointer(error as i64)
+}
+
+fn wasm_type_error_value(message: &str) -> f64 {
+    let message_ptr = crate::string::js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    let error = crate::error::js_typeerror_new(message_ptr);
+    crate::value::js_nanbox_pointer(error as i64)
+}
+
+fn rejected_promise_value(reason: f64) -> f64 {
+    let promise = crate::promise::js_promise_rejected(reason);
+    crate::value::js_nanbox_pointer(promise as i64)
+}
+
+/// Compile `bytes_jsval` into a module wrapper. `Err` carries a ready-to-
+/// throw/reject JS error VALUE (TypeError for a non-buffer argument,
+/// CompileError for invalid bytes) so each caller can pick the spec-mandated
+/// delivery: `new WebAssembly.Module` throws synchronously, `compile` /
+/// `instantiate` reject their promise.
+fn module_new_value(bytes_jsval: f64) -> Result<f64, f64> {
+    let Some((ptr, len)) = extract_bytes(bytes_jsval) else {
+        return Err(wasm_type_error_value(
+            "WebAssembly.Module: argument must be a Uint8Array or ArrayBuffer",
+        ));
+    };
+    let mut err: *mut c_char = std::ptr::null_mut();
+    let module = unsafe { perry_wasm_host_module_new(ptr, len, &mut err) };
+    if module.is_null() {
+        return Err(wasm_error_value_from_host(
+            b"CompileError",
+            err,
+            "WebAssembly.Module(): compile failed",
+        ));
+    }
+    Ok(make_module_object(module))
+}
+
 fn string_value(bytes: &[u8]) -> f64 {
     let ptr = crate::string::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
     f64::from_bits(JSValue::string_ptr(ptr).bits())
@@ -338,33 +391,31 @@ pub extern "C" fn js_webassembly_validate(bytes_jsval: f64) -> f64 {
 }
 
 /// `new WebAssembly.Module(bytes)` — compile bytes and return a JS wrapper
-/// around the host module handle.
+/// around the host module handle. Per spec this constructor THROWS
+/// synchronously: TypeError for a non-buffer argument, CompileError for
+/// invalid bytes (#6558 — previously logged to stderr and returned
+/// `undefined`, which crashed callers later at the first property read).
 #[no_mangle]
 pub extern "C" fn js_webassembly_module_new(bytes_jsval: f64) -> f64 {
-    let Some((ptr, len)) = extract_bytes(bytes_jsval) else {
-        eprintln!("WebAssembly.Module: argument is not a Uint8Array or ArrayBuffer");
-        return nanbox_undefined();
-    };
-    let mut err: *mut c_char = std::ptr::null_mut();
-    let module = unsafe { perry_wasm_host_module_new(ptr, len, &mut err) };
-    if module.is_null() {
-        emit_error_to_stderr("WebAssembly.CompileError", err);
-        return nanbox_undefined();
+    match module_new_value(bytes_jsval) {
+        Ok(module) => module,
+        Err(error) => crate::exception::js_throw(error),
     }
-    make_module_object(module)
 }
 
 /// `WebAssembly.compile(bytes)` — async-standard shape, implemented as a
-/// pre-resolved Promise over the same module wrapper used by the constructor.
+/// pre-resolved Promise over the same module wrapper used by the
+/// constructor. Failures REJECT (never throw) with a `CompileError`-named
+/// error carrying the host's message, per spec.
 #[no_mangle]
 pub extern "C" fn js_webassembly_compile(bytes_jsval: f64) -> f64 {
-    let module = js_webassembly_module_new(bytes_jsval);
-    let promise = if module.to_bits() == TAG_UNDEFINED {
-        crate::promise::js_promise_rejected(string_value(b"WebAssembly compile failed"))
-    } else {
-        crate::promise::js_promise_resolved(module)
-    };
-    crate::value::js_nanbox_pointer(promise as i64)
+    match module_new_value(bytes_jsval) {
+        Ok(module) => {
+            let promise = crate::promise::js_promise_resolved(module);
+            crate::value::js_nanbox_pointer(promise as i64)
+        }
+        Err(error) => rejected_promise_value(error),
+    }
 }
 
 #[no_mangle]
@@ -455,24 +506,32 @@ pub extern "C" fn js_webassembly_module_custom_sections(module_jsval: f64, name_
     array_value(arr)
 }
 
-/// `WebAssembly.instantiate(bytes)` — synchronous, returns an opaque handle
-/// (NaN-boxed pointer) suitable for `callExport`. On error logs to stderr
-/// and returns `undefined`.
+/// `WebAssembly.instantiate(bytes)` — synchronous on SUCCESS, returning an
+/// opaque handle (NaN-boxed pointer) suitable for `callExport`. This is the
+/// Perry MVP shape, **not** the standard `Promise<{module,instance}>`; the
+/// standard async surface is tracked as follow-up work (see issue #76).
 ///
-/// Note: this is the Perry MVP shape, **not** the standard
-/// `Promise<{module,instance}>`. The standard async surface is tracked as
-/// follow-up work (see issue #76).
+/// Failures return a REJECTED PROMISE instead of `undefined` (#6558):
+/// TypeError for a non-buffer argument, CompileError for invalid bytes,
+/// LinkError for instantiation failure. `await`-shaped consumers (the
+/// standard spelling) then land in their own `catch` path instead of
+/// crashing on `undefined.instance`, and the MVP handle shape is unchanged
+/// on the success path.
 #[no_mangle]
 pub extern "C" fn js_webassembly_instantiate(bytes_jsval: f64) -> f64 {
     let Some((ptr, len)) = extract_bytes(bytes_jsval) else {
-        eprintln!("WebAssembly.instantiate: argument is not a Uint8Array or ArrayBuffer");
-        return nanbox_undefined();
+        return rejected_promise_value(wasm_type_error_value(
+            "WebAssembly.instantiate: argument must be a Uint8Array or ArrayBuffer",
+        ));
     };
     let mut err: *mut c_char = std::ptr::null_mut();
     let module = unsafe { perry_wasm_host_module_new(ptr, len, &mut err) };
     if module.is_null() {
-        emit_error_to_stderr("WebAssembly.CompileError", err);
-        return nanbox_undefined();
+        return rejected_promise_value(wasm_error_value_from_host(
+            b"CompileError",
+            err,
+            "WebAssembly.instantiate(): compile failed",
+        ));
     }
     let mut err2: *mut c_char = std::ptr::null_mut();
     let inst = unsafe { perry_wasm_host_instance_new(module, &mut err2) };
@@ -480,8 +539,11 @@ pub extern "C" fn js_webassembly_instantiate(bytes_jsval: f64) -> f64 {
     // wasmi's Arc. Leaks the wrapper but not the wasm module data.
     unsafe { perry_wasm_host_module_drop(module) };
     if inst.is_null() {
-        emit_error_to_stderr("WebAssembly.LinkError", err2);
-        return nanbox_undefined();
+        return rejected_promise_value(wasm_error_value_from_host(
+            b"LinkError",
+            err2,
+            "WebAssembly.instantiate(): instantiation failed",
+        ));
     }
     nanbox_pointer_raw(inst as *const c_void)
 }

--- a/docs/src/language/limitations.md
+++ b/docs/src/language/limitations.md
@@ -237,6 +237,45 @@ Caveat: only the `SharedArrayBuffer` itself shares — a typed-array *view*
 captured directly still deep-copies, so build the view per-agent from the shared
 SAB.
 
+## WebAssembly (#6558)
+
+Perry ships **no WebAssembly engine** in the default build. The current
+policy: **WASM-dependent features degrade gracefully**; full support is
+tracked in [#6558](https://github.com/PerryTS/perry/issues/6558).
+
+The `WebAssembly` global is spec-shaped — every standard member exists with
+the correct type and arity — and fails cleanly rather than crashing:
+
+- `WebAssembly.compile` / `compileStreaming` / `instantiate` /
+  `instantiateStreaming` return a Promise **rejected** with a
+  `WebAssembly.CompileError` whose message points at #6558.
+- `WebAssembly.validate(bytes)` returns `false` — the honest answer for
+  "can I run this module here".
+- `new WebAssembly.Module(...)` throws `CompileError` synchronously;
+  `Instance` throws `LinkError`; `Table` / `Global` throw `RuntimeError`.
+- `new WebAssembly.Memory({ initial })` genuinely works (a real zero-filled
+  `ArrayBuffer` backs it, and `grow()` is supported), so feature-detection
+  code that allocates a page succeeds.
+- `CompileError` / `LinkError` / `RuntimeError` are real error constructors
+  (`instanceof Error` and `instanceof WebAssembly.CompileError` both work).
+
+In practice this means lazy wasm consumers — wasm-bindgen loaders like
+`@silvia-odwyer/photon-node`, `@jsquash/webp` decoders, undici's llhttp
+probe — hit their own catch/fallback paths and the app keeps running with
+that feature degraded.
+
+Two spellings, two paths:
+
+- **Namespace access** (`const WA = globalThis.WebAssembly; WA.compile(...)`,
+  which is also what minified bundles evaluate through a namespace value)
+  uses the graceful surface above and needs nothing at link time.
+- **Literal static calls** (`WebAssembly.instantiate(bytes)` written against
+  the global) lower to the opt-in wasmi host runtime (issue #76,
+  `--enable-wasm-runtime`, auto-linked when usage is detected). These run
+  real WebAssembly through the wasmi interpreter but require
+  `libperry_wasm_host.a` to be built (`cargo build --release -p
+  perry-wasm-host`); without it the build fails with that instruction.
+
 ## npm Package Compatibility
 
 Not all npm packages work with Perry:

--- a/test-files/test_gap_6558_webassembly_graceful_fail.ts
+++ b/test-files/test_gap_6558_webassembly_graceful_fail.ts
@@ -1,0 +1,86 @@
+// #6558: graceful-fail baseline for the WebAssembly global. Perry ships no
+// WebAssembly engine by default; the namespace must be spec-SHAPED (every
+// standard member present with the right type) and fail GRACEFULLY: async
+// members reject with a CompileError, `validate` answers false, and
+// `new WebAssembly.Module` throws CompileError synchronously — so lazy
+// wasm-bindgen loaders (photon-node, @jsquash/webp, undici's llhttp probe)
+// land in their own catch/fallback paths instead of crashing the process.
+//
+// The module bytes below are deliberately INVALID so node degrades through
+// the exact same spec shapes and every line prints byte-identical output.
+// Aliased namespace access on purpose: the literal `WebAssembly.compile(...)`
+// spelling lowers to the wasmi host intrinsics (issue #76) and requires the
+// wasm host archive at link time; the namespace VALUE is the path minified
+// bundles take.
+const WA: any = (globalThis as any).WebAssembly;
+const garbage = new Uint8Array([0x01, 0x02, 0x03, 0x04]);
+
+// Feature-detection pattern (presence probe + validate).
+console.log("feature detect:", typeof WA !== "undefined");
+console.log("validate:", WA.validate(garbage));
+console.log(
+  "detect pattern:",
+  typeof WA !== "undefined" && WA.validate(garbage) ? "wasm" : "fallback",
+);
+
+// Member shapes: everything a loader might poke at exists as a function.
+for (const name of [
+  "compile",
+  "instantiate",
+  "compileStreaming",
+  "instantiateStreaming",
+  "validate",
+  "Module",
+  "Instance",
+  "Memory",
+  "Table",
+  "Global",
+  "CompileError",
+  "LinkError",
+  "RuntimeError",
+]) {
+  console.log(name + ":", typeof WA[name]);
+}
+
+// Synchronous constructor: CompileError, thrown (not returned, not crashed).
+try {
+  new WA.Module(garbage);
+  console.log("Module: constructed");
+} catch (e: any) {
+  console.log("Module threw:", e instanceof Error, e instanceof WA.CompileError, e.name);
+}
+
+// Async members REJECT — observable as clean rejections.
+try {
+  await WA.compile(garbage);
+  console.log("compile: resolved");
+} catch (e: any) {
+  console.log("compile rejected:", e instanceof Error, e instanceof WA.CompileError, e.name);
+}
+try {
+  await WA.instantiate(garbage);
+  console.log("instantiate: resolved");
+} catch (e: any) {
+  console.log("instantiate rejected:", e instanceof Error, e.name);
+}
+
+// Error classes construct branded instances.
+const ce = new WA.CompileError("boom");
+console.log("CompileError:", ce instanceof Error, ce instanceof WA.CompileError, ce.name, ce.message);
+
+// Memory allocates a real ArrayBuffer (feature-detection code does this).
+const mem = new WA.Memory({ initial: 1 });
+console.log("Memory buffer:", mem.buffer instanceof ArrayBuffer, mem.buffer.byteLength);
+
+// The photon-node loader pattern: lazy load, resolve null on failure, keep
+// running.
+async function lazyLoad(bytes: Uint8Array): Promise<unknown | null> {
+  try {
+    return await WA.compile(bytes);
+  } catch {
+    return null;
+  }
+}
+const loaded = await lazyLoad(garbage);
+console.log("loader result:", loaded === null ? "degraded" : "loaded");
+console.log("program continues");

--- a/test-parity/node-suite/globals/webassembly-graceful-degradation.ts
+++ b/test-parity/node-suite/globals/webassembly-graceful-degradation.ts
@@ -1,0 +1,123 @@
+// #6558 — graceful-fail baseline for the WebAssembly namespace.
+//
+// Perry ships no WebAssembly engine by default; the namespace is spec-shaped
+// and fails GRACEFULLY: async members reject with a CompileError, `validate`
+// answers false, `new WebAssembly.Module` throws CompileError synchronously,
+// and `Memory` is minimally functional (real ArrayBuffer backing). Every
+// line below prints identically under node, the default perry runtime, and
+// the wasm-host (wasmi) runtime — which is why the module bytes used here
+// are deliberately INVALID: node rejects them through the same spec shapes
+// perry uses for "no engine".
+//
+// Aliased access on purpose: the literal `WebAssembly.compile(...)` spelling
+// lowers to the wasmi host intrinsics (issue #76) and auto-links the wasm
+// host archive; the namespace VALUE below is the path minified bundles and
+// lazy wasm-bindgen loaders actually take.
+const WA: any = (globalThis as any).WebAssembly;
+
+// (c) Feature-detection pattern: presence probe + validate as the honest
+// "can I run this module here" answer.
+const garbage = new Uint8Array([0x01, 0x02, 0x03, 0x04]);
+console.log("feature detect:", typeof WA !== "undefined");
+console.log("validate garbage:", WA.validate(garbage));
+console.log(
+  "detect pattern:",
+  typeof WA !== "undefined" && WA.validate(garbage) ? "wasm" : "fallback",
+);
+
+// `new WebAssembly.Module(bytes)` throws a CompileError synchronously.
+try {
+  new WA.Module(garbage);
+  console.log("Module: constructed");
+} catch (e: any) {
+  console.log(
+    "Module threw:",
+    e instanceof Error,
+    e instanceof WA.CompileError,
+    e.name,
+  );
+}
+
+// Async members REJECT — never crash, never hang, never throw sync.
+try {
+  await WA.compile(garbage);
+  console.log("compile: resolved");
+} catch (e: any) {
+  console.log(
+    "compile rejected:",
+    e instanceof Error,
+    e instanceof WA.CompileError,
+    e.name,
+  );
+}
+
+try {
+  await WA.instantiate(garbage);
+  console.log("instantiate: resolved");
+} catch (e: any) {
+  console.log(
+    "instantiate rejected:",
+    e instanceof Error,
+    e instanceof WA.CompileError,
+    e.name,
+  );
+}
+
+// Streaming entry points also reject cleanly (reason type differs from
+// node's — TypeError there, CompileError here — so only the Error-ness is
+// asserted).
+try {
+  await WA.compileStreaming(garbage);
+  console.log("compileStreaming: resolved");
+} catch (e: any) {
+  console.log("compileStreaming rejected:", e instanceof Error);
+}
+
+try {
+  await WA.instantiateStreaming(garbage);
+  console.log("instantiateStreaming: resolved");
+} catch (e: any) {
+  console.log("instantiateStreaming rejected:", e instanceof Error);
+}
+
+// Error constructors are real constructors: `new` and plain call both
+// produce branded Error instances.
+const ce = new WA.CompileError("boom");
+console.log(
+  "CompileError:",
+  ce instanceof Error,
+  ce instanceof WA.CompileError,
+  ce instanceof WA.LinkError,
+  ce.name,
+  ce.message,
+);
+const le = new WA.LinkError();
+console.log("LinkError:", le instanceof Error, le instanceof WA.LinkError, le.name, le.message === "");
+const re = WA.RuntimeError("trap");
+console.log("RuntimeError:", re instanceof Error, re instanceof WA.RuntimeError, re.name, re.message);
+
+// Memory is minimally functional: a real zero-filled ArrayBuffer backs it,
+// and grow() re-backs it (returning the old page count).
+const mem = new WA.Memory({ initial: 1 });
+console.log(
+  "Memory:",
+  mem instanceof WA.Memory,
+  mem.buffer instanceof ArrayBuffer,
+  mem.buffer.byteLength,
+);
+const view = new Uint8Array(mem.buffer);
+console.log("Memory zeroed:", view[0], view[65535]);
+console.log("Memory grow:", mem.grow(1), mem.buffer.byteLength);
+
+// (b) The photon-node loader pattern: a lazy wasm loader that resolves null
+// on failure. The program must observe a clean rejection and continue.
+async function lazyLoad(bytes: Uint8Array): Promise<unknown | null> {
+  try {
+    return await WA.compile(bytes);
+  } catch {
+    return null;
+  }
+}
+const loaded = await lazyLoad(garbage);
+console.log("loader result:", loaded === null ? "degraded" : "loaded");
+console.log("program continues");

--- a/tests/test_webassembly_graceful_fail.sh
+++ b/tests/test_webassembly_graceful_fail.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# #6558 — graceful-fail baseline for the WebAssembly global (perry-only
+# assertions; the node-parity side lives in
+# test-files/test_gap_6558_webassembly_graceful_fail.ts and
+# test-parity/node-suite/globals/webassembly-graceful-degradation.ts).
+#
+# What node CANNOT parity-check: in the default perry build (no wasmi host
+# linked), even a perfectly VALID wasm module must be answered honestly —
+# `validate` → false, `compile` → rejection whose CompileError message names
+# the API and points at issue #6558 — while the program continues and exits 0.
+#
+# Uses the ALIASED namespace spelling: the literal `WebAssembly.compile(...)`
+# form lowers to the wasmi host intrinsics (issue #76) and auto-links
+# libperry_wasm_host.a, which is exactly the path this test must avoid.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PERRY="$SCRIPT_DIR/../target/release/perry"
+[ ! -f "$PERRY" ] && PERRY="$SCRIPT_DIR/../target/debug/perry"
+if [ ! -f "$PERRY" ]; then
+  echo "SKIP: perry binary not found (build with cargo build --release)"
+  exit 0
+fi
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+cat > "$TMPDIR/graceful.ts" << 'EOF'
+const WA: any = (globalThis as any).WebAssembly;
+
+// The canonical valid i32 add module (~41 bytes):
+//   (module (func (export "add") (param i32 i32) (result i32)
+//                  local.get 0 local.get 1 i32.add))
+const validAdd = new Uint8Array([
+  0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+  0x01, 0x07, 0x01, 0x60, 0x02, 0x7f, 0x7f, 0x01,
+  0x7f, 0x03, 0x02, 0x01, 0x00, 0x07, 0x07, 0x01,
+  0x03, 0x61, 0x64, 0x64, 0x00, 0x00, 0x0a, 0x09,
+  0x01, 0x07, 0x00, 0x20, 0x00, 0x20, 0x01, 0x6a,
+  0x0b,
+]);
+
+// Honest feature detection: a VALID module is still not runnable here.
+console.log("validate valid:", WA.validate(validAdd));
+
+// compile(valid) rejects with a CompileError pointing at #6558.
+try {
+  await WA.compile(validAdd);
+  console.log("compile: resolved");
+} catch (e: any) {
+  console.log("compile rejected:", e instanceof WA.CompileError, e.name);
+  console.log("mentions api:", e.message.includes("WebAssembly.compile"));
+  console.log("mentions issue:", e.message.includes("6558"));
+}
+
+// new Module(valid) throws a CompileError pointing at #6558.
+try {
+  new WA.Module(validAdd);
+  console.log("Module: constructed");
+} catch (e: any) {
+  console.log("Module threw:", e instanceof WA.CompileError, e.name);
+  console.log("Module mentions issue:", e.message.includes("6558"));
+}
+
+// instantiate(valid) rejects; the loader pattern degrades to null and the
+// program CONTINUES (photon-node shape).
+async function lazyLoad(bytes: Uint8Array): Promise<unknown | null> {
+  try {
+    return await WA.instantiate(bytes);
+  } catch {
+    return null;
+  }
+}
+const loaded = await lazyLoad(validAdd);
+console.log("loader result:", loaded === null ? "degraded" : "loaded");
+console.log("program continues");
+EOF
+
+OUT="$TMPDIR/out.txt"
+"$PERRY" compile "$TMPDIR/graceful.ts" -o "$TMPDIR/graceful" > "$TMPDIR/compile.log" 2>&1 || {
+  echo "FAIL: perry compile failed"
+  tail -20 "$TMPDIR/compile.log"
+  exit 1
+}
+"$TMPDIR/graceful" > "$OUT" 2>&1 || {
+  echo "FAIL: compiled binary exited non-zero"
+  cat "$OUT"
+  exit 1
+}
+
+expect() {
+  if ! grep -qF "$1" "$OUT"; then
+    echo "FAIL: missing expected line: $1"
+    echo "--- actual output ---"
+    cat "$OUT"
+    exit 1
+  fi
+}
+
+expect "validate valid: false"
+expect "compile rejected: true CompileError"
+expect "mentions api: true"
+expect "mentions issue: true"
+expect "Module threw: true CompileError"
+expect "Module mentions issue: true"
+expect "loader result: degraded"
+expect "program continues"
+
+echo "PASS: WebAssembly namespace degrades gracefully (#6558 baseline)"


### PR DESCRIPTION
## Summary

Baseline stage of #6558 (WebAssembly policy for the pi / kimi-code / opencode targets): make the `WebAssembly` global **spec-shaped and gracefully failing** so lazy wasm consumers (photon-node's wasm-bindgen loader, @jsquash/webp, undici's llhttp probe) hit their own catch/fallback paths instead of crashing the process. This is deliberately **not** a WASM engine — option (3) from the issue, leaving (1)/(2) open.

### Before

The namespace was shape-only: `compile`/`compileStreaming`/`instantiateStreaming` returned `undefined` (crashing every `.then`/`await` consumer at the first property read), all constructors were shared no-op thunks returning `{}`, and the error classes were not Error-like at all.

### After (default build — no engine linked)

| Member | Behavior |
|---|---|
| `compile` / `compileStreaming` / `instantiate` / `instantiateStreaming` | Promise **rejected** with a `WebAssembly.CompileError` naming the API and pointing at #6558 — never a crash/hang/sync-throw where the spec says reject |
| `validate(bytes)` | `false` (spec-legal; the honest "can I run this here") |
| `new Module(...)` | throws `CompileError` synchronously (spec shape for invalid/unsupported) |
| `new Instance(...)` | throws `LinkError` |
| `new Table(...)` / `new Global(...)` | throw `RuntimeError` |
| `new Memory({initial})` | **genuinely works**: real zero-filled `ArrayBuffer` backing (64KiB pages), descriptor validation (TypeError/RangeError arms), working `grow(delta)` |
| `CompileError` / `LinkError` / `RuntimeError` | real error constructors — `instanceof Error`, `.message`, `.stack`, callable with or without `new` |

All five non-error constructors reject plain calls with `requires 'new'` (new.target identity check). `e instanceof WebAssembly.CompileError` works via a new `js_instanceof_dynamic` hook: the ctor is identified by its dedicated thunk `func_ptr` (GC-move-safe), the instance by its error `.name` — needed because these ctors live on the namespace (not `globalThis`) and their instances are `ErrorHeader`-backed with no prototype chain to walk.

### wasmi opt-in path (issue #76) aligned

Under the `wasm-host` feature the namespace routes `validate`/`compile`/`instantiate`/`Module`(+metadata statics) to the real host shims, and the shims now deliver spec-shaped failures:

- `js_webassembly_module_new` **throws CompileError** (was: stderr + `undefined`)
- `js_webassembly_compile` **rejects with CompileError** (was: plain string reason)
- `js_webassembly_instantiate` **rejects** with TypeError/CompileError/LinkError per failure (was: `undefined`); the MVP sync-handle success shape is unchanged

### Scope note: two spellings, two paths

Literal static spellings (`WebAssembly.compile(bytes)` written against the global) lower to the #76 HIR intrinsics and auto-link `libperry_wasm_host.a` — absent the archive that is still a hard build error with an actionable message (unchanged here; changing that is a pipeline policy call for #6558, e.g. gating the intrinsic lowering on `--enable-wasm-runtime` or synthesizing zero-returning `perry_wasm_host_*` stubs, which with this PR's error paths would degrade cleanly). The namespace VALUE path — what minified bundles and the photon loader actually evaluate through — is fully graceful with nothing at link time.

## Tests (all verified locally, macOS arm64)

- **Unit**: 7 new tests in `global_this_webassembly.rs` (member shapes, rejection state + reason branding + #6558 message, error ctor coercion, instanceof hook incl. cross-brand negatives, Memory descriptor + grow arms). Full `cargo test -p perry-runtime -- --test-threads=1` green.
- **Parity fixtures** (invalid bytes on purpose so node degrades through the same spec shapes; aliased namespace access on purpose):
  - `test-files/test_gap_6558_webassembly_graceful_fail.ts` — feature-detection pattern, member shapes, sync throw, clean rejections, photon-loader pattern. **Byte-identical to node v26** under BOTH the default and the wasm-host runtime.
  - `test-parity/node-suite/globals/webassembly-graceful-degradation.ts` — same plus streaming rejections, error-class matrix, Memory zero-fill + grow. **Byte-identical to node v26 under both runtimes.**
  - Existing `webassembly-namespace.ts`, `webassembly-module-metadata.ts` fixtures and `test_wasm_add.ts` (wasmi MVP): still identical / OK.
- **Perry-only e2e**: `tests/test_webassembly_graceful_fail.sh` — a **valid** wasm module still answers `validate → false` and rejects with the #6558 CompileError (message names the API and the issue), the lazy-loader pattern resolves `null`, the program continues and exits 0.

## Docs

`docs/src/language/limitations.md` gains a "WebAssembly (#6558)" section: WASM-dependent features degrade gracefully; full support tracked in #6558; literal-vs-namespace path split documented.

Closes nothing — #6558 stays open as the policy/parity tracker.

Issue: https://github.com/PerryTS/perry/issues/6558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a spec-shaped `WebAssembly` global with graceful behavior when no engine is available.
  - Added functional `WebAssembly.Memory`, including validation, allocation, and `grow()`.
  - Added branded `CompileError`, `LinkError`, and `RuntimeError` constructors with working `instanceof` checks.
  - WebAssembly compilation and instantiation now report typed synchronous errors or rejected Promises instead of crashing.

- **Documentation**
  - Documented WebAssembly limitations, fallback behavior, and runtime requirements.

- **Tests**
  - Added coverage for namespace APIs, graceful failures, error branding, and memory behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->