### PR TITLE
fix(runtime): declare ExitProcess as never-returning on Windows (build break)

### DIFF
--- a/crates/perry-runtime/src/process/env_misc.rs
+++ b/crates/perry-runtime/src/process/env_misc.rs
@@ -113,7 +113,7 @@ fn terminate_without_atexit(exit_code: i32) -> ! {
     #[cfg(windows)]
     {
         extern "system" {
-            fn ExitProcess(uExitCode: u32);
+            fn ExitProcess(uExitCode: u32) -> !;
         }
         unsafe {
             ExitProcess(exit_code as u32);


### PR DESCRIPTION
## Problem

`perry-runtime` has not compiled on Windows since ~2026-07-14:

```
error[E0308]: mismatched types
   --> crates\perry-runtime\src\process\env_misc.rs:118:9
118 | /         unsafe {
119 | |             ExitProcess(exit_code as u32);
120 | |         }
    | |_________^ expected `!`, found `()`
```

`terminate_without_atexit` is typed `-> !`, but the hand-rolled extern declaration for `ExitProcess` returns `()`, so on Windows the `#[cfg(windows)]` arm is the function tail and fails E0308. (On Unix the `libc::_exit` arm diverges, so non-Windows builds never see it — and CI has no Windows build job to catch it.)

## Fix

Declare the extern as never-returning — `fn ExitProcess(uExitCode: u32) -> !` — matching `windows-sys`' own binding. `ExitProcess` never returns, so this is the accurate signature, and the cfg arm now types as `!`.

## Validation

- `cargo build --release -p perry-runtime` on Windows 11 x64 (MSVC): compiles past the previous error (rest of the workspace build proceeds).
- No behavior change on any platform; Unix/other arms untouched.

Found while auditing Windows support; a follow-up PR adds a `windows-latest` build job to CI so this class of break fails PRs instead of shipping.

Per maintainer instruction: no version bump / changelog entry — metadata folded in at merge time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows process termination handling to ensure the application exits reliably without running exit handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->