### PR TITLE
fix(codegen): drop stale CompileOptions field from name-collision test

### DIFF
--- a/crates/perry-codegen/tests/perry_builtin_name_collision.rs
+++ b/crates/perry-codegen/tests/perry_builtin_name_collision.rs
@@ -38,7 +38,6 @@ fn base_opts() -> CompileOptions {
         verify_native_regions: false,
         disable_buffer_fast_path: false,
         namespace_imports: Vec::new(),
-        namespace_reexport_named_imports: std::collections::HashSet::new(),
         imported_classes: Vec::new(),
         imported_enums: Vec::new(),
         imported_async_funcs: std::collections::HashSet::new(),


### PR DESCRIPTION
## What

`crates/perry-codegen/tests/perry_builtin_name_collision.rs` builds a `CompileOptions` value by listing every field explicitly. One of those fields — `namespace_reexport_named_imports` — was removed from the `CompileOptions` struct (it went stale after #6586), so the test file references a field that no longer exists.

## Effect

The test file fails to compile:

```
cargo check --tests -p perry-codegen
```

errors with `struct CompileOptions has no field named namespace_reexport_named_imports`.

## Why it wasn't caught

Integration tests under `crates/*/tests/*.rs` don't run on per-PR CI (only nightly/tag) — see CLAUDE.md — so the breakage landed green and sat red on `main` (present as of 58e555e58).

## Fix

Delete the one stale line from the test's field list so it matches the current struct shape. No production code changes; behaviour is identical. `cargo check --tests -p perry-codegen` compiles again.
