### PR TITLE
fix(codegen): select setjmp ABI from --target, not the host that built perry

### DIFF
--- a/crates/perry-codegen/src/lib.rs
+++ b/crates/perry-codegen/src/lib.rs
@@ -22,6 +22,7 @@ pub mod nanbox;
 pub(crate) mod native_value;
 pub(crate) mod nm_install;
 pub mod runtime_decls;
+pub(crate) mod setjmp_abi;
 pub(crate) mod stmt;
 pub mod strings;
 pub mod stubs;

--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -719,29 +719,16 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
     // js_has_exception() returns i32 (1 if exception is active, 0 otherwise).
     // js_enter_finally() / js_leave_finally() bracket finally blocks.
     module.declare_function("js_try_push", PTR, &[]);
-    // setjmp variant selection:
-    //   - Windows MSVC requires _setjmp(buf, frame_ptr)
-    //   - Apple targets: the default C `setjmp(3)` saves the signal mask
-    //     via a `sigprocmask` syscall (and the alt-signal-stack via
-    //     `__sigaltstack`) — together those syscalls dominate CPU for
-    //     async-heavy workloads (~43% of CPU on promise_all_chains.ts
-    //     before the swap). Perry never longjmps out of a signal
-    //     handler, so the fast `_setjmp(3)` (no sigprocmask) is
-    //     functionally equivalent for our exception path. The LLVM-IR
-    //     name `_setjmp` maps to the Mach-O linker symbol `__setjmp`
-    //     (the C ABI prepends an underscore), which is the fast
-    //     variant in libsystem_platform.dylib.
-    //   - Linux glibc: the C `setjmp(3)` already does NOT save the
-    //     signal mask (POSIX leaves it implementation-defined;
-    //     `sigsetjmp(env, 1)` is the signal-saving variant on Linux).
-    //     So `setjmp` on Linux is already the fast path; no swap
-    //     needed.
-    if cfg!(target_os = "windows") {
-        module.declare_function("_setjmp", I32, &[PTR, PTR]);
-    } else if cfg!(target_vendor = "apple") {
-        module.declare_function("_setjmp", I32, &[PTR]);
-    } else {
-        module.declare_function("setjmp", I32, &[PTR]);
+    // setjmp variant selection: decided by `crate::setjmp_abi` from the
+    // compile target's LLVM triple (`module.target_triple`), NOT host
+    // `cfg!` — cross-compiles must declare the *target's* setjmp ABI
+    // (Windows MSVC 2-arg `_setjmp`, Apple fast 1-arg `_setjmp`, plain
+    // `setjmp` elsewhere; full rationale in `crate::setjmp_abi`). The
+    // same `SetjmpAbi` drives the call sites in `stmt/try_stmt.rs`, so
+    // the declaration and the calls can never disagree on name or arity.
+    {
+        let abi = crate::setjmp_abi::setjmp_abi_for_triple(&module.target_triple);
+        module.declare_function(abi.callee(), I32, abi.param_types());
     }
     module.declare_function("js_try_end", VOID, &[]);
     module.declare_function("js_get_exception", DOUBLE, &[]);

--- a/crates/perry-codegen/src/setjmp_abi.rs
+++ b/crates/perry-codegen/src/setjmp_abi.rs
@@ -1,0 +1,193 @@
+//! Target-dependent setjmp ABI selection for try/catch lowering.
+//!
+//! Perry's try/catch (and the async rejection boundary) is setjmp/longjmp
+//! based, and the setjmp *variant* differs per target:
+//!
+//!   - Windows MSVC: `_setjmp(jmp_buf, frame_pointer)` — MSVCRT exports only
+//!     `_setjmp`/`_setjmpex` (there is no plain `setjmp` symbol), and the x64
+//!     intrinsic takes the frame pointer as a second argument (we pass null
+//!     to opt out of SEH unwinding through the frame).
+//!   - Apple: the fast `_setjmp(jmp_buf)` (LLVM-IR name `_setjmp` → Mach-O
+//!     symbol `__setjmp`), which skips the sigprocmask/sigaltstack syscalls
+//!     the default `setjmp(3)` performs on Darwin (~43% of CPU on
+//!     promise_all_chains.ts before the swap). Perry never longjmps out of a
+//!     signal handler, so the fast variant is functionally equivalent.
+//!   - Everything else (Linux glibc/musl, Android, OHOS): plain
+//!     `setjmp(jmp_buf)` — glibc's `setjmp(3)` already skips the signal
+//!     mask, so no swap is needed.
+//!
+//! The variant MUST be derived from the *compile target's* LLVM triple, not
+//! from host `cfg!`. The host `cfg!` version of this decision meant
+//! cross-compiling `--target windows` from Linux emitted `@setjmp` (LNK2019:
+//! MSVCRT has no `setjmp` export), from macOS emitted the 1-arg `_setjmp`
+//! (the MSVC x64 second argument — RDX — was garbage, so longjmp corrupted),
+//! and a Windows host emitted the 2-arg Windows form into linux/macos
+//! objects. Host-native compiles were always correct because
+//! `default_target_triple()` (the `CompileOptions.target == None` fallback)
+//! is the host triple — deriving from the effective triple preserves that
+//! behavior bit-for-bit. Same principle as `crate::target_layout`.
+//!
+//! Every consumer — the try/catch call site, the async-boundary call site,
+//! and the extern prototype in `runtime_decls` — must go through this one
+//! type so the call and its declaration can never disagree on the callee
+//! name or arity (that would be an LLVM verifier error, or silent stack
+//! corruption).
+
+use crate::types::{LlvmType, PTR};
+
+/// Which setjmp flavor the emitted IR calls (and declares).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SetjmpAbi {
+    /// `_setjmp(ptr jmp_buf, ptr frame_ptr)` — Windows MSVC x64.
+    WindowsMsvc,
+    /// `_setjmp(ptr jmp_buf)` — Apple's fast (no-sigprocmask) variant.
+    AppleFast,
+    /// `setjmp(ptr jmp_buf)` — default C ABI (Linux glibc/musl, Android, …).
+    CSetjmp,
+}
+
+/// Select the setjmp ABI for an LLVM target triple. `triple` is the
+/// *effective* triple for the compile — `CompileOptions.target` when
+/// `--target` was given, else `default_target_triple()` (the host) — so a
+/// host-native compile keeps today's behavior and a cross-compile follows
+/// the target.
+pub(crate) fn setjmp_abi_for_triple(triple: &str) -> SetjmpAbi {
+    if triple.contains("-windows-") {
+        SetjmpAbi::WindowsMsvc
+    } else if triple.contains("-apple-") {
+        SetjmpAbi::AppleFast
+    } else {
+        SetjmpAbi::CSetjmp
+    }
+}
+
+impl SetjmpAbi {
+    /// LLVM-IR callee name (also what `runtime_decls` declares).
+    pub(crate) fn callee(self) -> &'static str {
+        match self {
+            SetjmpAbi::WindowsMsvc | SetjmpAbi::AppleFast => "_setjmp",
+            SetjmpAbi::CSetjmp => "setjmp",
+        }
+    }
+
+    /// Parameter types for the extern declaration. Must stay in lock-step
+    /// with [`Self::call_instruction`] — the divergence test below enforces
+    /// the arity.
+    pub(crate) fn param_types(self) -> &'static [LlvmType] {
+        match self {
+            SetjmpAbi::WindowsMsvc => &[PTR, PTR],
+            SetjmpAbi::AppleFast | SetjmpAbi::CSetjmp => &[PTR],
+        }
+    }
+
+    /// The full call-site instruction. `#0` is the shared `returns_twice`
+    /// attribute group emitted by `LlModule` whenever a setjmp variant is
+    /// declared — it must be on the call site too, or LLVM -O2 promotes
+    /// allocas across the setjmp and the longjmp path reads stale values.
+    pub(crate) fn call_instruction(self, result_reg: &str, jmpbuf: &str) -> String {
+        match self {
+            SetjmpAbi::WindowsMsvc => format!(
+                "{} = call i32 @_setjmp(ptr {}, ptr null) #0",
+                result_reg, jmpbuf
+            ),
+            SetjmpAbi::AppleFast => {
+                format!("{} = call i32 @_setjmp(ptr {}) #0", result_reg, jmpbuf)
+            }
+            SetjmpAbi::CSetjmp => {
+                format!("{} = call i32 @setjmp(ptr {}) #0", result_reg, jmpbuf)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn windows_target_uses_two_arg_underscore_setjmp() {
+        let abi = setjmp_abi_for_triple("x86_64-pc-windows-msvc");
+        assert_eq!(abi, SetjmpAbi::WindowsMsvc);
+        assert_eq!(abi.callee(), "_setjmp");
+        assert_eq!(abi.param_types(), &[PTR, PTR]);
+        assert_eq!(
+            abi.call_instruction("%r7", "%r6"),
+            "%r7 = call i32 @_setjmp(ptr %r6, ptr null) #0"
+        );
+    }
+
+    #[test]
+    fn apple_targets_use_fast_one_arg_underscore_setjmp() {
+        for triple in [
+            "arm64-apple-macosx15.0.0",
+            "x86_64-apple-macosx15.0.0",
+            "aarch64-apple-darwin",
+            "aarch64-apple-ios",
+            "arm64-apple-ios17.0-simulator",
+            "aarch64-apple-tvos",
+            "aarch64-apple-watchos",
+            "arm64_32-apple-watchos",
+            "arm64-apple-xros1.0",
+        ] {
+            let abi = setjmp_abi_for_triple(triple);
+            assert_eq!(abi, SetjmpAbi::AppleFast, "triple: {}", triple);
+            assert_eq!(abi.callee(), "_setjmp");
+            assert_eq!(abi.param_types(), &[PTR]);
+            assert_eq!(
+                abi.call_instruction("%r7", "%r6"),
+                "%r7 = call i32 @_setjmp(ptr %r6) #0"
+            );
+        }
+    }
+
+    #[test]
+    fn linux_family_targets_use_plain_setjmp() {
+        for triple in [
+            "x86_64-unknown-linux-gnu",
+            "aarch64-unknown-linux-gnu",
+            "x86_64-unknown-linux-musl",
+            "aarch64-unknown-linux-musl",
+            "aarch64-unknown-linux-android",
+            "x86_64-unknown-linux-android",
+            "aarch64-unknown-linux-ohos",
+        ] {
+            let abi = setjmp_abi_for_triple(triple);
+            assert_eq!(abi, SetjmpAbi::CSetjmp, "triple: {}", triple);
+            assert_eq!(abi.callee(), "setjmp");
+            assert_eq!(abi.param_types(), &[PTR]);
+            assert_eq!(
+                abi.call_instruction("%r7", "%r6"),
+                "%r7 = call i32 @setjmp(ptr %r6) #0"
+            );
+        }
+    }
+
+    /// The declaration arity and the call-site arity must never diverge —
+    /// that's an IR verifier error (or, worse, a silently-garbage RDX on
+    /// MSVC x64). Count the `ptr ` argument slots in the emitted call and
+    /// compare against the declared parameter list, per variant.
+    #[test]
+    fn call_arity_matches_declared_arity_for_every_variant() {
+        for abi in [
+            SetjmpAbi::WindowsMsvc,
+            SetjmpAbi::AppleFast,
+            SetjmpAbi::CSetjmp,
+        ] {
+            let call = abi.call_instruction("%r1", "%r0");
+            let arg_count = call.matches("ptr ").count();
+            assert_eq!(
+                arg_count,
+                abi.param_types().len(),
+                "call/declaration arity diverged for {:?}: {}",
+                abi,
+                call
+            );
+            assert!(
+                call.contains(&format!("@{}(", abi.callee())),
+                "call names a different callee than the declaration for {:?}: {}",
+                abi,
+                call
+            );
+        }
+    }
+}

--- a/crates/perry-codegen/src/stmt/mod.rs
+++ b/crates/perry-codegen/src/stmt/mod.rs
@@ -75,7 +75,7 @@ fn lower_async_rejecting_stmts_inner(
     stmts: &[Stmt],
     emit_shadow_clears: bool,
 ) -> Result<()> {
-    use crate::types::{I32, I64, PTR};
+    use crate::types::I64;
 
     // Direct async functions that were not rewritten into generator state
     // machines still need the ECMAScript async boundary: any abrupt
@@ -91,24 +91,10 @@ fn lower_async_rejecting_stmts_inner(
     let catch_label = ctx.block_label(catch_idx);
     let merge_label = ctx.block_label(merge_idx);
 
-    let blk = ctx.block();
-    let jmpbuf = blk.call(PTR, "js_try_push", &[]);
-    let sjr_reg = blk.next_reg();
-    if cfg!(target_os = "windows") {
-        blk.emit_raw(format!(
-            "{} = call i32 @_setjmp(ptr {}, ptr null) #0",
-            sjr_reg, jmpbuf
-        ));
-    } else if cfg!(target_vendor = "apple") {
-        blk.emit_raw(format!(
-            "{} = call i32 @_setjmp(ptr {}) #0",
-            sjr_reg, jmpbuf
-        ));
-    } else {
-        blk.emit_raw(format!("{} = call i32 @setjmp(ptr {}) #0", sjr_reg, jmpbuf));
-    }
-    let is_exc = blk.icmp_ne(I32, &sjr_reg, "0");
-    blk.cond_br(&is_exc, &catch_label, &body_label);
+    // js_try_push + target-ABI setjmp + branch — shared with `lower_try` so
+    // the setjmp variant (chosen from `ctx.target_triple`, see
+    // `crate::setjmp_abi`) is decided in exactly one place.
+    try_stmt::emit_setjmp_dispatch(ctx, &catch_label, &body_label);
 
     ctx.current_block = body_idx;
     ctx.try_depth += 1;

--- a/crates/perry-codegen/src/stmt/try_stmt.rs
+++ b/crates/perry-codegen/src/stmt/try_stmt.rs
@@ -25,31 +25,24 @@ use super::*;
 /// pre-setjmp values. The standard `blk.call()` doesn't support call
 /// attributes, so the instruction is emitted manually.
 ///
-/// setjmp variant selection — must match the declaration in
-/// `runtime_decls.rs`:
-///   - Apple: `_setjmp` (LLVM-IR name) → linker `__setjmp` = fast variant
-///     (skips the sigprocmask / sigaltstack syscalls, ~500 ns each on
-///     macOS arm64).
-///   - Linux: `setjmp` is already fast — no swap needed.
-///   - Windows: `_setjmp(buf, frame_ptr)` (different ABI).
-fn emit_setjmp_dispatch(ctx: &mut FnCtx<'_>, exc_label: &str, normal_label: &str) {
+/// setjmp variant selection — decided by `crate::setjmp_abi` from the
+/// compile target's LLVM triple (`ctx.target_triple`), NOT host `cfg!`,
+/// so cross-compiles emit the target's ABI. The same `SetjmpAbi` drives
+/// the extern declaration in `runtime_decls/strings_part2.rs`, so the
+/// call and the prototype can't diverge. See `crate::setjmp_abi` for the
+/// per-target rationale (Windows 2-arg `_setjmp`, Apple fast `_setjmp`,
+/// plain `setjmp` elsewhere).
+///
+/// Also used by the async rejection boundary in `stmt/mod.rs`
+/// (`lower_async_rejecting_stmts_inner`) — same setjmp, different
+/// exception continuation.
+pub(super) fn emit_setjmp_dispatch(ctx: &mut FnCtx<'_>, exc_label: &str, normal_label: &str) {
     use crate::types::{I32, PTR};
+    let abi = crate::setjmp_abi::setjmp_abi_for_triple(ctx.target_triple);
     let blk = ctx.block();
     let jmpbuf = blk.call(PTR, "js_try_push", &[]);
     let sjr_reg = blk.next_reg();
-    if cfg!(target_os = "windows") {
-        blk.emit_raw(format!(
-            "{} = call i32 @_setjmp(ptr {}, ptr null) #0",
-            sjr_reg, jmpbuf
-        ));
-    } else if cfg!(target_vendor = "apple") {
-        blk.emit_raw(format!(
-            "{} = call i32 @_setjmp(ptr {}) #0",
-            sjr_reg, jmpbuf
-        ));
-    } else {
-        blk.emit_raw(format!("{} = call i32 @setjmp(ptr {}) #0", sjr_reg, jmpbuf));
-    }
+    blk.emit_raw(abi.call_instruction(&sjr_reg, &jmpbuf));
     let is_exc = blk.icmp_ne(I32, &sjr_reg, "0");
     blk.cond_br(&is_exc, exc_label, normal_label);
 }

--- a/crates/perry-ui-windows/src/ffi/lsp_camera_misc.rs
+++ b/crates/perry-ui-windows/src/ffi/lsp_camera_misc.rs
@@ -1,4 +1,4 @@
-// FFI: LSP bridge stubs, camera stubs (#191), setjmp override, cross-platform
+// FFI: LSP bridge stubs, camera stubs (#191), cross-platform
 // toast + reactive setText stubs (Phase 2 v3.3).
 
 // =============================================================================
@@ -51,14 +51,14 @@ pub extern "C" fn perry_ui_camera_sample_color(_x: f64, _y: f64) -> f64 {
 #[no_mangle]
 pub extern "C" fn perry_ui_camera_set_on_tap(_handle: i64, _callback: f64) {}
 
-// Override setjmp with a no-op stub that always returns 0.
-// Perry's try/catch uses setjmp/longjmp but since we make readFileSync
-// return empty string instead of throwing, longjmp is never called.
-// The MSVC CRT setjmp may corrupt the stack on x64.
-#[no_mangle]
-pub extern "C" fn setjmp(_env: *mut i32) -> i32 {
-    0
-}
+// NOTE: a fake no-op `setjmp` stub used to live here so links succeeded when
+// codegen host-cfg-gated the setjmp variant and emitted the bare `setjmp`
+// name into Windows-target objects (MSVCRT only exports `_setjmp`/
+// `_setjmpex`). Codegen now selects the setjmp ABI from the compile target's
+// triple (`perry-codegen/src/setjmp_abi.rs`), so Windows targets always get
+// the real 2-arg `_setjmp` — and a leftover bare-`setjmp` reference failing
+// to link is the DESIRED loud failure, not something to paper over with a
+// stub that silently corrupts try/catch (always-0 return, no saved context).
 
 // --- Cross-platform toast + reactive setText stubs (Phase 2 v3.3) ---
 // Full GTK4 implementation in perry-ui-gtk4. Present here so cross-platform


### PR DESCRIPTION
## Defect

Both the setjmp call emission and its extern prototype picked the variant via **host** `cfg!` — i.e. whichever OS built the `perry` binary — instead of the compile `--target`:

- `crates/perry-codegen/src/stmt/try_stmt.rs` (try/catch dispatch)
- `crates/perry-codegen/src/stmt/mod.rs` (`lower_async_rejecting_stmts_inner` — the async rejection boundary duplicated the same host-cfg block; found in the survey, same class)
- `crates/perry-codegen/src/runtime_decls/strings_part2.rs` (the extern declaration)

### Failure modes

1. **Linux host → `--target windows`**: emitted `@setjmp(ptr)`. MSVCRT exports only `_setjmp`/`_setjmpex` — there is no plain `setjmp` symbol — so the link dies with `LNK2019: unresolved external symbol setjmp`.
2. **macOS host → `--target windows`**: emitted the 1-arg `@_setjmp(ptr)`. The MSVC x64 `_setjmp` intrinsic takes a second argument (frame pointer, RDX). With no second arg, RDX is whatever garbage the caller left there, so a later `longjmp` restores a corrupt context — silent stack corruption instead of a link error.
3. **Windows host → `--target linux`/`macos`/mobile**: emitted the Windows 2-arg `_setjmp(ptr, ptr null)` into ELF/Mach-O objects (glibc has no `_setjmp` with that ABI; on Apple the extra arg is benign-by-luck at best).

## Fix

New module `crates/perry-codegen/src/setjmp_abi.rs` (sibling in spirit to `target_layout.rs`, which documents this exact "derive from the target triple, not the host" rule):

- `setjmp_abi_for_triple(&str) -> SetjmpAbi` maps the **effective LLVM triple** → `WindowsMsvc` (`-windows-`), `AppleFast` (`-apple-`), or `CSetjmp` (everything else).
- `SetjmpAbi::callee()` / `param_types()` / `call_instruction()` are the only source of the callee name, declaration arity, and call-site text. The prototype in `runtime_decls` and both call sites all consume the same enum value, so **the call and the declaration can never diverge** (that divergence would be an IR verifier error, or garbage RDX on MSVC).
- The two duplicated emission sites are now one: `lower_async_rejecting_stmts_inner` calls the shared `emit_setjmp_dispatch` from `try_stmt.rs`.

### Host-fallback preservation

The effective triple is `CompileOptions.target` when `--target` was given (the CLI resolves the short name via `resolve_target_triple` first), else `default_target_triple()` — **the host triple**. So a host-native compile derives the same answer the old host-`cfg!` gates produced, on every host OS: native output is unchanged (verified below, byte-level).

## Other host-cfg hits in perry-codegen (surveyed, deliberately left)

`grep -rn 'cfg!(target_os\|cfg!(target_vendor\|cfg!(windows)' crates/perry-codegen/src`:

- `codegen/helpers.rs:473` — inside `default_target_triple()` itself; that *is* the intended host fallback.
- `linker.rs:275/286/558/597/967/989` — clang-discovery error text, MinGW-vs-MSVC host toolchain warnings, and tests thereof. All gate host-side behavior (which linker runs / what hint prints), not emitted IR. Left as-is.

## Also removed: the fake `setjmp` stub in perry-ui-windows

`crates/perry-ui-windows/src/ffi/lsp_camera_misc.rs` carried a no-op `pub extern "C" fn setjmp() -> 0` whose comment admitted it existed so links succeeded when codegen (host-cfg bug) emitted the bare `setjmp` name for a Windows target. That stub is worse than the bug: any try/catch that resolved to it got an always-0 setjmp with no saved context — silently corrupt exception handling. With emission now target-gated, Windows targets always get the real 2-arg `_setjmp`, and a leftover bare-`setjmp` reference failing to link is the **desired** loud failure. (The neighboring `perry_ui_set_text`/`text_create_with_id` stubs are untouched — they're being handled in a parallel UI PR.)

## Verification (Windows 11 x64 host)

- `cargo check -p perry-codegen` clean; **209/209** perry-codegen lib tests pass, including 4 new `setjmp_abi` unit tests (per-variant callee/arity/call-text, plus a divergence guard asserting call arity == declared arity for every variant).
- `cargo check -p perry-ui-windows` clean after the stub removal.
- **End-to-end IR** — built the CLI (`perry-dev` profile) and compiled a try/catch + async-throw probe with `--trace llvm` for three targets from this one Windows-host binary:
  - native (no `--target`): `call i32 @_setjmp(ptr %rN, ptr null) #0` / `declare i32 @_setjmp(ptr, ptr) #0` — identical to pre-change host output; the probe **linked and ran correctly** (`finally ran` / `42` / `caught: async boom`, exit 0), exercising both the try/catch longjmp path and the async rejection boundary.
  - `--target linux`: `call i32 @setjmp(ptr %rN) #0` / `declare i32 @setjmp(ptr) #0` — previously this host emitted the Windows 2-arg form here.
  - `--target macos`: `call i32 @_setjmp(ptr %rN) #0` / `declare i32 @_setjmp(ptr) #0`.
- `scripts/check_file_size.sh` passes.

### Not verified here / needs maintainer E2E

- Actual cross-compiled **link + execution** on the failure-mode direction (Linux/macOS host → `--target windows`, and running the resulting .exe) — this box can only cross-emit IR, not cross-link.
- Pre-existing, unrelated breakage observed on `main` while verifying: `crates/perry-codegen/tests/*` integration tests don't compile (`CompileOptions` has no field `namespace_reexport_named_imports` — reproduced with this branch's changes stashed), and the Windows dev-profile `perry` bin link is missing `js_crypto_ed25519_verify` (perry-updater → perry-stdlib). Both worked around locally with uncommitted overlays for verification only; neither is touched by this PR.

No version bump / changelog per maintainer instruction (folded in at merge time).