### PR TITLE
feat(resolve): declaration/source-map-guided original TS source for compile packages (#2569)

### DIFF
--- a/crates/perry/src/commands/compile/resolve.rs
+++ b/crates/perry/src/commands/compile/resolve.rs
@@ -124,6 +124,8 @@ pub fn find_perry_workspace_root() -> Option<PathBuf> {
 #[cfg(test)]
 mod bun_store_tests;
 #[cfg(test)]
+mod declaration_map_source_tests;
+#[cfg(test)]
 mod extension_resolution_tests;
 #[cfg(test)]
 mod tests;
@@ -632,12 +634,100 @@ pub(super) fn resolve_package_entry(package_dir: &Path, subpath: Option<&str>) -
     resolve_with_extensions(&package_dir.join("index"))
 }
 
+/// Append `.map` to a path's file name (`index.js` → `index.js.map`,
+/// `index.d.ts` → `index.d.ts.map`). `Path::with_extension` cannot be used —
+/// it would rewrite the trailing component instead (`index.d.ts` →
+/// `index.d.map`).
+fn append_map_extension(path: &Path) -> PathBuf {
+    let mut name = path.as_os_str().to_os_string();
+    name.push(".map");
+    PathBuf::from(name)
+}
+
+/// Parse a source/declaration map and return the canonical path of its single
+/// original source, when that source exists on disk and is a real TypeScript
+/// source (`.ts`/`.tsx`/`.mts`/`.cts`, never a `.d.ts`).
+///
+/// Only a 1:1 emit is honored — a map carrying exactly one `sources` entry.
+/// A bundler that folds many inputs into one output lists several `sources`,
+/// and compiling any single one in place of the bundle would silently drop the
+/// rest, so those are left to the emitted-file path.
+fn original_source_from_map_file(map_path: &Path) -> Option<PathBuf> {
+    let content = fs::read_to_string(map_path).ok()?;
+    let map: serde_json::Value = serde_json::from_str(&content).ok()?;
+    let sources = map.get("sources")?.as_array()?;
+    if sources.len() != 1 {
+        return None;
+    }
+    let source = sources[0].as_str()?;
+    let source_root = map
+        .get("sourceRoot")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    // `sources` / `sourceRoot` are resolved relative to the map file's own
+    // directory (the tsc / Node source-map convention). An absolute `source`
+    // (or absolute `sourceRoot`) makes `join` discard the base, as intended.
+    let map_dir = map_path.parent()?;
+    let relative = if source_root.is_empty() {
+        PathBuf::from(source)
+    } else {
+        Path::new(source_root).join(source)
+    };
+    // canonicalize both proves the file exists and normalizes the `../` hops a
+    // `dist/ → src/` map almost always contains. A `webpack://`-style or other
+    // non-filesystem `source` simply fails to canonicalize and is skipped.
+    let canonical = map_dir.join(relative).canonicalize().ok()?;
+    if is_declaration_file(&canonical) {
+        return None;
+    }
+    let is_ts_source = matches!(
+        canonical.extension().and_then(|e| e.to_str()),
+        Some("ts" | "tsx" | "mts" | "cts")
+    );
+    is_ts_source.then_some(canonical)
+}
+
+/// Recover the ORIGINAL TypeScript source that a compiled package entry was
+/// emitted from by reading the declaration map (`*.d.ts.map`) or source map
+/// (`*.js.map`) written next to it. This is the authoritative pointer to the
+/// source — it survives non-`src/` layouts the name-based conventions in
+/// [`resolve_package_source_entry`] cannot guess. (Issue #2569 step 5: prefer
+/// original TS sources via source maps or declaration maps.)
+///
+/// The declaration map is consulted first: it exists specifically to link a
+/// `.d.ts` back to the `.ts` it describes, so its `sources` are the cleanest
+/// path to the original source. The JS source map is the fallback.
+fn original_source_via_map(entry: &Path) -> Option<PathBuf> {
+    if let Some(declaration) = declaration_sidecar_for_implementation(entry) {
+        if let Some(source) = original_source_from_map_file(&append_map_extension(&declaration)) {
+            return Some(source);
+        }
+    }
+    original_source_from_map_file(&append_map_extension(entry))
+}
+
 /// Resolve package entry preferring TypeScript source over compiled JS output.
 /// Used for compile_packages where we want to compile from TS source, not bundled JS.
 pub(super) fn resolve_package_source_entry(
     package_dir: &Path,
     subpath: Option<&str>,
 ) -> Option<PathBuf> {
+    let normal_entry = resolve_package_entry(package_dir, subpath);
+
+    // #2569 step 5: the most authoritative pointer to a package's original
+    // TypeScript source is the declaration/source map its build wrote next to
+    // the emitted entry — it records the exact source path even when the
+    // layout does not follow the `src/` ⇄ `dist/` naming the heuristics below
+    // assume. Consult it for the actual resolved entry first; fall through to
+    // the name-based conventions when no usable map is present.
+    if let Some(entry) = normal_entry.as_ref() {
+        if is_js_file(entry) {
+            if let Some(original) = original_source_via_map(entry) {
+                return Some(original);
+            }
+        }
+    }
+
     // For subpaths, try src/<subpath>.ts
     if let Some(sub) = subpath {
         let src_path = package_dir.join("src").join(sub);
@@ -657,7 +747,7 @@ pub(super) fn resolve_package_source_entry(
     }
 
     // Try using normal entry resolution but prefer TS over JS
-    let normal_entry = resolve_package_entry(package_dir, subpath)?;
+    let normal_entry = normal_entry?;
     if is_js_file(&normal_entry) {
         // Try .ts equivalent of the .js entry
         let ts_path = normal_entry.with_extension("ts");

--- a/crates/perry/src/commands/compile/resolve/declaration_map_source_tests.rs
+++ b/crates/perry/src/commands/compile/resolve/declaration_map_source_tests.rs
@@ -9,20 +9,19 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 /// Write a `compilePackages`-shaped package that ships `dist/index.js` +
-/// `dist/index.d.ts` alongside the original `src/index.ts`. Map files are added
-/// per-test. Returns the package dir and the canonical original source path.
-fn write_dist_package(root: &Path) -> (PathBuf, PathBuf) {
+/// `dist/index.d.ts`, but NO source file — each test writes the source it
+/// needs. Deliberately writes no `src/index.ts`, so the positive map tests
+/// below fail unless map-guided resolution actually fires (a `src/index.ts`
+/// would let the legacy naming convention pass them regardless).
+fn write_dist_package(root: &Path) -> PathBuf {
     let package_dir = root.join("node_modules").join("typed-dist");
     fs::create_dir_all(package_dir.join("dist")).expect("mkdir dist");
-    fs::create_dir_all(package_dir.join("src")).expect("mkdir src");
     fs::write(package_dir.join("dist/index.js"), "export class Codex {}\n").expect("js");
     fs::write(
         package_dir.join("dist/index.d.ts"),
         "export declare class Codex {}\n",
     )
     .expect("dts");
-    let original = package_dir.join("src/index.ts");
-    fs::write(&original, "export class Codex {}\n").expect("ts");
     fs::write(
         package_dir.join("package.json"),
         serde_json::json!({
@@ -35,7 +34,16 @@ fn write_dist_package(root: &Path) -> (PathBuf, PathBuf) {
         .to_string(),
     )
     .expect("package.json");
-    (package_dir, original.canonicalize().expect("canonical src"))
+    package_dir
+}
+
+/// Write a TypeScript source at `package_dir/rel` (creating parents) and return
+/// its canonical path.
+fn write_source(package_dir: &Path, rel: &str) -> PathBuf {
+    let path = package_dir.join(rel);
+    fs::create_dir_all(path.parent().expect("source parent")).expect("mkdir source parent");
+    fs::write(&path, "export class Codex {}\n").expect("write source");
+    path.canonicalize().expect("canonical source")
 }
 
 /// Canonicalize the result so the assertion is robust both to the naming-
@@ -49,14 +57,17 @@ fn resolved_source(package_dir: &Path) -> Option<PathBuf> {
 #[test]
 fn declaration_map_redirects_to_original_typescript_source() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let (package_dir, original) = write_dist_package(dir.path());
+    let package_dir = write_dist_package(dir.path());
+    // Source lives at a non-conventional path the naming heuristics can't find
+    // (not `src/`, not a `dist/ → src/` mirror) — only the map records it.
+    let original = write_source(&package_dir, "internal/entry.ts");
     fs::write(
         package_dir.join("dist/index.d.ts.map"),
         serde_json::json!({
             "version": 3,
             "file": "index.d.ts",
             "sourceRoot": "",
-            "sources": ["../src/index.ts"],
+            "sources": ["../internal/entry.ts"],
             "names": []
         })
         .to_string(),
@@ -69,13 +80,14 @@ fn declaration_map_redirects_to_original_typescript_source() {
 #[test]
 fn source_map_redirects_when_no_declaration_map() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let (package_dir, original) = write_dist_package(dir.path());
+    let package_dir = write_dist_package(dir.path());
+    let original = write_source(&package_dir, "internal/entry.ts");
     fs::write(
         package_dir.join("dist/index.js.map"),
         serde_json::json!({
             "version": 3,
             "file": "index.js",
-            "sources": ["../src/index.ts"],
+            "sources": ["../internal/entry.ts"],
             "names": [],
             "mappings": ""
         })
@@ -89,15 +101,16 @@ fn source_map_redirects_when_no_declaration_map() {
 #[test]
 fn source_root_is_prepended_to_map_sources() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let (package_dir, original) = write_dist_package(dir.path());
-    // sourceRoot "../src" + source "index.ts", both relative to dist/.
+    let package_dir = write_dist_package(dir.path());
+    let original = write_source(&package_dir, "internal/entry.ts");
+    // sourceRoot "../internal" + source "entry.ts", both relative to dist/.
     fs::write(
         package_dir.join("dist/index.js.map"),
         serde_json::json!({
             "version": 3,
             "file": "index.js",
-            "sourceRoot": "../src",
-            "sources": ["index.ts"],
+            "sourceRoot": "../internal",
+            "sources": ["entry.ts"],
             "names": [],
             "mappings": ""
         })
@@ -146,16 +159,18 @@ fn bundled_multi_source_map_is_not_redirected() {
 #[test]
 fn map_pointing_at_missing_source_falls_back_to_convention() {
     let dir = tempfile::tempdir().expect("tempdir");
-    let (package_dir, original) = write_dist_package(dir.path());
-    // A dist-only tarball: the map still records `../original/index.ts`, but
+    let package_dir = write_dist_package(dir.path());
+    // The convention target that must win when the map is unusable.
+    let convention = write_source(&package_dir, "src/index.ts");
+    // A dist-only tarball: the map still records `../original/missing.ts`, but
     // that file was never published. Resolution must not break — it falls
-    // through to the `src/index.ts` naming convention, which is present.
+    // through to the `src/index.ts` naming convention.
     fs::write(
         package_dir.join("dist/index.js.map"),
         serde_json::json!({
             "version": 3,
             "file": "index.js",
-            "sources": ["../original/index.ts"],
+            "sources": ["../original/missing.ts"],
             "names": [],
             "mappings": ""
         })
@@ -163,7 +178,7 @@ fn map_pointing_at_missing_source_falls_back_to_convention() {
     )
     .expect("write js.map");
 
-    assert_eq!(resolved_source(&package_dir), Some(original));
+    assert_eq!(resolved_source(&package_dir), Some(convention));
 }
 
 #[test]
@@ -171,6 +186,7 @@ fn no_map_uses_existing_src_index_convention() {
     // With no map at all, behavior is unchanged: the `src/index.ts` convention
     // still wins. Guards against a regression in the reorder.
     let dir = tempfile::tempdir().expect("tempdir");
-    let (package_dir, original) = write_dist_package(dir.path());
-    assert_eq!(resolved_source(&package_dir), Some(original));
+    let package_dir = write_dist_package(dir.path());
+    let convention = write_source(&package_dir, "src/index.ts");
+    assert_eq!(resolved_source(&package_dir), Some(convention));
 }

--- a/crates/perry/src/commands/compile/resolve/declaration_map_source_tests.rs
+++ b/crates/perry/src/commands/compile/resolve/declaration_map_source_tests.rs
@@ -1,0 +1,176 @@
+//! Issue #2569 step 5 — prefer the ORIGINAL TypeScript source when a package's
+//! build shipped a declaration map (`*.d.ts.map`) or source map (`*.js.map`)
+//! recording it. The name-based `src/ ⇄ dist/` heuristics in
+//! `resolve_package_source_entry` cannot recover a source whose layout does not
+//! mirror the emit; the map can, because it stores the exact original path.
+
+use super::resolve_package_source_entry;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Write a `compilePackages`-shaped package that ships `dist/index.js` +
+/// `dist/index.d.ts` alongside the original `src/index.ts`. Map files are added
+/// per-test. Returns the package dir and the canonical original source path.
+fn write_dist_package(root: &Path) -> (PathBuf, PathBuf) {
+    let package_dir = root.join("node_modules").join("typed-dist");
+    fs::create_dir_all(package_dir.join("dist")).expect("mkdir dist");
+    fs::create_dir_all(package_dir.join("src")).expect("mkdir src");
+    fs::write(package_dir.join("dist/index.js"), "export class Codex {}\n").expect("js");
+    fs::write(
+        package_dir.join("dist/index.d.ts"),
+        "export declare class Codex {}\n",
+    )
+    .expect("dts");
+    let original = package_dir.join("src/index.ts");
+    fs::write(&original, "export class Codex {}\n").expect("ts");
+    fs::write(
+        package_dir.join("package.json"),
+        serde_json::json!({
+            "name": "typed-dist",
+            "type": "module",
+            "module": "./dist/index.js",
+            "types": "./dist/index.d.ts",
+            "exports": { ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" } }
+        })
+        .to_string(),
+    )
+    .expect("package.json");
+    (package_dir, original.canonicalize().expect("canonical src"))
+}
+
+/// Canonicalize the result so the assertion is robust both to the naming-
+/// convention path returning a non-canonical path and to macOS resolving
+/// `/var` → `/private/var`.
+fn resolved_source(package_dir: &Path) -> Option<PathBuf> {
+    resolve_package_source_entry(package_dir, None)
+        .map(|p| p.canonicalize().expect("canonical resolved source"))
+}
+
+#[test]
+fn declaration_map_redirects_to_original_typescript_source() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (package_dir, original) = write_dist_package(dir.path());
+    fs::write(
+        package_dir.join("dist/index.d.ts.map"),
+        serde_json::json!({
+            "version": 3,
+            "file": "index.d.ts",
+            "sourceRoot": "",
+            "sources": ["../src/index.ts"],
+            "names": []
+        })
+        .to_string(),
+    )
+    .expect("write d.ts.map");
+
+    assert_eq!(resolved_source(&package_dir), Some(original));
+}
+
+#[test]
+fn source_map_redirects_when_no_declaration_map() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (package_dir, original) = write_dist_package(dir.path());
+    fs::write(
+        package_dir.join("dist/index.js.map"),
+        serde_json::json!({
+            "version": 3,
+            "file": "index.js",
+            "sources": ["../src/index.ts"],
+            "names": [],
+            "mappings": ""
+        })
+        .to_string(),
+    )
+    .expect("write js.map");
+
+    assert_eq!(resolved_source(&package_dir), Some(original));
+}
+
+#[test]
+fn source_root_is_prepended_to_map_sources() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (package_dir, original) = write_dist_package(dir.path());
+    // sourceRoot "../src" + source "index.ts", both relative to dist/.
+    fs::write(
+        package_dir.join("dist/index.js.map"),
+        serde_json::json!({
+            "version": 3,
+            "file": "index.js",
+            "sourceRoot": "../src",
+            "sources": ["index.ts"],
+            "names": [],
+            "mappings": ""
+        })
+        .to_string(),
+    )
+    .expect("write js.map");
+
+    assert_eq!(resolved_source(&package_dir), Some(original));
+}
+
+#[test]
+fn bundled_multi_source_map_is_not_redirected() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let package_dir = dir.path().join("node_modules").join("bundled");
+    fs::create_dir_all(package_dir.join("dist")).expect("mkdir dist");
+    fs::create_dir_all(package_dir.join("lib-src")).expect("mkdir lib-src");
+    fs::write(package_dir.join("dist/index.js"), "export const x = 1;\n").expect("js");
+    fs::write(package_dir.join("lib-src/a.ts"), "export const a = 1;\n").expect("a");
+    fs::write(package_dir.join("lib-src/b.ts"), "export const b = 2;\n").expect("b");
+    fs::write(
+        package_dir.join("package.json"),
+        serde_json::json!({ "name": "bundled", "type": "module", "module": "./dist/index.js" })
+            .to_string(),
+    )
+    .expect("package.json");
+    // A bundle folds many inputs into one output: several `sources`. There is
+    // no single original source to compile in place of the emit, and no
+    // `src/index.ts` for the name conventions to fall back to — so the result
+    // must be None rather than an arbitrary pick of one input.
+    fs::write(
+        package_dir.join("dist/index.js.map"),
+        serde_json::json!({
+            "version": 3,
+            "file": "index.js",
+            "sources": ["../lib-src/a.ts", "../lib-src/b.ts"],
+            "names": [],
+            "mappings": ""
+        })
+        .to_string(),
+    )
+    .expect("write js.map");
+
+    assert_eq!(resolve_package_source_entry(&package_dir, None), None);
+}
+
+#[test]
+fn map_pointing_at_missing_source_falls_back_to_convention() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (package_dir, original) = write_dist_package(dir.path());
+    // A dist-only tarball: the map still records `../original/index.ts`, but
+    // that file was never published. Resolution must not break — it falls
+    // through to the `src/index.ts` naming convention, which is present.
+    fs::write(
+        package_dir.join("dist/index.js.map"),
+        serde_json::json!({
+            "version": 3,
+            "file": "index.js",
+            "sources": ["../original/index.ts"],
+            "names": [],
+            "mappings": ""
+        })
+        .to_string(),
+    )
+    .expect("write js.map");
+
+    assert_eq!(resolved_source(&package_dir), Some(original));
+}
+
+#[test]
+fn no_map_uses_existing_src_index_convention() {
+    // With no map at all, behavior is unchanged: the `src/index.ts` convention
+    // still wins. Guards against a regression in the reorder.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (package_dir, original) = write_dist_package(dir.path());
+    assert_eq!(resolved_source(&package_dir), Some(original));
+}


### PR DESCRIPTION
## What

Implements **step 5** of #2569 — *"Prefer original TS sources when available via source maps or declaration maps"* — for the `perry.compilePackages` native-compile path.

When a package is opted into `compilePackages`, Perry already prefers a package's original TypeScript source over its emitted JS (`resolve_package_source_entry`). Today that preference is driven purely by **naming conventions** (`src/index.ts`, and a `dist/`→`src/` / `lib/`→`src/` path mirror). Those guesses miss any package whose source layout doesn't mirror its emit.

This PR makes the resolution **map-guided**: it reads the declaration map (`*.d.ts.map`) or source map (`*.js.map`) that tsc / a declaration-map-emitting bundler writes next to the emitted entry, and follows its recorded `sources` back to the original `.ts`. The map is the authoritative record of where the source lives, so it works regardless of directory layout.

## How

`crates/perry/src/commands/compile/resolve.rs`:

- `original_source_from_map_file` — parses a `.d.ts.map` / `.js.map`, and returns its single original source when that file **exists on disk** and is a real TypeScript source (`.ts`/`.tsx`/`.mts`/`.cts`, never a `.d.ts`). `sourceRoot` is honored; sources are resolved relative to the map file's directory (the tsc/Node convention).
  - **Only a 1:1 emit is honored** (exactly one `sources` entry). A bundle that folds many inputs into one output lists several `sources` and has no single original source to compile in its place, so those correctly fall through to the emitted file.
  - A `webpack://`-style or otherwise non-filesystem `source` simply fails to `canonicalize` and is skipped.
- `original_source_via_map` — consults the declaration map first (it exists specifically to link a `.d.ts` back to its `.ts`), then the JS source map.
- `resolve_package_source_entry` now consults the map for the actual resolved entry **before** the name-based conventions, and falls through to the existing conventions unchanged when no usable map is present.

Behavior is only affected when an authoritative single-source map is present and points to a real TS file on disk — otherwise resolution is byte-for-byte the previous conventions (covered by `no_map_uses_existing_src_index_convention` and `map_pointing_at_missing_source_falls_back_to_convention`).

## Why this scope

#2569 is a large, multi-step architecture (declaration-guided native package compilation). Its groundwork — declaration-sidecar resolution (`declaration_sidecar_for_resolved_import`) and the declaration-aware JS-runtime-gate diagnostic — has already landed. This is the next self-contained increment (issue step 5), independently useful for any `compilePackages` package that ships its original sources with `declarationMap`/`sourceMap` (e.g. `@openai/codex-sdk`'s `dist/index.js` + `dist/index.d.ts` + maps).

## Tests

New `crates/perry/src/commands/compile/resolve/declaration_map_source_tests.rs` (kept as its own file so `resolve/tests.rs` stays under the 2000-line lint cap):

- `declaration_map_redirects_to_original_typescript_source` — `.d.ts.map` wins.
- `source_map_redirects_when_no_declaration_map` — `.js.map` fallback.
- `source_root_is_prepended_to_map_sources` — `sourceRoot` honored.
- `bundled_multi_source_map_is_not_redirected` — multi-`sources` map is refused.
- `map_pointing_at_missing_source_falls_back_to_convention` — dist-only tarball still resolves via the naming convention.
- `no_map_uses_existing_src_index_convention` — no-map behavior unchanged.

No version bump / changelog per the external-contributor convention in CLAUDE.md (maintainer folds those in at merge).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package source resolution by recovering original TypeScript entry points using declaration and source maps when emitted file naming conventions don’t match.
  * Added handling for `sourceRoot` to correctly resolve mapped source paths.
  * Avoids incorrect matches for ambiguous multi-source maps and safely falls back when mapped sources are unavailable.
* **Tests**
  * Added coverage to verify map-based recovery across declaration maps, JavaScript maps, and fallback behavior when maps are missing or unusable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->