### PR TITLE
fix(runtime): atob returns a binary string, not UTF-8-mangled high bytes (Auth.js/jose session decrypt)

### DIFF
--- a/crates/perry-runtime/src/string/base64_codec.rs
+++ b/crates/perry-runtime/src/string/base64_codec.rs
@@ -48,7 +48,22 @@ pub extern "C" fn js_atob(value: f64) -> *const StringHeader {
         throw_invalid_character();
     }
     match base64::engine::general_purpose::STANDARD_NO_PAD.decode(&cleaned) {
-        Ok(decoded) => js_string_from_bytes(decoded.as_ptr(), decoded.len() as u32),
+        Ok(decoded) => {
+            // Spec (`atob`): the result is a "binary string" — each UTF-16
+            // code unit equals one decoded byte (0-255), so `charCodeAt(i)`
+            // returns byte `i`. Perry strings are UTF-8 backed, so the raw
+            // decoded bytes CANNOT be handed straight to `js_string_from_bytes`:
+            // any byte >= 0x80 is invalid UTF-8 on its own and `charCodeAt`
+            // then mis-decodes it (jose/Auth.js decode a JWE's random binary
+            // IV/ciphertext/tag through `atob`, so high bytes silently
+            // corrupted the session token → login "JWTSessionError"). Map each
+            // byte to its Latin-1 code point (U+0000..U+00FF) and encode THAT
+            // as UTF-8, which round-trips back to the byte value under
+            // `charCodeAt`. `btoa` already reads char code points and rejects
+            // > 0xff, so this is its exact inverse.
+            let s: String = decoded.iter().map(|&b| b as char).collect();
+            js_string_from_bytes(s.as_ptr(), s.len() as u32)
+        }
         Err(_) => throw_invalid_character(),
     }
 }

--- a/test-files/test_gap_atob_binary_high_bytes.ts
+++ b/test-files/test_gap_atob_binary_high_bytes.ts
@@ -1,0 +1,27 @@
+// `atob` must return a "binary string" — each UTF-16 code unit equals one
+// decoded byte (0-255), so `charCodeAt(i)` recovers byte i exactly, including
+// bytes >= 128. Perry stored the raw decoded bytes as UTF-8, so high bytes
+// (invalid UTF-8 on their own) were mis-decoded by charCodeAt — corrupting any
+// binary payload round-tripped through base64 (jose/Auth.js decode a JWE's
+// random binary IV/ciphertext/tag this way, which broke session-token
+// decryption → login failure).
+
+// Direct decode of bytes fa fb fc c8 80 7f.
+const b = atob("+vv8yIB/");
+console.log("length:", b.length);
+console.log("codes:", Array.from(b, (c) => c.charCodeAt(0)).join(","));
+
+// btoa/atob round-trip over the full 0..255 byte range.
+let src = "";
+for (let i = 0; i < 256; i++) src += String.fromCharCode(i);
+const round = atob(btoa(src));
+let ok = round.length === 256;
+for (let i = 0; i < 256 && ok; i++) ok = round.charCodeAt(i) === i;
+console.log("full 0-255 round-trip:", ok);
+
+// ASCII still decodes correctly (the JSON-header case that always worked).
+console.log("ascii:", atob("eyJhIjoxfQ"));
+
+// A byte with the high bit set on its own.
+const hi = atob("gA=="); // single byte 0x80
+console.log("single high byte:", hi.length, hi.charCodeAt(0));


### PR DESCRIPTION
## Summary

`atob` decoded base64 to raw bytes and passed them straight to `js_string_from_bytes`, which treats the buffer as UTF-8. Any decoded byte ≥ `0x80` is invalid UTF-8 on its own, so `charCodeAt` then mis-decoded it:

```js
atob("+vv8yIB/")               // bytes fa fb fc c8 80 7f
// node:  length 6, codes 250,251,252,200,128,127
// perry: length 3, codes 55983,NaN,127   ← wrong
```

Per the [WHATWG spec](https://html.spec.whatwg.org/multipage/webappapis.html#dom-atob), `atob` returns a "binary string" whose i-th UTF-16 code unit equals decoded byte `i` (0-255). The fix maps each byte to its Latin-1 code point (`U+0000..U+00FF`) and encodes that as UTF-8, so `charCodeAt` recovers the exact byte. This is the precise inverse of `btoa`, which already reads char code points and rejects `> 0xff`.

## How it was found

Verifying Auth.js credentials login on a Next.js 16 App Router app. The session token is a JWE (jose, `dir` / `A256CBC-HS512`); jose decodes its random binary IV, ciphertext, and HMAC tag through `atob` (the fallback taken when `Uint8Array.fromBase64` is unavailable). High bytes silently corrupted, so the token that Perry **encrypted and wrote correctly** (Node could decrypt Perry's cookie) **failed to decrypt on read** (Perry could not read its own cookie) → `JWTSessionError` → the session was never restored, so every authenticated page redirected back to login.

With this fix the full login round-trip restores the session end-to-end (`session.user` populated, authenticated routes reached).

## Verification

- `atob("+vv8yIB/")` → `250,251,252,200,128,127`; full `btoa`/`atob` round-trip over all 256 byte values; single high byte `atob("gA==")` → `[128]`; ASCII unchanged — all byte-identical to `node --experimental-strip-types`.
- New gap test `test_gap_atob_binary_high_bytes.ts`.
- jose's `A256CBC-HS512` encrypt→decrypt round-trip (via `node:crypto`, the exact backend calls) now round-trips through the base64 fallback; the real Auth.js login restores the session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `atob` decoding for binary data containing bytes above `0x7F`.
  * Ensured decoded byte values are preserved accurately in the resulting string.
  * Maintained correct behavior for ASCII and full-byte-range Base64 round trips.

* **Tests**
  * Added coverage for high-byte decoding, including `0x80` and all 256 byte values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->