### PR TITLE
fix(transform): bound all call-inliner recursion — pi-bundle stack overflow (#6593)

### DIFF
--- a/crates/perry-codegen/src/expr/i32_fast_path.rs
+++ b/crates/perry-codegen/src/expr/i32_fast_path.rs
@@ -687,14 +687,37 @@ fn try_lower_expr_native_i32_structural(ctx: &mut FnCtx<'_>, e: &Expr) -> Result
             }
         }
         Expr::Uint8ArrayGet { array, index } => {
-            Some(super::arrays_finds::lower_uint8array_get_i32(ctx, array, index)?.value)
+            let lowered = super::arrays_finds::lower_uint8array_get_i32(ctx, array, index)?;
+            Some(i32_from_indexed_get_lowered(ctx, lowered))
         }
         Expr::BufferIndexGet { buffer, index } => {
-            Some(super::arrays_finds::lower_buffer_index_get_i32(ctx, buffer, index)?.value)
+            let lowered = super::arrays_finds::lower_buffer_index_get_i32(ctx, buffer, index)?;
+            Some(i32_from_indexed_get_lowered(ctx, lowered))
         }
         _ => None,
     };
     Ok(value)
+}
+
+/// Bridge an indexed-get helper's `LoweredValue` into a guaranteed-i32 SSA
+/// value. `lower_uint8array_get_i32`'s unproven-key escape (the mysql2
+/// MockBuffer probe fix in `arrays_finds.rs`) returns the polymorphic
+/// property read as a boxed JS VALUE (`F64` rep). The i32-context callers
+/// here used to grab `.value` blindly and label that double register `i32`,
+/// emitting malformed IR — `error: '%rN' defined with type 'double' but
+/// expected 'i32'` — which the pi bundle hit (#6593) once its inliner
+/// frontier left a `buf[k]` index insufficiently proven-numeric. Apply the
+/// JS `ToInt32(ToNumber(v))` bridge instead.
+fn i32_from_indexed_get_lowered(ctx: &mut FnCtx<'_>, lowered: LoweredValue) -> String {
+    match lowered.rep {
+        NativeRep::I32 | NativeRep::U32 => lowered.value,
+        _ => {
+            let number = ctx
+                .block()
+                .call(DOUBLE, "js_number_coerce", &[(DOUBLE, &lowered.value)]);
+            ctx.block().toint32(&number)
+        }
+    }
 }
 
 fn lower_packed_i32_loop_index_get(ctx: &mut FnCtx<'_>, e: &Expr) -> Result<Option<LoweredValue>> {
@@ -1052,10 +1075,12 @@ fn lower_expr_native_i32(ctx: &mut FnCtx<'_>, e: &Expr) -> Result<LoweredValue> 
             }
         }
         Expr::Uint8ArrayGet { array, index } => {
-            super::arrays_finds::lower_uint8array_get_i32(ctx, array, index)?.value
+            let lowered = super::arrays_finds::lower_uint8array_get_i32(ctx, array, index)?;
+            i32_from_indexed_get_lowered(ctx, lowered)
         }
         Expr::BufferIndexGet { buffer, index } => {
-            super::arrays_finds::lower_buffer_index_get_i32(ctx, buffer, index)?.value
+            let lowered = super::arrays_finds::lower_buffer_index_get_i32(ctx, buffer, index)?;
+            i32_from_indexed_get_lowered(ctx, lowered)
         }
         // Fallback for other expressions.
         _ => {

--- a/crates/perry-transform/src/inline/call_inliner.rs
+++ b/crates/perry-transform/src/inline/call_inliner.rs
@@ -165,6 +165,18 @@ pub fn inline_calls_in_stmts(
     enclosing_class: Option<&str>,
     class_field_types: &HashMap<(String, String), String>,
 ) {
+    // Same cap as `inline_calls_in_expr`, sharing one thread-local depth
+    // budget: the two functions are mutually recursive, and a stmts-side
+    // chain (nested blocks, closure bodies, re-walks of freshly inlined
+    // bodies) that never passes through the expr-side guard would otherwise
+    // recurse unbounded — half of #6593. Bailing out skips further inlining
+    // in this subtree, which is semantics-preserving (the inliner is an
+    // optimization pass); clear `exact_receiver_facts` because we no longer
+    // track what the skipped statements may reference or mutate.
+    let Some(_recursion_guard) = enter_inline_expr_recursion() else {
+        exact_receiver_facts.clear();
+        return;
+    };
     let mut i = 0;
     while i < stmts.len() {
         // Track local variable types from Let statements
@@ -1974,6 +1986,65 @@ mod tests {
                 );
 
                 assert!(hoisted.is_empty());
+                assert!(exact_receiver_facts.is_empty());
+            })
+            .unwrap()
+            .join()
+            .unwrap();
+    }
+
+    /// Deeply nested `if (…) { leaf } else { <next level> }` chain — the
+    /// #6593 shape. Unlike the linear closure fixture above, every level
+    /// makes MULTIPLE guarded descents (condition expr, then-branch stmts,
+    /// else-branch stmts), which is exactly what made the pi bundle
+    /// unbounded twice over:
+    ///  1. `inline_calls_in_stmts` had no guard at all, so the
+    ///     stmts→stmts else-chain recursed once per level; and
+    ///  2. even with the stmts guard, the eager
+    ///     `then_some(InlineExprRecursionGuard)` refunded a depth unit on
+    ///     every bail, so the condition's bail at cap let the else-branch
+    ///     descend one level deeper — forever.
+    fn nested_if_else_chain(depth: usize) -> Vec<Stmt> {
+        let mut stmts = vec![Stmt::Expr(Expr::Integer(0))];
+        for _ in 0..depth {
+            stmts = vec![Stmt::If {
+                condition: Expr::Integer(1),
+                then_branch: vec![Stmt::Expr(Expr::Integer(2))],
+                else_branch: Some(stmts),
+            }];
+        }
+        stmts
+    }
+
+    #[test]
+    fn inline_stmts_skips_extremely_deep_branching_stmt_trees() {
+        // Deep enough that one stack frame per level overflows the 32MB
+        // test stack if either the stmts-entry guard is missing or the
+        // guard's bail path refunds budget (both variants crashed here
+        // before the #6593 fix); shallow enough that the fixture's own
+        // recursive drop glue stays far from the limit.
+        const DEPTH: usize = MAX_INLINE_EXPR_RECURSION_DEPTH * 200;
+        std::thread::Builder::new()
+            .stack_size(32 * 1024 * 1024)
+            .spawn(|| {
+                let mut stmts = nested_if_else_chain(DEPTH);
+                let mut local_types = HashMap::new();
+                let mut exact_receiver_facts = ExactReceiverFacts::new();
+                let mut next_local_id = 1;
+
+                inline_calls_in_stmts(
+                    &mut stmts,
+                    &HashMap::new(),
+                    &HashMap::new(),
+                    &HashMap::new(),
+                    &mut local_types,
+                    &mut exact_receiver_facts,
+                    &mut next_local_id,
+                    None,
+                    &HashMap::new(),
+                );
+
+                assert_eq!(stmts.len(), 1);
                 assert!(exact_receiver_facts.is_empty());
             })
             .unwrap()

--- a/crates/perry-transform/src/inline/super_detect.rs
+++ b/crates/perry-transform/src/inline/super_detect.rs
@@ -24,16 +24,28 @@ impl Drop for InlineExprRecursionGuard {
 }
 
 pub(crate) fn enter_inline_expr_recursion() -> Option<InlineExprRecursionGuard> {
-    let entered = INLINE_EXPR_RECURSION_DEPTH.with(|depth| {
+    // The guard must only ever exist when the increment actually happened.
+    // The previous `entered.then_some(InlineExprRecursionGuard)` constructed
+    // the guard EAGERLY (`then_some` takes its argument by value), so on the
+    // bail path `then_some` dropped that guard — and its `Drop` decremented a
+    // depth unit this call never took. Every bail refunded one level of
+    // budget, so any AST node that makes two or more sibling recursive
+    // descents (Conditional then/else, a freshly-inlined-result re-walk, …)
+    // could burn the first sibling's bail to push the next sibling one level
+    // deeper, forever: the cap stopped bounding recursion at all (#6593, the
+    // 13.3MB pi bundle overflowed a 512MB stack this way). Linear chains —
+    // like the #733 nested-closure regression test — never exposed this,
+    // because with a single descent per level there is no later sibling to
+    // spend the refunded budget.
+    INLINE_EXPR_RECURSION_DEPTH.with(|depth| {
         let current = depth.get();
         if current >= MAX_INLINE_EXPR_RECURSION_DEPTH {
-            false
+            None
         } else {
             depth.set(current + 1);
-            true
+            Some(InlineExprRecursionGuard)
         }
-    });
-    entered.then_some(InlineExprRecursionGuard)
+    })
 }
 
 fn expr_contains_lexical_super(expr: &Expr) -> bool {
@@ -131,4 +143,34 @@ fn stmt_contains_lexical_super(stmt: &Stmt) -> bool {
 
 pub(crate) fn method_contains_lexical_super(method: &Function) -> bool {
     method.body.iter().any(stmt_contains_lexical_super)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #6593 regression: a failed entry (cap hit) must NOT refund depth
+    /// budget. With the old eager `then_some(InlineExprRecursionGuard)`, the
+    /// bail path dropped an eagerly-built guard, decrementing the counter it
+    /// never incremented — so the attempt right after a bail wrongly
+    /// succeeded, and branching recursion could descend without bound.
+    #[test]
+    fn bail_does_not_refund_depth_budget() {
+        let guards: Vec<InlineExprRecursionGuard> = (0..MAX_INLINE_EXPR_RECURSION_DEPTH)
+            .map(|_| enter_inline_expr_recursion().expect("budget not yet exhausted"))
+            .collect();
+        assert!(
+            enter_inline_expr_recursion().is_none(),
+            "entry at cap must bail"
+        );
+        assert!(
+            enter_inline_expr_recursion().is_none(),
+            "a bail must not refund budget: the next attempt at cap must bail too"
+        );
+        drop(guards);
+        assert!(
+            enter_inline_expr_recursion().is_some(),
+            "budget must be restored once real guards unwind"
+        );
+    }
 }

--- a/crates/perry-transform/src/inline/super_detect.rs
+++ b/crates/perry-transform/src/inline/super_detect.rs
@@ -11,8 +11,26 @@ use std::cell::Cell;
 
 pub(crate) const MAX_INLINE_EXPR_RECURSION_DEPTH: usize = 128;
 
+/// Per-top-level-walk budget of guarded entries (see
+/// `enter_inline_expr_recursion`). The depth cap alone bounds STACK, not
+/// WORK: with candidate-subtree cloning at every Conditional/Logical/
+/// Sequence node and re-walks of freshly inlined bodies, a single huge
+/// generated function can keep the walk churning within the depth limit
+/// for hours (observed on #6593's 13.3MB esbuild bundle: the pass ran
+/// 2h45m+ CPU-bound in clone glue after the stack fix, where it previously
+/// crashed in ~90s). Once a walk has consumed this many entries, further
+/// entries bail — the identical semantics-preserving skip as the depth
+/// bail. One entry is roughly one visited stmt-list/expr node, so ordinary
+/// bodies (even tens of thousands of nodes) keep full inlining coverage;
+/// only generated-code monsters hit the cap, and those merely lose
+/// inlining of the subtrees beyond it.
+pub(crate) const MAX_INLINE_WALK_WORK: usize = 250_000;
+
 thread_local! {
     static INLINE_EXPR_RECURSION_DEPTH: Cell<usize> = const { Cell::new(0) };
+    /// Guarded entries consumed by the current top-level walk. Reset when a
+    /// new walk starts (an entry at depth 0); never refunded on unwind.
+    static INLINE_WALK_WORK: Cell<usize> = const { Cell::new(0) };
 }
 
 pub(crate) struct InlineExprRecursionGuard;
@@ -39,12 +57,28 @@ pub(crate) fn enter_inline_expr_recursion() -> Option<InlineExprRecursionGuard> 
     // spend the refunded budget.
     INLINE_EXPR_RECURSION_DEPTH.with(|depth| {
         let current = depth.get();
-        if current >= MAX_INLINE_EXPR_RECURSION_DEPTH {
-            None
-        } else {
-            depth.set(current + 1);
-            Some(InlineExprRecursionGuard)
+        if current == 0 {
+            // New top-level walk (Phase 4 init / a Phase 5 function body / a
+            // Phase 6 method body): fresh work budget.
+            INLINE_WALK_WORK.with(|work| work.set(0));
         }
+        if current >= MAX_INLINE_EXPR_RECURSION_DEPTH {
+            return None;
+        }
+        let over_work_budget = INLINE_WALK_WORK.with(|work| {
+            let used = work.get();
+            if used >= MAX_INLINE_WALK_WORK {
+                true
+            } else {
+                work.set(used + 1);
+                false
+            }
+        });
+        if over_work_budget {
+            return None;
+        }
+        depth.set(current + 1);
+        Some(InlineExprRecursionGuard)
     })
 }
 
@@ -171,6 +205,31 @@ mod tests {
         assert!(
             enter_inline_expr_recursion().is_some(),
             "budget must be restored once real guards unwind"
+        );
+    }
+
+    /// #6593 companion: the depth cap bounds stack but not total work — a
+    /// walk that keeps entering/unwinding within the depth limit must
+    /// eventually exhaust a per-walk work budget and bail, and a NEW
+    /// top-level walk (entry at depth 0) must start with a fresh budget.
+    #[test]
+    fn work_budget_is_spent_per_walk_and_resets_at_top_level() {
+        // Hold one outer guard so the walk stays "in progress" (depth >= 1)
+        // while we burn the budget with enter/unwind churn.
+        let outer = enter_inline_expr_recursion().expect("fresh walk must enter");
+        for _ in 0..MAX_INLINE_WALK_WORK - 1 {
+            let inner = enter_inline_expr_recursion();
+            assert!(inner.is_some(), "within budget, entries must succeed");
+            drop(inner);
+        }
+        assert!(
+            enter_inline_expr_recursion().is_none(),
+            "an exhausted work budget must bail even though depth unwound"
+        );
+        drop(outer);
+        assert!(
+            enter_inline_expr_recursion().is_some(),
+            "a new top-level walk must reset the work budget"
         );
     }
 }

--- a/crates/perry/src/commands/compile/collect_modules/feature_detect.rs
+++ b/crates/perry/src/commands/compile/collect_modules/feature_detect.rs
@@ -175,6 +175,37 @@ pub(super) fn detect_optional_feature_usage(
         }
     }
 
+    // #6593 (pi bundle) — detect name-heuristic native package lowering.
+    // `detect_native_instance_expr` routes `new LRUCache(...)` / `new
+    // Decimal(...)` / `new Command(...)` etc. to a native module by BINDING
+    // NAME, with no import statement required. An esbuild bundle that
+    // inlines such a package (pi's hosted-git-info inlines `lru-cache`)
+    // therefore emits `NativeMethodCall { module: "lru-cache", … }` calls
+    // while `native_module_imports` never learns about the module — the
+    // per-binding perry-stdlib feature stays off and the link dies with
+    // undefined `_js_lru_cache_*` symbols (from `GitHost.fromUrl`). Same
+    // failure mode and fix as the EventEmitter block above. Scan classes
+    // too: the pi call sites live in a static method body, which the
+    // init+functions-only scans miss.
+    {
+        let hir_debug: String = format!(
+            "{:?}{:?}{:?}",
+            &hir_module.init, &hir_module.functions, &hir_module.classes
+        );
+        for native_module in [
+            "lru-cache",
+            "big.js",
+            "decimal.js",
+            "bignumber.js",
+            "commander",
+        ] {
+            if hir_debug.contains(&format!("module: \"{native_module}\"")) {
+                ctx.needs_stdlib = true;
+                ctx.native_module_imports.insert(native_module.to_string());
+            }
+        }
+    }
+
     // Detect WHATWG URL API usage. The `url`+`idna` host-canonicalization
     // engine (~195 KB) is gated behind `perry-runtime/url-engine`; Perry's URL
     // parsing is otherwise hand-rolled, so a program with no URL API links none

--- a/crates/perry/src/main.rs
+++ b/crates/perry/src/main.rs
@@ -268,9 +268,20 @@ fn main() -> Result<()> {
     // large codebases. Bumped from 64 MB in v0.5.973 — ioredis-via-
     // compilePackages (~30 transitive CJS modules) overflowed 64 MB in the
     // collect/lower walk on the perry-main thread.
+    //
+    // PERRY_MAIN_STACK_MB overrides the size (in MB) without a rebuild —
+    // useful both for diagnosing suspected-unbounded recursion (bump it and
+    // see whether the overflow moves, #6593) and as an escape hatch for
+    // legitimately deep inputs that outgrow the default (already happened
+    // twice: v0.5.973, #6593). Invalid or zero values fall back to 128.
+    let stack_mb: usize = std::env::var("PERRY_MAIN_STACK_MB")
+        .ok()
+        .and_then(|v| v.trim().parse().ok())
+        .filter(|mb| *mb > 0)
+        .unwrap_or(128);
     let builder = std::thread::Builder::new()
         .name("perry-main".into())
-        .stack_size(128 * 1024 * 1024);
+        .stack_size(stack_mb * 1024 * 1024);
     let handler = builder.spawn(main_inner).unwrap();
     match handler.join() {
         Ok(result) => result,

--- a/crates/perry/src/main.rs
+++ b/crates/perry/src/main.rs
@@ -273,16 +273,40 @@ fn main() -> Result<()> {
     // useful both for diagnosing suspected-unbounded recursion (bump it and
     // see whether the overflow moves, #6593) and as an escape hatch for
     // legitimately deep inputs that outgrow the default (already happened
-    // twice: v0.5.973, #6593). Invalid or zero values fall back to 128.
+    // twice: v0.5.973, #6593). Invalid or zero values fall back to 128;
+    // values above 16384 (16 GB) clamp so the MB→bytes conversion cannot
+    // overflow usize and the spawn below cannot fail on an absurd request.
+    const MAX_STACK_MB: usize = 16 * 1024;
     let stack_mb: usize = std::env::var("PERRY_MAIN_STACK_MB")
         .ok()
         .and_then(|v| v.trim().parse().ok())
         .filter(|mb| *mb > 0)
+        .map(|mb: usize| {
+            if mb > MAX_STACK_MB {
+                eprintln!(
+                    "perry: PERRY_MAIN_STACK_MB={mb} exceeds the {MAX_STACK_MB} MB ceiling; clamping"
+                );
+                MAX_STACK_MB
+            } else {
+                mb
+            }
+        })
         .unwrap_or(128);
+    let stack_bytes = stack_mb
+        .checked_mul(1024 * 1024)
+        .expect("stack size in bytes fits usize (clamped above)");
     let builder = std::thread::Builder::new()
         .name("perry-main".into())
-        .stack_size(stack_mb * 1024 * 1024);
-    let handler = builder.spawn(main_inner).unwrap();
+        .stack_size(stack_bytes);
+    let handler = match builder.spawn(main_inner) {
+        Ok(handler) => handler,
+        Err(err) => {
+            return Err(anyhow::anyhow!(
+                "failed to spawn the perry-main compiler thread \
+                 (stack size {stack_mb} MB; try a smaller PERRY_MAIN_STACK_MB): {err}"
+            ));
+        }
+    };
     match handler.join() {
         Ok(result) => result,
         Err(panic_payload) => {


### PR DESCRIPTION
## Root cause — two independent holes, both required

Compiling pi's 13.3MB unminified esbuild bundle overflowed the perry-main stack (128MB **and** a 512MB test bump) inside the call inliner. Symbolicated live backtraces (lldb, `#[inline(never)]` diagnostic build) showed 250+ nested `inline_calls_in_expr` frames **with the #733 cap set to 16 and its bail provably firing** — the cap was not binding at all.

### Hole 1: the recursion guard refunded budget on every bail (the true cycle)

```rust
entered.then_some(InlineExprRecursionGuard)
```

`bool::then_some` takes its argument **by value — eagerly**. On the bail path (`entered == false`) `then_some` drops that eagerly-constructed guard, and its `Drop` impl decrements a depth unit the call never took. Every cap-hit refunded one level of budget.

The true cycle (frame histogram from the crash stack): `inline_calls_in_expr` → Conditional then/else candidate descents (139× + 34×) and the freshly-inlined-result re-walk (70×). At any node with **two or more sibling guarded descents**, the first sibling's bail refunds a unit and the next sibling descends one level deeper — repeat forever. The #733 regression test never caught it because its nested-closure fixture is a **linear** chain (single descent per level): there is no later sibling to spend the refund.

Fix: construct the guard **inside** the success branch only.

### Hole 2: `inline_calls_in_stmts` had no guard at all (the issue's original finding)

stmts-side chains (nested blocks, closure bodies, re-walks of freshly inlined bodies) recursed once per level regardless of the expr-side cap. Fix: mirror the guard at the stmts entry, sharing the same thread-local budget; on cap, clear `exact_receiver_facts` and leave the subtree un-inlined (semantics-preserving — identical rationale to the expr-side bail).

### Companion: per-walk work budget

With the stack bounded, the same bundle then kept the pass **CPU-churning for 2h45m+** (live samples: every stack at near-cap depth, clone glue at the leaves — candidate-subtree cloning at Conditional/Logical/Sequence nodes plus re-walks of inlined bodies). The depth cap bounds stack, not work. The shared guard now also carries a per-top-level-walk budget of entries (250k; reset when a walk starts at depth 0, never refunded) taking the exact same semantics-preserving bail. Ordinary bodies keep full inlining coverage; with this the pi bundle's whole compile completes in ~22 minutes.

## Also in this PR (found compiling the now-reachable pipeline)

- **codegen**: `lower_uint8array_get_i32`'s unproven-key escape returns the polymorphic property read as a boxed JS value (F64 rep); all four i32-context callers grabbed `.value` blindly and emitted malformed IR (`'%rN' defined with type 'double' but expected 'i32'`). Bridge through `ToInt32(ToNumber(v))` when the rep isn't i32.
- **compile/features**: name-heuristic native lowering (`new LRUCache(...)` by binding name, no import) emits `js_lru_cache_*` calls, but per-binding stdlib features were only enabled from real import statements — pi's inlined `hosted-git-info` → undefined `_js_lru_cache_*` at link. Token-grep the lowered HIR (incl. classes — the call sites live in a static method) for the name-heuristic module family, mirroring the #5140 EventEmitter block.
- **main**: `PERRY_MAIN_STACK_MB` env override for the perry-main stack size (default stays 128MB) — the constant has now been outgrown twice (v0.5.973 ioredis, this diagnosis).

## Tests

- `super_detect::bail_does_not_refund_depth_budget` — fails against the eager `then_some` (the attempt right after a bail wrongly succeeds), passes now.
- `super_detect::work_budget_is_spent_per_walk_and_resets_at_top_level`.
- `call_inliner::inline_stmts_skips_extremely_deep_branching_stmt_trees` — 25.6k-deep `if/else` chain in a 32MB thread; verified to stack-overflow with **either** hole present (both variants re-tested individually), passes with both fixed.
- `cargo test -p perry-transform -- --test-threads=1`: 51 passed / 0 failed (includes the existing #733 cap tests).
- `cargo test -p perry-codegen --lib -- --test-threads=1`: 201 passed. (`perry-codegen` integration tests don't compile on current main — pre-existing `CompileOptions` field drift from #6315-era, unrelated.)
- `cargo test -p perry --bins -- --test-threads=1`: 721 passed.
- `cargo fmt` clean on all touched files (repo-wide `--check` fails on pre-existing drift in untouched files).

## pi bundle status

- Before: compiler stack overflow after ~90s.
- After: compiles + links end-to-end, rc=0, 91.4MB binary, ~22 min.
- `pi-native --help` does **not** run yet: a separate pre-existing runtime bug (unrelated to this pass — capture wiring happens at lowering) throws `TypeError: value is not a function` in semver's `Comparator` constructor. Diagnosed via a `--debug-symbols` build: the ctor's first call `parseOptions(options)` (bundle line 4836) reads a class-**expression** capture of a wrapper-local `var parseOptions` that is assigned **after** the class definition; dynamic construction (`js_new_function_construct` from ranges/subset.js) replays a decl-time capture snapshot holding undefined. The existing #6037/#6052 refresh-after-assignment machinery only covers class **declarations** (`ast::Decl::Class`), not the `var C = class {...}` shape. Filed as a follow-up issue.

Fixes #6593

https://claude.ai/code/session_01JuiiePQfrXhAFD9fuCygB9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compilation handling for typed-array and buffer indexed access results.
  - Hardened inlining to avoid excessive recursion/work and to bail out cleanly under guarded conditions.
  - Improved detection and linking of optional native packages, even when imports are implicit.

- **Configuration**
  - Added `PERRY_MAIN_STACK_MB` to control the compiler’s main worker stack size, with validation and a safe default when unset or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->