### PR TITLE
fix(deps-check): resolve scoped subpath exports to the two-segment package name

### DIFF
--- a/changelog.d/7000-deps-check-scoped-subpath.md
+++ b/changelog.d/7000-deps-check-scoped-subpath.md
@@ -1,0 +1,1 @@
+fix(deps-check): resolve scoped subpath-exports specifiers — `--check-deps` treated the full specifier (`@scope/pkg/sub/path`) as a node_modules directory and emitted a false R003 "package not found" for every subpath-exports import; the package name is now the first two segments of a scoped specifier, matching what `perry compile` already resolves through the `exports` map.

--- a/crates/perry/src/commands/deps.rs
+++ b/crates/perry/src/commands/deps.rs
@@ -108,19 +108,13 @@ impl DependencyResolver {
     pub fn resolve_package(&self, package_name: &str) -> Option<PathBuf> {
         let node_modules = self.find_node_modules()?;
 
-        // Handle scoped packages (@org/pkg)
-        let package_path = if package_name.starts_with('@') {
-            let parts: Vec<&str> = package_name.splitn(2, '/').collect();
-            if parts.len() == 2 {
-                node_modules.join(parts[0]).join(parts[1])
-            } else {
-                node_modules.join(package_name)
-            }
-        } else {
-            // Handle subpath imports (lodash/map -> lodash)
-            let base_package = package_name.split('/').next().unwrap_or(package_name);
-            node_modules.join(base_package)
-        };
+        // The package name is the first segment (`lodash/map` -> `lodash`),
+        // or the first TWO segments for a scoped specifier
+        // (`@acme/toolkit/fs/safe` -> `@acme/toolkit`); the
+        // remainder is a subpath resolved against the package's `exports`
+        // map at compile time, never a directory under node_modules.
+        let base_package = package_base_name(package_name);
+        let package_path = node_modules.join(base_package);
 
         if package_path.exists() {
             Some(package_path)
@@ -195,14 +189,7 @@ impl DependencyResolver {
             .all_imports
             .iter()
             .filter(|s| !s.starts_with('.') && !is_node_builtin(s) && !is_perry_builtin(s))
-            .map(|s| {
-                // Extract base package name
-                if s.starts_with('@') {
-                    s.splitn(3, '/').take(2).collect::<Vec<_>>().join("/")
-                } else {
-                    s.split('/').next().unwrap_or(s).to_string()
-                }
-            })
+            .map(|s| package_base_name(s).to_string())
             .collect();
 
         for package_name in packages {
@@ -214,6 +201,22 @@ impl DependencyResolver {
         }
 
         Ok(results)
+    }
+}
+
+/// Extract the npm package name from an import specifier: the first
+/// path segment, or the first two for a scoped package
+/// (`@scope/name/sub/path` -> `@scope/name`).
+fn package_base_name(specifier: &str) -> &str {
+    let mut slashes = specifier.match_indices('/');
+    let cut = if specifier.starts_with('@') {
+        slashes.nth(1)
+    } else {
+        slashes.next()
+    };
+    match cut {
+        Some((idx, _)) => &specifier[..idx],
+        None => specifier,
     }
 }
 
@@ -809,6 +812,53 @@ pub fn compatibility_to_diagnostics(packages: &[PackageCompatibility]) -> Diagno
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A scoped specifier's package name is the first TWO segments; the
+    /// remainder is an `exports` subpath, not a node_modules directory
+    /// (`@acme/toolkit/fs/safe` was reported as R003 "package not
+    /// found" because the full specifier was joined as a path).
+    #[test]
+    fn package_base_name_splits_scoped_subpath_exports() {
+        assert_eq!(
+            package_base_name("@acme/toolkit/fs/safe"),
+            "@acme/toolkit"
+        );
+        assert_eq!(package_base_name("@acme/toolkit"), "@acme/toolkit");
+        assert_eq!(package_base_name("@scope/name/a/b/c"), "@scope/name");
+        assert_eq!(package_base_name("lodash/map"), "lodash");
+        assert_eq!(package_base_name("lodash"), "lodash");
+    }
+
+    /// The R003 path end-to-end: `record_import` resolves a scoped subpath
+    /// specifier through `resolve_package`, which must look up
+    /// `node_modules/@scope/pkg` — not join the full specifier as a
+    /// directory — so an installed package's subpath export is never
+    /// reported unresolved.
+    #[test]
+    fn scoped_subpath_import_resolves_against_installed_package() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pkg_dir = dir.path().join("node_modules/@scope/pkg");
+        std::fs::create_dir_all(&pkg_dir).expect("create @scope/pkg");
+        std::fs::write(
+            pkg_dir.join("package.json"),
+            "{\"name\":\"@scope/pkg\",\"version\":\"1.0.0\"}\n",
+        )
+        .expect("write package.json");
+
+        let mut resolver = DependencyResolver::new(dir.path().to_path_buf());
+        assert_eq!(
+            resolver.resolve_package("@scope/pkg/sub/path"),
+            Some(pkg_dir),
+            "subpath specifier resolves to the installed package directory"
+        );
+
+        resolver.record_import("@scope/pkg/sub/path", Path::new("src/main.ts"));
+        assert!(
+            resolver.get_unresolved_imports().is_empty(),
+            "installed scoped subpath must not be reported as R003 unresolved: {:?}",
+            resolver.get_unresolved_imports()
+        );
+    }
 
     /// D005 must key off the *argument*, not the line's formatting. Both call
     /// shapes below appear in the same file in the Vercel CLI


### PR DESCRIPTION
`perry check --check-deps` emits a false R003 "package not found" for every import of a scoped package's subpath export, even though the package is installed and `perry compile` resolves the same import fine.

A subpath export is an npm feature where a package's `exports` map in `package.json` publishes extra entry points under the package name: importing `@scope/pkg/sub/path` loads whatever file `@scope/pkg`'s `exports` map assigns to `./sub/path`. The subpath is a key in that map — it is not a directory on disk. So the only part of the specifier that corresponds to a `node_modules` directory is the package name itself: the first segment for a bare package (`lodash/map` → `lodash`), the first two for a scoped one (`@scope/pkg/sub/path` → `@scope/pkg`).

<details>
<summary>Minimal repro</summary>

```ts
// src/main.ts — @acme/toolkit is installed and exports "./fs/safe"
import { safeReadFile } from "@acme/toolkit/fs/safe";
```

```
$ perry check src --check-deps
R003: package not found: @acme/toolkit/fs/safe
```

</details>

<details>
<summary>Root cause</summary>

`DependencyResolver::resolve_package` (`crates/perry/src/commands/deps.rs:108`) split a scoped specifier with `splitn(2, '/')`, producing exactly two parts — `@scope` and `pkg/sub/path` — and joined both onto `node_modules`. The lookup path became `node_modules/@scope/pkg/sub/path`, a directory that does not exist for a subpath export, so the check reported the whole package missing. A second copy of the same name-extraction logic lived in `check_all_packages` a few lines down.

</details>

The fix replaces both copies with one helper, `package_base_name`, which cuts the specifier at the first slash (or the second slash when it starts with `@`) and joins only that onto `node_modules` — matching what `perry compile` already resolves through the `exports` map.

<details>
<summary>Test plan</summary>

```
$ cargo test -p perry --bin perry package_base_name
test commands::deps::tests::package_base_name_splits_scoped_subpath_exports ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 751 filtered out
```

The new unit test covers a scoped subpath, a bare scoped name, a deep scoped subpath, a bare subpath, and a bare name.

</details>

Found while compiling a manifest generation CLI — a real-world TypeScript CLI with a deep pnpm dependency graph. Independent of the other fixes from that effort; lands standalone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dependency checks for scoped packages imported via subpaths (for example, `@scope/pkg/...`), eliminating false R003 “package not found” results.
  * Improved handling of scoped subpath specifiers to match package resolution behavior used during compilation.
  * Enhanced consistency in how package names are identified across dependency resolution and compatibility checking, including scenarios involving export maps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->