### PR TITLE
fix(native): genuine module export wins over derived ergonomic alias (#6715)

### DIFF
--- a/crates/perry/src/commands/compile/run_pipeline.rs
+++ b/crates/perry/src/commands/compile/run_pipeline.rs
@@ -2742,10 +2742,33 @@ pub fn run_with_parse_cache(
                             .iter()
                             .find(|f| f.name == exported_name)
                             .map(|f| f.name.clone());
+                        // Issue #6715: a REAL module export wins over a derived
+                        // ergonomic alias. The `js_<pkg>_<snake>` ⇒ camelCase
+                        // routing (#5621) is a convenience for packages whose
+                        // `.ts` only holds ambient `export declare function`
+                        // signatures (no body) — those are skipped at lowering
+                        // (`module_decl.rs`: `body.is_none()`), so they never
+                        // enter `all_module_exports`. But the documented wrapper
+                        // convention (native-extensions.md) is an ambient
+                        // `declare function js_<pkg>_speak(...)` PLUS a real
+                        // `export async function speak(...)` that transforms args
+                        // and calls the FFI symbol. When such a wrapper's name
+                        // collides with a manifest symbol's derived alias
+                        // (`js_speech_speak` → `speak`), the alias must NOT
+                        // shadow it — the import binds to the wrapper, which the
+                        // module emits a `perry_fn_<pkg>__speak` symbol for and
+                        // the fall-through named-import path registers below.
+                        // Only genuine, implemented value exports land here, so
+                        // ambient-declare-only packages keep the #5621 routing.
+                        let has_genuine_module_export = all_module_exports
+                            .get(&resolved_path_str)
+                            .is_some_and(|exports| exports.contains_key(&exported_name));
                         // Collect ALL ergonomic matches so an ambiguous manifest
                         // (two symbols deriving the same camelCase binding) is
                         // rejected rather than silently bound to the first.
-                        let ergonomic_matches: Vec<String> = if exact_symbol.is_some() {
+                        let ergonomic_matches: Vec<String> = if exact_symbol.is_some()
+                            || has_genuine_module_export
+                        {
                             Vec::new()
                         } else {
                             nl.functions

--- a/crates/perry/tests/issue_6715_native_wrapper_precedence.rs
+++ b/crates/perry/tests/issue_6715_native_wrapper_precedence.rs
@@ -1,26 +1,29 @@
-//! Issue #5621: a `perry.nativeLibrary` package that exposes an ergonomic
-//! camelCase binding (`doThing`) over a snake_case `js_<pkg>_*` FFI symbol
-//! (`js_foo_do_thing`) via an ambient `export declare function` must route
-//! the call to the native symbol — there is no wrapper body to run.
+//! Issue #6715: a `perry.nativeLibrary` package whose `src/index.ts`
+//! exports a REAL wrapper function whose name equals the derived ergonomic
+//! alias (#5621) of one of its manifest symbols must run the wrapper — the
+//! derived alias must NOT silently shadow it and bind the import straight to
+//! the FFI symbol.
 //!
-//! Before the #5621 fix, Perry only routed a native-library import to its
-//! FFI symbol when the import binding was byte-for-byte equal to the
-//! manifest symbol name (the `@perryts/storekit` raw-ambient-export
-//! convention). An ergonomic camelCase binding never matched, so the link
-//! failed on the missing `perry_fn_<foo>__doThing` wrapper symbol.
+//! The documented convention (`docs/src/plugins/native-extensions.md`) is an
+//! ambient `declare function js_<pkg>_speak(...)` for the raw FFI symbol PLUS
+//! a real `export function speak(...)` that transforms arguments and calls
+//! the native function. When `<pkg>` happens to make the manifest symbol
+//! follow `js_<pkg>_<snake>` (`js_foo_do_thing`), its derived alias
+//! (`doThing`) collides with the wrapper's name. Before the fix Perry bound
+//! the import to the FFI symbol, so the wrapper body was dead code and the
+//! caller's arguments were passed raw to the native ABI — a silent failure
+//! ("await never resolves") three layers from the cause.
 //!
-//! Issue #6715 refined the rule: the ergonomic alias is a convenience for
-//! packages that only export ambient `declare` signatures. A *genuine*
-//! implemented export of the same name wins over the derived alias (covered
-//! by `issue_6715_native_wrapper_precedence.rs`). This test therefore
-//! exercises the ambient-declare form, which is the case the alias exists
-//! for: `export declare function doThing(): number;` has no body, is
-//! skipped at lowering, and so is resolved purely through the manifest.
+//! After the fix a genuine, implemented module export wins over the derived
+//! alias. Ambient-declare-only packages (no body) keep the #5621 routing
+//! (covered by `issue_5621_native_camel_export_routing.rs`).
 //!
 //! This test links a real one-function static archive (`js_foo_do_thing`
 //! → `42`) via the manifest's `prebuilt` field, then asserts the compiled
-//! program prints `42` — only possible if `doThing()` reached the native
-//! symbol through the ergonomic alias.
+//! program (1) prints the wrapper's side-effect marker and (2) prints the
+//! wrapper's TRANSFORMED result (`42 + 1 == 43`) — neither is possible if
+//! the import bound directly to the FFI symbol (which would print no marker
+//! and yield the raw `42`).
 
 #![cfg(unix)]
 
@@ -79,14 +82,14 @@ fn build_static_lib(pkg_dir: &Path) -> Option<PathBuf> {
 }
 
 #[test]
-fn camel_case_native_export_routes_to_ffi_symbol() {
+fn real_wrapper_wins_over_derived_alias() {
     let dir = tempfile::tempdir().expect("tempdir");
     let root = dir.path();
 
-    // The native-library package: an ambient camelCase `doThing` surface
-    // over the `js_foo_do_thing` FFI symbol. `export declare function` has
-    // NO body, so there is nothing to run — the binding resolves purely
-    // through the manifest's ergonomic alias to the native symbol.
+    // The native-library package: an ambient `declare` for the raw FFI
+    // symbol PLUS a real `doThing` wrapper that logs a marker and transforms
+    // the native return value. `doThing` collides with the derived alias of
+    // `js_foo_do_thing` — the wrapper must win.
     let pkg_dir = root.join("node_modules/foo");
     std::fs::create_dir_all(pkg_dir.join("src")).expect("mkdir pkg src");
 
@@ -97,7 +100,13 @@ fn camel_case_native_export_routes_to_ffi_symbol() {
 
     std::fs::write(
         pkg_dir.join("src/index.ts"),
-        r#"export declare function doThing(): number;
+        r#"export declare function js_foo_do_thing(): number;
+
+// Same name as the derived alias of `js_foo_do_thing` → "doThing".
+export function doThing(): number {
+  console.log("wrapper ran");
+  return js_foo_do_thing() + 1;
+}
 "#,
     )
     .expect("write pkg index.ts");
@@ -126,7 +135,7 @@ fn camel_case_native_export_routes_to_ffi_symbol() {
     )
     .expect("write pkg package.json");
 
-    // Host project: allow the native library and import the camelCase API.
+    // Host project: allow the native library and import the wrapper API.
     std::fs::write(
         root.join("package.json"),
         r#"{
@@ -171,11 +180,21 @@ console.log("result:", doThing());
     let stderr = String::from_utf8_lossy(&run.stderr);
     assert!(
         run.status.success(),
-        "binary aborted — the ambient camelCase binding failed to route to \
-         js_foo_do_thing\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        "binary aborted\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
+    // The wrapper's side effect proves it executed — under the bug the import
+    // bound straight to the FFI symbol and this marker never printed.
     assert!(
-        stdout.contains("result: 42"),
-        "expected the native FFI symbol's return value (42)\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        stdout.contains("wrapper ran"),
+        "the wrapper body never ran — the derived alias shadowed the real \
+         `doThing` export\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    // The wrapper's transformed result (native 42 + 1) proves both that the
+    // wrapper ran AND that it reached the native symbol internally. A raw
+    // `42` here would mean the import bound directly to the FFI symbol.
+    assert!(
+        stdout.contains("result: 43"),
+        "expected the wrapper's transformed result (43), not the raw FFI \
+         value (42)\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
 }

--- a/docs/src/plugins/native-extensions.md
+++ b/docs/src/plugins/native-extensions.md
@@ -147,6 +147,33 @@ export async function requestReview(): Promise<void> {
 
 `declare function` tells Perry the function is provided by native code. The raw return type is `number` because all values cross the FFI boundary as NaN-boxed `f64` values. Promise handles are NaN-boxed pointers that Perry's runtime knows how to `await`.
 
+#### Ergonomic aliases and the wrapper-name collision rule
+
+For manifest symbols that follow the `js_<pkg>_<snake_case>` convention (where `<pkg>` is the sanitized last segment of the package name), Perry derives an **ergonomic camelCase alias** so consumers can import a spec-faithful name without you writing any wrapper (issue #5621). For `@perryts/webgpu` a manifest symbol `js_webgpu_request_adapter` is importable as `requestAdapter`:
+
+```ts
+// The package's src/index.ts only ambient-declares the raw symbols…
+export declare function js_webgpu_request_adapter(): Promise<number>;
+
+// …and consumers import the derived alias:
+import { requestAdapter } from "@perryts/webgpu"; // → js_webgpu_request_adapter
+```
+
+The alias is a convenience **for packages that only export ambient `declare` signatures**. A *genuine* implemented export always wins over a derived alias (issue #6715): if your `src/index.ts` also exports a real wrapper whose name equals a manifest symbol's derived alias, the import binds to **your wrapper**, not the FFI symbol — your wrapper code runs, and it can call the raw symbol internally:
+
+```ts
+export declare function js_speech_speak(
+  text: string, rate: number, pitch: number, locale: string, voiceId: string): Promise<number>;
+
+// `speak` is the derived alias of `js_speech_speak` — this real wrapper WINS.
+export async function speak(text: string, options?: { rate?: number }): Promise<boolean> {
+  const rate = options?.rate ?? -1;
+  return (await js_speech_speak(text, rate, -1, "", "")) !== 0;
+}
+```
+
+> **Recommended convention.** If you write real wrapper logic (options objects, JSON parsing, bool coercion) around your externs, name the manifest symbols `js_<pkg>_native_<snake>` so their derived aliases become `nativeSpeak`, `nativeDoThing`, etc. — names your package simply doesn't re-export. This keeps the aliases out of your public namespace and removes any chance of a wrapper/alias name clash. If two manifest symbols ever derive the *same* alias, Perry reports a hard compile error rather than binding to one silently.
+
 ### Rust side
 
 Each platform crate is a `staticlib` that implements the declared functions using `#[no_mangle] pub extern "C"`:


### PR DESCRIPTION
## Summary

Fixes #6715. A `perry.nativeLibrary` package whose `src/index.ts` exports a **real wrapper function** whose name equals the derived ergonomic alias (#5621) of one of its manifest symbols was **silently shadowed** — the import bound to the FFI symbol, the wrapper became dead code, and the caller's arguments were passed raw to the native ABI. The reported symptom was an `await` that hangs forever, three layers from the cause, with zero diagnostics.

## Root cause

The `js_<pkg>_<snake>` ⇒ camelCase ergonomic routing was applied to **any** import binding that matched a manifest symbol's derived alias, without checking whether the package actually implements an export of that name. So for a `@perryts/speech`-shaped package:

```ts
export declare function js_speech_speak(text: string, rate: number, /* … */): Promise<number>;

// `speak` is the derived alias of `js_speech_speak` — this real wrapper was shadowed.
export async function speak(text: string, options?: { rate?: number }): Promise<boolean> {
  const rate = options?.rate ?? -1;
  return (await js_speech_speak(text, rate, -1, "", "")) !== 0;
}
```

`import { speak }` bound straight to `js_speech_speak`, and `speak`'s body never ran.

## Fix (Expected option 1 from the issue)

A **genuine, implemented module export wins over the derived alias.** The ergonomic alias is a convenience for packages that only export ambient `declare function` signatures — those have no body, so lowering skips them (`module_decl.rs`: `body.is_none()`) and they never enter `all_module_exports`. A real value export does. So the ergonomic-alias routing is now gated on the source module **not** having a genuine export of the imported name; when it does, the import falls through to the normal named-import path and binds to the wrapper's `perry_fn_<pkg>__<name>` symbol (which the module actually emits).

The exact-match raw-ambient convention (`@perryts/storekit`, import by the literal `js_*` name) is unchanged, and ambient-declare-only packages keep the #5621 FFI routing.

This is the documented wrapper pattern in `docs/src/plugins/native-extensions.md` (ambient `declare` for the raw symbol + a real `export` wrapper that calls it) — it just wasn't safe when the manifest symbol happened to follow `js_<pkg>_<snake>` and the wrapper name collided with the derived alias.

## Changes

- **`run_pipeline.rs`** — suppress the ergonomic alias when a genuine module export of the imported name exists (`has_genuine_module_export`).
- **`issue_6715_native_wrapper_precedence.rs`** *(new)* — links a real `js_foo_do_thing → 42` archive; asserts a real `doThing` wrapper runs (prints its marker) and returns the transformed value `43`, not the raw FFI `42`.
- **`issue_5621_native_camel_export_routing.rs`** — switched to the ambient `declare` form, which is the case the ergonomic alias legitimately exists for. Its old throwing-body form asserted the exact behavior this change corrects.
- **`docs/src/plugins/native-extensions.md`** — documents the collision rule and recommends the `js_<pkg>_native_*` symbol convention for packages that ship real wrapper logic (the Docs ask in the issue).

## Testing

- `cargo test -p perry --test issue_6715_native_wrapper_precedence` ✅ (real wrapper wins → `43`)
- `cargo test -p perry --test issue_5621_native_camel_export_routing` ✅ (ambient declare → FFI `42`)
- `cargo test -p perry --bins ergonomic` ✅ (8 `ergonomic_alias_tests`, incl. storekit exact-match)
- `cargo fmt -p perry --check` and `scripts/check_file_size.sh` clean.

No version bump or changelog entry (per request — maintainer folds those in at merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved native extension imports using ergonomic camelCase aliases derived from manifest symbols.
  * Real wrapper exports now take precedence over generated aliases, ensuring custom wrapper logic runs correctly.
  * Ambiguous generated aliases continue to produce a clear compile-time error.

* **Documentation**
  * Added guidance on native symbol naming, camelCase aliases, ambient declarations, wrapper precedence, and avoiding alias collisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->