### PR TITLE
test(runtime): clear C5a per-key vetting sets in the inline-guard test reset

### DIFF
--- a/changelog.d/6805-test-reset-c5a-sets.md
+++ b/changelog.d/6805-test-reset-c5a-sets.md
@@ -1,0 +1,1 @@
+test(runtime): the class-field inline-guard test reset also clears the C5a per-key vetting hash sets, removing cross-test order dependence for reused key names (CodeRabbit follow-up on #6802).

--- a/crates/perry-runtime/src/object/descriptor_state.rs
+++ b/crates/perry-runtime/src/object/descriptor_state.rs
@@ -147,6 +147,16 @@ pub(crate) fn class_field_inline_guard_enabled() -> bool {
 #[cfg(test)]
 pub(crate) fn test_reset_class_field_inline_guard() {
     PERRY_CLASS_FIELD_INLINE_GUARD_DISABLED.store(0, Ordering::Relaxed);
+    // Also clear the C5a per-key vetting sets (production-monotonic, so
+    // without this a key name reused across tests in one process would
+    // inherit an earlier test's declared-field / installed-key state and
+    // make the disable decision order-dependent (CodeRabbit on #6802).
+    if let Ok(mut guard) = DECLARED_FIELD_NAME_HASHES.write() {
+        guard.take();
+    }
+    if let Ok(mut guard) = PROTO_DESCRIPTOR_KEY_HASHES.write() {
+        guard.take();
+    }
 }
 
 /// #5654: flip the process-wide inline gate only when the descriptor target can


### PR DESCRIPTION
Follow-up to CodeRabbit's post-merge review finding on #6802: `test_reset_class_field_inline_guard()` reset only the sticky disable flag, leaving `DECLARED_FIELD_NAME_HASHES` / `PROTO_DESCRIPTOR_KEY_HASHES` accumulated across tests in one process — a key name reused by a later test would inherit earlier state and make the disable decision order-dependent. The reset now clears both sets (`cfg(test)`-only change; the sets stay monotonic in production by design).

Both `c5a_tests` green with the fix. Includes the changelog.d fragment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test isolation by fully resetting cached state between class-field validation tests.
  - Prevented test results from depending on execution order or reused field and descriptor names.
  - Added a changelog entry documenting the test reliability improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->