### PR TITLE
fix(compile): Windows staticlib without MSVC, actionable dylib error, .dll default, /STACK comment

### DIFF
--- a/crates/perry/src/commands/compile.rs
+++ b/crates/perry/src/commands/compile.rs
@@ -76,7 +76,8 @@ use library_search::{
     find_geisterhand_stdlib, find_geisterhand_ui, find_harmonyos_sdk, find_lld_link,
     find_llvm_tool, find_msvc_lib_paths, find_msvc_link_exe, find_perry_windows_sdk,
     find_runtime_library, find_stdlib_library, find_ui_library, find_wasm_host_library,
-    windows_default_output_extension, windows_pe_subsystem_flag, windows_subsystem_needs_ui,
+    find_windows_archiver, windows_archiver_command, windows_default_output_extension,
+    windows_pe_subsystem_flag, windows_subsystem_needs_ui,
 };
 use link::{build_and_run_link, write_link_cache_manifest};
 pub use lock_scan::collect_native_archives_for_lock;

--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -325,6 +325,101 @@ pub(super) fn find_lld_link() -> Option<PathBuf> {
     None
 }
 
+/// MSVC `lib.exe` — the archive manager that ships in the same MSVC bin
+/// directory as `link.exe`. Located via vswhere (through `find_msvc_link_exe`,
+/// which already picks the newest VC tools bin dir) first, then PATH (covers
+/// vcvars64 developer prompts). Windows-host only: on other hosts a
+/// Windows-target archive is built with llvm-lib / llvm-ar instead.
+#[cfg(target_os = "windows")]
+pub(super) fn find_msvc_lib_exe() -> Option<PathBuf> {
+    if let Some(link_exe) = find_msvc_link_exe() {
+        let lib = link_exe.with_file_name("lib.exe");
+        if lib.exists() {
+            return Some(lib);
+        }
+    }
+    if let Ok(output) = Command::new("where").arg("lib.exe").output() {
+        if output.status.success() {
+            let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if let Some(first) = s.lines().next() {
+                let p = PathBuf::from(first.trim());
+                if p.exists() {
+                    return Some(p);
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(not(target_os = "windows"))]
+pub(super) fn find_msvc_lib_exe() -> Option<PathBuf> {
+    None
+}
+
+/// The archiver selected for bundling a Windows `--output-type staticlib`
+/// (#1088). Selection is split from discovery so the precedence is
+/// unit-testable off-Windows (`windows_link_tests`).
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum WindowsArchiver {
+    /// MSVC `lib.exe`, or LLVM's `llvm-lib` — a drop-in lib.exe replacement
+    /// (same `/OUT:` command line) that ships with `winget install LLVM.LLVM`.
+    LibExe(PathBuf),
+    /// LLVM's generic `ar` — last resort (rustup's llvm-tools component
+    /// carries llvm-ar but not llvm-lib). `--format=coff` makes it emit the
+    /// MSVC-compatible archive flavor.
+    LlvmAr(PathBuf),
+}
+
+/// Pick the Windows archiver from the tools that resolved, in precedence
+/// order: MSVC `lib.exe` → `llvm-lib` → `llvm-ar`. `None` when no archiver
+/// is installed at all — the caller emits the two-toolchain install hint.
+pub(super) fn choose_windows_archiver(
+    msvc_lib_exe: Option<PathBuf>,
+    llvm_lib: Option<PathBuf>,
+    llvm_ar: Option<PathBuf>,
+) -> Option<WindowsArchiver> {
+    if let Some(p) = msvc_lib_exe {
+        return Some(WindowsArchiver::LibExe(p));
+    }
+    if let Some(p) = llvm_lib {
+        return Some(WindowsArchiver::LibExe(p));
+    }
+    llvm_ar.map(WindowsArchiver::LlvmAr)
+}
+
+/// Locate the archiver for a Windows-target staticlib. `find_llvm_tool`
+/// contributes the `PERRY_LLVM_LIB` / `PERRY_LLVM_AR` env overrides, the
+/// rustup-sysroot probe, and the PATH lookup for free, so all three rungs
+/// follow the established lookup precedence.
+pub(super) fn find_windows_archiver() -> Option<WindowsArchiver> {
+    choose_windows_archiver(
+        find_msvc_lib_exe(),
+        find_llvm_tool("llvm-lib"),
+        find_llvm_tool("llvm-ar"),
+    )
+}
+
+/// Build the archive command for the selected archiver. The caller appends
+/// the object files.
+pub(super) fn windows_archiver_command(archiver: &WindowsArchiver, out: &Path) -> Command {
+    match archiver {
+        WindowsArchiver::LibExe(path) => {
+            let mut c = Command::new(path);
+            c.arg(format!("/OUT:{}", out.display()));
+            c
+        }
+        WindowsArchiver::LlvmAr(path) => {
+            let mut c = Command::new(path);
+            // `c` create, `r` insert/replace, `s` write index — same as the
+            // Unix `ar crs` branch; `--format=coff` selects the MSVC archive
+            // flavor so `link.exe` / `lld-link` consume the result.
+            c.arg("--format=coff").arg("crs").arg(out);
+            c
+        }
+    }
+}
+
 /// Location where `perry setup windows` writes the xwin'd Microsoft CRT +
 /// Windows SDK. Returns `Some(root)` only when `<root>/crt/lib/x86_64` exists,
 /// so callers can treat `Some` as "toolchain is complete and ready to link."

--- a/crates/perry/src/commands/compile/link/platform_cmd.rs
+++ b/crates/perry/src/commands/compile/link/platform_cmd.rs
@@ -826,8 +826,12 @@ pub fn select_linker_command(
         .arg("/ENTRY:mainCRTStartup")
         .arg("/NOLOGO")
         // Perry generates large init functions for TS modules (one function
-        // per module). Large codebases (100+ modules) can overflow the
-        // default 1MB stack. Reserve 8MB.
+        // per module), and compiled TS + game workloads recurse deeply
+        // (Bloom-engine scene graphs, recursive descent over user data).
+        // Large codebases (100+ modules) overflow the default 1 MB stack.
+        // Reserve 64 MiB (67108864 = 64 * 1024 * 1024) — this bakes in the
+        // `editbin /STACK:67108864` post-link step users previously had to
+        // run by hand.
         .arg("/STACK:67108864")
         // Native libs (hone_editor_windows etc) bundle perry_runtime objects
         // that can't be fully stripped. Identical symbols are safe to merge.

--- a/crates/perry/src/commands/compile/output_path.rs
+++ b/crates/perry/src/commands/compile/output_path.rs
@@ -19,12 +19,17 @@ pub(super) fn default_output_path(
     stem: &str,
 ) -> PathBuf {
     if is_dylib {
-        #[cfg(target_os = "macos")]
-        {
+        // #4771 — keyed on the target like the rest of this file (host is
+        // only the fallback when no `--target` was given), not on host cfg
+        // alone: `--target windows` must yield `.dll` regardless of host.
+        // Same by-output-type table as `windows_default_output_extension`,
+        // which already covered the `-o NAME` path; this covers the
+        // no-`-o` default, which used to fall through to `.so` on Windows.
+        if is_windows_target(target) {
+            PathBuf::from(format!("{}.dll", stem))
+        } else if is_apple_target(target) {
             PathBuf::from(format!("{}.dylib", stem))
-        }
-        #[cfg(not(target_os = "macos"))]
-        {
+        } else {
             PathBuf::from(format!("{}.so", stem))
         }
     } else if is_staticlib {
@@ -67,6 +72,25 @@ pub(super) fn default_output_path(
 fn is_windows_target(target: Option<&str>) -> bool {
     matches!(target, Some("windows") | Some("windows-winui"))
         || (target.is_none() && cfg!(target_os = "windows"))
+}
+
+/// `--target macos` or any embedded-Apple target, or a native build on a
+/// macOS host — the platforms whose shared-library convention is `.dylib`.
+fn is_apple_target(target: Option<&str>) -> bool {
+    matches!(
+        target,
+        Some(
+            "macos"
+                | "ios"
+                | "ios-simulator"
+                | "tvos"
+                | "tvos-simulator"
+                | "watchos"
+                | "watchos-simulator"
+                | "visionos"
+                | "visionos-simulator"
+        )
+    ) || (target.is_none() && cfg!(target_os = "macos"))
 }
 
 #[cfg(test)]
@@ -131,12 +155,29 @@ mod tests {
         );
     }
 
+    /// #4771 finish — an extension-less `--output-type dylib` build keys the
+    /// extension on the target: `.dll` for Windows (used to fall through to
+    /// `.so`), `.dylib` for the Apple family, `.so` elsewhere.
+    #[test]
+    fn dylib_extension_keys_on_target() {
+        let dylib = |target| default_output_path(true, false, target, "app");
+        assert_eq!(dylib(Some("windows")), PathBuf::from("app.dll"));
+        assert_eq!(dylib(Some("windows-winui")), PathBuf::from("app.dll"));
+        assert_eq!(dylib(Some("macos")), PathBuf::from("app.dylib"));
+        assert_eq!(dylib(Some("ios")), PathBuf::from("app.dylib"));
+        assert_eq!(dylib(Some("ios-simulator")), PathBuf::from("app.dylib"));
+        assert_eq!(dylib(Some("linux")), PathBuf::from("app.so"));
+    }
+
+    /// No `--target` falls back to the host's shared-library convention.
     #[test]
     fn dylib_uses_the_host_shared_library_extension() {
         let out = default_output_path(true, false, None, "app");
         #[cfg(target_os = "macos")]
         assert_eq!(out, PathBuf::from("app.dylib"));
-        #[cfg(not(target_os = "macos"))]
+        #[cfg(target_os = "windows")]
+        assert_eq!(out, PathBuf::from("app.dll"));
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
         assert_eq!(out, PathBuf::from("app.so"));
     }
 }

--- a/crates/perry/src/commands/compile/run_pipeline.rs
+++ b/crates/perry/src/commands/compile/run_pipeline.rs
@@ -5148,12 +5148,32 @@ pub fn run_with_parse_cache(
         // previous build's contents.
         let _ = fs::remove_file(&exe_path);
         let mut cmd = if is_windows_target {
-            // MSVC `lib.exe` is the standard host on Windows; mingw users
-            // can override with `AR=...` since `cc::ar_name()` parity isn't
-            // available here.
-            let mut c = Command::new("lib.exe");
-            c.arg(format!("/OUT:{}", exe_path.display()));
-            c
+            // Archiver precedence (2026-07 audit): MSVC `lib.exe` when a
+            // Visual Studio install (or a vcvars prompt) provides one, else
+            // LLVM's `llvm-lib` — a drop-in lib.exe replacement that ships
+            // with `winget install LLVM.LLVM`, i.e. the lightweight-toolchain
+            // path from `perry setup windows` — else `llvm-ar --format=coff`
+            // as a last resort (rustup's llvm-tools carries llvm-ar but not
+            // llvm-lib). Previously this spawned `lib.exe` unconditionally,
+            // so LLVM+xwin users got a raw "program not found" spawn error.
+            let Some(archiver) = find_windows_archiver() else {
+                return Err(anyhow!(
+                    "No Windows archiver found for --output-type staticlib. Perry needs \
+                     MSVC lib.exe, or LLVM's llvm-lib / llvm-ar. Pick whichever is \
+                     lighter for you:\n\
+                     \n\
+                     \x20  A) Lightweight (LLVM, no Visual Studio needed):\n\
+                     \x20       winget install LLVM.LLVM\n\
+                     \n\
+                     \x20  B) MSVC (Visual Studio Build Tools + C++ workload):\n\
+                     \x20       Visual Studio Installer → Modify → \"Desktop development with C++\"\n\
+                     \x20       or: winget install Microsoft.VisualStudio.2022.BuildTools --override \
+                     \"--quiet --wait --add Microsoft.VisualStudio.Workload.VCTools --includeRecommended\"\n\
+                     \n\
+                     Then open a new terminal and retry. Run `perry doctor` to verify."
+                ));
+            };
+            windows_archiver_command(&archiver, &exe_path)
         } else {
             let mut c = Command::new("ar");
             // `c` create, `r` insert/replace, `s` write index. Matches what
@@ -5309,13 +5329,41 @@ pub fn run_with_parse_cache(
             // link fails with LNK2019 on the first unresolved `js_*` symbol
             // and no DLL is emitted.
             //
-            // We use lld-link rather than MSVC link.exe here: lld-link honors
-            // /FORCE:UNRESOLVED on the LLVM .o files that Perry emits (treating
-            // the missing symbols as warnings that produce a runnable DLL),
-            // whereas MSVC link.exe returns 0 without writing the DLL — see
-            // the cross-linker note in `select_linker_command`.
-            let linker = find_lld_link().unwrap_or_else(|| PathBuf::from("lld-link"));
+            // lld-link is preferred here: it has always honored
+            // /FORCE:UNRESOLVED on the LLVM .o files that Perry emits
+            // (treating the missing symbols as warnings that produce a
+            // runnable DLL). MSVC link.exe was historically excluded because
+            // it returned 0 WITHOUT writing the DLL on this input; re-tested
+            // 2026-07 against MSVC 14.50 (VS 2026 Build Tools), link.exe now
+            // writes a loadable DLL (exit 0 + LNK4088, exports resolve via
+            // GetProcAddress), so it is accepted as a fallback when lld-link
+            // is absent. The post-link existence check below turns any older
+            // toolset that still silently drops the output into an
+            // actionable error instead of a mystery "file not found" later.
+            // See also the cross-linker note in `select_linker_command`.
+            let Some(linker) = find_lld_link()
+                .or_else(|| find_llvm_tool("lld-link"))
+                .or_else(find_msvc_link_exe)
+            else {
+                return Err(anyhow!(
+                    "Building a Windows plugin .dll requires a COFF linker and none was \
+                     found. Preferred: LLVM's lld-link — install via:\n\
+                     \x20  winget install LLVM.LLVM\n\
+                     then open a new terminal and retry (or set PERRY_LLD_LINK to an \
+                     existing lld-link.exe).\n\
+                     MSVC link.exe from Visual Studio Build Tools (\"Desktop development \
+                     with C++\" workload) also works as a fallback."
+                ));
+            };
             let mut c = Command::new(linker);
+            // Both linkers need the CRT + SDK lib dirs for /defaultlib:libcmt.
+            // Mirror `select_linker_command`: leave a user-provided LIB alone,
+            // otherwise resolve it (xwin sysroot first, then vswhere).
+            if std::env::var("LIB").is_err() {
+                if let Some(lib_paths) = find_msvc_lib_paths() {
+                    c.env("LIB", lib_paths);
+                }
+            }
             c.arg("/NOLOGO").arg("/DLL").arg("/FORCE:UNRESOLVED");
             let stem = exe_path
                 .file_stem()
@@ -5390,6 +5438,19 @@ pub fn run_with_parse_cache(
         let status = cmd.status()?;
         if !status.success() {
             return Err(anyhow!("Linking dylib failed"));
+        }
+        if is_dylib_windows && !exe_path.exists() {
+            // Guard for the legacy MSVC link.exe failure mode: some toolsets
+            // exit 0 under /FORCE:UNRESOLVED yet never write the DLL (the
+            // reason lld-link is preferred above).
+            return Err(anyhow!(
+                "The linker reported success but did not write {}.\n\
+                 This is a known MSVC link.exe behavior with /FORCE:UNRESOLVED on \
+                 some toolsets. Install LLVM's lld-link and retry:\n\
+                 \x20  winget install LLVM.LLVM\n\
+                 (or set PERRY_LLD_LINK to an existing lld-link.exe).",
+                exe_path.display()
+            ));
         }
 
         match format {

--- a/crates/perry/src/commands/compile/windows_link_tests.rs
+++ b/crates/perry/src/commands/compile/windows_link_tests.rs
@@ -3,10 +3,13 @@
 //! `#[cfg(test)] mod windows_link_tests;` in compile.rs.
 
 use super::library_search::newest_mt_dir_under;
+use super::library_search::{choose_windows_archiver, WindowsArchiver};
 use super::link::{embed_app_manifest, linker_is_msvc_link_exe, WINDOWS_APP_MANIFEST};
+use super::windows_archiver_command;
 use super::windows_default_output_extension;
 use super::windows_pe_subsystem_flag;
 use super::windows_subsystem_needs_ui;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 // Regression guard for issue #120: without an explicit subsystem flag the
@@ -102,6 +105,68 @@ fn windows_output_extension_defaults_by_type() {
     assert_eq!(windows_default_output_extension(false, false), "exe");
     assert_eq!(windows_default_output_extension(true, false), "dll");
     assert_eq!(windows_default_output_extension(false, true), "lib");
+}
+
+// 2026-07 audit: a Windows `--output-type staticlib` no longer hard-requires
+// MSVC lib.exe. Precedence: lib.exe → llvm-lib (drop-in replacement, ships
+// with `winget install LLVM.LLVM`) → llvm-ar (rustup llvm-tools); None when
+// nothing is installed, which the pipeline turns into the two-toolchain
+// install hint instead of a raw spawn error.
+#[test]
+fn windows_archiver_precedence_prefers_lib_exe_then_llvm() {
+    let lib_exe = PathBuf::from(r"C:/VS/VC/Tools/MSVC/14.50.35717/bin/Hostx64/x64/lib.exe");
+    let llvm_lib = PathBuf::from(r"C:/Program Files/LLVM/bin/llvm-lib.exe");
+    let llvm_ar = PathBuf::from(r"C:/Program Files/LLVM/bin/llvm-ar.exe");
+    assert_eq!(
+        choose_windows_archiver(
+            Some(lib_exe.clone()),
+            Some(llvm_lib.clone()),
+            Some(llvm_ar.clone())
+        ),
+        Some(WindowsArchiver::LibExe(lib_exe))
+    );
+    assert_eq!(
+        choose_windows_archiver(None, Some(llvm_lib.clone()), Some(llvm_ar.clone())),
+        Some(WindowsArchiver::LibExe(llvm_lib))
+    );
+    assert_eq!(
+        choose_windows_archiver(None, None, Some(llvm_ar.clone())),
+        Some(WindowsArchiver::LlvmAr(llvm_ar))
+    );
+    assert_eq!(choose_windows_archiver(None, None, None), None);
+}
+
+// lib.exe / llvm-lib take the MSVC-style `/OUT:` argument (objects appended
+// by the caller).
+#[test]
+fn lib_exe_archiver_command_uses_out_flag() {
+    let archiver = WindowsArchiver::LibExe(PathBuf::from("lib.exe"));
+    let cmd = windows_archiver_command(&archiver, Path::new("app.lib"));
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+    assert_eq!(args, vec!["/OUT:app.lib".to_string()]);
+}
+
+// llvm-ar needs the COFF archive flavor spelled out, plus the same `crs`
+// modifiers the Unix `ar` branch uses.
+#[test]
+fn llvm_ar_archiver_command_uses_coff_format() {
+    let archiver = WindowsArchiver::LlvmAr(PathBuf::from("llvm-ar.exe"));
+    let cmd = windows_archiver_command(&archiver, Path::new("app.lib"));
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+    assert_eq!(
+        args,
+        vec![
+            "--format=coff".to_string(),
+            "crs".to_string(),
+            "app.lib".to_string()
+        ]
+    );
 }
 
 // Issue #4681 / discussion #3486: the embedded app manifest must declare the


### PR DESCRIPTION
Fixes the four Windows toolchain holes from the 2026-07-18 audit (main @ 58e555e58). All changes in `crates/perry/src/commands/compile/`.

## (a) `--output-type staticlib` no longer hard-requires MSVC `lib.exe`

`run_pipeline.rs` unconditionally spawned `Command::new("lib.exe")`, so a lightweight-toolchain user (LLVM + xwin via `perry setup windows`, no Visual Studio) got a raw spawn error.

Now the archiver is selected with the established lookup precedence (`library_search.rs`):

1. **MSVC `lib.exe`** — vswhere-located MSVC bin dir (the same dir `find_msvc_link_exe` picks), then PATH (covers vcvars prompts);
2. **`llvm-lib`** — drop-in lib.exe replacement, ships with `winget install LLVM.LLVM`, resolved via `find_llvm_tool` (so `PERRY_LLVM_LIB`, rustup sysroot, and PATH all work);
3. **`llvm-ar --format=coff crs`** — last resort (rustup's llvm-tools component carries llvm-ar but not llvm-lib).

If none resolve, the compile fails with the same two-toolchain install hint style as the executable linker path (LLVM winget line + VS Build Tools workload line), instead of an opaque spawn error.

## (b) `--output-type dylib` on Windows: actionable failure + the link.exe /DLL investigation

### Investigation result (required by the audit)

The code comment claimed MSVC link.exe "returns 0 without writing the DLL" under `/DLL /FORCE:UNRESOLVED`, which is why it was deliberately excluded. **This no longer reproduces.** Tested on this box with MSVC 14.50.35717 (VS 2026 Build Tools) against a clang-built COFF object with an unresolved `js_*` symbol, using Perry's exact dylib link line (`/NOLOGO /DLL /FORCE:UNRESOLVED /DEF:... /OUT:... /defaultlib:libcmt`):

- **MSVC link.exe**: exit 0, DLL **written** (LNK2019 report + LNK4088 "image may not run" warning); loads via `LoadLibrary`; both `.def` exports resolve via `GetProcAddress`; `perry_plugin_abi_version()` callable and returns the right value.
- **lld-link** (LLVM 22.1.3): exit 0, DLL written, identical load/export behavior.

Caveat: verified on MSVC 14.50 only — older toolsets may still exhibit the silent-drop behavior, which shaped the fix below.

### Fix

Per the audit's guidance ("if it actually works now, wiring MSVC link.exe as fallback is the better fix"):

- lld-link stays **preferred** (`find_lld_link()`, plus `find_llvm_tool("lld-link")` so Unix cross-hosts get a `which` probe too — same reach as the old `PathBuf::from("lld-link")` PATH-at-spawn fallback, but resolved up front).
- MSVC link.exe (`find_msvc_link_exe`) is wired as the **fallback** when lld-link is absent.
- If neither exists, the compile errors **before spawning** with an actionable message (winget LLVM line, `PERRY_LLD_LINK`, VS Build Tools alternative) instead of the raw spawn failure.
- A **post-link existence check** guards the legacy failure mode: if an older toolset exits 0 without writing the DLL, the user gets "linker reported success but did not write X — install lld-link" instead of a mystery downstream failure.
- The dylib link now also sets `LIB` (xwin sysroot first, then vswhere — mirroring `select_linker_command`) when the user hasn't, so `/defaultlib:libcmt` resolves from a plain shell for both linkers.

## (c) `/STACK` comment corrected

`link/platform_cmd.rs` said "Reserve 8MB" next to `/STACK:67108864`, which is 64 MiB. The comment now says 64 MiB and why it's that large (deep recursion in compiled TS + game workloads; bakes in the old manual `editbin /STACK` post-link step this replaced).

## (d) Extension-less `--output-type dylib` defaults to `.dll` on Windows

`output_path.rs` picked `.dylib` (host-macOS cfg) else `.so` — no Windows branch, so a no-`-o` dylib build on Windows produced `app.so`. The dylib arm is now **target-keyed** like the rest of the file (host cfg only as the no-`--target` fallback): `windows`/`windows-winui` → `.dll`, Apple family → `.dylib`, else `.so`. Matches `windows_default_output_extension`, which already handled the `-o NAME` path. Finishes #4771.

## Verification

- `cargo check -p perry` passes (0 errors; the only warnings are pre-existing ones in untouched files). Note: origin/main's perry-runtime doesn't compile on Windows (pre-existing `ExitProcess` divergence, fix in PR #6609); verified with that one-line local overlay applied — the overlay is **not** part of this PR.
- New unit tests in `windows_link_tests.rs` (archiver precedence lib.exe → llvm-lib → llvm-ar → None; `/OUT:` vs `--format=coff crs` command shapes) and `output_path.rs` (target-keyed dylib extension incl. `.dll`, host-fallback matrix): **all 29 matching tests pass** (`cargo test -p perry --bin perry -- output_path windows_link`). Running them on Windows needed a local, uncommitted link shim for a *second pre-existing* Windows hole: the perry (test) binary fails to link with `LNK2019: js_crypto_ed25519_verify` — a perry-updater extern defined in perry-stdlib, which the perry CLI bin does not depend on (release-profile CGU partitioning is why release builds don't hit it). Not introduced by this PR; may be worth its own issue.
- End-to-end staticlib smoke: **done** — perry-dev build, then `perry hello.ts --output-type staticlib -o hello.lib` → exit 0; the MSVC "Library Manager 14.50" banner confirms the new selector picked lib.exe via the vswhere rung; `lib.exe /LIST hello.lib` shows the member; `hello.linkdeps.json` sidecar written. The other two rungs were validated manually against the same object: both the `llvm-lib`-built and the `llvm-ar --format=coff crs`-built archives are readable by MSVC lib.exe (exit 0). (The perry-dev bin build itself required the same local shim for the pre-existing LNK2019 above.)
- `cargo fmt -p perry` clean; diff touches only the intended files.

No version bump / changelog per maintainer instruction (folded in at merge time).
