### PR TITLE
fix(http2): align request headers and loopback session order

### DIFF
--- a/changelog.d/6786-http2-request-session-order.md
+++ b/changelog.d/6786-http2-request-session-order.md
@@ -1,0 +1,1 @@
+fix(http2): expose pseudo-headers on server requests and match Node's loopback client/server session event order.

--- a/crates/perry-ext-http-server/src/http2_server.rs
+++ b/crates/perry-ext-http-server/src/http2_server.rs
@@ -77,8 +77,8 @@ pub(crate) use pump::{
 };
 pub(crate) use session::{
     h2_listening_server_for_authority, local_client_connect_ready, local_server_handle_for_client,
-    mark_server_sessions_closed, mark_session_closed, parse_headers_object,
-    register_server_session, start_client_request,
+    local_server_session_event_ready, mark_server_sessions_closed, mark_session_closed,
+    parse_headers_object, register_server_session, start_client_request,
 };
 
 // `handle_h2_request` is consumed by `js_node_http2_server_listen` below.
@@ -126,7 +126,13 @@ pub struct Http2SecureServer {
 
 pub struct Http2SessionHandle {
     pub server_handle: i64,
+    /// Client-side local TCP port / server-side peer TCP port. A loopback
+    /// client reserves and records its local port before connecting, so the
+    /// two independently-created session handles can be paired without
+    /// relying on global event order.
+    pub connection_port: u16,
     pub session_event_emitted: bool,
+    pub connect_event_emitted: bool,
     pub session_type: i32,
     pub connected: bool,
     pub encrypted: bool,
@@ -541,7 +547,8 @@ pub unsafe extern "C" fn js_node_http2_server_listen(server_handle: i64, args_ar
                                 let acceptor = acceptor.clone();
                                 let request_tx = request_tx_for_spawn.clone();
                                 tokio::spawn(async move {
-                                    let session_handle = register_server_session(server_handle);
+                                    let session_handle =
+                                        register_server_session(server_handle, peer);
                                     match acceptor {
                                         Some(acceptor) => {
                                             let tls_stream = match acceptor.accept(stream).await {

--- a/crates/perry-ext-http-server/src/http2_server/pump.rs
+++ b/crates/perry-ext-http-server/src/http2_server/pump.rs
@@ -273,20 +273,10 @@ pub(crate) fn has_active_h2_clients() -> bool {
 }
 
 pub(crate) fn process_pending_h2_events() -> i32 {
-    let mut events: Vec<Http2PendingEvent> = match H2_PENDING_EVENTS.lock() {
+    let events: Vec<Http2PendingEvent> = match H2_PENDING_EVENTS.lock() {
         Ok(mut q) => q.drain(..).collect(),
         Err(_) => return 0,
     };
-    // Causally, the server creates its session and sends its SETTINGS frame
-    // before a client can complete its connect handshake, so the server-side
-    // `session` event fires BEFORE the client-side `connect` (Node on Linux:
-    // `server>client`). Drain `Session` first so a single-process loopback
-    // observes `session` then `connect`, matching the causal/Linux ordering.
-    events.sort_by_key(|event| match event {
-        Http2PendingEvent::Session { .. } => 0,
-        Http2PendingEvent::ClientConnect { .. } => 1,
-        _ => 2,
-    });
     let count = events.len() as i32;
     for event in events {
         match event {
@@ -294,6 +284,13 @@ pub(crate) fn process_pending_h2_events() -> i32 {
                 server_handle,
                 session_handle,
             } => {
+                if !local_server_session_event_ready(session_handle) {
+                    push_h2_event(Http2PendingEvent::Session {
+                        server_handle,
+                        session_handle,
+                    });
+                    continue;
+                }
                 let listeners = get_handle::<Http2SecureServer>(server_handle)
                     .and_then(|s| s.base.listeners.get("session").cloned())
                     .unwrap_or_default();
@@ -321,6 +318,9 @@ pub(crate) fn process_pending_h2_events() -> i32 {
                     unsafe {
                         js_promise_run_microtasks();
                     }
+                }
+                if let Some(session) = get_handle_mut::<Http2SessionHandle>(session_handle) {
+                    session.connect_event_emitted = true;
                 }
             }
             Http2PendingEvent::ClientResponse {
@@ -485,4 +485,69 @@ pub(crate) fn process_pending_h2_events() -> i32 {
         }
     }
     count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    fn test_session(
+        server_handle: i64,
+        session_type: i32,
+        connection_port: u16,
+        connect_event_emitted: bool,
+    ) -> Http2SessionHandle {
+        Http2SessionHandle {
+            server_handle,
+            connection_port,
+            session_event_emitted: false,
+            connect_event_emitted,
+            session_type,
+            connected: true,
+            encrypted: false,
+            alpn_protocol: "h2c".to_string(),
+            connecting: false,
+            closed: false,
+            destroyed: false,
+            pending_settings_ack: false,
+            authority: String::new(),
+            local_settings: Http2SettingsState::default(),
+            remote_settings: Http2SettingsState::default(),
+            local_window_size: 65_535,
+            sender: Arc::new(Mutex::new(None)),
+            listeners: HashMap::new(),
+            close_callbacks: Vec::new(),
+            pending_callbacks: Vec::new(),
+            timeout_callback: 0,
+        }
+    }
+
+    #[test]
+    fn loopback_session_waits_only_for_its_paired_client() {
+        let server_handle = i64::MAX - 6786;
+        let client_a = register_handle(test_session(server_handle, 1, 41_001, true));
+        let client_b = register_handle(test_session(server_handle, 1, 41_002, false));
+        let server_a = register_handle(test_session(server_handle, 0, 41_001, false));
+        let server_b = register_handle(test_session(server_handle, 0, 41_002, false));
+
+        assert!(
+            local_server_session_event_ready(server_a),
+            "client B must not delay client A's paired server session"
+        );
+        assert!(
+            !local_server_session_event_ready(server_b),
+            "a server session must wait for its own client connect callback"
+        );
+
+        get_handle_mut::<Http2SessionHandle>(client_b)
+            .unwrap()
+            .connect_event_emitted = true;
+        assert!(local_server_session_event_ready(server_b));
+
+        // Keep the handles visibly used so future cleanup instrumentation
+        // cannot optimize this into a single-pair test.
+        assert_ne!(client_a, client_b);
+    }
 }

--- a/crates/perry-ext-http-server/src/http2_server/session.rs
+++ b/crates/perry-ext-http-server/src/http2_server/session.rs
@@ -4,6 +4,8 @@
 use super::*;
 
 use std::collections::HashMap;
+use std::io;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::{Arc, Mutex};
 
 use bytes::Bytes;
@@ -18,10 +20,12 @@ use crate::ensure_gc_scanner_registered;
 use crate::http2_session_settings::Http2SettingsState;
 use crate::types::jsvalue_to_owned_string;
 
-pub(crate) fn register_server_session(server_handle: i64) -> i64 {
+pub(crate) fn register_server_session(server_handle: i64, peer_addr: SocketAddr) -> i64 {
     let session_handle = register_handle(Http2SessionHandle {
         server_handle,
+        connection_port: peer_addr.port(),
         session_event_emitted: false,
+        connect_event_emitted: false,
         session_type: 0,
         connected: true,
         encrypted: false,
@@ -148,6 +152,95 @@ pub(crate) fn local_client_connect_ready(session_handle: i64) -> bool {
     has_active_server_session(server_handle)
 }
 
+pub(crate) fn local_server_session_event_ready(server_session_handle: i64) -> bool {
+    let Some(server_session) = get_handle::<Http2SessionHandle>(server_session_handle) else {
+        return true;
+    };
+    if server_session.session_type != 0
+        || server_session.server_handle == 0
+        || server_session.connection_port == 0
+    {
+        return true;
+    }
+    let server_handle = server_session.server_handle;
+    let connection_port = server_session.connection_port;
+    let mut ready = true;
+    iter_handles_of::<Http2SessionHandle, _>(|session| {
+        if session.session_type == 1
+            && session.server_handle == server_handle
+            && session.connection_port == connection_port
+            && !session.closed
+            && !session.destroyed
+            && !session.connect_event_emitted
+        {
+            ready = false;
+        }
+    });
+    ready
+}
+
+async fn connect_h2_stream(
+    host: &str,
+    port: u16,
+    session_handle: i64,
+    reserve_pairing_port: bool,
+) -> io::Result<tokio::net::TcpStream> {
+    if !reserve_pairing_port {
+        return tokio::net::TcpStream::connect(format!("{host}:{port}")).await;
+    }
+
+    // A same-process server accepts on another Tokio runtime. Reserve and
+    // publish the client's ephemeral port *before* connect(), so whichever
+    // runtime wakes first can pair the server session with this exact client.
+    // The peer port observed by accept() is the same reserved port.
+    let addresses: Vec<_> = tokio::net::lookup_host((host, port)).await?.collect();
+    let mut last_error = None;
+    for address in addresses {
+        let socket = if address.is_ipv4() {
+            tokio::net::TcpSocket::new_v4()
+        } else {
+            tokio::net::TcpSocket::new_v6()
+        };
+        let socket = match socket {
+            Ok(socket) => socket,
+            Err(err) => {
+                last_error = Some(err);
+                continue;
+            }
+        };
+        let bind_addr = if address.is_ipv4() {
+            SocketAddr::from((Ipv4Addr::UNSPECIFIED, 0))
+        } else {
+            SocketAddr::from((Ipv6Addr::UNSPECIFIED, 0))
+        };
+        if let Err(err) = socket.bind(bind_addr) {
+            last_error = Some(err);
+            continue;
+        }
+        let local_port = match socket.local_addr() {
+            Ok(local) => local.port(),
+            Err(err) => {
+                last_error = Some(err);
+                continue;
+            }
+        };
+        if let Some(session) = get_handle_mut::<Http2SessionHandle>(session_handle) {
+            session.connection_port = local_port;
+        }
+        match socket.connect(address).await {
+            Ok(stream) => return Ok(stream),
+            Err(err) => last_error = Some(err),
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::AddrNotAvailable,
+            format!("no address resolved for {host}:{port}"),
+        )
+    }))
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn js_node_http2_connect(
     authority_f64: f64,
@@ -174,7 +267,9 @@ pub unsafe extern "C" fn js_node_http2_connect(
     }
     let session_handle = register_handle(Http2SessionHandle {
         server_handle: local_server_handle,
+        connection_port: 0,
         session_event_emitted: false,
+        connect_event_emitted: false,
         session_type: 1,
         connected: false,
         encrypted: false,
@@ -200,8 +295,14 @@ pub unsafe extern "C" fn js_node_http2_connect(
             .build()
             .expect("Failed to create http2 client runtime");
         runtime.block_on(async move {
-            let addr = format!("{}:{}", host, port);
-            let stream = match tokio::net::TcpStream::connect(&addr).await {
+            let stream = match connect_h2_stream(
+                &host,
+                port,
+                session_handle,
+                local_server_handle != 0,
+            )
+            .await
+            {
                 Ok(stream) => {
                     // Node default: TCP_NODELAY on for a freshly-connected socket.
                     let _ = stream.set_nodelay(true);

--- a/crates/perry-ext-http-server/src/request.rs
+++ b/crates/perry-ext-http-server/src/request.rs
@@ -249,7 +249,7 @@ pub(crate) fn incoming_http_version_part(handle: i64, minor: bool) -> f64 {
 #[no_mangle]
 pub extern "C" fn js_node_http_im_headers_json(handle: i64) -> *mut StringHeader {
     let s = get_handle::<IncomingMessage>(handle)
-        .map(|im| combined_headers_json(&im.raw_headers))
+        .map(|im| combined_headers_json(&im.raw_headers, Some(&im.headers)))
         .unwrap_or_else(|| "{}".to_string());
     alloc_string(&s).as_raw()
 }
@@ -282,12 +282,20 @@ fn is_single_value_header(name: &str) -> bool {
     )
 }
 
-/// Build the combined `req.headers` JSON object from the raw
-/// `(name, value)` pairs, applying Node's `matchKnownFields` rules
-/// (#5079): `set-cookie` → string array (even for one cookie),
-/// single-value fields keep-first, everything else joined with `, `.
-/// Keys are lower-cased to match Node's `headers` view.
-fn combined_headers_json(raw: &[(String, String)]) -> String {
+/// Build the combined `req.headers` JSON object from the raw `(name, value)`
+/// pairs, applying Node's `matchKnownFields` rules (#5079): `set-cookie` →
+/// string array (even for one cookie), single-value fields keep-first,
+/// everything else joined with `, `. Keys are lower-cased to match Node's
+/// `headers` view.
+///
+/// HTTP/2 pseudo-headers are synthesized into `IncomingMessage::headers` but
+/// intentionally omitted from `rawHeaders`. Add entries missing from the raw
+/// view after combining so `req.headers[":path"]` and its peers remain visible
+/// without leaking them into `rawHeaders`.
+fn combined_headers_json(
+    raw: &[(String, String)],
+    supplemental: Option<&HashMap<String, String>>,
+) -> String {
     use serde_json::Value;
     // Key order in the serialized object is not significant here (the
     // previous `HashMap` serialization was already unordered); what
@@ -317,6 +325,12 @@ fn combined_headers_json(raw: &[(String, String)]) -> String {
             _ => {
                 map.insert(key, Value::String(value.clone()));
             }
+        }
+    }
+    if let Some(supplemental) = supplemental {
+        for (name, value) in supplemental {
+            map.entry(name.to_ascii_lowercase())
+                .or_insert_with(|| Value::String(value.clone()));
         }
     }
     serde_json::to_string(&Value::Object(map)).unwrap_or_else(|_| "{}".to_string())
@@ -1124,6 +1138,21 @@ mod add_header_line_tests {
         assert_eq!(kind("Cookie"), (2, "cookie".to_string()));
         assert_eq!(kind("Set-Cookie"), (3, "set-cookie".to_string()));
         assert_eq!(kind("set-cookie"), (3, "set-cookie".to_string()));
+    }
+
+    #[test]
+    fn combined_headers_adds_http2_pseudo_headers_without_overwriting_raw_values() {
+        let raw = vec![("X-Test".to_string(), "raw".to_string())];
+        let supplemental = HashMap::from([
+            (":method".to_string(), "GET".to_string()),
+            (":path".to_string(), "/probe?x=1".to_string()),
+            ("x-test".to_string(), "supplemental".to_string()),
+        ]);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&combined_headers_json(&raw, Some(&supplemental))).unwrap();
+        assert_eq!(parsed["x-test"], "raw");
+        assert_eq!(parsed[":method"], "GET");
+        assert_eq!(parsed[":path"], "/probe?x=1");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- merge synthesized HTTP/2 pseudo-headers into the compatibility `Http2ServerRequest.headers` view without exposing them through `rawHeaders`
- deliver a same-process client `connect` callback before the paired server `session` callback, including when the events arrive in separate pump drains
- add unit guards for pseudo-header merging and same-batch event priority

## Validation

- `cargo build --release -p perry-ext-http`
- compared Node and Perry output byte-for-byte for all 9 `test-parity/node-suite/http2` fixtures using the supported no-auto runtime/archive path — 9/9 matched
- repaired fixtures matched all 18 lines (`plaintext/loopback-streams`) and all 14 lines (`session/controls`)

Closes #6786

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - HTTP/2 request headers now include pseudo-headers (e.g., `:method`, `:path`) alongside raw headers.
  - When adding HTTP/2 pseudo-headers, existing raw header values are preserved and never overwritten.
  - HTTP/2 loopback connection events and server session events now occur in the correct order, with server session dispatch waiting only for its paired client’s connect readiness.
- **Tests**
  - Added coverage to ensure server sessions aren’t delayed by unrelated clients.
- **Documentation**
  - Updated the changelog with the HTTP/2 header and event-ordering fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->