### PR TITLE
fix(runtime): resolve the subclass in Promise SpeciesConstructor (#5907)

### DIFF
--- a/crates/perry-runtime/src/promise/then.rs
+++ b/crates/perry-runtime/src/promise/then.rs
@@ -1021,6 +1021,22 @@ pub(crate) fn promise_has_own_property(promise_addr: usize, name: &str) -> bool 
     )
 }
 
+// True iff `c` is the intrinsic `Promise` or a `class … extends Promise`
+// constructor — the constructors that inherit the standard
+// `Promise[Symbol.species]` getter (which returns `this`). Used by
+// `promise_species_constructor` to decide whether an absent `@@species` read
+// should emulate that getter (return `C`) or fall back to the `%Promise%`
+// default.
+fn is_promise_brand_constructor(c: f64) -> bool {
+    if super::spec_combinators::is_default_promise_constructor(c) {
+        return true;
+    }
+    match crate::object::class_ref_id(c) {
+        Some(class_id) => crate::object::promise_parent_in_chain(class_id),
+        None => false,
+    }
+}
+
 // SpeciesConstructor(promiseReceiver, %Promise%) per ECMA-262 §7.3.25.
 // Reads `this.constructor` once, then `C[@@species]`, returns the resolved constructor.
 // Throws TypeError for null/non-object constructor, non-constructor species, or getter throws.
@@ -1055,8 +1071,30 @@ fn promise_species_constructor(receiver: f64) -> f64 {
         unsafe { crate::symbol::js_object_get_symbol_property(c, sym_val) }
     };
 
-    // Step 5: undefined or null → use intrinsic %Promise%.
-    if s.to_bits() == TAG_UNDEFINED || s.to_bits() == TAG_NULL {
+    // Step 5: `null` species → spec default (%Promise%).
+    if s.to_bits() == TAG_NULL {
+        return get_intrinsic_promise();
+    }
+
+    // Step 5 (cont.): `undefined` species. Perry does not install the standard
+    // `Promise[Symbol.species]` accessor — an inherited getter that returns
+    // `this` — so `Get(C, @@species)` genuinely reads `undefined` for the
+    // intrinsic `Promise` and every subclass of it (a user override, if any,
+    // is stored and surfaces above). Emulate that getter: an `undefined`
+    // species resolves to `C` itself, the value real engines observe. For the
+    // intrinsic `Promise`, `C` IS `%Promise%`, so plain promises keep the
+    // native fast path unchanged; for a `class X extends Promise`, `C` is the
+    // subclass, so `X.prototype.{then,catch,finally}` chain a subclass promise
+    // through `NewPromiseCapability(X)` (ECMA-262 27.2.5.4.1) instead of
+    // silently collapsing to the intrinsic fast path. The standard getter is
+    // inherited only by `Promise` and its subclasses, so restrict the emulation
+    // to Promise-branded constructors — a non-Promise `constructor` reassigned
+    // onto the receiver carries no such getter and keeps the `%Promise%`
+    // default.
+    if s.to_bits() == TAG_UNDEFINED {
+        if is_promise_brand_constructor(c) {
+            return c;
+        }
         return get_intrinsic_promise();
     }
 

--- a/crates/perry-runtime/src/promise/then.rs
+++ b/crates/perry-runtime/src/promise/then.rs
@@ -1062,7 +1062,12 @@ fn promise_species_constructor(receiver: f64) -> f64 {
         throw_type_error_thunk("Promise.prototype.then: constructor property is not an object");
     }
 
-    // Step 4: S = Get(C, @@species) — getter throws → propagate.
+    // Step 4: S = Get(C, @@species) — getter throws → propagate. A user
+    // `@@species` accessor runs arbitrary code that can allocate and evacuate
+    // the (movable, heap-pointer) constructor, so root `C` across the read and
+    // reload it from the rewritten handle before any later reuse below.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let c_handle = scope.root_nanbox_f64(c);
     let sp = crate::symbol::well_known_symbol("species");
     let s = if sp.is_null() {
         f64::from_bits(TAG_UNDEFINED)
@@ -1070,6 +1075,7 @@ fn promise_species_constructor(receiver: f64) -> f64 {
         let sym_val = f64::from_bits(crate::value::JSValue::pointer(sp as *const u8).bits());
         unsafe { crate::symbol::js_object_get_symbol_property(c, sym_val) }
     };
+    let c = c_handle.get_nanbox_f64();
 
     // Step 5: `null` species → spec default (%Promise%).
     if s.to_bits() == TAG_NULL {


### PR DESCRIPTION
## Summary

`Promise.prototype.{then,catch,finally}` run **SpeciesConstructor(receiver, %Promise%)**, which reads `receiver.constructor[Symbol.species]`. Perry installs no `Promise[Symbol.species]` accessor, so that read always returned `undefined` and SpeciesConstructor fell back to the intrinsic `%Promise%`. The effect: every `class X extends Promise` chain collapsed onto the native fast path and **never routed through `NewPromiseCapability(X)`**, so subclass `then`/`catch`/`finally` produced the wrong number of chained promises.

## Root cause

In `promise_species_constructor` (`crates/perry-runtime/src/promise/then.rs`), step 5 mapped an `undefined` species to `%Promise%`. Since the standard `Promise[Symbol.species]` getter (which returns `this`) is never installed, the read is *always* `undefined`, so the subclass was lost and the fast path was always taken.

## Fix

Emulate the standard getter directly in `promise_species_constructor`: an absent `@@species` on a **Promise-branded** constructor resolves to `C` itself — the value real engines observe from the inherited getter. Now:

- the intrinsic `Promise` still resolves to `%Promise%` (fast path unchanged for plain promises);
- a `class X extends Promise` resolves to `X`, so `X.prototype.{then,catch,finally}` chain a subclass promise via `NewPromiseCapability(X)` (ECMA-262 27.2.5.4.1);
- the emulation is guarded to Promise/subclass constructors — a reassigned non-Promise `.constructor` carries no such inherited getter and keeps the `%Promise%` default;
- an explicit `null` species still yields the spec default.

## Validation

`scripts/test262_subset.py --dir built-ins/Promise` (serial):

| | pass | diff | runtime-fail |
|---|---|---|---|
| before | 563 | 3 | 8 |
| after | **565** | 2 | 7 |

Newly passing (0 regressions, diffed by test path):

- `built-ins/Promise/prototype/finally/subclass-resolve-count.js`
- `built-ins/Promise/prototype/finally/subclass-reject-count.js`

Also verified: 14 promise/async gap tests still match the Node oracle byte-for-byte; the promise-scoped `perry-runtime` unit tests pass; `rustfmt --check` clean on the changed file.

Code-only PR (no version bump / CHANGELOG / CLAUDE.md — maintainer folds metadata). Refs #5907.

The deeper remaining `built-ins/Promise` failures the issue tracks (subclass constructors that override `this` by returning a plain object — `then/capability-executor-*`, `then/deferred-is-resolved-value` — and the per-step observable `PromiseResolve` count in `finally/{resolved,rejected}-observable-then-calls-PromiseResolve`) are out of scope here; they need derived-constructor return-value semantics and the full finally routing, respectively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `Promise.prototype.then` handling of `@@species` by correctly distinguishing `null` vs `undefined` reads.
  * `null` `@@species` continues to fall back to the intrinsic `%Promise%`.
  * `undefined` `@@species` now resolves to the receiver constructor only when it’s Promise-branded; otherwise it falls back to `%Promise%`, improving compatibility with Promise subclasses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->