### PR TITLE
fix(thread): make static dispatch IDs worker-safe

### DIFF
--- a/changelog.d/6784-diagnostics-worker-dispatch.md
+++ b/changelog.d/6784-diagnostics-worker-dispatch.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Make AOT static property and method dispatch IDs safe across `perry/thread`
+  workers, allowing worker-side `diagnostics_channel` publishes and subscriber
+  ownership checks to reach the main-thread runtime correctly.

--- a/crates/perry-codegen/src/codegen/string_pool.rs
+++ b/crates/perry-codegen/src/codegen/string_pool.rs
@@ -190,6 +190,23 @@ pub(super) fn emit_string_pool(
     for entry in strings.iter() {
         // .rodata bytes — `[N+1 x i8]` because we include the null terminator.
         llmod.add_named_string_constant(&entry.bytes_global, entry.byte_len + 1, &entry.escaped_ir);
+        if entry.dispatch_used {
+            // AOT-stable property/method dispatch id. Unlike `handle_global`,
+            // this descriptor never points into a thread-local GC arena, so
+            // compiled worker closures can resolve static names without
+            // sharing a main-thread StringHeader. Carrying the precomputed
+            // content hash lets the runtime's per-thread materialization cache
+            // avoid re-hashing the name on every property access.
+            llmod.add_raw_global(format!(
+                "@{} = private unnamed_addr constant {{ i32, i32, i64, ptr }} \
+                 {{ i32 {}, i32 {}, i64 {}, ptr @{} }}",
+                entry.dispatch_global,
+                entry.byte_len,
+                i32::from(entry.is_wtf8),
+                crate::nanbox::i64_literal(entry.dispatch_hash),
+                entry.bytes_global
+            ));
+        }
         llmod.add_internal_global(&entry.handle_global, DOUBLE, "0.0");
     }
 

--- a/crates/perry-codegen/src/expr/call_spread.rs
+++ b/crates/perry-codegen/src/expr/call_spread.rs
@@ -262,13 +262,9 @@ pub(crate) fn lower(ctx: &mut FnCtx<'_>, expr: &Expr) -> Result<String> {
                         }
                     }
                     let key_idx = ctx.strings.intern(property);
-                    let entry = ctx.strings.entry(key_idx);
-                    let key_handle_global = format!("@{}", entry.handle_global);
-                    let key_box = ctx.block().load(DOUBLE, &key_handle_global);
-                    let key_bits = ctx.block().bitcast_double_to_i64(&key_box);
+                    let dispatch_global = ctx.strings.static_dispatch_global(key_idx);
                     let method_id =
-                        ctx.block()
-                            .and(I64, &key_bits, crate::nanbox::POINTER_MASK_I64);
+                        crate::strings::emit_static_dispatch_id(ctx.block(), &dispatch_global);
                     return Ok(ctx.block().call(
                         DOUBLE,
                         "js_native_call_method_apply_by_id",

--- a/crates/perry-codegen/src/expr/property_get/helpers.rs
+++ b/crates/perry-codegen/src/expr/property_get/helpers.rs
@@ -9,7 +9,6 @@ use super::*;
 use anyhow::Result;
 use perry_hir::Expr;
 
-use crate::nanbox::POINTER_MASK_I64;
 use crate::native_value::{
     BoundsState, BufferAccessMode, LoweredValue, MaterializationReason, NativeRep, SemanticKind,
 };
@@ -29,15 +28,13 @@ pub(crate) fn lower_runtime_property_get_by_name(
 ) -> Result<String> {
     let recv_box = lower_expr(ctx, object)?;
     let key_idx = ctx.strings.intern(property);
-    let key_handle_global = format!("@{}", ctx.strings.entry(key_idx).handle_global);
+    let dispatch_global = ctx.strings.static_dispatch_global(key_idx);
     let blk = ctx.block();
     let obj_bits = blk.bitcast_double_to_i64(&recv_box);
     // The helper takes a raw `*const ObjectHeader`, so strip the NaN-box
-    // POINTER_TAG to a canonical pointer (mirrors the property_id masking).
-    let obj_handle = blk.and(I64, &obj_bits, POINTER_MASK_I64);
-    let key_box = blk.load(DOUBLE, &key_handle_global);
-    let key_bits = blk.bitcast_double_to_i64(&key_box);
-    let property_id = blk.and(I64, &key_bits, POINTER_MASK_I64);
+    // POINTER_TAG to a canonical pointer.
+    let obj_handle = blk.and(I64, &obj_bits, crate::nanbox::POINTER_MASK_I64);
+    let property_id = crate::strings::emit_static_dispatch_id(blk, &dispatch_global);
     Ok(blk.call(
         DOUBLE,
         "js_object_get_field_by_property_id_f64",
@@ -52,11 +49,9 @@ pub(crate) fn lower_class_method_bind(
 ) -> Result<String> {
     let recv_box = lower_expr(ctx, object)?;
     let key_idx = ctx.strings.intern(method_name);
-    let key_handle_global = format!("@{}", ctx.strings.entry(key_idx).handle_global);
+    let dispatch_global = ctx.strings.static_dispatch_global(key_idx);
     let blk = ctx.block();
-    let key_box = blk.load(DOUBLE, &key_handle_global);
-    let key_bits = blk.bitcast_double_to_i64(&key_box);
-    let method_id = blk.and(I64, &key_bits, POINTER_MASK_I64);
+    let method_id = crate::strings::emit_static_dispatch_id(blk, &dispatch_global);
     Ok(blk.call(
         DOUBLE,
         "js_class_method_bind_by_id",

--- a/crates/perry-codegen/src/expr/property_set.rs
+++ b/crates/perry-codegen/src/expr/property_set.rs
@@ -51,12 +51,10 @@ fn lower_runtime_property_set_by_name(
     let recv_box = lower_expr(ctx, object)?;
     let val_double = lower_expr(ctx, value)?;
     let key_idx = ctx.strings.intern(property);
-    let key_handle_global = format!("@{}", ctx.strings.entry(key_idx).handle_global);
+    let dispatch_global = ctx.strings.static_dispatch_global(key_idx);
     let blk = ctx.block();
     let obj_bits = blk.bitcast_double_to_i64(&recv_box);
-    let key_box = blk.load(DOUBLE, &key_handle_global);
-    let key_bits = blk.bitcast_double_to_i64(&key_box);
-    let property_id = blk.and(I64, &key_bits, POINTER_MASK_I64);
+    let property_id = crate::strings::emit_static_dispatch_id(blk, &dispatch_global);
     blk.call_void(
         "js_object_set_field_by_property_id",
         &[(I64, &obj_bits), (I64, &property_id), (DOUBLE, &val_double)],

--- a/crates/perry-codegen/src/lower_call/console_promise.rs
+++ b/crates/perry-codegen/src/lower_call/console_promise.rs
@@ -845,17 +845,13 @@ pub fn try_lower_native_method_str_dispatch(
             for a in args {
                 lowered_args.push(lower_expr(ctx, a)?);
             }
-            // Intern the method name and pass its heap string handle as the
-            // static-name method id. The typed-feedback wrapper resolves the
-            // id to bytes only at the runtime boundary.
+            // Pass a tagged pointer to the immutable StringPool dispatch
+            // descriptor. A GC-backed string handle belongs to the main
+            // thread's arena and cannot be resolved safely by a
+            // `perry/thread` worker executing this compiled closure.
             let key_idx = ctx.strings.intern(property);
-            let entry = ctx.strings.entry(key_idx);
-            let key_handle_global = format!("@{}", entry.handle_global);
-            let key_box = ctx.block().load(DOUBLE, &key_handle_global);
-            let key_bits = ctx.block().bitcast_double_to_i64(&key_box);
-            let method_id = ctx
-                .block()
-                .and(I64, &key_bits, crate::nanbox::POINTER_MASK_I64);
+            let dispatch_global = ctx.strings.static_dispatch_global(key_idx);
+            let method_id = crate::strings::emit_static_dispatch_id(ctx.block(), &dispatch_global);
             // Stack-allocate the args array if any. The alloca MUST live in
             // the function entry block — emitting it into the current block
             // (which may be a loop body) makes LLVM lower it as a runtime

--- a/crates/perry-codegen/src/lower_call/method_override.rs
+++ b/crates/perry-codegen/src/lower_call/method_override.rs
@@ -203,8 +203,8 @@ pub(super) fn emit_guarded_direct_method_call(
     let key_idx = ctx.strings.intern(property);
     let entry = ctx.strings.entry(key_idx);
     let bytes_global = format!("@{}", entry.bytes_global);
-    let key_handle_global = format!("@{}", entry.handle_global);
     let name_len_str = entry.byte_len.to_string();
+    let dispatch_global = ctx.strings.static_dispatch_global(key_idx);
     let site_id = if shape_only_guard {
         None
     } else {
@@ -782,11 +782,7 @@ pub(super) fn emit_guarded_direct_method_call(
         ctx.block()
             .call_void("js_typed_feedback_record_fallback_call", &[(I64, &site_id)]);
     }
-    let key_box = ctx.block().load(DOUBLE, &key_handle_global);
-    let key_bits = ctx.block().bitcast_double_to_i64(&key_box);
-    let method_id = ctx
-        .block()
-        .and(I64, &key_bits, crate::nanbox::POINTER_MASK_I64);
+    let method_id = crate::strings::emit_static_dispatch_id(ctx.block(), &dispatch_global);
     let fallback_value = ctx.block().call(
         DOUBLE,
         "js_native_call_method_by_id",

--- a/crates/perry-codegen/src/lower_call/property_get/dynamic_dispatch.rs
+++ b/crates/perry-codegen/src/lower_call/property_get/dynamic_dispatch.rs
@@ -451,13 +451,8 @@ pub(crate) fn try_lower_instance_method_call(
             // method of the same name.
             ctx.current_block = default_idx;
             let key_idx = ctx.strings.intern(property);
-            let entry = ctx.strings.entry(key_idx);
-            let key_handle_global = format!("@{}", entry.handle_global);
-            let key_box = ctx.block().load(DOUBLE, &key_handle_global);
-            let key_bits = ctx.block().bitcast_double_to_i64(&key_box);
-            let method_id = ctx
-                .block()
-                .and(I64, &key_bits, crate::nanbox::POINTER_MASK_I64);
+            let dispatch_global = ctx.strings.static_dispatch_global(key_idx);
+            let method_id = crate::strings::emit_static_dispatch_id(ctx.block(), &dispatch_global);
             let (fb_args_ptr, fb_args_len) = if static_user_args.is_empty() {
                 ("null".to_string(), "0".to_string())
             } else {

--- a/crates/perry-codegen/src/lower_call/scalar_method.rs
+++ b/crates/perry-codegen/src/lower_call/scalar_method.rs
@@ -775,12 +775,8 @@ fn lower_materialized_receiver_dispatch(
 ) -> Result<String> {
     let recv_box = materialize_scalar_receiver(ctx, receiver_id, class_name)?;
     let key_idx = ctx.strings.intern(property);
-    let key_handle_global = format!("@{}", ctx.strings.entry(key_idx).handle_global);
-    let key_box = ctx.block().load(DOUBLE, &key_handle_global);
-    let key_bits = ctx.block().bitcast_double_to_i64(&key_box);
-    let method_id = ctx
-        .block()
-        .and(I64, &key_bits, crate::nanbox::POINTER_MASK_I64);
+    let dispatch_global = ctx.strings.static_dispatch_global(key_idx);
+    let method_id = crate::strings::emit_static_dispatch_id(ctx.block(), &dispatch_global);
     let (args_ptr, args_len) = if lowered_args.is_empty() {
         ("null".to_string(), "0".to_string())
     } else {

--- a/crates/perry-codegen/src/nanbox.rs
+++ b/crates/perry-codegen/src/nanbox.rs
@@ -34,6 +34,11 @@ pub const BIGINT_TAG: u64 = 0x7FFA_0000_0000_0000;
 /// Must match `perry-runtime::value::tags::SHORT_STRING_TAG` (used by the
 /// inline `is-number` guard in `stmt::loops`).
 pub const SHORT_STRING_TAG: u64 = 0x7FF9_0000_0000_0000;
+/// Internal-only tag for a pointer to an immutable static-dispatch string
+/// descriptor. This is not a JavaScript value; it travels only through the
+/// property/method `*_by_id` ABI. `0x7FF8` is outside Perry's JS-value tag
+/// band and corresponds to the otherwise-unused canonical quiet-NaN prefix.
+pub const STATIC_DISPATCH_TAG: u64 = 0x7FF8_0000_0000_0000;
 pub const TAG_MASK: u64 = 0xFFFF_0000_0000_0000;
 
 pub const TAG_UNDEFINED_I64: &str = "9222246136947933185";
@@ -101,6 +106,7 @@ mod tests {
         assert_eq!(i64_literal(INT32_TAG), INT32_TAG_I64);
         assert_eq!(i64_literal(STRING_TAG), STRING_TAG_I64);
         assert_eq!(i64_literal(BIGINT_TAG), BIGINT_TAG_I64);
+        assert_eq!(i64_literal(STATIC_DISPATCH_TAG), "9221120237041090560");
     }
 
     #[test]

--- a/crates/perry-codegen/src/strings.rs
+++ b/crates/perry-codegen/src/strings.rs
@@ -17,6 +17,11 @@
 //! @.str.<idx>.handle = internal global double 0.0
 //! ```
 //!
+//! Static property/method names used by a `*_by_id` runtime ABI also receive
+//! an immutable `.str.<idx>.dispatch` descriptor. Descriptors are emitted only
+//! for entries that need them, avoiding binary/RSS overhead for ordinary
+//! literals.
+//!
 //! The `bytes` global lives in `.rodata` — it's static, immutable, and never
 //! touched by the GC. The `handle` global is mutable and holds the
 //! NaN-boxed string pointer that the runtime allocates at init time.
@@ -108,6 +113,16 @@ pub struct StringEntry {
     pub bytes_global: String,
     /// Symbol name of the mutable handle global (`.str.N.handle`).
     pub handle_global: String,
+    /// Symbol name of the immutable static-dispatch descriptor
+    /// (`.str.N.dispatch`). Property/method by-id ABIs use this instead of
+    /// smuggling the GC-backed `handle_global` string pointer across
+    /// `perry/thread` arena boundaries.
+    pub dispatch_global: String,
+    /// Precomputed FNV-1a content hash carried by the dispatch descriptor.
+    pub dispatch_hash: u64,
+    /// Whether codegen emitted a `*_by_id` use for this entry. Ordinary string
+    /// literals do not need a descriptor in the final object.
+    pub dispatch_used: bool,
     /// true = bytes contain WTF-8 lone surrogates; use js_string_from_wtf8_bytes at init.
     pub is_wtf8: bool,
 }
@@ -220,6 +235,11 @@ impl StringPool {
         } else {
             format!("{}_.str.{}.handle", self.module_prefix, idx)
         };
+        let dispatch_global = if self.module_prefix.is_empty() {
+            format!(".str.{}.dispatch", idx)
+        } else {
+            format!("{}_.str.{}.dispatch", self.module_prefix, idx)
+        };
         let entry = StringEntry {
             idx,
             value: value.to_string(),
@@ -227,6 +247,9 @@ impl StringPool {
             escaped_ir,
             bytes_global,
             handle_global,
+            dispatch_global,
+            dispatch_hash: fnv1a(value.as_bytes()),
+            dispatch_used: false,
             is_wtf8: false,
         };
         self.entries.push(entry);
@@ -254,6 +277,11 @@ impl StringPool {
         } else {
             format!("{}_.str.{}.handle", self.module_prefix, idx)
         };
+        let dispatch_global = if self.module_prefix.is_empty() {
+            format!(".str.{}.dispatch", idx)
+        } else {
+            format!("{}_.str.{}.dispatch", self.module_prefix, idx)
+        };
         let entry = StringEntry {
             idx,
             value: key.clone(),
@@ -261,6 +289,9 @@ impl StringPool {
             escaped_ir,
             bytes_global,
             handle_global,
+            dispatch_global,
+            dispatch_hash: fnv1a(bytes),
+            dispatch_used: false,
             is_wtf8: true,
         };
         self.entries.push(entry);
@@ -270,6 +301,14 @@ impl StringPool {
 
     pub fn entry(&self, idx: u32) -> &StringEntry {
         &self.entries[idx as usize]
+    }
+
+    /// Mark an interned entry as a static property/method dispatch key and
+    /// return the descriptor symbol codegen should tag into the by-id ABI.
+    pub fn static_dispatch_global(&mut self, idx: u32) -> String {
+        let entry = &mut self.entries[idx as usize];
+        entry.dispatch_used = true;
+        entry.dispatch_global.clone()
     }
 
     pub fn iter(&self) -> impl Iterator<Item = &StringEntry> {
@@ -283,6 +322,23 @@ impl StringPool {
     pub fn len(&self) -> usize {
         self.entries.len()
     }
+}
+
+/// Emit the process-stable id consumed by the runtime's property/method by-id
+/// ABIs. The id is a tagged pointer to an immutable
+/// `{ byte_len, flags, hash, bytes }` descriptor in the compiled module's
+/// read-only data, so it is safe to use from a `perry/thread` worker with an
+/// independent GC arena.
+pub(crate) fn emit_static_dispatch_id(
+    block: &mut crate::block::LlBlock,
+    dispatch_global: &str,
+) -> String {
+    let descriptor = block.ptrtoint(&format!("@{dispatch_global}"), crate::types::I64);
+    block.or(
+        crate::types::I64,
+        &descriptor,
+        &crate::nanbox::i64_literal(crate::nanbox::STATIC_DISPATCH_TAG),
+    )
 }
 
 impl Default for StringPool {
@@ -310,6 +366,15 @@ fn escape_for_llvm_ir(bytes: &[u8]) -> String {
     s
 }
 
+fn fnv1a(bytes: &[u8]) -> u64 {
+    let mut hash = 0xcbf2_9ce4_8422_2325u64;
+    for &byte in bytes {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(0x0100_0000_01b3);
+    }
+    hash
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -333,6 +398,29 @@ mod tests {
         assert_eq!(e.byte_len, 11);
         assert_eq!(e.bytes_global, ".str.0.bytes");
         assert_eq!(e.handle_global, ".str.0.handle");
+        assert_eq!(e.dispatch_global, ".str.0.dispatch");
+        assert!(!e.dispatch_used);
+    }
+
+    #[test]
+    fn entries_apply_module_prefix_to_dispatch_descriptors() {
+        let mut pool = StringPool::with_prefix("worker".to_string());
+        let idx = pool.intern("publish");
+        let e = pool.entry(idx);
+        assert_eq!(e.bytes_global, "worker_.str.0.bytes");
+        assert_eq!(e.handle_global, "worker_.str.0.handle");
+        assert_eq!(e.dispatch_global, "worker_.str.0.dispatch");
+    }
+
+    #[test]
+    fn dispatch_descriptors_are_opt_in_and_prehashed() {
+        let mut pool = StringPool::new();
+        let idx = pool.intern("publish");
+        let global = pool.static_dispatch_global(idx);
+        let e = pool.entry(idx);
+        assert_eq!(global, ".str.0.dispatch");
+        assert!(e.dispatch_used);
+        assert_eq!(e.dispatch_hash, 0xe2bf_e841_1c47_2768);
     }
 
     #[test]

--- a/crates/perry-codegen/tests/native_proof_regressions.rs
+++ b/crates/perry-codegen/tests/native_proof_regressions.rs
@@ -13184,7 +13184,7 @@ fn static_property_access_on_computed_class_uses_property_id_wrappers() {
 }
 
 #[test]
-fn static_name_method_fallback_uses_method_id_wrapper() {
+fn static_name_method_fallback_uses_rodata_method_id_wrapper() {
     let module = module_with_classes_and_params(
         "method_id_static_name_fallback.ts",
         Vec::new(),
@@ -13208,6 +13208,14 @@ fn static_name_method_fallback_uses_method_id_wrapper() {
     assert!(
         !ir.contains("call double @js_typed_feedback_native_call_method(i64"),
         "static-name dynamic method fallback should not pass raw name bytes:\n{ir}"
+    );
+    assert!(
+        ir.contains(".dispatch = private unnamed_addr constant { i32, i32, i64, ptr }"),
+        "static method ids should be immutable rodata descriptors:\n{ir}"
+    );
+    assert!(
+        ir.contains(".dispatch to i64"),
+        "method-id lowering should tag the descriptor address, not load a GC string handle:\n{ir}"
     );
 }
 

--- a/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
+++ b/crates/perry-runtime/src/object/field_get_set/ic_miss.rs
@@ -106,10 +106,9 @@ pub(crate) fn is_primitive_proto_method(key: &[u8]) -> bool {
     )
 }
 
-/// Static-name lowering should traffic in interned property ids instead of
-/// raw name bytes. The first representation is the interned heap string
-/// pointer already emitted by the StringPool; the wrapper preserves the
-/// existing by-name semantics while giving codegen a by-id ABI to target.
+/// Static-name lowering traffics in immutable AOT descriptors instead of
+/// thread-local heap pointers. APIs below this wrapper still consume a
+/// `StringHeader*`, so descriptors are lazily interned once per runtime thread.
 #[no_mangle]
 pub extern "C" fn js_object_get_field_by_property_id_f64(
     obj: *const ObjectHeader,
@@ -120,18 +119,12 @@ pub extern "C" fn js_object_get_field_by_property_id_f64(
     else {
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     };
-    let key = if key_ref.heap.is_null() {
-        crate::string::js_string_from_bytes(key_ref.ptr, key_ref.len as u32)
-            as *const crate::StringHeader
-    } else {
-        key_ref.heap
-    };
+    let key = crate::string::materialize_dispatch_key(key_ref);
     js_object_get_field_by_name_f64(obj, key)
 }
 
 /// By-id sibling of `js_object_set_field_by_name`. See
-/// `js_object_get_field_by_property_id_f64` for why the initial id
-/// representation is the interned StringHeader pointer.
+/// `js_object_get_field_by_property_id_f64` for descriptor materialization.
 #[no_mangle]
 pub extern "C" fn js_object_set_field_by_property_id(
     obj: *mut ObjectHeader,
@@ -143,12 +136,7 @@ pub extern "C" fn js_object_set_field_by_property_id(
     else {
         return;
     };
-    let key = if key_ref.heap.is_null() {
-        crate::string::js_string_from_bytes(key_ref.ptr, key_ref.len as u32)
-            as *const crate::StringHeader
-    } else {
-        key_ref.heap
-    };
+    let key = crate::string::materialize_dispatch_key(key_ref);
     js_object_set_field_by_name(obj, key, value);
 }
 

--- a/crates/perry-runtime/src/object/native_call_method.rs
+++ b/crates/perry-runtime/src/object/native_call_method.rs
@@ -189,10 +189,9 @@ pub unsafe extern "C" fn js_native_call_method_str_key(
     )
 }
 
-/// Static-name compiled callsites pass an interned method id rather than raw
-/// bytes. For now the id is the interned heap StringHeader pointer emitted by
-/// the StringPool, which lets the runtime preserve the existing dispatch tower
-/// while codegen stops plumbing byte pointer + length pairs through hot paths.
+/// Static-name compiled callsites pass an immutable AOT descriptor rather than
+/// a thread-local heap pointer. The runtime resolves it to its read-only byte
+/// slice while preserving the existing dispatch tower.
 #[no_mangle]
 pub unsafe extern "C" fn js_native_call_method_by_id(
     object: f64,

--- a/crates/perry-runtime/src/object/native_module.rs
+++ b/crates/perry-runtime/src/object/native_module.rs
@@ -1047,9 +1047,8 @@ pub extern "C" fn js_class_method_bind(
 
 /// By-ID sibling of `js_class_method_bind` for static-name lowering.
 ///
-/// The current ID is the interned StringPool `StringHeader*` payload, but this
-/// also accepts boxed heap/short-string ids so future lowering paths do not
-/// reintroduce heap-only string assumptions.
+/// Current codegen passes an immutable AOT descriptor. Legacy heap/short-string
+/// ids remain accepted for ABI compatibility.
 #[no_mangle]
 pub extern "C" fn js_class_method_bind_by_id(instance: f64, method_id: i64) -> f64 {
     let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
@@ -1057,13 +1056,7 @@ pub extern "C" fn js_class_method_bind_by_id(instance: f64, method_id: i64) -> f
     else {
         return f64::from_bits(crate::value::TAG_UNDEFINED);
     };
-    if name_ref.heap.is_null() {
-        let heap = crate::string::js_string_from_bytes(name_ref.ptr, name_ref.len as u32);
-        let ptr = unsafe { (heap as *const u8).add(std::mem::size_of::<crate::StringHeader>()) };
-        js_class_method_bind(instance, ptr, name_ref.len)
-    } else {
-        js_class_method_bind(instance, name_ref.ptr, name_ref.len)
-    }
+    js_class_method_bind(instance, name_ref.ptr, name_ref.len)
 }
 
 #[used]

--- a/crates/perry-runtime/src/string/intern.rs
+++ b/crates/perry-runtime/src/string/intern.rs
@@ -26,12 +26,19 @@ pub(crate) const INTERN_MAX_BYTE_LEN: u32 = 64;
 /// `static mut`, which both raced under concurrent allocation and risked
 /// handing back foreign-arena pointers.
 thread_local! {
-    // arm64_32 fix: HEAP-allocate (Box) this ~128KB table instead of inline TLS.
+    // arm64_32 fix: HEAP-allocate this table instead of inline TLS.
     // Oversized `#[thread_local]` storage overflows the ILP32 TLS layout and its
     // writes corrupt adjacent thread-locals. Boxing keeps only a pointer in TLS.
     pub(crate) static INTERN_TABLE: std::cell::UnsafeCell<Box<[InternEntry]>> =
         std::cell::UnsafeCell::new(
-            vec![InternEntry { hash: 0, string_ptr: 0 }; INTERN_TABLE_SIZE].into_boxed_slice(),
+            vec![
+                InternEntry {
+                    hash: 0,
+                    string_ptr: 0,
+                };
+                INTERN_TABLE_SIZE
+            ]
+            .into_boxed_slice(),
         );
 }
 
@@ -94,6 +101,79 @@ pub extern "C" fn js_string_intern(key: *const StringHeader, hash: u64) -> *cons
 
         key
     }
+}
+
+/// Materialize an immutable AOT dispatch descriptor into the current thread's
+/// intern table. The precomputed content hash selects the existing direct-
+/// mapped slot without re-hashing; content comparison preserves correctness
+/// across hash collisions while keeping the table's per-thread RSS unchanged.
+pub(crate) fn intern_dispatch_bytes(
+    static_dispatch_id: usize,
+    bytes: *const u8,
+    byte_len: usize,
+    precomputed_hash: u64,
+    is_wtf8: bool,
+) -> *const StringHeader {
+    if (bytes.is_null() && byte_len != 0) || byte_len > u32::MAX as usize {
+        return std::ptr::null();
+    }
+    let input = if byte_len == 0 {
+        &[][..]
+    } else {
+        unsafe { std::slice::from_raw_parts(bytes, byte_len) }
+    };
+    let hash = if static_dispatch_id != 0 {
+        precomputed_hash
+    } else {
+        let mut hash = 0xcbf2_9ce4_8422_2325u64;
+        for &byte in input {
+            hash ^= byte as u64;
+            hash = hash.wrapping_mul(0x0100_0000_01b3);
+        }
+        hash
+    };
+    let slot = (hash as usize) & INTERN_TABLE_MASK;
+
+    let hit = with_intern_table(|table| unsafe {
+        let entry = &mut (*table)[slot];
+        if entry.string_ptr == 0 {
+            return None;
+        }
+        let existing = entry.string_ptr as *const StringHeader;
+        if entry.hash == hash
+            && is_valid_string_ptr(existing)
+            && (*existing).byte_len as usize == byte_len
+            && std::slice::from_raw_parts(
+                (existing as *const u8).add(std::mem::size_of::<StringHeader>()),
+                byte_len,
+            ) == input
+        {
+            return Some(existing);
+        }
+        None
+    });
+    if let Some(existing) = hit {
+        return existing;
+    }
+
+    let key = if is_wtf8 {
+        js_string_from_wtf8_bytes(bytes, byte_len as u32)
+    } else {
+        js_string_from_bytes(bytes, byte_len as u32)
+    };
+    unsafe {
+        let gc_header =
+            (key as *const u8).sub(crate::gc::GC_HEADER_SIZE) as *mut crate::gc::GcHeader;
+        (*gc_header).gc_flags |= crate::gc::GC_FLAG_INTERNED;
+        (*key).refcount = 0;
+    }
+    with_intern_table(|table| unsafe {
+        (*table)[slot] = InternEntry {
+            hash,
+            string_ptr: key as usize,
+        };
+    });
+    key
 }
 
 /// Byte-level content comparison for intern table lookups.

--- a/crates/perry-runtime/src/string/mod.rs
+++ b/crates/perry-runtime/src/string/mod.rs
@@ -148,21 +148,46 @@ pub fn is_valid_string_ptr(p: *const StringHeader) -> bool {
 
 /// Borrowed byte view for a Perry string-like dispatch key.
 ///
-/// Static dispatch IDs currently use the raw interned `StringHeader*` pointer
-/// payload. Newer lowering paths may naturally carry a full NaN-boxed string
-/// value, including `SHORT_STRING_TAG`. This view lets by-ID wrappers accept
-/// both forms without open-coding heap-only string reads at each callsite.
+/// Current static dispatch IDs use immutable descriptors emitted into the
+/// compiled module. Legacy lowering paths may carry a raw `StringHeader*`,
+/// while dynamic paths may naturally carry a full NaN-boxed string value,
+/// including `SHORT_STRING_TAG`. This view lets by-ID wrappers accept all
+/// forms without open-coding heap-only string reads at each callsite.
 #[derive(Clone, Copy)]
 pub struct PerryStringRef {
     pub ptr: *const u8,
     pub len: usize,
     pub heap: *const StringHeader,
+    /// Address of the immutable AOT descriptor, or zero for legacy/dynamic
+    /// forms. A nonzero value tells heap materialization that `hash` was
+    /// precomputed by trusted codegen.
+    pub static_id: usize,
+    /// Precomputed FNV-1a content hash for a static descriptor.
+    pub hash: u64,
+    /// Whether descriptor bytes use Perry's WTF-8 representation.
+    pub is_wtf8: bool,
 }
+
+/// Immutable descriptor emitted into the compiled module's read-only data for
+/// static property/method names. By-id dispatch uses a tagged pointer to this
+/// descriptor instead of a `StringHeader*`, because the latter belongs to the
+/// main thread's moving GC arena and is not valid in `perry/thread` workers.
+#[repr(C)]
+struct StaticDispatchString {
+    byte_len: u32,
+    flags: u32,
+    hash: u64,
+    bytes: *const u8,
+}
+
+const STATIC_DISPATCH_TAG: u64 = 0x7FF8_0000_0000_0000;
+const STATIC_DISPATCH_FLAG_WTF8: u32 = 1;
 
 /// Resolve a static property/method id into a byte view.
 ///
 /// Accepted forms:
-/// - raw interned `StringHeader*` pointer payload (today's StringPool id);
+/// - tagged immutable [`StaticDispatchString`] pointer (current codegen);
+/// - raw interned `StringHeader*` pointer payload (legacy codegen);
 /// - boxed heap `STRING_TAG` bits;
 /// - boxed inline `SHORT_STRING_TAG` bits, copied into `scratch`.
 #[inline]
@@ -176,6 +201,28 @@ pub fn perry_string_ref_from_dispatch_id(
 
     let bits = id as u64;
     let tag = bits & crate::value::TAG_MASK;
+    if tag == STATIC_DISPATCH_TAG {
+        let descriptor =
+            (bits & crate::value::POINTER_MASK) as usize as *const StaticDispatchString;
+        if descriptor.is_null()
+            || (descriptor as usize & (std::mem::align_of::<StaticDispatchString>() - 1)) != 0
+        {
+            return None;
+        }
+        unsafe {
+            if (*descriptor).bytes.is_null() {
+                return None;
+            }
+            return Some(PerryStringRef {
+                ptr: (*descriptor).bytes,
+                len: (*descriptor).byte_len as usize,
+                heap: std::ptr::null(),
+                static_id: descriptor as usize,
+                hash: (*descriptor).hash,
+                is_wtf8: (*descriptor).flags & STATIC_DISPATCH_FLAG_WTF8 != 0,
+            });
+        }
+    }
     if tag == crate::value::STRING_TAG || tag == crate::value::SHORT_STRING_TAG {
         return str_bytes_from_jsvalue(f64::from_bits(bits), scratch).map(|(ptr, len)| {
             let jsval = crate::value::JSValue::from_bits(bits);
@@ -187,6 +234,9 @@ pub fn perry_string_ref_from_dispatch_id(
                 } else {
                     std::ptr::null()
                 },
+                static_id: 0,
+                hash: 0,
+                is_wtf8: false,
             }
         });
     }
@@ -207,7 +257,23 @@ pub fn perry_string_ref_from_dispatch_id(
             ptr: (hdr as *const u8).add(std::mem::size_of::<StringHeader>()),
             len: (*hdr).byte_len as usize,
             heap: hdr,
+            static_id: 0,
+            hash: 0,
+            is_wtf8: (*hdr).flags & STRING_FLAG_HAS_LONE_SURROGATES != 0,
         })
+    }
+}
+
+/// Return a current-thread heap key for an API that still consumes a
+/// `StringHeader*`. Static AOT descriptors are materialized at most once per
+/// content-hash slot and thread; subsequent accesses are allocation-free, and
+/// the existing intern-table root scanner keeps the pointer GC-safe.
+#[inline]
+pub(crate) fn materialize_dispatch_key(key: PerryStringRef) -> *const StringHeader {
+    if !key.heap.is_null() {
+        key.heap
+    } else {
+        intern::intern_dispatch_bytes(key.static_id, key.ptr, key.len, key.hash, key.is_wtf8)
     }
 }
 

--- a/crates/perry-runtime/src/string/tests.rs
+++ b/crates/perry-runtime/src/string/tests.rs
@@ -2,7 +2,7 @@
 //!
 //! Moved verbatim from the pre-split monolithic `string.rs`.
 
-use super::intern::{with_intern_table, InternEntry, INTERN_TABLE_MASK};
+use super::intern::{with_intern_table, INTERN_TABLE_MASK};
 use super::*;
 
 fn malloc_object_count_for_test() -> usize {
@@ -67,6 +67,66 @@ fn dispatch_id_resolver_accepts_raw_heap_and_sso_string_forms() {
         .unwrap()
         .bits() as i64;
     assert_eq!(bytes_from(boxed_sso), b"id");
+}
+
+#[test]
+fn dispatch_id_resolver_accepts_static_rodata_descriptor_form() {
+    let bytes = b"publish";
+    let descriptor = StaticDispatchString {
+        byte_len: bytes.len() as u32,
+        flags: 0,
+        hash: 0xe2bf_e841_1c47_2768,
+        bytes: bytes.as_ptr(),
+    };
+    let id = STATIC_DISPATCH_TAG
+        | ((&descriptor as *const StaticDispatchString as u64) & crate::value::POINTER_MASK);
+    let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    let resolved = perry_string_ref_from_dispatch_id(id as i64, &mut scratch).unwrap();
+    assert!(resolved.heap.is_null());
+    assert_eq!(
+        unsafe { std::slice::from_raw_parts(resolved.ptr, resolved.len) },
+        bytes
+    );
+}
+
+#[test]
+fn static_dispatch_key_materialization_is_cached_per_thread() {
+    let bytes = b"publish";
+    let descriptor = StaticDispatchString {
+        byte_len: bytes.len() as u32,
+        flags: 0,
+        hash: 0xe2bf_e841_1c47_2768,
+        bytes: bytes.as_ptr(),
+    };
+    let id = STATIC_DISPATCH_TAG
+        | ((&descriptor as *const StaticDispatchString as u64) & crate::value::POINTER_MASK);
+    let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    let key = perry_string_ref_from_dispatch_id(id as i64, &mut scratch).unwrap();
+    let first = materialize_dispatch_key(key);
+    let second = materialize_dispatch_key(key);
+    assert!(!first.is_null());
+    assert_eq!(first, second);
+}
+
+#[test]
+fn static_dispatch_key_materialization_preserves_wtf8_flag() {
+    let bytes = b"\xED\xA0\x80";
+    let descriptor = StaticDispatchString {
+        byte_len: bytes.len() as u32,
+        flags: STATIC_DISPATCH_FLAG_WTF8,
+        hash: fnv1a_for_test(bytes),
+        bytes: bytes.as_ptr(),
+    };
+    let id = STATIC_DISPATCH_TAG
+        | ((&descriptor as *const StaticDispatchString as u64) & crate::value::POINTER_MASK);
+    let mut scratch = [0u8; crate::value::SHORT_STRING_MAX_LEN];
+    let key = perry_string_ref_from_dispatch_id(id as i64, &mut scratch).unwrap();
+    let heap = materialize_dispatch_key(key);
+    assert!(!heap.is_null());
+    assert_ne!(
+        unsafe { (*heap).flags } & STRING_FLAG_HAS_LONE_SURROGATES,
+        0
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #6784

## Summary

- replace GC-backed static property/method IDs with immutable AOT descriptors in read-only data
- resolve descriptors directly for byte-based dispatch and lazily materialize heap keys in each worker’s existing intern table
- preserve legacy raw/boxed heap and short-string ID forms, including WTF-8 property names
- emit descriptors only for strings actually used by `*_by_id` lowering, avoiding broad binary/RSS growth

Static StringPool handles are allocated in the main thread’s GC arena. Worker closures previously embedded those pointers, so worker-side method dispatch rejected them as foreign-arena strings and silently produced `undefined`. The descriptor carries length, encoding flags, precomputed FNV-1a hash, and a pointer to immutable string bytes; each runtime thread owns any heap materialization it needs.

## Validation

- `cargo check -p perry-codegen -p perry-runtime`
- `cargo test -p perry-codegen`
- `cargo test -p perry-runtime --lib string::tests` (39 passed)
- `cargo test -p perry-runtime --lib -- --test-threads=1` (1,465 passed, 3 ignored)
- full `diagnostics_channel` parity suite (69 passed, 0 failed; baseline 67/69)
- cache-free `worker-main-publish` parity (pass)
- cache-free `worker-subscriber-policy` parity (pass)
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed AOT property and method dispatch across worker threads.
  - Enabled diagnostic channel publishing and subscriber ownership checks to work reliably from workers.
  - Improved compatibility for static method calls, property access, and class method binding.
  - Preserved correct handling of UTF-8 and WTF-8 property and method names.
- **Tests**
  - Added regression coverage for static dispatch descriptors, worker-safe resolution, caching, and special-character handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->