### PR TITLE
docs: regenerate API reference + .d.ts (api-docs-drift is red on every PR)

### DIFF
--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -1,6 +1,6 @@
 // Auto-generated from Perry's API manifest (#465). Do not edit by hand.
 // Source: perry-api-manifest::API_MANIFEST
-// Coverage: 1980 entries across 119 modules
+// Coverage: 1981 entries across 119 modules
 
 type PerryU32 = number & { readonly __perryU32?: never };
 type PerryU64 = number & { readonly __perryU64?: never };
@@ -918,6 +918,8 @@ declare module "constants" {
 
 declare module "cron" {
   /** stdlib */
+  export class CronJob { [key: string]: any; }
+  /** stdlib */
   export function describe(expr: string): string;
   /** stdlib */
   export function schedule(expr: string, handler: any): any;
@@ -1093,9 +1095,9 @@ declare module "date-fns" {
 
 declare module "dayjs" {
   /** stdlib */
-  export function dayjs(...args: any[]): any;
+  export function dayjs(input?: any): any;
   /** stdlib */
-  export default function (...args: any[]): any;
+  export default function (input?: any): any;
 }
 
 declare module "dgram" {
@@ -2070,9 +2072,9 @@ declare module "module" {
 
 declare module "moment" {
   /** stdlib */
-  export default function (...args: any[]): any;
+  export default function (input?: any): any;
   /** stdlib */
-  export function moment(...args: any[]): any;
+  export function moment(input?: any): any;
 }
 
 declare module "mongodb" {
@@ -3490,9 +3492,9 @@ declare module "sharp" {
 
 declare module "slugify" {
   /** stdlib */
-  export default function (p0: string, p1: string, p2: string): string;
+  export default function (p0: string, p1?: any): string;
   /** stdlib */
-  export function slugify(p0: string, p1: string, p2: string): string;
+  export function slugify(p0: string, p1?: any): string;
 }
 
 declare module "sqlite" {

--- a/docs/src/api/reference.md
+++ b/docs/src/api/reference.md
@@ -2,7 +2,7 @@
 
 This page is auto-generated from Perry's compile-time API manifest (`perry-api-manifest::API_MANIFEST`). It is the source of truth for what `perry compile` accepts; references to symbols not listed here produce `R005 UnimplementedApi` (issue #463). Stubs (#464) are flagged ⚠ — they link cleanly but no-op at runtime on the chosen target.
 
-Total: 2855 entries across 121 modules.
+Total: 2887 entries across 121 modules.
 
 ## Modules
 
@@ -738,6 +738,10 @@ Total: 2855 entries across 121 modules.
 - `defaultCoreCipherList`
 
 ## `cron`
+
+### Classes
+
+- `CronJob`
 
 ### Methods
 
@@ -1933,8 +1937,33 @@ Total: 2855 entries across 121 modules.
 
 ### Methods
 
+- `add` — instance
+- `clone` — instance
+- `date` — instance
+- `day` — instance
 - `default` — module
+- `diff` — instance
+- `endOf` — instance
+- `format` — instance
+- `fromNow` — instance
+- `hour` — instance
+- `isAfter` — instance
+- `isBefore` — instance
+- `isBetween` — instance
+- `isSame` — instance
+- `isValid` — instance
+- `millisecond` — instance
+- `minute` — instance
 - `moment` — module
+- `month` — instance
+- `second` — instance
+- `startOf` — instance
+- `subtract` — instance
+- `toDate` — instance
+- `toISOString` — instance
+- `unix` — instance
+- `valueOf` — instance
+- `year` — instance
 
 ## `mongodb`
 
@@ -2934,6 +2963,15 @@ Total: 2855 entries across 121 modules.
 
 - `RateLimiterAbstract`
 - `RateLimiterMemory`
+
+### Methods
+
+- `block` — instance
+- `consume` — instance
+- `delete` — instance
+- `get` — instance
+- `penalty` — instance
+- `reward` — instance
 
 ## `readline`
 


### PR DESCRIPTION
The required api-docs-drift check currently fails on **every PR**: commit 50fbc5889 (bun-compat shim pack, #6578) edited crates/perry-api-manifest/src/entries.rs without regenerating the derived docs. This PR is exactly the remediation the check's own error message prescribes: ./scripts/regen_api_docs.sh + commit docs/src/api/reference.md and docs/api/perry.d.ts. No manifest or code changes.

Diff is the CronJob/date-instance entries the shim pack added (2887 entries / 121 modules after regen).

Merging this unblocks the api-docs-drift check for all currently open PRs (they run the check against their merge-commit with main).

No version bump / changelog per maintainer instruction.