### PR TITLE
ci(bench): make embedded README benchmark table optional in the freshness gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,10 @@ jobs:
       - name: Public benchmark evidence freshness
         run: |
           PYTHONPATH=. python3 tests/test_public_baseline.py
-          python3 benchmarks/public_baseline.py check --max-age-days 45
+          # README embedded table is optional since #6736 (marketing landing
+          # page); this wrapper still enforces artifact freshness + RESULTS.md
+          # drift. Kept out of public_baseline.py to preserve harness_fingerprint.
+          python3 benchmarks/ci_public_baseline_check.py
 
       # File-size gate (v0.5.1019): fails the PR if any tracked source
       # file exceeds the LOC threshold (5000 initially; eventual target

--- a/benchmarks/ci_public_baseline_check.py
+++ b/benchmarks/ci_public_baseline_check.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""CI freshness gate for the public Node/Bun benchmark artifact.
+
+Thin wrapper over :mod:`public_baseline` that keeps the parts that still matter —
+artifact freshness/integrity (age, schema, source + harness fingerprints) and
+``benchmarks/suite/results/RESULTS.md`` drift — while treating the *embedded
+README table as optional*: README drift is enforced only when the generated
+``<!-- public-node-bun:start/end -->`` markers are present.
+
+Rationale: #6736 rewrote ``README.md`` as a concise marketing landing page with a
+different, hand-curated performance section and intentionally dropped the
+auto-generated public-node-bun block. ``public_baseline.py check`` still *requires*
+that block, so it fails on every PR ("README generated markers are missing").
+
+This policy lives in a SEPARATE module on purpose: ``public_baseline.py`` is a
+fingerprinted harness file (``HARNESS_PATHS``), so relaxing the check there would
+change ``harness_fingerprint`` and trip ``validate_public``'s "harness changed;
+regenerate" guard — which can't be satisfied without re-running the full
+Node/Bun/Perry benchmark suite. Reusing its functions from here leaves the file,
+and therefore the fingerprint, untouched.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import public_baseline as pb
+
+MAX_AGE_DAYS = 45
+
+
+def main() -> int:
+    try:
+        artifact = pb._load(pb.DEFAULT_ARTIFACT)
+        # Freshness + integrity (age, schema, source/harness fingerprints).
+        pb.validate_public(artifact, MAX_AGE_DAYS)
+        # Generated docs table must still track the artifact.
+        if pb.suite_results(artifact) != pb.SUITE_RESULTS.read_text(encoding="utf-8"):
+            raise pb.ArtifactError("suite RESULTS.md has drifted from the public artifact")
+        # README table is optional; enforce drift only when the markers exist.
+        readme = pb.README.read_text(encoding="utf-8")
+        if pb.README_START in readme and pb.README_END in readme:
+            if pb._replace_block(readme, pb.readme_block(artifact)) != readme:
+                raise pb.ArtifactError(
+                    "README Node/Bun table has drifted from the public artifact"
+                )
+    except (pb.ArtifactError, KeyError, OSError) as exc:
+        print(f"public baseline error: {exc}", file=sys.stderr)
+        return 2
+    print("public baseline freshness OK (embedded README table optional)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Problem

The `lint` job's **Public benchmark evidence freshness** step fails on every PR:

```
public baseline error: README generated markers are missing
```

**#6736** ("rewrite README as a concise, marketing-focused landing page") replaced
the auto-generated `<!-- public-node-bun:start/end -->` benchmark block with a
different, hand-curated performance section — but `benchmarks/public_baseline.py check`
still *requires* that block. Result: `lint` has been red on main and every open PR
since #6736 merged, unrelated to any PR's code.

## Fix

Relax the gate so the embedded README table is **optional**, without touching the
README:

- New `benchmarks/ci_public_baseline_check.py` reuses `public_baseline`'s functions
  to enforce **artifact freshness/integrity** (age ≤ 45d, schema, source + harness
  fingerprints) and **`suite/results/RESULTS.md` drift** — but validates README
  drift only when the generated markers are present.
- The `lint` step now runs the wrapper instead of `public_baseline.py check`.

### Why a separate module (not a patch to `public_baseline.py`)

`public_baseline.py` is a **fingerprinted harness file** (`HARNESS_PATHS`). Editing it
changes `harness_fingerprint`, which makes `validate_public` fail with
*"harness changed; regenerate it"* — unsatisfiable without re-running the full
Node/Bun/Perry benchmark suite. Importing its functions from a new, non-fingerprinted
file keeps the fingerprint (and the freshness guarantee) intact.

## Validation

Local run of the exact lint step:

```
PYTHONPATH=. python3 tests/test_public_baseline.py     # 7 tests OK
python3 benchmarks/ci_public_baseline_check.py         # exit 0: "freshness OK (README table optional)"
python3 benchmarks/public_baseline.py check ...        # still exit 2 (proves the block was the only failure)
```

`README.md` is unchanged. When a future change re-adds the markers, README drift is
enforced again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated validation of public benchmark data for freshness and integrity.
  - Benchmark checks now consistently verify that published results remain synchronized.
  - Optional documentation tables no longer cause validation failures when absent, while detected inconsistencies are still reported.
  - Added clearer validation status and error reporting to help identify outdated or mismatched benchmark information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->