### PR TITLE
fix(codegen): address object-write review feedback

### DIFF
--- a/changelog.d/6821-review-followups.md
+++ b/changelog.d/6821-review-followups.md
@@ -1,0 +1,1 @@
+fix(codegen): preserve immutable literal key and loop-bound metadata when a local uses module-global or boxed storage, and share static property-key resolution across object-write optimizers.

--- a/crates/perry-codegen/src/expr/proxy_reflect.rs
+++ b/crates/perry-codegen/src/expr/proxy_reflect.rs
@@ -1081,10 +1081,16 @@ fn lower_put_value_dyn_ic_inline(
     Ok(result)
 }
 
-fn static_write_key(ctx: &FnCtx<'_>, key: &Expr) -> Option<String> {
+pub(crate) fn static_string_write_key(ctx: &FnCtx<'_>, key: &Expr) -> Option<String> {
     match key {
         Expr::String(property) => Some(property.clone()),
         Expr::LocalGet(id) => ctx.const_string_locals.get(id).cloned(),
+        _ => None,
+    }
+}
+
+pub(crate) fn static_write_key(ctx: &FnCtx<'_>, key: &Expr) -> Option<String> {
+    static_string_write_key(ctx, key).or_else(|| match key {
         // #6812 (w13): `o[7] = v` — a constant integer key is the canonical
         // numeric-string property key ("7"; i64 formatting is canonical for
         // every integer, including negatives). Real arrays never take the IC
@@ -1093,7 +1099,7 @@ fn static_write_key(ctx: &FnCtx<'_>, key: &Expr) -> Option<String> {
         // generic write, which performs the element store.
         Expr::Integer(n) => Some(n.to_string()),
         _ => None,
-    }
+    })
 }
 
 fn put_value_rhs_is_safepoint_free(ctx: &FnCtx<'_>, expr: &Expr) -> bool {

--- a/crates/perry-codegen/src/stmt/let_stmt.rs
+++ b/crates/perry-codegen/src/stmt/let_stmt.rs
@@ -93,8 +93,21 @@ pub(crate) fn lower_let(
     // class-alias chain resolution below (and any other site
     // that needs id → name) can use it.
     ctx.local_id_to_name.insert(id, name.to_string());
+    // Record immutable literal metadata before the module-global and boxed
+    // storage paths return. The loop/PIC matchers reason from the HIR local id,
+    // so the storage representation does not change the const proof.
     if !mutable {
         if let Some(init_expr) = init {
+            if let perry_hir::Expr::String(value) = init_expr {
+                ctx.const_string_locals.insert(id, value.clone());
+            }
+            if let Some(value) = match init_expr {
+                perry_hir::Expr::Integer(value) => Some(*value as f64),
+                perry_hir::Expr::Number(value) if value.is_finite() => Some(*value),
+                _ => None,
+            } {
+                ctx.const_number_locals.insert(id, value);
+            }
             if let Some(props) = crate::lower_call::extract_options_fields(ctx, init_expr) {
                 ctx.option_object_locals.insert(id, props);
             }
@@ -1964,18 +1977,6 @@ pub(crate) fn lower_let(
         // of TAG_UNDEFINED (a NaN that fails all numeric comparisons).
         let lit = crate::nanbox::double_literal(*cv);
         ctx.block().store(DOUBLE, &lit, &slot);
-    }
-    if !mutable {
-        if let Some(perry_hir::Expr::String(value)) = init {
-            ctx.const_string_locals.insert(id, value.clone());
-        }
-        if let Some(value) = init.and_then(|expr| match expr {
-            perry_hir::Expr::Integer(value) => Some(*value as f64),
-            perry_hir::Expr::Number(value) if value.is_finite() => Some(*value),
-            _ => None,
-        }) {
-            ctx.const_number_locals.insert(id, value);
-        }
     }
     Ok(())
 }

--- a/crates/perry-codegen/src/stmt/loops.rs
+++ b/crates/perry-codegen/src/stmt/loops.rs
@@ -2740,18 +2740,7 @@ fn match_object_array_write_loop(
                 // v1: a table-driven lane must be the group's only store.
                 return None;
             }
-            let property = match key.as_ref() {
-                Expr::String(property) => property.clone(),
-                Expr::LocalGet(id) => ctx.const_string_locals.get(id).cloned()?,
-                // #6812 (w13): `o[7] = v` — a constant integer key IS the
-                // canonical numeric-string property ("7") on a plain
-                // object. Receivers that are real arrays at runtime are
-                // safe: the preflight guard type-checks every element as
-                // GC_TYPE_OBJECT and rejects the nest, and the per-write
-                // fallback handles element writes generically.
-                Expr::Integer(n) => n.to_string(),
-                _ => return None,
-            };
+            let property = crate::expr::proxy_reflect::static_write_key(ctx, key.as_ref())?;
             let value =
                 match_object_array_write_number(value, outer_counter_id, inner_counter_id, &temps)?;
             // Same size budget as the temps: a value combining several
@@ -3702,11 +3691,9 @@ fn match_class_field_versioned_loop(
             if t != r {
                 return None;
             }
-            let prop = match key.as_ref() {
-                Expr::String(prop) => prop.clone(),
-                Expr::LocalGet(id) => ctx.const_string_locals.get(id).cloned()?,
-                _ => return None,
-            };
+            // Keep this class-field clone's existing string-only contract;
+            // integer keys are handled by the general object-write matcher.
+            let prop = crate::expr::proxy_reflect::static_string_write_key(ctx, key.as_ref())?;
             recv = Some(*t);
             if !class_field_loop_pure_expr_collect(ctx, value, counter_id, &mut recv, &mut props) {
                 return None;

--- a/crates/perry-codegen/tests/native_proof_regressions.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions.rs
@@ -14485,6 +14485,52 @@ fn immutable_string_key_reuses_static_write_pic() {
 }
 
 #[test]
+fn module_global_immutable_string_key_reuses_static_write_pic() {
+    let key = 2u32;
+    let object = 3u32;
+    let mut module = module_with_classes_and_params(
+        "module_global_immutable_string_key_write_pic",
+        Vec::new(),
+        Vec::new(),
+        Type::String,
+        vec![Stmt::Return(Some(Expr::LocalGet(key)))],
+    );
+    module.init = vec![
+        Stmt::Let {
+            id: key,
+            name: "key".to_string(),
+            ty: Type::String,
+            mutable: false,
+            init: Some(Expr::String("x".to_string())),
+        },
+        Stmt::Let {
+            id: object,
+            name: "object".to_string(),
+            ty: Type::Any,
+            mutable: false,
+            init: Some(Expr::Object(vec![("x".to_string(), Expr::Integer(0))])),
+        },
+        Stmt::Expr(Expr::PutValueSet {
+            target: Box::new(Expr::LocalGet(object)),
+            key: Box::new(Expr::LocalGet(key)),
+            value: Box::new(Expr::Integer(1)),
+            receiver: Box::new(Expr::LocalGet(object)),
+            strict: false,
+        }),
+    ];
+
+    let ir = compile_ir_for_module_with_opts(module, empty_opts()).unwrap();
+    assert!(
+        ir.contains("call double @js_put_value_set_ic_miss"),
+        "an immutable string key promoted to module-global storage should retain its static-key metadata:\n{ir}"
+    );
+    assert!(
+        !ir.contains("call double @js_put_value_set_dyn_ic("),
+        "the module-global immutable literal key should not fall through to dynamic PutValue:\n{ir}"
+    );
+}
+
+#[test]
 fn mutable_string_key_rejects_static_write_pic() {
     let object = 1u32;
     let key = 2u32;


### PR DESCRIPTION
## Summary

- Preserve immutable string and finite-number literal metadata before module-global and boxed-local lowering paths return.
- Centralize static property-key resolution across the write PIC and object-write loop matchers while preserving the class-field matcher’s existing string-only contract.
- Add regression coverage for immutable string keys promoted to module-global storage.

## Related issue

Follow-up to #6812. The broader performance issue remains open for its remaining matrix gaps; this PR does not close it.

## Test plan

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p perry-codegen --test native_proof_regressions` — 274 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved property writes using immutable string and numeric keys, including module-level and boxed variables.
  * Enhanced loop optimizations for dense object arrays, supporting more written fields, dynamic keys, bounded ranges, and multiple array layouts.
  * Preserved fast property-write paths in additional storage scenarios.

* **Tests**
  * Added regression coverage confirming optimized writes for immutable module-level string keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->