### PR TITLE
fix: proxy-forwarded class-method `this` binding — TUI-init undefined.get divergence (#6699)

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -49,10 +49,29 @@ pub extern "C" fn js_object_get_field_by_name(
     {
         // Proxy ids live in the proxy id band; `js_proxy_is_proxy` confirms
         // it is a *registered* proxy before we route to the proxy getter.
+        //
+        // #6699: the receiver arrives in two encodings. A generic property read
+        // passes the raw small proxy-id pointer (`top16 == 0`). The class-field
+        // IC-miss fallback (`js_object_get_field_by_name_f64`, reached when the
+        // typed-`this` field guard rejects an off-shape receiver) instead
+        // forwards the *full NaN-box* value with the `0x7FFD` heap-pointer tag
+        // still set — exactly the tagged encoding the FAST LANE below already
+        // strips. A tagged proxy value (`0x7FFD_0000_000F_xxxx`) is not itself
+        // in the proxy id band, so the un-normalized band test missed it and the
+        // read fell through to `undefined` instead of the get trap. This bit a
+        // typed-`this` field read whose `this` is a Proxy — e.g. pi's TUI theme
+        // is a `new Proxy({}, …)` whose `get` trap forwards to the real Theme;
+        // `theme.fg()` runs with `this === proxy`, and `this.fgColors` must hit
+        // the trap. Normalize the tag first so both encodings route identically.
         let addr = obj as u64;
-        if crate::value::addr_class::is_proxy_id_band(addr as usize) && !key.is_null() {
+        let raw_addr = if (addr >> 48) == 0x7FFD {
+            addr & 0x0000_FFFF_FFFF_FFFF
+        } else {
+            addr
+        };
+        if crate::value::addr_class::is_proxy_id_band(raw_addr as usize) && !key.is_null() {
             const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
-            let boxed = f64::from_bits(POINTER_TAG | (addr & 0x0000_FFFF_FFFF_FFFF));
+            let boxed = f64::from_bits(POINTER_TAG | (raw_addr & 0x0000_FFFF_FFFF_FFFF));
             if crate::proxy::js_proxy_is_proxy(boxed) != 0 {
                 let key_f64 = f64::from_bits(crate::value::js_nanbox_string(key as i64).to_bits());
                 let v = crate::proxy::js_proxy_get(boxed, key_f64);

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -308,10 +308,24 @@ pub extern "C" fn js_object_set_field_by_name(
     // the value is a *registered* proxy so a real heap object whose masked
     // address happens to be small isn't misrouted.
     {
+        // #6699 (mirror of the read side): the class-field IC-miss fallback
+        // (`js_class_field_set_fallback`, reached when a typed-`this` field set
+        // rejects an off-shape receiver) forwards the *full NaN-box* value with
+        // the `0x7FFD` heap-pointer tag still set, whereas the `obj.prop++`
+        // path (#5135) hands us the bare masked band. A tagged proxy value is
+        // not itself in the proxy id band, so the un-normalized test missed it
+        // and a `this.field = v` write whose `this` is a Proxy skipped the set
+        // trap. Strip the tag first (the FAST LANE below already does) so both
+        // encodings route to `js_proxy_set` identically.
         let addr = obj as u64;
-        if crate::value::addr_class::is_proxy_id_band(addr as usize) && !key.is_null() {
+        let raw_addr = if (addr >> 48) == 0x7FFD {
+            addr & 0x0000_FFFF_FFFF_FFFF
+        } else {
+            addr
+        };
+        if crate::value::addr_class::is_proxy_id_band(raw_addr as usize) && !key.is_null() {
             const POINTER_TAG: u64 = 0x7FFD_0000_0000_0000;
-            let boxed = f64::from_bits(POINTER_TAG | (addr & 0x0000_FFFF_FFFF_FFFF));
+            let boxed = f64::from_bits(POINTER_TAG | (raw_addr & 0x0000_FFFF_FFFF_FFFF));
             if crate::proxy::js_proxy_is_proxy(boxed) != 0 {
                 let key_f64 = f64::from_bits(crate::value::js_nanbox_string(key as i64).to_bits());
                 crate::proxy::js_proxy_set(boxed, key_f64, value);

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -1222,7 +1222,10 @@ pub unsafe extern "C" fn js_native_call_method(
         let method_handle = root_scope.root_nanbox_f64(method_value);
         let args = refreshed_args();
         // Bind `this` to the proxy for the duration of the call, matching the
-        // receiver semantics of a normal `obj.method(args)` invocation.
+        // receiver semantics of a normal `obj.method(args)` invocation. A
+        // canonical class-method value reads its receiver from IMPLICIT_THIS via
+        // `canonical_bound_method_receiver` (#6699 routes a proxy receiver
+        // through there).
         let prev_this = IMPLICIT_THIS.with(|c| c.replace(object_handle.get_nanbox_f64().to_bits()));
         let result = crate::closure::js_native_call_value(
             method_handle.get_nanbox_f64(),

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1212,6 +1212,22 @@ pub(crate) fn canonical_bound_method_receiver(captured: f64) -> f64 {
         if class_id_from_method_receiver(call_this).is_some() {
             return call_this;
         }
+        // #6699: a PROXY call-site `this` is a legitimate spec receiver for a
+        // class method reached through the proxy's get trap. `proxy.method()`
+        // is `Get(proxy, "method")` (the trap forwards to the real instance's
+        // method) then `Call(method, proxy)`, so the body must run with
+        // `this === proxy` — its `this.field` accesses then route back through
+        // the trap. A proxy id lives in the handle band, so
+        // `class_id_from_method_receiver` (which requires an above-band heap
+        // object) rejects it and we would otherwise fall through and leak the
+        // INT32 owner-marker as `this` (`typeof this === "number"`), exactly the
+        // marker-leak the #6475 closure case below guards against. pi's TUI
+        // theme is a `new Proxy({}, …)` whose get trap forwards to the real
+        // Theme; `theme.fg()` → `this.fgColors.get(...)` threw
+        // `Cannot read properties of undefined (reading 'get')` without this.
+        if crate::proxy::js_proxy_is_proxy(call_this) != 0 {
+            return call_this;
+        }
         // #6475: a FUNCTION-object call-site `this` — effect's `TagClass`, a
         // plain function given the Tag class prototype via
         // `Object.setPrototypeOf(TagClass, Object.getPrototypeOf(tagInstance))` —

--- a/crates/perry/tests/issue_6699_proxy_class_method_this.rs
+++ b/crates/perry/tests/issue_6699_proxy_class_method_this.rs
@@ -1,0 +1,147 @@
+//! Regression tests for #6699 (pi TUI wall #13 / gate 3): a class method
+//! invoked through a `Proxy` must run with `this === proxy`, so the method
+//! body's `this.field` reads/writes route back through the proxy's traps —
+//! exactly as node does.
+//!
+//! Trigger in the wild: pi's theme accessor is
+//! `const theme = new Proxy({}, { get(_t, prop) { return
+//! globalThis[THEME_KEY][prop]; } })` — an empty-target proxy whose get trap
+//! forwards every read to the real `Theme` instance. The TUI render path calls
+//! `theme.fg("...")`, and `Theme.fg` does `this.fgColors.get(color)`. Under
+//! perry `this.fgColors` came back `undefined`, so `.get` threw
+//! `TypeError: Cannot read properties of undefined (reading 'get')` where node
+//! renders the full onboarding screen.
+//!
+//! Root cause: a canonical class-method VALUE (what the get trap returns for
+//! `real.fg`) resolves its receiver through `canonical_bound_method_receiver`,
+//! which reads the call-site `this` (IMPLICIT_THIS, correctly the proxy) but
+//! then required it to be an above-handle-band heap object. A proxy id lives in
+//! the handle band, so that check rejected it and the code fell through to
+//! return the INT32 owner-marker — leaking `typeof this === "number"` (the same
+//! marker-leak the #6475 closure case guards against). With `this` a bare
+//! number, `this.fgColors` read off a non-proxy and missed the get trap.
+//! Additionally, the typed-`this` class-field get/set fast path forwards the
+//! full NaN-boxed (0x7FFD-tagged) receiver to `js_object_get/set_field_by_name`,
+//! whose proxy-band test did not strip the tag, so `this.field` on a proxy
+//! `this` had to be normalized there too.
+//!
+//! Expected outputs are node v26's, byte for byte.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+fn compile_and_run(dir: &std::path::Path, source: &str) -> String {
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, source).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
+        run.status,
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+/// pi's theme shape verbatim: an empty-target `Proxy` whose get trap forwards
+/// to a `Theme` instance held under a global `Symbol`. Calling `theme.fg(name)`
+/// must run `Theme.fg` with `this === proxy` so `this.fgColors.get(name)` reads
+/// the real `Map` through the trap. Also pins the `this` identity/typeof that
+/// the marker-leak corrupted.
+#[test]
+fn proxy_forwarded_class_method_reads_this_field_through_get_trap() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+class Theme {
+  fgColors;
+  constructor(entries: [string, string][]) {
+    this.fgColors = new Map(entries);
+  }
+  fg(name: string): string {
+    const ansi = this.fgColors.get(name);
+    if (!ansi) throw new Error("unknown color: " + name);
+    return "<" + ansi + ">";
+  }
+  whoami(): unknown {
+    return this;
+  }
+}
+const KEY = Symbol.for("pi:theme");
+(globalThis as any)[KEY] = new Theme([["red", "31"], ["green", "32"]]);
+const theme: any = new Proxy({}, {
+  get(_t, prop) {
+    const t = (globalThis as any)[KEY];
+    if (!t) throw new Error("Theme not initialized. Call initTheme() first.");
+    return t[prop];
+  },
+});
+console.log("fg red:", theme.fg("red"));
+console.log("fg green:", theme.fg("green"));
+console.log("this===proxy:", theme.whoami() === theme);
+console.log("typeof this:", typeof theme.whoami());
+"#,
+    );
+    assert_eq!(
+        stdout,
+        "fg red: <31>\n\
+         fg green: <32>\n\
+         this===proxy: true\n\
+         typeof this: object\n"
+    );
+}
+
+/// The symmetric write path: a proxy with both get and set traps forwarding to
+/// the real instance. `Counter.bump` does `this.count = this.count + 1` with
+/// `this === proxy`, so the field WRITE must route through the set trap (and
+/// the read through the get trap) to mutate the real instance.
+#[test]
+fn proxy_forwarded_class_method_writes_this_field_through_set_trap() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        r#"
+class Counter {
+  count;
+  constructor() { this.count = 0; }
+  bump(): number { this.count = this.count + 1; return this.count; }
+  value(): number { return this.count; }
+}
+const KEY = Symbol.for("pi:counter");
+(globalThis as any)[KEY] = new Counter();
+const counter: any = new Proxy({}, {
+  get(_t, prop) { return (globalThis as any)[KEY][prop]; },
+  set(_t, prop, value) { (globalThis as any)[KEY][prop] = value; return true; },
+});
+console.log("bump:", counter.bump(), counter.bump(), counter.bump());
+console.log("value:", counter.value());
+"#,
+    );
+    assert_eq!(stdout, "bump: 1 2 3\nvalue: 3\n");
+}


### PR DESCRIPTION
## Root cause

pi's TUI wall #13 (gate 3). The accel-off pi bundle crashed ~7.5s into TUI init with `TypeError: Cannot read properties of undefined (reading 'get')` where node renders the full 23,733-byte onboarding screen on the identical bundle.

pi's theme accessor is a **Proxy over an empty target** whose get trap forwards every read to the real `Theme` instance:

```js
var theme = new Proxy({}, { get(_t, prop) { return globalThis[THEME_KEY][prop]; } });
```

The render path calls `theme.fg("...")`, and `Theme.fg` does `this.fgColors.get(color)`. Under perry `this.fgColors` came back `undefined`, so `.get` threw.

Two runtime divergences from node, both needed:

1. **`canonical_bound_method_receiver` dropped a proxy receiver.** A canonical class-method *value* (what the get trap returns for `real.fg`) resolves its receiver via `canonical_bound_method_receiver`. It read the call-site `this` (`IMPLICIT_THIS`, correctly the proxy) but then required an *above-handle-band heap object*. A proxy id lives in the handle band, so the check rejected it and the code fell through to return the INT32 owner-marker — leaking `typeof this === "number"` (the exact marker-leak the neighboring #6475 closure case guards against). With `this` a bare number, `theme.fg()` ran `this.fgColors.get(...)` off a non-proxy and threw.

2. **The typed-`this` class-field get/set fast path didn't strip the pointer tag before its proxy-band test.** The class-field IC-miss fallback forwards the *full NaN-boxed* receiver (`0x7FFD` tag set) to `js_object_get/set_field_by_name`, whose proxy-band check used the un-normalized value — so even with `this` correctly the proxy, `this.field` on a proxy `this` missed the get/set trap and fell through to `undefined`/a corrupt cell. (The helpers' own fast lane already strips this tag; the proxy check just wasn't consistent with it.)

## Fix

1. `object/native_module.rs` — in `canonical_bound_method_receiver`, route a registered-proxy call-site `this` through, mirroring the #6475 closure-receiver case.
2. `object/field_get_set/get_field_by_name.rs` and `object/field_set_by_name.rs` — normalize the `0x7FFD` pointer tag before the proxy-id-band test so both encodings (raw small proxy id, and full tagged NaN-box) route to the proxy get/set trap.
3. `object/native_call_method.rs` — comment only (documents the IMPLICIT_THIS handoff).

General perry semantics, not a pi-specific patch: a class method invoked through any Proxy now runs with `this === proxy`, and `this.field` reads/writes route back through the proxy traps, matching node.

## Tests

`crates/perry/tests/issue_6699_proxy_class_method_this.rs` (2 tests, byte-identical to node v26):
- proxy → class-method get + `this`-identity (`theme.fg()` reads `this.fgColors` through the get trap; `this === proxy`, `typeof this === "object"`);
- proxy → class-method set (a proxy with a set trap; `this.count = this.count + 1` mutates the real instance through the traps).

`cargo test -p perry-runtime --lib -- --test-threads=1`: 1425 passed; the one failure (`gc::…::test_json_stringify_object_rederives_fields_after_tojson_minor_gc`) reproduces on unmodified `origin/main` and is unrelated (pre-existing/flaky). `cargo fmt --check` clean on touched files.

## How far pi's TUI gets now

Recompiled the accel-off bundle (`perry compile pi-noaccel.mjs`) and ran it under the PTY harness with a clean HOME:

- **Before:** crashed ~7.5s into init with `Cannot read properties of undefined (reading 'get')`.
- **After:** **no crash** (0 `(reading 'get')`, 0 `uncaughtException`); renders the **full onboarding screen** — banner, help line, "Pi can explain its own features", the "No models available — use `/login`" warning with docs paths, the "Update Available / New version 0.73.1" notice, borders, cwd, and status line — byte-for-byte the same visible content as node, and stays running until the harness timeout. (Raw byte counts 18,453 vs node's 23,733 differ only by redraw-frame timing within the capture window; visible content is identical.)

Fixes #6699

https://claude.ai/code/session_01JuiiePQfrXhAFD9fuCygB9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed class methods called through proxies so `this` correctly refers to the proxy.
  * Restored proper proxy interception for property reads and writes within class methods.
  * Prevented proxy receivers from being misidentified, which could cause incorrect results or corrupted `this` values.

* **Tests**
  * Added regression coverage for proxy-based class method property access and state updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->