### PR TITLE
runtime: node:sqlite built-in (DatabaseSync/StatementSync) (#6561)

### DIFF
--- a/crates/perry-runtime/src/array/iter_object.rs
+++ b/crates/perry-runtime/src/array/iter_object.rs
@@ -37,6 +37,11 @@ pub const ARRAY_ITERATOR_CLASS_ID: u32 = 0xFFFF_0006;
 const KIND_VALUES: i32 = 0;
 const KIND_KEYS: i32 = 1;
 const KIND_ENTRIES: i32 = 2;
+/// Values iterator with Node's `node:sqlite` result protocol (#6561):
+/// exhaustion and `return()` yield `{ done: true, value: null }` (the
+/// array iterator yields `value: undefined`), and `return()` terminates
+/// the iterator. Produced only by `StatementSync.prototype.iterate()`.
+const KIND_VALUES_NULL_DONE: i32 = 3;
 
 /// Clean a NaN-boxed array pointer to a raw `*mut ArrayHeader`, or null.
 fn unbox_array_ptr(value: f64) -> *mut ArrayHeader {
@@ -69,6 +74,17 @@ pub fn array_values_iter(arr_f64: f64) -> f64 {
         return f64::from_bits(TAG_UNDEFINED);
     }
     unsafe { alloc_iterator(arr_ptr, KIND_VALUES) }
+}
+
+/// Values iterator whose done-result carries `value: null` and whose
+/// `return()` terminates it — the `node:sqlite` `iterate()` protocol
+/// (#6561). See [`KIND_VALUES_NULL_DONE`].
+pub fn array_values_iter_null_done(arr_f64: f64) -> f64 {
+    let arr_ptr = unbox_array_ptr(arr_f64);
+    if arr_ptr.is_null() {
+        return f64::from_bits(TAG_UNDEFINED);
+    }
+    unsafe { alloc_iterator(arr_ptr, KIND_VALUES_NULL_DONE) }
 }
 
 /// `arr.keys()` iterator — yields each index `0..length`.
@@ -413,6 +429,17 @@ pub unsafe fn dispatch_array_iterator_method(
     iter_obj: *mut ObjectHeader,
     method_name: &str,
 ) -> f64 {
+    // Field 2: iterator kind — read up front so the exhausted paths can pick
+    // the kind's done-value (`null` for KIND_VALUES_NULL_DONE, `undefined`
+    // otherwise).
+    let kind = f64::from_bits(js_object_get_field(iter_obj, 2).bits()) as i32;
+    let done_value = || {
+        if kind == KIND_VALUES_NULL_DONE {
+            JSValue::null()
+        } else {
+            JSValue::undefined()
+        }
+    };
     match method_name {
         "next" => {
             // Field 0: backing array pointer (NaN-boxed).
@@ -424,15 +451,12 @@ pub unsafe fn dispatch_array_iterator_method(
             // (test262 Array/prototype/{values,keys,entries}/iteration-mutable:
             // pushing AFTER the iterator reported done must not resurface).
             if JSValue::from_bits(backing_f64.to_bits()).is_undefined() {
-                return make_iter_result(JSValue::undefined(), true);
+                return make_iter_result(done_value(), true);
             }
             let arr_ptr = js_nanbox_get_pointer(backing_f64) as *const ArrayHeader;
             // Field 1: current index.
             let idx_field = js_object_get_field(iter_obj, 1);
             let idx = f64::from_bits(idx_field.bits()) as u32;
-            // Field 2: iterator kind.
-            let kind_field = js_object_get_field(iter_obj, 2);
-            let kind = f64::from_bits(kind_field.bits()) as i32;
 
             let len = if arr_ptr.is_null() {
                 0u32
@@ -442,7 +466,7 @@ pub unsafe fn dispatch_array_iterator_method(
 
             if idx >= len {
                 js_object_set_field(iter_obj, 0, JSValue::undefined());
-                return make_iter_result(JSValue::undefined(), true);
+                return make_iter_result(done_value(), true);
             }
 
             // Advance the stored cursor before computing the value so a
@@ -456,7 +480,7 @@ pub unsafe fn dispatch_array_iterator_method(
             };
 
             let value = match kind {
-                KIND_VALUES => JSValue::from_bits(elem.to_bits()),
+                KIND_VALUES | KIND_VALUES_NULL_DONE => JSValue::from_bits(elem.to_bits()),
                 KIND_KEYS => JSValue::number(idx as f64),
                 KIND_ENTRIES => {
                     let pair = make_pair_array(idx, elem);
@@ -473,7 +497,15 @@ pub unsafe fn dispatch_array_iterator_method(
         // `return`/`throw` are part of the iterator spec; Node's array
         // iterator inherits them from %IteratorPrototype%. Return a
         // `{ value: undefined, done: true }` shape for early-exit code.
-        "return" | "throw" => make_iter_result(JSValue::undefined(), true),
+        // KIND_VALUES_NULL_DONE (`node:sqlite` iterate()) additionally
+        // TERMINATES the iterator on `return()` — a later `.next()` stays
+        // `{ done: true, value: null }` — matching Node's sqlite iterator.
+        "return" | "throw" => {
+            if kind == KIND_VALUES_NULL_DONE {
+                js_object_set_field(iter_obj, 0, JSValue::undefined());
+            }
+            make_iter_result(done_value(), true)
+        }
         _ => f64::from_bits(TAG_UNDEFINED),
     }
 }

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -101,9 +101,9 @@ pub use self::iter_methods::{
     js_validate_array_map_callback,
 };
 pub use self::iter_object::{
-    array_entries_iter, array_keys_iter, array_values_iter, dispatch_array_iterator_method,
-    js_array_entries_iter_obj, js_array_keys_iter_obj, js_array_values_iter_obj,
-    ARRAY_ITERATOR_CLASS_ID,
+    array_entries_iter, array_keys_iter, array_values_iter, array_values_iter_null_done,
+    dispatch_array_iterator_method, js_array_entries_iter_obj, js_array_keys_iter_obj,
+    js_array_values_iter_obj, ARRAY_ITERATOR_CLASS_ID,
 };
 pub(crate) use self::iterator::is_builtin_iterator_class_id;
 pub(crate) use self::iterator::iter_bt_dump;

--- a/crates/perry-stdlib/src/common/dispatch/method_dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch/method_dispatch.rs
@@ -108,6 +108,16 @@ pub unsafe extern "C" fn js_handle_method_dispatch(
             | "close"
             | "exec"
             | "prepare"
+            // `function`/`aggregate`/`enableDefensive`/`setAuthorizer` were
+            // missing from this gate (#6561): an any-typed
+            // `db.function(...)` / `db.aggregate(...)` fell through the
+            // tower and silently no-op'd, so the SQL function was never
+            // registered and the next query failed with
+            // "no such function: <name>".
+            | "function"
+            | "aggregate"
+            | "enableDefensive"
+            | "setAuthorizer"
             | "createTagStore"
             | "createSession"
             | "applyChangeset"

--- a/crates/perry-stdlib/src/sqlite/backup.rs
+++ b/crates/perry-stdlib/src/sqlite/backup.rs
@@ -113,7 +113,14 @@ pub(crate) unsafe fn sqlite_error_value(error: NodeSqliteBackupError) -> f64 {
 
     if let Some(errcode) = error.errcode {
         let key = js_string_from_bytes(b"errcode".as_ptr(), "errcode".len() as u32);
-        js_object_set_field_by_name(err_obj, key, f64::from_bits(JSValue::int32(errcode).bits()));
+        // NUMBER-tagged, not INT32-tagged: small extended result codes can
+        // collide with registered class ids, which makes `typeof e.errcode`
+        // report "function" (see node_sqlite_integer_value, #6561).
+        js_object_set_field_by_name(
+            err_obj,
+            key,
+            f64::from_bits(JSValue::number(errcode as f64).bits()),
+        );
     }
     if let Some(errstr) = error.errstr {
         let key = js_string_from_bytes(b"errstr".as_ptr(), "errstr".len() as u32);
@@ -126,6 +133,28 @@ pub(crate) unsafe fn sqlite_error_value(error: NodeSqliteBackupError) -> f64 {
     }
 
     js_nanbox_pointer(err as i64)
+}
+
+/// Throw a synchronous `ERR_SQLITE_ERROR` carrying Node's `errcode`
+/// (extended result code) and `errstr` (`sqlite3_errstr` text) own
+/// properties, matching `node:sqlite`'s error shape (#6561). The plain
+/// [`throw_sqlite_error`] path only sets `code`; Node also exposes the
+/// SQLite result code on every SQL-level failure.
+pub(crate) unsafe fn throw_sqlite_error_ext(message: &str, errcode: i32) -> ! {
+    let error = NodeSqliteBackupError {
+        message: message.to_string(),
+        errcode: Some(errcode),
+        errstr: Some(sqlite_errstr(errcode)),
+    };
+    perry_runtime::exception::js_throw(sqlite_error_value(error))
+}
+
+/// Throw `ERR_SQLITE_ERROR` for the connection's current error state:
+/// `sqlite3_errmsg` message + `sqlite3_extended_errcode` code (#6561).
+pub(crate) unsafe fn throw_sqlite_error_from_conn(conn: &Connection) -> ! {
+    let errcode = ffi::sqlite3_extended_errcode(conn.handle());
+    let message = sqlite_error_message(conn);
+    throw_sqlite_error_ext(&message, errcode)
 }
 
 pub(crate) fn backup_path_type_error(name: &str, value: f64) -> ! {
@@ -300,12 +329,12 @@ pub(crate) unsafe fn call_backup_progress(
     js_object_set_field_by_name(
         info,
         total_key,
-        f64::from_bits(JSValue::int32(total_pages).bits()),
+        f64::from_bits(JSValue::number(total_pages as f64).bits()),
     );
     js_object_set_field_by_name(
         info,
         remaining_key,
-        f64::from_bits(JSValue::int32(remaining_pages).bits()),
+        f64::from_bits(JSValue::number(remaining_pages as f64).bits()),
     );
     js_closure_call1(
         progress,

--- a/crates/perry-stdlib/src/sqlite/bind.rs
+++ b/crates/perry-stdlib/src/sqlite/bind.rs
@@ -105,7 +105,7 @@ pub(crate) unsafe fn prepare_node_raw_statement(conn: &Connection, sql: &str) ->
         std::ptr::null_mut(),
     );
     if rc != ffi::SQLITE_OK {
-        throw_sqlite_error(&sqlite_error_message(conn));
+        throw_sqlite_error_from_conn(conn);
     }
     RawNodeStatement { ptr: raw }
 }
@@ -143,7 +143,7 @@ pub(crate) fn bigint_to_i64(ptr: *const BigIntHeader) -> Option<i64> {
 
 pub(crate) unsafe fn node_sqlite_bind_error(conn: &Connection, rc: c_int) {
     if rc != ffi::SQLITE_OK {
-        throw_sqlite_error(&sqlite_error_message(conn));
+        throw_sqlite_error_from_conn(conn);
     }
 }
 
@@ -172,23 +172,19 @@ pub(crate) unsafe fn bind_node_sqlite_value(
             ffi::sqlite3_bind_text(raw_stmt, index, data_ptr, len, ffi::SQLITE_TRANSIENT())
         }
     } else if js.is_int32() {
-        ffi::sqlite3_bind_int64(raw_stmt, index, js.as_int32() as i64)
+        // Node binds every JS number via sqlite3_bind_double — even
+        // integral values (a column with no affinity stores them as REAL,
+        // and `stmt.expandedSQL` renders `5.0`). Match that instead of
+        // promoting integral numbers to SQLite INTEGERs (#6561); only
+        // BigInt binds as INTEGER.
+        ffi::sqlite3_bind_double(raw_stmt, index, js.as_int32() as f64)
     } else if js.is_bigint() {
         let Some(value) = bigint_to_i64(js.as_bigint_ptr()) else {
             throw_arg_value("BigInt value is too large to bind.");
         };
         ffi::sqlite3_bind_int64(raw_stmt, index, value)
     } else if js.is_number() {
-        let number = js.as_number();
-        if number.is_finite()
-            && number.fract() == 0.0
-            && number >= i64::MIN as f64
-            && number <= i64::MAX as f64
-        {
-            ffi::sqlite3_bind_int64(raw_stmt, index, number as i64)
-        } else {
-            ffi::sqlite3_bind_double(raw_stmt, index, number)
-        }
+        ffi::sqlite3_bind_double(raw_stmt, index, js.as_number())
     } else {
         let raw = raw_addr_from_value(value);
         if raw != 0 && is_registered_buffer(raw) {
@@ -337,7 +333,10 @@ pub(crate) unsafe fn bind_node_sqlite_params(
 
     let positional_count = args.len().saturating_sub(positional_start);
     if positional_count > anonymous_indices.len() {
-        throw_sqlite_error("column index out of range");
+        // Node raises ERR_SQLITE_ERROR with errcode 25 (SQLITE_RANGE) when
+        // more anonymous values are supplied than the statement has
+        // anonymous parameters (#6561).
+        throw_sqlite_error_ext("column index out of range", ffi::SQLITE_RANGE);
     }
     for (offset, index) in anonymous_indices.into_iter().enumerate() {
         if let Some(value) = args.get(positional_start + offset).copied() {
@@ -367,11 +366,14 @@ pub(crate) unsafe fn node_sqlite_integer_value(value: i64, read_bigints: bool) -
             value
         ));
     }
-    if (i32::MIN as i64..=i32::MAX as i64).contains(&value) {
-        JSValue::int32(value as i32)
-    } else {
-        JSValue::number(value as f64)
-    }
+    // Always hand out a NUMBER-tagged double, never an INT32-tagged value
+    // (#6561). Node's node:sqlite returns plain JS numbers, and perry's
+    // INT32 tag shares its storage shape with `Expr::ClassRef`
+    // (`INT32_TAG | class_id`, see #618): when a small integer like a
+    // rowid `1` escapes into an any-typed context, `js_value_typeof`
+    // cannot tell it apart from a registered class id and reports
+    // "function" instead of "number".
+    JSValue::number(value as f64)
 }
 
 pub(crate) unsafe fn node_sqlite_column_value(
@@ -829,17 +831,17 @@ where
         throw_invalid_state("statement has been finalized");
     }
     let db = get_handle::<NodeSqliteDbHandle>(stmt.db_handle)
-        .unwrap_or_else(|| throw_invalid_state("Database is not open"));
+        .unwrap_or_else(|| throw_invalid_state("database is not open"));
     let conn_ptr = {
         let conn_guard = db
             .conn
             .lock()
-            .unwrap_or_else(|_| throw_invalid_state("Database is not open"));
+            .unwrap_or_else(|_| throw_invalid_state("database is not open"));
         if let Some(conn) = conn_guard.as_ref() {
             conn as *const Connection
         } else {
             drop(conn_guard);
-            throw_invalid_state("Database is not open");
+            throw_invalid_state("database is not open");
         }
     };
     let conn = &*conn_ptr;

--- a/crates/perry-stdlib/src/sqlite/connection.rs
+++ b/crates/perry-stdlib/src/sqlite/connection.rs
@@ -113,36 +113,23 @@ where
     F: FnOnce(&Connection) -> R,
 {
     let db = get_handle::<NodeSqliteDbHandle>(db_handle)
-        .unwrap_or_else(|| throw_invalid_state("Database is not open"));
+        .unwrap_or_else(|| throw_invalid_state("database is not open"));
     let conn_ptr = {
         let conn = db
             .conn
             .lock()
-            .unwrap_or_else(|_| throw_invalid_state("Database is not open"));
+            .unwrap_or_else(|_| throw_invalid_state("database is not open"));
         if let Some(conn) = conn.as_ref() {
             conn as *const Connection
         } else {
             drop(conn);
-            throw_invalid_state("Database is not open")
+            throw_invalid_state("database is not open")
         }
     };
     f(&*conn_ptr)
 }
 
 pub(crate) unsafe fn ensure_open_node_database(db_handle: Handle) {
-    let db = get_handle::<NodeSqliteDbHandle>(db_handle)
-        .unwrap_or_else(|| throw_invalid_state("Database is not open"));
-    let conn = db
-        .conn
-        .lock()
-        .unwrap_or_else(|_| throw_invalid_state("Database is not open"));
-    if conn.is_none() {
-        drop(conn);
-        throw_invalid_state("Database is not open");
-    }
-}
-
-pub(crate) unsafe fn ensure_open_node_database_lowercase(db_handle: Handle) {
     let db = get_handle::<NodeSqliteDbHandle>(db_handle)
         .unwrap_or_else(|| throw_invalid_state("database is not open"));
     let conn = db

--- a/crates/perry-stdlib/src/sqlite/dispatch.rs
+++ b/crates/perry-stdlib/src/sqlite/dispatch.rs
@@ -380,7 +380,7 @@ pub unsafe fn dispatch_node_sqlite_limits_property(
     Some(with_open_node_connection(limits.db_handle, |conn| {
         // rusqlite 0.37: Connection::limit is now fallible. The category was
         // already validated by node_sqlite_limit above, so it won't error here.
-        JSValue::int32(conn.limit(limit).unwrap_or(0))
+        JSValue::number(conn.limit(limit).unwrap_or(0) as f64)
     }))
     .map(|value| f64::from_bits(value.bits()))
 }

--- a/crates/perry-stdlib/src/sqlite/node_db.rs
+++ b/crates/perry-stdlib/src/sqlite/node_db.rs
@@ -110,12 +110,45 @@ pub unsafe extern "C" fn js_node_sqlite_backup(
     }
 }
 
+/// Validate the `DatabaseSync` `path` argument per Node: a string,
+/// Uint8Array/Buffer, or `file:` URL, none of which may contain null
+/// bytes — with Node's exact `ERR_INVALID_ARG_TYPE` message (#6561).
+pub(crate) unsafe fn node_sqlite_database_path(value: f64) -> String {
+    const PATH_TYPE_MSG: &str =
+        "The \"path\" argument must be a string, Uint8Array, or URL without null bytes.";
+    let js = value_from_f64(value);
+    let path = if js.is_any_string() {
+        let ptr = js_get_string_pointer_unified(value) as *const StringHeader;
+        string_from_header(ptr).unwrap_or_else(|| throw_type(PATH_TYPE_MSG))
+    } else if let Some(bytes) = bytes_from_path_like(value) {
+        if bytes.contains(&0) {
+            throw_type(PATH_TYPE_MSG);
+        }
+        String::from_utf8_lossy(&bytes).into_owned()
+    } else if js.is_pointer() {
+        // URL object — accept `file:` URLs, decoding the percent-encoded
+        // pathname like Node's `fileURLToPath`.
+        let protocol = string_from_jsvalue(object_field(value, "protocol")).unwrap_or_default();
+        let pathname = string_from_jsvalue(object_field(value, "pathname")).unwrap_or_default();
+        if protocol != "file:" || pathname.is_empty() {
+            throw_type(PATH_TYPE_MSG);
+        }
+        percent_decode_pathname(&pathname)
+    } else {
+        throw_type(PATH_TYPE_MSG);
+    };
+    if path.as_bytes().contains(&0) {
+        throw_type(PATH_TYPE_MSG);
+    }
+    path
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn js_node_sqlite_database_sync_new(
     path_value: f64,
     options_value: f64,
 ) -> Handle {
-    let path = string_from_value(path_value, "path");
+    let path = node_sqlite_database_path(path_value);
     let options = parse_node_sqlite_options(options_value);
     let open = options.open;
     let handle = register_handle(NodeSqliteDbHandle {
@@ -147,20 +180,24 @@ pub unsafe extern "C" fn js_node_sqlite_database_sync_new(
 #[no_mangle]
 pub unsafe extern "C" fn js_node_sqlite_database_sync_open(db_handle: Handle) -> i32 {
     let db = get_handle::<NodeSqliteDbHandle>(db_handle)
-        .unwrap_or_else(|| throw_invalid_state("Database is not open"));
+        .unwrap_or_else(|| throw_invalid_state("database is not open"));
     {
         let conn = db
             .conn
             .lock()
-            .unwrap_or_else(|_| throw_invalid_state("Database is not open"));
+            .unwrap_or_else(|_| throw_invalid_state("database is not open"));
         if conn.is_some() {
             drop(conn);
-            throw_invalid_state("Database is already open");
+            throw_invalid_state("database is already open");
         }
     }
     let opened = match open_node_sqlite_connection(db) {
         Ok(opened) => opened,
-        Err(err) => throw_sqlite_error(&err.to_string()),
+        // Carry the SQLite result code through (`errcode`/`errstr`), e.g.
+        // errcode 14 "unable to open database file" — matching Node (#6561).
+        Err(err) => {
+            perry_runtime::exception::js_throw(sqlite_error_value(sqlite_error_from_rusqlite(err)))
+        }
     };
     if let Err(err) = configure_node_sqlite_defensive(&opened, db.defensive.load(Ordering::Relaxed))
     {
@@ -175,7 +212,7 @@ pub unsafe extern "C" fn js_node_sqlite_database_sync_open(db_handle: Handle) ->
     let mut conn = db
         .conn
         .lock()
-        .unwrap_or_else(|_| throw_invalid_state("Database is not open"));
+        .unwrap_or_else(|_| throw_invalid_state("database is not open"));
     *conn = Some(opened);
     1
 }
@@ -183,15 +220,15 @@ pub unsafe extern "C" fn js_node_sqlite_database_sync_open(db_handle: Handle) ->
 #[no_mangle]
 pub unsafe extern "C" fn js_node_sqlite_database_sync_close(db_handle: Handle) -> i32 {
     let db = get_handle::<NodeSqliteDbHandle>(db_handle)
-        .unwrap_or_else(|| throw_invalid_state("Database is not open"));
+        .unwrap_or_else(|| throw_invalid_state("database is not open"));
     {
         let conn = db
             .conn
             .lock()
-            .unwrap_or_else(|_| throw_invalid_state("Database is not open"));
+            .unwrap_or_else(|_| throw_invalid_state("database is not open"));
         if conn.is_none() {
             drop(conn);
-            throw_invalid_state("Database is not open");
+            throw_invalid_state("database is not open");
         }
     }
     finalize_node_sqlite_statements(db);
@@ -202,7 +239,7 @@ pub unsafe extern "C" fn js_node_sqlite_database_sync_close(db_handle: Handle) -
     let mut conn = db
         .conn
         .lock()
-        .unwrap_or_else(|_| throw_invalid_state("Database is not open"));
+        .unwrap_or_else(|_| throw_invalid_state("database is not open"));
     if conn.is_some() {
         *conn = None;
     }
@@ -247,7 +284,7 @@ pub unsafe extern "C" fn js_node_sqlite_database_sync_exec(
     let result = with_open_node_connection(db_handle, |conn| node_sqlite_exec_batch(conn, &sql));
     match result {
         Ok(_) => 1,
-        Err(err) => throw_sqlite_error(&err),
+        Err((message, errcode)) => throw_sqlite_error_ext(&message, errcode),
     }
 }
 
@@ -265,7 +302,7 @@ pub(crate) unsafe fn parse_statement_options(
         };
     }
     if js.is_null() || !is_object_like(options_value) {
-        throw_type("The \"options\" argument must be an object");
+        throw_type("The \"options\" argument must be an object.");
     }
     NodeSqliteStmtOptions {
         read_bigints: bool_option(options_value, "readBigInts", db.read_bigints),
@@ -292,7 +329,7 @@ pub unsafe extern "C" fn js_node_sqlite_database_sync_prepare(
     ensure_open_node_database(db_handle);
     let sql = string_from_value(sql_value, "sql");
     let db = get_handle::<NodeSqliteDbHandle>(db_handle)
-        .unwrap_or_else(|| throw_invalid_state("Database is not open"));
+        .unwrap_or_else(|| throw_invalid_state("database is not open"));
     let options = parse_statement_options(db, options_value);
     let expanded_sql = with_open_node_connection(db_handle, |conn| {
         let raw = prepare_node_raw_statement(conn, &sql);
@@ -403,8 +440,7 @@ pub unsafe extern "C" fn js_node_sqlite_database_sync_function(
         if unregister_node_sqlite_custom_function(info) {
             drop(Box::from_raw(info));
         }
-        let message = with_open_node_connection(db_handle, |conn| sqlite_error_message(conn));
-        throw_sqlite_error(&message);
+        with_open_node_connection(db_handle, |conn| throw_sqlite_error_from_conn(conn))
     }
     1
 }
@@ -485,8 +521,7 @@ pub unsafe extern "C" fn js_node_sqlite_database_sync_aggregate(
         if unregister_node_sqlite_custom_aggregate(aggregate) {
             drop(Box::from_raw(aggregate));
         }
-        let message = with_open_node_connection(db_handle, |conn| sqlite_error_message(conn));
-        throw_sqlite_error(&message);
+        with_open_node_connection(db_handle, |conn| throw_sqlite_error_from_conn(conn))
     }
     1
 }
@@ -554,7 +589,7 @@ pub(crate) unsafe extern "C" fn node_sqlite_authorizer_callback(
         return ffi::SQLITE_OK;
     };
     let args = [
-        f64_from_jsvalue(JSValue::int32(action_code)),
+        f64_from_jsvalue(JSValue::number(action_code as f64)),
         f64_from_jsvalue(sqlite_c_string_value(arg1)),
         f64_from_jsvalue(sqlite_c_string_value(arg2)),
         f64_from_jsvalue(sqlite_c_string_value(db_name)),
@@ -615,11 +650,10 @@ pub unsafe extern "C" fn js_node_sqlite_database_sync_set_authorizer(
         )
     });
     if rc != ffi::SQLITE_OK {
-        let message = with_open_node_connection(db_handle, |conn| sqlite_error_message(conn));
-        throw_sqlite_error(&message);
+        with_open_node_connection(db_handle, |conn| throw_sqlite_error_from_conn(conn))
     }
     let db = get_handle::<NodeSqliteDbHandle>(db_handle)
-        .unwrap_or_else(|| throw_invalid_state("Database is not open"));
+        .unwrap_or_else(|| throw_invalid_state("database is not open"));
     if let Ok(mut stored) = db.authorizer_callback.lock() {
         *stored = callback;
     }

--- a/crates/perry-stdlib/src/sqlite/node_stmt_session.rs
+++ b/crates/perry-stdlib/src/sqlite/node_stmt_session.rs
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn js_node_sqlite_statement_sync_run(
             match rc {
                 ffi::SQLITE_ROW => continue,
                 ffi::SQLITE_DONE => break,
-                _ => throw_sqlite_error(&sqlite_error_message(conn)),
+                _ => throw_sqlite_error_from_conn(conn),
             }
         }
         let read_bigints = stmt.read_bigints.load(Ordering::Relaxed);
@@ -87,7 +87,7 @@ pub unsafe extern "C" fn js_node_sqlite_statement_sync_get(
         match ffi::sqlite3_step(raw_stmt) {
             ffi::SQLITE_ROW => f64_from_jsvalue(node_sqlite_row_value(stmt, raw_stmt)),
             ffi::SQLITE_DONE => undefined_f64(),
-            _ => throw_sqlite_error(&sqlite_error_message(conn)),
+            _ => throw_sqlite_error_from_conn(conn),
         }
     })
 }
@@ -105,7 +105,7 @@ pub unsafe extern "C" fn js_node_sqlite_statement_sync_all(
                     rows = js_array_push(rows, node_sqlite_row_value(stmt, raw_stmt));
                 }
                 ffi::SQLITE_DONE => break,
-                _ => throw_sqlite_error(&sqlite_error_message(conn)),
+                _ => throw_sqlite_error_from_conn(conn),
             }
         }
         rows
@@ -117,8 +117,12 @@ pub unsafe extern "C" fn js_node_sqlite_statement_sync_iterate(
     stmt_handle: Handle,
     params_arr: *const ArrayHeader,
 ) -> f64 {
+    // Rows are materialized eagerly (a known divergence from Node's lazy
+    // stepping — see the module TODO), but the iterator protocol matches
+    // Node (#6561): exhaustion and `return()` produce
+    // `{ done: true, value: null }`, and `return()` terminates iteration.
     let rows = js_node_sqlite_statement_sync_all(stmt_handle, params_arr);
-    perry_runtime::array::array_values_iter(f64_from_jsvalue(JSValue::array_ptr(rows)))
+    perry_runtime::array::array_values_iter_null_done(f64_from_jsvalue(JSValue::array_ptr(rows)))
 }
 
 #[no_mangle]
@@ -297,12 +301,13 @@ pub(crate) unsafe fn sqlite_session_blob(
     );
     if rc != ffi::SQLITE_OK {
         let message = sqlite_error_message(conn);
+        let errcode = ffi::sqlite3_extended_errcode(conn.handle());
         drop(session);
         drop(conn_guard);
         if !data.is_null() {
             ffi::sqlite3_free(data);
         }
-        throw_sqlite_error(&message);
+        throw_sqlite_error_ext(&message, errcode);
     }
 
     let len = len.max(0) as usize;
@@ -408,7 +413,7 @@ pub unsafe extern "C" fn js_node_sqlite_database_sync_create_session(
     validate_optional_object(options_value);
     let db_name = string_option(options_value, "db", Some("main")).unwrap_or_else(|| "main".into());
     let table_name = string_option(options_value, "table", None);
-    ensure_open_node_database_lowercase(db_handle);
+    ensure_open_node_database(db_handle);
 
     let db_name_c = CString::new(db_name)
         .unwrap_or_else(|_| throw_type("The \"options.db\" argument must not contain null bytes"));
@@ -433,8 +438,9 @@ pub unsafe extern "C" fn js_node_sqlite_database_sync_create_session(
     let rc = ffi::sqlite3session_create(conn.handle(), db_name_c.as_ptr(), &mut raw_session);
     if rc != ffi::SQLITE_OK {
         let message = sqlite_error_message(conn);
+        let errcode = ffi::sqlite3_extended_errcode(conn.handle());
         drop(conn_guard);
-        throw_sqlite_error(&message);
+        throw_sqlite_error_ext(&message, errcode);
     }
     let table_ptr = table_name_c
         .as_ref()
@@ -443,9 +449,10 @@ pub unsafe extern "C" fn js_node_sqlite_database_sync_create_session(
     let rc = ffi::sqlite3session_attach(raw_session, table_ptr);
     if rc != ffi::SQLITE_OK {
         let message = sqlite_error_message(conn);
+        let errcode = ffi::sqlite3_extended_errcode(conn.handle());
         ffi::sqlite3session_delete(raw_session);
         drop(conn_guard);
-        throw_sqlite_error(&message);
+        throw_sqlite_error_ext(&message, errcode);
     }
     drop(conn_guard);
 
@@ -491,7 +498,10 @@ pub(crate) unsafe extern "C" fn node_sqlite_changeset_conflict(
     let Some(on_conflict) = ctx.on_conflict else {
         return ffi::SQLITE_CHANGESET_ABORT;
     };
-    let result = js_closure_call1(on_conflict, f64::from_bits(JSValue::int32(conflict).bits()));
+    let result = js_closure_call1(
+        on_conflict,
+        f64::from_bits(JSValue::number(conflict as f64).bits()),
+    );
     let result = value_from_f64(result);
     if result.is_int32() {
         return result.as_int32() as c_int;
@@ -515,7 +525,7 @@ pub unsafe extern "C" fn js_node_sqlite_database_sync_apply_changeset(
     changeset_value: f64,
     options_value: f64,
 ) -> f64 {
-    ensure_open_node_database_lowercase(db_handle);
+    ensure_open_node_database(db_handle);
     let changeset = changeset_bytes_from_value(changeset_value);
     validate_optional_object(options_value);
     let filter = function_option(options_value, "filter").and_then(closure_ptr_from_value);
@@ -552,8 +562,9 @@ pub unsafe extern "C" fn js_node_sqlite_database_sync_apply_changeset(
         ffi::SQLITE_ABORT => bool_f64(false),
         _ => {
             let message = sqlite_error_message(conn);
+            let errcode = ffi::sqlite3_extended_errcode(conn.handle());
             drop(conn_guard);
-            throw_sqlite_error(&message);
+            throw_sqlite_error_ext(&message, errcode);
         }
     }
 }
@@ -572,7 +583,7 @@ pub unsafe extern "C" fn js_node_sqlite_database_sync_enable_load_extension(
     };
 
     let db = get_handle::<NodeSqliteDbHandle>(db_handle)
-        .unwrap_or_else(|| throw_invalid_state("Database is not open"));
+        .unwrap_or_else(|| throw_invalid_state("database is not open"));
     if allow && !db.allow_load_extension {
         throw_invalid_state(
             "Cannot enable extension loading because it was disabled at database creation.",
@@ -582,7 +593,7 @@ pub unsafe extern "C" fn js_node_sqlite_database_sync_enable_load_extension(
     let conn = db
         .conn
         .lock()
-        .unwrap_or_else(|_| throw_invalid_state("Database is not open"));
+        .unwrap_or_else(|_| throw_invalid_state("database is not open"));
     let config_error = conn
         .as_ref()
         .and_then(|conn| configure_node_sqlite_load_extension(conn, allow).err());
@@ -600,15 +611,15 @@ pub unsafe extern "C" fn js_node_sqlite_database_sync_load_extension(
     path_value: f64,
 ) -> i32 {
     let db = get_handle::<NodeSqliteDbHandle>(db_handle)
-        .unwrap_or_else(|| throw_invalid_state("Database is not open"));
+        .unwrap_or_else(|| throw_invalid_state("database is not open"));
     {
         let conn = db
             .conn
             .lock()
-            .unwrap_or_else(|_| throw_invalid_state("Database is not open"));
+            .unwrap_or_else(|_| throw_invalid_state("database is not open"));
         if conn.is_none() {
             drop(conn);
-            throw_invalid_state("Database is not open");
+            throw_invalid_state("database is not open");
         }
     }
 
@@ -622,10 +633,10 @@ pub unsafe extern "C" fn js_node_sqlite_database_sync_load_extension(
     let conn_guard = db
         .conn
         .lock()
-        .unwrap_or_else(|_| throw_invalid_state("Database is not open"));
+        .unwrap_or_else(|_| throw_invalid_state("database is not open"));
     let Some(conn) = conn_guard.as_ref() else {
         drop(conn_guard);
-        throw_invalid_state("Database is not open");
+        throw_invalid_state("database is not open");
     };
     let mut error_message = std::ptr::null_mut();
     let rc = ffi::sqlite3_load_extension(
@@ -684,11 +695,11 @@ pub unsafe extern "C" fn js_node_sqlite_database_sync_location(
 pub unsafe extern "C" fn js_node_sqlite_database_sync_limits(db_handle: Handle) -> Handle {
     ensure_open_node_database(db_handle);
     let db = get_handle::<NodeSqliteDbHandle>(db_handle)
-        .unwrap_or_else(|| throw_invalid_state("Database is not open"));
+        .unwrap_or_else(|| throw_invalid_state("database is not open"));
     let mut limits_handle = db
         .limits_handle
         .lock()
-        .unwrap_or_else(|_| throw_invalid_state("Database is not open"));
+        .unwrap_or_else(|_| throw_invalid_state("database is not open"));
     if let Some(handle) = *limits_handle {
         return handle;
     }

--- a/crates/perry-stdlib/src/sqlite/node_tag_store.rs
+++ b/crates/perry-stdlib/src/sqlite/node_tag_store.rs
@@ -96,7 +96,7 @@ pub(crate) unsafe fn node_sqlite_tag_store_statement(
 ) -> (Handle, Vec<f64>, bool) {
     let store = get_handle::<NodeSqliteTagStoreHandle>(tag_store_handle)
         .unwrap_or_else(|| throw_invalid_state("SQLTagStore is not open"));
-    ensure_open_node_database_lowercase(store.db_handle);
+    ensure_open_node_database(store.db_handle);
 
     let (sql, values) = node_sqlite_tag_store_template_args(args_arr);
     if store.capacity == 0 {
@@ -158,7 +158,7 @@ pub unsafe extern "C" fn js_node_sqlite_database_sync_create_tag_store(
     db_handle: Handle,
     max_size_value: f64,
 ) -> Handle {
-    ensure_open_node_database_lowercase(db_handle);
+    ensure_open_node_database(db_handle);
     register_handle(NodeSqliteTagStoreHandle {
         db_handle,
         capacity: node_sqlite_tag_store_capacity(max_size_value),

--- a/crates/perry-stdlib/src/sqlite/options.rs
+++ b/crates/perry-stdlib/src/sqlite/options.rs
@@ -98,9 +98,19 @@ pub(crate) fn throw_load_sqlite_extension(message: &str) -> ! {
     perry_runtime::fs::validate::throw_error_with_code(message, "ERR_LOAD_SQLITE_EXTENSION")
 }
 
-pub(crate) unsafe fn node_sqlite_exec_batch(conn: &Connection, sql: &str) -> Result<(), String> {
-    let c_sql =
-        CString::new(sql).map_err(|_| "SQL string must not contain null bytes".to_string())?;
+/// Run a multi-statement SQL batch. On failure returns the error message
+/// plus the extended result code so callers can raise Node-shaped
+/// `ERR_SQLITE_ERROR`s carrying `errcode`/`errstr` (#6561).
+pub(crate) unsafe fn node_sqlite_exec_batch(
+    conn: &Connection,
+    sql: &str,
+) -> Result<(), (String, i32)> {
+    let c_sql = CString::new(sql).map_err(|_| {
+        (
+            "SQL string must not contain null bytes".to_string(),
+            ffi::SQLITE_MISUSE,
+        )
+    })?;
     let mut error_message = std::ptr::null_mut();
     let rc = ffi::sqlite3_exec(
         conn.handle(),
@@ -113,6 +123,7 @@ pub(crate) unsafe fn node_sqlite_exec_batch(conn: &Connection, sql: &str) -> Res
         return Ok(());
     }
 
+    let errcode = ffi::sqlite3_extended_errcode(conn.handle());
     let message = if error_message.is_null() {
         CStr::from_ptr(ffi::sqlite3_errmsg(conn.handle()))
             .to_string_lossy()
@@ -122,7 +133,7 @@ pub(crate) unsafe fn node_sqlite_exec_batch(conn: &Connection, sql: &str) -> Res
         ffi::sqlite3_free(error_message.cast());
         message
     };
-    Err(message)
+    Err((message, errcode))
 }
 
 pub(crate) unsafe fn string_from_value(value: f64, name: &str) -> String {
@@ -290,7 +301,7 @@ pub(crate) unsafe fn parse_node_sqlite_options(options_value: f64) -> NodeSqlite
         return options;
     }
     if js.is_null() || !is_object_like(options_value) {
-        throw_type("The \"options\" argument must be an object");
+        throw_type("The \"options\" argument must be an object.");
     }
 
     options.open = bool_option(options_value, "open", options.open);
@@ -325,7 +336,7 @@ pub(crate) unsafe fn parse_node_sqlite_options(options_value: f64) -> NodeSqlite
     if !limits.is_undefined() {
         let limits_value = f64::from_bits(limits.bits());
         if limits.is_null() || !is_object_like(limits_value) {
-            throw_type("The \"limits\" option must be an object");
+            throw_type("The \"options.limits\" argument must be an object.");
         }
         for name in [
             "length",

--- a/test-parity/node-suite/sqlite/database-sync/exec-errors.ts
+++ b/test-parity/node-suite/sqlite/database-sync/exec-errors.ts
@@ -1,0 +1,47 @@
+// parity-node-argv: --experimental-sqlite
+// node:sqlite error-shape conformance (#6561): ERR_SQLITE_ERROR errors carry
+// `errcode` (extended result code) and `errstr` (sqlite3_errstr text) own
+// properties in addition to `code`/`message`.
+import { DatabaseSync } from "node:sqlite";
+
+function shape(error) {
+  return [
+    `name=${error.name}`,
+    `code=${error.code}`,
+    `errcode=${error.errcode} (${typeof error.errcode})`,
+    `errstr=${error.errstr}`,
+    `msg=${String(error.message).split("\n")[0]}`,
+  ].join(" | ");
+}
+
+function reportThrow(label, fn) {
+  try {
+    fn();
+    console.log(label, "NO-THROW");
+  } catch (error) {
+    console.log(label, shape(error));
+  }
+}
+
+const db = new DatabaseSync(":memory:");
+db.exec("CREATE TABLE t(a UNIQUE); INSERT INTO t VALUES (1);");
+console.log(
+  "exec multi count:",
+  (db.prepare("SELECT COUNT(*) AS n FROM t").get() as any).n
+);
+
+reportThrow("syntax error", () => db.exec("NOT VALID SQL"));
+reportThrow("prepare missing table", () => db.prepare("SELECT * FROM missing_table"));
+reportThrow("unique violation", () => db.prepare("INSERT INTO t VALUES (?)").run(1));
+
+const fkdb = new DatabaseSync(":memory:");
+fkdb.exec("CREATE TABLE p(id INTEGER PRIMARY KEY); CREATE TABLE c(pid REFERENCES p(id));");
+reportThrow("fk violation (default on)", () => fkdb.exec("INSERT INTO c VALUES (99)"));
+fkdb.close();
+
+const nofk = new DatabaseSync(":memory:", { enableForeignKeyConstraints: false });
+nofk.exec("CREATE TABLE p(id INTEGER PRIMARY KEY); CREATE TABLE c(pid REFERENCES p(id));");
+reportThrow("fk violation (disabled)", () => nofk.exec("INSERT INTO c VALUES (99)"));
+nofk.close();
+
+db.close();

--- a/test-parity/node-suite/sqlite/database-sync/functions-aggregates.ts
+++ b/test-parity/node-suite/sqlite/database-sync/functions-aggregates.ts
@@ -1,0 +1,100 @@
+// parity-node-argv: --experimental-sqlite
+// node:sqlite user-defined functions and aggregates (#6561), including the
+// dynamically-dispatched (any-typed receiver, closure context) paths that
+// previously fell through perry's method tower and silently no-op'd.
+import { DatabaseSync } from "node:sqlite";
+
+function report(label, fn) {
+  try {
+    console.log(label, "OK", fn());
+  } catch (error) {
+    console.log(label, "THROW", `${error.name}:${error.code}:${String(error.message).split("\n")[0]}`);
+  }
+}
+
+report("function simple", () => {
+  const db = new DatabaseSync(":memory:");
+  db.function("double_it", (x: any) => x * 2);
+  const v = (db.prepare("SELECT double_it(21) AS v").get() as any).v;
+  db.close();
+  return v;
+});
+
+report("function varargs option", () => {
+  const db = new DatabaseSync(":memory:");
+  db.function("addall", { varargs: true }, (...args: number[]) =>
+    args.reduce((acc, value) => acc + value, 0)
+  );
+  const v = (db.prepare("SELECT addall(1,2,3,4) AS v").get() as any).v;
+  db.close();
+  return v;
+});
+
+report("function deterministic option", () => {
+  const db = new DatabaseSync(":memory:");
+  db.function("three", { deterministic: true }, () => 3);
+  const v = (db.prepare("SELECT three() AS v").get() as any).v;
+  db.close();
+  return v;
+});
+
+report("aggregate", () => {
+  const db = new DatabaseSync(":memory:");
+  db.exec("CREATE TABLE t(a); INSERT INTO t VALUES (1),(2),(3)");
+  db.aggregate("sumsq", {
+    start: 0,
+    step: (acc: number, value: number) => acc + value * value,
+  });
+  const v = (db.prepare("SELECT sumsq(a) AS v FROM t").get() as any).v;
+  db.close();
+  return v;
+});
+
+report("aggregate with result callback", () => {
+  const db = new DatabaseSync(":memory:");
+  db.exec("CREATE TABLE t(a); INSERT INTO t VALUES (2),(4)");
+  db.aggregate("avg2", {
+    start: () => ({ sum: 0, count: 0 } as any),
+    step: (acc: any, value: number) => ({ sum: acc.sum + value, count: acc.count + 1 }),
+    result: (acc: any) => (acc.count === 0 ? null : acc.sum / acc.count),
+  });
+  const v = (db.prepare("SELECT avg2(a) AS v FROM t").get() as any).v;
+  db.close();
+  return v;
+});
+
+// Regression: any-typed receiver inside a closure goes through the dynamic
+// method tower; `function`/`aggregate` were missing from its name gate.
+report("function via any-typed receiver", () => {
+  const db = new DatabaseSync(":memory:");
+  (db as any).function("addall2", { varargs: true }, (...args: number[]) =>
+    args.reduce((acc, value) => acc + value, 0)
+  );
+  const v = (db.prepare("SELECT addall2(5,6) AS v").get() as any).v;
+  db.close();
+  return v;
+});
+
+report("aggregate via any-typed receiver", () => {
+  const db = new DatabaseSync(":memory:");
+  db.exec("CREATE TABLE t(a); INSERT INTO t VALUES (1),(2)");
+  (db as any).aggregate("sumsq2", {
+    start: 0,
+    step: (acc: number, value: number) => acc + value * value,
+  });
+  const v = (db.prepare("SELECT sumsq2(a) AS v FROM t").get() as any).v;
+  db.close();
+  return v;
+});
+
+report("function receives sqlite values", () => {
+  const db = new DatabaseSync(":memory:");
+  db.exec("CREATE TABLE t(a INTEGER, b TEXT, c REAL)");
+  db.exec("INSERT INTO t VALUES (7, 'x', 1.5)");
+  db.function("kinds", { varargs: true }, (...args: any[]) =>
+    args.map((value) => `${typeof value}:${String(value)}`).join("|")
+  );
+  const v = (db.prepare("SELECT kinds(a, b, c, NULL) AS v FROM t").get() as any).v;
+  db.close();
+  return v;
+});

--- a/test-parity/node-suite/sqlite/database-sync/lifecycle.ts
+++ b/test-parity/node-suite/sqlite/database-sync/lifecycle.ts
@@ -1,0 +1,60 @@
+// parity-node-argv: --experimental-sqlite
+// node:sqlite DatabaseSync lifecycle conformance (#6561): constructor
+// validation, open/close state machine, isOpen/isTransaction, location().
+import { DatabaseSync } from "node:sqlite";
+
+function summarizeError(error) {
+  return `${error.name}:${error.code || "nocode"}:${String(error.message).split("\n")[0]}`;
+}
+
+function report(label, fn) {
+  try {
+    const value = fn();
+    console.log(label, "OK", value === undefined ? "undefined" : String(value));
+  } catch (error) {
+    console.log(label, "THROW", summarizeError(error));
+  }
+}
+
+const db = new DatabaseSync(":memory:");
+console.log("fresh isOpen:", db.isOpen, "isTransaction:", db.isTransaction);
+console.log("location:", db.location());
+
+report("open while open", () => db.open());
+db.close();
+console.log("closed isOpen:", db.isOpen);
+report("close while closed", () => db.close());
+report("exec while closed", () => db.exec("SELECT 1"));
+report("prepare while closed", () => db.prepare("SELECT 1"));
+
+report("deferred open", () => {
+  const deferred = new DatabaseSync(":memory:", { open: false });
+  const before = deferred.isOpen;
+  deferred.open();
+  const after = deferred.isOpen;
+  deferred.close();
+  return `${before}->${after}`;
+});
+
+report("path number", () => new DatabaseSync(42 as any));
+report("path null", () => new DatabaseSync(null as any));
+report("path undefined", () => new DatabaseSync(undefined as any));
+report("path uint8array", () => {
+  const bytes = new TextEncoder().encode(":memory:");
+  const u8db = new DatabaseSync(bytes as any);
+  const open = u8db.isOpen;
+  u8db.close();
+  return open;
+});
+
+report("options null", () => new DatabaseSync(":memory:", null as any));
+report("transaction state", () => {
+  const t = new DatabaseSync(":memory:");
+  t.exec("CREATE TABLE x(a)");
+  t.exec("BEGIN");
+  const during = t.isTransaction;
+  t.exec("ROLLBACK");
+  const after = t.isTransaction;
+  t.close();
+  return `${during}->${after}`;
+});

--- a/test-parity/node-suite/sqlite/integration/drizzle-critical-path.ts
+++ b/test-parity/node-suite/sqlite/integration/drizzle-critical-path.ts
@@ -1,0 +1,62 @@
+// parity-node-argv: --experimental-sqlite
+// The opencode critical path (#6561): its `sqlite.node.ts` uses
+// `import { DatabaseSync } from "node:sqlite"` under drizzle-orm's pure-JS
+// `node-sqlite` adapter. This mirrors the adapter's call shapes without the
+// npm dependency: schema DDL via exec, prepared inserts with named params,
+// selects with positional params, Uint8Array blob round-trip, and SQL
+// transactions.
+import { DatabaseSync } from "node:sqlite";
+
+const db = new DatabaseSync(":memory:");
+
+db.exec(`
+  CREATE TABLE session (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    version INTEGER NOT NULL DEFAULT 1,
+    time_created INTEGER NOT NULL,
+    data BLOB
+  );
+  CREATE INDEX session_time_idx ON session (time_created);
+`);
+
+const insert = db.prepare(
+  "INSERT INTO session (id, title, version, time_created, data) VALUES ($id, $title, $version, $time, $data)"
+);
+const blob = new Uint8Array([104, 101, 108, 108, 111]);
+const r1 = insert.run({ id: "s1", title: "first", version: 2, time: 1000, data: blob });
+const r2 = insert.run({ id: "s2", title: "second", version: 1, time: 2000, data: null });
+console.log("insert changes:", r1.changes, r2.changes, "rowid type:", typeof r2.lastInsertRowid);
+
+const byId = db.prepare("SELECT id, title, version, time_created FROM session WHERE id = ?");
+console.log("get s1:", JSON.stringify(byId.get("s1")));
+console.log("get missing:", String(byId.get("nope")));
+
+const list = db.prepare("SELECT id FROM session ORDER BY time_created DESC").all() as any[];
+console.log("ordered ids:", list.map((row) => row.id).join(","));
+
+const stored = db.prepare("SELECT data FROM session WHERE id = ?").get("s1") as any;
+console.log(
+  "blob round-trip:",
+  stored.data instanceof Uint8Array,
+  Array.from(stored.data).join(","),
+  "text:",
+  new TextDecoder().decode(stored.data)
+);
+
+const upd = db.prepare("UPDATE session SET title = $title WHERE id = $id").run({ id: "s1", title: "renamed" });
+console.log("update changes:", upd.changes, "->", (byId.get("s1") as any).title);
+
+db.exec("BEGIN");
+db.prepare("DELETE FROM session WHERE id = ?").run("s2");
+console.log("in tx:", db.isTransaction, "count:", (db.prepare("SELECT COUNT(*) n FROM session").get() as any).n);
+db.exec("ROLLBACK");
+console.log("after rollback count:", (db.prepare("SELECT COUNT(*) n FROM session").get() as any).n);
+
+db.exec("BEGIN");
+db.prepare("DELETE FROM session WHERE id = ?").run("s2");
+db.exec("COMMIT");
+console.log("after commit count:", (db.prepare("SELECT COUNT(*) n FROM session").get() as any).n);
+
+db.close();
+console.log("done isOpen:", db.isOpen);

--- a/test-parity/node-suite/sqlite/statement-sync/iterate-metadata.ts
+++ b/test-parity/node-suite/sqlite/statement-sync/iterate-metadata.ts
@@ -1,0 +1,80 @@
+// parity-node-argv: --experimental-sqlite
+// node:sqlite StatementSync iterate() protocol + statement metadata
+// conformance (#6561): for..of, manual next() with `value: null` on done,
+// return() termination, sourceSQL/expandedSQL, columns().
+import { DatabaseSync } from "node:sqlite";
+
+function report(label, fn) {
+  try {
+    console.log(label, "OK", fn());
+  } catch (error) {
+    console.log(label, "THROW", `${error.name}:${error.code}:${String(error.message).split("\n")[0]}`);
+  }
+}
+
+const db = new DatabaseSync(":memory:");
+db.exec("CREATE TABLE t(a INTEGER, b TEXT)");
+db.exec("INSERT INTO t VALUES (1,'one'),(2,'two'),(3,'three')");
+
+report("for..of", () => {
+  const seen: string[] = [];
+  for (const row of db.prepare("SELECT a FROM t ORDER BY a").iterate() as any) {
+    seen.push(String(row.a));
+  }
+  return seen.join(",");
+});
+report("iterate with param", () => {
+  const seen: string[] = [];
+  for (const row of db.prepare("SELECT a FROM t WHERE a > ? ORDER BY a").iterate(1) as any) {
+    seen.push(String(row.a));
+  }
+  return seen.join(",");
+});
+report("manual next / done value", () => {
+  // Note: next() after the done result is deliberately NOT probed — Node's
+  // lazy iterator resets the statement on exhaustion and a further next()
+  // restarts the query, a quirk of its lazy stepping.
+  const it: any = db.prepare("SELECT a FROM t ORDER BY a LIMIT 1").iterate();
+  const r1 = it.next();
+  const r2 = it.next();
+  return [
+    `done=${r1.done} a=${r1.value?.a}`,
+    `done=${r2.done} value=${String(r2.value)}`,
+  ].join(" | ");
+});
+report("return() terminates", () => {
+  const it: any = db.prepare("SELECT a FROM t ORDER BY a").iterate();
+  const first = it.next();
+  const ret = it.return();
+  const after = it.next();
+  return `first=${first.value?.a} ret done=${ret.done} value=${String(ret.value)} after done=${after.done} value=${String(after.value)}`;
+});
+report("break in for..of", () => {
+  let count = 0;
+  for (const _row of db.prepare("SELECT a FROM t").iterate() as any) {
+    count += 1;
+    if (count === 2) break;
+  }
+  return count;
+});
+
+report("sourceSQL", () => db.prepare("SELECT a FROM t WHERE a = ?").sourceSQL);
+report("expandedSQL", () => {
+  const stmt = db.prepare("SELECT a FROM t WHERE a = ?");
+  stmt.get(2);
+  return stmt.expandedSQL;
+});
+report("columns()", () => {
+  const cols = (db.prepare("SELECT a, b AS bee, 1 + 1 AS calc FROM t") as any).columns();
+  return JSON.stringify(cols);
+});
+
+report("statement after close finalized", () => {
+  const tmp = new DatabaseSync(":memory:");
+  tmp.exec("CREATE TABLE x(a)");
+  const stmt = tmp.prepare("SELECT * FROM x");
+  tmp.close();
+  return stmt.get();
+});
+
+db.close();

--- a/test-parity/node-suite/sqlite/statement-sync/parameters.ts
+++ b/test-parity/node-suite/sqlite/statement-sync/parameters.ts
@@ -1,0 +1,86 @@
+// parity-node-argv: --experimental-sqlite
+// node:sqlite StatementSync parameter binding conformance (#6561):
+// anonymous, named ($/:/@), bare vs prefixed keys, unknown-named errors,
+// mixed named+anonymous, and the setAllow* toggles.
+import { DatabaseSync } from "node:sqlite";
+
+function row(value) {
+  if (value === undefined) return "undefined";
+  return JSON.stringify(value);
+}
+
+function report(label, fn) {
+  try {
+    console.log(label, "OK", fn());
+  } catch (error) {
+    console.log(label, "THROW", `${error.name}:${error.code}:${String(error.message).split("\n")[0]}`);
+  }
+}
+
+const db = new DatabaseSync(":memory:");
+db.exec("CREATE TABLE t(a, b)");
+const clear = () => db.exec("DELETE FROM t");
+const first = () => row(db.prepare("SELECT a, b FROM t LIMIT 1").get());
+
+report("anonymous", () => {
+  db.prepare("INSERT INTO t VALUES (?, ?)").run(1, "one");
+  return first();
+});
+report("named dollar bare keys", () => {
+  clear();
+  db.prepare("INSERT INTO t VALUES ($x, $y)").run({ x: 2, y: "two" });
+  return first();
+});
+report("named colon and at", () => {
+  clear();
+  db.prepare("INSERT INTO t VALUES (:x, @y)").run({ x: 3, y: "three" });
+  return first();
+});
+report("named prefixed keys", () => {
+  clear();
+  db.prepare("INSERT INTO t VALUES ($x, $y)").run({ $x: 4, $y: "four" });
+  return first();
+});
+report("named mixed with anonymous", () => {
+  clear();
+  db.prepare("INSERT INTO t VALUES ($x, ?)").run({ x: 5 }, "five");
+  return first();
+});
+report("missing trailing anonymous", () => {
+  clear();
+  db.prepare("INSERT INTO t VALUES (?, ?)").run(6);
+  return first();
+});
+report("too many anonymous", () => {
+  db.prepare("INSERT INTO t VALUES (?, ?)").run(1, 2, 3);
+  return first();
+});
+report("unknown named key", () => {
+  db.prepare("INSERT INTO t VALUES ($x, $y)").run({ x: 1, y: 2, nope: 3 });
+  return first();
+});
+report("select with named param", () => {
+  clear();
+  db.prepare("INSERT INTO t VALUES ($x, $y)").run({ x: 7, y: "seven" });
+  return row(db.prepare("SELECT b FROM t WHERE a = $x").get({ x: 7 }));
+});
+
+report("setAllowBareNamedParameters(false)", () => {
+  const stmt = db.prepare("INSERT INTO t VALUES ($x, 'bare')");
+  stmt.setAllowBareNamedParameters(false);
+  try {
+    stmt.run({ x: 8 });
+    return "bare accepted";
+  } catch (error) {
+    return `bare rejected ${error.code}`;
+  }
+});
+report("setAllowUnknownNamedParameters(true)", () => {
+  clear();
+  const stmt = db.prepare("INSERT INTO t VALUES ($x, 'unk')");
+  stmt.setAllowUnknownNamedParameters(true);
+  stmt.run({ x: 9, extra: "ignored" });
+  return first();
+});
+
+db.close();

--- a/test-parity/node-suite/sqlite/statement-sync/type-coercion.ts
+++ b/test-parity/node-suite/sqlite/statement-sync/type-coercion.ts
@@ -1,0 +1,77 @@
+// parity-node-argv: --experimental-sqlite
+// node:sqlite JS<->SQLite type coercion conformance (#6561): null/number/
+// bigint/string/Uint8Array binding, boolean/undefined rejection, numbers
+// always bind as REAL, INTEGER reads come back as plain numbers (typeof
+// "number"), safe-integer overflow throws, setReadBigInts round-trips.
+import { DatabaseSync } from "node:sqlite";
+
+function describe(value) {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  if (value instanceof Uint8Array) return `u8[${Array.from(value).join(",")}]`;
+  return `${typeof value}:${String(value)}`;
+}
+
+function report(label, fn) {
+  try {
+    console.log(label, "OK", fn());
+  } catch (error) {
+    console.log(label, "THROW", `${error.name}:${error.code}:${String(error.message).split("\n")[0]}`);
+  }
+}
+
+const db = new DatabaseSync(":memory:");
+db.exec("CREATE TABLE t(v)"); // no affinity: stored types reflect the binding
+
+report("bind null", () => {
+  db.prepare("INSERT INTO t VALUES (?)").run(null);
+  return describe((db.prepare("SELECT v FROM t LIMIT 1").get() as any).v);
+});
+report("numbers bind as REAL", () => {
+  db.exec("DELETE FROM t");
+  db.prepare("INSERT INTO t VALUES (?)").run(5);
+  db.prepare("INSERT INTO t VALUES (?)").run(5.5);
+  const rows = db.prepare("SELECT v, typeof(v) AS ty FROM t").all() as any[];
+  return rows.map((r) => `${describe(r.v)}/${r.ty}`).join(" ");
+});
+report("bigint binds as INTEGER", () => {
+  db.exec("DELETE FROM t");
+  db.prepare("INSERT INTO t VALUES (?)").run(123n);
+  const r = db.prepare("SELECT v, typeof(v) AS ty FROM t").get() as any;
+  return `${describe(r.v)}/${r.ty}`;
+});
+report("string round-trip", () => {
+  db.exec("DELETE FROM t");
+  db.prepare("INSERT INTO t VALUES (?)").run("hello");
+  return describe((db.prepare("SELECT v FROM t").get() as any).v);
+});
+report("blob round-trip", () => {
+  db.exec("DELETE FROM t");
+  const buf = new Uint8Array([0, 255, 128, 7]);
+  db.prepare("INSERT INTO t VALUES (?)").run(buf);
+  const v = (db.prepare("SELECT v FROM t").get() as any).v;
+  return `${describe(v)} isU8=${v instanceof Uint8Array}`;
+});
+report("bind boolean rejected", () => db.prepare("INSERT INTO t VALUES (?)").run(true as any));
+report("bind undefined rejected", () => db.prepare("INSERT INTO t VALUES (?)").run(undefined as any));
+report("huge bigint rejected", () => db.prepare("INSERT INTO t VALUES (?)").run(2n ** 70n));
+
+report("run() result typeofs", () => {
+  db.exec("DELETE FROM t");
+  const r = db.prepare("INSERT INTO t VALUES (?)").run("x");
+  return `changes=${describe(r.changes)} lastInsertRowid=${describe(r.lastInsertRowid)}`;
+});
+
+const intdb = new DatabaseSync(":memory:");
+intdb.exec("CREATE TABLE i(v INTEGER)");
+intdb.prepare("INSERT INTO i VALUES (?)").run(9007199254740993n);
+report("unsafe INTEGER read throws", () => intdb.prepare("SELECT v FROM i").get());
+report("setReadBigInts(true)", () => {
+  const stmt = intdb.prepare("SELECT v FROM i");
+  stmt.setReadBigInts(true);
+  const big = describe((stmt.get() as any).v);
+  stmt.setReadBigInts(false);
+  return big;
+});
+intdb.close();
+db.close();


### PR DESCRIPTION
Closes #6561.

`node:sqlite` (`DatabaseSync`/`StatementSync`) was already substantially implemented in `perry-stdlib/src/sqlite/` (rusqlite `bundled`, so real SQLite is statically linked). This PR closes the conformance gaps against Node v26 found by differential testing, and adds the granular parity suite the issue asks for. A 55-case differential harness (every DatabaseSync/StatementSync surface in the issue's priority list) is now **byte-identical between `node` and the perry-compiled binary**.

## Fixes

**1. `db.function(...)` / `db.aggregate(...)` silently no-op'd through the dynamic method tower** — the method-name gate in `common/dispatch/method_dispatch.rs` was missing `function` / `aggregate` / `enableDefensive` / `setAuthorizer`, so an any-typed receiver (e.g. inside a closure) fell through and the SQL function was never registered; the next query failed with `no such function: <name>`. The typed path was unaffected, which is why this hid so well.

**2. Integer reads reported `typeof` `"function"`** — sqlite INTEGER columns, `run().changes`, `lastInsertRowid`, custom-function args, `errcode`, authorizer/changeset codes were returned INT32-tagged. Perry's INT32 tag shares its storage shape with `Expr::ClassRef` (`INT32_TAG | class_id`, #618), so `js_value_typeof` on a small integer like rowid `1` that collides with a registered class id reported `"function"`. All node:sqlite outputs now hand out NUMBER-tagged doubles, exactly what Node produces.

**3. Numbers now bind as REAL** — Node binds every JS number via `sqlite3_bind_double` (only BigInt binds as INTEGER); perry promoted integral numbers to SQLite INTEGERs. Observable via `typeof(col)` in SQL and `stmt.expandedSQL` (`5` vs Node's `5.0`).

**4. `ERR_SQLITE_ERROR`s now carry `errcode`/`errstr`** — Node attaches the extended result code and `sqlite3_errstr` text as own properties on every SQL-level error. All node-path sync throws now go through new `throw_sqlite_error_ext` / `throw_sqlite_error_from_conn` helpers (exec, prepare, step, bind, open, function/aggregate registration, setAuthorizer, session create/attach, changeset/patchset, applyChangeset). Too-many-anonymous-params now matches Node's `errcode: 25` (SQLITE_RANGE).

**5. Message wording matched to Node v26** — `"database is not open"` / `"database is already open"` (were capitalized on several paths; the duplicate `ensure_open_node_database_lowercase` helper is gone), `The "options" argument must be an object.`, `The "options.limits" argument must be an object.`, and the constructor path error is now Node's exact `The "path" argument must be a string, Uint8Array, or URL without null bytes.` — with actual Uint8Array/Buffer and `file:` URL path support.

**6. `iterate()` protocol** — exhaustion and `return()` now produce `{ done: true, value: null }` (was `undefined`), and `return()` terminates the iterator, via a new `KIND_VALUES_NULL_DONE` array-iterator kind in `perry-runtime` (same class id, so for..of/spread paths are untouched).

## Tests

`test-parity/node-suite/sqlite/` grows from 1 file to 8 (node run live as oracle, diffed against the compiled binary):

- `database-sync/lifecycle.ts` — ctor validation (string/Uint8Array/URL paths), open/close state machine, `isOpen`/`isTransaction`, `location()`
- `database-sync/exec-errors.ts` — error shape (`code`/`errcode`/`errstr`/message), constraint + FK errors, `enableForeignKeyConstraints`
- `database-sync/functions-aggregates.ts` — scalar fns (varargs/deterministic/options), aggregates (object state, `result` callback), the any-typed-receiver regression, arg coercions
- `statement-sync/parameters.ts` — anonymous/named (`$` `:` `@`), bare vs prefixed keys, unknown-named, mixed, missing/too-many, `setAllowBareNamedParameters`, `setAllowUnknownNamedParameters`
- `statement-sync/type-coercion.ts` — null/number/bigint/string/Uint8Array, boolean/undefined rejection, REAL binding, blob round-trip, safe-integer overflow → RangeError, `setReadBigInts`, run() result typeofs
- `statement-sync/iterate-metadata.ts` — for..of, manual `next()`/done-value, `return()`, break, `sourceSQL`/`expandedSQL`, `columns()`, finalized statements
- `integration/drizzle-critical-path.ts` — the opencode path (`sqlite.node.ts` + drizzle-orm's pure-JS `node-sqlite` adapter call shapes): schema DDL, named-param inserts, positional selects, Uint8Array blob round-trip, SQL transactions

`./run_parity_tests.sh --suite node-suite --module sqlite`: **8/8 PASS** (includes the pre-existing `extension-loading/controls`).

## Verification

- 55-case differential harness: `diff` of node vs perry output — identical.
- `cargo test -p perry-stdlib --features database-sqlite`, `cargo test -p perry-runtime`: pass (the known parallel-flaky runtime tests pass with `--test-threads=1`; `promise::keyed_table::settling_many_keys_is_not_quadratic` is a timing test that only failed while a release build saturated the machine — nothing in this diff touches `promise/`).

## Known gaps (unchanged behavior, documented)

- `iterate()` materializes rows eagerly; Node steps lazily. Only observable through Node's own quirk (post-done `next()` restarts the query because the statement was reset) or mid-iteration table mutation.
- `DatabaseSync.prototype.location()` verified for `:memory:` (→ `null`); file-path resolution untested against Node.
- `backup()`, `loadExtension`, `createSession`/`applyChangeset` pre-existed and got the error-shape upgrade, but no new conformance surface beyond the existing extension-loading test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded SQLite support for custom functions, aggregates, authorizers, sessions, tag stores, and backup operations.
  * Improved SQLite parameter binding, numeric conversion, BigInt handling, and iterator compatibility.
  * Added Node-compatible validation for database paths and lifecycle operations.
* **Bug Fixes**
  * Improved SQLite errors with standardized messages, error codes, and detailed properties.
  * Corrected database limit and callback value types.
* **Tests**
  * Added comprehensive coverage for SQLite errors, lifecycle, iteration, parameters, coercion, integrations, functions, and aggregates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->