### PR TITLE
fix(proxy): dispatch target [[IsExtensible]] in setPrototypeOf trap invariant (#5905)

### DIFF
--- a/crates/perry-runtime/src/json/stringify.rs
+++ b/crates/perry-runtime/src/json/stringify.rs
@@ -1237,6 +1237,25 @@ pub(crate) unsafe fn stringify_object_inner(ptr: *const u8, buf: &mut String, de
             }
         }
 
+        // `member_to_json` above may have run a user `toJSON` — a GC /
+        // evacuation point that moves the key string. The raw `key_ptr`
+        // captured before it is then dangling, so re-derive it from the rooted
+        // object header before the property name is written. Without this, a
+        // member whose `toJSON` forces a copying-minor GC (#5909's pre-key
+        // member probe) emitted a corrupted key
+        // (gc::tests …test_json_stringify_object_rederives_fields_after_tojson_minor_gc).
+        let key_ptr = if member_probed {
+            let kb = key_at(f).to_bits();
+            let kt = kb & 0xFFFF_0000_0000_0000;
+            if kt == STRING_TAG || kt == POINTER_TAG {
+                (kb & POINTER_MASK) as *const StringHeader
+            } else {
+                kb as *const StringHeader
+            }
+        } else {
+            key_ptr
+        };
+
         if !first {
             buf.push(',');
         }

--- a/crates/perry-runtime/src/proxy/prototype.rs
+++ b/crates/perry-runtime/src/proxy/prototype.rs
@@ -2,7 +2,7 @@
 //! entry point. Split out of `proxy.rs` to keep that file under the size gate.
 
 use super::{
-    call_trap, handler_trap, is_callable_function, lookup, nanbox_bool,
+    call_trap, handler_trap, is_callable_function, js_reflect_is_extensible, lookup, nanbox_bool,
     reflect_non_object_typeerror, reflect_target_get_prototype_of, reflect_value_is_object,
     revoked_return, throw_type_error, PROXIES, TAG_NULL, TAG_UNDEFINED,
 };
@@ -94,12 +94,21 @@ fn proxy_set_prototype_of(proxy_boxed: f64, proto: f64) -> f64 {
     if crate::value::js_is_truthy(trap_result) == 0 {
         return nanbox_bool(false);
     }
-    // Invariant: if the target is non-extensible, the proto must not change.
-    let target = target_h.get_nanbox_f64();
-    let proto = proto_h.get_nanbox_f64();
-    if crate::object::obj_value_no_extend(target) {
-        let current = reflect_target_get_prototype_of(target);
-        if current.to_bits() != proto.to_bits() {
+    // Invariant (ECMA-262 §10.5.2 steps 10-14): re-validate against the
+    // target's own `[[IsExtensible]]` / `[[GetPrototypeOf]]`. When the target
+    // is itself a Proxy these run ITS isExtensible / getPrototypeOf traps,
+    // which may observe state or throw — a bare `obj_value_no_extend` flag read
+    // dispatched neither, so the target-proxy's throwing trap never fired
+    // (test262 setPrototypeOf/return-abrupt-from-isextensible-target and
+    // return-abrupt-from-target-getprototypeof). An extensible target accepts
+    // the change; otherwise the new proto must SameValue the target's current
+    // proto. `reflect_target_get_prototype_of` already recurses through a proxy
+    // target's getPrototypeOf trap.
+    let extensible =
+        crate::value::js_is_truthy(js_reflect_is_extensible(target_h.get_nanbox_f64())) != 0;
+    if !extensible {
+        let current = reflect_target_get_prototype_of(target_h.get_nanbox_f64());
+        if current.to_bits() != proto_h.get_nanbox_f64().to_bits() {
             return throw_type_error(
                 "proxy setPrototypeOf trap violates non-extensible target invariant",
             );

--- a/crates/perry-runtime/src/proxy/prototype.rs
+++ b/crates/perry-runtime/src/proxy/prototype.rs
@@ -74,21 +74,26 @@ fn proxy_set_prototype_of(proxy_boxed: f64, proto: f64) -> f64 {
     if revoked {
         return revoked_return();
     }
-    let trap = handler_trap(handler, "setPrototypeOf");
-    let trap_bits = trap.to_bits();
-    if trap_bits == TAG_UNDEFINED || trap_bits == TAG_NULL {
-        // No trap — forward to the target's [[SetPrototypeOf]].
-        return js_reflect_set_prototype_of(target, proto);
-    }
-    if !is_callable_function(trap) {
-        return throw_type_error("proxy setPrototypeOf trap is not a function");
-    }
+    // Root target/proto/handler before `handler_trap`, which allocates a key
+    // string (and may fire a handler getter) — either can trigger a GC that
+    // evacuates these heap values. Rooted handles are rewritten on evacuation,
+    // so every read below stays valid across user code.
     let scope = crate::gc::RuntimeHandleScope::new();
     let target_h = scope.root_nanbox_f64(target);
     let proto_h = scope.root_nanbox_f64(proto);
+    let handler_h = scope.root_nanbox_f64(handler);
+    let trap_h = scope.root_nanbox_f64(handler_trap(handler_h.get_nanbox_f64(), "setPrototypeOf"));
+    let trap_bits = trap_h.get_nanbox_f64().to_bits();
+    if trap_bits == TAG_UNDEFINED || trap_bits == TAG_NULL {
+        // No trap — forward to the target's [[SetPrototypeOf]].
+        return js_reflect_set_prototype_of(target_h.get_nanbox_f64(), proto_h.get_nanbox_f64());
+    }
+    if !is_callable_function(trap_h.get_nanbox_f64()) {
+        return throw_type_error("proxy setPrototypeOf trap is not a function");
+    }
     let trap_result = call_trap(
-        handler,
-        trap,
+        handler_h.get_nanbox_f64(),
+        trap_h.get_nanbox_f64(),
         &[target_h.get_nanbox_f64(), proto_h.get_nanbox_f64()],
     );
     if crate::value::js_is_truthy(trap_result) == 0 {

--- a/scripts/check_file_size.sh
+++ b/scripts/check_file_size.sh
@@ -98,6 +98,23 @@ crates/perry-runtime/src/typed_feedback/tests.rs
 # JSON/pretty emitters + self-tests in one file). Splitting the emitters from
 # the schema they render obscures the report contract; revisit if it grows.
 crates/perry/src/commands/compile/lowering_report.rs
+# --- Grew a few lines past the gate on main (2026-07); each is a coupled
+# core whose split is a mechanical follow-up, allowlisted here to unblock the
+# required lint gate rather than fold an unrelated refactor into an in-flight
+# PR. Tracked under #1435. ---
+# HIR member-access lowering: the `Expr::Member` dispatch tree (per-builtin
+# static-method + property arms). 2049 lines; splitting the arm groups into
+# sibling modules is a mechanical follow-up.
+crates/perry-hir/src/lower/expr_member.rs
+# Runtime `js_native_call_method` dispatch trunk (2002 lines): the by-name
+# native method switch; the peeled arms already live in native_call_method/.
+crates/perry-runtime/src/object/native_call_method.rs
+# Inliner call-site rewriter (2056 lines): the single `CallInliner` pass with
+# its argument/return remapping tables threaded through one walker.
+crates/perry-transform/src/inline/call_inliner.rs
+# Windows UI widget registry (2118 lines): the Win32 widget create/dispatch
+# table; a per-widget-family split is a mechanical follow-up.
+crates/perry-ui-windows/src/widgets/mod.rs
 EOF
 )
 


### PR DESCRIPTION
## Summary

Part of the test262 `built-ins/Proxy` worklist (#5905). Fixes the two
`setPrototypeOf` return-abrupt cases, plus a couple of unrelated main-side CI
failures folded in at the maintainer's request (see the last two commits).

### 1. Proxy `setPrototypeOf` invariant (the #5905 fix)

After a Proxy's `setPrototypeOf` trap returns truthy, ECMA-262 §10.5.2 steps
10–14 re-validate against the target's **own internal methods** — `?
IsExtensible(target)` then `? target.[[GetPrototypeOf]]()`. Perry read a bare
`obj_value_no_extend` flag, which dispatches neither, so when the target is
itself a Proxy its `isExtensible` / `getPrototypeOf` traps never ran and the
abrupt completions the spec mandates were swallowed. Fix routes the
extensibility check through the trap-dispatching `js_reflect_is_extensible`
(the prototype read already recurses via `reflect_target_get_prototype_of`).
Second commit is a GC-rooting hardening from CodeRabbit review (root the trap
args before `handler_trap`).

Newly passing: `setPrototypeOf/return-abrupt-from-isextensible-target.js`,
`setPrototypeOf/return-abrupt-from-target-getprototypeof.js`. Proxy slice
228 → 230 pass, 0 regressions.

### 2. `fix(json)`: member-key stale pointer after a member `toJSON` GC

Fixes a **deterministic** main-side `cargo-test` failure
(`gc::tests::…test_json_stringify_object_rederives_fields_after_tojson_minor_gc`),
a regression from #6686. `stringify_object_inner` captured the raw key
`StringHeader*`, then ran the member's `toJSON` (user code → copying-minor GC
that moves the key string) before writing the property name, emitting a
corrupted key. Re-derives `key_ptr` from the rooted object after the probe.
Verified failing on clean `origin/main` and fixed.

### 3. `chore(lint)`: file-size allowlist

Four files crossed the 2000-line gate via unrelated merges on main
(expr_member.rs, native_call_method.rs, call_inliner.rs, ui-windows
widgets/mod.rs); allowlisted via the script's own mechanism to unblock the
required `lint` gate. None are touched by this PR.

## Not addressed here (main-side, owned elsewhere)

- **fmt drift + addr-class ratchet + conformance `test_gap_handle_band_object_ops`
  SIGSEGV** are one and the same main-side regression, already fixed by the
  dedicated **#6636** ("guard handle-band address sites flagged by the
  addr-class ratchet"), which touches the same files. I deliberately did **not**
  reformat those files (would conflict with #6636) or suppress the addr-class
  ratchet (that would mask the very Linux segfault #6636 fixes). These clear
  once #6636 lands and this branch rebases.
- **conformance shard-8 diffs** (`test_gap_stream_tee_tick_parity`,
  `test_gap_symbols`) are separate, unrelated main-side regressions.

Code-only PR (no version bump / changelog). Refs #5905.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
