### PR TITLE
fix(gc): prune KEYS_INDEX side table on object death

### DIFF
--- a/crates/perry-runtime/src/gc/tests/dead_owner_side_tables.rs
+++ b/crates/perry-runtime/src/gc/tests/dead_owner_side_tables.rs
@@ -441,6 +441,28 @@ fn test_closure_dead_payload_arm_clears_side_tables() {
     assert!(!crate::closure::closure_is_key_deleted(owner, "length"));
 }
 
+/// The `ObjectOverflowFields` dead-payload arm pruned only OVERFLOW_FIELDS;
+/// its address-keyed sibling KEYS_INDEX (the key→slot sidecar built for
+/// objects past KEYS_INDEX_THRESHOLD own keys) was never removed on death, so
+/// entries accumulated forever under recycled addresses — an unbounded leak.
+/// Assert the arm now clears the KEYS_INDEX entry alongside the overflow one.
+#[test]
+fn test_object_dead_payload_arm_clears_keys_index() {
+    let _global = global_side_table_test_lock();
+    let owner: usize = 0x0BEC_1DE0_0000_2026;
+    crate::object::test_seed_keys_index_entry(owner);
+    assert!(crate::object::test_keys_index_entry_exists(owner));
+
+    gc_type_clear_dead_payload_side_tables(GC_TYPE_OBJECT, owner);
+
+    assert!(
+        !crate::object::test_keys_index_entry_exists(owner),
+        "dead object's KEYS_INDEX entry must be pruned by the \
+         ObjectOverflowFields dead-payload arm (else it leaks forever \
+         keyed on the recycled address)"
+    );
+}
+
 #[test]
 fn test_dead_arguments_object_entry_pruned_on_full_gc() {
     let _guard = GcTestIsolationGuard::new();

--- a/crates/perry-runtime/src/gc/types.rs
+++ b/crates/perry-runtime/src/gc/types.rs
@@ -646,6 +646,11 @@ pub(crate) fn gc_type_clear_dead_payload_side_tables(obj_type: u8, user_ptr: usi
     match gc_type_info(obj_type).map_or(GcMoveHookKind::None, |info| info.move_hook_kind) {
         GcMoveHookKind::ObjectOverflowFields => {
             crate::object::clear_overflow_for_ptr(user_ptr);
+            // Sibling of the overflow prune above: the object's KEYS_INDEX
+            // sidecar (built for objects past KEYS_INDEX_THRESHOLD own keys)
+            // is also address-keyed and must be dropped on death, else it
+            // leaks forever under the recycled address.
+            crate::object::clear_keys_index_for_ptr(user_ptr);
         }
         GcMoveHookKind::ClosureDynamicProps => {
             // 2026-07-09 GC audit wave 2: previously an explicit no-op — a

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -1411,6 +1411,19 @@ pub(crate) fn test_overflow_field_bits(owner: usize, index: usize) -> u64 {
 }
 
 #[cfg(test)]
+pub(crate) fn test_seed_keys_index_entry(owner: usize) {
+    KEYS_INDEX.with(|m| {
+        m.borrow_mut()
+            .insert(owner, (0, std::collections::HashMap::new()));
+    });
+}
+
+#[cfg(test)]
+pub(crate) fn test_keys_index_entry_exists(owner: usize) -> bool {
+    KEYS_INDEX.with(|m| m.borrow().get(&owner).is_some())
+}
+
+#[cfg(test)]
 pub(crate) fn test_seed_object_cache_roots(object_cache_bits: [u64; 7], global_this_ptr: i64) {
     // GC_STORE_AUDIT(ROOT): test seed mirrors object cache roots scanned by scan_object_cache_roots_mut.
     crate::gc::runtime_store_root_atomic_nanbox_u64(
@@ -1529,6 +1542,21 @@ pub fn clear_overflow_for_ptr(obj_ptr: usize) {
         if (*c.get()).0 == obj_ptr {
             *c.get() = (0, std::ptr::null_mut());
         }
+    });
+}
+
+/// Remove the `KEYS_INDEX` sidecar entry for a freed object pointer.
+/// Sibling of `clear_overflow_for_ptr`: called from the same GC
+/// dead-owner dispatch when a `GC_TYPE_OBJECT` header is reclaimed.
+/// `KEYS_INDEX` is keyed on the object address, so without this prune
+/// the entry (a whole `HashMap<u64, Vec<u32>>`) would persist forever
+/// keyed by a recycled address — a monotonic leak over a long-running
+/// process, and a stale index a fresh object at the same address could
+/// read. Unlike `clear_overflow_for_ptr` there is no last-accessed
+/// cache to invalidate: `keys_index_lookup` always goes through the map.
+pub fn clear_keys_index_for_ptr(obj_ptr: usize) {
+    KEYS_INDEX.with(|m| {
+        m.borrow_mut().remove(&obj_ptr);
     });
 }
 


### PR DESCRIPTION
## Problem

`KEYS_INDEX` (the per-object key→slot sidecar in `crates/perry-runtime/src/object/mod.rs` — `PtrHashMap<usize, (u32, HashMap<u64, Vec<u32>>)>`, keyed by object address, built for any object that exceeds `KEYS_INDEX_THRESHOLD` own keys to avoid O(N²) linear key scans) is **never pruned when its owning object dies.**

Its sibling side table `OVERFLOW_FIELDS` *is* pruned on object death: `clear_overflow_for_ptr` is called from the GC dead-owner dispatch (`gc_type_clear_dead_payload_side_tables`, the `ObjectOverflowFields` arm in `gc/types.rs`). There was **no equivalent for `KEYS_INDEX`**, so its entries persist forever, keyed by addresses that the allocator later recycles.

Consequences:
- **Unbounded growth** in long-running processes — each entry is a whole `HashMap<u64, Vec<u32>>`, retained for the life of the process keyed on a dead address. This is a genuine correctness bug (monotonic leak), independent of the modest steady-state MB.
- A **stale index** that a fresh object allocated at the same recycled address could read (tolerated today only because content-validation on the linear-scan fallback catches mismatches — but the memory is still leaked).

Found by a memory-parity analysis of the GC side tables.

## Fix

Mirror the proven `OVERFLOW_FIELDS` prune exactly:

1. `object/mod.rs`: add `clear_keys_index_for_ptr`, the sibling of `clear_overflow_for_ptr`. It removes the `KEYS_INDEX` entry for the freed pointer. (Unlike the overflow path there is no last-accessed cache to invalidate — `keys_index_lookup` always goes through the map.)
2. `gc/types.rs`: call it from the `ObjectOverflowFields` dead-payload arm, immediately after `clear_overflow_for_ptr`, under the same gate and for the same `GC_TYPE_OBJECT` population (`KEYS_INDEX` applies to exactly that population).
3. Regression test in `gc/tests/dead_owner_side_tables.rs`, mirroring `test_closure_dead_payload_arm_clears_side_tables`: seed a `KEYS_INDEX` entry, run the dead-owner arm, assert the entry is gone. Verified failing-before / passing-after.

## Verification

- `cargo check -p perry-runtime` — clean (only pre-existing snake_case warnings).
- `cargo test -p perry-runtime --lib dead_owner` — **19/19 pass**, including the new `test_object_dead_payload_arm_clears_keys_index`.
- Negative check: with the new `clear_keys_index_for_ptr` call commented out, the new test fails as expected (the `KEYS_INDEX` entry survives) — confirming it exercises the fix.

This is a correctness fix for unbounded growth in long-running processes, plus a small steady-state RSS reduction.

https://claude.ai/code/session_01P1wVEe2UwHapgxLY52ydgZ