### PR TITLE
fix(wasm-host): enable wasmi simd feature for SIMD-built wasm payloads

### DIFF
--- a/changelog.d/7003-wasmi-simd.md
+++ b/changelog.d/7003-wasmi-simd.md
@@ -1,0 +1,1 @@
+fix(wasm-host): enable wasmi's `simd` feature — real-world wasm payloads are built with SIMD on (Rust wasm32 `+simd128` is the default for wasm-bindgen toolchains), and `new WebAssembly.Module(bytes)` rejected them at load with "unexpected SIMD opcode: 0xfd".

--- a/crates/perry-wasm-host/Cargo.toml
+++ b/crates/perry-wasm-host/Cargo.toml
@@ -16,7 +16,10 @@ crate-type = ["rlib", "staticlib"]
 # wasmi: pure-Rust WebAssembly interpreter. Default-features off so we don't pull
 # the std-only "string-interner" extras that bloat binary size — the issue
 # measured ~1.1 MB delta with default-features=false.
-wasmi = { version = "1.1", default-features = false }
+# `simd`: real-world wasm payloads are built with SIMD on (e.g. Rust's
+# wasm32 target with `+simd128`); without it `new WebAssembly.Module`
+# rejects them at instantiation with "unexpected SIMD opcode: 0xfd".
+wasmi = { version = "1.1", default-features = false, features = ["simd"] }
 
 [features]
 default = []


### PR DESCRIPTION
`new WebAssembly.Module(bytes)` rejects most real-world wasm binaries at load time with `unexpected SIMD opcode: 0xfd`.

The wasm SIMD proposal (128-bit vector instructions, all prefixed with the `0xfd` opcode byte) has been a standard part of WebAssembly since 2021, and mainstream toolchains emit it by default — Rust's `wasm32-unknown-unknown` target under wasm-bindgen builds with `+simd128` on, and Emscripten and AssemblyScript ship SIMD-enabled presets. A wasm engine with SIMD support compiled out therefore fails not on exotic payloads but on the typical output of today's toolchains, e.g. a wasm-bindgen module built with `+simd128`.

<details>
<summary>Root cause</summary>

`crates/perry-wasm-host/Cargo.toml:19` pulls wasmi with `default-features = false` to keep binary size down (the comment documents a measured ~1.1 MB delta from the std-only string-interner extras). But wasmi's default feature set is also what carries `simd` — so the size optimization silently dropped SIMD decoding, and the interpreter's validator bails at the first `0xfd`-prefixed instruction.

</details>

The fix re-enables exactly the one feature: `wasmi = { version = "1.1", default-features = false, features = ["simd"] }`. The string-interner extras the size note targets stay off.

<details>
<summary>Test plan</summary>

```
$ cargo build -p perry-wasm-host
Finished `dev` profile
$ cargo test -p perry-wasm-host
test result: ok. 3 passed; 0 failed
```

Verified end-to-end against a wasm-bindgen module built with `+simd128`: loads and instantiates where it previously threw at `new WebAssembly.Module`.

</details>

Found while compiling a manifest generation CLI — a real-world TypeScript CLI with a deep pnpm dependency graph. Independent of the other fixes from that effort; lands standalone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where SIMD-enabled WebAssembly modules could fail to load due to unsupported SIMD handling.
  * Improved compatibility with real-world WebAssembly payloads compiled with SIMD support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->