### PR TITLE
perf(runtime): gate node:http2 constant tables behind mod-http2-constants (#6468)

### DIFF
--- a/crates/perry-runtime/Cargo.toml
+++ b/crates/perry-runtime/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["rlib"]
 # actually needs (see optimized_libs.rs), so the heavy subsystems below
 # (regex engine, Temporal, URL/IDNA, normalize, segmenter) are *opt-in per
 # app* and absent from binaries that never use them.
-default = ["full", "regex-engine", "temporal", "url-engine", "string-normalize", "intl-segmenter", "intl-locale", "intl-datetime", "diagnostics", "mod-dgram", "dyn-eval"]
+default = ["full", "regex-engine", "temporal", "url-engine", "string-normalize", "intl-segmenter", "intl-locale", "intl-datetime", "diagnostics", "mod-dgram", "mod-http2-constants", "dyn-eval"]
 # Per-module Node-API gate (binary-size): compiles `node:dgram`'s UDP-socket
 # implementation (`crate::dgram` + `crate::dgram_reactor`, ~2.2k LOC, incl. the
 # `js_dgram_*` externs codegen emits direct calls to) + its dispatch arm only
@@ -29,6 +29,18 @@ default = ["full", "regex-engine", "temporal", "url-engine", "string-normalize",
 # the first instance of a general per-module gating pattern; more modules can
 # follow the same shape.)
 mod-dgram = []
+# Per-module Node-API gate (binary-size, issue #6468): compiles the
+# `node:http2` module-level constant tables (`crate::node_http2_constants` —
+# the NGHTTP2_*/HTTP_STATUS_* number tables, the `http2.constants`
+# sub-namespace key list, and the lazily-materialized `sensitiveHeaders`
+# symbol, ~20 KB of otherwise-unreachable cold data) only when the program
+# imports `node:http2`. The compiler enables it on `http2` in
+# `native_module_imports` (see `auto_optimized_cross_features`), so a program
+# that never imports `http2` links none of these tables and macOS
+# `-dead_strip` recovers the space. Pure cfg gate, no extra deps. This gates
+# only the constant tables — the HTTP/2 server surface (`js_node_http2_*`) is
+# unaffected (it lives in perry-ext-http-server, routed via `http-client`).
+mod-http2-constants = []
 # Cold-path diagnostic JSON serializers (~67 KB of code + the `serde_json`
 # pulled only by them, which dead-strips when unreferenced): GC cycle telemetry
 # (`PERRY_GC_DIAG`), typed-feedback trace dump (`PERRY_TYPED_FEEDBACK`), the v8

--- a/crates/perry-runtime/src/lib.rs
+++ b/crates/perry-runtime/src/lib.rs
@@ -84,6 +84,11 @@ pub mod native_arena;
 pub mod native_handle;
 pub mod navigator;
 pub mod net_validate;
+// #6468: the `node:http2` constant tables are only reachable through the
+// `http2` native-module namespace, so a program that never imports `node:http2`
+// links none of them. The auto-optimizer enables `mod-http2-constants` on an
+// `http2` import; every callsite has a benign `None`/no-op fallback when off.
+#[cfg(feature = "mod-http2-constants")]
 pub mod node_http2_constants;
 pub mod node_inspector;
 pub mod node_repl;

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -235,6 +235,10 @@ pub fn scan_native_callable_export_roots_mut(visitor: &mut crate::gc::RuntimeRoo
             visitor.visit_nanbox_u64_slot(value_bits);
         }
     });
+    // #6468: only present when the program imports `node:http2`; when the gate
+    // is off the `sensitiveHeaders` symbol slot doesn't exist, so there's no
+    // root to scan.
+    #[cfg(feature = "mod-http2-constants")]
     crate::node_http2_constants::scan_roots_mut(visitor);
     scan_stream_event_emitter_prototype_roots_mut(visitor);
 }

--- a/crates/perry-runtime/src/object/native_module/constants.rs
+++ b/crates/perry-runtime/src/object/native_module/constants.rs
@@ -1462,6 +1462,13 @@ pub(crate) unsafe fn get_native_module_constant(
         // `createSecureServer` exports are handled elsewhere (#1651).
         "http2" => match property {
             "constants" => Some(create_sub_namespace("http2.constants")),
+            // #6468: `sensitiveHeaders` / `http2.constants` are the only http2
+            // props backed by `crate::node_http2_constants`, gated behind
+            // `mod-http2-constants`. This whole `"http2"` arm is only reached
+            // through the http2 namespace object, which materializes on a
+            // `node:http2` import — the same signal that enables the gate — so
+            // the `None` fallback when the gate is off is never observed.
+            #[cfg(feature = "mod-http2-constants")]
             "sensitiveHeaders" => Some(crate::node_http2_constants::sensitive_headers_symbol()),
             // `Http2ServerRequest` / `Http2ServerResponse` imported as VALUES are
             // used by libraries purely for `req instanceof Http2ServerRequest`
@@ -1483,6 +1490,7 @@ pub(crate) unsafe fn get_native_module_constant(
             "default" => Some(native_namespace_or_create("http2", namespace_obj)),
             _ => None,
         },
+        #[cfg(feature = "mod-http2-constants")]
         "http2.constants" => crate::node_http2_constants::constant(property),
         "dns" => dns_const(property),
         // node:cluster — primary-side settings and Worker handles are backed

--- a/crates/perry-runtime/src/object/native_module/module_keys.rs
+++ b/crates/perry-runtime/src/object/native_module/module_keys.rs
@@ -1812,7 +1812,13 @@ pub(crate) fn native_module_enumerable_keys(module_name: &str) -> Option<&'stati
             b"request",
             b"globalAgent",
         ]),
+        // #6468: the http2 namespace + `http2.constants` key lists live in
+        // `crate::node_http2_constants`, gated behind `mod-http2-constants`.
+        // These keys are only enumerated for an existing http2 namespace object,
+        // which only exists after a `node:http2` import turns the gate on.
+        #[cfg(feature = "mod-http2-constants")]
         "http2" => Some(crate::node_http2_constants::HTTP2_NAMESPACE_KEYS),
+        #[cfg(feature = "mod-http2-constants")]
         "http2.constants" => Some(crate::node_http2_constants::HTTP2_CONSTANTS_KEYS),
         // #3906: native-module default/namespace objects previously enumerated
         // only the internal `__module__` sentinel. List each module's supported

--- a/crates/perry/src/commands/compile/optimized_libs/freshness.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/freshness.rs
@@ -63,7 +63,7 @@ pub(crate) fn auto_optimized_cache_key(
 ) -> String {
     let target_str = target.unwrap_or("host");
     format!(
-        "{}|{}|{}|wasm={}|regex={}|temporal={}|ee={}|url={}|norm={}|seg={}|loc={}|diag={}|dgram={}|dyneval={}|v={}",
+        "{}|{}|{}|wasm={}|regex={}|temporal={}|ee={}|url={}|norm={}|seg={}|loc={}|diag={}|dgram={}|http2={}|dyneval={}|v={}",
         feature_arg,
         panic_abort_safe,
         target_str,
@@ -77,6 +77,10 @@ pub(crate) fn auto_optimized_cache_key(
         ctx.uses_intl_locale,
         ctx.uses_diagnostics,
         ctx.uses_dgram,
+        // #6468: an http2 import pulls in `perry-runtime/mod-http2-constants`,
+        // so a runtime built without the constant tables must not be reused for
+        // an http2 program — key the freshness stamp on it like the other gates.
+        ctx.native_module_imports.contains("http2"),
         // #6559: dyn-eval presence changes the built archive, so it must
         // key the freshness stamp like every other runtime feature toggle.
         perry_hir::has_deferred_dynamic_code_sites(),
@@ -150,6 +154,15 @@ pub(crate) fn auto_optimized_cross_features(
     }
     if ctx.uses_dgram {
         cross_features.push("perry-runtime/mod-dgram".to_string());
+    }
+    // #6468 — the `node:http2` constant tables (`node_http2_constants`, ~20 KB
+    // of NGHTTP2_*/HTTP_STATUS_* cold data) are only reachable through the http2
+    // namespace object, which only exists when the program imports `node:http2`.
+    // `http2` is a stdlib-backed module, so its import is recorded in
+    // `native_module_imports` — a reliable, zero-false-negative activation
+    // signal. A program that never imports it links none of the tables.
+    if ctx.native_module_imports.contains("http2") {
+        cross_features.push("perry-runtime/mod-http2-constants".to_string());
     }
     // #6559: a deferred dynamic-code site (`eval(...)` / `new Function(...)`
     // with a runtime body) means the binary may construct functions from

--- a/crates/perry/src/commands/compile/optimized_libs/tests.rs
+++ b/crates/perry/src/commands/compile/optimized_libs/tests.rs
@@ -345,6 +345,56 @@ fn explicit_node_fetch_import_still_routes_to_well_known_fetch() {
 }
 
 #[test]
+fn http2_import_enables_http2_constants_cross_feature() {
+    // #6468: importing `node:http2` records "http2" in `native_module_imports`,
+    // which must flip on `perry-runtime/mod-http2-constants` so the constant
+    // tables (`node_http2_constants`) are linked. A program that never imports
+    // it must leave the feature off so the tables dead-strip.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let empty_features: std::collections::BTreeSet<&'static str> =
+        std::collections::BTreeSet::new();
+
+    let mut with_http2 = CompilationContext::new(dir.path().to_path_buf());
+    with_http2.native_module_imports.insert("http2".to_string());
+    let cross_on = auto_optimized_cross_features(&with_http2, &empty_features, &[]);
+    assert!(
+        cross_on
+            .iter()
+            .any(|f| f == "perry-runtime/mod-http2-constants"),
+        "http2 import should enable mod-http2-constants, got {cross_on:?}"
+    );
+
+    let without = CompilationContext::new(dir.path().to_path_buf());
+    let cross_off = auto_optimized_cross_features(&without, &empty_features, &[]);
+    assert!(
+        !cross_off
+            .iter()
+            .any(|f| f == "perry-runtime/mod-http2-constants"),
+        "no http2 import should leave mod-http2-constants off, got {cross_off:?}"
+    );
+}
+
+#[test]
+fn http2_import_changes_optimized_libs_cache_key() {
+    // #6468: the http2-constants usage bit participates in the auto-build cache
+    // key, so a runtime built without the constant tables is never reused for a
+    // program that imports `node:http2`.
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    let base = CompilationContext::new(dir.path().to_path_buf());
+    let key_without = auto_optimized_cache_key("", true, None, &base);
+
+    let mut with_http2 = CompilationContext::new(dir.path().to_path_buf());
+    with_http2.native_module_imports.insert("http2".to_string());
+    let key_with = auto_optimized_cache_key("", true, None, &with_http2);
+
+    assert_ne!(
+        key_without, key_with,
+        "an http2 import must change the auto-optimized cache key"
+    );
+}
+
+#[test]
 fn forced_well_known_env_extends_iteration_set() {
     let _guard = env_lock();
     let old_force_well_known = std::env::var("PERRY_FORCE_WELL_KNOWN").ok();


### PR DESCRIPTION
## Summary

First Phase-1 tracer-bullet slice for #6468 (eliminate fixed runtime bloat from minimal native binaries): gate the `node:http2` module-level **constant tables** behind a new `perry-runtime/mod-http2-constants` Cargo feature, so a program that never imports `node:http2` links none of them and the auto-optimizer / macOS `-dead_strip` recovers the space.

This is exactly the slice the issue describes as the first tracer bullet ("HTTP/2 constants"), and follows the established `mod-dgram` per-module gating pattern end-to-end.

## What's gated

`crate::node_http2_constants` — the `NGHTTP2_*` / `HTTP_STATUS_*` number tables, the `http2.constants` sub-namespace key list, the top-level `http2` namespace key list, and the lazily-materialized `sensitiveHeaders` symbol. Pure `cfg` gate, **no dependency changes**.

The HTTP/2 **server** surface (`js_node_http2_*`, in `perry-ext-http-server`, routed via `http-client`) is untouched — only the cold constant data is gated.

## Mechanism

- `perry-runtime/Cargo.toml`: new `mod-http2-constants` feature, added to `default` so full/default builds and the shipped prebuilt `libperry_runtime.a` are unchanged.
- The module declaration and all 5 in-crate callsites (GC root scan, the `sensitiveHeaders` + `http2.constants` constant arms, and the two namespace-key arms) are `#[cfg]`-gated with benign `None`/no-op fallbacks. Those arms are only reachable through the `http2` namespace object, which only materializes on a `node:http2` import — the same signal that turns the gate on — so the off-path fallback is never observed at runtime.
- `auto_optimized_cross_features` enables `perry-runtime/mod-http2-constants` when `http2` is present in `native_module_imports`. `http2` is a stdlib-backed module (`requires_stdlib` → not runtime-only), so its import is always recorded there — a reliable, zero-false-negative activation signal.
- `auto_optimized_cache_key` gains an `http2=` bit so a runtime built without the constant tables is never reused for an http2 program.

## Verification

- **Absent when unused**: `libperry_runtime.a` for a `console.log("hello")` program (feature off) contains **0** `node_http2_constants` symbols; the same archive built with the feature on contains them. Single-variable A/B on the release archive (identical `--no-default-features --features perry-runtime/full [+mod-http2-constants]`): **20,899,720 B (off) → 20,958,360 B (on) = 58,640 B of `node_http2_constants` object code+data removed** when http2 is unused. The final-linked-binary reduction is smaller after LTO/`-dead_strip`; #6468's prototype measured ~33,032 B (−0.64%) off the empty binary for this exact slice.
- **Works when imported** (feature on): a program reading `constants.*` / `http2.constants.*` / `sensitiveHeaders` / `http2.sensitiveHeaders` produces output **byte-identical to Node `26.3.0`**.
- **No regression**: the feature-off `hello` binary links and runs (`hello world!`, exit 0).
- **Feature-off and feature-on runtime builds both compile** (`cargo check -p perry-runtime --no-default-features --features full`, and the full default build).
- Two unit tests added (`optimized_libs/tests.rs`): cross-feature is present iff `http2` is imported, and the cache key changes with the http2 bit. Both pass.

## Notes

- No version bump / no `CHANGELOG.md` entry (left to the maintainer at merge time, per the external-contributor convention).
- Follow-up Phase-1 slices (web storage, messaging, TUI/Yoga, cluster scheduling) can reuse this same shape.

Closes part of #6468.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Reduced unnecessary HTTP/2 constant data in builds that do not use `node:http2`.
  - Improved optimized-build caching so HTTP/2-enabled and HTTP/2-disabled builds remain separate.

- **Compatibility**
  - HTTP/2 constants are available when `node:http2` is imported, while existing HTTP/2 server functionality remains unaffected.

- **Bug Fixes**
  - Prevented optimized builds from incorrectly reusing cached runtime data with mismatched HTTP/2 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->