### PR TITLE
chore(node-suite): stop committing derived overall aggregate

### DIFF
--- a/scripts/node_suite_regression_check.py
+++ b/scripts/node_suite_regression_check.py
@@ -74,7 +74,12 @@ def main():
         elif cur["pass"] > floor["pass"]:
             improvements.append(f"{mod}: {cur['pass']}/{cur['total']}  (+{cur['pass'] - floor['pass']})")
 
+    # Overall is derived, not stored (avoids cross-PR merge conflicts on a
+    # shared aggregate). Compute it from the per-module floors at report time.
+    bp = sum(m["pass"] for m in baseline.values())
+    bt = sum(m["total"] for m in baseline.values())
     print("\n=== node-suite regression check ===")
+    print(f"baseline floor overall: {bp}/{bt} ({round(100 * bp / bt, 1)}%)")
     if improvements:
         print("improvements (ratchet the baseline up):")
         for s in improvements:

--- a/test-parity/node_suite_baseline.json
+++ b/test-parity/node_suite_baseline.json
@@ -2,12 +2,7 @@
   "_schema": {
     "description": "Floor baseline for scripts/node_suite_regression_check.py. Each module's run must produce pass >= floor.pass; dropping below is a regression (exit 1). Improvements are always accepted and reported as ratchet candidates. Captured in the node-26 environment with scripts/node_suite_run.py (pre-warm + fast/slow lanes).",
     "oracle": "node v26.5.0 (pinned by .node-version)",
-    "note": "Deterministic modules are floored at full pass. Timing/racy modules (http2, net, stream, diagnostics_channel, fs-promises) carry a small margin below observed pass so ordinary flake does not false-alarm; the guard still catches real regressions, which are large (e.g. dns 6->0, http 19->9). node_suite_run.normalize() scrubs environment-variant tokens (console.time hrtime durations, stack-trace frame lines) symmetrically before the stdout compare, so console is floored at full pass (119) on its deterministic content. http is verified 19/19 in isolation but the full-suite harness flakes to 17 under port contention, so it is floored at 17 (flake margin, not a regression); a real http break is a much larger drop. Floors were refreshed from a clean node-26 run at 2810/2863 (98.1%), then the deterministic child_process floor was measured independently at 43/53 on Node 26.5.0. The overall summary is the sum of the committed per-module floors."
-  },
-  "overall": {
-    "pass": 2820,
-    "total": 2919,
-    "pct": 96.6
+    "note": "Deterministic modules are floored at full pass. Timing/racy modules (http2, net, stream, diagnostics_channel, fs-promises) carry a small margin below observed pass so ordinary flake does not false-alarm; the guard still catches real regressions, which are large (e.g. dns 6->0, http 19->9). node_suite_run.normalize() scrubs environment-variant tokens (console.time hrtime durations, stack-trace frame lines) symmetrically before the stdout compare, so console is floored at full pass (119) on its deterministic content. http is verified 19/19 in isolation but the full-suite harness flakes to 17 under port contention, so it is floored at 17 (flake margin, not a regression); a real http break is a much larger drop. Floors were refreshed from a clean node-26 run at 2810/2863 (98.1%), then the deterministic child_process floor was measured independently at 43/53 on Node 26.5.0."
   },
   "modules": {
     "assert": {


### PR DESCRIPTION
## Problem

`test-parity/node_suite_baseline.json` stored a top-level `overall` `{pass,total,pct}` block, but **nothing reads it**:

- `scripts/node_suite_regression_check.py` reads only `.get("modules", {})` — the gate is 100% per-module.
- `scripts/node_suite_run.py` computes its own overall from the live run.
- No CI workflow or doc parses the `overall` key.

Because every floor-bumping parity PR rewrote those same three `overall` lines, any two such PRs collided pairwise on that shared triple — currently blocking ~10 open parity PRs from rebasing cleanly.

The stored value had also drifted stale (`2820/2919` vs the real module sum `2834/2959`), confirming it as write-only bookkeeping nobody kept in sync.

## Change

- Remove the `overall` block from the baseline JSON (and drop the now-obsolete `_schema.note` sentence describing it).
- Compute the overall from the per-module floors at report time in `node_suite_regression_check.py`, printed as `baseline floor overall: <sum>/<sum> (<pct>%)`.

Per-module data — the exhaustive analysis — is untouched. The gate's pass/fail decision is unchanged (still per-module floors only). Each parity PR now edits only its own module block, so the conflict class is gone permanently.

## Notes

- No JSON-schema validation or test asserts the key's presence; removal is safe.
- Version bump + CHANGELOG entry follow separately at merge time (maintainer convention).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an overall baseline floor summary showing aggregate passing and total test counts with the corresponding percentage.

* **Documentation**
  * Updated baseline notes to reflect the revised summary description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->