### PR TITLE
fix(hir): read inherited Function.prototype props off the Function constructor (#5908)

### DIFF
--- a/crates/perry-hir/src/lower/expr_member/member_tail.rs
+++ b/crates/perry-hir/src/lower/expr_member/member_tail.rs
@@ -358,10 +358,28 @@ pub(crate) fn lower_member_tail(
                     // `Math.PI`, … depend on it — so lifting it for those needs a
                     // complete per-builtin intrinsic-member table and is tracked
                     // separately.
+                    //
+                    // #5908: the `Function` constructor is the same safe case as
+                    // `RegExp`. It has no intrinsic static-member fast path keyed
+                    // on the collapsed shape (`Function.length` folds off either
+                    // the bare `GlobalGet(0)` or the `PropertyGet { GlobalGet(0),
+                    // "Function" }` value-form in the `.length` arm below, and
+                    // `Function.name` / `Function.prototype` / `Function.{call,
+                    // apply,bind}` are handled by their own dedicated arms), so
+                    // collapsing only LOSES the receiver — after
+                    // `Function.prototype.indicator = 1`, reading `Function.indicator`
+                    // (inherited via the ctor's [[Prototype]] = `%Function.prototype%`)
+                    // came back `undefined` instead of `1` (test262
+                    // built-ins/Function/S15.3.3_A2_T2). Keeping the receiver lets the
+                    // runtime walk the prototype chain, which already resolves the
+                    // inherited property (`closure_get_dynamic_prop`'s
+                    // `function_prototype_fallback_target`).
                     let receiver_is_regexp_ctor = property == "RegExp";
+                    let receiver_is_function_ctor = property == "Function";
                     if !outer_is_prototype_or_proto
                         && !receiver_is_namespace_value
                         && !receiver_is_regexp_ctor
+                        && !receiver_is_function_ctor
                         && !outer_is_websocket_static
                         && !outer_is_reified_object_static_value
                         && !outer_is_reified_builtin_static_value

--- a/test-files/test_issue_5908_function_ctor_inherits_proto.ts
+++ b/test-files/test_issue_5908_function_ctor_inherits_proto.ts
@@ -1,0 +1,38 @@
+// #5908 (test262 built-ins/Function worklist): the `Function` constructor's
+// [[Prototype]] is `%Function.prototype%`, so a property installed on
+// `Function.prototype` is readable off the constructor object itself
+// (`Function.prototype.indicator = 1` ⇒ `Function.indicator === 1`, test262
+// S15.3.3_A2_T2).
+//
+// The HIR member-lowering was collapsing `Function.<unknown>` to
+// `globalThis.<unknown>`, dropping the constructor receiver, so the inherited
+// read resolved against `globalThis` and came back `undefined`. This is the
+// same receiver-drop already fixed for `RegExp` (#5897, S15.10.5_A2_T2);
+// `Function` is the same safe case — nothing downstream keys on the collapsed
+// `GlobalGet(0).<prop>` shape for it, and its `.name` / `.length` /
+// `.prototype` reads are handled by dedicated arms. Keeping the receiver lets
+// the runtime walk the prototype chain
+// (`closure_get_dynamic_prop`'s `function_prototype_fallback_target`), which
+// already resolves the inherited property.
+//
+// Validated byte-for-byte against `node --experimental-strip-types`.
+
+// --- the fix: inherited read off the Function constructor -----------------
+(Function.prototype as any).indicator = 1;
+console.log("Function.indicator :", (Function as any).indicator); // 1
+
+// --- inherited read off ordinary function instances (already worked;
+//     guards that keeping the receiver didn't disturb the closure path) ----
+function userFn() {}
+const arrow = () => {};
+console.log("userFn.indicator   :", (userFn as any).indicator);            // 1
+console.log("arrow.indicator    :", (arrow as any).indicator);             // 1
+console.log("bound.indicator    :", (userFn.bind(null) as any).indicator); // 1
+
+// --- regression guards: dedicated static-member arms still resolve --------
+console.log("Function.name      :", Function.name);   // "Function"
+console.log("Function.length    :", Function.length); // 1
+
+// --- reassignment on the shared prototype is observed through the ctor ----
+(Function.prototype as any).indicator = 42;
+console.log("after reassign     :", (Function as any).indicator); // 42


### PR DESCRIPTION
## Summary

Fixes one case from the test262 `built-ins/Function` worklist (#5908): **`built-ins/Function/S15.3.3_A2_T2.js`**.

`Function`'s `[[Prototype]]` is `%Function.prototype%`, so a property installed on `Function.prototype` must be readable off the constructor object itself:

```js
Function.prototype.indicator = 1;
assert.sameValue(Function.indicator, 1); // was: undefined
```

HIR member-lowering was collapsing `Function.<unknown>` to `globalThis.<unknown>`, dropping the constructor receiver, so the inherited read resolved against `globalThis` and returned `undefined`.

## Fix

This is the exact same receiver-drop already fixed for `RegExp` (#5897, `S15.10.5_A2_T2`), and `Function` is the same safe case:

- nothing downstream keys on the collapsed `GlobalGet(0).<prop>` shape for `Function`;
- `.name` / `.length` / `.prototype` / `.{call,apply,bind}` are each handled by their own dedicated lowering arms;

so collapsing can only *lose* the receiver. Keeping it lets the runtime walk the prototype chain (`closure_get_dynamic_prop`'s `function_prototype_fallback_target`), which already resolves the inherited property. The change is a two-line guard mirroring `receiver_is_regexp_ctor`.

## Verification

Measured with `scripts/test262_subset.py` against the pinned test262 checkout, Node v26.3.0.

- **`built-ins/Function` slice: 443 → 444 pass, zero regressions** — `S15.3.3_A2_T2` is the only case that moved (`diff` of the `.failures.txt` before/after).
- Broad regression sweep across `language/function-code`, `built-ins/RegExp`, `built-ins/Object/getPrototypeOf`, `built-ins/Object/getOwnPropertyDescriptor`, `language/expressions/instanceof` (1776 cases): 99.2% parity, and all 14 residual failures are pre-existing (11 read no `Function.<prop>` at all; 3 read only `Function.prototype`, which is exempt from the collapse both before and after this change).
- `Function.name === "Function"`, `Function.length === 1`, `Function.prototype`, and the `RegExp` path are all unaffected (verified byte-for-byte against Node).
- All 247 `perry-hir` unit tests pass; `cargo fmt` clean on the changed file; `scripts/check_file_size.sh` passes.

Adds a behavioral parity test-file (`test-files/test_issue_5908_function_ctor_inherits_proto.ts`) mirroring the `#5897` precedent.

Code-only PR — no version bump, no `CHANGELOG.md`, no `CLAUDE.md` edit (maintainer folds metadata at merge).

Refs #5908.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inherited properties on the `Function` constructor so they now resolve consistently with other function objects.
  * Preserved correct access to static properties such as `Function.name` and `Function.length`.

* **Tests**
  * Added regression coverage for inherited properties on regular, arrow, bound, and constructor functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->