### PR TITLE
fix(regex): RegExp.prototype.compile error semantics (Annex B) — #5910

### DIFF
--- a/crates/perry-runtime/src/object/global_this/proto_methods.rs
+++ b/crates/perry-runtime/src/object/global_this/proto_methods.rs
@@ -574,9 +574,12 @@ pub(crate) fn populate_builtin_prototype_methods(builtin_name: &str, proto_obj: 
             // (`getOwnPropertyDescriptor(RegExp.prototype, "source").get`) and
             // brand-checked `.call(this)` work, and instances inherit them.
             super::super::regex_proto_thunks::install_regex_proto_accessors(proto_obj);
-            // Real brand-checking `exec`/`test`/`toString`; `compile` stays a
-            // no-op (Annex B).
+            // Real brand-checking `exec`/`test`/`toString`/`compile` (Annex B).
             super::super::regex_proto_thunks::install_regex_proto_methods(proto_obj);
+            // `compile` is installed as a real brand-checking thunk by
+            // `install_regex_proto_methods` when `regex-engine` is on; without an
+            // engine it falls back to the Annex-B no-op here.
+            #[cfg(not(feature = "regex-engine"))]
             install_noop_proto_methods(proto_obj, &[("compile", 2)]);
             install_noop_proto_methods(proto_obj, OBJECT_PROTO_METHODS);
         }

--- a/crates/perry-runtime/src/object/regex_proto_thunks.rs
+++ b/crates/perry-runtime/src/object/regex_proto_thunks.rs
@@ -258,6 +258,23 @@ pub(super) extern "C" fn regex_proto_test_thunk(
     f64::from_bits(crate::value::JSValue::bool(matched).bits())
 }
 
+/// `RegExp.prototype.compile(pattern, flags)` (Annex B §B.2.5.1) — brand-checks
+/// `this` has a `[[RegExpMatcher]]` internal slot (a registered RegExp; a
+/// non-Object or non-RegExp receiver throws `TypeError`), then re-initializes
+/// the receiver in place. Reflective: `RegExp.prototype.compile.call(re, p, f)`
+/// and the extracted-then-called form both route here; a direct `re.compile(p,
+/// f)` is fast-pathed in `native_call_method` but ends in the same
+/// `js_regexp_compile_value`.
+#[cfg(feature = "regex-engine")]
+pub(super) extern "C" fn regex_proto_compile_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    pattern: f64,
+    flags: f64,
+) -> f64 {
+    let re = regex_instance_or_throw("compile");
+    crate::regex::js_regexp_compile_value(re as *mut crate::regex::RegExpHeader, pattern, flags)
+}
+
 /// `RegExp.prototype.toString()` — per spec reads `source`/`flags` off the
 /// (generic) receiver via `Get` and returns `/source/flags`. Throws `TypeError`
 /// only when `this` is not an Object, so
@@ -312,14 +329,26 @@ fn regex_instance_or_throw(method: &str) -> *const crate::regex::RegExpHeader {
     ))
 }
 
-/// Install the real (brand-checking) `exec`/`test`/`toString` prototype methods.
-/// `compile` stays a no-op (Annex B, rarely exercised).
+/// Install the real (brand-checking) `exec`/`test`/`toString`/`compile`
+/// prototype methods. `compile` is only installed here when the `regex-engine`
+/// feature is on; the fallback no-op (for builds without an engine) is installed
+/// by the caller.
 pub(super) fn install_regex_proto_methods(proto_obj: *mut ObjectHeader) {
     use super::global_this::install_proto_method as ipm;
     #[cfg(feature = "regex-engine")]
     ipm(proto_obj, "exec", regex_proto_exec_thunk as *const u8, 1);
     #[cfg(feature = "regex-engine")]
     ipm(proto_obj, "test", regex_proto_test_thunk as *const u8, 1);
+    // Annex B `compile` re-initializes the receiver in place. It needs a real
+    // brand check so `RegExp.prototype.compile.call(non-regexp)` throws a
+    // `TypeError` (test262 annexB `.../compile/this-{not-object,obj-not-regexp}`).
+    #[cfg(feature = "regex-engine")]
+    ipm(
+        proto_obj,
+        "compile",
+        regex_proto_compile_thunk as *const u8,
+        2,
+    );
     ipm(
         proto_obj,
         "toString",

--- a/crates/perry-runtime/src/regex/compile.rs
+++ b/crates/perry-runtime/src/regex/compile.rs
@@ -58,9 +58,13 @@ pub extern "C" fn js_regexp_compile_value(
         (src_s, flg_s)
     } else {
         // ToString(pattern), with `undefined` -> "" (spec); same for flags.
+        // Abstract ToString (§7.1.17) rejects a Symbol with a `TypeError` — the
+        // lenient `js_string_coerce` would otherwise stringify it to
+        // "Symbol(desc)" (annexB `.../compile/{pattern,flags}-to-string-err`).
         let pat = if pj.is_undefined() {
             String::new()
         } else {
+            crate::builtins::reject_symbol_to_string(pattern_val);
             let p = crate::builtins::js_string_coerce(pattern_val);
             if is_valid_ptr(p) {
                 string_as_str(p).to_string()
@@ -71,6 +75,7 @@ pub extern "C" fn js_regexp_compile_value(
         let flg = if fj.is_undefined() {
             String::new()
         } else {
+            crate::builtins::reject_symbol_to_string(flags_val);
             let f = crate::builtins::js_string_coerce(flags_val);
             if is_valid_ptr(f) {
                 string_as_str(f).to_string()
@@ -166,7 +171,6 @@ pub extern "C" fn js_regexp_compile_value(
         (*re).dot_all = flags_str.contains('s');
         (*re).unicode = flags_str.contains('u') || flags_str.contains('v');
         (*re).has_indices = flags_str.contains('d');
-        (*re).last_index = 0;
         super::REGEX_SOURCE_TABLE.with(|t| {
             t.borrow_mut().insert(
                 re as usize,
@@ -174,5 +178,11 @@ pub extern "C" fn js_regexp_compile_value(
             );
         });
     }
+    // Spec RegExpInitialize step 12: `Set(obj, "lastIndex", 0, true)` runs LAST,
+    // with the *Throw* flag. A user-frozen `lastIndex`
+    // (`Object.defineProperty(re, "lastIndex", { writable: false })`) makes this
+    // a `TypeError` — but only *after* `.source`/`.flags` have already been
+    // updated above (annexB `.../compile/pattern-regexp-immutable-lastindex`).
+    super::set_last_index_throwing(re, 0);
     f64::from_bits(crate::value::JSValue::pointer(re as *const u8).bits())
 }


### PR DESCRIPTION
## Summary

Fixes a coherent single-root subcluster of the #5910 annexB worklist: the
`RegExp.prototype.compile` (Annex B §B.2.5.1) error-handling cases. `compile`
was installed as a **no-op** prototype thunk and its coercion path was lenient,
so several required error behaviours were missed.

Fixes these 5 `annexB/built-ins/RegExp/prototype/compile/*` cases (all listed in #5910):

| case | before | after |
|------|--------|-------|
| `this-not-object.js` | `undefined` | `TypeError` |
| `this-obj-not-regexp.js` | `undefined` | `TypeError` |
| `flags-to-string-err.js` | `Symbol` → `"Symbol()"` | `TypeError` |
| `pattern-to-string-err.js` | `Symbol` → `"Symbol()"` | `TypeError` |
| `pattern-regexp-immutable-lastindex.js` | no throw | `TypeError`, source/flags still updated |

## Root cause & fix (3 small runtime edits, all in `perry-runtime`)

1. **Missing brand check.** `RegExp.prototype.compile` was a no-op thunk, so
   `compile.call(<non-regexp>)` returned `undefined` instead of throwing. Replaced
   it with a real `regex_proto_compile_thunk` that reuses the existing
   `regex_instance_or_throw` brand check (same one `exec`/`test` use) and routes a
   valid receiver to `js_regexp_compile_value`. The Annex-B no-op is retained only
   for builds compiled **without** the `regex-engine` feature.

2. **Lenient argument coercion.** A `Symbol` pattern/flags stringified to
   `"Symbol(desc)"`. Added `reject_symbol_to_string` before `ToString`, matching
   the abstract ToString operation (§7.1.17) — same guard already used by
   `String.prototype.pad*`, `String.raw`, etc.

3. **`lastIndex` reset ignored writability.** RegExpInitialize step 12 is
   `Set(obj, "lastIndex", 0, true)` — a *throwing* set. The reset is now moved
   **after** the source/flags update and routed through the existing
   `set_last_index_throwing`, so a frozen `lastIndex` throws `TypeError` while
   `.source`/`.flags` are still updated (exactly what the immutable-lastindex case
   asserts).

Descriptors are preserved: `compile.length === 2`, `compile.name === "compile"`,
and the `{writable, !enumerable, configurable}` method descriptor are unchanged
(the real thunk goes through the same `install_proto_method` path as the old no-op).

## Validation

Measured with `scripts/test262_subset.py --all-features` against a from-scratch
base-`main` build (A/B), test262 pinned SHA `4249661…`:

- **compile subtree:** base 16 pass / 6 fail → **patched 20 pass / 2 fail**.
- **`annexB/built-ins/RegExp` + `built-ins/RegExp` (1915 judged):** base 1524 pass
  → **patched 1528 pass** (net +4; the exact 5 target cases flip base-fail → patched-pass,
  no other case regresses).
- `cargo fmt` clean on all touched files; `scripts/check_file_size.sh` unaffected
  (largest touched file 387 lines).

## Note on `this-subclass-instance.js` (out of scope, disclosed for transparency)

Under `--all-features` the differential radar shows one case shifting
base-pass → patched-"runtime-fail": `.../compile/this-subclass-instance.js`
(`features: [legacy-regexp, class]`, **not** in the #5910 list). This is a
differential/oracle artifact, not a correctness regression:

- The case asserts `subclassInstance.compile()` throws `TypeError`.
- Perry's `new (class extends RegExp {})("")` does **not** produce a functioning
  `[[RegExpMatcher]]` (its `.source` is `undefined` — a pre-existing RegExp-
  *subclassing* gap, unrelated to `compile`). Given no matcher slot, throwing
  `TypeError` is the **consistent** brand-check result — patched Perry now
  satisfies the case's own `assert.throws` (Perry exit 0).
- The local Node oracle (26.3) instead *recompiles* the subclass (its instance
  has a real matcher) and so **fails** the assert — which is why the differential
  flags the divergence. Base "passed" only because its no-op `compile` failed the
  assert the same way Node does.

i.e. patched Perry is *more* conformant to what this case asserts; fully fixing it
belongs to the separate RegExp-subclassing gap.

Per the external-contributor guidance, no version bump / CHANGELOG / CLAUDE.md
edits are included.

Refs #5910

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added functional support for `RegExp.prototype.compile()` when the regex engine is enabled.
  * RegExp patterns and flags are recompiled in place with standard validation behavior.

* **Bug Fixes**
  * Invalid Symbol-based pattern or flag values now correctly raise errors.
  * Compilation now properly resets `lastIndex` and respects observable property behavior.
  * Calls on non-RegExp receivers are rejected as required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->