### PR TITLE
fix(axios): restore typed async response access

### DIFF
--- a/changelog.d/6852-axios-async-response-properties.md
+++ b/changelog.d/6852-axios-async-response-properties.md
@@ -1,0 +1,1 @@
+Fix Axios default-export types and async response properties without leaking them onto unrelated native handles.

--- a/changelog.d/6852-axios-async-response-properties.md
+++ b/changelog.d/6852-axios-async-response-properties.md
@@ -1,1 +1,1 @@
-Fix Axios default-export types and async response properties without leaking them onto unrelated native handles.
+Fix Axios default-export types, add native `head` and `options`, and preserve async response properties without leaking them onto unrelated native handles.

--- a/crates/perry-api-manifest/src/emit.rs
+++ b/crates/perry-api-manifest/src/emit.rs
@@ -203,6 +203,8 @@ pub fn emit_dts(_perry_version: &str) -> String {
         // Followup under #466 will tighten this when signature data lands.
         let mut emitted_fn_names: std::collections::HashSet<&str> =
             std::collections::HashSet::new();
+        let mut emitted_static_methods = Vec::new();
+        let mut callable_default = None;
         for e in entries.iter().filter(|e| {
             matches!(
                 e.kind,
@@ -218,15 +220,19 @@ pub fn emit_dts(_perry_version: &str) -> String {
             if !emitted_fn_names.insert(e.name) {
                 continue;
             }
-            let _ = writeln!(out, "  /** {}{} */", source_dts_tag(e), stub_dts_suffix(e));
-            // `default` is the npm convention for "the module is
-            // callable" (e.g. `import sharp from 'sharp'`). TypeScript
-            // expresses that as `export default function (...)`, with
-            // no name on the function declaration.
-            let signature = render_signature(e);
             if e.name == "default" {
-                let _ = writeln!(out, "  export default function {};", signature);
-            } else if is_ts_reserved_word(e.name) {
+                if *module == "axios" {
+                    callable_default = Some(*e);
+                } else {
+                    let _ = writeln!(out, "  /** {}{} */", source_dts_tag(e), stub_dts_suffix(e));
+                    let _ = writeln!(out, "  export default function {};", render_signature(e));
+                }
+                continue;
+            }
+            emitted_static_methods.push(*e);
+            let _ = writeln!(out, "  /** {}{} */", source_dts_tag(e), stub_dts_suffix(e));
+            let signature = render_signature(e);
+            if is_ts_reserved_word(e.name) {
                 // Reserved words (e.g. `axios.delete`) can't appear as
                 // a function declaration's name — `tsc` rejects
                 // `export function delete(...)` with TS1359 (#526).
@@ -238,6 +244,35 @@ pub fn emit_dts(_perry_version: &str) -> String {
                 let _ = writeln!(out, "  export {{ {} as {} }};", alias, e.name);
             } else {
                 let _ = writeln!(out, "  export function {}{};", ts_ident(e.name), signature);
+            }
+        }
+
+        if let Some(default) = callable_default {
+            let _ = writeln!(
+                out,
+                "  /** {}{} */",
+                source_dts_tag(default),
+                stub_dts_suffix(default)
+            );
+            if emitted_static_methods.is_empty() {
+                let _ = writeln!(
+                    out,
+                    "  export default function {};",
+                    render_signature(default)
+                );
+            } else {
+                let signature = render_signature(default).replacen("): ", ") => ", 1);
+                let _ = writeln!(out, "  const _default: ({}) & {{", signature);
+                for method in emitted_static_methods {
+                    let target = if is_ts_reserved_word(method.name) {
+                        format!("_{}", method.name)
+                    } else {
+                        ts_ident(method.name)
+                    };
+                    let _ = writeln!(out, "    {}: typeof {};", ts_ident(method.name), target);
+                }
+                let _ = writeln!(out, "  }};");
+                let _ = writeln!(out, "  export default _default;");
             }
         }
 
@@ -772,6 +807,22 @@ mod tests {
             block.contains("function _delete(") && block.contains("_delete as delete"),
             "axios.delete should use the `function _delete; export {{ _delete as delete }}` \
              alias pattern\nblock: {}",
+            block
+        );
+    }
+
+    #[test]
+    fn dts_axios_default_export_exposes_static_methods() {
+        let dts = emit_dts("test");
+        let block_start = dts.find("declare module \"axios\"").expect("axios block");
+        let after = &dts[block_start..];
+        let block_end = after.find("\n}\n").expect("block end");
+        let block = &after[..block_end];
+        assert!(
+            block.contains("get: typeof get;")
+                && block.contains("delete: typeof _delete;")
+                && block.contains("export default _default;"),
+            "the callable axios default must expose its static methods\nblock: {}",
             block
         );
     }

--- a/crates/perry-codegen/src/lower_call/options/fetch.rs
+++ b/crates/perry-codegen/src/lower_call/options/fetch.rs
@@ -157,7 +157,7 @@ pub(in crate::lower_call) fn lower_fetch_native_method(
         }
     }
 
-    // ── axios: static method calls (axios.get/post/put/delete/patch) ──
+    // ── axios: static HTTP method calls ──
     // Must be before the receiver guard — these are receiver-less calls.
     if module == "axios" && object.is_none() {
         let url_box = if !args.is_empty() {
@@ -168,8 +168,13 @@ pub(in crate::lower_call) fn lower_fetch_native_method(
         let blk = ctx.block();
         let url_handle = unbox_to_i64(blk, &url_box);
         match method {
-            "get" => {
-                let promise = blk.call(I64, "js_axios_get", &[(I64, &url_handle)]);
+            "get" | "head" | "options" => {
+                let rt_fn = match method {
+                    "get" => "js_axios_get",
+                    "head" => "js_axios_head",
+                    _ => "js_axios_options",
+                };
+                let promise = blk.call(I64, rt_fn, &[(I64, &url_handle)]);
                 return Ok(Some(nanbox_pointer_inline(blk, &promise)));
             }
             "delete" => {

--- a/crates/perry-codegen/src/runtime_decls/stdlib_ffi/third_party.rs
+++ b/crates/perry-codegen/src/runtime_decls/stdlib_ffi/third_party.rs
@@ -74,6 +74,8 @@ pub(crate) fn declare_third_party(module: &mut LlModule) {
     module.declare_function("js_axios_create", DOUBLE, &[I64]);
     module.declare_function("js_axios_delete", I64, &[I64]);
     module.declare_function("js_axios_get", I64, &[I64]);
+    module.declare_function("js_axios_head", I64, &[I64]);
+    module.declare_function("js_axios_options", I64, &[I64]);
     // #598: body arg is a NaN-boxed f64 (DOUBLE) so the runtime can
     // distinguish strings from objects via the tag and JSON.stringify
     // non-string bodies. Pre-fix this was I64 (raw unboxed pointer)

--- a/crates/perry-ext-axios/src/lib.rs
+++ b/crates/perry-ext-axios/src/lib.rs
@@ -149,6 +149,30 @@ pub unsafe extern "C" fn js_axios_get(url_ptr: *const StringHeader) -> *mut Prom
     run_request("GET", url, |client, url| client.get(&url))
 }
 
+/// `axios.head(url) -> Promise<Response>`.
+///
+/// # Safety
+///
+/// `url_ptr` must be null or a Perry-runtime `StringHeader`.
+#[no_mangle]
+pub unsafe extern "C" fn js_axios_head(url_ptr: *const StringHeader) -> *mut Promise {
+    let url = read_str(url_ptr).ok_or("Invalid URL");
+    run_request("HEAD", url, |client, url| client.head(&url))
+}
+
+/// `axios.options(url) -> Promise<Response>`.
+///
+/// # Safety
+///
+/// `url_ptr` must be null or a Perry-runtime `StringHeader`.
+#[no_mangle]
+pub unsafe extern "C" fn js_axios_options(url_ptr: *const StringHeader) -> *mut Promise {
+    let url = read_str(url_ptr).ok_or("Invalid URL");
+    run_request("OPTIONS", url, |client, url| {
+        client.request(reqwest::Method::OPTIONS, &url)
+    })
+}
+
 /// `axios.post(url, data) -> Promise<Response>`.
 ///
 /// # Safety

--- a/crates/perry-hir/src/js_transform/local_natives.rs
+++ b/crates/perry-hir/src/js_transform/local_natives.rs
@@ -1346,7 +1346,10 @@ pub fn detect_native_instance_creation_with_context(
                 ("http2", "createSecureServer") => "Http2SecureServer",
                 ("node-cron", "schedule") => "CronJob",
                 ("readline", "createInterface") => "Interface",
-                ("axios", "get" | "post" | "put" | "delete" | "patch" | "request") => "Response",
+                (
+                    "axios",
+                    "get" | "post" | "put" | "delete" | "patch" | "head" | "options" | "request",
+                ) => "Response",
                 // Issue #1193: `const $ = load(html)` / `loadFragment(html)`
                 // returns the jQuery-like callable used as `$(selector)`.
                 // Tagging the local as CheerioAPI lets the rewriter below

--- a/crates/perry-hir/src/js_transform/local_natives.rs
+++ b/crates/perry-hir/src/js_transform/local_natives.rs
@@ -1159,6 +1159,9 @@ pub fn fix_native_instance_expr_with_locals(
         Expr::Unary { operand, .. } => {
             fix_native_instance_expr_with_locals(operand, native_instances, local_id_instances);
         }
+        Expr::StringCoerce(value) => {
+            fix_native_instance_expr_with_locals(value, native_instances, local_id_instances);
+        }
         Expr::Logical { left, right, .. } => {
             fix_native_instance_expr_with_locals(left, native_instances, local_id_instances);
             fix_native_instance_expr_with_locals(right, native_instances, local_id_instances);
@@ -1217,6 +1220,24 @@ pub fn fix_native_instance_expr_with_locals(
         Expr::PropertyGet {
             object, property, ..
         } => {
+            if let Expr::LocalGet(local_id) = object.as_ref() {
+                if matches!(property.as_str(), "status" | "statusText" | "data")
+                    && matches!(
+                        local_id_instances.get(local_id),
+                        Some((module, class)) if module == "axios" && class == "Response"
+                    )
+                {
+                    let object_expr = std::mem::replace(object.as_mut(), Expr::Undefined);
+                    *expr = Expr::NativeMethodCall {
+                        module: "axios".to_string(),
+                        class_name: Some("Response".to_string()),
+                        object: Some(Box::new(object_expr)),
+                        method: property.clone(),
+                        args: Vec::new(),
+                    };
+                    return;
+                }
+            }
             // Recurse into the object first so any nested `$(sel)` Call has
             // been rewritten to a cheerio NativeMethodCall.
             fix_native_instance_expr_with_locals(object, native_instances, local_id_instances);
@@ -1325,6 +1346,7 @@ pub fn detect_native_instance_creation_with_context(
                 ("http2", "createSecureServer") => "Http2SecureServer",
                 ("node-cron", "schedule") => "CronJob",
                 ("readline", "createInterface") => "Interface",
+                ("axios", "get" | "post" | "put" | "delete" | "patch" | "request") => "Response",
                 // Issue #1193: `const $ = load(html)` / `loadFragment(html)`
                 // returns the jQuery-like callable used as `$(selector)`.
                 // Tagging the local as CheerioAPI lets the rewriter below

--- a/crates/perry-hir/tests/axios_response_property_lowering.rs
+++ b/crates/perry-hir/tests/axios_response_property_lowering.rs
@@ -1,0 +1,44 @@
+use perry_diagnostics::SourceCache;
+use perry_hir::{clear_current_module_source, fix_local_native_instances, lower_module};
+use perry_parser::parse_typescript_with_cache;
+
+#[test]
+fn awaited_axios_response_properties_keep_native_dispatch() {
+    let mut cache = SourceCache::new();
+    let parsed = parse_typescript_with_cache(
+        r#"
+        import axios from "axios";
+
+        async function main() {
+            const response = await axios.get("https://example.com/data");
+            console.log(`status=${response.status}`);
+            console.log(`ok=${response.data.ok}`);
+        }
+        "#,
+        "/tmp/axios_response_property_lowering.ts",
+        &mut cache,
+    )
+    .expect("parse");
+    let mut module = lower_module(
+        &parsed.module,
+        "test",
+        "/tmp/axios_response_property_lowering.ts",
+    )
+    .expect("lower");
+    clear_current_module_source();
+    fix_local_native_instances(&mut module);
+
+    let main = module
+        .functions
+        .iter()
+        .find(|function| function.name == "main")
+        .expect("main function");
+    let hir = format!("{:#?}", main.body);
+    assert!(
+        hir.matches("class_name: Some(").count() == 2
+            && hir.matches("\"Response\"").count() == 2
+            && hir.contains("method: \"status\"")
+            && hir.contains("method: \"data\""),
+        "awaited Axios response properties lost native dispatch:\n{hir}"
+    );
+}

--- a/crates/perry-hir/tests/axios_response_property_lowering.rs
+++ b/crates/perry-hir/tests/axios_response_property_lowering.rs
@@ -11,8 +11,12 @@ fn awaited_axios_response_properties_keep_native_dispatch() {
 
         async function main() {
             const response = await axios.get("https://example.com/data");
+            const head = await axios.head("https://example.com/data");
+            const options = await axios.options("https://example.com/data");
             console.log(`status=${response.status}`);
             console.log(`ok=${response.data.ok}`);
+            console.log(`head=${head.status}:${head.data}`);
+            console.log(`options=${options.status}:${options.data}`);
         }
         "#,
         "/tmp/axios_response_property_lowering.ts",
@@ -35,8 +39,8 @@ fn awaited_axios_response_properties_keep_native_dispatch() {
         .expect("main function");
     let hir = format!("{:#?}", main.body);
     assert!(
-        hir.matches("class_name: Some(").count() == 2
-            && hir.matches("\"Response\"").count() == 2
+        hir.matches("class_name: Some(").count() == 6
+            && hir.matches("\"Response\"").count() == 6
             && hir.contains("method: \"status\"")
             && hir.contains("method: \"data\""),
         "awaited Axios response properties lost native dispatch:\n{hir}"

--- a/crates/perry-stdlib/src/axios.rs
+++ b/crates/perry-stdlib/src/axios.rs
@@ -53,9 +53,10 @@ pub struct AxiosResponseHandle {
     pub headers: Vec<(String, String)>,
 }
 
-/// axios.get(url) -> Promise<AxiosResponse>
-#[no_mangle]
-pub unsafe extern "C" fn js_axios_get(url_ptr: *const StringHeader) -> *mut Promise {
+unsafe fn request_without_body(
+    url_ptr: *const StringHeader,
+    method: reqwest::Method,
+) -> *mut Promise {
     let promise = js_promise_new();
 
     let url = match string_from_header(url_ptr) {
@@ -69,7 +70,7 @@ pub unsafe extern "C" fn js_axios_get(url_ptr: *const StringHeader) -> *mut Prom
     };
     spawn_for_promise(promise as *mut u8, async move {
         let client = reqwest::Client::new();
-        match client.get(&url).send().await {
+        match client.request(method, &url).send().await {
             Ok(response) => {
                 let status = response.status().as_u16();
                 let status_text = response
@@ -91,10 +92,8 @@ pub unsafe extern "C" fn js_axios_get(url_ptr: *const StringHeader) -> *mut Prom
                             data,
                             headers,
                         });
-                        // Issue #340: NaN-box the handle as POINTER_TAG
-                        // (0x7FFD) so the awaiter sees a proper handle
-                        // value, not a subnormal float that decays to
-                        // undefined on `r.status` / `r.data` accesses.
+                        // NaN-box the handle so the awaiter keeps it as an
+                        // object instead of treating the small id as a number.
                         Ok((handle as u64) | 0x7FFD_0000_0000_0000)
                     }
                     Err(e) => Err(format!("Failed to read response body: {}", e)),
@@ -105,6 +104,24 @@ pub unsafe extern "C" fn js_axios_get(url_ptr: *const StringHeader) -> *mut Prom
     });
 
     promise
+}
+
+/// axios.get(url) -> Promise<AxiosResponse>
+#[no_mangle]
+pub unsafe extern "C" fn js_axios_get(url_ptr: *const StringHeader) -> *mut Promise {
+    request_without_body(url_ptr, reqwest::Method::GET)
+}
+
+/// axios.head(url) -> Promise<AxiosResponse>
+#[no_mangle]
+pub unsafe extern "C" fn js_axios_head(url_ptr: *const StringHeader) -> *mut Promise {
+    request_without_body(url_ptr, reqwest::Method::HEAD)
+}
+
+/// axios.options(url) -> Promise<AxiosResponse>
+#[no_mangle]
+pub unsafe extern "C" fn js_axios_options(url_ptr: *const StringHeader) -> *mut Promise {
+    request_without_body(url_ptr, reqwest::Method::OPTIONS)
 }
 
 /// axios.post(url, data) -> Promise<AxiosResponse>

--- a/crates/perry-ui-android/src/stdlib_stubs.rs
+++ b/crates/perry-ui-android/src/stdlib_stubs.rs
@@ -67,6 +67,16 @@ pub extern "C" fn js_axios_delete() -> i64 {
 pub extern "C" fn js_axios_get() -> i64 {
     0
 }
+
+#[no_mangle]
+pub extern "C" fn js_axios_head() -> i64 {
+    0
+}
+
+#[no_mangle]
+pub extern "C" fn js_axios_options() -> i64 {
+    0
+}
 #[no_mangle]
 pub extern "C" fn js_axios_post() -> i64 {
     0

--- a/crates/perry/src/commands/compile/collect_modules.rs
+++ b/crates/perry/src/commands/compile/collect_modules.rs
@@ -760,6 +760,9 @@ fn collect_module_one(
         }
     };
     *next_class_id = new_next_class_id; // Update the global class_id counter
+    // Preserve native result types before async lowering splits awaited values
+    // across synthetic locals. The later global fixup remains for inlined code.
+    perry_hir::fix_local_native_instances(&mut hir_module);
 
     // #2309 Stage 2: fold build-time `process.env` branches BEFORE dynamic
     // `import()` edges are registered below, so a dead `import()` inside a

--- a/docs/api/perry.d.ts
+++ b/docs/api/perry.d.ts
@@ -205,8 +205,6 @@ declare module "axios" {
   /** stdlib */
   export function create(...args: any[]): any;
   /** stdlib */
-  export default function (...args: any[]): any;
-  /** stdlib */
   function _delete(...args: any[]): any;
   export { _delete as delete };
   /** stdlib */
@@ -223,6 +221,20 @@ declare module "axios" {
   export function put(...args: any[]): any;
   /** stdlib */
   export function request(...args: any[]): any;
+  /** stdlib */
+  const _default: ((...args: any[]) => any) & {
+    all: typeof all;
+    create: typeof create;
+    delete: typeof _delete;
+    get: typeof get;
+    head: typeof head;
+    options: typeof options;
+    patch: typeof patch;
+    post: typeof post;
+    put: typeof put;
+    request: typeof request;
+  };
+  export default _default;
 }
 
 declare module "bcrypt" {

--- a/tests/release/packages/axios-get/entry.ts
+++ b/tests/release/packages/axios-get/entry.ts
@@ -1,7 +1,13 @@
 import axios from "axios";
+import { createHash } from "node:crypto";
 import { createServer, IncomingMessage, ServerResponse } from "node:http";
 
 async function main(): Promise<void> {
+    const hashes: any[] = [];
+    for (let i = 0; i < 16; i++) {
+        hashes.push(createHash("sha256"));
+    }
+
     const port = 18902;
     const server = createServer((req: IncomingMessage, res: ServerResponse) => {
         if (req.url === "/json") {
@@ -22,6 +28,14 @@ async function main(): Promise<void> {
     console.log(`status=${r.status}`);
     console.log(`data.ok=${r.data.ok}`);
     console.log(`data.path=${r.data.path}`);
+
+    let foreignStatus: any = undefined;
+    for (let i = 0; i < hashes.length; i++) {
+        if (hashes[i].status !== undefined) {
+            foreignStatus = hashes[i].status;
+        }
+    }
+    console.log(`foreign.status=${String(foreignStatus)}`);
 
     server.close();
 }

--- a/tests/release/packages/axios-get/entry.ts
+++ b/tests/release/packages/axios-get/entry.ts
@@ -25,7 +25,11 @@ async function main(): Promise<void> {
     });
 
     const r = await axios.get(`http://127.0.0.1:${port}/json`);
+    const head = await axios.head(`http://127.0.0.1:${port}/json`);
+    const options = await axios.options(`http://127.0.0.1:${port}/json`);
     console.log(`status=${r.status}`);
+    console.log(`head.status=${head.status}`);
+    console.log(`options.status=${options.status}`);
     console.log(`data.ok=${r.data.ok}`);
     console.log(`data.path=${r.data.path}`);
 

--- a/tests/release/packages/axios-get/expected.txt
+++ b/tests/release/packages/axios-get/expected.txt
@@ -1,3 +1,4 @@
 status=200
 data.ok=true
 data.path=/json
+foreign.status=undefined

--- a/tests/release/packages/axios-get/expected.txt
+++ b/tests/release/packages/axios-get/expected.txt
@@ -1,4 +1,6 @@
 status=200
+head.status=200
+options.status=200
 data.ok=true
 data.path=/json
 foreign.status=undefined

--- a/tests/release/packages/axios-get/package.json
+++ b/tests/release/packages/axios-get/package.json
@@ -3,14 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "Tier-3 fixture: GET round-trip via the `axios` npm package against an in-process node:http server. Tests axios end-to-end + the node:http server path that issue #589 surfaced — both pieces in one fixture so a regression in either side fails this.",
+  "description": "Tier-3 fixture: GET round-trip via Perry's native axios module against an in-process node:http server.",
   "dependencies": {
     "axios": "^1.18.0"
-  },
-  "perry": {
-    "compilePackages": ["axios"],
-    "allow": {
-      "compilePackages": ["axios"]
-    }
   }
 }


### PR DESCRIPTION
## Summary

Fix Axios editor types and preserve response properties through async lowering without exposing them on unrelated native handles.

## Changes

- Preserve Axios `Response` native-instance metadata before async lowering splits awaited values across synthetic locals.
- Lower `status`, `statusText`, and `data` reads to the existing Axios accessors.
- Add native `axios.head()` and `axios.options()` support across optimized and bundled runtime paths.
- Type the callable Axios default export with its static methods.
- Run the release fixture through Perry's supported native Axios path.
- Add a mixed Axios and `node:crypto` regression check for handle collisions.
- Regenerate the Perry declaration file and add a changelog fragment.

## Related issue

Fixes #6851

## Test plan

- [x] `cargo build --release -p perry`
- [x] `cargo test -p perry-hir --test axios_response_property_lowering`
- [x] `cargo test -p perry-api-manifest`
- [x] `cargo check -p perry-ext-axios`
- [x] `PERRY_NO_CACHE=1 tests/release/packages/axios-get/fixture.sh`
- [x] `tsc --noEmit` against `docs/api/perry.d.ts`
- [x] `git diff --check`

## Output

```text
status=200
head.status=200
options.status=200
data.ok=true
data.path=/json
foreign.status=undefined
PASS axios-get
```

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commit follows the repository's conventional prefix style
- [x] I have read CONTRIBUTING.md and agree to the Code of Conduct
