### PR TITLE
fix(runtime): class extends a bound function with no valid prototype throws TypeError (#5893)

### DIFF
--- a/crates/perry-runtime/src/object/class_registry/construct.rs
+++ b/crates/perry-runtime/src/object/class_registry/construct.rs
@@ -1185,7 +1185,7 @@ fn bound_function_target_ptr(value: f64) -> Option<*mut crate::closure::ClosureH
     }
 }
 
-fn is_bound_function_closure_value(value: f64) -> bool {
+pub(crate) fn is_bound_function_closure_value(value: f64) -> bool {
     bound_function_target_ptr(value).is_some()
 }
 

--- a/crates/perry-runtime/src/object/class_registry/parent_static.rs
+++ b/crates/perry-runtime/src/object/class_registry/parent_static.rs
@@ -61,7 +61,7 @@ pub extern "C" fn js_register_class_parent(class_id: u32, parent_class_id: u32) 
 /// Self-registration (`parent_cid == class_id`) is rejected so a
 /// recursive helper that returns its receiver can't create a cycle.
 #[no_mangle]
-pub extern "C" fn js_register_class_parent_dynamic(class_id: u32, parent_value: f64) {
+pub extern "C" fn js_register_class_parent_dynamic(class_id: u32, mut parent_value: f64) {
     // Stash the parent VALUE keyed by child class id so `super()` can read it
     // back (`js_get_dynamic_parent_value`) instead of re-evaluating the extends
     // expression inside the constructor scope. The decl-time call here runs in
@@ -121,11 +121,6 @@ pub extern "C" fn js_register_class_parent_dynamic(class_id: u32, parent_value: 
         );
     }
 
-    let bits = parent_value.to_bits();
-    let tag = bits & 0xFFFF_0000_0000_0000;
-    const INT32_TAG: u64 = 0x7FFE_0000_0000_0000;
-    const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
-
     // #5893 (ClassDefinitionEvaluation): once the superclass is confirmed a
     // constructor (above), `Get(superclass, "prototype")` must be an Object or
     // null, else a TypeError is thrown at class-definition time. A *bound*
@@ -146,6 +141,15 @@ pub extern "C" fn js_register_class_parent_dynamic(class_id: u32, parent_value: 
     // — the getter-invocation count is observable (prototype-getter.js asserts
     // the accessor runs exactly once per class definition).
     if super::construct::is_bound_function_closure_value(parent_value) {
+        // `js_get_property` can run a user-defined `prototype` getter, which may
+        // allocate and move `parent_value`'s nan-boxed object under GC. Root it
+        // across the call and refresh from the handle so the later reuses below
+        // (`js_nanbox_get_pointer(parent_value)`) see the current address rather
+        // than a stale pre-evacuation pointer. (The `CLASS_DYNAMIC_PARENT_VALUE`
+        // stash above is a rewritten GC root — see `class_registry/gc_roots.rs`
+        // — so it needs no equivalent refresh.)
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let parent_handle = scope.root_nanbox_f64(parent_value);
         let proto = unsafe {
             crate::value::js_get_property(
                 parent_value,
@@ -153,7 +157,9 @@ pub extern "C" fn js_register_class_parent_dynamic(class_id: u32, parent_value: 
                 b"prototype".len() as i64,
             )
         };
+        parent_value = parent_handle.get_nanbox_f64();
         const TAG_NULL: u64 = 0x7FFC_0000_0000_0002;
+        const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
         let pbits = proto.to_bits();
         let proto_is_object_or_null =
             pbits == TAG_NULL || (pbits & 0xFFFF_0000_0000_0000) == POINTER_TAG;
@@ -163,6 +169,11 @@ pub extern "C" fn js_register_class_parent_dynamic(class_id: u32, parent_value: 
             );
         }
     }
+
+    let bits = parent_value.to_bits();
+    let tag = bits & 0xFFFF_0000_0000_0000;
+    const INT32_TAG: u64 = 0x7FFE_0000_0000_0000;
+    const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
 
     let parent_cid: u32 = if tag == INT32_TAG {
         // ClassRef: lower 32 bits are the class id. Verify it's

--- a/crates/perry-runtime/src/object/class_registry/parent_static.rs
+++ b/crates/perry-runtime/src/object/class_registry/parent_static.rs
@@ -126,6 +126,44 @@ pub extern "C" fn js_register_class_parent_dynamic(class_id: u32, parent_value: 
     const INT32_TAG: u64 = 0x7FFE_0000_0000_0000;
     const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
 
+    // #5893 (ClassDefinitionEvaluation): once the superclass is confirmed a
+    // constructor (above), `Get(superclass, "prototype")` must be an Object or
+    // null, else a TypeError is thrown at class-definition time. A *bound*
+    // function (`fn.bind(...)`) has no intrinsic `.prototype`, so its
+    // `Get(_, "prototype")` yields either whatever a `defineProperty`
+    // accessor/data on the bound function provides or `undefined` — and
+    // `undefined`, a number, etc. are neither Object nor null. test262
+    // language/statements/class/definition/{constructable-but-no-prototype,
+    // prototype-getter,prototype-setter}.
+    //
+    // Scope to bound functions specifically: an ordinary function always
+    // carries a valid object prototype (even after unrelated `defineProperty`
+    // calls on it — see superclass-static-method-override), and a real class
+    // (ClassRef, INT32) or per-evaluation class object likewise. So this stays
+    // purely additive — it cannot reject anything Node accepts, since Node also
+    // throws for every `class C extends aBoundFunction` whose bound function
+    // lacks a valid `prototype`. The `prototype` read happens exactly once here
+    // — the getter-invocation count is observable (prototype-getter.js asserts
+    // the accessor runs exactly once per class definition).
+    if super::construct::is_bound_function_closure_value(parent_value) {
+        let proto = unsafe {
+            crate::value::js_get_property(
+                parent_value,
+                b"prototype".as_ptr() as i64,
+                b"prototype".len() as i64,
+            )
+        };
+        const TAG_NULL: u64 = 0x7FFC_0000_0000_0002;
+        let pbits = proto.to_bits();
+        let proto_is_object_or_null =
+            pbits == TAG_NULL || (pbits & 0xFFFF_0000_0000_0000) == POINTER_TAG;
+        if !proto_is_object_or_null {
+            super::super::object_ops::throw_object_type_error(
+                b"Class extends value does not have valid prototype property",
+            );
+        }
+    }
+
     let parent_cid: u32 = if tag == INT32_TAG {
         // ClassRef: lower 32 bits are the class id. Verify it's
         // actually a registered class id before trusting it.


### PR DESCRIPTION
Part of #5893 (test262 language/class tail).

## What

Per ClassDefinitionEvaluation, after a class's `extends` superclass is confirmed to be a constructor, the engine performs `Get(superclass, "prototype")` and throws a **TypeError** if the result is neither an Object nor `null`. Perry skipped this check, so several class-definition negatives were silently accepted.

A **bound function** (`fn.bind(...)`) has no intrinsic `.prototype`, so `Get(_, "prototype")` yields either whatever an `Object.defineProperty` accessor/data on the bound function provides, or `undefined`. `undefined`/numbers/etc. are neither Object nor null and must throw:

```js
var Base = function () {}.bind();
class C extends Base {}          // now throws TypeError (was silently accepted)
```

## How

Added the check in `js_register_class_parent_dynamic` (the class-definition-time heritage hook), scoped to bound-function superclasses via the existing `is_bound_function_closure_value` helper (promoted to `pub(crate)`).

Why scoping to bound functions is safe and **purely additive**:
- An ordinary function always carries a valid object prototype — *even after unrelated `defineProperty` calls on it* (this is why the first draft, which checked all closure superclasses, regressed `superclass-static-method-override.js`; the runtime `js_get_property` helper doesn't fall back to the intrinsic prototype once a dynamic-props store exists — but a bound function has no intrinsic prototype to fall back to, so it's unaffected).
- A real class (`ClassRef`) or per-evaluation class object likewise always has a valid object prototype, so the check is inert for them.
- It cannot reject anything Node accepts: Node throws for **every** `class C extends aBoundFunction` whose bound function lacks a valid `prototype`.

The `prototype` read happens exactly once, matching the spec's single `Get` — the getter-invocation count is observable (`prototype-getter.js` asserts the accessor runs exactly once per class definition).

## Validation

test262 `language/statements/class` + `language/expressions/class` subset radar (`scripts/test262_subset.py`), before → after:

| bucket | before | after |
|---|---|---|
| pass | 5193 | **5196** |
| runtime-fail | 150 | **147** |

**3 newly passing, 0 regressions:**
- `language/statements/class/definition/constructable-but-no-prototype.js`
- `language/statements/class/definition/prototype-getter.js`
- `language/statements/class/definition/prototype-setter.js`

(The `Proxy/no-prototype-throws.js` case is the same spec rule but for the global `Proxy` constructor, which flows through a different heritage branch — left for a follow-up to keep this change minimal.)

Per the external-contributor convention in CLAUDE.md, this PR does not bump the version or add a changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when a dynamically registered class extends a bound function.
  * The runtime now checks the bound function’s `prototype` value and throws a `TypeError` if it’s not `null` or an object (for example, `undefined` or a non-object), matching expected JavaScript behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->