### PR TITLE
fix(runtime): close node:util parity tail

### DIFF
--- a/changelog.d/6792-util-isarray-arity.md
+++ b/changelog.d/6792-util-isarray-arity.md
@@ -1,0 +1,1 @@
+fix(runtime): expose Node-compatible `length === 1` metadata on both namespace and named `node:util.isArray` imports, and keep boxed-String `length` hidden in `util.inspect` after the descriptor fast-path refactor.

--- a/crates/perry-runtime/src/builtins/formatting.rs
+++ b/crates/perry-runtime/src/builtins/formatting.rs
@@ -1409,7 +1409,15 @@ unsafe fn format_object_as_json(
             }
         }
 
-        let is_enumerable = if descriptors_in_use {
+        // `String` exotic objects always have a non-enumerable own `length`.
+        // Its descriptor is installed through the gate-neutral built-in
+        // descriptor path, so the process-wide user-descriptor fast-path flag
+        // can legitimately still be false. Do not let that optimization make
+        // util.inspect print `length` as an ordinary enumerable property.
+        let is_boxed_string_length = boxed_string_char_count.is_some() && key_str == "length";
+        let is_enumerable = if is_boxed_string_length {
+            false
+        } else if descriptors_in_use {
             crate::object::get_property_attrs(obj_addr, &key_str)
                 .map(|a| a.enumerable())
                 .unwrap_or(true)

--- a/crates/perry-runtime/src/node_submodules/tests.rs
+++ b/crates/perry-runtime/src/node_submodules/tests.rs
@@ -127,6 +127,29 @@ fn http_outgoing_message_export_is_callable() {
     assert!(found, "http namespace keys should include OutgoingMessage");
 }
 
+#[test]
+fn util_is_array_export_records_its_node_arity() {
+    // Namespace reads (`util.isArray`) and named-import materialization
+    // (`import { isArray }`) intentionally converge on this same native-module
+    // property helper. The node-suite fixture exercises both source forms
+    // end-to-end; this unit test pins the shared closure metadata they consume.
+    let value = unsafe {
+        crate::object::js_native_module_property_by_name(
+            b"util".as_ptr(),
+            "util".len(),
+            b"isArray".as_ptr(),
+            "isArray".len(),
+        )
+    };
+    let closure = crate::value::JSValue::from_bits(value.to_bits())
+        .as_pointer::<crate::closure::ClosureHeader>();
+
+    assert_eq!(
+        crate::object::builtin_closure_length(closure as usize),
+        Some(1)
+    );
+}
+
 fn boxed_ptr(ptr: *const u8) -> f64 {
     f64::from_bits(JSValue::pointer(ptr).bits())
 }

--- a/crates/perry-runtime/src/object/native_module/callable_exports.rs
+++ b/crates/perry-runtime/src/object/native_module/callable_exports.rs
@@ -473,6 +473,7 @@ fn native_callable_export_arity(module: &str, prop: &str) -> Option<u32> {
         ) => Some(1),
         ("process", "hasUncaughtExceptionCaptureCallback") => Some(0),
         ("fs", "_toUnixTimestamp") => Some(1),
+        ("util", "isArray") => Some(1),
         ("util", "debug" | "debuglog" | "inherits") => Some(2),
         ("console", "context") => Some(1),
         ("console", "createTask") => Some(0),


### PR DESCRIPTION
## Summary

Make `node:util.isArray` expose Node-compatible function arity for namespace and named imports, closing the final baseline util mismatch. Also preserve boxed-String inspection semantics after the recent descriptor fast-path refactor so the complete current-main util module stays green.

## Changes

- record `isArray.length === 1` on the materialized native callable
- add a runtime regression test for the stored export arity
- treat boxed String `length` as non-enumerable in `util.inspect` even when no user descriptor has enabled the global slow path
- add a changelog fragment

## Related issue

Closes #6792

## Test plan

- [x] `cargo test -p perry-runtime util_is_array_export_records_its_node_arity --lib`
- [x] `./run_parity_tests.sh --suite node-suite --module util --filter is-array`
- [x] `./run_parity_tests.sh --suite node-suite --module util --filter boxed-and-symbols`
- [x] `./run_parity_tests.sh --suite node-suite --module util` — 86 pass, 0 fail, 0 compile fail, 0 crash
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commit follows the repository prefix convention

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `node:util.isArray` so its exported callable metadata reports `length: 1`, matching Node.js behavior.
  * Adjusted object inspection so boxed `String` objects never expose their `"length"` as a normal enumerable property.
* **Tests**
  * Added coverage ensuring `util.isArray` reports the expected 1-arity callable value for the native export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->