### PR TITLE
fix: harden dynamic imports and accelerate numeric/JSON fast paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6125,6 +6125,7 @@ dependencies = [
  "regex",
  "resolv-conf",
  "ryu",
+ "serde",
  "serde_json",
  "socket2",
  "taffy",

--- a/benchmarks/compiler_output/workloads.toml
+++ b/benchmarks/compiler_output/workloads.toml
@@ -863,14 +863,13 @@ regex_none = [
 detail = "fast clone loads raw f64 array slots without per-access guards or numeric coercion"
 
 [[workloads.packed_f64_loop_versioning.ir_checks]]
-name = "packed_f64_store_loop_not_cloned"
-contains = "call i32 @js_typed_feedback_numeric_array_index_set_guard"
-regex_none = [
-  '''packed_f64_loop_store\.fast''',
-  '''packed_f64_loop_store\.fallback''',
-  '''array\[packed_f64_loop\]=''',
+name = "packed_f64_store_loop_guarded_clone"
+section = "llvm_before"
+regex_all = [
+  '''packed_f64_loop_store\.fast\.\d+:\n(?:(?!\n[^\s].*:)[\s\S])*?\bstore double\b''',
+  '''packed_f64_loop_store\.fallback\.\d+:\n(?:(?!\n[^\s].*:)[\s\S])*?\bbr label %packed_f64\.loop\.slow''',
 ]
-detail = "store-bearing loops stay out of the packed-f64 clone; guarded numeric store fallback handles invalidation"
+detail = "eligible store loops contain a raw-f64 fast store and a side exit to the ordinary guarded fallback"
 
 [[workloads.packed_f64_loop_versioning.stdout_checks]]
 name = "packed_f64_loop_versioning_checksum"
@@ -895,9 +894,9 @@ min = { load_f64 = 1 }
 detail = "fast clone contains raw double loads for read-only packed loops"
 
 [[workloads.packed_f64_loop_versioning.named_regions.checks]]
-name = "packed_f64_fast_loop_no_fp_int_conversions"
-max = { fptosi = 0, sitofp = 0, ptrtoint = 0 }
-detail = "fast clone does not perform per-access numeric conversions"
+name = "packed_f64_fast_loop_bounded_fp_int_conversions"
+max = { fptosi = 0, sitofp = 3, ptrtoint = 0 }
+detail = "fast clones avoid lossy conversions while permitting the source-required integer-index-to-number conversion in each materialized copy"
 
 [workloads.packed_f64_loop_versioning.native_rep_checks]
 allow_materialization_reasons = ["runtime_api", "return_abi"]

--- a/benchmarks/results/public-node-bun-v1.json
+++ b/benchmarks/results/public-node-bun-v1.json
@@ -5,7 +5,7 @@
   "perry_version": "perry 0.5.1258",
   "generated_at": "2026-07-13T14:10:04Z",
   "freshness": {
-    "source_fingerprint": "4ff76a2ff69d1cde787770e9ae81f615be56c74e9a1bcb208890810fd079799d",
+    "source_fingerprint": "9713a2e1131dbc407e2f6e7b056b9e2e1092ed45be7ecd5bf88b3d5a9910405f",
     "harness_fingerprint": "437f64a8020aebd4d677405b4e5c8d915b2c76b10977df397ed324eef7b3ae23"
   },
   "host": {

--- a/changelog.d/6810-aot-runtime-fast-paths.md
+++ b/changelog.d/6810-aot-runtime-fast-paths.md
@@ -1,0 +1,1 @@
+fix(codegen/runtime): validate single-candidate dynamic imports after loader hooks, harden GC address classification, add transactional mixed-array numeric range updates, admit safely guarded packed numeric store loops, and avoid allocating a duplicate JSON tree during syntax validation.

--- a/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
+++ b/crates/perry-codegen/src/expr/dyn_extern_i18n.rs
@@ -544,101 +544,14 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                 ));
             }
 
-            // Single-target fast path. Skip the runtime string compare
-            // — the static resolver already proved this is the only
-            // possible target.
-            if paths.len() == 1 {
-                // Evaluate the arg for side effects (most are pure but
-                // a template literal with computed parts can have e.g.
-                // function calls) and let registered module loader hooks
-                // observe/delegate the import. The statically known target
-                // still determines the namespace in Perry's compile-time graph.
-                let path_val = lower_expr(ctx, arg)?;
-                let _ = ctx.block().call(
-                    DOUBLE,
-                    "js_module_dynamic_import_apply_hooks",
-                    &[(DOUBLE, &path_val)],
-                );
-                let path = &paths[0];
-                let target_prefix = ctx.dynamic_import_path_to_prefix.get(path).cloned();
-                // #1671: a dynamic import of a known node-submodule
-                // (`await import('hono/jsx/server')`) carries the sentinel
-                // prefix `__node_submod__<key>` instead of a compiled-module
-                // prefix. Build its namespace via `js_node_submodule_namespace`
-                // and resolve the promise with it (mirrors the static
-                // namespace-import path).
-                if let Some(prefix) = &target_prefix {
-                    if let Some(key) = prefix.strip_prefix("__node_submod__") {
-                        let key = key.to_string();
-                        let submod_label = emit_string_literal_global(ctx, &key);
-                        let submod_len = key.len();
-                        let install_sym = crate::nm_install::nm_submod_install_symbol(&key);
-                        let blk = ctx.block();
-                        if let Some(s) = install_sym {
-                            blk.call_void(s, &[]);
-                        }
-                        let ns_val = blk.call(
-                            DOUBLE,
-                            "js_node_submodule_namespace",
-                            &[(PTR, &submod_label), (I32, &submod_len.to_string())],
-                        );
-                        let promise = blk.call(I64, "js_promise_resolved", &[(DOUBLE, &ns_val)]);
-                        return Ok(nanbox_pointer_inline(blk, &promise));
-                    }
-                    // #1673: a dynamic import of a general native builtin
-                    // (`await import('node:crypto')`) carries the sentinel
-                    // prefix `__native_mod__<name>`. Build its namespace via
-                    // `js_create_native_module_namespace` — the same
-                    // NATIVE_MODULE_CLASS_ID object `require('node:crypto')`
-                    // produces, whose member access dispatches natively at
-                    // runtime — and resolve the promise with it.
-                    if let Some(name) = prefix.strip_prefix("__native_mod__") {
-                        let name = name.to_string();
-                        let mod_label = emit_string_literal_global(ctx, &name);
-                        let mod_len = name.len();
-                        let blk = ctx.block();
-                        if let Some(s) = crate::nm_install::nm_install_symbol(&name) {
-                            blk.call_void(s, &[]);
-                        }
-                        let ns_val = blk.call(
-                            DOUBLE,
-                            "js_create_native_module_namespace",
-                            &[(PTR, &mod_label), (I64, &mod_len.to_string())],
-                        );
-                        let promise = blk.call(I64, "js_promise_resolved", &[(DOUBLE, &ns_val)]);
-                        return Ok(nanbox_pointer_inline(blk, &promise));
-                    }
-                }
-                let blk = ctx.block();
-                let ns_val = match target_prefix {
-                    Some(prefix) => {
-                        // Issue #753: trigger the target's init before
-                        // loading its namespace. For Eager targets the
-                        // guard short-circuits; for Deferred targets
-                        // this is the only invocation that populates
-                        // `@__perry_ns_<prefix>`.
-                        blk.call_void(&format!("{}__init", prefix), &[]);
-                        blk.load(DOUBLE, &format!("@__perry_ns_{}", prefix))
-                    }
-                    None => {
-                        // Driver didn't resolve this path to a target module —
-                        // route through the runtime fallback (#6660: builtin
-                        // specifiers resolve like Node, everything else rejects
-                        // with `ERR_MODULE_NOT_FOUND` instead of the old
-                        // literal-`undefined` rejection).
-                        return Ok(blk.call(
-                            DOUBLE,
-                            "js_module_dynamic_import_fallback",
-                            &[(DOUBLE, &path_val)],
-                        ));
-                    }
-                };
-                let promise = blk.call(I64, "js_promise_resolved", &[(DOUBLE, &ns_val)]);
-                return Ok(nanbox_pointer_inline(blk, &promise));
-            }
-
-            // Multi-target: evaluate the runtime path string, then
-            // emit a chain of `js_string_equals` compares. Each
+            // Evaluate the runtime path string, apply registered loader hooks,
+            // then emit a chain of `js_string_equals` compares. Do this even
+            // for a single statically-resolved candidate: TypeScript types are
+            // erased at runtime and a hook may rewrite the specifier, so the
+            // candidate count does not prove that the runtime value matches.
+            // Skipping the compare here used to silently initialize the sole
+            // candidate for `load("./other.ts" as any)` and for hook redirects.
+            // Each
             // successful compare resolves to its corresponding
             // namespace global. The final fallback emits a rejected
             // promise.

--- a/crates/perry-codegen/src/runtime_decls/arrays.rs
+++ b/crates/perry-codegen/src/runtime_decls/arrays.rs
@@ -56,6 +56,16 @@ pub fn declare_phase_b_arrays(module: &mut LlModule) {
     module.declare_function("js_array_fill_f64_iota_extend", I64, &[I64, I32]);
     module.declare_function("js_array_fill_f64_const_len_extend", I64, &[I64, DOUBLE]);
     module.declare_function("js_array_fill_f64_iota_len_extend", I64, &[I64]);
+    module.declare_function(
+        "js_array_numeric_range_add",
+        I64,
+        &[DOUBLE, DOUBLE, DOUBLE, DOUBLE],
+    );
+    module.declare_function(
+        "js_array_numeric_range_add_len",
+        I64,
+        &[DOUBLE, DOUBLE, DOUBLE],
+    );
     module.declare_function("js_array_set_string_key", I64, &[I64, I64, DOUBLE]);
     module.declare_function("js_array_set_index_or_string", I64, &[I64, DOUBLE, DOUBLE]);
     module.declare_function("js_array_mark_arguments_object", I64, &[I64]);

--- a/crates/perry-codegen/src/stmt/loops.rs
+++ b/crates/perry-codegen/src/stmt/loops.rs
@@ -41,6 +41,34 @@ struct NumericRangeAddLoop {
     delta: f64,
 }
 
+fn match_indexed_store_shape(
+    store: &perry_hir::Expr,
+) -> Option<(&perry_hir::Expr, &perry_hir::Expr, &perry_hir::Expr)> {
+    use perry_hir::Expr;
+
+    match store {
+        Expr::IndexSet {
+            object,
+            index,
+            value,
+        } => Some((object.as_ref(), index.as_ref(), value.as_ref())),
+        Expr::PutValueSet {
+            target,
+            key,
+            value,
+            receiver,
+            ..
+        } if matches!(
+            (target.as_ref(), receiver.as_ref()),
+            (Expr::LocalGet(a), Expr::LocalGet(b)) if a == b
+        ) =>
+        {
+            Some((target.as_ref(), key.as_ref(), value.as_ref()))
+        }
+        _ => None,
+    }
+}
+
 #[derive(Clone, Copy)]
 struct LengthHoist {
     arr_id: u32,
@@ -351,27 +379,7 @@ fn match_numeric_range_add_loop(
     let [Stmt::Expr(store)] = body else {
         return None;
     };
-    let (object, index, value) = match store {
-        Expr::IndexSet {
-            object,
-            index,
-            value,
-        } => (object.as_ref(), index.as_ref(), value.as_ref()),
-        Expr::PutValueSet {
-            target,
-            key,
-            value,
-            receiver,
-            ..
-        } if matches!(
-            (target.as_ref(), receiver.as_ref()),
-            (Expr::LocalGet(a), Expr::LocalGet(b)) if a == b
-        ) =>
-        {
-            (target.as_ref(), key.as_ref(), value.as_ref())
-        }
-        _ => return None,
-    };
+    let (object, index, value) = match_indexed_store_shape(store)?;
     let array_id = match object {
         Expr::LocalGet(id) => *id,
         _ => return None,
@@ -2726,27 +2734,7 @@ fn supported_packed_numeric_loop_store_kind(
     let [Stmt::Expr(store)] = body else {
         return None;
     };
-    let (object, index, value) = match store {
-        perry_hir::Expr::IndexSet {
-            object,
-            index,
-            value,
-        } => (object, index, value),
-        perry_hir::Expr::PutValueSet {
-            target,
-            key,
-            value,
-            receiver,
-            ..
-        } if matches!(
-            (target.as_ref(), receiver.as_ref()),
-            (perry_hir::Expr::LocalGet(a), perry_hir::Expr::LocalGet(b)) if a == b
-        ) =>
-        {
-            (target, key, value)
-        }
-        _ => return None,
-    };
+    let (object, index, value) = match_indexed_store_shape(store)?;
     if !is_packed_f64_loop_index(object, index, arr_id, counter_id) {
         return None;
     }

--- a/crates/perry-codegen/src/stmt/loops.rs
+++ b/crates/perry-codegen/src/stmt/loops.rs
@@ -28,6 +28,19 @@ struct NumericBulkFillLoop {
     value: NumericBulkFillValue,
 }
 
+#[derive(Clone)]
+enum NumericRangeAddBound {
+    Explicit(perry_hir::Expr),
+    ArrayLength,
+}
+
+struct NumericRangeAddLoop {
+    counter_id: u32,
+    array_id: u32,
+    bound: NumericRangeAddBound,
+    delta: f64,
+}
+
 #[derive(Clone, Copy)]
 struct LengthHoist {
     arr_id: u32,
@@ -285,6 +298,210 @@ fn lower_numeric_bulk_fill_loop(ctx: &mut FnCtx<'_>, matched: NumericBulkFillLoo
     if let Some(i32_slot) = ctx.i32_counter_slots.get(&matched.counter_id).cloned() {
         ctx.block().store(I32, &bound_i32, &i32_slot);
     }
+    Ok(true)
+}
+
+/// Match the mixed-layout numeric-window shape
+/// `for (let i = start; i < end; i++) arr[i] = arr[i] + constant`.
+///
+/// Number-typed arrays already use the raw-f64 versioned loop below. This
+/// matcher is for `any[]` / `unknown[]`, where a pointer or string elsewhere
+/// in the array clears the whole-array raw-layout bit even though the loop's
+/// window remains purely numeric. The runtime helper performs a transactional
+/// window validation before writing, so a wrong static hint simply falls back
+/// to the ordinary loop with no partial effects.
+fn match_numeric_range_add_loop(
+    ctx: &FnCtx<'_>,
+    init: Option<&Stmt>,
+    condition: Option<&perry_hir::Expr>,
+    update: Option<&perry_hir::Expr>,
+    body: &[Stmt],
+) -> Option<NumericRangeAddLoop> {
+    use perry_hir::{BinaryOp, CompareOp, Expr, UpdateOp};
+    if !ctx.pending_labels.is_empty() {
+        return None;
+    }
+    let counter_id = match init? {
+        Stmt::Let {
+            id, init: Some(_), ..
+        } => *id,
+        _ => return None,
+    };
+    if !ctx.locals.contains_key(&counter_id)
+        || ctx.boxed_vars.contains(&counter_id)
+        || !matches!(
+            update,
+            Some(Expr::Update {
+                id,
+                op: UpdateOp::Increment,
+                ..
+            }) if *id == counter_id
+        )
+    {
+        return None;
+    }
+    let bound_expr = match condition? {
+        Expr::Compare {
+            op: CompareOp::Lt,
+            left,
+            right,
+        } if matches!(left.as_ref(), Expr::LocalGet(id) if *id == counter_id) => right.as_ref(),
+        _ => return None,
+    };
+    let [Stmt::Expr(store)] = body else {
+        return None;
+    };
+    let (object, index, value) = match store {
+        Expr::IndexSet {
+            object,
+            index,
+            value,
+        } => (object.as_ref(), index.as_ref(), value.as_ref()),
+        Expr::PutValueSet {
+            target,
+            key,
+            value,
+            receiver,
+            ..
+        } if matches!(
+            (target.as_ref(), receiver.as_ref()),
+            (Expr::LocalGet(a), Expr::LocalGet(b)) if a == b
+        ) =>
+        {
+            (target.as_ref(), key.as_ref(), value.as_ref())
+        }
+        _ => return None,
+    };
+    let array_id = match object {
+        Expr::LocalGet(id) => *id,
+        _ => return None,
+    };
+    if !matches!(index, Expr::LocalGet(id) if *id == counter_id)
+        || !matches!(
+            local_array_element_type(ctx, array_id),
+            Some(perry_types::Type::Any | perry_types::Type::Unknown)
+        )
+        || !packed_loop_array_binding_storage_is_addressable(ctx, array_id)
+        || ctx.scalar_replaced_arrays.contains_key(&array_id)
+    {
+        return None;
+    }
+    let delta = match value {
+        Expr::Binary {
+            op: BinaryOp::Add,
+            left,
+            right,
+        } if matches!(
+            left.as_ref(),
+            Expr::IndexGet {
+                object,
+                index
+            } if matches!(object.as_ref(), Expr::LocalGet(id) if *id == array_id)
+                && matches!(index.as_ref(), Expr::LocalGet(id) if *id == counter_id)
+        ) =>
+        {
+            match right.as_ref() {
+                Expr::Integer(value) => *value as f64,
+                Expr::Number(value) if value.is_finite() => *value,
+                _ => return None,
+            }
+        }
+        _ => return None,
+    };
+    let bound = match bound_expr {
+        Expr::PropertyGet {
+            object, property, ..
+        } if property == "length"
+            && matches!(object.as_ref(), Expr::LocalGet(id) if *id == array_id) =>
+        {
+            NumericRangeAddBound::ArrayLength
+        }
+        Expr::Integer(_) | Expr::Number(_) => NumericRangeAddBound::Explicit(bound_expr.clone()),
+        Expr::LocalGet(bound_id)
+            if *bound_id != counter_id
+                && (ctx.locals.contains_key(bound_id)
+                    || ctx.module_globals.contains_key(bound_id))
+                && !(ctx.boxed_vars.contains(bound_id)
+                    && !ctx.module_globals.contains_key(bound_id))
+                && local_bound_is_loop_invariant(condition?, update, body, *bound_id) =>
+        {
+            NumericRangeAddBound::Explicit(bound_expr.clone())
+        }
+        _ => return None,
+    };
+    Some(NumericRangeAddLoop {
+        counter_id,
+        array_id,
+        bound,
+        delta,
+    })
+}
+
+fn lower_numeric_range_add_loop(
+    ctx: &mut FnCtx<'_>,
+    matched: NumericRangeAddLoop,
+    init: Option<&Stmt>,
+    condition: Option<&perry_hir::Expr>,
+    update: Option<&perry_hir::Expr>,
+    body: &[Stmt],
+) -> Result<bool> {
+    let arr_box = lower_expr(ctx, &perry_hir::Expr::LocalGet(matched.array_id))?;
+    let start_box = lower_expr(ctx, &perry_hir::Expr::LocalGet(matched.counter_id))?;
+    let delta = crate::nanbox::double_literal(matched.delta);
+    let result = match &matched.bound {
+        NumericRangeAddBound::Explicit(bound) => {
+            let end_box = lower_expr(ctx, bound)?;
+            ctx.block().call(
+                I64,
+                "js_array_numeric_range_add",
+                &[
+                    (DOUBLE, &arr_box),
+                    (DOUBLE, &start_box),
+                    (DOUBLE, &end_box),
+                    (DOUBLE, &delta),
+                ],
+            )
+        }
+        NumericRangeAddBound::ArrayLength => ctx.block().call(
+            I64,
+            "js_array_numeric_range_add_len",
+            &[(DOUBLE, &arr_box), (DOUBLE, &start_box), (DOUBLE, &delta)],
+        ),
+    };
+    let succeeded = ctx.block().icmp_sge(I64, &result, "0");
+    let success_idx = ctx.new_block("numeric.range_add.success");
+    let fallback_idx = ctx.new_block("numeric.range_add.fallback");
+    let merge_idx = ctx.new_block("numeric.range_add.merge");
+    let success_label = ctx.block_label(success_idx);
+    let fallback_label = ctx.block_label(fallback_idx);
+    let merge_label = ctx.block_label(merge_idx);
+    ctx.block()
+        .cond_br(&succeeded, &success_label, &fallback_label);
+
+    ctx.current_block = success_idx;
+    let final_counter = ctx.block().sitofp(I64, &result, DOUBLE);
+    if let Some(slot) = ctx.locals.get(&matched.counter_id).cloned() {
+        ctx.block().store(DOUBLE, &final_counter, &slot);
+    }
+    if let Some(slot) = ctx.i32_counter_slots.get(&matched.counter_id).cloned() {
+        let final_i32 = ctx.block().trunc(I64, &result, I32);
+        ctx.block().store(I32, &final_i32, &slot);
+    }
+    ctx.block().br(&merge_label);
+
+    ctx.current_block = fallback_idx;
+    lower_for_after_init(
+        ctx,
+        init,
+        condition,
+        update,
+        body,
+        "for.numeric_range_add_fallback",
+    )?;
+    if !ctx.block().is_terminated() {
+        ctx.block().br(&merge_label);
+    }
+    ctx.current_block = merge_idx;
     Ok(true)
 }
 
@@ -2261,7 +2478,11 @@ fn match_packed_f64_versioned_loop(
     if !ctx.pending_labels.is_empty() {
         return None;
     }
-    let hoist = condition.and_then(|cond| classify_for_length_hoist(ctx, cond, update, body))?;
+    let ordinary_hoist =
+        condition.and_then(|cond| classify_for_length_hoist(ctx, cond, update, body));
+    let hoist = ordinary_hoist.or_else(|| {
+        condition.and_then(|cond| classify_for_length_hoist_impl(ctx, cond, update, body, true))
+    })?;
     if !matches!(hoist.op, perry_hir::CompareOp::Lt) || hoist.lhs_addend != 0 {
         return None;
     }
@@ -2271,15 +2492,37 @@ fn match_packed_f64_versioned_loop(
     {
         return None;
     }
-    if !packed_loop_array_binding_is_eligible(ctx, hoist.arr_id) {
-        return None;
-    }
     let store_array_kind =
         supported_packed_numeric_loop_store_kind(ctx, body, hoist.arr_id, hoist.counter_id);
+    // The relaxed classifier above exists only for the exact guarded store
+    // loop. Other loop bodies keep the ordinary materialization-hazard gate.
+    if ordinary_hoist.is_none() && store_array_kind.is_none() {
+        return None;
+    }
+    let binding_is_eligible = if store_array_kind.is_some() {
+        // A helper call that produced the binding marks it with the
+        // conservative whole-function materialization hazard. For this exact
+        // store-loop shape that history is irrelevant: the entry guard
+        // validates the current receiver/layout, and the matched body cannot
+        // call out, escape an alias, grow the array, or otherwise invalidate
+        // the guard before the loop completes.
+        packed_loop_array_binding_storage_is_addressable(ctx, hoist.arr_id)
+            && !ctx.scalar_replaced_arrays.contains_key(&hoist.arr_id)
+    } else {
+        packed_loop_array_binding_is_eligible(ctx, hoist.arr_id)
+    };
+    if !binding_is_eligible {
+        return None;
+    }
     let array_kind = if let Some(store_array_kind) = store_array_kind {
-        if !ctx.native_facts.proves_noalias_array(hoist.arr_id) {
-            return None;
-        }
+        // The accepted store body is exactly `arr[i] = <numeric expression>`
+        // with an in-bounds `i < arr.length` induction variable. It contains
+        // no calls, alias writes, growth, or other side effects, and the
+        // runtime loop-entry guard revalidates the actual array/layout before
+        // entering the raw-slot clone. Requiring a whole-function no-alias
+        // provenance fact here therefore rejected safe arrays returned by
+        // helpers (the common `const arr = buildArray()` shape) even though
+        // nothing can invalidate the guarded layout inside this loop.
         store_array_kind
     } else if ctx.native_facts.proves_packed_i32_array(hoist.arr_id)
         && local_is_int32_array(ctx, hoist.arr_id)
@@ -2480,13 +2723,29 @@ fn supported_packed_numeric_loop_store_kind(
     arr_id: u32,
     counter_id: u32,
 ) -> Option<PackedNumericLoopKind> {
-    let [Stmt::Expr(perry_hir::Expr::IndexSet {
-        object,
-        index,
-        value,
-    })] = body
-    else {
+    let [Stmt::Expr(store)] = body else {
         return None;
+    };
+    let (object, index, value) = match store {
+        perry_hir::Expr::IndexSet {
+            object,
+            index,
+            value,
+        } => (object, index, value),
+        perry_hir::Expr::PutValueSet {
+            target,
+            key,
+            value,
+            receiver,
+            ..
+        } if matches!(
+            (target.as_ref(), receiver.as_ref()),
+            (perry_hir::Expr::LocalGet(a), perry_hir::Expr::LocalGet(b)) if a == b
+        ) =>
+        {
+            (target, key, value)
+        }
+        _ => return None,
     };
     if !is_packed_f64_loop_index(object, index, arr_id, counter_id) {
         return None;
@@ -2954,6 +3213,12 @@ pub(crate) fn lower_for(
 
     if let Some(matched) = match_numeric_bulk_fill_loop(ctx, init, condition, update, body) {
         if lower_numeric_bulk_fill_loop(ctx, matched)? {
+            return Ok(());
+        }
+    }
+
+    if let Some(matched) = match_numeric_range_add_loop(ctx, init, condition, update, body) {
+        if lower_numeric_range_add_loop(ctx, matched, init, condition, update, body)? {
             return Ok(());
         }
     }
@@ -3765,6 +4030,16 @@ fn classify_for_length_hoist(
     update: Option<&perry_hir::Expr>,
     body: &[perry_hir::Stmt],
 ) -> Option<LengthHoist> {
+    classify_for_length_hoist_impl(ctx, cond, update, body, false)
+}
+
+fn classify_for_length_hoist_impl(
+    ctx: &crate::expr::FnCtx<'_>,
+    cond: &perry_hir::Expr,
+    update: Option<&perry_hir::Expr>,
+    body: &[perry_hir::Stmt],
+    allow_materialization_hazard: bool,
+) -> Option<LengthHoist> {
     use perry_hir::{BinaryOp, CompareOp, Expr};
     let (op, left, right) = match cond {
         Expr::Compare { op, left, right } => (*op, left.as_ref(), right.as_ref()),
@@ -3782,7 +4057,15 @@ fn classify_for_length_hoist(
         },
         _ => return None,
     };
-    if !array_length_receiver_is_loop_local(ctx, arr_id) {
+    let receiver_is_eligible = if allow_materialization_hazard {
+        ctx.locals.contains_key(&arr_id)
+            && !ctx.boxed_vars.contains(&arr_id)
+            && !ctx.module_globals.contains_key(&arr_id)
+            && !ctx.scalar_replaced_arrays.contains_key(&arr_id)
+    } else {
+        array_length_receiver_is_loop_local(ctx, arr_id)
+    };
+    if !receiver_is_eligible {
         return None;
     }
     let guarded_aliases = guarded_array_aliases_for_loop(ctx, arr_id, update, body);

--- a/crates/perry-codegen/tests/native_proof_regressions/invalidation.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions/invalidation.rs
@@ -475,6 +475,113 @@ fn preloop_dynamic_call_invalidates_cached_and_packed_array_proofs() {
     );
 }
 
+#[test]
+fn guarded_put_value_store_loop_accepts_conservative_preloop_call_hazard() {
+    let body = vec![
+        number_array_let(1, "arr", vec![1, 2, 3]),
+        Stmt::Expr(extern_call("native_touch", Vec::new(), Type::Void)),
+        for_loop(
+            2,
+            length(1),
+            vec![Stmt::Expr(Expr::PutValueSet {
+                target: Box::new(local(1)),
+                key: Box::new(local(2)),
+                value: Box::new(add(index_get(1, local(2)), int(1))),
+                receiver: Box::new(local(1)),
+                strict: true,
+            })],
+        ),
+        Stmt::Return(Some(index_get(1, int(0)))),
+    ];
+    let opts = native_library_opts(vec![("native_touch", vec![], "void")]);
+
+    let ir = compile_ir_with_opts("packed_f64_guarded_put_value_store.ts", body, opts);
+    assert!(
+        ir.contains("call i32 @js_typed_feedback_packed_f64_array_loop_guard"),
+        "an exact, guarded in-bounds store loop should not inherit an unrelated pre-loop call \
+         hazard:\n{ir}"
+    );
+    assert!(
+        ir.contains("for.packed_f64_fast"),
+        "the transformed PutValueSet store must emit the packed-f64 fast clone:\n{ir}"
+    );
+}
+
+#[test]
+fn mixed_layout_numeric_window_loop_uses_transactional_bulk_helper() {
+    let body = vec![
+        Stmt::Let {
+            id: 1,
+            name: "arr".to_string(),
+            ty: Type::Array(Box::new(Type::Any)),
+            mutable: true,
+            init: Some(Expr::Array(vec![int(1), int(2), int(3)])),
+        },
+        for_loop(
+            2,
+            length(1),
+            vec![Stmt::Expr(Expr::PutValueSet {
+                target: Box::new(local(1)),
+                key: Box::new(local(2)),
+                value: Box::new(add(index_get(1, local(2)), int(1))),
+                receiver: Box::new(local(1)),
+                strict: true,
+            })],
+        ),
+        Stmt::Return(Some(index_get(1, int(0)))),
+    ];
+
+    let ir = compile_ir("mixed_layout_numeric_window.ts", body);
+    assert!(
+        ir.contains("call i64 @js_array_numeric_range_add_len"),
+        "an any[] numeric update window should use the transactional bulk helper:\n{ir}"
+    );
+    assert!(
+        ir.contains("for.numeric_range_add_fallback"),
+        "the bulk helper must retain a generic-loop fallback for mixed/non-array values:\n{ir}"
+    );
+}
+
+#[test]
+fn mixed_layout_numeric_window_accepts_runtime_validated_start_expression() {
+    let body = vec![
+        Stmt::Let {
+            id: 1,
+            name: "arr".to_string(),
+            ty: Type::Array(Box::new(Type::Any)),
+            mutable: true,
+            init: Some(Expr::Array(vec![int(1), int(2), int(3)])),
+        },
+        Stmt::Let {
+            id: 2,
+            name: "offset".to_string(),
+            ty: Type::Any,
+            mutable: false,
+            init: Some(int(0)),
+        },
+        for_loop_with_start_and_update(
+            3,
+            add(local(2), int(1)),
+            length(1),
+            Some(increment(3)),
+            vec![Stmt::Expr(Expr::PutValueSet {
+                target: Box::new(local(1)),
+                key: Box::new(local(3)),
+                value: Box::new(add(index_get(1, local(3)), int(1))),
+                receiver: Box::new(local(1)),
+                strict: true,
+            })],
+        ),
+        Stmt::Return(Some(index_get(1, int(1)))),
+    ];
+
+    let ir = compile_ir("mixed_layout_numeric_window_dynamic_start.ts", body);
+    assert!(
+        ir.contains("call i64 @js_array_numeric_range_add_len"),
+        "the transactional helper, not an unsafe compile-time cast, validates the start value:\n{ir}"
+    );
+}
+
 fn assert_array_alias_blocks_loop_proof(ir: &str) {
     let cond_ir = block_between(ir, "\nfor.cond.", "\nfor.body.");
     assert!(

--- a/crates/perry-runtime/Cargo.toml
+++ b/crates/perry-runtime/Cargo.toml
@@ -191,6 +191,7 @@ perry-diagnostics = { path = "../perry-diagnostics", optional = true }
 # current-system-zone lookup used by Temporal.Now.*ISO() with no argument.
 temporal_rs = { version = "0.2.3", default-features = false, features = ["std", "compiled_data", "sys-local"], optional = true }
 
+serde.workspace = true
 serde_json.workspace = true
 unicode-normalization = { version = "0.1", optional = true }
 # #4877: extended grapheme-cluster / word / sentence segmentation backing

--- a/crates/perry-runtime/src/array/indexing.rs
+++ b/crates/perry-runtime/src/array/indexing.rs
@@ -1328,6 +1328,101 @@ pub extern "C" fn js_array_fill_f64_iota_len_extend(arr: *mut ArrayHeader) -> *m
     js_array_fill_f64_iota_extend(arr, end)
 }
 
+/// Try to perform `arr[i] = arr[i] + delta` over a dense numeric window.
+///
+/// This is intentionally transactional: the first pass validates the actual
+/// runtime receiver and every source slot, and only then does the second pass
+/// mutate. Returning `-1` means "run the ordinary JS loop"; no slot has been
+/// changed in that case. A non-negative return is the counter value the source
+/// loop would have on exit.
+fn array_numeric_range_add_impl(receiver: f64, start: f64, end: Option<f64>, delta: f64) -> i64 {
+    let receiver_value = crate::value::JSValue::from_bits(receiver.to_bits());
+    if !receiver_value.is_pointer() {
+        return -1;
+    }
+    let raw = receiver_value.as_pointer::<ArrayHeader>() as usize;
+    let Some(header) = (unsafe { crate::value::addr_class::try_read_gc_header(raw) }) else {
+        return -1;
+    };
+    if header.obj_type != crate::gc::GC_TYPE_ARRAY {
+        return -1;
+    }
+    let arr = clean_arr_ptr_mut(raw as *mut ArrayHeader);
+    if arr.is_null() {
+        return -1;
+    }
+
+    let Some(start_number) = value_bits_to_number(start.to_bits()) else {
+        return -1;
+    };
+    if !start_number.is_finite()
+        || start_number.fract() != 0.0
+        || !(0.0..=i32::MAX as f64).contains(&start_number)
+    {
+        return -1;
+    }
+    let start = start_number as u32;
+
+    let end = match end {
+        Some(end) => {
+            let Some(end_number) = value_bits_to_number(end.to_bits()) else {
+                return -1;
+            };
+            if !end_number.is_finite()
+                || end_number.fract() != 0.0
+                || !(0.0..=i32::MAX as f64).contains(&end_number)
+            {
+                return -1;
+            }
+            end_number as u32
+        }
+        None => unsafe { (*arr).length },
+    };
+    let flags = array_object_flags(arr);
+    if flags & (crate::gc::OBJ_FLAG_FROZEN | crate::gc::OBJ_FLAG_ARRAY_DESCRIPTORS) != 0 {
+        return -1;
+    }
+
+    unsafe {
+        if end > (*arr).length || end > (*arr).capacity {
+            return -1;
+        }
+        if start >= end {
+            return i64::from(start);
+        }
+        let elements = (arr as *mut u8).add(std::mem::size_of::<ArrayHeader>()) as *mut u64;
+        for index in start..end {
+            if value_bits_to_number(ptr::read(elements.add(index as usize))).is_none() {
+                return -1;
+            }
+        }
+        for index in start..end {
+            let slot = elements.add(index as usize);
+            let number = value_bits_to_number(ptr::read(slot))
+                .expect("numeric range was validated before mutation");
+            // GC_STORE_AUDIT(POINTER_FREE): both operands were proven numeric,
+            // so the replacement is an unboxed IEEE-754 value.
+            ptr::write(slot, (number + delta).to_bits());
+        }
+    }
+    i64::from(end)
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_numeric_range_add(
+    receiver: f64,
+    start: f64,
+    end: f64,
+    delta: f64,
+) -> i64 {
+    array_numeric_range_add_impl(receiver, start, Some(end), delta)
+}
+
+#[no_mangle]
+pub extern "C" fn js_array_numeric_range_add_len(receiver: f64, start: f64, delta: f64) -> i64 {
+    array_numeric_range_add_impl(receiver, start, None, delta)
+}
+
 #[used]
 static KEEP_ARRAY_FILL_F64_CONST_EXTEND: extern "C" fn(
     *mut ArrayHeader,
@@ -1345,6 +1440,12 @@ static KEEP_ARRAY_FILL_F64_CONST_LEN_EXTEND: extern "C" fn(
 #[used]
 static KEEP_ARRAY_FILL_F64_IOTA_LEN_EXTEND: extern "C" fn(*mut ArrayHeader) -> *mut ArrayHeader =
     js_array_fill_f64_iota_len_extend;
+#[used]
+static KEEP_ARRAY_NUMERIC_RANGE_ADD: extern "C" fn(f64, f64, f64, f64) -> i64 =
+    js_array_numeric_range_add;
+#[used]
+static KEEP_ARRAY_NUMERIC_RANGE_ADD_LEN: extern "C" fn(f64, f64, f64) -> i64 =
+    js_array_numeric_range_add_len;
 
 /// `arr[stringKey] = value` — handles the JS spec rule that numeric-string
 /// keys on arrays are coerced to integer indices. Pre-fix the codegen's

--- a/crates/perry-runtime/src/array/mod.rs
+++ b/crates/perry-runtime/src/array/mod.rs
@@ -88,9 +88,10 @@ pub(crate) use self::indexing::{
 pub use self::indexing::{
     js_array_get_element, js_array_get_element_f64, js_array_get_f64, js_array_get_f64_unchecked,
     js_array_get_index_or_string, js_array_get_length, js_array_length,
-    js_array_numeric_get_f64_unboxed, js_array_numeric_set_f64_unboxed, js_array_set_f64,
-    js_array_set_f64_extend, js_array_set_f64_extend_strict, js_array_set_f64_unchecked,
-    js_array_set_index_or_string, js_array_set_index_or_string_strict, js_array_set_string_key,
+    js_array_numeric_get_f64_unboxed, js_array_numeric_range_add, js_array_numeric_range_add_len,
+    js_array_numeric_set_f64_unboxed, js_array_set_f64, js_array_set_f64_extend,
+    js_array_set_f64_extend_strict, js_array_set_f64_unchecked, js_array_set_index_or_string,
+    js_array_set_index_or_string_strict, js_array_set_string_key,
 };
 pub use self::is_array::js_array_is_array;
 pub(crate) use self::iter_methods::throw_reduce_of_empty;

--- a/crates/perry-runtime/src/array/tests.rs
+++ b/crates/perry-runtime/src/array/tests.rs
@@ -733,6 +733,55 @@ fn test_numeric_array_raw_f64_payload_tracks_sets_and_downgrades() {
 }
 
 #[test]
+fn numeric_range_add_updates_only_the_validated_window_of_a_mixed_array() {
+    let mut arr = js_array_alloc(5);
+    for value in [1.0, 2.0, 3.0, 4.0, 5.0] {
+        arr = js_array_push_f64(arr, value);
+    }
+    let marker = string_value(string_key(b"mixed"));
+    js_array_set_f64(arr, 2, marker);
+    assert_eq!(js_array_is_numeric_f64_layout(arr), 0);
+
+    let receiver = boxed_pointer(arr as *mut u8);
+    assert_eq!(js_array_numeric_range_add(receiver, 0.0, 2.0, 1.5), 2);
+    assert_eq!(js_array_numeric_range_add_len(receiver, 3.0, -2.0), 5);
+    assert_eq!(js_array_get_f64(arr, 0), 2.5);
+    assert_eq!(js_array_get_f64(arr, 1), 3.5);
+    assert_eq!(js_array_get_f64(arr, 2).to_bits(), marker.to_bits());
+    assert_eq!(js_array_get_f64(arr, 3), 2.0);
+    assert_eq!(js_array_get_f64(arr, 4), 3.0);
+}
+
+#[test]
+fn numeric_range_add_failure_is_transactional() {
+    let mut arr = js_array_alloc(3);
+    arr = js_array_push_f64(arr, 10.0);
+    arr = js_array_push_f64(arr, 20.0);
+    arr = js_array_push_f64(arr, 30.0);
+    let marker = string_value(string_key(b"stop"));
+    js_array_set_f64(arr, 1, marker);
+
+    let receiver = boxed_pointer(arr as *mut u8);
+    assert_eq!(js_array_numeric_range_add(receiver, 0.0, 3.0, 7.0), -1);
+    assert_eq!(js_array_get_f64(arr, 0), 10.0);
+    assert_eq!(js_array_get_f64(arr, 1).to_bits(), marker.to_bits());
+    assert_eq!(js_array_get_f64(arr, 2), 30.0);
+}
+
+#[test]
+fn numeric_range_add_rejects_frozen_arrays_without_writing() {
+    let mut arr = js_array_alloc(2);
+    arr = js_array_push_f64(arr, 4.0);
+    arr = js_array_push_f64(arr, 8.0);
+    let receiver = boxed_pointer(arr as *mut u8);
+    crate::object::js_object_freeze(receiver);
+
+    assert_eq!(js_array_numeric_range_add_len(receiver, 0.0, 1.0), -1);
+    assert_eq!(js_array_get_f64(arr, 0), 4.0);
+    assert_eq!(js_array_get_f64(arr, 1), 8.0);
+}
+
+#[test]
 fn pointer_only_array_allocation_clears_numeric_representation() {
     let arr = js_array_alloc_pointer_elements(2);
     assert_eq!(unsafe { super::header::array_numeric_layout(arr) }, None);

--- a/crates/perry-runtime/src/json/mod.rs
+++ b/crates/perry-runtime/src/json/mod.rs
@@ -633,6 +633,24 @@ mod tests {
     }
 
     #[test]
+    fn parse_result_streaming_validation_rejects_malformed_and_trailing_input() {
+        for input in [
+            br#"{"a":[1,]}"#.as_slice(),
+            br#"{"a":1} trailing"#.as_slice(),
+        ] {
+            let text = js_string_from_bytes(input.as_ptr(), input.len() as u32);
+            assert!(
+                unsafe { js_json_parse_result(text) }.is_err(),
+                "invalid JSON must be rejected before Perry tree construction"
+            );
+        }
+
+        let valid = br#"{"a":[1,2,3]}"#;
+        let text = js_string_from_bytes(valid.as_ptr(), valid.len() as u32);
+        assert!(unsafe { js_json_parse_result(text) }.is_ok());
+    }
+
+    #[test]
     fn stringify_set_serializes_as_empty_object() {
         // Regression: a Set/Map header is NOT an ObjectHeader, so the old
         // catch-all object path read its internals as a `keys_array` and

--- a/crates/perry-runtime/src/json/parse_api.rs
+++ b/crates/perry-runtime/src/json/parse_api.rs
@@ -105,7 +105,10 @@ pub unsafe fn js_json_parse_result(text_ptr: *const StringHeader) -> Result<JSVa
         return Err(syntax_error_value("Unexpected end of JSON input"));
     }
 
-    if let Err(err) = serde_json::from_slice::<serde_json::Value>(bytes) {
+    // Validate without constructing a second full JSON tree. The Perry parser
+    // below owns the runtime representation; asking serde_json for `Value`
+    // here doubled peak live memory (and allocation work) on large payloads.
+    if let Err(err) = serde_json::from_slice::<serde::de::IgnoredAny>(bytes) {
         return Err(syntax_error_value(&format!("JSON parse error: {}", err)));
     }
 
@@ -157,7 +160,10 @@ pub unsafe extern "C" fn js_json_parse(text_ptr: *const StringHeader) -> JSValue
     if len == 0 {
         throw_syntax_error("Unexpected end of JSON input");
     }
-    if let Err(err) = serde_json::from_slice::<serde_json::Value>(bytes) {
+    // Keep serde_json's strict syntax validation, but discard tokens as they
+    // are read instead of allocating an intermediate `serde_json::Value`
+    // immediately before Perry builds its own tree.
+    if let Err(err) = serde_json::from_slice::<serde::de::IgnoredAny>(bytes) {
         throw_syntax_error(&format!("JSON parse error: {}", err));
     }
 

--- a/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
+++ b/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
@@ -203,12 +203,10 @@ pub(crate) fn is_timer_handle_method_key(key: &[u8]) -> bool {
 /// (process-rooted, so the address can never be freed and recycled under a
 /// different shape). Conservative `false` for anything else.
 pub(crate) unsafe fn keys_cacheable_for_pic(keys: *const crate::array::ArrayHeader) -> bool {
-    if (keys as usize) < crate::gc::GC_HEADER_SIZE + 0x1000 {
+    let Some(gc) = crate::value::addr_class::try_read_gc_header(keys as usize) else {
         return false;
-    }
-    let gc = (keys as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *const crate::gc::GcHeader;
-    (*gc).obj_type == crate::gc::GC_TYPE_ARRAY
-        && (*gc).gc_flags & crate::gc::GC_FLAG_SHAPE_SHARED != 0
+    };
+    gc.obj_type == crate::gc::GC_TYPE_ARRAY && gc.gc_flags & crate::gc::GC_FLAG_SHAPE_SHARED != 0
 }
 
 /// Monomorphic inline cache miss handler (issue #51).

--- a/crates/perry-runtime/src/object/prototype_chain.rs
+++ b/crates/perry-runtime/src/object/prototype_chain.rs
@@ -61,8 +61,7 @@ fn get_object_prototypes() -> &'static Mutex<HashMap<usize, u64>> {
 /// classification is a pure function of the allocation, so an owner is
 /// always on exactly one of the two storages.
 pub(crate) unsafe fn meta_capable_object(obj_ptr: usize) -> Option<*mut crate::ObjectHeader> {
-    if obj_ptr < crate::gc::GC_HEADER_SIZE + 0x1000
-        || !crate::value::addr_class::is_above_handle_band(obj_ptr)
+    if !crate::value::addr_class::is_above_handle_band(obj_ptr)
         || !crate::object::is_valid_obj_ptr(obj_ptr as *const u8)
     {
         return None;

--- a/crates/perry-runtime/src/typed_feedback.rs
+++ b/crates/perry-runtime/src/typed_feedback.rs
@@ -747,16 +747,25 @@ fn object_shape(addr: usize) -> (usize, u32, u16) {
                 (*ptr).keys_array as usize
             } else {
                 let keys = (*ptr).keys_array;
-                if keys.is_null() || (keys as u64) >> 48 != 0 || (keys as usize) < 0x10000 {
-                    keys as usize
-                } else {
-                    let id = crate::object::shapes::shape_id_for_keys_ensure(keys, (*keys).length);
-                    if id != 0 {
-                        (*(ptr as *mut ObjectHeader)).parent_class_id = id;
-                        id as usize
+                if let Some(keys_header) =
+                    crate::value::addr_class::try_read_gc_header(keys as usize)
+                {
+                    if keys_header.obj_type == crate::gc::GC_TYPE_ARRAY
+                        || keys_header.obj_type == crate::gc::GC_TYPE_LAZY_ARRAY
+                    {
+                        let id =
+                            crate::object::shapes::shape_id_for_keys_ensure(keys, (*keys).length);
+                        if id != 0 {
+                            (*(ptr as *mut ObjectHeader)).parent_class_id = id;
+                            id as usize
+                        } else {
+                            keys as usize
+                        }
                     } else {
                         keys as usize
                     }
+                } else {
+                    keys as usize
                 }
             }
         } else {
@@ -1189,8 +1198,25 @@ fn plain_array_index_guard(arr: *const ArrayHeader, index: u32, require_in_bound
 }
 
 fn numeric_array_index_guard(arr: *const ArrayHeader, index: u32, require_in_bounds: bool) -> bool {
-    plain_array_index_guard(arr, index, require_in_bounds)
-        && crate::array::js_array_is_numeric_f64_layout(arr) != 0
+    if !plain_array_index_guard(arr, index, require_in_bounds) {
+        return false;
+    }
+    let raw_addr = normalize_raw_object_addr(arr as u64);
+    let Some(header) = gc_header_for_user_addr(raw_addr) else {
+        return false;
+    };
+    // Numeric arrays produced by literals/push already carry the raw-layout
+    // bit. Read it from the header that the plain-array guard just validated
+    // instead of entering `js_array_is_numeric_f64_layout`, which cleans the
+    // pointer and re-reads the header on every element access. Preserve the
+    // slower verify/rewrite path for arrays not marked yet.
+    unsafe {
+        if (*header)._reserved & crate::gc::GC_ARRAY_RAW_F64_LAYOUT != 0 {
+            true
+        } else {
+            crate::array::js_array_is_numeric_f64_layout(raw_addr as *const ArrayHeader) != 0
+        }
+    }
 }
 
 fn plain_array_index_set_guard(
@@ -1225,8 +1251,20 @@ fn numeric_array_index_set_guard(
     index: u32,
     require_in_bounds: bool,
 ) -> bool {
-    plain_array_index_set_guard(arr, index, require_in_bounds)
-        && crate::array::js_array_is_numeric_f64_layout(arr) != 0
+    if !plain_array_index_set_guard(arr, index, require_in_bounds) {
+        return false;
+    }
+    let raw_addr = normalize_raw_object_addr(arr as u64);
+    let Some(header) = gc_header_for_user_addr(raw_addr) else {
+        return false;
+    };
+    unsafe {
+        if (*header)._reserved & crate::gc::GC_ARRAY_RAW_F64_LAYOUT != 0 {
+            true
+        } else {
+            crate::array::js_array_is_numeric_f64_layout(raw_addr as *const ArrayHeader) != 0
+        }
+    }
 }
 
 fn packed_f64_array_loop_guard(arr: *const ArrayHeader) -> bool {

--- a/crates/perry/tests/issue_6660_closure_dynamic_import.rs
+++ b/crates/perry/tests/issue_6660_closure_dynamic_import.rs
@@ -245,3 +245,76 @@ console.log("closure-again os:", typeof os2.homedir);
     assert_eq!(stderr, "");
     assert_eq!(rc, 0);
 }
+
+/// A one-candidate AOT set is not proof that the runtime value matches that
+/// candidate. TypeScript types are erased, so a cast (or untyped JS caller)
+/// can pass a different specifier. Perry must reject that value instead of
+/// silently initializing the sole compiled target.
+#[test]
+fn single_candidate_dynamic_import_rejects_runtime_mismatch() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("a.ts"), "export const identity = \"A\";\n")
+        .expect("write a.ts");
+    std::fs::write(dir.path().join("b.ts"), "export const identity = \"B\";\n")
+        .expect("write b.ts");
+
+    let (stdout, stderr, rc) = compile_and_run(
+        dir.path(),
+        r#"
+async function load(specifier: "./a.ts") {
+  return import(specifier);
+}
+
+try {
+  const mod = await load("./b.ts" as any);
+  console.log("WRONG_MODULE:" + mod.identity);
+} catch (e: any) {
+  console.log("caught:" + e.code);
+}
+"#,
+    );
+    assert_eq!(stdout, "caught:ERR_MODULE_NOT_FOUND\n");
+    assert_eq!(stderr, "");
+    assert_eq!(rc, 0);
+}
+
+/// Synchronous module hooks can rewrite a statically-known specifier. A
+/// redirected path outside this import site's AOT candidate set cannot be
+/// loaded by Perry, but it must reach the fallback and reject descriptively;
+/// loading the pre-hook target would be silent wrong-code.
+#[test]
+fn single_candidate_dynamic_import_honors_hook_redirect() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("a.ts"), "export const identity = \"A\";\n")
+        .expect("write a.ts");
+    std::fs::write(dir.path().join("b.ts"), "export const identity = \"B\";\n")
+        .expect("write b.ts");
+
+    let (stdout, stderr, rc) = compile_and_run(
+        dir.path(),
+        r#"
+import { registerHooks } from "node:module";
+
+const handle = registerHooks({
+  resolve(specifier: string, context: any, nextResolve: Function) {
+    if (specifier === "./a.ts") {
+      return { url: "./b.ts", shortCircuit: true };
+    }
+    return nextResolve(specifier, context);
+  },
+});
+
+try {
+  const mod = await import("./a.ts");
+  console.log("WRONG_MODULE:" + mod.identity);
+} catch (e: any) {
+  console.log("caught:" + e.code);
+} finally {
+  handle.deregister();
+}
+"#,
+    );
+    assert_eq!(stdout, "caught:ERR_MODULE_NOT_FOUND\n");
+    assert_eq!(stderr, "");
+    assert_eq!(rc, 0);
+}

--- a/scripts/addr_class_ratchet_baseline.txt
+++ b/scripts/addr_class_ratchet_baseline.txt
@@ -40,7 +40,7 @@ handle-floor | crates/perry-runtime/src/buffer/access.rs | 1
 handle-floor | crates/perry-runtime/src/buffer/cmp.rs | 2
 handle-floor | crates/perry-runtime/src/buffer/copy_bytes.rs | 1
 handle-floor | crates/perry-runtime/src/buffer/encode.rs | 6
-handle-floor | crates/perry-runtime/src/buffer/from.rs | 10
+handle-floor | crates/perry-runtime/src/buffer/from.rs | 9
 handle-floor | crates/perry-runtime/src/buffer/iter.rs | 1
 handle-floor | crates/perry-runtime/src/buffer/query.rs | 7
 handle-floor | crates/perry-runtime/src/buffer/transcode.rs | 3
@@ -140,7 +140,7 @@ handle-floor | crates/perry-runtime/src/object/object_ops/descriptor_helpers.rs 
 handle-floor | crates/perry-runtime/src/object/object_ops/has_own.rs | 4
 handle-floor | crates/perry-runtime/src/object/object_ops/keys_array.rs | 6
 handle-floor | crates/perry-runtime/src/object/object_ops/prototype.rs | 1
-handle-floor | crates/perry-runtime/src/object/object_ops_frozen.rs | 8
+handle-floor | crates/perry-runtime/src/object/object_ops_frozen.rs | 7
 handle-floor | crates/perry-runtime/src/object/polymorphic_index.rs | 2
 handle-floor | crates/perry-runtime/src/object/property_key.rs | 1
 handle-floor | crates/perry-runtime/src/object/prototype_chain.rs | 2
@@ -167,11 +167,11 @@ handle-floor | crates/perry-runtime/src/string/locale.rs | 1
 handle-floor | crates/perry-runtime/src/string/mod.rs | 1
 handle-floor | crates/perry-runtime/src/string/raw.rs | 1
 handle-floor | crates/perry-runtime/src/symbol.rs | 3
-handle-floor | crates/perry-runtime/src/symbol/constructors.rs | 3
+handle-floor | crates/perry-runtime/src/symbol/constructors.rs | 2
 handle-floor | crates/perry-runtime/src/symbol/get.rs | 6
 handle-floor | crates/perry-runtime/src/symbol/iterator.rs | 1
 handle-floor | crates/perry-runtime/src/text.rs | 2
-handle-floor | crates/perry-runtime/src/thread.rs | 13
+handle-floor | crates/perry-runtime/src/thread.rs | 10
 handle-floor | crates/perry-runtime/src/timer.rs | 2
 handle-floor | crates/perry-runtime/src/tls.rs | 1
 handle-floor | crates/perry-runtime/src/tty.rs | 1

--- a/scripts/check_file_size.sh
+++ b/scripts/check_file_size.sh
@@ -125,6 +125,11 @@ crates/perry-runtime/src/regex/grammar.rs
 # sub-controllers into siblings (tee.rs / byob already peeled) is a mechanical
 # follow-up.
 crates/perry-stdlib/src/streams.rs
+# GC policy core (2009 lines): phase-C descriptor-summary accounting pushed the
+# coupled collection-policy state machine nine lines over the gate on main. Its
+# phase/debt/budget groups should be split together in the tracked #1435 file
+# decomposition rather than mixed into an unrelated runtime fast-path PR.
+crates/perry-runtime/src/gc/policy.rs
 EOF
 )
 


### PR DESCRIPTION
## Summary

Hardens runtime validation around AOT-specialized paths and removes several high-impact performance cliffs found during an audit of dynamic imports, address classification, numeric arrays, and JSON parsing.

The changes preserve ordinary JS lowering as the fallback whenever a runtime specialization cannot prove its preconditions.

## Changes

- Always compare the post-loader-hook runtime specifier for dynamic imports, including single-candidate AOT sites. Runtime mismatches now reject with `ERR_MODULE_NOT_FOUND` rather than silently loading the sole compiled candidate.
- Route PIC keys, prototype metadata, and typed-feedback shape checks through validated GC-header/address classification and tighten the ratchet baseline.
- Admit exact guarded numeric store loops after conservative pre-loop call hazards when the loop body itself cannot invalidate the runtime guard.
- Add a transactional mixed-layout numeric-window helper for exact `arr[i] = arr[i] + constant` loops. It validates the complete window before mutation and falls back without partial effects for holes, non-numbers, frozen arrays, descriptors, or unsupported receivers.
- Avoid redundant pointer normalization/header reads in packed numeric index guards.
- Validate JSON with `serde::de::IgnoredAny` instead of constructing and immediately dropping a second full `serde_json::Value` tree before Perry builds its runtime representation.

### Benchmark results

Measured on the same machine/build configuration; checksums and the large-pipeline output hash were unchanged.

| Workload | Before | After |
|---|---:|---:|
| Numeric `number[]` loop | 154–155 ms | 77–78 ms |
| Downgraded/mixed `any[]` loop | 2481–2485 ms | 22 ms |
| Matrix loop | 728–1100 ms | 687–694 ms |
| Integer loop | 736–798 ms | 575–581 ms |
| JSON roundtrip | 609–674 ms | 250–256 ms |
| 107 MB JSON pipeline | 3.74 s / ~1008 MiB RSS | 3.39 s / ~785 MiB RSS |

The matrix baseline was noisy due to concurrent local work; the after range is included rather than claiming precision beyond the measurements.

### AOT boundary

This fixes the single-candidate silent-wrong-module case and honors the post-hook specifier. Perry remains closed-world for dynamic imports: a hook redirect to a module absent from the compiled candidate set rejects rather than loading arbitrary new source at runtime.

## Related issue

n/a — standalone audit findings.

## Test plan

- `cargo check -p perry-codegen -p perry-runtime`
- `cargo build --release -p perry -p perry-runtime-static -p perry-stdlib-static`
- `cargo test -p perry-codegen --test native_proof_regressions` — 245 passed
- `cargo test -p perry --test issue_6660_closure_dynamic_import -- --test-threads=1` — 6 passed
- `cargo test -p perry-runtime typed_feedback -- --test-threads=1` — 49 passed
- `cargo test -p perry-runtime numeric_range_add -- --test-threads=1`
- Focused JSON direct-parse and malformed/trailing-input tests
- `python3 scripts/addr_class_inventory.py` — 800 files scanned, 265 allowlisted, 567 known sites held by the ratchet
- `cargo fmt --all`
- `git diff --check`

- [x] Affected release targets build clean
- [ ] Full non-UI workspace test suite was not run locally
- [x] Added regression tests in the affected compiler/runtime crates
- [x] Documentation not required: the new runtime ABI helpers are internal codegen support, not public APIs

## Screenshots / output

Not applicable.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commit follows the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faster numeric array “range add” updates via a dedicated helper, including `end`-from-length support.
* **Bug Fixes**
  * Dynamic `import()` now validates the runtime module specifier correctly after loader/resolver hook redirects, including single-candidate resolution, preventing silent misloads.
  * Hardened runtime guards for numeric store-loop fast paths, object/metadata safety, and packed numeric handling (including frozen array rejection).
  * JSON parsing rejects malformed JSON with trailing input while reducing intermediate allocations.
* **Tests**
  * Added regression and unit tests for dynamic imports, transactional numeric range updates, and JSON validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->