### PR TITLE
fix(hir): named class expression `.name` keeps the explicit class name (#6679)

### DIFF
--- a/crates/perry-hir/src/lower/stmt.rs
+++ b/crates/perry-hir/src/lower/stmt.rs
@@ -718,6 +718,23 @@ pub(crate) fn lower_stmt(
                                             false,
                                         )?;
                                     if let Some(inner_name) = inner_name_for_register {
+                                        // #6679: a NAMED class EXPRESSION's `.name`
+                                        // is its own explicit name (`Named` in
+                                        // `const B = class Named {}`), NOT the outer
+                                        // binding name. Per spec a named class
+                                        // expression is not an anonymous function
+                                        // definition, so assignment NamedEvaluation
+                                        // (`SetFunctionName` from `const B =`) must
+                                        // not override the declared name. This fast
+                                        // path registers the class under `bind_name`
+                                        // so `new B()` / `instanceof B` resolve
+                                        // statically, so record a display-name
+                                        // override (the #5592 mechanism, exactly like
+                                        // the mixin arm below) that codegen emits for
+                                        // the `.name` string constant instead of the
+                                        // `bind_name` registration key.
+                                        ctx.class_display_names
+                                            .insert(lowered_class.id, inner_name.clone());
                                         lowered_class.aliases.push(inner_name);
                                     }
                                     // Computed member keys (`static get [expr]()`,

--- a/crates/perry-hir/src/lower/tests.rs
+++ b/crates/perry-hir/src/lower/tests.rs
@@ -507,3 +507,44 @@ fn test_plain_class_to_class_heritage_keeps_static_extends_name() {
         "static class-to-class heritage keeps its extends_name"
     );
 }
+
+/// #6679: a NAMED class EXPRESSION's `.name` is its own explicit name
+/// (`Named` in `const B = class Named {}`), not the outer binding name. Per
+/// spec a named class expression is not an anonymous function definition, so
+/// the assignment's NamedEvaluation (`SetFunctionName` from `const B =`) must
+/// not clobber the declared name. The module-top-level `const X = class {…}`
+/// fast path registers the class under the binding name so `new B()` /
+/// `instanceof B` resolve statically, and records a `class_display_names`
+/// override to the explicit name for codegen to emit as `.name`. An ANONYMOUS
+/// `const A = class {}` takes the inferred binding name and needs no override.
+#[test]
+fn test_named_class_expression_var_decl_reports_explicit_name() {
+    let source = r#"
+        const B = class Named {};
+        const A = class {};
+    "#;
+    let module = perry_parser::parse_typescript(source, "t.ts").expect("source parses");
+    let hir = super::lower_module(&module, "t", "t.ts").expect("source lowers");
+
+    let named = hir
+        .classes
+        .iter()
+        .find(|c| c.name == "B")
+        .expect("class registered under binding name `B`");
+    assert_eq!(
+        hir.class_display_names.get(&named.id).map(String::as_str),
+        Some("Named"),
+        "named class expression must report its explicit name as `.name`"
+    );
+
+    let anon = hir
+        .classes
+        .iter()
+        .find(|c| c.name == "A")
+        .expect("anonymous class registered under inferred name `A`");
+    assert_eq!(
+        hir.class_display_names.get(&anon.id),
+        None,
+        "anonymous class expression uses the inferred binding name, no override"
+    );
+}

--- a/crates/perry-hir/tests/c262_parity.rs
+++ b/crates/perry-hir/tests/c262_parity.rs
@@ -139,6 +139,48 @@ fn assignment_named_evaluation_names_anonymous_class_identifier_rhs_only() {
 }
 
 #[test]
+fn named_class_expression_var_decl_reports_explicit_name() {
+    // #6679: `const B = class Named {}` binds `B`, but the class was declared
+    // `Named`, so `B.name === "Named"`. The module-top-level fast path
+    // registers the class under the binding name `B` (so `new B()` resolves
+    // statically) and records a `class_display_names` override to the explicit
+    // name for codegen to emit as `.name`. An ANONYMOUS class expression
+    // (`const A = class {}`) takes the inferred binding name and needs no
+    // override.
+    let module = lower_src(
+        r#"
+        const B = class Named {};
+        const A = class {};
+        "#,
+    );
+
+    let named = module
+        .classes
+        .iter()
+        .find(|class| class.name == "B")
+        .expect("class registered under binding name `B`");
+    assert_eq!(
+        module
+            .class_display_names
+            .get(&named.id)
+            .map(String::as_str),
+        Some("Named"),
+        "named class expression must report its explicit name as `.name`"
+    );
+
+    let anon = module
+        .classes
+        .iter()
+        .find(|class| class.name == "A")
+        .expect("anonymous class registered under inferred name `A`");
+    assert_eq!(
+        module.class_display_names.get(&anon.id),
+        None,
+        "anonymous class expression uses the inferred binding name, no override"
+    );
+}
+
+#[test]
 fn array_is_array_static_alias_call_lowers_to_intrinsic() {
     let module = lower_src(
         r#"

--- a/crates/perry-hir/tests/c262_parity.rs
+++ b/crates/perry-hir/tests/c262_parity.rs
@@ -139,48 +139,6 @@ fn assignment_named_evaluation_names_anonymous_class_identifier_rhs_only() {
 }
 
 #[test]
-fn named_class_expression_var_decl_reports_explicit_name() {
-    // #6679: `const B = class Named {}` binds `B`, but the class was declared
-    // `Named`, so `B.name === "Named"`. The module-top-level fast path
-    // registers the class under the binding name `B` (so `new B()` resolves
-    // statically) and records a `class_display_names` override to the explicit
-    // name for codegen to emit as `.name`. An ANONYMOUS class expression
-    // (`const A = class {}`) takes the inferred binding name and needs no
-    // override.
-    let module = lower_src(
-        r#"
-        const B = class Named {};
-        const A = class {};
-        "#,
-    );
-
-    let named = module
-        .classes
-        .iter()
-        .find(|class| class.name == "B")
-        .expect("class registered under binding name `B`");
-    assert_eq!(
-        module
-            .class_display_names
-            .get(&named.id)
-            .map(String::as_str),
-        Some("Named"),
-        "named class expression must report its explicit name as `.name`"
-    );
-
-    let anon = module
-        .classes
-        .iter()
-        .find(|class| class.name == "A")
-        .expect("anonymous class registered under inferred name `A`");
-    assert_eq!(
-        module.class_display_names.get(&anon.id),
-        None,
-        "anonymous class expression uses the inferred binding name, no override"
-    );
-}
-
-#[test]
 fn array_is_array_static_alias_call_lowers_to_intrinsic() {
     let module = lower_src(
         r#"

--- a/test-files/test_gap_6679_named_class_expr_name.ts
+++ b/test-files/test_gap_6679_named_class_expr_name.ts
@@ -1,0 +1,66 @@
+// Issue #6679: a NAMED class EXPRESSION's `.name` must be its own explicit
+// class name, not the outer binding name. `const B = class Named {}` binds
+// `B`, but the class was declared `Named`, so `B.name === "Named"`. Per spec a
+// named class expression is NOT an anonymous function definition, so the
+// assignment's NamedEvaluation (`SetFunctionName` from the `const B =` target)
+// must not clobber the declared name. perry's module-top-level
+// `const X = class {…}` fast path registered the class under the binding name
+// and used that for `.name`, so `B.name` wrongly returned "B". An ANONYMOUS
+// class expression (`const A = class {}`) still infers "A" — that is correct.
+//
+// Expected output:
+// Named
+// A
+// Foo
+// D
+// Named
+// Baz
+// Meth
+// Inner
+// Exp
+// object
+
+// Module-top-level fast path (the bug site): explicit name wins.
+const B = class Named {};
+console.log(B.name); // Named
+
+// Control: anonymous class expression correctly infers the binding name.
+const A = class {};
+console.log(A.name); // A
+
+// Explicit name wins even with static members present.
+const C = class Foo {
+  static bar() {
+    return 1;
+  }
+};
+console.log(C.name); // Foo
+
+// Inner name equal to the binding name: unchanged.
+const D = class D {};
+console.log(D.name); // D
+
+// An instance's constructor.name follows the class's `.name`.
+console.log(new B().constructor.name); // Named
+
+// Assignment name-inference path also honors the explicit name.
+let E;
+E = class Baz {};
+console.log(E.name); // Baz
+
+// Object-property position (general class-expression value arm).
+const obj = { m: class Meth {} };
+console.log(obj.m.name); // Meth
+
+// Class expression returned from a function body.
+function f() {
+  return class Inner {};
+}
+console.log(f().name); // Inner
+
+// Exported named class expression.
+export const G = class Exp {};
+console.log(G.name); // Exp
+
+// The named class expression is still constructible via the binding.
+console.log(typeof new C()); // object


### PR DESCRIPTION
Fixes #6679.

## Symptom

For a **named** class expression, the explicit class name must win, but perry returned the outer binding name:

```ts
const B = class Named {};
console.log(B.name);   // spec: "Named"   perry (before): "B"   <-- BUG
const A = class {};
console.log(A.name);   // spec: "A"        perry: "A"           (control: inferred name is correct)
```

## Root cause

Per spec, a **named** class expression is *not* an anonymous function definition, so the assignment's `NamedEvaluation`/`SetFunctionName` (inferred from the `const B =` target) must not override the declared class name.

The module-top-level `const X = class {…}` fast path in `crates/perry-hir/src/lower/stmt.rs` lowers the class under the **binding** name (`B`) — deliberately, so `new B()` / `instanceof B` resolve statically — and recorded the explicit name (`Named`) only as a lookup *alias*. Since codegen derives `.name` from the registration key, `B.name` came out `"B"`.

The general class-expression value arm (`lower_expr/arm_class.rs`) and the assignment arm (`expr_assign.rs`) already guard on the explicit name; only this fast path was missing it.

## Fix

Record a `class_display_names` override (the #5592 mechanism, mirroring the sibling mixin arm ~30 lines below) mapping the class's id to its explicit name. Codegen then emits the explicit name for the `.name` string constant while the class stays registered under the binding name for static construction/`instanceof`.

One-line behavioral change; anonymous class expressions are untouched (they correctly keep the inferred binding name).

## Tests

- **Gap parity test** `test-files/test_gap_6679_named_class_expr_name.ts` — 10 cases: the bug site, the anonymous control, static members, inner-name == binding-name, `new B().constructor.name`, the assignment path, object-property position, function-body return, exported named class expression, and constructibility via the binding. Byte-for-byte matches `node --experimental-strip-types`.
- **HIR regression unit test** in `crates/perry-hir/tests/c262_parity.rs` — asserts the display override is recorded for a named class expression and *not* for an anonymous one.

## Validation

- Repro now matches node exactly on all cases (`Named`, `A`, `Foo`, `D`, `Named`, …).
- New HIR test passes. (The unrelated `logical_property_assignment_short_circuits_the_store_4586` in the same file fails identically on pristine `main` — a pre-existing failure, not introduced here.)
- Re-compiled 7 existing class-expression gap tests (`#4461`, `#5592`, `class_expr_identity`, `class_expr_instance_fields`, `class_field_named_stack_index`, `dup_class_name_field_layout`) against node — all match, no regressions.

Per contributor guidance, no version bump / CHANGELOG entry (maintainer folds those in at merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed named class expressions so their `.name` property preserves the explicitly declared class name instead of the surrounding variable name.
  * Ensured consistent naming across static members, assignments, object properties, returned classes, and exported class expressions.
  * Preserved inferred names for anonymous class expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->