### PR TITLE
fix(symbol): ToString-coerce non-string Symbol.for keys (#6681)

### DIFF
--- a/crates/perry-runtime/src/symbol/constructors.rs
+++ b/crates/perry-runtime/src/symbol/constructors.rs
@@ -54,7 +54,11 @@ pub unsafe extern "C" fn js_symbol_for(key_f64: f64) -> f64 {
     // TypeError, matching `ToString(symbol)` (and `Symbol()`'s coercion).
     let key_ptr = if tag == STRING_TAG {
         (bits & POINTER_MASK) as *const StringHeader
-    } else if (0x1000..0x0000_FFFF_FFFF_FFFF).contains(&bits) {
+    } else if crate::value::addr_class::is_plausible_heap_addr(bits as usize) {
+        // Raw StringHeader pointer from a legacy callsite. Use the canonical
+        // heap-address predicate rather than a duplicated literal range so a
+        // small-magnitude (e.g. denormal) double key isn't misclassified as a
+        // pointer — it falls through to ToString below and coerces correctly.
         bits as *const StringHeader
     } else {
         if js_is_symbol(key_f64) != 0 {

--- a/crates/perry-runtime/src/symbol/constructors.rs
+++ b/crates/perry-runtime/src/symbol/constructors.rs
@@ -45,12 +45,25 @@ pub unsafe extern "C" fn js_symbol_new(description_f64: f64) -> f64 {
 pub unsafe extern "C" fn js_symbol_for(key_f64: f64) -> f64 {
     let bits = key_f64.to_bits();
     let tag = bits & 0xFFFF_0000_0000_0000;
+    // Resolve the registry key string. Spec step 1 (sec-symbol.for):
+    // `key = ToString(key)`. A NaN-boxed heap string is used directly, as is a
+    // raw StringHeader pointer from legacy callsites; every other value is
+    // ToString-coerced so `Symbol.for(undefined)` registers under "undefined",
+    // `Symbol.for(42)` under "42", `Symbol.for(null)`/`true` likewise — and
+    // `Symbol.for(x) === Symbol.for(String(x))`. A Symbol key throws a
+    // TypeError, matching `ToString(symbol)` (and `Symbol()`'s coercion).
     let key_ptr = if tag == STRING_TAG {
         (bits & POINTER_MASK) as *const StringHeader
     } else if (0x1000..0x0000_FFFF_FFFF_FFFF).contains(&bits) {
         bits as *const StringHeader
     } else {
-        return f64::from_bits(TAG_UNDEFINED);
+        if js_is_symbol(key_f64) != 0 {
+            crate::collection_iter::throw_type_error("Cannot convert a Symbol value to a string");
+        }
+        // `js_string_coerce` is the full ToString: undefined→"undefined",
+        // null→"null", numbers/bools/objects coerce, and short (SSO) strings
+        // materialize onto the heap so `str_from_header` can read them.
+        crate::builtins::js_string_coerce(key_f64) as *const StringHeader
     };
     let key = match str_from_header(key_ptr) {
         Some(s) => s,

--- a/test-files/test_gap_symbol_for_coercion.ts
+++ b/test-files/test_gap_symbol_for_coercion.ts
@@ -1,0 +1,44 @@
+// Test: Symbol.for(key) ToString-coerces a non-string key (Perry gap #6681)
+// Per sec-symbol.for step 1, `key = ToString(key)`, so Symbol.for(undefined)
+// is Symbol.for("undefined"), Symbol.for(42) is Symbol.for("42"), etc.
+// Run: node --experimental-strip-types test-files/test_gap_symbol_for_coercion.ts
+
+// --- undefined coerces to "undefined" ---
+const su = Symbol.for(undefined as any);
+console.log(su.toString());                                 // Symbol(undefined)
+console.log(String(su));                                    // Symbol(undefined)
+console.log(su === Symbol.for("undefined"));                // true
+console.log(Symbol.keyFor(su));                             // undefined  (the string key)
+
+// --- number coerces to its decimal string ---
+const s42 = Symbol.for(42 as any);
+console.log(s42.toString());                                // Symbol(42)
+console.log(s42 === Symbol.for("42"));                      // true
+console.log(Symbol.for(0 as any) === Symbol.for("0"));      // true
+
+// --- null coerces to "null" ---
+const sn = Symbol.for(null as any);
+console.log(sn.toString());                                 // Symbol(null)
+console.log(sn === Symbol.for("null"));                     // true
+
+// --- booleans coerce to "true"/"false" ---
+console.log(Symbol.for(true as any) === Symbol.for("true"));    // true
+console.log(Symbol.for(false as any) === Symbol.for("false"));  // true
+
+// --- object coerces via ToString ---
+console.log(Symbol.for({} as any) === Symbol.for("[object Object]")); // true
+console.log(Symbol.for([1, 2] as any) === Symbol.for("1,2"));         // true
+
+// --- distinct coerced keys stay distinct ---
+console.log(Symbol.for(1 as any) === Symbol.for(2 as any)); // false
+
+// --- Symbol key throws (ToString(symbol) is a TypeError) ---
+let threw = false;
+try {
+  Symbol.for(Symbol("x") as any);
+} catch (e) {
+  threw = e instanceof TypeError;
+}
+console.log(threw); // true
+
+console.log("ALL SYMBOL.FOR COERCION TESTS PASSED");


### PR DESCRIPTION
## Summary

Fixes #6681. `Symbol.for(key)` skipped spec step 1 (`key = ToString(key)`) for any `key` that was not already a heap string or a raw `StringHeader` pointer, and returned `undefined` for it. So `Symbol.for(undefined)`, `Symbol.for(42)`, `Symbol.for(null)`, `Symbol.for(true)`, and object keys all produced `undefined` instead of the registered symbol for the coerced key string — breaking the identity `Symbol.for(x) === Symbol.for(String(x))`.

```js
Symbol.for(undefined)                              // node: Symbol(undefined)   was perry: undefined
Symbol.for(undefined) === Symbol.for("undefined")  // node: true                was perry: false
```

## Fix

In `js_symbol_for` (`crates/perry-runtime/src/symbol/constructors.rs`), non-string keys now route through `js_string_coerce` — the same full ToString used by `Symbol()`'s description coercion — before the registry lookup, and a Symbol key throws a `TypeError` to match `ToString(symbol)`. The existing `STRING_TAG` heap-string and raw-`StringHeader`-pointer fast paths are unchanged, so well-known-symbol resolution (`Symbol.toPrimitive` etc., lowered to `SymbolFor(String("@@__perry_wk_…"))`) is untouched.

This also incidentally fixes short (SSO ≤5-byte) string keys, which the old `STRING_TAG` / raw-pointer checks did not match — `js_string_coerce` materializes them onto the heap.

## Test

Adds `test-files/test_gap_symbol_for_coercion.ts` covering `undefined` / number / `null` / boolean / object coercion, the `Symbol.for(x) === Symbol.for(String(x))` identities, distinct-key non-identity, and the Symbol-key `TypeError`.

Verified byte-identical to `node --experimental-strip-types` on macOS arm64. Confirmed no regression in the existing symbol gap tests (the plain-object `Symbol.toPrimitive` case in `test_gap_symbols.ts` still matches Node; its class-instance `Temperature` case is a separate, pre-existing prototype-method gap tracked under #5917/#2374, not affected by this change).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected `Symbol.for` to coerce non-string keys according to JavaScript rules.
  * `Symbol.for` now throws a `TypeError` when passed a symbol key.
  * Added support for keys such as `undefined`, numbers, booleans, `null`, and objects through string conversion.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->