### PR TITLE
refactor(perry-ui-macos): single canonical extern decls for clashing FFI symbols

### DIFF
--- a/crates/perry-ui-macos/src/app.rs
+++ b/crates/perry-ui-macos/src/app.rs
@@ -1,3 +1,5 @@
+use crate::ffi::sel_registerName;
+use crate::ffi::class_addMethod;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, Sel};
 use objc2::{define_class, msg_send, AnyThread, DefinedClass, MainThreadOnly};
@@ -829,17 +831,10 @@ pub fn app_set_frameless(app_handle: i64, value: f64) {
                         extra: usize,
                     ) -> *mut std::ffi::c_void;
                     fn objc_registerClassPair(cls: *mut std::ffi::c_void);
-                    fn class_addMethod(
-                        cls: *mut std::ffi::c_void,
-                        sel: *const std::ffi::c_void,
-                        imp: extern "C" fn(*mut std::ffi::c_void, *mut std::ffi::c_void) -> i8,
-                        types: *const i8,
-                    ) -> i8;
                     fn object_setClass(
                         obj: *mut std::ffi::c_void,
                         cls: *mut std::ffi::c_void,
                     ) -> *mut std::ffi::c_void;
-                    fn sel_registerName(name: *const i8) -> *mut std::ffi::c_void;
                     fn object_getClass(obj: *const std::ffi::c_void) -> *mut std::ffi::c_void;
                 }
                 extern "C" fn can_become_key(
@@ -859,7 +854,7 @@ pub fn app_set_frameless(app_handle: i64, value: f64) {
                     let cls = objc_allocateClassPair(parent_class, subclass_name.as_ptr(), 0);
                     if !cls.is_null() {
                         let sel = sel_registerName(c"canBecomeKeyWindow".as_ptr());
-                        class_addMethod(cls, sel, can_become_key, c"B@:".as_ptr());
+                        class_addMethod(cls, sel, can_become_key as *const std::ffi::c_void, c"B@:".as_ptr());
                         objc_registerClassPair(cls);
                     }
                     cls

--- a/crates/perry-ui-macos/src/audio.rs
+++ b/crates/perry-ui-macos/src/audio.rs
@@ -1,3 +1,5 @@
+use crate::ffi::js_array_push_f64;
+use crate::ffi::js_string_from_bytes;
 use objc2::msg_send;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyClass, AnyObject};
@@ -144,9 +146,7 @@ thread_local! {
 // =============================================================================
 
 extern "C" {
-    fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
     fn js_array_create() -> i64;
-    fn js_array_push_f64(array_ptr: i64, value: f64);
 }
 
 /// ObjC type encoding for AVAudioPCMBuffer block:
@@ -291,7 +291,7 @@ pub fn get_waveform(count: f64) -> f64 {
             // Read from ring buffer, starting from oldest
             let idx = (write_idx + WAVEFORM_SIZE - n + i) % WAVEFORM_SIZE;
             let sample = WAVEFORM_BUFFER[idx];
-            js_array_push_f64(array, sample);
+            js_array_push_f64(array as *mut std::ffi::c_void, sample);
         }
         // Return as f64 (NaN-boxed pointer)
         f64::from_bits(array as u64)
@@ -305,7 +305,7 @@ pub fn get_waveform(count: f64) -> f64 {
 /// pointer bits through as a double and callers read `NaN`).
 pub fn get_device_model() -> i64 {
     let model = get_sysctl_model();
-    unsafe { js_string_from_bytes(model.as_ptr(), model.len() as i32) }
+    unsafe { js_string_from_bytes(model.as_ptr(), model.len() as u32) as i64 }
 }
 
 /// Set the output filename a subsequent `start_recording()` will write to.

--- a/crates/perry-ui-macos/src/audio_playback.rs
+++ b/crates/perry-ui-macos/src/audio_playback.rs
@@ -9,6 +9,8 @@
 //!   PlaybackId  0x10000001 ..= 0x1FFFFFFF  — live AVAudioPlayerNode voice
 //!   Bus         0x20000001 ..= 0x2FFFFFFF  — AVAudioMixerNode group (0 = master)
 
+use crate::ffi::sel_registerName;
+use crate::ffi::class_addMethod;
 use objc2::msg_send;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyClass, AnyObject, Sel};
@@ -31,13 +33,6 @@ extern "C" {
         extra_bytes: usize,
     ) -> *mut std::ffi::c_void;
     fn objc_registerClassPair(cls: *mut std::ffi::c_void);
-    fn class_addMethod(
-        cls: *mut std::ffi::c_void,
-        sel: *const std::ffi::c_void,
-        imp: *const std::ffi::c_void,
-        types: *const i8,
-    ) -> bool;
-    fn sel_registerName(name: *const i8) -> *const std::ffi::c_void;
     fn objc_getClass(name: *const i8) -> *const std::ffi::c_void;
 }
 

--- a/crates/perry-ui-macos/src/clipboard.rs
+++ b/crates/perry-ui-macos/src/clipboard.rs
@@ -1,10 +1,10 @@
+use crate::ffi::js_string_from_bytes;
 use objc2::msg_send;
 use objc2::rc::Retained;
 use objc2_app_kit::NSPasteboard;
 use objc2_foundation::NSString;
 
 extern "C" {
-    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
     fn js_nanbox_string(ptr: i64) -> f64;
 }
 
@@ -18,7 +18,7 @@ pub fn read() -> f64 {
         if let Some(text) = result {
             let rust_str = text.to_string();
             let bytes = rust_str.as_bytes();
-            let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+            let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
             js_nanbox_string(str_ptr as i64)
         } else {
             // Return TAG_UNDEFINED

--- a/crates/perry-ui-macos/src/deeplinks.rs
+++ b/crates/perry-ui-macos/src/deeplinks.rs
@@ -22,6 +22,7 @@
 //! handler is held in `PENDING_COLD_START` and replayed synchronously
 //! when the handler eventually arrives.
 
+use crate::ffi::js_string_from_bytes;
 use std::cell::RefCell;
 
 use objc2::msg_send;
@@ -33,7 +34,6 @@ extern "C" {
     fn js_promise_run_microtasks() -> i32;
     fn js_nanbox_get_pointer(value: f64) -> i64;
     fn js_closure_call2(closure: *const u8, arg0: f64, arg1: f64) -> f64;
-    fn js_string_from_bytes(ptr: *const u8, len: u32) -> *mut u8;
     fn js_nanbox_string(ptr: i64) -> f64;
 }
 

--- a/crates/perry-ui-macos/src/drag_drop.rs
+++ b/crates/perry-ui-macos/src/drag_drop.rs
@@ -23,6 +23,8 @@
 //! advertises copy. When no provider is set, `mouseDown:` forwards to the
 //! original class's implementation so interactive controls keep working.
 
+use crate::ffi::js_array_push_f64;
+use crate::ffi::js_string_from_bytes;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyClass, AnyObject, Bool, ClassBuilder, Imp, Sel};
 use objc2::{msg_send, sel};
@@ -39,11 +41,9 @@ extern "C" {
     fn js_nanbox_get_pointer(value: f64) -> i64;
     fn js_nanbox_pointer(ptr: i64) -> f64;
     fn js_nanbox_string(ptr: i64) -> f64;
-    fn js_string_from_bytes(ptr: *const u8, len: u32) -> *mut c_void;
     fn js_object_alloc(class_id: u32, field_count: u32) -> *mut c_void;
     fn js_object_set_field_by_name(obj: *mut c_void, key: *const c_void, value: f64);
     fn js_array_alloc(capacity: u32) -> *mut c_void;
-    fn js_array_push_f64(arr: *mut c_void, value: f64) -> *mut c_void;
     fn js_jsvalue_to_string(value: f64) -> *const u8;
 }
 

--- a/crates/perry-ui-macos/src/ffi.rs
+++ b/crates/perry-ui-macos/src/ffi.rs
@@ -1,0 +1,68 @@
+//! Canonical `extern "C"` declarations shared across this crate.
+//!
+//! These symbols were previously re-declared per-file with divergent signatures,
+//! triggering ~44 `clashing_extern_declarations` warnings — and, for
+//! `js_string_from_bytes`, a real ABI mismatch (`len: i64` vs the runtime's
+//! `len: u32`) that only worked by register luck. Declare each exactly once here,
+//! matching perry-runtime's real ABI (or the system ABI for objc/CoreGraphics),
+//! and have every call site `use crate::ffi::*`.
+
+use std::ffi::c_void;
+
+use crate::string_header::StringHeader;
+
+// ---------------------------------------------------------------------------
+// perry-runtime symbols
+// ---------------------------------------------------------------------------
+
+extern "C" {
+    /// Canonical: perry-runtime `js_string_from_bytes(data: *const u8, len: u32) -> *mut StringHeader`.
+    pub fn js_string_from_bytes(data: *const u8, len: u32) -> *mut StringHeader;
+
+    /// Canonical: perry-runtime returns the array header pointer. Opaque here.
+    pub fn js_array_push_f64(arr: *mut c_void, value: f64) -> *mut c_void;
+
+    /// Canonical: perry-runtime `js_get_string_pointer_unified(value: f64) -> i64`.
+    pub fn js_get_string_pointer_unified(value: f64) -> i64;
+}
+
+// ---------------------------------------------------------------------------
+// Objective-C runtime symbols (system ABI)
+// ---------------------------------------------------------------------------
+
+extern "C" {
+    /// objc `sel_registerName(const char *) -> SEL`. SEL is an opaque pointer.
+    pub fn sel_registerName(name: *const i8) -> *const c_void;
+
+    /// objc `class_addMethod(Class, SEL, IMP, const char *types) -> BOOL`.
+    /// `imp` and `sel` are opaque pointers; pass function pointers via `as *const c_void`.
+    pub fn class_addMethod(
+        cls: *mut c_void,
+        sel: *const c_void,
+        imp: *const c_void,
+        types: *const i8,
+    ) -> bool;
+}
+
+// ---------------------------------------------------------------------------
+// CoreGraphics symbols (system ABI)
+//
+// The context is an opaque `CGContextRef` (`*mut c_void`); pass any objc
+// `*mut AnyObject` handle via `as *mut c_void`. Only the functions declared by
+// more than one file live here — file-specific ones (gradients, image drawing,
+// arcs) stay local to their single caller.
+// ---------------------------------------------------------------------------
+
+extern "C" {
+    pub fn CGContextSetRGBFillColor(c: *mut c_void, r: f64, g: f64, b: f64, a: f64);
+    pub fn CGContextSetRGBStrokeColor(c: *mut c_void, r: f64, g: f64, b: f64, a: f64);
+    pub fn CGContextSetLineWidth(c: *mut c_void, width: f64);
+    pub fn CGContextFillRect(c: *mut c_void, rect: objc2_core_foundation::CGRect);
+    pub fn CGContextStrokeRect(c: *mut c_void, rect: objc2_core_foundation::CGRect);
+    pub fn CGContextBeginPath(c: *mut c_void);
+    pub fn CGContextMoveToPoint(c: *mut c_void, x: f64, y: f64);
+    pub fn CGContextAddLineToPoint(c: *mut c_void, x: f64, y: f64);
+    pub fn CGContextStrokePath(c: *mut c_void);
+    pub fn CGContextFillPath(c: *mut c_void);
+    pub fn CGContextClosePath(c: *mut c_void);
+}

--- a/crates/perry-ui-macos/src/file_dialog.rs
+++ b/crates/perry-ui-macos/src/file_dialog.rs
@@ -1,3 +1,4 @@
+use crate::ffi::js_string_from_bytes;
 use objc2::msg_send;
 use objc2_app_kit::NSOpenPanel;
 use objc2_foundation::{MainThreadMarker, NSString};
@@ -5,7 +6,6 @@ use objc2_foundation::{MainThreadMarker, NSString};
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;
-    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
     fn js_nanbox_string(ptr: i64) -> f64;
 }
 
@@ -34,7 +34,7 @@ pub fn open_dialog(callback: f64) {
                 let path_str: objc2::rc::Retained<NSString> = msg_send![url, path];
                 let rust_str = path_str.to_string();
                 let bytes = rust_str.as_bytes();
-                let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
                 let nanboxed = js_nanbox_string(str_ptr as i64);
                 js_closure_call1(closure_ptr, nanboxed);
             } else {
@@ -70,7 +70,7 @@ pub fn open_folder_dialog(callback: f64) {
                 let path_str: objc2::rc::Retained<NSString> = msg_send![url, path];
                 let rust_str = path_str.to_string();
                 let bytes = rust_str.as_bytes();
-                let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
                 let nanboxed = js_nanbox_string(str_ptr as i64);
                 js_closure_call1(closure_ptr, nanboxed);
             } else {
@@ -121,7 +121,7 @@ pub fn save_dialog(callback: f64, default_name_ptr: *const u8, _allowed_types_pt
                 let path_str: objc2::rc::Retained<NSString> = msg_send![url, path];
                 let rust_str = path_str.to_string();
                 let bytes = rust_str.as_bytes();
-                let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
                 let nanboxed = js_nanbox_string(str_ptr as i64);
                 js_closure_call1(closure_ptr, nanboxed);
             } else {

--- a/crates/perry-ui-macos/src/geolocation.rs
+++ b/crates/perry-ui-macos/src/geolocation.rs
@@ -4,6 +4,9 @@
 //! older API; this module ships the issue-#552 surface with a 4-arg success
 //! callback `(lat, lng, accuracy, timestamp)` plus a separate error callback.
 
+use crate::ffi::sel_registerName;
+use crate::ffi::class_addMethod;
+use crate::ffi::js_string_from_bytes;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyClass, AnyObject};
 use objc2::{msg_send, Encode, Encoding, RefEncode};
@@ -17,7 +20,6 @@ extern "C" {
     fn js_nanbox_get_pointer(value: f64) -> i64;
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_closure_call4(closure: *const u8, arg0: f64, arg1: f64, arg2: f64, arg3: f64) -> f64;
-    fn js_string_from_bytes(ptr: *const u8, len: u32) -> *mut u8;
     fn js_nanbox_string(ptr: i64) -> f64;
 }
 
@@ -28,13 +30,6 @@ extern "C" {
         extra_bytes: usize,
     ) -> *mut std::ffi::c_void;
     fn objc_registerClassPair(cls: *mut std::ffi::c_void);
-    fn class_addMethod(
-        cls: *mut std::ffi::c_void,
-        sel: *const std::ffi::c_void,
-        imp: *const std::ffi::c_void,
-        types: *const i8,
-    ) -> bool;
-    fn sel_registerName(name: *const i8) -> *const std::ffi::c_void;
     fn objc_getClass(name: *const i8) -> *const std::ffi::c_void;
 }
 

--- a/crates/perry-ui-macos/src/image_picker.rs
+++ b/crates/perry-ui-macos/src/image_picker.rs
@@ -1,6 +1,8 @@
 //! Photo-library image picker (issue #552) — macOS NSOpenPanel filtered
 //! to common image UTIs. Returns an array of absolute filesystem paths.
 
+use crate::ffi::js_array_push_f64;
+use crate::ffi::js_string_from_bytes;
 use objc2::msg_send;
 use objc2_app_kit::NSOpenPanel;
 use objc2_foundation::{MainThreadMarker, NSArray, NSString};
@@ -10,10 +12,8 @@ extern "C" {
     fn js_promise_run_microtasks() -> i32;
     fn js_nanbox_get_pointer(value: f64) -> i64;
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
-    fn js_string_from_bytes(ptr: *const u8, len: u32) -> *mut u8;
     fn js_nanbox_string(ptr: i64) -> f64;
     fn js_array_alloc(capacity: u32) -> *mut std::ffi::c_void;
-    fn js_array_push_f64(arr: *mut std::ffi::c_void, value: f64) -> *mut std::ffi::c_void;
     fn js_nanbox_pointer(ptr: i64) -> f64;
 }
 

--- a/crates/perry-ui-macos/src/keychain.rs
+++ b/crates/perry-ui-macos/src/keychain.rs
@@ -1,7 +1,7 @@
+use crate::ffi::js_string_from_bytes;
 use std::ffi::c_void;
 
 extern "C" {
-    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
     fn js_nanbox_string(ptr: i64) -> f64;
 }
 
@@ -126,7 +126,7 @@ pub fn get(key_ptr: *const u8) -> f64 {
             let bytes: *const u8 = objc2::msg_send![data, bytes];
             let length: usize = objc2::msg_send![data, length];
 
-            let str_ptr = js_string_from_bytes(bytes, length as i64);
+            let str_ptr = js_string_from_bytes(bytes, length as u32);
             js_nanbox_string(str_ptr as i64)
         } else {
             f64::from_bits(0x7FFC_0000_0000_0001) // TAG_UNDEFINED

--- a/crates/perry-ui-macos/src/lib.rs
+++ b/crates/perry-ui-macos/src/lib.rs
@@ -5,6 +5,7 @@ pub mod background;
 pub mod clipboard;
 pub mod crash_log;
 pub mod deeplinks;
+pub mod ffi;
 pub mod drag_drop;
 pub mod file_dialog;
 pub mod geolocation;

--- a/crates/perry-ui-macos/src/lib_ffi/core_widgets.rs
+++ b/crates/perry-ui-macos/src/lib_ffi/core_widgets.rs
@@ -1,3 +1,4 @@
+use crate::ffi::js_string_from_bytes;
 use crate::*;
 
 // =============================================================================
@@ -79,15 +80,9 @@ pub extern "C" fn perry_ui_poll_open_file() -> i64 {
     let path = app::poll_open_file();
     if path.is_empty() {
         // Return empty string
-        extern "C" {
-            fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
-        }
-        unsafe { js_string_from_bytes(std::ptr::null(), 0) }
+        unsafe { js_string_from_bytes(std::ptr::null(), 0) as i64 }
     } else {
-        extern "C" {
-            fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
-        }
-        unsafe { js_string_from_bytes(path.as_ptr(), path.len() as i32) }
+        unsafe { js_string_from_bytes(path.as_ptr(), path.len() as u32) as i64 }
     }
 }
 

--- a/crates/perry-ui-macos/src/lib_ffi/system.rs
+++ b/crates/perry-ui-macos/src/lib_ffi/system.rs
@@ -1,3 +1,4 @@
+use crate::ffi::js_string_from_bytes;
 use crate::*;
 
 // =============================================================================
@@ -187,10 +188,7 @@ pub extern "C" fn perry_system_app_group_set(key_ptr: i64, value_ptr: i64) {
 /// the issue: "" if absent).
 #[no_mangle]
 pub extern "C" fn perry_system_app_group_get(key_ptr: i64) -> i64 {
-    extern "C" {
-        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
-    }
-    let empty = || unsafe { js_string_from_bytes(std::ptr::null(), 0) };
+    let empty = || unsafe { js_string_from_bytes(std::ptr::null(), 0) as i64 };
     let key = appgroup_str_from_header(key_ptr as *const u8);
     if key.is_empty() {
         return empty();
@@ -215,7 +213,7 @@ pub extern "C" fn perry_system_app_group_get(key_ptr: i64) -> i64 {
         if utf8_len == 0 {
             return empty();
         }
-        js_string_from_bytes(utf8_ptr, utf8_len as i32)
+        js_string_from_bytes(utf8_ptr, utf8_len as u32) as i64
     }
 }
 
@@ -357,7 +355,6 @@ pub extern "C" fn perry_system_preferences_get(key_ptr: i64) -> f64 {
         }
     }
     extern "C" {
-        fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
         fn js_nanbox_string(ptr: i64) -> f64;
     }
     let key = str_from_header(key_ptr as *const u8);
@@ -379,7 +376,7 @@ pub extern "C" fn perry_system_preferences_get(key_ptr: i64) -> f64 {
                     &*(obj as *const objc2_foundation::NSString);
                 let rust_str = ns_str.to_string();
                 let bytes = rust_str.as_bytes();
-                let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                let str_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
                 return js_nanbox_string(str_ptr as i64);
             }
         }

--- a/crates/perry-ui-macos/src/lib_ffi/system_aux.rs
+++ b/crates/perry-ui-macos/src/lib_ffi/system_aux.rs
@@ -1,3 +1,4 @@
+use crate::ffi::js_string_from_bytes;
 use crate::*;
 
 // =============================================================================
@@ -42,21 +43,18 @@ pub extern "C" fn perry_system_image_picker_pick(
 /// window is available (e.g. headless CLI builds) or capture fails.
 #[no_mangle]
 pub extern "C" fn perry_system_take_screenshot() -> i64 {
-    extern "C" {
-        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
-    }
     use base64::Engine as _;
     unsafe {
         let mut len: usize = 0;
         let ptr = crate::screenshot::perry_ui_screenshot_capture(&mut len as *mut usize);
         if ptr.is_null() || len == 0 {
-            return js_string_from_bytes(std::ptr::null(), 0);
+            return js_string_from_bytes(std::ptr::null(), 0) as i64;
         }
         let bytes = std::slice::from_raw_parts(ptr, len);
         let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
         // perry_ui_screenshot_capture allocates with libc::malloc; release it.
         libc::free(ptr as *mut libc::c_void);
-        js_string_from_bytes(encoded.as_ptr(), encoded.len() as i32)
+        js_string_from_bytes(encoded.as_ptr(), encoded.len() as u32) as i64
     }
 }
 
@@ -94,9 +92,6 @@ pub extern "C" fn perry_system_app_on_open_url(callback: f64) {
 pub extern "C" fn perry_system_app_get_launch_url() -> i64 {
     let s = deeplinks::launch_url();
     let bytes = s.as_bytes();
-    extern "C" {
-        fn js_string_from_bytes(ptr: *const u8, len: u32) -> *mut u8;
-    }
     unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32) as i64 }
 }
 
@@ -173,29 +168,26 @@ pub extern "C" fn perry_system_get_device_model() -> i64 {
 /// number too. Returned as a Perry-managed string.
 #[no_mangle]
 pub extern "C" fn perry_system_get_os_version() -> i64 {
-    extern "C" {
-        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
-    }
     unsafe {
         let cls = objc2::runtime::AnyClass::get(c"NSProcessInfo").unwrap();
         let info: *mut objc2::runtime::AnyObject = objc2::msg_send![cls, processInfo];
         if info.is_null() {
-            return js_string_from_bytes(std::ptr::null(), 0);
+            return js_string_from_bytes(std::ptr::null(), 0) as i64;
         }
         let s: *mut objc2::runtime::AnyObject =
             objc2::msg_send![info, operatingSystemVersionString];
         if s.is_null() {
-            return js_string_from_bytes(std::ptr::null(), 0);
+            return js_string_from_bytes(std::ptr::null(), 0) as i64;
         }
         let utf8_ptr: *const u8 = objc2::msg_send![s, UTF8String];
         if utf8_ptr.is_null() {
-            return js_string_from_bytes(std::ptr::null(), 0);
+            return js_string_from_bytes(std::ptr::null(), 0) as i64;
         }
         let utf8_len: usize = objc2::msg_send![s, lengthOfBytesUsingEncoding: 4u64];
         if utf8_len == 0 {
-            return js_string_from_bytes(std::ptr::null(), 0);
+            return js_string_from_bytes(std::ptr::null(), 0) as i64;
         }
-        js_string_from_bytes(utf8_ptr, utf8_len as i32)
+        js_string_from_bytes(utf8_ptr, utf8_len as u32) as i64
     }
 }
 
@@ -237,9 +229,6 @@ pub extern "C" fn perry_system_get_app_icon(path_ptr: i64) -> i64 {
 
 #[no_mangle]
 pub extern "C" fn perry_system_get_locale() -> i64 {
-    extern "C" {
-        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
-    }
     unsafe {
         let ns_locale: *mut objc2::runtime::AnyObject = objc2::msg_send![
             objc2::runtime::AnyClass::get(c"NSLocale").unwrap(),
@@ -248,11 +237,11 @@ pub extern "C" fn perry_system_get_locale() -> i64 {
         let lang_code: *mut objc2::runtime::AnyObject = objc2::msg_send![ns_locale, languageCode];
         if lang_code.is_null() {
             let fallback = b"en";
-            return js_string_from_bytes(fallback.as_ptr(), 2);
+            return js_string_from_bytes(fallback.as_ptr(), 2) as i64;
         }
         let utf8: *const u8 = objc2::msg_send![lang_code, UTF8String];
         let len = libc::strlen(utf8 as *const i8);
         let code_len = if len >= 2 { 2 } else { len };
-        js_string_from_bytes(utf8, code_len as i32)
+        js_string_from_bytes(utf8, code_len as u32) as i64
     }
 }

--- a/crates/perry-ui-macos/src/lib_ffi/window_misc.rs
+++ b/crates/perry-ui-macos/src/lib_ffi/window_misc.rs
@@ -1,3 +1,4 @@
+use crate::ffi::js_string_from_bytes;
 use crate::*;
 
 // =============================================================================
@@ -215,10 +216,7 @@ pub extern "C" fn perry_on_layout_change(_callback: f64) {}
 /// and misreported a Mac as a phone.
 #[no_mangle]
 pub extern "C" fn perry_get_device_idiom() -> i64 {
-    extern "C" {
-        fn js_string_from_bytes(ptr: *const u8, len: i32) -> i64;
-    }
-    unsafe { js_string_from_bytes(b"mac".as_ptr(), 3) }
+    unsafe { js_string_from_bytes(b"mac".as_ptr(), 3) as i64 }
 }
 
 // --- TabBar stubs (not yet implemented for macOS) ---

--- a/crates/perry-ui-macos/src/location.rs
+++ b/crates/perry-ui-macos/src/location.rs
@@ -1,3 +1,5 @@
+use crate::ffi::sel_registerName;
+use crate::ffi::class_addMethod;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyClass, AnyObject};
 use objc2::{msg_send, Encode, Encoding, RefEncode};
@@ -18,13 +20,6 @@ extern "C" {
         extra_bytes: usize,
     ) -> *mut std::ffi::c_void;
     fn objc_registerClassPair(cls: *mut std::ffi::c_void);
-    fn class_addMethod(
-        cls: *mut std::ffi::c_void,
-        sel: *const std::ffi::c_void,
-        imp: *const std::ffi::c_void,
-        types: *const i8,
-    ) -> bool;
-    fn sel_registerName(name: *const i8) -> *const std::ffi::c_void;
     fn objc_getClass(name: *const i8) -> *const std::ffi::c_void;
 }
 

--- a/crates/perry-ui-macos/src/media_playback.rs
+++ b/crates/perry-ui-macos/src/media_playback.rs
@@ -18,6 +18,8 @@
 //! - Now Playing metadata uses `MPNowPlayingInfoCenter`. Lock-screen / Touch
 //!   Bar / Siri Remote play/pause/skip routes through `MPRemoteCommandCenter`.
 
+use crate::ffi::sel_registerName;
+use crate::ffi::js_string_from_bytes;
 use objc2::msg_send;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyClass, AnyObject, Sel};
@@ -32,7 +34,6 @@ extern "C" {
     // Signature matches the rest of perry-ui-macos (see audio.rs:133,
     // lib.rs:113/118/1662). Runtime returns `*mut StringHeader` which is
     // i64-sized on Apple platforms.
-    fn js_string_from_bytes(data: *const u8, len: i32) -> i64;
     fn js_string_new_sso(data: *const u8, len: u32) -> f64;
     fn js_run_stdlib_pump();
     fn js_promise_run_microtasks() -> i32;
@@ -46,7 +47,6 @@ extern "C" {
         extra: usize,
     ) -> *mut std::ffi::c_void;
     fn objc_registerClassPair(cls: *mut std::ffi::c_void);
-    fn sel_registerName(name: *const i8) -> *mut std::ffi::c_void;
     fn objc_getClass(name: *const i8) -> *const std::ffi::c_void;
 
     // class_addMethod takes a function pointer of arbitrary shape — every
@@ -347,7 +347,7 @@ pub fn get_state(handle: f64) -> i64 {
             .unwrap_or(MediaState::Idle)
     });
     let s = state.as_str();
-    unsafe { js_string_from_bytes(s.as_ptr(), s.len() as i32) }
+    unsafe { js_string_from_bytes(s.as_ptr(), s.len() as u32) as i64 }
 }
 
 pub fn is_playing(handle: f64) -> f64 {
@@ -501,7 +501,7 @@ fn handle_to_index(handle: f64) -> Option<usize> {
 
 fn empty_state_string() -> i64 {
     let s = "idle";
-    unsafe { js_string_from_bytes(s.as_ptr(), s.len() as i32) }
+    unsafe { js_string_from_bytes(s.as_ptr(), s.len() as u32) as i64 }
 }
 
 unsafe fn current_time_seconds(player: &AnyObject) -> f64 {

--- a/crates/perry-ui-macos/src/network.rs
+++ b/crates/perry-ui-macos/src/network.rs
@@ -7,6 +7,7 @@
 //! (cellular is detectable on macOS too — Mac Catalyst apps and tethered
 //! iPhone connections both surface as `nw_interface_type_cellular`).
 
+use crate::ffi::js_string_from_bytes;
 use block2::RcBlock;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -18,7 +19,6 @@ extern "C" {
     fn js_promise_run_microtasks() -> i32;
     fn js_nanbox_get_pointer(value: f64) -> i64;
     fn js_closure_call2(closure: *const u8, arg0: f64, arg1: f64) -> f64;
-    fn js_string_from_bytes(ptr: *const u8, len: u32) -> *mut u8;
     fn js_nanbox_string(ptr: i64) -> f64;
 }
 

--- a/crates/perry-ui-macos/src/notifications.rs
+++ b/crates/perry-ui-macos/src/notifications.rs
@@ -1,3 +1,4 @@
+use crate::ffi::js_string_from_bytes;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyClass, AnyObject};
 use objc2::{define_class, msg_send, AnyThread};
@@ -23,7 +24,6 @@ thread_local! {
 extern "C" {
     fn js_nanbox_get_pointer(value: f64) -> i64;
     fn js_nanbox_string(ptr: i64) -> f64;
-    fn js_string_from_bytes(data: *const u8, len: u32) -> *mut crate::string_header::StringHeader;
     fn js_closure_call1(closure: *const u8, arg0: f64) -> f64;
     fn js_closure_call2(closure: *const u8, arg0: f64, arg1: f64) -> f64;
     fn js_json_parse(text_ptr: *const crate::string_header::StringHeader) -> u64;

--- a/crates/perry-ui-macos/src/state.rs
+++ b/crates/perry-ui-macos/src/state.rs
@@ -1,3 +1,4 @@
+use crate::ffi::js_get_string_pointer_unified;
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::rc::Rc;
@@ -7,7 +8,6 @@ use crate::widgets;
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;
-    fn js_get_string_pointer_unified(value: f64) -> *const u8;
 }
 
 struct StateEntry {
@@ -111,7 +111,7 @@ fn is_nanboxed_string(value: f64) -> bool {
 /// pointer (the SSO payload bytes look like a bogus address to
 /// `js_nanbox_get_pointer`).
 fn extract_nanboxed_string(value: f64) -> String {
-    let ptr = unsafe { js_get_string_pointer_unified(value) };
+    let ptr = unsafe { js_get_string_pointer_unified(value) as *const u8 };
     str_from_header(ptr).to_string()
 }
 

--- a/crates/perry-ui-macos/src/widgets/alert.rs
+++ b/crates/perry-ui-macos/src/widgets/alert.rs
@@ -1,3 +1,4 @@
+use crate::ffi::js_get_string_pointer_unified;
 use objc2::msg_send;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyClass, AnyObject};
@@ -42,7 +43,6 @@ pub fn show(title_ptr: *const u8, message_ptr: *const u8, arr_ptr: i64, callback
         extern "C" {
             fn js_array_get_length(arr: i64) -> i64;
             fn js_array_get_element(arr: i64, index: i64) -> f64;
-            fn js_get_string_pointer_unified(val: f64) -> i64;
         }
 
         let len = if arr_ptr != 0 {

--- a/crates/perry-ui-macos/src/widgets/calendar.rs
+++ b/crates/perry-ui-macos/src/widgets/calendar.rs
@@ -10,6 +10,7 @@
 //! overlap layout, all-day row. Filed back into #481 for follow-up
 //! once the calendar widget plumbing exists in user-facing TS.
 
+use crate::ffi::js_string_from_bytes;
 use objc2::msg_send;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyClass, AnyObject, Sel};
@@ -22,7 +23,6 @@ use std::collections::HashMap;
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;
-    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
     fn js_nanbox_string(ptr: i64) -> f64;
 }
 
@@ -56,7 +56,7 @@ define_class!(
                     }
                     let iso = format_iso_date(date_obj);
                     let bytes = iso.as_bytes();
-                    let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                    let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
                     let arg = js_nanbox_string(header as i64);
                     let closure_ptr = js_nanbox_get_pointer(callback) as *const u8;
                     js_closure_call1(closure_ptr, arg);
@@ -179,7 +179,7 @@ pub fn get_selected_date(handle: i64) -> f64 {
         }
         let iso = format_iso_date(date_obj);
         let bytes = iso.as_bytes();
-        let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+        let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
         js_nanbox_string(header as i64)
     }
 }

--- a/crates/perry-ui-macos/src/widgets/canvas.rs
+++ b/crates/perry-ui-macos/src/widgets/canvas.rs
@@ -3,6 +3,18 @@
 // Stores a command buffer that replays on each drawRect: call.
 // Commands: MoveTo, LineTo, Stroke, FillGradient, BeginPath, Clear.
 
+use crate::ffi::CGContextClosePath;
+use crate::ffi::CGContextFillPath;
+use crate::ffi::CGContextStrokePath;
+use crate::ffi::CGContextAddLineToPoint;
+use crate::ffi::CGContextMoveToPoint;
+use crate::ffi::CGContextBeginPath;
+use crate::ffi::CGContextStrokeRect;
+use crate::ffi::CGContextFillRect;
+use crate::ffi::CGContextSetLineWidth;
+use crate::ffi::CGContextSetRGBStrokeColor;
+use crate::ffi::CGContextSetRGBFillColor;
+use crate::ffi::js_string_from_bytes;
 use objc2::rc::Retained;
 use objc2::runtime::AnyObject;
 use objc2::{define_class, msg_send, AnyThread, DefinedClass, MainThreadOnly};
@@ -29,20 +41,9 @@ type CGFloat = f64;
 extern "C" {
     fn CGContextSaveGState(c: CGContextRef);
     fn CGContextRestoreGState(c: CGContextRef);
-    fn CGContextBeginPath(c: CGContextRef);
-    fn CGContextMoveToPoint(c: CGContextRef, x: CGFloat, y: CGFloat);
-    fn CGContextAddLineToPoint(c: CGContextRef, x: CGFloat, y: CGFloat);
-    fn CGContextStrokePath(c: CGContextRef);
-    fn CGContextClosePath(c: CGContextRef);
     fn CGContextClip(c: CGContextRef);
-    fn CGContextSetLineWidth(c: CGContextRef, width: CGFloat);
     fn CGContextSetLineCap(c: CGContextRef, cap: i32);
     fn CGContextSetLineJoin(c: CGContextRef, join: i32);
-    fn CGContextSetRGBStrokeColor(c: CGContextRef, r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat);
-    fn CGContextSetRGBFillColor(c: CGContextRef, r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat);
-    fn CGContextFillPath(c: CGContextRef);
-    fn CGContextFillRect(c: CGContextRef, rect: CGRect);
-    fn CGContextStrokeRect(c: CGContextRef, rect: CGRect);
     fn CGContextDrawImage(c: CGContextRef, rect: CGRect, image: CGImageRef);
     fn CGContextDrawLinearGradient(
         c: CGContextRef,
@@ -182,7 +183,6 @@ extern "C" {
     fn js_object_alloc(class_id: u32, field_count: u32) -> *mut c_void;
     fn js_object_set_field_by_name(obj: *mut c_void, key: *const c_void, value: f64);
     fn js_object_get_field_by_name_f64(obj: *mut c_void, key: *const c_void) -> f64;
-    fn js_string_from_bytes(data: *const u8, len: u32) -> *mut c_void;
     fn js_nanbox_pointer(ptr: i64) -> f64;
     fn js_nanbox_string(ptr: i64) -> f64;
     fn js_promise_resolved(value: f64) -> *mut c_void;
@@ -190,7 +190,7 @@ extern "C" {
 }
 
 fn js_key(name: &[u8]) -> *mut c_void {
-    unsafe { js_string_from_bytes(name.as_ptr(), name.len() as u32) }
+    unsafe { js_string_from_bytes(name.as_ptr(), name.len() as u32) as *mut c_void }
 }
 
 fn set_image_field(obj: *mut c_void, name: &[u8], value: f64) {

--- a/crates/perry-ui-macos/src/widgets/chart.rs
+++ b/crates/perry-ui-macos/src/widgets/chart.rs
@@ -18,6 +18,16 @@
 //! first; richer modes follow as #474 follow-ups once the surface is
 //! used in TS apps.
 
+use crate::ffi::CGContextClosePath;
+use crate::ffi::CGContextFillPath;
+use crate::ffi::CGContextStrokePath;
+use crate::ffi::CGContextAddLineToPoint;
+use crate::ffi::CGContextMoveToPoint;
+use crate::ffi::CGContextBeginPath;
+use crate::ffi::CGContextFillRect;
+use crate::ffi::CGContextSetLineWidth;
+use crate::ffi::CGContextSetRGBStrokeColor;
+use crate::ffi::CGContextSetRGBFillColor;
 use objc2::msg_send;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyClass, AnyObject};
@@ -112,7 +122,7 @@ impl PerryChartView {
 // Drawing routines — CoreGraphics on the current NSGraphicsContext.
 // ===========================================================================
 
-unsafe fn current_cg_context() -> *mut AnyObject {
+unsafe fn current_cg_context() -> *mut std::ffi::c_void {
     let ctx_cls = AnyClass::get(c"NSGraphicsContext").unwrap();
     let cur: *mut AnyObject = msg_send![ctx_cls, currentContext];
     if cur.is_null() {
@@ -122,30 +132,8 @@ unsafe fn current_cg_context() -> *mut AnyObject {
 }
 
 extern "C" {
-    fn CGContextSetRGBFillColor(
-        c: *mut AnyObject,
-        red: CGFloat,
-        green: CGFloat,
-        blue: CGFloat,
-        alpha: CGFloat,
-    );
-    fn CGContextSetRGBStrokeColor(
-        c: *mut AnyObject,
-        red: CGFloat,
-        green: CGFloat,
-        blue: CGFloat,
-        alpha: CGFloat,
-    );
-    fn CGContextSetLineWidth(c: *mut AnyObject, width: CGFloat);
-    fn CGContextFillRect(c: *mut AnyObject, rect: objc2_core_foundation::CGRect);
-    fn CGContextStrokeRect(c: *mut AnyObject, rect: objc2_core_foundation::CGRect);
-    fn CGContextBeginPath(c: *mut AnyObject);
-    fn CGContextMoveToPoint(c: *mut AnyObject, x: CGFloat, y: CGFloat);
-    fn CGContextAddLineToPoint(c: *mut AnyObject, x: CGFloat, y: CGFloat);
-    fn CGContextStrokePath(c: *mut AnyObject);
-    fn CGContextFillPath(c: *mut AnyObject);
     fn CGContextAddArc(
-        c: *mut AnyObject,
+        c: *mut std::ffi::c_void,
         x: CGFloat,
         y: CGFloat,
         radius: CGFloat,
@@ -153,7 +141,6 @@ extern "C" {
         end_angle: CGFloat,
         clockwise: i32,
     );
-    fn CGContextClosePath(c: *mut AnyObject);
 }
 
 const PADDING: CGFloat = 24.0;
@@ -220,7 +207,7 @@ unsafe fn draw_chart(
 }
 
 unsafe fn draw_line(
-    ctx: *mut AnyObject,
+    ctx: *mut std::ffi::c_void,
     plot: objc2_core_foundation::CGRect,
     data: &[(String, f64)],
 ) {
@@ -268,7 +255,7 @@ unsafe fn draw_line(
 }
 
 unsafe fn draw_bars(
-    ctx: *mut AnyObject,
+    ctx: *mut std::ffi::c_void,
     plot: objc2_core_foundation::CGRect,
     data: &[(String, f64)],
 ) {
@@ -297,7 +284,7 @@ unsafe fn draw_bars(
 }
 
 unsafe fn draw_pie(
-    ctx: *mut AnyObject,
+    ctx: *mut std::ffi::c_void,
     plot: objc2_core_foundation::CGRect,
     data: &[(String, f64)],
 ) {

--- a/crates/perry-ui-macos/src/widgets/combobox.rs
+++ b/crates/perry-ui-macos/src/widgets/combobox.rs
@@ -9,6 +9,7 @@
 //! See `picker.rs` for the sibling `NSPopUpButton` widget — combobox is
 //! the editable + filterable variant.
 
+use crate::ffi::js_string_from_bytes;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyClass, AnyObject, Sel};
 use objc2::{define_class, msg_send, AnyThread, DefinedClass, MainThreadOnly};
@@ -24,7 +25,6 @@ thread_local! {
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;
-    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
     fn js_nanbox_string(ptr: i64) -> f64;
 }
 
@@ -72,7 +72,7 @@ fn fire_callback(target_addr: usize, handle: i64) {
             unsafe {
                 let ns_str: Retained<NSString> = msg_send![&*view, stringValue];
                 let bytes = ns_str.to_string();
-                let header_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                let header_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
                 let arg = js_nanbox_string(header_ptr as i64);
                 let closure_ptr = js_nanbox_get_pointer(callback) as *const u8;
                 js_closure_call1(closure_ptr, arg);
@@ -178,7 +178,7 @@ pub fn get_value(handle: i64) -> f64 {
     unsafe {
         let ns_str: Retained<NSString> = msg_send![&*view, stringValue];
         let bytes = ns_str.to_string();
-        let header_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+        let header_ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
         js_nanbox_string(header_ptr as i64)
     }
 }

--- a/crates/perry-ui-macos/src/widgets/date_picker.rs
+++ b/crates/perry-ui-macos/src/widgets/date_picker.rs
@@ -10,6 +10,7 @@
 //! (POSIX-locale formatter, stable across user locales) — matching the
 //! `Calendar` twin.
 
+use crate::ffi::js_string_from_bytes;
 use objc2::msg_send;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyClass, AnyObject, Sel};
@@ -22,7 +23,6 @@ use std::collections::HashMap;
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;
-    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
     fn js_nanbox_string(ptr: i64) -> f64;
 }
 
@@ -56,7 +56,7 @@ define_class!(
                     }
                     let iso = format_iso_date(date_obj);
                     let bytes = iso.as_bytes();
-                    let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                    let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
                     let arg = js_nanbox_string(header as i64);
                     let closure_ptr = js_nanbox_get_pointer(callback) as *const u8;
                     js_closure_call1(closure_ptr, arg);
@@ -178,7 +178,7 @@ pub fn get_selected_date(handle: i64) -> f64 {
         }
         let iso = format_iso_date(date_obj);
         let bytes = iso.as_bytes();
-        let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+        let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
         js_nanbox_string(header as i64)
     }
 }

--- a/crates/perry-ui-macos/src/widgets/rich_text.rs
+++ b/crates/perry-ui-macos/src/widgets/rich_text.rs
@@ -15,6 +15,7 @@
 //! cover the inline-formatting commands; toolbar + block commands +
 //! markdown ship in a follow-up.
 
+use crate::ffi::js_string_from_bytes;
 use objc2::msg_send;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyClass, AnyObject, Sel};
@@ -27,7 +28,6 @@ use std::collections::HashMap;
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;
-    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
     fn js_nanbox_string(ptr: i64) -> f64;
 }
 
@@ -84,7 +84,7 @@ define_class!(
                 let plain = get_string_inner(handle);
                 unsafe {
                     let bytes = plain.as_bytes();
-                    let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                    let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
                     let arg = js_nanbox_string(header as i64);
                     let closure_ptr = js_nanbox_get_pointer(callback) as *const u8;
                     js_closure_call1(closure_ptr, arg);
@@ -176,7 +176,7 @@ pub fn get_string(handle: i64) -> f64 {
     let s = get_string_inner(handle);
     unsafe {
         let bytes = s.as_bytes();
-        let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+        let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
         js_nanbox_string(header as i64)
     }
 }
@@ -253,7 +253,7 @@ pub fn get_html(handle: i64) -> f64 {
         };
         let html = str_obj.to_string();
         let bytes = html.as_bytes();
-        let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+        let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
         js_nanbox_string(header as i64)
     }
 }

--- a/crates/perry-ui-macos/src/widgets/scrollview.rs
+++ b/crates/perry-ui-macos/src/widgets/scrollview.rs
@@ -1,3 +1,5 @@
+use crate::ffi::sel_registerName;
+use crate::ffi::class_addMethod;
 use objc2::msg_send;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyClass, AnyObject, Sel};
@@ -22,13 +24,6 @@ extern "C" {
         extra_bytes: usize,
     ) -> *mut std::ffi::c_void;
     fn objc_registerClassPair(cls: *mut std::ffi::c_void);
-    fn class_addMethod(
-        cls: *mut std::ffi::c_void,
-        sel: *const std::ffi::c_void,
-        imp: *const std::ffi::c_void,
-        types: *const i8,
-    ) -> bool;
-    fn sel_registerName(name: *const i8) -> *const std::ffi::c_void;
     fn objc_getClass(name: *const i8) -> *const std::ffi::c_void;
 }
 

--- a/crates/perry-ui-macos/src/widgets/securefield.rs
+++ b/crates/perry-ui-macos/src/widgets/securefield.rs
@@ -1,3 +1,4 @@
+use crate::ffi::js_string_from_bytes;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, Sel};
 use objc2::{define_class, msg_send, AnyThread, DefinedClass, MainThreadOnly};
@@ -15,7 +16,6 @@ thread_local! {
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;
-    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
     fn js_nanbox_string(ptr: i64) -> f64;
 }
 
@@ -55,7 +55,7 @@ define_class!(
                         let rust_str = text.to_string();
                         let bytes = rust_str.as_bytes();
 
-                        let str_ptr = unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64) };
+                        let str_ptr = unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32) };
                         let nanboxed = unsafe { js_nanbox_string(str_ptr as i64) };
 
                         let closure_ptr = unsafe { js_nanbox_get_pointer(closure_f64) };

--- a/crates/perry-ui-macos/src/widgets/table.rs
+++ b/crates/perry-ui-macos/src/widgets/table.rs
@@ -1,3 +1,4 @@
+use crate::ffi::js_string_from_bytes;
 use objc2::msg_send;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyClass, AnyObject};
@@ -553,9 +554,6 @@ pub fn set_filter_text(handle: i64, text_ptr: *const u8) {
 /// arranges NaN-boxing on the codegen side. Pinned to survive GC until the
 /// caller consumes it (mirrors `textfield::get_string_value`).
 pub fn get_filter_text(handle: i64) -> *const u8 {
-    extern "C" {
-        fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
-    }
     let text = if let Some(idx) = find_entry_idx(handle) {
         TABLES.with(|t| {
             t.borrow()
@@ -568,10 +566,10 @@ pub fn get_filter_text(handle: i64) -> *const u8 {
     };
     let bytes = text.as_bytes();
     unsafe {
-        let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+        let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
         // Pin the GC allocation: GcHeader sits at ptr-8, gc_flags at offset 1.
         let gc_flags_ptr = (ptr as *mut u8).sub(8).add(1);
         *gc_flags_ptr |= 0x04; // GC_FLAG_PINNED
-        ptr
+        ptr as *const u8
     }
 }

--- a/crates/perry-ui-macos/src/widgets/textarea.rs
+++ b/crates/perry-ui-macos/src/widgets/textarea.rs
@@ -1,3 +1,4 @@
+use crate::ffi::js_string_from_bytes;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyClass, AnyObject, Sel};
 use objc2::{define_class, msg_send, AnyThread, DefinedClass};
@@ -15,7 +16,6 @@ thread_local! {
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;
-    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
     fn js_nanbox_string(ptr: i64) -> f64;
 }
 
@@ -52,7 +52,7 @@ define_class!(
                         let s = rust_str.to_string();
                         let bytes = s.as_bytes();
 
-                        let str_ptr = unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64) };
+                        let str_ptr = unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32) };
                         let nanboxed = unsafe { js_nanbox_string(str_ptr as i64) };
 
                         let closure_ptr = unsafe { js_nanbox_get_pointer(closure_f64) };
@@ -194,9 +194,9 @@ pub fn get_string(handle: i64) -> *const u8 {
                 let text: Retained<AnyObject> = msg_send![tv, string];
                 let ns_str: &NSString = &*(Retained::as_ptr(&text) as *const NSString);
                 let s = ns_str.to_string();
-                return js_string_from_bytes(s.as_ptr(), s.len() as i64);
+                return js_string_from_bytes(s.as_ptr(), s.len() as u32) as *const u8;
             }
         }
     }
-    unsafe { js_string_from_bytes(std::ptr::null(), 0) }
+    unsafe { js_string_from_bytes(std::ptr::null(), 0) as *const u8 }
 }

--- a/crates/perry-ui-macos/src/widgets/textfield.rs
+++ b/crates/perry-ui-macos/src/widgets/textfield.rs
@@ -1,3 +1,4 @@
+use crate::ffi::js_string_from_bytes;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, Sel};
 use objc2::{define_class, msg_send, AnyThread, DefinedClass};
@@ -20,7 +21,6 @@ thread_local! {
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;
-    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
     fn js_nanbox_string(ptr: i64) -> f64;
 }
 
@@ -61,7 +61,7 @@ define_class!(
                         let rust_str = text.to_string();
                         let bytes = rust_str.as_bytes();
 
-                        let str_ptr = unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64) };
+                        let str_ptr = unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32) };
                         let nanboxed = unsafe { js_nanbox_string(str_ptr as i64) };
 
                         let closure_ptr = unsafe { js_nanbox_get_pointer(closure_f64) };
@@ -136,7 +136,7 @@ define_class!(
                         let rust_str = text.to_string();
                         let bytes = rust_str.as_bytes();
 
-                        let str_ptr = unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64) };
+                        let str_ptr = unsafe { js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32) };
                         let nanboxed = unsafe { js_nanbox_string(str_ptr as i64) };
 
                         let closure_ptr = unsafe { js_nanbox_get_pointer(closure_f64) };
@@ -262,7 +262,7 @@ pub fn get_string_value(handle: i64) -> *const u8 {
             let tf: &NSTextField = &*(Retained::as_ptr(&view) as *const NSTextField);
             let value = tf.stringValue();
             let bytes = value.to_string();
-            let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+            let ptr = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
             // Pin the GC allocation so it won't be collected before the caller uses it.
             // GcHeader layout: obj_type(u8) + gc_flags(u8) + reserved(u16) + size(u32) = 8 bytes
             // GcHeader sits BEFORE the user pointer (ptr - 8). gc_flags is at offset 1.
@@ -270,10 +270,10 @@ pub fn get_string_value(handle: i64) -> *const u8 {
             // Pin the GC allocation so it survives until the caller consumes it
             let gc_flags_ptr = (ptr as *mut u8).sub(8).add(1);
             *gc_flags_ptr |= 0x04; // GC_FLAG_PINNED
-            return ptr;
+            return ptr as *const u8;
         }
     }
-    unsafe { js_string_from_bytes(std::ptr::null(), 0) }
+    unsafe { js_string_from_bytes(std::ptr::null(), 0) as *const u8 }
 }
 
 /// Set an onSubmit callback (fires when user presses Enter/Return).

--- a/crates/perry-ui-macos/src/widgets/tree_view.rs
+++ b/crates/perry-ui-macos/src/widgets/tree_view.rs
@@ -13,6 +13,7 @@
 //! Out of scope this iteration: drag-and-drop, lazy loading, multi-
 //! select, inline rename, icons. Filed back into #480 for follow-up.
 
+use crate::ffi::js_string_from_bytes;
 use objc2::msg_send;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyClass, AnyObject, Sel};
@@ -25,7 +26,6 @@ use std::collections::HashMap;
 extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;
-    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
     fn js_nanbox_string(ptr: i64) -> f64;
 }
 
@@ -245,7 +245,7 @@ define_class!(
                     });
                     let Some(id) = id_str else { return };
                     let bytes = id.as_bytes();
-                    let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+                    let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
                     let arg = js_nanbox_string(header as i64);
                     let closure = js_nanbox_get_pointer(on_select) as *const u8;
                     js_closure_call1(closure, arg);
@@ -416,7 +416,7 @@ pub fn get_selected_id(handle: i64) -> f64 {
             return f64::from_bits(0x7FFC_0000_0000_0001);
         };
         let bytes = id.as_bytes();
-        let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+        let header = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
         js_nanbox_string(header as i64)
     }
 }

--- a/crates/perry-ui-macos/src/widgets/webview.rs
+++ b/crates/perry-ui-macos/src/widgets/webview.rs
@@ -20,6 +20,8 @@
 //! per the design — auth flows reusing a logged-in browser session is usually
 //! a footgun. Opt out via `ephemeral: false` when needed.
 
+use crate::ffi::js_get_string_pointer_unified;
+use crate::ffi::js_string_from_bytes;
 use objc2::msg_send;
 use objc2::rc::Retained;
 use objc2::runtime::{AnyClass, AnyObject};
@@ -34,7 +36,6 @@ extern "C" {
     fn js_closure_call1(closure: *const u8, arg: f64) -> f64;
     fn js_closure_call2(closure: *const u8, arg1: f64, arg2: f64) -> f64;
     fn js_nanbox_get_pointer(value: f64) -> i64;
-    fn js_string_from_bytes(ptr: *const u8, len: i64) -> *const u8;
     fn js_nanbox_string(ptr: i64) -> f64;
     fn js_is_truthy(value: f64) -> i32;
 }
@@ -83,7 +84,7 @@ fn str_from_header(ptr: *const u8) -> &'static str {
 fn nanbox_str(s: &str) -> f64 {
     let bytes = s.as_bytes();
     unsafe {
-        let p = js_string_from_bytes(bytes.as_ptr(), bytes.len() as i64);
+        let p = js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
         js_nanbox_string(p as i64)
     }
 }
@@ -737,7 +738,6 @@ pub fn set_allowed_domains(handle: i64, domains_arr_handle: i64) {
     extern "C" {
         fn js_array_get_length(arr: i64) -> i64;
         fn js_array_get_element_f64(arr: i64, index: i64) -> f64;
-        fn js_get_string_pointer_unified(value: f64) -> *const u8;
     }
 
     let mut domains = Vec::new();
@@ -745,7 +745,7 @@ pub fn set_allowed_domains(handle: i64, domains_arr_handle: i64) {
         let len = js_array_get_length(domains_arr_handle);
         for i in 0..len {
             let elem = js_array_get_element_f64(domains_arr_handle, i);
-            let str_ptr = js_get_string_pointer_unified(elem);
+            let str_ptr = js_get_string_pointer_unified(elem) as *const u8;
             if !str_ptr.is_null() {
                 domains.push(str_from_header(str_ptr).to_string());
             }


### PR DESCRIPTION
## Why

`perry-ui-macos` re-declared 16 runtime/objc/CoreGraphics symbols per-file with divergent signatures, producing ~44 `clashing_extern_declarations` warnings on macOS `cargo check`. The worst offender, `js_string_from_bytes` (~30 declarations, 5 signatures), had a **real ABI mismatch** — `len: i64` in some files vs the runtime's canonical `u32` — that only worked by x86-64/arm64 register luck.

## What

- New `crate::ffi` module with **one canonical declaration per symbol**, matching perry-runtime's real ABI (`js_string_from_bytes` → `(*const u8, u32) -> *mut StringHeader`, `js_array_push_f64`, `js_get_string_pointer_unified`) or the system ABI for objc (`sel_registerName`, `class_addMethod`) and the 11 shared `CGContext*` functions.
- Every call site now imports from `crate::ffi`; ~65 sites adjusted with the necessary casts (`as u32` on lengths, `as i64` / `as *const u8` / `as *mut c_void` on returns).
- `chart.rs`'s CoreGraphics context switched from `*mut AnyObject` to the canonical `*mut c_void` (via `current_cg_context` + helpers) so its calls match with no per-call casts.
- Removed the empty `extern "C" {}` blocks left where a symbol was the sole declaration.

`class_add_method_raw` is deliberately left as-is — single declaration, never clashed.

## Result

44 → 0 `clashing_extern_declarations` warnings; clean `cargo check -p perry-ui-macos`. No behavior change (all divergent variants were 8-byte/ABI-compatible except the `js_string_from_bytes` length, which is now correct rather than lucky).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS interoperability for strings, graphics, windowing, media, and system features.
  * Corrected string length handling across dialogs, widgets, clipboard, keychain, networking, and device APIs.
  * Improved reliability of text conversion, drawing, and native window behavior.

* **Refactor**
  * Consolidated macOS native integration through shared interface handling for more consistent behavior and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->