### PR TITLE
test(zlib): expand granular Node parity coverage

### DIFF
--- a/test-parity/node-suite/zlib/README.md
+++ b/test-parity/node-suite/zlib/README.md
@@ -1,22 +1,176 @@
-# node:zlib granular parity suite
+# `node:zlib` granular parity suite
 
-Focused Node.js parity cases for Perry's `node:zlib` compatibility layer,
-ported from `nodejs/node` `test/parallel/test-zlib-*.js` plus Deno's
-node_compat zlib tests.
+This suite compares small, fixed `node:zlib` contracts. Node 26.5.0 is the
+oracle. Each fixture prints semantic state or error shape; no fixture compares
+backend-specific compressed bytes.
 
-Cases are deterministic: every encode/decode is a closed round-trip on a
-fixed input, every raw-bytes assertion is printed in hex so byte-for-byte
-diff against `node --experimental-strip-types` is reliable.
+## Locked sources
 
-Coverage areas:
-- `imports/` — module shape (named / namespace / prefixless)
-- `constants/` — `zlib.constants.*` flush/return/level/strategy values
-- `gzip/` — `gzipSync` / `gunzipSync` and `gzip` / `gunzip` promise round-trips
-- `deflate/` — `deflateSync` / `inflateSync` zlib-format round-trips
-- `raw/` — `deflateRawSync` / `inflateRawSync` raw deflate (no header)
-- `unzip/` — `unzipSync` auto-detect gzip vs deflate
-- `crc32/` — `zlib.crc32(buf, [seed])`
-- `brotli/` — `brotliCompressSync` / `brotliDecompressSync` round-trips
-- `convenience/` — `typeof` checks of class/factory exports
+- Node 26.5.0 commit [`bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb`][node-tree]:
+  [`lib/zlib.js`][node-lib] and all 68 zlib-named tests under `test/`.
+- Deno commit [`34c46613cbe20450b74c0e8d4f0fd8f6f781d807`][deno-tree]:
+  [`tests/unit_node/zlib_test.ts`][deno-test],
+  [`ext/node/polyfills/zlib.js`][deno-lib], and the native zlib ops.
+- Bun commit [`43d60f69c95a9f31591165816ced29b83e94673e`][bun-tree]:
+  [`src/js/node/zlib.ts`][bun-lib], [`test/js/node/zlib/`][bun-zlib-tests], and
+  Bun's vendored Node zlib tests.
+- Local runtimes: Node 26.5.0, Bun 1.2.18, and Deno 2.9.3.
 
-Compatibility target: Node 22+ / current LTS behavior.
+## Measurements
+
+The audit grew the suite from 58 to 92 fixtures. Three independent Node runs
+produced 92 clean exits and the same ordered stdout SHA-256:
+`20e40e51e5edc045cc61980f1bcc7a1c404d2dc2af096527c0dea925c536da76`.
+
+| Runtime     |               Result | Stable differences                        |
+| ----------- | -------------------: | ----------------------------------------- |
+| Node 26.5.0 |   92/92 oracle exits | none                                      |
+| Perry       | 63 matches, 29 diffs | no compile failures, crashes, or timeouts |
+| Bun 1.2.18  |  86 matches, 6 diffs | no errors, crashes, or timeouts           |
+| Deno 2.9.3  |  84 matches, 8 diffs | no errors, crashes, or timeouts           |
+
+Perry's 29 diffs cover callback context, immutable exports, constructor and
+prototype identity, `info`, CRC seed validation, dictionary application,
+trailing input, option validation and getter order, exact stream state,
+`bytesWritten`, multi-codec stream behavior, flush order, and truncated input.
+Five new contracts already match: dictionary source types, `SharedArrayBuffer`
+input, semantic Brotli params, level/strategy defaults and ranges, and
+reset/params before the first write.
+
+Bun differs on Brotli and Zstd dictionary application, option getter order, the
+legacy `bytesRead` alias, `crc32(ArrayBuffer)`, and `rejectGarbageAfterEnd`.
+Deno differs on all four dictionary application fixtures, invalid Brotli input,
+legacy alias enumerability, getter order, and `rejectGarbageAfterEnd`.
+
+Run the focused Perry comparison with:
+
+```sh
+NODE_BIN=/path/to/node-v26.5.0/bin/node \
+  python3 scripts/node_suite_run.py target/release/perry "$PWD" zlib
+```
+
+## Added contracts
+
+Every row names the exact upstream evidence and the gap in the old 58-fixture
+suite.
+
+| Fixture                                  | Source                                                                                                               | Missing contract                                                                                      |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `async/error-callback-shape.ts`          | [`lib/zlib.js`][node-lib], [`test-zlib-from-gzip-with-trailing-garbage.js`][node-trailing]                           | Async decode errors call back later with one error argument, no output, and the engine receiver.      |
+| `async/options-overload-and-callback.ts` | [`test-zlib-convenience-methods.js`][node-convenience]                                                               | The three-argument options overload preserves callback arity, receiver, result type, and async order. |
+| `constants/immutability.ts`              | [`test-zlib-const.js`][node-const]                                                                                   | `codes`, its values, and `constants` values reject writes and keep their values.                      |
+| `convenience/constructors.ts`            | [`test-zlib-deflate-constructors.js`][node-constructors], [`zlib.test.js`][bun-zlib-main]                            | Public constructors work with and without `new`, keep their names, and create matching instances.     |
+| `convenience/factory-instances.ts`       | [`lib/zlib.js`][node-lib], [`zlib.test.js`][bun-zlib-main]                                                           | Every `create*` factory returns its matching public class.                                            |
+| `convenience/info-result.ts`             | [`test-zlib-convenience-methods.js`][node-convenience]                                                               | Sync compression and decompression with `info: true` return `{ buffer, engine }`.                     |
+| `convenience/prototype-chains.ts`        | [`lib/zlib.js`][node-lib], [`zlib.test.js`][bun-zlib-main]                                                           | Constructor descriptors and Zlib/Brotli prototype parents match Node.                                 |
+| `crc32/seed-validation.ts`               | [`test-zlib-crc32.js`][node-crc], [`test-zlib-negative-zero.js`][node-negative-zero]                                 | CRC seeds accept uint32 bounds, coerce `-0`, and reject wrong types and ranges.                       |
+| `dictionary/brotli-roundtrip.ts`         | [`test-zlib-brotli-dictionary.js`][node-brotli-dictionary]                                                           | Brotli uses the supplied dictionary and fails without it.                                             |
+| `dictionary/deflate-roundtrip.ts`        | [`test-zlib-dictionary.js`][node-dictionary]                                                                         | Deflate output requires the matching preset dictionary.                                               |
+| `dictionary/invalid-type.ts`             | [`test-zlib-deflate-constructors.js`][node-constructors]                                                             | Deflate rejects non-buffer dictionary values with `ERR_INVALID_ARG_TYPE`.                             |
+| `dictionary/source-types.ts`             | [`test-zlib-deflate-constructors.js`][node-constructors], [`test-zlib-brotli-dictionary.js`][node-brotli-dictionary] | Buffer, Uint8Array, DataView, and ArrayBuffer dictionaries keep their bytes.                          |
+| `dictionary/stream-application.ts`       | [`test-zlib-dictionary.js`][node-dictionary]                                                                         | `createDeflate()` applies, rather than only accepts, its dictionary.                                  |
+| `dictionary/zstd-roundtrip.ts`           | [`test-zlib-zstd-dictionary.js`][node-zstd-dictionary]                                                               | Zstd output requires the matching dictionary.                                                         |
+| `gzip/trailing-null-bytes.ts`            | [`test-zlib-from-gzip-with-trailing-garbage.js`][node-trailing]                                                      | Sync and callback gunzip ignore fixed trailing NUL bytes after valid members.                         |
+| `imports/legacy-constant-aliases.ts`     | [`lib/zlib.js`][node-lib]                                                                                            | Legacy direct constants equal `constants.*` and use non-enumerable, read-only descriptors.            |
+| `inputs/shared-array-buffer.ts`          | [`lib/zlib.js`][node-lib], [`test-zlib-convenience-methods.js`][node-convenience]                                    | One-shot codecs accept `SharedArrayBuffer` and return a Buffer.                                       |
+| `options/brotli-params-roundtrip.ts`     | [`test-zlib-brotli.js`][node-brotli], [`zlib_test.ts`][deno-test]                                                    | Fixed Brotli quality values round-trip semantically at min, middle, and max.                          |
+| `options/chunk-size-validation.ts`       | [`test-zlib-deflate-constructors.js`][node-constructors]                                                             | `chunkSize` checks type, lower bound, NaN, and infinity.                                              |
+| `options/flush-validation.ts`            | [`test-zlib-flush-flags.js`][node-flush-flags]                                                                       | `flush` and `finishFlush` accept valid flags and reject wrong types and ranges.                       |
+| `options/level-strategy-validation.ts`   | [`test-zlib-deflate-constructors.js`][node-constructors], [`test-zlib-failed-init.js`][node-failed-init]             | `level`, `memLevel`, and `strategy` enforce type/range rules and map NaN to defaults.                 |
+| `options/max-output-length.ts`           | [`test-zlib-maxOutputLength.js`][node-max-output], [`zlib_test.ts`][deno-test]                                       | Sync and callback Brotli enforce the output cap and return `ERR_BUFFER_TOO_LARGE`.                    |
+| `options/validation-order.ts`            | [`lib/zlib.js`][node-lib]                                                                                            | Observable option getters run in Node's exact order.                                                  |
+| `options/window-bits-zero.ts`            | [`test-zlib-zero-windowBits.js`][node-zero-window]                                                                   | Zero is valid for inflate/gunzip/unzip and invalid for compressors.                                   |
+| `streams/bytes-written-trailing.ts`      | [`test-zlib-premature-end.js`][node-premature], [`bytesWritten.test.ts`][bun-bytes-written]                          | A decoder counts consumed compressed bytes, not fixed trailing input.                                 |
+| `streams/close-state.ts`                 | [`test-zlib-close-after-write.js`][node-close-write], [`lib/zlib.js`][node-lib]                                      | `close()` returns undefined, clears the handle, sets closed state, and stays idempotent.              |
+| `streams/codec-roundtrips.ts`            | [`test-zlib-create-raw.js`][node-create-raw], [`test-zlib-brotli-from-string.js`][node-brotli-string]                | Deflate, raw, gzip, unzip, and Brotli factories each complete a stream round-trip.                    |
+| `streams/error-close.ts`                 | [`test-zlib-close-after-error.js`][node-close-error]                                                                 | A decode error closes and destroys the zlib stream before a second close.                             |
+| `streams/flush-order.ts`                 | [`test-zlib-flush-write-sync-interleaved.js`][node-flush-order]                                                      | Write and flush callbacks keep enqueue order through end.                                             |
+| `streams/reset-before-write.ts`          | [`test-zlib-reset-before-write.js`][node-reset-before]                                                               | `reset()` and `params()` both work before the first write.                                            |
+| `unzip/one-byte-members.ts`              | [`test-zlib-unzip-one-byte-chunks.js`][node-one-byte]                                                                | Streaming unzip detects concatenated gzip members across one-byte writes.                             |
+| `validation/params-arguments.ts`         | [`test-zlib-deflate-constructors.js`][node-constructors]                                                             | `params()` validates level before strategy and reports exact error classes and codes.                 |
+| `validation/reject-trailing-garbage.ts`  | [`test-zlib-reject-garbage-after-end.js`][node-reject-garbage]                                                       | The new Node 26 boolean option rejects a second deflate stream and validates its type.                |
+| `validation/truncated-finish-flush.ts`   | [`test-zlib-truncated.js`][node-truncated]                                                                           | Default decompression rejects truncation while `Z_SYNC_FLUSH` returns a valid prefix.                 |
+
+## Complete fixture map
+
+Each name below is relative to this directory. The added-contract table gives
+the exact source for every new fixture; the original fixtures use the same
+locked Node, Deno, and Bun source families.
+
+| Area           | Fixtures                                                                                                                                                                                                                                               | Contract group                                                                         |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| `async/`       | `callback-one-shot.ts`, `error-callback-shape.ts`, `options-overload-and-callback.ts`, `promisify-gzip.ts`, `promisify-one-shot.ts`                                                                                                                    | Callback and promisify one-shot behavior.                                              |
+| `brotli/`      | `roundtrip-ascii.ts`, `roundtrip-empty.ts`, `roundtrip-large.ts`                                                                                                                                                                                       | Semantic sync Brotli round-trips.                                                      |
+| `constants/`   | `brotli.ts`, `codes.ts`, `compression-levels.ts`, `flush-values.ts`, `immutability.ts`, `modern-version-table.ts`, `return-codes.ts`, `strategy.ts`                                                                                                    | Public constant values, reverse codes, modern entries, and mutability.                 |
+| `convenience/` | `callback-fn-shapes.ts`, `class-shapes.ts`, `constructors.ts`, `factory-instances.ts`, `factory-shapes.ts`, `info-result.ts`, `prototype-chains.ts`                                                                                                    | Function, class, factory, instance, prototype, and info shapes.                        |
+| `crc32/`       | `basic.ts`, `binary-vectors.ts`, `seed-chaining.ts`, `seed-validation.ts`, `string-input.ts`                                                                                                                                                           | Reference vectors, input forms, chaining, and seed rules.                              |
+| `deflate/`     | `roundtrip-ascii.ts`, `roundtrip-binary.ts`, `roundtrip-empty.ts`, `zlib-format-header.ts`                                                                                                                                                             | Zlib-wrapped deflate semantics and framing.                                            |
+| `dictionary/`  | `brotli-roundtrip.ts`, `deflate-roundtrip.ts`, `invalid-type.ts`, `source-types.ts`, `stream-application.ts`, `zstd-roundtrip.ts`                                                                                                                      | Dictionary application, source types, and validation.                                  |
+| `errors/`      | `brotli-invalid.ts`, `gunzip-bad-magic.ts`, `gunzip-truncated.ts`, `inflate-raw-format.ts`, `unzip-garbage.ts`                                                                                                                                         | Fixed invalid and truncated inputs.                                                    |
+| `gzip/`        | `magic-bytes.ts`, `multi-member.ts`, `roundtrip-ascii.ts`, `roundtrip-binary.ts`, `roundtrip-empty.ts`, `roundtrip-large.ts`, `roundtrip-utf8.ts`, `trailing-null-bytes.ts`                                                                            | Gzip framing, inputs, members, and allowed trailing NUL bytes.                         |
+| `imports/`     | `class-exports.ts`, `legacy-constant-aliases.ts`, `named-import.ts`, `namespace-import.ts`, `prefixless-import.ts`                                                                                                                                     | ESM/module shape and legacy aliases.                                                   |
+| `inputs/`      | `hex-encoding.ts`, `shared-array-buffer.ts`, `string-direct.ts`, `uint8array.ts`                                                                                                                                                                       | Fixed binary and string input forms.                                                   |
+| `options/`     | `brotli-params-roundtrip.ts`, `chunk-size-validation.ts`, `flush-validation.ts`, `level-strategy-validation.ts`, `max-output-length.ts`, `validation-order.ts`, `window-bits-zero.ts`                                                                  | Option semantics, validation, defaults, getters, and output caps.                      |
+| `raw/`         | `no-zlib-header.ts`, `roundtrip-ascii.ts`, `roundtrip-empty.ts`                                                                                                                                                                                        | Raw deflate framing and round-trips.                                                   |
+| `streams/`     | `bytes-written-trailing.ts`, `close-destroy-method-values.ts`, `close-state.ts`, `codec-roundtrips.ts`, `create-gzip-roundtrip.ts`, `error-close.ts`, `factory-typeofs.ts`, `flush-order.ts`, `instance-methods-and-bytes.ts`, `reset-before-write.ts` | Zlib stream methods, state, codecs, ordering, cleanup, and byte counts.                |
+| `unzip/`       | `auto-detect-deflate.ts`, `auto-detect-gzip.ts`, `one-byte-members.ts`                                                                                                                                                                                 | Format detection and member boundaries.                                                |
+| `validation/`  | `callback-required.ts`, `one-shot-buffer-sources.ts`, `one-shot-invalid-data.ts`, `one-shot-return-buffers.ts`, `params-arguments.ts`, `reject-trailing-garbage.ts`, `truncated-finish-flush.ts`                                                       | Trust-boundary types, callbacks, return types, params, trailing input, and truncation. |
+| `zstd/`        | `one-shot-roundtrip.ts`, `stream-roundtrip.ts`                                                                                                                                                                                                         | Zstd sync, callback, promisify, constructor, and stream behavior.                      |
+
+## Audit exclusions and stop rule
+
+The audit read every Node 26.5.0 zlib-named test plus the primary
+implementation. It stopped after the second pass found no other contract that
+was deterministic, portable, non-redundant, and safe for this granular suite.
+
+- We excluded 16 GiB, `kMaxLength`, OOM, memory-pressure, heapdump, fuzz,
+  random-byte, GC, weak-reference, and race tests.
+- We excluded fixture-file and fs-pipeline tests when a fixed in-memory fixture
+  already covers the zlib contract.
+- We excluded exact Brotli, Zstd, gzip, and flush bytes because backend and
+  library versions may change them. The suite compares decoded content, error
+  shape, or state instead.
+- We excluded generic Transform behavior already owned by the stream suite:
+  object writes, pipe teardown, write-after-end, write-after-close, and drain
+  pressure. The retained lifecycle cases probe zlib-specific state or ordering.
+- We excluded snapshot, worker, async-hooks provider, and ALS propagation tests.
+- We excluded private handle calls, internal inheritance hacks, and private
+  write-state memory tests. They test Node, Deno, or Bun internals rather than
+  Perry's public `node:zlib` contract.
+- We used no files, workers, signals, sleeps, timers, random data, large inputs,
+  forced GC, or backend-specific compressed fixtures.
+
+[node-tree]: https://github.com/nodejs/node/tree/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb
+[node-lib]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/lib/zlib.js
+[node-const]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-const.js
+[node-convenience]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-convenience-methods.js
+[node-constructors]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-deflate-constructors.js
+[node-crc]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-crc32.js
+[node-negative-zero]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-negative-zero.js
+[node-dictionary]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-dictionary.js
+[node-brotli-dictionary]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-brotli-dictionary.js
+[node-zstd-dictionary]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-zstd-dictionary.js
+[node-trailing]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-from-gzip-with-trailing-garbage.js
+[node-brotli]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-brotli.js
+[node-flush-flags]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-flush-flags.js
+[node-failed-init]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-failed-init.js
+[node-max-output]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-maxOutputLength.js
+[node-zero-window]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-zero-windowBits.js
+[node-premature]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-premature-end.js
+[node-close-write]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-close-after-write.js
+[node-create-raw]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-create-raw.js
+[node-brotli-string]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-brotli-from-string.js
+[node-close-error]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-close-after-error.js
+[node-flush-order]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-flush-write-sync-interleaved.js
+[node-reset-before]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-reset-before-write.js
+[node-one-byte]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-unzip-one-byte-chunks.js
+[node-reject-garbage]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-reject-garbage-after-end.js
+[node-truncated]: https://github.com/nodejs/node/blob/bebd1b8d92bf4cc917844d6335ed1ecf9c2a75fb/test/parallel/test-zlib-truncated.js
+[deno-tree]: https://github.com/denoland/deno/tree/34c46613cbe20450b74c0e8d4f0fd8f6f781d807
+[deno-test]: https://github.com/denoland/deno/blob/34c46613cbe20450b74c0e8d4f0fd8f6f781d807/tests/unit_node/zlib_test.ts
+[deno-lib]: https://github.com/denoland/deno/blob/34c46613cbe20450b74c0e8d4f0fd8f6f781d807/ext/node/polyfills/zlib.js
+[bun-tree]: https://github.com/oven-sh/bun/tree/43d60f69c95a9f31591165816ced29b83e94673e
+[bun-lib]: https://github.com/oven-sh/bun/blob/43d60f69c95a9f31591165816ced29b83e94673e/src/js/node/zlib.ts
+[bun-zlib-tests]: https://github.com/oven-sh/bun/tree/43d60f69c95a9f31591165816ced29b83e94673e/test/js/node/zlib
+[bun-zlib-main]: https://github.com/oven-sh/bun/blob/43d60f69c95a9f31591165816ced29b83e94673e/test/js/node/zlib/zlib.test.js
+[bun-bytes-written]: https://github.com/oven-sh/bun/blob/43d60f69c95a9f31591165816ced29b83e94673e/test/js/node/zlib/bytesWritten.test.ts

--- a/test-parity/node-suite/zlib/README.md
+++ b/test-parity/node-suite/zlib/README.md
@@ -20,26 +20,26 @@ backend-specific compressed bytes.
 
 The audit grew the suite from 58 to 92 fixtures. Three independent Node runs
 produced 92 clean exits and the same ordered stdout SHA-256:
-`20e40e51e5edc045cc61980f1bcc7a1c404d2dc2af096527c0dea925c536da76`.
+`9fca491aaffd2caea529f91f2e41b13b76dd773e049e25c39ac4fad6aa430658`.
 
 | Runtime     |               Result | Stable differences                        |
 | ----------- | -------------------: | ----------------------------------------- |
 | Node 26.5.0 |   92/92 oracle exits | none                                      |
-| Perry       | 63 matches, 29 diffs | no compile failures, crashes, or timeouts |
+| Perry       | 62 matches, 30 diffs | no compile failures, crashes, or timeouts |
 | Bun 1.2.18  |  86 matches, 6 diffs | no errors, crashes, or timeouts           |
-| Deno 2.9.3  |  84 matches, 8 diffs | no errors, crashes, or timeouts           |
+| Deno 2.9.3  |  83 matches, 9 diffs | no errors, crashes, or timeouts           |
 
-Perry's 29 diffs cover callback context, immutable exports, constructor and
+Perry's 30 diffs cover callback context, immutable exports, constructor and
 prototype identity, `info`, CRC seed validation, dictionary application,
 trailing input, option validation and getter order, exact stream state,
 `bytesWritten`, multi-codec stream behavior, flush order, and truncated input.
-Five new contracts already match: dictionary source types, `SharedArrayBuffer`
-input, semantic Brotli params, level/strategy defaults and ranges, and
-reset/params before the first write.
+Four new contracts already match: `SharedArrayBuffer` input, semantic Brotli
+params, level/strategy defaults and ranges, and reset/params before the first
+write.
 
 Bun differs on Brotli and Zstd dictionary application, option getter order, the
 legacy `bytesRead` alias, `crc32(ArrayBuffer)`, and `rejectGarbageAfterEnd`.
-Deno differs on all four dictionary application fixtures, invalid Brotli input,
+Deno differs on all five dictionary application fixtures, invalid Brotli input,
 legacy alias enumerability, getter order, and `rejectGarbageAfterEnd`.
 
 Run the focused Perry comparison with:
@@ -60,7 +60,7 @@ suite.
 | `async/options-overload-and-callback.ts` | [`test-zlib-convenience-methods.js`][node-convenience]                                                               | The three-argument options overload preserves callback arity, receiver, result type, and async order. |
 | `constants/immutability.ts`              | [`test-zlib-const.js`][node-const]                                                                                   | `codes`, its values, and `constants` values reject writes and keep their values.                      |
 | `convenience/constructors.ts`            | [`test-zlib-deflate-constructors.js`][node-constructors], [`zlib.test.js`][bun-zlib-main]                            | Public constructors work with and without `new`, keep their names, and create matching instances.     |
-| `convenience/factory-instances.ts`       | [`lib/zlib.js`][node-lib], [`zlib.test.js`][bun-zlib-main]                                                           | Every `create*` factory returns its matching public class.                                            |
+| `convenience/factory-instances.ts`       | [`lib/zlib.js`][node-lib], [`zlib.test.js`][bun-zlib-main]                                                           | Deflate, Inflate, Gzip, Unzip, and Brotli factories return their matching public classes.             |
 | `convenience/info-result.ts`             | [`test-zlib-convenience-methods.js`][node-convenience]                                                               | Sync compression and decompression with `info: true` return `{ buffer, engine }`.                     |
 | `convenience/prototype-chains.ts`        | [`lib/zlib.js`][node-lib], [`zlib.test.js`][bun-zlib-main]                                                           | Constructor descriptors and Zlib/Brotli prototype parents match Node.                                 |
 | `crc32/seed-validation.ts`               | [`test-zlib-crc32.js`][node-crc], [`test-zlib-negative-zero.js`][node-negative-zero]                                 | CRC seeds accept uint32 bounds, coerce `-0`, and reject wrong types and ranges.                       |

--- a/test-parity/node-suite/zlib/async/error-callback-shape.ts
+++ b/test-parity/node-suite/zlib/async/error-callback-shape.ts
@@ -1,0 +1,18 @@
+import { gunzip } from "node:zlib";
+
+const order: string[] = [];
+await new Promise<void>((resolve) => {
+  gunzip(Buffer.from("invalid"), function (this: any, error, output) {
+    order.push("callback");
+    console.log("error:", error?.name, error?.code);
+    console.log("output undefined:", output === undefined);
+    console.log("arguments length:", arguments.length);
+    console.log(
+      "receiver:",
+      this === undefined ? "undefined" : this?.constructor?.name,
+    );
+    resolve();
+  });
+  order.push("after-call");
+});
+console.log("order:", order.join(","));

--- a/test-parity/node-suite/zlib/async/options-overload-and-callback.ts
+++ b/test-parity/node-suite/zlib/async/options-overload-and-callback.ts
@@ -1,0 +1,19 @@
+import { gzip } from "node:zlib";
+
+const order: string[] = [];
+const settled = new Promise<void>((resolve) => {
+  gzip("callback contract", { level: 1 }, function (this: any, error, output) {
+    order.push("callback");
+    console.log("error:", error === null ? "null" : error?.name);
+    console.log("output buffer:", Buffer.isBuffer(output));
+    console.log("arguments length:", arguments.length);
+    console.log(
+      "receiver:",
+      this === undefined ? "undefined" : this?.constructor?.name,
+    );
+    resolve();
+  });
+});
+order.push("after-call");
+await settled;
+console.log("order:", order.join(","));

--- a/test-parity/node-suite/zlib/constants/immutability.ts
+++ b/test-parity/node-suite/zlib/constants/immutability.ts
@@ -1,0 +1,19 @@
+import * as zlib from "node:zlib";
+
+function assignmentResult(target: any, key: string, value: any) {
+  try {
+    target[key] = value;
+    return "assigned";
+  } catch (error: any) {
+    return `${error.name}:${error.code}`;
+  }
+}
+
+console.log("codes frozen:", Object.isFrozen(zlib.codes));
+console.log("codes value write:", assignmentResult(zlib.codes, "Z_OK", 1));
+console.log("codes export write:", assignmentResult(zlib, "codes", {}));
+console.log(
+  "constant value write:",
+  assignmentResult(zlib.constants, "Z_OK", 1),
+);
+console.log("values unchanged:", zlib.codes.Z_OK, zlib.constants.Z_OK);

--- a/test-parity/node-suite/zlib/constants/immutability.ts
+++ b/test-parity/node-suite/zlib/constants/immutability.ts
@@ -1,4 +1,4 @@
-import * as zlib from "node:zlib";
+import zlib from "node:zlib";
 
 function assignmentResult(target: any, key: string, value: any) {
   try {

--- a/test-parity/node-suite/zlib/convenience/constructors.ts
+++ b/test-parity/node-suite/zlib/convenience/constructors.ts
@@ -1,0 +1,27 @@
+import * as zlib from "node:zlib";
+
+for (
+  const name of [
+    "Deflate",
+    "DeflateRaw",
+    "Gzip",
+    "Gunzip",
+    "Inflate",
+    "InflateRaw",
+    "Unzip",
+    "BrotliCompress",
+    "BrotliDecompress",
+  ] as const
+) {
+  const Ctor = zlib[name] as any;
+  const called = Ctor();
+  const constructed = new Ctor();
+  console.log(
+    name,
+    called instanceof Ctor,
+    constructed instanceof Ctor,
+    Ctor.name,
+  );
+  called.destroy();
+  constructed.destroy();
+}

--- a/test-parity/node-suite/zlib/convenience/factory-instances.ts
+++ b/test-parity/node-suite/zlib/convenience/factory-instances.ts
@@ -1,0 +1,19 @@
+import * as zlib from "node:zlib";
+
+for (
+  const [factoryName, className] of [
+    ["createDeflate", "Deflate"],
+    ["createDeflateRaw", "DeflateRaw"],
+    ["createGzip", "Gzip"],
+    ["createGunzip", "Gunzip"],
+    ["createInflate", "Inflate"],
+    ["createInflateRaw", "InflateRaw"],
+    ["createUnzip", "Unzip"],
+    ["createBrotliCompress", "BrotliCompress"],
+    ["createBrotliDecompress", "BrotliDecompress"],
+  ] as const
+) {
+  const stream = (zlib[factoryName] as any)();
+  console.log(factoryName, stream instanceof (zlib[className] as any));
+  stream.destroy();
+}

--- a/test-parity/node-suite/zlib/convenience/info-result.ts
+++ b/test-parity/node-suite/zlib/convenience/info-result.ts
@@ -1,0 +1,17 @@
+import * as zlib from "node:zlib";
+
+const compressed = zlib.deflateSync(
+  "info contract",
+  { info: true } as any,
+) as any;
+console.log("compress keys:", Object.keys(compressed).sort().join(","));
+console.log("compress buffer:", Buffer.isBuffer(compressed.buffer));
+console.log("compress engine:", compressed.engine instanceof zlib.Deflate);
+
+const decompressed = zlib.inflateSync(
+  compressed.buffer,
+  { info: true } as any,
+) as any;
+console.log("decompress keys:", Object.keys(decompressed).sort().join(","));
+console.log("decompress output:", decompressed.buffer.toString());
+console.log("decompress engine:", decompressed.engine instanceof zlib.Inflate);

--- a/test-parity/node-suite/zlib/convenience/prototype-chains.ts
+++ b/test-parity/node-suite/zlib/convenience/prototype-chains.ts
@@ -1,0 +1,29 @@
+import * as zlib from "node:zlib";
+
+for (
+  const [name, parent] of [
+    ["Deflate", "Zlib"],
+    ["DeflateRaw", "Zlib"],
+    ["Gzip", "Zlib"],
+    ["Gunzip", "Zlib"],
+    ["Inflate", "Zlib"],
+    ["InflateRaw", "Zlib"],
+    ["Unzip", "Zlib"],
+    ["BrotliCompress", "Brotli"],
+    ["BrotliDecompress", "Brotli"],
+  ] as const
+) {
+  const Ctor = (zlib as any)[name];
+  const descriptor = Object.getOwnPropertyDescriptor(
+    Ctor.prototype,
+    "constructor",
+  )!;
+  console.log(
+    name,
+    Ctor.prototype.constructor === Ctor,
+    Object.getPrototypeOf(Ctor.prototype).constructor.name === parent,
+    descriptor.enumerable,
+    descriptor.writable,
+    descriptor.configurable,
+  );
+}

--- a/test-parity/node-suite/zlib/crc32/seed-validation.ts
+++ b/test-parity/node-suite/zlib/crc32/seed-validation.ts
@@ -1,0 +1,10 @@
+import { crc32 } from "node:zlib";
+
+console.log("negative zero:", crc32("abc", -0) === crc32("abc", 0));
+for (const value of [0, 0xffffffff, -1, 0x100000000, 1.5, "0"] as any[]) {
+  try {
+    console.log(String(value), crc32("abc", value));
+  } catch (error: any) {
+    console.log(String(value), error.name, error.code);
+  }
+}

--- a/test-parity/node-suite/zlib/dictionary/brotli-roundtrip.ts
+++ b/test-parity/node-suite/zlib/dictionary/brotli-roundtrip.ts
@@ -1,0 +1,19 @@
+import * as zlib from "node:zlib";
+
+const dictionary = Buffer.from(
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+);
+const input = Buffer.from(
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+);
+const compressed = zlib.brotliCompressSync(input, { dictionary } as any);
+console.log(
+  "with dictionary:",
+  zlib.brotliDecompressSync(compressed, { dictionary } as any).equals(input),
+);
+try {
+  zlib.brotliDecompressSync(compressed);
+  console.log("without dictionary: ok");
+} catch (error: any) {
+  console.log("without dictionary:", error.name, error.code);
+}

--- a/test-parity/node-suite/zlib/dictionary/deflate-roundtrip.ts
+++ b/test-parity/node-suite/zlib/dictionary/deflate-roundtrip.ts
@@ -1,0 +1,16 @@
+import * as zlib from "node:zlib";
+
+const dictionary = Buffer.from("common words for a preset dictionary");
+const input = Buffer.from("common words common words");
+const compressed = zlib.deflateSync(input, { dictionary });
+
+console.log(
+  "with dictionary:",
+  zlib.inflateSync(compressed, { dictionary }).toString(),
+);
+try {
+  zlib.inflateSync(compressed);
+  console.log("without dictionary: ok");
+} catch (error: any) {
+  console.log("without dictionary:", error.name, error.code);
+}

--- a/test-parity/node-suite/zlib/dictionary/invalid-type.ts
+++ b/test-parity/node-suite/zlib/dictionary/invalid-type.ts
@@ -1,0 +1,15 @@
+import * as zlib from "node:zlib";
+
+for (const value of ["dictionary", 1, true, {}, [1, 2, 3]] as any[]) {
+  try {
+    const stream = zlib.createDeflate({ dictionary: value });
+    console.log(typeof value, "ok");
+    stream.destroy();
+  } catch (error: any) {
+    console.log(
+      Array.isArray(value) ? "array" : typeof value,
+      error.name,
+      error.code,
+    );
+  }
+}

--- a/test-parity/node-suite/zlib/dictionary/source-types.ts
+++ b/test-parity/node-suite/zlib/dictionary/source-types.ts
@@ -24,6 +24,12 @@ const sources = [
 
 for (const [name, source] of sources) {
   const compressed = zlib.deflateSync(input, { dictionary: source as any });
+  try {
+    zlib.inflateSync(compressed);
+    console.log(name, "without dictionary: ok");
+  } catch (error: any) {
+    console.log(name, "without dictionary:", error.name, error.code);
+  }
   const output = zlib.inflateSync(compressed, { dictionary: source as any });
   console.log(name, output.toString());
 }

--- a/test-parity/node-suite/zlib/dictionary/source-types.ts
+++ b/test-parity/node-suite/zlib/dictionary/source-types.ts
@@ -1,0 +1,29 @@
+import * as zlib from "node:zlib";
+
+const dictionary = Buffer.from("dictionary bytes");
+const input = Buffer.from("dictionary bytes dictionary bytes");
+const sources = [
+  ["buffer", dictionary],
+  ["uint8array", new Uint8Array(dictionary)],
+  [
+    "dataview",
+    new DataView(
+      dictionary.buffer,
+      dictionary.byteOffset,
+      dictionary.byteLength,
+    ),
+  ],
+  [
+    "arraybuffer",
+    dictionary.buffer.slice(
+      dictionary.byteOffset,
+      dictionary.byteOffset + dictionary.byteLength,
+    ),
+  ],
+] as const;
+
+for (const [name, source] of sources) {
+  const compressed = zlib.deflateSync(input, { dictionary: source as any });
+  const output = zlib.inflateSync(compressed, { dictionary: source as any });
+  console.log(name, output.toString());
+}

--- a/test-parity/node-suite/zlib/dictionary/stream-application.ts
+++ b/test-parity/node-suite/zlib/dictionary/stream-application.ts
@@ -1,0 +1,24 @@
+import * as zlib from "node:zlib";
+
+const dictionary = Buffer.from("stream dictionary words");
+const input = Buffer.from("stream dictionary words stream dictionary words");
+const stream = zlib.createDeflate({ dictionary });
+const chunks: Buffer[] = [];
+stream.on("data", (chunk: Buffer) => chunks.push(chunk));
+await new Promise<void>((resolve, reject) => {
+  stream.on("end", resolve);
+  stream.on("error", reject);
+  stream.end(input);
+});
+const compressed = Buffer.concat(chunks);
+console.log(
+  "with dictionary:",
+  zlib.inflateSync(compressed, { dictionary }).toString(),
+);
+try {
+  zlib.inflateSync(compressed);
+  console.log("without dictionary: ok");
+} catch (error: any) {
+  console.log("without dictionary:", error.name, error.code);
+}
+stream.destroy();

--- a/test-parity/node-suite/zlib/dictionary/zstd-roundtrip.ts
+++ b/test-parity/node-suite/zlib/dictionary/zstd-roundtrip.ts
@@ -1,0 +1,19 @@
+import * as zlib from "node:zlib";
+
+const dictionary = Buffer.from(
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+);
+const input = Buffer.from(
+  "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+);
+const compressed = zlib.zstdCompressSync(input, { dictionary } as any);
+console.log(
+  "with dictionary:",
+  zlib.zstdDecompressSync(compressed, { dictionary } as any).equals(input),
+);
+try {
+  zlib.zstdDecompressSync(compressed);
+  console.log("without dictionary: ok");
+} catch (error: any) {
+  console.log("without dictionary:", error.name, error.code);
+}

--- a/test-parity/node-suite/zlib/gzip/trailing-null-bytes.ts
+++ b/test-parity/node-suite/zlib/gzip/trailing-null-bytes.ts
@@ -1,0 +1,15 @@
+import * as zlib from "node:zlib";
+
+const input = Buffer.concat([
+  zlib.gzipSync("abc"),
+  zlib.gzipSync("def"),
+  Buffer.alloc(4),
+]);
+
+console.log("sync:", zlib.gunzipSync(input).toString());
+await new Promise<void>((resolve) => {
+  zlib.gunzip(input, (error, output) => {
+    console.log("async:", error === null, output.toString());
+    resolve();
+  });
+});

--- a/test-parity/node-suite/zlib/imports/legacy-constant-aliases.ts
+++ b/test-parity/node-suite/zlib/imports/legacy-constant-aliases.ts
@@ -1,0 +1,14 @@
+import zlib from "node:zlib";
+
+for (
+  const key of ["Z_OK", "Z_FINISH", "Z_DEFAULT_COMPRESSION", "DEFLATE", "GZIP"]
+) {
+  const descriptor = Object.getOwnPropertyDescriptor(zlib, key)!;
+  console.log(
+    key,
+    (zlib as any)[key] === (zlib.constants as any)[key],
+    descriptor.enumerable,
+    descriptor.writable,
+    descriptor.configurable,
+  );
+}

--- a/test-parity/node-suite/zlib/inputs/shared-array-buffer.ts
+++ b/test-parity/node-suite/zlib/inputs/shared-array-buffer.ts
@@ -1,0 +1,7 @@
+import { gunzipSync, gzipSync } from "node:zlib";
+
+const input = new SharedArrayBuffer(5);
+new Uint8Array(input).set([104, 101, 108, 108, 111]);
+const output = gunzipSync(gzipSync(input));
+console.log("output:", output.toString());
+console.log("buffer:", Buffer.isBuffer(output));

--- a/test-parity/node-suite/zlib/options/brotli-params-roundtrip.ts
+++ b/test-parity/node-suite/zlib/options/brotli-params-roundtrip.ts
@@ -1,0 +1,9 @@
+import * as zlib from "node:zlib";
+
+const input = Buffer.from("brotli params contract ".repeat(4));
+for (const quality of [0, 6, 11]) {
+  const compressed = zlib.brotliCompressSync(input, {
+    params: { [zlib.constants.BROTLI_PARAM_QUALITY]: quality },
+  });
+  console.log(quality, zlib.brotliDecompressSync(compressed).equals(input));
+}

--- a/test-parity/node-suite/zlib/options/chunk-size-validation.ts
+++ b/test-parity/node-suite/zlib/options/chunk-size-validation.ts
@@ -1,0 +1,11 @@
+import { createDeflate } from "node:zlib";
+
+for (const value of ["64", 0, 63, 64, NaN, Infinity] as any[]) {
+  try {
+    const stream = createDeflate({ chunkSize: value });
+    console.log(String(value), "ok");
+    stream.destroy();
+  } catch (error: any) {
+    console.log(String(value), error.name, error.code);
+  }
+}

--- a/test-parity/node-suite/zlib/options/flush-validation.ts
+++ b/test-parity/node-suite/zlib/options/flush-validation.ts
@@ -1,0 +1,20 @@
+import { constants, createGzip } from "node:zlib";
+
+for (
+  const [key, value] of [
+    ["flush", constants.Z_SYNC_FLUSH],
+    ["flush", "sync"],
+    ["flush", 10000],
+    ["finishFlush", constants.Z_SYNC_FLUSH],
+    ["finishFlush", "sync"],
+    ["finishFlush", 10000],
+  ] as const
+) {
+  try {
+    const stream = createGzip({ [key]: value });
+    console.log(key, String(value), "ok");
+    stream.destroy();
+  } catch (error: any) {
+    console.log(key, String(value), error.name, error.code);
+  }
+}

--- a/test-parity/node-suite/zlib/options/level-strategy-validation.ts
+++ b/test-parity/node-suite/zlib/options/level-strategy-validation.ts
@@ -1,0 +1,27 @@
+import { constants, createDeflate } from "node:zlib";
+
+for (
+  const [key, values] of [
+    ["level", ["1", -2, -1, 0, 9, 10, NaN, Infinity]],
+    ["memLevel", ["1", 0, 1, 9, 10, Infinity]],
+    ["strategy", [
+      "0",
+      -1,
+      constants.Z_DEFAULT_STRATEGY,
+      constants.Z_FIXED,
+      5,
+      NaN,
+      Infinity,
+    ]],
+  ] as const
+) {
+  for (const value of values) {
+    try {
+      const stream = createDeflate({ [key]: value } as any);
+      console.log(key, String(value), "ok");
+      stream.destroy();
+    } catch (error: any) {
+      console.log(key, String(value), error.name, error.code);
+    }
+  }
+}

--- a/test-parity/node-suite/zlib/options/max-output-length.ts
+++ b/test-parity/node-suite/zlib/options/max-output-length.ts
@@ -1,0 +1,23 @@
+import * as zlib from "node:zlib";
+
+const compressed = zlib.brotliCompressSync(Buffer.alloc(128, 97));
+
+for (const maxOutputLength of [64, 128]) {
+  try {
+    const output = zlib.brotliDecompressSync(compressed, { maxOutputLength });
+    console.log(maxOutputLength, "ok", output.length);
+  } catch (error: any) {
+    console.log(maxOutputLength, error.name, error.code);
+  }
+}
+
+await new Promise<void>((resolve) => {
+  zlib.brotliDecompress(
+    compressed,
+    { maxOutputLength: 64 },
+    (error, output) => {
+      console.log("async", error?.name, error?.code, output === undefined);
+      resolve();
+    },
+  );
+});

--- a/test-parity/node-suite/zlib/options/validation-order.ts
+++ b/test-parity/node-suite/zlib/options/validation-order.ts
@@ -1,0 +1,30 @@
+import { createGzip } from "node:zlib";
+
+const reads: string[] = [];
+const options: any = {};
+for (
+  const key of [
+    "flush",
+    "finishFlush",
+    "chunkSize",
+    "maxOutputLength",
+    "rejectGarbageAfterEnd",
+    "windowBits",
+    "level",
+    "memLevel",
+    "strategy",
+    "dictionary",
+  ]
+) {
+  Object.defineProperty(options, key, {
+    enumerable: true,
+    get() {
+      reads.push(key);
+      return undefined;
+    },
+  });
+}
+
+const stream = createGzip(options);
+console.log("reads:", reads.join(","));
+stream.destroy();

--- a/test-parity/node-suite/zlib/options/window-bits-zero.ts
+++ b/test-parity/node-suite/zlib/options/window-bits-zero.ts
@@ -1,0 +1,19 @@
+import * as zlib from "node:zlib";
+
+for (
+  const [name, factory] of [
+    ["gzip", zlib.createGzip],
+    ["deflate", zlib.createDeflate],
+    ["inflate", zlib.createInflate],
+    ["gunzip", zlib.createGunzip],
+    ["unzip", zlib.createUnzip],
+  ] as const
+) {
+  try {
+    const stream = factory({ windowBits: 0 });
+    console.log(name, "ok");
+    stream.destroy();
+  } catch (error: any) {
+    console.log(name, error.name, error.code);
+  }
+}

--- a/test-parity/node-suite/zlib/streams/bytes-written-trailing.ts
+++ b/test-parity/node-suite/zlib/streams/bytes-written-trailing.ts
@@ -1,0 +1,20 @@
+import * as zlib from "node:zlib";
+
+const compressed = zlib.deflateSync("bytes written");
+const input = Buffer.concat([compressed, Buffer.from("trailing")]);
+const stream = zlib.createInflate();
+const chunks: Buffer[] = [];
+stream.on("data", (chunk: Buffer) => chunks.push(chunk));
+await new Promise<void>((resolve, reject) => {
+  stream.on("end", resolve);
+  stream.on("error", reject);
+  stream.end(input);
+});
+console.log("output:", Buffer.concat(chunks).toString());
+console.log(
+  "bytesWritten:",
+  stream.bytesWritten,
+  compressed.length,
+  input.length,
+);
+stream.destroy();

--- a/test-parity/node-suite/zlib/streams/close-state.ts
+++ b/test-parity/node-suite/zlib/streams/close-state.ts
@@ -1,0 +1,24 @@
+import { createGzip } from "node:zlib";
+
+const stream = createGzip();
+console.log(
+  "initial:",
+  stream.destroyed,
+  stream.closed,
+  (stream as any)._closed,
+);
+console.log("return:", stream.close());
+console.log(
+  "closed:",
+  stream.destroyed,
+  stream.closed,
+  (stream as any)._closed,
+  (stream as any)._handle === null,
+);
+stream.close();
+console.log(
+  "idempotent:",
+  stream.destroyed,
+  stream.closed,
+  (stream as any)._closed,
+);

--- a/test-parity/node-suite/zlib/streams/codec-roundtrips.ts
+++ b/test-parity/node-suite/zlib/streams/codec-roundtrips.ts
@@ -1,0 +1,29 @@
+import * as zlib from "node:zlib";
+
+async function collect(stream: any, input: Buffer) {
+  const chunks: Buffer[] = [];
+  stream.on("data", (chunk: Buffer) => chunks.push(chunk));
+  const settled = new Promise<void>((resolve, reject) => {
+    stream.on("end", resolve);
+    stream.on("error", reject);
+  });
+  stream.end(input);
+  await settled;
+  stream.destroy();
+  return Buffer.concat(chunks);
+}
+
+const input = Buffer.from("stream codec contract");
+for (
+  const [name, createCompress, createDecompress] of [
+    ["deflate", zlib.createDeflate, zlib.createInflate],
+    ["raw", zlib.createDeflateRaw, zlib.createInflateRaw],
+    ["gzip", zlib.createGzip, zlib.createGunzip],
+    ["unzip", zlib.createGzip, zlib.createUnzip],
+    ["brotli", zlib.createBrotliCompress, zlib.createBrotliDecompress],
+  ] as const
+) {
+  const compressed = await collect(createCompress(), input);
+  const output = await collect(createDecompress(), compressed);
+  console.log(name, output.toString());
+}

--- a/test-parity/node-suite/zlib/streams/error-close.ts
+++ b/test-parity/node-suite/zlib/streams/error-close.ts
@@ -1,0 +1,23 @@
+import { createGunzip } from "node:zlib";
+
+const stream = createGunzip();
+await new Promise<void>((resolve) => {
+  stream.on("error", (error: any) => {
+    console.log("error:", error.name, error.code);
+    console.log(
+      "closed:",
+      (stream as any)._closed,
+      stream.destroyed,
+      stream.closed,
+    );
+    stream.close();
+    console.log(
+      "close again:",
+      (stream as any)._closed,
+      stream.destroyed,
+      stream.closed,
+    );
+    resolve();
+  });
+  stream.end(Buffer.from("invalid"));
+});

--- a/test-parity/node-suite/zlib/streams/flush-order.ts
+++ b/test-parity/node-suite/zlib/streams/flush-order.ts
@@ -1,0 +1,18 @@
+import { constants, createGzip } from "node:zlib";
+
+const events: string[] = [];
+const stream = createGzip();
+stream.on("data", () => {});
+stream.write("a", () => events.push("write-a"));
+stream.flush(constants.Z_PARTIAL_FLUSH, () => events.push("flush-a"));
+stream.write("b", () => events.push("write-b"));
+
+await new Promise<void>((resolve, reject) => {
+  stream.flush(constants.Z_PARTIAL_FLUSH, () => events.push("flush-b"));
+  stream.on("end", resolve);
+  stream.on("error", reject);
+  stream.end(() => events.push("end-callback"));
+});
+
+console.log("events:", events.join(","));
+stream.destroy();

--- a/test-parity/node-suite/zlib/streams/reset-before-write.ts
+++ b/test-parity/node-suite/zlib/streams/reset-before-write.ts
@@ -1,0 +1,33 @@
+import * as zlib from "node:zlib";
+
+async function collect(reset: (stream: any, callback: () => void) => void) {
+  const deflate = zlib.createDeflate();
+  const inflate = zlib.createInflate();
+  const chunks: Buffer[] = [];
+  inflate.on("data", (chunk: Buffer) => chunks.push(chunk));
+  const settled = new Promise<void>((resolve, reject) => {
+    inflate.on("end", resolve);
+    inflate.on("error", reject);
+    deflate.on("error", reject);
+  });
+  deflate.pipe(inflate);
+  reset(deflate, () => deflate.end("abc"));
+  await settled;
+  deflate.destroy();
+  inflate.destroy();
+  return Buffer.concat(chunks).toString();
+}
+
+console.log(
+  "reset:",
+  await collect((stream, callback) => {
+    stream.reset();
+    callback();
+  }),
+);
+console.log(
+  "params:",
+  await collect((stream, callback) => {
+    stream.params(0, zlib.constants.Z_DEFAULT_STRATEGY, callback);
+  }),
+);

--- a/test-parity/node-suite/zlib/unzip/one-byte-members.ts
+++ b/test-parity/node-suite/zlib/unzip/one-byte-members.ts
@@ -1,0 +1,15 @@
+import * as zlib from "node:zlib";
+
+const input = Buffer.concat([zlib.gzipSync("abc"), zlib.gzipSync("def")]);
+const stream = zlib.createUnzip();
+const chunks: Buffer[] = [];
+stream.on("data", (chunk: Buffer) => chunks.push(chunk));
+await new Promise<void>((resolve, reject) => {
+  stream.on("end", resolve);
+  stream.on("error", reject);
+  for (const byte of input) stream.write(Buffer.from([byte]));
+  stream.end();
+});
+console.log("output:", Buffer.concat(chunks).toString());
+console.log("bytesWritten:", stream.bytesWritten, input.length);
+stream.destroy();

--- a/test-parity/node-suite/zlib/validation/params-arguments.ts
+++ b/test-parity/node-suite/zlib/validation/params-arguments.ts
@@ -1,0 +1,21 @@
+import * as zlib from "node:zlib";
+
+for (
+  const [level, strategy] of [
+    ["1", 0],
+    [-2, 0],
+    [0, "0"],
+    [0, -1],
+    [0, 5],
+  ] as any[]
+) {
+  const stream = zlib.createDeflate();
+  try {
+    stream.params(level, strategy);
+    console.log(String(level), String(strategy), "ok");
+  } catch (error: any) {
+    console.log(String(level), String(strategy), error.name, error.code);
+  } finally {
+    stream.destroy();
+  }
+}

--- a/test-parity/node-suite/zlib/validation/reject-trailing-garbage.ts
+++ b/test-parity/node-suite/zlib/validation/reject-trailing-garbage.ts
@@ -1,0 +1,21 @@
+import * as zlib from "node:zlib";
+
+const compressed = zlib.deflateSync("a");
+const doubled = Buffer.concat([compressed, compressed]);
+console.log("default:", zlib.inflateSync(doubled).toString());
+
+try {
+  zlib.inflateSync(doubled, { rejectGarbageAfterEnd: true } as any);
+  console.log("reject: ok");
+} catch (error: any) {
+  console.log("reject:", error.name, error.code);
+}
+
+for (const value of [1, "true", null] as any[]) {
+  try {
+    zlib.inflateSync(compressed, { rejectGarbageAfterEnd: value } as any);
+    console.log("type", String(value), "ok");
+  } catch (error: any) {
+    console.log("type", String(value), error.name, error.code);
+  }
+}

--- a/test-parity/node-suite/zlib/validation/truncated-finish-flush.ts
+++ b/test-parity/node-suite/zlib/validation/truncated-finish-flush.ts
@@ -1,0 +1,28 @@
+import * as zlib from "node:zlib";
+
+const input = "truncated input contract ".repeat(4);
+for (
+  const [name, compress, decompress] of [
+    ["gzip", zlib.gzipSync, zlib.gunzipSync],
+    ["deflate", zlib.deflateSync, zlib.inflateSync],
+    ["raw", zlib.deflateRawSync, zlib.inflateRawSync],
+  ] as const
+) {
+  const compressed = compress(input);
+  const truncated = compressed.subarray(0, Math.ceil(compressed.length / 2));
+  try {
+    decompress(truncated);
+    console.log(name, "default ok");
+  } catch (error: any) {
+    console.log(name, "default", error.name, error.code);
+  }
+  const partial = decompress(truncated, {
+    finishFlush: zlib.constants.Z_SYNC_FLUSH,
+  });
+  console.log(
+    name,
+    "partial prefix",
+    input.startsWith(partial.toString()),
+    partial.length > 0,
+  );
+}

--- a/test-parity/node_suite_baseline.json
+++ b/test-parity/node_suite_baseline.json
@@ -214,8 +214,8 @@
       "total": 205
     },
     "zlib": {
-      "pass": 58,
-      "total": 58
+      "pass": 63,
+      "total": 92
     }
   }
 }

--- a/test-parity/node_suite_baseline.json
+++ b/test-parity/node_suite_baseline.json
@@ -214,7 +214,7 @@
       "total": 205
     },
     "zlib": {
-      "pass": 63,
+      "pass": 62,
       "total": 92
     }
   }


### PR DESCRIPTION
## Summary

- expand the granular `node:zlib` parity suite from 58 to 92 fixtures
- cover exports, constructors, dictionaries, callback shapes, options, truncation, trailing input, and zlib-specific stream lifecycle
- pin evidence to Node 26.5.0 and compare Bun 1.2.18 and Deno 2.9.3
- update the clean Perry baseline from 58/58 to 62/92

## Changes

| File | Change |
| --- | --- |
| `test-parity/node-suite/zlib/**` | Add 34 deterministic fixtures and a complete evidence map |
| `test-parity/node_suite_baseline.json` | Set the measured zlib floor to 62/92 |

## Related issue

n/a — standalone parity coverage expansion

## Test plan

- [x] Node 26.5.0: 92/92 clean exits with the same stdout hash across three runs
- [x] Perry: 62 matches and 30 stable diffs across three focused runs; no compile failures, crashes, or timeouts
- [x] Bun 1.2.18: 86 matches and 6 stable diffs; no errors, crashes, or timeouts
- [x] Deno 2.9.3: 83 matches and 9 stable diffs; no errors, crashes, or timeouts
- [x] `cargo build --release -p perry -p perry-runtime -p perry-stdlib -p perry-runtime-static -p perry-stdlib-static`
- [x] `deno fmt --check` for the README and all added fixtures
- [x] `python3 -m json.tool test-parity/node_suite_baseline.json`
- [x] `git diff --check`

`scripts/check_file_size.sh` reports two pre-existing main-branch failures: `crates/perry-runtime/src/object/mod.rs` at 2039 lines and `crates/perry-stdlib/src/readline.rs` at 2066 lines. This pull request changes neither file.

## Scope exclusions

Large inputs, OOM and memory pressure, random data, fuzzing, GC, weak references, races, workers, signals, snapshots, private handles, fs pipelines, generic stream behavior, and backend-specific compressed bytes remain excluded. The README records each boundary and the stopping rule.

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)
- [x] No changes under `test-files/test_parity_*.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the zlib compatibility suite from 58 to 92 contracts with added coverage for callbacks, option validation/order, immutable exports/constants, constructor/prototype behavior, dictionaries (including Brotli/Zstandard and type variants), CRC32 edge cases, and gzip/unzip stream edge scenarios.
  * Added additional stream lifecycle and roundtrip checks (including flush/close/reset behaviors, output limits, and codec conversions).
* **Documentation**
  * Reworked the zlib parity documentation with expanded contract detail, fixture inventory, evidence references, measurements, and audit criteria.
* **Tests**
  * Updated worker baseline thresholds to match the expanded suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
