### PR TITLE
style: restore rustfmt formatting on main (unblocks the lint gate on every open PR)

### DIFF
--- a/crates/perry-runtime/src/gc/mod.rs
+++ b/crates/perry-runtime/src/gc/mod.rs
@@ -135,7 +135,8 @@ pub(super) fn gc_collect_minor_with_trigger(trigger: GcTriggerSnapshot) -> GcCol
     // live bytes exceed K× the last full's live set (belt-and-suspenders for
     // callers that reach a minor outside the budgeted pressure path).
     if arena_growth_full_escalation_due() {
-        let outcome = gc_collect_full_mark_sweep_with_trigger(GcTriggerSnapshot::capture(trigger.kind));
+        let outcome =
+            gc_collect_full_mark_sweep_with_trigger(GcTriggerSnapshot::capture(trigger.kind));
         restore_minor_in_alloc(prev_in_alloc);
         return outcome;
     }

--- a/crates/perry-runtime/src/temporal/now.rs
+++ b/crates/perry-runtime/src/temporal/now.rs
@@ -9,9 +9,9 @@
 use super::dispatch::{self, ok_or_throw, raw_arg, string};
 use super::{alloc_temporal_cell, TemporalValue};
 use temporal_rs::host::{HostClock, HostHooks, HostTimeZone};
+use temporal_rs::now::Now;
 use temporal_rs::provider::TimeZoneProvider;
 use temporal_rs::unix_time::EpochNanoseconds;
-use temporal_rs::now::Now;
 use temporal_rs::{TemporalError, TemporalResult, TimeZone};
 
 /// Perry's own `Temporal.Now` host system, replacing temporal_rs's
@@ -42,7 +42,10 @@ impl HostTimeZone for PerryHostSystem {
         &self,
         provider: &(impl TimeZoneProvider + ?Sized),
     ) -> TemporalResult<TimeZone> {
-        TimeZone::try_from_identifier_str_with_provider(crate::date::host_time_zone_name(), provider)
+        TimeZone::try_from_identifier_str_with_provider(
+            crate::date::host_time_zone_name(),
+            provider,
+        )
     }
 }
 
@@ -70,9 +73,7 @@ fn tz_arg(v: f64) -> Option<TimeZone> {
 }
 
 pub fn instant(_args: &[f64]) -> f64 {
-    alloc_temporal_cell(TemporalValue::Instant(ok_or_throw(
-        perry_now().instant(),
-    )))
+    alloc_temporal_cell(TemporalValue::Instant(ok_or_throw(perry_now().instant())))
 }
 
 pub fn time_zone_id(_args: &[f64]) -> f64 {


### PR DESCRIPTION
`cargo fmt --all -- --check` has been red on `main` since #6939, which fails the required **`lint`** gate on **every open PR** — independent of what that PR changes.

Two files drifted:
- `crates/perry-runtime/src/temporal/now.rs` — import ordering (+2 more sites)
- `crates/perry-runtime/src/gc/mod.rs` — wrapping

Formatting only; no functional change. Verified `cargo fmt --all -- --check` is clean afterwards.

Surfaced while validating #6948 (that PR had to carry its own isolated rustfmt commit to go green — it can drop it once this lands).
