### PR TITLE
test(http): handle fixture error events

### DIFF
--- a/test-parity/node-suite/http/incoming-message/response-metadata.ts
+++ b/test-parity/node-suite/http/incoming-message/response-metadata.ts
@@ -17,6 +17,7 @@ try {
   }
   await new Promise<void>((resolve, reject) => {
     get({ hostname: "127.0.0.1", port: address.port }, (res) => {
+      res.once("error", reject);
       console.log(
         "meta:",
         res.statusCode,

--- a/test-parity/node-suite/http/server-response/state-lifecycle.ts
+++ b/test-parity/node-suite/http/server-response/state-lifecycle.ts
@@ -35,6 +35,7 @@ try {
   }
   await new Promise<void>((resolve, reject) => {
     get({ hostname: "127.0.0.1", port: address.port }, (res) => {
+      res.once("error", reject);
       res.resume();
       res.on("end", resolve);
     }).once("error", reject);

--- a/test-parity/node-suite/http/server/expectation-events.ts
+++ b/test-parity/node-suite/http/server/expectation-events.ts
@@ -33,6 +33,7 @@ try {
         method: "POST",
         headers: { Expect: expectation },
       }, (res) => {
+        res.once("error", reject);
         res.resume();
         res.on("end", resolve);
       });

--- a/test-parity/node-suite/http/server/listen-close-lifecycle.ts
+++ b/test-parity/node-suite/http/server/listen-close-lifecycle.ts
@@ -4,6 +4,9 @@ const server = createServer();
 const events: string[] = [];
 server.on("listening", () => events.push("listening"));
 server.on("close", () => events.push("close"));
+server.once("error", (error: any) => {
+  console.error("listen error:", error.name, error.code);
+});
 console.log("before:", server.listening, server.address());
 const listening = server.listen(0, "127.0.0.1", () => {
   const address = server.address();


### PR DESCRIPTION
## Summary

Add the four error guards requested by CodeRabbit after #6875 merged, without changing successful fixture output.

## Changes

- Forward response-stream errors to the existing promise rejection path in three fixtures.
- Attach a one-shot server error reporter before `listen()` in the listen/close lifecycle fixture.

## Related issue

Refs #4975. Follow-up to #6875.

## Test plan

- `deno fmt --check` on all four changed fixtures
- `git diff --check`
- Node 26.5.0: 4/4 fixtures, three identical runs
- Deno 2.9.3: 4/4 fixtures, three identical runs
- Bun 1.2.18: 4/4 fixtures, three identical runs
- Perry: compiled all four fixtures and confirmed three identical runs preserve each pre-fix exit code and stdout
- `cargo build --release -p perry-runtime`

- [x] `cargo build --release` clean
- [ ] `cargo test --workspace --exclude perry-ui-ios --exclude perry-ui-tvos --exclude perry-ui-watchos --exclude perry-ui-gtk4 --exclude perry-ui-android --exclude perry-ui-windows` passes
- [ ] (if user-facing) Added or updated a test under `test-files/` or a `#[test]` in the affected crate
- [ ] (if CLI / stdlib / runtime API changed) Updated `docs/src/`
- [ ] (if touching a platform UI backend) Built `-p perry-ui-<backend>` locally on that platform

## Screenshots / output

n/a

## Checklist

- [x] I have NOT bumped the workspace version or edited CLAUDE.md / CHANGELOG.md (maintainer handles these at merge)
- [x] My commits follow the loose `feat:` / `fix:` / `docs:` / `chore:` prefix convention used in the log
- [x] I've read [CONTRIBUTING.md](../CONTRIBUTING.md) and agree to the [Code of Conduct](../CODE_OF_CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved HTTP test coverage by explicitly handling errors from response streams and server listen operations.
  * Ensured relevant asynchronous tests fail clearly when response-level or server startup errors occur.
  * Added logging for HTTP server listen errors, including error name and code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->