### PR TITLE
feat(ui-windows): geisterhand assertion hooks (query_widget_tree / read_widget_value / scroll_set_offset)

### DIFF
--- a/crates/perry-ui-windows/src/app.rs
+++ b/crates/perry-ui-windows/src/app.rs
@@ -429,18 +429,33 @@ pub fn app_run(app_handle: i64) {
                     f: extern "C" fn(*mut usize) -> *mut u8,
                 );
                 fn perry_geisterhand_register_textfield_set_string(f: extern "C" fn(i64, i64));
+                fn perry_geisterhand_register_scroll_set(f: extern "C" fn(i64, f64, f64));
+                fn perry_geisterhand_register_read_value(
+                    f: extern "C" fn(i64, *mut usize) -> *mut u8,
+                );
+                fn perry_geisterhand_register_query_tree(f: extern "C" fn(*mut usize) -> *mut u8);
                 fn perry_geisterhand_register_apply_style(
                     f: extern "C" fn(i64, u32, f64, f64, f64, f64),
                 );
             }
             unsafe {
-                perry_geisterhand_register_state_set(crate::perry_ui_state_set);
+                perry_geisterhand_register_state_set(
+                    crate::ffi::widget_tree_state::perry_ui_state_set,
+                );
                 perry_geisterhand_register_screenshot_capture(
                     crate::screenshot::perry_ui_screenshot_capture,
                 );
                 perry_geisterhand_register_textfield_set_string(
-                    crate::perry_ui_textfield_set_string,
+                    crate::ffi::textfield_scroll::perry_ui_textfield_set_string,
                 );
+                // Assertion-side hooks (query/read/scroll) — macOS has had
+                // these since the geisterhand harness landed; without them
+                // Windows UI state was write-only from a test's viewpoint.
+                perry_geisterhand_register_scroll_set(
+                    crate::widgets::scrollview::perry_ui_scroll_set_offset,
+                );
+                perry_geisterhand_register_read_value(crate::widgets::perry_ui_read_widget_value);
+                perry_geisterhand_register_query_tree(crate::widgets::perry_ui_query_widget_tree);
                 perry_geisterhand_register_apply_style(crate::geisterhand_style::apply_style);
             }
         }

--- a/crates/perry-ui-windows/src/geisterhand_style.rs
+++ b/crates/perry-ui-windows/src/geisterhand_style.rs
@@ -38,8 +38,12 @@ pub extern "C" fn apply_style(handle: i64, prop_id: u32, a0: f64, a1: f64, a2: f
         // Windows uses `set_insets` (vs `set_edge_insets` on macOS / GTK4) —
         // same FFI shape, different helper name internal to the crate.
         PADDING_UNIFORM => widgets::set_insets(handle, a0, a0, a0, a0),
-        HIDDEN => crate::perry_ui_set_widget_hidden(handle, if a0 != 0.0 { 1 } else { 0 }),
-        ENABLED => crate::perry_ui_widget_set_enabled(handle, if a0 != 0.0 { 1 } else { 0 }),
+        HIDDEN => {
+            crate::ffi::styling::perry_ui_set_widget_hidden(handle, if a0 != 0.0 { 1 } else { 0 })
+        }
+        ENABLED => {
+            crate::ffi::styling::perry_ui_widget_set_enabled(handle, if a0 != 0.0 { 1 } else { 0 })
+        }
         _ => {}
     }
 }

--- a/crates/perry-ui-windows/src/widgets/mod.rs
+++ b/crates/perry-ui-windows/src/widgets/mod.rs
@@ -464,6 +464,134 @@ pub fn find_handle_by_hwnd(_hwnd: isize) -> i64 {
     0
 }
 
+// =============================================================================
+// Geisterhand (UI test automation) hooks — Windows ports of the macOS
+// implementations in `perry-ui-macos/src/widgets/mod.rs`. These are what a
+// test harness needs to ASSERT on Windows UI (the crate previously only
+// registered state_set / screenshot / textfield_set / apply_style, so
+// widget state was write-only from a harness's point of view). Returned
+// buffers are `libc::malloc`'d — the geisterhand host frees them with
+// `free()`, so the allocators must match.
+// =============================================================================
+
+/// Copy `s` into a malloc'd buffer, writing its length to `out_len`.
+/// Contract (mirrors macOS): null return = "not found / not readable";
+/// non-null with `*out_len == 0` = "found, empty value" (`len.max(1)`
+/// keeps malloc(0) well-defined).
+#[cfg(all(feature = "geisterhand", target_os = "windows"))]
+fn alloc_string_result(s: &str, out_len: *mut usize) -> *mut u8 {
+    let bytes = s.as_bytes();
+    let len = bytes.len();
+    let buf = unsafe { libc::malloc(len.max(1)) as *mut u8 };
+    if buf.is_null() {
+        return std::ptr::null_mut();
+    }
+    if len > 0 {
+        unsafe {
+            std::ptr::copy_nonoverlapping(bytes.as_ptr(), buf, len);
+        }
+    }
+    unsafe {
+        *out_len = len;
+    }
+    buf
+}
+
+/// Read the current value of a widget by handle. Kind mapping mirrors the
+/// macOS hook: text-bearing widgets → their text, Slider → its numeric
+/// value (user units), Toggle/Button → checked state as "true"/"false".
+#[cfg(all(feature = "geisterhand", target_os = "windows"))]
+#[no_mangle]
+pub extern "C" fn perry_ui_read_widget_value(handle: i64, out_len: *mut usize) -> *mut u8 {
+    unsafe {
+        *out_len = 0;
+    }
+    let Some(info) = get_widget_info(handle) else {
+        return std::ptr::null_mut();
+    };
+    let Some(hwnd) = get_hwnd(handle) else {
+        return std::ptr::null_mut();
+    };
+    match info.kind {
+        WidgetKind::Text
+        | WidgetKind::TextField
+        | WidgetKind::SecureField
+        | WidgetKind::TextArea => unsafe {
+            let len = GetWindowTextLengthW(hwnd);
+            let mut buf = vec![0u16; (len + 1) as usize];
+            let copied = GetWindowTextW(hwnd, &mut buf);
+            let s = String::from_utf16_lossy(&buf[..copied.max(0) as usize]);
+            alloc_string_result(&s, out_len)
+        },
+        WidgetKind::Slider => match slider::get_value(handle) {
+            Some(v) => alloc_string_result(&format!("{}", v), out_len),
+            None => std::ptr::null_mut(),
+        },
+        WidgetKind::Toggle | WidgetKind::Button => unsafe {
+            // BM_GETCHECK: BST_CHECKED == 1. Plain push buttons report
+            // "false", same as macOS's NSButton state for momentary buttons.
+            const BM_GETCHECK: u32 = 0x00F0;
+            let checked = SendMessageW(hwnd, BM_GETCHECK, Some(WPARAM(0)), Some(LPARAM(0))).0 == 1;
+            alloc_string_result(if checked { "true" } else { "false" }, out_len)
+        },
+        _ => std::ptr::null_mut(),
+    }
+}
+
+/// Query all widgets: JSON array of handle / visible / frame, where frame
+/// is in the widget's top-level window's client coordinates (stable
+/// regardless of window position on screen). Shape mirrors macOS.
+#[cfg(all(feature = "geisterhand", target_os = "windows"))]
+#[no_mangle]
+pub extern "C" fn perry_ui_query_widget_tree(out_len: *mut usize) -> *mut u8 {
+    let json = WIDGETS.with(|w| {
+        let widgets = w.borrow();
+        let mut s = String::from("[");
+        for (i, entry) in widgets.iter().enumerate() {
+            let handle = (i + 1) as i64;
+            if i > 0 {
+                s.push(',');
+            }
+            unsafe {
+                let visible = !entry.hidden && IsWindowVisible(entry.hwnd).as_bool();
+                let mut rect = RECT::default();
+                let _ = GetWindowRect(entry.hwnd, &mut rect);
+                let root = GetAncestor(entry.hwnd, GA_ROOT);
+                let mut origin = POINT {
+                    x: rect.left,
+                    y: rect.top,
+                };
+                let _ = windows::Win32::Graphics::Gdi::ScreenToClient(root, &mut origin);
+                s.push_str(&format!(
+                    r#"{{"handle":{},"visible":{},"frame":{{"x":{},"y":{},"width":{},"height":{}}}}}"#,
+                    handle,
+                    visible,
+                    origin.x,
+                    origin.y,
+                    rect.right - rect.left,
+                    rect.bottom - rect.top
+                ));
+            }
+        }
+        s.push(']');
+        s
+    });
+    let bytes = json.into_bytes();
+    let len = bytes.len();
+    let buf = unsafe { libc::malloc(len.max(1)) as *mut u8 };
+    if buf.is_null() {
+        unsafe {
+            *out_len = 0;
+        }
+        return std::ptr::null_mut();
+    }
+    unsafe {
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), buf, len);
+        *out_len = len;
+    }
+    buf
+}
+
 /// Find widget handle by control ID.
 pub fn find_handle_by_control_id(id: u16) -> i64 {
     WIDGETS.with(|w| {

--- a/crates/perry-ui-windows/src/widgets/scrollview.rs
+++ b/crates/perry-ui-windows/src/widgets/scrollview.rs
@@ -367,6 +367,16 @@ pub fn get_offset(scroll_handle: i64) -> f64 {
     })
 }
 
+/// Geisterhand automation hook — same registered shape as the macOS
+/// `perry_ui_scroll_set_offset` (handle, x, y). The Windows ScrollView is
+/// vertical-only, so `x` is accepted for cross-platform harness parity
+/// and ignored.
+#[cfg(all(feature = "geisterhand", target_os = "windows"))]
+#[no_mangle]
+pub extern "C" fn perry_ui_scroll_set_offset(handle: i64, _x: f64, y: f64) {
+    set_offset(handle, y);
+}
+
 /// Set the vertical scroll offset.
 pub fn set_offset(scroll_handle: i64, offset: f64) {
     let new_offset = offset as i32;

--- a/crates/perry-ui-windows/src/widgets/slider.rs
+++ b/crates/perry-ui-windows/src/widgets/slider.rs
@@ -167,6 +167,28 @@ pub fn create(min: f64, max: f64, initial: f64, on_change: f64) -> i64 {
     }
 }
 
+/// Current slider value in user units (trackbar pos mapped back through
+/// the stored [min, max]). None when `handle` isn't a slider. Used by the
+/// geisterhand `read_widget_value` hook.
+pub fn get_value(handle: i64) -> Option<f64> {
+    #[cfg(target_os = "windows")]
+    {
+        let hwnd = super::get_hwnd(handle)?;
+        let pos =
+            unsafe { SendMessageW(hwnd, TBM_GETPOS, Some(WPARAM(0)), Some(LPARAM(0))).0 as i32 };
+        return SLIDER_INFO.with(|info| {
+            info.borrow()
+                .get(&handle)
+                .map(|si| pos_to_value(pos, si.min, si.max))
+        });
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = handle;
+        None
+    }
+}
+
 /// Handle WM_HSCROLL from trackbar — read position and call callback.
 pub fn handle_scroll(handle: i64) {
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
Windows registered only the write-side geisterhand hooks (state_set, screenshot, textfield_set_string, apply_style) — macOS additionally registers scroll_set, read_value, and query_tree (`perry-ui-macos/src/app.rs:610-614`), which are what a harness needs to **assert** on UI state. Found in the 2026-07-18 Windows audit; this is a big part of why no automated UI test can catch Windows regressions today.

## Ports (mirroring the macOS implementations and buffer contract — malloc'd results, null = not-found, non-null + len 0 = empty)

- `perry_ui_query_widget_tree`: JSON array of `{handle, visible, frame}` with frames in the widget's top-level window client coordinates (stable regardless of window screen position).
- `perry_ui_read_widget_value`: Text/TextField/SecureField/TextArea → window text; Slider → numeric value in user units (new `slider::get_value` reusing the WM_HSCROLL mapping); Toggle/Button → `BM_GETCHECK` as `"true"`/`"false"` (momentary push buttons read "false", same as NSButton state on macOS).
- `perry_ui_scroll_set_offset`: `(handle, x, y)` shape; wraps the existing vertical `set_offset` (`x` accepted for cross-platform harness parity, ignored — the Windows ScrollView is vertical-only).

## Also fixed: the geisterhand feature didn't compile at all on Windows

`cargo build -p perry-ui-windows --features geisterhand` failed with four E0425s on **pre-existing** code — crate-root paths that no longer exist (`crate::perry_ui_state_set`, `crate::perry_ui_textfield_set_string` in app.rs; `crate::perry_ui_set_widget_hidden` / `perry_ui_widget_set_enabled` in geisterhand_style.rs). The feature had never been compiled for this crate — which is exactly how the hook gap survived unnoticed. Paths corrected to their `ffi::` homes.

## Verification (Windows 11 x64)

- `cargo build --release -p perry-ui-windows` clean **both** with and without `--features geisterhand` (the feature build previously failed E0425 ×4).
- Runtime round-trip through the geisterhand host needs the harness stack, which Windows CI doesn't run yet (#6623/#6624). The registrar symbols and function signatures are byte-identical to what macOS links against.

No version bump / changelog per maintainer instruction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Windows UI automation and inspection support.
  - Added the ability to read current widget values, including text, sliders, toggles, and buttons.
  - Added widget-tree queries with visibility and layout information.
  - Added support for setting vertical scroll positions through automation.
  - Enhanced automated styling and interaction handling for hidden and enabled states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->