### PR TITLE
perf(runtime): #6759 Phase A follow-up — reuse the captured state() across hot get/set gates

### DIFF
--- a/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
+++ b/crates/perry-runtime/src/object/field_get_set/get_field_by_name_tail.rs
@@ -1568,7 +1568,7 @@ pub(crate) fn get_field_by_name_object_tail(
                 // thread-local gate keeps this off the hot path in the common case;
                 // the per-object flag gate avoids invoking a stale getter left by a
                 // freed object whose address this fresh object reused.
-                if crate::state::state().descriptors.accessors_in_use.get()
+                if st.descriptors.accessors_in_use.get()
                     && super::super::object_has_descriptors(obj as usize)
                 {
                     if let Ok(name) = std::str::from_utf8(key_bytes) {
@@ -1597,7 +1597,7 @@ pub(crate) fn get_field_by_name_object_tail(
         // linear scan below (the index is an accelerator, not authoritative).
         if key_count >= WIDE_KEY_INDEX_MIN_KEYS {
             if let Some(i) = wide_key_index_lookup(keys_id, key_bytes, key, keys, key_count) {
-                if crate::state::state().descriptors.accessors_in_use.get()
+                if st.descriptors.accessors_in_use.get()
                     && super::super::object_has_descriptors(obj as usize)
                 {
                     if let Ok(name) = std::str::from_utf8(key_bytes) {
@@ -1640,7 +1640,7 @@ pub(crate) fn get_field_by_name_object_tail(
                     wide_key_index_note_hit(keys_id, key_bytes, i as u32);
                 }
                 // Accessor short-circuit (see fast path above).
-                if crate::state::state().descriptors.accessors_in_use.get()
+                if st.descriptors.accessors_in_use.get()
                     && super::super::object_has_descriptors(obj as usize)
                 {
                     if let Ok(name) = std::str::from_utf8(key_bytes) {

--- a/crates/perry-runtime/src/object/field_set_by_name.rs
+++ b/crates/perry-runtime/src/object/field_set_by_name.rs
@@ -299,6 +299,9 @@ pub extern "C" fn js_object_set_field_by_name(
     key: *const crate::StringHeader,
     value: f64,
 ) {
+    // #6759 A: one state fetch for the whole write path — the descriptor
+    // gates below all reuse it.
+    let st = crate::state::state();
     // #5135: the receiver may be a Proxy id arriving with its NaN-box tag
     // already masked off (the `obj.prop++` / `PropertyUpdate` codegen path
     // hands us the bare pointer band, not the full POINTER_TAG value). A Proxy
@@ -907,7 +910,7 @@ pub extern "C" fn js_object_set_field_by_name(
             // fresh array reusing a freed address (its `_reserved` zeroed at
             // allocation) skips this lookup and can't fire a previous tenant's
             // stale accessor.
-            if crate::state::state().descriptors.accessors_in_use.get()
+            if st.descriptors.accessors_in_use.get()
                 && (*gc_header)._reserved & crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS != 0
             {
                 if let Some(acc) = get_accessor_descriptor(obj as usize, name) {
@@ -1351,11 +1354,8 @@ pub extern "C" fn js_object_set_field_by_name(
         // honored), so the descriptor key string can never be consulted: skip
         // the per-store String allocation entirely.
         let needs_descriptor_key = !plan_fast
-            && (crate::state::state().descriptors.accessors_in_use.get()
-                || crate::state::state()
-                    .descriptors
-                    .property_attrs_in_use
-                    .get());
+            && (st.descriptors.accessors_in_use.get()
+                || st.descriptors.property_attrs_in_use.get());
         let incoming_key_str: Option<String> = if needs_descriptor_key && !key.is_null() {
             let name_ptr = (key as *const u8).add(std::mem::size_of::<crate::StringHeader>());
             let name_len = (*key).byte_len as usize;
@@ -1383,7 +1383,7 @@ pub extern "C" fn js_object_set_field_by_name(
         // app-page-turbo runtime's `exports.Fragment = …`). A fresh allocation
         // has the flag clear, so it skips the stale lookup entirely.
         if !plan_fast
-            && crate::state::state().descriptors.accessors_in_use.get()
+            && st.descriptors.accessors_in_use.get()
             && super::object_has_descriptors(obj as usize)
         {
             if let Some(ref k) = incoming_key_str {
@@ -1589,10 +1589,7 @@ pub extern "C" fn js_object_set_field_by_name(
                 // read only property" on a plain `{}` (Next.js app-page-turbo
                 // runtime's `exports.Fragment = …`). A fresh allocation has the
                 // flag clear, so it skips the lookup entirely.
-                if crate::state::state()
-                    .descriptors
-                    .property_attrs_in_use
-                    .get()
+                if st.descriptors.property_attrs_in_use.get()
                     && super::object_has_descriptors(obj as usize)
                 {
                     if let Some(ref k) = incoming_key_str {


### PR DESCRIPTION
Follow-up to #6795 (merged mid-review): applies CodeRabbit's remaining finding — the hot `js_object_set_field_by_name` path captures `state()` once at entry and the `get_field_by_name` tail reuses its already-captured `st` for the accessor/attrs gate checks, instead of re-fetching per gate. Pure mechanical hoist, no behavior change; `cargo test -p perry-runtime --lib -- --test-threads=1` 1439/1439 green. CodeRabbit's other finding (version/CHANGELOG metadata) is superseded by the `changelog.d/` fragment convention, which #6795 already satisfied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal runtime efficiency during object field access and updates.
  * Preserved existing field lookup, accessor handling, and property-setting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->