### PR TITLE
test(gc): de-duplicate the matrix corpus entry registered twice by #6977

### DIFF
--- a/changelog.d/7010-corpus-duplicate-entry.md
+++ b/changelog.d/7010-corpus-duplicate-entry.md
@@ -1,0 +1,9 @@
+De-duplicated `test-parity/gc_repsel_corpus.txt`: `test_gap_repsel_proven_this_frozen`
+was registered twice (#6977 added it in two places), so the file held 23 entries with
+22 unique names.
+
+The duplicate was not cosmetic — it ran the same file twice per arm, inflating every
+`gc_repsel_matrix.sh` count by 20 cells (one per arm) and skewing the liveness
+denominators the matrix reports ("collected N/23", "moved-objects N/23"). Conclusions
+drawn from the affected runs were unaffected, but the totals were not comparable to
+runs taken before the duplication.

--- a/test-parity/gc_repsel_corpus.txt
+++ b/test-parity/gc_repsel_corpus.txt
@@ -75,9 +75,3 @@ test_gap_repsel_scalar_replaced_locals
 # "collect" arms actually bite. Keep it registered and keep it collecting.
 test_gap_repsel_gc_stress
 
-# --- Phase 5a: Ptr<Shape> proven `this` in methods (#6925) -------------------
-# Landed in 1a533a3a8 WITHOUT registering here, which made
-# `gc_repsel_matrix.sh --arms all` refuse to run at all (the UNREGISTERED gate
-# fires before any cell is evaluated). Registering it is the action that gate
-# asks for.
-test_gap_repsel_proven_this_frozen


### PR DESCRIPTION
`test-parity/gc_repsel_corpus.txt` held **23 entries with 22 unique names** — `test_gap_repsel_proven_this_frozen` was registered twice, both blocks added by #6977 documenting the same thing (that #6925 landed the file without registering it, tripping the `UNREGISTERED` gate).

## Why it isn't cosmetic

The corpus drives `scripts/gc_repsel_matrix.sh`. A duplicated row runs that file **twice per arm**, which:

- inflates every reported count by 20 cells (one per arm) — the matrix run on `393a36aa4` reported 460 cells where 440 was correct;
- skews the liveness denominators the matrix prints (`collected 22/23`, `moved-objects 22/23`), which are exactly the figures used to decide whether an arm was live enough for its green cells to mean anything.

Conclusions drawn from the affected runs were unaffected — the duplicate row passes or fails identically both times — but the totals are not comparable across runs taken before and after the duplication, which matters because the campaign is tracking a delta.

## Change

Dropped the second block, kept the first (its comment explains the `UNREGISTERED` gate). No test files added or removed; no behaviour change.

Found while re-measuring the matrix after today's GC series.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a duplicated entry in the GC representation-selection test matrix.
  * Prevented duplicate test execution and inflated result totals.
  * Restored accurate liveness and moved-object denominators for comparable results.

* **Tests**
  * Added GC stress coverage for a representation-selection test that performs collections.
  * Updated the test corpus classification to accurately reflect its active garbage-collection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->