### PR TITLE
fix(native-module): enumerate crypto exports so wildcard interop copies them (#6667)

### DIFF
--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -798,6 +798,21 @@ pub unsafe extern "C" fn js_object_copy_own_fields(dst_i64: i64, src_f64: f64) {
     }
     let src = src_raw as *const ObjectHeader;
 
+    // #6667: a native-module namespace (`{ ...require("crypto") }`) stores no
+    // real fields — only the internal `__module__` sentinel — so the raw
+    // keys_array walk below would copy nothing usable. Enumerate + resolve its
+    // export surface instead (the same list `Object.keys` returns), so wildcard
+    // interop and object spread see the exports Node's namespace exposes.
+    {
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let dst_h = scope.root_raw_mut_ptr(dst);
+        if super::native_module::copy_native_module_exports(src, |key_ptr, value| {
+            js_object_set_field_by_name(dst_h.get_raw_mut_ptr::<ObjectHeader>(), key_ptr, value);
+        }) {
+            return;
+        }
+    }
+
     // Iterate src's keys and copy each value via set_field_by_name.
     let src_keys = (*src).keys_array;
     if src_keys.is_null() || (src_keys as usize) < 0x10000 {
@@ -1203,6 +1218,30 @@ pub unsafe extern "C" fn js_object_assign_one(target_f64: f64, source_f64: f64) 
     }
 
     let src = src_raw as *const ObjectHeader;
+
+    // #6667: native-module namespace source (`Object.assign(t, require("crypto"))`).
+    // Its exports resolve lazily through the vtable, so the raw keys_array walk
+    // below sees only `__module__`. Enumerate + resolve the export surface, then
+    // return — native-module namespaces carry no own symbol-keyed properties, so
+    // the symbol-copy tail below would be a no-op.
+    {
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let tgt_h = scope.root_raw_mut_ptr(target);
+        if super::native_module::copy_native_module_exports(src, |key_ptr, value| {
+            object_assign_set_string_key(
+                tgt_h.get_raw_mut_ptr::<ObjectHeader>(),
+                target_is_array,
+                key_ptr,
+                value,
+            );
+        }) {
+            // `copy_native_module_exports` allocates (fresh export closures +
+            // key strings); a minor GC there can evacuate `target`. Return the
+            // handle-reloaded pointer so the caller threads the post-GC
+            // location, not the stale `target_f64`.
+            return crate::value::js_nanbox_pointer(tgt_h.get_raw_mut_ptr::<ObjectHeader>() as i64);
+        }
+    }
 
     // An array source (`Object.assign(t, [1,2])`, `{ ...[1,2] }`) stores its
     // indexed elements in the `ArrayHeader` element buffer, NOT in an

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1507,3 +1507,70 @@ pub(crate) unsafe fn vt_own_keys_array(
     }
     Some(out)
 }
+
+/// #6667: materialize a native-module namespace's exports into `dst` during
+/// object spread (`{ ...crypto }`) or `Object.assign(dst, crypto)`. A
+/// native-module object physically stores only the internal `__module__`
+/// sentinel — every real export resolves lazily through the vtable — so the
+/// raw `keys_array` walk both copy helpers use otherwise copies nothing, and
+/// every enumeration-based interop layer (turbopack `e.i`, Babel
+/// `interopRequireWildcard`, plain spread) produced an empty namespace. Here
+/// we enumerate the module's export names (`native_module_enumerable_keys`, the
+/// same list `Object.keys` returns) and resolve each to its live value through
+/// the authoritative `[[Get]]` path, handing `(key, value)` to `set`.
+///
+/// Returns `true` when `src` is a native-module namespace with a known export
+/// set (the caller then skips its fallback walk); `false` otherwise, so a
+/// namespace with no key table degrades to the pre-existing behavior.
+///
+/// GC: a callable export resolves to a freshly allocated bound-method closure,
+/// so `src`, the key string, and the resolved value are each rooted across the
+/// allocations that would otherwise move them out from under the raw pointers.
+///
+/// # Safety
+/// `src` must point to a live `ObjectHeader`.
+pub(crate) unsafe fn copy_native_module_exports(
+    mut src: *const ObjectHeader,
+    mut set: impl FnMut(*const crate::StringHeader, f64),
+) -> bool {
+    if (*src).class_id != NATIVE_MODULE_CLASS_ID {
+        return false;
+    }
+    let Some(module_name) = read_native_module_name(src) else {
+        return false;
+    };
+    let Some(keys) = native_module_enumerable_keys(&module_name) else {
+        return false;
+    };
+    let include_permission = matches!(
+        module_name.as_str(),
+        "process" | "process.namespace" | "process.default"
+    ) && crate::process::process_permission_enabled();
+
+    for key_bytes in keys
+        .iter()
+        .copied()
+        .chain(include_permission.then_some(b"permission" as &[u8]))
+    {
+        let scope = crate::gc::RuntimeHandleScope::new();
+        let src_h = scope.root_raw_const_ptr(src);
+        let key_ptr =
+            crate::string::js_string_from_bytes(key_bytes.as_ptr(), key_bytes.len() as u32);
+        let key_h = scope.root_string_ptr(key_ptr);
+        let value = js_object_get_field_by_name(
+            src_h.get_raw_const_ptr::<ObjectHeader>(),
+            key_h.get_raw_const_ptr::<crate::StringHeader>(),
+        );
+        let value_h = scope.root_nanbox_f64(f64::from_bits(value.bits()));
+        set(
+            key_h.get_raw_const_ptr::<crate::StringHeader>(),
+            value_h.get_nanbox_f64(),
+        );
+        // The allocations above (key string, resolved-export closure, the `set`
+        // store) can trigger a minor GC that evacuates `src`. `src_h` tracked
+        // the move; write the refreshed pointer back before its scope drops so
+        // the next iteration re-roots the live location, not a stale one.
+        src = src_h.get_raw_const_ptr::<ObjectHeader>();
+    }
+    true
+}

--- a/crates/perry-runtime/src/object/native_module/constants.rs
+++ b/crates/perry-runtime/src/object/native_module/constants.rs
@@ -3,6 +3,93 @@ use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
 use std::ptr::null_mut;
 use std::sync::atomic::{AtomicPtr, Ordering};
+
+// #6667: `node:crypto` export surface. Node 22–26 enumerate 70 own keys on the
+// CJS namespace (`Object.keys(require("crypto")).length === 70`); order matches
+// Node's insertion order. Every key resolves to a live value through this
+// module's crypto property-resolution (callable exports, sub-namespaces,
+// constants) with the single exception of `setEngine`, whose OpenSSL-engine
+// implementation Perry does not ship — it is listed for enumeration/interop
+// parity and reads `undefined`, mirroring the module's other yet-unimplemented
+// tails. Consumed by `module_keys::native_module_enumerable_keys` and, through
+// it, by `copy_native_module_exports` for object spread / `Object.assign`.
+// Before this table existed, `Object.keys`/for-in/spread saw only the internal
+// `__module__` sentinel, so every enumeration-based interop layer (turbopack
+// `e.i`, Babel `interopRequireWildcard`, plain `{ ...crypto }`) produced an
+// empty namespace — e.g. jose's HKDF fell back to `(0, ns.createHmac)(...)` on
+// `undefined` and threw on the Auth.js success path.
+pub(super) const CRYPTO_NAMESPACE_KEYS: &[&[u8]] = &[
+    b"argon2",
+    b"argon2Sync",
+    b"checkPrime",
+    b"checkPrimeSync",
+    b"createCipheriv",
+    b"createDecipheriv",
+    b"createDiffieHellman",
+    b"createDiffieHellmanGroup",
+    b"createECDH",
+    b"createHash",
+    b"createHmac",
+    b"createPrivateKey",
+    b"createPublicKey",
+    b"createSecretKey",
+    b"createSign",
+    b"createVerify",
+    b"diffieHellman",
+    b"generatePrime",
+    b"generatePrimeSync",
+    b"getCiphers",
+    b"getCipherInfo",
+    b"getCurves",
+    b"getDiffieHellman",
+    b"getHashes",
+    b"hkdf",
+    b"hkdfSync",
+    b"pbkdf2",
+    b"pbkdf2Sync",
+    b"generateKeyPair",
+    b"generateKeyPairSync",
+    b"generateKey",
+    b"generateKeySync",
+    b"privateDecrypt",
+    b"privateEncrypt",
+    b"publicDecrypt",
+    b"publicEncrypt",
+    b"randomBytes",
+    b"randomFill",
+    b"randomFillSync",
+    b"randomInt",
+    b"randomUUID",
+    b"randomUUIDv7",
+    b"scrypt",
+    b"scryptSync",
+    b"sign",
+    b"setEngine",
+    b"timingSafeEqual",
+    b"getFips",
+    b"setFips",
+    b"verify",
+    b"hash",
+    b"encapsulate",
+    b"decapsulate",
+    b"Certificate",
+    b"Cipheriv",
+    b"Decipheriv",
+    b"DiffieHellman",
+    b"DiffieHellmanGroup",
+    b"ECDH",
+    b"Hash",
+    b"Hmac",
+    b"KeyObject",
+    b"Sign",
+    b"Verify",
+    b"X509Certificate",
+    b"secureHeapUsed",
+    b"constants",
+    b"webcrypto",
+    b"subtle",
+    b"getRandomValues",
+];
 fn dns_lookup_flag_constant(property: &str) -> Option<f64> {
     #[cfg(unix)]
     fn ai_addrconfig() -> f64 {

--- a/crates/perry-runtime/src/object/native_module/module_keys.rs
+++ b/crates/perry-runtime/src/object/native_module/module_keys.rs
@@ -1663,6 +1663,10 @@ pub(crate) fn native_module_enumerable_keys(module_name: &str) -> Option<&'stati
             b"strict",
         ]),
         "buffer.constants" => Some(&[b"MAX_LENGTH", b"MAX_STRING_LENGTH"]),
+        // #6667: `require("crypto")` / `import * as crypto` enumerate the full
+        // export surface so wildcard interop + object spread copy the exports.
+        // The table lives beside crypto's value-resolution in `constants.rs`.
+        "crypto" => Some(super::constants::CRYPTO_NAMESPACE_KEYS),
         "sqlite" => Some(&[
             b"DatabaseSync",
             b"Session",


### PR DESCRIPTION
Fixes #6667.

## Problem

Native-module namespace objects (`NATIVE_MODULE_CLASS_ID`) physically store only the internal `__module__` sentinel — every real export resolves lazily through the vtable. So enumeration saw nothing:

```js
const crypto = require("crypto");
Object.keys(crypto).length;              // before: 1     node: 70
let n = 0; for (const k in crypto) n++;  // before: 0     node: 70
({ ...crypto }).createHmac;              // before: undefined   node: [Function]
```

Every interop layer that builds a namespace by enumeration therefore produced an **empty namespace**: turbopack's ESM-import interop (`e.i(...)`), Babel's `interopRequireWildcard`, and plain object spread / `Object.assign`.

**Production impact:** Auth.js credentials login on a Next.js 16 standalone failed with `CallbackRouteError: TypeError: value is not a function` **on the success path only**. jose's compiled HKDF does `Z = e.i(<crypto>)`, probes `typeof Z.hkdf` (undefined → picks its pure-JS fallback), and the fallback calls `(0, Z.createHmac)(...)` — also undefined through the empty interop namespace → session-token derivation throws, so every successful password check still 302s to `error=Configuration`. Failed logins never reach HKDF, which masked it.

## Fix

- **`constants.rs`** — add the full Node 22–26 `crypto` export list (70 keys, in Node's insertion order) beside crypto's value-resolution, exposed via `native_module_enumerable_keys`. This fixes `Object.keys` / `getOwnPropertyNames` / for-in / `hasOwnProperty` / `in`, which already route through the module key table.
- **`native_module.rs`** — add `copy_native_module_exports`, which enumerates a namespace's export names and resolves each to its live value through the authoritative `[[Get]]` path, rooting `src` / key / value across the closure allocations a callable export triggers.
- **`alloc.rs`** — call it from `js_object_copy_own_fields` (object spread) and `js_object_assign_one` (`Object.assign`) so copies materialize the exports instead of the empty `keys_array`. **General across every native module**, not just crypto.

## Verification

Diffed against `node --experimental-strip-types`:

| check | before | node | after |
|---|---|---|---|
| `Object.keys(crypto).length` | 1 | 70 | **70** |
| `for..in` count | 0 | 70 | **70** |
| `{...crypto}.createHmac` etc. | undefined | function | **function** |
| `Object.assign({}, crypto).createHmac` | undefined | function | **function** |
| `interopRequireWildcard(crypto).hkdf` | undefined | function | **function** |
| hmac round-trip through the spread copy | — | 64-hex | **64-hex** |

Regression sweep matches Node byte-for-byte: `os` / `path` / `util` / `events` namespace spread, plain-object + array spread, merge-override ordering, `Object.assign` array/proxy sources, for-in, and the existing crypto method-dispatch tests. `cargo fmt` and the 2000-line file-size gate pass.

## Out of scope (unchanged, pre-existing)

- `Object.getOwnPropertyNames(crypto)` returns 70 vs Node's 74 — native-module objects don't yet model non-enumerable own props (a separate limitation shared by all native modules; still up from 1).
- `import * as crypto` enumerates 70 vs Node's 71 — the ESM-synthesized `default` key. The reported break (and turbopack/jose) is the CJS `require` path, which is now exactly 70. Wiring `crypto` into the CJS-default-namespace machinery to split the two forms is a larger, riskier change deferred as a follow-up.
- `crypto.setEngine` is the one enumerated key Perry doesn't implement; it reads `undefined` (same as the module's other unimplemented tails) but is listed for count/interop parity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native module namespace exports are now included in object spread and `Object.assign`, not just key iteration.
  * `crypto` namespace imports now expose the full enumerable export surface.
  * Process-related namespace exports now include a `permission` property when enabled.
* **Bug Fixes**
  * Improved correctness when copying or merging native-module exports into destination objects, including proper handling of lazily resolved exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->