### PR TITLE
fix(compile): namespace import of a CJS default-function links its direct call (#6586)

### DIFF
--- a/crates/perry/src/commands/compile/run_pipeline.rs
+++ b/crates/perry/src/commands/compile/run_pipeline.rs
@@ -2440,6 +2440,71 @@ pub fn run_with_parse_cache(
                     };
                     if let Some(local) = namespace_like_local {
                         namespace_imports.push(local.clone());
+                        // Issue #6586: a namespace import of a CommonJS module
+                        // whose `module.exports` value is itself the export
+                        // (`module.exports = function equal(){}`, no
+                        // `__esModule` marker) is TypeScript's
+                        // esModuleInterop=false interop — `import * as equal
+                        // from "fast-deep-equal"` binds `equal` to the whole
+                        // `require()` result (the default export), so a DIRECT
+                        // call `equal(a, b)` is a call OF that value. ajv's
+                        // `lib/compile/resolve.ts` does exactly this for
+                        // `fast-deep-equal` and `json-schema-traverse`, and
+                        // fast-json-stringify pulls ajv in. The CJS wrap emits
+                        // the value under the module's `default` symbol, but the
+                        // namespace binding had no `import_function_prefixes`
+                        // entry, so the direct call fell through to a bare
+                        // `equal` extern and the link died with
+                        // `Undefined symbols: "_equal"`. Wire the whole-value
+                        // binding to the `default` export exactly like a Default
+                        // specifier does below (member reads `ns.foo` are keyed
+                        // per-namespace via `namespace_member_prefixes` and are
+                        // unaffected). Only genuine namespace imports of a module
+                        // that actually HAS a `default` export qualify — the
+                        // #4872 default-import-of-a-named-only-barrel case that
+                        // also lands here has no `default` and is skipped.
+                        if matches!(spec, perry_hir::ImportSpecifier::Namespace { .. }) {
+                            if let Some(default_origin_path) = all_module_exports
+                                .get(&resolved_path_str)
+                                .and_then(|exports| exports.get("default"))
+                                .cloned()
+                            {
+                                let default_prefix = compute_module_prefix(
+                                    &default_origin_path,
+                                    &ctx.project_root,
+                                );
+                                let default_suffix = all_module_export_origin_names
+                                    .get(&resolved_path_str)
+                                    .and_then(|m| m.get("default"))
+                                    .cloned()
+                                    .unwrap_or_else(|| "default".to_string());
+                                import_function_prefixes
+                                    .entry(local.clone())
+                                    .or_insert(default_prefix);
+                                import_function_origin_names
+                                    .entry(local.clone())
+                                    .or_insert(default_suffix.clone());
+                                // A CJS `module.exports = <expr>` becomes a
+                                // var-shaped default: a value binding emitted as
+                                // a zero-arg getter. A direct call must fetch the
+                                // closure via that getter and THEN invoke it with
+                                // the args (`js_closure_callN`), so mark the local
+                                // as an imported var — otherwise the call site
+                                // treats the getter's return value AS the call
+                                // result and `equal(1, 1)` yields the function
+                                // itself instead of `true`. Mirrors the
+                                // Default-import var classification below.
+                                if exported_var_names
+                                    .contains(&(default_origin_path.clone(), default_suffix))
+                                    || exported_var_names.contains(&(
+                                        resolved_path_str.clone(),
+                                        "default".to_string(),
+                                    ))
+                                {
+                                    imported_vars.insert(local.clone());
+                                }
+                            }
+                        }
                         // Register all exports from the source module
                         if let Some(exports) = all_module_exports.get(&resolved_path_str) {
                             for (export_name, origin_path) in exports {

--- a/crates/perry/src/commands/compile/run_pipeline.rs
+++ b/crates/perry/src/commands/compile/run_pipeline.rs
@@ -2480,10 +2480,16 @@ pub fn run_with_parse_cache(
                                     .unwrap_or_else(|| "default".to_string());
                                 import_function_prefixes
                                     .entry(local.clone())
-                                    .or_insert(default_prefix);
+                                    .or_insert(default_prefix.clone());
                                 import_function_origin_names
                                     .entry(local.clone())
                                     .or_insert(default_suffix.clone());
+                                // The metadata maps are keyed by
+                                // (declaring-path, exported-name); the default
+                                // is declared at `default_origin_path` under
+                                // `default_suffix` (== "default" unless a
+                                // re-export renamed it).
+                                let key = (default_origin_path.clone(), default_suffix);
                                 // A CJS `module.exports = <expr>` becomes a
                                 // var-shaped default: a value binding emitted as
                                 // a zero-arg getter. A direct call must fetch the
@@ -2494,14 +2500,57 @@ pub fn run_with_parse_cache(
                                 // result and `equal(1, 1)` yields the function
                                 // itself instead of `true`. Mirrors the
                                 // Default-import var classification below.
-                                if exported_var_names
-                                    .contains(&(default_origin_path.clone(), default_suffix))
+                                if exported_var_names.contains(&key)
                                     || exported_var_names.contains(&(
                                         resolved_path_str.clone(),
                                         "default".to_string(),
                                     ))
                                 {
                                     imported_vars.insert(local.clone());
+                                }
+                                // A non-var-shaped default — a `module.exports =
+                                // function foo(){}` static-function or a
+                                // `module.exports = class Foo{}` — is called /
+                                // instantiated through the direct
+                                // `perry_fn_<mod>__default` symbol, so it needs
+                                // the same arity / rest / synthetic-arguments /
+                                // return-type / async / class / enum metadata the
+                                // Default specifier propagates below. Without it a
+                                // rest-param default mis-bundles its trailing args
+                                // and a class default has no ImportedClass entry
+                                // (so `new ns()` can't resolve). Key everything by
+                                // the namespace LOCAL, the name the consumer's
+                                // ExternFuncRef carries.
+                                if let Some(&param_count) = exported_func_param_counts.get(&key) {
+                                    imported_param_counts.insert(local.clone(), param_count);
+                                }
+                                if exported_func_has_rest.get(&key).copied().unwrap_or(false) {
+                                    imported_has_rest.insert(local.clone());
+                                }
+                                if exported_func_synthetic_arguments.contains(&key) {
+                                    imported_synthetic_arguments.insert(local.clone());
+                                }
+                                if let Some(return_type) = exported_func_return_types.get(&key) {
+                                    imported_return_types.insert(local.clone(), return_type.clone());
+                                }
+                                if exported_async_funcs.contains(&key) {
+                                    imported_async_set.insert(local.clone());
+                                }
+                                if let Some(class) = exported_classes.get(&key) {
+                                    let class_prefix = canonical_class_source_prefix(
+                                        class,
+                                        &class_canonical_path,
+                                        &ctx.project_root,
+                                        &default_prefix,
+                                    );
+                                    imported_classes.push(imported_class_from_hir(
+                                        class,
+                                        class_prefix,
+                                        Some(local.clone()),
+                                    ));
+                                }
+                                if let Some(members) = exported_enums.get(&key) {
+                                    imported_enums.push((local.clone(), members.clone()));
                                 }
                             }
                         }

--- a/crates/perry/tests/issue_6586_namespace_cjs_default_import.rs
+++ b/crates/perry/tests/issue_6586_namespace_cjs_default_import.rs
@@ -1,0 +1,129 @@
+//! Regression test for #6586: a namespace import of a CommonJS module whose
+//! `module.exports` value is itself the export
+//! (`module.exports = function equal(){}`) — TypeScript's
+//! `esModuleInterop=false` interop shape — must bind the namespace local to the
+//! default export so a DIRECT call of it (`equal(a, b)`) links.
+//!
+//! This is the wall that blocks `fast-json-stringify` (via `ajv`): ajv's
+//! `lib/compile/resolve.ts` does
+//!
+//! ```ts
+//! import * as equal from "fast-deep-equal"
+//! import * as traverse from "json-schema-traverse"
+//! // ...
+//! traverse(schema, {allKeys: true}, (sch) => { /* ... */ })
+//! if (!equal(sch1, sch2)) throw ambiguos(ref)
+//! ```
+//!
+//! where both deps are pure CJS `module.exports = function`. Pre-fix, the
+//! namespace binding had no `import_function_prefixes` entry, so the direct
+//! calls fell through to bare `equal` / `traverse` externs and the link died
+//! with `Undefined symbols: "_equal", "_traverse"`. A DEFAULT import of the
+//! same module (`import equal from "..."`) always linked — the fix routes the
+//! namespace whole-value binding to the module's `default` symbol the same way.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+#[test]
+fn namespace_import_of_cjs_default_function_links_and_calls() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+
+    std::fs::write(
+        root.join("package.json"),
+        r#"{
+  "name": "ns-cjs-default",
+  "private": true,
+  "perry": {
+    "compilePackages": ["fakeequal", "faketraverse"],
+    "allow": { "compilePackages": ["fakeequal", "faketraverse"] }
+  }
+}"#,
+    )
+    .expect("write consumer package.json");
+
+    // fast-deep-equal shape: a bare `module.exports = function`.
+    let equal_pkg = root.join("node_modules").join("fakeequal");
+    std::fs::create_dir_all(&equal_pkg).expect("mkdir fakeequal");
+    std::fs::write(
+        equal_pkg.join("package.json"),
+        r#"{ "name": "fakeequal", "version": "1.0.0", "main": "index.js" }"#,
+    )
+    .expect("write fakeequal package.json");
+    std::fs::write(
+        equal_pkg.join("index.js"),
+        "'use strict';\nmodule.exports = function equal(a, b) { return a === b; };\n",
+    )
+    .expect("write fakeequal index.js");
+
+    // json-schema-traverse shape: `module.exports = fn` PLUS a
+    // `module.exports.default = fn` self-reference (a named `default` on top of
+    // the CJS default value).
+    let traverse_pkg = root.join("node_modules").join("faketraverse");
+    std::fs::create_dir_all(&traverse_pkg).expect("mkdir faketraverse");
+    std::fs::write(
+        traverse_pkg.join("package.json"),
+        r#"{ "name": "faketraverse", "version": "1.0.0", "main": "index.js" }"#,
+    )
+    .expect("write faketraverse package.json");
+    std::fs::write(
+        traverse_pkg.join("index.js"),
+        "'use strict';\nfunction traverse(schema, cb) { cb(schema); return schema.n * 2; }\nmodule.exports = traverse;\nmodule.exports.default = traverse;\n",
+    )
+    .expect("write faketraverse index.js");
+
+    // Consumer imports both as namespaces and CALLS them directly — the exact
+    // ajv `resolve.ts` shape.
+    let entry = root.join("main.ts");
+    std::fs::write(
+        &entry,
+        r#"
+import * as equal from "fakeequal";
+import * as traverse from "faketraverse";
+
+const eq: boolean = (equal as any)({ a: 1 }, { a: 1 } as any) === false;
+console.log("equal:", (equal as any)(1, 1), (equal as any)(1, 2));
+
+let seen = 0;
+const doubled: number = (traverse as any)({ n: 21 }, (_s: any) => { seen++; });
+console.log("traverse:", doubled, "seen:", seen);
+console.log("eq_ref:", eq);
+"#,
+    )
+    .expect("write entry");
+
+    let output = root.join("main_bin");
+    let compile = Command::new(perry_bin())
+        .current_dir(root)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed (namespace-import-of-CJS-default link wall regressed?)\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output).output().expect("run compiled binary");
+    let stdout = String::from_utf8_lossy(&run.stdout);
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        stdout,
+        String::from_utf8_lossy(&run.stderr)
+    );
+    assert_eq!(
+        stdout, "equal: true false\ntraverse: 42 seen: 1\neq_ref: true\n",
+        "namespace import of a CJS default function must call the default export"
+    );
+}

--- a/crates/perry/tests/issue_6586_namespace_cjs_default_import.rs
+++ b/crates/perry/tests/issue_6586_namespace_cjs_default_import.rs
@@ -40,8 +40,8 @@ fn namespace_import_of_cjs_default_function_links_and_calls() {
   "name": "ns-cjs-default",
   "private": true,
   "perry": {
-    "compilePackages": ["fakeequal", "faketraverse"],
-    "allow": { "compilePackages": ["fakeequal", "faketraverse"] }
+    "compilePackages": ["fakeequal", "faketraverse", "fakecls"],
+    "allow": { "compilePackages": ["fakeequal", "faketraverse", "fakecls"] }
   }
 }"#,
     )
@@ -77,6 +77,23 @@ fn namespace_import_of_cjs_default_function_links_and_calls() {
     )
     .expect("write faketraverse index.js");
 
+    // A CJS default that is a CLASS (`module.exports = class Foo {}`) —
+    // exercises the class/metadata propagation for the namespace binding so
+    // `new ns(...)` resolves an ImportedClass entry instead of a phantom
+    // `perry_fn_<mod>__default` function wrapper.
+    let cls_pkg = root.join("node_modules").join("fakecls");
+    std::fs::create_dir_all(&cls_pkg).expect("mkdir fakecls");
+    std::fs::write(
+        cls_pkg.join("package.json"),
+        r#"{ "name": "fakecls", "version": "1.0.0", "main": "index.js" }"#,
+    )
+    .expect("write fakecls package.json");
+    std::fs::write(
+        cls_pkg.join("index.js"),
+        "'use strict';\nmodule.exports = class Box { constructor(x) { this.x = x; } doubled() { return this.x * 2; } };\n",
+    )
+    .expect("write fakecls index.js");
+
     // Consumer imports both as namespaces and CALLS them directly — the exact
     // ajv `resolve.ts` shape.
     let entry = root.join("main.ts");
@@ -85,6 +102,7 @@ fn namespace_import_of_cjs_default_function_links_and_calls() {
         r#"
 import * as equal from "fakeequal";
 import * as traverse from "faketraverse";
+import * as Box from "fakecls";
 
 const eq: boolean = (equal as any)({ a: 1 }, { a: 1 } as any) === false;
 console.log("equal:", (equal as any)(1, 1), (equal as any)(1, 2));
@@ -93,6 +111,10 @@ let seen = 0;
 const doubled: number = (traverse as any)({ n: 21 }, (_s: any) => { seen++; });
 console.log("traverse:", doubled, "seen:", seen);
 console.log("eq_ref:", eq);
+
+// `new` through a namespace binding whose CJS default is a class.
+const b: any = new (Box as any)(21);
+console.log("box:", b.doubled());
 "#,
     )
     .expect("write entry");
@@ -123,7 +145,7 @@ console.log("eq_ref:", eq);
         String::from_utf8_lossy(&run.stderr)
     );
     assert_eq!(
-        stdout, "equal: true false\ntraverse: 42 seen: 1\neq_ref: true\n",
-        "namespace import of a CJS default function must call the default export"
+        stdout, "equal: true false\ntraverse: 42 seen: 1\neq_ref: true\nbox: 42\n",
+        "namespace import of a CJS default function/class must resolve the default export"
     );
 }


### PR DESCRIPTION
## Summary

Progresses **#6586** (fast-json-stringify@7 native compile). On current `main`, compiling `fast-json-stringify` no longer even reaches the reported `ReferenceError: module is not defined` — it fails earlier at **link time** with:

```
Undefined symbols for architecture arm64:
  "_equal",    referenced from: … in node_modules_ajv_lib_compile_resolve_ts.o
  "_traverse", referenced from: … in node_modules_ajv_lib_compile_resolve_ts.o
```

This PR fixes that link wall. Afterwards fjs compiles **and links**, and running it reproduces exactly the `module is not defined` the issue describes (a separate, deeper wall — see "Remaining work" below).

## Root cause

For `compilePackages` targets, `resolve_package_source_entry` (#2569) redirects a package's entry to its original TypeScript source via the source map, so `ajv`'s entry `dist/ajv.js` resolves to `lib/ajv.ts` and the whole ajv tree compiles from `lib/*.ts`. Those `.ts` files are written for **tsc's CommonJS emit** (`esModuleInterop=false`), and `lib/compile/resolve.ts` does:

```ts
import * as equal from "fast-deep-equal"          // module.exports = function equal(){}
import * as traverse from "json-schema-traverse"  // module.exports = function traverse(){}
// …
traverse(schema, {allKeys: true}, (sch) => { /* … */ })
if (!equal(sch1, sch2)) throw ambiguos(ref)
```

`fast-deep-equal` / `json-schema-traverse` are pure CJS `module.exports = function`. Under TypeScript's non-`esModuleInterop` semantics, `import * as equal` binds `equal` to the whole `require()` result (the default export), so a **direct call `equal(a, b)`** is a call of that value.

Perry's CJS wrap already emits that value as the module's public `default` symbol (`perry_fn_<mod>__default`), and a **default import** of the same module (`import equal from "fast-deep-equal"; equal(…)`) links and runs correctly. But a **namespace import** never got an `import_function_prefixes` / `import_function_origin_names` entry for its whole-value binding, so the direct call fell through to a bare `equal` extern → undefined symbol `_equal`.

## Fix

`crates/perry/src/commands/compile/run_pipeline.rs` — in the namespace-import branch, when the target module has a `default` export, wire the namespace local's whole-value binding to that `default` symbol, exactly like a Default specifier does:

- `import_function_prefixes[local]` → the default's origin prefix
- `import_function_origin_names[local]` → `"default"` (or the resolved re-export origin name)
- and, when the default is var-shaped (a `module.exports = <expr>` value emitted as a zero-arg getter), add the local to `imported_vars` so the call site does `getter + js_closure_callN(args)` instead of treating the getter's return value as the call result.

Namespace **member** reads (`ns.foo`) are keyed per-namespace via `namespace_member_prefixes` and are unaffected. The `#4872` default-import-of-a-named-only-barrel case that also lands in this branch has no `default` export and is skipped. Consumer-side only — no runtime/codegen change; the exporting module already emits the `default` symbol as public.

## Verification

- New `crates/perry/tests/issue_6586_namespace_cjs_default_import.rs`: a `import * as equal from "cjs-default-fn-pkg"; equal(1, 1)` fixture (both the `fast-deep-equal` and `json-schema-traverse` shapes) now compiles, links and prints the expected values. Pre-fix it failed the link with `Undefined symbols: "_equal"`.
- `fast-json-stringify@7` (via the `#[ignore]`d `real_fast_json_stringify_serializer` e2e) now compiles and links; the failure moves from the link wall to the runtime `module is not defined` the issue documents.
- A **default** import of the same module still links and runs identically (no regression); `issue_4872_barrel_default_reexports` (which exercises the same namespace-like machinery) still passes.

## Remaining work (not in this PR)

The `module is not defined` in the issue title is the **next** wall, now reproducible. Root cause: ajv's `lib/*.ts` are **dual ESM+CJS** files — ESM `import`/`export default Ajv` (so Perry classifies them ESM and skips the CJS wrap) plus a trailing `module.exports = exports = Ajv` for tsc's CJS emit. Compiled as ESM, that trailing dead-code line reads an unbound `module` and throws at load. Both walls share the same deeper cause: Perry compiles ajv's `lib/*.ts` (written for tsc CJS output, never loaded by Node) instead of the `dist/*.js` CJS that Node actually loads. That's a larger change (either narrow #2569 for dual files, or inject ambient `module`/`exports` bindings for dual ESM+CJS files) and is left as a follow-up.

No version bump / changelog per request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of `import * as <local> from "<cjs-module>"` for CommonJS modules that export their “default” via `module.exports` (no `__esModule` interop marker).
  * Direct calls and `new` through these namespace bindings now resolve to the correct CommonJS default implementation and link/execute properly.

* **Tests**
  * Added a regression test for issue coverage around CommonJS namespace imports, validating the generated binary runs and matches expected stdout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->