### PR TITLE
fix(runtime): async child.kill/timeout/AbortSignal terminate children on Windows

### DIFF
--- a/crates/perry-runtime/Cargo.toml
+++ b/crates/perry-runtime/Cargo.toml
@@ -246,6 +246,7 @@ windows-sys = { version = "0.61", features = [
     "Win32_System_Console",
     "Win32_Foundation",
     "Win32_System_LibraryLoader",
+    "Win32_System_Threading",
 ] }
 
 # #855: libc::mach_host_self is deprecated; the mach2 crate is the

--- a/crates/perry-runtime/src/child_process/reactor.rs
+++ b/crates/perry-runtime/src/child_process/reactor.rs
@@ -125,12 +125,40 @@ struct LiveChild {
     /// arrives, keeping the JS-visible exit identical to the unix arm's.
     #[cfg(windows)]
     win_kill_signal: Option<i32>,
+    /// Windows: a process handle duplicated at spawn time
+    /// (`cp_win_dup_proc_handle`), stored as a raw `isize` so the registry
+    /// stays `Send`. The kill paths act on THIS handle, never the pid: the
+    /// waiter thread's `Child::wait()` reaps the process (freeing the pid for
+    /// OS reuse) *before* its `Exited` event reaches the pump, so a `kill()`
+    /// racing into that window could otherwise `OpenProcess` a recycled pid
+    /// and terminate an innocent process. A held handle keeps naming the
+    /// original process object forever — the same strategy as libuv's
+    /// `uv_process_kill`. `0` if duplication failed. Closed by `Drop`.
+    #[cfg(windows)]
+    win_proc_handle: isize,
     /// #4912: present for children launched by the async `exec`/`execFile`
     /// callback form. When set, the pump buffers stdout/stderr instead of
     /// emitting stream events and fires this single `(err, stdout, stderr)`
     /// callback on `close` — Node's "run off-thread, call back on a later
     /// tick" model. `None` for `spawn`/`fork`.
     exec: Option<Box<CpExecPending>>,
+}
+
+#[cfg(windows)]
+impl Drop for LiveChild {
+    /// Close the process handle duplicated at spawn. The registry entry is
+    /// the single owner: Phase B's `map.remove` drops the entry once the
+    /// child has fully closed (exit reported + streams at EOF), and process
+    /// teardown drops whatever remains.
+    fn drop(&mut self) {
+        if self.win_proc_handle != 0 {
+            unsafe {
+                let _ = windows_sys::Win32::Foundation::CloseHandle(
+                    self.win_proc_handle as windows_sys::Win32::Foundation::HANDLE,
+                );
+            }
+        }
+    }
 }
 
 /// Buffered state for an async `exec`/`execFile` child (#4912). Output is
@@ -330,6 +358,10 @@ pub(super) fn cp_register_live_child(
 ) -> u64 {
     let pid = child.id();
     cp_set_field(cp, b"pid", pid as f64);
+    // Duplicate the process handle BEFORE `child` moves to the waiter thread —
+    // the kill paths act on it instead of the recyclable pid.
+    #[cfg(windows)]
+    let win_proc_handle = cp_win_dup_proc_handle(&child);
 
     let stdout_pipe = child.stdout.take();
     let stderr_pipe = child.stderr.take();
@@ -375,6 +407,8 @@ pub(super) fn cp_register_live_child(
                 abort_kill_signal: libc_sigterm(),
                 #[cfg(windows)]
                 win_kill_signal: None,
+                #[cfg(windows)]
+                win_proc_handle,
                 exec: None,
             },
         );
@@ -813,6 +847,10 @@ pub(super) fn cp_exec_async(
     match command.spawn() {
         Ok(mut child) => {
             let pid = child.id();
+            // Duplicate the process handle BEFORE `child` moves to the waiter
+            // thread — the kill paths act on it instead of the recyclable pid.
+            #[cfg(windows)]
+            let win_proc_handle = cp_win_dup_proc_handle(&child);
             let stdout_pipe = child.stdout.take();
             let stderr_pipe = child.stderr.take();
             let stdout_open = stdout_pipe.is_some();
@@ -853,6 +891,8 @@ pub(super) fn cp_exec_async(
                         abort_kill_signal: libc_sigterm(),
                         #[cfg(windows)]
                         win_kill_signal: None,
+                        #[cfg(windows)]
+                        win_proc_handle,
                         exec: Some(exec),
                     },
                 );
@@ -1286,49 +1326,71 @@ pub(super) fn cp_live_stdin_close(handle: u64) {
     }
 }
 
-/// Terminate (or probe) a process by pid on Windows — the structural analogue
-/// of the unix arm's `libc::kill(pid, sig)`. The reactor cannot reach the
-/// `Child` here (the waiter thread owns it, blocked in `Child::wait()`), so it
-/// acts on the pid alone, the way libuv's `uv_kill` does:
+/// Duplicate `child`'s process handle before the `Child` moves to the waiter
+/// thread, so the kill paths can act on the process object itself rather than
+/// the recyclable pid (see `cp_win_kill`). The registry entry owns the
+/// duplicate; `LiveChild::drop` closes it. Returns `0` when duplication fails
+/// — kills on that child then report undelivered rather than falling back to
+/// a racy pid-based kill.
+#[cfg(windows)]
+fn cp_win_dup_proc_handle(child: &Child) -> isize {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Foundation::{DuplicateHandle, DUPLICATE_SAME_ACCESS, HANDLE};
+    use windows_sys::Win32::System::Threading::GetCurrentProcess;
+    let mut dup: HANDLE = std::ptr::null_mut();
+    let ok = unsafe {
+        DuplicateHandle(
+            GetCurrentProcess(),
+            child.as_raw_handle() as HANDLE,
+            GetCurrentProcess(),
+            &mut dup,
+            0,
+            0,
+            DUPLICATE_SAME_ACCESS,
+        )
+    };
+    if ok != 0 {
+        dup as isize
+    } else {
+        0
+    }
+}
+
+/// Terminate (or probe) a live child on Windows through the process handle
+/// duplicated at spawn time — the structural analogue of the unix arm's
+/// `libc::kill(pid, sig)`, and the same strategy as libuv's
+/// `uv_process_kill`. Acting on the held handle (never the pid) closes the
+/// pid-reuse race: the waiter thread may already have reaped the `Child` —
+/// freeing the pid for OS reuse — before its `Exited` event reaches the pump,
+/// but the duplicate keeps naming the original process object forever, so a
+/// recycled pid can never be terminated by mistake.
 ///
 /// * `signum == 0` — the POSIX existence probe: no side effect, just "is the
 ///   process still alive?" (`GetExitCodeProcess` still reporting
-///   `STILL_ACTIVE` on a `PROCESS_QUERY_LIMITED_INFORMATION` handle).
+///   `STILL_ACTIVE`).
 /// * any other signal — degrades to `TerminateProcess(handle, 1)`, exactly
-///   like Node on Windows (there are no POSIX signals to deliver).
+///   like Node on Windows (there are no POSIX signals to deliver). On an
+///   already-exited process `TerminateProcess` fails, so the kill correctly
+///   reports undelivered.
 ///
 /// Returns whether the operation succeeded (the `libc::kill(..) == 0`
 /// analogue). The terminated child is reaped by the waiter thread as usual —
 /// `Child::wait()` returns once the process dies — so the existing
 /// Eof → Exited → exit/close pipeline completes naturally.
 #[cfg(windows)]
-fn cp_win_kill(pid: i32, signum: i32) -> bool {
-    use windows_sys::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
-    use windows_sys::Win32::System::Threading::{
-        GetExitCodeProcess, OpenProcess, TerminateProcess, PROCESS_QUERY_LIMITED_INFORMATION,
-        PROCESS_TERMINATE,
-    };
-    if pid <= 0 {
-        return false;
+fn cp_win_kill(proc_handle: isize, signum: i32) -> bool {
+    use windows_sys::Win32::Foundation::{HANDLE, STILL_ACTIVE};
+    use windows_sys::Win32::System::Threading::{GetExitCodeProcess, TerminateProcess};
+    if proc_handle == 0 {
+        return false; // spawn-time DuplicateHandle failed — nothing to act on
     }
+    let handle = proc_handle as HANDLE;
     if signum == 0 {
-        let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid as u32) };
-        if handle.is_null() {
-            return false;
-        }
         let mut code: u32 = 0;
-        let alive =
-            unsafe { GetExitCodeProcess(handle, &mut code) } != 0 && code == STILL_ACTIVE as u32;
-        unsafe { CloseHandle(handle) };
-        return alive;
+        return unsafe { GetExitCodeProcess(handle, &mut code) } != 0
+            && code == STILL_ACTIVE as u32;
     }
-    let handle = unsafe { OpenProcess(PROCESS_TERMINATE, 0, pid as u32) };
-    if handle.is_null() {
-        return false;
-    }
-    let ok = unsafe { TerminateProcess(handle, 1) } != 0;
-    unsafe { CloseHandle(handle) };
-    ok
+    unsafe { TerminateProcess(handle, 1) != 0 }
 }
 
 /// Record a successful Windows termination so the waiter's eventual `Exited`
@@ -1347,18 +1409,32 @@ fn cp_note_win_kill(handle: u64, signum: i32) {
     }
 }
 
+/// What the platform kill primitive acts on: the pid for unix `libc::kill`,
+/// the spawn-time duplicated process handle on Windows (immune to pid reuse —
+/// see `cp_win_kill`).
+#[cfg(not(windows))]
+#[inline]
+fn cp_kill_target(lc: &LiveChild) -> i32 {
+    lc.pid
+}
+#[cfg(windows)]
+#[inline]
+fn cp_kill_target(lc: &LiveChild) -> isize {
+    lc.win_proc_handle
+}
+
 fn cp_live_kill_signum(handle: u64, signum: i32) -> Option<u64> {
-    let (pid, cp_bits) = {
+    let (target, cp_bits) = {
         let guard = cp_live_lock();
         match guard.as_ref().and_then(|map| map.get(&handle)) {
             // Skip if already reaped — the pid may have been recycled by the OS.
-            Some(lc) if lc.exited.is_none() => (lc.pid, lc.cp_bits),
+            Some(lc) if lc.exited.is_none() => (cp_kill_target(lc), lc.cp_bits),
             _ => return None,
         }
     };
     #[cfg(unix)]
     {
-        if unsafe { libc::kill(pid, signum) == 0 } {
+        if unsafe { libc::kill(target, signum) == 0 } {
             Some(cp_bits)
         } else {
             None
@@ -1366,7 +1442,7 @@ fn cp_live_kill_signum(handle: u64, signum: i32) -> Option<u64> {
     }
     #[cfg(windows)]
     {
-        if cp_win_kill(pid, signum) {
+        if cp_win_kill(target, signum) {
             cp_note_win_kill(handle, signum);
             Some(cp_bits)
         } else {
@@ -1375,7 +1451,7 @@ fn cp_live_kill_signum(handle: u64, signum: i32) -> Option<u64> {
     }
     #[cfg(not(any(unix, windows)))]
     {
-        let _ = (pid, signum, cp_bits);
+        let _ = (target, signum, cp_bits);
         None
     }
 }
@@ -1389,21 +1465,21 @@ pub(super) fn cp_live_kill(handle: u64, signal: f64) -> bool {
 }
 
 fn cp_live_kill_signal(handle: u64, signum: i32) -> bool {
-    let pid = {
+    let target = {
         let guard = cp_live_lock();
         match guard.as_ref().and_then(|map| map.get(&handle)) {
             // Skip if already reaped — the pid may have been recycled by the OS.
-            Some(lc) if lc.exited.is_none() => lc.pid,
+            Some(lc) if lc.exited.is_none() => cp_kill_target(lc),
             _ => return false,
         }
     };
     #[cfg(unix)]
     {
-        unsafe { libc::kill(pid, signum) == 0 }
+        unsafe { libc::kill(target, signum) == 0 }
     }
     #[cfg(windows)]
     {
-        if cp_win_kill(pid, signum) {
+        if cp_win_kill(target, signum) {
             cp_note_win_kill(handle, signum);
             true
         } else {
@@ -1412,7 +1488,7 @@ fn cp_live_kill_signal(handle: u64, signum: i32) -> bool {
     }
     #[cfg(not(any(unix, windows)))]
     {
-        let _ = (pid, signum);
+        let _ = (target, signum);
         false
     }
 }
@@ -1510,8 +1586,11 @@ pub(crate) fn cp_reactor_scan_roots_mut(visitor: &mut crate::gc::RuntimeRootVisi
 mod windows_kill_tests {
     use super::*;
 
-    /// Raw `cp_win_kill`: sig-0 existence probe on a live child, terminate on
-    /// a real signal, probe failure after death.
+    /// Raw `cp_win_dup_proc_handle` + `cp_win_kill`: sig-0 existence probe on
+    /// a live child, terminate through the duplicated handle, probe + kill
+    /// failure after death. The held duplicate keeps naming the original
+    /// process object even once the child is reaped — exactly the property
+    /// that closes the pid-reuse race.
     #[test]
     fn win_kill_probe_and_terminate() {
         let mut child = std::process::Command::new("ping")
@@ -1520,19 +1599,36 @@ mod windows_kill_tests {
             .stderr(Stdio::null())
             .spawn()
             .expect("spawn ping");
-        let pid = child.id() as i32;
+        let proc_handle = cp_win_dup_proc_handle(&child);
+        assert_ne!(proc_handle, 0, "DuplicateHandle should succeed");
 
         // POSIX `kill(pid, 0)` analogue: existence probe, no side effect.
-        assert!(cp_win_kill(pid, 0), "probe should see the live child");
+        assert!(
+            cp_win_kill(proc_handle, 0),
+            "probe should see the live child"
+        );
 
         // Any terminating signal degrades to `TerminateProcess(handle, 1)`.
-        assert!(cp_win_kill(pid, 15), "terminate should succeed");
+        assert!(cp_win_kill(proc_handle, 15), "terminate should succeed");
         let status = child.wait().expect("wait after TerminateProcess");
         assert_eq!(status.code(), Some(1), "TerminateProcess exit code");
 
-        // `child` still holds a process handle, so the pid cannot have been
-        // recycled: the probe now deterministically reports "not alive".
-        assert!(!cp_win_kill(pid, 0), "probe should fail once terminated");
+        // The duplicate still names the original (now-dead) process after the
+        // reap, so both the probe and a second kill deterministically fail —
+        // no pid-recycling flake window exists for a handle.
+        assert!(!cp_win_kill(proc_handle, 0), "probe should fail once dead");
+        assert!(
+            !cp_win_kill(proc_handle, 15),
+            "kill after death reports undelivered"
+        );
+
+        // The test owns this duplicate (no LiveChild registry entry) — close
+        // it by hand.
+        unsafe {
+            let _ = windows_sys::Win32::Foundation::CloseHandle(
+                proc_handle as windows_sys::Win32::Foundation::HANDLE,
+            );
+        }
     }
 
     /// Registry-level liveness: the pump removes the entry once the child has

--- a/crates/perry-runtime/src/child_process/reactor.rs
+++ b/crates/perry-runtime/src/child_process/reactor.rs
@@ -116,6 +116,15 @@ struct LiveChild {
     abort_listener_bits: u64,
     /// Signal number used when `options.signal` aborts this child.
     abort_kill_signal: i32,
+    /// Windows: the signal number of a successful `kill()` / timeout / abort
+    /// termination. On Windows the child dies via `TerminateProcess(h, 1)`, so
+    /// the waiter's `Child::wait()` reports the synthetic exit code 1 and no
+    /// signal; Node (via libuv's `uv_process_kill`) instead reports
+    /// `code: null, signal: <requested>`. Recording the requested signal here
+    /// lets the pump substitute the Node shape when the `Exited` event
+    /// arrives, keeping the JS-visible exit identical to the unix arm's.
+    #[cfg(windows)]
+    win_kill_signal: Option<i32>,
     /// #4912: present for children launched by the async `exec`/`execFile`
     /// callback form. When set, the pump buffers stdout/stderr instead of
     /// emitting stream events and fires this single `(err, stdout, stderr)`
@@ -364,6 +373,8 @@ pub(super) fn cp_register_live_child(
                 abort_signal_bits: 0,
                 abort_listener_bits: 0,
                 abort_kill_signal: libc_sigterm(),
+                #[cfg(windows)]
+                win_kill_signal: None,
                 exec: None,
             },
         );
@@ -443,8 +454,11 @@ fn cp_signal_number_from_value(signal: f64) -> i32 {
     }
     #[cfg(not(unix))]
     {
-        let _ = signal;
-        libc_sigterm()
+        // Windows: parse names/numbers with the shared cross-platform mapper
+        // so `killSignal: 'SIGKILL'` round-trips into the exit event's
+        // `signal` field. The number is only a reporting token — every
+        // terminating signal degrades to `TerminateProcess` at the kill site.
+        cp_signal_from_value(signal)
     }
 }
 
@@ -837,6 +851,8 @@ pub(super) fn cp_exec_async(
                         abort_signal_bits: 0,
                         abort_listener_bits: 0,
                         abort_kill_signal: libc_sigterm(),
+                        #[cfg(windows)]
+                        win_kill_signal: None,
                         exec: Some(exec),
                     },
                 );
@@ -1072,6 +1088,17 @@ fn cp_reactor_pump_inner() {
             } => {
                 if let Some(map) = cp_live_lock().as_mut() {
                     if let Some(lc) = map.get_mut(&handle) {
+                        // Windows: a kill()/timeout/abort termination surfaces
+                        // here as the synthetic `TerminateProcess` exit code
+                        // with no signal. Substitute the signal recorded at
+                        // kill time so the exit event carries Node's
+                        // `(code: null, signal: <requested>)` shape — see
+                        // `LiveChild::win_kill_signal`.
+                        #[cfg(windows)]
+                        let (code, signal) = match lc.win_kill_signal {
+                            Some(sig) if signal.is_none() => (None, Some(sig)),
+                            _ => (code, signal),
+                        };
                         lc.exited = Some((code, signal));
                     }
                 }
@@ -1259,6 +1286,67 @@ pub(super) fn cp_live_stdin_close(handle: u64) {
     }
 }
 
+/// Terminate (or probe) a process by pid on Windows — the structural analogue
+/// of the unix arm's `libc::kill(pid, sig)`. The reactor cannot reach the
+/// `Child` here (the waiter thread owns it, blocked in `Child::wait()`), so it
+/// acts on the pid alone, the way libuv's `uv_kill` does:
+///
+/// * `signum == 0` — the POSIX existence probe: no side effect, just "is the
+///   process still alive?" (`GetExitCodeProcess` still reporting
+///   `STILL_ACTIVE` on a `PROCESS_QUERY_LIMITED_INFORMATION` handle).
+/// * any other signal — degrades to `TerminateProcess(handle, 1)`, exactly
+///   like Node on Windows (there are no POSIX signals to deliver).
+///
+/// Returns whether the operation succeeded (the `libc::kill(..) == 0`
+/// analogue). The terminated child is reaped by the waiter thread as usual —
+/// `Child::wait()` returns once the process dies — so the existing
+/// Eof → Exited → exit/close pipeline completes naturally.
+#[cfg(windows)]
+fn cp_win_kill(pid: i32, signum: i32) -> bool {
+    use windows_sys::Win32::Foundation::{CloseHandle, STILL_ACTIVE};
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, TerminateProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+        PROCESS_TERMINATE,
+    };
+    if pid <= 0 {
+        return false;
+    }
+    if signum == 0 {
+        let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, pid as u32) };
+        if handle.is_null() {
+            return false;
+        }
+        let mut code: u32 = 0;
+        let alive =
+            unsafe { GetExitCodeProcess(handle, &mut code) } != 0 && code == STILL_ACTIVE as u32;
+        unsafe { CloseHandle(handle) };
+        return alive;
+    }
+    let handle = unsafe { OpenProcess(PROCESS_TERMINATE, 0, pid as u32) };
+    if handle.is_null() {
+        return false;
+    }
+    let ok = unsafe { TerminateProcess(handle, 1) } != 0;
+    unsafe { CloseHandle(handle) };
+    ok
+}
+
+/// Record a successful Windows termination so the waiter's eventual `Exited`
+/// event reports Node's `(code: null, signal: <requested>)` shape instead of
+/// the synthetic `TerminateProcess` exit code — see
+/// `LiveChild::win_kill_signal`.
+#[cfg(windows)]
+fn cp_note_win_kill(handle: u64, signum: i32) {
+    if signum == 0 {
+        return; // sig-0 probe — nothing was terminated
+    }
+    if let Some(map) = cp_live_lock().as_mut() {
+        if let Some(lc) = map.get_mut(&handle) {
+            lc.win_kill_signal = Some(signum);
+        }
+    }
+}
+
 fn cp_live_kill_signum(handle: u64, signum: i32) -> Option<u64> {
     let (pid, cp_bits) = {
         let guard = cp_live_lock();
@@ -1276,7 +1364,16 @@ fn cp_live_kill_signum(handle: u64, signum: i32) -> Option<u64> {
             None
         }
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+        if cp_win_kill(pid, signum) {
+            cp_note_win_kill(handle, signum);
+            Some(cp_bits)
+        } else {
+            None
+        }
+    }
+    #[cfg(not(any(unix, windows)))]
     {
         let _ = (pid, signum, cp_bits);
         None
@@ -1304,7 +1401,16 @@ fn cp_live_kill_signal(handle: u64, signum: i32) -> bool {
     {
         unsafe { libc::kill(pid, signum) == 0 }
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+        if cp_win_kill(pid, signum) {
+            cp_note_win_kill(handle, signum);
+            true
+        } else {
+            false
+        }
+    }
+    #[cfg(not(any(unix, windows)))]
     {
         let _ = (pid, signum);
         false
@@ -1388,5 +1494,116 @@ pub(crate) fn cp_reactor_scan_roots_mut(visitor: &mut crate::gc::RuntimeRootVisi
                 visitor.visit_nanbox_u64_slot(&mut exec.cb_bits);
             }
         }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+/// Windows termination tests. `child.kill()`, spawn `{ timeout }`,
+/// `AbortSignal`, and the exec `maxBuffer` breach all funnel through
+/// `cp_live_kill_signum` / `cp_live_kill_signal` → `cp_win_kill`, so
+/// terminating one live child through the shared path exercises the machinery
+/// all of them rely on.
+#[cfg(all(test, windows))]
+mod windows_kill_tests {
+    use super::*;
+
+    /// Raw `cp_win_kill`: sig-0 existence probe on a live child, terminate on
+    /// a real signal, probe failure after death.
+    #[test]
+    fn win_kill_probe_and_terminate() {
+        let mut child = std::process::Command::new("ping")
+            .args(["-n", "30", "127.0.0.1"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn ping");
+        let pid = child.id() as i32;
+
+        // POSIX `kill(pid, 0)` analogue: existence probe, no side effect.
+        assert!(cp_win_kill(pid, 0), "probe should see the live child");
+
+        // Any terminating signal degrades to `TerminateProcess(handle, 1)`.
+        assert!(cp_win_kill(pid, 15), "terminate should succeed");
+        let status = child.wait().expect("wait after TerminateProcess");
+        assert_eq!(status.code(), Some(1), "TerminateProcess exit code");
+
+        // `child` still holds a process handle, so the pid cannot have been
+        // recycled: the probe now deterministically reports "not alive".
+        assert!(!cp_win_kill(pid, 0), "probe should fail once terminated");
+    }
+
+    /// Registry-level liveness: the pump removes the entry once the child has
+    /// fully closed (exit reported + both streams at EOF).
+    fn handle_is_live(handle: u64) -> bool {
+        cp_live_lock()
+            .as_ref()
+            .is_some_and(|map| map.contains_key(&handle))
+    }
+
+    /// End-to-end through the reactor: spawn a long-running child via the
+    /// spawn FFI, terminate it through the same shared path `child.kill()` /
+    /// `{ timeout }` / `AbortSignal` use, and drive the pump until the exit
+    /// machinery completes. Asserts the Node-shaped exit for a Windows kill:
+    /// `exitCode: null`, `signalCode: 'SIGTERM'`.
+    #[test]
+    fn reactor_kill_terminates_live_child() {
+        // `ping -n 30 127.0.0.1` runs ~29s if not killed — long enough that a
+        // pass can only come from the kill path, short enough to bound a
+        // failure without hanging the suite.
+        let cmd = "ping";
+        let cmd_ptr = crate::string::js_string_from_bytes(cmd.as_ptr(), cmd.len() as u32);
+        let mut args = crate::array::js_array_alloc(3);
+        for a in ["-n", "30", "127.0.0.1"] {
+            let s = crate::string::js_string_from_bytes(a.as_ptr(), a.len() as u32);
+            args = crate::array::js_array_push_f64(args, crate::value::js_nanbox_string(s as i64));
+        }
+        let start = std::time::Instant::now();
+        let cp = js_child_process_spawn_streams(cmd_ptr as i64, args as i64, 0);
+
+        let pid = cp_get_field(cp, b"pid");
+        assert!(pid > 0.0, "spawn should set a real pid, got {pid}");
+        let handle = cp_get_field(cp, b"__cpHandle") as u64;
+        assert!(handle_is_live(handle));
+
+        // Phase 0 marks `spawned` — Phase B refuses to close before that.
+        cp_reactor_pump();
+
+        // Kill through the shared path (undefined signal → SIGTERM).
+        assert!(
+            cp_live_kill(handle, cp_undefined()),
+            "kill should be delivered"
+        );
+
+        // Drive the pump until the exit machinery completes: waiter reaps →
+        // `Exited` event → exit/close emitted → registry entry removed.
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        while handle_is_live(handle) {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "child did not close within 15s of kill()"
+            );
+            cp_reactor_pump();
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        // Well under ping's ~29s natural runtime — it died from the kill.
+        assert!(start.elapsed() < Duration::from_secs(20));
+
+        // Node's Windows kill shape: exitCode null, signalCode 'SIGTERM'
+        // (the requested signal, not TerminateProcess's synthetic exit code).
+        assert_eq!(
+            cp_get_field(cp, b"exitCode").to_bits(),
+            TAG_NULL_F64.to_bits(),
+            "exitCode should be null after a signal kill"
+        );
+        assert_eq!(
+            cp_value_to_string(cp_get_field(cp, b"signalCode")).as_deref(),
+            Some("SIGTERM")
+        );
+
+        // The child is reaped and deregistered — a second kill reports false.
+        assert!(!cp_live_kill(handle, cp_undefined()));
     }
 }

--- a/crates/perry-runtime/src/child_process/signals.rs
+++ b/crates/perry-runtime/src/child_process/signals.rs
@@ -88,9 +88,22 @@ pub(crate) fn cp_signal_number(name: &str) -> Option<i32> {
     })
 }
 
+/// Non-unix inverse of `cp_signal_name`, using the conventional POSIX numbers
+/// for the names the non-unix `cp_signal_name` can report back. The number is
+/// only a reporting token on Windows — every terminating signal degrades to
+/// `TerminateProcess` at the kill site, exactly like Node — so the table
+/// deliberately mirrors `cp_signal_name` above and nothing more.
 #[cfg(not(unix))]
-pub(crate) fn cp_signal_number(_name: &str) -> Option<i32> {
-    None
+pub(crate) fn cp_signal_number(name: &str) -> Option<i32> {
+    Some(match name {
+        "SIGHUP" => 1,
+        "SIGINT" => 2,
+        "SIGABRT" => 6,
+        "SIGKILL" => 9,
+        "SIGSEGV" => 11,
+        "SIGTERM" => 15,
+        _ => return None,
+    })
 }
 
 pub(crate) fn cp_signal_from_value(signal: f64) -> i32 {


### PR DESCRIPTION
## Problem

The async child-process reactor (`crates/perry-runtime/src/child_process/reactor.rs`) hands the `std::process::Child` to a waiter thread blocked in `Child::wait()`, so its kill paths must terminate by pid. Only a `libc::kill` unix arm existed — the `#[cfg(not(unix))]` arms of `cp_live_kill_signum` / `cp_live_kill_signal` were stubs returning `None` / `false`. Consequence on Windows: `child.kill()`, spawn `{ timeout }`, `AbortSignal` (`options.signal`), and the exec `maxBuffer` breach could not reap a hung child. (The sync path already worked via `Child::kill()` in `sync_run.rs:316-325`.)

## Mechanism

New `#[cfg(windows)] cp_win_kill(pid, signum) -> bool` — the structural analogue of the unix arm's `libc::kill(pid, sig)`, acting on the pid alone the way libuv's `uv_kill` does:

- any terminating signal → `OpenProcess(PROCESS_TERMINATE)` + `TerminateProcess(handle, 1)` + `CloseHandle` — every signal degrades to a forced kill, exactly like Node on Windows;
- `signum == 0` → the POSIX existence probe: `OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)` + `GetExitCodeProcess == STILL_ACTIVE`, no side effect.

Bindings follow the crate's existing style: `windows-sys` with function-local `use` under `#[cfg(windows)]`. One new feature (`Win32_System_Threading`) on the already-present dependency; `Cargo.lock` unchanged.

## Unix-arm parity

The shared contracts are preserved exactly: `cp_live_kill_signum` still returns `Option<u64>` (cp_bits on delivery), `cp_live_kill_signal` still returns `bool`, and both still skip already-reaped children (the pid-recycling guard). All four consumers — `kill()`, `CpEvent::Timeout`, `CpEvent::Abort`, exec `maxBuffer` — flow through unchanged shared code, so the `killed` flag flip, the AbortError `error` event, and the exec timeout error shape now behave on Windows exactly as on unix.

## Exit-event semantics after a Windows kill

On Windows, `Child::wait()` reports the synthetic `TerminateProcess` exit status (`code: 1`, no signal) — the OS has no signal concept. Node (via libuv's `uv_process_kill`) reports `code: null, signal: '<requested>'` instead. This PR matches Node: a successful Windows termination records the requested signal number in a new `#[cfg(windows)] LiveChild::win_kill_signal` field, and the pump substitutes `(None, Some(sig))` when the waiter's `Exited` event is applied. The `exit`/`close` events therefore carry `code: null, signal: 'SIGTERM'` (or the requested `killSignal`), with `exitCode`/`signalCode` fields to match — identical to the unix arm. **No divergence to document.** A child that exits on its own keeps its real exit code (the substitution only happens when a kill was actually delivered, mirroring libuv recording `exit_signal` only on successful `uv_process_kill`).

Two supporting fixes so signal *names* round-trip on Windows:

- `signals.rs`: the non-unix `cp_signal_number` was a `None` stub, which collapsed `kill('SIGKILL')` to SIGTERM before it ever reached the kill site; it now mirrors the non-unix `cp_signal_name` table (HUP/INT/ABRT/KILL/SEGV/TERM, conventional POSIX numbers). The number is purely a reporting token — the kill site always calls `TerminateProcess`.
- `reactor.rs cp_signal_number_from_value`: the non-unix arm now parses the abort `killSignal` option through the shared `cp_signal_from_value` instead of hardcoding SIGTERM, so `spawn(cmd, { signal, killSignal: 'SIGKILL' })` aborts report `SIGKILL`.

Waiter/stream teardown needed no changes: `TerminateProcess` makes `Child::wait()` return and breaks the stdio pipes, so the existing Eof → Exited → exit/close pipeline completes naturally (verified by the reactor test below — the killed child fully closes in well under a second).

## Tests

Two `#[cfg(all(test, windows))]` tests in `reactor.rs`. All kill consumers funnel through the same two helpers, so terminating one live child through the shared path covers the machinery `kill()` / `{ timeout }` / `AbortSignal` all rely on:

- `win_kill_probe_and_terminate` — raw `cp_win_kill`: sig-0 probe true on a live `ping -n 30 127.0.0.1`, terminate succeeds, `wait()` observes exit code 1, probe false after death (deterministic: the test still holds the process handle, so the pid cannot be recycled).
- `reactor_kill_terminates_live_child` — end-to-end through the reactor FFI: `js_child_process_spawn_streams("ping", ["-n","30","127.0.0.1"])`, kill via `cp_live_kill` (the exact function `child.kill()` calls), pump until the registry entry closes. Asserts: closes in seconds (15s bound vs ping's ~29s natural runtime — a pass can only come from the kill path), `exitCode: null`, `signalCode: 'SIGTERM'`, and a second `kill()` after reap returns `false`.

Verified locally on Windows 11 x64 / MSVC: `cargo check -p perry-runtime` (no new warnings from the touched files), `cargo test -p perry-runtime --release windows_kill` (2 passed), `cargo fmt` (touched files clean; several unrelated files are not fmt-clean under the local rustfmt and were left untouched).

Reviewer note: origin/main does not compile on Windows due to the pre-existing `ExitProcess` signature issue in `process/env_misc.rs` (fix tracked in PR #6609). That one-line local overlay was applied for building/testing only and is deliberately **not** part of this PR.

No version bump / changelog per maintainer instruction (external-contributor PR flow — the maintainer folds in metadata at merge).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Windows child-process termination support, including process-existence checks and signal handling.
  * Windows child processes now report termination events with the requested signal and a null exit code, matching Node.js behavior.
  * Added support for resolving named signals on Windows and other non-Unix platforms.

* **Bug Fixes**
  * Fixed repeated termination attempts to correctly report failure after the process has exited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->