### PR TITLE
fix(runtime): instanceof with null/undefined LHS returns false, not throw (#6587)

### DIFF
--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -602,6 +602,22 @@ fn ordinary_has_instance_prototype_walk(value: f64, type_ref: f64) -> bool {
     extern "C" {
         fn js_object_get_prototype_of(obj_value: f64) -> f64;
     }
+    // OrdinaryHasInstance(C, O) step 5 (ECMA-262 7.3.20): "If Type(O) is not
+    // Object, return false." A `null`/`undefined` left operand is not an
+    // object, so it is never `instanceof` anything. Guard here BEFORE the
+    // `js_object_get_prototype_of(value)` walk below, which would instead throw
+    // `TypeError: Cannot convert undefined or null to object` on such a value.
+    // #6587: `FindMyWay(opts)` (find-my-way@9) is called without `new`, so its
+    // `Router` body evaluates `this instanceof Router` with `this === undefined`
+    // — a dynamic (function-value) RHS routes through `js_instanceof_dynamic`'s
+    // synthetic-class-id tail into this walk, and the unguarded getPrototypeOf
+    // aborted module init before any route was registered.
+    {
+        let jv = crate::value::JSValue::from_bits(value.to_bits());
+        if jv.is_null() || jv.is_undefined() {
+            return false;
+        }
+    }
     // P = type_ref.prototype (the constructor's `.prototype` data property).
     let proto = unsafe {
         crate::value::js_dynamic_object_get_property(
@@ -1500,5 +1516,25 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
         }
 
         false_val
+    }
+}
+
+#[cfg(test)]
+mod null_lhs_tests {
+    use super::*;
+
+    /// #6587: `OrdinaryHasInstance` with a `null`/`undefined` left operand must
+    /// answer `false`, NOT throw `Cannot convert undefined or null to object`.
+    /// The guard short-circuits before any prototype access, so the RHS is
+    /// irrelevant and no arena/runtime state is touched — this exercises the
+    /// exact path find-my-way@9 hits when `FindMyWay(opts)` is called without
+    /// `new` and its `Router` body evaluates `this instanceof Router`.
+    #[test]
+    fn ordinary_has_instance_walk_is_false_for_null_and_undefined_lhs() {
+        let undefined = f64::from_bits(crate::value::TAG_UNDEFINED);
+        let null = f64::from_bits(crate::value::TAG_NULL);
+        // A dummy non-object RHS is never consulted for a non-object LHS.
+        assert!(!ordinary_has_instance_prototype_walk(undefined, 0.0));
+        assert!(!ordinary_has_instance_prototype_walk(null, 0.0));
     }
 }

--- a/crates/perry-runtime/src/object/instanceof.rs
+++ b/crates/perry-runtime/src/object/instanceof.rs
@@ -602,19 +602,35 @@ fn ordinary_has_instance_prototype_walk(value: f64, type_ref: f64) -> bool {
     extern "C" {
         fn js_object_get_prototype_of(obj_value: f64) -> f64;
     }
-    // OrdinaryHasInstance(C, O) step 5 (ECMA-262 7.3.20): "If Type(O) is not
-    // Object, return false." A `null`/`undefined` left operand is not an
-    // object, so it is never `instanceof` anything. Guard here BEFORE the
-    // `js_object_get_prototype_of(value)` walk below, which would instead throw
-    // `TypeError: Cannot convert undefined or null to object` on such a value.
-    // #6587: `FindMyWay(opts)` (find-my-way@9) is called without `new`, so its
-    // `Router` body evaluates `this instanceof Router` with `this === undefined`
-    // — a dynamic (function-value) RHS routes through `js_instanceof_dynamic`'s
-    // synthetic-class-id tail into this walk, and the unguarded getPrototypeOf
-    // aborted module init before any route was registered.
+    // OrdinaryHasInstance(C, O) step 3 (ECMA-262 7.3.21): "If Type(O) is not
+    // Object, return false." A primitive left operand is never `instanceof`
+    // anything, so guard it here BEFORE the `js_object_get_prototype_of(value)`
+    // walk below. Routing a primitive into that walk is wrong two ways:
+    //   * `null`/`undefined` THROW `TypeError: Cannot convert undefined or null
+    //     to object` (#6587: find-my-way@9's `FindMyWay(opts)` is called without
+    //     `new`, so its `Router` body evaluates `this instanceof Router` with
+    //     `this === undefined` — a function-value RHS routes through
+    //     `js_instanceof_dynamic`'s synthetic-class-id tail into this walk, and
+    //     the unguarded getPrototypeOf aborted module init before any route was
+    //     registered);
+    //   * a heap-allocated string/bigint/symbol gets ToObject-wrapped by
+    //     getPrototypeOf, so the walk climbs the wrapper chain and can spuriously
+    //     match (`Symbol() instanceof Object` wrongly returned `true`).
+    // Every tag below is checked without dereferencing. Real f64 numbers are
+    // already answered `false` by the primitive fast paths before this point and
+    // share tag-space with raw heap pointers (a bare `is_number()` would
+    // misclassify a module-level object var), so they are intentionally left to
+    // those paths rather than guarded here.
     {
         let jv = crate::value::JSValue::from_bits(value.to_bits());
-        if jv.is_null() || jv.is_undefined() {
+        if jv.is_null()
+            || jv.is_undefined()
+            || jv.is_bool()
+            || jv.is_int32()
+            || jv.is_any_string()
+            || jv.is_bigint()
+            || unsafe { crate::symbol::js_is_symbol(value) != 0 }
+        {
             return false;
         }
     }
@@ -1307,6 +1323,13 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
     const CLASS_ID_OBJECT: u32 = 0xFFFF0050;
     if class_id == CLASS_ID_OBJECT {
         if jsval.is_pointer() {
+            // A Symbol is a POINTER_TAG heap allocation but a PRIMITIVE, not an
+            // object, so `Symbol() instanceof Object` is false (the comment
+            // above says "any non-primitive"). Every other primitive is
+            // non-pointer-tagged and already falls through below. #6587 review.
+            if unsafe { crate::symbol::js_is_symbol(value) != 0 } {
+                return false_val;
+            }
             // Covers every heap object, including a Date (now a NaN-boxed
             // `DateCell` pointer — #2089) and an Invalid Date.
             return true_val;
@@ -1523,18 +1546,36 @@ pub extern "C" fn js_instanceof(value: f64, class_id: u32) -> f64 {
 mod null_lhs_tests {
     use super::*;
 
-    /// #6587: `OrdinaryHasInstance` with a `null`/`undefined` left operand must
-    /// answer `false`, NOT throw `Cannot convert undefined or null to object`.
-    /// The guard short-circuits before any prototype access, so the RHS is
-    /// irrelevant and no arena/runtime state is touched — this exercises the
-    /// exact path find-my-way@9 hits when `FindMyWay(opts)` is called without
-    /// `new` and its `Router` body evaluates `this instanceof Router`.
+    /// `OrdinaryHasInstance` with a primitive left operand must answer `false`,
+    /// never throw or spuriously match. The guard is purely tag-based and
+    /// short-circuits before any prototype access, so the RHS is irrelevant and
+    /// no arena/runtime state is touched.
+    ///
+    /// * `null`/`undefined` — #6587: previously threw `Cannot convert undefined
+    ///   or null to object` (find-my-way@9's `FindMyWay(opts)` called without
+    ///   `new` evaluates `this instanceof Router` with `this === undefined`).
+    /// * boolean / int32 / string / bigint — a primitive is never `instanceof`
+    ///   anything; a string's ToObject wrapper chain must not spuriously match.
+    ///
+    /// (Symbols are also guarded, but constructing one needs the runtime arena,
+    /// so that arm is covered by the behavioral e2e/compiled tests instead.)
     #[test]
-    fn ordinary_has_instance_walk_is_false_for_null_and_undefined_lhs() {
-        let undefined = f64::from_bits(crate::value::TAG_UNDEFINED);
-        let null = f64::from_bits(crate::value::TAG_NULL);
-        // A dummy non-object RHS is never consulted for a non-object LHS.
-        assert!(!ordinary_has_instance_prototype_walk(undefined, 0.0));
-        assert!(!ordinary_has_instance_prototype_walk(null, 0.0));
+    fn ordinary_has_instance_walk_is_false_for_primitive_lhs() {
+        let cases = [
+            f64::from_bits(crate::value::TAG_UNDEFINED),
+            f64::from_bits(crate::value::TAG_NULL),
+            f64::from_bits(crate::value::TAG_TRUE),
+            f64::from_bits(crate::value::INT32_TAG | 5), // int32 5
+            f64::from_bits(crate::value::STRING_TAG | 0x1000), // string tag (addr never deref'd)
+            f64::from_bits(crate::value::BIGINT_TAG | 0x1000), // bigint tag (addr never deref'd)
+        ];
+        for lhs in cases {
+            // A dummy non-object RHS is never consulted for a non-object LHS.
+            assert!(
+                !ordinary_has_instance_prototype_walk(lhs, 0.0),
+                "primitive LHS {:#018x} must not be instanceof anything",
+                lhs.to_bits()
+            );
+        }
     }
 }

--- a/crates/perry/tests/issue_6559_real_libs_e2e.rs
+++ b/crates/perry/tests/issue_6559_real_libs_e2e.rs
@@ -3,14 +3,15 @@
 //! with their runtime `new Function` codegen evaluated by the dyn-eval
 //! interpreter.
 //!
-//! STATUS: currently `#[ignore]`d — all three libraries now COMPILE natively
-//! (perry.compilePackages opt-in below) but hit PRE-EXISTING perry
-//! CJS-compilation gaps at module load / library init, BEFORE any
-//! runtime-generated code runs (per-test reasons on the #[ignore]
-//! attributes). The interpreter itself is proven end-to-end against the
-//! captured generated-code shapes of these exact library versions in
-//! issue_6559_dyn_function_interpreter.rs (always-on, green). Un-ignore as
-//! the CJS walls fall.
+//! STATUS: find-my-way is now un-ignored and green (#6587: `x instanceof C`
+//! with a `null`/`undefined` LHS no longer throws — see
+//! `perry-runtime/src/object/instanceof.rs`). ajv and fast-json-stringify
+//! remain `#[ignore]`d on PRE-EXISTING perry CJS-compilation gaps at module
+//! load / library init, BEFORE any runtime-generated code runs (per-test
+//! reasons on the #[ignore] attributes). The interpreter itself is proven
+//! end-to-end against the captured generated-code shapes of these exact
+//! library versions in issue_6559_dyn_function_interpreter.rs (always-on,
+//! green). Un-ignore each remaining test as its CJS wall falls.
 //!
 //! Each test provisions its own tempdir project via `npm install` (pinned
 //! majors matching the versions the shapes were captured from). When npm or
@@ -350,10 +351,12 @@ try {
 /// (version + host), then look them up — every matcher (`matchPrefix`,
 /// `_createParamsObject`, `deriveSyncConstraints`, `getMatchingHandler`) is
 /// runtime-generated via `new Function`.
+// #6587 fixed the CJS-init wall (`FindMyWay(opts)` called without `new`
+// evaluated `this instanceof Router` with `this === undefined`, which threw
+// `TypeError: Cannot convert undefined or null to object` before any route was
+// registered). This test now runs end-to-end; it still SKIPs when npm / the
+// network is unavailable unless `PERRY_REQUIRE_NPM_E2E=1` is set.
 #[test]
-#[ignore = "blocked on a PRE-EXISTING perry CJS-compilation gap, not the #6559 interpreter: \
-the compiled find-my-way module tree throws `TypeError: Cannot convert undefined or null to \
-object` at load. Run with PERRY_REQUIRE_NPM_E2E=1 -- --ignored once the gap is fixed."]
 fn real_find_my_way_router() {
     let dir = tempfile::tempdir().expect("tempdir");
     let root = dir.path();


### PR DESCRIPTION
## Summary

Fixes **#6587** — `find-my-way@9` threw `TypeError: Cannot convert undefined or null to object` at module init (before any route was registered), blocking the #6559 real-library e2e.

### Root cause
`OrdinaryHasInstance(C, O)` (ECMA-262 7.3.20, step 5) must return `false` when the left operand is not an object. Perry's `ordinary_has_instance_prototype_walk` (in `crates/perry-runtime/src/object/instanceof.rs`) walked the LHS's `[[Prototype]]` chain via `js_object_get_prototype_of(value)` **without** guarding `null`/`undefined` — and that helper throws `Cannot convert undefined or null to object` on those.

`FindMyWay(opts)` is called **without `new`**, so the `Router` body runs `if (!(this instanceof Router))` with `this === undefined`. Because the RHS is a function *value* (not a statically class-id-resolvable local), it routes through the dynamic `js_instanceof_dynamic` tail, which computes a synthetic class id and falls into the prototype walk — throwing before init finished.

### Fix
A `null`/`undefined` LHS short-circuits the walk to `false` (spec-correct). One-line guard; strictly turns an incorrect throw into the correct `false`.

### Verification
- New runtime unit test `null_lhs_tests` (cargo-test-visible, runs per-PR).
- Un-ignored `real_find_my_way_router` in `issue_6559_real_libs_e2e.rs` — now **green**, output byte-identical to Node (`user: 42`, `book: 1,9`, versioned/host/wild/miss, `handlers: user book wild`).
- `undefined instanceof Foo` / `null instanceof Foo` now return `false` (matches Node) instead of throwing.

### Scope note on #6586
`#6586` (fast-json-stringify) is **not** addressed here. It was investigated and root-caused to a *deeper, separate* problem: perry compiles `ajv`'s TypeScript source (`lib/*.ts`, via the source-map/`.ts`-preference resolution) rather than the `dist/*.js` CJS that Node loads, and `import * as equal from "fast-deep-equal"; equal(...)` (a namespace import of a CJS default-function, called as a function) fails to link — the exporting module never emits the callable default as a public symbol for a namespace-import call. That is a larger codegen/linking change (and the documented `module is not defined` wall lies beyond it), so it's left as follow-up rather than bundled into this small, low-risk runtime fix.

No version bump / changelog per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `instanceof` handling for primitive left-hand values, including `null` and `undefined`, so it returns `false` rather than throwing.
- **Tests**
  - Added tests ensuring `instanceof` safely handles multiple primitive and nullish inputs without errors.
  - Enabled the `find-my-way` end-to-end router test (and updated its notes on when it may be skipped based on network/package availability).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->