### PR TITLE
fix(url): route URLSearchParams subclass instances to their native backing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,43 @@
+## v0.5.1264 — fix(url): route URLSearchParams subclass instances to their native backing (#6738)
+
+`class X extends URLSearchParams` — most importantly Next.js's `ReadonlyURLSearchParams`
+returned by `useSearchParams()`, on the logout path — lost its entire inherited surface:
+`r.get(k)`/`r.has(k)` threw `TypeError: value is not a function`, `r.toString()` returned
+`"[object Object]"`, `r.size` read `undefined`, and `for (const [k, v] of r)` threw
+`next is not a function`. Root cause: Perry lowers the URLSearchParams method/property
+surface by the receiver's **static type** (`Expr::UrlSearchParams*`), not as real
+`URLSearchParams.prototype` methods, so a subclass-typed receiver matches none of those
+static arms and falls through to generic class dispatch, which has no such member.
+
+Fix — attach a hidden **native URLSearchParams backing** to the subclass instance at
+`super()` and delegate the inherited surface to it:
+
+- **Runtime backing** (`url/search_params.rs`): `js_url_search_params_subclass_init` creates a
+  native URLSearchParams and stashes it on `this` under a hidden key;
+  `url_search_params_backing_of` / `resolve_search_params_receiver` resolve it, and the
+  read/write runtime methods resolve the backing internally so the subclass instance stays
+  the observable object. All three helpers root the receiver across the (heap-allocating)
+  backing-key string and `js_url_search_params_new_any` via `RuntimeHandleScope`.
+- **super() codegen**: emit the init from all three derived-construction paths — explicit
+  `super(init)`, implicit `super(...args)` (`SuperCallSpread`), and the no-constructor `new`
+  path.
+- **Method dispatch**: the existing `#5961` dynamic-URLSearchParams block in
+  `js_native_call_method` resolves the backing when the native shape probe misses, reusing
+  `url_search_params_dynamic_call` (correct boolean/string/array boxing), extracted to
+  `try_url_search_params_dynamic_dispatch`. A codegen carve-out routes subclass method calls
+  into `js_native_call_method` instead of the static class tower, and the universal
+  `.toString()` arm defers to it.
+- **`.size` and iteration**: new codegen `.size` property arm and a `js_get_iterator`
+  backing branch (yields `[key, value]` pairs).
+
+A user override (Next's throwing `append`/`delete`/`set`/`sort` on `ReadonlyURLSearchParams`)
+still resolves first via the static class tower, preserving read-only semantics. Validated
+byte-identical to `node --experimental-strip-types` across get/getAll/has(name[,value])/set/
+append/delete/toString/forEach/sort, `.size`, entries()/keys()/values()/for-of, explicit and
+implicit super, and throwing read-only overrides; GC-rooting verified under
+`PERRY_GC_FORCE_EVACUATE=1 PERRY_GC_VERIFY_EVACUATION=1`. No regression to native
+URLSearchParams, Map/Set subclasses, plain-class or user `toString`, or `number.toString(radix)`.
+
 ## v0.5.1263 — fix(cache): key the object cache on all codegen-affecting env vars (#6394, PR #6526)
 
 The per-module object cache (`node_modules/.cache/perry`) keyed on a curated

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Perry is a native TypeScript compiler written in Rust that compiles TypeScript source code directly to native executables. It uses SWC for TypeScript parsing and LLVM for code generation.
 
-**Current Version:** 0.5.1263
+**Current Version:** 0.5.1264
 
 
 ## TypeScript Parity Status

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -343,7 +343,7 @@ codegen-units = 16
 codegen-units = 16
 
 [workspace.package]
-version = "0.5.1263"
+version = "0.5.1264"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/PerryTS/perry"

--- a/crates/perry-codegen/src/expr/property_get.rs
+++ b/crates/perry-codegen/src/expr/property_get.rs
@@ -14,7 +14,8 @@ use crate::native_value::{
 };
 use crate::type_analysis::{
     is_array_expr, is_map_expr, is_numeric_typed_array_class, is_set_expr, is_string_expr,
-    is_url_search_params_expr, receiver_class_name, receiver_is_error_type,
+    is_url_search_params_expr, is_url_search_params_subclass_expr, receiver_class_name,
+    receiver_is_error_type,
 };
 use crate::types::{DOUBLE, I1, I32, I64, I8, PTR};
 
@@ -431,6 +432,19 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
         Expr::PropertyGet {
             object, property, ..
         } if property == "size" && is_url_search_params_expr(ctx, object) => {
+            let recv_box = lower_expr(ctx, object)?;
+            let blk = ctx.block();
+            let recv_handle = unbox_to_i64(blk, &recv_box);
+            let i32_v = blk.call(I32, "js_url_search_params_size", &[(I64, &recv_handle)]);
+            Ok(blk.sitofp(I32, &i32_v, DOUBLE))
+        }
+        // #6710: `class X extends URLSearchParams` instance `.size` — the
+        // generic object-field lookup returns undefined (the entries live on the
+        // hidden native backing, not a `size` field). `js_url_search_params_size`
+        // resolves the backing internally, so pass the subclass instance.
+        Expr::PropertyGet {
+            object, property, ..
+        } if property == "size" && is_url_search_params_subclass_expr(ctx, object) => {
             let recv_box = lower_expr(ctx, object)?;
             let blk = ctx.block();
             let recv_handle = unbox_to_i64(blk, &recv_box);

--- a/crates/perry-codegen/src/expr/this_super_call.rs
+++ b/crates/perry-codegen/src/expr/this_super_call.rs
@@ -186,6 +186,34 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 )?;
                 return Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));
             }
+            // `class X extends URLSearchParams` via a spread/implicit super
+            // (`class R extends URLSearchParams {}` synthesizes `super(...args)`)
+            // — install the native backing from the first arg instead of routing
+            // the uncallable builtin ctor through `js_super_construct_apply`.
+            // Mirrors the non-spread `Expr::SuperCall` URLSearchParams arm.
+            let is_usp = ctx
+                .classes
+                .get(&current_class_name)
+                .and_then(|c| c.extends_name.as_deref())
+                .map(|p| p == "URLSearchParams")
+                .unwrap_or(false);
+            if is_usp {
+                let zero_idx = "0".to_string();
+                let first =
+                    ctx.block()
+                        .call(DOUBLE, "js_array_get_f64", &[(I64, &arr), (I32, &zero_idx)]);
+                ctx.block().call(
+                    DOUBLE,
+                    "js_url_search_params_subclass_init",
+                    &[(DOUBLE, &this_box), (DOUBLE, &first)],
+                );
+                crate::lower_call::apply_field_initializers_recursive(
+                    ctx,
+                    &current_class_name,
+                    crate::lower_call::FieldInitMode::SelfOnly,
+                )?;
+                return Ok(double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED)));
+            }
             if let Some(&child_cid) = ctx.class_ids.get(&current_class_name) {
                 let cid_str = child_cid.to_string();
                 let blk = ctx.block();
@@ -265,6 +293,37 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
             let parent_class = match static_parent_lookup {
                 Some(c) => c,
                 None => {
+                    // #6710 follow-up: `class X extends URLSearchParams` (Next's
+                    // `ReadonlyURLSearchParams`). The parent is a construct-only
+                    // builtin — not a user class and not a callable value — so the
+                    // dynamic-parent / `js_fetch_or_value_super` dispatch below
+                    // would call it as a plain function and throw "not a function".
+                    // Build the native params and stash them on `this` as a hidden
+                    // backing instead; the inherited surface resolves it via
+                    // `resolve_search_params_receiver`.
+                    if parent_name == "URLSearchParams" {
+                        let undef = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+                        let mut lowered: Vec<String> = Vec::with_capacity(super_args.len());
+                        for a in super_args {
+                            lowered.push(lower_expr(ctx, a)?);
+                        }
+                        let init = lowered.first().cloned().unwrap_or_else(|| undef.clone());
+                        let this_box = match ctx.this_stack.last().cloned() {
+                            Some(slot) => ctx.block().load(DOUBLE, &slot),
+                            None => undef.clone(),
+                        };
+                        ctx.block().call(
+                            DOUBLE,
+                            "js_url_search_params_subclass_init",
+                            &[(DOUBLE, &this_box), (DOUBLE, &init)],
+                        );
+                        crate::lower_call::apply_field_initializers_recursive(
+                            ctx,
+                            &current_class_name,
+                            crate::lower_call::FieldInitMode::SelfOnly,
+                        )?;
+                        return Ok(undef);
+                    }
                     // #321 / #66 (#1787 follow-up): `class Sub extends <runtimeValueFn>`
                     // — the parent is a runtime-value function/closure (the IIFE-
                     // returned constructor function `Base` in Effect's `Data.Class`).

--- a/crates/perry-codegen/src/lower_call/console_promise.rs
+++ b/crates/perry-codegen/src/lower_call/console_promise.rs
@@ -781,6 +781,17 @@ pub fn try_lower_native_method_str_dispatch(
             .as_deref()
             .is_some_and(|n| class_extends_builtin_array(ctx, n))
             && is_array_like_method(property.as_str());
+        // A `class X extends URLSearchParams` instance's methods (`get`/`has`/
+        // `set`/…) are NOT class methods — they live on the hidden native
+        // backing installed by `js_url_search_params_subclass_init` at
+        // `super()`. The static class-dispatch tower would read them as a
+        // non-callable property and throw "value is not a function", so route
+        // them through `js_native_call_method` (whose `dispatch_url_search_params`
+        // redirects onto the backing). Mirrors `is_collection_subclass_method`.
+        let is_url_search_params_subclass_method = class_name_opt
+            .as_deref()
+            .is_some_and(|n| crate::type_analysis::class_name_extends_url_search_params(ctx, n))
+            && is_url_search_params_method(property.as_str());
         let skip_native = matches!(object.as_ref(), Expr::GlobalGet(_))
             || matches!(object.as_ref(), Expr::NativeModuleRef(_))
             || (class_name_opt.is_some()
@@ -788,7 +799,8 @@ pub fn try_lower_native_method_str_dispatch(
                 && !class_unknown_to_codegen
                 && !is_well_known_proto_method
                 && !is_collection_subclass_method
-                && !is_array_subclass_method);
+                && !is_array_subclass_method
+                && !is_url_search_params_subclass_method);
         if !skip_native {
             // Issue #92 fast path: intrinsify Buffer numeric reads
             // (`buf.readInt32BE(off)` etc.) when the receiver is a tracked
@@ -1034,6 +1046,29 @@ pub fn class_extends_builtin_array(ctx: &FnCtx<'_>, cls_name: &str) -> bool {
         depth += 1;
     }
     false
+}
+
+/// The `URLSearchParams.prototype` methods handled by the runtime's
+/// `dispatch_url_search_params` over a subclass instance's hidden native
+/// backing. A name outside this set stays on the normal class-dispatch path (a
+/// genuine user override already resolved earlier). `size` is a getter, not a
+/// method, so it is intentionally absent.
+fn is_url_search_params_method(method: &str) -> bool {
+    matches!(
+        method,
+        "get"
+            | "getAll"
+            | "has"
+            | "set"
+            | "append"
+            | "delete"
+            | "toString"
+            | "entries"
+            | "keys"
+            | "values"
+            | "forEach"
+            | "sort"
+    )
 }
 
 /// The inherited `Array.prototype` methods the runtime's spec-generic array-like

--- a/crates/perry-codegen/src/lower_call/new.rs
+++ b/crates/perry-codegen/src/lower_call/new.rs
@@ -980,6 +980,12 @@ fn lower_new_impl(
     // Promise constructor against a hidden backing cell (see new_helpers). (#5991)
     let promise_parent_runtime =
         !has_own_ctor && !has_imported_ctor && class.extends_name.as_deref() == Some("Promise");
+    // `class X extends URLSearchParams {}` (Next's `ReadonlyURLSearchParams`) with
+    // no own ctor — `new X(init)` builds a native URLSearchParams and stashes it
+    // as a hidden backing on `this` (#6710 follow-up).
+    let usp_parent_runtime = !has_own_ctor
+        && !has_imported_ctor
+        && class.extends_name.as_deref() == Some("URLSearchParams");
     let inherited_ctor_class: Option<String> = if !has_own_ctor && has_extends {
         // Walk the inheritance chain to find the closest ancestor with
         // an explicit ctor — same logic as the body-inlining loop below.
@@ -1336,6 +1342,25 @@ fn lower_new_impl(
             emit_promise_subclass_init(ctx, &lowered_args);
             found_inherited_ctor = true;
         }
+        if usp_parent_runtime {
+            let undef_lit = double_literal(f64::from_bits(crate::nanbox::TAG_UNDEFINED));
+            let init = lowered_args
+                .first()
+                .cloned()
+                .unwrap_or_else(|| undef_lit.clone());
+            let this_box = ctx
+                .this_stack
+                .last()
+                .cloned()
+                .map(|slot| ctx.block().load(DOUBLE, &slot))
+                .unwrap_or_else(|| undef_lit.clone());
+            ctx.block().call(
+                DOUBLE,
+                "js_url_search_params_subclass_init",
+                &[(DOUBLE, &this_box), (DOUBLE, &init)],
+            );
+            found_inherited_ctor = true;
+        }
         // If no parent constructor was found (imported class with no
         // inlineable constructor body), call the cross-module constructor.
         // Refs #420: walk past empty-bodied ancestors with param_count==0
@@ -1591,6 +1616,7 @@ fn lower_new_impl(
         if builtin_parent_runtime.is_some()
             || fetch_parent_runtime.is_some()
             || promise_parent_runtime
+            || usp_parent_runtime
             || (class.extends_expr.is_some() && !has_extends)
         {
             apply_field_initializers_recursive(ctx, class_name, FieldInitMode::SelfOnly)?;

--- a/crates/perry-codegen/src/lower_call/property_get/number_string.rs
+++ b/crates/perry-codegen/src/lower_call/property_get/number_string.rs
@@ -9,7 +9,8 @@ use perry_hir::Expr;
 use crate::expr::{lower_expr, nanbox_string_inline, FnCtx};
 use crate::nanbox::double_literal;
 use crate::type_analysis::{
-    is_array_expr, is_native_module_dynamic_index, is_string_expr, receiver_class_name,
+    is_array_expr, is_native_module_dynamic_index, is_string_expr,
+    is_url_search_params_subclass_expr, receiver_class_name,
 };
 use crate::types::{DOUBLE, I32, I64};
 
@@ -152,6 +153,7 @@ pub(crate) fn try_lower_number_string_methods(
         && !is_string_expr(ctx, object)
         && !is_array_expr(ctx, object)
         && !is_date_receiver(ctx, object)
+        && !is_url_search_params_subclass_expr(ctx, object)
     {
         // Only treat as radix call if class doesn't have toString.
         let has_user_to_string = receiver_class_name(ctx, object)
@@ -197,6 +199,7 @@ pub(crate) fn try_lower_number_string_methods(
         && !is_string_expr(ctx, object)
         && !is_array_expr(ctx, object)
         && !is_date_receiver(ctx, object)
+        && !is_url_search_params_subclass_expr(ctx, object)
     {
         // Check whether the receiver class (if any) defines
         // toString itself or via inheritance.

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi/web.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi/web.rs
@@ -66,6 +66,13 @@ pub(crate) fn declare_web(module: &mut LlModule) {
     // undefined — see `js_url_search_params_new_any` rustdoc. Refs #575.
     module.declare_function("js_url_search_params_new_any", I64, &[DOUBLE]);
     module.declare_function("js_url_search_params_new_empty", I64, &[]);
+    // #6710 follow-up: `super(init)` for `class X extends URLSearchParams`
+    // (this, init) -> undefined. Stashes a native backing on `this`.
+    module.declare_function(
+        "js_url_search_params_subclass_init",
+        DOUBLE,
+        &[DOUBLE, DOUBLE],
+    );
     module.declare_function("js_url_search_params_set", VOID, &[I64, DOUBLE, DOUBLE]);
     module.declare_function("js_url_search_params_to_string", I64, &[I64]);
     // Issue #650: URLSearchParams.size getter — returns entries count.

--- a/crates/perry-codegen/src/type_analysis.rs
+++ b/crates/perry-codegen/src/type_analysis.rs
@@ -52,7 +52,8 @@ pub(crate) use refine::{
     is_process_namespace_version_property, refine_type_from_init,
 };
 pub(crate) use strings::{
-    is_definitely_string_expr, is_map_expr, is_set_expr, is_string_expr, is_url_search_params_expr,
+    class_name_extends_url_search_params, is_definitely_string_expr, is_map_expr, is_set_expr,
+    is_string_expr, is_url_search_params_expr, is_url_search_params_subclass_expr,
     map_static_type_args, set_static_type_args,
 };
 

--- a/crates/perry-codegen/src/type_analysis/strings.rs
+++ b/crates/perry-codegen/src/type_analysis/strings.rs
@@ -93,6 +93,45 @@ pub(crate) fn is_url_search_params_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
     }
 }
 
+/// #6710: True when `name` is a user class that (transitively) extends the
+/// builtin `URLSearchParams` — `class ReadonlyURLSearchParams extends
+/// URLSearchParams` (Next.js), `class B extends ReadonlyURLSearchParams`, …
+/// `URLSearchParams` itself returns false: a directly-typed receiver is lowered
+/// statically (`Expr::UrlSearchParams*`) and must not be treated as a subclass.
+/// Shared by the codegen carve-outs that route a subclass instance's inherited
+/// surface (methods, `.size`, iteration) onto its hidden native backing.
+pub(crate) fn class_name_extends_url_search_params(ctx: &FnCtx<'_>, name: &str) -> bool {
+    if name == "URLSearchParams" {
+        return false;
+    }
+    let mut cur = Some(name.to_string());
+    let mut depth = 0usize;
+    while let Some(c) = cur {
+        if depth > 32 {
+            break;
+        }
+        match ctx.classes.get(&c) {
+            Some(cd) => {
+                if cd.extends_name.as_deref() == Some("URLSearchParams") {
+                    return true;
+                }
+                cur = cd.extends_name.clone();
+            }
+            // Reached a name codegen doesn't track — it may be the builtin
+            // `URLSearchParams` heritage itself.
+            None => return c == "URLSearchParams",
+        }
+        depth += 1;
+    }
+    false
+}
+
+/// Expr form of [`class_name_extends_url_search_params`] — resolves the
+/// receiver's class name first, then walks its heritage.
+pub(crate) fn is_url_search_params_subclass_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
+    receiver_class_name(ctx, e).is_some_and(|n| class_name_extends_url_search_params(ctx, &n))
+}
+
 pub(crate) fn is_map_expr(ctx: &FnCtx<'_>, e: &Expr) -> bool {
     match e {
         Expr::MapNew | Expr::MapNewFromArray(_) => true,

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -855,56 +855,19 @@ pub unsafe extern "C" fn js_native_call_method(
             }
         }
     }
-    // #5961: native URLSearchParams is an ordinary object (class_id == 0,
-    // leading `_entries` slot) whose method surface normally resolves via
-    // static type-directed lowering. A fused dynamic call on a type-erased
-    // receiver lands here — dispatch the covered surface to the natives
-    // before the generic field-scan misses and throws "is not a function".
-    if matches!(
+    // #5961/#6710: native URLSearchParams (class_id == 0, leading `_entries`
+    // slot) AND `class X extends URLSearchParams` subclass instances resolve
+    // their method surface via static type-directed lowering. A fused dynamic
+    // call on a type-erased receiver lands here — dispatch the covered surface
+    // to the natives (shape-probed for the native form, hidden backing for the
+    // subclass) before the generic field-scan misses.
+    if let Some(result) = crate::url::search_params::try_url_search_params_dynamic_dispatch(
+        object,
         method_name,
-        "append"
-            | "set"
-            | "get"
-            | "has"
-            | "delete"
-            | "toString"
-            | "entries"
-            | "keys"
-            | "values"
-            | "getAll"
-            | "sort"
-            | "forEach"
+        args_ptr,
+        args_len,
     ) {
-        // Only a pointer-shaped receiver (NaN-boxed pointer above the handle
-        // band, or a raw untagged heap address) may be shape-probed. A plain
-        // double must NOT have its low 48 bits read as an address: a Web
-        // Streams handle id (`1049102.0`) extracts to `(id - 2^20) * 2^32`,
-        // which passes the macOS 2 TB heap floor once ~512 stream ids are
-        // live and the probe then dereferences unmapped memory — the
-        // gscmaster request-12 SIGSEGV (`for await` resolves @@asyncIterator
-        // to a bound `values` re-dispatch landing here with the numeric
-        // handle as receiver; Linux's 0x1000 floor probes low memory from
-        // id 1). Numeric stream receivers fall through to the
-        // primitive-methods stream dispatch that owns them.
-        let bits = object.to_bits();
-        let top16 = bits >> 48;
-        let payload = (bits & 0x0000_FFFF_FFFF_FFFF) as usize;
-        let pointer_shaped = (top16 == 0x7FFD
-            && crate::value::addr_class::is_above_handle_band(payload))
-            || (top16 == 0 && payload >= 0x10000);
-        if pointer_shaped {
-            let recv_ptr = payload as *mut ObjectHeader;
-            if crate::url::search_params::shape_is_url_search_params(recv_ptr) {
-                if let Some(result) = crate::url::search_params::url_search_params_dynamic_call(
-                    recv_ptr,
-                    method_name,
-                    args_ptr,
-                    args_len,
-                ) {
-                    return result;
-                }
-            }
-        }
+        return result;
     }
     // AbortSignal on a type-erased receiver — same wall class as the
     // URLSearchParams block above (#5961/#5964): the statically-typed receiver

--- a/crates/perry-runtime/src/symbol/iterator.rs
+++ b/crates/perry-runtime/src/symbol/iterator.rs
@@ -290,6 +290,16 @@ pub extern "C" fn js_get_iterator(val_f64: f64) -> f64 {
                 let entries = crate::url::js_url_search_params_entries_arr(obj);
                 return crate::array::array_values_iter(entries);
             }
+            // #6710: a `class X extends URLSearchParams` instance (Next's
+            // `ReadonlyURLSearchParams`) stores its entries on a hidden native
+            // backing rather than its own `_entries`/`_owner` fields, so the
+            // shape probe above misses. Default `for (const [k, v] of r)` still
+            // yields `[key, value]` pairs from the backing.
+            if let Some(backing) = crate::url::search_params::url_search_params_backing_of(val_f64)
+            {
+                let entries = crate::url::js_url_search_params_entries_arr(backing);
+                return crate::array::array_values_iter(entries);
+            }
         }
     }
     match crate::object::map_set_subclass::subclass_backing_for_default_iteration(val_f64) {

--- a/crates/perry-runtime/src/url/search_params.rs
+++ b/crates/perry-runtime/src/url/search_params.rs
@@ -17,6 +17,120 @@ pub(crate) const URL_SEARCH_PARAMS_ENTRIES: u32 = 0; // Array of [key, value] pa
 pub(crate) const URL_SEARCH_PARAMS_OWNER: u32 = 1;
 pub(crate) const URL_SEARCH_PARAMS_FIELD_COUNT: u32 = 2;
 
+/// Hidden field installed on a `class X extends URLSearchParams` instance by
+/// `js_url_search_params_subclass_init`, holding the native backing params
+/// object that the inherited method surface actually operates on.
+pub(crate) const URL_SEARCH_PARAMS_BACKING_KEY: &[u8] = b"__perry_usp_backing__";
+
+/// Resolve a URLSearchParams method receiver to the native params object it
+/// operates on.
+///
+/// `new URLSearchParams(...)` returns a native object (entries at slot 0)
+/// directly. A `class X extends URLSearchParams` instance is a plain object
+/// that carries the native params under [`URL_SEARCH_PARAMS_BACKING_KEY`]; every
+/// read/write funnels through here so the inherited surface behaves correctly on
+/// the subclass (Next's `ReadonlyURLSearchParams` — a `class extends
+/// URLSearchParams` — is on the logout path). A native params object has no such
+/// field, so the lookup misses and the receiver is returned unchanged.
+pub(crate) fn resolve_search_params_receiver(params: *mut ObjectHeader) -> *mut ObjectHeader {
+    if params.is_null() {
+        return params;
+    }
+    // `URL_SEARCH_PARAMS_BACKING_KEY` is longer than a short string, so
+    // `js_string_from_bytes` heap-allocates and may GC-evacuate `params` before
+    // the field read dereferences it. Root it across the allocation and reload.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let params_handle = scope.root_raw_mut_ptr(params);
+    let key = js_string_from_bytes(
+        URL_SEARCH_PARAMS_BACKING_KEY.as_ptr(),
+        URL_SEARCH_PARAMS_BACKING_KEY.len() as u32,
+    );
+    let params = params_handle.get_raw_mut_ptr::<ObjectHeader>();
+    let backing = unsafe { crate::object::js_object_get_field_by_name(params, key) };
+    if backing.is_pointer() {
+        let ptr = backing.as_pointer::<ObjectHeader>() as *mut ObjectHeader;
+        if !ptr.is_null() {
+            return ptr;
+        }
+    }
+    params
+}
+
+/// The native backing params for a `class X extends URLSearchParams` instance,
+/// or `None` for a native URLSearchParams / any other object. Lets the runtime
+/// method dispatcher (`native_call_method`) recognize a subclass instance whose
+/// `r.get()`/`r.has()`/… lowered generically (the HIR method-lowering only fires
+/// for a statically `URLSearchParams`-typed receiver, not a subclass type).
+pub(crate) fn url_search_params_backing_of(object: f64) -> Option<*mut ObjectHeader> {
+    let jv = crate::value::JSValue::from_bits(object.to_bits());
+    if !jv.is_pointer() {
+        return None;
+    }
+    let obj = crate::value::js_nanbox_get_pointer(object) as *mut ObjectHeader;
+    if obj.is_null() {
+        return None;
+    }
+    // Root `obj` across the (heap-allocating) key string so a GC evacuation
+    // mid-allocation can't leave it dangling before the field read.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let obj_handle = scope.root_raw_mut_ptr(obj);
+    let key = js_string_from_bytes(
+        URL_SEARCH_PARAMS_BACKING_KEY.as_ptr(),
+        URL_SEARCH_PARAMS_BACKING_KEY.len() as u32,
+    );
+    let obj = obj_handle.get_raw_mut_ptr::<ObjectHeader>();
+    let backing = unsafe { crate::object::js_object_get_field_by_name(obj, key) };
+    if backing.is_pointer() {
+        let ptr = backing.as_pointer::<ObjectHeader>() as *mut ObjectHeader;
+        if !ptr.is_null() {
+            return Some(ptr);
+        }
+    }
+    None
+}
+
+/// `super(init)` for `class X extends URLSearchParams`. Builds a native
+/// URLSearchParams from `init` and stashes it on `this` under
+/// [`URL_SEARCH_PARAMS_BACKING_KEY`]; the inherited method surface resolves it
+/// via [`resolve_search_params_receiver`]. Returns undefined (super's value).
+#[no_mangle]
+pub extern "C" fn js_url_search_params_subclass_init(this: f64, init: f64) -> f64 {
+    let undef = f64::from_bits(crate::value::TAG_UNDEFINED);
+    let this_jv = crate::value::JSValue::from_bits(this.to_bits());
+    if !this_jv.is_pointer() {
+        return undef;
+    }
+    let this_obj = crate::value::js_nanbox_get_pointer(this) as *mut ObjectHeader;
+    if this_obj.is_null() {
+        return undef;
+    }
+    // Every allocation below (the key string, the native backing, and the
+    // field-storage growth in the final write) can GC-evacuate the objects held
+    // in raw pointers. Root `this`, the key, and the backing, and reload each
+    // from its handle after the last allocation before the field write.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let this_handle = scope.root_raw_mut_ptr(this_obj);
+    let key = js_string_from_bytes(
+        URL_SEARCH_PARAMS_BACKING_KEY.as_ptr(),
+        URL_SEARCH_PARAMS_BACKING_KEY.len() as u32,
+    );
+    let key_handle = scope.root_string_ptr(key);
+    let backing = js_url_search_params_new_any(init);
+    let backing_handle = scope.root_raw_mut_ptr(backing);
+    let this_obj = this_handle.get_raw_mut_ptr::<ObjectHeader>();
+    let key = key_handle.get_raw_const_ptr::<crate::StringHeader>();
+    let backing_ptr = backing_handle.get_raw_mut_ptr::<ObjectHeader>();
+    let backing_f64 = crate::value::js_nanbox_pointer(backing_ptr as i64);
+    unsafe { crate::object::js_object_set_field_by_name(this_obj, key, backing_f64) };
+    undef
+}
+
+/// Reached only from codegen-emitted IR (the `Expr::SuperCall` URLSearchParams
+/// arm); pin it so the auto-optimize bitcode rebuild's dead-strip can't drop it.
+#[used]
+static KEEP_JS_URL_SEARCH_PARAMS_SUBCLASS_INIT: extern "C" fn(f64, f64) -> f64 =
+    js_url_search_params_subclass_init;
+
 fn throw_invalid_query_pair_tuple() -> ! {
     let msg = b"Each query pair must be an iterable [name, value] tuple";
     let s = js_string_from_bytes(msg.as_ptr(), msg.len() as u32);
@@ -229,6 +343,8 @@ pub(crate) fn get_url_search_params_entries(params: *mut ObjectHeader) -> Vec<(S
     if params.is_null() {
         return Vec::new();
     }
+    // Subclass instances carry the native params under a hidden backing field.
+    let params = resolve_search_params_receiver(params);
 
     let entries_f64 = crate::object::js_object_get_field_f64(params, URL_SEARCH_PARAMS_ENTRIES);
     let entries_ptr: *mut ArrayHeader = f64::to_bits(entries_f64).cast_signed() as *mut ArrayHeader;
@@ -550,7 +666,11 @@ pub extern "C" fn js_url_search_params_set(
         entries_array = js_array_push_f64(entries_array, pair_f64);
     }
     let entries_f64 = f64::from_bits(i64::cast_unsigned(entries_array as i64));
-    js_object_set_field_f64(params, URL_SEARCH_PARAMS_ENTRIES, entries_f64);
+    js_object_set_field_f64(
+        resolve_search_params_receiver(params),
+        URL_SEARCH_PARAMS_ENTRIES,
+        entries_f64,
+    );
     unsafe { maybe_sync_params_to_owner(params) };
 }
 
@@ -578,7 +698,11 @@ pub extern "C" fn js_url_search_params_append(
         entries_array = js_array_push_f64(entries_array, pair_f64);
     }
     let entries_f64 = f64::from_bits(i64::cast_unsigned(entries_array as i64));
-    js_object_set_field_f64(params, URL_SEARCH_PARAMS_ENTRIES, entries_f64);
+    js_object_set_field_f64(
+        resolve_search_params_receiver(params),
+        URL_SEARCH_PARAMS_ENTRIES,
+        entries_f64,
+    );
     unsafe { maybe_sync_params_to_owner(params) };
 }
 
@@ -601,7 +725,11 @@ pub extern "C" fn js_url_search_params_delete(params: *mut ObjectHeader, name_va
         entries_array = js_array_push_f64(entries_array, pair_f64);
     }
     let entries_f64 = f64::from_bits(i64::cast_unsigned(entries_array as i64));
-    js_object_set_field_f64(params, URL_SEARCH_PARAMS_ENTRIES, entries_f64);
+    js_object_set_field_f64(
+        resolve_search_params_receiver(params),
+        URL_SEARCH_PARAMS_ENTRIES,
+        entries_f64,
+    );
     unsafe { maybe_sync_params_to_owner(params) };
 }
 
@@ -652,7 +780,11 @@ pub extern "C" fn js_url_search_params_delete2(
         entries_array = js_array_push_f64(entries_array, pair_f64);
     }
     let entries_f64 = f64::from_bits(i64::cast_unsigned(entries_array as i64));
-    js_object_set_field_f64(params, URL_SEARCH_PARAMS_ENTRIES, entries_f64);
+    js_object_set_field_f64(
+        resolve_search_params_receiver(params),
+        URL_SEARCH_PARAMS_ENTRIES,
+        entries_f64,
+    );
     unsafe { maybe_sync_params_to_owner(params) };
 }
 
@@ -665,6 +797,7 @@ pub extern "C" fn js_url_search_params_size(params: *mut ObjectHeader) -> i32 {
     if params.is_null() {
         return 0;
     }
+    let params = resolve_search_params_receiver(params);
     let entries_f64 = crate::object::js_object_get_field_f64(params, URL_SEARCH_PARAMS_ENTRIES);
     let entries_ptr: *const ArrayHeader =
         f64::to_bits(entries_f64).cast_signed() as *const ArrayHeader;
@@ -749,7 +882,11 @@ pub extern "C" fn js_url_search_params_sort(params: *mut ObjectHeader) {
         entries_array = js_array_push_f64(entries_array, pair_f64);
     }
     let entries_f64 = f64::from_bits(i64::cast_unsigned(entries_array as i64));
-    js_object_set_field_f64(params, URL_SEARCH_PARAMS_ENTRIES, entries_f64);
+    js_object_set_field_f64(
+        resolve_search_params_receiver(params),
+        URL_SEARCH_PARAMS_ENTRIES,
+        entries_f64,
+    );
     unsafe { maybe_sync_params_to_owner(params) };
 }
 
@@ -914,6 +1051,72 @@ extern "C" fn usp_delete_thunk(closure: *const crate::closure::ClosureHeader, na
 /// on a type-erased receiver): dispatch the covered URLSearchParams surface to
 /// the natives. Returns `None` for uncovered names so the generic dispatch
 /// keeps its existing behavior.
+/// #5961/#6710: dispatch the covered URLSearchParams method surface for a
+/// type-erased (fused dynamic) receiver — both a native-shape URLSearchParams
+/// and a `class X extends URLSearchParams` subclass instance (Next's
+/// `ReadonlyURLSearchParams`), whose entries live on a hidden native backing.
+/// The statically-typed form lowers to the native call; this handles the fused
+/// dynamic form before the generic field-scan misses and throws
+/// "is not a function" (or the generic `toString` → "[object Object]" default).
+/// `object` is the NaN-boxed receiver. Returns `Some(result)` when handled,
+/// `None` to fall through to generic dispatch. The receiver's pointer payload
+/// is only handed to a shape probe after `pointer_shaped` rejects plain doubles
+/// and low handle-band ids (a Web Streams handle id extracts to an unmapped
+/// address past the macOS 2 TB heap floor).
+pub(crate) fn try_url_search_params_dynamic_dispatch(
+    object: f64,
+    method_name: &str,
+    args_ptr: *const f64,
+    args_len: usize,
+) -> Option<f64> {
+    if !matches!(
+        method_name,
+        "append"
+            | "set"
+            | "get"
+            | "has"
+            | "delete"
+            | "toString"
+            | "entries"
+            | "keys"
+            | "values"
+            | "getAll"
+            | "sort"
+            | "forEach"
+    ) {
+        return None;
+    }
+    // Only a pointer-shaped receiver (NaN-boxed pointer above the handle band,
+    // or a raw untagged heap address) may be shape-probed. A plain double must
+    // NOT have its low 48 bits read as an address: a Web Streams handle id
+    // (`1049102.0`) extracts to `(id - 2^20) * 2^32`, which passes the macOS
+    // 2 TB heap floor once ~512 stream ids are live and the probe then
+    // dereferences unmapped memory (the gscmaster request-12 SIGSEGV; Linux's
+    // 0x1000 floor probes low memory from id 1). Numeric stream receivers fall
+    // through to the primitive-methods stream dispatch that owns them.
+    let bits = object.to_bits();
+    let top16 = bits >> 48;
+    let payload = (bits & 0x0000_FFFF_FFFF_FFFF) as usize;
+    let pointer_shaped = (top16 == 0x7FFD
+        && crate::value::addr_class::is_above_handle_band(payload))
+        || (top16 == 0 && payload >= 0x10000);
+    if !pointer_shaped {
+        return None;
+    }
+    let recv_ptr = payload as *mut ObjectHeader;
+    if shape_is_url_search_params(recv_ptr) {
+        return url_search_params_dynamic_call(recv_ptr, method_name, args_ptr, args_len);
+    }
+    // #6710: a `class X extends URLSearchParams` instance — the native store
+    // lives on the hidden backing that `js_url_search_params_subclass_init`
+    // stashed at `super()`. Reuse the same dynamic dispatch (correct boolean/
+    // string/array boxing) the native-shape path uses.
+    if let Some(backing) = url_search_params_backing_of(object) {
+        return url_search_params_dynamic_call(backing, method_name, args_ptr, args_len);
+    }
+    None
+}
+
 pub(crate) fn url_search_params_dynamic_call(
     params: *mut ObjectHeader,
     name: &str,


### PR DESCRIPTION
## Problem

A `class X extends URLSearchParams` instance — most notably Next.js's
`ReadonlyURLSearchParams` returned by `useSearchParams()` — lost its entire
inherited surface:

- `r.get(k)` / `r.has(k)` threw `TypeError: value is not a function`
- `r.toString()` returned `"[object Object]"`
- `r.size` read `undefined`
- `for (const [k, v] of r)` threw `next is not a function`

Root cause: Perry lowers the URLSearchParams method/property surface by the
receiver's **static type** (`Expr::UrlSearchParams*`), not as real
`URLSearchParams.prototype` methods. A subclass-typed receiver
(`ReadonlyURLSearchParams`) matches none of those static arms, so every call
fell through to generic class dispatch, which has no such member.

This surfaced as a server-side exception on logout in a real Next.js 16 app.

## Fix

Attach a hidden **native URLSearchParams backing** to the subclass instance at
`super()` and delegate the inherited surface to it:

1. **Runtime backing** — `js_url_search_params_subclass_init` creates a native
   URLSearchParams and stashes it under a hidden key on `this`;
   `url_search_params_backing_of` / `resolve_search_params_receiver` resolve it.
   The read/write runtime methods resolve the backing internally, so the
   subclass instance stays the observable object.
2. **super() codegen** — emit the init from all three derived-construction
   paths: explicit `super(init)`, implicit `super(...args)`, and the
   no-constructor `new` path.
3. **Method dispatch** — the existing `#5961` dynamic-URLSearchParams block in
   `js_native_call_method` resolves the backing when the native shape probe
   misses, reusing `url_search_params_dynamic_call` (correct boolean / string /
   array boxing). It runs before the generic `toString → "[object Object]"`
   default. A codegen carve-out routes subclass method calls into
   `js_native_call_method` instead of the static class tower.
4. **`.size`, `.toString()`, iteration** — new codegen/runtime carve-outs route
   these to the backing (`.size` property arm, `toString` defers the universal
   arm, `js_get_iterator` yields `[key, value]` from the backing).

A **user override** (Next's throwing `append`/`delete`/`set`/`sort` on
`ReadonlyURLSearchParams`) still resolves first via the static class tower, so
read-only semantics are preserved.

## Validation

Byte-identical to `node --experimental-strip-types` across:

- `get` / `getAll` / `has(name[, value])` / `set` / `append` / `delete` /
  `toString` / `forEach` / `sort`
- `.size`, `entries()` / `keys()` / `values()`, and default `for...of`
- explicit and implicit `super`, and throwing read-only overrides

No regression to: native `URLSearchParams` (static lowering intact), `Map`/`Set`
subclasses, plain-class `toString` (`[object Object]`), user-defined
`toString`, or `number.toString(radix)`. Runtime `url`/`iterator`/`search_params`
lib tests pass; `cargo fmt --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored correct runtime behavior for classes extending `URLSearchParams`, including `super()`/`new` construction and native-backed state for derived variants such as `ReadonlyURLSearchParams`.
  * Fixed subclass handling for `.size`, method calls (including universal `.toString()`), and iterator behavior so it no longer falls back to generic/incorrect results.
  * Ensured all mutating `URLSearchParams` methods update the underlying entries consistently for subclasses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->