### PR TITLE
fix(runtime): pass the property key to JSON.stringify toJSON, omit undefined members (#5909)

### DIFF
--- a/crates/perry-runtime/src/json/mod.rs
+++ b/crates/perry-runtime/src/json/mod.rs
@@ -86,7 +86,9 @@ pub(crate) use stringify_buffer::{
 };
 #[allow(unused_imports)]
 pub(crate) use stringify_tojson_probe::{
-    invalidate_object_proto_tojson_state, to_json_definitely_absent, PROTO_TOJSON_DIRTY,
+    current_to_json_key_arg, invalidate_object_proto_tojson_state, reset_to_json_key,
+    set_to_json_key_index, set_to_json_key_str, set_to_json_key_value, to_json_definitely_absent,
+    PROTO_TOJSON_DIRTY,
 };
 
 // ─── Circular reference detection ────────────────────────────────────────────
@@ -162,6 +164,20 @@ thread_local! {
     /// result object emits its own fields while its children recurse normally.
     pub(crate) static SUPPRESS_NEXT_TO_JSON: std::cell::Cell<bool> =
         const { std::cell::Cell::new(false) };
+
+    /// The property key handed to `toJSON` for the value currently being
+    /// serialized (#5909 — test262 JSON/stringify/value-tojson-arguments).
+    /// ECMA-262 §25.5.2.2 SerializeJSONProperty step 2.b.i is
+    /// `Call(toJSON, value, « key »)`, where `key` is the empty String at the
+    /// root, an object's own property name for a member, and the stringified
+    /// index for an array element. Set right before recursing into each child
+    /// and read by `object_get_to_json` / `array_get_to_json` /
+    /// `bigint_apply_to_json`. Held as an owned Rust `String` (not a JS heap
+    /// pointer) so it never roots a movable GC allocation across the string
+    /// allocation the probes perform, and reset at every top-level stringify
+    /// entry so a key from one call can't leak into the next.
+    pub(crate) static TO_JSON_KEY: std::cell::RefCell<String> =
+        const { std::cell::RefCell::new(String::new()) };
 
     /// Cached verdict on whether the default `Object.prototype` carries a
     /// `toJSON` property (#6009). One of `PROTO_TOJSON_DIRTY` /

--- a/crates/perry-runtime/src/json/replacer.rs
+++ b/crates/perry-runtime/src/json/replacer.rs
@@ -194,11 +194,14 @@ unsafe fn write_replaced_scalar(buf: &mut String, replaced: f64) -> bool {
 /// Resolve `value.toJSON(key)` (spec `SerializeJSONProperty` step 2 — run
 /// BEFORE the replacer). `key_f64` is the property key passed to `toJSON`.
 #[inline]
-unsafe fn apply_to_json_keyed(value: f64, _key_f64: f64) -> f64 {
-    // `object_get_to_json` calls toJSON with the empty-string key arg, matching
-    // the no-replacer path. (Effect's Inspectable.toJSON ignores its argument;
-    // Node passes the property key. We mirror the no-replacer path's empty key
-    // to stay byte-identical with the rest of Perry's JSON suite.)
+unsafe fn apply_to_json_keyed(value: f64, key_f64: f64) -> f64 {
+    // SerializeJSONProperty step 2.b.i passes the property key to `toJSON`
+    // (#5909, test262 JSON/stringify/value-tojson-arguments). The replacer walk
+    // already carries the key here (empty String at the root, own key for a
+    // member, stringified index for an element); record it so the shared
+    // `object_get_to_json` / `array_get_to_json` / `bigint_apply_to_json` probes
+    // hand it to `toJSON`.
+    set_to_json_key_value(key_f64);
     apply_to_json(value)
 }
 

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -268,12 +268,12 @@ pub(crate) unsafe fn object_get_to_json(ptr: *const u8) -> Option<f64> {
     let recv = recv_handle.get_nanbox_f64();
     let bound = crate::closure::clone_closure_rebind_this(method_bits, recv);
 
-    // Per spec, `toJSON(key)` receives the property key. The pre-#321 own-key
-    // path passed the empty string, and Effect's `Inspectable.toJSON` ignores
-    // its argument, so we keep the empty-string key to stay byte-identical with
-    // the rest of Perry's JSON suite.
-    let empty_str = js_string_from_bytes(b"".as_ptr(), 0);
-    let key_f64_arg = f64::from_bits(STRING_TAG | (empty_str as u64 & POINTER_MASK));
+    // Per spec (§25.5.2.2 step 2.b.i), `toJSON(key)` receives the property key
+    // of the value being serialized — the empty String at the root, the own key
+    // for an object member, the stringified index for an array element (#5909,
+    // test262 JSON/stringify/value-tojson-arguments). The serialization loops
+    // record it in `TO_JSON_KEY` before recursing here.
+    let key_f64_arg = current_to_json_key_arg();
 
     let prev_this = crate::object::js_implicit_this_set(recv);
     let result = crate::closure::js_native_call_value(f64::from_bits(bound), &key_f64_arg, 1);
@@ -310,8 +310,8 @@ pub(crate) unsafe fn array_get_to_json(arr: *const crate::ArrayHeader) -> Option
     let recv = f64::from_bits(make_pointer_bits(arr as *const u8));
     let scope = crate::gc::RuntimeHandleScope::new();
     let recv_handle = scope.root_nanbox_f64(recv);
-    let empty_str = js_string_from_bytes(b"".as_ptr(), 0);
-    let key_f64_arg = f64::from_bits(STRING_TAG | (empty_str as u64 & POINTER_MASK));
+    // `toJSON(key)` receives the property key of this array value (#5909).
+    let key_f64_arg = current_to_json_key_arg();
     let prev_this = crate::object::js_implicit_this_set(recv_handle.get_nanbox_f64());
     let result = crate::closure::js_native_call_value(f64::from_bits(method_bits), &key_f64_arg, 1);
     crate::object::js_implicit_this_set(prev_this);
@@ -839,6 +839,58 @@ pub(crate) unsafe fn write_url_href_json(url: *mut crate::ObjectHeader, buf: &mu
     stringify_value(href, TYPE_UNKNOWN, buf);
 }
 
+/// SerializeJSONProperty step 2 (`toJSON`) for a heap-valued object member,
+/// applied by the object walk BEFORE the member's key is written so a member
+/// whose `toJSON` returns `undefined` can be OMITTED per spec (test262
+/// JSON/stringify/value-tojson-arguments) instead of emitting `"k":null` — the
+/// key used to be written first, with `toJSON` running only in the value
+/// recursion below.
+///
+/// Returns `Some(result)` ONLY when a callable `toJSON` actually ran (the value
+/// is a plain object/array carrying one); `result` is what it returned. The
+/// caller then omits the member if `result` is `undefined`/function/Symbol, or
+/// serializes `result` with the one-shot `SUPPRESS_NEXT_TO_JSON` guard armed so
+/// its own walk doesn't re-invoke `toJSON`. Returns `None` when no `toJSON`
+/// applies — a plain object/array without one, or any value that isn't a plain
+/// object/array — so the caller serializes the ORIGINAL value through the
+/// normal dispatch (never arming the guard: arming it for a value that then
+/// doesn't self-probe would leak the one-shot into the next member's `toJSON`).
+/// Because `None` means "serialize normally", a plain data object member keeps
+/// the #6009 fast path (its own walk skips the `toJSON` probe when
+/// `class_id == 0`), so this adds no probe there.
+///
+/// Guards, in an order safe for the `gc_obj_type` read below: handle ids and
+/// buffers/typed arrays carry no `GcHeader`; RegExp shares the
+/// `GC_TYPE_OBJECT` tag but is not an `ObjectHeader`; a boxed primitive is a
+/// real object but must serialize as its primitive (see `stringify_value_depth`)
+/// so it is left to the normal dispatch. Date/Temporal cells carry their own
+/// `GC_TYPE_*` tags, so the `gc_obj_type` match's `_` arm already skips them.
+/// The pending `toJSON` key must already be recorded.
+unsafe fn member_to_json(value: f64) -> Option<f64> {
+    let bits = value.to_bits();
+    let ptr = extract_pointer(bits)?;
+    if crate::value::addr_class::is_handle_band(ptr as usize) {
+        return None;
+    }
+    if crate::buffer::is_registered_buffer(ptr as usize) {
+        return None;
+    }
+    if crate::typedarray::lookup_typed_array_kind(ptr as usize).is_some() {
+        return None;
+    }
+    if crate::regex::regex_header_has_magic(ptr as *const crate::regex::RegExpHeader) {
+        return None;
+    }
+    if crate::builtins::boxed_primitive_json_value(value).is_some() {
+        return None;
+    }
+    match gc_obj_type(ptr) {
+        crate::gc::GC_TYPE_ARRAY => array_get_to_json(ptr as *const crate::ArrayHeader),
+        crate::gc::GC_TYPE_OBJECT => object_get_to_json(ptr),
+        _ => None,
+    }
+}
+
 pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, depth: u32) {
     // #6519: a WHATWG `URL` instance is a plain `GC_TYPE_OBJECT` (class_id 0)
     // whose `searchParams` field points back at the URL — walking its fields
@@ -1135,7 +1187,7 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
                 field_bits = gv.to_bits();
             }
         }
-        let field_val = f64::from_bits(field_bits);
+        let mut field_val = f64::from_bits(field_bits);
         // Skip undefined per JSON spec (incl. a getter that returned undefined).
         if field_bits == TAG_UNDEFINED {
             continue;
@@ -1148,11 +1200,8 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
             continue;
         }
 
-        if !first {
-            buf.push(',');
-        }
-        first = false;
-
+        // Resolve the member key up front — needed both to record the `toJSON`
+        // key (#5909) and to write the property name below.
         let key_f64 = key_at(f);
         let key_bits = key_f64.to_bits();
         let key_tag = key_bits & 0xFFFF_0000_0000_0000;
@@ -1161,6 +1210,38 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
         } else {
             key_bits as *const StringHeader
         };
+
+        // SerializeJSONProperty step 2 (#5909): apply a heap-valued member's
+        // `toJSON` HERE, before the comma/key are written, so a member whose
+        // `toJSON` returns `undefined` (or a function/Symbol) is OMITTED per
+        // spec — the value recursion below runs `toJSON` only AFTER the key, so
+        // such a member wrongly emitted `"k":null`. A member's `toJSON` key is
+        // its own property name; the synthetic `field{f}` fallback name is
+        // unreadable, so pass "" as it did before.
+        let mut member_probed = false;
+        if (field_bits & 0xFFFF_0000_0000_0000) == POINTER_TAG || is_raw_pointer(field_bits) {
+            set_to_json_key_str(str_from_header(key_ptr).unwrap_or(""));
+            if let Some(resolved) = member_to_json(field_val) {
+                let rb = resolved.to_bits();
+                if rb == TAG_UNDEFINED || is_closure_value(rb) || is_symbol_value(rb) {
+                    continue;
+                }
+                field_bits = rb;
+                field_val = resolved;
+                // `toJSON` already ran; arm the one-shot guard so the resolved
+                // value's own serialization doesn't invoke `toJSON` a second
+                // time (SerializeJSONProperty applies it once). Disarmed after
+                // the pointer dispatch below, gated on `member_probed`.
+                arm_to_json_result_guard(resolved);
+                member_probed = true;
+            }
+        }
+
+        if !first {
+            buf.push(',');
+        }
+        first = false;
+
         if let Some(key_str) = str_from_header(key_ptr) {
             // A key can itself contain `"`/`\`/control characters (e.g. a
             // `Symbol`-adjacent computed key or `Object.defineProperty`
@@ -1174,7 +1255,9 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
             let _ = write!(buf, "\"field{}\":", f);
         }
 
-        // Inline value dispatch for common types to avoid function call overhead
+        // Inline value dispatch for common types to avoid function call
+        // overhead. `field_bits`/`field_val` are the post-`toJSON` value when a
+        // `toJSON` ran above.
         let val_tag = field_bits & 0xFFFF_0000_0000_0000;
         if field_bits == TAG_NULL {
             buf.push_str("null");
@@ -1200,8 +1283,12 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
                 buf.push_str("null");
             }
         } else if val_tag == POINTER_TAG || is_raw_pointer(field_bits) {
-            // Nested object/array — recurse with depth
+            // Nested object/array (or the object/array `toJSON` returned). The
+            // `toJSON` key was recorded above; `member_probed` armed the guard.
             stringify_value_depth(field_val, TYPE_UNKNOWN, buf, depth + 1);
+            if member_probed {
+                SUPPRESS_NEXT_TO_JSON.with(|c| c.set(false));
+            }
         } else {
             // Number (most common for data objects) — or Date, handled
             // centrally by `write_number` via DATE_REGISTRY lookup.
@@ -1395,6 +1482,23 @@ pub(crate) unsafe fn build_shape_prefix_template(first_elem_bits: u64) -> Option
     })
 }
 
+/// Record field `f`'s property name (from the shape template's shared
+/// `keys_arr`) as the pending `toJSON` key before recursing into that field
+/// (#5909). Mirrors the key decode in `build_shape_prefix_template`.
+#[inline]
+unsafe fn set_to_json_key_for_template_field(template: &ShapeTemplate, f: usize) {
+    let keys_elements = (template.keys_arr as *const u8)
+        .add(std::mem::size_of::<crate::ArrayHeader>()) as *const f64;
+    let key_bits = (*keys_elements.add(f)).to_bits();
+    let key_tag = key_bits & 0xFFFF_0000_0000_0000;
+    let key_ptr = if key_tag == STRING_TAG || key_tag == POINTER_TAG {
+        (key_bits & POINTER_MASK) as *const StringHeader
+    } else {
+        key_bits as *const StringHeader
+    };
+    set_to_json_key_str(str_from_header(key_ptr).unwrap_or(""));
+}
+
 /// Fast emission path for an object element that matches the cached shape
 /// template. Returns `true` when the element was emitted via the template;
 /// `false` when the element diverges (different shape, skippable field, or
@@ -1468,6 +1572,7 @@ pub(crate) unsafe fn try_emit_shape_element(
                     buf.push_str("null");
                 }
             } else if vtag == POINTER_TAG || is_raw_pointer(fb) {
+                set_to_json_key_for_template_field(template, f);
                 stringify_value_depth(field_val, TYPE_UNKNOWN, buf, depth + 1);
             } else {
                 write_number(buf, field_val);
@@ -1529,6 +1634,7 @@ pub(crate) unsafe fn try_emit_shape_element(
                 buf.push_str("null");
             }
         } else if vtag == POINTER_TAG || is_raw_pointer(fb) {
+            set_to_json_key_for_template_field(template, f);
             stringify_value_depth(field_val, TYPE_UNKNOWN, buf, depth + 1);
         } else {
             write_number(buf, field_val);
@@ -1645,6 +1751,10 @@ pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, dep
             if i > 0 {
                 buf.push(',');
             }
+            // An element's `toJSON` key is its stringified index (#5909). Set
+            // before the shape emit (which may run the element's own `toJSON`)
+            // and the per-element fallback below.
+            set_to_json_key_index(i as usize);
             // Re-derived per element: the previous element's serialization can
             // have run user code / allocated (and moved this array).
             let elem = elem_at(i as usize);
@@ -1695,8 +1805,13 @@ pub(crate) unsafe fn stringify_array_depth(ptr: *const u8, buf: &mut String, dep
         } else if elem_bits == TAG_FALSE {
             buf.push_str("false");
         } else if elem_tag == BIGINT_TAG {
+            // A BigInt element's `toJSON` key is its stringified index (#5909).
+            set_to_json_key_index(i as usize);
             serialize_bigint(elem, buf);
         } else if elem_tag == POINTER_TAG || is_raw_pointer(elem_bits) {
+            // An element's `toJSON` key is its stringified index (#5909) — set
+            // before the object/array `toJSON` probes and the recursion below.
+            set_to_json_key_index(i as usize);
             let elem_ptr = if elem_tag == POINTER_TAG {
                 (elem_bits & POINTER_MASK) as *const u8
             } else {

--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -1291,7 +1291,13 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
             }
         } else {
             // Number (most common for data objects) — or Date, handled
-            // centrally by `write_number` via DATE_REGISTRY lookup.
+            // centrally by `write_number` via DATE_REGISTRY lookup. A BigInt
+            // member funnels through `write_number` to `serialize_bigint` /
+            // `bigint_apply_to_json`, which reads the pending `toJSON` key, so
+            // record this member's key first (#5909).
+            if val_tag == BIGINT_TAG {
+                set_to_json_key_str(str_from_header(key_ptr).unwrap_or(""));
+            }
             write_number(buf, field_val);
         }
     }
@@ -1575,6 +1581,11 @@ pub(crate) unsafe fn try_emit_shape_element(
                 set_to_json_key_for_template_field(template, f);
                 stringify_value_depth(field_val, TYPE_UNKNOWN, buf, depth + 1);
             } else {
+                // A BigInt field reaches `serialize_bigint` via `write_number`,
+                // which reads the pending `toJSON` key — record it first (#5909).
+                if vtag == BIGINT_TAG {
+                    set_to_json_key_for_template_field(template, f);
+                }
                 write_number(buf, field_val);
             }
         }
@@ -1637,6 +1648,11 @@ pub(crate) unsafe fn try_emit_shape_element(
             set_to_json_key_for_template_field(template, f);
             stringify_value_depth(field_val, TYPE_UNKNOWN, buf, depth + 1);
         } else {
+            // A BigInt field reaches `serialize_bigint` via `write_number`,
+            // which reads the pending `toJSON` key — record it first (#5909).
+            if vtag == BIGINT_TAG {
+                set_to_json_key_for_template_field(template, f);
+            }
             write_number(buf, field_val);
         }
     }

--- a/crates/perry-runtime/src/json/stringify_api.rs
+++ b/crates/perry-runtime/src/json/stringify_api.rs
@@ -183,6 +183,12 @@ pub unsafe extern "C" fn js_json_stringify(value: f64, type_hint: u32) -> *mut S
     // String::reserve. `push_str` grows on overflow for the rare
     // single-call output that exceeds that, so skip the estimate call
     // (issue #67: it was ~10ns of wasted work per call for small values).
+    //
+    // The root value's `toJSON` key is the empty String (§25.5.2.2). Reset it
+    // unconditionally so a nested `JSON.stringify` inside a `toJSON`/replacer
+    // callback also sees `""` at its own root, and so a key left by a prior
+    // top-level call can't leak in (#5909).
+    super::reset_to_json_key();
     stringify_value(value, type_hint, &mut buf);
     let ptr = json_string_from_output_bytes(buf.as_bytes());
     restore_stringify_buf(buf);

--- a/crates/perry-runtime/src/json/stringify_scalars.rs
+++ b/crates/perry-runtime/src/json/stringify_scalars.rs
@@ -231,8 +231,8 @@ pub(crate) unsafe fn bigint_apply_to_json(value: f64) -> Option<f64> {
         return None;
     }
     let recv = value_handle.get_nanbox_f64();
-    let empty_str = js_string_from_bytes(b"".as_ptr(), 0);
-    let key_f64_arg = f64::from_bits(STRING_TAG | (empty_str as u64 & POINTER_MASK));
+    // `toJSON(key)` receives the property key of this BigInt value (#5909).
+    let key_f64_arg = super::stringify_tojson_probe::current_to_json_key_arg();
     let prev_this = crate::object::js_implicit_this_set(recv);
     let result = crate::closure::js_native_call_value(f64::from_bits(method_bits), &key_f64_arg, 1);
     crate::object::js_implicit_this_set(prev_this);

--- a/crates/perry-runtime/src/json/stringify_tojson_probe.rs
+++ b/crates/perry-runtime/src/json/stringify_tojson_probe.rs
@@ -222,3 +222,70 @@ pub(crate) unsafe fn to_json_definitely_absent(ptr: *const u8) -> bool {
     }
     true
 }
+
+// ─── SerializeJSONProperty key (#5909) ───────────────────────────────────────
+// ECMA-262 §25.5.2.2 SerializeJSONProperty step 2.b.i calls `toJSON` with the
+// property key. `TO_JSON_KEY` carries that key from each serialization loop
+// (which knows the child's key) down to the three `toJSON` probes (which don't).
+// See the thread-local's doc comment in `mod.rs`.
+
+/// Reset the pending `toJSON` key to the empty String — the root key, and the
+/// safe default at every top-level `JSON.stringify` entry so a key set during
+/// a previous call can't leak into the next.
+#[inline]
+pub(crate) fn reset_to_json_key() {
+    TO_JSON_KEY.with(|c| c.borrow_mut().clear());
+}
+
+/// Record an object's own property name as the key to hand `toJSON` for the
+/// member about to be serialized.
+#[inline]
+pub(crate) fn set_to_json_key_str(key: &str) {
+    TO_JSON_KEY.with(|c| {
+        let mut s = c.borrow_mut();
+        s.clear();
+        s.push_str(key);
+    });
+}
+
+/// Record an array index (its stringified form) as the key to hand `toJSON`
+/// for the element about to be serialized.
+#[inline]
+pub(crate) fn set_to_json_key_index(index: usize) {
+    use std::fmt::Write;
+    TO_JSON_KEY.with(|c| {
+        let mut s = c.borrow_mut();
+        s.clear();
+        let _ = write!(s, "{index}");
+    });
+}
+
+/// Record a NaN-boxed JS string value as the pending `toJSON` key. The
+/// replacer walk (`apply_to_json_keyed`) already carries the property key as a
+/// value rather than a `&str`, so decode it here. Copies the bytes into the
+/// owned `String`, so nothing borrows the source header afterward.
+#[inline]
+pub(crate) unsafe fn set_to_json_key_value(key: f64) {
+    let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    match crate::string::str_bytes_from_jsvalue(key, &mut scratch) {
+        Some((ptr, len)) => {
+            let bytes = std::slice::from_raw_parts(ptr, len as usize);
+            TO_JSON_KEY.with(|c| {
+                let mut s = c.borrow_mut();
+                s.clear();
+                s.push_str(&String::from_utf8_lossy(bytes));
+            });
+        }
+        None => reset_to_json_key(),
+    }
+}
+
+/// Allocate the current pending `toJSON` key as a JS string value to pass as
+/// the `toJSON(key)` argument. The bytes are copied out of the thread-local
+/// first so the string allocation can't observe the cell still borrowed.
+#[inline]
+pub(crate) unsafe fn current_to_json_key_arg() -> f64 {
+    let bytes = TO_JSON_KEY.with(|c| c.borrow().as_bytes().to_vec());
+    let key = crate::js_string_from_bytes(bytes.as_ptr(), bytes.len() as u32);
+    f64::from_bits(STRING_TAG | (key as u64 & POINTER_MASK))
+}


### PR DESCRIPTION
## Summary

Fixes `built-ins/JSON/stringify/value-tojson-arguments.js` from the test262 JSON worklist (#5909). `SerializeJSONProperty` (ECMA-262 §25.5.2.2 step 2) now:

1. **Passes the correct property key to `toJSON`** — the empty String at the root, an object's own key for a member, the stringified index for an array element. Perry previously always passed `""`.
2. **Applies `toJSON` to an object member *before* its key is written**, so a member whose `toJSON` returns `undefined` is **omitted** per spec instead of being emitted as `"k":null`.

Both are the same root: getting `Call(toJSON, value, « key »)` and the "undefined member is omitted" rule right.

## What changed (perry-runtime `json/`)

- **`TO_JSON_KEY` thread-local** (`mod.rs`) — an owned Rust `String` (so it never roots a movable GC pointer) holding the key to hand `toJSON`. Reset to `""` at each top-level `JSON.stringify` entry; set before each child recursion by the object-property loop, the array-element loops, the shape-template fast path, and the replacer walk (`apply_to_json_keyed`, which already carried the key but discarded it). The three probes (`object_get_to_json` / `array_get_to_json` / `bigint_apply_to_json`) read it instead of allocating a hardcoded empty string.
- **`member_to_json`** (`stringify.rs`) — applies a heap-valued member's `toJSON` up front in the object walk, returning `Some(result)` **only** when a `toJSON` actually ran. The caller omits the member when the result is `undefined`/function/Symbol, else serializes the result with `SUPPRESS_NEXT_TO_JSON` armed (so it isn't re-probed). Returns `None` — "serialize normally" — for plain objects without a `toJSON` and for non-object/array values, so a plain data-object member keeps the #6009 fast path (no added probe) and the one-shot guard is never leaked into a sibling member.

## Verification

- **test262 `built-ins/JSON` slice** (`scripts/test262_subset.py --dir built-ins/JSON`), baseline vs. patched built the same way (`target/release`):
  - `value-tojson-arguments` : **fail → pass**
  - **zero regressions** (every other pass/fail unchanged; 120 → 121 pass)
- ~30 hand-written stringify cases (nested no-`toJSON` objects wrapping `toJSON` objects, `toJSON`→undefined omission with surrounding keys, replacer + `toJSON` keys, class instances, Date/Buffer/RegExp members, shape-template arrays) all match Node 26 byte-for-byte.
- `cargo fmt` clean on the changed files; `scripts/check_file_size.sh` passes (`stringify.rs` 1959 < 2000).

### Scope note

The `toJSON`-key threading also covers the compact **replacer** walk (via `apply_to_json_keyed`). The pretty-print serializer (`stringify_value_pretty`, used when a `space` argument is given) pre-builds its member list with comma placement keyed on that list's length, so applying the same "omit an `undefined`-`toJSON` member" rule there is a separate change; it keeps its prior (pre-existing) behavior in this PR. The target test and every case in the `built-ins/JSON` slice use the compact form, so this is a follow-up, not a regression.

Code-only per the issue: no version bump, no `CHANGELOG`/`CLAUDE.md` edits.

Refs #5909.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JSON serialization so `toJSON` callbacks receive the correct property name or array index.
  * Improved serialization of nested objects, arrays, BigInts, and replacer callbacks.
  * Ensured nested `JSON.stringify` calls use the correct root key and do not inherit stale key values.
  * Corrected handling of values omitted when `toJSON` returns `undefined`, functions, or Symbols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->