### PR TITLE
fix(symbol): resolve computed Symbol[key] well-known symbols (#6676)

### DIFF
--- a/crates/perry-codegen/src/runtime_decls/strings_part2.rs
+++ b/crates/perry-codegen/src/runtime_decls/strings_part2.rs
@@ -259,6 +259,8 @@ pub(crate) fn declare_phase_b_strings_part2(module: &mut LlModule) {
     module.declare_function("js_symbol_new", DOUBLE, &[DOUBLE]);
     module.declare_function("js_symbol_new_empty", DOUBLE, &[]);
     module.declare_function("js_symbol_for", DOUBLE, &[DOUBLE]);
+    // #6676: computed `Symbol[key]` (constructor value + runtime key).
+    module.declare_function("js_symbol_computed_member", DOUBLE, &[DOUBLE, DOUBLE]);
     module.declare_function("js_symbol_key_for", DOUBLE, &[DOUBLE]);
     module.declare_function("js_symbol_description", DOUBLE, &[DOUBLE]);
     module.declare_function("js_symbol_to_string", I64, &[DOUBLE]);

--- a/crates/perry-hir/src/lower/expr_member.rs
+++ b/crates/perry-hir/src/lower/expr_member.rs
@@ -99,6 +99,34 @@ pub(crate) fn static_member_prop_name(prop: &ast::MemberProp) -> Option<String> 
     }
 }
 
+/// The well-known-symbol member names exposed on the `Symbol` constructor
+/// (`Symbol.iterator`, `Symbol.asyncIterator`, `Symbol.toPrimitive`, …). Both the
+/// dot-access fold and the computed-access fold (#6676, `Symbol["iterator"]`)
+/// rewrite these to the `@@__perry_wk_<name>` sentinel that `js_symbol_for`
+/// resolves from the well-known cache, so a single list keeps the two forms in
+/// lockstep. `dispose`/`asyncDispose` are included because Perry surfaces them as
+/// well-known symbols (`using`/`await using`).
+pub(crate) fn is_well_known_symbol_member(name: &str) -> bool {
+    matches!(
+        name,
+        "toPrimitive"
+            | "hasInstance"
+            | "toStringTag"
+            | "species"
+            | "match"
+            | "matchAll"
+            | "replace"
+            | "search"
+            | "split"
+            | "isConcatSpreadable"
+            | "unscopables"
+            | "iterator"
+            | "asyncIterator"
+            | "dispose"
+            | "asyncDispose"
+    )
+}
+
 pub(super) fn lower_member(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Result<Expr> {
     // #1723: when THIS access is the auditable `ns[dynamicKey].staticMember`
     // shape — a dynamic stdlib SUB-namespace selection (`path.win32` /
@@ -613,32 +641,71 @@ fn lower_member_inner(ctx: &mut LoweringContext, member: &ast::MemberExpr) -> Re
     // runtime's `js_symbol_for` sniffs via prefix and resolves from
     // the well-known cache (not the registry). Gives each well-known
     // symbol a stable pointer without needing a new HIR variant.
-    if let ast::Expr::Ident(obj_ident) = member.obj.as_ref() {
+    if let ast::Expr::Ident(obj_ident) = unwrap_transparent(member.obj.as_ref()) {
         if obj_ident.sym.as_ref() == "Symbol" {
             if let ast::MemberProp::Ident(prop_ident) = &member.prop {
                 let prop_name = prop_ident.sym.as_ref();
-                if matches!(
-                    prop_name,
-                    "toPrimitive"
-                        | "hasInstance"
-                        | "toStringTag"
-                        | "species"
-                        | "match"
-                        | "matchAll"
-                        | "replace"
-                        | "search"
-                        | "split"
-                        | "isConcatSpreadable"
-                        | "unscopables"
-                        | "iterator"
-                        | "asyncIterator"
-                        | "dispose"
-                        | "asyncDispose"
-                ) {
+                if is_well_known_symbol_member(prop_name) {
                     return Ok(Expr::SymbolFor(Box::new(Expr::String(format!(
                         "@@__perry_wk_{}",
                         prop_name
                     )))));
+                }
+            }
+        }
+    }
+
+    // #6676: the COMPUTED form `Symbol["iterator"]` / `Symbol[name]`. The dot
+    // fold above only matches `MemberProp::Ident`, so a bracket read fell
+    // through to a generic property get on the `Symbol` constructor and returned
+    // `undefined`. This is exactly what breaks esbuild's `__knownSymbol` helper
+    // — `(symbol = Symbol[name]) ? symbol : Symbol.for("Symbol." + name)` —
+    // which every downleveled `yield*`/`for-of`/spread routes through at
+    // `--target=es2015|es2017`: keyed under `undefined`, the delegate iterator
+    // dies with "Cannot read properties of undefined (reading 'next')".
+    //
+    // A string-literal key folds to the same `@@__perry_wk_` sentinel the dot
+    // form uses, so `Symbol["iterator"] === Symbol.iterator` holds by
+    // construction. A *runtime* key can't be folded (the esbuild helper passes
+    // `name` as a parameter), so it resolves through `js_symbol_computed_member`,
+    // which maps a well-known name to the cached symbol and otherwise falls back
+    // to the ordinary `Symbol[key]` read — a strict superset of prior behavior.
+    // Gated on `Symbol` being the real global (a local binding of that name
+    // resolves normally, matching JS scoping).
+    if let ast::Expr::Ident(obj_ident) = unwrap_transparent(member.obj.as_ref()) {
+        if obj_ident.sym.as_ref() == "Symbol" && ctx.lookup_local("Symbol").is_none() {
+            if let ast::MemberProp::Computed(computed) = &member.prop {
+                match computed.expr.as_ref() {
+                    ast::Expr::Lit(ast::Lit::Str(s)) => {
+                        if let Some(prop_name) = s.value.as_str() {
+                            if is_well_known_symbol_member(prop_name) {
+                                return Ok(Expr::SymbolFor(Box::new(Expr::String(format!(
+                                    "@@__perry_wk_{}",
+                                    prop_name
+                                )))));
+                            }
+                        }
+                    }
+                    _ => {
+                        let key_expr = lower_expr(ctx, &computed.expr)?;
+                        return Ok(Expr::Call {
+                            callee: Box::new(Expr::ExternFuncRef {
+                                name: "js_symbol_computed_member".to_string(),
+                                param_types: vec![Type::Any, Type::Any],
+                                return_type: Type::Any,
+                            }),
+                            args: vec![
+                                Expr::PropertyGet {
+                                    byte_offset: 0,
+                                    object: Box::new(Expr::GlobalGet(0)),
+                                    property: "Symbol".to_string(),
+                                },
+                                key_expr,
+                            ],
+                            type_args: vec![],
+                            byte_offset: 0,
+                        });
+                    }
                 }
             }
         }

--- a/crates/perry-runtime/src/symbol/constructors.rs
+++ b/crates/perry-runtime/src/symbol/constructors.rs
@@ -105,6 +105,69 @@ pub unsafe extern "C" fn js_symbol_for(key_f64: f64) -> f64 {
     f64::from_bits(POINTER_TAG | (sym_ptr as u64 & POINTER_MASK))
 }
 
+/// #6676: a *computed* read of a well-known symbol off the `Symbol`
+/// constructor — `Symbol[name]` with a runtime key. Dot access (`Symbol.iterator`)
+/// and a string-literal bracket key are folded to the `@@__perry_wk_` sentinel at
+/// HIR, but a dynamic key can't be folded. This is the exact shape esbuild's
+/// `__knownSymbol` helper emits when downleveling `yield*`/`async` to
+/// es2015/es2017: `(symbol = Symbol[name]) ? symbol : Symbol.for("Symbol." + name)`.
+///
+/// Map a well-known member name to the cached well-known symbol — identity-equal
+/// to the dot form, so `Symbol[name] === Symbol.iterator`. Any other key (a
+/// non-string, or a name that isn't a well-known symbol) falls back to the
+/// ordinary `Symbol[key]` read on the constructor value, making this a strict
+/// superset of the prior behavior (a non-well-known key still reads `undefined`,
+/// which is exactly what lets the `__knownSymbol` fallback to `Symbol.for` fire).
+#[no_mangle]
+pub unsafe extern "C" fn js_symbol_computed_member(ctor_f64: f64, key_f64: f64) -> f64 {
+    let bits = key_f64.to_bits();
+    if bits & 0xFFFF_0000_0000_0000 == STRING_TAG {
+        let key_ptr = (bits & POINTER_MASK) as *const StringHeader;
+        if let Some(name) = str_from_header(key_ptr) {
+            if is_well_known_symbol_member_name(&name) {
+                let wk_ptr = well_known_symbol(&name);
+                return f64::from_bits(POINTER_TAG | (wk_ptr as u64 & POINTER_MASK));
+            }
+        }
+    }
+    // Not a well-known symbol name — behave exactly like a plain `Symbol[key]`
+    // read on the constructor value.
+    crate::value::js_dyn_index_get(ctor_f64, key_f64)
+}
+
+/// The well-known-symbol member names surfaced on the `Symbol` constructor. Kept
+/// in sync with `is_well_known_symbol_member` in perry-hir's `expr_member.rs`
+/// (the dot / string-literal fold) so all three forms — `Symbol.iterator`,
+/// `Symbol["iterator"]`, `Symbol[name]` — resolve to the same cached symbol.
+fn is_well_known_symbol_member_name(name: &str) -> bool {
+    matches!(
+        name,
+        "toPrimitive"
+            | "hasInstance"
+            | "toStringTag"
+            | "species"
+            | "match"
+            | "matchAll"
+            | "replace"
+            | "search"
+            | "split"
+            | "isConcatSpreadable"
+            | "unscopables"
+            | "iterator"
+            | "asyncIterator"
+            | "dispose"
+            | "asyncDispose"
+    )
+}
+
+// #1561-style force-keep: `js_symbol_computed_member` has no internal Rust
+// callers — only generated IR (perry-hir lowers `Symbol[key]` to a call to it),
+// so LTO / whole-program-bitcode link modes are free to internalize and
+// dead-strip it. The `#[used]` reference edge keeps the export alive.
+#[used]
+static KEEP_JS_SYMBOL_COMPUTED_MEMBER: unsafe extern "C" fn(f64, f64) -> f64 =
+    js_symbol_computed_member;
+
 /// `Symbol.keyFor(sym)` — reverse lookup. Returns the registration key as a
 /// string for registered symbols, or undefined for non-registered symbols.
 #[no_mangle]

--- a/test-files/test_gap_6676_computed_symbol_iterator.ts
+++ b/test-files/test_gap_6676_computed_symbol_iterator.ts
@@ -1,0 +1,83 @@
+// #6676: reading a well-known symbol off the `Symbol` constructor through a
+// COMPUTED key (`Symbol["iterator"]`, or `Symbol[name]` with a runtime key)
+// must return the same symbol as dot access (`Symbol.iterator`). Perry only
+// intercepted the dot form at HIR lowering, so the bracket form fell through to
+// a generic property read and returned `undefined`.
+//
+// This is exactly what breaks esbuild's `__knownSymbol` helper —
+// `(symbol = Symbol[name]) ? symbol : Symbol.for("Symbol." + name)` — that its
+// `yield*` / `for-of` / spread downleveling emits for `--target=es2015|es2017`:
+// keyed under `undefined`, the delegate iterator dies with "Cannot read
+// properties of undefined (reading 'next')".
+//
+// Validated byte-for-byte against `node --experimental-strip-types`.
+
+// ── string-literal computed key === dot access ──────────────────────────────
+console.log(Symbol["iterator"] === Symbol.iterator, typeof Symbol["iterator"]);
+console.log(
+  Symbol["asyncIterator"] === Symbol.asyncIterator,
+  typeof Symbol["asyncIterator"],
+);
+console.log(
+  Symbol["toPrimitive"] === Symbol.toPrimitive,
+  typeof Symbol["toPrimitive"],
+);
+console.log(
+  Symbol["hasInstance"] === Symbol.hasInstance,
+  typeof Symbol["hasInstance"],
+);
+console.log(
+  Symbol["toStringTag"] === Symbol.toStringTag,
+  typeof Symbol["toStringTag"],
+);
+
+// ── dynamic (runtime) key — the shape esbuild's __knownSymbol emits ──────────
+// Form A: bare `Symbol` receiver, cast only on the key (esbuild's exact shape).
+const __knownSymbol = (name: string, symbol?: any): any =>
+  (symbol = Symbol[name as any]) ? symbol : Symbol.for("Symbol." + name);
+console.log(__knownSymbol("iterator") === Symbol.iterator);
+console.log(__knownSymbol("asyncIterator") === Symbol.asyncIterator);
+
+// Form B: cast on the receiver (what a TS author writes) — exercises the
+// transparent-wrapper unwrap so `(Symbol as any)[name]` resolves too.
+const grab = (name: string): any => (Symbol as any)[name];
+const keys = ["iterator", "asyncIterator", "toPrimitive", "match", "species"];
+for (const k of keys) {
+  console.log(k, grab(k) === (Symbol as any)[k], typeof grab(k));
+}
+
+// ── a non-well-known key stays undefined (so the ?: fallback fires) ──────────
+console.log(typeof Symbol["definitelyNotAWellKnownSymbol" as any]);
+const fallback = __knownSymbol("notAKnownSymbol");
+console.log(typeof fallback, (fallback as symbol).description);
+
+// ── the real manifestation: esbuild's es2015 __generator lowering ───────────
+// esbuild rewrites generators into PLAIN objects whose `[Symbol.iterator]` is
+// SET via `__knownSymbol("iterator")`, then consumed by spread / for-of. Before
+// the fix the SET keyed the method under `undefined`, so the consumer (which
+// looks up the real `Symbol.iterator`) never found it.
+function makeIter(values: number[]): any {
+  let i = 0;
+  const obj: any = {};
+  obj[__knownSymbol("iterator")] = function () {
+    return this;
+  };
+  obj.next = function () {
+    return i < values.length
+      ? { value: values[i++], done: false }
+      : { value: undefined, done: true };
+  };
+  return obj;
+}
+console.log(JSON.stringify([...makeIter([1, 2, 3])])); // spread
+const collected: number[] = [];
+for (const v of makeIter([4, 5])) collected.push(v); // for-of
+console.log(collected.join(","));
+console.log(Math.max(...makeIter([7, 9, 2]))); // spread into a call
+
+// computed `Symbol.iterator` also resolves the built-in iterator of an array
+const arr = [10, 20, 30];
+const iterFn = (arr as any)[Symbol["iterator"]].bind(arr);
+const viaArray: number[] = [];
+for (const v of { [Symbol.iterator]: iterFn }) viaArray.push(v);
+console.log(viaArray.join(","));


### PR DESCRIPTION
Fixes #6676.

## Problem
Reading a well-known symbol off the `Symbol` constructor through a **computed** key returned `undefined`, while dot access returned the real symbol:

```ts
console.log(Symbol["iterator"] === Symbol.iterator, typeof Symbol["iterator"]);
// node : true symbol
// perry: false undefined   <-- BUG
```

Only `Symbol.iterator` (dot) was intercepted at HIR lowering (`expr_member.rs`) and folded to the `@@__perry_wk_` sentinel; the bracket form — and crucially `Symbol[name]` with a **runtime** key — fell through to a generic property read on the `Symbol` constructor and returned `undefined`.

This is exactly what breaks esbuild's `__knownSymbol` helper, emitted whenever `yield*`/`async`/`for-of`/spread is downleveled to `--target=es2015|es2017`:

```js
var __knownSymbol = (name, symbol) => (symbol = Symbol[name]) ? symbol : Symbol.for("Symbol." + name);
```

With `Symbol[name]` returning `undefined`, the helper falls back to `Symbol.for("Symbol.iterator")` — a *different*, registered symbol — so the object's iterator is keyed under the wrong symbol and driving it dies with `TypeError: Cannot read properties of undefined (reading 'next')`.

## Fix
- **HIR (`expr_member.rs`)** — intercept the computed form `Symbol[key]`:
  - a **string-literal** key folds to the same `@@__perry_wk_<name>` sentinel dot access uses, so `Symbol["iterator"] === Symbol.iterator` holds by construction;
  - a **runtime** key resolves through a new runtime helper.
  - Gated on `Symbol` being the real (unshadowed) global; `unwrap_transparent` lets `(Symbol as any)[name]` (what a TS author writes) resolve too. The well-known-name list is factored into a shared `is_well_known_symbol_member` helper.
- **runtime (`symbol/constructors.rs`)** — `js_symbol_computed_member(ctor, key)` maps a well-known name to the cached symbol (identity-equal to the dot form) and otherwise **falls back to the ordinary `Symbol[key]` read** (`js_dyn_index_get`), making it a strict superset of prior behavior (a non-well-known key still reads `undefined`, which is what lets the `__knownSymbol` `?:` fallback fire). A `#[used]` guard keeps the codegen-only export alive under LTO.
- **codegen** — declares the new FFI function.

## Testing
`test-files/test_gap_6676_computed_symbol_iterator.ts` is byte-for-byte identical to `node --experimental-strip-types`. It covers string-literal keys, dynamic keys (both `Symbol[name as any]` and `(Symbol as any)[name]`), the non-well-known fallback, and the real esbuild manifestation — a plain `__generator`-style object whose `[Symbol.iterator]` is *set* via the computed symbol and then consumed by spread / for-of / `Math.max(...)`.

Regression sweep over 14 existing Symbol/iterator gap tests: all pass identically to Node except `test_gap_symbols` and `test_gap_iterator_helpers_2874`, which are **pre-existing** entries in `test-parity/known_failures.json` (the `Symbol.toPrimitive`-on-class gap #2374 and the Iterator Helpers gap — both untouched by this change).

> Note: explicitly reading `[Symbol.iterator]` off a **native** generator object (`(function*(){})()[Symbol.iterator]`) is a separate pre-existing gap and is out of scope here — esbuild's es2015 output uses plain `__generator` objects, not native generators, so #6676 does not depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for computed access to well-known symbols, including `Symbol["iterator"]`, `Symbol["asyncIterator"]`, and `Symbol["toPrimitive"]`.
  * Preserved standard dynamic property behavior for unknown computed keys.
  * Improved handling of wrapped `Symbol` expressions and computed symbol access.

* **Bug Fixes**
  * Ensured computed well-known symbols work correctly with iteration, spread syntax, and generator-transformed code.

* **Tests**
  * Added regression coverage for computed symbol access and iterator behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->