### PR TITLE
fix(http): clear per-handle JS side tables on handle-id recycle (#6710)

### DIFF
--- a/crates/perry-ext-http-server/src/http2_server/pump.rs
+++ b/crates/perry-ext-http-server/src/http2_server/pump.rs
@@ -159,9 +159,12 @@ pub(crate) fn process_pending_h2(pending: HttpPendingRequest) {
     let res_f64 = handle_to_pointer_f64(pending.response_handle);
     // #6710 — clear a possibly-recycled handle id's per-handle JS side tables
     // before the handler observes req/res (see process_pending in server.rs).
+    // The HTTP/2 stream handle is recycled from the same pool, so clear it too
+    // (no-op when `h2_stream_handle == 0`).
     unsafe {
         crate::types::js_handle_clear_side_tables(pending.request_handle);
         crate::types::js_handle_clear_side_tables(pending.response_handle);
+        crate::types::js_handle_clear_side_tables(pending.h2_stream_handle);
     }
     // #4903 — Node invokes `'request'` listeners (and the `createServer`
     // handler, which is one) with `this` bound to the server.

--- a/crates/perry-ext-http-server/src/http2_server/pump.rs
+++ b/crates/perry-ext-http-server/src/http2_server/pump.rs
@@ -157,6 +157,12 @@ pub(crate) fn try_recv_pending_h2_nonblocking(server_handle: i64) -> Option<Http
 pub(crate) fn process_pending_h2(pending: HttpPendingRequest) {
     let req_f64 = handle_to_pointer_f64(pending.request_handle);
     let res_f64 = handle_to_pointer_f64(pending.response_handle);
+    // #6710 — clear a possibly-recycled handle id's per-handle JS side tables
+    // before the handler observes req/res (see process_pending in server.rs).
+    unsafe {
+        crate::types::js_handle_clear_side_tables(pending.request_handle);
+        crate::types::js_handle_clear_side_tables(pending.response_handle);
+    }
     // #4903 — Node invokes `'request'` listeners (and the `createServer`
     // handler, which is one) with `this` bound to the server.
     let server_this = handle_to_pointer_f64(pending.server_handle);

--- a/crates/perry-ext-http-server/src/https_server.rs
+++ b/crates/perry-ext-http-server/src/https_server.rs
@@ -448,6 +448,12 @@ pub(crate) fn try_recv_pending_https_nonblocking(server_handle: i64) -> Option<H
 pub(crate) fn process_pending_https(pending: HttpPendingRequest) {
     let req_f64 = handle_to_pointer_f64(pending.request_handle);
     let res_f64 = handle_to_pointer_f64(pending.response_handle);
+    // #6710 — clear a possibly-recycled handle id's per-handle JS side tables
+    // before the handler observes req/res (see process_pending in server.rs).
+    unsafe {
+        crate::types::js_handle_clear_side_tables(pending.request_handle);
+        crate::types::js_handle_clear_side_tables(pending.response_handle);
+    }
     // #4903 — Node invokes `'request'` listeners (and the `createServer`
     // handler, which is one) with `this` bound to the server.
     let server_this = handle_to_pointer_f64(pending.server_handle);

--- a/crates/perry-ext-http-server/src/server.rs
+++ b/crates/perry-ext-http-server/src/server.rs
@@ -1601,6 +1601,16 @@ pub extern "C" fn js_node_http_server_process_pending() -> i32 {
         // Drain upgrades first so they don't get starved by a busy
         // request stream.
         while let Some(up) = try_recv_upgrade(h) {
+            // #6710 — the upgrade path bypasses `process_pending`, but its
+            // request handle and the adopted socket / WebSocket handles are
+            // recycled from the same freelist. Clear their per-handle JS side
+            // tables here, on the main thread, before any upgrade listener sees
+            // them (no-op for a zero handle).
+            unsafe {
+                js_handle_clear_side_tables(up.request_handle);
+                js_handle_clear_side_tables(up.raw_socket_id);
+                js_handle_clear_side_tables(up.ws_id);
+            }
             if up.raw_socket_id != 0 {
                 // #4973 raw path: make sure the adopted net.Socket's
                 // dispatch extensions + GC scanner are registered on the

--- a/crates/perry-ext-http-server/src/server.rs
+++ b/crates/perry-ext-http-server/src/server.rs
@@ -38,9 +38,9 @@ use crate::response::{
     alloc_server_response_for_request, HyperResponseShape, ResponseBody, ServerResponse,
 };
 use crate::types::{
-    extract_host, extract_port, js_promise_run_microtasks, js_promise_state, js_value_is_closure,
-    jsvalue_to_owned_string, read_string_header, Promise, POINTER_TAG, PTR_MASK, TAG_NULL,
-    TAG_UNDEFINED,
+    extract_host, extract_port, js_handle_clear_side_tables, js_promise_run_microtasks,
+    js_promise_state, js_value_is_closure, jsvalue_to_owned_string, read_string_header, Promise,
+    POINTER_TAG, PTR_MASK, TAG_NULL, TAG_UNDEFINED,
 };
 
 // #4728 — in-flight (async-handler) request tracking + the reaper that
@@ -1739,6 +1739,25 @@ pub(crate) fn try_recv_pending_nonblocking(server_handle: i64) -> Option<HttpPen
 fn process_pending(pending: HttpPendingRequest) {
     let req_f64 = handle_to_pointer_f64(pending.request_handle);
     let res_f64 = handle_to_pointer_f64(pending.response_handle);
+
+    // #6710: this handler is about to run on a possibly-RECYCLED handle id —
+    // perry-ffi's bounded freelist hands a freed `IncomingMessage` /
+    // `ServerResponse` id back out to a later `register_handle`. The per-handle
+    // JS-property side tables (`HANDLE_EXPANDO_PROPS` string props +
+    // `SYMBOL_PROPERTIES`/attrs/accessors symbol props) are keyed by that id and
+    // are NOT cleared on recycle, so without this a fresh request would inherit
+    // the previous request's arbitrary own props — e.g. Next.js stores
+    // `isRSCRequest` / `NextInternalRequestMeta` on `req` — crossing per-request
+    // state across concurrent requests and wedging the App Router render
+    // pipeline. Clear them here, on the MAIN thread that owns the thread-local
+    // expando table, before any `'request'` listener or the handler observes
+    // `req`/`res`. (The Rust `IncomingMessage`/`ServerResponse` structs are
+    // already fresh per request via `IncomingMessage::new`; only these
+    // id-keyed JS side tables leak.)
+    unsafe {
+        js_handle_clear_side_tables(pending.request_handle);
+        js_handle_clear_side_tables(pending.response_handle);
+    }
 
     // Fire `'request'` listeners (Node's `server.on('request', ...)`).
     // Node's emitter invokes them with `this` bound to the server, so the

--- a/crates/perry-ext-http-server/src/types.rs
+++ b/crates/perry-ext-http-server/src/types.rs
@@ -14,6 +14,13 @@ pub const STRING_TAG: u64 = 0x7FFF_0000_0000_0000;
 // Runtime symbols not yet wrapped by perry-ffi — declared locally.
 extern "C" {
     pub fn js_promise_run_microtasks() -> i32;
+    /// #6710 — clear every per-handle JS-property side table (string expando +
+    /// symbol props/attrs/accessors) for a recycled handle id, so a reused
+    /// `IncomingMessage`/`ServerResponse` id does not carry the previous
+    /// request's own props (Next.js `isRSCRequest` / `NextInternalRequestMeta`).
+    /// Must be called on the main thread. Defined in
+    /// `crates/perry-runtime/src/symbol/properties.rs::js_handle_clear_side_tables`.
+    pub fn js_handle_clear_side_tables(handle: i64);
     pub fn js_promise_state(ptr: *mut Promise) -> i32;
     pub fn js_promise_reason(ptr: *mut Promise) -> f64;
     pub fn js_json_stringify(value: f64, type_hint: u32) -> *mut StringHeader;

--- a/crates/perry-runtime/src/object/descriptor_state.rs
+++ b/crates/perry-runtime/src/object/descriptor_state.rs
@@ -712,6 +712,28 @@ pub(crate) fn prune_dead_descriptor_owner_entries(is_dead_owner: &dyn Fn(usize) 
     });
 }
 
+/// #6710: drop every property-attr + accessor descriptor owned by `obj`.
+///
+/// The generic descriptor tables are keyed by owner address; for a native
+/// handle that address is its (recycled) handle id. `gc_sweep_dead_descriptors`
+/// only reaps entries whose owner is a dead *heap* object, so a recycled handle
+/// id's descriptors survive into the next owner. Called from
+/// `handle_expando_clear` when perry-ffi hands a freed handle id back out.
+pub(crate) fn clear_object_descriptors(obj: usize) {
+    PROPERTY_DESCRIPTORS.with(|m| {
+        let mut m = m.borrow_mut();
+        if !m.is_empty() {
+            m.retain(|(owner, _), _| *owner != obj);
+        }
+    });
+    ACCESSOR_DESCRIPTORS.with(|m| {
+        let mut m = m.borrow_mut();
+        if !m.is_empty() {
+            m.retain(|(owner, _), _| *owner != obj);
+        }
+    });
+}
+
 /// Rewrite a descriptor table's owner ADDRESS during the GC metadata-rewrite
 /// phase (evacuation moved the owning object), mirroring the symbol-keyed
 /// twin tables' owner rekey (`symbol/gc_roots.rs`). Outside that phase the

--- a/crates/perry-runtime/src/object/descriptor_state.rs
+++ b/crates/perry-runtime/src/object/descriptor_state.rs
@@ -294,7 +294,17 @@ pub(crate) unsafe fn class_instance_set_may_intercept(
 /// `GLOBAL_DESCRIPTORS_IN_USE`, neither is poisoned by the runtime
 /// installing attrs on unrelated builtins (RegExp prototype etc.), so the
 /// dynamic-write fast path stays precise.
+/// #6710: set once a native HANDLE-band owner (small id, not a heap object)
+/// gets a property-attr / accessor descriptor. Heap owners record this on their
+/// GC header (`OBJ_FLAG_HAS_DESCRIPTORS`) but a handle id has no header, so
+/// `clear_object_descriptors` uses this flag to skip the O(N) `retain` scans on
+/// the common path where no handle was ever `defineProperty`'d.
+static HANDLE_HAS_DESCRIPTORS: AtomicBool = AtomicBool::new(false);
+
 pub(crate) fn note_descriptor_target(obj: usize) {
+    if crate::value::addr_class::is_handle_band(obj) {
+        HANDLE_HAS_DESCRIPTORS.store(true, Ordering::Relaxed);
+    }
     if crate::array::object_prototype_addr_matches(obj) {
         OBJECT_PROTO_DESCRIPTORS.store(true, Ordering::Relaxed);
     }
@@ -720,6 +730,12 @@ pub(crate) fn prune_dead_descriptor_owner_entries(is_dead_owner: &dyn Fn(usize) 
 /// id's descriptors survive into the next owner. Called from
 /// `handle_expando_clear` when perry-ffi hands a freed handle id back out.
 pub(crate) fn clear_object_descriptors(obj: usize) {
+    // Fast path: if no handle-band owner ever received a descriptor, these
+    // tables hold only heap owners — none of whose keys can match `obj` (a
+    // handle id) — so the O(N) `retain` scans would remove nothing. Skip them.
+    if !HANDLE_HAS_DESCRIPTORS.load(Ordering::Relaxed) {
+        return;
+    }
     PROPERTY_DESCRIPTORS.with(|m| {
         let mut m = m.borrow_mut();
         if !m.is_empty() {

--- a/crates/perry-runtime/src/object/handle_expando.rs
+++ b/crates/perry-runtime/src/object/handle_expando.rs
@@ -80,6 +80,29 @@ pub fn handle_expando_set(handle: i64, name: &str, value: f64) {
     crate::gc::runtime_write_barrier_external_slot(0, 0, bits);
 }
 
+/// Drop every expando property stored under `handle`.
+///
+/// #6710: handle ids are recycled through perry-ffi's freelist — a freed
+/// `IncomingMessage`/`ServerResponse`/Blob/stream id is handed back out by a
+/// later `register_handle`. This table (like the symbol-property table) is
+/// keyed by that id, so without an explicit clear the NEW owner inherits the
+/// PREVIOUS owner's arbitrary JS props. Under concurrent HTTP requests that
+/// crosses per-request state — Next.js stores `isRSCRequest` /
+/// `NextInternalRequestMeta` on `req`, so a recycled id makes one request read
+/// another's flags and the App Router render pipeline wedges. Callers clear a
+/// recycled id's side tables on the MAIN (JS-owning) thread before reuse.
+pub fn handle_expando_clear(handle: i64) {
+    if handle == 0 {
+        return;
+    }
+    HANDLE_EXPANDO_PROPS.with(|cell| {
+        cell.borrow_mut().remove(&handle);
+    });
+    // Also drop the handle's property-attr / accessor descriptors, which live
+    // in the generic per-owner descriptor tables (keyed by the handle id).
+    super::descriptor_state::clear_object_descriptors(handle as usize);
+}
+
 /// Read back an own property previously stored via `handle_expando_set`.
 /// Returns `None` when no such property exists (caller falls through to its
 /// `undefined` default). Mirrors `closure_get_own_dynamic_prop`.
@@ -304,6 +327,25 @@ mod tests {
         HANDLE_EXPANDO_PROPS.with(|cell| {
             cell.borrow_mut().remove(&h);
         });
+    }
+
+    #[test]
+    fn clear_drops_all_props() {
+        // #6710: a recycled handle id must not carry the prior owner's props.
+        let h = 0x4_2426i64;
+        handle_expando_set(h, "a", f64::from_bits(0x7FFD_0000_0000_0011));
+        handle_expando_set(h, "b", f64::from_bits(0x7FFD_0000_0000_0022));
+        assert!(handle_expando_has_any(h));
+        handle_expando_clear(h);
+        assert!(
+            !handle_expando_has_any(h),
+            "clear must drop the owner entry"
+        );
+        assert!(handle_expando_get(h, "a").is_none());
+        assert!(handle_expando_get(h, "b").is_none());
+        // Clearing an absent id and the null id (0) are no-ops, not panics.
+        handle_expando_clear(0x9_9999i64);
+        handle_expando_clear(0);
     }
 
     #[test]

--- a/crates/perry-runtime/src/object/handle_expando.rs
+++ b/crates/perry-runtime/src/object/handle_expando.rs
@@ -349,6 +349,28 @@ mod tests {
     }
 
     #[test]
+    fn clear_drops_handle_descriptors() {
+        // #6710: a handle that received a `defineProperty` descriptor must also
+        // have it cleared on recycle — exercises the HANDLE_HAS_DESCRIPTORS-gated
+        // path in `clear_object_descriptors`.
+        use super::super::descriptor_state::{
+            get_property_attrs, set_property_attrs, PropertyAttrs,
+        };
+        let h = 0x4_2427i64;
+        set_property_attrs(
+            h as usize,
+            "d".to_string(),
+            PropertyAttrs::new(false, true, true),
+        );
+        assert!(get_property_attrs(h as usize, "d").is_some());
+        handle_expando_clear(h);
+        assert!(
+            get_property_attrs(h as usize, "d").is_none(),
+            "clear must drop the handle's property descriptor"
+        );
+    }
+
+    #[test]
     fn scanner_visits_stored_values() {
         let h = 0x4_2425i64;
         let v_bits = 0x7FFD_1234_5678_9ABCu64;

--- a/crates/perry-runtime/src/symbol/accessors.rs
+++ b/crates/perry-runtime/src/symbol/accessors.rs
@@ -23,6 +23,16 @@ pub(super) fn clear_symbol_accessor_property(obj_key: usize, sym_key: usize) {
     }
 }
 
+/// #6710: drop every symbol accessor descriptor owned by `obj_key` — used when
+/// a handle id is recycled so a reused id can't carry the prior owner's
+/// accessors. Keyed by `(obj_key, sym_key)`, so retain everything else.
+pub(super) fn clear_all_symbol_accessor_properties_for_object(obj_key: usize) {
+    let mut guard = crate::gc::lock_gc_root_registry(&SYMBOL_ACCESSOR_PROPERTIES);
+    if let Some(map) = guard.as_mut() {
+        map.retain(|(o, _), _| *o != obj_key);
+    }
+}
+
 pub(crate) unsafe fn set_symbol_accessor_property(
     obj_f64: f64,
     sym_f64: f64,

--- a/crates/perry-runtime/src/symbol/properties.rs
+++ b/crates/perry-runtime/src/symbol/properties.rs
@@ -108,6 +108,47 @@ pub(crate) unsafe fn js_object_delete_symbol_property(obj_f64: f64, sym_f64: f64
     1
 }
 
+/// #6710: drop ALL symbol-keyed props (data + attrs + accessors) owned by
+/// `obj_key`. Used when a handle id is recycled so the reused id starts with a
+/// clean symbol side table — mirrors `handle_expando_clear` for the string
+/// table. The three tables are keyed by `obj_key` (`SYMBOL_PROPERTIES`) or
+/// `(obj_key, sym_key)` (attrs / accessors), so a single object drops in one
+/// `remove` and two `retain`s.
+pub(crate) fn clear_all_symbol_properties_for_object(obj_key: usize) {
+    if obj_key == 0 {
+        return;
+    }
+    accessors::clear_all_symbol_accessor_properties_for_object(obj_key);
+    {
+        let mut guard = crate::gc::lock_gc_root_registry(&SYMBOL_PROPERTIES);
+        if let Some(map) = guard.as_mut() {
+            map.remove(&obj_key);
+        }
+    }
+    {
+        let mut guard = crate::gc::lock_gc_root_registry(&SYMBOL_PROPERTY_ATTRS);
+        if let Some(map) = guard.as_mut() {
+            map.retain(|(o, _), _| *o != obj_key);
+        }
+    }
+}
+
+/// #6710: clear every per-handle JS-property side table for a recycled handle
+/// id (the string expando table AND the symbol tables). Called on the MAIN
+/// (JS-owning) thread from perry-ext-http-server just before a recycled
+/// `IncomingMessage`/`ServerResponse` id is handed to a new request's handler,
+/// so no request inherits a prior request's `req.__rid` / `isRSCRequest` /
+/// `NextInternalRequestMeta`. The `handle` id equals `obj_key_from_f64` of the
+/// handle's NaN-boxed pointer, so one id keys all four tables.
+#[no_mangle]
+pub extern "C" fn js_handle_clear_side_tables(handle: i64) {
+    if handle == 0 {
+        return;
+    }
+    crate::object::handle_expando::handle_expando_clear(handle);
+    clear_all_symbol_properties_for_object(handle as usize);
+}
+
 pub(crate) fn symbol_property_is_enumerable(owner: usize, sym_key: usize) -> bool {
     get_symbol_property_attrs(owner, sym_key)
         .map(|attrs| attrs.enumerable())


### PR DESCRIPTION
## Problem (#6710)

Under concurrent requests, a Next.js App Router (standalone) app compiled by Perry intermittently wedges: HTML routes start returning 500 with `InvariantError: Expected RSC response, got text/html` (E789) escaping as an unhandled rejection. Node running the identical bundle never does this.

## Root cause

`perry-ffi`'s handle registry hands a freed `IncomingMessage` / `ServerResponse` handle id back out from its bounded freelist (`register_handle` → `pop_free_handle`). The JS `req`/`res` object is just `POINTER_TAG | handle_id`, and every per-handle JS side table is keyed by that id:

- `HANDLE_EXPANDO_PROPS` — arbitrary string own-props (`req.foo = ...`)
- `SYMBOL_PROPERTIES` / `SYMBOL_PROPERTY_ATTRS` / `SYMBOL_ACCESSOR_PROPERTIES` — symbol-keyed props
- `descriptor_state::{PROPERTY_DESCRIPTORS, ACCESSOR_DESCRIPTORS}` — attrs / accessors

None of these were cleared when an id is recycled. (The GC dead-owner sweep only reaps entries whose owner is a dead *heap* object; a recycled handle id is not a heap owner, so its entries survive.) A new request that reuses a recycled id therefore inherits the previous request's props.

Next.js stores `isRSCRequest` on `req` via `req[Symbol.for("NextInternalRequestMeta")]`. So a plain HTML request that reuses a concurrent RSC request's id reads `isRSCRequest = true`, takes the RSC response branch, and rejects its own (correct) HTML output → E789 → unhandled rejection → wedge.

Minimal, framework-free reproduction (`http.createServer` that stamps each `req` with a unique id, 100 concurrent requests): **19 distinct `req` objects before this change, 100 after — node is 100.**

## Fix

Add `js_handle_clear_side_tables(id)` in perry-runtime, which clears all four id-keyed tables for a handle id, and call it from the HTTP request pump (`process_pending` / `process_pending_https` / `process_pending_h2`) on the main (JS-owning) thread — before any `'request'` listener or the handler observes `req`/`res`. Each request now starts with a clean `req`/`res`. This mirrors the existing `exotic_expando::expando_clear_on_alloc` precedent that solves the same address-reuse leak for heap objects.

The clear runs on the main thread because `HANDLE_EXPANDO_PROPS` is thread-local and the handle is allocated on a tokio worker while its JS props are only ever set on the main thread.

## Validation

- Minimal repro above: 19 → 100 distinct req objects (matches node).
- gscmaster (Next 16 App Router): the concurrent mixed RSC/HTML burst that wedged by round 2–3 now runs clean — zero `Expected RSC response` invariants, no unhandled rejections, `/de` stays 200.
- `cargo test -p perry-runtime --lib` (single-threaded): 1438 passed, 0 failed. New unit test `handle_expando::tests::clear_drops_all_props`.
- `cargo fmt --all -- --check`: clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where recycled HTTP request/response handles could retain stale JavaScript properties or symbol metadata.
  * Improved cleanup consistency across HTTP, HTTPS, and HTTP/2, ensuring request/response objects start in a clean state before any listeners or handlers run.
  * Reduced the risk of cross-request data leakage for expando properties and descriptor-related state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->