### PR TITLE
fix(codegen): sort closure-source emission so the same input compiles to the same IR (#7038)

### DIFF
--- a/changelog.d/7039-codegen-determinism.md
+++ b/changelog.d/7039-codegen-determinism.md
@@ -1,0 +1,13 @@
+Fixed non-deterministic LLVM IR: `emit_artifacts` iterated `hir.closure_source_text`
+(a `HashMap`) when emitting retained closure-source constants, so the `@.str.N`
+numbering of those constants was a per-process permutation — the same input
+compiled to different IR on every run.
+
+This was not cosmetic. It silently invalidates any A/B comparison of raw LLVM IR,
+a technique several representation-selection and GC investigations relied on for
+evidence. PR #7037 hit it directly: its first proof that `--opt-report` was
+observational passed on nondeterministic output and had to be redone with four
+runs per arm and a normalizer.
+
+Measured over 6 compiles of one file (md5 of the concatenated per-module `.ll`):
+5 distinct hashes before, 1 after. Emission order is the only thing that changes.

--- a/crates/perry-codegen/src/codegen/artifacts.rs
+++ b/crates/perry-codegen/src/codegen/artifacts.rs
@@ -1858,10 +1858,23 @@ pub(super) fn emit_module_artifacts(c: ModuleArtifactsCtx<'_>) -> Result<()> {
             }
         }
     }
-    for (func_id, src) in &hir.closure_source_text {
-        if registered_fn_ids.contains(func_id) || !materialized_closure_ids.contains(func_id) {
-            continue;
-        }
+    // Sorted, NOT raw `HashMap` iteration (#7038). The loop above walks
+    // `hir.functions` (a `Vec`) and is already deterministic; this one keyed off
+    // the map's iteration order, so the `@.str.N` numbering of the emitted
+    // string constants was a per-process permutation. Same input, different
+    // `.ll` on every run — which silently invalidates any A/B that compares raw
+    // IR, a technique several representation and GC investigations relied on.
+    // Emission order is the only thing that changes; sorting by `FuncId` makes
+    // it stable without altering what is emitted.
+    let mut materialized_closure_sources: Vec<(&perry_hir::types::FuncId, &String)> = hir
+        .closure_source_text
+        .iter()
+        .filter(|(func_id, _)| {
+            !registered_fn_ids.contains(*func_id) && materialized_closure_ids.contains(*func_id)
+        })
+        .collect();
+    materialized_closure_sources.sort_by_key(|(func_id, _)| **func_id);
+    for (func_id, src) in materialized_closure_sources {
         let sym = format!("perry_closure_{}__{}", module_prefix, func_id);
         user_fn_source.push((sym, src.clone()));
     }


### PR DESCRIPTION
Closes #7038.

## What

`emit_artifacts` (`codegen/artifacts.rs`) iterated `hir.closure_source_text` — a `HashMap` — when emitting retained closure-source constants. The `@.str.N` numbering of those constants was therefore a per-process permutation: **the same input compiled to different LLVM IR on every run.**

The loop immediately above it walks `hir.functions` (a `Vec`) and was already deterministic; only the materialized-closure loop keyed off map iteration order. The fix collects, filters, sorts by `FuncId`, then emits. **Emission order is the only thing that changes** — the set of emitted constants and every other instruction is untouched.

## Why it is not cosmetic

It silently invalidates any A/B that compares raw LLVM IR — a technique several representation-selection and GC investigations have relied on for evidence.

PR #7037 hit it head-on. Its first proof that `--opt-report` was observational was the obvious one: compile with the flag off, compile with it on, diff the `.ll`. That **passed, and was not evidence** — two runs can match by luck or differ for reasons unrelated to the change. It had to be redone with four runs per arm plus a content-canonicalising normalizer.

It also matters for what comes next: the planned codegen-perturbation measurement (how many hot loops lose native regions to rooting calls) works by comparing emitted IR. That measurement is unsound while codegen is nondeterministic.

## Evidence

6 compiles of one file (arrow functions in `map`/`filter`/`reduce`/`sort`, so several materialized closures), md5 of the concatenated per-module `.ll`, `PERRY_NO_AUTO_OPTIMIZE=1`, same binary and same source in each arm:

| arm | distinct hashes across 6 runs |
|---|---|
| pristine `main` | **5** |
| this fix | **1** |

Falsifiable in both directions: if the diagnosis were wrong, the fixed arm would still show multiple hashes; if the file exercised no materialized closures, the unfixed arm would show one.

## Scope

One function, one loop. No behaviour change to emitted code — only the order in which two string constants are written.

## Note for reviewers: `lint` on this branch

`cargo fmt --all -- --check` fails on **four files this PR does not touch**, all pre-existing on `main` at `b5dbf3f63`:

```
crates/perry-codegen/src/lower_call/native/mod.rs:409
crates/perry-runtime/src/object/global_this/install_static.rs:899
crates/perry/src/commands/check.rs:783
crates/perry/src/commands/deps.rs:819
```

They are deliberately not fixed here — that is a separate janitorial change and folding it in would obscure a one-loop diff. The file this PR touches is `rustfmt --check` clean.

`lint` is in any case already red repo-wide on the stale public benchmark baseline, which fails before the fmt step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent generated LLVM IR across repeated compilations.
  * Stabilized string-constant numbering to ensure identical inputs produce reproducible output.
  * Improved reliability of raw IR comparisons and optimization reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->