### PR TITLE
chore(warnings): sweep mechanical Rust warnings and drop blanket #[allow(unused_imports)]

### DIFF
--- a/crates/perry-codegen-wasm/src/emit/compile.rs
+++ b/crates/perry-codegen-wasm/src/emit/compile.rs
@@ -927,7 +927,6 @@ impl WasmModuleEmitter {
                     // suffix/basename match on `import.source`.
                     let src_idx_opt = resolve_source_module_idx(modules, import, &name_to_idx);
                     let Some(src_idx) = src_idx_opt else { continue };
-                    let src_lets = &src_let_names[src_idx];
                     for spec in &import.specifiers {
                         if let perry_hir::ir::ImportSpecifier::Named { imported, local } = spec {
                             // Resolve the public `imported` name to a let

--- a/crates/perry-codegen-wasm/src/emit/mod.rs
+++ b/crates/perry-codegen-wasm/src/emit/mod.rs
@@ -53,7 +53,6 @@ use wasm_encoder::{
 use closures::{collect_closures_from_expr, collect_closures_from_stmts};
 // `f64_const_bits` is held alive for future use (matches the pre-split
 // `#[allow(dead_code)]` annotation on its original definition).
-#[allow(unused_imports)]
 use constants::f64_const_bits;
 use constants::{
     f64_const, EnumResolvedValue, STRING_TAG, TAG_FALSE, TAG_NULL, TAG_TRUE, TAG_UNDEFINED,

--- a/crates/perry-codegen-wasm/src/emit/runtime_imports.rs
+++ b/crates/perry-codegen-wasm/src/emit/runtime_imports.rs
@@ -3,7 +3,6 @@
 //!
 //! Pure code-movement from `mod.rs`.
 
-#[allow(unused_imports)]
 use super::*;
 
 /// Import function indices (must match the order imports are added)

--- a/crates/perry-codegen-wasm/src/emit/ui_method_map.rs
+++ b/crates/perry-codegen-wasm/src/emit/ui_method_map.rs
@@ -1,7 +1,6 @@
 //! `map_ui_method`: maps perry/ui and perry/system method names to bridge
 //! function names. Pure code-movement from `mod.rs`.
 
-#[allow(unused_imports)]
 use super::*;
 
 /// Map perry/ui and perry/system method names to bridge function names.

--- a/crates/perry-codegen/src/codegen/boxed_locals.rs
+++ b/crates/perry-codegen/src/codegen/boxed_locals.rs
@@ -6,21 +6,12 @@
 //! the module init — and accumulate a single flat set/map keyed by HIR
 //! LocalId (which is globally unique within the module).
 
-use super::*;
-
 use std::collections::HashMap;
 
-use anyhow::{Context, Result};
 use perry_hir::Module as HirModule;
-
-use crate::module::LlModule;
-use crate::runtime_decls;
-use crate::strings::StringPool;
-use crate::types::{LlvmType, DOUBLE, I64};
 
 // Collector and boxing-analysis walkers live in dedicated modules.
 use crate::boxed_vars::{collect_boxed_param_ids, collect_boxed_vars, collect_let_types_in_stmts};
-use crate::collectors::{collect_closures_in_stmts, collect_let_ids, collect_ref_ids_in_stmts};
 
 /// Module-level boxed_vars: union of every per-function/method/
 /// closure/module-init boxed set. We compute this once because

--- a/crates/perry-codegen/src/codegen/closure.rs
+++ b/crates/perry-codegen/src/codegen/closure.rs
@@ -4,7 +4,6 @@
 use std::collections::{HashMap, HashSet};
 
 use anyhow::{anyhow, Context, Result};
-use perry_hir::Stmt;
 
 use crate::collectors::{collect_let_ids, collect_ref_ids_in_stmts};
 use crate::expr::FnCtx;

--- a/crates/perry-codegen/src/codegen/closure_collect.rs
+++ b/crates/perry-codegen/src/codegen/closure_collect.rs
@@ -8,21 +8,12 @@
 //! every `Expr::Closure` so the closure creation site can take its address,
 //! then derives the rest/arity/arguments/arrow maps from the collected set.
 
-use super::*;
-
 use std::collections::HashMap;
 
-use anyhow::{Context, Result};
 use perry_hir::Module as HirModule;
 
-use crate::module::LlModule;
-use crate::runtime_decls;
-use crate::strings::StringPool;
-use crate::types::{LlvmType, DOUBLE, I64};
-
 // Collector and boxing-analysis walkers live in dedicated modules.
-use crate::boxed_vars::{collect_boxed_param_ids, collect_boxed_vars, collect_let_types_in_stmts};
-use crate::collectors::{collect_closures_in_stmts, collect_let_ids, collect_ref_ids_in_stmts};
+use crate::collectors::collect_closures_in_stmts;
 
 // `spec_function_length` is a trunk free fn (also reachable via `super::*`).
 use super::spec_function_length;

--- a/crates/perry-codegen/src/codegen/func_registry.rs
+++ b/crates/perry-codegen/src/codegen/func_registry.rs
@@ -6,21 +6,11 @@
 //! about emission order, and records each function's ABI signature
 //! `(param_count, has_rest, returns_number, synthetic_is_rest)`.
 
-use super::*;
-
 use std::collections::HashMap;
 
-use anyhow::{Context, Result};
 use perry_hir::Module as HirModule;
 
-use crate::module::LlModule;
-use crate::runtime_decls;
-use crate::strings::StringPool;
-use crate::types::{LlvmType, DOUBLE, I64};
-
 // Collector and boxing-analysis walkers live in dedicated modules.
-use crate::boxed_vars::{collect_boxed_param_ids, collect_boxed_vars, collect_let_types_in_stmts};
-use crate::collectors::{collect_closures_in_stmts, collect_let_ids, collect_ref_ids_in_stmts};
 
 // Name-mangling helper from the trunk (also reachable via `super::*`).
 use super::helpers::scoped_fn_name;

--- a/crates/perry-codegen/src/codegen/function.rs
+++ b/crates/perry-codegen/src/codegen/function.rs
@@ -5,7 +5,7 @@
 use std::collections::{HashMap, HashSet};
 
 use anyhow::{anyhow, Context, Result};
-use perry_hir::{Function, Stmt};
+use perry_hir::Function;
 
 use crate::expr::FnCtx;
 use crate::module::LlModule;

--- a/crates/perry-codegen/src/codegen/i64_spec.rs
+++ b/crates/perry-codegen/src/codegen/i64_spec.rs
@@ -6,21 +6,14 @@
 //! the f64 wrapper calls fptosi → i64_fn → sitofp. Returns the set of FuncIds
 //! that were specialized so the main compile loop can skip re-emitting them.
 
-use super::*;
-
 use std::collections::HashMap;
 
-use anyhow::{Context, Result};
 use perry_hir::Module as HirModule;
 
 use crate::module::LlModule;
-use crate::runtime_decls;
-use crate::strings::StringPool;
 use crate::types::{LlvmType, DOUBLE, I64};
 
 // Collector and boxing-analysis walkers live in dedicated modules.
-use crate::boxed_vars::{collect_boxed_param_ids, collect_boxed_vars, collect_let_types_in_stmts};
-use crate::collectors::{collect_closures_in_stmts, collect_let_ids, collect_ref_ids_in_stmts};
 
 /// Emit i64-specialized bodies (+ f64 wrappers) for integer-specializable
 /// functions. Returns the set of specialized FuncIds.

--- a/crates/perry-codegen/src/codegen/method_registry.rs
+++ b/crates/perry-codegen/src/codegen/method_registry.rs
@@ -6,21 +6,14 @@
 //! and pre-declares imported-class methods/getters/setters/ctors/statics as
 //! extern LLVM functions so the linker can resolve cross-module method calls.
 
-use super::*;
-
 use std::collections::HashMap;
 
-use anyhow::{Context, Result};
 use perry_hir::Module as HirModule;
 
 use crate::module::LlModule;
-use crate::runtime_decls;
-use crate::strings::StringPool;
-use crate::types::{LlvmType, DOUBLE, I64};
+use crate::types::DOUBLE;
 
 // Collector and boxing-analysis walkers live in dedicated modules.
-use crate::boxed_vars::{collect_boxed_param_ids, collect_boxed_vars, collect_let_types_in_stmts};
-use crate::collectors::{collect_closures_in_stmts, collect_let_ids, collect_ref_ids_in_stmts};
 
 // Name-mangling helpers from the trunk (also reachable via `super::*`).
 use super::helpers::{sanitize, sanitize_member, scoped_method_name, scoped_static_method_name};

--- a/crates/perry-codegen/src/codegen/mod.rs
+++ b/crates/perry-codegen/src/codegen/mod.rs
@@ -83,7 +83,7 @@ use function::{
 };
 use helpers::{
     collect_return_class, emit_buffer_alias_metadata, function_body_returns_generator_object,
-    sanitize, sanitize_member, scoped_fn_name, scoped_method_name, scoped_static_method_name,
+    sanitize,
 };
 
 // Collector and boxing-analysis walkers live in dedicated modules. The

--- a/crates/perry-codegen/src/codegen/module_globals_emit.rs
+++ b/crates/perry-codegen/src/codegen/module_globals_emit.rs
@@ -6,20 +6,14 @@
 //! globalized), emits the backing `@perry_global_*` globals + exported-var
 //! getters, and registers/emits the `@perry_static_*` class-field globals.
 
-use super::*;
-
 use std::collections::HashMap;
 
-use anyhow::{Context, Result};
 use perry_hir::Module as HirModule;
 
 use crate::module::LlModule;
-use crate::runtime_decls;
-use crate::strings::StringPool;
-use crate::types::{LlvmType, DOUBLE, I64};
+use crate::types::DOUBLE;
 
 // Collector and boxing-analysis walkers live in dedicated modules.
-use crate::boxed_vars::{collect_boxed_param_ids, collect_boxed_vars, collect_let_types_in_stmts};
 use crate::collectors::{collect_closures_in_stmts, collect_let_ids, collect_ref_ids_in_stmts};
 
 // Name-mangling helpers + ImportedClass from the trunk (also via `super::*`).

--- a/crates/perry-codegen/src/collectors/mod.rs
+++ b/crates/perry-codegen/src/collectors/mod.rs
@@ -37,39 +37,13 @@ pub use i64_emit::emit_i64_function;
 // Internal-to-crate re-exports — explicit names because globs don't
 // transitively expose through `pub(crate) use crate::collectors::*`.
 pub(crate) use class_accessors::{is_class_getter, is_class_setter};
-pub(crate) use closures::{collect_closures_in_expr, collect_closures_in_stmts};
-pub(crate) use escape_arrays::{
-    check_array_escapes_in_expr, check_array_escapes_in_stmts, collect_non_escaping_arrays,
-    const_index, find_array_candidates, MAX_SCALAR_OBJECT_FIELDS,
-};
-pub(crate) use escape_check::{check_escapes_in_expr, check_escapes_in_stmts, find_new_candidates};
-pub(crate) use escape_news::{
-    collect_non_escaping_new_used_fields, collect_non_escaping_news, MAX_SCALAR_ARRAY_LEN,
-};
-pub(crate) use escape_objects::{
-    check_object_literal_escapes_in_expr, check_object_literal_escapes_in_stmts,
-    collect_non_escaping_object_literals, find_object_literal_candidates,
-};
-pub(crate) use hir_facts::{
-    collect_hir_facts, collect_native_region_fact_graph, collect_type_facts, NativeRegionFactGraph,
-};
-pub(crate) use i32_locals::{
-    collect_integer_let_ids, collect_localset_ids_in_expr_filtered, collect_localset_ids_in_stmts,
-    collect_localset_ids_in_stmts_filtered, collect_strictly_i32_bounded_locals,
-    collect_unsigned_i32_locals, is_bitwise_expr, is_flat_const_indexget,
-    is_strictly_i32_bounded_expr, is_ushr_zero, walk_writes_for_strict,
-    walk_writes_in_expr_for_strict,
-};
-pub(crate) use i64_emit::{i64_body, i64_cond, i64_val};
-pub(crate) use index_uses::{
-    absorb_writes_in_expr, absorb_writes_into_index_used, collect_index_used_locals,
-    collect_localsets_in_expr_for_propagate, propagate_index_used_transitive,
-    walk_index_uses_in_expr, walk_index_uses_in_stmts,
-};
-pub(crate) use integer_locals::{
-    collect_extra_integer_let_ids, collect_flat_row_aliases, collect_integer_locals,
-    is_int32_producing_expr,
-};
+pub(crate) use closures::collect_closures_in_stmts;
+pub(crate) use escape_arrays::{const_index, MAX_SCALAR_OBJECT_FIELDS};
+pub(crate) use escape_check::{check_escapes_in_stmts, find_new_candidates};
+pub(crate) use escape_news::MAX_SCALAR_ARRAY_LEN;
+pub(crate) use hir_facts::{collect_native_region_fact_graph, NativeRegionFactGraph};
+pub(crate) use i32_locals::{collect_integer_let_ids, collect_localset_ids_in_stmts, is_ushr_zero};
+pub(crate) use integer_locals::{collect_flat_row_aliases, is_int32_producing_expr};
 pub(crate) use local_refs::{expr_contains_local_get, mark_all_candidate_refs_in_expr};
 pub(crate) use mutation::has_any_mutation;
 pub(crate) use pointer_locals::collect_pointer_typed_locals;

--- a/crates/perry-codegen/src/expr/array_methods.rs
+++ b/crates/perry-codegen/src/expr/array_methods.rs
@@ -5,45 +5,14 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::nanbox::double_literal;
+use crate::types::{DOUBLE, I32, I64};
 
-#[allow(unused_imports)]
 use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_math_operand, lower_object_literal,
-    lower_stream_super_init, lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
+    i32_bool_to_nanbox, lower_expr, lower_math_operand, nanbox_pointer_inline,
+    nanbox_string_inline, unbox_str_handle, unbox_to_i64, FnCtx,
 };
 
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {

--- a/crates/perry-codegen/src/expr/array_push.rs
+++ b/crates/perry-codegen/src/expr/array_push.rs
@@ -5,53 +5,23 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::{anyhow, Result};
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
 use crate::native_value::{
     BoundsState, BufferAccessMode, ExpectedNativeRep, LoweredValue, MaterializationReason,
     NativeRep, SemanticKind,
 };
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I16, I32, I64, I8, PTR};
+use crate::type_analysis::is_numeric_expr;
+use crate::types::{DOUBLE, I1, I16, I32, I64, I8};
 
-#[allow(unused_imports)]
 use super::{
-    array_store_needs_layout_note, array_store_needs_write_barrier, buffer_alias_metadata_suffix,
-    can_lower_expr_as_i32, emit_array_numeric_write_note_on_block,
-    emit_jsvalue_slot_store_on_block, emit_jsvalue_slot_store_with_value_bits_on_block,
-    emit_layout_note_slot_on_block, emit_root_nanbox_store_on_block, emit_shadow_slot_clear,
-    emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_typed_feedback_register_site, emit_v8_export_call, emit_v8_member_method_call,
-    emit_write_barrier, emit_write_barrier_slot_on_block,
-    expr_has_numeric_pointer_free_array_layout, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32, lower_expr_native,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, raw_f64_layout_fact,
-    try_flat_const_2d_int, try_lower_flat_const_index_get, try_match_channel_reduction,
-    try_static_class_name, unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction,
-    FlatConstInfo, FnCtx, I18nLowerCtx, TypedFeedbackContract, TypedFeedbackKind,
+    array_store_needs_layout_note, array_store_needs_write_barrier,
+    emit_array_numeric_write_note_on_block, emit_jsvalue_slot_store_on_block,
+    emit_jsvalue_slot_store_with_value_bits_on_block, emit_root_nanbox_store_on_block,
+    emit_typed_feedback_register_site, emit_write_barrier,
+    expr_has_numeric_pointer_free_array_layout, lower_expr, lower_expr_native,
+    nanbox_pointer_inline, raw_f64_layout_fact, unbox_to_i64, FnCtx, TypedFeedbackContract,
+    TypedFeedbackKind,
 };
 
 fn emit_array_handle_length(ctx: &mut FnCtx<'_>, array_handle: &str) -> String {

--- a/crates/perry-codegen/src/expr/arrays_finds.rs
+++ b/crates/perry-codegen/src/expr/arrays_finds.rs
@@ -5,49 +5,22 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::{anyhow, bail, Result};
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
+use perry_hir::{BinaryOp, Expr};
 use perry_types::Type as HirType;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
+use crate::nanbox::double_literal;
 use crate::native_value::{
     layout_runtime_id, BoundsState, BufferAccessMode, LoweredValue, MaterializationReason,
     NativeRep, PodLayoutManifest, SemanticKind,
 };
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::type_analysis::is_numeric_expr;
+use crate::types::{DOUBLE, I32, I64, PTR};
 
-#[allow(unused_imports)]
 use super::{
-    buffer_access_materialization_reason, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_root_nanbox_store_on_block, emit_shadow_slot_clear, emit_shadow_slot_update_for_expr,
-    emit_string_literal_global, emit_v8_export_call, emit_v8_member_method_call,
-    emit_write_barrier, emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix, int_range_expr,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_buffer_load, lower_buffer_store, lower_channel_reduction,
-    lower_expr, lower_expr_as_i32, lower_index_set_fast, lower_js_args_array, lower_object_literal,
-    lower_stream_super_init, lower_url_string_getter, materialize_js_value, nanbox_bigint_inline,
-    nanbox_pointer_inline, nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array,
-    try_flat_const_2d_int, try_lower_flat_const_index_get, try_match_channel_reduction,
-    try_static_class_name, unbox_str_handle, unbox_to_i64, variant_name, BufferAccessSpec,
-    ChannelReduction, FlatConstInfo, FnCtx, I18nLowerCtx,
+    buffer_access_materialization_reason, can_lower_expr_as_i32, i32_bool_to_nanbox,
+    int_range_expr, lower_buffer_load, lower_buffer_store, lower_expr, lower_expr_as_i32,
+    materialize_js_value, nanbox_pointer_inline, nanbox_string_inline, unbox_to_i64,
+    BufferAccessSpec, FnCtx,
 };
 
 fn lower_index_i32(ctx: &mut FnCtx<'_>, index: &Expr) -> Result<String> {

--- a/crates/perry-codegen/src/expr/bigint_set.rs
+++ b/crates/perry-codegen/src/expr/bigint_set.rs
@@ -5,49 +5,21 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::{anyhow, Result};
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
+use perry_hir::{BinaryOp, Expr};
 use perry_types::Type as HirType;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
 use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
 use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_definitely_string_expr,
-    is_map_expr, is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr,
-    receiver_class_name, set_static_type_args,
+    is_bigint_expr, is_definitely_string_expr, is_numeric_expr, set_static_type_args,
 };
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, F32, I1, I32, I64, I8, PTR};
+use crate::types::{DOUBLE, F32, I1, I32, I64, PTR};
 
-#[allow(unused_imports)]
 use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_root_nanbox_store_on_block, emit_shadow_slot_clear, emit_shadow_slot_update_for_expr,
-    emit_string_literal_global, emit_v8_export_call, emit_v8_member_method_call,
-    emit_write_barrier, emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32, lower_expr_native,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array,
-    record_collection_number_key_fallback, record_collection_number_key_selected,
-    record_collection_string_key_fallback, record_collection_string_key_selected,
-    record_collection_typed_value_fallback, record_collection_typed_value_selected,
-    try_flat_const_2d_int, try_lower_flat_const_index_get, try_match_channel_reduction,
-    try_static_class_name, unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction,
-    FlatConstInfo, FnCtx, I18nLowerCtx,
+    can_lower_expr_as_i32, i32_bool_to_nanbox, lower_expr, lower_expr_native, nanbox_bigint_inline,
+    nanbox_pointer_inline, record_collection_number_key_fallback,
+    record_collection_number_key_selected, record_collection_string_key_fallback,
+    record_collection_string_key_selected, record_collection_typed_value_fallback,
+    record_collection_typed_value_selected, unbox_to_i64, FnCtx,
 };
 
 fn number_coerce_operand_is_already_primitive_number(ctx: &FnCtx<'_>, operand: &Expr) -> bool {

--- a/crates/perry-codegen/src/expr/binary.rs
+++ b/crates/perry-codegen/src/expr/binary.rs
@@ -5,52 +5,24 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::{BinaryOp, Expr};
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
 use crate::lower_string_method::{
     flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
+    lower_string_concat_chain,
 };
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
 use crate::native_value::{
     materialize_small_bigint_pointer_to_js_value, BufferAccessMode, LoweredValue,
     MaterializationReason,
 };
-#[allow(unused_imports)]
 use crate::type_analysis::{
-    add_operands_have_pod_materialization_hazard, compute_auto_captures,
-    expr_may_return_boxed_value_from_raw_f64_fallback, is_array_expr, is_bigint_expr, is_bool_expr,
-    is_map_expr, is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr,
-    receiver_class_name,
+    add_operands_have_pod_materialization_hazard,
+    expr_may_return_boxed_value_from_raw_f64_fallback, is_bigint_expr, is_bool_expr,
+    is_numeric_expr,
 };
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I128, I32, I64, I8, PTR};
+use crate::types::{DOUBLE, I1, I128, I32, I64};
 
-#[allow(unused_imports)]
-use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
-};
+use super::{is_known_finite, lower_expr, FnCtx};
 
 fn lower_arithmetic_operand(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<(String, bool)> {
     if expr_may_return_boxed_value_from_raw_f64_fallback(ctx, expr) {

--- a/crates/perry-codegen/src/expr/buffer_access.rs
+++ b/crates/perry-codegen/src/expr/buffer_access.rs
@@ -10,7 +10,7 @@ use crate::types::{DOUBLE, F32, I16, I32, I8, PTR};
 use super::{
     attach_native_owned_view_fact, bounds_for_buffer_access_width, buffer_alias_metadata_suffix,
     buffer_view_lowered_value, can_lower_expr_as_i32, effective_alias_state_for_access,
-    int_range_expr, is_numeric_expr, lower_expr, lower_expr_native, FnCtx,
+    int_range_expr, is_numeric_expr, lower_expr_native, FnCtx,
 };
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/perry-codegen/src/expr/call_spread.rs
+++ b/crates/perry-codegen/src/expr/call_spread.rs
@@ -5,47 +5,14 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
+use crate::nanbox::double_literal;
 use crate::native_value::MaterializationReason;
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::type_analysis::receiver_class_name;
+use crate::types::{DOUBLE, I32, I64};
 
-#[allow(unused_imports)]
-use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, downgrade_buffer_aliases_in_expr,
-    emit_layout_note_slot_on_block, emit_shadow_slot_clear, emit_shadow_slot_update_for_expr,
-    emit_string_literal_global, emit_v8_export_call, emit_v8_member_method_call,
-    emit_write_barrier, emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
-};
+use super::{downgrade_buffer_aliases_in_expr, lower_expr, nanbox_pointer_inline, FnCtx};
 
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {

--- a/crates/perry-codegen/src/expr/calls.rs
+++ b/crates/perry-codegen/src/expr/calls.rs
@@ -9,46 +9,15 @@
 //! delegates each large arm body to a sibling helper.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-    static_type_of,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::lower_call::{lower_call, lower_native_method_call};
+use crate::nanbox::double_literal;
+use crate::types::DOUBLE;
 
-#[allow(unused_imports)]
 use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
+    emit_string_literal_global, lower_expr, nanbox_pointer_inline, nanbox_string_inline,
+    unbox_str_handle, unbox_to_i64, FnCtx,
 };
 
 mod crypto_hash;

--- a/crates/perry-codegen/src/expr/calls/crypto_hash.rs
+++ b/crates/perry-codegen/src/expr/calls/crypto_hash.rs
@@ -1,32 +1,10 @@
 use super::*;
-#[allow(unused_imports)]
-use crate::expr::*;
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-    static_type_of,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::nanbox::double_literal;
+use crate::types::{DOUBLE, I32, I64, PTR};
 
 /// Phase H crypto: collapse `crypto.createHash(alg).update(data).digest(enc)`
 /// into a single runtime call (chain-collapse arm). `outer_callee`/`outer_args`

--- a/crates/perry-codegen/src/expr/calls/crypto_kdf.rs
+++ b/crates/perry-codegen/src/expr/calls/crypto_kdf.rs
@@ -1,32 +1,10 @@
 use super::*;
-#[allow(unused_imports)]
-use crate::expr::*;
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-    static_type_of,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::nanbox::double_literal;
+use crate::types::{DOUBLE, I64};
 
 /// crypto.argon2Sync(algorithm, parameters) -> Buffer.
 pub(crate) fn arm_crypto_argon2_sync(

--- a/crates/perry-codegen/src/expr/calls/crypto_keys.rs
+++ b/crates/perry-codegen/src/expr/calls/crypto_keys.rs
@@ -1,32 +1,10 @@
 use super::*;
-#[allow(unused_imports)]
-use crate::expr::*;
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-    static_type_of,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::nanbox::double_literal;
+use crate::types::{DOUBLE, I64};
 
 /// `crypto.createSign(alg)` / legacy `crypto.Sign(alg)` and
 /// `crypto.createVerify(alg)` / legacy `crypto.Verify(alg)` streaming

--- a/crates/perry-codegen/src/expr/calls/crypto_misc.rs
+++ b/crates/perry-codegen/src/expr/calls/crypto_misc.rs
@@ -1,32 +1,10 @@
 use super::*;
-#[allow(unused_imports)]
-use crate::expr::*;
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-    static_type_of,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::nanbox::double_literal;
+use crate::types::{DOUBLE, I64};
 
 /// Standalone `crypto.createHmac(alg, key)` / legacy `crypto.Hmac(alg, key)`.
 pub(crate) fn arm_crypto_create_hmac(

--- a/crates/perry-codegen/src/expr/calls/fs.rs
+++ b/crates/perry-codegen/src/expr/calls/fs.rs
@@ -1,32 +1,11 @@
 use super::*;
-#[allow(unused_imports)]
-use crate::expr::*;
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-    static_type_of,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::lower_call::lower_call;
+use crate::nanbox::double_literal;
+use crate::types::{DOUBLE, I32, I64};
 
 /// Phase H fs: `fs.promises.METHOD(args...)`.
 pub(crate) fn arm_fs_promises(ctx: &mut FnCtx<'_>, callee: &Expr, args: &[Expr]) -> Result<String> {

--- a/crates/perry-codegen/src/expr/calls/helpers.rs
+++ b/crates/perry-codegen/src/expr/calls/helpers.rs
@@ -1,32 +1,11 @@
 use super::*;
-#[allow(unused_imports)]
-use crate::expr::*;
 
-use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
+use perry_hir::Expr;
 use perry_types::Type as HirType;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-    static_type_of,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::nanbox::double_literal;
+use crate::type_analysis::static_type_of;
+use crate::types::{DOUBLE, I32, I64, PTR};
 
 /// #5247: under `--debug-symbols`, emit a `js_set_call_location(file, line)`
 /// runtime call right before a dynamic method dispatch so the

--- a/crates/perry-codegen/src/expr/child_proc.rs
+++ b/crates/perry-codegen/src/expr/child_proc.rs
@@ -5,45 +5,14 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::nanbox::double_literal;
+use crate::types::{DOUBLE, I32, I64, PTR};
 
-#[allow(unused_imports)]
 use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
+    emit_string_literal_global, lower_expr, nanbox_pointer_inline, nanbox_string_inline,
+    unbox_to_i64, FnCtx,
 };
 
 /// #3079: emit a setup-time `command`/`file` validation call. `cmd_box` is the

--- a/crates/perry-codegen/src/expr/closure.rs
+++ b/crates/perry-codegen/src/expr/closure.rs
@@ -5,46 +5,12 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::{anyhow, Result};
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::POINTER_MASK_I64;
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::type_analysis::compute_auto_captures;
+use crate::types::{DOUBLE, I32, I64, PTR};
 
-#[allow(unused_imports)]
-use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
-};
+use super::{lower_expr, nanbox_pointer_inline, FnCtx};
 
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {

--- a/crates/perry-codegen/src/expr/compare.rs
+++ b/crates/perry-codegen/src/expr/compare.rs
@@ -5,47 +5,16 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
+use perry_hir::{CompareOp, Expr};
 use perry_types::Type as HirType;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
 use crate::type_analysis::{
-    compute_auto_captures, expr_may_return_boxed_value_from_raw_f64_fallback, is_array_expr,
-    is_bigint_expr, is_bool_expr, is_map_expr, is_numeric_expr, is_set_expr, is_string_expr,
-    is_url_search_params_expr, receiver_class_name,
+    expr_may_return_boxed_value_from_raw_f64_fallback, is_bigint_expr, is_bool_expr,
+    is_numeric_expr, is_string_expr,
 };
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::types::{DOUBLE, I32, I64};
 
-#[allow(unused_imports)]
-use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
-};
+use super::{lower_expr, unbox_str_handle, unbox_to_i64, FnCtx};
 
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {

--- a/crates/perry-codegen/src/expr/conditional.rs
+++ b/crates/perry-codegen/src/expr/conditional.rs
@@ -5,46 +5,11 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::lower_conditional::lower_conditional;
 
-#[allow(unused_imports)]
-use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
-};
+use super::FnCtx;
 
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {

--- a/crates/perry-codegen/src/expr/dispatch.rs
+++ b/crates/perry-codegen/src/expr/dispatch.rs
@@ -8,22 +8,11 @@
 use super::*;
 
 use anyhow::{bail, Result};
-use perry_hir::{BinaryOp, Expr};
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-use crate::block::LlBlock;
-use crate::codegen::AppMetadata;
-use crate::collectors::NativeRegionFactGraph;
-use crate::function::LlFunction;
-use crate::native_value::{
-    AliasState, BoundedBufferIndex, BoundsProof, BoundsState, BufferAccessFacts, BufferAccessMode,
-    BufferViewSlot, GuardedBufferIndex, LoweredValue, MaterializationReason, NativeAbiTypeRecord,
-    NativeFactUse, NativeRep, NativeRepRecord, NativeValueState, PodLayoutManifest,
-    PodRecordViewManifest, ScalarConversionRecord,
-};
-use crate::strings::StringPool;
+use crate::native_value::MaterializationReason;
 use crate::type_analysis::is_numeric_expr;
-use crate::types::{DOUBLE, I32, I64, PTR};
+use crate::types::DOUBLE;
 
 /// Lower an expression to a raw LLVM `double` value. Returns the string form
 /// of the value (either a `%rN` register or a literal like `42.0`).

--- a/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
+++ b/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
@@ -5,45 +5,15 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::{anyhow, bail, Result};
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
+use perry_hir::Expr;
 use perry_types::Type as HirType;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
 use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::types::{DOUBLE, I32, I64, PTR};
 
-#[allow(unused_imports)]
 use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
+    emit_string_literal_global, import_origin_suffix, is_global_this_builtin_name, lower_expr,
+    nanbox_pointer_inline, nanbox_string_inline, unbox_to_i64, FnCtx, I18nLowerCtx,
 };
 
 /// Build the namespace value for a resolved dynamic-import/require target prefix

--- a/crates/perry-codegen/src/expr/env_clones.rs
+++ b/crates/perry-codegen/src/expr/env_clones.rs
@@ -5,46 +5,12 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::{bail, Result};
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::nanbox::double_literal;
+use crate::types::{DOUBLE, I32, I64};
 
-#[allow(unused_imports)]
-use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
-};
+use super::{lower_expr, nanbox_pointer_inline, nanbox_string_inline, unbox_to_i64, FnCtx};
 
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {

--- a/crates/perry-codegen/src/expr/fs_await.rs
+++ b/crates/perry-codegen/src/expr/fs_await.rs
@@ -5,46 +5,12 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::nanbox::double_literal;
+use crate::types::{DOUBLE, I1, I32, I64};
 
-#[allow(unused_imports)]
-use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
-};
+use super::{lower_expr, unbox_to_i64, FnCtx};
 
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {

--- a/crates/perry-codegen/src/expr/index_get.rs
+++ b/crates/perry-codegen/src/expr/index_get.rs
@@ -5,50 +5,22 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
+use perry_hir::{BinaryOp, Expr};
 use perry_types::Type as HirType;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
+use crate::nanbox::POINTER_MASK_I64;
 use crate::native_value::{
     BoundsState, BufferAccessMode, LoweredValue, MaterializationReason, NativeRep, SemanticKind,
 };
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, F32, I1, I16, I32, I64, I8, PTR};
+use crate::type_analysis::{is_array_expr, is_numeric_expr, is_string_expr, receiver_class_name};
+use crate::types::{DOUBLE, F32, I1, I16, I32, I64, I8};
 
-#[allow(unused_imports)]
 use super::{
-    array_kind_fact, buffer_access_materialization_reason, buffer_alias_metadata_suffix,
-    emit_layout_note_slot_on_block, emit_shadow_slot_clear, emit_shadow_slot_update_for_expr,
-    emit_string_literal_global, emit_typed_feedback_register_site, emit_v8_export_call,
-    emit_v8_member_method_call, emit_write_barrier, emit_write_barrier_slot_on_block,
-    expr_has_numeric_pointer_free_array_layout, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix, int_range_expr,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_buffer_load, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_typed_array_load, lower_url_string_getter, materialize_js_value, nanbox_bigint_inline,
-    nanbox_pointer_inline, nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array,
-    raw_f64_layout_fact, try_flat_const_2d_int, try_lower_flat_const_index_get,
-    try_match_channel_reduction, try_static_class_name, unbox_str_handle, unbox_to_i64,
-    variant_name, BufferAccessSpec, ChannelReduction, FlatConstInfo, FnCtx, I18nLowerCtx,
-    PackedF64LoopFact, PackedNumericLoopKind, TypedFeedbackContract, TypedFeedbackKind,
+    array_kind_fact, buffer_access_materialization_reason, emit_typed_feedback_register_site,
+    expr_has_numeric_pointer_free_array_layout, int_range_expr, lower_buffer_load, lower_expr,
+    lower_expr_as_i32, lower_typed_array_load, materialize_js_value, raw_f64_layout_fact,
+    try_lower_flat_const_index_get, unbox_str_handle, unbox_to_i64, BufferAccessSpec, FnCtx,
+    PackedF64LoopFact, TypedFeedbackContract, TypedFeedbackKind,
 };
 
 fn is_width_tracked_typed_array_receiver(ctx: &FnCtx<'_>, object: &Expr) -> bool {

--- a/crates/perry-codegen/src/expr/index_set.rs
+++ b/crates/perry-codegen/src/expr/index_set.rs
@@ -5,54 +5,25 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::{BinaryOp, Expr};
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
 use crate::nanbox::{double_literal, POINTER_MASK_I64};
 use crate::native_value::{
     BoundsState, BufferAccessMode, ExpectedNativeRep, LoweredValue, MaterializationReason,
     NativeRep, SemanticKind,
 };
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, F32, I1, I16, I32, I64, I8, PTR};
+use crate::type_analysis::{is_array_expr, is_numeric_expr, is_string_expr, receiver_class_name};
+use crate::types::{DOUBLE, F32, I1, I16, I32, I64, I8};
 
-#[allow(unused_imports)]
 use super::{
     array_kind_fact, array_store_needs_layout_note, array_store_needs_write_barrier,
-    buffer_access_materialization_reason, buffer_alias_metadata_suffix,
-    emit_array_numeric_write_note_on_block, emit_jsvalue_slot_store_on_block,
-    emit_layout_note_slot_on_block, emit_root_nanbox_store_on_block, emit_shadow_slot_clear,
-    emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_typed_feedback_register_site, emit_v8_export_call, emit_v8_member_method_call,
-    emit_write_barrier, emit_write_barrier_slot_on_block,
-    expr_has_numeric_pointer_free_array_layout, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix, int_range_expr,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_buffer_store, lower_channel_reduction, lower_expr,
-    lower_expr_as_i32, lower_expr_native, lower_index_set_fast, lower_js_args_array,
-    lower_object_literal, lower_stream_super_init, lower_typed_array_store,
-    lower_url_string_getter, materialize_js_value, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, raw_f64_layout_fact,
-    try_flat_const_2d_int, try_lower_flat_const_index_get, try_match_channel_reduction,
-    try_static_class_name, unbox_str_handle, unbox_to_i64, variant_name, BufferAccessSpec,
-    ChannelReduction, FlatConstInfo, FnCtx, I18nLowerCtx, PackedF64LoopFact, PackedNumericLoopKind,
+    buffer_access_materialization_reason, emit_array_numeric_write_note_on_block,
+    emit_jsvalue_slot_store_on_block, emit_root_nanbox_store_on_block,
+    emit_typed_feedback_register_site, emit_write_barrier,
+    expr_has_numeric_pointer_free_array_layout, int_range_expr, lower_buffer_store, lower_expr,
+    lower_expr_as_i32, lower_expr_native, lower_index_set_fast, lower_typed_array_store,
+    materialize_js_value, nanbox_pointer_inline, raw_f64_layout_fact, unbox_str_handle,
+    unbox_to_i64, BufferAccessSpec, FnCtx, PackedF64LoopFact, PackedNumericLoopKind,
     TypedFeedbackContract, TypedFeedbackKind,
 };
 

--- a/crates/perry-codegen/src/expr/instance_misc1.rs
+++ b/crates/perry-codegen/src/expr/instance_misc1.rs
@@ -5,45 +5,16 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::{anyhow, Result};
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp, WithSetFallback};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::{BinaryOp, Expr, WithSetFallback};
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
 use crate::nanbox::{double_literal, i64_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::type_analysis::is_string_expr;
+use crate::types::{DOUBLE, I1, I32, I64, PTR};
 
-#[allow(unused_imports)]
 use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_root_nanbox_store_on_block, emit_shadow_slot_bind_for_local, emit_shadow_slot_clear,
-    emit_shadow_slot_update_for_expr, emit_string_literal_global, emit_v8_export_call,
-    emit_v8_member_method_call, emit_write_barrier, emit_write_barrier_slot_on_block,
-    expr_is_known_non_pointer_shadow_value, extract_array_of_object_shape, i32_bool_to_nanbox,
-    import_origin_suffix, is_global_this_builtin_function_name, is_global_this_builtin_name,
-    is_known_finite, lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
+    emit_root_nanbox_store_on_block, emit_shadow_slot_bind_for_local, emit_string_literal_global,
+    emit_write_barrier, extract_array_of_object_shape, i32_bool_to_nanbox, lower_array_literal,
+    lower_expr, nanbox_pointer_inline, nanbox_string_inline, unbox_str_handle, unbox_to_i64, FnCtx,
 };
 
 /// Reserved runtime class id for a built-in constructor usable as a class

--- a/crates/perry-codegen/src/expr/js_runtime.rs
+++ b/crates/perry-codegen/src/expr/js_runtime.rs
@@ -5,46 +5,13 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
 use crate::native_value::MaterializationReason;
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::types::{DOUBLE, I64, PTR};
 
-#[allow(unused_imports)]
 use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, downgrade_buffer_aliases_in_expr,
-    emit_layout_note_slot_on_block, emit_shadow_slot_clear, emit_shadow_slot_update_for_expr,
-    emit_string_literal_global, emit_v8_export_call, emit_v8_member_method_call,
-    emit_write_barrier, emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
+    downgrade_buffer_aliases_in_expr, lower_expr, lower_js_args_array, unbox_to_i64, FnCtx,
 };
 
 fn downgrade_unknown_call_expr(ctx: &mut FnCtx<'_>, expr: &Expr) {

--- a/crates/perry-codegen/src/expr/literals_vars.rs
+++ b/crates/perry-codegen/src/expr/literals_vars.rs
@@ -5,46 +5,20 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::{anyhow, Result};
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
+use perry_hir::{BinaryOp, Expr, UpdateOp};
 use perry_types::Type as HirType;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
+use crate::lower_string_method::lower_string_self_append;
+use crate::nanbox::double_literal;
 use crate::native_value::MaterializationReason;
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::type_analysis::{is_map_expr, is_set_expr, receiver_class_name};
+use crate::types::{DOUBLE, I32, I64};
 
-#[allow(unused_imports)]
 use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, can_lower_expr_as_i32_in_current_region,
-    emit_layout_note_slot_on_block, emit_root_nanbox_store_on_block, emit_shadow_slot_clear,
-    emit_shadow_slot_update_for_expr, emit_string_literal_global, emit_v8_export_call,
-    emit_v8_member_method_call, emit_write_barrier, emit_write_barrier_slot_on_block,
-    expr_is_known_non_pointer_shadow_value, extract_array_of_object_shape, i32_bool_to_nanbox,
-    import_origin_suffix, is_global_this_builtin_function_name, is_global_this_builtin_name,
-    is_known_finite, lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_pod_local_reassignment,
-    lower_stream_super_init, lower_url_string_getter, materialize_pod_local, nanbox_bigint_inline,
-    nanbox_pointer_inline, nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array,
-    try_flat_const_2d_int, try_lower_flat_const_index_get, try_match_channel_reduction,
-    try_static_class_name, unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction,
-    FlatConstInfo, FnCtx, I18nLowerCtx,
+    can_lower_expr_as_i32_in_current_region, emit_root_nanbox_store_on_block,
+    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_write_barrier,
+    is_global_this_builtin_function_name, lower_expr, lower_expr_as_i32,
+    lower_pod_local_reassignment, materialize_pod_local, nanbox_string_inline, FnCtx,
 };
 
 /// #1380: method names addressable on a `Set` instance, used by the

--- a/crates/perry-codegen/src/expr/logical_collections.rs
+++ b/crates/perry-codegen/src/expr/logical_collections.rs
@@ -5,48 +5,19 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::{bail, Result};
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
+use perry_hir::Expr;
 use perry_types::Type as HirType;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
+use crate::lower_conditional::lower_logical;
 use crate::nanbox::{double_literal, POINTER_MASK_I64, TAG_UNDEFINED};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_definitely_string_expr,
-    is_map_expr, is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr,
-    map_static_type_args, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::type_analysis::{is_definitely_string_expr, is_numeric_expr, map_static_type_args};
+use crate::types::{DOUBLE, I32, I64, PTR};
 
-#[allow(unused_imports)]
 use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array,
-    record_collection_number_key_fallback, record_collection_number_key_selected,
-    record_collection_string_key_fallback, record_collection_string_key_selected,
-    try_flat_const_2d_int, try_lower_flat_const_index_get, try_match_channel_reduction,
-    try_static_class_name, unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction,
-    FlatConstInfo, FnCtx, I18nLowerCtx,
+    emit_string_literal_global, i32_bool_to_nanbox, lower_expr, nanbox_pointer_inline,
+    nanbox_string_inline, record_collection_number_key_fallback,
+    record_collection_number_key_selected, record_collection_string_key_fallback,
+    record_collection_string_key_selected, unbox_str_handle, unbox_to_i64, FnCtx,
 };
 
 fn is_static_string_key_map(ctx: &FnCtx<'_>, map: &Expr) -> bool {

--- a/crates/perry-codegen/src/expr/math_simple.rs
+++ b/crates/perry-codegen/src/expr/math_simple.rs
@@ -5,49 +5,19 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
+use perry_hir::{BinaryOp, Expr};
 use perry_types::Type as HirType;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_definitely_string_expr,
-    is_map_expr, is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr,
-    map_static_type_args, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, F32, I1, I32, I64, I8, PTR};
+use crate::type_analysis::{is_definitely_string_expr, is_numeric_expr, map_static_type_args};
+use crate::types::{DOUBLE, F32, I1, I32, I64};
 
-#[allow(unused_imports)]
 use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32, lower_expr_native,
-    lower_index_set_fast, lower_js_args_array, lower_math_operand, lower_object_literal,
-    lower_stream_super_init, lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array,
-    record_collection_number_key_fallback, record_collection_number_key_selected,
-    record_collection_string_key_fallback, record_collection_string_key_selected,
-    record_collection_string_key_value_selected, record_collection_typed_value_fallback,
-    record_collection_typed_value_selected, try_flat_const_2d_int, try_lower_flat_const_index_get,
-    try_match_channel_reduction, try_static_class_name, unbox_str_handle, unbox_to_i64,
-    variant_name, ChannelReduction, FlatConstInfo, FnCtx, I18nLowerCtx,
+    can_lower_expr_as_i32, lower_expr, lower_expr_native, lower_math_operand,
+    nanbox_pointer_inline, nanbox_string_inline, record_collection_number_key_fallback,
+    record_collection_number_key_selected, record_collection_string_key_fallback,
+    record_collection_string_key_selected, record_collection_string_key_value_selected,
+    record_collection_typed_value_fallback, record_collection_typed_value_selected,
+    unbox_str_handle, unbox_to_i64, FnCtx,
 };
 
 fn is_static_string_number_map(ctx: &FnCtx<'_>, map: &Expr) -> bool {

--- a/crates/perry-codegen/src/expr/misc_methods.rs
+++ b/crates/perry-codegen/src/expr/misc_methods.rs
@@ -5,46 +5,17 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::{Expr, UnaryOp};
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
+use crate::nanbox::double_literal;
 use crate::native_value::{ExpectedNativeRep, LoweredValue, MaterializationReason, NativeRep};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
+use crate::type_analysis::is_numeric_expr;
 use crate::types::{DOUBLE, F32, I1, I32, I64, I8, PTR};
 
-#[allow(unused_imports)]
 use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32, lower_expr_native,
-    lower_expr_value, lower_index_set_fast, lower_js_args_array, lower_math_operand,
-    lower_object_literal, lower_stream_super_init, lower_url_string_getter, materialize_js_value,
-    nanbox_bigint_inline, nanbox_pointer_inline, nanbox_pointer_inline_pub, nanbox_string_inline,
-    proxy_build_args_array, try_flat_const_2d_int, try_lower_flat_const_index_get,
-    try_match_channel_reduction, try_static_class_name, unbox_str_handle, unbox_to_i64,
-    variant_name, ChannelReduction, FlatConstInfo, FnCtx, I18nLowerCtx,
+    i32_bool_to_nanbox, lower_expr, lower_expr_native, lower_expr_value, lower_math_operand,
+    materialize_js_value, nanbox_pointer_inline, nanbox_string_inline, unbox_str_handle,
+    unbox_to_i64, FnCtx,
 };
 
 fn lowered_value_to_iter_result_f64(

--- a/crates/perry-codegen/src/expr/mod.rs
+++ b/crates/perry-codegen/src/expr/mod.rs
@@ -8,7 +8,7 @@
 //! error so a user running `--backend llvm` on richer TypeScript gets a
 //! one-line explanation instead of a silent broken binary.
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, Result};
 use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp};
 use perry_types::Type as HirType;
 
@@ -18,17 +18,13 @@ use crate::collectors::NativeRegionFactGraph;
 use crate::function::LlFunction;
 use crate::nanbox::double_literal;
 use crate::native_value::{
-    AliasState, BoundedBufferIndex, BoundsProof, BoundsState, BufferAccessFacts, BufferAccessMode,
-    BufferViewSlot, ExpectedNativeRep, GuardedBufferIndex, LoweredValue, MaterializationReason,
-    NativeAbiTypeRecord, NativeFactUse, NativeRep, NativeRepRecord, NativeValueState,
-    PodLayoutManifest, PodRecordViewManifest, ScalarConversionRecord,
+    AliasState, BoundedBufferIndex, BoundsProof, BoundsState, BufferAccessMode, BufferViewSlot,
+    ExpectedNativeRep, GuardedBufferIndex, LoweredValue, MaterializationReason, NativeFactUse,
+    NativeRep, NativeRepRecord,
 };
 use crate::strings::StringPool;
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-use crate::types::{DOUBLE, F32, I1, I32, I64, I8, PTR};
+use crate::type_analysis::{is_bigint_expr, is_bool_expr, is_numeric_expr};
+use crate::types::{DOUBLE, F32, I1, I32, I64, I8};
 
 // Issue #1098: expr.rs split into expr/ submodules. These are pure
 // mechanical moves of self-contained helper clusters out of this file;
@@ -69,10 +65,9 @@ pub(crate) use buffer_views::{
     invalidate_native_owned_views_for_dispose, native_arena_canonical_owner_id,
     record_native_arena_owner_assignment, update_buffer_view_for_assignment,
 };
-#[allow(unused_imports)] // ChannelReduction kept reachable for surface stability
 pub(crate) use channel::{
     extract_array_of_object_shape, lower_channel_reduction, try_match_channel_reduction,
-    variant_name, ChannelReduction,
+    variant_name,
 };
 pub(crate) use helpers::{
     array_store_needs_layout_note, array_store_needs_write_barrier, buffer_alias_metadata_suffix,
@@ -116,10 +111,10 @@ pub(crate) use v8_interop::{
 pub(crate) use write_barrier::{
     emit_array_numeric_write_note_on_block, emit_jsvalue_slot_store_on_block,
     emit_jsvalue_slot_store_scalar_aware_on_block,
-    emit_jsvalue_slot_store_with_value_bits_on_block, emit_layout_note_slot_on_block,
-    emit_root_heap_word_store_on_block, emit_root_nanbox_store_on_block, emit_write_barrier,
-    emit_write_barrier_slot_on_block, lower_array_super_init, lower_event_emitter_subclass_init,
-    lower_node_stream_super_init, lower_stream_super_init,
+    emit_jsvalue_slot_store_with_value_bits_on_block, emit_root_heap_word_store_on_block,
+    emit_root_nanbox_store_on_block, emit_write_barrier, emit_write_barrier_slot_on_block,
+    lower_array_super_init, lower_event_emitter_subclass_init, lower_node_stream_super_init,
+    lower_stream_super_init,
 };
 
 // Issue #1098 phase 3: the `FnCtx` definition stays in this trunk, but its

--- a/crates/perry-codegen/src/expr/new_dynamic.rs
+++ b/crates/perry-codegen/src/expr/new_dynamic.rs
@@ -5,46 +5,18 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
+use perry_hir::Expr;
 use perry_types::Type as HirType;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
+use crate::lower_call::lower_new;
+use crate::lower_conditional::lower_conditional;
 use crate::nanbox::{double_literal, POINTER_MASK_I64};
 use crate::native_value::MaterializationReason;
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::types::{DOUBLE, I32, I64, PTR};
 
-#[allow(unused_imports)]
 use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, downgrade_buffer_aliases_in_expr,
-    emit_layout_note_slot_on_block, emit_shadow_slot_clear, emit_shadow_slot_update_for_expr,
-    emit_string_literal_global, emit_v8_export_call, emit_v8_member_method_call,
-    emit_write_barrier, emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
+    downgrade_buffer_aliases_in_expr, lower_expr, lower_js_args_array, nanbox_pointer_inline,
+    try_static_class_name, FnCtx,
 };
 
 /// A `new` callee that is a primitive literal — never a constructor, so

--- a/crates/perry-codegen/src/expr/objects_arrays_lit.rs
+++ b/crates/perry-codegen/src/expr/objects_arrays_lit.rs
@@ -5,46 +5,11 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::types::{DOUBLE, I32, I64};
 
-#[allow(unused_imports)]
-use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
-};
+use super::{lower_array_literal, lower_expr, lower_object_literal, nanbox_pointer_inline, FnCtx};
 
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {

--- a/crates/perry-codegen/src/expr/os_uri_dates.rs
+++ b/crates/perry-codegen/src/expr/os_uri_dates.rs
@@ -5,46 +5,12 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::nanbox::double_literal;
+use crate::types::{DOUBLE, I1, I32, I64, PTR};
 
-#[allow(unused_imports)]
-use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
-};
+use super::{lower_expr, nanbox_pointer_inline, nanbox_string_inline, unbox_to_i64, FnCtx};
 
 /// Field selector codes for `js_date_apply_setter`. Must match the runtime
 /// (`crates/perry-runtime/src/date.rs`): 0=FullYear 1=Month 2=Date 3=Hours

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -5,32 +5,17 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
+use perry_hir::Expr;
 use perry_types::Type as HirType;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
 use crate::nanbox::{double_literal, POINTER_MASK_I64};
 use crate::native_value::{
     BoundsState, BufferAccessMode, LoweredValue, MaterializationReason, NativeRep, SemanticKind,
 };
-#[allow(unused_imports)]
 use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_numeric_typed_array_class, is_set_expr, is_string_expr,
+    is_array_expr, is_map_expr, is_numeric_typed_array_class, is_set_expr, is_string_expr,
     is_url_search_params_expr, receiver_class_name, receiver_is_error_type,
 };
-#[allow(unused_imports)]
 use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
 
 use super::property_get_names::{
@@ -48,27 +33,16 @@ pub(crate) use generic_dispatch::lower_generic_property_get;
 pub(crate) use globalget::lower_globalget_property;
 pub(crate) use helpers::{
     builtin_prototype_method_read, class_has_computed_runtime_members,
-    is_global_builtin_value_expr, is_primitive_builtin_proto_method, lower_class_method_bind,
-    lower_global_builtin_static_value, lower_raw_f64_class_field_get_for_number_context,
-    lower_runtime_property_get_by_name, promise_static_function_length_expr,
+    is_global_builtin_value_expr, lower_class_method_bind, lower_global_builtin_static_value,
+    lower_raw_f64_class_field_get_for_number_context, lower_runtime_property_get_by_name,
+    promise_static_function_length_expr,
 };
 
-#[allow(unused_imports)]
 use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_typed_feedback_register_site, emit_v8_export_call, emit_v8_member_method_call,
-    emit_write_barrier, emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    import_origin_suffix_ns, is_global_this_builtin_function_name, is_global_this_builtin_name,
-    is_known_finite, lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, raw_f64_layout_fact,
-    try_flat_const_2d_int, try_lower_flat_const_index_get, try_lower_pod_field_get,
-    try_match_channel_reduction, try_static_class_name, unbox_str_handle, unbox_to_i64,
-    variant_name, ChannelReduction, FlatConstInfo, FnCtx, I18nLowerCtx, TypedFeedbackContract,
-    TypedFeedbackKind,
+    emit_string_literal_global, emit_typed_feedback_register_site, import_origin_suffix,
+    import_origin_suffix_ns, is_global_this_builtin_name, lower_expr, nanbox_pointer_inline,
+    nanbox_string_inline, raw_f64_layout_fact, try_lower_pod_field_get, unbox_to_i64, FnCtx,
+    TypedFeedbackContract, TypedFeedbackKind,
 };
 
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {

--- a/crates/perry-codegen/src/expr/property_get/generic_dispatch.rs
+++ b/crates/perry-codegen/src/expr/property_get/generic_dispatch.rs
@@ -8,32 +8,9 @@
 use super::*;
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
-use crate::native_value::{
-    BoundsState, BufferAccessMode, LoweredValue, MaterializationReason, NativeRep, SemanticKind,
-};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_numeric_typed_array_class, is_set_expr, is_string_expr,
-    is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
+use crate::nanbox::POINTER_MASK_I64;
 use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
 
 /// The generic per-site monomorphic inline-cache dispatch for `obj.property`.

--- a/crates/perry-codegen/src/expr/property_get/globalget.rs
+++ b/crates/perry-codegen/src/expr/property_get/globalget.rs
@@ -7,33 +7,9 @@
 use super::*;
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
 use crate::nanbox::{double_literal, POINTER_MASK_I64};
-use crate::native_value::{
-    BoundsState, BufferAccessMode, LoweredValue, MaterializationReason, NativeRep, SemanticKind,
-};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_numeric_typed_array_class, is_set_expr, is_string_expr,
-    is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::types::{DOUBLE, I64, PTR};
 
 /// Lower a `PropertyGet` whose receiver is the `GlobalGet(0)` builtin-global
 /// sentinel, read by the `property` string alone (the receiver name has been

--- a/crates/perry-codegen/src/expr/property_get/helpers.rs
+++ b/crates/perry-codegen/src/expr/property_get/helpers.rs
@@ -7,33 +7,14 @@
 use super::*;
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
+use crate::nanbox::POINTER_MASK_I64;
 use crate::native_value::{
     BoundsState, BufferAccessMode, LoweredValue, MaterializationReason, NativeRep, SemanticKind,
 };
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_numeric_typed_array_class, is_set_expr, is_string_expr,
-    is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::type_analysis::receiver_class_name;
+use crate::types::{DOUBLE, I32, I64, I8, PTR};
 
 pub(crate) fn class_has_computed_runtime_members(ctx: &FnCtx<'_>, class_name: &str) -> bool {
     ctx.classes

--- a/crates/perry-codegen/src/expr/property_set.rs
+++ b/crates/perry-codegen/src/expr/property_set.rs
@@ -5,51 +5,23 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
+use perry_hir::Expr;
 use perry_types::Type as HirType;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
+use crate::nanbox::POINTER_MASK_I64;
 use crate::native_value::{
     BoundsState, BufferAccessMode, ExpectedNativeRep, LoweredValue, MaterializationReason,
     NativeRep, SemanticKind,
 };
-#[allow(unused_imports)]
 use crate::type_analysis::{
-    compute_auto_captures, expr_may_return_boxed_value_from_raw_f64_fallback, is_array_expr,
-    is_bigint_expr, is_bool_expr, is_map_expr, is_numeric_expr, is_set_expr, is_string_expr,
-    is_url_search_params_expr, receiver_class_name,
+    expr_may_return_boxed_value_from_raw_f64_fallback, is_numeric_expr, receiver_class_name,
 };
-#[allow(unused_imports)]
 use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
 
-#[allow(unused_imports)]
 use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_jsvalue_slot_store_on_block,
-    emit_layout_note_slot_on_block, emit_shadow_slot_clear, emit_shadow_slot_update_for_expr,
-    emit_string_literal_global, emit_typed_feedback_register_site, emit_v8_export_call,
-    emit_v8_member_method_call, emit_write_barrier, emit_write_barrier_slot_on_block,
-    expr_is_known_non_pointer_shadow_value, expr_produces_non_pointer_bits_by_construction,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32, lower_expr_native,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, raw_f64_layout_fact,
-    try_flat_const_2d_int, try_lower_flat_const_index_get, try_lower_pod_field_set,
-    try_match_channel_reduction, try_static_class_name, unbox_str_handle, unbox_to_i64,
-    variant_name, ChannelReduction, FlatConstInfo, FnCtx, I18nLowerCtx, TypedFeedbackContract,
+    emit_jsvalue_slot_store_on_block, emit_typed_feedback_register_site,
+    expr_produces_non_pointer_bits_by_construction, lower_expr, lower_expr_native,
+    raw_f64_layout_fact, try_lower_pod_field_set, unbox_to_i64, FnCtx, TypedFeedbackContract,
     TypedFeedbackKind,
 };
 

--- a/crates/perry-codegen/src/expr/proxy_reflect.rs
+++ b/crates/perry-codegen/src/expr/proxy_reflect.rs
@@ -5,46 +5,16 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
 use crate::nanbox::{double_literal, POINTER_MASK_I64};
 use crate::native_value::MaterializationReason;
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::type_analysis::{is_array_expr, is_string_expr, receiver_class_name};
+use crate::types::{DOUBLE, I32, I64, PTR};
 
-#[allow(unused_imports)]
 use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, downgrade_buffer_aliases_in_expr,
-    emit_layout_note_slot_on_block, emit_shadow_slot_clear, emit_shadow_slot_update_for_expr,
-    emit_string_literal_global, emit_v8_export_call, emit_v8_member_method_call,
-    emit_write_barrier, emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
+    downgrade_buffer_aliases_in_expr, lower_expr, nanbox_pointer_inline, proxy_build_args_array,
+    unbox_str_handle, unbox_to_i64, FnCtx,
 };
 
 fn downgrade_unknown_call_expr(ctx: &mut FnCtx<'_>, expr: &Expr) {

--- a/crates/perry-codegen/src/expr/record_value.rs
+++ b/crates/perry-codegen/src/expr/record_value.rs
@@ -5,23 +5,11 @@
 //! module path.
 use super::*;
 
-use anyhow::{bail, Result};
-use perry_hir::{BinaryOp, Expr};
-use perry_types::Type as HirType;
-
-use crate::block::LlBlock;
-use crate::codegen::AppMetadata;
-use crate::collectors::NativeRegionFactGraph;
-use crate::function::LlFunction;
 use crate::native_value::{
-    AliasState, BoundedBufferIndex, BoundsProof, BoundsState, BufferAccessFacts, BufferAccessMode,
-    BufferViewSlot, GuardedBufferIndex, LoweredValue, MaterializationReason, NativeAbiTypeRecord,
-    NativeFactUse, NativeRep, NativeRepRecord, NativeValueState, PodLayoutManifest,
-    PodRecordViewManifest, ScalarConversionRecord,
+    AliasState, BoundsState, BufferAccessFacts, BufferAccessMode, LoweredValue,
+    MaterializationReason, NativeAbiTypeRecord, NativeFactUse, NativeRepRecord, NativeValueState,
+    PodLayoutManifest, PodRecordViewManifest, ScalarConversionRecord,
 };
-use crate::strings::StringPool;
-use crate::type_analysis::is_numeric_expr;
-use crate::types::{DOUBLE, I32, I64, PTR};
 
 impl<'a> FnCtx<'a> {
     pub fn record_lowered_value(

--- a/crates/perry-codegen/src/expr/shadow_slot.rs
+++ b/crates/perry-codegen/src/expr/shadow_slot.rs
@@ -5,23 +5,10 @@
 //! `crate::expr::X` call paths resolve unchanged.
 use super::*;
 
-use anyhow::{bail, Result};
 use perry_hir::{BinaryOp, Expr};
 use perry_types::Type as HirType;
 
-use crate::block::LlBlock;
-use crate::codegen::AppMetadata;
-use crate::collectors::NativeRegionFactGraph;
-use crate::function::LlFunction;
-use crate::native_value::{
-    AliasState, BoundedBufferIndex, BoundsProof, BoundsState, BufferAccessFacts, BufferAccessMode,
-    BufferViewSlot, GuardedBufferIndex, LoweredValue, MaterializationReason, NativeAbiTypeRecord,
-    NativeFactUse, NativeRep, NativeRepRecord, NativeValueState, PodLayoutManifest,
-    PodRecordViewManifest, ScalarConversionRecord,
-};
-use crate::strings::StringPool;
-use crate::type_analysis::is_numeric_expr;
-use crate::types::{DOUBLE, I32, I64, PTR};
+use crate::types::{I32, I64, PTR};
 
 pub(crate) fn expr_is_known_non_pointer_shadow_value(ctx: &FnCtx<'_>, expr: &Expr) -> bool {
     match expr {

--- a/crates/perry-codegen/src/expr/static_field_meta.rs
+++ b/crates/perry-codegen/src/expr/static_field_meta.rs
@@ -5,46 +5,12 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::nanbox::double_literal;
+use crate::types::{DOUBLE, I32, I64, PTR};
 
-#[allow(unused_imports)]
-use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_root_nanbox_store_on_block, emit_shadow_slot_clear, emit_shadow_slot_update_for_expr,
-    emit_string_literal_global, emit_v8_export_call, emit_v8_member_method_call,
-    emit_write_barrier, emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
-};
+use super::{emit_root_nanbox_store_on_block, lower_expr, nanbox_pointer_inline, FnCtx};
 
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {

--- a/crates/perry-codegen/src/expr/static_method.rs
+++ b/crates/perry-codegen/src/expr/static_method.rs
@@ -5,46 +5,16 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::{bail, Result};
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
+use perry_hir::Expr;
 use perry_types::Type as HirType;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
+use crate::nanbox::double_literal;
 use crate::native_value::MaterializationReason;
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::types::{DOUBLE, I32, I64, PTR};
 
-#[allow(unused_imports)]
 use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, downgrade_buffer_aliases_in_expr,
-    emit_layout_note_slot_on_block, emit_shadow_slot_clear, emit_shadow_slot_update_for_expr,
-    emit_string_literal_global, emit_v8_export_call, emit_v8_member_method_call,
-    emit_write_barrier, emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix_ns,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
+    downgrade_buffer_aliases_in_expr, emit_v8_export_call, emit_v8_member_method_call,
+    import_origin_suffix_ns, lower_expr, nanbox_pointer_inline, unbox_to_i64, FnCtx,
 };
 
 fn downgrade_unknown_call_args(ctx: &mut FnCtx<'_>, args: &[Expr]) {

--- a/crates/perry-codegen/src/expr/string_regex_proc.rs
+++ b/crates/perry-codegen/src/expr/string_regex_proc.rs
@@ -5,45 +5,14 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::nanbox::double_literal;
+use crate::types::{DOUBLE, I32, I64};
 
-#[allow(unused_imports)]
 use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_math_operand, lower_object_literal,
-    lower_stream_super_init, lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
+    lower_array_literal, lower_expr, lower_math_operand, nanbox_pointer_inline,
+    nanbox_string_inline, unbox_to_i64, FnCtx,
 };
 
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {

--- a/crates/perry-codegen/src/expr/super_method.rs
+++ b/crates/perry-codegen/src/expr/super_method.rs
@@ -5,46 +5,12 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::{anyhow, Result};
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::nanbox::double_literal;
+use crate::types::{DOUBLE, I32, I64, PTR};
 
-#[allow(unused_imports)]
-use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
-};
+use super::{emit_string_literal_global, lower_expr, nanbox_pointer_inline, FnCtx};
 
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {

--- a/crates/perry-codegen/src/expr/this_super_call.rs
+++ b/crates/perry-codegen/src/expr/this_super_call.rs
@@ -5,49 +5,15 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{
-    bind_inline_constructor_params, lower_call, lower_native_method_call, lower_new,
-    restore_inline_constructor_scope,
-};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
+use crate::lower_call::{bind_inline_constructor_params, restore_inline_constructor_scope};
 use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::types::{DOUBLE, I32, I64};
 
-#[allow(unused_imports)]
 use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_array_super_init, lower_channel_reduction,
-    lower_event_emitter_subclass_init, lower_expr, lower_expr_as_i32, lower_index_set_fast,
-    lower_js_args_array, lower_node_stream_super_init, lower_object_literal,
-    lower_stream_super_init, lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
+    lower_array_super_init, lower_event_emitter_subclass_init, lower_expr,
+    lower_node_stream_super_init, lower_stream_super_init, nanbox_pointer_inline, FnCtx,
 };
 
 /// Built-in constructor names (beyond Error/stream/fetch, which have their own

--- a/crates/perry-codegen/src/expr/unary.rs
+++ b/crates/perry-codegen/src/expr/unary.rs
@@ -5,47 +5,15 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::{Expr, UnaryOp};
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
+use crate::lower_conditional::lower_truthy;
 use crate::type_analysis::{
-    compute_auto_captures, expr_may_return_boxed_value_from_raw_f64_fallback, is_array_expr,
-    is_bigint_expr, is_bool_expr, is_map_expr, is_numeric_expr, is_set_expr, is_string_expr,
-    is_url_search_params_expr, receiver_class_name,
+    expr_may_return_boxed_value_from_raw_f64_fallback, is_bigint_expr, is_numeric_expr,
 };
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::types::{DOUBLE, I64};
 
-#[allow(unused_imports)]
-use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
-};
+use super::{lower_expr, FnCtx};
 
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
     match expr {

--- a/crates/perry-codegen/src/expr/url_main.rs
+++ b/crates/perry-codegen/src/expr/url_main.rs
@@ -5,45 +5,14 @@
 //! `lower_expr`'s outer dispatch.
 
 use anyhow::Result;
-#[allow(unused_imports)]
-use perry_hir::{BinaryOp, CompareOp, Expr, UnaryOp, UpdateOp};
-#[allow(unused_imports)]
-use perry_types::Type as HirType;
+use perry_hir::Expr;
 
-#[allow(unused_imports)]
-use crate::lower_call::{lower_call, lower_native_method_call, lower_new};
-#[allow(unused_imports)]
-use crate::lower_conditional::{lower_conditional, lower_logical, lower_truthy};
-#[allow(unused_imports)]
-use crate::lower_string_method::{
-    flatten_string_add_chain, lower_string_coerce_concat, lower_string_concat,
-    lower_string_concat_chain, lower_string_self_append,
-};
-#[allow(unused_imports)]
-use crate::nanbox::{double_literal, POINTER_MASK_I64};
-#[allow(unused_imports)]
-use crate::type_analysis::{
-    compute_auto_captures, is_array_expr, is_bigint_expr, is_bool_expr, is_map_expr,
-    is_numeric_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-#[allow(unused_imports)]
-use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
+use crate::nanbox::double_literal;
+use crate::types::{DOUBLE, I1, I32, I64};
 
-#[allow(unused_imports)]
 use super::{
-    buffer_alias_metadata_suffix, can_lower_expr_as_i32, emit_layout_note_slot_on_block,
-    emit_shadow_slot_clear, emit_shadow_slot_update_for_expr, emit_string_literal_global,
-    emit_v8_export_call, emit_v8_member_method_call, emit_write_barrier,
-    emit_write_barrier_slot_on_block, expr_is_known_non_pointer_shadow_value,
-    extract_array_of_object_shape, i32_bool_to_nanbox, import_origin_suffix,
-    is_global_this_builtin_function_name, is_global_this_builtin_name, is_known_finite,
-    lower_array_literal, lower_channel_reduction, lower_expr, lower_expr_as_i32,
-    lower_index_set_fast, lower_js_args_array, lower_object_literal, lower_stream_super_init,
-    lower_url_string_getter, nanbox_bigint_inline, nanbox_pointer_inline,
-    nanbox_pointer_inline_pub, nanbox_string_inline, proxy_build_args_array, try_flat_const_2d_int,
-    try_lower_flat_const_index_get, try_match_channel_reduction, try_static_class_name,
-    unbox_str_handle, unbox_to_i64, variant_name, ChannelReduction, FlatConstInfo, FnCtx,
-    I18nLowerCtx,
+    lower_expr, lower_url_string_getter, nanbox_pointer_inline, nanbox_string_inline, unbox_to_i64,
+    FnCtx,
 };
 
 pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {

--- a/crates/perry-codegen/src/lower_call/mod.rs
+++ b/crates/perry-codegen/src/lower_call/mod.rs
@@ -63,9 +63,7 @@ mod web_storage;
 
 use buffer_intrinsic::try_emit_buffer_read_intrinsic;
 use builtin::lower_builtin_new;
-use event_target::lower_event_target_call;
 use jsx::try_rewrite_perry_tui_jsx_intrinsic;
-use method_override::{emit_guarded_direct_method_call, emit_own_method_override_check};
 // `options/` (#1099): the options-object-literal lowering family,
 // split by native-API surface (notification / abort / fetch) under
 // `options/`. Bring the per-surface entry points + shared helpers
@@ -73,8 +71,8 @@ use method_override::{emit_guarded_direct_method_call, emit_own_method_override_
 // sites in sibling submodules (builtin/native/ui_styling) keep
 // resolving unchanged after the split.
 use options::{
-    build_headers_from_object, get_raw_string_ptr, lower_abort_controller_call,
-    lower_fetch_native_method, lower_notification_schedule,
+    build_headers_from_object, get_raw_string_ptr, lower_fetch_native_method,
+    lower_notification_schedule,
 };
 // `native_table.rs` (#1099): the ~5k-row `NATIVE_MODULE_TABLE` data +
 // arg/ret kind types. The dispatch consumers below

--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -6,7 +6,7 @@
 //! in the sibling `field_init` module.
 
 use anyhow::Result;
-use perry_hir::{Expr, Param};
+use perry_hir::Expr;
 use perry_types::Type as HirType;
 
 use super::field_init::{apply_field_initializers_recursive, FieldInitMode};
@@ -17,9 +17,8 @@ use super::new_ctor_args::{
 };
 use super::new_helpers::{
     collect_decl_local_ids, ctor_body_calls_super, ctor_body_closure_calls_super,
-    ctor_body_has_value_return, ctor_body_uses_new_target, ctor_body_uses_this,
-    ctor_chain_uses_new_target, effective_constructor_param_count, emit_promise_subclass_init,
-    local_constructor_symbol_exists, node_stream_parent_kind,
+    ctor_body_has_value_return, ctor_body_uses_this, ctor_chain_uses_new_target,
+    emit_promise_subclass_init, local_constructor_symbol_exists, node_stream_parent_kind,
 };
 use crate::expr::{lower_expr, lower_js_args_array, nanbox_pointer_inline, FnCtx};
 use crate::nanbox::{double_literal, POINTER_MASK_I64};
@@ -1516,7 +1515,6 @@ fn lower_new_impl(
             .unwrap_or(false);
         if !found_inherited_ctor && class.extends_expr.is_some() && !parent_is_uncallable_builtin {
             if let Some(cid) = ctx.class_ids.get(class_name).copied().filter(|c| *c != 0) {
-                let undef_lit = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
                 let parent_val = ctx.block().call(
                     DOUBLE,
                     "js_get_dynamic_parent_value",

--- a/crates/perry-codegen/src/lower_call/omitted_native_params.rs
+++ b/crates/perry-codegen/src/lower_call/omitted_native_params.rs
@@ -27,8 +27,7 @@ use perry_api_manifest::NativeAbiType;
 use perry_hir::Expr;
 
 use super::extern_func::{
-    lower_buffer_and_len_param, lower_manifest_param, lower_manifest_pod_param,
-    lower_manifest_pod_view_param,
+    lower_buffer_and_len_param, lower_manifest_pod_param, lower_manifest_pod_view_param,
 };
 use crate::expr::FnCtx;
 use crate::nanbox::double_literal;

--- a/crates/perry-codegen/src/lower_call/property_get.rs
+++ b/crates/perry-codegen/src/lower_call/property_get.rs
@@ -10,20 +10,10 @@
 use anyhow::Result;
 use perry_hir::Expr;
 
-use crate::expr::{lower_expr, nanbox_pointer_inline, nanbox_string_inline, unbox_to_i64, FnCtx};
+use crate::expr::FnCtx;
 use crate::lower_array_method::lower_array_method;
 use crate::lower_string_method::{is_known_string_method_name, lower_string_method};
-use crate::nanbox::double_literal;
-use crate::type_analysis::{
-    is_array_expr, is_global_constructor_expr, is_map_expr, is_native_module_dynamic_index,
-    is_promise_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-use crate::types::{DOUBLE, I32, I64};
-
-use super::{
-    emit_guarded_direct_method_call, emit_own_method_override_check, lower_abort_controller_call,
-    lower_event_target_call, lower_fetch_native_method,
-};
+use crate::type_analysis::{is_array_expr, is_native_module_dynamic_index, is_string_expr};
 
 mod dynamic_dispatch;
 mod fetch_chain;

--- a/crates/perry-codegen/src/lower_call/property_get/dynamic_dispatch.rs
+++ b/crates/perry-codegen/src/lower_call/property_get/dynamic_dispatch.rs
@@ -7,14 +7,9 @@ use super::*;
 use anyhow::Result;
 use perry_hir::Expr;
 
-use crate::expr::{lower_expr, nanbox_pointer_inline, nanbox_string_inline, unbox_to_i64, FnCtx};
-use crate::lower_array_method::lower_array_method;
-use crate::lower_string_method::{is_known_string_method_name, lower_string_method};
+use crate::expr::{lower_expr, nanbox_pointer_inline, unbox_to_i64, FnCtx};
 use crate::nanbox::double_literal;
-use crate::type_analysis::{
-    is_array_expr, is_global_constructor_expr, is_map_expr, is_native_module_dynamic_index,
-    is_promise_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
+use crate::type_analysis::receiver_class_name;
 use crate::types::{DOUBLE, I32, I64};
 
 // Reach the override-emit helpers (`pub(super)` of `lower_call`) by their

--- a/crates/perry-codegen/src/lower_call/property_get/fetch_chain.rs
+++ b/crates/perry-codegen/src/lower_call/property_get/fetch_chain.rs
@@ -2,20 +2,10 @@
 //! (`r.headers.get(k)`, `r.clone().status`, `new Response(...).text()`).
 //! Pure code move from `property_get.rs` — no behavior change.
 
-use super::*;
-
 use anyhow::Result;
 use perry_hir::Expr;
 
-use crate::expr::{lower_expr, nanbox_pointer_inline, nanbox_string_inline, unbox_to_i64, FnCtx};
-use crate::lower_array_method::lower_array_method;
-use crate::lower_string_method::{is_known_string_method_name, lower_string_method};
-use crate::nanbox::double_literal;
-use crate::type_analysis::{
-    is_array_expr, is_global_constructor_expr, is_map_expr, is_native_module_dynamic_index,
-    is_promise_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-use crate::types::{DOUBLE, I32, I64};
+use crate::expr::FnCtx;
 
 // Reach the dispatch helpers (`pub(in crate::lower_call)` / `pub(super)`) by
 // their canonical crate-relative paths — they live in sibling modules of the

--- a/crates/perry-codegen/src/lower_call/property_get/helpers.rs
+++ b/crates/perry-codegen/src/lower_call/property_get/helpers.rs
@@ -2,20 +2,10 @@
 //! dispatch tower (`try_lower_property_get_method_call`). Pure code move from
 //! `property_get.rs` — no behavior change.
 
-use super::*;
-
-use anyhow::Result;
 use perry_hir::Expr;
 
-use crate::expr::{lower_expr, nanbox_pointer_inline, nanbox_string_inline, unbox_to_i64, FnCtx};
-use crate::lower_array_method::lower_array_method;
-use crate::lower_string_method::{is_known_string_method_name, lower_string_method};
-use crate::nanbox::double_literal;
-use crate::type_analysis::{
-    is_array_expr, is_global_constructor_expr, is_map_expr, is_native_module_dynamic_index,
-    is_promise_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-use crate::types::{DOUBLE, I32, I64};
+use crate::expr::FnCtx;
+use crate::type_analysis::receiver_class_name;
 
 /// Methods that exist on `Array.prototype` but NOT on `String.prototype`.
 /// Used to keep the string-method dispatch from claiming a call site

--- a/crates/perry-codegen/src/lower_call/property_get/map_set.rs
+++ b/crates/perry-codegen/src/lower_call/property_get/map_set.rs
@@ -1,20 +1,13 @@
 //! Map / Set method dispatch + Map/Set/URLSearchParams `.forEach`.
 //! Pure code move from `property_get.rs` — no behavior change.
 
-use super::*;
-
 use anyhow::Result;
 use perry_hir::Expr;
 
-use crate::expr::{lower_expr, nanbox_pointer_inline, nanbox_string_inline, unbox_to_i64, FnCtx};
-use crate::lower_array_method::lower_array_method;
-use crate::lower_string_method::{is_known_string_method_name, lower_string_method};
+use crate::expr::{lower_expr, unbox_to_i64, FnCtx};
 use crate::nanbox::double_literal;
-use crate::type_analysis::{
-    is_array_expr, is_global_constructor_expr, is_map_expr, is_native_module_dynamic_index,
-    is_promise_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-use crate::types::{DOUBLE, I32, I64};
+use crate::type_analysis::{is_map_expr, is_set_expr, is_url_search_params_expr};
+use crate::types::{DOUBLE, I64};
 
 /// Map/Set methods on PropertyGet receivers. The HIR only folds
 /// `m.set(...)`/`m.get(...)` to MapSet/MapGet when `m` is an Ident receiver.

--- a/crates/perry-codegen/src/lower_call/property_get/number_string.rs
+++ b/crates/perry-codegen/src/lower_call/property_get/number_string.rs
@@ -6,13 +6,10 @@ use super::*;
 use anyhow::Result;
 use perry_hir::Expr;
 
-use crate::expr::{lower_expr, nanbox_pointer_inline, nanbox_string_inline, unbox_to_i64, FnCtx};
-use crate::lower_array_method::lower_array_method;
-use crate::lower_string_method::{is_known_string_method_name, lower_string_method};
+use crate::expr::{lower_expr, nanbox_string_inline, FnCtx};
 use crate::nanbox::double_literal;
 use crate::type_analysis::{
-    is_array_expr, is_global_constructor_expr, is_map_expr, is_native_module_dynamic_index,
-    is_promise_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
+    is_array_expr, is_native_module_dynamic_index, is_string_expr, receiver_class_name,
 };
 use crate::types::{DOUBLE, I32, I64};
 

--- a/crates/perry-codegen/src/lower_call/property_get/promise_chain.rs
+++ b/crates/perry-codegen/src/lower_call/property_get/promise_chain.rs
@@ -1,20 +1,13 @@
 //! Promise `.then` / `.catch` / `.finally` PropertyGet dispatch.
 //! Pure code move from `property_get.rs` — no behavior change.
 
-use super::*;
-
 use anyhow::Result;
 use perry_hir::Expr;
 
-use crate::expr::{lower_expr, nanbox_pointer_inline, nanbox_string_inline, FnCtx};
-use crate::lower_array_method::lower_array_method;
-use crate::lower_string_method::{is_known_string_method_name, lower_string_method};
+use crate::expr::{lower_expr, nanbox_pointer_inline, FnCtx};
 use crate::nanbox::double_literal;
-use crate::type_analysis::{
-    is_array_expr, is_global_constructor_expr, is_map_expr, is_native_module_dynamic_index,
-    is_promise_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
-use crate::types::{DOUBLE, I32, I64};
+use crate::type_analysis::{is_global_constructor_expr, is_promise_expr};
+use crate::types::{DOUBLE, I64};
 
 /// `undefined`, boxed — the "no handler" default for an omitted
 /// `.then`/`.catch`/`.finally` argument. `js_promise_then_checked` /

--- a/crates/perry-codegen/src/lower_call/property_get/static_dispatch.rs
+++ b/crates/perry-codegen/src/lower_call/property_get/static_dispatch.rs
@@ -6,14 +6,8 @@ use super::*;
 use anyhow::Result;
 use perry_hir::Expr;
 
-use crate::expr::{lower_expr, nanbox_pointer_inline, nanbox_string_inline, unbox_to_i64, FnCtx};
-use crate::lower_array_method::lower_array_method;
-use crate::lower_string_method::{is_known_string_method_name, lower_string_method};
+use crate::expr::{lower_expr, nanbox_pointer_inline, FnCtx};
 use crate::nanbox::double_literal;
-use crate::type_analysis::{
-    is_array_expr, is_global_constructor_expr, is_map_expr, is_native_module_dynamic_index,
-    is_promise_expr, is_set_expr, is_string_expr, is_url_search_params_expr, receiver_class_name,
-};
 use crate::types::{DOUBLE, I32, I64};
 
 /// Issue #687 — ClassRef receiver static-method dispatch.

--- a/crates/perry-codegen/src/native_value/verify.rs
+++ b/crates/perry-codegen/src/native_value/verify.rs
@@ -1,16 +1,12 @@
 use anyhow::{bail, Result};
 
 #[cfg(test)]
-use super::artifact::NativeAbiTransitionRecord;
-use super::artifact::{
-    NativeAbiDirection, NativeAbiTransitionOp, NativeFactUse, NativeRepRecord, NativeValueState,
-    PodLayoutManifest,
-};
+use super::artifact::{NativeAbiTransitionOp, NativeAbiTransitionRecord};
+use super::artifact::{NativeRepRecord, NativeValueState};
 use super::buffer::{AliasState, BoundsState, BufferAccessMode};
-use super::materialize::MaterializationReason;
+#[cfg(test)]
 use super::pod::recompute_layout_from_fields;
 use super::rep::NativeRep;
-use crate::types::{DOUBLE, F32, I32, I64, I8, PTR};
 
 mod abi;
 mod layout;

--- a/crates/perry-codegen/src/native_value/verify/abi.rs
+++ b/crates/perry-codegen/src/native_value/verify/abi.rs
@@ -1,18 +1,5 @@
-use super::*;
-
-use anyhow::{bail, Result};
-
-#[cfg(test)]
-use crate::native_value::artifact::NativeAbiTransitionRecord;
-use crate::native_value::artifact::{
-    NativeAbiDirection, NativeAbiTransitionOp, NativeFactUse, NativeRepRecord, NativeValueState,
-    PodLayoutManifest,
-};
-use crate::native_value::buffer::{AliasState, BoundsState, BufferAccessMode};
-use crate::native_value::materialize::MaterializationReason;
-use crate::native_value::pod::recompute_layout_from_fields;
+use crate::native_value::artifact::{NativeAbiDirection, NativeRepRecord};
 use crate::native_value::rep::NativeRep;
-use crate::types::{DOUBLE, F32, I32, I64, I8, PTR};
 
 pub(crate) fn validate_native_abi_type_record(
     record: &NativeRepRecord,

--- a/crates/perry-codegen/src/native_value/verify/layout.rs
+++ b/crates/perry-codegen/src/native_value/verify/layout.rs
@@ -1,15 +1,4 @@
-use super::*;
-
-use anyhow::{bail, Result};
-
-#[cfg(test)]
-use crate::native_value::artifact::NativeAbiTransitionRecord;
-use crate::native_value::artifact::{
-    NativeAbiDirection, NativeAbiTransitionOp, NativeFactUse, NativeRepRecord, NativeValueState,
-    PodLayoutManifest,
-};
-use crate::native_value::buffer::{AliasState, BoundsState, BufferAccessMode};
-use crate::native_value::materialize::MaterializationReason;
+use crate::native_value::artifact::{NativeAbiTransitionOp, NativeRepRecord, PodLayoutManifest};
 use crate::native_value::pod::recompute_layout_from_fields;
 use crate::native_value::rep::NativeRep;
 use crate::types::{DOUBLE, F32, I1, I128, I32, I64, I8, PTR};

--- a/crates/perry-codegen/src/native_value/verify/raw_f64.rs
+++ b/crates/perry-codegen/src/native_value/verify/raw_f64.rs
@@ -1,18 +1,9 @@
 use super::*;
 
-use anyhow::{bail, Result};
-
-#[cfg(test)]
-use crate::native_value::artifact::NativeAbiTransitionRecord;
-use crate::native_value::artifact::{
-    NativeAbiDirection, NativeAbiTransitionOp, NativeFactUse, NativeRepRecord, NativeValueState,
-    PodLayoutManifest,
-};
+use crate::native_value::artifact::{NativeFactUse, NativeRepRecord, NativeValueState};
 use crate::native_value::buffer::{AliasState, BoundsState, BufferAccessMode};
 use crate::native_value::materialize::MaterializationReason;
-use crate::native_value::pod::recompute_layout_from_fields;
 use crate::native_value::rep::NativeRep;
-use crate::types::{DOUBLE, F32, I32, I64, I8, PTR};
 
 pub(crate) fn raw_f64_checked_native_consumer(record: &NativeRepRecord) -> bool {
     matches!(

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi/data_stores.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi/data_stores.rs
@@ -1,9 +1,8 @@
 //! Database / data-store / crypto / OS stdlib FFI declarations
 //! (extracted from stdlib_ffi.rs): pg, redis, mongodb, sqlite, OS, crypto, nanoid.
 
-use super::*;
 use crate::module::LlModule;
-use crate::types::{DOUBLE, F32, I1, I16, I32, I64, I8, PTR, VOID};
+use crate::types::{DOUBLE, I32, I64, VOID};
 
 pub(crate) fn declare_data_stores(module: &mut LlModule) {
     // ========== PostgreSQL (pg) ==========

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi/language_core.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi/language_core.rs
@@ -4,9 +4,8 @@
 //! async-step, slugify, class registration, runtime init/module-loader,
 //! well-known Symbol hooks, Object.groupBy, JSX runtime adapter.
 
-use super::*;
 use crate::module::LlModule;
-use crate::types::{DOUBLE, F32, I1, I16, I32, I64, I8, PTR, VOID};
+use crate::types::{DOUBLE, I32, I64, PTR, VOID};
 
 pub(crate) fn declare_core(module: &mut LlModule) {
     // ========== Date ==========

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi/net_http.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi/net_http.rs
@@ -1,9 +1,8 @@
 //! HTTP / HTTPS / HTTP2 server + client, agents, vm/repl/worker_threads
 //! stdlib FFI declarations (extracted from stdlib_ffi.rs).
 
-use super::*;
 use crate::module::LlModule;
-use crate::types::{DOUBLE, F32, I1, I16, I32, I64, I8, PTR, VOID};
+use crate::types::{DOUBLE, I32, I64, VOID};
 
 pub(crate) fn declare_net_http(module: &mut LlModule) {
     // ========== node:vm ==========

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi/streams_events.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi/streams_events.rs
@@ -2,9 +2,8 @@
 //! nodemailer, rate-limit, validator stdlib FFI declarations
 //! (extracted from stdlib_ffi.rs).
 
-use super::*;
 use crate::module::LlModule;
-use crate::types::{DOUBLE, F32, I1, I16, I32, I64, I8, PTR, VOID};
+use crate::types::{DOUBLE, I32, I64, VOID};
 
 pub(crate) fn declare_streams_events(module: &mut LlModule) {
     // ========== node:stream stubs (issue #631) ==========

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi/third_party.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi/third_party.rs
@@ -3,9 +3,8 @@
 //! async_hooks/AsyncLocalStorage, DisposableStack, zlib, Buffer, child_process,
 //! cheerio.
 
-use super::*;
 use crate::module::LlModule;
-use crate::types::{DOUBLE, F32, I1, I16, I32, I64, I8, PTR, VOID};
+use crate::types::{DOUBLE, I32, I64, PTR, VOID};
 
 pub(crate) fn declare_third_party(module: &mut LlModule) {
     // ========== bcrypt / argon2 ==========

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi/utilities.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi/utilities.rs
@@ -2,9 +2,8 @@
 //! @perryts/pdf, commander, dotenv, date libs (dayjs/datefns/moment),
 //! decimal.js, ethers, lodash, lru-cache.
 
-use super::*;
 use crate::module::LlModule;
-use crate::types::{DOUBLE, F32, I1, I16, I32, I64, I8, PTR, VOID};
+use crate::types::{DOUBLE, I64, VOID};
 
 pub(crate) fn declare_utilities(module: &mut LlModule) {
     // ========== @perryts/pdf (issue #516) ==========

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi/web.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi/web.rs
@@ -1,9 +1,8 @@
 //! URL / URLSearchParams + WebSocket stdlib FFI declarations
 //! (extracted from stdlib_ffi.rs).
 
-use super::*;
 use crate::module::LlModule;
-use crate::types::{DOUBLE, F32, I1, I16, I32, I64, I8, PTR, VOID};
+use crate::types::{DOUBLE, I32, I64, VOID};
 
 pub(crate) fn declare_web(module: &mut LlModule) {
     // ========== URL / URLSearchParams ==========

--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -4,26 +4,21 @@
 //! Used by `expr.rs`, `lower_call.rs`, `lower_string_method.rs`,
 //! `lower_conditional.rs`, and `stmt.rs`.
 
-use perry_hir::{BinaryOp, Expr, UnaryOp};
-use perry_types::Type as HirType;
-
-use crate::expr::FnCtx;
-use crate::type_analysis_facts::{
-    function_type_from_decl, hir_inferred_refinable_type, hir_inferred_static_type,
-};
-use crate::type_analysis_net::{net_result_class, net_result_type};
-
 #[cfg(test)]
 pub(crate) use crate::type_analysis_facts::{
     hir_inferred_refinable_type_from_facts, hir_inferred_refinable_type_from_locals,
     hir_inferred_static_type_from_locals, CodegenTypeFacts,
 };
+#[cfg(test)]
+use perry_hir::Expr;
+#[cfg(test)]
+use perry_types::Type as HirType;
 
 // Class-field layout / declared-type resolution lives in a sibling module
 // (file-size gate). Re-exported here so existing `type_analysis::*` call
 // sites keep resolving, and brought into scope for local callers.
 pub(crate) use crate::type_analysis_class_fields::{
-    class_field_declared_type, class_field_global_index, declared_field_type,
+    class_field_declared_type, class_field_global_index,
 };
 
 // The body of this module was split into topical sub-modules to keep each
@@ -45,8 +40,8 @@ pub(crate) use pod::{
     scalar_replaced_field_raw_f64_store_state,
 };
 pub(crate) use predicates::{
-    is_array_expr, is_global_builtin_named, is_native_module_dynamic_index, is_promise_expr,
-    receiver_class_name, receiver_is_error_type, static_type_of,
+    is_array_expr, is_native_module_dynamic_index, is_promise_expr, receiver_class_name,
+    receiver_is_error_type, static_type_of,
 };
 // Re-exported so the `#[cfg(test)] mod tests` (which reaches trunk items via
 // `super::*`) can keep calling `tuple_index_literal` directly.

--- a/crates/perry-codegen/src/type_analysis/numeric.rs
+++ b/crates/perry-codegen/src/type_analysis/numeric.rs
@@ -8,13 +8,6 @@ use perry_hir::{BinaryOp, Expr, UnaryOp};
 use perry_types::Type as HirType;
 
 use crate::expr::FnCtx;
-use crate::type_analysis_class_fields::{
-    class_field_declared_type, class_field_global_index, declared_field_type,
-};
-use crate::type_analysis_facts::{
-    function_type_from_decl, hir_inferred_refinable_type, hir_inferred_static_type,
-};
-use crate::type_analysis_net::{net_result_class, net_result_type};
 
 /// Statically determine whether an expression evaluates to a real numeric
 /// `double` (NOT a NaN-boxed value). Used by `lower_truthy` to decide

--- a/crates/perry-codegen/src/type_analysis/pod.rs
+++ b/crates/perry-codegen/src/type_analysis/pod.rs
@@ -4,17 +4,11 @@
 
 use super::*;
 
-use perry_hir::{BinaryOp, Expr, UnaryOp};
+use perry_hir::Expr;
 use perry_types::Type as HirType;
 
 use crate::expr::FnCtx;
-use crate::type_analysis_class_fields::{
-    class_field_declared_type, class_field_global_index, declared_field_type,
-};
-use crate::type_analysis_facts::{
-    function_type_from_decl, hir_inferred_refinable_type, hir_inferred_static_type,
-};
-use crate::type_analysis_net::{net_result_class, net_result_type};
+use crate::type_analysis_class_fields::{class_field_declared_type, declared_field_type};
 
 pub(crate) fn is_numeric_typed_array_class(name: &str) -> bool {
     matches!(

--- a/crates/perry-codegen/src/type_analysis/predicates.rs
+++ b/crates/perry-codegen/src/type_analysis/predicates.rs
@@ -4,16 +4,11 @@
 
 use super::*;
 
-use perry_hir::{BinaryOp, Expr, UnaryOp};
+use perry_hir::Expr;
 use perry_types::Type as HirType;
 
 use crate::expr::FnCtx;
-use crate::type_analysis_class_fields::{
-    class_field_declared_type, class_field_global_index, declared_field_type,
-};
-use crate::type_analysis_facts::{
-    function_type_from_decl, hir_inferred_refinable_type, hir_inferred_static_type,
-};
+use crate::type_analysis_facts::{function_type_from_decl, hir_inferred_static_type};
 use crate::type_analysis_net::{net_result_class, net_result_type};
 
 /// Statically determine whether an expression evaluates to a Promise.

--- a/crates/perry-codegen/src/type_analysis/refine.rs
+++ b/crates/perry-codegen/src/type_analysis/refine.rs
@@ -8,13 +8,8 @@ use perry_hir::{BinaryOp, Expr, UnaryOp};
 use perry_types::Type as HirType;
 
 use crate::expr::FnCtx;
-use crate::type_analysis_class_fields::{
-    class_field_declared_type, class_field_global_index, declared_field_type,
-};
-use crate::type_analysis_facts::{
-    function_type_from_decl, hir_inferred_refinable_type, hir_inferred_static_type,
-};
-use crate::type_analysis_net::{net_result_class, net_result_type};
+use crate::type_analysis_facts::hir_inferred_refinable_type;
+use crate::type_analysis_net::net_result_type;
 
 pub(crate) fn is_global_constructor_expr(e: &Expr, name: &str) -> bool {
     matches!(e, Expr::GlobalGet(_))

--- a/crates/perry-codegen/src/type_analysis/strings.rs
+++ b/crates/perry-codegen/src/type_analysis/strings.rs
@@ -4,17 +4,11 @@
 
 use super::*;
 
-use perry_hir::{BinaryOp, Expr, UnaryOp};
+use perry_hir::{BinaryOp, Expr};
 use perry_types::Type as HirType;
 
 use crate::expr::FnCtx;
-use crate::type_analysis_class_fields::{
-    class_field_declared_type, class_field_global_index, declared_field_type,
-};
-use crate::type_analysis_facts::{
-    function_type_from_decl, hir_inferred_refinable_type, hir_inferred_static_type,
-};
-use crate::type_analysis_net::{net_result_class, net_result_type};
+use crate::type_analysis_class_fields::declared_field_type;
 
 pub(crate) fn is_set_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
     match e {

--- a/crates/perry-ext-http/src/lib.rs
+++ b/crates/perry-ext-http/src/lib.rs
@@ -42,7 +42,6 @@
 //! a v0.6.0 followup that needs a cooperative `spawn_async` surface
 //! on perry-ffi (today's surface is sync-via-blocking-pool only).
 
-#[allow(unused_imports)]
 extern crate perry_ext_http_server as _server_link;
 
 mod agent;

--- a/crates/perry-hir/src/destructuring/mod.rs
+++ b/crates/perry-hir/src/destructuring/mod.rs
@@ -34,10 +34,7 @@ pub(crate) use assignment_expr::lower_destructuring_assignment;
 pub(crate) use assignment_stmt::{
     lower_destructuring_assignment_stmt, lower_destructuring_assignment_stmt_from_local,
 };
-pub(crate) use helpers::{
-    ast_expr_contains_function_expr, get_fetch_module, is_member_fetch_call,
-    rewrite_use_state_tuple,
-};
-pub(crate) use pattern_binding::{lower_pattern_binding, lower_pattern_binding_into};
+pub(crate) use helpers::{ast_expr_contains_function_expr, rewrite_use_state_tuple};
+pub(crate) use pattern_binding::lower_pattern_binding;
 pub(crate) use var_decl::lower_var_decl_with_destructuring;
 pub(crate) use var_decl_sources::resolvable_native_module_for_spec;

--- a/crates/perry-hir/src/destructuring/var_decl/alias_tracking.rs
+++ b/crates/perry-hir/src/destructuring/var_decl/alias_tracking.rs
@@ -3,15 +3,10 @@
 
 use super::*;
 
-use anyhow::{anyhow, Result};
-use perry_types::{LocalId, Type};
+use perry_types::LocalId;
 use swc_ecma_ast as ast;
 
-use crate::ir::*;
-use crate::lower::{lower_expr, LoweringContext};
-use crate::lower_patterns::*;
-
-use crate::destructuring::var_decl_sources::*;
+use crate::lower::LoweringContext;
 
 /// Records the various alias/prototype/static-method facts a freshly-bound
 /// simple identifier (`id`, lowered `init`) carries. Pure side effects on

--- a/crates/perry-hir/src/destructuring/var_decl/binding_guards.rs
+++ b/crates/perry-hir/src/destructuring/var_decl/binding_guards.rs
@@ -2,17 +2,10 @@
 //! shadow-tombstones for a simple `let/const/var` identifier binding
 //! (extracted from `var_decl.rs`'s `Pat::Ident` arm).
 
-use super::*;
-
-use anyhow::{anyhow, Result};
-use perry_types::{LocalId, Type};
+use anyhow::Result;
 use swc_ecma_ast as ast;
 
-use crate::ir::*;
-use crate::lower::{lower_expr, LoweringContext};
-use crate::lower_patterns::*;
-
-use crate::destructuring::var_decl_sources::*;
+use crate::lower::LoweringContext;
 
 /// Applies the strict-mode early error and the native-instance/module
 /// shadow tombstones for a fresh `name` binding. Mirrors the original

--- a/crates/perry-hir/src/destructuring/var_decl/native_fetch.rs
+++ b/crates/perry-hir/src/destructuring/var_decl/native_fetch.rs
@@ -4,16 +4,12 @@
 
 use super::*;
 
-use anyhow::{anyhow, Result};
-use perry_types::{LocalId, Type};
+use perry_types::Type;
 use swc_ecma_ast as ast;
 
-use crate::ir::*;
-use crate::lower::{lower_expr, LoweringContext};
-use crate::lower_patterns::*;
+use crate::lower::LoweringContext;
 
 use crate::destructuring::helpers::{get_fetch_module, is_member_fetch_call};
-use crate::destructuring::var_decl_sources::*;
 
 /// Handles the `require(...)` namespace-binding fast path and the fetch /
 /// Web-Streams / Blob native-instance registrations. May refine `ty`.

--- a/crates/perry-hir/src/destructuring/var_decl/native_new.rs
+++ b/crates/perry-hir/src/destructuring/var_decl/native_new.rs
@@ -4,15 +4,9 @@
 
 use super::*;
 
-use anyhow::{anyhow, Result};
-use perry_types::{LocalId, Type};
 use swc_ecma_ast as ast;
 
-use crate::ir::*;
-use crate::lower::{lower_expr, LoweringContext};
-use crate::lower_patterns::*;
-
-use crate::destructuring::var_decl_sources::*;
+use crate::lower::LoweringContext;
 
 /// Registers `name` as a native instance based on `new ClassName(...)`,
 /// `new mod.Class(...)`, `await new Class(...)`, native-module factory calls,

--- a/crates/perry-hir/src/destructuring/var_decl/type_infer.rs
+++ b/crates/perry-hir/src/destructuring/var_decl/type_infer.rs
@@ -2,18 +2,11 @@
 //! `let/const/var` identifier binding (extracted from `var_decl.rs`'s
 //! `Pat::Ident` arm).
 
-use super::*;
-
-use anyhow::{anyhow, Result};
-use perry_types::{LocalId, Type};
+use perry_types::Type;
 use swc_ecma_ast as ast;
 
-use crate::ir::*;
-use crate::lower::{lower_expr, LoweringContext};
-use crate::lower_patterns::*;
+use crate::lower::LoweringContext;
 use crate::lower_types::{extract_ts_type, infer_type_from_expr};
-
-use crate::destructuring::var_decl_sources::*;
 
 /// Computes the declared/inferred `Type` for the binding and records the
 /// `plain_object_locals` tag where applicable. Mirrors the original inline

--- a/crates/perry-hir/src/lower/closure_analysis.rs
+++ b/crates/perry-hir/src/lower/closure_analysis.rs
@@ -4,14 +4,8 @@
 //! visibility and are re-exported from `lower/mod.rs` so the existing
 //! `expr_*` submodules and the rest of the crate keep compiling unchanged.
 
-#![allow(unused_imports)]
+use perry_types::LocalId;
 
-use anyhow::{anyhow, Result};
-use perry_types::{FuncId, FunctionType, GlobalId, LocalId, Type, TypeParam};
-use std::collections::{HashMap, HashSet};
-use swc_ecma_ast as ast;
-
-use super::*;
 use crate::ir::*;
 
 /// Post-lowering pass that widens every `Expr::Closure`'s `mutable_captures`

--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -4,12 +4,8 @@
 //! visibility and are re-exported from `lower/mod.rs` so the existing
 //! `expr_*` submodules and the rest of the crate keep compiling unchanged.
 
-#![allow(unused_imports)]
-
-use anyhow::{anyhow, Result};
-use perry_types::{FuncId, FunctionType, GlobalId, LocalId, Type, TypeParam};
+use perry_types::{FuncId, LocalId, Type, TypeParam};
 use std::collections::{HashMap, HashSet};
-use swc_ecma_ast as ast;
 
 use super::*;
 use crate::ir::*;

--- a/crates/perry-hir/src/lower/decorators.rs
+++ b/crates/perry-hir/src/lower/decorators.rs
@@ -4,12 +4,7 @@
 //! visibility and are re-exported from `lower/mod.rs` so the existing
 //! `expr_*` submodules and the rest of the crate keep compiling unchanged.
 
-#![allow(unused_imports)]
-
-use anyhow::{anyhow, Result};
-use perry_types::{FuncId, FunctionType, GlobalId, LocalId, Type, TypeParam};
-use std::collections::{HashMap, HashSet};
-use swc_ecma_ast as ast;
+use perry_types::{FunctionType, Type};
 
 use super::*;
 use crate::ir::*;

--- a/crates/perry-hir/src/lower/expr_call/intrinsics.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics.rs
@@ -16,14 +16,7 @@
 //! one `pub(crate)` helper (`as_builtin_proto_method_ref`) reached from
 //! `pre_scan`.
 
-use anyhow::Result;
-use perry_types::Type;
-use swc_ecma_ast as ast;
-
 use crate::ir::*;
-use crate::lower_types::extract_ts_type_with_ctx;
-
-use super::super::{is_known_namespace_static_function, lower_expr, LoweringContext};
 
 mod apply_call;
 mod bare_builtins;

--- a/crates/perry-hir/src/lower/expr_call/intrinsics/apply_call.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics/apply_call.rs
@@ -4,10 +4,7 @@ use anyhow::Result;
 use perry_types::Type;
 use swc_ecma_ast as ast;
 
-use crate::ir::*;
-use crate::lower_types::extract_ts_type_with_ctx;
-
-use super::super::super::{is_known_namespace_static_function, lower_expr, LoweringContext};
+use super::super::super::{lower_expr, LoweringContext};
 
 /// Issue #957 — `(function(...) { ... }.call(<thisArg>, ...args))` IIFE
 /// pattern used at the top of older CJS packages (lodash, underscore, and

--- a/crates/perry-hir/src/lower/expr_call/intrinsics/bare_builtins.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics/bare_builtins.rs
@@ -1,13 +1,9 @@
 use super::*;
 
 use anyhow::Result;
-use perry_types::Type;
 use swc_ecma_ast as ast;
 
-use crate::ir::*;
-use crate::lower_types::extract_ts_type_with_ctx;
-
-use super::super::super::{is_known_namespace_static_function, lower_expr, LoweringContext};
+use super::super::super::{lower_expr, LoweringContext};
 
 /// Followup to #957 / PR #959 — `Function('return this')()`.
 ///

--- a/crates/perry-hir/src/lower/expr_call/intrinsics/eval_strict.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics/eval_strict.rs
@@ -4,10 +4,7 @@ use anyhow::Result;
 use perry_types::Type;
 use swc_ecma_ast as ast;
 
-use crate::ir::*;
-use crate::lower_types::extract_ts_type_with_ctx;
-
-use super::super::super::{is_known_namespace_static_function, lower_expr, LoweringContext};
+use super::super::super::LoweringContext;
 
 /// #1678 (Phase 0 of #1677) — classify a bare `Function(...)` /
 /// `eval(...)` call. The `Function('return this')()` globalThis fold runs

--- a/crates/perry-hir/src/lower/expr_call/intrinsics/namespace_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics/namespace_static.rs
@@ -1,13 +1,9 @@
 use super::*;
 
 use anyhow::Result;
-use perry_types::Type;
 use swc_ecma_ast as ast;
 
-use crate::ir::*;
-use crate::lower_types::extract_ts_type_with_ctx;
-
-use super::super::super::{is_known_namespace_static_function, lower_expr, LoweringContext};
+use super::super::super::{is_known_namespace_static_function, LoweringContext};
 
 /// #2143 — namespace-static `.bind`/`.call`/`.apply` immediate-call rewrites.
 ///

--- a/crates/perry-hir/src/lower/expr_call/intrinsics/native_arena.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics/native_arena.rs
@@ -4,10 +4,9 @@ use anyhow::Result;
 use perry_types::Type;
 use swc_ecma_ast as ast;
 
-use crate::ir::*;
 use crate::lower_types::extract_ts_type_with_ctx;
 
-use super::super::super::{is_known_namespace_static_function, lower_expr, LoweringContext};
+use super::super::super::{lower_expr, LoweringContext};
 
 fn pod_layout_intrinsic_is_shadowed(ctx: &LoweringContext, name: &str) -> bool {
     ctx.lookup_local(name).is_some()

--- a/crates/perry-hir/src/lower/expr_call/intrinsics/precompile_wasm.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics/precompile_wasm.rs
@@ -1,13 +1,9 @@
 use super::*;
 
 use anyhow::Result;
-use perry_types::Type;
 use swc_ecma_ast as ast;
 
-use crate::ir::*;
-use crate::lower_types::extract_ts_type_with_ctx;
-
-use super::super::super::{is_known_namespace_static_function, lower_expr, LoweringContext};
+use super::super::super::{lower_expr, LoweringContext};
 
 /// #1681 (Phase 3 of #1677) — `precompile(EXPR)` build-time intrinsic.
 ///

--- a/crates/perry-hir/src/lower/expr_call/intrinsics/require.rs
+++ b/crates/perry-hir/src/lower/expr_call/intrinsics/require.rs
@@ -1,13 +1,9 @@
 use super::*;
 
 use anyhow::Result;
-use perry_types::Type;
 use swc_ecma_ast as ast;
 
-use crate::ir::*;
-use crate::lower_types::extract_ts_type_with_ctx;
-
-use super::super::super::{is_known_namespace_static_function, lower_expr, LoweringContext};
+use super::super::super::{lower_expr, LoweringContext};
 
 /// Issue #668 / #5216: a string-literal `require("<module>")` from user source.
 ///

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -11,7 +11,6 @@
 
 use anyhow::Result;
 use perry_types::Type;
-use swc_common::Spanned;
 use swc_ecma_ast as ast;
 
 use crate::ir::Expr;

--- a/crates/perry-hir/src/lower/expr_member/native_dispatch.rs
+++ b/crates/perry-hir/src/lower/expr_member/native_dispatch.rs
@@ -2,17 +2,6 @@
 //!
 //! Split out of `expr_member.rs` (pure code move).
 
-use anyhow::Result;
-use perry_types::Type;
-use swc_common::Spanned;
-use swc_ecma_ast as ast;
-
-use crate::ir::Expr;
-
-use super::{lower_expr, LoweringContext};
-
-use super::*;
-
 /// Issue #562 — does `prop` name a stream-API method or property on the
 /// given stream module? Used to gate the native-instance property
 /// rerouting so subclass-declared fields fall through to regular object

--- a/crates/perry-hir/src/lower/expr_member/private_guard.rs
+++ b/crates/perry-hir/src/lower/expr_member/private_guard.rs
@@ -2,16 +2,9 @@
 //!
 //! Split out of `expr_member.rs` (pure code move).
 
-use anyhow::Result;
-use perry_types::Type;
-use swc_common::Spanned;
-use swc_ecma_ast as ast;
-
 use crate::ir::Expr;
 
-use super::{lower_expr, LoweringContext};
-
-use super::*;
+use super::LoweringContext;
 
 /// Wire codes for `Expr::PrivateGuard.op` — the operation a private member
 /// access performs. Keep in sync with the `js_private_guard` runtime helper:

--- a/crates/perry-hir/src/lower/expr_member/process_literals.rs
+++ b/crates/perry-hir/src/lower/expr_member/process_literals.rs
@@ -2,16 +2,7 @@
 //!
 //! Split out of `expr_member.rs` (pure code move).
 
-use anyhow::Result;
-use perry_types::Type;
-use swc_common::Spanned;
-use swc_ecma_ast as ast;
-
 use crate::ir::Expr;
-
-use super::{lower_expr, LoweringContext};
-
-use super::*;
 
 /// #1378: `process.features` literal. Boolean capability flags Node
 /// exposes so libraries can detect what the runtime links in. Perry

--- a/crates/perry-hir/src/lower/expr_member/process_props.rs
+++ b/crates/perry-hir/src/lower/expr_member/process_props.rs
@@ -2,16 +2,11 @@
 //!
 //! Split out of `expr_member.rs` (pure code move).
 
-use anyhow::Result;
-use perry_types::Type;
-use swc_common::Spanned;
 use swc_ecma_ast as ast;
 
 use crate::ir::Expr;
 
-use super::{lower_expr, LoweringContext};
-
-use super::*;
+use super::LoweringContext;
 
 /// #3946: lower a value-read of a `node:process` core property imported by
 /// name (`import { pid, arch } from "node:process"`) or read off a namespace

--- a/crates/perry-hir/src/lower/expr_member/stdlib_guard.rs
+++ b/crates/perry-hir/src/lower/expr_member/stdlib_guard.rs
@@ -2,16 +2,7 @@
 //!
 //! Split out of `expr_member.rs` (pure code move).
 
-use anyhow::Result;
-use perry_types::Type;
-use swc_common::Spanned;
 use swc_ecma_ast as ast;
-
-use crate::ir::Expr;
-
-use super::{lower_expr, LoweringContext};
-
-use super::*;
 
 /// #503 — Node-core stdlib namespace receivers whose dynamic (`obj[x]`)
 /// member access is refused at compile time. These are the namespaces

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -9,17 +9,14 @@
 //! `Expr::TypedArrayNew`, etc.), (c) the dynamic
 //! `new (someFn)(args)` form via `Expr::NewDynamic`.
 
-use anyhow::{anyhow, Result};
-use perry_types::{LocalId, Type};
+use anyhow::Result;
+use perry_types::LocalId;
 use swc_ecma_ast as ast;
 
 use crate::ir::Expr;
-use crate::lower_decl::lower_class_from_ast;
 use crate::lower_types::extract_ts_type_with_ctx;
 
-use super::expr_new_builtins::{
-    global_member_constructor_name, is_reified_global_builtin_constructor, module_constructor_name,
-};
+use super::expr_new_builtins::{is_reified_global_builtin_constructor, module_constructor_name};
 use super::{lower_expr, LoweringContext};
 
 mod helpers;
@@ -27,12 +24,11 @@ mod member;
 mod non_ident;
 
 pub(crate) use helpers::{
-    callee_is_generic_construct_shape, collect_const_string_parts, is_depd_wrapfunction_shape,
-    is_fetch_constructor_name, is_global_object_expr, is_url_encoding_constructor_name,
-    is_worker_messaging_constructor_name, is_worker_threads_module_name, lower_new_spread_args,
-    lower_optional_args, lower_text_decoder_new, lower_url_encoding_constructor,
-    lower_worker_messaging_new, lower_worker_new, nonconstructable_builtin_throw_expr,
-    peel_new_callee,
+    callee_is_generic_construct_shape, is_depd_wrapfunction_shape, is_fetch_constructor_name,
+    is_global_object_expr, is_url_encoding_constructor_name, is_worker_messaging_constructor_name,
+    is_worker_threads_module_name, lower_new_spread_args, lower_optional_args,
+    lower_text_decoder_new, lower_url_encoding_constructor, lower_worker_messaging_new,
+    lower_worker_new, nonconstructable_builtin_throw_expr, peel_new_callee,
 };
 pub(crate) use member::lower_new_member_native;
 pub(crate) use non_ident::{lower_new_non_ident, register_stream_controller_params};

--- a/crates/perry-hir/src/lower/expr_new/helpers.rs
+++ b/crates/perry-hir/src/lower/expr_new/helpers.rs
@@ -2,17 +2,12 @@
 //! `expr_new.rs` so the trunk stays under the file-size budget. Pure code move
 //! — no behavior change.
 
-use super::*;
-
 use anyhow::{anyhow, Result};
-use perry_types::{LocalId, Type};
+use perry_types::Type;
 use swc_ecma_ast as ast;
 
 use crate::ir::Expr;
-use crate::lower_decl::lower_class_from_ast;
-use crate::lower_types::extract_ts_type_with_ctx;
 
-use super::super::expr_new_builtins::{global_member_constructor_name, module_constructor_name};
 use super::super::{lower_expr, LoweringContext};
 
 /// Collect the compile-time-constant string fragments of a `+`-concatenation

--- a/crates/perry-hir/src/lower/expr_new/member.rs
+++ b/crates/perry-hir/src/lower/expr_new/member.rs
@@ -10,10 +10,8 @@ use perry_types::Type;
 use swc_ecma_ast as ast;
 
 use crate::ir::Expr;
-use crate::lower_decl::lower_class_from_ast;
-use crate::lower_types::extract_ts_type_with_ctx;
 
-use super::super::expr_new_builtins::{global_member_constructor_name, module_constructor_name};
+use super::super::expr_new_builtins::global_member_constructor_name;
 use super::super::{lower_expr, LoweringContext};
 
 /// Issue #422: `new net.Socket()` over a `net` module alias and the many other

--- a/crates/perry-hir/src/lower/expr_new/non_ident.rs
+++ b/crates/perry-hir/src/lower/expr_new/non_ident.rs
@@ -12,7 +12,6 @@ use crate::ir::Expr;
 use crate::lower_decl::lower_class_from_ast;
 use crate::lower_types::extract_ts_type_with_ctx;
 
-use super::super::expr_new_builtins::{global_member_constructor_name, module_constructor_name};
 use super::super::{lower_expr, LoweringContext};
 
 /// Issue #237: pre-register the controller param of every

--- a/crates/perry-hir/src/lower/expr_object.rs
+++ b/crates/perry-hir/src/lower/expr_object.rs
@@ -22,8 +22,7 @@ use crate::analysis::{
 };
 use crate::ir::{EnumValue, Expr, Function, Param, Stmt};
 use crate::lower_decl::{
-    append_synthetic_arguments_param, body_uses_arguments, lower_block_stmt,
-    lower_fn_body_block_stmt,
+    append_synthetic_arguments_param, body_uses_arguments, lower_fn_body_block_stmt,
 };
 use crate::lower_patterns::{
     generate_param_destructuring_stmts, get_param_default, get_pat_name, is_destructuring_pattern,

--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -15,13 +15,11 @@
 //! re-exports can propagate them.
 
 use anyhow::{anyhow, Result};
-use perry_types::{LocalId, Type};
 use swc_common::Spanned;
 use swc_ecma_ast as ast;
 
 use super::*;
 use crate::ir::*;
-use crate::lower_types::extract_ts_type_with_ctx;
 
 // Sibling modules holding the extracted helpers and large match arms.
 mod arm_bin;
@@ -41,11 +39,10 @@ pub(crate) use arm_unary::lower_unary_expr;
 pub(crate) use assignment::lower_expr_assignment;
 pub(crate) use helpers::{
     anonymous_class_has_static_name_member, expr_uses_stack_heavy_chain_lowering,
-    global_script_this_enabled, is_cjs_style_native_default_import, is_fetch_global_value_name,
-    is_known_global_identifier_name, lower_expr_with_json_parse_type_hint,
-    native_module_binding_value, opt_call_func_nullish_guard, opt_call_receiver_repeatable,
-    relower_trace, strict_global_assign_existing_or_throw, throw_reference_error_expr,
-    typed_parse_codegen_supports, with_implicit_unset_let, with_set_fallback_for_ident,
+    global_script_this_enabled, is_fetch_global_value_name, is_known_global_identifier_name,
+    lower_expr_with_json_parse_type_hint, native_module_binding_value, opt_call_func_nullish_guard,
+    opt_call_receiver_repeatable, relower_trace, strict_global_assign_existing_or_throw,
+    throw_reference_error_expr, with_implicit_unset_let, with_set_fallback_for_ident,
     wrap_with_gets,
 };
 pub(crate) use reactive_text::try_desugar_reactive_text;

--- a/crates/perry-hir/src/lower/lower_expr/arm_bin.rs
+++ b/crates/perry-hir/src/lower/lower_expr/arm_bin.rs
@@ -2,14 +2,8 @@
 //! Pure code move — no behavior change.
 
 use super::*;
-use crate::lower::*;
 use anyhow::{anyhow, Result};
-use perry_types::{LocalId, Type};
-use swc_common::Spanned;
 use swc_ecma_ast as ast;
-
-use crate::ir::*;
-use crate::lower_types::extract_ts_type_with_ctx;
 
 pub(crate) fn lower_bin_expr(ctx: &mut LoweringContext, bin: &ast::BinExpr) -> Result<Expr> {
     // Handle 'in' operator: property in object

--- a/crates/perry-hir/src/lower/lower_expr/arm_class.rs
+++ b/crates/perry-hir/src/lower/lower_expr/arm_class.rs
@@ -2,14 +2,8 @@
 //! extracted to a helper. Pure code move — no behavior change.
 
 use super::*;
-use crate::lower::*;
-use anyhow::{anyhow, Result};
-use perry_types::{LocalId, Type};
-use swc_common::Spanned;
+use anyhow::Result;
 use swc_ecma_ast as ast;
-
-use crate::ir::*;
-use crate::lower_types::extract_ts_type_with_ctx;
 
 pub(crate) fn lower_class_expr(
     ctx: &mut LoweringContext,

--- a/crates/perry-hir/src/lower/lower_expr/arm_ident.rs
+++ b/crates/perry-hir/src/lower/lower_expr/arm_ident.rs
@@ -2,14 +2,9 @@
 //! Pure code move — no behavior change.
 
 use super::*;
-use crate::lower::*;
-use anyhow::{anyhow, Result};
-use perry_types::{LocalId, Type};
-use swc_common::Spanned;
+use anyhow::Result;
+use perry_types::Type;
 use swc_ecma_ast as ast;
-
-use crate::ir::*;
-use crate::lower_types::extract_ts_type_with_ctx;
 
 pub(crate) fn lower_ident_expr(ctx: &mut LoweringContext, ident: &ast::Ident) -> Result<Expr> {
     let expr_ident = ast::Expr::Ident(ident.clone());

--- a/crates/perry-hir/src/lower/lower_expr/arm_optchain.rs
+++ b/crates/perry-hir/src/lower/lower_expr/arm_optchain.rs
@@ -2,14 +2,8 @@
 //! Pure code move — no behavior change.
 
 use super::*;
-use crate::lower::*;
-use anyhow::{anyhow, Result};
-use perry_types::{LocalId, Type};
-use swc_common::Spanned;
+use anyhow::Result;
 use swc_ecma_ast as ast;
-
-use crate::ir::*;
-use crate::lower_types::extract_ts_type_with_ctx;
 
 pub(crate) fn lower_opt_chain_expr(
     ctx: &mut LoweringContext,

--- a/crates/perry-hir/src/lower/lower_expr/arm_unary.rs
+++ b/crates/perry-hir/src/lower/lower_expr/arm_unary.rs
@@ -2,14 +2,9 @@
 //! Pure code move — no behavior change.
 
 use super::*;
-use crate::lower::*;
 use anyhow::{anyhow, Result};
-use perry_types::{LocalId, Type};
-use swc_common::Spanned;
+use perry_types::Type;
 use swc_ecma_ast as ast;
-
-use crate::ir::*;
-use crate::lower_types::extract_ts_type_with_ctx;
 
 pub(crate) fn lower_unary_expr(ctx: &mut LoweringContext, unary: &ast::UnaryExpr) -> Result<Expr> {
     // AST-level typeof fold for `typeof Object.<known>` /

--- a/crates/perry-hir/src/lower/lower_expr/assignment.rs
+++ b/crates/perry-hir/src/lower/lower_expr/assignment.rs
@@ -2,14 +2,8 @@
 //! Extracted from the trunk `lower_expr.rs`. Pure code move.
 
 use super::*;
-use crate::lower::*;
 use anyhow::{anyhow, Result};
-use perry_types::LocalId;
-use swc_common::Spanned;
 use swc_ecma_ast as ast;
-
-use crate::ir::*;
-use crate::lower_types::extract_ts_type_with_ctx;
 
 pub(crate) fn lower_expr_assignment(
     ctx: &mut LoweringContext,

--- a/crates/perry-hir/src/lower/lower_expr/helpers.rs
+++ b/crates/perry-hir/src/lower/lower_expr/helpers.rs
@@ -6,13 +6,10 @@ use super::*;
 // Pull in the parent `lower` module's full (re-exported) surface so moved
 // helpers resolve names like `LoweringContext`, `expr_member`,
 // `is_builtin_function`, etc. exactly as they did in the trunk.
-use crate::lower::*;
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use perry_types::{LocalId, Type};
-use swc_common::Spanned;
 use swc_ecma_ast as ast;
 
-use crate::ir::*;
 use crate::lower_types::extract_ts_type_with_ctx;
 
 /// Whether `PERRY_GLOBAL_SCRIPT_THIS` is set — compile the program as a

--- a/crates/perry-hir/src/lower/lower_expr/reactive_text.rs
+++ b/crates/perry-hir/src/lower/lower_expr/reactive_text.rs
@@ -2,14 +2,9 @@
 //! desugar helper. Extracted from the trunk `lower_expr.rs`. Pure code move.
 
 use super::*;
-use crate::lower::*;
 use anyhow::{anyhow, Result};
 use perry_types::{LocalId, Type};
-use swc_common::Spanned;
 use swc_ecma_ast as ast;
-
-use crate::ir::*;
-use crate::lower_types::extract_ts_type_with_ctx;
 
 /// If `call` matches `Text(\`...${state.value}...\`)` with at least one State
 /// interpolation, desugar into an auto-reactive binding. Returns `Ok(None)`

--- a/crates/perry-hir/src/lower/misc.rs
+++ b/crates/perry-hir/src/lower/misc.rs
@@ -4,11 +4,7 @@
 //! visibility and are re-exported from `lower/mod.rs` so the existing
 //! `expr_*` submodules and the rest of the crate keep compiling unchanged.
 
-#![allow(unused_imports)]
-
-use anyhow::{anyhow, Result};
-use perry_types::{FuncId, FunctionType, GlobalId, LocalId, Type, TypeParam};
-use std::collections::{HashMap, HashSet};
+use perry_types::Type;
 use swc_ecma_ast as ast;
 
 use super::*;

--- a/crates/perry-hir/src/lower/module_decl.rs
+++ b/crates/perry-hir/src/lower/module_decl.rs
@@ -4,11 +4,8 @@
 //! visibility and are re-exported from `lower/mod.rs` so the existing
 //! `expr_*` submodules and the rest of the crate keep compiling unchanged.
 
-#![allow(unused_imports)]
-
-use anyhow::{anyhow, Result};
-use perry_types::{FuncId, FunctionType, GlobalId, LocalId, Type, TypeParam};
-use std::collections::{HashMap, HashSet};
+use anyhow::Result;
+use perry_types::{LocalId, Type};
 use swc_ecma_ast as ast;
 
 use super::*;

--- a/crates/perry-hir/src/lower/module_decl/namespace.rs
+++ b/crates/perry-hir/src/lower/module_decl/namespace.rs
@@ -1,15 +1,11 @@
 //! TypeScript namespace → synthetic-class lowering — extracted from
 //! `lower/module_decl.rs` (pure mechanical split, no logic changes).
 
-#![allow(unused_imports)]
-
-use anyhow::{anyhow, Result};
-use perry_types::{FuncId, FunctionType, GlobalId, LocalId, Type, TypeParam};
-use std::collections::{HashMap, HashSet};
+use anyhow::Result;
+use perry_types::Type;
 use swc_ecma_ast as ast;
 
 use super::*;
-use crate::ir::*;
 
 /// Lower a TypeScript namespace declaration into a synthetic class with static methods.
 /// `export namespace Slug { export function create() { ... } }` becomes a class `Slug`

--- a/crates/perry-hir/src/lower/module_decl/native_default_import.rs
+++ b/crates/perry-hir/src/lower/module_decl/native_default_import.rs
@@ -1,16 +1,6 @@
 //! Native/CJS-style default-import classification helpers — extracted from
 //! `lower/module_decl.rs` (pure mechanical split, no logic changes).
 
-#![allow(unused_imports)]
-
-use anyhow::{anyhow, Result};
-use perry_types::{FuncId, FunctionType, GlobalId, LocalId, Type, TypeParam};
-use std::collections::{HashMap, HashSet};
-use swc_ecma_ast as ast;
-
-use super::*;
-use crate::ir::*;
-
 pub(crate) fn is_cjs_style_native_default_import(module_name: &str) -> bool {
     matches!(
         module_name,

--- a/crates/perry-hir/src/lower/pre_scan.rs
+++ b/crates/perry-hir/src/lower/pre_scan.rs
@@ -4,10 +4,6 @@
 //! visibility and are re-exported from `lower/mod.rs` so the existing
 //! `expr_*` submodules and the rest of the crate keep compiling unchanged.
 
-#![allow(unused_imports)]
-
-use anyhow::{anyhow, Result};
-use perry_types::{FuncId, FunctionType, GlobalId, LocalId, Type, TypeParam};
 use std::collections::{HashMap, HashSet};
 use swc_ecma_ast as ast;
 

--- a/crates/perry-hir/src/lower/shared_mutable_capture.rs
+++ b/crates/perry-hir/src/lower/shared_mutable_capture.rs
@@ -363,7 +363,7 @@ fn retype_capture_holders(module: &mut Module, shared: &HashSet<LocalId>) {
                 f.ty = Type::Any;
             }
         }
-        let mut retype_fn = |f: &mut Function| {
+        let retype_fn = |f: &mut Function| {
             for p in &mut f.params {
                 if is_cap_name_of(&p.name, targets) {
                     p.ty = Type::Any;
@@ -407,7 +407,7 @@ fn retype_lets_in_stmt(stmt: &mut Stmt, targets: &HashSet<LocalId>) {
             retype_lets_in_expr(e, targets);
         }
     }
-    let mut recur = |body: &mut Vec<Stmt>| retype_lets_in_stmts(body, targets);
+    let recur = |body: &mut Vec<Stmt>| retype_lets_in_stmts(body, targets);
     match stmt {
         Stmt::If {
             then_branch,
@@ -509,7 +509,7 @@ fn class_mutates_capture(c: &Class, id: LocalId) -> bool {
 /// closure) plus every `Let` name in member bodies and field initializers.
 fn collect_class_names(c: &Class) -> HashMap<LocalId, String> {
     let mut id_name: HashMap<LocalId, String> = HashMap::new();
-    let mut add_fn = |f: &Function, m: &mut HashMap<LocalId, String>| {
+    let add_fn = |f: &Function, m: &mut HashMap<LocalId, String>| {
         for p in &f.params {
             m.insert(p.id, p.name.clone());
         }

--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -4,11 +4,8 @@
 //! visibility and are re-exported from `lower/mod.rs` so the existing
 //! `expr_*` submodules and the rest of the crate keep compiling unchanged.
 
-#![allow(unused_imports)]
-
 use anyhow::{anyhow, Result};
-use perry_types::{FuncId, FunctionType, GlobalId, LocalId, Type, TypeParam};
-use std::collections::{HashMap, HashSet};
+use perry_types::{LocalId, Type};
 use swc_ecma_ast as ast;
 
 use super::*;

--- a/crates/perry-hir/src/lower/template.rs
+++ b/crates/perry-hir/src/lower/template.rs
@@ -4,11 +4,7 @@
 //! visibility and are re-exported from `lower/mod.rs` so the existing
 //! `expr_*` submodules and the rest of the crate keep compiling unchanged.
 
-#![allow(unused_imports)]
-
-use anyhow::{anyhow, Result};
-use perry_types::{FuncId, FunctionType, GlobalId, LocalId, Type, TypeParam};
-use std::collections::{HashMap, HashSet};
+use anyhow::Result;
 use swc_ecma_ast as ast;
 
 use super::*;

--- a/crates/perry-hir/src/lower/widget_decl.rs
+++ b/crates/perry-hir/src/lower/widget_decl.rs
@@ -4,11 +4,6 @@
 //! visibility and are re-exported from `lower/mod.rs` so the existing
 //! `expr_*` submodules and the rest of the crate keep compiling unchanged.
 
-#![allow(unused_imports)]
-
-use anyhow::{anyhow, Result};
-use perry_types::{FuncId, FunctionType, GlobalId, LocalId, Type, TypeParam};
-use std::collections::{HashMap, HashSet};
 use swc_ecma_ast as ast;
 
 use super::*;

--- a/crates/perry-hir/src/lower/widget_decl/reactive_animate.rs
+++ b/crates/perry-hir/src/lower/widget_decl/reactive_animate.rs
@@ -4,11 +4,8 @@
 //! visibility (re-exported from `widget_decl.rs`) so the
 //! `pub(crate) use widget_decl::*` in `lower/mod.rs` still resolves it.
 
-#![allow(unused_imports)]
-
 use anyhow::{anyhow, Result};
-use perry_types::{FuncId, FunctionType, GlobalId, LocalId, Type, TypeParam};
-use std::collections::{HashMap, HashSet};
+use perry_types::{LocalId, Type};
 use swc_ecma_ast as ast;
 
 use super::super::*;

--- a/crates/perry-hir/src/lower_decl/block.rs
+++ b/crates/perry-hir/src/lower_decl/block.rs
@@ -1,14 +1,11 @@
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use perry_types::{LocalId, Type};
 use swc_ecma_ast as ast;
 
 use crate::analysis::*;
 use crate::destructuring::*;
 use crate::ir::*;
-use crate::lower::{
-    collect_for_of_pattern_leaves, emit_for_of_pattern_binding, lower_expr, LoweringContext,
-};
-use crate::lower_patterns::*;
+use crate::lower::LoweringContext;
 
 use super::*;
 

--- a/crates/perry-hir/src/lower_decl/mod.rs
+++ b/crates/perry-hir/src/lower_decl/mod.rs
@@ -30,7 +30,6 @@ mod typeof_narrow;
 // this list in sync with each sibling's `pub fn` declarations.
 pub(crate) use block::{
     collect_annexb_block_fn_decl_names, collect_lexical_decl_names,
-    collect_refs_in_closure_bodies_stmt, collect_top_level_let_ids_stmt,
     collect_var_binding_names_from_pat, collect_var_binding_names_from_stmt,
     compute_prealloc_for_hoisted_closures, lower_block_stmt, lower_block_stmt_scoped,
     lower_fn_body_block_stmt, lower_stmts_using_aware, pre_register_forward_captured_lets,

--- a/crates/perry-hir/src/lower_types.rs
+++ b/crates/perry-hir/src/lower_types.rs
@@ -3,10 +3,9 @@
 //! Contains functions for inferring types from expressions, extracting
 //! TypeScript type annotations, and parsing function parameter types.
 
-use perry_types::{Type, TypeParam};
+use perry_types::Type;
 use swc_ecma_ast as ast;
 
-use crate::ir::*;
 use crate::lower::LoweringContext;
 use crate::lower_patterns::get_pat_name;
 
@@ -1441,7 +1440,7 @@ pub(crate) fn infer_call_return_type(callee: &ast::Expr, ctx: &LoweringContext) 
 mod extract;
 
 pub(crate) use extract::{
-    extract_binding_type, extract_member_class_name, extract_param_type_with_ctx,
-    extract_pattern_type, extract_pattern_type_with_ctx, extract_ts_type, extract_ts_type_with_ctx,
-    extract_type_params, get_fn_param_name_and_type_with_ctx, get_ts_entity_name, lower_decorators,
+    extract_binding_type, extract_member_class_name, extract_param_type_with_ctx, extract_ts_type,
+    extract_ts_type_with_ctx, extract_type_params, get_fn_param_name_and_type_with_ctx,
+    lower_decorators,
 };

--- a/crates/perry-hir/src/lower_types/extract.rs
+++ b/crates/perry-hir/src/lower_types/extract.rs
@@ -9,7 +9,7 @@ use swc_ecma_ast as ast;
 
 use crate::ir::*;
 use crate::lower::{lower_expr, LoweringContext};
-use crate::lower_patterns::{get_pat_name, lower_lit};
+use crate::lower_patterns::lower_lit;
 
 /// Extract type parameters from SWC's TsTypeParamDecl
 pub(crate) fn extract_type_params(decl: &ast::TsTypeParamDecl) -> Vec<TypeParam> {

--- a/crates/perry-runtime/src/array/from_concat.rs
+++ b/crates/perry-runtime/src/array/from_concat.rs
@@ -903,7 +903,7 @@ unsafe fn try_concat_all_dense(
     // is what makes the single deferred rebuild sound.
     let dst = (result as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut f64;
     let mut off: usize = 0;
-    let mut copy_array = |src: *const ArrayHeader, len: u32, off: &mut usize| {
+    let copy_array = |src: *const ArrayHeader, len: u32, off: &mut usize| {
         if len == 0 {
             return;
         }

--- a/crates/perry-runtime/src/buffer/header.rs
+++ b/crates/perry-runtime/src/buffer/header.rs
@@ -1,5 +1,3 @@
-use super::*;
-
 /// Type ID constant for Buffer/Uint8Array - matches class_id 0xFFFF0004
 pub const BUFFER_TYPE_ID: u32 = 0xFFFF0004;
 

--- a/crates/perry-runtime/src/buffer/mod.rs
+++ b/crates/perry-runtime/src/buffer/mod.rs
@@ -1,6 +1,5 @@
 //! Buffer module - provides binary data handling similar to Node.js Buffer
 
-use std::alloc::Layout;
 use std::ptr;
 
 use crate::array::ArrayHeader;

--- a/crates/perry-runtime/src/buffer/view.rs
+++ b/crates/perry-runtime/src/buffer/view.rs
@@ -37,7 +37,6 @@
 use super::*;
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 
 /// Each live slice/subarray records its ultimate backing buffer plus
 /// the [offset, offset + length) range within that backing.  The

--- a/crates/perry-runtime/src/child_process/builder.rs
+++ b/crates/perry-runtime/src/child_process/builder.rs
@@ -1,28 +1,9 @@
 use super::*;
 
-use std::collections::HashMap;
-use std::fs::File;
-use std::process::{Command, Stdio};
-use std::sync::{
-    atomic::{AtomicU64, Ordering},
-    Mutex,
-};
-
-use sync_run::{
-    cp_read_async_run_options, cp_read_spawn_sync_run_options, cp_read_sync_stdio_run_options,
-    cp_run_to_completion, CpRun, CpRunError, CpRunOptions,
-};
-
 use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_ptr, js_closure_set_capture_ptr, js_native_call_value,
-    js_register_closure_arity, ClosureHeader,
+    js_closure_alloc, js_closure_set_capture_ptr, js_register_closure_arity, ClosureHeader,
 };
-use crate::object::{
-    js_implicit_this_get, js_implicit_this_set, js_object_alloc_with_shape,
-    js_object_get_field_by_name_f64, js_object_set_field, js_object_set_field_by_name,
-    ObjectHeader,
-};
-use crate::string::{js_string_from_bytes, StringHeader};
+use crate::object::{js_object_alloc_with_shape, js_object_set_field, ObjectHeader};
 use crate::value::JSValue;
 
 // Shape-id band kept clear of node_stream (0x7FFF_FE60+), fs streams

--- a/crates/perry-runtime/src/child_process/emitter.rs
+++ b/crates/perry-runtime/src/child_process/emitter.rs
@@ -1,28 +1,11 @@
 use super::*;
 
-use std::collections::HashMap;
-use std::fs::File;
-use std::process::{Command, Stdio};
-use std::sync::{
-    atomic::{AtomicU64, Ordering},
-    Mutex,
-};
-
-use sync_run::{
-    cp_read_async_run_options, cp_read_spawn_sync_run_options, cp_read_sync_stdio_run_options,
-    cp_run_to_completion, CpRun, CpRunError, CpRunOptions,
-};
-
 use crate::closure::{
     js_closure_alloc, js_closure_get_capture_ptr, js_closure_set_capture_ptr, js_native_call_value,
     js_register_closure_arity, ClosureHeader,
 };
-use crate::object::{
-    js_implicit_this_get, js_implicit_this_set, js_object_alloc_with_shape,
-    js_object_get_field_by_name_f64, js_object_set_field, js_object_set_field_by_name,
-    ObjectHeader,
-};
-use crate::string::{js_string_from_bytes, StringHeader};
+use crate::object::js_implicit_this_set;
+use crate::string::js_string_from_bytes;
 use crate::value::JSValue;
 
 /// Hidden field key holding the listener array for `event`.

--- a/crates/perry-runtime/src/child_process/exec.rs
+++ b/crates/perry-runtime/src/child_process/exec.rs
@@ -1,27 +1,17 @@
 use super::*;
 
-use std::collections::HashMap;
-use std::fs::File;
-use std::process::{Command, Stdio};
-use std::sync::{
-    atomic::{AtomicU64, Ordering},
-    Mutex,
-};
+use std::process::Command;
 
 use sync_run::{
     cp_read_async_run_options, cp_read_spawn_sync_run_options, cp_read_sync_stdio_run_options,
-    cp_run_to_completion, CpRun, CpRunError, CpRunOptions,
+    cp_run_to_completion,
 };
 
 use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_ptr, js_closure_set_capture_ptr, js_native_call_value,
+    js_closure_alloc, js_closure_get_capture_ptr, js_closure_set_capture_ptr,
     js_register_closure_arity, ClosureHeader,
 };
-use crate::object::{
-    js_implicit_this_get, js_implicit_this_set, js_object_alloc_with_shape,
-    js_object_get_field_by_name_f64, js_object_set_field, js_object_set_field_by_name,
-    ObjectHeader,
-};
+use crate::object::{js_object_set_field_by_name, ObjectHeader};
 use crate::string::{js_string_from_bytes, StringHeader};
 use crate::value::JSValue;
 

--- a/crates/perry-runtime/src/child_process/mod.rs
+++ b/crates/perry-runtime/src/child_process/mod.rs
@@ -27,28 +27,17 @@ pub(crate) use v8_serde::{
     v8_serialize,
 };
 
-use std::collections::HashMap;
-use std::fs::File;
 use std::process::{Command, Stdio};
-use std::sync::{
-    atomic::{AtomicU64, Ordering},
-    Mutex,
-};
 
-use sync_run::{
-    cp_read_async_run_options, cp_read_spawn_sync_run_options, cp_read_sync_stdio_run_options,
-    cp_run_to_completion, CpRun, CpRunError, CpRunOptions,
-};
+#[cfg(test)]
+use crate::object::js_object_get_field_by_name_f64;
+
+use sync_run::{CpRun, CpRunError, CpRunOptions};
 
 use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_ptr, js_closure_set_capture_ptr, js_native_call_value,
-    js_register_closure_arity, ClosureHeader,
+    js_closure_alloc, js_closure_get_capture_ptr, js_closure_set_capture_ptr, ClosureHeader,
 };
-use crate::object::{
-    js_implicit_this_get, js_implicit_this_set, js_object_alloc_with_shape,
-    js_object_get_field_by_name_f64, js_object_set_field, js_object_set_field_by_name,
-    ObjectHeader,
-};
+use crate::object::{js_object_set_field_by_name, ObjectHeader};
 use crate::string::{js_string_from_bytes, StringHeader};
 use crate::value::JSValue;
 
@@ -71,7 +60,7 @@ mod value_util;
 // item's own visibility.
 
 // registry.rs — background-process registry + detach FFI.
-pub(crate) use registry::{extract_string_from_nanboxed, make_two_field_object};
+pub(crate) use registry::make_two_field_object;
 pub use registry::{
     js_child_process_get_process_status, js_child_process_kill_process,
     js_child_process_spawn_background, js_child_process_spawn_detached, spawn_detached_command,
@@ -81,38 +70,34 @@ pub use registry::{
 pub(crate) use value_util::{
     cp_args_from_value, cp_array_ptr, cp_box_ptr, cp_box_string, cp_box_string_bytes,
     cp_coerce_string, cp_get_field, cp_make_buffer, cp_object_ptr, cp_read_arg_strings,
-    cp_read_string_header, cp_set_field, cp_str_key, cp_this, cp_undefined, cp_value_to_bytes,
+    cp_read_string_header, cp_set_field, cp_this, cp_undefined, cp_value_to_bytes,
     cp_value_to_string,
 };
 
 // signals.rs — signal name/number mapping + kill/timeout reads.
 pub(crate) use signals::{
-    cp_read_kill_signal, cp_read_timeout, cp_signal_from_value, cp_signal_name, cp_signal_number,
-    CP_SIGTERM,
+    cp_read_kill_signal, cp_read_timeout, cp_signal_from_value, cp_signal_name, CP_SIGTERM,
 };
 
 // emitter.rs — EventEmitter listener registry, method bodies, IPC send/disconnect.
 pub(crate) use emitter::{
-    cp_channel_closed_error, cp_defer_send_callback, cp_emit, cp_handle_of, cp_listener_key,
-    cp_method_disconnect, cp_method_dispose, cp_method_emit, cp_method_kill, cp_method_on,
+    cp_emit, cp_method_disconnect, cp_method_dispose, cp_method_emit, cp_method_kill, cp_method_on,
     cp_method_pipe, cp_method_read, cp_method_remove_all_listeners, cp_method_remove_listener,
     cp_method_send, cp_method_stdin_end, cp_method_this0, cp_method_this1, cp_method_write2,
-    cp_pipe_data_thunk, cp_pipe_end_thunk, cp_register, cp_send_callback_thunk, js_fork_child,
+    cp_send_callback_thunk, js_fork_child,
 };
 
 // builder.rs — heap object construction + shape ids.
 pub(crate) use builder::{
     cp_build_object, cp_build_readable, cp_build_writable, cp_cast0, cp_cast1, cp_cast2, cp_cast4,
-    cp_install_dispose, cp_register_arities, CpFn, CP_READABLE_SHAPE_ID, CP_SHAPE_ID,
-    CP_WRITABLE_SHAPE_ID,
+    cp_install_dispose, cp_register_arities, CpFn, CP_SHAPE_ID,
 };
 
 // options.rs — command option application (cwd/env/uid/gid/argv0/detached/stdio).
 pub(crate) use options::{
     cp_abort_signal_is_aborted, cp_apply_argv0, cp_apply_detached, cp_apply_live_stdio,
-    cp_apply_options, cp_apply_uid_gid, cp_build_command, cp_read_abort_signal, cp_read_argv0,
-    cp_read_stdio, cp_read_uid_gid_option, cp_spawnargs_argv0, cp_stdio_from_fd, cp_stdio_js_value,
-    CpStdio,
+    cp_apply_options, cp_build_command, cp_read_abort_signal, cp_read_stdio, cp_spawnargs_argv0,
+    cp_stdio_from_fd, cp_stdio_js_value, CpStdio,
 };
 
 // output.rs — output encoding, error shape, exit decoding.
@@ -120,7 +105,6 @@ pub(crate) use output::{
     cp_abort_error, cp_box_output, cp_box_run_output, cp_decode_status, cp_errno_number,
     cp_exec_callback_args, cp_exec_callback_output_bytes, cp_file_cmd_display, cp_io_error_code,
     cp_make_error, cp_output_array, cp_read_output_mode, cp_sync_throw_error, CpExit, CpOutput,
-    CP_ABORT_ERROR_CLASS_ID,
 };
 
 // exec.rs — exec / execFile / spawnSync / execSync FFI + promisify wrappers.

--- a/crates/perry-runtime/src/child_process/options.rs
+++ b/crates/perry-runtime/src/child_process/options.rs
@@ -1,28 +1,7 @@
 use super::*;
 
-use std::collections::HashMap;
-use std::fs::File;
 use std::process::{Command, Stdio};
-use std::sync::{
-    atomic::{AtomicU64, Ordering},
-    Mutex,
-};
 
-use sync_run::{
-    cp_read_async_run_options, cp_read_spawn_sync_run_options, cp_read_sync_stdio_run_options,
-    cp_run_to_completion, CpRun, CpRunError, CpRunOptions,
-};
-
-use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_ptr, js_closure_set_capture_ptr, js_native_call_value,
-    js_register_closure_arity, ClosureHeader,
-};
-use crate::object::{
-    js_implicit_this_get, js_implicit_this_set, js_object_alloc_with_shape,
-    js_object_get_field_by_name_f64, js_object_set_field, js_object_set_field_by_name,
-    ObjectHeader,
-};
-use crate::string::{js_string_from_bytes, StringHeader};
 use crate::value::JSValue;
 
 pub(crate) fn cp_read_uid_gid_option(opts_val: f64, key: &[u8]) -> Option<u32> {

--- a/crates/perry-runtime/src/child_process/output.rs
+++ b/crates/perry-runtime/src/child_process/output.rs
@@ -1,27 +1,8 @@
 use super::*;
 
-use std::collections::HashMap;
-use std::fs::File;
-use std::process::{Command, Stdio};
-use std::sync::{
-    atomic::{AtomicU64, Ordering},
-    Mutex,
-};
+use sync_run::{CpRun, CpRunError, CpRunOptions};
 
-use sync_run::{
-    cp_read_async_run_options, cp_read_spawn_sync_run_options, cp_read_sync_stdio_run_options,
-    cp_run_to_completion, CpRun, CpRunError, CpRunOptions,
-};
-
-use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_ptr, js_closure_set_capture_ptr, js_native_call_value,
-    js_register_closure_arity, ClosureHeader,
-};
-use crate::object::{
-    js_implicit_this_get, js_implicit_this_set, js_object_alloc_with_shape,
-    js_object_get_field_by_name_f64, js_object_set_field, js_object_set_field_by_name,
-    ObjectHeader,
-};
+use crate::object::js_object_set_field_by_name;
 use crate::string::{js_string_from_bytes, StringHeader};
 use crate::value::JSValue;
 

--- a/crates/perry-runtime/src/child_process/registry.rs
+++ b/crates/perry-runtime/src/child_process/registry.rs
@@ -8,22 +8,8 @@ use std::sync::{
     Mutex,
 };
 
-use sync_run::{
-    cp_read_async_run_options, cp_read_spawn_sync_run_options, cp_read_sync_stdio_run_options,
-    cp_run_to_completion, CpRun, CpRunError, CpRunOptions,
-};
-
-use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_ptr, js_closure_set_capture_ptr, js_native_call_value,
-    js_register_closure_arity, ClosureHeader,
-};
-use crate::object::{
-    js_implicit_this_get, js_implicit_this_set, js_object_alloc_with_shape,
-    js_object_get_field_by_name_f64, js_object_set_field, js_object_set_field_by_name,
-    ObjectHeader,
-};
+use crate::object::ObjectHeader;
 use crate::string::{js_string_from_bytes, StringHeader};
-use crate::value::JSValue;
 
 // ============================================================================
 // Background Process Registry

--- a/crates/perry-runtime/src/child_process/signals.rs
+++ b/crates/perry-runtime/src/child_process/signals.rs
@@ -1,28 +1,5 @@
 use super::*;
 
-use std::collections::HashMap;
-use std::fs::File;
-use std::process::{Command, Stdio};
-use std::sync::{
-    atomic::{AtomicU64, Ordering},
-    Mutex,
-};
-
-use sync_run::{
-    cp_read_async_run_options, cp_read_spawn_sync_run_options, cp_read_sync_stdio_run_options,
-    cp_run_to_completion, CpRun, CpRunError, CpRunOptions,
-};
-
-use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_ptr, js_closure_set_capture_ptr, js_native_call_value,
-    js_register_closure_arity, ClosureHeader,
-};
-use crate::object::{
-    js_implicit_this_get, js_implicit_this_set, js_object_alloc_with_shape,
-    js_object_get_field_by_name_f64, js_object_set_field, js_object_set_field_by_name,
-    ObjectHeader,
-};
-use crate::string::{js_string_from_bytes, StringHeader};
 use crate::value::JSValue;
 
 pub(crate) const CP_SIGTERM: i32 = 15;

--- a/crates/perry-runtime/src/child_process/value_util.rs
+++ b/crates/perry-runtime/src/child_process/value_util.rs
@@ -1,25 +1,8 @@
 use super::*;
 
-use std::collections::HashMap;
-use std::fs::File;
-use std::process::{Command, Stdio};
-use std::sync::{
-    atomic::{AtomicU64, Ordering},
-    Mutex,
-};
-
-use sync_run::{
-    cp_read_async_run_options, cp_read_spawn_sync_run_options, cp_read_sync_stdio_run_options,
-    cp_run_to_completion, CpRun, CpRunError, CpRunOptions,
-};
-
-use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_ptr, js_closure_set_capture_ptr, js_native_call_value,
-    js_register_closure_arity, ClosureHeader,
-};
+use crate::closure::{js_closure_get_capture_ptr, ClosureHeader};
 use crate::object::{
-    js_implicit_this_get, js_implicit_this_set, js_object_alloc_with_shape,
-    js_object_get_field_by_name_f64, js_object_set_field, js_object_set_field_by_name,
+    js_implicit_this_get, js_object_get_field_by_name_f64, js_object_set_field_by_name,
     ObjectHeader,
 };
 use crate::string::{js_string_from_bytes, StringHeader};

--- a/crates/perry-runtime/src/closure/dispatch/bound.rs
+++ b/crates/perry-runtime/src/closure/dispatch/bound.rs
@@ -1,7 +1,6 @@
 //! Bound-method / bound-function dispatch, `Function.prototype.bind`, and the
 //! `call`/`apply`/`bind`-as-value reification helpers.
 
-use super::super::*;
 use super::*;
 
 /// Dispatch a bound method call with the given arguments.

--- a/crates/perry-runtime/src/closure/dispatch/calln.rs
+++ b/crates/perry-runtime/src/closure/dispatch/calln.rs
@@ -2,7 +2,6 @@
 //! hot-loop helper, and the shared `dispatch_registered_call` /
 //! `dispatch_rest_or_declared_arity` routing helpers.
 
-use super::super::*;
 use super::*;
 
 /// Call a closure with 0 arguments, returning f64

--- a/crates/perry-runtime/src/closure/dispatch/errors.rs
+++ b/crates/perry-runtime/src/closure/dispatch/errors.rs
@@ -1,9 +1,6 @@
 //! Not-callable error path: `throw_not_callable` plus its #922 runaway-loop
 //! circuit breaker and the counter reset hook the async-step driver calls.
 
-use super::super::*;
-use super::*;
-
 /// Issue #648: calling a value that isn't a function (most commonly the
 /// result of a property lookup that returned undefined, e.g.
 /// `obj.missingFn()`) must throw a TypeError that user code can catch via

--- a/crates/perry-runtime/src/closure/dispatch/validate.rs
+++ b/crates/perry-runtime/src/closure/dispatch/validate.rs
@@ -1,7 +1,6 @@
 //! Closure-pointer validation: GC-forwarding resolution (`clean_closure_ptr`)
 //! and the speculation-safe `get_valid_func_ptr` gate.
 
-use super::super::*;
 use super::*;
 
 /// Resolve a closure pointer through any GC forwarding stubs left behind by

--- a/crates/perry-runtime/src/closure/dispatch/value_call.rs
+++ b/crates/perry-runtime/src/closure/dispatch/value_call.rs
@@ -2,7 +2,6 @@
 //! NaN-boxed callee dispatcher), the V8 trampoline bridge `js_closure_call_array`,
 //! and the spread-apply bridge `js_closure_call_apply_with_spread`.
 
-use super::super::*;
 use super::*;
 
 /// Call a JavaScript function value with variable arguments

--- a/crates/perry-runtime/src/dgram.rs
+++ b/crates/perry-runtime/src/dgram.rs
@@ -10,16 +10,15 @@
 //! touching the network.
 
 use std::collections::HashMap;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs, UdpSocket};
-use std::sync::{Arc, LazyLock, Mutex};
+use std::net::ToSocketAddrs;
+use std::sync::{LazyLock, Mutex};
 
 use crate::array::ArrayHeader;
 use crate::closure::{
     js_closure_alloc, js_closure_set_capture_ptr, js_register_closure_rest, ClosureHeader,
 };
 use crate::object::{
-    js_object_alloc, js_object_get_field_by_name_f64, js_object_keys, js_object_set_field_by_name,
-    ObjectHeader,
+    js_object_alloc, js_object_get_field_by_name_f64, js_object_set_field_by_name, ObjectHeader,
 };
 use crate::value::{
     js_nanbox_pointer, JSValue, POINTER_MASK, TAG_FALSE, TAG_NULL, TAG_TRUE, TAG_UNDEFINED,
@@ -57,8 +56,8 @@ pub(crate) use listeners::{
 // `crate::dgram_reactor`).
 pub(crate) use net::{
     bind_socket, build_address_info, build_rinfo, deterministic, dgram_emit_message, ensure_bound,
-    finish_send, live_udp, lookup_bound_socket, message_value, parse_multicast_v4,
-    parse_multicast_v6, reactor_id, real_bind, real_send, ref_impl, remove_bound_socket, with_udp,
+    live_udp, lookup_bound_socket, message_value, parse_multicast_v4, parse_multicast_v6,
+    reactor_id, real_bind, real_send, ref_impl, remove_bound_socket, with_udp,
 };
 
 // Socket operation implementations (used by thunks + FFI siblings).
@@ -67,7 +66,6 @@ pub(crate) use ops::{
     get_buffer_size_impl, membership_impl, remote_address_impl, send_destination, send_impl,
     set_broadcast_impl, set_buffer_size_impl, set_multicast_interface_impl,
     set_multicast_loopback_impl, set_multicast_ttl_impl, set_ttl_impl, source_membership_impl,
-    validate_buffer_size,
 };
 
 // Closure thunks referenced by SOCKET_METHODS in this trunk.

--- a/crates/perry-runtime/src/dgram/ffi.rs
+++ b/crates/perry-runtime/src/dgram/ffi.rs
@@ -5,21 +5,7 @@
 
 use super::*;
 
-use std::collections::HashMap;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs, UdpSocket};
-use std::sync::{Arc, LazyLock, Mutex};
-
 use crate::array::ArrayHeader;
-use crate::closure::{
-    js_closure_alloc, js_closure_set_capture_ptr, js_register_closure_rest, ClosureHeader,
-};
-use crate::object::{
-    js_object_alloc, js_object_get_field_by_name_f64, js_object_keys, js_object_set_field_by_name,
-    ObjectHeader,
-};
-use crate::value::{
-    js_nanbox_pointer, JSValue, POINTER_MASK, TAG_FALSE, TAG_NULL, TAG_TRUE, TAG_UNDEFINED,
-};
 
 #[no_mangle]
 pub extern "C" fn js_dgram_create_socket(args: *const ArrayHeader) -> f64 {

--- a/crates/perry-runtime/src/dgram/listeners.rs
+++ b/crates/perry-runtime/src/dgram/listeners.rs
@@ -5,21 +5,11 @@
 
 use super::*;
 
-use std::collections::HashMap;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs, UdpSocket};
-use std::sync::{Arc, LazyLock, Mutex};
-
 use crate::array::ArrayHeader;
-use crate::closure::{
-    js_closure_alloc, js_closure_set_capture_ptr, js_register_closure_rest, ClosureHeader,
-};
 use crate::object::{
-    js_object_alloc, js_object_get_field_by_name_f64, js_object_keys, js_object_set_field_by_name,
-    ObjectHeader,
+    js_object_get_field_by_name_f64, js_object_keys, js_object_set_field_by_name, ObjectHeader,
 };
-use crate::value::{
-    js_nanbox_pointer, JSValue, POINTER_MASK, TAG_FALSE, TAG_NULL, TAG_TRUE, TAG_UNDEFINED,
-};
+use crate::value::TAG_UNDEFINED;
 
 pub(crate) fn listener_event_key(prefix: &[u8], event: f64) -> Option<*mut crate::StringHeader> {
     let event = string_to_rust(event)?;

--- a/crates/perry-runtime/src/dgram/net.rs
+++ b/crates/perry-runtime/src/dgram/net.rs
@@ -7,21 +7,11 @@
 
 use super::*;
 
-use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs, UdpSocket};
-use std::sync::{Arc, LazyLock, Mutex};
+use std::sync::Arc;
 
-use crate::array::ArrayHeader;
-use crate::closure::{
-    js_closure_alloc, js_closure_set_capture_ptr, js_register_closure_rest, ClosureHeader,
-};
-use crate::object::{
-    js_object_alloc, js_object_get_field_by_name_f64, js_object_keys, js_object_set_field_by_name,
-    ObjectHeader,
-};
-use crate::value::{
-    js_nanbox_pointer, JSValue, POINTER_MASK, TAG_FALSE, TAG_NULL, TAG_TRUE, TAG_UNDEFINED,
-};
+use crate::object::{js_object_alloc, js_object_set_field_by_name};
+use crate::value::JSValue;
 
 pub(crate) fn allocate_port(registry: &mut DgramRegistry, address: &str) -> u16 {
     for _ in 0..16384 {

--- a/crates/perry-runtime/src/dgram/ops.rs
+++ b/crates/perry-runtime/src/dgram/ops.rs
@@ -7,21 +7,7 @@
 
 use super::*;
 
-use std::collections::HashMap;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs, UdpSocket};
-use std::sync::{Arc, LazyLock, Mutex};
-
-use crate::array::ArrayHeader;
-use crate::closure::{
-    js_closure_alloc, js_closure_set_capture_ptr, js_register_closure_rest, ClosureHeader,
-};
-use crate::object::{
-    js_object_alloc, js_object_get_field_by_name_f64, js_object_keys, js_object_set_field_by_name,
-    ObjectHeader,
-};
-use crate::value::{
-    js_nanbox_pointer, JSValue, POINTER_MASK, TAG_FALSE, TAG_NULL, TAG_TRUE, TAG_UNDEFINED,
-};
+use std::net::Ipv4Addr;
 
 pub(crate) fn create_socket_impl(args: &[f64]) -> f64 {
     let first = args.first().copied().unwrap_or_else(undefined_value);

--- a/crates/perry-runtime/src/dgram/thunks.rs
+++ b/crates/perry-runtime/src/dgram/thunks.rs
@@ -6,21 +6,7 @@
 
 use super::*;
 
-use std::collections::HashMap;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs, UdpSocket};
-use std::sync::{Arc, LazyLock, Mutex};
-
-use crate::array::ArrayHeader;
-use crate::closure::{
-    js_closure_alloc, js_closure_set_capture_ptr, js_register_closure_rest, ClosureHeader,
-};
-use crate::object::{
-    js_object_alloc, js_object_get_field_by_name_f64, js_object_keys, js_object_set_field_by_name,
-    ObjectHeader,
-};
-use crate::value::{
-    js_nanbox_pointer, JSValue, POINTER_MASK, TAG_FALSE, TAG_NULL, TAG_TRUE, TAG_UNDEFINED,
-};
+use crate::closure::ClosureHeader;
 
 pub(crate) extern "C" fn dgram_send_thunk(closure: *const ClosureHeader, rest: f64) -> f64 {
     send_impl(this_value(closure), &collect_rest_args(rest))

--- a/crates/perry-runtime/src/dns.rs
+++ b/crates/perry-runtime/src/dns.rs
@@ -11,7 +11,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs};
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::{LazyLock, Mutex};
 
-use crate::dns_resolver::{self, Answer, DnsError, QueryType, ResolvedRecord};
+use crate::dns_resolver::{self, DnsError, QueryType};
 
 use crate::closure::{js_closure_alloc, js_register_closure_arity, ClosureHeader};
 use crate::object::{js_object_alloc, js_object_set_field_by_name, ObjectHeader};
@@ -25,9 +25,7 @@ pub(crate) use records::{
     any_address_record, caa_record, hex_encode, mx_record, naptr_record, object_value, soa_record,
     srv_record, tlsa_record,
 };
-pub(crate) use resolve_build::{
-    build_any_record, build_resolve_value, deterministic_resolve_records,
-};
+pub(crate) use resolve_build::{build_resolve_value, deterministic_resolve_records};
 
 const RESULT_ORDER_VERBATIM: u8 = 0;
 const RESULT_ORDER_IPV4_FIRST: u8 = 1;

--- a/crates/perry-runtime/src/dns/ffi.rs
+++ b/crates/perry-runtime/src/dns/ffi.rs
@@ -1,14 +1,6 @@
 use super::*;
 
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs};
-use std::sync::atomic::{AtomicU8, Ordering};
-use std::sync::{LazyLock, Mutex};
-
-use crate::dns_resolver::{self, Answer, DnsError, QueryType, ResolvedRecord};
-
-use crate::closure::{js_closure_alloc, js_register_closure_arity, ClosureHeader};
-use crate::object::{js_object_alloc, js_object_set_field_by_name, ObjectHeader};
-use crate::value::{js_nanbox_pointer, JSValue, TAG_NULL, TAG_UNDEFINED};
+use crate::value::{js_nanbox_pointer, JSValue};
 
 #[no_mangle]
 pub extern "C" fn js_dns_noop(_args: i64) -> f64 {

--- a/crates/perry-runtime/src/dns/records.rs
+++ b/crates/perry-runtime/src/dns/records.rs
@@ -1,14 +1,6 @@
 use super::*;
 
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs};
-use std::sync::atomic::{AtomicU8, Ordering};
-use std::sync::{LazyLock, Mutex};
-
-use crate::dns_resolver::{self, Answer, DnsError, QueryType, ResolvedRecord};
-
-use crate::closure::{js_closure_alloc, js_register_closure_arity, ClosureHeader};
-use crate::object::{js_object_alloc, js_object_set_field_by_name, ObjectHeader};
-use crate::value::{js_nanbox_pointer, JSValue, TAG_NULL, TAG_UNDEFINED};
+use crate::object::{js_object_alloc, js_object_set_field_by_name};
 
 pub(crate) fn object_value(fields: &[(&str, f64)]) -> f64 {
     let obj = js_object_alloc(0, fields.len() as u32);

--- a/crates/perry-runtime/src/dns/resolve_build.rs
+++ b/crates/perry-runtime/src/dns/resolve_build.rs
@@ -1,14 +1,6 @@
 use super::*;
 
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs};
-use std::sync::atomic::{AtomicU8, Ordering};
-use std::sync::{LazyLock, Mutex};
-
-use crate::dns_resolver::{self, Answer, DnsError, QueryType, ResolvedRecord};
-
-use crate::closure::{js_closure_alloc, js_register_closure_arity, ClosureHeader};
-use crate::object::{js_object_alloc, js_object_set_field_by_name, ObjectHeader};
-use crate::value::{js_nanbox_pointer, JSValue, TAG_NULL, TAG_UNDEFINED};
+use crate::dns_resolver::{Answer, ResolvedRecord};
 
 /// Deterministic-mode (`PERRY_DETERMINISTIC_NET=1`) loopback answers — the
 /// pre-#4911 behavior, kept for reproducible parity fixtures.

--- a/crates/perry-runtime/src/fs/dir_glob_watch.rs
+++ b/crates/perry-runtime/src/fs/dir_glob_watch.rs
@@ -1,23 +1,9 @@
 //! opendir / glob / watch / watchFile / unwatchFile.
 
-use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap, VecDeque};
-use std::fs;
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
 // `PathBuf` is only named by the regex-engine-gated glob helpers
 // (`pathbuf_to_slashes`); the cp path at the bottom uses the fully-qualified
 // `std::path::PathBuf`, so the bare import is gated to avoid an unused-import
 // warning when the engine is off.
-#[cfg(feature = "regex-engine")]
-use std::path::PathBuf;
-use std::sync::Once;
-
-use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_f64, js_closure_set_capture_f64,
-    js_register_closure_arity, ClosureHeader,
-};
 
 use super::*;
 
@@ -28,12 +14,12 @@ mod watch;
 // Re-export the opendir entry points consumed cross-module (callbacks.rs,
 // node_submodules/fs_promises.rs) plus the unmangled FFI sync symbol.
 pub use opendir::js_fs_opendir_sync;
-pub(crate) use opendir::{js_fs_opendir_value, js_fs_opendir_value_with_path};
+pub(crate) use opendir::js_fs_opendir_value_with_path;
 
 // Re-export the glob machinery: the `#[no_mangle]` FFI sync symbols are `pub`,
 // while the run/value helpers and match types are consumed by the `watch`
 // sibling (glob iterator) and stay `pub(crate)`.
-pub(crate) use glob::{glob_entry_value, run_fs_glob_result, FsGlobMatch, FsGlobRun};
+pub(crate) use glob::{glob_entry_value, run_fs_glob_result, FsGlobMatch};
 pub use glob::{js_fs_glob_sync, js_fs_glob_sync_options};
 
 // Re-export the watch/watchFile entry points + GC scanner + the shared promise

--- a/crates/perry-runtime/src/fs/dir_glob_watch/glob.rs
+++ b/crates/perry-runtime/src/fs/dir_glob_watch/glob.rs
@@ -6,26 +6,14 @@ use super::string_value;
 // See the note in `opendir.rs`: the parent `fs` module's helpers are globbed in
 // directly here (we are a grandchild of `fs`); the two private-to-`fs/mod.rs`
 // helpers are named explicitly so a glob that skips privates can't drop them.
-use crate::fs::*;
-#[allow(unused_imports)]
-use crate::fs::{encoded_string_ptr, fs_encoding_option};
-#[allow(unused_imports)]
-use crate::string::js_string_from_bytes;
 
-use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::BTreeMap;
 use std::fs;
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 #[cfg(feature = "regex-engine")]
 use std::path::PathBuf;
-use std::sync::Once;
 
-use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_f64, js_closure_set_capture_f64,
-    js_register_closure_arity, ClosureHeader,
-};
+use crate::closure::ClosureHeader;
 
 /// Compiled exclude-pattern type for `fs.glob`. Backed by `fancy_regex::Regex`.
 /// Only referenced by the regex-engine-gated glob machinery (`FsGlobOptions`),

--- a/crates/perry-runtime/src/fs/dir_glob_watch/opendir.rs
+++ b/crates/perry-runtime/src/fs/dir_glob_watch/opendir.rs
@@ -8,26 +8,8 @@ use super::*;
 // grandchild we glob the `fs` module directly. `fs_encoding_option` /
 // `encoded_string_ptr` are private to `fs/mod.rs` but reachable here as a
 // descendant module, so name them explicitly in case the glob skips privates.
-use crate::fs::*;
-#[allow(unused_imports)]
-use crate::fs::{encoded_string_ptr, fs_encoding_option};
-#[allow(unused_imports)]
-use crate::string::js_string_from_bytes;
 
-use std::cell::RefCell;
-use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::fs;
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
-#[cfg(feature = "regex-engine")]
-use std::path::PathBuf;
-use std::sync::Once;
-
-use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_f64, js_closure_set_capture_f64,
-    js_register_closure_arity, ClosureHeader,
-};
 
 /// `fs.opendirSync(path)` — codegen emits a direct call to the unmangled
 /// `js_fs_opendir_sync` symbol (runtime_decls/strings.rs). Without `#[no_mangle]`

--- a/crates/perry-runtime/src/fs/dir_glob_watch/watch.rs
+++ b/crates/perry-runtime/src/fs/dir_glob_watch/watch.rs
@@ -6,10 +6,7 @@ use super::string_value;
 // See the note in `opendir.rs`: the parent `fs` module's helpers are globbed in
 // directly here (we are a grandchild of `fs`); the two private-to-`fs/mod.rs`
 // helpers are named explicitly so a glob that skips privates can't drop them.
-use crate::fs::*;
-#[allow(unused_imports)]
 use crate::fs::{encoded_string_ptr, fs_encoding_option};
-#[allow(unused_imports)]
 use crate::string::js_string_from_bytes;
 
 use std::cell::RefCell;
@@ -18,8 +15,6 @@ use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
-#[cfg(feature = "regex-engine")]
-use std::path::PathBuf;
 use std::sync::Once;
 
 use crate::closure::{

--- a/crates/perry-runtime/src/fs/errors.rs
+++ b/crates/perry-runtime/src/fs/errors.rs
@@ -1,7 +1,6 @@
 //! fs error-value construction + callback-error probes (extracted from
 //! fs/mod.rs to keep it under the 2000-line cap). `use super::*` preserves
 //! parent visibility.
-#![allow(unused_imports)]
 use super::*;
 
 pub(crate) fn io_error_code(err: &std::io::Error) -> &'static str {

--- a/crates/perry-runtime/src/fs/fd_sync_ops.rs
+++ b/crates/perry-runtime/src/fs/fd_sync_ops.rs
@@ -1,19 +1,11 @@
 use super::*;
 
-use std::cell::RefCell;
-use std::collections::HashMap as StdHashMap;
 use std::fs;
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::Write;
 #[cfg(unix)]
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 #[cfg(unix)]
 use std::os::unix::io::AsRawFd;
-use std::path::Path;
-use std::sync::atomic::{AtomicI32, Ordering};
-
-use crate::closure::ClosureHeader;
-use crate::string::{js_string_from_bytes, StringHeader};
-use crate::value::{POINTER_MASK, POINTER_TAG};
 
 /// Core path-based `truncate` op. Node surfaces the `open` syscall error
 /// when the path can't be opened for truncation (ENOENT / EISDIR / EACCES),

--- a/crates/perry-runtime/src/fs/mod.rs
+++ b/crates/perry-runtime/src/fs/mod.rs
@@ -41,8 +41,8 @@ pub mod validate;
 pub use time::js_fs_to_unix_timestamp;
 mod fd_sync_ops;
 pub(crate) use fd_sync_ops::{
-    fchown_sync_inner, fchown_sync_inner_result, fdatasync_sync_inner, fstat_stats_value,
-    fsync_sync_inner, js_fs_fchown_result, js_fs_ftruncate_result, js_fs_truncate_result,
+    fchown_sync_inner, fdatasync_sync_inner, fstat_stats_value, fsync_sync_inner,
+    js_fs_fchown_result, js_fs_ftruncate_result, js_fs_truncate_result,
 };
 pub use fd_sync_ops::{
     js_fs_fchmod_sync, js_fs_fchown_sync, js_fs_fdatasync_sync, js_fs_fstat_sync,

--- a/crates/perry-runtime/src/gc/copying.rs
+++ b/crates/perry-runtime/src/gc/copying.rs
@@ -920,7 +920,7 @@ pub(super) fn gc_collect_minor_copying_fast_path_with_eligibility(
     trace: &mut Option<GcCycleTrace>,
     start: Instant,
     eligibility: CopiedMinorEligibility,
-    trigger_kind: GcTriggerKind,
+    _trigger_kind: GcTriggerKind,
 ) -> Option<CopiedMinorFastPathOutcome> {
     if let Some(trace) = trace.as_mut() {
         trace.copying_nursery = eligibility.trace_stats();

--- a/crates/perry-runtime/src/gc/cycle.rs
+++ b/crates/perry-runtime/src/gc/cycle.rs
@@ -748,7 +748,7 @@ fn record_test_malloc_trim_call() {
     TEST_MALLOC_TRIM_CALLS.with(|calls| calls.set(calls.get().saturating_add(1)));
 }
 
-fn run_malloc_trim(progress_kind: GcProgressKind) -> MallocTrimOutcome {
+fn run_malloc_trim(_progress_kind: GcProgressKind) -> MallocTrimOutcome {
     // #6179/#6180 RSS floor: budgeted cycles are the DEFAULT-path collector
     // once incremental graduates — skipping allocator trim there meant a
     // long-lived incremental process never returned freed allocator pages to

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -60,7 +60,7 @@ mod copying;
 use copying::*;
 // The copied-minor pointer classifier is consumed by the weak-holder registry
 // pass in `crate::weakref` (#6182), which lives outside the gc module.
-pub(crate) use copying::{CopyingPointer, CopyingPointerSet};
+pub(crate) use copying::CopyingPointerSet;
 mod dead_owner;
 mod oldgen;
 use oldgen::*;

--- a/crates/perry-runtime/src/gc/tests/triggers.rs
+++ b/crates/perry-runtime/src/gc/tests/triggers.rs
@@ -1,5 +1,4 @@
 use super::super::*;
-#[allow(unused_imports)]
 use super::support::*;
 
 struct GcBumpTriggerTestGuard {

--- a/crates/perry-runtime/src/intl.rs
+++ b/crates/perry-runtime/src/intl.rs
@@ -14,8 +14,6 @@ use crate::object::{
 use crate::string::{js_string_from_bytes, str_bytes_from_jsvalue};
 use crate::value::{js_jsvalue_to_string, js_nanbox_pointer, JSValue};
 use crate::StringHeader;
-#[cfg(feature = "intl-segmenter")]
-use unicode_segmentation::UnicodeSegmentation;
 
 mod ctor_guard;
 use ctor_guard::{constructor_target_prototype, require_new_target};
@@ -29,7 +27,7 @@ mod date_names;
 #[cfg(feature = "intl-datetime")]
 pub(crate) mod icu_dtf;
 mod time_zone;
-pub(crate) use time_zone::{canonicalize_named_time_zone, resolved_date_time_zone};
+pub(crate) use time_zone::resolved_date_time_zone;
 mod install;
 use install::install_constructor;
 mod subclass;
@@ -46,57 +44,37 @@ mod segmenter;
 use canon_aliases::canonicalize_unicode_extension_types;
 
 pub(crate) use date_collator::{
-    collator_bound_compare_thunk, collator_bound_resolved_options_thunk, collator_compare_object,
-    collator_compare_thunk, collator_resolved_options_object, collator_resolved_options_thunk,
-    compare_strings, date_range_parts_from_ms, date_short_utc_from_ms,
-    date_time_format_bound_format_thunk, date_time_format_bound_range_thunk,
-    date_time_format_bound_range_to_parts_thunk, date_time_format_bound_resolved_options_thunk,
-    date_time_format_bound_to_parts_thunk, date_time_format_format_getter_thunk,
-    date_time_format_format_thunk, date_time_format_format_value,
-    date_time_format_range_parts_value, date_time_format_range_thunk,
-    date_time_format_range_to_parts_thunk, date_time_format_range_value,
-    date_time_format_resolved_options_object, date_time_format_resolved_options_thunk,
-    date_time_format_to_parts_thunk, date_time_range_clip, range_parts_to_js_array,
-    swedish_collation_key, temporal_locale_string, TemporalLocaleCtx,
+    collator_bound_compare_thunk, collator_bound_resolved_options_thunk, collator_compare_thunk,
+    collator_resolved_options_thunk, date_time_format_bound_format_thunk,
+    date_time_format_bound_range_thunk, date_time_format_bound_range_to_parts_thunk,
+    date_time_format_bound_resolved_options_thunk, date_time_format_bound_to_parts_thunk,
+    date_time_format_format_getter_thunk, date_time_format_range_thunk,
+    date_time_format_range_to_parts_thunk, date_time_format_resolved_options_thunk,
+    date_time_format_to_parts_thunk, temporal_locale_string, TemporalLocaleCtx,
 };
 pub(crate) use list_relative_plural::{
-    canonicalize_calendar_id, canonicalize_offset_time_zone, collect_string_list,
-    is_valid_offset_time_zone, list_format_bound_format_thunk,
-    list_format_bound_resolved_options_thunk, list_format_bound_to_parts_thunk,
-    list_format_format_thunk, list_format_instance_parts, list_format_parts,
-    list_format_resolved_options_object, list_format_resolved_options_thunk,
-    list_format_to_parts_thunk, list_separators, plural_categories,
+    canonicalize_calendar_id, canonicalize_offset_time_zone, is_valid_offset_time_zone,
+    list_format_bound_format_thunk, list_format_bound_resolved_options_thunk,
+    list_format_bound_to_parts_thunk, list_format_format_thunk, list_format_parts,
+    list_format_resolved_options_thunk, list_format_to_parts_thunk,
     plural_rules_bound_resolved_options_thunk, plural_rules_bound_select_range_thunk,
-    plural_rules_bound_select_thunk, plural_rules_resolved_options_object,
-    plural_rules_resolved_options_thunk, plural_rules_select, plural_rules_select_range_thunk,
-    plural_rules_select_thunk, plural_select_en, plural_select_range, rtf_bound_format_thunk,
+    plural_rules_bound_select_thunk, plural_rules_resolved_options_thunk,
+    plural_rules_select_range_thunk, plural_rules_select_thunk, rtf_bound_format_thunk,
     rtf_bound_resolved_options_thunk, rtf_bound_to_parts_thunk, rtf_format_thunk,
-    rtf_instance_parts, rtf_parts, rtf_resolved_options_object, rtf_resolved_options_thunk,
-    rtf_singular_unit, rtf_to_parts_thunk,
+    rtf_resolved_options_thunk, rtf_to_parts_thunk,
 };
 pub(crate) use number_format::{
-    bigint_to_locale_string, captured_intl_object, compact_round, compact_suffix,
-    currency_instance_parts, decimal_msd_exponent, format_number_instance, grouping_enabled,
-    increment_decimal, intl_object_from_value, nf_coerce_number, nf_load, nf_resolved_default,
+    bigint_to_locale_string, captured_intl_object, nf_resolved_default,
     number_format_bound_format_thunk, number_format_bound_resolved_options_thunk,
     number_format_bound_to_parts_thunk, number_format_format_getter_thunk,
-    number_format_format_object, number_format_range_thunk, number_format_range_to_parts_thunk,
-    number_format_resolved_options_object, number_format_resolved_options_thunk,
-    number_format_to_parts_thunk, number_instance_parts, number_parts_from_resolved,
-    parts_to_js_array, push_grouped_integer, push_sign, push_style_suffix, round_integer_to_place,
-    round_mode_code, round_to_fraction, round_to_significant, rounding_up, set_round_ctx,
-    significant_count, strip_leading_zeros, this_intl_object, trim_fraction, NfResolved,
+    number_format_range_thunk, number_format_range_to_parts_thunk,
+    number_format_resolved_options_thunk, number_format_to_parts_thunk, number_parts_from_resolved,
+    parts_to_js_array, this_intl_object,
 };
-pub(crate) use number_format_options::{
-    configure_number_format, is_well_formed_currency_code, is_well_formed_unit_identifier,
-};
-#[cfg(feature = "intl-segmenter")]
-pub(crate) use segmenter::segment_is_word_like;
+pub(crate) use number_format_options::configure_number_format;
 pub(crate) use segmenter::{
-    build_segments, make_segment_record, normalize_granularity,
-    segmenter_bound_resolved_options_thunk, segmenter_bound_segment_thunk,
-    segmenter_resolved_options_object, segmenter_resolved_options_thunk, segmenter_segment_object,
-    segmenter_segment_thunk, utf16_len,
+    normalize_granularity, segmenter_bound_resolved_options_thunk, segmenter_bound_segment_thunk,
+    segmenter_resolved_options_thunk, segmenter_segment_thunk,
 };
 
 const KIND_NUMBER: &str = "NumberFormat";

--- a/crates/perry-runtime/src/intl/date_collator.rs
+++ b/crates/perry-runtime/src/intl/date_collator.rs
@@ -1,16 +1,9 @@
 use super::*;
 
-use crate::array::{js_array_alloc, js_array_get_f64, js_array_length, js_array_push_f64};
+use crate::array::{js_array_alloc, js_array_push_f64};
 use crate::closure::ClosureHeader;
-use crate::object::{
-    js_object_alloc, js_object_get_field_by_name_f64, js_object_set_field_by_name,
-    set_builtin_property_attrs, ObjectHeader, PropertyAttrs,
-};
-use crate::string::{js_string_from_bytes, str_bytes_from_jsvalue};
-use crate::value::{js_jsvalue_to_string, js_nanbox_pointer, JSValue};
-use crate::StringHeader;
-#[cfg(feature = "intl-segmenter")]
-use unicode_segmentation::UnicodeSegmentation;
+use crate::object::{js_object_alloc, ObjectHeader};
+use crate::value::{js_nanbox_pointer, JSValue};
 
 /// ECMA-402 FormatDateTime / HandleDateTimeValue step 1: coerce the
 /// `format`/`formatToParts` argument to a TimeClip'd integer-millisecond value.

--- a/crates/perry-runtime/src/intl/list_relative_plural.rs
+++ b/crates/perry-runtime/src/intl/list_relative_plural.rs
@@ -2,15 +2,8 @@ use super::*;
 
 use crate::array::{js_array_alloc, js_array_push_f64};
 use crate::closure::ClosureHeader;
-use crate::object::{
-    js_object_alloc, js_object_get_field_by_name_f64, js_object_set_field_by_name,
-    set_builtin_property_attrs, ObjectHeader, PropertyAttrs,
-};
-use crate::string::{js_string_from_bytes, str_bytes_from_jsvalue};
-use crate::value::{js_jsvalue_to_string, js_nanbox_pointer, JSValue};
-use crate::StringHeader;
-#[cfg(feature = "intl-segmenter")]
-use unicode_segmentation::UnicodeSegmentation;
+use crate::object::{js_object_alloc, ObjectHeader};
+use crate::value::{js_nanbox_pointer, JSValue};
 
 /// Validate and canonicalize a `calendar` option per the Unicode Locale
 /// Identifier `type` nonterminal: one or more `-`-joined segments, each 3–8

--- a/crates/perry-runtime/src/intl/number_format.rs
+++ b/crates/perry-runtime/src/intl/number_format.rs
@@ -1,17 +1,12 @@
 use super::*;
 
 use super::number_format_digits::numbering_system_digits;
-use crate::array::{js_array_alloc, js_array_get_f64, js_array_length, js_array_push_f64};
+use crate::array::{js_array_alloc, js_array_push_f64};
 use crate::closure::ClosureHeader;
-use crate::object::{
-    js_object_alloc, js_object_get_field_by_name_f64, js_object_set_field_by_name,
-    set_builtin_property_attrs, ObjectHeader, PropertyAttrs,
-};
-use crate::string::{js_string_from_bytes, str_bytes_from_jsvalue};
-use crate::value::{js_jsvalue_to_string, js_nanbox_pointer, JSValue};
+use crate::object::{js_object_alloc, ObjectHeader};
+use crate::string::js_string_from_bytes;
+use crate::value::{js_nanbox_pointer, JSValue};
 use crate::StringHeader;
-#[cfg(feature = "intl-segmenter")]
-use unicode_segmentation::UnicodeSegmentation;
 
 pub(crate) struct NfResolved {
     pub(crate) locale: String,

--- a/crates/perry-runtime/src/intl/number_format_options.rs
+++ b/crates/perry-runtime/src/intl/number_format_options.rs
@@ -1,16 +1,7 @@
 use super::*;
 
-use crate::array::{js_array_alloc, js_array_get_f64, js_array_length, js_array_push_f64};
-use crate::closure::ClosureHeader;
-use crate::object::{
-    js_object_alloc, js_object_get_field_by_name_f64, js_object_set_field_by_name,
-    set_builtin_property_attrs, ObjectHeader, PropertyAttrs,
-};
-use crate::string::{js_string_from_bytes, str_bytes_from_jsvalue};
-use crate::value::{js_jsvalue_to_string, js_nanbox_pointer, JSValue};
-use crate::StringHeader;
-#[cfg(feature = "intl-segmenter")]
-use unicode_segmentation::UnicodeSegmentation;
+use crate::object::ObjectHeader;
+use crate::value::JSValue;
 
 /// Read, validate, and store the NumberFormat option slots (ECMA-402
 /// CreateNumberFormat / SetNumberFormatUnitOptions / SetNumberFormatDigitOptions).

--- a/crates/perry-runtime/src/intl/segmenter.rs
+++ b/crates/perry-runtime/src/intl/segmenter.rs
@@ -1,14 +1,9 @@
 use super::*;
 
-use crate::array::{js_array_alloc, js_array_get_f64, js_array_length, js_array_push_f64};
+use crate::array::{js_array_alloc, js_array_push_f64};
 use crate::closure::ClosureHeader;
-use crate::object::{
-    js_object_alloc, js_object_get_field_by_name_f64, js_object_set_field_by_name,
-    set_builtin_property_attrs, ObjectHeader, PropertyAttrs,
-};
-use crate::string::{js_string_from_bytes, str_bytes_from_jsvalue};
-use crate::value::{js_jsvalue_to_string, js_nanbox_pointer, JSValue};
-use crate::StringHeader;
+use crate::object::{js_object_alloc, ObjectHeader};
+use crate::value::js_nanbox_pointer;
 #[cfg(feature = "intl-segmenter")]
 use unicode_segmentation::UnicodeSegmentation;
 

--- a/crates/perry-runtime/src/json/mod.rs
+++ b/crates/perry-runtime/src/json/mod.rs
@@ -51,44 +51,25 @@ pub use stringify_api::{
 // so every cross-sibling helper must be visible at the mod-root scope.
 // `ShapeTemplate` is referenced by the `SHAPE_CACHE` thread-local declared
 // below so the re-export must precede the `thread_local!` block.
-//
-// `#[allow(unused_imports)]`: many helpers are self-referenced from their
-// home sibling and don't need the re-export there, but keeping the surface
-// uniform makes the split predictable and resilient to future cross-
-// sibling references.
 #[cfg(test)]
 pub(crate) use parse_api::test_json_parse_direct;
-#[allow(unused_imports)]
-pub(crate) use parse_api::{try_parse_via_tape, TapeMode};
-#[allow(unused_imports)]
 pub(crate) use parser::{DirectParser, ObjectShapeHint};
-#[allow(unused_imports)]
-pub(crate) use raw_json::{ptr_is_raw_json_wrapper, raw_json_text_bytes, RAW_JSON_CLASS_ID};
+pub(crate) use raw_json::{ptr_is_raw_json_wrapper, raw_json_text_bytes};
 #[cfg(test)]
 pub(crate) use reviver::test_apply_reviver_for_value;
-#[allow(unused_imports)]
 pub(crate) use simd::find_string_terminator;
-#[allow(unused_imports)]
 pub(crate) use stringify::{
-    arm_to_json_result_guard, build_shape_prefix_template, estimate_json_size, is_closure_value,
-    is_object_pointer, is_symbol_value, object_get_to_json, shape_template_for, stringify_array,
-    stringify_array_depth, stringify_object, stringify_object_inner, stringify_value,
-    stringify_value_depth, try_emit_shape_element, write_escaped_string, write_number,
+    arm_to_json_result_guard, estimate_json_size, is_closure_value, is_object_pointer,
+    is_symbol_value, object_get_to_json, stringify_value, write_escaped_string, write_number,
     ShapeTemplate,
 };
-#[allow(unused_imports)]
-pub(crate) use stringify_api::{
-    redirect_lazy_to_materialized, string_from_header, try_stringify_lazy_array,
-};
-#[allow(unused_imports)]
+pub(crate) use stringify_api::{redirect_lazy_to_materialized, try_stringify_lazy_array};
 pub(crate) use stringify_buffer::{
     stringify_buffer, stringify_buffer_pretty, stringify_typed_array, stringify_typed_array_pretty,
 };
-#[allow(unused_imports)]
 pub(crate) use stringify_tojson_probe::{
     current_to_json_key_arg, invalidate_object_proto_tojson_state, reset_to_json_key,
     set_to_json_key_index, set_to_json_key_str, set_to_json_key_value, to_json_definitely_absent,
-    PROTO_TOJSON_DIRTY,
 };
 
 // ─── Circular reference detection ────────────────────────────────────────────

--- a/crates/perry-runtime/src/json/replacer.rs
+++ b/crates/perry-runtime/src/json/replacer.rs
@@ -76,7 +76,6 @@ unsafe fn root_holder(value_f64: f64) -> f64 {
 /// (top 16 bits 0 or 1) and 8-byte aligned. A value whose extracted
 /// "pointer" fails this is a corrupted / mis-encoded pointer, never a
 /// dereferenceable `GcHeader` — feeding it to `gc_obj_type` SIGBUSes.
-#[inline]
 fn ptr_derefable(ptr: usize) -> bool {
     // Top-16-bits check: a real heap pointer sits in the low canonical VA
     // range (bits 48-63 are 0 or 1). On 32-bit targets (arm64_32/watchOS)

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -28,7 +28,6 @@ pub(crate) use super::stringify_scalars::{
 /// yet point at an UNMAPPED page — `is_valid_obj_ptr` accepts it and the
 /// subsequent `(*obj).keys_array` read then SIGSEGVs. Mirrors the `path.rs` /
 /// `current_heap_header_for_user_ptr` Unknown→malloc rule.
-#[inline]
 pub(super) unsafe fn ptr_is_tracked_heap_object(ptr: *const u8) -> bool {
     let addr = ptr as usize;
     if crate::value::addr_class::is_handle_band(addr) {

--- a/crates/perry-runtime/src/json/stringify_scalars.rs
+++ b/crates/perry-runtime/src/json/stringify_scalars.rs
@@ -5,8 +5,6 @@
 //! move — no behaviour change.
 
 use super::*;
-use crate::JSValue;
-use std::fmt::Write as FmtWrite;
 
 #[inline]
 pub(crate) unsafe fn write_number(buf: &mut String, value: f64) {

--- a/crates/perry-runtime/src/json/stringify_tojson_probe.rs
+++ b/crates/perry-runtime/src/json/stringify_tojson_probe.rs
@@ -6,7 +6,7 @@
 //! allocations. Split out of `stringify.rs` for the 2000-line file gate.
 
 use super::*;
-use crate::{JSValue, StringHeader};
+use crate::JSValue;
 
 // ─── toJSON fast-negative probe (#6009) ──────────────────────────────────────
 

--- a/crates/perry-runtime/src/map.rs
+++ b/crates/perry-runtime/src/map.rs
@@ -2279,7 +2279,6 @@ fn js_map_foreach_impl(
     let has_override = collection_override.to_bits() != crate::value::TAG_UNDEFINED;
     let collection_handle = scope.root_nanbox_f64(collection_override);
     unsafe {
-        let map = map_handle.get_raw_const_ptr::<MapHeader>();
         // The collection itself is the third callback argument and the
         // identity user code compares `self === m` against.
         // ECMA-262 24.1.3.5: forEach iterates [[MapData]] in insertion order,

--- a/crates/perry-runtime/src/node_stream_compose_live.rs
+++ b/crates/perry-runtime/src/node_stream_compose_live.rs
@@ -3,7 +3,6 @@
 //! readable as a live pipe participant and consume its buffered front when it
 //! re-emits, so `pipe()`, `pipeline()`, and `compose()` chains don't replay the
 //! same flowing chunk from retained readable storage.
-#![allow(unused_imports)]
 use super::*;
 
 pub(super) fn mark_live_pipe_consume_on_emit(stream: f64) {

--- a/crates/perry-runtime/src/node_stream_constructors.rs
+++ b/crates/perry-runtime/src/node_stream_constructors.rs
@@ -1,20 +1,8 @@
 //! node:stream — constructors, init/option-parsing, and module-level FFI entry points (split out of node_stream.rs for the 2000-line
 //! file-size gate, #1987). Shares the parent module's constants, hidden-key
 //! accessors and state primitives via `use super::*`.
-#![allow(unused_imports)]
 use super::*;
-use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_f64, js_closure_get_capture_ptr,
-    js_closure_set_capture_f64, js_closure_set_capture_ptr, ClosureHeader,
-};
-use crate::object::{
-    js_object_alloc, js_object_alloc_with_shape, js_object_get_field,
-    js_object_get_field_by_name_f64, js_object_set_field, js_object_set_field_by_name,
-    ObjectHeader,
-};
 use crate::value::JSValue;
-use std::os::raw::c_int;
-use std::sync::atomic::{AtomicPtr, Ordering};
 
 thread_local! {
     static ITER_HELPER_ARITIES_REGISTERED: std::cell::Cell<bool> =

--- a/crates/perry-runtime/src/node_stream_constructors/builders.rs
+++ b/crates/perry-runtime/src/node_stream_constructors/builders.rs
@@ -1,21 +1,12 @@
 //! node:stream — the `js_node_stream_*_new` / `*_subclass_init` constructors
 //! and `Readable.from` factory (split out of node_stream_constructors.rs for
 //! the 2000-line file-size gate, #1987).
-#![allow(unused_imports)]
 use super::super::*;
 use super::*;
-use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_f64, js_closure_get_capture_ptr,
-    js_closure_set_capture_f64, js_closure_set_capture_ptr, ClosureHeader,
-};
-use crate::object::{
-    js_object_alloc, js_object_alloc_with_shape, js_object_get_field,
-    js_object_get_field_by_name_f64, js_object_set_field, js_object_set_field_by_name,
-    ObjectHeader,
-};
+use crate::closure::ClosureHeader;
+use crate::object::{js_object_get_field_by_name_f64, js_object_set_field_by_name, ObjectHeader};
 use crate::value::JSValue;
 use std::os::raw::c_int;
-use std::sync::atomic::{AtomicPtr, Ordering};
 
 #[no_mangle]
 pub extern "C" fn js_node_stream_readable_new(opts: f64) -> f64 {

--- a/crates/perry-runtime/src/node_stream_constructors/introspection.rs
+++ b/crates/perry-runtime/src/node_stream_constructors/introspection.rs
@@ -3,21 +3,10 @@
 //! `_isArrayBufferView` type predicates), default-highWaterMark accessors and
 //! abort-signal wiring (split out of node_stream_constructors.rs for the
 //! 2000-line file-size gate, #1987).
-#![allow(unused_imports)]
 use super::super::*;
 use super::*;
-use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_f64, js_closure_get_capture_ptr,
-    js_closure_set_capture_f64, js_closure_set_capture_ptr, ClosureHeader,
-};
-use crate::object::{
-    js_object_alloc, js_object_alloc_with_shape, js_object_get_field,
-    js_object_get_field_by_name_f64, js_object_set_field, js_object_set_field_by_name,
-    ObjectHeader,
-};
+use crate::closure::{js_closure_alloc, js_closure_set_capture_ptr};
 use crate::value::JSValue;
-use std::os::raw::c_int;
-use std::sync::atomic::{AtomicPtr, Ordering};
 
 // ─────────────────────────────────────────────────────────────────
 // #1534: static introspection helpers `Readable.isDisturbed(s)` and

--- a/crates/perry-runtime/src/node_stream_constructors/pipeline.rs
+++ b/crates/perry-runtime/src/node_stream_constructors/pipeline.rs
@@ -1,21 +1,13 @@
 //! node:stream — `Duplex.from`, `compose`, `finished`, `pipeline` and
 //! `duplexPair` (split out of node_stream_constructors.rs for the 2000-line
 //! file-size gate, #1987).
-#![allow(unused_imports)]
 use super::super::*;
 use super::*;
 use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_f64, js_closure_get_capture_ptr,
-    js_closure_set_capture_f64, js_closure_set_capture_ptr, ClosureHeader,
+    js_closure_alloc, js_closure_get_capture_f64, js_closure_set_capture_f64, ClosureHeader,
 };
-use crate::object::{
-    js_object_alloc, js_object_alloc_with_shape, js_object_get_field,
-    js_object_get_field_by_name_f64, js_object_set_field, js_object_set_field_by_name,
-    ObjectHeader,
-};
+use crate::object::{js_object_set_field_by_name, ObjectHeader};
 use crate::value::JSValue;
-use std::os::raw::c_int;
-use std::sync::atomic::{AtomicPtr, Ordering};
 
 fn attach_duplex_readable_source(duplex: f64, source: f64) -> Result<(), f64> {
     let chunks = if let Some(chunks) = readable_hidden_chunks(source) {

--- a/crates/perry-runtime/src/node_stream_constructors/web_adapter.rs
+++ b/crates/perry-runtime/src/node_stream_constructors/web_adapter.rs
@@ -1,20 +1,13 @@
 //! node:stream — WHATWG Web-stream interop (`Readable.toWeb`/`fromWeb`, the
 //! adapter pumps, and the fallback stub) split out of
 //! node_stream_constructors.rs for the 2000-line file-size gate, #1987.
-#![allow(unused_imports)]
 use super::super::*;
 use super::*;
 use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_f64, js_closure_get_capture_ptr,
-    js_closure_set_capture_f64, js_closure_set_capture_ptr, ClosureHeader,
+    js_closure_alloc, js_closure_get_capture_f64, js_closure_set_capture_f64, ClosureHeader,
 };
-use crate::object::{
-    js_object_alloc, js_object_alloc_with_shape, js_object_get_field,
-    js_object_get_field_by_name_f64, js_object_set_field, js_object_set_field_by_name,
-    ObjectHeader,
-};
+use crate::object::{js_object_alloc, js_object_set_field};
 use crate::value::JSValue;
-use std::os::raw::c_int;
 use std::sync::atomic::{AtomicPtr, Ordering};
 
 // ─────────────────────────────────────────────────────────────────

--- a/crates/perry-runtime/src/node_stream_dispatch.rs
+++ b/crates/perry-runtime/src/node_stream_dispatch.rs
@@ -1,19 +1,13 @@
 //! node:stream — method-table builders, stub-arity registration, pointer/GC helpers (split out of node_stream.rs for the 2000-line
 //! file-size gate, #1987). Shares the parent module's constants, hidden-key
 //! accessors and state primitives via `use super::*`.
-#![allow(unused_imports)]
 use super::*;
-use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_f64, js_closure_get_capture_ptr,
-    js_closure_set_capture_f64, js_closure_set_capture_ptr, ClosureHeader,
-};
+use crate::closure::{js_closure_alloc, ClosureHeader};
 use crate::object::{
-    js_object_alloc, js_object_alloc_with_shape, js_object_get_field,
-    js_object_get_field_by_name_f64, js_object_set_field, js_object_set_field_by_name,
-    ObjectHeader,
+    js_object_alloc_with_shape, js_object_get_field_by_name_f64, js_object_set_field,
+    js_object_set_field_by_name, ObjectHeader,
 };
 use crate::value::JSValue;
-use std::os::raw::c_int;
 
 pub(super) type StubFn = unsafe extern "C" fn();
 

--- a/crates/perry-runtime/src/node_stream_duplex_methods.rs
+++ b/crates/perry-runtime/src/node_stream_duplex_methods.rs
@@ -1,6 +1,5 @@
 //! node:stream — Duplex prototype method table. Split out of
 //! node_stream_readwrite.rs for the 2000-line file-size gate.
-#![allow(unused_imports)]
 use super::*;
 
 pub(super) fn duplex_methods() -> [(&'static str, StubFn); 44] {

--- a/crates/perry-runtime/src/node_stream_iter_helpers.rs
+++ b/crates/perry-runtime/src/node_stream_iter_helpers.rs
@@ -1,19 +1,13 @@
 //! node:stream — async-consume + iterator-helper machinery (map/filter/reduce/compose/...) (split out of node_stream.rs for the 2000-line
 //! file-size gate, #1987). Shares the parent module's constants, hidden-key
 //! accessors and state primitives via `use super::*`.
-#![allow(unused_imports)]
 use super::*;
 use crate::closure::{
     js_closure_alloc, js_closure_get_capture_f64, js_closure_get_capture_ptr,
     js_closure_set_capture_f64, js_closure_set_capture_ptr, ClosureHeader,
 };
-use crate::object::{
-    js_object_alloc, js_object_alloc_with_shape, js_object_get_field,
-    js_object_get_field_by_name_f64, js_object_set_field, js_object_set_field_by_name,
-    ObjectHeader,
-};
+use crate::object::{js_object_get_field_by_name_f64, js_object_set_field_by_name, ObjectHeader};
 use crate::value::JSValue;
-use std::os::raw::c_int;
 
 pub(super) extern "C" fn ns_undefined0(_closure: *const ClosureHeader) -> f64 {
     f64::from_bits(TAG_UNDEFINED)

--- a/crates/perry-runtime/src/node_stream_json.rs
+++ b/crates/perry-runtime/src/node_stream_json.rs
@@ -2,7 +2,6 @@
 //! out of node_stream_readwrite.rs for the 2000-line file-size gate (#1987).
 //! Shares the parent module's constants, hidden-key accessors and state
 //! primitives via `use super::*`.
-#![allow(unused_imports)]
 use super::*;
 use crate::object::ObjectHeader;
 

--- a/crates/perry-runtime/src/node_stream_keys.rs
+++ b/crates/perry-runtime/src/node_stream_keys.rs
@@ -1,19 +1,7 @@
 //! node:stream — hidden-property key accessors (split out of node_stream.rs for the 2000-line
 //! file-size gate, #1987). Shares the parent module's constants, hidden-key
 //! accessors and state primitives via `use super::*`.
-#![allow(unused_imports)]
 use super::*;
-use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_f64, js_closure_get_capture_ptr,
-    js_closure_set_capture_f64, js_closure_set_capture_ptr, ClosureHeader,
-};
-use crate::object::{
-    js_object_alloc, js_object_alloc_with_shape, js_object_get_field,
-    js_object_get_field_by_name_f64, js_object_set_field, js_object_set_field_by_name,
-    ObjectHeader,
-};
-use crate::value::JSValue;
-use std::os::raw::c_int;
 
 #[inline]
 pub(super) fn hidden_chunks_key() -> *mut crate::string::StringHeader {

--- a/crates/perry-runtime/src/node_stream_pipeline.rs
+++ b/crates/perry-runtime/src/node_stream_pipeline.rs
@@ -1,18 +1,13 @@
 //! node:stream — pipeline() / stream.compose() data-flow engine (split out of node_stream.rs for the 2000-line
 //! file-size gate, #1987). Shares the parent module's constants, hidden-key
 //! accessors and state primitives via `use super::*`.
-#![allow(unused_imports)]
 use super::*;
 use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_f64, js_closure_get_capture_ptr,
-    js_closure_set_capture_f64, js_closure_set_capture_ptr, ClosureHeader,
+    js_closure_alloc, js_closure_get_capture_f64, js_closure_set_capture_f64, ClosureHeader,
 };
 use crate::object::{
-    js_object_alloc, js_object_alloc_with_shape, js_object_get_field,
-    js_object_get_field_by_name_f64, js_object_set_field, js_object_set_field_by_name,
-    ObjectHeader,
+    js_object_alloc, js_object_get_field_by_name_f64, js_object_set_field_by_name, ObjectHeader,
 };
-use crate::value::JSValue;
 use std::os::raw::c_int;
 
 #[derive(Clone, Copy)]

--- a/crates/perry-runtime/src/node_stream_readwrite.rs
+++ b/crates/perry-runtime/src/node_stream_readwrite.rs
@@ -1,17 +1,10 @@
 //! node:stream readable/writable state, split from node_stream.rs for #1987.
-#![allow(unused_imports)]
 use super::*;
-use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_f64, js_closure_get_capture_ptr,
-    js_closure_set_capture_f64, js_closure_set_capture_ptr, ClosureHeader,
-};
+use crate::closure::{js_closure_alloc, js_closure_set_capture_f64, js_closure_set_capture_ptr};
 use crate::object::{
-    js_object_alloc, js_object_alloc_with_shape, js_object_get_field,
-    js_object_get_field_by_name_f64, js_object_set_field, js_object_set_field_by_name,
-    ObjectHeader,
+    js_object_get_field, js_object_get_field_by_name_f64, js_object_set_field_by_name, ObjectHeader,
 };
 use crate::value::JSValue;
-use std::os::raw::c_int;
 
 /// Mark a stream as disturbed (it has been read from / resumed). Backs
 /// `Readable.isDisturbed(s)` (#1534).

--- a/crates/perry-runtime/src/object/class_meta_registry.rs
+++ b/crates/perry-runtime/src/object/class_meta_registry.rs
@@ -2,15 +2,7 @@
 //! `extends Error`, `Symbol.hasInstance` / `Symbol.toStringTag` hooks
 //! (split out of `object/mod.rs`, behavior-preserving).
 
-use super::*;
-
-use crate::arena::arena_alloc_gc;
-use crate::ArrayHeader;
-use crate::JSValue;
-use std::cell::{Cell, RefCell, UnsafeCell};
 use std::collections::HashMap;
-use std::ptr;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicU8, Ordering};
 use std::sync::RwLock;
 
 /// Global class registry mapping class_id -> parent_class_id for inheritance chain lookups

--- a/crates/perry-runtime/src/object/class_registry.rs
+++ b/crates/perry-runtime/src/object/class_registry.rs
@@ -49,17 +49,16 @@ mod state;
 
 // ── state.rs ────────────────────────────────────────────────────────────────
 pub(crate) use state::{
-    class_decl_prototype_object, class_decl_prototype_object_root_store,
-    class_decl_prototype_value, class_decl_prototype_value_for_instance_class,
-    class_delete_own_dynamic_prop, class_dynamic_prop_root_store, class_has_own_dynamic_prop,
-    class_id_for_decl_prototype_object, class_is_key_deleted, class_mark_key_deleted,
-    class_object_value_for_cid, class_object_value_root_store, class_own_enumerable_field_names,
-    class_own_static_field_value, class_parent_closure, class_parent_closure_root_store,
-    class_prototype_method_is_enumerable, class_prototype_method_set_enumerable,
-    class_prototype_method_value_cache_root_store, class_prototype_object_root_store,
-    global_object_prototype_bits, is_bound_native_method_closure_value,
-    is_non_constructable_builtin_function_value, parent_closure_in_chain,
-    throw_non_constructable_builtin_function,
+    class_decl_prototype_object, class_decl_prototype_value,
+    class_decl_prototype_value_for_instance_class, class_delete_own_dynamic_prop,
+    class_dynamic_prop_root_store, class_has_own_dynamic_prop, class_id_for_decl_prototype_object,
+    class_is_key_deleted, class_mark_key_deleted, class_object_value_for_cid,
+    class_object_value_root_store, class_own_enumerable_field_names, class_own_static_field_value,
+    class_parent_closure, class_parent_closure_root_store, class_prototype_method_is_enumerable,
+    class_prototype_method_set_enumerable, class_prototype_method_value_cache_root_store,
+    class_prototype_object_root_store, global_object_prototype_bits,
+    is_bound_native_method_closure_value, is_non_constructable_builtin_function_value,
+    parent_closure_in_chain, throw_non_constructable_builtin_function,
 };
 pub use state::{
     ClassVTable, VTableMethodEntry, CLASS_DECL_PROTOTYPE_OBJECTS, CLASS_DYNAMIC_PARENT_VALUE,
@@ -87,10 +86,10 @@ pub use class_meta::{
     js_text_encoding_stream_new, ANON_SHAPE_CLASS_IDS, CLASS_NAMES,
 };
 pub(crate) use class_meta::{
-    dispatch_diag_enabled, identify_global_builtin_constructor, report_dispatch_miss,
-    text_decoder_bool_option, text_encoding_stream_new_with_constructor,
-    validate_web_compression_stream_format, CLASS_ID_COMPRESSION_STREAM,
-    CLASS_ID_DECOMPRESSION_STREAM, CLASS_ID_TEXT_DECODER_STREAM, CLASS_ID_TEXT_ENCODER_STREAM,
+    identify_global_builtin_constructor, report_dispatch_miss, text_decoder_bool_option,
+    text_encoding_stream_new_with_constructor, validate_web_compression_stream_format,
+    CLASS_ID_COMPRESSION_STREAM, CLASS_ID_DECOMPRESSION_STREAM, CLASS_ID_TEXT_DECODER_STREAM,
+    CLASS_ID_TEXT_ENCODER_STREAM,
 };
 #[cfg(test)]
 pub(crate) use prototype_methods::CLASS_PROTOTYPE_FAST_GUARDS_INVALIDATED;
@@ -124,7 +123,6 @@ pub use construct::{
 // ── gc_roots.rs ─────────────────────────────────────────────────────────────
 pub(crate) use gc_roots::{
     new_class_side_table_root_scan_state, scan_class_side_table_roots_mut_step,
-    ClassSideTableRootScanState,
 };
 pub use gc_roots::{scan_class_side_table_roots, scan_class_side_table_roots_mut};
 #[cfg(test)]

--- a/crates/perry-runtime/src/object/class_registry/class_meta.rs
+++ b/crates/perry-runtime/src/object/class_registry/class_meta.rs
@@ -1,9 +1,5 @@
 use super::*;
-use crate::object::*;
-use crate::{ArrayHeader, JSValue};
-use std::cell::{Cell, RefCell, UnsafeCell};
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicU8, Ordering};
 use std::sync::RwLock;
 
 /// Register a class id so `js_value_typeof` can distinguish class refs

--- a/crates/perry-runtime/src/object/class_registry/construct.rs
+++ b/crates/perry-runtime/src/object/class_registry/construct.rs
@@ -1,10 +1,5 @@
 use super::*;
-use crate::object::*;
-use crate::{ArrayHeader, JSValue};
-use std::cell::{Cell, RefCell, UnsafeCell};
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicU8, Ordering};
-use std::sync::RwLock;
+use crate::JSValue;
 
 thread_local! {
     static CURRENT_NEW_TARGET: std::cell::Cell<u64> =

--- a/crates/perry-runtime/src/object/class_registry/dispatch.rs
+++ b/crates/perry-runtime/src/object/class_registry/dispatch.rs
@@ -1,10 +1,7 @@
 use super::*;
-use crate::object::*;
-use crate::{ArrayHeader, JSValue};
-use std::cell::{Cell, RefCell, UnsafeCell};
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicU8, Ordering};
-use std::sync::RwLock;
+use crate::JSValue;
+use std::cell::UnsafeCell;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 // ============================================================================
 // Per-callsite-keyed inline cache for vtable method dispatch.

--- a/crates/perry-runtime/src/object/class_registry/gc_roots.rs
+++ b/crates/perry-runtime/src/object/class_registry/gc_roots.rs
@@ -1,10 +1,4 @@
 use super::*;
-use crate::object::*;
-use crate::{ArrayHeader, JSValue};
-use std::cell::{Cell, RefCell, UnsafeCell};
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicU8, Ordering};
-use std::sync::RwLock;
 
 #[derive(Clone)]
 enum ClassSideTableRootSlot {

--- a/crates/perry-runtime/src/object/class_registry/parent_static.rs
+++ b/crates/perry-runtime/src/object/class_registry/parent_static.rs
@@ -1,10 +1,7 @@
 use super::*;
-use crate::object::*;
-use crate::{ArrayHeader, JSValue};
-use std::cell::{Cell, RefCell, UnsafeCell};
+use crate::JSValue;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicU8, Ordering};
-use std::sync::RwLock;
+use std::sync::atomic::Ordering;
 
 /// Register a class with its parent class ID in the global registry
 pub(crate) fn register_class(class_id: u32, parent_class_id: u32) {

--- a/crates/perry-runtime/src/object/class_registry/prototype_methods.rs
+++ b/crates/perry-runtime/src/object/class_registry/prototype_methods.rs
@@ -1,9 +1,5 @@
 use super::*;
-use crate::object::*;
-use crate::{ArrayHeader, JSValue};
-use std::cell::{Cell, RefCell, UnsafeCell};
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicU8, Ordering};
 use std::sync::RwLock;
 
 /// Register a static field value on a class so `Cls.field` (when `Cls` is

--- a/crates/perry-runtime/src/object/class_registry/prototype_objects.rs
+++ b/crates/perry-runtime/src/object/class_registry/prototype_objects.rs
@@ -1,10 +1,6 @@
 use super::*;
-use crate::object::*;
-use crate::{ArrayHeader, JSValue};
-use std::cell::{Cell, RefCell, UnsafeCell};
+use crate::JSValue;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicU8, Ordering};
-use std::sync::RwLock;
 
 pub(crate) fn ensure_function_prototype_object(
     func_value: f64,

--- a/crates/perry-runtime/src/object/class_registry/registration.rs
+++ b/crates/perry-runtime/src/object/class_registry/registration.rs
@@ -1,10 +1,6 @@
 use super::*;
-use crate::object::*;
-use crate::{ArrayHeader, JSValue};
-use std::cell::{Cell, RefCell, UnsafeCell};
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicU8, Ordering};
-use std::sync::RwLock;
+use std::sync::atomic::Ordering;
 
 /// Returns true if `class_id` corresponds to a registered class. Used by
 /// `js_value_typeof` (refs #618 / #420 followup) to distinguish a class

--- a/crates/perry-runtime/src/object/class_registry/state.rs
+++ b/crates/perry-runtime/src/object/class_registry/state.rs
@@ -1,9 +1,5 @@
 use super::*;
-use crate::object::*;
-use crate::{ArrayHeader, JSValue};
-use std::cell::{Cell, RefCell, UnsafeCell};
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicU8, Ordering};
 use std::sync::RwLock;
 
 thread_local! {

--- a/crates/perry-runtime/src/object/descriptor_state.rs
+++ b/crates/perry-runtime/src/object/descriptor_state.rs
@@ -3,15 +3,10 @@
 
 use super::*;
 
-use crate::arena::arena_alloc_gc;
 use crate::fast_hash::{new_fast_key_hash_map, FastKeyHashMap};
-use crate::ArrayHeader;
-use crate::JSValue;
-use std::cell::{Cell, RefCell, UnsafeCell};
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
-use std::ptr;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicU8, Ordering};
-use std::sync::RwLock;
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
 /// Per-property attribute flags set by `Object.defineProperty` / `Object.freeze` / `Object.seal`.
 /// Tracks the JS PropertyDescriptor attributes (writable, enumerable, configurable) for keys

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -138,9 +138,8 @@ pub(crate) use crypto_key::{
     CLASS_ID_BOXED_NUMBER, CLASS_ID_BOXED_STRING, CLASS_ID_BOXED_SYMBOL,
 };
 pub(crate) use enumeration::{
-    canonical_array_index, descriptor_marks_non_enumerable, ecma_own_key_order,
-    instance_private_key_hidden, is_internal_runtime_key, is_internal_runtime_key_bytes,
-    keys_contain_array_index,
+    canonical_array_index, ecma_own_key_order, instance_private_key_hidden,
+    is_internal_runtime_key, is_internal_runtime_key_bytes, keys_contain_array_index,
 };
 pub use enumeration::{
     js_for_in_keys_value, js_object_entries, js_object_entries_value, js_object_keys,

--- a/crates/perry-runtime/src/object/global_this.rs
+++ b/crates/perry-runtime/src/object/global_this.rs
@@ -22,13 +22,7 @@ mod proto_methods;
 mod typed_array;
 
 pub(crate) use array_error::{
-    array_proto_at_thunk, array_proto_join_thunk, array_prototype_concat_thunk,
-    array_prototype_pop_thunk, array_prototype_push_thunk, array_prototype_reverse_thunk,
-    array_prototype_shift_thunk, array_prototype_slice_thunk, array_prototype_sort_thunk,
-    array_prototype_splice_thunk, array_prototype_unshift_thunk, date_prototype_to_string_thunk,
-    error_prototype_to_string_thunk, function_prototype_apply_thunk, function_prototype_bind_thunk,
-    function_prototype_call_thunk, function_prototype_to_string_thunk, generic_array_like_to_vec,
-    global_this_clear_immediate_thunk, global_this_clear_interval_thunk,
+    generic_array_like_to_vec, global_this_clear_immediate_thunk, global_this_clear_interval_thunk,
     global_this_clear_timeout_thunk, global_this_queue_microtask_thunk,
     global_this_rest_array_values, global_this_set_immediate_thunk, global_this_set_interval_thunk,
     global_this_set_timeout_thunk, is_native_error_subclass_constructor,
@@ -66,9 +60,7 @@ pub(crate) use builtin_thunks::{
     global_this_is_finite_thunk, global_this_is_nan_thunk, global_this_number_thunk,
     global_this_object_thunk, global_this_parse_float_thunk, global_this_parse_int_thunk,
     global_this_string_thunk, global_this_structured_clone_thunk, global_this_unescape_thunk,
-    js_math_round_value, math_atan2_thunk, math_clz32_thunk, math_f16round_thunk, math_hypot_thunk,
-    math_imul_thunk, math_max_thunk, math_min_thunk, math_pow_thunk, math_random_thunk,
-    math_round_thunk, math_sign_thunk, proxy_revocable_thunk,
+    js_math_round_value, proxy_revocable_thunk,
 };
 pub use ctor_thunks::js_webcrypto_illegal_constructor;
 pub(crate) use ctor_thunks::{

--- a/crates/perry-runtime/src/object/global_this/bigint_promise.rs
+++ b/crates/perry-runtime/src/object/global_this/bigint_promise.rs
@@ -1,4 +1,3 @@
-use super::super::*;
 use super::*;
 
 fn nanbox_array_or_undef(arr: *mut crate::array::ArrayHeader) -> f64 {

--- a/crates/perry-runtime/src/object/global_this/builtin_thunks.rs
+++ b/crates/perry-runtime/src/object/global_this/builtin_thunks.rs
@@ -1,4 +1,3 @@
-use super::super::*;
 use super::*;
 
 pub(crate) extern "C" fn global_this_array_thunk(

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -9,10 +9,10 @@
 use crate::arena::arena_alloc_gc;
 use crate::ArrayHeader;
 use crate::JSValue;
-use std::cell::{Cell, RefCell, UnsafeCell};
+use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::ptr;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
 use std::sync::RwLock;
 
 /// Minimum number of inline field slots every object is allocated with, even
@@ -63,9 +63,7 @@ mod native_module;
 pub(crate) use native_module::class_instance_has_member;
 pub(crate) use native_module::class_ref_id;
 pub(crate) use native_module::install_native_module_vtable;
-pub(crate) use native_module::{
-    build_bound_method_closure, class_prototype_ref_id, SYMBOL_BOUND_METHOD_NAME,
-};
+pub(crate) use native_module::{class_prototype_ref_id, SYMBOL_BOUND_METHOD_NAME};
 mod native_module_crypto_key_object;
 mod native_module_crypto_random;
 mod native_module_dispatch;
@@ -164,16 +162,15 @@ pub use class_meta_registry::{
 };
 pub use descriptor_state::PERRY_CLASS_FIELD_INLINE_GUARD_DISABLED;
 pub(crate) use descriptor_state::{
-    accessor_descriptor_keys_for_obj, class_field_inline_guard_enabled,
-    class_instance_set_may_intercept, clear_accessor_descriptor, clear_property_attrs,
-    constructor_accessor_ever_installed, descriptors_in_use, disable_class_field_inline_guard,
-    get_accessor_descriptor, get_property_attrs, json_object_getter_value, mark_all_keys,
-    note_descriptor_target, object_has_descriptors, object_proto_descriptors_in_use,
+    accessor_descriptor_keys_for_obj, class_instance_set_may_intercept, clear_accessor_descriptor,
+    clear_property_attrs, constructor_accessor_ever_installed, descriptors_in_use,
+    disable_class_field_inline_guard, get_accessor_descriptor, get_property_attrs,
+    json_object_getter_value, mark_all_keys, object_has_descriptors,
     object_proto_may_intercept_key, plain_data_write_may_intercept,
     prune_dead_descriptor_owner_entries, reflect_getter_closure_bits, set_accessor_descriptor,
     set_builtin_accessor_descriptor, set_builtin_property_attrs, set_property_attrs,
     AccessorDescriptor, PropertyAttrs, ACCESSORS_IN_USE, ACCESSOR_DESCRIPTORS,
-    GLOBAL_DESCRIPTORS_IN_USE, PROPERTY_ATTRS_IN_USE, PROPERTY_DESCRIPTORS,
+    PROPERTY_ATTRS_IN_USE, PROPERTY_DESCRIPTORS,
 };
 pub use this_binding::{
     js_implicit_this_get, js_implicit_this_get_sloppy, js_implicit_this_set, js_new_target_get,
@@ -182,10 +179,10 @@ pub use this_binding::{
 };
 pub(crate) use this_binding::{
     scan_implicit_this_roots_mut, static_this_arm, static_this_arm_if_unarmed, static_this_disarm,
-    IMPLICIT_THIS, NEW_TARGET,
+    IMPLICIT_THIS,
 };
 pub use to_string_tag::js_object_to_string;
-pub(crate) use to_string_tag::{typed_array_to_string_tag_name, web_stream_to_string_tag};
+pub(crate) use to_string_tag::typed_array_to_string_tag_name;
 
 static HTTP_METHODS_CACHE: AtomicU64 = AtomicU64::new(0);
 static FS_CONSTANTS_CACHE: AtomicU64 = AtomicU64::new(0);

--- a/crates/perry-runtime/src/object/native_call_method/collection_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/collection_methods.rs
@@ -1,8 +1,4 @@
 use super::super::*;
-use super::disposal::*;
-use super::object_proto::*;
-use super::proto_dispatch::*;
-use super::typed_array::*;
 use super::*;
 
 /// Whether `method` is a backing-store collection method for a `class … extends

--- a/crates/perry-runtime/src/object/native_call_method/common_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/common_methods.rs
@@ -1,8 +1,6 @@
 use super::super::*;
-use super::disposal::*;
 use super::object_proto::*;
 use super::proto_dispatch::*;
-use super::typed_array::*;
 use super::*;
 
 pub(super) unsafe fn dispatch_common(

--- a/crates/perry-runtime/src/object/native_call_method/disposal.rs
+++ b/crates/perry-runtime/src/object/native_call_method/disposal.rs
@@ -1,7 +1,4 @@
 use super::super::*;
-use super::object_proto::*;
-use super::proto_dispatch::*;
-use super::typed_array::*;
 use super::*;
 
 /// #4795: resolve `obj[Symbol.dispose]` / `obj[Symbol.asyncDispose]` for the

--- a/crates/perry-runtime/src/object/native_call_method/handle_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/handle_methods.rs
@@ -1,7 +1,4 @@
 use super::super::*;
-use super::disposal::*;
-use super::object_proto::*;
-use super::proto_dispatch::*;
 use super::typed_array::*;
 use super::*;
 

--- a/crates/perry-runtime/src/object/native_call_method/object_proto.rs
+++ b/crates/perry-runtime/src/object/native_call_method/object_proto.rs
@@ -1,7 +1,4 @@
 use super::super::*;
-use super::disposal::*;
-use super::proto_dispatch::*;
-use super::typed_array::*;
 use super::*;
 
 pub(super) unsafe fn object_has_null_proto_flag(object: *const ObjectHeader) -> bool {

--- a/crates/perry-runtime/src/object/native_call_method/primitive_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/primitive_methods.rs
@@ -1,7 +1,4 @@
 use super::super::*;
-use super::disposal::*;
-use super::object_proto::*;
-use super::proto_dispatch::*;
 use super::typed_array::*;
 use super::*;
 

--- a/crates/perry-runtime/src/object/native_call_method/proto_dispatch.rs
+++ b/crates/perry-runtime/src/object/native_call_method/proto_dispatch.rs
@@ -1,7 +1,4 @@
 use super::super::*;
-use super::disposal::*;
-use super::object_proto::*;
-use super::typed_array::*;
 use super::*;
 
 /// #3716: a built-in *prototype method* read off its prototype and called *as

--- a/crates/perry-runtime/src/object/native_call_method/string_methods.rs
+++ b/crates/perry-runtime/src/object/native_call_method/string_methods.rs
@@ -1,8 +1,3 @@
-use super::super::*;
-use super::disposal::*;
-use super::object_proto::*;
-use super::proto_dispatch::*;
-use super::typed_array::*;
 use super::*;
 
 pub(super) unsafe fn dispatch_string(

--- a/crates/perry-runtime/src/object/native_call_method/typed_array.rs
+++ b/crates/perry-runtime/src/object/native_call_method/typed_array.rs
@@ -1,7 +1,3 @@
-use super::super::*;
-use super::disposal::*;
-use super::object_proto::*;
-use super::proto_dispatch::*;
 use super::*;
 
 /// Dispatch a `%TypedArray%` instance method on an already-resolved

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -9,7 +9,6 @@
 
 use super::*;
 use std::cell::{Cell, RefCell};
-use std::collections::VecDeque;
 use std::ptr::null_mut;
 use std::sync::atomic::{AtomicPtr, Ordering};
 
@@ -24,22 +23,21 @@ pub(crate) use callable_export_check::is_native_module_callable_export;
 pub(crate) use callable_exports::{
     bound_native_callable_export_value, bound_native_callable_module_and_method,
     bound_native_callable_value_arity, buffer_constructor_value,
-    builtin_closure_is_non_constructable, builtin_closure_is_non_constructable_value,
-    builtin_closure_length, fs_namespace_descriptor_getter_value,
-    fs_namespace_descriptor_setter_value, is_buffer_constructor_value, is_cluster_emitter_method,
-    module_cjs_cache_value, module_cjs_extensions_value, module_cjs_global_paths_value,
-    module_cjs_path_cache_value, native_string_value, set_bound_native_closure_name,
-    set_builtin_closure_length, set_builtin_closure_non_constructable,
-    sqlite_session_constructor_value, sqlite_statement_sync_constructor_value,
-    timers_promises_parent_namespace, util_debuglog_logger_value,
+    builtin_closure_is_non_constructable_value, builtin_closure_length,
+    fs_namespace_descriptor_getter_value, fs_namespace_descriptor_setter_value,
+    is_buffer_constructor_value, is_cluster_emitter_method, module_cjs_cache_value,
+    module_cjs_extensions_value, module_cjs_global_paths_value, module_cjs_path_cache_value,
+    native_string_value, set_bound_native_closure_name, set_builtin_closure_length,
+    set_builtin_closure_non_constructable, sqlite_session_constructor_value,
+    sqlite_statement_sync_constructor_value, timers_promises_parent_namespace,
     util_inspect_default_options_value, zlib_codes_object,
 };
 pub(crate) use constants::get_native_module_constant;
 pub(crate) use module_keys::{native_module_enumerable_keys, native_module_has_enumerable_key};
 pub(crate) use namespace_builders::{
-    create_cached_sub_namespace, create_fs_constants_object, create_sub_namespace,
-    http_global_agent_object, http_methods_array, http_status_codes_object,
-    https_global_agent_object, native_namespace_or_create,
+    create_cached_sub_namespace, create_sub_namespace, http_global_agent_object,
+    http_methods_array, http_status_codes_object, https_global_agent_object,
+    native_namespace_or_create,
 };
 pub(crate) use web_locks::{worker_threads_locks_value, WebLocksState};
 

--- a/crates/perry-runtime/src/object/native_module/callable_export_check.rs
+++ b/crates/perry-runtime/src/object/native_module/callable_export_check.rs
@@ -1,8 +1,4 @@
 use super::*;
-use std::cell::{Cell, RefCell};
-use std::collections::VecDeque;
-use std::ptr::null_mut;
-use std::sync::atomic::{AtomicPtr, Ordering};
 
 /// Whitelist of (module, property) pairs for which property-read should
 /// produce a callable handle (a bound-method closure) rather than undefined.

--- a/crates/perry-runtime/src/object/native_module/callable_exports.rs
+++ b/crates/perry-runtime/src/object/native_module/callable_exports.rs
@@ -1,8 +1,5 @@
 use super::*;
-use std::cell::{Cell, RefCell};
-use std::collections::VecDeque;
-use std::ptr::null_mut;
-use std::sync::atomic::{AtomicPtr, Ordering};
+use std::cell::Cell;
 
 pub(crate) fn bound_native_callable_export_value(module_name: &str, property_name: &str) -> f64 {
     // Bound-native closures carry (module, method) metadata that the

--- a/crates/perry-runtime/src/object/native_module/constants.rs
+++ b/crates/perry-runtime/src/object/native_module/constants.rs
@@ -1,8 +1,5 @@
 use super::*;
-use std::cell::{Cell, RefCell};
-use std::collections::VecDeque;
-use std::ptr::null_mut;
-use std::sync::atomic::{AtomicPtr, Ordering};
+use std::sync::atomic::Ordering;
 
 // #6667: `node:crypto` export surface. Node 22–26 enumerate 70 own keys on the
 // CJS namespace (`Object.keys(require("crypto")).length === 70`); order matches

--- a/crates/perry-runtime/src/object/native_module/module_keys.rs
+++ b/crates/perry-runtime/src/object/native_module/module_keys.rs
@@ -1,8 +1,4 @@
 use super::*;
-use std::cell::{Cell, RefCell};
-use std::collections::VecDeque;
-use std::ptr::null_mut;
-use std::sync::atomic::{AtomicPtr, Ordering};
 
 // #3677: `Object.keys(zlib.constants)` enumeration. Node exposes the full
 // Z_*/BROTLI_*/ZSTD_* table as enumerable own keys (170 keys). Every key here

--- a/crates/perry-runtime/src/object/native_module/namespace_builders.rs
+++ b/crates/perry-runtime/src/object/native_module/namespace_builders.rs
@@ -1,8 +1,5 @@
 use super::*;
-use std::cell::{Cell, RefCell};
-use std::collections::VecDeque;
-use std::ptr::null_mut;
-use std::sync::atomic::{AtomicPtr, Ordering};
+use std::sync::atomic::Ordering;
 /// Create a NativeModuleRef sub-namespace (e.g. "fs.constants", "path.posix").
 /// The compiled code treats the result as another NativeModuleRef, so chained
 /// property accesses like `fs.constants.O_RDONLY` work through the dispatch table.

--- a/crates/perry-runtime/src/object/native_module/web_locks.rs
+++ b/crates/perry-runtime/src/object/native_module/web_locks.rs
@@ -1,8 +1,6 @@
 use super::*;
-use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
 use std::ptr::null_mut;
-use std::sync::atomic::{AtomicPtr, Ordering};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub(crate) enum WebLockMode {

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -34,7 +34,7 @@ pub use prototype::{
 
 // Internal `pub(crate)` helpers shared between siblings / the rest of the crate.
 pub(crate) use descriptor_helpers::{
-    closure_ptr_from_value, define_property_force_store_value, desc_has_field, desc_read_field,
+    define_property_force_store_value, desc_has_field, desc_read_field,
     describe_value_for_type_error, descriptor_enumerable, enforce_define_property_invariants,
     registered_buffer_index_own_property_present, throw_object_type_error,
     throw_object_type_error_with_suffix, validate_nonconfigurable_redefine,
@@ -44,7 +44,6 @@ pub(crate) use descriptor_helpers::{
 // object_ops children (`accessors.rs`, `descriptor_helpers.rs`) but NOT
 // re-exported, so `crate::object::value_is_callable` resolves uniquely to the
 // `instanceof.rs` definition (preserves the pre-split resolution).
-use descriptor_helpers::value_is_callable;
 pub(crate) use keys_array::{ensure_key_in_keys_array, install_builtin_getter, own_key_present};
 
 /// Helper: extract object pointer from NaN-boxed f64. Returns null on failure.

--- a/crates/perry-runtime/src/object/object_ops/define_properties.rs
+++ b/crates/perry-runtime/src/object/object_ops/define_properties.rs
@@ -1,5 +1,4 @@
 //! `Object.defineProperties` and `Object.setPrototypeOf`.
-use super::super::*;
 use super::*;
 
 /// `Object.defineProperties(target, descriptors)` — iterate the descriptor

--- a/crates/perry-runtime/src/object/this_binding.rs
+++ b/crates/perry-runtime/src/object/this_binding.rs
@@ -3,14 +3,7 @@
 
 use super::*;
 
-use crate::arena::arena_alloc_gc;
-use crate::ArrayHeader;
-use crate::JSValue;
-use std::cell::{Cell, RefCell, UnsafeCell};
-use std::collections::HashMap;
-use std::ptr;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicU8, Ordering};
-use std::sync::RwLock;
+use std::cell::Cell;
 
 // Implicit `this` for closure-typed class fields invoked method-style.
 //

--- a/crates/perry-runtime/src/object/to_string_tag.rs
+++ b/crates/perry-runtime/src/object/to_string_tag.rs
@@ -3,15 +3,6 @@
 
 use super::*;
 
-use crate::arena::arena_alloc_gc;
-use crate::ArrayHeader;
-use crate::JSValue;
-use std::cell::{Cell, RefCell, UnsafeCell};
-use std::collections::HashMap;
-use std::ptr;
-use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, AtomicU8, Ordering};
-use std::sync::RwLock;
-
 pub(crate) fn web_stream_to_string_tag(value: f64) -> Option<&'static str> {
     if !value.is_finite() || value <= 0.0 || value.fract() != 0.0 {
         return None;

--- a/crates/perry-runtime/src/process.rs
+++ b/crates/perry-runtime/src/process.rs
@@ -6,9 +6,6 @@
 //! and static state, the metadata-property dispatcher, and the re-exports that
 //! preserve the existing `crate::process::*` call paths.
 
-use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_f64, js_closure_set_capture_f64, ClosureHeader,
-};
 use crate::string::{js_string_from_bytes, StringHeader};
 use crate::value::JSValue;
 use std::cell::{Cell, RefCell};

--- a/crates/perry-runtime/src/process/env_misc.rs
+++ b/crates/perry-runtime/src/process/env_misc.rs
@@ -12,7 +12,6 @@ use crate::closure::{
 };
 use crate::string::{js_string_from_bytes, StringHeader};
 use crate::value::JSValue;
-use std::cell::{Cell, RefCell};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 static PROCESS_UNCAUGHT_CAPTURE_CALLBACK_SET: AtomicBool = AtomicBool::new(false);

--- a/crates/perry-runtime/src/process/finalization.rs
+++ b/crates/perry-runtime/src/process/finalization.rs
@@ -3,13 +3,6 @@
 //! of the `process` trunk. Pure code move — no behavior change.
 
 use super::*;
-use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_f64, js_closure_set_capture_f64, ClosureHeader,
-};
-use crate::string::{js_string_from_bytes, StringHeader};
-use crate::value::JSValue;
-use std::cell::{Cell, RefCell};
-use std::sync::atomic::{AtomicBool, Ordering};
 
 extern "C" fn process_finalization_before_exit_listener(
     _closure: *const crate::closure::ClosureHeader,

--- a/crates/perry-runtime/src/process/node_module.rs
+++ b/crates/perry-runtime/src/process/node_module.rs
@@ -9,10 +9,10 @@ use super::*;
 use crate::closure::{
     js_closure_alloc, js_closure_get_capture_f64, js_closure_set_capture_f64, ClosureHeader,
 };
-use crate::string::{js_string_from_bytes, StringHeader};
+use crate::string::js_string_from_bytes;
 use crate::value::JSValue;
-use std::cell::{Cell, RefCell};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::cell::Cell;
+use std::sync::atomic::Ordering;
 
 pub fn scan_process_module_loader_roots_mut(visitor: &mut crate::gc::RuntimeRootVisitor<'_>) {
     MODULE_LOADER_HOOKS.with(|hooks| {

--- a/crates/perry-runtime/src/process/permission.rs
+++ b/crates/perry-runtime/src/process/permission.rs
@@ -3,13 +3,7 @@
 //! move — no behavior change.
 
 use super::*;
-use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_f64, js_closure_set_capture_f64, ClosureHeader,
-};
-use crate::string::{js_string_from_bytes, StringHeader};
 use crate::value::JSValue;
-use std::cell::{Cell, RefCell};
-use std::sync::atomic::{AtomicBool, Ordering};
 
 pub(crate) fn process_permission_enabled() -> bool {
     let mut enabled = false;

--- a/crates/perry-runtime/src/process/report.rs
+++ b/crates/perry-runtime/src/process/report.rs
@@ -4,13 +4,7 @@
 //! `process` trunk. Pure code move — no behavior change.
 
 use super::*;
-use crate::closure::{
-    js_closure_alloc, js_closure_get_capture_f64, js_closure_set_capture_f64, ClosureHeader,
-};
-use crate::string::{js_string_from_bytes, StringHeader};
 use crate::value::JSValue;
-use std::cell::{Cell, RefCell};
-use std::sync::atomic::{AtomicBool, Ordering};
 
 pub(crate) fn process_release_value() -> f64 {
     let obj = crate::object::js_object_alloc(0, 3);

--- a/crates/perry-runtime/src/promise/then.rs
+++ b/crates/perry-runtime/src/promise/then.rs
@@ -1420,7 +1420,6 @@ pub(crate) extern "C" fn promise_prototype_finally_thunk(
 
     // SpeciesConstructor(receiver, %Promise%).
     let c = promise_species_constructor(receiver);
-    let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
 
     let (then_finally, catch_finally) = if !super::spec_combinators::is_callable_value(on_finally) {
         // Not callable: pass on_finally as both args (§27.2.5.3 step 5).

--- a/crates/perry-runtime/src/proxy/reflect_misc.rs
+++ b/crates/perry-runtime/src/proxy/reflect_misc.rs
@@ -3,8 +3,6 @@
 //! recipe). Pure relocation; `use super::*` preserves visibility of the
 //! parent's private registry helpers.
 
-#![allow(unused_imports)]
-
 use super::*;
 
 pub(super) fn array_from_args(args: &[f64]) -> f64 {

--- a/crates/perry-runtime/src/regex/exec.rs
+++ b/crates/perry-runtime/src/regex/exec.rs
@@ -1,20 +1,12 @@
 use super::*;
 
-#[cfg(feature = "regex-engine")]
-use regex::Regex;
-use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
 use std::ptr;
-#[cfg(feature = "regex-engine")]
-use std::sync::Arc;
 
 #[cfg(feature = "regex-engine")]
 use crate::array::ArrayHeader;
 use crate::string::StringHeader;
 #[cfg(feature = "regex-engine")]
 use crate::value::js_nanbox_string;
-
-use crate::object::ObjectHeader;
 
 /// regex.exec(string) -> match array (like string.match) with thread-local index/groups
 /// For global regexes, starts matching at lastIndex and updates it.

--- a/crates/perry-runtime/src/regex/match_string.rs
+++ b/crates/perry-runtime/src/regex/match_string.rs
@@ -1,20 +1,12 @@
 use super::*;
 
-#[cfg(feature = "regex-engine")]
-use regex::Regex;
-use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
 use std::ptr;
-#[cfg(feature = "regex-engine")]
-use std::sync::Arc;
 
 #[cfg(feature = "regex-engine")]
 use crate::array::ArrayHeader;
 use crate::string::StringHeader;
 #[cfg(feature = "regex-engine")]
 use crate::value::js_nanbox_string;
-
-use crate::object::ObjectHeader;
 
 /// Coerce a `String.prototype.search`/`match` argument into a RegExp
 /// (ECMA-262 §22.1.3.12 / §22.1.3.20 → `RegExpCreate`). A RegExp value passes

--- a/crates/perry-runtime/src/symbol.rs
+++ b/crates/perry-runtime/src/symbol.rs
@@ -75,7 +75,7 @@ pub(crate) use gc_roots::{
     test_symbol_property_root_bits, test_symbol_property_roots,
 };
 
-use crate::string::{js_string_from_bytes, StringHeader};
+use crate::string::StringHeader;
 use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 

--- a/crates/perry-runtime/src/symbol/constructors.rs
+++ b/crates/perry-runtime/src/symbol/constructors.rs
@@ -4,8 +4,7 @@
 
 use super::*;
 use crate::string::{js_string_from_bytes, StringHeader};
-use std::collections::{HashMap, HashSet};
-use std::sync::Mutex;
+use std::collections::HashMap;
 
 /// `Symbol()` with no description — allocates a fresh unique symbol.
 #[no_mangle]

--- a/crates/perry-runtime/src/symbol/gc_roots.rs
+++ b/crates/perry-runtime/src/symbol/gc_roots.rs
@@ -4,9 +4,6 @@
 //! `#[cfg(test)]` seed/inspect helpers.
 
 use super::*;
-use crate::string::{js_string_from_bytes, StringHeader};
-use std::collections::{HashMap, HashSet};
-use std::sync::Mutex;
 
 pub(crate) fn merge_symbol_property_entries(dst: &mut Vec<(usize, u64)>, src: Vec<(usize, u64)>) {
     for (sym_key, value_bits) in src {

--- a/crates/perry-runtime/src/symbol/get.rs
+++ b/crates/perry-runtime/src/symbol/get.rs
@@ -2,9 +2,7 @@
 //! and its prototype-chain / well-known-symbol / handle helpers.
 
 use super::*;
-use crate::string::{js_string_from_bytes, StringHeader};
-use std::collections::{HashMap, HashSet};
-use std::sync::Mutex;
+use crate::string::js_string_from_bytes;
 
 /// #5128: map a well-known-symbol key to the synthetic class-method name used
 /// for a symbol-keyed instance *method* (`*[Symbol.iterator]()` →

--- a/crates/perry-runtime/src/symbol/iterator.rs
+++ b/crates/perry-runtime/src/symbol/iterator.rs
@@ -4,8 +4,6 @@
 
 use super::*;
 use crate::string::{js_string_from_bytes, StringHeader};
-use std::collections::{HashMap, HashSet};
-use std::sync::Mutex;
 
 /// `Object.getOwnPropertySymbols(obj)` — returns an array of symbol keys on
 /// the object. Looks up the side table populated by

--- a/crates/perry-runtime/src/symbol/properties.rs
+++ b/crates/perry-runtime/src/symbol/properties.rs
@@ -4,8 +4,7 @@
 
 use super::*;
 use crate::string::{js_string_from_bytes, StringHeader};
-use std::collections::{HashMap, HashSet};
-use std::sync::Mutex;
+use std::collections::HashMap;
 
 /// Look up the cached pointer for the registered `util.inspect.custom` symbol
 /// (description `"nodejs.util.inspect.custom"`). Returns 0 if the symbol has

--- a/crates/perry-runtime/src/temporal/plain_date_time.rs
+++ b/crates/perry-runtime/src/temporal/plain_date_time.rs
@@ -6,9 +6,7 @@
 use super::dispatch::{
     self, boolean, field_u16, field_u8, ok_or_throw, raw_arg, string, undefined,
 };
-use super::{
-    alloc_temporal_cell, temporal_value_ref, temporal_value_ref_or_subclass, TemporalValue,
-};
+use super::{alloc_temporal_cell, temporal_value_ref_or_subclass, TemporalValue};
 use crate::value::JSValue;
 use temporal_rs::{Calendar, PlainDateTime};
 

--- a/crates/perry-runtime/src/temporal/plain_time.rs
+++ b/crates/perry-runtime/src/temporal/plain_time.rs
@@ -4,9 +4,7 @@
 //! the plain types.
 
 use super::dispatch::{self, field_u16, field_u8, ok_or_throw, raw_arg, string};
-use super::{
-    alloc_temporal_cell, temporal_value_ref, temporal_value_ref_or_subclass, TemporalValue,
-};
+use super::{alloc_temporal_cell, temporal_value_ref_or_subclass, TemporalValue};
 use crate::value::JSValue;
 use temporal_rs::options::ToStringRoundingOptions;
 use temporal_rs::PlainTime;

--- a/crates/perry-runtime/src/temporal/plain_year_month.rs
+++ b/crates/perry-runtime/src/temporal/plain_year_month.rs
@@ -3,9 +3,7 @@
 //! A calendar year + month (e.g. a billing period), no day/time/timezone.
 
 use super::dispatch::{self, boolean, ok_or_throw, raw_arg, string, undefined};
-use super::{
-    alloc_temporal_cell, temporal_value_ref, temporal_value_ref_or_subclass, TemporalValue,
-};
+use super::{alloc_temporal_cell, temporal_value_ref_or_subclass, TemporalValue};
 use crate::value::JSValue;
 use temporal_rs::PlainYearMonth;
 

--- a/crates/perry-runtime/src/typedarray/access.rs
+++ b/crates/perry-runtime/src/typedarray/access.rs
@@ -4,14 +4,7 @@
 
 use super::*;
 
-use std::alloc::{alloc, Layout};
-use std::cell::RefCell;
-use std::ptr;
-use std::sync::atomic::{AtomicU64, Ordering};
-
 use crate::array::ArrayHeader;
-use crate::closure::ClosureHeader;
-use crate::typedarray_half::{f16_bits_to_f64, f64_to_f16_bits};
 
 /// Element count.
 #[no_mangle]

--- a/crates/perry-runtime/src/typedarray/construct.rs
+++ b/crates/perry-runtime/src/typedarray/construct.rs
@@ -4,14 +4,9 @@
 
 use super::*;
 
-use std::alloc::{alloc, Layout};
-use std::cell::RefCell;
 use std::ptr;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::array::ArrayHeader;
-use crate::closure::ClosureHeader;
-use crate::typedarray_half::{f16_bits_to_f64, f64_to_f16_bits};
 
 /// Allocate a typed array of `length` elements, all zero.
 #[no_mangle]

--- a/crates/perry-runtime/src/typedarray/iterate.rs
+++ b/crates/perry-runtime/src/typedarray/iterate.rs
@@ -3,14 +3,7 @@
 
 use super::*;
 
-use std::alloc::{alloc, Layout};
-use std::cell::RefCell;
-use std::ptr;
-use std::sync::atomic::{AtomicU64, Ordering};
-
-use crate::array::ArrayHeader;
 use crate::closure::ClosureHeader;
-use crate::typedarray_half::{f16_bits_to_f64, f64_to_f16_bits};
 
 // %TypedArray%.prototype iteration methods. The generic `js_array_*` helpers
 // detect a TypedArray receiver via `lookup_typed_array_kind` and delegate

--- a/crates/perry-runtime/src/typedarray/mod.rs
+++ b/crates/perry-runtime/src/typedarray/mod.rs
@@ -14,8 +14,6 @@ use std::cell::RefCell;
 use std::ptr;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use crate::array::ArrayHeader;
-use crate::closure::ClosureHeader;
 use crate::typedarray_half::{f16_bits_to_f64, f64_to_f16_bits};
 
 pub(crate) mod bigint;

--- a/crates/perry-runtime/src/typedarray/slice_ops.rs
+++ b/crates/perry-runtime/src/typedarray/slice_ops.rs
@@ -3,14 +3,7 @@
 
 use super::*;
 
-use std::alloc::{alloc, Layout};
-use std::cell::RefCell;
 use std::ptr;
-use std::sync::atomic::{AtomicU64, Ordering};
-
-use crate::array::ArrayHeader;
-use crate::closure::ClosureHeader;
-use crate::typedarray_half::{f16_bits_to_f64, f64_to_f16_bits};
 
 // #3148: %TypedArray%.prototype join / slice / reverse / fill / subarray.
 // (reduce/reduceRight/copyWithin/set_from/findIndex live elsewhere — added separately.)

--- a/crates/perry-runtime/src/typedarray/transform.rs
+++ b/crates/perry-runtime/src/typedarray/transform.rs
@@ -4,14 +4,9 @@
 
 use super::*;
 
-use std::alloc::{alloc, Layout};
-use std::cell::RefCell;
 use std::ptr;
-use std::sync::atomic::{AtomicU64, Ordering};
 
-use crate::array::ArrayHeader;
 use crate::closure::ClosureHeader;
-use crate::typedarray_half::{f16_bits_to_f64, f64_to_f16_bits};
 
 /// Materialize a typed array as a regular Array of f64s. Each element is
 /// loaded via the per-kind accessor (`load_at`) so `Uint8Array([10,20,30,40])`

--- a/crates/perry-runtime/src/url/node_compat.rs
+++ b/crates/perry-runtime/src/url/node_compat.rs
@@ -4,7 +4,7 @@
 
 use super::*;
 
-use super::parse::{create_url_object, is_valid_absolute_url, parse_url, resolve_url};
+use super::parse::{create_url_object, is_valid_absolute_url, resolve_url};
 use super::search_params::url_decode;
 
 const QUERYSTRING_ESCAPE_HEX: &[u8; 16] = b"0123456789ABCDEF";

--- a/crates/perry-stdlib/src/common/dispatch.rs
+++ b/crates/perry-stdlib/src/common/dispatch.rs
@@ -5,8 +5,6 @@
 //! the codegen can't statically determine the type. This module provides
 //! runtime dispatch by checking the handle type in the registry.
 
-use super::handle::*;
-
 mod emitter_als;
 mod fastify_net_zlib;
 mod init;

--- a/crates/perry-stdlib/src/common/dispatch/fastify_net_zlib.rs
+++ b/crates/perry-stdlib/src/common/dispatch/fastify_net_zlib.rs
@@ -1,6 +1,3 @@
-use super::super::handle::*;
-use super::*;
-
 /// Dispatch method calls on net.Socket handles when codegen couldn't tag
 /// the receiver type. Mirrors the static NATIVE_MODULE_TABLE entries for
 /// the same methods (write/end/destroy/on/upgradeToTLS).

--- a/crates/perry-stdlib/src/common/dispatch/init.rs
+++ b/crates/perry-stdlib/src/common/dispatch/init.rs
@@ -1,4 +1,3 @@
-use super::super::handle::*;
 use super::*;
 
 /// Dispatch property set on a handle-based object.

--- a/crates/perry-stdlib/src/common/dispatch/sqlite.rs
+++ b/crates/perry-stdlib/src/common/dispatch/sqlite.rs
@@ -1,6 +1,3 @@
-use super::super::handle::*;
-use super::*;
-
 /// Dispatch method calls on SQLite Statement handles. Routes the
 /// dynamic-receiver chain `this.stmt.raw().all(...params)` (drizzle's
 /// PreparedQuery.values()) and similar shapes where the codegen

--- a/crates/perry-stdlib/src/crypto.rs
+++ b/crates/perry-stdlib/src/crypto.rs
@@ -22,12 +22,8 @@ mod sign;
 pub(crate) mod util;
 mod x509;
 
-#[allow(unused_imports)]
 // Private imports keep sibling modules able to share `pub(super)` helpers.
-use self::{
-    certificate::*, cipher::*, ecdh::*, handles::*, hash::*, hash_handles::*, kdf::*, keys::*,
-    prime::*, random::*, sign::*, util::*, x509::*,
-};
+use self::{cipher::*, kdf::*, keys::*, random::*, util::*, x509::*};
 
 // Public re-exports preserve the parent module surface for FFI entry points.
 pub use self::{

--- a/crates/perry-stdlib/src/events.rs
+++ b/crates/perry-stdlib/src/events.rs
@@ -21,9 +21,9 @@
 
 use perry_runtime::{
     js_array_alloc, js_array_length, js_array_push_f64, js_closure_call0, js_closure_call1,
-    js_closure_call2, js_nanbox_get_pointer, js_nanbox_pointer, js_nanbox_string, js_object_alloc,
-    js_object_get_field_by_name_f64, js_promise_new, js_promise_reject, js_promise_resolve,
-    js_string_from_bytes, ArrayHeader, ClosureHeader, JSValue, ObjectHeader, Promise, StringHeader,
+    js_closure_call2, js_nanbox_get_pointer, js_nanbox_pointer, js_nanbox_string,
+    js_object_get_field_by_name_f64, js_promise_reject, js_promise_resolve, js_string_from_bytes,
+    ArrayHeader, ClosureHeader, JSValue, ObjectHeader, Promise, StringHeader,
 };
 use std::collections::{HashMap, HashSet};
 

--- a/crates/perry-stdlib/src/events/events_on.rs
+++ b/crates/perry-stdlib/src/events/events_on.rs
@@ -8,14 +8,12 @@ use super::handle_probes::stream_value_from_handle;
 use super::*;
 
 use perry_runtime::{
-    js_array_alloc, js_array_length, js_array_push_f64, js_closure_call0, js_closure_call1,
-    js_closure_call2, js_nanbox_get_pointer, js_nanbox_pointer, js_nanbox_string, js_object_alloc,
-    js_object_get_field_by_name_f64, js_promise_new, js_promise_reject, js_promise_resolve,
-    js_string_from_bytes, ArrayHeader, ClosureHeader, JSValue, ObjectHeader, Promise, StringHeader,
+    js_array_alloc, js_array_length, js_array_push_f64, js_nanbox_get_pointer, js_nanbox_pointer,
+    js_nanbox_string, js_promise_new, js_promise_reject, js_promise_resolve, ArrayHeader,
+    ClosureHeader, JSValue, ObjectHeader, Promise, StringHeader,
 };
-use std::collections::{HashMap, HashSet};
 
-use crate::common::{for_each_handle_mut_of, get_handle, get_handle_mut, Handle};
+use crate::common::{get_handle_mut, Handle};
 
 // `events.on(...)` async-iterator state. Node's `on()` returns an async
 // iterator that buffers emitted events and blocks `next()` until one arrives.

--- a/crates/perry-stdlib/src/events/module_helpers.rs
+++ b/crates/perry-stdlib/src/events/module_helpers.rs
@@ -8,14 +8,11 @@
 use super::*;
 
 use perry_runtime::{
-    js_array_alloc, js_array_length, js_array_push_f64, js_closure_call0, js_closure_call1,
-    js_closure_call2, js_nanbox_get_pointer, js_nanbox_pointer, js_nanbox_string, js_object_alloc,
-    js_object_get_field_by_name_f64, js_promise_new, js_promise_reject, js_promise_resolve,
-    js_string_from_bytes, ArrayHeader, ClosureHeader, JSValue, ObjectHeader, Promise, StringHeader,
+    js_array_alloc, js_array_length, js_nanbox_pointer, js_nanbox_string, js_object_alloc,
+    js_string_from_bytes, ArrayHeader, ClosureHeader, StringHeader,
 };
-use std::collections::{HashMap, HashSet};
 
-use crate::common::{for_each_handle_mut_of, get_handle, get_handle_mut, Handle};
+use crate::common::get_handle_mut;
 
 extern "C" fn events_abort_listener_dispose(closure: *const ClosureHeader) -> f64 {
     use perry_runtime::closure::js_closure_get_capture_ptr;

--- a/crates/perry-stdlib/src/events/once_helpers.rs
+++ b/crates/perry-stdlib/src/events/once_helpers.rs
@@ -5,14 +5,12 @@
 use super::*;
 
 use perry_runtime::{
-    js_array_alloc, js_array_length, js_array_push_f64, js_closure_call0, js_closure_call1,
-    js_closure_call2, js_nanbox_get_pointer, js_nanbox_pointer, js_nanbox_string, js_object_alloc,
-    js_object_get_field_by_name_f64, js_promise_new, js_promise_reject, js_promise_resolve,
-    js_string_from_bytes, ArrayHeader, ClosureHeader, JSValue, ObjectHeader, Promise, StringHeader,
+    js_array_alloc, js_array_length, js_array_push_f64, js_nanbox_get_pointer, js_nanbox_pointer,
+    js_nanbox_string, js_promise_new, js_promise_reject, js_promise_resolve, js_string_from_bytes,
+    ArrayHeader, ClosureHeader, JSValue, ObjectHeader, Promise, StringHeader,
 };
-use std::collections::{HashMap, HashSet};
 
-use crate::common::{for_each_handle_mut_of, get_handle, get_handle_mut, Handle};
+use crate::common::{get_handle_mut, Handle};
 
 extern "C" fn events_once_abort_listener(closure: *const ClosureHeader) -> f64 {
     use perry_runtime::closure::js_closure_get_capture_ptr;

--- a/crates/perry-stdlib/src/framework/multipart.rs
+++ b/crates/perry-stdlib/src/framework/multipart.rs
@@ -348,7 +348,7 @@ mod tests {
 
     #[test]
     fn test_parse_multipart_with_file() {
-        let boundary = "boundary456";
+        let _boundary = "boundary456";
         let file_content = vec![0u8, 1, 2, 3, 4, 5, 255, 254, 253];
         let mut body = Vec::new();
         body.extend_from_slice(b"--boundary456\r\n");

--- a/crates/perry-stdlib/src/sqlite.rs
+++ b/crates/perry-stdlib/src/sqlite.rs
@@ -3,27 +3,11 @@
 //! Native implementation of the 'better-sqlite3' npm package using rusqlite.
 //! Provides synchronous SQLite database operations.
 
-use crate::common::{for_each_handle_mut_of, get_handle, register_handle, Handle};
-use perry_runtime::{
-    buffer::{
-        buffer_alloc, buffer_data, buffer_data_mut, is_any_array_buffer, is_data_view,
-        is_registered_buffer, mark_as_uint8array, BufferHeader,
-    },
-    closure::{is_closure_ptr, js_closure_call1, js_closure_call_array, ClosureHeader},
-    js_array_alloc, js_array_get, js_array_is_array, js_array_length, js_array_push,
-    js_array_push_f64, js_get_string_pointer_unified, js_nanbox_pointer, js_object_alloc,
-    js_object_alloc_null_proto, js_object_alloc_with_shape, js_object_get_field_by_name,
-    js_object_set_field, js_object_set_field_by_name, js_object_set_keys, js_promise_rejected,
-    js_promise_resolved, js_string_from_bytes, ArrayHeader, BigIntHeader, JSValue, ObjectHeader,
-    Promise, StringHeader,
-};
-use rusqlite::{ffi, limits::Limit, types::Value as SqliteValue, Connection, OpenFlags};
+use crate::common::{for_each_handle_mut_of, Handle};
+use rusqlite::Connection;
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::ffi::{CStr, CString};
-use std::os::raw::{c_char, c_int, c_void};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::sync::{Mutex, Once, OnceLock};
-use std::time::Duration;
 
 mod backup;
 mod better;
@@ -39,7 +23,6 @@ mod options;
 // module namespace so existing intra-crate paths (`crate::sqlite::Foo`)
 // keep resolving and sibling modules reach one another via `use super::*`.
 pub(crate) use backup::*;
-pub(crate) use better::*;
 pub(crate) use bind::*;
 pub(crate) use connection::*;
 pub(crate) use dispatch::*;

--- a/crates/perry-stdlib/src/sqlite/backup.rs
+++ b/crates/perry-stdlib/src/sqlite/backup.rs
@@ -1,25 +1,13 @@
 use super::*;
-use crate::common::{for_each_handle_mut_of, get_handle, register_handle, Handle};
+use crate::common::{get_handle, Handle};
 use perry_runtime::{
-    buffer::{
-        buffer_alloc, buffer_data, buffer_data_mut, is_any_array_buffer, is_data_view,
-        is_registered_buffer, mark_as_uint8array, BufferHeader,
-    },
-    closure::{is_closure_ptr, js_closure_call1, js_closure_call_array, ClosureHeader},
-    js_array_alloc, js_array_get, js_array_is_array, js_array_length, js_array_push,
-    js_array_push_f64, js_get_string_pointer_unified, js_nanbox_pointer, js_object_alloc,
-    js_object_alloc_null_proto, js_object_alloc_with_shape, js_object_get_field_by_name,
-    js_object_set_field, js_object_set_field_by_name, js_object_set_keys, js_promise_rejected,
-    js_promise_resolved, js_string_from_bytes, ArrayHeader, BigIntHeader, JSValue, ObjectHeader,
-    Promise, StringHeader,
+    buffer::{buffer_data, is_registered_buffer, BufferHeader},
+    closure::{js_closure_call1, ClosureHeader},
+    js_get_string_pointer_unified, js_nanbox_pointer, js_object_alloc, js_object_set_field_by_name,
+    js_string_from_bytes, JSValue, ObjectHeader, StringHeader,
 };
-use rusqlite::{ffi, limits::Limit, types::Value as SqliteValue, Connection, OpenFlags};
-use std::collections::{HashMap, HashSet, VecDeque};
+use rusqlite::{ffi, Connection, OpenFlags};
 use std::ffi::{CStr, CString};
-use std::os::raw::{c_char, c_int, c_void};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Mutex, Once, OnceLock};
-use std::time::Duration;
 
 pub(crate) struct NodeSqliteBackupOptions {
     source: String,

--- a/crates/perry-stdlib/src/sqlite/better.rs
+++ b/crates/perry-stdlib/src/sqlite/better.rs
@@ -1,25 +1,12 @@
 use super::*;
-use crate::common::{for_each_handle_mut_of, get_handle, register_handle, Handle};
+use crate::common::{get_handle, register_handle, Handle};
 use perry_runtime::{
-    buffer::{
-        buffer_alloc, buffer_data, buffer_data_mut, is_any_array_buffer, is_data_view,
-        is_registered_buffer, mark_as_uint8array, BufferHeader,
-    },
-    closure::{is_closure_ptr, js_closure_call1, js_closure_call_array, ClosureHeader},
-    js_array_alloc, js_array_get, js_array_is_array, js_array_length, js_array_push,
-    js_array_push_f64, js_get_string_pointer_unified, js_nanbox_pointer, js_object_alloc,
-    js_object_alloc_null_proto, js_object_alloc_with_shape, js_object_get_field_by_name,
-    js_object_set_field, js_object_set_field_by_name, js_object_set_keys, js_promise_rejected,
-    js_promise_resolved, js_string_from_bytes, ArrayHeader, BigIntHeader, JSValue, ObjectHeader,
-    Promise, StringHeader,
+    js_array_alloc, js_array_push, js_object_alloc_with_shape, js_object_set_field,
+    js_string_from_bytes, ArrayHeader, JSValue, ObjectHeader, StringHeader,
 };
-use rusqlite::{ffi, limits::Limit, types::Value as SqliteValue, Connection, OpenFlags};
-use std::collections::{HashMap, HashSet, VecDeque};
-use std::ffi::{CStr, CString};
-use std::os::raw::{c_char, c_int, c_void};
+use rusqlite::{types::Value as SqliteValue, Connection};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Mutex, Once, OnceLock};
-use std::time::Duration;
+use std::sync::Mutex;
 
 /// new Database(filename) -> Database
 ///

--- a/crates/perry-stdlib/src/sqlite/bind.rs
+++ b/crates/perry-stdlib/src/sqlite/bind.rs
@@ -1,25 +1,21 @@
 use super::*;
-use crate::common::{for_each_handle_mut_of, get_handle, register_handle, Handle};
+use crate::common::{get_handle, Handle};
 use perry_runtime::{
     buffer::{
         buffer_alloc, buffer_data, buffer_data_mut, is_any_array_buffer, is_data_view,
         is_registered_buffer, mark_as_uint8array, BufferHeader,
     },
-    closure::{is_closure_ptr, js_closure_call1, js_closure_call_array, ClosureHeader},
-    js_array_alloc, js_array_get, js_array_is_array, js_array_length, js_array_push,
-    js_array_push_f64, js_get_string_pointer_unified, js_nanbox_pointer, js_object_alloc,
-    js_object_alloc_null_proto, js_object_alloc_with_shape, js_object_get_field_by_name,
-    js_object_set_field, js_object_set_field_by_name, js_object_set_keys, js_promise_rejected,
-    js_promise_resolved, js_string_from_bytes, ArrayHeader, BigIntHeader, JSValue, ObjectHeader,
-    Promise, StringHeader,
+    closure::js_closure_call_array,
+    js_array_alloc, js_array_get, js_array_length, js_array_push, js_get_string_pointer_unified,
+    js_object_alloc_null_proto, js_object_get_field_by_name, js_object_set_field,
+    js_object_set_keys, js_string_from_bytes, ArrayHeader, BigIntHeader, JSValue, ObjectHeader,
+    StringHeader,
 };
-use rusqlite::{ffi, limits::Limit, types::Value as SqliteValue, Connection, OpenFlags};
-use std::collections::{HashMap, HashSet, VecDeque};
+use rusqlite::{ffi, types::Value as SqliteValue, Connection};
+use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int, c_void};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Mutex, Once, OnceLock};
-use std::time::Duration;
+use std::sync::atomic::Ordering;
 
 /// Convert SQLite value to JSValue
 pub(crate) unsafe fn sqlite_value_to_jsvalue(value: &SqliteValue) -> JSValue {

--- a/crates/perry-stdlib/src/sqlite/connection.rs
+++ b/crates/perry-stdlib/src/sqlite/connection.rs
@@ -1,24 +1,8 @@
 use super::*;
-use crate::common::{for_each_handle_mut_of, get_handle, register_handle, Handle};
-use perry_runtime::{
-    buffer::{
-        buffer_alloc, buffer_data, buffer_data_mut, is_any_array_buffer, is_data_view,
-        is_registered_buffer, mark_as_uint8array, BufferHeader,
-    },
-    closure::{is_closure_ptr, js_closure_call1, js_closure_call_array, ClosureHeader},
-    js_array_alloc, js_array_get, js_array_is_array, js_array_length, js_array_push,
-    js_array_push_f64, js_get_string_pointer_unified, js_nanbox_pointer, js_object_alloc,
-    js_object_alloc_null_proto, js_object_alloc_with_shape, js_object_get_field_by_name,
-    js_object_set_field, js_object_set_field_by_name, js_object_set_keys, js_promise_rejected,
-    js_promise_resolved, js_string_from_bytes, ArrayHeader, BigIntHeader, JSValue, ObjectHeader,
-    Promise, StringHeader,
-};
-use rusqlite::{ffi, limits::Limit, types::Value as SqliteValue, Connection, OpenFlags};
-use std::collections::{HashMap, HashSet, VecDeque};
-use std::ffi::{CStr, CString};
-use std::os::raw::{c_char, c_int, c_void};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Mutex, Once, OnceLock};
+use crate::common::{get_handle, Handle};
+use rusqlite::{ffi, limits::Limit, Connection, OpenFlags};
+use std::ffi::CStr;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 pub(crate) fn open_node_sqlite_connection(db: &NodeSqliteDbHandle) -> rusqlite::Result<Connection> {

--- a/crates/perry-stdlib/src/sqlite/dispatch.rs
+++ b/crates/perry-stdlib/src/sqlite/dispatch.rs
@@ -1,25 +1,9 @@
 use super::*;
-use crate::common::{for_each_handle_mut_of, get_handle, register_handle, Handle};
+use crate::common::{get_handle, Handle};
 use perry_runtime::{
-    buffer::{
-        buffer_alloc, buffer_data, buffer_data_mut, is_any_array_buffer, is_data_view,
-        is_registered_buffer, mark_as_uint8array, BufferHeader,
-    },
-    closure::{is_closure_ptr, js_closure_call1, js_closure_call_array, ClosureHeader},
-    js_array_alloc, js_array_get, js_array_is_array, js_array_length, js_array_push,
-    js_array_push_f64, js_get_string_pointer_unified, js_nanbox_pointer, js_object_alloc,
-    js_object_alloc_null_proto, js_object_alloc_with_shape, js_object_get_field_by_name,
-    js_object_set_field, js_object_set_field_by_name, js_object_set_keys, js_promise_rejected,
-    js_promise_resolved, js_string_from_bytes, ArrayHeader, BigIntHeader, JSValue, ObjectHeader,
-    Promise, StringHeader,
+    closure::ClosureHeader, js_array_alloc, js_array_push_f64, js_nanbox_pointer,
+    js_string_from_bytes, ArrayHeader, JSValue,
 };
-use rusqlite::{ffi, limits::Limit, types::Value as SqliteValue, Connection, OpenFlags};
-use std::collections::{HashMap, HashSet, VecDeque};
-use std::ffi::{CStr, CString};
-use std::os::raw::{c_char, c_int, c_void};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Mutex, Once, OnceLock};
-use std::time::Duration;
 
 pub unsafe fn dispatch_node_sqlite_database_method(
     handle: Handle,

--- a/crates/perry-stdlib/src/sqlite/node_db.rs
+++ b/crates/perry-stdlib/src/sqlite/node_db.rs
@@ -1,25 +1,15 @@
 use super::*;
-use crate::common::{for_each_handle_mut_of, get_handle, register_handle, Handle};
+use crate::common::{get_handle, register_handle, Handle};
 use perry_runtime::{
-    buffer::{
-        buffer_alloc, buffer_data, buffer_data_mut, is_any_array_buffer, is_data_view,
-        is_registered_buffer, mark_as_uint8array, BufferHeader,
-    },
-    closure::{is_closure_ptr, js_closure_call1, js_closure_call_array, ClosureHeader},
-    js_array_alloc, js_array_get, js_array_is_array, js_array_length, js_array_push,
-    js_array_push_f64, js_get_string_pointer_unified, js_nanbox_pointer, js_object_alloc,
-    js_object_alloc_null_proto, js_object_alloc_with_shape, js_object_get_field_by_name,
-    js_object_set_field, js_object_set_field_by_name, js_object_set_keys, js_promise_rejected,
-    js_promise_resolved, js_string_from_bytes, ArrayHeader, BigIntHeader, JSValue, ObjectHeader,
-    Promise, StringHeader,
+    js_get_string_pointer_unified, js_nanbox_pointer, js_promise_rejected, js_promise_resolved,
+    JSValue, Promise, StringHeader,
 };
-use rusqlite::{ffi, limits::Limit, types::Value as SqliteValue, Connection, OpenFlags};
-use std::collections::{HashMap, HashSet, VecDeque};
+use rusqlite::{ffi, Connection};
+use std::collections::HashSet;
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int, c_void};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Mutex, Once, OnceLock};
-use std::time::Duration;
+use std::sync::Mutex;
 
 #[no_mangle]
 pub unsafe extern "C" fn js_node_sqlite_database_sync_call(

--- a/crates/perry-stdlib/src/sqlite/node_stmt_session.rs
+++ b/crates/perry-stdlib/src/sqlite/node_stmt_session.rs
@@ -1,25 +1,19 @@
 use super::*;
-use crate::common::{for_each_handle_mut_of, get_handle, register_handle, Handle};
+use crate::common::{get_handle, register_handle, Handle};
 use perry_runtime::{
     buffer::{
         buffer_alloc, buffer_data, buffer_data_mut, is_any_array_buffer, is_data_view,
         is_registered_buffer, mark_as_uint8array, BufferHeader,
     },
-    closure::{is_closure_ptr, js_closure_call1, js_closure_call_array, ClosureHeader},
-    js_array_alloc, js_array_get, js_array_is_array, js_array_length, js_array_push,
-    js_array_push_f64, js_get_string_pointer_unified, js_nanbox_pointer, js_object_alloc,
-    js_object_alloc_null_proto, js_object_alloc_with_shape, js_object_get_field_by_name,
-    js_object_set_field, js_object_set_field_by_name, js_object_set_keys, js_promise_rejected,
-    js_promise_resolved, js_string_from_bytes, ArrayHeader, BigIntHeader, JSValue, ObjectHeader,
-    Promise, StringHeader,
+    closure::{js_closure_call1, ClosureHeader},
+    js_array_alloc, js_array_push, js_object_alloc_with_shape, js_object_set_field,
+    js_string_from_bytes, ArrayHeader, JSValue, ObjectHeader, StringHeader,
 };
-use rusqlite::{ffi, limits::Limit, types::Value as SqliteValue, Connection, OpenFlags};
-use std::collections::{HashMap, HashSet, VecDeque};
+use rusqlite::ffi;
 use std::ffi::{CStr, CString};
 use std::os::raw::{c_char, c_int, c_void};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Mutex, Once, OnceLock};
-use std::time::Duration;
+use std::sync::Mutex;
 
 #[no_mangle]
 pub unsafe extern "C" fn js_node_sqlite_statement_sync_call(_arg0: f64, _arg1: f64) -> Handle {

--- a/crates/perry-stdlib/src/sqlite/node_tag_store.rs
+++ b/crates/perry-stdlib/src/sqlite/node_tag_store.rs
@@ -1,25 +1,13 @@
 use super::*;
-use crate::common::{for_each_handle_mut_of, get_handle, register_handle, Handle};
+use crate::common::{get_handle, register_handle, Handle};
 use perry_runtime::{
-    buffer::{
-        buffer_alloc, buffer_data, buffer_data_mut, is_any_array_buffer, is_data_view,
-        is_registered_buffer, mark_as_uint8array, BufferHeader,
-    },
-    closure::{is_closure_ptr, js_closure_call1, js_closure_call_array, ClosureHeader},
     js_array_alloc, js_array_get, js_array_is_array, js_array_length, js_array_push,
-    js_array_push_f64, js_get_string_pointer_unified, js_nanbox_pointer, js_object_alloc,
-    js_object_alloc_null_proto, js_object_alloc_with_shape, js_object_get_field_by_name,
-    js_object_set_field, js_object_set_field_by_name, js_object_set_keys, js_promise_rejected,
-    js_promise_resolved, js_string_from_bytes, ArrayHeader, BigIntHeader, JSValue, ObjectHeader,
-    Promise, StringHeader,
+    js_object_alloc_with_shape, js_object_set_field, js_string_from_bytes, ArrayHeader, JSValue,
+    ObjectHeader,
 };
-use rusqlite::{ffi, limits::Limit, types::Value as SqliteValue, Connection, OpenFlags};
-use std::collections::{HashMap, HashSet, VecDeque};
-use std::ffi::{CStr, CString};
-use std::os::raw::{c_char, c_int, c_void};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Mutex, Once, OnceLock};
-use std::time::Duration;
+use rusqlite::{ffi, Connection};
+use std::sync::atomic::Ordering;
+use std::sync::Mutex;
 
 pub(crate) fn node_sqlite_tag_store_capacity(value: f64) -> usize {
     let js = value_from_f64(value);

--- a/crates/perry-stdlib/src/sqlite/options.rs
+++ b/crates/perry-stdlib/src/sqlite/options.rs
@@ -1,25 +1,11 @@
 use super::*;
-use crate::common::{for_each_handle_mut_of, get_handle, register_handle, Handle};
 use perry_runtime::{
-    buffer::{
-        buffer_alloc, buffer_data, buffer_data_mut, is_any_array_buffer, is_data_view,
-        is_registered_buffer, mark_as_uint8array, BufferHeader,
-    },
-    closure::{is_closure_ptr, js_closure_call1, js_closure_call_array, ClosureHeader},
-    js_array_alloc, js_array_get, js_array_is_array, js_array_length, js_array_push,
-    js_array_push_f64, js_get_string_pointer_unified, js_nanbox_pointer, js_object_alloc,
-    js_object_alloc_null_proto, js_object_alloc_with_shape, js_object_get_field_by_name,
-    js_object_set_field, js_object_set_field_by_name, js_object_set_keys, js_promise_rejected,
-    js_promise_resolved, js_string_from_bytes, ArrayHeader, BigIntHeader, JSValue, ObjectHeader,
-    Promise, StringHeader,
+    closure::{is_closure_ptr, ClosureHeader},
+    js_get_string_pointer_unified, js_nanbox_pointer, js_object_get_field_by_name,
+    js_string_from_bytes, JSValue, ObjectHeader, StringHeader,
 };
-use rusqlite::{ffi, limits::Limit, types::Value as SqliteValue, Connection, OpenFlags};
-use std::collections::{HashMap, HashSet, VecDeque};
+use rusqlite::{ffi, limits::Limit, Connection};
 use std::ffi::{CStr, CString};
-use std::os::raw::{c_char, c_int, c_void};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Mutex, Once, OnceLock};
-use std::time::Duration;
 
 /// Helper to extract string from StringHeader pointer
 pub(crate) unsafe fn string_from_header(ptr: *const StringHeader) -> Option<String> {

--- a/crates/perry-stdlib/src/webcrypto.rs
+++ b/crates/perry-stdlib/src/webcrypto.rs
@@ -19,12 +19,8 @@ mod supports;
 mod util;
 mod wrap;
 
-#[allow(unused_imports)]
 // Private imports keep sibling modules able to share `pub(super)` helpers.
-use self::{
-    aes::*, digest::*, encapsulation::*, hmac::*, jwk::*, kdf::*, key_object::*, keys::*,
-    supports::*, util::*, wrap::*,
-};
+use self::{aes::*, hmac::*, jwk::*, key_object::*, util::*};
 
 // Public re-exports preserve the parent module surface for FFI entry points.
 pub use self::{

--- a/crates/perry/src/commands/compile/cjs_wrap/detect.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/detect.rs
@@ -1,6 +1,5 @@
 //! CommonJS-vs-ESM heuristic detection plus reserved-word filtering.
 
-#[allow(unused_imports)]
 use super::*;
 
 /// Heuristic CJS detection. Same shape as

--- a/crates/perry/src/commands/compile/cjs_wrap/extract_requires.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/extract_requires.rs
@@ -1,6 +1,5 @@
 //! `require(...)` specifier extraction and alias detection.
 
-#[allow(unused_imports)]
 use super::*;
 
 /// Extract `require('X')` / `require("X")` specifiers, preserving order and

--- a/crates/perry/src/commands/compile/cjs_wrap/hoist_classes.rs
+++ b/crates/perry/src/commands/compile/cjs_wrap/hoist_classes.rs
@@ -1,6 +1,5 @@
 //! Top-level `class` hoisting and `module.exports = class …` rewrite passes.
 
-#[allow(unused_imports)]
 use super::*;
 
 /// Issue #665 (fifth pass): rewrite the leaf-file shape


### PR DESCRIPTION
## Summary

Mechanical Rust warning cleanup across the workspace — no behavioral change. This is the first, zero-risk slice of a larger warning-elimination effort (the workspace currently emits ~1338 warnings on a clean `cargo check`); it clears the fully mechanical categories and the blanket import-suppression debt.

Two commits:

1. **`cargo fix` mechanical sweep** — removes unused imports, unnecessary `unsafe` blocks, unused `mut`/braces, and unused assignments. `cargo fix` handles most of these; `unused_unsafe` is applied by a span-driven pass because rustc emits that lint without a machine-applicable suggestion (removing an unnecessary `unsafe` block is safe by definition — if it were needed, it would not be flagged).

2. **Drop 444 blanket `#[allow(unused_imports)]` and prune** — these attributes papered over duplicated import preambles in mechanically-split files. Removing them and re-running `cargo fix` prunes the now-visible unused imports. The warning count does **not** rise afterward, confirming the suppressed imports were all genuinely removable. Two documented, intentional allows remain.

## Impact

- Workspace warning count: **1338 → 281** (this branch covers the mechanical + import-suppression share).
- `#[allow(unused_imports)]`: **444 → 2** (both remaining are documented and deliberate).

## Validation

- `cargo check --workspace` (excluding cross-host UI crates): **0 errors**.
- `cargo fmt --all --check`: clean.
- `cargo check --workspace --tests`: no new errors from this change (the one pre-existing failure — a stale `CompileOptions` field reference in `perry-codegen/tests/perry_builtin_name_collision.rs` — is unrelated and already present on `main`).

## Notes

- No version bump or CHANGELOG entry — left for the maintainer to fold in at merge, per the repo's contributor convention.
- Remaining 281 warnings need per-item judgment (dead_code, clashing extern declarations, unreachable patterns, etc.) and are handled in follow-up PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native-call handling when optional parameters are omitted, supplying appropriate default values for more reliable execution.
* **Refactor**
  * Streamlined internal module wiring and removed redundant imports across compilation, runtime, standard-library, and analysis components.
  * Consolidated selected compilation and runtime helpers without changing supported APIs or normal behavior.
* **Maintenance**
  * Reduced warning suppressions and clarified internal dependencies, improving build cleanliness and long-term maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->