### PR TITLE
fix(modules): exports aliasing a declared function are functions, not var getters

### DIFF
--- a/crates/perry/src/commands/compile/run_pipeline.rs
+++ b/crates/perry/src/commands/compile/run_pipeline.rs
@@ -830,8 +830,24 @@ pub fn run_with_parse_cache(
             .filter(|f| f.is_exported)
             .map(|f| &f.name)
             .collect();
+        // Alias exports bound to DECLARED functions (`export const decodeSync =
+        // decodeUnknownSync` / `export { impl as api }`) land in BOTH
+        // `exported_objects` and `exported_functions` (HIR records the alias
+        // with the origin FuncId, gated on `lookup_func`, so const-closures
+        // never appear here). Their cross-module symbol resolves through
+        // origin-name mapping to the FUNCTION BODY, not a var getter —
+        // classifying them as vars made consumers 0-arg "getter"-call the
+        // symbol, silently EXECUTING the function at import-read time
+        // (Effect's `decodeSync` ran `decodeUnknownSync(undefined)` during
+        // module init → "Cannot read properties of undefined (reading
+        // 'checks')").
+        let function_alias_names: std::collections::HashSet<&String> = hir_module
+            .exported_functions
+            .iter()
+            .map(|(n, _)| n)
+            .collect();
         for obj_name in &hir_module.exported_objects {
-            if is_function_decl.contains(obj_name) {
+            if is_function_decl.contains(obj_name) || function_alias_names.contains(obj_name) {
                 continue;
             }
             let key = (path_str.clone(), obj_name.clone());
@@ -1867,6 +1883,30 @@ pub fn run_with_parse_cache(
                         global.id
                     );
                     perry_codegen::NamespaceEntryKind::LocalVar { global_name: gname }
+                } else if let Some(func) = target_hir
+                    .exported_functions
+                    .iter()
+                    .find(|(n, _)| n == &fe.source_local || n == &fe.name)
+                    .and_then(|(_, fid)| target_hir.functions.iter().find(|f| f.id == *fid))
+                {
+                    // Alias export bound to a declared function
+                    // (`export const decodeEffect = decodeUnknownEffect`).
+                    // The ForeignVar fallback below getter-CALLS
+                    // `perry_fn_<mod>__<alias>` — but for aliases that symbol
+                    // is the #460 forwarding wrapper (the function body), so
+                    // the populator EXECUTED the function with zeroed args at
+                    // module init (Effect SchemaParser: decodeUnknownEffect
+                    // ran during init → "Cannot read properties of undefined
+                    // (reading 'checks')"). Resolve to the ORIGIN function's
+                    // closure singleton instead, matching plain declarations.
+                    let scoped = format!(
+                        "perry_fn_{}__{}",
+                        sanitize_module_name(&target_hir.name),
+                        sanitize_module_name(&func.name)
+                    );
+                    perry_codegen::NamespaceEntryKind::LocalFunction {
+                        wrap_symbol: format!("__perry_wrap_{}", scoped),
+                    }
                 } else {
                     // Best-effort: treat unknown locals as Var sourced
                     // by getter. This covers re-export shapes that the
@@ -1893,6 +1933,22 @@ pub fn run_with_parse_cache(
                         src.classes.iter().find(|c| c.name == fe.source_local)
                     {
                         perry_codegen::NamespaceEntryKind::LocalClass { class_id: class.id }
+                    } else if let Some(func) = src
+                        .exported_functions
+                        .iter()
+                        .find(|(n, _)| n == &fe.source_local || n == &fe.name)
+                        .and_then(|(_, fid)| src.functions.iter().find(|f| f.id == *fid))
+                    {
+                        // Cross-module alias of a declared function — same
+                        // hazard as the local-binding arm above: the
+                        // ForeignVar getter-call would EXECUTE the forwarding
+                        // wrapper. Route to the origin function's closure
+                        // singleton via ForeignFunction under its ORIGIN name.
+                        perry_codegen::NamespaceEntryKind::ForeignFunction {
+                            source_prefix: source_prefix.clone(),
+                            source_local: func.name.clone(),
+                            param_count: func.params.len(),
+                        }
                     } else {
                         perry_codegen::NamespaceEntryKind::ForeignVar {
                             source_prefix: source_prefix.clone(),

--- a/crates/perry/tests/namespace_alias_export_of_function.rs
+++ b/crates/perry/tests/namespace_alias_export_of_function.rs
@@ -1,0 +1,122 @@
+//! Regression test: an export that ALIASES a declared function
+//! (`export const alias = impl`) must reach consumers as the function
+//! itself, not as a getter-call result.
+//!
+//! Such an alias lands in BOTH `exported_objects` and `exported_functions`
+//! (HIR records the alias with the origin's FuncId). The var-vs-function
+//! classification in `run_pipeline` only excluded *declaration* names, so
+//! the alias was treated as an exported VARIABLE — whose cross-module
+//! symbol convention is a zero-arg getter. But origin-name resolution
+//! points `perry_fn_<mod>__<alias>` at the #460 forwarding wrapper (the
+//! function BODY), so the "getter" call actually invoked the function:
+//! reading `NS.alias` produced the return value of `impl(<zeroed args>)`
+//! instead of the closure, and calling it threw "value is not a function".
+//!
+//! Found compiling the t3 Code server (Effect 4.0.0-beta.78), whose
+//! `SchemaParser.ts` is built almost entirely out of this shape
+//! (`export const decodeSync = decodeUnknownSync`, `decodeEffect =
+//! decodeUnknownEffect`, …). There it surfaced two ways: the consumer-side
+//! binding read, and the source module's own namespace populator executing
+//! the function while building its namespace object at module init.
+//!
+//! Expected outputs match `node --experimental-strip-types`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn perry_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_perry"))
+}
+
+/// Writes `inner.ts` + `main.ts` into `dir`, compiles `main.ts`, runs it.
+fn compile_and_run(dir: &std::path::Path, inner: &str, main: &str) -> String {
+    std::fs::write(dir.join("inner.ts"), inner).expect("write inner");
+    let entry = dir.join("main.ts");
+    let output = dir.join("main_bin");
+    std::fs::write(&entry, main).expect("write entry");
+
+    let compile = Command::new(perry_bin())
+        .current_dir(dir)
+        .arg("compile")
+        .arg(&entry)
+        .arg("-o")
+        .arg(&output)
+        .arg("--no-cache")
+        .output()
+        .expect("run perry compile");
+    assert!(
+        compile.status.success(),
+        "perry compile failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&compile.stdout),
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new(&output)
+        .current_dir(dir)
+        .output()
+        .expect("run compiled binary");
+    assert!(
+        run.status.success(),
+        "compiled binary failed (exit {:?})\nstdout:\n{}\nstderr:\n{}",
+        run.status.code(),
+        String::from_utf8_lossy(&run.stdout),
+        String::from_utf8_lossy(&run.stderr)
+    );
+    String::from_utf8_lossy(&run.stdout).into_owned()
+}
+
+const INNER: &str = r#"
+let ranAtInit = 0;
+export function impl(x: number): number {
+  ranAtInit += 1;
+  return x * 2;
+}
+export const alias = impl;
+export function ranCount(): number {
+  return ranAtInit;
+}
+"#;
+
+/// Namespace import (`import * as NS`): reading `NS.alias` must yield the
+/// function without invoking it, and calling it must work. Pre-fix this
+/// printed `alias-typeof: number` and then threw "value is not a function".
+#[test]
+fn namespace_member_alias_of_function_is_the_function() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        INNER,
+        r#"
+import * as NS from "./inner.ts";
+console.log("ran-during-init:", NS.ranCount());
+console.log("alias-typeof:", typeof NS.alias);
+console.log("alias-call:", NS.alias(21));
+"#,
+    );
+    assert_eq!(
+        stdout, "ran-during-init: 0\nalias-typeof: function\nalias-call: 42\n",
+        "namespace member aliasing a declared function must read as the function"
+    );
+}
+
+/// Named import of the same alias — the consumer-side binding read must not
+/// execute the origin function either.
+#[test]
+fn named_import_alias_of_function_is_not_executed_on_read() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stdout = compile_and_run(
+        dir.path(),
+        INNER,
+        r#"
+import { alias, ranCount } from "./inner.ts";
+const held = alias;
+console.log("ran-during-init:", ranCount());
+console.log("held-typeof:", typeof held);
+console.log("held-call:", held(4));
+"#,
+    );
+    assert_eq!(
+        stdout, "ran-during-init: 0\nheld-typeof: function\nheld-call: 8\n",
+        "reading a named-imported function alias must not invoke it"
+    );
+}


### PR DESCRIPTION
## The bug

`export const alias = impl` (where `impl` is a declared function) lands in **both** `exported_objects` and `exported_functions` — HIR records the alias with the origin's `FuncId`. The var-vs-function classification in `run_pipeline` only excluded *declaration* names, so the alias was classified as an exported **variable**, whose cross-module convention is a zero-arg getter. But origin-name resolution points `perry_fn_<mod>__<alias>` at the #460 forwarding wrapper — the function **body** — so the "getter" call actually **invoked the function**.

Two user-visible failures:

```ts
// inner.ts
export function impl(x: number): number { return x * 2 }
export const alias = impl

// main.ts
import * as NS from "./inner.ts"
console.log(typeof NS.alias)   // "number"  (expected "function")
console.log(NS.alias(21))      // TypeError: value is not a function
```

…and the source module's own **namespace populator** hits the same path while building its namespace object, so the aliased function *runs during module init* with zeroed arguments.

## The fix

In `run_pipeline`:

- exclude `exported_functions` alias names from `exported_var_names` (the consumer-side binding read), and
- resolve alias entries in the namespace-entry builder to the **origin function's** wrap symbol — `LocalFunction` same-module, `ForeignFunction` (under the origin name) cross-module — instead of falling through to the `ForeignVar` getter.

## Tests

`crates/perry/tests/namespace_alias_export_of_function.rs` — two cases (namespace member, named import). Both **fail on main** (`alias-typeof: number` → `TypeError: value is not a function`) and pass with the fix. Full repro suite for the surrounding campaign also green, no regressions.

## Provenance

Found compiling the [t3 Code](https://github.com/pingdotgg/t3code) server to native with Effect `4.0.0-beta.78`, whose `SchemaParser.ts` is built almost entirely out of this shape (`export const decodeSync = decodeUnknownSync`, `decodeEffect = decodeUnknownEffect`, …). Diagnosed by disassembling that module's `__init_body`: sibling plain exports lowered to `js_closure_alloc_singleton`, while the aliases lowered to a direct `bl perry_fn_…__decodeEffect` with zeroed argument registers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed aliased exported functions being incorrectly executed when accessed through dynamic namespaces or named imports.
  * Aliased functions now remain callable function values and are not invoked during module initialization or import binding.
* **Tests**
  * Added regression coverage for namespace and named imports, including function type checks, return values, and initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->