### PR TITLE
fix(transform): run comma-operator side effects before a nested yield suspends (#6678)

### DIFF
--- a/crates/perry-transform/src/generator/hoist_yields.rs
+++ b/crates/perry-transform/src/generator/hoist_yields.rs
@@ -167,6 +167,15 @@ fn hoist_yields_in_expr_full(expr: &mut Expr, next_id: &mut LocalId, hoisted: &m
         lift_logical_with_yield_rhs(expr, next_id, hoisted);
         return;
     }
+    // A sequence (comma) `(e0, e1, …, en)` with a yield in any operand must be
+    // linearized into ordered statements: operands to the LEFT of a yield run
+    // BEFORE it suspends, not after it resumes. The generic child-walk would
+    // hoist only the yield sub-expression, stranding earlier operands behind it
+    // in the now-yield-free comma (#6678).
+    if matches!(expr, Expr::Sequence(_)) && expr_contains_yield(expr) {
+        lift_sequence_with_yield(expr, next_id, hoisted);
+        return;
+    }
 
     // Recurse into children first so inner yields are hoisted before the outer
     // expression's own yield (innermost-first, left-to-right).
@@ -214,6 +223,13 @@ fn hoist_yields_avoiding_top_level(
     }
     if matches!(expr, Expr::Logical { .. }) && logical_rhs_contains_yield(expr) {
         lift_logical_with_yield_rhs(expr, next_id, hoisted);
+        return;
+    }
+    // A statement-positioned comma `push(x), yield …` (esbuild's lowered async
+    // bodies) must run its left operands BEFORE the yield suspends. Lift it
+    // the same way as the conditional/logical forms (#6678).
+    if matches!(expr, Expr::Sequence(_)) && expr_contains_yield(expr) {
+        lift_sequence_with_yield(expr, next_id, hoisted);
         return;
     }
     // Outer is not a yield: children may hold yields, which are nested — fully
@@ -376,5 +392,117 @@ fn lift_logical_with_yield_rhs(expr: &mut Expr, next_id: &mut LocalId, hoisted: 
             then_branch,
             else_branch: None,
         });
+    }
+}
+
+/// Replace a sequence (comma) expression `(e0, e1, …, en)` that contains a yield
+/// with `LocalGet(__yseq_N)` and emit, before the containing statement, each
+/// operand in source order so side effects to the LEFT of a yield run BEFORE the
+/// yield suspends — not after it resumes. The final operand carries the
+/// sequence's value into the temp.
+///
+/// Without this, the generic child-walk hoists only the yield sub-expression
+/// into a preceding `let __ygen = yield …;`, leaving the earlier operands behind
+/// in the now-yield-free comma. They then execute on RESUME (in the next state)
+/// instead of before the suspend — the esbuild `__async` lowering emits
+/// `push(x), yield …` bodies exactly, so the pre-yield side effect ran a
+/// microtask late (or was dropped entirely when the generator was `.next()`-ed
+/// only once). See #6678.
+///
+/// Each operand is emitted as its own statement and re-run through
+/// `hoist_yields_in_stmts`, so a yield in any operand lands in a position the
+/// linearizer already splits (`yield E;` / `let x = yield E;`).
+fn lift_sequence_with_yield(expr: &mut Expr, next_id: &mut LocalId, hoisted: &mut Vec<Stmt>) {
+    let temp_id = alloc_local(next_id);
+    let owned = std::mem::replace(expr, Expr::LocalGet(temp_id));
+    if let Expr::Sequence(mut items) = owned {
+        // The last operand is the sequence's value; everything before it runs
+        // only for its side effects.
+        let Some(last) = items.pop() else {
+            // Degenerate empty sequence — a comma always has ≥2 operands in
+            // source, but guard rather than allocate a dangling temp read.
+            *expr = Expr::Undefined;
+            return;
+        };
+        let mut stmts: Vec<Stmt> = Vec::with_capacity(items.len() + 1);
+        for item in items {
+            stmts.push(Stmt::Expr(item));
+        }
+        stmts.push(Stmt::Let {
+            id: temp_id,
+            name: format!("__yseq_{}", temp_id),
+            ty: Type::Any,
+            mutable: false,
+            init: Some(last),
+        });
+        // Split each operand's own yields (and the value operand's) into the
+        // suspend/resume states the linearizer understands.
+        hoist_yields_in_stmts(&mut stmts, next_id);
+        hoisted.extend(stmts);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn is_yield(e: &Expr) -> bool {
+        matches!(e, Expr::Yield { .. })
+    }
+
+    /// #6678: `sideEffect, yield x` at statement position must run `sideEffect`
+    /// BEFORE the yield suspends. The old generic child-walk hoisted only the
+    /// yield into a preceding `let __ygen = yield …;` and left the side effect
+    /// stranded in the now-yield-free comma, so it executed on RESUME. The lift
+    /// must decompose the comma into ordered statements: the pre-yield operand
+    /// precedes the hoisted yield-let, and no `Sequence` is left carrying a
+    /// `Yield`.
+    #[test]
+    fn comma_before_yield_runs_left_operand_first() {
+        let side_effect = Expr::LocalSet(5, Box::new(Expr::Integer(1)));
+        let yld = Expr::Yield {
+            value: Some(Box::new(Expr::Null)),
+            delegate: false,
+        };
+        let mut stmts = vec![Stmt::Expr(Expr::Sequence(vec![side_effect, yld]))];
+        let mut next_id: LocalId = 100;
+        hoist_yields_in_stmts(&mut stmts, &mut next_id);
+
+        let side_idx = stmts
+            .iter()
+            .position(|s| matches!(s, Stmt::Expr(Expr::LocalSet(5, _))))
+            .expect("pre-yield side effect kept as its own statement");
+        let yield_let_idx = stmts
+            .iter()
+            .position(|s| matches!(s, Stmt::Let { init: Some(e), .. } if is_yield(e)))
+            .expect("yield hoisted into a `let __yseq = yield …`");
+        assert!(
+            side_idx < yield_let_idx,
+            "side effect must run before the yield suspends: {stmts:?}"
+        );
+
+        // The bug signature: an operand stranded behind a yield inside a comma.
+        for s in &stmts {
+            if let Stmt::Expr(Expr::Sequence(items)) = s {
+                assert!(
+                    !items.iter().any(is_yield),
+                    "sequence still carries a yield: {items:?}"
+                );
+            }
+        }
+    }
+
+    /// A comma with no yield is left intact — the lift must not fire spuriously.
+    #[test]
+    fn comma_without_yield_is_untouched() {
+        let seq = Expr::Sequence(vec![Expr::Integer(1), Expr::Integer(2), Expr::Integer(3)]);
+        let mut stmts = vec![Stmt::Expr(seq)];
+        let mut next_id: LocalId = 100;
+        hoist_yields_in_stmts(&mut stmts, &mut next_id);
+        assert_eq!(stmts.len(), 1, "no-yield comma should not be decomposed");
+        assert!(
+            matches!(&stmts[0], Stmt::Expr(Expr::Sequence(items)) if items.len() == 3),
+            "sequence should be preserved verbatim: {stmts:?}"
+        );
     }
 }

--- a/crates/perry-transform/src/generator/hoist_yields.rs
+++ b/crates/perry-transform/src/generator/hoist_yields.rs
@@ -415,31 +415,36 @@ fn lift_logical_with_yield_rhs(expr: &mut Expr, next_id: &mut LocalId, hoisted: 
 fn lift_sequence_with_yield(expr: &mut Expr, next_id: &mut LocalId, hoisted: &mut Vec<Stmt>) {
     let temp_id = alloc_local(next_id);
     let owned = std::mem::replace(expr, Expr::LocalGet(temp_id));
-    if let Expr::Sequence(mut items) = owned {
-        // The last operand is the sequence's value; everything before it runs
-        // only for its side effects.
-        let Some(last) = items.pop() else {
-            // Degenerate empty sequence — a comma always has ≥2 operands in
-            // source, but guard rather than allocate a dangling temp read.
-            *expr = Expr::Undefined;
-            return;
-        };
-        let mut stmts: Vec<Stmt> = Vec::with_capacity(items.len() + 1);
-        for item in items {
-            stmts.push(Stmt::Expr(item));
-        }
-        stmts.push(Stmt::Let {
-            id: temp_id,
-            name: format!("__yseq_{}", temp_id),
-            ty: Type::Any,
-            mutable: false,
-            init: Some(last),
-        });
-        // Split each operand's own yields (and the value operand's) into the
-        // suspend/resume states the linearizer understands.
-        hoist_yields_in_stmts(&mut stmts, next_id);
-        hoisted.extend(stmts);
+    // Both callers gate on `matches!(expr, Expr::Sequence(_))`; asserting it here
+    // panics loudly if that invariant ever drifts rather than silently leaving
+    // the dangling `LocalGet(temp_id)` placeholder in the AST.
+    let Expr::Sequence(mut items) = owned else {
+        unreachable!("lift_sequence_with_yield called on a non-Sequence expr");
+    };
+
+    // The last operand is the sequence's value; everything before it runs only
+    // for its side effects.
+    let Some(last) = items.pop() else {
+        // Degenerate empty sequence — a comma always has ≥2 operands in source,
+        // but guard rather than allocate a dangling temp read.
+        *expr = Expr::Undefined;
+        return;
+    };
+    let mut stmts: Vec<Stmt> = Vec::with_capacity(items.len() + 1);
+    for item in items {
+        stmts.push(Stmt::Expr(item));
     }
+    stmts.push(Stmt::Let {
+        id: temp_id,
+        name: format!("__yseq_{}", temp_id),
+        ty: Type::Any,
+        mutable: false,
+        init: Some(last),
+    });
+    // Split each operand's own yields (and the value operand's) into the
+    // suspend/resume states the linearizer understands.
+    hoist_yields_in_stmts(&mut stmts, next_id);
+    hoisted.extend(stmts);
 }
 
 #[cfg(test)]

--- a/test-files/test_gap_6678_comma_yield_order.ts
+++ b/test-files/test_gap_6678_comma_yield_order.ts
@@ -1,0 +1,69 @@
+// Test: #6678 — a `yield` (or lowered `await`) nested inside a sequence/comma
+// expression must run the operands to its LEFT *before* the suspend, not after
+// the resume. esbuild's `--target=es2015` async lowering emits bodies shaped
+// `push(x), yield …`; perry's generator yield-hoister pulled only the `yield`
+// out into a preceding `let __ygen = yield …;` and stranded `push(x)` behind it
+// in the now-yield-free comma, so the side effect ran on RESUME (one microtask
+// late) — or was dropped entirely when the generator was `.next()`-ed only once.
+// Validated byte-for-byte against `node --experimental-strip-types`.
+
+const log: string[] = [];
+
+// --- root cause: `sideEffect, yield null` — side effect runs before suspend ---
+function* g1(): any {
+  log.push("A"), yield null;
+  log.push("B");
+}
+const it1: any = g1();
+it1.next();
+console.log("after next#1:", JSON.stringify(log)); // ["A"]
+it1.next();
+console.log("after next#2:", JSON.stringify(log)); // ["A","B"]
+
+// --- single .next() must NOT drop the pre-yield side effect ---
+const dropped: string[] = [];
+function* g2(): any {
+  dropped.push("ran"), yield null;
+}
+g2().next();
+console.log("single-next side effect:", JSON.stringify(dropped)); // ["ran"]
+
+// --- value-position: `let x = (a, yield b, c)` -> x === c, a's side effect first ---
+const seqLog: string[] = [];
+function* g3(): any {
+  const x = ((seqLog.push("lhs"), 0), yield "Y", "VAL");
+  seqLog.push("x=" + x);
+}
+const it3: any = g3();
+const r3 = it3.next();
+console.log("value-seq yielded:", r3.value, "log:", JSON.stringify(seqLog)); // Y ["lhs"]
+it3.next(99);
+console.log("value-seq final:", JSON.stringify(seqLog)); // ["lhs","x=VAL"]
+
+// --- multiple pre-yield operands, all before the suspend, in order ---
+const multi: string[] = [];
+function* g4(): any {
+  multi.push("1"), multi.push("2"), yield 0;
+  multi.push("3");
+}
+const it4: any = g4();
+it4.next();
+console.log("multi mid:", JSON.stringify(multi)); // ["1","2"]
+it4.next();
+console.log("multi end:", JSON.stringify(multi)); // ["1","2","3"]
+
+// --- observable microtask order: an async IIFE body `push, await` (which
+//     lowers through the same yield-hoist path) must run its synchronous prefix
+//     before already-queued microtasks ---
+const order: string[] = [];
+order.push("sync-start");
+Promise.resolve().then(() => order.push("micro"));
+(async () => {
+  order.push("iife-body"), await null;
+})();
+order.push("sync-end");
+setTimeout(() => {
+  // iife-body runs synchronously before the queued "micro"
+  console.log("microtask order:", JSON.stringify(order));
+  console.log("ALL COMMA-YIELD-ORDER TESTS PASSED");
+}, 0);


### PR DESCRIPTION
## Summary

Fixes #6678 — under `esbuild --target=es2015 --minify`, an async IIFE's body was deferred past already-queued microtasks, reordering observable side effects:

```
node : ["async-body","sync-end","micro"]
perry: ["sync-end","micro","async-body"]   <-- BUG
```

## Root cause

The bug is **not** in the `__async`/`__commonJS` composition — it reduces to a single construct: a **`yield` (or lowered `await`) nested inside a sequence/comma expression**. esbuild's es2015 async lowering emits generator bodies shaped `push(x), yield …`.

perry's generator yield-hoister (`hoist_yields.rs`) special-cases a `yield` at every compound position *except* a comma. `Expr::Sequence` fell into the generic child-walk, which hoisted **only** the `yield` sub-expression into a preceding `let __ygen = yield …;` and left the earlier operands stranded in the now-yield-free comma. Those operands then executed on **resume** (the next state-machine state) instead of **before the suspend**.

Reduced repro (no bundler needed):

```ts
function* g(){ log.push("A"), yield null; log.push("B"); }
const it = g();
it.next();  // node: log === ["A"]   perry(before): log === []   ← A ran on resume
it.next();  // both: ["A","B"]
```

When the generator is `.next()`-ed only once, the pre-yield side effect was **dropped entirely**.

## Fix

Give `Expr::Sequence` the same yield-lift the conditional/logical forms already have. When a comma contains a yield, decompose it into ordered statements — each operand as its own statement, the final operand carrying the value into a temp — and re-run the statement hoister. Left operands land before the suspend; a yield in any operand ends up in a position the linearizer already splits (`yield E;` / `let x = yield E;`). Yield-free commas are untouched.

## Validation

- The issue's exact `esbuild --bundle --format=esm --target=es2015 --minify` bundle now matches Node: `["async-body","sync-end","micro"]`.
- New unit tests in `hoist_yields.rs` (run per-PR via `cargo test --lib`): ordering + no-op on yield-free commas.
- New gap test `test_gap_6678_comma_yield_order.ts` — byte-identical to `node --experimental-strip-types` (root-cause stepping, single-`.next()` no-drop, value-position `(a, yield b, c)`, multi-operand order, and the async-IIFE microtask ordering).
- All 53 `perry-transform` lib tests pass; a focused sweep of generator/async gap tests (generators, `yield*`, multi-yield-expr, return/throw/finally, async-advanced, per-iteration bindings, cross-await bindings) shows no regressions.

Per maintainer instruction, this PR intentionally omits the version bump and CHANGELOG entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed execution order for sequence/comma expressions containing `yield` (or lowered `await`), ensuring left-hand operands run before suspension.
  * Ensured observable timing is correct (including single-step `.next()` behavior) and that multiple preceding expressions execute in order.
  * Preserved the original value of comma/sequence expressions across suspension points.

* **Tests**
  * Added a new test suite for issue `#6678` to validate side effects ordering, value preservation, repeated operands, and microtask timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->