### PR TITLE
docs(gc): policy gate defaults said OFF while the code defaults ON (#6987)

### DIFF
--- a/changelog.d/6989-gc-policy-default-docs.md
+++ b/changelog.d/6989-gc-policy-default-docs.md
@@ -1,0 +1,13 @@
+Corrected two GC policy-gate doc comments that claimed the opposite of the code's
+actual default. `gc_incremental_enabled` said "EXPERIMENTAL — default OFF" while
+defaulting ON since the #6180 flip, and `gc_safepoint_moving_minor` described its
+gate as "(default off)" when `gc_moving_safepoint_enabled` is also default ON.
+
+This was not cosmetic: the stale comment led #6972 to dismiss the production
+reachability of an unrooted-operand bug (#6970) on the reasoning that the
+automatic collection arms force a conservative stack scan. With the incremental
+stepper on, budgeted cycles skip that subphase structurally, so a compiled
+program completes precise-roots-only cycles in its shipped configuration —
+measured at 2 of 3 cycles with `conservative_root_count = 0` and no environment
+variables set. The corrected comment now records why the default is load-bearing
+for rooting arguments, not only for pause times.

--- a/crates/perry-runtime/src/gc/policy.rs
+++ b/crates/perry-runtime/src/gc/policy.rs
@@ -288,17 +288,26 @@ pub(crate) fn gc_moving_safepoint_enabled() -> bool {
 }
 
 /// Phase 4 of the moving-GC project: gate the INCREMENTAL old-gen collector (the
-/// budgeted stepper). **EXPERIMENTAL — default OFF.** Perry has a full budgeted
-/// mark/sweep stepper but it never runs, because every compiled program
+/// budgeted stepper). **DEFAULT ON since the #6180 flip**; `PERRY_GC_INCREMENTAL=0`
+/// (or `off`/`false`) is the kill switch. Perry has a full budgeted
+/// mark/sweep stepper which, before that flip, never ran: every compiled program
 /// registers unbudgeted mutable root scanners and
-/// `registered_root_scanners_block_budgeted_gc()` blocks the cycle from ever
+/// `registered_root_scanners_block_budgeted_gc()` blocked the cycle from ever
 /// starting. When this is on, the stepper is allowed to start and runs those
 /// unbudgeted scanners SYNCHRONOUSLY in its initial root-scan step (a bounded
 /// initial-mark pause), then marks/sweeps the old gen incrementally across
 /// safepoints — the standard "initial-mark + incremental-mark" design. Off ⇒
-/// exactly today's non-incremental GC (the whole path is skipped). Independent
+/// exactly the non-incremental GC (the whole path is skipped). Independent
 /// of `PERRY_GC_MOVING_SAFEPOINT`; this is the concurrency layer that reduces
 /// old-gen pause time.
+///
+/// ★ This default is load-bearing for rooting arguments, not just for pause
+/// times: with the stepper on, budgeted cycles skip the conservative
+/// stack-scan subphase *structurally* (`gc/cycle.rs`, classifier mode), so a
+/// compiled program completes precise-roots-only cycles in its shipped
+/// configuration. Reasoning that assumes "the automatic arms force a
+/// conservative scan" is therefore wrong by default — that mistake was made in
+/// #6972 while this doc comment still claimed the gate was off (#6987).
 pub(crate) fn gc_incremental_enabled() -> bool {
     static CACHED: OnceLock<bool> = OnceLock::new();
     *CACHED.get_or_init(|| {
@@ -1393,7 +1402,8 @@ fn gc_budgeted_due_trigger() -> Option<BudgetedGcTrigger> {
 /// (compacting, O(survivors), no sweep) instead of falling back to the
 /// non-moving minor. Trigger detection + re-baseline mirror the nursery-churn
 /// arm; this is purely additive (the alloc-point fallback is untouched) and
-/// gated by `gc_moving_safepoint_enabled` (default off).
+/// gated by `gc_moving_safepoint_enabled` (**default ON**; the kill switch is
+/// `PERRY_GC_MOVING_SAFEPOINT=0`).
 pub(crate) fn gc_safepoint_moving_minor() {
     // Same start guards the budgeted collector uses, minus the (here
     // irrelevant) scanner block: never collect mid-allocation, inside a


### PR DESCRIPTION
Fixes #6987.

## What

Two GC policy gates documented themselves as **default OFF** while defaulting **ON**.

| site | said | actually |
|---|---|---|
| `gc_incremental_enabled` (`policy.rs:291`) | "**EXPERIMENTAL — default OFF**" | `DEFAULT ON (#6180 flip)` — stated in its own body comment eight lines below |
| `gc_safepoint_moving_minor` (`policy.rs:1396`) | "gated by `gc_moving_safepoint_enabled` (default off)" | that accessor is `!matches!(env, "0"\|"off"\|"false")` — default ON |

`gc_moving_loop_polls_enabled` (`policy.rs:320`) also says "opt-in, default OFF" and that one is **accurate** (`matches!(env, "1"|"on"|"true")`) — left unchanged.

## Why this is not a cosmetic nit

It changed a merge decision. PR #6972 dismissed the production-reachability of #6970 on the grounds that `gc_check_trigger` forces the conservative scan on both automatic arms. That reasoning depends on incremental mode being off. It is on, so budgeted cycles skip the conservative subphase *structurally* (`gc/cycle.rs`, classifier mode), independent of any guard.

Measured with `PERRY_GC_TRACE=1` and **no environment variables set**: 3 completed cycles, **2 with `conservative_root_count = 0`**. A compiled program completes precise-roots-only cycles in its shipped configuration today.

The #6972 conclusion was reached honestly from the documented behaviour and was wrong because the documentation was wrong. Two separate investigations tripped over these comments within hours of each other.

So the fix adds more than corrected defaults: it records *why* the incremental default is load-bearing for rooting arguments, not just pause times, so the next reader doesn't repeat the inference.

## Scope

Comment-only — no behaviour change, no code touched.

**A test asserting the defaults was considered and deliberately not included here.** Both gates cache in a `OnceLock` over a process-global env read, so an in-process assertion is order-dependent and would need either a subprocess harness or extracting the decision into a pure `fn(Option<&str>) -> bool` helper. That refactor touches GC policy while several rooting PRs are in flight against neighbouring code, and it is the kind of change that deserves its own review rather than riding along with a doc correction. #6987 stays open for it.

## Validation

`cargo fmt --all -- --check` clean. No code paths modified, so no behavioural verification is claimed or needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated garbage-collection configuration documentation to accurately reflect current default settings.
  * Clarified that incremental collection and moving minor safepoints are enabled by default.
  * Added context about how these settings affect collection behavior in shipped configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->