### PR TITLE
perf(object): O(1) own-key answers for wide-object defineProperty and `in` (#6748)

### DIFF
--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -256,7 +256,12 @@ pub(crate) fn array_iteration_is_exotic(arr: *const ArrayHeader) -> bool {
 /// is `index` present as an *own* property (dense non-hole slot, sparse named
 /// data property, or an accessor descriptor)?
 pub(crate) unsafe fn array_has_own_index(arr: *const ArrayHeader, index: u32) -> bool {
-    if crate::object::descriptors_in_use() {
+    // #6748 grind: gate on the PER-ARRAY descriptor flag (set by every
+    // `define_array_property` install), not the process-global
+    // `descriptors_in_use()` — the global flag flips during builtin init, so
+    // every array element probe paid an `index.to_string()` + accessor-map
+    // String-key alloc for arrays that have no descriptors at all.
+    if array_object_flags(arr) & crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS != 0 {
         let key = index.to_string();
         if crate::object::get_accessor_descriptor(arr as usize, &key).is_some() {
             return true;
@@ -690,7 +695,11 @@ pub extern "C" fn js_array_get_f64(arr: *const ArrayHeader, index: u32) -> f64 {
             return std::ptr::read(entries.add(index as usize * 2));
         }
     }
-    if crate::object::descriptors_in_use() {
+    // #6748 grind: per-array flag, not the process-global gate (see
+    // `array_has_own_index`) — this probe allocated two Strings on EVERY
+    // checked element read once any descriptor existed process-wide, which
+    // taxed every internal keys_array walk (`in`, defineProperty, Object.keys).
+    if array_object_flags(arr) & crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS != 0 {
         let key = index.to_string();
         if let Some(acc) = crate::object::get_accessor_descriptor(arr as usize, &key) {
             if acc.get != 0 {
@@ -1441,7 +1450,7 @@ pub extern "C" fn js_array_set_string_key(
     }
     // Named accessor installed via `Object.defineProperty(arr, "prop",
     // {get,set})`: dispatch the setter instead of the expando store.
-    if crate::object::descriptors_in_use() {
+    if array_object_flags(arr) & crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS != 0 {
         if let Some(acc) = crate::object::get_accessor_descriptor(arr as usize, key_str) {
             if acc.set != 0 {
                 unsafe {

--- a/crates/perry-runtime/src/object/field_get_set/has_property.rs
+++ b/crates/perry-runtime/src/object/field_get_set/has_property.rs
@@ -949,8 +949,17 @@ unsafe fn ordinary_has_property(
         }
         // Own accessor property (also mirrored into `keys_array`, but check the
         // side table directly so a get-only accessor is never missed).
+        // #6748 follow-up: gate on the thread flag + the per-object
+        // `OBJ_FLAG_HAS_DESCRIPTORS` header bit (the same address-reuse-safe
+        // gate the [[Set]] path uses) — `get_accessor_descriptor` allocates a
+        // `String` map key per probe, and this ran per prototype level on
+        // EVERY `in`, dominating its profile (~60% of samples on a
+        // descriptor-less receiver).
         if let Some(name) = key_name {
-            if get_accessor_descriptor(cur as usize, name).is_some() {
+            if crate::object::descriptor_state::ACCESSORS_IN_USE.with(|c| c.get())
+                && crate::object::descriptor_state::object_has_descriptors(cur as usize)
+                && get_accessor_descriptor(cur as usize, name).is_some()
+            {
                 return true;
             }
         }
@@ -1139,8 +1148,9 @@ pub(crate) unsafe fn native_module_own_field_by_key(
         return None;
     }
     let key_count = crate::array::js_array_length(keys);
-    for i in 0..key_count {
-        let stored = crate::array::js_array_get(keys, i);
+    let (slots, slot_len) = super::super::keys_array_dense_slots(keys);
+    for i in 0..key_count.min(slot_len as u32) {
+        let stored = crate::JSValue::from_bits((*slots.add(i as usize)).to_bits());
         let mut sso_buf = [0u8; crate::value::SHORT_STRING_MAX_LEN];
         if crate::string::js_string_key_bytes(stored, &mut sso_buf) == Some(target) {
             return Some(js_object_get_field(obj, i));
@@ -1194,8 +1204,9 @@ pub(crate) unsafe fn wide_key_index_lookup(
                 // linear-scan order).
                 let mut map = std::collections::HashMap::with_capacity(key_count);
                 let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
-                for i in 0..key_count {
-                    let stored = crate::array::js_array_get(keys, i as u32);
+                let (slots, slot_len) = super::super::keys_array_dense_slots(keys);
+                for i in 0..key_count.min(slot_len) {
+                    let stored = crate::JSValue::from_bits((*slots.add(i)).to_bits());
                     if let Some(b) = crate::string::js_string_key_bytes(stored, &mut sso) {
                         map.entry(b.to_vec()).or_insert(i as u32);
                     }
@@ -1224,8 +1235,9 @@ pub(crate) unsafe fn wide_key_index_lookup(
         if (key_count as u32) > entry.indexed_len {
             // Catch up on appended keys.
             let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
-            for i in entry.indexed_len as usize..key_count {
-                let stored = crate::array::js_array_get(keys, i as u32);
+            let (slots, slot_len) = super::super::keys_array_dense_slots(keys);
+            for i in entry.indexed_len as usize..key_count.min(slot_len) {
+                let stored = crate::JSValue::from_bits((*slots.add(i)).to_bits());
                 if let Some(b) = crate::string::js_string_key_bytes(stored, &mut sso) {
                     entry.map.entry(b.to_vec()).or_insert(i as u32);
                 }
@@ -1235,7 +1247,12 @@ pub(crate) unsafe fn wide_key_index_lookup(
         let idx = entry.map.get(key_bytes).copied();
         match idx {
             Some(i) if (i as usize) < key_count => {
-                let stored = crate::array::js_array_get(keys, i);
+                let (slots, slot_len) = super::super::keys_array_dense_slots(keys);
+                if (i as usize) >= slot_len {
+                    table.remove(pos);
+                    return None;
+                }
+                let stored = crate::JSValue::from_bits((*slots.add(i as usize)).to_bits());
                 if crate::string::js_string_key_matches(stored, key) {
                     if pos != 0 {
                         let e = table.remove(pos);

--- a/crates/perry-runtime/src/object/field_get_set/has_property.rs
+++ b/crates/perry-runtime/src/object/field_get_set/has_property.rs
@@ -932,11 +932,20 @@ unsafe fn ordinary_has_property(
             ) {
                 return true;
             }
-        } else if super::super::own_key_present(cur as *mut ObjectHeader, key) {
-            // Own data / overflow key present (value-agnostic: `delete`
-            // removes the key, so a present key — even one holding
-            // `undefined` — is an own property).
-            return true;
+        } else {
+            // #6743: wide objects answer own-key presence via the O(1) sidecar
+            // the [[Set]]/define append paths maintain — the linear
+            // `own_key_present` scan made `k in wideObj` O(N) per MISS, which
+            // turned webpack/Babel's re-export loop (`if (k in exports) …` per
+            // key) quadratic. Narrow or non-indexable receivers keep the scan.
+            let own = super::super::own_key_present_via_index(cur as *mut ObjectHeader, key)
+                .unwrap_or_else(|| super::super::own_key_present(cur as *mut ObjectHeader, key));
+            if own {
+                // Own data / overflow key present (value-agnostic: `delete`
+                // removes the key, so a present key — even one holding
+                // `undefined` — is an own property).
+                return true;
+            }
         }
         // Own accessor property (also mirrored into `keys_array`, but check the
         // side table directly so a get-only accessor is never missed).

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -313,19 +313,18 @@ unsafe fn keys_index_lookup(
     if needs_rebuild {
         let mut map: std::collections::HashMap<u64, Vec<u32>> =
             std::collections::HashMap::with_capacity(key_count as usize);
+        // SSO-aware key decode (#1781 family): short keys can be stored INLINE
+        // (`SHORT_STRING_TAG`), not as heap `STRING_TAG` pointers. The previous
+        // heap-only `is_string()` gate silently dropped them from the index, so
+        // an authoritative-miss caller (the [[Set]] fast path's append, and now
+        // the defineProperty path) could duplicate an SSO-stored key.
+        let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
         for i in 0..key_count {
             let v = crate::array::js_array_get(keys, i);
-            if !v.is_string() {
-                continue;
+            if let Some(b) = crate::string::js_string_key_bytes(v, &mut sso) {
+                let h = key_bytes_hash(b.as_ptr(), b.len());
+                map.entry(h).or_default().push(i);
             }
-            let sp = v.as_string_ptr();
-            if sp.is_null() {
-                continue;
-            }
-            let sname_ptr = (sp as *const u8).add(std::mem::size_of::<crate::StringHeader>());
-            let sname_len = (*sp).byte_len as usize;
-            let h = key_bytes_hash(sname_ptr, sname_len);
-            map.entry(h).or_default().push(i);
         }
         KEYS_INDEX.with(|m| {
             m.borrow_mut().insert(obj_addr, (key_count, map));
@@ -335,21 +334,12 @@ unsafe fn keys_index_lookup(
         let m = m.borrow();
         let (_, map) = m.get(&obj_addr)?;
         let candidates = map.get(&key_hash)?;
+        let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
         for &i in candidates {
             let v = crate::array::js_array_get(keys, i);
-            if !v.is_string() {
+            let Some(stored_bytes) = crate::string::js_string_key_bytes(v, &mut sso) else {
                 continue;
-            }
-            let sp = v.as_string_ptr();
-            if sp.is_null() {
-                continue;
-            }
-            let sname_ptr = (sp as *const u8).add(std::mem::size_of::<crate::StringHeader>());
-            let sname_len = (*sp).byte_len as usize;
-            if sname_len != key_bytes.len() {
-                continue;
-            }
-            let stored_bytes = std::slice::from_raw_parts(sname_ptr, sname_len);
+            };
             if stored_bytes == key_bytes {
                 return Some(i);
             }

--- a/crates/perry-runtime/src/object/mod.rs
+++ b/crates/perry-runtime/src/object/mod.rs
@@ -264,6 +264,30 @@ thread_local! {
 /// faster than the hash overhead (memory access, cache footprint).
 const KEYS_INDEX_THRESHOLD: u32 = 32;
 
+/// Raw dense-slot view of a (validated) keys array: resolve a grow-forward
+/// pointer ONCE, then hand back the backing slots for direct indexing. The
+/// generic `js_array_get` element getter re-runs the whole per-element
+/// gauntlet — forward-resolution, lazy/Map/Set receiver probes (each a TLS +
+/// registry HashMap hit), descriptor gates — on EVERY slot, which made the
+/// keys_array scan loops (`own_key_present`, the sidecar/wide-index builds)
+/// pay ~µs per element. Callers have already validated `keys` is a
+/// `GC_TYPE_ARRAY`; keys arrays are dense (no holes), and a slot that is not
+/// a string simply fails the key match. (#6748 grind)
+#[inline]
+pub(crate) unsafe fn keys_array_dense_slots(
+    keys: *const crate::array::ArrayHeader,
+) -> (*const f64, usize) {
+    let arr = crate::array::clean_arr_ptr(keys);
+    if arr.is_null() {
+        return (std::ptr::null(), 0);
+    }
+    let len = (*arr).length.min((*arr).capacity) as usize;
+    (
+        (arr as *const u8).add(std::mem::size_of::<crate::array::ArrayHeader>()) as *const f64,
+        len,
+    )
+}
+
 /// FNV-1a hash of the bytes behind a string header. Same hash function
 /// as `key_content_hash_impl` so callers can mix paths.
 #[inline(always)]
@@ -319,8 +343,9 @@ unsafe fn keys_index_lookup(
         // an authoritative-miss caller (the [[Set]] fast path's append, and now
         // the defineProperty path) could duplicate an SSO-stored key.
         let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
-        for i in 0..key_count {
-            let v = crate::array::js_array_get(keys, i);
+        let (slots, slot_len) = keys_array_dense_slots(keys);
+        for i in 0..key_count.min(slot_len as u32) {
+            let v = crate::JSValue::from_bits((*slots.add(i as usize)).to_bits());
             if let Some(b) = crate::string::js_string_key_bytes(v, &mut sso) {
                 let h = key_bytes_hash(b.as_ptr(), b.len());
                 map.entry(h).or_default().push(i);
@@ -335,8 +360,12 @@ unsafe fn keys_index_lookup(
         let (_, map) = m.get(&obj_addr)?;
         let candidates = map.get(&key_hash)?;
         let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+        let (slots, slot_len) = keys_array_dense_slots(keys);
         for &i in candidates {
-            let v = crate::array::js_array_get(keys, i);
+            if (i as usize) >= slot_len {
+                continue;
+            }
+            let v = crate::JSValue::from_bits((*slots.add(i as usize)).to_bits());
             let Some(stored_bytes) = crate::string::js_string_key_bytes(v, &mut sso) else {
                 continue;
             };

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -44,7 +44,9 @@ pub(crate) use descriptor_helpers::{
 // object_ops children (`accessors.rs`, `descriptor_helpers.rs`) but NOT
 // re-exported, so `crate::object::value_is_callable` resolves uniquely to the
 // `instanceof.rs` definition (preserves the pre-split resolution).
-pub(crate) use keys_array::{ensure_key_in_keys_array, install_builtin_getter, own_key_present};
+pub(crate) use keys_array::{
+    ensure_key_in_keys_array, install_builtin_getter, own_key_present, own_key_present_via_index,
+};
 
 /// Helper: extract object pointer from NaN-boxed f64. Returns null on failure.
 pub(crate) unsafe fn extract_obj_ptr(value: f64) -> *mut ObjectHeader {

--- a/crates/perry-runtime/src/object/object_ops/define_property.rs
+++ b/crates/perry-runtime/src/object/object_ops/define_property.rs
@@ -936,7 +936,12 @@ pub extern "C" fn js_object_define_property(
         // attributes before any mutation below. `None` ⇒ the key is new, so the
         // historical all-`false` (writable defaults to `has_accessor`) applies.
         let existing_attrs: Option<PropertyAttrs> = key_rust.as_ref().and_then(|k| {
-            if super::super::obj_value_has_own_key(obj_value, key_value) {
+            // #6743: wide objects answer own-key presence via the O(1) sidecar
+            // (repeated defines were O(N²) through this check); narrow or
+            // non-indexable receivers keep the general path.
+            let present = own_key_present_via_index(obj, key_str)
+                .unwrap_or_else(|| super::super::obj_value_has_own_key(obj_value, key_value));
+            if present {
                 Some(
                     super::super::get_property_attrs(obj as usize, k)
                         .unwrap_or_else(|| PropertyAttrs::new(true, true, true)),

--- a/crates/perry-runtime/src/object/object_ops/descriptor_helpers.rs
+++ b/crates/perry-runtime/src/object/object_ops/descriptor_helpers.rs
@@ -303,7 +303,9 @@ pub(crate) unsafe fn enforce_define_property_invariants(
     let gc = gc_header_for(obj);
     let no_extend = (*gc)._reserved & crate::gc::OBJ_FLAG_NO_EXTEND != 0;
 
-    let exists = own_key_present(obj, key);
+    // #6743: wide objects answer via the O(1) sidecar; the linear scan is the
+    // narrow-object fallback (repeated defines were O(N²) through this check).
+    let exists = own_key_present_via_index(obj, key).unwrap_or_else(|| own_key_present(obj, key));
 
     if !exists {
         // Adding a new property to a non-extensible object always throws.

--- a/crates/perry-runtime/src/object/object_ops/keys_array.rs
+++ b/crates/perry-runtime/src/object/object_ops/keys_array.rs
@@ -50,16 +50,35 @@ pub(crate) unsafe fn ensure_key_in_keys_array(
     if (keys_ptr as u64) >> 48 != 0 || keys_ptr < 0x10000 || !is_valid_obj_ptr(keys as *const u8) {
         return;
     }
-    // Check if key already exists
+    // Check if key already exists. Past the sidecar threshold, probe the same
+    // key→slot hash index the [[Set]] fast path maintains instead of scanning:
+    // repeated `Object.defineProperty` on one object (Babel-style
+    // `exports` re-export modules install hundreds of getters) made this
+    // linear dup-check O(N²) total — the dominant cost of pi's module init
+    // under perry (a single @babel/types re-export module took ~292ms vs
+    // node's 3ms). A sidecar miss is authoritative here exactly as it is for
+    // the [[Set]] append path ("the sidecar would have found it if it
+    // existed"), and the append below records the new key via
+    // `keys_index_insert` so the index stays fresh across the loop.
     let key_count = crate::array::js_array_length(keys) as usize;
-    for i in 0..key_count {
-        let stored = crate::array::js_array_get(keys, i as u32);
-        // #1781: SSO-aware match — pre-fix an existing inline-SSO key
-        // wasn't seen here, so `Object.defineProperty(obj, "id", ...)`
-        // on an object that already had `id` as an SSO key
-        // double-inserted instead of overwriting.
-        if crate::string::js_string_key_matches(stored, key) {
+    if key_count >= super::super::KEYS_INDEX_THRESHOLD as usize {
+        let name_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        let name_len = (*key).byte_len as usize;
+        let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
+        let key_hash = super::super::key_bytes_hash(name_ptr, name_len);
+        if super::super::keys_index_lookup(obj, keys, name_bytes, key_hash).is_some() {
             return; // already present
+        }
+    } else {
+        for i in 0..key_count {
+            let stored = crate::array::js_array_get(keys, i as u32);
+            // #1781: SSO-aware match — pre-fix an existing inline-SSO key
+            // wasn't seen here, so `Object.defineProperty(obj, "id", ...)`
+            // on an object that already had `id` as an SSO key
+            // double-inserted instead of overwriting.
+            if crate::string::js_string_key_matches(stored, key) {
+                return; // already present
+            }
         }
     }
     // Clone shared keys array if needed, then append.
@@ -85,6 +104,20 @@ pub(crate) unsafe fn ensure_key_in_keys_array(
     let _owned_keys = owned_keys_handle.get_raw_mut_ptr::<ArrayHeader>();
     refresh_define_property_roots!();
     set_object_keys_array(obj, new_keys);
+    // Keep the sidecar fresh (mirrors the [[Set]] append path): the entry is
+    // keyed by the OBJECT address and length-stamped, so this contiguous
+    // insert lets the next probe answer without a rebuild. No-op below the
+    // index threshold or when no entry exists yet.
+    {
+        let name_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+        let key_hash = super::super::key_bytes_hash(name_ptr, (*key).byte_len as usize);
+        super::super::keys_index_insert(
+            obj as usize,
+            key_count as u32 + 1,
+            key_hash,
+            key_count as u32,
+        );
+    }
     // `field_count` is the inline/overflow boundary consulted by the read path
     // (`js_object_get_field`: index < field_count ⇒ read inline slot, else the
     // overflow map). It must never exceed the object's physically-allocated
@@ -146,6 +179,48 @@ pub(crate) unsafe fn install_builtin_getter(proto: *mut ObjectHeader, key: &str,
         // writable is N/A for an accessor; enumerable=false, configurable=true.
         PropertyAttrs::new(true, false, true),
     );
+}
+
+/// O(1) own-key presence via the [[Set]]-path sidecar, for the
+/// `Object.defineProperty` flow (#6743). Returns `Some(present)` when the
+/// sidecar is applicable — a genuine wide object (keys past
+/// `KEYS_INDEX_THRESHOLD`) with a valid heap string key — using the same
+/// authoritative-miss trust model as the fast [[Set]] append. Returns `None`
+/// when not applicable (caller falls back to the linear `own_key_present` /
+/// `obj_value_has_own_key`). Native-module namespaces expose VIRTUAL keys
+/// that never live in `keys_array`, so they always fall back.
+pub(crate) unsafe fn own_key_present_via_index(
+    obj: *mut ObjectHeader,
+    key: *const crate::StringHeader,
+) -> Option<bool> {
+    if obj.is_null() || key.is_null() {
+        return None;
+    }
+    // Centralized address classification (rejects handle bands / non-heap /
+    // header-less slab addrs without dereferencing) + GC-type brand check —
+    // both for the receiver and for whatever the keys_array slot holds (a
+    // corrupted slot must classify as "no keys array", not fault; #321/#3527).
+    match crate::value::addr_class::try_read_gc_header(obj as usize) {
+        Some(h) if h.obj_type == crate::gc::GC_TYPE_OBJECT => {}
+        _ => return None,
+    }
+    if (*obj).class_id == super::super::native_module::NATIVE_MODULE_CLASS_ID {
+        return None;
+    }
+    let keys = (*obj).keys_array;
+    match crate::value::addr_class::try_read_gc_header(keys as usize) {
+        Some(h) if h.obj_type == crate::gc::GC_TYPE_ARRAY => {}
+        _ => return None,
+    }
+    let key_count = crate::array::js_array_length(keys) as usize;
+    if key_count < super::super::KEYS_INDEX_THRESHOLD as usize || key_count > 65536 {
+        return None;
+    }
+    let name_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+    let name_len = (*key).byte_len as usize;
+    let name_bytes = std::slice::from_raw_parts(name_ptr, name_len);
+    let key_hash = super::super::key_bytes_hash(name_ptr, name_len);
+    Some(super::super::keys_index_lookup(obj, keys, name_bytes, key_hash).is_some())
 }
 
 /// Helper: does `key` appear in `obj.keys_array`?

--- a/crates/perry-runtime/src/object/object_ops/keys_array.rs
+++ b/crates/perry-runtime/src/object/object_ops/keys_array.rs
@@ -70,8 +70,9 @@ pub(crate) unsafe fn ensure_key_in_keys_array(
             return; // already present
         }
     } else {
-        for i in 0..key_count {
-            let stored = crate::array::js_array_get(keys, i as u32);
+        let (slots, slot_len) = super::super::keys_array_dense_slots(keys);
+        for i in 0..key_count.min(slot_len) {
+            let stored = JSValue::from_bits((*slots.add(i)).to_bits());
             // #1781: SSO-aware match — pre-fix an existing inline-SSO key
             // wasn't seen here, so `Object.defineProperty(obj, "id", ...)`
             // on an object that already had `id` as an SSO key
@@ -300,8 +301,9 @@ pub(crate) unsafe fn own_key_present(
             return true;
         }
     }
-    for i in 0..key_count {
-        let stored = crate::array::js_array_get(keys, i as u32);
+    let (slots, slot_len) = super::super::keys_array_dense_slots(keys);
+    for i in 0..key_count.min(slot_len) {
+        let stored = JSValue::from_bits((*slots.add(i)).to_bits());
         // #1781: SSO-aware match — `hasOwnProperty("id")` previously
         // returned false when "id" lived as an inline SSO key.
         if crate::string::js_string_key_matches(stored, key) {

--- a/tests/test_wide_object_define_in_linear.sh
+++ b/tests/test_wide_object_define_in_linear.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Regression for the wide-object quadratic (#6743 family): repeated
+# `Object.defineProperty` and `k in obj` on an object past the keys-index
+# threshold were O(N) per call (three linear scans in the define flow + one in
+# the `in` operator's own-key walk) — O(N²) total. Webpack/Babel CJS re-export
+# modules (`if (k in exports) …; Object.defineProperty(exports, k, {get})` per
+# key) made a single @babel/types module take ~292ms vs node's 3ms, the
+# dominant cost of pi's module init under perry.
+#
+# The fix answers own-key presence through the same authoritative sidecar the
+# [[Set]] append path maintains. This test pins CORRECTNESS of that authority
+# model (differential vs node) on the shapes it could get wrong:
+#   - dedup: redefining an existing key on a wide object must not duplicate it
+#   - attrs retention: redefine keeps omitted attributes of the existing prop
+#   - SSO keys: short (<=5 byte) keys stored inline must be seen by the index
+#   - delete-then-redefine: a shrunken keys array must invalidate the index
+#   - non-extensible: define of a NEW key still throws after many defines
+#   - `in`: present/absent/deleted answers on a wide object
+# Plus a scaling sanity check: 2400 getter-defines must run well under the
+# quadratic regime's time.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PERRY="$SCRIPT_DIR/../target/release/perry"
+[ ! -f "$PERRY" ] && PERRY="$SCRIPT_DIR/../target/debug/perry"
+if [ ! -f "$PERRY" ]; then
+  echo "SKIP: perry binary not found (build with cargo build --release)"
+  exit 0
+fi
+if ! command -v node >/dev/null 2>&1; then
+  echo "SKIP: node not found (differential test needs node)"
+  exit 0
+fi
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+COMPILE_ENV=()
+if [ -f "$SCRIPT_DIR/../target/debug/libperry_runtime.a" ] || [ -f "$SCRIPT_DIR/../target/release/libperry_runtime.a" ]; then
+  COMPILE_ENV=(env PERRY_NO_AUTO_OPTIMIZE=1)
+fi
+
+cat > "$TMPDIR/main.ts" << 'EOF'
+const N = 300; // past the keys-index threshold (32)
+
+// 1. Build a wide object via defineProperty getters (the Babel re-export shape),
+//    with a mix of long and SSO-short (<=5 byte) keys.
+const t: any = {};
+Object.defineProperty(t, "__esModule", { value: true });
+for (let i = 0; i < N; i++) {
+  const k = i % 3 === 0 ? "k" + i : "longKey_" + i; // "k7" etc. are SSO-short
+  if (k in t) continue;
+  Object.defineProperty(t, k, { enumerable: true, configurable: true, get: () => i });
+}
+console.log("keys", Object.keys(t).length, "sample", t.k3, t.longKey_1);
+
+// 2. Dedup: redefining every existing key must not grow the key set.
+for (let i = 0; i < N; i++) {
+  const k = i % 3 === 0 ? "k" + i : "longKey_" + i;
+  Object.defineProperty(t, k, { enumerable: true, configurable: true, get: () => i * 2 });
+}
+console.log("after-redef keys", Object.keys(t).length, "val", t.k3, t.longKey_1);
+
+// 3. Attribute retention on redefine (omitted attrs keep current values).
+const w: any = {};
+for (let i = 0; i < 50; i++) w["p" + i] = i;
+Object.defineProperty(w, "p10", { value: 99, writable: false, enumerable: true, configurable: true });
+Object.defineProperty(w, "p10", { value: 100 }); // omits attrs -> retained
+const d = Object.getOwnPropertyDescriptor(w, "p10")!;
+console.log("retention", d.value, d.writable, d.enumerable, d.configurable);
+
+// 4. delete-then-redefine: shrink must not leave a stale index answer.
+delete t.longKey_1;
+console.log("deleted", "longKey_1" in t, Object.keys(t).length);
+Object.defineProperty(t, "longKey_1", { enumerable: true, configurable: true, get: () => -1 });
+console.log("readded", "longKey_1" in t, t.longKey_1, Object.keys(t).length);
+
+// 4b. Redefining a NON-configurable accessor must throw (invariants still
+//     enforced through the sidecar presence answer).
+Object.defineProperty(t, "lockedKey", { enumerable: true, get: () => 7 });
+let lockedThrew = false;
+try { Object.defineProperty(t, "lockedKey", { get: () => 8 }); } catch { lockedThrew = true; }
+console.log("nonconfigurable-redef-throws", lockedThrew, t.lockedKey);
+
+// 5. Non-extensible wide object: NEW key throws, existing configurable redefine ok.
+Object.preventExtensions(t);
+let threw = false;
+try { Object.defineProperty(t, "brandNew", { value: 1 }); } catch { threw = true; }
+console.log("nonextensible-new-throws", threw);
+
+// 6. `in` answers across the wide object.
+console.log("in-checks", "k3" in t, "longKey_2" in t, "absent_xyz" in t, "__esModule" in t);
+
+// 7. Scaling sanity: 2400 getter defines (was ~527ms quadratic; linear is ~100ms).
+const big: any = {};
+const t0 = Date.now();
+for (let i = 0; i < 2400; i++) Object.defineProperty(big, "g" + i, { enumerable: true, get: () => i });
+const dt = Date.now() - t0;
+console.log("scale-2400 keys", Object.keys(big).length, "fast", dt < 400);
+EOF
+
+cd "$TMPDIR"
+"${COMPILE_ENV[@]}" "$PERRY" compile main.ts --output test_bin --no-cache >/dev/null 2>&1
+PERRY_OUT=$(./test_bin 2>&1)
+NODE_OUT=$(node main.ts 2>&1)
+
+if [ "$PERRY_OUT" = "$NODE_OUT" ]; then
+  echo "PASS"
+  exit 0
+fi
+
+echo "FAIL: perry output diverged from node (wide-object define/in)"
+echo "--- node ---"; echo "$NODE_OUT"
+echo "--- perry ---"; echo "$PERRY_OUT"
+diff <(echo "$NODE_OUT") <(echo "$PERRY_OUT") || true
+exit 1


### PR DESCRIPTION
Fixes #6748.

Two commits: (1) removes the **quadratic** own-key scans from wide-object `Object.defineProperty` + `in`; (2) removes the dominant **constant** costs found by profiling the result.

## Commit 1 — O(1) own-key answers (the quadratic)
The define flow ran three linear `keys_array` scans per call (`enforce_define_property_invariants` → `own_key_present`, the existing-attrs check → `obj_value_has_own_key`, `ensure_key_in_keys_array`'s dup check) and the `in` operator's own-key walk ran a fourth. Build-then-fill loops — exactly the webpack/Babel CJS re-export shape (`if (k in exports)…; defineProperty(exports, k, {get})` per key) — were O(N²).

Fix: answer own-key presence through the same authoritative `KEYS_INDEX` sidecar the [[Set]] fast path has used since #5054, maintained from `ensure_key_in_keys_array` appends; new `own_key_present_via_index` (falls back for narrow/non-indexable/native-module receivers); SSO-aware sidecar rebuild (`js_string_key_bytes` instead of the heap-only `is_string()` gate — also hardens the existing [[Set]] authoritative miss).

## Commit 2 — the constants (found by sampling the fixed build)
1. **`js_array_get_f64`/`array_has_own_index`/named-setter dispatch gated their per-index accessor probe on the process-global `descriptors_in_use()`** — flipped by builtin init for every program — then paid `index.to_string()` + a `(usize, String)` map probe (2 String allocs + TLS) on *every checked array element read*. The runtime's own keys_array walks read through this path, so every object-key operation was taxed. Now gated on the per-array `OBJ_FLAG_ARRAY_DESCRIPTORS` header bit (the flag `js_array_get_f64_unchecked` already trusts, set by every `define_array_property` install site).
2. `ordinary_has_property`'s per-prototype-level accessor probe now honors `ACCESSORS_IN_USE` + per-object `OBJ_FLAG_HAS_DESCRIPTORS` (the address-reuse-safe [[Set]] gate) before the String-key side-table lookup.
3. Keys-array scan loops resolve the grow-forward pointer once (`keys_array_dense_slots`) and index the dense backing directly instead of re-running the generic per-element gauntlet (forward-resolution + lazy/Map/Set registry probes).

## Commit 3 — ordinary-object fast path for `in`
`js_object_has_property` ran every receiver through a ~10-arm classification gauntlet (proxy/handle/symbol/class-ref/fetch-subclass/exotic/typed-array/buffer/Map/Set/SAB), each arm a TLS + registry probe — for a plain object with a string key, the preamble WAS the cost (`_tlv_get_addr` alone = 26% of samples). Now one `try_read_gc_header` classifies the receiver: `GC_TYPE_OBJECT` skips the gauntlet wholesale (RegExp cells — the one OBJECT-typed exotic — keep routing to the exotic arm via a single registry probe; fetch-subclass forwarding is preserved behind a process-global "ever stashed" flag; `#private` hiding and native-module virtual keys are kept). This also accelerates defineProperty for free — `ToPropertyDescriptor`'s per-field `HasProperty` probes ride the same path. A/B against the parent commit confirmed the two remaining `in` divergences vs node (`"#x" in {"#x":1}`, inherited `"call" in f`) are pre-existing gaps, not introduced here.

## Results (2400-op micros; node in parens)
| benchmark | before | after | node |
|---|---|---|---|
| `in` hit | 259ms | **0.3ms** | 0.4ms — **parity** |
| `in` miss | 267ms | **4.0ms** | 0.6ms |
| getter defines | 527ms (×3.4/doubling) | **62ms (linear)** | 3.7ms |
| value defines (same-key) | 393ms | **48ms** | 3.0ms |
| `@babel/types` re-export init | 292ms | **~40ms self** | 3.1ms |
| full `jiti/dist/babel.cjs` init (pi's biggest startup module) | 688ms | **~300ms** | 44ms |

Remaining gap is now diffuse (per-call descriptor-field decoding with String allocs, `(usize, String)`-keyed side tables, generic module-init execution) — follow-up material, tracked in #6748.

## Validation
- perry-runtime full suite: **1439 passed / 0 failed** (single-threaded), after each of the three commits.
- Differential regression test `tests/test_wide_object_define_in_linear.sh` — byte-match vs node on: dedup on redefine, attribute retention, SSO short keys, delete-then-redefine, non-configurable redefine throw, non-extensible new-key throw, `in` present/absent/deleted, an `in` receiver-kind section (class instance / prototype chain / array / Date / RegExp / Map / frozen / null-proto / numeric keys), scaling bound.
- Address-classification audit clean (uses the centralized `try_read_gc_header` predicates).

Found while profiling pi's startup (follow-on from #6728/#6740 and #6741/#6742; independent of both).
