### PR TITLE
diagnose: async-generator `await` on a pending Promise deadlocks (busy-wait, no suspend) — pi interactive Enter-submit divergence (#6709)

### DIFF
--- a/crates/perry/tests/issue_6709_async_generator_pending_await.rs
+++ b/crates/perry/tests/issue_6709_async_generator_pending_await.rs
@@ -1,0 +1,176 @@
+//! Regression test for #6709: `await` on a *pending* Promise inside an
+//! `async function*` (async generator) must SUSPEND the generator and return
+//! control to the caller — not busy-wait.
+//!
+//! ## Root cause
+//!
+//! `crates/perry-transform/src/async_to_generator.rs` — the pass that rewrites
+//! every `await` into a state-machine suspend point (`await` → yield → an
+//! `AsyncStepChain` continuation via `Promise.resolve(x).then(step)`, so the
+//! function returns a pending Promise and the rest of the body runs on the
+//! microtask queue) — is a **no-op for generators**:
+//!
+//! ```ignore
+//! if !func.is_async || func.is_generator {   // async_to_generator.rs:89
+//!     return;
+//! }
+//! ```
+//!
+//! So an `async function*` keeps its `Expr::Await` nodes un-rewritten, and they
+//! lower via the *busy-wait poll loop* in
+//! `crates/perry-codegen/src/expr/fs_await.rs` (`js_await_any_promise` +
+//! `js_promise_run_microtasks_await_loop` + `js_await_loop_tick_timers`, spun
+//! until the awaited Promise settles).
+//!
+//! That poll loop never returns to the caller. When the awaited Promise is
+//! *pending* and can only be settled by code that runs **after** `.next()`
+//! returns (the classic push/pull async-iterator: the generator awaits
+//! `new Promise(r => this.waiting.push(r))` and a later `push()` calls `r`),
+//! `.next()` busy-waits forever on a Promise nobody can resolve → **deadlock**.
+//! The event loop then drains and prints "Detected unsettled top-level await".
+//!
+//! Already-resolved awaits (`await Promise.resolve(x)`) and yield-only async
+//! generators work — the poll loop sees the Promise settled immediately — so
+//! this is specific to *pending* awaits.
+//!
+//! ## Impact (the reported symptom)
+//!
+//! pi's interactive TUI wires agent → session → UI events through a hand-rolled
+//! `EventStream` async generator (`for await (const event of stream)` on the
+//! consumer side, `stream.push(event)` on the producer side, the generator
+//! `await`ing `new Promise(r => waiting.push(r))`). Under perry the async
+//! generator deadlocks on the first pending `await`, so `agent_start` /
+//! `message_*` / the 401 `error` events never reach the UI subscriber: pressing
+//! Enter runs the whole submit → `session.prompt` → `agent.prompt` chain (the
+//! HTTP request even fires) but no "Working…" and no error ever render. Node,
+//! running the identical bundle, submits and shows the 401.
+//!
+//! ## The fix (scoped follow-up)
+//!
+//! Make `async function*` bodies suspend on `await` like plain async functions:
+//! split the generator state machine at `await` points (distinct from consumer
+//! `yield` points) and drive them through the existing `AsyncStepChain`
+//! async-step machinery, so `.next()` returns a pending Promise immediately and
+//! resumes on the microtask queue when the awaited Promise settles. This
+//! touches the async generator lowering (`generator/lower.rs`,
+//! `generator/linearize.rs`) + the `Expr::Yield` discriminator and must be
+//! validated against the full async-generator test262 suite; it is intentionally
+//! not squeezed into this diagnosis change.
+//!
+//! `#[ignore]`d until that fix lands (the buggy runtime deadlocks; the test uses
+//! a hard timeout so it fails deterministically rather than hanging).
+
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+/// Minimal push/pull async-iterator (the shape pi's `EventStream` uses): an
+/// async generator that `await`s a Promise resolved by a later `push()`.
+const FIXTURE: &str = r#"
+const log = (m) => process.stderr.write(m + "\n");
+class EventStream {
+  queue = []; waiting = []; done = false;
+  push(event) {
+    if (this.done) return;
+    const waiter = this.waiting.shift();
+    if (waiter) { waiter({ value: event, done: false }); }
+    else { this.queue.push(event); }
+  }
+  end() { this.done = true; while (this.waiting.length > 0) { const w = this.waiting.shift(); w({ value: void 0, done: true }); } }
+  async *[Symbol.asyncIterator]() {
+    while (true) {
+      if (this.queue.length > 0) { yield this.queue.shift(); }
+      else if (this.done) { return; }
+      else {
+        const result = await new Promise((resolve) => this.waiting.push(resolve));
+        if (result.done) return;
+        yield result.value;
+      }
+    }
+  }
+}
+async function main() {
+  const s = new EventStream();
+  const consumer = (async () => { for await (const e of s) { log("GOT " + e.type); } })();
+  await Promise.resolve(); await Promise.resolve();
+  s.push({ type: "agent_start" });
+  s.push({ type: "turn_start" });
+  await Promise.resolve(); await Promise.resolve();
+  s.push({ type: "message_start" });
+  await Promise.resolve(); await Promise.resolve();
+  s.end();
+  await consumer;
+  log("done");
+}
+main().then(() => log("main:resolved"));
+"#;
+
+/// Node v26 output (stderr), for reference:
+///   GOT agent_start
+///   GOT turn_start
+///   GOT message_start
+///   done
+///   main:resolved
+const EXPECTED: &str = "GOT agent_start\nGOT turn_start\nGOT message_start\ndone\nmain:resolved\n";
+
+#[test]
+#[ignore = "unfixed #6709: async-generator `await` on a pending Promise busy-waits (deadlocks) \
+            instead of suspending; needs the async-generator await-suspension fix"]
+fn async_generator_pending_await_suspends_not_deadlocks() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let entry = dir.path().join("main.mjs");
+    let output = dir.path().join("main_bin");
+    std::fs::write(&entry, FIXTURE).unwrap();
+
+    let status = Command::new(perry_bin())
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .status()
+        .expect("perry compile");
+    assert!(status.success(), "compile failed");
+
+    // Run with a hard timeout — the buggy runtime deadlocks, so poll for exit
+    // and drain stderr on a reader thread (a pipe can't be read after the child
+    // is reaped by `try_wait`).
+    let mut child = Command::new(&output)
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn");
+    let mut stderr_pipe = child.stderr.take().expect("stderr pipe");
+    let reader = std::thread::spawn(move || {
+        let mut buf = String::new();
+        let _ = stderr_pipe.read_to_string(&mut buf);
+        buf
+    });
+    let start = Instant::now();
+    let mut deadlocked = false;
+    loop {
+        if child.try_wait().expect("try_wait").is_some() {
+            break;
+        }
+        if start.elapsed() > Duration::from_secs(10) {
+            let _ = child.kill();
+            let _ = child.wait();
+            deadlocked = true;
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    let stderr = reader.join().expect("reader join");
+    assert!(
+        !deadlocked,
+        "async generator deadlocked (never exited) — pending await busy-waited; got so far: {stderr:?}"
+    );
+    assert_eq!(
+        stderr, EXPECTED,
+        "async generator output diverged from node"
+    );
+}


### PR DESCRIPTION
## Root cause

`async function*` bodies **do not suspend on `await`** — they busy-wait, and deadlock when the awaited Promise is resolved by an ancestor stack frame.

`crates/perry-transform/src/async_to_generator.rs` — the pass that turns every `await` into a state-machine suspend point (rewrites `await`→yield and drives it through `AsyncStepChain` = `Promise.resolve(x).then(step)`, so an async function returns a pending Promise and resumes on the microtask queue) — is a **no-op for generators**:

```rust
// async_to_generator.rs:89
if !func.is_async || func.is_generator {
    return;
}
```

So an `async function*` keeps its `Expr::Await` nodes un-rewritten, and they lower via the **busy-wait poll loop** in `crates/perry-codegen/src/expr/fs_await.rs` (`js_await_any_promise` + `js_promise_run_microtasks_await_loop` + `js_await_loop_tick_timers`, spun until the awaited Promise settles).

That poll loop **never returns to the caller**. When the awaited Promise is *pending* and can only be settled by code that runs **after** `.next()` returns — the classic push/pull async iterator, where the generator awaits `new Promise(r => waiting.push(r))` and a later `push()` calls `r` — `.next()` busy-waits forever on a Promise nobody can resolve → **deadlock** (the event loop then drains and prints `Detected unsettled top-level await`).

Already-resolved awaits (`await Promise.resolve(x)`) and yield-only async generators work (the poll loop sees the Promise settled immediately), so this is specific to **pending** awaits.

## Minimal reproduction (node-vs-perry)

`crates/perry/tests/issue_6709_async_generator_pending_await.rs` compiles a minimal push/pull async iterator (an `EventStream` async generator that `await`s a Promise resolved by a later `push()`), added `#[ignore]`d with a hard timeout so it fails deterministically instead of hanging.

```
$ node repro.mjs           $ ./perry-compiled-repro
GOT agent_start            (hangs)
GOT turn_start             Warning: Detected unsettled top-level await
GOT message_start
done
main:resolved
```

Even reduced to a bare async generator, `it.next()` never returns when the body suspends at a pending `await`:

```js
async function* gen() { console.error("gen:start"); const v = await new Promise(r => { resolver = r; }); console.error("gen:got"); yield v; }
const it = gen();
const p = it.next();               // node: returns a pending Promise; perry: never returns
console.error("after-next");       // node prints this; perry deadlocks before it
```

## Impact (the reported symptom)

pi's interactive TUI routes agent → session → UI events through a hand-rolled `EventStream` **async generator** (`for await (const event of stream)` on the consumer side; `stream.push(event)` on the producer side; the generator `await`s `new Promise(r => waiting.push(r))`). Under perry the async generator deadlocks on the first pending `await`, so **no agent events** (`agent_start`, `message_*`, the 401 `error`) ever reach the UI subscriber.

Instrumenting the actual pi bundle confirmed this precisely: pressing Enter runs the **entire** submit → `session.prompt` → `agent.prompt` → `runAgentLoop` chain (the HTTP request even fires — probe `@@SAR before streamFunction`), but the event-forwarding async generator delivers **nothing** to the session subscriber (probe `@@HAE` never fires; only the session's own `agent_settled`, emitted outside the stream, arrives). So no "Working…", no request result, no 401 renders. Node, running the identical bundle, submits and shows the 401. `-p` one-shot mode is byte-identical to node because it consumes the stream with a **synchronous** subscriber path that doesn't hit the deadlocking async-generator await pattern the interactive path does.

## The fix (scoped follow-up — intentionally not in this change)

Make `async function*` bodies suspend on `await` like plain async functions: the generator state machine must split at `await` points (distinct from consumer `yield` points) and drive them through the existing `AsyncStepChain` async-step machinery (or a queue-level await-marker), so `.next()` returns a pending Promise immediately and resumes on the microtask queue when the awaited Promise settles. This touches the async-generator lowering (`generator/lower.rs`, `generator/linearize.rs`), a `yield`-vs-`await` discriminator, and the `async_generator_queue` driver, and must be validated against the full async-generator test262 suite (try/catch/finally across awaits, `yield*`, `.return()`/`.throw()` while suspended mid-await). It is deliberately left as a follow-up rather than squeezed into this diagnosis to avoid an under-validated change to the async-generator runtime.

Refs #6709

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a regression test covering async generators awaiting unresolved Promises.
  * Verifies generators suspend correctly, return control to the caller, and avoid hangs.
  * Confirms output matches expected runtime behavior with a watchdog timeout.
  * Test is currently disabled pending implementation of the underlying fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->