### PR TITLE
perf(runtime,gc): fix quadratic downgraded-array element writes (~4.3×) + O(1) layout store probe (#5094)

### DIFF
--- a/crates/perry-runtime/src/gc/layout.rs
+++ b/crates/perry-runtime/src/gc/layout.rs
@@ -449,11 +449,15 @@ pub(crate) fn layout_clear_for_ptr(user_ptr: usize) {
     }
 }
 
+/// True when `user_ptr`'s object currently has a canonical `TypedLayoutDescriptor`
+/// installed in `TYPED_LAYOUTS`. Reads the O(1) `GC_OBJ_TYPED_LAYOUT_INTACT`
+/// header bit instead of probing the thread-local map: the bit is maintained in
+/// lock-step with every map insert/remove (intact set ⟺ descriptor present — see
+/// the invariant documented on `GC_OBJ_TYPED_LAYOUT_INTACT`), so it answers the
+/// same question without a per-call TLS hashmap touch. This is on the dynamic
+/// object-store hot path via `mark_object_dynamic_shape_unknown` (#5094).
 pub(crate) fn layout_has_typed_descriptor(user_ptr: usize) -> bool {
-    if user_ptr == 0 {
-        return false;
-    }
-    TYPED_LAYOUTS.with(|m| m.borrow().contains_key(&user_ptr))
+    layout_typed_intact_for_user(user_ptr)
 }
 
 pub(super) unsafe fn layout_set_typed_unknown(header: *mut GcHeader, user_ptr: usize) {
@@ -486,23 +490,36 @@ pub(crate) fn layout_note_slot(parent_user: usize, slot_index: usize, value_bits
         if (*header)._reserved & GC_LAYOUT_STATE_MASK == GC_LAYOUT_UNKNOWN {
             return;
         }
-        if let Some(typed) = TYPED_LAYOUTS.with(|m| m.borrow().get(&parent_user).cloned()) {
-            if slot_index >= typed.slot_count {
-                layout_set_typed_unknown(header, parent_user);
-                return;
-            }
-            if typed.raw_f64_mask.contains_slot(slot_index) {
-                if !layout_raw_f64_bits(value_bits) {
+        // The canonical typed-shape descriptor probe below is a thread-local
+        // hashmap lookup, paid on every field/element store. Gate it on the
+        // O(1) `GC_OBJ_TYPED_LAYOUT_INTACT` header bit: that bit is set and
+        // cleared in lock-step with every `TYPED_LAYOUTS` insert/remove (see the
+        // invariant documented on `GC_OBJ_TYPED_LAYOUT_INTACT`), so a clear bit
+        // proves the map has no entry for this object — the probe would return
+        // `None` and fall through to the pointer-mask path below. Skipping it
+        // removes the per-write TLS touch on the common dynamic-shape /
+        // pointer-free object and array store path (#5094). The inner `if let`
+        // still tolerates a `None` defensively, so a transiently desynced bit
+        // can only cost an extra fall-through, never mis-track a slot.
+        if (*header)._reserved & GC_OBJ_TYPED_LAYOUT_INTACT != 0 {
+            if let Some(typed) = TYPED_LAYOUTS.with(|m| m.borrow().get(&parent_user).cloned()) {
+                if slot_index >= typed.slot_count {
                     layout_set_typed_unknown(header, parent_user);
+                    return;
+                }
+                if typed.raw_f64_mask.contains_slot(slot_index) {
+                    if !layout_raw_f64_bits(value_bits) {
+                        layout_set_typed_unknown(header, parent_user);
+                    }
+                    return;
+                }
+                let pointer = layout_pointer_bearing_bits(value_bits);
+                if pointer && !typed.pointer_mask.contains_slot(slot_index) {
+                    layout_set_typed_unknown(header, parent_user);
+                    return;
                 }
                 return;
             }
-            let pointer = layout_pointer_bearing_bits(value_bits);
-            if pointer && !typed.pointer_mask.contains_slot(slot_index) {
-                layout_set_typed_unknown(header, parent_user);
-                return;
-            }
-            return;
         }
         let pointer = layout_pointer_bearing_bits(value_bits);
         // A result array built by a runtime helper can declare that its live

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -1385,6 +1385,16 @@ fn shape_keyed_object_addr(source: ObservationSource, object_addr: usize) -> usi
 }
 
 fn observe_array(site_id: u64, arr: *const ArrayHeader, index: u32) {
+    // #5094: recording-only helper. When typed-feedback is off (the default),
+    // `observe` records nothing, so the whole body is dead work — and
+    // `classify_array` walks the per-object pointer-slot layout, which is O(len)
+    // for a downgraded (SIDE_MASK) array. This ran per `arr[i] = v` on a
+    // heterogeneous array (via `js_typed_feedback_array_set_index_or_string` and
+    // the polymorphic / string-key set wrappers), making the write loop
+    // quadratic. Bail before the walk, matching every other recording path.
+    if !typed_feedback_enabled() {
+        return;
+    }
     let raw_addr = normalize_raw_object_addr(arr as u64);
     let (class_id, heap_type, aux, element_kind) = classify_array(raw_addr, Some(index));
     observe(
@@ -1409,6 +1419,17 @@ pub extern "C" fn js_typed_feedback_array_get_f64(
     arr: *const ArrayHeader,
     index: u32,
 ) -> f64 {
+    // #5094: when typed-feedback recording is off (the default — `guard_observe`
+    // early-returns with no side effect), the whole classify/observe block is
+    // dead work. `classify_array` walks the per-object pointer-slot layout
+    // (`array_layout_kind` → `layout_visit_pointer_slots`), which is O(len) for a
+    // downgraded (SIDE_MASK) array — so this ran per element and made
+    // `arr[i]` on a heterogeneous array quadratic. Mirror the gate the sibling
+    // guard wrappers already carry (`plain_array_index_get_guard_impl`) and take
+    // the underlying array op directly.
+    if !typed_feedback_enabled() {
+        return crate::array::js_array_get_f64(arr, index);
+    }
     let raw_addr = normalize_raw_object_addr(arr as u64);
     let (class_id, heap_type, aux, element_kind) = classify_array(raw_addr, Some(index));
     let observation = Observation {
@@ -1846,6 +1867,13 @@ pub extern "C" fn js_typed_feedback_array_set_f64(
     index: u32,
     value: f64,
 ) {
+    // #5094: skip the dead classify/observe block when recording is off (see
+    // `js_typed_feedback_array_get_f64`). The tail array op is the only
+    // observable effect in that case.
+    if !typed_feedback_enabled() {
+        crate::array::js_array_set_f64(arr, index, value);
+        return;
+    }
     let raw_addr = normalize_raw_object_addr(arr as u64);
     let (class_id, heap_type, aux, _element_kind) = classify_array(raw_addr, Some(index));
     let observation = Observation {
@@ -1877,6 +1905,12 @@ pub extern "C" fn js_typed_feedback_array_set_f64_extend(
     index: u32,
     value: f64,
 ) -> *mut ArrayHeader {
+    // #5094: skip the dead classify/observe block when recording is off (see
+    // `js_typed_feedback_array_get_f64`). Preserve the strict extend semantics
+    // documented below by routing straight to the same tail op.
+    if !typed_feedback_enabled() {
+        return crate::array::js_array_set_f64_extend_strict(arr, index, value);
+    }
     let raw_addr = normalize_raw_object_addr(arr as u64);
     let (class_id, heap_type, aux, _element_kind) = classify_array(raw_addr, Some(index));
     let observation = Observation {


### PR DESCRIPTION
## Summary

Two per-op-overhead fixes on the array/object element + field store hot path, both under the #5094 GC-layout umbrella. Headline: `arr[i] = v` on a downgraded (heterogeneous) array was **quadratic** because the typed-feedback wrappers ran an O(len) pointer-slot layout walk on *every* element even when feedback recording is off (the default). Gating that dead work takes `bench_numeric_array_downgrade` from **~10.6s → ~2.46s (~4.3×)**, checksum-identical to Node.

## Changes

- **`crates/perry-runtime/src/typed_feedback.rs`** — gate the array feedback *recording* paths on `typed_feedback_enabled()`:
  - `observe_array` (used by `js_typed_feedback_array_set_index_or_string`, `js_typed_feedback_object_set_index_polymorphic`, `js_typed_feedback_array_set_string_key`, `js_typed_feedback_observe_array_element`) now bails before `classify_array` when recording is off.
  - `js_typed_feedback_array_get_f64` / `array_set_f64` / `array_set_f64_extend` take the underlying array op directly when recording is off.
  - Why it mattered: `classify_array` → `array_layout_kind` → `layout_visit_pointer_slots` is **O(len)** for a `SIDE_MASK` (downgraded) array, so it ran per element → quadratic write loop. `guard_observe`/`observe` already early-return with no side effect when disabled, so the classify/observe block was pure dead work. This mirrors the gate the sibling guard wrappers already carry (`plain_array_index_get_guard_impl`, `js_typed_feedback_plain_array_index_set_guard`). The tail array op is unchanged, and the skipped `record_*` calls are already no-ops when disabled.
- **`crates/perry-runtime/src/gc/layout.rs`** — replace the per-write `TYPED_LAYOUTS` thread-local probe in `layout_note_slot` and `layout_has_typed_descriptor` with the O(1) `GC_OBJ_TYPED_LAYOUT_INTACT` header bit. The bit is maintained in lock-step with every map insert/remove (**intact set ⟺ descriptor present**), so it is behavior-preserving; I audited all insert sites (set the bit: 630/735/841) and remove sites (clear the bit: 378/394/411/420/441/462/762/839/856). Shaves one per-write TLS lookup from the object field-store path (and the downgraded-array store path).

## Related issue

Refs #5094 (the GC per-object-layout / per-op-TLS umbrella).

Verification notes for the umbrella's other headline benchmarks on current `main`:
- **`bench_object_property`**: perry ~90ms vs Node ~17ms (~5×). The issue text cites "~17×/70×"; that figure is **stale** — intervening work has largely closed it. The remaining cost is the dynamic-set dispatch (exotic-type triage + `PROPERTY_DESCRIPTORS`/`ACCESSOR_DESCRIPTORS` SipHash + key-string alloc), *not* the GC-layout TLS; the `layout.rs` change here is a small step. Gating the exotic-triage dispatch for plain objects is the bigger follow-up.
- **Remaining `numeric_array_downgrade` cost** after this PR is `note_array_slot` → `layout_note_slot`'s `LAYOUT_SLOT_MASKS` TLS on the **runtime** `js_array_set_index_or_string_strict` path — the runtime-path analog of the codegen scalar-aware note #5098 added. It needs capturing the old slot value before the store; left as a follow-up.

## Test plan

- `cargo test -p perry-runtime --lib typed_feedback` (49 passed) and `gc::tests::layout_trace` (38 passed) — 0 failures.
- `bench_numeric_array_downgrade`: **10.6s → 2.46s**; checksum `6500875` matches Node. Re-profiled: `classify_array`/`array_layout_kind` gone from the hot path.
- Feedback **enabled** path unchanged: `PERRY_TYPED_FEEDBACK=1 ./bench` → checksum `6500875` (full observe path runs correctly; unit tests also exercise it via `#[cfg(test)]`).
- GC stress, all checksum-correct, no panics: `PERRY_GC_VERIFY_EVACUATION=1 PERRY_GC_FORCE_EVACUATE=1` and `PERRY_GEN_GC=0` (full mark-sweep) on both `numeric_array_downgrade` and `object_property` (checksums `6500875` / `1999990000`).
- Targeted gap parity (`run_parity_tests.sh --filter`) over the array/object/class-field surface these changes touch: **48/48 pass, 0 fail, 0 crash** (array 10, object 9, class 24, typed_array 3, map_set 2). The full `test_gap_` sweep was not run to completion locally — it hangs on unrelated network-server tests (`test_net_echo_server`, `test_gap_fetch_request_from_node_incoming_message`) that have no effective macOS timeout and are orthogonal to these runtime changes; CI conformance-smoke covers the full set.

## Checklist

- [x] No version bump; no `CLAUDE.md` / `CHANGELOG.md` edits (maintainer folds these in at merge).
- [x] Conventional commit prefixes (`perf:`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved handling of typed object layouts during memory updates.
  * Reduced overhead for array reads and writes when typed-feedback recording is disabled.
  * Prevented unnecessary per-element layout checks that could cause slowdowns with heterogeneous arrays.
* **Reliability**
  * Strengthened validation of typed layout information and safely falls back when mismatches are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->