### PR TITLE
fix(crypto): route createSecretKey/createPrivateKey/createPublicKey through value-dispatch (#6675)

### DIFF
--- a/crates/perry-stdlib/src/crypto/random.rs
+++ b/crates/perry-stdlib/src/crypto/random.rs
@@ -346,6 +346,32 @@ pub unsafe extern "C" fn js_crypto_native_dispatch(
         "generateKeySync" => {
             pointer_value(js_crypto_generate_key_sync(str_ptr(0), arg(1)) as *mut u8)
         }
+        // #6675: the key-material constructors reached as a VALUE — a named
+        // import (`import { createPrivateKey } from "crypto"`), a computed
+        // property access, or a bundled `require('crypto').createPrivateKey`
+        // (turbopack/webpack) — route here instead of through the codegen
+        // fast-path. Without these arms they fell to `_ => undefined`, so
+        // `createPrivateKey(secret)` returned `undefined` rather than THROWING
+        // on non-key material. jsonwebtoken's sign()/verify() depend on the
+        // throw: `try { createPrivateKey(secret) } catch { createSecretKey(...) }`.
+        // The missing throw left `secretOrPrivateKey` undefined and crashed at
+        // `secretOrPrivateKey.type` ("Cannot read properties of undefined").
+        // The runtime helpers throw on invalid material, matching Node.
+        "createSecretKey" => {
+            let encoding = if args_len >= 2 && JSValue::from_bits(arg(1).to_bits()).is_any_string()
+            {
+                str_ptr(1)
+            } else {
+                0
+            };
+            pointer_value(js_crypto_create_secret_key(bytes_ptr(0), encoding) as *mut u8)
+        }
+        "createPrivateKey" => {
+            f64::from_bits(JSValue::string_ptr(js_crypto_create_private_key_value(arg(0))).bits())
+        }
+        "createPublicKey" => {
+            f64::from_bits(JSValue::string_ptr(js_crypto_create_public_key_value(arg(0))).bits())
+        }
         "generatePrime" if args_len >= 3 => js_crypto_generate_prime_async(arg(0), arg(1), arg(2)),
         "generatePrime" | "generatePrimeSync" => js_crypto_generate_prime_sync(arg(0), arg(1)),
         "checkPrime" if args_len >= 3 => js_crypto_check_prime_async(arg(0), arg(1), arg(2)),

--- a/test-files/test_issue_6675_createprivatekey_throws.ts
+++ b/test-files/test_issue_6675_createprivatekey_throws.ts
@@ -1,0 +1,76 @@
+// Issue #6675: jsonwebtoken jwt.sign(payload, "<string secret>", {algorithm:"HS256"})
+// threw "Cannot read properties of undefined (reading 'type')" under Perry.
+//
+// jsonwebtoken's sign.js normalizes a string secret with:
+//   if (secretOrPrivateKey != null && !(secretOrPrivateKey instanceof KeyObject)) {
+//     try { secretOrPrivateKey = createPrivateKey(secretOrPrivateKey) }
+//     catch (_) { try { secretOrPrivateKey = createSecretKey(Buffer.from(secretOrPrivateKey)) } catch (_) {...} }
+//   }
+//   if (header.alg.startsWith('HS') && secretOrPrivateKey.type !== 'secret') {...}
+//
+// In Node, createPrivateKey("<plain string>") THROWS (invalid key material), so
+// the catch runs createSecretKey and produces a KeyObject with .type === "secret".
+//
+// The bundled jsonwebtoken reaches these constructors as VALUES (via
+// require('crypto').createPrivateKey) rather than direct member calls, so it hits
+// the runtime value-dispatch. That dispatch had no arms for the key constructors
+// and returned undefined without throwing, so the catch never ran,
+// secretOrPrivateKey became undefined, and reading `.type` crashed.
+//
+// This test mirrors that by obtaining the constructors through a value the
+// compiler can't statically resolve to crypto.<method> — exercising the runtime
+// value-dispatch path exactly like the bundled package does.
+import * as cryptoNs from "crypto";
+
+function assert(condition: boolean, message: string) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const crypto = cryptoNs as any;
+const createPrivateKey = crypto["createPrivateKey"];
+const createSecretKey = crypto["createSecretKey"];
+const KeyObject = crypto["KeyObject"];
+
+function normalizeSecret(secretOrPrivateKey: any): any {
+  if (secretOrPrivateKey != null && !(secretOrPrivateKey instanceof KeyObject)) {
+    try {
+      secretOrPrivateKey = createPrivateKey(secretOrPrivateKey);
+    } catch (_) {
+      try {
+        secretOrPrivateKey = createSecretKey(
+          typeof secretOrPrivateKey === "string"
+            ? Buffer.from(secretOrPrivateKey)
+            : secretOrPrivateKey,
+        );
+      } catch (_) {
+        throw new Error("secretOrPrivateKey is not valid key material");
+      }
+    }
+  }
+  return secretOrPrivateKey;
+}
+
+const key = normalizeSecret("secret-value-here");
+// The console.log lines are the byte-for-byte parity oracle (diffed against
+// `node --experimental-strip-types`); the asserts make the test fail loudly if
+// it is ever run standalone with an incorrect result.
+console.log("type:", key.type);
+console.log("isSecret:", key.type === "secret");
+assert(
+  key.type === "secret",
+  "normalizeSecret must fall back to a secret KeyObject",
+);
+
+// createPublicKey must also THROW on a plain string (the verify() path relies on
+// this to fall through to createSecretKey for HS* tokens).
+const createPublicKey = crypto["createPublicKey"];
+let pubThrew = false;
+try {
+  createPublicKey("secret-value-here");
+} catch (_) {
+  pubThrew = true;
+}
+console.log("createPublicKey throws on plain string:", pubThrew);
+assert(pubThrew, "createPublicKey must throw on a plain (non-key) string");


### PR DESCRIPTION
## Summary

Fixes #6675 — `jsonwebtoken.sign(payload, "<string secret>", { algorithm: "HS256" })` threw `TypeError: Cannot read properties of undefined (reading 'type')` under Perry, while Node signs the identical call.

## Root cause

`jsonwebtoken`'s `sign.js` normalizes a string secret into a `KeyObject`:

```js
if (secretOrPrivateKey != null && !(secretOrPrivateKey instanceof KeyObject)) {
  try { secretOrPrivateKey = createPrivateKey(secretOrPrivateKey) }
  catch (_) {
    try { secretOrPrivateKey = createSecretKey(Buffer.from(secretOrPrivateKey)) }
    catch (_) { /* invalid key material */ }
  }
}
if (header.alg.startsWith('HS') && secretOrPrivateKey.type !== 'secret') { … }
```

In Node, `createPrivateKey("<plain string>")` **throws** (not valid key material), so the `catch` runs `createSecretKey` and produces a `secret` `KeyObject`.

The bundled `jsonwebtoken` (turbopack/webpack) reaches these constructors **as values** — `require('crypto').createPrivateKey` — rather than as direct `crypto.createPrivateKey(...)` member calls. That value-form dispatches through the runtime crypto value-dispatch (`js_crypto_native_dispatch`), which had **no arms** for `createSecretKey` / `createPrivateKey` / `createPublicKey`. They fell to `_ => undefined`, so `createPrivateKey(secret)` returned `undefined` **without throwing** — the `catch` never ran, `secretOrPrivateKey` became `undefined`, and reading `.type` crashed.

The direct member-call form (`crypto.createPrivateKey(...)`) already worked because codegen lowers it through a static fast-path that calls the throwing runtime helpers — which is why the primitives looked correct in isolation.

## Fix

Add the three missing arms to `js_crypto_native_dispatch`, routing to the same runtime helpers the codegen fast-path uses:

- `createSecretKey` → `js_crypto_create_secret_key`
- `createPrivateKey` → `js_crypto_create_private_key_value`
- `createPublicKey` → `js_crypto_create_public_key_value`

Those helpers already throw on invalid key material (`ERR_OSSL_PEM_NO_START_LINE` / `ERR_INVALID_ARG_TYPE`), so the value-form now matches both the direct member-call form and Node.

## Verification

New parity test `test-files/test_issue_6675_createprivatekey_throws.ts` reproduces jsonwebtoken's normalize shape through the dynamic value-dispatch path (computed access, so it exercises the runtime dispatch exactly like the bundled package). Byte-identical to `node --experimental-strip-types`:

```
type: secret
isSecret: true
createPublicKey throws on plain string: true
```

Before the fix, the same test produced `type: undefined` (would crash at `.type` in the real jsonwebtoken path); a multi-form probe confirmed the direct import / member-call forms throw (static path) while the computed/value forms returned `undefined` (dynamic path) — now all forms throw as Node does.

Regression check: `test_gap_crypto_cipher_3382_3381_2954` (the existing test that exercises these constructors) stays byte-identical; the static `crypto.createSecretKey(...)` surface in `test_parity_crypto` is unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for creating secret, private, and public key objects when key material is provided in value form.
  * Fixed key creation flows that could incorrectly return no result.
  * Improved compatibility with JSON Web Token signing when using string-based secrets.

* **Tests**
  * Added a regression test covering secret/private key normalization for token signing.
  * Added an assertion that public key creation correctly rejects plain string secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->