### PR TITLE
chore(changelog): freeze CHANGELOG.md, adopt per-PR changesets in changelog.d/

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,6 +114,23 @@ jobs:
       - name: File size limit
         run: ./scripts/check_file_size.sh
 
+      # Changeset gate: every PR touching crates/ must ship its own
+      # changelog fragment (changelog.d/<PR>-<slug>.md, see the README
+      # there). Fragments are folded into GitHub Release notes at tag
+      # time (scripts/cut_release_notes.sh); CHANGELOG.md is frozen.
+      # Escape hatch: the `skip-changelog` label (re-run the job after
+      # applying it).
+      - name: Changeset fragment gate
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate -q '.[].filename')
+          echo "$files" | grep -q '^crates/' || { echo "No crates/ changes — gate not applicable."; exit 0; }
+          echo "$files" | grep -q '^changelog\.d/' && exit 0
+          echo "::error::This PR changes crates/ but adds no changelog.d/ fragment. Add changelog.d/<PR>-<slug>.md (see changelog.d/README.md) or apply the 'skip-changelog' label."
+          exit 1
+
       # GC write-barrier store-site inventory: every raw heap-slot store in
       # perry-codegen / perry-runtime / perry-stdlib must be barriered or
       # carry a justified GC_STORE_AUDIT(...) marker (or a justified entry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,31 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------------
+  # Changeset gate: PRs touching crates/ must ship changelog.d/<PR>-<slug>.md
+  # (see changelog.d/README.md; fragments fold into GitHub Release notes at
+  # tag time via scripts/cut_release_notes.sh — CHANGELOG.md is frozen).
+  # Standalone job, NOT a step inside `lint`, so it can be its own required
+  # status check: lint carries unrelated red debt that gets admin-bypassed,
+  # and this gate must not ride along with that. The `skip-changelog` label
+  # skips it (the `labeled` trigger above refires the workflow, and a skipped
+  # required check counts as satisfied).
+  # ---------------------------------------------------------------------------
+  changeset-gate:
+    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require a changelog.d/ fragment for crates/ changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate -q '.[].filename')
+          echo "$files" | grep -q '^crates/' || { echo "No crates/ changes — gate not applicable."; exit 0; }
+          echo "$files" | grep -q '^changelog\.d/' && exit 0
+          echo "::error::This PR changes crates/ but adds no changelog.d/ fragment. Add changelog.d/<PR>-<slug>.md (see changelog.d/README.md) or apply the 'skip-changelog' label."
+          exit 1
+
+  # ---------------------------------------------------------------------------
   # Lint: cargo fmt --check (formatting gate for every PR)
   # ---------------------------------------------------------------------------
   lint:
@@ -113,23 +138,6 @@ jobs:
       # Allowlist + exclusions live in the script.
       - name: File size limit
         run: ./scripts/check_file_size.sh
-
-      # Changeset gate: every PR touching crates/ must ship its own
-      # changelog fragment (changelog.d/<PR>-<slug>.md, see the README
-      # there). Fragments are folded into GitHub Release notes at tag
-      # time (scripts/cut_release_notes.sh); CHANGELOG.md is frozen.
-      # Escape hatch: the `skip-changelog` label (re-run the job after
-      # applying it).
-      - name: Changeset fragment gate
-        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'skip-changelog')
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate -q '.[].filename')
-          echo "$files" | grep -q '^crates/' || { echo "No crates/ changes — gate not applicable."; exit 0; }
-          echo "$files" | grep -q '^changelog\.d/' && exit 0
-          echo "::error::This PR changes crates/ but adds no changelog.d/ fragment. Add changelog.d/<PR>-<slug>.md (see changelog.d/README.md) or apply the 'skip-changelog' label."
-          exit 1
 
       # GC write-barrier store-site inventory: every raw heap-slot store in
       # perry-codegen / perry-runtime / perry-stdlib must be barriered or

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,9 +73,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          files=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate -q '.[].filename')
-          echo "$files" | grep -q '^crates/' || { echo "No crates/ changes — gate not applicable."; exit 0; }
-          echo "$files" | grep -q '^changelog\.d/' && exit 0
+          gh api "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --paginate > files.json
+          jq -r '.[].filename' files.json | grep -q '^crates/' || { echo "No crates/ changes — gate not applicable."; exit 0; }
+          # The fragment must be ADDED in this PR (editing a leftover file
+          # doesn't count) and match the root-level <digits>-<slug>.md shape
+          # cut_release_notes.sh folds at release time.
+          jq -r '.[] | select(.status == "added") | .filename' files.json | grep -qE '^changelog\.d/[0-9]+-[^/]+\.md$' && exit 0
           echo "::error::This PR changes crates/ but adds no changelog.d/ fragment. Add changelog.d/<PR>-<slug>.md (see changelog.d/README.md) or apply the 'skip-changelog' label."
           exit 1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# Changelog — FROZEN at v0.5.1264
+
+This file is a historical archive (v0.5.0 – v0.5.1264) and no longer grows.
+New changes land as per-PR fragments in `changelog.d/` (see its README) and
+are folded into the GitHub Release notes at each tag via
+`scripts/cut_release_notes.sh`.
+
+---
+
 ## v0.5.1264 — fix(url): route URLSearchParams subclass instances to their native backing (#6738)
 
 `class X extends URLSearchParams` — most importantly Next.js's `ReadonlyURLSearchParams`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-**NOTE**: Keep this file concise. Detailed changelogs live in CHANGELOG.md.
+**NOTE**: Keep this file concise. Detailed changelogs live as `changelog.d/` fragments (folded into GitHub Release notes at each tag); `CHANGELOG.md` is a frozen archive (≤ v0.5.1264).
 
 ## Project Overview
 
@@ -40,14 +40,14 @@ Two workflows are deliberately exempt and say so inline: `node-core-subset.yml` 
 **For every change that lands on `main`** (whether via PR or admin bypass):
 
 1. **Bump version**: Increment patch in `[workspace.package].version` in `Cargo.toml` and the `**Current Version:**` line above. That is the ONLY metadata edit CLAUDE.md needs.
-2. **Add changelog entry**: Prepend a new `## v0.5.x — <one-line summary>` block at the top of `CHANGELOG.md`. Detail can go below in the same block — long-form root-cause writeups, file paths, validation notes, etc. all belong here, NOT in CLAUDE.md.
-3. **Commit changes**: Include code, `Cargo.toml`/`Cargo.lock`, `CLAUDE.md` (version bump only), and `CHANGELOG.md` updates together.
+2. **Add a changeset**: create `changelog.d/<PR>-<slug>.md` with the entry body (no version header — see `changelog.d/README.md`). Long-form root-cause writeups, file paths, validation notes all belong in the fragment, NOT in CLAUDE.md. **Never append to `CHANGELOG.md`** — it is frozen at v0.5.1264. Fragments are folded into the GitHub Release notes at tag time (`scripts/cut_release_notes.sh`) and deleted.
+3. **Commit changes**: Include code, `Cargo.toml`/`Cargo.lock`, `CLAUDE.md` (version bump only), and the `changelog.d/` fragment together.
 
-**Do not write changelog entries into CLAUDE.md.** This file is for orientation (architecture, common pitfalls, build commands). Per-version history lives in `CHANGELOG.md` so CLAUDE.md stays small and stable across context loads.
+**Do not write changelog entries into CLAUDE.md.** This file is for orientation (architecture, common pitfalls, build commands). Per-change history lives in `changelog.d/` → GitHub Releases so CLAUDE.md stays small and stable across context loads.
 
 ### External contributor PRs
 
-PRs from outside contributors should **not** touch `[workspace.package] version` in `Cargo.toml`, the `**Current Version:**` line in `CLAUDE.md`, or `CHANGELOG.md`. The maintainer bumps the version and writes the changelog entry at merge time — usually by rebasing the PR branch and amending. This avoids the patch-version collisions that happen when Perry's `main` ships several commits while a PR is in review (each on-main commit bumps the version; a PR that bumped to the same patch on day 1 is already behind by merge day). Contributors just write code; let the maintainer fold in the metadata last.
+PRs from outside contributors should **not** touch `[workspace.package] version` in `Cargo.toml` or the `**Current Version:**` line in `CLAUDE.md`. The maintainer bumps the version at merge time — usually by rebasing the PR branch and amending. This avoids the patch-version collisions that happen when Perry's `main` ships several commits while a PR is in review (each on-main commit bumps the version; a PR that bumped to the same patch on day 1 is already behind by merge day). Contributors **do** write their own `changelog.d/<PR>-<slug>.md` fragment — the filename is PR-keyed, so in-flight PRs never collide.
 
 ## Build Commands
 
@@ -198,6 +198,6 @@ Build outputs are invisible to `git status`, so a clean tree tells you nothing a
 
 ## Recent Changes
 
-Per-version entries live in CHANGELOG.md.
+Per-change entries live as `changelog.d/` fragments until the next tag, then in that tag's GitHub Release notes (historical archive ≤ v0.5.1264 in the frozen `CHANGELOG.md`).
 
-**Do not add changelog entries to this file.** Bump only the `**Current Version:**` line above when you ship a release; everything else goes in CHANGELOG.md as a new `## v0.5.x — ...` block at the top.
+**Do not add changelog entries to this file.** Bump only the `**Current Version:**` line above when you ship a change; the entry itself goes in `changelog.d/<PR>-<slug>.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,9 +195,3 @@ Build outputs are invisible to `git status`, so a clean tree tells you nothing a
 - **Async-to-generator transform, body locals.** It boxes every body local into a shared mutable cell typed `Any`. Two consequences seen in the wild: per-iteration `let`/`const` bindings collapse for closures created in a loop, and computed numeric-key calls (`arr[i](x)`) lose their type proof and silently resolve by *method name*, evaporating the call.
 - **Native base-class subclassing.** A native base's surface is installed at `super()` time and its parent edge lives in the class registry; keying any of that on a literal `extends` name loses it for fieldless classes, indirect subclasses, and class expressions.
 - **Two prototype-resolution paths.** `CLASS_PROTOTYPE_OBJECTS` (synthetic: `Object.create`, plain-function ctors) vs `CLASS_DECL_PROTOTYPE_OBJECTS` (declared classes). `in`/`for…in` and `getPrototypeOf` have disagreed about the same chain.
-
-## Recent Changes
-
-Per-change entries live as `changelog.d/` fragments until the next tag, then in that tag's GitHub Release notes (historical archive ≤ v0.5.1264 in the frozen `CHANGELOG.md`).
-
-**Do not add changelog entries to this file.** Bump only the `**Current Version:**` line above when you ship a change; the entry itself goes in `changelog.d/<PR>-<slug>.md`.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,23 @@
+# changelog.d/ — per-PR changelog fragments
+
+One markdown file per change, added **in the same PR as the code**:
+
+    changelog.d/<PR-number>-<short-slug>.md
+
+The file body is the changelog entry (same style the old CHANGELOG.md blocks
+had), **without** a version header — the filename is keyed on the PR number
+precisely so contributors don't need to know which patch version they'll land
+as, and so two in-flight PRs never collide on the same file.
+
+At each release tag the maintainer runs:
+
+    ./scripts/cut_release_notes.sh vX.Y.Z
+
+which concatenates all fragments (newest PR first) into the GitHub Release
+notes, then deletes them. History lives in GitHub Releases and in git history
+(`git log -- changelog.d/`). `CHANGELOG.md` is a frozen archive of everything
+up to v0.5.1264 and no longer grows.
+
+CI: a PR that touches `crates/` must add a fragment here (enforced in the
+`lint` job). Apply the `skip-changelog` label to opt out — typo fixes,
+CI-only churn, etc.

--- a/scripts/cut_release_notes.sh
+++ b/scripts/cut_release_notes.sh
@@ -12,9 +12,10 @@ cd "$(dirname "$0")/.."
 
 tag="${1:?usage: cut_release_notes.sh vX.Y.Z}"
 
-# Fragments are <PR>-<slug>.md; README.md is documentation, not an entry.
-# Sort by PR number descending (newest change first in the notes).
-frags=$(find changelog.d -name '[0-9]*.md' | sort -t/ -k2 -rn)
+# Fragments are root-level regular files named <PR>-<slug>.md; README.md is
+# documentation, not an entry. Sort by PR number descending (newest change
+# first in the notes). Contract matches the changeset-gate job in test.yml.
+frags=$(find changelog.d -maxdepth 1 -type f -name '[0-9]*.md' | sort -t/ -k2 -rn)
 [ -n "$frags" ] || { echo "ERROR: no fragments in changelog.d/ — nothing to release." >&2; exit 1; }
 
 notes=$(mktemp)
@@ -23,8 +24,11 @@ while IFS= read -r f; do
   printf '\n\n' >> "$notes"
 done <<< "$frags"
 
-gh release create "$tag" --title "$tag" --notes-file "$notes"
-# shellcheck disable=SC2086  # word-splitting intended; fragment names have no spaces
-git rm -q $frags
+# --target pins the tag to the checked-out commit; gh's default is the tip
+# of the default branch, which may have moved past HEAD.
+gh release create "$tag" --target "$(git rev-parse HEAD)" --title "$tag" --notes-file "$notes"
+while IFS= read -r f; do
+  git rm -q -- "$f"
+done <<< "$frags"
 git commit -m "chore(release): fold changesets into $tag release notes"
 echo "Release $tag created ($(echo "$frags" | wc -l | tr -d ' ') fragments folded). Push the removal commit."

--- a/scripts/cut_release_notes.sh
+++ b/scripts/cut_release_notes.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Fold changelog.d/ fragments into a GitHub Release's notes, then delete them.
+#
+# Usage (maintainer, from a clean main at the commit to release):
+#   ./scripts/cut_release_notes.sh v0.5.1265
+#
+# Creates the tag + GitHub Release at HEAD via `gh release create` (which
+# triggers release-packages.yml, same as today), then commits the fragment
+# removal — push that commit via the normal PR/bypass flow.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+tag="${1:?usage: cut_release_notes.sh vX.Y.Z}"
+
+# Fragments are <PR>-<slug>.md; README.md is documentation, not an entry.
+# Sort by PR number descending (newest change first in the notes).
+frags=$(find changelog.d -name '[0-9]*.md' | sort -t/ -k2 -rn)
+[ -n "$frags" ] || { echo "ERROR: no fragments in changelog.d/ — nothing to release." >&2; exit 1; }
+
+notes=$(mktemp)
+while IFS= read -r f; do
+  cat "$f" >> "$notes"
+  printf '\n\n' >> "$notes"
+done <<< "$frags"
+
+gh release create "$tag" --title "$tag" --notes-file "$notes"
+# shellcheck disable=SC2086  # word-splitting intended; fragment names have no spaces
+git rm -q $frags
+git commit -m "chore(release): fold changesets into $tag release notes"
+echo "Release $tag created ($(echo "$frags" | wc -l | tr -d ' ') fragments folded). Push the removal commit."


### PR DESCRIPTION
CHANGELOG.md reached 2.8MB (one prepended block per commit) and every in-flight PR conflicted on its first line. This replaces the prepend flow with towncrier-style fragments:

- Each PR ships `changelog.d/<PR>-<slug>.md` — PR-keyed filename, so contributors write their own entry with no merge conflicts and no maintainer amend at merge time.
- `scripts/cut_release_notes.sh vX.Y.Z` folds all fragments into the GitHub Release notes at tag time (triggering `release-packages.yml` as before) and deletes them; history lives in GitHub Releases and `git log -- changelog.d/`.
- New `lint`-job gate: a PR touching `crates/` without a fragment fails; `skip-changelog` label opts out.
- CHANGELOG.md is frozen at v0.5.1264 as a historical archive.

Version-bump rules are unchanged (maintainer bumps `Cargo.toml` per merge).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automation to validate per-PR changelog fragments and compile them into GitHub Release notes when publishing a release.
* **Documentation**
  * Clarified that `CHANGELOG.md` is a frozen archive and documented the `changelog.d/` fragment format, ordering, and release-note build workflow.
  * Updated contributor guidance to ensure new entries are added only as fragments.
* **Chores**
  * Added CI checks requiring appropriate `changelog.d/<PR>-<slug>.md` fragments for crate-touching pull requests (with an opt-out via `skip-changelog`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->