### PR TITLE
fix(#6728): pi interactive mode renders nothing after Enter — 3 async/codegen fixes

### DIFF
--- a/crates/perry-codegen/src/codegen/boxed_locals.rs
+++ b/crates/perry-codegen/src/codegen/boxed_locals.rs
@@ -57,6 +57,32 @@ pub(crate) fn collect_module_boxed_vars(hir: &HirModule) -> std::collections::Ha
             module_boxed_vars.extend(collect_boxed_vars(&ctor.body));
             module_boxed_vars.extend(collect_boxed_param_ids(&ctor.params, &ctor.body));
         }
+        // #6728: instance + static FIELD initializers can hold async closures
+        // (`f = async () => { await x }`). `async_to_generator` rewrites those
+        // into async-step state machines whose state locals (`__state`,
+        // `__done`, `__sent`, …) are MUTATED across resumes and CAPTURED by the
+        // step closure — so they MUST be boxed (shared heap cells) exactly like
+        // the same closure written as `const f = …` (module init) or `this.f = …`
+        // (ctor body), both walked above. Field initializers were the one
+        // closure-bearing member kind this module-wide boxed-var scan missed, so
+        // a field-init async closure's step locals were emitted as raw (unboxed)
+        // captures: the wrapper boxed them but the step closure overwrote the
+        // capture slots with raw values, desyncing the state machine — calling
+        // the closure ran no body and the `await` on it resolved immediately.
+        // Walk the inits (wrapped as a statement, mirroring the closure/global
+        // collectors) so their nested closures' boxed locals are seen too.
+        for field in c.fields.iter().chain(c.static_fields.iter()) {
+            if let Some(init) = &field.init {
+                module_boxed_vars.extend(collect_boxed_vars(std::slice::from_ref(
+                    &perry_hir::Stmt::Expr(init.clone()),
+                )));
+            }
+            if let Some(key_expr) = &field.key_expr {
+                module_boxed_vars.extend(collect_boxed_vars(std::slice::from_ref(
+                    &perry_hir::Stmt::Expr(key_expr.clone()),
+                )));
+            }
+        }
     }
     module_boxed_vars.extend(collect_boxed_vars(&hir.init));
     module_boxed_vars
@@ -111,6 +137,23 @@ pub(crate) fn collect_module_local_types(hir: &HirModule) -> HashMap<u32, perry_
                 module_local_types.insert(p.id, p.ty.clone());
             }
             collect_let_types_in_stmts(&member.function.body, &mut module_local_types);
+        }
+        // #6728: field / static-field initializers can hold async closures whose
+        // nested step-machine locals need their types known at their capture
+        // sites (see the matching walk in `collect_module_boxed_vars`).
+        for field in c.fields.iter().chain(c.static_fields.iter()) {
+            if let Some(init) = &field.init {
+                collect_let_types_in_stmts(
+                    std::slice::from_ref(&perry_hir::Stmt::Expr(init.clone())),
+                    &mut module_local_types,
+                );
+            }
+            if let Some(key_expr) = &field.key_expr {
+                collect_let_types_in_stmts(
+                    std::slice::from_ref(&perry_hir::Stmt::Expr(key_expr.clone())),
+                    &mut module_local_types,
+                );
+            }
         }
     }
     module_local_types

--- a/crates/perry-runtime/src/promise/async_step.rs
+++ b/crates/perry-runtime/src/promise/async_step.rs
@@ -287,7 +287,28 @@ fn then_backpatch_result(
         super::then::js_promise_attach_handlers(awaited, fulfill, reject);
         result
     } else {
-        js_promise_then(awaited, fulfill, reject)
+        // #6728: `trap_next` non-null means this is a SUBSEQUENT `await` (the
+        // 2nd or later) in the activation — the result promise already exists
+        // and the resume thunks already carry it (capture slot 1, set by
+        // `build_async_step_thunks`). Attach the thunks to `awaited` WITHOUT a
+        // chained then-result promise, exactly like the first-await
+        // (`trap_next.is_null()`) branch above, and return `trap_next` (which is
+        // what the reuse fast paths in `js_async_step_chain` return too).
+        //
+        // A plain `js_promise_then` here mints an intermediate then-result
+        // promise. When the resumed step later THROWS — a `throw` reached after
+        // two-or-more awaits — its fulfill thunk returns the step body's fresh
+        // `Promise.reject(e)` (see `forward_swallowed_rejection`), and that
+        // then-result promise ADOPTS the rejection, becoming a REJECTED promise
+        // with NO handler attached. The orphan surfaces a spurious
+        // "Uncaught (in promise)" (and exits the process non-zero) even though a
+        // surrounding `try/catch` already handled the throw via `trap_next`.
+        // The first-await path never hit this because it uses `attach_handlers`
+        // (`next` = null, nothing to propagate the thunk's rejected return to);
+        // extend the same shape to every await so multi-await async functions
+        // that throw reject exactly one promise — the activation result.
+        super::then::js_promise_attach_handlers(awaited, fulfill, reject);
+        trap_next
     }
 }
 

--- a/crates/perry-transform/src/generator/break_continue.rs
+++ b/crates/perry-transform/src/generator/break_continue.rs
@@ -282,6 +282,33 @@ pub fn body_contains_yield(stmts: &[Stmt]) -> bool {
                 ..
             } => return true,
             Stmt::Return(Some(Expr::Yield { .. })) => return true,
+            // #6728: in an async generator, a statement-level `await` (post
+            // `hoist_awaits_in_stmts`: bare / `let =` / `return` / `throw`) is a
+            // suspend point too — it must be split into its own state via
+            // `StateExit::Await`, exactly like a `yield`. Without counting it
+            // here, an enclosing `if` / loop / `try` whose only suspend point is
+            // an `await` (e.g. pi's EventStream `while(true){ if(empty){ await …
+            // } yield … }`) fails `body_contains_yield`, is NOT linearized into
+            // states, and the `await` stays inline → lowered to the busy-wait
+            // poll loop → deadlock when the awaited Promise is settled by an
+            // external producer. Gated on `linearize_async_generator()` and on
+            // `Expr::Await` (which only survives to the linearizer for async
+            // generators — plain async fns rewrite `await`→`yield` upstream),
+            // so plain generators / async functions are unaffected. Mirrors the
+            // four `Expr::Await` statement arms in `linearize.rs`.
+            Stmt::Expr(Expr::Await(_)) if super::linearize::linearize_async_generator() => {
+                return true
+            }
+            Stmt::Let {
+                init: Some(Expr::Await(_)),
+                ..
+            } if super::linearize::linearize_async_generator() => return true,
+            Stmt::Return(Some(Expr::Await(_))) if super::linearize::linearize_async_generator() => {
+                return true
+            }
+            Stmt::Throw(Expr::Await(_)) if super::linearize::linearize_async_generator() => {
+                return true
+            }
             Stmt::If {
                 then_branch,
                 else_branch,

--- a/crates/perry-transform/src/generator/linearize.rs
+++ b/crates/perry-transform/src/generator/linearize.rs
@@ -25,7 +25,7 @@ pub(crate) fn set_linearize_async_generator(v: bool) {
     LINEARIZE_IS_ASYNC_GEN.with(|c| c.set(v));
 }
 
-fn linearize_async_generator() -> bool {
+pub(crate) fn linearize_async_generator() -> bool {
     LINEARIZE_IS_ASYNC_GEN.with(|c| c.get())
 }
 

--- a/tests/test_issue_6728_async_gen_await_in_conditional.sh
+++ b/tests/test_issue_6728_async_gen_await_in_conditional.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Regression coverage for #6728 / #6709 completion: an `await` nested inside an
+# `if` (or any control-flow construct whose branch has no `yield`) in an
+# async generator must SUSPEND on the microtask queue, not busy-wait. This is
+# pi's EventStream push/pull async iterator shape:
+#     while (true) {
+#       if (queue.length === 0) { if (done) return; await producerPromise; }
+#       while (queue.length > 0) yield queue.shift();
+#     }
+# Before the fix the `await` inside the `if` was never split into a suspend
+# state (the split gate only checked for `yield`), so it deadlocked whenever the
+# awaited Promise was settled by an external producer (here: a timer).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PERRY="$SCRIPT_DIR/../target/release/perry"
+[ ! -f "$PERRY" ] && PERRY="$SCRIPT_DIR/../target/debug/perry"
+if [ ! -f "$PERRY" ]; then
+  echo "SKIP: perry binary not found (build with cargo build --release)"
+  exit 0
+fi
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+COMPILE_ENV=()
+if [ -f "$SCRIPT_DIR/../target/debug/libperry_runtime.a" ] || [ -f "$SCRIPT_DIR/../target/release/libperry_runtime.a" ]; then
+  COMPILE_ENV=(env PERRY_NO_AUTO_OPTIMIZE=1)
+fi
+
+cat > "$TMPDIR/main.ts" << 'EOF'
+class EventStream {
+  queue: string[] = [];
+  resolve: (() => void) | null = null;
+  done = false;
+  push(e: string) { this.queue.push(e); if (this.resolve) { const r = this.resolve; this.resolve = null; r(); } }
+  async *[Symbol.asyncIterator](): AsyncGenerator<string> {
+    while (true) {
+      if (this.queue.length === 0) {              // await nested in `if` — no yield here
+        if (this.done) return;
+        await new Promise<void>((r) => { this.resolve = r; }); // settled by push() from a timer
+      }
+      while (this.queue.length > 0) yield this.queue.shift() as string;
+    }
+  }
+}
+const stream = new EventStream();
+(async () => {
+  for await (const e of stream) {
+    console.log("event " + e);
+    if (e === "last") { console.log("got last"); process.exit(0); }
+  }
+})();
+setTimeout(() => stream.push("working"), 50);
+setTimeout(() => stream.push("token"), 100);
+setTimeout(() => stream.push("last"), 150);
+setTimeout(() => { console.log("GUARD (deadlocked)"); process.exit(2); }, 3000);
+EOF
+
+cd "$TMPDIR"
+"${COMPILE_ENV[@]}" "$PERRY" compile main.ts --output test_bin --no-cache >/dev/null 2>&1
+RUN_OUTPUT=$(./test_bin 2>&1)
+RUN_EXIT=$?
+
+EXPECTED="event working
+event token
+event last
+got last"
+
+if [ "$RUN_OUTPUT" = "$EXPECTED" ] && [ "$RUN_EXIT" -eq 0 ]; then
+  echo "PASS"
+  exit 0
+fi
+
+echo "FAIL: async-generator await-in-conditional deadlocked (#6728/#6709 regression)"
+echo "Expected (exit 0):"
+echo "$EXPECTED"
+echo ""
+echo "Got (exit $RUN_EXIT):"
+echo "$RUN_OUTPUT"
+exit 1

--- a/tests/test_issue_6728_class_field_async_arrow.sh
+++ b/tests/test_issue_6728_class_field_async_arrow.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Regression coverage for #6728: a CLASS-FIELD-INITIALIZER async arrow whose body
+# contains `await` must run its body when called. Before the fix its async-step
+# state locals were not boxed (the module-wide boxed-var scan skipped class field
+# initializers), so calling it ran no body and the `await` on it resolved with no
+# effect. This is pi's `_handleAgentEvent` shape — agent events never rendered.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PERRY="$SCRIPT_DIR/../target/release/perry"
+[ ! -f "$PERRY" ] && PERRY="$SCRIPT_DIR/../target/debug/perry"
+if [ ! -f "$PERRY" ]; then
+  echo "SKIP: perry binary not found (build with cargo build --release)"
+  exit 0
+fi
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+COMPILE_ENV=()
+if [ -f "$SCRIPT_DIR/../target/debug/libperry_runtime.a" ] || [ -f "$SCRIPT_DIR/../target/release/libperry_runtime.a" ]; then
+  COMPILE_ENV=(env PERRY_NO_AUTO_OPTIMIZE=1)
+fi
+
+cat > "$TMPDIR/main.ts" << 'EOF'
+class Session {
+  steering: string[] = [];
+  // class-field async arrow that uses `this`, an await, and a nested `if`
+  handle = async (event: any) => {
+    console.log("handle-enter " + event.type);
+    if (event.type === "msg" && this.steering.length > 0) {
+      this.steering.pop();
+    }
+    await Promise.resolve(1);
+    console.log("handle-after-await " + event.type);
+  };
+}
+// call it directly, via a reference, and via a Set (mirrors the listener path)
+(async () => {
+  const s = new Session();
+  await s.handle({ type: "a" });
+  const ref = s.handle;
+  await ref({ type: "b" });
+  const listeners = new Set<any>([s.handle]);
+  for (const l of listeners) await l({ type: "msg" });
+  console.log("done");
+  process.exit(0);
+})();
+EOF
+
+cd "$TMPDIR"
+"${COMPILE_ENV[@]}" "$PERRY" compile main.ts --output test_bin --no-cache >/dev/null 2>&1
+RUN_OUTPUT=$(./test_bin 2>&1)
+RUN_EXIT=$?
+
+EXPECTED="handle-enter a
+handle-after-await a
+handle-enter b
+handle-after-await b
+handle-enter msg
+handle-after-await msg
+done"
+
+if [ "$RUN_OUTPUT" = "$EXPECTED" ] && [ "$RUN_EXIT" -eq 0 ]; then
+  echo "PASS"
+  exit 0
+fi
+
+echo "FAIL: class-field async-arrow body did not run (#6728 regression)"
+echo "Expected (exit 0):"
+echo "$EXPECTED"
+echo ""
+echo "Got (exit $RUN_EXIT):"
+echo "$RUN_OUTPUT"
+exit 1

--- a/tests/test_issue_6728_multi_await_throw_no_orphan_rejection.sh
+++ b/tests/test_issue_6728_multi_await_throw_no_orphan_rejection.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Regression coverage for #6728: an async function that reaches a `throw` after
+# TWO-OR-MORE `await`s must reject exactly ONE promise (its result, caught by a
+# surrounding try/catch). Before the fix, each await past the first minted an
+# intermediate then-result promise that adopted the throw's rejection with no
+# handler attached, surfacing a spurious "Uncaught (in promise)" and exiting the
+# process non-zero — even though the throw was already handled. This is the pi
+# interactive-TUI blocker (the Anthropic SDK's makeRequest throws its error
+# after many awaits).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PERRY="$SCRIPT_DIR/../target/release/perry"
+[ ! -f "$PERRY" ] && PERRY="$SCRIPT_DIR/../target/debug/perry"
+if [ ! -f "$PERRY" ]; then
+  echo "SKIP: perry binary not found (build with cargo build --release)"
+  exit 0
+fi
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+COMPILE_ENV=()
+if [ -f "$SCRIPT_DIR/../target/debug/libperry_runtime.a" ] || [ -f "$SCRIPT_DIR/../target/release/libperry_runtime.a" ]; then
+  COMPILE_ENV=(env PERRY_NO_AUTO_OPTIMIZE=1)
+fi
+
+cat > "$TMPDIR/main.ts" << 'EOF'
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// >=2 awaits before the throw is the trigger; 0 or 1 await never orphaned.
+async function twoAwaitsThenThrow(): Promise<void> {
+  await sleep(1);
+  await sleep(1);
+  throw new Error("boom");
+}
+
+// Nested async layer (mirrors the SDK: makeRequest awaited by a caller).
+async function callLayer(): Promise<void> {
+  await twoAwaitsThenThrow();
+}
+
+async function main(): Promise<void> {
+  try {
+    await callLayer();
+    console.log("no throw (wrong)");
+  } catch (e: any) {
+    console.log("caught " + (e && e.message));
+  }
+  console.log("done");
+}
+
+main();
+EOF
+
+cd "$TMPDIR"
+"${COMPILE_ENV[@]}" "$PERRY" compile main.ts --output test_bin --no-cache >/dev/null 2>&1
+RUN_OUTPUT=$(./test_bin 2>&1)
+RUN_EXIT=$?
+
+EXPECTED="caught boom
+done"
+
+if [ "$RUN_OUTPUT" = "$EXPECTED" ] && [ "$RUN_EXIT" -eq 0 ]; then
+  echo "PASS"
+  exit 0
+fi
+
+echo "FAIL: multi-await throw produced an orphaned rejection (#6728 regression)"
+echo "Expected (exit 0):"
+echo "$EXPECTED"
+echo ""
+echo "Got (exit $RUN_EXIT):"
+echo "$RUN_OUTPUT"
+exit 1


### PR DESCRIPTION
Fixes #6728.

## The blocker

pi's interactive TUI mode renders **nothing** after the user types a prompt and
presses Enter — no "Working…" spinner, no assistant text, not even the `401`
error that one-shot `-p` mode renders correctly. The process does not crash.
Node runs the identical bundle and shows "Working…" then the error. This PR
fixes it: after these changes the perry-compiled pi renders end-to-end
(bogus key → "Working…" → `Error: 401 authentication_error`, identical to Node;
a real key streams a real API response).

pi's turn UI is an `EventStream` (`async *[Symbol.asyncIterator]()` push/pull
iterator) whose events are dispatched through a class-field async arrow
(`_handleAgentEvent`). Reproducing what pi actually does turned up **three
independent, pre-existing bugs** — all on the async / async-generator lowering
path that #6709 (#6727, now merged) opened up. Each is fixed and covered by a
regression test below.

## 1. Async-generator `await` inside a control-flow construct never suspends (completes #6709)

`crates/perry-transform/src/generator/break_continue.rs`

#6709 made statement-level `await`s in an `async function*` suspend on the
microtask queue. But the linearizer only splits a control-flow construct
(`if` / loop / `try`) into suspend states when `body_contains_yield` sees a
`yield` inside it — it did not count a nested `await`. So an `await` inside an
`if` (with no `yield`) in an async generator fell back to a busy-wait and
deadlocked — exactly pi's `EventStream`, which `await`s inside conditionals.

Fix: in an async generator (`linearize_async_generator()`), `body_contains_yield`
also treats a statement-level `await` (`Expr` / `Let` init / `Return` / `Throw`)
as a suspend point, so the enclosing construct is split into states.

## 2. A `throw` after ≥2 `await`s leaves an orphaned rejected promise

`crates/perry-runtime/src/promise/async_step.rs`

An `async` function that `throw`s after two or more `await`s (even when the
throw is caught by the caller) also emitted a spurious
`Uncaught (in promise)` and exited 1. The subsequent-await backpatch path minted
an intermediate then-result promise via `js_promise_then`; that promise adopted
the throw's rejection with no handler attached → phantom unhandled rejection.

Fix: subsequent awaits use `js_promise_attach_handlers` (no intermediate
then-result promise) and return the existing `trap_next`, matching the
first-await path. A genuinely-uncaught rejection still reports and exits 1.

## 3. Class-field async-arrow async-step state locals are not boxed

`crates/perry-codegen/src/codegen/boxed_locals.rs`

This is the one that made agent events reach pi's UI. `_handleAgentEvent` is a
**class-field** async arrow. `async_to_generator` lowers a field-init async
closure with `await` into an async-step state machine whose state locals
(`__state` / `__done` / `__sent` / …) are mutated across resumes and captured by
the step closure — so they must be **boxed** (shared heap cells), exactly like
the same closure written as `const f = …` (module init) or `this.f = …` (ctor
body).

But `collect_module_boxed_vars` / `collect_module_local_types` walked every
closure-bearing member (functions, methods, getters/setters, static methods,
computed members, constructors, module init) **except class field
initializers**. So a field-init async closure's step locals were emitted as raw
(unboxed) captures: the wrapper boxed them, but the step closure overwrote the
box slots with raw values (`js_closure_set_capture_bits`), desyncing the state
machine — calling the closure ran **no body**, and the `await` on it resolved
immediately with no effect. Agent-event dispatch silently died there.

Pinpointed by an LLVM-IR diff (`PERRY_SAVE_LL`): the field-init step closure used
raw capture writes where the equivalent ctor-body step closure used
`js_box_set_bits`.

Fix: walk `class.fields` / `class.static_fields` initializers (and computed
keys) in both collectors, so a field-init closure's boxed locals are seen at
every capture site.

## Tests

- `tests/test_issue_6728_async_gen_await_in_conditional.sh` — await inside `if`
  in an `async function*` resumes (fix 1).
- `tests/test_issue_6728_multi_await_throw_no_orphan_rejection.sh` — caught throw
  after 3 awaits exits 0, no phantom rejection; genuine uncaught still exits 1
  (fix 2).
- `tests/test_issue_6728_class_field_async_arrow.sh` — class-field async arrow's
  body runs when called directly, via a reference, and via a `Set` (fix 3).

## Validation

- Unit suites green: perry-transform, perry-runtime promise/async/closure/box +
  class/field/generator.
- End-to-end: the perry-compiled pi now renders after Enter — bogus key →
  "Working…" → `Error: 401 authentication_error` (final screen identical to
  Node); a real key produces a real streamed API response.

Each fix is independent and separately testable. Built on current `main`
(which includes #6709 / #6727).
