### PR TITLE
fix(intl): built-in Intl functions have no own `prototype` (#5904)

### DIFF
--- a/crates/perry-runtime/src/intl.rs
+++ b/crates/perry-runtime/src/intl.rs
@@ -1553,6 +1553,13 @@ fn install_bound_instance_function(
     crate::closure::js_closure_set_capture_f64(closure, 0, js_nanbox_pointer(obj as i64));
     crate::object::set_bound_native_closure_name(closure, name);
     crate::object::set_builtin_closure_length(closure as usize, arity);
+    // A bound Intl instance method (`nf.format`, `nf.resolvedOptions`, …) is a
+    // built-in non-constructor function: it has NO `[[Construct]]` and therefore
+    // no own `prototype` property (ECMA-262 §17 — built-in functions that aren't
+    // constructors don't get the auto-created `.prototype`). Flag it so
+    // `function_would_have_own_prototype` / the `new` path treat it like any
+    // other builtin (`Math.max`), matching `format-function-builtin.js`.
+    crate::object::set_builtin_closure_non_constructable(closure as usize);
     crate::object::set_builtin_property_attrs(
         closure as usize,
         "name".to_string(),
@@ -1702,6 +1709,13 @@ fn install_function(
     }
     crate::object::set_bound_native_closure_name(closure, name);
     crate::object::set_builtin_closure_length(closure as usize, length);
+    // Intl prototype methods (`formatToParts`, `resolvedOptions`, …), the static
+    // `supportedLocalesOf`, and the this-based instance methods
+    // (`formatRange`/`formatRangeToParts`) installed through here are all
+    // built-in non-constructor functions: no `[[Construct]]`, hence no own
+    // `prototype` property (`builtin.js` asserts `hasOwnProperty("prototype")`
+    // is false and `isConstructor` is false). Flag them like any other builtin.
+    crate::object::set_builtin_closure_non_constructable(closure as usize);
     crate::object::set_builtin_property_attrs(
         closure as usize,
         "name".to_string(),

--- a/crates/perry-runtime/src/intl/install.rs
+++ b/crates/perry-runtime/src/intl/install.rs
@@ -64,6 +64,10 @@ pub(super) fn install_constructor(
         crate::closure::js_register_closure_arity(ptr, 0);
         crate::object::set_bound_native_closure_name(closure, &format!("get {getter_name}"));
         crate::object::set_builtin_closure_length(closure as usize, 0);
+        // The `get Intl.X.prototype.format` accessor is a built-in
+        // non-constructor function — no `[[Construct]]`, no own `prototype`
+        // property (`format/builtin.js` reads the getter and asserts both).
+        crate::object::set_builtin_closure_non_constructable(closure as usize);
         crate::object::set_builtin_property_attrs(
             closure as usize,
             "name".to_string(),

--- a/test-files/test_gap_intl_builtin_fn_no_prototype_5904.ts
+++ b/test-files/test_gap_intl_builtin_fn_no_prototype_5904.ts
@@ -1,0 +1,57 @@
+// #5904 — Intl builtin functions that aren't constructors must not have an own
+// `prototype` property, and must not be constructable (ECMA-262 §17: built-in
+// functions only get the auto-created `.prototype` when they implement
+// [[Construct]]). test262 intl402/NumberFormat/prototype/{format,formatRange,
+// formatRangeToParts,resolvedOptions}/builtin.js and supportedLocalesOf/
+// builtin.js all assert this on the NumberFormat method/getter functions.
+//
+// Perry created these via `js_closure_alloc` without flagging them
+// non-constructable, so `fn.hasOwnProperty("prototype")` lazily synthesized an
+// object (unlike `Math.max` / `Array.prototype.map`, which correctly report
+// false). Must match `node --experimental-strip-types` byte-for-byte.
+function isConstructor(f: unknown): boolean {
+  try {
+    Reflect.construct(function () {}, [], f as new () => unknown);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Assert the ECMA-262 §17 built-in-function surface for a non-constructor `fn`.
+function report(label: string, fn: unknown): void {
+  const f = fn as { hasOwnProperty(k: string): boolean };
+  console.log(label, "tag", Object.prototype.toString.call(fn));
+  console.log(label, "extensible", Object.isExtensible(fn as object));
+  console.log(label, "proto===Function.prototype", Object.getPrototypeOf(fn) === Function.prototype);
+  console.log(label, "hasOwn prototype", f.hasOwnProperty("prototype"));
+  console.log(label, "typeof .prototype", typeof (fn as { prototype?: unknown }).prototype);
+  console.log(label, "isConstructor", isConstructor(fn));
+}
+
+const nf = new Intl.NumberFormat("en-US");
+
+// The `format` accessor (getter) and the bound [[BoundFormat]] function.
+report("format getter", Object.getOwnPropertyDescriptor(Intl.NumberFormat.prototype, "format")!.get);
+report("bound format", nf.format);
+
+// Plain prototype methods.
+report("resolvedOptions", Intl.NumberFormat.prototype.resolvedOptions);
+report("formatToParts", Intl.NumberFormat.prototype.formatToParts);
+report("formatRange", Intl.NumberFormat.prototype.formatRange);
+report("formatRangeToParts", Intl.NumberFormat.prototype.formatRangeToParts);
+
+// Static method.
+report("supportedLocalesOf", Intl.NumberFormat.supportedLocalesOf);
+
+// The fix is shared across Intl services — spot-check DateTimeFormat + Collator.
+report("DTF resolvedOptions", Intl.DateTimeFormat.prototype.resolvedOptions);
+report("Collator supportedLocalesOf", Intl.Collator.supportedLocalesOf);
+
+// The constructor itself keeps [[Construct]] and its own `prototype`.
+console.log("ctor isConstructor", isConstructor(Intl.NumberFormat));
+console.log("ctor hasOwn prototype", Intl.NumberFormat.hasOwnProperty("prototype"));
+
+// Regression guard: the functions still work as callables.
+console.log("format works", nf.format(1234.5));
+console.log("resolvedOptions.locale", nf.resolvedOptions().locale);


### PR DESCRIPTION
## Summary

Part of the `intl402/NumberFormat` worklist (#5904). Fixes the largest coherent single-root subcluster: **built-in Intl functions must not have an own `prototype` property and must not be constructable.**

The `Intl.NumberFormat` method/getter/bound functions — the `format` accessor, the bound `[[BoundFormat]]` function, `resolvedOptions`, `formatToParts`, `formatRange`, `formatRangeToParts`, and the static `supportedLocalesOf` — were created via `js_closure_alloc` without being flagged non-constructable. That let `function_would_have_own_prototype` lazily synthesize a `.prototype` object for them and left them dynamically `new`-able, unlike ordinary built-ins (`Math.max`, `Array.prototype.map`) which correctly report `hasOwnProperty("prototype") === false` and `isConstructor === false`.

Per ECMA-262 §17, a built-in function only gets the auto-created `.prototype` when it implements `[[Construct]]`. The fix marks the closures created by the three shared Intl installation helpers as non-constructable — the same flag the native-module builtin methods already carry:

- `install_function` — prototype methods (`formatToParts`/`resolvedOptions`/…), the static `supportedLocalesOf`, and the this-based instance methods (`formatRange`/`formatRangeToParts`).
- `install_bound_instance_function` — the bound instance methods (`format`/`formatToParts`/`resolvedOptions`).
- the accessor-getter path in `install_constructor` — the `get …prototype.format` accessor.

The constructor closures themselves are untouched, so `new Intl.NumberFormat()` and `Reflect.construct(Intl.X, args, Custom)` still work.

## Tests fixed (test262, `intl402/NumberFormat`)

```
prototype/format/builtin.js
prototype/format/format-function-builtin.js
prototype/formatRange/builtin.js
prototype/formatRangeToParts/builtin.js
prototype/resolvedOptions/builtin.js
supportedLocalesOf/builtin.js
```

## Verification

Same-methodology A/B on the pinned test262 slice (`PERRY_NO_AUTO_OPTIMIZE=1`, one perry binary, base commit differing only by this edit):

- `intl402/NumberFormat`: **217 → 223 pass, 31 → 25 runtime-fail**. The 6 fixed cases are exactly the `builtin.js` cluster above.
- Full `intl402` slice: **3100 → 3120 pass, 228 → 208 runtime-fail, 0 → 0 diff, 2 → 2 compile-fail** — **20 cases fixed, zero regressions**. Because the fix lives in the shared installation helpers, the same class of assertion now passes across every Intl service:

  ```
  NumberFormat   6  (format builtin, format-function-builtin, formatRange,
                     formatRangeToParts, resolvedOptions, supportedLocalesOf)
  DateTimeFormat 6  (format, format-function, formatRange, formatRangeToParts,
                     resolvedOptions, supportedLocalesOf)
  Collator       3  (compare-function-builtin, resolvedOptions, supportedLocalesOf)
  PluralRules    2  (resolvedOptions, supportedLocalesOf)
  DurationFormat 2  (format not-a-constructor, formatToParts not-a-constructor)
  Intl           1  (supportedValuesOf builtin)
  ```

Added a per-PR-visible gap test (`test-files/test_gap_intl_builtin_fn_no_prototype_5904.ts`) that asserts the full ECMA-262 §17 surface (`[object Function]` tag, extensibility, `[[Prototype]] === Function.prototype`, no own `prototype`, not a constructor) for the NumberFormat functions plus `DateTimeFormat.prototype.resolvedOptions` and `Collator.supportedLocalesOf`; byte-identical to `node --experimental-strip-types`.

Code-only PR (no version bump / CHANGELOG / CLAUDE.md edit) per the worklist instructions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Intl built-in functions so they no longer expose an own `prototype` property when they are not constructable.
  * Aligned constructability behavior across Intl formatters, prototype methods, accessors, and locale utilities.
  * Preserved normal functionality for formatting, resolved options, and locale-related operations.

* **Tests**
  * Added regression coverage for Intl function descriptors, constructability, and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->