### PR TITLE
fix(path): link regex runtime for matchesGlob dispatch

### DIFF
--- a/changelog.d/6787-path-matches-glob-feature.md
+++ b/changelog.d/6787-path-matches-glob-feature.md
@@ -1,0 +1,1 @@
+fix(path): link the regex engine when `matchesGlob` is reached through Win32 or dynamic sub-namespace dispatch.

--- a/crates/perry/src/commands/compile/collect_modules/feature_detect.rs
+++ b/crates/perry/src/commands/compile/collect_modules/feature_detect.rs
@@ -10,6 +10,25 @@
 use super::crypto_ns::module_uses_global_crypto_namespace;
 use crate::commands::compile::CompilationContext;
 
+fn debug_hir_uses_regex(hir_debug: &str) -> bool {
+    hir_debug.contains("RegExp") // RegExp / RegExpDynamic / RegExpTest / RegExpExec / RegExpEscape / RegExpReplaceFn / RegExpExec{Index,Groups}
+        || hir_debug.contains("StringMatch") // dedicated .match / .matchAll variants
+        // Covers both `PathMatchesGlob` and
+        // `PathWin32 { method: MatchesGlob, ... }`.
+        || hir_debug.contains("MatchesGlob")
+        // Dynamic sub-namespace dispatch keeps the method name in a
+        // runtime-dispatch expression, but its Debug representation is not
+        // guaranteed to be a plain `method: "..."` field. Match the API name
+        // itself: a false positive only links the optional engine, whereas a
+        // false negative makes `matchesGlob` silently return false.
+        || hir_debug.contains("matchesGlob")
+        || hir_debug.contains("property: \"search\"")
+        || hir_debug.contains("property: \"match\"")
+        || hir_debug.contains("property: \"matchAll\"")
+        || hir_debug.contains("property: \"glob\"")
+        || hir_debug.contains("property: \"globSync\"")
+}
+
 /// Inspect a lowered module and set the optional-feature gates it needs.
 pub(super) fn detect_optional_feature_usage(
     ctx: &mut CompilationContext,
@@ -122,15 +141,7 @@ pub(super) fn detect_optional_feature_usage(
     // non-functional in Perry so it can't create a regex at runtime.
     {
         let hir_debug: String = format!("{:?}{:?}", &hir_module.init, &hir_module.functions);
-        if hir_debug.contains("RegExp")            // RegExp / RegExpDynamic / RegExpTest / RegExpExec / RegExpEscape / RegExpReplaceFn / RegExpExec{Index,Groups}
-            || hir_debug.contains("StringMatch")   // dedicated .match / .matchAll variants
-            || hir_debug.contains("PathMatchesGlob")
-            || hir_debug.contains("property: \"search\"")
-            || hir_debug.contains("property: \"match\"")
-            || hir_debug.contains("property: \"matchAll\"")
-            || hir_debug.contains("property: \"glob\"")
-            || hir_debug.contains("property: \"globSync\"")
-        {
+        if debug_hir_uses_regex(&hir_debug) {
             ctx.uses_regex = true;
         }
     }
@@ -330,5 +341,20 @@ pub(super) fn detect_optional_feature_usage(
     if found_ioredis {
         ctx.needs_stdlib = true;
         ctx.native_module_imports.insert("ioredis".to_string());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::debug_hir_uses_regex;
+
+    #[test]
+    fn regex_gate_detects_static_and_dynamic_path_matches_glob() {
+        assert!(debug_hir_uses_regex(
+            r#"PathWin32 { method: MatchesGlob, args: [] }"#
+        ));
+        assert!(debug_hir_uses_regex(
+            r#"NativeMethodCall { module: String("path.win32"), method: String("matchesGlob"), args: [] }"#
+        ));
     }
 }


### PR DESCRIPTION
## Summary

- recognize static Win32 `matchesGlob` HIR when selecting the optional regex runtime
- recognize dynamically dispatched `path[k].matchesGlob(...)` even when the method name is wrapped in the lowered HIR debug form
- add detector coverage for both lowering shapes

Without the regex feature, the runtime fallback made every `matchesGlob` call return `false` in size-optimized binaries.

## Validation

- `cargo build --release -p perry`
- `./run_parity_tests.sh --suite node-suite --module path --filter method-dispatch` — 1/1
- `./run_parity_tests.sh --suite node-suite --module path --filter win32-separators` — 1/1
- `./run_parity_tests.sh --suite node-suite --module path` — 92/92, zero failures or crashes

Closes #6787

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `path.matchesGlob` handling for Windows and dynamically dispatched calls.
  * Ensured the required pattern-matching support is correctly enabled in these scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->