### PR TITLE
fix(runtime): honor promisify.custom on stream.pipeline/finished (#6692)

### DIFF
--- a/crates/perry-runtime/src/node_submodules/mod.rs
+++ b/crates/perry-runtime/src/node_submodules/mod.rs
@@ -1564,6 +1564,25 @@ pub unsafe extern "C" fn js_node_submodule_export_as_function(
     f64::from_bits(JSValue::pointer(closure_ptr as *const u8).bits())
 }
 
+/// #6692: the `node:stream/promises` `pipeline` / `finished` callable — the
+/// promise-based implementations Node exposes via
+/// `stream.pipeline[util.promisify.custom]`. Installs the submodule registry
+/// entry first so the lookup succeeds even when the program never imported
+/// `node:stream/promises` itself. Returns NaN-boxed `TAG_TRUE` (the historical
+/// unlisted-export sentinel) if `name` is unknown — callers should verify the
+/// result is a callable closure before using it.
+pub(crate) fn stream_promises_export_callable(name: &str) -> f64 {
+    js_node_submod_install_stream_promises();
+    unsafe {
+        js_node_submodule_export_as_function(
+            b"stream_promises".as_ptr(),
+            "stream_promises".len() as u32,
+            name.as_ptr(),
+            name.len() as u32,
+        )
+    }
+}
+
 /// Returns a namespace-member value for a known Node submodule namespace import.
 ///
 /// This differs from `js_node_submodule_export_as_function`: direct named-import

--- a/crates/perry-runtime/src/object/native_module/callable_exports.rs
+++ b/crates/perry-runtime/src/object/native_module/callable_exports.rs
@@ -78,6 +78,14 @@ pub(crate) fn bound_native_callable_export_value(module_name: &str, property_nam
     {
         attach_stream_constructor_prototype(value, property_name);
     }
+    // #6692: Node defines `stream.pipeline[util.promisify.custom]` and
+    // `stream.finished[util.promisify.custom]` pointing at the promise-based
+    // `stream/promises` implementations, so `promisify(stream.pipeline)` returns
+    // that impl rather than the generic callback-appending wrapper. Wire the
+    // same hooks so `custom_promisified_value` (util_promisify.rs) honors them.
+    if export_module_name == "stream" && matches!(property_name, "pipeline" | "finished") {
+        attach_stream_promisify_custom(value, property_name);
+    }
     if export_module_name == "sqlite" && property_name == "DatabaseSync" {
         attach_sqlite_database_sync_prototype(value);
     }
@@ -215,6 +223,39 @@ pub(crate) fn bound_native_callable_export_value(module_name: &str, property_nam
         crate::gc::runtime_write_barrier_root_nanbox(value.to_bits());
     });
     value
+}
+
+/// #6692: install `stream.pipeline[util.promisify.custom]` (or `.finished`'s)
+/// pointing at the promise-based `stream/promises` export, matching Node. With
+/// the hook present, `promisify(stream.pipeline)` resolves through
+/// `custom_promisified_value` to the promise implementation instead of the
+/// generic wrapper (whose appended callback the `promisify.custom`-aware caller
+/// in `pi`'s bundled node-fetch never provides). `property_name` is `"pipeline"`
+/// or `"finished"` — the matching `stream/promises` export name.
+fn attach_stream_promisify_custom(pipeline_value: f64, property_name: &str) {
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let target = scope.root_nanbox_f64(pipeline_value);
+    let promise_impl = crate::node_submodules::stream_promises_export_callable(property_name);
+    // The submodule may be unavailable (returns the `TAG_TRUE` sentinel); only
+    // wire the hook when it resolved to a real callable closure, otherwise leave
+    // the generic promisify fallback in place.
+    let impl_bits = promise_impl.to_bits();
+    let impl_addr = (impl_bits & crate::value::POINTER_MASK) as usize;
+    if (impl_bits & crate::value::TAG_MASK) != crate::value::POINTER_TAG
+        || !crate::closure::is_closure_ptr(impl_addr)
+    {
+        return;
+    }
+    let impl_handle = scope.root_nanbox_f64(promise_impl);
+    let custom_symbol = crate::util_promisify::promisify_custom_symbol();
+    let symbol_handle = scope.root_nanbox_f64(custom_symbol);
+    unsafe {
+        crate::symbol::js_object_set_symbol_property(
+            target.get_nanbox_f64(),
+            symbol_handle.get_nanbox_f64(),
+            impl_handle.get_nanbox_f64(),
+        );
+    }
 }
 
 fn async_hooks_static_method_value(

--- a/crates/perry-runtime/src/object/native_module/callable_exports.rs
+++ b/crates/perry-runtime/src/object/native_module/callable_exports.rs
@@ -52,7 +52,7 @@ pub(crate) fn bound_native_callable_export_value(module_name: &str, property_nam
     if let Some(length) = native_callable_export_arity(export_module_name, property_name) {
         set_builtin_closure_length(closure as usize, length);
     }
-    let value = crate::value::js_nanbox_pointer(closure as i64);
+    let mut value = crate::value::js_nanbox_pointer(closure as i64);
     let closure_addr = closure as usize;
 
     if export_module_name == "module" && property_name == "Module" {
@@ -84,7 +84,9 @@ pub(crate) fn bound_native_callable_export_value(module_name: &str, property_nam
     // that impl rather than the generic callback-appending wrapper. Wire the
     // same hooks so `custom_promisified_value` (util_promisify.rs) honors them.
     if export_module_name == "stream" && matches!(property_name, "pipeline" | "finished") {
-        attach_stream_promisify_custom(value, property_name);
+        // Reassign: the attach helper roots `value` and allocates (which may
+        // evacuate the closure), so it returns the possibly-relocated pointer.
+        value = attach_stream_promisify_custom(value, property_name);
     }
     if export_module_name == "sqlite" && property_name == "DatabaseSync" {
         attach_sqlite_database_sync_prototype(value);
@@ -232,7 +234,11 @@ pub(crate) fn bound_native_callable_export_value(module_name: &str, property_nam
 /// generic wrapper (whose appended callback the `promisify.custom`-aware caller
 /// in `pi`'s bundled node-fetch never provides). `property_name` is `"pipeline"`
 /// or `"finished"` — the matching `stream/promises` export name.
-fn attach_stream_promisify_custom(pipeline_value: f64, property_name: &str) {
+///
+/// Returns the (possibly relocated) receiver value: the allocations below can
+/// trigger a GC that evacuates the closure, and only the `scope` handle tracks
+/// the move, so the caller must adopt the returned pointer.
+fn attach_stream_promisify_custom(pipeline_value: f64, property_name: &str) -> f64 {
     let scope = crate::gc::RuntimeHandleScope::new();
     let target = scope.root_nanbox_f64(pipeline_value);
     let promise_impl = crate::node_submodules::stream_promises_export_callable(property_name);
@@ -241,21 +247,21 @@ fn attach_stream_promisify_custom(pipeline_value: f64, property_name: &str) {
     // the generic promisify fallback in place.
     let impl_bits = promise_impl.to_bits();
     let impl_addr = (impl_bits & crate::value::POINTER_MASK) as usize;
-    if (impl_bits & crate::value::TAG_MASK) != crate::value::POINTER_TAG
-        || !crate::closure::is_closure_ptr(impl_addr)
+    if (impl_bits & crate::value::TAG_MASK) == crate::value::POINTER_TAG
+        && crate::closure::is_closure_ptr(impl_addr)
     {
-        return;
+        let impl_handle = scope.root_nanbox_f64(promise_impl);
+        let custom_symbol = crate::util_promisify::promisify_custom_symbol();
+        let symbol_handle = scope.root_nanbox_f64(custom_symbol);
+        unsafe {
+            crate::symbol::js_object_set_symbol_property(
+                target.get_nanbox_f64(),
+                symbol_handle.get_nanbox_f64(),
+                impl_handle.get_nanbox_f64(),
+            );
+        }
     }
-    let impl_handle = scope.root_nanbox_f64(promise_impl);
-    let custom_symbol = crate::util_promisify::promisify_custom_symbol();
-    let symbol_handle = scope.root_nanbox_f64(custom_symbol);
-    unsafe {
-        crate::symbol::js_object_set_symbol_property(
-            target.get_nanbox_f64(),
-            symbol_handle.get_nanbox_f64(),
-            impl_handle.get_nanbox_f64(),
-        );
-    }
+    target.get_nanbox_f64()
 }
 
 fn async_hooks_static_method_value(

--- a/test-files/test_gap_promisify_pipeline_custom_6692.ts
+++ b/test-files/test_gap_promisify_pipeline_custom_6692.ts
@@ -1,0 +1,59 @@
+// #6692: `promisify(stream.pipeline)` must honor Node's
+// `stream.pipeline[util.promisify.custom]` hook (the promise-based
+// `stream/promises` impl) instead of falling back to the generic
+// callback-appending wrapper. Same for `stream.finished`.
+import { promisify } from "util";
+import { pipeline, finished, Readable, Writable } from "stream";
+
+const CUSTOM = Symbol.for("nodejs.util.promisify.custom");
+console.log("pipeline custom:", typeof (pipeline as any)[CUSTOM]);
+console.log("finished custom:", typeof (finished as any)[CUSTOM]);
+
+const p = promisify(pipeline);
+const f = promisify(finished);
+
+async function main() {
+  // promisified pipeline forwards all stream args and resolves with undefined.
+  const chunks: string[] = [];
+  const result = await p(
+    Readable.from(["a", "b", "c"]),
+    new Writable({
+      write(c: any, _e: any, cb: any) {
+        chunks.push(c.toString());
+        cb();
+      },
+    }),
+  );
+  console.log("pipeline output:", chunks.join(""));
+  console.log("pipeline resolved:", String(result));
+
+  // promisified pipeline with a transform stage in the middle.
+  const { Transform } = await import("stream");
+  const upper: string[] = [];
+  await p(
+    Readable.from(["d", "e"]),
+    new Transform({
+      transform(c: any, _e: any, cb: any) {
+        cb(null, c.toString().toUpperCase());
+      },
+    }),
+    new Writable({
+      write(c: any, _e: any, cb: any) {
+        upper.push(c.toString());
+        cb();
+      },
+    }),
+  );
+  console.log("transform output:", upper.join(""));
+
+  // promisified finished resolves once the stream is fully consumed.
+  const r = Readable.from(["x"]);
+  r.resume();
+  await f(r);
+  console.log("finished resolved");
+}
+
+main().then(
+  () => console.log("done"),
+  (err) => console.log("error:", err && err.code, err && err.message),
+);


### PR DESCRIPTION
## Summary

Fixes #6692. Node defines `stream.pipeline[util.promisify.custom]` and `stream.finished[util.promisify.custom]`, pointing at the promise-based `node:stream/promises` implementations. So `promisify(stream.pipeline)` in Node returns a `(...streams) => Promise` with **no** trailing callback.

Perry never installed those hooks, so `promisify(stream.pipeline)` fell back to the generic callback-appending wrapper. The bundled node-fetch that pi uses to download `fd` does:

```js
const pipeline = promisify(Stream.pipeline);   // expects Node's promise impl
...
await pipeline(body, dest);
```

Routing that through the generic wrapper (instead of Node's dedicated promise-pipeline) is where the stream args got dropped under some dispatch paths, surfacing as `TypeError: The "streams" argument must be specified` (`ERR_MISSING_ARGS`).

## Fix

Install the `promisify.custom` symbol on the `stream.pipeline` / `stream.finished` bound-native exports, pointing at the corresponding `stream/promises` callables. The existing `custom_promisified_value` path in `util_promisify.rs` then honors them, so `promisify(stream.pipeline)` returns the dedicated, well-tested promise-pipeline (`thunk_streamP_pipeline`, registered rest `fixed_arity = 2`) instead of the generic wrapper — matching Node exactly and sidestepping the fragile forwarding path entirely.

- `object/native_module/callable_exports.rs`: wire the custom hook when minting the `pipeline` / `finished` exports (GC-rooted via a handle scope; no-ops if `stream/promises` is unavailable, leaving the generic fallback in place).
- `node_submodules/mod.rs`: `stream_promises_export_callable` helper that installs the submodule registry entry (so the lookup succeeds even when the program never imported `stream/promises`) and returns its export value.

## Behavior parity (Node 26.5.0)

| expression | before | after / Node |
|---|---|---|
| `typeof stream.pipeline[Symbol.for("nodejs.util.promisify.custom")]` | `undefined` | `function` |
| `typeof stream.finished[Symbol.for("nodejs.util.promisify.custom")]` | `undefined` | `function` |
| `promisify(pipeline)(src, dst)` | generic wrapper | promise-pipeline; resolves `undefined` |

## Testing

- New `test-files/test_gap_promisify_pipeline_custom_6692.ts` — byte-matches Node 26.5.0 (custom-symbol presence, promisified pipeline with a transform stage, promisified `finished`). Verified under both the fast dev build and the full auto-optimize / LTO (release) path.
- Existing `test_parity_stream_promises`, `test_issue_3070_stream_promises_input_validation`, `test_issue_1856_1857_exports_promisify` still byte-match Node.
- `cargo test -p perry-runtime --lib` stream_promises / native_module_stream suites pass.

## Notes

- Per maintainer instruction this PR carries **no version bump / changelog** entry.
- Separate pre-existing gap (not addressed here): a **web** `ReadableStream` passed as a pipeline *body* isn't recognized by the `stream/promises` body validator — after this change it rejects with `ERR_INVALID_ARG_TYPE` (previously the generic path silently hung). Both diverge from Node, which accepts web streams; that's a distinct web-stream-support gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added promise-based custom behavior for `util.promisify` when promisifying `stream.pipeline` and `stream.finished`.

* **Bug Fixes**
  * Ensures promisified `pipeline`/`finished` properly hook into the corresponding `stream/promises` implementations, with correct handling for unknown exports.

* **Tests**
  * Added a test validating `util.promisify.custom` for `stream.pipeline` (including transform stages) and `stream.finished` promise resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->