### PR TITLE
fix(gc): root globalThis across its own lazy builtin population (#6982)

### DIFF
--- a/changelog.d/6994-gc-globalthis-population-rooting.md
+++ b/changelog.d/6994-gc-globalthis-population-rooting.md
@@ -1,0 +1,44 @@
+### Fixed
+
+- **gc: `globalThis` lazy builtin population held a raw pointer across its own
+  allocations (#6982).** `js_get_global_this` registers *two* root slots for the
+  freshly allocated singleton (`THREAD_GLOBAL_THIS` and `GLOBAL_THIS_PTR`)
+  precisely so an evacuating collector rewrites them on a move — and then passed
+  the raw, pre-GC pointer by value into `populate_global_this_builtins`, which
+  installs several hundred builtins and allocates on nearly every step. When a
+  copying minor relocated the singleton mid-population, every later
+  `js_object_set_field_by_name(singleton, ..)` /
+  `set_builtin_property_attrs(singleton as usize, ..)` addressed the dead
+  from-space copy, whose bytes had already been recycled for freshly relocated
+  objects. `js_get_global_this` then returned that stale address too.
+
+  The singleton (plus the intermediate pointers in
+  `alias_number_static_to_global_function` and
+  `alias_typed_array_proto_to_string`) is now rooted in a `RuntimeHandleScope`
+  and re-read through the handle at every use, and `js_get_global_this` returns
+  the value re-read from its registered cache slot. Binding `singleton` as a
+  closure rather than a value makes the conversion exhaustive by construction —
+  any use that was not converted fails to compile.
+
+  Only reachable with the conservative native-stack scan off, which is what
+  production's `Auto -> SkipDisabled` resolves to; the scan was masking the bug
+  by pinning the argument register. This is the same class as #6951/#6972 (a raw
+  reference held across a collection point), one layer further out.
+
+  Measured on the #6981 representation corpus (macOS arm64, pinned Node 26.5.0,
+  `PERRY_GC_HEAP_LIMIT=8 PERRY_GC_INCREMENTAL=0
+  PERRY_CONSERVATIVE_STACK_SCAN=off`, `copied_objects` > 0 on every run):
+
+  - crashes on the evacuating precise-roots arm: **6 -> 2**
+    (`repsel_canonical_i32`, `ta_param_numeric_read`, `typedarray_param_read`,
+    `repsel_ptr_shape_barriers` no longer crash);
+  - `repsel_canonical_i32` flips all the way to **OK** (byte-identical to Node),
+    the rest become mismatches — progress, still red, tracked separately;
+  - all 21 corpus files remain byte-identical to Node on the as-shipped
+    configuration (no regression).
+
+  Removing this shared first hurdle exposed two independent defects that were
+  previously masked by it: a compiled constructor's receiver going stale across
+  the same collection (`repsel_ptr_shape_locals`, still SIGSEGV) and a lost
+  method value (`repsel_proven_this_frozen`, now `TypeError: bump is not a
+  function`). Both are filed separately.

--- a/crates/perry-runtime/src/object/global_this/fetch_globals.rs
+++ b/crates/perry-runtime/src/object/global_this/fetch_globals.rs
@@ -91,7 +91,14 @@ pub extern "C" fn js_get_global_this() -> f64 {
     // reads without changing bare `new Array`.
     populate_global_this_builtins(new_ptr as *mut ObjectHeader);
     GLOBAL_THIS_READY.store(true, Ordering::Release);
-    crate::value::js_nanbox_pointer(new_ptr)
+    // #6982: population allocates heavily, so an evacuating minor may have moved
+    // the singleton since `new_ptr` was taken. The registered root slot above is
+    // rewritten to the forwarding address by the collector, so re-read it rather
+    // than handing back the stale from-space pointer. (`GLOBAL_THIS_PTR` is
+    // likewise rewritten by `scan_object_cache_roots_mut`.) Falling back to
+    // `new_ptr` keeps the pre-existing behaviour if the cache was cleared.
+    let current = THREAD_GLOBAL_THIS.with(|c| c.get());
+    crate::value::js_nanbox_pointer(if current != 0 { current } else { new_ptr })
 }
 
 #[no_mangle]

--- a/crates/perry-runtime/src/object/global_this/populate.rs
+++ b/crates/perry-runtime/src/object/global_this/populate.rs
@@ -11,18 +11,46 @@ use super::*;
 /// pointer instead of undefined, which is what unblocks lodash's
 /// `var arrayProto = Array.prototype` chained read inside
 /// `runInContext`.
-pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
-    if singleton.is_null() {
+pub(crate) fn populate_global_this_builtins(singleton_at_entry: *mut ObjectHeader) {
+    if singleton_at_entry.is_null() {
         return;
     }
+    // #6982: this function installs several hundred builtins, and nearly every
+    // step allocates (name strings, constructor closures, prototype objects).
+    // Any of those allocations can trigger a collection, and an *evacuating*
+    // minor relocates the globalThis singleton itself — it is an ordinary
+    // nursery object at this point, not pinned.
+    //
+    // `js_get_global_this` registers the two slots that cache the singleton
+    // (`THREAD_GLOBAL_THIS` and `GLOBAL_THIS_PTR`) as mutable roots precisely so
+    // the collector rewrites them on a move, but the raw pointer handed to this
+    // function is a plain by-value argument that nothing rewrites. After a move
+    // every later `js_object_set_field_by_name(singleton, ..)` /
+    // `set_builtin_property_attrs(singleton as usize, ..)` addressed the dead
+    // from-space copy, whose bytes had already been recycled for freshly
+    // relocated objects — the observed crashes read string payload where an
+    // ArrayHeader/descriptor was expected (faulting addresses whose high half
+    // was ASCII: 0x434c4f53_00000010 = "CLOS", 0x004e614e_00000008 = "NaN").
+    //
+    // Root the singleton in a `RuntimeHandleScope` and re-read it through the
+    // handle at every use, so each use observes the post-move address. Binding
+    // `singleton` as a closure rather than a value makes this exhaustive by
+    // construction: any use that was not converted fails to compile.
+    //
+    // Only reachable when the conservative native-stack scan is off, which is
+    // production's `Auto -> SkipDisabled` resolution; the scan was masking this
+    // by pinning the argument register.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let singleton_handle = scope.root_raw_mut_ptr(singleton_at_entry);
+    let singleton = || singleton_handle.get_raw_mut_ptr::<ObjectHeader>();
     let proto_key_bytes = b"prototype";
     let proto_key =
         crate::string::js_string_from_bytes(proto_key_bytes.as_ptr(), proto_key_bytes.len() as u32);
     {
         let name = b"globalThis";
         let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-        let value = crate::value::js_nanbox_pointer(singleton as i64);
-        js_object_set_field_by_name(singleton, key, value);
+        let value = crate::value::js_nanbox_pointer(singleton() as i64);
+        js_object_set_field_by_name(singleton(), key, value);
     }
     {
         // #4511: Node exposes the global object as `global` too
@@ -31,10 +59,10 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
         // instead of the unknown-identifier sentinel.
         let name = b"global";
         let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-        let value = crate::value::js_nanbox_pointer(singleton as i64);
-        js_object_set_field_by_name(singleton, key, value);
+        let value = crate::value::js_nanbox_pointer(singleton() as i64);
+        js_object_set_field_by_name(singleton(), key, value);
         super::super::set_builtin_property_attrs(
-            singleton as usize,
+            singleton() as usize,
             "global".to_string(),
             super::super::PropertyAttrs::new(true, true, true),
         );
@@ -60,9 +88,9 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
             let name_key =
                 crate::string::js_string_from_bytes(name_bytes.as_ptr(), name_bytes.len() as u32);
             let ctor_value = super::super::native_module::buffer_constructor_value();
-            js_object_set_field_by_name(singleton, name_key, ctor_value);
+            js_object_set_field_by_name(singleton(), name_key, ctor_value);
             super::super::set_builtin_property_attrs(
-                singleton as usize,
+                singleton() as usize,
                 name.to_string(),
                 super::super::PropertyAttrs::new(true, false, true),
             );
@@ -282,7 +310,7 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
             }
             if name == "Storage" {
                 crate::web_storage::install_storage_globals(
-                    singleton,
+                    singleton(),
                     closure_ptr,
                     proto_obj,
                     ctor_value,
@@ -391,9 +419,9 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
         let name_bytes = name.as_bytes();
         let name_key =
             crate::string::js_string_from_bytes(name_bytes.as_ptr(), name_bytes.len() as u32);
-        js_object_set_field_by_name(singleton, name_key, ctor_value);
+        js_object_set_field_by_name(singleton(), name_key, ctor_value);
         super::super::set_builtin_property_attrs(
-            singleton as usize,
+            singleton() as usize,
             name.to_string(),
             super::super::PropertyAttrs::new(true, false, true),
         );
@@ -494,9 +522,9 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
         let name_key =
             crate::string::js_string_from_bytes(name_bytes.as_ptr(), name_bytes.len() as u32);
         let fn_value = crate::value::js_nanbox_pointer(closure_ptr as i64);
-        js_object_set_field_by_name(singleton, name_key, fn_value);
+        js_object_set_field_by_name(singleton(), name_key, fn_value);
         super::super::set_builtin_property_attrs(
-            singleton as usize,
+            singleton() as usize,
             name.to_string(),
             super::super::PropertyAttrs::new(true, enumerable, true),
         );
@@ -509,8 +537,8 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
     // singleton. A value-read of `Number.parseFloat` resolves to the Number
     // constructor's own `parseFloat` field (see expr_member.rs reroute-undo),
     // which now holds the identical closure the bare `parseFloat` resolves to.
-    alias_number_static_to_global_function(singleton, "parseFloat");
-    alias_number_static_to_global_function(singleton, "parseInt");
+    alias_number_static_to_global_function(singleton(), "parseFloat");
+    alias_number_static_to_global_function(singleton(), "parseInt");
     // Namespaces: plain ObjectHeader so typeof is "object" per spec.
     for name in GLOBAL_THIS_BUILTIN_NAMESPACES.iter().copied() {
         let name_bytes = name.as_bytes();
@@ -574,9 +602,9 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
             }
             crate::value::js_nanbox_pointer(ns_obj as i64)
         };
-        js_object_set_field_by_name(singleton, name_key, ns_value);
+        js_object_set_field_by_name(singleton(), name_key, ns_value);
         super::super::set_builtin_property_attrs(
-            singleton as usize,
+            singleton() as usize,
             name.to_string(),
             super::super::PropertyAttrs::new(true, false, true),
         );
@@ -588,7 +616,7 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
         let pname = b"performance";
         let pkey = crate::string::js_string_from_bytes(pname.as_ptr(), pname.len() as u32);
         let pval = crate::perf_hooks::performance_namespace();
-        js_object_set_field_by_name(singleton, pkey, pval);
+        js_object_set_field_by_name(singleton(), pkey, pval);
     }
     // Perf_hooks constructors are globals identical to the module exports.
     for name in [
@@ -603,9 +631,9 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
         let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
         let value =
             super::super::native_module::bound_native_callable_export_value("perf_hooks", name);
-        js_object_set_field_by_name(singleton, key, value);
+        js_object_set_field_by_name(singleton(), key, value);
     }
-    super::super::native_module::install_global_webcrypto(singleton);
+    super::super::native_module::install_global_webcrypto(singleton());
     let func_ptr = global_this_crypto_getter_thunk as *const u8;
     crate::closure::js_register_closure_arity(func_ptr, 0);
     let getter = crate::closure::js_closure_alloc(func_ptr, 0);
@@ -615,7 +643,7 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
         crate::value::js_nanbox_pointer(getter as i64).to_bits()
     };
     super::super::set_builtin_accessor_descriptor(
-        singleton as usize,
+        singleton() as usize,
         "crypto".to_string(),
         super::super::AccessorDescriptor {
             get: getter_bits,
@@ -635,10 +663,10 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
         // re-enter this very lazy-init (GLOBAL_THIS_READY is still false until we
         // return) and recurse/spin forever.
         let nav_ctor_key = crate::string::js_string_from_bytes(b"Navigator".as_ptr(), 9);
-        let nav_ctor = js_object_get_field_by_name(singleton, nav_ctor_key);
+        let nav_ctor = js_object_get_field_by_name(singleton(), nav_ctor_key);
         let nval =
             crate::navigator::navigator_object_with_constructor(f64::from_bits(nav_ctor.bits()));
-        js_object_set_field_by_name(singleton, nkey, nval);
+        js_object_set_field_by_name(singleton(), nkey, nval);
     }
     // ECMA-262 19.1/19.2/19.3: NaN, Infinity, and undefined are own data
     // properties of the global object with {writable:false, enumerable:false,
@@ -650,18 +678,18 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
         let non_writable = super::super::PropertyAttrs::new(false, false, false);
         for (name, value) in [("NaN", f64::NAN), ("Infinity", f64::INFINITY)] {
             let key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-            js_object_set_field_by_name(singleton, key, value);
+            js_object_set_field_by_name(singleton(), key, value);
             super::super::set_builtin_property_attrs(
-                singleton as usize,
+                singleton() as usize,
                 name.to_string(),
                 non_writable,
             );
         }
         let undef_key = crate::string::js_string_from_bytes(b"undefined".as_ptr(), 9);
         let undef_val = f64::from_bits(crate::value::TAG_UNDEFINED);
-        js_object_set_field_by_name(singleton, undef_key, undef_val);
+        js_object_set_field_by_name(singleton(), undef_key, undef_val);
         super::super::set_builtin_property_attrs(
-            singleton as usize,
+            singleton() as usize,
             "undefined".to_string(),
             super::super::PropertyAttrs::new(false, false, false),
         );
@@ -669,20 +697,28 @@ pub(crate) fn populate_global_this_builtins(singleton: *mut ObjectHeader) {
     // ECMA-262 §23.2.3.33: `%TypedArray%.prototype.toString` must be the
     // same function object as `Array.prototype.toString`. Alias it now that
     // both the Array constructor and the TypedArray intrinsic are set up.
-    alias_typed_array_proto_to_string(singleton);
+    alias_typed_array_proto_to_string(singleton());
 }
 
 /// Install `%TypedArray%.prototype.toString` as the same closure object as
 /// `Array.prototype.toString` (ECMA-262 §23.2.3.33).
-fn alias_typed_array_proto_to_string(singleton: *mut ObjectHeader) {
+fn alias_typed_array_proto_to_string(singleton_at_entry: *mut ObjectHeader) {
     let ta_proto_addr = crate::object::TYPED_ARRAY_INTRINSIC_PROTO_PTR.load(Ordering::Acquire);
     if ta_proto_addr == 0 {
         return;
     }
-    let ta_proto = ta_proto_addr as *mut ObjectHeader;
+    // #6982: `js_string_from_bytes` allocates, so every pointer held across the
+    // lookups below can be relocated by an evacuating minor. Root them and read
+    // back through the handles. `TYPED_ARRAY_INTRINSIC_PROTO_PTR` is itself a
+    // scanned root, but the local copy taken above is not.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let singleton_handle = scope.root_raw_mut_ptr(singleton_at_entry);
+    let singleton = || singleton_handle.get_raw_mut_ptr::<ObjectHeader>();
+    let ta_proto_handle = scope.root_raw_mut_ptr(ta_proto_addr as *mut ObjectHeader);
+
     // Read Array constructor from globalThis, then Array.prototype.toString.
     let arr_key = crate::string::js_string_from_bytes(b"Array".as_ptr(), 5);
-    let arr_ctor = js_object_get_field_by_name(singleton, arr_key);
+    let arr_ctor = js_object_get_field_by_name(singleton(), arr_key);
     if (arr_ctor.bits() >> 48) != 0x7FFD {
         return;
     }
@@ -690,8 +726,11 @@ fn alias_typed_array_proto_to_string(singleton: *mut ObjectHeader) {
     if arr_ctor_ptr.is_null() {
         return;
     }
+    let arr_ctor_handle = scope.root_raw_mut_ptr(arr_ctor_ptr);
+
     let proto_key = crate::string::js_string_from_bytes(b"prototype".as_ptr(), 9);
-    let arr_proto = js_object_get_field_by_name(arr_ctor_ptr, proto_key);
+    let arr_proto =
+        js_object_get_field_by_name(arr_ctor_handle.get_raw_mut_ptr::<ObjectHeader>(), proto_key);
     if (arr_proto.bits() >> 48) != 0x7FFD {
         return;
     }
@@ -699,15 +738,24 @@ fn alias_typed_array_proto_to_string(singleton: *mut ObjectHeader) {
     if arr_proto_ptr.is_null() {
         return;
     }
+    let arr_proto_handle = scope.root_raw_mut_ptr(arr_proto_ptr);
+
     let ts_key = crate::string::js_string_from_bytes(b"toString".as_ptr(), 8);
-    let to_string_fn = js_object_get_field_by_name(arr_proto_ptr, ts_key);
+    let to_string_fn =
+        js_object_get_field_by_name(arr_proto_handle.get_raw_mut_ptr::<ObjectHeader>(), ts_key);
     if to_string_fn.bits() == crate::value::TAG_UNDEFINED {
         return;
     }
+    let to_string_handle = scope.root_nanbox_u64(to_string_fn.bits());
+
     let ts_key2 = crate::string::js_string_from_bytes(b"toString".as_ptr(), 8);
-    js_object_set_field_by_name(ta_proto, ts_key2, f64::from_bits(to_string_fn.bits()));
+    js_object_set_field_by_name(
+        ta_proto_handle.get_raw_mut_ptr::<ObjectHeader>(),
+        ts_key2,
+        f64::from_bits(to_string_handle.get_nanbox_u64()),
+    );
     super::super::set_builtin_property_attrs(
-        ta_proto as usize,
+        ta_proto_handle.get_raw_mut_ptr::<ObjectHeader>() as usize,
         "toString".to_string(),
         super::super::PropertyAttrs::new(true, false, true),
     );
@@ -717,14 +765,24 @@ fn alias_typed_array_proto_to_string(singleton: *mut ObjectHeader) {
 /// the two are the identical object (`Number.parseFloat === parseFloat`). Both
 /// the global helper and the `Number` constructor are already installed on the
 /// `singleton` by the time this runs. No-op if either lookup fails.
-fn alias_number_static_to_global_function(singleton: *mut ObjectHeader, name: &str) {
+fn alias_number_static_to_global_function(singleton_at_entry: *mut ObjectHeader, name: &str) {
+    // #6982: same window as `populate_global_this_builtins` — every
+    // `js_string_from_bytes` here can trigger an evacuating minor that relocates
+    // `singleton`, the resolved global function and the `Number` constructor.
+    // Root each across the allocations and re-read through the handles.
+    let scope = crate::gc::RuntimeHandleScope::new();
+    let singleton_handle = scope.root_raw_mut_ptr(singleton_at_entry);
+    let singleton = || singleton_handle.get_raw_mut_ptr::<ObjectHeader>();
+
     let global_key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-    let global_fn = js_object_get_field_by_name(singleton, global_key);
+    let global_fn = js_object_get_field_by_name(singleton(), global_key);
     if (global_fn.bits() >> 48) != 0x7FFD {
         return;
     }
+    let global_fn_handle = scope.root_nanbox_u64(global_fn.bits());
+
     let number_key = crate::string::js_string_from_bytes(b"Number".as_ptr(), 6);
-    let number_ctor = js_object_get_field_by_name(singleton, number_key);
+    let number_ctor = js_object_get_field_by_name(singleton(), number_key);
     if (number_ctor.bits() >> 48) != 0x7FFD {
         return;
     }
@@ -732,10 +790,17 @@ fn alias_number_static_to_global_function(singleton: *mut ObjectHeader, name: &s
     if ctor_ptr.is_null() {
         return;
     }
+    let ctor_handle = scope.root_raw_mut_ptr(ctor_ptr);
+
     let static_key = crate::string::js_string_from_bytes(name.as_ptr(), name.len() as u32);
-    js_object_set_field_by_name(ctor_ptr, static_key, f64::from_bits(global_fn.bits()));
+    let ctor_ptr = ctor_handle.get_raw_mut_ptr::<ObjectHeader>();
+    js_object_set_field_by_name(
+        ctor_ptr,
+        static_key,
+        f64::from_bits(global_fn_handle.get_nanbox_u64()),
+    );
     super::super::set_builtin_property_attrs(
-        ctor_ptr as usize,
+        ctor_handle.get_raw_mut_ptr::<ObjectHeader>() as usize,
         name.to_string(),
         super::super::PropertyAttrs::new(true, false, true),
     );


### PR DESCRIPTION
Fixes the largest slice of #6982 / #6981.

## First: the premise in #6982 was wrong, and the symbolized stacks say so

#6982 recorded that the five crashers faulted on `ldrb w8, [x21, #-0x8]!` and concluded this was "a GC-header `obj_type` read at `addr-8` — the collector validating a pointer that should never have reached it". It also flagged that as an n=2 hypothesis matched by *offset into an unnamed symbol*, and asked for a symbols build before any fix. That was the right call.

No special build was needed: `post_link.rs::strip_final_binary` skips `strip` when `PERRY_DEBUG_SYMBOLS=1` is set. With real symbols, all five:

```
repsel_canonical_i32 / repsel_ptr_shape_locals   SIGBUS  0x18400001fc
  0  js_array_length + 488
  1  js_object_set_field_by_name + 5964
  2  populate_global_this_builtins + 45592
  3  js_get_global_this + 156
  4  js_get_global_this_builtin_value + 72

repsel_proven_this_frozen                        SIGSEGV 0x434c4f5300000010
  0  descriptor_state::get_accessor_descriptor + 136
  1  js_object_set_field_by_name + 5728
  2  populate_global_this_builtins + 45592

ta_param_numeric_read                            SIGSEGV 0x004e614e00000008
  0  descriptor_state::set_builtin_property_attrs + 456
  1  populate_global_this_builtins + 46820

typedarray_param_read                            SIGBUS  0x300000020b
  0  get_field_by_name_tail::get_field_by_name_object_tail + 10444
  1  js_object_get_field_by_name + 8048
  2  js_get_global_this_builtin_value + 396
```

**There is not a single GC frame in any of them.** No mark, no trace, no copying, no evacuate. The faulting `ldrb [x21, #-0x8]!` is `js_array_length` reading an array header at `arr-8` — an ordinary *mutator* read, not collector validation. The collector is not the faulting code; it is the code that moved the object out from under the mutator.

The faulting addresses are the tell: their high halves are ASCII — `0x434c4f53` is `"CLOS"`, `0x004e614e` is `"NaN"` — relocated *string payload* read where a pointer/descriptor was expected.

## Root cause

`js_get_global_this` registers **two** root slots for the freshly allocated singleton (`THREAD_GLOBAL_THIS`, `GLOBAL_THIS_PTR`), with a long comment explaining that this exists precisely so an evacuating collector rewrites them on a move. It then hands the **raw, pre-GC pointer by value** to `populate_global_this_builtins`, which installs several hundred builtins and allocates on nearly every step:

```rust
crate::gc::js_gc_register_global_root(cache_slot as i64);           // slot IS rewritten
crate::gc::runtime_store_root_atomic_raw_i64(&GLOBAL_THIS_PTR, ..); // slot IS rewritten
populate_global_this_builtins(new_ptr as *mut ObjectHeader);        // <-- raw, never re-read
```

Those allocations are exactly the 4 579–5 965 objects the copying minor reports. When it relocates the singleton mid-population, the two registered slots are rewritten and the by-value argument is not, so every later `js_object_set_field_by_name(singleton, ..)` / `set_builtin_property_attrs(singleton as usize, ..)` addresses the dead from-space copy whose bytes have been recycled. `js_get_global_this` then returns that stale address too.

The GC diagnostics for the cycle immediately before each crash confirm the shape: `compiled_shadow` and `shadow_roots` entirely zero, `native_stack_fallback.decision = "skip_disabled"`. Nothing kept that pointer alive or current.

Same class as #6951/#6972 (a raw reference held across a collection point), one layer further out. Only reachable with the conservative native-stack scan off — production's `Auto -> SkipDisabled` — which is #6981's "the scan is load-bearing for correctness": it was pinning the argument register.

## The fix

Root the singleton in a `RuntimeHandleScope` and re-read it through the handle at every use (`root_raw_mut_ptr` / `get_raw_mut_ptr` — the idiom `array/header.rs` already uses), and return the value re-read from the registered cache slot. The two helpers that take the singleton (`alias_number_static_to_global_function`, `alias_typed_array_proto_to_string`) had the same window and get the same treatment.

`singleton` is rebound as a **closure** rather than a value, so the conversion is exhaustive by construction: any use not converted fails to compile.

## Measurements

macOS arm64, pinned Node 26.5.0, release build from `aa1c15028`, evacuating precise-roots arm `PERRY_GC_HEAP_LIMIT=8 PERRY_GC_INCREMENTAL=0 PERRY_CONSERVATIVE_STACK_SCAN=off`, with `copied_objects > 0` verified on every run (4 579 / 4 640 / 4 614 / 5 948 / 5 965 before; 9 672 / 15 368 / 15 409 after, on the files that now run to completion).

Control arms pin causality — on the **unfixed** build each of the five passes with the conservative scan *on*, passes with precise roots and *no* pressure, and crashes only with both.

| corpus file | before | after |
|---|---|---|
| `repsel_canonical_i32` | SIGBUS | **OK** (byte-identical to Node) |
| `ta_param_numeric_read` | SIGSEGV | mismatch (no longer crashes) |
| `typedarray_param_read` | SIGBUS | mismatch (no longer crashes) |
| `repsel_ptr_shape_barriers` | SIGSEGV | mismatch (no longer crashes) |
| `repsel_ptr_shape_locals` | SIGBUS | SIGSEGV — different, now-unmasked defect (#6991) |
| `repsel_proven_this_frozen` | SIGSEGV | `TypeError: bump is not a function` (#6992) |

Crashes on that arm: **6 -> 2**. All **21** corpus files remain byte-identical to Node on the as-shipped configuration — no regression.

## One defect or several? (the question #6982 asked)

**The five crashes shared one blocking defect, and it was masking at least two more.** All five faulted downstream of the same `js_get_global_this_builtin_value -> populate_global_this_builtins` spine, at four different sites, purely depending on where the recycled bytes landed. Removing that shared first hurdle made two independent defects observable:

- **#6991** — `repsel_ptr_shape_locals` now crashes with a completely different 2-frame stack (`..._Pt_constructor + 236 -> js_object_set_field_by_name + 3044`): a compiled constructor's receiver going stale across the same collection. That is the ctor-receiver rooting class #6983 is already addressing, so it is deliberately untouched here.
- **#6992** — `repsel_proven_this_frozen` no longer crashes but loses a method value.

## What I did NOT do, and one thing reviewers should know

**No cargo-test-visible unit test.** I verified the fix on the real reproducer in both directions, but I did not land a Rust unit test, and I would rather say so than imply coverage that does not exist. The guards needed to force a relocating minor at a controlled point (`CopyingNurseryTestGuard`, `ConservativeScanDisabledGuard`, `GcTriggerThresholdTestGuard::make_arena_trigger_due`) are `pub(super)` inside `gc::tests`, while the functions under test are private to `object::global_this`; bridging them is real work and I did not want to ship a test whose teeth I had not verified in both directions.

**The corpus does not gate this class on PRs — filed as #6993.** Measured directly on the *unfixed* binaries, every PR-gated arm is green:

```
                        default  verify_evac  cons_scan_off  shipped_default
repsel_canonical_i32    0        0            0              0
typedarray_param_read   0        0            0              0
```

`PR_ARMS` is `default,verify_evac,cons_scan_off,shipped_default`, and the evacuating base needs `PERRY_GC_INCREMENTAL=0` *and* `PERRY_CONSERVATIVE_STACK_SCAN=off` together — a combination that appears only in `--arms all`, which runs on push, not on `pull_request`. I did not simply add the arm to `PR_ARMS` because 13 corpus cells are still red on it and that would block every unrelated PR.

Verified on the quiet mini, pinned Node 26.5.0, `cargo fmt --all -- --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a GC-related correctness issue during `globalThis` lazy singleton population that could lead to stale pointers and crashes while initializing global built-ins.
  * Made global built-in installation and related aliasing logic relocation-safe, ensuring `globalThis` reads return the currently valid object after garbage collection moves it.
* **Documentation**
  * Updated the changelog with the fix details and validation results, noting any remaining separately tracked discrepancies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->