### PR TITLE
chore(lint): recover main lint — rustfmt #6712 drift + allowlist regex/grammar.rs (#6711)

### DIFF
--- a/crates/perry-runtime/src/json/parser.rs
+++ b/crates/perry-runtime/src/json/parser.rs
@@ -368,7 +368,8 @@ impl<'a> DirectParser<'a> {
         // Initialize all fields to undefined so JSON with missing
         // fields returns `undefined` for absent properties (matches
         // spec: access to absent own property returns undefined).
-        let alloc_field_count = std::cmp::max(shape.field_count as usize, crate::object::INLINE_SLOT_FLOOR);
+        let alloc_field_count =
+            std::cmp::max(shape.field_count as usize, crate::object::INLINE_SLOT_FLOOR);
         for i in 0..alloc_field_count {
             let fields_ptr =
                 (js_obj as *mut u8).add(std::mem::size_of::<crate::ObjectHeader>()) as *mut JSValue;
@@ -657,7 +658,8 @@ impl<'a> DirectParser<'a> {
             self.parse_shape_keys_array_hot(&inline_keys[..inline_len])
         };
         let js_obj = crate::object::js_object_alloc_class_inline_keys(0, 0, field_count, keys_arr);
-        let alloc_field_count = std::cmp::max(field_count as usize, crate::object::INLINE_SLOT_FLOOR);
+        let alloc_field_count =
+            std::cmp::max(field_count as usize, crate::object::INLINE_SLOT_FLOOR);
         let fields_ptr =
             (js_obj as *mut u8).add(std::mem::size_of::<crate::ObjectHeader>()) as *mut JSValue;
         for i in 0..alloc_field_count {

--- a/crates/perry-runtime/src/object/alloc.rs
+++ b/crates/perry-runtime/src/object/alloc.rs
@@ -688,7 +688,10 @@ pub unsafe extern "C" fn js_object_clone_with_extra(
     // Physical slot capacity: src_field_count + extra_count, but at least max(fc, 8) to match
     // js_object_set_field's alloc_limit check. Extra slots are scratch space for subsequent
     // js_object_set_field_by_name calls.
-    let phys_slots = std::cmp::max(src_field_count + extra_count, crate::object::INLINE_SLOT_FLOOR as u32);
+    let phys_slots = std::cmp::max(
+        src_field_count + extra_count,
+        crate::object::INLINE_SLOT_FLOOR as u32,
+    );
     let total_size = header_size + phys_slots as usize * 8;
     let new_ptr = arena_alloc_gc(total_size, 8, crate::gc::GC_TYPE_OBJECT) as *mut ObjectHeader;
     (*new_ptr).object_type = crate::error::OBJECT_TYPE_REGULAR;

--- a/crates/perry-runtime/src/object/arguments.rs
+++ b/crates/perry-runtime/src/object/arguments.rs
@@ -558,7 +558,8 @@ unsafe fn read_ordinary_own_value(
 ) -> JSValue {
     let keys = (*obj).keys_array;
     let key_count = crate::array::js_array_length(keys) as usize;
-    let alloc_limit = std::cmp::max((*obj).field_count, crate::object::INLINE_SLOT_FLOOR as u32) as usize;
+    let alloc_limit =
+        std::cmp::max((*obj).field_count, crate::object::INLINE_SLOT_FLOOR as u32) as usize;
     for i in 0..key_count {
         let key_val = crate::array::js_array_get(keys, i as u32);
         if crate::string::js_string_key_matches(key_val, key) {
@@ -580,7 +581,8 @@ unsafe fn write_ordinary_own_value(
 ) {
     let keys = (*obj).keys_array;
     let key_count = crate::array::js_array_length(keys) as usize;
-    let alloc_limit = std::cmp::max((*obj).field_count, crate::object::INLINE_SLOT_FLOOR as u32) as usize;
+    let alloc_limit =
+        std::cmp::max((*obj).field_count, crate::object::INLINE_SLOT_FLOOR as u32) as usize;
     for i in 0..key_count {
         let key_val = crate::array::js_array_get(keys, i as u32);
         if crate::string::js_string_key_matches(key_val, key) {

--- a/crates/perry-runtime/src/object/field_get_set/accessors.rs
+++ b/crates/perry-runtime/src/object/field_get_set/accessors.rs
@@ -94,7 +94,8 @@ pub(crate) unsafe fn own_data_field_by_name(
     if key_count > 65536 {
         return None;
     }
-    let alloc_limit = std::cmp::max((*obj).field_count, crate::object::INLINE_SLOT_FLOOR as u32) as usize;
+    let alloc_limit =
+        std::cmp::max((*obj).field_count, crate::object::INLINE_SLOT_FLOOR as u32) as usize;
     for i in 0..key_count {
         let key_val = crate::array::js_array_get(keys, i as u32);
         // #1781: accept inline SSO short keys — `is_string()` is

--- a/crates/perry-runtime/src/object/field_get_set/field_ops.rs
+++ b/crates/perry-runtime/src/object/field_get_set/field_ops.rs
@@ -125,7 +125,8 @@ pub extern "C" fn js_object_set_field(obj: *mut ObjectHeader, field_index: u32, 
         // We use a generous limit of max(field_count, 8) to avoid false positives from
         // js_object_alloc_with_shape's extra padding while still catching real overflows.
         let stored_field_count = (*obj).field_count;
-        let alloc_limit = std::cmp::max(stored_field_count, crate::object::INLINE_SLOT_FLOOR as u32);
+        let alloc_limit =
+            std::cmp::max(stored_field_count, crate::object::INLINE_SLOT_FLOOR as u32);
         if field_index >= alloc_limit {
             eprintln!(
                 "[PERRY WARN] js_object_set_field: OOB write field_index={} alloc_limit={} (field_count={}) obj={:p} class_id={}",
@@ -278,7 +279,8 @@ pub extern "C" fn js_object_set_unboxed_f64_field(
             return;
         }
         let stored_field_count = (*obj).field_count;
-        let alloc_limit = std::cmp::max(stored_field_count, crate::object::INLINE_SLOT_FLOOR as u32);
+        let alloc_limit =
+            std::cmp::max(stored_field_count, crate::object::INLINE_SLOT_FLOOR as u32);
         if field_index >= alloc_limit {
             eprintln!(
                 "[PERRY WARN] js_object_set_unboxed_f64_field: OOB write field_index={} alloc_limit={} (field_count={}) obj={:p} class_id={}",

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name.rs
@@ -139,7 +139,10 @@ pub extern "C" fn js_object_get_field_by_name(
                             && ((keys as u64) >> 48) == 0
                             && crate::value::addr_class::is_above_handle_band(keys as usize)
                         {
-                            let alloc_limit = std::cmp::max((*o).field_count, crate::object::INLINE_SLOT_FLOOR as u32) as usize;
+                            let alloc_limit = std::cmp::max(
+                                (*o).field_count,
+                                crate::object::INLINE_SLOT_FLOOR as u32,
+                            ) as usize;
                             if let Some(idx) = super::super::prop_plan::read_plan_lookup(
                                 keys as usize,
                                 key as usize,

--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
@@ -1594,7 +1594,8 @@ pub(crate) fn get_field_by_name_object_tail(
         // Slow path: linear scan through keys array
         let _field_count = (*obj).field_count as usize;
 
-        let alloc_limit = std::cmp::max((*obj).field_count, crate::object::INLINE_SLOT_FLOOR as u32) as usize;
+        let alloc_limit =
+            std::cmp::max((*obj).field_count, crate::object::INLINE_SLOT_FLOOR as u32) as usize;
 
         // #5054: wide objects get a validated key→index map so per-key reads
         // stay O(1) instead of O(key_count). A `None` falls through to the

--- a/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
+++ b/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
@@ -408,7 +408,8 @@ pub extern "C" fn js_object_get_field_ic_miss(
             }
             let key_count = *(keys as *const u32) as usize;
             let keys_data = (keys as *const u8).add(8) as *const f64;
-            let alloc_limit = std::cmp::max((*obj).field_count, crate::object::INLINE_SLOT_FLOOR as u32) as usize;
+            let alloc_limit =
+                std::cmp::max((*obj).field_count, crate::object::INLINE_SLOT_FLOOR as u32) as usize;
             for i in 0..key_count {
                 let k_bits = (*keys_data.add(i)).to_bits();
                 let k_ptr = (k_bits & 0x0000_FFFF_FFFF_FFFF) as *const crate::StringHeader;

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -138,7 +138,8 @@ pub extern "C" fn js_object_set_field_by_name_transition_fast(
         set_object_keys_array(obj, next_keys as *mut ArrayHeader);
         super::mark_object_dynamic_shape_unknown(obj);
 
-        let alloc_limit = std::cmp::max((*obj).field_count, crate::object::INLINE_SLOT_FLOOR as u32) as usize;
+        let alloc_limit =
+            std::cmp::max((*obj).field_count, crate::object::INLINE_SLOT_FLOOR as u32) as usize;
         let slot_usize = slot_idx as usize;
         let vbits = value.to_bits();
         let vbits = if (vbits >> 48) == 0x7FFD && (vbits & 0x0000_FFFF_FFFF_FFFF) == 0 {
@@ -437,7 +438,11 @@ pub extern "C" fn js_object_set_field_by_name(
                                     // pointer-ness may change — degrade the
                                     // layout to full-visit before the store.
                                     super::mark_object_dynamic_shape_unknown(o);
-                                    let alloc_limit = std::cmp::max((*o).field_count, crate::object::INLINE_SLOT_FLOOR as u32) as usize;
+                                    let alloc_limit = std::cmp::max(
+                                        (*o).field_count,
+                                        crate::object::INLINE_SLOT_FLOOR as u32,
+                                    )
+                                        as usize;
                                     if (idx as usize) < alloc_limit {
                                         let fields_ptr = (o as *mut u8)
                                             .add(std::mem::size_of::<ObjectHeader>())
@@ -475,7 +480,10 @@ pub extern "C" fn js_object_set_field_by_name(
                                 };
                                 set_object_keys_array(o, next_keys as *mut ArrayHeader);
                                 super::mark_object_dynamic_shape_unknown(o);
-                                let alloc_limit = std::cmp::max((*o).field_count, crate::object::INLINE_SLOT_FLOOR as u32) as usize;
+                                let alloc_limit = std::cmp::max(
+                                    (*o).field_count,
+                                    crate::object::INLINE_SLOT_FLOOR as u32,
+                                ) as usize;
                                 if (slot_idx as usize) < alloc_limit {
                                     let fields_ptr = (o as *mut u8)
                                         .add(std::mem::size_of::<ObjectHeader>())
@@ -1249,7 +1257,9 @@ pub extern "C" fn js_object_set_field_by_name(
                 };
                 set_object_keys_array(obj, next_keys as *mut ArrayHeader);
                 super::mark_object_dynamic_shape_unknown(obj);
-                let alloc_limit = std::cmp::max((*obj).field_count, crate::object::INLINE_SLOT_FLOOR as u32) as usize;
+                let alloc_limit =
+                    std::cmp::max((*obj).field_count, crate::object::INLINE_SLOT_FLOOR as u32)
+                        as usize;
                 if (slot_idx as usize) < alloc_limit {
                     // Inline the field write — `obj` has already been
                     // validated (GC header read, type check, closure
@@ -1393,7 +1403,8 @@ pub extern "C" fn js_object_set_field_by_name(
 
         // Search through the keys array for a match
         let key_count = crate::array::js_array_length(keys) as usize;
-        let alloc_limit = std::cmp::max((*obj).field_count, crate::object::INLINE_SLOT_FLOOR as u32) as usize;
+        let alloc_limit =
+            std::cmp::max((*obj).field_count, crate::object::INLINE_SLOT_FLOOR as u32) as usize;
 
         // Sidecar O(1) lookup when keys_array has grown past the
         // linear-scan break-even. Without this, the build-then-fill

--- a/crates/perry-runtime/src/object/object_ops/accessors.rs
+++ b/crates/perry-runtime/src/object/object_ops/accessors.rs
@@ -158,7 +158,8 @@ pub extern "C" fn js_object_get_own_field_or_undef(
         if key_count > 65536 {
             return f64::from_bits(TAG_UNDEF);
         }
-        let alloc_limit = std::cmp::max((*obj).field_count, crate::object::INLINE_SLOT_FLOOR as u32) as usize;
+        let alloc_limit =
+            std::cmp::max((*obj).field_count, crate::object::INLINE_SLOT_FLOOR as u32) as usize;
         for i in 0..key_count {
             let key_val = crate::array::js_array_get(keys, i as u32);
             // #1781: SSO-aware match by byte slice — the

--- a/crates/perry-runtime/src/object/object_ops/keys_array.rs
+++ b/crates/perry-runtime/src/object/object_ops/keys_array.rs
@@ -101,7 +101,8 @@ pub(crate) unsafe fn ensure_key_in_keys_array(
     // getter here bumped field_count from 8 (the proto's physical capacity) to
     // 11, exposing the overflowed `values` slot and corrupting the boundary.
     let new_index = key_count as u32;
-    let inline_capacity = std::cmp::max((*obj).field_count, crate::object::INLINE_SLOT_FLOOR as u32);
+    let inline_capacity =
+        std::cmp::max((*obj).field_count, crate::object::INLINE_SLOT_FLOOR as u32);
     if new_index < inline_capacity && new_index >= (*obj).field_count {
         (*obj).field_count = new_index + 1;
     }

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -1355,7 +1355,8 @@ fn object_key_matches_field(
     }
     unsafe {
         let obj = object_addr as *mut ObjectHeader;
-        let alloc_limit = std::cmp::max((*obj).field_count, crate::object::INLINE_SLOT_FLOOR as u32);
+        let alloc_limit =
+            std::cmp::max((*obj).field_count, crate::object::INLINE_SLOT_FLOOR as u32);
         if field_index >= alloc_limit {
             return false;
         }

--- a/scripts/check_file_size.sh
+++ b/scripts/check_file_size.sh
@@ -115,6 +115,11 @@ crates/perry-transform/src/inline/call_inliner.rs
 # Windows UI widget registry (2118 lines): the Win32 widget create/dispatch
 # table; a per-widget-family split is a mechanical follow-up.
 crates/perry-ui-windows/src/widgets/mod.rs
+# Regex grammar/parser (2075 lines): the single recursive-descent PCRE grammar;
+# #6711 (ReDoS-guard bounded-quantifier collapse) pushed it 75 lines over. A
+# split of the character-class / quantifier sub-parsers is a mechanical
+# follow-up.
+crates/perry-runtime/src/regex/grammar.rs
 EOF
 )
 


### PR DESCRIPTION
## Summary

The required `lint` gate is red on `main` (and every open PR) after two perf merges:

- **#6712** (lower inline-slot floor 8→4) landed **12 unformatted files** (`perry-runtime/src/object/{field_get_set,object_ops}/`, `alloc.rs`, `arguments.rs`, `typed_feedback.rs`, `json/parser.rs`). → pure `cargo fmt --all`.
- **#6711** (ReDoS-guard bounded-quantifier collapse) grew `regex/grammar.rs` to **2075 lines** (75 over the file-size gate). → allowlisted (sub-parser split is a mechanical follow-up).

No logic changes.

## Verification (local, current main)
- fmt / file-size / addr-class / gc-store / benchmark-freshness gates: **all pass**
- perry-runtime lib tests: **1430 passed / 0 failed** (single-threaded, CI-mode) — no regression from the recent merges

Code-only, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code formatting and readability across runtime object, JSON, and field-access operations without changing behavior.
  * Clarified an internal safety boundary during object key matching.

* **Chores**
  * Updated source-size validation to account for the larger regular-expression grammar file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->