### PR TITLE
fix(net): close node:net parity tail

### DIFF
--- a/changelog.d/6790-net-connection-state.md
+++ b/changelog.d/6790-net-connection-state.md
@@ -1,0 +1,1 @@
+Fixed `node:net` loopback connection event ordering and `Server#getConnections()` visibility while preserving `maxConnections` admission accounting and buffering accepted data until server listeners are installed.

--- a/crates/perry-ext-net/src/adopt.rs
+++ b/crates/perry-ext-net/src/adopt.rs
@@ -52,6 +52,7 @@ pub fn adopt_upgraded_tcp_stream(stream: tokio::net::TcpStream) -> i64 {
             timeout: None,
             type_of_service: 0,
             server_id: None,
+            server_connection_active: false,
         },
     );
     statics::listeners()

--- a/crates/perry-ext-net/src/lib.rs
+++ b/crates/perry-ext-net/src/lib.rs
@@ -263,6 +263,8 @@ pub(crate) struct ServerState {
     pub bound_host: String,
     pub listening: bool,
     pub active_connections: usize,
+    pub pending_connections: usize,
+    pub pending_local_connect_events: usize,
     pub max_connections: Option<usize>,
     pub drop_max_connection: Option<bool>,
 }
@@ -335,6 +337,7 @@ pub(crate) struct SocketState {
     pub(crate) timeout: Option<u64>,
     pub(crate) type_of_service: u8,
     pub(crate) server_id: Option<i64>,
+    pub(crate) server_connection_active: bool,
 }
 
 #[cfg(test)]
@@ -354,6 +357,7 @@ impl SocketState {
             timeout: None,
             type_of_service: 0,
             server_id: None,
+            server_connection_active: false,
         }
     }
 }
@@ -384,7 +388,9 @@ pub(crate) enum SocketCommand {
 
 #[derive(Debug)]
 enum PendingNetEvent {
-    Connect(i64),
+    /// `.1` identifies a same-process server target and whether its admission
+    /// is expected to hit `dropMaxConnection`; external connects use `None`.
+    Connect(i64, Option<(i64, bool)>),
     /// One chunk of read data. Carried as a refcounted `Bytes` — a zero-copy
     /// view sliced out of the socket task's reused read buffer (`split_to`) —
     /// so the path from the receive buffer to the main-thread drain handler
@@ -403,7 +409,8 @@ enum PendingNetEvent {
     /// listeners with the new socket handle.
     ///   `.0` = server id (for listener lookup)
     ///   `.1` = socket id (passed to listeners as the arg)
-    ServerConnection(i64, i64),
+    ///   `.2` = loopback client callback has crossed a pump boundary
+    ServerConnection(i64, i64, bool),
     /// Issue #1123 followup — `listener.bind()` resolved + accept
     /// loop is running. Fires `'listening'` listeners + the
     /// `.listen(port, cb)` callback. `.0` = server id.
@@ -431,6 +438,11 @@ extern "C" {
 }
 
 fn push_event(ev: PendingNetEvent) {
+    if let PendingNetEvent::ServerConnection(server_id, socket_id, false) = &ev {
+        if !server_state::queue_server_connection(*server_id, *socket_id) {
+            return;
+        }
+    }
     statics::pending_events().lock().unwrap().push(ev);
     // Wake the main thread so its `js_wait_for_event` returns
     // promptly instead of waiting on the heartbeat cap (#84
@@ -439,28 +451,8 @@ fn push_event(ev: PendingNetEvent) {
     perry_ffi::notify_main_thread();
 }
 
-fn is_local_server_target(host: &str, port: u16) -> bool {
-    let local_host = matches!(host, "localhost" | "127.0.0.1" | "::1" | "0.0.0.0");
-    if !local_host {
-        return false;
-    }
-    statics::servers().lock().ok().is_some_and(|servers| {
-        servers
-            .values()
-            .any(|server| server.listening && server.bound_port == port)
-    })
-}
-
 fn mark_closed(id: i64) {
-    let owner = if let Some(s) = statics::sockets().lock().unwrap().get_mut(&id) {
-        s.is_open = false;
-        s.server_id.take()
-    } else {
-        None
-    };
-    if let Some(server_id) = owner {
-        server_state::socket_closed(server_id);
-    }
+    server_state::mark_socket_closed(id);
 }
 
 // ─── Spawning helper ─────────────────────────────────────────────────────────
@@ -624,6 +616,7 @@ pub unsafe extern "C" fn js_net_socket_alloc() -> i64 {
             timeout: None,
             type_of_service: 0,
             server_id: None,
+            server_connection_active: false,
         },
     );
     statics::listeners()
@@ -661,6 +654,8 @@ pub unsafe extern "C" fn js_net_create_server(
             bound_host: String::new(),
             listening: false,
             active_connections: 0,
+            pending_connections: 0,
+            pending_local_connect_events: 0,
             max_connections: None,
             drop_max_connection: None,
         },
@@ -826,6 +821,7 @@ pub unsafe extern "C" fn js_net_server_listen(handle: i64, port: f64, arg2: f64,
                             // loop; the synchronous client-facing entry points
                             // still surface a throwable EMFILE.
                             if socket_id == perry_ffi::INVALID_HANDLE {
+                                server_state::cancel_pending_connection(server_id);
                                 drop(stream);
                                 continue;
                             }
@@ -855,6 +851,7 @@ pub unsafe extern "C" fn js_net_server_listen(handle: i64, port: f64, arg2: f64,
                                     timeout: None,
                                     type_of_service: 0,
                                     server_id: Some(server_id),
+                                    server_connection_active: false,
                                 },
                             );
                             statics::listeners()
@@ -870,7 +867,9 @@ pub unsafe extern "C" fn js_net_server_listen(handle: i64, port: f64, arg2: f64,
                             // and we want those in place before
                             // bytes start arriving. The accepted
                             // stream's read loop spawns next.
-                            push_event(PendingNetEvent::ServerConnection(server_id, socket_id));
+                            push_event(PendingNetEvent::ServerConnection(
+                                server_id, socket_id, false,
+                            ));
 
                             // Spawn the per-socket read/write loop on
                             // the same shared runtime as this accept
@@ -1050,6 +1049,7 @@ pub unsafe extern "C" fn js_net_socket_method_connect(handle: i64, port: f64, ho
         }
     };
 
+    let local_server = server_state::begin_local_connect(&host, port);
     spawn_socket_runner(move || {
         Box::pin(async move {
             let mut rx = rx;
@@ -1057,6 +1057,7 @@ pub unsafe extern "C" fn js_net_socket_method_connect(handle: i64, port: f64, ho
             let tcp = match TcpStream::connect(&addr).await {
                 Ok(s) => s,
                 Err(e) => {
+                    server_state::cancel_local_connect(local_server);
                     push_event(PendingNetEvent::Error(handle, format!("{}", e)));
                     push_event(PendingNetEvent::Close(handle));
                     mark_closed(handle);
@@ -1073,12 +1074,8 @@ pub unsafe extern "C" fn js_net_socket_method_connect(handle: i64, port: f64, ho
                 s.is_open = true;
                 s.local_addr = local;
             }
-            if is_local_server_target(&host, port) {
-                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
-            } else {
-                tokio::task::yield_now().await;
-            }
-            push_event(PendingNetEvent::Connect(handle));
+            tokio::task::yield_now().await;
+            push_event(PendingNetEvent::Connect(handle, local_server));
 
             run_socket_task(handle, Transport::Plain(tcp), &mut rx).await;
         })
@@ -1101,6 +1098,10 @@ pub(crate) fn spawn_socket_task(
     dispatch::ensure_runtime_dispatch_registered();
     let id = next_id_or_throw();
     let (tx, rx) = mpsc::unbounded_channel::<SocketCommand>();
+    let local_server = direct_tls
+        .is_none()
+        .then(|| server_state::begin_local_connect(&host, port))
+        .flatten();
 
     statics::sockets().lock().unwrap().insert(
         id,
@@ -1116,6 +1117,7 @@ pub(crate) fn spawn_socket_task(
             timeout: None,
             type_of_service: 0,
             server_id: None,
+            server_connection_active: false,
         },
     );
     statics::listeners()
@@ -1130,6 +1132,7 @@ pub(crate) fn spawn_socket_task(
             let tcp = match TcpStream::connect(&addr).await {
                 Ok(s) => s,
                 Err(e) => {
+                    server_state::cancel_local_connect(local_server);
                     push_event(PendingNetEvent::Error(id, format!("{}", e)));
                     push_event(PendingNetEvent::Close(id));
                     mark_closed(id);
@@ -1150,6 +1153,7 @@ pub(crate) fn spawn_socket_task(
                     match do_tls_handshake(tcp, &servername, verify).await {
                         Ok(tls) => Transport::Tls(Box::new(tls)),
                         Err(e) => {
+                            server_state::cancel_local_connect(local_server);
                             push_event(PendingNetEvent::Error(id, e));
                             push_event(PendingNetEvent::Close(id));
                             mark_closed(id);
@@ -1164,12 +1168,8 @@ pub(crate) fn spawn_socket_task(
                 s.is_open = true;
                 s.local_addr = local;
             }
-            if is_local_server_target(&host, port) {
-                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
-            } else {
-                tokio::task::yield_now().await;
-            }
-            push_event(PendingNetEvent::Connect(id));
+            tokio::task::yield_now().await;
+            push_event(PendingNetEvent::Connect(id, local_server));
 
             run_socket_task(id, transport, &mut rx).await;
         })
@@ -1490,7 +1490,8 @@ pub unsafe extern "C" fn js_ext_net_drain_pending() -> i32 {
 
     for ev in events.drain(..) {
         match ev {
-            PendingNetEvent::Connect(id) => {
+            PendingNetEvent::Connect(id, local_server) => {
+                server_state::finish_local_connect(local_server);
                 for cb in listeners_for(id, "connect") {
                     if cb != 0 {
                         let _ = JsClosure::from_raw(cb as *const RawClosureHeader).call0();
@@ -1511,6 +1512,7 @@ pub unsafe extern "C" fn js_ext_net_drain_pending() -> i32 {
             PendingNetEvent::Data(id, bytes) => {
                 let cbs = listeners_for(id, "data");
                 if cbs.is_empty() {
+                    server_state::buffer_pending_server_data(id, bytes);
                     continue;
                 }
                 // #4973: `socket.setEncoding(enc)` switches 'data' delivery
@@ -1584,18 +1586,24 @@ pub unsafe extern "C" fn js_ext_net_drain_pending() -> i32 {
                 statics::sockets().lock().unwrap().remove(&id);
                 statics::once_flags().lock().unwrap().remove(&id);
                 statics::encodings().lock().unwrap().remove(&id);
+                server_state::discard_pending_server_data(id);
             }
             // Issue #1123 followup — server-side events. The
             // accept loop pushes `ServerConnection`/`ServerListening`/
             // `ServerError`/`ServerClose`; the main-thread pump
             // converts them into the appropriate JS dispatch.
-            PendingNetEvent::ServerConnection(server_id, socket_id) => {
+            PendingNetEvent::ServerConnection(server_id, socket_id, released) => {
+                if !released && server_state::defer_server_connection(server_id, socket_id) {
+                    continue;
+                }
+                server_state::activate_connection(server_id, socket_id);
                 let cbs = listeners_for(server_id, "connection");
                 if cbs.is_empty() {
                     // Drain any `server.once('connection', cb)` flagged
                     // here too — listeners_for returned empty but the
                     // once-set may still be holding stale entries.
                     lifecycle::drain_once_listeners(server_id, "connection");
+                    server_state::release_pending_server_data(socket_id);
                     continue;
                 }
                 // Sockets returned by the codegen's `net.connect`
@@ -1618,6 +1626,7 @@ pub unsafe extern "C" fn js_ext_net_drain_pending() -> i32 {
                     }
                 }
                 lifecycle::drain_once_listeners(server_id, "connection");
+                server_state::release_pending_server_data(socket_id);
             }
             PendingNetEvent::ServerListening(server_id) => {
                 // Take + drain the 'listening' listeners so the
@@ -1659,6 +1668,7 @@ pub unsafe extern "C" fn js_ext_net_drain_pending() -> i32 {
                 // Tear down the server entry so the keepalive gate
                 // (`js_ext_net_has_active_handles`) lets the runtime
                 // exit cleanly after the user's close() resolves.
+                server_state::remove_server(server_id);
                 statics::servers().lock().unwrap().remove(&server_id);
                 statics::listeners().lock().unwrap().remove(&server_id);
                 statics::once_flags().lock().unwrap().remove(&server_id);

--- a/crates/perry-ext-net/src/server_state.rs
+++ b/crates/perry-ext-net/src/server_state.rs
@@ -1,13 +1,157 @@
+use bytes::Bytes;
 use perry_ffi::{
     alloc_string, build_object_shape, js_object_alloc_with_shape, js_object_set_field, JsValue,
     ObjectHeader,
 };
+use std::collections::{HashMap, VecDeque};
 use std::net::SocketAddr;
+use std::sync::{Mutex, OnceLock};
 use tokio::net::TcpStream;
 
-use crate::statics;
+use crate::{statics, PendingNetEvent};
 
 const TAG_UNDEFINED: u64 = 0x7FFC_0000_0000_0001;
+
+#[derive(Default)]
+struct ConnectionOrderState {
+    // An accepted loopback socket must not become visible to
+    // `server.getConnections()` until the matching client-side `connect`
+    // callback has returned to the event loop. The accept and connect tasks
+    // run concurrently, so either side can reach the main-thread queue first.
+    deferred_connections: HashMap<i64, VecDeque<i64>>,
+    // A connect callback can run before accept queues ServerConnection. Keep
+    // a per-server credit so the later accept still crosses a pump boundary.
+    completed_local_connects: HashMap<i64, usize>,
+    // The accepted socket's read task can receive bytes during that boundary.
+    // Preserve those chunks until the server `connection` callback has had a
+    // chance to install its socket listeners.
+    pending_socket_data: HashMap<i64, VecDeque<Bytes>>,
+}
+
+fn connection_order_state() -> &'static Mutex<ConnectionOrderState> {
+    static STATE: OnceLock<Mutex<ConnectionOrderState>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(ConnectionOrderState::default()))
+}
+
+fn schedule_server_connection(server_id: i64, socket_id: i64) {
+    perry_ffi::spawn_async(async move {
+        // `js_run_stdlib_pump` can reach ext-net twice in one invocation
+        // (the stdlib feature arm and the auxiliary-pump registry). Crossing
+        // the timer boundary lets the compiled await poll observe the client
+        // callback before the server connection becomes visible.
+        tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        statics::pending_events()
+            .lock()
+            .unwrap()
+            .push(PendingNetEvent::ServerConnection(
+                server_id, socket_id, true,
+            ));
+        perry_ffi::notify_main_thread();
+    });
+}
+
+fn take_completed_local_connect(state: &mut ConnectionOrderState, server_id: i64) -> bool {
+    let remove = match state.completed_local_connects.get_mut(&server_id) {
+        Some(count) if *count > 0 => {
+            *count -= 1;
+            *count == 0
+        }
+        _ => return false,
+    };
+    if remove {
+        state.completed_local_connects.remove(&server_id);
+    }
+    true
+}
+
+fn pop_deferred_connection(state: &mut ConnectionOrderState, server_id: i64) -> Option<i64> {
+    let (socket_id, remove) = {
+        let queue = state.deferred_connections.get_mut(&server_id)?;
+        let socket_id = queue.pop_front();
+        (socket_id, queue.is_empty())
+    };
+    if remove {
+        state.deferred_connections.remove(&server_id);
+    }
+    socket_id
+}
+
+pub(crate) fn queue_server_connection(server_id: i64, socket_id: i64) -> bool {
+    let mut state = connection_order_state().lock().unwrap();
+    if !take_completed_local_connect(&mut state, server_id) {
+        return true;
+    }
+    drop(state);
+    schedule_server_connection(server_id, socket_id);
+    false
+}
+
+pub(crate) fn defer_server_connection(server_id: i64, socket_id: i64) -> bool {
+    let pending_local_connect = statics::servers()
+        .lock()
+        .unwrap()
+        .get(&server_id)
+        .is_some_and(|server| server.pending_local_connect_events > 0);
+    let mut state = connection_order_state().lock().unwrap();
+    if take_completed_local_connect(&mut state, server_id) {
+        drop(state);
+        schedule_server_connection(server_id, socket_id);
+        return true;
+    }
+    if !pending_local_connect {
+        return false;
+    }
+    state
+        .deferred_connections
+        .entry(server_id)
+        .or_default()
+        .push_back(socket_id);
+    true
+}
+
+pub(crate) fn buffer_pending_server_data(socket_id: i64, bytes: Bytes) {
+    let mut state = connection_order_state().lock().unwrap();
+    let pending_connection = statics::sockets()
+        .lock()
+        .unwrap()
+        .get(&socket_id)
+        .is_some_and(|socket| socket.server_id.is_some() && !socket.server_connection_active);
+    if !pending_connection {
+        return;
+    }
+    state
+        .pending_socket_data
+        .entry(socket_id)
+        .or_default()
+        .push_back(bytes);
+}
+
+pub(crate) fn release_pending_server_data(socket_id: i64) {
+    let chunks = connection_order_state()
+        .lock()
+        .unwrap()
+        .pending_socket_data
+        .remove(&socket_id);
+    let Some(chunks) = chunks else {
+        return;
+    };
+    let mut events = statics::pending_events().lock().unwrap();
+    events.extend(
+        chunks
+            .into_iter()
+            .map(|bytes| PendingNetEvent::Data(socket_id, bytes)),
+    );
+    drop(events);
+    perry_ffi::notify_main_thread();
+}
+
+pub(crate) fn discard_pending_server_data(socket_id: i64) {
+    connection_order_state()
+        .lock()
+        .unwrap()
+        .pending_socket_data
+        .remove(&socket_id);
+}
 
 #[derive(Debug)]
 pub(crate) struct DropInfo {
@@ -80,7 +224,7 @@ pub(crate) fn should_drop_connection(server_id: i64, stream: &TcpStream) -> Opti
     let server = servers.get_mut(&server_id)?;
     if server
         .max_connections
-        .is_some_and(|max| server.active_connections >= max)
+        .is_some_and(|max| server.active_connections + server.pending_connections >= max)
         && server.drop_max_connection.unwrap_or(false)
     {
         return Some(DropInfo {
@@ -88,16 +232,104 @@ pub(crate) fn should_drop_connection(server_id: i64, stream: &TcpStream) -> Opti
             remote: stream.peer_addr().ok(),
         });
     }
-    server.active_connections += 1;
+    server.pending_connections += 1;
     None
 }
 
-pub(crate) fn socket_closed(server_id: i64) {
-    if let Ok(mut servers) = statics::servers().lock() {
-        if let Some(server) = servers.get_mut(&server_id) {
+pub(crate) fn cancel_pending_connection(server_id: i64) {
+    if let Some(server) = statics::servers().lock().unwrap().get_mut(&server_id) {
+        server.pending_connections = server.pending_connections.saturating_sub(1);
+    }
+}
+
+pub(crate) fn begin_local_connect(host: &str, port: u16) -> Option<(i64, bool)> {
+    if !matches!(host, "localhost" | "127.0.0.1" | "::1" | "0.0.0.0") {
+        return None;
+    }
+    let mut servers = statics::servers().lock().ok()?;
+    let (server_id, server) = servers
+        .iter_mut()
+        .find(|(_, server)| server.listening && server.bound_port == port)?;
+    let completed = connection_order_state()
+        .lock()
+        .unwrap()
+        .completed_local_connects
+        .get(server_id)
+        .copied()
+        .unwrap_or(0);
+    let expects_drop = server.drop_max_connection.unwrap_or(false)
+        && server.max_connections.is_some_and(|max| {
+            server.active_connections + server.pending_connections + completed >= max
+        });
+    server.pending_local_connect_events += 1;
+    Some((*server_id, expects_drop))
+}
+
+fn complete_local_connect(local_server: Option<(i64, bool)>, connected: bool) {
+    let Some((server_id, expects_drop)) = local_server else {
+        return;
+    };
+    if let Some(server) = statics::servers().lock().unwrap().get_mut(&server_id) {
+        server.pending_local_connect_events = server.pending_local_connect_events.saturating_sub(1);
+    }
+    if !connected || expects_drop {
+        return;
+    }
+    let mut state = connection_order_state().lock().unwrap();
+    let socket_id = pop_deferred_connection(&mut state, server_id);
+    if let Some(socket_id) = socket_id {
+        drop(state);
+        schedule_server_connection(server_id, socket_id);
+    } else {
+        *state.completed_local_connects.entry(server_id).or_default() += 1;
+    }
+}
+
+pub(crate) fn finish_local_connect(local_server: Option<(i64, bool)>) {
+    complete_local_connect(local_server, true);
+}
+
+pub(crate) fn cancel_local_connect(local_server: Option<(i64, bool)>) {
+    complete_local_connect(local_server, false);
+}
+
+pub(crate) fn activate_connection(server_id: i64, socket_id: i64) {
+    let mut sockets = statics::sockets().lock().unwrap();
+    let Some(socket) = sockets.get_mut(&socket_id) else {
+        return;
+    };
+    if socket.server_id != Some(server_id) || socket.server_connection_active {
+        return;
+    }
+    socket.server_connection_active = true;
+    if let Some(server) = statics::servers().lock().unwrap().get_mut(&server_id) {
+        server.pending_connections = server.pending_connections.saturating_sub(1);
+        server.active_connections += 1;
+    }
+}
+
+pub(crate) fn mark_socket_closed(socket_id: i64) {
+    let mut sockets = statics::sockets().lock().unwrap();
+    let Some(socket) = sockets.get_mut(&socket_id) else {
+        return;
+    };
+    socket.is_open = false;
+    let Some(server_id) = socket.server_id.take() else {
+        return;
+    };
+    if let Some(server) = statics::servers().lock().unwrap().get_mut(&server_id) {
+        if socket.server_connection_active {
             server.active_connections = server.active_connections.saturating_sub(1);
+        } else {
+            server.pending_connections = server.pending_connections.saturating_sub(1);
         }
     }
+}
+
+pub(crate) fn remove_server(server_id: i64) {
+    let mut state = connection_order_state().lock().unwrap();
+    state.deferred_connections.remove(&server_id);
+    state.completed_local_connects.remove(&server_id);
 }
 
 /// Returns true while queued net events, connecting/open sockets, or listening
@@ -179,4 +411,35 @@ pub extern "C" fn js_net_server_set_drop_max_connection(handle: i64, value: f64)
         }
     }
     value
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deferred_connections_are_fifo_and_remove_empty_server_queues() {
+        let mut state = ConnectionOrderState::default();
+        state
+            .deferred_connections
+            .insert(7, VecDeque::from([101, 102]));
+
+        assert_eq!(pop_deferred_connection(&mut state, 7), Some(101));
+        assert!(state.deferred_connections.contains_key(&7));
+        assert_eq!(pop_deferred_connection(&mut state, 7), Some(102));
+        assert!(!state.deferred_connections.contains_key(&7));
+        assert_eq!(pop_deferred_connection(&mut state, 7), None);
+    }
+
+    #[test]
+    fn completed_connect_credits_are_consumed_and_removed() {
+        let mut state = ConnectionOrderState::default();
+        state.completed_local_connects.insert(7, 2);
+
+        assert!(take_completed_local_connect(&mut state, 7));
+        assert_eq!(state.completed_local_connects.get(&7), Some(&1));
+        assert!(take_completed_local_connect(&mut state, 7));
+        assert!(!state.completed_local_connects.contains_key(&7));
+        assert!(!take_completed_local_connect(&mut state, 7));
+    }
 }

--- a/test-parity/node-suite/net/server/connection-state-limits.ts
+++ b/test-parity/node-suite/net/server/connection-state-limits.ts
@@ -6,27 +6,22 @@ function getConnections(server: net.Server): Promise<[any, number]> {
   });
 }
 
+let serverConnectionCount = 0;
+let acceptedError: any;
+let dropData: any;
+
+// The relative order of the independent client-side "connect" and
+// server-side "drop" callbacks varies across Node runs. Buffer those
+// observations so this fixture measures connection state, not scheduler luck.
 const server = net.createServer((socket) => {
-  console.log("server connection");
+  serverConnectionCount++;
   socket.on("error", (err: any) => {
-    console.log("accepted error:", err.code || err.message);
+    acceptedError = err;
   });
 });
 
 server.on("drop", (data: any) => {
-  console.log("server drop keys:", Object.keys(data).sort().join(","));
-  console.log(
-    "server drop local:",
-    typeof data.localAddress,
-    typeof data.localPort,
-    data.localFamily,
-  );
-  console.log(
-    "server drop remote:",
-    typeof data.remoteAddress,
-    typeof data.remotePort,
-    data.remoteFamily,
-  );
+  dropData = data;
 });
 server.on("close", () => console.log("server close event"));
 
@@ -69,11 +64,46 @@ const [oneErr, oneCount] = await getConnections(server);
 console.log("getConnections one:", oneErr && oneErr.name, oneCount);
 
 const client2 = net.connect(port, "127.0.0.1");
-client2.on("connect", () => console.log("client2 connected"));
-client2.on("error", (err: any) => console.log("client2 error:", err.name, err.code));
-client2.on("close", (hadError) => console.log("client2 close:", hadError));
+let client2Connected = false;
+let client2Error: any;
+let client2Close: boolean | undefined;
+client2.on("connect", () => {
+  client2Connected = true;
+});
+client2.on("error", (err: any) => {
+  client2Error = err;
+});
+client2.on("close", (hadError) => {
+  client2Close = hadError;
+});
 
 await new Promise((resolve) => setTimeout(resolve, 300));
+for (let i = 0; i < serverConnectionCount; i++) {
+  console.log("server connection");
+}
+if (acceptedError) {
+  console.log("accepted error:", acceptedError.code || acceptedError.message);
+}
+console.log("server drop keys:", Object.keys(dropData).sort().join(","));
+console.log(
+  "server drop local:",
+  typeof dropData.localAddress,
+  typeof dropData.localPort,
+  dropData.localFamily,
+);
+console.log(
+  "server drop remote:",
+  typeof dropData.remoteAddress,
+  typeof dropData.remotePort,
+  dropData.remoteFamily,
+);
+if (client2Connected) {
+  console.log("client2 connected");
+}
+if (client2Error) {
+  console.log("client2 error:", client2Error.name, client2Error.code);
+}
+console.log("client2 close:", client2Close);
 const [afterErr, afterCount] = await getConnections(server);
 console.log("getConnections after second:", afterErr && afterErr.name, afterCount);
 


### PR DESCRIPTION
## Summary

- distinguish accepted-but-undispatched sockets from active server connections, so `getConnections()` matches Node callback visibility
- preserve `maxConnections` admission accounting with pending reservations and release the correct counter on close/refusal
- correlate same-process loopback connect/accept events across Perry’s duplicate ext-net pump paths, moving the existing 1 ms handoff from the client callback to the matched server callback
- make the parity fixture deterministic around Node’s nondeterministic ordering of independent `drop` and client events

## Validation

- `cargo check -p perry-ext-net`
- `cargo test -p perry-ext-net --lib` (25 passed)
- `cargo fmt --all -- --check`
- `git diff --check`
- `bash scripts/check_file_size.sh`
- focused `connection-state-limits` parity: 7 consecutive passes after the final scheduler design
- `./run_parity_tests.sh --suite node-suite --module net` (13/13, 100%)

Closes #6790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `node:net` loopback connection event ordering for more consistent callback behavior.
  * Improved `Server#getConnections()` visibility so accepted connections are surfaced at the correct time.
  * Preserved accurate `maxConnections` admission and drop accounting, including correct handling of pending/queued connections.
  * Improved connection cleanup and buffering/release behavior for data received before server listeners are installed.
* **Tests**
  * Updated connection-state-limit coverage to capture accept/drop outcomes more deterministically across runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->