### PR TITLE
fix(runtime): exclude class objects from the store-plan cache (#6595)

### DIFF
--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -363,7 +363,14 @@ pub extern "C" fn js_object_set_field_by_name(
                 {
                     let o = raw as *mut ObjectHeader;
                     let class_id = (*o).class_id;
-                    if class_id != 0
+                    // #6595: a per-evaluation CLASS OBJECT must never take
+                    // this lane — it skips the #6530
+                    // `mirror_class_object_static_write` hook every in-body
+                    // completion runs, and (template cid, key) plans recorded
+                    // by instances sharing the cid would falsely certify it.
+                    // See the matching gates at the plan record sites.
+                    if (*o).object_type == crate::error::OBJECT_TYPE_REGULAR
+                        && class_id != 0
                         && class_id != NATIVE_MODULE_CLASS_ID
                         && super::prop_plan::store_plan_check(class_id, key as usize)
                     {
@@ -1035,9 +1042,14 @@ pub extern "C" fn js_object_set_field_by_name(
             | crate::gc::OBJ_FLAG_NULL_PROTO
             | crate::gc::OBJ_FLAG_HAS_DESCRIPTORS;
         let obj_class_id = (*obj).class_id;
+        // #6595: class objects (`OBJECT_TYPE_CLASS`) are excluded — their
+        // writes must always reach the `mirror_class_object_static_write`
+        // completions, and their cid is shared with their instances so a
+        // plan keyed on it conflates two different prototype chains.
         let plan_eligible = !key.is_null()
             && obj_class_id != 0
             && obj_class_id != NATIVE_MODULE_CLASS_ID
+            && (*obj).object_type == crate::error::OBJECT_TYPE_REGULAR
             && (*gc_header)._reserved & PLAN_BLOCKING_FLAGS == 0;
         let plan_fast = plan_eligible
             && super::prop_plan::store_plan_check(obj_class_id, interned_key as usize);
@@ -1203,6 +1215,7 @@ pub extern "C" fn js_object_set_field_by_name(
             if !plan_fast
                 && obj_class_id != 0
                 && obj_class_id != NATIVE_MODULE_CLASS_ID
+                && (*obj).object_type == crate::error::OBJECT_TYPE_REGULAR
                 && obj_flags & PLAN_BLOCKING_FLAGS == 0
             {
                 super::prop_plan::store_plan_record(obj_class_id, interned_key as usize);

--- a/crates/perry-runtime/src/proxy.rs
+++ b/crates/perry-runtime/src/proxy.rs
@@ -1354,8 +1354,23 @@ fn ordinary_set_with_receiver(target: f64, key: f64, value: f64, receiver: f64) 
                             let key_ptr = crate::builtins::js_string_coerce(key)
                                 as *const crate::StringHeader;
                             let interned = crate::object::interned_key_ptr(key_ptr);
+                            // #6595: a per-evaluation CLASS OBJECT (what a
+                            // capture-carrying class materializes as,
+                            // `object_type == OBJECT_TYPE_CLASS`) shares its
+                            // template cid with its instances, and its own-data
+                            // writes must reach the #6530
+                            // `mirror_class_object_static_write` hook in
+                            // `js_object_set_field_by_name`. Recording a plan
+                            // here armed the mirror-free fast lane for the very
+                            // store being vetted, so from the second same-shaped
+                            // class on (shape-transition cache hit) post-class
+                            // statics like bundled zod's `ZodX.create` vanished
+                            // from ClassRef static dispatch. Class objects
+                            // neither record nor honor store plans.
                             let plan_eligible = header._reserved & CHAIN_DIVERGE == 0
                                 && class_id != crate::object::NATIVE_MODULE_CLASS_ID
+                                && (*(addr as *const crate::ObjectHeader)).object_type
+                                    == crate::error::OBJECT_TYPE_REGULAR
                                 && interned != 0;
                             if plan_eligible
                                 && crate::object::prop_plan::store_plan_check(class_id, interned)

--- a/test-files/test_gap_6595_repeated_capture_class_statics.ts
+++ b/test-files/test_gap_6595_repeated_capture_class_statics.ts
@@ -7,12 +7,16 @@
 // `CLASS_DYNAMIC_PROPS` mirror — sibling-method dispatch through the INT32
 // ClassRef then missed and returned the class ref itself.
 //
-// One class (test_gap_class_capture_forward_static.ts) can't catch this: the
-// first class of a shape always misses the transition cache and falls to the
-// mirroring path. Bundled zod has ~40 same-shaped classes; two suffice.
+// Every class here must be CAPTURE-CARRYING (methods referencing outer
+// locals) or it stays an INT32 ClassRef and the statics never touch the
+// heap-class-object store path. One class alone can't catch the bug either:
+// the first class of a shape misses the transition cache and falls to the
+// mirroring path. Bundled zod has ~32 same-shaped classes; two suffice.
 
 function makeModule() {
   const tag = (s: string) => "[" + s + "]";
+  const isUndef = (x: any) => typeof x === "undefined";
+  const isNull = (x: any) => x === null;
 
   class Base {
     _def: any;
@@ -41,7 +45,7 @@ function makeModule() {
 
   class SubOpt extends Base {
     _parse(ctx: any) {
-      if (typeof ctx.data === "undefined") return undefined;
+      if (isUndef(ctx.data)) return undefined;
       return "opt:" + ctx.errorMap + ":" + ctx.data;
     }
     unwrap() {
@@ -51,7 +55,7 @@ function makeModule() {
 
   class SubNull extends Base {
     _parse(ctx: any) {
-      if (ctx.data === null) return null;
+      if (isNull(ctx.data)) return null;
       return "null:" + ctx.errorMap + ":" + ctx.data;
     }
     unwrap() {

--- a/test-files/test_gap_6595_repeated_capture_class_statics.ts
+++ b/test-files/test_gap_6595_repeated_capture_class_statics.ts
@@ -1,0 +1,99 @@
+// #6595 (regression of #6530 introduced by #6541): post-class arrow statics
+// on REPEATED same-shaped capture-carrying classes. The receiver-based
+// `[[Set]]` records a store plan for (template_cid, key) BEFORE the store
+// reaches `js_object_set_field_by_name`, so from the SECOND same-shaped class
+// object on (identical key-append sequence → shape-transition cache hit) the
+// static write took the raw fast lane and skipped the #6530
+// `CLASS_DYNAMIC_PROPS` mirror — sibling-method dispatch through the INT32
+// ClassRef then missed and returned the class ref itself.
+//
+// One class (test_gap_class_capture_forward_static.ts) can't catch this: the
+// first class of a shape always misses the transition cache and falls to the
+// mirroring path. Bundled zod has ~40 same-shaped classes; two suffice.
+
+function makeModule() {
+  const tag = (s: string) => "[" + s + "]";
+
+  class Base {
+    _def: any;
+    constructor(def: any) {
+      this._def = def;
+      this.parse = this.parse.bind(this);
+      this.optional = this.optional.bind(this);
+      this.nullable = this.nullable.bind(this);
+    }
+    parse(x: any) {
+      return this._parse({ data: x, errorMap: this._def.errorMap });
+    }
+    _parse(ctx: any): any {
+      return "base:" + ctx.data;
+    }
+    optional() {
+      return (SubOpt as any).create(this, this._def);
+    }
+    nullable() {
+      return (SubNull as any).create(this, this._def);
+    }
+    label() {
+      return tag(this._def.name);
+    }
+  }
+
+  class SubOpt extends Base {
+    _parse(ctx: any) {
+      if (typeof ctx.data === "undefined") return undefined;
+      return "opt:" + ctx.errorMap + ":" + ctx.data;
+    }
+    unwrap() {
+      return this._def.innerType;
+    }
+  }
+
+  class SubNull extends Base {
+    _parse(ctx: any) {
+      if (ctx.data === null) return null;
+      return "null:" + ctx.errorMap + ":" + ctx.data;
+    }
+    unwrap() {
+      return this._def.innerType;
+    }
+  }
+
+  // Identical post-class static write sequence on same-shaped class objects:
+  // the first write learns the shape-transition edge, the second must still
+  // mirror into the ClassRef-world static table.
+  (SubOpt as any).create = (inner: any, def: any) =>
+    new SubOpt({ innerType: inner, errorMap: "eo", name: "opt" });
+  (SubNull as any).create = (inner: any, def: any) =>
+    new SubNull({ innerType: inner, errorMap: "en", name: "null" });
+
+  return { Base, SubOpt, SubNull };
+}
+
+const m = makeModule();
+const b = new m.Base({ errorMap: "bm", name: "base" });
+
+// First same-shaped class: static via sibling-method ClassRef dispatch.
+const o = b.optional();
+console.log("opt typeof:", typeof o);
+console.log("opt instanceof SubOpt:", o instanceof m.SubOpt);
+console.log("opt _def set:", o._def !== undefined);
+console.log("opt parse undef:", o.parse(undefined));
+console.log("opt parse val:", o.parse(7));
+console.log("opt label:", o.label());
+
+// SECOND same-shaped class — the transition-cache-hit static write.
+const n = b.nullable();
+console.log("null typeof:", typeof n);
+console.log("null instanceof SubNull:", n instanceof m.SubNull);
+console.log("null _def set:", n._def !== undefined);
+console.log("null parse null:", n.parse(null));
+console.log("null parse val:", n.parse(3));
+console.log("null label:", n.label());
+console.log("null unwrap is base:", n.unwrap() === b);
+
+// Chained: optional-of-nullable exercises both static dispatches in sequence.
+const chained = b.nullable().optional();
+console.log("chain typeof:", typeof chained);
+console.log("chain parse undef:", chained.parse(undefined));
+console.log("chain parse val:", chained.parse(5));


### PR DESCRIPTION
Fixes #6595.

## Root cause

#6541 consults **and records** the shared store-plan cache in `ordinary_set_with_receiver` *before* the store flows through `target_set` → `js_object_set_field_by_name`. That ordering is the regression: the very store being vetted arrives at `js_object_set_field_by_name` with its own `(class_id, key)` plan freshly recorded, so it takes the top fast lane — which performs a raw slot store and skips every in-body write completion, including the #6530/#6537 `mirror_class_object_static_write` hook that syncs per-evaluation class objects into `CLASS_DYNAMIC_PROPS`.

For a **class object** (what a capture-carrying class materializes as — bundled zod's entire `ZodType` family) the failure needs one more ingredient, which is why the single-class #6537 gap test stayed green: the lane's raw store also needs a shape-transition cache hit, and class objects repeat identical key-append sequences. So the **first** class of a shape falls through to the mirroring path (simple cases pass), and from the **second same-shaped class on** (`zodlocal.cjs` has 32 `ZodX.create = ...` writes) the static lands only on the class object's own fields. `js_class_static_method_call` through the INT32 ClassRef then misses and returns the receiver — `.optional()` evaluates to the class itself, `this._def` is `undefined`, and every downstream read blows up (`errorMap` / `_getType` / `description`), exactly the #6530 symptom set.

Confirmed with a temporary diagnostic on the bundled-zod repro — per class, in order:

```
ordinary_set class-object cid=N  plan check: miss   ← #6541 records after the walk
top-lane     class-object cid=N key=create plan_hit=true   ← same store, mirror skipped
[perry dispatch-miss] static-member-call: class-ref `ZodOptional` (id 133)."create"
  did not resolve → returning the receiver (class ref)
```

## Fix

Class objects (`object_type == OBJECT_TYPE_CLASS`) are now **ineligible for the store-plan cache** at all four gates:

- `proxy.rs` `ordinary_set_with_receiver` fast path (`plan_eligible` — blocks both check and record),
- `field_set_by_name.rs` top fast lane gate,
- `field_set_by_name.rs` in-body `plan_eligible` (check),
- `field_set_by_name.rs` in-body record site.

Their writes always take the mirroring completions again (statics writes are cold — no measurable cost), and this also closes the latent cross-poisoning both ways: a class object shares its template cid with its instances, so a plan learned on one chain could falsely certify a store on the other (the interception verdict is per-chain, and the two chains differ). Instances (`OBJECT_TYPE_REGULAR`) keep the #6539/#6541 fast lanes unchanged.

## Regression test

`test_gap_6595_repeated_capture_class_statics.ts` — **two** same-shaped capture-carrying classes with post-class arrow statics, dispatched from a sibling method through the ClassRef world. Two subtleties baked into the test (both learned the hard way):

- every class must capture an outer local, or it stays an INT32 ClassRef and never touches the heap-class-object store path;
- one class cannot catch the bug — the first class of a shape misses the transition cache and still mirrors.

Fails on current `main` (`null typeof: function`, `_def set: false`, then the `errorMap` TypeError); byte-identical to `node --experimental-strip-types` with the fix.

## Validation

- Issue repro (`next/dist/compiled/zod/index.cjs` copied locally): both cases match node byte-for-byte with the fix (`undefined` / `{"a":{"p":"x"}}`); both threw on baseline.
- Guard tests byte-identical to node: `test_gap_class_capture_forward_static.ts` (#6537), `test_gap_put_value_plan_cache.ts` (#6541), `test_gap_field_lane_semantics.ts` (#6539).
- `test_gap_prop_plan_cache_invalidation.ts` (#6532): same TypeError, same exit code; the receiver rendering differs from node (`#<Object>` vs `#<H>`) — verified **pre-existing on unmodified `main`** by rebuilding the baseline runtime and re-running (the frozen-write throw path sits behind the frozen-family flag checks, before every gate this PR touches).
- `cargo test -p perry-runtime` green single-threaded; `cargo fmt --check` clean on the touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed incorrect handling of static properties on dynamically created classes.
  - Ensured class-based writes consistently preserve static behavior across repeated, similarly shaped instances.
  - Improved chained optional and nullable operations involving class static properties, including correct parsing, type checks, and unwrapping results.

- **Tests**
  - Added regression coverage for captured classes, inherited static behavior, and repeated property access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->