### PR TITLE
perf(object): `in` fast path (re-land) + single-pass descriptor decode for defineProperty (#6748)

### DIFF
--- a/crates/perry-runtime/src/object/array_object_ops.rs
+++ b/crates/perry-runtime/src/object/array_object_ops.rs
@@ -398,6 +398,7 @@ pub(crate) unsafe fn define_array_property(
                         cur_accessor,
                         cur_value,
                         descriptor_value,
+                        None,
                     );
                 }
             }
@@ -608,6 +609,7 @@ pub(crate) unsafe fn define_array_property(
                     cur_accessor,
                     cur_value,
                     descriptor_value,
+                    None,
                 );
             }
         }

--- a/crates/perry-runtime/src/object/exotic_expando.rs
+++ b/crates/perry-runtime/src/object/exotic_expando.rs
@@ -491,6 +491,7 @@ pub(crate) unsafe fn exotic_define_own_property(
                 existing_accessor,
                 cur_value,
                 descriptor_value,
+                None,
             );
         }
     } else {

--- a/crates/perry-runtime/src/object/field_get_set.rs
+++ b/crates/perry-runtime/src/object/field_get_set.rs
@@ -18,6 +18,13 @@ use super::*;
 /// chain, so a subclass instance can only reach those members via the handle.
 pub(crate) const FETCH_SUBCLASS_HANDLE_FIELD: &[u8] = b"__perry_fetch_handle__";
 
+/// Has any fetch-subclass instance EVER stashed a native handle in this
+/// process? `fetch_subclass_handle_id` costs a key-string alloc + a full
+/// property read per call; the `in`-operator fast path (#6748) gates on this
+/// flag so the overwhelmingly-common no-fetch-subclass program never pays it.
+pub(crate) static FETCH_SUBCLASS_EVER: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
 /// If `obj` (a raw heap object address) is a `class X extends Request/Response`
 /// instance, return the id of its underlying native fetch handle. Returns
 /// `None` for any non-object / non-subclass receiver, so callers can fall

--- a/crates/perry-runtime/src/object/field_get_set/has_property.rs
+++ b/crates/perry-runtime/src/object/field_get_set/has_property.rs
@@ -213,6 +213,34 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
     };
     let key_val = JSValue::from_bits(key.to_bits());
 
+    // ── #6748 fast path: ordinary heap object + string key ────────────────
+    // One GC-header read classifies the receiver. A `GC_TYPE_OBJECT` cannot
+    // be a proxy or handle-band id (non-heap addresses, rejected by
+    // `try_read_gc_header`), a typed array / buffer / Map / Set / promise /
+    // error / date / temporal cell (each has its own GC type), a closure
+    // (`GC_TYPE_CLOSURE`), or an INT32 class ref (not a pointer). So the
+    // per-registry probe gauntlet below — each arm a TLS access + HashMap
+    // lookup, together the dominant cost of `in` on plain objects — is
+    // skipped wholesale. The three object-relevant arms are preserved in
+    // `object_string_key_has_property`.
+    if key_val.is_any_string() && obj_val.is_pointer() {
+        let addr = (obj_val.bits() & crate::value::POINTER_MASK) as usize;
+        if let Some(h) = unsafe { crate::value::addr_class::try_read_gc_header(addr) } {
+            // RegExp cells (unlike Date/Error/Map/Set/…, which carry their own
+            // GC types) are OBJECT-typed allocations registered in the exotic
+            // expando registry — they must keep routing through the exotic arm
+            // below (`"lastIndex" in re`), so one registry probe stays in the
+            // fast path. Everything else OBJECT-typed is an ordinary object.
+            if h.obj_type == crate::gc::GC_TYPE_OBJECT
+                && super::super::exotic_expando::exotic_expando_kind(addr).is_none()
+            {
+                return unsafe {
+                    object_string_key_has_property(addr as *const ObjectHeader, key, key_val)
+                };
+            }
+        }
+    }
+
     // A Proxy is a small registered id (POINTER_TAG with a tiny pointer), not a
     // heap object. Falling through to the symbol/class/pointer paths below would
     // deref the fake pointer (or call symbol helpers that do) and segfault. Route
@@ -873,6 +901,82 @@ pub extern "C" fn js_object_has_property(obj: f64, key: f64) -> f64 {
         } else {
             nanbox_false
         }
+    }
+}
+
+/// #6748 fast-path tail for `js_object_has_property`: the receiver is a
+/// verified `GC_TYPE_OBJECT` and the key is a string. Replicates exactly the
+/// object-relevant arms of the full gauntlet — the fetch-subclass native
+/// forward (gated on the process-global "ever stashed" flag), `#private`-name
+/// hiding, native-module virtual keys — then the ordinary spec walk.
+unsafe fn object_string_key_has_property(
+    obj_ptr: *const ObjectHeader,
+    key: f64,
+    key_val: JSValue,
+) -> f64 {
+    let nanbox_false = f64::from_bits(0x7FFC_0000_0000_0003u64); // TAG_FALSE
+    let nanbox_true = f64::from_bits(0x7FFC_0000_0000_0004u64); // TAG_TRUE
+
+    // `class X extends Request/Response` instances forward native members
+    // (`body`/`method`/…) through their stashed fetch handle. Gated: programs
+    // that never construct a fetch subclass skip the per-call key alloc +
+    // property read entirely.
+    if crate::object::field_get_set::FETCH_SUBCLASS_EVER.load(std::sync::atomic::Ordering::Relaxed)
+    {
+        if let Some(handle_id) = super::fetch_subclass_handle_id(obj_ptr as usize) {
+            if let Some(dispatch) = super::super::class_registry::handle_property_dispatch() {
+                let key_ptr =
+                    crate::value::js_get_string_pointer_unified(key) as *const crate::StringHeader;
+                if !key_ptr.is_null() {
+                    let name_ptr =
+                        (key_ptr as *const u8).add(std::mem::size_of::<crate::StringHeader>());
+                    let name_len = (*key_ptr).byte_len as usize;
+                    let result = dispatch(handle_id, name_ptr, name_len);
+                    if result.to_bits() != crate::value::TAG_UNDEFINED {
+                        return nanbox_true;
+                    }
+                }
+            }
+        }
+    }
+
+    let class_id = (*obj_ptr).class_id;
+    if class_id != 0 {
+        // `#name`-prefixed string keys on class instances are private elements —
+        // invisible to ordinary [[HasProperty]] (mirrors the slow-path arm).
+        let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+        if let Some(b) = crate::string::js_string_key_bytes(key_val, &mut sso) {
+            if b.first() == Some(&b'#') {
+                return nanbox_false;
+            }
+        }
+        // Native-module namespaces (console, fs, …) expose VIRTUAL keys —
+        // dispatch tables, not keys_array entries.
+        if class_id == NATIVE_MODULE_CLASS_ID {
+            let key_str =
+                crate::value::js_get_string_pointer_unified(key) as *const crate::StringHeader;
+            if key_str.is_null() {
+                return nanbox_false;
+            }
+            let key_name = match super::super::has_own_helpers::str_from_string_header(key_str) {
+                Some(name) => name,
+                None => return nanbox_false,
+            };
+            let present = read_native_module_name(obj_ptr)
+                .as_deref()
+                .is_some_and(|module_name| {
+                    super::super::native_module::native_module_vtable()
+                        .is_some_and(|vt| (vt.has_enumerable_key)(module_name, key_name))
+                });
+            return if present { nanbox_true } else { nanbox_false };
+        }
+    }
+
+    let key_str = crate::value::js_get_string_pointer_unified(key) as *const crate::StringHeader;
+    if ordinary_has_property(obj_ptr, key_str) {
+        nanbox_true
+    } else {
+        nanbox_false
     }
 }
 

--- a/crates/perry-runtime/src/object/global_this/fetch_globals.rs
+++ b/crates/perry-runtime/src/object/global_this/fetch_globals.rs
@@ -363,6 +363,8 @@ unsafe fn subclass_this_object_ptr(this_box: f64) -> Option<*mut ObjectHeader> {
 /// plain numeric f64 — `fetch_subclass_handle_id` reads it back.
 unsafe fn attach_fetch_handle_to_this(this_box: f64, handle_box: f64) {
     if let Some(obj) = subclass_this_object_ptr(this_box) {
+        crate::object::field_get_set::FETCH_SUBCLASS_EVER
+            .store(true, std::sync::atomic::Ordering::Relaxed);
         let id = crate::value::js_nanbox_get_pointer(handle_box);
         let key = crate::string::js_string_from_bytes(
             FETCH_SUBCLASS_HANDLE_FIELD.as_ptr(),

--- a/crates/perry-runtime/src/object/object_ops.rs
+++ b/crates/perry-runtime/src/object/object_ops.rs
@@ -37,8 +37,9 @@ pub(crate) use descriptor_helpers::{
     define_property_force_store_value, desc_has_field, desc_read_field,
     describe_value_for_type_error, descriptor_enumerable, enforce_define_property_invariants,
     registered_buffer_index_own_property_present, throw_object_type_error,
-    throw_object_type_error_with_suffix, validate_nonconfigurable_redefine,
-    validate_property_descriptor, value_is_object_like,
+    throw_object_type_error_with_suffix, try_decode_descriptor, validate_nonconfigurable_redefine,
+    validate_property_descriptor, validate_property_descriptor_view, value_is_object_like,
+    DescView, DESC_CONFIGURABLE, DESC_ENUMERABLE, DESC_GET, DESC_SET, DESC_VALUE, DESC_WRITABLE,
 };
 // Module-private `unsafe fn value_is_callable` (descriptor_helpers): used by the
 // object_ops children (`accessors.rs`, `descriptor_helpers.rs`) but NOT

--- a/crates/perry-runtime/src/object/object_ops/define_property.rs
+++ b/crates/perry-runtime/src/object/object_ops/define_property.rs
@@ -300,6 +300,22 @@ pub extern "C" fn js_object_define_property(
     descriptor_value: f64,
 ) -> f64 {
     unsafe {
+        // #6748 follow-up: classify the receiver ONCE. A `GC_TYPE_OBJECT` that
+        // is not an exotic cell (RegExp is the one OBJECT-typed exotic) cannot
+        // be a proxy or handle id, a typed array, a buffer, a closure, or an
+        // exotic Date/Error/Map/Set — so each of those arms (a TLS + registry
+        // probe apiece) is skipped below. Mirrors the `in` operator's fast
+        // path in `has_property.rs`.
+        let receiver_plain_object = {
+            let jv = crate::value::JSValue::from_bits(obj_value.to_bits());
+            jv.is_pointer() && {
+                let a = jv.as_pointer::<u8>() as usize;
+                matches!(
+                    crate::value::addr_class::try_read_gc_header(a),
+                    Some(h) if h.obj_type == crate::gc::GC_TYPE_OBJECT
+                ) && super::super::exotic_expando::exotic_expando_kind(a).is_none()
+            }
+        };
         // A Proxy receiver is a small registered id, not a heap object — it
         // fails the `value_is_object_like` test below (so it would wrongly throw
         // "called on non-object") and the ordinary paths would deref the fake
@@ -307,7 +323,7 @@ pub extern "C" fn js_object_define_property(
         // validate the descriptor (ToPropertyDescriptor), invoke the
         // `[[DefineOwnProperty]]` trap, and throw a TypeError if it reports
         // failure. (Proxy crash cluster.)
-        if crate::proxy::js_proxy_is_proxy(obj_value) != 0 {
+        if !receiver_plain_object && crate::proxy::js_proxy_is_proxy(obj_value) != 0 {
             if !value_is_object_like(descriptor_value)
                 || crate::symbol::js_is_symbol(descriptor_value) != 0
             {
@@ -400,26 +416,41 @@ pub extern "C" fn js_object_define_property(
             let desc = describe_value_for_type_error(descriptor_value);
             throw_object_type_error_with_suffix("Property description must be an object: ", &desc);
         }
-        validate_property_descriptor(descriptor_value);
+        // #6748 follow-up: decode the descriptor's 6 fields in ONE pass when it
+        // is a plain default-prototype object (the overwhelming majority) —
+        // the per-field `desc_has_field`/`desc_read_field` helpers each cost a
+        // key-string alloc plus a HasProperty/[[Get]] walk. `None` keeps the
+        // spec-general per-field path everywhere below.
+        let desc_view = try_decode_descriptor(descriptor_value);
+        match &desc_view {
+            Some(v) => validate_property_descriptor_view(v),
+            None => validate_property_descriptor(descriptor_value),
+        }
 
         // TypedArrays are Integer-Indexed exotic objects: a canonical numeric
         // index key bypasses ordinary define entirely (validate the index, then
         // either write the element or reject with a TypeError).
-        match super::super::typed_array_define_own_property(obj_value, key_value, descriptor_value)
-        {
-            super::super::TypedArrayDefineOutcome::Defined => return obj_value,
-            super::super::TypedArrayDefineOutcome::Rejected => {
-                throw_object_type_error(b"Cannot redefine property")
+        if !receiver_plain_object {
+            match super::super::typed_array_define_own_property(
+                obj_value,
+                key_value,
+                descriptor_value,
+            ) {
+                super::super::TypedArrayDefineOutcome::Defined => return obj_value,
+                super::super::TypedArrayDefineOutcome::Rejected => {
+                    throw_object_type_error(b"Cannot redefine property")
+                }
+                super::super::TypedArrayDefineOutcome::NotTypedArray => {}
             }
-            super::super::TypedArrayDefineOutcome::NotTypedArray => {}
         }
 
         // Date / RegExp / Error instances are exotic cells, not
         // `ObjectHeader`s — the ordinary define path below would bit-cast
         // them and corrupt memory. Route through the expando-aware
         // [[DefineOwnProperty]] (side-table storage + attrs + accessors).
-        if let Some((addr, kind)) =
-            super::super::exotic_expando::exotic_expando_kind_of_value(obj_value)
+        if let Some((addr, kind)) = (!receiver_plain_object)
+            .then(|| super::super::exotic_expando::exotic_expando_kind_of_value(obj_value))
+            .flatten()
         {
             if crate::symbol::js_is_symbol(key_value) != 0 {
                 let value_field = desc_read_field(descriptor_value, b"value");
@@ -503,7 +534,9 @@ pub extern "C" fn js_object_define_property(
 
         // Closures are object-like but not ObjectHeader-backed, so descriptor
         // writes have to route through the closure property side tables.
-        let target_closure_ptr = {
+        let target_closure_ptr = if receiver_plain_object {
+            None
+        } else {
             let value = crate::value::JSValue::from_bits(obj_value.to_bits());
             let raw = if value.is_pointer() {
                 value.as_pointer::<u8>() as usize
@@ -619,6 +652,7 @@ pub extern "C" fn js_object_define_property(
                         cur_accessor,
                         cur_value,
                         descriptor_value,
+                        desc_view.as_ref(),
                     );
                 }
             }
@@ -687,7 +721,10 @@ pub extern "C" fn js_object_define_property(
             return obj_value;
         }
 
-        if let Some(addr) = crate::typedarray_props::typed_array_addr_from_value(obj_value) {
+        if let Some(addr) = (!receiver_plain_object)
+            .then(|| crate::typedarray_props::typed_array_addr_from_value(obj_value))
+            .flatten()
+        {
             // A Symbol key on a TypedArray is an ORDINARY define — store it in
             // the symbol side tables (string-coercing it would file the value
             // under a "Symbol(x)" string name, unreachable via `ta[sym]`),
@@ -887,7 +924,9 @@ pub extern "C" fn js_object_define_property(
                 }
             }
         }
-        if crate::typedarray::lookup_typed_array_kind(obj as usize).is_some() {
+        if !receiver_plain_object
+            && crate::typedarray::lookup_typed_array_kind(obj as usize).is_some()
+        {
             if let Some(ref key_name) = key_rust {
                 return crate::typedarray_props::typed_array_define_own_property(
                     obj_value,
@@ -899,13 +938,18 @@ pub extern "C" fn js_object_define_property(
             }
             return obj_value;
         }
-        if let Some(ok) = super::super::define_array_property(
-            obj,
-            obj_value,
-            key_str,
-            key_rust.as_deref(),
-            descriptor_value,
-        ) {
+        if let Some(ok) = (!receiver_plain_object)
+            .then(|| {
+                super::super::define_array_property(
+                    obj,
+                    obj_value,
+                    key_str,
+                    key_rust.as_deref(),
+                    descriptor_value,
+                )
+            })
+            .flatten()
+        {
             if ok {
                 return obj_value;
             }
@@ -920,7 +964,13 @@ pub extern "C" fn js_object_define_property(
         // mutation, so a rejected definition leaves the object untouched and the
         // thrown TypeError matches Node.
         if let Some(ref k) = key_rust {
-            enforce_define_property_invariants(obj, key_str, k, descriptor_value);
+            enforce_define_property_invariants(
+                obj,
+                key_str,
+                k,
+                descriptor_value,
+                desc_view.as_ref(),
+            );
         }
         super::super::mark_object_dynamic_shape_unknown(obj);
         // Extract descriptor object
@@ -956,10 +1006,20 @@ pub extern "C" fn js_object_define_property(
         // PRESENCE (HasProperty — own OR inherited) on the descriptor object,
         // not by `is_undefined`: `{ get: undefined }` is an explicit (present)
         // accessor field, and an *inherited* `value`/`get` counts as present.
-        let desc_has_get = desc_has_field(descriptor_value, b"get");
-        let desc_has_set = desc_has_field(descriptor_value, b"set");
-        let get_field = desc_read_field(descriptor_value, b"get");
-        let set_field = desc_read_field(descriptor_value, b"set");
+        let (desc_has_get, desc_has_set, get_field, set_field) = match &desc_view {
+            Some(v) => (
+                v.has(DESC_GET),
+                v.has(DESC_SET),
+                v.read(DESC_GET),
+                v.read(DESC_SET),
+            ),
+            None => (
+                desc_has_field(descriptor_value, b"get"),
+                desc_has_field(descriptor_value, b"set"),
+                desc_read_field(descriptor_value, b"get"),
+                desc_read_field(descriptor_value, b"set"),
+            ),
+        };
         let has_accessor = desc_has_get || desc_has_set;
 
         // The existing accessor (if the property is currently an accessor) —
@@ -1024,8 +1084,13 @@ pub extern "C" fn js_object_define_property(
             // descriptor (only `enumerable`/`configurable`). Detect by own-field
             // presence so `{ value: undefined }` (present) stores `undefined`,
             // while a generic descriptor on an existing accessor leaves it intact.
-            let desc_has_value = desc_has_field(descriptor_value, b"value");
-            let desc_has_writable = desc_has_field(descriptor_value, b"writable");
+            let (desc_has_value, desc_has_writable) = match &desc_view {
+                Some(v) => (v.has(DESC_VALUE), v.has(DESC_WRITABLE)),
+                None => (
+                    desc_has_field(descriptor_value, b"value"),
+                    desc_has_field(descriptor_value, b"writable"),
+                ),
+            };
             let is_data = desc_has_value || desc_has_writable;
 
             if is_data {
@@ -1040,7 +1105,10 @@ pub extern "C" fn js_object_define_property(
                     });
                     clear_property_attrs(obj as usize, k);
                 }
-                let value_field = desc_read_field(descriptor_value, b"value");
+                let value_field = match &desc_view {
+                    Some(v) => v.read(DESC_VALUE),
+                    None => desc_read_field(descriptor_value, b"value"),
+                };
                 // Ensure the key exists; store the (possibly `undefined`) value
                 // via `[[DefineOwnProperty]]`, bypassing the `[[Set]]` writability
                 // / frozen guard (invariants already enforced above). When
@@ -1075,7 +1143,14 @@ pub extern "C" fn js_object_define_property(
         // Read attribute flags from descriptor. JS defaults when omitted in
         // `Object.defineProperty` are `false` (NOT `true` like for direct assignment).
         let read_bool = |name: &[u8]| -> Option<bool> {
-            let v = desc_read_field(descriptor_value, name);
+            let v = match &desc_view {
+                Some(view) => view.read(match name {
+                    b"writable" => DESC_WRITABLE,
+                    b"enumerable" => DESC_ENUMERABLE,
+                    _ => DESC_CONFIGURABLE,
+                }),
+                None => desc_read_field(descriptor_value, name),
+            };
             if v.is_undefined() {
                 None
             } else {
@@ -1094,8 +1169,13 @@ pub extern "C" fn js_object_define_property(
         // retained-attrs rule doesn't apply across the kind switch).
         let accessor_to_data = existing_accessor.is_some()
             && !has_accessor
-            && (desc_has_field(descriptor_value, b"value")
-                || desc_has_field(descriptor_value, b"writable"));
+            && match &desc_view {
+                Some(v) => v.has(DESC_VALUE) || v.has(DESC_WRITABLE),
+                None => {
+                    desc_has_field(descriptor_value, b"value")
+                        || desc_has_field(descriptor_value, b"writable")
+                }
+            };
         let writable = read_bool(b"writable").unwrap_or_else(|| {
             if accessor_to_data {
                 false

--- a/crates/perry-runtime/src/object/object_ops/descriptor_helpers.rs
+++ b/crates/perry-runtime/src/object/object_ops/descriptor_helpers.rs
@@ -117,6 +117,203 @@ pub(crate) unsafe fn registered_buffer_index_own_property_present(
 /// `HasProperty` then `Get`, so an inherited `value`/`get`/... counts as
 /// present (e.g. `Object.defineProperty(o, k, child)` where `child`'s prototype
 /// carries `value`). `descriptor_value` is the NaN-boxed descriptor object.
+// ─── #6748 follow-up: single-pass descriptor decode ──────────────────────────
+// `ToPropertyDescriptor` reads up to 6 fields; the per-field helpers below
+// each allocate the field-name string and run a full `HasProperty`/`[[Get]]`
+// (absent fields walk the prototype chain), so one defineProperty paid ~10
+// such probes. For the overwhelmingly-common descriptor — a plain object
+// literal with the default prototype and no accessor-backed fields — a single
+// walk of its own keys answers everything. `try_decode_descriptor` returns
+// `None` whenever any spec-visible subtlety could apply (closure/exotic/class
+// receivers, custom [[Prototype]], accessor-backed fields, a polluted
+// `Object.prototype`), and callers keep the general per-field path.
+
+pub(crate) const DESC_VALUE: usize = 0;
+pub(crate) const DESC_GET: usize = 1;
+pub(crate) const DESC_SET: usize = 2;
+pub(crate) const DESC_WRITABLE: usize = 3;
+pub(crate) const DESC_ENUMERABLE: usize = 4;
+pub(crate) const DESC_CONFIGURABLE: usize = 5;
+
+pub(crate) struct DescView {
+    present: [bool; 6],
+    vals: [crate::value::JSValue; 6],
+}
+
+impl DescView {
+    #[inline]
+    pub(crate) fn has(&self, f: usize) -> bool {
+        self.present[f]
+    }
+    /// Field value; `undefined` when absent (matching the per-field readers).
+    #[inline]
+    pub(crate) fn read(&self, f: usize) -> crate::value::JSValue {
+        self.vals[f]
+    }
+}
+
+#[inline]
+fn desc_field_index(b: &[u8]) -> Option<usize> {
+    match b {
+        b"value" => Some(DESC_VALUE),
+        b"get" => Some(DESC_GET),
+        b"set" => Some(DESC_SET),
+        b"writable" => Some(DESC_WRITABLE),
+        b"enumerable" => Some(DESC_ENUMERABLE),
+        b"configurable" => Some(DESC_CONFIGURABLE),
+        _ => None,
+    }
+}
+
+/// Does `Object.prototype` carry any of the 6 descriptor field names (own key
+/// or any descriptor/accessor installed on it)? Pollution like
+/// `Object.prototype.enumerable = true` is spec-visible through
+/// `ToPropertyDescriptor`'s inherited-field reads, so a polluted prototype
+/// forces the general path.
+unsafe fn object_prototype_has_desc_field() -> bool {
+    let op = crate::object::builtin_prototype_value("Object");
+    let ptr = extract_obj_ptr(op);
+    if ptr.is_null() {
+        return false;
+    }
+    // NOTE: builtin init legitimately installs (non-field-named) descriptors
+    // on Object.prototype, so the per-object flag is no signal here. Every own
+    // install — data write, defineProperty accessor, builtin getter — mirrors
+    // its key into keys_array, so scanning it for the 6 names is sufficient.
+    let keys = (*(ptr as *const ObjectHeader)).keys_array;
+    match crate::value::addr_class::try_read_gc_header(keys as usize) {
+        Some(h) if h.obj_type == crate::gc::GC_TYPE_ARRAY => {}
+        Some(_) => return true, // unexpected shape — be conservative
+        None => return false,   // no keys array — nothing own
+    }
+    let key_count = crate::array::js_array_length(keys) as usize;
+    let (slots, slot_len) = super::super::keys_array_dense_slots(keys);
+    let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    for i in 0..key_count.min(slot_len) {
+        let stored = crate::value::JSValue::from_bits((*slots.add(i)).to_bits());
+        if let Some(b) = crate::string::js_string_key_bytes(stored, &mut sso) {
+            if desc_field_index(b).is_some() {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Single-pass decode of `descriptor_value`'s 6 `ToPropertyDescriptor` fields.
+/// `Some(view)` is exactly equivalent to running `desc_has_field` /
+/// `desc_read_field` per field; `None` means the caller must use those.
+pub(crate) unsafe fn try_decode_descriptor(descriptor_value: f64) -> Option<DescView> {
+    let jv = crate::value::JSValue::from_bits(descriptor_value.to_bits());
+    if !jv.is_pointer() {
+        return None;
+    }
+    let addr = jv.as_pointer::<u8>() as usize;
+    match crate::value::addr_class::try_read_gc_header(addr) {
+        Some(h) if h.obj_type == crate::gc::GC_TYPE_OBJECT => {}
+        _ => return None,
+    }
+    // RegExp cells are OBJECT-typed exotics; class instances can carry
+    // prototype getters named like a field; accessor-backed own fields
+    // (`get value() {…}` in the literal) fire on [[Get]]; a custom
+    // [[Prototype]] contributes inherited fields. All → general path.
+    if super::super::exotic_expando::exotic_expando_kind(addr).is_some() {
+        return None;
+    }
+    let obj = addr as *const ObjectHeader;
+    // A nonzero class_id is usually just a LITERAL SHAPE id (every object
+    // literal gets one) — only a real class with a prototype surface (vtable
+    // methods/getters, `C.prototype.x = …` assignments, or a parent chain)
+    // could contribute inherited/accessor-backed descriptor fields. Literal
+    // shapes have none of those registries populated, so three cheap misses
+    // admit them; any registered surface falls back to the general path.
+    let class_id = (*obj).class_id;
+    if class_id != 0 {
+        if super::super::class_registry::get_parent_class_id(class_id).is_some() {
+            return None;
+        }
+        if super::super::class_registry::CLASS_VTABLE_REGISTRY
+            .read()
+            .ok()
+            .and_then(|g| g.as_ref().map(|m| m.contains_key(&class_id)))
+            .unwrap_or(false)
+        {
+            return None;
+        }
+        if super::super::class_registry::CLASS_PROTOTYPE_METHODS
+            .read()
+            .ok()
+            .and_then(|g| g.as_ref().map(|m| m.contains_key(&class_id)))
+            .unwrap_or(false)
+        {
+            return None;
+        }
+    }
+    if crate::object::descriptor_state::object_has_descriptors(addr) {
+        return None;
+    }
+    if super::super::prototype_chain::object_static_prototype(addr).is_some() {
+        return None;
+    }
+
+    const UNDEF: u64 = crate::value::TAG_UNDEFINED;
+    let mut view = DescView {
+        present: [false; 6],
+        vals: [crate::value::JSValue::from_bits(UNDEF); 6],
+    };
+    let keys = (*obj).keys_array;
+    if !keys.is_null() {
+        match crate::value::addr_class::try_read_gc_header(keys as usize) {
+            Some(h) if h.obj_type == crate::gc::GC_TYPE_ARRAY => {}
+            _ => return None, // corrupted keys slot — let the guarded path cope
+        }
+        let key_count = crate::array::js_array_length(keys) as usize;
+        let (slots, slot_len) = super::super::keys_array_dense_slots(keys);
+        let mut sso = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+        for i in 0..key_count.min(slot_len) {
+            let stored = crate::value::JSValue::from_bits((*slots.add(i)).to_bits());
+            if let Some(b) = crate::string::js_string_key_bytes(stored, &mut sso) {
+                if let Some(fi) = desc_field_index(b) {
+                    if !view.present[fi] {
+                        view.present[fi] = true;
+                        view.vals[fi] = js_object_get_field(obj, i as u32);
+                    }
+                }
+            }
+        }
+    }
+    // Absent fields may still be inherited through the (default) prototype.
+    if !view.present.iter().all(|&p| p) && object_prototype_has_desc_field() {
+        return None;
+    }
+    Some(view)
+}
+
+/// `validate_property_descriptor`, view form (see the f64 form below).
+pub(crate) unsafe fn validate_property_descriptor_view(view: &DescView) {
+    let has_get = view.has(DESC_GET);
+    let has_set = view.has(DESC_SET);
+    if (has_get || has_set) && (view.has(DESC_VALUE) || view.has(DESC_WRITABLE)) {
+        throw_object_type_error(
+            b"Invalid property descriptor. Cannot both specify accessors and a value or writable attribute, #<Object>",
+        );
+    }
+    if has_get {
+        let g = view.read(DESC_GET);
+        if !g.is_undefined() && !value_is_callable(f64::from_bits(g.bits())) {
+            let s = describe_value_for_type_error(f64::from_bits(g.bits()));
+            throw_object_type_error_with_suffix("Getter must be a function: ", &s);
+        }
+    }
+    if has_set {
+        let s_field = view.read(DESC_SET);
+        if !s_field.is_undefined() && !value_is_callable(f64::from_bits(s_field.bits())) {
+            let s = describe_value_for_type_error(f64::from_bits(s_field.bits()));
+            throw_object_type_error_with_suffix("Setter must be a function: ", &s);
+        }
+    }
+}
+
 pub(crate) unsafe fn desc_has_field(descriptor_value: f64, name: &[u8]) -> bool {
     // A function object used as a descriptor (`Object.defineProperty(o, k,
     // funObj)`, test262 15.2.3.6-3-139-1 …) is a closure, not an
@@ -296,6 +493,7 @@ pub(crate) unsafe fn enforce_define_property_invariants(
     key: *const crate::StringHeader,
     key_name: &str,
     descriptor_value: f64,
+    desc_view: Option<&DescView>,
 ) {
     if obj.is_null() || (obj as usize) <= 0x10000 {
         return;
@@ -336,7 +534,14 @@ pub(crate) unsafe fn enforce_define_property_invariants(
     } else {
         f64::from_bits(crate::value::TAG_UNDEFINED)
     };
-    validate_nonconfigurable_redefine(key_name, attrs, cur_accessor, cur_value, descriptor_value);
+    validate_nonconfigurable_redefine(
+        key_name,
+        attrs,
+        cur_accessor,
+        cur_value,
+        descriptor_value,
+        desc_view,
+    );
 }
 
 /// The non-configurable branch of `ValidateAndApplyPropertyDescriptor`, factored
@@ -352,19 +557,40 @@ pub(crate) unsafe fn validate_nonconfigurable_redefine(
     cur_accessor: Option<AccessorDescriptor>,
     cur_value: f64,
     descriptor_value: f64,
+    desc_view: Option<&DescView>,
 ) {
     const TAG_TRUE: u64 = 0x7FFC_0000_0000_0004;
     let desc_ptr = extract_obj_ptr(descriptor_value);
-    if desc_ptr.is_null() {
+    if desc_ptr.is_null() && desc_view.is_none() {
         return;
     }
     let reject = || throw_object_type_error_with_suffix("Cannot redefine property: ", key_name);
 
+    let view_index = |name: &[u8]| -> usize {
+        match name {
+            b"value" => DESC_VALUE,
+            b"get" => DESC_GET,
+            b"set" => DESC_SET,
+            b"writable" => DESC_WRITABLE,
+            b"enumerable" => DESC_ENUMERABLE,
+            _ => DESC_CONFIGURABLE,
+        }
+    };
     // `ToPropertyDescriptor` field presence is HasProperty (own OR inherited).
-    let has_field = |name: &[u8]| -> bool { desc_has_field(descriptor_value, name) };
+    let has_field = |name: &[u8]| -> bool {
+        match desc_view {
+            Some(v) => v.has(view_index(name)),
+            None => desc_has_field(descriptor_value, name),
+        }
+    };
     let read = |name: &[u8]| -> crate::value::JSValue {
-        let k = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-        js_object_get_field_by_name(desc_ptr as *const ObjectHeader, k)
+        match desc_view {
+            Some(v) => v.read(view_index(name)),
+            None => {
+                let k = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
+                js_object_get_field_by_name(desc_ptr as *const ObjectHeader, k)
+            }
+        }
     };
     let read_bool = |name: &[u8]| -> Option<bool> {
         if !has_field(name) {

--- a/tests/test_descriptor_decode_parity.sh
+++ b/tests/test_descriptor_decode_parity.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Regression for the single-pass descriptor decode (#6748 follow-up): the
+# fast decode must be indistinguishable from the per-field spec path. Pins
+# the exact conditions under which it must FALL BACK: descriptors with
+# inherited fields (custom [[Prototype]]), accessor-backed fields (literal
+# getters), class instances as descriptors, and Object.prototype pollution.
+# Differential: perry output must byte-match node.
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PERRY="$SCRIPT_DIR/../target/release/perry"
+[ ! -f "$PERRY" ] && PERRY="$SCRIPT_DIR/../target/debug/perry"
+[ ! -f "$PERRY" ] && { echo "SKIP: perry binary not found"; exit 0; }
+command -v node >/dev/null 2>&1 || { echo "SKIP: node not found"; exit 0; }
+TMPDIR=$(mktemp -d); trap "rm -rf $TMPDIR" EXIT
+COMPILE_ENV=()
+{ [ -f "$SCRIPT_DIR/../target/debug/libperry_runtime.a" ] || [ -f "$SCRIPT_DIR/../target/release/libperry_runtime.a" ]; } && COMPILE_ENV=(env PERRY_NO_AUTO_OPTIMIZE=1)
+cat > "$TMPDIR/main.ts" << 'EOF'
+const show = (o: any, k: string) => {
+  const d = Object.getOwnPropertyDescriptor(o, k)!;
+  console.log(k, d.value, typeof d.get, d.writable, d.enumerable, d.configurable);
+};
+// 1. plain literal descriptors (the fast-decoded shape)
+const a: any = {};
+Object.defineProperty(a, "p1", { value: 1 });
+Object.defineProperty(a, "p2", { value: 2, writable: true, enumerable: true, configurable: true });
+Object.defineProperty(a, "p3", { enumerable: true, get: () => 3 });
+show(a, "p1"); show(a, "p2"); show(a, "p3"); console.log("p3-read", a.p3);
+// 2. INHERITED descriptor fields (custom proto) must be honored
+const dproto = { value: 42, enumerable: true };
+const dchild = Object.create(dproto);
+Object.defineProperty(a, "inh", dchild);
+show(a, "inh");
+// 3. ACCESSOR-BACKED descriptor fields must fire
+let fired = 0;
+const dacc = { get value() { fired++; return 7; }, enumerable: true };
+Object.defineProperty(a, "acc", dacc);
+show(a, "acc"); console.log("getter-fired", fired >= 1);
+// 4. class INSTANCE as descriptor with prototype getter named `value`
+class DescLike { get value() { return 9; } }
+Object.defineProperty(a, "cls", new DescLike());
+show(a, "cls");
+// 5. Object.prototype pollution honored (then cleaned)
+(Object.prototype as any).enumerable = true;
+Object.defineProperty(a, "pol", { value: 5 });
+show(a, "pol");
+delete (Object.prototype as any).enumerable;
+Object.defineProperty(a, "unpol", { value: 6 });
+show(a, "unpol");
+// 6. attrs retention + accessor->data + data->accessor transitions
+const b: any = {};
+Object.defineProperty(b, "t", { value: 1, writable: true, enumerable: true, configurable: true });
+Object.defineProperty(b, "t", { get: () => 2, configurable: true });
+show(b, "t"); console.log("t-read", b.t);
+Object.defineProperty(b, "t", { value: 3 });
+show(b, "t");
+// 7. freeze/seal still enforced through the decode
+const c: any = { x: 1 }; Object.freeze(c);
+let threw = false; try { Object.defineProperty(c, "x", { value: 2 }); } catch { threw = true; }
+console.log("frozen-throws", threw, c.x);
+EOF
+cd "$TMPDIR"
+"${COMPILE_ENV[@]}" "$PERRY" compile main.ts --output test_bin --no-cache >/dev/null 2>&1
+P=$(./test_bin 2>&1); N=$(node main.ts 2>&1)
+if [ "$P" = "$N" ]; then echo "PASS"; exit 0; fi
+echo "FAIL"; echo "--- node ---"; echo "$N"; echo "--- perry ---"; echo "$P"; diff <(echo "$N") <(echo "$P") || true; exit 1

--- a/tests/test_wide_object_define_in_linear.sh
+++ b/tests/test_wide_object_define_in_linear.sh
@@ -92,6 +92,24 @@ console.log("nonextensible-new-throws", threw);
 // 6. `in` answers across the wide object.
 console.log("in-checks", "k3" in t, "longKey_2" in t, "absent_xyz" in t, "__esModule" in t);
 
+// 6b. `in` fast-path receiver-kind coverage: the ordinary-object fast path
+//     must not change answers for any receiver kind (RegExp cells are
+//     OBJECT-typed and must keep routing through the exotic arm).
+{
+  const rk: any[] = [];
+  const oo = { a: 1 }; rk.push("a" in oo, "b" in oo, "toString" in oo);
+  class K { x = 1; m() {} } const ki = new K(); rk.push("x" in ki, "m" in ki, "y" in ki);
+  const ch = Object.create({ pp: 7 }); rk.push("pp" in ch, "zz" in ch);
+  const ar = [1, 2]; rk.push(0 in ar, 2 in ar, "length" in ar, "map" in ar);
+  const dt = new Date(); rk.push("getTime" in dt, "nope" in dt);
+  const re = /x/; rk.push("lastIndex" in re, "exec" in re);
+  const mp = new Map([["k", 1]]); rk.push("size" in mp, "k" in mp);
+  const fr = Object.freeze({ fz: 1 }); rk.push("fz" in fr);
+  const nl = Object.create(null); nl.nk = 1; rk.push("nk" in nl, "toString" in nl);
+  rk.push("307" in { 307: true }, 307 in { 307: true });
+  console.log("receiver-kinds", rk.join(","));
+}
+
 // 7. Scaling sanity: 2400 getter defines (was ~527ms quadratic; linear is ~100ms).
 const big: any = {};
 const t0 = Date.now();


### PR DESCRIPTION
Continues #6748 (follow-up to #6749). Two commits:

## Commit 1 — the `in`-operator fast path (re-landed)
This commit was pushed to the #6749 branch moments after that PR was merged, so it never landed — cherry-picked here unchanged. One `try_read_gc_header` classifies the receiver and skips the ~10-arm TLS/registry gauntlet for plain objects (RegExp — the one OBJECT-typed exotic — keeps routing to the exotic arm; fetch-subclass forwarding preserved behind a process-global "ever stashed" flag; `#private` hiding and native-module virtual keys kept). **`in` hit: 259ms → 0.3ms @2400 — node parity** (node 0.4ms); miss → 4.0ms (node 0.6). A/B against the parent verified the two remaining `in` divergences vs node are pre-existing gaps.

## Commit 2 — single-pass descriptor decode + define receiver fast-dispatch
`ToPropertyDescriptor` field probes (`desc_has_field`/`desc_read_field`) each ran a full spec `HasProperty`/`[[Get]]` — key-string alloc + the whole gauntlet, with **absent** fields walking the prototype chain — ~10 per define. Measurably inverted: a 1-field descriptor cost *more* than a 4-field one.

New `try_decode_descriptor` reads all 6 fields in one walk of the descriptor's own keys, firing only when nothing spec-visible can differ (plain object, not exotic, no accessors/attrs on it, default prototype, no prototype surface behind its shape id — a literal's class_id admits via three registry misses — and an unpolluted `Object.prototype`). Everything else keeps the per-field spec path. Plus: the define entry's own probe gauntlet (proxy/TA/exotic/closure/array arms) is now gated behind one receiver classification, mirroring the `in` fast path.

## Results (2400-op micros; node in parens)
| benchmark | #6749 merge | now | node |
|---|---|---|---|
| `in` hit / miss | 103 / 106ms | **0.3 / 4.0ms** | 0.4 / 0.6ms |
| fresh getter defines | 64ms | **12.6ms** | 3.7ms |
| same-key redefine | 49ms | **5.8ms** | 0.4ms |
| 1-field value defines | 89ms | **4.2ms** (inversion gone) | 3.4ms |
| 4-field value defines | 50ms | **5.9ms** | 3.0ms |
| **`jiti/babel.cjs` init (pi's biggest startup module)** | 334ms | **~225ms** | 44ms |

Session arc for the babel module: **688ms → 225ms** (3×), `in` from 111µs/op to parity.

## Validation
- perry-runtime full suite **1439/0** after each commit; focused define/descriptor/freeze/seal 40/0.
- `tests/test_wide_object_define_in_linear.sh` PASS (incl. the `in` receiver-kind section).
- New differential `tests/test_descriptor_decode_parity.sh` — byte-matches node on every decode fallback condition: inherited descriptor fields (custom prototype), accessor-backed fields (getter observably fires), class-instance descriptors with a prototype `value` getter, **live `Object.prototype` pollution** (honored, then clean again after `delete`), attribute retention across accessor↔data transitions, frozen-target rejection.
- Address-classification audit clean; fmt clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved property checks for ordinary objects, making the `in` operator faster in common cases.
  * Streamlined property descriptor processing for more efficient `Object.defineProperty` operations.

* **Bug Fixes**
  * Preserved correct behavior for complex descriptors, inherited properties, accessors, frozen objects, arrays, and specialized built-ins.
  * Improved handling of fetch-based subclass properties.

* **Tests**
  * Added regression coverage for descriptor decoding and `in` operator behavior across diverse object types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->