### PR TITLE
fix(runtime): closure-nested dynamic import() invisible to the resolver rejected with literal undefined — pi one-shot lost-rejection wall (#6660)

### DIFF
--- a/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
+++ b/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
@@ -536,33 +536,42 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             }
             // #5230: a non-resolvable (runtime-computed) specifier was
             // *deferred* (the default, non-strict policy — analog of #5206's
-            // eval deferral). Evaluate the arg for its side effects, then
-            // reject the promise with a descriptive `Error` so
-            // `await import(spec)` throws only if this site is actually
-            // reached, instead of failing the whole build.
+            // eval deferral). Evaluate the arg, then hand the runtime value to
+            // the deferred-fallback helper (#6660): a specifier that names a
+            // node BUILTIN at runtime (`imp("node:os")` through a helper the
+            // resolver couldn't fold) resolves to the builtin namespace like
+            // Node; anything else rejects with the descriptive deferral
+            // `Error` so `await import(spec)` throws only if this site is
+            // actually reached, instead of failing the whole build.
             if let Some(msg) = deferred_error {
-                let _ = lower_expr(ctx, arg)?;
-                // Build the `Error(msg)` value the same way `new Error(<str>)`
-                // does (see `Expr::ErrorNew`): intern the message as a string
-                // literal handle, then `js_error_new_from_value`.
+                let spec_val = lower_expr(ctx, arg)?;
                 let msg_val = lower_expr(ctx, &Expr::String(msg.clone()))?;
-                let blk = ctx.block();
-                let err_ptr = blk.call(I64, "js_error_new_from_value", &[(DOUBLE, &msg_val)]);
-                let err_box = nanbox_pointer_inline(blk, &err_ptr);
-                let p = blk.call(I64, "js_promise_rejected", &[(DOUBLE, &err_box)]);
-                return Ok(nanbox_pointer_inline(blk, &p));
+                return Ok(ctx.block().call(
+                    DOUBLE,
+                    "js_module_dynamic_import_deferred",
+                    &[(DOUBLE, &spec_val), (DOUBLE, &msg_val)],
+                ));
             }
 
             // Defensive: an empty `paths` list means the resolver pass
             // failed to populate this node, which `collect_modules`
-            // should have raised as a compile error. Fall through to a
-            // rejected promise rather than crashing the IR.
+            // should have raised as a compile error. Fall through to the
+            // runtime fallback (#6660: builtin-or-`ERR_MODULE_NOT_FOUND`
+            // rejection — historically this arm rejected with literal
+            // `undefined`, which surfaced as a reasonless
+            // `Uncaught (in promise) undefined`) rather than crashing the IR.
             if paths.is_empty() {
-                let _ = lower_expr(ctx, arg)?;
-                let blk = ctx.block();
-                let undef = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
-                let p = blk.call(I64, "js_promise_rejected", &[(DOUBLE, &undef)]);
-                return Ok(nanbox_pointer_inline(blk, &p));
+                let spec_val = lower_expr(ctx, arg)?;
+                let hooked = ctx.block().call(
+                    DOUBLE,
+                    "js_module_dynamic_import_apply_hooks",
+                    &[(DOUBLE, &spec_val)],
+                );
+                return Ok(ctx.block().call(
+                    DOUBLE,
+                    "js_module_dynamic_import_fallback",
+                    &[(DOUBLE, &hooked)],
+                ));
             }
 
             // Single-target fast path. Skip the runtime string compare
@@ -642,11 +651,16 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         blk.load(DOUBLE, &format!("@__perry_ns_{}", prefix))
                     }
                     None => {
-                        // Driver didn't resolve this path to a target
-                        // module — surface a rejected promise.
-                        let undef = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
-                        let p = blk.call(I64, "js_promise_rejected", &[(DOUBLE, &undef)]);
-                        return Ok(nanbox_pointer_inline(blk, &p));
+                        // Driver didn't resolve this path to a target module —
+                        // route through the runtime fallback (#6660: builtin
+                        // specifiers resolve like Node, everything else rejects
+                        // with `ERR_MODULE_NOT_FOUND` instead of the old
+                        // literal-`undefined` rejection).
+                        return Ok(blk.call(
+                            DOUBLE,
+                            "js_module_dynamic_import_fallback",
+                            &[(DOUBLE, &path_val)],
+                        ));
                     }
                 };
                 let promise = blk.call(I64, "js_promise_resolved", &[(DOUBLE, &ns_val)]);
@@ -772,14 +786,18 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 ctx.current_block = next_label;
             }
 
-            // No-match fallthrough: rejected promise. Reuses the same
-            // pattern as the empty-paths defensive arm.
+            // No-match fallthrough: runtime fallback (#6660) — a builtin
+            // specifier resolves like Node, everything else rejects with
+            // `ERR_MODULE_NOT_FOUND` (this arm used to reject with literal
+            // `undefined`).
             let join_label = ctx.block_label(join_block_idx);
             let blk = ctx.block();
-            let undef = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
-            let p = blk.call(I64, "js_promise_rejected", &[(DOUBLE, &undef)]);
-            let boxed = nanbox_pointer_inline(blk, &p);
-            blk.store(DOUBLE, &boxed, &result_slot);
+            let fallback = blk.call(
+                DOUBLE,
+                "js_module_dynamic_import_fallback",
+                &[(DOUBLE, &path_val)],
+            );
+            blk.store(DOUBLE, &fallback, &result_slot);
             blk.br(&join_label);
 
             // Join: load result and return.

--- a/crates/perry-codegen/src/runtime_decls/strings.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings.rs
@@ -1397,6 +1397,17 @@ pub fn declare_phase_b_strings(module: &mut LlModule) {
     // #5389 Tier 2: synchronous ambient require(spec) resolution — the codegen
     // fallthrough when a computed require() didn't const-fold to a compiled target.
     module.declare_function("js_module_ambient_require_apply", DOUBLE, &[DOUBLE]);
+    // #6660: dynamic-`import(spec)` unresolved / no-match fallback — builtins
+    // resolve by string (promise-wrapped), everything else rejects with an
+    // `ERR_MODULE_NOT_FOUND` Error (never literal `undefined`). The deferred
+    // variant carries the #5230 compile-time deferral message for unknown
+    // modules.
+    module.declare_function("js_module_dynamic_import_fallback", DOUBLE, &[DOUBLE]);
+    module.declare_function(
+        "js_module_dynamic_import_deferred",
+        DOUBLE,
+        &[DOUBLE, DOUBLE],
+    );
     // #6644: `module.createRequire(...)` devirt entry — arms the nm/submod
     // install-all hooks before delegating (see js_process_get_builtin_module_devirt).
     module.declare_function("js_module_create_require_devirt", DOUBLE, &[DOUBLE]);

--- a/crates/perry-hir/src/dynamic_import/visitors.rs
+++ b/crates/perry-hir/src/dynamic_import/visitors.rs
@@ -436,8 +436,30 @@ fn visit_expr_for_dyn_imports<F: FnMut(&mut Expr)>(expr: &mut Expr, f: &mut F) {
 }
 
 fn visit_expr_for_dyn_imports_ref<F: FnMut(&Expr)>(expr: &Expr, f: &mut F) {
-    if matches!(expr, Expr::DynamicImport { .. }) {
+    if let Expr::DynamicImport { arg, .. } = expr {
         f(expr);
+        // Mirror the `_mut` sibling: after reporting the node, still descend
+        // into the `arg` so nested dynamic imports are visited.
+        visit_expr_for_dyn_imports_ref(arg, f);
+        return;
+    }
+    // Closure bodies — descend manually (the walker intentionally doesn't).
+    //
+    // #6660: this MUST stay in traversal lockstep with the `_mut` sibling
+    // above. The driver's resolution pass walks the read-only visitor and
+    // records one outcome per site; the fill pass walks the `_mut` visitor
+    // and applies them 1:1 by order. This arm used to be missing here, so
+    // every `import()` inside a closure (`const imp = (s) => import(s)`) was
+    // invisible to the resolver but still visited by the fill pass — the
+    // outcome stream ran dry (or mis-assigned), the site kept empty `paths`
+    // with no `deferred_error`, and codegen's defensive arm lowered it to
+    // `js_promise_rejected(undefined)`: an uncatchable-looking
+    // `Uncaught (in promise) undefined` at runtime instead of the resolved
+    // namespace.
+    if let Expr::Closure { body, .. } = expr {
+        for s in body {
+            visit_stmt_for_dyn_imports_ref(s, f);
+        }
     }
     walk_expr_children(expr, &mut |child| visit_expr_for_dyn_imports_ref(child, f));
 }

--- a/crates/perry-runtime/src/module_require.rs
+++ b/crates/perry-runtime/src/module_require.rs
@@ -514,6 +514,88 @@ pub extern "C" fn js_module_ambient_require_apply(spec: f64) -> f64 {
 static KEEP_JS_MODULE_AMBIENT_REQUIRE_APPLY: extern "C" fn(f64) -> f64 =
     js_module_ambient_require_apply;
 
+/// #6660 (pi wall #8): shared runtime fallback for a dynamic `import(spec)`
+/// whose specifier did not match a compiled-module target at the dispatch
+/// site. The `import()` analog of `js_module_ambient_require_apply` (#5389
+/// Tier 2): builtins (`node:fs/promises`, `os`, …) resolve by string to the
+/// same namespace `require(spec)` / `process.getBuiltinModule(spec)` produce,
+/// wrapped in a resolved promise; anything else becomes a promise rejected
+/// with a descriptive `Error` (`code: 'ERR_MODULE_NOT_FOUND'`, Node's dynamic
+/// import failure family) — never a rejection with literal `undefined`, which
+/// is what the old codegen fallthrough arms produced and what surfaced as the
+/// reasonless `Uncaught (in promise) undefined` one-shot wall.
+///
+/// `deferred_note` carries the compile-time deferral message for #5230 sites
+/// (runtime-computed specifier, non-strict policy) so a genuinely unknown
+/// module still reports the site's `file:line`.
+fn dynamic_import_fallback_promise(spec: f64, deferred_note: Option<String>) -> f64 {
+    // Arm the install-all hooks the way `getBuiltinModule`'s devirt entry does
+    // (#6644): the namespace handed back below must dispatch methods even when
+    // no static import of the module exists anywhere in the program. Codegen
+    // references this symbol only from dynamic-import fallback sites, so
+    // programs without them keep per-module stripping.
+    crate::object::js_nm_enable_install_all();
+    crate::node_submodules::js_node_submod_enable_install_all();
+    // `import()` performs ToString on the specifier: a string resolves
+    // directly, any other value participates via its string form.
+    let jv = JSValue::from_bits(spec.to_bits());
+    let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    let spec_str = match unsafe { crate::string::js_string_key_bytes(jv, &mut sso) } {
+        Some(bytes) => String::from_utf8_lossy(bytes).into_owned(),
+        None => unsafe {
+            crate::exception::string_header_to_string(crate::value::js_jsvalue_to_string(spec))
+        },
+    };
+    if let Some(module_name) = supported_require_builtin(&spec_str) {
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let ns_handle = scope.root_nanbox_f64(require_builtin_value(module_name));
+        let promise = crate::promise::js_promise_resolved(ns_handle.get_nanbox_f64());
+        return js_nanbox_pointer(promise as i64);
+    }
+    let message = deferred_note.unwrap_or_else(|| format!("Cannot find module '{spec_str}'"));
+    let msg_ptr = js_string_from_bytes(message.as_ptr(), message.len() as u32);
+    crate::node_submodules::register_error_code_pub(msg_ptr, "ERR_MODULE_NOT_FOUND");
+    let err = crate::error::js_error_new_with_message(msg_ptr);
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let err_handle = scope.root_nanbox_f64(js_nanbox_pointer(err as i64));
+    let promise = crate::promise::js_promise_rejected(err_handle.get_nanbox_f64());
+    js_nanbox_pointer(promise as i64)
+}
+
+/// Codegen entry for the unresolved / no-match dynamic-`import()` fallthrough
+/// arms (#6660). Returns a NaN-boxed promise; never throws synchronously
+/// (`import()` always rejects, per spec).
+#[no_mangle]
+pub extern "C" fn js_module_dynamic_import_fallback(spec: f64) -> f64 {
+    dynamic_import_fallback_promise(spec, None)
+}
+
+/// Keepalive anchor (same pattern as the ambient-require anchors above).
+#[used]
+static KEEP_JS_MODULE_DYNAMIC_IMPORT_FALLBACK: extern "C" fn(f64) -> f64 =
+    js_module_dynamic_import_fallback;
+
+/// Codegen entry for #5230 *deferred* dynamic-import sites (runtime-computed
+/// specifier under the default non-strict policy). Same builtin-or-reject
+/// fallback, but a genuinely unknown module rejects with the compile-time
+/// deferral message (which names the site's `file:line`) instead of the
+/// generic `Cannot find module` text. `msg` is the NaN-boxed deferral string.
+#[no_mangle]
+pub extern "C" fn js_module_dynamic_import_deferred(spec: f64, msg: f64) -> f64 {
+    let note = {
+        let jv = JSValue::from_bits(msg.to_bits());
+        let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+        unsafe { crate::string::js_string_key_bytes(jv, &mut sso) }
+            .map(|bytes| String::from_utf8_lossy(bytes).into_owned())
+    };
+    dynamic_import_fallback_promise(spec, note)
+}
+
+/// Keepalive anchor (same pattern as the ambient-require anchors above).
+#[used]
+static KEEP_JS_MODULE_DYNAMIC_IMPORT_DEFERRED: extern "C" fn(f64, f64) -> f64 =
+    js_module_dynamic_import_deferred;
+
 /// #6651 family regression guard: createRequire's resolver must never drift
 /// from `process.getBuiltinModule`'s again. Today they are the same function;
 /// this pins the contract so a future re-split of the implementations still

--- a/crates/perry-runtime/src/promise/rejection.rs
+++ b/crates/perry-runtime/src/promise/rejection.rs
@@ -112,7 +112,80 @@ pub(super) fn track_unhandled_rejection(promise: *mut Promise) {
     if promise.is_null() {
         return;
     }
+    if rejection_diag_enabled() {
+        rejection_diag("track", promise);
+    }
     REJECTIONS.with(|t| t.borrow_mut().unhandled.push(promise as usize));
+}
+
+/// `PERRY_REJECTION_DIAG=1`: dump the raw rejection reason (tag class, bits,
+/// value preview) plus a native backtrace when a rejection is first tracked as
+/// unhandled — the backtrace there is the rejecting call site — and again when
+/// it is reported at a checkpoint. Diagnostic aid for compiled bundles, where
+/// an `Uncaught (in promise) undefined` line gives no way to tell whether the
+/// reason was genuinely `undefined` or was lost en route (used to root-cause
+/// #6660; same opt-in pattern as `PERRY_BIGINT_MIX_DIAG`). Only consulted on
+/// the already-cold unhandled-rejection paths.
+fn rejection_diag_enabled() -> bool {
+    std::env::var_os("PERRY_REJECTION_DIAG").is_some()
+}
+
+#[cold]
+fn rejection_diag(stage: &str, promise: *mut Promise) {
+    let (state, reason) = unsafe { ((*promise).state, (*promise).reason) };
+    eprintln!(
+        "[rejection-diag] {stage} promise=0x{:x} state={state:?} reason_bits=0x{:016x} reason={}",
+        promise as usize,
+        reason.to_bits(),
+        describe_rejection_reason(reason),
+    );
+    eprintln!("{}", std::backtrace::Backtrace::force_capture());
+}
+
+/// Tag-class + preview description of a rejection reason for the
+/// `PERRY_REJECTION_DIAG=1` dump. Pointer reasons additionally note whether
+/// they are an Error object (and if so include its `stack`, which begins
+/// `<Name>: <message>`).
+#[cold]
+fn describe_rejection_reason(v: f64) -> String {
+    let jv = crate::value::JSValue::from_bits(v.to_bits());
+    if jv.is_undefined() {
+        return "undefined".to_string();
+    }
+    if jv.is_null() {
+        return "null".to_string();
+    }
+    if jv.is_bool() {
+        return format!("bool({})", jv.as_bool());
+    }
+    if jv.is_int32() {
+        return format!("int32({})", jv.as_int32());
+    }
+    if jv.is_any_string() {
+        let ptr =
+            crate::value::js_get_string_pointer_unified(v) as *const crate::string::StringHeader;
+        let mut s = unsafe { crate::exception::string_header_to_string(ptr) };
+        if s.len() > 120 {
+            let cut = (0..=120)
+                .rev()
+                .find(|i| s.is_char_boundary(*i))
+                .unwrap_or(0);
+            s.truncate(cut);
+        }
+        return format!("string({s:?})");
+    }
+    if jv.is_pointer() {
+        let ptr = jv.as_pointer::<u8>() as usize;
+        if crate::value::addr_class::is_plausible_heap_addr(ptr)
+            && unsafe { *(ptr as *const u32) } == crate::error::OBJECT_TYPE_ERROR
+        {
+            let eh = ptr as *const crate::error::ErrorHeader;
+            let stack = unsafe { crate::exception::string_header_to_string((*eh).stack) };
+            return format!("error(0x{ptr:x}) stack={stack:?}");
+        }
+        return format!("pointer(0x{ptr:x})");
+    }
+    format!("number({v})")
 }
 
 /// A handler was attached to `promise` — it is no longer an unhandled
@@ -326,6 +399,9 @@ fn with_listener_uncaught_trap<F: FnOnce()>(f: F) {
 ///    `'unhandledRejection'` — and still suppresses the crash.
 /// 3. else print the diagnostic and exit(1).
 fn report_unhandled(promise: *mut Promise) {
+    if rejection_diag_enabled() {
+        rejection_diag("report", promise);
+    }
     let scope = crate::gc::RuntimeHandleScope::new();
     let promise_handle = scope.root_raw_mut_ptr(promise);
     let reason_handle =

--- a/crates/perry/tests/issue_6660_closure_dynamic_import.rs
+++ b/crates/perry/tests/issue_6660_closure_dynamic_import.rs
@@ -1,0 +1,247 @@
+//! Regression tests for #6660 (pi wall #8): a dynamic `import()` inside a
+//! CLOSURE — `const imp = (s) => import(s)` — rejected with literal
+//! `undefined`, killing the one-shot flow with a reasonless
+//! `Uncaught (in promise) undefined` where node completes normally.
+//!
+//! Trigger in the wild: pi-ai's auth context helper
+//! (`importNodeModule = (specifier) => import(rewrite(specifier))`,
+//! awaited inside `async fileExists` with a swallowing try/catch) — the
+//! rejected promise's `undefined` reason escaped as an unhandled rejection
+//! before the first stdout write of the `-p` flow.
+//!
+//! Two root causes, both covered here:
+//!
+//! 1. Visitor asymmetry (perry-hir `dynamic_import/visitors.rs`): the
+//!    read-only `for_each_dynamic_import` did NOT descend into
+//!    `Expr::Closure` bodies while its `_mut` sibling did. The driver aligns
+//!    resolution outcomes 1:1 by traversal order (collect via ref visitor,
+//!    fill via mut visitor), so every closure-nested `import()` was invisible
+//!    to the resolver but still consumed a slot in the fill pass — the site
+//!    kept empty `paths` with no `deferred_error` and codegen lowered it to
+//!    its defensive `js_promise_rejected(undefined)` arm.
+//!
+//! 2. Reasonless fallthroughs (perry-codegen `dyn_extern_i18n.rs`): the
+//!    empty-paths / unmapped-target / no-match arms rejected with literal
+//!    `undefined`. They now route through the runtime fallback
+//!    (`js_module_dynamic_import_fallback` — the `import()` analog of the
+//!    #5389 ambient-require fallthrough): node builtins resolve by string to
+//!    the same namespace `require(spec)` produces, anything else rejects
+//!    with a descriptive `Error` carrying `code: 'ERR_MODULE_NOT_FOUND'`.
+//!    The #5230 deferred arm keeps its site-specific `file:line` message for
+//!    unknown modules but now also resolves builtins at runtime.
+//!
+//! Expected outputs are node v26's, byte for byte (stdout + stderr + rc).
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Once;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonicalize workspace root")
+}
+
+fn target_debug_dir() -> PathBuf {
+    std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| workspace_root().join("target"))
+        .join("debug")
+}
+
+/// Build `libperry_runtime.a` once so the compiled binaries can link (mirrors
+/// the #5230 test; the CI `cargo-test` job doesn't pre-build the staticlib).
+fn ensure_runtime_archive() {
+    static BUILD_RUNTIME: Once = Once::new();
+    BUILD_RUNTIME.call_once(|| {
+        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+        let build = Command::new(cargo)
+            .current_dir(workspace_root())
+            .arg("build")
+            .arg("-p")
+            .arg("perry-runtime")
+            .output()
+            .expect("run cargo build -p perry-runtime");
+        assert!(
+            build.status.success(),
+            "cargo build -p perry-runtime failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&build.stdout),
+            String::from_utf8_lossy(&build.stderr)
+        );
+    });
+}
+
+fn runtime_dir() -> PathBuf {
+    ensure_runtime_archive();
+    target_debug_dir()
+}
+
+/// Compile `main.ts` in `dir` and run it, returning (stdout, stderr, rc).
+fn compile_and_run(dir: &std::path::Path, source: &str) -> (String, String, i32) {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .env("PERRY_NO_AUTO_OPTIMIZE", "1")
+        .env("PERRY_RUNTIME_DIR", runtime_dir())
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    (
+        String::from_utf8_lossy(&run.stdout).into_owned(),
+        String::from_utf8_lossy(&run.stderr).into_owned(),
+        run.status.code().unwrap_or(-1),
+    )
+}
+
+/// The wild shape, minimized: pi-ai's `importNodeModule` closure (specifier
+/// routed through a rewrite helper, so the resolver cannot const-fold it) and
+/// its `async fileExists` consumer with the swallowing try/catch. Node prints
+/// `true` / `false`; the pre-fix binary printed `false` / `false` (dynamic
+/// import of `node:fs/promises` rejected) and — in pi's larger flow — died
+/// with `Uncaught (in promise) undefined`.
+#[test]
+fn closure_dynamic_import_of_builtin_matches_node() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (stdout, stderr, rc) = compile_and_run(
+        dir.path(),
+        r#"
+const rewrite = (p: string) => {
+  if (typeof p === "string" && /^\.\.?\//.test(p)) {
+    return p.replace(/\.ts$/i, ".js");
+  }
+  return p;
+};
+const importNodeModule = (specifier: string) => import(rewrite(specifier));
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    const fs = await importNodeModule("node:fs/promises");
+    await fs.access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+console.log(await fileExists("/"));
+console.log(await fileExists("/definitely-missing-perry-6660"));
+"#,
+    );
+    assert_eq!(stdout, "true\nfalse\n");
+    assert_eq!(stderr, "");
+    assert_eq!(rc, 0);
+}
+
+/// Bare param-passthrough closure (`const imp = (s) => import(s)`) — the
+/// minimal visitor-asymmetry trigger — resolving both a submodule-spec
+/// builtin (`node:fs/promises`) and a native-module builtin (`node:os`).
+/// Under the broken visitor this printed nothing and died with
+/// `Uncaught exception: undefined` at the top-level await.
+#[test]
+fn closure_dynamic_import_passthrough_builtins_match_node() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (stdout, stderr, rc) = compile_and_run(
+        dir.path(),
+        r#"
+const imp = (s: string) => import(s);
+const fsp = await imp("node:fs/promises");
+console.log("fs/promises access:", typeof fsp.access);
+const os = await imp("node:os");
+console.log("os homedir:", typeof os.homedir);
+console.log("homedir is string:", typeof os.homedir() === "string");
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "fs/promises access: function\nos homedir: function\nhomedir is string: true\n"
+    );
+    assert_eq!(stderr, "");
+    assert_eq!(rc, 0);
+}
+
+/// A runtime-computed specifier that names an UNKNOWN module must reject with
+/// a real, catchable `Error` (code `ERR_MODULE_NOT_FOUND` family) — never
+/// with literal `undefined`. Message text differs from node (node names the
+/// importing file; an AOT binary reports the deferral site), so this pins
+/// the behavior contract rather than bytes: caught, `instanceof Error`,
+/// non-empty message, and reason !== undefined.
+#[test]
+fn closure_dynamic_import_unknown_module_rejects_with_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (stdout, stderr, rc) = compile_and_run(
+        dir.path(),
+        r#"
+const imp = (s: string) => import(s);
+try {
+  await imp("definitely-not-a-module-perry-6660");
+  console.log("NO_THROW");
+} catch (e: any) {
+  console.log("caught error:", e instanceof Error);
+  console.log("reason defined:", e !== undefined);
+  console.log("has message:", typeof e.message === "string" && e.message.length > 0);
+}
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "caught error: true\nreason defined: true\nhas message: true\n"
+    );
+    assert_eq!(stderr, "");
+    assert_eq!(rc, 0);
+}
+
+/// Outcome-alignment guard: a module with BOTH a closure-nested dynamic
+/// import and a top-level literal one. Before the visitor fix the collection
+/// pass saw only the top-level site while the fill pass visited both in
+/// order, so outcomes could cross-assign between sites. Both must work, in
+/// both call orders.
+#[test]
+fn closure_and_toplevel_dynamic_imports_stay_aligned() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(
+        dir.path().join("real.ts"),
+        "export const greeting = \"hello from real module\";\n",
+    )
+    .expect("write real.ts");
+    let (stdout, stderr, rc) = compile_and_run(
+        dir.path(),
+        r#"
+const imp = (s: string) => import(s);
+const os = await imp("node:os");
+const real = await import("./real.ts");
+console.log("closure-first os:", typeof os.homedir);
+console.log("literal real:", real.greeting);
+const os2 = await imp("node:os");
+console.log("closure-again os:", typeof os2.homedir);
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "closure-first os: function\nliteral real: hello from real module\nclosure-again os: function\n"
+    );
+    assert_eq!(stderr, "");
+    assert_eq!(rc, 0);
+}


### PR DESCRIPTION
Wall #8 of the one-shot bring-up (tracker #6564): the compiled binary's `-p` flow died with a reasonless `Uncaught (in promise) undefined` (stdout empty) where node completes a full API 401 round-trip.

## Root cause

Diagnosis (breakpoint on `track_unhandled_rejection` + the new `PERRY_REJECTION_DIAG=1` dump) traced the rejection to an async `fileExists` helper awaiting a **dynamic `import()` inside a closure**:

```js
const importNodeModule = (specifier) => import(rewrite(specifier));
async function fileExists(p) {
  try {
    const fs = await importNodeModule("node:fs/promises");
    await fs.access(p);
    return true;
  } catch { return false; }
}
```

Under the compiled binary the `import()` compiled to a bare `js_promise_rejected(undefined)` (disassembly-confirmed: no hooks call, no error construction) — codegen's *"unreachable"* defensive arm for a `DynamicImport` with empty `paths` and no `deferred_error`.

Two real bugs stacked:

1. **Visitor asymmetry** (`perry-hir/src/dynamic_import/visitors.rs`): the read-only `for_each_dynamic_import` did **not** descend into `Expr::Closure` bodies, while its `_mut` sibling did. The driver aligns per-site resolution outcomes 1:1 by traversal order (collect via ref visitor → fill via mut visitor), so every closure-nested `import()` was invisible to the resolver but still visited by the fill pass: the outcome stream ran dry / mis-assigned, the site kept empty `paths` with no `deferred_error`, and codegen emitted the reject-undefined arm. (The `for_each_worker_new` pair already descends on both sides — this was the one odd visitor out.)

2. **Reasonless fallthroughs** (`perry-codegen/src/expr/dyn_extern_i18n.rs`): the empty-paths / unmapped-target / no-match arms rejected with **literal `undefined`** — an unreportable, uncatchable-looking failure.

## Fix

- The ref visitor now descends into closure bodies exactly like the mut one, with a lockstep-contract comment on both.
- The three fallthrough arms route through a new runtime fallback, `js_module_dynamic_import_fallback` — the `import()` analog of the #5389 Tier-2 ambient-require fallthrough: a specifier naming a node builtin resolves by string to the same namespace `require(spec)` / `process.getBuiltinModule(spec)` produce (install-all hooks armed, #6644 pattern), anything else rejects with a descriptive `Error` carrying `code: 'ERR_MODULE_NOT_FOUND'` (node's dynamic-import failure family) — never literal `undefined`.
- The #5230 deferred arm routes through `js_module_dynamic_import_deferred`: a runtime-computed specifier that names a builtin now **resolves like node**; a genuinely unknown module keeps the site-specific `file:line` deferral message.
- Kept diagnostics: `PERRY_REJECTION_DIAG=1` dumps the raw rejection reason (tag class, bits, value preview, Error stack when present) plus a native backtrace at unhandled-rejection **track** time (= the rejecting call site) and **report** time. Documented like `PERRY_BIGINT_MIX_DIAG`.

## Tests

`crates/perry/tests/issue_6660_closure_dynamic_import.rs` (all byte-identical to node v26 where node semantics are reproducible):

- the wild shape verbatim (rewrite-wrapped closure import + async try/catch `fileExists`) → `true` / `false`
- bare passthrough closure (`const imp = (s) => import(s)`) resolving a submodule-spec builtin (`node:fs/promises`) and a native-module builtin (`node:os`)
- unknown-module rejection contract: caught, `instanceof Error`, defined reason, non-empty message (message text pins behavior, not bytes — node's names the importing file, an AOT binary reports the deferral site)
- outcome-alignment guard: closure-nested + top-level literal imports in one module, both orders

Suites: `cargo test -p perry-runtime --lib -- --test-threads=1` → 1426 passed / 0 failed. `issue_5230_deferred_dynamic_import`, `issue_5207_registry_object_dynamic_import`, `createrequire_builtin_modules`, and the new test file all green. `cargo fmt` clean on touched files. (Pre-existing, unrelated on the base commit: `c262_parity::logical_property_assignment_short_circuits_the_store_4586` — verified failing at the parent commit in a pristine worktree.)

## End-to-end (GATE 2a)

Full recompile of the 13 MB one-shot target: the previously-dying repro now completes the full live API round-trip with stdout+stderr **byte-identical to node v26** after masking the per-request `request_id` — model-not-in-catalog warning, deprecation notice, and the `401 authentication_error` JSON:

```
Warning: Model "claude-3-5-haiku-latest" not found for provider "anthropic". Using custom model id.
The model 'claude-3-5-haiku-latest' is deprecated and will reach end-of-life on February 19th, 2026
Please migrate to a newer model. Visit https://docs.anthropic.com/en/docs/resources/model-deprecations for more information.
401 {"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"},"request_id":"req_MASKED"}
```

The compile notice now correctly lists the closure-nested `import()` sites as runtime-deferred (they were silently mis-lowered before).

**New wall exposed behind this one (documented, out of scope here): exit code.** node exits `1` (the one-shot flow sets `process.exitCode = 1` on stream error and returns), the compiled binary exits `0`. Isolated to two 2-line fixtures: `process.exitCode = 1` at top level (node rc=1, perry rc=0). The runtime HAS the `PROCESS_EXIT_CODE` cell (#1350) and `process.exit()` honors it, but the natural-exit epilogue (event-loop drain → main return) never consults it. Distinct root cause, next wall in the ladder.

Fixes #6660

https://claude.ai/code/session_01JuiiePQfrXhAFD9fuCygB9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic `import()` handling for unresolved and runtime-computed module specifiers.
  * Unresolved imports now produce catchable module-not-found errors instead of an undefined rejection.
  * Fixed dynamic imports nested inside closures, including built-in module imports.
  * Added support for deferred import errors with meaningful messages.

* **Diagnostics**
  * Added optional promise-rejection diagnostics through `PERRY_REJECTION_DIAG`, including reason previews and backtraces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->