### PR TITLE
fix(ffi,net): recycle reserved socket handle ids; degrade exhaustion instead of panicking (#6441)

### DIFF
--- a/crates/perry-ext-http-server/src/raw_upgrade.rs
+++ b/crates/perry-ext-http-server/src/raw_upgrade.rs
@@ -172,6 +172,14 @@ pub(crate) async fn peek_and_maybe_dispatch_raw_upgrade(
     im.complete = true;
     let im_handle = alloc_incoming_message(im);
     let socket_id = perry_ext_net::adopt_upgraded_tcp_stream(stream);
+    // #6441: `adopt_upgraded_tcp_stream` returns `INVALID_HANDLE` and drops the
+    // stream when the shared net handle-id band is exhausted. Abort the upgrade
+    // rather than forward a phantom id-0 socket downstream, and reclaim the
+    // just-allocated incoming-message handle so it doesn't orphan.
+    if socket_id == perry_ffi::INVALID_HANDLE {
+        perry_ffi::drop_handle(im_handle);
+        return PeekResult::Handled;
+    }
 
     let pending = HttpPendingUpgrade {
         server_handle,

--- a/crates/perry-ext-net/src/adopt.rs
+++ b/crates/perry-ext-net/src/adopt.rs
@@ -28,6 +28,14 @@ use tokio::sync::mpsc;
 /// socket.
 pub fn adopt_upgraded_tcp_stream(stream: tokio::net::TcpStream) -> i64 {
     let id = next_id();
+    // #6441: called from the HTTP accept task (a background tokio thread), so
+    // exhaustion can't throw to a JS frame here. Drop the upgraded stream and
+    // return the `0` sentinel rather than register a phantom socket under it;
+    // the caller aborts the upgrade when it sees `INVALID_HANDLE`.
+    if id == perry_ffi::INVALID_HANDLE {
+        drop(stream);
+        return perry_ffi::INVALID_HANDLE;
+    }
     let (tx, rx) = mpsc::unbounded_channel::<SocketCommand>();
     let local = stream.local_addr().ok();
     statics::sockets().lock().unwrap().insert(

--- a/crates/perry-ext-net/src/classes.rs
+++ b/crates/perry-ext-net/src/classes.rs
@@ -5,7 +5,9 @@ use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::{Mutex, OnceLock};
 
-use crate::{get_object_number_field, get_object_string_field, next_id, string_from_header_i64};
+use crate::{
+    get_object_number_field, get_object_string_field, next_id_or_throw, string_from_header_i64,
+};
 
 const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
 
@@ -214,7 +216,7 @@ fn string_from_js_value(value: JsValue) -> Option<String> {
 pub unsafe extern "C" fn js_net_block_list_new() -> i64 {
     crate::ensure_gc_scanner_registered();
     crate::dispatch::ensure_runtime_dispatch_registered();
-    let id = next_id();
+    let id = next_id_or_throw();
     block_lists()
         .lock()
         .unwrap()
@@ -332,7 +334,7 @@ pub unsafe extern "C" fn js_net_block_list_from_json(handle: i64, value: f64) ->
 
 fn socket_address_new(address: IpAddr, port: u16, flowlabel: u32) -> f64 {
     crate::dispatch::ensure_runtime_dispatch_registered();
-    let id = next_id();
+    let id = next_id_or_throw();
     socket_addresses().lock().unwrap().insert(
         id,
         SocketAddressState {

--- a/crates/perry-ext-net/src/handle_ids.rs
+++ b/crates/perry-ext-net/src/handle_ids.rs
@@ -1,0 +1,56 @@
+//! Socket / server / block-list handle-id allocation.
+//!
+//! Split out of `lib.rs` to keep that file under the file-size gate. These
+//! helpers wrap perry-ffi's SHARED handle-id allocator and add the
+//! exhaustion-degradation policy (#6441).
+
+/// Socket / server / block-list ids come from perry-ffi's SHARED handle-id
+/// allocator, not a private counter.
+///
+/// Every ext staticlib that mints ids privately from 1 aliases the others
+/// inside the shared `[1, 0x40000)` band, and the composite handle-method
+/// dispatch (`class_handles.rs::composite_handle_method_dispatch`) asks each
+/// registered extension "is this handle yours?" — so the FIRST extension whose
+/// private counter reached that number claims the call. Next.js's HTTP server
+/// (perry-ext-http-server handle 1, via `register_handle`) therefore claimed
+/// `socket.on('data', …)` on this crate's socket 1: the listener landed on the
+/// HTTP server, the reader delivered the MySQL greeting to an empty listener
+/// list, and mysql2's handshake hung to ETIMEDOUT.
+///
+/// `reserve_handle_id` consumes an id from the same counter `register_handle`
+/// uses, so ids stay globally unique across every ext library while this
+/// crate keeps its own object map.
+///
+/// Returns [`perry_ffi::INVALID_HANDLE`] (`0`) when that shared band is
+/// exhausted rather than aborting the process (#6441). Reserved ids currently
+/// leak — a `net.Socket`'s id lives as long as the JS object, not the TCP
+/// connection, so freeing on `'close'` would let a stale reference alias a
+/// recycled socket (the aliasing class #6407 fixes) — so a long-running server
+/// will eventually drain the band. Callers on a synchronous FFI path must route
+/// the `0` sentinel through [`next_id_or_throw`]; background callers must guard
+/// it explicitly (never register an object under `0`).
+pub(crate) fn next_id() -> i64 {
+    perry_ffi::reserve_handle_id()
+}
+
+/// [`next_id`] for the synchronous FFI entry points (`new net.Socket()`,
+/// `net.createServer`, `net.connect`, `new net.BlockList()`,
+/// `new net.SocketAddress()`): on band exhaustion, throw a recoverable,
+/// JS-visible `EMFILE`-coded error instead of returning the `0` sentinel that
+/// would otherwise be registered as a phantom socket. Node surfaces file-handle
+/// exhaustion the same way, so `try/catch` and `'error'` handlers can react.
+///
+/// Diverges on exhaustion (via `perry_ffi::throw_with_code`), exactly like this
+/// crate's Node argument validators — so it must be called BEFORE acquiring any
+/// `statics::*` lock, which every alloc site already does (`let id = ...` first).
+pub(crate) fn next_id_or_throw() -> i64 {
+    let id = next_id();
+    if id == perry_ffi::INVALID_HANDLE {
+        perry_ffi::throw_with_code(
+            "too many open handles: net handle-id space exhausted",
+            "EMFILE",
+            perry_ffi::ErrorKind::Error,
+        );
+    }
+    id
+}

--- a/crates/perry-ext-net/src/lib.rs
+++ b/crates/perry-ext-net/src/lib.rs
@@ -70,6 +70,8 @@ mod lifecycle;
 pub use lifecycle::*;
 mod classes;
 pub use classes::*;
+mod handle_ids;
+pub(crate) use handle_ids::{next_id, next_id_or_throw};
 mod dispatch;
 // #2154 — raw-consumer bridge so perry-ext-http can drive an HTTP exchange
 // over a socket produced by `agent.createConnection` (split out for the gate).
@@ -428,26 +430,6 @@ extern "C" {
     fn js_net_callback_ptr(value: f64) -> i64;
 }
 
-/// Socket / server / block-list ids come from perry-ffi's SHARED handle-id
-/// allocator, not a private counter.
-///
-/// Every ext staticlib that mints ids privately from 1 aliases the others
-/// inside the shared `[1, 0x40000)` band, and the composite handle-method
-/// dispatch (`class_handles.rs::composite_handle_method_dispatch`) asks each
-/// registered extension "is this handle yours?" — so the FIRST extension whose
-/// private counter reached that number claims the call. Next.js's HTTP server
-/// (perry-ext-http-server handle 1, via `register_handle`) therefore claimed
-/// `socket.on('data', …)` on this crate's socket 1: the listener landed on the
-/// HTTP server, the reader delivered the MySQL greeting to an empty listener
-/// list, and mysql2's handshake hung to ETIMEDOUT.
-///
-/// `reserve_handle_id` consumes an id from the same counter `register_handle`
-/// uses, so ids stay globally unique across every ext library while this
-/// crate keeps its own object map.
-pub(crate) fn next_id() -> i64 {
-    perry_ffi::reserve_handle_id()
-}
-
 fn push_event(ev: PendingNetEvent) {
     statics::pending_events().lock().unwrap().push(ev);
     // Wake the main thread so its `js_wait_for_event` returns
@@ -626,7 +608,7 @@ pub unsafe extern "C" fn js_net_socket_connect(arg1_f64: f64, arg2_f64: f64, arg
 pub unsafe extern "C" fn js_net_socket_alloc() -> i64 {
     ensure_gc_scanner_registered();
     dispatch::ensure_runtime_dispatch_registered();
-    let id = next_id();
+    let id = next_id_or_throw();
     let (tx, rx) = mpsc::unbounded_channel::<SocketCommand>();
     statics::sockets().lock().unwrap().insert(
         id,
@@ -661,7 +643,7 @@ pub unsafe extern "C" fn js_net_create_server(
 ) -> i64 {
     ensure_gc_scanner_registered();
     dispatch::ensure_runtime_dispatch_registered();
-    let id = next_id();
+    let id = next_id_or_throw();
     statics::listeners()
         .lock()
         .unwrap()
@@ -833,6 +815,20 @@ pub unsafe extern "C" fn js_net_server_listen(handle: i64, port: f64, arg2: f64,
                             // call `run_socket_task` directly with
                             // the accepted stream.
                             let socket_id = next_id();
+                            // #6441: on a background thread there is no JS frame
+                            // to unwind to, so exhaustion can't throw here.
+                            // Drop the accepted stream — closing the connection,
+                            // the EMFILE-style degradation Node applies when it
+                            // can't accept — rather than register a phantom
+                            // socket under the `0` sentinel. Refuse quietly: once
+                            // the band is exhausted every accept fails, so an
+                            // 'error' event per connection would flood a hot
+                            // loop; the synchronous client-facing entry points
+                            // still surface a throwable EMFILE.
+                            if socket_id == perry_ffi::INVALID_HANDLE {
+                                drop(stream);
+                                continue;
+                            }
                             let (tx, rx) = mpsc::unbounded_channel::<SocketCommand>();
                             // Node sets TCP_NODELAY on every accepted socket by
                             // default (Nagle off). Match that so small writes
@@ -1103,7 +1099,7 @@ pub(crate) fn spawn_socket_task(
 ) -> i64 {
     ensure_gc_scanner_registered();
     dispatch::ensure_runtime_dispatch_registered();
-    let id = next_id();
+    let id = next_id_or_throw();
     let (tx, rx) = mpsc::unbounded_channel::<SocketCommand>();
 
     statics::sockets().lock().unwrap().insert(

--- a/crates/perry-ffi/src/handle.rs
+++ b/crates/perry-ffi/src/handle.rs
@@ -470,8 +470,17 @@ pub fn register_handle<T: 'static + Send + Sync>(value: T) -> Handle {
     ensure_handle_exists_probe_registered();
     // Reuse a reclaimed id when one is parked, else mint a fresh one. A
     // recycled id was removed from `HANDLES` before being parked, so inserting
-    // under it here cannot collide with a live registration.
-    let handle = pop_free_handle().unwrap_or_else(next_fresh_handle_id);
+    // under it here cannot collide with a live registration. Unlike
+    // `reserve_handle_id`, exhaustion still aborts here: `register_handle` must
+    // return a live key to insert under, and there is no valid id left to hand
+    // out. A leaking `register_handle` workload is a bug (its ids are recycled
+    // by `drop_handle`), so exhaustion here means the concurrent live-handle
+    // count genuinely exceeded the band.
+    let handle = pop_free_handle()
+        .or_else(next_fresh_handle_id)
+        .unwrap_or_else(|| {
+            panic!("perry-ffi handle id range exhausted before reserved Web handle bands")
+        });
     HANDLES.insert(handle, Box::new(value));
     handle
 }
@@ -485,16 +494,87 @@ pub fn register_handle<T: 'static + Send + Sync>(value: T) -> Handle {
 /// `socket.on('data', …)` on ext-net socket #1 got claimed by ext-http-server
 /// (whose server was also #1) and the mysql2 handshake hung: the listener
 /// registered on the HTTP server and the socket's bytes reached nobody.
+///
+/// Return [`INVALID_HANDLE`] when the visible id band is exhausted rather than
+/// aborting the process (#6441). A reserved id is not recycled until the owning
+/// subsystem calls [`free_handle_id`]; a subsystem that never frees (or frees
+/// more slowly than it reserves) will eventually drain the band, and a
+/// long-running server must degrade that to a recoverable, JS-visible error
+/// (e.g. an `EMFILE`-style throw at the socket-alloc site) instead of a crash.
+/// The `0` sentinel is safe to route on: callers must NOT register an object
+/// under it — `0` is the "no handle" value — so the guard turns exhaustion into
+/// a caught error at the boundary, never a phantom id-0 entry.
 pub fn reserve_handle_id() -> Handle {
-    pop_free_handle().unwrap_or_else(next_fresh_handle_id)
+    pop_free_handle()
+        .or_else(next_fresh_handle_id)
+        .unwrap_or(INVALID_HANDLE)
 }
 
-fn next_fresh_handle_id() -> Handle {
-    let handle = NEXT_HANDLE.fetch_add(1, Ordering::SeqCst);
-    if handle >= FFI_HANDLE_ID_END {
-        panic!("perry-ffi handle id range exhausted before reserved Web handle bands");
+/// Free a handle id previously minted by [`reserve_handle_id`], returning it to
+/// circulation through the same quarantine [`drop_handle`] uses.
+///
+/// [`reserve_handle_id`] hands a subsystem that keeps its OWN object map (e.g.
+/// perry-ext-net's socket registry) a globally-unique id without storing
+/// anything in [`HANDLES`] — so there is nothing to remove here; this recycles
+/// only the *id*. The caller MUST have already dropped the id from its own map
+/// and must guarantee no further dispatch will resolve it, exactly the contract
+/// [`drop_handle`] places on [`register_handle`] ids.
+///
+/// Like every freed id it is parked in the one-tick quarantine
+/// ([`QUARANTINED_HANDLES`]) and only promoted to the freelist by
+/// [`drain_quarantined_handles`], so a stale bare reference dispatched before
+/// the next tick spends against an empty slot instead of aliasing a freshly
+/// reserved id — the ABA / use-after-recycle class #6407 fixes. See
+/// [`QUARANTINED_HANDLES`]. Passing [`INVALID_HANDLE`] is a no-op, so a caller
+/// can free the result of a possibly-exhausted [`reserve_handle_id`]
+/// unconditionally.
+///
+/// This is the primitive both candidate free-when-unreachable fixes for the
+/// reserved-id leak build on (a GC-finalized socket object, or a handle-band
+/// liveness sweep — #6441). It performs no reachability analysis itself: a
+/// stale JS reference to a `net.Socket` can outlive its `'close'`, so freeing
+/// on `'close'` alone is unsafe and left to that follow-up.
+pub fn free_handle_id(id: Handle) {
+    if id == INVALID_HANDLE {
+        return;
     }
-    handle
+    recycle_handle(id);
+}
+
+/// Deadline-gated twin of [`free_handle_id`]: holds the reserved id in the
+/// [`QUARANTINED_UNTIL`] tier until `Instant::now()` passes `deadline`, rather
+/// than merely until the next tick. For a subsystem that frees an id while a
+/// stale holder may still resume and dispatch on it within a known grace window
+/// (mirrors [`drop_handle_until`]). Passing [`INVALID_HANDLE`] is a no-op.
+pub fn free_handle_id_until(id: Handle, deadline: Instant) {
+    if id == INVALID_HANDLE {
+        return;
+    }
+    recycle_handle_until(id, deadline);
+}
+
+/// Mint a never-before-used id, or `None` once the visible band is exhausted.
+///
+/// Returns `None` rather than panicking so callers choose their own exhaustion
+/// policy: [`reserve_handle_id`] degrades to a recoverable [`INVALID_HANDLE`]
+/// (#6441), while [`register_handle`] — which has no valid key to insert under
+/// — still aborts. The atomic keeps advancing past [`FFI_HANDLE_ID_END`] on
+/// each post-exhaustion call; that is harmless (every such call maps to `None`)
+/// and the `i64` counter cannot realistically wrap.
+fn next_fresh_handle_id() -> Option<Handle> {
+    fresh_id_or_exhausted(NEXT_HANDLE.fetch_add(1, Ordering::SeqCst))
+}
+
+/// Classify a raw counter value as a usable fresh id or band-exhausted.
+/// Factored out so the exhaustion boundary is unit-testable without advancing
+/// the process-wide [`NEXT_HANDLE`] past [`FFI_HANDLE_ID_END`] (which would
+/// break every other test in this binary).
+fn fresh_id_or_exhausted(raw: Handle) -> Option<Handle> {
+    if raw >= FFI_HANDLE_ID_END {
+        None
+    } else {
+        Some(raw)
+    }
 }
 
 /// Look up a handle and run `f` against the borrowed value.
@@ -1277,5 +1357,169 @@ mod tests {
              no-reclaim registry would mint one per allocation and exhaust \
              the band"
         );
+    }
+
+    // ----------------------------------------------------------------
+    // Reserved-id recycling (#6441).
+    //
+    // `reserve_handle_id` mints a globally-unique id WITHOUT storing a
+    // value in `HANDLES` — for a subsystem (perry-ext-net's socket map)
+    // that keeps its own object map. Before `free_handle_id` existed
+    // nothing ever returned a reserved id, so a long-running server
+    // leaked the whole `[1, 0x40000)` band and then crashed. These tests
+    // pin the two halves of the fix: reserved ids now recycle through the
+    // same quarantine as `drop_handle` ids, and exhaustion degrades to
+    // `INVALID_HANDLE` instead of a panic.
+    // ----------------------------------------------------------------
+
+    #[test]
+    fn fresh_id_or_exhausted_flags_the_band_boundary() {
+        // Pure boundary logic, tested without advancing the process-wide
+        // `NEXT_HANDLE` past `FFI_HANDLE_ID_END` (which would break every
+        // other test in this binary). Ids strictly below the end are usable;
+        // the end value and anything past it are exhausted (`None`).
+        assert_eq!(fresh_id_or_exhausted(1), Some(1));
+        assert_eq!(
+            fresh_id_or_exhausted(FFI_HANDLE_ID_END - 1),
+            Some(FFI_HANDLE_ID_END - 1)
+        );
+        assert_eq!(fresh_id_or_exhausted(FFI_HANDLE_ID_END), None);
+        assert_eq!(fresh_id_or_exhausted(FFI_HANDLE_ID_END + 4096), None);
+    }
+
+    #[test]
+    fn reserve_free_reserve_recycles_the_id() {
+        let _serial = RECYCLE_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+        // Reserve/free churn far past the band size while holding at most one
+        // id live. With `free_handle_id` recycling each id through the
+        // quarantine, the fresh counter barely moves — cumulative reservations
+        // decouple from fresh-id consumption, exactly as `register`/`drop` do.
+        //
+        // Before this fix `reserve_handle_id` had no `free_*` twin, so this
+        // loop would advance the counter by `iterations`, exhaust the band, and
+        // (post-#6441) start returning `INVALID_HANDLE` — tripping the
+        // `assert_ne!` below. (Pre-#6441 it panicked outright.) Either way a
+        // no-recycle build cannot complete the loop.
+        let iterations = FFI_HANDLE_ID_END as usize + 8192;
+        let before = NEXT_HANDLE.load(Ordering::SeqCst);
+        for _ in 0..iterations {
+            let id = reserve_handle_id();
+            assert_ne!(
+                id, INVALID_HANDLE,
+                "reserve_handle_id must not run out of ids once freed ids recycle"
+            );
+            free_handle_id(id);
+            // Promote the just-quarantined id back to the freelist (the host
+            // pump's per-tick drain) so the next reserve reuses it.
+            drain_quarantined_handles();
+        }
+        let fresh_minted = (NEXT_HANDLE.load(Ordering::SeqCst) - before) as usize;
+        assert!(
+            fresh_minted < 4096,
+            "fresh-id consumption ({fresh_minted}) over {iterations} \
+             reserve/free cycles should stay tiny once reserved ids recycle"
+        );
+    }
+
+    #[test]
+    fn freed_reserved_id_not_reusable_until_drained() {
+        // The ABA guarantee for reserved ids, mirroring
+        // `freed_id_is_not_reusable_until_drained_no_cross_request_bleed`: a
+        // socket id freed on `'close'` must not be handed to a *new* reservation
+        // within the same tick, or a stale JS `socket` reference dispatched
+        // before the next drain would alias the new socket (the exact aliasing
+        // class #6407 fixes). While quarantined the id maps to nothing, so the
+        // stale dispatch spends against an empty slot.
+        let _serial = RECYCLE_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+        let h = reserve_handle_id();
+        assert_ne!(h, INVALID_HANDLE);
+        free_handle_id(h);
+
+        // No drain yet: `h` sits in the quarantine, NOT the freelist, so neither
+        // a fresh reservation nor a registration can re-mint it this tick. Only
+        // the serialized recycle tests call `drain`, and this test holds the
+        // lock, so `h` provably stays quarantined here.
+        let other_reserved = reserve_handle_id();
+        assert_ne!(
+            other_reserved, h,
+            "a just-freed reserved id must not be reusable within the same tick"
+        );
+        let other_registered = register_handle(0_i64);
+        assert_ne!(
+            other_registered, h,
+            "a just-freed reserved id must not leak into register_handle this tick"
+        );
+
+        // After a drain boundary the id is promoted and eventually reused.
+        free_handle_id(other_reserved);
+        let reused = drop_then_register_reusing(other_registered, 55_i64);
+        assert_eq!(with_handle::<i64, _, _>(reused, |v| *v), Some(55));
+        drop_handle(reused);
+        drain_quarantined_handles();
+    }
+
+    #[test]
+    fn free_handle_id_until_holds_reserved_id_past_ticks() {
+        // The deadline-gated twin for reserved ids (the reaper's peer-disconnect
+        // path in handle-registry terms): a reserved id freed with a future
+        // grace deadline stays parked across EVERY drain until the deadline
+        // elapses, then recycles cleanly.
+        let _serial = RECYCLE_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
+        let h = reserve_handle_id();
+        assert_ne!(h, INVALID_HANDLE);
+        free_handle_id_until(h, Instant::now() + Duration::from_secs(3600));
+
+        for _ in 0..5 {
+            drain_quarantined_handles();
+            let probe = reserve_handle_id();
+            assert_ne!(
+                probe, h,
+                "a deadline-gated reserved id must not recycle before its grace \
+                 deadline elapses"
+            );
+            free_handle_id(probe);
+        }
+
+        // An id parked with an already-elapsed deadline is promoted by the very
+        // next drain and reused (retry to absorb parallel tests racing the
+        // shared freelist, same pattern as `drop_then_register_reusing`).
+        let dead = reserve_handle_id();
+        free_handle_id_until(dead, Instant::now() - Duration::from_secs(1));
+        let mut recycled = false;
+        for _ in 0..10_000 {
+            drain_quarantined_handles();
+            let candidate = reserve_handle_id();
+            if candidate == dead {
+                recycled = true;
+                free_handle_id(candidate);
+                break;
+            }
+            free_handle_id(candidate);
+        }
+        assert!(
+            recycled,
+            "an elapsed-deadline reserved id must recycle once its grace passes"
+        );
+        // `h`'s far-future entry stays parked — the point of the test. The
+        // freelist is bounded, so a single held id leaks nothing that matters.
+        drain_quarantined_handles();
+    }
+
+    #[test]
+    fn free_handle_id_ignores_invalid_handle() {
+        // `reserve_handle_id` returns `INVALID_HANDLE` on exhaustion, so callers
+        // free its result unconditionally; freeing the sentinel must be a no-op
+        // (never park `0` for reuse — it is the "no handle" value).
+        free_handle_id(INVALID_HANDLE);
+        free_handle_id_until(INVALID_HANDLE, Instant::now());
+        drain_quarantined_handles();
+        // `register_handle` never returns `INVALID_HANDLE`, so if `0` had been
+        // parked and handed back this would fail its own non-null invariant.
+        let h = register_handle(1_i64);
+        assert_ne!(h, INVALID_HANDLE);
+        drop_handle(h);
     }
 }

--- a/crates/perry-ffi/src/lib.rs
+++ b/crates/perry-ffi/src/lib.rs
@@ -63,11 +63,11 @@ mod handle;
 #[allow(deprecated)]
 pub use handle::gc_register_root_scanner;
 pub use handle::{
-    drain_quarantined_handles, drop_handle, drop_handle_until, gc_register_mutable_root_scanner,
-    gc_register_mutable_root_scanner_named, get_handle, get_handle_mut, handle_exists,
-    iter_handle_ids_of, iter_handles_of, iter_handles_of_mut, register_handle, reserve_handle_id,
-    take_handle, with_handle, with_handle_mut, GcMutableRootScanner, GcRootVisitor, Handle,
-    INVALID_HANDLE,
+    drain_quarantined_handles, drop_handle, drop_handle_until, free_handle_id,
+    free_handle_id_until, gc_register_mutable_root_scanner, gc_register_mutable_root_scanner_named,
+    get_handle, get_handle_mut, handle_exists, iter_handle_ids_of, iter_handles_of,
+    iter_handles_of_mut, register_handle, reserve_handle_id, take_handle, with_handle,
+    with_handle_mut, GcMutableRootScanner, GcRootVisitor, Handle, INVALID_HANDLE,
 };
 
 mod jsvalue;


### PR DESCRIPTION
Fixes #6441. Follow-up to #6407, which fixed the ext-lib handle-id **collision**; this addresses the remaining **leak** + **exhaustion panic**.

## Problem

`reserve_handle_id()` mints a globally-unique id per ext-net socket, but nothing ever returns it, and `next_fresh_handle_id()` `panic!`d on exhaustion — so a long-running server leaks the whole `[1, 0x40000)` band and crashes after ~262k accepted connections.

The full free-when-unreachable fix is a large, critical-path change (represent `net.Socket` as a GC heap object, or add a GC handle-band liveness sweep — see the issue). A `net.Socket` stays inspectable after `'close'`, so its id's lifetime is the **JS object's**, not the TCP connection's, and freeing on `'close'` alone would just trade the leak for the fast cross-object aliasing #6407 fixes. That rewrite is **deferred**. This PR lands the two pieces the issue calls out as belonging here now: the shared **primitive** both candidate fixes need, and the **exhaustion de-risk**.

## Changes

**perry-ffi (`handle.rs`)**
- Add `free_handle_id` / `free_handle_id_until` — recycle a `reserve_handle_id` id through the existing quarantine (one-tick and deadline-gated tiers), mirroring `drop_handle` / `drop_handle_until`. A stale bare reference dispatched before the next `drain_quarantined_handles` tick spends against an empty slot instead of aliasing a freshly reserved id. This is the building block the eventual free-when-unreachable fix wires up; it performs **no reachability analysis itself** (deliberately), so it is exported but not yet called from a free site.
- `next_fresh_handle_id` now returns `Option`; `reserve_handle_id` degrades to `INVALID_HANDLE` on exhaustion instead of aborting. `register_handle` **still panics** — it has no valid key to insert under, and its ids recycle via `drop_handle`, so it isn't the leaker.

**perry-ext-net**
- Synchronous entry points (`new net.Socket()`, `createServer`, `net.connect`, `new net.BlockList()`, `new net.SocketAddress()`) route through `next_id_or_throw`, which throws a recoverable, JS-visible `EMFILE`-coded error on exhaustion (Node's behavior for fd exhaustion) rather than registering a phantom id-0 socket.
- Background paths (server accept loop, `adopt_upgraded_tcp_stream`) have no JS frame to unwind to, so they drop the connection instead of registering under the `0` sentinel; the raw-upgrade caller in perry-ext-http-server aborts the upgrade and reclaims the incoming-message handle.
- Id helpers extracted into `handle_ids.rs` to keep `lib.rs` under the file-size gate.

## Tests

5 new perry-ffi unit tests: reserved-id recycling decouples fresh-id consumption from cumulative reservations (churn past the band size); the ABA quarantine guarantee for reserved ids; the deadline-gated tier; the `INVALID_HANDLE` no-op; and the exhaustion boundary (unit-tested via an extracted pure helper, so it doesn't advance the process-wide counter past the band and break other tests).

`cargo test -p perry-ffi` (17 pass) and `cargo test -p perry-ext-net` (23 pass) green locally; all three touched crates `cargo check` clean.

## Notes for reviewers
- The `free_handle_id` primitive is intentionally unwired — the actual free-on-unreachable is the deferred follow-up. Landing the primitive now (drafted during #6407 review) is what the issue asks for.
- CI `lint` may be red on an unrelated pre-existing main-side file-size failure (`crates/perry-runtime/src/bigint.rs`, 2201 lines); not introduced here.
- No version bump / changelog per the maintainer-folds-metadata-at-merge convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented invalid network handles from creating phantom sockets or disrupting HTTP upgrade handling.
  - Network resource allocation now reports a recoverable “too many open files” error when capacity is exhausted.
  - Improved recycling of released handles while preventing unsafe immediate reuse.

- **Reliability**
  - Accepted connections and upgraded streams are safely discarded when no valid handle is available.
  - Added safeguards for handle exhaustion and cleanup paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->