### PR TITLE
fix(ui-ios): make root rebuild resilient to system modals on iOS 26 (#5203)

### DIFF
--- a/crates/perry-ui-ios/src/app.rs
+++ b/crates/perry-ui-ios/src/app.rs
@@ -673,6 +673,11 @@ define_class!(
                         perry_geisterhand_pump();
                     }
                 }
+                // Issue #5203 — root-window health check. Replays root
+                // rebuilds deferred while a system modal was presented and
+                // re-asserts the window if a dismissed modal left it detached
+                // ("white, frozen, unrecoverable by rebuild").
+                run_root_health_check();
             }));
         }
     }
@@ -682,6 +687,173 @@ impl PerryPumpTarget {
     fn new() -> Retained<Self> {
         let this = Self::alloc().set_ivars(PerryPumpTargetIvars);
         unsafe { msg_send![super(this), init] }
+    }
+}
+
+// ============================================================================
+// Root-window resilience while a system modal is presented (#5203)
+// ============================================================================
+//
+// Mutating the root widget tree — an app's `rebuild()` that clears+rebuilds the
+// root container — while a *system-presented modal* is on screen (the StoreKit
+// purchase sheet, GoogleSignIn's ASWebAuthenticationSession, a share sheet, or
+// a Perry alert) can SIGSEGV on iOS 26, and replacing the root can leave the
+// window detached ("white, frozen, unrecoverable by rebuild") after the sheet
+// dismisses. This is the same hazard class the button path already avoids by
+// deferring touch-driven work, but for presented modals.
+//
+// Two guards cooperate:
+//   1. `state::state_set` defers destructive forEach rebuilds while
+//      `system_modal_presented()` is true, coalescing per container.
+//   2. `run_root_health_check()` (below, driven by the pump) replays those
+//      deferred rebuilds and re-asserts the window once no modal is on screen.
+
+thread_local! {
+    static HEALTH_TICK: std::cell::Cell<u32> = std::cell::Cell::new(0);
+    static WAS_MODAL_PRESENTED: std::cell::Cell<bool> = std::cell::Cell::new(false);
+}
+
+/// Issue #5203 — true when a modal view controller is presented over the key
+/// window's root view controller (StoreKit / ASWebAuthenticationSession / share
+/// sheet / Perry alert). Callers gate destructive root-container rebuilds on
+/// this and defer them until it returns false.
+pub(crate) fn system_modal_presented() -> bool {
+    unsafe {
+        let root_vc = key_window_root_vc();
+        if root_vc.is_null() {
+            return false;
+        }
+        let presented: *mut AnyObject = msg_send![root_vc, presentedViewController];
+        !presented.is_null()
+    }
+}
+
+/// The key window's rootViewController via the scene graph (iOS 13+), with a
+/// deprecated `keyWindow` fallback. Null when none is found.
+unsafe fn key_window_root_vc() -> *mut AnyObject {
+    let app_cls = match AnyClass::get(c"UIApplication") {
+        Some(c) => c,
+        None => return std::ptr::null_mut(),
+    };
+    let app: *mut AnyObject = msg_send![app_cls, sharedApplication];
+    if app.is_null() {
+        return std::ptr::null_mut();
+    }
+
+    let mut root_vc: *mut AnyObject = std::ptr::null_mut();
+    let scenes: *mut AnyObject = msg_send![app, connectedScenes];
+    if !scenes.is_null() {
+        let enumerator: *mut AnyObject = msg_send![scenes, objectEnumerator];
+        if !enumerator.is_null() {
+            loop {
+                let scene: *mut AnyObject = msg_send![enumerator, nextObject];
+                if scene.is_null() {
+                    break;
+                }
+                if let Some(ws_cls) = AnyClass::get(c"UIWindowScene") {
+                    let is_ws: bool = msg_send![scene, isKindOfClass: ws_cls];
+                    if !is_ws {
+                        continue;
+                    }
+                }
+                let windows: *mut AnyObject = msg_send![scene, windows];
+                if windows.is_null() {
+                    continue;
+                }
+                let count: i64 = msg_send![windows, count];
+                for i in 0..count {
+                    let w: *mut AnyObject = msg_send![windows, objectAtIndex: i as u64];
+                    if w.is_null() {
+                        continue;
+                    }
+                    let is_key: bool = msg_send![w, isKeyWindow];
+                    if is_key {
+                        root_vc = msg_send![w, rootViewController];
+                        break;
+                    }
+                }
+                if !root_vc.is_null() {
+                    break;
+                }
+            }
+        }
+    }
+
+    if root_vc.is_null() {
+        let key_window: *mut AnyObject = msg_send![app, keyWindow];
+        if !key_window.is_null() {
+            root_vc = msg_send![key_window, rootViewController];
+        }
+    }
+    root_vc
+}
+
+/// Issue #5203 — pump-driven recovery, throttled off the 8 ms cadence. When no
+/// modal is on screen, replays root rebuilds deferred while one was up and
+/// re-asserts the window if a dismissed modal left it detached. No-op in the
+/// normal case (no modal, window key & visible).
+fn run_root_health_check() {
+    // ~every 6th pump tick (~48 ms at 120 Hz): keep the scene-graph walk off
+    // the hot path. Recovery within ~48 ms of a modal dismissing is
+    // imperceptible.
+    let due = HEALTH_TICK.with(|c| {
+        let n = c.get().wrapping_add(1);
+        c.set(n);
+        n % 6 == 0
+    });
+    if !due {
+        return;
+    }
+
+    let now = system_modal_presented();
+    let was = WAS_MODAL_PRESENTED.with(|c| c.replace(now));
+    if now {
+        // A modal is up: leave deferred rebuilds queued and don't touch the
+        // window — it belongs to the presentation for now.
+        return;
+    }
+
+    // No modal on screen. Replay rebuilds deferred while one was up — on the
+    // dismissal edge, or if a defer/dismiss slipped between throttled samples.
+    if was || crate::state::has_deferred_rebuilds() {
+        crate::state::replay_deferred_rebuilds();
+    }
+    // Re-assert the window if a dismissed modal left it detached. `force` on
+    // the dismissal edge recovers the ASWebAuthenticationSession "white/frozen"
+    // case; otherwise only a definitively hidden window is recovered.
+    reassert_root_window(was);
+}
+
+/// Issue #5203 — re-make the app's window key & visible if it has become
+/// detached. `force` (set on a modal-dismissal edge) also recovers a window
+/// that is merely no longer key; otherwise only a hidden window is recovered,
+/// to avoid fighting legitimate key changes (e.g. iPad multi-window). Only
+/// while the app is foreground-active, so we don't fight background transitions.
+fn reassert_root_window(force: bool) {
+    unsafe {
+        let app_cls = match AnyClass::get(c"UIApplication") {
+            Some(c) => c,
+            None => return,
+        };
+        let app: *mut AnyObject = msg_send![app_cls, sharedApplication];
+        if app.is_null() {
+            return;
+        }
+        // UIApplicationStateActive == 0.
+        let state: i64 = msg_send![app, applicationState];
+        if state != 0 {
+            return;
+        }
+        APPS.with(|a| {
+            for entry in a.borrow().iter() {
+                let win: &UIWindow = &entry.window;
+                let hidden: bool = msg_send![win, isHidden];
+                let is_key: bool = msg_send![win, isKeyWindow];
+                if hidden || (force && !is_key) {
+                    win.makeKeyAndVisible();
+                }
+            }
+        });
     }
 }
 

--- a/crates/perry-ui-ios/src/app.rs
+++ b/crates/perry-ui-ios/src/app.rs
@@ -813,23 +813,33 @@ fn run_root_health_check() {
         return;
     }
 
-    // No modal on screen. Replay rebuilds deferred while one was up — on the
-    // dismissal edge, or if a defer/dismiss slipped between throttled samples.
-    if was || crate::state::has_deferred_rebuilds() {
-        crate::state::replay_deferred_rebuilds();
+    // No modal on screen. Recover only when there is evidence of modal-related
+    // work: a modal we observed going away (`was`), or a rebuild deferred while
+    // one was up. The defer-and-dismiss race can slip a modal entirely between
+    // throttled samples (state_set checks live, every tick), so a queued
+    // deferral is the more reliable "a modal was just up" signal than `was`
+    // alone. Without such evidence, leave the window alone — don't resurrect an
+    // unrelated hidden window and break the no-modal behavior contract.
+    if !was && !crate::state::has_deferred_rebuilds() {
+        return;
     }
-    // Re-assert the window if a dismissed modal left it detached. `force` on
-    // the dismissal edge recovers the ASWebAuthenticationSession "white/frozen"
-    // case; otherwise only a definitively hidden window is recovered.
-    reassert_root_window(was);
+    crate::state::replay_deferred_rebuilds();
+    // A dismissed modal can leave the window visible but no longer key (the
+    // ASWebAuthenticationSession "white/frozen" case), not just hidden — so
+    // recover both here, unconditionally, now that we know a modal was up.
+    reassert_root_window();
 }
 
-/// Issue #5203 — re-make the app's window key & visible if it has become
-/// detached. `force` (set on a modal-dismissal edge) also recovers a window
-/// that is merely no longer key; otherwise only a hidden window is recovered,
-/// to avoid fighting legitimate key changes (e.g. iPad multi-window). Only
-/// while the app is foreground-active, so we don't fight background transitions.
-fn reassert_root_window(force: bool) {
+/// Issue #5203 — re-make the app's window key & visible if a dismissed modal
+/// left it detached (hidden, or visible-but-no-longer-key). Only called from
+/// the recovery path (a modal was just up), and only while the app is
+/// foreground-active so we don't fight background/inactive transitions.
+///
+/// Iterating every `APPS` entry is exact rather than approximate here: Perry's
+/// generated Info.plist sets `UIApplicationSupportsMultipleScenes=false`
+/// (`bundle_ios.rs`), so there is a single scene/window and this loop touches
+/// exactly the window whose modal just dismissed.
+fn reassert_root_window() {
     unsafe {
         let app_cls = match AnyClass::get(c"UIApplication") {
             Some(c) => c,
@@ -849,7 +859,7 @@ fn reassert_root_window(force: bool) {
                 let win: &UIWindow = &entry.window;
                 let hidden: bool = msg_send![win, isHidden];
                 let is_key: bool = msg_send![win, isKeyWindow];
-                if hidden || (force && !is_key) {
+                if hidden || !is_key {
                     win.makeKeyAndVisible();
                 }
             }

--- a/crates/perry-ui-ios/src/state.rs
+++ b/crates/perry-ui-ios/src/state.rs
@@ -50,6 +50,16 @@ struct ForEachBinding {
     render_closure: f64,
 }
 
+/// Issue #5203 — a forEach rebuild deferred because a system modal (StoreKit
+/// sheet, ASWebAuthenticationSession, Perry alert, …) was presented. Keyed by
+/// container handle so repeated heartbeat rebuilds of the same container
+/// coalesce to a single replay once the modal dismisses.
+struct DeferredRebuild {
+    container_handle: i64,
+    render_closure: f64,
+    state_handle: i64,
+}
+
 thread_local! {
     static STATES: RefCell<Vec<StateEntry>> = RefCell::new(Vec::new());
     static TEXT_BINDINGS: RefCell<HashMap<i64, Vec<TextBinding>>> = RefCell::new(HashMap::new());
@@ -61,6 +71,10 @@ thread_local! {
     static VISIBILITY_BINDINGS: RefCell<HashMap<i64, Vec<VisibilityBinding>>> = RefCell::new(HashMap::new());
     static FOR_EACH_BINDINGS: RefCell<HashMap<i64, Vec<ForEachBinding>>> = RefCell::new(HashMap::new());
     static ON_CHANGE_CALLBACKS: RefCell<HashMap<i64, Vec<f64>>> = RefCell::new(HashMap::new());
+    /// Issue #5203 — forEach rebuilds deferred while a system modal was on
+    /// screen. Drained by the pump (`replay_deferred_rebuilds`) once no modal
+    /// is presented.
+    static DEFERRED_REBUILDS: RefCell<Vec<DeferredRebuild>> = RefCell::new(Vec::new());
 }
 
 fn str_from_header(ptr: *const u8) -> &'static str {
@@ -208,9 +222,24 @@ pub fn state_set(handle: i64, value: f64) {
             })
             .unwrap_or_default()
     });
-    for (container, closure) in foreach_snapshot {
-        widgets::clear_children(container);
-        render_for_each(container, closure, value);
+    if !foreach_snapshot.is_empty() {
+        // Issue #5203 — a forEach rebuild clears+rebuilds its container. Doing
+        // that while a system modal (StoreKit purchase sheet,
+        // ASWebAuthenticationSession, share sheet, or a Perry alert) is
+        // presented can SIGSEGV on iOS 26+, and a rebuild under a modal is
+        // invisible anyway. Defer it (coalesced per container) and let the pump
+        // replay the freshest state once the modal dismisses. This mirrors the
+        // touch-processing hazard the button path already avoids, but for
+        // presented modals rather than touch dispatch.
+        let modal_up = crate::app::system_modal_presented();
+        for (container, closure) in foreach_snapshot {
+            if modal_up {
+                defer_foreach_rebuild(container, closure, handle);
+            } else {
+                widgets::clear_children(container);
+                render_for_each(container, closure, value);
+            }
+        }
     }
 
     // Invoke onChange callbacks.
@@ -269,6 +298,44 @@ fn render_for_each(container: i64, closure: f64, count: f64) {
         let child_f64 = unsafe { js_closure_call1(closure_ptr, i as f64) };
         let child_handle = unsafe { js_nanbox_get_pointer(child_f64) };
         widgets::add_child(container, child_handle);
+    }
+}
+
+/// Issue #5203 — queue a forEach rebuild that can't run now because a system
+/// modal is presented. Coalesces per container so a heartbeat that fires many
+/// times under a modal only replays once (latest closure/state wins).
+fn defer_foreach_rebuild(container: i64, closure: f64, state_handle: i64) {
+    DEFERRED_REBUILDS.with(|d| {
+        let mut d = d.borrow_mut();
+        if let Some(existing) = d.iter_mut().find(|e| e.container_handle == container) {
+            existing.render_closure = closure;
+            existing.state_handle = state_handle;
+        } else {
+            d.push(DeferredRebuild {
+                container_handle: container,
+                render_closure: closure,
+                state_handle,
+            });
+        }
+    });
+}
+
+/// Issue #5203 — whether any forEach rebuild is waiting for a modal to dismiss.
+pub fn has_deferred_rebuilds() -> bool {
+    DEFERRED_REBUILDS.with(|d| !d.borrow().is_empty())
+}
+
+/// Issue #5203 — replay forEach rebuilds deferred while a system modal was
+/// presented, using the freshest state value. Called by the pump once no modal
+/// is on screen. The queue is taken before invoking user closures so a
+/// re-entrant `state_set` sees an empty queue.
+pub fn replay_deferred_rebuilds() {
+    let pending: Vec<DeferredRebuild> =
+        DEFERRED_REBUILDS.with(|d| std::mem::take(&mut *d.borrow_mut()));
+    for item in pending {
+        let value = state_get(item.state_handle);
+        widgets::clear_children(item.container_handle);
+        render_for_each(item.container_handle, item.render_closure, value);
     }
 }
 


### PR DESCRIPTION
Fixes #5203.

## Problem

Mutating the widget tree — an app's `rebuild()` that clears+rebuilds the root container — **while a system modal is presented** (StoreKit's purchase sheet via `Product.purchase()`, or GoogleSignIn's `ASWebAuthenticationSession`) either **SIGSEGVs** or leaves the app's **root window detached** (white, frozen, and *not recoverable by subsequent rebuilds*) on iOS 26. When the scheduled rebuild fires via the heartbeat while the sheet is up:

- StoreKit sheet → SIGSEGV
- ASWebAuthenticationSession → white/frozen window after the sheet dismisses (the most serious case — the root window never comes back)

This is the same hazard class the button path already documents/avoids for touch processing (`button.rs`: *"Dispatch async to avoid modifying the view hierarchy during UIKit touch event processing (crashes on iOS 26+)"*), but it also applies to **presented modals**, not just touch dispatch.

## Fix

Two cooperating guards, both **gated on a system modal actually being presented**, so behavior is byte-identical in the normal (no-modal) case:

1. **Defer destructive rebuilds while a modal is up** (`state.rs`). The reactive `forEach` rebuild path (`clear_children` + re-render) is exactly how a heartbeat-driven `rebuild()` tears down and rebuilds the root. While `system_modal_presented()` is true it is deferred (coalesced per container) instead of mutating the hierarchy underneath the presented sheet → no SIGSEGV.

2. **Self-heal the window on dismissal** (`app.rs`). A throttled pump health check (~every 48 ms) replays the deferred rebuilds with the freshest state and re-asserts the window `makeKeyAndVisible` once no modal is on screen → recovers the "white/frozen, unrecoverable" case. Re-assertion is *forced* on the modal-dismissal edge and otherwise only recovers a definitively hidden window (to avoid fighting legitimate key changes, e.g. iPad multi-window), and runs only while the app is foreground-active.

`system_modal_presented()` walks the scene graph to the key window's `rootViewController` and checks `presentedViewController` (reusing the same pattern as `alert.rs`).

## Behavior notes / tradeoffs

- A `forEach` list update that happens **behind** a presented modal (including a Perry `alertWithButtons` alert) is now applied when the modal dismisses rather than live. Since the list is behind the modal it's invisible either way, and this is the safer choice on iOS 26. Normal Perry navigation (NavStack routes toggle `hidden`, they don't `present`) does **not** set `presentedViewController`, so it's unaffected.
- Scope is iOS only, matching the issue. tvOS/visionOS could take the same treatment if the hazard is confirmed there.

## Validation

I don't have an iOS 26 device to reproduce the crash end-to-end, so this is validated by:
- Compiles cleanly against the **iOS 26.5 SDK** (`cargo check --target aarch64-apple-ios-sim -p perry-ui-ios`), no new warnings.
- The guard is inert unless a modal is presented; the recovery path is a no-op while the window is key & visible.

Feedback welcome on whether the deferral should also cover imperative `clear_children`/`add_child` called directly from app code (this PR covers the reactive `state`-driven rebuild path, which is the documented heartbeat repro), and on the ~48 ms health-check cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS behavior when system modals are presented or dismissed.
  * Deferred `forEach` interface list updates while a system modal is visible to prevent flicker and inconsistent UI.
  * Automatically restores and replays deferred updates after the modal closes.
  * Reasserts app window key/visibility when modal presentation can leave windows hidden or detached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->