### PR TITLE
fix(hir): close node:readline parity tail

### DIFF
--- a/changelog.d/6791-readline-interface-properties.md
+++ b/changelog.d/6791-readline-interface-properties.md
@@ -1,0 +1,1 @@
+fix(hir): route `readline.Interface` `line` and `terminal` property reads through their native getters instead of returning `undefined`.

--- a/crates/perry-hir/src/lower/expr_member/native_dispatch.rs
+++ b/crates/perry-hir/src/lower/expr_member/native_dispatch.rs
@@ -116,6 +116,10 @@ pub(crate) fn is_native_dispatch_member(module: &str, class: &str, prop: &str) -
         // user own-property surface in the bundle walls, so keep dispatching
         // for any member to preserve existing behaviour.
         "events" | "net" => true,
+        // readline Interface stores its public `line` and `terminal` state
+        // behind a compact native handle. Bare reads must invoke the FFI
+        // getters; methods still travel through the call-expression path.
+        "readline" => matches!(prop, "line" | "terminal"),
         // #6364 — DisposableStack / AsyncDisposableStack: `disposed` is the
         // only native data getter (its value comes from the FFI helper
         // `js_disposable_stack_disposed`), so a bare read must dispatch as a
@@ -559,4 +563,29 @@ pub(crate) fn is_worker_instance_value_property(prop: &str) -> bool {
             | "once"
             | "off"
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_native_dispatch_member;
+
+    #[test]
+    fn readline_interface_dispatches_only_native_data_getters() {
+        assert!(is_native_dispatch_member("readline", "Interface", "line"));
+        assert!(is_native_dispatch_member(
+            "readline",
+            "Interface",
+            "terminal"
+        ));
+        assert!(!is_native_dispatch_member(
+            "readline",
+            "Interface",
+            "getPrompt"
+        ));
+        assert!(!is_native_dispatch_member(
+            "readline",
+            "Interface",
+            "custom"
+        ));
+    }
 }


### PR DESCRIPTION
## Summary

Route `readline.Interface.line` and `.terminal` reads through the native getters Perry already implements. This closes the sole `node:readline` mismatch in the 2026-07-22 baseline.

## Changes

- recognize `line` and `terminal` as native data getters on readline Interface instances
- preserve ordinary property reads for method values and user expandos
- add a focused HIR routing regression test
- add a changelog fragment

## Related issue

Closes #6791

## Test plan

- [x] `cargo test -p perry-hir readline_interface_dispatches_only_native_data_getters --lib`
- [x] `./run_parity_tests.sh --suite node-suite --module readline --filter control-methods`
- [x] `./run_parity_tests.sh --suite node-suite --module readline` — 12 pass, 0 fail, 0 compile fail, 0 crash
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commit follows the repository prefix convention

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `readline.Interface` so the `line` and `terminal` properties now return their correct values instead of `undefined`.
  * Other interface properties continue to behave as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->