### PR TITLE
fix(runtime): guard AbortSignal handle resolution

### DIFF
--- a/crates/perry-runtime/src/url/abort.rs
+++ b/crates/perry-runtime/src/url/abort.rs
@@ -188,6 +188,9 @@ pub(crate) fn abort_signal_ptr_from_value(value: f64) -> Option<*mut ObjectHeade
     if ptr.is_null() {
         return None;
     }
+    if crate::value::addr_class::is_handle_band(ptr as usize) {
+        return None;
+    }
     let is_signal = unsafe { (*ptr).class_id == ABORT_SIGNAL_CLASS_ID };
     is_signal.then_some(ptr)
 }
@@ -641,3 +644,14 @@ static KEEP_ABORT_SIGNAL_ANY: extern "C" fn(*mut crate::array::ArrayHeader) -> *
 #[used]
 static KEEP_ABORT_SIGNAL_THROW_IF_ABORTED: extern "C" fn(*mut ObjectHeader) -> f64 =
     js_abort_signal_throw_if_aborted;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_ptr_rejects_pointer_tagged_handle() {
+        let value = f64::from_bits(POINTER_TAG_AC | 5);
+        assert!(js_abort_signal_resolve_ptr(value).is_null());
+    }
+}


### PR DESCRIPTION
## Summary

Reject pointer-tagged registry handles before checking whether a value is an AbortSignal.

## Changes

- Guard `abort_signal_ptr_from_value` against the shared handle band.
- Add a regression test for a pointer-tagged handle.
- Remove seven `node:events` SIGSEGVs.

## Related issue

Closes #6779

## Test plan

- [x] `cargo test -p perry-runtime resolve_ptr_rejects_pointer_tagged_handle --lib`
- [x] `./run_parity_tests.sh --suite node-suite --module events` — 69 pass, 0 failures, 0 crashes, 0 skips

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md
- [x] My commit follows the `fix:` convention
- [x] I have read CONTRIBUTING.md and agree to the Code of Conduct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of abort signal values to reject invalid tagged handle representations.
  * Prevented handle-like values from being incorrectly interpreted as valid abort signals.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->