### PR TITLE
feat(error): #5247 — source location on property-read-on-nullish TypeError

### DIFF
--- a/crates/perry-codegen-arkts/src/conditions.rs
+++ b/crates/perry-codegen-arkts/src/conditions.rs
@@ -166,7 +166,9 @@ pub(crate) fn serialize_condition(
             // identifier into the page struct (see #410 lines 48/52/68).
             "true".to_string()
         }
-        Expr::PropertyGet { object, property } => {
+        Expr::PropertyGet {
+            object, property, ..
+        } => {
             // `obj.prop` shape — used commonly in conditions like
             // `props.mobile`. Recursively stringify the object access
             // chain. Keeps the predicate syntactically valid; the

--- a/crates/perry-codegen-arkts/src/emit_widget.rs
+++ b/crates/perry-codegen-arkts/src/emit_widget.rs
@@ -45,7 +45,10 @@ pub(crate) fn emit_widget(
     // registered synth_id + initial value (uses the v3.2 path).
     if let Expr::Call { callee, args, .. } = expr {
         if args.is_empty() {
-            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+            if let Expr::PropertyGet {
+                object, property, ..
+            } = callee.as_ref()
+            {
                 if property == "text" {
                     if let Expr::LocalGet(state_id) = object.as_ref() {
                         if let Some(binding) = state_registry.get(state_id) {

--- a/crates/perry-codegen-arkts/src/state_rewrite.rs
+++ b/crates/perry-codegen-arkts/src/state_rewrite.rs
@@ -68,7 +68,10 @@ pub(crate) fn rewrite_state_in_expr(e: &mut Expr, reg: &HashMap<LocalId, StateBi
     // Detect `state.set(v)` first (most specific shape).
     if let Expr::Call { callee, args, .. } = e {
         if args.len() == 1 {
-            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+            if let Expr::PropertyGet {
+                object, property, ..
+            } = callee.as_ref()
+            {
                 if property == "set" {
                     if let Expr::LocalGet(state_id) = object.as_ref() {
                         if let Some(binding) = reg.get(state_id) {

--- a/crates/perry-codegen-arkts/src/tests.rs
+++ b/crates/perry-codegen-arkts/src/tests.rs
@@ -107,6 +107,7 @@ pub(crate) fn state_call(initial: Expr) -> Expr {
 pub(crate) fn state_method_call(state_id: u32, method: &str, args: Vec<Expr>) -> Expr {
     Expr::Call {
         callee: Box::new(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::LocalGet(state_id)),
             property: method.to_string(),
         }),

--- a/crates/perry-codegen-arkts/src/tests/conditions.rs
+++ b/crates/perry-codegen-arkts/src/tests/conditions.rs
@@ -74,6 +74,7 @@ fn issue_410_local_get_resolves_through_bindings_not_placeholder() {
     let init = Expr::Compare {
         op: perry_hir::ir::CompareOp::Eq,
         left: Box::new(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::LocalGet(99)), // unresolvable
             property: "screen".to_string(),
         }),
@@ -382,6 +383,7 @@ fn issue_413_evaluate_condition_returns_none_for_runtime_value() {
     let bindings = HashMap::new();
     let consts = HashMap::new();
     let prop = Expr::PropertyGet {
+        byte_offset: 0,
         object: Box::new(Expr::LocalGet(99)),
         property: "isMobile".to_string(),
     };
@@ -866,6 +868,7 @@ fn issue_490_unfoldable_unresolvable_condition_walks_only_then_branch() {
     ));
     m.init.push(Stmt::If {
         condition: Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::LocalGet(9999)),
             property: "isMobile".to_string(),
         },

--- a/crates/perry-codegen-arkts/src/tests/mutations.rs
+++ b/crates/perry-codegen-arkts/src/tests/mutations.rs
@@ -279,6 +279,7 @@ fn issue_408_conditional_widget_add_child_emits_if_else() {
     // Expr::Conditional emit_widget arm).
     m.init.push(Stmt::If {
         condition: Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::LocalGet(9999)),
             property: "isMobile".to_string(),
         },

--- a/crates/perry-codegen-arkts/tests/phase2_full_app_smoke.rs
+++ b/crates/perry-codegen-arkts/tests/phase2_full_app_smoke.rs
@@ -148,6 +148,7 @@ fn full_phase2_app_emits_canonical_arkui() {
     // --- Phase 2 v6: state<T>.text() — reactive Text bound to synth id ---
     let counter_state_text = Expr::Call {
         callee: Box::new(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::LocalGet(counter_id)),
             property: "text".to_string(),
         }),
@@ -160,6 +161,7 @@ fn full_phase2_app_emits_canonical_arkui() {
     // Button("Inc", () => { counter.set(counter.value + 1) }, { backgroundColor: "blue", borderRadius: 8 })
     let inc_body = vec![Stmt::Expr(Expr::Call {
         callee: Box::new(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::LocalGet(counter_id)),
             property: "set".to_string(),
         }),
@@ -524,6 +526,7 @@ fn minimal_counter_app_emits_clean_page() {
             // c.text() → reactive Text bound to the synth id.
             Expr::Call {
                 callee: Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::LocalGet(counter_id)),
                     property: "text".to_string(),
                 }),

--- a/crates/perry-codegen-js/src/emit/exprs.rs
+++ b/crates/perry-codegen-js/src/emit/exprs.rs
@@ -200,7 +200,7 @@ impl JsEmitter {
             }
 
             // --- Property access ---
-            Expr::PropertyGet { object, property } => {
+            Expr::PropertyGet { object, property, .. } => {
                 self.emit_expr(object);
                 if is_valid_identifier(property) {
                     let _ = write!(self.output, ".{}", property);

--- a/crates/perry-codegen-wasm/src/emit/expr/calls.rs
+++ b/crates/perry-codegen-wasm/src/emit/expr/calls.rs
@@ -10,7 +10,10 @@ impl<'a> FuncEmitCtx<'a> {
         match expr {
             Expr::Call { callee, args, .. } => {
                 // Check for method call patterns: obj.method(args)
-                if let Expr::PropertyGet { object, property } = callee.as_ref() {
+                if let Expr::PropertyGet {
+                    object, property, ..
+                } = callee.as_ref()
+                {
                     // Namespace-import member call (`import * as W from "./mod";
                     // W.fn(args)`): resolve to a DIRECT wasm call of the source
                     // module's function — the same lowering `fn(args)` gets via
@@ -22,7 +25,9 @@ impl<'a> FuncEmitCtx<'a> {
                             self.emitter.current_mod_idx,
                             format!("{}.{}", name, property),
                         );
-                        if let Some(&idx) = self.emitter.imported_ns_funcs.get(&key).copied().as_ref() {
+                        if let Some(&idx) =
+                            self.emitter.imported_ns_funcs.get(&key).copied().as_ref()
+                        {
                             for arg in args {
                                 self.emit_expr(func, arg);
                             }
@@ -184,8 +189,7 @@ impl<'a> FuncEmitCtx<'a> {
                         // fallback, since its bare-name keys collide across
                         // modules. See FuncRef arm above for why both pad-up
                         // and drop-excess are required (#183).
-                        let consumer_key =
-                            (self.emitter.current_mod_idx, name.clone());
+                        let consumer_key = (self.emitter.current_mod_idx, name.clone());
                         if let Some(&idx) = self
                             .emitter
                             .imported_func_indices

--- a/crates/perry-codegen-wasm/src/emit/expr/objects.rs
+++ b/crates/perry-codegen-wasm/src/emit/expr/objects.rs
@@ -105,7 +105,9 @@ impl<'a> FuncEmitCtx<'a> {
                 }
             }
 
-            Expr::PropertyGet { object, property } => {
+            Expr::PropertyGet {
+                object, property, ..
+            } => {
                 // Namespace-import member read (`import * as W; W.MEMBER`):
                 // the object lowers to ExternFuncRef("W"), which as a value is
                 // undefined — resolve the member against the source module's
@@ -420,7 +422,9 @@ impl<'a> FuncEmitCtx<'a> {
                 self.emit_expr(func, object);
             }
             Expr::Delete(expr) => match expr.as_ref() {
-                Expr::PropertyGet { object, property } => {
+                Expr::PropertyGet {
+                    object, property, ..
+                } => {
                     self.emit_expr(func, object);
                     let key_id = self
                         .emitter

--- a/crates/perry-codegen-wasm/src/emit/js_fallback.rs
+++ b/crates/perry-codegen-wasm/src/emit/js_fallback.rs
@@ -329,7 +329,9 @@ impl WasmModuleEmitter {
                             "u64ToF64(TAG_UNDEFINED)".to_string()
                         }
                     }
-                    Expr::PropertyGet { object, property } => {
+                    Expr::PropertyGet {
+                        object, property, ..
+                    } => {
                         let obj = self.emit_js_expr(object, locals);
                         let _args_str = args_js.join(", ");
                         format!(
@@ -383,7 +385,9 @@ impl WasmModuleEmitter {
                 opts.push('}');
                 format!("fromJsValue(await fetch(getString({}), {}))", url_js, opts)
             }
-            Expr::PropertyGet { object, property } => {
+            Expr::PropertyGet {
+                object, property, ..
+            } => {
                 let obj = self.emit_js_expr(object, locals);
                 format!("fromJsValue(toJsValue({}).{})", obj, property)
             }

--- a/crates/perry-codegen-wasm/src/emit/stmt.rs
+++ b/crates/perry-codegen-wasm/src/emit/stmt.rs
@@ -445,7 +445,10 @@ impl<'a> FuncEmitCtx<'a> {
             }
             // console.log/warn/error via Call + PropertyGet pattern
             Expr::Call { callee, .. } => {
-                if let Expr::PropertyGet { object, property } = callee.as_ref() {
+                if let Expr::PropertyGet {
+                    object, property, ..
+                } = callee.as_ref()
+                {
                     if let Expr::GlobalGet(_) = object.as_ref() {
                         if matches!(property.as_str(), "log" | "warn" | "error") {
                             return false;

--- a/crates/perry-codegen-wasm/src/emit/string_collection.rs
+++ b/crates/perry-codegen-wasm/src/emit/string_collection.rs
@@ -501,7 +501,9 @@ impl WasmModuleEmitter {
                     self.collect_strings_in_expr(v);
                 }
             }
-            Expr::PropertyGet { object, property } => {
+            Expr::PropertyGet {
+                object, property, ..
+            } => {
                 self.collect_strings_in_expr(object);
                 self.intern_string(property);
             }

--- a/crates/perry-codegen/src/boxed_vars.rs
+++ b/crates/perry-codegen/src/boxed_vars.rs
@@ -992,7 +992,10 @@ fn collect_outer_writes_in_expr(expr: &perry_hir::Expr, out: &mut HashSet<u32>) 
     use perry_hir::Expr;
     // Same mutating-method detection as the closure walker.
     if let Expr::Call { callee, .. } = expr {
-        if let Expr::PropertyGet { object, property } = callee.as_ref() {
+        if let Expr::PropertyGet {
+            object, property, ..
+        } = callee.as_ref()
+        {
             if let Expr::LocalGet(id) = object.as_ref() {
                 // Array-specific mutating methods only. "add"/"set"/
                 // "delete"/"clear" collide with user-defined custom
@@ -1202,7 +1205,10 @@ fn collect_write_ids_in_expr(expr: &perry_hir::Expr, out: &mut HashSet<u32>) {
     use perry_hir::Expr;
     // Mutating method calls count as writes on the receiver.
     if let Expr::Call { callee, .. } = expr {
-        if let Expr::PropertyGet { object, property } = callee.as_ref() {
+        if let Expr::PropertyGet {
+            object, property, ..
+        } = callee.as_ref()
+        {
             if let Expr::LocalGet(id) = object.as_ref() {
                 // Array-specific mutating methods only. "add"/"set"/
                 // "delete"/"clear" collide with user-defined custom

--- a/crates/perry-codegen/src/codegen/typed_abi.rs
+++ b/crates/perry-codegen/src/codegen/typed_abi.rs
@@ -1012,7 +1012,9 @@ fn receiver_expr_is_typed_f64_safe(
         Expr::Number(_) | Expr::Integer(_) => Ok(()),
         Expr::LocalGet(id) if matches!(locals.get(id), Some(TypedParamRep::F64)) => Ok(()),
         Expr::LocalGet(_) => Err(TypedCloneRejectionReason::ReturnExprNotTypedF64Safe),
-        Expr::PropertyGet { object, property } if matches!(object.as_ref(), Expr::This) => {
+        Expr::PropertyGet {
+            object, property, ..
+        } if matches!(object.as_ref(), Expr::This) => {
             let index = typed_receiver_own_field_index(class, property)?;
             if used_field_names.insert(property.clone()) {
                 used_fields.push(TypedReceiverField {
@@ -1625,7 +1627,9 @@ fn lower_typed_f64_receiver_expr_with_env(
             .get(id)
             .cloned()
             .unwrap_or_else(|| format!("%arg{id}"))),
-        Expr::PropertyGet { object, property } if matches!(object.as_ref(), Expr::This) => {
+        Expr::PropertyGet {
+            object, property, ..
+        } if matches!(object.as_ref(), Expr::This) => {
             let Some(field_index) = receiver.field_index(property) else {
                 anyhow::bail!("typed-f64 receiver clone cannot lower unproven receiver field")
             };

--- a/crates/perry-codegen/src/collectors/escape_arrays.rs
+++ b/crates/perry-codegen/src/collectors/escape_arrays.rs
@@ -185,7 +185,10 @@ fn collect_length_only_indices_in_expr(
             }
         }
     }
-    if let Expr::PropertyGet { object, property } = expr {
+    if let Expr::PropertyGet {
+        object, property, ..
+    } = expr
+    {
         if property == "length" {
             if let Expr::IndexGet { object, index } = object.as_ref() {
                 if let (Expr::LocalGet(id), Some(index)) = (object.as_ref(), const_index(index)) {
@@ -367,7 +370,7 @@ pub fn find_array_candidates(
                 && !module_globals.contains_key(id)
                 && matches!(
                     callee.as_ref(),
-                    Expr::PropertyGet { object, property }
+                    Expr::PropertyGet { object, property, .. }
                         if matches!(object.as_ref(), Expr::LocalGet(_))
                             && property == "split"
                 )
@@ -573,7 +576,9 @@ pub fn check_array_escapes_in_expr(
         }
 
         // Safe: `arr.length` read folds to the constant N.
-        Expr::PropertyGet { object, property } => {
+        Expr::PropertyGet {
+            object, property, ..
+        } => {
             if let Expr::LocalGet(id) = object.as_ref() {
                 if let Some(&len) = candidates.get(id) {
                     if property == "length" {

--- a/crates/perry-codegen/src/collectors/escape_check.rs
+++ b/crates/perry-codegen/src/collectors/escape_check.rs
@@ -215,7 +215,7 @@ pub fn check_escapes_in_expr(
         // an uninitialized alloca → segfault. (Method calls are
         // already covered: they're wrapped in `Expr::Call` and the
         // Call/CallSpread arms below mark the receiver escaped.)
-        Expr::PropertyGet { object, property } => {
+        Expr::PropertyGet { object, property, .. } => {
             if let Expr::LocalGet(id) = object.as_ref() {
                 if let Some(class_name) = candidates.get(id) {
                     if is_class_getter(classes, class_name, property) {

--- a/crates/perry-codegen/src/collectors/escape_news.rs
+++ b/crates/perry-codegen/src/collectors/escape_news.rs
@@ -214,7 +214,9 @@ fn collect_used_new_fields_in_expr(
     use perry_hir::{ArrayElement, CallArg, Expr};
 
     match expr {
-        Expr::PropertyGet { object, property }
+        Expr::PropertyGet {
+            object, property, ..
+        }
         | Expr::PropertyUpdate {
             object, property, ..
         } => {

--- a/crates/perry-codegen/src/collectors/escape_objects.rs
+++ b/crates/perry-codegen/src/collectors/escape_objects.rs
@@ -175,7 +175,10 @@ fn collect_used_object_fields_in_expr(
     used: &mut HashMap<u32, HashSet<String>>,
 ) {
     use perry_hir::Expr;
-    if let Expr::PropertyGet { object, property } = expr {
+    if let Expr::PropertyGet {
+        object, property, ..
+    } = expr
+    {
         if let Expr::LocalGet(id) = object.as_ref() {
             if let Some(fields) = non_escaping_object_literals.get(id) {
                 if fields.iter().any(|field| field == property) {
@@ -409,7 +412,7 @@ pub fn check_object_literal_escapes_in_expr(
 
     match e {
         // Safe: `o.known_field` read.
-        Expr::PropertyGet { object, property } => {
+        Expr::PropertyGet { object, property, .. } => {
             if let Expr::LocalGet(id) = object.as_ref() {
                 if let Some(keys) = candidates.get(id) {
                     if keys.iter().any(|k| k == property) {

--- a/crates/perry-codegen/src/collectors/hir_facts.rs
+++ b/crates/perry-codegen/src/collectors/hir_facts.rs
@@ -1990,6 +1990,7 @@ mod tests {
                 else_branch: Some(vec![Stmt::Expr(Expr::LocalSet(
                     1,
                     Box::new(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::LocalGet(99)),
                         property: "value".to_string(),
                     }),
@@ -2067,6 +2068,7 @@ mod tests {
             Stmt::Expr(Expr::LocalSet(
                 1,
                 Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::LocalGet(99)),
                     property: "value".to_string(),
                 }),
@@ -2118,6 +2120,7 @@ mod tests {
             Stmt::Expr(Expr::LocalSet(
                 1,
                 Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::LocalGet(99)),
                     property: "value".to_string(),
                 }),
@@ -2187,6 +2190,7 @@ mod tests {
             Stmt::Expr(Expr::LocalSet(
                 1,
                 Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::LocalGet(99)),
                     property: "value".to_string(),
                 }),
@@ -2217,6 +2221,7 @@ mod tests {
             Stmt::Expr(Expr::LocalSet(
                 1,
                 Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::LocalGet(99)),
                     property: "value".to_string(),
                 }),

--- a/crates/perry-codegen/src/collectors/scalar_method_dispatch.rs
+++ b/crates/perry-codegen/src/collectors/scalar_method_dispatch.rs
@@ -167,7 +167,9 @@ fn note_prototype_effect(expr: &Expr, facts: &mut ModuleDispatchFacts) {
         Expr::RegisterFunctionPrototypeMethod { .. } | Expr::SetFunctionPrototype { .. } => {}
         // Any expression that so much as NAMES a prototype object: the value
         // can be aliased into a local and written through later.
-        Expr::PropertyGet { object, property } if is_prototype_key(property) => {
+        Expr::PropertyGet {
+            object, property, ..
+        } if is_prototype_key(property) => {
             note_prototype_holder(object, facts);
         }
         Expr::PropertySet {
@@ -277,7 +279,10 @@ pub fn mark_unstable_scalar_method_receivers(
         let Expr::Call { callee, args, .. } = expr else {
             return;
         };
-        let Expr::PropertyGet { object, property } = callee.as_ref() else {
+        let Expr::PropertyGet {
+            object, property, ..
+        } = callee.as_ref()
+        else {
             return;
         };
         let Expr::LocalGet(id) = object.as_ref() else {
@@ -437,6 +442,7 @@ mod tests {
                 params: Vec::new(),
                 return_type: Type::Number,
                 body: vec![Stmt::Return(Some(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::This),
                     property: "value".to_string(),
                 }))],
@@ -482,6 +488,7 @@ mod tests {
     fn call_method_stmt(method: &str) -> Stmt {
         Stmt::Return(Some(Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(RECEIVER)),
                 property: method.to_string(),
             }),
@@ -614,6 +621,7 @@ mod tests {
         let mut module = Module::new("m.ts");
         module.init.push(Stmt::Expr(Expr::ObjectDefineProperty(
             Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::ClassRef("C".to_string())),
                 property: "prototype".to_string(),
             }),
@@ -639,6 +647,7 @@ mod tests {
             ty: Type::Any,
             mutable: false,
             init: Some(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(6)),
                 property: "prototype".to_string(),
             }),

--- a/crates/perry-codegen/src/collectors/scalar_methods.rs
+++ b/crates/perry-codegen/src/collectors/scalar_methods.rs
@@ -210,7 +210,9 @@ fn numeric_scalar_method_expr_is_safe(
             ) && numeric_scalar_method_expr_is_safe(classes, class_name, left, numeric_params)
                 && numeric_scalar_method_expr_is_safe(classes, class_name, right, numeric_params)
         }
-        Expr::PropertyGet { object, property } if matches!(object.as_ref(), Expr::This) => {
+        Expr::PropertyGet {
+            object, property, ..
+        } if matches!(object.as_ref(), Expr::This) => {
             public_numeric_field(classes, class_name, property)
         }
         _ => false,
@@ -237,7 +239,9 @@ fn int32_scalar_method_expr_is_safe(
             ) && int32_scalar_method_expr_is_safe(classes, class_name, left, numeric_params)
                 && int32_scalar_method_expr_is_safe(classes, class_name, right, numeric_params)
         }
-        Expr::PropertyGet { object, property } if matches!(object.as_ref(), Expr::This) => {
+        Expr::PropertyGet {
+            object, property, ..
+        } if matches!(object.as_ref(), Expr::This) => {
             public_int32_field(classes, class_name, property)
         }
         _ => false,

--- a/crates/perry-codegen/src/collectors/this_as_value.rs
+++ b/crates/perry-codegen/src/collectors/this_as_value.rs
@@ -300,7 +300,9 @@ pub fn expr_uses_this_as_value(e: &perry_hir::Expr, fields: &HashSet<String>) ->
         // PropertyGet/Set/Update with `this.<field>` is the safe pattern —
         // scalar replacement intercepts it. With `this.<method>` it falls
         // through to the heap-dispatch path which materializes `this`.
-        Expr::PropertyGet { object, property } => {
+        Expr::PropertyGet {
+            object, property, ..
+        } => {
             if matches!(object.as_ref(), Expr::This) {
                 return !fields.contains(property);
             }
@@ -545,6 +547,7 @@ mod tests {
         child.constructor = Some(function(
             "constructor",
             vec![Stmt::Return(Some(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::This),
                 property: "value".to_string(),
             }))],

--- a/crates/perry-codegen/src/collectors/uppercase_strings.rs
+++ b/crates/perry-codegen/src/collectors/uppercase_strings.rs
@@ -43,7 +43,7 @@ fn find_candidates(stmts: &[Stmt], candidates: &mut HashSet<u32>) {
             } if args.is_empty()
                 && matches!(
                     callee.as_ref(),
-                    Expr::PropertyGet { object, property }
+                    Expr::PropertyGet { object, property, .. }
                         if matches!(object.as_ref(), Expr::LocalGet(_))
                             && property == "toUpperCase"
                 ) =>
@@ -126,7 +126,7 @@ fn check_uses_in_stmts(
                 && matches!(args.as_slice(), [Expr::String(separator)] if !separator.is_empty())
                 && matches!(
                     callee.as_ref(),
-                    Expr::PropertyGet { object, property }
+                    Expr::PropertyGet { object, property, .. }
                         if matches!(object.as_ref(), Expr::LocalGet(_)) && property == "split"
                 )
                 && split_parts_are_length_only(
@@ -412,7 +412,7 @@ fn check_uses_in_expr(
             && matches!(args.as_slice(), [Expr::String(_)])
             && matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property }
+                Expr::PropertyGet { object, property, .. }
                     if matches!(object.as_ref(), Expr::LocalGet(_)) && property == "indexOf"
             )
         {

--- a/crates/perry-codegen/src/expr/call_spread.rs
+++ b/crates/perry-codegen/src/expr/call_spread.rs
@@ -79,7 +79,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // as a closure value and js_closure_call_apply_with_spread fails
             // to dispatch (issue #407). Mirrors the multi-arg console.* path
             // in the Expr::Call codegen at lower_call.rs.
-            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+            if let Expr::PropertyGet {
+                object, property, ..
+            } = callee.as_ref()
+            {
                 if matches!(object.as_ref(), Expr::GlobalGet(_))
                     && matches!(
                         property.as_str(),
@@ -229,7 +232,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // NativeModuleRef (dedicated codegen elsewhere), and ExternFuncRef
             // (the previous `FuncRef` arm catches the FuncRef case; ExternFuncRef
             // here means a top-level imported function reference, not a method).
-            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+            if let Expr::PropertyGet {
+                object, property, ..
+            } = callee.as_ref()
+            {
                 let mut skip = matches!(
                     object.as_ref(),
                     Expr::GlobalGet(_) | Expr::NativeModuleRef(_) | Expr::ExternFuncRef { .. }
@@ -374,7 +380,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // slot and call the symbol directly, exactly as the regular path
             // does for `fixed_count == 0`. Gated on a known rest-function
             // export, so class members and non-rest shapes are untouched.
-            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+            if let Expr::PropertyGet {
+                object, property, ..
+            } = callee.as_ref()
+            {
                 if let Expr::ExternFuncRef { name: ns_name, .. } = object.as_ref() {
                     if ctx.namespace_imports.contains(ns_name)
                         && ctx.imported_func_has_rest.contains(property)

--- a/crates/perry-codegen/src/expr/calls.rs
+++ b/crates/perry-codegen/src/expr/calls.rs
@@ -113,7 +113,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property }
+                Expr::PropertyGet { object, property, .. }
                     if property == "from"
                         && matches!(
                             object.as_ref(),
@@ -145,15 +145,15 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             ..
         } if matches!(
             outer_callee.as_ref(),
-            Expr::PropertyGet { property: p, object } if p == "digest" && matches!(
+            Expr::PropertyGet { property: p, object, .. } if p == "digest" && matches!(
                 object.as_ref(),
                 Expr::Call { callee: c2, .. } if matches!(
                     c2.as_ref(),
-                    Expr::PropertyGet { property: p2, object: obj2 } if p2 == "update" && matches!(
+                    Expr::PropertyGet { property: p2, object: obj2, .. } if p2 == "update" && matches!(
                         obj2.as_ref(),
                         Expr::Call { callee: c3, .. } if matches!(
                             c3.as_ref(),
-                            Expr::PropertyGet { property: p3, object: obj3 } if (p3 == "createHash" || p3 == "Hash" || p3 == "createHmac" || p3 == "Hmac") && matches!(
+                            Expr::PropertyGet { property: p3, object: obj3, .. } if (p3 == "createHash" || p3 == "Hash" || p3 == "createHmac" || p3 == "Hmac") && matches!(
                                 obj3.as_ref(),
                                 Expr::NativeModuleRef(n) if n == "crypto"
                             )
@@ -178,7 +178,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if (property == "createHash" || property == "Hash") && matches!(
+                Expr::PropertyGet { object, property, .. } if (property == "createHash" || property == "Hash") && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -193,7 +193,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if (property == "createSign" || property == "Sign" || property == "createVerify" || property == "Verify") && matches!(
+                Expr::PropertyGet { object, property, .. } if (property == "createSign" || property == "Sign" || property == "createVerify" || property == "Verify") && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -208,7 +208,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "createECDH" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "createECDH" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -224,7 +224,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if (property == "createDiffieHellman" || property == "DiffieHellman" || property == "getDiffieHellman" || property == "createDiffieHellmanGroup" || property == "DiffieHellmanGroup") && matches!(
+                Expr::PropertyGet { object, property, .. } if (property == "createDiffieHellman" || property == "DiffieHellman" || property == "getDiffieHellman" || property == "createDiffieHellmanGroup" || property == "DiffieHellmanGroup") && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -240,7 +240,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if (property == "createPrivateKey" || property == "createPublicKey") && matches!(
+                Expr::PropertyGet { object, property, .. } if (property == "createPrivateKey" || property == "createPublicKey") && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -255,7 +255,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "generateKeyPair" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "generateKeyPair" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -269,7 +269,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "generateKeyPairSync" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "generateKeyPairSync" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -283,7 +283,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "diffieHellman" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "diffieHellman" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -297,7 +297,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "encapsulate" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "encapsulate" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -311,7 +311,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "decapsulate" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "decapsulate" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -332,7 +332,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if (property == "createHmac" || property == "Hmac") && matches!(
+                Expr::PropertyGet { object, property, .. } if (property == "createHmac" || property == "Hmac") && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -352,7 +352,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property }
+                Expr::PropertyGet { object, property, .. }
                     if (property == "createCipheriv" || property == "createDecipheriv")
                         && matches!(
                             object.as_ref(),
@@ -369,7 +369,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "randomBytes" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "randomBytes" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -382,7 +382,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "randomFill" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "randomFill" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -399,7 +399,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property }
+                Expr::PropertyGet { object, property, .. }
                     if (property == "createSign" || property == "createVerify")
                         && matches!(
                             object.as_ref(),
@@ -414,7 +414,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "randomBytes" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "randomBytes" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -427,7 +427,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "randomUUID" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "randomUUID" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -440,7 +440,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "randomUUIDv7" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "randomUUIDv7" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -458,7 +458,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "randomInt" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "randomInt" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -472,7 +472,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "timingSafeEqual" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "timingSafeEqual" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -490,7 +490,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if matches!(property.as_str(), "generatePrimeSync" | "generatePrime" | "checkPrimeSync" | "checkPrime") && matches!(
+                Expr::PropertyGet { object, property, .. } if matches!(property.as_str(), "generatePrimeSync" | "generatePrime" | "checkPrimeSync" | "checkPrime") && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -505,7 +505,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if matches!(property.as_str(), "getHashes" | "getCiphers" | "getCurves") && matches!(
+                Expr::PropertyGet { object, property, .. } if matches!(property.as_str(), "getHashes" | "getCiphers" | "getCurves") && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -519,7 +519,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "getCipherInfo" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "getCipherInfo" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -532,7 +532,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "getFips" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "getFips" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -546,7 +546,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "setFips" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "setFips" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -560,7 +560,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "secureHeapUsed" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "secureHeapUsed" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -575,7 +575,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "sign" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "sign" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -587,7 +587,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "verify" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "verify" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -603,7 +603,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if (property == "publicEncrypt" || property == "privateDecrypt" || property == "privateEncrypt" || property == "publicDecrypt") && matches!(
+                Expr::PropertyGet { object, property, .. } if (property == "publicEncrypt" || property == "privateDecrypt" || property == "privateEncrypt" || property == "publicDecrypt") && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -620,7 +620,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "createSecretKey" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "createSecretKey" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -635,7 +635,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "generateKeySync" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "generateKeySync" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -650,7 +650,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "generateKey" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "generateKey" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -663,7 +663,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "argon2Sync" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "argon2Sync" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -676,7 +676,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "argon2" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "argon2" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -689,7 +689,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "hkdfSync" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "hkdfSync" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -702,7 +702,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "hkdf" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "hkdf" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -715,7 +715,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "scrypt" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "scrypt" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -732,7 +732,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "pbkdf2Sync" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "pbkdf2Sync" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -745,7 +745,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "pbkdf2" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "pbkdf2" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -762,7 +762,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "scryptSync" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "scryptSync" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -777,7 +777,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "hkdfSync" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "hkdfSync" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -793,7 +793,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::Call { callee, args, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { object, property } if property == "generateKeyPairSync" && matches!(
+                Expr::PropertyGet { object, property, .. } if property == "generateKeyPairSync" && matches!(
                     object.as_ref(),
                     Expr::NativeModuleRef(n) if n == "crypto"
                 )
@@ -812,7 +812,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 callee.as_ref(),
                 Expr::PropertyGet { object, .. } if matches!(
                     object.as_ref(),
-                    Expr::PropertyGet { object: inner, property: p }
+                    Expr::PropertyGet { object: inner, property: p, .. }
                         if p == "promises" && matches!(
                             inner.as_ref(),
                             Expr::NativeModuleRef(name) if name == "fs"

--- a/crates/perry-codegen/src/expr/calls/helpers.rs
+++ b/crates/perry-codegen/src/expr/calls/helpers.rs
@@ -150,7 +150,10 @@ pub(crate) fn hash_input_is_buffer(ctx: &FnCtx<'_>, e: &Expr) -> bool {
     // that statically without this hint, so without it `createHmac(secretKey, ...)`
     // would route to the string fast-path that misreads buffer bytes as UTF-8.
     if let Expr::Call { callee, .. } = e {
-        if let Expr::PropertyGet { object, property } = callee.as_ref() {
+        if let Expr::PropertyGet {
+            object, property, ..
+        } = callee.as_ref()
+        {
             if matches!(object.as_ref(), Expr::NativeModuleRef(n) if n == "crypto")
                 && matches!(
                     property.as_str(),

--- a/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
+++ b/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
@@ -1006,6 +1006,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     );
                     for member in &members {
                         let member_get = Expr::PropertyGet {
+                            byte_offset: 0,
                             object: Box::new(Expr::ExternFuncRef {
                                 name: name.clone(),
                                 param_types: Vec::new(),

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -271,6 +271,7 @@ pub(crate) fn index_object_is_class_or_proto_ref(ctx: &FnCtx<'_>, object: &Expr)
         Expr::PropertyGet {
             object: inner,
             property,
+            ..
         } if property.as_str() == "prototype" => {
             index_object_is_class_or_proto_ref(ctx, inner.as_ref())
         }

--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -666,7 +666,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     blk.call_void("js_removeenv", &[(I64, &key_handle)]);
                     Ok(blk.bitcast_i64_to_double(crate::nanbox::TAG_TRUE_I64))
                 }
-                Expr::PropertyGet { object, property } => {
+                Expr::PropertyGet {
+                    object, property, ..
+                } => {
                     let obj_box = lower_expr(ctx, object)?;
                     // `delete null.x` / `delete undefined.x` → TypeError. The
                     // `delete` algorithm calls `ToObject(GetBase)` on a property

--- a/crates/perry-codegen/src/expr/literals_vars.rs
+++ b/crates/perry-codegen/src/expr/literals_vars.rs
@@ -223,7 +223,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 // global object as `GlobalGet(0)` lowering to `0.0`, same
                 // misclassification.
                 Expr::GlobalGet(_) => Some("object"),
-                Expr::PropertyGet { object, property } => {
+                Expr::PropertyGet {
+                    object, property, ..
+                } => {
                     // #1380: `typeof set.has` / `typeof map.get` → "function".
                     // Set/Map methods aren't materialized as real function
                     // objects — a bare `set.has` read returns the (absent)

--- a/crates/perry-codegen/src/expr/new_dynamic.rs
+++ b/crates/perry-codegen/src/expr/new_dynamic.rs
@@ -261,7 +261,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // ObjectHeader. Pre-fix the NewDynamic fallback returned a
             // placeholder object — `cloned.getTime()` then read garbage
             // and the equality failed. Refs date-fns blocker.
-            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+            if let Expr::PropertyGet {
+                object, property, ..
+            } = callee.as_ref()
+            {
                 if property == "constructor" {
                     if let Expr::LocalGet(id) = object.as_ref() {
                         let is_date = matches!(
@@ -287,7 +290,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // make_assertion_error path the failing-assert helpers
             // already use, so the resulting instance has the same
             // class_id-extends-Error registration).
-            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+            if let Expr::PropertyGet {
+                object, property, ..
+            } = callee.as_ref()
+            {
                 if property == "AssertionError" {
                     if let Expr::NativeModuleRef(mod_name) = object.as_ref() {
                         if mod_name == "assert" || mod_name == "assert/strict" {
@@ -327,7 +333,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // `PropertyGet { NativeModuleRef("net"), ... }` rather than a bare
             // built-in class name. Route them through `lower_new` so the
             // handle-producing constructor arms allocate registered net handles.
-            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+            if let Expr::PropertyGet {
+                object, property, ..
+            } = callee.as_ref()
+            {
                 if matches!(property.as_str(), "BlockList" | "SocketAddress") {
                     if let Expr::NativeModuleRef(mod_name) = object.as_ref() {
                         if mod_name == "net" || mod_name == "node:net" {
@@ -339,7 +348,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 }
             }
 
-            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+            if let Expr::PropertyGet {
+                object, property, ..
+            } = callee.as_ref()
+            {
                 if property == "WebSocket" {
                     if let Expr::NativeModuleRef(mod_name) = object.as_ref() {
                         if mod_name == "http" || mod_name == "node:http" {
@@ -356,7 +368,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // helper methods as `crypto.Certificate.*`. Represent instances as
             // the `crypto.Certificate` native namespace so method calls dispatch
             // through the existing native-module path.
-            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+            if let Expr::PropertyGet {
+                object, property, ..
+            } = callee.as_ref()
+            {
                 if property == "Certificate" && args.is_empty() {
                     if let Expr::NativeModuleRef(mod_name) = object.as_ref() {
                         if mod_name == "crypto" {
@@ -383,7 +398,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // `new crypto.DiffieHellman(...)` /
             // `new crypto.DiffieHellmanGroup(name)` are legacy constructor
             // aliases for the existing classic-DH factory helpers.
-            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+            if let Expr::PropertyGet {
+                object, property, ..
+            } = callee.as_ref()
+            {
                 if matches!(property.as_str(), "DiffieHellman" | "DiffieHellmanGroup") {
                     if let Expr::NativeModuleRef(mod_name) = object.as_ref() {
                         if mod_name == "crypto" {
@@ -428,7 +446,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // `new v8.GCProfiler()` (#3142) — allocate a fresh native-module
             // instance whose `start()` / `stop()` methods dispatch through the
             // runtime native-module method table.
-            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+            if let Expr::PropertyGet {
+                object, property, ..
+            } = callee.as_ref()
+            {
                 if property == "GCProfiler" {
                     if let Expr::NativeModuleRef(mod_name) = object.as_ref() {
                         if mod_name == "v8" {
@@ -466,7 +487,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // `.on()`/`.write()`/`.pipe()` throw "is not a function". Route to
             // the same `lower_builtin_new` stream handler the named-import path
             // uses so the runtime allocates the fully-methoded stream object.
-            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+            if let Expr::PropertyGet {
+                object, property, ..
+            } = callee.as_ref()
+            {
                 if let Expr::NativeModuleRef(mod_name) = object.as_ref() {
                     if mod_name == "stream"
                         && matches!(
@@ -485,7 +509,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // `Default*` subclasses) (#3680) — route to the runtime
             // constructors that allocate a codec-backed instance object whose
             // methods dispatch through the native-module method table.
-            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+            if let Expr::PropertyGet {
+                object, property, ..
+            } = callee.as_ref()
+            {
                 if let Expr::NativeModuleRef(mod_name) = object.as_ref() {
                     if mod_name == "v8" {
                         match property.as_str() {
@@ -537,7 +564,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // handled in lower_call/builtin.rs. Route to the same runtime
             // registrar so the no-callback TypeError (and normal construction)
             // fire. Refs #1388.
-            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+            if let Expr::PropertyGet {
+                object, property, ..
+            } = callee.as_ref()
+            {
                 if property == "PerformanceObserver" {
                     if let Expr::NativeModuleRef(mod_name) = object.as_ref() {
                         if mod_name == "perf_hooks" {
@@ -572,7 +602,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             // `lower_new_member_captured` which fills the synthesized
             // `__perry_cap_*` ctor params from the class's decl-site capture
             // snapshot instead of binding them to `undefined`.
-            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+            if let Expr::PropertyGet {
+                object, property, ..
+            } = callee.as_ref()
+            {
                 if let Expr::LocalGet(obj_id) = object.as_ref() {
                     if let Some(class_name) = ctx
                         .local_class_field_aliases

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -41,6 +41,8 @@ use super::property_get_names::{
 mod generic_dispatch;
 mod globalget;
 mod helpers;
+#[cfg(test)]
+mod nullish_read_location_tests;
 
 pub(crate) use generic_dispatch::lower_generic_property_get;
 pub(crate) use globalget::lower_globalget_property;

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -74,7 +74,10 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     // read the precomputed numeric length directly. The split part itself was
     // never observable as a string, so materializing a StringHeader would only
     // create short-lived garbage.
-    if let Expr::PropertyGet { object, property } = expr {
+    if let Expr::PropertyGet {
+        object, property, ..
+    } = expr
+    {
         if property == "length" {
             if let Expr::IndexGet { object, index } = object.as_ref() {
                 if let (Expr::LocalGet(id), Some(index)) =
@@ -94,8 +97,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     }
 
     match expr {
-        Expr::PropertyGet { object, property }
-            if matches!(object.as_ref(), Expr::LocalGet(id)
+        Expr::PropertyGet {
+            object, property, ..
+        } if matches!(object.as_ref(), Expr::LocalGet(id)
                 if ctx.pod_records.get(id).is_some_and(|local| local
                     .layout
                     .fields
@@ -109,12 +113,13 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             }
             unreachable!("POD field guard should imply a lowered field")
         }
-        Expr::PropertyGet { object, property }
-            if property == "length"
-                && matches!(
-                    object.as_ref(),
-                    Expr::PropertyGet { property: p, .. } if p == "errors"
-                ) =>
+        Expr::PropertyGet {
+            object, property, ..
+        } if property == "length"
+            && matches!(
+                object.as_ref(),
+                Expr::PropertyGet { property: p, .. } if p == "errors"
+            ) =>
         {
             let recv_box = lower_expr(ctx, object)?;
             let blk = ctx.block();
@@ -137,9 +142,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // `String(f.errors)` → "[object Object]"). Non-error receivers fall
         // through to the generic property read below, which returns the
         // stored value — including `null` — correctly.
-        Expr::PropertyGet { object, property }
-            if property == "errors" && receiver_is_error_type(ctx, object) =>
-        {
+        Expr::PropertyGet {
+            object, property, ..
+        } if property == "errors" && receiver_is_error_type(ctx, object) => {
             let recv_box = lower_expr(ctx, object)?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
@@ -147,33 +152,35 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             Ok(nanbox_pointer_inline(blk, &arr_handle))
         }
 
-        Expr::PropertyGet { object, property }
-            if is_global_builtin_value_expr(object, "Promise")
-                && matches!(
-                    property.as_str(),
-                    "resolve"
-                        | "reject"
-                        | "all"
-                        | "race"
-                        | "allSettled"
-                        | "any"
-                        | "withResolvers"
-                        | "try"
-                ) =>
+        Expr::PropertyGet {
+            object, property, ..
+        } if is_global_builtin_value_expr(object, "Promise")
+            && matches!(
+                property.as_str(),
+                "resolve"
+                    | "reject"
+                    | "all"
+                    | "race"
+                    | "allSettled"
+                    | "any"
+                    | "withResolvers"
+                    | "try"
+            ) =>
         {
             Ok(lower_global_builtin_static_value(ctx, "Promise", property))
         }
 
-        Expr::PropertyGet { object, property }
-            if property == "length" && promise_static_function_length_expr(object).is_some() =>
-        {
+        Expr::PropertyGet {
+            object, property, ..
+        } if property == "length" && promise_static_function_length_expr(object).is_some() => {
             let len = promise_static_function_length_expr(object).unwrap();
             Ok(double_literal(len as f64))
         }
 
-        Expr::PropertyGet { object, property }
-            if property == "length"
-                && matches!(object.as_ref(), Expr::LocalGet(id)
+        Expr::PropertyGet {
+            object, property, ..
+        } if property == "length"
+            && matches!(object.as_ref(), Expr::LocalGet(id)
                     if ctx.buffer_data_slots.contains_key(id)) =>
         {
             let arr_id = match object.as_ref() {
@@ -228,11 +235,12 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // TypedArray `.length` can be shadowed by an own property, so use
         // the runtime length helper only when lowering has not already
         // registered the receiver as a native Buffer/TypedArray view above.
-        Expr::PropertyGet { object, property }
-            if property == "length"
-                && receiver_class_name(ctx, object)
-                    .as_deref()
-                    .is_some_and(is_numeric_typed_array_class) =>
+        Expr::PropertyGet {
+            object, property, ..
+        } if property == "length"
+            && receiver_class_name(ctx, object)
+                .as_deref()
+                .is_some_and(is_numeric_typed_array_class) =>
         {
             let recv_box = lower_expr(ctx, object)?;
             Ok(ctx
@@ -247,21 +255,22 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // `.length` — INLINE for array, string, and interface-typed
         // receivers. Named types (interfaces, class instances) often
         // wrap strings or arrays at runtime, where length is at offset 0.
-        Expr::PropertyGet { object, property }
-            if property == "length"
-                && (is_array_expr(ctx, object)
-                    || is_string_expr(ctx, object)
-                    || match crate::type_analysis::static_type_of(ctx, object) {
-                        // A `Function`-typed receiver is a closure, not a
-                        // String/Array — its `.length` is the spec param
-                        // count, served by the runtime reflection path
-                        // (`closure_length` table). Loading a u32 from
-                        // payload offset 0 here would read 0. Let it fall
-                        // through to the generic property path.
-                        Some(HirType::Named(n)) => n != "Function",
-                        Some(HirType::Tuple(_)) => true,
-                        _ => false,
-                    }) =>
+        Expr::PropertyGet {
+            object, property, ..
+        } if property == "length"
+            && (is_array_expr(ctx, object)
+                || is_string_expr(ctx, object)
+                || match crate::type_analysis::static_type_of(ctx, object) {
+                    // A `Function`-typed receiver is a closure, not a
+                    // String/Array — its `.length` is the spec param
+                    // count, served by the runtime reflection path
+                    // (`closure_length` table). Loading a u32 from
+                    // payload offset 0 here would read 0. Let it fall
+                    // through to the generic property path.
+                    Some(HirType::Named(n)) => n != "Function",
+                    Some(HirType::Tuple(_)) => true,
+                    _ => false,
+                }) =>
         {
             // Scalar-replaced array literal: length is a compile-time
             // constant — no header to load from (the heap array doesn't
@@ -418,18 +427,18 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // `set.size` / `map.size` — route to runtime helpers. The HIR
         // doesn't synthesize SetSize/MapSize expressions for the
         // property-access form, so we recognize the pattern here.
-        Expr::PropertyGet { object, property }
-            if property == "size" && is_set_expr(ctx, object) =>
-        {
+        Expr::PropertyGet {
+            object, property, ..
+        } if property == "size" && is_set_expr(ctx, object) => {
             let recv_box = lower_expr(ctx, object)?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
             let i32_v = blk.call(I32, "js_set_size", &[(I64, &recv_handle)]);
             Ok(blk.sitofp(I32, &i32_v, DOUBLE))
         }
-        Expr::PropertyGet { object, property }
-            if property == "size" && is_map_expr(ctx, object) =>
-        {
+        Expr::PropertyGet {
+            object, property, ..
+        } if property == "size" && is_map_expr(ctx, object) => {
             let recv_box = lower_expr(ctx, object)?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
@@ -443,16 +452,20 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         // "size"). Routed via `is_url_search_params_expr` so it only
         // fires on receivers we can prove are URLSearchParams (immediate
         // ctor, typed locals, `url.searchParams` accessor).
-        Expr::PropertyGet { object, property }
-            if property == "size" && is_url_search_params_expr(ctx, object) =>
-        {
+        Expr::PropertyGet {
+            object, property, ..
+        } if property == "size" && is_url_search_params_expr(ctx, object) => {
             let recv_box = lower_expr(ctx, object)?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);
             let i32_v = blk.call(I32, "js_url_search_params_size", &[(I64, &recv_handle)]);
             Ok(blk.sitofp(I32, &i32_v, DOUBLE))
         }
-        Expr::PropertyGet { object, property } => {
+        Expr::PropertyGet {
+            object,
+            property,
+            byte_offset,
+        } => {
             if property == "prototype"
                 && matches!(object.as_ref(), Expr::FuncRef(_) | Expr::Closure { .. })
             {
@@ -1504,7 +1517,7 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                     return lower_class_method_bind(ctx, object, property);
                 }
             }
-            lower_generic_property_get(ctx, object, property)
+            lower_generic_property_get(ctx, object, property, *byte_offset)
         }
 
         // -------- Ternary `cond ? a : b` (Phase B.7) --------

--- a/crates/perry-codegen/src/expr/property_get/generic_dispatch.rs
+++ b/crates/perry-codegen/src/expr/property_get/generic_dispatch.rs
@@ -43,8 +43,18 @@ pub(crate) fn lower_generic_property_get(
     ctx: &mut FnCtx<'_>,
     object: &Expr,
     property: &str,
+    byte_offset: u32,
 ) -> Result<String> {
     let obj_box = lower_expr(ctx, object)?;
+    // #5247: record this access's source location right after the receiver is
+    // evaluated and before the nullish-receiver throw path (the inline diamond
+    // OR the full-outline `js_object_get_field_ic` helper — both throw "Cannot
+    // read properties of null/undefined"). No-op unless compiled with
+    // `--debug-symbols` (the offset resolves to `None` without the debug
+    // context) or when `byte_offset` is 0 (a synthesized node). Emitted after
+    // the receiver so a nested `a.b.c` chain keeps the inner `.b` access's more
+    // specific location when *it* is the throwing read.
+    crate::expr::calls::emit_call_location_at(ctx, byte_offset);
     let key_idx = ctx.strings.intern(property);
     let key_handle_global = format!("@{}", ctx.strings.entry(key_idx).handle_global);
     let blk = ctx.block();

--- a/crates/perry-codegen/src/expr/property_get/helpers.rs
+++ b/crates/perry-codegen/src/expr/property_get/helpers.rs
@@ -102,6 +102,7 @@ pub(crate) fn builtin_prototype_method_read<'a>(
     let Expr::PropertyGet {
         object: ctor_object,
         property: proto_property,
+        ..
     } = object
     else {
         return None;
@@ -112,6 +113,7 @@ pub(crate) fn builtin_prototype_method_read<'a>(
     let Expr::PropertyGet {
         object: global_object,
         property: builtin_name,
+        ..
     } = ctor_object.as_ref()
     else {
         return None;
@@ -126,13 +128,16 @@ pub(crate) fn builtin_prototype_method_read<'a>(
 pub(crate) fn is_global_builtin_value_expr(expr: &Expr, name: &str) -> bool {
     matches!(
         expr,
-        Expr::PropertyGet { object, property }
+        Expr::PropertyGet { object, property, .. }
             if property == name && matches!(object.as_ref(), Expr::GlobalGet(_))
     )
 }
 
 pub(crate) fn promise_static_function_length_expr(expr: &Expr) -> Option<u32> {
-    let Expr::PropertyGet { object, property } = expr else {
+    let Expr::PropertyGet {
+        object, property, ..
+    } = expr
+    else {
         return None;
     };
     let is_promise_receiver = matches!(object.as_ref(), Expr::GlobalGet(_))
@@ -189,7 +194,10 @@ pub(crate) fn lower_raw_f64_class_field_get_for_number_context(
     ctx: &mut FnCtx<'_>,
     expr: &Expr,
 ) -> Result<Option<String>> {
-    let Expr::PropertyGet { object, property } = expr else {
+    let Expr::PropertyGet {
+        object, property, ..
+    } = expr
+    else {
         return Ok(None);
     };
 

--- a/crates/perry-codegen/src/expr/property_get/nullish_read_location_tests.rs
+++ b/crates/perry-codegen/src/expr/property_get/nullish_read_location_tests.rs
@@ -1,0 +1,122 @@
+//! #5247 — cargo-test-visible coverage for the property-read-on-nullish source
+//! location. The integration twin (`crates/perry/tests/
+//! issue_5247_property_read_source_location.rs`) compiles + runs a real program
+//! and only executes on nightly/tag workflows; this unit test asserts the
+//! codegen contract directly on the emitted LLVM IR so it runs on every PR
+//! (#5960 guideline).
+//!
+//! Contract: a general `Expr::PropertyGet` carrying a non-zero `byte_offset`
+//! emits a `js_set_call_location` call in `lower_generic_property_get` under a
+//! debug-location context (`--debug-symbols`), and emits NONE without it (the
+//! default build stays overhead-free / byte-identical).
+
+use crate::{compile_module, AppMetadata, CompileOptions};
+use perry_hir::{Expr, Module, ModuleInitKind, Stmt};
+
+fn ir_opts(debug_locations: bool, module_source: Option<&str>) -> CompileOptions {
+    CompileOptions {
+        target: None,
+        is_entry_module: true,
+        non_entry_module_prefixes: Vec::new(),
+        nextjs_path_init_modules: Vec::new(),
+        import_function_prefixes: std::collections::HashMap::new(),
+        import_function_ffi_aliases: std::collections::HashMap::new(),
+        import_function_origin_names: std::collections::HashMap::new(),
+        import_function_v8_specifiers: std::collections::HashMap::new(),
+        import_function_node_submodule: std::collections::HashMap::new(),
+        namespace_node_submodules: std::collections::HashMap::new(),
+        namespace_v8_specifiers: std::collections::HashMap::new(),
+        namespace_member_prefixes: std::collections::HashMap::new(),
+        namespace_member_origin_names: std::collections::HashMap::new(),
+        emit_ir_only: true,
+        verify_native_regions: false,
+        disable_buffer_fast_path: false,
+        namespace_imports: Vec::new(),
+        imported_classes: Vec::new(),
+        imported_enums: Vec::new(),
+        imported_async_funcs: std::collections::HashSet::new(),
+        type_aliases: std::collections::HashMap::new(),
+        imported_func_param_counts: std::collections::HashMap::new(),
+        imported_func_has_rest: std::collections::HashSet::new(),
+        imported_func_synthetic_arguments: std::collections::HashSet::new(),
+        imported_func_return_types: std::collections::HashMap::new(),
+        imported_vars: std::collections::HashSet::new(),
+        output_type: "executable".to_string(),
+        needs_stdlib: false,
+        needs_ui: false,
+        needs_geisterhand: false,
+        geisterhand_port: 7676,
+        enabled_features: Vec::new(),
+        native_module_init_names: Vec::new(),
+        js_module_specifiers: Vec::new(),
+        bundled_extensions: Vec::new(),
+        native_library_functions: Vec::new(),
+        i18n_table: None,
+        fast_math: false,
+        fp_contract_mode: crate::FpContractMode::Off,
+        app_metadata: AppMetadata::default(),
+        namespace_entries: Vec::new(),
+        dynamic_import_path_to_prefix: std::collections::HashMap::new(),
+        deferred_module_prefixes: std::collections::HashSet::new(),
+        module_init_deps: Vec::new(),
+        is_dynamic_import_target: false,
+        debug_locations,
+        module_source: module_source.map(str::to_string),
+        debug_source_line_offset: 0,
+    }
+}
+
+/// Source whose byte offset 8 (1-based) lands on line 2 (`o.foo;`).
+const SRC: &str = "let o;\no.foo;\n";
+
+/// A module whose init reads `o.foo` where `o` is a nullish local — reaching
+/// `lower_generic_property_get`. The `PropertyGet` carries a non-zero
+/// `byte_offset` exactly as `expr_member/member_tail.rs` now emits for a real
+/// `obj.prop` source read.
+fn module_with_nullish_read() -> Module {
+    let mut m = Module::new("read.ts");
+    m.init = vec![
+        Stmt::Let {
+            id: 1,
+            name: "o".to_string(),
+            ty: perry_types::Type::Any,
+            mutable: false,
+            init: Some(Expr::Undefined),
+        },
+        Stmt::Expr(Expr::PropertyGet {
+            object: Box::new(Expr::LocalGet(1)),
+            property: "foo".to_string(),
+            // BytePos 8 → source index 7 ('o' on line 2) → line 2.
+            byte_offset: 8,
+        }),
+    ];
+    m.init_kind = ModuleInitKind::Eager;
+    m
+}
+
+fn emit(debug: bool, source: Option<&str>) -> String {
+    String::from_utf8(compile_module(&module_with_nullish_read(), ir_opts(debug, source)).unwrap())
+        .expect("LLVM IR should be UTF-8")
+}
+
+#[test]
+fn property_read_emits_call_location_under_debug_symbols() {
+    let ir = emit(true, Some(SRC));
+    // Match the CALL, not the always-present `declare` in the runtime preamble.
+    assert!(
+        ir.contains("call void @js_set_call_location"),
+        "expected a js_set_call_location call for the nullish read under \
+         --debug-symbols:\n{ir}"
+    );
+}
+
+#[test]
+fn no_call_location_without_debug_symbols() {
+    // Default build: debug_locations off → no per-read location call is emitted,
+    // keeping release/default output overhead-free.
+    let ir = emit(false, None);
+    assert!(
+        !ir.contains("call void @js_set_call_location"),
+        "no js_set_call_location CALL should be emitted without --debug-symbols:\n{ir}"
+    );
+}

--- a/crates/perry-codegen/src/expr/proxy_reflect.rs
+++ b/crates/perry-codegen/src/expr/proxy_reflect.rs
@@ -254,10 +254,13 @@ fn same_side_effect_free_receiver(target: &Expr, receiver: &Expr) -> bool {
         (Expr::LocalGet(id), Expr::LocalGet(receiver_id)) => id == receiver_id,
         (Expr::This, Expr::This) => true,
         (
-            Expr::PropertyGet { object, property },
+            Expr::PropertyGet {
+                object, property, ..
+            },
             Expr::PropertyGet {
                 object: receiver_object,
                 property: receiver_property,
+                ..
             },
         ) => {
             property == receiver_property
@@ -349,10 +352,12 @@ fn same_put_value_receiver_expr(target: &Expr, receiver: &Expr) -> bool {
             Expr::PropertyGet {
                 object: a_object,
                 property: a_property,
+                ..
             },
             Expr::PropertyGet {
                 object: b_object,
                 property: b_property,
+                ..
             },
         ) => a_property == b_property && same_put_value_receiver_expr(a_object, b_object),
         (

--- a/crates/perry-codegen/src/expr/range_facts.rs
+++ b/crates/perry-codegen/src/expr/range_facts.rs
@@ -738,7 +738,9 @@ fn local_buffer_length_expr(expr: &Expr) -> Option<u32> {
             Expr::LocalGet(id) => Some(*id),
             _ => None,
         },
-        Expr::PropertyGet { object, property } if property == "length" => match object.as_ref() {
+        Expr::PropertyGet {
+            object, property, ..
+        } if property == "length" => match object.as_ref() {
             Expr::LocalGet(id) => Some(*id),
             _ => None,
         },

--- a/crates/perry-codegen/src/expr/v8_interop.rs
+++ b/crates/perry-codegen/src/expr/v8_interop.rs
@@ -279,9 +279,9 @@ pub(crate) fn emit_v8_member_method_call(
 fn is_global_object_expr(expr: &Expr) -> bool {
     match expr {
         Expr::GlobalGet(_) => true,
-        Expr::PropertyGet { object, property } if property == "globalThis" => {
-            is_global_object_expr(object)
-        }
+        Expr::PropertyGet {
+            object, property, ..
+        } if property == "globalThis" => is_global_object_expr(object),
         _ => false,
     }
 }
@@ -300,7 +300,9 @@ pub(crate) fn try_static_class_name<'a>(callee: &'a Expr, ctx: &FnCtx<'_>) -> Op
         // empty-object placeholder path with class_id=0 and method dispatch
         // breaks on the resulting instance.
         Expr::ExternFuncRef { name, .. } if ctx.class_ids.contains_key(name) => Some(name.as_str()),
-        Expr::PropertyGet { object, property } => {
+        Expr::PropertyGet {
+            object, property, ..
+        } => {
             if is_global_object_expr(object.as_ref()) {
                 return Some(property.as_str());
             }

--- a/crates/perry-codegen/src/lower_call/atomics.rs
+++ b/crates/perry-codegen/src/lower_call/atomics.rs
@@ -10,7 +10,7 @@ use crate::types::{DOUBLE, PTR};
 fn is_global_this_atomics_expr(e: &Expr) -> bool {
     matches!(
         e,
-        Expr::PropertyGet { object, property }
+        Expr::PropertyGet { object, property, .. }
             if property == "Atomics" && matches!(object.as_ref(), Expr::GlobalGet(_))
     )
 }
@@ -20,7 +20,10 @@ pub fn try_lower_atomics_static_call(
     callee: &Expr,
     args: &[Expr],
 ) -> Result<Option<String>> {
-    let Expr::PropertyGet { object, property } = callee else {
+    let Expr::PropertyGet {
+        object, property, ..
+    } = callee
+    else {
         return Ok(None);
     };
     if !is_global_this_atomics_expr(object) {

--- a/crates/perry-codegen/src/lower_call/console_promise.rs
+++ b/crates/perry-codegen/src/lower_call/console_promise.rs
@@ -151,7 +151,10 @@ pub fn try_lower_console_call(
     // already adds a newline, so multi-arg console.log will be
     // separated by newlines instead of spaces. Spec-compliant
     // separator handling lives in a future Phase I tweak.
-    if let Expr::PropertyGet { object, property } = callee {
+    if let Expr::PropertyGet {
+        object, property, ..
+    } = callee
+    {
         if matches!(object.as_ref(), Expr::GlobalGet(_))
             && matches!(
                 property.as_str(),
@@ -521,7 +524,10 @@ pub fn try_lower_promise_static_call(
     // The HIR doesn't have dedicated PromiseResolve/Reject variants. Depending
     // on the lowering path they appear either as a bare GlobalGet receiver or
     // as `globalThis.Promise.<method>`.
-    if let Expr::PropertyGet { object, property } = callee {
+    if let Expr::PropertyGet {
+        object, property, ..
+    } = callee
+    {
         if is_global_constructor_expr(object, "Promise") {
             match property.as_str() {
                 "resolve" => {
@@ -657,7 +663,10 @@ pub fn try_lower_native_method_str_dispatch(
     // method name as a raw rodata byte pointer (the StringPool already
     // emits the bytes as `[N+1 x i8]` for every interned string), and
     // materialize the args into a stack `[N x double]` slot.
-    if let Expr::PropertyGet { object, property } = callee {
+    if let Expr::PropertyGet {
+        object, property, ..
+    } = callee
+    {
         if is_message_port_closure_method(object, property) {
             return Ok(None);
         }
@@ -1161,7 +1170,10 @@ pub fn try_lower_closure_call_fallthrough(
     // default build) → no emission, unchanged `<anonymous>` frame.
     let call_byte_offset = ctx.strings.pending_call_offset();
     let prelowered_recv: Option<(String, String)> =
-        if let Expr::PropertyGet { object, property } = callee {
+        if let Expr::PropertyGet {
+            object, property, ..
+        } = callee
+        {
             if receiver_must_eval_once(object.as_ref()) {
                 Some((lower_expr(ctx, object)?, property.clone()))
             } else {

--- a/crates/perry-codegen/src/lower_call/early_branches.rs
+++ b/crates/perry-codegen/src/lower_call/early_branches.rs
@@ -93,7 +93,10 @@ pub fn try_lower_native_chain_method_call(
     // already the authoritative source for "what method names this
     // native module exposes"). Scoped narrowly — falls back to the
     // existing call lowering if the lookup misses.
-    if let Expr::PropertyGet { object, property } = callee {
+    if let Expr::PropertyGet {
+        object, property, ..
+    } = callee
+    {
         if let Some(module) = native_receiver_module(object.as_ref()) {
             if super::native_module_lookup(module, true, property, None).is_some() {
                 return Ok(Some(super::lower_native_method_call(
@@ -131,7 +134,10 @@ fn native_receiver_module(expr: &Expr) -> Option<&str> {
     match expr {
         Expr::NativeMethodCall { module, .. } => Some(module.as_str()),
         Expr::Call { callee, .. } => {
-            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+            if let Expr::PropertyGet {
+                object, property, ..
+            } = callee.as_ref()
+            {
                 let module = native_receiver_module(object.as_ref())?;
                 if native_method_returns_self_instance(module, property) {
                     return Some(module);

--- a/crates/perry-codegen/src/lower_call/namespace_call.rs
+++ b/crates/perry-codegen/src/lower_call/namespace_call.rs
@@ -29,7 +29,10 @@ pub fn try_lower_namespace_member_call(
     // through `js_closure_callN`. If it's a function declaration
     // (`export function make(s)`), call the symbol directly with rest
     // bundling — same as the existing FuncRef path.
-    let Expr::PropertyGet { object, property } = callee else {
+    let Expr::PropertyGet {
+        object, property, ..
+    } = callee
+    else {
         return Ok(None);
     };
     let Expr::ExternFuncRef { name: ns_name, .. } = object.as_ref() else {

--- a/crates/perry-codegen/src/lower_call/native/native_instance_branch.rs
+++ b/crates/perry-codegen/src/lower_call/native/native_instance_branch.rs
@@ -266,8 +266,7 @@
                 }
                 Expr::PropertyGet {
                     object: obj_expr,
-                    property,
-                } => {
+                    property, .. } => {
                     let obj_box = lower_expr(ctx, obj_expr)?;
                     let key_idx = ctx.strings.intern(property);
                     let key_handle_global =
@@ -353,8 +352,7 @@
                 }
                 Expr::PropertyGet {
                     object: obj_expr,
-                    property,
-                } => {
+                    property, .. } => {
                     let obj_box = lower_expr(ctx, obj_expr)?;
                     let key_idx = ctx.strings.intern(property);
                     let key_handle_global =

--- a/crates/perry-codegen/src/lower_call/options/abort.rs
+++ b/crates/perry-codegen/src/lower_call/options/abort.rs
@@ -59,6 +59,7 @@ pub(in crate::lower_call) fn lower_abort_controller_call(
         if let Expr::PropertyGet {
             object: inner_obj,
             property: inner_prop,
+            ..
         } = object
         {
             if inner_prop == "signal" && is_abort_controller_expr(ctx, inner_obj) {
@@ -122,6 +123,7 @@ pub(in crate::lower_call) fn lower_abort_controller_call(
         if let Expr::PropertyGet {
             object: inner_obj,
             property: inner_prop,
+            ..
         } = object
         {
             if inner_prop == "signal" && is_abort_controller_expr(ctx, inner_obj) {

--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -52,7 +52,10 @@ pub fn try_lower_property_get_method_call(
     // String/array method dispatch (Phase B.12) and class method
     // dispatch (Phase C.2). For PropertyGet receivers, dispatch based
     // on the receiver's static type.
-    let Expr::PropertyGet { object, property } = callee else {
+    let Expr::PropertyGet {
+        object, property, ..
+    } = callee
+    else {
         return Ok(None);
     };
     // #5247: capture this call's source byte offset now, before any argument

--- a/crates/perry-codegen/src/lower_call/property_get/helpers.rs
+++ b/crates/perry-codegen/src/lower_call/property_get/helpers.rs
@@ -195,9 +195,10 @@ pub(crate) fn resolve_static_dispatch_cls(
     match expr {
         Expr::ClassRef(name) => Some(name.clone()),
         Expr::ExternFuncRef { name, .. } if class_ids.contains_key(name) => Some(name.clone()),
-        Expr::PropertyGet { object, property }
-            if matches!(object.as_ref(), Expr::ExternFuncRef { .. })
-                && class_ids.contains_key(property) =>
+        Expr::PropertyGet {
+            object, property, ..
+        } if matches!(object.as_ref(), Expr::ExternFuncRef { .. })
+            && class_ids.contains_key(property) =>
         {
             Some(property.clone())
         }

--- a/crates/perry-codegen/src/lower_call/property_get/promise_chain.rs
+++ b/crates/perry-codegen/src/lower_call/property_get/promise_chain.rs
@@ -60,8 +60,7 @@ pub(crate) fn try_lower_promise_chain_method(
                     {
                         if let Expr::PropertyGet {
                             object: inner_object,
-                            property: inner_property,
-                        } = inner_callee.as_ref()
+                            property: inner_property, .. } = inner_callee.as_ref()
                         {
                             // #1008: accept both the legacy `Promise` =
                             // GlobalGet shape and the post-#973

--- a/crates/perry-codegen/src/lower_call/property_get/static_dispatch.rs
+++ b/crates/perry-codegen/src/lower_call/property_get/static_dispatch.rs
@@ -339,7 +339,7 @@ pub(crate) fn try_lower_static_dispatch(
         // really is a class.
         let receiver_is_dispatchable_class = matches!(object, Expr::ClassRef(_))
             || matches!(object, Expr::ExternFuncRef { name, .. } if ctx.class_ids.contains_key(name))
-            || matches!(object, Expr::PropertyGet { object: inner, property }
+            || matches!(object, Expr::PropertyGet { object: inner, property, .. }
                 if matches!(inner.as_ref(), Expr::ExternFuncRef { .. }) && ctx.class_ids.contains_key(property));
         if receiver_is_dispatchable_class {
             let recv_box = lower_expr(ctx, object)?;

--- a/crates/perry-codegen/src/lower_call/scalar_method.rs
+++ b/crates/perry-codegen/src/lower_call/scalar_method.rs
@@ -971,7 +971,10 @@ pub(super) fn try_lower_scalar_replaced_method_call(
     callee: &Expr,
     args: &[Expr],
 ) -> Result<Option<String>> {
-    let Expr::PropertyGet { object, property } = callee else {
+    let Expr::PropertyGet {
+        object, property, ..
+    } = callee
+    else {
         return Ok(None);
     };
     let Expr::LocalGet(receiver_id) = object.as_ref() else {

--- a/crates/perry-codegen/src/lower_call/web_storage.rs
+++ b/crates/perry-codegen/src/lower_call/web_storage.rs
@@ -9,7 +9,7 @@ use crate::types::{DOUBLE, I64, PTR};
 fn is_web_storage_global_expr(e: &Expr) -> bool {
     matches!(
         e,
-        Expr::PropertyGet { object, property }
+        Expr::PropertyGet { object, property, .. }
             if matches!(property.as_str(), "localStorage" | "sessionStorage")
                 && matches!(object.as_ref(), Expr::GlobalGet(_))
     )

--- a/crates/perry-codegen/src/stmt/let_stmt.rs
+++ b/crates/perry-codegen/src/stmt/let_stmt.rs
@@ -43,7 +43,7 @@ fn is_global_this_value(expr: &perry_hir::Expr) -> bool {
     matches!(expr, perry_hir::Expr::GlobalGet(_))
         || matches!(
             expr,
-            perry_hir::Expr::PropertyGet { object, property }
+            perry_hir::Expr::PropertyGet { object, property, .. }
                 if matches!(object.as_ref(), perry_hir::Expr::GlobalGet(_))
                     && property == "globalThis"
         )
@@ -148,7 +148,9 @@ pub(crate) fn lower_let(
         // literal that holds a class ref under "Inner" — promote
         // X to a class alias so `new X(args)` dispatches to the
         // real class instead of the empty-object placeholder.
-        Some(perry_hir::Expr::PropertyGet { object, property }) => {
+        Some(perry_hir::Expr::PropertyGet {
+            object, property, ..
+        }) => {
             if is_global_this_value(object.as_ref())
                 && matches!(
                     property.as_str(),
@@ -421,7 +423,7 @@ pub(crate) fn lower_let(
             && args.is_empty()
             && matches!(
                 callee.as_ref(),
-                perry_hir::Expr::PropertyGet { object, property }
+                perry_hir::Expr::PropertyGet { object, property, .. }
                     if is_string_expr(ctx, object) && property == "toUpperCase"
             )
         {
@@ -452,7 +454,7 @@ pub(crate) fn lower_let(
             && matches!(args.as_slice(), [perry_hir::Expr::String(s)] if !s.is_empty())
             && matches!(
                 callee.as_ref(),
-                perry_hir::Expr::PropertyGet { object, property }
+                perry_hir::Expr::PropertyGet { object, property, .. }
                     if is_string_expr(ctx, object)
                         && matches!(object.as_ref(), perry_hir::Expr::LocalGet(_))
                         && property == "split"
@@ -1760,12 +1762,12 @@ fn length_of_local_buffer_id(expr: &perry_hir::Expr) -> Option<u32> {
                 _ => None,
             }
         }
-        perry_hir::Expr::PropertyGet { object, property } if property == "length" => {
-            match object.as_ref() {
-                perry_hir::Expr::LocalGet(id) => Some(*id),
-                _ => None,
-            }
-        }
+        perry_hir::Expr::PropertyGet {
+            object, property, ..
+        } if property == "length" => match object.as_ref() {
+            perry_hir::Expr::LocalGet(id) => Some(*id),
+            _ => None,
+        },
         _ => None,
     }
 }

--- a/crates/perry-codegen/src/stmt/loops.rs
+++ b/crates/perry-codegen/src/stmt/loops.rs
@@ -217,7 +217,7 @@ fn lower_numeric_bulk_fill_loop(ctx: &mut FnCtx<'_>, matched: NumericBulkFillLoo
 
     let is_len_bound = matches!(
         &matched.bound,
-        perry_hir::Expr::PropertyGet { object, property }
+        perry_hir::Expr::PropertyGet { object, property, .. }
             if property == "length"
                 && matches!(object.as_ref(), perry_hir::Expr::LocalGet(id) if *id == matched.array_id)
     );
@@ -1061,7 +1061,9 @@ fn class_field_loop_pure_expr_collect(
 ) -> bool {
     use perry_hir::Expr;
     match expr {
-        Expr::PropertyGet { object, property } => {
+        Expr::PropertyGet {
+            object, property, ..
+        } => {
             let Expr::LocalGet(obj_id) = object.as_ref() else {
                 return false;
             };
@@ -2011,7 +2013,9 @@ fn expr_is_packed_f64_loop_safe(
                 && expr_is_packed_f64_loop_safe(ctx, value, arr_id, counter_id)
         }
         Expr::Update { id, .. } => *id != arr_id && *id != counter_id,
-        Expr::PropertyGet { object, property } => {
+        Expr::PropertyGet {
+            object, property, ..
+        } => {
             if matches!(object.as_ref(), Expr::LocalGet(id) if *id == arr_id) {
                 property == "length"
             } else {
@@ -2451,6 +2455,7 @@ fn lower_for_after_init_with_i32_bound(
         let arr_box_loaded = lower_expr(
             ctx,
             &perry_hir::Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(perry_hir::Expr::LocalGet(hoist.arr_id)),
                 property: "length".to_string(),
             },
@@ -3154,7 +3159,9 @@ fn classify_for_length_hoist(
         return None;
     }
     let arr_id = match right {
-        Expr::PropertyGet { object, property } if property == "length" => match object.as_ref() {
+        Expr::PropertyGet {
+            object, property, ..
+        } if property == "length" => match object.as_ref() {
             Expr::LocalGet(id) => *id,
             _ => return None,
         },
@@ -3239,7 +3246,9 @@ fn classify_for_length_hoist_rejection(
         return None;
     }
     let arr_id = match right {
-        Expr::PropertyGet { object, property } if property == "length" => match object.as_ref() {
+        Expr::PropertyGet {
+            object, property, ..
+        } if property == "length" => match object.as_ref() {
             Expr::LocalGet(id) => *id,
             _ => return None,
         },
@@ -4032,7 +4041,10 @@ fn expr_array_length_effect(
             }
         }
         Expr::Call { callee, args, .. } => {
-            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+            if let Expr::PropertyGet {
+                object, property, ..
+            } = callee.as_ref()
+            {
                 if is_buffer_numeric_read_method(property) && is_static_buffer_receiver(ctx, object)
                 {
                     return first_blocking_loop_effect(
@@ -4480,7 +4492,10 @@ pub(crate) fn expr_preserves_array_length(
         // outer scope would make the cached length and bounded-index facts
         // unsound.
         Expr::Call { callee, args, .. } => {
-            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+            if let Expr::PropertyGet {
+                object, property, ..
+            } = callee.as_ref()
+            {
                 if is_buffer_numeric_read_method(property) && is_static_buffer_receiver(ctx, object)
                 {
                     return walk(object) && args.iter().all(&walk);

--- a/crates/perry-codegen/src/type_analysis/numeric.rs
+++ b/crates/perry-codegen/src/type_analysis/numeric.rs
@@ -195,7 +195,9 @@ pub(crate) fn is_numeric_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
         // LLVM from doing GVN/LICM on the load. The class field
         // walker matches `class_field_global_index`'s inheritance
         // traversal so the type of any inherited field is also seen.
-        Expr::PropertyGet { object, property } => {
+        Expr::PropertyGet {
+            object, property, ..
+        } => {
             if property == "length" && expression_has_numeric_length(ctx, object) {
                 return true;
             }
@@ -284,7 +286,10 @@ pub(crate) fn is_numeric_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
         // Without this, `fib(n-1) + fib(n-2)` wraps both results in
         // js_number_coerce — ~4 billion wasted runtime calls on fib(40).
         Expr::Call { callee, .. } => {
-            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+            if let Expr::PropertyGet {
+                object, property, ..
+            } = callee.as_ref()
+            {
                 if is_fixed_width_buffer_numeric_read(property)
                     && receiver_class_name(ctx, object)
                         .as_deref()

--- a/crates/perry-codegen/src/type_analysis/pod.rs
+++ b/crates/perry-codegen/src/type_analysis/pod.rs
@@ -85,9 +85,10 @@ pub(crate) fn pod_record_field_is_numeric(ctx: &FnCtx<'_>, object: &Expr, field:
 
 fn collect_pod_numeric_field_read_locals(ctx: &FnCtx<'_>, expr: &Expr, out: &mut Vec<u32>) {
     match expr {
-        Expr::PropertyGet { object, property }
-            if matches!(object.as_ref(), Expr::LocalGet(_))
-                && pod_record_field_is_numeric(ctx, object, property) =>
+        Expr::PropertyGet {
+            object, property, ..
+        } if matches!(object.as_ref(), Expr::LocalGet(_))
+            && pod_record_field_is_numeric(ctx, object, property) =>
         {
             if let Expr::LocalGet(id) = object.as_ref() {
                 out.push(*id);
@@ -167,15 +168,16 @@ fn collect_pod_numeric_field_read_locals(ctx: &FnCtx<'_>, expr: &Expr, out: &mut
 fn expr_may_materialize_pod_local(ctx: &FnCtx<'_>, expr: &Expr, target_id: u32) -> bool {
     match expr {
         Expr::LocalGet(id) => *id == target_id && ctx.pod_records.contains_key(id),
-        Expr::PropertyGet { object, property }
-            if matches!(object.as_ref(), Expr::LocalGet(id) if *id == target_id)
-                && ctx.pod_records.get(&target_id).is_some_and(|local| {
-                    local
-                        .layout
-                        .fields
-                        .iter()
-                        .any(|field| field.name == *property)
-                }) =>
+        Expr::PropertyGet {
+            object, property, ..
+        } if matches!(object.as_ref(), Expr::LocalGet(id) if *id == target_id)
+            && ctx.pod_records.get(&target_id).is_some_and(|local| {
+                local
+                    .layout
+                    .fields
+                    .iter()
+                    .any(|field| field.name == *property)
+            }) =>
         {
             false
         }
@@ -411,7 +413,9 @@ pub(crate) fn expr_may_return_boxed_value_from_raw_f64_fallback(
     expr: &Expr,
 ) -> bool {
     match expr {
-        Expr::PropertyGet { object, property } => receiver_class_name(ctx, object)
+        Expr::PropertyGet {
+            object, property, ..
+        } => receiver_class_name(ctx, object)
             .and_then(|class_name| class_field_declared_type(ctx, &class_name, property))
             .as_ref()
             .is_some_and(crate::typed_shape::type_is_raw_f64_candidate),

--- a/crates/perry-codegen/src/type_analysis/predicates.rs
+++ b/crates/perry-codegen/src/type_analysis/predicates.rs
@@ -43,7 +43,10 @@ pub(crate) fn is_global_builtin_named(expr: &Expr, name: &str) -> bool {
     if matches!(expr, Expr::GlobalGet(_)) {
         return true;
     }
-    if let Expr::PropertyGet { object, property } = expr {
+    if let Expr::PropertyGet {
+        object, property, ..
+    } = expr
+    {
         if matches!(object.as_ref(), Expr::GlobalGet(_)) && property == name {
             return true;
         }
@@ -74,7 +77,9 @@ pub(crate) fn is_promise_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
         },
         // Promise.resolve / reject / all / race / allSettled / any
         Expr::Call { callee, .. } => match callee.as_ref() {
-            Expr::PropertyGet { object, property } => {
+            Expr::PropertyGet {
+                object, property, ..
+            } => {
                 // `Promise.resolve(...)` etc. The receiver `Promise` can
                 // appear in two shapes:
                 //   - Legacy: bare ident → `Expr::GlobalGet(_)` directly.
@@ -308,7 +313,9 @@ pub(crate) fn receiver_class_name(ctx: &FnCtx<'_>, e: &Expr) -> Option<String> {
         // `this.field` or `obj.field` where the field's declared type
         // is a class. Walk the class definition to find the field's
         // type. Honors the parent inheritance chain.
-        Expr::PropertyGet { object, property } => {
+        Expr::PropertyGet {
+            object, property, ..
+        } => {
             let owner_class_name = receiver_class_name(ctx, object)?;
             let class = ctx.classes.get(&owner_class_name)?;
             // Look in own fields, then walk parent chain.
@@ -454,7 +461,9 @@ pub(crate) fn static_type_of(ctx: &FnCtx<'_>, e: &Expr) -> Option<HirType> {
             })
             .map(|method| method.return_type.clone()),
         e if net_result_type(e).is_some() => net_result_type(e),
-        Expr::PropertyGet { object, property } => {
+        Expr::PropertyGet {
+            object, property, ..
+        } => {
             if property == "length" && expression_has_numeric_length(ctx, object) {
                 return Some(HirType::Number);
             }
@@ -570,7 +579,7 @@ pub(crate) fn static_type_of(ctx: &FnCtx<'_>, e: &Expr) -> Option<HirType> {
         Expr::Call { callee, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { property, object } if matches!(
+                Expr::PropertyGet { property, object, .. } if matches!(
                     property.as_str(), "split" | "match"
                 ) && is_string_expr(ctx, object)
             ) =>
@@ -594,7 +603,7 @@ pub(crate) fn static_type_of(ctx: &FnCtx<'_>, e: &Expr) -> Option<HirType> {
         Expr::Call { callee, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { property, object }
+                Expr::PropertyGet { property, object, .. }
                     if matches!(object.as_ref(), Expr::NativeModuleRef(m) if m == "crypto")
                         && matches!(property.as_str(), "getHashes" | "getCiphers" | "getCurves")
             ) =>

--- a/crates/perry-codegen/src/type_analysis/refine.rs
+++ b/crates/perry-codegen/src/type_analysis/refine.rs
@@ -20,7 +20,7 @@ pub(crate) fn is_global_constructor_expr(e: &Expr, name: &str) -> bool {
     matches!(e, Expr::GlobalGet(_))
         || matches!(
             e,
-            Expr::PropertyGet { object, property }
+            Expr::PropertyGet { object, property, .. }
                 if property == name && matches!(object.as_ref(), Expr::GlobalGet(_))
         )
 }
@@ -365,7 +365,7 @@ pub(crate) fn refine_type_from_init(ctx: &FnCtx<'_>, init: &Expr) -> Option<HirT
             }
             None
         }
-        Expr::PropertyGet { object, property } => {
+        Expr::PropertyGet { object, property, .. } => {
             if is_process_namespace_version_property(object, property) {
                 return Some(HirType::String);
             }
@@ -410,7 +410,7 @@ pub(crate) fn refine_type_from_init(ctx: &FnCtx<'_>, init: &Expr) -> Option<HirT
             // property: "readdirSync" } }` — refine so `entries.includes(...)`
             // hits the array fast path via is_array_expr.
             // Same for realpathSync/mkdtempSync (string-returning).
-            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+            if let Expr::PropertyGet { object, property, .. } = callee.as_ref() {
                 if matches!(object.as_ref(), Expr::NativeModuleRef(m) if m == "fs") {
                     match property.as_str() {
                         "readdirSync" => {
@@ -484,7 +484,7 @@ pub(crate) fn refine_type_from_init(ctx: &FnCtx<'_>, init: &Expr) -> Option<HirT
             // gets typed as Any and chained `fixed.isWellFormed()` routes
             // through dynamic dispatch (which prints `[object Object]`).
             // Mirrors the `is_string_expr` logic just below.
-            if let Expr::PropertyGet { property, object } = callee.as_ref() {
+            if let Expr::PropertyGet { property, object, .. } = callee.as_ref() {
                 let returns_string = matches!(
                     property.as_str(),
                     "toString" | "toLowerCase" | "toUpperCase" | "trim"
@@ -524,6 +524,7 @@ fn crypto_digest_chain_has_string_encoding(callee: &Expr) -> Option<bool> {
     let Expr::PropertyGet {
         property: p1,
         object: o1,
+        ..
     } = callee
     else {
         return None;
@@ -542,6 +543,7 @@ fn crypto_digest_chain_has_string_encoding(callee: &Expr) -> Option<bool> {
     let Expr::PropertyGet {
         property: p2,
         object: o2,
+        ..
     } = c2.as_ref()
     else {
         return None;
@@ -555,6 +557,7 @@ fn crypto_digest_chain_has_string_encoding(callee: &Expr) -> Option<bool> {
     let Expr::PropertyGet {
         property: p3,
         object: o3,
+        ..
     } = c3.as_ref()
     else {
         return None;

--- a/crates/perry-codegen/src/type_analysis/strings.rs
+++ b/crates/perry-codegen/src/type_analysis/strings.rs
@@ -25,7 +25,9 @@ pub(crate) fn is_set_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
         ),
         // `this.field` where the field is declared as `Set<T>` on the
         // enclosing class. Same rationale as is_map_expr.
-        Expr::PropertyGet { object, property } => {
+        Expr::PropertyGet {
+            object, property, ..
+        } => {
             if let Some(cls_name) = receiver_class_name(ctx, object) {
                 if let Some(cls) = ctx.classes.get(&cls_name) {
                     if let Some(field) = cls.fields.iter().find(|f| f.name == *property) {
@@ -50,7 +52,9 @@ pub(crate) fn set_static_type_args<'a>(ctx: &'a FnCtx<'_>, e: &Expr) -> Option<&
             }
             _ => None,
         },
-        Expr::PropertyGet { object, property } => {
+        Expr::PropertyGet {
+            object, property, ..
+        } => {
             let cls_name = receiver_class_name(ctx, object)?;
             let cls = ctx.classes.get(&cls_name)?;
             let field = cls.fields.iter().find(|f| f.name == *property)?;
@@ -80,7 +84,9 @@ pub(crate) fn is_url_search_params_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
         // PropertyGet (the URL HIR variant only fires for direct typed
         // receivers in `lower_member`). Detect the chained access here
         // so `url.searchParams.size` works without an intermediate let.
-        Expr::PropertyGet { object, property } if property == "searchParams" => {
+        Expr::PropertyGet {
+            object, property, ..
+        } if property == "searchParams" => {
             if let Expr::LocalGet(id) = object.as_ref() {
                 return matches!(
                     ctx.local_types.get(id),
@@ -105,7 +111,9 @@ pub(crate) fn is_map_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
         // `this.handlers.get(...)` inside class methods dispatch
         // through the Map fast path instead of the dynamic field-set
         // fallback.
-        Expr::PropertyGet { object, property } => {
+        Expr::PropertyGet {
+            object, property, ..
+        } => {
             if let Some(cls_name) = receiver_class_name(ctx, object) {
                 if let Some(cls) = ctx.classes.get(&cls_name) {
                     if let Some(field) = cls.fields.iter().find(|f| f.name == *property) {
@@ -130,7 +138,9 @@ pub(crate) fn map_static_type_args<'a>(ctx: &'a FnCtx<'_>, e: &Expr) -> Option<&
             }
             _ => None,
         },
-        Expr::PropertyGet { object, property } => {
+        Expr::PropertyGet {
+            object, property, ..
+        } => {
             let cls_name = receiver_class_name(ctx, object)?;
             let cls = ctx.classes.get(&cls_name)?;
             let field = cls.fields.iter().find(|f| f.name == *property)?;
@@ -251,11 +261,9 @@ pub(crate) fn is_definitely_string_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
             else_expr,
             ..
         } => is_definitely_string_expr(ctx, then_expr) && is_definitely_string_expr(ctx, else_expr),
-        Expr::PropertyGet { object, property }
-            if is_process_namespace_version_property(object, property) =>
-        {
-            true
-        }
+        Expr::PropertyGet {
+            object, property, ..
+        } if is_process_namespace_version_property(object, property) => true,
         _ => false,
     }
 }
@@ -404,7 +412,7 @@ pub(crate) fn is_string_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
         Expr::Call { callee, .. }
             if matches!(
                 callee.as_ref(),
-                Expr::PropertyGet { property, object } if matches!(
+                Expr::PropertyGet { property, object, .. } if matches!(
                     property.as_str(),
                     "toString" | "toLowerCase" | "toUpperCase" | "trim"
                         | "trimStart" | "trimEnd" | "slice" | "substring"
@@ -434,7 +442,7 @@ pub(crate) fn is_string_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
         // to a concrete declared field type, defer to it; only fall
         // back to the Error-string assumption when the receiver's type
         // is genuinely unknown (a real caught `Error`/`unknown`/`any`).
-        Expr::PropertyGet { object, property }
+        Expr::PropertyGet { object, property, .. }
             // `.stack` excluded — may be an array via `Error.prepareStackTrace`.
             if matches!(property.as_str(), "message" | "name") =>
         {
@@ -452,7 +460,7 @@ pub(crate) fn is_string_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
         // surface as bare `process`. Keep the string method dispatch
         // available for namespace imports:
         // `import * as process from "node:process"; process.version.startsWith("v")`.
-        Expr::PropertyGet { object, property }
+        Expr::PropertyGet { object, property, .. }
             if is_process_namespace_version_property(object, property) =>
         {
             true
@@ -460,7 +468,7 @@ pub(crate) fn is_string_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
         // Perry's native crypto.generateKeyPairSync returns a plain object
         // with PEM string fields. Refining these fields keeps
         // `pair.publicKey.includes(...)` on the string fast path.
-        Expr::PropertyGet { object, property }
+        Expr::PropertyGet { object, property, .. }
             if matches!(property.as_str(), "publicKey" | "privateKey")
                 && matches!(
                     static_type_of(ctx, object),
@@ -470,7 +478,7 @@ pub(crate) fn is_string_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
             true
         }
         // PropertyGet on a known class field with declared type String.
-        Expr::PropertyGet { object, property } => {
+        Expr::PropertyGet { object, property, .. } => {
             let Some(class_name) = receiver_class_name(ctx, object) else {
                 return false;
             };

--- a/crates/perry-codegen/src/type_analysis_tests.rs
+++ b/crates/perry-codegen/src/type_analysis_tests.rs
@@ -89,6 +89,7 @@ fn hir_inferred_static_type_provides_codegen_fallback_facts() {
         hir_inferred_static_type_from_locals(
             &local_types,
             &Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::Object(vec![(
                     "answer".to_string(),
                     Expr::Number(1.0)
@@ -312,6 +313,7 @@ fn hir_inferred_types_reuse_codegen_contextual_class_facts() {
     assert_eq!(
         infer_expr_type(
             &Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(1)),
                 property: "label".to_string(),
             },
@@ -323,6 +325,7 @@ fn hir_inferred_types_reuse_codegen_contextual_class_facts() {
         infer_expr_type(
             &Expr::Call {
                 callee: Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::LocalGet(1)),
                     property: "score".to_string(),
                 }),

--- a/crates/perry-codegen/tests/argless_builtin_extra_args.rs
+++ b/crates/perry-codegen/tests/argless_builtin_extra_args.rs
@@ -101,6 +101,7 @@ fn module_with_init(init: Vec<Stmt>) -> Module {
 fn string_trim_with_extra_arg_compiles() {
     let stmt = Stmt::Expr(Expr::Call {
         callee: Box::new(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::String("  x  ".to_string())),
             property: "trim".to_string(),
         }),
@@ -124,6 +125,7 @@ fn string_trim_with_extra_arg_compiles() {
 fn array_pop_with_extra_arg_compiles() {
     let stmt = Stmt::Expr(Expr::Call {
         callee: Box::new(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::Array(vec![Expr::Number(1.0)])),
             property: "pop".to_string(),
         }),

--- a/crates/perry-codegen/tests/native_proof_buffer_views.rs
+++ b/crates/perry-codegen/tests/native_proof_buffer_views.rs
@@ -443,6 +443,7 @@ fn add(left: Expr, right: Expr) -> Expr {
 
 fn length(local_id: u32) -> Expr {
     Expr::PropertyGet {
+        byte_offset: 0,
         object: Box::new(local(local_id)),
         property: "length".to_string(),
     }
@@ -459,6 +460,7 @@ fn buffer_set(buffer_id: u32, index: Expr) -> Stmt {
 fn buffer_read(buffer_id: u32, method: &str, index: Expr) -> Expr {
     call(
         Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(local(buffer_id)),
             property: method.to_string(),
         },
@@ -605,6 +607,7 @@ fn artifact_records_buffer_read_u32_and_unsigned_materialization() {
         buffer_let(1, "buf", int(8)),
         Stmt::Return(Some(Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(1)),
                 property: "readUInt32BE".to_string(),
             }),
@@ -657,6 +660,7 @@ fn loop_length_bound_does_not_prove_multibyte_buffer_read_inbounds() {
             length(1),
             vec![Stmt::Expr(call(
                 Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(local(1)),
                     property: "readUInt32BE".to_string(),
                 },
@@ -689,6 +693,7 @@ fn artifact_records_buffer_read_double_as_f64() {
         buffer_let(1, "buf", int(8)),
         Stmt::Return(Some(Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(1)),
                 property: "readDoubleLE".to_string(),
             }),
@@ -727,6 +732,7 @@ fn artifact_records_buffer_read_float_as_f32_and_float_extend_materialization() 
         buffer_let(1, "buf", int(8)),
         Stmt::Return(Some(call(
             Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(1)),
                 property: "readFloatLE".to_string(),
             },

--- a/crates/perry-codegen/tests/native_proof_regressions.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions.rs
@@ -545,6 +545,7 @@ fn add(left: Expr, right: Expr) -> Expr {
 
 fn length(local_id: u32) -> Expr {
     Expr::PropertyGet {
+        byte_offset: 0,
         object: Box::new(local(local_id)),
         property: "length".to_string(),
     }
@@ -561,6 +562,7 @@ fn buffer_set(buffer_id: u32, index: Expr) -> Stmt {
 fn buffer_read(buffer_id: u32, method: &str, index: Expr) -> Expr {
     call(
         Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(local(buffer_id)),
             property: method.to_string(),
         },
@@ -791,6 +793,7 @@ fn artifact_schema_v6_records_c_layout_pod_manifest() {
             value: Box::new(int(9)),
         }),
         Stmt::Return(Some(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(local(1)),
             property: "gain".to_string(),
         })),
@@ -1288,6 +1291,7 @@ fn artifact_schema_v6_records_pod_dynamic_write_fallback() {
             value: Box::new(Expr::String("x".to_string())),
         }),
         Stmt::Return(Some(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(local(1)),
             property: "tag".to_string(),
         })),
@@ -1337,6 +1341,7 @@ fn pod_field_read_after_dynamic_materialization_uses_dynamic_numeric_sub() {
         Stmt::Return(Some(Expr::Binary {
             op: BinaryOp::Sub,
             left: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(1)),
                 property: "tag".to_string(),
             }),
@@ -1487,6 +1492,7 @@ fn scalar_replaced_raw_f64_field_store_keeps_numeric_array_fallback_boxed() {
                 }),
             }),
             Stmt::Return(Some(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(2)),
                 property: "gain".to_string(),
             })),
@@ -1522,6 +1528,7 @@ fn artifact_schema_v8_rejects_inexact_pod_initializer_values() {
             ],
         ),
         Stmt::Return(Some(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(local(1)),
             property: "tag".to_string(),
         })),
@@ -1573,6 +1580,7 @@ fn artifact_schema_v6_records_pod_pointerful_field_rejection() {
             vec![("tag", int(7)), ("name", Expr::String("x".to_string()))],
         ),
         Stmt::Return(Some(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(local(1)),
             property: "tag".to_string(),
         })),
@@ -8077,6 +8085,7 @@ fn typed_f64_method_clone_module() -> Module {
         Type::Number,
         vec![Stmt::Return(Some(Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(1)),
                 property: "mix".to_string(),
             }),
@@ -8134,6 +8143,7 @@ fn typed_f64_i32_local_method_clone_module() -> Module {
         Type::Number,
         vec![Stmt::Return(Some(Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(1)),
                 property: "mix".to_string(),
             }),
@@ -8195,6 +8205,7 @@ fn typed_f64_method_negative_module(case: &str) -> Module {
         Type::Number,
         vec![Stmt::Return(Some(Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(1)),
                 property: "mix".to_string(),
             }),
@@ -8207,6 +8218,7 @@ fn typed_f64_method_negative_module(case: &str) -> Module {
 
 fn this_field(name: &str) -> Expr {
     Expr::PropertyGet {
+        byte_offset: 0,
         object: Box::new(Expr::This),
         property: name.to_string(),
     }
@@ -8272,6 +8284,7 @@ fn typed_f64_receiver_method_positive_module() -> Module {
         Type::Number,
         vec![Stmt::Return(Some(Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(1)),
                 property: "score".to_string(),
             }),
@@ -8315,6 +8328,7 @@ fn typed_f64_receiver_method_negative_module(case: &str) -> Module {
         "nested_call" => {
             method_body = vec![Stmt::Return(Some(Expr::Call {
                 callee: Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::This),
                     property: "other".to_string(),
                 }),
@@ -8366,6 +8380,7 @@ fn typed_f64_receiver_method_negative_module(case: &str) -> Module {
                 Type::Number,
                 vec![Stmt::Return(Some(Expr::Call {
                     callee: Box::new(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(local(1)),
                         property: "score".to_string(),
                     }),
@@ -8392,6 +8407,7 @@ fn typed_f64_receiver_method_negative_module(case: &str) -> Module {
         Type::Number,
         vec![Stmt::Return(Some(Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(1)),
                 property: "score".to_string(),
             }),
@@ -8713,6 +8729,7 @@ fn typed_i1_method_clone_module(case: &str) -> Module {
         Type::Boolean,
         vec![Stmt::Return(Some(Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(1)),
                 property: "check".to_string(),
             }),
@@ -8808,6 +8825,7 @@ fn typed_i32_method_clone_module(case: &str) -> Module {
         },
         vec![Stmt::Return(Some(Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(1)),
                 property: "mix_i32".to_string(),
             }),
@@ -8888,6 +8906,7 @@ fn typed_string_method_clone_module(case: &str) -> Module {
         Type::String,
         vec![Stmt::Return(Some(Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(1)),
                 property: "pick".to_string(),
             }),
@@ -8945,6 +8964,7 @@ fn typed_i1_numeric_predicate_method_module() -> Module {
         Type::Boolean,
         vec![Stmt::Return(Some(Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(1)),
                 property: "above".to_string(),
             }),
@@ -9234,10 +9254,12 @@ fn scalar_method_summary_module() -> Module {
         body: vec![Stmt::Return(Some(Expr::Binary {
             op: BinaryOp::Add,
             left: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::This),
                 property: "x".to_string(),
             }),
             right: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::This),
                 property: "y".to_string(),
             }),
@@ -9273,6 +9295,7 @@ fn scalar_method_summary_module() -> Module {
             },
             Stmt::Return(Some(Expr::Call {
                 callee: Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(local(20)),
                     property: "sum".to_string(),
                 }),
@@ -9312,6 +9335,7 @@ fn scalar_method_numeric_local_temp_module(case: &str, mutable_temp: bool) -> Mo
                 init: Some(Expr::Binary {
                     op: BinaryOp::Add,
                     left: Box::new(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::This),
                         property: "x".to_string(),
                     }),
@@ -9327,6 +9351,7 @@ fn scalar_method_numeric_local_temp_module(case: &str, mutable_temp: bool) -> Mo
                     op: BinaryOp::Mul,
                     left: Box::new(local(130)),
                     right: Box::new(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::This),
                         property: "y".to_string(),
                     }),
@@ -9359,6 +9384,7 @@ fn scalar_method_numeric_local_temp_module(case: &str, mutable_temp: bool) -> Mo
         },
         Stmt::Return(Some(Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(20)),
                 property: "weighted".to_string(),
             }),
@@ -9374,6 +9400,7 @@ fn scalar_predicate_method_body(field: &str) -> Expr {
     Expr::Compare {
         op: CompareOp::Gt,
         left: Box::new(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::This),
             property: field.to_string(),
         }),
@@ -9401,6 +9428,7 @@ fn scalar_method_boolean_predicate_module() -> Module {
         },
         Stmt::Return(Some(Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(20)),
                 property: "isAbove".to_string(),
             }),
@@ -9449,6 +9477,7 @@ fn scalar_method_boolean_public_numeric_arg_module(case: &str, arg_ty: Type) -> 
         },
         Stmt::Return(Some(Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(20)),
                 property: "isAbove".to_string(),
             }),
@@ -9483,6 +9512,7 @@ fn scalar_method_boolean_public_numeric_expr_arg_module() -> Module {
         },
         Stmt::Return(Some(Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(20)),
                 property: "isAbove".to_string(),
             }),
@@ -9554,12 +9584,14 @@ fn scalar_method_int32_bitwise_module(case: &str, field_ty: Type, arg_ty: Type) 
                 left: Box::new(Expr::Binary {
                     op: BinaryOp::BitXor,
                     left: Box::new(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::This),
                         property: "mask".to_string(),
                     }),
                     right: Box::new(local(12)),
                 }),
                 right: Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::This),
                     property: "salt".to_string(),
                 }),
@@ -9604,6 +9636,7 @@ fn scalar_method_int32_bitwise_module(case: &str, field_ty: Type, arg_ty: Type) 
             },
             Stmt::Return(Some(Expr::Call {
                 callee: Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(local(20)),
                     property: "mix".to_string(),
                 }),
@@ -9631,6 +9664,7 @@ fn scalar_method_int32_unsigned_shift_module() -> Module {
     module.classes[0].methods[0].body = vec![Stmt::Return(Some(Expr::Binary {
         op: BinaryOp::UShr,
         left: Box::new(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::This),
             property: "mask".to_string(),
         }),
@@ -9650,6 +9684,7 @@ fn scalar_method_int32_bitwise_local_temp_module() -> Module {
             init: Some(Expr::Binary {
                 op: BinaryOp::BitXor,
                 left: Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::This),
                     property: "mask".to_string(),
                 }),
@@ -9671,6 +9706,7 @@ fn scalar_method_int32_bitwise_local_temp_module() -> Module {
             op: BinaryOp::BitOr,
             left: Box::new(local(131)),
             right: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::This),
                 property: "salt".to_string(),
             }),
@@ -9706,6 +9742,7 @@ fn scalar_method_boolean_negative_module(case: &str) -> Module {
                 params: Vec::new(),
                 return_type: Type::Number,
                 body: vec![Stmt::Return(Some(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::This),
                     property: "x".to_string(),
                 }))],
@@ -9722,6 +9759,7 @@ fn scalar_method_boolean_negative_module(case: &str) -> Module {
                 op: CompareOp::Gt,
                 left: Box::new(Expr::Call {
                     callee: Box::new(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::This),
                         property: "readX".to_string(),
                     }),
@@ -9742,6 +9780,7 @@ fn scalar_method_boolean_negative_module(case: &str) -> Module {
                     params: Vec::new(),
                     return_type: Type::Number,
                     body: vec![Stmt::Return(Some(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::This),
                         property: "x".to_string(),
                     }))],
@@ -9816,6 +9855,7 @@ fn scalar_method_boolean_negative_module(case: &str) -> Module {
                 },
                 Stmt::Return(Some(Expr::Call {
                     callee: Box::new(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(local(20)),
                         property: "isAbove".to_string(),
                     }),
@@ -9843,6 +9883,7 @@ fn scalar_method_boolean_negative_module(case: &str) -> Module {
                 },
                 Stmt::Return(Some(Expr::Call {
                     callee: Box::new(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(local(20)),
                         property: "isAbove".to_string(),
                     }),
@@ -13123,6 +13164,7 @@ fn static_property_access_on_computed_class_uses_property_id_wrappers() {
                 value: Box::new(local(2)),
             }),
             Stmt::Return(Some(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(1)),
                 property: "score".to_string(),
             })),
@@ -13149,6 +13191,7 @@ fn static_name_method_fallback_uses_method_id_wrapper() {
         Type::Number,
         vec![Stmt::Return(Some(call(
             Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(1)),
                 property: "score".to_string(),
             },
@@ -13179,6 +13222,7 @@ fn static_name_spread_method_fallback_uses_method_id_wrapper() {
         Type::Number,
         vec![Stmt::Return(Some(Expr::CallSpread {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(1)),
                 property: "score".to_string(),
             }),
@@ -13219,6 +13263,7 @@ fn static_name_class_method_value_uses_method_id_bind_wrapper() {
         vec![param(1, "obj", Type::Named("Calc".to_string()))],
         Type::Any,
         vec![Stmt::Return(Some(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(local(1)),
             property: "score".to_string(),
         }))],
@@ -13249,6 +13294,7 @@ fn raw_numeric_class_field_rejects_unknown_or_dynamic_shape_receiver() {
                 value: Box::new(number(7.0)),
             }),
             Stmt::Return(Some(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(1)),
                 property: "x".to_string(),
             })),
@@ -13270,6 +13316,7 @@ fn raw_numeric_class_field_rejects_unknown_or_dynamic_shape_receiver() {
                 value: Box::new(number(7.0)),
             }),
             Stmt::Return(Some(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(1)),
                 property: "x".to_string(),
             })),
@@ -13349,6 +13396,7 @@ fn put_value_set_index_keeps_the_numeric_array_fast_path() {
                 op: CompareOp::Lt,
                 left: Box::new(Expr::LocalGet(i)),
                 right: Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::LocalGet(arr)),
                     property: "length".to_string(),
                 }),

--- a/crates/perry-codegen/tests/native_proof_regressions/artifact_records.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions/artifact_records.rs
@@ -234,6 +234,7 @@ fn artifact_records_raw_numeric_class_field_f64_fast_paths_and_fallback_reasons(
                 value: Box::new(Expr::Number(7.0)),
             }),
             Stmt::Return(Some(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(local(1)),
                 property: "x".to_string(),
             })),

--- a/crates/perry-codegen/tests/native_proof_regressions/invalidation.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions/invalidation.rs
@@ -714,6 +714,7 @@ fn async_microtask_effect_blocks_length_and_bounds_proofs_with_artifact_reason()
 fn local_array_alias_generic_receiver_call_blocks_length_and_bounds_proofs() {
     let body = aliased_array_loop(call(
         Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(local(2)),
             property: "push".to_string(),
         },

--- a/crates/perry-codegen/tests/typed_feedback.rs
+++ b/crates/perry-codegen/tests/typed_feedback.rs
@@ -244,6 +244,7 @@ fn typed_feedback_instruments_property_and_method_boundaries() {
             }),
             Stmt::Expr(Expr::Call {
                 callee: Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::LocalGet(1)),
                     property: "run".to_string(),
                 }),
@@ -252,6 +253,7 @@ fn typed_feedback_instruments_property_and_method_boundaries() {
                 byte_offset: 0,
             }),
             Stmt::Return(Some(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(1)),
                 property: "x".to_string(),
             })),
@@ -294,6 +296,7 @@ fn typed_feedback_guards_direct_class_field_specialization() {
             Stmt::Return(Some(Expr::Binary {
                 op: BinaryOp::Sub,
                 left: Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::LocalGet(1)),
                     property: "x".to_string(),
                 }),
@@ -397,6 +400,7 @@ fn full_outline_ic_collapses_class_field_get_to_single_call() {
             vec![param(1, "p", Type::Named("Point".to_string()))],
             Type::Number,
             vec![Stmt::Return(Some(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(1)),
                 property: "x".to_string(),
             }))],
@@ -590,6 +594,7 @@ fn typed_feedback_guards_direct_class_method_specialization() {
         Type::Number,
         vec![Stmt::Return(Some(Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(1)),
                 property: "inc".to_string(),
             }),

--- a/crates/perry-codegen/tests/typed_shape_descriptors.rs
+++ b/crates/perry-codegen/tests/typed_shape_descriptors.rs
@@ -196,6 +196,7 @@ fn scalar_object_literal_skips_pure_unobserved_initializers() {
                 ])),
             },
             Stmt::Return(Some(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(1)),
                 property: "used".to_string(),
             })),
@@ -269,6 +270,7 @@ fn scalar_object_literal_keeps_observable_unobserved_initializers() {
                 ])),
             },
             Stmt::Return(Some(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(1)),
                 property: "used".to_string(),
             })),
@@ -487,6 +489,7 @@ fn c262_array_has_own_property_uses_object_prototype_dispatch() {
             },
             Stmt::Return(Some(Expr::Call {
                 callee: Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::LocalGet(1)),
                     property: "hasOwnProperty".to_string(),
                 }),
@@ -561,6 +564,7 @@ fn bounded_integer_array_store_omits_layout_note_and_barrier() {
                     op: CompareOp::Lt,
                     left: Box::new(Expr::LocalGet(2)),
                     right: Box::new(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::LocalGet(1)),
                         property: "length".to_string(),
                     }),
@@ -654,6 +658,7 @@ fn numeric_iota_fill_loop_uses_bulk_helper_without_barrier() {
                     op: CompareOp::Lt,
                     left: Box::new(Expr::LocalGet(2)),
                     right: Box::new(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::LocalGet(1)),
                         property: "length".to_string(),
                     }),

--- a/crates/perry-hir/src/analysis/value_types.rs
+++ b/crates/perry-hir/src/analysis/value_types.rs
@@ -706,7 +706,9 @@ pub fn infer_expr_type<F: HirTypeFacts + ?Sized>(expr: &Expr, env: &F) -> Type {
             env.super_property_type(property).unwrap_or(Type::Any)
         }
 
-        Expr::PropertyGet { object, property } => infer_property_get_type(object, property, env),
+        Expr::PropertyGet {
+            object, property, ..
+        } => infer_property_get_type(object, property, env),
         Expr::PropertySet { value, .. } => infer_expr_type(value, env),
         Expr::PropertyUpdate { .. } => Type::Number,
         Expr::IndexGet { object, .. } => match infer_expr_type(object, env) {

--- a/crates/perry-hir/src/analysis/value_types_tests.rs
+++ b/crates/perry-hir/src/analysis/value_types_tests.rs
@@ -226,6 +226,7 @@ fn infers_object_and_array_shapes_conservatively() {
     let env = empty_env();
     let object = Expr::Object(vec![("answer".to_string(), Expr::Number(42.0))]);
     let get = Expr::PropertyGet {
+        byte_offset: 0,
         object: Box::new(object),
         property: "answer".to_string(),
     };
@@ -755,6 +756,7 @@ fn infers_named_class_and_interface_property_facts() {
     assert_eq!(
         infer_expr_type(
             &Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(1)),
                 property: "label".to_string(),
             },
@@ -766,6 +768,7 @@ fn infers_named_class_and_interface_property_facts() {
         infer_expr_type(
             &Expr::Call {
                 callee: Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::LocalGet(1)),
                     property: "score".to_string(),
                 }),
@@ -801,6 +804,7 @@ fn infers_named_class_and_interface_property_facts() {
     assert_eq!(
         infer_expr_type(
             &Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(2)),
                 property: "items".to_string(),
             },
@@ -812,6 +816,7 @@ fn infers_named_class_and_interface_property_facts() {
         infer_expr_type(
             &Expr::Call {
                 callee: Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::LocalGet(2)),
                     property: "done".to_string(),
                 }),
@@ -1685,6 +1690,7 @@ fn resolves_this_and_super_in_class_context() {
 
     let mut env = HirTypeEnv::from_module(&module);
     let this_label = Expr::PropertyGet {
+        byte_offset: 0,
         object: Box::new(Expr::This),
         property: "label".to_string(),
     };

--- a/crates/perry-hir/src/destructuring/assignment_expr.rs
+++ b/crates/perry-hir/src/destructuring/assignment_expr.rs
@@ -163,14 +163,17 @@ pub(crate) fn lower_destructuring_assignment(
                         // { key: target } - extract obj.key into target
                         let prop_expr = match &kv.key {
                             ast::PropName::Ident(ident) => Expr::PropertyGet {
+                                byte_offset: 0,
                                 object: value.clone(),
                                 property: ident.sym.to_string(),
                             },
                             ast::PropName::Str(s) => Expr::PropertyGet {
+                                byte_offset: 0,
                                 object: value.clone(),
                                 property: s.value.as_str().unwrap_or("").to_string(),
                             },
                             ast::PropName::Num(n) => Expr::PropertyGet {
+                                byte_offset: 0,
                                 object: value.clone(),
                                 property: n.value.to_string(),
                             },
@@ -226,6 +229,7 @@ pub(crate) fn lower_destructuring_assignment(
                         // Shorthand: { a } means { a: a }
                         let name = assign.key.sym.to_string();
                         let prop_expr = Expr::PropertyGet {
+                            byte_offset: 0,
                             object: value.clone(),
                             property: name.clone(),
                         };

--- a/crates/perry-hir/src/destructuring/assignment_stmt.rs
+++ b/crates/perry-hir/src/destructuring/assignment_stmt.rs
@@ -176,6 +176,7 @@ fn iterator_next_value_stmts(
         },
         Stmt::If {
             condition: Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(step_id)),
                 property: "done".to_string(),
             },
@@ -186,6 +187,7 @@ fn iterator_next_value_stmts(
             else_branch: Some(vec![Stmt::Expr(Expr::LocalSet(
                 value_id,
                 Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::LocalGet(step_id)),
                     property: "value".to_string(),
                 }),
@@ -245,6 +247,7 @@ fn lower_object_assignment_from_expr(
                     ty: Type::Any,
                     mutable: false,
                     init: Some(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(source.clone()),
                         property: name.clone(),
                     }),
@@ -325,6 +328,7 @@ fn object_property_get_expr(
         ast::PropName::Ident(ident) => Ok((
             Vec::new(),
             Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(source),
                 property: ident.sym.to_string(),
             },
@@ -332,6 +336,7 @@ fn object_property_get_expr(
         ast::PropName::Str(s) => Ok((
             Vec::new(),
             Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(source),
                 property: s.value.as_str().unwrap_or("").to_string(),
             },
@@ -339,6 +344,7 @@ fn object_property_get_expr(
         ast::PropName::Num(n) => Ok((
             Vec::new(),
             Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(source),
                 property: n.value.to_string(),
             },

--- a/crates/perry-hir/src/destructuring/pattern_binding.rs
+++ b/crates/perry-hir/src/destructuring/pattern_binding.rs
@@ -6,7 +6,7 @@ fn is_global_this_value(ctx: &LoweringContext, expr: &Expr) -> bool {
     matches!(expr, Expr::GlobalGet(_))
         || matches!(
             expr,
-            Expr::PropertyGet { object, property }
+            Expr::PropertyGet { object, property, .. }
                 if matches!(object.as_ref(), Expr::GlobalGet(_))
                     && property == "globalThis"
         )
@@ -123,6 +123,7 @@ fn iterator_next_value_stmts(
         },
         Stmt::If {
             condition: Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(step_id)),
                 property: "done".to_string(),
             },
@@ -133,6 +134,7 @@ fn iterator_next_value_stmts(
             else_branch: Some(vec![Stmt::Expr(Expr::LocalSet(
                 value_id,
                 Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::LocalGet(step_id)),
                     property: "value".to_string(),
                 }),
@@ -540,6 +542,7 @@ pub(crate) fn lower_pattern_binding_into(
                                     }
                                 }
                                 Expr::PropertyGet {
+                                    byte_offset: 0,
                                     object: Box::new(Expr::LocalGet(tmp_id)),
                                     property: key,
                                 }
@@ -563,6 +566,7 @@ pub(crate) fn lower_pattern_binding_into(
                                     }
                                 }
                                 Expr::PropertyGet {
+                                    byte_offset: 0,
                                     object: Box::new(Expr::LocalGet(tmp_id)),
                                     property: key,
                                 }
@@ -571,6 +575,7 @@ pub(crate) fn lower_pattern_binding_into(
                                 let key = n.value.to_string();
                                 static_keys.push(key.clone());
                                 Expr::PropertyGet {
+                                    byte_offset: 0,
                                     object: Box::new(Expr::LocalGet(tmp_id)),
                                     property: key,
                                 }
@@ -682,6 +687,7 @@ pub(crate) fn lower_pattern_binding_into(
                                 ty: Type::Any,
                                 mutable: false,
                                 init: Some(Expr::PropertyGet {
+                                    byte_offset: 0,
                                     object: Box::new(Expr::LocalGet(tmp_id)),
                                     property: name.clone(),
                                 }),
@@ -697,6 +703,7 @@ pub(crate) fn lower_pattern_binding_into(
                             }
                         } else {
                             Expr::PropertyGet {
+                                byte_offset: 0,
                                 object: Box::new(Expr::LocalGet(tmp_id)),
                                 property: name.clone(),
                             }

--- a/crates/perry-hir/src/destructuring/var_decl.rs
+++ b/crates/perry-hir/src/destructuring/var_decl.rs
@@ -108,7 +108,10 @@ pub(crate) fn lower_var_decl_with_destructuring(
                         }
                     }
                     Some(Expr::NewDynamic { callee, .. }) => {
-                        if let Expr::PropertyGet { object, property } = callee.as_ref() {
+                        if let Expr::PropertyGet {
+                            object, property, ..
+                        } = callee.as_ref()
+                        {
                             if matches!(object.as_ref(), Expr::NativeModuleRef(module) if module == "net" || module == "node:net")
                                 && matches!(property.as_str(), "BlockList" | "SocketAddress")
                             {

--- a/crates/perry-hir/src/destructuring/var_decl/alias_tracking.rs
+++ b/crates/perry-hir/src/destructuring/var_decl/alias_tracking.rs
@@ -218,22 +218,23 @@ pub(crate) fn track_decl_aliases(
                     ctx.array_static_method_aliases.insert(id, method_name);
                 }
             }
-            Expr::PropertyGet { object, property }
-                if is_global_this_value(ctx, object.as_ref())
-                    && matches!(
-                        property.as_str(),
-                        "URL"
-                            | "URLSearchParams"
-                            | "TextEncoder"
-                            | "TextDecoder"
-                            | "Blob"
-                            | "File"
-                            | "FormData"
-                            | "Headers"
-                            | "Request"
-                            | "Response"
-                            | "WebSocket"
-                    ) =>
+            Expr::PropertyGet {
+                object, property, ..
+            } if is_global_this_value(ctx, object.as_ref())
+                && matches!(
+                    property.as_str(),
+                    "URL"
+                        | "URLSearchParams"
+                        | "TextEncoder"
+                        | "TextDecoder"
+                        | "Blob"
+                        | "File"
+                        | "FormData"
+                        | "Headers"
+                        | "Request"
+                        | "Response"
+                        | "WebSocket"
+                ) =>
             {
                 ctx.register_let_class_alias(name.to_string(), property.clone());
                 if matches!(
@@ -243,10 +244,11 @@ pub(crate) fn track_decl_aliases(
                     ctx.uses_fetch = true;
                 }
             }
-            Expr::PropertyGet { object, property }
-                if matches!(object.as_ref(), Expr::NativeModuleRef(module)
+            Expr::PropertyGet {
+                object, property, ..
+            } if matches!(object.as_ref(), Expr::NativeModuleRef(module)
                     if module == "buffer" || module == "node:buffer")
-                    && matches!(property.as_str(), "Blob" | "File") =>
+                && matches!(property.as_str(), "Blob" | "File") =>
             {
                 ctx.register_let_class_alias(name.to_string(), property.clone());
                 ctx.uses_fetch = true;
@@ -268,7 +270,9 @@ pub(crate) fn track_decl_aliases(
             // assignment recogniser can route to the
             // function-flavoured prototype-method registration
             // path (synthetic class id allocated at runtime).
-            Expr::PropertyGet { object, property } if property == "prototype" => {
+            Expr::PropertyGet {
+                object, property, ..
+            } if property == "prototype" => {
                 match object.as_ref() {
                     Expr::ClassRef(class_name) => {
                         ctx.prototype_aliases.insert(id, class_name.clone());

--- a/crates/perry-hir/src/destructuring/var_decl_sources.rs
+++ b/crates/perry-hir/src/destructuring/var_decl_sources.rs
@@ -7,7 +7,7 @@ pub(super) fn is_global_this_value(ctx: &LoweringContext, expr: &Expr) -> bool {
     matches!(expr, Expr::GlobalGet(_))
         || matches!(
             expr,
-            Expr::PropertyGet { object, property }
+            Expr::PropertyGet { object, property, .. }
                 if matches!(object.as_ref(), Expr::GlobalGet(_))
                     && property == "globalThis"
         )

--- a/crates/perry-hir/src/dynamic_import.rs
+++ b/crates/perry-hir/src/dynamic_import.rs
@@ -1697,7 +1697,9 @@ fn static_string_replace_target<'a>(callee: &'a Expr, args: &[Expr]) -> Option<&
         return None;
     }
     match callee {
-        Expr::PropertyGet { object, property } if property == "replace" => Some(object),
+        Expr::PropertyGet {
+            object, property, ..
+        } if property == "replace" => Some(object),
         _ => None,
     }
 }
@@ -1744,7 +1746,10 @@ fn resolve_string_replace_parts<V: Borrow<Expr>>(
 }
 
 fn is_static_path_join_call(callee: &Expr) -> bool {
-    let Expr::PropertyGet { object, property } = callee else {
+    let Expr::PropertyGet {
+        object, property, ..
+    } = callee
+    else {
         return false;
     };
     property == "join" && is_static_path_module_expr(object)
@@ -1753,9 +1758,9 @@ fn is_static_path_join_call(callee: &Expr) -> bool {
 fn is_static_path_module_expr(expr: &Expr) -> bool {
     match expr {
         Expr::NativeModuleRef(module) => module == "path" || module == "node:path",
-        Expr::PropertyGet { object, property } if property == "default" => {
-            is_static_path_module_expr(object)
-        }
+        Expr::PropertyGet {
+            object, property, ..
+        } if property == "default" => is_static_path_module_expr(object),
         _ => false,
     }
 }

--- a/crates/perry-hir/src/dynamic_import/tests.rs
+++ b/crates/perry-hir/src/dynamic_import/tests.rs
@@ -188,6 +188,7 @@ fn resolve_registry_computed_key_enumerates_all() {
 fn resolve_registry_static_property_enumerates_all() {
     // `import(R.a)` — over-approximate to the whole (relative) chunk set.
     assert_resolves_both_chunks(&Expr::PropertyGet {
+        byte_offset: 0,
         object: Box::new(Expr::LocalGet(5)),
         property: "a".to_string(),
     });
@@ -275,6 +276,7 @@ fn resolve_chained_distinct_registries_resolves() {
     let b = Expr::Object(vec![(
         "y".to_string(),
         Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::LocalGet(1)),
             property: "x".to_string(),
         },
@@ -297,6 +299,7 @@ fn resolve_chained_distinct_registries_resolves() {
 fn resolve_non_registry_member_access_defers() {
     // `import(cfg.path)` where cfg is opaque — must keep deferring, not panic.
     let arg = Expr::PropertyGet {
+        byte_offset: 0,
         object: Box::new(Expr::LocalGet(7)),
         property: "path".to_string(),
     };
@@ -654,6 +657,7 @@ fn resolve_cjs_path_default_join_over_replaced_dirname_local() {
         mutable: true,
         init: Some(Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::String(
                     "D:\\tmp\\probe\\node_modules\\node-pty\\lib".to_string(),
                 )),
@@ -670,7 +674,9 @@ fn resolve_cjs_path_default_join_over_replaced_dirname_local() {
 
     let filename = Expr::Call {
         callee: Box::new(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::NativeModuleRef("path".to_string())),
                 property: "default".to_string(),
             }),

--- a/crates/perry-hir/src/enums.rs
+++ b/crates/perry-hir/src/enums.rs
@@ -115,7 +115,9 @@ pub(crate) fn fix_imported_enums_in_expr(
 ) {
     match expr {
         // The key pattern: PropertyGet on an ExternFuncRef that's actually an enum
-        Expr::PropertyGet { object, property } => {
+        Expr::PropertyGet {
+            object, property, ..
+        } => {
             if let Expr::ExternFuncRef { name, .. } = object.as_ref() {
                 if let Some(members) = enums.get(name.as_str()) {
                     // Look up the member value

--- a/crates/perry-hir/src/ir/expr.rs
+++ b/crates/perry-hir/src/ir/expr.rs
@@ -169,6 +169,15 @@ pub enum Expr {
     PropertyGet {
         object: Box<Expr>,
         property: String,
+        /// #5247: byte offset (`member.span.lo.0`) of this member access in its
+        /// module source, captured at AST→HIR lowering. Codegen (under
+        /// `--debug-symbols`) resolves it to `file:line` and attaches it to the
+        /// runtime "Cannot read properties of null/undefined" TypeError thrown
+        /// when the receiver is nullish, so `.stack` shows `at <file>:<line>`
+        /// instead of `<anonymous>`. `0` when unknown (nodes synthesized by
+        /// transforms/desugaring) — resolves to no location. Mirrors
+        /// `Call.byte_offset` / `New::byte_offset`; excluded from stable-hashing.
+        byte_offset: u32,
     },
     PropertySet {
         object: Box<Expr>,

--- a/crates/perry-hir/src/js_transform/cross_module_natives.rs
+++ b/crates/perry-hir/src/js_transform/cross_module_natives.rs
@@ -776,7 +776,10 @@ pub fn fix_native_instance_expr(
         // The key case: method calls that might be on native instances
         Expr::Call { callee, args, .. } => {
             // Check if this is a method call: obj.method(args)
-            if let Expr::PropertyGet { object, property } = callee.as_mut() {
+            if let Expr::PropertyGet {
+                object, property, ..
+            } = callee.as_mut()
+            {
                 // Check if the object is a native instance (ExternFuncRef or LocalGet)
                 if let Some((native_module, native_class)) =
                     resolve_native_instance(object.as_ref(), native_instances, local_id_instances)
@@ -893,7 +896,10 @@ pub fn fix_native_instance_expr(
         Expr::Await(inner) => {
             // Handle Await(Call{PropertyGet{obj...}}) pattern for native instances
             if let Expr::Call { callee, args, .. } = inner.as_mut() {
-                if let Expr::PropertyGet { object, property } = callee.as_mut() {
+                if let Expr::PropertyGet {
+                    object, property, ..
+                } = callee.as_mut()
+                {
                     if let Some((native_module, native_class)) = resolve_native_instance(
                         object.as_ref(),
                         native_instances,

--- a/crates/perry-hir/src/js_transform/imports.rs
+++ b/crates/perry-hir/src/js_transform/imports.rs
@@ -546,7 +546,7 @@ pub fn transform_expr(
         // Call expressions - may be method calls on JS objects or direct function calls
         Expr::Call { callee, args, .. } => {
             // First check if this is a method call on a JS object: obj.method(args)
-            if let Expr::PropertyGet { object, property } = callee.as_mut() {
+            if let Expr::PropertyGet { object, property, .. } = callee.as_mut() {
                 // Transform the object first
                 transform_expr(object.as_mut(), js_imports, extern_func_to_js, local_name_to_js, tracker);
 
@@ -728,7 +728,7 @@ pub fn transform_expr(
         }
 
         // Property access - may be on JS objects
-        Expr::PropertyGet { object, property } => {
+        Expr::PropertyGet { object, property, .. } => {
             transform_expr(object, js_imports, extern_func_to_js, local_name_to_js, tracker);
 
             // Check if the object is a JS value

--- a/crates/perry-hir/src/js_transform/local_natives.rs
+++ b/crates/perry-hir/src/js_transform/local_natives.rs
@@ -417,11 +417,13 @@ pub fn fix_class_field_expr(
                 Expr::PropertyGet {
                     object: outer_obj,
                     property: method_name,
+                    ..
                 } => {
                     let mut direct = None;
                     if let Expr::PropertyGet {
                         object: inner_obj,
                         property: field_name,
+                        ..
                     } = outer_obj.as_ref()
                     {
                         if let Some((module_name, class_name)) = lookup_field_native(
@@ -534,11 +536,13 @@ pub fn fix_class_field_expr(
                 if let Expr::PropertyGet {
                     object: outer_obj,
                     property: method_name,
+                    ..
                 } = callee.as_mut()
                 {
                     if let Expr::PropertyGet {
                         object: inner_obj,
                         property: field_name,
+                        ..
                     } = outer_obj.as_ref()
                     {
                         if let Some((module_name, class_name)) = lookup_field_native(
@@ -969,7 +973,10 @@ pub fn fix_native_instance_expr_with_locals(
             }
 
             // Check if this is a method call: obj.method(args)
-            if let Expr::PropertyGet { object, property } = callee.as_mut() {
+            if let Expr::PropertyGet {
+                object, property, ..
+            } = callee.as_mut()
+            {
                 // Check for LocalGet (local variable)
                 if let Expr::LocalGet(local_id) = object.as_ref() {
                     let found = local_id_instances.get(local_id);
@@ -1084,7 +1091,10 @@ pub fn fix_native_instance_expr_with_locals(
         Expr::Await(inner) => {
             // Handle Await(Call{PropertyGet{LocalGet...}}) pattern for async method calls
             if let Expr::Call { callee, args, .. } = inner.as_mut() {
-                if let Expr::PropertyGet { object, property } = callee.as_mut() {
+                if let Expr::PropertyGet {
+                    object, property, ..
+                } = callee.as_mut()
+                {
                     // Check for LocalGet
                     if let Expr::LocalGet(local_id) = object.as_ref() {
                         if let Some((native_module, native_class)) =
@@ -1204,7 +1214,9 @@ pub fn fix_native_instance_expr_with_locals(
                 fix_native_instance_expr_with_locals(value, native_instances, local_id_instances);
             }
         }
-        Expr::PropertyGet { object, property } => {
+        Expr::PropertyGet {
+            object, property, ..
+        } => {
             // Recurse into the object first so any nested `$(sel)` Call has
             // been rewritten to a cheerio NativeMethodCall.
             fix_native_instance_expr_with_locals(object, native_instances, local_id_instances);
@@ -1362,7 +1374,10 @@ pub fn detect_native_instance_creation_with_context(
         // Handle Call expressions where the object is a known native instance
         // This is the pattern BEFORE transformation: pool.getConnection()
         Expr::Call { callee, .. } => {
-            if let Expr::PropertyGet { object, property } = callee.as_ref() {
+            if let Expr::PropertyGet {
+                object, property, ..
+            } = callee.as_ref()
+            {
                 // Check if object is a LocalGet of a known native instance
                 if let Expr::LocalGet(local_id) = object.as_ref() {
                     if let Some((module, class)) = local_ids.get(local_id) {

--- a/crates/perry-hir/src/jsx.rs
+++ b/crates/perry-hir/src/jsx.rs
@@ -117,6 +117,7 @@ fn react_create_element_call(
     };
     Some(Expr::Call {
         callee: Box::new(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(object),
             property: "createElement".to_string(),
         }),
@@ -162,6 +163,7 @@ pub(crate) fn lower_jsx_fragment(
     // props)` — see `react_create_element_call`.
     if let Some(react_local) = ctx.react_default_import_local.clone() {
         let fragment_type = Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(if let Some(id) = ctx.lookup_local(&react_local) {
                 Expr::LocalGet(id)
             } else {
@@ -257,6 +259,7 @@ pub(crate) fn lower_jsx_element_name(
             // e.g. React.Fragment → PropertyGet on the namespace
             let obj_expr = lower_jsx_object(ctx, &member.obj)?;
             Ok(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(obj_expr),
                 property: member.prop.sym.to_string(),
             })
@@ -294,6 +297,7 @@ pub(crate) fn lower_jsx_object(ctx: &mut LoweringContext, obj: &ast::JSXObject) 
         ast::JSXObject::JSXMemberExpr(member) => {
             let obj_expr = lower_jsx_object(ctx, &member.obj)?;
             Ok(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(obj_expr),
                 property: member.prop.sym.to_string(),
             })

--- a/crates/perry-hir/src/lower/array_fold.rs
+++ b/crates/perry-hir/src/lower/array_fold.rs
@@ -26,7 +26,9 @@ pub(crate) fn try_fold_array_method_call(call: Expr) -> Expr {
         other => return other,
     };
     let (object, property) = match *callee {
-        Expr::PropertyGet { object, property } => (object, property),
+        Expr::PropertyGet {
+            object, property, ..
+        } => (object, property),
         other => {
             return Expr::Call {
                 callee: Box::new(other),
@@ -39,6 +41,7 @@ pub(crate) fn try_fold_array_method_call(call: Expr) -> Expr {
     // Helper to rebuild the original Call if we don't want to fold.
     let rebuild = |obj: Box<Expr>, prop: String, args: Vec<Expr>| Expr::Call {
         callee: Box::new(Expr::PropertyGet {
+            byte_offset: 0,
             object: obj,
             property: prop,
         }),

--- a/crates/perry-hir/src/lower/expr_assign.rs
+++ b/crates/perry-hir/src/lower/expr_assign.rs
@@ -495,6 +495,7 @@ pub(crate) fn lower_ident_assignment(
         // "globalThis" }` shape resolves to the real global object.
         Ok(Expr::PropertySet {
             object: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::GlobalGet(0)),
                 property: "globalThis".to_string(),
             }),
@@ -1319,6 +1320,7 @@ pub(crate) fn hoist_compound_member_assign(
 
     let read = match (&prop, key_id) {
         (Some(p), _) => Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::LocalGet(base_id)),
             property: p.clone(),
         },

--- a/crates/perry-hir/src/lower/expr_call/crypto.rs
+++ b/crates/perry-hir/src/lower/expr_call/crypto.rs
@@ -119,6 +119,7 @@ pub(super) fn lower_crypto_passthrough(method: &str, args: Vec<Expr>) -> Option<
         "randomUUID" if args.is_empty() => Some(Expr::CryptoRandomUUID),
         "randomUUID" => Some(Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::NativeModuleRef("crypto".to_string())),
                 property: "randomUUID".to_string(),
             }),
@@ -141,6 +142,7 @@ pub(super) fn lower_crypto_passthrough(method: &str, args: Vec<Expr>) -> Option<
                 // Expr::CryptoRandomBytes that targets only the sync form.
                 return Some(Expr::Call {
                     callee: Box::new(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::NativeModuleRef("crypto".to_string())),
                         property: "randomBytes".to_string(),
                     }),
@@ -207,6 +209,7 @@ pub(super) fn lower_crypto_passthrough(method: &str, args: Vec<Expr>) -> Option<
         | "createCipheriv"
         | "createDecipheriv" => Some(Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::NativeModuleRef("crypto".to_string())),
                 property: method.to_string(),
             }),
@@ -228,10 +231,13 @@ pub(super) fn lower_crypto_passthrough(method: &str, args: Vec<Expr>) -> Option<
             let enc = iter.next().unwrap_or_else(|| Expr::String("hex".into()));
             Some(Expr::Call {
                 callee: Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::Call {
                         callee: Box::new(Expr::PropertyGet {
+                            byte_offset: 0,
                             object: Box::new(Expr::Call {
                                 callee: Box::new(Expr::PropertyGet {
+                                    byte_offset: 0,
                                     object: Box::new(Expr::NativeModuleRef("crypto".to_string())),
                                     property: "createHash".to_string(),
                                 }),

--- a/crates/perry-hir/src/lower/expr_call/globals.rs
+++ b/crates/perry-hir/src/lower/expr_call/globals.rs
@@ -840,6 +840,7 @@ pub(super) fn try_global_builtins(
                         }
                         return Ok(Ok(Expr::Call {
                             callee: Box::new(Expr::PropertyGet {
+                                byte_offset: 0,
                                 object: Box::new(Expr::NativeModuleRef("crypto".to_string())),
                                 property: "createSecretKey".to_string(),
                             }),
@@ -860,6 +861,7 @@ pub(super) fn try_global_builtins(
                         let options_arg = iter.next().unwrap();
                         return Ok(Ok(Expr::Call {
                             callee: Box::new(Expr::PropertyGet {
+                                byte_offset: 0,
                                 object: Box::new(Expr::NativeModuleRef("crypto".to_string())),
                                 property: "generateKeySync".to_string(),
                             }),

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -1031,6 +1031,7 @@ pub(super) fn try_module_static_methods(
                             let buf_arg = args.into_iter().next().unwrap();
                             return Ok(Ok(Expr::Call {
                                 callee: Box::new(Expr::PropertyGet {
+                                    byte_offset: 0,
                                     object: Box::new(buf_arg),
                                     property: "$$cryptoFillRandom".to_string(),
                                 }),
@@ -1228,6 +1229,7 @@ pub(super) fn try_module_static_methods(
                             let b = iter.next().unwrap();
                             return Ok(Ok(Expr::Call {
                                 callee: Box::new(Expr::PropertyGet {
+                                    byte_offset: 0,
                                     object: Box::new(a),
                                     property: "compare".to_string(),
                                 }),

--- a/crates/perry-hir/src/lower/expr_call/native_module.rs
+++ b/crates/perry-hir/src/lower/expr_call/native_module.rs
@@ -844,6 +844,7 @@ pub(super) fn try_native_module_methods(
                             let b = iter.next().unwrap();
                             return Ok(Ok(Expr::Call {
                                 callee: Box::new(Expr::PropertyGet {
+                                    byte_offset: 0,
                                     object: Box::new(a),
                                     property: "compare".to_string(),
                                 }),

--- a/crates/perry-hir/src/lower/expr_call/nested_namespace.rs
+++ b/crates/perry-hir/src/lower/expr_call/nested_namespace.rs
@@ -64,6 +64,7 @@ pub(super) fn try_process_memory_usage_rss(
                             if let ast::MemberProp::Ident(method_ident) = &outer_member.prop {
                                 if method_ident.sym.as_ref() == "rss" {
                                     return Ok(Expr::PropertyGet {
+                                        byte_offset: 0,
                                         object: Box::new(Expr::ProcessMemoryUsage),
                                         property: "rss".to_string(),
                                     });

--- a/crates/perry-hir/src/lower/expr_call/url_date_instance.rs
+++ b/crates/perry-hir/src/lower/expr_call/url_date_instance.rs
@@ -172,6 +172,7 @@ pub(super) fn try_url_date_weakref_instance(
                 ) {
                     return Ok(Ok(Expr::Call {
                         callee: Box::new(Expr::PropertyGet {
+                            byte_offset: 0,
                             object: Box::new(recv_expr),
                             property: "toJSON".to_string(),
                         }),

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -189,6 +189,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                 // `new.target` is `undefined`, so the runtime read yields
                 // `undefined.<prop>` semantics via the same PropertyGet.
                 return Ok(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::NewTarget),
                     property: prop_name.to_string(),
                 });
@@ -223,6 +224,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                         | "fileURLToPath"
                 ) {
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::NativeModuleRef("bun".to_string())),
                         property: prop_ident.sym.as_ref().to_string(),
                     });
@@ -251,7 +253,9 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
             if let Some(static_member) = static_member {
                 if crate::analysis::is_builtin_static_function_member("Promise", static_member) {
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::PropertyGet {
+                            byte_offset: 0,
                             object: Box::new(Expr::GlobalGet(0)),
                             property: "Promise".to_string(),
                         }),
@@ -472,6 +476,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     Some(perry_api_manifest::ApiKind::Method { .. })
                 ) {
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::NativeModuleRef("process".to_string())),
                         property: prop.to_string(),
                     });
@@ -589,6 +594,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     | "setMaxListeners"
                     | "getMaxListeners" => {
                         return Ok(Expr::PropertyGet {
+                            byte_offset: 0,
                             object: Box::new(Expr::GlobalGet(0)),
                             property: prop_ident.sym.to_string(),
                         });
@@ -1117,6 +1123,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                         "Readable" | "Writable" | "Duplex" | "Transform" | "PassThrough"
                     ) {
                         return Ok(Expr::PropertyGet {
+                            byte_offset: 0,
                             object: Box::new(Expr::NativeModuleRef("stream".to_string())),
                             property: class_name.to_string(),
                         });
@@ -1160,6 +1167,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                 ) {
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1199,6 +1207,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // (handled by `is_stream_api_member` above) keep dispatching.
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1218,6 +1227,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // read, so they still dispatch.
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1230,6 +1240,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // via the call path and keep dispatching.
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1238,6 +1249,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                 {
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1247,6 +1259,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                 {
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1265,6 +1278,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                 {
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1278,6 +1292,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // receiver method with no args.
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1302,6 +1317,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // codegen NativeModSig table dispatches them to their FFI.
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1315,6 +1331,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // can bind a callable to the socket handle.
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1348,6 +1365,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                 {
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1361,6 +1379,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // so runtime lookup can return a bound callable.
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1385,6 +1404,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // Console / net.Socket method-value-read arms above.
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1405,6 +1425,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // the native method with zero arguments.
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1427,6 +1448,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // rather than invoking the native method with zero args.
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1440,6 +1462,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // invoking the receiver stub as a 0-arg getter.
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1453,6 +1476,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // instead of invoking the receiver stub as a getter.
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1465,6 +1489,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                 {
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1477,6 +1502,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // method table; only bare reads use property dispatch.
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1505,6 +1531,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // lifecycle method as a zero-arg getter.
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1514,6 +1541,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                 {
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1526,6 +1554,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                 {
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1549,6 +1578,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // keep the native getter path below.
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1558,6 +1588,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // (`headers.entries()`) is handled by expr_call lowering.
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1578,6 +1609,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // handle, not a real object).
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1592,6 +1624,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // the native method table.
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1625,6 +1658,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // rs.getReader; f()` both work.
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1634,6 +1668,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                 {
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1643,6 +1678,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                 {
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1652,6 +1688,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                 {
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1661,6 +1698,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                 {
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1670,6 +1708,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                 {
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });
@@ -1806,6 +1845,7 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
                     // persists and reads back here.
                     let object_expr = lower_expr(ctx, &member.obj)?;
                     return Ok(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(object_expr),
                         property: property_name,
                     });

--- a/crates/perry-hir/src/lower/expr_member/member_tail.rs
+++ b/crates/perry-hir/src/lower/expr_member/member_tail.rs
@@ -46,6 +46,7 @@ pub(crate) fn lower_member_tail(
                 let obj_name = obj_ident.sym.as_ref();
                 if crate::analysis::is_builtin_global_value_name(obj_name) {
                     object_expr = Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::GlobalGet(0)),
                         property: obj_name.to_string(),
                     };
@@ -105,6 +106,7 @@ pub(crate) fn lower_member_tail(
     if let Expr::PropertyGet {
         object: inner,
         property,
+        ..
     } = &object_expr
     {
         if matches!(inner.as_ref(), Expr::GlobalGet(0))
@@ -426,9 +428,9 @@ pub(crate) fn lower_member_tail(
                 // so the fold is correctly skipped.
                 let is_global_builtin = match &object_expr {
                     Expr::GlobalGet(0) => true,
-                    Expr::PropertyGet { object, property } => {
-                        matches!(object.as_ref(), Expr::GlobalGet(0)) && property.as_str() == name
-                    }
+                    Expr::PropertyGet {
+                        object, property, ..
+                    } => matches!(object.as_ref(), Expr::GlobalGet(0)) && property.as_str() == name,
                     _ => false,
                 };
                 if is_global_builtin {
@@ -442,6 +444,7 @@ pub(crate) fn lower_member_tail(
             if let Expr::PropertyGet {
                 object: inner,
                 property,
+                ..
             } = &object_expr
             {
                 if matches!(inner.as_ref(), Expr::GlobalGet(0)) {
@@ -479,6 +482,7 @@ pub(crate) fn lower_member_tail(
                 Expr::PropertyGet {
                     object: inner,
                     property,
+                    ..
                 } => {
                     if matches!(inner.as_ref(), Expr::GlobalGet(0)) {
                         if let ast::Expr::Member(inner_member) = member.obj.as_ref() {
@@ -656,7 +660,13 @@ pub(crate) fn lower_member_tail(
     match &member.prop {
         ast::MemberProp::Ident(ident) => {
             let property = ident.sym.to_string();
-            Ok(Expr::PropertyGet { object, property })
+            Ok(Expr::PropertyGet {
+                // #5247: carry the member access's source offset so a nullish
+                // receiver ("Cannot read properties of undefined") localizes.
+                byte_offset: member.span.lo.0,
+                object,
+                property,
+            })
         }
         ast::MemberProp::Computed(computed) => {
             // #503: refuse compile-time dynamic dispatch on stdlib namespace
@@ -789,6 +799,9 @@ pub(crate) fn lower_member_tail(
                     && !(key.len() > 1 && key.starts_with('0'));
                 if !is_numeric_string {
                     return Ok(Expr::PropertyGet {
+                        // #5247: `obj["prop"]` folds to a PropertyGet — carry the
+                        // member offset so a nullish receiver localizes too.
+                        byte_offset: member.span.lo.0,
                         object,
                         property: key.clone(),
                     });
@@ -826,7 +839,13 @@ pub(crate) fn lower_member_tail(
             // member on a wrong receiver throws TypeError per spec.
             let property = format!("#{}", private.name);
             let object = wrap_private_guard(ctx, object, &property, PRIV_OP_READ);
-            Ok(Expr::PropertyGet { object, property })
+            Ok(Expr::PropertyGet {
+                // #5247: `this.#field` — carry the member offset for nullish-receiver
+                // localization (consistency with the public-property path).
+                byte_offset: member.span.lo.0,
+                object,
+                property,
+            })
         }
     }
 }

--- a/crates/perry-hir/src/lower/expr_member/process_props.rs
+++ b/crates/perry-hir/src/lower/expr_member/process_props.rs
@@ -38,6 +38,7 @@ pub(crate) fn lower_process_named_property(prop: &str) -> Option<Expr> {
 
 pub(crate) fn process_native_property(prop: &str) -> Expr {
     Expr::PropertyGet {
+        byte_offset: 0,
         object: Box::new(Expr::NativeModuleRef("process".to_string())),
         property: prop.to_string(),
     }
@@ -85,17 +86,16 @@ pub(crate) fn is_ws_ready_state_receiver(
     fn native_ws_class_property(expr: &Expr) -> bool {
         match expr {
             Expr::NativeModuleRef(module) if module == "ws" => true,
-            Expr::PropertyGet { object, property }
-                if matches!(property.as_str(), "WebSocket" | "default")
-                    && matches!(object.as_ref(), Expr::NativeModuleRef(module) if module == "ws") =>
+            Expr::PropertyGet {
+                object, property, ..
+            } if matches!(property.as_str(), "WebSocket" | "default")
+                && matches!(object.as_ref(), Expr::NativeModuleRef(module) if module == "ws") =>
             {
                 true
             }
-            Expr::PropertyGet { object, property }
-                if property == "WebSocket" && matches!(object.as_ref(), Expr::GlobalGet(0)) =>
-            {
-                true
-            }
+            Expr::PropertyGet {
+                object, property, ..
+            } if property == "WebSocket" && matches!(object.as_ref(), Expr::GlobalGet(0)) => true,
             _ => false,
         }
     }

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -241,6 +241,7 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 let args = lower_optional_args(ctx, new_expr.args.as_deref())?;
                 return Ok(Expr::Call {
                     callee: Box::new(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::NativeModuleRef("crypto".to_string())),
                         property: method_name,
                     }),
@@ -318,6 +319,7 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 let args = lower_optional_args(ctx, new_expr.args.as_deref())?;
                 return Ok(Expr::NewDynamic {
                     callee: Box::new(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::NativeModuleRef(module_name)),
                         property: method_name,
                     }),
@@ -346,6 +348,7 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 let args = lower_optional_args(ctx, new_expr.args.as_deref())?;
                 return Ok(Expr::NewDynamic {
                     callee: Box::new(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::NativeModuleRef("http".to_string())),
                         property: export,
                     }),
@@ -384,6 +387,7 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                 let args = lower_optional_args(ctx, new_expr.args.as_deref())?;
                 return Ok(Expr::NewDynamic {
                     callee: Box::new(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::NativeModuleRef("v8".to_string())),
                         property: "GCProfiler".to_string(),
                     }),

--- a/crates/perry-hir/src/lower/expr_new/helpers.rs
+++ b/crates/perry-hir/src/lower/expr_new/helpers.rs
@@ -374,9 +374,9 @@ pub(crate) fn is_global_object_expr(ctx: &LoweringContext, expr: &Expr) -> bool 
     match expr {
         Expr::GlobalGet(_) => true,
         Expr::LocalGet(id) => ctx.global_this_aliases.contains(id),
-        Expr::PropertyGet { object, property } => {
-            property == "globalThis" && matches!(object.as_ref(), Expr::GlobalGet(_))
-        }
+        Expr::PropertyGet {
+            object, property, ..
+        } => property == "globalThis" && matches!(object.as_ref(), Expr::GlobalGet(_)),
         _ => false,
     }
 }

--- a/crates/perry-hir/src/lower/expr_new/member.rs
+++ b/crates/perry-hir/src/lower/expr_new/member.rs
@@ -157,6 +157,7 @@ pub(crate) fn lower_new_member_native(
                 let args = lower_optional_args(ctx, new_expr.args.as_deref())?;
                 return Ok(Some(Expr::NewDynamic {
                     callee: Box::new(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::NativeModuleRef("http".to_string())),
                         property: prop_ident.sym.to_string(),
                     }),

--- a/crates/perry-hir/src/lower/expr_new/non_ident.rs
+++ b/crates/perry-hir/src/lower/expr_new/non_ident.rs
@@ -228,7 +228,10 @@ pub(crate) fn lower_new_non_ident(
         })
         .transpose()?
         .unwrap_or_default();
-    if let Expr::PropertyGet { object, property } = callee.as_ref() {
+    if let Expr::PropertyGet {
+        object, property, ..
+    } = callee.as_ref()
+    {
         if is_global_object_expr(ctx, object.as_ref())
             && matches!(property.as_str(), "Symbol" | "BigInt" | "Math")
         {

--- a/crates/perry-hir/src/lower/expr_object.rs
+++ b/crates/perry-hir/src/lower/expr_object.rs
@@ -65,6 +65,7 @@ fn builtin_global_value_expr(ctx: &mut LoweringContext, name: &str) -> Option<Ex
         ctx.uses_fetch = true;
     }
     Some(Expr::PropertyGet {
+        byte_offset: 0,
         object: Box::new(Expr::GlobalGet(0)),
         property: name.to_string(),
     })

--- a/crates/perry-hir/src/lower/for_head.rs
+++ b/crates/perry-hir/src/lower/for_head.rs
@@ -286,6 +286,7 @@ pub(crate) fn map_set_delete_safe_for_of(
     // codegen expressions), matching the original loop bound.
     let size_of = |a: Expr| -> Expr {
         Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(a),
             property: "size".to_string(),
         }

--- a/crates/perry-hir/src/lower/lower_expr/arm_ident.rs
+++ b/crates/perry-hir/src/lower/lower_expr/arm_ident.rs
@@ -205,6 +205,7 @@ pub(crate) fn lower_ident_expr(ctx: &mut LoweringContext, ident: &ast::Ident) ->
         // have matched `ctx.lookup_local` earlier and never reached
         // here.
         Ok(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::GlobalGet(0)),
             property: name,
         })
@@ -280,6 +281,7 @@ pub(crate) fn lower_ident_expr(ctx: &mut LoweringContext, ident: &ast::Ident) ->
                 ctx.uses_fetch = true;
             }
             return Ok(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::GlobalGet(0)),
                 property: name,
             });

--- a/crates/perry-hir/src/lower/lower_expr/arm_optchain.rs
+++ b/crates/perry-hir/src/lower/lower_expr/arm_optchain.rs
@@ -41,6 +41,7 @@ pub(crate) fn lower_opt_chain_expr(
                         // fold hardcoded the enclosing class name (wrong
                         // leaf) and undefined for `.prototype`.
                         return Ok(Expr::PropertyGet {
+                            byte_offset: 0,
                             object: Box::new(Expr::NewTarget),
                             property: prop_name.to_string(),
                         });
@@ -61,6 +62,7 @@ pub(crate) fn lower_opt_chain_expr(
                     // stored result correct after an intervening match
                     // on another regex.
                     Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(obj_expr.clone()),
                         property: prop_name,
                     }
@@ -80,7 +82,11 @@ pub(crate) fn lower_opt_chain_expr(
                         &property,
                         expr_member::PRIV_OP_READ,
                     );
-                    Expr::PropertyGet { object, property }
+                    Expr::PropertyGet {
+                        byte_offset: 0,
+                        object,
+                        property,
+                    }
                 }
             };
 
@@ -157,6 +163,7 @@ pub(crate) fn lower_opt_chain_expr(
                     let obj = lower_expr(ctx, &member.obj)?;
                     let prop = match &member.prop {
                         ast::MemberProp::Ident(id) => Expr::PropertyGet {
+                            byte_offset: 0,
                             object: Box::new(obj.clone()),
                             property: id.sym.to_string(),
                         },
@@ -176,6 +183,7 @@ pub(crate) fn lower_opt_chain_expr(
                                 expr_member::PRIV_OP_READ,
                             );
                             Expr::PropertyGet {
+                                byte_offset: 0,
                                 object: guarded,
                                 property,
                             }
@@ -269,6 +277,7 @@ pub(crate) fn lower_opt_chain_expr(
                 // Build the callee with inner_else as the object (not the full Conditional)
                 let fixed_callee = match callee_expr {
                     Expr::PropertyGet { property, .. } => Expr::PropertyGet {
+                        byte_offset: 0,
                         object: inner_else,
                         property,
                     },

--- a/crates/perry-hir/src/lower/lower_expr/helpers.rs
+++ b/crates/perry-hir/src/lower/lower_expr/helpers.rs
@@ -352,6 +352,7 @@ pub(crate) fn native_module_binding_value(ctx: &LoweringContext, name: &str) -> 
         if let Some(method) = method_name {
             if matches!(method, "constants" | "kMaxLength" | "kStringMaxLength") {
                 return Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::NativeModuleRef("buffer".to_string())),
                     property: method.to_string(),
                 };
@@ -363,6 +364,7 @@ pub(crate) fn native_module_binding_value(ctx: &LoweringContext, name: &str) -> 
         if let Some(method) = method_name {
             if method == "workerData" {
                 return Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::NativeModuleRef("worker_threads".to_string())),
                     property: "workerData".to_string(),
                 };
@@ -381,6 +383,7 @@ pub(crate) fn native_module_binding_value(ctx: &LoweringContext, name: &str) -> 
             }
         }
         return Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::NativeModuleRef(module_name.to_string())),
             property: method.to_string(),
         };
@@ -389,6 +392,7 @@ pub(crate) fn native_module_binding_value(ctx: &LoweringContext, name: &str) -> 
         && is_cjs_style_native_default_import(module_name)
     {
         return Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::NativeModuleRef(module_name.to_string())),
             property: "default".to_string(),
         };

--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -266,6 +266,7 @@ pub(crate) fn emit_for_of_pattern_binding(
                     ast::ObjectPatProp::Assign(assign) => {
                         let key = assign.key.sym.to_string();
                         let prop_access = Expr::PropertyGet {
+                            byte_offset: 0,
                             object: Box::new(Expr::LocalGet(tmp_id)),
                             property: key,
                         };
@@ -300,6 +301,7 @@ pub(crate) fn emit_for_of_pattern_binding(
                             _ => continue,
                         };
                         let elem_src = Expr::PropertyGet {
+                            byte_offset: 0,
                             object: Box::new(Expr::LocalGet(tmp_id)),
                             property: key,
                         };

--- a/crates/perry-hir/src/lower/stmt_loops.rs
+++ b/crates/perry-hir/src/lower/stmt_loops.rs
@@ -250,6 +250,7 @@ fn async_iterator_method_call(iterable: Expr) -> Expr {
 fn iterator_return_call(iter_id: LocalId, needs_await: bool) -> Expr {
     let call = Expr::Call {
         callee: Box::new(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::LocalGet(iter_id)),
             property: "return".to_string(),
         }),
@@ -319,6 +320,7 @@ pub(crate) fn lazy_or_index_elem(
 ) -> Expr {
     if use_lazy_iter {
         Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::LocalGet(result_id)),
             property: "value".to_string(),
         }
@@ -349,6 +351,7 @@ fn iterator_result_validated(call: Expr) -> Expr {
 pub(crate) fn iterator_next_call(iter_id: LocalId) -> Expr {
     iterator_result_validated(Expr::Call {
         callee: Box::new(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::LocalGet(iter_id)),
             property: "next".to_string(),
         }),
@@ -378,6 +381,7 @@ fn iter_driver_while_stmt(result_id: LocalId, next_call: Expr, rest: Vec<Stmt>) 
         Stmt::Expr(Expr::LocalSet(result_id, Box::new(next_call))),
         Stmt::If {
             condition: Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(result_id)),
                 property: "done".to_string(),
             },
@@ -415,6 +419,7 @@ pub(crate) fn lazy_iter_for_stmt(
         condition: Some(Expr::Unary {
             op: UnaryOp::Not,
             operand: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(result_id)),
                 property: "done".to_string(),
             }),
@@ -436,6 +441,7 @@ pub(crate) fn iterator_close_guarded_stmt(iter_id: LocalId) -> Stmt {
         condition: Expr::Compare {
             op: CompareOp::LooseNe,
             left: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(iter_id)),
                 property: "return".to_string(),
             }),
@@ -487,6 +493,7 @@ pub(crate) fn wrap_lazy_for_of_body_close_on_throw(
             condition: Expr::Compare {
                 op: CompareOp::LooseNe,
                 left: Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::LocalGet(iter_id)),
                     property: "return".to_string(),
                 }),
@@ -704,6 +711,7 @@ fn lower_runtime_for_await_iterator(
         .push((format!("__result_{}", result_id), result_id, Type::Any));
     let raw_next_call = Expr::Call {
         callee: Box::new(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::LocalGet(iter_id)),
             property: "next".to_string(),
         }),
@@ -741,6 +749,7 @@ fn lower_runtime_for_await_iterator(
         ctx,
         binding_pat,
         Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::LocalGet(result_id)),
             property: "value".to_string(),
         },
@@ -902,6 +911,7 @@ pub(crate) fn lower_stmt_for_of(
         } else if is_node_readable_for_await {
             Expr::Call {
                 callee: Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(iter_expr),
                     property: "iterator".to_string(),
                 }),
@@ -942,6 +952,7 @@ pub(crate) fn lower_stmt_for_of(
         // (`{value, done}`) is what's stored, not the Promise.
         let raw_next_call = Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(iter_id)),
                 property: "next".to_string(),
             }),
@@ -974,6 +985,7 @@ pub(crate) fn lower_stmt_for_of(
                 None
             };
         let value_expr = Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::LocalGet(result_id)),
             property: "value".to_string(),
         };
@@ -1176,6 +1188,7 @@ pub(crate) fn lower_stmt_for_of(
                 ty: Type::Any,
                 mutable: false,
                 init: Some(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::LocalGet(res_id)),
                     property: "value".to_string(),
                 }),
@@ -1668,6 +1681,7 @@ pub(crate) fn lower_stmt_for_of(
                 let item_expr = if use_lazy_iter {
                     // Lazy path: the element is `__result.value`.
                     Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::LocalGet(result_id)),
                         property: "value".to_string(),
                     }
@@ -1862,6 +1876,7 @@ pub(crate) fn lower_stmt_for_of(
             op: CompareOp::Lt,
             left: Box::new(Expr::LocalGet(idx_id)),
             right: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(arr_id)),
                 property: "length".to_string(),
             }),
@@ -1968,6 +1983,7 @@ pub(crate) fn lower_stmt_for_in(
             op: CompareOp::Lt,
             left: Box::new(Expr::LocalGet(idx_id)),
             right: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(keys_id)),
                 property: "length".to_string(),
             }),

--- a/crates/perry-hir/src/lower/tests.rs
+++ b/crates/perry-hir/src/lower/tests.rs
@@ -172,7 +172,9 @@ fn test_native_module_binding_value_named_import() {
     );
     let value = super::lower_expr::native_module_binding_value(&ctx, "relative");
     match value {
-        crate::ir::Expr::PropertyGet { object, property } => {
+        crate::ir::Expr::PropertyGet {
+            object, property, ..
+        } => {
             assert_eq!(property, "relative");
             assert!(matches!(*object, crate::ir::Expr::NativeModuleRef(ref m) if m == "path"));
         }

--- a/crates/perry-hir/src/lower_decl/block.rs
+++ b/crates/perry-hir/src/lower_decl/block.rs
@@ -1781,6 +1781,7 @@ fn lower_stmts_using_aware_inner(
                 for &id in &decl_ids {
                     let check_call = Expr::Call {
                         callee: Box::new(Expr::PropertyGet {
+                            byte_offset: 0,
                             object: Box::new(Expr::LocalGet(id)),
                             property: "__perry_using_check__".to_string(),
                         }),
@@ -1861,6 +1862,7 @@ fn lower_stmts_using_aware_inner(
                 };
                 let mut call_expr = Expr::Call {
                     callee: Box::new(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::LocalGet(id)),
                         property: method_name.to_string(),
                     }),

--- a/crates/perry-hir/src/lower_decl/body_stmt.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt.rs
@@ -87,6 +87,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                                                 ty: Type::Array(Box::new(Type::Any)),
                                                 mutable: true,
                                                 init: Some(Expr::PropertyGet {
+                                                    byte_offset: 0,
                                                     object: Box::new(Expr::This),
                                                     property: field_name.clone(),
                                                 }),
@@ -1015,6 +1016,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                         ty: Type::Any,
                         mutable: false,
                         init: Some(Expr::PropertyGet {
+                            byte_offset: 0,
                             object: Box::new(Expr::LocalGet(res_id)),
                             property: "value".to_string(),
                         }),
@@ -1028,6 +1030,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                         Stmt::Expr(Expr::LocalSet(res_id, Box::new(read_call()))),
                         Stmt::If {
                             condition: Expr::PropertyGet {
+                                byte_offset: 0,
                                 object: Box::new(Expr::LocalGet(res_id)),
                                 property: "done".to_string(),
                             },
@@ -1166,6 +1169,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                 } else if is_node_readable_for_await {
                     Expr::Call {
                         callee: Box::new(Expr::PropertyGet {
+                            byte_offset: 0,
                             object: Box::new(iter_expr_raw),
                             property: "iterator".to_string(),
                         }),
@@ -1200,6 +1204,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                     .push((format!("__result_{}", result_id), result_id, Type::Any));
                 let raw_next_call = Expr::Call {
                     callee: Box::new(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::LocalGet(iter_id)),
                         property: "next".to_string(),
                     }),
@@ -1227,6 +1232,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                         None
                     };
                 let value_expr = Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::LocalGet(result_id)),
                     property: "value".to_string(),
                 };
@@ -1284,6 +1290,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                     Stmt::Expr(Expr::LocalSet(result_id, Box::new(next_call))),
                     Stmt::If {
                         condition: Expr::PropertyGet {
+                            byte_offset: 0,
                             object: Box::new(Expr::LocalGet(result_id)),
                             property: "done".to_string(),
                         },
@@ -1852,6 +1859,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                     op: CompareOp::Lt,
                     left: Box::new(Expr::LocalGet(idx_id)),
                     right: Box::new(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::LocalGet(arr_id)),
                         property: "length".to_string(),
                     }),
@@ -1937,6 +1945,7 @@ pub fn lower_body_stmt(ctx: &mut LoweringContext, stmt: &ast::Stmt) -> Result<Ve
                     op: CompareOp::Lt,
                     left: Box::new(Expr::LocalGet(idx_id)),
                     right: Box::new(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::LocalGet(keys_id)),
                         property: "length".to_string(),
                     }),

--- a/crates/perry-hir/src/lower_decl/body_stmt/detect.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt/detect.rs
@@ -175,6 +175,7 @@ pub(super) fn is_fs_dir_for_await_target(ctx: &LoweringContext, expr: &ast::Expr
 pub(super) fn iterator_return_call(iter_id: LocalId, needs_await: bool) -> Expr {
     let call = Expr::Call {
         callee: Box::new(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::LocalGet(iter_id)),
             property: "return".to_string(),
         }),

--- a/crates/perry-hir/src/lower_decl/body_stmt/for_await.rs
+++ b/crates/perry-hir/src/lower_decl/body_stmt/for_await.rs
@@ -24,6 +24,7 @@ pub(super) fn lower_runtime_for_await_iterator_body(
         .push((format!("__result_{}", result_id), result_id, Type::Any));
     let raw_next_call = Expr::Call {
         callee: Box::new(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::LocalGet(iter_id)),
             property: "next".to_string(),
         }),
@@ -61,6 +62,7 @@ pub(super) fn lower_runtime_for_await_iterator_body(
         ctx,
         binding_pat,
         Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::LocalGet(result_id)),
             property: "value".to_string(),
         },
@@ -85,6 +87,7 @@ pub(super) fn lower_runtime_for_await_iterator_body(
         Stmt::Expr(Expr::LocalSet(result_id, Box::new(next_call))),
         Stmt::If {
             condition: Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(result_id)),
                 property: "done".to_string(),
             },

--- a/crates/perry-hir/src/lower_decl/class_captures.rs
+++ b/crates/perry-hir/src/lower_decl/class_captures.rs
@@ -244,6 +244,7 @@ pub fn synthesize_class_captures(
                     class_name: name.to_string(),
                     index: index as u32,
                     fallback: Some(Box::new(Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::This),
                         property: crate::cap_fields::cap_field_name(cap_salt, outer_id),
                     })),

--- a/crates/perry-hir/src/lower_patterns.rs
+++ b/crates/perry-hir/src/lower_patterns.rs
@@ -233,7 +233,11 @@ pub(crate) fn lower_assign_target_to_expr(
             match &member.prop {
                 ast::MemberProp::Ident(ident) => {
                     let property = ident.sym.to_string();
-                    Ok(Expr::PropertyGet { object, property })
+                    Ok(Expr::PropertyGet {
+                        byte_offset: 0,
+                        object,
+                        property,
+                    })
                 }
                 ast::MemberProp::Computed(computed) => {
                     let index = Box::new(lower_expr(ctx, &computed.expr)?);
@@ -241,7 +245,11 @@ pub(crate) fn lower_assign_target_to_expr(
                 }
                 ast::MemberProp::PrivateName(private) => {
                     let property = format!("#{}", private.name);
-                    Ok(Expr::PropertyGet { object, property })
+                    Ok(Expr::PropertyGet {
+                        byte_offset: 0,
+                        object,
+                        property,
+                    })
                 }
             }
         }

--- a/crates/perry-hir/src/lower_types/extract.rs
+++ b/crates/perry-hir/src/lower_types/extract.rs
@@ -566,6 +566,7 @@ fn lower_decorator_arg(ctx: &mut LoweringContext, expr: &ast::Expr) -> Option<Ex
             Some(Expr::PropertyGet {
                 object: ref obj,
                 property: _,
+                ..
             }) if matches!(obj.as_ref(), Expr::GlobalGet(0)) => {
                 Some(Expr::ClassRef(ident.sym.to_string()))
             }

--- a/crates/perry-hir/src/monomorph/substitute_expr.rs
+++ b/crates/perry-hir/src/monomorph/substitute_expr.rs
@@ -149,7 +149,10 @@ pub(crate) fn substitute_expr(expr: &Expr, substitutions: &HashMap<String, Type>
         },
 
         // Property access
-        Expr::PropertyGet { object, property } => Expr::PropertyGet {
+        Expr::PropertyGet {
+            object, property, ..
+        } => Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(substitute_expr(object, substitutions)),
             property: property.clone(),
         },

--- a/crates/perry-hir/src/stable_hash/expr.rs
+++ b/crates/perry-hir/src/stable_hash/expr.rs
@@ -62,7 +62,7 @@ impl SH for Expr {
             Expr::ExternFuncRef { name, param_types, return_type, } => { tag(h, 21); name.hash(h); param_types.hash(h); return_type.hash(h); }
             Expr::NativeModuleRef(s) => { tag(h, 22); s.hash(h); }
             Expr::NativeMethodCall { module, class_name, object, method, args, } => { tag(h, 23); module.hash(h); class_name.hash(h); object.hash(h); method.hash(h); args.hash(h); }
-            Expr::PropertyGet { object, property } => { tag(h, 24); object.as_ref().hash(h); property.hash(h); }
+            Expr::PropertyGet { object, property, .. } => { tag(h, 24); object.as_ref().hash(h); property.hash(h); }
             Expr::PropertySet { object, property, value, } => { tag(h, 25); object.as_ref().hash(h); property.hash(h); value.as_ref().hash(h); }
             Expr::PropertyUpdate { object, property, op, prefix, } => { tag(h, 26); object.as_ref().hash(h); property.hash(h); op.hash(h); prefix.hash(h); }
             Expr::IndexGet { object, index } => { tag(h, 27); object.as_ref().hash(h); index.as_ref().hash(h); }

--- a/crates/perry-hir/tests/c262_parity.rs
+++ b/crates/perry-hir/tests/c262_parity.rs
@@ -347,6 +347,7 @@ fn implicit_global_property_set_value<'a>(expr: &'a Expr, name: &str) -> Option<
         Expr::PropertyGet {
             object: inner,
             property: gt,
+            ..
         } if gt == "globalThis" && matches!(inner.as_ref(), Expr::GlobalGet(0)) => {
             Some(value.as_ref())
         }

--- a/crates/perry-hir/tests/cheerio_call_rewrite.rs
+++ b/crates/perry-hir/tests/cheerio_call_rewrite.rs
@@ -111,6 +111,7 @@ fn non_native_fluent_chains_are_walked_linearly() {
     for i in 0..32 {
         init = Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(init),
                 property: "command".to_string(),
             }),
@@ -126,6 +127,7 @@ fn non_native_fluent_chains_are_walked_linearly() {
 
     init = Expr::Call {
         callee: Box::new(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(init),
             property: "strict".to_string(),
         }),

--- a/crates/perry-transform/src/async_to_generator.rs
+++ b/crates/perry-transform/src/async_to_generator.rs
@@ -1341,7 +1341,10 @@ fn try_strip_promise_resolve(expr: &Expr, non_promise: &HashSet<LocalId>) -> Opt
     if args.len() != 1 {
         return None;
     }
-    let Expr::PropertyGet { object, property } = callee.as_ref() else {
+    let Expr::PropertyGet {
+        object, property, ..
+    } = callee.as_ref()
+    else {
         return None;
     };
     if property != "resolve" {

--- a/crates/perry-transform/src/deforest/call_sites.rs
+++ b/crates/perry-transform/src/deforest/call_sites.rs
@@ -297,7 +297,9 @@ fn match_consume_loop(
                 return None;
             }
             match right.as_ref() {
-                Expr::PropertyGet { object, property } if property == "length" => {
+                Expr::PropertyGet {
+                    object, property, ..
+                } if property == "length" => {
                     if !matches!(object.as_ref(), Expr::LocalGet(id) if *id == child_id) {
                         return None;
                     }
@@ -334,7 +336,9 @@ fn match_consume_loop(
             Some(*array_id)
         }
         Expr::Call { callee, args, .. } => match callee.as_ref() {
-            Expr::PropertyGet { object, property } if property == "push" => {
+            Expr::PropertyGet {
+                object, property, ..
+            } if property == "push" => {
                 let outer_id = match object.as_ref() {
                     Expr::LocalGet(id) => *id,
                     _ => return None,

--- a/crates/perry-transform/src/deforest/out_usage.rs
+++ b/crates/perry-transform/src/deforest/out_usage.rs
@@ -132,9 +132,10 @@ impl OutUsageAnalyzer {
                 self.visit_expr(source);
                 return;
             }
-            Expr::PropertyGet { object, property }
-                if matches!(object.as_ref(), Expr::LocalGet(id) if *id == self.out_id)
-                    && property == "length" =>
+            Expr::PropertyGet {
+                object, property, ..
+            } if matches!(object.as_ref(), Expr::LocalGet(id) if *id == self.out_id)
+                && property == "length" =>
             {
                 // Safe: out.length read.
                 return;

--- a/crates/perry-transform/src/deforest/tests.rs
+++ b/crates/perry-transform/src/deforest/tests.rs
@@ -165,6 +165,7 @@ fn rejects_producer_called_inside_closure() {
             },
             // return v.length;
             Stmt::Return(Some(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(30)),
                 property: "length".to_string(),
             })),
@@ -314,6 +315,7 @@ fn deforests_producer_called_from_class_method() {
                 }),
             },
             Stmt::Return(Some(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(30)),
                 property: "length".to_string(),
             })),
@@ -521,6 +523,7 @@ fn still_deforests_when_method_has_no_super() {
                 }),
             },
             Stmt::Return(Some(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(30)),
                 property: "length".to_string(),
             })),

--- a/crates/perry-transform/src/generator/helpers.rs
+++ b/crates/perry-transform/src/generator/helpers.rs
@@ -102,6 +102,7 @@ pub fn make_iter_result(value: Expr, done: bool) -> Expr {
 pub fn wrap_in_promise_resolve(value: Expr) -> Expr {
     Expr::Call {
         callee: Box::new(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::GlobalGet(0)),
             property: "resolve".to_string(),
         }),

--- a/crates/perry-transform/src/generator/linearize.rs
+++ b/crates/perry-transform/src/generator/linearize.rs
@@ -167,6 +167,7 @@ fn delegate_next_call(del_next_id: LocalId, del_iter_id: LocalId, arg: Expr) -> 
         }),
         then_expr: Box::new(Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(del_next_id)),
                 property: "call".to_string(),
             }),
@@ -176,6 +177,7 @@ fn delegate_next_call(del_next_id: LocalId, del_iter_id: LocalId, arg: Expr) -> 
         }),
         else_expr: Box::new(Expr::Call {
             callee: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(del_iter_id)),
                 property: "next".to_string(),
             }),
@@ -221,6 +223,7 @@ fn emit_yield_star_loop(
     current.push(Stmt::Expr(Expr::LocalSet(
         del_next_id,
         Box::new(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::LocalGet(del_iter_id)),
             property: "next".to_string(),
         }),
@@ -251,6 +254,7 @@ fn emit_yield_star_loop(
         // (via `delegate_await` on the pull below).
         Stmt::Expr(Expr::Yield {
             value: Some(Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(del_result_id)),
                 property: "value".to_string(),
             })),
@@ -271,6 +275,7 @@ fn emit_yield_star_loop(
         condition: Expr::Unary {
             op: UnaryOp::Not,
             operand: Box::new(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(del_result_id)),
                 property: "done".to_string(),
             }),
@@ -320,6 +325,7 @@ fn emit_yield_star_loop(
     current.push(Stmt::Expr(Expr::LocalSet(
         del_value_id,
         Box::new(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::LocalGet(del_result_id)),
             property: "value".to_string(),
         }),

--- a/crates/perry-transform/src/generator/lower/abrupt.rs
+++ b/crates/perry-transform/src/generator/lower/abrupt.rs
@@ -680,6 +680,7 @@ pub(crate) fn build_yield_star_return_routes(
             ty: Type::Any,
             mutable: false,
             init: Some(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(route.iter_id)),
                 property: "return".to_string(),
             }),
@@ -716,6 +717,7 @@ pub(crate) fn build_yield_star_return_routes(
             mutable: false,
             init: Some(Expr::Await(Box::new(Expr::Call {
                 callee: Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::LocalGet(m_id)),
                     property: "call".to_string(),
                 }),
@@ -739,6 +741,7 @@ pub(crate) fn build_yield_star_return_routes(
         // else            return {__r.value, false};   // re-yield, generator not done
         let dispatch_done = Stmt::If {
             condition: Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(r_id)),
                 property: "done".to_string(),
             },
@@ -746,6 +749,7 @@ pub(crate) fn build_yield_star_return_routes(
                 Stmt::Expr(Expr::LocalSet(done_id, Box::new(Expr::Bool(true)))),
                 Stmt::Return(Some(make_iter_result(
                     Expr::PropertyGet {
+                        byte_offset: 0,
                         object: Box::new(Expr::LocalGet(r_id)),
                         property: "value".to_string(),
                     },
@@ -754,6 +758,7 @@ pub(crate) fn build_yield_star_return_routes(
             ],
             else_branch: Some(vec![Stmt::Return(Some(make_iter_result(
                 Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::LocalGet(r_id)),
                     property: "value".to_string(),
                 },
@@ -852,6 +857,7 @@ pub(crate) fn build_yield_star_throw_routes(
             ty: Type::Any,
             mutable: false,
             init: Some(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(route.iter_id)),
                 property: "throw".to_string(),
             }),
@@ -871,6 +877,7 @@ pub(crate) fn build_yield_star_throw_routes(
             ty: Type::Any,
             mutable: false,
             init: Some(Expr::PropertyGet {
+                byte_offset: 0,
                 object: Box::new(Expr::LocalGet(route.iter_id)),
                 property: "return".to_string(),
             }),
@@ -897,6 +904,7 @@ pub(crate) fn build_yield_star_throw_routes(
                     mutable: false,
                     init: Some(Expr::Await(Box::new(Expr::Call {
                         callee: Box::new(Expr::PropertyGet {
+                            byte_offset: 0,
                             object: Box::new(Expr::LocalGet(ret_m_id)),
                             property: "call".to_string(),
                         }),
@@ -944,6 +952,7 @@ pub(crate) fn build_yield_star_throw_routes(
             route.result_id,
             Box::new(Expr::Await(Box::new(Expr::Call {
                 callee: Box::new(Expr::PropertyGet {
+                    byte_offset: 0,
                     object: Box::new(Expr::LocalGet(m_id)),
                     property: "call".to_string(),
                 }),

--- a/crates/perry-transform/src/generator/lower/async_step.rs
+++ b/crates/perry-transform/src/generator/lower/async_step.rs
@@ -123,6 +123,7 @@ pub fn build_async_step_driver_direct(
     // symmetry of the async-step driver; not emitted on the current path.
     let _promise_resolve = |arg: Expr| Expr::Call {
         callee: Box::new(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(promise_global()),
             property: "resolve".to_string(),
         }),
@@ -132,6 +133,7 @@ pub fn build_async_step_driver_direct(
     };
     let promise_reject = |arg: Expr| Expr::Call {
         callee: Box::new(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(promise_global()),
             property: "reject".to_string(),
         }),

--- a/crates/perry-transform/src/generator/lower/resume.rs
+++ b/crates/perry-transform/src/generator/lower/resume.rs
@@ -60,6 +60,7 @@ pub(crate) fn generator_executing_type_error() -> Expr {
 pub(crate) fn promise_reject(value: Expr) -> Expr {
     Expr::Call {
         callee: Box::new(Expr::PropertyGet {
+            byte_offset: 0,
             object: Box::new(Expr::GlobalGet(0)),
             property: "reject".to_string(),
         }),

--- a/crates/perry-transform/src/inline/analysis.rs
+++ b/crates/perry-transform/src/inline/analysis.rs
@@ -518,7 +518,9 @@ pub fn construction_expr_can_affect_method_lookup(
 ) -> bool {
     match expr {
         Expr::This => true,
-        Expr::PropertyGet { object, property } if matches!(object.as_ref(), Expr::This) => {
+        Expr::PropertyGet {
+            object, property, ..
+        } if matches!(object.as_ref(), Expr::This) => {
             property == method_name
                 || !data_fields.contains(property)
                 || getter_names.contains(property)

--- a/crates/perry-transform/src/inline/call_inliner.rs
+++ b/crates/perry-transform/src/inline/call_inliner.rs
@@ -1517,6 +1517,7 @@ pub fn try_inline_simple_call(
         if let Expr::PropertyGet {
             object,
             property: method_name,
+            ..
         } = callee.as_ref()
         {
             // Method inlining requires an exact `let obj = new C(...)`
@@ -1771,6 +1772,7 @@ pub fn try_inline_call(
         if let Expr::PropertyGet {
             object,
             property: method_name,
+            ..
         } = callee.as_ref()
         {
             // Method inlining requires an exact `let obj = new C(...)`

--- a/crates/perry-transform/src/inline/exact_receivers.rs
+++ b/crates/perry-transform/src/inline/exact_receivers.rs
@@ -17,7 +17,9 @@ pub fn resolve_receiver_class(
     match obj {
         Expr::LocalGet(id) => local_types.get(id).map(|cn| (cn.clone(), Some(*id))),
         Expr::This => enclosing_class.map(|cn| (cn.to_string(), None)),
-        Expr::PropertyGet { object, property } => {
+        Expr::PropertyGet {
+            object, property, ..
+        } => {
             // Recursive resolution: get the inner receiver's class, then
             // look up the field on that class. Field-walking chains like
             // `world.commandBuffer.set(...)` benefit — without this the

--- a/crates/perry-transform/src/inline/factory_specialize.rs
+++ b/crates/perry-transform/src/inline/factory_specialize.rs
@@ -86,7 +86,9 @@ pub fn specialize_captured_class_factories(module: &mut Module) {
                     args,
                     ..
                 },
-                Expr::PropertyGet { object, property },
+                Expr::PropertyGet {
+                    object, property, ..
+                },
             ) => {
                 if let Expr::LocalGet(o_ref) = object.as_ref() {
                     if *o_ref != *bound_id {

--- a/crates/perry-transform/src/state_desugar.rs
+++ b/crates/perry-transform/src/state_desugar.rs
@@ -900,7 +900,10 @@ fn expr_kind_for_diag(e: &Expr) -> &'static str {
 /// after this returns `None`.
 fn try_rewrite_state_access(e: &Expr, bindings: &HashMap<LocalId, StateBinding>) -> Option<Expr> {
     if let Expr::Call { callee, args, .. } = e {
-        if let Expr::PropertyGet { object, property } = callee.as_ref() {
+        if let Expr::PropertyGet {
+            object, property, ..
+        } = callee.as_ref()
+        {
             if let Expr::LocalGet(state_id) = object.as_ref() {
                 if let Some(binding) = bindings.get(state_id) {
                     return match property.as_str() {
@@ -915,7 +918,10 @@ fn try_rewrite_state_access(e: &Expr, bindings: &HashMap<LocalId, StateBinding>)
             }
         }
     }
-    if let Expr::PropertyGet { object, property } = e {
+    if let Expr::PropertyGet {
+        object, property, ..
+    } = e
+    {
         if property == "value" {
             if let Expr::LocalGet(state_id) = object.as_ref() {
                 if let Some(binding) = bindings.get(state_id) {

--- a/crates/perry/src/commands/compile/collect_modules/crypto_ns.rs
+++ b/crates/perry/src/commands/compile/collect_modules/crypto_ns.rs
@@ -11,7 +11,7 @@ use perry_hir::{Expr, Stmt};
 fn expr_uses_global_crypto_namespace(expr: &Expr) -> bool {
     if matches!(
         expr,
-        Expr::PropertyGet { object, property }
+        Expr::PropertyGet { object, property, .. }
             if property == "crypto" && matches!(object.as_ref(), Expr::GlobalGet(0))
     ) {
         return true;

--- a/crates/perry/tests/issue_5247_property_read_source_location.rs
+++ b/crates/perry/tests/issue_5247_property_read_source_location.rs
@@ -1,0 +1,188 @@
+//! Regression test for #5247 (follow-up to #5250/#5253/#5573): the runtime
+//! source-location diagnostics that earlier increments gave the method-dispatch,
+//! construct, ReferenceError and bare value-call throws are extended to the
+//! **property-read-on-nullish** throw class, gated on `--debug-symbols`:
+//!
+//!   `obj.prop` where `obj` is `null` / `undefined` →
+//!   `TypeError: Cannot read properties of undefined (reading 'prop')`.
+//!
+//! This is the standalone READ shape (no enclosing call): `const x = o.foo;`
+//! and the chained `a.b.c` (inner `a.b` undefined) both lower to a general
+//! `Expr::PropertyGet`, which now carries the member access's source
+//! `byte_offset` (`member.span.lo.0`). Codegen's generic property-get dispatch
+//! (`lower_generic_property_get`) replays it as `js_set_call_location` right
+//! before the nullish-receiver throw path (both the inline diamond and the
+//! full-outline `js_object_get_field_ic` helper), so `.stack` shows
+//! `at <file>:<line>` instead of `<anonymous>`. This is the single most common
+//! JS runtime error ("Cannot read properties of undefined") and the last
+//! uncovered "property-on-non-object" read case of the bounded #5247 increment.
+//!
+//! Behavior:
+//!   • WITH `--debug-symbols`: the thrown TypeError's `.stack` contains
+//!     `at <file>:<line>` pointing at the offending read's line.
+//!   • WITHOUT the flag (default build): unchanged — `at <anonymous>`.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Once;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize workspace root")
+}
+
+fn target_debug_dir() -> PathBuf {
+    std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| workspace_root().join("target"))
+        .join("debug")
+}
+
+/// Build `libperry_runtime.a` once so the compiled binaries can link.
+fn ensure_runtime_archive() {
+    static BUILD_RUNTIME: Once = Once::new();
+    BUILD_RUNTIME.call_once(|| {
+        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+        let build = Command::new(cargo)
+            .current_dir(workspace_root())
+            .arg("build")
+            .arg("-p")
+            .arg("perry-runtime")
+            .output()
+            .expect("run cargo build -p perry-runtime");
+        assert!(
+            build.status.success(),
+            "cargo build -p perry-runtime failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&build.stdout),
+            String::from_utf8_lossy(&build.stderr)
+        );
+    });
+}
+
+fn runtime_dir() -> PathBuf {
+    ensure_runtime_archive();
+    target_debug_dir()
+}
+
+/// The throwing read lives on line 4 (1 = blank from the raw-string leading
+/// newline, 2 = `const`, 3 = `try {`, 4 = `const x = o.foo;`).
+const FIXTURE_READ: &str = r#"
+const o: any = undefined;
+try {
+  const x = o.foo;
+  console.log(x);
+} catch (e: any) {
+  console.log("MSG:" + e.message);
+  console.log("STACK:" + e.stack);
+}
+"#;
+
+/// Chained read: `a` is an object, `a.b` is `undefined`, so the throwing access
+/// is the outer `.c` on line 4.
+const FIXTURE_CHAIN: &str = r#"
+const a: any = {};
+try {
+  const x = a.b.c;
+  console.log(x);
+} catch (e: any) {
+  console.log("MSG:" + e.message);
+  console.log("STACK:" + e.stack);
+}
+"#;
+
+fn compile(root: &std::path::Path, extra_args: &[&str]) -> std::process::Output {
+    let entry = root.join("main.ts");
+    let output = root.join("main_bin");
+    let mut cmd = Command::new(perry_bin());
+    cmd.current_dir(root)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache");
+    for a in extra_args {
+        cmd.arg(a);
+    }
+    cmd.env("PERRY_NO_AUTO_OPTIMIZE", "1");
+    cmd.env("PERRY_RUNTIME_DIR", runtime_dir());
+    cmd.output().expect("run perry compile")
+}
+
+fn run_fixture(fixture: &str, extra_args: &[&str]) -> String {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+    std::fs::write(root.join("main.ts"), fixture).expect("write entry");
+
+    let out = compile(root, extra_args);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "compile {extra_args:?} must succeed; stderr:\n{stderr}"
+    );
+
+    let bin = root.join("main_bin");
+    let run = Command::new(&bin).output().expect("run compiled binary");
+    // The fixture catches the throw and logs it, so it exits cleanly.
+    assert!(
+        run.status.success(),
+        "compiled binary must exit 0 (throw is caught); status: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr),
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+#[test]
+fn debug_symbols_attaches_file_line_to_property_read_on_undefined() {
+    let stdout = run_fixture(FIXTURE_READ, &["--debug-symbols"]);
+    assert!(
+        stdout.contains("MSG:Cannot read properties of undefined"),
+        "expected the nullish-read TypeError; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("at main.ts:4"),
+        "expected 'at main.ts:4' frame with --debug-symbols; got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("<anonymous>"),
+        "the location must replace the <anonymous> frame; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn debug_symbols_localizes_chained_read_at_the_throwing_access() {
+    let stdout = run_fixture(FIXTURE_CHAIN, &["--debug-symbols"]);
+    assert!(
+        stdout.contains("MSG:Cannot read properties of undefined"),
+        "expected the nullish-read TypeError for the chained access; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("at main.ts:4"),
+        "expected 'at main.ts:4' frame for the chained read; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn default_build_keeps_anonymous_frame_for_property_read() {
+    let stdout = run_fixture(FIXTURE_READ, &[]);
+    assert!(
+        stdout.contains("Cannot read properties of undefined"),
+        "expected the nullish-read TypeError; got:\n{stdout}"
+    );
+    // Default build is unchanged: the coarse <anonymous> frame, no file:line.
+    assert!(
+        stdout.contains("at <anonymous>"),
+        "default build must keep the <anonymous> frame; got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("at main.ts:"),
+        "default build must NOT emit a source location; got:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## #5247 — source location on property-read-on-nullish `TypeError`

Extends the `--debug-symbols` runtime source-location pipeline
(#5250 / #5253 / #5573) to the last uncovered **"at minimum"** throw class of
the bounded #5247 increment: a **standalone property read on a nullish
receiver**.

```ts
const x = o.foo;   // o is null/undefined
const x = a.b.c;   // a.b is undefined
```

Both throw `TypeError: Cannot read properties of undefined (reading 'foo')` —
the single most common JS runtime error. Before this change these **reads**
reported `at <anonymous>`. The method-call form (`o.foo()`), construct
(`new X()`), bare value-call (`f()`) and "not a function" throws already
localized via the earlier increments; this closes the read gap.

### What changed

- **HIR (`perry-hir`)** — `Expr::PropertyGet` gains a `byte_offset: u32` field,
  mirroring the existing `Call.byte_offset` / `New::byte_offset`. It is captured
  at AST→HIR lowering (`member.span.lo.0`) in `expr_member/member_tail.rs` for
  the general `obj.prop`, the computed-string `obj["prop"]` fold, and the private
  `this.#field` read. Synthesized nodes (transforms / desugaring / intrinsics)
  pass `0`, which resolves to *no location*. Excluded from stable-hashing, like
  the sibling offsets.
- **Codegen (`perry-codegen`)** — `lower_generic_property_get` takes the offset
  and replays it as `js_set_call_location` right **after the receiver is
  lowered** and **before** the nullish-receiver throw path. This covers *both*
  the inline diamond and the full-outline `js_object_get_field_ic` helper.
  Emitting after the receiver means a nested `a.b.c` chain keeps the inner `.b`
  read's more specific location when *it* is the throwing access.

### Default builds are unchanged

`emit_call_location_at` is a no-op unless the debug-location context (installed
only under `--debug-symbols`) is present, and the offset is `0` for synthesized
nodes — so release/default builds still render `<anonymous>` with zero added
work. The bulk of the diff is a **mechanical, behavior-inert** `byte_offset: 0`
(construction) / pattern `..` (destructure) across the existing `PropertyGet`
sites required by the new field.

### Verification

- New `crates/perry/tests/issue_5247_property_read_source_location.rs`:
  `const x = o.foo` and chained `a.b.c` both report `at main.ts:4` **with**
  `--debug-symbols`; the default build keeps `at <anonymous>` / no `file:line`.
- Equivalent standalone compiles confirmed: read-on-`undefined`, read-on-`null`,
  and nested-read now localize; method-call / primitive-method throws still
  localize; normal (non-throwing) property access, optional chaining,
  computed-string access and private-field reads all still evaluate correctly in
  both build modes.
- `cargo test --lib` green for `perry-hir` / `perry-codegen` / `perry-transform`.

### Scope / deferred

This is the property **read** case (`PropertyGet`). Property **set**
(`o.x = 1`) and index access on a nullish receiver (`o[0]`) are the same
"property-on-non-object" family but live on different pervasive nodes
(`PropertySet` / `IndexGet`); they remain `<anonymous>` and are a natural
follow-up. Full V8-style multi-frame stack traces stay out of scope per the
issue.

Per the contributor-PR guidance, this branch does **not** bump the workspace
version or touch `CHANGELOG.md` / `CLAUDE.md` — maintainer folds that in at
merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime diagnostics for nullish property reads when debug symbols are enabled, including accurate source file/line stack frames instead of `<anonymous>`.
  * Fixed object rest destructuring so remaining properties are assigned correctly, including with computed keys.
  * Improved static method dispatch for property-based class receivers.

* **Tests**
  * Added regression coverage for nullish property-read source-location behavior and destructuring correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->