### PR TITLE
fix(generator): expose [Symbol.iterator] on sync generators (#6696)

### DIFF
--- a/crates/perry-runtime/src/object/global_this/generator.rs
+++ b/crates/perry-runtime/src/object/global_this/generator.rs
@@ -282,6 +282,16 @@ extern "C" fn async_generator_proto_async_iterator_thunk(
     crate::object::js_implicit_this_get()
 }
 
+/// `%Generator.prototype%[Symbol.iterator]()` returns `this` (spec inherits this
+/// from `%IteratorPrototype%`). Mirrors the async thunk above; see the install
+/// note in `build_generator_tower` for why the sync prototype now carries this.
+extern "C" fn generator_proto_iterator_thunk(
+    _c: *const crate::closure::ClosureHeader,
+    _arg: f64,
+) -> f64 {
+    crate::object::js_implicit_this_get()
+}
+
 /// Install a well-known-symbol-keyed method (returning `this`) on a
 /// generator/async-generator prototype, with the spec descriptor shape
 /// (`name`/`length` own props, non-enumerable value).
@@ -554,27 +564,39 @@ fn build_generator_tower(
     install_proto_method(gen_proto, "return", return_thunk, 1);
     install_proto_method(gen_proto, "throw", throw_thunk, 1);
     // Spec: `%AsyncGenerator.prototype%` inherits `[Symbol.asyncIterator]` from
-    // `%AsyncIteratorPrototype%` (returning `this`). Without it, `for await (x of
-    // gen())` over an async-generator *method instance* can't resolve the async
-    // iterator and hangs/yields nothing (the instance carries no own iterator
-    // symbol). The async-iterator-acquisition path (`js_get_async_iterator`)
-    // sets the implicit-this before invoking this thunk, so it returns the
-    // generator instance.
+    // `%AsyncIteratorPrototype%` and `%Generator.prototype%` inherits
+    // `[Symbol.iterator]` from `%IteratorPrototype%` — both returning `this`.
+    // Without the async one, `for await (x of gen())` over an async-generator
+    // *method instance* can't resolve the async iterator and hangs/yields nothing
+    // (the instance carries no own iterator symbol). The async-iterator-
+    // acquisition path (`js_get_async_iterator`) sets the implicit-this before
+    // invoking this thunk, so it returns the generator instance.
     //
-    // Note: the SYNC `%Generator.prototype%` deliberately gets NO own
-    // `[Symbol.iterator]` here — the sync `for-of` iterator-acquisition path
-    // (`js_get_iterator`) does NOT bind implicit-this before invoking a
-    // `[Symbol.iterator]` method, so a `this`-returning thunk would resolve to
-    // `undefined` and break `for (x of gen())`. Sync generators already iterate
-    // through their own `next` via the builtin-iterator recognizers.
-    if is_async {
-        install_proto_symbol_self_method(
-            gen_proto,
+    // The SYNC `%Generator.prototype%` carries `[Symbol.iterator]` for the same
+    // reason (#6696): a *computed* read `gen[Symbol.iterator]` walks the
+    // prototype chain and must resolve to a callable that returns the generator
+    // — Node exposes it via `%IteratorPrototype%`, and esbuild's `__yieldStar`
+    // helper (emitted for `yield*` at `--target=es2015|es2017`) does
+    // `value[Symbol.iterator]()` on the delegate generator. `for (x of gen())`
+    // is unaffected: it drives the generator's own `.next()` directly (the
+    // builtin-iterator recognizers), and where the sync iterator-acquisition
+    // path (`js_get_iterator`) does read `[Symbol.iterator]`, it binds
+    // implicit-this before invoking the method, so the thunk returns the
+    // generator instance.
+    let (symbol_name, display_name, thunk) = if is_async {
+        (
             "asyncIterator",
             "[Symbol.asyncIterator]",
             async_generator_proto_async_iterator_thunk as *const u8,
-        );
-    }
+        )
+    } else {
+        (
+            "iterator",
+            "[Symbol.iterator]",
+            generator_proto_iterator_thunk as *const u8,
+        )
+    };
+    install_proto_symbol_self_method(gen_proto, symbol_name, display_name, thunk);
     set_intrinsic_to_string_tag(gen_proto, inst_tag);
 
     ctor_slot.store(ctor as i64, Ordering::Release);

--- a/test-files/test_gap_6696_generator_symbol_iterator.ts
+++ b/test-files/test_gap_6696_generator_symbol_iterator.ts
@@ -1,0 +1,92 @@
+// #6696 (follow-up to #6676): a GENERATOR object must expose `[Symbol.iterator]`
+// through COMPUTED property access, returning a function that yields the
+// generator itself. Perry lowers `g()` to a plain `{next,return,throw}` object
+// and the sync `%Generator.prototype%` carried no `[Symbol.iterator]`, so
+// `gen[Symbol.iterator]` read `undefined` even though `for (x of gen())` worked
+// (that path drives the generator's own `.next()` directly).
+//
+// The end-to-end victim is esbuild's `__yieldStar` helper, emitted for `yield*`
+// at `--target=es2015|es2017`: it does `obj = value[Symbol.iterator]()` on the
+// delegate generator, so an `undefined` read makes the helper die one step later
+// with "Cannot use 'in' operator to search for 'throw' in undefined".
+//
+// Validated byte-for-byte against `node --experimental-strip-types`.
+
+function* g() {
+  yield 1;
+  yield 2;
+}
+
+// ── the direct symptom ──────────────────────────────────────────────────────
+const it: any = g();
+console.log(typeof it[Symbol.iterator]); // "function"
+console.log(it[Symbol.iterator]() === it); // true
+console.log(Symbol.iterator in it); // true
+
+// The bound method drives the same generator (its own `.next()`).
+const it2: any = g();
+const iterFn = it2[Symbol.iterator];
+const self = iterFn.call(it2);
+console.log(self === it2); // true
+console.log(JSON.stringify(self.next())); // {"value":1,"done":false}
+console.log(JSON.stringify([...it2])); // [2] — one value already consumed
+
+// ── the original #6676 e2e: esbuild's __yieldStar over a delegate generator ──
+// This is the shape esbuild emits when downleveling `yield*` to es2015/es2017.
+function __yieldStar(inner: any) {
+  let obj: any;
+  let iter =
+    typeof Symbol !== "undefined" && Symbol.iterator && inner[Symbol.iterator];
+  if (!iter) return inner;
+  iter = iter.call(inner);
+  const result: number[] = [];
+  let step: any;
+  while (!(step = iter.next()).done) result.push(step.value);
+  return result;
+}
+function* inner() {
+  yield 1;
+  yield 2;
+}
+console.log(JSON.stringify(__yieldStar(inner()))); // [1,2]
+
+// ── native `yield*` (es2020) still works, unchanged ─────────────────────────
+function* innerN() {
+  yield 1;
+  yield 2;
+}
+function* outerN() {
+  yield* innerN();
+}
+console.log(JSON.stringify([...outerN()])); // [1,2]
+
+// ── plain `for…of` over a generator is unaffected (drives own .next()) ──────
+function* nums() {
+  yield 10;
+  yield 20;
+  yield 30;
+}
+const collected: number[] = [];
+for (const n of nums()) collected.push(n);
+console.log(collected.join(",")); // 10,20,30
+
+// ── spread / Array.from / Math.max over a generator ─────────────────────────
+function* seq() {
+  yield 3;
+  yield 7;
+  yield 5;
+}
+console.log(JSON.stringify([...seq()])); // [3,7,5]
+console.log(JSON.stringify(Array.from(seq()))); // [3,7,5]
+console.log(Math.max(...seq())); // 7
+
+// ── the resolved method is callable and reusable across instances ───────────
+function* pair() {
+  yield "a";
+  yield "b";
+}
+const p1: any = pair();
+const p2: any = pair();
+console.log(typeof p1[Symbol.iterator] === typeof p2[Symbol.iterator]); // true
+console.log([...p1[Symbol.iterator]()].join("")); // ab
+console.log([...p2].join("")); // ab


### PR DESCRIPTION
Fixes #6696 (follow-up to #6676).

## Problem
A generator object returned `undefined` for a **computed** `[Symbol.iterator]` read:

```ts
function* g() { yield 1; yield 2; }
const it: any = g();
typeof it[Symbol.iterator];   // node: "function"   perry (before): "undefined"
it[Symbol.iterator]() === it; // node: true         perry (before): false / TypeError
```

Perry lowers `g()` to a plain `{next,return,throw}` object, and the sync `%Generator.prototype%` deliberately carried **no** `[Symbol.iterator]` (only the async prototype got `[Symbol.asyncIterator]`). So the computed read walked the prototype chain and found nothing. `for (x of gen())` still worked because `js_get_iterator` returns the generator as its own iterator and drives `.next()` directly — which is why iteration worked but the symbol read did not.

This is the residual behind #6676's end-to-end case: esbuild's `__yieldStar` helper (emitted for `yield*` at `--target=es2015|es2017`) does `value[Symbol.iterator]()` on the delegate generator, so the `undefined` read made the helper die one step later.

## Fix
Install `[Symbol.iterator]` (a `this`-returning thunk) on the sync `%Generator.prototype%`, mirroring the existing `[Symbol.asyncIterator]` install on `%AsyncGenerator.prototype%` in the same function. Node exposes it via `%IteratorPrototype%`.

The old "deliberately omitted" rationale is stale: `js_get_iterator` now binds implicit-`this` before invoking a resolved `[Symbol.iterator]` method, so `for (x of gen())` is unaffected (it returns the generator either way). Async generators are untouched — they keep only `[Symbol.asyncIterator]` and remain non-sync-iterable.

- **runtime** (`object/global_this/generator.rs`): add `generator_proto_iterator_thunk` and install the sync symbol in `build_generator_tower`.
- **test**: `test_gap_6696_generator_symbol_iterator.ts` (byte-identical to Node) — the direct symptom, the `__yieldStar` e2e, native `yield*`, `for-of`, spread / `Array.from` / `Math.max`, and cross-instance reuse.

## Verification
Built the runtime static libs locally and ran an A/B against a pristine `main` (`e7626a102`) runtime:

- `test_gap_6696_generator_symbol_iterator` — **baseline**: `undefined` / `false` / `TypeError`; **patched**: all 15 lines byte-identical to Node. ✅
- 24 generator / `yield*` / iterator / symbol gap tests pass byte-identical to Node. The only two that DIFF — `test_gap_symbols` (#5917) and `test_gap_iterator_helpers_2874` (#2874) — are pre-existing triaged known-failures, and are **byte-identical between baseline and patched** (this change touches neither).
- Sanity: sync generators gain `[Symbol.iterator]`; async generators keep only `[Symbol.asyncIterator]` and stay non-sync-iterable; `for await` still works.

No version bump / changelog (maintainer folds those in at merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generator objects now correctly expose a functional `[Symbol.iterator]` method.
  * Improved compatibility with `yield*`, `for…of`, spread syntax, `Array.from`, and related iteration operations.
  * Calling a generator’s iterator method now returns the generator itself, as expected.

* **Tests**
  * Added coverage for computed iterator access, repeated use across generator instances, and downlevel iteration helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->