### PR TITLE
ci: add windows-latest build job so Windows compile/link breaks fail PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -599,6 +599,48 @@ jobs:
           exit "$status"
 
   # ---------------------------------------------------------------------------
+  # Windows build gate
+  #
+  # Exists because Windows-only compile/link breaks previously shipped to main
+  # unseen — every other job runs on ubuntu/macos. Two real examples that
+  # landed through green required checks: an MSVC-only rustc error (E0308 on
+  # the `ExitProcess` extern in crates/perry-runtime/src/process/env_misc.rs)
+  # and an MSVC-only link error (LNK2019: `js_crypto_ed25519_verify`
+  # unresolved when linking perry.exe — Unix linkers dead-strip the unused
+  # extern, link.exe errors). Building `perry` LINKS perry.exe, so the LNK2019
+  # class is caught here, not just rustc errors. The perry-dev profile
+  # (opt-level 1, no LTO) keeps a cold Windows build inside a PR-sized budget;
+  # --release would be far too slow for per-PR CI.
+  # ---------------------------------------------------------------------------
+  windows-build:
+    runs-on: windows-latest
+    # Cold Windows builds are slow, and this workflow never runs on pushes to
+    # main, so rust-cache only saves on the nightly cron (github.ref is
+    # refs/heads/main for `schedule`) — PR runs after a quiet night can be
+    # near-cold. 75 leaves headroom over a fully cold build while still
+    # bounding a true hang (same reasoning as conformance-smoke's bump: a
+    # timeout on a required-path job is a deterministic PR blocker).
+    timeout-minutes: 75
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "${{ runner.os }}-perry"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      # perry-dev (see Cargo.toml [profile.perry-dev]) trades peak optimization
+      # for build speed. The package set covers the compiler binary (link
+      # gate), the runtime/stdlib pair (the usual source of cfg(windows)
+      # externs), and both Windows UI crates — the ones cargo-test's ubuntu
+      # runner must exclude and therefore never compiles.
+      - name: Build compiler + runtime + Windows UI crates (perry-dev)
+        run: cargo build --profile perry-dev -p perry -p perry-runtime -p perry-stdlib -p perry-ui-windows -p perry-ui-windows-winui
+
+  # ---------------------------------------------------------------------------
   # GC write-barrier stress (optional / non-blocking)
   #
   # `crates/perry/tests/gc_write_barrier_stress.rs` runs compiled binaries


### PR DESCRIPTION
## What

Adds a `windows-build` job to `.github/workflows/test.yml` (the required-checks workflow). It runs on `windows-latest` and builds:

```
cargo build --profile perry-dev -p perry -p perry-runtime -p perry-stdlib -p perry-ui-windows -p perry-ui-windows-winui
```

That package set covers the compiler binary (so `perry.exe` actually **links**), the runtime/stdlib pair (the usual home of `cfg(windows)` externs), and both Windows UI crates — exactly the crates `cargo-test`'s ubuntu runner must `--exclude` and therefore never compiles. Setup mirrors the workflow's existing conventions: `actions/checkout@v7`, `dtolnay/rust-toolchain@stable`, `Swatinem/rust-cache@v2` with `shared-key: "${{ runner.os }}-perry"` (auto-keyed per OS) and the same main-only `save-if` (the nightly cron warms it, since `schedule` runs on `refs/heads/main`).

## Why

Every job in this workflow runs exclusively on ubuntu/macos, so Windows builds of `main` break silently. Two real, current examples that shipped through green required checks:

1. **rustc E0308** in `perry-runtime` — the `ExitProcess` extern declaration in `crates/perry-runtime/src/process/env_misc.rs` (Windows-only `cfg`, so Unix CI never type-checks it). Fix in flight on `fix/windows-exitprocess-never`.
2. **LNK2019: `js_crypto_ed25519_verify` unresolved** when linking `perry.exe` — the extern is declared in `perry-updater` but only defined in `perry-stdlib`; Unix linkers dead-strip the unused reference, MSVC's `link.exe` hard-errors. Fix in a parallel PR.

This job would have turned both into a red PR check instead of a broken `main`.

## Why the perry-dev profile

`perry-dev` (opt-level 1, codegen-units 16, no LTO — see `[profile.perry-dev]` in `Cargo.toml`) builds in minutes instead of the ~30+ a `--release`/LTO build takes, while still driving the full compile **and link** of `perry.exe` — so both the E0308 class and the LNK2019 class are caught. `--release` would be far too slow for per-PR CI and adds nothing for this gate.

## Notes

- `timeout-minutes: 75`: cold Windows builds are slow and this workflow never runs on pushes to main, so PR runs after a cache-less night can be near-cold; a timeout on a required-path job is a deterministic PR blocker (same reasoning as the conformance-smoke bump in #6456).
- Making the job a *required* check is repo branch-protection settings, not yml — left to the maintainer.
- Expect this job to be **red on this PR** until the two fixes above merge: it is gating exactly the breaks that motivated it.
- No version bump / changelog per maintainer instruction — folded in at merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a Windows build verification job to detect platform-specific compilation and linking issues.
  * Windows builds now cover the core application, runtime, standard library, and Windows UI components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->