### PR TITLE
fix(fetch): report FormData constructor arity

### DIFF
--- a/changelog.d/6789-form-data-constructor-length.md
+++ b/changelog.d/6789-form-data-constructor-length.md
@@ -1,0 +1,1 @@
+**Fetch parity:** report the spec-correct zero-argument `FormData.length` when the constructor is read through Perry's AOT-lowered global path.

--- a/crates/perry-hir/src/analysis/builtins.rs
+++ b/crates/perry-hir/src/analysis/builtins.rs
@@ -183,9 +183,8 @@ pub(crate) fn is_builtin_global_value_name(name: &str) -> bool {
 /// (`Array.length === 1`, `Date.length === 7`, …). Folding the read here at
 /// lowering time yields the spec constant directly.
 ///
-/// Returns `None` for names that are *not* standard constructors with a
-/// well-defined `.length` (`globalThis`, `process`, `console`, `Buffer`,
-/// `TextEncoderStream`, `TextDecoderStream`) — those keep their existing
+/// Returns `None` for names that are *not* constructors tracked by this
+/// table (`globalThis`, `process`, `console`, …) — those keep their existing
 /// lowering so the read falls through to the runtime unchanged.
 ///
 /// Only consulted when the receiver lowered to bare `GlobalGet(0)` (no local
@@ -198,7 +197,8 @@ pub(crate) fn builtin_constructor_length(name: &str) -> Option<u32> {
             1
         }
         "Symbol" | "Map" | "Set" | "WeakMap" | "WeakSet" | "MessageChannel" | "MessagePort"
-        | "Navigator" | "TextEncoderStream" | "TextDecoderStream" | "DOMException" | "Storage" => 0,
+        | "Navigator" | "TextEncoderStream" | "TextDecoderStream" | "DOMException" | "Storage"
+        | "FormData" => 0,
         "CompressionStream" | "DecompressionStream" => 1,
         "RegExp" | "Proxy" | "File" => 2,
         "BroadcastChannel" => 1,
@@ -209,6 +209,16 @@ pub(crate) fn builtin_constructor_length(name: &str) -> Option<u32> {
         _ => return None,
     };
     Some(len)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::builtin_constructor_length;
+
+    #[test]
+    fn form_data_constructor_has_zero_declared_parameters() {
+        assert_eq!(builtin_constructor_length("FormData"), Some(0));
+    }
 }
 
 /// Spec-defined `.length` for callable global function values that lower as


### PR DESCRIPTION
## Summary
- teach the AOT HIR constructor metadata fold that FormData declares zero parameters
- add a focused regression test for the shared constructor-length lookup
- correct the stale lookup documentation and add the required changelog fragment

## Test plan
- cargo fmt --all -- --check
- cargo test -p perry-hir form_data_constructor_has_zero_declared_parameters
- cargo check -p perry-hir
- ./run_parity_tests.sh --suite node-suite --module fetch --filter constructor-mutators (1/1)
- ./run_parity_tests.sh --suite node-suite --module fetch (12/12)

Closes #6789.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `FormData.length` to return the standards-compliant value of `0` when accessed through ahead-of-time compiled global code.
* **Documentation**
  * Updated the changelog to document the corrected `FormData.length` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->