### PR TITLE
fix(runtime): materialize Uint8Array base64/hex methods as readable values (#6674)

### DIFF
--- a/crates/perry-codegen/src/expr/property_get/globalget.rs
+++ b/crates/perry-codegen/src/expr/property_get/globalget.rs
@@ -181,6 +181,39 @@ pub(crate) fn lower_globalget_property(ctx: &mut FnCtx<'_>, property: &str) -> R
             &[(I64, &ctor_handle), (I64, &key_raw)],
         ));
     }
+    // #6674: `Uint8Array.fromBase64` / `fromHex` read as a VALUE (not a direct
+    // call) — jose/Auth.js feature-detect with `Uint8Array.fromBase64 ? native
+    // : fallback`. The bare `Uint8Array` receiver collapses to `GlobalGet(0)`
+    // here (HIR: `PropertyGet { object: GlobalGet(0), property: "fromBase64" }`),
+    // so without this arm the read fell through to the `undefined` sentinel
+    // below even though the runtime constructor closure now carries the static.
+    // These names are distinctive to `Uint8Array` among the builtin globals
+    // (Buffer inherits them via its constructor's prototype chain, matching
+    // Node), so route by property name — resolve the reified ctor closure and
+    // read the static installed by `install_builtin_constructor_statics`. The
+    // direct call form is intercepted earlier in HIR (`module_static.rs`).
+    if matches!(property, "fromBase64" | "fromHex") {
+        let ctor_idx = ctx.strings.intern("Uint8Array");
+        let ctor_bytes_global = format!("@{}", ctx.strings.entry(ctor_idx).bytes_global);
+        let ctor_len = "Uint8Array".len().to_string();
+        let ctor = ctx.block().call(
+            DOUBLE,
+            "js_get_global_this_builtin_value",
+            &[(PTR, &ctor_bytes_global), (I64, &ctor_len)],
+        );
+        let key_idx = ctx.strings.intern(property);
+        let key_handle_global = format!("@{}", ctx.strings.entry(key_idx).handle_global);
+        let blk = ctx.block();
+        let ctor_handle = unbox_to_i64(blk, &ctor);
+        let key_box = blk.load(DOUBLE, &key_handle_global);
+        let key_bits = blk.bitcast_double_to_i64(&key_box);
+        let key_raw = blk.and(I64, &key_bits, POINTER_MASK_I64);
+        return Ok(blk.call(
+            DOUBLE,
+            "js_object_get_field_by_name_f64",
+            &[(I64, &ctor_handle), (I64, &key_raw)],
+        ));
+    }
     if property == "supports" {
         let ctor_idx = ctx.strings.intern("SubtleCrypto");
         let ctor_bytes_global = format!("@{}", ctx.strings.entry(ctor_idx).bytes_global);

--- a/crates/perry-runtime/src/object/global_this/install_static.rs
+++ b/crates/perry-runtime/src/object/global_this/install_static.rs
@@ -84,6 +84,29 @@ extern "C" fn url_parse_thunk(
     }
 }
 
+// #6674: static-factory thunks for `Uint8Array.fromBase64` / `fromHex`. The
+// `str_handle` is the argument's raw NaN-boxed bits reinterpreted as `i64`, the
+// convention `js_u8_from_base64` / `js_u8_from_hex` expect (matching the
+// instance `setFromBase64` dispatch in `buffer_dispatch.rs`). The returned
+// `BufferHeader*` is nan-boxed as a pointer — identical to the value the
+// compile-time `Uint8Array.fromBase64(str)` call path produces.
+extern "C" fn uint8array_from_base64_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    input: f64,
+    opts: f64,
+) -> f64 {
+    let buf = crate::buffer::js_u8_from_base64(input.to_bits() as i64, opts);
+    crate::value::js_nanbox_pointer(buf as i64)
+}
+
+extern "C" fn uint8array_from_hex_thunk(
+    _closure: *const crate::closure::ClosureHeader,
+    input: f64,
+) -> f64 {
+    let buf = crate::buffer::js_u8_from_hex(input.to_bits() as i64);
+    crate::value::js_nanbox_pointer(buf as i64)
+}
+
 extern "C" fn subtle_crypto_supports_thunk(
     _closure: *const crate::closure::ClosureHeader,
     rest: f64,
@@ -647,6 +670,33 @@ pub(crate) fn install_builtin_constructor_statics(
                 "revocable",
                 proxy_revocable_thunk as *const u8,
                 2,
+                false,
+            );
+        }
+        // #6674: TC39 `Uint8Array.fromBase64(str, opts)` / `fromHex(str)` static
+        // factories, materialized as readable own statics on the `Uint8Array`
+        // constructor closure. The direct call form is already intercepted at
+        // compile time (HIR `module_static.rs`), so these thunks back the value
+        // read (`typeof Uint8Array.fromBase64 === "function"`, the jose/Auth.js
+        // feature-detection gate) and the rebound-call form
+        // (`const f = Uint8Array.fromBase64; f(s)`). They route to the same
+        // `js_u8_from_base64` / `js_u8_from_hex` runtime helpers the compile-time
+        // path uses, so the produced value is identical. `fromBase64.length` is
+        // 1 (the optional opts is the 2nd, undefined-padded, ABI slot).
+        "Uint8Array" => {
+            install_constructor_static_with_call_arity(
+                ctor,
+                "fromBase64",
+                uint8array_from_base64_thunk as *const u8,
+                1,
+                2,
+                false,
+            );
+            install_constructor_static(
+                ctor,
+                "fromHex",
+                uint8array_from_hex_thunk as *const u8,
+                1,
                 false,
             );
         }

--- a/crates/perry-runtime/src/object/global_this/populate.rs
+++ b/crates/perry-runtime/src/object/global_this/populate.rs
@@ -345,6 +345,19 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
                     );
                 }
             }
+            // #6674: the TC39 base64/hex conversion methods
+            // (`toBase64`/`toHex`/`setFromBase64`/`setFromHex`) are Uint8Array-ONLY
+            // (they don't exist on other typed arrays), so install them as own
+            // methods on the `Uint8Array` per-kind prototype — not the shared
+            // `%TypedArray%.prototype` intrinsic. This materializes the value read
+            // `typeof Uint8Array.prototype.toBase64 === "function"`; the static
+            // factories `fromBase64`/`fromHex` are installed on the constructor by
+            // `install_builtin_constructor_statics`.
+            if name == "Uint8Array" {
+                super::super::typed_array_proto_thunks::install_uint8array_base64_hex_proto_methods(
+                    proto_obj,
+                );
+            }
             // #4140: per-kind `BYTES_PER_ELEMENT` own data property on BOTH the
             // constructor and its prototype, matching Node's descriptor
             // `{ value, writable:false, enumerable:false, configurable:false }`.

--- a/crates/perry-runtime/src/object/typed_array_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/typed_array_proto_thunks.rs
@@ -889,3 +889,117 @@ pub(super) extern "C" fn ta_generic_thunk(
         brand_then_dispatch(name, &all)
     }
 }
+
+// ---------------------------------------------------------------------------
+// #6674: `Uint8Array.prototype` base64/hex conversion methods.
+//
+// `toBase64`/`toHex`/`setFromBase64`/`setFromHex` are Uint8Array-ONLY in the
+// spec (they do not exist on `Int8Array.prototype` etc.), so they are installed
+// as own methods on the Uint8Array per-kind prototype via
+// `install_uint8array_base64_hex_proto_methods`, NOT on the shared
+// `%TypedArray%.prototype` intrinsic (`TYPED_ARRAY_PROTO_METHODS`).
+//
+// Pre-fix these methods dispatched on CALL (`b.toBase64(…)` reaches
+// `dispatch_buffer_method` because Uint8Array instances are Buffer-backed) but
+// were not materialized as readable property VALUES on the prototype, so
+// `typeof Uint8Array.prototype.toBase64` read `"undefined"` and feature
+// detection (`Uint8Array.prototype.toBase64 ? native : fallback`, as jose /
+// Auth.js do) took the fallback path. These thunks make the value read report a
+// function and route a reflective `.call`/`.apply` through the same
+// `dispatch_buffer_method` base64/hex arms the instance fast path already uses.
+// ---------------------------------------------------------------------------
+
+/// Throw `TypeError: Method Uint8Array.prototype.<m> called on incompatible
+/// receiver` (Test262 brand checks assert only the error *type*; the wording is
+/// informational). Never returns.
+fn throw_not_uint8_array(method: &str) -> ! {
+    let msg = format!("Method Uint8Array.prototype.{method} called on incompatible receiver");
+    let s = crate::string::js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
+    let err = crate::error::js_typeerror_new(s);
+    crate::exception::js_throw(f64::from_bits(
+        crate::value::JSValue::pointer(err as *const u8).bits(),
+    ))
+}
+
+/// Resolve the `IMPLICIT_THIS` receiver to a Uint8Array-backed buffer address.
+/// The base64/hex methods only exist on Uint8Array, so a multi-byte typed-array
+/// receiver (`Uint8Array.prototype.toBase64.call(new Int8Array())`) is rejected
+/// with a `TypeError` just like Node's `ValidateUint8Array`.
+#[inline]
+unsafe fn uint8_receiver_or_throw(method: &str) -> usize {
+    match ta_receiver_or_throw(method) {
+        TypedArrayProtoReceiver::Uint8Buffer(addr) => addr,
+        TypedArrayProtoReceiver::TypedArray(_) => throw_not_uint8_array(method),
+    }
+}
+
+pub(super) extern "C" fn u8_to_base64_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    opts: f64,
+    _b: f64,
+    _d: f64,
+) -> f64 {
+    unsafe {
+        let addr = uint8_receiver_or_throw("toBase64");
+        let args = [opts];
+        super::dispatch_buffer_method(addr, "toBase64", args.as_ptr(), args.len())
+    }
+}
+
+pub(super) extern "C" fn u8_to_hex_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    _a: f64,
+    _b: f64,
+    _d: f64,
+) -> f64 {
+    unsafe {
+        let addr = uint8_receiver_or_throw("toHex");
+        super::dispatch_buffer_method(addr, "toHex", std::ptr::null(), 0)
+    }
+}
+
+pub(super) extern "C" fn u8_set_from_base64_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    str_arg: f64,
+    opts: f64,
+    _d: f64,
+) -> f64 {
+    unsafe {
+        let addr = uint8_receiver_or_throw("setFromBase64");
+        let args = [str_arg, opts];
+        super::dispatch_buffer_method(addr, "setFromBase64", args.as_ptr(), args.len())
+    }
+}
+
+pub(super) extern "C" fn u8_set_from_hex_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    str_arg: f64,
+    _b: f64,
+    _d: f64,
+) -> f64 {
+    unsafe {
+        let addr = uint8_receiver_or_throw("setFromHex");
+        let args = [str_arg];
+        super::dispatch_buffer_method(addr, "setFromHex", args.as_ptr(), args.len())
+    }
+}
+
+/// Install the Uint8Array-only base64/hex methods as readable own methods on the
+/// `Uint8Array.prototype` object (#6674). Each `(name, thunk, spec_length)` pair
+/// gets the spec `.length` recorded by `install_proto_method`, then the ABI call
+/// arity is widened to 3 (the uniform native thunk signature) so omitted trailing
+/// arguments are padded with `undefined` instead of reading unset register slots
+/// — the same convention `install_typed_array_proto_methods` uses.
+pub(super) fn install_uint8array_base64_hex_proto_methods(proto_obj: *mut ObjectHeader) {
+    use super::global_this::install_proto_method as ipm;
+    let methods: &[(&str, *const u8, u32)] = &[
+        ("toBase64", u8_to_base64_thunk as *const u8, 0),
+        ("toHex", u8_to_hex_thunk as *const u8, 0),
+        ("setFromBase64", u8_set_from_base64_thunk as *const u8, 1),
+        ("setFromHex", u8_set_from_hex_thunk as *const u8, 1),
+    ];
+    for &(name, func_ptr, spec_length) in methods {
+        ipm(proto_obj, name, func_ptr, spec_length);
+        crate::closure::js_register_closure_arity(func_ptr, 3);
+    }
+}

--- a/test-files/test_gap_u8_base64_hex_2901.ts
+++ b/test-files/test_gap_u8_base64_hex_2901.ts
@@ -54,3 +54,47 @@ console.log(JSON.stringify([...d2]), JSON.stringify(r4));
 const orig = new Uint8Array([0, 1, 2, 250, 251, 255]);
 console.log(JSON.stringify([...Uint8Array.fromBase64(orig.toBase64())]));
 console.log(JSON.stringify([...Uint8Array.fromHex(orig.toHex())]));
+
+// #6674: the methods must be readable as property VALUES (not just callable),
+// so feature-detection (`Uint8Array.prototype.toBase64 ? native : fallback`, as
+// jose/Auth.js do) sees them. These read "undefined" pre-fix even though the
+// call form dispatched.
+console.log(typeof Uint8Array.prototype.toBase64);
+console.log(typeof Uint8Array.prototype.toHex);
+console.log(typeof Uint8Array.prototype.setFromBase64);
+console.log(typeof Uint8Array.prototype.setFromHex);
+console.log(typeof Uint8Array.fromBase64);
+console.log(typeof Uint8Array.fromHex);
+console.log("in:", "toBase64" in Uint8Array.prototype, "toHex" in Uint8Array.prototype);
+console.log(
+  "detect:",
+  typeof Uint8Array.prototype.toBase64 === "function" &&
+    typeof Uint8Array.fromBase64 === "function",
+);
+
+// Spec `.length` (own arity) of the reified methods.
+console.log(
+  "len:",
+  Uint8Array.prototype.toBase64.length,
+  Uint8Array.prototype.toHex.length,
+  Uint8Array.prototype.setFromBase64.length,
+  Uint8Array.prototype.setFromHex.length,
+  Uint8Array.fromBase64.length,
+  Uint8Array.fromHex.length,
+);
+
+// Negative controls: instance methods are not statics, static factories are not
+// on the prototype (must stay "undefined" — the fix must not over-install).
+console.log(typeof (Uint8Array as any).toBase64, typeof (Uint8Array.prototype as any).fromBase64);
+
+// The reified prototype value dispatches on reflective `.call` too (brand-checks
+// `this`). Compare against the instance form to avoid hardcoding encodings.
+const rv = new Uint8Array([0, 1, 2, 250, 255]);
+console.log(Uint8Array.prototype.toHex.call(rv) === rv.toHex());
+console.log(Uint8Array.prototype.toBase64.call(rv) === rv.toBase64());
+
+// Rebound static factory (`const f = Uint8Array.fromBase64; f(...)`).
+const reboundFromB64 = Uint8Array.fromBase64;
+const reboundFromHex = Uint8Array.fromHex;
+console.log(JSON.stringify([...reboundFromB64("AQID")]));
+console.log(JSON.stringify([...reboundFromHex("0aff")]));


### PR DESCRIPTION
## Summary

Fixes #6674. The TC39 `Uint8Array` base64/hex methods (`toBase64`, `toHex`, `fromBase64`, `fromHex`, `setFromBase64`, `setFromHex`) dispatch correctly when **called** but read as `undefined` as property **values** — so feature-detection like jose/Auth.js's `Uint8Array.prototype.toBase64 ? native : fallback` (and the `Uint8Array.fromBase64` truthiness gate) took the fallback path on Perry even though the native methods are present. Surfaced while fixing #6673.

## Root cause

Perry's `Uint8Array` is a **dedicated typed-array constructor**, not the `Buffer` constructor — the `Uint8Array ≡ Buffer` aliasing exists only at the instance-dispatch level (which is why instance calls, and instance value reads via `is_buffer_method_name`, already worked). The prototype-object and constructor-object value reads were never materialized, in two independent spots:

- **Prototype reads** (`Uint8Array.prototype.toBase64` …) resolve through the shared `%TypedArray%.prototype` method table, which omits these Uint8Array-only names.
- **Static reads** (`Uint8Array.fromBase64` …) hit the bare-global codegen path, which returns the `undefined` sentinel for unrecognized property names (the receiver name collapses to `GlobalGet(0)` in HIR before the runtime static is consulted).

## Changes

- **`typed_array_proto_thunks.rs`** — brand-checking prototype thunks for `toBase64`/`toHex`/`setFromBase64`/`setFromHex` + an installer for the Uint8Array per-kind prototype. These methods are Uint8Array-only, so they go on the per-kind proto, **not** the shared `%TypedArray%` intrinsic. They route to the existing `dispatch_buffer_method` base64/hex arms.
- **`populate.rs`** — wires the prototype installer into the `Uint8Array` branch.
- **`install_static.rs`** — installs `fromBase64`/`fromHex` as own statics on the Uint8Array constructor closure, calling the same `js_u8_from_base64`/`js_u8_from_hex` helpers the compile-time call path uses (so rebound calls produce identical values).
- **`globalget.rs`** — routes the bare-global value read `Uint8Array.fromBase64`/`fromHex` to that reified static instead of the `undefined` sentinel.

The direct **call** forms are unchanged — they're intercepted earlier in HIR (`module_static.rs`).

## Testing

Extended `test_gap_u8_base64_hex_2901.ts` with `typeof` reads for all six methods (prototype + static), `in` / `.length` reflection, the jose-style feature-detection expression, reflective `Uint8Array.prototype.toX.call(u8)`, rebound static factory calls (`const f = Uint8Array.fromBase64; f(...)`), and negative controls (`typeof Uint8Array.toBase64` and `typeof Uint8Array.prototype.fromBase64` stay `undefined` — the fix must not over-install).

Verified **byte-for-byte** against Node 26. Also ran 8 typed-array/buffer gap tests (`test_gap_typed_array_proto_methods`, `test_issue_3988_typedarray_static_accessors`, `test_issue_2063_typed_array_method_access`, `test_gap_uint8array_source_dispatch`, `test_issue_2060_typed_array_accessor_descriptors`, `test_gap_typed_arrays`, `test_gap_buffer_ops`, `test_gap_3662_typedarray_length`) as a regression check — all pass.

No version bump / changelog in this PR (folded in at merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Base64 and hexadecimal conversion APIs for `Uint8Array`.
  * Added static `Uint8Array.fromBase64()` and `Uint8Array.fromHex()` factory methods.
  * Added `Uint8Array` instance methods: `toBase64()`, `toHex()`, `setFromBase64()`, and `setFromHex()`.
  * Added validation to ensure these methods are used with `Uint8Array` instances.
* **Tests**
  * Added coverage for feature detection, reflective calls, rebound factory usage, and method metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->