### PR TITLE
fix(hir): construct real intrinsic for `new globalThis.<Builtin>()` (#6726)

### DIFF
--- a/crates/perry-hir/src/lower/context.rs
+++ b/crates/perry-hir/src/lower/context.rs
@@ -116,6 +116,7 @@ impl LoweringContext {
             suppress_stdlib_dispatch_guard_once: false,
             lowering_call_callee: false,
             unresolved_ident_as_global: false,
+            global_intrinsic_new_once: false,
             with_env_stack: Vec::new(),
             var_hoisted_ids: HashSet::new(),
             tdz_forward_ids: HashSet::new(),

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -39,6 +39,12 @@ pub(crate) use non_ident::{lower_new_non_ident, register_stream_controller_param
 
 pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> Result<Expr> {
     let callee_expr = peel_new_callee(new_expr.callee.as_ref());
+    // #6726: consume the one-shot "this callee is an unambiguous global
+    // intrinsic" flag set by the `new globalThis.<Builtin>()` re-dispatch below.
+    // Taken here (before any argument lowering) so it applies ONLY to the
+    // synthesized bare-identifier callee and never leaks into arguments or
+    // nested `new` expressions.
+    let force_global_intrinsic = std::mem::take(&mut ctx.global_intrinsic_new_once);
     // #5253: source byte offset of this `new` expression, captured once and
     // threaded into every `New`/`NewDynamic`/`NewDynamicSpread` we build below.
     // Under `--debug-symbols`, codegen resolves it to a `file:line` for the
@@ -158,12 +164,23 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
     // `lower_new_member_native` above) and re-dispatch through a synthesized
     // bare-identifier `new <Ident>(...)`. The recursion terminates because the
     // synthesized callee is an `Ident`, not a `Member`.
+    //
+    // Two subtleties (both raised in review):
+    //  - The `globalThis` guard uses `shadows_unqualified_global` (locals,
+    //    functions, imports AND classes), not just `lookup_local`, so a
+    //    `function globalThis` / `class globalThis` / imported `globalThis` that
+    //    rebinds the name suppresses the rewrite — the member then reads that
+    //    user binding, matching Node.
+    //  - `globalThis.Set` is the intrinsic even when a lexical `class Set {}`
+    //    shadows the bare name, so the re-dispatch sets
+    //    `global_intrinsic_new_once` to tell the recursive call to ignore that
+    //    shadowing (consumed at the top of `lower_new`, above).
     if let ast::Expr::Member(member) = callee_expr {
         if let (ast::Expr::Ident(obj_ident), ast::MemberProp::Ident(prop_ident)) =
             (peel_new_callee(member.obj.as_ref()), &member.prop)
         {
             if obj_ident.sym.as_ref() == "globalThis"
-                && ctx.lookup_local("globalThis").is_none()
+                && !ctx.shadows_unqualified_global("globalThis")
                 && is_reified_global_builtin_constructor(prop_ident.sym.as_ref())
             {
                 let mut synthetic = new_expr.clone();
@@ -172,6 +189,7 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
                     prop_ident.span,
                     Default::default(),
                 )));
+                ctx.global_intrinsic_new_once = true;
                 return lower_new(ctx, &synthetic);
             }
         }
@@ -229,7 +247,16 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
             // class-decl name only carries a local slot when the module
             // reassigns it (#5833), and for a reassigned binding reading the
             // slot is the spec-correct behavior for `new` too.
-            let callee_local_at_entry: Option<LocalId> = ctx.lookup_local(&class_name);
+            // #6726: when this callee was re-dispatched from
+            // `new globalThis.<Builtin>()`, the name is an unambiguous global
+            // intrinsic — a lexical `class Set {}` / `const Set = …` must NOT
+            // capture it. Suppress the local snapshot (and the shadow flag
+            // below) so the built-in arms fire.
+            let callee_local_at_entry: Option<LocalId> = if force_global_intrinsic {
+                None
+            } else {
+                ctx.lookup_local(&class_name)
+            };
             // #6233: a user-declared binding — `class Symbol extends Base {}`,
             // a local/param, a `function` declaration, or an imported binding —
             // lexically shadows the same-named global for every reference in
@@ -245,11 +272,12 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
             // fresh lookup later is unreliable. `forward_class_names` covers a
             // sibling `class X` declared later in the same function body
             // (pre-registered by the Phase-1.5 scan but not yet lowered).
-            let shadowed_by_user_binding = ctx.lookup_class(&class_name).is_some()
-                || callee_local_at_entry.is_some()
-                || ctx.lookup_func(&class_name).is_some()
-                || ctx.lookup_imported_func(&class_name).is_some()
-                || ctx.forward_class_names.contains(class_name.as_str());
+            let shadowed_by_user_binding = !force_global_intrinsic
+                && (ctx.lookup_class(&class_name).is_some()
+                    || callee_local_at_entry.is_some()
+                    || ctx.lookup_func(&class_name).is_some()
+                    || ctx.lookup_imported_func(&class_name).is_some()
+                    || ctx.forward_class_names.contains(class_name.as_str()));
             if matches!(
                 ctx.lookup_native_module(&class_name),
                 Some(("url", Some("Url")))

--- a/crates/perry-hir/src/lower/expr_new.rs
+++ b/crates/perry-hir/src/lower/expr_new.rs
@@ -17,7 +17,9 @@ use crate::ir::Expr;
 use crate::lower_decl::lower_class_from_ast;
 use crate::lower_types::extract_ts_type_with_ctx;
 
-use super::expr_new_builtins::{global_member_constructor_name, module_constructor_name};
+use super::expr_new_builtins::{
+    global_member_constructor_name, is_reified_global_builtin_constructor, module_constructor_name,
+};
 use super::{lower_expr, LoweringContext};
 
 mod helpers;
@@ -138,6 +140,41 @@ pub(super) fn lower_new(ctx: &mut LoweringContext, new_expr: &ast::NewExpr) -> R
     // instance so subsequent method calls dispatch correctly.
     if let Some(expr) = lower_new_member_native(ctx, new_expr, callee_expr, new_byte_offset)? {
         return Ok(expr);
+    }
+
+    // #6726: `new globalThis.<Builtin>(...)` must construct the exact same
+    // intrinsic as `new <Builtin>(...)`. The bare-identifier arm below routes
+    // every built-in constructor to its real allocator (`Set` → `Expr::SetNew`,
+    // `Map` → `MapNew`, `Date` → `DateNew`, `RegExp`, the Error family, the
+    // typed arrays, boxed primitives, `Proxy`, `WeakRef`, …), but the
+    // member-expression callee never reaches it — it fell through to
+    // `lower_new_non_ident` → `Expr::NewDynamic`, and for the data-structure
+    // builtins (whose construction lives in a dedicated HIR variant, not in
+    // codegen's `lower_builtin_new`) codegen's `try_static_class_name` reroute
+    // dead-ended at an empty-object placeholder. So `new globalThis.Set().has(x)`
+    // threw "has is not a function". Detect the `globalThis.<Ident>` callee
+    // (the real global object — `globalThis` not lexically rebound — and a
+    // built-in constructor name that isn't already handled by
+    // `lower_new_member_native` above) and re-dispatch through a synthesized
+    // bare-identifier `new <Ident>(...)`. The recursion terminates because the
+    // synthesized callee is an `Ident`, not a `Member`.
+    if let ast::Expr::Member(member) = callee_expr {
+        if let (ast::Expr::Ident(obj_ident), ast::MemberProp::Ident(prop_ident)) =
+            (peel_new_callee(member.obj.as_ref()), &member.prop)
+        {
+            if obj_ident.sym.as_ref() == "globalThis"
+                && ctx.lookup_local("globalThis").is_none()
+                && is_reified_global_builtin_constructor(prop_ident.sym.as_ref())
+            {
+                let mut synthetic = new_expr.clone();
+                synthetic.callee = Box::new(ast::Expr::Ident(ast::Ident::new(
+                    prop_ident.sym.clone(),
+                    prop_ident.span,
+                    Default::default(),
+                )));
+                return lower_new(ctx, &synthetic);
+            }
+        }
     }
 
     // Issue #237: pre-register the controller param of every

--- a/crates/perry-hir/src/lower/expr_new_builtins.rs
+++ b/crates/perry-hir/src/lower/expr_new_builtins.rs
@@ -30,6 +30,102 @@ pub(super) fn module_constructor_name(
     }
 }
 
+/// Names on the global object that are real JS / Web built-in *constructors*
+/// (`typeof === "function"`, invokable with `new`). Consulted by `lower_new`
+/// to re-dispatch `new globalThis.<Ctor>(...)` through the bare-identifier
+/// `new <Ctor>(...)` path so a member-expression callee constructs the exact
+/// same intrinsic as the plain form (#6726: `new globalThis.Set()` used to
+/// fall through to an empty-object placeholder with no `.has`, because the
+/// data-structure builtins have a dedicated HIR variant — `Expr::SetNew`,
+/// `MapNew`, `DateNew`, … — but no codegen `lower_builtin_new` arm for the
+/// member-callee reroute to land on).
+///
+/// Symbol/BigInt/Math/JSON are intentionally omitted: `new globalThis.Symbol()`
+/// already throws the correct "not a constructor" TypeError via the
+/// non-identifier path, so re-routing them here would be redundant. URL /
+/// TextEncoder / the fetch + worker-messaging constructors are handled earlier
+/// by `lower_new_member_native` and never reach the re-dispatch, but are listed
+/// for completeness since routing them through the bare-ident path is
+/// equivalent. Kept in step with codegen's `is_global_this_builtin_function_name`
+/// (perry-codegen cannot be imported from perry-hir); over-inclusion is harmless
+/// because an unrecognized name still lowers to the generic `Expr::New` the bare
+/// form uses.
+pub(super) fn is_reified_global_builtin_constructor(name: &str) -> bool {
+    matches!(
+        name,
+        "Object"
+            | "Array"
+            | "Function"
+            | "Boolean"
+            | "Number"
+            | "String"
+            | "Date"
+            | "RegExp"
+            | "Error"
+            | "TypeError"
+            | "RangeError"
+            | "ReferenceError"
+            | "SyntaxError"
+            | "EvalError"
+            | "URIError"
+            | "AggregateError"
+            | "Map"
+            | "Set"
+            | "WeakMap"
+            | "WeakSet"
+            | "WeakRef"
+            | "Promise"
+            | "Proxy"
+            | "FinalizationRegistry"
+            | "ArrayBuffer"
+            | "SharedArrayBuffer"
+            | "DataView"
+            | "Int8Array"
+            | "Uint8Array"
+            | "Uint8ClampedArray"
+            | "Int16Array"
+            | "Uint16Array"
+            | "Int32Array"
+            | "Uint32Array"
+            | "Float16Array"
+            | "Float32Array"
+            | "Float64Array"
+            | "BigInt64Array"
+            | "BigUint64Array"
+            | "URL"
+            | "URLSearchParams"
+            | "URLPattern"
+            | "TextEncoder"
+            | "TextDecoder"
+            | "TextEncoderStream"
+            | "TextDecoderStream"
+            | "CompressionStream"
+            | "DecompressionStream"
+            | "ReadableStream"
+            | "WritableStream"
+            | "TransformStream"
+            | "AbortController"
+            | "AbortSignal"
+            | "EventTarget"
+            | "Event"
+            | "CustomEvent"
+            | "DOMException"
+            | "FormData"
+            | "Blob"
+            | "File"
+            | "Headers"
+            | "Request"
+            | "Response"
+            | "MessageChannel"
+            | "MessagePort"
+            | "BroadcastChannel"
+            | "WebSocket"
+            | "DisposableStack"
+            | "AsyncDisposableStack"
+            | "SuppressedError"
+    )
+}
+
 /// Resolve `new <obj>.<prop>()` against the global object or a built-in /
 /// native module alias to a canonical built-in constructor name.
 pub(super) fn global_member_constructor_name(

--- a/crates/perry-hir/src/lower/lowering_context.rs
+++ b/crates/perry-hir/src/lower/lowering_context.rs
@@ -431,6 +431,14 @@ pub struct LoweringContext {
     /// unresolvable identifiers throw ReferenceError, but member receivers are
     /// still allowed to use the existing GlobalGet sentinel path.
     pub(crate) unresolved_ident_as_global: bool,
+    /// #6726 — one-shot flag set when `lower_new` re-dispatches a
+    /// `new globalThis.<Builtin>(...)` through a synthesized bare-identifier
+    /// `new <Builtin>(...)`. `globalThis.Set` refers UNAMBIGUOUSLY to the
+    /// intrinsic, so the recursive call must construct the built-in even when a
+    /// lexical `class Set {}` / `const Set = …` shadows the bare name. Consumed
+    /// (cleared) at the top of `lower_new` so it scopes to that single
+    /// re-dispatched callee and never leaks into argument lowering.
+    pub(crate) global_intrinsic_new_once: bool,
     /// Active `with` object environment records. Each frame points at the
     /// synthetic local that stores the object value and the locals length when
     /// the frame was entered, so declarations inside the block/function can

--- a/test-files/test_gap_new_globalthis_builtin_6726.ts
+++ b/test-files/test_gap_new_globalthis_builtin_6726.ts
@@ -1,0 +1,59 @@
+// #6726 — `new globalThis.<Builtin>()` must construct the exact same intrinsic
+// as `new <Builtin>()`. The member-expression callee (`globalThis.Set`) used to
+// fall through to an empty-object placeholder with none of the builtin's
+// methods, so `new globalThis.Set().has(x)` threw "has is not a function". The
+// bare form (`new Set()`) and the local-alias form (`const S = globalThis.Set;
+// new S()`) always worked — the failure was specific to the inline member
+// callee.
+
+// The exact reproduction from the issue.
+const values = new globalThis.Set();
+console.log(values.has(42));
+
+// Set with an iterable argument.
+const s2 = new globalThis.Set([1, 2, 2, 3]);
+console.log(s2.size, s2.has(2), s2.has(9));
+
+// Map, empty and from entries.
+const m0 = new globalThis.Map();
+m0.set("k", 7);
+console.log(m0.get("k"), m0.has("k"));
+const m1 = new globalThis.Map([
+  ["a", 1],
+  ["b", 2],
+]);
+console.log(m1.size, m1.get("a"), m1.get("b"));
+
+// Date from a fixed timestamp (deterministic — no wall clock).
+const d = new globalThis.Date(0);
+console.log(d.getTime(), d.toISOString());
+
+// WeakMap / WeakSet through the global object.
+const wm = new globalThis.WeakMap();
+const key = {};
+wm.set(key, "v");
+console.log(wm.get(key), wm.has(key));
+const ws = new globalThis.WeakSet();
+ws.add(key);
+console.log(ws.has(key));
+
+// Error family through the global object.
+const te = new globalThis.TypeError("boom");
+console.log(te instanceof Error, te instanceof TypeError, te.message, te.name);
+
+// Array through the global object.
+const arr = new globalThis.Array(1, 2, 3);
+console.log(arr.length, arr[0], arr[2]);
+
+// Promise through the global object still resolves.
+new globalThis.Promise<number>((resolve) => resolve(11)).then((v) =>
+  console.log("promise", v),
+);
+
+// Regression guards: the two forms that already worked must keep working.
+const bare = new Set([5]);
+console.log(bare.has(5));
+const S = globalThis.Set;
+const aliased = new S();
+aliased.add(8);
+console.log(aliased.has(8), aliased.size);

--- a/test-files/test_gap_new_globalthis_builtin_6726.ts
+++ b/test-files/test_gap_new_globalthis_builtin_6726.ts
@@ -57,3 +57,28 @@ const S = globalThis.Set;
 const aliased = new S();
 aliased.add(8);
 console.log(aliased.has(8), aliased.size);
+
+// #6726 review (CodeRabbit): `globalThis.<Builtin>` is the intrinsic even when a
+// lexical binding shadows the bare name — a block-scoped `class Set {}` must NOT
+// capture `new globalThis.Set()`.
+{
+  class Set {
+    isLocal = true;
+  }
+  const shadowed = new globalThis.Set([1, 2]);
+  console.log(shadowed.has(1), (shadowed as any).isLocal, shadowed.size);
+  // The bare name still resolves to the local class in the same scope.
+  console.log((new Set() as any).isLocal);
+}
+
+// Conversely, a locally-rebound `globalThis` is an ordinary object, so
+// `new globalThis.Set()` must construct THAT object's `Set`, not the intrinsic.
+{
+  const globalThis = {
+    Set: class {
+      isFake = true;
+    },
+  };
+  const fake = new globalThis.Set();
+  console.log((fake as any).isFake);
+}


### PR DESCRIPTION
## Summary

Fixes #6726. `new globalThis.Set()` compiled but produced an object without any Set methods — `new globalThis.Set().has(42)` threw `TypeError: has is not a function`. The plain `new Set()` and the local-alias `const S = globalThis.Set; new S()` forms both worked, so the failure was specific to constructing through the inline member-expression callee.

## Root cause

The bare-identifier `new <Builtin>()` arm in `lower_new` routes every built-in constructor to its real allocator — `Set` → `Expr::SetNew`, `Map` → `MapNew`, `Date` → `DateNew`, the Error family, typed arrays, boxed primitives, `Proxy`, `WeakRef`, and so on. A **member-expression** callee (`globalThis.Set`) never reaches that arm: it falls through to `lower_new_non_ident` → `Expr::NewDynamic`.

For the data-structure builtins — whose construction lives in a dedicated HIR variant rather than in codegen's `lower_builtin_new` — codegen's `try_static_class_name` then rerouted the `PropertyGet { globalThis, "Set" }` callee to `lower_new("Set")`, which has **no `Set`/`Map`/`Date` arm** and dead-ended at a `class_id=0` empty-object placeholder. (The `const S = globalThis.Set; new S()` form works because a `LocalGet` callee instead reaches the runtime `js_new_function_construct` helper, which *does* recognise the reified global builtin thunks.)

## Fix

In `lower_new`, detect the `new globalThis.<Ident>(...)` callee — the real global object (`globalThis` not lexically rebound) with a recognised built-in constructor name — and re-dispatch through a synthesized bare-identifier `new <Ident>(...)`. A member callee then constructs the exact same intrinsic as the plain form.

- Placed **after** `lower_new_member_native`, so the already-working member paths (`URL` / streams / fetch / worker-messaging) are untouched.
- A shadowing local (`const globalThis = { Set: ... }`) suppresses the re-dispatch via the `ctx.lookup_local("globalThis").is_none()` guard, so it keeps using the local object — matching Node.
- Recursion terminates: the synthesized callee is an `Ident`, not a `Member`.

## Testing

`test-files/test_gap_new_globalthis_builtin_6726.ts` covers the repro plus `Set`/`Map`/`Date`/`WeakMap`/`WeakSet`/`TypeError`/`Array`/`Promise` through `globalThis`, and the two forms that already worked (bare + local alias) as regression guards. Perry output is **byte-for-byte identical to Node**.

Verified manually against Node, all matching:

```
new globalThis.Set().has(42)            → false
new globalThis.Set([1,2,2,3]).size      → 3
new globalThis.Map([["a",1]]).get("a")  → 1
new globalThis.Date(0).getTime()        → 0
new globalThis.TypeError("boom")        → instanceof Error, name "TypeError"
new globalThis.Uint8Array(3)            → real typed array
new globalThis.RegExp("a.c","g")        → real regex
new globalThis.Proxy(...)               → real proxy
const globalThis = {...}; new globalThis.Set()  → uses the local (shadow respected)
```

`cargo test -p perry-hir --lib` passes (247/247). No version bump / changelog per the contributor-PR convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `new globalThis.<Builtin>(...)` construction to match `new <Builtin>(...)` for supported JavaScript and Web/DOM built-in constructors.
  * Added safeguards so this works correctly despite user shadowing of the bare constructor name and non-intrinsic rebindings of `globalThis`.

* **Tests**
  * Added a regression test covering many built-ins (e.g., `Set`, `Map`, `Date`, `WeakMap`/`WeakSet`, `Array`, `Promise`, and more) and verifying equivalent behavior across the different construction forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->