### PR TITLE
fix(dispatch): computed tagged-template tag `String["raw"]`…`` in a closure (#6697)

### DIFF
--- a/crates/perry-hir/src/lower/lower_expr.rs
+++ b/crates/perry-hir/src/lower/lower_expr.rs
@@ -239,10 +239,18 @@ fn lower_expr_impl(ctx: &mut LoweringContext, expr: &ast::Expr) -> Result<Expr> 
                         ast::Expr::Ident(id) => id.sym.as_ref() == "String",
                         _ => false,
                     };
-                    let prop_is_raw = match &member.prop {
-                        ast::MemberProp::Ident(id) => id.sym.as_ref() == "raw",
-                        _ => false,
-                    };
+                    // #6697: recognize the computed-key form `String["raw"]`
+                    // (string-literal computed member), not just the dot form.
+                    // Without this, `` String["raw"]`…` `` fell through to the
+                    // general tag-desugar path below, whose `String["raw"]`
+                    // value-read reroute resolves to a non-function when the
+                    // tag is emitted inside a nested closure (top-level worked
+                    // by luck) — "value is not a function". Routing both forms
+                    // through this string-concat fast path keeps them in
+                    // lockstep, mirroring the read-side computed-key
+                    // normalization (#6676/#6677).
+                    let prop_is_raw = expr_member::static_member_prop_name(&member.prop).as_deref()
+                        == Some("raw");
                     obj_is_string && prop_is_raw
                 }
                 _ => false,

--- a/test-files/test_gap_computed_tagged_template_closure.ts
+++ b/test-files/test_gap_computed_tagged_template_closure.ts
@@ -1,0 +1,41 @@
+// #6697 (follow-up to #6677): a computed-member tagged-template TAG —
+// `` String["raw"]`…` `` — threw `TypeError: value is not a function` when the
+// tag expression appeared inline inside a nested closure. The dot form
+// (`String.raw`…``) took a string-concat fast path that works everywhere, but
+// the string-literal computed form fell through to the general tag-desugar,
+// whose `String["raw"]` value-read reroute resolved to a non-function once
+// emitted inside a function/arrow scope. Minifiers/bundlers routinely rewrite
+// `String.raw` to `String["raw"]`, so both forms must match Node in every
+// scope. Fix routes both forms through the same fast path.
+
+// --- controls that already worked (regression guards) ---
+console.log(String.raw`plain-dot`); // dot, top level
+console.log(String["raw"]`plain-computed`); // computed, top level (worked)
+console.log((() => String.raw`plain-dot-closure`)()); // dot inside closure
+{
+  const t = String["raw"];
+  console.log((() => t`plain-alias`)()); // aliased-first inside closure
+}
+
+// --- the bug: inline computed tag inside a nested closure ---
+console.log((() => String["raw"]`plain-BUG`)());
+
+// --- backslash preservation (raw semantics, not cooked) ---
+console.log(String["raw"]`a\nb\t\\c`); // top level
+console.log((() => String["raw"]`a\nb\t\\c`)()); // inside closure
+
+// --- substitutions preserved through the fast path ---
+const x = 42;
+const y = "Z";
+console.log(String["raw"]`v=${x} and ${y}!`);
+console.log((() => String["raw"]`v=${x} and ${y}!`)());
+console.log(((): string => String["raw"]`sum=${x + 1}\path`)());
+
+// --- deeper nesting: function declaration + nested arrows ---
+function outer(): string {
+  const inner = () => String["raw"]`deep\nesting`;
+  return inner();
+}
+console.log(outer());
+
+console.log([1, 2, 3].map((n) => String["raw"]`n\=${n}`).join(","));


### PR DESCRIPTION
## Summary

Fixes #6697 (follow-up to #6677). A computed-member tagged-template tag —
`` String["raw"]`…` `` — threw `TypeError: value is not a function` when the
tag expression appeared inline inside a nested closure:

```ts
console.log((() => String["raw"]`plain`)());   // node: "plain"   perry: TypeError
```

## Root cause

The `TaggedTpl` lowering in `crates/perry-hir/src/lower/lower_expr.rs` has a
`String.raw` fast path that desugars `` String.raw`…` `` into direct string
concatenation (raw text interleaved with substitutions), which is correct in
every scope. But its `is_string_raw` detection matched only the **dot** form
(`MemberProp::Ident`):

```rust
let prop_is_raw = match &member.prop {
    ast::MemberProp::Ident(id) => id.sym.as_ref() == "raw",
    _ => false,   // String["raw"] never matched
};
```

The string-literal **computed** form `` String["raw"]`…` `` fell through to
the general tag-desugar (`Expr::Call { callee: <read of String["raw"]>, … }`).
Inspecting the HIR shows why the closure case breaks:

| form | lowered tag callee |
|------|--------------------|
| top level | `globalThis.String.raw` ✓ |
| inside closure | `globalThis.raw` ✗ (the `String` hop is dropped → `GlobalGet(0).raw` = undefined) |

Inside a closure the builtin-identifier reroute for the `String` base collapses
to `GlobalGet(0)`, so the callee resolves to a non-function. At top level the
same read happens to resolve to the real `String.raw`, which is why the
controls in the issue (top-level computed, dot-in-closure, aliased-var) all
worked.

## Fix

Normalize the tag's property name with the existing
`static_member_prop_name` helper (handles both `Ident` and string-literal
`Computed`) so **both** `` String.raw`…` `` and `` String["raw"]`…` `` take
the same string-concat fast path in every scope — the same read-side
computed-key normalization established by #6676/#6677. The fast path emits a
plain string/concatenation, so there is no member read or closure capture of
`String` to mis-resolve.

Surgical: only `` String["raw"]`…` `` changes behavior. Every other
tagged-template form is untouched — a dynamic (non-literal) computed key still
returns `None` and keeps the general desugar; custom tag functions and
computed custom tags (`` obj["m"]`…` ``) are unaffected.

## Testing

New `test-files/test_gap_computed_tagged_template_closure.ts` — **byte-identical
to Node** (oracle v26). Covers the reported closure form, the three working
controls (regression guards), backslash-raw semantics, substitutions, and
deeper nesting (function decl + nested arrows + `Array.map`).

Regression guards (all byte-identical to Node, unchanged):
- `test_gap_2786_2880_2782_2789_string_semantics` (callable `String.raw`)
- `test_gap_computed_namespace_dispatch` (#6677 computed-key dispatch)
- `test_gap_string_methods`

Per contributor guidance, no version bump / CHANGELOG entry (maintainer folds
those in at merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed computed tagged templates such as `String["raw"]` so they behave consistently with `String.raw`.
  - Preserved correct backslash handling and value interpolation when used inside nested functions, arrows, closures, or aliases.

- **Tests**
  - Added regression coverage for computed-member tagged templates across nested scopes and function patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->