### PR TITLE
fix(compile): #5779 — discover a bitcode-compatible LLVM tool so the runtime-dedup strip runs on macOS

### DIFF
--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -229,7 +229,82 @@ pub(super) fn find_llvm_tool(tool_name: &str) -> Option<PathBuf> {
         }
     }
 
+    // 4. Well-known LLVM install directories (#5779). The prebuilt runtime/stdlib
+    //    and well-known-wrapper archives carry LLVM *bitcode* emitted by the
+    //    active Rust toolchain's LLVM (thin-LTO). Inspecting/rewriting them for
+    //    the runtime-dedup strip (see `strip_bundled_runtime_from_well_known_lib`)
+    //    needs an `llvm-nm`/`llvm-ar`/`llvm-objcopy` whose LLVM is >= the
+    //    toolchain's — an older one fails (`nm: ... Unknown attribute kind`) and
+    //    the strip silently no-ops, leaving two disjoint copies of perry-runtime's
+    //    event-loop globals (the #5779 in-process server+fetch deadlock). The
+    //    system `nm` on macOS (Apple LLVM) is routinely too old, and Homebrew's
+    //    LLVM is keg-only (not on PATH), so it is missed by the checks above.
+    //    Search the standard keg/versioned locations, preferring the newest, so a
+    //    matching tool is found without the user having to add the toolchain's
+    //    `llvm-tools` component or put Homebrew LLVM on PATH.
+    if let Some(p) = find_tool_in_well_known_llvm_dirs(tool_name) {
+        return Some(p);
+    }
+
     None
+}
+
+/// Fallback LLVM-tool locator used by [`find_llvm_tool`]: scan the standard
+/// LLVM install directories that are commonly NOT on `PATH` — Homebrew's
+/// keg-only LLVM on macOS (`/opt/homebrew/opt/llvm`, `/usr/local/opt/llvm`,
+/// including versioned `llvm@NN` kegs) and Debian/Ubuntu's `/usr/lib/llvm-NN`.
+/// Versioned directories are tried newest-first so the returned tool is as new
+/// as possible (bitcode inspection needs LLVM >= the Rust toolchain's).
+fn find_tool_in_well_known_llvm_dirs(tool_name: &str) -> Option<PathBuf> {
+    let exe = format!("{tool_name}{}", std::env::consts::EXE_SUFFIX);
+
+    // Unversioned "current" kegs/prefixes first.
+    let mut dirs: Vec<PathBuf> = vec![
+        PathBuf::from("/opt/homebrew/opt/llvm/bin"),
+        PathBuf::from("/usr/local/opt/llvm/bin"),
+    ];
+
+    // Versioned kegs/installs, newest first. `(parent, prefix)`: e.g.
+    // `/opt/homebrew/opt/llvm@18` and `/usr/lib/llvm-18`.
+    for (parent, prefix) in [
+        ("/opt/homebrew/opt", "llvm@"),
+        ("/usr/local/opt", "llvm@"),
+        ("/usr/lib", "llvm-"),
+    ] {
+        let names: Vec<String> = std::fs::read_dir(parent)
+            .map(|entries| {
+                entries
+                    .flatten()
+                    .map(|e| e.file_name().to_string_lossy().into_owned())
+                    .collect()
+            })
+            .unwrap_or_default();
+        dirs.extend(versioned_llvm_bin_dirs(parent, prefix, &names));
+    }
+
+    dirs.into_iter()
+        .map(|d| d.join(&exe))
+        .find(|candidate| candidate.is_file())
+}
+
+/// Pure helper for [`find_tool_in_well_known_llvm_dirs`]: given the entry
+/// `names` found directly under `parent`, return the `<parent>/<name>/bin`
+/// paths for entries shaped `<prefix><MAJOR>[...]` (e.g. `llvm@18`, `llvm-17`),
+/// ordered newest major version first. Non-matching or non-numeric entries are
+/// ignored. Kept separate (no filesystem access) so the version ordering is
+/// unit-testable.
+fn versioned_llvm_bin_dirs(parent: &str, prefix: &str, names: &[String]) -> Vec<PathBuf> {
+    let mut versioned: Vec<(u32, PathBuf)> = names
+        .iter()
+        .filter_map(|name| {
+            let ver = name.strip_prefix(prefix)?;
+            let major: String = ver.chars().take_while(|c| c.is_ascii_digit()).collect();
+            let n = major.parse::<u32>().ok()?;
+            Some((n, Path::new(parent).join(name).join("bin")))
+        })
+        .collect();
+    versioned.sort_by(|a, b| b.0.cmp(&a.0));
+    versioned.into_iter().map(|(_, p)| p).collect()
 }
 
 /// Find MSVC link.exe by searching Visual Studio installation directories.
@@ -1695,6 +1770,54 @@ mod native_lib_artifact_tests {
         fs::create_dir_all(&target_dir).expect("mkdir target");
         let found = locate_native_lib_artifact(&target_dir, None, "libfoo.a");
         assert!(found.is_none());
+    }
+}
+
+#[cfg(test)]
+mod llvm_tool_discovery_tests {
+    use super::versioned_llvm_bin_dirs;
+    use std::path::PathBuf;
+
+    // #5779: the well-known-LLVM-dir fallback must return versioned kegs
+    // newest-first, so bitcode inspection uses an LLVM at least as new as the
+    // Rust toolchain's. Ordering is the only non-trivial part, and it is pure,
+    // so exercise it directly without touching the filesystem.
+    #[test]
+    fn versioned_llvm_dirs_are_newest_first() {
+        let names = vec![
+            "llvm@15".to_string(),
+            "llvm@18".to_string(),
+            "llvm@9".to_string(),
+            "llvm".to_string(),    // unversioned — ignored here
+            "node@20".to_string(), // wrong prefix — ignored
+        ];
+        let dirs = versioned_llvm_bin_dirs("/opt/homebrew/opt", "llvm@", &names);
+        assert_eq!(
+            dirs,
+            vec![
+                PathBuf::from("/opt/homebrew/opt/llvm@18/bin"),
+                PathBuf::from("/opt/homebrew/opt/llvm@15/bin"),
+                PathBuf::from("/opt/homebrew/opt/llvm@9/bin"),
+            ]
+        );
+    }
+
+    #[test]
+    fn versioned_llvm_dirs_handles_debian_prefix_and_ignores_nonmatching() {
+        let names = vec![
+            "llvm-17".to_string(),
+            "llvm-16.0".to_string(),
+            "gcc-12".to_string(),
+            "llvm-".to_string(), // no numeric version — ignored
+        ];
+        let dirs = versioned_llvm_bin_dirs("/usr/lib", "llvm-", &names);
+        assert_eq!(
+            dirs,
+            vec![
+                PathBuf::from("/usr/lib/llvm-17/bin"),
+                PathBuf::from("/usr/lib/llvm-16.0/bin"),
+            ]
+        );
     }
 }
 

--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -298,12 +298,12 @@ fn versioned_llvm_bin_dirs(parent: &str, prefix: &str, names: &[String]) -> Vec<
         .iter()
         .filter_map(|name| {
             let ver = name.strip_prefix(prefix)?;
-            let major: String = ver.chars().take_while(|c| c.is_ascii_digit()).collect();
-            let n = major.parse::<u32>().ok()?;
+            let end = ver.find(|c: char| !c.is_ascii_digit()).unwrap_or(ver.len());
+            let n = ver[..end].parse::<u32>().ok()?;
             Some((n, Path::new(parent).join(name).join("bin")))
         })
         .collect();
-    versioned.sort_by(|a, b| b.0.cmp(&a.0));
+    versioned.sort_by_key(|k| std::cmp::Reverse(k.0));
     versioned.into_iter().map(|(_, p)| p).collect()
 }
 

--- a/crates/perry/src/commands/compile/link/build_and_run.rs
+++ b/crates/perry/src/commands/compile/link/build_and_run.rs
@@ -344,6 +344,17 @@ pub(crate) fn build_and_run_link(
                                 "[strip-dedup] bundled-runtime drop skipped for {} (non-fatal): {e}",
                                 wk.display()
                             );
+                            // #5779: skipping this leaves two copies of perry-runtime's
+                            // mutable globals; an in-process HTTP server + fetch program
+                            // can then deadlock. It fails when no LLVM tool new enough to
+                            // read the archives' bitcode is found — install the toolchain's
+                            // llvm-tools (`rustup component add llvm-tools`) or a current LLVM.
+                            eprintln!(
+                                "[strip-dedup] warning: could not de-duplicate the bundled \
+                                 perry-runtime — an in-process server+fetch program may \
+                                 deadlock (#5779). Install `rustup component add llvm-tools` \
+                                 or a current LLVM (e.g. `brew install llvm`)."
+                            );
                             wk.clone()
                         }),
                     None => wk.clone(),


### PR DESCRIPTION
## What

Fixes #5779: a Perry process that is **both** a `node:http` server and a `fetch` client can hang forever on macOS — the in-process loopback `fetch()` never settles.

## Root cause (it's a link-level bug, not a reqwest lost-wakeup)

The issue's original diagnosis (a parked reqwest future) predates the single-thread-runtime rewrite (#5831). Re-diagnosing on current `main`: the hung process is a **single thread parked on a condvar** — the tokio runtime is never driven — and the wait-driver slot the main loop reads is `null` even though `fetch` registered it. Address diagnostics show the register **writes one `WAIT_DRIVER_SLEEP`** and the main loop **reads a different one**: there are **two copies of perry-runtime's mutable globals**.

This is exactly the failure the comment in `strip_bundled_runtime_from_well_known_lib` describes. `perry-ext-*` wrapper crates are `staticlib`s that bundle their own copy of perry-runtime and are linked before perry-stdlib (`prefer_well_known_before_stdlib`), so the strip is supposed to drop the wrapper's bundled copy and leave stdlib's as the single provider. On macOS it **silently no-ops**:

```
[strip-dedup] bundled-runtime drop skipped for libperry_ext_http.a (non-fatal): failed to inspect defined symbols
```

The strip inspects the archives with `llvm-nm`, but they carry **LLVM bitcode** emitted by the active Rust toolchain's LLVM (`Producer: LLVM22.1.6-rust-1.97.1-stable`). macOS's system `nm` is Apple LLVM 21 and can't read it (`error: ... Unknown attribute kind (105)`), so it exits non-zero and the strip bails. The surviving duplicate gives the process two disjoint copies of the event-loop globals: the wait-driver / stdlib pump is registered in stdlib's copy (via LTO-internal refs) while the generated main loop's `js_wait_for_event` / pump resolve to the wrapper's copy and read a never-written slot → the runtime is never driven and the fetch promise never settles. Which global lands in the wrong copy shifts with link layout, so it presents as the flaky, load-sensitive hang the issue reports.

A compatible tool exists — Homebrew's LLVM, or the toolchain's own `llvm-tools` — but is missed: Homebrew's LLVM is keg-only (not on `PATH`) and the `llvm-tools` component may be absent, so `find_llvm_tool` falls through to the too-old Apple `nm`.

## Fix

`find_llvm_tool` gains a final fallback that searches the standard LLVM install directories commonly **off `PATH`** — Homebrew's keg (`/opt/homebrew/opt/llvm`, `/usr/local/opt/llvm`, versioned `llvm@NN` kegs) and Debian/Ubuntu's `/usr/lib/llvm-NN` — **newest version first** (bitcode inspection needs LLVM ≥ the toolchain's). With a bitcode-compatible `llvm-nm`/`llvm-ar` found, the existing dedup runs and drops the duplicate runtime:

```
[strip-dedup] libperry_ext_http.a: dropped 1 bundled perry-runtime member(s) (stdlib provides the single runtime copy)
```

The toolchain's own `llvm-tools` (checked earlier via the sysroot, version-exact) is still preferred when installed. The skip path — previously a silent no-op whose consequence is a hard-to-diagnose deadlock — now emits an actionable warning pointing at `rustup component add llvm-tools` / installing a current LLVM.

No runtime code changes; no behavior change on platforms where the strip already succeeds (the new fallback only fires after env / sysroot / `PATH` all miss).

## Verification

- The issue's exact program (200 sequential in-process POST fetches): hung within ~20 iterations before (SIGKILL by watchdog, empty output); now runs to `done` with **no env override** on this macOS box (Homebrew LLVM auto-discovered).
- Stress: **8/8 runs complete under 4 busy-loop CPU-load processes** (the "reliable under load" condition from the issue) — 0 hangs.
- New unit tests for the version ordering (`versioned_llvm_bin_dirs`); existing `library_search` (14) and `strip_dedup` (6) tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved LLVM tool discovery, including common installations outside the system `PATH`.
  - When multiple LLVM versions are available, the newest matching version is preferred.

- **Bug Fixes**
  - Added clearer diagnostics when runtime deduplication cannot be completed.
  - Warnings now explain the potential impact on in-process HTTP and fetch programs and recommend installing LLVM tools or updating LLVM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->