### PR TITLE
fix(runtime): retag mimalloc OS mappings off the IOAccelerator VM tag (#6882)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1560,6 +1560,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4330,6 +4336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
 dependencies = [
  "cc",
+ "cty",
 ]
 
 [[package]]
@@ -6109,6 +6116,7 @@ dependencies = [
  "itoa",
  "lazy_static",
  "libc",
+ "libmimalloc-sys",
  "mach2",
  "mimalloc",
  "perry-diagnostics",

--- a/crates/perry-runtime/Cargo.toml
+++ b/crates/perry-runtime/Cargo.toml
@@ -245,6 +245,15 @@ socket2 = { version = "0.6", features = ["all"] }
 [target.'cfg(target_pointer_width = "64")'.dependencies]
 mimalloc = { version = "0.1", default-features = false }
 
+# #6882: mimalloc tags its OS mappings with VM tag 100, which macOS tooling
+# (vmmap, Instruments' VM Tracker, `footprint`) decodes as `IOAccelerator` —
+# the entire JS heap renders as GPU-driver memory. `js_gc_init` retags to
+# VM_MEMORY_APPLICATION_SPECIFIC_1 (240) via mi_option_set(mi_option_os_tag),
+# which lives behind libmimalloc-sys's `extended` API. Apple-only: the tag is
+# only consulted by Apple kernels, and mimalloc itself is 64-bit-only (above).
+[target.'cfg(all(target_pointer_width = "64", target_vendor = "apple"))'.dependencies]
+libmimalloc-sys = { version = "0.1", features = ["extended"] }
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = [
     "Win32_System_Console",

--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -555,6 +555,21 @@ pub extern "C" fn js_gc_init() {
     // a second js_gc_init on another thread is harmless.
     #[cfg(windows)]
     crate::win_console::enable_vt_output();
+    // #6882: mimalloc (the global allocator, #62) tags its OS mappings with
+    // VM tag 100, which macOS tooling — vmmap, Instruments' VM Tracker,
+    // `footprint` — decodes as `IOAccelerator`: the entire JS heap renders
+    // as GPU-driver memory (644 MB of "IOAccelerator" on an allocation-heavy
+    // benchmark). Retag to VM_MEMORY_APPLICATION_SPECIFIC_1 (240) so heap
+    // regions show up as a neutral, distinctive "Memory Tag 240" instead.
+    // An explicit `MIMALLOC_OS_TAG` env setting still wins — skip the
+    // override so profilers can keep steering the tag themselves. Regions
+    // mapped before this call (early Rust startup) keep tag 100; the bulk
+    // of the heap (arena blocks, GC metadata) maps afterwards. Idempotent,
+    // like the rest of this function.
+    #[cfg(all(target_pointer_width = "64", target_vendor = "apple"))]
+    if std::env::var_os("MIMALLOC_OS_TAG").is_none() {
+        unsafe { libmimalloc_sys::mi_option_set(libmimalloc_sys::mi_option_os_tag, 240) };
+    }
     crate::node_submodules::diagnostics_channel_init_main_thread();
     // #5093: force every class-field access back through the full guard call —
     // i.e. disable the codegen-inlined fast path — when:

--- a/crates/perry-runtime/src/gc/tests/mod.rs
+++ b/crates/perry-runtime/src/gc/tests/mod.rs
@@ -15,6 +15,7 @@ mod host_safepoints;
 mod incremental_sweep_reclaim;
 mod layout_trace;
 mod oldgen;
+mod os_tag;
 mod roots;
 mod runtime_roots;
 mod smoke;

--- a/crates/perry-runtime/src/gc/tests/os_tag.rs
+++ b/crates/perry-runtime/src/gc/tests/os_tag.rs
@@ -1,0 +1,20 @@
+//! #6882: `js_gc_init` must move mimalloc's OS-mapping VM tag off 100 —
+//! macOS tooling decodes tag 100 as `IOAccelerator`, so the whole JS heap
+//! shows up as GPU-driver memory in vmmap/Instruments/footprint.
+
+#[cfg(all(target_pointer_width = "64", target_vendor = "apple"))]
+#[test]
+fn js_gc_init_retags_mimalloc_os_mappings() {
+    // Only asserts when the profiler override isn't steering the tag —
+    // js_gc_init deliberately defers to an explicit MIMALLOC_OS_TAG.
+    if std::env::var_os("MIMALLOC_OS_TAG").is_some() {
+        return;
+    }
+    crate::gc::js_gc_init();
+    let tag = unsafe { libmimalloc_sys::mi_option_get(libmimalloc_sys::mi_option_os_tag) };
+    assert_eq!(
+        tag, 240,
+        "js_gc_init must retag mimalloc mappings to VM_MEMORY_APPLICATION_SPECIFIC_1 \
+         (240); tag 100 renders the heap as IOAccelerator in macOS tools (#6882)"
+    );
+}

--- a/docs/src/internals/memory-model.md
+++ b/docs/src/internals/memory-model.md
@@ -125,6 +125,30 @@ The combination — NaN-boxing for cheap value representation, per-thread arenas
 
 Going to native code does not preclude having a GC. It just means the GC's relationship with the compiled code is mediated by an ABI: codegen emits calls to `gc_malloc`, `js_shadow_frame_push/pop`/`js_shadow_slot_set`, and `js_write_barrier`, and the runtime crate (linked in as native code) is a real generational mark-sweep collector. There is nothing reference-counted at runtime.
 
+## Profiling Perry's memory on macOS
+
+Two things to know before reading `vmmap`, Instruments' VM Tracker, or
+`footprint` output for a Perry binary:
+
+- **The heap does not show up under `MALLOC_*`.** Perry routes all runtime
+  allocation through mimalloc (`#[global_allocator]`, issue #62), whose
+  mappings appear as their own anonymous regions, not in the system malloc
+  zones.
+- **Those regions used to render as `IOAccelerator`** — i.e. GPU driver
+  memory — because mimalloc tags its mappings with VM tag 100, which macOS
+  tooling decodes as `IOAccelerator`. Since #6882 the runtime retags them to
+  `VM_MEMORY_APPLICATION_SPECIFIC_1` (240) during `js_gc_init`, so the JS
+  heap shows up as **`Memory Tag 240`**. If you see large `IOAccelerator`
+  regions in a Perry process, you are either on a pre-#6882 build or looking
+  at the few pages mapped before `js_gc_init` ran; there is no GPU memory
+  involved. Set `MIMALLOC_OS_TAG=<n>` to steer the tag yourself — the
+  runtime's retag defers to an explicit env setting.
+
+Also note that mimalloc purges freed memory with `MADV_FREE`-style advice:
+macOS keeps such pages counted in RSS and `phys_footprint` until memory
+pressure, so headline RSS numbers overstate what the process would actually
+hold onto under pressure.
+
 ## Source map
 
 | Topic | File |


### PR DESCRIPTION
Closes #6882.

## Problem

mimalloc (Perry's `#[global_allocator]` since #62) tags its OS mappings with **VM tag 100**, which macOS tooling — `vmmap`, Instruments' VM Tracker, `footprint` — decodes as **`IOAccelerator`**. Every Perry process on macOS therefore appears to hold hundreds of MB of GPU-driver memory (644 MB mapped / 422 MB resident on the churn benchmark in #6882), and the actual JS heap is invisible as a category. Anyone profiling Perry memory starts by chasing a GPU ghost.

## Fix

`js_gc_init` — the first runtime call in every compiled binary's prelude, already home to per-platform one-time setup — retags mimalloc's mappings to `VM_MEMORY_APPLICATION_SPECIFIC_1` (240) via `mi_option_set(mi_option_os_tag, 240)`:

- **Apple 64-bit only** (`cfg(all(target_pointer_width = "64", target_vendor = "apple"))`): the tag is only consulted by Apple kernels, and mimalloc itself is already 64-bit-only.
- **An explicit `MIMALLOC_OS_TAG` env setting wins** — the retag is skipped so profilers can keep steering the tag themselves.
- Idempotent, like the rest of `js_gc_init`.
- Pages mapped before `js_gc_init` (early Rust startup) keep tag 100; the bulk of the heap (arena blocks, GC metadata) maps afterwards.

Adds `libmimalloc-sys` (the crate mimalloc already depends on, same version resolution) as an Apple-only dependency for its `extended` option API.

## Also in this PR

- `docs/src/internals/memory-model.md`: new **"Profiling Perry's memory on macOS"** section — where the heap shows up (`Memory Tag 240`, not `MALLOC_*`), what pre-#6882 `IOAccelerator` regions meant, the `MIMALLOC_OS_TAG` override, and the `MADV_FREE`/RSS accounting caveat.
- Unit test `gc::tests::os_tag::js_gc_init_retags_mimalloc_os_mappings` pinning the retag (skips itself when `MIMALLOC_OS_TAG` is set, mirroring the runtime's deference).

## Verification

`vmmap -summary` on the #6882 churn benchmark compiled with this branch (macOS 26.5, Apple Silicon):

```
before (main):
IOAccelerator                    644.4M   422.1M   422.1M        8

after (this branch):
IOAccelerator                     4352K      32K     32K         1   ← pre-js_gc_init residue only
Memory Tag 240                   640.1M   421.8M  387.5M         7   ← the JS heap, correctly attributed
Memory Tag 240 (reserved)        384.0M       0K      0K         1
```

Benchmark output unchanged (`39998000000`).

Unit suite: `cargo test -p perry-runtime --lib gc::` — 477 passed, 2 failed; the same 2 failures (`gc::tests::copying::large_object_old_born_array_slot_write_keeps_young_child_alive`, `gc::tests::teardown::map_set_side_allocations_release_on_thread_exit`) reproduce on pristine `origin/main` (fd7475182) with this branch's changes stashed — pre-existing on main, unrelated to this PR.

No behavior change beyond the mapping tag — allocation paths, sizes, and performance are untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved macOS memory tagging so Perry heap allocations are classified more clearly in profiling tools.
  * Added support for extended memory-tagging behavior on 64-bit Apple platforms.

* **Documentation**
  * Added guidance for interpreting Perry memory usage, heap classifications, and RSS measurements in macOS profiling tools.

* **Tests**
  * Added coverage verifying the expected macOS memory tag during garbage collector initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->