### PR TITLE
fix(streams): recycle Web Streams handle ids so the band survives long-running servers

### DIFF
--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -48,6 +48,7 @@ pub(crate) fn internal_promise() -> *mut Promise {
 
 mod byob;
 mod expando;
+mod idalloc;
 mod pipe;
 mod strategy;
 mod subclass;
@@ -270,14 +271,16 @@ lazy_static::lazy_static! {
     static ref TRANSFORM_STREAMS: Mutex<HashMap<usize, TransformStreamData>> = Mutex::new(HashMap::new());
     static ref READERS: Mutex<HashMap<usize, ReaderData>> = Mutex::new(HashMap::new());
     static ref WRITERS: Mutex<HashMap<usize, WriterData>> = Mutex::new(HashMap::new());
-    // #1545: ONE id counter shared across all five Web Streams registries.
-    // Stream handles are raw numeric f64 values, not POINTER_TAG small handles,
-    // so they live just above the runtime's `< 0x100000` small-handle band.
-    // That keeps them disjoint from Fetch/native/proxy pointer-tagged ids while
-    // the runtime's finite-number stream probes still route dynamic calls like
-    // `src.pipeThrough(ts).getReader()`.
-    static ref NEXT_STREAM_ID: Mutex<usize> = Mutex::new(STREAM_HANDLE_ID_START);
 }
+
+// #1545: ONE id allocator shared across all five Web Streams registries.
+// Stream handles are raw numeric f64 values, not POINTER_TAG small handles,
+// so they live just above the runtime's `< 0x100000` small-handle band. That
+// keeps them disjoint from Fetch/native/proxy pointer-tagged ids while the
+// runtime's finite-number stream probes still route dynamic calls like
+// `src.pipeThrough(ts).getReader()`. #6602: ids of terminal objects recycle
+// through `idalloc` so the finite band survives long-running servers.
+use self::idalloc::next_stream_id;
 
 static GC_REGISTERED: std::sync::Once = std::sync::Once::new();
 
@@ -382,16 +385,6 @@ fn scan_stream_roots_mut(visitor: &mut perry_runtime::gc::RuntimeRootVisitor<'_>
 // ─────────────────────────────────────────────────────────────────────
 // Helpers
 // ─────────────────────────────────────────────────────────────────────
-
-fn next_id(slot: &Mutex<usize>) -> usize {
-    let mut guard = slot.lock().unwrap();
-    let id = *guard;
-    if id >= STREAM_HANDLE_ID_END {
-        panic!("Web Streams handle id range exhausted");
-    }
-    *guard += 1;
-    id
-}
 
 unsafe fn closure_from_bits(bits: u64) -> i64 {
     if bits == TAG_UNDEFINED || bits == TAG_NULL || bits == 0 {
@@ -572,7 +565,7 @@ fn alloc_readable_with_strategy(
     is_byte_stream: bool,
     strategy_size_cb: i64,
 ) -> usize {
-    let id = next_id(&NEXT_STREAM_ID);
+    let id = next_stream_id();
     READABLE_STREAMS.lock().unwrap().insert(
         id,
         ReadableStreamData {
@@ -624,7 +617,7 @@ fn alloc_writable_with_strategy(
     hwm: f64,
     strategy_size_cb: i64,
 ) -> usize {
-    let id = next_id(&NEXT_STREAM_ID);
+    let id = next_stream_id();
     let ready = internal_promise();
     let closed = internal_promise();
     js_promise_resolve(ready, f64::from_bits(TAG_UNDEFINED));
@@ -790,6 +783,7 @@ unsafe fn close_pending(stream_id: usize) {
     // #5437: stream is done — drop any expando entries so the table doesn't
     // grow one row per stream over the server's lifetime.
     expando::stream_expando_clear(stream_id);
+    idalloc::retire_readable_terminal(stream_id);
 }
 
 unsafe fn error_pending(stream_id: usize, reason_bits: u64) {
@@ -806,6 +800,7 @@ unsafe fn error_pending(stream_id: usize, reason_bits: u64) {
     byob::error_pending_byob(stream_id, reason_bits);
     // #5437: stream errored — drop any expando entries (see close_pending).
     expando::stream_expando_clear(stream_id);
+    idalloc::retire_readable_terminal(stream_id);
 }
 
 // ─────────────────────────────────────────────────────────────────────
@@ -993,7 +988,7 @@ pub unsafe extern "C" fn js_readable_stream_get_reader_with_options(
         if s.reader_handle.is_some() {
             true
         } else {
-            let reader_id = next_id(&NEXT_STREAM_ID);
+            let reader_id = next_stream_id();
             let closed_p = internal_promise();
             if s.state == ReadableState::Closed {
                 js_promise_resolve(closed_p, f64::from_bits(TAG_UNDEFINED));
@@ -1928,6 +1923,7 @@ pub unsafe extern "C" fn js_reader_release_lock(reader_handle: f64) -> f64 {
     // #5437: the reader instance is done — drop any expando entries keyed by
     // its handle id so the table doesn't retain them for the process lifetime.
     expando::stream_expando_clear(reader_id);
+    idalloc::retire_reader_if_released(reader_id);
     f64::from_bits(TAG_UNDEFINED)
 }
 

--- a/crates/perry-stdlib/src/streams/byob.rs
+++ b/crates/perry-stdlib/src/streams/byob.rs
@@ -36,6 +36,15 @@ lazy_static::lazy_static! {
         Mutex::new(HashMap::new());
 }
 
+/// #6602: eviction hook — drop the (drained) BYOB queue slot of an evicted id.
+pub(super) fn evict_ids(batch: &[usize]) {
+    if let Ok(mut map) = BYOB_PENDING.lock() {
+        for id in batch {
+            map.remove(id);
+        }
+    }
+}
+
 /// True while at least one `read(view)` is parked on this stream — feeds
 /// the ShouldCallPull check in `maybe_pull`.
 pub(super) fn has_pending(stream_id: usize) -> bool {
@@ -221,7 +230,7 @@ pub(super) unsafe fn get_reader_for_stream(stream_id: usize, is_byob: bool) -> u
         drop(g);
         throw_type_error("ReadableStream is locked");
     }
-    let reader_id = next_id(&NEXT_STREAM_ID);
+    let reader_id = next_stream_id();
     let closed_p = internal_promise();
     if s.state == ReadableState::Closed {
         js_promise_resolve(closed_p, f64::from_bits(TAG_UNDEFINED));

--- a/crates/perry-stdlib/src/streams/idalloc.rs
+++ b/crates/perry-stdlib/src/streams/idalloc.rs
@@ -1,0 +1,325 @@
+//! #6602: Web Streams handle-id allocation with recycling.
+//!
+//! Ids for streams, readers, writers and transform streams all come from the
+//! fixed band `[STREAM_HANDLE_ID_START, STREAM_HANDLE_ID_END)` owned by
+//! `perry_runtime::value::addr_class`. The band is only `0x100000` wide and
+//! every band-gated classification path stops recognizing a handle past its
+//! end, so the old monotonic never-reused counter exhausted it after ~21k
+//! requests on a server that mints ~48 stream-family ids per request.
+//!
+//! Lifecycle: an id is RETIRED when its object reaches a terminal state —
+//! readable: errored, or closed with queue and pending reads drained;
+//! writable: closed/errored with no write in flight; reader/writer:
+//! `releaseLock()` (an attached reader/writer also dies with its terminal
+//! stream); transform: its writable side reaching terminal; pipeTo lock ids
+//! (never registered anywhere): pipe completion. Retired ids sit in a FIFO
+//! quarantine with their registry entries INTACT, so a wrapper still held by
+//! user code keeps full post-terminal semantics (`locked`, `getReader()` on a
+//! closed stream, error values, promise getters). Only when the quarantine
+//! overflows `PERRY_STREAM_ID_QUARANTINE` (default 16384; the debug knob that
+//! makes exhaustion tests cheap) is the oldest id EVICTED — registry and
+//! side-table entries removed, GC roots dropped — and pushed onto the free
+//! list `next_stream_id` reuses. A stale wrapper can only observe the
+//! recycling after its id survived a full quarantine's worth of later
+//! teardowns; before that it degrades to the registry-miss defaults, the same
+//! answers a plain in-band number gets.
+//!
+//! Locking: the allocator mutex is a LEAF lock — `get_reader` / `get_writer`
+//! call `next_stream_id` while holding a registry lock, so nothing here may
+//! acquire a registry lock while holding the allocator lock. Eviction's
+//! registry cleanup therefore runs BETWEEN two allocator-lock sections; the
+//! evicted batch stays in `pooled` throughout, so a concurrent duplicate
+//! retire of a mid-eviction id is rejected, and `retire_*` entry checks run
+//! before the allocator lock is taken.
+
+use super::transform::TRANSFORM_PAIRS;
+use super::{
+    byob, expando, tee, ReadableState, WritableState, READABLE_STREAMS, READERS,
+    STREAM_HANDLE_ID_END, STREAM_HANDLE_ID_START, TRANSFORM_STREAMS, WRITABLE_STREAMS, WRITERS,
+};
+use std::collections::{HashSet, VecDeque};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+
+pub(super) const DEFAULT_QUARANTINE: usize = 16384;
+
+struct IdAlloc {
+    /// Next never-yet-used id (monotonic bump while fresh ids remain).
+    next: usize,
+    /// Evicted ids ready for reuse, oldest first.
+    free: VecDeque<usize>,
+    /// Terminal ids in quarantine, retirement order. Registry entries intact.
+    retired: VecDeque<usize>,
+    /// Every id currently in `retired` or `free` — the double-retire /
+    /// double-free guard. Ids leave on allocation.
+    pooled: HashSet<usize>,
+}
+
+lazy_static::lazy_static! {
+    static ref IDALLOC: Mutex<IdAlloc> = Mutex::new(IdAlloc {
+        next: STREAM_HANDLE_ID_START,
+        free: VecDeque::new(),
+        retired: VecDeque::new(),
+        pooled: HashSet::new(),
+    });
+}
+
+/// Quarantine length that triggers eviction of the oldest retired id.
+/// 0 = not yet initialized from `PERRY_STREAM_ID_QUARANTINE`.
+static QUARANTINE: AtomicUsize = AtomicUsize::new(0);
+
+fn quarantine_limit() -> usize {
+    let q = QUARANTINE.load(Ordering::Relaxed);
+    if q != 0 {
+        return q;
+    }
+    let q = std::env::var("PERRY_STREAM_ID_QUARANTINE")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        // Below 2 the reuse distance vanishes; above half the band the
+        // allocator can never recycle enough to matter.
+        .map(|v| v.clamp(2, (STREAM_HANDLE_ID_END - STREAM_HANDLE_ID_START) / 2))
+        .unwrap_or(DEFAULT_QUARANTINE);
+    QUARANTINE.store(q, Ordering::Relaxed);
+    q
+}
+
+#[cfg(test)]
+pub(super) fn set_quarantine_limit_for_test(limit: usize) {
+    QUARANTINE.store(limit.max(2), Ordering::Relaxed);
+}
+
+/// How many times `id` currently sits in the quarantine + free pools
+/// (correctness invariant: never more than 1).
+#[cfg(test)]
+pub(super) fn test_pool_occurrences(id: usize) -> usize {
+    let a = IDALLOC.lock().unwrap();
+    a.retired.iter().filter(|&&r| r == id).count() + a.free.iter().filter(|&&f| f == id).count()
+}
+
+/// Evict and DISCARD everything pooled so a test observes deterministic
+/// free-list behavior regardless of what earlier tests retired. The
+/// discarded ids are simply never reused — harmless at test scale.
+#[cfg(test)]
+pub(super) fn test_reset_pools() {
+    let retired = {
+        let mut a = IDALLOC.lock().unwrap();
+        let retired: Vec<usize> = a.retired.drain(..).collect();
+        a.free.clear();
+        a.pooled.clear();
+        retired
+    };
+    evict_ids(&retired);
+}
+
+/// Allocate a stream-family handle id. Prefers recycled ids (their previous
+/// registry entries were fully evicted), then fresh monotonic ids. May be
+/// called with registry locks held — takes only the allocator (leaf) lock.
+pub(super) fn next_stream_id() -> usize {
+    let mut a = IDALLOC.lock().unwrap();
+    if let Some(id) = a.free.pop_front() {
+        a.pooled.remove(&id);
+        return id;
+    }
+    if a.next >= STREAM_HANDLE_ID_END {
+        panic!(
+            "Web Streams handle id band exhausted: {} ids live or quarantined \
+             (see PERRY_STREAM_ID_QUARANTINE)",
+            STREAM_HANDLE_ID_END - STREAM_HANDLE_ID_START
+        );
+    }
+    let id = a.next;
+    a.next += 1;
+    id
+}
+
+/// Move `id` into quarantine; once it ages past the quarantine window, evict
+/// its registry footprint and hand the id to the free list. Callers must hold
+/// NO streams locks and must have verified the id's terminal state (or, for
+/// pipe lock ids, that it is registered nowhere).
+fn retire(id: usize) {
+    if !(STREAM_HANDLE_ID_START..STREAM_HANDLE_ID_END).contains(&id) {
+        return;
+    }
+    let evicted = {
+        let mut a = IDALLOC.lock().unwrap();
+        if !a.pooled.insert(id) {
+            return;
+        }
+        a.retired.push_back(id);
+        let limit = quarantine_limit();
+        if a.retired.len() <= limit {
+            return;
+        }
+        let n = a.retired.len() - limit;
+        a.retired.drain(..n).collect::<Vec<_>>()
+        // The drained ids stay in `pooled` until they reach `free` below.
+    };
+    evict_ids(&evicted);
+    IDALLOC.lock().unwrap().free.extend(evicted);
+}
+
+/// Remove every registry and side-table trace of the batch. After this the
+/// ids answer like plain in-band numbers until they are reallocated; the GC
+/// scanners stop rooting their callbacks, chunks and promises.
+fn evict_ids(batch: &[usize]) {
+    {
+        let mut g = READABLE_STREAMS.lock().unwrap();
+        for id in batch {
+            g.remove(id);
+        }
+    }
+    {
+        let mut g = WRITABLE_STREAMS.lock().unwrap();
+        for id in batch {
+            g.remove(id);
+        }
+    }
+    {
+        let mut g = TRANSFORM_STREAMS.lock().unwrap();
+        for id in batch {
+            g.remove(id);
+        }
+    }
+    {
+        let mut g = READERS.lock().unwrap();
+        for id in batch {
+            g.remove(id);
+        }
+    }
+    {
+        let mut g = WRITERS.lock().unwrap();
+        for id in batch {
+            g.remove(id);
+        }
+    }
+    {
+        let mut g = TRANSFORM_PAIRS.lock().unwrap();
+        for id in batch {
+            g.remove(id);
+        }
+    }
+    {
+        let mut g = super::transform::TRANSFORM_WRITE_RELEASES.lock().unwrap();
+        for id in batch {
+            g.remove(id);
+        }
+    }
+    byob::evict_ids(batch);
+    tee::evict_ids(batch);
+    for &id in batch {
+        expando::stream_expando_clear(id);
+    }
+}
+
+/// Retire a readable stream that reached a terminal state: errored, or closed
+/// with its queue and pending reads drained. A still-attached reader dies
+/// with it (a released one goes through [`retire_reader_if_released`]); the
+/// tee lock sentinel (`usize::MAX`) fails `retire`'s band guard.
+pub(super) fn retire_readable_terminal(stream_id: usize) {
+    let reader = {
+        let g = READABLE_STREAMS.lock().unwrap();
+        match g.get(&stream_id) {
+            Some(s)
+                if match s.state {
+                    ReadableState::Errored => true,
+                    ReadableState::Closed => s.chunks.is_empty() && s.pending_reads.is_empty(),
+                    ReadableState::Readable => false,
+                } =>
+            {
+                s.reader_handle
+            }
+            _ => return,
+        }
+    };
+    retire(stream_id);
+    if let Some(reader_id) = reader {
+        let attached = READERS
+            .lock()
+            .unwrap()
+            .get(&reader_id)
+            .map(|r| r.stream_handle == stream_id)
+            .unwrap_or(false);
+        if attached {
+            retire(reader_id);
+        }
+    }
+}
+
+/// Retire a writable stream that reached a terminal state (closed / errored /
+/// aborted) with no write in flight and an empty queue. A still-attached
+/// writer dies with it, and so does the transform stream whose sink this
+/// writable was (its readable side retires through its own terminal path).
+pub(super) fn retire_writable_terminal(stream_id: usize) {
+    let writer = {
+        let g = WRITABLE_STREAMS.lock().unwrap();
+        match g.get(&stream_id) {
+            Some(s)
+                if matches!(s.state, WritableState::Closed | WritableState::Errored)
+                    && !s.in_flight
+                    && s.write_queue.is_empty() =>
+            {
+                s.writer_handle
+            }
+            _ => return,
+        }
+    };
+    retire(stream_id);
+    if let Some(writer_id) = writer {
+        let attached = WRITERS
+            .lock()
+            .unwrap()
+            .get(&writer_id)
+            .map(|w| w.stream_handle == stream_id)
+            .unwrap_or(false);
+        if attached {
+            retire(writer_id);
+        }
+    }
+    let transform_id = TRANSFORM_PAIRS.lock().unwrap().get(&stream_id).copied();
+    if let Some(transform_id) = transform_id {
+        if TRANSFORM_STREAMS.lock().unwrap().contains_key(&transform_id) {
+            retire(transform_id);
+        }
+    }
+}
+
+/// Retire a reader whose lock was released (`releaseLock()` / iterator
+/// return). Post-release calls already answer through the registry-miss arms
+/// (`read()` → TypeError, `closed` → resolved promise).
+pub(super) fn retire_reader_if_released(reader_id: usize) {
+    let released = READERS
+        .lock()
+        .unwrap()
+        .get(&reader_id)
+        .map(|r| !r.locked)
+        .unwrap_or(false);
+    if released {
+        retire(reader_id);
+    }
+}
+
+/// Writer counterpart of [`retire_reader_if_released`].
+pub(super) fn retire_writer_if_released(writer_id: usize) {
+    let released = WRITERS
+        .lock()
+        .unwrap()
+        .get(&writer_id)
+        .map(|w| !w.locked)
+        .unwrap_or(false);
+    if released {
+        retire(writer_id);
+    }
+}
+
+/// Retire a pipeTo lock id. These ids are stamped into `reader_handle` /
+/// `writer_handle` as lock markers but never own a registry entry, so the
+/// terminal-state retires above can't see them. The kind check keeps a stale
+/// duplicate release from retiring the id's NEXT life: once recycled into a
+/// real stream/reader/writer, the id has a registry entry again and is
+/// skipped here.
+pub(super) fn retire_unregistered_id(id: usize) {
+    if super::subclass::js_stream_handle_kind(id) == 0 {
+        retire(id);
+    }
+}

--- a/crates/perry-stdlib/src/streams/idalloc.rs
+++ b/crates/perry-stdlib/src/streams/idalloc.rs
@@ -53,6 +53,13 @@ struct IdAlloc {
     /// Every id currently in `retired` or `free` — the double-retire /
     /// double-free guard. Ids leave on allocation.
     pooled: HashSet<usize>,
+    /// Live pipeTo lock ids. Pipe lock ids never own a registry entry, so the
+    /// allocator itself tracks their ownership: marked atomically at
+    /// allocation, unmarked exactly once at retire. A stale duplicate release
+    /// finds no mark and can never touch the id's next life (a registry-
+    /// absence probe instead would race the alloc→register window of a reused
+    /// id).
+    pipe_ids: HashSet<usize>,
 }
 
 lazy_static::lazy_static! {
@@ -61,6 +68,7 @@ lazy_static::lazy_static! {
         free: VecDeque::new(),
         retired: VecDeque::new(),
         pooled: HashSet::new(),
+        pipe_ids: HashSet::new(),
     });
 }
 
@@ -112,13 +120,11 @@ pub(super) fn test_reset_pools() {
     evict_ids(&retired);
 }
 
-/// Allocate a stream-family handle id. Prefers recycled ids (their previous
-/// registry entries were fully evicted), then fresh monotonic ids. May be
-/// called with registry locks held — takes only the allocator (leaf) lock.
-pub(super) fn next_stream_id() -> usize {
-    let mut a = IDALLOC.lock().unwrap();
+fn alloc_locked(a: &mut IdAlloc) -> usize {
     if let Some(id) = a.free.pop_front() {
         a.pooled.remove(&id);
+        // Free ids are never marked (the mark clears at retire) — defensive.
+        a.pipe_ids.remove(&id);
         return id;
     }
     if a.next >= STREAM_HANDLE_ID_END {
@@ -133,30 +139,58 @@ pub(super) fn next_stream_id() -> usize {
     id
 }
 
+/// Allocate a stream-family handle id. Prefers recycled ids (their previous
+/// registry entries were fully evicted), then fresh monotonic ids. May be
+/// called with registry locks held — takes only the allocator (leaf) lock.
+pub(super) fn next_stream_id() -> usize {
+    alloc_locked(&mut IDALLOC.lock().unwrap())
+}
+
+/// Allocate a pipeTo lock id and mark its ownership in the same lock section,
+/// so retirement can key on the mark instead of probing registries.
+pub(super) fn next_pipe_lock_id() -> usize {
+    let mut a = IDALLOC.lock().unwrap();
+    let id = alloc_locked(&mut a);
+    a.pipe_ids.insert(id);
+    id
+}
+
+/// Under the allocator lock: pool `id` into quarantine. Returns the overflow
+/// batch whose eviction the caller must finish AFTER dropping the lock; the
+/// drained ids stay in `pooled` until they reach `free`.
+fn pool_retired(a: &mut IdAlloc, id: usize) -> Option<Vec<usize>> {
+    if !a.pooled.insert(id) {
+        return None;
+    }
+    a.retired.push_back(id);
+    let limit = quarantine_limit();
+    if a.retired.len() <= limit {
+        return None;
+    }
+    let n = a.retired.len() - limit;
+    Some(a.retired.drain(..n).collect())
+}
+
+/// Registry cleanup + free-list handoff for a quarantine overflow batch.
+/// Must run with NO locks held (takes registry locks, then the allocator).
+fn finish_eviction(evicted: Option<Vec<usize>>) {
+    let Some(evicted) = evicted else { return };
+    evict_ids(&evicted);
+    IDALLOC.lock().unwrap().free.extend(evicted);
+}
+
 /// Move `id` into quarantine; once it ages past the quarantine window, evict
 /// its registry footprint and hand the id to the free list. Callers must hold
-/// NO streams locks and must have verified the id's terminal state (or, for
-/// pipe lock ids, that it is registered nowhere).
+/// NO streams locks and must have verified the id's terminal state.
 fn retire(id: usize) {
     if !(STREAM_HANDLE_ID_START..STREAM_HANDLE_ID_END).contains(&id) {
         return;
     }
     let evicted = {
         let mut a = IDALLOC.lock().unwrap();
-        if !a.pooled.insert(id) {
-            return;
-        }
-        a.retired.push_back(id);
-        let limit = quarantine_limit();
-        if a.retired.len() <= limit {
-            return;
-        }
-        let n = a.retired.len() - limit;
-        a.retired.drain(..n).collect::<Vec<_>>()
-        // The drained ids stay in `pooled` until they reach `free` below.
+        pool_retired(&mut a, id)
     };
-    evict_ids(&evicted);
-    IDALLOC.lock().unwrap().free.extend(evicted);
+    finish_eviction(evicted);
 }
 
 /// Remove every registry and side-table trace of the batch. After this the
@@ -318,12 +352,20 @@ pub(super) fn retire_writer_if_released(writer_id: usize) {
 
 /// Retire a pipeTo lock id. These ids are stamped into `reader_handle` /
 /// `writer_handle` as lock markers but never own a registry entry, so the
-/// terminal-state retires above can't see them. The kind check keeps a stale
-/// duplicate release from retiring the id's NEXT life: once recycled into a
-/// real stream/reader/writer, the id has a registry entry again and is
-/// skipped here.
-pub(super) fn retire_unregistered_id(id: usize) {
-    if super::subclass::js_stream_handle_kind(id) == 0 {
-        retire(id);
+/// terminal-state retires above can't see them. Retirement keys on the
+/// ownership mark set by [`next_pipe_lock_id`]: the mark clears exactly once,
+/// so a stale duplicate release is a no-op and can never retire the id's
+/// next life, however far allocation has moved on.
+pub(super) fn retire_pipe_lock_id(id: usize) {
+    if !(STREAM_HANDLE_ID_START..STREAM_HANDLE_ID_END).contains(&id) {
+        return;
     }
+    let evicted = {
+        let mut a = IDALLOC.lock().unwrap();
+        if !a.pipe_ids.remove(&id) {
+            return;
+        }
+        pool_retired(&mut a, id)
+    };
+    finish_eviction(evicted);
 }

--- a/crates/perry-stdlib/src/streams/idalloc.rs
+++ b/crates/perry-stdlib/src/streams/idalloc.rs
@@ -278,7 +278,11 @@ pub(super) fn retire_writable_terminal(stream_id: usize) {
     }
     let transform_id = TRANSFORM_PAIRS.lock().unwrap().get(&stream_id).copied();
     if let Some(transform_id) = transform_id {
-        if TRANSFORM_STREAMS.lock().unwrap().contains_key(&transform_id) {
+        if TRANSFORM_STREAMS
+            .lock()
+            .unwrap()
+            .contains_key(&transform_id)
+        {
             retire(transform_id);
         }
     }

--- a/crates/perry-stdlib/src/streams/pipe.rs
+++ b/crates/perry-stdlib/src/streams/pipe.rs
@@ -1,8 +1,8 @@
 //! `ReadableStream.pipeTo` implementation details.
 
 use super::{
-    box_promise, js_writable_stream_close, maybe_pull, next_id, reject_type_error, transform_close,
-    writable_stream_write, ReadableState, NEXT_STREAM_ID, READABLE_STREAMS, TAG_UNDEFINED,
+    box_promise, idalloc, js_writable_stream_close, maybe_pull, next_stream_id, reject_type_error,
+    transform_close, writable_stream_write, ReadableState, READABLE_STREAMS, TAG_UNDEFINED,
     TRANSFORM_PAIRS, WRITABLE_STREAMS,
 };
 use perry_runtime::{
@@ -20,8 +20,27 @@ struct PipeLockIds {
 }
 
 fn acquire_pipe_locks(readable_id: usize, writable_id: usize) -> Result<PipeLockIds, &'static str> {
-    let reader_id = next_id(&NEXT_STREAM_ID);
-    let writer_id = next_id(&NEXT_STREAM_ID);
+    let reader_id = next_stream_id();
+    let writer_id = next_stream_id();
+    // #6602: on failure the two freshly minted ids were never stamped (or were
+    // just unstamped) — recycle them. Runs after every registry guard above is
+    // released; `retire_unregistered_id` takes those locks itself.
+    if let Err(message) = try_acquire_pipe_locks(readable_id, writable_id, reader_id, writer_id) {
+        retire_pipe_lock_ids(reader_id, writer_id);
+        return Err(message);
+    }
+    Ok(PipeLockIds {
+        reader_id,
+        writer_id,
+    })
+}
+
+fn try_acquire_pipe_locks(
+    readable_id: usize,
+    writable_id: usize,
+    reader_id: usize,
+    writer_id: usize,
+) -> Result<(), &'static str> {
     {
         let mut readable = READABLE_STREAMS.lock().unwrap();
         match readable.get_mut(&readable_id) {
@@ -56,10 +75,15 @@ fn acquire_pipe_locks(readable_id: usize, writable_id: usize) -> Result<PipeLock
             }
         }
     }
-    Ok(PipeLockIds {
-        reader_id,
-        writer_id,
-    })
+    Ok(())
+}
+
+/// #6602: pipe lock ids are stamped as lock markers but never own a registry
+/// entry, so nothing else retires them — without this every pipeTo burned two
+/// band ids for the life of the process.
+fn retire_pipe_lock_ids(reader_id: usize, writer_id: usize) {
+    idalloc::retire_unregistered_id(reader_id);
+    idalloc::retire_unregistered_id(writer_id);
 }
 
 fn release_pipe_locks(readable_id: usize, writable_id: usize, locks: PipeLockIds) {
@@ -73,6 +97,7 @@ fn release_pipe_locks(readable_id: usize, writable_id: usize, locks: PipeLockIds
             s.writer_handle = None;
         }
     }
+    retire_pipe_lock_ids(locks.reader_id, locks.writer_id);
 }
 
 #[inline]

--- a/crates/perry-stdlib/src/streams/pipe.rs
+++ b/crates/perry-stdlib/src/streams/pipe.rs
@@ -1,9 +1,9 @@
 //! `ReadableStream.pipeTo` implementation details.
 
 use super::{
-    box_promise, idalloc, js_writable_stream_close, maybe_pull, next_stream_id, reject_type_error,
-    transform_close, writable_stream_write, ReadableState, READABLE_STREAMS, TAG_UNDEFINED,
-    TRANSFORM_PAIRS, WRITABLE_STREAMS,
+    box_promise, idalloc, js_writable_stream_close, maybe_pull, reject_type_error, transform_close,
+    writable_stream_write, ReadableState, READABLE_STREAMS, TAG_UNDEFINED, TRANSFORM_PAIRS,
+    WRITABLE_STREAMS,
 };
 use perry_runtime::{
     js_nanbox_get_pointer, js_object_get_field_by_name, js_promise_new, js_promise_reject,
@@ -20,11 +20,12 @@ struct PipeLockIds {
 }
 
 fn acquire_pipe_locks(readable_id: usize, writable_id: usize) -> Result<PipeLockIds, &'static str> {
-    let reader_id = next_stream_id();
-    let writer_id = next_stream_id();
+    let reader_id = idalloc::next_pipe_lock_id();
+    let writer_id = idalloc::next_pipe_lock_id();
     // #6602: on failure the two freshly minted ids were never stamped (or were
-    // just unstamped) — recycle them. Runs after every registry guard above is
-    // released; `retire_unregistered_id` takes those locks itself.
+    // just unstamped) — recycle them. Runs after every registry guard in
+    // `try_acquire_pipe_locks` is released; a quarantine overflow inside the
+    // retire takes registry locks for eviction cleanup.
     if let Err(message) = try_acquire_pipe_locks(readable_id, writable_id, reader_id, writer_id) {
         retire_pipe_lock_ids(reader_id, writer_id);
         return Err(message);
@@ -80,10 +81,12 @@ fn try_acquire_pipe_locks(
 
 /// #6602: pipe lock ids are stamped as lock markers but never own a registry
 /// entry, so nothing else retires them — without this every pipeTo burned two
-/// band ids for the life of the process.
+/// band ids for the life of the process. Retirement keys on the allocator's
+/// ownership mark, so a duplicate release (close-fulfilled then a late
+/// rejection) is a no-op.
 fn retire_pipe_lock_ids(reader_id: usize, writer_id: usize) {
-    idalloc::retire_unregistered_id(reader_id);
-    idalloc::retire_unregistered_id(writer_id);
+    idalloc::retire_pipe_lock_id(reader_id);
+    idalloc::retire_pipe_lock_id(writer_id);
 }
 
 fn release_pipe_locks(readable_id: usize, writable_id: usize, locks: PipeLockIds) {

--- a/crates/perry-stdlib/src/streams/subclass.rs
+++ b/crates/perry-stdlib/src/streams/subclass.rs
@@ -139,7 +139,7 @@ pub extern "C" fn js_stream_handle_kind(id: usize) -> u8 {
 /// `js_handle_method_dispatch` with a bare numeric handle.
 ///
 /// Because every Web Streams handle now lives in one shared id space based at
-/// `STREAM_HANDLE_ID_START` (see `NEXT_STREAM_ID`), the handle is (a)
+/// `STREAM_HANDLE_ID_START` (see `idalloc::next_stream_id`), the handle is (a)
 /// recognisable by range and (b) present in exactly one of the five registries,
 /// so routing by
 /// `(registry-membership, method-name)` is unambiguous and can never collide

--- a/crates/perry-stdlib/src/streams/tee.rs
+++ b/crates/perry-stdlib/src/streams/tee.rs
@@ -8,8 +8,8 @@
 //! `controller_close` / `controller_error`).
 
 use super::{
-    build_iter_result, byob, close_pending, error_pending, js_promise_resolve, next_id,
-    throw_type_error, ReadableState, ReadableStreamData, NEXT_STREAM_ID, READABLE_STREAMS,
+    build_iter_result, byob, close_pending, error_pending, idalloc, js_promise_resolve,
+    next_stream_id, throw_type_error, ReadableState, ReadableStreamData, READABLE_STREAMS,
 };
 use perry_runtime::array::{js_array_alloc, js_array_push};
 use perry_runtime::closure::ClosureHeader;
@@ -120,6 +120,19 @@ pub(super) unsafe fn tee_error_branches(source: usize, reason_bits: u64) {
     let Some((a, b)) = tee_branches_of(source) else {
         return;
     };
+    // #6602: stamp the source itself terminal. It used to stay `Readable`
+    // forever, leaking its registry entry, queued chunks and id once the tee
+    // links were gone; nothing can drive it after the unlink below.
+    {
+        let mut g = READABLE_STREAMS.lock().unwrap();
+        if let Some(s) = g.get_mut(&source) {
+            if s.state == ReadableState::Readable {
+                s.state = ReadableState::Errored;
+                s.error_value = reason_bits;
+            }
+            s.clear_chunks();
+        }
+    }
     for branch in [a, b] {
         {
             let mut g = READABLE_STREAMS.lock().unwrap();
@@ -137,9 +150,37 @@ pub(super) unsafe fn tee_error_branches(source: usize, reason_bits: u64) {
 
 fn tee_unlink(source: usize, a: usize, b: usize) {
     TEE_SOURCE_BRANCHES.lock().unwrap().remove(&source);
-    let mut bs = TEE_BRANCH_SOURCE.lock().unwrap();
-    bs.remove(&a);
-    bs.remove(&b);
+    {
+        let mut bs = TEE_BRANCH_SOURCE.lock().unwrap();
+        bs.remove(&a);
+        bs.remove(&b);
+    }
+    // #6602: the unlinked source is terminal (close flow: Closed and drained
+    // by pull discovery; error flow: stamped Errored above) — retire its id.
+    // Its `TEE_LOCK_SENTINEL` reader_handle matches no READERS entry.
+    idalloc::retire_readable_terminal(source);
+}
+
+/// #6602: eviction hook — drop any tee links keyed by an evicted id.
+pub(super) fn evict_ids(batch: &[usize]) {
+    {
+        let mut g = TEE_SOURCE_BRANCHES.lock().unwrap();
+        for id in batch {
+            g.remove(id);
+        }
+    }
+    {
+        let mut g = TEE_BRANCH_SOURCE.lock().unwrap();
+        for id in batch {
+            g.remove(id);
+        }
+    }
+    {
+        let mut g = TEE_PULLING.lock().unwrap();
+        for id in batch {
+            g.remove(id);
+        }
+    }
 }
 
 /// Enqueue on a tee'd SOURCE: the chunk stays in the source queue (spec size
@@ -382,8 +423,8 @@ pub unsafe extern "C" fn js_readable_stream_tee(stream_handle: f64) -> f64 {
     } else {
         0
     };
-    let id_a = next_id(&NEXT_STREAM_ID);
-    let id_b = next_id(&NEXT_STREAM_ID);
+    let id_a = next_stream_id();
+    let id_b = next_stream_id();
     {
         let mut g = READABLE_STREAMS.lock().unwrap();
         for new_id in [id_a, id_b] {

--- a/crates/perry-stdlib/src/streams/tee.rs
+++ b/crates/perry-stdlib/src/streams/tee.rs
@@ -161,19 +161,33 @@ fn tee_unlink(source: usize, a: usize, b: usize) {
     idalloc::retire_readable_terminal(source);
 }
 
-/// #6602: eviction hook — drop any tee links keyed by an evicted id.
+/// #6602: eviction hook — scrub BOTH directions of every tee relationship an
+/// evicted id participates in. A one-directional key removal would leave a
+/// `TEE_SOURCE_BRANCHES` tuple naming an evicted branch (a cancelled branch
+/// keeps its links), and once that id is reused the source's fan-out would
+/// deliver chunks into an unrelated new stream. An evicted branch slot is
+/// zeroed (0 never matches a registry entry) so the live sibling keeps
+/// receiving; the entry drops when both slots are dead.
 pub(super) fn evict_ids(batch: &[usize]) {
+    let dead: HashSet<usize> = batch.iter().copied().collect();
     {
         let mut g = TEE_SOURCE_BRANCHES.lock().unwrap();
-        for id in batch {
-            g.remove(id);
-        }
+        g.retain(|source, (a, b)| {
+            if dead.contains(source) {
+                return false;
+            }
+            if dead.contains(a) {
+                *a = 0;
+            }
+            if dead.contains(b) {
+                *b = 0;
+            }
+            *a != 0 || *b != 0
+        });
     }
     {
         let mut g = TEE_BRANCH_SOURCE.lock().unwrap();
-        for id in batch {
-            g.remove(id);
-        }
+        g.retain(|branch, source| !dead.contains(branch) && !dead.contains(source));
     }
     {
         let mut g = TEE_PULLING.lock().unwrap();
@@ -463,6 +477,13 @@ pub unsafe extern "C" fn js_readable_stream_tee(stream_handle: f64) -> f64 {
         let mut bs = TEE_BRANCH_SOURCE.lock().unwrap();
         bs.insert(id_a, id);
         bs.insert(id_b, id);
+    } else {
+        // #6602: born-Errored branches have no tee lifecycle (no links) and no
+        // error_pending ever fires for them — retire now so repeatedly teeing
+        // an errored stream can't exhaust the band. Quarantine keeps their
+        // registry entries, so reads still reject with the source's error.
+        idalloc::retire_readable_terminal(id_a);
+        idalloc::retire_readable_terminal(id_b);
     }
 
     let arr = js_array_alloc(2);

--- a/crates/perry-stdlib/src/streams/tests.rs
+++ b/crates/perry-stdlib/src/streams/tests.rs
@@ -1,9 +1,28 @@
 use super::transform::{run_web_compression_codec, split_utf8_prefix};
 use super::*;
 
+/// #6602: the id-allocator tests below mutate shared pool state (quarantine
+/// limit, free list) — serialize them so cargo's parallel test threads don't
+/// interleave allocations between a retire and its recycle assertion.
+static ALLOCATOR_TEST_SERIAL: Mutex<()> = Mutex::new(());
+
+fn serial_guard() -> std::sync::MutexGuard<'static, ()> {
+    ALLOCATOR_TEST_SERIAL
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn alloc_closed_readable() -> usize {
+    let id = alloc_readable(0, 0, 0, 1.0);
+    let mut g = READABLE_STREAMS.lock().unwrap();
+    g.get_mut(&id).unwrap().state = ReadableState::Closed;
+    drop(g);
+    id
+}
+
 #[test]
 fn stream_ids_live_outside_pointer_tag_small_handle_band() {
-    let id = next_id(&NEXT_STREAM_ID);
+    let id = next_stream_id();
     assert!(
         (STREAM_HANDLE_ID_START..STREAM_HANDLE_ID_END).contains(&id),
         "stream id {id:#x} must stay in the raw numeric stream band"
@@ -15,7 +34,109 @@ fn stream_ids_live_outside_pointer_tag_small_handle_band() {
 }
 
 #[test]
+fn terminal_stream_ids_recycle_after_quarantine_eviction() {
+    let _serial = serial_guard();
+    idalloc::test_reset_pools();
+    idalloc::set_quarantine_limit_for_test(2);
+    let ids: Vec<usize> = (0..3)
+        .map(|_| {
+            let id = alloc_closed_readable();
+            idalloc::retire_readable_terminal(id);
+            id
+        })
+        .collect();
+    idalloc::set_quarantine_limit_for_test(idalloc::DEFAULT_QUARANTINE);
+    // The third retire overflowed the quarantine of 2: the oldest id lost its
+    // registry entry (eviction really cleans up)…
+    assert!(
+        !READABLE_STREAMS.lock().unwrap().contains_key(&ids[0]),
+        "evicted id must leave the registry"
+    );
+    assert!(
+        READABLE_STREAMS.lock().unwrap().contains_key(&ids[2]),
+        "quarantined id keeps its registry entry"
+    );
+    // …and the allocator hands it back, oldest first, before any fresh id.
+    let reused = next_stream_id();
+    assert_eq!(reused, ids[0], "evicted id recycles FIFO");
+    assert!((STREAM_HANDLE_ID_START..STREAM_HANDLE_ID_END).contains(&reused));
+    // With the free list drained the allocator is back on fresh ids.
+    let fresh = alloc_readable(0, 0, 0, 1.0);
+    assert_ne!(fresh, reused);
+}
+
+#[test]
+fn retire_is_idempotent_per_id() {
+    let _serial = serial_guard();
+    idalloc::test_reset_pools();
+    idalloc::set_quarantine_limit_for_test(idalloc::DEFAULT_QUARANTINE);
+    let id = alloc_closed_readable();
+    idalloc::retire_readable_terminal(id);
+    idalloc::retire_readable_terminal(id);
+    // The unregistered-id path must also skip it: the registry entry is still
+    // present in quarantine.
+    idalloc::retire_unregistered_id(id);
+    assert_eq!(
+        idalloc::test_pool_occurrences(id),
+        1,
+        "an id may sit in the pools at most once — twice means double-alloc"
+    );
+}
+
+#[test]
+fn live_stream_ids_never_enter_the_pool() {
+    let _serial = serial_guard();
+    idalloc::test_reset_pools();
+    let id = alloc_readable(0, 0, 0, 1.0);
+    idalloc::retire_readable_terminal(id); // Readable → not terminal
+    idalloc::retire_unregistered_id(id); // registered → guarded
+    assert_eq!(idalloc::test_pool_occurrences(id), 0);
+    {
+        // Closed but undrained (slow consumer with queued chunks) stays live.
+        let mut g = READABLE_STREAMS.lock().unwrap();
+        let s = g.get_mut(&id).unwrap();
+        s.state = ReadableState::Closed;
+        s.push_chunk(TAG_UNDEFINED, 1.0);
+    }
+    idalloc::retire_readable_terminal(id);
+    assert_eq!(idalloc::test_pool_occurrences(id), 0);
+}
+
+#[test]
+fn attached_reader_dies_with_terminal_stream_but_not_before() {
+    let _serial = serial_guard();
+    idalloc::test_reset_pools();
+    let stream = alloc_readable(0, 0, 0, 1.0);
+    let reader = next_stream_id();
+    READERS.lock().unwrap().insert(
+        reader,
+        ReaderData {
+            stream_handle: stream,
+            locked: true,
+            closed_promise: 0x2345_6780 as *mut Promise,
+            is_byob: false,
+        },
+    );
+    {
+        let mut g = READABLE_STREAMS.lock().unwrap();
+        let s = g.get_mut(&stream).unwrap();
+        s.reader_handle = Some(reader);
+        s.state = ReadableState::Closed;
+    }
+    // A still-locked reader does not retire on its own…
+    idalloc::retire_reader_if_released(reader);
+    assert_eq!(idalloc::test_pool_occurrences(reader), 0);
+    // …but goes down with its terminal stream.
+    idalloc::retire_readable_terminal(stream);
+    assert_eq!(idalloc::test_pool_occurrences(stream), 1);
+    assert_eq!(idalloc::test_pool_occurrences(reader), 1);
+}
+
+#[test]
 fn root_scanner_emits_callbacks_chunks_and_promises() {
+    // Clears READABLE_STREAMS wholesale — serialize against the allocator
+    // tests, whose assertions read that registry.
+    let _serial = serial_guard();
     {
         let mut readable = READABLE_STREAMS.lock().unwrap();
         readable.clear();

--- a/crates/perry-stdlib/src/streams/tests.rs
+++ b/crates/perry-stdlib/src/streams/tests.rs
@@ -22,6 +22,9 @@ fn alloc_closed_readable() -> usize {
 
 #[test]
 fn stream_ids_live_outside_pointer_tag_small_handle_band() {
+    // Allocates from the shared pools — serialize so this can't steal the
+    // free-list id the recycle test below asserts on.
+    let _serial = serial_guard();
     let id = next_stream_id();
     assert!(
         (STREAM_HANDLE_ID_START..STREAM_HANDLE_ID_END).contains(&id),
@@ -73,9 +76,8 @@ fn retire_is_idempotent_per_id() {
     let id = alloc_closed_readable();
     idalloc::retire_readable_terminal(id);
     idalloc::retire_readable_terminal(id);
-    // The unregistered-id path must also skip it: the registry entry is still
-    // present in quarantine.
-    idalloc::retire_unregistered_id(id);
+    // The pipe-lock path must also skip it: it carries no ownership mark.
+    idalloc::retire_pipe_lock_id(id);
     assert_eq!(
         idalloc::test_pool_occurrences(id),
         1,
@@ -89,7 +91,7 @@ fn live_stream_ids_never_enter_the_pool() {
     idalloc::test_reset_pools();
     let id = alloc_readable(0, 0, 0, 1.0);
     idalloc::retire_readable_terminal(id); // Readable → not terminal
-    idalloc::retire_unregistered_id(id); // registered → guarded
+    idalloc::retire_pipe_lock_id(id); // no ownership mark → guarded
     assert_eq!(idalloc::test_pool_occurrences(id), 0);
     {
         // Closed but undrained (slow consumer with queued chunks) stays live.
@@ -100,6 +102,21 @@ fn live_stream_ids_never_enter_the_pool() {
     }
     idalloc::retire_readable_terminal(id);
     assert_eq!(idalloc::test_pool_occurrences(id), 0);
+}
+
+#[test]
+fn pipe_lock_ids_retire_once_via_ownership_mark() {
+    let _serial = serial_guard();
+    idalloc::test_reset_pools();
+    let id = idalloc::next_pipe_lock_id();
+    idalloc::retire_pipe_lock_id(id);
+    idalloc::retire_pipe_lock_id(id); // stale duplicate release: mark gone
+    assert_eq!(idalloc::test_pool_occurrences(id), 1);
+    // A live registered id is untouchable through the pipe path even though
+    // it, too, has no ownership mark.
+    let live = alloc_readable(0, 0, 0, 1.0);
+    idalloc::retire_pipe_lock_id(live);
+    assert_eq!(idalloc::test_pool_occurrences(live), 0);
 }
 
 #[test]

--- a/crates/perry-stdlib/src/streams/transform.rs
+++ b/crates/perry-stdlib/src/streams/transform.rs
@@ -74,7 +74,7 @@ unsafe fn alloc_transform_stream_with_strategies(
 
     // Allocate writable side; its write_cb is synthesized via the
     // dispatcher table below to invoke transform(chunk, controller).
-    let writable_id = next_id(&NEXT_STREAM_ID);
+    let writable_id = next_stream_id();
     let ready = internal_promise();
     let closed = internal_promise();
     js_promise_resolve(ready, f64::from_bits(TAG_UNDEFINED));
@@ -106,7 +106,7 @@ unsafe fn alloc_transform_stream_with_strategies(
         },
     );
 
-    let id = next_id(&NEXT_STREAM_ID);
+    let id = next_stream_id();
     TRANSFORM_STREAMS.lock().unwrap().insert(
         id,
         TransformStreamData {
@@ -464,6 +464,7 @@ pub(super) unsafe fn transform_close(writable_id: usize) -> *mut Promise {
             let cp = s.closed_promise;
             js_promise_reject(cp, f64::from_bits(error_bits));
         }
+        super::idalloc::retire_writable_terminal(writable_id);
         js_promise_reject(promise, f64::from_bits(error_bits));
         return promise;
     }
@@ -569,6 +570,7 @@ unsafe fn finish_transform_close(
         let cp = s.closed_promise;
         js_promise_resolve(cp, f64::from_bits(TAG_UNDEFINED));
     }
+    super::idalloc::retire_writable_terminal(writable_id);
     js_promise_resolve(close_promise, f64::from_bits(TAG_UNDEFINED));
 }
 
@@ -590,6 +592,7 @@ unsafe fn error_transform_close(
         let cp = s.closed_promise;
         js_promise_reject(cp, f64::from_bits(reason_bits));
     }
+    super::idalloc::retire_writable_terminal(writable_id);
     js_promise_reject(close_promise, f64::from_bits(reason_bits));
 }
 

--- a/crates/perry-stdlib/src/streams/writable.rs
+++ b/crates/perry-stdlib/src/streams/writable.rs
@@ -102,7 +102,7 @@ pub unsafe extern "C" fn js_writable_stream_get_writer(stream_handle: f64) -> f6
         drop(g);
         throw_type_error("WritableStream is locked");
     }
-    let writer_id = next_id(&NEXT_STREAM_ID);
+    let writer_id = next_stream_id();
     s.writer_handle = Some(writer_id);
     let closed_p = s.closed_promise;
     let ready_p = s.ready_promise;
@@ -219,6 +219,7 @@ pub(super) unsafe fn js_writable_stream_abort_inner(
     }
     // #5437: writable stream aborted (terminal Errored) — drop expandos.
     super::expando::stream_expando_clear(id);
+    super::idalloc::retire_writable_terminal(id);
     js_promise_resolve(promise, f64::from_bits(TAG_UNDEFINED));
     promise
 }
@@ -469,6 +470,7 @@ unsafe fn finish_writable_close_success(stream_id: usize, promise: *mut Promise)
     }
     // #5437: writable stream reached its terminal Closed state — drop expandos.
     super::expando::stream_expando_clear(stream_id);
+    super::idalloc::retire_writable_terminal(stream_id);
 }
 
 unsafe fn finish_writable_close_error(stream_id: usize, promise: *mut Promise, reason: f64) {
@@ -496,6 +498,7 @@ unsafe fn finish_writable_close_error(stream_id: usize, promise: *mut Promise, r
     }
     // #5437: writable stream reached its terminal Errored state — drop expandos.
     super::expando::stream_expando_clear(stream_id);
+    super::idalloc::retire_writable_terminal(stream_id);
 }
 
 pub(super) unsafe fn run_writable_write(
@@ -687,6 +690,7 @@ unsafe fn finish_writable_write_error(stream_id: usize, promise: *mut Promise, r
     if !closed.is_null() {
         js_promise_reject(closed, reason);
     }
+    super::idalloc::retire_writable_terminal(stream_id);
 }
 
 #[no_mangle]
@@ -768,6 +772,7 @@ pub unsafe extern "C" fn js_writer_release_lock(writer_handle: f64) -> f64 {
     // #5437: writer instance done — drop its expando entries (see the reader
     // release path in streams.rs).
     super::expando::stream_expando_clear(writer_id);
+    super::idalloc::retire_writer_if_released(writer_id);
     f64::from_bits(TAG_UNDEFINED)
 }
 


### PR DESCRIPTION
Fixes #6602.

## Problem

All Web Streams handle ids (streams, readers, writers, transform streams, and pipeTo's internal lock ids) come from one monotonic counter over the band `[0x100000, 0x200000)` and were never reused. A server minting ~48 stream-family ids per request exhausts the band after ~21k requests; past `STREAM_ID_BAND_END` every band-gated classification path stops recognizing handles — the same failure class as #6599 with a ~20k-request fuse. Independently, the five registries never removed entries, so registry memory (and the GC root set) grew one entry per stream for the life of the process.

## Fix: retire → quarantine → evict → free list (`streams/idalloc.rs`)

An id **retires** when its object reaches a terminal state:

| object | terminal point |
|---|---|
| readable | errored, or closed with queue + pending reads drained (`close_pending` / `error_pending`) |
| writable | closed/errored/aborted with no in-flight write and empty queue |
| reader / writer | `releaseLock()`, or their stream reaching terminal while still attached |
| transform | its writable side reaching terminal (close / flush error / abort, via `TRANSFORM_PAIRS`) |
| tee source | unlink (close discovery or branch error) |
| pipeTo lock ids | pipe completion/rejection and acquire-failure paths — these ids never owned a registry entry at all, so every pipe burned two band ids permanently |

A retired id sits in a FIFO **quarantine** with its registry entry intact, so a wrapper still held by user code keeps full post-terminal semantics (`locked`, `getReader()` on a closed stream, stored error values, promise getters). Only when the quarantine overflows `PERRY_STREAM_ID_QUARANTINE` (default 16384; clamped to `[2, band/2]`) is the oldest id **evicted** — its entry removed from all five registries plus the byob/tee/transform/expando side tables (dropping its GC roots) — and pushed to the free list that `next_stream_id` prefers over fresh ids. A stale wrapper can only observe recycling after its id survived a full quarantine of later teardowns; before that a registry miss degrades to the same defaults a plain in-band number gets (which for the common patterns is still spec-correct: `read()` on a torn-down closed stream resolves `{done: true}`, `cancel()` resolves undefined, `locked` is `false`).

Double-retire / double-free is structurally prevented: a `pooled` set covers both pool stages, per-kind terminal checks gate registration-owning ids, and the pipe-id path requires `js_stream_handle_kind(id) == 0` so a stale duplicate release can never retire the id's next life.

Lock order: the allocator mutex is a leaf (`get_reader`/`get_writer` allocate under registry locks), so eviction's registry cleanup runs between two allocator-lock sections and every retire call site sits outside registry guards (`acquire_pipe_locks` was split so its failure paths retire after guards drop).

Also fixed on the way: `tee_error_branches` now stamps the orphaned source `Errored` (it stayed `Readable` forever, leaking its entry, queued chunks, and id — post-unlink enqueues now drop instead of piling into a dead queue).

## Why quarantine + free list instead of alternatives

- Recycling at terminal time *without* quarantine breaks legal post-terminal API use (`getReader()` on a closed stream, `locked`, error-value reads) the moment an id is reused.
- A wrap-around allocator probing registries for liveness reuses ids adjacent to still-live wrappers with no reuse-distance guarantee (called out in the issue).
- Widening the band just moves the fuse and eats into heap-address plausibility space (#1843/#6599 history).

## Validation

- `cargo test -p perry-stdlib --lib streams::` — 8/8 (4 new tests: FIFO recycle-after-eviction with registry cleanup asserted, per-id retire idempotence, live/undrained ids never pool, attached reader dies with terminal stream but not before). The pre-existing `crypto::random::tests::native_dispatch_random_bytes_value_form_fires_callback` failure reproduces identically on the base commit.
- End-to-end churn repro (compiled with the branch compiler): 2000 create/read/release cycles + 500 pipeTo + 500 cancels, then transform/tee/closed-stream use — byte-identical to `node --experimental-strip-types` for the streaming sections at `PERRY_STREAM_ID_QUARANTINE=8` (heavy recycling), proving recycled ids classify and dispatch correctly through `getReader`/`read`/`releaseLock`/`pipeTo`/`tee`/`for await`.
- `cargo fmt --all -- --check` clean for all touched files (several unrelated files on main currently have fmt diffs).

The repro also surfaced two pre-existing divergences, both verified to reproduce identically on the unmodified base commit and filed separately: #6606 (`k≥512`-class numeric-handle misclassification SIGSEGV in the tee/iteration path — a third #6599-class site; this PR's recycling masks it when ids stay low but does not fix it) and #6607 (`TransformStream` unawaited writes dropped by a synchronous `writer.close()`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Web Streams handle lifecycle management across closure, errors, reader/writer releases, `pipeTo`, BYOB, and tee operations.
  - Added safer handle/terminal retirement with recycling after quarantine eviction to reduce leaks and stale registry entries.
  - Improved tee error behavior by clearing queued chunks and updating source/branch state consistently.
- **Tests**
  - Added/extended serialized tests covering handle reuse, retirement idempotency, pipe-lock ownership behavior, and lifecycle invariants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->