### PR TITLE
fix(streams): defer TransformStream sink close behind queued write jobs

### DIFF
--- a/crates/perry-stdlib/src/streams.rs
+++ b/crates/perry-stdlib/src/streams.rs
@@ -369,6 +369,24 @@ fn scan_stream_roots_mut(visitor: &mut perry_runtime::gc::RuntimeRootVisitor<'_>
             visitor.visit_i64_slot(&mut t.flush_cb);
         }
     }
+    // Parked/deferred transform promises are held only as raw addresses in
+    // these maps (an unawaited write/close has no other root).
+    if let Ok(mut map) = transform::TRANSFORM_WRITE_RELEASES.lock() {
+        for promises in map.values_mut() {
+            for slot in promises.iter_mut() {
+                let mut p = *slot as *mut Promise;
+                visitor.visit_raw_mut_ptr_slot(&mut p);
+                *slot = p as usize;
+            }
+        }
+    }
+    if let Ok(mut map) = transform::TRANSFORM_PENDING_CLOSE.lock() {
+        for slot in map.values_mut() {
+            let mut p = *slot as *mut Promise;
+            visitor.visit_raw_mut_ptr_slot(&mut p);
+            *slot = p as usize;
+        }
+    }
     if let Ok(mut map) = READERS.lock() {
         for r in map.values_mut() {
             visitor.visit_raw_mut_ptr_slot(&mut r.closed_promise);

--- a/crates/perry-stdlib/src/streams/transform.rs
+++ b/crates/perry-stdlib/src/streams/transform.rs
@@ -245,11 +245,19 @@ pub(super) unsafe fn transform_write(writable_id: usize, chunk: f64) -> *mut Pro
     // write promise resolves in the job, after the transform enqueues.
     let job_fn = transform_write_job as *const u8;
     perry_runtime::closure::js_register_closure_arity(job_fn, 0);
-    let job = perry_runtime::closure::js_closure_alloc(job_fn, 4);
+    let job = perry_runtime::closure::js_closure_alloc(job_fn, 5);
     perry_runtime::closure::js_closure_set_capture_ptr(job, 0, transform_cb);
     perry_runtime::closure::js_closure_set_capture_ptr(job, 1, readable_id as i64);
     perry_runtime::closure::js_closure_set_capture_ptr(job, 2, chunk.to_bits() as i64);
     perry_runtime::closure::js_closure_set_capture_ptr(job, 3, promise as i64);
+    perry_runtime::closure::js_closure_set_capture_ptr(job, 4, writable_id as i64);
+    // #6607: a `writer.close()` in the same synchronous run must not close the
+    // readable ahead of this queued job — count it so transform_close defers.
+    *TRANSFORM_PENDING_WRITES
+        .lock()
+        .unwrap()
+        .entry(writable_id)
+        .or_insert(0) += 1;
     perry_runtime::builtins::js_queue_microtask(job as i64);
     promise
 }
@@ -262,8 +270,8 @@ extern "C" fn transform_write_job(closure: *const ClosureHeader) -> f64 {
     unsafe {
         let job_fn = transform_write_job2 as *const u8;
         perry_runtime::closure::js_register_closure_arity(job_fn, 0);
-        let job = perry_runtime::closure::js_closure_alloc(job_fn, 4);
-        for i in 0..4 {
+        let job = perry_runtime::closure::js_closure_alloc(job_fn, 5);
+        for i in 0..5 {
             perry_runtime::closure::js_closure_set_capture_ptr(
                 job,
                 i,
@@ -282,6 +290,7 @@ extern "C" fn transform_write_job2(closure: *const ClosureHeader) -> f64 {
         let chunk_bits = perry_runtime::closure::js_closure_get_capture_ptr(closure, 2) as u64;
         let promise =
             perry_runtime::closure::js_closure_get_capture_ptr(closure, 3) as *mut Promise;
+        let writable_id = perry_runtime::closure::js_closure_get_capture_ptr(closure, 4) as usize;
         let chunk = f64::from_bits(chunk_bits);
         if transform_cb != 0 && readable_id != 0 {
             let ret = js_closure_call2(
@@ -301,12 +310,14 @@ extern "C" fn transform_write_job2(closure: *const ClosureHeader) -> f64 {
                     let r = transform_write_settle_rejected as *const u8;
                     perry_runtime::closure::js_register_closure_arity(f, 1);
                     perry_runtime::closure::js_register_closure_arity(r, 1);
-                    let fc = perry_runtime::closure::js_closure_alloc(f, 2);
+                    let fc = perry_runtime::closure::js_closure_alloc(f, 3);
                     perry_runtime::closure::js_closure_set_capture_ptr(fc, 0, readable_id as i64);
                     perry_runtime::closure::js_closure_set_capture_ptr(fc, 1, promise as i64);
-                    let rc = perry_runtime::closure::js_closure_alloc(r, 2);
+                    perry_runtime::closure::js_closure_set_capture_ptr(fc, 2, writable_id as i64);
+                    let rc = perry_runtime::closure::js_closure_alloc(r, 3);
                     perry_runtime::closure::js_closure_set_capture_ptr(rc, 0, readable_id as i64);
                     perry_runtime::closure::js_closure_set_capture_ptr(rc, 1, promise as i64);
+                    perry_runtime::closure::js_closure_set_capture_ptr(rc, 2, writable_id as i64);
                     let _ = perry_runtime::promise::js_promise_then(inner, fc, rc);
                     return f64::from_bits(TAG_UNDEFINED);
                 }
@@ -326,6 +337,7 @@ extern "C" fn transform_write_job2(closure: *const ClosureHeader) -> f64 {
         // stalled here, so the flight branch's read #3 stays pending while
         // the module-require chain finishes).
         settle_transform_write(readable_id, promise);
+        transform_write_job_done(writable_id);
     }
     f64::from_bits(TAG_UNDEFINED)
 }
@@ -366,6 +378,55 @@ lazy_static::lazy_static! {
     /// when the consumer drains the readable (see `transform_release_writes`).
     pub(super) static ref TRANSFORM_WRITE_RELEASES: Mutex<HashMap<usize, Vec<usize>>> =
         Mutex::new(HashMap::new());
+    /// #6607: transform writable id -> count of write jobs queued by
+    /// `transform_write` whose transformer hasn't finished delivering yet
+    /// (async transformers count until their returned promise settles).
+    static ref TRANSFORM_PENDING_WRITES: Mutex<HashMap<usize, usize>> =
+        Mutex::new(HashMap::new());
+    /// #6607: transform writable id -> close-request promise (as address)
+    /// deferred until the pending write jobs above drain.
+    pub(super) static ref TRANSFORM_PENDING_CLOSE: Mutex<HashMap<usize, usize>> =
+        Mutex::new(HashMap::new());
+}
+
+/// #6607: a queued transform write job finished delivering its chunk. When the
+/// last pending job for the writable drains, run any close request that
+/// arrived while the jobs were still queued (see `transform_close`).
+unsafe fn transform_write_job_done(writable_id: usize) {
+    let drained = {
+        let mut g = TRANSFORM_PENDING_WRITES.lock().unwrap();
+        match g.get_mut(&writable_id) {
+            Some(count) => {
+                *count -= 1;
+                if *count == 0 {
+                    g.remove(&writable_id);
+                    true
+                } else {
+                    false
+                }
+            }
+            None => true,
+        }
+    };
+    if !drained {
+        return;
+    }
+    let deferred = TRANSFORM_PENDING_CLOSE.lock().unwrap().remove(&writable_id);
+    if let Some(promise_addr) = deferred {
+        let promise = promise_addr as *mut Promise;
+        // The stream may have errored (writer.abort(), controller.error(...))
+        // while the close waited on the jobs — settle the close request with
+        // that error instead of running flush on an errored stream.
+        let errored = WRITABLE_STREAMS
+            .lock()
+            .unwrap()
+            .get(&writable_id)
+            .and_then(|s| (s.state == WritableState::Errored).then_some(s.error_value));
+        match errored {
+            Some(reason) => js_promise_reject(promise, f64::from_bits(reason)),
+            None => perform_transform_close(writable_id, promise),
+        }
+    }
 }
 
 /// The async transformer's returned promise fulfilled — settle the write with
@@ -375,7 +436,9 @@ extern "C" fn transform_write_settle_fulfilled(closure: *const ClosureHeader, _v
         let readable_id = perry_runtime::closure::js_closure_get_capture_ptr(closure, 0) as usize;
         let promise =
             perry_runtime::closure::js_closure_get_capture_ptr(closure, 1) as *mut Promise;
+        let writable_id = perry_runtime::closure::js_closure_get_capture_ptr(closure, 2) as usize;
         settle_transform_write(readable_id, promise);
+        transform_write_job_done(writable_id);
     }
     f64::from_bits(TAG_UNDEFINED)
 }
@@ -388,10 +451,12 @@ extern "C" fn transform_write_settle_rejected(closure: *const ClosureHeader, rea
         let readable_id = perry_runtime::closure::js_closure_get_capture_ptr(closure, 0) as usize;
         let promise =
             perry_runtime::closure::js_closure_get_capture_ptr(closure, 1) as *mut Promise;
+        let writable_id = perry_runtime::closure::js_closure_get_capture_ptr(closure, 2) as usize;
         if readable_id != 0 {
             js_readable_stream_controller_error(readable_id as f64, reason);
         }
         js_promise_reject(promise, reason);
+        transform_write_job_done(writable_id);
     }
     f64::from_bits(TAG_UNDEFINED)
 }
@@ -428,7 +493,43 @@ pub(super) unsafe fn transform_release_writes(readable_id: usize) {
 }
 
 pub(super) unsafe fn transform_close(writable_id: usize) -> *mut Promise {
+    // #6607 (WHATWG TransformStreamDefaultSinkCloseAlgorithm ordering): the
+    // sink close runs only after queued writes complete. `transform_write`
+    // defers the transformer invocation through a two-hop microtask job, so a
+    // same-run `writer.close()` would otherwise close the readable before the
+    // jobs deliver their chunks — controller_enqueue would then silently drop
+    // them on a Closed readable. Defer the whole close (flush included)
+    // behind the pending jobs; `transform_write_job_done` resumes it.
+    if let Some(&pending) = TRANSFORM_PENDING_CLOSE.lock().unwrap().get(&writable_id) {
+        return pending as *mut Promise;
+    }
     let promise = js_promise_new();
+    let jobs_pending = TRANSFORM_PENDING_WRITES
+        .lock()
+        .unwrap()
+        .get(&writable_id)
+        .copied()
+        .unwrap_or(0)
+        > 0;
+    if jobs_pending {
+        TRANSFORM_PENDING_CLOSE
+            .lock()
+            .unwrap()
+            .insert(writable_id, promise as usize);
+        // Close is requested: writes arriving during the wait must reject
+        // ("Stream is closed or closing"), same as the plain-writable path.
+        if let Some(s) = WRITABLE_STREAMS.lock().unwrap().get_mut(&writable_id) {
+            if s.state == WritableState::Writable {
+                s.state = WritableState::Closing;
+            }
+        }
+        return promise;
+    }
+    perform_transform_close(writable_id, promise);
+    promise
+}
+
+unsafe fn perform_transform_close(writable_id: usize, promise: *mut Promise) {
     let mut handled_native = false;
     let mut native_error = None;
     let (flush_cb, readable_id) = {
@@ -466,7 +567,7 @@ pub(super) unsafe fn transform_close(writable_id: usize) -> *mut Promise {
         }
         super::idalloc::retire_writable_terminal(writable_id);
         js_promise_reject(promise, f64::from_bits(error_bits));
-        return promise;
+        return;
     }
     // Invoke the user `flush(controller)`. It may return a promise: e.g.
     // Next.js' `createBufferedTransformStream` buffers chunks in `transform()`
@@ -497,7 +598,7 @@ pub(super) unsafe fn transform_close(writable_id: usize) -> *mut Promise {
                     2 => {
                         let reason = perry_runtime::promise::js_promise_reason(inner);
                         error_transform_close(writable_id, readable_id, promise, reason.to_bits());
-                        return promise;
+                        return;
                     }
                     // Pending — chain the close onto flush's settlement so the
                     // deferred enqueue lands on the still-open readable first.
@@ -541,7 +642,7 @@ pub(super) unsafe fn transform_close(writable_id: usize) -> *mut Promise {
                             promise as i64,
                         );
                         let _ = perry_runtime::promise::js_promise_then(inner, fulfill, reject);
-                        return promise;
+                        return;
                     }
                 }
             }
@@ -549,7 +650,6 @@ pub(super) unsafe fn transform_close(writable_id: usize) -> *mut Promise {
     }
 
     finish_transform_close(writable_id, readable_id, promise);
-    promise
 }
 
 /// Close a TransformStream's writable side once `flush()` has settled: close


### PR DESCRIPTION
Fixes #6607.

## Problem

Unawaited `writer.write()` chunks on a `TransformStream` were silently dropped when `writer.close()` ran in the same synchronous run:

```ts
const ts = new TransformStream();
const writer = ts.writable.getWriter();
writer.write("hello");
writer.write(" world");
writer.close();
let out = "";
for await (const chunk of ts.readable) out += chunk;
// Node: "hello world" — Perry: "" (empty)
```

`transform_write` defers the transformer invocation through a two-hop microtask job (tick-parity work from the cold-start head-reorder campaign), but `transform_close` closed the readable side immediately. The queued jobs then delivered their chunks onto a `Closed` controller and `controller_enqueue` discarded them — while the write promises still resolved, so the loss was silent.

## Fix

Per WHATWG, `TransformStreamDefaultSinkCloseAlgorithm` runs only after queued writes complete. The close now chains behind the pending write jobs:

- `transform_write` counts each queued job per transform writable (`TRANSFORM_PENDING_WRITES`); async transformers count until their returned promise settles.
- `transform_close` with jobs pending parks the close request (`TRANSFORM_PENDING_CLOSE`), marks the writable `Closing` so late writes reject with "Stream is closed or closing" (same as the plain-writable path), and returns the parked promise on repeat close calls.
- The last job's completion resumes the full close — flush included, so the existing #5989 deferred-flush chaining composes on top. If the stream errored while the close was parked (abort / `controller.error`), the close request rejects with that error instead of running flush.

Also: the streams GC root scanner now visits the parked-promise maps (the pre-existing `TRANSFORM_WRITE_RELEASES` and the new `TRANSFORM_PENDING_CLOSE`). Promises parked there are held only as raw addresses; an unawaited write/close has no other root, so a sweep could otherwise free the promise (or evacuation could fail to rewrite the address) before it settles.

Not affected: pipeTo-driven paths await each write, so the deferral never triggers there — no tick-cadence change to the Next.js promise-hop parity behavior. The `perry-ext-streams` port runs transformers synchronously and never had this bug.

## Validation

Built with the perry-dev profile; all outputs compared against `node --experimental-strip-types`:

- Issue repro: `transform: hello world` — matches Node (was empty).
- Variants, all byte-identical to Node: sync transformer + flush trailer (`AB!`), async transformer (`x.y.`), write-after-close rejects while the parked chunk is still delivered (`rejected kept`), close/closed promise settlement, awaited-write regression guard.
- Stream gap/parity sweep (10 tests): `test_gap_readable_stream_tee_pull`, `test_gap_stream_async_transform_tick_parity`, `test_gap_stream_livetee_tick_parity`, `test_gap_transform_stream_deferred_flush`, `test_issue_237_streams_pipe`, `test_issue_320_readable_stream`, `test_parity_stream_consumers`, `test_parity_stream_promises`, `test_data_pipeline` all match Node. `test_gap_stream_tee_tick_parity` shows a one-tick drift that reproduces identically on a pristine `origin/main` build of the same profile — pre-existing, unrelated to this change.

Per contributor guidelines, no version bump or CHANGELOG entry — maintainer folds metadata at merge.
