### PR TITLE
fix(compile): probe bare target/{release,debug} for --target macos on macOS host

### DIFF
--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -1940,11 +1940,15 @@ mod macos_host_candidate_tests {
     #[test]
     fn macos_target_probes_bare_target_dirs() {
         let cands = collect_library_candidates("libperry_ui_macos.a", Some("macos"));
-        // Triple-qualified dir is still searched...
+        // Triple-qualified dir is still searched — derive the triple from the
+        // same mapping the production code uses rather than hardcoding it, so
+        // this stays in sync if the `macos` → triple mapping ever changes.
+        let triple = super::rust_target_triple(Some("macos"))
+            .expect("macos target should resolve to a triple");
         assert!(
-            cands.contains(&PathBuf::from(
-                "target/aarch64-apple-darwin/release/libperry_ui_macos.a"
-            )),
+            cands.contains(&PathBuf::from(format!(
+                "target/{triple}/release/libperry_ui_macos.a"
+            ))),
             "missing triple dir in {cands:?}"
         );
         // ...and so is the bare host-native dir the suggested build command writes to.

--- a/crates/perry/src/commands/compile/library_search.rs
+++ b/crates/perry/src/commands/compile/library_search.rs
@@ -1018,6 +1018,18 @@ pub(super) fn collect_library_candidates(name: &str, target: Option<&str>) -> Ve
             candidates.push(PathBuf::from(format!("target/release/{}", name)));
             candidates.push(PathBuf::from(format!("target/debug/{}", name)));
         }
+        // #6716: `--target macos` on a macOS host is host-native, not a
+        // cross-compile — `cargo build --release -p perry-ui-macos` (the
+        // command the missing-UI-lib error suggests) writes to `target/release/`
+        // without the `aarch64-apple-darwin` triple subdir, so mirror the
+        // Windows/Linux branches above and probe the bare dirs too. Guarded on
+        // the host cfg so a genuine cross-compile to macOS (e.g. from Linux)
+        // still avoids picking up host-platform libs from `target/release/`.
+        #[cfg(target_os = "macos")]
+        if matches!(target, Some("macos")) {
+            candidates.push(PathBuf::from(format!("target/release/{}", name)));
+            candidates.push(PathBuf::from(format!("target/debug/{}", name)));
+        }
         // Also check directories relative to the perry executable.
         if let Ok(exe) = std::env::current_exe() {
             if let Some(dir) = exe.parent() {
@@ -1912,6 +1924,48 @@ mod llvm_tool_discovery_tests {
                 PathBuf::from("/usr/lib/llvm-17/bin"),
                 PathBuf::from("/usr/lib/llvm-16.0/bin"),
             ]
+        );
+    }
+}
+
+// #6716: `--target macos` on a macOS host is host-native — the candidate list
+// must probe the bare `target/{release,debug}/` dirs (where a plain
+// `cargo build -p perry-ui-macos` lands), while a genuine cross target keeps the
+// conservative triple-only search.
+#[cfg(all(test, target_os = "macos"))]
+mod macos_host_candidate_tests {
+    use super::collect_library_candidates;
+    use std::path::PathBuf;
+
+    #[test]
+    fn macos_target_probes_bare_target_dirs() {
+        let cands = collect_library_candidates("libperry_ui_macos.a", Some("macos"));
+        // Triple-qualified dir is still searched...
+        assert!(
+            cands.contains(&PathBuf::from(
+                "target/aarch64-apple-darwin/release/libperry_ui_macos.a"
+            )),
+            "missing triple dir in {cands:?}"
+        );
+        // ...and so is the bare host-native dir the suggested build command writes to.
+        assert!(
+            cands.contains(&PathBuf::from("target/release/libperry_ui_macos.a")),
+            "missing bare target/release in {cands:?}"
+        );
+        assert!(
+            cands.contains(&PathBuf::from("target/debug/libperry_ui_macos.a")),
+            "missing bare target/debug in {cands:?}"
+        );
+    }
+
+    #[test]
+    fn cross_target_keeps_conservative_search() {
+        // A real cross-compile (iOS) must NOT fall back to the host's bare
+        // target/release — that would risk linking a macOS lib into an iOS app.
+        let cands = collect_library_candidates("libperry_ui_ios.a", Some("ios"));
+        assert!(
+            !cands.contains(&PathBuf::from("target/release/libperry_ui_ios.a")),
+            "cross target unexpectedly probed bare target/release in {cands:?}"
         );
     }
 }


### PR DESCRIPTION
## Problem

Closes #6716.

On a macOS host, compiling a `perry/ui` app with `--target macos` fails to find `libperry_ui_macos.a` even after building it exactly as the error message instructs:

```
$ perry app.ts -o app --target macos
Error: perry/ui imported but libperry_ui_macos.a not found. Build with: cargo build --release -p perry-ui-macos
$ cargo build --release -p perry-ui-macos     # produces target/release/libperry_ui_macos.a
$ perry app.ts -o app --target macos
Error: perry/ui imported but libperry_ui_macos.a not found. …   # same error
```

`--target macos` maps to the `aarch64-apple-darwin` triple, so `collect_library_candidates` (`library_search.rs`) takes the cross-compile path and only probes triple-qualified dirs (`target/aarch64-apple-darwin/{release,debug}/`). The bare `target/{release,debug}/` dirs — where a plain `cargo build --release -p perry-ui-macos` actually lands the archive — are added **only** for the Windows and Linux host-native branches. There was no macOS equivalent, even though `--target macos` on a macOS host is exactly as host-native.

## Fix

Mirror the existing Windows/Linux host-native branches: on a macOS host (`#[cfg(target_os = "macos")]`) with `--target macos`, also probe `target/{release,debug}/`. This makes the command the error message suggests actually satisfy the search (issue's option 1, "matches what the other host platforms already do").

The `#[cfg]` guard keeps the search conservative for a genuine cross-compile to macOS (e.g. from Linux), where `target/release/` would hold host-platform libs — those builds still see triple-only candidates.

## Tests

Added `macos_host_candidate_tests` (macOS-gated):
- `macos_target_probes_bare_target_dirs` — `--target macos` yields both the triple dir **and** the bare `target/{release,debug}/` candidates.
- `cross_target_keeps_conservative_search` — `--target ios` does **not** add the host's bare `target/release/`.

Full `library_search` module suite (16 tests) passes; `cargo fmt --check` and the 2000-line file-size gate are clean.

_No version bump / changelog per maintainer convention (folded in at merge)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved macOS native builds by also searching host-native `target/release`/`target/debug` directories in addition to the usual triple-qualified paths.
  - Ensured cross-compilation (e.g., iOS from a non-matching target) does not mistakenly fall back to macOS host directories.
- **Tests**
  - Added macOS-only test coverage to confirm native macOS discovery includes both candidate directory styles, while cross targets do not probe the host-native ones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->