### PR TITLE
fix(hir): spread call of a native crypto method must not collapse the spread

### DIFF
--- a/crates/perry-hir/src/lower/expr_call/globals.rs
+++ b/crates/perry-hir/src/lower/expr_call/globals.rs
@@ -19,6 +19,8 @@ pub(super) fn try_global_builtins(
     // Check for global built-in function calls (parseInt, parseFloat, Number, String, isNaN, isFinite)
     if let ast::Expr::Ident(ident) = expr {
         let func_name = ident.sym.as_ref();
+        // #6668: used by the crypto named-import spread guard below.
+        let has_spread = call.args.iter().any(|a| a.spread.is_some());
         if ctx.lookup_local(func_name).is_some()
             || ctx.lookup_func(func_name).is_some()
             || ctx.lookup_imported_func(func_name).is_some()
@@ -499,6 +501,19 @@ pub(super) fn try_global_builtins(
             // aliased local (`p`) matched no arm and fell through to a generic
             // path that evaluated to `undefined` — e.g. `p(home, ".x").normalize()`.
             let func_name = method.unwrap_or(func_name);
+            // #6668: a spread call of a crypto method imported by name
+            // (`import { hkdf } from "crypto"; hkdf(...args, cb)`) must not be
+            // collapsed by the per-module fast-path arms below nor the generic
+            // `Expr::NativeMethodCall` further down — a spread operand would be
+            // passed as the array itself, so the codegen fast-path sees too few
+            // args and silently no-ops (the callback never fires). Decline so the
+            // generic tail builds an `Expr::CallSpread`, routed through the same
+            // bound-native dispatch the value-read form (`const f = hkdf; f(...)`)
+            // already uses. Scoped to crypto — the reported module, whose runtime
+            // dispatcher resolves every callable export by name.
+            if has_spread && module_name == "crypto" {
+                return Ok(Err(args));
+            }
             if module_name == "child_process" {
                 match func_name {
                     "execSync" if !args.is_empty() => {

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -969,7 +969,22 @@ pub(super) fn try_module_static_methods(
                     // #1434: keep the named-import + dotted form on one
                     // shared lowering path for the methods whose shape
                     // matches between sites.
-                    if super::crypto::is_passthrough_method(method_name) {
+                    //
+                    // #6668: only for a NON-spread call. `lower_crypto_passthrough`
+                    // collapses the call into a flat `Expr::Call` whose args are
+                    // the lowered AST arguments verbatim — a spread operand
+                    // (`crypto.hkdf(...args, cb)`) is passed as the ARRAY itself,
+                    // not expanded, so the codegen fast-path (e.g.
+                    // `arm_crypto_hkdf_async_alg`) sees too few args and silently
+                    // returns `undefined` (callback never fires). When a spread is
+                    // present, fall through so the generic tail builds an
+                    // `Expr::CallSpread` with callee `PropertyGet{
+                    // NativeModuleRef("crypto"), method }`; codegen then routes it
+                    // through `js_closure_call_apply_with_spread` →
+                    // `dispatch_bound_method` → `js_native_call_method`, the same
+                    // bound-native dispatch the value-read form
+                    // (`const f = crypto.hkdf; f(...)`) already uses.
+                    if !has_spread && super::crypto::is_passthrough_method(method_name) {
                         if let Some(expr) = super::crypto::lower_crypto_passthrough(
                             method_name,
                             std::mem::take(&mut args),

--- a/crates/perry-hir/src/lower/expr_call/module_static.rs
+++ b/crates/perry-hir/src/lower/expr_call/module_static.rs
@@ -964,27 +964,30 @@ pub(super) fn try_module_static_methods(
             let is_crypto_module =
                 obj_name == "crypto" || ctx.lookup_builtin_module_alias(obj_name) == Some("crypto");
             if is_crypto_module {
+                // #6668: a spread call declines the whole crypto fast-path.
+                // `lower_crypto_passthrough` AND the manual `sha256`/`md5`/
+                // `getRandomValues` arms below collapse the call into a flat
+                // `Expr::Call`/intrinsic whose args are the lowered AST arguments
+                // verbatim — a spread operand (`crypto.hkdf(...args, cb)`) is
+                // passed as the ARRAY itself, not expanded, so the codegen
+                // fast-path (e.g. `arm_crypto_hkdf_async_alg`) sees too few args
+                // and silently returns `undefined` (callback never fires). Bail so
+                // the generic tail builds an `Expr::CallSpread` with callee
+                // `PropertyGet{ NativeModuleRef("crypto"), method }`; codegen then
+                // routes it through `js_closure_call_apply_with_spread` →
+                // `dispatch_bound_method` → `js_native_call_method`, the same
+                // bound-native dispatch the value-read form
+                // (`const f = crypto.hkdf; f(...)`) already uses. Mirrors the
+                // crypto guard in `globals.rs` (named-import form).
+                if has_spread {
+                    return Ok(Err(args));
+                }
                 if let ast::MemberProp::Ident(method_ident) = &member.prop {
                     let method_name = method_ident.sym.as_ref();
                     // #1434: keep the named-import + dotted form on one
                     // shared lowering path for the methods whose shape
                     // matches between sites.
-                    //
-                    // #6668: only for a NON-spread call. `lower_crypto_passthrough`
-                    // collapses the call into a flat `Expr::Call` whose args are
-                    // the lowered AST arguments verbatim — a spread operand
-                    // (`crypto.hkdf(...args, cb)`) is passed as the ARRAY itself,
-                    // not expanded, so the codegen fast-path (e.g.
-                    // `arm_crypto_hkdf_async_alg`) sees too few args and silently
-                    // returns `undefined` (callback never fires). When a spread is
-                    // present, fall through so the generic tail builds an
-                    // `Expr::CallSpread` with callee `PropertyGet{
-                    // NativeModuleRef("crypto"), method }`; codegen then routes it
-                    // through `js_closure_call_apply_with_spread` →
-                    // `dispatch_bound_method` → `js_native_call_method`, the same
-                    // bound-native dispatch the value-read form
-                    // (`const f = crypto.hkdf; f(...)`) already uses.
-                    if !has_spread && super::crypto::is_passthrough_method(method_name) {
+                    if super::crypto::is_passthrough_method(method_name) {
                         if let Some(expr) = super::crypto::lower_crypto_passthrough(
                             method_name,
                             std::mem::take(&mut args),

--- a/test-files/test_crypto_hkdf_spread_6668.ts
+++ b/test-files/test_crypto_hkdf_spread_6668.ts
@@ -16,7 +16,9 @@ const salt = new Uint8Array(0);
 const info = new Uint8Array([4, 5]);
 
 // Sync spread — returns a value, fully deterministic.
-const sargs = ["sha256", ikm, salt, info, 64];
+// `as const` makes the arg lists tuples so the spreads satisfy the parameter
+// signatures under `tsc` (TS2556); runtime is unaffected.
+const sargs = ["sha256", ikm, salt, info, 64] as const;
 const syncOut = crypto.hkdfSync(...sargs);
 console.log("hkdfSync-spread =", new Uint8Array(syncOut).length);
 
@@ -34,15 +36,15 @@ function record(label: string, err: unknown, out: ArrayBuffer) {
 }
 
 // 1. dotted, full spread + trailing regular callback
-const a1 = ["sha256", ikm, salt, info, 64];
+const a1 = ["sha256", ikm, salt, info, 64] as const;
 crypto.hkdf(...a1, (e, out) => record("dotted-spread", e, out));
 
 // 2. dotted, interleaved: regular, regular, spread, regular, callback
-const mid = [salt, info];
+const mid = [salt, info] as const;
 crypto.hkdf("sha256", ikm, ...mid, 64, (e, out) => record("dotted-interleaved", e, out));
 
 // 3. named import, full spread
-const a3 = ["sha256", ikm, salt, info, 64];
+const a3 = ["sha256", ikm, salt, info, 64] as const;
 hkdf(...a3, (e, out) => record("named-spread", e, out));
 
 // 4. plain direct call (regression guard for the non-spread fast-path)

--- a/test-files/test_crypto_hkdf_spread_6668.ts
+++ b/test-files/test_crypto_hkdf_spread_6668.ts
@@ -1,0 +1,49 @@
+// Regression test for #6668: a spread call of a native crypto method
+// (`crypto.hkdf(...args, cb)`) must not silently no-op.
+//
+// The HIR crypto passthrough used to collapse a spread call into a flat
+// `Expr::Call`, passing the spread operand as the array itself instead of
+// expanding it. The codegen fast-path (`arm_crypto_hkdf_async_alg`) then saw
+// too few positional args and returned `undefined` without dispatching, so the
+// callback never fired. Spread calls now fall through to `CallSpread`, which
+// dispatches through the same bound-native path the value-read form uses.
+
+import * as crypto from "crypto";
+import { hkdf } from "crypto";
+
+const ikm = new Uint8Array([1, 2, 3]);
+const salt = new Uint8Array(0);
+const info = new Uint8Array([4, 5]);
+
+// Sync spread — returns a value, fully deterministic.
+const sargs = ["sha256", ikm, salt, info, 64];
+const syncOut = crypto.hkdfSync(...sargs);
+console.log("hkdfSync-spread =", new Uint8Array(syncOut).length);
+
+// Async spread forms — collect, then print in a fixed sorted order once every
+// callback has fired, so the output is deterministic regardless of scheduling.
+const results: Record<string, number> = {};
+let remaining = 4;
+function record(label: string, err: unknown, out: ArrayBuffer) {
+  results[label] = err ? -1 : new Uint8Array(out).length;
+  if (--remaining === 0) {
+    for (const k of Object.keys(results).sort()) {
+      console.log(k, "=", results[k]);
+    }
+  }
+}
+
+// 1. dotted, full spread + trailing regular callback
+const a1 = ["sha256", ikm, salt, info, 64];
+crypto.hkdf(...a1, (e, out) => record("dotted-spread", e, out));
+
+// 2. dotted, interleaved: regular, regular, spread, regular, callback
+const mid = [salt, info];
+crypto.hkdf("sha256", ikm, ...mid, 64, (e, out) => record("dotted-interleaved", e, out));
+
+// 3. named import, full spread
+const a3 = ["sha256", ikm, salt, info, 64];
+hkdf(...a3, (e, out) => record("named-spread", e, out));
+
+// 4. plain direct call (regression guard for the non-spread fast-path)
+crypto.hkdf("sha256", ikm, salt, info, 64, (e, out) => record("direct", e, out));


### PR DESCRIPTION
## Summary

Fixes #6668 — a spread call of a native `crypto` method
(`crypto.hkdf(...args, cb)`) silently no-ops: no dispatch, no throw, the
callback never fires, and the call evaluates to `undefined`.

## Root cause

The bug is in **HIR lowering**, not the runtime spread bridge the issue
suspected. The crypto fast-path (`lower_crypto_passthrough`, reached from both
the dotted `crypto.hkdf(...)` form in `module_static.rs` and the named-import
`import { hkdf } from "crypto"` form in `globals.rs`) collapses the call into a
flat `Expr::Call`/`Expr::NativeMethodCall` whose args are the lowered AST
arguments **verbatim** — a spread operand (`...args`) is passed as the *array
itself*, not expanded. Codegen's `arm_crypto_hkdf_async_alg` then sees
`args.len() < 6` and returns `undefined` without ever dispatching, so the
callback never runs.

Confirmed by dumping HIR: `crypto.hkdf(...args, cb)` lowered to
`Call { callee: PropertyGet{NativeModuleRef("crypto"), "hkdf"}, args: [<args array>, cb] }`
— 2 positional args instead of 6.

The value-read form (`const f = crypto.hkdf; f(...)`) already works because it
dispatches through the bound-native path
(`js_native_call_value` → `dispatch_bound_method` → `js_native_call_method`).

## Fix

When a spread argument is present, the crypto fast-paths **decline** so the
generic lowering tail builds an `Expr::CallSpread` instead. That CallSpread
routes through `js_closure_call_apply_with_spread` →
`dispatch_bound_method("hkdf")` → `js_native_call_method` — the exact
bound-native dispatch the value-read form uses (and which the runtime crypto
dispatcher already handles for every callable export by name).

- `module_static.rs` — gate the dotted-form crypto passthrough on `!has_spread`.
- `globals.rs` — decline named-import crypto method calls that carry a spread.

Both are one-line guards; no runtime changes. Scoped to `crypto` (the reported
module), whose runtime dispatcher resolves every callable export by name.

## Verification

`test-files/test_crypto_hkdf_spread_6668.ts` (new) — byte-identical to
`node --experimental-strip-types` across five forms:

```
hkdfSync-spread = 64      # sync spread, returns a value
direct = 64               # non-spread fast-path (regression guard)
dotted-interleaved = 64   # crypto.hkdf("sha256", ikm, ...mid, 64, cb)
dotted-spread = 64        # crypto.hkdf(...args, cb)
named-spread = 64         # import { hkdf }; hkdf(...args, cb)
```

Before the fix, `dotted-spread`, `dotted-interleaved`, and `named-spread` were
missing entirely (silent no-op).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `crypto.hkdf`/`hkdfSync` behavior when invoked with spread arguments, preventing incorrect simplification.
  * Ensured spread-based HKDF calls are lowered and dispatched correctly so callbacks don’t get skipped.
* **Tests**
  * Added a regression test for `crypto.hkdf` spread-call variants to verify deterministic synchronous output and reliable asynchronous callback execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->