### PR TITLE
docs(gc): write down why the this-patch closure roots need no explicit release

### DIFF
--- a/changelog.d/6979-temp-root-cut-invariant.md
+++ b/changelog.d/6979-temp-root-cut-invariant.md
@@ -1,0 +1,5 @@
+Documented why the deferred `this`-patch closure roots in object-literal lowering
+need no explicit release: `temp_root` truncation is a stack cut, so the enclosing
+scope's single truncate already releases every root pushed after it. A #6972
+review finding read the missing per-root release as a leak; it is not, and the
+absence of a comment saying so is what made it look like one.

--- a/crates/perry-codegen/src/expr/object_literal.rs
+++ b/crates/perry-codegen/src/expr/object_literal.rs
@@ -496,6 +496,14 @@ pub(crate) fn lower_object_literal(
             let this_idx = auto_caps.len() as u32;
 
             let v = lower_expr(ctx, value_expr)?;
+            // No explicit release for these: `js_gc_temp_root_truncate` is a
+            // stack CUT, not a pop, and `rooted` was pushed before the loop —
+            // so the single `rooted_handle_release` at the end of this function
+            // drops the object handle AND every closure root above it. That
+            // depends on the push order, so keep `rooted_handle_begin` ahead of
+            // this loop and the release after the patch loop.
+            // (`gc::tests::temp_roots::truncate_drops_every_slot_above_the_base`
+            // pins the cut semantics.)
             let closure_root = protect_handle.then(|| temp_root_push_double(ctx, &v));
             this_patches.push((closure_root, v.clone(), this_idx));
 


### PR DESCRIPTION
Comment only — no codegen change.

CodeRabbit's review of #6975 raised one more finding after that PR merged:

> **Release `this`-closure temp roots before the final rooted handle release.**
> `rooted_handle_release(ctx, rooted)` only truncates the root pushed by `rooted_handle_begin`, so `temp_root_push_double` entries added for `captures_this: true` closures in `this_patches` remain on the temp-root stack.

**That one is a false positive**, but only because of a semantic that was never written down at the site: `js_gc_temp_root_truncate` is a stack **cut**, not a pop. It truncates the vector to `base`, dropping `base` and everything pushed above it. In `lower_object_literal`:

1. `rooted_handle_begin` pushes the object handle (index *N*),
2. the property loop pushes each `captures_this` closure value (*N+1*, *N+2*, …),
3. `rooted_handle_release(ctx, rooted)` at the end truncates to *N*,

so the single release does drop every closure root. `gc::tests::temp_roots::truncate_drops_every_slot_above_the_base` pins the cut semantics.

It *does* depend on the push order, though, and nothing said so — a refactor that hoisted the closure pushes above `rooted_handle_begin`, or moved the release before the patch loop, would silently leak (or under-root). This adds eight lines of comment stating the invariant, naming the two constraints it rests on, and pointing at the test.

Verified: `cargo check -p perry-codegen` and `cargo fmt --all -- --check` clean; no emitted IR changes (comment only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the lifetime and release semantics for temporary `this`-related closure roots during object-literal lowering.
  * Explained how `temp_root` truncation works as a stack cut and how a later single release covers roots created afterward, removing ambiguity around expected cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->